### PR TITLE
[Remove deprecated merge-mode and retry paths](7) Refresh canonical persistence docs

### DIFF
--- a/docs/persistence-architecture-single-writer.md
+++ b/docs/persistence-architecture-single-writer.md
@@ -40,13 +40,13 @@ This table lists every mutating command path and how the owner-boundary contract
 | `invoker:approve` | main.ts:966 | N/A (owner) | `orchestrator.approve()` → persistence writes | |
 | `invoker:reject` | main.ts:984 | N/A (owner) | `rejectTask()` → orchestrator → persistence | |
 | `invoker:select-experiment` | main.ts:988 | N/A (owner) | `sharedSelectExperiments()` → persistence | |
-| `invoker:restart-task` | main.ts:1000 | N/A (owner) | `orchestrator.restartTask()` → persistence | |
+| `invoker:retry-task` | gui-mutation-handlers.ts:894 | N/A (owner) | `commandService.retryTask()` → persistence | |
 | `invoker:cancel-task` | main.ts:1019 | N/A (owner) | `performCancelTask()` → orchestrator → persistence | |
 | `invoker:cancel-workflow` | main.ts:1029 | N/A (owner) | `performCancelWorkflow()` → orchestrator → persistence | |
 | `invoker:recreate-workflow` | main.ts:1043 | N/A (owner) | `sharedRecreateWorkflow()` → persistence bump + orchestrator | |
 | `invoker:recreate-task` | main.ts:1060 | N/A (owner) | `sharedRecreateTask()` → persistence | |
 | `invoker:retry-workflow` | main.ts:1077 | N/A (owner) | `sharedRetryWorkflow()` → orchestrator | |
-| `invoker:rebase-and-retry` | main.ts:1094 | N/A (owner) | `rebaseAndRetry()` → persistence + orchestrator | Deprecated alias; prefer `recreate-with-rebase` |
+| `invoker:rebase-recreate` | gui-mutation-handlers.ts:2060 | N/A (owner) | `rebaseRecreate()` → persistence + orchestrator | Fresh-base workflow recreation |
 | `invoker:set-merge-mode` | main.ts:1129 | N/A (owner) | `setWorkflowMergeMode()` → persistence.updateWorkflow | |
 | `invoker:approve-merge` | main.ts:1147 | N/A (owner) | `orchestrator.approve()` → persistence | |
 | `invoker:resolve-conflict` | main.ts:1182 | N/A (owner) | `resolveConflictAction()` → persistence + orchestrator | |
@@ -60,10 +60,10 @@ This table lists every mutating command path and how the owner-boundary contract
 | **Headless Commands** (delegate when GUI present, standalone otherwise) |
 | `run` | headless.ts:565 | **Yes** (line 356) | `tryDelegateRun()` → IPC `headless.run` (owner handles) OR standalone opens writable via `initServices({ readOnly: false })` | Delegation timeout = 5s |
 | `resume` | headless.ts:620 | **Yes** (line 361) | `tryDelegateResume()` → IPC `headless.resume` OR standalone writable | |
-| `restart` | headless.ts:707 | **Yes** (line 365) | `tryDelegateExec()` → IPC `headless.exec` OR standalone writable | Workflow-scoped `restart wf-…` delegates with a 60s timeout; task-scoped restart stays at 5s |
+| `retry-task` | headless.ts:273 | **Yes** (line 365) | `tryDelegateExec()` → IPC `headless.exec` OR standalone writable | Task-scoped retry uses the default 5s delegation timeout |
 | `recreate` | headless.ts:769 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
 | `recreate-task` | headless.ts:788 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `rebase` / `recreate-with-rebase` | headless.ts:754 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | Workflow-scoped `recreate-with-rebase wf-…` (first-class) and deprecated `rebase-and-retry wf-…` delegates use a 60s timeout; task-scoped rebase stays at 5s |
+| `rebase-retry` / `rebase-recreate` | headless.ts:296 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | Workflow-scoped fresh-base commands delegate with a 60s timeout; task-scoped fresh-base commands stay at 5s |
 | `approve` | headless.ts:666 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
 | `reject` | headless.ts:681 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
 | `input` | headless.ts:688 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
@@ -105,7 +105,7 @@ This table lists every mutating command path and how the owner-boundary contract
 | Component | File | Line(s) | Enforcement Mechanism |
 |-----------|------|---------|----------------------|
 | **GUI main process** | packages/app/src/main.ts | 605-613 | `initServices()` opens writable DB (no `readOnly` flag) |
-| **Headless delegation** | packages/app/src/main.ts, packages/app/src/headless-delegation.ts | 346-381, 14-65 | `tryDelegateRun()`, `tryDelegateResume()`, `tryDelegateExec()` send IPC request to owner; `run`, `resume`, and default `exec` delegation use 5s timeout, while workflow-scoped `rebase` / `recreate-with-rebase` / `rebase-and-retry` / `restart` use 60s before standalone fallback |
+| **Headless delegation** | packages/app/src/main.ts, packages/app/src/headless-delegation.ts | 346-381, 68-145 | `tryDelegateRun()`, `tryDelegateResume()`, `tryDelegateExec()` send IPC request to owner; `run`, `resume`, and default `exec` delegation use 5s timeout, while workflow-scoped `rebase-retry` / `rebase-recreate` use 60s before standalone fallback |
 | **Headless standalone** | packages/app/src/main.ts | 386 | `initServices({ readOnly: isHeadlessReadOnlyCommand(cliArgs) })` — read-only for query commands, writable for standalone mutating commands (when `INVOKER_HEADLESS_STANDALONE=1` or no GUI) |
 | **SQLiteAdapter read-only gate** | packages/persistence/src/sqlite-adapter.ts | 113-117 | `ensureWritable()` throws if `readOnly: true` and a write is attempted |
 | **Delegation handlers (owner)** | packages/app/src/main.ts | 618-674 | `headless.run`, `headless.resume`, `headless.exec` IPC handlers receive delegated commands, execute via owner's writable orchestrator/persistence |
@@ -113,10 +113,10 @@ This table lists every mutating command path and how the owner-boundary contract
 ### Critical Guarantees
 
 1. **GUI always owns DB**: When GUI is running, `initServices()` (main.ts:605) opens writable persistence. All IPC handlers mutate via this owner instance.
-2. **Headless delegates by default**: When GUI is present, headless commands try delegation first. `run`, `resume`, and most `headless.exec` commands use a 5s timeout; workflow-scoped `rebase`, `recreate-with-rebase`, `rebase-and-retry`, and `restart` use 60s. Only if delegation fails (no GUI or timeout) does headless open its own writable DB.
+2. **Headless delegates by default**: When GUI is present, headless commands try delegation first. `run`, `resume`, and most `headless.exec` commands use a 5s timeout; workflow-scoped `rebase-retry` and `rebase-recreate` use 60s. Only if delegation fails (no GUI or timeout) does headless open its own writable DB.
 3. **Read-only commands never delegate**: `query` subcommands always open `readOnly: true` persistence (main.ts:386), never write.
 4. **Standalone escape hatch**: `INVOKER_HEADLESS_STANDALONE=1` skips delegation, allowing headless to own the DB (main.ts:348-349).
-5. **Delegation timeout prevents deadlock**: IPC delegation is bounded so headless does not hang if GUI is unresponsive. The default is 5s, with a 60s allowance for workflow-scoped `rebase`, `recreate-with-rebase`, `rebase-and-retry`, and `restart` command shapes in `headless.exec`.
+5. **Delegation timeout prevents deadlock**: IPC delegation is bounded so headless does not hang if GUI is unresponsive. The default is 5s, with a 60s allowance for workflow-scoped `rebase-retry` and `rebase-recreate` command shapes in `headless.exec`.
 
 ### Test Coverage
 

--- a/invoker-ctl
+++ b/invoker-ctl
@@ -13,7 +13,7 @@
 #   ./invoker-ctl audit <taskId>                   Show audit event log for a task
 #   ./invoker-ctl output <taskId>                  Show captured output for a task
 #   ./invoker-ctl cancel <taskId>                  Cancel a running task
-#   ./invoker-ctl restart <taskId>                 Restart a failed task
+#   ./invoker-ctl retry-task <taskId>              Retry a failed task
 #   ./invoker-ctl recreate-workflow <workflowId>    Recreate entire workflow (bump generation)
 #   ./invoker-ctl resolve-conflict <taskId> [agent] Resolve merge conflict (→ awaiting_approval)
 #   ./invoker-ctl approve <taskId>                 Approve a task awaiting approval
@@ -73,7 +73,7 @@ case "${1:-}" in
       echo "Usage: invoker-ctl recreate-workflow <workflowId>" >&2
       exit 1
     fi
-    curl -sf -X POST "$BASE/api/workflows/$2/restart" | fmt '.'
+    curl -sf -X POST "$BASE/api/workflows/$2/recreate" | fmt '.'
     ;;
 
   delete-workflow)
