### PR TITLE
[Bugfix: truthful planning draft readiness](3) Gate terminal confirmation command

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -16,6 +16,7 @@ import {
   setPlanningChatTerminalMode,
   submitPlanningChatDraft,
   updatePlanningChatTerminalState,
+  type InAppPlanningChatSession,
   type LoadedGeneratedPlan,
 } from '../in-app-planner.js';
 import { ConversationRepository, SQLiteAdapter, type InAppPlanningSessionRecord } from '@invoker/data-store';
@@ -45,6 +46,24 @@ tasks:
     description: Second task
     dependencies: [first]
     command: echo second`;
+
+const NO_COMPLETE_PLAN_DRAFTED_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
+
+function planningSession(
+  overrides: Partial<InAppPlanningChatSession> & Pick<InAppPlanningChatSession, 'id' | 'title'>,
+): InAppPlanningChatSession {
+  return {
+    presetKey: 'codex',
+    confirmationMode: 'require',
+    status: 'still_discussing',
+    messages: [],
+    conversation: new PlanConversation({}),
+    createdAt: '2026-07-07T00:00:00.000Z',
+    updatedAt: '2026-07-07T00:00:00.000Z',
+    nextMessageId: 1,
+    ...overrides,
+  };
+}
 
 const VALID_PLAN_WITHOUT_CLOSING_FENCE = `Here is the plan.
 
@@ -353,7 +372,7 @@ describe('planning chat', () => {
     }, {
       sessions,
       loadGeneratedPlan,
-    })).resolves.toMatchObject({ ok: false });
+    })).resolves.toEqual({ ok: false, error: NO_COMPLETE_PLAN_DRAFTED_ERROR });
     expect(loadGeneratedPlan).not.toHaveBeenCalled();
   });
 
@@ -416,9 +435,9 @@ describe('planning chat', () => {
       await expect(submitPlanningChatDraft({ sessionId: session.id }, {
         sessions,
         loadGeneratedPlan,
-    })).resolves.toMatchObject({ ok: false });
-    expect(loadGeneratedPlan).not.toHaveBeenCalled();
-    expect(sessions.get(session.id)?.draftPlanText).toBeUndefined();
+      })).resolves.toEqual({ ok: false, error: NO_COMPLETE_PLAN_DRAFTED_ERROR });
+      expect(loadGeneratedPlan).not.toHaveBeenCalled();
+      expect(sessions.get(session.id)?.draftPlanText).toBeUndefined();
     } finally {
       rmSync(workingDir, { recursive: true, force: true });
     }
@@ -443,7 +462,7 @@ describe('planning chat', () => {
     await expect(submitPlanningChatDraft({ sessionId: result.sessionId }, {
       sessions,
       loadGeneratedPlan,
-    })).resolves.toMatchObject({ ok: false });
+    })).resolves.toEqual({ ok: false, error: NO_COMPLETE_PLAN_DRAFTED_ERROR });
     expect(loadGeneratedPlan).not.toHaveBeenCalled();
   });
 
@@ -538,6 +557,7 @@ describe('planning chat', () => {
       planningCommandBuilder,
     });
     if (!sent.ok) throw new Error(sent.error);
