### PR TITLE
[Remove deprecated merge-mode and retry paths](2) Reject removed aliases before owner startup

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -130,6 +130,10 @@ import {
   isHeadlessReadOnlyCommand,
   resolveHeadlessTargetWorkflowId,
 } from './headless-command-classification.js';
+import {
+  isHeadlessHelpCommand,
+  isRemovedHeadlessCommandAlias,
+} from './headless-command-registry.js';
 import { backupPlan } from './plan-backup.js';
 import { startApiServer, type ApiServer } from './api-server.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
@@ -145,6 +149,7 @@ import {
   wireHeadlessApproveHook,
   type HeadlessDeps,
 } from './headless.js';
+import { printHeadlessUsage } from './headless-usage.js';
 import { buildHeadlessApiServerDeps } from './headless-shared.js';
 import { parseReviewGatePrNumber, repairReviewGateCiByPr } from './review-gate-ci-repair-command.js';
 import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
@@ -865,6 +870,18 @@ function startHeadlessMode(): void {
     const mutatingMode = isHeadlessMutatingCommand(cliArgs);
     const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1' || command === 'owner-serve';
     const ownsHeadlessShutdown = standaloneMode && !readOnlyMode && command === 'owner-serve';
+
+    if (isHeadlessHelpCommand(command)) {
+      printHeadlessUsage();
+      process.exit(0);
+      return;
+    }
+
+    if (isRemovedHeadlessCommandAlias(command)) {
+      process.stderr.write(`${RED}Error:${RESET} Unknown command: ${command}. Run with --help for usage.\n`);
+      process.exit(1);
+      return;
+    }
 
     // Try delegation for mutating commands first (owner mode).
     // In standalone mode we skip delegation and run locally.


### PR DESCRIPTION
## Summary

This slice adds an argv guard to owner startup.

Direct owner-mode argv now exits before runtime initialization when `set-merge-mode` is supplied.

## Review Claim

Owner startup stops the `set-merge-mode` argv token before runtime initialization.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice changes the owner entrypoint guard only. Normal startup continues through the existing path.

## Slice Rationale

The client wrapper is covered earlier; this slice closes the direct owner startup path.

## Non-goals

- No parser table changes.
- No IPC contract changes.
- No HTTP endpoint changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `./run.sh --headless set-merge-mode wf-123 manual`
- [x] `./run.sh --headless --help`

</details>

## Visual Proof

Owner startup proof: direct headless argv exits before runtime initialization when the retired token is supplied.

![Owner startup argv proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-159e87/slice2-owner-entrypoint-before-startup.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <published commit sha>`
- Post-revert steps: Rerun the focused headless smoke checks.
- Data migration? No

</details>
