### PR TITLE
[Stack-batched CI repair](1) Add PR stack detection

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-stack-detection.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-stack-detection.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { detectStack, type StackPrRecord } from '../pr-stack-detection.js';
+
+function pr(overrides: Partial<StackPrRecord> & { number: number }): StackPrRecord {
+  return {
+    state: 'OPEN',
+    baseRefName: 'master',
+    headRefName: `stack/pr-${overrides.number}`,
+    headRefOid: `sha-${overrides.number}`,
+    ...overrides,
+  };
+}
+
+describe('detectStack', () => {
+  it('Case A: finds a full linear 3-PR stack from the bottom member, bottom-to-top', () => {
+    // Models the real #6097->#6098->#6099 "spawn-repair-workflow command" stack.
+    const bottom = pr({ number: 9001, baseRefName: 'master', headRefName: 'stack/a' });
+    const middle = pr({ number: 9002, baseRefName: 'stack/a', headRefName: 'stack/b' });
+    const top = pr({ number: 9003, baseRefName: 'stack/b', headRefName: 'stack/c' });
+    const allOpenPrs = [bottom, middle, top];
+
+    const result = detectStack(bottom, allOpenPrs);
+
+    expect(result.members.map((m) => m.number)).toEqual([9001, 9002, 9003]);
+    expect(result.stackId).toBe('stack:master:9001,9002,9003');
+  });
+
+  it('Case A: finds the same stack when detection starts from the TOP member', () => {
+    const bottom = pr({ number: 9001, baseRefName: 'master', headRefName: 'stack/a' });
+    const middle = pr({ number: 9002, baseRefName: 'stack/a', headRefName: 'stack/b' });
+    const top = pr({ number: 9003, baseRefName: 'stack/b', headRefName: 'stack/c' });
+    const allOpenPrs = [bottom, middle, top];
+
+    const result = detectStack(top, allOpenPrs);
+
+    expect(result.members.map((m) => m.number)).toEqual([9001, 9002, 9003]);
+  });
+
+  it('Case B: finds a 2-PR stack where the bottom already has failing checks', () => {
+    // Models the real #6146->#6173 "Review Gate CI Repair" stack.
+    const bottom = pr({ number: 9101, baseRefName: 'master', headRefName: 'stack/x' });
+    const top = pr({ number: 9102, baseRefName: 'stack/x', headRefName: 'stack/y' });
+    const allOpenPrs = [bottom, top];
+
+    const result = detectStack(bottom, allOpenPrs);
+
+    expect(result.members.map((m) => m.number)).toEqual([9101, 9102]);
+    expect(result.stackId).toBe('stack:master:9101,9102');
+  });
+
+  it('degenerates to a stack of one when the PR is not on a stack/-prefixed branch', () => {
+    const failing = pr({ number: 42, headRefName: 'feature/plain-branch' });
+
+    const result = detectStack(failing, [failing]);
+
+    expect(result.members).toEqual([failing]);
+    expect(result.stackId).toBe('single:42');
+  });
+
+  it('degenerates to a stack of one when no sibling PRs share the branch chain', () => {
+    const failing = pr({ number: 9201, baseRefName: 'master', headRefName: 'stack/lonely' });
+    const unrelated = pr({ number: 9202, baseRefName: 'master', headRefName: 'stack/other' });
+
+    const result = detectStack(failing, [failing, unrelated]);
+
+    expect(result.members.map((m) => m.number)).toEqual([9201]);
+  });
+
+  it('stops growing upward on an ambiguous branch (two open children of the same base)', () => {
+    const bottom = pr({ number: 9301, baseRefName: 'master', headRefName: 'stack/a' });
+    const childOne = pr({ number: 9302, baseRefName: 'stack/a', headRefName: 'stack/b1' });
+    const childTwo = pr({ number: 9303, baseRefName: 'stack/a', headRefName: 'stack/b2' });
+
+    const result = detectStack(bottom, [bottom, childOne, childTwo]);
+
+    expect(result.members.map((m) => m.number)).toEqual([9301]);
+  });
+
+  it('stops walking downward when a lower stack PR is missing from the open set (already merged)', () => {
+    // Models #6146/#6173: the bottom PR merged, only the top sibling is still open.
+    const top = pr({ number: 9102, baseRefName: 'stack/x', headRefName: 'stack/y' });
+
+    const result = detectStack(top, [top]);
+
+    expect(result.members.map((m) => m.number)).toEqual([9102]);
+  });
+
+  it('excludes non-OPEN PRs from the walked stack even if passed in allOpenPrs', () => {
+    const bottom = pr({ number: 9401, baseRefName: 'master', headRefName: 'stack/a' });
+    const mergedMiddle = pr({ number: 9402, baseRefName: 'stack/a', headRefName: 'stack/b', state: 'MERGED' });
+
+    const result = detectStack(bottom, [bottom, mergedMiddle]);
+
+    expect(result.members.map((m) => m.number)).toEqual([9401]);
+  });
+});

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -61,6 +61,7 @@ export * from './auto-fix-recovery.js';
 export * from './review-gate-ci-repair.js';
 export * from './repair-workflow-spec.js';
 export * from './ci-failure-infra-classifier.js';
