### PR TITLE
[Start Ready recreate+rebase expansion](6) Keep fresh-base delegation scoped

### DIFF
--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -100,6 +100,8 @@ describe('headless→owner delegation', () => {
       ['failed fresh-base', ['--fresh-base-failed']],
       ['failed and pending fresh-base', ['--fresh-base-failed-and-pending']],
       ['failed, pending, and running fresh-base', ['--fresh-base-failed-pending-and-running']],
+      ['all fresh-base', ['--fresh-base-all']],
+      ['fresh-base with recreate-all present', ['--recreate-all', '--fresh-base-failed']],
     ])('uses 60s timeout for global start-ready %s scope', async (_label, flags) => {
       const args = ['start-ready', ...flags];
 
@@ -307,6 +309,11 @@ describe('headless→owner delegation', () => {
       ['rebase-retry', ['rebase-retry', 'wf-1']],
       ['rebase-recreate', ['rebase-recreate', 'wf-1']],
       ['restart workflow', ['restart', 'wf-123']],
+      ['start-ready fresh-base failed', ['start-ready', '--fresh-base-failed']],
+      ['start-ready fresh-base failed and pending', ['start-ready', '--fresh-base-failed-and-pending']],
+      ['start-ready fresh-base failed, pending, and running', ['start-ready', '--fresh-base-failed-pending-and-running']],
+      ['start-ready fresh-base all', ['start-ready', '--fresh-base-all']],
+      ['start-ready fresh-base with recreate-all present', ['start-ready', '--recreate-all', '--fresh-base-failed']],
     ])('keeps %s pending at 5s and only times out at 60s', async (_label, args) => {
       const delegatedPromise = tryDelegateExec(
         args,

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -20,6 +20,12 @@ export const WORKFLOW_DELEGATION_TIMEOUT_MS = 60_000;
 /** start-ready --recreate-all can recreate dozens of workflows inline on the owner. */
 export const START_READY_RECREATE_ALL_DELEGATION_TIMEOUT_MS = 300_000;
 const START_READY_RECREATE_ALL_FLAG = '--recreate-all';
+const START_READY_FRESH_BASE_FLAGS = new Set([
+  '--fresh-base-failed',
+  '--fresh-base-failed-and-pending',
+  '--fresh-base-failed-pending-and-running',
+  '--fresh-base-all',
+]);
 
 // ---------------------------------------------------------------------------
 // DelegationOutcome — typed result union for delegation attempts
@@ -96,9 +102,13 @@ function looksLikeWorkflowId(target: unknown): boolean {
 }
 
 function startReadyDelegationTimeoutMs(args: readonly string[]): number {
-  return args.includes(START_READY_RECREATE_ALL_FLAG)
-    ? START_READY_RECREATE_ALL_DELEGATION_TIMEOUT_MS
-    : WORKFLOW_DELEGATION_TIMEOUT_MS;
+  if (args.some((arg) => START_READY_FRESH_BASE_FLAGS.has(arg))) {
+    return WORKFLOW_DELEGATION_TIMEOUT_MS;
+  }
+  if (args.includes(START_READY_RECREATE_ALL_FLAG)) {
+    return START_READY_RECREATE_ALL_DELEGATION_TIMEOUT_MS;
+  }
+  return WORKFLOW_DELEGATION_TIMEOUT_MS;
 }
 
 export function delegationTimeoutMs(


### PR DESCRIPTION
## Summary

Global Start Ready fresh-base flags now take precedence over the broad recreate-all timeout when both flags appear.

The delegation path also recognizes the fresh-base all scope, so every fresh-base variant stays in the scoped timeout bucket.

## Review Claim

Keep Start Ready fresh-base delegation flags in the scoped owner timeout bucket, including `--fresh-base-all` and mixed recreate-all arguments.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The edit stays inside headless delegation timeout classification and its direct regression file, so review is limited to the owner timeout rule.

## Slice Rationale

This repairs the delegation rule after the headless fresh-base all flag exists, without rebundling the earlier backend or rail exposure slices.

## Non-goals

- No backend Start Ready execution changes.
- No headless help, parsing, or rail UI changes.
- No change to the plain `--recreate-all` timeout.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/owner-delegation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2ab3f9f2b`
- Post-revert steps: Re-run the focused owner delegation regression command.
- Data migration? No

</details>
