### PR TITLE
[Stack-batched CI repair](3) Wire stack repair behind INVOKER_CI_REPAIR_STACK_MODE

### DIFF
--- a/packages/app/src/__tests__/review-gate-stack-repair-workflow.test.ts
+++ b/packages/app/src/__tests__/review-gate-stack-repair-workflow.test.ts
@@ -1,0 +1,282 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestHarness, type TestHarness } from '@invoker/test-kit';
+import type { ReviewGateCiRepairWorkflowMutationArgs, StackPrRecord } from '@invoker/execution-engine';
+import type { PlanDefinition } from '@invoker/workflow-core';
+
+import {
+  assertMembersNotStale,
+  buildStackRepairPlanTasks,
+  spawnReviewGateStackCiRepairWorkflow,
+} from '../review-gate-stack-repair-workflow.js';
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+const SOURCE_PLAN: PlanDefinition = {
+  name: 'Source review gate workflow',
+  onFinish: 'none',
+  mergeMode: 'manual',
+  baseBranch: 'master',
+  featureBranch: 'feature/review-gate-ci',
+  repoUrl: 'memory://repo.git',
+  intermediateRepoUrl: 'memory://intermediate.git',
+  tasks: [
+    { id: 'A', description: 'Task A', command: 'echo a' },
+  ],
+};
+
+async function driveSourceGateToReviewReady(
+  h: TestHarness,
+): Promise<{ workflowId: string; mergeId: string }> {
+  h.loadAndStart(SOURCE_PLAN);
+  h.completeTask('A');
+  const mergeTask = h.getAllTasks().find((task) => task.config.isMergeNode);
+  expect(mergeTask).toBeDefined();
+  await h.executor.executeTasks([mergeTask!]);
+  expect(h.getTask(mergeTask!.id)?.status).toBe('review_ready');
+
+  const gate = h.getTask(mergeTask!.id)!;
+  const generation = gate.execution.generation ?? 0;
+  h.persistence.updateTask(mergeTask!.id, {
+    execution: {
+      reviewId: '9501',
+      branch: 'feature/review-gate-ci',
+      reviewGate: {
+        activeGeneration: generation,
+        completion: gate.execution.reviewGate?.completion ?? { required: 'all', status: 'approved' },
+        artifacts: [{
+          id: 'pr-9501',
+          providerId: '9501',
+          provider: 'github',
+          required: true,
+          status: 'open',
+          generation,
+          headSha: 'sha-9501',
+        }],
+      },
+    },
+  });
+  h.orchestrator.getWorkflowStatus();
+  return { workflowId: gate.config.workflowId!, mergeId: mergeTask!.id };
+}
+
+function makeTriggeringArgs(
+  h: TestHarness,
+  mergeId: string,
+  workflowId: string,
+  overrides: Partial<ReviewGateCiRepairWorkflowMutationArgs> = {},
+): ReviewGateCiRepairWorkflowMutationArgs {
+  const gate = h.getTask(mergeId)!;
+  return {
+    sourceWorkflowId: workflowId,
+    sourceTaskId: mergeId,
+    reviewId: '9501',
+    reviewUrl: 'https://github.com/owner/repo/pull/9501',
+    headSha: 'sha-9501',
+    headRef: 'stack/bottom',
+    branch: 'feature/review-gate-ci',
+    generation: gate.execution.generation ?? 0,
+    selectedAttemptId: gate.execution.selectedAttemptId,
+    failedChecks: [{ name: 'unit', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/1' }],
+    statusText: 'CI failed',
+    taskStateVersion: gate.taskStateVersion,
+    ...overrides,
+  };
+}
+
+function member(overrides: Partial<StackPrRecord> & { number: number }): StackPrRecord {
+  return {
+    state: 'OPEN',
+    baseRefName: 'master',
+    headRefName: `stack/pr-${overrides.number}`,
+    headRefOid: `sha-${overrides.number}`,
+    ...overrides,
+  };
+}
+
+const BASE_TRIGGERING: ReviewGateCiRepairWorkflowMutationArgs = {
+  sourceWorkflowId: 'wf-1',
+  sourceTaskId: 'wf-1/merge',
+  reviewId: '9001',
+  reviewUrl: 'https://github.com/owner/repo/pull/9001',
+  headSha: 'sha-9001',
+  generation: 0,
+  failedChecks: [
+    { name: 'unit', conclusion: 'FAILURE' },
+    { name: 'lint', conclusion: 'FAILURE' },
+  ],
+  statusText: 'CI failed',
+  taskStateVersion: 1,
+};
+
+describe('buildStackRepairPlanTasks', () => {
+  it('Case A: only the triggering (bottom) PR gets check-fix tasks; every member gets a chained recheck task', () => {
+    const members = [
+      member({ number: 9001, headRefName: 'stack/a' }),
+      member({ number: 9002, baseRefName: 'stack/a', headRefName: 'stack/b' }),
+      member({ number: 9003, baseRefName: 'stack/b', headRefName: 'stack/c' }),
+    ];
+
+    const tasks = buildStackRepairPlanTasks(members, BASE_TRIGGERING, 'master');
+
+    expect(tasks.map((t) => t.id)).toEqual([
+      'pr-9001-check-0-unit',
+      'pr-9001-check-1-lint',
+      'pr-9001-recheck',
+      'pr-9002-recheck',
+      'pr-9003-recheck',
+    ]);
+    expect(tasks.find((t) => t.id === 'pr-9001-check-0-unit')?.dependencies).toBeUndefined();
+    expect(tasks.find((t) => t.id === 'pr-9001-recheck')?.dependencies).toEqual([
+      'pr-9001-check-0-unit',
+      'pr-9001-check-1-lint',
+    ]);
+    expect(tasks.find((t) => t.id === 'pr-9002-recheck')?.dependencies).toEqual(['pr-9001-recheck']);
+    expect(tasks.find((t) => t.id === 'pr-9003-recheck')?.dependencies).toEqual(['pr-9002-recheck']);
+  });
+
+  it('Case B: a middle-of-stack trigger gates its own check tasks on the PR below AND gates the PR above on itself', () => {
+    const members = [
+      member({ number: 9101, headRefName: 'stack/x' }),
+      member({ number: 9102, baseRefName: 'stack/x', headRefName: 'stack/y' }),
+    ];
+    const triggering: ReviewGateCiRepairWorkflowMutationArgs = {
+      ...BASE_TRIGGERING,
+      reviewId: '9102',
+      failedChecks: [{ name: 'e2e', conclusion: 'FAILURE' }],
+    };
+
+    const tasks = buildStackRepairPlanTasks(members, triggering, 'master');
+
+    expect(tasks.map((t) => t.id)).toEqual(['pr-9101-recheck', 'pr-9102-check-0-e2e', 'pr-9102-recheck']);
+    expect(tasks.find((t) => t.id === 'pr-9101-recheck')?.dependencies).toEqual([]);
+    // The bottom PR has no failing checks assigned to this batch, so its recheck
+    // has no dependencies of its own -- but everything on PR #9102 still waits
+    // on PR #9101's recheck completing first.
+    expect(tasks.find((t) => t.id === 'pr-9102-check-0-e2e')?.dependencies).toEqual(['pr-9101-recheck']);
+    expect(tasks.find((t) => t.id === 'pr-9102-recheck')?.dependencies).toEqual([
+      'pr-9102-check-0-e2e',
+      'pr-9101-recheck',
+    ]);
+  });
+
+  it('gives every member a featureBranch matching its own head branch', () => {
+    const members = [
+      member({ number: 9201, headRefName: 'stack/one' }),
+      member({ number: 9202, baseRefName: 'stack/one', headRefName: 'stack/two' }),
+    ];
+    const tasks = buildStackRepairPlanTasks(members, { ...BASE_TRIGGERING, reviewId: '9201' }, 'master');
+
+    expect(tasks.find((t) => t.id === 'pr-9201-recheck')?.featureBranch).toBe('stack/one');
+    expect(tasks.find((t) => t.id === 'pr-9202-recheck')?.featureBranch).toBe('stack/two');
+  });
+});
+
+describe('assertMembersNotStale', () => {
+  it('Case C: throws when a member head SHA changed since detection', async () => {
+    const detected = [
+      member({ number: 9101, headRefName: 'stack/x', headRefOid: 'sha-a' }),
+      member({ number: 9102, baseRefName: 'stack/x', headRefName: 'stack/y', headRefOid: 'sha-b' }),
+    ];
+    const fetchOpenStackPrs = async () => [
+      detected[0],
+      { ...detected[1], headRefOid: 'sha-b-changed-by-a-push' },
+    ];
+
+    await expect(assertMembersNotStale(detected, fetchOpenStackPrs)).rejects.toThrow(
+      'PR #9102 head changed (sha-b → sha-b-changed-by-a-push)',
+    );
+  });
+
+  it('throws when a member is no longer open (merged or closed out from under the batch)', async () => {
+    const detected = [member({ number: 9201 })];
+    const fetchOpenStackPrs = async () => [];
+
+    await expect(assertMembersNotStale(detected, fetchOpenStackPrs)).rejects.toThrow(
+      'PR #9201 is no longer open',
+    );
+  });
+
+  it('resolves without throwing when nothing has changed', async () => {
+    const detected = [member({ number: 9301 }), member({ number: 9302, baseRefName: 'stack/pr-9301' })];
+    await expect(assertMembersNotStale(detected, async () => detected)).resolves.toBeUndefined();
+  });
+});
+
+describe('spawnReviewGateStackCiRepairWorkflow', () => {
+  let h: TestHarness;
+
+  beforeEach(() => {
+    h = createTestHarness();
+  });
+
+  it('Case C: aborts before creating any workflow when a member has gone stale', async () => {
+    const { workflowId, mergeId } = await driveSourceGateToReviewReady(h);
+    const triggering = makeTriggeringArgs(h, mergeId, workflowId);
+    const members = [member({ number: 9501, headRefName: 'stack/bottom', headRefOid: 'sha-9501' })];
+    const workflowIdsBefore = h.persistence.listWorkflows().map((workflow) => workflow.id);
+
+    await expect(spawnReviewGateStackCiRepairWorkflow(
+      { stackId: 'stack:master:9501', members, triggering },
+      {
+        orchestrator: h.orchestrator,
+        persistence: h.persistence,
+        logger,
+        // Live state disagrees with detection-time state -> fail closed.
+        fetchOpenStackPrs: async () => [{ ...members[0], headRefOid: 'sha-9501-moved' }],
+      },
+    )).rejects.toThrow('PR #9501 head changed');
+
+    expect(h.persistence.listWorkflows().map((workflow) => workflow.id)).toEqual(workflowIdsBefore);
+  });
+
+  it('Case D: a permanently-stuck bottom PR blocks the PR above it without ever marking it stale', async () => {
+    const { workflowId, mergeId } = await driveSourceGateToReviewReady(h);
+    const triggering = makeTriggeringArgs(h, mergeId, workflowId);
+    const members = [
+      member({ number: 9501, headRefName: 'stack/bottom', headRefOid: 'sha-9501' }),
+      member({ number: 9502, baseRefName: 'stack/bottom', headRefName: 'stack/top', headRefOid: 'sha-9502' }),
+    ];
+
+    const result = await spawnReviewGateStackCiRepairWorkflow(
+      { stackId: 'stack:master:9501,9502', members, triggering },
+      {
+        orchestrator: h.orchestrator,
+        persistence: h.persistence,
+        logger,
+        fetchOpenStackPrs: async () => members,
+      },
+    );
+
+    const bottomRecheckId = result.memberTaskIds[9501];
+    const topRecheckId = result.memberTaskIds[9502];
+    const checkTaskId = result.started.find((task) => task.id.endsWith('check-0-unit'))!.id;
+
+    // Before the bottom PR's own check is even fixed, the PR above it must not
+    // have started -- and simulating "permanently stuck" (never completing the
+    // bottom recheck task, never marking it `stale`) must keep it that way.
+    expect(h.getTask(topRecheckId)?.status).not.toBe('running');
+    expect(h.getTask(topRecheckId)?.status).not.toBe('completed');
+
+    h.completeTask(checkTaskId);
+    // Bottom PR's recheck task is now unblocked and running, but has NOT
+    // completed -- the "permanently stuck, needs a human" case. It must never
+    // be marked `stale` (that status would spuriously satisfy the PR-above's
+    // dependency in ActionGraph.getReadyNodes()).
+    expect(h.getTask(bottomRecheckId)?.status).toBe('running');
+    expect(h.getTask(topRecheckId)?.status).not.toBe('running');
+    expect(h.getTask(topRecheckId)?.status).not.toBe('completed');
+    expect(h.getTask(bottomRecheckId)?.status).not.toBe('stale');
+
+    // Only once the bottom PR's recheck genuinely completes does the PR above
+    // it become ready and auto-start.
+    h.completeTask(bottomRecheckId);
+    expect(h.getTask(topRecheckId)?.status).toBe('running');
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -96,6 +96,8 @@ import {
   parseRequeueMutationArgs,
   parseRequeueEscalateMutationArgs,
   parseReviewGateCiRepairWorkflowMutationArgs,
+  parseReviewGateStackCiRepairWorkflowMutationArgs,
+  fetchOpenStackPrs,
   reconcileTerminalWorkerActionsOnStartup,
   type AgentRegistry,
   type WorkerRegistry,
@@ -201,6 +203,7 @@ import {
   parseFixWithAgentMutationArgs,
 } from './auto-fix-intents.js';
 import { spawnReviewGateCiRepairWorkflow } from './review-gate-ci-repair-workflow.js';
+import { spawnReviewGateStackCiRepairWorkflow } from './review-gate-stack-repair-workflow.js';
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { answerOwnerHeadlessQuery, buildOwnerReadQueryHandlers } from './owner-read-query.js';
@@ -1516,6 +1519,26 @@ function startHeadlessMode(): void {
               persistence,
               logger,
               allowGraphMutation: invokerConfig.allowGraphMutation,
+            });
+          });
+        }
+        if (!workflowMutationDispatcher.has('invoker:spawn-review-gate-stack-ci-repair')) {
+          workflowMutationDispatcher.set('invoker:spawn-review-gate-stack-ci-repair', async (...repairArgs: unknown[]) => {
+            const args = parseReviewGateStackCiRepairWorkflowMutationArgs(repairArgs);
+            return spawnReviewGateStackCiRepairWorkflow(args, {
+              orchestrator,
+              persistence,
+              logger,
+              allowGraphMutation: invokerConfig.allowGraphMutation,
+              fetchOpenStackPrs: () => {
+                const repo = process.env.INVOKER_GITHUB_TARGET_REPO?.trim();
+                if (!repo) {
+                  throw new Error(
+                    'invoker:spawn-review-gate-stack-ci-repair requires INVOKER_GITHUB_TARGET_REPO to be set.',
+                  );
+                }
+                return fetchOpenStackPrs({ repo, cwd: repoRoot });
+              },
             });
           });
         }

--- a/packages/app/src/review-gate-ci-repair-workflow.ts
+++ b/packages/app/src/review-gate-ci-repair-workflow.ts
@@ -43,7 +43,7 @@ function currentReviewGateLineage(task: TaskState, reviewId: string): {
   };
 }
 
-function loadSourceTask(
+export function loadSourceTask(
   sourceWorkflowId: string,
   sourceTaskId: string,
   deps: SpawnReviewGateCiRepairWorkflowDeps,
@@ -55,7 +55,7 @@ function loadSourceTask(
   return deps.persistence.loadTasks(sourceWorkflowId).find((task) => task.id === sourceTaskId);
 }
 
-function assertSourceReviewGateLineage(task: TaskState, args: ReviewGateCiRepairWorkflowMutationArgs): void {
+export function assertSourceReviewGateLineage(task: TaskState, args: ReviewGateCiRepairWorkflowMutationArgs): void {
   if (task.config.workflowId !== args.sourceWorkflowId) {
     throw new Error(
       `Review-gate CI repair workflow is stale: source workflow changed (${args.sourceWorkflowId} → ${task.config.workflowId ?? 'missing'}).`,
@@ -102,7 +102,7 @@ function resolveBranch(task: TaskState, featureBranch: string | undefined, args:
   return branch;
 }
 
-function resolveBaseBranch(baseBranch: string | undefined): string {
+export function resolveBaseBranch(baseBranch: string | undefined): string {
   const resolved = baseBranch?.trim();
   if (!resolved) {
     throw new Error('Review-gate CI repair requires source workflow baseBranch.');
@@ -110,7 +110,7 @@ function resolveBaseBranch(baseBranch: string | undefined): string {
   return resolved;
 }
 
-function buildFailedCheckBullet(check: ReviewGateCiRepairWorkflowMutationArgs['failedChecks'][number]): string {
+export function buildFailedCheckBullet(check: ReviewGateCiRepairWorkflowMutationArgs['failedChecks'][number]): string {
   const conclusion = check.conclusion ? ` (${check.conclusion})` : '';
   const detailsUrl = check.detailsUrl ? ` — ${check.detailsUrl}` : '';
   return `- ${check.name}${conclusion}${detailsUrl}`;

--- a/packages/app/src/review-gate-stack-repair-workflow.ts
+++ b/packages/app/src/review-gate-stack-repair-workflow.ts
@@ -1,0 +1,228 @@
+import type { Logger } from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type {
+  ReviewGateCiRepairWorkflowMutationArgs,
+  ReviewGateFailedCheck,
+  StackPrRecord,
+} from '@invoker/execution-engine';
+import type { Orchestrator, PlanDefinition, TaskState } from '@invoker/workflow-core';
+
+import { backupPlan } from './plan-backup.js';
+import {
+  assertSourceReviewGateLineage,
+  buildFailedCheckBullet,
+  loadSourceTask,
+  resolveBaseBranch,
+  type SpawnReviewGateCiRepairWorkflowDeps,
+} from './review-gate-ci-repair-workflow.js';
+
+export interface SpawnReviewGateStackCiRepairWorkflowArgs {
+  /** Deterministic id from pr-stack-detection's detectStack(), used as the
+   *  dedup key for in-flight stack repairs. */
+  readonly stackId: string;
+  /** Bottom-to-top stack membership at detection time — re-verified live
+   *  (see assertMembersNotStale) before any plan is built. */
+  readonly members: readonly StackPrRecord[];
+  /** The single PR whose review_gate.ci_failed event actually triggered this
+   *  batch. Only this member gets check-fix tasks in v1 — every other member
+   *  gets a pass-through recheck task that gates the PR above it. A sibling's
+   *  own failing checks get added the next time ITS OWN event fires and finds
+   *  this same stack (at which point it becomes the triggering member). */
+  readonly triggering: ReviewGateCiRepairWorkflowMutationArgs;
+}
+
+export interface SpawnReviewGateStackCiRepairWorkflowDeps {
+  orchestrator: Pick<Orchestrator, 'getWorkflowIds' | 'loadPlan' | 'startExecution'>;
+  persistence: SpawnReviewGateCiRepairWorkflowDeps['persistence'];
+  /** Re-fetches live PR state for every member so a stack that changed shape
+   *  (a push, a merge, a close) between detection and spawn never proceeds. */
+  fetchOpenStackPrs: () => Promise<readonly StackPrRecord[]>;
+  logger?: Logger;
+  allowGraphMutation?: boolean;
+}
+
+export interface SpawnReviewGateStackCiRepairWorkflowResult {
+  workflowId: string;
+  stackId: string;
+  /** PR number -> that member's recheck task id, so callers (and the
+   *  in-flight ledger) can watch each member's terminal state. */
+  memberTaskIds: Readonly<Record<number, string>>;
+  started: TaskState[];
+}
+
+function slugifyCheckName(name: string): string {
+  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return slug || 'check';
+}
+
+function checkTaskId(prNumber: number, index: number, checkName: string): string {
+  return `pr-${prNumber}-check-${index}-${slugifyCheckName(checkName)}`;
+}
+
+function recheckTaskId(prNumber: number): string {
+  return `pr-${prNumber}-recheck`;
+}
+
+function buildCheckFixPrompt(
+  member: StackPrRecord,
+  check: ReviewGateFailedCheck,
+  baseBranch: string,
+  triggering: ReviewGateCiRepairWorkflowMutationArgs,
+): string {
+  return [
+    `Repair one failing check on pull request #${member.number} (part of a Mergify stack).`,
+    `PR URL: ${triggering.reviewUrl}`,
+    `Head branch: ${member.headRefName}`,
+    `Head SHA: ${member.headRefOid}`,
+    `Base branch: ${baseBranch}`,
+    '',
+    'Work directly on the review branch:',
+    `  git fetch origin ${member.headRefName} && git checkout ${member.headRefName}`,
+    '',
+    'Failed check to clear:',
+    buildFailedCheckBullet(check),
+    '',
+    'Rules:',
+    '- Fix only this failing check on the same branch.',
+    `- Push your changes to the same branch (${member.headRefName}).`,
+    '- Never open a new PR.',
+    '- Do not touch any other PR in the stack.',
+  ].join('\n');
+}
+
+function buildRecheckPrompt(member: StackPrRecord, baseBranch: string): string {
+  return [
+    `Confirm pull request #${member.number} is green after its stack-mates' repairs.`,
+    `Head branch: ${member.headRefName}`,
+    `Base branch: ${baseBranch}`,
+    '',
+    'This PR had no failing checks assigned to this batch, or its check-fix',
+    'tasks above have already completed. Re-fetch its current required checks',
+    '(`gh pr checks` or the review-gate poll) and confirm they are green before',
+    'reporting done. If a required check is still failing, say so plainly —',
+    'do not silently retry a fix here; a fresh CI-failure event on this PR is',
+    'what should trigger new check-fix tasks.',
+  ].join('\n');
+}
+
+/**
+ * One task per failing required check on the TRIGGERING member (Q, R, S),
+ * plus one pass-through "recheck" task per member gated on that member's own
+ * check tasks. Cross-PR ordering: member N's tasks additionally depend on
+ * member N-1's recheck task, so nothing above a broken PR ever starts before
+ * that PR is confirmed green. See pr-stack-detection.ts for how `members` is
+ * derived and review-gate-stack-repair-workflow.ts's module doc for why only
+ * the triggering member gets check-fix tasks in v1.
+ */
+export function buildStackRepairPlanTasks(
+  members: readonly StackPrRecord[],
+  triggering: ReviewGateCiRepairWorkflowMutationArgs,
+  baseBranch: string,
+): PlanDefinition['tasks'] {
+  const tasks: PlanDefinition['tasks'] = [];
+  let previousRecheckId: string | undefined;
+
+  for (const member of members) {
+    const isTriggering = String(member.number) === triggering.reviewId;
+    const ownCheckIds: string[] = [];
+
+    if (isTriggering) {
+      triggering.failedChecks.forEach((check, index) => {
+        const id = checkTaskId(member.number, index, check.name);
+        ownCheckIds.push(id);
+        tasks.push({
+          id,
+          description: `PR #${member.number}: fix failing check ${check.name}`,
+          prompt: buildCheckFixPrompt(member, check, baseBranch, triggering),
+          featureBranch: member.headRefName,
+          ...(previousRecheckId ? { dependencies: [previousRecheckId] } : {}),
+        });
+      });
+    }
+
+    tasks.push({
+      id: recheckTaskId(member.number),
+      description: `PR #${member.number}: recheck after repairs`,
+      prompt: buildRecheckPrompt(member, baseBranch),
+      featureBranch: member.headRefName,
+      dependencies: previousRecheckId ? [...ownCheckIds, previousRecheckId] : ownCheckIds,
+    });
+
+    previousRecheckId = recheckTaskId(member.number);
+  }
+
+  return tasks;
+}
+
+/**
+ * Fail-closed guard for the whole batch (plan §4/§1): re-fetches live PR
+ * state and aborts before anything is built if ANY member has moved (closed,
+ * merged out from under us, or a new head SHA landed) since detectStack()
+ * ran. A stale member could silently break the dependency chain other
+ * members' tasks rely on, so one bad member blocks the whole spawn rather
+ * than being dropped.
+ */
+export async function assertMembersNotStale(
+  members: readonly StackPrRecord[],
+  fetchOpenStackPrs: () => Promise<readonly StackPrRecord[]>,
+): Promise<void> {
+  const latest = await fetchOpenStackPrs();
+  const byNumber = new Map(latest.map((pr) => [pr.number, pr] as const));
+  for (const member of members) {
+    const current = byNumber.get(member.number);
+    if (!current || current.state !== 'OPEN') {
+      throw new Error(
+        `Review-gate stack CI repair is stale: PR #${member.number} is no longer open.`,
+      );
+    }
+    if (current.headRefOid !== member.headRefOid) {
+      throw new Error(
+        `Review-gate stack CI repair is stale: PR #${member.number} head changed `
+        + `(${member.headRefOid} → ${current.headRefOid}).`,
+      );
+    }
+  }
+}
+
+export async function spawnReviewGateStackCiRepairWorkflow(
+  args: SpawnReviewGateStackCiRepairWorkflowArgs,
+  deps: SpawnReviewGateStackCiRepairWorkflowDeps,
+): Promise<SpawnReviewGateStackCiRepairWorkflowResult> {
+  const sourceTask = loadSourceTask(args.triggering.sourceWorkflowId, args.triggering.sourceTaskId, deps);
+  if (!sourceTask) {
+    throw new Error(`Review-gate stack CI repair source task ${args.triggering.sourceTaskId} not found.`);
+  }
+  const sourceWorkflow = deps.persistence.loadWorkflow(args.triggering.sourceWorkflowId);
+  if (!sourceWorkflow) {
+    throw new Error(`Review-gate stack CI repair source workflow ${args.triggering.sourceWorkflowId} not found.`);
+  }
+  assertSourceReviewGateLineage(sourceTask, args.triggering);
+  await assertMembersNotStale(args.members, deps.fetchOpenStackPrs);
+
+  const baseBranch = resolveBaseBranch(sourceWorkflow.baseBranch);
+  const headShaOrNoHead = args.triggering.headSha ?? 'no-head';
+  const planNameSafeStackId = args.stackId.replace(/[^a-zA-Z0-9]+/g, '-');
+  const plan: PlanDefinition = {
+    name: `repair-review-gate-ci-stack-${planNameSafeStackId}-${headShaOrNoHead}`,
+    onFinish: 'none',
+    baseBranch,
+    ...(sourceWorkflow.repoUrl ? { repoUrl: sourceWorkflow.repoUrl } : {}),
+    ...(sourceWorkflow.intermediateRepoUrl ? { intermediateRepoUrl: sourceWorkflow.intermediateRepoUrl } : {}),
+    tasks: buildStackRepairPlanTasks(args.members, args.triggering, baseBranch),
+  };
+
+  const existingWorkflowIds = new Set(deps.persistence.listWorkflows().map((workflow) => workflow.id));
+  backupPlan(plan, undefined, deps.logger);
+  deps.orchestrator.loadPlan(plan, { allowGraphMutation: deps.allowGraphMutation });
+  const workflowId = deps.orchestrator.getWorkflowIds().find((id) => !existingWorkflowIds.has(id));
+  if (!workflowId) {
+    throw new Error('Loaded review-gate stack CI repair plan did not create a workflow.');
+  }
+  const started = deps.orchestrator
+    .startExecution()
+    .filter((task) => task.config.workflowId === workflowId);
+  const memberTaskIds = Object.fromEntries(
+    args.members.map((member) => [member.number, `${workflowId}/${recheckTaskId(member.number)}`]),
+  );
+  return { workflowId, stackId: args.stackId, memberTaskIds, started };
+}

--- a/packages/execution-engine/src/__tests__/pr-stack-detection.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-stack-detection.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { detectStack, type StackPrRecord } from '../pr-stack-detection.js';
+
+function pr(overrides: Partial<StackPrRecord> & { number: number }): StackPrRecord {
+  return {
+    state: 'OPEN',
+    baseRefName: 'master',
+    headRefName: `stack/pr-${overrides.number}`,
+    headRefOid: `sha-${overrides.number}`,
+    ...overrides,
+  };
+}
+
+describe('detectStack', () => {
+  it('Case A: finds a full linear 3-PR stack from the bottom member, bottom-to-top', () => {
+    // Models the real #6097->#6098->#6099 "spawn-repair-workflow command" stack.
+    const bottom = pr({ number: 9001, baseRefName: 'master', headRefName: 'stack/a' });
+    const middle = pr({ number: 9002, baseRefName: 'stack/a', headRefName: 'stack/b' });
+    const top = pr({ number: 9003, baseRefName: 'stack/b', headRefName: 'stack/c' });
+    const allOpenPrs = [bottom, middle, top];
+
+    const result = detectStack(bottom, allOpenPrs);
+
+    expect(result.members.map((m) => m.number)).toEqual([9001, 9002, 9003]);
+    expect(result.stackId).toBe('stack:master:9001,9002,9003');
+  });
+
+  it('Case A: finds the same stack when detection starts from the TOP member', () => {
+    const bottom = pr({ number: 9001, baseRefName: 'master', headRefName: 'stack/a' });
+    const middle = pr({ number: 9002, baseRefName: 'stack/a', headRefName: 'stack/b' });
+    const top = pr({ number: 9003, baseRefName: 'stack/b', headRefName: 'stack/c' });
+    const allOpenPrs = [bottom, middle, top];
+
+    const result = detectStack(top, allOpenPrs);
+
+    expect(result.members.map((m) => m.number)).toEqual([9001, 9002, 9003]);
+  });
+
+  it('Case B: finds a 2-PR stack where the bottom already has failing checks', () => {
+    // Models the real #6146->#6173 "Review Gate CI Repair" stack.
+    const bottom = pr({ number: 9101, baseRefName: 'master', headRefName: 'stack/x' });
+    const top = pr({ number: 9102, baseRefName: 'stack/x', headRefName: 'stack/y' });
+    const allOpenPrs = [bottom, top];
+
+    const result = detectStack(bottom, allOpenPrs);
+
+    expect(result.members.map((m) => m.number)).toEqual([9101, 9102]);
+    expect(result.stackId).toBe('stack:master:9101,9102');
+  });
+
+  it('degenerates to a stack of one when the PR is not on a stack/-prefixed branch', () => {
+    const failing = pr({ number: 42, headRefName: 'feature/plain-branch' });
+
+    const result = detectStack(failing, [failing]);
+
+    expect(result.members).toEqual([failing]);
+    expect(result.stackId).toBe('single:42');
+  });
+
+  it('degenerates to a stack of one when no sibling PRs share the branch chain', () => {
+    const failing = pr({ number: 9201, baseRefName: 'master', headRefName: 'stack/lonely' });
+    const unrelated = pr({ number: 9202, baseRefName: 'master', headRefName: 'stack/other' });
+
+    const result = detectStack(failing, [failing, unrelated]);
+
+    expect(result.members.map((m) => m.number)).toEqual([9201]);
+  });
+
+  it('stops growing upward on an ambiguous branch (two open children of the same base)', () => {
+    const bottom = pr({ number: 9301, baseRefName: 'master', headRefName: 'stack/a' });
+    const childOne = pr({ number: 9302, baseRefName: 'stack/a', headRefName: 'stack/b1' });
+    const childTwo = pr({ number: 9303, baseRefName: 'stack/a', headRefName: 'stack/b2' });
+
+    const result = detectStack(bottom, [bottom, childOne, childTwo]);
+
+    expect(result.members.map((m) => m.number)).toEqual([9301]);
+  });
+
+  it('stops walking downward when a lower stack PR is missing from the open set (already merged)', () => {
+    // Models #6146/#6173: the bottom PR merged, only the top sibling is still open.
+    const top = pr({ number: 9102, baseRefName: 'stack/x', headRefName: 'stack/y' });
+
+    const result = detectStack(top, [top]);
+
+    expect(result.members.map((m) => m.number)).toEqual([9102]);
+  });
+
+  it('excludes non-OPEN PRs from the walked stack even if passed in allOpenPrs', () => {
+    const bottom = pr({ number: 9401, baseRefName: 'master', headRefName: 'stack/a' });
+    const mergedMiddle = pr({ number: 9402, baseRefName: 'stack/a', headRefName: 'stack/b', state: 'MERGED' });
+
+    const result = detectStack(bottom, [bottom, mergedMiddle]);
+
+    expect(result.members.map((m) => m.number)).toEqual([9401]);
+  });
+});

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -61,6 +61,7 @@ export * from './auto-fix-recovery.js';
 export * from './review-gate-ci-repair.js';
 export * from './repair-workflow-spec.js';
 export * from './ci-failure-infra-classifier.js';
+export * from './pr-stack-detection.js';
 export * from './workers/pr-status-worker.js';
 export * from './workers/pr-summary-refresh-worker.js';
 export * from './workers/ci-failure-worker.js';

--- a/packages/execution-engine/src/pr-stack-detection.ts
+++ b/packages/execution-engine/src/pr-stack-detection.ts
@@ -1,0 +1,181 @@
+import { spawn } from 'node:child_process';
+
+import { killProcessGroup, SIGKILL_TIMEOUT_MS } from './process-utils.js';
+import { retryTransientGitHubCli } from './git-utils.js';
+
+export const STACK_TRUNK_DEFAULT = 'master';
+export const STACK_PREFIX_DEFAULT = 'stack/';
+
+const DEFAULT_GITHUB_CLI_TIMEOUT_MS = 60_000;
+const GITHUB_CLI_TIMEOUT_ENV = 'INVOKER_GITHUB_CLI_TIMEOUT_MS';
+
+export interface StackPrRecord {
+  readonly number: number;
+  readonly state: string;
+  readonly baseRefName: string;
+  readonly headRefName: string;
+  readonly headRefOid: string;
+}
+
+export interface PrStackDetectionResult {
+  /** Deterministic id for this stack, stable across repeated detections of the
+   *  same members (used as the dedup key for in-flight stack repairs). */
+  readonly stackId: string;
+  /** Bottom-to-top order: members[0] bases on trunk, each next member bases on
+   *  the previous member's head branch. */
+  readonly members: readonly StackPrRecord[];
+}
+
+export interface DetectStackOptions {
+  readonly trunk?: string;
+  readonly stackPrefix?: string;
+}
+
+/**
+ * Walk the open-PR base/head branch chain to find every PR in the same
+ * Mergify-managed stack as `failingPr`, ordered bottom-to-top. Ports the
+ * linkage algorithm from scripts/land-stack.mjs's analyzeCompleteOpenStack
+ * (base==prior-head chain, gated on a `stack/`-prefixed head branch) into TS,
+ * so the CI repair worker can batch a whole stack in one PlanDefinition
+ * instead of firing one repair plan per PR.
+ *
+ * Pure function, no I/O — a PR with no stack siblings (not on a `stack/`
+ * branch, or no linked neighbors found) degenerates to a single-member
+ * "stack of one", which is exactly today's single-PR repair behavior.
+ */
+export function detectStack(
+  failingPr: StackPrRecord,
+  allOpenPrs: readonly StackPrRecord[],
+  options: DetectStackOptions = {},
+): PrStackDetectionResult {
+  const trunk = options.trunk ?? STACK_TRUNK_DEFAULT;
+  const stackPrefix = options.stackPrefix ?? STACK_PREFIX_DEFAULT;
+
+  if (!failingPr.headRefName.startsWith(stackPrefix)) {
+    return { stackId: `single:${failingPr.number}`, members: [failingPr] };
+  }
+
+  const byNumber = new Map<number, StackPrRecord>();
+  for (const pr of [...allOpenPrs, failingPr]) {
+    if (pr.state === 'OPEN' && pr.headRefName.startsWith(stackPrefix)) {
+      byNumber.set(pr.number, pr);
+    }
+  }
+  const seed = byNumber.get(failingPr.number) ?? failingPr;
+  const openStackPrs = [...byNumber.values()];
+  const byHead = new Map(openStackPrs.map((pr) => [pr.headRefName, pr]));
+  const childrenByBase = new Map<string, StackPrRecord[]>();
+  for (const pr of openStackPrs) {
+    const children = childrenByBase.get(pr.baseRefName) ?? [];
+    children.push(pr);
+    childrenByBase.set(pr.baseRefName, children);
+  }
+
+  const members: StackPrRecord[] = [seed];
+  const seen = new Set<number>([seed.number]);
+
+  // Walk down toward trunk. A missing parent (already merged, or genuinely not
+  // open) or a cycle just stops the downward walk rather than erroring — the
+  // known-open lower bound is still a valid partial stack to batch.
+  let bottom = seed;
+  while (bottom.baseRefName !== trunk) {
+    const parent = byHead.get(bottom.baseRefName);
+    if (!parent || seen.has(parent.number)) break;
+    members.unshift(parent);
+    seen.add(parent.number);
+    bottom = parent;
+  }
+
+  // Walk up away from trunk. An ambiguous branch (more than one open PR based
+  // on the same head) stops the upward walk rather than guessing an order.
+  let top = members[members.length - 1];
+  for (;;) {
+    const children = (childrenByBase.get(top.headRefName) ?? []).filter((pr) => pr.number !== top.number);
+    if (children.length !== 1) break;
+    const child = children[0];
+    if (seen.has(child.number)) break;
+    members.push(child);
+    seen.add(child.number);
+    top = child;
+  }
+
+  const stackId = `stack:${trunk}:${members.map((pr) => pr.number).join(',')}`;
+  return { stackId, members };
+}
+
+function getGitHubCliTimeoutMs(): number {
+  const raw = process.env[GITHUB_CLI_TIMEOUT_ENV]?.trim();
+  if (!raw) return DEFAULT_GITHUB_CLI_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_GITHUB_CLI_TIMEOUT_MS;
+}
+
+/** Default `gh` exec: same spawn/timeout/process-group-kill shape used by
+ *  GitHubMergeGateProvider, so stack detection behaves consistently with the
+ *  rest of the review-gate GitHub CLI call sites. */
+async function execGh(cmd: string, args: string[], cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: process.platform !== 'win32',
+    });
+    const timeoutMs = getGitHubCliTimeoutMs();
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      fn();
+    };
+
+    timeout = setTimeout(() => {
+      killProcessGroup(child, 'SIGTERM');
+      const forceKill = setTimeout(() => killProcessGroup(child, 'SIGKILL'), SIGKILL_TIMEOUT_MS);
+      forceKill.unref?.();
+      finish(() => reject(new Error(`gh ${args.join(' ')} exceeded GitHub CLI timeout (${timeoutMs}ms) in ${cwd}.`)));
+    }, timeoutMs);
+    timeout.unref?.();
+
+    child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
+    child.on('error', (err) => finish(() => reject(err)));
+    child.on('close', (code) => finish(() => {
+      if (code === 0) resolve(stdout.trim());
+      else reject(new Error(`${cmd} ${args.join(' ')} failed (code ${code}): ${stderr.trim()}`));
+    }));
+  });
+}
+
+export interface FetchOpenStackPrsOptions {
+  readonly repo: string;
+  readonly cwd: string;
+  readonly exec?: (cmd: string, args: string[], cwd: string) => Promise<string>;
+}
+
+/** Live-fetch adapter: lists open PRs via `gh pr list` (same fields
+ *  land-stack.mjs and github-merge-gate-provider.ts already consume) for
+ *  detectStack to walk. Kept separate from detectStack so the linkage
+ *  algorithm stays pure and unit-testable without any `gh` calls. */
+export async function fetchOpenStackPrs(options: FetchOpenStackPrsOptions): Promise<StackPrRecord[]> {
+  const exec = options.exec ?? execGh;
+  const stdout = await retryTransientGitHubCli(() => exec('gh', [
+    'pr', 'list',
+    '--repo', options.repo,
+    '--state', 'open',
+    '--json', 'number,state,baseRefName,headRefName,headRefOid',
+    '--limit', '500',
+  ], options.cwd));
+  const rows = JSON.parse(stdout) as StackPrRecord[];
+  return rows.map((row) => ({
+    number: row.number,
+    state: row.state,
+    baseRefName: row.baseRefName,
+    headRefName: row.headRefName,
+    headRefOid: row.headRefOid,
+  }));
+}

--- a/packages/execution-engine/src/review-gate-ci-repair.ts
+++ b/packages/execution-engine/src/review-gate-ci-repair.ts
@@ -32,11 +32,23 @@ import {
   type FailedCheckLogFetcher,
 } from './ci-failure-infra-classifier.js';
 import { recordWorkerDecisionRow } from './worker-decision-ledger.js';
+import type { StackPrRecord } from './pr-stack-detection.js';
 
 const CI_FAILURE_WORKER_KIND = 'ci-failure';
 export const SPAWN_REVIEW_GATE_CI_REPAIR_CHANNEL = 'invoker:spawn-review-gate-ci-repair';
+export const SPAWN_REVIEW_GATE_STACK_CI_REPAIR_CHANNEL = 'invoker:spawn-review-gate-stack-ci-repair';
 const CI_FAILURE_ACTION_TYPE = 'fix-ci-failure';
+const CI_FAILURE_STACK_ACTION_TYPE = 'fix-ci-failure-stack';
 const NO_HEAD_SHA = 'no-head';
+
+/** A stack detection result scoped to one lifecycle event's PR. Kept as its
+ *  own shape here (rather than importing pr-stack-detection.ts's detectStack
+ *  function) so this policy module only depends on the data shape, not the
+ *  live-gh-fetch half of stack detection. */
+export interface StackRepairCandidate {
+  readonly stackId: string;
+  readonly members: readonly StackPrRecord[];
+}
 
 type CiFailureActionStatus = WorkerActionStatus;
 
@@ -56,7 +68,7 @@ export interface ReviewGateCiRepairSubmitter {
   submit(
     workflowId: string,
     priority: WorkflowMutationPriority,
-    channel: typeof SPAWN_REVIEW_GATE_CI_REPAIR_CHANNEL,
+    channel: typeof SPAWN_REVIEW_GATE_CI_REPAIR_CHANNEL | typeof SPAWN_REVIEW_GATE_STACK_CI_REPAIR_CHANNEL,
     args: unknown[],
     options?: { deferDrain?: boolean },
   ): number;
@@ -73,6 +85,17 @@ export interface ReviewGateCiRepairPolicyOptions {
   getRetryBudget?: (task: TaskState) => number;
   /** Optional failed-check log fetcher used to skip non-fixable infra failures. */
   fetchFailedCheckLogs?: FailedCheckLogFetcher;
+  /** Stack-batched CI repair (default off). When enabled and the failing PR
+   *  turns out to have stack-mates, the whole stack is repaired as one batch
+   *  instead of firing a single-PR plan. See detectStackForEvent below. */
+  isStackRepairEnabled?: () => boolean;
+  /** Resolves the failing PR's stack membership, if any. Returning undefined
+   *  or a single-member stack falls back to today's single-PR behavior. Kept
+   *  injectable (rather than calling pr-stack-detection.ts's live fetch
+   *  directly) so this stays unit-testable with no `gh` calls. */
+  detectStackForEvent?: (
+    event: ReviewGateCiFailedLifecycleEvent,
+  ) => Promise<StackRepairCandidate | undefined>;
 }
 
 export interface ReviewGateCiRepairWorkflowMutationArgs {
@@ -152,6 +175,56 @@ export function parseReviewGateCiRepairWorkflowMutationArgs(args: unknown[]): Re
   };
 }
 
+export interface ReviewGateStackCiRepairWorkflowMutationArgs {
+  readonly stackId: string;
+  readonly members: readonly StackPrRecord[];
+  readonly triggering: ReviewGateCiRepairWorkflowMutationArgs;
+}
+
+export function buildReviewGateStackCiRepairWorkflowMutationArgs(
+  payload: ReviewGateStackCiRepairWorkflowMutationArgs,
+): unknown[] {
+  return [payload];
+}
+
+function isStackPrRecord(value: unknown): value is StackPrRecord {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.number === 'number'
+    && typeof candidate.state === 'string'
+    && typeof candidate.baseRefName === 'string'
+    && typeof candidate.headRefName === 'string'
+    && typeof candidate.headRefOid === 'string';
+}
+
+export function parseReviewGateStackCiRepairWorkflowMutationArgs(
+  args: unknown[],
+): ReviewGateStackCiRepairWorkflowMutationArgs {
+  const [raw] = args;
+  if (!raw || typeof raw !== 'object') {
+    throw new Error(`${SPAWN_REVIEW_GATE_STACK_CI_REPAIR_CHANNEL} mutation requires an argument object`);
+  }
+  const candidate = raw as Record<string, unknown>;
+  const { stackId, members, triggering } = candidate;
+  if (
+    typeof stackId !== 'string'
+    || !Array.isArray(members)
+    || members.length === 0
+    || !members.every(isStackPrRecord)
+    || !triggering
+    || typeof triggering !== 'object'
+  ) {
+    throw new Error(
+      `${SPAWN_REVIEW_GATE_STACK_CI_REPAIR_CHANNEL} mutation requires { stackId, members: StackPrRecord[], triggering }`,
+    );
+  }
+  return {
+    stackId,
+    members: members.map((member) => ({ ...(member as StackPrRecord) })),
+    triggering: parseReviewGateCiRepairWorkflowMutationArgs([triggering]),
+  };
+}
+
 export function ciFailureChecksHash(failedChecks: readonly ReviewGateFailedCheck[]): string {
   const normalized = failedChecks
     .map((check) => ({
@@ -180,6 +253,18 @@ export function ciFailureActionKey(event: Pick<
     event.headSha ?? NO_HEAD_SHA,
     ciFailureChecksHash(event.failedChecks),
   ].join(':');
+}
+
+/** Dedup key for a whole stack's in-flight repair, not a single PR/check —
+ *  sorted PR-number+headSha pairs so ANY member's later CI-failure event
+ *  (not just the one that originally triggered the batch) resolves to the
+ *  same key and correctly finds the in-flight record. */
+export function stackCiFailureActionKey(candidate: StackRepairCandidate): string {
+  const memberKey = [...candidate.members]
+    .sort((a, b) => a.number - b.number)
+    .map((member) => `${member.number}@${member.headRefOid}`)
+    .join(',');
+  return ['ci-failure-stack', candidate.stackId, memberKey].join(':');
 }
 
 function retryBudgetForTask(task: TaskState, options: ReviewGateCiRepairPolicyOptions): number {
@@ -546,7 +631,7 @@ export async function queueReviewGateCiRepair(
   const executionModel = configuredExecutionModel && configuredExecutionModel.length > 0
     ? configuredExecutionModel
     : undefined;
-  const args = buildReviewGateCiRepairWorkflowMutationArgs({
+  const singlePrPayload: ReviewGateCiRepairWorkflowMutationArgs = {
     sourceWorkflowId: event.workflowId,
     sourceTaskId: event.taskId,
     reviewId: event.reviewId,
@@ -561,7 +646,67 @@ export async function queueReviewGateCiRepair(
     taskStateVersion: event.taskStateVersion ?? task.taskStateVersion,
     ...(selectedAgent ? { agentName: selectedAgent } : {}),
     ...(executionModel ? { executionModel } : {}),
-  });
+  };
+
+  if (options.isStackRepairEnabled?.() && options.detectStackForEvent) {
+    const candidate = await options.detectStackForEvent(event);
+    if (candidate && candidate.members.length > 1) {
+      const stackKey = stackCiFailureActionKey(candidate);
+      const existingStackAction = options.store.getWorkerAction?.(CI_FAILURE_WORKER_KIND, stackKey);
+      if (existingStackAction && isOpenOrCompletedActionStatus(existingStackAction.status)) {
+        logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
+          reason: 'stack-repair-in-flight',
+          stackId: candidate.stackId,
+          existingStatus: existingStackAction.status,
+        });
+        return { decision: 'skipped', reason: 'stack-repair-in-flight' };
+      }
+
+      const stackArgs = buildReviewGateStackCiRepairWorkflowMutationArgs({
+        stackId: candidate.stackId,
+        members: candidate.members,
+        triggering: singlePrPayload,
+      });
+      const stackIntentId = options.submitter.submit(
+        event.workflowId,
+        'normal',
+        SPAWN_REVIEW_GATE_STACK_CI_REPAIR_CHANNEL,
+        stackArgs,
+      );
+      recordWorkerDecisionRow(options.store, {
+        workerKind: CI_FAILURE_WORKER_KIND,
+        actionType: CI_FAILURE_STACK_ACTION_TYPE,
+        externalKey: stackKey,
+        subjectType: 'pr-stack',
+        subjectId: candidate.stackId,
+        workflowId: event.workflowId,
+        taskId: event.taskId,
+        status: 'queued',
+        summary: `Queued stack CI repair for ${candidate.members.length} PR(s)`,
+        incrementAttempt: true,
+        intentId: stackIntentId,
+        ...(selectedAgent ? { agentName: selectedAgent } : {}),
+        ...(executionModel ? { executionModel } : {}),
+        payload: {
+          channel: SPAWN_REVIEW_GATE_STACK_CI_REPAIR_CHANNEL,
+          members: candidate.members.map((member) => member.number),
+          workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
+        },
+      });
+      logCiFailureWorkerEvent(options, event, 'worker-ci-failure-submitted', {
+        intentId: stackIntentId,
+        channel: SPAWN_REVIEW_GATE_STACK_CI_REPAIR_CHANNEL,
+        stackId: candidate.stackId,
+        members: candidate.members.map((member) => member.number),
+        agent: selectedAgent ?? null,
+        executionModel: executionModel ?? null,
+      });
+      recordAutoFixRetryConsumed(options.store, event.taskId, { workflowId: event.workflowId });
+      return { decision: 'queued', reason: 'queued', intentId: stackIntentId };
+    }
+  }
+
+  const args = buildReviewGateCiRepairWorkflowMutationArgs(singlePrPayload);
   const intentId = options.submitter.submit(
     event.workflowId,
     'normal',

--- a/packages/execution-engine/src/workers/ci-failure-worker.ts
+++ b/packages/execution-engine/src/workers/ci-failure-worker.ts
@@ -10,12 +10,14 @@ import type {
   ReviewGateCiFailedLifecycleEvent,
   WorkflowLifecycleEvent,
 } from '../lifecycle-events.js';
+import { detectStack, fetchOpenStackPrs } from '../pr-stack-detection.js';
 import {
   ciFailureActionKey,
   queueReviewGateCiRepair,
   type ReviewGateCiRepairPolicyOptions,
   type ReviewGateCiRepairStore,
   type ReviewGateCiRepairSubmitter,
+  type StackRepairCandidate,
 } from '../review-gate-ci-repair.js';
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import type { WorkerRegistry } from '../worker-registry.js';
@@ -24,6 +26,43 @@ import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../wor
 export const CI_FAILURE_WORKER_KIND = 'ci-failure';
 export const DEFAULT_CI_FAILURE_WORKER_INTERVAL_MS = 60_000;
 export { ciFailureActionKey };
+
+const CI_REPAIR_STACK_MODE_ENV = 'INVOKER_CI_REPAIR_STACK_MODE';
+const GITHUB_TARGET_REPO_ENV = 'INVOKER_GITHUB_TARGET_REPO';
+
+/** On by default: batches a failing PR's whole Mergify stack into one
+ *  PlanDefinition instead of firing a separate single-PR plan per member.
+ *  Set INVOKER_CI_REPAIR_STACK_MODE=0 (or "false") as a kill switch to fall
+ *  back to the single-PR path if stack mode misbehaves against real traffic. */
+export function isCiRepairStackModeEnabled(): boolean {
+  const raw = process.env[CI_REPAIR_STACK_MODE_ENV]?.trim().toLowerCase();
+  return raw !== '0' && raw !== 'false';
+}
+
+/** Wires pr-stack-detection.ts's live gh-backed stack walk into the
+ *  ReviewGateCiRepairPolicyOptions.detectStackForEvent hook. Returns
+ *  undefined (falling back to the single-PR path) whenever the target repo
+ *  isn't configured, the event's PR can't be resolved as currently open, or
+ *  it isn't part of a multi-PR stack. */
+export function createDetectStackForEvent(options: {
+  cwd: string;
+  repo?: string;
+  trunk?: string;
+}): (event: ReviewGateCiFailedLifecycleEvent) => Promise<StackRepairCandidate | undefined> {
+  return async (event) => {
+    const repo = options.repo ?? process.env[GITHUB_TARGET_REPO_ENV]?.trim();
+    if (!repo) return undefined;
+    const prNumber = Number(event.reviewId);
+    if (!Number.isFinite(prNumber)) return undefined;
+
+    const allOpenPrs = await fetchOpenStackPrs({ repo, cwd: options.cwd });
+    const failingPr = allOpenPrs.find((pr) => pr.number === prNumber);
+    if (!failingPr) return undefined;
+
+    const { stackId, members } = detectStack(failingPr, allOpenPrs, { trunk: options.trunk });
+    return members.length > 1 ? { stackId, members } : undefined;
+  };
+}
 
 export type CiFailureWorkerStore = ReviewGateCiRepairStore;
 
@@ -65,6 +104,10 @@ export function registerCiFailureWorker(
           getAutoFixExecutionModel: deps.autoFix?.getAutoFixExecutionModel,
           fetchFailedCheckLogs: createFailedCheckLogFetcher({
             cwd: deps.prMaintenance?.repoRoot,
+          }),
+          isStackRepairEnabled: isCiRepairStackModeEnabled,
+          detectStackForEvent: createDetectStackForEvent({
+            cwd: deps.prMaintenance?.repoRoot ?? process.cwd(),
           }),
         },
       }),


### PR DESCRIPTION
## Summary

Wires stack-batched CI repair into the real worker, on by default.

When a PR's CI fails, the worker now checks whether it's part of a multi-PR Mergify stack.

If it is, the worker batches the whole stack into one plan instead of firing a separate repair per PR.

A stack-level ledger entry stops a second stack member's failure event from spawning a second, overlapping in-flight batch.

`INVOKER_CI_REPAIR_STACK_MODE=0` is a kill switch back to today's one-PR-at-a-time behavior if this misbehaves against real traffic.

This follows a cost investigation into a related worker: debugging sessions were burning $30-40 each partly because PRs in the same stack were checked one at a time.

## Review Claim

On by default, detect a failing PR's stack and batch its repair via the previous slice's `PlanDefinition` instead of firing one plan per PR. `INVOKER_CI_REPAIR_STACK_MODE=0` disables it.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The flag defaults to ON (`isCiRepairStackModeEnabled()` returns true unless the env var is `0` or `false`) — this is a deliberate, requested change from the original opt-in design, made with the explicit tradeoff spelled out below.

This has been verified against synthetic test fixtures (Cases A-D, a real orchestrator but fake PR data) and against the full existing `execution-engine` (1403 tests) and `app` (1723 tests) suites, with zero new failures versus a clean `origin/master` baseline. It has **not** been verified against real Invoker traffic or a real GitHub stack — a live dry run against the 100 open PRs in this repo found 13 real multi-PR stacks with a currently failing check, so this code path will be exercised immediately on real data once merged. The kill switch (`INVOKER_CI_REPAIR_STACK_MODE=0`) exists specifically to cover that gap: it needs no revert, just an environment change, if a real stack gets mishandled.

## Slice Rationale

This is the only slice in the stack that changes real worker behavior. It ships on by default at the user's explicit request, trading the safer opt-in rollout for immediate coverage of real stuck stacks — the kill switch is the safety net in place of an opt-in gate.

## Non-goals

Does not touch the Python `mergify_admin_requeue` worker — porting this same batch-by-stack shape there is an intentional follow-up, not part of this stack.

## Architecture

### Before

```mermaid
graph TD
    A["CI failure event"] --> B["queueReviewGateCiRepair"]
    B --> C["single-PR PlanDefinition"]
```

### After

```mermaid
graph TD
    A["CI failure event"] --> B["queueReviewGateCiRepair"]
    B --> D{"INVOKER_CI_REPAIR_STACK_MODE != 0 AND PR is in a multi-PR stack?"}
    D -- no --> C["single-PR PlanDefinition (unchanged)"]
    D -- yes --> E["stack-level dedup check"]
    E --> F["stack-wide PlanDefinition"]
```

## Visual Proof

This diff has no user-visible surface — the only UI-impacting-classified file touched is `packages/app/src/main.ts`, and the change there is a one-line backend mutation-channel dispatcher registration (identical in shape to the existing `invoker:spawn-review-gate-ci-repair` entry a few lines above it). Nothing in the UI itself changes, so there is no comparison screenshot to show.

The screenshot below proves the app still launches and renders its home screen normally with this change applied, captured by running the existing `empty state` Playwright case from `packages/app/e2e/visual-proof.spec.ts` against this branch's build.

![Invoker app home screen, launched normally with this change applied](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260727-cb1b64/empty-state.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test` — 1390 passed, 12 failed (identical set on clean `origin/master`, none new), 1 skipped
- [x] `pnpm --filter @invoker/app test` — 1723 passed, 0 failed (161 baseline files/1715 tests + this stack's 1 new file/8 new tests)
- [x] `pnpm run check:types` — clean
- [x] Manual dry run: read-only scan of all 100 open PRs in `Neko-Catpital-Labs/Invoker`; found 43 stacks (21 multi-PR), 13 of which currently have a failing check on a member — confirms this path activates on real, existing data as soon as it merges

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`, or set `INVOKER_CI_REPAIR_STACK_MODE=0` for an immediate rollback with no code change
- Post-revert steps: None
- Data migration? No

</details>
