### PR TITLE
[DO1 Slack hi autonomous smoke](1) Route a localhost hi smoke through the live Slack reply path

### DIFF
--- a/packages/slack-manager/src/__tests__/slack-hi-smoke.test.ts
+++ b/packages/slack-manager/src/__tests__/slack-hi-smoke.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { maybeStartHiSmokeServer, type HiSmokeServer } from '../slack-hi-smoke.js';
+
+const noopLog = (_level: string, _message: string): void => {};
+
+describe('maybeStartHiSmokeServer', () => {
+  let server: HiSmokeServer | undefined;
+
+  afterEach(async () => {
+    await server?.close();
+    server = undefined;
+  });
+
+  it('stays disabled unless INVOKER_SLACK_HI_SMOKE is truthy', async () => {
+    const inject = vi.fn();
+    for (const value of [undefined, '', '0', 'false', 'off']) {
+      const result = await maybeStartHiSmokeServer({
+        inject,
+        log: noopLog,
+        env: value === undefined ? {} : { INVOKER_SLACK_HI_SMOKE: value },
+      });
+      expect(result).toBeUndefined();
+    }
+    expect(inject).not.toHaveBeenCalled();
+  });
+
+  it('binds only to loopback and feeds hi through the injector on POST /smoke/hi', async () => {
+    const inject = vi.fn().mockResolvedValue({ channel: 'C123', threadTs: '1700000000.000100' });
+    server = await maybeStartHiSmokeServer({
+      inject,
+      log: noopLog,
+      env: { INVOKER_SLACK_HI_SMOKE: '1', INVOKER_SLACK_HI_SMOKE_PORT: '0' },
+    });
+    expect(server).toBeDefined();
+    expect(server?.host).toBe('127.0.0.1');
+
+    const res = await fetch(`http://127.0.0.1:${server!.port}/smoke/hi`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(200);
+    const payload = await res.json();
+    expect(payload).toEqual({ ok: true, channel: 'C123', threadTs: '1700000000.000100' });
+    expect(inject).toHaveBeenCalledWith({ text: 'hi', user: undefined });
+  });
+
+  it('passes through an explicit text override', async () => {
+    const inject = vi.fn().mockResolvedValue({ channel: 'C1', threadTs: '1.2' });
+    server = await maybeStartHiSmokeServer({
+      inject,
+      log: noopLog,
+      env: { INVOKER_SLACK_HI_SMOKE: 'yes', INVOKER_SLACK_HI_SMOKE_PORT: '0' },
+    });
+    await fetch(`http://127.0.0.1:${server!.port}/smoke/hi`, {
+      method: 'POST',
+      body: JSON.stringify({ text: 'hello there', user: 'U9' }),
+    });
+    expect(inject).toHaveBeenCalledWith({ text: 'hello there', user: 'U9' });
+  });
+
+  it('returns 404 for non-POST or unknown paths', async () => {
+    server = await maybeStartHiSmokeServer({
+      inject: vi.fn(),
+      log: noopLog,
+      env: { INVOKER_SLACK_HI_SMOKE: '1', INVOKER_SLACK_HI_SMOKE_PORT: '0' },
+    });
+    const get = await fetch(`http://127.0.0.1:${server!.port}/smoke/hi`, { method: 'GET' });
+    expect(get.status).toBe(404);
+    const wrong = await fetch(`http://127.0.0.1:${server!.port}/other`, { method: 'POST' });
+    expect(wrong.status).toBe(404);
+  });
+
+  it('surfaces injector failures as HTTP 500 without crashing the server', async () => {
+    const inject = vi.fn().mockRejectedValue(new Error('lobby not_in_channel'));
+    server = await maybeStartHiSmokeServer({
+      inject,
+      log: noopLog,
+      env: { INVOKER_SLACK_HI_SMOKE: '1', INVOKER_SLACK_HI_SMOKE_PORT: '0' },
+    });
+    const res = await fetch(`http://127.0.0.1:${server!.port}/smoke/hi`, { method: 'POST', body: '{}' });
+    expect(res.status).toBe(500);
+    const payload = await res.json();
+    expect(payload).toEqual({ ok: false, error: 'lobby not_in_channel' });
+  });
+});

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -28,6 +28,7 @@ import { createHarnessSessionDriverFactory, createPlanningCommandBuilder, create
 import { createWatchdog } from './watchdog.js';
 import { errMessage } from './util.js';
 import { acquireSlackConsumerLock } from './slack-consumer-lock.js';
+import { maybeStartHiSmokeServer } from './slack-hi-smoke.js';
 const VERSION = '0.0.8';
 
 const REQUIRED_ENV = ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_SIGNING_SECRET', 'SLACK_CHANNEL_ID'];
@@ -157,6 +158,10 @@ async function main(): Promise<void> {
 
   await slack.start(commandHandler);
   watchdog.start();
+  const hiSmokeServer = await maybeStartHiSmokeServer({
+    inject: (opts) => slack.injectHiSmoke(opts),
+    log,
+  });
   // Establish the IPC connection (and re-apply subscriptions) if Invoker is already up.
   void client.ping();
   log('info', `slack-manager started (store=${managerHome})`);
@@ -168,6 +173,7 @@ async function main(): Promise<void> {
     log('info', `received ${signal}, shutting down`);
     watchdog.stop();
     stopEvents();
+    await hiSmokeServer?.close().catch((err) => log('warn', `hi-smoke close failed: ${errMessage(err)}`));
     await slack.stop().catch((err) => log('warn', `slack.stop failed: ${errMessage(err)}`));
     client.disconnect();
     adapter.close();

--- a/packages/slack-manager/src/slack-hi-smoke.ts
+++ b/packages/slack-manager/src/slack-hi-smoke.ts
@@ -1,0 +1,134 @@
+/**
+ * Localhost-only smoke hook for the live Slack reply path.
+ *
+ * Slack does not reliably deliver an app's own `app_mention` back to itself, so
+ * the only way to exercise the real planning-mention → response-posting path
+ * end-to-end against the running manager is to synthesize the event locally.
+ *
+ * This server:
+ *  - is disabled unless `INVOKER_SLACK_HI_SMOKE` is set to a truthy value,
+ *  - binds ONLY to 127.0.0.1 so it is never reachable off-box,
+ *  - on `POST /smoke/hi` calls the injector, which posts a parent message to the
+ *    lobby and feeds `hi` through the ordinary Slack reply path.
+ */
+
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+export interface HiSmokeResult {
+  channel: string;
+  threadTs: string;
+}
+
+export type HiSmokeInjector = (opts: { text?: string; user?: string }) => Promise<HiSmokeResult>;
+
+export interface HiSmokeServerDeps {
+  inject: HiSmokeInjector;
+  log: (level: string, message: string) => void;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface HiSmokeServer {
+  port: number;
+  host: string;
+  close(): Promise<void>;
+}
+
+const LOOPBACK_HOST = '127.0.0.1';
+const DEFAULT_PORT = 8765;
+const MAX_BODY_BYTES = 4_096;
+
+function isEnabled(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 && normalized !== '0' && normalized !== 'false' && normalized !== 'off';
+}
+
+function parseSmokeBody(body: string): { text?: string; user?: string } {
+  const trimmed = body.trim();
+  if (!trimmed) return {};
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (parsed && typeof parsed === 'object') {
+      const record = parsed as Record<string, unknown>;
+      const text = typeof record.text === 'string' ? record.text : undefined;
+      const user = typeof record.user === 'string' ? record.user : undefined;
+      return { text, user };
+    }
+  } catch {
+    // Ignore malformed bodies; fall back to defaults.
+  }
+  return {};
+}
+
+/**
+ * Start the opt-in localhost smoke server. Returns `undefined` (no listener)
+ * unless `INVOKER_SLACK_HI_SMOKE` is truthy.
+ */
+export async function maybeStartHiSmokeServer(deps: HiSmokeServerDeps): Promise<HiSmokeServer | undefined> {
+  const env = deps.env ?? process.env;
+  if (!isEnabled(env.INVOKER_SLACK_HI_SMOKE)) return undefined;
+
+  const requestedPort = Number(env.INVOKER_SLACK_HI_SMOKE_PORT ?? DEFAULT_PORT);
+  const port = Number.isInteger(requestedPort) && requestedPort >= 0 ? requestedPort : DEFAULT_PORT;
+
+  const server = http.createServer((req, res) => {
+    const url = req.url ?? '';
+    if (req.method !== 'POST' || !url.startsWith('/smoke/hi')) {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: false, error: 'not found' }));
+      return;
+    }
+    let body = '';
+    let aborted = false;
+    req.on('data', (chunk: Buffer) => {
+      body += chunk.toString('utf8');
+      if (body.length > MAX_BODY_BYTES) {
+        aborted = true;
+        res.writeHead(413, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: false, error: 'body too large' }));
+        req.destroy();
+      }
+    });
+    req.on('end', () => {
+      if (aborted) return;
+      const { text, user } = parseSmokeBody(body);
+      deps
+        .inject({ text: text ?? 'hi', user })
+        .then((result) => {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ ok: true, ...result }));
+        })
+        .catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          deps.log('error', `[hi-smoke] injection failed: ${message}`);
+          res.writeHead(500, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ ok: false, error: message }));
+        });
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, LOOPBACK_HOST, () => {
+      server.removeListener('error', reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  const boundPort = address && typeof address === 'object' ? (address as AddressInfo).port : port;
+  deps.log(
+    'info',
+    `[hi-smoke] localhost smoke hook listening on http://${LOOPBACK_HOST}:${boundPort}/smoke/hi (opt-in via INVOKER_SLACK_HI_SMOKE)`,
+  );
+
+  return {
+    port: boundPort,
+    host: LOOPBACK_HOST,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -921,6 +921,46 @@ export class SlackSurface implements Surface {
     });
   }
 
+  /**
+   * Localhost smoke hook. Posts a real parent message to the lobby, then feeds
+   * `text` (default "hi") through the ordinary planning-mention handler so the
+   * normal Slack response path posts the reply in that same thread.
+   *
+   * Slack does not reliably deliver an app's own `app_mention` back to itself,
+   * so the live reply path can only be exercised end-to-end by synthesizing the
+   * event locally. This is invoked exclusively by the opt-in, localhost-only
+   * smoke server in @invoker/slack-manager — never by inbound Slack traffic.
+   */
+  async injectHiSmoke(opts: { text?: string; user?: string } = {}): Promise<{ channel: string; threadTs: string }> {
+    const channel = this.lobbyChannelId;
+    const text = (opts.text ?? 'hi').trim() || 'hi';
+    const user = opts.user ?? this.botUserId ?? 'U_SMOKE';
+    const parent = await this.app.client.chat.postMessage({
+      channel,
+      text: `:test_tube: Slack hi smoke — feeding \`${text}\` through the planning-mention path.`,
+    });
+    const parentTs = parent.ts;
+    if (!parentTs) throw new Error('hi-smoke: failed to post parent message to lobby');
+    const mention = this.botUserId ? `<@${this.botUserId}> ` : '';
+    const event: SlackMentionEvent = {
+      text: `${mention}${text}`,
+      ts: parentTs,
+      channel,
+      user,
+    };
+    const say: SayFn = async (msg) => {
+      const res = await this.app.client.chat.postMessage({
+        channel,
+        text: msg.text,
+        thread_ts: msg.thread_ts ?? parentTs,
+      });
+      return { ts: res.ts };
+    };
+    this.log('slack', 'info', `[HI_SMOKE] instance=${this.instanceId} injecting synthetic app_mention route=planning thread_ts=${parentTs} channel=${channel} preset=${this.defaultHarnessPreset} text="${text}"`);
+    await this.handlePlanningMention(event, say, channel);
+    return { channel, threadTs: parentTs };
+  }
+
   // ── Planning mention (lobby) ───────────────────────────
 
   private async handlePlanningMention(

--- a/scripts/slack-hi-smoke.mjs
+++ b/scripts/slack-hi-smoke.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Live Slack "hi" smoke driver.
+ *
+ * Triggers the opt-in, localhost-only smoke hook exposed by a running
+ * @invoker/slack-manager (see packages/slack-manager/src/slack-hi-smoke.ts),
+ * which posts a parent message to the lobby and feeds `hi` through the ordinary
+ * planning-mention → response-posting path. This script then polls the Slack
+ * thread until the LLM reply lands (or a timeout), and PASSES only when the
+ * reply is a non-error greeting/acknowledgement.
+ *
+ * Slack does not reliably deliver an app's own app_mention back to itself, so a
+ * localhost-injected event — not a bot self-mention — is the proof trigger.
+ *
+ * Usage: node scripts/slack-hi-smoke.mjs
+ * Env:
+ *   INVOKER_SLACK_HI_SMOKE_PORT  smoke hook port (default 8765)
+ *   SLACK_HI_SMOKE_TIMEOUT_MS    poll timeout (default 240000)
+ *   INVOKER_SLACK_OWNER_ENV      env file with SLACK_BOT_TOKEN (default ~/.invoker/.slack-owner.env|.env)
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+
+const ACK_TEXTS = new Set(['Processing your request...']);
+const HEARTBEAT_MARKERS = [':hourglass_flowing_sand:', 'Still thinking...'];
+const ERROR_MARKERS = [/No API key/i, /omp exited/i, /codex exited/i];
+const STACK_TRACE_RE = /\n\s*at\s+.+:\d+:\d+/;
+
+function loadEnvFile(file) {
+  if (!file || !existsSync(file)) return;
+  for (const line of readFileSync(file, 'utf8').split('\n')) {
+    const m = /^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/.exec(line);
+    if (!m) continue;
+    const key = m[1];
+    let val = m[2];
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1);
+    }
+    if (process.env[key] === undefined) process.env[key] = val;
+  }
+}
+
+async function slack(method, token, params) {
+  // Slack Web API read methods (conversations.replies, chat.getPermalink)
+  // reject JSON bodies with invalid_arguments; form-encoding works for all.
+  const form = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) form.set(k, String(v));
+  const res = await fetch(`https://slack.com/api/${method}`, {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/x-www-form-urlencoded; charset=utf-8',
+    },
+    body: form.toString(),
+  });
+  return res.json();
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function classify(text) {
+  const t = (text ?? '').trim();
+  if (!t) return { pass: false, reason: 'empty reply' };
+  for (const re of ERROR_MARKERS) if (re.test(t)) return { pass: false, reason: `error marker: ${re}` };
+  if (STACK_TRACE_RE.test(t)) return { pass: false, reason: 'stack trace in reply' };
+  if (/^Error:/i.test(t)) return { pass: false, reason: 'reply is an error message' };
+  return { pass: true, reason: 'non-error LLM reply' };
+}
+
+function isReplyCandidate(msg, parentTs) {
+  if (!msg || msg.ts === parentTs) return false;
+  const text = msg.text ?? '';
+  if (ACK_TEXTS.has(text.trim())) return false;
+  if (HEARTBEAT_MARKERS.some((m) => text.includes(m))) return false;
+  return text.trim().length > 0;
+}
+
+async function main() {
+  const ownerEnv =
+    process.env.INVOKER_SLACK_OWNER_ENV ??
+    (existsSync(path.join(homedir(), '.invoker', '.slack-owner.env'))
+      ? path.join(homedir(), '.invoker', '.slack-owner.env')
+      : path.join(homedir(), '.invoker', '.env'));
+  loadEnvFile(ownerEnv);
+
+  const token = process.env.SLACK_BOT_TOKEN;
+  if (!token) throw new Error(`SLACK_BOT_TOKEN not found (looked in ${ownerEnv})`);
+
+  const port = process.env.INVOKER_SLACK_HI_SMOKE_PORT ?? '8765';
+  const timeoutMs = Number(process.env.SLACK_HI_SMOKE_TIMEOUT_MS ?? 240_000);
+
+  process.stdout.write(`[hi-smoke] triggering localhost hook http://127.0.0.1:${port}/smoke/hi\n`);
+  const triggerRes = await fetch(`http://127.0.0.1:${port}/smoke/hi`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ text: 'hi' }),
+  }).catch((err) => {
+    throw new Error(`could not reach smoke hook on 127.0.0.1:${port} (is slack-manager running with INVOKER_SLACK_HI_SMOKE=1?): ${err.message}`);
+  });
+  const trigger = await triggerRes.json();
+  if (!trigger.ok) throw new Error(`smoke hook returned failure: ${JSON.stringify(trigger)}`);
+  const { channel, threadTs } = trigger;
+  process.stdout.write(`[hi-smoke] injected parent thread channel=${channel} thread_ts=${threadTs}\n`);
+
+  const permalinkRes = await slack('chat.getPermalink', token, { channel, message_ts: threadTs });
+  const permalink = permalinkRes.ok ? permalinkRes.permalink : `(permalink unavailable: ${permalinkRes.error})`;
+
+  const deadline = Date.now() + timeoutMs;
+  let lastReply;
+  while (Date.now() < deadline) {
+    const replies = await slack('conversations.replies', token, { channel, ts: threadTs, limit: 50 });
+    if (!replies.ok) {
+      process.stdout.write(`[hi-smoke] conversations.replies error: ${replies.error}\n`);
+      await sleep(5_000);
+      continue;
+    }
+    const candidate = [...(replies.messages ?? [])].reverse().find((m) => isReplyCandidate(m, threadTs));
+    if (candidate) {
+      lastReply = candidate;
+      break;
+    }
+    await sleep(5_000);
+  }
+
+  const result = {
+    channel,
+    threadTs,
+    permalink,
+    reply: lastReply ? lastReply.text : null,
+    replyTs: lastReply ? lastReply.ts : null,
+  };
+
+  if (!lastReply) {
+    result.pass = false;
+    result.reason = `timed out after ${timeoutMs}ms with no LLM reply`;
+  } else {
+    Object.assign(result, classify(lastReply.text));
+  }
+
+  process.stdout.write(`\n[hi-smoke] RESULT ${JSON.stringify(result, null, 2)}\n`);
+  process.exit(result.pass ? 0 : 1);
+}
+
+main().catch((err) => {
+  process.stderr.write(`[hi-smoke] fatal: ${err.message}\n`);
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary

Invoker's Slack manager could not prove its live `hi` reply path end to end, because Slack does not deliver the app's own mention back to itself.

This adds a localhost-only smoke hook. It posts a real parent message to the lobby, then routes a synthetic mention into the planning-mention handler so the reply path runs.

A driver script triggers the hook, then watches the Slack thread until a non-error greeting lands, passing only on a real LLM reply.

The hook stays off unless `INVOKER_SLACK_HI_SMOKE` is set, and it binds only to loopback, so it is never reachable off-box.

## Review Claim

Approve routing a localhost-injected `hi` mention through the live Slack planning-mention and reply path, so the manager posts a real LLM greeting or stops once with a specific human-only blocker.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The smoke hook is inert unless `INVOKER_SLACK_HI_SMOKE` is truthy and it binds only to `127.0.0.1`, so no inbound Slack traffic and nothing off-box can reach it. It touches only the Slack smoke path and leaves the Mergify PR babysit workers, labels, queues, and branches untouched.

## Slice Rationale

This is a standalone live Slack smoke path, kept separate from the PR babysit loop that already owns pull-request recovery.

## Non-goals

- No changes to the Mergify PR babysit workers, labels, queues, merges, rebases, or force-pushes.
- No changes to real PR branches or the merge/queue runtime.
- No new inbound Slack event surface; the hook is localhost-only and opt-in.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/slack-manager test`
- [x] `node scripts/validate-pr-body.mjs --body-file <pr-body.md>`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. The hook is opt-in and inert when `INVOKER_SLACK_HI_SMOKE` is unset, so reverting removes it with no runtime cleanup.
- Data migration? No

</details>
