### PR TITLE
[Remote Sync Step 1: Sync Schema and Change Journal](1) Add data-store sync schema and journal

### DIFF
--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createAttempt, createTaskState } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { Workflow } from '../adapter.js';
+import type { SqliteExecutor } from '../sqlite-executor.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  readJournalSince,
+  setSyncCursor,
+} from '../sync-journal.js';
+
+describe('sync journal', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function exec(): SqliteExecutor {
+    return (adapter as unknown as { executor: SqliteExecutor }).executor;
+  }
+
+  function workflow(id: string): Workflow {
+    return {
+      id,
+      name: id,
+      status: 'pending',
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+    };
+  }
+
+  it('rolls back a journal append with the mutation that created it', () => {
+    expect(() => {
+      adapter.runInTransaction(() => {
+        adapter.saveWorkflow(workflow('wf-rollback'));
+        throw new Error('rollback sentinel');
+      });
+    }).toThrow(/rollback sentinel/);
+
+    expect(adapter.loadWorkflow('wf-rollback', { includeDeleted: true })).toBeUndefined();
+    expect(readJournalSince(exec(), 0, 10)).toEqual([]);
+  });
+
+  it('allocates strictly monotonic seq values', () => {
+    adapter.saveWorkflow(workflow('wf-seq'));
+    adapter.saveTask(
+      'wf-seq',
+      createTaskState('task-seq', 'Task Seq', [], { workflowId: 'wf-seq' }),
+    );
+    adapter.updateTask('task-seq', { status: 'running' });
+    adapter.saveAttempt(createAttempt('task-seq', { status: 'running' }));
+
+    const entries = readJournalSince(exec(), 0, 20);
+    expect(entries.length).toBeGreaterThanOrEqual(4);
+    for (let i = 1; i < entries.length; i += 1) {
+      expect(entries[i].seq).toBeGreaterThan(entries[i - 1].seq);
+    }
+  });
+
+  it('reads journal entries after the provided cursor', () => {
+    appendJournalEntry(exec(), {
+      entityType: 'event',
+      entityId: 'event-1',
+      op: 'upsert',
+      payload: { id: 1 },
+    });
+    appendJournalEntry(exec(), {
+      entityType: 'event',
+      entityId: 'event-2',
+      op: 'upsert',
+      payload: { id: 2 },
+    });
+    appendJournalEntry(exec(), {
+      entityType: 'event',
+      entityId: 'event-3',
+      op: 'upsert',
+      payload: { id: 3 },
+    });
+
+    const [first] = readJournalSince(exec(), 0, 1);
+    setSyncCursor(exec(), {
+      peerId: 'peer-a',
+      lastSentSeq: first.seq,
+      lastReceivedSeq: 7,
+      updatedAt: '2026-07-27T00:01:00.000Z',
+    });
+
+    const cursor = getSyncCursor(exec(), 'peer-a')!;
+    expect(cursor).toMatchObject({
+      peerId: 'peer-a',
+      lastSentSeq: first.seq,
+      lastReceivedSeq: 7,
+      updatedAt: '2026-07-27T00:01:00.000Z',
+    });
+    expect(readJournalSince(exec(), cursor.lastSentSeq, 10).map((entry) => entry.entityId))
+      .toEqual(['event-2', 'event-3']);
+  });
+
+  it('excludes soft-deleted workflows by default and includes them on request', () => {
+    adapter.saveWorkflow(workflow('wf-delete'));
+    adapter.saveWorkflow(workflow('wf-keep'));
+
+    adapter.deleteWorkflow('wf-delete');
+
+    expect(adapter.listWorkflows().map((wf) => wf.id)).toEqual(['wf-keep']);
+    const withDeleted = adapter.listWorkflows({ includeDeleted: true });
+    const deleted = withDeleted.find((wf) => wf.id === 'wf-delete');
+    expect(deleted?.deletedAt).toEqual(expect.any(Number));
+    expect(adapter.loadWorkflow('wf-delete')).toBeUndefined();
+    expect(adapter.loadWorkflow('wf-delete', { includeDeleted: true })?.deletedAt)
+      .toEqual(expect.any(Number));
+  });
+
+  it('writes a tombstone journal entry when a workflow is soft-deleted', () => {
+    adapter.saveWorkflow(workflow('wf-tombstone'));
+
+    adapter.deleteWorkflow('wf-tombstone');
+
+    const tombstone = readJournalSince(exec(), 0, 20)
+      .find((entry) => (
+        entry.entityType === 'workflow'
+        && entry.entityId === 'wf-tombstone'
+        && entry.op === 'tombstone'
+      ));
+    expect(tombstone).toBeDefined();
+    expect(tombstone!.origin).toBe('home');
+    expect(tombstone!.payload).toMatchObject({
+      id: 'wf-tombstone',
+      deleted_at: expect.any(Number),
+    });
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -124,10 +124,14 @@ export interface Workflow {
   /** Read-only provenance for dependencies removed by `detachWorkflow`. Never re-read by scheduling. */
   detachedExternalDependencies?: DetachedExternalDependency[];
   generation?: number;
+  deletedAt?: number;
   createdAt: string;
   updatedAt: string;
 }
-export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup'>;
+export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup' | 'deletedAt'>;
+export interface WorkflowListOptions {
+  includeDeleted?: boolean;
+}
 
 /**
  * Result of resolving a published PR back to its Invoker workflow via the merge
@@ -333,8 +337,8 @@ export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
-  loadWorkflow(workflowId: string): Workflow | undefined;
-  listWorkflows(): Workflow[];
+  loadWorkflow(workflowId: string, opts?: WorkflowListOptions): Workflow | undefined;
+  listWorkflows(opts?: WorkflowListOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
   /** Resolve a GitHub PR number back to its Invoker workflow via the merge node. */
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined;

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -7,3 +7,4 @@ export * from './slack-session-repository.js';
 export * from './slack-plan-draft-repository.js';
 export * from './sqlite-task-repository.js';
 export * from './workflow-channel-repository.js';
+export * from './sync-journal.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -38,6 +38,7 @@ import type {
   PersistenceAdapter,
   ReviewGateLookup,
   Workflow,
+  WorkflowListOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
   TaskEvent,
@@ -78,6 +79,7 @@ import type { SqliteExecutor } from './sqlite-executor.js';
 import * as migrations from './sqlite-migrations.js';
 import { SqliteTaskAttemptRepository } from './sqlite-task-attempt-repository.js';
 import { SqliteWorkflowRepository, type WorkflowMetadataChanges } from './sqlite-workflow-repository.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 function normalizeWorkerActionStatus(status: string): string {
   return status === 'canceled' ? 'cancelled' : status;
@@ -1054,12 +1056,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.workflowRepo.updateWorkflow(workflowId, changes);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    return this.workflowRepo.loadWorkflow(workflowId);
+  loadWorkflow(workflowId: string, opts?: WorkflowListOptions): Workflow | undefined {
+    return this.workflowRepo.loadWorkflow(workflowId, opts);
   }
 
-  listWorkflows(): Workflow[] {
-    return this.workflowRepo.listWorkflows();
+  listWorkflows(opts?: WorkflowListOptions): Workflow[] {
+    return this.workflowRepo.listWorkflows(opts);
   }
 
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
@@ -1559,6 +1561,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
   deleteWorkflow(workflowId: string): void {
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
     this.runTransaction(() => {
+      const workflow = this.queryOne(
+        'SELECT id FROM workflows WHERE id = ? AND deleted_at IS NULL',
+        [workflowId],
+      );
+      if (!workflow) return;
+      const deletedAt = Date.now();
+      const updatedAt = new Date(deletedAt).toISOString();
       this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM task_launch_dispatch WHERE workflow_id = ?', [workflowId]);
@@ -1598,7 +1607,18 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
+      this.execRun(
+        'UPDATE workflows SET deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL',
+        [deletedAt, updatedAt, workflowId],
+      );
+      const row = this.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+      if (!row) return;
+      appendJournalEntry(this.executor, {
+        entityType: 'workflow',
+        entityId: workflowId,
+        op: 'tombstone',
+        payload: row,
+      });
     });
     this.removeOutputFiles(taskIds);
   }

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -47,6 +47,7 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
     externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
     detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) as DetachedExternalDependency[] : undefined,
     generation: row.generation ?? 0,
+    deletedAt: row.deleted_at ?? undefined,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -27,8 +27,26 @@ export const SCHEMA_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_journal (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+        entity_id TEXT NOT NULL,
+        op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+        payload TEXT NOT NULL CHECK (json_valid(payload)),
+        origin TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_cursors (
+        peer_id TEXT PRIMARY KEY,
+        last_sent_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_sent_seq) = 'integer' AND last_sent_seq >= 0),
+        last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
       );
 
       CREATE TABLE IF NOT EXISTS tasks (
@@ -597,6 +615,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
+  'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
 ];
 
 /**
@@ -628,6 +647,21 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  `CREATE TABLE IF NOT EXISTS sync_journal (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+    entity_id TEXT NOT NULL,
+    op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    origin TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`,
+  `CREATE TABLE IF NOT EXISTS sync_cursors (
+    peer_id TEXT PRIMARY KEY,
+    last_sent_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_sent_seq) = 'integer' AND last_sent_seq >= 0),
+    last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`,
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */
@@ -651,6 +685,7 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       )
@@ -662,12 +697,12 @@ export const WORKFLOWS_REBUILD_INSERT_DDL = `
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       FROM workflows
     `;

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -17,6 +17,7 @@ import {
 import { mapRowToTask, mapRowToAttempt } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
@@ -113,120 +114,127 @@ export class SqliteTaskAttemptRepository {
     assertTaskConsistent(task);
     const cfg = task.config;
     const exec = task.execution;
-    this.exec.execRun(`
-      INSERT OR REPLACE INTO tasks (
-        id, workflow_id, description, status, blocked_by, dependencies,
-        command, prompt, experiment_prompt, exit_code, error, protocol_error_code, protocol_error_message, input_prompt, external_dependencies,
-        summary, problem, approach, test_plan, repro_command, fix_prompt, fix_context,
-        branch, commit_hash, fixed_integration_sha, fixed_integration_recorded_at, fixed_integration_source, parent_task,
-        pivot, experiment_variants, is_reconciliation, selected_experiment,
-        selected_experiments, experiment_results, requires_manual_approval,
-        repo_url, feature_branch,
-        is_merge_node, auto_fix, max_fix_attempts,
-        runner_kind, pool_id, agent_session_id, workspace_path, container_id,
-        last_agent_session_id, last_agent_name,
-        action_request_id, experiments,
-        created_at, launch_phase, launch_started_at, launch_completed_at, started_at, completed_at, last_heartbeat_at,
-        utilization, pending_fix_error, fix_session_entry_status, failure_class,
-        review_url, review_id, review_status, review_provider_id, review_gate,
-        is_fixing_with_ai,
-        execution_generation,
-        selected_attempt_id,
-        pool_member_id,
-        docker_image,
-        execution_agent,
-        execution_model,
-        agent_name,
-        task_state_version
-      ) VALUES (
-        ?, ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?, ?,
-        ?, ?, ?, ?,
-        ?, ?, ?,
-        ?, ?,
-        ?, ?, ?,
-        ?, ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?, ?,
-        ?, ?,
-        ?, ?, ?, ?,
-        ?, ?,
-        ?, ?, ?, ?, ?,
-        ?,
-        ?,
-        ?,
-        ?,
-        ?,
-        ?,
-        ?,
-        ?,
-        ?
-      )
-    `, [
-      task.id, workflowId, task.description, task.status,
-      exec.blockedBy ?? null,
-      JSON.stringify(task.dependencies),
-      cfg.command ?? null, cfg.prompt ?? null, cfg.experimentPrompt ?? null,
-      exec.exitCode ?? null, exec.error ?? null, exec.protocolErrorCode ?? null, exec.protocolErrorMessage ?? null, exec.inputPrompt ?? null,
-      null,
-      cfg.summary ?? null, cfg.problem ?? null, cfg.approach ?? null,
-      cfg.testPlan ?? null, cfg.reproCommand ?? null, cfg.fixPrompt ?? null, cfg.fixContext ?? null,
-      exec.branch ?? null,
-      exec.commit ?? null,
-      exec.fixedIntegrationSha ?? null,
-      exec.fixedIntegrationRecordedAt?.toISOString() ?? null,
-      exec.fixedIntegrationSource ?? null,
-      cfg.parentTask ?? null,
-      cfg.pivot ? 1 : 0,
-      cfg.experimentVariants ? JSON.stringify(cfg.experimentVariants) : null,
-      cfg.isReconciliation ? 1 : 0,
-      exec.selectedExperiment ?? null,
-      exec.selectedExperiments ? JSON.stringify(exec.selectedExperiments) : null,
-      exec.experimentResults ? JSON.stringify(exec.experimentResults) : null,
-      cfg.requiresManualApproval ? 1 : 0,
-      null, cfg.featureBranch ?? null,
-      cfg.isMergeNode ? 1 : 0,
-      0, null,
-      cfg.runnerKind ?? null,
-      cfg.poolId ?? null,
-      exec.agentSessionId ?? null,
-      exec.workspacePath ?? null,
-      exec.containerId ?? null,
-      exec.lastAgentSessionId ?? null,
-      exec.lastAgentName ?? null,
-      exec.actionRequestId ?? null,
-      exec.experiments ? JSON.stringify(exec.experiments) : null,
-      task.createdAt.toISOString(),
-      exec.phase ?? null,
-      exec.launchStartedAt?.toISOString() ?? null,
-      exec.launchCompletedAt?.toISOString() ?? null,
-      exec.startedAt?.toISOString() ?? null,
-      exec.completedAt?.toISOString() ?? null,
-      exec.lastHeartbeatAt?.toISOString() ?? null,
-      null,
-      exec.pendingFixError ?? null,
-      exec.fixSessionEntryStatus ?? null,
-      exec.failureClass ?? null,
-      exec.reviewUrl ?? null,
-      exec.reviewId ?? null,
-      exec.reviewStatus ?? null,
-      exec.reviewProviderId ?? null,
-      exec.reviewGate ? JSON.stringify(exec.reviewGate) : null,
-      exec.isFixingWithAI ? 1 : 0,
-      exec.generation ?? 0,
-      exec.selectedAttemptId ?? null,
-      (cfg as { poolMemberId?: string }).poolMemberId ?? null,
-      cfg.dockerImage ?? null,
-      cfg.executionAgent ?? null,
-      cfg.executionModel ?? null,
-      exec.agentName ?? null,
-      task.taskStateVersion ?? 1,
-    ]);
-    this.syncCrashPreservationState(task.id, undefined, task.execution);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`
+        INSERT OR REPLACE INTO tasks (
+          id, workflow_id, description, status, blocked_by, dependencies,
+          command, prompt, experiment_prompt, exit_code, error, protocol_error_code, protocol_error_message, input_prompt, external_dependencies,
+          summary, problem, approach, test_plan, repro_command, fix_prompt, fix_context,
+          branch, commit_hash, fixed_integration_sha, fixed_integration_recorded_at, fixed_integration_source, parent_task,
+          pivot, experiment_variants, is_reconciliation, selected_experiment,
+          selected_experiments, experiment_results, requires_manual_approval,
+          repo_url, feature_branch,
+          is_merge_node, auto_fix, max_fix_attempts,
+          runner_kind, pool_id, agent_session_id, workspace_path, container_id,
+          last_agent_session_id, last_agent_name,
+          action_request_id, experiments,
+          created_at, launch_phase, launch_started_at, launch_completed_at, started_at, completed_at, last_heartbeat_at,
+          utilization, pending_fix_error, fix_session_entry_status, failure_class,
+          review_url, review_id, review_status, review_provider_id, review_gate,
+          is_fixing_with_ai,
+          execution_generation,
+          selected_attempt_id,
+          pool_member_id,
+          docker_image,
+          execution_agent,
+          execution_model,
+          agent_name,
+          task_state_version
+        ) VALUES (
+          ?, ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?,
+          ?, ?, ?, ?,
+          ?, ?, ?,
+          ?, ?,
+          ?, ?, ?,
+          ?, ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?, ?,
+          ?, ?,
+          ?, ?, ?, ?,
+          ?, ?,
+          ?, ?, ?, ?, ?,
+          ?,
+          ?,
+          ?,
+          ?,
+          ?,
+          ?,
+          ?,
+          ?,
+          ?
+        )
+      `, [
+        task.id, workflowId, task.description, task.status,
+        exec.blockedBy ?? null,
+        JSON.stringify(task.dependencies),
+        cfg.command ?? null, cfg.prompt ?? null, cfg.experimentPrompt ?? null,
+        exec.exitCode ?? null, exec.error ?? null, exec.protocolErrorCode ?? null, exec.protocolErrorMessage ?? null, exec.inputPrompt ?? null,
+        null,
+        cfg.summary ?? null, cfg.problem ?? null, cfg.approach ?? null,
+        cfg.testPlan ?? null, cfg.reproCommand ?? null, cfg.fixPrompt ?? null, cfg.fixContext ?? null,
+        exec.branch ?? null,
+        exec.commit ?? null,
+        exec.fixedIntegrationSha ?? null,
+        exec.fixedIntegrationRecordedAt?.toISOString() ?? null,
+        exec.fixedIntegrationSource ?? null,
+        cfg.parentTask ?? null,
+        cfg.pivot ? 1 : 0,
+        cfg.experimentVariants ? JSON.stringify(cfg.experimentVariants) : null,
+        cfg.isReconciliation ? 1 : 0,
+        exec.selectedExperiment ?? null,
+        exec.selectedExperiments ? JSON.stringify(exec.selectedExperiments) : null,
+        exec.experimentResults ? JSON.stringify(exec.experimentResults) : null,
+        cfg.requiresManualApproval ? 1 : 0,
+        null, cfg.featureBranch ?? null,
+        cfg.isMergeNode ? 1 : 0,
+        0, null,
+        cfg.runnerKind ?? null,
+        cfg.poolId ?? null,
+        exec.agentSessionId ?? null,
+        exec.workspacePath ?? null,
+        exec.containerId ?? null,
+        exec.lastAgentSessionId ?? null,
+        exec.lastAgentName ?? null,
+        exec.actionRequestId ?? null,
+        exec.experiments ? JSON.stringify(exec.experiments) : null,
+        task.createdAt.toISOString(),
+        exec.phase ?? null,
+        exec.launchStartedAt?.toISOString() ?? null,
+        exec.launchCompletedAt?.toISOString() ?? null,
+        exec.startedAt?.toISOString() ?? null,
+        exec.completedAt?.toISOString() ?? null,
+        exec.lastHeartbeatAt?.toISOString() ?? null,
+        null,
+        exec.pendingFixError ?? null,
+        exec.fixSessionEntryStatus ?? null,
+        exec.failureClass ?? null,
+        exec.reviewUrl ?? null,
+        exec.reviewId ?? null,
+        exec.reviewStatus ?? null,
+        exec.reviewProviderId ?? null,
+        exec.reviewGate ? JSON.stringify(exec.reviewGate) : null,
+        exec.isFixingWithAI ? 1 : 0,
+        exec.generation ?? 0,
+        exec.selectedAttemptId ?? null,
+        (cfg as { poolMemberId?: string }).poolMemberId ?? null,
+        cfg.dockerImage ?? null,
+        cfg.executionAgent ?? null,
+        cfg.executionModel ?? null,
+        exec.agentName ?? null,
+        task.taskStateVersion ?? 1,
+      ]);
+      this.syncCrashPreservationState(task.id, undefined, task.execution);
+      this.appendTaskJournal(task.id);
+    });
   }
 
   updateTask(taskId: string, changes: TaskStateChanges): void {
+    this.exec.runTransaction(() => this.updateTaskInTransaction(taskId, changes));
+  }
+
+  private updateTaskInTransaction(taskId: string, changes: TaskStateChanges): void {
     const beforeTask = this.loadTask(taskId);
     if (!beforeTask) return;
 
@@ -418,6 +426,20 @@ export class SqliteTaskAttemptRepository {
       console.log(`[persist-sql] taskId=${taskId} columns=[${cols}]`);
     }
     this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    if (changes.status !== undefined) {
+      this.appendTaskJournal(taskId);
+    }
+  }
+
+  private appendTaskJournal(taskId: string): void {
+    const row = this.exec.queryOne('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (!row) return;
+    appendJournalEntry(this.exec, {
+      entityType: 'task',
+      entityId: taskId,
+      op: 'upsert',
+      payload: row,
+    });
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -594,40 +616,43 @@ export class SqliteTaskAttemptRepository {
   // ── Attempt CRUD ─────────────────────────────────────────
 
   saveAttempt(attempt: Attempt): void {
-    this.exec.execRun(`
-      INSERT OR REPLACE INTO attempts (
-        id, node_id, attempt_number, queue_priority, status,
-        snapshot_commit, base_branch, upstream_attempt_ids,
-        command_override, prompt_override,
-        claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
-        branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
-        supersedes_attempt_id, created_at, merge_conflict
-      ) VALUES (
-        ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?,
-        ?, ?,
-        ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?, ?,
-        ?, ?, ?
-      )
-    `, [
-      attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
-      attempt.snapshotCommit ?? null, attempt.baseBranch ?? null,
-      JSON.stringify(attempt.upstreamAttemptIds),
-      attempt.commandOverride ?? null, attempt.promptOverride ?? null,
-      attempt.claimedAt?.toISOString() ?? null,
-      attempt.startedAt?.toISOString() ?? null,
-      attempt.completedAt?.toISOString() ?? null,
-      attempt.exitCode ?? null, attempt.error ?? null,
-      attempt.lastHeartbeatAt?.toISOString() ?? null,
-      attempt.leaseExpiresAt?.toISOString() ?? null,
-      attempt.branch ?? null, attempt.commit ?? null, attempt.summary ?? null,
-      attempt.workspacePath ?? null, attempt.agentSessionId ?? null,
-      attempt.containerId ?? null,
-      attempt.supersedesAttemptId ?? null,
-      attempt.createdAt.toISOString(),
-      attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
-    ]);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`
+        INSERT OR REPLACE INTO attempts (
+          id, node_id, attempt_number, queue_priority, status,
+          snapshot_commit, base_branch, upstream_attempt_ids,
+          command_override, prompt_override,
+          claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
+          branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
+          supersedes_attempt_id, created_at, merge_conflict
+        ) VALUES (
+          ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?,
+          ?, ?,
+          ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?,
+          ?, ?, ?
+        )
+      `, [
+        attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
+        attempt.snapshotCommit ?? null, attempt.baseBranch ?? null,
+        JSON.stringify(attempt.upstreamAttemptIds),
+        attempt.commandOverride ?? null, attempt.promptOverride ?? null,
+        attempt.claimedAt?.toISOString() ?? null,
+        attempt.startedAt?.toISOString() ?? null,
+        attempt.completedAt?.toISOString() ?? null,
+        attempt.exitCode ?? null, attempt.error ?? null,
+        attempt.lastHeartbeatAt?.toISOString() ?? null,
+        attempt.leaseExpiresAt?.toISOString() ?? null,
+        attempt.branch ?? null, attempt.commit ?? null, attempt.summary ?? null,
+        attempt.workspacePath ?? null, attempt.agentSessionId ?? null,
+        attempt.containerId ?? null,
+        attempt.supersedesAttemptId ?? null,
+        attempt.createdAt.toISOString(),
+        attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
+      ]);
+      this.appendAttemptJournal(attempt.id);
+    });
   }
 
   loadAttempts(nodeId: string): Attempt[] {
@@ -689,6 +714,10 @@ export class SqliteTaskAttemptRepository {
   }
 
   updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void {
+    this.exec.runTransaction(() => this.updateAttemptInTransaction(attemptId, changes));
+  }
+
+  private updateAttemptInTransaction(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void {
     const setClauses: string[] = [];
     const values: unknown[] = [];
 
@@ -712,6 +741,24 @@ export class SqliteTaskAttemptRepository {
     if (setClauses.length === 0) return;
     values.push(attemptId);
     this.exec.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    if (
+      changes.completedAt !== undefined
+      || changes.status === 'completed'
+      || changes.status === 'failed'
+    ) {
+      this.appendAttemptJournal(attemptId);
+    }
+  }
+
+  private appendAttemptJournal(attemptId: string): void {
+    const row = this.exec.queryOne('SELECT * FROM attempts WHERE id = ?', [attemptId]);
+    if (!row) return;
+    appendJournalEntry(this.exec, {
+      entityType: 'attempt',
+      entityId: attemptId,
+      op: 'upsert',
+      payload: row,
+    });
   }
 
   claimAttemptForLaunch(

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -27,11 +27,13 @@ import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ReviewGateLookup,
   Workflow,
+  WorkflowListOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
 } from './adapter.js';
 import { mapRowToWorkflow, mapRowToTask } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 export type WorkflowMetadataChanges = Partial<
   Pick<
@@ -88,23 +90,26 @@ export class SqliteWorkflowRepository {
 
   saveWorkflow(workflow: WorkflowSaveInput): void {
     assertWorkflowConsistent(workflow);
-    this.exec.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `, [
-      workflow.id, workflow.name,
-      workflow.description ?? null,
-      workflow.visualProof ? 1 : 0,
-      workflow.planFile ?? null, workflow.repoUrl ?? null, workflow.intermediateRepoUrl ?? null, workflow.branch ?? null,
-      workflow.onFinish ?? null, workflow.baseBranch ?? null, null, workflow.featureBranch ?? null,
-      workflow.mergeMode ?? null,
-      workflow.reviewProvider ?? null,
-      workflow.externalDependencies ? JSON.stringify(workflow.externalDependencies) : null,
-      workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
-      workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
-      workflow.generation ?? 0,
-      workflow.createdAt, workflow.updatedAt,
-    ]);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`
+        INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `, [
+        workflow.id, workflow.name,
+        workflow.description ?? null,
+        workflow.visualProof ? 1 : 0,
+        workflow.planFile ?? null, workflow.repoUrl ?? null, workflow.intermediateRepoUrl ?? null, workflow.branch ?? null,
+        workflow.onFinish ?? null, workflow.baseBranch ?? null, null, workflow.featureBranch ?? null,
+        workflow.mergeMode ?? null,
+        workflow.reviewProvider ?? null,
+        workflow.externalDependencies ? JSON.stringify(workflow.externalDependencies) : null,
+        workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
+        workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
+        workflow.generation ?? 0,
+        workflow.createdAt, workflow.updatedAt,
+      ]);
+      this.appendWorkflowJournal(workflow.id, 'upsert');
+    });
   }
 
   updateWorkflow(workflowId: string, changes: WorkflowMetadataChanges): void {
@@ -171,19 +176,25 @@ export class SqliteWorkflowRepository {
     assertWorkflowPatchConsistent(before, after, changes);
 
     values.push(workflowId);
-    this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
+      this.appendWorkflowJournal(workflowId, 'upsert');
+    });
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+  loadWorkflow(workflowId: string, opts?: WorkflowListOptions): Workflow | undefined {
+    const row = this.exec.queryOne(
+      `SELECT * FROM workflows WHERE id = ?${opts?.includeDeleted ? '' : ' AND deleted_at IS NULL'}`,
+      [workflowId],
+    );
     if (!row) return undefined;
     const rollup = this.loadWorkflowRollups([workflowId]).get(workflowId);
     return this.rowToWorkflow(row, rollup);
   }
 
-  listWorkflows(): Workflow[] {
+  listWorkflows(opts?: WorkflowListOptions): Workflow[] {
     const rows = this.exec.queryAll(
-      'SELECT * FROM workflows ORDER BY created_at DESC',
+      `SELECT * FROM workflows${opts?.includeDeleted ? '' : ' WHERE deleted_at IS NULL'} ORDER BY created_at DESC`,
     );
     const workflowIds = rows.map((row) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
@@ -205,7 +216,9 @@ export class SqliteWorkflowRepository {
               w.base_branch AS baseBranch
          FROM tasks t
          JOIN workflows w ON w.id = t.workflow_id
-        WHERE t.is_merge_node = 1 AND (t.review_id = ? OR t.review_url LIKE ?)`,
+        WHERE w.deleted_at IS NULL
+          AND t.is_merge_node = 1
+          AND (t.review_id = ? OR t.review_url LIKE ?)`,
       [pr, `%/pull/${pr}`],
     );
     if (rows.length === 0) return undefined;
@@ -257,7 +270,8 @@ export class SqliteWorkflowRepository {
     if (type === 'workflows' || type === 'all') {
       const workflows = this.exec.queryAll(
         `SELECT id, name, description, plan_file, repo_url, branch, created_at FROM workflows 
-         WHERE name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ? 
+         WHERE deleted_at IS NULL
+           AND (name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{ id: string; name?: string | null; created_at: string }>;
@@ -326,10 +340,16 @@ export class SqliteWorkflowRepository {
   loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
     const totalStartedAt = Date.now();
     const workflowQueryStartedAt = Date.now();
-    const workflowRows = this.exec.queryAll('SELECT * FROM workflows ORDER BY created_at DESC');
+    const workflowRows = this.exec.queryAll('SELECT * FROM workflows WHERE deleted_at IS NULL ORDER BY created_at DESC');
     const workflowMetadataQueryMs = Date.now() - workflowQueryStartedAt;
     const taskQueryStartedAt = Date.now();
-    const taskRows = this.exec.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC');
+    const taskRows = this.exec.queryAll(`
+      SELECT t.*
+        FROM tasks t
+        JOIN workflows w ON w.id = t.workflow_id
+       WHERE w.deleted_at IS NULL
+       ORDER BY t.workflow_id ASC, t.id ASC
+    `);
     const taskQueryMs = Date.now() - taskQueryStartedAt;
     const tasksByWorkflowId = new Map<string, TaskState[]>();
     const workflowIds = workflowRows.map((row) => String(row.id));
@@ -465,5 +485,16 @@ export class SqliteWorkflowRepository {
 
   private rowToWorkflow(row: Record<string, unknown>, rollup?: WorkflowRollup): Workflow {
     return mapRowToWorkflow(row, rollup);
+  }
+
+  private appendWorkflowJournal(workflowId: string, op: 'upsert' | 'tombstone'): void {
+    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+    if (!row) return;
+    appendJournalEntry(this.exec, {
+      entityType: 'workflow',
+      entityId: workflowId,
+      op,
+      payload: row,
+    });
   }
 }

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -1,0 +1,141 @@
+import type { SqliteExecutor } from './sqlite-executor.js';
+
+export const SYNC_ENTITY_TYPES = [
+  'workflow',
+  'task',
+  'attempt',
+  'event',
+  // Reserved for future output-spool replication. Output rows are intentionally
+  // not journaled yet because they are high-volume append streams.
+  'output',
+] as const;
+
+export type SyncEntityType = (typeof SYNC_ENTITY_TYPES)[number];
+export type SyncJournalOp = 'upsert' | 'tombstone';
+
+export interface SyncJournalEntryInput {
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOp;
+  payload: unknown;
+  origin?: string;
+  createdAt?: string;
+}
+
+export interface SyncJournalEntry {
+  seq: number;
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOp;
+  payload: unknown;
+  origin: string;
+  createdAt: string;
+}
+
+export interface SyncCursor {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt: string;
+}
+
+export interface SyncCursorInput {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt?: string;
+}
+
+interface SyncJournalRow {
+  seq: number;
+  entity_type: string;
+  entity_id: string;
+  op: string;
+  payload: string;
+  origin: string;
+  created_at: string;
+}
+
+interface SyncCursorRow {
+  peer_id: string;
+  last_sent_seq: number;
+  last_received_seq: number;
+  updated_at: string;
+}
+
+export function appendJournalEntry(db: SqliteExecutor, entry: SyncJournalEntryInput): number {
+  db.execRun(
+    `INSERT INTO sync_journal (entity_type, entity_id, op, payload, origin, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [
+      entry.entityType,
+      entry.entityId,
+      entry.op,
+      JSON.stringify(entry.payload ?? null),
+      entry.origin ?? 'home',
+      entry.createdAt ?? new Date().toISOString(),
+    ],
+  );
+  const row = db.queryOne('SELECT last_insert_rowid() AS seq');
+  return Number(row?.seq ?? 0);
+}
+
+export function readJournalSince(
+  db: SqliteExecutor,
+  seq: number,
+  limit: number,
+): SyncJournalEntry[] {
+  const cappedLimit = Number.isFinite(limit) ? Math.max(0, Math.trunc(limit)) : 0;
+  if (cappedLimit === 0) return [];
+  const cursorSeq = Number.isFinite(seq) ? Math.max(0, Math.trunc(seq)) : 0;
+  const rows = db.queryAll(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq > ?
+      ORDER BY seq ASC
+      LIMIT ?`,
+    [cursorSeq, cappedLimit],
+  ) as unknown as SyncJournalRow[];
+  return rows.map((row) => ({
+    seq: Number(row.seq),
+    entityType: row.entity_type as SyncEntityType,
+    entityId: String(row.entity_id),
+    op: row.op as SyncJournalOp,
+    payload: JSON.parse(String(row.payload)),
+    origin: String(row.origin),
+    createdAt: String(row.created_at),
+  }));
+}
+
+export function getSyncCursor(db: SqliteExecutor, peerId: string): SyncCursor | undefined {
+  const row = db.queryOne(
+    `SELECT peer_id, last_sent_seq, last_received_seq, updated_at
+       FROM sync_cursors
+      WHERE peer_id = ?`,
+    [peerId],
+  ) as unknown as SyncCursorRow | undefined;
+  if (!row) return undefined;
+  return {
+    peerId: String(row.peer_id),
+    lastSentSeq: Number(row.last_sent_seq ?? 0),
+    lastReceivedSeq: Number(row.last_received_seq ?? 0),
+    updatedAt: String(row.updated_at),
+  };
+}
+
+export function setSyncCursor(db: SqliteExecutor, cursor: SyncCursorInput): void {
+  db.execRun(
+    `INSERT INTO sync_cursors (peer_id, last_sent_seq, last_received_seq, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(peer_id) DO UPDATE SET
+       last_sent_seq = excluded.last_sent_seq,
+       last_received_seq = excluded.last_received_seq,
+       updated_at = excluded.updated_at`,
+    [
+      cursor.peerId,
+      cursor.lastSentSeq,
+      cursor.lastReceivedSeq,
+      cursor.updatedAt ?? new Date().toISOString(),
+    ],
+  );
+}


### PR DESCRIPTION
## Summary

Remote Sync Step 1: Sync Schema and Change Journal — 2 tasks completed, 0 failed, 0 closed, 0 sk&#105;pped

Adds sync journal and cursor tables, workflow tombstones, and journal helpers for future remote sync.

Journal rows are appended in the same SQLite transactions as workflow, task, and attempt mutations.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926077035-3/implement-sync-schema | Add sync journal, cursor, and tombstone schema to data-store | completed |
| wf-1784926077035-3/verify-sync-schema | Run data-store package tests covering the new schema and journal | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784926077035-3/implement-sync-schema — Add sync journal, cursor, and tombstone schema to data-store

### wf-1784926077035-3/verify-sync-schema — Run data-store package tests covering the new schema and journal

</details>

## Review Claim

Approve the data-store sync contract for journaling workflow, task, and attempt mutations with cursors and workflow tombstones.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Journal rows are appended inside the existing SQLite transaction, so rollback removes both entity rows and sync evidence.

## Slice Rationale

This is the foundation slice for remote sync. It adds durable local sync records before any transport or peer reconciliation code consumes them.

## Non-goals

- No remote transport.
- No peer reconciliation.
- No UI changes.
- No output spool replication.

## Architecture

### Before

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["Entity table rows"]
    C["Workflow removal request"] --> D["Workflow row removed"]
```

### After

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["Entity table rows"]
    A --> C["sync_journal upsert rows"]
    D["Workflow removal request"] --> E["Workflow tombstone state"]
    D --> F["sync_journal tombstone row"]
    G["Peer replication checkpoint"] --> H["sync_cursors row"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store test`
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-bodies/remote-sync-step-1.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-bodies/remote-sync-step-1.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert b7e6722ed`
- Post-revert steps: Rerun `pnpm --filter @invoker/data-store test`.
- Data migration? Yes. Existing local databases may retain unused sync tables and the workflow tombstone column after code revert.

</details>
