### PR TITLE
[Skill store integrity](2) Refuse to install a corrupt bundled skill

### DIFF
--- a/packages/app/src/__tests__/bundled-skill-frontmatter.test.ts
+++ b/packages/app/src/__tests__/bundled-skill-frontmatter.test.ts
@@ -1,0 +1,42 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = join(dirname(new URL(import.meta.url).pathname), '..', '..', '..', '..');
+const skillsRoot = join(repoRoot, 'skills');
+
+function bundledSkillNames(): string[] {
+  return readdirSync(skillsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && existsSync(join(skillsRoot, entry.name, 'SKILL.md')))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+// Guards against the class of corruption behind #5231: a botched stacked-PR
+// conflict resolution gutted skills/plan-to-invoker/SKILL.md into a raw `git show`
+// blob (no frontmatter, `commit <sha>` + `diff --git` text), which every agent
+// runtime rejects with "missing YAML frontmatter". This test fails in repo CI the
+// moment any bundled SKILL.md loses its frontmatter or becomes a git artifact,
+// before the installer can mirror it into an agent's global skill store.
+describe('bundled skill SKILL.md integrity', () => {
+  const names = bundledSkillNames();
+
+  it('finds bundled skills to check', () => {
+    expect(names.length).toBeGreaterThan(0);
+  });
+
+  it.each(names)('skills/%s/SKILL.md opens with a YAML frontmatter block', (name) => {
+    const content = readFileSync(join(skillsRoot, name, 'SKILL.md'), 'utf8');
+    const lines = content.split('\n');
+
+    expect(lines[0]?.trim(), `${name}/SKILL.md must start with '---'`).toBe('---');
+    expect(
+      lines.slice(1).some((line) => line.trim() === '---'),
+      `${name}/SKILL.md must close its frontmatter with '---'`,
+    ).toBe(true);
+    expect(content, `${name}/SKILL.md must not contain a raw git diff header`).not.toContain('diff --git ');
+    expect(content, `${name}/SKILL.md must not contain merge conflict markers`).not.toMatch(/^(?:<{7}|={7}|>{7})/m);
+    expect(content, `${name}/SKILL.md must not be a raw git-show blob`).not.toMatch(/^commit [0-9a-f]{40}$/m);
+  });
+});

--- a/packages/app/src/__tests__/bundled-skills.test.ts
+++ b/packages/app/src/__tests__/bundled-skills.test.ts
@@ -16,7 +16,7 @@ function makeTempRoot(prefix: string): string {
 function writeSkill(sourceRoot: string, name: string): void {
   const skillDir = join(sourceRoot, 'skills', name);
   mkdirSync(join(skillDir, 'scripts'), { recursive: true });
-  writeFileSync(join(skillDir, 'SKILL.md'), `# ${name}\n`);
+  writeFileSync(join(skillDir, 'SKILL.md'), `---\nname: ${name}\ndescription: test skill\n---\n\n# ${name}\n`);
   writeFileSync(join(skillDir, 'scripts', 'check.sh'), '#!/usr/bin/env bash\necho ok\n');
 }
 
@@ -329,6 +329,38 @@ describe('bundled-skills', () => {
       expect(status.targets[0]?.staleReason).toBe('bundle-updated');
       expect(status.targets[0]?.diagnostic).toContain('bundled source changed');
       expect(status.targets[0]?.diagnostic).toContain('prefix "invoker-"');
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('refuses to install a skill whose SKILL.md lost its YAML frontmatter', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const codexHome = makeTempRoot('invoker-codex-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = codexHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      // Simulate a botched conflict resolution that gutted SKILL.md into a git-show blob.
+      const gutted = 'commit 37fa96068caa9b94559d52edf10a677a95178cf5\nAuthor: x\n\ndiff --git a/x b/x\n';
+      writeFileSync(join(resourcesRoot, 'skills', 'plan-to-invoker', 'SKILL.md'), gutted);
+
+      expect(() => installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+      })).toThrow(/missing YAML frontmatter/);
+
+      // Nothing corrupt reached the agent skill store.
+      expect(existsSync(join(codexHome, '.codex', 'skills', 'invoker-plan-to-invoker', 'SKILL.md'))).toBe(false);
     } finally {
       if (originalHome === undefined) {
         delete process.env.HOME;

--- a/packages/app/src/bundled-skills.ts
+++ b/packages/app/src/bundled-skills.ts
@@ -56,6 +56,29 @@ function listBundledSkillNames(sourceRoot: string): string[] {
     .sort();
 }
 
+/** A SKILL.md must open with a YAML frontmatter block (`---` … `---`); the agent
+ * runtimes (codex, claude, omp) reject one without it. A botched stacked-PR
+ * conflict resolution has gutted plan-to-invoker/SKILL.md into a raw `git show`
+ * blob before (commit fd5c6bbfc), and the old blind cpSync then mirrored that
+ * corruption into every agent's global skill store — poisoning executions on
+ * every branch, since the store lives outside the per-worktree sandbox. Fail the
+ * install loudly instead of propagating a skill no agent can load. */
+function assertSkillSourceValid(sourceDir: string, skillName: string): void {
+  const skillMd = path.join(sourceDir, 'SKILL.md');
+  const content = readFileSync(skillMd, 'utf8');
+  const lines = content.split('\n');
+  const hasFrontmatter = lines[0]?.trim() === '---'
+    && lines.slice(1).some((line) => line.trim() === '---');
+  if (!hasFrontmatter) {
+    const preview = content.slice(0, 80).replace(/\s+/g, ' ').trim();
+    throw new Error(
+      `Bundled skill "${skillName}" has a corrupt SKILL.md at ${skillMd}: missing YAML `
+      + 'frontmatter delimited by ---. The bundled source looks damaged (starts with '
+      + `"${preview}"). Restore it from a clean checkout, then reinstall skills.`,
+    );
+  }
+}
+
 function hashDirectory(root: string): string {
   const hash = createHash('sha256');
 
@@ -465,6 +488,9 @@ export function installBundledSkills(
   }
 
   const bundledSkillNames = listBundledSkillNames(sourceRoot);
+  for (const skillName of bundledSkillNames) {
+    assertSkillSourceValid(path.join(sourceRoot, skillName), skillName);
+  }
   const bundledHash = hashDirectory(sourceRoot);
   const installedNames = prefixedSkillNames(bundledSkillNames);
   const targets = resolveManagedTargets();


### PR DESCRIPTION
## Summary

The skill installer copied whatever sat in the source folder straight into every agent's global skill folder, with no check.

So when a bundled skill file was corrupted upstream, the installer faithfully mirrored the broken file everywhere, and every agent run on every branch broke.

Now the installer stops with a clear, actionable error before copying a bundled skill whose file has no `---` header. A damaged skill can no longer reach an agent's folder.

## Review Claim

The installer refuses to copy a bundled skill whose file is missing its `---` header, and fails loudly instead.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The guard runs before any file is written, so a healthy install is unchanged and a corrupt one aborts before touching an agent folder. All existing install tests stay green.

## Slice Rationale

The install-time guard is its own behavior change. It is kept apart from the repo test that proves the breakage and from the unrelated failure-message change.

## Non-goals

Does not change how a healthy skill installs. Does not change codex's own file parsing. No error-message formatting is touched here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/bundled-skills.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-install-skills.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #6303
