### PR TITLE
[CodeRabbit repair workflow](2) Prove the CodeRabbit repair path end to end

### DIFF
--- a/scripts/cron-coderabbit-address.sh
+++ b/scripts/cron-coderabbit-address.sh
@@ -8,6 +8,8 @@ MAX_CODERABBIT_ATTEMPTS="${INVOKER_PR_CODERABBIT_MAX_ATTEMPTS:-3}"
 STATE_FILE="${INVOKER_PR_CODERABBIT_STATE_FILE:-${HOME}/.invoker/coderabbit-address-submissions.tsv}"
 WORKDIR="${INVOKER_PR_CRON_WORKDIR:-${HOME}/.invoker/pr-cron-work}"
 WORKDIR_MAX_AGE_DAYS="${INVOKER_PR_CRON_WORKDIR_MAX_AGE_DAYS:-7}"
+SUBMIT_CMD="${INVOKER_PR_CODERABBIT_SUBMIT_CMD:-$REPO_ROOT/submit-plan.sh}"
+REPO_URL="${INVOKER_PR_CODERABBIT_REPO_URL:-$(git remote get-url origin 2>/dev/null || echo .)}"
 
 cron_lock
 ledger_init "$STATE_FILE"
@@ -33,48 +35,33 @@ collect_coderabbit() {
   '
 }
 
-# Prepare a checkout of the PR head branch; sets CHECKOUT_DIR. Logs to stderr so
-# callers can capture nothing on stdout.
-CHECKOUT_DIR=""
-prepare_checkout() {
-  local num="$1"
-  local dir="$WORKDIR/$num"
-  mkdir -p "$WORKDIR"
-  if [ ! -d "$dir/.git" ]; then
-    rm -rf "$dir"
-    if ! gh repo clone "$TARGET_REPO" "$dir" -- --quiet >/dev/null 2>&1; then
-      log_line "PR #$num: clone failed" >&2
-      return 1
-    fi
-  elif ! ( cd "$dir" && git reset --hard && git clean -fd ) >/dev/null 2>&1; then
-    # A prior omp run that exited non-zero can leave a dirty worktree; reset it
-    # so the next attempt never fails checkout on, or pushes, stale edits.
-    log_line "PR #$num: failed to clean reused checkout" >&2
-    return 1
-  fi
-  if ! ( cd "$dir" && git fetch --quiet --all && gh pr checkout "$num" --repo "$TARGET_REPO" && git reset --hard && git clean -fd ) >/dev/null 2>&1; then
-    log_line "PR #$num: gh pr checkout failed" >&2
-    return 1
-  fi
-  touch "$dir/$PR_CRON_WORKDIR_STAMP_NAME" >/dev/null 2>&1 || true
-  CHECKOUT_DIR="$dir"
+# Build a JSON string literal that is safe to embed directly in YAML.
+json_quote() {
+  jq -nr --arg v "$1" '$v'
+}
+
+slugify_marker() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | tr -cs 'a-z0-9' '-' \
+    | sed -e 's/^-*//' -e 's/-*$//'
 }
 
 build_prompt() {
-  # build_prompt <num> <base_branch> <head_branch> <ctx_file>
-  local num="$1" base="$2" head="$3" ctx="$4"
+  # build_prompt <num> <base_branch> <head_branch> <ctx_json>
+  local num="$1" base="$2" head="$3" ctx_json="$4"
   cat <<EOF
 You are addressing CodeRabbit review feedback on GitHub PR #$num in repository $TARGET_REPO.
-You are running inside a fresh checkout of the PR head branch ($head); HEAD is already on that
-branch and 'git push' updates the PR.
+Invoker created a dedicated repair workflow for this feedback batch. You are working on the
+PR head branch ($head) inside an Invoker task; when this workflow succeeds, Invoker's merge
+gate will push the merged result back to that PR branch. Do not open, retitle, or edit the
+GitHub PR yourself, and do not run 'git push' manually.
 
-Context for this PR is in the JSON file: $ctx
-Fields: .pr, .prTitle, .prBody, .headBranch, .baseBranch,
-        .coderabbitComments (array of {body, updated_at, path, html_url}),
-        .invokerTasks (the Invoker tasks that produced this PR, or null if none).
+Context JSON for this PR:
+$ctx_json
 
 Do this:
-1. Read the CodeRabbit comments in $ctx. Also read the actual change under review:
+1. Read the CodeRabbit comments in the JSON context. Also read the actual change under review:
    'git log origin/$base..HEAD' and 'git diff origin/$base...HEAD', plus the Invoker task list.
 2. For EACH distinct CodeRabbit concern, decide whether it is genuinely valid (a real bug,
    correctness, or safety issue) — not style noise or a false positive.
@@ -84,19 +71,51 @@ Do this:
       'set -euo pipefail', derive the repo root, print a clear PASS/FAIL).
    b. Implement the minimal fix so the repro passes.
 4. For concerns you judge NOT valid, take no code action.
-5. Commit the repro(s) + fix(es) with a clear message and 'git push' to the PR head branch.
+5. If NO concern is valid, make no code changes and explain that in your task summary.
 
 Constraints: change ONLY what the valid concerns require. Do NOT reformat unrelated code, bump
-versions, or touch files outside a concern's scope. If NO concern is valid, make no commit and
-exit without pushing.
+versions, or touch files outside a concern's scope. Leave the branch ready for Invoker's merge
+gate to publish the fix back to the PR branch.
 EOF
 }
 
