### PR TITLE
[Remote Sync Step 1: Sync Schema and Change Journal](1) Add data-store sync schema and journal

### DIFF
--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { TaskState } from '@invoker/workflow-core';
+import { createAttempt } from '@invoker/workflow-core';
+import type { Workflow } from '../adapter.js';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  readJournalSince,
+  setSyncCursor,
+  type SyncJournalDb,
+} from '../sync-journal.js';
+
+describe('sync journal', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function journalDb(): SyncJournalDb {
+    return (adapter as unknown as { executor: SyncJournalDb }).executor;
+  }
+
+  function makeWorkflow(id: string, createdAt = '2026-07-01T00:00:00.000Z'): Workflow {
+    return {
+      id,
+      name: `Workflow ${id}`,
+      status: 'pending',
+      createdAt,
+      updatedAt: createdAt,
+    };
+  }
+
+  function makeTask(id: string, workflowId: string, status: TaskState['status'] = 'pending'): TaskState {
+    return {
+      id,
+      description: `Task ${id}`,
+      status,
+      dependencies: [],
+      createdAt: new Date('2026-07-01T00:00:00.000Z'),
+      config: { workflowId },
+      execution: {},
+      taskStateVersion: 1,
+    };
+  }
+
+  it('rolls back journal entries with the enclosing mutation transaction', () => {
+    adapter.saveWorkflow(makeWorkflow('wf-rollback'));
+    adapter.saveTask('wf-rollback', makeTask('task-rollback', 'wf-rollback'));
+
+    expect(() => adapter.runInTransaction(() => {
+      adapter.updateTask('task-rollback', { status: 'running' });
+      throw new Error('rollback requested');
+    })).toThrow('rollback requested');
+
+    expect(adapter.loadTask('task-rollback')?.status).toBe('pending');
+    expect(readJournalSince(journalDb(), 0, 10)).toEqual([]);
+  });
+
+  it('fails loudly and rolls back the mutation when a journal append fails', () => {
+    adapter.saveWorkflow(makeWorkflow('wf-failure'));
+    adapter.saveTask('wf-failure', makeTask('task-failure', 'wf-failure'));
+
+    const db = (adapter as unknown as { db: { run: (sql: string, params?: unknown[]) => void } }).db;
+    const originalRun = db.run;
+    db.run = function runWithJournalFailure(sql: string, params?: unknown[]): void {
+      if (sql.includes('INSERT INTO sync_journal')) {
+        throw new Error('journal insert failed');
+      }
+      return originalRun.call(this, sql, params);
+    };
+
+    try {
+      expect(() => adapter.updateTask('task-failure', { status: 'running' }))
+        .toThrow('journal insert failed');
+    } finally {
+      db.run = originalRun;
+    }
+
+    expect(adapter.loadTask('task-failure')?.status).toBe('pending');
+    expect(readJournalSince(journalDb(), 0, 10)).toEqual([]);
+  });
+
+  it('allocates strictly monotonic journal sequences', () => {
+    const seqs = [
+      appendJournalEntry(journalDb(), {
+        entityType: 'task',
+        entityId: 'task-1',
+        op: 'upsert',
+        payload: { id: 'task-1' },
+      }),
+      appendJournalEntry(journalDb(), {
+        entityType: 'attempt',
+        entityId: 'attempt-1',
+        op: 'upsert',
+        payload: { id: 'attempt-1' },
+      }),
+      appendJournalEntry(journalDb(), {
+        entityType: 'event',
+        entityId: 'event-1',
+        op: 'upsert',
+        payload: { id: 1 },
+      }),
+    ];
+
+    expect(seqs[1]).toBeGreaterThan(seqs[0]);
+    expect(seqs[2]).toBeGreaterThan(seqs[1]);
+    expect(readJournalSince(journalDb(), 0, 10).map((entry) => entry.seq)).toEqual(seqs);
+  });
+
+  it('reads journal rows after the cursor and persists cursor pairs', () => {
+    const firstSeq = appendJournalEntry(journalDb(), {
+      entityType: 'task',
+      entityId: 'task-cursor-1',
+      op: 'upsert',
+      payload: { id: 'task-cursor-1' },
+    });
+    const secondSeq = appendJournalEntry(journalDb(), {
+      entityType: 'task',
+      entityId: 'task-cursor-2',
+      op: 'upsert',
+      payload: { id: 'task-cursor-2' },
+    });
+    const thirdSeq = appendJournalEntry(journalDb(), {
+      entityType: 'task',
+      entityId: 'task-cursor-3',
+      op: 'upsert',
+      payload: { id: 'task-cursor-3' },
+    });
+
+    setSyncCursor(journalDb(), {
+      peerId: 'peer-a',
+      lastSentSeq: secondSeq,
+      lastReceivedSeq: firstSeq,
+      updatedAt: 123,
+    });
+    expect(getSyncCursor(journalDb(), 'peer-a')).toEqual({
+      peerId: 'peer-a',
+      lastSentSeq: secondSeq,
+      lastReceivedSeq: firstSeq,
+      updatedAt: 123,
+    });
+
+    const unread = readJournalSince(journalDb(), getSyncCursor(journalDb(), 'peer-a')!.lastSentSeq, 10);
+    expect(unread.map((entry) => entry.seq)).toEqual([thirdSeq]);
+    expect(readJournalSince(journalDb(), secondSeq, 0)).toEqual([]);
+
+    setSyncCursor(journalDb(), 'peer-a', { lastReceivedSeq: thirdSeq, updatedAt: 456 });
+    expect(getSyncCursor(journalDb(), 'peer-a')).toEqual({
+      peerId: 'peer-a',
+      lastSentSeq: secondSeq,
+      lastReceivedSeq: thirdSeq,
+      updatedAt: 456,
+    });
+  });
+
+  it('excludes soft-deleted workflows from default listings and includes them explicitly', () => {
+    adapter.saveWorkflow(makeWorkflow('wf-delete', '2026-07-01T00:00:00.000Z'));
+    adapter.saveWorkflow(makeWorkflow('wf-live', '2026-07-02T00:00:00.000Z'));
+
+    adapter.deleteWorkflow('wf-delete');
+
+    expect(adapter.loadWorkflow('wf-delete')).toBeUndefined();
+    expect(adapter.listWorkflows().map((workflow) => workflow.id)).toEqual(['wf-live']);
+
+    expect(adapter.loadWorkflow('wf-delete', { includeDeleted: true })?.deletedAt)
+      .toEqual(expect.any(Number));
+    const deleted = adapter.listWorkflows({ includeDeleted: true })
+      .find((workflow) => workflow.id === 'wf-delete');
+    expect(deleted?.deletedAt).toEqual(expect.any(Number));
+  });
+
+  it('writes a tombstone journal entry when deleting a workflow', () => {
+    adapter.saveWorkflow(makeWorkflow('wf-tombstone'));
+    adapter.saveTask('wf-tombstone', makeTask('task-tombstone', 'wf-tombstone'));
+    const attempt = createAttempt('task-tombstone', { status: 'running' });
+    adapter.saveAttempt(attempt);
+    const lastSeedSeq = readJournalSince(journalDb(), 0, 10).at(-1)?.seq ?? 0;
+
+    adapter.deleteWorkflow('wf-tombstone');
+
+    const [entry] = readJournalSince(journalDb(), lastSeedSeq, 10);
+    expect(entry).toMatchObject({
+      entityType: 'workflow',
+      entityId: 'wf-tombstone',
+      op: 'tombstone',
+      origin: 'home',
+    });
+    expect(entry.payload).toEqual(expect.objectContaining({
+      id: 'wf-tombstone',
+      deleted_at: expect.any(Number),
+    }));
+  });
+});

