### PR TITLE
[Delete planning terminals — UI](1) Add Planning Terminal rail controls

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -47,6 +47,7 @@ import { BrowserTaskRow, BrowserWorkflowRow } from './components/BrowserListRows
 import { useTheme } from './lib/theme.js';
 import { InvokerTerminal, type InvokerTerminalLine, type PlanningTerminalMode } from './components/InvokerTerminal.js';
 import { Toaster, toast } from 'sonner';
+import { Trash2 } from 'lucide-react';
 import { Button } from './components/primitives/index.js';
 import { ChevronDownIcon, PlayIcon } from './components/icons/index.js';
 import { CommandPalette, COMMAND_PALETTE_MAX_ROWS } from './components/CommandPalette.js';
@@ -2981,23 +2982,95 @@ export function App() {
     workflows.size,
   ]);
 
-  const handleCreatePlanningSession = useCallback(() => {
+  const makeFreshLocalPlanningSession = useCallback((): PlanningSessionView => {
     const index = nextPlanningSessionLocalIdRef.current;
     nextPlanningSessionLocalIdRef.current += 1;
     const now = new Date().toISOString();
     const localId = `local-planning-session-${index}`;
-    const session: PlanningSessionView = {
+    return {
       ...makeInitialPlanningSession(now, selectedPlanningConfirmationMode),
       id: localId,
       conversationKey: localId,
       presetKey: selectedPlanningPresetKey,
       confirmationMode: selectedPlanningConfirmationMode,
     };
+  }, [selectedPlanningConfirmationMode, selectedPlanningPresetKey]);
+
+  const handleCreatePlanningSession = useCallback(() => {
+    const session = makeFreshLocalPlanningSession();
     setPlanningSessions((prev) => [session, ...prev]);
     setActivePlanningSessionId(session.id);
     setSidebarSurface('home');
     focusKeyboardRegion('planning');
-  }, [focusKeyboardRegion, selectedPlanningConfirmationMode, selectedPlanningPresetKey]);
+  }, [focusKeyboardRegion, makeFreshLocalPlanningSession]);
+
+  const removePlanningSessionsById = useCallback((sessionIds: string[]) => {
+    const ids = new Set(sessionIds);
+    if (ids.size === 0) return;
+
+    clearPlanningStreamForSessionIds(sessionIds);
+    forgetPlanningStreamAliasesForSessionIds(sessionIds);
+    for (const id of ids) {
+      pendingPlanningStreamSessionIdsRef.current.delete(id);
+    }
+    setKeptPlanningDraftSessionIds((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const id of ids) {
+        if (next.delete(id)) changed = true;
+      }
+      return changed ? next : prev;
+    });
+    setReviewDraftSessionId((current) => (current && ids.has(current) ? null : current));
+
+    const previousSessions = planningSessionsRef.current;
+    const remainingSessions = previousSessions.filter((session) => !ids.has(session.id));
+    if (remainingSessions.length === previousSessions.length) return;
+
+    let nextSessions = remainingSessions;
+    let nextActiveSessionId = activePlanningSessionIdRef.current;
+    if (!nextSessions.some((session) => session.id === nextActiveSessionId)) {
+      if (nextSessions.length === 0) {
+        const session = makeFreshLocalPlanningSession();
+        nextSessions = [session];
+        nextActiveSessionId = session.id;
+      } else {
+        const previousActiveIndex = previousSessions.findIndex((session) => session.id === nextActiveSessionId);
+        nextActiveSessionId = nextSessions[previousActiveIndex]?.id
+          ?? nextSessions[nextSessions.length - 1]?.id
+          ?? nextSessions[0].id;
+      }
+    }
+
+    planningSessionsRef.current = nextSessions;
+    activePlanningSessionIdRef.current = nextActiveSessionId;
+    setPlanningSessions(nextSessions);
+    setActivePlanningSessionId(nextActiveSessionId);
+  }, [clearPlanningStreamForSessionIds, forgetPlanningStreamAliasesForSessionIds, makeFreshLocalPlanningSession]);
+
+  const handleDeletePlanningSession = useCallback((sessionId: string) => {
+    if (activePlanningReadOnly) {
+      return;
+    }
+    if (!sessionId.startsWith('local-')) {
+      void invoker?.planningChatDelete?.({ sessionId });
+    }
+    removePlanningSessionsById([sessionId]);
+  }, [activePlanningReadOnly, invoker, removePlanningSessionsById]);
+
+  const handleClearSubmittedPlanningSessions = useCallback(() => {
+    if (activePlanningReadOnly) {
+      return;
+    }
+    const confirmed = window.confirm('Clear all submitted planning chats? This cannot be undone.');
+    if (!confirmed) return;
+    const submittedIds = planningSessionsRef.current
+      .filter((session) => session.status === 'submitted')
+      .map((session) => session.id);
+    if (submittedIds.length === 0) return;
+    void invoker?.planningChatDeleteSubmitted?.();
+    removePlanningSessionsById(submittedIds);
+  }, [activePlanningReadOnly, invoker, removePlanningSessionsById]);
 
   const handlePlanningModeChange = useCallback(async (mode: PlanningTerminalMode) => {
     const sourceSession = activePlanningSession;
@@ -4262,30 +4335,49 @@ export function App() {
           const selected = session.id === activePlanningSession.id;
           const preview = previewPlanningMessage(session);
           return (
-            <button
+            <div
               key={session.id}
-              type="button"
-              onClick={() => setActivePlanningSessionId(session.id)}
-              className={`flex w-full items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              data-testid="planning-session-row"
+              className={`flex w-full items-stretch ${selected ? 'bg-accent/40' : ''}`}
             >
-              <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-start justify-between gap-2">
-                  <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
-                    {session.title}
+              <button
+                type="button"
+                onClick={() => setActivePlanningSessionId(session.id)}
+                className={`flex w-full min-w-0 flex-1 items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              >
+                <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
+                      {session.title}
+                    </div>
+                    <span className="shrink-0 text-[11px] text-muted-foreground">
+                      {relativePlanningUpdatedAt(session.updatedAt)}
+                    </span>
                   </div>
-                  <span className="shrink-0 text-[11px] text-muted-foreground">
-                    {relativePlanningUpdatedAt(session.updatedAt)}
-                  </span>
+                  <div
+                    className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
+                    title={preview}
+                  >
+                    {preview}
+                  </div>
                 </div>
-                <div
-                  className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
-                  title={preview}
+              </button>
+              {!activePlanningReadOnly && (
+                <button
+                  type="button"
+                  aria-label="Delete planning chat"
+                  title="Delete planning chat"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleDeletePlanningSession(session.id);
+                  }}
+                  className="flex w-9 shrink-0 items-start justify-center px-2 py-2 text-muted-foreground transition-colors hover:bg-red-950/40 hover:text-red-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 >
-                  {preview}
-                </div>
-              </div>
-            </button>
+                  <Trash2 aria-hidden="true" className="mt-0.5 h-3.5 w-3.5" strokeWidth={1.75} />
+                </button>
+              )}
+            </div>
           );
         })}
       </div>
