### PR TITLE
[Delete planning terminals — UI](2) Verify Planning Terminal rail delete + clear-submitted UI

### DIFF
--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -27,6 +27,7 @@ describe('Invoker terminal (component)', () => {
 
   afterEach(() => {
     mock.cleanup();
+    vi.restoreAllMocks();
   });
 
   async function openPlanningTerminal() {
@@ -47,6 +48,17 @@ describe('Invoker terminal (component)', () => {
   function expectRailListScrollContract(list: HTMLElement) {
     expect(list).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto');
     expect(list.parentElement).toHaveClass('flex', 'min-h-0', 'flex-1', 'flex-col');
+  }
+
+  function getPlanningSessionRows(): HTMLElement[] {
+    return within(screen.getByTestId('planning-session-list')).getAllByTestId('planning-session-row');
+  }
+
+  function getPlanningSessionRowByTitle(title: string): HTMLElement {
+    const titleElement = within(screen.getByTestId('planning-session-list')).getByText(title);
+    const row = titleElement.closest('[data-testid="planning-session-row"]');
+    if (!row) throw new Error(`Missing planning session row for ${title}`);
+    return row as HTMLElement;
   }
 
   async function expectSurfaceRailList(surface: 'home' | 'workflows' | 'attention', listTestId: string) {
@@ -271,7 +283,7 @@ describe('Invoker terminal (component)', () => {
     const secondPanel = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(secondPanel).toHaveTextContent('Drafting your plan…');
 
-    fireEvent.click(within(screen.getByTestId('planning-session-list')).getByRole('button', { name: /first session request/ }));
+    fireEvent.click(within(screen.getByTestId('planning-session-list')).getByText('first session request').closest('button')!);
 
     const firstPanel = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(firstPanel).toHaveTextContent('Drafting your plan…');
@@ -667,6 +679,174 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('2 chats'));
     expect(within(screen.getByTestId('sidebar-home')).queryByText('0')).not.toBeInTheDocument();
     expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('2 chats');
+  });
+
+  it('deletes an individual saved planning chat from the rail', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'saved-alpha',
+          title: 'Saved alpha',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+        }),
+        makePlanningSessionSummary({
+          id: 'saved-beta',
+          title: 'Saved beta',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    await waitFor(() => {
+      expect(within(screen.getByTestId('planning-session-list')).getByText('Saved alpha')).toBeInTheDocument();
+      expect(within(screen.getByTestId('planning-session-list')).getByText('Saved beta')).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(getPlanningSessionRowByTitle('Saved alpha')).getByRole('button', { name: 'Delete planning chat' }));
+
+    await waitFor(() => {
+      expect(within(screen.getByTestId('planning-session-list')).queryByText('Saved alpha')).not.toBeInTheDocument();
+    });
+    expect(within(screen.getByTestId('planning-session-list')).getByText('Saved beta')).toBeInTheDocument();
+    expect(mock.api.planningChatDelete).toHaveBeenCalledWith({ sessionId: 'saved-alpha' });
+  });
+
+  it('deletes a local planning chat without calling the bridge delete channel', async () => {
+    render(<App />);
+    await openPlanningTerminal();
+
+    fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
+    await waitFor(() => expect(getPlanningSessionRows()).toHaveLength(2));
+
+    const firstRow = getPlanningSessionRows()[0];
+    expect(firstRow).toBeDefined();
+    fireEvent.click(within(firstRow!).getByRole('button', { name: 'Delete planning chat' }));
+
+    await waitFor(() => expect(getPlanningSessionRows()).toHaveLength(1));
+    expect(mock.api.planningChatDelete).not.toHaveBeenCalled();
+  });
+
+  it('clears submitted planning chats after confirmation', async () => {
+    const { unmount } = render(<App />);
+    await openPlanningTerminal();
+    expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
+    unmount();
+
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'active-draft',
+          title: 'Active draft',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+        }),
+        makePlanningSessionSummary({
+          id: 'submitted-one',
+          title: 'Submitted one',
+          status: 'submitted',
+          draftPlanAvailable: false,
+        }),
+        makePlanningSessionSummary({
+          id: 'submitted-two',
+          title: 'Submitted two',
+          status: 'submitted',
+          draftPlanAvailable: false,
+        }),
+      ],
+    }));
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    await waitFor(() => {
+      expect(within(screen.getByTestId('planning-session-list')).getByText('Submitted one')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear submitted' }));
+
+    await waitFor(() => {
+      expect(within(screen.getByTestId('planning-session-list')).queryByText('Submitted one')).not.toBeInTheDocument();
+      expect(within(screen.getByTestId('planning-session-list')).queryByText('Submitted two')).not.toBeInTheDocument();
+    });
+    expect(within(screen.getByTestId('planning-session-list')).getByText('Active draft')).toBeInTheDocument();
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(mock.api.planningChatDeleteSubmitted).toHaveBeenCalledTimes(1);
+  });
+
+  it('recreates a fresh empty planning chat after deleting the last row', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'only-saved-chat',
+          title: 'Only saved chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    await waitFor(() => expect(within(screen.getByTestId('planning-session-list')).getByText('Only saved chat')).toBeInTheDocument());
+
+    fireEvent.click(within(getPlanningSessionRowByTitle('Only saved chat')).getByRole('button', { name: 'Delete planning chat' }));
+
+    await waitFor(() => {
+      expect(within(screen.getByTestId('planning-session-list')).queryByText('Only saved chat')).not.toBeInTheDocument();
+      expect(getPlanningSessionRows()).toHaveLength(1);
+    });
+    expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
+    expect(screen.getByText('What do you want to build?')).toBeInTheDocument();
+    expect(screen.getByTestId('invoker-terminal-input')).toBeEnabled();
+    expect(mock.api.planningChatDelete).toHaveBeenCalledWith({ sessionId: 'only-saved-chat' });
+  });
+
+  it('hides planning chat delete controls and disables clear submitted in read-only mode', async () => {
+    mock.api.getRuntimeStatus = vi.fn(async () => ({
+      ownerMode: false,
+      readOnly: true,
+      mode: 'read-only',
+    }));
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'readonly-active',
+          title: 'Read-only active',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+        }),
+        makePlanningSessionSummary({
+          id: 'readonly-submitted',
+          title: 'Read-only submitted',
+          status: 'submitted',
+          draftPlanAvailable: false,
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
+      expect(within(screen.getByTestId('planning-session-list')).queryByRole('button', { name: 'Delete planning chat' })).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear submitted' }));
+    expect(mock.api.planningChatDelete).not.toHaveBeenCalled();
+    expect(mock.api.planningChatDeleteSubmitted).not.toHaveBeenCalled();
   });
 
   it('continues the same planning session', async () => {


### PR DESCRIPTION
## Summary

Add focused renderer proof for saved row disposal, local row disposal, header clearing, last-row recovery, read-only mode, and stream isolation.

## Review Claim

The stack has focused renderer proof for the Planning Terminal rail trash and clear controls.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes renderer tests only. It does not change renderer logic, IPC contracts, planning data storage, or workflow execution.

## Slice Rationale

The behavior slice stays reviewable while this final slice carries the verification cases for the new user-visible rail controls.

## Non-goals

No renderer logic changes.

No IPC contract changes.

No screenshot baseline updates.

No planner behavior changes.

## Visual Proof

The walkthrough recording shows the Planning rail controls, submitted rows leaving after confirmation, and the remaining chat staying selected.

[Planning Terminal delete and clear walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-e67212/planning-terminal-delete-controls-walkthrough.webm)

![Planning Terminal rail with row trash controls and Clear submitted enabled](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-e67212/planning-terminal-delete-controls-current.png)

![Planning Terminal rail after submitted chats are cleared](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-e67212/planning-terminal-delete-controls-after-clear.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- --run src/__tests__/invoker-terminal.test.tsx`
- [x] `pnpm --filter @invoker/app exec node --input-type=module <inline Playwright visual proof capture script>`
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-bodies/delete-planning-terminals-ui-2.md --require-visual-proof`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-bodies/delete-planning-terminals-ui-2.md --base stack/EdbertChan/plan/delete-planning-terminals-ui/delete-planning-terminals-ui-1-add-planning--5870c998`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d2b8dca2b7f424f8024a6eb50d4c78eded33c77b`
- Post-revert steps: Re-run the focused Planning Terminal UI test.
- Data migration? No

</details>

## Workflow Summary

Delete planning terminals — UI — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784313643126-2/ui-delete-planning-chat | Add per-row trash button (instant) + header Clear submitted button (confirm) to the Planning Terminal rail with reselection, empty-recreate, read-only gating, and stream cleanup | completed |
| wf-1784313643126-2/verify-ui-planning-terminal | Verify Planning Terminal rail delete + clear-submitted UI | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784313643126-2/ui-delete-planning-chat — Add per-row trash button (instant) + header Clear submitted button (confirm) to the Planning Terminal rail with reselection, empty-recreate, read-only gating, and stream cleanup

### wf-1784313643126-2/verify-ui-planning-terminal — Verify Planning Terminal rail delete + clear-submitted UI

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved planning chat session management, including deleting saved chats, clearing submitted chats with confirmation, and recreating a fresh chat after the last one is removed.
  * Ensured local-only chats are removed without triggering unnecessary backend actions.
  * Updated read-only mode to hide deletion controls and disable chat-clearing actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->