### PR TITLE
[Infra Repair Worker](3) Wire headless worker surface

### DIFF
--- a/packages/app/src/__tests__/headless-worker.test.ts
+++ b/packages/app/src/__tests__/headless-worker.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
-import { PR_SUMMARY_REFRESH_WORKER_KIND } from '@invoker/execution-engine';
-import { resolveHeadlessDiskHeadroomConfig, runHeadless } from '../headless.js';
+import {
+  INFRA_REPAIR_WORKER_KIND,
+  PR_SUMMARY_REFRESH_WORKER_KIND,
+} from '@invoker/execution-engine';
+import {
+  resolveHeadlessDiskHeadroomConfig,
+  resolveHeadlessInfraRepairConfig,
+  runHeadless,
+} from '../headless.js';
 
 describe('headless worker registry', () => {
   it('lists the PR summary refresh worker kind', async () => {
@@ -18,6 +25,7 @@ describe('headless worker registry', () => {
 
     expect(stdout).toContain('Worker kinds');
     expect(stdout).toContain(PR_SUMMARY_REFRESH_WORKER_KIND);
+    expect(stdout).toContain(INFRA_REPAIR_WORKER_KIND);
   });
 
   it('maps configured SSH targets into disk-headroom worker dependencies', () => {
@@ -42,5 +50,35 @@ describe('headless worker registry', () => {
       },
       remotePath: '~/.invoker',
     }]);
+  });
+
+  it('maps configured SSH targets into infra-repair worker dependencies', () => {
+    const config = resolveHeadlessInfraRepairConfig({
+      remoteTargets: {
+        digitalOcean: {
+          host: '203.0.113.10',
+          user: 'invoker',
+          sshKeyPath: '/tmp/test-key',
+          port: 2222,
+          provisionCommand: 'bash scripts/provision-ssh-worker.sh ensure-repo-ready',
+          remoteInvokerHome: '~/.invoker-custom',
+        },
+      },
+    }, '/tmp/repo-root');
+
+    expect(config).toEqual({
+      ownerRepoRoot: '/tmp/repo-root',
+      ownerInvokerHome: expect.any(String),
+      remoteTargets: {
+        digitalOcean: {
+          host: '203.0.113.10',
+          user: 'invoker',
+          sshKeyPath: '/tmp/test-key',
+          port: 2222,
+          provisionCommand: 'bash scripts/provision-ssh-worker.sh ensure-repo-ready',
+          remoteInvokerHome: '~/.invoker-custom',
+        },
+      },
+    });
   });
 });

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -421,6 +421,29 @@ export function resolveHeadlessDiskHeadroomConfig(
   };
 }
 
+export function resolveHeadlessInfraRepairConfig(
+  invokerConfig: HeadlessDeps['invokerConfig'],
+  repoRoot: string,
+): NonNullable<WorkerRuntimeDependencies['infraRepair']> {
+  return {
+    ownerRepoRoot: repoRoot,
+    ownerInvokerHome: resolveInvokerHomeRoot(),
+    remoteTargets: Object.fromEntries(
+      Object.entries(invokerConfig.remoteTargets ?? {}).map(([name, target]) => [
+        name,
+        {
+          host: target.host,
+          user: target.user,
+          sshKeyPath: target.sshKeyPath,
+          port: target.port,
+          provisionCommand: target.provisionCommand,
+          remoteInvokerHome: target.remoteInvokerHome,
+        },
+      ]),
+    ),
+  };
+}
+
 async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0] ?? 'list';
   const registry = registerExternalWorkersFromConfig(
@@ -478,6 +501,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
       },
       prMaintenance: resolvePrMaintenanceWorkerConfig(deps.invokerConfig),
       diskHeadroom: resolveHeadlessDiskHeadroomConfig(deps.invokerConfig),
+      infraRepair: resolveHeadlessInfraRepairConfig(deps.invokerConfig, deps.repoRoot),
       mergeGateProvider: new GitHubMergeGateProvider(),
     });
     await worker.tick('manual');

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -355,6 +355,23 @@ function buildRegisteredOwnerWorkerDeps(
       localPath: resolveInvokerHomeRoot(),
       remoteTargets,
     },
+    infraRepair: {
+      ownerRepoRoot: repoRoot,
+      ownerInvokerHome: resolveInvokerHomeRoot(),
+      remoteTargets: Object.fromEntries(
+        Object.entries(invokerConfig.remoteTargets ?? {}).map(([name, target]) => [
+          name,
+          {
+            host: target.host,
+            user: target.user,
+            sshKeyPath: target.sshKeyPath,
+            port: target.port,
+            provisionCommand: target.provisionCommand,
+            remoteInvokerHome: target.remoteInvokerHome,
+          },
+        ]),
+      ),
+    },
     e2eAutoFix: { intervalMs: invokerConfig.e2eAutoFixIntervalMs },
     autoApprove: {
       enabled: resolveAutoApproveAIFixes(invokerConfig),


### PR DESCRIPTION
## Summary

This slice wires the `infraRepair` config into the headless CLI's worker dependency builder.

It adds `resolveHeadlessInfraRepairConfig`, mirroring the existing `resolveHeadlessDiskHeadroomConfig` mapping, and passes its output into `headlessWorker`'s `WorkerRuntimeDependencies`.

No repair logic runs yet. This only makes the config reachable by the worker's dependency wiring, this time from the headless entry point instead of the main process.

## Review Claim

Approve wiring `infraRepair` config into the headless worker command's dependency builder, mirroring the existing disk-headroom config mapping.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The `infra-repair` worker registered in #6314 still defaults to a no-op `onTick` with `tickOnStart: false`, so populating its config here cannot trigger any SSH connection or repair action; it only makes config data available to a handler that does nothing yet.

## Slice Rationale

Keeping this headless wiring in its own slice, separate from the main-process wiring in #6315, lets reviewers check the CLI-specific config mapping on its own.

## Non-goals

This slice does not implement any SSH connection, remote provisioning, or repair logic. It does not change the worker's tick behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9dfecaad9`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #6315
