### PR TITLE
[Delete planning terminals — UI](1) Add Planning Terminal rail controls

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -49,6 +49,7 @@ import { InvokerTerminal, type InvokerTerminalLine, type PlanningTerminalMode } 
 import { Toaster, toast } from 'sonner';
 import { Button } from './components/primitives/index.js';
 import { ChevronDownIcon, PlayIcon } from './components/icons/index.js';
+import { Trash2 } from 'lucide-react';
 import { CommandPalette, COMMAND_PALETTE_MAX_ROWS } from './components/CommandPalette.js';
 import {
   getAttentionTaskEntries,
@@ -2981,23 +2982,95 @@ export function App() {
     workflows.size,
   ]);
 
-  const handleCreatePlanningSession = useCallback(() => {
+  const createLocalPlanningSession = useCallback((): PlanningSessionView => {
     const index = nextPlanningSessionLocalIdRef.current;
     nextPlanningSessionLocalIdRef.current += 1;
     const now = new Date().toISOString();
     const localId = `local-planning-session-${index}`;
-    const session: PlanningSessionView = {
+    return {
       ...makeInitialPlanningSession(now, selectedPlanningConfirmationMode),
       id: localId,
       conversationKey: localId,
       presetKey: selectedPlanningPresetKey,
       confirmationMode: selectedPlanningConfirmationMode,
     };
+  }, [selectedPlanningConfirmationMode, selectedPlanningPresetKey]);
+
+  const removePlanningSessionsFromRail = useCallback((sessionIds: string[]) => {
+    const deletedIds = new Set(sessionIds.filter(Boolean));
+    if (deletedIds.size === 0) return;
+
+    clearPlanningStreamForSessionIds([...deletedIds]);
+    forgetPlanningStreamAliasesForSessionIds([...deletedIds]);
+    for (const sessionId of deletedIds) {
+      pendingPlanningStreamSessionIdsRef.current.delete(sessionId);
+    }
+    setKeptPlanningDraftSessionIds((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const sessionId of deletedIds) {
+        if (next.delete(sessionId)) changed = true;
+      }
+      return changed ? next : prev;
+    });
+    setReviewDraftSessionId((currentSessionId) => (
+      currentSessionId && deletedIds.has(currentSessionId) ? null : currentSessionId
+    ));
+
+    const currentSessions = planningSessionsRef.current;
+    const removedIndex = currentSessions.findIndex((session) => deletedIds.has(session.id));
+    const remainingSessions = currentSessions.filter((session) => !deletedIds.has(session.id));
+    if (remainingSessions.length === currentSessions.length) return;
+
+    let nextSessions = remainingSessions;
+    let nextActiveSessionId = activePlanningSessionIdRef.current;
+    if (nextSessions.length === 0) {
+      const session = createLocalPlanningSession();
+      nextSessions = [session];
+      nextActiveSessionId = session.id;
+    } else if (deletedIds.has(nextActiveSessionId) || !nextSessions.some((session) => session.id === nextActiveSessionId)) {
+      const activeIndex = currentSessions.findIndex((session) => session.id === nextActiveSessionId);
+      const preferredIndex = activeIndex >= 0 ? activeIndex : Math.max(0, removedIndex);
+      nextActiveSessionId = nextSessions[Math.min(preferredIndex, nextSessions.length - 1)]?.id ?? nextSessions[0]?.id ?? nextActiveSessionId;
+    }
+
+    planningSessionsRef.current = nextSessions;
+    activePlanningSessionIdRef.current = nextActiveSessionId;
+    setPlanningSessions(nextSessions);
+    setActivePlanningSessionId(nextActiveSessionId);
+  }, [
+    clearPlanningStreamForSessionIds,
+    createLocalPlanningSession,
+    forgetPlanningStreamAliasesForSessionIds,
+  ]);
+
+  const handleDeletePlanningSession = useCallback((sessionId: string) => {
+    if (activePlanningReadOnly) return;
+    if (!sessionId.startsWith('local-')) {
+      void invoker?.planningChatDelete?.({ sessionId });
+    }
+    removePlanningSessionsFromRail([sessionId]);
+  }, [activePlanningReadOnly, invoker, removePlanningSessionsFromRail]);
+
+  const handleClearSubmittedPlanningSessions = useCallback(() => {
+    if (activePlanningReadOnly) return;
+    const submittedSessionIds = planningSessionsRef.current
+      .filter((session) => session.status === 'submitted')
+      .map((session) => session.id);
+    if (submittedSessionIds.length === 0) return;
+    const confirmed = window.confirm('Clear all submitted planning chats? This cannot be undone.');
+    if (!confirmed) return;
+    void invoker?.planningChatDeleteSubmitted?.();
+    removePlanningSessionsFromRail(submittedSessionIds);
+  }, [activePlanningReadOnly, invoker, removePlanningSessionsFromRail]);
+
+  const handleCreatePlanningSession = useCallback(() => {
+    const session = createLocalPlanningSession();
     setPlanningSessions((prev) => [session, ...prev]);
     setActivePlanningSessionId(session.id);
     setSidebarSurface('home');
     focusKeyboardRegion('planning');
-  }, [focusKeyboardRegion, selectedPlanningConfirmationMode, selectedPlanningPresetKey]);
+  }, [createLocalPlanningSession, focusKeyboardRegion]);
 
   const handlePlanningModeChange = useCallback(async (mode: PlanningTerminalMode) => {
     const sourceSession = activePlanningSession;
@@ -4262,30 +4335,48 @@ export function App() {
           const selected = session.id === activePlanningSession.id;
           const preview = previewPlanningMessage(session);
           return (
-            <button
+            <div
               key={session.id}
-              type="button"
-              onClick={() => setActivePlanningSessionId(session.id)}
-              className={`flex w-full items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              data-testid="planning-session-row"
+              className="group flex items-stretch"
             >
-              <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-start justify-between gap-2">
-                  <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
-                    {session.title}
+              <button
+                type="button"
+                onClick={() => setActivePlanningSessionId(session.id)}
+                className={`flex min-w-0 flex-1 items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              >
+                <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
+                      {session.title}
+                    </div>
+                    <span className="shrink-0 text-[11px] text-muted-foreground">
+                      {relativePlanningUpdatedAt(session.updatedAt)}
+                    </span>
                   </div>
-                  <span className="shrink-0 text-[11px] text-muted-foreground">
-                    {relativePlanningUpdatedAt(session.updatedAt)}
-                  </span>
+                  <div
+                    className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
+                    title={preview}
+                  >
+                    {preview}
+                  </div>
                 </div>
-                <div
-                  className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
-                  title={preview}
+              </button>
+              {!activePlanningReadOnly && (
+                <button
+                  type="button"
+                  aria-label="Delete planning chat"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleDeletePlanningSession(session.id);
+                  }}
+                  className={`flex w-9 shrink-0 items-start justify-center px-2 py-2 text-muted-foreground transition-colors hover:text-destructive ${selected ? 'bg-accent/40' : 'hover:bg-accent/20'}`}
                 >
-                  {preview}
-                </div>
-              </div>
-            </button>
+                  <Trash2 className="mt-0.5 h-3.5 w-3.5" strokeWidth={1.75} aria-hidden="true" />
+                </button>
+              )}
+            </div>
           );
         })}
       </div>
