### PR TITLE
[Skill store integrity](1) Add bundled SKILL.md frontmatter regression test

### DIFF
--- a/packages/app/src/__tests__/bundled-skill-frontmatter.test.ts
+++ b/packages/app/src/__tests__/bundled-skill-frontmatter.test.ts
@@ -1,0 +1,42 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = join(dirname(new URL(import.meta.url).pathname), '..', '..', '..', '..');
+const skillsRoot = join(repoRoot, 'skills');
+
+function bundledSkillNames(): string[] {
+  return readdirSync(skillsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && existsSync(join(skillsRoot, entry.name, 'SKILL.md')))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+// Guards against the class of corruption behind #5231: a botched stacked-PR
+// conflict resolution gutted skills/plan-to-invoker/SKILL.md into a raw `git show`
+// blob (no frontmatter, `commit <sha>` + `diff --git` text), which every agent
+// runtime rejects with "missing YAML frontmatter". This test fails in repo CI the
+// moment any bundled SKILL.md loses its frontmatter or becomes a git artifact,
+// before the installer can mirror it into an agent's global skill store.
+describe('bundled skill SKILL.md integrity', () => {
+  const names = bundledSkillNames();
+
+  it('finds bundled skills to check', () => {
+    expect(names.length).toBeGreaterThan(0);
+  });
+
+  it.each(names)('skills/%s/SKILL.md opens with a YAML frontmatter block', (name) => {
+    const content = readFileSync(join(skillsRoot, name, 'SKILL.md'), 'utf8');
+    const lines = content.split('\n');
+
+    expect(lines[0]?.trim(), `${name}/SKILL.md must start with '---'`).toBe('---');
+    expect(
+      lines.slice(1).some((line) => line.trim() === '---'),
+      `${name}/SKILL.md must close its frontmatter with '---'`,
+    ).toBe(true);
+    expect(content, `${name}/SKILL.md must not contain a raw git diff header`).not.toContain('diff --git ');
+    expect(content, `${name}/SKILL.md must not contain merge conflict markers`).not.toMatch(/^(?:<{7}|={7}|>{7})/m);
+    expect(content, `${name}/SKILL.md must not be a raw git-show blob`).not.toMatch(/^commit [0-9a-f]{40}$/m);
+  });
+});


### PR DESCRIPTION
## Summary

A bad stacked-PR merge once turned a bundled skill file into raw git text, and nothing in the repo caught it before it shipped to users' agent folders.

This adds a test that reads every bundled skill file and fails the moment one loses its `---` header or becomes a git blob.

It is green on the current tree and would have gone red on the broken file, so the same breakage cannot land again unnoticed.

## Review Claim

Every bundled skill file must open with a `---` header and must not be raw git text; a repo test now enforces that.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only. It adds no runtime code and touches no product path, so it cannot change how the app behaves.

## Slice Rationale

The proof lands first, before the guards it justifies, so a reviewer sees the breakage demonstrated before approving any behavior change.

## Non-goals

Does not change the installer. Does not change any error message. No product code is touched here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/bundled-skill-frontmatter.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
