### PR TITLE
[CI Fix Step 3 - SSH Shard Stability](9) Root worktree executors under Invoker home

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2770,6 +2770,31 @@ describe('TaskRunner', () => {
       expect(poolProvider).toHaveBeenCalledTimes(2);
       expect(targetProvider).toHaveBeenCalledTimes(2);
     });
+    it('roots lazy worktree executors under INVOKER_DB_DIR when set', () => {
+      const previousDbDir = process.env.INVOKER_DB_DIR;
+      const invokerHome = createTempWorkspace();
+      process.env.INVOKER_DB_DIR = invokerHome;
+      try {
+        const executor = new TaskRunner({
+          orchestrator: { getTask: () => undefined } as any,
+          persistence: {} as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
+          cwd: '/tmp',
+        } as any);
+
+        const selected = executor.selectExecutor(makeTask({
+          id: 'worktree-task',
+          config: { runnerKind: 'worktree' },
+        }));
+
+        expect(selected.executor.type).toBe('worktree');
+        expect(Reflect.get(selected.executor, 'worktreeBaseDir')).toBe(join(invokerHome, 'worktrees'));
+        expect(Reflect.get(Reflect.get(selected.executor, 'pool'), 'cacheDir')).toBe(join(invokerHome, 'repos'));
+      } finally {
+        if (previousDbDir === undefined) delete process.env.INVOKER_DB_DIR;
+        else process.env.INVOKER_DB_DIR = previousDbDir;
+      }
+    });
     it('bypasses arbitrary registered worktree executors so target provisioning fingerprints win', () => {
       const preRegistered = { type: 'worktree' };
       const executor = new TaskRunner({

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -11,8 +11,8 @@
  */
 
 import { resolve } from 'node:path';
-import { homedir } from 'node:os';
 
+import { resolveInvokerHomeRoot } from '@invoker/contracts';
 import type { TaskState } from '@invoker/workflow-core';
 import type { Executor, ExecutorHandle } from './executor.js';
 import { ResourceLimitError } from './repo-pool.js';
@@ -686,7 +686,7 @@ export function selectExecutor(
     }
 
     if (effectiveType === 'worktree') {
-      const invokerHome = resolve(homedir(), '.invoker');
+      const invokerHome = resolveInvokerHomeRoot();
       const worktreeTargets = host.getWorktreeTargets();
       const selectedWorktreeTarget = selectedWorktreeTargetId
         ? worktreeTargets[selectedWorktreeTargetId]


### PR DESCRIPTION
## Summary

Route lazy worktree executor storage through the configured Invoker home.

Shard runs that override `INVOKER_DB_DIR` now place repos and worktrees under that same root.

## Review Claim

Approve worktree executor routing to `resolveInvokerHomeRoot()` for lazy executor creation.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the default lazy worktree root changes; explicit configured worktree targets keep their existing paths.

## Slice Rationale

This keeps runtime storage routing isolated from SSH bootstrap and shell harness changes.

## Non-goals

Does not change executor pool selection, configured target resolution, or task concurrency limits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts`
- [x] `bash scripts/test-suites/optional/30-e2e-ssh.sh`
- [x] `bash scripts/test-suites/optional/31-e2e-ssh-merge.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a872aceb1`
- Post-revert steps: None
- Data migration? No

</details>