+export * from './pr-stack-detection.js';
 export * from './workers/pr-status-worker.js';
 export * from './workers/pr-summary-refresh-worker.js';
 export * from './workers/ci-failure-worker.js';

--- a/packages/execution-engine/src/pr-stack-detection.ts
+++ b/packages/execution-engine/src/pr-stack-detection.ts
@@ -1,0 +1,181 @@
+import { spawn } from 'node:child_process';
+
+import { killProcessGroup, SIGKILL_TIMEOUT_MS } from './process-utils.js';
+import { retryTransientGitHubCli } from './git-utils.js';
+
+export const STACK_TRUNK_DEFAULT = 'master';
+export const STACK_PREFIX_DEFAULT = 'stack/';
+
+const DEFAULT_GITHUB_CLI_TIMEOUT_MS = 60_000;
+const GITHUB_CLI_TIMEOUT_ENV = 'INVOKER_GITHUB_CLI_TIMEOUT_MS';
+
+export interface StackPrRecord {
+  readonly number: number;
+  readonly state: string;
+  readonly baseRefName: string;
+  readonly headRefName: string;
+  readonly headRefOid: string;
+}
+
+export interface PrStackDetectionResult {
+  /** Deterministic id for this stack, stable across repeated detections of the
+   *  same members (used as the dedup key for in-flight stack repairs). */
+  readonly stackId: string;
+  /** Bottom-to-top order: members[0] bases on trunk, each next member bases on
+   *  the previous member's head branch. */
+  readonly members: readonly StackPrRecord[];
+}
+
+export interface DetectStackOptions {
+  readonly trunk?: string;
+  readonly stackPrefix?: string;
+}
+
+/**
+ * Walk the open-PR base/head branch chain to find every PR in the same
+ * Mergify-managed stack as `failingPr`, ordered bottom-to-top. Ports the
+ * linkage algorithm from scripts/land-stack.mjs's analyzeCompleteOpenStack
+ * (base==prior-head chain, gated on a `stack/`-prefixed head branch) into TS,
+ * so the CI repair worker can batch a whole stack in one PlanDefinition
+ * instead of firing one repair plan per PR.
+ *
+ * Pure function, no I/O — a PR with no stack siblings (not on a `stack/`
+ * branch, or no linked neighbors found) degenerates to a single-member
+ * "stack of one", which is exactly today's single-PR repair behavior.
+ */
+export function detectStack(
+  failingPr: StackPrRecord,
+  allOpenPrs: readonly StackPrRecord[],
+  options: DetectStackOptions = {},
+): PrStackDetectionResult {
+  const trunk = options.trunk ?? STACK_TRUNK_DEFAULT;
+  const stackPrefix = options.stackPrefix ?? STACK_PREFIX_DEFAULT;
+
+  if (!failingPr.headRefName.startsWith(stackPrefix)) {
+    return { stackId: `single:${failingPr.number}`, members: [failingPr] };
+  }
+
+  const byNumber = new Map<number, StackPrRecord>();
+  for (const pr of [...allOpenPrs, failingPr]) {
+    if (pr.state === 'OPEN' && pr.headRefName.startsWith(stackPrefix)) {
+      byNumber.set(pr.number, pr);
+    }
+  }
+  const seed = byNumber.get(failingPr.number) ?? failingPr;
+  const openStackPrs = [...byNumber.values()];
+  const byHead = new Map(openStackPrs.map((pr) => [pr.headRefName, pr]));
+  const childrenByBase = new Map<string, StackPrRecord[]>();
+  for (const pr of openStackPrs) {
+    const children = childrenByBase.get(pr.baseRefName) ?? [];
+    children.push(pr);
+    childrenByBase.set(pr.baseRefName, children);
+  }
+
+  const members: StackPrRecord[] = [seed];
+  const seen = new Set<number>([seed.number]);
+
+  // Walk down toward trunk. A missing parent (already merged, or genuinely not
+  // open) or a cycle just stops the downward walk rather than erroring — the
+  // known-open lower bound is still a valid partial stack to batch.
+  let bottom = seed;
+  while (bottom.baseRefName !== trunk) {
+    const parent = byHead.get(bottom.baseRefName);
+    if (!parent || seen.has(parent.number)) break;
+    members.unshift(parent);
+    seen.add(parent.number);
+    bottom = parent;
+  }
+
+  // Walk up away from trunk. An ambiguous branch (more than one open PR based
+  // on the same head) stops the upward walk rather than guessing an order.
+  let top = members[members.length - 1];
+  for (;;) {
+    const children = (childrenByBase.get(top.headRefName) ?? []).filter((pr) => pr.number !== top.number);
+    if (children.length !== 1) break;
+    const child = children[0];
+    if (seen.has(child.number)) break;
+    members.push(child);
+    seen.add(child.number);
+    top = child;
+  }
+
+  const stackId = `stack:${trunk}:${members.map((pr) => pr.number).join(',')}`;
+  return { stackId, members };
+}
+
+function getGitHubCliTimeoutMs(): number {
+  const raw = process.env[GITHUB_CLI_TIMEOUT_ENV]?.trim();
+  if (!raw) return DEFAULT_GITHUB_CLI_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_GITHUB_CLI_TIMEOUT_MS;
+}
+
+/** Default `gh` exec: same spawn/timeout/process-group-kill shape used by
+ *  GitHubMergeGateProvider, so stack detection behaves consistently with the
+ *  rest of the review-gate GitHub CLI call sites. */
+async function execGh(cmd: string, args: string[], cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: process.platform !== 'win32',
+    });
+    const timeoutMs = getGitHubCliTimeoutMs();
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      fn();
+    };
+
+    timeout = setTimeout(() => {
+      killProcessGroup(child, 'SIGTERM');
+      const forceKill = setTimeout(() => killProcessGroup(child, 'SIGKILL'), SIGKILL_TIMEOUT_MS);
+      forceKill.unref?.();
+      finish(() => reject(new Error(`gh ${args.join(' ')} exceeded GitHub CLI timeout (${timeoutMs}ms) in ${cwd}.`)));
+    }, timeoutMs);
+    timeout.unref?.();
+
+    child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
+    child.on('error', (err) => finish(() => reject(err)));
+    child.on('close', (code) => finish(() => {
+      if (code === 0) resolve(stdout.trim());
+      else reject(new Error(`${cmd} ${args.join(' ')} failed (code ${code}): ${stderr.trim()}`));
+    }));
+  });
+}
+
+export interface FetchOpenStackPrsOptions {
+  readonly repo: string;
+  readonly cwd: string;
+  readonly exec?: (cmd: string, args: string[], cwd: string) => Promise<string>;
+}
+
+/** Live-fetch adapter: lists open PRs via `gh pr list` (same fields
+ *  land-stack.mjs and github-merge-gate-provider.ts already consume) for
+ *  detectStack to walk. Kept separate from detectStack so the linkage
+ *  algorithm stays pure and unit-testable without any `gh` calls. */
+export async function fetchOpenStackPrs(options: FetchOpenStackPrsOptions): Promise<StackPrRecord[]> {
+  const exec = options.exec ?? execGh;
+  const stdout = await retryTransientGitHubCli(() => exec('gh', [
+    'pr', 'list',
+    '--repo', options.repo,
+    '--state', 'open',
+    '--json', 'number,state,baseRefName,headRefName,headRefOid',
+    '--limit', '500',
+  ], options.cwd));
+  const rows = JSON.parse(stdout) as StackPrRecord[];
+  return rows.map((row) => ({
+    number: row.number,
+    state: row.state,
+    baseRefName: row.baseRefName,
+    headRefName: row.headRefName,
+    headRefOid: row.headRefOid,
+  }));
+}


### PR DESCRIPTION
## Summary

Adds a pure, unit-tested function that finds a failing PR's full Mergify stack.

It walks the same base/head branch-chain logic already used by `scripts/land-stack.mjs`, ported to TypeScript.

Given one PR and the set of currently open PRs, it returns every stack member, ordered bottom-to-top.

Nothing calls this yet. It exists so later work can batch repair across a whole stack instead of one PR at a time.

## Review Claim

Add `detectStack()` (pure) and a `gh`-backed `fetchOpenStackPrs()` adapter, with no call sites anywhere yet.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This is a brand-new file with zero imports anywhere else in the codebase. `grep -rn pr-stack-detection` (outside this file and its test) returns nothing, so this diff cannot change any runtime behavior.

## Slice Rationale

Foundation before behavior: the branch-chain walk is reused by the task-graph builder and the worker wiring that follow in this stack. Landing it standalone lets a reviewer verify the pure algorithm (and its edge cases — ambiguous branches, already-merged lower PRs, non-stack branches) before judging how it gets used.

## Non-goals

Does not wire into any worker. Does not change CI-repair behavior in any way.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/pr-stack-detection.test.ts` — 8 passed
- [x] `pnpm run check:types` — clean

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
