### PR TITLE
[Continue babysit worker landing loop](10) Stop retrying human-blocked stack repairs

### DIFF
--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -269,8 +269,6 @@ def latest_queue_only_noop_check(stack: StackGroup, ledger: Ledger, trunk: str) 
 
 
 def latest_repair_invalid_blocker(pr: PrSnapshot, blocker: Blocker, ledger: Ledger) -> Blocker | None:
-    if blocker.kind != "failed_check":
-        return None
     latest = ledger.latest("repair-invalid", pr.number, pr.head_ref_oid, blocker.key)
     if latest is None:
         return None
@@ -482,10 +480,14 @@ def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
     )
 
 
+def _pr_has_human_decision(facts: StackFacts, pr_number: int) -> bool:
+    return any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr_number])
+
+
 def plan_mergify_queue_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     del max_repair_attempts
     for pr in facts.stack.prs:
-        if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
+        if _pr_has_human_decision(facts, pr.number):
             continue
         if facts.upper_stack_needs_acceptance and facts.bottom and pr.number == facts.bottom.number:
             continue
@@ -497,6 +499,8 @@ def plan_mergify_queue_repairs(facts: StackFacts, ledger: Ledger, max_repair_att
 
 def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     for pr in facts.stack.prs:
+        if _pr_has_human_decision(facts, pr.number):
+            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "conflict":
                 key = f"conflict:{pr.number}"
@@ -513,6 +517,8 @@ def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: 
 
 def plan_bot_thread_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     for pr in facts.stack.prs:
+        if _pr_has_human_decision(facts, pr.number):
+            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "outdated_bot_review_thread":
                 return Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail)
@@ -528,6 +534,8 @@ def plan_bot_thread_repairs(facts: StackFacts, ledger: Ledger, max_repair_attemp
 
 def plan_hard_blockers(facts: StackFacts, ledger: Ledger) -> Action | None:
     for pr in facts.stack.prs:
+        if _pr_has_human_decision(facts, pr.number):
+            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "pending_check":
                 return None

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -488,9 +488,53 @@ Failing checks
     def test_plan_stack_actions_stop_retrying_after_repair_invalid(self):
         ledger = self.ledger()
         ledger.record("repair-invalid", 2606, HEAD, "PR Body", 1, meta={"errors": ["human stack split required"]})
-        stack = StackGroup("s", (pr(2606, labels={"admin-bypass"}, checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}),))
+        stack = StackGroup(
+            "s",
+            (pr(
+                2606,
+                labels={"admin-bypass"},
+                checks={
+                    "PR Body": check("PR Body", "failure"),
+                    "quality / TypeScript Types": check("quality / TypeScript Types"),
+                },
+            ),),
+        )
         actions = plan_stack_actions(stack, REQUIRED, ledger, 2)
         self.assertEqual(actions, ())
+
+    def test_repair_invalid_stops_other_repairs_on_same_pr_head(self):
+        ledger = self.ledger()
+        ledger.record("repair-invalid", 6163, HEAD, "UI Vitest", 1, meta={"errors": ["manual split required"]})
+        checks = {
+            "UI Vitest": check("UI Vitest", "failure"),
+            "quality / TypeScript Types": check("quality / TypeScript Types", "failure"),
+        }
+        stack = StackGroup("s", (pr(6163, labels={"admin-bypass"}, checks=checks),))
+        actions = plan_stack_actions(stack, REQUIRED | {"UI Vitest"}, ledger, 2)
+        self.assertEqual(actions, ())
+
+    def test_bot_thread_repair_invalid_stops_retrying_thread_repair(self):
+        ledger = self.ledger()
+        ledger.record("repair-bot-thread", 6158, HEAD, "PRRT_kwDOSFkSDM6T97v9", 1)
+        ledger.record(
+            "repair-invalid",
+            6158,
+            HEAD,
+            "PRRT_kwDOSFkSDM6T97v9",
+            1,
+            meta={"errors": ["PR body Review Unit must be split"]},
+        )
+        stack = StackGroup(
+            "s",
+            (pr(
+                6158,
+                threads=(ReviewThread("PRRT_kwDOSFkSDM6T97v9", False, ("coderabbitai[bot]",)),),
+                latest=mergify(),
+            ),),
+        )
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 2)
+        self.assertEqual(actions, ())
+
     def test_queue_only_repair_uses_mergify_job_log_and_returns_noop(self):
         stderr = io.StringIO()
         latest = MergifyQueueEvent(


### PR DESCRIPTION
## Summary

The babysit worker could keep planning other repairs for a PR after a repair-invalid entry already proved that same head needs a human decision.

Now the planner treats that recorded human decision as terminal for direct, queue, bot-thread, and hard-blocker repair paths.

That keeps the worker stopped on the exact human-only reason it already surfaced.

## Review Claim

Approve that a repair-invalid human decision suppresses every other repair path for the same PR head.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change only narrows repair planning after a same-head human decision exists; PR selection, queue labels, merge actions, and branch mutation remain unchanged.

## Slice Rationale

This slice carries the planner rule and focused unit coverage. The fake-GitHub repro is separate so policy behavior and proof harness stay reviewable independently.

## Non-goals

Does not manually requeue, relabel, merge, split, rebase, or force-push real PR branches.

Does not change retries for worker-owned failures that do not already have a same-head human decision.

## Architecture

### Before

```mermaid
graph TD
    A["repair-invalid recorded for PR head"] --> B["planner scans later blockers on the same PR"]
    B --> C["worker may schedule another repair"]
```

### After

```mermaid
graph TD
    A["repair-invalid recorded for PR head"] --> B["planner marks that PR as having a human decision"]
    B --> C["direct, queue, bot-thread, and hard-blocker repair paths skip that PR"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -m unittest scripts/test_mergify_admin_requeue.py`
- [ ] `bash ./loop-driver.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert be17a5b7b`
- Post-revert steps: None
- Data migration? No

</details>
