### PR TITLE
[Delete planning terminals — UI](2) Verify Planning Terminal rail delete + clear-submitted UI

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -797,6 +797,63 @@ test.describe('Visual proof capture', () => {
     });
   });
 
+  test('planning rail — per-row delete and clear-submitted controls', async ({ page }) => {
+    // Regression/visual proof for the Planning rail delete controls: a
+    // per-row trash button on every session row, and a header "Clear
+    // submitted" button. Needs at least one 'submitted' session (to enable
+    // "Clear submitted") and at least one other-status session (to show the
+    // rail with more than one row of trash buttons).
+    const plannedYaml = yamlStringify(TERMINAL_PLANNED_PLAN);
+    const fullPlanReply = `I drafted the plan.\n\n\`\`\`yaml\n${plannedYaml}\`\`\``;
+    await page.evaluate(async ({ planYaml, planName, reply }) => {
+      await window.invoker.setTestPlanningChatResponse({ planYaml, planName, reply });
+    }, { planYaml: plannedYaml, planName: 'Terminal Planned Flow', reply: fullPlanReply });
+
+    await expect(page.getByRole('heading', { name: 'Planning chat' })).toBeVisible();
+    await page.getByTestId('invoker-terminal-input').fill('Draft a plan to submit');
+    await page.getByRole('button', { name: 'Send' }).click();
+    await expect(page.getByTestId('invoker-terminal-ready-bar')).toBeVisible();
+    await page.getByRole('button', { name: 'Review draft' }).click();
+    await expect(page.getByRole('heading', { name: 'Review draft' })).toBeVisible();
+    await page.getByTestId('planning-create-workflow').click();
+    await expect(page.getByRole('heading', { name: 'Planning chat' })).toBeVisible();
+
+    await page.evaluate(async () => {
+      await window.invoker.setTestPlanningChatResponse(null);
+    });
+
+    // A second, non-submitted session alongside the now-submitted one:
+    // this is what makes the active session non-read-only, which is what
+    // reveals the per-row trash buttons on every row (including the
+    // submitted row) plus the enabled "Clear submitted" header button.
+    await page.getByRole('button', { name: 'New chat' }).click();
+
+    const rows = page.getByTestId('planning-session-row');
+    await expect(rows).toHaveCount(2);
+    await expect(rows.first().getByRole('button', { name: 'Delete planning chat' })).toBeVisible();
+    await expect(rows.last().getByRole('button', { name: 'Delete planning chat' })).toBeVisible();
+
+    const clearSubmittedButton = page.getByRole('button', { name: 'Clear submitted' });
+    await expect(clearSubmittedButton).toBeEnabled();
+
+    await captureScreenshot(page, 'planning-rail-delete-controls');
+
+    // The native window.confirm() dialog Playwright/Electron shows for
+    // "Clear submitted" is an OS-level modal, not part of the page DOM, so
+    // it cannot be meaningfully captured via captureScreenshot (which
+    // screenshots the Electron page content). We only verify the dialog
+    // fires with the expected copy, then dismiss it without deleting
+    // anything, and skip a second screenshot of that moment.
+    let confirmDialogMessage: string | null = null;
+    page.once('dialog', (dialog) => {
+      confirmDialogMessage = dialog.message();
+      dialog.dismiss().catch(() => {});
+    });
+    await clearSubmittedButton.click();
+    await expect.poll(() => confirmDialogMessage).toBe('Clear all submitted planning chats? This cannot be undone.');
+    await expect(rows).toHaveCount(2);
+  });
+
   test('terminal planning captures long transcript follow surface', async ({ page }) => {
     const longTranscriptPlan = {
       ...TERMINAL_PLANNED_PLAN,

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -47,6 +47,7 @@ import { BrowserTaskRow, BrowserWorkflowRow } from './components/BrowserListRows
 import { useTheme } from './lib/theme.js';
 import { InvokerTerminal, type InvokerTerminalLine, type PlanningTerminalMode } from './components/InvokerTerminal.js';
 import { Toaster, toast } from 'sonner';
+import { Trash2 } from 'lucide-react';
 import { Button } from './components/primitives/index.js';
 import { ChevronDownIcon, PlayIcon } from './components/icons/index.js';
 import { CommandPalette, COMMAND_PALETTE_MAX_ROWS } from './components/CommandPalette.js';
@@ -2981,23 +2982,95 @@ export function App() {
     workflows.size,
   ]);
 
-  const handleCreatePlanningSession = useCallback(() => {
+  const makeFreshLocalPlanningSession = useCallback((): PlanningSessionView => {
     const index = nextPlanningSessionLocalIdRef.current;
     nextPlanningSessionLocalIdRef.current += 1;
     const now = new Date().toISOString();
     const localId = `local-planning-session-${index}`;
-    const session: PlanningSessionView = {
+    return {
       ...makeInitialPlanningSession(now, selectedPlanningConfirmationMode),
       id: localId,
       conversationKey: localId,
       presetKey: selectedPlanningPresetKey,
       confirmationMode: selectedPlanningConfirmationMode,
     };
+  }, [selectedPlanningConfirmationMode, selectedPlanningPresetKey]);
+
+  const handleCreatePlanningSession = useCallback(() => {
+    const session = makeFreshLocalPlanningSession();
     setPlanningSessions((prev) => [session, ...prev]);
     setActivePlanningSessionId(session.id);
     setSidebarSurface('home');
     focusKeyboardRegion('planning');
-  }, [focusKeyboardRegion, selectedPlanningConfirmationMode, selectedPlanningPresetKey]);
+  }, [focusKeyboardRegion, makeFreshLocalPlanningSession]);
+
+  const removePlanningSessionsById = useCallback((sessionIds: string[]) => {
+    const ids = new Set(sessionIds);
+    if (ids.size === 0) return;
+
+    clearPlanningStreamForSessionIds(sessionIds);
+    forgetPlanningStreamAliasesForSessionIds(sessionIds);
+    for (const id of ids) {
+      pendingPlanningStreamSessionIdsRef.current.delete(id);
+    }
+    setKeptPlanningDraftSessionIds((prev) => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const id of ids) {
+        if (next.delete(id)) changed = true;
+      }
+      return changed ? next : prev;
+    });
+    setReviewDraftSessionId((current) => (current && ids.has(current) ? null : current));
+
+    const previousSessions = planningSessionsRef.current;
+    const remainingSessions = previousSessions.filter((session) => !ids.has(session.id));
+    if (remainingSessions.length === previousSessions.length) return;
+
+    let nextSessions = remainingSessions;
+    let nextActiveSessionId = activePlanningSessionIdRef.current;
+    if (!nextSessions.some((session) => session.id === nextActiveSessionId)) {
+      if (nextSessions.length === 0) {
+        const session = makeFreshLocalPlanningSession();
+        nextSessions = [session];
+        nextActiveSessionId = session.id;
+      } else {
+        const previousActiveIndex = previousSessions.findIndex((session) => session.id === nextActiveSessionId);
+        nextActiveSessionId = nextSessions[previousActiveIndex]?.id
+          ?? nextSessions[nextSessions.length - 1]?.id
+          ?? nextSessions[0].id;
+      }
+    }
+
+    planningSessionsRef.current = nextSessions;
+    activePlanningSessionIdRef.current = nextActiveSessionId;
+    setPlanningSessions(nextSessions);
+    setActivePlanningSessionId(nextActiveSessionId);
+  }, [clearPlanningStreamForSessionIds, forgetPlanningStreamAliasesForSessionIds, makeFreshLocalPlanningSession]);
+
+  const handleDeletePlanningSession = useCallback((sessionId: string) => {
+    if (activePlanningReadOnly) {
+      return;
+    }
+    if (!sessionId.startsWith('local-')) {
+      void invoker?.planningChatDelete?.({ sessionId });
+    }
+    removePlanningSessionsById([sessionId]);
+  }, [activePlanningReadOnly, invoker, removePlanningSessionsById]);
+
+  const handleClearSubmittedPlanningSessions = useCallback(() => {
+    if (activePlanningReadOnly) {
+      return;
+    }
+    const confirmed = window.confirm('Clear all submitted planning chats? This cannot be undone.');
+    if (!confirmed) return;
+    const submittedIds = planningSessionsRef.current
+      .filter((session) => session.status === 'submitted')
+      .map((session) => session.id);
+    if (submittedIds.length === 0) return;
+    void invoker?.planningChatDeleteSubmitted?.();
+    removePlanningSessionsById(submittedIds);
+  }, [activePlanningReadOnly, invoker, removePlanningSessionsById]);
 
   const handlePlanningModeChange = useCallback(async (mode: PlanningTerminalMode) => {
     const sourceSession = activePlanningSession;
@@ -4262,30 +4335,49 @@ export function App() {
           const selected = session.id === activePlanningSession.id;
           const preview = previewPlanningMessage(session);
           return (
-            <button
+            <div
               key={session.id}
-              type="button"
-              onClick={() => setActivePlanningSessionId(session.id)}
-              className={`flex w-full items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              data-testid="planning-session-row"
+              className={`flex w-full items-stretch ${selected ? 'bg-accent/40' : ''}`}
             >
-              <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-start justify-between gap-2">
-                  <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
-                    {session.title}
+              <button
+                type="button"
+                onClick={() => setActivePlanningSessionId(session.id)}
+                className={`flex w-full min-w-0 flex-1 items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
+              >
+                <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>
+                      {session.title}
+                    </div>
+                    <span className="shrink-0 text-[11px] text-muted-foreground">
+                      {relativePlanningUpdatedAt(session.updatedAt)}
+                    </span>
                   </div>
-                  <span className="shrink-0 text-[11px] text-muted-foreground">
-                    {relativePlanningUpdatedAt(session.updatedAt)}
-                  </span>
+                  <div
+                    className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
+                    title={preview}
+                  >
+                    {preview}
+                  </div>
                 </div>
-                <div
-                  className="mt-1 line-clamp-3 break-words text-[11px] leading-4 text-muted-foreground"
-                  title={preview}
+              </button>
+              {!activePlanningReadOnly && (
+                <button
+                  type="button"
+                  aria-label="Delete planning chat"
+                  title="Delete planning chat"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleDeletePlanningSession(session.id);
+                  }}
+                  className="flex w-9 shrink-0 items-start justify-center px-2 py-2 text-muted-foreground transition-colors hover:bg-red-950/40 hover:text-red-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 >
-                  {preview}
-                </div>
-              </div>
-            </button>
+                  <Trash2 aria-hidden="true" className="mt-0.5 h-3.5 w-3.5" strokeWidth={1.75} />
+                </button>
+              )}
+            </div>
           );
         })}
       </div>
