### PR TITLE
[CodeRabbit repair workflow](1) Submit an Invoker repair workflow for CodeRabbit feedback

### DIFF
--- a/scripts/cron-coderabbit-address.sh
+++ b/scripts/cron-coderabbit-address.sh
@@ -8,6 +8,8 @@ MAX_CODERABBIT_ATTEMPTS="${INVOKER_PR_CODERABBIT_MAX_ATTEMPTS:-3}"
 STATE_FILE="${INVOKER_PR_CODERABBIT_STATE_FILE:-${HOME}/.invoker/coderabbit-address-submissions.tsv}"
 WORKDIR="${INVOKER_PR_CRON_WORKDIR:-${HOME}/.invoker/pr-cron-work}"
 WORKDIR_MAX_AGE_DAYS="${INVOKER_PR_CRON_WORKDIR_MAX_AGE_DAYS:-7}"
+SUBMIT_CMD="${INVOKER_PR_CODERABBIT_SUBMIT_CMD:-$REPO_ROOT/submit-plan.sh}"
+REPO_URL="${INVOKER_PR_CODERABBIT_REPO_URL:-$(git remote get-url origin 2>/dev/null || echo .)}"
 
 cron_lock
 ledger_init "$STATE_FILE"
@@ -33,48 +35,33 @@ collect_coderabbit() {
   '
 }
 
-# Prepare a checkout of the PR head branch; sets CHECKOUT_DIR. Logs to stderr so
-# callers can capture nothing on stdout.
-CHECKOUT_DIR=""
-prepare_checkout() {
-  local num="$1"
-  local dir="$WORKDIR/$num"
-  mkdir -p "$WORKDIR"
-  if [ ! -d "$dir/.git" ]; then
-    rm -rf "$dir"
-    if ! gh repo clone "$TARGET_REPO" "$dir" -- --quiet >/dev/null 2>&1; then
-      log_line "PR #$num: clone failed" >&2
-      return 1
-    fi
-  elif ! ( cd "$dir" && git reset --hard && git clean -fd ) >/dev/null 2>&1; then
-    # A prior omp run that exited non-zero can leave a dirty worktree; reset it
-    # so the next attempt never fails checkout on, or pushes, stale edits.
-    log_line "PR #$num: failed to clean reused checkout" >&2
-    return 1
-  fi
-  if ! ( cd "$dir" && git fetch --quiet --all && gh pr checkout "$num" --repo "$TARGET_REPO" && git reset --hard && git clean -fd ) >/dev/null 2>&1; then
-    log_line "PR #$num: gh pr checkout failed" >&2
-    return 1
-  fi
-  touch "$dir/$PR_CRON_WORKDIR_STAMP_NAME" >/dev/null 2>&1 || true
-  CHECKOUT_DIR="$dir"
+# Build a JSON string literal that is safe to embed directly in YAML.
+json_quote() {
+  jq -nr --arg v "$1" '$v'
+}
+
+slugify_marker() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | tr -cs 'a-z0-9' '-' \
+    | sed -e 's/^-*//' -e 's/-*$//'
 }
 
 build_prompt() {
-  # build_prompt <num> <base_branch> <head_branch> <ctx_file>
-  local num="$1" base="$2" head="$3" ctx="$4"
+  # build_prompt <num> <base_branch> <head_branch> <ctx_json>
+  local num="$1" base="$2" head="$3" ctx_json="$4"
   cat <<EOF
 You are addressing CodeRabbit review feedback on GitHub PR #$num in repository $TARGET_REPO.
-You are running inside a fresh checkout of the PR head branch ($head); HEAD is already on that
-branch and 'git push' updates the PR.
+Invoker created a dedicated repair workflow for this feedback batch. You are working on the
+PR head branch ($head) inside an Invoker task; when this workflow succeeds, Invoker's merge
+gate will push the merged result back to that PR branch. Do not open, retitle, or edit the
+GitHub PR yourself, and do not run 'git push' manually.
 
-Context for this PR is in the JSON file: $ctx
-Fields: .pr, .prTitle, .prBody, .headBranch, .baseBranch,
-        .coderabbitComments (array of {body, updated_at, path, html_url}),
-        .invokerTasks (the Invoker tasks that produced this PR, or null if none).
+Context JSON for this PR:
+$ctx_json
 
 Do this:
-1. Read the CodeRabbit comments in $ctx. Also read the actual change under review:
+1. Read the CodeRabbit comments in the JSON context. Also read the actual change under review:
    'git log origin/$base..HEAD' and 'git diff origin/$base...HEAD', plus the Invoker task list.
 2. For EACH distinct CodeRabbit concern, decide whether it is genuinely valid (a real bug,
    correctness, or safety issue) — not style noise or a false positive.
@@ -84,19 +71,51 @@ Do this:
       'set -euo pipefail', derive the repo root, print a clear PASS/FAIL).
    b. Implement the minimal fix so the repro passes.
 4. For concerns you judge NOT valid, take no code action.
