### PR TITLE
[Infra Repair Worker](1) Add contract and registry seam

### DIFF
--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -21,6 +21,7 @@ import {
 import { PR_STATUS_WORKER_KIND } from '../workers/pr-status-worker.js';
 import { PR_SUMMARY_REFRESH_WORKER_KIND } from '../workers/pr-summary-refresh-worker.js';
 import { DISK_HEADROOM_WORKER_KIND } from '../workers/disk-headroom-worker.js';
+import { INFRA_REPAIR_WORKER_KIND } from '../workers/infra-repair-worker.js';
 import { REQUEUE_WORKER_KIND } from '../workers/requeue-worker.js';
 import { WORKFLOW_RESUME_WORKER_KIND } from '../workers/workflow-resume-worker.js';
 import { E2E_AUTOFIX_WORKER_KIND } from '../workers/e2e-autofix-worker.js';
@@ -75,6 +76,7 @@ describe('worker registry', () => {
       WORKFLOW_RESUME_WORKER_KIND,
       PR_STATUS_WORKER_KIND,
       PR_SUMMARY_REFRESH_WORKER_KIND,
+      INFRA_REPAIR_WORKER_KIND,
       DISK_HEADROOM_WORKER_KIND,
       AUTO_APPROVE_WORKER_KIND,
       CODERABBIT_ADDRESS_WORKER_KIND,
@@ -89,6 +91,7 @@ describe('worker registry', () => {
     expect(registry.get(WORKFLOW_RESUME_WORKER_KIND)).toBeDefined();
     expect(registry.get(PR_STATUS_WORKER_KIND)).toBeDefined();
     expect(registry.get(PR_SUMMARY_REFRESH_WORKER_KIND)).toBeDefined();
+    expect(registry.get(INFRA_REPAIR_WORKER_KIND)).toBeDefined();
     expect(registry.get(DISK_HEADROOM_WORKER_KIND)).toBeDefined();
     expect(registry.get(AUTO_APPROVE_WORKER_KIND)).toBeDefined();
     expect(registry.get(CODERABBIT_ADDRESS_WORKER_KIND)).toBeDefined();
@@ -121,6 +124,7 @@ describe('worker registry', () => {
     expect(registry.get(PR_STATUS_WORKER_KIND)?.factory(deps()).identity.kind).toBe(PR_STATUS_WORKER_KIND);
     expect(registry.get(PR_SUMMARY_REFRESH_WORKER_KIND)?.factory(deps()).identity.kind)
       .toBe(PR_SUMMARY_REFRESH_WORKER_KIND);
+    expect(registry.get(INFRA_REPAIR_WORKER_KIND)?.factory(deps()).identity.kind).toBe(INFRA_REPAIR_WORKER_KIND);
     expect(registry.get(CODERABBIT_ADDRESS_WORKER_KIND)?.factory(deps()).identity.kind)
       .toBe(CODERABBIT_ADDRESS_WORKER_KIND);
     expect(registry.get(PR_CONFLICT_REBASE_WORKER_KIND)?.factory(deps()).identity.kind)

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -4,6 +4,7 @@ import type { WorkerRuntimeDependencies } from './worker-runtime-dependencies.js
 import type { WorkerRegistry } from './worker-registry.js';
 import { registerE2eAutoFixWorker } from './workers/e2e-autofix-worker.js';
 import { registerDiskHeadroomWorker } from './workers/disk-headroom-worker.js';
+import { registerInfraRepairWorker } from './workers/infra-repair-worker.js';
 import { registerPrMaintenanceWorkers } from './workers/pr-maintenance-workers.js';
 import { registerPrSummaryRefreshWorker } from './workers/pr-summary-refresh-worker.js';
 import { registerPrStatusWorker } from './workers/pr-status-worker.js';
@@ -19,6 +20,7 @@ export function registerBuiltinWorkers(
   registerWorkflowResumeWorker(registry);
   registerPrStatusWorker(registry);
   registerPrSummaryRefreshWorker(registry);
+  registerInfraRepairWorker(registry);
   registerDiskHeadroomWorker(registry);
   registerAutoApproveWorker(registry);
   registerPrMaintenanceWorkers(registry);

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -64,6 +64,7 @@ export * from './ci-failure-infra-classifier.js';
 export * from './pr-stack-detection.js';
 export * from './workers/pr-status-worker.js';
 export * from './workers/pr-summary-refresh-worker.js';
+export * from './workers/infra-repair-worker.js';
 export * from './workers/auto-approve-worker.js';
 export * from './workers/disk-headroom-worker.js';
 export * from './workers/disk-headroom-monitor.js';

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -16,6 +16,7 @@ import type {
 import type { PrMaintenanceWorkerConfig } from './workers/pr-maintenance-workers.js';
 import type { E2eAutoFixWorkerConfig } from './workers/e2e-autofix-worker.js';
 import type { DiskHeadroomWorkerConfig } from './workers/disk-headroom-worker.js';
+import type { InfraRepairWorkerConfig } from './workers/infra-repair-worker.js';
 import type { PrStatusReviewGate } from './workers/pr-status-worker.js';
 import type { RequeueWorkerConfig, RequeueWorkerSubmitter } from './workers/requeue-worker.js';
 import type {
@@ -55,6 +56,8 @@ export interface WorkerRuntimeDependencies {
   prMaintenance?: PrMaintenanceWorkerConfig;
   /** Disk-headroom worker configuration (local/remote paths and thresholds). */
   diskHeadroom?: DiskHeadroomWorkerConfig;
+  /** Infra-repair worker configuration (owner/local repo plus remote SSH repair targets). */
+  infraRepair?: InfraRepairWorkerConfig;
   /** Auto-approval tuning for worker-owned AI fix approvals. */
   autoApprove?: AutoApproveWorkerConfig;
   /** Workflow-resume worker tuning (cooldown and poll cadence). */

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -1,0 +1,55 @@
+import type { Logger } from '@invoker/contracts';
+
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const INFRA_REPAIR_WORKER_KIND = 'infra-repair';
+export const DEFAULT_INFRA_REPAIR_WORKER_INTERVAL_MS = 60_000;
+
+export interface InfraRepairRemoteTargetConfig {
+  host: string;
+  user: string;
+  sshKeyPath: string;
+  port?: number;
+  provisionCommand?: string;
+  remoteInvokerHome?: string;
+}
+
+export interface InfraRepairWorkerConfig {
+  ownerRepoRoot: string;
+  ownerInvokerHome: string;
+  remoteTargets: Record<string, InfraRepairRemoteTargetConfig>;
+  repairCooldownMs?: number;
+}
+
+export interface InfraRepairWorkerOptions {
+  logger: Logger;
+  intervalMs?: number;
+  tickOnStart?: boolean;
+  onTick?: WorkerTick;
+}
+
+export function createInfraRepairWorker(options: InfraRepairWorkerOptions): WorkerRuntime {
+  return createWorkerRuntime({
+    kind: INFRA_REPAIR_WORKER_KIND,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_INFRA_REPAIR_WORKER_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    onTick: options.onTick ?? (async () => {}),
+  });
+}
+
+export function registerInfraRepairWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: INFRA_REPAIR_WORKER_KIND,
+    note: 'Repairs infra-owned SSH and review-gate CI failures before retrying them.',
+    source: 'built-in',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime => createInfraRepairWorker({
+      logger: deps.logger,
+    }),
+  });
+  return registry;
+}


### PR DESCRIPTION
## Summary

This slice registers a new `infra-repair` worker kind in the built-in worker registry.

It adds the worker's config fields and a no-op tick handler, wired into the registry the same way other built-in workers are wired in.

Later slices will add the actual SSH repair logic behind this registration.

## Review Claim

Approve registering an `infra-repair` worker kind with an empty tick handler and its config fields.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The worker's `onTick` defaults to a no-op async function and `tickOnStart` defaults to `false`, so registering this worker cannot change runtime behavior for any existing process until a later slice wires in real repair logic.

## Slice Rationale

Landing the registration first lets reviewers check the new worker kind and its wiring independently of the SSH repair behavior that later slices will add.

## Non-goals

This slice does not implement any SSH connection, remote provisioning, or repair logic. It does not wire `infraRepair` config into any running process.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1412d0587`
- Post-revert steps: None
- Data migration? No

</details>
