### PR TITLE
[Tmux Summary Bridge Step 1 Contract](2) Stabilize focused terminal bridge verification

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -62,7 +62,7 @@
     "dist": "electron-builder --publish never",
     "dist:linux": "electron-builder --linux AppImage deb --publish never",
     "dist:mac": "electron-builder --mac dmg --publish never",
-    "test": "vitest run",
+    "test": "node scripts/run-vitest.mjs",
     "start": "unset ELECTRON_RUN_AS_NODE && node ../../scripts/electron.cjs dist/main.js",
     "dev": "tsup src/main.ts src/preload.ts --format cjs --outDir dist --external electron && unset ELECTRON_RUN_AS_NODE && node ../../scripts/electron.cjs dist/main.js",
     "test:e2e": "sh -c 'if [ \"${1-}\" = \"--\" ]; then shift; fi; if command -v xvfb-run >/dev/null 2>&1; then exec xvfb-run --auto-servernum playwright test \"$@\"; else exec playwright test \"$@\"; fi' --",

--- a/packages/app/scripts/run-vitest.mjs
+++ b/packages/app/scripts/run-vitest.mjs
@@ -1,0 +1,23 @@
+import { spawn } from "node:child_process";
+
+const forwardedArgs = process.argv.slice(2);
+const vitestArgs = forwardedArgs[0] === "--" ? forwardedArgs.slice(1) : forwardedArgs;
+
+const child = spawn("vitest", ["run", ...vitestArgs], {
+  stdio: "inherit",
+  shell: process.platform === "win32",
+});
+
+child.on("error", (error) => {
+  console.error(error);
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 1);
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1732,24 +1732,6 @@ function startHeadlessMode(): void {
           );
         }
         workerRuntimeController.startAutoStartedWorkers();
-        if (command === 'owner-serve') {
-          const ownerServeTaskExecutor = createStandaloneTaskExecutor();
-          const apiServerDeps = buildHeadlessApiServerDeps(headlessDeps, ownerServeTaskExecutor);
-          headlessWebBridge = startWebSurfaceForHeadless(
-            {
-              logger,
-              orchestrator,
-              persistence,
-              messageBus,
-              executionAgentRegistry: agentRegistry,
-              invokerConfig,
-              repoRoot,
-              executorRegistry,
-              appRootDir: __dirname,
-            },
-            apiServerDeps,
-          );
-        }
 
         // Owner discovery and exec handlers must exist before dispatch polling starts.
         if (!readOnlyMode) {
@@ -1771,6 +1753,8 @@ function startHeadlessMode(): void {
               messageBus,
               executionAgentRegistry: agentRegistry,
               invokerConfig,
+              repoRoot,
+              executorRegistry,
               appRootDir: __dirname,
             },
             apiServerDeps,


### PR DESCRIPTION
## Summary

Owner-serve now routes web startup from one path after the launch dispatcher is ready.

That path keeps the terminal-capable dependencies that task terminal actions need.

The app test script now forwards focused Vitest file arguments to Vitest.

## Review Claim

Focused terminal bridge verification can run through app Vitest forwarding while owner-serve routes one terminal-capable web startup path.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change is limited to app test command forwarding and owner-serve startup routing; task execution, terminal argv, persisted state, and bridge output remain unchanged.

## Slice Rationale

The verification path depends on focused app Vitest forwarding and owner-serve web startup routing, so this keeps the enabling behavior in one routing slice.

## Non-goals

Do not add task or planning summary generation.

Do not change Codex, Claude, OMP, Docker, or SSH terminal command builders.

Do not add a persistence column or change saved task state.

## Architecture

### Before

```mermaid
graph TD
    A["owner-serve starts workers"] --> B["first web surface starts with terminal deps"]
    B --> C["launch dispatcher starts later"]
    C --> D["second web surface can replace the first without terminal deps"]
```

### After

```mermaid
graph TD
    A["owner-serve starts workers"] --> B["launch dispatcher starts"]
    B --> C["single web surface starts with terminal deps"]
```

## Visual Proof

[Owner-serve startup walkthrough](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30257117201/job/89948179651)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/worktree-executor.test.ts`
- [x] `cd packages/app && pnpm run test -- src/__tests__/embedded-terminal-manager.test.ts src/__tests__/open-terminal.test.ts`
- [x] `cd packages/app && pnpm run test -- src/__tests__/standalone-owner-web-surface.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <pr-commit-sha>`
- Post-revert steps: Re-run the focused app and execution-engine Vitest commands listed above.
- Data migration? No

</details>
