### PR TITLE
[Failure Class Unification](1) Add failure-class taxonomy and shared classifier

### DIFF
--- a/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
+++ b/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { FailureClassifier, SSH_INFRA_FAILURE_CLASSES } from '../failure-classifier.js';
+
+describe('FailureClassifier.classifyError', () => {
+  it('classifies the env.sh invalid-export signature', () => {
+    expect(FailureClassifier.classifyError(
+      'export BADVAR: not a valid identifier while sourcing /home/ci/.invoker/env.sh',
+    )).toBe('ssh-env-invalid-export');
+  });
+
+  it('classifies the missing-worktree signature', () => {
+    expect(FailureClassifier.classifyError(
+      'cd ~/.invoker/worktrees/repo/task-1: No such file or directory',
+    )).toBe('ssh-worktree-missing');
+  });
+
+  it('classifies the invalid-reference signatures', () => {
+    expect(FailureClassifier.classifyError('fatal: invalid reference: refs/heads/x')).toBe('ssh-invalid-reference');
+    expect(FailureClassifier.classifyError('Cannot apply a fix because this task has no saved workspace.'))
+      .toBe('ssh-invalid-reference');
+  });
+
+  it('returns undefined for ordinary code failures and non-strings', () => {
+    expect(FailureClassifier.classifyError('AssertionError: expected 1 to be 2')).toBeUndefined();
+    expect(FailureClassifier.classifyError(undefined)).toBeUndefined();
+    expect(FailureClassifier.classifyError(42 as unknown as string)).toBeUndefined();
+  });
+});
+
+describe('FailureClassifier predicates', () => {
+  it('isLiveness only matches liveness_stall', () => {
+    expect(FailureClassifier.isLiveness('liveness_stall')).toBe(true);
+    expect(FailureClassifier.isLiveness('ssh-env-invalid-export')).toBe(false);
+    expect(FailureClassifier.isLiveness(undefined)).toBe(false);
+  });
+
+  it('isSshInfra matches every ssh infra bucket and nothing else', () => {
+    for (const cls of SSH_INFRA_FAILURE_CLASSES) {
+      expect(FailureClassifier.isSshInfra(cls)).toBe(true);
+    }
+    expect(FailureClassifier.isSshInfra('liveness_stall')).toBe(false);
+    expect(FailureClassifier.isSshInfra(undefined)).toBe(false);
+  });
+
+  it('isCancellation matches operator cancellations only', () => {
+    expect(FailureClassifier.isCancellation('Cancelled by user')).toBe(true);
+    expect(FailureClassifier.isCancellation('Terminated: shutdown')).toBe(true);
+    expect(FailureClassifier.isCancellation('boom')).toBe(false);
+    expect(FailureClassifier.isCancellation(undefined)).toBe(false);
+  });
+});

