### PR TITLE
[Bugfix: truthful planning draft readiness](1) Keep planner submit text draft-backed

### DIFF
--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -40,6 +40,8 @@ tasks:
     dependencies: []
 `;
 
+const SUBMIT_REPLY_LINE = 'Reply `submit` to submit it.';
+
 const INLINE_PLAN_RESPONSE = `Here is the plan:
 
 \`\`\`yaml
@@ -52,7 +54,7 @@ tasks:
     dependencies: []
 \`\`\`
 
-Reply \`submit\` to submit it.`;
+${SUBMIT_REPLY_LINE}`;
 
 describe('plan draft file - activation side', () => {
   let workingDir: string;
@@ -92,24 +94,30 @@ describe('plan draft file - activation side', () => {
     if (!path) throw new Error('expected a plan draft path');
 
     mockSpawn.mockReturnValueOnce(fakePlannerChild(
-      'Drafted the plan.\n\nReply `submit` to submit it.',
+      `Drafted the plan.\n\n${SUBMIT_REPLY_LINE}`,
       () => writeFileSync(path, VALID_PLAN_YAML, 'utf8'),
     ));
-    await conversation.sendMessage('Draft it');
+    const firstReply = await conversation.sendMessage('Draft it');
+    expect(firstReply).toContain(SUBMIT_REPLY_LINE);
 
-    mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the plan. Summary: one step.'));
-    await conversation.sendMessage('What does it do?');
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(`Drafted the plan. Summary: one step.\n\n${SUBMIT_REPLY_LINE}`));
+    const followUpReply = await conversation.sendMessage('What does it do?');
 
     expect(existsSync(path)).toBe(false);
+    expect(followUpReply).toBe('Drafted the plan. Summary: one step.');
+    expect(conversation.history[conversation.history.length - 1]?.content).toBe(followUpReply);
     expect(conversation.getDraftedPlan()).toBe(VALID_PLAN_YAML.trim());
   });
 
   it('does not expose a plan when a summary-only turn has no prior draft', async () => {
     const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', plannerRetryLimit: 0 });
 
-    mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the plan. Summary: one step.'));
-    await conversation.sendMessage('Draft it');
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(`Drafted the plan. Summary: one step.\n\n${SUBMIT_REPLY_LINE}`));
+    const reply = await conversation.sendMessage('Draft it');
 
+    expect(reply).toBe('Drafted the plan. Summary: one step.');
+    expect(conversation.history[conversation.history.length - 1]?.content).toBe(reply);
+    expect(reply).not.toContain(SUBMIT_REPLY_LINE);
     expect(conversation.getDraftedPlan()).toBeNull();
   });
 
@@ -119,7 +127,7 @@ describe('plan draft file - activation side', () => {
 
     const prompt = conversation.buildCursorPrompt();
 
-    expect(prompt).not.toContain('Reply `submit` to submit it.');
+    expect(prompt).not.toContain(SUBMIT_REPLY_LINE);
     expect(prompt).toContain('wait for approval before any submission step');
     expect(prompt).toContain('Do not tell the user to reply `submit`');
   });
@@ -130,11 +138,12 @@ describe('plan draft file - activation side', () => {
     if (!path) throw new Error('expected a plan draft path');
 
     mockSpawn.mockReturnValueOnce(fakePlannerChild(
-      'Drafted the plan.\n\nReply `submit` to submit it.',
+      `Drafted the plan.\n\n${SUBMIT_REPLY_LINE}`,
       () => writeFileSync(path, VALID_PLAN_YAML, 'utf8'),
     ));
-    await conversation.sendMessage('Create the plan');
+    const reply = await conversation.sendMessage('Create the plan');
 
+    expect(reply).toContain(SUBMIT_REPLY_LINE);
     expect(isConfirmation('submit')).toBe(true);
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     expect(conversation.planSubmitted).toBe(false);
@@ -184,7 +193,7 @@ describe('plan draft-file activation prompt policy', () => {
     expect(prompt).toContain('explain like the user is five');
     expect(prompt).not.toContain('name: "Plan Name"');
     expect(prompt).not.toContain('When ready, output the plan inside a ```yaml code block');
-    expect(prompt).not.toContain('Reply `submit` to submit it.');
+    expect(prompt).not.toContain(SUBMIT_REPLY_LINE);
   });
 
   it('restores YAML drafting instructions after conversational authorization', () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -411,6 +411,14 @@ export function isDangerousCommand(cmd: string): boolean {
 // ── Constants ───────────────────────────────────────────────
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const SUBMIT_INSTRUCTION_LINE = 'Reply `submit` to submit it.';
+
+function removeStandaloneSubmitInstruction(message: string): string {
+  const lines = message.split(/\r?\n/);
+  const filtered = lines.filter((line) => line.trim() !== SUBMIT_INSTRUCTION_LINE);
+  if (filtered.length === lines.length) return message;
+  return filtered.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd();
+}
 
 // ── PlanConversation ────────────────────────────────────────
 
@@ -548,6 +556,9 @@ export class PlanConversation {
       : inlineDraft;
     this._lastTurnDraftPlanText = nextDraft;
     if (nextDraft) this.lastKnownGoodPlanText = nextDraft;
+    if (!nextDraft) {
+      message = removeStandaloneSubmitInstruction(message);
+    }
     this._lastTurnReasoning = formatted.reasoning;
     this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: responseLen=${response.length}, messageLen=${message.length}, reasoningParts=${formatted.reasoning.length}, responsePreview="${message.slice(0, 500).replace(/\n/g, '\\n')}"`);
 


### PR DESCRIPTION
## Summary

Planning replies now append the confirmation instruction only when this turn produced a real draft.

Question-only turns keep the conversation open without advertising a draft that cannot be handed off.

## Review Claim

The standalone confirmation instruction appears only when the current turn creates a draft.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This only changes Slack planning reply formatting and the directly affected regression coverage; valid draft replies keep the same ready path.

## Slice Rationale

The misleading user-facing instruction is created with the assistant reply, so this slice fixes that surface before lower layers change.

## Non-goals

- No in-app approval precondition changes.
- No terminal command behavior changes.
- No model or harness changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/plan-draft-file-activation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert e249340d4`
- Post-revert steps: Rerun the focused surfaces regression.
- Data migration? No.

</details>