-5. Commit the repro(s) + fix(es) with a clear message and 'git push' to the PR head branch.
+5. If NO concern is valid, make no code changes and explain that in your task summary.
 
 Constraints: change ONLY what the valid concerns require. Do NOT reformat unrelated code, bump
-versions, or touch files outside a concern's scope. If NO concern is valid, make no commit and
-exit without pushing.
+versions, or touch files outside a concern's scope. Leave the branch ready for Invoker's merge
+gate to publish the fix back to the PR branch.
 EOF
 }
 
-launch_omp() {
-  # launch_omp <num> <pr_title> <head_branch> <base_branch>; exits the script.
+write_repair_plan() {
+  # write_repair_plan <path> <name> <description> <head_branch> <task_id> <task_description> <prompt>
+  #
+  # Both baseBranch and featureBranch are the PR head branch on purpose. The
+  # repair must layer its fix on TOP of the PR's existing commits and push the
+  # result back to that same branch. If baseBranch were the PR base, Invoker's
+  # merge gate would rebuild the head branch from base + the fix and force-push
+  # that, discarding the PR author's own commits. Manual mergeMode means the
+  # gate parks at review_ready after pushing the head branch and never
+  # squash-merges to base, so base == feature is safe here.
+  local plan_path="$1" plan_name="$2" plan_description="$3" head_branch="$4"
+  local task_id="$5" task_description="$6" prompt="$7"
+  {
+    printf 'name: %s\n' "$(json_quote "$plan_name")"
+    printf 'description: %s\n' "$(json_quote "$plan_description")"
+    printf 'repoUrl: %s\n' "$(json_quote "$REPO_URL")"
+    printf 'baseBranch: %s\n' "$(json_quote "$head_branch")"
+    printf 'featureBranch: %s\n' "$(json_quote "$head_branch")"
+    printf 'onFinish: merge\n'
+    printf 'mergeMode: manual\n'
+    printf 'tasks:\n'
+    printf '  - id: %s\n' "$(json_quote "$task_id")"
+    printf '    description: %s\n' "$(json_quote "$task_description")"
+    printf '    executionAgent: omp\n'
+    if [ -n "${INVOKER_PR_CRON_OMP_MODEL:-}" ]; then
+      printf '    executionModel: %s\n' "$(json_quote "$INVOKER_PR_CRON_OMP_MODEL")"
+    fi
+    printf '    prompt: |\n'
+    printf '%s\n' "$prompt" | sed 's/^/      /'
+  } > "$plan_path"
+}
+
+submit_repair_workflow() {
+  # submit_repair_workflow <num> <pr_title> <head_branch> <base_branch>; exits the script.
   local num="$1" pr_title="$2" head_branch="$3" base_branch="$4"
 
-  # Count every real attempt (not just successes) so repeated failures hit the
+  # Count every real attempt (not just successes) so repeated submit failures hit the
   # cap instead of retrying forever; dedup still keys off the success marker.
   ledger_record coderabbit-attempt "$num" "$LATEST_MARKER"
 
@@ -113,48 +132,50 @@ launch_omp() {
     log_line "PR #$num: review-gate lookup failed; proceeding without task context"
   fi
 
-  local pr_view pr_body
+  local pr_view pr_body ctx_json marker_slug plan_path prompt workflow_id="" submit_output=""
   pr_view="$(gh_json pr view "$num" --repo "$TARGET_REPO" --json title,body,headRefName,baseRefName || printf '{}')"
   pr_body="$(jq -r '.body // ""' <<<"$pr_view")"
-
-  local ctx_file
-  ctx_file="$(mktemp -t invoker-cr-ctx.XXXXXX)"
-  jq -n --arg pr "$num" --arg title "$pr_title" --arg body "$pr_body" \
+  ctx_json="$(jq -n --arg pr "$num" --arg title "$pr_title" --arg body "$pr_body" \
         --arg head "$head_branch" --arg base "$base_branch" \
         --argjson comments "$COLLECTED_COMMENTS" --argjson tasks "$tasks" '
     { pr: ($pr | tonumber), prTitle: $title, prBody: $body,
       headBranch: $head, baseBranch: $base,
       coderabbitComments: $comments, invokerTasks: $tasks }
-  ' > "$ctx_file"
+  ')"
 
-  if ! prepare_checkout "$num"; then
-    rm -f "$ctx_file"
-    exit 1
-  fi
+  mkdir -p "$WORKDIR"
+  marker_slug="$(slugify_marker "$LATEST_MARKER")"
+  plan_path="$WORKDIR/coderabbit-pr-${num}-${marker_slug}.yaml"
+  prompt="$(build_prompt "$num" "$base_branch" "$head_branch" "$ctx_json")"
+  write_repair_plan \
+    "$plan_path" \
+    "CodeRabbit repair PR #$num @ $LATEST_MARKER" \
+    "Address CodeRabbit feedback batch from $LATEST_MARKER on PR #$num through a dedicated Invoker repair workflow." \
+    "$head_branch" \
+    "coderabbit-repair-pr-$num" \
+    "Address CodeRabbit review feedback for PR #$num" \
+    "$prompt"
 
-  local omp_cmd prompt
-  omp_cmd="${INVOKER_OMP_COMMAND:-omp}"
-  prompt="$(build_prompt "$num" "$base_branch" "$head_branch" "$ctx_file")"
-  local omp_args=(--no-title --auto-approve)
-  [ -n "${INVOKER_PR_CRON_OMP_MODEL:-}" ] && omp_args+=(--model "$INVOKER_PR_CRON_OMP_MODEL")
-  omp_args+=(-p "$prompt")
-
-  log_line "PR #$num: launching omp on $CHECKOUT_DIR"
-  # omp reads $ctx_file during the run, so clean it up only after omp returns.
-  # Bound the run so a hung omp cannot hold the shared cron lock indefinitely;
-  # a timeout exits non-zero and is handled exactly like any other failure.
-  local omp_run=("$omp_cmd" "${omp_args[@]}")
-  if command -v timeout >/dev/null 2>&1; then
-    omp_run=(timeout --kill-after=1m "${INVOKER_PR_CRON_OMP_TIMEOUT:-45m}" "$omp_cmd" "${omp_args[@]}")
-  fi
-  if ( cd "$CHECKOUT_DIR" && "${omp_run[@]}" ); then
-    rm -f "$ctx_file"
-    ledger_record coderabbit "$num" "$LATEST_MARKER"
-    log_line "PR #$num: omp addressed CodeRabbit feedback; recorded marker $LATEST_MARKER"
+  if [ "$DRY_RUN" = "1" ]; then
+    log_line "PR #$num: would submit repair workflow $plan_path for new CodeRabbit activity at $LATEST_MARKER"
     exit 0
   fi
-  rm -f "$ctx_file"
-  log_line "PR #$num: omp exited non-zero; not recording (retry next tick)"
+
+  log_line "PR #$num: submitting repair workflow $plan_path"
+  if submit_output="$("$SUBMIT_CMD" "$plan_path" 2>&1)"; then
+    [ -n "$submit_output" ] && printf '%s\n' "$submit_output"
+    ledger_record coderabbit "$num" "$LATEST_MARKER"
+    workflow_id="$(printf '%s\n' "$submit_output" | sed -n 's/^Workflow ID: //p' | sed -n '1p')"
+    if [ -n "$workflow_id" ]; then
+      log_line "PR #$num: submitted CodeRabbit repair workflow $workflow_id; recorded marker $LATEST_MARKER"
+    else
+      log_line "PR #$num: submitted CodeRabbit repair workflow; recorded marker $LATEST_MARKER"
+    fi
+    exit 0
+  fi
+
+  [ -n "$submit_output" ] && printf '%s\n' "$submit_output" >&2
+  log_line "PR #$num: repair workflow submit failed; not recording (retry next tick)"
   exit 1
 }
 
@@ -204,8 +225,8 @@ while IFS= read -r pr; do
   fi
 
   # Per-feedback-batch attempt cap: counts attempts for THIS comment marker
-  # (incl. failed omp runs), so repeated failures on the same feedback stop but
-  # genuinely new CodeRabbit comments still get a fresh budget.
+  # (incl. failed submit runs), so repeated failures on the same feedback stop
+  # but genuinely new CodeRabbit comments still get a fresh budget.
   if [ "$(ledger_count coderabbit-attempt "$num" "$LATEST_MARKER")" -ge "$MAX_CODERABBIT_ATTEMPTS" ]; then
     log_line "PR #$num: CodeRabbit address hit cap of $MAX_CODERABBIT_ATTEMPTS; skip"
     continue
@@ -216,12 +237,7 @@ while IFS= read -r pr; do
     continue
   fi
 
-  if [ "$DRY_RUN" = "1" ]; then
-    log_line "PR #$num: would launch omp for new CodeRabbit activity at $LATEST_MARKER"
-    exit 0
-  fi
-
-  launch_omp "$num" "$pr_title" "$head_branch" "$base_branch"
+  submit_repair_workflow "$num" "$pr_title" "$head_branch" "$base_branch"
 done < <(jq -c '.[]' <<<"$prs_json")
 
 log_line "no PRs with new CodeRabbit feedback this tick"

--- a/scripts/test-coderabbit-address-submit.sh
+++ b/scripts/test-coderabbit-address-submit.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Behavior test for scripts/cron-coderabbit-address.sh after the repair-workflow
+# cutover. No real Invoker, no network, no repo checkout.
+#
+# Covers:
+#   A. Dry-run: logs the intended repair-workflow submission, writes a YAML plan,
+#      and never calls the submit command.
+#   B. Real run: submits exactly once, records the success marker, and surfaces
+#      the workflow id from the submit path.
+#   C. Dedup: once the marker is recorded, the same feedback batch is skipped.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+WORKER="$REPO_ROOT/scripts/cron-coderabbit-address.sh"
+UPDATED="2026-07-01T12:34:56Z"
+HEAD_BRANCH="feature/coderabbit-fix"
+BASE_BRANCH="main"
+PR_TITLE="Keep PR title"
+PR_BODY="Keep PR body"
+COMMENT_BODY="Please add a null guard before reading response.data"
+
+SANDBOXES=()
+cleanup() { local d; for d in ${SANDBOXES[@]+"${SANDBOXES[@]}"}; do rm -rf "$d"; done; return 0; }
+trap cleanup EXIT
+
+fail() { echo "FAIL: $1" >&2; [ -n "${2:-}" ] && { echo "----- log -----" >&2; cat "$2" >&2; }; exit 1; }
+
+run_worker() {
+  local dry_run="$1"
+  sb="$(mktemp -d "${TMPDIR:-/tmp}/test-coderabbit-submit.XXXXXX")"
+  SANDBOXES+=("$sb")
+  mkdir -p "$sb/bin" "$sb/work"
+  calls="$sb/submit-calls"
+  ledger="$sb/ledger.tsv"
+  : > "$ledger"
+
+  cat > "$sb/bin/gh" <<GH
+#!/usr/bin/env bash
+case "\${1:-}" in
+  pr)
+    case "\${2:-}" in
+      list)
+        printf '%s\n' '[{"number":777,"url":"https://github.com/owner/repo/pull/777","headRefName":"$HEAD_BRANCH","baseRefName":"$BASE_BRANCH","title":"$PR_TITLE"}]'
+        exit 0 ;;
+      view)
+        printf '%s\n' '{"title":"$PR_TITLE","body":"$PR_BODY","headRefName":"$HEAD_BRANCH","baseRefName":"$BASE_BRANCH"}'
+        exit 0 ;;
+    esac ;;
+  api)
+    case "\${2:-}" in
+      */pulls/*/comments)
+        printf '%s\n' '[{"user":{"login":"coderabbitai[bot]"},"body":"$COMMENT_BODY","updated_at":"$UPDATED","path":"src/app.ts","html_url":"https://github.com/owner/repo/pull/777#discussion_r1"}]'
+        exit 0 ;;
+      */issues/*/comments)
+        printf '[]\n'
+        exit 0 ;;
+    esac ;;
+esac
+echo "fake gh: unhandled: \$*" >&2
+exit 1
+GH
+  chmod +x "$sb/bin/gh"
+
+  cat > "$sb/review-gate-empty.sh" <<'RG'
+#!/usr/bin/env bash
+printf '{}\n'
+RG
+  chmod +x "$sb/review-gate-empty.sh"
+
+  cat > "$sb/bin/submit-stub" <<STUB
+#!/usr/bin/env bash
+echo "\$1" >> "$calls"
+printf 'Workflow ID: wf-coderabbit-submit-test\n'
+exit 0
+STUB
+  chmod +x "$sb/bin/submit-stub"
+
+  log="$sb/worker.log"
+  env \
+    PATH="$sb/bin:$PATH" \
+    INVOKER_PR_CRON_DRY_RUN="$dry_run" \
+    INVOKER_PR_CODERABBIT_STATE_FILE="$ledger" \
+    INVOKER_PR_CRON_LOCK="$sb/coderabbit.lock" \
+    INVOKER_PR_CRON_WORKDIR="$sb/work" \
+    INVOKER_PR_CRON_REVIEW_GATE_CMD="$sb/review-gate-empty.sh" \
+    INVOKER_PR_CODERABBIT_SUBMIT_CMD="$sb/bin/submit-stub" \
+    INVOKER_PR_CODERABBIT_REPO_URL="git@github.com:Neko-Catpital-Labs/Invoker.git" \
+    bash "$WORKER" > "$log" 2>&1 || true
+}
+
+# A. Dry-run: intended submission only; valid YAML plan.
+run_worker 1
+[ ! -s "$calls" ] || fail "A: submit command must not run in dry-run" "$log"
+grep -q "would submit repair workflow" "$log" \
+  || fail "A: dry-run did not log the intended repair-workflow submission" "$log"
+plan="$(printf '%s\n' "$sb"/work/coderabbit-pr-777-*.yaml | sed -n '1p')"
+[ -f "$plan" ] || fail "A: expected generated repair plan YAML" "$log"
+PLAN="$plan" UPDATED="$UPDATED" HEAD_BRANCH="$HEAD_BRANCH" BASE_BRANCH="$BASE_BRANCH" COMMENT_BODY="$COMMENT_BODY" PR_BODY="$PR_BODY" node <<'NODE' >/dev/null \
+  || fail "A: generated plan YAML is not the expected repair-workflow shape" "$log"
+const YAML = require("yaml");
+const fs = require("fs");
+const d = YAML.parse(fs.readFileSync(process.env.PLAN, "utf8"));
+if (d.onFinish !== "merge") throw new Error("onFinish=" + d.onFinish);
+if (d.mergeMode !== "manual") throw new Error("mergeMode=" + d.mergeMode);
+// baseBranch AND featureBranch must both be the PR head branch, so the fix
+// layers on top of the PR's commits instead of rebuilding from the PR base.
+if (d.baseBranch !== process.env.HEAD_BRANCH) throw new Error("baseBranch=" + d.baseBranch);
+if (d.featureBranch !== process.env.HEAD_BRANCH) throw new Error("featureBranch=" + d.featureBranch);
+if (!Array.isArray(d.tasks) || d.tasks.length !== 1) throw new Error("expected one task");
+if (d.tasks[0].executionAgent !== "omp") throw new Error("executionAgent=" + d.tasks[0].executionAgent);
+const prompt = d.tasks[0].prompt || "";
+if (!prompt.includes("do not run 'git push' manually")) throw new Error("missing no-push instruction");
+if (!prompt.includes(process.env.COMMENT_BODY)) throw new Error("missing comment body");
+if (!prompt.includes(process.env.PR_BODY)) throw new Error("missing PR body context");
+if (!prompt.includes(process.env.UPDATED)) throw new Error("missing feedback timestamp");
+NODE
+echo "  A ok: dry-run writes the repair workflow plan and does not submit"
+
+# B. Real run: submits once, records marker, surfaces workflow id.
+run_worker 0
+[ "$(wc -l < "$calls")" -eq 1 ] || fail "B: expected exactly one submission" "$log"
+grep -q "coderabbit-pr-777-" "$calls" || fail "B: submitted the wrong plan path" "$log"
+awk -F '\t' -v marker="$UPDATED" '$1=="coderabbit" && $2=="777" && $3==marker { found=1 } END { exit found ? 0 : 1 }' "$ledger" \
+  || fail "B: success marker was not recorded" "$log"
+grep -q "submitted CodeRabbit repair workflow wf-coderabbit-submit-test" "$log" \
+  || fail "B: workflow id was not surfaced after submit" "$log"
+echo "  B ok: real run submits once and records the feedback marker"
+
+# C. Dedup: same feedback batch skips after marker recorded.
+env \
+  PATH="$sb/bin:$PATH" \
+  INVOKER_PR_CRON_DRY_RUN=0 \
+  INVOKER_PR_CODERABBIT_STATE_FILE="$ledger" \
+  INVOKER_PR_CRON_LOCK="$sb/coderabbit.lock" \
+  INVOKER_PR_CRON_WORKDIR="$sb/work" \
+  INVOKER_PR_CRON_REVIEW_GATE_CMD="$sb/review-gate-empty.sh" \
+  INVOKER_PR_CODERABBIT_SUBMIT_CMD="$sb/bin/submit-stub" \
+  INVOKER_PR_CODERABBIT_REPO_URL="git@github.com:Neko-Catpital-Labs/Invoker.git" \
+  bash "$WORKER" > "$sb/worker2.log" 2>&1 || true
+grep -q "no new CodeRabbit comments since $UPDATED; skip" "$sb/worker2.log" \
+  || fail "C: same feedback batch did not dedup after marker was recorded" "$sb/worker2.log"
+[ "$(wc -l < "$calls")" -eq 1 ] || fail "C: dedup run must not submit again" "$sb/worker2.log"
+echo "  C ok: same feedback batch is skipped after submission marker"
+
+echo "PASS: coderabbit repair workflow submission verified (dry-run, submit, dedup)"
+exit 0


### PR DESCRIPTION
## Summary

CodeRabbit review fixes used to run as a one-off OMP process inside a throwaway local checkout that pushed straight to the PR branch, leaving no durable record of the work.

This makes the `coderabbit-address` worker submit a real Invoker workflow instead. When there is new feedback, it writes a dedicated single-task repair plan and submits it through `submit-plan.sh`.

The fix then runs as a durable, restartable Invoker task rather than a fire-and-forget subprocess.

The plan uses `onFinish: merge` with `mergeMode: manual`, and sets BOTH `baseBranch` and `featureBranch` to the PR head. That layers the fix on the PR author's commits and pushes the head branch back.

Using the PR base as `baseBranch` would rebuild the head branch and drop the author's commits. Manual mode parks at `review_ready` and never squash-merges to base.

## Review Claim

Approve making the CodeRabbit worker submit a dedicated Invoker repair workflow (base and feature both the PR head) for new feedback, in place of running OMP inside a local checkout.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The detection, dedup, attempt-cap, and orphan-repair ownership checks are byte-for-byte unchanged; only the terminal action swaps from `launch_omp` to `submit_repair_workflow`. Because both `baseBranch` and `featureBranch` are the PR head, the merge gate layers the fix on top of the PR's commits (never rebuilds from base) and, in manual mode, parks at `review_ready` without touching the base branch. The success marker is recorded only on a successful submit, so a failed submit retries within the same cap. `scripts/test-coderabbit-address-submit.sh` covers the dry-run, submit, dedup, and the base==feature plan shape.

## Slice Rationale

This slice carries the cron worker script and its offline submission test together, since the test drives the script directly. The end-to-end proof and the dependent repro updates ride in the follow-up proof PR because `scripts/repro/` files review as a distinct proof unit.

## Non-goals

Does not change how CodeRabbit feedback is detected, collected, deduplicated, or capped. Does not change the orphan-repair ownership guard. Does not change the merge gate, `submit-plan.sh`, or the native worker wrapper. Does not add a CHANGELOG entry, matching the repo convention that code PRs omit it.

## Architecture

The worker's terminal action changes from an in-process OMP run to submitting an Invoker workflow that owns the fix and the push-back.

### Before

```mermaid
graph TD
    A["coderabbit-address worker: new feedback"] --> B["gh pr checkout PR head into local workdir"]
    B --> C["run OMP in checkout"]
    C --> D["OMP commits and 'git push' to PR head"]
```

### After

```mermaid
graph TD
    A["coderabbit-address worker: new feedback"] --> B["write single-task repair plan (onFinish: merge, mergeMode: manual, base = feature = PR head)"]
    B --> C["submit-plan.sh -> Invoker workflow"]
    C --> D["omp task fixes on top of the PR head; Invoker auto-commits"]
    D --> E["merge gate consolidates onto PR head and force-pushes it back, parked at review_ready"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/test-coderabbit-address-submit.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e9e7a73`
- Post-revert steps: None
- Data migration? No

</details>
