### PR TITLE
[Failure Class Unification](2) Classify infra failures at finalize

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -8615,4 +8615,48 @@ describe('Orchestrator', () => {
 
   // ── Merge gate leaf reconciliation ────────────────────────
 
+  describe('finalize failure classification', () => {
+    function loadSingleTask(planName: string): { wfId: string; taskId: string } {
+      orchestrator.loadPlan({ name: planName, onFinish: 'none', tasks: [{ id: 't1', description: 'd', command: 'x' }] });
+      const wfId = orchestrator.getWorkflowIds()[0]!;
+      const taskId = orchestrator.getAllTasks().find((t) => t.config.workflowId === wfId && !t.config.isMergeNode)!.id;
+      return { wfId, taskId };
+    }
+
+    it('classifies an ssh env.sh failure into a persisted failureClass', () => {
+      const { wfId, taskId } = loadSingleTask('infra-ssh');
+      const cfg = orchestrator.getTask(taskId)!.config;
+      persistence.updateTask(taskId, { config: { ...cfg, runnerKind: 'ssh' } });
+      orchestrator.syncFromDb(wfId);
+      orchestrator.startExecution();
+
+      orchestrator.handleWorkerResponse(makeResponse({
+        actionId: taskId,
+        status: 'failed',
+        outputs: {
+          exitCode: 1,
+          error: 'export BADVAR: not a valid identifier while sourcing /home/ci/.invoker/env.sh',
+        },
+      }));
+
+      expect(orchestrator.getTask(taskId)!.execution.failureClass).toBe('ssh-env-invalid-export');
+    });
+
+    it('does not classify a non-ssh task with the same error text', () => {
+      const { taskId } = loadSingleTask('infra-nonssh');
+      orchestrator.startExecution();
+
+      orchestrator.handleWorkerResponse(makeResponse({
+        actionId: taskId,
+        status: 'failed',
+        outputs: {
+          exitCode: 1,
+          error: 'export BADVAR: not a valid identifier while sourcing /home/ci/.invoker/env.sh',
+        },
+      }));
+
+      expect(orchestrator.getTask(taskId)!.execution.failureClass).toBeUndefined();
+    });
+  });
+
 });

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -13,7 +13,7 @@
  * downstream auto-start / deferred re-enqueue sequence are preserved exactly.
  */
 
-import type { FailureClass, TaskState, TaskDelta, TaskStateChanges } from '@invoker/workflow-graph';
+import { FailureClassifier, type FailureClass, type TaskState, type TaskDelta, type TaskStateChanges } from '@invoker/workflow-graph';
 import type { Logger } from '@invoker/contracts';
 import type { ParsedResponse } from '../response-handler.js';
 import { scopePlanTaskId } from '../task-id-scope.js';
@@ -208,10 +208,16 @@ export function finalizeFailedTaskImpl(
     throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `finalizeFailedTask: task ${taskId} not found in graph`);
   }
 
+  const failureClass = executionFields.failureClass
+    ?? (existing.config.runnerKind === 'ssh'
+      ? FailureClassifier.classifyError(executionFields.error)
+      : undefined);
+
   const changes: TaskStateChanges = {
     status: 'failed',
     execution: {
       ...executionFields,
+      failureClass,
       completedAt: new Date(),
     },
   };


### PR DESCRIPTION
## Summary

This slice sets the machine-failure class when an SSH task finishes as failed.

Finalize now maps the failure text to a persisted class for ssh-runner tasks, and leaves ordinary code failures unclassified.

## Review Claim

Failed SSH tasks now carry a persisted machine-failure class from finalize.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only ssh-runner failures are classified, and an explicit class from the caller still wins.

## Slice Rationale

The class must be stamped at finalize so downstream slices read one value.

## Non-goals

- No change to non-ssh failures.
- No worker consumption yet.
- No gating change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <published commit sha>`
- Post-revert steps: Rerun the workflow-core orchestrator suite.
- Data migration? No

</details>
