### PR TITLE
[Remote Sync Step 1: Sync Schema and Change Journal](1) Add data-store sync schema and journal

### DIFF
--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createAttempt } from '@invoker/workflow-core';
+import type { TaskState } from '@invoker/workflow-core';
+import type { SqliteExecutor } from '../sqlite-executor.js';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  readJournalSince,
+  setSyncCursor,
+} from '../sync-journal.js';
+
+describe('sync journal', () => {
+  let adapter: SQLiteAdapter;
+  let exec: SqliteExecutor;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    exec = (adapter as any).executor as SqliteExecutor;
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function workflow(id: string) {
+    return {
+      id,
+      name: `Workflow ${id}`,
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+    };
+  }
+
+  function task(id: string, status: TaskState['status'] = 'pending'): TaskState {
+    return {
+      id,
+      description: `Task ${id}`,
+      status,
+      dependencies: [],
+      createdAt: new Date('2026-07-27T00:00:00.000Z'),
+      config: {},
+      execution: {},
+      taskStateVersion: 1,
+    };
+  }
+
+  it('rolls back journal rows with the mutation transaction', () => {
+    expect(() =>
+      exec.runTransaction(() => {
+        exec.execRun(
+          `INSERT INTO workflows (id, name, created_at, updated_at)
+           VALUES (?, ?, ?, ?)`,
+          ['wf-rollback', 'Rollback', '2026-07-27T00:00:00.000Z', '2026-07-27T00:00:00.000Z'],
+        );
+        appendJournalEntry(exec, {
+          entityType: 'workflow',
+          entityId: 'wf-rollback',
+          op: 'upsert',
+          payload: { id: 'wf-rollback' },
+        });
+        throw new Error('rollback sentinel');
+      }),
+    ).toThrow(/rollback sentinel/);
+
+    expect(adapter.loadWorkflow('wf-rollback', { includeDeleted: true })).toBeUndefined();
+    expect(readJournalSince(exec, 0, 10)).toEqual([]);
+  });
+
+  it('fails the enclosing mutation when a journal write fails', () => {
+    (adapter as any).db.run(`
+      CREATE TRIGGER fail_sync_journal_insert
+      BEFORE INSERT ON sync_journal
+      BEGIN
+        SELECT RAISE(FAIL, 'journal fail');
+      END
+    `);
+
+    expect(() => adapter.saveWorkflow(workflow('wf-fail'))).toThrow(/journal fail/);
+    expect(adapter.loadWorkflow('wf-fail', { includeDeleted: true })).toBeUndefined();
+
+    (adapter as any).db.run('DROP TRIGGER fail_sync_journal_insert');
+    expect(readJournalSince(exec, 0, 10)).toEqual([]);
+  });
+
+  it('assigns strictly monotonic seq values for adapter-journaled mutations', () => {
+    adapter.saveWorkflow(workflow('wf-seq'));
+    adapter.saveTask('wf-seq', task('t-seq'));
+    adapter.updateTask('t-seq', { status: 'running' });
+    const attempt = {
+      ...createAttempt('t-seq', { status: 'running' }),
+      createdAt: new Date('2026-07-27T00:00:01.000Z'),
+    };
+    adapter.saveAttempt(attempt);
+    adapter.updateAttempt(attempt.id, {
+      status: 'completed',
+      completedAt: new Date('2026-07-27T00:00:02.000Z'),
+    });
+
+    const rows = adapter.readJournalSince(0, 20);
+    expect(rows.map((row) => [row.entityType, row.entityId, row.op])).toEqual([
+      ['workflow', 'wf-seq', 'upsert'],
+      ['task', 't-seq', 'upsert'],
+      ['task', 't-seq', 'upsert'],
+      ['attempt', attempt.id, 'upsert'],
+      ['attempt', attempt.id, 'upsert'],
+    ]);
+    expect(rows.map((row) => row.seq)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('reads journal entries after the supplied cursor and stores peer cursors', () => {
+    const first = appendJournalEntry(exec, {
+      entityType: 'workflow',
+      entityId: 'wf-1',
+      op: 'upsert',
+      payload: { id: 'wf-1' },
+      createdAt: 1,
+    });
+    const second = appendJournalEntry(exec, {
+      entityType: 'workflow',
+      entityId: 'wf-2',
+      op: 'upsert',
+      payload: { id: 'wf-2' },
+      createdAt: 2,
+    });
+    appendJournalEntry(exec, {
+      entityType: 'workflow',
+      entityId: 'wf-3',
+      op: 'upsert',
+      payload: { id: 'wf-3' },
+      createdAt: 3,
+    });
+
+    const cursor = setSyncCursor(exec, {
+      peerId: 'peer-a',
+      lastSentSeq: second.seq,
+      lastReceivedSeq: first.seq,
+      updatedAt: 4,
+    });
+
+    expect(getSyncCursor(exec, 'peer-a')).toEqual(cursor);
+    expect(readJournalSince(exec, cursor.lastSentSeq, 10).map((row) => row.entityId)).toEqual(['wf-3']);
+    expect(readJournalSince(exec, first.seq, 1).map((row) => row.entityId)).toEqual(['wf-2']);
+  });
+
+  it('excludes soft-deleted workflows by default but includes them when requested', () => {
+    adapter.saveWorkflow(workflow('wf-deleted'));
+    adapter.saveWorkflow(workflow('wf-live'));
+
+    adapter.deleteWorkflow('wf-deleted');
+
+    expect(adapter.loadWorkflow('wf-deleted')).toBeUndefined();
+    expect(adapter.listWorkflows().map((row) => row.id)).toEqual(['wf-live']);
+
+    const all = adapter.listWorkflows({ includeDeleted: true });
+    const deleted = all.find((row) => row.id === 'wf-deleted');
+    expect(all.map((row) => row.id).sort()).toEqual(['wf-deleted', 'wf-live']);
+    expect(deleted?.deletedAt).toEqual(expect.any(Number));
+  });
+
+  it('writes a tombstone journal entry when deleting a workflow', () => {
+    adapter.saveWorkflow(workflow('wf-tombstone'));
+
+    adapter.deleteWorkflow('wf-tombstone');
+
+    const tombstone = adapter.readJournalSince(0, 10).find((row) => row.op === 'tombstone');
+    expect(tombstone).toMatchObject({
+      entityType: 'workflow',
+      entityId: 'wf-tombstone',
+      op: 'tombstone',
+      origin: 'home',
+    });
+    expect(tombstone?.payload).toMatchObject({
+      id: 'wf-tombstone',
+      deleted_at: expect.any(Number),
+    });
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -124,10 +124,15 @@ export interface Workflow {
   /** Read-only provenance for dependencies removed by `detachWorkflow`. Never re-read by scheduling. */
   detachedExternalDependencies?: DetachedExternalDependency[];
   generation?: number;
+  deletedAt?: number;
   createdAt: string;
   updatedAt: string;
 }
 export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup'>;
+
+export interface WorkflowReadOptions {
+  includeDeleted?: boolean;
+}
 
 /**
  * Result of resolving a published PR back to its Invoker workflow via the merge
@@ -333,8 +338,8 @@ export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
-  loadWorkflow(workflowId: string): Workflow | undefined;
-  listWorkflows(): Workflow[];
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined;
+  listWorkflows(options?: WorkflowReadOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
   /** Resolve a GitHub PR number back to its Invoker workflow via the merge node. */
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined;

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -1,6 +1,7 @@
 export * from './adapter.js';
 export * from './attempt-read-models.js';
 export * from './sqlite-adapter.js';
+export * from './sync-journal.js';
 export * from './slow-query-aggregator.js';
 export * from './conversation-repository.js';
 export * from './slack-session-repository.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -39,6 +39,7 @@ import type {
   ReviewGateLookup,
   Workflow,
   WorkflowSaveInput,
+  WorkflowReadOptions,
   WorkflowTaskSnapshot,
   TaskEvent,
   TaskEventListFilters,
@@ -78,6 +79,18 @@ import type { SqliteExecutor } from './sqlite-executor.js';
 import * as migrations from './sqlite-migrations.js';
 import { SqliteTaskAttemptRepository } from './sqlite-task-attempt-repository.js';
 import { SqliteWorkflowRepository, type WorkflowMetadataChanges } from './sqlite-workflow-repository.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  readJournalSince,
+  setSyncCursor,
+  type SyncCursor,
+  type SyncCursorInput,
+  type SyncJournalEntryInput,
+  type SyncJournalEntityType,
+  type SyncJournalOperation,
+  type SyncJournalRecord,
+} from './sync-journal.js';
 
 function normalizeWorkerActionStatus(status: string): string {
   return status === 'canceled' ? 'cancelled' : status;
@@ -951,6 +964,54 @@ export class SQLiteAdapter implements PersistenceAdapter {
     };
   }
 
+  private rawRowForJournal(
+    entityType: Exclude<SyncJournalEntityType, 'output'>,
+    entityId: string,
+  ): Record<string, unknown> | undefined {
+    switch (entityType) {
+      case 'workflow':
+        return this.queryOne('SELECT * FROM workflows WHERE id = ?', [entityId]);
+      case 'task':
+        return this.queryOne('SELECT * FROM tasks WHERE id = ?', [entityId]);
+      case 'attempt':
+        return this.queryOne('SELECT * FROM attempts WHERE id = ?', [entityId]);
+      case 'event':
+        return this.queryOne('SELECT * FROM events WHERE id = ?', [entityId]);
+    }
+  }
+
+  private appendRowJournalEntry(
+    entityType: Exclude<SyncJournalEntityType, 'output'>,
+    entityId: string,
+    op: SyncJournalOperation,
+  ): SyncJournalRecord | undefined {
+    const payload = this.rawRowForJournal(entityType, entityId);
+    if (!payload) return undefined;
+    return appendJournalEntry(this.executor, {
+      entityType,
+      entityId,
+      op,
+      payload,
+      origin: 'home',
+    });
+  }
+
+  appendJournalEntry(entry: SyncJournalEntryInput): SyncJournalRecord {
+    return appendJournalEntry(this.executor, entry);
+  }
+
+  readJournalSince(seq: number, limit: number): SyncJournalRecord[] {
+    return readJournalSince(this.executor, seq, limit);
+  }
+
+  getSyncCursor(peerId: string): SyncCursor | undefined {
+    return getSyncCursor(this.executor, peerId);
+  }
+
+  setSyncCursor(cursor: SyncCursorInput): SyncCursor {
+    return setSyncCursor(this.executor, cursor);
+  }
+
   runCompatibilityMigration(): {
     migratedFixingWithAiStatuses: number;
     normalizedMergeModes: number;
@@ -1047,19 +1108,26 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Workflows ─────────────────────────────────────────
 
   saveWorkflow(workflow: WorkflowSaveInput): void {
-    this.workflowRepo.saveWorkflow(workflow);
+    this.runTransaction(() => {
+      this.workflowRepo.saveWorkflow(workflow);
+      this.appendRowJournalEntry('workflow', workflow.id, 'upsert');
+    });
   }
 
   updateWorkflow(workflowId: string, changes: WorkflowMetadataChanges): void {
-    this.workflowRepo.updateWorkflow(workflowId, changes);
+    this.runTransaction(() => {
+      if (!this.workflowRepo.loadWorkflow(workflowId)) return;
+      this.workflowRepo.updateWorkflow(workflowId, changes);
+      this.appendRowJournalEntry('workflow', workflowId, 'upsert');
+    });
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    return this.workflowRepo.loadWorkflow(workflowId);
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined {
+    return this.workflowRepo.loadWorkflow(workflowId, options);
   }
 
-  listWorkflows(): Workflow[] {
-    return this.workflowRepo.listWorkflows();
+  listWorkflows(options?: WorkflowReadOptions): Workflow[] {
+    return this.workflowRepo.listWorkflows(options);
   }
 
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
@@ -1081,11 +1149,21 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Tasks ─────────────────────────────────────────────
 
   saveTask(workflowId: string, task: TaskState): void {
-    this.taskAttemptRepo.saveTask(workflowId, task);
+    this.runTransaction(() => {
+      this.taskAttemptRepo.saveTask(workflowId, task);
+      this.appendRowJournalEntry('task', task.id, 'upsert');
+    });
   }
 
   updateTask(taskId: string, changes: TaskStateChanges): void {
-    this.taskAttemptRepo.updateTask(taskId, changes);
+    if (changes.status === undefined) {
+      this.taskAttemptRepo.updateTask(taskId, changes);
+      return;
+    }
+    this.runTransaction(() => {
+      this.taskAttemptRepo.updateTask(taskId, changes);
+      this.appendRowJournalEntry('task', taskId, 'upsert');
+    });
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -1558,7 +1636,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   deleteWorkflow(workflowId: string): void {
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
+    let deleted = false;
     this.runTransaction(() => {
+      const workflow = this.queryOne('SELECT id FROM workflows WHERE id = ? AND deleted_at IS NULL', [workflowId]);
+      if (!workflow) return;
       this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM task_launch_dispatch WHERE workflow_id = ?', [workflowId]);
@@ -1598,9 +1679,19 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
+      const deletedAt = Date.now();
+      this.db.run(
+        'UPDATE workflows SET deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL',
+        [deletedAt, new Date(deletedAt).toISOString(), workflowId],
+      );
+      if (this.db.getRowsModified() > 0) {
+        this.appendRowJournalEntry('workflow', workflowId, 'tombstone');
+        deleted = true;
+      }
     });
-    this.removeOutputFiles(taskIds);
+    if (deleted) {
+      this.removeOutputFiles(taskIds);
+    }
   }
 
   // ── Events ────────────────────────────────────────────
@@ -2630,7 +2721,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Attempts ────────────────────────────────────────────
 
   saveAttempt(attempt: Attempt): void {
-    this.taskAttemptRepo.saveAttempt(attempt);
+    this.runTransaction(() => {
+      this.taskAttemptRepo.saveAttempt(attempt);
+      this.appendRowJournalEntry('attempt', attempt.id, 'upsert');
+    });
   }
 
   loadAttempts(nodeId: string): Attempt[] {
@@ -2654,7 +2748,17 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void {
-    this.taskAttemptRepo.updateAttempt(attemptId, changes);
+    const shouldJournal =
+      changes.status === 'completed'
+      || changes.completedAt !== undefined;
+    if (!shouldJournal) {
+      this.taskAttemptRepo.updateAttempt(attemptId, changes);
+      return;
+    }
+    this.runTransaction(() => {
+      this.taskAttemptRepo.updateAttempt(attemptId, changes);
+      this.appendRowJournalEntry('attempt', attemptId, 'upsert');
+    });
   }
 
   claimAttemptForLaunch(

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -47,6 +47,7 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
     externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
     detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) as DetachedExternalDependency[] : undefined,
     generation: row.generation ?? 0,
+    deletedAt: row.deleted_at === null || row.deleted_at === undefined ? undefined : Number(row.deleted_at),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -27,6 +27,7 @@ export const SCHEMA_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       );
@@ -511,6 +512,23 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_terminal_sessions_status_updated
         ON terminal_sessions(status, updated_at);
 
+      CREATE TABLE IF NOT EXISTS sync_journal (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+        entity_id TEXT NOT NULL,
+        op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+        payload TEXT NOT NULL CHECK (json_valid(payload)),
+        origin TEXT NOT NULL,
+        created_at INTEGER NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_cursors (
+        peer_id TEXT PRIMARY KEY,
+        last_sent_seq INTEGER NOT NULL DEFAULT 0,
+        last_received_seq INTEGER NOT NULL DEFAULT 0,
+        updated_at INTEGER NOT NULL
+      );
+
     `;
 
 /** Idempotent `ALTER TABLE ... ADD COLUMN` migrations for older databases. */
@@ -597,6 +615,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
+  'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
 ];
 
 /**
@@ -628,6 +647,21 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  `CREATE TABLE IF NOT EXISTS sync_journal (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+    entity_id TEXT NOT NULL,
+    op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    origin TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+  )`,
+  `CREATE TABLE IF NOT EXISTS sync_cursors (
+    peer_id TEXT PRIMARY KEY,
+    last_sent_seq INTEGER NOT NULL DEFAULT 0,
+    last_received_seq INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER NOT NULL
+  )`,
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */
@@ -651,6 +685,7 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       )
@@ -662,12 +697,12 @@ export const WORKFLOWS_REBUILD_INSERT_DDL = `
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       FROM workflows
     `;

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -459,7 +459,8 @@ export class SqliteTaskAttemptRepository {
              w.name AS workflow_name
       FROM tasks t${this.taskSelectJoin('t')}
       JOIN workflows w ON w.id = t.workflow_id
-      WHERE t.status = 'completed'
+      WHERE w.deleted_at IS NULL
+        AND t.status = 'completed'
       ORDER BY t.completed_at DESC
     `);
     return rows.map((row) => ({
@@ -481,7 +482,8 @@ export class SqliteTaskAttemptRepository {
         FROM events
         GROUP BY task_id
       ) e ON e.task_id = t.id
-      WHERE COALESCE(e.event_count, 0) > 0 OR t.status != 'pending'
+      WHERE w.deleted_at IS NULL
+        AND (COALESCE(e.event_count, 0) > 0 OR t.status != 'pending')
       ORDER BY COALESCE(e.max_created_at, t.completed_at, t.started_at, t.created_at) DESC
     `);
     return rows.map((row) => {

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -27,6 +27,7 @@ import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ReviewGateLookup,
   Workflow,
+  WorkflowReadOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
 } from './adapter.js';
@@ -89,8 +90,8 @@ export class SqliteWorkflowRepository {
   saveWorkflow(workflow: WorkflowSaveInput): void {
     assertWorkflowConsistent(workflow);
     this.exec.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, deleted_at, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       workflow.id, workflow.name,
       workflow.description ?? null,
@@ -103,6 +104,7 @@ export class SqliteWorkflowRepository {
       workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
       workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
       workflow.generation ?? 0,
+      workflow.deletedAt ?? null,
       workflow.createdAt, workflow.updatedAt,
     ]);
   }
@@ -174,16 +176,19 @@ export class SqliteWorkflowRepository {
     this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined {
+    const row = this.exec.queryOne(
+      `SELECT * FROM workflows WHERE id = ?${options?.includeDeleted ? '' : ' AND deleted_at IS NULL'}`,
+      [workflowId],
+    );
     if (!row) return undefined;
     const rollup = this.loadWorkflowRollups([workflowId]).get(workflowId);
     return this.rowToWorkflow(row, rollup);
   }
 
-  listWorkflows(): Workflow[] {
+  listWorkflows(options?: WorkflowReadOptions): Workflow[] {
     const rows = this.exec.queryAll(
-      'SELECT * FROM workflows ORDER BY created_at DESC',
+      `SELECT * FROM workflows${options?.includeDeleted ? '' : ' WHERE deleted_at IS NULL'} ORDER BY created_at DESC`,
     );
     const workflowIds = rows.map((row) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
@@ -205,7 +210,9 @@ export class SqliteWorkflowRepository {
               w.base_branch AS baseBranch
          FROM tasks t
          JOIN workflows w ON w.id = t.workflow_id
-        WHERE t.is_merge_node = 1 AND (t.review_id = ? OR t.review_url LIKE ?)`,
+        WHERE w.deleted_at IS NULL
+          AND t.is_merge_node = 1
+          AND (t.review_id = ? OR t.review_url LIKE ?)`,
       [pr, `%/pull/${pr}`],
     );
     if (rows.length === 0) return undefined;
@@ -257,7 +264,8 @@ export class SqliteWorkflowRepository {
     if (type === 'workflows' || type === 'all') {
       const workflows = this.exec.queryAll(
         `SELECT id, name, description, plan_file, repo_url, branch, created_at FROM workflows 
-         WHERE name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ? 
+         WHERE deleted_at IS NULL
+           AND (name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{ id: string; name?: string | null; created_at: string }>;
@@ -281,8 +289,10 @@ export class SqliteWorkflowRepository {
     
     if (type === 'tasks' || type === 'all') {
       const tasks = this.exec.queryAll(
-        `SELECT id, workflow_id, description, command, prompt, summary, problem, approach, test_plan, repro_command, status, created_at FROM tasks 
-         WHERE description LIKE ? OR command LIKE ? OR prompt LIKE ? OR summary LIKE ? OR problem LIKE ? OR approach LIKE ? OR test_plan LIKE ? OR repro_command LIKE ? 
+        `SELECT t.id, t.workflow_id, t.description, t.command, t.prompt, t.summary, t.problem, t.approach, t.test_plan, t.repro_command, t.status, t.created_at FROM tasks t
+         JOIN workflows w ON w.id = t.workflow_id
+         WHERE w.deleted_at IS NULL
+           AND (t.description LIKE ? OR t.command LIKE ? OR t.prompt LIKE ? OR t.summary LIKE ? OR t.problem LIKE ? OR t.approach LIKE ? OR t.test_plan LIKE ? OR t.repro_command LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{
@@ -298,7 +308,7 @@ export class SqliteWorkflowRepository {
       if (workflowIds.length > 0) {
         const placeholders = workflowIds.map(() => '?').join(',');
         const workflowRows = this.exec.queryAll(
-          `SELECT id, name FROM workflows WHERE id IN (${placeholders})`,
+          `SELECT id, name FROM workflows WHERE deleted_at IS NULL AND id IN (${placeholders})`,
           workflowIds
         ) as Array<{ id: string; name?: string | null }>;
         for (const wf of workflowRows) {
@@ -326,13 +336,18 @@ export class SqliteWorkflowRepository {
   loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
     const totalStartedAt = Date.now();
     const workflowQueryStartedAt = Date.now();
-    const workflowRows = this.exec.queryAll('SELECT * FROM workflows ORDER BY created_at DESC');
+    const workflowRows = this.exec.queryAll('SELECT * FROM workflows WHERE deleted_at IS NULL ORDER BY created_at DESC');
     const workflowMetadataQueryMs = Date.now() - workflowQueryStartedAt;
     const taskQueryStartedAt = Date.now();
-    const taskRows = this.exec.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC');
+    const workflowIds = workflowRows.map((row) => String(row.id));
+    const taskRows = workflowIds.length === 0
+      ? []
+      : this.exec.queryAll(
+        `SELECT * FROM tasks WHERE workflow_id IN (${workflowIds.map(() => '?').join(', ')}) ORDER BY workflow_id ASC, id ASC`,
+        workflowIds,
+      );
     const taskQueryMs = Date.now() - taskQueryStartedAt;
     const tasksByWorkflowId = new Map<string, TaskState[]>();
-    const workflowIds = workflowRows.map((row) => String(row.id));
     const rollupStartedAt = Date.now();
     const rollups = this.computeWorkflowRollupsFromRows(workflowIds, taskRows);
     const rollupComputationMs = Date.now() - rollupStartedAt;

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -1,0 +1,179 @@
+import type { SqliteExecutor } from './sqlite-executor.js';
+
+export type SyncJournalEntityType =
+  | 'workflow'
+  | 'task'
+  | 'attempt'
+  | 'event'
+  // Reserved for output-spool sync; adapter output writes intentionally do not
+  // append journal rows yet because they are high volume.
+  | 'output';
+
+export type SyncJournalOperation = 'upsert' | 'tombstone';
+
+export interface SyncJournalEntryInput {
+  entityType: SyncJournalEntityType;
+  entityId: string;
+  op: SyncJournalOperation;
+  payload: unknown;
+  origin?: string;
+  createdAt?: number;
+}
+
+export interface SyncJournalRecord {
+  seq: number;
+  entityType: SyncJournalEntityType;
+  entityId: string;
+  op: SyncJournalOperation;
+  payload: unknown;
+  origin: string;
+  createdAt: number;
+}
+
+export interface SyncCursor {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt: number;
+}
+
+export interface SyncCursorInput {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt?: number;
+}
+
+interface SyncJournalRow {
+  seq: unknown;
+  entity_type: unknown;
+  entity_id: unknown;
+  op: unknown;
+  payload: unknown;
+  origin: unknown;
+  created_at: unknown;
+}
+
+interface SyncCursorRow {
+  peer_id: unknown;
+  last_sent_seq: unknown;
+  last_received_seq: unknown;
+  updated_at: unknown;
+}
+
+function requireFiniteInteger(value: number, name: string): number {
+  if (!Number.isFinite(value) || !Number.isInteger(value)) {
+    throw new Error(`${name} must be a finite integer`);
+  }
+  return value;
+}
+
+function toJournalRecord(row: SyncJournalRow): SyncJournalRecord {
+  const payloadRaw = typeof row.payload === 'string' ? row.payload : String(row.payload ?? 'null');
+  return {
+    seq: Number(row.seq),
+    entityType: String(row.entity_type) as SyncJournalEntityType,
+    entityId: String(row.entity_id),
+    op: String(row.op) as SyncJournalOperation,
+    payload: JSON.parse(payloadRaw),
+    origin: String(row.origin),
+    createdAt: Number(row.created_at),
+  };
+}
+
+function toCursor(row: SyncCursorRow): SyncCursor {
+  return {
+    peerId: String(row.peer_id),
+    lastSentSeq: Number(row.last_sent_seq),
+    lastReceivedSeq: Number(row.last_received_seq),
+    updatedAt: Number(row.updated_at),
+  };
+}
+
+export function appendJournalEntry(
+  db: SqliteExecutor,
+  entry: SyncJournalEntryInput,
+): SyncJournalRecord {
+  const createdAt = requireFiniteInteger(entry.createdAt ?? Date.now(), 'createdAt');
+  const origin = entry.origin ?? 'home';
+  const payload = JSON.stringify(entry.payload);
+  if (payload === undefined) {
+    throw new Error('sync journal payload must be JSON-serializable');
+  }
+  db.execRun(
+    `INSERT INTO sync_journal (
+       entity_type, entity_id, op, payload, origin, created_at
+     ) VALUES (?, ?, ?, ?, ?, ?)`,
+    [
+      entry.entityType,
+      entry.entityId,
+      entry.op,
+      payload,
+      origin,
+      createdAt,
+    ],
+  );
+
+  const row = db.queryOne(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq = last_insert_rowid()`,
+  ) as SyncJournalRow | undefined;
+  if (!row) {
+    throw new Error('failed to read appended sync journal row');
+  }
+  return toJournalRecord(row);
+}
+
+export function readJournalSince(
+  db: SqliteExecutor,
+  seq: number,
+  limit: number,
+): SyncJournalRecord[] {
+  const cursor = requireFiniteInteger(Math.trunc(seq), 'seq');
+  const boundedLimit = Math.max(0, requireFiniteInteger(Math.trunc(limit), 'limit'));
+  if (boundedLimit === 0) return [];
+
+  const rows = db.queryAll(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq > ?
+      ORDER BY seq ASC
+      LIMIT ?`,
+    [cursor, boundedLimit],
+  ) as unknown as SyncJournalRow[];
+  return rows.map((row) => toJournalRecord(row));
+}
+
+export function getSyncCursor(db: SqliteExecutor, peerId: string): SyncCursor | undefined {
+  const row = db.queryOne(
+    `SELECT peer_id, last_sent_seq, last_received_seq, updated_at
+       FROM sync_cursors
+      WHERE peer_id = ?`,
+    [peerId],
+  ) as SyncCursorRow | undefined;
+  return row ? toCursor(row) : undefined;
+}
+
+export function setSyncCursor(db: SqliteExecutor, cursor: SyncCursorInput): SyncCursor {
+  const updatedAt = requireFiniteInteger(cursor.updatedAt ?? Date.now(), 'updatedAt');
+  const lastSentSeq = requireFiniteInteger(cursor.lastSentSeq, 'lastSentSeq');
+  const lastReceivedSeq = requireFiniteInteger(cursor.lastReceivedSeq, 'lastReceivedSeq');
+
+  db.execRun(
+    `INSERT INTO sync_cursors (
+       peer_id, last_sent_seq, last_received_seq, updated_at
+     ) VALUES (?, ?, ?, ?)
+     ON CONFLICT(peer_id) DO UPDATE SET
+       last_sent_seq = excluded.last_sent_seq,
+       last_received_seq = excluded.last_received_seq,
+       updated_at = excluded.updated_at`,
+    [cursor.peerId, lastSentSeq, lastReceivedSeq, updatedAt],
+  );
+
+  const saved = getSyncCursor(db, cursor.peerId);
+  if (!saved) {
+    throw new Error(`failed to read sync cursor for peer ${cursor.peerId}`);
+  }
+  return saved;
+}


### PR DESCRIPTION
## Summary

Remote Sync Step 1: Sync Schema and Change Journal - 2 tasks completed, 0 failed, 0 closed, 0 sk&#105;pped

Adds sync journal and cursor tables, workflow tombstones, and journal helpers for future remote sync.

Journal rows are appended in the same SQLite transactions as workflow, task, and attempt mutations.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926077035-3/implement-sync-schema | Add sync journal, cursor, and tombstone schema to data-store | completed |
| wf-1784926077035-3/verify-sync-schema | Run data-store package tests covering the new schema and journal | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784926077035-3/implement-sync-schema - Add sync journal, cursor, and tombstone schema to data-store

### wf-1784926077035-3/verify-sync-schema - Run data-store package tests covering the new schema and journal

</details>

## Review Claim

Approve the data-store sync contract for journaling workflow, task, and attempt mutations with cursors and workflow tombstones.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Journal rows are appended inside the existing SQLite transaction, so rollback removes both entity rows and sync evidence.

## Slice Rationale

This is the foundation slice for remote sync. It adds durable local sync records before any transport or peer reconciliation code consumes them.

## Non-goals

- No remote transport.
- No peer reconciliation.
- No UI changes.
- No output spool replication.

## Architecture

### Before

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["Entity table rows"]
    C["Workflow removal request"] --> D["Workflow row removed"]
```

### After

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["Entity table rows"]
    A --> C["sync_journal upsert rows"]
    D["Workflow removal request"] --> E["Workflow tombstone state"]
    D --> F["sync_journal tombstone row"]
    G["Peer replication checkpoint"] --> H["sync_cursors row"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sync-journal.test.ts` (25 files, 435 tests passed)
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-bodies/remote-sync-step-1-g35.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-bodies/remote-sync-step-1-g35.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 3a4541de0`
- Post-revert steps: Rerun `pnpm --filter @invoker/data-store test -- src/__tests__/sync-journal.test.ts`.
- Data migration? Yes. Existing local databases may retain unused sync tables and the workflow tombstone column after code revert.

</details>
