### PR TITLE
[Remote Sync Step 1: Sync Schema and Change Journal](1) Add data-store sync schema and journal

### DIFF
--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createAttempt, createTaskState } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { Workflow } from '../adapter.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  readJournalSince,
+  setSyncCursor,
+} from '../sync-journal.js';
+
+describe('sync journal', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function executor() {
+    return (adapter as any).executor;
+  }
+
+  function makeWorkflow(id = 'wf-1'): Workflow {
+    return {
+      id,
+      name: `Workflow ${id}`,
+      status: 'pending',
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+    };
+  }
+
+  it('rolls back journal rows with the enclosing mutation transaction', () => {
+    expect(() => {
+      adapter.runInTransaction(() => {
+        adapter.saveWorkflow(makeWorkflow('wf-rollback'));
+        throw new Error('rollback mutation');
+      });
+    }).toThrow('rollback mutation');
+
+    expect(adapter.listWorkflows({ includeDeleted: true })).toEqual([]);
+    expect(readJournalSince(executor(), 0, 100)).toEqual([]);
+  });
+
+  it('assigns strictly monotonic seq values for adapter-journaled mutations', () => {
+    adapter.saveWorkflow(makeWorkflow('wf-mono'));
+    adapter.saveTask('wf-mono', createTaskState('task-mono', 'Task mono', [], { workflowId: 'wf-mono' }));
+    adapter.updateTask('task-mono', { status: 'running' });
+    const attempt = createAttempt('task-mono', { status: 'running' });
+    adapter.saveAttempt(attempt);
+    adapter.updateAttempt(attempt.id, {
+      status: 'completed',
+      completedAt: new Date('2026-07-27T00:01:00.000Z'),
+      exitCode: 0,
+    });
+
+    const seqs = readJournalSince(executor(), 0, 100).map((entry) => entry.seq);
+    expect(seqs.length).toBeGreaterThanOrEqual(5);
+    for (let i = 1; i < seqs.length; i += 1) {
+      expect(seqs[i]).toBeGreaterThan(seqs[i - 1]);
+    }
+  });
+
+  it('reads journal entries after a cursor and persists peer cursors', () => {
+    const first = appendJournalEntry(executor(), {
+      entityType: 'workflow',
+      entityId: 'wf-cursor-1',
+      op: 'upsert',
+      payload: { id: 'wf-cursor-1' },
+      createdAt: 1000,
+    });
+    const second = appendJournalEntry(executor(), {
+      entityType: 'task',
+      entityId: 'task-cursor-2',
+      op: 'upsert',
+      payload: { id: 'task-cursor-2' },
+      createdAt: 1001,
+    });
+    const third = appendJournalEntry(executor(), {
+      entityType: 'attempt',
+      entityId: 'attempt-cursor-3',
+      op: 'upsert',
+      payload: { id: 'attempt-cursor-3' },
+      createdAt: 1002,
+    });
+
+    const cursor = setSyncCursor(executor(), {
+      peerId: 'peer-a',
+      lastSentSeq: first.seq,
+      lastReceivedSeq: 17,
+      updatedAt: 2000,
+    });
+
+    expect(cursor).toEqual({
+      peerId: 'peer-a',
+      lastSentSeq: first.seq,
+      lastReceivedSeq: 17,
+      updatedAt: 2000,
+    });
+    expect(getSyncCursor(executor(), 'peer-a')).toEqual(cursor);
+    expect(readJournalSince(executor(), cursor.lastSentSeq, 10).map((entry) => entry.seq)).toEqual([
+      second.seq,
+      third.seq,
+    ]);
+  });
+
+  it('excludes soft-deleted workflows by default but includes them on request', () => {
+    adapter.saveWorkflow(makeWorkflow('wf-soft-delete'));
+
+    adapter.deleteWorkflow('wf-soft-delete');
+
+    expect(adapter.listWorkflows()).toEqual([]);
+    expect(adapter.loadWorkflow('wf-soft-delete')).toBeUndefined();
+    const deleted = adapter.listWorkflows({ includeDeleted: true });
+    expect(deleted).toHaveLength(1);
+    expect(deleted[0]).toMatchObject({
+      id: 'wf-soft-delete',
+      name: 'Workflow wf-soft-delete',
+    });
+    expect(deleted[0].deletedAt).toEqual(expect.any(Number));
+    expect(adapter.loadWorkflow('wf-soft-delete', { includeDeleted: true })?.deletedAt).toEqual(expect.any(Number));
+  });
+
+  it('writes a workflow tombstone journal entry on delete', () => {
+    adapter.saveWorkflow(makeWorkflow('wf-tombstone'));
+    adapter.saveTask('wf-tombstone', createTaskState('task-tombstone', 'Task tombstone', [], { workflowId: 'wf-tombstone' }));
+
+    adapter.deleteWorkflow('wf-tombstone');
+
+    const tombstone = readJournalSince(executor(), 0, 100)
+      .find((entry) => entry.entityType === 'workflow' && entry.entityId === 'wf-tombstone' && entry.op === 'tombstone');
+    expect(tombstone).toBeDefined();
+    expect(tombstone!.origin).toBe('home');
+    expect(tombstone!.payload).toMatchObject({
+      id: 'wf-tombstone',
+      deleted_at: expect.any(Number),
+    });
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -126,8 +126,12 @@ export interface Workflow {
   generation?: number;
   createdAt: string;
   updatedAt: string;
+  deletedAt?: number;
 }
 export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup'>;
+export interface WorkflowReadOptions {
+  includeDeleted?: boolean;
+}
 
 /**
  * Result of resolving a published PR back to its Invoker workflow via the merge
@@ -333,8 +337,8 @@ export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
-  loadWorkflow(workflowId: string): Workflow | undefined;
-  listWorkflows(): Workflow[];
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined;
+  listWorkflows(options?: WorkflowReadOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
   /** Resolve a GitHub PR number back to its Invoker workflow via the merge node. */
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined;

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -7,3 +7,4 @@ export * from './slack-session-repository.js';
 export * from './slack-plan-draft-repository.js';
 export * from './sqlite-task-repository.js';
 export * from './workflow-channel-repository.js';
+export * from './sync-journal.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -57,6 +57,7 @@ import type {
   TerminalSessionRecord,
   InAppPlanningSessionPatch,
   InAppPlanningSessionRecord,
+  WorkflowReadOptions,
 } from './adapter.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
 import { SCHEMA_DDL } from './sqlite-schema.js';
@@ -78,6 +79,7 @@ import type { SqliteExecutor } from './sqlite-executor.js';
 import * as migrations from './sqlite-migrations.js';
 import { SqliteTaskAttemptRepository } from './sqlite-task-attempt-repository.js';
 import { SqliteWorkflowRepository, type WorkflowMetadataChanges } from './sqlite-workflow-repository.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 function normalizeWorkerActionStatus(status: string): string {
   return status === 'canceled' ? 'cancelled' : status;
@@ -1054,12 +1056,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.workflowRepo.updateWorkflow(workflowId, changes);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    return this.workflowRepo.loadWorkflow(workflowId);
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined {
+    return this.workflowRepo.loadWorkflow(workflowId, options);
   }
 
-  listWorkflows(): Workflow[] {
-    return this.workflowRepo.listWorkflows();
+  listWorkflows(options?: WorkflowReadOptions): Workflow[] {
+    return this.workflowRepo.listWorkflows(options);
   }
 
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
@@ -1557,8 +1559,15 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   deleteWorkflow(workflowId: string): void {
-    const taskIds = this.getTaskIdsForWorkflow(workflowId);
-    this.runTransaction(() => {
+    const taskIds = this.runTransaction(() => {
+      const existing = this.queryOne(
+        'SELECT id FROM workflows WHERE id = ? AND deleted_at IS NULL',
+        [workflowId],
+      );
+      if (!existing) return [];
+      const workflowTaskIds = this.getTaskIdsForWorkflow(workflowId);
+      const deletedAt = Date.now();
+      const updatedAt = new Date(deletedAt).toISOString();
       this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM task_launch_dispatch WHERE workflow_id = ?', [workflowId]);
@@ -1598,7 +1607,22 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
+      this.db.run(
+        'UPDATE workflows SET deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL',
+        [deletedAt, updatedAt, workflowId],
+      );
+      const tombstone = this.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+      if (!tombstone) {
+        throw new Error(`Cannot journal missing workflow tombstone "${workflowId}"`);
+      }
+      appendJournalEntry(this.executor, {
+        entityType: 'workflow',
+        entityId: workflowId,
+        op: 'tombstone',
+        payload: tombstone,
+        createdAt: deletedAt,
+      });
+      return workflowTaskIds;
     });
     this.removeOutputFiles(taskIds);
   }
@@ -1606,10 +1630,24 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Events ────────────────────────────────────────────
 
   logEvent(taskId: string, eventType: string, payload?: unknown): void {
-    this.execRun(`
-      INSERT INTO events (task_id, event_type, payload)
-      VALUES (?, ?, ?)
-    `, [taskId, eventType, payload ? JSON.stringify(payload) : null]);
+    this.runTransaction(() => {
+      this.execRun(`
+        INSERT INTO events (task_id, event_type, payload)
+        VALUES (?, ?, ?)
+      `, [taskId, eventType, payload ? JSON.stringify(payload) : null]);
+      const row = this.queryOne(
+        'SELECT * FROM events WHERE rowid = last_insert_rowid()',
+      );
+      if (!row) {
+        throw new Error(`Cannot journal missing event for task "${taskId}"`);
+      }
+      appendJournalEntry(this.executor, {
+        entityType: 'event',
+        entityId: String(row.id),
+        op: 'upsert',
+        payload: row,
+      });
+    });
   }
 
   getEvents(taskId: string): TaskEvent[];

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -49,6 +49,7 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
     generation: row.generation ?? 0,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+    deletedAt: row.deleted_at === null || row.deleted_at === undefined ? undefined : Number(row.deleted_at),
   };
 }
 

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -28,7 +28,28 @@ export const SCHEMA_DDL = `
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
         created_at TEXT DEFAULT (datetime('now')),
-        updated_at TEXT DEFAULT (datetime('now'))
+        updated_at TEXT DEFAULT (datetime('now')),
+        deleted_at INTEGER
+      );
+
+      CREATE TABLE IF NOT EXISTS sync_journal (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+        entity_id TEXT NOT NULL,
+        op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+        payload TEXT NOT NULL CHECK (json_valid(payload)),
+        origin TEXT NOT NULL DEFAULT 'home',
+        created_at INTEGER NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_sync_journal_entity_seq
+        ON sync_journal(entity_type, entity_id, seq);
+
+      CREATE TABLE IF NOT EXISTS sync_cursors (
+        peer_id TEXT PRIMARY KEY,
+        last_sent_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_sent_seq) = 'integer' AND last_sent_seq >= 0),
+        last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
+        updated_at INTEGER NOT NULL
       );
 
       CREATE TABLE IF NOT EXISTS tasks (
@@ -597,6 +618,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
+  'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
 ];
 
 /**
@@ -628,6 +650,22 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  `CREATE TABLE IF NOT EXISTS sync_journal (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+    entity_id TEXT NOT NULL,
+    op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    origin TEXT NOT NULL DEFAULT 'home',
+    created_at INTEGER NOT NULL
+  )`,
+  'CREATE INDEX IF NOT EXISTS idx_sync_journal_entity_seq ON sync_journal(entity_type, entity_id, seq)',
+  `CREATE TABLE IF NOT EXISTS sync_cursors (
+    peer_id TEXT PRIMARY KEY,
+    last_sent_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_sent_seq) = 'integer' AND last_sent_seq >= 0),
+    last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
+    updated_at INTEGER NOT NULL
+  )`,
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */
@@ -652,7 +690,8 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
         created_at TEXT DEFAULT (datetime('now')),
-        updated_at TEXT DEFAULT (datetime('now'))
+        updated_at TEXT DEFAULT (datetime('now')),
+        deleted_at INTEGER
       )
     `;
 
@@ -662,12 +701,12 @@ export const WORKFLOWS_REBUILD_INSERT_DDL = `
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, created_at, updated_at, deleted_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, created_at, updated_at, deleted_at
       FROM workflows
     `;

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -17,6 +17,7 @@ import {
 import { mapRowToTask, mapRowToAttempt } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
@@ -113,7 +114,8 @@ export class SqliteTaskAttemptRepository {
     assertTaskConsistent(task);
     const cfg = task.config;
     const exec = task.execution;
-    this.exec.execRun(`
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`
       INSERT OR REPLACE INTO tasks (
         id, workflow_id, description, status, blocked_by, dependencies,
         command, prompt, experiment_prompt, exit_code, error, protocol_error_code, protocol_error_message, input_prompt, external_dependencies,
@@ -222,8 +224,10 @@ export class SqliteTaskAttemptRepository {
       cfg.executionModel ?? null,
       exec.agentName ?? null,
       task.taskStateVersion ?? 1,
-    ]);
-    this.syncCrashPreservationState(task.id, undefined, task.execution);
+      ]);
+      this.syncCrashPreservationState(task.id, undefined, task.execution);
+      this.appendTaskJournalEntry(task.id);
+    });
   }
 
   updateTask(taskId: string, changes: TaskStateChanges): void {
@@ -299,7 +303,6 @@ export class SqliteTaskAttemptRepository {
     }
 
     if (changes.execution) {
-      this.syncCrashPreservationState(taskId, beforeTask, changes.execution);
       const execution = changes.execution as Record<string, unknown>;
       const execMap: Record<string, string> = {
         blockedBy: 'blocked_by',
@@ -385,7 +388,24 @@ export class SqliteTaskAttemptRepository {
       execution: changes.execution ? { ...beforeTask.execution, ...changes.execution } : beforeTask.execution,
     });
 
-    if (setClauses.length === 0) return;
+    const hasCrashPreservationChange = Boolean(
+      changes.execution
+      && (
+        'crashPreservedAt' in changes.execution
+        || 'crashPreservedOwnerPid' in changes.execution
+        || 'crashPreservedReportPath' in changes.execution
+        || 'crashPreservedDiagnosticSummary' in changes.execution
+      ),
+    );
+    if (setClauses.length === 0) {
+      const executionChanges = changes.execution;
+      if (executionChanges && hasCrashPreservationChange) {
+        this.exec.runTransaction(() => {
+          this.syncCrashPreservationState(taskId, beforeTask, executionChanges);
+        });
+      }
+      return;
+    }
 
     // Atomically bump task-state version with every mutation
     setClauses.push('task_state_version = task_state_version + 1');
@@ -417,7 +437,16 @@ export class SqliteTaskAttemptRepository {
       const cols = setClauses.map((c) => c.split(/\s*=\s*/)[0]!.trim()).join(', ');
       console.log(`[persist-sql] taskId=${taskId} columns=[${cols}]`);
     }
-    this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    const shouldJournalStatusChange = changes.status !== undefined;
+    this.exec.runTransaction(() => {
+      if (changes.execution && hasCrashPreservationChange) {
+        this.syncCrashPreservationState(taskId, beforeTask, changes.execution);
+      }
+      this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
+      if (shouldJournalStatusChange) {
+        this.appendTaskJournalEntry(taskId);
+      }
+    });
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -459,7 +488,8 @@ export class SqliteTaskAttemptRepository {
              w.name AS workflow_name
       FROM tasks t${this.taskSelectJoin('t')}
       JOIN workflows w ON w.id = t.workflow_id
-      WHERE t.status = 'completed'
+      WHERE w.deleted_at IS NULL
+        AND t.status = 'completed'
       ORDER BY t.completed_at DESC
     `);
     return rows.map((row) => ({
@@ -481,7 +511,8 @@ export class SqliteTaskAttemptRepository {
         FROM events
         GROUP BY task_id
       ) e ON e.task_id = t.id
-      WHERE COALESCE(e.event_count, 0) > 0 OR t.status != 'pending'
+      WHERE w.deleted_at IS NULL
+        AND (COALESCE(e.event_count, 0) > 0 OR t.status != 'pending')
       ORDER BY COALESCE(e.max_created_at, t.completed_at, t.started_at, t.created_at) DESC
     `);
     return rows.map((row) => {
@@ -594,40 +625,43 @@ export class SqliteTaskAttemptRepository {
   // ── Attempt CRUD ─────────────────────────────────────────
 
   saveAttempt(attempt: Attempt): void {
-    this.exec.execRun(`
-      INSERT OR REPLACE INTO attempts (
-        id, node_id, attempt_number, queue_priority, status,
-        snapshot_commit, base_branch, upstream_attempt_ids,
-        command_override, prompt_override,
-        claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
-        branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
-        supersedes_attempt_id, created_at, merge_conflict
-      ) VALUES (
-        ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?,
-        ?, ?,
-        ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?, ?,
-        ?, ?, ?
-      )
-    `, [
-      attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
-      attempt.snapshotCommit ?? null, attempt.baseBranch ?? null,
-      JSON.stringify(attempt.upstreamAttemptIds),
-      attempt.commandOverride ?? null, attempt.promptOverride ?? null,
-      attempt.claimedAt?.toISOString() ?? null,
-      attempt.startedAt?.toISOString() ?? null,
-      attempt.completedAt?.toISOString() ?? null,
-      attempt.exitCode ?? null, attempt.error ?? null,
-      attempt.lastHeartbeatAt?.toISOString() ?? null,
-      attempt.leaseExpiresAt?.toISOString() ?? null,
-      attempt.branch ?? null, attempt.commit ?? null, attempt.summary ?? null,
-      attempt.workspacePath ?? null, attempt.agentSessionId ?? null,
-      attempt.containerId ?? null,
-      attempt.supersedesAttemptId ?? null,
-      attempt.createdAt.toISOString(),
-      attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
-    ]);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`
+        INSERT OR REPLACE INTO attempts (
+          id, node_id, attempt_number, queue_priority, status,
+          snapshot_commit, base_branch, upstream_attempt_ids,
+          command_override, prompt_override,
+          claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
+          branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
+          supersedes_attempt_id, created_at, merge_conflict
+        ) VALUES (
+          ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?,
+          ?, ?,
+          ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?,
+          ?, ?, ?
+        )
+      `, [
+        attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
+        attempt.snapshotCommit ?? null, attempt.baseBranch ?? null,
+        JSON.stringify(attempt.upstreamAttemptIds),
+        attempt.commandOverride ?? null, attempt.promptOverride ?? null,
+        attempt.claimedAt?.toISOString() ?? null,
+        attempt.startedAt?.toISOString() ?? null,
+        attempt.completedAt?.toISOString() ?? null,
+        attempt.exitCode ?? null, attempt.error ?? null,
+        attempt.lastHeartbeatAt?.toISOString() ?? null,
+        attempt.leaseExpiresAt?.toISOString() ?? null,
+        attempt.branch ?? null, attempt.commit ?? null, attempt.summary ?? null,
+        attempt.workspacePath ?? null, attempt.agentSessionId ?? null,
+        attempt.containerId ?? null,
+        attempt.supersedesAttemptId ?? null,
+        attempt.createdAt.toISOString(),
+        attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
+      ]);
+      this.appendAttemptJournalEntry(attempt.id);
+    });
   }
 
   loadAttempts(nodeId: string): Attempt[] {
@@ -711,7 +745,23 @@ export class SqliteTaskAttemptRepository {
 
     if (setClauses.length === 0) return;
     values.push(attemptId);
-    this.exec.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    const shouldJournalCompletion =
+      changes.status !== undefined ||
+      changes.completedAt !== undefined ||
+      changes.exitCode !== undefined ||
+      changes.error !== undefined ||
+      changes.branch !== undefined ||
+      changes.commit !== undefined ||
+      changes.summary !== undefined;
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
+      if (shouldJournalCompletion) {
+        const row = this.exec.queryOne('SELECT id FROM attempts WHERE id = ?', [attemptId]);
+        if (row) {
+          this.appendAttemptJournalEntry(attemptId);
+        }
+      }
+    });
   }
 
   claimAttemptForLaunch(
@@ -888,5 +938,31 @@ export class SqliteTaskAttemptRepository {
       [nodeId, selected.createdAt.toISOString(), cappedLimit],
     );
     return rows.map((row) => mapRowToAttempt(row));
+  }
+
+  private appendTaskJournalEntry(taskId: string): void {
+    const row = this.exec.queryOne('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (!row) {
+      throw new Error(`Cannot journal missing task "${taskId}"`);
+    }
+    appendJournalEntry(this.exec, {
+      entityType: 'task',
+      entityId: taskId,
+      op: 'upsert',
+      payload: row,
+    });
+  }
+
+  private appendAttemptJournalEntry(attemptId: string): void {
+    const row = this.exec.queryOne('SELECT * FROM attempts WHERE id = ?', [attemptId]);
+    if (!row) {
+      throw new Error(`Cannot journal missing attempt "${attemptId}"`);
+    }
+    appendJournalEntry(this.exec, {
+      entityType: 'attempt',
+      entityId: attemptId,
+      op: 'upsert',
+      payload: row,
+    });
   }
 }

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -27,11 +27,13 @@ import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ReviewGateLookup,
   Workflow,
