### PR TITLE
[Tmux Summary Bridge Step 1 Contract](1) Add display-only terminal bridge

### DIFF
--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -266,6 +266,62 @@ describe('EmbeddedTerminalManager', () => {
     expect(reused.outputSnapshot).toBe(firstFrame);
   });
 
+  it('seeds display bridge text before synchronous backend output', () => {
+    const spawned = {
+      write: vi.fn(),
+      resize: vi.fn(),
+      close: vi.fn(),
+    };
+    const backend: EmbeddedTerminalBackend = {
+      name: 'pty',
+      spawn: vi.fn((opts) => {
+        opts.emitOutput('backend-output\n');
+        return spawned;
+      }),
+    };
+    const mgr = new EmbeddedTerminalManager({ backend });
+
+    const session = mgr.openOrReuse({
+      taskId: 'task-bridge',
+      spec: {
+        cwd: '/tmp/wt',
+        displayOnlyBridgeText: 'Context: resume task-bridge',
+      },
+      cwd: '/tmp/wt',
+    });
+
+    expect(session.outputSnapshot).toBe('Context: resume task-bridge\nbackend-output\n');
+    expect(mgr.getPersistenceRecord(session.sessionId)?.outputSnapshot)
+      .toBe('Context: resume task-bridge\nbackend-output\n');
+  });
+
+  it('keeps display bridge text out of terminal target identity', () => {
+    const spawned = {
+      write: vi.fn(),
+      resize: vi.fn(),
+      close: vi.fn(),
+    };
+    const backend: EmbeddedTerminalBackend = {
+      name: 'bash',
+      spawn: vi.fn(() => spawned),
+    };
+    const mgr = new EmbeddedTerminalManager({ backend });
+
+    const first = mgr.openOrReuse({
+      taskId: 'task-same-target',
+      spec: { cwd: '/tmp/wt', displayOnlyBridgeText: 'First bridge' },
+      cwd: '/tmp/wt',
+    });
+    const second = mgr.openOrReuse({
+      taskId: 'task-same-target',
+      spec: { cwd: '/tmp/wt', displayOnlyBridgeText: 'Updated bridge' },
+      cwd: '/tmp/wt',
+    });
+
+    expect(second.sessionId).toBe(first.sessionId);
+    expect(backend.spawn).toHaveBeenCalledTimes(1);
+  });
+
   it('opens a distinct session when the same task resolves to a different terminal target', () => {
     const child1 = createFakeChild();
     const child2 = createFakeChild();

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -11,7 +11,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { mkdirSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 
 import {
@@ -432,6 +433,39 @@ describe('terminal-external-launch', () => {
     // Should use '\'' (backslash-quote) not '"'"' (double-quote idiom)
     expect(line).toContain("\\'");
     expect(line).not.toMatch(/'"'"'/);
+  });
+
+  it('prints display bridge text without injection and preserves command argv', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'terminal-bridge-'));
+    const marker = join(dir, 'injected');
+    try {
+      const line = buildTerminalShellCommand(
+        {
+          cwd: dir,
+          command: 'sh',
+          args: [
+            '-c',
+            'printf "%s\\n" "$@" > argv.txt',
+            'argv0',
+            'arg one',
+            'semi;colon',
+            "quote'arg",
+          ],
+          displayOnlyBridgeText: `bridge $(touch ${marker}); echo 'bad'`,
+        },
+        '/fallback',
+      );
+
+      execFileSync('bash', ['-c', line], { cwd: dir });
+
+      expect(readFileSync(join(dir, 'argv.txt'), 'utf8')).toBe(
+        "arg one\nsemi;colon\nquote'arg\n",
+      );
+      expect(readFileSync(join(dir, 'argv.txt'), 'utf8')).not.toContain('bad');
+      expect(() => readFileSync(marker)).toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('buildMacOSOsascriptArgs includes activate and uses multi-line AppleScript', () => {

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -26,6 +26,7 @@ export type EmbeddedTerminalBackendName = 'bash' | 'pty';
 export type EmbeddedTerminalSessionKind = 'task' | 'planning';
 
 export const MAX_OUTPUT_SNAPSHOT_CHARS = 64 * 1024;
+const MAX_DISPLAY_BRIDGE_CHARS = 8 * 1024;
 
 export interface PtyForkOptionsLike {
   name: string;
@@ -331,7 +332,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
       createdAt,
       updatedAt: createdAt,
       status: 'running' as const,
-      outputSnapshot: opts.outputSnapshot ?? '',
+      outputSnapshot: opts.outputSnapshot ?? buildDisplayBridgeSnapshot(opts.spec),
     };
 
     if (opts.attach) {
@@ -404,7 +405,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
       createdAt: seed.createdAt,
       updatedAt: new Date().toISOString(),
       status: 'running' as const,
-      outputSnapshot: trimOutputSnapshot(seed.outputSnapshot),
+      outputSnapshot: buildRestoredOutputSnapshot(seed.spec, seed.outputSnapshot),
     });
   }
 
@@ -735,6 +736,23 @@ export function trimPreservingEscapeSequences(text: string, maxChars: number): s
 
 function trimOutputSnapshot(snapshot: string): string {
   return trimPreservingEscapeSequences(snapshot, MAX_OUTPUT_SNAPSHOT_CHARS);
+}
+
+function buildDisplayBridgeSnapshot(spec: TerminalSpec): string {
+  const bridge = formatDisplayBridgeText(spec.displayOnlyBridgeText);
+  return bridge ?? '';
+}
+
+function buildRestoredOutputSnapshot(spec: TerminalSpec, outputSnapshot: string): string {
+  const bridge = formatDisplayBridgeText(spec.displayOnlyBridgeText);
+  if (!bridge || outputSnapshot.startsWith(bridge)) return trimOutputSnapshot(outputSnapshot);
+  return trimOutputSnapshot(bridge + outputSnapshot);
+}
+
+function formatDisplayBridgeText(bridgeText: string | undefined): string | undefined {
+  if (!bridgeText) return undefined;
+  const bounded = bridgeText.slice(0, MAX_DISPLAY_BRIDGE_CHARS);
+  return bounded.endsWith('\n') ? bounded : `${bounded}\n`;
 }
 
 function resolveBackend(options: EmbeddedTerminalManagerOptions): EmbeddedTerminalBackend {

--- a/packages/app/src/terminal-external-launch.ts
+++ b/packages/app/src/terminal-external-launch.ts
@@ -5,6 +5,16 @@
 
 import { spawn, type SpawnOptions } from 'node:child_process';
 
+const MAX_DISPLAY_BRIDGE_CHARS = 8 * 1024;
+
+type TerminalShellSpec = {
+  cwd?: string;
+  command?: string;
+  args?: string[];
+  linuxTerminalTail?: 'exec_bash' | 'pause';
+  displayOnlyBridgeText?: string;
+};
+
 /** Escape one argument for POSIX shell single-quoted strings. */
 export function shellSingleQuoteForPOSIX(s: string): string {
   return `'${s.replace(/'/g, `'\\''`)}'`;
@@ -16,7 +26,7 @@ export type InteractiveExecShell = 'bash' | 'zsh';
  * Full shell line: `cd '<cwd>' && ...` plus either `exec bash` / `exec zsh` or `command` with args properly quoted.
  */
 export function buildTerminalShellCommand(
-  spec: { cwd?: string; command?: string; args?: string[] },
+  spec: TerminalShellSpec,
   defaultCwd: string,
   options?: { interactiveExec?: InteractiveExecShell },
 ): string {
@@ -24,10 +34,13 @@ export function buildTerminalShellCommand(
   const cd = `cd ${shellSingleQuoteForPOSIX(cwd)}`;
   if (!spec.command) {
     const execSh = options?.interactiveExec === 'zsh' ? 'exec zsh' : 'exec bash';
-    return `${cd} && ${execSh}`;
+    return `${cd} && ${withDisplayBridge(spec.displayOnlyBridgeText, execSh)}`;
   }
   const argv = [spec.command, ...(spec.args ?? [])];
-  return `${cd} && ${argv.map(shellSingleQuoteForPOSIX).join(' ')}`;
+  return `${cd} && ${withDisplayBridge(
+    spec.displayOnlyBridgeText,
+    argv.map(shellSingleQuoteForPOSIX).join(' '),
+  )}`;
 }
 
 /** Escape for embedding in AppleScript: `tell application "Terminal" to do script "…"`. */
@@ -37,7 +50,7 @@ export function appleScriptEscapeForDoubleQuotedString(s: string): string {
 
 /** argv for `osascript` to run the built shell command in Terminal.app. */
 export function buildMacOSOsascriptArgs(
-  spec: { cwd?: string; command?: string; args?: string[] },
+  spec: TerminalShellSpec,
   defaultCwd: string,
 ): string[] {
   const shellCmd = buildTerminalShellCommand(spec, defaultCwd, { interactiveExec: 'zsh' });
@@ -54,7 +67,7 @@ export function buildMacOSOsascriptArgs(
  * Inner script passed to `bash -c` for Linux x-terminal-emulator (includes optional suffix).
  */
 export function buildLinuxXTerminalBashScript(
-  spec: { cwd?: string; command?: string; args?: string[]; linuxTerminalTail?: 'exec_bash' | 'pause' },
+  spec: TerminalShellSpec,
   defaultCwd: string,
 ): string {
   const base = buildTerminalShellCommand(spec, defaultCwd);
@@ -66,6 +79,22 @@ export function buildLinuxXTerminalBashScript(
     ? '; exec bash'
     : '; echo ""; echo "Exit code: $?"; echo "Press Enter to close..."; read';
   return base + suffix;
+}
+
+export function buildDisplayBridgePrintfCommand(bridgeText: string | undefined): string {
+  const bridge = formatDisplayBridgeText(bridgeText);
+  return bridge ? `printf '%s' ${shellSingleQuoteForPOSIX(bridge)}` : '';
+}
+
+function withDisplayBridge(bridgeText: string | undefined, commandLine: string): string {
+  const bridgeCommand = buildDisplayBridgePrintfCommand(bridgeText);
+  return bridgeCommand ? `{ ${bridgeCommand}; ${commandLine}; }` : commandLine;
+}
+
+function formatDisplayBridgeText(bridgeText: string | undefined): string | undefined {
+  if (!bridgeText) return undefined;
+  const bounded = bridgeText.slice(0, MAX_DISPLAY_BRIDGE_CHARS);
+  return bounded.endsWith('\n') ? bounded : `${bounded}\n`;
 }
 
 export type OpenTerminalResult = { opened: boolean; reason?: string };

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -1187,6 +1187,21 @@ describe('WorktreeExecutor', () => {
       taskProcess.emit('close', 0, null);
     });
 
+    it('getTerminalSpec preserves caller-supplied display bridge text', async () => {
+      const { taskProcess } = setupSpawnMock();
+
+      const request = makeRequest();
+      const handle = await executor.start(request);
+      handle.displayOnlyBridgeText = 'Context: live task handoff';
+
+      expect(executor.getTerminalSpec(handle)).toEqual(expect.objectContaining({
+        cwd: expect.stringMatching(/^\/fake\/worktrees\//),
+        displayOnlyBridgeText: 'Context: live task handoff',
+      }));
+
+      taskProcess.emit('close', 0, null);
+    });
+
     it('does not set agentSessionId for command tasks', async () => {
       const { taskProcess } = setupSpawnMock();
 
@@ -1418,6 +1433,23 @@ describe('WorktreeExecutor', () => {
     it('returns spec with undefined cwd when no workspace path', () => {
       const spec = executor.getRestoredTerminalSpec(baseMeta);
       expect(spec).toEqual({ cwd: undefined });
+    });
+
+    it('preserves caller-supplied display bridge text on restored specs', () => {
+      vi.mocked(existsSync).mockReturnValue(true);
+      const spec = executor.getRestoredTerminalSpec({
+        ...baseMeta,
+        workspacePath: '/home/user/.invoker/worktrees/wt-abc',
+        agentSessionId: 'session-wt-1',
+        displayOnlyBridgeText: 'Context: restored task handoff',
+      });
+
+      expect(spec).toEqual({
+        command: 'claude',
+        args: ['--resume', 'session-wt-1', '--dangerously-skip-permissions'],
+        cwd: '/home/user/.invoker/worktrees/wt-abc',
+        displayOnlyBridgeText: 'Context: restored task handoff',
+      });
     });
   });
 

--- a/packages/execution-engine/src/executor.ts
+++ b/packages/execution-engine/src/executor.ts
@@ -5,6 +5,8 @@ export type Unsubscribe = () => void;
 export interface ExecutorHandle {
   executionId: string;
   taskId: string;
+  /** Optional display-only text to show before terminal process output. */
+  displayOnlyBridgeText?: string;
   agentSessionId?: string;
   containerId?: string;
   workspacePath?: string;
@@ -24,11 +26,15 @@ export interface TerminalSpec {
   cols?: number;
   /** Initial PTY row count. Defaults to 24 when omitted. */
   rows?: number;
+  /** Optional bounded text rendered before terminal output; never passed to the process argv or stdin. */
+  displayOnlyBridgeText?: string;
 }
 
 export interface PersistedTaskMeta {
   taskId: string;
   runnerKind: string;
+  /** Optional display-only text to show before terminal process output. */
+  displayOnlyBridgeText?: string;
   agentSessionId?: string;
   /** Configured execution agent name (e.g. 'claude', 'codex'). Used for session resume. */
   executionAgent?: string;

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -575,14 +575,15 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
   getTerminalSpec(handle: ExecutorHandle): TerminalSpec | null {
     const entry = this.entries.get(handle.executionId);
     if (!entry) return null;
+    const displayBridge = getDisplayOnlyBridgeSpec(handle);
     if (entry.agentSessionId) {
       const agentName = entry.request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
       const resume = this.agentRegistry
         ? this.agentRegistry.getOrThrow(agentName).buildResumeArgs(entry.agentSessionId)
         : { cmd: 'claude', args: ['--resume', entry.agentSessionId, '--dangerously-skip-permissions'] };
-      return { command: resume.cmd, args: resume.args, cwd: entry.worktreeDir };
+      return { command: resume.cmd, args: resume.args, cwd: entry.worktreeDir, ...displayBridge };
     }
-    return { cwd: entry.worktreeDir };
+    return { cwd: entry.worktreeDir, ...displayBridge };
   }
 
   getRestoredTerminalSpec(meta: PersistedTaskMeta): TerminalSpec {
@@ -603,6 +604,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     if (meta.workspacePath) {
       traceExecution(`[WorktreeExecutor] getRestoredTerminalSpec task="${meta.taskId}" — worktree path exists: ${meta.workspacePath}`);
     }
+    const displayBridge = getDisplayOnlyBridgeSpec(meta);
     if (meta.agentSessionId) {
       const resume = this.agentRegistry
         ? this.agentRegistry.getOrThrow(meta.executionAgent ?? DEFAULT_EXECUTION_AGENT).buildResumeArgs(meta.agentSessionId)
@@ -611,6 +613,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         command: resume.cmd,
         args: resume.args,
         cwd: meta.workspacePath,
+        ...displayBridge,
       };
       traceExecution(
         `[agent-session-trace] WorktreeExecutor.getRestoredTerminalSpec: task="${meta.taskId}" resume with agentSessionId=${meta.agentSessionId}`,
@@ -625,12 +628,13 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         command: sh,
         args: ['-c', `git checkout '${meta.branch}' 2>/dev/null; exec ${sh}`],
         cwd: meta.workspacePath,
+        ...displayBridge,
       };
       traceExecution(`[WorktreeExecutor] getRestoredTerminalSpec task="${meta.taskId}" → checkout branch spec, branch="${meta.branch}" cwd="${spec.cwd}"`);
       return spec;
     }
     traceExecution(`[WorktreeExecutor] getRestoredTerminalSpec task="${meta.taskId}" → cwd-only spec, cwd="${meta.workspacePath}"`);
-    return { cwd: meta.workspacePath };
+    return { cwd: meta.workspacePath, ...displayBridge };
   }
 
   /**
@@ -717,4 +721,12 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       failurePrefix: 'Worktree provisioning failed:',
     });
   }
+}
+
+function getDisplayOnlyBridgeSpec(
+  source: { displayOnlyBridgeText?: string },
+): Pick<TerminalSpec, 'displayOnlyBridgeText'> {
+  return source.displayOnlyBridgeText === undefined
+    ? {}
+    : { displayOnlyBridgeText: source.displayOnlyBridgeText };
 }


### PR DESCRIPTION
## Summary

Terminal launch specs now carry optional intro text for resumed or restored sessions.

Embedded sessions prepend the text to output snapshots, and external terminal launchers print it before the resumed process starts.

The bridge is bounded, shell-escaped, and display-only.

## Review Claim

Terminal launch paths can show a bounded display-only bridge before resumed terminal output without changing agent execution.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The bridge text is inert terminal output only; it does not change agent argv, cwd selection, task execution, process lifecycle, or persisted task state.

## Slice Rationale

This adds the shared terminal-open primitive before any planning or task-specific summaries can depend on it.

## Non-goals

Do not add task or planning summary generation.

Do not change Codex, Claude, OMP, Docker, or SSH command builders.

Do not add a persistence column or change saved task state.

## Architecture

### Before

```mermaid
graph TD
    A["WorktreeExecutor builds restored terminal spec"] --> B["Terminal launcher starts command"]
    C["EmbeddedTerminalManager creates output snapshot"] --> D["Backend output appears first"]
```

### After

```mermaid
graph TD
    A["WorktreeExecutor builds restored terminal spec with optional bridge text"] --> B["Terminal launcher prints bounded bridge"]
    B --> C["Terminal launcher starts unchanged command"]
    D["EmbeddedTerminalManager stores bridge text in output snapshot"] --> E["Backend output follows it"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/worktree-executor.test.ts`
- [x] `cd packages/app && pnpm run test -- src/__tests__/embedded-terminal-manager.test.ts src/__tests__/open-terminal.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <pr-commit-sha>`
- Post-revert steps: Re-run the focused execution-engine and app terminal Vitest commands listed above.
- Data migration? No

</details>