@@ -4293,6 +4385,7 @@ export function App() {
   );
 
   const planningReadyCount = planningSessions.filter((session) => session.status === 'draft_ready').length;
+  const submittedPlanningSessionCount = planningSessions.filter((session) => session.status === 'submitted').length;
   const connectedAgentLabels = (systemDiagnostics?.tools ?? [])
     .filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed)
     .map((tool) => tool.name.replace(/\s+CLI$/i, ''));
@@ -4450,18 +4543,15 @@ export function App() {
           </div>
         ) : (
           <>
-            <div className="flex items-center justify-between gap-3 border-b border-border px-3 py-2.5">
-              <div className="min-w-0">
-                <h2 className="text-sm font-medium text-foreground">Planning</h2>
-                <p className="mt-0.5 text-[11px] text-muted-foreground">
-                  {planningSessions.length} chat{planningSessions.length === 1 ? '' : 's'}
-                  {planningReadyCount > 0 ? ` · ${planningReadyCount} ready` : ''}
-                </p>
-              </div>
-              <div className="flex items-center gap-2">
-                <Button variant="outline" size="sm" onClick={handleCreatePlanningSession}>
-                  New chat
-                </Button>
+            <div className="border-b border-border px-3 py-2.5">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <h2 className="text-sm font-medium text-foreground">Planning</h2>
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">
+                    {planningSessions.length} chat{planningSessions.length === 1 ? '' : 's'}
+                    {planningReadyCount > 0 ? ` · ${planningReadyCount} ready` : ''}
+                  </p>
+                </div>
                 <button
                   type="button"
                   data-testid="planning-session-rail-toggle"
@@ -4471,6 +4561,19 @@ export function App() {
                 >
                   ‹
                 </button>
+              </div>
+              <div className="mt-2 flex items-center gap-2">
+                <Button variant="outline" size="sm" onClick={handleCreatePlanningSession}>
+                  New chat
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleClearSubmittedPlanningSessions}
+                  disabled={activePlanningReadOnly || submittedPlanningSessionCount === 0}
+                >
+                  Clear submitted
+                </Button>
               </div>
             </div>
             <div className={RAIL_LIST_FRAME_CLASS}>{renderPlanningSessionList()}</div>

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -224,6 +224,8 @@ export function createMockInvoker(
     })),
     planningChatDiscardDraft: vi.fn(async () => ({ ok: true })),
     planningChatReset: vi.fn(async () => ({ ok: true })),