@@ -87,7 +87,7 @@ case "${1:-}" in
   set-merge-mode)
     if [ -z "${2:-}" ] || [ -z "${3:-}" ]; then
       echo "Usage: invoker-ctl set-merge-mode <workflowId> <mode>" >&2
-      echo "  mode: manual | automatic | github | external_review" >&2
+      echo "  mode: manual | automatic | external_review" >&2
       exit 1
     fi
     curl -sf -X POST -H 'Content-Type: application/json' \
@@ -127,12 +127,12 @@ case "${1:-}" in
     curl -sf -X POST "$BASE/api/tasks/$2/cancel" | fmt '.'
     ;;
 
-  restart)
+  retry-task)
     if [ -z "${2:-}" ]; then
-      echo "Usage: invoker-ctl restart <taskId>" >&2
+      echo "Usage: invoker-ctl retry-task <taskId>" >&2
       exit 1
     fi
-    curl -sf -X POST "$BASE/api/tasks/$2/restart" | fmt '.'
+    curl -sf -X POST "$BASE/api/tasks/$2/retry" | fmt '.'
     ;;
 
   resolve-conflict)
@@ -231,7 +231,7 @@ Usage:
   invoker-ctl audit <taskId>                   Show audit event log for a task
   invoker-ctl output <taskId>                  Show captured output for a task
   invoker-ctl cancel <taskId>                  Cancel a running task
-  invoker-ctl restart <taskId>                 Restart a failed task
+  invoker-ctl retry-task <taskId>              Retry a failed task
   invoker-ctl recreate-workflow <workflowId>    Recreate an entire workflow (bump generation)
   invoker-ctl resolve-conflict <taskId> [agent] Resolve merge conflict (→ awaiting_approval)
   invoker-ctl approve <taskId>                 Approve a task awaiting approval
@@ -241,7 +241,7 @@ Usage:
   invoker-ctl edit-type <taskId> <type>        Change a task's executor type
   invoker-ctl edit-agent <taskId> <agent>      Change a task's execution agent (claude|codex)
   invoker-ctl delete-workflow <workflowId>     Delete a workflow
-  invoker-ctl set-merge-mode <id> <mode>       Set merge mode (manual|automatic|github)
+  invoker-ctl set-merge-mode <id> <mode>       Set merge mode (manual|automatic|external_review)
 
 Environment:
   INVOKER_API_PORT    API port (default: 4100)

--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -597,25 +597,25 @@ describe('workflow HTTP mutation boundary', () => {
   });
 });
 
