### PR TITLE
[Admin Bypass Topology](3) Register stale-base repros in required shard

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -44,6 +44,9 @@ def print_action(action: Action, pr: PrSnapshot | None, dry_run: bool, as_json: 
         print(f"{prefix}comment-admin-bypass-nudge PR #{action.pr_number}")
     elif action.kind == "restore_admin_bypass_label":
         print(f"{prefix}restore-admin-bypass-label PR #{action.pr_number}")
+    elif action.kind == "retarget_base":
+        from_base = pr.base_ref_name if pr else ""
+        print(f"{prefix}retarget-base PR #{action.pr_number} from={from_base} to={action.key}")
     elif action.kind == "remove_merge_hold":
         print(f"{prefix}remove-merge-hold PR #{action.pr_number}")
     elif action.kind == "resolve_bot_threads":
@@ -139,7 +142,8 @@ def run_cycle(args: argparse.Namespace) -> bool:
     loader = AdminBypassStackLoader(gh)
     executor = AdminBypassGhExecutor(gh, ledger, logger, args.repo)
     repairer = AdminBypassRepairer(gh, executor, logger, ledger, args.repo)
-    stacks = loader.load(args.repo, args.author, args.pr, required_checks, trunk)
+    loaded = loader.load(args.repo, args.author, args.pr, required_checks, trunk)
+    stacks = loaded.stacks
     now = int(time.time())
     pr_by_number = {pr.number: pr for stack in stacks for pr in stack.prs}
     logger.trace(
@@ -157,6 +161,7 @@ def run_cycle(args: argparse.Namespace) -> bool:
             ledger,
             now,
             open_pr_numbers,
+            loaded.open_pr_numbers_by_head,
             args.max_requeue_attempts,
             args.max_repair_attempts,
             trunk,

--- a/scripts/mergify_admin_requeue_gh_executor.py
+++ b/scripts/mergify_admin_requeue_gh_executor.py
@@ -58,6 +58,10 @@ class AdminBypassGhExecutor:
             self.gh.edit_label(self.repo, pr.number, add="admin-bypass")
             self.ledger.record(RESTORE_ADMIN_BYPASS_LABEL_LEDGER_KIND, pr.number, pr.head_ref_oid, "admin-bypass", now)
 
+    def retarget_base(self, pr: PrSnapshot, new_base: str, now: int) -> None:
+        self.gh.retarget_base(self.repo, pr.number, new_base)
+        self.ledger.record("retarget-base", pr.number, pr.head_ref_oid, f"{pr.base_ref_name}->{new_base}", now)
+
     def comment_admin_bypass_nudge(self, pr: PrSnapshot, key: str, now: int) -> None:
         if self.ledger.count(ADMIN_BYPASS_NUDGE_LEDGER_KIND, pr.number, pr.head_ref_oid, key) == 0:
             self.gh.comment(self.repo, pr.number, admin_bypass_nudge_body())
@@ -106,6 +110,9 @@ class AdminBypassGhExecutor:
             return
         if action.kind == "restore_admin_bypass_label":
             self.restore_admin_bypass_label(pr, now)
+            return
+        if action.kind == "retarget_base":
+            self.retarget_base(pr, action.key, now)
             return
         if action.kind == "comment_admin_bypass_nudge":
             self.comment_admin_bypass_nudge(pr, action.key, now)

--- a/scripts/mergify_admin_requeue_loader.py
+++ b/scripts/mergify_admin_requeue_loader.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from typing import Mapping, Sequence
 
 try:
-    from .mergify_admin_requeue_model import StackGroup
+    from .mergify_admin_requeue_model import LoadedStacks, StackGroup
     from .mergify_admin_requeue_snapshot import GhClient, group_stack_prs, parse_stack_metadata, snapshot_from_detail
 except ImportError:
-    from mergify_admin_requeue_model import StackGroup
+    from mergify_admin_requeue_model import LoadedStacks, StackGroup
     from mergify_admin_requeue_snapshot import GhClient, group_stack_prs, parse_stack_metadata, snapshot_from_detail
 
 
@@ -21,17 +21,26 @@ class AdminBypassStackLoader:
         pr_numbers: Sequence[int],
         required_checks: Sequence[str],
         trunk: str,
-    ) -> tuple[StackGroup, ...]:
+    ) -> LoadedStacks:
         candidates = self.gh.list_candidate_prs(repo, author, pr_numbers)
         candidate_numbers = {int(pr.get("number") or 0) for pr in candidates}
         if not candidate_numbers:
-            return ()
+            return LoadedStacks(stacks=(), open_pr_numbers_by_head={})
 
         raw_by_number = {
             int(pr.get("number") or 0): pr
             for pr in self.gh.list_open_prs(repo)
         }
         raw_by_number.update({int(pr.get("number") or 0): pr for pr in candidates})
+        open_pr_numbers_by_head: dict[str, list[int]] = {}
+        for raw in raw_by_number.values():
+            if str(raw.get("state") or "").upper() != "OPEN":
+                continue
+            head_ref_name = str(raw.get("headRefName") or "")
+            number = int(raw.get("number") or 0)
+            if head_ref_name and number:
+                open_pr_numbers_by_head.setdefault(head_ref_name, []).append(number)
+
 
         comments_cache: dict[int, list[dict]] = {}
 
@@ -72,8 +81,14 @@ class AdminBypassStackLoader:
                 metadata[pr_number] = meta
             metadata[number] = meta
 
