### PR TITLE
[Planning Terminal Tmux Blank Fix](3) Keep owner-serve web bridge startup single

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1732,25 +1732,6 @@ function startHeadlessMode(): void {
           );
         }
         workerRuntimeController.startAutoStartedWorkers();
-        if (command === 'owner-serve') {
-          const ownerServeTaskExecutor = createStandaloneTaskExecutor();
-          const apiServerDeps = buildHeadlessApiServerDeps(headlessDeps, ownerServeTaskExecutor);
-          headlessWebBridge = startWebSurfaceForHeadless(
-            {
-              logger,
-              orchestrator,
-              persistence,
-              messageBus,
-              executionAgentRegistry: agentRegistry,
-              invokerConfig,
-              repoRoot,
-              executorRegistry,
-              appRootDir: __dirname,
-            },
-            apiServerDeps,
-          );
-        }
-
         // Owner discovery and exec handlers must exist before dispatch polling starts.
         if (!readOnlyMode) {
           standaloneLaunchDispatcherController = startStandaloneLaunchDispatcher({
@@ -1771,6 +1752,7 @@ function startHeadlessMode(): void {
               messageBus,
               executionAgentRegistry: agentRegistry,
               invokerConfig,
+              repoRoot,
               appRootDir: __dirname,
             },
             apiServerDeps,


### PR DESCRIPTION
## Summary

Planning Terminal Tmux Blank Fix - owner-serve startup slice.

Owner-serve now starts one web bridge after launch dispatcher setup.

The web surface still receives the repository root from the host dependency object.

## Review Claim

Owner-serve web bridge startup runs once while preserving the repo root passed to the web surface.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice only changes main-process owner-serve startup wiring. Planning terminal runtime and renderer behavior are already isolated in earlier PRs.

## Slice Rationale

The cleanup stays last because it was found during verification and is separate from planning terminal replay.

## Non-goals

- No planning terminal runtime changes.
- No renderer behavior changes.
- No test expectation changes.

## Architecture

### Before

```mermaid
graph TD
    A["owner-serve starts"] --> B["First web bridge setup"]
    B --> C["Launch dispatcher setup"]
    C --> D["Second web bridge setup"]
```

### After

```mermaid
graph TD
    A["owner-serve starts"] --> B["Launch dispatcher setup"]
    B --> C["Single web bridge setup with repoRoot"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && CAPTURE_VIDEO=1 pnpm --filter @invoker/app test:e2e -- planning-terminal-tmux-blank-repro.spec.ts --reporter=line`
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-bodies/planning-terminal-tmux-blank-fix-3.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-bodies/planning-terminal-tmux-blank-fix-3.md --base stack/EdbertChan/plan/planning-terminal-tmux-blank-fix/planning-terminal-tmux-blank-fix-2-replay--86139c07`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a776e0c11`
- Post-revert steps: None
- Data migration? No

</details>
