### PR TITLE
[Bugfix: main-process planner surfaces lazy-load](1) Defer planner surfaces load

### DIFF
--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -43,8 +43,13 @@ import {
   summarizePlanText,
   type PlanningMessage,
 } from '@invoker/planning-core';
-import { selectHarnessSessionDriver } from '@invoker/surfaces';
-import type { HarnessPreset, PlanConversation, PlanConversationConfig, PlanningCommandBuilder } from '@invoker/surfaces';
+import type {
+  HarnessPreset,
+  HarnessSessionDriverDeps,
+  PlanConversation,
+  PlanConversationConfig,
+  PlanningCommandBuilder,
+} from '@invoker/surfaces';
 import type { InvokerConfig } from './config.js';
 
 export interface LoadedGeneratedPlan {
@@ -113,12 +118,17 @@ function isModuleResolutionError(error: unknown): boolean {
 }
 
 type PlanConversationConstructor = new (config: PlanConversationConfig) => PlanConversation;
+type HarnessSessionDriverSelector = (
+  preset: HarnessPreset,
+  deps: HarnessSessionDriverDeps,
+) => PlanConversationConfig['harnessSessionDriver'];
 
 interface PlannerSurfacesModule {
   BUILTIN_HARNESS_PRESETS: Record<string, HarnessPreset>;
   DEFAULT_HARNESS_PRESET: string;
   PlanConversation: PlanConversationConstructor;
   extractYamlPlan: (output: string) => string | null;
+  selectHarnessSessionDriver: HarnessSessionDriverSelector;
 }
 
 async function loadPlannerSurfaces(): Promise<PlannerSurfacesModule> {
@@ -372,6 +382,7 @@ function planConversationConfig(
   preset: HarnessPreset,
   deps: Pick<InAppPlannerDeps, 'config' | 'workingDir' | 'planningCommandBuilder' | 'executionAgentRegistry' | 'conversationRepo' | 'onRawPlannerOutput'>,
   threadTs: string,
+  selectHarnessSessionDriver: HarnessSessionDriverSelector,
   options: { conversationalPlanning?: boolean } = {},
 ): PlanConversationConfig {
   return {
@@ -417,7 +428,7 @@ async function createSession(
     return { error: `Unknown planner preset "${presetKey}".` };
   }
 
-  const { PlanConversation } = await loadPlannerSurfaces();
+  const { PlanConversation, selectHarnessSessionDriver } = await loadPlannerSurfaces();
   const createdAt = new Date().toISOString();
   const id = randomUUID();
   const confirmationMode = normalizePlanningConfirmationMode(
@@ -431,7 +442,13 @@ async function createSession(
     confirmationMode,
     status: 'still_discussing',
     messages: [],
-    conversation: new PlanConversation(planConversationConfig(preset, deps, id, { conversationalPlanning: true })),
+    conversation: new PlanConversation(planConversationConfig(
+      preset,
+      deps,
+      id,
+      selectHarnessSessionDriver,
+      { conversationalPlanning: true },
+    )),
     createdAt,
     updatedAt: createdAt,
     nextMessageId: 1,
@@ -481,8 +498,13 @@ export async function planFromGoal(
   }
 
   try {
-    const { PlanConversation, extractYamlPlan } = await loadPlannerSurfaces();
-    const conversation = new PlanConversation(planConversationConfig(preset, deps, randomUUID()));
+    const { PlanConversation, extractYamlPlan, selectHarnessSessionDriver } = await loadPlannerSurfaces();
+    const conversation = new PlanConversation(planConversationConfig(
+      preset,
+      deps,
+      randomUUID(),
+      selectHarnessSessionDriver,
+    ));
     const plannerOutput = await conversation.sendMessage(goal);
     const planText = extractYamlPlan(plannerOutput);
     if (!planText) {
@@ -860,13 +882,18 @@ export async function restorePlanningChatSessions(
   // boots without surfaces/dist, so an eager load here would crash startup with no sessions.
   if (records.length === 0) return;
   const presets = await resolveHarnessPresets(deps.config);
-  const { PlanConversation } = await loadPlannerSurfaces();
+  const { PlanConversation, selectHarnessSessionDriver } = await loadPlannerSurfaces();
 
   for (const record of records) {
     const preset = presets[record.presetKey];
     if (!preset) continue;
 
-    const conversation = new PlanConversation(planConversationConfig(preset, deps, record.id));
+    const conversation = new PlanConversation(planConversationConfig(
+      preset,
+      deps,
+      record.id,
+      selectHarnessSessionDriver,
+    ));
     await conversation.init();
 
     const nextMessageId = Math.max(0, ...record.messages.map((message) => message.id)) + 1;


### PR DESCRIPTION
## Summary

`in-app-planner.ts` no longer imports the runtime surfaces selector while the module is being evaluated.

Planner sessions still load surfaces through the existing lazy fallback before they construct conversations.

## Review Claim

The planner module can be imported during desktop startup without resolving `@invoker/surfaces` before `loadPlannerSurfaces()` can run.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Session creation, restore, submit, and tmux state behavior stay unchanged except for deferring when the surfaces package is resolved.

## Slice Rationale

One behavior slice defers the runtime load boundary in `in-app-planner.ts`; the proof task stayed separate and produced no file changes.

## Non-goals

- No planning UX changes.
- No new preset behavior.
- No unrelated startup logging work.
- No proof harness changes in this PR.

## Architecture

### Before

```mermaid
graph TD
    A["main.ts imports in-app-planner.js"] --> B["module evaluation imports @invoker/surfaces"]
    B --> C["startup can fail before lazy fallback"]
```

### After

```mermaid
graph TD
    A["main.ts imports in-app-planner.js"] --> B["module evaluation keeps only surfaces types"]
    B --> C["planning flow calls loadPlannerSurfaces()"]
    C --> D["lazy package, dist, or source fallback resolves runtime exports"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `set -eu; mkdir -p .tmp; TMP=$(mktemp -d ./.tmp/verify-main-process-surfaces.XXXXXX); trap 'rm -rf "$TMP"' EXIT; cat > "$TMP/tsup.config.ts" <<EOF
import { defineConfig } from "tsup";

export default defineConfig({
  entry: ["packages/app/src/in-app-planner.ts"],
  format: ["cjs"],
  platform: "node",
  bundle: true,
  splitting: false,
  sourcemap: false,
  clean: true,
  outDir: "${TMP}/out",
  external: ["@invoker/surfaces"],
  noExternal: [
    "@invoker/contracts",
    "@invoker/data-store",
    "@invoker/execution-engine",
    "@invoker/planning-core"
  ]
});
EOF
pnpm exec tsup --config "$TMP/tsup.config.ts"; node - "$TMP/out/in-app-planner.js" <<'NODE'
const fs = require("node:fs");
const bundlePath = process.argv[2];
const bundle = fs.readFileSync(bundlePath, "utf8");
if (bundle.includes('require("@invoker/surfaces")')) {
  throw new Error('bundle still contains a top-level require("@invoker/surfaces")');
}
NODE
node "$TMP/out/in-app-planner.js"`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts -t "restores draft-ready sessions and submits from persisted approved draft text|restores persisted tmux mode and planning-owned terminal state|clears submitted pending-response state during restore"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 74113a088`
- Post-revert steps: None
- Data migration? No

</details>