+    planningChatDelete: vi.fn(async () => ({ ok: true })),
+    planningChatDeleteSubmitted: vi.fn(async () => ({ ok: true, deletedSessionIds: [] })),
     onPlanningChatStream: vi.fn((cb: (event: InAppPlanningStreamEvent) => void) => {
       planningChatStreamCallbacks.add(cb);
       return () => { planningChatStreamCallbacks.delete(cb); };

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -44,6 +44,41 @@ describe('Invoker terminal (component)', () => {
     fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
   }
 
+  function makeRailPlanningSession(
+    id: string,
+    title: string,
+    status: 'still_discussing' | 'submitted' = 'still_discussing',
+    message = title,
+  ) {
+    return makePlanningSessionSummary({
+      id,
+      title,
+      status,
+      messages: [
+        {
+          id: 1,
+          role: 'user',
+          text: message,
+          createdAt: '2026-07-07T00:00:01.000Z',
+        },
+      ],
+      draftPlanAvailable: false,
+      draftPlanSummary: undefined,
+      draftPlanText: undefined,
+      updatedAt: '2026-07-07T00:00:01.000Z',
+    });
+  }
+
+  function getPlanningSessionRowByText(text: string): HTMLElement {
+    const rail = screen.getByTestId('planning-session-list');
+    const textElement = within(rail).getAllByText(text)[0];
+    const row = textElement?.closest('[data-testid="planning-session-row"]');
+    if (!(row instanceof HTMLElement)) {
+      throw new Error(`Missing planning session row for ${text}`);
+    }
+    return row;
+  }
+
   function expectRailListScrollContract(list: HTMLElement) {
     expect(list).toHaveClass('min-h-0', 'flex-1', 'overflow-y-auto');
     expect(list.parentElement).toHaveClass('flex', 'min-h-0', 'flex-1', 'flex-col');
@@ -271,8 +306,7 @@ describe('Invoker terminal (component)', () => {
     const secondPanel = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(secondPanel).toHaveTextContent('Drafting your plan…');
 
-    const sessionButtons = within(screen.getByTestId('planning-session-list')).getAllByRole('button');
-    fireEvent.click(sessionButtons[1]);
+    fireEvent.click(within(screen.getByTestId('planning-session-list')).getByRole('button', { name: /first session request/i }));
 
     const firstPanel = await screen.findByTestId('invoker-terminal-planner-stream');
     expect(firstPanel).toHaveTextContent('Drafting your plan…');
@@ -668,6 +702,141 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('2 chats'));
     expect(within(screen.getByTestId('sidebar-home')).queryByText('0')).not.toBeInTheDocument();
     expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('2 chats');
+  });
+
+  it('deletes a saved planning chat from its row trash button', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makeRailPlanningSession('delete-saved-chat', 'Delete saved chat'),
+        makeRailPlanningSession('keep-saved-chat', 'Keep saved chat'),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    const rail = screen.getByTestId('planning-session-list');
+    await waitFor(() => expect(within(rail).getAllByText('Delete saved chat').length).toBeGreaterThan(0));
+
+    fireEvent.click(within(getPlanningSessionRowByText('Delete saved chat')).getByRole('button', { name: 'Delete planning chat' }));
+
+    await waitFor(() => {
+      expect(within(rail).queryByText('Delete saved chat')).not.toBeInTheDocument();
+    });
+    expect(within(rail).getAllByText('Keep saved chat').length).toBeGreaterThan(0);
+    expect(mock.api.planningChatDelete).toHaveBeenCalledWith({ sessionId: 'delete-saved-chat' });
+  });
+
+  it('deletes a local planning chat without calling planningChatDelete', async () => {
+    mock.api.planningChatSend = vi.fn(() => new Promise(() => {}) as any) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('local unsaved planning chat');
+    await waitFor(() => expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: 'New chat' }));
+    fireEvent.click(within(getPlanningSessionRowByText('local unsaved planning chat')).getByRole('button', { name: 'Delete planning chat' }));
+
+    await waitFor(() => {
+      expect(within(screen.getByTestId('planning-session-list')).queryByText('local unsaved planning chat')).not.toBeInTheDocument();
+    });
+    expect(mock.api.planningChatDelete).not.toHaveBeenCalled();
+  });
+
+  it('disables Clear submitted when there are no submitted planning chats', async () => {
+    render(<App />);
+    await openPlanningTerminal();
+
+    const clearButton = screen.getByRole('button', { name: 'Clear submitted' });
+    expect(clearButton).toBeDisabled();
+
+    fireEvent.click(clearButton);
+    expect(mock.api.planningChatDeleteSubmitted).not.toHaveBeenCalled();
+  });
+
+  it('clears all submitted planning chats after confirmation', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makeRailPlanningSession('active-chat', 'Active chat'),
+        makeRailPlanningSession('submitted-chat-1', 'Submitted one', 'submitted'),
+        makeRailPlanningSession('submitted-chat-2', 'Submitted two', 'submitted'),
+      ],
+    }));
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    try {
+      render(<App />);
+      await openPlanningTerminal();
+
+      const rail = screen.getByTestId('planning-session-list');
+      await waitFor(() => expect(within(rail).getAllByText('Submitted one').length).toBeGreaterThan(0));
+      const clearButton = screen.getByRole('button', { name: 'Clear submitted' });
+      expect(clearButton).toBeEnabled();
+
+      fireEvent.click(clearButton);
+
+      await waitFor(() => {
+        expect(within(rail).queryByText('Submitted one')).not.toBeInTheDocument();
+        expect(within(rail).queryByText('Submitted two')).not.toBeInTheDocument();
+      });
+      expect(within(rail).getAllByText('Active chat').length).toBeGreaterThan(0);
+      expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('1 chat');
+      expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
+      expect(confirmSpy).toHaveBeenCalledTimes(1);
+      expect(mock.api.planningChatDeleteSubmitted).toHaveBeenCalledTimes(1);
+    } finally {
+      confirmSpy.mockRestore();
+    }
+  });
+
+  it('recreates a fresh empty chat after deleting the last planning chat', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makeRailPlanningSession('only-saved-chat', 'Only saved chat'),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    await waitFor(() => expect(screen.getByTestId('planning-session-list')).toHaveTextContent('Only saved chat'));
+    fireEvent.click(within(getPlanningSessionRowByText('Only saved chat')).getByRole('button', { name: 'Delete planning chat' }));
+
+    await waitFor(() => {
+      expect(within(screen.getByTestId('planning-session-list')).queryByText('Only saved chat')).not.toBeInTheDocument();
+      expect(screen.getByText('What do you want to build?')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('1 chat');
+    expect(screen.getByTestId('invoker-terminal-input')).toBeEnabled();
+    expect(mock.api.planningChatDelete).toHaveBeenCalledWith({ sessionId: 'only-saved-chat' });
+  });
+
+  it('hides planning chat trash buttons and disables Clear submitted in read-only mode', async () => {
+    mock.setRuntimeStatus({
+      ownerMode: false,
+      readOnly: true,
+      mode: 'read-only',
+    });
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makeRailPlanningSession('readonly-active-chat', 'Readonly active chat'),
+        makeRailPlanningSession('readonly-submitted-chat', 'Readonly submitted chat', 'submitted'),
+      ],
+    }));
+    mock.install();
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    await waitFor(() => expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled());
+    expect(screen.queryByRole('button', { name: 'Delete planning chat' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Clear submitted' })).toBeDisabled();
   });
 
   it('continues the same planning session', async () => {


### PR DESCRIPTION
## Summary

This slice adds the Playwright visual-proof test case that exercises the new Planning Terminal rail controls from the previous PR.

The test drives a real planning session to a submitted state, adds a second session, and checks both the per-row trash controls and the header bulk-clear control.

It also confirms the native confirm dialog fires with the expected copy before anything is cleared.

## Review Claim

Add a Playwright visual-proof test case that exercises the Planning Terminal rail's per-row trash and header bulk-clear controls end to end.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds a test case to the visual-proof Playwright spec; it does not touch any product code, so it carries no runtime risk. The test itself only clicks through the existing UI and asserts on visible state.

## Slice Rationale

Keeping the exercising test in its own PR lets a reviewer approve the behavior slice and its regression coverage as two separate, clearly labeled review claims, stacked so the coverage lands right after the behavior it proves.

## Non-goals

- Does not change any product code in `packages/ui` or elsewhere.
- Does not add coverage for other rails or surfaces.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && CAPTURE_MODE=after CAPTURE_VIDEO=1 npx playwright test e2e/visual-proof.spec.ts -g "planning rail — per-row delete and clear-submitted controls"`
- [x] `cd packages/ui && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
