### PR TITLE
[Remote Sync Step 1: Sync Schema and Change Journal](1) Add data-store sync schema and journal

### DIFF
--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createAttempt, type TaskState } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { Workflow } from '../adapter.js';
+import type { SqliteExecutor } from '../sqlite-executor.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  readJournalSince,
+  setSyncCursor,
+} from '../sync-journal.js';
+
+describe('sync journal', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  const workflow: Workflow = {
+    id: 'wf-sync',
+    name: 'Sync Workflow',
+    status: 'pending',
+    createdAt: '2026-07-27T00:00:00.000Z',
+    updatedAt: '2026-07-27T00:00:00.000Z',
+  };
+
+  function executor(): SqliteExecutor {
+    return (adapter as any).executor as SqliteExecutor;
+  }
+
+  function scalar(sql: string): number {
+    const row = (adapter as any).queryOne(sql) as { c?: number } | undefined;
+    return Number(row?.c ?? 0);
+  }
+
+  function makeTask(id: string, overrides: Partial<TaskState> = {}): TaskState {
+    return {
+      id,
+      description: `Task ${id}`,
+      status: 'pending',
+      dependencies: [],
+      createdAt: new Date('2026-07-27T00:00:00.000Z'),
+      config: {},
+      execution: {},
+      taskStateVersion: 1,
+      ...overrides,
+    };
+  }
+
+  it('rolls back journal appends with the enclosing mutation transaction', () => {
+    expect(() => {
+      adapter.runInTransaction(() => {
+        (adapter as any).db.run(
+          `INSERT INTO workflows (id, name, created_at, updated_at)
+           VALUES ('wf-rollback', 'Rollback', '2026-07-27T00:00:00.000Z', '2026-07-27T00:00:00.000Z')`,
+        );
+        appendJournalEntry(executor(), {
+          entityType: 'workflow',
+          entityId: 'wf-rollback',
+          op: 'upsert',
+          payload: { id: 'wf-rollback' },
+        });
+        throw new Error('rollback sentinel');
+      });
+    }).toThrow('rollback sentinel');
+
+    expect(scalar("SELECT COUNT(*) AS c FROM workflows WHERE id = 'wf-rollback'")).toBe(0);
+    expect(scalar('SELECT COUNT(*) AS c FROM sync_journal')).toBe(0);
+  });
+
+  it('fails the mutation transaction loudly when the journal insert fails', () => {
+    adapter.saveWorkflow(workflow);
+    adapter.saveTask('wf-sync', makeTask('task-sync'));
+
+    const db = (adapter as any).db;
+    const originalRun = db.run.bind(db);
+    db.run = (sql: string, ...args: unknown[]) => {
+      if (sql.includes('INSERT INTO sync_journal')) {
+        throw new Error('journal disk failure');
+      }
+      return originalRun(sql, ...args);
+    };
+
+    expect(() => adapter.updateTask('task-sync', { status: 'running' })).toThrow('journal disk failure');
+    db.run = originalRun;
+
+    expect(adapter.loadTask('task-sync')?.status).toBe('pending');
+    expect(scalar('SELECT COUNT(*) AS c FROM sync_journal')).toBe(0);
+  });
+
+  it('allocates strictly monotonic journal seq values', () => {
+    const first = appendJournalEntry(executor(), {
+      entityType: 'workflow',
+      entityId: 'wf-1',
+      op: 'upsert',
+      payload: { id: 'wf-1' },
+    });
+    const second = appendJournalEntry(executor(), {
+      entityType: 'task',
+      entityId: 'task-1',
+      op: 'upsert',
+      payload: { id: 'task-1' },
+    });
+    const third = appendJournalEntry(executor(), {
+      entityType: 'attempt',
+      entityId: 'attempt-1',
+      op: 'upsert',
+      payload: { id: 'attempt-1' },
+    });
+
+    expect(second.seq).toBeGreaterThan(first.seq);
+    expect(third.seq).toBeGreaterThan(second.seq);
+    expect(readJournalSince(executor(), 0, 10).map((entry) => entry.seq)).toEqual([
+      first.seq,
+      second.seq,
+      third.seq,
+    ]);
+  });
+
+  it('reads journal entries after the stored peer cursor', () => {
+    const first = appendJournalEntry(executor(), {
+      entityType: 'workflow',
+      entityId: 'wf-1',
+      op: 'upsert',
+      payload: { id: 'wf-1' },
+    });
+    const second = appendJournalEntry(executor(), {
+      entityType: 'task',
+      entityId: 'task-1',
+      op: 'upsert',
+      payload: { id: 'task-1' },
+    });
+    const third = appendJournalEntry(executor(), {
+      entityType: 'attempt',
+      entityId: 'attempt-1',
+      op: 'upsert',
+      payload: { id: 'attempt-1' },
+    });
+
+    setSyncCursor(executor(), {
+      peerId: 'peer-a',
+      lastSentSeq: second.seq,
+      lastReceivedSeq: first.seq,
+      updatedAt: '2026-07-27T00:00:01.000Z',
+    });
+
+    const cursor = getSyncCursor(executor(), 'peer-a');
+    expect(cursor).toMatchObject({
+      peerId: 'peer-a',
+      lastSentSeq: second.seq,
+      lastReceivedSeq: first.seq,
+    });
+    expect(readJournalSince(executor(), cursor!.lastSentSeq, 10).map((entry) => entry.seq)).toEqual([
+      third.seq,
+    ]);
+  });
+
+  it('excludes soft-deleted workflows by default and exposes them with includeDeleted', () => {
+    adapter.saveWorkflow(workflow);
+    adapter.deleteWorkflow('wf-sync');
+
+    expect(adapter.listWorkflows()).toEqual([]);
+    expect(adapter.loadWorkflow('wf-sync')).toBeUndefined();
+
+    const deleted = adapter.listWorkflows({ includeDeleted: true });
+    expect(deleted).toHaveLength(1);
+    expect(deleted[0]).toMatchObject({
+      id: 'wf-sync',
+      name: 'Sync Workflow',
+    });
+    expect(deleted[0].deletedAt).toEqual(expect.any(Number));
+    expect(adapter.loadWorkflow('wf-sync', { includeDeleted: true })?.deletedAt).toEqual(expect.any(Number));
+  });
+
+  it('writes a tombstone journal entry when a workflow is deleted', () => {
+    adapter.saveWorkflow(workflow);
+    adapter.saveTask('wf-sync', makeTask('task-sync'));
+    const attempt = createAttempt('task-sync', { status: 'pending' });
+    adapter.saveAttempt(attempt);
+
+    const beforeDelete = readJournalSince(executor(), 0, 10).at(-1)?.seq ?? 0;
+    adapter.deleteWorkflow('wf-sync');
+
+    const entries = readJournalSince(executor(), beforeDelete, 10);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      entityType: 'workflow',
+      entityId: 'wf-sync',
+      op: 'tombstone',
+      origin: 'home',
+    });
+    expect(entries[0].payload).toMatchObject({
+      id: 'wf-sync',
+      deleted_at: expect.any(Number),
+    });
+  });
+
+  it('journals task status changes and attempt creation/completion snapshots', () => {
+    adapter.saveWorkflow(workflow);
+    adapter.saveTask('wf-sync', makeTask('task-sync'));
+    const attempt = createAttempt('task-sync', { status: 'pending' });
+
+    adapter.updateTask('task-sync', { status: 'running' });
+    adapter.saveAttempt(attempt);
+    adapter.updateAttempt(attempt.id, {
+      status: 'completed',
+      completedAt: new Date('2026-07-27T00:00:02.000Z'),
+      exitCode: 0,
+    });
+
+    const entries = readJournalSince(executor(), 0, 10);
+    expect(entries.map((entry) => [entry.entityType, entry.entityId, entry.op])).toEqual([
+      ['task', 'task-sync', 'upsert'],
+      ['workflow', 'wf-sync', 'upsert'],
+      ['attempt', attempt.id, 'upsert'],
+      ['attempt', attempt.id, 'upsert'],
+    ]);
+    expect(entries.at(-1)?.payload).toMatchObject({
+      id: attempt.id,
+      status: 'completed',
+      completed_at: '2026-07-27T00:00:02.000Z',
+    });
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -124,10 +124,15 @@ export interface Workflow {
   /** Read-only provenance for dependencies removed by `detachWorkflow`. Never re-read by scheduling. */
   detachedExternalDependencies?: DetachedExternalDependency[];
   generation?: number;
+  deletedAt?: number;
   createdAt: string;
   updatedAt: string;
 }
 export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup'>;
+
+export interface WorkflowListOptions {
+  includeDeleted?: boolean;
+}
 
 /**
  * Result of resolving a published PR back to its Invoker workflow via the merge
@@ -333,8 +338,8 @@ export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
-  loadWorkflow(workflowId: string): Workflow | undefined;
-  listWorkflows(): Workflow[];
+  loadWorkflow(workflowId: string, options?: WorkflowListOptions): Workflow | undefined;
+  listWorkflows(options?: WorkflowListOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
   /** Resolve a GitHub PR number back to its Invoker workflow via the merge node. */
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined;

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -7,3 +7,4 @@ export * from './slack-session-repository.js';
 export * from './slack-plan-draft-repository.js';
 export * from './sqlite-task-repository.js';
 export * from './workflow-channel-repository.js';
+export * from './sync-journal.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -38,6 +38,7 @@ import type {
   PersistenceAdapter,
   ReviewGateLookup,
   Workflow,
+  WorkflowListOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
   TaskEvent,
@@ -78,6 +79,7 @@ import type { SqliteExecutor } from './sqlite-executor.js';
 import * as migrations from './sqlite-migrations.js';
 import { SqliteTaskAttemptRepository } from './sqlite-task-attempt-repository.js';
 import { SqliteWorkflowRepository, type WorkflowMetadataChanges } from './sqlite-workflow-repository.js';
+import { appendEntitySnapshotJournalEntry } from './sync-journal.js';
 
 function normalizeWorkerActionStatus(status: string): string {
   return status === 'canceled' ? 'cancelled' : status;
@@ -1054,12 +1056,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.workflowRepo.updateWorkflow(workflowId, changes);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    return this.workflowRepo.loadWorkflow(workflowId);
+  loadWorkflow(workflowId: string, options?: WorkflowListOptions): Workflow | undefined {
+    return this.workflowRepo.loadWorkflow(workflowId, options);
   }
 
-  listWorkflows(): Workflow[] {
-    return this.workflowRepo.listWorkflows();
+  listWorkflows(options?: WorkflowListOptions): Workflow[] {
+    return this.workflowRepo.listWorkflows(options);
   }
 
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
@@ -1085,7 +1087,29 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   updateTask(taskId: string, changes: TaskStateChanges): void {
-    this.taskAttemptRepo.updateTask(taskId, changes);
+    if (changes.status === undefined) {
+      this.taskAttemptRepo.updateTask(taskId, changes);
+      return;
+    }
+
+    this.runTransaction(() => {
+      const beforeTask = this.taskAttemptRepo.loadTask(taskId);
+      if (!beforeTask) return;
+      const workflowId = beforeTask.config.workflowId;
+      const beforeWorkflowStatus = workflowId
+        ? this.workflowRepo.loadWorkflow(workflowId)?.status
+        : undefined;
+
+      this.taskAttemptRepo.updateTask(taskId, changes);
+
+      if (!workflowId || changes.status === beforeTask.status || beforeWorkflowStatus === undefined) {
+        return;
+      }
+      const afterWorkflowStatus = this.workflowRepo.loadWorkflow(workflowId)?.status;
+      if (afterWorkflowStatus !== undefined && afterWorkflowStatus !== beforeWorkflowStatus) {
+        appendEntitySnapshotJournalEntry(this.executor, 'workflow', workflowId, 'upsert');
+      }
+    });
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -1558,7 +1582,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   deleteWorkflow(workflowId: string): void {
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
+    let deleted = false;
     this.runTransaction(() => {
+      const existing = this.queryOne('SELECT id FROM workflows WHERE id = ? AND deleted_at IS NULL', [workflowId]);
+      if (!existing) return;
+
       this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM task_launch_dispatch WHERE workflow_id = ?', [workflowId]);
@@ -1598,9 +1626,16 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
+      this.db.run(
+        'UPDATE workflows SET deleted_at = ?, updated_at = ? WHERE id = ?',
+        [Date.now(), new Date().toISOString(), workflowId],
+      );
+      appendEntitySnapshotJournalEntry(this.executor, 'workflow', workflowId, 'tombstone');
+      deleted = true;
     });
-    this.removeOutputFiles(taskIds);
+    if (deleted) {
+      this.removeOutputFiles(taskIds);
+    }
   }
 
   // ── Events ────────────────────────────────────────────

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -47,6 +47,7 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
     externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
     detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) as DetachedExternalDependency[] : undefined,
     generation: row.generation ?? 0,
+    deletedAt: row.deleted_at === null || row.deleted_at === undefined ? undefined : Number(row.deleted_at),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -27,6 +27,7 @@ export const SCHEMA_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       );
@@ -487,6 +488,23 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_output_spool_task_offset
         ON output_spool(task_id, offset);
 
+      CREATE TABLE IF NOT EXISTS sync_journal (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+        entity_id TEXT NOT NULL,
+        op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+        payload TEXT NOT NULL CHECK (json_valid(payload)),
+        origin TEXT NOT NULL DEFAULT 'home',
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_cursors (
+        peer_id TEXT PRIMARY KEY,
+        last_sent_seq INTEGER NOT NULL DEFAULT 0,
+        last_received_seq INTEGER NOT NULL DEFAULT 0,
+        updated_at TEXT NOT NULL
+      );
+
       CREATE TABLE IF NOT EXISTS terminal_sessions (
         session_id TEXT PRIMARY KEY,
         task_id TEXT NOT NULL,
@@ -597,6 +615,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
+  'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
 ];
 
 /**
@@ -628,6 +647,21 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  `CREATE TABLE IF NOT EXISTS sync_journal (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+    entity_id TEXT NOT NULL,
+    op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    origin TEXT NOT NULL DEFAULT 'home',
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`,
+  `CREATE TABLE IF NOT EXISTS sync_cursors (
+    peer_id TEXT PRIMARY KEY,
+    last_sent_seq INTEGER NOT NULL DEFAULT 0,
+    last_received_seq INTEGER NOT NULL DEFAULT 0,
+    updated_at TEXT NOT NULL
+  )`,
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */
@@ -651,6 +685,7 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       )
@@ -662,12 +697,12 @@ export const WORKFLOWS_REBUILD_INSERT_DDL = `
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       FROM workflows
     `;

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -12,11 +12,13 @@ import type { TaskState, TaskStateChanges, Attempt, TaskExecution } from '@invok
 import {
   assertTaskConsistent,
   isDiscardedAttempt,
+  isOutcomeTerminalAttemptStatus,
   normalizeRunnerKind,
 } from '@invoker/workflow-core';
 import { mapRowToTask, mapRowToAttempt } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
+import { appendEntitySnapshotJournalEntry } from './sync-journal.js';
 
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
@@ -227,8 +229,11 @@ export class SqliteTaskAttemptRepository {
   }
 
   updateTask(taskId: string, changes: TaskStateChanges): void {
+    this.exec.runTransaction(() => {
     const beforeTask = this.loadTask(taskId);
     if (!beforeTask) return;
+    const shouldJournalStatusChange =
+      changes.status !== undefined && changes.status !== beforeTask.status;
 
     const setClauses: string[] = [];
     const values: unknown[] = [];
@@ -418,6 +423,11 @@ export class SqliteTaskAttemptRepository {
       console.log(`[persist-sql] taskId=${taskId} columns=[${cols}]`);
     }
     this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    const changed = this.exec.getRowsModified() > 0;
+    if (changed && shouldJournalStatusChange) {
+      appendEntitySnapshotJournalEntry(this.exec, 'task', taskId, 'upsert');
+    }
+    });
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -460,6 +470,7 @@ export class SqliteTaskAttemptRepository {
       FROM tasks t${this.taskSelectJoin('t')}
       JOIN workflows w ON w.id = t.workflow_id
       WHERE t.status = 'completed'
+        AND w.deleted_at IS NULL
       ORDER BY t.completed_at DESC
     `);
     return rows.map((row) => ({
@@ -481,7 +492,8 @@ export class SqliteTaskAttemptRepository {
         FROM events
         GROUP BY task_id
       ) e ON e.task_id = t.id
-      WHERE COALESCE(e.event_count, 0) > 0 OR t.status != 'pending'
+      WHERE w.deleted_at IS NULL
+        AND (COALESCE(e.event_count, 0) > 0 OR t.status != 'pending')
       ORDER BY COALESCE(e.max_created_at, t.completed_at, t.started_at, t.created_at) DESC
     `);
     return rows.map((row) => {
@@ -594,40 +606,43 @@ export class SqliteTaskAttemptRepository {
   // ── Attempt CRUD ─────────────────────────────────────────
 
   saveAttempt(attempt: Attempt): void {
-    this.exec.execRun(`
-      INSERT OR REPLACE INTO attempts (
-        id, node_id, attempt_number, queue_priority, status,
-        snapshot_commit, base_branch, upstream_attempt_ids,
-        command_override, prompt_override,
-        claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
-        branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
-        supersedes_attempt_id, created_at, merge_conflict
-      ) VALUES (
-        ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?,
-        ?, ?,
-        ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?, ?,
-        ?, ?, ?
-      )
-    `, [
-      attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
-      attempt.snapshotCommit ?? null, attempt.baseBranch ?? null,
-      JSON.stringify(attempt.upstreamAttemptIds),
-      attempt.commandOverride ?? null, attempt.promptOverride ?? null,
-      attempt.claimedAt?.toISOString() ?? null,
-      attempt.startedAt?.toISOString() ?? null,
-      attempt.completedAt?.toISOString() ?? null,
-      attempt.exitCode ?? null, attempt.error ?? null,
-      attempt.lastHeartbeatAt?.toISOString() ?? null,
-      attempt.leaseExpiresAt?.toISOString() ?? null,
-      attempt.branch ?? null, attempt.commit ?? null, attempt.summary ?? null,
-      attempt.workspacePath ?? null, attempt.agentSessionId ?? null,
-      attempt.containerId ?? null,
-      attempt.supersedesAttemptId ?? null,
-      attempt.createdAt.toISOString(),
-      attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
-    ]);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`
+        INSERT OR REPLACE INTO attempts (
+          id, node_id, attempt_number, queue_priority, status,
+          snapshot_commit, base_branch, upstream_attempt_ids,
+          command_override, prompt_override,
+          claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
+          branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
+          supersedes_attempt_id, created_at, merge_conflict
+        ) VALUES (
+          ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?,
+          ?, ?,
+          ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?,
+          ?, ?, ?
+        )
+      `, [
+        attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
+        attempt.snapshotCommit ?? null, attempt.baseBranch ?? null,
+        JSON.stringify(attempt.upstreamAttemptIds),
+        attempt.commandOverride ?? null, attempt.promptOverride ?? null,
+        attempt.claimedAt?.toISOString() ?? null,
+        attempt.startedAt?.toISOString() ?? null,
+        attempt.completedAt?.toISOString() ?? null,
+        attempt.exitCode ?? null, attempt.error ?? null,
+        attempt.lastHeartbeatAt?.toISOString() ?? null,
+        attempt.leaseExpiresAt?.toISOString() ?? null,
+        attempt.branch ?? null, attempt.commit ?? null, attempt.summary ?? null,
+        attempt.workspacePath ?? null, attempt.agentSessionId ?? null,
+        attempt.containerId ?? null,
+        attempt.supersedesAttemptId ?? null,
+        attempt.createdAt.toISOString(),
+        attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
+      ]);
+      appendEntitySnapshotJournalEntry(this.exec, 'attempt', attempt.id, 'upsert');
+    });
   }
 
   loadAttempts(nodeId: string): Attempt[] {
@@ -689,8 +704,12 @@ export class SqliteTaskAttemptRepository {
   }
 
   updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void {
+    this.exec.runTransaction(() => {
     const setClauses: string[] = [];
     const values: unknown[] = [];
+    const shouldJournalCompletion =
+      (changes.status !== undefined && isOutcomeTerminalAttemptStatus(changes.status))
+      || changes.completedAt !== undefined;
 
     if (changes.status !== undefined) { setClauses.push('status = ?'); values.push(changes.status); }
     if (changes.claimedAt !== undefined) { setClauses.push('claimed_at = ?'); values.push(changes.claimedAt instanceof Date ? changes.claimedAt.toISOString() : changes.claimedAt ?? null); }
@@ -712,6 +731,11 @@ export class SqliteTaskAttemptRepository {
     if (setClauses.length === 0) return;
     values.push(attemptId);
     this.exec.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    const changed = this.exec.getRowsModified() > 0;
+    if (changed && shouldJournalCompletion) {
+      appendEntitySnapshotJournalEntry(this.exec, 'attempt', attemptId, 'upsert');
+    }
+    });
   }
 
   claimAttemptForLaunch(

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -27,6 +27,7 @@ import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ReviewGateLookup,
   Workflow,
+  WorkflowListOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
 } from './adapter.js';
@@ -89,8 +90,8 @@ export class SqliteWorkflowRepository {
   saveWorkflow(workflow: WorkflowSaveInput): void {
     assertWorkflowConsistent(workflow);
     this.exec.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, deleted_at, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       workflow.id, workflow.name,
       workflow.description ?? null,
@@ -103,6 +104,7 @@ export class SqliteWorkflowRepository {
       workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
       workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
       workflow.generation ?? 0,
+      workflow.deletedAt ?? null,
       workflow.createdAt, workflow.updatedAt,
     ]);
   }
@@ -174,16 +176,19 @@ export class SqliteWorkflowRepository {
     this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+  loadWorkflow(workflowId: string, options?: WorkflowListOptions): Workflow | undefined {
+    const row = this.exec.queryOne(
+      `SELECT * FROM workflows WHERE id = ?${options?.includeDeleted ? '' : ' AND deleted_at IS NULL'}`,
+      [workflowId],
+    );
     if (!row) return undefined;
     const rollup = this.loadWorkflowRollups([workflowId]).get(workflowId);
     return this.rowToWorkflow(row, rollup);
   }
 
-  listWorkflows(): Workflow[] {
+  listWorkflows(options?: WorkflowListOptions): Workflow[] {
     const rows = this.exec.queryAll(
-      'SELECT * FROM workflows ORDER BY created_at DESC',
+      `SELECT * FROM workflows${options?.includeDeleted ? '' : ' WHERE deleted_at IS NULL'} ORDER BY created_at DESC`,
     );
     const workflowIds = rows.map((row) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
@@ -205,7 +210,9 @@ export class SqliteWorkflowRepository {
               w.base_branch AS baseBranch
          FROM tasks t
          JOIN workflows w ON w.id = t.workflow_id
-        WHERE t.is_merge_node = 1 AND (t.review_id = ? OR t.review_url LIKE ?)`,
+        WHERE w.deleted_at IS NULL
+          AND t.is_merge_node = 1
+          AND (t.review_id = ? OR t.review_url LIKE ?)`,
       [pr, `%/pull/${pr}`],
     );
     if (rows.length === 0) return undefined;
@@ -257,7 +264,8 @@ export class SqliteWorkflowRepository {
     if (type === 'workflows' || type === 'all') {
       const workflows = this.exec.queryAll(
         `SELECT id, name, description, plan_file, repo_url, branch, created_at FROM workflows 
-         WHERE name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ? 
+         WHERE deleted_at IS NULL
+           AND (name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{ id: string; name?: string | null; created_at: string }>;
@@ -282,7 +290,11 @@ export class SqliteWorkflowRepository {
     if (type === 'tasks' || type === 'all') {
       const tasks = this.exec.queryAll(
         `SELECT id, workflow_id, description, command, prompt, summary, problem, approach, test_plan, repro_command, status, created_at FROM tasks 
-         WHERE description LIKE ? OR command LIKE ? OR prompt LIKE ? OR summary LIKE ? OR problem LIKE ? OR approach LIKE ? OR test_plan LIKE ? OR repro_command LIKE ? 
+         WHERE EXISTS (
+             SELECT 1 FROM workflows w
+             WHERE w.id = tasks.workflow_id AND w.deleted_at IS NULL
+           )
+           AND (description LIKE ? OR command LIKE ? OR prompt LIKE ? OR summary LIKE ? OR problem LIKE ? OR approach LIKE ? OR test_plan LIKE ? OR repro_command LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{
@@ -298,7 +310,7 @@ export class SqliteWorkflowRepository {
       if (workflowIds.length > 0) {
         const placeholders = workflowIds.map(() => '?').join(',');
         const workflowRows = this.exec.queryAll(
-          `SELECT id, name FROM workflows WHERE id IN (${placeholders})`,
+          `SELECT id, name FROM workflows WHERE deleted_at IS NULL AND id IN (${placeholders})`,
           workflowIds
         ) as Array<{ id: string; name?: string | null }>;
         for (const wf of workflowRows) {
@@ -326,7 +338,7 @@ export class SqliteWorkflowRepository {
   loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
     const totalStartedAt = Date.now();
     const workflowQueryStartedAt = Date.now();
-    const workflowRows = this.exec.queryAll('SELECT * FROM workflows ORDER BY created_at DESC');
+    const workflowRows = this.exec.queryAll('SELECT * FROM workflows WHERE deleted_at IS NULL ORDER BY created_at DESC');
     const workflowMetadataQueryMs = Date.now() - workflowQueryStartedAt;
     const taskQueryStartedAt = Date.now();
     const taskRows = this.exec.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC');

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -1,0 +1,200 @@
+import type { SqliteExecutor } from './sqlite-executor.js';
+
+export const SYNC_JOURNAL_ENTITY_TYPES = [
+  'workflow',
+  'task',
+  'attempt',
+  'event',
+  // Reserved for future output-spool sync. High-volume output rows are not
+  // journaled by adapter mutation paths yet.
+  'output',
+] as const;
+
+export type SyncJournalEntityType = (typeof SYNC_JOURNAL_ENTITY_TYPES)[number];
+export type SyncJournalOperation = 'upsert' | 'tombstone';
+
+export interface SyncJournalEntryInput {
+  entityType: SyncJournalEntityType;
+  entityId: string;
+  op: SyncJournalOperation;
+  payload: unknown;
+  origin?: string;
+  createdAt?: string;
+}
+
+export interface SyncJournalEntry {
+  seq: number;
+  entityType: SyncJournalEntityType;
+  entityId: string;
+  op: SyncJournalOperation;
+  payload: unknown;
+  origin: string;
+  createdAt: string;
+}
+
+export interface SyncCursor {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt: string;
+}
+
+export interface SyncCursorWrite {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt?: string;
+}
+
+type SyncEntityTable = Exclude<SyncJournalEntityType, 'output'>;
+
+const ENTITY_ROW_SELECT: Record<SyncEntityTable, string> = {
+  workflow: 'SELECT * FROM workflows WHERE id = ?',
+  task: 'SELECT * FROM tasks WHERE id = ?',
+  attempt: 'SELECT * FROM attempts WHERE id = ?',
+  event: 'SELECT * FROM events WHERE id = ?',
+};
+
+function serializeJournalPayload(payload: unknown): string {
+  const serialized = JSON.stringify(payload);
+  if (serialized === undefined) {
+    throw new Error('sync journal payload must be JSON-serializable');
+  }
+  return serialized;
+}
+
+function parseJournalPayload(raw: unknown, seq: unknown): unknown {
+  try {
+    return JSON.parse(String(raw));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Invalid sync_journal payload JSON at seq ${String(seq)}: ${message}`);
+  }
+}
+
+function normalizeEntityType(value: unknown): SyncJournalEntityType {
+  if ((SYNC_JOURNAL_ENTITY_TYPES as readonly unknown[]).includes(value)) {
+    return value as SyncJournalEntityType;
+  }
+  throw new Error(`Invalid sync journal entity_type: ${String(value)}`);
+}
+
+function normalizeOperation(value: unknown): SyncJournalOperation {
+  if (value === 'upsert' || value === 'tombstone') return value;
+  throw new Error(`Invalid sync journal op: ${String(value)}`);
+}
+
+function mapJournalRow(row: Record<string, unknown>): SyncJournalEntry {
+  return {
+    seq: Number(row.seq),
+    entityType: normalizeEntityType(row.entity_type),
+    entityId: String(row.entity_id),
+    op: normalizeOperation(row.op),
+    payload: parseJournalPayload(row.payload, row.seq),
+    origin: String(row.origin),
+    createdAt: String(row.created_at),
+  };
+}
+
+export function appendJournalEntry(db: SqliteExecutor, entry: SyncJournalEntryInput): SyncJournalEntry {
+  const origin = entry.origin ?? 'home';
+  const createdAt = entry.createdAt ?? new Date().toISOString();
+  db.execRun(
+    `INSERT INTO sync_journal (
+      entity_type, entity_id, op, payload, origin, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?)`,
+    [
+      entry.entityType,
+      entry.entityId,
+      entry.op,
+      serializeJournalPayload(entry.payload),
+      origin,
+      createdAt,
+    ],
+  );
+  const seqRow = db.queryOne('SELECT last_insert_rowid() AS seq') as { seq?: number | bigint } | undefined;
+  const seq = Number(seqRow?.seq ?? 0);
+  return {
+    seq,
+    entityType: entry.entityType,
+    entityId: entry.entityId,
+    op: entry.op,
+    payload: entry.payload,
+    origin,
+    createdAt,
+  };
+}
+
+export function appendEntitySnapshotJournalEntry(
+  db: SqliteExecutor,
+  entityType: SyncEntityTable,
+  entityId: string,
+  op: SyncJournalOperation,
+): SyncJournalEntry {
+  const row = db.queryOne(ENTITY_ROW_SELECT[entityType], [entityId]);
+  if (!row) {
+    throw new Error(`Cannot append sync journal entry for missing ${entityType} "${entityId}"`);
+  }
+  return appendJournalEntry(db, {
+    entityType,
+    entityId,
+    op,
+    payload: row,
+  });
+}
+
+export function readJournalSince(
+  db: SqliteExecutor,
+  seq: number,
+  limit: number,
+): SyncJournalEntry[] {
+  const safeSeq = Math.max(0, Math.trunc(seq));
+  const safeLimit = Math.max(0, Math.trunc(limit));
+  if (safeLimit === 0) return [];
+
+  const rows = db.queryAll(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq > ?
+      ORDER BY seq ASC
+      LIMIT ?`,
+    [safeSeq, safeLimit],
+  );
+  return rows.map((row) => mapJournalRow(row));
+}
+
+export function getSyncCursor(db: SqliteExecutor, peerId: string): SyncCursor | undefined {
+  const row = db.queryOne(
+    `SELECT peer_id, last_sent_seq, last_received_seq, updated_at
+       FROM sync_cursors
+      WHERE peer_id = ?`,
+    [peerId],
+  );
+  if (!row) return undefined;
+  return {
+    peerId: String(row.peer_id),
+    lastSentSeq: Number(row.last_sent_seq ?? 0),
+    lastReceivedSeq: Number(row.last_received_seq ?? 0),
+    updatedAt: String(row.updated_at),
+  };
+}
+
+export function setSyncCursor(db: SqliteExecutor, cursor: SyncCursorWrite): SyncCursor {
+  const updatedAt = cursor.updatedAt ?? new Date().toISOString();
+  db.execRun(
+    `INSERT INTO sync_cursors (
+      peer_id, last_sent_seq, last_received_seq, updated_at
+    ) VALUES (?, ?, ?, ?)
+    ON CONFLICT(peer_id) DO UPDATE SET
+      last_sent_seq = excluded.last_sent_seq,
+      last_received_seq = excluded.last_received_seq,
+      updated_at = excluded.updated_at`,
+    [cursor.peerId, cursor.lastSentSeq, cursor.lastReceivedSeq, updatedAt],
+  );
+  return {
+    peerId: cursor.peerId,
+    lastSentSeq: cursor.lastSentSeq,
+    lastReceivedSeq: cursor.lastReceivedSeq,
+    updatedAt,
+  };
+}


### PR DESCRIPTION
## Summary

Remote Sync Step 1: Sync Schema and Change Journal — 2 tasks completed, 0 failed, 0 closed, 0 sk&#105;pped

Adds sync journal and cursor tables, workflow tombstones, and journal helpers for future remote sync.

Journal rows are appended in the same SQLite transactions as workflow, task, and attempt mutations.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926077035-3/implement-sync-schema | Add sync journal, cursor, and tombstone schema to data-store | completed |
| wf-1784926077035-3/verify-sync-schema | Run data-store package tests covering the new schema and journal | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784926077035-3/implement-sync-schema — Add sync journal, cursor, and tombstone schema to data-store

### wf-1784926077035-3/verify-sync-schema — Run data-store package tests covering the new schema and journal

</details>

## Review Claim

Approve the data-store sync contract for journaling workflow, task, and attempt mutations with cursors and workflow tombstones.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Journal rows are appended inside the existing SQLite transaction, so rollback removes both entity rows and sync evidence.

## Slice Rationale

This is the foundation slice for remote sync. It adds durable local sync records before any transport or peer reconciliation code consumes them.

## Non-goals

- No remote transport.
- No peer reconciliation.
- No UI changes.
- No output spool replication.

## Architecture

### Before

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["Entity table rows"]
    C["Workflow removal request"] --> D["Workflow row removed"]
```

### After

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["Entity table rows"]
    A --> C["sync_journal upsert rows"]
    D["Workflow removal request"] --> E["Workflow tombstone state"]
    D --> F["sync_journal tombstone row"]
    G["Peer replication checkpoint"] --> H["sync_cursors row"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/data-store test`
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-bodies/remote-sync-step-1-g34.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-bodies/remote-sync-step-1-g34.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 1c57e1ec0`
- Post-revert steps: Rerun `pnpm --filter @invoker/data-store test`.
- Data migration? Yes. Existing local databases may retain unused sync tables and the workflow tombstone column after code revert.

</details>
