### PR TITLE
[Stack-batched CI repair](2) Add the stack-wide task-graph builder

### DIFF
--- a/packages/app/src/__tests__/review-gate-stack-repair-workflow.test.ts
+++ b/packages/app/src/__tests__/review-gate-stack-repair-workflow.test.ts
@@ -1,0 +1,282 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestHarness, type TestHarness } from '@invoker/test-kit';
+import type { ReviewGateCiRepairWorkflowMutationArgs, StackPrRecord } from '@invoker/execution-engine';
+import type { PlanDefinition } from '@invoker/workflow-core';
+
+import {
+  assertMembersNotStale,
+  buildStackRepairPlanTasks,
+  spawnReviewGateStackCiRepairWorkflow,
+} from '../review-gate-stack-repair-workflow.js';
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+const SOURCE_PLAN: PlanDefinition = {
+  name: 'Source review gate workflow',
+  onFinish: 'none',
+  mergeMode: 'manual',
+  baseBranch: 'master',
+  featureBranch: 'feature/review-gate-ci',
+  repoUrl: 'memory://repo.git',
+  intermediateRepoUrl: 'memory://intermediate.git',
+  tasks: [
+    { id: 'A', description: 'Task A', command: 'echo a' },
+  ],
+};
+
+async function driveSourceGateToReviewReady(
+  h: TestHarness,
+): Promise<{ workflowId: string; mergeId: string }> {
+  h.loadAndStart(SOURCE_PLAN);
+  h.completeTask('A');
+  const mergeTask = h.getAllTasks().find((task) => task.config.isMergeNode);
+  expect(mergeTask).toBeDefined();
+  await h.executor.executeTasks([mergeTask!]);
+  expect(h.getTask(mergeTask!.id)?.status).toBe('review_ready');
+
+  const gate = h.getTask(mergeTask!.id)!;
+  const generation = gate.execution.generation ?? 0;
+  h.persistence.updateTask(mergeTask!.id, {
+    execution: {
+      reviewId: '9501',
+      branch: 'feature/review-gate-ci',
+      reviewGate: {
+        activeGeneration: generation,
+        completion: gate.execution.reviewGate?.completion ?? { required: 'all', status: 'approved' },
+        artifacts: [{
+          id: 'pr-9501',
+          providerId: '9501',
+          provider: 'github',
+          required: true,
+          status: 'open',
+          generation,
+          headSha: 'sha-9501',
+        }],
+      },
+    },
+  });
+  h.orchestrator.getWorkflowStatus();
+  return { workflowId: gate.config.workflowId!, mergeId: mergeTask!.id };
+}
+
+function makeTriggeringArgs(
+  h: TestHarness,
+  mergeId: string,
+  workflowId: string,
+  overrides: Partial<ReviewGateCiRepairWorkflowMutationArgs> = {},
+): ReviewGateCiRepairWorkflowMutationArgs {
+  const gate = h.getTask(mergeId)!;
+  return {
+    sourceWorkflowId: workflowId,
+    sourceTaskId: mergeId,
+    reviewId: '9501',
+    reviewUrl: 'https://github.com/owner/repo/pull/9501',
+    headSha: 'sha-9501',
+    headRef: 'stack/bottom',
+    branch: 'feature/review-gate-ci',
+    generation: gate.execution.generation ?? 0,
+    selectedAttemptId: gate.execution.selectedAttemptId,
+    failedChecks: [{ name: 'unit', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/1' }],
+    statusText: 'CI failed',
+    taskStateVersion: gate.taskStateVersion,
+    ...overrides,
+  };
+}
+
+function member(overrides: Partial<StackPrRecord> & { number: number }): StackPrRecord {
+  return {
+    state: 'OPEN',
+    baseRefName: 'master',
+    headRefName: `stack/pr-${overrides.number}`,
+    headRefOid: `sha-${overrides.number}`,
+    ...overrides,
+  };
+}
+
+const BASE_TRIGGERING: ReviewGateCiRepairWorkflowMutationArgs = {
+  sourceWorkflowId: 'wf-1',
+  sourceTaskId: 'wf-1/merge',
+  reviewId: '9001',
+  reviewUrl: 'https://github.com/owner/repo/pull/9001',
+  headSha: 'sha-9001',
+  generation: 0,
+  failedChecks: [
+    { name: 'unit', conclusion: 'FAILURE' },
+    { name: 'lint', conclusion: 'FAILURE' },
+  ],
+  statusText: 'CI failed',
+  taskStateVersion: 1,
+};
+
+describe('buildStackRepairPlanTasks', () => {
+  it('Case A: only the triggering (bottom) PR gets check-fix tasks; every member gets a chained recheck task', () => {
+    const members = [
+      member({ number: 9001, headRefName: 'stack/a' }),
+      member({ number: 9002, baseRefName: 'stack/a', headRefName: 'stack/b' }),
+      member({ number: 9003, baseRefName: 'stack/b', headRefName: 'stack/c' }),
+    ];
+
+    const tasks = buildStackRepairPlanTasks(members, BASE_TRIGGERING, 'master');
+
+    expect(tasks.map((t) => t.id)).toEqual([
+      'pr-9001-check-0-unit',
+      'pr-9001-check-1-lint',
+      'pr-9001-recheck',
+      'pr-9002-recheck',
+      'pr-9003-recheck',
+    ]);
+    expect(tasks.find((t) => t.id === 'pr-9001-check-0-unit')?.dependencies).toBeUndefined();
+    expect(tasks.find((t) => t.id === 'pr-9001-recheck')?.dependencies).toEqual([
+      'pr-9001-check-0-unit',
+      'pr-9001-check-1-lint',
+    ]);
+    expect(tasks.find((t) => t.id === 'pr-9002-recheck')?.dependencies).toEqual(['pr-9001-recheck']);
+    expect(tasks.find((t) => t.id === 'pr-9003-recheck')?.dependencies).toEqual(['pr-9002-recheck']);
+  });
+
+  it('Case B: a middle-of-stack trigger gates its own check tasks on the PR below AND gates the PR above on itself', () => {
+    const members = [
+      member({ number: 9101, headRefName: 'stack/x' }),
+      member({ number: 9102, baseRefName: 'stack/x', headRefName: 'stack/y' }),
+    ];
+    const triggering: ReviewGateCiRepairWorkflowMutationArgs = {
+      ...BASE_TRIGGERING,
+      reviewId: '9102',
+      failedChecks: [{ name: 'e2e', conclusion: 'FAILURE' }],
+    };
+
+    const tasks = buildStackRepairPlanTasks(members, triggering, 'master');
+
+    expect(tasks.map((t) => t.id)).toEqual(['pr-9101-recheck', 'pr-9102-check-0-e2e', 'pr-9102-recheck']);
+    expect(tasks.find((t) => t.id === 'pr-9101-recheck')?.dependencies).toEqual([]);
+    // The bottom PR has no failing checks assigned to this batch, so its recheck
+    // has no dependencies of its own -- but everything on PR #9102 still waits
+    // on PR #9101's recheck completing first.
+    expect(tasks.find((t) => t.id === 'pr-9102-check-0-e2e')?.dependencies).toEqual(['pr-9101-recheck']);
+    expect(tasks.find((t) => t.id === 'pr-9102-recheck')?.dependencies).toEqual([
+      'pr-9102-check-0-e2e',
+      'pr-9101-recheck',
+    ]);
+  });
+
+  it('gives every member a featureBranch matching its own head branch', () => {
+    const members = [
+      member({ number: 9201, headRefName: 'stack/one' }),
+      member({ number: 9202, baseRefName: 'stack/one', headRefName: 'stack/two' }),
+    ];
+    const tasks = buildStackRepairPlanTasks(members, { ...BASE_TRIGGERING, reviewId: '9201' }, 'master');
+
+    expect(tasks.find((t) => t.id === 'pr-9201-recheck')?.featureBranch).toBe('stack/one');
+    expect(tasks.find((t) => t.id === 'pr-9202-recheck')?.featureBranch).toBe('stack/two');
+  });
+});
+
+describe('assertMembersNotStale', () => {
+  it('Case C: throws when a member head SHA changed since detection', async () => {
+    const detected = [
+      member({ number: 9101, headRefName: 'stack/x', headRefOid: 'sha-a' }),
+      member({ number: 9102, baseRefName: 'stack/x', headRefName: 'stack/y', headRefOid: 'sha-b' }),
+    ];
+    const fetchOpenStackPrs = async () => [
+      detected[0],
+      { ...detected[1], headRefOid: 'sha-b-changed-by-a-push' },
+    ];
+
+    await expect(assertMembersNotStale(detected, fetchOpenStackPrs)).rejects.toThrow(
+      'PR #9102 head changed (sha-b → sha-b-changed-by-a-push)',
+    );
+  });
+
+  it('throws when a member is no longer open (merged or closed out from under the batch)', async () => {
+    const detected = [member({ number: 9201 })];
+    const fetchOpenStackPrs = async () => [];
+
+    await expect(assertMembersNotStale(detected, fetchOpenStackPrs)).rejects.toThrow(
+      'PR #9201 is no longer open',
+    );
+  });
+
+  it('resolves without throwing when nothing has changed', async () => {
+    const detected = [member({ number: 9301 }), member({ number: 9302, baseRefName: 'stack/pr-9301' })];
+    await expect(assertMembersNotStale(detected, async () => detected)).resolves.toBeUndefined();
+  });
+});
+
+describe('spawnReviewGateStackCiRepairWorkflow', () => {
+  let h: TestHarness;
+
+  beforeEach(() => {
+    h = createTestHarness();
+  });
+
+  it('Case C: aborts before creating any workflow when a member has gone stale', async () => {
+    const { workflowId, mergeId } = await driveSourceGateToReviewReady(h);
+    const triggering = makeTriggeringArgs(h, mergeId, workflowId);
+    const members = [member({ number: 9501, headRefName: 'stack/bottom', headRefOid: 'sha-9501' })];
+    const workflowIdsBefore = h.persistence.listWorkflows().map((workflow) => workflow.id);
+
+    await expect(spawnReviewGateStackCiRepairWorkflow(
+      { stackId: 'stack:master:9501', members, triggering },
+      {
+        orchestrator: h.orchestrator,
+        persistence: h.persistence,
+        logger,
+        // Live state disagrees with detection-time state -> fail closed.
+        fetchOpenStackPrs: async () => [{ ...members[0], headRefOid: 'sha-9501-moved' }],
+      },
+    )).rejects.toThrow('PR #9501 head changed');
+
+    expect(h.persistence.listWorkflows().map((workflow) => workflow.id)).toEqual(workflowIdsBefore);
+  });
+
+  it('Case D: a permanently-stuck bottom PR blocks the PR above it without ever marking it stale', async () => {
+    const { workflowId, mergeId } = await driveSourceGateToReviewReady(h);
+    const triggering = makeTriggeringArgs(h, mergeId, workflowId);
+    const members = [
+      member({ number: 9501, headRefName: 'stack/bottom', headRefOid: 'sha-9501' }),
+      member({ number: 9502, baseRefName: 'stack/bottom', headRefName: 'stack/top', headRefOid: 'sha-9502' }),
+    ];
+
+    const result = await spawnReviewGateStackCiRepairWorkflow(
+      { stackId: 'stack:master:9501,9502', members, triggering },
+      {
+        orchestrator: h.orchestrator,
+        persistence: h.persistence,
+        logger,
+        fetchOpenStackPrs: async () => members,
+      },
+    );
+
+    const bottomRecheckId = result.memberTaskIds[9501];
+    const topRecheckId = result.memberTaskIds[9502];
+    const checkTaskId = result.started.find((task) => task.id.endsWith('check-0-unit'))!.id;
+
+    // Before the bottom PR's own check is even fixed, the PR above it must not
+    // have started -- and simulating "permanently stuck" (never completing the
+    // bottom recheck task, never marking it `stale`) must keep it that way.
+    expect(h.getTask(topRecheckId)?.status).not.toBe('running');
+    expect(h.getTask(topRecheckId)?.status).not.toBe('completed');
+
+    h.completeTask(checkTaskId);
+    // Bottom PR's recheck task is now unblocked and running, but has NOT
+    // completed -- the "permanently stuck, needs a human" case. It must never
+    // be marked `stale` (that status would spuriously satisfy the PR-above's
+    // dependency in ActionGraph.getReadyNodes()).
+    expect(h.getTask(bottomRecheckId)?.status).toBe('running');
+    expect(h.getTask(topRecheckId)?.status).not.toBe('running');
+    expect(h.getTask(topRecheckId)?.status).not.toBe('completed');
+    expect(h.getTask(bottomRecheckId)?.status).not.toBe('stale');
+
+    // Only once the bottom PR's recheck genuinely completes does the PR above
+    // it become ready and auto-start.
+    h.completeTask(bottomRecheckId);
+    expect(h.getTask(topRecheckId)?.status).toBe('running');
+  });
+});

--- a/packages/app/src/review-gate-ci-repair-workflow.ts
+++ b/packages/app/src/review-gate-ci-repair-workflow.ts
@@ -43,7 +43,7 @@ function currentReviewGateLineage(task: TaskState, reviewId: string): {
   };
 }
 
-function loadSourceTask(
+export function loadSourceTask(
   sourceWorkflowId: string,
   sourceTaskId: string,
   deps: SpawnReviewGateCiRepairWorkflowDeps,
@@ -55,7 +55,7 @@ function loadSourceTask(
   return deps.persistence.loadTasks(sourceWorkflowId).find((task) => task.id === sourceTaskId);
 }
 
-function assertSourceReviewGateLineage(task: TaskState, args: ReviewGateCiRepairWorkflowMutationArgs): void {
+export function assertSourceReviewGateLineage(task: TaskState, args: ReviewGateCiRepairWorkflowMutationArgs): void {
   if (task.config.workflowId !== args.sourceWorkflowId) {
     throw new Error(
       `Review-gate CI repair workflow is stale: source workflow changed (${args.sourceWorkflowId} → ${task.config.workflowId ?? 'missing'}).`,
@@ -102,7 +102,7 @@ function resolveBranch(task: TaskState, featureBranch: string | undefined, args:
   return branch;
 }
 
-function resolveBaseBranch(baseBranch: string | undefined): string {
+export function resolveBaseBranch(baseBranch: string | undefined): string {
   const resolved = baseBranch?.trim();
   if (!resolved) {
     throw new Error('Review-gate CI repair requires source workflow baseBranch.');
@@ -110,7 +110,7 @@ function resolveBaseBranch(baseBranch: string | undefined): string {
   return resolved;
 }
 
-function buildFailedCheckBullet(check: ReviewGateCiRepairWorkflowMutationArgs['failedChecks'][number]): string {
+export function buildFailedCheckBullet(check: ReviewGateCiRepairWorkflowMutationArgs['failedChecks'][number]): string {
   const conclusion = check.conclusion ? ` (${check.conclusion})` : '';
   const detailsUrl = check.detailsUrl ? ` — ${check.detailsUrl}` : '';
   return `- ${check.name}${conclusion}${detailsUrl}`;

--- a/packages/app/src/review-gate-stack-repair-workflow.ts
+++ b/packages/app/src/review-gate-stack-repair-workflow.ts
@@ -1,0 +1,228 @@
+import type { Logger } from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type {
+  ReviewGateCiRepairWorkflowMutationArgs,
+  ReviewGateFailedCheck,
+  StackPrRecord,
+} from '@invoker/execution-engine';
+import type { Orchestrator, PlanDefinition, TaskState } from '@invoker/workflow-core';
+
+import { backupPlan } from './plan-backup.js';
+import {
+  assertSourceReviewGateLineage,
+  buildFailedCheckBullet,
+  loadSourceTask,
+  resolveBaseBranch,
+  type SpawnReviewGateCiRepairWorkflowDeps,
+} from './review-gate-ci-repair-workflow.js';
+
+export interface SpawnReviewGateStackCiRepairWorkflowArgs {
+  /** Deterministic id from pr-stack-detection's detectStack(), used as the
+   *  dedup key for in-flight stack repairs. */
+  readonly stackId: string;
+  /** Bottom-to-top stack membership at detection time — re-verified live
+   *  (see assertMembersNotStale) before any plan is built. */
+  readonly members: readonly StackPrRecord[];
+  /** The single PR whose review_gate.ci_failed event actually triggered this
+   *  batch. Only this member gets check-fix tasks in v1 — every other member
+   *  gets a pass-through recheck task that gates the PR above it. A sibling's
+   *  own failing checks get added the next time ITS OWN event fires and finds
+   *  this same stack (at which point it becomes the triggering member). */
+  readonly triggering: ReviewGateCiRepairWorkflowMutationArgs;
+}
+
+export interface SpawnReviewGateStackCiRepairWorkflowDeps {
+  orchestrator: Pick<Orchestrator, 'getWorkflowIds' | 'loadPlan' | 'startExecution'>;
+  persistence: SpawnReviewGateCiRepairWorkflowDeps['persistence'];
+  /** Re-fetches live PR state for every member so a stack that changed shape
+   *  (a push, a merge, a close) between detection and spawn never proceeds. */
+  fetchOpenStackPrs: () => Promise<readonly StackPrRecord[]>;
+  logger?: Logger;
+  allowGraphMutation?: boolean;
+}
+
+export interface SpawnReviewGateStackCiRepairWorkflowResult {
+  workflowId: string;
+  stackId: string;
+  /** PR number -> that member's recheck task id, so callers (and the
+   *  in-flight ledger) can watch each member's terminal state. */
+  memberTaskIds: Readonly<Record<number, string>>;
+  started: TaskState[];
+}
+
+function slugifyCheckName(name: string): string {
+  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return slug || 'check';
+}
+
+function checkTaskId(prNumber: number, index: number, checkName: string): string {
+  return `pr-${prNumber}-check-${index}-${slugifyCheckName(checkName)}`;
+}
+
+function recheckTaskId(prNumber: number): string {
+  return `pr-${prNumber}-recheck`;
+}
+
+function buildCheckFixPrompt(
+  member: StackPrRecord,
+  check: ReviewGateFailedCheck,
+  baseBranch: string,
+  triggering: ReviewGateCiRepairWorkflowMutationArgs,
+): string {
+  return [
+    `Repair one failing check on pull request #${member.number} (part of a Mergify stack).`,
+    `PR URL: ${triggering.reviewUrl}`,
+    `Head branch: ${member.headRefName}`,
+    `Head SHA: ${member.headRefOid}`,
+    `Base branch: ${baseBranch}`,
+    '',
+    'Work directly on the review branch:',
+    `  git fetch origin ${member.headRefName} && git checkout ${member.headRefName}`,
+    '',
+    'Failed check to clear:',
+    buildFailedCheckBullet(check),
+    '',
+    'Rules:',
+    '- Fix only this failing check on the same branch.',
+    `- Push your changes to the same branch (${member.headRefName}).`,
+    '- Never open a new PR.',
+    '- Do not touch any other PR in the stack.',
+  ].join('\n');
+}
+
+function buildRecheckPrompt(member: StackPrRecord, baseBranch: string): string {
+  return [
+    `Confirm pull request #${member.number} is green after its stack-mates' repairs.`,
+    `Head branch: ${member.headRefName}`,
+    `Base branch: ${baseBranch}`,
+    '',
+    'This PR had no failing checks assigned to this batch, or its check-fix',
+    'tasks above have already completed. Re-fetch its current required checks',
+    '(`gh pr checks` or the review-gate poll) and confirm they are green before',
+    'reporting done. If a required check is still failing, say so plainly —',
+    'do not silently retry a fix here; a fresh CI-failure event on this PR is',
+    'what should trigger new check-fix tasks.',
+  ].join('\n');
+}
+
+/**
+ * One task per failing required check on the TRIGGERING member (Q, R, S),
+ * plus one pass-through "recheck" task per member gated on that member's own
+ * check tasks. Cross-PR ordering: member N's tasks additionally depend on
+ * member N-1's recheck task, so nothing above a broken PR ever starts before
+ * that PR is confirmed green. See pr-stack-detection.ts for how `members` is
+ * derived and review-gate-stack-repair-workflow.ts's module doc for why only
+ * the triggering member gets check-fix tasks in v1.
+ */
+export function buildStackRepairPlanTasks(
+  members: readonly StackPrRecord[],
+  triggering: ReviewGateCiRepairWorkflowMutationArgs,
+  baseBranch: string,
+): PlanDefinition['tasks'] {
+  const tasks: PlanDefinition['tasks'] = [];
+  let previousRecheckId: string | undefined;
+
+  for (const member of members) {
+    const isTriggering = String(member.number) === triggering.reviewId;
+    const ownCheckIds: string[] = [];
+
+    if (isTriggering) {
+      triggering.failedChecks.forEach((check, index) => {
+        const id = checkTaskId(member.number, index, check.name);
+        ownCheckIds.push(id);
+        tasks.push({
+          id,
+          description: `PR #${member.number}: fix failing check ${check.name}`,
+          prompt: buildCheckFixPrompt(member, check, baseBranch, triggering),
+          featureBranch: member.headRefName,
+          ...(previousRecheckId ? { dependencies: [previousRecheckId] } : {}),
+        });
+      });
+    }
+
+    tasks.push({
+      id: recheckTaskId(member.number),
+      description: `PR #${member.number}: recheck after repairs`,
+      prompt: buildRecheckPrompt(member, baseBranch),
+      featureBranch: member.headRefName,
+      dependencies: previousRecheckId ? [...ownCheckIds, previousRecheckId] : ownCheckIds,
+    });
+
+    previousRecheckId = recheckTaskId(member.number);
+  }
+
+  return tasks;
+}
+
+/**
+ * Fail-closed guard for the whole batch (plan §4/§1): re-fetches live PR
+ * state and aborts before anything is built if ANY member has moved (closed,
+ * merged out from under us, or a new head SHA landed) since detectStack()
+ * ran. A stale member could silently break the dependency chain other
+ * members' tasks rely on, so one bad member blocks the whole spawn rather
+ * than being dropped.
+ */
+export async function assertMembersNotStale(
+  members: readonly StackPrRecord[],
+  fetchOpenStackPrs: () => Promise<readonly StackPrRecord[]>,
+): Promise<void> {
+  const latest = await fetchOpenStackPrs();
+  const byNumber = new Map(latest.map((pr) => [pr.number, pr] as const));
+  for (const member of members) {
+    const current = byNumber.get(member.number);
+    if (!current || current.state !== 'OPEN') {
+      throw new Error(
+        `Review-gate stack CI repair is stale: PR #${member.number} is no longer open.`,
+      );
+    }
+    if (current.headRefOid !== member.headRefOid) {
+      throw new Error(
+        `Review-gate stack CI repair is stale: PR #${member.number} head changed `
+        + `(${member.headRefOid} → ${current.headRefOid}).`,
+      );
+    }
+  }
+}
+
+export async function spawnReviewGateStackCiRepairWorkflow(
+  args: SpawnReviewGateStackCiRepairWorkflowArgs,
+  deps: SpawnReviewGateStackCiRepairWorkflowDeps,
+): Promise<SpawnReviewGateStackCiRepairWorkflowResult> {
+  const sourceTask = loadSourceTask(args.triggering.sourceWorkflowId, args.triggering.sourceTaskId, deps);
+  if (!sourceTask) {
+    throw new Error(`Review-gate stack CI repair source task ${args.triggering.sourceTaskId} not found.`);
+  }
+  const sourceWorkflow = deps.persistence.loadWorkflow(args.triggering.sourceWorkflowId);
+  if (!sourceWorkflow) {
+    throw new Error(`Review-gate stack CI repair source workflow ${args.triggering.sourceWorkflowId} not found.`);
+  }
+  assertSourceReviewGateLineage(sourceTask, args.triggering);
+  await assertMembersNotStale(args.members, deps.fetchOpenStackPrs);
+
+  const baseBranch = resolveBaseBranch(sourceWorkflow.baseBranch);
+  const headShaOrNoHead = args.triggering.headSha ?? 'no-head';
+  const planNameSafeStackId = args.stackId.replace(/[^a-zA-Z0-9]+/g, '-');
+  const plan: PlanDefinition = {
+    name: `repair-review-gate-ci-stack-${planNameSafeStackId}-${headShaOrNoHead}`,
+    onFinish: 'none',
+    baseBranch,
+    ...(sourceWorkflow.repoUrl ? { repoUrl: sourceWorkflow.repoUrl } : {}),
+    ...(sourceWorkflow.intermediateRepoUrl ? { intermediateRepoUrl: sourceWorkflow.intermediateRepoUrl } : {}),
+    tasks: buildStackRepairPlanTasks(args.members, args.triggering, baseBranch),
+  };
+
+  const existingWorkflowIds = new Set(deps.persistence.listWorkflows().map((workflow) => workflow.id));
+  backupPlan(plan, undefined, deps.logger);
+  deps.orchestrator.loadPlan(plan, { allowGraphMutation: deps.allowGraphMutation });
+  const workflowId = deps.orchestrator.getWorkflowIds().find((id) => !existingWorkflowIds.has(id));
+  if (!workflowId) {
+    throw new Error('Loaded review-gate stack CI repair plan did not create a workflow.');
+  }
+  const started = deps.orchestrator
+    .startExecution()
+    .filter((task) => task.config.workflowId === workflowId);
+  const memberTaskIds = Object.fromEntries(
+    args.members.map((member) => [member.number, `${workflowId}/${recheckTaskId(member.number)}`]),
+  );
+  return { workflowId, stackId: args.stackId, memberTaskIds, started };
+}

--- a/packages/execution-engine/src/__tests__/pr-stack-detection.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-stack-detection.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { detectStack, type StackPrRecord } from '../pr-stack-detection.js';
+
+function pr(overrides: Partial<StackPrRecord> & { number: number }): StackPrRecord {
+  return {
+    state: 'OPEN',
+    baseRefName: 'master',
+    headRefName: `stack/pr-${overrides.number}`,
+    headRefOid: `sha-${overrides.number}`,
+    ...overrides,
+  };
+}
+
+describe('detectStack', () => {
+  it('Case A: finds a full linear 3-PR stack from the bottom member, bottom-to-top', () => {
+    // Models the real #6097->#6098->#6099 "spawn-repair-workflow command" stack.
+    const bottom = pr({ number: 9001, baseRefName: 'master', headRefName: 'stack/a' });
+    const middle = pr({ number: 9002, baseRefName: 'stack/a', headRefName: 'stack/b' });
+    const top = pr({ number: 9003, baseRefName: 'stack/b', headRefName: 'stack/c' });
+    const allOpenPrs = [bottom, middle, top];
+
+    const result = detectStack(bottom, allOpenPrs);
+
+    expect(result.members.map((m) => m.number)).toEqual([9001, 9002, 9003]);
+    expect(result.stackId).toBe('stack:master:9001,9002,9003');
+  });
+
+  it('Case A: finds the same stack when detection starts from the TOP member', () => {
+    const bottom = pr({ number: 9001, baseRefName: 'master', headRefName: 'stack/a' });
+    const middle = pr({ number: 9002, baseRefName: 'stack/a', headRefName: 'stack/b' });
+    const top = pr({ number: 9003, baseRefName: 'stack/b', headRefName: 'stack/c' });
+    const allOpenPrs = [bottom, middle, top];
+
+    const result = detectStack(top, allOpenPrs);
+
+    expect(result.members.map((m) => m.number)).toEqual([9001, 9002, 9003]);
+  });
+
+  it('Case B: finds a 2-PR stack where the bottom already has failing checks', () => {
+    // Models the real #6146->#6173 "Review Gate CI Repair" stack.
+    const bottom = pr({ number: 9101, baseRefName: 'master', headRefName: 'stack/x' });
+    const top = pr({ number: 9102, baseRefName: 'stack/x', headRefName: 'stack/y' });
+    const allOpenPrs = [bottom, top];
+
+    const result = detectStack(bottom, allOpenPrs);
+
+    expect(result.members.map((m) => m.number)).toEqual([9101, 9102]);
+    expect(result.stackId).toBe('stack:master:9101,9102');
+  });
+
+  it('degenerates to a stack of one when the PR is not on a stack/-prefixed branch', () => {
+    const failing = pr({ number: 42, headRefName: 'feature/plain-branch' });
+
+    const result = detectStack(failing, [failing]);
+
+    expect(result.members).toEqual([failing]);
+    expect(result.stackId).toBe('single:42');
+  });
+
+  it('degenerates to a stack of one when no sibling PRs share the branch chain', () => {
+    const failing = pr({ number: 9201, baseRefName: 'master', headRefName: 'stack/lonely' });
+    const unrelated = pr({ number: 9202, baseRefName: 'master', headRefName: 'stack/other' });
+
+    const result = detectStack(failing, [failing, unrelated]);
+
+    expect(result.members.map((m) => m.number)).toEqual([9201]);
+  });
+
+  it('stops growing upward on an ambiguous branch (two open children of the same base)', () => {
+    const bottom = pr({ number: 9301, baseRefName: 'master', headRefName: 'stack/a' });
+    const childOne = pr({ number: 9302, baseRefName: 'stack/a', headRefName: 'stack/b1' });
+    const childTwo = pr({ number: 9303, baseRefName: 'stack/a', headRefName: 'stack/b2' });
+
+    const result = detectStack(bottom, [bottom, childOne, childTwo]);
+
+    expect(result.members.map((m) => m.number)).toEqual([9301]);
+  });
+
+  it('stops walking downward when a lower stack PR is missing from the open set (already merged)', () => {
+    // Models #6146/#6173: the bottom PR merged, only the top sibling is still open.
+    const top = pr({ number: 9102, baseRefName: 'stack/x', headRefName: 'stack/y' });
+
+    const result = detectStack(top, [top]);
+
+    expect(result.members.map((m) => m.number)).toEqual([9102]);
+  });
+
+  it('excludes non-OPEN PRs from the walked stack even if passed in allOpenPrs', () => {
+    const bottom = pr({ number: 9401, baseRefName: 'master', headRefName: 'stack/a' });
+    const mergedMiddle = pr({ number: 9402, baseRefName: 'stack/a', headRefName: 'stack/b', state: 'MERGED' });
+
+    const result = detectStack(bottom, [bottom, mergedMiddle]);
+
+    expect(result.members.map((m) => m.number)).toEqual([9401]);
+  });
+});

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -61,6 +61,7 @@ export * from './auto-fix-recovery.js';
 export * from './review-gate-ci-repair.js';
 export * from './repair-workflow-spec.js';
 export * from './ci-failure-infra-classifier.js';
+export * from './pr-stack-detection.js';
 export * from './workers/pr-status-worker.js';
 export * from './workers/pr-summary-refresh-worker.js';
 export * from './workers/ci-failure-worker.js';

--- a/packages/execution-engine/src/pr-stack-detection.ts
+++ b/packages/execution-engine/src/pr-stack-detection.ts
@@ -1,0 +1,181 @@
+import { spawn } from 'node:child_process';
+
+import { killProcessGroup, SIGKILL_TIMEOUT_MS } from './process-utils.js';
+import { retryTransientGitHubCli } from './git-utils.js';
+
+export const STACK_TRUNK_DEFAULT = 'master';
+export const STACK_PREFIX_DEFAULT = 'stack/';
+
+const DEFAULT_GITHUB_CLI_TIMEOUT_MS = 60_000;
+const GITHUB_CLI_TIMEOUT_ENV = 'INVOKER_GITHUB_CLI_TIMEOUT_MS';
+
+export interface StackPrRecord {
+  readonly number: number;
+  readonly state: string;
+  readonly baseRefName: string;
+  readonly headRefName: string;
+  readonly headRefOid: string;
+}
+
+export interface PrStackDetectionResult {
+  /** Deterministic id for this stack, stable across repeated detections of the
+   *  same members (used as the dedup key for in-flight stack repairs). */
+  readonly stackId: string;
+  /** Bottom-to-top order: members[0] bases on trunk, each next member bases on
+   *  the previous member's head branch. */
+  readonly members: readonly StackPrRecord[];
+}
+
+export interface DetectStackOptions {
+  readonly trunk?: string;
+  readonly stackPrefix?: string;
+}
+
+/**
+ * Walk the open-PR base/head branch chain to find every PR in the same
+ * Mergify-managed stack as `failingPr`, ordered bottom-to-top. Ports the
+ * linkage algorithm from scripts/land-stack.mjs's analyzeCompleteOpenStack
+ * (base==prior-head chain, gated on a `stack/`-prefixed head branch) into TS,
+ * so the CI repair worker can batch a whole stack in one PlanDefinition
+ * instead of firing one repair plan per PR.
+ *
+ * Pure function, no I/O — a PR with no stack siblings (not on a `stack/`
+ * branch, or no linked neighbors found) degenerates to a single-member
+ * "stack of one", which is exactly today's single-PR repair behavior.
+ */
+export function detectStack(
+  failingPr: StackPrRecord,
+  allOpenPrs: readonly StackPrRecord[],
+  options: DetectStackOptions = {},
+): PrStackDetectionResult {
+  const trunk = options.trunk ?? STACK_TRUNK_DEFAULT;
+  const stackPrefix = options.stackPrefix ?? STACK_PREFIX_DEFAULT;
+
+  if (!failingPr.headRefName.startsWith(stackPrefix)) {
+    return { stackId: `single:${failingPr.number}`, members: [failingPr] };
+  }
+
+  const byNumber = new Map<number, StackPrRecord>();
+  for (const pr of [...allOpenPrs, failingPr]) {
+    if (pr.state === 'OPEN' && pr.headRefName.startsWith(stackPrefix)) {
+      byNumber.set(pr.number, pr);
+    }
+  }
+  const seed = byNumber.get(failingPr.number) ?? failingPr;
+  const openStackPrs = [...byNumber.values()];
+  const byHead = new Map(openStackPrs.map((pr) => [pr.headRefName, pr]));
+  const childrenByBase = new Map<string, StackPrRecord[]>();
+  for (const pr of openStackPrs) {
+    const children = childrenByBase.get(pr.baseRefName) ?? [];
+    children.push(pr);
+    childrenByBase.set(pr.baseRefName, children);
+  }
+
+  const members: StackPrRecord[] = [seed];
+  const seen = new Set<number>([seed.number]);
+
+  // Walk down toward trunk. A missing parent (already merged, or genuinely not
+  // open) or a cycle just stops the downward walk rather than erroring — the
+  // known-open lower bound is still a valid partial stack to batch.
+  let bottom = seed;
+  while (bottom.baseRefName !== trunk) {
+    const parent = byHead.get(bottom.baseRefName);
+    if (!parent || seen.has(parent.number)) break;
+    members.unshift(parent);
+    seen.add(parent.number);
+    bottom = parent;
+  }
+
+  // Walk up away from trunk. An ambiguous branch (more than one open PR based
+  // on the same head) stops the upward walk rather than guessing an order.
+  let top = members[members.length - 1];
+  for (;;) {
+    const children = (childrenByBase.get(top.headRefName) ?? []).filter((pr) => pr.number !== top.number);
+    if (children.length !== 1) break;
+    const child = children[0];
+    if (seen.has(child.number)) break;
+    members.push(child);
+    seen.add(child.number);
+    top = child;
+  }
+
+  const stackId = `stack:${trunk}:${members.map((pr) => pr.number).join(',')}`;
+  return { stackId, members };
+}
+
+function getGitHubCliTimeoutMs(): number {
+  const raw = process.env[GITHUB_CLI_TIMEOUT_ENV]?.trim();
+  if (!raw) return DEFAULT_GITHUB_CLI_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_GITHUB_CLI_TIMEOUT_MS;
+}
+
+/** Default `gh` exec: same spawn/timeout/process-group-kill shape used by
+ *  GitHubMergeGateProvider, so stack detection behaves consistently with the
+ *  rest of the review-gate GitHub CLI call sites. */
+async function execGh(cmd: string, args: string[], cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: process.platform !== 'win32',
+    });
+    const timeoutMs = getGitHubCliTimeoutMs();
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      fn();
+    };
+
+    timeout = setTimeout(() => {
+      killProcessGroup(child, 'SIGTERM');
+      const forceKill = setTimeout(() => killProcessGroup(child, 'SIGKILL'), SIGKILL_TIMEOUT_MS);
+      forceKill.unref?.();
+      finish(() => reject(new Error(`gh ${args.join(' ')} exceeded GitHub CLI timeout (${timeoutMs}ms) in ${cwd}.`)));
+    }, timeoutMs);
+    timeout.unref?.();
+
+    child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
+    child.on('error', (err) => finish(() => reject(err)));
+    child.on('close', (code) => finish(() => {
+      if (code === 0) resolve(stdout.trim());
+      else reject(new Error(`${cmd} ${args.join(' ')} failed (code ${code}): ${stderr.trim()}`));
+    }));
+  });
+}
+
+export interface FetchOpenStackPrsOptions {
+  readonly repo: string;
+  readonly cwd: string;
+  readonly exec?: (cmd: string, args: string[], cwd: string) => Promise<string>;
+}
+
+/** Live-fetch adapter: lists open PRs via `gh pr list` (same fields
+ *  land-stack.mjs and github-merge-gate-provider.ts already consume) for
+ *  detectStack to walk. Kept separate from detectStack so the linkage
+ *  algorithm stays pure and unit-testable without any `gh` calls. */
+export async function fetchOpenStackPrs(options: FetchOpenStackPrsOptions): Promise<StackPrRecord[]> {
+  const exec = options.exec ?? execGh;
+  const stdout = await retryTransientGitHubCli(() => exec('gh', [
+    'pr', 'list',
+    '--repo', options.repo,
+    '--state', 'open',
+    '--json', 'number,state,baseRefName,headRefName,headRefOid',
+    '--limit', '500',
+  ], options.cwd));
+  const rows = JSON.parse(stdout) as StackPrRecord[];
+  return rows.map((row) => ({
+    number: row.number,
+    state: row.state,
+    baseRefName: row.baseRefName,
+    headRefName: row.headRefName,
+    headRefOid: row.headRefOid,
+  }));
+}


### PR DESCRIPTION
## Summary

Adds the task-graph builder for stack-batched CI repair.

`spawnReviewGateStackCiRepairWorkflow()` builds one `PlanDefinition` per stack instead of one per PR.

Each PR in the stack gets one task per failing required check, plus a "recheck" task gated on those.

A PR's tasks additionally depend on the PR below it, so nothing above a broken PR starts before that PR is confirmed green.

A fail-closed staleness guard re-fetches every member's live PR state right before the plan loads, and aborts the whole spawn if anything changed since detection.

Nothing calls this yet — it lands here so the task-graph shape can be reviewed on its own terms.

## Review Claim

Add `spawnReviewGateStackCiRepairWorkflow()` and its task-graph builder, with no call sites anywhere yet.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

New file, plus 4 newly-exported (unchanged) helpers from the existing single-PR workflow file — export-only, zero logic changes to those functions. Nothing in the codebase calls `spawnReviewGateStackCiRepairWorkflow` yet, so this diff cannot change runtime behavior. Covered by 8 new tests, including a real-orchestrator test proving cross-PR dependency gating and that a permanently-stuck PR is never marked `stale` (which would otherwise spuriously unblock the PR above it).

## Slice Rationale

Still foundation, not the worker wiring: this is the reusable planning logic, landed before the next slice hooks it up behind a flag, so the DAG shape (does "fix Q, R, S then recheck X, then gate the PR above" actually hold) can be reviewed independent of the worker plumbing that will call it.

## Non-goals

Does not enable stack-batched repair for any real worker. Does not change the existing single-PR repair path's behavior — the existing `review-gate-ci-repair-workflow.test.ts` suite passes unchanged.

## Architecture

### Before

```mermaid
graph TD
    A["One PlanDefinition, one task, one PR"]
```

### After

```mermaid
graph TD
    A["PR bottom: check-fix task(s)"] --> B["PR bottom: recheck task"]
    B --> C["PR top: check-fix task(s)"]
    C --> D["PR top: recheck task"]
    B --> D
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/review-gate-stack-repair-workflow.test.ts` — 8 passed
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/review-gate-ci-repair-workflow.test.ts src/__tests__/review-gate-ci-repair-command.test.ts` — 6 passed (unchanged, confirms the export-only refactor is behavior-neutral)
- [x] `pnpm run check:types` — clean

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
