### PR TITLE
[Failure Class Unification](4) Read persisted failure class in infra-repair worker

### DIFF
--- a/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
@@ -229,6 +229,24 @@ describe('infra-repair worker', () => {
     ]));
   });
 
+  it('reads the persisted failureClass subtype when the error text is opaque', async () => {
+    const h = makeHarness([
+      makeTask({
+        execution: {
+          error: 'Executor startup failed (ssh): opaque wrapper with no signature',
+          failureClass: 'ssh-env-invalid-export',
+        },
+      }),
+    ]);
+
+    await h.tick(POLL_CTX);
+
+    expect(h.runRemoteProvisionRepairFn).toHaveBeenCalledTimes(1);
+    expect(h.submit).toHaveBeenCalledTimes(1);
+    expect(h.submissions[0]?.channel).toBe(INFRA_REPAIR_RETRY_TASK_CHANNEL);
+    expect(parseInfraRepairRetryTaskMutationArgs(h.submissions[0]?.args ?? [])).toEqual({ taskId: 'wf-1/task-1' });
+  });
+
   it('repairs missing worktree owner path, updates workspacePath, and queues retry-task', async () => {
     const h = makeHarness([
       makeTask({

--- a/packages/execution-engine/src/auto-fix-gating.ts
+++ b/packages/execution-engine/src/auto-fix-gating.ts
@@ -1,4 +1,4 @@
-import { isLivenessFailureClass, type TaskState } from '@invoker/workflow-core';
+import { FailureClassifier, type TaskState } from '@invoker/workflow-core';
 
 export function normalizeAutoFixRetryBudget(raw: unknown): number {
   if (raw === Number.POSITIVE_INFINITY) {
@@ -13,13 +13,9 @@ export function normalizeAutoFixRetryBudget(raw: unknown): number {
 
 
 export function shouldSkipAutoFixForError(errorText: unknown): boolean {
-  if (typeof errorText !== 'string') {
-    return false;
-  }
-  return errorText.startsWith('Cancelled by user') || errorText.startsWith('Cancelled:')
-    || errorText.startsWith('Terminated by user') || errorText.startsWith('Terminated:');
+  return FailureClassifier.isCancellation(errorText);
 }
 
 export function isLivenessFailureTask(task: Pick<TaskState, 'execution'>): boolean {
-  return isLivenessFailureClass(task.execution.failureClass);
+  return FailureClassifier.isLiveness(task.execution.failureClass);
 }

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -7,7 +7,8 @@ import type {
   WorkflowMutationPriority,
 } from '@invoker/data-store';
 import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
-import type { TaskState, TaskStateChanges } from '@invoker/workflow-core';
+import { FailureClassifier } from '@invoker/workflow-core';
+import type { SshInfraFailureClass, TaskState, TaskStateChanges } from '@invoker/workflow-core';
 
 import { isLivenessFailureTask } from '../auto-fix-gating.js';
 import type { ConflictResolverHost } from '../conflict-resolver.js';
@@ -58,10 +59,7 @@ const MAX_OUTPUT_TAIL_CHARS = 400;
 type InfraRepairTaskDecisionStatus = Extract<WorkerActionStatus, 'completed' | 'failed' | 'skipped'>;
 type InfraRepairTargetActionStatus = Extract<WorkerActionStatus, 'running' | 'completed' | 'failed'>;
 
-export type InfraRepairReason =
-  | 'ssh-env-invalid-export'
-  | 'ssh-worktree-missing'
-  | 'ssh-invalid-reference';
+export type InfraRepairReason = SshInfraFailureClass;
 
 export interface InfraRepairRemoteTargetConfig {
   host: string;
@@ -351,20 +349,7 @@ export function listInfraRepairScanCandidates(
 }
 
 export function classifyGenericSshInfraFailure(errorText: unknown): InfraRepairReason | undefined {
-  if (typeof errorText !== 'string') return undefined;
-  if (errorText.includes('.invoker/env.sh') && errorText.includes('not a valid identifier')) {
-    return 'ssh-env-invalid-export';
-  }
-  if (errorText.includes('.invoker/worktrees/') && errorText.includes('No such file or directory')) {
-    return 'ssh-worktree-missing';
-  }
-  if (
-    errorText.includes('fatal: invalid reference:')
-    || errorText.includes('Cannot apply a fix because this task has no saved workspace.')
-  ) {
-    return 'ssh-invalid-reference';
-  }
-  return undefined;
+  return FailureClassifier.classifyError(typeof errorText === 'string' ? errorText : undefined);
 }
 
 function resolveRemoteTargetId(
@@ -390,7 +375,9 @@ function validateGenericSshInfraCandidate(
   if (latest.config.runnerKind !== 'ssh') return undefined;
   if (isLivenessFailureTask(latest)) return undefined;
 
-  const reason = classifyGenericSshInfraFailure(latest.execution.error);
+  const reason = FailureClassifier.isSshInfra(latest.execution.failureClass)
+    ? latest.execution.failureClass
+    : classifyGenericSshInfraFailure(latest.execution.error);
   if (!reason) return undefined;
 
   const targetId = resolveRemoteTargetId(options.store, latest);


### PR DESCRIPTION
## Summary

This slice makes the infra-repair worker trust the persisted failure class.

It reads the class stamped at finalize and only falls back to the old text matching for older failed tasks.

Behavior is the same.

## Review Claim

The infra-repair worker prefers the persisted failure class.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

The worker still acts on the same three machine-owned buckets; only where it learns the bucket changed.

## Slice Rationale

The worker should consume the shared class rather than re-deriving it from text.

## Non-goals

- Behavior unchanged.
- No new failure buckets.
- No taxonomy change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/infra-repair-worker.test.ts src/__tests__/worker-registry.test.ts`
- [x] `pnpm --filter @invoker/app build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <published commit sha>`
- Post-revert steps: Rerun the focused infra-repair worker suite.
- Data migration? No

</details>
