### PR TITLE
[CI Fix Step 3 - SSH Shard Stability](1) Direct owner launch through electron.cjs

### DIFF
--- a/packages/contracts/src/__tests__/headless-owner-launch.test.ts
+++ b/packages/contracts/src/__tests__/headless-owner-launch.test.ts
@@ -60,10 +60,8 @@ describe('resolveHeadlessOwnerLaunchSpec', () => {
       which: () => undefined,
       existsSync: (path) => path === '/repo/scripts/electron.cjs' || path === '/repo/packages/app/dist/main.js',
     })).toEqual({
-      command: 'xvfb-run',
+      command: './scripts/electron.cjs',
       args: [
-        '--auto-servernum',
-        './scripts/electron.cjs',
         ...LINUX_HEADLESS_ELECTRON_FLAGS,
         'packages/app/dist/main.js',
         '--headless',

--- a/packages/contracts/src/headless-owner-launch.ts
+++ b/packages/contracts/src/headless-owner-launch.ts
@@ -95,13 +95,6 @@ export function resolveHeadlessOwnerLaunchSpec(
   const mainJs = join(options.repoRoot, 'packages', 'app', 'dist', 'main.js');
   if (fileExists(electronCjs) && fileExists(mainJs)) {
     const launchArgs = buildElectronHeadlessArgs('packages/app/dist/main.js', ['owner-serve'], platform);
-    if (platform === 'linux') {
-      return {
-        command: 'xvfb-run',
-        args: ['--auto-servernum', './scripts/electron.cjs', ...launchArgs],
-        cwd: options.repoRoot,
-      };
-    }
     return {
       command: './scripts/electron.cjs',
       args: launchArgs,


### PR DESCRIPTION
## Summary

Change the owner launch resolver to call `./scripts/electron.cjs` directly on Linux.

The electron argument builder already adds Linux runtime flags, so the extra wrapper is no longer needed.

## Review Claim

Approve the owner launch contract returning `./scripts/electron.cjs` directly when the monorepo build is available.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The change is limited to the shared launch resolver and its unit test; callers keep the same main process arguments.

## Slice Rationale

This PR isolates the shared launch contract before app and shell callers adopt the same direct electron path.

## Non-goals

Does not change packaged `invoker-ui` resolution. Does not change planner execution, SSH transport, or worktree publication behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/contracts exec vitest run src/__tests__/headless-owner-launch.test.ts`
- [x] `bash scripts/test-suites/optional/30-e2e-ssh.sh`
- [x] `bash scripts/test-suites/optional/31-e2e-ssh-merge.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3abf7eb31`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved headless application startup in built Linux environments by launching the Electron runtime directly.
  * Preserved the required headless display and application startup options for reliable execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->