-describe('POST /api/tasks/:id/restart', () => {
-  it('restarts task via facade retryTask', async () => {
-    const res = await request(port, 'POST', '/api/tasks/task-1/restart');
+describe('POST /api/tasks/:id/retry', () => {
+  it('retries task via facade retryTask', async () => {
+    const res = await request(port, 'POST', '/api/tasks/task-1/retry');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
-    expect(res.body.action).toBe('restarted');
+    expect(res.body.action).toBe('retried');
     expect(mocks.orchestrator.retryTask).toHaveBeenCalledWith('task-1');
   });
 
   it('returns 400 on error', async () => {
     mocks.orchestrator.retryTask.mockImplementation(() => {
-      throw new Error('task not restartable');
+      throw new Error('task not retriable');
     });
-    const res = await request(port, 'POST', '/api/tasks/task-1/restart');
+    const res = await request(port, 'POST', '/api/tasks/task-1/retry');
     expect(res.status).toBe(400);
-    expect(res.body.error).toBe('task not restartable');
+    expect(res.body.error).toBe('task not retriable');
   });
 
-  it('tops up globally ready tasks after scoped restart launch', async () => {
+  it('tops up globally ready tasks after scoped retry launch', async () => {
     const scoped = makeTask({
       id: 'task-1',
       status: 'running',
@@ -630,7 +630,7 @@ describe('POST /api/tasks/:id/restart', () => {
     mocks.orchestrator.retryTask.mockReturnValue([scoped]);
     mocks.orchestrator.startExecution.mockReturnValue([topup]);
 
-    const res = await request(port, 'POST', '/api/tasks/task-1/restart');
+    const res = await request(port, 'POST', '/api/tasks/task-1/retry');
     expect(res.status).toBe(200);
     expect(mocks.orchestrator.startExecution).toHaveBeenCalled();
     expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
@@ -650,9 +650,18 @@ describe('POST /api/tasks/:id/restart', () => {
     mocks.orchestrator.retryTask.mockReturnValue([scoped]);
     mocks.orchestrator.startExecution.mockReturnValue([duplicate]);
 
-    const res = await request(port, 'POST', '/api/tasks/task-1/restart');
+    const res = await request(port, 'POST', '/api/tasks/task-1/retry');
     expect(res.status).toBe(200);
     expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/tasks/:id/restart', () => {
+  it('returns 404 and does not route to retryTask', async () => {
+    const res = await request(port, 'POST', '/api/tasks/task-1/restart');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Not found');
+    expect(mocks.orchestrator.retryTask).not.toHaveBeenCalled();
   });
 });
 
@@ -997,23 +1006,23 @@ describe('POST /api/tasks/:id/gate-policy', () => {
   });
 });
 
-describe('POST /api/workflows/:id/restart', () => {
-  it('restarts workflow via facade recreateWorkflow', async () => {
+describe('POST /api/workflows/:id/recreate', () => {
+  it('recreates workflow via facade recreateWorkflow', async () => {
     mocks.orchestrator.recreateWorkflow = vi.fn(() => [makeTask()]);
-    const res = await request(port, 'POST', '/api/workflows/wf-1/restart');
+    const res = await request(port, 'POST', '/api/workflows/wf-1/recreate');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
-    expect(res.body.action).toBe('restarted');
+    expect(res.body.action).toBe('recreated');
     expect(mocks.persistence.loadWorkflow).toHaveBeenCalledWith('wf-1');
     expect(mocks.persistence.updateWorkflow).toHaveBeenCalled();
   });
 
-  it('handles concurrent restart requests independently', async () => {
+  it('handles concurrent recreate requests independently', async () => {
     mocks.orchestrator.recreateWorkflow = vi.fn(() => [makeTask()]);
 
     const [r1, r2] = await Promise.all([
-      request(port, 'POST', '/api/workflows/wf-1/restart'),
-      request(port, 'POST', '/api/workflows/wf-1/restart'),
+      request(port, 'POST', '/api/workflows/wf-1/recreate'),
+      request(port, 'POST', '/api/workflows/wf-1/recreate'),
     ]);
 
     expect(r1.status).toBe(200);
@@ -1027,12 +1036,12 @@ describe('POST /api/workflows/:id/restart', () => {
 
   it('returns 404 when workflow not found', async () => {
     mocks.persistence.loadWorkflow.mockReturnValue(undefined);
-    const res = await request(port, 'POST', '/api/workflows/missing/restart');
+    const res = await request(port, 'POST', '/api/workflows/missing/recreate');
     expect(res.status).toBe(404);
     expect(res.body.error).toContain('not found');
   });
 
-  it('tops up globally ready tasks after workflow restart launch', async () => {
+  it('tops up globally ready tasks after workflow recreate launch', async () => {
     const scoped = makeTask({
       id: 'wf-1/task-1',
       config: { workflowId: 'wf-1' },
@@ -1046,11 +1055,22 @@ describe('POST /api/workflows/:id/restart', () => {
     mocks.orchestrator.recreateWorkflow = vi.fn(() => [scoped]);
     mocks.orchestrator.startExecution.mockReturnValue([topup]);
 
-    const res = await request(port, 'POST', '/api/workflows/wf-1/restart');
+    const res = await request(port, 'POST', '/api/workflows/wf-1/recreate');
     expect(res.status).toBe(200);
     expect(res.body.tasksStarted).toBe(1);
     expect(mocks.orchestrator.startExecution).toHaveBeenCalled();
     expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/workflows/:id/restart', () => {
+  it('returns 404 and does not route to recreateWorkflow', async () => {
+    mocks.orchestrator.recreateWorkflow = vi.fn(() => [makeTask()]);
+    const res = await request(port, 'POST', '/api/workflows/wf-1/restart');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Not found');
+    expect(mocks.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+    expect(mocks.persistence.updateWorkflow).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -160,7 +160,7 @@ describe('auto-fix recovery worker', () => {
     await runtime.stop();
   });
 
-  it('scans every failed task and submits a bare restart on the first tick when the registered worker is turned on', async () => {
+  it('scans every failed task and submits a bare retry on the first tick when the registered worker is turned on', async () => {
     const harness = makeRecoveryPolicyHarness();
     const registry = registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>());
     const definition = registry.get(AUTO_FIX_WORKER_KIND);
@@ -187,7 +187,7 @@ describe('auto-fix recovery worker', () => {
     expect(harness.submit).toHaveBeenCalledWith(
       'wf-1',
       'normal',
-      'invoker:restart-task',
+      'invoker:retry-task',
       ['wf-1/task-1'],
     );
   });
@@ -398,14 +398,14 @@ describe('auto-fix recovery candidate validation', () => {
     expect(harness.submit).toHaveBeenCalledWith(
       'wf-1',
       'normal',
-      'invoker:restart-task',
+      'invoker:retry-task',
       ['wf-1/task-1'],
     );
   });
 });
 
 describe('auto-fix recovery scan submission', () => {
-  it('submits a bare restart first, then escalates to fix-with-agent', async () => {
+  it('submits a bare retry first, then escalates to fix-with-agent', async () => {
     const harness = makeRecoveryPolicyHarness();
     const tick = createAutoFixRecoveryTick(harness.options);
 
@@ -419,7 +419,7 @@ describe('auto-fix recovery scan submission', () => {
     expect(harness.submit).toHaveBeenCalledWith(
       'wf-1',
       'normal',
-      'invoker:restart-task',
+      'invoker:retry-task',
       ['wf-1/task-1'],
     );
     expect(harness.logEvent).toHaveBeenCalledWith(
@@ -427,7 +427,7 @@ describe('auto-fix recovery scan submission', () => {
       'debug.auto-fix',
       expect.objectContaining({
         phase: 'worker-autofix-bare-retry-submitted',
-        channel: 'invoker:restart-task',
+        channel: 'invoker:retry-task',
       }),
     );
 
@@ -477,10 +477,10 @@ describe('auto-fix recovery scan submission', () => {
     harness.intents.length = 0;
     await tick({ identity: { kind: 'recovery', instanceId: 'test' }, reason: 'startup', tickNumber: 3 });
 
-    // budget=1 → exactly one automatic retry total (the bare restart counts),
+    // budget=1 → exactly one automatic retry total (the bare retry counts),
     // then the durable per-task cap exhausts.
     expect(harness.submit).toHaveBeenCalledTimes(1);
-    expect(harness.submit.mock.calls.map((call) => call[2])).toEqual(['invoker:restart-task']);
+    expect(harness.submit.mock.calls.map((call) => call[2])).toEqual(['invoker:retry-task']);
     expect(task.execution).not.toHaveProperty(attemptStateKey);
     expect(harness.logEvent).toHaveBeenCalledWith(
       'wf-1/task-1',
@@ -512,7 +512,7 @@ describe('auto-fix recovery scan submission', () => {
     // The generation bump must NOT reset the budget (incident 2026-07-12): the
     // durable per-task counter already spent its single retry, so no second one.
     expect(harness.submit).toHaveBeenCalledTimes(1);
-    expect(harness.submit.mock.calls.map((call) => call[2])).toEqual(['invoker:restart-task']);
+    expect(harness.submit.mock.calls.map((call) => call[2])).toEqual(['invoker:retry-task']);
     expect(harness.logEvent).toHaveBeenCalledWith(
       'wf-1/task-1',
       'debug.auto-fix',

--- a/packages/app/src/__tests__/gui-mutation-translation.test.ts
+++ b/packages/app/src/__tests__/gui-mutation-translation.test.ts
@@ -62,7 +62,7 @@ describe('GUI mutation translation', () => {
     );
   });
   it.each([
-    ['invoker:restart-task', 'retry-task'],
+    ['invoker:retry-task', 'retry-task'],
     ['invoker:cancel-task', 'cancel'],
     ['invoker:delete-task', 'delete-task'],
     ['invoker:cancel-workflow', 'cancel-workflow'],

--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -46,7 +46,7 @@ describe('headless auto-fix cutover', () => {
 });
 
 describe('headless worker autofix', () => {
-  it('runs a one-shot scan under the single-instance lock and enqueues a bare restart first', async () => {
+  it('runs a one-shot scan under the single-instance lock and enqueues a bare retry first', async () => {
     const task = makeTask();
     const actions = new Map<string, WorkerActionRecord>();
     const enqueueWorkflowMutationIntent = vi.fn((
@@ -99,7 +99,7 @@ describe('headless worker autofix', () => {
 
     expect(enqueueWorkflowMutationIntent).toHaveBeenCalledWith(
       'wf-1',
-      'invoker:restart-task',
+      'invoker:retry-task',
       ['wf-1/task-1'],
       'normal',
     );

--- a/packages/app/src/__tests__/headless-command-classification.test.ts
+++ b/packages/app/src/__tests__/headless-command-classification.test.ts
@@ -34,8 +34,10 @@ describe('headless-command-classification', () => {
   it('classifies read-only commands', () => {
     expect(isHeadlessReadOnlyCommand([])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['query'])).toBe(true);
-    expect(isHeadlessReadOnlyCommand(['list'])).toBe(true);
-    expect(isHeadlessReadOnlyCommand(['session'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['query', 'workflows'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['query', 'session'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['list'])).toBe(false);
+    expect(isHeadlessReadOnlyCommand(['session'])).toBe(false);
     expect(isHeadlessReadOnlyCommand(['open-terminal'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['worker'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['worker', 'status'])).toBe(true);

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -163,35 +163,36 @@ describe('headless delegation enforcement', () => {
       stdout.mockRestore();
     });
 
-      it('allows deprecated list command in read-only mode', async () => {
-        await expect(
-          runHeadless(['list'], mockDeps)
-        ).resolves.toBeUndefined();
-      });
+    it('rejects the removed list alias with normal unknown-command behavior', async () => {
+      await expect(
+        runHeadless(['list'], mockDeps),
+      ).rejects.toThrow('Unknown command: list');
+    });
 
-      it('allows query workflow for a single workflow', async () => {
-        mockDeps.persistence.loadWorkflow = vi.fn(() => ({
-          id: 'wf-1',
-          name: 'Workflow one',
-          status: 'pending',
-          generation: 0,
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-        } as any));
+    it('allows query workflow for a single workflow', async () => {
+      mockDeps.persistence.loadWorkflow = vi.fn(() => ({
+        id: 'wf-1',
+        name: 'Workflow one',
+        status: 'pending',
+        generation: 0,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      } as any));
 
-        await expect(
-          runHeadless(['query', 'workflow', 'wf-1', '--output', 'json'], mockDeps),
-        ).resolves.toBeUndefined();
+      await expect(
+        runHeadless(['query', 'workflow', 'wf-1', '--output', 'json'], mockDeps),
+      ).resolves.toBeUndefined();
 
-        expect(mockDeps.persistence.loadWorkflow).toHaveBeenCalledWith('wf-1');
-      });
+      expect(mockDeps.persistence.loadWorkflow).toHaveBeenCalledWith('wf-1');
+    });
 
-    it('allows deprecated status command in read-only mode', async () => {
+    it('rejects the removed status alias with normal unknown-command behavior', async () => {
       mockDeps.orchestrator.syncFromDb = vi.fn();
       mockDeps.orchestrator.getAllTasks = vi.fn(() => []);
       await expect(
-        runHeadless(['status'], mockDeps)
-      ).resolves.toBeUndefined();
+        runHeadless(['status'], mockDeps),
+      ).rejects.toThrow('Unknown command: status');
+      expect(mockDeps.orchestrator.syncFromDb).not.toHaveBeenCalled();
     });
   });
 
@@ -1799,15 +1800,28 @@ describe('headless delegation enforcement', () => {
     });
   });
 
-  describe('delete-workflow lifecycle bridge', () => {
-    it('headless delete-workflow always routes through commandService.deleteWorkflow', async () => {
+  describe('delete workflow lifecycle bridge', () => {
+    it('rejects the removed delete-workflow alias with normal unknown-command behavior', async () => {
       mockDeps.commandService.deleteWorkflow = vi.fn(async () => ({ ok: true as const, data: undefined })) as any;
       mockDeps.commandService.cancelWorkflow = vi.fn(async () => ({
         ok: true as const,
         data: { cancelled: [], runningCancelled: [] },
       }));
 
-      await runHeadless(['delete-workflow', 'wf-1'], mockDeps);
+      await expect(runHeadless(['delete-workflow', 'wf-1'], mockDeps))
+        .rejects.toThrow('Unknown command: delete-workflow');
+
+      expect(mockDeps.commandService.deleteWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('headless delete always routes through commandService.deleteWorkflow', async () => {
+      mockDeps.commandService.deleteWorkflow = vi.fn(async () => ({ ok: true as const, data: undefined })) as any;
+      mockDeps.commandService.cancelWorkflow = vi.fn(async () => ({
+        ok: true as const,
+        data: { cancelled: [], runningCancelled: [] },
+      }));
+
+      await runHeadless(['delete', 'wf-1'], mockDeps);
 
       expect(mockDeps.commandService.deleteWorkflow).toHaveBeenCalled();
     });

--- a/packages/app/src/__tests__/headless-query-capture.test.ts
+++ b/packages/app/src/__tests__/headless-query-capture.test.ts
@@ -56,10 +56,11 @@ describe('runReadOnlyHeadlessQueryToString', () => {
     }
   });
 
-  it('maps the deprecated alias `list` to `query workflows`', async () => {
+  it('rejects the removed list alias instead of mapping it to query workflows', async () => {
     const deps = makeQueryDeps(() => [{ id: 'wf-9' }]);
-    const output = await runReadOnlyHeadlessQueryToString(['list', '--output', 'label'], deps);
-    expect(output).toBe('wf-9\n');
+    await expect(
+      runReadOnlyHeadlessQueryToString(['list', '--output', 'label'], deps),
+    ).rejects.toThrow('Command "list" is not a delegatable read-only query');
   });
 
   it('uses configured default agent when session task has no persisted agent name', async () => {
@@ -85,7 +86,7 @@ describe('runReadOnlyHeadlessQueryToString', () => {
       getAllTasks: vi.fn(() => [task]),
     } as unknown as HeadlessQueryDeps['orchestrator'];
 
-    const output = await runReadOnlyHeadlessQueryToString(['session', 'task-1'], deps);
+    const output = await runReadOnlyHeadlessQueryToString(['query', 'session', 'task-1'], deps);
 
     expect(output).toContain('agent=custom-agent sessionId=sess-1\n');
   });

--- a/packages/app/src/__tests__/parity-regression.test.ts
+++ b/packages/app/src/__tests__/parity-regression.test.ts
@@ -456,7 +456,7 @@ describe('Parity: API endpoints wire to facade methods', () => {
     orchestratorMethod: string;
     expectTopup: boolean;
   }> = [
-    { name: 'POST /api/tasks/:id/restart', method: 'POST', path: '/api/tasks/task-1/restart', orchestratorMethod: 'retryTask', expectTopup: true },
+    { name: 'POST /api/tasks/:id/retry', method: 'POST', path: '/api/tasks/task-1/retry', orchestratorMethod: 'retryTask', expectTopup: true },
     { name: 'POST /api/tasks/:id/edit', method: 'POST', path: '/api/tasks/task-1/edit', body: { command: 'echo ok' }, orchestratorMethod: 'editTaskCommand', expectTopup: true },
     { name: 'POST /api/tasks/:id/edit-prompt', method: 'POST', path: '/api/tasks/task-1/edit-prompt', body: { prompt: 'do it' }, orchestratorMethod: 'editTaskPrompt', expectTopup: true },
     { name: 'POST /api/tasks/:id/edit-agent', method: 'POST', path: '/api/tasks/task-1/edit-agent', body: { agent: 'codex' }, orchestratorMethod: 'editTaskAgent', expectTopup: true },
@@ -498,13 +498,21 @@ describe('Parity: API endpoints wire to facade methods', () => {
     expect(mocks.orchestrator.provideInput).toHaveBeenCalledWith('task-1', 'yes');
   });
 
-  it('POST /api/workflows/:id/restart routes through facade recreateWorkflow', async () => {
-    const res = await httpRequest(port, 'POST', '/api/workflows/wf-1/restart');
+  it('POST /api/workflows/:id/recreate routes through facade recreateWorkflow', async () => {
+    const res = await httpRequest(port, 'POST', '/api/workflows/wf-1/recreate');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(mocks.persistence.loadWorkflow).toHaveBeenCalledWith('wf-1');
     expect(mocks.persistence.updateWorkflow).toHaveBeenCalled();
     expect(mocks.orchestrator.recreateWorkflow).toHaveBeenCalled();
+  });
+
+  it('removed legacy /restart API aliases return 404', async () => {
+    const taskRes = await httpRequest(port, 'POST', '/api/tasks/task-1/restart');
+    const workflowRes = await httpRequest(port, 'POST', '/api/workflows/wf-1/restart');
+
+    expect(taskRes.status).toBe(404);
+    expect(workflowRes.status).toBe(404);
   });
 });
 
@@ -607,16 +615,6 @@ describe('Parity: CommandService routes to correct orchestrator primitives', () 
     expect(result.ok).toBe(true);
     expect(orchestrator.revertFixSession).toHaveBeenCalledWith('task-1', { savedError: 'merge conflict' });
     expect(orchestrator.reject).not.toHaveBeenCalled();
-  });
-
-  it('restartTask (deprecated) delegates to recreateTask', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const result = await commandService.restartTask(envelope({ taskId: 'task-1' }));
-
-    expect(result.ok).toBe(true);
-    expect(orchestrator.recreateTask).toHaveBeenCalledWith('task-1');
-    expect(orchestrator.retryTask).not.toHaveBeenCalled();
-    warnSpy.mockRestore();
   });
 
   it('all commands wrap OrchestratorError into { ok: false }', async () => {

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -19,7 +19,8 @@
  *
  * Write endpoints:
  *   POST   /api/tasks/:id/cancel
- *   POST   /api/tasks/:id/restart
+ *   POST   /api/tasks/:id/retry
+ *   POST   /api/tasks/:id/recreate
  *   POST   /api/tasks/:id/recreate-downstream
  *   POST   /api/tasks/:id/resolve-conflict  body: { agent? }
  *   POST   /api/tasks/:id/approve
@@ -32,7 +33,8 @@
  *   POST   /api/tasks/:id/gate-policy  body: { updates: [{ workflowId, taskId?, gatePolicy: completed|review_ready|ci_failed }] }
  *   DELETE /api/tasks/:id
  *   POST   /api/workflows/:id/detach  body: { upstreamWorkflowId }
- *   POST   /api/workflows/:id/restart
+ *   POST   /api/workflows/:id/recreate
+ *   POST   /api/workflows/:id/retry
  *   POST   /api/workflows/:id/rebase-retry
  *   POST   /api/workflows/:id/rebase-recreate
  *   POST   /api/workflows/:id/cancel
@@ -284,26 +286,17 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
-      // POST /api/tasks/:id/retry  (legacy: /api/tasks/:id/restart)
+      // POST /api/tasks/:id/retry
       const retryMatch = path.match(/^\/api\/tasks\/([^/]+)\/retry$/);
-      const restartMatch = path.match(/^\/api\/tasks\/([^/]+)\/restart$/);
-      if (method === 'POST' && (retryMatch || restartMatch)) {
-        const isLegacy = !!restartMatch;
-        const taskId = decodeURIComponent((retryMatch ?? restartMatch)![1]);
+      if (method === 'POST' && retryMatch) {
+        const taskId = decodeURIComponent(retryMatch[1]);
         try {
           const result = await mutations.retryTask(taskId);
-          if (isLegacy) {
-            res.setHeader(
-              'Deprecation',
-              'true; reason="Use /api/tasks/:id/retry or /api/tasks/:id/recreate"',
-            );
-          }
           json(res, 200, {
             ok: true,
             taskId,
-            action: isLegacy ? 'restarted' : 'retried',
+            action: 'retried',
             tasksStarted: result.runnable.length,
-            ...(isLegacy ? { deprecated: true, replacement: '/api/tasks/:id/retry' } : {}),
           });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
@@ -429,27 +422,18 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
-      // POST /api/workflows/:id/recreate  (legacy: /api/workflows/:id/restart)
+      // POST /api/workflows/:id/recreate
       const wfRecreateMatch = path.match(/^\/api\/workflows\/([^/]+)\/recreate$/);
-      const wfRestartMatch = path.match(/^\/api\/workflows\/([^/]+)\/restart$/);
-      if (method === 'POST' && (wfRecreateMatch || wfRestartMatch)) {
-        const isLegacy = !!wfRestartMatch;
-        const workflowId = decodeURIComponent((wfRecreateMatch ?? wfRestartMatch)![1]);
+      if (method === 'POST' && wfRecreateMatch) {
+        const workflowId = decodeURIComponent(wfRecreateMatch[1]);
         try {
           const result = await mutations.recreateWorkflow(workflowId);
-          if (isLegacy) {
-            res.setHeader(
-              'Deprecation',
-              'true; reason="Use /api/workflows/:id/recreate"',
-            );
-          }
           const tasksStarted = result.runnable.length;
           json(res, 200, {
             ok: true,
             workflowId,
-            action: isLegacy ? 'restarted' : 'recreated',
+            action: 'recreated',
             tasksStarted,
-            ...(isLegacy ? { deprecated: true, replacement: '/api/workflows/:id/recreate' } : {}),
           });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -43,6 +43,11 @@ import {
   tryAcknowledgeNoTrackTaskMutationWithoutDb,
   tryAcknowledgeNoTrackTaskMutationWithoutOwner,
 } from './headless-no-track-fallback.js';
+import {
+  isHeadlessHelpCommand,
+  isRemovedHeadlessCommandAlias,
+} from './headless-command-registry.js';
+import { printHeadlessUsage } from './headless-usage.js';
 
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
@@ -672,7 +677,17 @@ export async function runHeadlessClientCommand(
 
   const { args, waitForApproval, noTrack } = parseArgs(argv);
   const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1';
-  const internalOwnerServe = args[0] === 'owner-serve';
+  const command = args[0];
+  const internalOwnerServe = command === 'owner-serve';
+
+  if (isHeadlessHelpCommand(command)) {
+    printHeadlessUsage();
+    return 0;
+  }
+
+  if (isRemovedHeadlessCommandAlias(command)) {
+    throw new Error(`Unknown command: ${command}. Run with --help for usage.`);
+  }
 
   if (!internalOwnerServe && await delegateWorkerControl(args, deps.messageBus, invokerConfig, deps.refreshMessageBus)) {
     const exitCode = process.exitCode;

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -3,7 +3,6 @@ export type HeadlessCommandKind = 'read' | 'write' | 'special';
 export interface HeadlessCommandDefinition {
   readonly name: string;
   readonly kind: HeadlessCommandKind;
-  readonly aliases?: readonly string[];
 }
 
 export const HEADLESS_SET_SUBCOMMANDS = [
@@ -54,30 +53,24 @@ export const HEADLESS_COMMANDS = [
   { name: 'cancel', kind: 'write' },
   { name: 'cancel-workflow', kind: 'write' },
   { name: 'delete-task', kind: 'write' },
-  { name: 'delete-workflow', kind: 'write', aliases: ['delete'] },
+  { name: 'delete', kind: 'write' },
   { name: 'delete-all', kind: 'write' },
   { name: 'open-terminal', kind: 'read' },
   { name: 'query-select', kind: 'read' },
   { name: 'worker', kind: 'read' },
-  { name: 'list', kind: 'read' },
-  { name: 'status', kind: 'read' },
-  { name: 'task-status', kind: 'read' },
-  { name: 'queue', kind: 'read' },
-  { name: 'audit', kind: 'read' },
-  { name: 'session', kind: 'read' },
-  { name: 'edit', kind: 'write' },
-  { name: 'edit-executor', kind: 'write' },
-  { name: 'edit-type', kind: 'write' },
-  { name: 'edit-agent', kind: 'write' },
-  { name: 'set-merge-mode', kind: 'write' },
 ] as const satisfies readonly HeadlessCommandDefinition[];
 
 export function findHeadlessCommandDefinition(command: string | undefined): HeadlessCommandDefinition | undefined {
   if (!command) return undefined;
-  return HEADLESS_COMMANDS.find((definition) => (
-    definition.name === command
-      || ('aliases' in definition && (definition.aliases as readonly string[]).includes(command))
-  ));
+  return HEADLESS_COMMANDS.find((definition) => definition.name === command);
+}
+
+export function isHeadlessHelpCommand(command: string | undefined): boolean {
+  return command === undefined || command === '--help' || command === '-h';
+}
+
+export function isRemovedHeadlessCommandAlias(command: string | undefined): boolean {
+  return command === 'set-merge-mode';
 }
 
 export function isMutatingSetSubcommand(subcommand: string | undefined): boolean {

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -5,9 +5,8 @@
  * collection/rollup
  * helpers, agent session resolution, and `query-select`.
  *
- * The deprecated top-level aliases (`list`, `status`, `task-status`, `queue`,
- * `audit`, `session`) route here through the `headless.ts` router. It depends on
- * `headless-shared.ts` and reuses `worker-control.ts` for the worker-decisions view.
+ * It depends on `headless-shared.ts` and reuses `worker-control.ts` for the
+ * worker-decisions view.
  */
 
 import { AsyncLocalStorage } from 'node:async_hooks';
@@ -981,19 +980,6 @@ async function dispatchReadOnlyHeadlessQuery(args: string[], deps: HeadlessQuery
       return headlessQuery(args.slice(1), deps);
     case 'query-select':
       return headlessQuerySelect(args[1], deps);
-    // Deprecated top-level aliases → canonical `query <sub>`.
-    case 'list':
-      return headlessQuery(['workflows', ...args.slice(1)], deps);
-    case 'status':
-      return headlessQuery(['tasks', ...args.slice(1)], deps);
-    case 'task-status':
-      return headlessQuery(['task', ...args.slice(1)], deps);
-    case 'queue':
-      return headlessQuery(['queue', ...args.slice(1)], deps);
-    case 'audit':
-      return headlessQuery(['audit', ...args.slice(1)], deps);
-    case 'session':
-      return headlessQuery(['session', ...args.slice(1)], deps);
     case 'worker': {
       const workerSub = args[1] ?? 'list';
       if (workerSub === 'status') {

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -519,7 +519,7 @@ export async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Pro
       await preemptTaskSubgraph(taskId, deps);
     }
 
-    const envelope = makeEnvelope('restart-task', 'headless', 'task', { taskId });
+    const envelope = makeEnvelope('retry-task', 'headless', 'task', { taskId });
     const result = deps.mutationTiming
       ? await deps.mutationTiming.span(
         'headless.retry-task.commandService.retryTask',
@@ -566,7 +566,7 @@ export async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Pro
       orchestrator: deps.orchestrator,
       taskExecutor,
       logger: deps.logger,
-      context: 'headless.restart-task',
+      context: 'headless.retry-task',
       started: result.data,
       scopedTaskIds: [taskId],
       mutationTiming: deps.mutationTiming,

--- a/packages/app/src/headless-usage.ts
+++ b/packages/app/src/headless-usage.ts
@@ -1,0 +1,85 @@
+const RESET = '\x1b[0m';
+const BOLD = '\x1b[1m';
+
+export function printHeadlessUsage(): void {
+  process.stdout.write(`${BOLD}invoker${RESET} — Headless workflow runner (Electron)
+
+${BOLD}Usage:${RESET}  electron dist/main.js --headless <command> [args...]
+
+${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
+  query workflows [--status S] [--output F]          List all saved workflows
+  query workflow <workflowId> [--output F]           Show one workflow
+  query tasks [--workflow <id>|<workflowId>] [--status S]
+                                                      Show task states (latest workflow by default)
+    [--no-merge] [--output F]
+  query task <taskId> [--output F]                    Print single task status
+  query queue [--output F]                            Show queue status
+  query review-gate <prNumber|prUrl> [--output F]    Resolve a PR back to its Invoker workflow
+  query action-graph [--output F]                     Print action graph source-of-truth snapshot
+  query audit <taskId> [--output F]                   Print event history
+  query session <taskId>                              Print agent session messages
+  query worker-actions [--workflow <id>] [--status S] [--decision act|skip]
+                                                      List durable worker action rows (all workers)
+  query worker-decisions [--workflow <id>] [--decision act|skip] [--reason <substr>]
+                                                      Show what each worker decided: submitted vs skipped, and why
+  query ui-perf [--output F] [--reset]               Print live UI perf stats
+  query stats [--output F]                           Aggregate stats across all workflows
+  query execution-leases [--output F]               List live SSH/host execution resource leases
+
+${BOLD}Execute:${RESET}
+  watch [<workflowId>]                                Watch workflow status until settled or Ctrl-C
+  run <plan.yaml>                                     Load and execute plan
+  start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--recreate-all]
+              [--fresh-base-failed] [--fresh-base-failed-and-pending] [--fresh-base-failed-pending-and-running] [--fresh-base-all] [--no-track]
+                                                      Start pending work that is ready to execute
+                                                      Fresh-base flags recreate selected workflows from a refreshed base
+  resume <id>                                         Resume incomplete workflow
+  retry <workflowId>                                  Retry workflow: rerun failed, keep completed
+  retry-task <taskId>                                 Retry a single failed/stuck task
+  recreate <workflowId>                                Recreate workflow: wipe all state, new generation
+  recreate-task <taskId>                               Recreate task + downstream (task-scoped reset)
+  recreate-downstream <taskId>                         Recreate downstream of task only (target preserved)
+  fork-workflow <workflowId>                          Fork a live workflow into a new branched workflow (Step 14)
+  detach-workflow <workflowId> <upstreamWorkflowId>  Detach one upstream workflow and void downstream to pending
+  rebase-retry <workflowId|mergeTaskId|taskId>        Refresh pool base, then retry incomplete work
+  rebase-recreate <workflowId|mergeTaskId|taskId>     Refresh pool base, then recreate workflow
+  repair-review-gate-ci <prNumber|prUrl>              Queue CI repair for one mapped review-gate PR
+  fix <taskId> [claude|codex]                         Fix a failed task (default: claude)
+
+${BOLD}Respond:${RESET}
+  approve <taskId>                                    Approve a task
+  reject <taskId> [reason]                            Reject a task
+  input <taskId> <text>                               Provide input to task
+  select <taskId> <experimentId>                      Select winning experiment
+
+${BOLD}Configure:${RESET}
+  install-skills [install|update|reinstall]          Install bundled Invoker AI helpers
+  set command <taskId> <cmd>                          Edit task command and re-run
+  set prompt <taskId> <text>                          Edit task prompt and re-run
+  set pool <taskId> <type> [poolMemberId]           Change execution pool (worktree|docker|ssh)
+  set agent <taskId> <agent>                          Change execution agent (claude|codex|omp)
+  set merge-mode <workflowId> <mode>                  manual | automatic | external_review
+  set fix-prompt <taskId> <text>                      Update fix-session prompt and retry
+  set fix-context <taskId> <text>                     Update fix-session context and retry
+  set gate-policy <taskId> <wfId> [depTaskId] <policy>
+                                                      policy: completed | review_ready | ci_failed
+  set workflow <workflowId> <fieldPath> <value>      Safely update workflow metadata/config
+  set task <taskId> <fieldPath> <value>              Safely update task metadata/config
+  migrate-compat                                     Normalize persisted compatibility workflow/task state
+
+${BOLD}Lifecycle:${RESET}
+  cancel <taskId>                                     Cancel task + all downstream
+  cancel-workflow <workflowId>                        Cancel all active tasks in a workflow
+  delete-task <taskId>                                 Delete one task and retarget dependents
+  delete <workflowId>                                  Delete a single workflow
+  delete-all                                           Delete all workflows (requires INVOKER_ALLOW_DELETE_ALL=1)
+  open-terminal <taskId>                              Open OS terminal for a task
+  slack                                               Start Slack bot (long-running)
+  worker [kind|list|status]                           Run/list registry worker kinds (autofix scans failed tasks)
+
+${BOLD}Options:${RESET}
+  --wait-for-approval    Keep running until PR approval (use with 'run' or 'resume')
+  --no-track             Submit and return immediately after printing Workflow ID
+  --do-not-track         Alias for --no-track
+`);
+}

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -42,7 +42,12 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
-import { formatHeadlessSetSubcommands } from './headless-command-registry.js';
+import {
+  formatHeadlessSetSubcommands,
+  isHeadlessHelpCommand,
+  isRemovedHeadlessCommandAlias,
+} from './headless-command-registry.js';
+import { printHeadlessUsage } from './headless-usage.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 
 export {
@@ -63,7 +68,6 @@ import {
   type QueryFlags,
   BOLD,
   RESET,
-  YELLOW,
   createHeadlessExecutor,
   wireHeadlessApproveHook,
   parseQueryFlags,
@@ -146,14 +150,6 @@ async function dispatchHeadlessRunnableTasks(
   const timer = setInterval(poll, 250);
   timer.unref?.();
   await new Promise<void>((resolve) => setImmediate(resolve));
-}
-
-// ── Deprecation Warning ─────────────────────────────────────
-
-function warnDeprecated(oldCmd: string, newCmd: string): void {
-  process.stderr.write(
-    `${YELLOW}[deprecated]${RESET} "${oldCmd}" is deprecated. Use "${newCmd}" instead.\n`,
-  );
 }
 
 function assertDeleteAllEnabled(): void {
@@ -244,6 +240,15 @@ async function headlessInstallSkills(
 
 export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<void> {
   const command = args[0];
+
+  if (isHeadlessHelpCommand(command)) {
+    printHeadlessUsage();
+    return;
+  }
+
+  if (isRemovedHeadlessCommandAlias(command)) {
+    throw new Error(`Unknown command: ${command}. Run with --help for usage.`);
+  }
 
   switch (command) {
     case 'owner-serve':
@@ -366,7 +371,6 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       await headlessDeleteTask(args[1], deps);
       break;
     case 'delete':
-    case 'delete-workflow':
       await headlessDeleteWorkflow(args[1], deps);
       break;
     case 'delete-all':
@@ -394,56 +398,6 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       await headlessWorker(args.slice(1), deps);
       break;
 
-    // ── Deprecated aliases → query ──
-    case 'list':
-      warnDeprecated('list', 'query workflows');
-      await headlessQuery(['workflows', ...args.slice(1)], deps);
-      break;
-    case 'status':
-      warnDeprecated('status', 'query tasks');
-      await headlessQuery(['tasks', ...args.slice(1)], deps);
-      break;
-    case 'task-status':
-      warnDeprecated('task-status', 'query task');
-      await headlessQuery(['task', ...args.slice(1)], deps);
-      break;
-    case 'queue':
-      warnDeprecated('queue', 'query queue');
-      await headlessQuery(['queue', ...args.slice(1)], deps);
-      break;
-    case 'audit':
-      warnDeprecated('audit', 'query audit');
-      await headlessQuery(['audit', ...args.slice(1)], deps);
-      break;
-    case 'session':
-      warnDeprecated('session', 'query session');
-      await headlessQuery(['session', ...args.slice(1)], deps);
-      break;
-
-    // ── Deprecated aliases → set ──
-    case 'edit':
-      warnDeprecated('edit', 'set command');
-      await headlessSet(['command', ...args.slice(1)], deps);
-      break;
-    case 'edit-executor':
-    case 'edit-type':
-      warnDeprecated(command, 'set pool');
-      await headlessSet(['pool', ...args.slice(1)], deps);
-      break;
-    case 'edit-agent':
-      warnDeprecated('edit-agent', 'set agent');
-      await headlessSet(['agent', ...args.slice(1)], deps);
-      break;
-    case 'set-merge-mode':
-      warnDeprecated('set-merge-mode', 'set merge-mode');
-      await headlessSet(['merge-mode', ...args.slice(1)], deps);
-      break;
-
-    case '--help':
-    case '-h':
-    case undefined:
-      printHeadlessUsage();
-      break;
     default:
       throw new Error(`Unknown command: ${command}. Run with --help for usage.`);
   }
@@ -556,99 +510,8 @@ async function headlessOwnerServe(deps: Pick<HeadlessDeps, 'isStandaloneOwnerIdl
   });
 }
 
-function printHeadlessUsage(): void {
-  process.stdout.write(`${BOLD}invoker${RESET} — Headless workflow runner (Electron)
-
-${BOLD}Usage:${RESET}  electron dist/main.js --headless <command> [args...]
-
-${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
-  query workflows [--status S] [--output F]          List all saved workflows
-  query workflow <workflowId> [--output F]           Show one workflow
-  query tasks [--workflow <id>|<workflowId>] [--status S]
-                                                      Show task states (latest workflow by default)
-    [--no-merge] [--output F]
-  query task <taskId> [--output F]                    Print single task status
-  query queue [--output F]                            Show queue status
-  query review-gate <prNumber|prUrl> [--output F]    Resolve a PR back to its Invoker workflow
-  query action-graph [--output F]                     Print action graph source-of-truth snapshot
-  query audit <taskId> [--output F]                   Print event history
-  query session <taskId>                              Print agent session messages
-  query worker-actions [--workflow <id>] [--status S] [--decision act|skip]
-                                                      List durable worker action rows (all workers)
-  query worker-decisions [--workflow <id>] [--decision act|skip] [--reason <substr>]
-                                                      Show what each worker decided: submitted vs skipped, and why
-  query ui-perf [--output F] [--reset]               Print live UI perf stats
-  query stats [--output F]                           Aggregate stats across all workflows
-  query execution-leases [--output F]               List live SSH/host execution resource leases
-
-${BOLD}Execute:${RESET}
-  watch [<workflowId>]                                Watch workflow status until settled or Ctrl-C
-  run <plan.yaml>                                     Load and execute plan
-  start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--recreate-all]
-              [--fresh-base-failed] [--fresh-base-failed-and-pending] [--fresh-base-failed-pending-and-running] [--fresh-base-all] [--no-track]
-                                                      Start pending work that is ready to execute
-                                                      Fresh-base flags recreate selected workflows from a refreshed base
-  resume <id>                                         Resume incomplete workflow
-  retry <workflowId>                                  Retry workflow: rerun failed, keep completed
-  retry-task <taskId>                                 Retry a single failed/stuck task
-  recreate <workflowId>                                Recreate workflow: wipe all state, new generation
-  recreate-task <taskId>                               Recreate task + downstream (task-scoped reset)
-  recreate-downstream <taskId>                         Recreate downstream of task only (target preserved)
-  fork-workflow <workflowId>                          Fork a live workflow into a new branched workflow (Step 14)
-  detach-workflow <workflowId> <upstreamWorkflowId>  Detach one upstream workflow and void downstream to pending
-  rebase-retry <workflowId|mergeTaskId|taskId>        Refresh pool base, then retry incomplete work
-  rebase-recreate <workflowId|mergeTaskId|taskId>     Refresh pool base, then recreate workflow
-  reset-autofix-budget --exhausted                    Reset exhausted automatic recovery budgets only
-  repair-review-gate-ci <prNumber|prUrl>              Queue CI repair for one mapped review-gate PR
-  fix <taskId> [claude|codex]                         Fix a failed task (default: claude)
-
-${BOLD}Respond:${RESET}
-  approve <taskId>                                    Approve a task
-  reject <taskId> [reason]                            Reject a task
-  input <taskId> <text>                               Provide input to task
-  select <taskId> <experimentId>                      Select winning experiment
-
-${BOLD}Configure:${RESET}
-  install-skills [install|update|reinstall]          Install bundled Invoker AI helpers
-  set command <taskId> <cmd>                          Edit task command and re-run
-  set prompt <taskId> <text>                          Edit task prompt and re-run
-  set pool <taskId> <type> [poolMemberId]           Change execution pool (worktree|docker|ssh)
-  set agent <taskId> <agent>                          Change execution agent (claude|codex|omp)
-  set merge-mode <workflowId> <mode>                  manual | automatic | external_review
-  set fix-prompt <taskId> <text>                      Update fix-session prompt and retry
-  set fix-context <taskId> <text>                     Update fix-session context and retry
-  set gate-policy <taskId> <wfId> [depTaskId] <policy>
-                                                      policy: completed | review_ready | ci_failed
-  set workflow <workflowId> <fieldPath> <value>      Safely update workflow metadata/config
-  set task <taskId> <fieldPath> <value>              Safely update task metadata/config
-  migrate-compat                                     Normalize persisted compatibility workflow/task state
-
-${BOLD}Lifecycle:${RESET}
-  cancel <taskId>                                     Cancel task + all downstream
-  cancel-workflow <workflowId>                        Cancel all active tasks in a workflow
-  delete-task <taskId>                                 Delete one task and retarget dependents
-  delete <workflowId>                                  Delete a single workflow
-  delete-all                                           Delete all workflows (requires INVOKER_ALLOW_DELETE_ALL=1)
-  open-terminal <taskId>                              Open OS terminal for a task
-  slack                                               Start Slack bot (long-running)
-  worker [kind|list|status]                           Run/list registry worker kinds (autofix scans failed tasks)
-
-${BOLD}Deprecated${RESET} (use new names above):
-  list → query workflows       status → query tasks       task-status → query task
-  queue → query queue           audit → query audit         session → query session
-  edit → set command            edit-executor → set pool
-  edit-agent → set agent        set-merge-mode → set merge-mode
-  delete-workflow → delete
-
-${BOLD}Options:${RESET}
-  --wait-for-approval    Keep running until PR approval (use with 'run' or 'resume')
-  --no-track             Submit and return immediately after printing Workflow ID
-  --do-not-track         Alias for --no-track
-`);
-}
-
 async function headlessEdit(taskId: string, newCommand: string, deps: HeadlessDeps): Promise<void> {
-  if (!taskId || !newCommand) throw new Error('Missing arguments. Usage: --headless edit <taskId> <newCommand>');
+  if (!taskId || !newCommand) throw new Error('Missing arguments. Usage: --headless set command <taskId> <newCommand>');
   const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'set command');
   if (!restored) return;
   taskId = restored.resolvedTaskId;
@@ -790,9 +653,7 @@ async function headlessEditAgent(taskId: string, agentName: string, deps: Headle
  * `retryTask` compatibility wire — see `MUTATION_POLICIES.mergeMode`
  * and `buildInvalidationDeps`).
  *
- * The CLI argument is still a workflow id (matches the legacy
- * `set-merge-mode <workflowId> <mode>` surface and the
- * `invoker:set-merge-mode` IPC). `mergeMode` is normalized at the
+ * The CLI argument is a workflow id. `mergeMode` is normalized at the
  * app boundary because that concerns UI/CLI input parsing, not the
  * chart's invalidation routing. The merge-task-id translation
  * (`workflowId → __merge__<workflowId>`) happens here because the
@@ -808,7 +669,7 @@ async function headlessSetMergeMode(
 ): Promise<void> {
   if (!workflowId || !mergeMode) {
     throw new Error(
-      'Missing arguments. Usage: --headless set-merge-mode <workflowId> <manual|automatic|external_review>',
+      'Missing arguments. Usage: --headless set merge-mode <workflowId> <manual|automatic|external_review>',
     );
   }
   const normalized = normalizeMergeModeForPersistence(mergeMode);

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -892,7 +892,7 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
       case 'invoker:select-experiment':
         if (Array.isArray(arg1)) return null;
         return { channel: 'headless.exec', request: { args: ['select', String(arg0), String(arg1)], noTrack: true } };
-      case 'invoker:restart-task':
+      case 'invoker:retry-task':
         return { channel: 'headless.exec', request: { args: ['retry-task', String(arg0)], noTrack: true } };
       case 'invoker:cancel-task':
         return { channel: 'headless.exec', request: { args: ['cancel', String(arg0)], noTrack: true } };
@@ -1645,21 +1645,13 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     }
   });
 
-  // `invoker:restart-task` IPC channel — the channel name is kept
-  // for UI compatibility (renaming would require coordinated UI
-  // changes, deferred to a follow-up). The handler now routes
-  // through `commandService.retryTask` per Step 13's vocabulary
-  // cleanup so the UI's "Restart" context-menu action keeps its
-  // historical retry-class semantics (preserves
-  // branch/workspacePath lineage). The channel itself carries an
-  // `@deprecated` marker in `packages/contracts/src/ipc-channels.ts`.
   registerWorkflowScopedGuiMutationHandler(
-    'invoker:restart-task',
+    'invoker:retry-task',
     (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
     'high',
     async (taskIdArg: unknown) => {
     const taskId = String(taskIdArg);
-    logger.info(`restart-task → retry-task (Step 13 vocabulary): "${taskId}"`, { module: 'ipc' });
+    logger.info(`retry-task: "${taskId}"`, { module: 'ipc' });
     try {
       await preemptTaskSubgraph(taskId);
       const envelope = makeEnvelope('retry-task', 'ui', 'task', { taskId });
@@ -1667,24 +1659,24 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       if (!result.ok) throw new Error(result.error.message);
       const started = result.data;
       logger.info(
-        `${RESTART_TO_BRANCH_TRACE} ipc invoker:restart-task after commandService.retryTask: count=${started.length} [${started.map((t) => `${t.id}(${t.status})`).join(', ')}]`,
+        `${RESTART_TO_BRANCH_TRACE} ipc invoker:retry-task after commandService.retryTask: count=${started.length} [${started.map((t) => `${t.id}(${t.status})`).join(', ')}]`,
         { module: 'ipc' },
       );
       const runnable = started.filter(isDispatchableLaunch);
       logger.info(
-        `${RESTART_TO_BRANCH_TRACE} ipc invoker:restart-task runnable=${runnable.length} [${runnable.map((t) => t.id).join(', ') || '(none)'}] → taskExecutor.executeTasks`,
+        `${RESTART_TO_BRANCH_TRACE} ipc invoker:retry-task runnable=${runnable.length} [${runnable.map((t) => t.id).join(', ') || '(none)'}] → taskExecutor.executeTasks`,
         { module: 'ipc' },
       );
       await dispatchStartedTasksWithGlobalTopup({
         orchestrator,
         taskExecutor: requireTaskExecutor(),
         logger,
-        context: 'ipc.restart-task',
+        context: 'ipc.retry-task',
         started,
         scopedTaskIds: [taskId],
       });
     } catch (err) {
-      logger.error(`restart-task failed: ${err}`, { module: 'ipc' });
+      logger.error(`retry-task failed: ${err}`, { module: 'ipc' });
       throw err;
     }
     },

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -130,6 +130,10 @@ import {
   isHeadlessReadOnlyCommand,
   resolveHeadlessTargetWorkflowId,
 } from './headless-command-classification.js';
+import {
+  isHeadlessHelpCommand,
+  isRemovedHeadlessCommandAlias,
+} from './headless-command-registry.js';
 import { backupPlan } from './plan-backup.js';
 import { startApiServer, type ApiServer } from './api-server.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
@@ -145,6 +149,7 @@ import {
   wireHeadlessApproveHook,
   type HeadlessDeps,
 } from './headless.js';
+import { printHeadlessUsage } from './headless-usage.js';
 import { buildHeadlessApiServerDeps } from './headless-shared.js';
 import { parseReviewGatePrNumber, repairReviewGateCiByPr } from './review-gate-ci-repair-command.js';
 import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
@@ -865,6 +870,18 @@ function startHeadlessMode(): void {
     const mutatingMode = isHeadlessMutatingCommand(cliArgs);
     const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1' || command === 'owner-serve';
     const ownsHeadlessShutdown = standaloneMode && !readOnlyMode && command === 'owner-serve';
+
+    if (isHeadlessHelpCommand(command)) {
+      printHeadlessUsage();
+      process.exit(0);
+      return;
+    }
+
+    if (isRemovedHeadlessCommandAlias(command)) {
+      process.stderr.write(`${RED}Error:${RESET} Unknown command: ${command}. Run with --help for usage.\n`);
+      process.exit(1);
+      return;
+    }
 
     // Try delegation for mutating commands first (owner mode).
     // In standalone mode we skip delegation and run locally.

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -40,7 +40,7 @@ const TASK_SCOPED_MUTATION_CHANNELS = new Set([
   'invoker:reject',
   'invoker:provide-input',
   'invoker:select-experiment',
-  'invoker:restart-task',
+  'invoker:retry-task',
   'invoker:cancel-task',
   'invoker:recreate-task',
   'invoker:recreate-downstream',

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -192,7 +192,7 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return mutations.rejectTask(String(args[0]), args[1] === undefined ? undefined : String(args[1]));
       case 'invoker:provide-input':
         return mutations.provideInput(String(args[0]), String(args[1]));
-      case 'invoker:restart-task':
+      case 'invoker:retry-task':
         return mutations.retryTask(String(args[0]));
       case 'invoker:recreate-task':
         return mutations.recreateTask(String(args[0]));

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1072,20 +1072,7 @@ export const IpcChannels = {
     request: [taskId: string, experimentId: string | string[]];
     response: WorkflowMutationAcceptedResult;
   },
-  /**
-   * @deprecated Step 13 (`docs/architecture/task-invalidation-roadmap.md`):
-   * `invoker:restart-task` is the legacy channel name from when
-   * `restartTask` was the overloaded "retry-or-recreate" verb the
-   * chart's "Naming inconsistency" section flagged. The channel
-   * itself is preserved for UI compatibility but its handler in
-   * `main.ts` now routes through `commandService.retryTask` →
-   * `Orchestrator.retryTask` (retry-class semantics: preserves
-   * branch/workspacePath lineage). Prefer the explicit channels —
-   * `invoker:retry-task` (when wired) for retry-class invalidation
-   * or `invoker:recreate-task` for recreate-class invalidation.
-   * Once UI is migrated this channel can be removed.
-   */
-  'invoker:restart-task': {} as {
+  'invoker:retry-task': {} as {
     request: [taskId: string];
     response: WorkflowMutationAcceptedResult;
   },

--- a/packages/execution-engine/src/__tests__/auto-fix-bare-retry.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-bare-retry.test.ts
@@ -82,7 +82,7 @@ function makeHarness(task = makeFailedTask()) {
 }
 
 describe('AutoFixWorker attempt-0 bare retry', () => {
-  it('submits invoker:restart-task on the first tick and does not consume an auto-fix attempt', async () => {
+  it('submits invoker:retry-task on the first tick and does not consume an auto-fix attempt', async () => {
     const harness = makeHarness();
     const tick = createAutoFixRecoveryTick({
       store: harness.store,
@@ -99,7 +99,7 @@ describe('AutoFixWorker attempt-0 bare retry', () => {
     const [workflowId, priority, channel, args] = harness.submit.mock.calls[0]!;
     expect(workflowId).toBe('wf-1');
     expect(priority).toBe('normal');
-    expect(channel).toBe('invoker:restart-task');
+    expect(channel).toBe('invoker:retry-task');
     expect(args).toEqual(['wf-1/build']);
 
     const retryRow = harness.actions.get(`${AUTO_FIX_WORKER_KIND}:${AUTO_FIX_WORKER_KIND}:retry:wf-1/build`);
@@ -194,7 +194,7 @@ describe('AutoFixWorker attempt-0 bare retry', () => {
     });
 
     await tick({ reason: 'poll' } as never);
-    expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:restart-task');
+    expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:retry-task');
     harness.submit.mockClear();
 
     // Bare retry succeeded then failed again under a new generation/attempt.
@@ -237,7 +237,7 @@ describe('AutoFixWorker attempt-0 bare retry', () => {
     });
 
     await tick({ reason: 'poll' } as never);
-    expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:restart-task');
+    expect(harness.submit.mock.calls[0]?.[2]).toBe('invoker:retry-task');
     harness.submit.mockClear();
 
     harness.tasks.set('wf-1/build', makeFailedTask({
@@ -271,6 +271,6 @@ describe('AutoFixWorker attempt-0 bare retry', () => {
     expect(submitCalls.length).toBeGreaterThan(0);
     const payload = submitCalls[0]?.[2] as { phase?: string; details?: { channel?: string } };
     expect(payload.phase).toBe('worker-autofix-bare-retry-submitted');
-    expect(payload.details?.channel).toBe('invoker:restart-task');
+    expect(payload.details?.channel).toBe('invoker:retry-task');
   });
 });

--- a/packages/execution-engine/src/__tests__/worker-decision-ledger.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-decision-ledger.test.ts
@@ -190,7 +190,7 @@ describe('autofix decision ledger', () => {
     await tick(tickCtx);
 
     expect(submit).toHaveBeenCalledTimes(2);
-    expect(submit.mock.calls[0]?.[2]).toBe('invoker:restart-task');
+    expect(submit.mock.calls[0]?.[2]).toBe('invoker:retry-task');
     expect(submit.mock.calls[1]?.[2]).toBe('invoker:fix-with-agent');
     const autoFixWrite = upserts.find((w) => w.actionType === 'auto-fix');
     expect(autoFixWrite).toMatchObject({

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -42,7 +42,7 @@ export const RECOVERY_WORKER_KIND = 'recovery';
 
 const DEFAULT_RECOVERY_POLL_INTERVAL_MS = 60_000;
 const AUTO_FIX_COMMAND_CHANNEL = 'invoker:fix-with-agent';
-const AUTO_FIX_BARE_RETRY_CHANNEL = 'invoker:restart-task';
+const AUTO_FIX_BARE_RETRY_CHANNEL = 'invoker:retry-task';
 const AUTO_FIX_ACTION_TYPE = 'auto-fix';
 const AUTO_FIX_BARE_RETRY_ACTION_TYPE = 'auto-retry';
 

--- a/packages/execution-engine/src/auto-fix-retry-cap.ts
+++ b/packages/execution-engine/src/auto-fix-retry-cap.ts
@@ -17,7 +17,7 @@ import { recordWorkerDecisionRow, type WorkerDecisionStore } from './worker-deci
  * This counter is stored in the durable `worker_actions` table under a key that
  * is stable across generations, attempts, and process restarts, so the total
  * number of worker-initiated retries for a task can never exceed the config.
- * Both automatic retry kinds (bare `restart-task` and `fix-with-agent`) count,
+ * Both automatic retry kinds (bare `retry-task` and `fix-with-agent`) count,
  * and every worker shares the one counter so the cap is per-task, not
  * per-worker. It is a hard cap across restarts and generation bumps. Recreate-
  * class lifecycle resets deliberately clear it for the affected task; a human

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2313,7 +2313,7 @@ export function App() {
     if (!invoker) return;
     setContextMenu(null);
     try {
-      const result = await invoker.restartTask(taskId);
+      const result = await invoker.retryTask(taskId);
       trackAcceptedMutation(result);
     } catch (err) {
       notifyMutationError('Failed to restart task', err);

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -515,7 +515,7 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
     await expectHighlightedMenuItem('Restart Task');
     pressMenuKey('Enter');
 
-    await waitFor(() => expect(mock.api.restartTask).toHaveBeenCalledWith('task-disabled-terminal'));
+    await waitFor(() => expect(mock.api.retryTask).toHaveBeenCalledWith('task-disabled-terminal'));
     expect(mock.api.openTerminal).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -259,7 +259,7 @@ export function createMockInvoker(
     approve: vi.fn(async () => accepted('invoker:approve')),
     reject: vi.fn(async () => accepted('invoker:reject')),
     selectExperiment: vi.fn(async () => accepted('invoker:select-experiment')),
-    restartTask: vi.fn(async () => accepted('invoker:restart-task')),
+    retryTask: vi.fn(async () => accepted('invoker:retry-task')),
     editTaskCommand: vi.fn(async () => accepted('invoker:edit-task-command')),
     editTaskPrompt: vi.fn(async () => accepted('invoker:edit-task-prompt')),
     editTaskPool: vi.fn(async () => accepted('invoker:edit-task-pool')),


### PR DESCRIPTION
## Summary

This slice refreshes the persistence architecture doc.

It keeps the allowed SQLite migration note while naming only live task-rerun and merge-mode surfaces.

## Review Claim

`docs/persistence-architecture-single-writer.md` now describes only the live task-rerun and merge-mode surfaces.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice is prose-only and keeps the explicitly allowed SQLite migration context intact.

## Slice Rationale

The prose update stays last so reviewers can inspect documentation drift after the runtime names are final.

## Non-goals

- No runtime changes.
- No test expectation changes.
- No SQLite migration change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `rg -n "set-merge-mode" packages docs invoker-ctl`
- [x] `rg -n "invoker:restart-task|restartTask\\(|/api/tasks/.*/restart|/api/workflows/.*/restart" packages docs invoker-ctl`
- [x] `rg -n "github \\| external_review|merge_mode = 'github'|Use /api/.*/restart" packages docs invoker-ctl`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <published commit sha>`
- Post-revert steps: Rerun the canonical-name sweeps.
- Data migration? No

</details>
