### PR TITLE
[Failure Class Unification](3) Delegate auto-fix gating to shared classifier

### DIFF
--- a/packages/execution-engine/src/auto-fix-gating.ts
+++ b/packages/execution-engine/src/auto-fix-gating.ts
@@ -1,4 +1,4 @@
-import { isLivenessFailureClass, type TaskState } from '@invoker/workflow-core';
+import { FailureClassifier, type TaskState } from '@invoker/workflow-core';
 
 export function normalizeAutoFixRetryBudget(raw: unknown): number {
   if (raw === Number.POSITIVE_INFINITY) {
@@ -13,13 +13,9 @@ export function normalizeAutoFixRetryBudget(raw: unknown): number {
 
 
 export function shouldSkipAutoFixForError(errorText: unknown): boolean {
-  if (typeof errorText !== 'string') {
-    return false;
-  }
-  return errorText.startsWith('Cancelled by user') || errorText.startsWith('Cancelled:')
-    || errorText.startsWith('Terminated by user') || errorText.startsWith('Terminated:');
+  return FailureClassifier.isCancellation(errorText);
 }
 
 export function isLivenessFailureTask(task: Pick<TaskState, 'execution'>): boolean {
-  return isLivenessFailureClass(task.execution.failureClass);
+  return FailureClassifier.isLiveness(task.execution.failureClass);
 }


### PR DESCRIPTION
## Summary

This slice points the auto-fix gating helpers at the shared classifier.

The cancellation and liveness helpers now defer to the shared utility instead of holding their own copies.

Behavior is the same.

## Review Claim

Auto-fix gating helpers now defer to the shared classifier.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

The helpers keep the same inputs and outputs; only their implementation now calls the shared utility.

## Slice Rationale

Gating should not keep a second copy of the failure logic.

## Non-goals

- Behavior unchanged.
- No worker consumption yet.
- No taxonomy change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/requeue-worker.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/auto-fix-recovery.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <published commit sha>`
- Post-revert steps: Rerun the focused requeue and auto-fix suites.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic fix handling by more reliably identifying cancelled executions.
  * Improved detection of liveness-related failures, resulting in more accurate automatic fix decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->