-launch_omp() {
-  # launch_omp <num> <pr_title> <head_branch> <base_branch>; exits the script.
+write_repair_plan() {
+  # write_repair_plan <path> <name> <description> <head_branch> <task_id> <task_description> <prompt>
+  #
+  # Both baseBranch and featureBranch are the PR head branch on purpose. The
+  # repair must layer its fix on TOP of the PR's existing commits and push the
+  # result back to that same branch. If baseBranch were the PR base, Invoker's
+  # merge gate would rebuild the head branch from base + the fix and force-push
+  # that, discarding the PR author's own commits. Manual mergeMode means the
+  # gate parks at review_ready after pushing the head branch and never
+  # squash-merges to base, so base == feature is safe here.
+  local plan_path="$1" plan_name="$2" plan_description="$3" head_branch="$4"
+  local task_id="$5" task_description="$6" prompt="$7"
+  {
+    printf 'name: %s\n' "$(json_quote "$plan_name")"
+    printf 'description: %s\n' "$(json_quote "$plan_description")"
+    printf 'repoUrl: %s\n' "$(json_quote "$REPO_URL")"
+    printf 'baseBranch: %s\n' "$(json_quote "$head_branch")"
+    printf 'featureBranch: %s\n' "$(json_quote "$head_branch")"
+    printf 'onFinish: merge\n'
+    printf 'mergeMode: manual\n'
+    printf 'tasks:\n'
+    printf '  - id: %s\n' "$(json_quote "$task_id")"
+    printf '    description: %s\n' "$(json_quote "$task_description")"
+    printf '    executionAgent: omp\n'
+    if [ -n "${INVOKER_PR_CRON_OMP_MODEL:-}" ]; then
+      printf '    executionModel: %s\n' "$(json_quote "$INVOKER_PR_CRON_OMP_MODEL")"
+    fi
+    printf '    prompt: |\n'
+    printf '%s\n' "$prompt" | sed 's/^/      /'
+  } > "$plan_path"
+}
+
+submit_repair_workflow() {
+  # submit_repair_workflow <num> <pr_title> <head_branch> <base_branch>; exits the script.
   local num="$1" pr_title="$2" head_branch="$3" base_branch="$4"
 
-  # Count every real attempt (not just successes) so repeated failures hit the
+  # Count every real attempt (not just successes) so repeated submit failures hit the
   # cap instead of retrying forever; dedup still keys off the success marker.
   ledger_record coderabbit-attempt "$num" "$LATEST_MARKER"
 
@@ -113,48 +132,50 @@ launch_omp() {
     log_line "PR #$num: review-gate lookup failed; proceeding without task context"
   fi
 
-  local pr_view pr_body
+  local pr_view pr_body ctx_json marker_slug plan_path prompt workflow_id="" submit_output=""
   pr_view="$(gh_json pr view "$num" --repo "$TARGET_REPO" --json title,body,headRefName,baseRefName || printf '{}')"
   pr_body="$(jq -r '.body // ""' <<<"$pr_view")"
-
-  local ctx_file
-  ctx_file="$(mktemp -t invoker-cr-ctx.XXXXXX)"
-  jq -n --arg pr "$num" --arg title "$pr_title" --arg body "$pr_body" \
+  ctx_json="$(jq -n --arg pr "$num" --arg title "$pr_title" --arg body "$pr_body" \
         --arg head "$head_branch" --arg base "$base_branch" \
         --argjson comments "$COLLECTED_COMMENTS" --argjson tasks "$tasks" '
     { pr: ($pr | tonumber), prTitle: $title, prBody: $body,
       headBranch: $head, baseBranch: $base,
       coderabbitComments: $comments, invokerTasks: $tasks }
-  ' > "$ctx_file"
+  ')"
 
-  if ! prepare_checkout "$num"; then
-    rm -f "$ctx_file"
-    exit 1
-  fi
+  mkdir -p "$WORKDIR"
+  marker_slug="$(slugify_marker "$LATEST_MARKER")"
+  plan_path="$WORKDIR/coderabbit-pr-${num}-${marker_slug}.yaml"
+  prompt="$(build_prompt "$num" "$base_branch" "$head_branch" "$ctx_json")"
+  write_repair_plan \
+    "$plan_path" \
+    "CodeRabbit repair PR #$num @ $LATEST_MARKER" \
+    "Address CodeRabbit feedback batch from $LATEST_MARKER on PR #$num through a dedicated Invoker repair workflow." \
+    "$head_branch" \
+    "coderabbit-repair-pr-$num" \
+    "Address CodeRabbit review feedback for PR #$num" \
+    "$prompt"
 
-  local omp_cmd prompt
-  omp_cmd="${INVOKER_OMP_COMMAND:-omp}"
-  prompt="$(build_prompt "$num" "$base_branch" "$head_branch" "$ctx_file")"
-  local omp_args=(--no-title --auto-approve)
-  [ -n "${INVOKER_PR_CRON_OMP_MODEL:-}" ] && omp_args+=(--model "$INVOKER_PR_CRON_OMP_MODEL")
-  omp_args+=(-p "$prompt")
-
-  log_line "PR #$num: launching omp on $CHECKOUT_DIR"
-  # omp reads $ctx_file during the run, so clean it up only after omp returns.
-  # Bound the run so a hung omp cannot hold the shared cron lock indefinitely;
-  # a timeout exits non-zero and is handled exactly like any other failure.
-  local omp_run=("$omp_cmd" "${omp_args[@]}")
-  if command -v timeout >/dev/null 2>&1; then
-    omp_run=(timeout --kill-after=1m "${INVOKER_PR_CRON_OMP_TIMEOUT:-45m}" "$omp_cmd" "${omp_args[@]}")
-  fi
-  if ( cd "$CHECKOUT_DIR" && "${omp_run[@]}" ); then
-    rm -f "$ctx_file"
-    ledger_record coderabbit "$num" "$LATEST_MARKER"
-    log_line "PR #$num: omp addressed CodeRabbit feedback; recorded marker $LATEST_MARKER"
+  if [ "$DRY_RUN" = "1" ]; then
+    log_line "PR #$num: would submit repair workflow $plan_path for new CodeRabbit activity at $LATEST_MARKER"
     exit 0
   fi
-  rm -f "$ctx_file"
-  log_line "PR #$num: omp exited non-zero; not recording (retry next tick)"
+
+  log_line "PR #$num: submitting repair workflow $plan_path"
+  if submit_output="$("$SUBMIT_CMD" "$plan_path" 2>&1)"; then
+    [ -n "$submit_output" ] && printf '%s\n' "$submit_output"
+    ledger_record coderabbit "$num" "$LATEST_MARKER"
+    workflow_id="$(printf '%s\n' "$submit_output" | sed -n 's/^Workflow ID: //p' | sed -n '1p')"
+    if [ -n "$workflow_id" ]; then
+      log_line "PR #$num: submitted CodeRabbit repair workflow $workflow_id; recorded marker $LATEST_MARKER"
+    else
+      log_line "PR #$num: submitted CodeRabbit repair workflow; recorded marker $LATEST_MARKER"
+    fi
+    exit 0
+  fi
+
+  [ -n "$submit_output" ] && printf '%s\n' "$submit_output" >&2
+  log_line "PR #$num: repair workflow submit failed; not recording (retry next tick)"
   exit 1
 }
 
@@ -204,8 +225,8 @@ while IFS= read -r pr; do
   fi
 
   # Per-feedback-batch attempt cap: counts attempts for THIS comment marker
-  # (incl. failed omp runs), so repeated failures on the same feedback stop but
-  # genuinely new CodeRabbit comments still get a fresh budget.
+  # (incl. failed submit runs), so repeated failures on the same feedback stop
+  # but genuinely new CodeRabbit comments still get a fresh budget.
   if [ "$(ledger_count coderabbit-attempt "$num" "$LATEST_MARKER")" -ge "$MAX_CODERABBIT_ATTEMPTS" ]; then
     log_line "PR #$num: CodeRabbit address hit cap of $MAX_CODERABBIT_ATTEMPTS; skip"
     continue
@@ -216,12 +237,7 @@ while IFS= read -r pr; do
     continue
   fi
 
-  if [ "$DRY_RUN" = "1" ]; then
-    log_line "PR #$num: would launch omp for new CodeRabbit activity at $LATEST_MARKER"
-    exit 0
-  fi
-
-  launch_omp "$num" "$pr_title" "$head_branch" "$base_branch"
+  submit_repair_workflow "$num" "$pr_title" "$head_branch" "$base_branch"
 done < <(jq -c '.[]' <<<"$prs_json")
 
 log_line "no PRs with new CodeRabbit feedback this tick"

--- a/scripts/repro/repro-coderabbit-address-dedup.sh
+++ b/scripts/repro/repro-coderabbit-address-dedup.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Dedup proof for the native coderabbit-address worker path:
-#   1. a PR with a coderabbitai[bot] comment updated at T -> "would launch omp ... at T"
+#   1. a PR with a coderabbitai[bot] comment updated at T -> "would submit repair workflow ... at T"
 #   2. once T is in the ledger -> "no new CodeRabbit comments since T; skip"
-#   3. a newer comment T2 -> "would launch omp ... at T2" again
+#   3. a newer comment T2 -> "would submit repair workflow ... at T2" again
 #   4. once the per-PR attempt cap is reached -> "hit cap"
 #
 # Runs fully offline through `./run.sh --headless worker coderabbit-address`
@@ -103,12 +103,12 @@ T1="2026-06-25T08:00:00Z"
 T2="2026-06-25T09:30:00Z"
 T3="2026-06-25T11:45:00Z"
 
-# Check 1: new feedback at T1 -> would launch omp.
+# Check 1: new feedback at T1 -> would submit a repair workflow.
 out="$(INVOKER_TEST_CR_UPDATED="$T1" run)"
-echo "$out" | grep -q "would launch omp for new CodeRabbit activity at $T1" \
-  || fail "check 1: expected 'would launch omp ... at $T1'" "$out"
+echo "$out" | grep -q "would submit repair workflow .* new CodeRabbit activity at $T1" \
+  || fail "check 1: expected 'would submit repair workflow ... at $T1'" "$out"
 
-# Record marker T1, as a successful omp run would.
+# Record marker T1, as a successful repair-workflow submission would.
 printf 'coderabbit\t777\t%s\t%s\n' "$T1" "$(date +%s)" >> "$LEDGER"
 
 # Check 2: same latest T1 -> skip.
@@ -116,10 +116,10 @@ out="$(INVOKER_TEST_CR_UPDATED="$T1" run)"
 echo "$out" | grep -q "no new CodeRabbit comments since $T1; skip" \
   || fail "check 2: expected 'no new CodeRabbit comments since $T1; skip'" "$out"
 
-# Check 3: newer T2 -> would launch again.
+# Check 3: newer T2 -> would submit again.
 out="$(INVOKER_TEST_CR_UPDATED="$T2" run)"
-echo "$out" | grep -q "would launch omp for new CodeRabbit activity at $T2" \
-  || fail "check 3: expected 'would launch omp ... at $T2'" "$out"
+echo "$out" | grep -q "would submit repair workflow .* new CodeRabbit activity at $T2" \
+  || fail "check 3: expected 'would submit repair workflow ... at $T2'" "$out"
 
 # Check 4: reach the cap. The cap is scoped to the CURRENT comment marker, so
 # seed three attempt rows for T3; that exact batch is then capped.
@@ -133,7 +133,7 @@ echo "$out" | grep -q "hit cap" \
 # Check 5: a NEWER comment T4 gets a fresh budget (cap is per-batch, not per-PR).
 T4="2026-06-25T12:00:00Z"
 out="$(INVOKER_TEST_CR_UPDATED="$T4" run)"
-echo "$out" | grep -q "would launch omp for new CodeRabbit activity at $T4" \
+echo "$out" | grep -q "would submit repair workflow .* new CodeRabbit activity at $T4" \
   || fail "check 5: newer feedback T4 must get a fresh budget, not stay capped" "$out"
 
 echo "[repro] passed"

--- a/scripts/repro/repro-coderabbit-workflow-e2e.sh
+++ b/scripts/repro/repro-coderabbit-workflow-e2e.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Self-contained END-TO-END proof for the coderabbit-address worker.
+#
+# Drives the REAL worker (scripts/cron-coderabbit-address.sh) against a LOCAL
+# bare git repo standing in for GitHub — no network, no gh auth, no real LLM:
+#
+#   fake `gh`      -> serves the PR list, the CodeRabbit comment, and PR view
+#   stubbed `omp`  -> the execution agent; writes a deterministic fix in the
+#                     task worktree (Invoker auto-commits it)
+#   real submit    -> the worker calls the real submit-plan.sh, which runs a
+#                     real headless Invoker workflow (task -> merge gate)
+#
+# It proves the full chain: detect feedback -> build plan -> submit workflow ->
+# agent fixes on the PR head branch -> merge gate force-pushes the repaired
+# head branch back to origin, PRESERVING the PR's existing commits and WITHOUT
+# touching the base branch.
+#
+# Skips cleanly (exit 0) if the app bundle is not built.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+if [ ! -f packages/app/dist/main.js ]; then
+  echo "[e2e] SKIP: packages/app/dist/main.js not built (run: pnpm --filter @invoker/app build)"
+  exit 0
+fi
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-coderabbit-e2e.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+fail() { echo "[e2e] FAIL: $1"; [ -n "${2:-}" ] && { echo "----- log -----"; cat "$2"; }; exit 1; }
+
+BARE="$TMP/repo.git"
+SEED="$TMP/seed"
+HEAD_BRANCH="feature/coderabbit-e2e"
+BASE_BRANCH="master"
+PR_NUM=4321
+MARKER="2026-07-27T10:00:00Z"
+export GIT_AUTHOR_NAME="cr-e2e" GIT_AUTHOR_EMAIL="cr-e2e@invoker"
+export GIT_COMMITTER_NAME="cr-e2e" GIT_COMMITTER_EMAIL="cr-e2e@invoker"
+
+# --- Local "GitHub": bare origin with master + a PR head branch that carries
+#     the PR author's own commit (which the repair must preserve). ------------
+git init --bare -q "$BARE"
+git --git-dir="$BARE" symbolic-ref HEAD "refs/heads/$BASE_BRANCH"
+git init -q "$SEED"
+git -C "$SEED" config user.email cr-e2e@invoker
+git -C "$SEED" config user.name cr-e2e
+printf 'export function read(r){ return r.data[0]; }\n' > "$SEED/api.js"
+git -C "$SEED" add api.js
+git -C "$SEED" commit -qm "seed: api"
+git -C "$SEED" branch -M "$BASE_BRANCH"
+git -C "$SEED" remote add origin "$BARE"
+git -C "$SEED" push -q origin "$BASE_BRANCH"
+git -C "$SEED" checkout -q -b "$HEAD_BRANCH"
+printf 'export const FEATURE = true;\n' > "$SEED/feature.js"   # the PR author's own work
+git -C "$SEED" add feature.js
+git -C "$SEED" commit -qm "feat: add feature.js (PR author commit)"
+git -C "$SEED" push -q origin "$HEAD_BRANCH"
+PR_HEAD_SHA="$(git --git-dir="$BARE" rev-parse "$HEAD_BRANCH")"
+
+# --- Stubs on PATH ----------------------------------------------------------
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/gh" <<GH
+#!/usr/bin/env bash
+case "\${1:-}" in
+  pr)
+    case "\${2:-}" in
+      list)
+        printf '%s\n' '[{"number":$PR_NUM,"url":"https://github.com/owner/repo/pull/$PR_NUM","headRefName":"$HEAD_BRANCH","baseRefName":"$BASE_BRANCH","title":"Add feature"}]'
+        exit 0 ;;
+      view)
+        # Orphan guard asks for mergeable/mergeStateStatus/statusCheckRollup;
+        # submit path asks for title/body/head/base. One clean payload serves both.
+        printf '%s\n' '{"title":"Add feature","body":"Adds the feature.","headRefName":"$HEAD_BRANCH","baseRefName":"$BASE_BRANCH","mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","statusCheckRollup":[]}'
+        exit 0 ;;
+    esac ;;
+  api)
+    case "\${2:-}" in
+      */pulls/*/comments)
+        printf '%s\n' '[{"user":{"login":"coderabbitai[bot]"},"body":"read() dereferences r.data without a null guard.","updated_at":"$MARKER","path":"api.js","html_url":"https://github.com/owner/repo/pull/$PR_NUM#discussion_r1"}]'
+        exit 0 ;;
+      */issues/*/comments)
+        printf '[]\n'; exit 0 ;;
+    esac ;;
+esac
+echo "fake gh: unhandled: \$*" >&2; exit 1
+GH
+chmod +x "$TMP/bin/gh"
+
+# Stubbed omp execution agent: apply a deterministic fix in the worktree.
+# Invoker auto-commits and pushes the task branch; the agent must NOT commit.
+cat > "$TMP/bin/omp" <<'OMP'
+#!/usr/bin/env bash
+set -euo pipefail
+# A real fix layered on top of the PR head checkout.
+printf 'export function read(r){ if (!r || !r.data) return undefined; return r.data[0]; }\n' > api.js
+printf 'coderabbit fix: null guard added\n' > coderabbit-fix.txt
+exit 0
+OMP
+chmod +x "$TMP/bin/omp"
+
+cat > "$TMP/review-gate.sh" <<'RG'
+#!/usr/bin/env bash
+printf '{}\n'
+RG
+chmod +x "$TMP/review-gate.sh"
+
+echo '{"autoFixRetries":0}' > "$TMP/config.json"
+
+# --- Run the REAL worker end-to-end ----------------------------------------
+echo "[e2e] running coderabbit-address worker against local origin $BARE"
+LOG="$TMP/worker.log"
+set +e
+env \
+  PATH="$TMP/bin:$PATH" \
+  HOME="$TMP/home" \
+  INVOKER_DB_DIR="$TMP/home/.invoker" \
+  INVOKER_REPO_CONFIG_PATH="$TMP/config.json" \
+  INVOKER_HEADLESS_STANDALONE=1 \
+  INVOKER_OMP_COMMAND="$TMP/bin/omp" \
+  INVOKER_GITHUB_TARGET_REPO="owner/repo" \
+  INVOKER_PR_CRON_AUTHOR="cr-e2e-author" \
+  INVOKER_PR_CRON_DRY_RUN=0 \
+  INVOKER_PR_CODERABBIT_STATE_FILE="$TMP/ledger.tsv" \
+  INVOKER_PR_CRON_LOCK="$TMP/crons.lock" \
+  INVOKER_PR_CRON_WORKDIR="$TMP/work" \
+  INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh" \
+  INVOKER_PR_CODERABBIT_REPO_URL="file://$BARE" \
+  bash scripts/cron-coderabbit-address.sh > "$LOG" 2>&1
+WORKER_CODE=$?
+set -e
+sed 's/^/[worker] /' "$LOG" | tail -25
+
+# --- Assertions -------------------------------------------------------------
+[ "$WORKER_CODE" -eq 0 ] || fail "worker exited non-zero ($WORKER_CODE)" "$LOG"
+
+grep -q "submitted CodeRabbit repair workflow" "$LOG" \
+  || fail "worker did not report a submitted repair workflow" "$LOG"
+
+awk -F '\t' -v m="$MARKER" '$1=="coderabbit" && $2=="'"$PR_NUM"'" && $3==m { ok=1 } END { exit ok?0:1 }' "$TMP/ledger.tsv" \
+  || fail "success marker for PR #$PR_NUM @ $MARKER not recorded" "$LOG"
+
+NEW_HEAD_SHA="$(git --git-dir="$BARE" rev-parse "$HEAD_BRANCH")"
+[ "$NEW_HEAD_SHA" != "$PR_HEAD_SHA" ] \
+  || fail "PR head branch $HEAD_BRANCH did not advance (still $PR_HEAD_SHA)" "$LOG"
+
+git --git-dir="$BARE" cat-file -e "$HEAD_BRANCH:coderabbit-fix.txt" 2>/dev/null \
+  || fail "fix file not pushed to PR head branch $HEAD_BRANCH" "$LOG"
+
+# The PR author's own commit must survive (the fix layers ON TOP, not a rebuild).
+git --git-dir="$BARE" cat-file -e "$HEAD_BRANCH:feature.js" 2>/dev/null \
+  || fail "PR author's feature.js was LOST from $HEAD_BRANCH (head rebuilt from base?)" "$LOG"
+
+# The fix actually changed the reviewed file.
+git --git-dir="$BARE" show "$HEAD_BRANCH:api.js" | grep -q "null guard\|!r.data\|return undefined" \
+  || fail "api.js on $HEAD_BRANCH does not contain the fix" "$LOG"
+
+# Manual mergeMode must NOT advance the base branch.
+if git --git-dir="$BARE" cat-file -e "$BASE_BRANCH:coderabbit-fix.txt" 2>/dev/null; then
+  fail "fix leaked onto base branch $BASE_BRANCH (manual mode must not squash-merge)" "$LOG"
+fi
+
+echo "[e2e] PASS: worker submitted a repair workflow; merge gate pushed the fix"
+echo "[e2e]       onto $HEAD_BRANCH ($PR_HEAD_SHA -> $NEW_HEAD_SHA), preserved the"
+echo "[e2e]       PR author's feature.js, and left $BASE_BRANCH untouched."
+echo "[repro] passed"

--- a/scripts/repro/repro-pr-cron-attempt-cap.sh
+++ b/scripts/repro/repro-pr-cron-attempt-cap.sh
@@ -2,7 +2,7 @@
 # End-to-end proof that the PR cron jobs cannot retry a failing operation
 # forever (CodeRabbit findings: count attempts, not just successes).
 #
-# Before the fix both jobs only recorded SUCCESS markers, so a failed omp run
+# Before the fix both jobs only recorded SUCCESS markers, so a failed submit
 # (Job 1) or an accepted-but-unconfirmed rebase-recreate (Job 2) recorded
 # nothing and re-fired every tick indefinitely. The fix records an attempt on
 # every real try and caps on that ledger.
@@ -11,8 +11,9 @@
 # offline with fakes:
 #   Job 2: fake `node` accepts the dispatch; CONFIRM_TIMEOUT=0 means it never
 #          confirms -> each run records one rebase-recreate-attempt and exits 1.
-#   Job 1: fake `gh repo clone` fails -> prepare_checkout fails after the
-#          attempt is recorded -> each run records one coderabbit-attempt, exits 1.
+#   Job 1: fake submit command exits 1 AFTER the repair plan is generated ->
+#          each run records one coderabbit-attempt, exits 1, and does not record
+#          the success marker.
 # After MAX attempts the next run hits the cap instead of dispatching again.
 set -euo pipefail
 
@@ -117,7 +118,7 @@ echo "$out" | grep -q "giving up" \
   || fail "Job 2: 4th run must hit the cap (giving up), not dispatch again" "$out"
 
 # ---------------------------------------------------------------------------
-# Job 1 — omp attempt fails (clone fails) but the attempt is still counted.
+# Job 1 — repair workflow submit fails but the attempt is still counted.
 # ---------------------------------------------------------------------------
 cat > "$TMP/bin/gh" <<'GH'
 #!/usr/bin/env bash
@@ -132,33 +133,36 @@ case "${1:-}" in
       */pulls/*/comments) printf '%s\n' '[{"user":{"login":"coderabbitai[bot]"},"body":"x","updated_at":"2026-06-25T10:00:00Z"}]'; exit 0;;
       */issues/*/comments) printf '[]\n'; exit 0;;
     esac;;
-  repo)
-    # Force prepare_checkout to fail AFTER the attempt has been recorded.
-    [ "${2:-}" = "clone" ] && exit 1;;
 esac
 echo "fake gh: unhandled: $*" >&2; exit 1
 GH
 chmod +x "$TMP/bin/gh"
 
 # Job 1's task context is irrelevant to the attempt cap; return an empty result
-# so launch_omp skips the (real) tasks query and stays fully offline.
+# so the worker stays fully offline. The submit stub fails after the plan is
+# generated, so each tick records one attempt without the success marker.
 cat > "$TMP/review-gate-empty.sh" <<'RG'
 #!/usr/bin/env bash
 printf '{}\n'
 RG
-chmod +x "$TMP/review-gate-empty.sh"
+cat > "$TMP/submit-fail.sh" <<'SUBMIT'
+#!/usr/bin/env bash
+echo "fake submit failure for $1" >&2
+exit 1
+SUBMIT
+chmod +x "$TMP/review-gate-empty.sh" "$TMP/submit-fail.sh"
 
 J1_LEDGER="$TMP/j1.tsv"; : > "$J1_LEDGER"
 J1_CONFIG="$TMP/j1-config.json"
 cat > "$J1_CONFIG" <<EOF
-{"prMaintenance":{"enabled":true,"repoRoot":"$ROOT","lockPath":"$TMP/j1.lock","env":{"PATH":"$TMP/bin:$PATH","INVOKER_PR_CRON_DRY_RUN":"0","INVOKER_PR_CODERABBIT_STATE_FILE":"$J1_LEDGER","INVOKER_PR_CRON_LOCK":"$TMP/j1.lock","INVOKER_PR_CRON_WORKDIR":"$TMP/work","INVOKER_PR_CRON_REVIEW_GATE_CMD":"$TMP/review-gate-empty.sh"}}}
+{"prMaintenance":{"enabled":true,"repoRoot":"$ROOT","lockPath":"$TMP/j1.lock","env":{"PATH":"$TMP/bin:$PATH","INVOKER_PR_CRON_DRY_RUN":"0","INVOKER_PR_CODERABBIT_STATE_FILE":"$J1_LEDGER","INVOKER_PR_CRON_LOCK":"$TMP/j1.lock","INVOKER_PR_CRON_WORKDIR":"$TMP/work","INVOKER_PR_CRON_REVIEW_GATE_CMD":"$TMP/review-gate-empty.sh","INVOKER_PR_CODERABBIT_SUBMIT_CMD":"$TMP/submit-fail.sh"}}}
 EOF
 run_job1() { run_native_worker coderabbit-address "$J1_CONFIG"; }
 
 for i in 1 2 3; do
   out="$(run_job1 || true)"
-  echo "$out" | grep -q "clone failed" \
-    || fail "Job 1 run $i: expected the omp checkout to fail" "$out"
+  echo "$out" | grep -q "repair workflow submit failed" \
+    || fail "Job 1 run $i: expected the repair-workflow submit to fail" "$out"
 done
 n="$(awk -F'\t' '$1=="coderabbit-attempt" && $2=="556"{c++} END{print c+0}' "$J1_LEDGER")"
 [ "$n" -eq 3 ] || fail "Job 1: expected 3 recorded attempts, got $n"

--- a/scripts/test-coderabbit-address-submit.sh
+++ b/scripts/test-coderabbit-address-submit.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Behavior test for scripts/cron-coderabbit-address.sh after the repair-workflow
+# cutover. No real Invoker, no network, no repo checkout.
+#
+# Covers:
+#   A. Dry-run: logs the intended repair-workflow submission, writes a YAML plan,
+#      and never calls the submit command.
+#   B. Real run: submits exactly once, records the success marker, and surfaces
+#      the workflow id from the submit path.
+#   C. Dedup: once the marker is recorded, the same feedback batch is skipped.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+WORKER="$REPO_ROOT/scripts/cron-coderabbit-address.sh"
+UPDATED="2026-07-01T12:34:56Z"
+HEAD_BRANCH="feature/coderabbit-fix"
+BASE_BRANCH="main"
+PR_TITLE="Keep PR title"
+PR_BODY="Keep PR body"
+COMMENT_BODY="Please add a null guard before reading response.data"
+
+SANDBOXES=()
+cleanup() { local d; for d in ${SANDBOXES[@]+"${SANDBOXES[@]}"}; do rm -rf "$d"; done; return 0; }
+trap cleanup EXIT
+
+fail() { echo "FAIL: $1" >&2; [ -n "${2:-}" ] && { echo "----- log -----" >&2; cat "$2" >&2; }; exit 1; }
+
+run_worker() {
+  local dry_run="$1"
+  sb="$(mktemp -d "${TMPDIR:-/tmp}/test-coderabbit-submit.XXXXXX")"
+  SANDBOXES+=("$sb")
+  mkdir -p "$sb/bin" "$sb/work"
+  calls="$sb/submit-calls"
+  ledger="$sb/ledger.tsv"
+  : > "$ledger"
+
+  cat > "$sb/bin/gh" <<GH
+#!/usr/bin/env bash
+case "\${1:-}" in
+  pr)
+    case "\${2:-}" in
+      list)
+        printf '%s\n' '[{"number":777,"url":"https://github.com/owner/repo/pull/777","headRefName":"$HEAD_BRANCH","baseRefName":"$BASE_BRANCH","title":"$PR_TITLE"}]'
+        exit 0 ;;
+      view)
+        printf '%s\n' '{"title":"$PR_TITLE","body":"$PR_BODY","headRefName":"$HEAD_BRANCH","baseRefName":"$BASE_BRANCH"}'
+        exit 0 ;;
+    esac ;;
+  api)
+    case "\${2:-}" in
+      */pulls/*/comments)
+        printf '%s\n' '[{"user":{"login":"coderabbitai[bot]"},"body":"$COMMENT_BODY","updated_at":"$UPDATED","path":"src/app.ts","html_url":"https://github.com/owner/repo/pull/777#discussion_r1"}]'
+        exit 0 ;;
+      */issues/*/comments)
+        printf '[]\n'
+        exit 0 ;;
+    esac ;;
+esac
+echo "fake gh: unhandled: \$*" >&2
+exit 1
+GH
+  chmod +x "$sb/bin/gh"
+
+  cat > "$sb/review-gate-empty.sh" <<'RG'
+#!/usr/bin/env bash
+printf '{}\n'
+RG
+  chmod +x "$sb/review-gate-empty.sh"
+
+  cat > "$sb/bin/submit-stub" <<STUB
+#!/usr/bin/env bash
+echo "\$1" >> "$calls"
+printf 'Workflow ID: wf-coderabbit-submit-test\n'
+exit 0
+STUB
+  chmod +x "$sb/bin/submit-stub"
+
+  log="$sb/worker.log"
+  env \
+    PATH="$sb/bin:$PATH" \
+    INVOKER_PR_CRON_DRY_RUN="$dry_run" \
+    INVOKER_PR_CODERABBIT_STATE_FILE="$ledger" \
+    INVOKER_PR_CRON_LOCK="$sb/coderabbit.lock" \
+    INVOKER_PR_CRON_WORKDIR="$sb/work" \
+    INVOKER_PR_CRON_REVIEW_GATE_CMD="$sb/review-gate-empty.sh" \
+    INVOKER_PR_CODERABBIT_SUBMIT_CMD="$sb/bin/submit-stub" \
+    INVOKER_PR_CODERABBIT_REPO_URL="git@github.com:Neko-Catpital-Labs/Invoker.git" \
+    bash "$WORKER" > "$log" 2>&1 || true
+}
+
+# A. Dry-run: intended submission only; valid YAML plan.
+run_worker 1
+[ ! -s "$calls" ] || fail "A: submit command must not run in dry-run" "$log"
+grep -q "would submit repair workflow" "$log" \
+  || fail "A: dry-run did not log the intended repair-workflow submission" "$log"
+plan="$(printf '%s\n' "$sb"/work/coderabbit-pr-777-*.yaml | sed -n '1p')"
+[ -f "$plan" ] || fail "A: expected generated repair plan YAML" "$log"
+PLAN="$plan" UPDATED="$UPDATED" HEAD_BRANCH="$HEAD_BRANCH" BASE_BRANCH="$BASE_BRANCH" COMMENT_BODY="$COMMENT_BODY" PR_BODY="$PR_BODY" node <<'NODE' >/dev/null \
+  || fail "A: generated plan YAML is not the expected repair-workflow shape" "$log"
+const YAML = require("yaml");
+const fs = require("fs");
+const d = YAML.parse(fs.readFileSync(process.env.PLAN, "utf8"));
+if (d.onFinish !== "merge") throw new Error("onFinish=" + d.onFinish);
+if (d.mergeMode !== "manual") throw new Error("mergeMode=" + d.mergeMode);
+// baseBranch AND featureBranch must both be the PR head branch, so the fix
+// layers on top of the PR's commits instead of rebuilding from the PR base.
+if (d.baseBranch !== process.env.HEAD_BRANCH) throw new Error("baseBranch=" + d.baseBranch);
+if (d.featureBranch !== process.env.HEAD_BRANCH) throw new Error("featureBranch=" + d.featureBranch);
+if (!Array.isArray(d.tasks) || d.tasks.length !== 1) throw new Error("expected one task");
+if (d.tasks[0].executionAgent !== "omp") throw new Error("executionAgent=" + d.tasks[0].executionAgent);
+const prompt = d.tasks[0].prompt || "";
+if (!prompt.includes("do not run 'git push' manually")) throw new Error("missing no-push instruction");
+if (!prompt.includes(process.env.COMMENT_BODY)) throw new Error("missing comment body");
+if (!prompt.includes(process.env.PR_BODY)) throw new Error("missing PR body context");
+if (!prompt.includes(process.env.UPDATED)) throw new Error("missing feedback timestamp");
+NODE
+echo "  A ok: dry-run writes the repair workflow plan and does not submit"
+
+# B. Real run: submits once, records marker, surfaces workflow id.
+run_worker 0
+[ "$(wc -l < "$calls")" -eq 1 ] || fail "B: expected exactly one submission" "$log"
+grep -q "coderabbit-pr-777-" "$calls" || fail "B: submitted the wrong plan path" "$log"
+awk -F '\t' -v marker="$UPDATED" '$1=="coderabbit" && $2=="777" && $3==marker { found=1 } END { exit found ? 0 : 1 }' "$ledger" \
+  || fail "B: success marker was not recorded" "$log"
+grep -q "submitted CodeRabbit repair workflow wf-coderabbit-submit-test" "$log" \
+  || fail "B: workflow id was not surfaced after submit" "$log"
+echo "  B ok: real run submits once and records the feedback marker"
+
+# C. Dedup: same feedback batch skips after marker recorded.
+env \
+  PATH="$sb/bin:$PATH" \
+  INVOKER_PR_CRON_DRY_RUN=0 \
+  INVOKER_PR_CODERABBIT_STATE_FILE="$ledger" \
+  INVOKER_PR_CRON_LOCK="$sb/coderabbit.lock" \
+  INVOKER_PR_CRON_WORKDIR="$sb/work" \
+  INVOKER_PR_CRON_REVIEW_GATE_CMD="$sb/review-gate-empty.sh" \
+  INVOKER_PR_CODERABBIT_SUBMIT_CMD="$sb/bin/submit-stub" \
+  INVOKER_PR_CODERABBIT_REPO_URL="git@github.com:Neko-Catpital-Labs/Invoker.git" \
+  bash "$WORKER" > "$sb/worker2.log" 2>&1 || true
+grep -q "no new CodeRabbit comments since $UPDATED; skip" "$sb/worker2.log" \
+  || fail "C: same feedback batch did not dedup after marker was recorded" "$sb/worker2.log"
+[ "$(wc -l < "$calls")" -eq 1 ] || fail "C: dedup run must not submit again" "$sb/worker2.log"
+echo "  C ok: same feedback batch is skipped after submission marker"
+
+echo "PASS: coderabbit repair workflow submission verified (dry-run, submit, dedup)"
+exit 0


### PR DESCRIPTION
## Summary

The CodeRabbit repair path had offline tests for the worker's decision, but nothing exercised the whole pipeline through a real Invoker workflow.

This adds `scripts/repro/repro-coderabbit-workflow-e2e.sh`: a self-contained, network-free end-to-end proof. It stands up a local bare git repo, a fake `gh`, and a stubbed `omp`, then runs the real worker.

The proof asserts the merge gate pushes the fix onto the PR head branch, preserves the PR author's commits, and leaves the base branch untouched.

It also points the dedup and attempt-cap repros at the submit path: the dry-run log is now `would submit repair workflow`, and the attempt-cap Job 1 drives a failing submit stub instead of a failing checkout clone.

## Review Claim

Approve the end-to-end proof and the repro updates that verify the CodeRabbit repair path against a real Invoker workflow.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only. The e2e boots a headless Invoker against a local bare repo with fake `gh` and a stubbed `omp`; it touches no product code and skips cleanly when the app bundle is not built. The dedup and attempt-cap repros run fully offline and assert the same dedup and cap invariants against the new dry-run log line.

## Slice Rationale

These `scripts/repro/` files review as a proof unit, kept out of the base worker PR so the runtime change and its proof land as separate reviewable units. Stacked on the worker PR so the proof runs against the shipped behavior and stays green.

## Non-goals

Does not change the worker script, the submission test, or any product code. Does not require GitHub, `gh` auth, or a real LLM; the live GitHub battle path stays separate under `INVOKER_BATTLE_REPO`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-coderabbit-workflow-e2e.sh`
- [ ] `bash scripts/repro/repro-coderabbit-address-dedup.sh`
- [ ] `bash scripts/repro/repro-pr-cron-attempt-cap.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0e91a21`
- Post-revert steps: None
- Data migration? No

</details>
