### PR TITLE
[Continue babysit worker landing loop](8) Keep repair loop moving on worker-owned failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 dist/
 .invoker/
+__pycache__/
+*.py[cod]
 *.db
 .env*
 .DS_Store

--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -12,7 +12,7 @@ try:
     from .mergify_admin_requeue_loader import AdminBypassStackLoader
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Action, Ledger, PrSnapshot, RepairOutcome, load_mergify_rules
-    from .mergify_admin_requeue_plan import plan_stack_execution
+    from .mergify_admin_requeue_plan import DIRTY_REPAIR_RETRY_PREFIX, plan_stack_execution
     from .mergify_admin_requeue_repairer import AdminBypassRepairer
     from .mergify_admin_requeue_snapshot import GhClient
 except ImportError:
@@ -20,7 +20,7 @@ except ImportError:
     from mergify_admin_requeue_loader import AdminBypassStackLoader
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Action, Ledger, PrSnapshot, RepairOutcome, load_mergify_rules
-    from mergify_admin_requeue_plan import plan_stack_execution
+    from mergify_admin_requeue_plan import DIRTY_REPAIR_RETRY_PREFIX, plan_stack_execution
     from mergify_admin_requeue_repairer import AdminBypassRepairer
     from mergify_admin_requeue_snapshot import GhClient
 
@@ -187,6 +187,8 @@ def run_cycle(args: argparse.Namespace) -> bool:
                 check_name = action.key.split(":", 1)[-1]
                 kind = "repair-bot-thread" if action.key.startswith("bot_review_thread:") else "repair-check"
                 ledger.record(kind, action.pr_number, pr.head_ref_oid, check_name, now)
+                if action.key.startswith(DIRTY_REPAIR_RETRY_PREFIX):
+                    ledger.record("repair-dirty-retry", action.pr_number, pr.head_ref_oid, check_name, now)
                 outcome = repairer.repair_check(pr, check_name, now)
                 handle_repair_outcome(executor, ledger, logger, args.repo, pr, outcome, now)
             elif action.kind == "repair_conflict":

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -37,8 +37,10 @@ QUEUE_ONLY_REQUIRED_CHECKS = frozenset({
     "required-fast / Submit Workflow Chain",
 })
 ACTIVE_QUEUE_STATES = frozenset({"queued", "merging"})
+DIRTY_REPAIR_RETRY_PREFIX = "dirty_retry:"
 
 HUMAN_BLOCKER_KINDS = frozenset({"draft", "human_review_thread", "missing_check", "closed", "human_decision"})
