### PR TITLE
[Remote Sync Step 1: Sync Schema and Change Journal](1) Add data-store sync schema and journal

### DIFF
--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createAttempt } from '@invoker/workflow-core';
+import type { TaskState } from '@invoker/workflow-core';
+import type { Workflow } from '../adapter.js';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { SqliteExecutor } from '../sqlite-executor.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  readJournalSince,
+  setSyncCursor,
+} from '../sync-journal.js';
+
+describe('sync journal', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function executor(): SqliteExecutor {
+    return (adapter as unknown as { executor: SqliteExecutor }).executor;
+  }
+
+  function rawDb(): { run(sql: string, params?: unknown[]): void } {
+    return (adapter as unknown as { db: { run(sql: string, params?: unknown[]): void } }).db;
+  }
+
+  function makeWorkflow(id = 'wf-1'): Workflow {
+    return {
+      id,
+      name: `Workflow ${id}`,
+      status: 'pending',
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+    };
+  }
+
+  function makeTask(id = 'task-1', workflowId = 'wf-1'): TaskState {
+    return {
+      id,
+      description: `Task ${id}`,
+      status: 'pending',
+      dependencies: [],
+      createdAt: new Date('2026-07-27T00:00:00.000Z'),
+      config: { workflowId },
+      execution: {},
+      taskStateVersion: 1,
+    };
+  }
+
+  function clearJournal(): void {
+    rawDb().run('DELETE FROM sync_journal');
+  }
+
+  it('rolls back the mutation when the journal append fails', () => {
+    adapter.saveWorkflow(makeWorkflow());
+    adapter.saveTask('wf-1', makeTask());
+    clearJournal();
+
+    rawDb().run(`
+      CREATE TRIGGER fail_sync_journal
+      BEFORE INSERT ON sync_journal
+      BEGIN
+        SELECT RAISE(FAIL, 'journal fail');
+      END
+    `);
+
+    expect(() => adapter.updateTask('task-1', { status: 'running' })).toThrow('journal fail');
+    rawDb().run('DROP TRIGGER fail_sync_journal');
+
+    expect(adapter.loadTask('task-1')?.status).toBe('pending');
+    expect(readJournalSince(executor(), 0, 10)).toEqual([]);
+  });
+
+  it('assigns strictly monotonic seq values', () => {
+    const first = appendJournalEntry(executor(), {
+      entityType: 'workflow',
+      entityId: 'wf-a',
+      op: 'upsert',
+      payload: { id: 'wf-a' },
+    });
+    const second = appendJournalEntry(executor(), {
+      entityType: 'task',
+      entityId: 'task-a',
+      op: 'upsert',
+      payload: { id: 'task-a' },
+    });
+    const third = appendJournalEntry(executor(), {
+      entityType: 'attempt',
+      entityId: 'attempt-a',
+      op: 'upsert',
+      payload: { id: 'attempt-a' },
+    });
+
+    expect(second).toBeGreaterThan(first);
+    expect(third).toBeGreaterThan(second);
+  });
+
+  it('reads journal rows after the supplied cursor and honors limit', () => {
+    const first = appendJournalEntry(executor(), {
+      entityType: 'workflow',
+      entityId: 'wf-a',
+      op: 'upsert',
+      payload: { id: 'wf-a' },
+    });
+    const second = appendJournalEntry(executor(), {
+      entityType: 'workflow',
+      entityId: 'wf-b',
+      op: 'upsert',
+      payload: { id: 'wf-b' },
+    });
+    const third = appendJournalEntry(executor(), {
+      entityType: 'workflow',
+      entityId: 'wf-c',
+      op: 'upsert',
+      payload: { id: 'wf-c' },
+    });
+
+    expect(readJournalSince(executor(), first, 10).map((entry) => entry.seq)).toEqual([second, third]);
+    expect(readJournalSince(executor(), 0, 2).map((entry) => entry.seq)).toEqual([first, second]);
+  });
+
+  it('gets and sets peer cursor pairs', () => {
+    expect(getSyncCursor(executor(), 'peer-a')).toBeUndefined();
+
+    setSyncCursor(executor(), {
+      peerId: 'peer-a',
+      lastSentSeq: 12,
+      lastReceivedSeq: 7,
+      updatedAt: 1_722_000_000_000,
+    });
+
+    expect(getSyncCursor(executor(), 'peer-a')).toEqual({
+      peerId: 'peer-a',
+      lastSentSeq: 12,
+      lastReceivedSeq: 7,
+      updatedAt: 1_722_000_000_000,
+    });
+  });
+
+  it('journals attempt creation and completion as row snapshots', () => {
+    adapter.saveWorkflow(makeWorkflow());
+    adapter.saveTask('wf-1', makeTask());
+    clearJournal();
+
+    const attempt = createAttempt('task-1', {
+      status: 'running',
+      startedAt: new Date('2026-07-27T00:01:00.000Z'),
+    });
+    adapter.saveAttempt(attempt);
+    adapter.updateAttempt(attempt.id, {
+      status: 'completed',
+      exitCode: 0,
+      completedAt: new Date('2026-07-27T00:02:00.000Z'),
+    });
+
+    const entries = readJournalSince(executor(), 0, 10);
+    expect(entries.map((entry) => [entry.entityType, entry.entityId, entry.op])).toEqual([
+      ['attempt', attempt.id, 'upsert'],
+      ['attempt', attempt.id, 'upsert'],
+    ]);
+    expect(entries[1].seq).toBeGreaterThan(entries[0].seq);
+    expect(entries[1].payload).toMatchObject({
+      id: attempt.id,
+      status: 'completed',
+      exit_code: 0,
+    });
+  });
+
+  it('hides soft-deleted workflows by default and exposes them with includeDeleted', () => {
+    adapter.saveWorkflow({
+      ...makeWorkflow('wf-delete'),
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+    });
+    adapter.saveWorkflow({
+      ...makeWorkflow('wf-keep'),
+      createdAt: '2026-07-27T00:01:00.000Z',
+      updatedAt: '2026-07-27T00:01:00.000Z',
+    });
+    clearJournal();
+
+    adapter.deleteWorkflow('wf-delete');
+
+    expect(adapter.listWorkflows().map((workflow) => workflow.id)).toEqual(['wf-keep']);
+    expect(adapter.loadWorkflow('wf-delete')).toBeUndefined();
+
+    const deleted = adapter.loadWorkflow('wf-delete', { includeDeleted: true });
+    expect(deleted?.deletedAt).toEqual(expect.any(Number));
+    expect(adapter.listWorkflows({ includeDeleted: true }).map((workflow) => workflow.id)).toEqual([
+      'wf-keep',
+      'wf-delete',
+    ]);
+  });
+
+  it('writes a tombstone journal entry when deleting a workflow', () => {
+    adapter.saveWorkflow(makeWorkflow('wf-delete'));
+    clearJournal();
+
+    adapter.deleteWorkflow('wf-delete');
+
+    const [entry] = readJournalSince(executor(), 0, 10);
+    expect(entry).toMatchObject({
+      entityType: 'workflow',
+      entityId: 'wf-delete',
+      op: 'tombstone',
+      origin: 'home',
+    });
+    expect(entry.payload).toMatchObject({
+      id: 'wf-delete',
+      deleted_at: expect.any(Number),
+    });
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -124,10 +124,14 @@ export interface Workflow {
   /** Read-only provenance for dependencies removed by `detachWorkflow`. Never re-read by scheduling. */
   detachedExternalDependencies?: DetachedExternalDependency[];
   generation?: number;
+  deletedAt?: number;
   createdAt: string;
   updatedAt: string;
 }
 export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup'>;
+export interface WorkflowReadOptions {
+  includeDeleted?: boolean;
+}
 
 /**
  * Result of resolving a published PR back to its Invoker workflow via the merge
@@ -333,8 +337,8 @@ export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
-  loadWorkflow(workflowId: string): Workflow | undefined;
-  listWorkflows(): Workflow[];
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined;
+  listWorkflows(options?: WorkflowReadOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
   /** Resolve a GitHub PR number back to its Invoker workflow via the merge node. */
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined;

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -7,3 +7,4 @@ export * from './slack-session-repository.js';
 export * from './slack-plan-draft-repository.js';
 export * from './sqlite-task-repository.js';
 export * from './workflow-channel-repository.js';
+export * from './sync-journal.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -38,6 +38,7 @@ import type {
   PersistenceAdapter,
   ReviewGateLookup,
   Workflow,
+  WorkflowReadOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
   TaskEvent,
@@ -75,6 +76,7 @@ import {
 } from './sqlite-output-spool.js';
 import { SlowQueryAggregator, type SlowQueryShapeStats } from './slow-query-aggregator.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
+import { appendJournalEntry } from './sync-journal.js';
 import * as migrations from './sqlite-migrations.js';
 import { SqliteTaskAttemptRepository } from './sqlite-task-attempt-repository.js';
 import { SqliteWorkflowRepository, type WorkflowMetadataChanges } from './sqlite-workflow-repository.js';
@@ -1054,12 +1056,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.workflowRepo.updateWorkflow(workflowId, changes);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    return this.workflowRepo.loadWorkflow(workflowId);
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined {
+    return this.workflowRepo.loadWorkflow(workflowId, options);
   }
 
-  listWorkflows(): Workflow[] {
-    return this.workflowRepo.listWorkflows();
+  listWorkflows(options?: WorkflowReadOptions): Workflow[] {
+    return this.workflowRepo.listWorkflows(options);
   }
 
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
@@ -1558,7 +1560,29 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   deleteWorkflow(workflowId: string): void {
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
+    let workflowFound = false;
     this.runTransaction(() => {
+      const workflowRow = this.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+      if (!workflowRow) return;
+      workflowFound = true;
+
+      const deletedAt = Date.now();
+      this.db.run(
+        'UPDATE workflows SET deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL',
+        [deletedAt, new Date(deletedAt).toISOString(), workflowId],
+      );
+      if (this.db.getRowsModified() > 0) {
+        const tombstoneRow = this.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+        if (!tombstoneRow) {
+          throw new Error(`Cannot journal missing workflow tombstone row: ${workflowId}`);
+        }
+        appendJournalEntry(this.executor, {
+          entityType: 'workflow',
+          entityId: workflowId,
+          op: 'tombstone',
+          payload: tombstoneRow,
+        });
+      }
       this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM task_launch_dispatch WHERE workflow_id = ?', [workflowId]);
@@ -1598,9 +1622,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
     });
-    this.removeOutputFiles(taskIds);
+    if (workflowFound) {
+      this.removeOutputFiles(taskIds);
+    }
   }
 
   // ── Events ────────────────────────────────────────────

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -47,6 +47,7 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
     externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
     detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) as DetachedExternalDependency[] : undefined,
     generation: row.generation ?? 0,
+    ...(row.deleted_at === null || row.deleted_at === undefined ? {} : { deletedAt: Number(row.deleted_at) }),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -28,7 +28,28 @@ export const SCHEMA_DDL = `
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
         created_at TEXT DEFAULT (datetime('now')),
-        updated_at TEXT DEFAULT (datetime('now'))
+        updated_at TEXT DEFAULT (datetime('now')),
+        deleted_at INTEGER
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_journal (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+        entity_id TEXT NOT NULL,
+        op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+        payload TEXT NOT NULL CHECK (json_valid(payload)),
+        origin TEXT NOT NULL DEFAULT 'home',
+        created_at INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_sync_journal_seq
+        ON sync_journal(seq);
+
+      CREATE TABLE IF NOT EXISTS sync_cursors (
+        peer_id TEXT PRIMARY KEY,
+        last_sent_seq INTEGER NOT NULL DEFAULT 0,
+        last_received_seq INTEGER NOT NULL DEFAULT 0,
+        updated_at INTEGER NOT NULL
       );
 
       CREATE TABLE IF NOT EXISTS tasks (
@@ -597,6 +618,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
+  'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
 ];
 
 /**
@@ -628,6 +650,22 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  `CREATE TABLE IF NOT EXISTS sync_journal (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+    entity_id TEXT NOT NULL,
+    op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    origin TEXT NOT NULL DEFAULT 'home',
+    created_at INTEGER NOT NULL
+  )`,
+  'CREATE INDEX IF NOT EXISTS idx_sync_journal_seq ON sync_journal(seq)',
+  `CREATE TABLE IF NOT EXISTS sync_cursors (
+    peer_id TEXT PRIMARY KEY,
+    last_sent_seq INTEGER NOT NULL DEFAULT 0,
+    last_received_seq INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER NOT NULL
+  )`,
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */
@@ -652,7 +690,8 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
         created_at TEXT DEFAULT (datetime('now')),
-        updated_at TEXT DEFAULT (datetime('now'))
+        updated_at TEXT DEFAULT (datetime('now')),
+        deleted_at INTEGER
       )
     `;
 
@@ -662,12 +701,12 @@ export const WORKFLOWS_REBUILD_INSERT_DDL = `
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, created_at, updated_at, deleted_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, created_at, updated_at, deleted_at
       FROM workflows
     `;

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -17,6 +17,7 @@ import {
 import { mapRowToTask, mapRowToAttempt } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
@@ -230,194 +231,199 @@ export class SqliteTaskAttemptRepository {
     const beforeTask = this.loadTask(taskId);
     if (!beforeTask) return;
 
-    const setClauses: string[] = [];
-    const values: unknown[] = [];
+    this.exec.runTransaction(() => {
+      const setClauses: string[] = [];
+      const values: unknown[] = [];
 
-    if (changes.description !== undefined) {
-      setClauses.push('description = ?');
-      values.push(changes.description);
-    }
-    if (changes.status !== undefined) {
-      setClauses.push('status = ?');
-      values.push(changes.status);
-    }
-    if (changes.dependencies !== undefined) {
-      setClauses.push('dependencies = ?');
-      values.push(JSON.stringify(changes.dependencies));
-    }
+      if (changes.description !== undefined) {
+        setClauses.push('description = ?');
+        values.push(changes.description);
+      }
+      if (changes.status !== undefined) {
+        setClauses.push('status = ?');
+        values.push(changes.status);
+      }
+      if (changes.dependencies !== undefined) {
+        setClauses.push('dependencies = ?');
+        values.push(JSON.stringify(changes.dependencies));
+      }
 
-    if (changes.config) {
-      const config = changes.config as Record<string, unknown>;
-      const configMap: Record<string, string> = {
-        workflowId: 'workflow_id',
-        parentTask: 'parent_task',
-        command: 'command',
-        prompt: 'prompt',
-        experimentPrompt: 'experiment_prompt',
-        summary: 'summary',
-        problem: 'problem',
-        approach: 'approach',
-        testPlan: 'test_plan',
-        reproCommand: 'repro_command',
-        featureBranch: 'feature_branch',
-        runnerKind: 'runner_kind',
-        poolId: 'pool_id',
-        poolMemberId: 'pool_member_id',
-        dockerImage: 'docker_image',
-        executionAgent: 'execution_agent',
-        executionModel: 'execution_model',
-        fixPrompt: 'fix_prompt',
-        fixContext: 'fix_context',
-      };
-      const configBoolMap: Record<string, string> = {
-        pivot: 'pivot',
-        isReconciliation: 'is_reconciliation',
-        requiresManualApproval: 'requires_manual_approval',
-        isMergeNode: 'is_merge_node',
-      };
+      if (changes.config) {
+        const config = changes.config as Record<string, unknown>;
+        const configMap: Record<string, string> = {
+          workflowId: 'workflow_id',
+          parentTask: 'parent_task',
+          command: 'command',
+          prompt: 'prompt',
+          experimentPrompt: 'experiment_prompt',
+          summary: 'summary',
+          problem: 'problem',
+          approach: 'approach',
+          testPlan: 'test_plan',
+          reproCommand: 'repro_command',
+          featureBranch: 'feature_branch',
+          runnerKind: 'runner_kind',
+          poolId: 'pool_id',
+          poolMemberId: 'pool_member_id',
+          dockerImage: 'docker_image',
+          executionAgent: 'execution_agent',
+          executionModel: 'execution_model',
+          fixPrompt: 'fix_prompt',
+          fixContext: 'fix_context',
+        };
+        const configBoolMap: Record<string, string> = {
+          pivot: 'pivot',
+          isReconciliation: 'is_reconciliation',
+          requiresManualApproval: 'requires_manual_approval',
+          isMergeNode: 'is_merge_node',
+        };
 
-      for (const [key, col] of Object.entries(configMap)) {
-        if (key in config) {
-          setClauses.push(`${col} = ?`);
-          values.push(config[key] ?? null);
+        for (const [key, col] of Object.entries(configMap)) {
+          if (key in config) {
+            setClauses.push(`${col} = ?`);
+            values.push(config[key] ?? null);
+          }
+        }
+        for (const [key, col] of Object.entries(configBoolMap)) {
+          if (key in config) {
+            setClauses.push(`${col} = ?`);
+            values.push(config[key] ? 1 : 0);
+          }
+        }
+        if ('experimentVariants' in changes.config) {
+          setClauses.push('experiment_variants = ?');
+          values.push(changes.config.experimentVariants ? JSON.stringify(changes.config.experimentVariants) : null);
+        }
+        if ('externalDependencies' in changes.config) {
+          setClauses.push('external_dependencies = ?');
+          values.push(changes.config.externalDependencies ? JSON.stringify(changes.config.externalDependencies) : null);
         }
       }
-      for (const [key, col] of Object.entries(configBoolMap)) {
-        if (key in config) {
-          setClauses.push(`${col} = ?`);
-          values.push(config[key] ? 1 : 0);
-        }
-      }
-      if ('experimentVariants' in changes.config) {
-        setClauses.push('experiment_variants = ?');
-        values.push(changes.config.experimentVariants ? JSON.stringify(changes.config.experimentVariants) : null);
-      }
-      if ('externalDependencies' in changes.config) {
-        setClauses.push('external_dependencies = ?');
-        values.push(changes.config.externalDependencies ? JSON.stringify(changes.config.externalDependencies) : null);
-      }
-    }
 
-    if (changes.execution) {
-      this.syncCrashPreservationState(taskId, beforeTask, changes.execution);
-      const execution = changes.execution as Record<string, unknown>;
-      const execMap: Record<string, string> = {
-        blockedBy: 'blocked_by',
-        inputPrompt: 'input_prompt',
-        exitCode: 'exit_code',
-        error: 'error',
-        protocolErrorCode: 'protocol_error_code',
-        protocolErrorMessage: 'protocol_error_message',
-        actionRequestId: 'action_request_id',
-        branch: 'branch',
-        commit: 'commit_hash',
-        fixedIntegrationSha: 'fixed_integration_sha',
-        fixedIntegrationSource: 'fixed_integration_source',
-        agentSessionId: 'agent_session_id',
-        lastAgentSessionId: 'last_agent_session_id',
-        workspacePath: 'workspace_path',
-        containerId: 'container_id',
-        selectedExperiment: 'selected_experiment',
-        fixSessionEntryStatus: 'fix_session_entry_status',
-        pendingFixError: 'pending_fix_error',
-        failureClass: 'failure_class',
-        reviewUrl: 'review_url',
-        reviewId: 'review_id',
-        reviewStatus: 'review_status',
-        reviewProviderId: 'review_provider_id',
-        phase: 'launch_phase',
-        generation: 'execution_generation',
-        selectedAttemptId: 'selected_attempt_id',
-        agentName: 'agent_name',
-        lastAgentName: 'last_agent_name',
-      };
-      const execDateMap: Record<string, string> = {
-        startedAt: 'started_at',
-        completedAt: 'completed_at',
-        lastHeartbeatAt: 'last_heartbeat_at',
-        launchStartedAt: 'launch_started_at',
-        launchCompletedAt: 'launch_completed_at',
-        fixedIntegrationRecordedAt: 'fixed_integration_recorded_at',
-      };
-      const execJsonFields: Record<string, string> = {
-        experiments: 'experiments',
-        selectedExperiments: 'selected_experiments',
-        experimentResults: 'experiment_results',
-        reviewGate: 'review_gate',
-      };
+      if (changes.execution) {
+        this.syncCrashPreservationState(taskId, beforeTask, changes.execution);
+        const execution = changes.execution as Record<string, unknown>;
+        const execMap: Record<string, string> = {
+          blockedBy: 'blocked_by',
+          inputPrompt: 'input_prompt',
+          exitCode: 'exit_code',
+          error: 'error',
+          protocolErrorCode: 'protocol_error_code',
+          protocolErrorMessage: 'protocol_error_message',
+          actionRequestId: 'action_request_id',
+          branch: 'branch',
+          commit: 'commit_hash',
+          fixedIntegrationSha: 'fixed_integration_sha',
+          fixedIntegrationSource: 'fixed_integration_source',
+          agentSessionId: 'agent_session_id',
+          lastAgentSessionId: 'last_agent_session_id',
+          workspacePath: 'workspace_path',
+          containerId: 'container_id',
+          selectedExperiment: 'selected_experiment',
+          fixSessionEntryStatus: 'fix_session_entry_status',
+          pendingFixError: 'pending_fix_error',
+          failureClass: 'failure_class',
+          reviewUrl: 'review_url',
+          reviewId: 'review_id',
+          reviewStatus: 'review_status',
+          reviewProviderId: 'review_provider_id',
+          phase: 'launch_phase',
+          generation: 'execution_generation',
+          selectedAttemptId: 'selected_attempt_id',
+          agentName: 'agent_name',
+          lastAgentName: 'last_agent_name',
+        };
+        const execDateMap: Record<string, string> = {
+          startedAt: 'started_at',
+          completedAt: 'completed_at',
+          lastHeartbeatAt: 'last_heartbeat_at',
+          launchStartedAt: 'launch_started_at',
+          launchCompletedAt: 'launch_completed_at',
+          fixedIntegrationRecordedAt: 'fixed_integration_recorded_at',
+        };
+        const execJsonFields: Record<string, string> = {
+          experiments: 'experiments',
+          selectedExperiments: 'selected_experiments',
+          experimentResults: 'experiment_results',
+          reviewGate: 'review_gate',
+        };
 
-      for (const [key, col] of Object.entries(execMap)) {
-        if (key in execution) {
-          setClauses.push(`${col} = ?`);
-          values.push(execution[key] ?? null);
+        for (const [key, col] of Object.entries(execMap)) {
+          if (key in execution) {
+            setClauses.push(`${col} = ?`);
+            values.push(execution[key] ?? null);
+          }
+        }
+        for (const [key, col] of Object.entries(execDateMap)) {
+          if (key in execution) {
+            setClauses.push(`${col} = ?`);
+            const val = execution[key];
+            values.push(val instanceof Date ? val.toISOString() : val ?? null);
+          }
+        }
+        for (const [key, col] of Object.entries(execJsonFields)) {
+          if (key in execution) {
+            setClauses.push(`${col} = ?`);
+            const val = execution[key];
+            values.push(val ? JSON.stringify(val) : null);
+          }
+        }
+        const execBoolMap: Record<string, string> = {
+          isFixingWithAI: 'is_fixing_with_ai',
+        };
+        for (const [key, col] of Object.entries(execBoolMap)) {
+          if (key in execution) {
+            setClauses.push(`${col} = ?`);
+            values.push(execution[key] ? 1 : 0);
+          }
         }
       }
-      for (const [key, col] of Object.entries(execDateMap)) {
-        if (key in execution) {
-          setClauses.push(`${col} = ?`);
-          const val = execution[key];
-          values.push(val instanceof Date ? val.toISOString() : val ?? null);
-        }
-      }
-      for (const [key, col] of Object.entries(execJsonFields)) {
-        if (key in execution) {
-          setClauses.push(`${col} = ?`);
-          const val = execution[key];
-          values.push(val ? JSON.stringify(val) : null);
-        }
-      }
-      const execBoolMap: Record<string, string> = {
-        isFixingWithAI: 'is_fixing_with_ai',
-      };
-      for (const [key, col] of Object.entries(execBoolMap)) {
-        if (key in execution) {
-          setClauses.push(`${col} = ?`);
-          values.push(execution[key] ? 1 : 0);
-        }
-      }
-    }
 
 
-    assertTaskConsistent({
-      ...beforeTask,
-      ...changes,
-      config: changes.config ? ({ ...beforeTask.config, ...changes.config } as TaskState['config']) : beforeTask.config,
-      execution: changes.execution ? { ...beforeTask.execution, ...changes.execution } : beforeTask.execution,
+      assertTaskConsistent({
+        ...beforeTask,
+        ...changes,
+        config: changes.config ? ({ ...beforeTask.config, ...changes.config } as TaskState['config']) : beforeTask.config,
+        execution: changes.execution ? { ...beforeTask.execution, ...changes.execution } : beforeTask.execution,
+      });
+
+      if (setClauses.length === 0) return;
+
+      // Atomically bump task-state version with every mutation
+      setClauses.push('task_state_version = task_state_version + 1');
+
+      if (changes.execution && 'workspacePath' in changes.execution) {
+        try {
+          const row = this.exec.queryOne(
+            'SELECT is_merge_node AS isMerge, workspace_path AS prevPath FROM tasks WHERE id = ?',
+            [taskId],
+          ) as { isMerge?: number; prevPath?: string | null } | undefined;
+          if (row?.isMerge === 1) {
+            const nextWs = (changes.execution as { workspacePath?: string }).workspacePath;
+            console.log(
+              `[merge-gate-workspace] sqlite.updateTask mergeNode task=${taskId} ` +
+                `workspace_path ${row.prevPath ?? 'NULL'} → ${nextWs ?? 'NULL'} ` +
+                '(caller sets executor worktree path and/or gate clone path)',
+            );
+          }
+        } catch {
+          /* best-effort diagnostics only */
+        }
+      }
+
+      values.push(taskId);
+      const heartbeatOnly =
+        setClauses.length === 1 && setClauses[0].trimStart().startsWith('last_heartbeat_at =');
+
+      if (!heartbeatOnly && process.env.NODE_ENV !== 'test' && process.env.INVOKER_TRACE_PERSIST_SQL === '1') {
+        const cols = setClauses.map((c) => c.split(/\s*=\s*/)[0]!.trim()).join(', ');
+        console.log(`[persist-sql] taskId=${taskId} columns=[${cols}]`);
+      }
+      this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
+      if (changes.status !== undefined) {
+        this.appendTaskJournalEntry(taskId);
+      }
     });
-
-    if (setClauses.length === 0) return;
-
-    // Atomically bump task-state version with every mutation
-    setClauses.push('task_state_version = task_state_version + 1');
-
-    if (changes.execution && 'workspacePath' in changes.execution) {
-      try {
-        const row = this.exec.queryOne(
-          'SELECT is_merge_node AS isMerge, workspace_path AS prevPath FROM tasks WHERE id = ?',
-          [taskId],
-        ) as { isMerge?: number; prevPath?: string | null } | undefined;
-        if (row?.isMerge === 1) {
-          const nextWs = (changes.execution as { workspacePath?: string }).workspacePath;
-          console.log(
-            `[merge-gate-workspace] sqlite.updateTask mergeNode task=${taskId} ` +
-              `workspace_path ${row.prevPath ?? 'NULL'} → ${nextWs ?? 'NULL'} ` +
-              '(caller sets executor worktree path and/or gate clone path)',
-          );
-        }
-      } catch {
-        /* best-effort diagnostics only */
-      }
-    }
-
-    values.push(taskId);
-    const heartbeatOnly =
-      setClauses.length === 1 && setClauses[0].trimStart().startsWith('last_heartbeat_at =');
-
-    if (!heartbeatOnly && process.env.NODE_ENV !== 'test' && process.env.INVOKER_TRACE_PERSIST_SQL === '1') {
-      const cols = setClauses.map((c) => c.split(/\s*=\s*/)[0]!.trim()).join(', ');
-      console.log(`[persist-sql] taskId=${taskId} columns=[${cols}]`);
-    }
-    this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -594,40 +600,43 @@ export class SqliteTaskAttemptRepository {
   // ── Attempt CRUD ─────────────────────────────────────────
 
   saveAttempt(attempt: Attempt): void {
-    this.exec.execRun(`
-      INSERT OR REPLACE INTO attempts (
-        id, node_id, attempt_number, queue_priority, status,
-        snapshot_commit, base_branch, upstream_attempt_ids,
-        command_override, prompt_override,
-        claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
-        branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
-        supersedes_attempt_id, created_at, merge_conflict
-      ) VALUES (
-        ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?,
-        ?, ?,
-        ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?, ?,
-        ?, ?, ?
-      )
-    `, [
-      attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
-      attempt.snapshotCommit ?? null, attempt.baseBranch ?? null,
-      JSON.stringify(attempt.upstreamAttemptIds),
-      attempt.commandOverride ?? null, attempt.promptOverride ?? null,
-      attempt.claimedAt?.toISOString() ?? null,
-      attempt.startedAt?.toISOString() ?? null,
-      attempt.completedAt?.toISOString() ?? null,
-      attempt.exitCode ?? null, attempt.error ?? null,
-      attempt.lastHeartbeatAt?.toISOString() ?? null,
-      attempt.leaseExpiresAt?.toISOString() ?? null,
-      attempt.branch ?? null, attempt.commit ?? null, attempt.summary ?? null,
-      attempt.workspacePath ?? null, attempt.agentSessionId ?? null,
-      attempt.containerId ?? null,
-      attempt.supersedesAttemptId ?? null,
-      attempt.createdAt.toISOString(),
-      attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
-    ]);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`
+        INSERT OR REPLACE INTO attempts (
+          id, node_id, attempt_number, queue_priority, status,
+          snapshot_commit, base_branch, upstream_attempt_ids,
+          command_override, prompt_override,
+          claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
+          branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
+          supersedes_attempt_id, created_at, merge_conflict
+        ) VALUES (
+          ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?,
+          ?, ?,
+          ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?,
+          ?, ?, ?
+        )
+      `, [
+        attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
+        attempt.snapshotCommit ?? null, attempt.baseBranch ?? null,
+        JSON.stringify(attempt.upstreamAttemptIds),
+        attempt.commandOverride ?? null, attempt.promptOverride ?? null,
+        attempt.claimedAt?.toISOString() ?? null,
+        attempt.startedAt?.toISOString() ?? null,
+        attempt.completedAt?.toISOString() ?? null,
+        attempt.exitCode ?? null, attempt.error ?? null,
+        attempt.lastHeartbeatAt?.toISOString() ?? null,
+        attempt.leaseExpiresAt?.toISOString() ?? null,
+        attempt.branch ?? null, attempt.commit ?? null, attempt.summary ?? null,
+        attempt.workspacePath ?? null, attempt.agentSessionId ?? null,
+        attempt.containerId ?? null,
+        attempt.supersedesAttemptId ?? null,
+        attempt.createdAt.toISOString(),
+        attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
+      ]);
+      this.appendAttemptJournalEntry(attempt.id);
+    });
   }
 
   loadAttempts(nodeId: string): Attempt[] {
@@ -711,7 +720,12 @@ export class SqliteTaskAttemptRepository {
 
     if (setClauses.length === 0) return;
     values.push(attemptId);
-    this.exec.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
+      if (changes.status !== undefined || changes.completedAt !== undefined) {
+        this.appendAttemptJournalEntry(attemptId);
+      }
+    });
   }
 
   claimAttemptForLaunch(
@@ -888,5 +902,31 @@ export class SqliteTaskAttemptRepository {
       [nodeId, selected.createdAt.toISOString(), cappedLimit],
     );
     return rows.map((row) => mapRowToAttempt(row));
+  }
+
+  private appendTaskJournalEntry(taskId: string): void {
+    const row = this.exec.queryOne('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (!row) {
+      throw new Error(`Cannot journal missing task row: ${taskId}`);
+    }
+    appendJournalEntry(this.exec, {
+      entityType: 'task',
+      entityId: taskId,
+      op: 'upsert',
+      payload: row,
+    });
+  }
+
+  private appendAttemptJournalEntry(attemptId: string): void {
+    const row = this.exec.queryOne('SELECT * FROM attempts WHERE id = ?', [attemptId]);
+    if (!row) {
+      throw new Error(`Cannot journal missing attempt row: ${attemptId}`);
+    }
+    appendJournalEntry(this.exec, {
+      entityType: 'attempt',
+      entityId: attemptId,
+      op: 'upsert',
+      payload: row,
+    });
   }
 }

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -27,11 +27,13 @@ import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ReviewGateLookup,
   Workflow,
+  WorkflowReadOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
 } from './adapter.js';
 import { mapRowToWorkflow, mapRowToTask } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 export type WorkflowMetadataChanges = Partial<
   Pick<
@@ -88,23 +90,27 @@ export class SqliteWorkflowRepository {
 
   saveWorkflow(workflow: WorkflowSaveInput): void {
     assertWorkflowConsistent(workflow);
-    this.exec.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `, [
-      workflow.id, workflow.name,
-      workflow.description ?? null,
-      workflow.visualProof ? 1 : 0,
-      workflow.planFile ?? null, workflow.repoUrl ?? null, workflow.intermediateRepoUrl ?? null, workflow.branch ?? null,
-      workflow.onFinish ?? null, workflow.baseBranch ?? null, null, workflow.featureBranch ?? null,
-      workflow.mergeMode ?? null,
-      workflow.reviewProvider ?? null,
-      workflow.externalDependencies ? JSON.stringify(workflow.externalDependencies) : null,
-      workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
-      workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
-      workflow.generation ?? 0,
-      workflow.createdAt, workflow.updatedAt,
-    ]);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`
+        INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at, deleted_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `, [
+        workflow.id, workflow.name,
+        workflow.description ?? null,
+        workflow.visualProof ? 1 : 0,
+        workflow.planFile ?? null, workflow.repoUrl ?? null, workflow.intermediateRepoUrl ?? null, workflow.branch ?? null,
+        workflow.onFinish ?? null, workflow.baseBranch ?? null, null, workflow.featureBranch ?? null,
+        workflow.mergeMode ?? null,
+        workflow.reviewProvider ?? null,
+        workflow.externalDependencies ? JSON.stringify(workflow.externalDependencies) : null,
+        workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
+        workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
+        workflow.generation ?? 0,
+        workflow.createdAt, workflow.updatedAt,
+        workflow.deletedAt ?? null,
+      ]);
+      this.appendWorkflowJournalEntry(workflow.id, 'upsert');
+    });
   }
 
   updateWorkflow(workflowId: string, changes: WorkflowMetadataChanges): void {
@@ -171,19 +177,28 @@ export class SqliteWorkflowRepository {
     assertWorkflowPatchConsistent(before, after, changes);
 
     values.push(workflowId);
-    this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
+      this.appendWorkflowJournalEntry(workflowId, 'upsert');
+    });
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined {
+    const row = this.exec.queryOne(
+      `SELECT * FROM workflows
+       WHERE id = ?${options?.includeDeleted ? '' : ' AND deleted_at IS NULL'}`,
+      [workflowId],
+    );
     if (!row) return undefined;
     const rollup = this.loadWorkflowRollups([workflowId]).get(workflowId);
     return this.rowToWorkflow(row, rollup);
   }
 
-  listWorkflows(): Workflow[] {
+  listWorkflows(options?: WorkflowReadOptions): Workflow[] {
     const rows = this.exec.queryAll(
-      'SELECT * FROM workflows ORDER BY created_at DESC',
+      `SELECT * FROM workflows
+       ${options?.includeDeleted ? '' : 'WHERE deleted_at IS NULL'}
+       ORDER BY created_at DESC`,
     );
     const workflowIds = rows.map((row) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
@@ -205,7 +220,9 @@ export class SqliteWorkflowRepository {
               w.base_branch AS baseBranch
          FROM tasks t
          JOIN workflows w ON w.id = t.workflow_id
-        WHERE t.is_merge_node = 1 AND (t.review_id = ? OR t.review_url LIKE ?)`,
+        WHERE w.deleted_at IS NULL
+          AND t.is_merge_node = 1
+          AND (t.review_id = ? OR t.review_url LIKE ?)`,
       [pr, `%/pull/${pr}`],
     );
     if (rows.length === 0) return undefined;
@@ -257,7 +274,8 @@ export class SqliteWorkflowRepository {
     if (type === 'workflows' || type === 'all') {
       const workflows = this.exec.queryAll(
         `SELECT id, name, description, plan_file, repo_url, branch, created_at FROM workflows 
-         WHERE name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ? 
+         WHERE deleted_at IS NULL
+           AND (name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{ id: string; name?: string | null; created_at: string }>;
@@ -281,8 +299,10 @@ export class SqliteWorkflowRepository {
     
     if (type === 'tasks' || type === 'all') {
       const tasks = this.exec.queryAll(
-        `SELECT id, workflow_id, description, command, prompt, summary, problem, approach, test_plan, repro_command, status, created_at FROM tasks 
-         WHERE description LIKE ? OR command LIKE ? OR prompt LIKE ? OR summary LIKE ? OR problem LIKE ? OR approach LIKE ? OR test_plan LIKE ? OR repro_command LIKE ? 
+        `SELECT t.id, t.workflow_id, t.description, t.command, t.prompt, t.summary, t.problem, t.approach, t.test_plan, t.repro_command, t.status, t.created_at FROM tasks t
+         JOIN workflows w ON w.id = t.workflow_id
+         WHERE w.deleted_at IS NULL
+           AND (t.description LIKE ? OR t.command LIKE ? OR t.prompt LIKE ? OR t.summary LIKE ? OR t.problem LIKE ? OR t.approach LIKE ? OR t.test_plan LIKE ? OR t.repro_command LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{
@@ -298,7 +318,7 @@ export class SqliteWorkflowRepository {
       if (workflowIds.length > 0) {
         const placeholders = workflowIds.map(() => '?').join(',');
         const workflowRows = this.exec.queryAll(
-          `SELECT id, name FROM workflows WHERE id IN (${placeholders})`,
+          `SELECT id, name FROM workflows WHERE deleted_at IS NULL AND id IN (${placeholders})`,
           workflowIds
         ) as Array<{ id: string; name?: string | null }>;
         for (const wf of workflowRows) {
@@ -326,10 +346,18 @@ export class SqliteWorkflowRepository {
   loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
     const totalStartedAt = Date.now();
     const workflowQueryStartedAt = Date.now();
-    const workflowRows = this.exec.queryAll('SELECT * FROM workflows ORDER BY created_at DESC');
+    const workflowRows = this.exec.queryAll(
+      'SELECT * FROM workflows WHERE deleted_at IS NULL ORDER BY created_at DESC',
+    );
     const workflowMetadataQueryMs = Date.now() - workflowQueryStartedAt;
     const taskQueryStartedAt = Date.now();
-    const taskRows = this.exec.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC');
+    const taskRows = this.exec.queryAll(
+      `SELECT t.*
+         FROM tasks t
+         JOIN workflows w ON w.id = t.workflow_id
+        WHERE w.deleted_at IS NULL
+        ORDER BY t.workflow_id ASC, t.id ASC`,
+    );
     const taskQueryMs = Date.now() - taskQueryStartedAt;
     const tasksByWorkflowId = new Map<string, TaskState[]>();
     const workflowIds = workflowRows.map((row) => String(row.id));
@@ -465,5 +493,21 @@ export class SqliteWorkflowRepository {
 
   private rowToWorkflow(row: Record<string, unknown>, rollup?: WorkflowRollup): Workflow {
     return mapRowToWorkflow(row, rollup);
+  }
+
+  private appendWorkflowJournalEntry(
+    workflowId: string,
+    op: 'upsert' | 'tombstone',
+  ): void {
+    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+    if (!row) {
+      throw new Error(`Cannot journal missing workflow row: ${workflowId}`);
+    }
+    appendJournalEntry(this.exec, {
+      entityType: 'workflow',
+      entityId: workflowId,
+      op,
+      payload: row,
+    });
   }
 }

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -1,0 +1,179 @@
+import type { SqliteExecutor } from './sqlite-executor.js';
+
+export const SYNC_JOURNAL_ENTITY_TYPES = [
+  'workflow',
+  'task',
+  'attempt',
+  'event',
+  // Reserved for output synchronization. High-volume output_spool writes are
+  // intentionally not journaled until batching/compaction semantics exist.
+  'output',
+] as const;
+
+export type SyncJournalEntityType = (typeof SYNC_JOURNAL_ENTITY_TYPES)[number];
+export type SyncJournalOperation = 'upsert' | 'tombstone';
+
+export interface SyncJournalEntryInput {
+  entityType: SyncJournalEntityType;
+  entityId: string;
+  op: SyncJournalOperation;
+  payload: unknown;
+  origin?: string;
+  createdAt?: number;
+}
+
+export interface SyncJournalEntry {
+  seq: number;
+  entityType: SyncJournalEntityType;
+  entityId: string;
+  op: SyncJournalOperation;
+  payload: unknown;
+  origin: string;
+  createdAt: number;
+}
+
+export interface SyncCursor {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt: number;
+}
+
+const ENTITY_TYPES = new Set<string>(SYNC_JOURNAL_ENTITY_TYPES);
+const OPERATIONS = new Set<string>(['upsert', 'tombstone']);
+
+function assertEntityType(value: string): asserts value is SyncJournalEntityType {
+  if (!ENTITY_TYPES.has(value)) {
+    throw new Error(`Invalid sync journal entity_type: ${value}`);
+  }
+}
+
+function assertOperation(value: string): asserts value is SyncJournalOperation {
+  if (!OPERATIONS.has(value)) {
+    throw new Error(`Invalid sync journal op: ${value}`);
+  }
+}
+
+function normalizeSeq(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function normalizeLimit(value: number): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error('limit must be a positive integer');
+  }
+  return value;
+}
+
+export function appendJournalEntry(db: SqliteExecutor, entry: SyncJournalEntryInput): number {
+  assertEntityType(entry.entityType);
+  assertOperation(entry.op);
+  if (!entry.entityId) {
+    throw new Error('sync journal entityId is required');
+  }
+  const origin = entry.origin ?? 'home';
+  if (!origin) {
+    throw new Error('sync journal origin is required');
+  }
+  const payload = JSON.stringify(entry.payload);
+  if (payload === undefined) {
+    throw new Error('sync journal payload must be JSON-serializable');
+  }
+  const createdAt = entry.createdAt ?? Date.now();
+  normalizeSeq(createdAt, 'createdAt');
+
+  db.execRun(
+    `INSERT INTO sync_journal (
+      entity_type, entity_id, op, payload, origin, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?)`,
+    [entry.entityType, entry.entityId, entry.op, payload, origin, createdAt],
+  );
+  const row = db.queryOne('SELECT last_insert_rowid() AS seq');
+  return Number(row?.seq ?? 0);
+}
+
+export function readJournalSince(
+  db: SqliteExecutor,
+  seq: number,
+  limit: number,
+): SyncJournalEntry[] {
+  const cursor = normalizeSeq(seq, 'seq');
+  const cappedLimit = normalizeLimit(limit);
+  const rows = db.queryAll(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq > ?
+      ORDER BY seq ASC
+      LIMIT ?`,
+    [cursor, cappedLimit],
+  );
+
+  return rows.map((row) => {
+    const entityType = String(row.entity_type ?? '');
+    const op = String(row.op ?? '');
+    assertEntityType(entityType);
+    assertOperation(op);
+    return {
+      seq: Number(row.seq),
+      entityType,
+      entityId: String(row.entity_id),
+      op,
+      payload: JSON.parse(String(row.payload)),
+      origin: String(row.origin),
+      createdAt: Number(row.created_at),
+    };
+  });
+}
+
+export function getSyncCursor(db: SqliteExecutor, peerId: string): SyncCursor | undefined {
+  if (!peerId) {
+    throw new Error('peerId is required');
+  }
+  const row = db.queryOne(
+    `SELECT peer_id, last_sent_seq, last_received_seq, updated_at
+       FROM sync_cursors
+      WHERE peer_id = ?`,
+    [peerId],
+  );
+  if (!row) return undefined;
+  return {
+    peerId: String(row.peer_id),
+    lastSentSeq: Number(row.last_sent_seq),
+    lastReceivedSeq: Number(row.last_received_seq),
+    updatedAt: Number(row.updated_at),
+  };
+}
+
+export function setSyncCursor(
+  db: SqliteExecutor,
+  cursor: Pick<SyncCursor, 'peerId' | 'lastSentSeq' | 'lastReceivedSeq'> & Partial<Pick<SyncCursor, 'updatedAt'>>,
+): SyncCursor {
+  if (!cursor.peerId) {
+    throw new Error('peerId is required');
+  }
+  const lastSentSeq = normalizeSeq(cursor.lastSentSeq, 'lastSentSeq');
+  const lastReceivedSeq = normalizeSeq(cursor.lastReceivedSeq, 'lastReceivedSeq');
+  const updatedAt = cursor.updatedAt ?? Date.now();
+  normalizeSeq(updatedAt, 'updatedAt');
+
+  db.execRun(
+    `INSERT INTO sync_cursors (
+      peer_id, last_sent_seq, last_received_seq, updated_at
+    ) VALUES (?, ?, ?, ?)
+    ON CONFLICT(peer_id) DO UPDATE SET
+      last_sent_seq = excluded.last_sent_seq,
+      last_received_seq = excluded.last_received_seq,
+      updated_at = excluded.updated_at`,
+    [cursor.peerId, lastSentSeq, lastReceivedSeq, updatedAt],
+  );
+
+  return {
+    peerId: cursor.peerId,
+    lastSentSeq,
+    lastReceivedSeq,
+    updatedAt,
+  };
+}


### PR DESCRIPTION
## Summary

Remote Sync Step 1: Sync Schema and Change Journal — 2 tasks completed, 0 failed, 0 closed, 0 sk&#105;pped

Adds sync journal and cursor tables, workflow tombstones, and journal helpers for future remote sync.

Journal rows are appended in the same SQLite transactions as workflow, task, and attempt mutations.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926077035-3/implement-sync-schema | Add sync journal, cursor, and tombstone schema to data-store | completed |
| wf-1784926077035-3/verify-sync-schema | Run data-store package tests covering the new schema and journal | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784926077035-3/implement-sync-schema — Add sync journal, cursor, and tombstone schema to data-store

### wf-1784926077035-3/verify-sync-schema — Run data-store package tests covering the new schema and journal

</details>

## Review Claim

Approve the data-store sync contract for journaling workflow, task, and attempt mutations with cursors and workflow tombstones.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Journal rows are appended inside the existing SQLite transaction, so rollback removes both entity rows and sync evidence.

## Slice Rationale

This is the foundation slice for remote sync. It adds durable local sync records before any transport or peer reconciliation code consumes them.

## Non-goals

- No remote transport.
- No peer reconciliation.
- No UI changes.
- No output spool replication.

## Architecture

### Before

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["Entity table rows"]
    C["Workflow removal request"] --> D["Workflow row removed"]
```

### After

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["Entity table rows"]
    A --> C["sync_journal upsert rows"]
    D["Workflow removal request"] --> E["Workflow tombstone state"]
    D --> F["sync_journal tombstone row"]
    G["Peer replication checkpoint"] --> H["sync_cursors row"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile --ignore-scripts`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sync-journal.test.ts` (25 files, 436 tests passed)
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-bodies/remote-sync-step-1-g36.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-bodies/remote-sync-step-1-g36.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 0c40ebefb`
- Post-revert steps: Rerun `pnpm --filter @invoker/data-store test -- src/__tests__/sync-journal.test.ts`.
- Data migration? Yes. Existing local databases may retain unused sync tables and the workflow tombstone column after code revert.

</details>