-        return tuple(
-            stack
-            for stack in group_stack_prs(snapshots, metadata, trunk)
-            if any(pr.number in candidate_numbers for pr in stack.prs)
+        return LoadedStacks(
+            stacks=tuple(
+                stack
+                for stack in group_stack_prs(snapshots, metadata, trunk)
+                if any(pr.number in candidate_numbers for pr in stack.prs)
+            ),
+            open_pr_numbers_by_head={
+                head_ref_name: tuple(sorted(numbers))
+                for head_ref_name, numbers in open_pr_numbers_by_head.items()
+            },
         )

--- a/scripts/mergify_admin_requeue_model.py
+++ b/scripts/mergify_admin_requeue_model.py
@@ -78,6 +78,13 @@ class StackGroup:
     stack_id: str
     prs: tuple[PrSnapshot, ...]
 
+@dataclass(frozen=True)
+class LoadedStacks:
+    stacks: tuple[StackGroup, ...]
+    open_pr_numbers_by_head: Mapping[str, tuple[int, ...]]
+
+
+
 
 @dataclass(frozen=True)
 class Blocker:

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Collection, Mapping
+from typing import Collection, Literal, Mapping
 
 try:
     from .mergify_admin_requeue_model import (
@@ -51,10 +51,19 @@ MANUAL_SPLIT_STOP_MARKERS = (
 
 
 @dataclass(frozen=True)
+class BottomTopology:
+    kind: Literal["current_bottom", "external_open_base", "stale_unowned_base"]
+    root: PrSnapshot
+    bottom: PrSnapshot | None
+    external_open_base_pr_numbers: tuple[int, ...]
+
+
+@dataclass(frozen=True)
 class StackFacts:
     stack: StackGroup
     required_checks: frozenset[str]
     trunk: str
+    bottom_topology: BottomTopology
     bottom: PrSnapshot | None
     upper_stack_needs_acceptance: bool
     prereq_status: RepairPrereqStatus | None
@@ -72,17 +81,12 @@ def is_queue_only_required_check(name: str) -> bool:
 
 def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) -> tuple[Blocker, ...]:
     blockers: list[Blocker] = []
-    if pr.state == "MERGED":
-        blockers.append(Blocker("merged", "merged", pr.number, "state=MERGED"))
-        return tuple(blockers)
     if pr.state != "OPEN":
         blockers.append(Blocker("closed", "closed", pr.number, f"state={pr.state}"))
         return tuple(blockers)
     if pr.is_draft:
         blockers.append(Blocker("draft", "draft", pr.number, "PR is draft"))
         return tuple(blockers)
-    if pr.base_ref_name != trunk:
-        blockers.append(Blocker("not_current_bottom", "not_current_bottom", pr.number, f"base={pr.base_ref_name}"))
     if "merge-hold" in pr.labels:
         blockers.append(Blocker("merge-hold", "merge_hold", pr.number, "merge-hold label present"))
 
@@ -136,7 +140,7 @@ def effective_blockers(
     suppressed = set(suppressed_failed_checks)
     blockers = [
         b for b in classify_pr(pr, required_checks, trunk)
-        if b.kind != "not_current_bottom" and not (b.kind == "failed_check" and b.key in suppressed)
+        if not (b.kind == "failed_check" and b.key in suppressed)
     ]
     latest = pr.latest_mergify
     if not latest or latest.head_sha != pr.head_ref_oid:
@@ -181,6 +185,42 @@ def current_bottom_pr(stack: StackGroup, trunk: str) -> PrSnapshot | None:
         if pr.state == "OPEN" and pr.base_ref_name == trunk:
             return pr
     return None
+
+def classify_bottom_topology(
+    stack: StackGroup,
+    trunk: str,
+    open_pr_numbers_by_head: Mapping[str, Collection[int]],
+) -> BottomTopology:
+    root = stack.prs[0]
+    bottom = current_bottom_pr(stack, trunk)
+    if bottom is not None:
+        return BottomTopology(
+            kind="current_bottom",
+            root=root,
+            bottom=bottom,
+            external_open_base_pr_numbers=(),
+        )
+    current_stack_numbers = {pr.number for pr in stack.prs}
+    external_open_base_pr_numbers = tuple(sorted(
+        number
+        for number in open_pr_numbers_by_head.get(root.base_ref_name, ())
+        if number not in current_stack_numbers
+    ))
+    if external_open_base_pr_numbers:
+        return BottomTopology(
+            kind="external_open_base",
+            root=root,
+            bottom=None,
+            external_open_base_pr_numbers=external_open_base_pr_numbers,
+        )
+    return BottomTopology(
+        kind="stale_unowned_base",
+        root=root,
+        bottom=None,
+        external_open_base_pr_numbers=(),
+    )
+
+
 
 
 def stack_has_unaccepted_upper_pr(stack: StackGroup, bottom: PrSnapshot | None) -> bool:
@@ -269,6 +309,8 @@ def latest_queue_only_noop_check(stack: StackGroup, ledger: Ledger, trunk: str) 
 
 
 def latest_repair_invalid_blocker(pr: PrSnapshot, blocker: Blocker, ledger: Ledger) -> Blocker | None:
+    if blocker.kind != "failed_check":
+        return None
     latest = ledger.latest("repair-invalid", pr.number, pr.head_ref_oid, blocker.key)
     if latest is None:
         return None
@@ -297,11 +339,6 @@ def existing_split_stop_blocker(pr: PrSnapshot, blocker: Blocker) -> Blocker | N
             continue
         return Blocker(blocker.key, "human_decision", pr.number, detail)
     return None
-
-
-def has_exact_repair_stop_comment(pr: PrSnapshot, detail: str) -> bool:
-    expected = f"{REPAIR_STOP_PREFIX}{detail}".strip()
-    return any(comment.body.strip() == expected for comment in pr.repair_stop_comments)
 
 
 def latest_mergify_repair_invalid_blockers(
@@ -338,6 +375,15 @@ def _assert_stack_facts_invariants(facts: StackFacts) -> None:
         for blocker in facts.blockers_by_pr[pr.number]
     )
     assert facts.all_blockers == expected_all, "all_blockers must flatten blockers_by_pr in stack order"
+    assert facts.bottom is facts.bottom_topology.bottom, "bottom mirror must track bottom topology"
+    assert (facts.bottom_topology.kind == "current_bottom") is (facts.bottom is not None), "current_bottom topology must match bottom presence"
+    assert (facts.bottom_topology.kind != "current_bottom") is (facts.bottom is None), "non-current topology must match missing bottom"
+    assert (facts.bottom_topology.kind == "external_open_base") is bool(facts.bottom_topology.external_open_base_pr_numbers), "external owners must only appear on external_open_base topology"
+    assert (
+        facts.bottom_topology.kind == "stale_unowned_base"
+    ) is (
+        facts.bottom is None and facts.bottom_topology.external_open_base_pr_numbers == ()
+    ), "stale_unowned_base must mean no bottom and no external owners"
     if facts.suppressed_failed_checks_by_pr:
         assert facts.bottom is not None, "suppression requires a current bottom PR"
         assert set(facts.suppressed_failed_checks_by_pr) == {facts.bottom.number}, "derived suppression is bottom-only"
@@ -358,10 +404,12 @@ def build_stack_facts(
     required_checks: Collection[str],
     ledger: Ledger,
     open_pr_numbers: Collection[int],
+    open_pr_numbers_by_head: Mapping[str, Collection[int]],
     trunk: str,
 ) -> StackFacts:
     required = frozenset(required_checks)
-    bottom = current_bottom_pr(stack, trunk)
+    bottom_topology = classify_bottom_topology(stack, trunk, open_pr_numbers_by_head)
+    bottom = bottom_topology.bottom
     upper_stack_needs_acceptance = stack_has_unaccepted_upper_pr(stack, bottom)
     prereq_status = latest_repair_prereq_status(stack, ledger, open_pr_numbers, trunk)
     queue_only_noop_check = latest_queue_only_noop_check(stack, ledger, trunk)
@@ -399,6 +447,7 @@ def build_stack_facts(
         stack=stack,
         required_checks=required,
         trunk=trunk,
+        bottom_topology=bottom_topology,
         bottom=bottom,
         upper_stack_needs_acceptance=upper_stack_needs_acceptance,
         prereq_status=prereq_status,
@@ -420,6 +469,7 @@ def build_stack_facts(
 def summarize_stack(facts: StackFacts) -> dict[str, object]:
     return {
         "stack_id": facts.stack.stack_id,
+        "bottom_topology": facts.bottom_topology.kind,
         "bottom_pr": facts.bottom.number if facts.bottom else None,
         "upper_stack_needs_acceptance": facts.upper_stack_needs_acceptance,
         "prs": [
@@ -480,14 +530,10 @@ def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
     )
 
 
-def _pr_has_human_decision(facts: StackFacts, pr_number: int) -> bool:
-    return any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr_number])
-
-
 def plan_mergify_queue_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     del max_repair_attempts
     for pr in facts.stack.prs:
-        if _pr_has_human_decision(facts, pr.number):
+        if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
             continue
         if facts.upper_stack_needs_acceptance and facts.bottom and pr.number == facts.bottom.number:
             continue
@@ -499,8 +545,6 @@ def plan_mergify_queue_repairs(facts: StackFacts, ledger: Ledger, max_repair_att
 
 def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     for pr in facts.stack.prs:
-        if _pr_has_human_decision(facts, pr.number):
-            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "conflict":
                 key = f"conflict:{pr.number}"
@@ -517,8 +561,6 @@ def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: 
 
 def plan_bot_thread_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     for pr in facts.stack.prs:
-        if _pr_has_human_decision(facts, pr.number):
-            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "outdated_bot_review_thread":
                 return Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail)
@@ -534,8 +576,6 @@ def plan_bot_thread_repairs(facts: StackFacts, ledger: Ledger, max_repair_attemp
 
 def plan_hard_blockers(facts: StackFacts, ledger: Ledger) -> Action | None:
     for pr in facts.stack.prs:
-        if _pr_has_human_decision(facts, pr.number):
-            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "pending_check":
                 return None
@@ -568,21 +608,22 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
     if any(blocker.kind == "merge_hold" for blocker in facts.all_blockers):
         return None
     if not facts.bottom:
-        first = next((pr for pr in facts.stack.prs if pr.state == "OPEN"), None)
-        if first is None:
-            return None
-        detail = (
-            f"no current bottom on {facts.trunk}: lowest open stack PR #{first.number} "
-            f"is based on `{first.base_ref_name}`, not `{facts.trunk}`; land or retarget "
-            "that base before babysitting can queue this stack"
-        )
-        if has_exact_repair_stop_comment(first, detail):
-            return None
+        if facts.bottom_topology.kind == "current_bottom":
+            raise AssertionError("current_bottom topology reached no-bottom branch")
+        root = facts.bottom_topology.root
+        if facts.bottom_topology.kind == "external_open_base":
+            owners = ", ".join(f"#{number}" for number in facts.bottom_topology.external_open_base_pr_numbers)
+            return Action(
+                "comment_blocked",
+                root.number,
+                "external-open-base-pr",
+                f"lowest open stack PR #{root.number} is based on `{root.base_ref_name}`, which still belongs to open PR(s) {owners} outside this stack; leaving it alone to avoid dropping dependency changes",
+            )
         return Action(
-            "comment_blocked",
-            first.number,
-            "no-current-bottom",
-            detail,
+            "retarget_base",
+            root.number,
+            facts.trunk,
+            f"retarget stack root from `{root.base_ref_name}` to `{facts.trunk}`",
         )
 
     bottom = facts.bottom
@@ -653,10 +694,18 @@ def plan_stack_actions(
     max_requeue_attempts: int = 2,
     max_repair_attempts: int = 3,
     suppressed_failed_checks_by_pr: Mapping[int, Collection[str]] | None = None,
+    open_pr_numbers_by_head: Mapping[str, Collection[int]] | None = None,
 ) -> tuple[Action, ...]:
     del now_epoch
     del suppressed_failed_checks_by_pr
-    facts = build_stack_facts(stack, required_checks, ledger, open_pr_numbers=(), trunk=TRUNK)
+    facts = build_stack_facts(
+        stack,
+        required_checks,
+        ledger,
+        open_pr_numbers=(),
+        open_pr_numbers_by_head=open_pr_numbers_by_head or {},
+        trunk=TRUNK,
+    )
     return plan_actions_from_facts(facts, ledger, max_requeue_attempts, max_repair_attempts)
 
 
@@ -666,12 +715,13 @@ def plan_stack_execution(
     ledger: Ledger,
     now_epoch: int,
     open_pr_numbers: Collection[int],
+    open_pr_numbers_by_head: Mapping[str, Collection[int]],
     max_requeue_attempts: int = 2,
     max_repair_attempts: int = 3,
     trunk: str = TRUNK,
 ) -> StackExecutionPlan:
     del now_epoch
-    facts = build_stack_facts(stack, required_checks, ledger, open_pr_numbers, trunk)
+    facts = build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head, trunk)
     summary = summarize_stack(facts)
     if facts.prereq_status and facts.prereq_status.is_open:
         return StackExecutionPlan(

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -165,6 +165,14 @@ class GhClient:
                 capture_output=True,
             )
 
+    def retarget_base(self, repo: str, number: int, base: str) -> None:
+        subprocess.run(
+            ["gh", "api", "--method", "PATCH", f"repos/{repo}/pulls/{number}", "-f", f"base={base}"],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
     def resolve_review_thread(self, thread_id: str) -> None:
         query = "mutation($threadId:ID!) { resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } } }"
         subprocess.run(["gh", "api", "graphql", "-f", f"threadId={thread_id}", "-f", f"query={query}"], check=True, text=True, capture_output=True)

--- a/scripts/repro/fixtures/fake-gh/bin/gh
+++ b/scripts/repro/fixtures/fake-gh/bin/gh
@@ -246,6 +246,14 @@ def main() -> None:
             save_state(state)
             print(json.dumps(created))
             return
+        retarget_base_match = re.fullmatch(r"repos/[^/]+/[^/]+/pulls/(\d+)", path)
+        if retarget_base_match and flag_value("--method") == "PATCH":
+            pr = find_pr(state, int(retarget_base_match.group(1)))
+            base = (flag_value("-f") or "").split("=", 1)[-1]
+            if pr is not None and base:
+                pr["baseRefName"] = base
+                save_state(state)
+            return
         add_label_match = re.fullmatch(r"repos/[^/]+/[^/]+/issues/(\d+)/labels", path)
         if add_label_match and flag_value("--method") == "POST":
             pr = find_pr(state, int(add_label_match.group(1)))

--- a/scripts/repro/repro-babysit-retarget-stale-bottom-base.sh
+++ b/scripts/repro/repro-babysit-retarget-stale-bottom-base.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
-TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-no-current-bottom-comment.XXXXXX")"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-retarget-stale-bottom-base.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
 
 fail() {
@@ -54,7 +54,7 @@ state = {
         {
             "number": 5885,
             "title": "Tighten Slack repo routing",
-            "body": "## Summary\n\nExternal dependency blocker repro.\n",
+            "body": "## Summary\n\nStale base retarget repro.\n",
             "url": "https://github.com/fake/repo/pull/5885",
             "state": "OPEN",
             "isDraft": False,
@@ -84,22 +84,6 @@ state = {
             "checks": {"*": "SUCCESS"},
         },
         {
-            "number": 7001,
-            "title": "Prerequisite split still open",
-            "body": "## Summary\n\nExternal owner of the stale base branch.\n",
-            "url": "https://github.com/fake/repo/pull/7001",
-            "state": "OPEN",
-            "isDraft": False,
-            "baseRefName": "master",
-            "headRefName": "pr/babysit-prereq-split",
-            "headRefOid": "3333333333333333333333333333333333333333",
-            "mergeStateStatus": "CLEAN",
-            "mergeable": "MERGEABLE",
-            "labels": [],
-            "reviewThreads": [],
-            "checks": {"*": "SUCCESS"},
-        },
-        {
             "number": 7002,
             "title": "Unrelated stack root",
             "body": "## Summary\n\nUnrelated stack should stay untouched.\n",
@@ -111,7 +95,23 @@ state = {
             "headRefOid": "4444444444444444444444444444444444444444",
             "mergeStateStatus": "CLEAN",
             "mergeable": "MERGEABLE",
-            "labels": [],
+            "labels": ["admin-bypass"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS"},
+        },
+        {
+            "number": 7003,
+            "title": "Unrelated stack child",
+            "body": "## Summary\n\nUnrelated stack child should stay untouched.\n",
+            "url": "https://github.com/fake/repo/pull/7003",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "stack/unrelated-root",
+            "headRefName": "stack/unrelated-top",
+            "headRefOid": "5555555555555555555555555555555555555555",
+            "mergeStateStatus": "CLEAN",
+            "mergeable": "MERGEABLE",
+            "labels": ["admin-bypass"],
             "reviewThreads": [],
             "checks": {"*": "SUCCESS"},
         },
@@ -119,8 +119,8 @@ state = {
     "issue_comments": {
         "5885": [stack_comment],
         "5886": [dict(stack_comment, html_url="https://github.com/fake/repo/pull/5886#stack")],
-        "7001": [],
         "7002": [],
+        "7003": [],
     },
     "job_logs": {},
 }
@@ -129,44 +129,47 @@ PY
 : > "$LEDGER_PATH"
 
 run_worker() {
-  python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5886 2>&1
+  python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 5886 "$@" 2>&1
 }
 
 if ! out1="$(run_worker)"; then
   fail 'tick 1: worker failed' "$out1"
 fi
-if ! out2="$(run_worker)"; then
-  fail 'tick 2: worker failed' "$out2"
-fi
 
-python3 - <<'PY' || fail 'expected one external-open-base comment on root only' "$(cat "$STATE_PATH")"
+echo "$out1" | grep -q 'retarget-base PR #5885 from=pr/babysit-prereq-split to=master' || fail 'tick 1 output did not show root retarget' "$out1"
+
+python3 - <<'PY' || fail 'expected root-only base retarget on tick 1' "$(cat "$STATE_PATH")"
 import json
 import os
 from pathlib import Path
 
 state = json.loads(Path(os.environ["STATE_PATH"]).read_text(encoding="utf-8"))
-comments = [
-    comment for comment in state.get("issue_comments", {}).get("5885", [])
-    if str(comment.get("body", "")).startswith("Mergify repair stopped:")
-]
-if len(comments) != 1:
-    raise SystemExit(f"expected 1 blocker comment on #5885, saw {len(comments)}")
-body = comments[0].get("body", "")
-expected = "lowest open stack PR #5885 is based on `pr/babysit-prereq-split`, which still belongs to open PR(s) #7001 outside this stack"
-if expected not in body:
-    raise SystemExit(body)
-for number in (5886, 7001, 7002):
+prs = {pr["number"]: pr for pr in state["prs"]}
+if prs[5885]["baseRefName"] != "master":
+    raise SystemExit(f"expected #5885 baseRefName=master, saw {prs[5885]['baseRefName']}")
+if prs[5886]["baseRefName"] != "stack/slack-routing-1":
+    raise SystemExit("upper PR base changed unexpectedly")
+if prs[7002]["baseRefName"] != "master" or prs[7003]["baseRefName"] != "stack/unrelated-root":
+    raise SystemExit("unrelated stack changed unexpectedly")
+for number in (5885, 5886, 7002, 7003):
     blocker_comments = [
         comment for comment in state.get("issue_comments", {}).get(str(number), [])
         if str(comment.get("body", "")).startswith("Mergify repair stopped:")
     ]
     if blocker_comments:
         raise SystemExit(f"unexpected blocker comment on #{number}")
-if next(pr for pr in state["prs"] if pr["number"] == 5885)["baseRefName"] != "pr/babysit-prereq-split":
-    raise SystemExit("root base changed unexpectedly")
 PY
 
-python3 - <<'PY' || fail 'expected one external-open-base ledger row' "$(cat "$LEDGER_PATH")"
+grep -q 'gh api --method PATCH repos/fake/repo/pulls/5885 -f base=master' "$CALLS_PATH" || fail 'tick 1 did not PATCH the root base' "$(cat "$CALLS_PATH")"
+
+if ! out2="$(run_worker --dry-run)"; then
+  fail 'tick 2: worker failed' "$out2"
+fi
+
+echo "$out2" | grep -q 'DRY-RUN requeue PR #5885' || fail 'tick 2 dry-run did not requeue the retargeted root' "$out2"
+! echo "$out2" | grep -q 'retarget-base PR #5885' || fail 'tick 2 planned another retarget instead of re-reading state' "$out2"
+
+python3 - <<'PY' || fail 'expected one retarget-base ledger row' "$(cat "$LEDGER_PATH")"
 import json
 import os
 from pathlib import Path
@@ -178,16 +181,12 @@ rows = [
 ]
 matches = [
     row for row in rows
-    if row.get("kind") == "comment-blocked"
-    and row.get("key") == "external-open-base-pr"
+    if row.get("kind") == "retarget-base"
+    and row.get("key") == "pr/babysit-prereq-split->master"
     and int(row.get("pr", 0)) == 5885
 ]
 if len(matches) != 1:
     raise SystemExit(f"expected 1 matching row, saw {len(matches)}")
 PY
-
-! grep -q 'gh api --method PATCH repos/fake/repo/pulls/5885 -f base=master' "$CALLS_PATH" || fail 'saw unexpected base retarget PATCH' "$(cat "$CALLS_PATH")"
-echo "$out1$out2" | grep -q 'external-open-base-pr' || fail 'worker output did not name the external dependency blocker' "$out1$out2"
-echo "$out1$out2" | grep -q '#7001' || fail 'worker output did not name the external owner PR' "$out1$out2"
 
 echo '[repro] passed'

--- a/scripts/test-suites/required/12-mergify-admin-requeue.sh
+++ b/scripts/test-suites/required/12-mergify-admin-requeue.sh
@@ -8,3 +8,5 @@ bash scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh
 bash scripts/repro/repro-mergify-rejected-pr.sh
 bash scripts/repro/repro-mergify-closed-pr-guard.sh
 bash scripts/repro/repro-babysit-pr-body-human-split.sh
+bash scripts/repro/repro-babysit-no-current-bottom-comment.sh
+bash scripts/repro/repro-babysit-retarget-stale-bottom-base.sh

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -27,9 +27,9 @@ from scripts.mergify_admin_requeue import (
     plan_stack_actions,
 )
 from scripts.mergify_admin_requeue_gh_executor import ADMIN_BYPASS_NUDGE_LEDGER_KIND, AdminBypassGhExecutor
+from scripts.mergify_admin_requeue_model import LoadedStacks
 from scripts.mergify_admin_requeue_loader import AdminBypassStackLoader
 from scripts.mergify_admin_requeue_logger import AdminBypassLogger
-from scripts.mergify_admin_requeue_model import RepairStopComment
 from scripts.mergify_admin_requeue_repairer import (
     NON_TRUNK_MANUAL_SPLIT_ERROR,
     NON_TRUNK_PREREQ_ERROR,
@@ -51,7 +51,7 @@ def mergify(state="dequeued", comment_id="m1", sha=HEAD):
     return MergifyQueueEvent(comment_id, state, "admin-bypass", "2026-07-03T00:00:00Z", sha, (), (), "https://example.invalid/comment")
 
 
-def pr(number, *, base="master", head=None, labels=None, checks=None, threads=(), latest=None, merge_state="CLEAN", mergeable="MERGEABLE", state="OPEN", draft=False, body="", repair_stop_comments=()):
+def pr(number, *, base="master", head=None, labels=None, checks=None, threads=(), latest=None, merge_state="CLEAN", mergeable="MERGEABLE", state="OPEN", draft=False, body=""):
     return PrSnapshot(
         number=number,
         title=f"PR {number}",
@@ -68,7 +68,6 @@ def pr(number, *, base="master", head=None, labels=None, checks=None, threads=()
         checks=checks if checks is not None else {name: check(name) for name in REQUIRED},
         review_threads=tuple(threads),
         latest_mergify=latest,
-        repair_stop_comments=tuple(repair_stop_comments),
     )
 
 PROOF_BODY = """## Summary
@@ -394,9 +393,9 @@ Failing checks
             def issue_comments(self, repo, number):
                 return []
 
-        stacks = AdminBypassStackLoader(FakeGh()).load("owner/repo", None, [], REQUIRED, "master")
-        self.assertEqual(len(stacks), 1)
-        self.assertEqual([item.number for item in stacks[0].prs], [1, 2])
+        loaded = AdminBypassStackLoader(FakeGh()).load("owner/repo", None, [], REQUIRED, "master")
+        self.assertEqual(len(loaded.stacks), 1)
+        self.assertEqual([item.number for item in loaded.stacks[0].prs], [1, 2])
 
     def test_repair_check_logs_work_context(self):
         stderr = io.StringIO()
@@ -420,38 +419,6 @@ Failing checks
         self.assertIn('"check_name": "PR Body"', log)
         self.assertIn('"log_path": "/tmp/pr-body.log"', log)
         self.assertIn('"pr_number": 2647', log)
-
-    def test_repair_check_noop_skips_validation_when_pr_merges_during_repair(self):
-        class FakeGh:
-            def pr_detail(self, repo, number):
-                return {"number": number, "state": "MERGED"}
-
-        stderr = io.StringIO()
-        item = pr(6111, latest=mergify(state="queued"))
-        repairer = self.repairer(FakeGh(), self.ledger())
-        git_rev_parse = iter([HEAD, HEAD])
-        git_commands = []
-
-        def fake_git_output(_work_root, *args):
-            git_commands.append(args)
-            if args == ("rev-parse", "HEAD"):
-                return next(git_rev_parse)
-            return ""
-
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
-                with mock.patch.object(repairer, "git_output", side_effect=fake_git_output):
-                    with mock.patch.object(repairer, "git_lines", return_value=()):
-                        with mock.patch.object(repairer, "run_claude_repair"):
-                            with mock.patch.object(repairer, "validate_current_pr_body") as validate:
-                                with redirect_stderr(stderr):
-                                    result = repairer.repair_check(item, "PR Body")
-
-        validate.assert_not_called()
-        self.assertEqual(result.status, "noop")
-        self.assertIn(("reset", "--hard", HEAD), git_commands)
-        self.assertIn(("clean", "-fd"), git_commands)
-        self.assertIn('"event": "admin-bypass-repair-check-terminal"', stderr.getvalue())
 
 
     def test_repair_check_noop_invalid_non_trunk_blocks_human_split(self):
@@ -488,53 +455,9 @@ Failing checks
     def test_plan_stack_actions_stop_retrying_after_repair_invalid(self):
         ledger = self.ledger()
         ledger.record("repair-invalid", 2606, HEAD, "PR Body", 1, meta={"errors": ["human stack split required"]})
-        stack = StackGroup(
-            "s",
-            (pr(
-                2606,
-                labels={"admin-bypass"},
-                checks={
-                    "PR Body": check("PR Body", "failure"),
-                    "quality / TypeScript Types": check("quality / TypeScript Types"),
-                },
-            ),),
-        )
+        stack = StackGroup("s", (pr(2606, labels={"admin-bypass"}, checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}),))
         actions = plan_stack_actions(stack, REQUIRED, ledger, 2)
         self.assertEqual(actions, ())
-
-    def test_repair_invalid_stops_other_repairs_on_same_pr_head(self):
-        ledger = self.ledger()
-        ledger.record("repair-invalid", 6163, HEAD, "UI Vitest", 1, meta={"errors": ["manual split required"]})
-        checks = {
-            "UI Vitest": check("UI Vitest", "failure"),
-            "quality / TypeScript Types": check("quality / TypeScript Types", "failure"),
-        }
-        stack = StackGroup("s", (pr(6163, labels={"admin-bypass"}, checks=checks),))
-        actions = plan_stack_actions(stack, REQUIRED | {"UI Vitest"}, ledger, 2)
-        self.assertEqual(actions, ())
-
-    def test_bot_thread_repair_invalid_stops_retrying_thread_repair(self):
-        ledger = self.ledger()
-        ledger.record("repair-bot-thread", 6158, HEAD, "PRRT_kwDOSFkSDM6T97v9", 1)
-        ledger.record(
-            "repair-invalid",
-            6158,
-            HEAD,
-            "PRRT_kwDOSFkSDM6T97v9",
-            1,
-            meta={"errors": ["PR body Review Unit must be split"]},
-        )
-        stack = StackGroup(
-            "s",
-            (pr(
-                6158,
-                threads=(ReviewThread("PRRT_kwDOSFkSDM6T97v9", False, ("coderabbitai[bot]",)),),
-                latest=mergify(),
-            ),),
-        )
-        actions = plan_stack_actions(stack, REQUIRED, ledger, 2)
-        self.assertEqual(actions, ())
-
     def test_queue_only_repair_uses_mergify_job_log_and_returns_noop(self):
         stderr = io.StringIO()
         latest = MergifyQueueEvent(
@@ -612,7 +535,7 @@ Failing checks
         stdout = io.StringIO()
         with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
             with mock.patch.object(exec_impl, "GhClient", return_value=object()):
-                with mock.patch.object(AdminBypassStackLoader, "load", return_value=(stack,)):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
                     with redirect_stdout(stdout), redirect_stderr(stderr):
                         should_poll = exec_impl.run_cycle(args)
         self.assertFalse(should_poll)
@@ -629,7 +552,7 @@ Failing checks
         stderr = io.StringIO()
         with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
             with mock.patch.object(exec_impl, "GhClient", return_value=object()):
-                with mock.patch.object(AdminBypassStackLoader, "load", return_value=(stack,)):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
                     with redirect_stderr(stderr):
                         should_poll = exec_impl.run_cycle(args)
         self.assertTrue(should_poll)
@@ -732,7 +655,7 @@ Failing checks
         stdout = io.StringIO()
         with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
             with mock.patch.object(exec_impl, "GhClient", return_value=object()):
-                with mock.patch.object(AdminBypassStackLoader, "load", return_value=(original, prereq)):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(original, prereq), open_pr_numbers_by_head={})):
                     with redirect_stdout(stdout), redirect_stderr(stderr):
                         should_poll = exec_impl.run_cycle(args)
         self.assertTrue(should_poll)
@@ -757,7 +680,7 @@ Failing checks
         fake_gh = FakeGh()
         with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
             with mock.patch.object(exec_impl, "GhClient", return_value=fake_gh):
-                with mock.patch.object(AdminBypassStackLoader, "load", return_value=(stack,)):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
                     with redirect_stdout(stdout), redirect_stderr(stderr):
                         should_poll = exec_impl.run_cycle(requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(ledger.path)]))
         self.assertTrue(should_poll)
@@ -799,7 +722,7 @@ Failing checks
         first_stack = StackGroup("orig", (pr(5811, labels={"dequeued"}, checks={}, latest=latest),))
         with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), {"required-fast / Guardrails"})):
             with mock.patch.object(exec_impl, "GhClient", return_value=fake_gh):
-                with mock.patch.object(AdminBypassStackLoader, "load", return_value=(first_stack,)):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(first_stack,), open_pr_numbers_by_head={})):
                     with redirect_stdout(stdout), redirect_stderr(stderr):
                         should_poll = exec_impl.run_cycle(requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(ledger.path)]))
         self.assertTrue(should_poll)
@@ -809,7 +732,7 @@ Failing checks
         second_stack = StackGroup("orig", (pr(5811, labels={"admin-bypass", "dequeued"}, checks={}, latest=latest),))
         with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), {"required-fast / Guardrails"})):
             with mock.patch.object(exec_impl, "GhClient", return_value=fake_gh):
-                with mock.patch.object(AdminBypassStackLoader, "load", return_value=(second_stack,)):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(second_stack,), open_pr_numbers_by_head={})):
                     with redirect_stdout(stdout), redirect_stderr(stderr):
                         should_poll = exec_impl.run_cycle(requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(ledger.path)]))
         self.assertTrue(should_poll)
@@ -827,7 +750,7 @@ Failing checks
         stdout = io.StringIO()
         with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
             with mock.patch.object(exec_impl, "GhClient", return_value=object()):
-                with mock.patch.object(AdminBypassStackLoader, "load", return_value=(stack,)):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
                     with redirect_stdout(stdout), redirect_stderr(stderr):
                         should_poll = exec_impl.run_cycle(args)
         self.assertFalse(should_poll)
@@ -858,6 +781,23 @@ Failing checks
         executor.execute(action, item, 1)
         executor.execute(action, item, 2)
         self.assertEqual(len(fake.comments), 1)
+
+    def test_retarget_base_executes_once_and_records_ledger(self):
+        class FakeGh:
+            def __init__(self):
+                self.retargets = []
+
+            def retarget_base(self, repo, pr_number, base):
+                self.retargets.append((repo, pr_number, base))
+
+        ledger = self.ledger()
+        item = pr(5811, base="pr/babysit-prereq-split", labels={"admin-bypass"}, latest=mergify())
+        action = Action("retarget_base", 5811, "master", "retarget stack root from `pr/babysit-prereq-split` to `master`")
+        fake = FakeGh()
+        executor = self.executor(fake, ledger, "owner/repo")
+        executor.execute(action, item, 1)
+        self.assertEqual(fake.retargets, [("owner/repo", 5811, "master")])
+        self.assertEqual(ledger.count("retarget-base", 5811, HEAD, "pr/babysit-prereq-split->master"), 1)
 
     def test_human_blocker_comment_records_once(self):
         class FakeGh:
@@ -905,31 +845,6 @@ Failing checks
         executor.execute(action, item, 3)
         self.assertEqual([comment["body"] for comment in fake.comments].count(f"Mergify repair stopped: {detail}"), 1)
         self.assertEqual(ledger.count("comment-blocked", 2647, HEAD, "no-current-bottom:exact"), 1)
-
-    def test_no_current_bottom_exact_comment_stops_future_planning(self):
-        detail = "no current bottom on master: lowest open stack PR #2647 is based on `feature/base`, not `master`; land or retarget that base before babysitting can queue this stack"
-        bottom = pr(
-            2647,
-            base="feature/base",
-            head="stack/bottom",
-            labels={"admin-bypass"},
-            repair_stop_comments=(RepairStopComment(f"Mergify repair stopped: {detail}", "2026-07-27T00:00:00Z", "EdbertChan"),),
-        )
-        top = pr(2648, base="stack/bottom", labels={"admin-bypass"})
-        ledger = self.ledger()
-        ledger.record("comment-blocked", 2647, HEAD, "no-current-bottom", 1)
-        actions = plan_stack_actions(StackGroup("s", (bottom, top)), REQUIRED, ledger, 2)
-        self.assertEqual(actions, ())
-
-        legacy = pr(
-            2647,
-            base="feature/base",
-            head="stack/bottom",
-            labels={"admin-bypass"},
-            repair_stop_comments=(RepairStopComment("Mergify repair stopped: no current bottom on master", "2026-07-27T00:00:00Z", "EdbertChan"),),
-        )
-        actions = plan_stack_actions(StackGroup("s", (legacy, top)), REQUIRED, ledger, 3)
-        self.assertEqual([(a.kind, a.key, a.detail) for a in actions], [("comment_blocked", "no-current-bottom", detail)])
 
     def test_human_block_comment_records_once_then_waits(self):
         class FakeGh:
@@ -1047,11 +962,6 @@ The merge conditions cannot be satisfied due to failing checks
         stack = StackGroup("s", (pr(2999, state="CLOSED", latest=mergify()),))
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2999, "state=CLOSED")])
-
-    def test_merged_pr_is_terminal_success_not_blocked(self):
-        stack = StackGroup("s", (pr(6108, state="MERGED", latest=mergify(state="merged")),))
-        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
-        self.assertEqual(actions, ())
 
 
 if __name__ == "__main__":

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -73,9 +73,9 @@ class PlannerTestCase(unittest.TestCase):
         self.addCleanup(lambda: shutil.rmtree(d, ignore_errors=True))
         return m.Ledger(Path(d) / "ledger.jsonl")
 
-    def _facts(self, stack, required_checks=REQUIRED, ledger=None, open_pr_numbers=(), trunk="master"):
+    def _facts(self, stack, required_checks=REQUIRED, ledger=None, open_pr_numbers=(), open_pr_numbers_by_head=None, trunk="master"):
         ledger = ledger or self._ledger()
-        return p.build_stack_facts(stack, required_checks, ledger, open_pr_numbers, trunk), ledger
+        return p.build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head or {}, trunk), ledger
 
 
 class ClassifyPr(unittest.TestCase):
@@ -99,7 +99,7 @@ class ClassifyPr(unittest.TestCase):
     def test_missing_required_check_only_on_bottom(self):
         # Missing check counts as a blocker only when the PR sits on trunk.
         self.assertEqual(self._kinds(pr(checks={})), {"missing_check"})
-        self.assertEqual(self._kinds(pr(checks={}, base_ref_name="other")), {"not_current_bottom"})
+        self.assertEqual(self._kinds(pr(checks={}, base_ref_name="other")), set())
 
     def test_conflict_from_git_state(self):
         self.assertIn("conflict", self._kinds(pr(merge_state_status="DIRTY")))
@@ -151,6 +151,56 @@ class EffectiveBlockers(unittest.TestCase):
             )
         }
         self.assertNotIn("missing_check", kinds)
+
+
+
+class ClassifyBottomTopology(unittest.TestCase):
+    def test_open_trunk_root_is_current_bottom(self):
+        stack = m.StackGroup("s", (pr(number=10),))
+        topology = p.classify_bottom_topology(stack, "master", {})
+        self.assertEqual(topology.kind, "current_bottom")
+        self.assertEqual(topology.root.number, 10)
+        self.assertEqual(topology.bottom.number, 10)
+        self.assertEqual(topology.external_open_base_pr_numbers, ())
+
+    def test_stale_root_with_outside_owner_is_external_open_base(self):
+        stack = m.StackGroup(
+            "s",
+            (
+                pr(number=10, base_ref_name="pr/babysit-prereq-split"),
+                pr(number=11, base_ref_name="stack/a"),
+            ),
+        )
+        topology = p.classify_bottom_topology(stack, "master", {"pr/babysit-prereq-split": (7001,)})
+        self.assertEqual(topology.kind, "external_open_base")
+        self.assertIsNone(topology.bottom)
+        self.assertEqual(topology.external_open_base_pr_numbers, (7001,))
+
+    def test_stale_root_with_no_outside_owner_is_stale_unowned_base(self):
+        stack = m.StackGroup(
+            "s",
+            (
+                pr(number=10, base_ref_name="pr/babysit-prereq-split"),
+                pr(number=11, base_ref_name="stack/a"),
+            ),
+        )
+        topology = p.classify_bottom_topology(stack, "master", {})
+        self.assertEqual(topology.kind, "stale_unowned_base")
+        self.assertIsNone(topology.bottom)
+        self.assertEqual(topology.external_open_base_pr_numbers, ())
+
+    def test_same_stack_parent_owner_is_not_treated_as_external(self):
+        stack = m.StackGroup(
+            "s",
+            (
+                pr(number=10, base_ref_name="stack/shared-parent", head_ref_name="stack/child"),
+                pr(number=11, base_ref_name="stack/child", head_ref_name="stack/shared-parent"),
+            ),
+        )
+        topology = p.classify_bottom_topology(stack, "master", {"stack/shared-parent": (11,)})
+        self.assertEqual(topology.kind, "stale_unowned_base")
+        self.assertIsNone(topology.bottom)
+        self.assertEqual(topology.external_open_base_pr_numbers, ())
 
 
 class BuildStackFacts(PlannerTestCase):
@@ -274,10 +324,10 @@ class BuildStackFacts(PlannerTestCase):
 class PlanStackActions(PlannerTestCase):
     """Named planning passes over prebuilt facts still honor the same ladder."""
 
-    def _plan(self, stack_or_snapshot, ledger=None, required_checks=REQUIRED, open_pr_numbers=()):
+    def _plan(self, stack_or_snapshot, ledger=None, required_checks=REQUIRED, open_pr_numbers=(), open_pr_numbers_by_head=None):
         ledger = ledger or self._ledger()
         stack = stack_or_snapshot if isinstance(stack_or_snapshot, m.StackGroup) else m.StackGroup("s", (stack_or_snapshot,))
-        facts = p.build_stack_facts(stack, required_checks, ledger, open_pr_numbers, "master")
+        facts = p.build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head or {}, "master")
         return p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
 
     def test_pending_check_means_wait_do_nothing(self):
@@ -333,27 +383,95 @@ class PlanStackActions(PlannerTestCase):
         actions = self._plan(m.StackGroup("s", (bottom, upper)))
         self.assertEqual((actions[0].kind, actions[0].pr_number), ("requeue", 10))
 
-    def test_no_current_bottom_blocker_names_base_branch(self):
-        actions = self._plan(
-            m.StackGroup(
-                "s",
-                (
-                    pr(
-                        number=5885,
-                        base_ref_name="pr/babysit-prereq-split",
-                        labels=frozenset({"admin-bypass"}),
-                    ),
-                    pr(
-                        number=5886,
-                        base_ref_name="stack/slack-routing",
-                        labels=frozenset({"admin-bypass"}),
-                    ),
+    def test_stale_root_base_retargets_root_pr(self):
+        stack = m.StackGroup(
+            "s",
+            (
+                pr(
+                    number=5885,
+                    base_ref_name="pr/babysit-prereq-split",
+                    labels=frozenset({"admin-bypass"}),
                 ),
-            )
+                pr(
+                    number=5886,
+                    base_ref_name="stack/slack-routing",
+                    labels=frozenset({"admin-bypass"}),
+                ),
+            ),
         )
-        self.assertEqual((actions[0].kind, actions[0].key), ("comment_blocked", "no-current-bottom"))
-        self.assertIn("lowest open stack PR #5885 is based on `pr/babysit-prereq-split`", actions[0].detail)
-        self.assertIn("land or retarget that base", actions[0].detail)
+        facts, ledger = self._facts(stack, open_pr_numbers_by_head={})
+        self.assertEqual(facts.bottom_topology.kind, "stale_unowned_base")
+        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        self.assertEqual((actions[0].kind, actions[0].pr_number, actions[0].key), ("retarget_base", 5885, "master"))
+        self.assertIn("`pr/babysit-prereq-split`", actions[0].detail)
+        self.assertIn("`master`", actions[0].detail)
+
+    def test_external_open_base_owner_blocks_instead_of_retargeting(self):
+        stack = m.StackGroup(
+            "s",
+            (
+                pr(
+                    number=5885,
+                    base_ref_name="pr/babysit-prereq-split",
+                    labels=frozenset({"admin-bypass"}),
+                ),
+                pr(
+                    number=5886,
+                    base_ref_name="stack/slack-routing",
+                    labels=frozenset({"admin-bypass"}),
+                ),
+            ),
+        )
+        facts, ledger = self._facts(stack, open_pr_numbers_by_head={"pr/babysit-prereq-split": (7001,)})
+        self.assertEqual(facts.bottom_topology.kind, "external_open_base")
+        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        self.assertEqual((actions[0].kind, actions[0].pr_number, actions[0].key), ("comment_blocked", 5885, "external-open-base-pr"))
+        self.assertIn("#7001", actions[0].detail)
+
+    def test_stale_root_retarget_ignores_unrelated_stack(self):
+        stale_stack = m.StackGroup(
+            "stack-a",
+            (
+                pr(
+                    number=5885,
+                    base_ref_name="pr/babysit-prereq-split",
+                    head_ref_name="stack/slack-routing-1",
+                    labels=frozenset({"admin-bypass"}),
+                ),
+                pr(
+                    number=5886,
+                    base_ref_name="stack/slack-routing-1",
+                    head_ref_name="stack/slack-routing-2",
+                    labels=frozenset({"admin-bypass"}),
+                ),
+            ),
+        )
+        facts, ledger = self._facts(stale_stack, open_pr_numbers_by_head={})
+        self.assertEqual(facts.bottom_topology.kind, "stale_unowned_base")
+        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        self.assertEqual([(action.kind, action.pr_number) for action in actions], [("retarget_base", 5885)])
+
+    def test_stale_root_failed_check_repairs_before_retarget(self):
+        stack = m.StackGroup(
+            "s",
+            (
+                pr(
+                    number=5885,
+                    base_ref_name="pr/babysit-prereq-split",
+                    labels=frozenset({"admin-bypass"}),
+                    checks={"build": check("failure")},
+                ),
+                pr(
+                    number=5886,
+                    base_ref_name="stack/slack-routing",
+                    labels=frozenset({"admin-bypass"}),
+                ),
+            ),
+        )
+        facts, _ledger = self._facts(stack, open_pr_numbers_by_head={})
+        self.assertEqual(facts.bottom_topology.kind, "stale_unowned_base")
+        actions = p.plan_stack_actions(stack, REQUIRED, self._ledger(), now_epoch=0, open_pr_numbers_by_head={})
+        self.assertEqual([(action.kind, action.key) for action in actions], [("repair_check", "build")])
 
     def test_requeue_is_capped_after_repeated_attempts(self):
         ledger = self._ledger()
@@ -426,6 +544,7 @@ class PlanStackExecution(PlannerTestCase):
             ledger,
             now_epoch=0,
             open_pr_numbers={10, 99},
+            open_pr_numbers_by_head={},
         )
         self.assertEqual(plan.wait_reason, "repair-prereq-open")
         self.assertEqual(plan.actions, ())
@@ -455,6 +574,7 @@ class PlanStackExecution(PlannerTestCase):
             ledger,
             now_epoch=0,
             open_pr_numbers={10},
+            open_pr_numbers_by_head={},
         )
         self.assertEqual(plan.actions[0].kind, "requeue")
         self.assertTrue(plan.prereq_status.needs_followup_requeue)
@@ -478,6 +598,7 @@ class PlanStackExecution(PlannerTestCase):
             ledger,
             now_epoch=0,
             open_pr_numbers={10},
+            open_pr_numbers_by_head={},
         )
         self.assertEqual(
             [(action.kind, action.key) for action in restore.actions],
@@ -505,6 +626,7 @@ class PlanStackExecution(PlannerTestCase):
             ledger,
             now_epoch=0,
             open_pr_numbers={10},
+            open_pr_numbers_by_head={},
         )
         self.assertEqual(
             [(action.kind, action.key) for action in requeue.actions],
@@ -532,6 +654,7 @@ class PlanStackExecution(PlannerTestCase):
             ledger,
             now_epoch=0,
             open_pr_numbers={10},
+            open_pr_numbers_by_head={},
         )
         self.assertEqual(
             [(action.kind, action.key) for action in retry.actions],
@@ -564,6 +687,7 @@ class PlanStackExecution(PlannerTestCase):
             ledger,
             now_epoch=0,
             open_pr_numbers={5873},
+            open_pr_numbers_by_head={},
         )
         self.assertEqual(plan.actions, ())
         self.assertEqual(plan.wait_reason, "blocked-needs-human")


### PR DESCRIPTION
## Summary

This branch wires the two new stale-base repros into the required admin-bypass shard.

That keeps the stale-base retarget and external-owner cases running in the required test suite so they cannot silently regress.

## Review Claim

The required admin-bypass shard now runs the new stale-base repros.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only appends two repro invocations to the required shard script; the repros it calls already exist in the slice below.

## Slice Rationale

The shard wiring is a `scripts/` tooling-policy change, kept separate from the proof repros it registers.

## Non-goals

- Do not change planner, executor, or repro behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-suites/required/12-mergify-admin-requeue.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 87547b2f3235bed975451804e1e43ea5362a68f5`
- Post-revert steps: None
- Data migration? No

</details>