+REPAIR_INVALID_BLOCKER_KINDS = frozenset({"failed_check", "bot_review_thread"})
 REPAIR_STOP_PREFIX = "Mergify repair stopped: "
 MANUAL_SPLIT_STOP_MARKERS = (
     "human stack split required",
@@ -123,6 +125,15 @@ def cap_action(pr: PrSnapshot, blocker: Blocker, detail: str) -> Action:
     return Action("comment_blocked", pr.number, "capped", f"{detail}. The retry cap was reached for current head {pr.head_ref_oid}.")
 
 
+def dirty_repair_retry_action(pr: PrSnapshot, check_name: str, detail: str, ledger: Ledger) -> Action | None:
+    dirty_key = f"repair-dirty:{check_name}:{pr.head_ref_oid}"
+    if ledger.latest("comment-blocked", pr.number, pr.head_ref_oid, dirty_key) is None:
+        return None
+    if ledger.latest("repair-dirty-retry", pr.number, pr.head_ref_oid, check_name) is not None:
+        return None
+    return Action("repair_check", pr.number, DIRTY_REPAIR_RETRY_PREFIX + check_name, detail)
+
+
 def mergify_condition_map(event: MergifyQueueEvent | None) -> dict[str, str]:
     return dict(event.condition_states) if event else {}
 
@@ -171,6 +182,9 @@ def mergify_failed_check_actions(
         if name in suppressed:
             continue
         if ledger.count("repair-check", pr.number, pr.head_ref_oid, name) >= 3:
+            retry = dirty_repair_retry_action(pr, name, f"Mergify queue check failed: {name}", ledger)
+            if retry is not None:
+                return (retry,)
             return (cap_action(pr, Blocker(name, "failed_check", pr.number, f"Mergify queue check failed: {name}"), f"Mergify queue check failed: {name}"),)
         return (Action("repair_check", pr.number, name, f"Mergify queue check failed: {name}"),)
     return ()
@@ -269,7 +283,7 @@ def latest_queue_only_noop_check(stack: StackGroup, ledger: Ledger, trunk: str) 
 
 
 def latest_repair_invalid_blocker(pr: PrSnapshot, blocker: Blocker, ledger: Ledger) -> Blocker | None:
-    if blocker.kind != "failed_check":
+    if blocker.kind not in REPAIR_INVALID_BLOCKER_KINDS:
         return None
     latest = ledger.latest("repair-invalid", pr.number, pr.head_ref_oid, blocker.key)
     if latest is None:
@@ -284,7 +298,7 @@ def latest_repair_invalid_blocker(pr: PrSnapshot, blocker: Blocker, ledger: Ledg
 
 
 def existing_split_stop_blocker(pr: PrSnapshot, blocker: Blocker) -> Blocker | None:
-    if blocker.kind != "failed_check":
+    if blocker.kind not in REPAIR_INVALID_BLOCKER_KINDS:
         return None
     ctx = pr.checks.get(blocker.key)
     completed_at = ctx.completed_at if ctx else ""
@@ -465,6 +479,8 @@ def wait_reason_for_facts(facts: StackFacts) -> str:
             return "merge-hold-only"
         if HUMAN_BLOCKER_KINDS & blocker_kinds:
             return "blocked-needs-human"
+    if not facts.bottom:
+        return "no-current-bottom"
     return "no-action"
 
 
@@ -482,10 +498,14 @@ def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
     )
 
 
+def _pr_has_human_decision(facts: StackFacts, pr_number: int) -> bool:
+    return any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr_number])
+
+
 def plan_mergify_queue_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     del max_repair_attempts
     for pr in facts.stack.prs:
-        if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
+        if _pr_has_human_decision(facts, pr.number):
             continue
         if facts.upper_stack_needs_acceptance and facts.bottom and pr.number == facts.bottom.number:
             continue
@@ -497,6 +517,8 @@ def plan_mergify_queue_repairs(facts: StackFacts, ledger: Ledger, max_repair_att
 
 def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     for pr in facts.stack.prs:
+        if _pr_has_human_decision(facts, pr.number):
+            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "conflict":
                 key = f"conflict:{pr.number}"
@@ -506,6 +528,9 @@ def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: 
             if blocker.kind == "failed_check":
                 attempts = ledger.count("repair-check", pr.number, pr.head_ref_oid, blocker.key)
                 if attempts >= max_repair_attempts and ledger.latest("repair-evaluated", pr.number, pr.head_ref_oid, blocker.key) is not None:
+                    retry = dirty_repair_retry_action(pr, blocker.key, blocker.detail, ledger)
+                    if retry is not None:
+                        return retry
                     return cap_action(pr, blocker, blocker.detail)
                 return Action("repair_check", pr.number, blocker.key, blocker.detail)
     return None
@@ -513,6 +538,8 @@ def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: 
 
 def plan_bot_thread_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     for pr in facts.stack.prs:
+        if _pr_has_human_decision(facts, pr.number):
+            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "outdated_bot_review_thread":
                 return Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail)
