### PR TITLE
[Skill store integrity](3) Surface agent failure signal over raw log tail

### DIFF
--- a/packages/app/src/__tests__/bundled-skill-frontmatter.test.ts
+++ b/packages/app/src/__tests__/bundled-skill-frontmatter.test.ts
@@ -1,0 +1,42 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = join(dirname(new URL(import.meta.url).pathname), '..', '..', '..', '..');
+const skillsRoot = join(repoRoot, 'skills');
+
+function bundledSkillNames(): string[] {
+  return readdirSync(skillsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && existsSync(join(skillsRoot, entry.name, 'SKILL.md')))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+// Guards against the class of corruption behind #5231: a botched stacked-PR
+// conflict resolution gutted skills/plan-to-invoker/SKILL.md into a raw `git show`
+// blob (no frontmatter, `commit <sha>` + `diff --git` text), which every agent
+// runtime rejects with "missing YAML frontmatter". This test fails in repo CI the
+// moment any bundled SKILL.md loses its frontmatter or becomes a git artifact,
+// before the installer can mirror it into an agent's global skill store.
+describe('bundled skill SKILL.md integrity', () => {
+  const names = bundledSkillNames();
+
+  it('finds bundled skills to check', () => {
+    expect(names.length).toBeGreaterThan(0);
+  });
+
+  it.each(names)('skills/%s/SKILL.md opens with a YAML frontmatter block', (name) => {
+    const content = readFileSync(join(skillsRoot, name, 'SKILL.md'), 'utf8');
+    const lines = content.split('\n');
+
+    expect(lines[0]?.trim(), `${name}/SKILL.md must start with '---'`).toBe('---');
+    expect(
+      lines.slice(1).some((line) => line.trim() === '---'),
+      `${name}/SKILL.md must close its frontmatter with '---'`,
+    ).toBe(true);
+    expect(content, `${name}/SKILL.md must not contain a raw git diff header`).not.toContain('diff --git ');
+    expect(content, `${name}/SKILL.md must not contain merge conflict markers`).not.toMatch(/^(?:<{7}|={7}|>{7})/m);
+    expect(content, `${name}/SKILL.md must not be a raw git-show blob`).not.toMatch(/^commit [0-9a-f]{40}$/m);
+  });
+});

--- a/packages/app/src/__tests__/bundled-skills.test.ts
+++ b/packages/app/src/__tests__/bundled-skills.test.ts
@@ -16,7 +16,7 @@ function makeTempRoot(prefix: string): string {
 function writeSkill(sourceRoot: string, name: string): void {
   const skillDir = join(sourceRoot, 'skills', name);
   mkdirSync(join(skillDir, 'scripts'), { recursive: true });
-  writeFileSync(join(skillDir, 'SKILL.md'), `# ${name}\n`);
+  writeFileSync(join(skillDir, 'SKILL.md'), `---\nname: ${name}\ndescription: test skill\n---\n\n# ${name}\n`);
   writeFileSync(join(skillDir, 'scripts', 'check.sh'), '#!/usr/bin/env bash\necho ok\n');
 }
 
@@ -329,6 +329,38 @@ describe('bundled-skills', () => {
       expect(status.targets[0]?.staleReason).toBe('bundle-updated');
       expect(status.targets[0]?.diagnostic).toContain('bundled source changed');
       expect(status.targets[0]?.diagnostic).toContain('prefix "invoker-"');
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('refuses to install a skill whose SKILL.md lost its YAML frontmatter', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const codexHome = makeTempRoot('invoker-codex-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = codexHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      // Simulate a botched conflict resolution that gutted SKILL.md into a git-show blob.
+      const gutted = 'commit 37fa96068caa9b94559d52edf10a677a95178cf5\nAuthor: x\n\ndiff --git a/x b/x\n';
+      writeFileSync(join(resourcesRoot, 'skills', 'plan-to-invoker', 'SKILL.md'), gutted);
+
+      expect(() => installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+      })).toThrow(/missing YAML frontmatter/);
+
+      // Nothing corrupt reached the agent skill store.
+      expect(existsSync(join(codexHome, '.codex', 'skills', 'invoker-plan-to-invoker', 'SKILL.md'))).toBe(false);
     } finally {
       if (originalHome === undefined) {
         delete process.env.HOME;

--- a/packages/app/src/bundled-skills.ts
+++ b/packages/app/src/bundled-skills.ts
@@ -56,6 +56,29 @@ function listBundledSkillNames(sourceRoot: string): string[] {
     .sort();
 }
 
+/** A SKILL.md must open with a YAML frontmatter block (`---` … `---`); the agent
+ * runtimes (codex, claude, omp) reject one without it. A botched stacked-PR
+ * conflict resolution has gutted plan-to-invoker/SKILL.md into a raw `git show`
+ * blob before (commit fd5c6bbfc), and the old blind cpSync then mirrored that
+ * corruption into every agent's global skill store — poisoning executions on
+ * every branch, since the store lives outside the per-worktree sandbox. Fail the
+ * install loudly instead of propagating a skill no agent can load. */
+function assertSkillSourceValid(sourceDir: string, skillName: string): void {
+  const skillMd = path.join(sourceDir, 'SKILL.md');
+  const content = readFileSync(skillMd, 'utf8');
+  const lines = content.split('\n');
+  const hasFrontmatter = lines[0]?.trim() === '---'
+    && lines.slice(1).some((line) => line.trim() === '---');
+  if (!hasFrontmatter) {
+    const preview = content.slice(0, 80).replace(/\s+/g, ' ').trim();
+    throw new Error(
+      `Bundled skill "${skillName}" has a corrupt SKILL.md at ${skillMd}: missing YAML `
+      + 'frontmatter delimited by ---. The bundled source looks damaged (starts with '
+      + `"${preview}"). Restore it from a clean checkout, then reinstall skills.`,
+    );
+  }
+}
+
 function hashDirectory(root: string): string {
   const hash = createHash('sha256');
 
@@ -465,6 +488,9 @@ export function installBundledSkills(
   }
 
   const bundledSkillNames = listBundledSkillNames(sourceRoot);
+  for (const skillName of bundledSkillNames) {
+    assertSkillSourceValid(path.join(sourceRoot, skillName), skillName);
+  }
   const bundledHash = hashDirectory(sourceRoot);
   const installedNames = prefixedSkillNames(bundledSkillNames);
   const targets = resolveManagedTargets();

--- a/packages/execution-engine/src/__tests__/process-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/process-utils.test.ts
@@ -301,4 +301,24 @@ describe('buildAgentExitFailureDetail', () => {
     expect(detail.length).toBe(2000);
     expect(detail).toBe(huge.slice(-2000));
   });
+
+  it('surfaces failure lines and drops surrounding build/progress noise', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const noisyLog = [
+      'ERROR codex_core::session::session: failed to load skill /home/u/.codex/skills/x/SKILL.md: missing YAML frontmatter delimited by ---',
+      'vite v6.4.1 building for production...',
+      '✓ 2326 modules transformed.',
+      'dist/assets/index-Bza8qXJb.js 340.96 kB │ gzip: 91.85 kB',
+      'CLI ⚡️ Build success in 190ms',
+      "No workflow named 'In-App Planning Chat Draft Gate Step 3' found.",
+      '[worktree] Process exited: actionId=wf-123/discover-delete-scope exitCode=1',
+    ].join('\n');
+    const detail = processUtils.buildAgentExitFailureDetail(noisyLog, '', undefined);
+    expect(detail).toContain('missing YAML frontmatter delimited by ---');
+    expect(detail).toContain("No workflow named 'In-App Planning Chat Draft Gate Step 3' found.");
+    expect(detail).toContain('exitCode=1');
+    expect(detail).not.toContain('modules transformed');
+    expect(detail).not.toContain('Build success');
+    expect(detail).not.toContain('gzip');
+  });
 });

--- a/packages/execution-engine/src/process-utils.ts
+++ b/packages/execution-engine/src/process-utils.ts
@@ -266,6 +266,20 @@ const AGENT_OUTPUT_DETAIL_MAX_CHARS = 2000;
 
 const CODEX_STDIN_NOISE = /^Reading additional input from stdin\.\.\.$/;
 
+/** Lines that actually explain a non-zero exit, as opposed to build progress,
+ * download spinners, or delegation traces that happen to print alongside them.
+ * Position-tailing the raw output buries the real cause under whatever printed
+ * last (e.g. a successful vite/tsup build log), so these lines are surfaced first. */
+const AGENT_ERROR_SIGNAL =
+  /\b(?:errors?|failed|failure|fatal|panic|exception|traceback|refused|denied|rejected|unable|cannot|missing)\b|\bexit(?:ed)?\b[^\n]*\bcode\b|exitcode|\btimed out\b|not found|\bno\b[^\n]+\bfound\b/i;
+
+/** Keep only the lines that read as failure signal. Returns '' when nothing
+ * matches, so callers can fall back to the raw (tail-limited) output. */
+function extractErrorSignal(text: string): string {
+  const signalLines = text.split('\n').filter((line) => AGENT_ERROR_SIGNAL.test(line));
+  return signalLines.join('\n');
+}
+
 function nonEmptyTrimmedLines(text: string): string[] {
   return text.split('\n').map((line) => line.trim()).filter(Boolean);
 }
@@ -294,7 +308,7 @@ export function buildAgentExitFailureDetail(
   const meaningfulDisplay = stripCodexStdinNoise(displayStdout ?? '');
   const meaningfulStdout = stripCodexStdinNoise(rawStdout);
   const candidate = meaningfulStderr || meaningfulDisplay || meaningfulStdout;
-  if (candidate) return tailChars(candidate);
+  if (candidate) return tailChars(extractErrorSignal(candidate) || candidate);
 
   // Nothing meaningful survived. If the only thing either stream emitted was the
   // benign codex stdin/TTY noise, return an actionable hint instead of echoing it


### PR DESCRIPTION
## Summary

When an agent run failed, the app pasted the last two thousand characters of the process output as the error.

That buried the one line that mattered under a wall of successful build noise, so the message read as gibberish.

Now the failure detail keeps the lines that explain the failure and drops the build and progress noise, falling back to the raw tail only when nothing matches.

## Review Claim

Agent-failure detail surfaces the real failure lines first, instead of a blind tail of the whole process output.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Pure string shaping on an already-failed path. It changes only the text of the error detail, never control flow, and keeps the raw-tail fallback for unmatched output.

## Slice Rationale

The message-shaping change is unrelated to the skill-integrity guards below it, so it ships as its own slice with its own claim.

## Non-goals

Does not change when a run fails or how it is handled. Does not change the installer. No skill file is touched here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/process-utils.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #6304
