### PR TITLE
[CI Fix Step 3 - SSH Shard Stability](10) Isolate SSH shard shell provisioning

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2770,6 +2770,31 @@ describe('TaskRunner', () => {
       expect(poolProvider).toHaveBeenCalledTimes(2);
       expect(targetProvider).toHaveBeenCalledTimes(2);
     });
+    it('roots lazy worktree executors under INVOKER_DB_DIR when set', () => {
+      const previousDbDir = process.env.INVOKER_DB_DIR;
+      const invokerHome = createTempWorkspace();
+      process.env.INVOKER_DB_DIR = invokerHome;
+      try {
+        const executor = new TaskRunner({
+          orchestrator: { getTask: () => undefined } as any,
+          persistence: {} as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
+          cwd: '/tmp',
+        } as any);
+
+        const selected = executor.selectExecutor(makeTask({
+          id: 'worktree-task',
+          config: { runnerKind: 'worktree' },
+        }));
+
+        expect(selected.executor.type).toBe('worktree');
+        expect(Reflect.get(selected.executor, 'worktreeBaseDir')).toBe(join(invokerHome, 'worktrees'));
+        expect(Reflect.get(Reflect.get(selected.executor, 'pool'), 'cacheDir')).toBe(join(invokerHome, 'repos'));
+      } finally {
+        if (previousDbDir === undefined) delete process.env.INVOKER_DB_DIR;
+        else process.env.INVOKER_DB_DIR = previousDbDir;
+      }
+    });
     it('bypasses arbitrary registered worktree executors so target provisioning fingerprints win', () => {
       const preRegistered = { type: 'worktree' };
       const executor = new TaskRunner({

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -11,8 +11,8 @@
  */
 
 import { resolve } from 'node:path';
-import { homedir } from 'node:os';
 
+import { resolveInvokerHomeRoot } from '@invoker/contracts';
 import type { TaskState } from '@invoker/workflow-core';
 import type { Executor, ExecutorHandle } from './executor.js';
 import { ResourceLimitError } from './repo-pool.js';
@@ -686,7 +686,7 @@ export function selectExecutor(
     }
 
     if (effectiveType === 'worktree') {
-      const invokerHome = resolve(homedir(), '.invoker');
+      const invokerHome = resolveInvokerHomeRoot();
       const worktreeTargets = host.getWorktreeTargets();
       const selectedWorktreeTarget = selectedWorktreeTargetId
         ? worktreeTargets[selectedWorktreeTargetId]

--- a/scripts/e2e-ssh/cases/case-3.7-ssh-target-provision.sh
+++ b/scripts/e2e-ssh/cases/case-3.7-ssh-target-provision.sh
@@ -11,7 +11,7 @@ trap invoker_e2e_ssh_full_cleanup EXIT
 cd "$INVOKER_E2E_REPO_ROOT"
 unset ELECTRON_RUN_AS_NODE
 
-expected_provision_cmd="$(invoker_e2e_ssh_provision_command)"
+expected_provision_cmd="$(invoker_e2e_ssh_config_provision_command)"
 actual_provision_cmd="$(jq -r '.remoteTargets["localhost-e2e"].provisionCommand' "$INVOKER_REPO_CONFIG_PATH")"
 if [ "$actual_provision_cmd" != "$expected_provision_cmd" ]; then
   echo "FAIL case 3.7: expected config provisionCommand '$expected_provision_cmd' but got '$actual_provision_cmd'"

--- a/scripts/e2e-ssh/lib/ssh-common.sh
+++ b/scripts/e2e-ssh/lib/ssh-common.sh
@@ -23,8 +23,9 @@ INVOKER_E2E_TIMEOUT="${INVOKER_E2E_TIMEOUT:-300}"
 # Tag for authorized_keys entries created by this process.
 _INVOKER_E2E_SSH_TAG="invoker-e2e-ssh-$$"
 
-# Temp directory for SSH key pair and config.
+# Temp directory for SSH key pair, config, and remote invoker home.
 _INVOKER_E2E_SSH_TMPDIR=""
+_INVOKER_E2E_SSH_REMOTE_HOME=""
 
 # SSH login user and passwd-backed home directory used by sshd.
 _INVOKER_E2E_SSH_USER=""
@@ -56,7 +57,9 @@ invoker_e2e_ssh_resolve_home() {
 # --------------------------------------------------------------------------- #
 invoker_e2e_ssh_setup_keys() {
   _INVOKER_E2E_SSH_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-e2e-ssh.XXXXXX")"
+  _INVOKER_E2E_SSH_REMOTE_HOME="$_INVOKER_E2E_SSH_TMPDIR/remote-invoker-home"
   local keyfile="$_INVOKER_E2E_SSH_TMPDIR/id_ed25519"
+  local known_hosts_file="$_INVOKER_E2E_SSH_TMPDIR/known_hosts"
   _INVOKER_E2E_SSH_USER="$(whoami)"
   _INVOKER_E2E_SSH_HOME="$(invoker_e2e_ssh_resolve_home "$_INVOKER_E2E_SSH_USER")"
 
@@ -67,6 +70,8 @@ invoker_e2e_ssh_setup_keys() {
 
   # -C sets the comment field to our PID-tagged identifier for cleanup.
   ssh-keygen -t ed25519 -f "$keyfile" -N "" -C "$_INVOKER_E2E_SSH_TAG" -q
+  touch "$known_hosts_file"
+  chmod 600 "$known_hosts_file"
 
   # sshd reads authorized_keys from the account's passwd home, which may differ
   # from $HOME inside CI containers.
@@ -79,6 +84,7 @@ invoker_e2e_ssh_setup_keys() {
   cat "${keyfile}.pub" >> "$_INVOKER_E2E_SSH_HOME/.ssh/authorized_keys"
 
   export INVOKER_E2E_SSH_KEY="$keyfile"
+  export INVOKER_SSH_USER_KNOWN_HOSTS_FILE="$known_hosts_file"
 }
 
 # --------------------------------------------------------------------------- #
@@ -86,7 +92,7 @@ invoker_e2e_ssh_setup_keys() {
 # --------------------------------------------------------------------------- #
 invoker_e2e_ssh_cleanup_keys() {
   local authorized_keys="${_INVOKER_E2E_SSH_HOME:-}/.ssh/authorized_keys"
-  local env_path="${_INVOKER_E2E_SSH_HOME:-}/.invoker/env.sh"
+  local env_path="${_INVOKER_E2E_SSH_REMOTE_HOME:-}/env.sh"
   if [ -n "${_INVOKER_E2E_SSH_TAG:-}" ] && [ -f "$authorized_keys" ]; then
     grep -v "$_INVOKER_E2E_SSH_TAG" "$authorized_keys" > "${authorized_keys}.tmp" || true
     mv "${authorized_keys}.tmp" "$authorized_keys"
@@ -102,6 +108,7 @@ invoker_e2e_ssh_cleanup_keys() {
     mv "${env_path}.tmp" "$env_path"
   fi
   rm -rf "${_INVOKER_E2E_SSH_TMPDIR:-}" 2>/dev/null || true
+  unset INVOKER_SSH_USER_KNOWN_HOSTS_FILE
 }
 
 # --------------------------------------------------------------------------- #
@@ -114,6 +121,10 @@ invoker_e2e_ssh_provision_command() {
   )
 }
 
+invoker_e2e_ssh_config_provision_command() {
+  printf 'INVOKER_SKIP_SHELL_HOOKS=1 %s\n' "$(invoker_e2e_ssh_provision_command)"
+}
+
 # --------------------------------------------------------------------------- #
 # Write temp JSON config with a localhost-e2e execution pool.
 # --------------------------------------------------------------------------- #
@@ -121,31 +132,33 @@ invoker_e2e_ssh_write_config() {
   local config_file="$_INVOKER_E2E_SSH_TMPDIR/invoker-config.json"
   local remote_home
   local provision_cmd
-  remote_home="$_INVOKER_E2E_SSH_TMPDIR/remote-invoker-home"
-  provision_cmd="$(invoker_e2e_ssh_provision_command)"
+  remote_home="$_INVOKER_E2E_SSH_REMOTE_HOME"
+  provision_cmd="$(invoker_e2e_ssh_config_provision_command)"
 
-  cat > "$config_file" <<EOJSON
-{
-  "executionPools": {
-    "localhost-e2e": {
-      "members": [
-        { "type": "ssh", "id": "localhost-e2e" }
-      ]
-    }
+  node - "$config_file" "$_INVOKER_E2E_SSH_USER" "$INVOKER_E2E_SSH_KEY" "$remote_home" "$provision_cmd" <<'NODE'
+const { writeFileSync } = require('node:fs');
+const [configFile, user, sshKeyPath, remoteInvokerHome, provisionCommand] = process.argv.slice(2);
+writeFileSync(configFile, `${JSON.stringify({
+  executionPools: {
+    'localhost-e2e': {
+      members: [
+        { type: 'ssh', id: 'localhost-e2e' },
+      ],
+    },
   },
-  "remoteTargets": {
-    "localhost-e2e": {
-      "host": "localhost",
-      "user": "$_INVOKER_E2E_SSH_USER",
-      "sshKeyPath": "$INVOKER_E2E_SSH_KEY",
-      "port": 22,
-      "managedWorkspaces": true,
-      "remoteInvokerHome": "$remote_home",
-      "provisionCommand": "$provision_cmd"
-    }
-  }
-}
-EOJSON
+  remoteTargets: {
+    'localhost-e2e': {
+      host: 'localhost',
+      user,
+      sshKeyPath,
+      port: 22,
+      managedWorkspaces: true,
+      remoteInvokerHome,
+      provisionCommand,
+    },
+  },
+}, null, 2)}\n`);
+NODE
 
   export INVOKER_REPO_CONFIG_PATH="$config_file"
 }
@@ -176,8 +189,8 @@ invoker_e2e_ssh_init() {
 }
 
 # --------------------------------------------------------------------------- #
-# Ensure host pnpm/node are on the remote login-shell PATH.
-# SshExecutor uses `bash -l` and does not forward the host PATH.
+# Ensure host pnpm/node are on the remote task PATH.
+# SshExecutor uses a non-login shell and sources remoteInvokerHome/env.sh.
 # --------------------------------------------------------------------------- #
 invoker_e2e_ssh_install_login_path() {
   local pnpm_bin node_bin pnpm_dir node_dir
@@ -190,36 +203,28 @@ invoker_e2e_ssh_install_login_path() {
   pnpm_dir="$(cd "$(dirname "$pnpm_bin")" && pwd)"
   node_dir="$(cd "$(dirname "$node_bin")" && pwd)"
 
-  ssh -o BatchMode=yes \
-      -o ConnectTimeout=5 \
-      -o StrictHostKeyChecking=no \
-      -i "$INVOKER_E2E_SSH_KEY" \
-      "$_INVOKER_E2E_SSH_USER@localhost" \
-      "bash -s" <<EOF
-set -euo pipefail
-marker='# invoker-e2e-ssh-pnpm-path ${_INVOKER_E2E_SSH_TAG}'
-mkdir -p "\$HOME/.invoker"
-touch "\$HOME/.invoker/env.sh"
-if ! grep -Fq "\$marker" "\$HOME/.invoker/env.sh" 2>/dev/null; then
-  {
-    printf '%s\n' "\$marker"
-    printf 'export PATH="%s:%s:\$PATH"\n' '${node_dir}' '${pnpm_dir}'
-  } >> "\$HOME/.invoker/env.sh"
-fi
-EOF
+  mkdir -p "$_INVOKER_E2E_SSH_REMOTE_HOME"
+  touch "$_INVOKER_E2E_SSH_REMOTE_HOME/env.sh"
+  chmod 600 "$_INVOKER_E2E_SSH_REMOTE_HOME/env.sh"
+  if ! grep -Fq "# invoker-e2e-ssh-pnpm-path ${_INVOKER_E2E_SSH_TAG}" "$_INVOKER_E2E_SSH_REMOTE_HOME/env.sh" 2>/dev/null; then
+    {
+      printf '%s\n' "# invoker-e2e-ssh-pnpm-path ${_INVOKER_E2E_SSH_TAG}"
+      printf 'export PATH="%s:%s:$PATH"\n' "$node_dir" "$pnpm_dir"
+    } >> "$_INVOKER_E2E_SSH_REMOTE_HOME/env.sh"
+  fi
 
-  # Verify via non-login bash — matches the executor sourcing ~/.invoker/env.sh explicitly.
+  # Verify via non-login bash — matches the executor sourcing remoteInvokerHome/env.sh explicitly.
   if ! ssh -o BatchMode=yes \
            -o ConnectTimeout=5 \
            -o StrictHostKeyChecking=no \
            -i "$INVOKER_E2E_SSH_KEY" \
            "$_INVOKER_E2E_SSH_USER@localhost" \
-           "bash -s" <<'EOF' >/dev/null 2>&1; then
-. "$HOME/.invoker/env.sh"
+           "bash -s" <<EOF >/dev/null 2>&1; then
+. "$_INVOKER_E2E_SSH_REMOTE_HOME/env.sh"
 command -v pnpm >/dev/null
 pnpm --version
 EOF
-    echo "ERROR: 'pnpm' not found after sourcing ~/.invoker/env.sh." >&2
+    echo "ERROR: 'pnpm' not found after sourcing $_INVOKER_E2E_SSH_REMOTE_HOME/env.sh." >&2
     return 1
   fi
 }

--- a/scripts/provision-ssh-worker.sh
+++ b/scripts/provision-ssh-worker.sh
@@ -9,6 +9,7 @@ REPO_DIR="$(pwd -P)"
 DRY_RUN=0
 SKIP_SYSTEM_PACKAGES="${INVOKER_SKIP_SYSTEM_PACKAGES:-0}"
 SKIP_AGENT_TOOLS="${INVOKER_SKIP_AGENT_TOOLS:-0}"
+SKIP_SHELL_HOOKS="${INVOKER_SKIP_SHELL_HOOKS:-0}"
 INVOKER_HOME="${INVOKER_HOME:-$HOME/.invoker}"
 INVOKER_ENV_FILE="${INVOKER_ENV_FILE:-$INVOKER_HOME/env.sh}"
 INVOKER_NODE_MAJOR="${INVOKER_NODE_MAJOR:-26}"
@@ -47,6 +48,7 @@ Environment overrides:
   INVOKER_GIT_USER_EMAIL       Git committer email for managed worktrees.
   INVOKER_SKIP_SYSTEM_PACKAGES Skip apt/brew package installation when set to 1.
   INVOKER_SKIP_AGENT_TOOLS     Skip codex/claude npm global installs when set to 1.
+  INVOKER_SKIP_SHELL_HOOKS     Skip login shell hook writes when set to 1.
   INVOKER_PROVISION_TRACE_FILE Optional file that receives one line per provision run.
 EOF
 }
@@ -183,6 +185,10 @@ EOF
 }
 
 ensure_shell_hooks() {
+  if [[ "$SKIP_SHELL_HOOKS" == "1" ]]; then
+    log "Skipping shell hook installation."
+    return 0
+  fi
   local marker="# >>> invoker ssh worker env >>>"
   local block
   block=$(cat <<EOF
@@ -526,7 +532,7 @@ ensure_repo_ready() {
 }
 
 print_provision_command() {
-  printf 'bash scripts/provision-ssh-worker.sh ensure-repo-ready && . "$HOME/.invoker/env.sh"\n'
+  printf 'bash scripts/provision-ssh-worker.sh ensure-repo-ready && . "${INVOKER_ENV_FILE:-$HOME/.invoker/env.sh}"\n'
 }
 
 while [[ "$#" -gt 0 ]]; do

--- a/submit-plan.sh
+++ b/submit-plan.sh
@@ -38,14 +38,18 @@ if [ "$(uname)" = "Linux" ]; then
 fi
 
 echo "==> Submitting plan: $PLAN_FILE"
-if [ "$(uname)" = "Linux" ] && [ -z "${DISPLAY:-}" ]; then
-  if ! command -v xvfb-run >/dev/null 2>&1; then
-    echo "ERROR: headless Electron launch requires Xvfb when DISPLAY is not set." >&2
-    echo "Install xvfb-run or set DISPLAY to an available X server." >&2
-    exit 1
-  fi
-  ELECTRON_ENABLE_LOGGING=1 exec xvfb-run --auto-servernum \
-    ./packages/app/node_modules/.bin/electron packages/app/dist/main.js $SANDBOX_FLAG --headless run "$PLAN_FILE"
+electron_args=()
+if [ -n "$SANDBOX_FLAG" ]; then
+  electron_args+=("$SANDBOX_FLAG")
+fi
+if [ "$(uname)" = "Linux" ]; then
+  electron_args+=(
+    --disable-dev-shm-usage
+    --disable-gpu
+    --disable-gpu-compositing
+    --disable-gpu-sandbox
+    --disable-software-rasterizer
+  )
 fi
 
-ELECTRON_ENABLE_LOGGING=1 exec ./packages/app/node_modules/.bin/electron packages/app/dist/main.js $SANDBOX_FLAG --headless run "$PLAN_FILE"
+ELECTRON_ENABLE_LOGGING=1 exec ./scripts/electron.cjs "${electron_args[@]}" packages/app/dist/main.js --headless run "$PLAN_FILE"


### PR DESCRIPTION
## Summary

The SSH shard shell harness now writes isolated remote-home config and a private known_hosts file.

Provisioning sources the configured env file without changing developer shell profiles during E2E.

## Review Claim

Approve the shell harness and provision script changes used by the CI SSH shards.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only test harness and helper shell scripts change; production TypeScript behavior is already covered in earlier stack slices.

## Slice Rationale

This final policy slice consumes the earlier runtime capabilities and keeps shell harness churn out of product PRs.

## Non-goals

Does not change non-SSH test suites, repository setup, packaged binaries, or workflow definitions.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-suites/optional/30-e2e-ssh.sh`
- [x] `bash scripts/test-suites/optional/31-e2e-ssh-merge.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8b824893e`
- Post-revert steps: None
- Data migration? No

</details>