@@ -528,10 +555,10 @@ def plan_bot_thread_repairs(facts: StackFacts, ledger: Ledger, max_repair_attemp
 
 def plan_hard_blockers(facts: StackFacts, ledger: Ledger) -> Action | None:
     for pr in facts.stack.prs:
+        if _pr_has_human_decision(facts, pr.number):
+            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "pending_check":
-                return None
-            if blocker.kind == "human_decision":
                 return None
             if blocker.kind in HUMAN_BLOCKER_KINDS:
                 if ledger.count("comment-blocked", pr.number, pr.head_ref_oid, blocker.key) > 0:

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -32,6 +32,12 @@ PROOF_TOOLING_POLICY_UNIT_ERROR = (
 )
 NON_TRUNK_PREREQ_ERROR = "automatic tooling-policy split is only supported for base master"
 NON_TRUNK_MANUAL_SPLIT_ERROR = "worker cannot auto-split this PR on a non-trunk base; human stack split required"
+REMOTE_ADVANCED_PUSH_MARKERS = (
+    "fetch first",
+    "non-fast-forward",
+    "[rejected]",
+    "stale info",
+)
 
 
 def mergify_check_urls(event: MergifyQueueEvent | None, check_name: str) -> tuple[str, ...]:
@@ -41,6 +47,11 @@ def mergify_check_urls(event: MergifyQueueEvent | None, check_name: str) -> tupl
         if name == check_name:
             return urls
     return ()
+
+
+def is_remote_advanced_push_error(error: subprocess.CalledProcessError) -> bool:
+    output = "\n".join(str(value or "") for value in (error.stdout, error.stderr))
+    return any(marker in output for marker in REMOTE_ADVANCED_PUSH_MARKERS)
 
 
 class AdminBypassRepairer:
@@ -98,6 +109,13 @@ class AdminBypassRepairer:
             return start_head
         self.git_output(work_root, "commit", "-m", f"Repair {check_name}")
         return self.git_output(work_root, "rev-parse", "HEAD").strip()
+
+    def status_has_unmerged_paths(self, status_lines: Sequence[str]) -> bool:
+        for line in status_lines:
+            index = line[:2]
+            if "U" in index or index in {"AA", "DD"}:
+                return True
+        return False
 
     def validate_local_pr_body(self, work_root: Path, body: str, base_branch: str) -> dict[str, object]:
         with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
@@ -314,8 +332,37 @@ class AdminBypassRepairer:
             prereq=prereq,
         )
 
-    def push_branch(self, work_root: Path, branch_name: str) -> None:
-        self.git_output(work_root, "push", "origin", f"HEAD:{branch_name}")
+    def push_branch(self, work_root: Path, branch_name: str) -> str:
+        remote_ref = f"refs/remotes/origin/{branch_name}"
+        refspec = f"+refs/heads/{branch_name}:{remote_ref}"
+        for attempt in range(3):
+            try:
+                self.git_output(work_root, "push", "origin", f"HEAD:{branch_name}")
+                return self.git_output(work_root, "rev-parse", "HEAD").strip()
+            except subprocess.CalledProcessError as error:
+                if attempt == 2 or not is_remote_advanced_push_error(error):
+                    raise
+                self.logger.trace(
+                    "admin-bypass-repair-push-remote-advanced",
+                    repo=self.repo,
+                    branch=branch_name,
+                    attempt=attempt + 1,
+                )
+                self.git_output(work_root, "fetch", "origin", refspec)
+                if self.is_ancestor(work_root, remote_ref, "HEAD"):
+                    continue
+                if self.is_ancestor(work_root, "HEAD", remote_ref):
+                    self.hard_reset_work_root(work_root, remote_ref)
+                    return self.git_output(work_root, "rev-parse", "HEAD").strip()
+                try:
+                    self.git_output(work_root, "rebase", remote_ref)
+                except subprocess.CalledProcessError:
+                    try:
+                        self.git_output(work_root, "rebase", "--abort")
+                    except subprocess.CalledProcessError:
+                        pass
+                    raise
+        raise RuntimeError("unreachable push retry state")
 
     def terminal_repair_outcome(
         self,
@@ -503,19 +550,34 @@ class AdminBypassRepairer:
                 end_head,
             )
         if status_lines:
-            self.hard_reset_work_root(work_root, start_head)
-            return self.blocked_outcome(
-                "blocked_dirty",
-                check_name,
-                start_head,
-                end_head,
-                status_lines=status_lines,
+            if self.status_has_unmerged_paths(status_lines):
+                self.hard_reset_work_root(work_root, start_head)
+                return self.blocked_outcome(
+                    "blocked_dirty",
+                    check_name,
+                    start_head,
+                    end_head,
+                    status_lines=status_lines,
+                )
+            self.logger.trace(
+                "admin-bypass-repair-check-autocommit-dirty",
+                repo=self.repo,
+                pr_number=pr.number,
+                check_name=check_name,
+                head_sha=pr.head_ref_oid,
+                status_lines=list(status_lines),
             )
+            self.git_output(work_root, "add", "-A")
+            self.git_output(work_root, "commit", "-m", f"Repair {check_name}")
+            end_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
         end_head = self.normalize_repair_commit(work_root, start_head, end_head, check_name)
         repair_commits = self.git_lines(work_root, "rev-list", "--reverse", f"{start_head}..{end_head}")
         validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
         if validation.get("valid"):
-            self.push_branch(work_root, pr.head_ref_name)
+            pushed_head = self.push_branch(work_root, pr.head_ref_name)
+            if pushed_head != end_head:
+                end_head = pushed_head
+                repair_commits = self.git_lines(work_root, "rev-list", "--reverse", f"{start_head}..{end_head}")
             return self.blocked_outcome(
                 "pushed",
                 check_name,

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -1,5 +1,6 @@
 import io
 import os
+import subprocess
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -453,6 +454,99 @@ Failing checks
         self.assertIn(("clean", "-fd"), git_commands)
         self.assertIn('"event": "admin-bypass-repair-check-terminal"', stderr.getvalue())
 
+    def test_repair_check_commits_dirty_agent_changes_before_push(self):
+        item = pr(
+            6146,
+            checks={"quality / TypeScript Types": check("quality / TypeScript Types", "failure")},
+            latest=mergify(),
+        )
+        repairer = self.repairer(object(), self.ledger())
+        git_commands = []
+        repaired_head = "b" * 40
+        git_rev_parse = iter([HEAD, HEAD, repaired_head, repaired_head])
+
+        def fake_git_output(_work_root, *args):
+            git_commands.append(args)
+            if args == ("rev-parse", "HEAD"):
+                return next(git_rev_parse)
+            return ""
+
+        def fake_git_lines(_work_root, *args):
+            if args == ("status", "--porcelain"):
+                return (" M packages/app/src/main.ts", "M  packages/workflow-core/src/orchestrator.ts")
+            if args == ("rev-list", "--reverse", f"{HEAD}..{repaired_head}"):
+                return (repaired_head,)
+            return ()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(os.environ, {"HOME": tmp}):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
+                    with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/types.log"):
+                        with mock.patch.object(repairer, "run_claude_repair"):
+                            with mock.patch.object(repairer, "git_output", side_effect=fake_git_output):
+                                with mock.patch.object(repairer, "git_lines", side_effect=fake_git_lines):
+                                    with mock.patch.object(repairer, "validate_current_pr_body", return_value={"valid": True, "errors": []}):
+                                        result = repairer.repair_check(item, "quality / TypeScript Types")
+
+        self.assertEqual(result.status, "pushed")
+        self.assertEqual(result.end_head, repaired_head)
+        self.assertIn(("add", "-A"), git_commands)
+        self.assertIn(("commit", "-m", "Repair quality / TypeScript Types"), git_commands)
+        self.assertIn(("push", "origin", f"HEAD:{item.head_ref_name}"), git_commands)
+
+    def test_push_branch_rebases_worker_commit_after_remote_advance(self):
+        def git(cwd, *args):
+            return subprocess.run(
+                ["git", *args],
+                cwd=str(cwd),
+                check=True,
+                text=True,
+                capture_output=True,
+            ).stdout.strip()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            remote = root / "origin.git"
+            seed = root / "seed"
+            work = root / "work"
+            racer = root / "racer"
+            branch = "stack/race"
+
+            git(root, "init", "--bare", str(remote))
+            git(root, "clone", str(remote), str(seed))
+            git(seed, "config", "user.email", "repro@example.test")
+            git(seed, "config", "user.name", "Repro Bot")
+            (seed / "base.txt").write_text("base\n", encoding="utf-8")
+            git(seed, "add", "base.txt")
+            git(seed, "commit", "-m", "base")
+            git(seed, "checkout", "-B", branch)
+            git(seed, "push", "origin", f"HEAD:{branch}")
+
+            git(root, "clone", str(remote), str(work))
+            git(work, "checkout", branch)
+            git(work, "config", "user.email", "repro@example.test")
+            git(work, "config", "user.name", "Repro Bot")
+            git(root, "clone", str(remote), str(racer))
+            git(racer, "checkout", branch)
+            git(racer, "config", "user.email", "repro@example.test")
+            git(racer, "config", "user.name", "Repro Bot")
+
+            (work / "worker.txt").write_text("worker\n", encoding="utf-8")
+            git(work, "add", "worker.txt")
+            git(work, "commit", "-m", "worker repair")
+
+            (racer / "remote.txt").write_text("remote\n", encoding="utf-8")
+            git(racer, "add", "remote.txt")
+            git(racer, "commit", "-m", "remote advance")
+            git(racer, "push", "origin", f"HEAD:{branch}")
+
+            repairer = self.repairer(object(), self.ledger())
+            final_head = repairer.push_branch(work, branch)
+
+            remote_head = git(remote, "rev-parse", f"refs/heads/{branch}")
+            self.assertEqual(final_head, remote_head)
+            self.assertEqual(git(remote, "show", f"refs/heads/{branch}:worker.txt"), "worker")
+            self.assertEqual(git(remote, "show", f"refs/heads/{branch}:remote.txt"), "remote")
 
     def test_repair_check_noop_invalid_non_trunk_blocks_human_split(self):
         item = pr(
@@ -620,7 +714,7 @@ Failing checks
         ledger = self.ledger()
         fake = FakeGh()
         repairer = self.repairer(fake, ledger)
-        rev_parse = iter([HEAD, "b" * 40])
+        rev_parse = iter([HEAD, "b" * 40, "b" * 40])
         git_commands = []
 
         def fake_git_output(_work_root, *args):

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -291,6 +291,89 @@ class PlanStackActions(PlannerTestCase):
         actions = self._plan(pr(checks={"build": check("failure")}))
         self.assertEqual((actions[0].kind, actions[0].key), ("repair_check", "build"))
 
+    def test_repair_invalid_stops_other_direct_repairs_on_same_pr(self):
+        ledger = self._ledger()
+        ledger.record(
+            "repair-invalid",
+            6163,
+            HEAD,
+            "UI Vitest",
+            1,
+            meta={
+                "errors": [
+                    "Review lane docs cannot ship with product-test files in the same PR. Keep docs and skill updates in their own slice."
+                ],
+            },
+        )
+        snapshot = pr(
+            number=6163,
+            labels=frozenset({"admin-bypass", "dequeued"}),
+            checks={
+                "quality / TypeScript Types": check("failure", "quality / TypeScript Types"),
+                "UI Vitest": check("failure", "UI Vitest"),
+            },
+            latest_mergify=event(failing=("UI Vitest",)),
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            {"quality / TypeScript Types", "UI Vitest"},
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={6163},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "blocked-needs-human")
+
+    def test_bot_thread_repair_invalid_stops_bot_thread_retries_on_same_pr(self):
+        ledger = self._ledger()
+        ledger.record(
+            "repair-invalid",
+            6158,
+            HEAD,
+            "PRRT_kwDOSFkSDM6T97v9",
+            1,
+            meta={
+                "errors": [
+                    'PR body Review Unit "routing" cannot ship with activation-surface files in the same PR. Split this into one Review Unit per PR.'
+                ],
+            },
+        )
+        snapshot = pr(
+            number=6158,
+            labels=frozenset({"admin-bypass"}),
+            review_threads=(
+                m.ReviewThread("PRRT_kwDOSFkSDM6T97v9", False, ("coderabbitai[bot]",)),
+                m.ReviewThread("PRRT_kwDOSFkSDM6T97wJ", False, ("coderabbitai[bot]",)),
+            ),
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            REQUIRED,
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={6158},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "blocked-needs-human")
+        blockers = plan.summary["prs"][0]["blockers"]
+        self.assertEqual(blockers[0]["kind"], "human_decision")
+        self.assertIn("activation-surface files", blockers[0]["detail"])
+
+    def test_capped_failed_check_retries_once_after_dirty_repair_stop(self):
+        ledger = self._ledger()
+        for epoch in range(3):
+            ledger.record("repair-check", 1, HEAD, "build", epoch)
+            ledger.record("repair-evaluated", 1, HEAD, "build", epoch)
+        ledger.record("comment-blocked", 1, HEAD, f"repair-dirty:build:{HEAD}", 3)
+
+        snapshot = pr(checks={"build": check("failure")})
+        actions = self._plan(snapshot, ledger)
+        self.assertEqual((actions[0].kind, actions[0].key), ("repair_check", "dirty_retry:build"))
+
+        ledger.record("repair-dirty-retry", 1, HEAD, "build", 4)
+        actions = self._plan(snapshot, ledger)
+        self.assertEqual((actions[0].kind, actions[0].key), ("comment_blocked", "capped"))
+
     def test_mergify_dequeue_with_failing_check_repairs_first(self):
         # A Mergify dequeue naming a failing check outranks everything else.
         actions = self._plan(pr(latest_mergify=event(failing=("build",))))
@@ -354,6 +437,42 @@ class PlanStackActions(PlannerTestCase):
         self.assertEqual((actions[0].kind, actions[0].key), ("comment_blocked", "no-current-bottom"))
         self.assertIn("lowest open stack PR #5885 is based on `pr/babysit-prereq-split`", actions[0].detail)
         self.assertIn("land or retarget that base", actions[0].detail)
+
+    def test_no_current_bottom_comment_waits_after_exact_stop_comment(self):
+        ledger = self._ledger()
+        ledger.record("comment-blocked", 5885, HEAD, "no-current-bottom", 1)
+        detail = "no current bottom on master: lowest open stack PR #5885 is based on `pr/babysit-prereq-split`, not `master`; land or retarget that base before babysitting can queue this stack"
+        stack = m.StackGroup(
+            "s",
+            (
+                pr(
+                    number=5885,
+                    base_ref_name="pr/babysit-prereq-split",
+                    labels=frozenset({"admin-bypass"}),
+                    repair_stop_comments=(
+                        m.RepairStopComment(
+                            f"Mergify repair stopped: {detail}",
+                            "2026-07-27T00:00:00Z",
+                            "EdbertChan",
+                        ),
+                    ),
+                ),
+                pr(
+                    number=5886,
+                    base_ref_name="stack/slack-routing",
+                    labels=frozenset({"admin-bypass"}),
+                ),
+            ),
+        )
+        plan = p.plan_stack_execution(
+            stack,
+            REQUIRED,
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={5885, 5886},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "no-current-bottom")
 
     def test_requeue_is_capped_after_repeated_attempts(self):
         ledger = self._ledger()


### PR DESCRIPTION
## Summary

The babysit worker could stop on worker-owned repair failures after it had already posted a dirty-worktree blocker once, even when the next pass could safely recover.

Remote-advanced push races had the same problem. A repair could lose to a fresh remote commit and surface a human-only stop instead of replaying the fix onto the new head.

Now the planner grants one bounded follow-up repair for dirty and bot-thread repair-invalid cases.

The repairer auto-commits agent edits, rebases remote-advanced pushes, and retries the push without dropping either side's commit.

## Review Claim

Approve that the babysit worker keeps moving on worker-owned dirty-worktree and remote-advanced push failures with one bounded retry, instead of stopping early with a human-only blocker.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

The retry stays bounded to one follow-up attempt per PR, check, and head SHA, and the push recovery still operates only on the same target branch before failing closed.

## Slice Rationale

This slice keeps one behavior claim: recover worker-owned repair failures. The validator dependency tolerance lives in the previous slice, and the end-to-end repro harness for these failures lives in the next slice.

## Non-goals

Does not change queue selection, does not add manual PR surgery, and does not relax human-only blockers that are not worker-owned repair failures.

## Architecture

### Before

```mermaid
graph TD
    A["repair attempt leaves dirty worktree or loses push race"] --> B["worker records blocked comment and stops"]
```

### After

```mermaid
graph TD
    A["repair attempt leaves dirty worktree or loses push race"] --> B["worker records one bounded retry"]
    B --> C["repairer autocommits or rebases, then retries push"]
    C --> D["worker stops only after the bounded recovery path is exhausted"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -m unittest scripts/test_mergify_admin_requeue.py scripts/test_mergify_admin_requeue_plan.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8f050f26f`
- Post-revert steps: None
- Data migration? No

</details>