--- a/packages/workflow-graph/src/failure-classifier.ts
+++ b/packages/workflow-graph/src/failure-classifier.ts
@@ -1,0 +1,67 @@
+import type { FailureClass, SshInfraFailureClass } from './types.js';
+
+/**
+ * Single source of truth for categorizing task failures from their error text.
+ *
+ * Failure categorization used to be scattered: the requeue worker keyed off
+ * `failureClass`, the infra-repair worker re-matched `execution.error`
+ * substrings, and auto-fix gating had its own error-string checks. This class
+ * centralizes the error-string → {@link FailureClass} mapping and the shared
+ * predicates so producers (failure finalize) and consumers (workers, gating)
+ * agree on one taxonomy.
+ *
+ * Note: review-gate CI infra is deliberately NOT handled here. It needs an
+ * async CI-log fetch and the log is not in `execution.error`, so it stays in
+ * `ci-failure-infra-classifier.ts`.
+ */
+export const SSH_INFRA_FAILURE_CLASSES: readonly SshInfraFailureClass[] = [
+  'ssh-env-invalid-export',
+  'ssh-worktree-missing',
+  'ssh-invalid-reference',
+];
+
+export class FailureClassifier {
+  /**
+   * Map a failed task's `execution.error` to a persisted infra failure class,
+   * or `undefined` when the text does not match a known machine-owned bucket.
+   * Matches are narrow and exact by design — an unknown failure is a code
+   * failure, not an infra failure.
+   */
+  static classifyError(errorText: string | undefined): SshInfraFailureClass | undefined {
+    if (typeof errorText !== 'string') return undefined;
+    if (errorText.includes('.invoker/env.sh') && errorText.includes('not a valid identifier')) {
+      return 'ssh-env-invalid-export';
+    }
+    if (errorText.includes('.invoker/worktrees/') && errorText.includes('No such file or directory')) {
+      return 'ssh-worktree-missing';
+    }
+    if (
+      errorText.includes('fatal: invalid reference:')
+      || errorText.includes('Cannot apply a fix because this task has no saved workspace.')
+    ) {
+      return 'ssh-invalid-reference';
+    }
+    return undefined;
+  }
+
+  /** True when the failure was a liveness stall (owned by the requeue worker). */
+  static isLiveness(failureClass: FailureClass | undefined): boolean {
+    return failureClass === 'liveness_stall';
+  }
+
+  /** True when the failure is a machine-owned SSH infra bucket (owned by infra-repair). */
+  static isSshInfra(failureClass: FailureClass | undefined): failureClass is SshInfraFailureClass {
+    return failureClass !== undefined
+      && (SSH_INFRA_FAILURE_CLASSES as readonly string[]).includes(failureClass);
+  }
+
+  /**
+   * True when the error text is an operator-initiated cancellation/termination
+   * rather than a genuine failure, so auto-fix should not engage.
+   */
+  static isCancellation(errorText: unknown): boolean {
+    if (typeof errorText !== 'string') return false;
+    return errorText.startsWith('Cancelled by user') || errorText.startsWith('Cancelled:')
+      || errorText.startsWith('Terminated by user') || errorText.startsWith('Terminated:');
+  }
+}

--- a/packages/workflow-graph/src/index.ts
+++ b/packages/workflow-graph/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './types.js';
+export * from './failure-classifier.js';
 export * from './runner-kind.js';
 export * from './workflow-rollup.js';
 export * from './dag.js';

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -183,7 +183,13 @@ export interface ReviewGateState {
   readonly artifacts: readonly ReviewGateArtifact[];
 }
 
-export type FailureClass = 'liveness_stall';
+/** Machine/infra failure buckets that require repairing host or workspace state, not a code fix. */
+export type SshInfraFailureClass =
+  | 'ssh-env-invalid-export'
+  | 'ssh-worktree-missing'
+  | 'ssh-invalid-reference';
+
+export type FailureClass = 'liveness_stall' | SshInfraFailureClass;
 
 export function isLivenessFailureClass(failureClass: FailureClass | undefined): boolean {
   return failureClass === 'liveness_stall';


### PR DESCRIPTION
## Summary

This slice adds a shared failure-class taxonomy and a small classifier utility.

The FailureClass type gains explicit machine-owned buckets, and one utility centralizes the error-text matching plus the shared boolean helpers.

Behavior stays the same; nothing on the failure path calls the new utility yet.

## Review Claim

Invoker gains a shared failure-class taxonomy and classifier type.

## Review Lane

refactor

## Review Unit

contract

## Safety Invariant

This slice only adds a type and a pure utility; no caller uses it yet.

## Slice Rationale

The taxonomy has to exist before the finalize, gating, and worker slices can share it.

## Non-goals

- Behavior unchanged.
- No finalize wiring yet.
- No gating or worker changes yet.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-graph exec vitest run src/__tests__/failure-classifier.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <published commit sha>`
- Post-revert steps: Rerun the focused workflow-graph suite.
- Data migration? No

</details>
