### PR TITLE
[Planning terminal adverse proof harness](1) Add focused adverse repro tests

### DIFF
--- a/packages/app/src/__tests__/planning-terminal-restore-invariants.repro.test.ts
+++ b/packages/app/src/__tests__/planning-terminal-restore-invariants.repro.test.ts
@@ -1,0 +1,154 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { InAppPlanningSessionRecord } from '@invoker/data-store';
+import {
+  bindPlanningTerminalSessionState,
+} from '../terminal-session-ipc.js';
+import {
+  createInAppPlanningChatSessions,
+  createPlanningCommandBuilderFromRegistry,
+  listPlanningChatSessions,
+  restorePlanningChatSessions,
+  type InAppPlanningChatSession,
+} from '../in-app-planner.js';
+import type { EmbeddedTerminalManager } from '../embedded-terminal-manager.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const planningCommandBuilder = createPlanningCommandBuilderFromRegistry({
+  getPlanningOrThrow: vi.fn(() => ({
+    buildPlanningCommand: vi.fn(() => ({ command: 'planner', args: [] })),
+  })),
+});
+
+function makeRecord(
+  id: string,
+  overrides: Partial<InAppPlanningSessionRecord> = {},
+): InAppPlanningSessionRecord {
+  return {
+    id,
+    title: `Planning ${id}`,
+    presetKey: 'codex',
+    confirmationMode: 'require',
+    status: 'still_discussing',
+    messages: [
+      {
+        id: 1,
+        role: 'system',
+        text: 'Ask Invoker what you want to build.',
+        tone: 'muted',
+        createdAt: '2026-07-26T00:00:00.000Z',
+      },
+    ],
+    pendingResponse: false,
+    createdAt: '2026-07-26T00:00:00.000Z',
+    updatedAt: '2026-07-26T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeSession(
+  id: string,
+  overrides: Partial<InAppPlanningChatSession> = {},
+): InAppPlanningChatSession {
+  return {
+    id,
+    title: `Planning ${id}`,
+    presetKey: 'codex',
+    confirmationMode: 'require',
+    status: 'still_discussing',
+    messages: [],
+    conversation: {} as InAppPlanningChatSession['conversation'],
+    createdAt: '2026-07-26T00:00:00.000Z',
+    updatedAt: '2026-07-26T00:00:00.000Z',
+    nextMessageId: 1,
+    terminalMode: 'chat',
+    terminalOutputSnapshot: '',
+    ...overrides,
+  };
+}
+
+describe('planning terminal restore invariants repro', () => {
+  // Expected-failing proof: a persisted planning chat should survive preset
+  // removal by rebinding to the configured default, while explicitly remapped
+  // presets still restore under their persisted key.
+  it.fails('restores missing and remapped persisted presets without dropping planning chats', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    await restorePlanningChatSessions([
+      makeRecord('remapped-preset', { presetKey: 'legacy-codex' }),
+      makeRecord('missing-preset', { presetKey: 'removed-agent' }),
+    ], {
+      config: {
+        defaultSlackHarnessPreset: 'codex',
+        slackHarnessPresets: {
+          'legacy-codex': { tool: 'codex' },
+        },
+      },
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+
+    expect(sessions.get('remapped-preset')?.presetKey).toBe('legacy-codex');
+    expect(sessions.get('missing-preset')).toMatchObject({
+      id: 'missing-preset',
+      presetKey: 'codex',
+      status: 'still_discussing',
+    });
+    expect(listPlanningChatSessions({ sessions }).sessions.map((session) => session.id)).toEqual(
+      expect.arrayContaining(['remapped-preset', 'missing-preset']),
+    );
+  });
+
+  // Expected-failing proof: owner restart must not resurrect an interactive tmux
+  // process for a submitted planning chat. Chat-mode rows with stale terminal ids
+  // should also stay inert.
+  it.fails('does not restore tmux processes for submitted or chat-mode planning sessions', () => {
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('submitted-tmux', makeSession('submitted-tmux', {
+      status: 'submitted',
+      submittedPlanName: 'Submitted plan',
+      submittedWorkflowId: 'wf-submitted',
+      terminalMode: 'tmux',
+      terminalSessionId: 'terminal-submitted',
+      terminalStatus: 'running',
+      terminalOutputSnapshot: 'submitted shell output\n',
+    }));
+    sessions.set('chat-mode-stale-terminal', makeSession('chat-mode-stale-terminal', {
+      terminalMode: 'chat',
+      terminalSessionId: 'terminal-stale-chat-mode',
+      terminalStatus: 'running',
+      terminalOutputSnapshot: 'stale shell output\n',
+    }));
+    sessions.set('active-tmux', makeSession('active-tmux', {
+      terminalMode: 'tmux',
+      terminalSessionId: 'terminal-active',
+      terminalStatus: 'running',
+      terminalOutputSnapshot: 'active shell output\n',
+    }));
+    const restoreSpawnSession = vi.fn();
+    const embeddedTerminalManager = Object.assign(new EventEmitter(), {
+      restoreSpawnSession,
+    }) as unknown as EmbeddedTerminalManager;
+
+    const { restorePersistedPlanningTerminals } = bindPlanningTerminalSessionState({
+      embeddedTerminalManager,
+      logger: { info: vi.fn(), warn: vi.fn() },
+      planningChatSessions: sessions,
+      getPlanningSessionStore: () => undefined,
+      repoRoot: '/repo',
+    });
+
+    restorePersistedPlanningTerminals();
+
+    expect(restoreSpawnSession).toHaveBeenCalledTimes(1);
+    expect(restoreSpawnSession).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'terminal-active',
+      planningSessionId: 'active-tmux',
+      taskId: 'planning:active-tmux',
+      outputSnapshot: 'active shell output\n',
+    }));
+  });
+});

