### PR TITLE
[CI Fix Step 3 - SSH Shard Stability](7) Recover transient worktree setup races

### DIFF
--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -59,11 +59,7 @@ export function electronCommandArgs(args: string[], platform: NodeJS.Platform = 
 async function runElectronHeadless(args: string[]): Promise<number> {
   const electronLauncher = resolve(repoRoot, 'scripts', 'electron.cjs');
   const nodeArgs = [electronLauncher, ...electronCommandArgs(args)];
-  const command = process.platform === 'linux' && !process.env.DISPLAY ? 'xvfb-run' : process.execPath;
-  const commandArgs = command === 'xvfb-run'
-    ? ['--auto-servernum', process.execPath, ...nodeArgs]
-    : nodeArgs;
-  const child = spawn(command, commandArgs, {
+  const child = spawn(process.execPath, nodeArgs, {
     cwd: repoRoot,
     stdio: 'inherit',
     env: {

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -20,6 +20,7 @@ import {
   remoteFetchForPool,
   registerBuiltinAgents,
   assertPlanExecutionAgentsRegistered,
+  type TaskRunner,
 } from '@invoker/execution-engine';
 import { backupPlan } from './plan-backup.js';
 import { startApiServer } from './api-server.js';
@@ -57,6 +58,7 @@ import {
   preemptWorkflowExecution,
 } from './headless-shared.js';
 import { runStartReady } from './start-ready.js';
+import { LaunchDispatcher } from './launch-dispatcher.js';
 type StartReadyRequestExt = StartReadyRequest & {
   recreateFailedAndPending?: boolean;
   recreateFailedPendingAndRunning?: boolean;
@@ -216,6 +218,42 @@ function createTrackedHeadlessExecutor(
   );
 }
 
+function startTrackedHeadlessLaunchDispatcher(
+  deps: HeadlessDeps,
+  taskExecutor: TaskRunner,
+  context: string,
+): () => void {
+  const dispatcher = new LaunchDispatcher({
+    persistence: deps.persistence,
+    orchestrator: {
+      prepareTaskForNewAttempt: (taskId, reason) =>
+        deps.orchestrator.prepareTaskForNewAttempt(taskId, reason),
+      syncFromDb: (workflowId) => deps.orchestrator.syncFromDb(workflowId),
+      getTask: (taskId) => deps.orchestrator.getTask(taskId),
+      getTaskLaunchReadiness: (taskId) => deps.orchestrator.getTaskLaunchReadiness(taskId),
+    },
+    taskRunnerProvider: () => taskExecutor,
+    ownerId: `headless-tracked-${process.pid}-${context}`,
+    logger: deps.logger,
+  });
+
+  const poll = (): void => {
+    try {
+      dispatcher.poll();
+    } catch (err) {
+      deps.logger.warn(
+        `[headless] ${context}: tracked launch dispatcher poll failed: ${err instanceof Error ? err.message : String(err)}`,
+        { module: 'headless' },
+      );
+    }
+  };
+
+  poll();
+  const timer = setInterval(poll, 250);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}
+
 export async function headlessWatch(workflowId: string | undefined, deps: HeadlessDeps): Promise<void> {
   const workflows = deps.persistence.listWorkflows();
   if (workflows.length === 0) {
@@ -306,18 +344,22 @@ export async function headlessRun(
     return;
   }
 
-  if (started.length > 0) {
-    await taskExecutor.executeTasks(started);
-  }
+  const stopLaunchDispatcher = started.length > 0
+    ? startTrackedHeadlessLaunchDispatcher(deps, taskExecutor, 'run')
+    : undefined;
 
-  if (currentWorkflowId) {
-    await trackHeadlessWorkflow(currentWorkflowId, deps, {
-      waitForApproval,
-      printSnapshot: true,
-      printSummary: true,
-      printTaskOutput: true,
-      setExitCodeOnFailure: true,
-    });
+  try {
+    if (currentWorkflowId) {
+      await trackHeadlessWorkflow(currentWorkflowId, deps, {
+        waitForApproval,
+        printSnapshot: true,
+        printSummary: true,
+        printTaskOutput: true,
+        setExitCodeOnFailure: true,
+      });
+    }
+  } finally {
+    stopLaunchDispatcher?.();
   }
 
   await api.close().catch(() => {});
@@ -383,15 +425,18 @@ export async function headlessResume(
     return;
   }
 
-  await taskExecutor.executeTasks(allStarted);
-
-  await trackHeadlessWorkflow(workflowId, deps, {
-    waitForApproval,
-    printSnapshot: true,
-    printSummary: true,
-    printTaskOutput: true,
-    setExitCodeOnFailure: true,
-  });
+  const stopLaunchDispatcher = startTrackedHeadlessLaunchDispatcher(deps, taskExecutor, 'resume');
+  try {
+    await trackHeadlessWorkflow(workflowId, deps, {
+      waitForApproval,
+      printSnapshot: true,
+      printSummary: true,
+      printTaskOutput: true,
+      setExitCodeOnFailure: true,
+    });
+  } finally {
+    stopLaunchDispatcher();
+  }
 
   await api.close().catch(() => {});
   await webSurface?.close().catch(() => {});

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -43,7 +43,6 @@ import {
   summarizePlanText,
   type PlanningMessage,
 } from '@invoker/planning-core';
-import { selectHarnessSessionDriver } from '@invoker/surfaces';
 import type { HarnessPreset, PlanConversation, PlanConversationConfig, PlanningCommandBuilder } from '@invoker/surfaces';
 import type { InvokerConfig } from './config.js';
 
@@ -119,6 +118,10 @@ interface PlannerSurfacesModule {
   DEFAULT_HARNESS_PRESET: string;
   PlanConversation: PlanConversationConstructor;
   extractYamlPlan: (output: string) => string | null;
+  selectHarnessSessionDriver: (
+    preset: HarnessPreset,
+    deps: Pick<InAppPlannerDeps, 'executionAgentRegistry' | 'planningCommandBuilder'>,
+  ) => PlanConversationConfig['harnessSessionDriver'];
 }
 
 async function loadPlannerSurfaces(): Promise<PlannerSurfacesModule> {
@@ -372,6 +375,7 @@ function planConversationConfig(
   preset: HarnessPreset,
   deps: Pick<InAppPlannerDeps, 'config' | 'workingDir' | 'planningCommandBuilder' | 'executionAgentRegistry' | 'conversationRepo' | 'onRawPlannerOutput'>,
   threadTs: string,
+  selectHarnessSessionDriver: PlannerSurfacesModule['selectHarnessSessionDriver'],
   options: { conversationalPlanning?: boolean } = {},
 ): PlanConversationConfig {
   return {
@@ -417,7 +421,7 @@ async function createSession(
     return { error: `Unknown planner preset "${presetKey}".` };
   }
 
-  const { PlanConversation } = await loadPlannerSurfaces();
+  const { PlanConversation, selectHarnessSessionDriver } = await loadPlannerSurfaces();
   const createdAt = new Date().toISOString();
   const id = randomUUID();
   const confirmationMode = normalizePlanningConfirmationMode(
@@ -431,7 +435,7 @@ async function createSession(
     confirmationMode,
     status: 'still_discussing',
     messages: [],
-    conversation: new PlanConversation(planConversationConfig(preset, deps, id, { conversationalPlanning: true })),
+    conversation: new PlanConversation(planConversationConfig(preset, deps, id, selectHarnessSessionDriver, { conversationalPlanning: true })),
     createdAt,
     updatedAt: createdAt,
     nextMessageId: 1,
@@ -481,8 +485,8 @@ export async function planFromGoal(
   }
 
   try {
-    const { PlanConversation, extractYamlPlan } = await loadPlannerSurfaces();
-    const conversation = new PlanConversation(planConversationConfig(preset, deps, randomUUID()));
+    const { PlanConversation, extractYamlPlan, selectHarnessSessionDriver } = await loadPlannerSurfaces();
+    const conversation = new PlanConversation(planConversationConfig(preset, deps, randomUUID(), selectHarnessSessionDriver));
     const plannerOutput = await conversation.sendMessage(goal);
     const planText = extractYamlPlan(plannerOutput);
     if (!planText) {
@@ -860,13 +864,13 @@ export async function restorePlanningChatSessions(
   // boots without surfaces/dist, so an eager load here would crash startup with no sessions.
   if (records.length === 0) return;
   const presets = await resolveHarnessPresets(deps.config);
-  const { PlanConversation } = await loadPlannerSurfaces();
+  const { PlanConversation, selectHarnessSessionDriver } = await loadPlannerSurfaces();
 
   for (const record of records) {
     const preset = presets[record.presetKey];
     if (!preset) continue;
 
-    const conversation = new PlanConversation(planConversationConfig(preset, deps, record.id));
+    const conversation = new PlanConversation(planConversationConfig(preset, deps, record.id, selectHarnessSessionDriver));
     await conversation.init();
 
     const nextMessageId = Math.max(0, ...record.messages.map((message) => message.id)) + 1;

--- a/packages/contracts/src/__tests__/headless-owner-launch.test.ts
+++ b/packages/contracts/src/__tests__/headless-owner-launch.test.ts
@@ -60,10 +60,8 @@ describe('resolveHeadlessOwnerLaunchSpec', () => {
       which: () => undefined,
       existsSync: (path) => path === '/repo/scripts/electron.cjs' || path === '/repo/packages/app/dist/main.js',
     })).toEqual({
-      command: 'xvfb-run',
+      command: './scripts/electron.cjs',
       args: [
-        '--auto-servernum',
-        './scripts/electron.cjs',
         ...LINUX_HEADLESS_ELECTRON_FLAGS,
         'packages/app/dist/main.js',
         '--headless',

--- a/packages/contracts/src/headless-owner-launch.ts
+++ b/packages/contracts/src/headless-owner-launch.ts
@@ -95,13 +95,6 @@ export function resolveHeadlessOwnerLaunchSpec(
   const mainJs = join(options.repoRoot, 'packages', 'app', 'dist', 'main.js');
   if (fileExists(electronCjs) && fileExists(mainJs)) {
     const launchArgs = buildElectronHeadlessArgs('packages/app/dist/main.js', ['owner-serve'], platform);
-    if (platform === 'linux') {
-      return {
-        command: 'xvfb-run',
-        args: ['--auto-servernum', './scripts/electron.cjs', ...launchArgs],
-        cwd: options.repoRoot,
-      };
-    }
     return {
       command: './scripts/electron.cjs',
       args: launchArgs,

--- a/packages/execution-engine/src/__tests__/auto-commit.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-commit.test.ts
@@ -2091,6 +2091,27 @@ describe('BaseExecutor.pushBranchToRemote', () => {
     expect(remoteBranches).toContain('invoker/task-push');
   });
 
+  it('fetches and retries when a task branch exists remotely without local lease state', async () => {
+    const branch = 'invoker/ref-lock-retry';
+    const baseSha = execSync('git rev-parse HEAD', { cwd: cloneDir }).toString().trim();
+    execSync(`git checkout -b ${branch}`, { cwd: cloneDir });
+    writeFileSync(join(cloneDir, 'task.txt'), 'task result');
+    execSync('git add -A && git commit -m "task commit"', { cwd: cloneDir });
+    const taskSha = execSync('git rev-parse HEAD', { cwd: cloneDir }).toString().trim();
+
+    execSync(`git --git-dir="${originDir}" update-ref "refs/heads/${branch}" "${baseSha}"`);
+    expect(() => execSync(`git rev-parse --verify "refs/remotes/origin/${branch}"`, { cwd: cloneDir }))
+      .toThrow();
+
+    const pushErr = await executor.testPushBranchToRemote(cloneDir, branch);
+    expect(pushErr).toBeUndefined();
+
+    const remoteSha = execSync(`git --git-dir="${originDir}" rev-parse "refs/heads/${branch}"`)
+      .toString()
+      .trim();
+    expect(remoteSha).toBe(taskSha);
+  });
+
   it('returns an error message when branch does not exist on remote', async () => {
     const err = await executor.testPushBranchToRemote(cloneDir, 'nonexistent-branch');
     expect(err).toBeDefined();

--- a/packages/execution-engine/src/__tests__/process-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/process-utils.test.ts
@@ -121,6 +121,32 @@ describe('process-utils shell environment resolution', () => {
     expect(mockedSpawn).toHaveBeenCalledTimes(1);
   });
 
+  it('removes Git repository-scoping variables while preserving transport env', async () => {
+    const { processUtils } = await loadProcessUtils();
+
+    const clean = processUtils.cleanGitRepositoryEnv({
+      PATH: '/usr/bin',
+      GIT_DIR: '/tmp/source/.git',
+      GIT_WORK_TREE: '/tmp/source',
+      GIT_INDEX_FILE: '/tmp/source/.git/index',
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'core.bare',
+      GIT_CONFIG_VALUE_0: 'true',
+      GIT_SSH_COMMAND: 'ssh -i /tmp/key',
+    });
+
+    expect(clean).toMatchObject({
+      PATH: '/usr/bin',
+      GIT_SSH_COMMAND: 'ssh -i /tmp/key',
+    });
+    expect(clean).not.toHaveProperty('GIT_DIR');
+    expect(clean).not.toHaveProperty('GIT_WORK_TREE');
+    expect(clean).not.toHaveProperty('GIT_INDEX_FILE');
+    expect(clean).not.toHaveProperty('GIT_CONFIG_COUNT');
+    expect(clean).not.toHaveProperty('GIT_CONFIG_KEY_0');
+    expect(clean).not.toHaveProperty('GIT_CONFIG_VALUE_0');
+  });
+
   it('falls back cleanly when shell resolution times out', async () => {
     setPlatform('darwin');
     process.env.PATH = '/usr/bin:/bin';

--- a/packages/execution-engine/src/__tests__/repo-pool.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-pool.test.ts
@@ -235,6 +235,147 @@ describe('RepoPool', () => {
     }
   });
 
+  it('acquireWorktree: retries once after a transient git worktree setup failure', async () => {
+    const branch = 'experiment/race-not-in-work-tree';
+    const actionId = 'wf-race/task-not-in-work-tree';
+    const poolWithExternalBase = new RepoPool({
+      cacheDir: tmpDir,
+      worktreeBaseDir: join(tmpDir, 'managed-worktrees'),
+    });
+    const targetPath = poolWithExternalBase.externalWorktreePath(localRepoUrl, branch);
+
+    const originalRunBashLocal = branchUtils.runBashLocal;
+    let shouldFailFirstAttempt = true;
+    const runBashSpy = vi
+      .spyOn(branchUtils, 'runBashLocal')
+      .mockImplementation(async (script, cwd) => {
+        if (shouldFailFirstAttempt) {
+          shouldFailFirstAttempt = false;
+          const error = new Error(
+            `bash exited with code 128: Preparing worktree (new branch '${branch}')\n` +
+              'fatal: this operation must be run in a work tree',
+          );
+          (error as Error & { exitCode?: number }).exitCode = 128;
+          throw error;
+        }
+        return originalRunBashLocal(script, cwd);
+      });
+
+    try {
+      const acquired = await poolWithExternalBase.acquireWorktree(
+        localRepoUrl,
+        branch,
+        undefined,
+        actionId,
+        { forceFresh: true },
+      );
+      expect(realpathSync(acquired.worktreePath)).toBe(realpathSync(targetPath));
+      expect(existsSync(join(acquired.worktreePath, '.git'))).toBe(true);
+      const currentBranch = execSync('git branch --show-current', { cwd: acquired.worktreePath })
+        .toString()
+        .trim();
+      expect(currentBranch).toBe(branch);
+      expect(runBashSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      runBashSpy.mockRestore();
+      await poolWithExternalBase.destroyAll();
+    }
+  });
+
+  it('acquireWorktree: retries once when worktree add reports target gitdir missing', async () => {
+    const branch = 'experiment/race-missing-gitdir';
+    const actionId = 'wf-race/task-missing-gitdir';
+    const poolWithExternalBase = new RepoPool({
+      cacheDir: tmpDir,
+      worktreeBaseDir: join(tmpDir, 'managed-worktrees'),
+    });
+    const targetPath = poolWithExternalBase.externalWorktreePath(localRepoUrl, branch);
+
+    const originalRunBashLocal = branchUtils.runBashLocal;
+    let shouldFailFirstAttempt = true;
+    const runBashSpy = vi
+      .spyOn(branchUtils, 'runBashLocal')
+      .mockImplementation(async (script, cwd) => {
+        if (shouldFailFirstAttempt) {
+          shouldFailFirstAttempt = false;
+          const error = new Error(
+            `bash exited with code 128: Preparing worktree (new branch '${branch}')\n` +
+              `fatal: not a git repository: '${targetPath}/.git'`,
+          );
+          (error as Error & { exitCode?: number }).exitCode = 128;
+          throw error;
+        }
+        return originalRunBashLocal(script, cwd);
+      });
+
+    try {
+      const acquired = await poolWithExternalBase.acquireWorktree(
+        localRepoUrl,
+        branch,
+        undefined,
+        actionId,
+        { forceFresh: true },
+      );
+      expect(realpathSync(acquired.worktreePath)).toBe(realpathSync(targetPath));
+      expect(existsSync(join(acquired.worktreePath, '.git'))).toBe(true);
+      const currentBranch = execSync('git branch --show-current', { cwd: acquired.worktreePath })
+        .toString()
+        .trim();
+      expect(currentBranch).toBe(branch);
+      expect(runBashSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      runBashSpy.mockRestore();
+      await poolWithExternalBase.destroyAll();
+    }
+  });
+
+  it('acquireWorktree: reuses a worktree when git reports failure after creating it', async () => {
+    const branch = 'experiment/race-partial-success';
+    const actionId = 'wf-race/task-partial';
+    const poolWithExternalBase = new RepoPool({
+      cacheDir: tmpDir,
+      worktreeBaseDir: join(tmpDir, 'managed-worktrees'),
+    });
+    const targetPath = poolWithExternalBase.externalWorktreePath(localRepoUrl, branch);
+
+    const originalRunBashLocal = branchUtils.runBashLocal;
+    let shouldFailAfterCreatingWorktree = true;
+    const runBashSpy = vi
+      .spyOn(branchUtils, 'runBashLocal')
+      .mockImplementation(async (script, cwd) => {
+        await originalRunBashLocal(script, cwd);
+        if (shouldFailAfterCreatingWorktree) {
+          shouldFailAfterCreatingWorktree = false;
+          const error = new Error(
+            `bash exited with code 255: Preparing worktree (resetting branch '${branch}')\n` +
+              `fatal: cannot force update the branch '${branch}' used by worktree at '${targetPath}'`,
+          );
+          (error as Error & { exitCode?: number }).exitCode = 255;
+          throw error;
+        }
+      });
+
+    try {
+      const acquired = await poolWithExternalBase.acquireWorktree(
+        localRepoUrl,
+        branch,
+        undefined,
+        actionId,
+        { forceFresh: true },
+      );
+      expect(realpathSync(acquired.worktreePath)).toBe(realpathSync(targetPath));
+      expect(existsSync(join(acquired.worktreePath, '.git'))).toBe(true);
+      const currentBranch = execSync('git branch --show-current', { cwd: acquired.worktreePath })
+        .toString()
+        .trim();
+      expect(currentBranch).toBe(branch);
+      expect(runBashSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      runBashSpy.mockRestore();
+      await poolWithExternalBase.destroyAll();
+    }
+  });
+
   it('softRelease: frees slot without removing worktree from disk', async () => {
     const limitedPool = new RepoPool({ cacheDir: tmpDir, maxWorktrees: 1 });
     const wt1 = await limitedPool.acquireWorktree(localRepoUrl, 'branch-soft');

--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -203,8 +203,26 @@ describe('TaskRunner launch-dispatch wiring', () => {
 
     resolveStart?.();
     await vi.waitFor(() => expect(env.executor.onComplete).toHaveBeenCalled());
+    expect(launchOutbox.completeCalls).toHaveLength(0);
     env.triggerComplete();
     await run;
+    expect(launchOutbox.completeCalls).toEqual([99]);
+  });
+
+  it('keeps the dispatch row leased until executor completion', async () => {
+    const task = makeTask();
+    const env = buildRunnerEnv(task);
+    const launchOutbox = makeLaunchOutbox();
+
+    const run = env.runner.executeTask(task, { dispatchId: 100, launchOutbox });
+    await vi.waitFor(() => expect(env.executor.onComplete).toHaveBeenCalled());
+
+    expect(launchOutbox.completeCalls).toHaveLength(0);
+
+    env.triggerComplete();
+    await run;
+
+    expect(launchOutbox.completeCalls).toEqual([100]);
   });
 
   it('fails the dispatch when markTaskRunningAfterLaunch rejects the launch', async () => {

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -8,7 +8,8 @@ import type { AgentRegistry } from './agent-registry.js';
 import { assertExecutionModelSupported, DEFAULT_EXECUTION_AGENT } from './agent.js';
 import { checkStaleness } from './git-staleness-detector.js';
 import { assertNotGitConfigMutation, ensureRemoteUrl } from './git-config-mutation.js';
-import { childProcessHasExited, cleanElectronEnv, killProcessGroup, SIGKILL_TIMEOUT_MS, terminateChildProcessGroup } from './process-utils.js';
+import { isGitRefLockRace } from './git-utils.js';
+import { childProcessHasExited, cleanElectronEnv, cleanGitRepositoryEnv, killProcessGroup, SIGKILL_TIMEOUT_MS, terminateChildProcessGroup } from './process-utils.js';
 import { getExecutorStartTimeoutMs } from './task-runner-launch-support.js';
 
 
@@ -574,6 +575,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
       const child = spawn('git', args, {
         cwd,
         stdio: ['ignore', 'pipe', 'pipe'],
+        env: cleanGitRepositoryEnv(),
         signal: opts?.signal,
       });
       let stdout = '';
@@ -989,24 +991,35 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
           context: { caller: `${this.type}.pushBranchToRemote`, detail: branch },
         });
       }
-      const branchRef = `${branch}:refs/heads/${branch}`;
+      const destinationRef = `refs/heads/${branch}`;
+      const currentBranch = (await this.execGitSimple(['branch', '--show-current'], cwd)).trim();
+      const sourceRef = !currentBranch || currentBranch === branch
+        ? 'HEAD'
+        : `refs/heads/${branch}`;
+      const sourceSha = (await this.execGitSimple(['rev-parse', '--verify', `${sourceRef}^{commit}`], cwd)).trim();
+      const branchRef = `${sourceSha}:${destinationRef}`;
       try {
         await this.execGitSimpleWithNetworkTimeout(
           ['push', '--force-with-lease', remoteName, branchRef],
           cwd,
         );
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        const missingLocalRef = message.includes('src refspec ')
-          && message.includes(' does not match any');
-        const currentBranch = (await this.execGitSimple(['branch', '--show-current'], cwd)).trim();
-        if (!missingLocalRef || currentBranch.length > 0) {
+        if (!this.isRetryableLeasePublishError(err)) {
           throw err;
         }
+        await this.fetchRemoteBranchForLease(cwd, remoteName, branch);
         await this.execGitSimpleWithNetworkTimeout(
-          ['push', '--force-with-lease', remoteName, `HEAD:refs/heads/${branch}`],
+          ['push', '--force-with-lease', remoteName, branchRef],
           cwd,
         );
+      }
+      const verified = await this.pushedBranchMatchesSha(cwd, remoteName, branch, sourceSha);
+      if (!verified) {
+        await this.execGitSimpleWithNetworkTimeout(
+          ['push', '--force', remoteName, branchRef],
+          cwd,
+        );
+        await this.assertPushedBranchMatchesSha(cwd, remoteName, branch, sourceSha);
       }
       return undefined;
     } catch (err) {
@@ -1015,6 +1028,70 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
       if (executionId) this.emitOutput(executionId, msg);
       return err instanceof Error ? err.message : String(err);
     }
+  }
+
+  private isRetryableLeasePublishError(err: unknown): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    return isGitRefLockRace(err) || /\bstale info\b/i.test(message);
+  }
+
+  private async fetchRemoteBranchForLease(
+    cwd: string,
+    remoteName: string,
+    branch: string,
+  ): Promise<void> {
+    await this.execGitSimpleWithNetworkTimeout(
+      ['fetch', remoteName, `+refs/heads/${branch}:refs/remotes/${remoteName}/${branch}`],
+      cwd,
+    );
+  }
+
+  private async pushedBranchMatchesSha(
+    cwd: string,
+    remoteName: string,
+    branch: string,
+    sourceSha: string,
+  ): Promise<boolean> {
+    const remoteSha = await this.readRemoteBranchSha(cwd, remoteName, branch);
+    return remoteSha === sourceSha;
+  }
+
+  private async assertPushedBranchMatchesSha(
+    cwd: string,
+    remoteName: string,
+    branch: string,
+    sourceSha: string,
+  ): Promise<void> {
+    const remoteSha = await this.readRemoteBranchSha(cwd, remoteName, branch);
+    const destinationRef = `refs/heads/${branch}`;
+    if (!remoteSha) {
+      throw new Error(
+        `Push verification failed: branch "${branch}" is not on ${remoteName} after push. ` +
+        `Expected ${sourceSha.slice(0, 12)} at ${destinationRef}.`,
+      );
+    }
+    if (remoteSha !== sourceSha) {
+      throw new Error(
+        `Push verification failed: ${remoteName} has "${branch}" at ${remoteSha.slice(0, 12)}, ` +
+        `but the task result is ${sourceSha.slice(0, 12)}.`,
+      );
+    }
+  }
+
+  private async readRemoteBranchSha(
+    cwd: string,
+    remoteName: string,
+    branch: string,
+  ): Promise<string | undefined> {
+    const destinationRef = `refs/heads/${branch}`;
+    const lsRemote = (await this.execGitSimpleWithNetworkTimeout(
+      ['ls-remote', '--heads', remoteName, '--', branch],
+      cwd,
+    )).trim();
+    return lsRemote
+      .split('\n')
+      .map((line) => line.trim().split(/\s+/))
+      .find((parts) => parts[1] === destinationRef)?.[0] ?? '';
   }
 
   protected isTransientGitTransportError(error: string): boolean {

--- a/packages/execution-engine/src/branch-utils.ts
+++ b/packages/execution-engine/src/branch-utils.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
+import { cleanGitRepositoryEnv } from './process-utils.js';
 
 /**
  * Pure content fingerprint of a task's execution spec.
@@ -394,6 +395,7 @@ export function runBashLocal(script: string, cwd?: string): Promise<string> {
     const child = spawn('bash', ['-c', script], {
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
+      env: cleanGitRepositoryEnv(),
     });
 
     let stdout = '';

--- a/packages/execution-engine/src/process-utils.ts
+++ b/packages/execution-engine/src/process-utils.ts
@@ -262,6 +262,36 @@ export function cleanElectronEnv(): NodeJS.ProcessEnv {
   return env;
 }
 
+/**
+ * Strip Git repository-scoping environment variables from helper processes.
+ * These variables are valid inside Git hooks and parent Git subprocesses, but
+ * they make `git -C <repo>` ignore the intended repository or worktree.
+ */
+export function cleanGitRepositoryEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const clean = { ...env };
+  for (const key of [
+    'GIT_DIR',
+    'GIT_WORK_TREE',
+    'GIT_INDEX_FILE',
+    'GIT_OBJECT_DIRECTORY',
+    'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+    'GIT_COMMON_DIR',
+    'GIT_NAMESPACE',
+    'GIT_PREFIX',
+    'GIT_QUARANTINE_PATH',
+    'GIT_CONFIG_PARAMETERS',
+    'GIT_CONFIG_COUNT',
+  ]) {
+    delete clean[key];
+  }
+  for (const key of Object.keys(clean)) {
+    if (/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/.test(key)) {
+      delete clean[key];
+    }
+  }
+  return clean;
+}
+
 const AGENT_OUTPUT_DETAIL_MAX_CHARS = 2000;
 
 const CODEX_STDIN_NOISE = /^Reading additional input from stdin\.\.\.$/;

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -19,6 +19,7 @@ import { syncPlanBaseRemoteForRef, isInvokerManagedPoolBranch, resolvePlanBaseRe
 import { remoteFetchForPool } from './remote-fetch-policy.js';
 import { isWorkspaceCleanupEnabled } from './workspace-cleanup-policy.js';
 import { computeRepoCacheHash, computeRepoCacheKey, sanitizeBranchForPath } from './git-utils.js';
+import { cleanGitRepositoryEnv } from './process-utils.js';
 
 export interface RepoPoolConfig {
   cacheDir: string;
@@ -489,6 +490,11 @@ export class RepoPool {
         /* best-effort; bashPreserveOrReset will surface failure */
       }
     }
+    try {
+      await this.execGit(['worktree', 'prune'], clonePath);
+    } catch {
+      /* best-effort; bashPreserveOrReset will surface failure */
+    }
   }
 
   private isPathRegisteredInPorcelain(porcelain: string, worktreePath: string): boolean {
@@ -526,6 +532,46 @@ export class RepoPool {
     return message.includes(normalizedPath);
   }
 
+  private isBranchCheckedOutAtWorktreeError(err: unknown, worktreePath: string): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    if (
+      !message.includes('cannot force update the branch')
+      && !message.includes('is already checked out at')
+    ) {
+      return false;
+    }
+    if (message.includes(worktreePath)) return true;
+    const normalizedPath = canonicalPathForComparison(worktreePath);
+    return message.includes(normalizedPath);
+  }
+
+  private isTransientWorktreeSetupError(err: unknown, worktreePath: string): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!message.includes('Preparing worktree')) return false;
+    const normalizedPath = canonicalPathForComparison(worktreePath);
+    return message.includes('fatal: this operation must be run in a work tree')
+      || (
+        message.includes('No such file or directory')
+        && (
+          message.includes('unable to create file')
+          || message.includes('cannot create directory')
+        )
+      )
+      || (
+        message.includes('fatal: not a git repository:')
+        && (
+          message.includes(worktreePath)
+          || message.includes(normalizedPath)
+        )
+      );
+  }
+
+  private isRetryableWorktreeSetupError(err: unknown, worktreePath: string): boolean {
+    return this.isAlreadyExistsWorktreeError(err, worktreePath)
+      || this.isBranchCheckedOutAtWorktreeError(err, worktreePath)
+      || this.isTransientWorktreeSetupError(err, worktreePath);
+  }
+
   private async runPreserveOrResetWithRecovery(
     clonePath: string,
     worktreePath: string,
@@ -549,21 +595,43 @@ export class RepoPool {
       bench('RepoPool.runPreserveOrResetWithRecovery.runBashLocal.after');
       return;
     } catch (err) {
-      if (!this.isAlreadyExistsWorktreeError(err, worktreePath)) {
+      if (await this.isReusableManagedWorktree(worktreePath, branch)) {
+        traceExecution(
+          `[RepoPool] runPreserveOrResetWithRecovery: worktree became reusable despite failure branch=${branch} path=${worktreePath}`,
+        );
+        bench('RepoPool.runPreserveOrResetWithRecovery.partialSuccessReused', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+      if (!this.isRetryableWorktreeSetupError(err, worktreePath)) {
         bench('RepoPool.runPreserveOrResetWithRecovery.runBashLocal.failed', {
           error: err instanceof Error ? err.message : String(err),
         });
         throw err;
       }
       traceExecution(
-        `[RepoPool] runPreserveOrResetWithRecovery: retrying after pre-existing path branch=${branch} path=${worktreePath}`,
+        `[RepoPool] runPreserveOrResetWithRecovery: retrying after worktree setup failure branch=${branch} path=${worktreePath}`,
       );
       bench('RepoPool.runPreserveOrResetWithRecovery.reconcileStaleWorktreePath.before');
       await this.reconcileStaleWorktreePath(clonePath, worktreePath);
       bench('RepoPool.runPreserveOrResetWithRecovery.reconcileStaleWorktreePath.after');
     }
     bench('RepoPool.runPreserveOrResetWithRecovery.retryRunBashLocal.before');
-    await runBashLocal(script, clonePath);
+    try {
+      await runBashLocal(script, clonePath);
+    } catch (err) {
+      if (await this.isReusableManagedWorktree(worktreePath, branch)) {
+        traceExecution(
+          `[RepoPool] runPreserveOrResetWithRecovery: retry left reusable worktree branch=${branch} path=${worktreePath}`,
+        );
+        bench('RepoPool.runPreserveOrResetWithRecovery.retryPartialSuccessReused', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+      throw err;
+    }
     bench('RepoPool.runPreserveOrResetWithRecovery.retryRunBashLocal.after');
   }
 
@@ -962,7 +1030,11 @@ export class RepoPool {
 
   private execGit(args: string[], cwd: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      const child = spawn('git', args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+      const child = spawn('git', args, {
+        cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: cleanGitRepositoryEnv(),
+      });
       let stdout = '';
       let stderr = '';
       child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -492,8 +492,10 @@ export class RepoPool {
     }
     try {
       await this.execGit(['worktree', 'prune'], clonePath);
-    } catch {
-      /* best-effort; bashPreserveOrReset will surface failure */
+    } catch (err) {
+      traceExecution(
+        `[RepoPool] reconcileStaleWorktreePath: worktree prune failed clonePath=${clonePath} worktreePath=${worktreePath} error=${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 

--- a/packages/execution-engine/src/task-runner-finalize.ts
+++ b/packages/execution-engine/src/task-runner-finalize.ts
@@ -116,11 +116,11 @@ export function wireCompletion(
       };
 
       await host.runSerializedCompletion(work);
+      if (dispatchOpts) {
+        dispatchOpts.launchOutbox.completeDispatch(dispatchOpts.dispatchId);
+      }
       resolvePromise();
     });
   });
-  if (dispatchOpts) {
-    dispatchOpts.launchOutbox.completeDispatch(dispatchOpts.dispatchId);
-  }
   return completionPromise;
 }


### PR DESCRIPTION
## Summary

Route managed worktree setup through one recovery pass when Git reports a transient setup race.

The pool prunes old records and reuses a usable worktree if Git created it before returning failure.

## Review Claim

Approve the RepoPool routing path that reconciles transient worktree setup races before surfacing startup failure.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The path runs only after a setup error and still throws if the managed worktree is not reusable.

## Slice Rationale

This follows the Git environment slice because RepoPool now shares that sanitized helper process setup.

## Non-goals

Does not change pool capacity accounting, branch naming, cleanup policy, or task scheduling.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/repo-pool.test.ts`
- [x] `bash scripts/test-suites/optional/30-e2e-ssh.sh`
- [x] `bash scripts/test-suites/optional/31-e2e-ssh-merge.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 024918b22`
- Post-revert steps: None
- Data migration? No

</details>