--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -175,6 +175,73 @@ describe('sync journal', () => {
     expect(deleted?.deletedAt).toEqual(expect.any(Number));
   });
 
+  it('removes workflow-channel mappings when soft-deleting a workflow', () => {
+    adapter.saveWorkflow(makeWorkflow('wf-channel'));
+    adapter.saveWorkflowChannel({
+      workflowId: 'wf-channel',
+      channelId: 'C123',
+      createdAt: '2026-07-01T00:00:00.000Z',
+    });
+
+    expect(adapter.loadWorkflowChannelByWorkflowId('wf-channel')).toMatchObject({
+      workflowId: 'wf-channel',
+      channelId: 'C123',
+    });
+
+    adapter.deleteWorkflow('wf-channel');
+
+    expect(adapter.loadWorkflowChannelByWorkflowId('wf-channel')).toBeUndefined();
+  });
+
+  it('journals non-status task updates', () => {
+    adapter.saveWorkflow(makeWorkflow('wf-task-journal'));
+    adapter.saveTask('wf-task-journal', makeTask('task-journal', 'wf-task-journal'));
+    const lastSeedSeq = readJournalSince(journalDb(), 0, 10).at(-1)?.seq ?? 0;
+
+    adapter.updateTask('task-journal', {
+      description: 'Task journal updated',
+      config: { summary: 'Updated summary' },
+      execution: { reviewStatus: 'Awaiting review' },
+    });
+
+    expect(readJournalSince(journalDb(), lastSeedSeq, 10)).toEqual([
+      expect.objectContaining({
+        entityType: 'task',
+        entityId: 'task-journal',
+        op: 'upsert',
+        payload: expect.objectContaining({
+          description: 'Task journal updated',
+          summary: 'Updated summary',
+          review_status: 'Awaiting review',
+        }),
+      }),
+    ]);
+  });
+
+  it('journals workflow rollup changes when moving a task between workflows', () => {
+    adapter.saveWorkflow(makeWorkflow('wf-source'));
+    adapter.saveWorkflow(makeWorkflow('wf-target'));
+    adapter.saveTask('wf-source', makeTask('task-move', 'wf-source', 'completed'));
+    adapter.saveTask('wf-target', makeTask('task-anchor', 'wf-target', 'pending'));
+    const lastSeedSeq = readJournalSince(journalDb(), 0, 10).at(-1)?.seq ?? 0;
+
+    adapter.updateTask('task-move', {
+      config: { workflowId: 'wf-target' },
+    });
+
+    expect(readJournalSince(journalDb(), lastSeedSeq, 10).map((entry) => ({
+      entityType: entry.entityType,
+      entityId: entry.entityId,
+      op: entry.op,
+    }))).toEqual([
+      { entityType: 'task', entityId: 'task-move', op: 'upsert' },
+      { entityType: 'workflow', entityId: 'wf-source', op: 'upsert' },
+      { entityType: 'workflow', entityId: 'wf-target', op: 'upsert' },
+    ]);
+    expect(adapter.loadWorkflow('wf-source')?.status).toBe('pending');
+    expect(adapter.loadWorkflow('wf-target')?.status).toBe('running');
+  });
+
   it('writes a tombstone journal entry when deleting a workflow', () => {
     adapter.saveWorkflow(makeWorkflow('wf-tombstone'));
     adapter.saveTask('wf-tombstone', makeTask('task-tombstone', 'wf-tombstone'));

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -124,10 +124,15 @@ export interface Workflow {
   /** Read-only provenance for dependencies removed by `detachWorkflow`. Never re-read by scheduling. */
   detachedExternalDependencies?: DetachedExternalDependency[];
   generation?: number;
+  deletedAt?: number;
   createdAt: string;
   updatedAt: string;
 }
 export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup'>;
+
+export interface WorkflowListOptions {
+  includeDeleted?: boolean;
+}
 
 /**
  * Result of resolving a published PR back to its Invoker workflow via the merge
@@ -333,8 +338,8 @@ export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
-  loadWorkflow(workflowId: string): Workflow | undefined;
-  listWorkflows(): Workflow[];
+  loadWorkflow(workflowId: string, options?: WorkflowListOptions): Workflow | undefined;
+  listWorkflows(options?: WorkflowListOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
   /** Resolve a GitHub PR number back to its Invoker workflow via the merge node. */
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined;

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -1,6 +1,7 @@
 export * from './adapter.js';
 export * from './attempt-read-models.js';
 export * from './sqlite-adapter.js';
+export * from './sync-journal.js';
 export * from './slow-query-aggregator.js';
 export * from './conversation-repository.js';
 export * from './slack-session-repository.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -38,6 +38,7 @@ import type {
   PersistenceAdapter,
   ReviewGateLookup,
   Workflow,
+  WorkflowListOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
   TaskEvent,
@@ -78,6 +79,7 @@ import type { SqliteExecutor } from './sqlite-executor.js';
 import * as migrations from './sqlite-migrations.js';
 import { SqliteTaskAttemptRepository } from './sqlite-task-attempt-repository.js';
 import { SqliteWorkflowRepository, type WorkflowMetadataChanges } from './sqlite-workflow-repository.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 function normalizeWorkerActionStatus(status: string): string {
   return status === 'canceled' ? 'cancelled' : status;
@@ -1054,12 +1056,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.workflowRepo.updateWorkflow(workflowId, changes);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    return this.workflowRepo.loadWorkflow(workflowId);
+  loadWorkflow(workflowId: string, options?: WorkflowListOptions): Workflow | undefined {
+    return this.workflowRepo.loadWorkflow(workflowId, options);
   }
 
-  listWorkflows(): Workflow[] {
-    return this.workflowRepo.listWorkflows();
+  listWorkflows(options?: WorkflowListOptions): Workflow[] {
+    return this.workflowRepo.listWorkflows(options);
   }
 
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
@@ -1558,6 +1560,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   deleteWorkflow(workflowId: string): void {
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
+    const workflowExists = this.queryOne(
+      'SELECT id FROM workflows WHERE id = ? AND deleted_at IS NULL',
+      [workflowId],
+    );
+    if (!workflowExists) return;
+    const deletedAt = Date.now();
+    const updatedAt = new Date(deletedAt).toISOString();
     this.runTransaction(() => {
       this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
@@ -1598,7 +1607,19 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
+      this.db.run(
+        'UPDATE workflows SET deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL',
+        [deletedAt, updatedAt, workflowId],
+      );
+      const payload = this.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+      if (payload) {
+        appendJournalEntry(this.executor, {
+          entityType: 'workflow',
+          entityId: workflowId,
+          op: 'tombstone',
+          payload,
+        });
+      }
     });
     this.removeOutputFiles(taskIds);
   }

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1607,6 +1607,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
+      this.db.run('DELETE FROM workflow_channels WHERE workflow_id = ?', [workflowId]);
       this.db.run(
         'UPDATE workflows SET deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL',
         [deletedAt, updatedAt, workflowId],

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -47,6 +47,7 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
     externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
     detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) as DetachedExternalDependency[] : undefined,
     generation: row.generation ?? 0,
+    deletedAt: row.deleted_at === null || row.deleted_at === undefined ? undefined : Number(row.deleted_at),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -27,8 +27,31 @@ export const SCHEMA_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_journal (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+        entity_id TEXT NOT NULL,
+        op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+        payload TEXT NOT NULL CHECK (json_valid(payload)),
+        origin TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+
+      -- output is reserved for future output-spool sync snapshots; output rows
+      -- are intentionally not journaled by the adapter yet.
+      CREATE INDEX IF NOT EXISTS idx_sync_journal_entity
+        ON sync_journal(entity_type, entity_id, seq);
+
+      CREATE TABLE IF NOT EXISTS sync_cursors (
+        peer_id TEXT PRIMARY KEY,
+        last_sent_seq INTEGER NOT NULL DEFAULT 0,
+        last_received_seq INTEGER NOT NULL DEFAULT 0,
+        updated_at INTEGER NOT NULL
       );
 
       CREATE TABLE IF NOT EXISTS tasks (
@@ -597,6 +620,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
+  'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
 ];
 
 /**
@@ -628,6 +652,22 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  `CREATE TABLE IF NOT EXISTS sync_journal (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+    entity_id TEXT NOT NULL,
+    op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    origin TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+  )`,
+  'CREATE INDEX IF NOT EXISTS idx_sync_journal_entity ON sync_journal(entity_type, entity_id, seq)',
+  `CREATE TABLE IF NOT EXISTS sync_cursors (
+    peer_id TEXT PRIMARY KEY,
+    last_sent_seq INTEGER NOT NULL DEFAULT 0,
+    last_received_seq INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER NOT NULL
+  )`,
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */
@@ -651,6 +691,7 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       )
@@ -662,12 +703,12 @@ export const WORKFLOWS_REBUILD_INSERT_DDL = `
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       FROM workflows
     `;

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -8,15 +8,17 @@
  * transactions. Row mapping keeps coming from sqlite-row-mappers.ts; the
  * adapter retains one-line delegates for every method here.
  */
-import type { TaskState, TaskStateChanges, Attempt, TaskExecution } from '@invoker/workflow-core';
+import type { TaskState, TaskStateChanges, Attempt, TaskExecution, WorkflowDerivedStatus } from '@invoker/workflow-core';
 import {
   assertTaskConsistent,
+  computeWorkflowRollupFromSummaries,
   isDiscardedAttempt,
   normalizeRunnerKind,
 } from '@invoker/workflow-core';
 import { mapRowToTask, mapRowToAttempt } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
@@ -229,6 +231,11 @@ export class SqliteTaskAttemptRepository {
   updateTask(taskId: string, changes: TaskStateChanges): void {
     const beforeTask = this.loadTask(taskId);
     if (!beforeTask) return;
+    const statusWillChange = changes.status !== undefined && changes.status !== beforeTask.status;
+    const workflowIdForStatus = statusWillChange ? beforeTask.config.workflowId : undefined;
+    const workflowStatusBefore = workflowIdForStatus
+      ? this.computeWorkflowStatus(workflowIdForStatus)
+      : undefined;
 
     const setClauses: string[] = [];
     const values: unknown[] = [];
@@ -417,7 +424,24 @@ export class SqliteTaskAttemptRepository {
       const cols = setClauses.map((c) => c.split(/\s*=\s*/)[0]!.trim()).join(', ');
       console.log(`[persist-sql] taskId=${taskId} columns=[${cols}]`);
     }
-    this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    const writeTaskUpdate = (): void => {
+      this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
+      if (!statusWillChange) return;
+
+      this.appendTaskJournalEntry(taskId);
+      if (!workflowIdForStatus || workflowStatusBefore === undefined) return;
+      const workflowStatusAfter = this.computeWorkflowStatus(workflowIdForStatus);
+      if (workflowStatusAfter !== workflowStatusBefore) {
+        this.appendWorkflowJournalEntry(workflowIdForStatus);
+      }
+    };
+
+    if (statusWillChange) {
+      this.exec.runTransaction(writeTaskUpdate);
+      return;
+    }
+
+    writeTaskUpdate();
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -594,40 +618,43 @@ export class SqliteTaskAttemptRepository {
   // ── Attempt CRUD ─────────────────────────────────────────
 
   saveAttempt(attempt: Attempt): void {
-    this.exec.execRun(`
-      INSERT OR REPLACE INTO attempts (
-        id, node_id, attempt_number, queue_priority, status,
-        snapshot_commit, base_branch, upstream_attempt_ids,
-        command_override, prompt_override,
-        claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
-        branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
-        supersedes_attempt_id, created_at, merge_conflict
-      ) VALUES (
-        ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?,
-        ?, ?,
-        ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?, ?,
-        ?, ?, ?
-      )
-    `, [
-      attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
-      attempt.snapshotCommit ?? null, attempt.baseBranch ?? null,
-      JSON.stringify(attempt.upstreamAttemptIds),
-      attempt.commandOverride ?? null, attempt.promptOverride ?? null,
-      attempt.claimedAt?.toISOString() ?? null,
-      attempt.startedAt?.toISOString() ?? null,
-      attempt.completedAt?.toISOString() ?? null,
-      attempt.exitCode ?? null, attempt.error ?? null,
-      attempt.lastHeartbeatAt?.toISOString() ?? null,
-      attempt.leaseExpiresAt?.toISOString() ?? null,
-      attempt.branch ?? null, attempt.commit ?? null, attempt.summary ?? null,
-      attempt.workspacePath ?? null, attempt.agentSessionId ?? null,
-      attempt.containerId ?? null,
-      attempt.supersedesAttemptId ?? null,
-      attempt.createdAt.toISOString(),
-      attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
-    ]);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`
+        INSERT OR REPLACE INTO attempts (
+          id, node_id, attempt_number, queue_priority, status,
+          snapshot_commit, base_branch, upstream_attempt_ids,
+          command_override, prompt_override,
+          claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
+          branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
+          supersedes_attempt_id, created_at, merge_conflict
+        ) VALUES (
+          ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?,
+          ?, ?,
+          ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?,
+          ?, ?, ?
+        )
+      `, [
+        attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
+        attempt.snapshotCommit ?? null, attempt.baseBranch ?? null,
+        JSON.stringify(attempt.upstreamAttemptIds),
+        attempt.commandOverride ?? null, attempt.promptOverride ?? null,
+        attempt.claimedAt?.toISOString() ?? null,
+        attempt.startedAt?.toISOString() ?? null,
+        attempt.completedAt?.toISOString() ?? null,
+        attempt.exitCode ?? null, attempt.error ?? null,
+        attempt.lastHeartbeatAt?.toISOString() ?? null,
+        attempt.leaseExpiresAt?.toISOString() ?? null,
+        attempt.branch ?? null, attempt.commit ?? null, attempt.summary ?? null,
+        attempt.workspacePath ?? null, attempt.agentSessionId ?? null,
+        attempt.containerId ?? null,
+        attempt.supersedesAttemptId ?? null,
+        attempt.createdAt.toISOString(),
+        attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
+      ]);
+      this.appendAttemptJournalEntry(attempt.id);
+    });
   }
 
   loadAttempts(nodeId: string): Attempt[] {
@@ -711,7 +738,20 @@ export class SqliteTaskAttemptRepository {
 
     if (setClauses.length === 0) return;
     values.push(attemptId);
-    this.exec.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    const shouldJournalCompletion = this.shouldJournalAttemptCompletion(changes);
+    const writeAttemptUpdate = (): void => {
+      this.exec.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
+      if (shouldJournalCompletion) {
+        this.appendAttemptJournalEntry(attemptId);
+      }
+    };
+
+    if (shouldJournalCompletion) {
+      this.exec.runTransaction(writeAttemptUpdate);
+      return;
+    }
+
+    writeAttemptUpdate();
   }
 
   claimAttemptForLaunch(
@@ -888,5 +928,68 @@ export class SqliteTaskAttemptRepository {
       [nodeId, selected.createdAt.toISOString(), cappedLimit],
     );
     return rows.map((row) => mapRowToAttempt(row));
+  }
+
+  private appendTaskJournalEntry(taskId: string): void {
+    const payload = this.exec.queryOne('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (!payload) return;
+    appendJournalEntry(this.exec, {
+      entityType: 'task',
+      entityId: taskId,
+      op: 'upsert',
+      payload,
+    });
+  }
+
+  private appendAttemptJournalEntry(attemptId: string): void {
+    const payload = this.exec.queryOne('SELECT * FROM attempts WHERE id = ?', [attemptId]);
+    if (!payload) return;
+    appendJournalEntry(this.exec, {
+      entityType: 'attempt',
+      entityId: attemptId,
+      op: 'upsert',
+      payload,
+    });
+  }
+
+  private appendWorkflowJournalEntry(workflowId: string): void {
+    const payload = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+    if (!payload) return;
+    appendJournalEntry(this.exec, {
+      entityType: 'workflow',
+      entityId: workflowId,
+      op: 'upsert',
+      payload,
+    });
+  }
+
+  private computeWorkflowStatus(workflowId: string): WorkflowDerivedStatus {
+    const rows = this.exec.queryAll(
+      `SELECT id, description, status, dependencies
+         FROM tasks
+        WHERE workflow_id = ?`,
+      [workflowId],
+    ) as Array<{
+      id: string;
+      description?: string | null;
+      status: TaskState['status'];
+      dependencies?: string | null;
+    }>;
+
+    return computeWorkflowRollupFromSummaries(rows.map((row) => ({
+      id: String(row.id),
+      description: row.description ?? '',
+      status: row.status,
+      dependencies: JSON.parse(row.dependencies || '[]'),
+    }))).status;
+  }
+
+  private shouldJournalAttemptCompletion(
+    changes: Partial<Pick<Attempt, 'status' | 'completedAt'>>,
+  ): boolean {
+    return changes.completedAt !== undefined
+      || changes.status === 'completed'
+      || changes.status === 'failed'
+      || changes.status === 'needs_input';
   }
 }

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -231,11 +231,25 @@ export class SqliteTaskAttemptRepository {
   updateTask(taskId: string, changes: TaskStateChanges): void {
     const beforeTask = this.loadTask(taskId);
     if (!beforeTask) return;
-    const statusWillChange = changes.status !== undefined && changes.status !== beforeTask.status;
-    const workflowIdForStatus = statusWillChange ? beforeTask.config.workflowId : undefined;
-    const workflowStatusBefore = workflowIdForStatus
-      ? this.computeWorkflowStatus(workflowIdForStatus)
-      : undefined;
+    const afterTask = {
+      ...beforeTask,
+      ...changes,
+      config: changes.config ? ({ ...beforeTask.config, ...changes.config } as TaskState['config']) : beforeTask.config,
+      execution: changes.execution ? { ...beforeTask.execution, ...changes.execution } : beforeTask.execution,
+    };
+    const workflowIdsNeedingRollupCheck = new Set<string>();
+    if (
+      afterTask.status !== beforeTask.status
+      || changes.dependencies !== undefined
+      || afterTask.config.workflowId !== beforeTask.config.workflowId
+    ) {
+      workflowIdsNeedingRollupCheck.add(beforeTask.config.workflowId);
+      workflowIdsNeedingRollupCheck.add(afterTask.config.workflowId);
+    }
+    const workflowStatusesBefore = new Map<string, WorkflowDerivedStatus>();
+    for (const workflowId of workflowIdsNeedingRollupCheck) {
+      workflowStatusesBefore.set(workflowId, this.computeWorkflowStatus(workflowId));
+    }
 
     const setClauses: string[] = [];
     const values: unknown[] = [];
@@ -384,13 +398,7 @@ export class SqliteTaskAttemptRepository {
       }
     }
 
-
-    assertTaskConsistent({
-      ...beforeTask,
-      ...changes,
-      config: changes.config ? ({ ...beforeTask.config, ...changes.config } as TaskState['config']) : beforeTask.config,
-      execution: changes.execution ? { ...beforeTask.execution, ...changes.execution } : beforeTask.execution,
-    });
+    assertTaskConsistent(afterTask);
 
     if (setClauses.length === 0) return;
 
@@ -426,22 +434,17 @@ export class SqliteTaskAttemptRepository {
     }
     const writeTaskUpdate = (): void => {
       this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
-      if (!statusWillChange) return;
-
       this.appendTaskJournalEntry(taskId);
-      if (!workflowIdForStatus || workflowStatusBefore === undefined) return;
-      const workflowStatusAfter = this.computeWorkflowStatus(workflowIdForStatus);
-      if (workflowStatusAfter !== workflowStatusBefore) {
-        this.appendWorkflowJournalEntry(workflowIdForStatus);
+
+      for (const [workflowId, workflowStatusBefore] of workflowStatusesBefore) {
+        const workflowStatusAfter = this.computeWorkflowStatus(workflowId);
+        if (workflowStatusAfter !== workflowStatusBefore) {
+          this.appendWorkflowJournalEntry(workflowId);
+        }
       }
     };
 
-    if (statusWillChange) {
-      this.exec.runTransaction(writeTaskUpdate);
-      return;
-    }
-
-    writeTaskUpdate();
+    this.exec.runTransaction(writeTaskUpdate);
   }
 
   loadTasks(workflowId: string): TaskState[] {

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -27,6 +27,7 @@ import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ReviewGateLookup,
   Workflow,
+  WorkflowListOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
 } from './adapter.js';
@@ -89,8 +90,8 @@ export class SqliteWorkflowRepository {
   saveWorkflow(workflow: WorkflowSaveInput): void {
     assertWorkflowConsistent(workflow);
     this.exec.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, deleted_at, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       workflow.id, workflow.name,
       workflow.description ?? null,
@@ -103,6 +104,7 @@ export class SqliteWorkflowRepository {
       workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
       workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
       workflow.generation ?? 0,
+      workflow.deletedAt ?? null,
       workflow.createdAt, workflow.updatedAt,
     ]);
   }
@@ -174,16 +176,23 @@ export class SqliteWorkflowRepository {
     this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+  loadWorkflow(workflowId: string, options?: WorkflowListOptions): Workflow | undefined {
+    const row = this.exec.queryOne(
+      options?.includeDeleted
+        ? 'SELECT * FROM workflows WHERE id = ?'
+        : 'SELECT * FROM workflows WHERE id = ? AND deleted_at IS NULL',
+      [workflowId],
+    );
     if (!row) return undefined;
     const rollup = this.loadWorkflowRollups([workflowId]).get(workflowId);
     return this.rowToWorkflow(row, rollup);
   }
 
-  listWorkflows(): Workflow[] {
+  listWorkflows(options?: WorkflowListOptions): Workflow[] {
     const rows = this.exec.queryAll(
-      'SELECT * FROM workflows ORDER BY created_at DESC',
+      options?.includeDeleted
+        ? 'SELECT * FROM workflows ORDER BY created_at DESC'
+        : 'SELECT * FROM workflows WHERE deleted_at IS NULL ORDER BY created_at DESC',
     );
     const workflowIds = rows.map((row) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
@@ -205,7 +214,9 @@ export class SqliteWorkflowRepository {
               w.base_branch AS baseBranch
          FROM tasks t
          JOIN workflows w ON w.id = t.workflow_id
-        WHERE t.is_merge_node = 1 AND (t.review_id = ? OR t.review_url LIKE ?)`,
+        WHERE w.deleted_at IS NULL
+          AND t.is_merge_node = 1
+          AND (t.review_id = ? OR t.review_url LIKE ?)`,
       [pr, `%/pull/${pr}`],
     );
     if (rows.length === 0) return undefined;
@@ -257,7 +268,8 @@ export class SqliteWorkflowRepository {
     if (type === 'workflows' || type === 'all') {
       const workflows = this.exec.queryAll(
         `SELECT id, name, description, plan_file, repo_url, branch, created_at FROM workflows 
-         WHERE name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ? 
+         WHERE deleted_at IS NULL
+           AND (name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{ id: string; name?: string | null; created_at: string }>;
@@ -281,8 +293,11 @@ export class SqliteWorkflowRepository {
     
     if (type === 'tasks' || type === 'all') {
       const tasks = this.exec.queryAll(
-        `SELECT id, workflow_id, description, command, prompt, summary, problem, approach, test_plan, repro_command, status, created_at FROM tasks 
-         WHERE description LIKE ? OR command LIKE ? OR prompt LIKE ? OR summary LIKE ? OR problem LIKE ? OR approach LIKE ? OR test_plan LIKE ? OR repro_command LIKE ? 
+        `SELECT t.id, t.workflow_id, t.description, t.command, t.prompt, t.summary, t.problem, t.approach, t.test_plan, t.repro_command, t.status, t.created_at
+         FROM tasks t
+         JOIN workflows w ON w.id = t.workflow_id
+         WHERE w.deleted_at IS NULL
+           AND (t.description LIKE ? OR t.command LIKE ? OR t.prompt LIKE ? OR t.summary LIKE ? OR t.problem LIKE ? OR t.approach LIKE ? OR t.test_plan LIKE ? OR t.repro_command LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{
@@ -298,7 +313,7 @@ export class SqliteWorkflowRepository {
       if (workflowIds.length > 0) {
         const placeholders = workflowIds.map(() => '?').join(',');
         const workflowRows = this.exec.queryAll(
-          `SELECT id, name FROM workflows WHERE id IN (${placeholders})`,
+          `SELECT id, name FROM workflows WHERE deleted_at IS NULL AND id IN (${placeholders})`,
           workflowIds
         ) as Array<{ id: string; name?: string | null }>;
         for (const wf of workflowRows) {
@@ -326,10 +341,16 @@ export class SqliteWorkflowRepository {
   loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
     const totalStartedAt = Date.now();
     const workflowQueryStartedAt = Date.now();
-    const workflowRows = this.exec.queryAll('SELECT * FROM workflows ORDER BY created_at DESC');
+    const workflowRows = this.exec.queryAll('SELECT * FROM workflows WHERE deleted_at IS NULL ORDER BY created_at DESC');
     const workflowMetadataQueryMs = Date.now() - workflowQueryStartedAt;
     const taskQueryStartedAt = Date.now();
-    const taskRows = this.exec.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC');
+    const taskRows = this.exec.queryAll(`
+      SELECT t.*
+      FROM tasks t
+      JOIN workflows w ON w.id = t.workflow_id
+      WHERE w.deleted_at IS NULL
+      ORDER BY t.workflow_id ASC, t.id ASC
+    `);
     const taskQueryMs = Date.now() - taskQueryStartedAt;
     const tasksByWorkflowId = new Map<string, TaskState[]>();
     const workflowIds = workflowRows.map((row) => String(row.id));

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -1,0 +1,147 @@
+import type { SqliteExecutor } from './sqlite-executor.js';
+
+export type SyncJournalEntityType = 'workflow' | 'task' | 'attempt' | 'event' | 'output';
+export type SyncJournalOperation = 'upsert' | 'tombstone';
+
+export interface SyncJournalEntryInput {
+  entityType: SyncJournalEntityType;
+  entityId: string;
+  op: SyncJournalOperation;
+  payload: unknown;
+  /** Local owner writes use `home`; remote replay can stamp the source machine id later. */
+  origin?: string;
+  createdAt?: number;
+}
+
+export interface SyncJournalEntry {
+  seq: number;
+  entityType: SyncJournalEntityType;
+  entityId: string;
+  op: SyncJournalOperation;
+  payload: unknown;
+  origin: string;
+  createdAt: number;
+}
+
+export interface SyncCursor {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt: number;
+}
+
+export interface SyncCursorValues {
+  lastSentSeq?: number;
+  lastReceivedSeq?: number;
+  updatedAt?: number;
+}
+
+export type SyncCursorUpdate = SyncCursorValues & { peerId: string };
+
+export type SyncJournalDb = Pick<SqliteExecutor, 'queryOne' | 'queryAll' | 'execRun'>;
+
+// `output` is intentionally part of the enum for the future output-spool sync
+// journal, but the adapter does not append high-volume output entries yet.
+const ENTITY_TYPES: ReadonlySet<string> = new Set(['workflow', 'task', 'attempt', 'event', 'output']);
+const OPERATIONS: ReadonlySet<string> = new Set(['upsert', 'tombstone']);
+
+export function appendJournalEntry(db: SyncJournalDb, entry: SyncJournalEntryInput): number {
+  if (!ENTITY_TYPES.has(entry.entityType)) {
+    throw new Error(`Invalid sync journal entity_type: ${entry.entityType}`);
+  }
+  if (!OPERATIONS.has(entry.op)) {
+    throw new Error(`Invalid sync journal op: ${entry.op}`);
+  }
+
+  const payloadJson = JSON.stringify(entry.payload ?? null);
+  db.execRun(
+    `INSERT INTO sync_journal (entity_type, entity_id, op, payload, origin, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [
+      entry.entityType,
+      entry.entityId,
+      entry.op,
+      payloadJson,
+      entry.origin ?? 'home',
+      entry.createdAt ?? Date.now(),
+    ],
+  );
+
+  const row = db.queryOne('SELECT last_insert_rowid() AS seq');
+  return Number(row?.seq ?? 0);
+}
+
+export function readJournalSince(
+  db: SyncJournalDb,
+  seq: number,
+  limit: number,
+): SyncJournalEntry[] {
+  const cappedLimit = Math.max(0, Math.trunc(limit));
+  if (cappedLimit === 0) return [];
+
+  const rows = db.queryAll(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq > ?
+      ORDER BY seq ASC
+      LIMIT ?`,
+    [Math.max(0, Math.trunc(seq)), cappedLimit],
+  );
+  return rows.map(mapJournalRow);
+}
+
+export function getSyncCursor(db: SyncJournalDb, peerId: string): SyncCursor | undefined {
+  const row = db.queryOne(
+    `SELECT peer_id, last_sent_seq, last_received_seq, updated_at
+       FROM sync_cursors
+      WHERE peer_id = ?`,
+    [peerId],
+  );
+  return row ? mapCursorRow(row) : undefined;
+}
+
+export function setSyncCursor(db: SyncJournalDb, cursor: SyncCursorUpdate): void;
+export function setSyncCursor(db: SyncJournalDb, peerId: string, values: SyncCursorValues): void;
+export function setSyncCursor(
+  db: SyncJournalDb,
+  cursorOrPeerId: SyncCursorUpdate | string,
+  values: SyncCursorValues = {},
+): void {
+  const peerId = typeof cursorOrPeerId === 'string' ? cursorOrPeerId : cursorOrPeerId.peerId;
+  const patch = typeof cursorOrPeerId === 'string' ? values : cursorOrPeerId;
+  const existing = getSyncCursor(db, peerId);
+  const lastSentSeq = patch.lastSentSeq ?? existing?.lastSentSeq ?? 0;
+  const lastReceivedSeq = patch.lastReceivedSeq ?? existing?.lastReceivedSeq ?? 0;
+  const updatedAt = patch.updatedAt ?? Date.now();
+
+  db.execRun(
+    `INSERT INTO sync_cursors (peer_id, last_sent_seq, last_received_seq, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(peer_id) DO UPDATE SET
+       last_sent_seq = excluded.last_sent_seq,
+       last_received_seq = excluded.last_received_seq,
+       updated_at = excluded.updated_at`,
+    [peerId, lastSentSeq, lastReceivedSeq, updatedAt],
+  );
+}
+
+function mapJournalRow(row: Record<string, unknown>): SyncJournalEntry {
+  return {
+    seq: Number(row.seq ?? 0),
+    entityType: String(row.entity_type) as SyncJournalEntityType,
+    entityId: String(row.entity_id),
+    op: String(row.op) as SyncJournalOperation,
+    payload: JSON.parse(String(row.payload ?? 'null')),
+    origin: String(row.origin ?? ''),
+    createdAt: Number(row.created_at ?? 0),
+  };
+}
+
+function mapCursorRow(row: Record<string, unknown>): SyncCursor {
+  return {
+    peerId: String(row.peer_id),
+    lastSentSeq: Number(row.last_sent_seq ?? 0),
+    lastReceivedSeq: Number(row.last_received_seq ?? 0),
+    updatedAt: Number(row.updated_at ?? 0),
+  };
+}

--- a/scripts/repro/repro-coderabbit-pr6198-stale-workflow-channel-on-soft-delete.sh
+++ b/scripts/repro/repro-coderabbit-pr6198-stale-workflow-channel-on-soft-delete.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "Repro: workflow soft-delete must clear workflow-channel mappings"
+if pnpm --filter @invoker/data-store test -- src/__tests__/sync-journal.test.ts -t "removes workflow-channel mappings when soft-deleting a workflow"; then
+  echo "PASS: soft-deleted workflows no longer keep workflow-channel mappings"
+else
+  echo "FAIL: soft-deleted workflows still keep workflow-channel mappings"
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr6198-task-update-sync-journal.sh
+++ b/scripts/repro/repro-coderabbit-pr6198-task-update-sync-journal.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "Repro: task updates must journal non-status mutations and affected workflow rollups"
+if ! pnpm --filter @invoker/data-store test -- src/__tests__/sync-journal.test.ts -t "journals non-status task updates"; then
+  echo "FAIL: non-status task updates still miss sync journal entries"
+  exit 1
+fi
+if ! pnpm --filter @invoker/data-store test -- src/__tests__/sync-journal.test.ts -t "journals workflow rollup changes when moving a task between workflows"; then
+  echo "FAIL: moved tasks still miss affected workflow journal entries"
+  exit 1
+fi
+
+echo "PASS: task updates journal non-status mutations and affected workflow rollups"


### PR DESCRIPTION
## Summary

Remote Sync Step 1: Sync Schema and Change Journal — 2 tasks completed, 0 failed, 0 closed, 0 ski&#112;ped

Remote sync now has data-store tables for journal entries, peer cursors, and workflow tombstones.

Workflow, task, and attempt writes append journal entries inside the same SQLite transaction.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926077035-3/implement-sync-schema | Add sync journal, cursor, and tombstone schema to data-store | completed |
| wf-1784926077035-3/verify-sync-schema | Run data-store package tests covering the new schema and journal | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784926077035-3/implement-sync-schema — Add sync journal, cursor, and tombstone schema to data-store

### wf-1784926077035-3/verify-sync-schema — Run data-store package tests covering the new schema and journal

</details>

## Review Claim

Approve the data-store sync schema contract: journal entries, peer cursors, and workflow tombstones are durable alongside existing persistence writes.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This slice stays inside data-store schema, repositories, mappers, adapter exports, and focused sync-journal tests.

## Slice Rationale

Remote sync needs durable change capture before later transport, replay, or conflict resolution slices can consume it.

## Non-goals

- No remote transport.
- No sync replay worker.
- No UI changes.

## Architecture

### Before

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["entity tables only"]
    C["Remote sync peers"] --> D["no durable cursor contract"]
```

### After

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["entity tables"]
    A --> C["sync_journal rows in the same transaction"]
    D["Remote sync peers"] --> E["sync_cursors record last sent and received sequence"]
    F["Workflow deletion"] --> G["deleted_at tombstone and journal row"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sync-journal.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 6a2109cc2`
- Post-revert steps: None
- Data migration? No production migration has shipped yet.

</details>