+    expect(sessions.get(sent.sessionId)?.status).toBe('draft_ready');
     const loadGeneratedPlan = vi.fn().mockResolvedValue({
       planName: 'Mock Plan',
       workflowId: 'wf-1',
@@ -757,7 +777,53 @@ tasks:
     }, {
       sessions,
       loadGeneratedPlan: vi.fn(),
-    })).resolves.toEqual({ ok: false, error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.' });
+    })).resolves.toEqual({ ok: false, error: NO_COMPLETE_PLAN_DRAFTED_ERROR });
+  });
+
+  it('rejects submit when a saved draft snapshot is not draft-ready', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('not-ready-with-draft', planningSession({
+      id: 'not-ready-with-draft',
+      title: 'Not ready with draft',
+      status: 'still_discussing',
+      draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+      draftPlanText: VALID_PLAN_TEXT,
+    }));
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+    } satisfies LoadedGeneratedPlan);
+
+    await expect(submitPlanningChatDraft({
+      sessionId: 'not-ready-with-draft',
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: NO_COMPLETE_PLAN_DRAFTED_ERROR });
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
+  it('rejects submit when draft-ready state has empty draft text', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('empty-draft-ready', planningSession({
+      id: 'empty-draft-ready',
+      title: 'Empty draft ready',
+      status: 'draft_ready',
+      draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+      draftPlanText: '   ',
+    }));
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+    } satisfies LoadedGeneratedPlan);
+
+    await expect(submitPlanningChatDraft({
+      sessionId: 'empty-draft-ready',
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: NO_COMPLETE_PLAN_DRAFTED_ERROR });
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
   });
 
   it('rejects submit when the draft summary cannot be read', async () => {

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -241,6 +241,8 @@ function hasDraftPlan(session: Pick<InAppPlanningChatSession, 'draftPlanSummary'
   return Boolean(session.draftPlanText || session.draftPlanSummary);
 }
 
+const NO_COMPLETE_PLAN_DRAFTED_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
+
 function sessionToRecord(session: InAppPlanningChatSession, pendingResponse: boolean): InAppPlanningSessionRecord {
   return {
     id: session.id,
@@ -703,6 +705,9 @@ export async function submitPlanningChatDraft(
   }
   if (session.pendingSubmit) {
     return session.pendingSubmit;
+  }
+  if (session.status !== 'draft_ready' || !session.draftPlanText?.trim()) {
+    return { ok: false, error: NO_COMPLETE_PLAN_DRAFTED_ERROR };
   }
 
   const submitAttempt = (async (): Promise<InAppPlanningSubmitResponse> => {

--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -40,6 +40,8 @@ tasks:
     dependencies: []
 `;
 
+const SUBMIT_REPLY_LINE = 'Reply `submit` to submit it.';
+
 const INLINE_PLAN_RESPONSE = `Here is the plan:
 
 \`\`\`yaml
@@ -52,7 +54,7 @@ tasks:
     dependencies: []
 \`\`\`
 
-Reply \`submit\` to submit it.`;
+${SUBMIT_REPLY_LINE}`;
 
 describe('plan draft file - activation side', () => {
   let workingDir: string;
@@ -92,24 +94,30 @@ describe('plan draft file - activation side', () => {
     if (!path) throw new Error('expected a plan draft path');
 
     mockSpawn.mockReturnValueOnce(fakePlannerChild(
-      'Drafted the plan.\n\nReply `submit` to submit it.',
+      `Drafted the plan.\n\n${SUBMIT_REPLY_LINE}`,
       () => writeFileSync(path, VALID_PLAN_YAML, 'utf8'),
     ));
-    await conversation.sendMessage('Draft it');
+    const firstReply = await conversation.sendMessage('Draft it');
+    expect(firstReply).toContain(SUBMIT_REPLY_LINE);
 
-    mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the plan. Summary: one step.'));
-    await conversation.sendMessage('What does it do?');
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(`Drafted the plan. Summary: one step.\n\n${SUBMIT_REPLY_LINE}`));
+    const followUpReply = await conversation.sendMessage('What does it do?');
 
     expect(existsSync(path)).toBe(false);
+    expect(followUpReply).toBe('Drafted the plan. Summary: one step.');
+    expect(conversation.history[conversation.history.length - 1]?.content).toBe(followUpReply);
     expect(conversation.getDraftedPlan()).toBe(VALID_PLAN_YAML.trim());
   });
 
   it('does not expose a plan when a summary-only turn has no prior draft', async () => {
     const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', plannerRetryLimit: 0 });
 
-    mockSpawn.mockReturnValueOnce(fakePlannerChild('Drafted the plan. Summary: one step.'));
-    await conversation.sendMessage('Draft it');
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(`Drafted the plan. Summary: one step.\n\n${SUBMIT_REPLY_LINE}`));
+    const reply = await conversation.sendMessage('Draft it');
 
+    expect(reply).toBe('Drafted the plan. Summary: one step.');
+    expect(conversation.history[conversation.history.length - 1]?.content).toBe(reply);
+    expect(reply).not.toContain(SUBMIT_REPLY_LINE);
     expect(conversation.getDraftedPlan()).toBeNull();
   });
 
@@ -119,7 +127,7 @@ describe('plan draft file - activation side', () => {
 
     const prompt = conversation.buildCursorPrompt();
 
-    expect(prompt).not.toContain('Reply `submit` to submit it.');
+    expect(prompt).not.toContain(SUBMIT_REPLY_LINE);
     expect(prompt).toContain('wait for approval before any submission step');
     expect(prompt).toContain('Do not tell the user to reply `submit`');
   });
@@ -130,11 +138,12 @@ describe('plan draft file - activation side', () => {
     if (!path) throw new Error('expected a plan draft path');
 
     mockSpawn.mockReturnValueOnce(fakePlannerChild(
-      'Drafted the plan.\n\nReply `submit` to submit it.',
+      `Drafted the plan.\n\n${SUBMIT_REPLY_LINE}`,
       () => writeFileSync(path, VALID_PLAN_YAML, 'utf8'),
     ));
-    await conversation.sendMessage('Create the plan');
+    const reply = await conversation.sendMessage('Create the plan');
 
+    expect(reply).toContain(SUBMIT_REPLY_LINE);
     expect(isConfirmation('submit')).toBe(true);
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     expect(conversation.planSubmitted).toBe(false);
@@ -184,7 +193,7 @@ describe('plan draft-file activation prompt policy', () => {
     expect(prompt).toContain('explain like the user is five');
     expect(prompt).not.toContain('name: "Plan Name"');
     expect(prompt).not.toContain('When ready, output the plan inside a ```yaml code block');
-    expect(prompt).not.toContain('Reply `submit` to submit it.');
+    expect(prompt).not.toContain(SUBMIT_REPLY_LINE);
   });
 
   it('restores YAML drafting instructions after conversational authorization', () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -411,6 +411,14 @@ export function isDangerousCommand(cmd: string): boolean {
 // ── Constants ───────────────────────────────────────────────
 
 const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const SUBMIT_INSTRUCTION_LINE = 'Reply `submit` to submit it.';
+
+function removeStandaloneSubmitInstruction(message: string): string {
+  const lines = message.split(/\r?\n/);
+  const filtered = lines.filter((line) => line.trim() !== SUBMIT_INSTRUCTION_LINE);
+  if (filtered.length === lines.length) return message;
+  return filtered.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd();
+}
 
 // ── PlanConversation ────────────────────────────────────────
 
@@ -548,6 +556,9 @@ export class PlanConversation {
       : inlineDraft;
     this._lastTurnDraftPlanText = nextDraft;
     if (nextDraft) this.lastKnownGoodPlanText = nextDraft;
+    if (!nextDraft) {
+      message = removeStandaloneSubmitInstruction(message);
+    }
     this._lastTurnReasoning = formatted.reasoning;
     this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: responseLen=${response.length}, messageLen=${message.length}, reasoningParts=${formatted.reasoning.length}, responsePreview="${message.slice(0, 500).replace(/\n/g, '\\n')}"`);
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2874,7 +2874,9 @@ export function App() {
     }
 
     if (/^submit(\s+to\s+invoker)?[.!?]*$/i.test(input)) {
-      await handlePlanningSubmitDraft();
+      if (activePlanningSession.draftPlanAvailable || activePlanningSession.status === 'draft_ready') {
+        await handlePlanningSubmitDraft();
+      }
       return;
     }
 
@@ -2971,6 +2973,8 @@ export function App() {
     hasLoadedPlan,
     keepPlanningStreamFailureForSessionIds,
     invoker,
+    activePlanningSession.draftPlanAvailable,
+    activePlanningSession.status,
     planningInput,
     planningSessionId,
     selectedPlanningConfirmationMode,

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -703,6 +703,49 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
+  it('does not submit or send typed submit before a draft is ready', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'session-1',
+          title: 'No draft chat',
+          status: 'still_discussing',
+          messages: [
+            {
+              id: 1,
+              role: 'user',
+              text: 'I need a plan.',
+              createdAt: '2026-07-07T00:00:01.000Z',
+            },
+            {
+              id: 2,
+              role: 'assistant',
+              text: 'What should the plan include?',
+              createdAt: '2026-07-07T00:00:02.000Z',
+            },
+          ],
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('What should the plan include?');
+    });
+
+    submitPlanningText('submit');
+
+    expect(mock.api.planningChatSubmit).not.toHaveBeenCalled();
+    expect(mock.api.planningChatSend).not.toHaveBeenCalled();
+    expect(mock.api.startReady).not.toHaveBeenCalled();
+  });
+
   it('submits a draft and starts ready work when the user types submit', async () => {
     mock.api.planningChatSend = vi.fn(async () => ({
       ok: true,


### PR DESCRIPTION
## Summary

The terminal confirmation command now checks active draft state before it invokes planning-chat approval.

No-draft conversations keep their transcript instead of reaching the approval API.

## Review Claim

The terminal confirmation command only invokes planning-chat approval when the active session has ready draft state.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This stays in terminal command handling and the focused terminal regression; the existing draft-ready path keeps the same call flow.

## Slice Rationale

This slice covers the typed terminal affordance, separate from backend preconditions and planner reply text.

## Non-goals

- No Slack reply text changes.
- No in-app approval guard changes.
- No workflow creation or ready-work behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx`
- [x] Captured `/tmp/pr-proof-terminal-submit-gate.png` with Playwright against the local Vite UI and asserted zero planning-chat approval, send, or ready-work API calls.

</details>

## Visual Proof

![No-draft terminal confirmation stays in the transcript without approval output](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-9490af/pr-proof-terminal-submit-gate.png)

The screenshot shows typed `submit` in a no-draft planning chat with no submitted-plan output. The regression asserts the planning-chat approval, send, and ready-work APIs were not called.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 345f1cb0a`
- Post-revert steps: Rerun the focused UI regression.
- Data migration? No.

</details>