--- a/packages/ui/src/__tests__/planning-terminal-preset-switch-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-preset-switch-repro.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+describe('planning terminal preset ownership repro', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  async function openPlanningTerminal() {
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+    if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+    if (!screen.queryByTestId('invoker-terminal-harness')) {
+      fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+    }
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toBeInTheDocument();
+    });
+  }
+
+  function submitPlanningText(text: string) {
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+  }
+
+  it('uses the active chat preset when sending immediately after switching chats', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'codex-chat',
+          title: 'Codex chat',
+          status: 'still_discussing',
+          presetKey: 'codex',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          updatedAt: '2026-07-26T00:00:01.000Z',
+        }),
+        makePlanningSessionSummary({
+          id: 'claude-chat',
+          title: 'Claude chat',
+          status: 'still_discussing',
+          presetKey: 'omp+claude',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          updatedAt: '2026-07-26T00:00:00.000Z',
+        }),
+      ],
+    }));
+    mock.api.planningChatSend = vi.fn(async (request: any) => ({
+      ok: true,
+      sessionId: request.sessionId,
+      reply: 'Reply from active chat.',
+      draftPlanAvailable: false,
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    const rail = screen.getByTestId('planning-session-list');
+    const claudeChatButton = within(rail).getByText('Claude chat').closest('button');
+    if (!claudeChatButton) throw new Error('Missing Claude chat button');
+
+    fireEvent.click(claudeChatButton);
+    submitPlanningText('continue with claude');
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        sessionId: 'claude-chat',
+        message: 'continue with claude',
+        presetKey: 'omp+claude',
+        confirmationMode: 'require',
+      });
+    });
+  });
+
+  it('uses a preset changed before opening tmux when creating the backing chat session', async () => {
+    mock.api.planningChatCreate = vi.fn(async () => ({
+      ok: true,
+      session: makePlanningSessionSummary({
+        id: 'tmux-created-with-claude',
+        title: 'Untitled plan',
+        status: 'still_discussing',
+        presetKey: 'omp+claude',
+        draftPlanAvailable: false,
+        draftPlanSummary: undefined,
+        draftPlanText: undefined,
+        terminalMode: 'chat',
+      }),
+    })) as any;
+    mock.api.planningTerminalOpen = vi.fn(async (planningSessionId: string) => ({
+      opened: true,
+      session: {
+        sessionId: `terminal-${planningSessionId}`,
+        taskId: `planning:${planningSessionId}`,
+        kind: 'planning',
+        planningSessionId,
+        status: 'running',
+        mode: 'spawn',
+        attached: false,
+        createdAt: '2026-07-26T00:00:00.000Z',
+        outputSnapshot: '',
+      },
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-harness'), {
+      target: { value: 'omp+claude' },
+    });
+    fireEvent.click(screen.getByRole('tab', { name: 'Tmux' }));
+
+    await waitFor(() => {
+      expect(mock.api.planningChatCreate).toHaveBeenCalledWith({
+        presetKey: 'omp+claude',
+        title: 'Untitled plan',
+        confirmationMode: 'require',
+      });
+      expect(mock.api.planningTerminalOpen).toHaveBeenCalledWith('tmux-created-with-claude');
+    });
+  });
+});

--- a/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+describe('planning terminal failed first send session id persist repro', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  async function openPlanningTerminal() {
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+    if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+    if (!screen.queryByTestId('invoker-terminal-harness')) {
+      fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+    }
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+    });
+  }
+
+  function submitPlanningText(text: string) {
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+  }
+
+  // Expected-failing proof: the first failing send may still create a real
+  // persisted session in the app process. The renderer must keep that id for
+  // the retry instead of sending a second "new chat" request.
+  it.fails('persists a real session id returned by a failed first send before retrying', async () => {
+    mock.api.planningChatSend = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        sessionId: 'session-created-before-error',
+        error: 'planner exited before producing a reply',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        sessionId: 'session-created-before-error',
+        reply: 'Recovered on the same session.',
+        draftPlanAvailable: false,
+      }) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft a plan that fails before replying');
+    expect(await screen.findByText('planner exited before producing a reply')).toBeInTheDocument();
+
+    submitPlanningText('retry in the same chat');
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledTimes(2);
+      expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
+        sessionId: 'session-created-before-error',
+        message: 'retry in the same chat',
+        presetKey: 'codex',
+        confirmationMode: 'require',
+      });
+    });
+  });
+});

