### PR TITLE
[CI Fix Step 3 - SSH Shard Stability](8) Export remote SSH env and known hosts

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -352,6 +352,69 @@ describe('SshExecutor managed workspace mode', () => {
     }
   });
 
+  it('exports remote invoker env variables to child provision commands', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+      remoteHeartbeatIntervalSeconds: 1,
+      remoteInvokerHome: '~/.invoker-e2e',
+      provisionCommand:
+        'bash -c \'printf "%s\\n" "$INVOKER_HOME" > "$HOME/provision-home.log"; ' +
+        'printf "%s\\n" "$INVOKER_ENV_FILE" > "$HOME/provision-env-file.log"; mkdir -p node_modules\'',
+    }) as any;
+
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return '__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=abc123def456abc123def456abc123def456abc1';
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      return '';
+    });
+    vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+
+    await ssh.start(makeRequest({
+      actionType: 'command',
+      inputs: {
+        command: "printf 'payload-ran\\n' > payload.out",
+        description: 'run tests',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    }));
+
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+    const writeMock = (proc.stdin as any).write as ReturnType<typeof vi.fn>;
+    const bootstrapScript = writeMock.mock.calls[0]![0] as string;
+    const workspaceMatch = bootstrapScript.match(/WT=\$\(normalize_remote_path '([^']+)'\)/);
+    if (!workspaceMatch?.[1]) {
+      throw new Error('Managed SSH bootstrap did not embed a workspace path');
+    }
+
+    const fakeHome = mkdtempSync(join(tmpdir(), 'ssh-provision-export-home-'));
+    try {
+      const workspacePath = workspaceMatch[1].replace(/^~(?=\/|$)/, fakeHome);
+      mkdirSync(workspacePath, { recursive: true });
+      writeFileSync(join(workspacePath, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n');
+
+      const childProcessModule = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+      const result = childProcessModule.spawnSync('/bin/bash', ['-c', bootstrapScript], {
+        encoding: 'utf8',
+        env: { ...process.env, HOME: fakeHome, PATH: process.env.PATH ?? '' },
+      });
+
+      expect(result.status).toBe(0);
+      expect(readFileSync(join(fakeHome, 'provision-home.log'), 'utf8')).toBe(`${fakeHome}/.invoker-e2e\n`);
+      expect(readFileSync(join(fakeHome, 'provision-env-file.log'), 'utf8')).toBe(`${fakeHome}/.invoker-e2e/env.sh\n`);
+      expect(readFileSync(join(workspacePath, 'payload.out'), 'utf8')).toBe('payload-ran\n');
+    } finally {
+      rmSync(fakeHome, { recursive: true, force: true });
+      proc.emit('close', 0, null);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  });
+
   it('reuses a managed SSH worktree by actionId when the old base is still compatible', async () => {
     const ssh = new SshExecutor({
       host: 'localhost',
@@ -1040,6 +1103,8 @@ describe('SshExecutor entry lifecycle', () => {
     const writeMock = (sshProcess.stdin as any).write as ReturnType<typeof vi.fn>;
     const script = writeMock.mock.calls[0]![0] as string;
     expect(script).toContain('INVOKER_ENV_FILE="$INVOKER_HOME/env.sh"');
+    expect(script).toContain('export INVOKER_HOME');
+    expect(script).toContain('export INVOKER_ENV_FILE');
     expect(script).toContain('. "$INVOKER_ENV_FILE"');
 
     sshProcess.emit('close', 0, null);
@@ -1374,6 +1439,7 @@ describe('SshExecutor entry lifecycle', () => {
     // bash would NOT expand) and avoiding base64 runtime delivery.
     expect(script).not.toContain('base64 -d');
     expect(script).toContain("INVOKER_HOME='~/.invoker'");
+    expect(script).toContain('export INVOKER_HOME');
     expect(script).toContain('WT=$(normalize_remote_path \'~/.invoker/worktrees/');
     expect(script).toContain(`if [[ "$path" == '~' ]]; then`);
     expect(script).not.toContain('WT="~/.invoker/');
@@ -1585,6 +1651,7 @@ describe('SshExecutor entry lifecycle', () => {
 
     expect(script).not.toContain('base64 -d');
     expect(script).toContain("INVOKER_HOME='/opt/invoker'");
+    expect(script).toContain('export INVOKER_HOME');
     expect(script).toContain('STAGING_DIR="$INVOKER_HOME/runtime/ssh-executor/');
     expect(script).toContain('WT=$(normalize_remote_path \'/opt/invoker/worktrees/');
     expect(script).toContain('RUNNER_PATH="$STAGING_DIR/runner.sh"');

--- a/packages/execution-engine/src/__tests__/ssh-transport-options.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-transport-options.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildSshConnectionArgs } from '../ssh-transport-options.js';
+
+const previousKnownHosts = process.env.INVOKER_SSH_USER_KNOWN_HOSTS_FILE;
+
+afterEach(() => {
+  if (previousKnownHosts === undefined) delete process.env.INVOKER_SSH_USER_KNOWN_HOSTS_FILE;
+  else process.env.INVOKER_SSH_USER_KNOWN_HOSTS_FILE = previousKnownHosts;
+});
+
+describe('ssh transport options', () => {
+  it('uses default known_hosts behavior when no override is configured', () => {
+    delete process.env.INVOKER_SSH_USER_KNOWN_HOSTS_FILE;
+
+    const args = buildSshConnectionArgs({
+      host: 'localhost',
+      user: 'invoker',
+      sshKeyPath: '/tmp/key',
+      port: 2222,
+    }, { batchMode: true });
+
+    expect(args).toContain('StrictHostKeyChecking=accept-new');
+    expect(args.join('\n')).not.toContain('UserKnownHostsFile=');
+  });
+
+  it('honors a caller-provided known_hosts file', () => {
+    process.env.INVOKER_SSH_USER_KNOWN_HOSTS_FILE = '/tmp/invoker-e2e-known-hosts';
+
+    const args = buildSshConnectionArgs({
+      host: 'localhost',
+      user: 'invoker',
+      sshKeyPath: '/tmp/key',
+    }, { batchMode: true });
+
+    expect(args).toContain('UserKnownHostsFile=/tmp/invoker-e2e-known-hosts');
+    expect(args).toContain('StrictHostKeyChecking=accept-new');
+  });
+});

--- a/packages/execution-engine/src/remote-shell-fragments.ts
+++ b/packages/execution-engine/src/remote-shell-fragments.ts
@@ -18,7 +18,9 @@ if [[ "$${varName}" == '~' ]]; then
 elif [[ "\${${varName}:0:2}" == '~/' ]]; then
   ${varName}="$HOME/\${${varName}:2}"
 fi
+export ${varName}
 INVOKER_ENV_FILE="$${varName}/env.sh"
+export INVOKER_ENV_FILE
 if [ -f "$INVOKER_ENV_FILE" ]; then
   . "$INVOKER_ENV_FILE"
 fi`;

--- a/packages/execution-engine/src/ssh-transport-options.ts
+++ b/packages/execution-engine/src/ssh-transport-options.ts
@@ -30,9 +30,11 @@ export function buildSshTransportOptions(opts: { batchMode: boolean }): string[]
     'INVOKER_SSH_SERVER_ALIVE_COUNT_MAX',
     DEFAULT_SERVER_ALIVE_COUNT_MAX,
   );
+  const userKnownHostsFile = process.env.INVOKER_SSH_USER_KNOWN_HOSTS_FILE?.trim();
 
   return [
     '-o', 'StrictHostKeyChecking=accept-new',
+    ...(userKnownHostsFile ? ['-o', `UserKnownHostsFile=${userKnownHostsFile}`] : []),
     '-o', `ConnectTimeout=${connectTimeout}`,
     '-o', `ServerAliveInterval=${serverAliveInterval}`,
     '-o', `ServerAliveCountMax=${serverAliveCountMax}`,


### PR DESCRIPTION
## Summary

Route SSH bootstrap environment through exported remote invoker variables.

Transport setup can also use a caller-provided known_hosts file for isolated shard runs.

## Review Claim

Approve the SSH routing path exporting remote invoker paths and honoring known_hosts isolation.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The default SSH options stay unchanged unless the known_hosts override environment variable is set.

## Slice Rationale

This runtime slice lands before shell harness changes consume the exported variables.

## Non-goals

Does not change SSH host selection, workspace branch selection, task payload staging, or pool capacity.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-executor.test.ts src/__tests__/ssh-transport-options.test.ts`
- [x] `bash scripts/test-suites/optional/30-e2e-ssh.sh`
- [x] `bash scripts/test-suites/optional/31-e2e-ssh-merge.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ea95bc8be`
- Post-revert steps: None
- Data migration? No

</details>