+  WorkflowReadOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
 } from './adapter.js';
 import { mapRowToWorkflow, mapRowToTask } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 export type WorkflowMetadataChanges = Partial<
   Pick<
@@ -88,23 +90,27 @@ export class SqliteWorkflowRepository {
 
   saveWorkflow(workflow: WorkflowSaveInput): void {
     assertWorkflowConsistent(workflow);
-    this.exec.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `, [
-      workflow.id, workflow.name,
-      workflow.description ?? null,
-      workflow.visualProof ? 1 : 0,
-      workflow.planFile ?? null, workflow.repoUrl ?? null, workflow.intermediateRepoUrl ?? null, workflow.branch ?? null,
-      workflow.onFinish ?? null, workflow.baseBranch ?? null, null, workflow.featureBranch ?? null,
-      workflow.mergeMode ?? null,
-      workflow.reviewProvider ?? null,
-      workflow.externalDependencies ? JSON.stringify(workflow.externalDependencies) : null,
-      workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
-      workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
-      workflow.generation ?? 0,
-      workflow.createdAt, workflow.updatedAt,
-    ]);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`
+        INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at, deleted_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `, [
+        workflow.id, workflow.name,
+        workflow.description ?? null,
+        workflow.visualProof ? 1 : 0,
+        workflow.planFile ?? null, workflow.repoUrl ?? null, workflow.intermediateRepoUrl ?? null, workflow.branch ?? null,
+        workflow.onFinish ?? null, workflow.baseBranch ?? null, null, workflow.featureBranch ?? null,
+        workflow.mergeMode ?? null,
+        workflow.reviewProvider ?? null,
+        workflow.externalDependencies ? JSON.stringify(workflow.externalDependencies) : null,
+        workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
+        workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
+        workflow.generation ?? 0,
+        workflow.createdAt, workflow.updatedAt,
+        workflow.deletedAt ?? null,
+      ]);
+      this.appendWorkflowJournalEntry(workflow.id, 'upsert');
+    });
   }
 
   updateWorkflow(workflowId: string, changes: WorkflowMetadataChanges): void {
@@ -171,19 +177,25 @@ export class SqliteWorkflowRepository {
     assertWorkflowPatchConsistent(before, after, changes);
 
     values.push(workflowId);
-    this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
+      this.appendWorkflowJournalEntry(workflowId, 'upsert');
+    });
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined {
+    const row = this.exec.queryOne(
+      `SELECT * FROM workflows WHERE id = ?${options?.includeDeleted ? '' : ' AND deleted_at IS NULL'}`,
+      [workflowId],
+    );
     if (!row) return undefined;
     const rollup = this.loadWorkflowRollups([workflowId]).get(workflowId);
     return this.rowToWorkflow(row, rollup);
   }
 
-  listWorkflows(): Workflow[] {
+  listWorkflows(options?: WorkflowReadOptions): Workflow[] {
     const rows = this.exec.queryAll(
-      'SELECT * FROM workflows ORDER BY created_at DESC',
+      `SELECT * FROM workflows${options?.includeDeleted ? '' : ' WHERE deleted_at IS NULL'} ORDER BY created_at DESC`,
     );
     const workflowIds = rows.map((row) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
@@ -205,7 +217,9 @@ export class SqliteWorkflowRepository {
               w.base_branch AS baseBranch
          FROM tasks t
          JOIN workflows w ON w.id = t.workflow_id
-        WHERE t.is_merge_node = 1 AND (t.review_id = ? OR t.review_url LIKE ?)`,
+        WHERE w.deleted_at IS NULL
+          AND t.is_merge_node = 1
+          AND (t.review_id = ? OR t.review_url LIKE ?)`,
       [pr, `%/pull/${pr}`],
     );
     if (rows.length === 0) return undefined;
@@ -257,7 +271,8 @@ export class SqliteWorkflowRepository {
     if (type === 'workflows' || type === 'all') {
       const workflows = this.exec.queryAll(
         `SELECT id, name, description, plan_file, repo_url, branch, created_at FROM workflows 
-         WHERE name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ? 
+         WHERE deleted_at IS NULL
+           AND (name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{ id: string; name?: string | null; created_at: string }>;
@@ -281,8 +296,11 @@ export class SqliteWorkflowRepository {
     
     if (type === 'tasks' || type === 'all') {
       const tasks = this.exec.queryAll(
-        `SELECT id, workflow_id, description, command, prompt, summary, problem, approach, test_plan, repro_command, status, created_at FROM tasks 
-         WHERE description LIKE ? OR command LIKE ? OR prompt LIKE ? OR summary LIKE ? OR problem LIKE ? OR approach LIKE ? OR test_plan LIKE ? OR repro_command LIKE ? 
+        `SELECT t.id, t.workflow_id, t.description, t.command, t.prompt, t.summary, t.problem, t.approach, t.test_plan, t.repro_command, t.status, t.created_at
+           FROM tasks t
+           JOIN workflows w ON w.id = t.workflow_id
+          WHERE w.deleted_at IS NULL
+            AND (t.description LIKE ? OR t.command LIKE ? OR t.prompt LIKE ? OR t.summary LIKE ? OR t.problem LIKE ? OR t.approach LIKE ? OR t.test_plan LIKE ? OR t.repro_command LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{
@@ -298,7 +316,7 @@ export class SqliteWorkflowRepository {
       if (workflowIds.length > 0) {
         const placeholders = workflowIds.map(() => '?').join(',');
         const workflowRows = this.exec.queryAll(
-          `SELECT id, name FROM workflows WHERE id IN (${placeholders})`,
+          `SELECT id, name FROM workflows WHERE deleted_at IS NULL AND id IN (${placeholders})`,
           workflowIds
         ) as Array<{ id: string; name?: string | null }>;
         for (const wf of workflowRows) {
@@ -326,10 +344,16 @@ export class SqliteWorkflowRepository {
   loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
     const totalStartedAt = Date.now();
     const workflowQueryStartedAt = Date.now();
-    const workflowRows = this.exec.queryAll('SELECT * FROM workflows ORDER BY created_at DESC');
+    const workflowRows = this.exec.queryAll('SELECT * FROM workflows WHERE deleted_at IS NULL ORDER BY created_at DESC');
     const workflowMetadataQueryMs = Date.now() - workflowQueryStartedAt;
     const taskQueryStartedAt = Date.now();
-    const taskRows = this.exec.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC');
+    const taskRows = this.exec.queryAll(`
+      SELECT t.*
+        FROM tasks t
+        JOIN workflows w ON w.id = t.workflow_id
+       WHERE w.deleted_at IS NULL
+       ORDER BY t.workflow_id ASC, t.id ASC
+    `);
     const taskQueryMs = Date.now() - taskQueryStartedAt;
     const tasksByWorkflowId = new Map<string, TaskState[]>();
     const workflowIds = workflowRows.map((row) => String(row.id));
@@ -465,5 +489,23 @@ export class SqliteWorkflowRepository {
 
   private rowToWorkflow(row: Record<string, unknown>, rollup?: WorkflowRollup): Workflow {
     return mapRowToWorkflow(row, rollup);
+  }
+
+  private appendWorkflowJournalEntry(
+    workflowId: string,
+    op: 'upsert' | 'tombstone',
+    createdAt?: number,
+  ): void {
+    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+    if (!row) {
+      throw new Error(`Cannot journal missing workflow "${workflowId}"`);
+    }
+    appendJournalEntry(this.exec, {
+      entityType: 'workflow',
+      entityId: workflowId,
+      op,
+      payload: row,
+      ...(createdAt === undefined ? {} : { createdAt }),
+    });
   }
 }

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -1,0 +1,155 @@
+import type { SqliteExecutor } from './sqlite-executor.js';
+
+export type SyncEntityType = 'workflow' | 'task' | 'attempt' | 'event' | 'output';
+export type SyncJournalOp = 'upsert' | 'tombstone';
+
+export const LOCAL_SYNC_ORIGIN = 'home';
+
+export interface SyncJournalEntryInput {
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOp;
+  payload: unknown;
+  origin?: string;
+  createdAt?: number;
+}
+
+export interface SyncJournalEntry {
+  seq: number;
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOp;
+  payload: unknown;
+  origin: string;
+  createdAt: number;
+}
+
+export interface SyncCursor {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt: number;
+}
+
+export interface SyncCursorInput {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt?: number;
+}
+
+type SyncJournalRow = {
+  seq: number;
+  entity_type: string;
+  entity_id: string;
+  op: string;
+  payload: string;
+  origin: string;
+  created_at: number;
+};
+
+type SyncCursorRow = {
+  peer_id: string;
+  last_sent_seq: number;
+  last_received_seq: number;
+  updated_at: number;
+};
+
+/**
+ * `output` is reserved in the entity enum for future output snapshot journaling.
+ * High-volume output spool rows intentionally do not append sync journal rows yet.
+ */
+export function appendJournalEntry(db: SqliteExecutor, entry: SyncJournalEntryInput): SyncJournalEntry {
+  const payloadJson = JSON.stringify(entry.payload);
+  if (payloadJson === undefined) {
+    throw new Error(`Sync journal payload for ${entry.entityType}:${entry.entityId} is not JSON-serializable`);
+  }
+
+  const createdAt = entry.createdAt ?? Date.now();
+  const origin = entry.origin ?? LOCAL_SYNC_ORIGIN;
+  db.execRun(
+    `INSERT INTO sync_journal (entity_type, entity_id, op, payload, origin, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [entry.entityType, entry.entityId, entry.op, payloadJson, origin, createdAt],
+  );
+
+  const row = db.queryOne('SELECT last_insert_rowid() AS seq') as { seq?: number } | undefined;
+  const seq = Number(row?.seq ?? 0);
+  if (!Number.isInteger(seq) || seq <= 0) {
+    throw new Error('Sync journal append succeeded but inserted seq could not be read back');
+  }
+  return {
+    seq,
+    entityType: entry.entityType,
+    entityId: entry.entityId,
+    op: entry.op,
+    payload: JSON.parse(payloadJson),
+    origin,
+    createdAt,
+  };
+}
+
+export function readJournalSince(db: SqliteExecutor, seq: number, limit: number): SyncJournalEntry[] {
+  const cappedLimit = Math.max(0, Math.trunc(limit));
+  if (cappedLimit === 0) return [];
+
+  const rows = db.queryAll(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq > ?
+      ORDER BY seq ASC
+      LIMIT ?`,
+    [Math.max(0, Math.trunc(seq)), cappedLimit],
+  ) as SyncJournalRow[];
+  return rows.map(mapJournalRow);
+}
+
+export function getSyncCursor(db: SqliteExecutor, peerId: string): SyncCursor | undefined {
+  const row = db.queryOne(
+    `SELECT peer_id, last_sent_seq, last_received_seq, updated_at
+       FROM sync_cursors
+      WHERE peer_id = ?`,
+    [peerId],
+  ) as SyncCursorRow | undefined;
+  return row ? mapCursorRow(row) : undefined;
+}
+
+export function setSyncCursor(db: SqliteExecutor, cursor: SyncCursorInput): SyncCursor {
+  const updatedAt = cursor.updatedAt ?? Date.now();
+  db.execRun(
+    `INSERT INTO sync_cursors (peer_id, last_sent_seq, last_received_seq, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(peer_id) DO UPDATE SET
+       last_sent_seq = excluded.last_sent_seq,
+       last_received_seq = excluded.last_received_seq,
+       updated_at = excluded.updated_at`,
+    [cursor.peerId, cursor.lastSentSeq, cursor.lastReceivedSeq, updatedAt],
+  );
+
+  const saved = getSyncCursor(db, cursor.peerId);
+  if (!saved) {
+    throw new Error(`Sync cursor for peer "${cursor.peerId}" could not be read after upsert`);
+  }
+  return saved;
+}
+
+function mapJournalRow(row: SyncJournalRow): SyncJournalEntry {
+  return {
+    seq: Number(row.seq),
+    entityType: row.entity_type as SyncEntityType,
+    entityId: row.entity_id,
+    op: row.op as SyncJournalOp,
+    payload: JSON.parse(row.payload),
+    origin: row.origin,
+    createdAt: Number(row.created_at),
+  };
+}
+
+function mapCursorRow(row: SyncCursorRow): SyncCursor {
+  return {
+    peerId: row.peer_id,
+    lastSentSeq: Number(row.last_sent_seq),
+    lastReceivedSeq: Number(row.last_received_seq),
+    updatedAt: Number(row.updated_at),
+  };
+}


### PR DESCRIPTION
## Summary

Remote Sync Step 1: Sync Schema and Change Journal — 2 tasks completed, 0 failed, 0 closed, 0 sk&#105;pped

Adds sync journal and cursor tables, workflow tombstones, and journal helpers for future remote sync.

Journal rows are appended in the same SQLite transactions as workflow, task, and attempt mutations.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926077035-3/implement-sync-schema | Add sync journal, cursor, and tombstone schema to data-store | completed |
| wf-1784926077035-3/verify-sync-schema | Run data-store package tests covering the new schema and journal | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784926077035-3/implement-sync-schema — Add sync journal, cursor, and tombstone schema to data-store

### wf-1784926077035-3/verify-sync-schema — Run data-store package tests covering the new schema and journal

</details>

## Review Claim

Approve the data-store sync contract for journaling workflow, task, and attempt mutations with cursors and workflow tombstones.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Journal rows are appended inside the existing SQLite transaction, so rollback removes both entity rows and sync evidence.

## Slice Rationale

This is the foundation slice for remote sync. It adds durable local sync records before any transport or peer reconciliation code consumes them.

## Non-goals

- No remote transport.
- No peer reconciliation.
- No UI changes.
- No output spool replication.

## Architecture

### Before

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["Entity table rows"]
    C["Workflow removal request"] --> D["Workflow row removed"]
```

### After

```mermaid
graph TD
    A["SQLite workflow, task, and attempt mutations"] --> B["Entity table rows"]
    A --> C["sync_journal upsert rows"]
    D["Workflow removal request"] --> E["Workflow tombstone state"]
    D --> F["sync_journal tombstone row"]
    G["Peer replication checkpoint"] --> H["sync_cursors row"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile --ignore-scripts`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sync-journal.test.ts` (25 files, 434 tests passed)
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-bodies/remote-sync-step-1-g38.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-bodies/remote-sync-step-1-g38.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert d76e2df3`
- Post-revert steps: Rerun `pnpm --filter @invoker/data-store test -- src/__tests__/sync-journal.test.ts`.
- Data migration? Yes. Existing local databases may retain unused sync tables and the workflow tombstone column after code revert.

</details>