@@ -4293,6 +4384,7 @@ export function App() {
   );
 
   const planningReadyCount = planningSessions.filter((session) => session.status === 'draft_ready').length;
+  const hasSubmittedPlanningSessions = planningSessions.some((session) => session.status === 'submitted');
   const connectedAgentLabels = (systemDiagnostics?.tools ?? [])
     .filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed)
     .map((tool) => tool.name.replace(/\s+CLI$/i, ''));
@@ -4450,18 +4542,15 @@ export function App() {
           </div>
         ) : (
           <>
-            <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2.5">
-              <div className="min-w-0">
-                <h2 className="text-sm font-medium text-foreground">Planning</h2>
-                <p className="mt-0.5 text-[11px] text-muted-foreground">
-                  {planningSessions.length} chat{planningSessions.length === 1 ? '' : 's'}
-                  {planningReadyCount > 0 ? ` · ${planningReadyCount} ready` : ''}
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                <Button variant="outline" size="sm" onClick={handleCreatePlanningSession}>
-                  New chat
-                </Button>
+            <div className="border-b border-border px-3 py-2.5">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h2 className="truncate text-sm font-medium text-foreground">Planning</h2>
+                  <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                    {planningSessions.length} chat{planningSessions.length === 1 ? '' : 's'}
+                    {planningReadyCount > 0 ? ` · ${planningReadyCount} ready` : ''}
+                  </p>
+                </div>
                 <button
                   type="button"
                   data-testid="planning-session-rail-toggle"
@@ -4471,6 +4560,20 @@ export function App() {
                 >
                   ‹
                 </button>
+              </div>
+              <div className="mt-2 grid grid-cols-2 gap-2">
+                <Button variant="outline" size="sm" onClick={handleCreatePlanningSession} className="w-full">
+                  New chat
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={activePlanningReadOnly || !hasSubmittedPlanningSessions}
+                  onClick={handleClearSubmittedPlanningSessions}
+                  className="w-full"
+                >
+                  Clear submitted
+                </Button>
               </div>
             </div>
             <div className={RAIL_LIST_FRAME_CLASS}>{renderPlanningSessionList()}</div>

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -224,6 +224,8 @@ export function createMockInvoker(
     })),
     planningChatDiscardDraft: vi.fn(async () => ({ ok: true })),
     planningChatReset: vi.fn(async () => ({ ok: true })),