@@ -4293,6 +4385,7 @@ export function App() {
   );
 
   const planningReadyCount = planningSessions.filter((session) => session.status === 'draft_ready').length;
+  const submittedPlanningSessionCount = planningSessions.filter((session) => session.status === 'submitted').length;
   const connectedAgentLabels = (systemDiagnostics?.tools ?? [])
     .filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed)
     .map((tool) => tool.name.replace(/\s+CLI$/i, ''));
@@ -4450,18 +4543,15 @@ export function App() {
           </div>
         ) : (
           <>
-            <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2.5">
-              <div className="min-w-0">
-                <h2 className="text-sm font-medium text-foreground">Planning</h2>
-                <p className="mt-0.5 text-[11px] text-muted-foreground">
-                  {planningSessions.length} chat{planningSessions.length === 1 ? '' : 's'}
-                  {planningReadyCount > 0 ? ` · ${planningReadyCount} ready` : ''}
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                <Button variant="outline" size="sm" onClick={handleCreatePlanningSession}>
-                  New chat
-                </Button>
+            <div className="border-b border-border px-3 py-2.5">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h2 className="text-sm font-medium text-foreground">Planning</h2>
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">
+                    {planningSessions.length} chat{planningSessions.length === 1 ? '' : 's'}
+                    {planningReadyCount > 0 ? ` · ${planningReadyCount} ready` : ''}
+                  </p>
+                </div>
                 <button
                   type="button"
                   data-testid="planning-session-rail-toggle"
@@ -4471,6 +4561,19 @@ export function App() {
                 >
                   ‹
                 </button>
+              </div>
+              <div className="mt-2 flex items-center gap-2">
+                <Button variant="outline" size="sm" onClick={handleCreatePlanningSession}>
+                  New chat
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleClearSubmittedPlanningSessions}
+                  disabled={activePlanningReadOnly || submittedPlanningSessionCount === 0}
+                >
+                  Clear submitted
+                </Button>
               </div>
             </div>
             <div className={RAIL_LIST_FRAME_CLASS}>{renderPlanningSessionList()}</div>

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -224,6 +224,8 @@ export function createMockInvoker(
     })),
     planningChatDiscardDraft: vi.fn(async () => ({ ok: true })),
     planningChatReset: vi.fn(async () => ({ ok: true })),
