### PR TITLE
[Planning Terminal Tmux Blank Fix](1) Restore planning tmux session snapshots

### DIFF
--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -368,6 +368,34 @@ describe('EmbeddedTerminalManager', () => {
     expect(snapshot).toBe(`${'a'.repeat(maxSnapshotChars - 'tail'.length)}tail`);
   });
 
+  it('bounds restored spawn session snapshots to the most recent 64 KiB', () => {
+    const maxSnapshotChars = 64 * 1024;
+    const spawned = {
+      write: vi.fn(),
+      resize: vi.fn(),
+      close: vi.fn(),
+    };
+    const backend: EmbeddedTerminalBackend = {
+      name: 'pty',
+      spawn: vi.fn(() => spawned),
+    };
+    const mgr = new EmbeddedTerminalManager({ backend });
+
+    const session = mgr.restoreSpawnSession({
+      sessionId: 'restored-large-snapshot',
+      taskId: 'task-restored-large-snapshot',
+      targetKey: 'target-restored-large-snapshot',
+      spec: { command: 'bash', args: ['-l'] },
+      cwd: '/tmp/restored',
+      createdAt: '2026-07-07T00:00:00.000Z',
+      outputSnapshot: `${'a'.repeat(maxSnapshotChars)}tail`,
+    });
+
+    expect(session.outputSnapshot).toHaveLength(maxSnapshotChars);
+    expect(session.outputSnapshot).toBe(`${'a'.repeat(maxSnapshotChars - 'tail'.length)}tail`);
+    expect(mgr.get(session.sessionId)?.outputSnapshot).toBe(session.outputSnapshot);
+  });
+
   it('emits session-updated on open, output, and natural exit', () => {
     const child = createFakeChild();
     const bashSpawnFn = vi.fn(() => child) as unknown as BashSpawnFn;

--- a/packages/app/src/__tests__/terminal-session-persistence.test.ts
+++ b/packages/app/src/__tests__/terminal-session-persistence.test.ts
@@ -7,12 +7,18 @@ import {
   type BashSpawnFn,
 } from '../embedded-terminal-manager.js';
 import {
+  bindPlanningTerminalSessionState,
   closeTaskTerminalSession,
   listTaskTerminalSessions,
+  registerPlanningTerminalSessionIpcHandlers,
   registerTerminalSessionIpcHandlers,
   registerTerminalSessionPersistence,
   restorePersistedTerminalSessions,
 } from '../terminal-session-ipc.js';
+import {
+  createInAppPlanningChatSessions,
+  type InAppPlanningChatSession,
+} from '../in-app-planner.js';
 import type { SQLiteAdapter, TerminalSessionRecord } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
 import {
@@ -62,6 +68,28 @@ function makeTerminalRow(
     ...overrides,
   };
 }
+
+function makePlanningSession(
+  id: string,
+  overrides: Partial<InAppPlanningChatSession> = {},
+): InAppPlanningChatSession {
+  return {
+    id,
+    title: `Planning ${id}`,
+    presetKey: 'codex',
+    confirmationMode: 'require',
+    status: 'still_discussing',
+    messages: [],
+    conversation: {} as InAppPlanningChatSession['conversation'],
+    createdAt: '2026-07-26T00:00:00.000Z',
+    updatedAt: '2026-07-26T00:00:00.000Z',
+    nextMessageId: 1,
+    terminalMode: 'chat',
+    terminalOutputSnapshot: '',
+    ...overrides,
+  };
+}
+
 describe('registerTerminalSessionPersistence coalesce', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -222,6 +250,88 @@ describe('registerTerminalSessionPersistence coalesce', () => {
 
     handle.dispose();
   });
+
+  it('restores persisted planning terminal sessions with saved output snapshots', () => {
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('plan-restore', makePlanningSession('plan-restore', {
+      terminalMode: 'tmux',
+      terminalSessionId: 'term-plan-restore',
+      terminalStatus: 'running',
+      terminalOutputSnapshot: 'saved planning tmux output\n',
+      terminalUpdatedAt: '2026-07-26T00:00:03.000Z',
+    }));
+    const restoreSpawnSession = vi.fn();
+    const embeddedTerminalManager = Object.assign(new EventEmitter(), {
+      restoreSpawnSession,
+    }) as unknown as EmbeddedTerminalManager;
+
+    const { restorePersistedPlanningTerminals } = bindPlanningTerminalSessionState({
+      embeddedTerminalManager,
+      logger: { info: vi.fn(), warn: vi.fn() },
+      planningChatSessions: sessions,
+      getPlanningSessionStore: () => undefined,
+      repoRoot: '/repo',
+    });
+
+    restorePersistedPlanningTerminals();
+
+    expect(restoreSpawnSession).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'term-plan-restore',
+      taskId: 'planning:plan-restore',
+      kind: 'planning',
+      planningSessionId: 'plan-restore',
+      cwd: '/repo',
+      outputSnapshot: 'saved planning tmux output\n',
+    }));
+  });
+
+  it('planning terminal open persists the returned session snapshot onto the planning chat', async () => {
+    type IpcHandler = (...args: unknown[]) => Promise<unknown>;
+    const handlers = new Map<string, IpcHandler>();
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('plan-open', makePlanningSession('plan-open'));
+    const openedSession = {
+      sessionId: 'term-plan-open',
+      taskId: 'planning:plan-open',
+      kind: 'planning' as const,
+      planningSessionId: 'plan-open',
+      status: 'running' as const,
+      cwd: '/repo',
+      mode: 'spawn' as const,
+      attached: false,
+      createdAt: '2026-07-26T00:00:00.000Z',
+      outputSnapshot: 'shell restored from open\n',
+    };
+    const embeddedTerminalManager = Object.assign(new EventEmitter(), {
+      openOrReuse: vi.fn(() => openedSession),
+    }) as unknown as EmbeddedTerminalManager;
+    const ipcMain = {
+      handle(channel: string, callback: IpcHandler) {
+        handlers.set(channel, callback);
+      },
+    };
+
+    registerPlanningTerminalSessionIpcHandlers({
+      ipcMain: ipcMain as unknown as IpcMain,
+      embeddedTerminalManager,
+      logger: { info: vi.fn(), warn: vi.fn() },
+      planningChatSessions: sessions,
+      getPlanningSessionStore: () => undefined,
+      repoRoot: '/repo',
+    });
+
+    await expect(handlers.get('invoker:planning-terminal-open')?.({}, 'plan-open')).resolves.toEqual({
+      opened: true,
+      session: openedSession,
+    });
+    expect(sessions.get('plan-open')).toMatchObject({
+      terminalMode: 'tmux',
+      terminalSessionId: 'term-plan-open',
+      terminalStatus: 'running',
+      terminalOutputSnapshot: 'shell restored from open\n',
+    });
+  });
+
   it('falls back to live task sessions when persisted terminal rows fail to load', () => {
     const child = createFakeChild();
     const mgr = new EmbeddedTerminalManager({

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -391,7 +391,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
       createdAt: seed.createdAt,
       updatedAt: new Date().toISOString(),
       status: 'running' as const,
-      outputSnapshot: seed.outputSnapshot,
+      outputSnapshot: trimOutputSnapshot(seed.outputSnapshot),
     });
   }
 


### PR DESCRIPTION
## Summary

Planning Terminal Tmux Blank Fix - backend snapshot restore slice.

Restored planning terminal sessions now trim saved output snapshots before reusing them.

Persisted planning chats restore their terminal session snapshot when planning tmux opens again.

## Review Claim

The backend preserves bounded planning tmux output snapshots when restoring or opening planning terminal sessions.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice stays in app terminal session state and focused app tests. Renderer replay and e2e assertions land in the next PR.

## Slice Rationale

Backend snapshot restore lands first so the renderer can depend on durable planning terminal output.

## Non-goals

- No renderer xterm lifecycle changes.
- No e2e expectation flip.
- No owner-serve web bridge startup changes.

## Architecture

### Before

```mermaid
graph TD
    A["Persisted planning chat has outputSnapshot"] --> B["restoreSpawnSession reuses the full snapshot"]
    B --> C["Restored terminal state can exceed the bounded live buffer"]
```

### After

```mermaid
graph TD
    A["Persisted planning chat has outputSnapshot"] --> B["restoreSpawnSession trims the snapshot"]
    B --> C["Planning terminal state restores with the same bounded buffer"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/embedded-terminal-manager.test.ts src/__tests__/terminal-session-persistence.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-bodies/planning-terminal-tmux-blank-fix-1.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-bodies/planning-terminal-tmux-blank-fix-1.md --base plan/planning-terminal-tmux-blank-repro`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert dfcaae5a9`
- Post-revert steps: None
- Data migration? No

</details>
