### PR TITLE
[Remove deprecated merge-mode and retry paths](4) Move app and UI bridges to retry-task

### DIFF
--- a/packages/app/src/__tests__/gui-mutation-translation.test.ts
+++ b/packages/app/src/__tests__/gui-mutation-translation.test.ts
@@ -62,7 +62,7 @@ describe('GUI mutation translation', () => {
     );
   });
   it.each([
-    ['invoker:restart-task', 'retry-task'],
+    ['invoker:retry-task', 'retry-task'],
     ['invoker:cancel-task', 'cancel'],
     ['invoker:delete-task', 'delete-task'],
     ['invoker:cancel-workflow', 'cancel-workflow'],

--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -46,7 +46,7 @@ describe('headless auto-fix cutover', () => {
 });
 
 describe('headless worker autofix', () => {
-  it('runs a one-shot scan under the single-instance lock and enqueues a bare restart first', async () => {
+  it('runs a one-shot scan under the single-instance lock and enqueues a bare retry first', async () => {
     const task = makeTask();
     const actions = new Map<string, WorkerActionRecord>();
     const enqueueWorkflowMutationIntent = vi.fn((
@@ -99,7 +99,7 @@ describe('headless worker autofix', () => {
 
     expect(enqueueWorkflowMutationIntent).toHaveBeenCalledWith(
       'wf-1',
-      'invoker:restart-task',
+      'invoker:retry-task',
       ['wf-1/task-1'],
       'normal',
     );

--- a/packages/app/src/__tests__/headless-command-classification.test.ts
+++ b/packages/app/src/__tests__/headless-command-classification.test.ts
@@ -34,8 +34,10 @@ describe('headless-command-classification', () => {
   it('classifies read-only commands', () => {
     expect(isHeadlessReadOnlyCommand([])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['query'])).toBe(true);
-    expect(isHeadlessReadOnlyCommand(['list'])).toBe(true);
-    expect(isHeadlessReadOnlyCommand(['session'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['query', 'workflows'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['query', 'session'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['list'])).toBe(false);
+    expect(isHeadlessReadOnlyCommand(['session'])).toBe(false);
     expect(isHeadlessReadOnlyCommand(['open-terminal'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['worker'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['worker', 'status'])).toBe(true);

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -163,35 +163,36 @@ describe('headless delegation enforcement', () => {
       stdout.mockRestore();
     });
 
-      it('allows deprecated list command in read-only mode', async () => {
-        await expect(
-          runHeadless(['list'], mockDeps)
-        ).resolves.toBeUndefined();
-      });
+    it('rejects the removed list alias with normal unknown-command behavior', async () => {
+      await expect(
+        runHeadless(['list'], mockDeps),
+      ).rejects.toThrow('Unknown command: list');
+    });
 
-      it('allows query workflow for a single workflow', async () => {
-        mockDeps.persistence.loadWorkflow = vi.fn(() => ({
-          id: 'wf-1',
-          name: 'Workflow one',
-          status: 'pending',
-          generation: 0,
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-        } as any));
+    it('allows query workflow for a single workflow', async () => {
+      mockDeps.persistence.loadWorkflow = vi.fn(() => ({
+        id: 'wf-1',
+        name: 'Workflow one',
+        status: 'pending',
+        generation: 0,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      } as any));
 
-        await expect(
-          runHeadless(['query', 'workflow', 'wf-1', '--output', 'json'], mockDeps),
-        ).resolves.toBeUndefined();
+      await expect(
+        runHeadless(['query', 'workflow', 'wf-1', '--output', 'json'], mockDeps),
+      ).resolves.toBeUndefined();
 
-        expect(mockDeps.persistence.loadWorkflow).toHaveBeenCalledWith('wf-1');
-      });
+      expect(mockDeps.persistence.loadWorkflow).toHaveBeenCalledWith('wf-1');
+    });
 
-    it('allows deprecated status command in read-only mode', async () => {
+    it('rejects the removed status alias with normal unknown-command behavior', async () => {
       mockDeps.orchestrator.syncFromDb = vi.fn();
       mockDeps.orchestrator.getAllTasks = vi.fn(() => []);
       await expect(
-        runHeadless(['status'], mockDeps)
-      ).resolves.toBeUndefined();
+        runHeadless(['status'], mockDeps),
+      ).rejects.toThrow('Unknown command: status');
+      expect(mockDeps.orchestrator.syncFromDb).not.toHaveBeenCalled();
     });
   });
 
@@ -1799,15 +1800,28 @@ describe('headless delegation enforcement', () => {
     });
   });
 
-  describe('delete-workflow lifecycle bridge', () => {
-    it('headless delete-workflow always routes through commandService.deleteWorkflow', async () => {
+  describe('delete workflow lifecycle bridge', () => {
+    it('rejects the removed delete-workflow alias with normal unknown-command behavior', async () => {
       mockDeps.commandService.deleteWorkflow = vi.fn(async () => ({ ok: true as const, data: undefined })) as any;
       mockDeps.commandService.cancelWorkflow = vi.fn(async () => ({
         ok: true as const,
         data: { cancelled: [], runningCancelled: [] },
       }));
 
-      await runHeadless(['delete-workflow', 'wf-1'], mockDeps);
+      await expect(runHeadless(['delete-workflow', 'wf-1'], mockDeps))
+        .rejects.toThrow('Unknown command: delete-workflow');
+
+      expect(mockDeps.commandService.deleteWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('headless delete always routes through commandService.deleteWorkflow', async () => {
+      mockDeps.commandService.deleteWorkflow = vi.fn(async () => ({ ok: true as const, data: undefined })) as any;
+      mockDeps.commandService.cancelWorkflow = vi.fn(async () => ({
+        ok: true as const,
+        data: { cancelled: [], runningCancelled: [] },
+      }));
+
+      await runHeadless(['delete', 'wf-1'], mockDeps);
 
       expect(mockDeps.commandService.deleteWorkflow).toHaveBeenCalled();
     });

--- a/packages/app/src/__tests__/headless-query-capture.test.ts
+++ b/packages/app/src/__tests__/headless-query-capture.test.ts
@@ -56,10 +56,11 @@ describe('runReadOnlyHeadlessQueryToString', () => {
     }
   });
 
-  it('maps the deprecated alias `list` to `query workflows`', async () => {
+  it('rejects the removed list alias instead of mapping it to query workflows', async () => {
     const deps = makeQueryDeps(() => [{ id: 'wf-9' }]);
-    const output = await runReadOnlyHeadlessQueryToString(['list', '--output', 'label'], deps);
-    expect(output).toBe('wf-9\n');
+    await expect(
+      runReadOnlyHeadlessQueryToString(['list', '--output', 'label'], deps),
+    ).rejects.toThrow('Command "list" is not a delegatable read-only query');
   });
 
   it('uses configured default agent when session task has no persisted agent name', async () => {
@@ -85,7 +86,7 @@ describe('runReadOnlyHeadlessQueryToString', () => {
       getAllTasks: vi.fn(() => [task]),
     } as unknown as HeadlessQueryDeps['orchestrator'];
 
-    const output = await runReadOnlyHeadlessQueryToString(['session', 'task-1'], deps);
+    const output = await runReadOnlyHeadlessQueryToString(['query', 'session', 'task-1'], deps);
 
     expect(output).toContain('agent=custom-agent sessionId=sess-1\n');
   });

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -43,6 +43,11 @@ import {
   tryAcknowledgeNoTrackTaskMutationWithoutDb,
   tryAcknowledgeNoTrackTaskMutationWithoutOwner,
 } from './headless-no-track-fallback.js';
+import {
+  isHeadlessHelpCommand,
+  isRemovedHeadlessCommandAlias,
+} from './headless-command-registry.js';
+import { printHeadlessUsage } from './headless-usage.js';
 
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
@@ -672,7 +677,17 @@ export async function runHeadlessClientCommand(
 
   const { args, waitForApproval, noTrack } = parseArgs(argv);
   const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1';
-  const internalOwnerServe = args[0] === 'owner-serve';
+  const command = args[0];
+  const internalOwnerServe = command === 'owner-serve';
+
+  if (isHeadlessHelpCommand(command)) {
+    printHeadlessUsage();
+    return 0;
+  }
+
+  if (isRemovedHeadlessCommandAlias(command)) {
+    throw new Error(`Unknown command: ${command}. Run with --help for usage.`);
+  }
 
   if (!internalOwnerServe && await delegateWorkerControl(args, deps.messageBus, invokerConfig, deps.refreshMessageBus)) {
     const exitCode = process.exitCode;

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -3,7 +3,6 @@ export type HeadlessCommandKind = 'read' | 'write' | 'special';
 export interface HeadlessCommandDefinition {
   readonly name: string;
   readonly kind: HeadlessCommandKind;
-  readonly aliases?: readonly string[];
 }
 
 export const HEADLESS_SET_SUBCOMMANDS = [
@@ -54,30 +53,24 @@ export const HEADLESS_COMMANDS = [
   { name: 'cancel', kind: 'write' },
   { name: 'cancel-workflow', kind: 'write' },
   { name: 'delete-task', kind: 'write' },
-  { name: 'delete-workflow', kind: 'write', aliases: ['delete'] },
+  { name: 'delete', kind: 'write' },
   { name: 'delete-all', kind: 'write' },
   { name: 'open-terminal', kind: 'read' },
   { name: 'query-select', kind: 'read' },
   { name: 'worker', kind: 'read' },
-  { name: 'list', kind: 'read' },
-  { name: 'status', kind: 'read' },
-  { name: 'task-status', kind: 'read' },
-  { name: 'queue', kind: 'read' },
-  { name: 'audit', kind: 'read' },
-  { name: 'session', kind: 'read' },
-  { name: 'edit', kind: 'write' },
-  { name: 'edit-executor', kind: 'write' },
-  { name: 'edit-type', kind: 'write' },
-  { name: 'edit-agent', kind: 'write' },
-  { name: 'set-merge-mode', kind: 'write' },
 ] as const satisfies readonly HeadlessCommandDefinition[];
 
 export function findHeadlessCommandDefinition(command: string | undefined): HeadlessCommandDefinition | undefined {
   if (!command) return undefined;
-  return HEADLESS_COMMANDS.find((definition) => (
-    definition.name === command
-      || ('aliases' in definition && (definition.aliases as readonly string[]).includes(command))
-  ));
+  return HEADLESS_COMMANDS.find((definition) => definition.name === command);
+}
+
+export function isHeadlessHelpCommand(command: string | undefined): boolean {
+  return command === undefined || command === '--help' || command === '-h';
+}
+
+export function isRemovedHeadlessCommandAlias(command: string | undefined): boolean {
+  return command === 'set-merge-mode';
 }
 
 export function isMutatingSetSubcommand(subcommand: string | undefined): boolean {

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -5,9 +5,8 @@
  * collection/rollup
  * helpers, agent session resolution, and `query-select`.
  *
- * The deprecated top-level aliases (`list`, `status`, `task-status`, `queue`,
- * `audit`, `session`) route here through the `headless.ts` router. It depends on
- * `headless-shared.ts` and reuses `worker-control.ts` for the worker-decisions view.
+ * It depends on `headless-shared.ts` and reuses `worker-control.ts` for the
+ * worker-decisions view.
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
@@ -981,19 +980,6 @@ async function dispatchReadOnlyHeadlessQuery(args: string[], deps: HeadlessQuery
       return headlessQuery(args.slice(1), deps);
     case 'query-select':
       return headlessQuerySelect(args[1], deps);
-    // Deprecated top-level aliases → canonical `query <sub>`.
-    case 'list':
-      return headlessQuery(['workflows', ...args.slice(1)], deps);
-    case 'status':
-      return headlessQuery(['tasks', ...args.slice(1)], deps);
-    case 'task-status':
-      return headlessQuery(['task', ...args.slice(1)], deps);
-    case 'queue':
-      return headlessQuery(['queue', ...args.slice(1)], deps);
-    case 'audit':
-      return headlessQuery(['audit', ...args.slice(1)], deps);
-    case 'session':
-      return headlessQuery(['session', ...args.slice(1)], deps);
     case 'worker': {
       const workerSub = args[1] ?? 'list';
       if (workerSub === 'status') {

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -519,7 +519,7 @@ export async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Pro
       await preemptTaskSubgraph(taskId, deps);
     }
 
-    const envelope = makeEnvelope('restart-task', 'headless', 'task', { taskId });
+    const envelope = makeEnvelope('retry-task', 'headless', 'task', { taskId });
     const result = deps.mutationTiming
       ? await deps.mutationTiming.span(
         'headless.retry-task.commandService.retryTask',
@@ -566,7 +566,7 @@ export async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Pro
       orchestrator: deps.orchestrator,
       taskExecutor,
       logger: deps.logger,
-      context: 'headless.restart-task',
+      context: 'headless.retry-task',
       started: result.data,
       scopedTaskIds: [taskId],
       mutationTiming: deps.mutationTiming,

--- a/packages/app/src/headless-usage.ts
+++ b/packages/app/src/headless-usage.ts
@@ -1,0 +1,85 @@
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+
+export function printHeadlessUsage(): void {
+  process.stdout.write(`${BOLD}invoker${RESET} — Headless workflow runner (Electron)
+
+${BOLD}Usage:${RESET}  electron dist/main.js --headless <command> [args...]
+
+${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
+  query workflows [--status S] [--output F]          List all saved workflows
+  query workflow <workflowId> [--output F]           Show one workflow
+  query tasks [--workflow <id>|<workflowId>] [--status S]
+                                                      Show task states (latest workflow by default)
+    [--no-merge] [--output F]
+  query task <taskId> [--output F]                    Print single task status
+  query queue [--output F]                            Show queue status
+  query review-gate <prNumber|prUrl> [--output F]    Resolve a PR back to its Invoker workflow
+  query action-graph [--output F]                     Print action graph source-of-truth snapshot
+  query audit <taskId> [--output F]                   Print event history
+  query session <taskId>                              Print agent session messages
+  query worker-actions [--workflow <id>] [--status S] [--decision act|skip]
+                                                      List durable worker action rows (all workers)
+  query worker-decisions [--workflow <id>] [--decision act|skip] [--reason <substr>]
+                                                      Show what each worker decided: submitted vs skipped, and why
+  query ui-perf [--output F] [--reset]               Print live UI perf stats
+  query stats [--output F]                           Aggregate stats across all workflows
+  query execution-leases [--output F]               List live SSH/host execution resource leases
+
+${BOLD}Execute:${RESET}
+  watch [<workflowId>]                                Watch workflow status until settled or Ctrl-C
+  run <plan.yaml>                                     Load and execute plan
+  start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--recreate-all]
+              [--fresh-base-failed] [--fresh-base-failed-and-pending] [--fresh-base-failed-pending-and-running] [--fresh-base-all] [--no-track]
+                                                      Start pending work that is ready to execute
+                                                      Fresh-base flags recreate selected workflows from a refreshed base
+  resume <id>                                         Resume incomplete workflow
+  retry <workflowId>                                  Retry workflow: rerun failed, keep completed
+  retry-task <taskId>                                 Retry a single failed/stuck task
+  recreate <workflowId>                                Recreate workflow: wipe all state, new generation
+  recreate-task <taskId>                               Recreate task + downstream (task-scoped reset)
+  recreate-downstream <taskId>                         Recreate downstream of task only (target preserved)
+  fork-workflow <workflowId>                          Fork a live workflow into a new branched workflow (Step 14)
+  detach-workflow <workflowId> <upstreamWorkflowId>  Detach one upstream workflow and void downstream to pending
+  rebase-retry <workflowId|mergeTaskId|taskId>        Refresh pool base, then retry incomplete work
+  rebase-recreate <workflowId|mergeTaskId|taskId>     Refresh pool base, then recreate workflow
+  repair-review-gate-ci <prNumber|prUrl>              Queue CI repair for one mapped review-gate PR
+  fix <taskId> [claude|codex]                         Fix a failed task (default: claude)
+
+${BOLD}Respond:${RESET}
+  approve <taskId>                                    Approve a task
+  reject <taskId> [reason]                            Reject a task
+  input <taskId> <text>                               Provide input to task
+  select <taskId> <experimentId>                      Select winning experiment
+
+${BOLD}Configure:${RESET}
+  install-skills [install|update|reinstall]          Install bundled Invoker AI helpers
+  set command <taskId> <cmd>                          Edit task command and re-run
+  set prompt <taskId> <text>                          Edit task prompt and re-run
+  set pool <taskId> <type> [poolMemberId]           Change execution pool (worktree|docker|ssh)
+  set agent <taskId> <agent>                          Change execution agent (claude|codex|omp)
+  set merge-mode <workflowId> <mode>                  manual | automatic | external_review
+  set fix-prompt <taskId> <text>                      Update fix-session prompt and retry
+  set fix-context <taskId> <text>                     Update fix-session context and retry
+  set gate-policy <taskId> <wfId> [depTaskId] <policy>
+                                                      policy: completed | review_ready | ci_failed
+  set workflow <workflowId> <fieldPath> <value>      Safely update workflow metadata/config
+  set task <taskId> <fieldPath> <value>              Safely update task metadata/config
+  migrate-compat                                     Normalize persisted compatibility workflow/task state
+
+${BOLD}Lifecycle:${RESET}
+  cancel <taskId>                                     Cancel task + all downstream
+  cancel-workflow <workflowId>                        Cancel all active tasks in a workflow
+  delete-task <taskId>                                 Delete one task and retarget dependents
+  delete <workflowId>                                  Delete a single workflow
+  delete-all                                           Delete all workflows (requires INVOKER_ALLOW_DELETE_ALL=1)
+  open-terminal <taskId>                              Open OS terminal for a task
+  slack                                               Start Slack bot (long-running)
+  worker [kind|list|status]                           Run/list registry worker kinds (autofix scans failed tasks)
+
+${BOLD}Options:${RESET}
+  --wait-for-approval    Keep running until PR approval (use with 'run' or 'resume')
+  --no-track             Submit and return immediately after printing Workflow ID
+  --do-not-track         Alias for --no-track
+`);
+}

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -42,7 +42,12 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
-import { formatHeadlessSetSubcommands } from './headless-command-registry.js';
+import {
+  formatHeadlessSetSubcommands,
+  isHeadlessHelpCommand,
+  isRemovedHeadlessCommandAlias,
+} from './headless-command-registry.js';
+import { printHeadlessUsage } from './headless-usage.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 
 export {
@@ -63,7 +68,6 @@ import {
   type QueryFlags,
   BOLD,
   RESET,
-  YELLOW,
   createHeadlessExecutor,
   wireHeadlessApproveHook,
   parseQueryFlags,
@@ -146,14 +150,6 @@ async function dispatchHeadlessRunnableTasks(
   const timer = setInterval(poll, 250);
   timer.unref?.();
   await new Promise<void>((resolve) => setImmediate(resolve));
-}
-
-// ── Deprecation Warning ─────────────────────────────────────
-
-function warnDeprecated(oldCmd: string, newCmd: string): void {
-  process.stderr.write(
-    `${YELLOW}[deprecated]${RESET} "${oldCmd}" is deprecated. Use "${newCmd}" instead.\n`,
-  );
 }
 
 function assertDeleteAllEnabled(): void {
@@ -244,6 +240,15 @@ async function headlessInstallSkills(
 
 export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<void> {
   const command = args[0];
+
+  if (isHeadlessHelpCommand(command)) {
+    printHeadlessUsage();
+    return;
+  }
+
+  if (isRemovedHeadlessCommandAlias(command)) {
+    throw new Error(`Unknown command: ${command}. Run with --help for usage.`);
+  }
 
   switch (command) {
     case 'owner-serve':
@@ -366,7 +371,6 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       await headlessDeleteTask(args[1], deps);
       break;
     case 'delete':
-    case 'delete-workflow':
       await headlessDeleteWorkflow(args[1], deps);
       break;
     case 'delete-all':
@@ -394,56 +398,6 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       await headlessWorker(args.slice(1), deps);
       break;
 
-    // ── Deprecated aliases → query ──
-    case 'list':
-      warnDeprecated('list', 'query workflows');
-      await headlessQuery(['workflows', ...args.slice(1)], deps);
-      break;
-    case 'status':
-      warnDeprecated('status', 'query tasks');
-      await headlessQuery(['tasks', ...args.slice(1)], deps);
-      break;
-    case 'task-status':
-      warnDeprecated('task-status', 'query task');
-      await headlessQuery(['task', ...args.slice(1)], deps);
-      break;
-    case 'queue':
-      warnDeprecated('queue', 'query queue');
-      await headlessQuery(['queue', ...args.slice(1)], deps);
-      break;
-    case 'audit':
-      warnDeprecated('audit', 'query audit');
-      await headlessQuery(['audit', ...args.slice(1)], deps);
-      break;
-    case 'session':
-      warnDeprecated('session', 'query session');
-      await headlessQuery(['session', ...args.slice(1)], deps);
-      break;
-
-    // ── Deprecated aliases → set ──
-    case 'edit':
-      warnDeprecated('edit', 'set command');
-      await headlessSet(['command', ...args.slice(1)], deps);
-      break;
-    case 'edit-executor':
-    case 'edit-type':
-      warnDeprecated(command, 'set pool');
-      await headlessSet(['pool', ...args.slice(1)], deps);
-      break;
-    case 'edit-agent':
-      warnDeprecated('edit-agent', 'set agent');
-      await headlessSet(['agent', ...args.slice(1)], deps);
-      break;
-    case 'set-merge-mode':
-      warnDeprecated('set-merge-mode', 'set merge-mode');
-      await headlessSet(['merge-mode', ...args.slice(1)], deps);
-      break;
-
-    case '--help':
-    case '-h':
-    case undefined:
-      printHeadlessUsage();
-      break;
     default:
       throw new Error(`Unknown command: ${command}. Run with --help for usage.`);
   }
@@ -556,99 +510,8 @@ async function headlessOwnerServe(deps: Pick<HeadlessDeps, 'isStandaloneOwnerIdl
   });
 }
 
-function printHeadlessUsage(): void {
-  process.stdout.write(`${BOLD}invoker${RESET} — Headless workflow runner (Electron)
-
-${BOLD}Usage:${RESET}  electron dist/main.js --headless <command> [args...]
-
-${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
-  query workflows [--status S] [--output F]          List all saved workflows
-  query workflow <workflowId> [--output F]           Show one workflow
-  query tasks [--workflow <id>|<workflowId>] [--status S]
-                                                      Show task states (latest workflow by default)
-    [--no-merge] [--output F]
-  query task <taskId> [--output F]                    Print single task status
-  query queue [--output F]                            Show queue status
-  query review-gate <prNumber|prUrl> [--output F]    Resolve a PR back to its Invoker workflow
-  query action-graph [--output F]                     Print action graph source-of-truth snapshot
-  query audit <taskId> [--output F]                   Print event history
-  query session <taskId>                              Print agent session messages
-  query worker-actions [--workflow <id>] [--status S] [--decision act|skip]
-                                                      List durable worker action rows (all workers)
-  query worker-decisions [--workflow <id>] [--decision act|skip] [--reason <substr>]
-                                                      Show what each worker decided: submitted vs skipped, and why
-  query ui-perf [--output F] [--reset]               Print live UI perf stats
-  query stats [--output F]                           Aggregate stats across all workflows
-  query execution-leases [--output F]               List live SSH/host execution resource leases
-
-${BOLD}Execute:${RESET}
-  watch [<workflowId>]                                Watch workflow status until settled or Ctrl-C
-  run <plan.yaml>                                     Load and execute plan
-  start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--recreate-all]
-              [--fresh-base-failed] [--fresh-base-failed-and-pending] [--fresh-base-failed-pending-and-running] [--fresh-base-all] [--no-track]
-                                                      Start pending work that is ready to execute
-                                                      Fresh-base flags recreate selected workflows from a refreshed base
-  resume <id>                                         Resume incomplete workflow
-  retry <workflowId>                                  Retry workflow: rerun failed, keep completed
-  retry-task <taskId>                                 Retry a single failed/stuck task
-  recreate <workflowId>                                Recreate workflow: wipe all state, new generation
-  recreate-task <taskId>                               Recreate task + downstream (task-scoped reset)
-  recreate-downstream <taskId>                         Recreate downstream of task only (target preserved)
-  fork-workflow <workflowId>                          Fork a live workflow into a new branched workflow (Step 14)
-  detach-workflow <workflowId> <upstreamWorkflowId>  Detach one upstream workflow and void downstream to pending
-  rebase-retry <workflowId|mergeTaskId|taskId>        Refresh pool base, then retry incomplete work
-  rebase-recreate <workflowId|mergeTaskId|taskId>     Refresh pool base, then recreate workflow
-  reset-autofix-budget --exhausted                    Reset exhausted automatic recovery budgets only
-  repair-review-gate-ci <prNumber|prUrl>              Queue CI repair for one mapped review-gate PR
-  fix <taskId> [claude|codex]                         Fix a failed task (default: claude)
-
-${BOLD}Respond:${RESET}
-  approve <taskId>                                    Approve a task
-  reject <taskId> [reason]                            Reject a task
-  input <taskId> <text>                               Provide input to task
-  select <taskId> <experimentId>                      Select winning experiment
-
-${BOLD}Configure:${RESET}
-  install-skills [install|update|reinstall]          Install bundled Invoker AI helpers
-  set command <taskId> <cmd>                          Edit task command and re-run
-  set prompt <taskId> <text>                          Edit task prompt and re-run
-  set pool <taskId> <type> [poolMemberId]           Change execution pool (worktree|docker|ssh)
-  set agent <taskId> <agent>                          Change execution agent (claude|codex|omp)
-  set merge-mode <workflowId> <mode>                  manual | automatic | external_review
-  set fix-prompt <taskId> <text>                      Update fix-session prompt and retry
-  set fix-context <taskId> <text>                     Update fix-session context and retry
-  set gate-policy <taskId> <wfId> [depTaskId] <policy>
-                                                      policy: completed | review_ready | ci_failed
-  set workflow <workflowId> <fieldPath> <value>      Safely update workflow metadata/config
-  set task <taskId> <fieldPath> <value>              Safely update task metadata/config
-  migrate-compat                                     Normalize persisted compatibility workflow/task state
-
-${BOLD}Lifecycle:${RESET}
-  cancel <taskId>                                     Cancel task + all downstream
-  cancel-workflow <workflowId>                        Cancel all active tasks in a workflow
-  delete-task <taskId>                                 Delete one task and retarget dependents
-  delete <workflowId>                                  Delete a single workflow
-  delete-all                                           Delete all workflows (requires INVOKER_ALLOW_DELETE_ALL=1)
-  open-terminal <taskId>                              Open OS terminal for a task
-  slack                                               Start Slack bot (long-running)
-  worker [kind|list|status]                           Run/list registry worker kinds (autofix scans failed tasks)
-
-${BOLD}Deprecated${RESET} (use new names above):
-  list → query workflows       status → query tasks       task-status → query task
-  queue → query queue           audit → query audit         session → query session
-  edit → set command            edit-executor → set pool
-  edit-agent → set agent        set-merge-mode → set merge-mode
-  delete-workflow → delete
-
-${BOLD}Options:${RESET}
-  --wait-for-approval    Keep running until PR approval (use with 'run' or 'resume')
-  --no-track             Submit and return immediately after printing Workflow ID
-  --do-not-track         Alias for --no-track
-`);
-}
-
 async function headlessEdit(taskId: string, newCommand: string, deps: HeadlessDeps): Promise<void> {
-  if (!taskId || !newCommand) throw new Error('Missing arguments. Usage: --headless edit <taskId> <newCommand>');
+  if (!taskId || !newCommand) throw new Error('Missing arguments. Usage: --headless set command <taskId> <newCommand>');
   const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'set command');
   if (!restored) return;
   taskId = restored.resolvedTaskId;
@@ -790,9 +653,7 @@ async function headlessEditAgent(taskId: string, agentName: string, deps: Headle
  * `retryTask` compatibility wire — see `MUTATION_POLICIES.mergeMode`
  * and `buildInvalidationDeps`).
  *
- * The CLI argument is still a workflow id (matches the legacy
- * `set-merge-mode <workflowId> <mode>` surface and the
- * `invoker:set-merge-mode` IPC). `mergeMode` is normalized at the
+ * The CLI argument is a workflow id. `mergeMode` is normalized at the
  * app boundary because that concerns UI/CLI input parsing, not the
  * chart's invalidation routing. The merge-task-id translation
  * (`workflowId → __merge__<workflowId>`) happens here because the
@@ -808,7 +669,7 @@ async function headlessSetMergeMode(
 ): Promise<void> {
   if (!workflowId || !mergeMode) {
     throw new Error(
-      'Missing arguments. Usage: --headless set-merge-mode <workflowId> <manual|automatic|external_review>',
+      'Missing arguments. Usage: --headless set merge-mode <workflowId> <manual|automatic|external_review>',
     );
   }
   const normalized = normalizeMergeModeForPersistence(mergeMode);

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -892,7 +892,7 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
       case 'invoker:select-experiment':
         if (Array.isArray(arg1)) return null;
         return { channel: 'headless.exec', request: { args: ['select', String(arg0), String(arg1)], noTrack: true } };
-      case 'invoker:restart-task':
+      case 'invoker:retry-task':
         return { channel: 'headless.exec', request: { args: ['retry-task', String(arg0)], noTrack: true } };
       case 'invoker:cancel-task':
         return { channel: 'headless.exec', request: { args: ['cancel', String(arg0)], noTrack: true } };
@@ -1645,21 +1645,13 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     }
   });
 
-  // `invoker:restart-task` IPC channel — the channel name is kept
-  // for UI compatibility (renaming would require coordinated UI
-  // changes, deferred to a follow-up). The handler now routes
-  // through `commandService.retryTask` per Step 13's vocabulary
-  // cleanup so the UI's "Restart" context-menu action keeps its
-  // historical retry-class semantics (preserves
-  // branch/workspacePath lineage). The channel itself carries an
-  // `@deprecated` marker in `packages/contracts/src/ipc-channels.ts`.
   registerWorkflowScopedGuiMutationHandler(
-    'invoker:restart-task',
+    'invoker:retry-task',
     (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
     'high',
     async (taskIdArg: unknown) => {
     const taskId = String(taskIdArg);
-    logger.info(`restart-task → retry-task (Step 13 vocabulary): "${taskId}"`, { module: 'ipc' });
+    logger.info(`retry-task: "${taskId}"`, { module: 'ipc' });
     try {
       await preemptTaskSubgraph(taskId);
       const envelope = makeEnvelope('retry-task', 'ui', 'task', { taskId });
@@ -1667,24 +1659,24 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       if (!result.ok) throw new Error(result.error.message);
       const started = result.data;
       logger.info(
-        `${RESTART_TO_BRANCH_TRACE} ipc invoker:restart-task after commandService.retryTask: count=${started.length} [${started.map((t) => `${t.id}(${t.status})`).join(', ')}]`,
+        `${RESTART_TO_BRANCH_TRACE} ipc invoker:retry-task after commandService.retryTask: count=${started.length} [${started.map((t) => `${t.id}(${t.status})`).join(', ')}]`,
         { module: 'ipc' },
       );
       const runnable = started.filter(isDispatchableLaunch);
       logger.info(
-        `${RESTART_TO_BRANCH_TRACE} ipc invoker:restart-task runnable=${runnable.length} [${runnable.map((t) => t.id).join(', ') || '(none)'}] → taskExecutor.executeTasks`,
+        `${RESTART_TO_BRANCH_TRACE} ipc invoker:retry-task runnable=${runnable.length} [${runnable.map((t) => t.id).join(', ') || '(none)'}] → taskExecutor.executeTasks`,
         { module: 'ipc' },
       );
       await dispatchStartedTasksWithGlobalTopup({
         orchestrator,
         taskExecutor: requireTaskExecutor(),
         logger,
-        context: 'ipc.restart-task',
+        context: 'ipc.retry-task',
         started,
         scopedTaskIds: [taskId],
       });
     } catch (err) {
-      logger.error(`restart-task failed: ${err}`, { module: 'ipc' });
+      logger.error(`retry-task failed: ${err}`, { module: 'ipc' });
       throw err;
     }
     },

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -130,6 +130,10 @@ import {
   isHeadlessReadOnlyCommand,
   resolveHeadlessTargetWorkflowId,
 } from './headless-command-classification.js';
+import {
+  isHeadlessHelpCommand,
+  isRemovedHeadlessCommandAlias,
+} from './headless-command-registry.js';
 import { backupPlan } from './plan-backup.js';
 import { startApiServer, type ApiServer } from './api-server.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
@@ -145,6 +149,7 @@ import {
   wireHeadlessApproveHook,
   type HeadlessDeps,
 } from './headless.js';
+import { printHeadlessUsage } from './headless-usage.js';
 import { buildHeadlessApiServerDeps } from './headless-shared.js';
 import { parseReviewGatePrNumber, repairReviewGateCiByPr } from './review-gate-ci-repair-command.js';
 import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
@@ -865,6 +870,18 @@ function startHeadlessMode(): void {
     const mutatingMode = isHeadlessMutatingCommand(cliArgs);
     const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1' || command === 'owner-serve';
     const ownsHeadlessShutdown = standaloneMode && !readOnlyMode && command === 'owner-serve';
+
+    if (isHeadlessHelpCommand(command)) {
+      printHeadlessUsage();
+      process.exit(0);
+      return;
+    }
+
+    if (isRemovedHeadlessCommandAlias(command)) {
+      process.stderr.write(`${RED}Error:${RESET} Unknown command: ${command}. Run with --help for usage.\n`);
+      process.exit(1);
+      return;
+    }
 
     // Try delegation for mutating commands first (owner mode).
     // In standalone mode we skip delegation and run locally.

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1072,20 +1072,7 @@ export const IpcChannels = {
     request: [taskId: string, experimentId: string | string[]];
     response: WorkflowMutationAcceptedResult;
   },
-  /**
-   * @deprecated Step 13 (`docs/architecture/task-invalidation-roadmap.md`):
-   * `invoker:restart-task` is the legacy channel name from when
-   * `restartTask` was the overloaded "retry-or-recreate" verb the
-   * chart's "Naming inconsistency" section flagged. The channel
-   * itself is preserved for UI compatibility but its handler in
-   * `main.ts` now routes through `commandService.retryTask` →
-   * `Orchestrator.retryTask` (retry-class semantics: preserves
-   * branch/workspacePath lineage). Prefer the explicit channels —
-   * `invoker:retry-task` (when wired) for retry-class invalidation
-   * or `invoker:recreate-task` for recreate-class invalidation.
-   * Once UI is migrated this channel can be removed.
-   */
-  'invoker:restart-task': {} as {
+  'invoker:retry-task': {} as {
     request: [taskId: string];
     response: WorkflowMutationAcceptedResult;
   },

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2313,7 +2313,7 @@ export function App() {
     if (!invoker) return;
     setContextMenu(null);
     try {
-      const result = await invoker.restartTask(taskId);
+      const result = await invoker.retryTask(taskId);
       trackAcceptedMutation(result);
     } catch (err) {
       notifyMutationError('Failed to restart task', err);

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -515,7 +515,7 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
     await expectHighlightedMenuItem('Restart Task');
     pressMenuKey('Enter');
 
-    await waitFor(() => expect(mock.api.restartTask).toHaveBeenCalledWith('task-disabled-terminal'));
+    await waitFor(() => expect(mock.api.retryTask).toHaveBeenCalledWith('task-disabled-terminal'));
     expect(mock.api.openTerminal).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -259,7 +259,7 @@ export function createMockInvoker(
     approve: vi.fn(async () => accepted('invoker:approve')),
     reject: vi.fn(async () => accepted('invoker:reject')),
     selectExperiment: vi.fn(async () => accepted('invoker:select-experiment')),
-    restartTask: vi.fn(async () => accepted('invoker:restart-task')),
+    retryTask: vi.fn(async () => accepted('invoker:retry-task')),
     editTaskCommand: vi.fn(async () => accepted('invoker:edit-task-command')),
     editTaskPrompt: vi.fn(async () => accepted('invoker:edit-task-prompt')),
     editTaskPool: vi.fn(async () => accepted('invoker:edit-task-pool')),


### PR DESCRIPTION
## Summary

This slice points the app and renderer bridge names at the live task-rerun channel.

The visible Restart Task action still appears, but the bridge method now uses `retryTask`.

## Review Claim

The app-facing and renderer bridge surfaces use the canonical task-rerun method name while visible copy stays unchanged.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice is a mechanical bridge rename. User-visible task action copy stays unchanged.

## Slice Rationale

Keeping bridge call sites separate lets reviewers inspect renderer-facing code without worker or HTTP churn.

## Non-goals

- No product-copy rename.
- No worker dispatch changes.
- No HTTP endpoint changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/gui-mutation-translation.test.ts src/__tests__/headless-autofix.test.ts`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/context-menu-e2e.test.tsx`

</details>

## Visual Proof

Focused UI bridge proof: the context-menu regression keeps the visible task action available while the bridge call uses `retryTask`.

![Context-menu retry bridge proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-1b34a4/slice5-ui-bridge-regressions-pass.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <published commit sha>`
- Post-revert steps: Rerun the focused app and UI bridge checks.
- Data migration? No

</details>
