### PR TITLE
[Remove deprecated merge-mode and retry paths](1) Remove deprecated headless aliases

### DIFF
--- a/packages/app/src/__tests__/headless-command-classification.test.ts
+++ b/packages/app/src/__tests__/headless-command-classification.test.ts
@@ -34,8 +34,10 @@ describe('headless-command-classification', () => {
   it('classifies read-only commands', () => {
     expect(isHeadlessReadOnlyCommand([])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['query'])).toBe(true);
-    expect(isHeadlessReadOnlyCommand(['list'])).toBe(true);
-    expect(isHeadlessReadOnlyCommand(['session'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['query', 'workflows'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['query', 'session'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['list'])).toBe(false);
+    expect(isHeadlessReadOnlyCommand(['session'])).toBe(false);
     expect(isHeadlessReadOnlyCommand(['open-terminal'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['worker'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['worker', 'status'])).toBe(true);

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -163,35 +163,36 @@ describe('headless delegation enforcement', () => {
       stdout.mockRestore();
     });
 
-      it('allows deprecated list command in read-only mode', async () => {
-        await expect(
-          runHeadless(['list'], mockDeps)
-        ).resolves.toBeUndefined();
-      });
+    it('rejects the removed list alias with normal unknown-command behavior', async () => {
+      await expect(
+        runHeadless(['list'], mockDeps),
+      ).rejects.toThrow('Unknown command: list');
+    });
 
-      it('allows query workflow for a single workflow', async () => {
-        mockDeps.persistence.loadWorkflow = vi.fn(() => ({
-          id: 'wf-1',
-          name: 'Workflow one',
-          status: 'pending',
-          generation: 0,
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-        } as any));
+    it('allows query workflow for a single workflow', async () => {
+      mockDeps.persistence.loadWorkflow = vi.fn(() => ({
+        id: 'wf-1',
+        name: 'Workflow one',
+        status: 'pending',
+        generation: 0,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      } as any));
 
-        await expect(
-          runHeadless(['query', 'workflow', 'wf-1', '--output', 'json'], mockDeps),
-        ).resolves.toBeUndefined();
+      await expect(
+        runHeadless(['query', 'workflow', 'wf-1', '--output', 'json'], mockDeps),
+      ).resolves.toBeUndefined();
 
-        expect(mockDeps.persistence.loadWorkflow).toHaveBeenCalledWith('wf-1');
-      });
+      expect(mockDeps.persistence.loadWorkflow).toHaveBeenCalledWith('wf-1');
+    });
 
-    it('allows deprecated status command in read-only mode', async () => {
+    it('rejects the removed status alias with normal unknown-command behavior', async () => {
       mockDeps.orchestrator.syncFromDb = vi.fn();
       mockDeps.orchestrator.getAllTasks = vi.fn(() => []);
       await expect(
-        runHeadless(['status'], mockDeps)
-      ).resolves.toBeUndefined();
+        runHeadless(['status'], mockDeps),
+      ).rejects.toThrow('Unknown command: status');
+      expect(mockDeps.orchestrator.syncFromDb).not.toHaveBeenCalled();
     });
   });
 
@@ -1799,15 +1800,28 @@ describe('headless delegation enforcement', () => {
     });
   });
 
-  describe('delete-workflow lifecycle bridge', () => {
-    it('headless delete-workflow always routes through commandService.deleteWorkflow', async () => {
+  describe('delete workflow lifecycle bridge', () => {
+    it('rejects the removed delete-workflow alias with normal unknown-command behavior', async () => {
       mockDeps.commandService.deleteWorkflow = vi.fn(async () => ({ ok: true as const, data: undefined })) as any;
       mockDeps.commandService.cancelWorkflow = vi.fn(async () => ({
         ok: true as const,
         data: { cancelled: [], runningCancelled: [] },
       }));
 
-      await runHeadless(['delete-workflow', 'wf-1'], mockDeps);
+      await expect(runHeadless(['delete-workflow', 'wf-1'], mockDeps))
+        .rejects.toThrow('Unknown command: delete-workflow');
+
+      expect(mockDeps.commandService.deleteWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('headless delete always routes through commandService.deleteWorkflow', async () => {
+      mockDeps.commandService.deleteWorkflow = vi.fn(async () => ({ ok: true as const, data: undefined })) as any;
+      mockDeps.commandService.cancelWorkflow = vi.fn(async () => ({
+        ok: true as const,
+        data: { cancelled: [], runningCancelled: [] },
+      }));
+
+      await runHeadless(['delete', 'wf-1'], mockDeps);
 
       expect(mockDeps.commandService.deleteWorkflow).toHaveBeenCalled();
     });

--- a/packages/app/src/__tests__/headless-query-capture.test.ts
+++ b/packages/app/src/__tests__/headless-query-capture.test.ts
@@ -56,10 +56,11 @@ describe('runReadOnlyHeadlessQueryToString', () => {
     }
   });
 
-  it('maps the deprecated alias `list` to `query workflows`', async () => {
+  it('rejects the removed list alias instead of mapping it to query workflows', async () => {
     const deps = makeQueryDeps(() => [{ id: 'wf-9' }]);
-    const output = await runReadOnlyHeadlessQueryToString(['list', '--output', 'label'], deps);
-    expect(output).toBe('wf-9\n');
+    await expect(
+      runReadOnlyHeadlessQueryToString(['list', '--output', 'label'], deps),
+    ).rejects.toThrow('Command "list" is not a delegatable read-only query');
   });
 
   it('uses configured default agent when session task has no persisted agent name', async () => {
@@ -85,7 +86,7 @@ describe('runReadOnlyHeadlessQueryToString', () => {
       getAllTasks: vi.fn(() => [task]),
     } as unknown as HeadlessQueryDeps['orchestrator'];
 
-    const output = await runReadOnlyHeadlessQueryToString(['session', 'task-1'], deps);
+    const output = await runReadOnlyHeadlessQueryToString(['query', 'session', 'task-1'], deps);
 
     expect(output).toContain('agent=custom-agent sessionId=sess-1\n');
   });

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -43,6 +43,11 @@ import {
   tryAcknowledgeNoTrackTaskMutationWithoutDb,
   tryAcknowledgeNoTrackTaskMutationWithoutOwner,
 } from './headless-no-track-fallback.js';
+import {
+  isHeadlessHelpCommand,
+  isRemovedHeadlessCommandAlias,
+} from './headless-command-registry.js';
+import { printHeadlessUsage } from './headless-usage.js';
 
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
@@ -672,7 +677,17 @@ export async function runHeadlessClientCommand(
 
   const { args, waitForApproval, noTrack } = parseArgs(argv);
   const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1';
-  const internalOwnerServe = args[0] === 'owner-serve';
+  const command = args[0];
+  const internalOwnerServe = command === 'owner-serve';
+
+  if (isHeadlessHelpCommand(command)) {
+    printHeadlessUsage();
+    return 0;
+  }
+
+  if (isRemovedHeadlessCommandAlias(command)) {
+    throw new Error(`Unknown command: ${command}. Run with --help for usage.`);
+  }
 
   if (!internalOwnerServe && await delegateWorkerControl(args, deps.messageBus, invokerConfig, deps.refreshMessageBus)) {
     const exitCode = process.exitCode;

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -3,7 +3,6 @@ export type HeadlessCommandKind = 'read' | 'write' | 'special';
 export interface HeadlessCommandDefinition {
   readonly name: string;
   readonly kind: HeadlessCommandKind;
-  readonly aliases?: readonly string[];
 }
 
 export const HEADLESS_SET_SUBCOMMANDS = [
@@ -54,30 +53,24 @@ export const HEADLESS_COMMANDS = [
   { name: 'cancel', kind: 'write' },
   { name: 'cancel-workflow', kind: 'write' },
   { name: 'delete-task', kind: 'write' },
-  { name: 'delete-workflow', kind: 'write', aliases: ['delete'] },
+  { name: 'delete', kind: 'write' },
   { name: 'delete-all', kind: 'write' },
   { name: 'open-terminal', kind: 'read' },
   { name: 'query-select', kind: 'read' },
   { name: 'worker', kind: 'read' },
-  { name: 'list', kind: 'read' },
-  { name: 'status', kind: 'read' },
-  { name: 'task-status', kind: 'read' },
-  { name: 'queue', kind: 'read' },
-  { name: 'audit', kind: 'read' },
-  { name: 'session', kind: 'read' },
-  { name: 'edit', kind: 'write' },
-  { name: 'edit-executor', kind: 'write' },
-  { name: 'edit-type', kind: 'write' },
-  { name: 'edit-agent', kind: 'write' },
-  { name: 'set-merge-mode', kind: 'write' },
 ] as const satisfies readonly HeadlessCommandDefinition[];
 
 export function findHeadlessCommandDefinition(command: string | undefined): HeadlessCommandDefinition | undefined {
   if (!command) return undefined;
-  return HEADLESS_COMMANDS.find((definition) => (
-    definition.name === command
-      || ('aliases' in definition && (definition.aliases as readonly string[]).includes(command))
-  ));
+  return HEADLESS_COMMANDS.find((definition) => definition.name === command);
+}
+
+export function isHeadlessHelpCommand(command: string | undefined): boolean {
+  return command === undefined || command === '--help' || command === '-h';
+}
+
+export function isRemovedHeadlessCommandAlias(command: string | undefined): boolean {
+  return command === 'set-merge-mode';
 }
 
 export function isMutatingSetSubcommand(subcommand: string | undefined): boolean {

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -5,9 +5,8 @@
  * collection/rollup
  * helpers, agent session resolution, and `query-select`.
  *
- * The deprecated top-level aliases (`list`, `status`, `task-status`, `queue`,
- * `audit`, `session`) route here through the `headless.ts` router. It depends on
- * `headless-shared.ts` and reuses `worker-control.ts` for the worker-decisions view.
+ * It depends on `headless-shared.ts` and reuses `worker-control.ts` for the
+ * worker-decisions view.
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
@@ -981,19 +980,6 @@ async function dispatchReadOnlyHeadlessQuery(args: string[], deps: HeadlessQuery
       return headlessQuery(args.slice(1), deps);
     case 'query-select':
       return headlessQuerySelect(args[1], deps);
-    // Deprecated top-level aliases → canonical `query <sub>`.
-    case 'list':
-      return headlessQuery(['workflows', ...args.slice(1)], deps);
-    case 'status':
-      return headlessQuery(['tasks', ...args.slice(1)], deps);
-    case 'task-status':
-      return headlessQuery(['task', ...args.slice(1)], deps);
-    case 'queue':
-      return headlessQuery(['queue', ...args.slice(1)], deps);
-    case 'audit':
-      return headlessQuery(['audit', ...args.slice(1)], deps);
-    case 'session':
-      return headlessQuery(['session', ...args.slice(1)], deps);
     case 'worker': {
       const workerSub = args[1] ?? 'list';
       if (workerSub === 'status') {

--- a/packages/app/src/headless-usage.ts
+++ b/packages/app/src/headless-usage.ts
@@ -1,0 +1,85 @@
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+
+export function printHeadlessUsage(): void {
+  process.stdout.write(`${BOLD}invoker${RESET} — Headless workflow runner (Electron)
+
+${BOLD}Usage:${RESET}  electron dist/main.js --headless <command> [args...]
+
+${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
+  query workflows [--status S] [--output F]          List all saved workflows
+  query workflow <workflowId> [--output F]           Show one workflow
+  query tasks [--workflow <id>|<workflowId>] [--status S]
+                                                      Show task states (latest workflow by default)
+    [--no-merge] [--output F]
+  query task <taskId> [--output F]                    Print single task status
+  query queue [--output F]                            Show queue status
+  query review-gate <prNumber|prUrl> [--output F]    Resolve a PR back to its Invoker workflow
+  query action-graph [--output F]                     Print action graph source-of-truth snapshot
+  query audit <taskId> [--output F]                   Print event history
+  query session <taskId>                              Print agent session messages
+  query worker-actions [--workflow <id>] [--status S] [--decision act|skip]
+                                                      List durable worker action rows (all workers)
+  query worker-decisions [--workflow <id>] [--decision act|skip] [--reason <substr>]
+                                                      Show what each worker decided: submitted vs skipped, and why
+  query ui-perf [--output F] [--reset]               Print live UI perf stats
+  query stats [--output F]                           Aggregate stats across all workflows
+  query execution-leases [--output F]               List live SSH/host execution resource leases
+
+${BOLD}Execute:${RESET}
+  watch [<workflowId>]                                Watch workflow status until settled or Ctrl-C
+  run <plan.yaml>                                     Load and execute plan
+  start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--recreate-all]
+              [--fresh-base-failed] [--fresh-base-failed-and-pending] [--fresh-base-failed-pending-and-running] [--fresh-base-all] [--no-track]
+                                                      Start pending work that is ready to execute
+                                                      Fresh-base flags recreate selected workflows from a refreshed base
+  resume <id>                                         Resume incomplete workflow
+  retry <workflowId>                                  Retry workflow: rerun failed, keep completed
+  retry-task <taskId>                                 Retry a single failed/stuck task
+  recreate <workflowId>                                Recreate workflow: wipe all state, new generation
+  recreate-task <taskId>                               Recreate task + downstream (task-scoped reset)
+  recreate-downstream <taskId>                         Recreate downstream of task only (target preserved)
+  fork-workflow <workflowId>                          Fork a live workflow into a new branched workflow (Step 14)
+  detach-workflow <workflowId> <upstreamWorkflowId>  Detach one upstream workflow and void downstream to pending
+  rebase-retry <workflowId|mergeTaskId|taskId>        Refresh pool base, then retry incomplete work
+  rebase-recreate <workflowId|mergeTaskId|taskId>     Refresh pool base, then recreate workflow
+  repair-review-gate-ci <prNumber|prUrl>              Queue CI repair for one mapped review-gate PR
+  fix <taskId> [claude|codex]                         Fix a failed task (default: claude)
+
+${BOLD}Respond:${RESET}
+  approve <taskId>                                    Approve a task
+  reject <taskId> [reason]                            Reject a task
+  input <taskId> <text>                               Provide input to task
+  select <taskId> <experimentId>                      Select winning experiment
+
+${BOLD}Configure:${RESET}
+  install-skills [install|update|reinstall]          Install bundled Invoker AI helpers
+  set command <taskId> <cmd>                          Edit task command and re-run
+  set prompt <taskId> <text>                          Edit task prompt and re-run
+  set pool <taskId> <type> [poolMemberId]           Change execution pool (worktree|docker|ssh)
+  set agent <taskId> <agent>                          Change execution agent (claude|codex|omp)
+  set merge-mode <workflowId> <mode>                  manual | automatic | external_review
+  set fix-prompt <taskId> <text>                      Update fix-session prompt and retry
+  set fix-context <taskId> <text>                     Update fix-session context and retry
+  set gate-policy <taskId> <wfId> [depTaskId] <policy>
+                                                      policy: completed | review_ready | ci_failed
+  set workflow <workflowId> <fieldPath> <value>      Safely update workflow metadata/config
+  set task <taskId> <fieldPath> <value>              Safely update task metadata/config
+  migrate-compat                                     Normalize persisted compatibility workflow/task state
+
+${BOLD}Lifecycle:${RESET}
+  cancel <taskId>                                     Cancel task + all downstream
+  cancel-workflow <workflowId>                        Cancel all active tasks in a workflow
+  delete-task <taskId>                                 Delete one task and retarget dependents
+  delete <workflowId>                                  Delete a single workflow
+  delete-all                                           Delete all workflows (requires INVOKER_ALLOW_DELETE_ALL=1)
+  open-terminal <taskId>                              Open OS terminal for a task
+  slack                                               Start Slack bot (long-running)
+  worker [kind|list|status]                           Run/list registry worker kinds (autofix scans failed tasks)
+
+${BOLD}Options:${RESET}
+  --wait-for-approval    Keep running until PR approval (use with 'run' or 'resume')
+  --no-track             Submit and return immediately after printing Workflow ID
+  --do-not-track         Alias for --no-track
+`);
+}

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -42,7 +42,12 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
-import { formatHeadlessSetSubcommands } from './headless-command-registry.js';
+import {
+  formatHeadlessSetSubcommands,
+  isHeadlessHelpCommand,
+  isRemovedHeadlessCommandAlias,
+} from './headless-command-registry.js';
+import { printHeadlessUsage } from './headless-usage.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 
 export {
@@ -63,7 +68,6 @@ import {
   type QueryFlags,
   BOLD,
   RESET,
-  YELLOW,
   createHeadlessExecutor,
   wireHeadlessApproveHook,
   parseQueryFlags,
@@ -146,14 +150,6 @@ async function dispatchHeadlessRunnableTasks(
   const timer = setInterval(poll, 250);
   timer.unref?.();
   await new Promise<void>((resolve) => setImmediate(resolve));
-}
-
-// ── Deprecation Warning ─────────────────────────────────────
-
-function warnDeprecated(oldCmd: string, newCmd: string): void {
-  process.stderr.write(
-    `${YELLOW}[deprecated]${RESET} "${oldCmd}" is deprecated. Use "${newCmd}" instead.\n`,
-  );
 }
 
 function assertDeleteAllEnabled(): void {
@@ -244,6 +240,15 @@ async function headlessInstallSkills(
 
 export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<void> {
   const command = args[0];
+
+  if (isHeadlessHelpCommand(command)) {
+    printHeadlessUsage();
+    return;
+  }
+
+  if (isRemovedHeadlessCommandAlias(command)) {
+    throw new Error(`Unknown command: ${command}. Run with --help for usage.`);
+  }
 
   switch (command) {
     case 'owner-serve':
@@ -366,7 +371,6 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       await headlessDeleteTask(args[1], deps);
       break;
     case 'delete':
-    case 'delete-workflow':
       await headlessDeleteWorkflow(args[1], deps);
       break;
     case 'delete-all':
@@ -394,56 +398,6 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       await headlessWorker(args.slice(1), deps);
       break;
 
-    // ── Deprecated aliases → query ──
-    case 'list':
-      warnDeprecated('list', 'query workflows');
-      await headlessQuery(['workflows', ...args.slice(1)], deps);
-      break;
-    case 'status':
-      warnDeprecated('status', 'query tasks');
-      await headlessQuery(['tasks', ...args.slice(1)], deps);
-      break;
-    case 'task-status':
-      warnDeprecated('task-status', 'query task');
-      await headlessQuery(['task', ...args.slice(1)], deps);
-      break;
-    case 'queue':
-      warnDeprecated('queue', 'query queue');
-      await headlessQuery(['queue', ...args.slice(1)], deps);
-      break;
-    case 'audit':
-      warnDeprecated('audit', 'query audit');
-      await headlessQuery(['audit', ...args.slice(1)], deps);
-      break;
-    case 'session':
-      warnDeprecated('session', 'query session');
-      await headlessQuery(['session', ...args.slice(1)], deps);
-      break;
-
-    // ── Deprecated aliases → set ──
-    case 'edit':
-      warnDeprecated('edit', 'set command');
-      await headlessSet(['command', ...args.slice(1)], deps);
-      break;
-    case 'edit-executor':
-    case 'edit-type':
-      warnDeprecated(command, 'set pool');
-      await headlessSet(['pool', ...args.slice(1)], deps);
-      break;
-    case 'edit-agent':
-      warnDeprecated('edit-agent', 'set agent');
-      await headlessSet(['agent', ...args.slice(1)], deps);
-      break;
-    case 'set-merge-mode':
-      warnDeprecated('set-merge-mode', 'set merge-mode');
-      await headlessSet(['merge-mode', ...args.slice(1)], deps);
-      break;
-
-    case '--help':
-    case '-h':
-    case undefined:
-      printHeadlessUsage();
-      break;
     default:
       throw new Error(`Unknown command: ${command}. Run with --help for usage.`);
   }
@@ -556,99 +510,8 @@ async function headlessOwnerServe(deps: Pick<HeadlessDeps, 'isStandaloneOwnerIdl
   });
 }
 
-function printHeadlessUsage(): void {
-  process.stdout.write(`${BOLD}invoker${RESET} — Headless workflow runner (Electron)
-
-${BOLD}Usage:${RESET}  electron dist/main.js --headless <command> [args...]
-
-${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
-  query workflows [--status S] [--output F]          List all saved workflows
-  query workflow <workflowId> [--output F]           Show one workflow
-  query tasks [--workflow <id>|<workflowId>] [--status S]
-                                                      Show task states (latest workflow by default)
-    [--no-merge] [--output F]
-  query task <taskId> [--output F]                    Print single task status
-  query queue [--output F]                            Show queue status
-  query review-gate <prNumber|prUrl> [--output F]    Resolve a PR back to its Invoker workflow
-  query action-graph [--output F]                     Print action graph source-of-truth snapshot
-  query audit <taskId> [--output F]                   Print event history
-  query session <taskId>                              Print agent session messages
-  query worker-actions [--workflow <id>] [--status S] [--decision act|skip]
-                                                      List durable worker action rows (all workers)
-  query worker-decisions [--workflow <id>] [--decision act|skip] [--reason <substr>]
-                                                      Show what each worker decided: submitted vs skipped, and why
-  query ui-perf [--output F] [--reset]               Print live UI perf stats
-  query stats [--output F]                           Aggregate stats across all workflows
-  query execution-leases [--output F]               List live SSH/host execution resource leases
-
-${BOLD}Execute:${RESET}
-  watch [<workflowId>]                                Watch workflow status until settled or Ctrl-C
-  run <plan.yaml>                                     Load and execute plan
-  start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--recreate-all]
-              [--fresh-base-failed] [--fresh-base-failed-and-pending] [--fresh-base-failed-pending-and-running] [--fresh-base-all] [--no-track]
-                                                      Start pending work that is ready to execute
-                                                      Fresh-base flags recreate selected workflows from a refreshed base
-  resume <id>                                         Resume incomplete workflow
-  retry <workflowId>                                  Retry workflow: rerun failed, keep completed
-  retry-task <taskId>                                 Retry a single failed/stuck task
-  recreate <workflowId>                                Recreate workflow: wipe all state, new generation
-  recreate-task <taskId>                               Recreate task + downstream (task-scoped reset)
-  recreate-downstream <taskId>                         Recreate downstream of task only (target preserved)
-  fork-workflow <workflowId>                          Fork a live workflow into a new branched workflow (Step 14)
-  detach-workflow <workflowId> <upstreamWorkflowId>  Detach one upstream workflow and void downstream to pending
-  rebase-retry <workflowId|mergeTaskId|taskId>        Refresh pool base, then retry incomplete work
-  rebase-recreate <workflowId|mergeTaskId|taskId>     Refresh pool base, then recreate workflow
-  reset-autofix-budget --exhausted                    Reset exhausted automatic recovery budgets only
-  repair-review-gate-ci <prNumber|prUrl>              Queue CI repair for one mapped review-gate PR
-  fix <taskId> [claude|codex]                         Fix a failed task (default: claude)
-
-${BOLD}Respond:${RESET}
-  approve <taskId>                                    Approve a task
-  reject <taskId> [reason]                            Reject a task
-  input <taskId> <text>                               Provide input to task
-  select <taskId> <experimentId>                      Select winning experiment
-
-${BOLD}Configure:${RESET}
-  install-skills [install|update|reinstall]          Install bundled Invoker AI helpers
-  set command <taskId> <cmd>                          Edit task command and re-run
-  set prompt <taskId> <text>                          Edit task prompt and re-run
-  set pool <taskId> <type> [poolMemberId]           Change execution pool (worktree|docker|ssh)
-  set agent <taskId> <agent>                          Change execution agent (claude|codex|omp)
-  set merge-mode <workflowId> <mode>                  manual | automatic | external_review
-  set fix-prompt <taskId> <text>                      Update fix-session prompt and retry
-  set fix-context <taskId> <text>                     Update fix-session context and retry
-  set gate-policy <taskId> <wfId> [depTaskId] <policy>
-                                                      policy: completed | review_ready | ci_failed
-  set workflow <workflowId> <fieldPath> <value>      Safely update workflow metadata/config
-  set task <taskId> <fieldPath> <value>              Safely update task metadata/config
-  migrate-compat                                     Normalize persisted compatibility workflow/task state
-
-${BOLD}Lifecycle:${RESET}
-  cancel <taskId>                                     Cancel task + all downstream
-  cancel-workflow <workflowId>                        Cancel all active tasks in a workflow
-  delete-task <taskId>                                 Delete one task and retarget dependents
-  delete <workflowId>                                  Delete a single workflow
-  delete-all                                           Delete all workflows (requires INVOKER_ALLOW_DELETE_ALL=1)
-  open-terminal <taskId>                              Open OS terminal for a task
-  slack                                               Start Slack bot (long-running)
-  worker [kind|list|status]                           Run/list registry worker kinds (autofix scans failed tasks)
-
-${BOLD}Deprecated${RESET} (use new names above):
-  list → query workflows       status → query tasks       task-status → query task
-  queue → query queue           audit → query audit         session → query session
-  edit → set command            edit-executor → set pool
-  edit-agent → set agent        set-merge-mode → set merge-mode
-  delete-workflow → delete
-
-${BOLD}Options:${RESET}
-  --wait-for-approval    Keep running until PR approval (use with 'run' or 'resume')
-  --no-track             Submit and return immediately after printing Workflow ID
-  --do-not-track         Alias for --no-track
-`);
-}
-
 async function headlessEdit(taskId: string, newCommand: string, deps: HeadlessDeps): Promise<void> {
-  if (!taskId || !newCommand) throw new Error('Missing arguments. Usage: --headless edit <taskId> <newCommand>');
+  if (!taskId || !newCommand) throw new Error('Missing arguments. Usage: --headless set command <taskId> <newCommand>');
   const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'set command');
   if (!restored) return;
   taskId = restored.resolvedTaskId;
@@ -790,9 +653,7 @@ async function headlessEditAgent(taskId: string, agentName: string, deps: Headle
  * `retryTask` compatibility wire — see `MUTATION_POLICIES.mergeMode`
  * and `buildInvalidationDeps`).
  *
- * The CLI argument is still a workflow id (matches the legacy
- * `set-merge-mode <workflowId> <mode>` surface and the
- * `invoker:set-merge-mode` IPC). `mergeMode` is normalized at the
+ * The CLI argument is a workflow id. `mergeMode` is normalized at the
  * app boundary because that concerns UI/CLI input parsing, not the
  * chart's invalidation routing. The merge-task-id translation
  * (`workflowId → __merge__<workflowId>`) happens here because the
@@ -808,7 +669,7 @@ async function headlessSetMergeMode(
 ): Promise<void> {
   if (!workflowId || !mergeMode) {
     throw new Error(
-      'Missing arguments. Usage: --headless set-merge-mode <workflowId> <manual|automatic|external_review>',
+      'Missing arguments. Usage: --headless set merge-mode <workflowId> <manual|automatic|external_review>',
     );
   }
   const normalized = normalizeMergeModeForPersistence(mergeMode);


### PR DESCRIPTION
## Summary

This slice narrows the headless CLI vocabulary.

Help now comes from the shared usage printer, and canonical grouped commands remain exposed.

## Review Claim

The headless CLI exposes only canonical commands, and unsupported aliases fall through the normal unknown-command path.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice stays in the headless parser, help, query, and direct headless regression files.

## Slice Rationale

Keeping the command vocabulary first gives later slices one CLI vocabulary.

## Non-goals

- No IPC contract changes.
- No HTTP endpoint changes.
- No worker retry behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-command-classification.test.ts src/__tests__/headless-delegation.test.ts src/__tests__/headless-query-capture.test.ts`
- [x] `./run.sh --headless --help`
- [x] `./run.sh --headless set-merge-mode wf-123 manual`
- [x] `./run.sh --headless retry-task wf-123/task-1`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <published commit sha>`
- Post-revert steps: Rerun the focused headless checks.
- Data migration? No

</details>
