### PR TITLE
[Infra Repair Worker](2) Wire owner config in main process

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -355,6 +355,23 @@ function buildRegisteredOwnerWorkerDeps(
       localPath: resolveInvokerHomeRoot(),
       remoteTargets,
     },
+    infraRepair: {
+      ownerRepoRoot: repoRoot,
+      ownerInvokerHome: resolveInvokerHomeRoot(),
+      remoteTargets: Object.fromEntries(
+        Object.entries(invokerConfig.remoteTargets ?? {}).map(([name, target]) => [
+          name,
+          {
+            host: target.host,
+            user: target.user,
+            sshKeyPath: target.sshKeyPath,
+            port: target.port,
+            provisionCommand: target.provisionCommand,
+            remoteInvokerHome: target.remoteInvokerHome,
+          },
+        ]),
+      ),
+    },
     e2eAutoFix: { intervalMs: invokerConfig.e2eAutoFixIntervalMs },
     autoApprove: {
       enabled: resolveAutoApproveAIFixes(invokerConfig),


### PR DESCRIPTION
## Summary

This slice wires the `infraRepair` config into `buildRegisteredOwnerWorkerDeps` in the main process.

It maps the app's configured remote targets into the shape the `infra-repair` worker expects.

No repair logic runs yet. This only makes the config reachable by the worker's dependency wiring added in #6314.

## Review Claim

Approve wiring `infraRepair` config (owner paths and remote targets) into the main process worker deps builder.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The `infra-repair` worker registered in #6314 still defaults to a no-op `onTick` with `tickOnStart: false`, so populating its config here cannot trigger any SSH connection or repair action; it only makes config data available to a handler that does nothing yet.

## Slice Rationale

Keeping this config wiring in its own slice, separate from the worker registration in #6314, lets reviewers check the data mapping (owner repo root, invoker home, remote targets) on its own.

## Non-goals

This slice does not implement any SSH connection, remote provisioning, or repair logic. It does not change the worker's tick behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4447a3cc6`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #6314