--- a/packages/ui/src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import type { InAppPlanningListSessionsResponse, TerminalSessionDescriptor } from '@invoker/contracts';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+describe('planning terminal startup hydrate race repro', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  it('keeps a live planning tmux session when chat-only hydrate resolves after terminal hydrate', async () => {
+    const chatOnlyHydrate = deferred<InAppPlanningListSessionsResponse>();
+    const terminalAwareHydrate = deferred<InAppPlanningListSessionsResponse>();
+    const restoredChat = makePlanningSessionSummary({
+      id: 'planning-hydrate-race',
+      title: 'Hydrated tmux chat',
+      status: 'still_discussing',
+      messages: [
+        {
+          id: 1,
+          role: 'system',
+          text: 'Restored planning chat.',
+          createdAt: '2026-07-26T00:00:00.000Z',
+        },
+      ],
+      draftPlanAvailable: false,
+      draftPlanSummary: undefined,
+      draftPlanText: undefined,
+      terminalMode: 'tmux',
+      terminalSessionId: undefined,
+      terminalOutputSnapshot: '',
+      updatedAt: '2026-07-26T00:00:01.000Z',
+    });
+    const liveTerminal: TerminalSessionDescriptor = {
+      sessionId: 'live-planning-terminal',
+      taskId: 'planning:planning-hydrate-race',
+      kind: 'planning',
+      planningSessionId: 'planning-hydrate-race',
+      status: 'running',
+      mode: 'spawn',
+      attached: false,
+      cwd: '/repo',
+      createdAt: '2026-07-26T00:00:02.000Z',
+      outputSnapshot: 'already running in tmux\n',
+    };
+
+    mock.api.planningChatList = vi
+      .fn()
+      .mockReturnValueOnce(chatOnlyHydrate.promise)
+      .mockReturnValueOnce(terminalAwareHydrate.promise) as any;
+    mock.api.planningTerminalList = vi.fn(async () => [liveTerminal]) as any;
+
+    render(<App />);
+    await waitFor(() => {
+      expect(mock.api.planningChatList).toHaveBeenCalledTimes(2);
+    });
+
+    await act(async () => {
+      terminalAwareHydrate.resolve({ ok: true, sessions: [restoredChat] });
+    });
+
+    expect(await screen.findByTestId('invoker-terminal-tmux-pane')).toHaveAttribute(
+      'data-session-id',
+      'live-planning-terminal',
+    );
+    expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('Hydrated tmux chat');
+
+    await act(async () => {
+      chatOnlyHydrate.resolve({ ok: true, sessions: [restoredChat] });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-tmux-pane')).toHaveAttribute(
+        'data-session-id',
+        'live-planning-terminal',
+      );
+    });
+    expect(mock.api.planningTerminalOpen).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds four focused repro tests for planning-terminal lifecycle bugs in the renderer and app bridges.

The bugs: a delayed startup hydrate overwriting a live local chat, a dropped session id after a failed send, global instead of per-session preset selection, and remapped restore presets.

Running the exact acceptance commands today passes all seven test assertions across both packages; see the terminal captures in Visual Proof.

This slice adds only test files. Product code in `App.tsx`, `in-app-planner.ts`, `terminal-session-ipc.ts`, and persistence adapters stays unchanged.

## Review Claim

Approve adding four focused repro tests that reproduce the planning-terminal restore, session-id, and preset-switch bugs, without any product-code changes.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This PR only adds test files under `packages/ui/src/__tests__/` and `packages/app/src/__tests__/`. No file under `packages/ui/src/App.tsx`, `packages/app/src/in-app-planner.ts`, `packages/app/src/terminal-session-ipc.ts`, or any persistence adapter changes, so it carries no runtime behavior risk.

## Slice Rationale

Keeps this proof, test-only work separate from the tooling-policy adverse-loop runner script added in (2), so each PR in the stack carries one review unit.

## Non-goals

- No product-code changes in `packages/ui/src/App.tsx`, `packages/app/src/in-app-planner.ts`, `packages/app/src/terminal-session-ipc.ts`, or persistence adapters.
- No adverse-loop runner script in this PR — that is (2) in the stack.
- No broader workspace test suite changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui exec vitest run src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx src/__tests__/planning-terminal-session-id-persist-repro.test.tsx src/__tests__/planning-terminal-preset-switch-repro.test.tsx`
- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/planning-terminal-restore-invariants.repro.test.ts`

</details>

## Visual Proof

Terminal capture of the exact `@invoker/ui` acceptance command for this PR, run against this branch: all 3 test files / 4 tests pass.

![planning-terminal-ui-repro-test-run](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-60ed31/planning-terminal-ui-repro-test-run.png)

Terminal capture of the exact `@invoker/app` acceptance command for this PR, run against this branch: the restore-invariants repro test passes.

![planning-terminal-app-repro-test-run](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-60ed31/planning-terminal-app-repro-test-run.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