+    planningChatDelete: vi.fn(async () => ({ ok: true })),
+    planningChatDeleteSubmitted: vi.fn(async () => ({ ok: true, deletedSessionIds: [] })),
     onPlanningChatStream: vi.fn((cb: (event: InAppPlanningStreamEvent) => void) => {
       planningChatStreamCallbacks.add(cb);
       return () => { planningChatStreamCallbacks.delete(cb); };

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -271,8 +271,7 @@ describe('Invoker terminal (component)', () => {
     const secondPanel = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(secondPanel).toHaveTextContent('Drafting your plan…');
 
-    const sessionButtons = within(screen.getByTestId('planning-session-list')).getAllByRole('button');
-    fireEvent.click(sessionButtons[1]);
+    fireEvent.click(within(screen.getByTestId('planning-session-list')).getByRole('button', { name: /first session request/ }));
 
     const firstPanel = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(firstPanel).toHaveTextContent('Drafting your plan…');


### PR DESCRIPTION
## Summary

Planning Terminal rows now have a direct trash affordance, and the rail header can clear done chats after confirmation.

The rail keeps a usable selected chat, recreates an empty row when needed, blocks read-only actions, and resets stream bookkeeping.

## Review Claim

The Planning Terminal rail exposes one-row disposal and done-state clearing controls on the existing Planning surface.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice stays in the Planning renderer path and uses existing optional planning chat bridge methods. It does not change storage, workflow execution, or planner submission.

## Slice Rationale

The row action, header action, selection fallback, empty-session fallback, and stream reset are one visible rail interaction path.

## Non-goals

No backend storage changes.

No workflow graph changes.

No planning preset changes.

No planner response generation changes.

## Architecture

### Before

```mermaid
graph TD
    A["Planning rail lists chat rows"]
    B["Rows only select the active chat"]
    C["Submitted chats remain visible until another refresh"]
    A --> B
    A --> C
```

### After

```mermaid
graph TD
    A["Planning rail lists chat rows"]
    B["Rows still select the active chat"]
    C["Row trash actions remove one saved or local chat"]
    D["Clear submitted removes submitted chats after confirmation"]
    E["Selection and stream state move to a remaining or fresh chat"]
    A --> B
    A --> C
    A --> D
    C --> E
    D --> E
```

## Visual Proof

The walkthrough recording shows the Planning rail controls, submitted rows leaving after confirmation, and the remaining chat staying selected.

[Planning Terminal delete and clear walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-d347af/planning-terminal-delete-controls-walkthrough.webm)

![Planning Terminal rail with row trash controls and Clear submitted enabled](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-d347af/planning-terminal-delete-controls-current.png)

![Planning Terminal rail after submitted chats are cleared](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-d347af/planning-terminal-delete-controls-after-clear.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- --run src/__tests__/invoker-terminal.test.tsx`
- [x] `pnpm --filter @invoker/app exec node --input-type=module <inline Playwright visual proof capture script>`
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-bodies/delete-planning-terminals-ui-1.md --require-visual-proof`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-bodies/delete-planning-terminals-ui-1.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert fda51dd058bda703319aa171b8c8c535acd3f5dd`
- Post-revert steps: Re-run the focused Planning Terminal UI test.
- Data migration? No

</details>

## Workflow Summary

Delete planning terminals — UI — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784313643126-2/ui-delete-planning-chat | Add per-row trash button (instant) + header Clear submitted button (confirm) to the Planning Terminal rail with reselection, empty-recreate, read-only gating, and stream cleanup | completed |
| wf-1784313643126-2/verify-ui-planning-terminal | Verify Planning Terminal rail delete + clear-submitted UI | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784313643126-2/ui-delete-planning-chat — Add per-row trash button (instant) + header Clear submitted button (confirm) to the Planning Terminal rail with reselection, empty-recreate, read-only gating, and stream cleanup

### wf-1784313643126-2/verify-ui-planning-terminal — Verify Planning Terminal rail delete + clear-submitted UI

</details>