+    planningChatDelete: vi.fn(async () => ({ ok: true })),
+    planningChatDeleteSubmitted: vi.fn(async () => ({ ok: true, deletedSessionIds: [] })),
     onPlanningChatStream: vi.fn((cb: (event: InAppPlanningStreamEvent) => void) => {
       planningChatStreamCallbacks.add(cb);
       return () => { planningChatStreamCallbacks.delete(cb); };

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -44,6 +44,41 @@ describe('Invoker terminal (component)', () => {
     fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
   }
 
+  function makeRailPlanningSession(
+    id: string,
+    title: string,
+    status: 'still_discussing' | 'submitted' = 'still_discussing',
+    message = title,
+  ) {
+    return makePlanningSessionSummary({
+      id,
+      title,
+      status,
+      messages: [
+        {
+          id: 1,
+          role: 'user',
+          text: message,
+          createdAt: '2026-07-07T00:00:01.000Z',
+        },
+      ],
+      draftPlanAvailable: false,
+      draftPlanSummary: undefined,
+      draftPlanText: undefined,
+      updatedAt: '2026-07-07T00:00:01.000Z',
+    });
+  }
+
+  function getPlanningSessionRowByText(text: string): HTMLElement {
+    const rail = screen.getByTestId('planning-session-list');
+    const textElement = within(rail).getAllByText(text)[0];
+    const row = textElement?.closest('[data-testid="planning-session-row"]');
+    if (!(row instanceof HTMLElement)) {
+      throw new Error(`Missing planning session row for ${text}`);
+    }
+    return row;
+  }
+
   function expectRailListScrollContract(list: HTMLElement) {
     expect(list).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto');
     expect(list.parentElement).toHaveClass('flex', 'min-h-0', 'flex-1', 'flex-col');
@@ -271,8 +306,7 @@ describe('Invoker terminal (component)', () => {
     const secondPanel = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(secondPanel).toHaveTextContent('Drafting your plan…');
 
-    const sessionButtons = within(screen.getByTestId('planning-session-list')).getAllByRole('button');
-    fireEvent.click(sessionButtons[1]);
+    fireEvent.click(within(screen.getByTestId('planning-session-list')).getByRole('button', { name: /first session request/i }));
 
     const firstPanel = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(firstPanel).toHaveTextContent('Drafting your plan…');
@@ -668,6 +702,141 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('2 chats'));
     expect(within(screen.getByTestId('sidebar-home')).queryByText('0')).not.toBeInTheDocument();
     expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('2 chats');
+  });
+
+  it('deletes a saved planning chat from its row trash button', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makeRailPlanningSession('delete-saved-chat', 'Delete saved chat'),
+        makeRailPlanningSession('keep-saved-chat', 'Keep saved chat'),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    const rail = screen.getByTestId('planning-session-list');
+    await waitFor(() => expect(within(rail).getAllByText('Delete saved chat').length).toBeGreaterThan(0));
+
+    fireEvent.click(within(getPlanningSessionRowByText('Delete saved chat')).getByRole('button', { name: 'Delete planning chat' }));
+
+    await waitFor(() => {
+      expect(within(rail).queryByText('Delete saved chat')).not.toBeInTheDocument();
+    });
+    expect(within(rail).getAllByText('Keep saved chat').length).toBeGreaterThan(0);
+    expect(mock.api.planningChatDelete).toHaveBeenCalledWith({ sessionId: 'delete-saved-chat' });
+  });
+
+  it('deletes a local planning chat without calling planningChatDelete', async () => {
+    mock.api.planningChatSend = vi.fn(() => new Promise(() => {}) as any) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('local unsaved planning chat');
+    await waitFor(() => expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
+    fireEvent.click(within(getPlanningSessionRowByText('local unsaved planning chat')).getByRole('button', { name: 'Delete planning chat' }));
+
+    await waitFor(() => {
+      expect(within(screen.getByTestId('planning-session-list')).queryByText('local unsaved planning chat')).not.toBeInTheDocument();
+    });
+    expect(mock.api.planningChatDelete).not.toHaveBeenCalled();
+  });
+
+  it('disables Clear submitted when there are no submitted planning chats', async () => {
+    render(<App />);
+    await openPlanningTerminal();
+
+    const clearButton = screen.getByRole('button', { name: 'Clear submitted' });
+    expect(clearButton).toBeDisabled();
+
+    fireEvent.click(clearButton);
+    expect(mock.api.planningChatDeleteSubmitted).not.toHaveBeenCalled();
+  });
+
+  it('clears all submitted planning chats after confirmation', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makeRailPlanningSession('active-chat', 'Active chat'),
+        makeRailPlanningSession('submitted-chat-1', 'Submitted one', 'submitted'),
+        makeRailPlanningSession('submitted-chat-2', 'Submitted two', 'submitted'),
+      ],
+    }));
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    try {
+      render(<App />);
+      await openPlanningTerminal();
+
+      const rail = screen.getByTestId('planning-session-list');
+      await waitFor(() => expect(within(rail).getAllByText('Submitted one').length).toBeGreaterThan(0));
+      const clearButton = screen.getByRole('button', { name: 'Clear submitted' });
+      expect(clearButton).toBeEnabled();
+
+      fireEvent.click(clearButton);
+
+      await waitFor(() => {
+        expect(within(rail).queryByText('Submitted one')).not.toBeInTheDocument();
+        expect(within(rail).queryByText('Submitted two')).not.toBeInTheDocument();
+      });
+      expect(within(rail).getAllByText('Active chat').length).toBeGreaterThan(0);
+      expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('1 chat');
+      expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
+      expect(confirmSpy).toHaveBeenCalledTimes(1);
+      expect(mock.api.planningChatDeleteSubmitted).toHaveBeenCalledTimes(1);
+    } finally {
+      confirmSpy.mockRestore();
+    }
+  });
+
+  it('recreates a fresh empty chat after deleting the last planning chat', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makeRailPlanningSession('only-saved-chat', 'Only saved chat'),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    await waitFor(() => expect(screen.getByTestId('planning-session-list')).toHaveTextContent('Only saved chat'));
+    fireEvent.click(within(getPlanningSessionRowByText('Only saved chat')).getByRole('button', { name: 'Delete planning chat' }));
+
+    await waitFor(() => {
+      expect(within(screen.getByTestId('planning-session-list')).queryByText('Only saved chat')).not.toBeInTheDocument();
+      expect(screen.getByText('What do you want to build?')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('1 chat');
+    expect(screen.getByTestId('invoker-terminal-input')).toBeEnabled();
+    expect(mock.api.planningChatDelete).toHaveBeenCalledWith({ sessionId: 'only-saved-chat' });
+  });
+
+  it('hides planning chat trash buttons and disables Clear submitted in read-only mode', async () => {
+    mock.setRuntimeStatus({
+      ownerMode: false,
+      readOnly: true,
+      mode: 'read-only',
+    });
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makeRailPlanningSession('readonly-active-chat', 'Readonly active chat'),
+        makeRailPlanningSession('readonly-submitted-chat', 'Readonly submitted chat', 'submitted'),
+      ],
+    }));
+    mock.install();
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    await waitFor(() => expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled());
+    expect(screen.queryByRole('button', { name: 'Delete planning chat' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
   });
 
   it('continues the same planning session', async () => {


### PR DESCRIPTION
## Summary

The Planning Terminal rail gets two new controls: a small trash icon on each chat row, and a header button that clears every already-sent chat at once.

Both actions only run when the rail is not read-only, and the bulk header button asks for confirmation first.

Nothing else about the Planning surface changes; the underlying session APIs already existed.

## Review Claim

Add a per-row trash control and a header bulk-clear control to the Planning Terminal rail.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Both controls are hidden or disabled while the active session is read-only, so a viewer can never trigger a destructive action. The bulk header action requires an explicit native confirm before it runs, and both paths funnel through one local reducer that keeps the active-session selection and stream cleanup consistent, so a partial UI state can't be left behind.

## Slice Rationale

This UI-only control addition is easy to review on its own and can land before the follow-up slice that exercises it.

## Non-goals

- Does not add or change the underlying session-management IPC methods; they already existed and are only wired up here.
- Does not touch any other rail (workflows, browser) or terminal surface.
- Does not add the Playwright regression test that exercises these controls; that ships as the next stacked PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test`

</details>

## Visual Proof

On this branch, the Planning rail header shows a "Clear submitted" button next to "New chat", and every session row has a trash icon (including the submitted row). Neither existed on `master`.

![Planning rail current layout — new per-row trash icons and the enabled Clear submitted header button](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-0547e8/planning-rail-delete-controls.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
