### PR TITLE
[DO1 Slack hi autonomous smoke](1) Route a localhost hi smoke through the live Slack reply path

### DIFF
--- a/packages/slack-manager/src/__tests__/hi-smoke-server.test.ts
+++ b/packages/slack-manager/src/__tests__/hi-smoke-server.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { startHiSmokeServer, HI_SMOKE_HOST, type HiSmokeServerHandle } from '../hi-smoke-server.js';
+
+const noop = (): void => {};
+
+async function withServer(
+  runHiSmoke: (opts: { text?: string }) => Promise<{ channel: string; parentTs: string }>,
+  fn: (base: string) => Promise<void>,
+): Promise<void> {
+  const handle = (await startHiSmokeServer({ enabled: true, port: 0, runHiSmoke, log: noop })) as HiSmokeServerHandle;
+  try {
+    await fn(`http://${HI_SMOKE_HOST}:${handle.port()}`);
+  } finally {
+    await handle.stop();
+  }
+}
+
+describe('startHiSmokeServer', () => {
+  it('does not start when disabled', async () => {
+    const runHiSmoke = vi.fn(async () => ({ channel: 'C1', parentTs: '1.1' }));
+    const handle = await startHiSmokeServer({ enabled: false, port: 0, runHiSmoke, log: noop });
+    expect(handle).toBeUndefined();
+    expect(runHiSmoke).not.toHaveBeenCalled();
+  });
+
+  it('binds loopback and feeds POST /hi text through runHiSmoke', async () => {
+    const runHiSmoke = vi.fn(async ({ text }: { text?: string }) => ({ channel: 'C0BCNM0UTFY', parentTs: `ts-${text}` }));
+    await withServer(runHiSmoke, async (base) => {
+      const res = await fetch(`${base}/hi`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ text: 'hi' }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true, channel: 'C0BCNM0UTFY', parentTs: 'ts-hi' });
+      expect(runHiSmoke).toHaveBeenCalledWith({ text: 'hi' });
+    });
+  });
+
+  it('defaults to text=hi when the body omits it', async () => {
+    const runHiSmoke = vi.fn(async () => ({ channel: 'C1', parentTs: '9.9' }));
+    await withServer(runHiSmoke, async (base) => {
+      const res = await fetch(`${base}/hi`, { method: 'POST' });
+      expect(res.status).toBe(200);
+      expect(runHiSmoke).toHaveBeenCalledWith({ text: undefined });
+    });
+  });
+
+  it('rejects non-POST and unknown paths with 404 without invoking the reply path', async () => {
+    const runHiSmoke = vi.fn(async () => ({ channel: 'C1', parentTs: '1.1' }));
+    await withServer(runHiSmoke, async (base) => {
+      const get = await fetch(`${base}/hi`, { method: 'GET' });
+      expect(get.status).toBe(404);
+      const wrong = await fetch(`${base}/nope`, { method: 'POST' });
+      expect(wrong.status).toBe(404);
+      expect(runHiSmoke).not.toHaveBeenCalled();
+    });
+  });
+
+  it('returns 500 with the error message when the reply path throws', async () => {
+    const runHiSmoke = vi.fn(async () => {
+      throw new Error('No API key found for openai-codex');
+    });
+    await withServer(runHiSmoke, async (base) => {
+      const res = await fetch(`${base}/hi`, { method: 'POST', body: '{}' });
+      expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({ ok: false, error: 'No API key found for openai-codex' });
+    });
+  });
+});

--- a/packages/slack-manager/src/hi-smoke-server.ts
+++ b/packages/slack-manager/src/hi-smoke-server.ts
@@ -1,0 +1,119 @@
+/**
+ * Opt-in, localhost-only smoke hook for the live Slack reply path.
+ *
+ * Slack does not reliably redeliver an app's own `app_mention` back to itself,
+ * so there is no safe way to prove the live planning-mention → LLM-reply path
+ * with a real bot self-mention. This server binds ONLY to 127.0.0.1 and is
+ * started ONLY when `INVOKER_SLACK_HI_SMOKE` is set. A POST to `/hi` posts a
+ * real parent message to the configured lobby and feeds `hi` through the exact
+ * same mention route a human `@Invoker hi` would take, letting the ordinary
+ * Slack response path post the reply in that same thread.
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+
+export const HI_SMOKE_HOST = '127.0.0.1';
+export const HI_SMOKE_DEFAULT_PORT = 8477;
+
+export interface HiSmokeResult {
+  channel: string;
+  parentTs: string;
+}
+
+export interface HiSmokeServerOptions {
+  /** Opt-in gate; when false the server is not started. */
+  enabled: boolean;
+  /** Loopback port (defaults to HI_SMOKE_DEFAULT_PORT, or 0 for ephemeral). */
+  port?: number;
+  /** Runs a single `hi` mention through the live reply path. */
+  runHiSmoke: (opts: { text?: string }) => Promise<HiSmokeResult>;
+  log: (level: string, message: string) => void;
+}
+
+export interface HiSmokeServerHandle {
+  server: Server;
+  /** Actual bound port (useful when port 0 requested an ephemeral one). */
+  port(): number;
+  stop(): Promise<void>;
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of req) {
+    const buf = chunk as Buffer;
+    size += buf.length;
+    if (size > 64 * 1024) throw new Error('request body too large');
+    chunks.push(buf);
+  }
+  const raw = Buffer.concat(chunks).toString('utf8').trim();
+  if (!raw) return {};
+  const parsed = JSON.parse(raw);
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+}
+
+/** The request listener, exported so it can be unit-tested without a socket. */
+export function createHiSmokeListener(
+  runHiSmoke: HiSmokeServerOptions['runHiSmoke'],
+  log: HiSmokeServerOptions['log'],
+): (req: IncomingMessage, res: ServerResponse) => void {
+  return (req, res) => {
+    void (async () => {
+      const respond = (status: number, body: unknown): void => {
+        const json = JSON.stringify(body);
+        res.writeHead(status, { 'content-type': 'application/json' });
+        res.end(json);
+      };
+      if (req.method !== 'POST' || (req.url ?? '').split('?')[0] !== '/hi') {
+        respond(404, { ok: false, error: 'POST /hi only' });
+        return;
+      }
+      try {
+        const body = await readJsonBody(req);
+        const text = typeof body.text === 'string' ? body.text : undefined;
+        log('info', `[HI_SMOKE] injection requested text="${text ?? 'hi'}"`);
+        const result = await runHiSmoke({ text });
+        respond(200, { ok: true, ...result });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log('error', `[HI_SMOKE] injection failed: ${message}`);
+        respond(500, { ok: false, error: message });
+      }
+    })();
+  };
+}
+
+/**
+ * Start the loopback smoke server. Returns undefined when disabled so callers
+ * can `?.stop()` unconditionally on shutdown.
+ */
+export function startHiSmokeServer(opts: HiSmokeServerOptions): Promise<HiSmokeServerHandle | undefined> {
+  if (!opts.enabled) {
+    opts.log('info', '[HI_SMOKE] disabled (set INVOKER_SLACK_HI_SMOKE to enable the localhost smoke hook)');
+    return Promise.resolve(undefined);
+  }
+  const port = opts.port ?? HI_SMOKE_DEFAULT_PORT;
+  const server = createServer(createHiSmokeListener(opts.runHiSmoke, opts.log));
+  const { promise, resolve, reject } = Promise.withResolvers<HiSmokeServerHandle | undefined>();
+  server.once('error', reject);
+  // Bind ONLY to loopback — never expose the injection hook off-host.
+  server.listen(port, HI_SMOKE_HOST, () => {
+    server.removeListener('error', reject);
+    const bound = server.address();
+    const boundPort = typeof bound === 'object' && bound ? bound.port : port;
+    opts.log('info', `[HI_SMOKE] listening on ${HI_SMOKE_HOST}:${boundPort} (POST /hi)`);
+    resolve({
+      server,
+      port: () => {
+        const addr = server.address();
+        return typeof addr === 'object' && addr ? addr.port : boundPort;
+      },
+      stop: () => {
+        const { promise: stopped, resolve: onClose } = Promise.withResolvers<void>();
+        server.close(() => onClose());
+        return stopped;
+      },
+    });
+  });
+  return promise;
+}

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -28,6 +28,7 @@ import { createHarnessSessionDriverFactory, createPlanningCommandBuilder, create
 import { createWatchdog } from './watchdog.js';
 import { errMessage } from './util.js';
 import { acquireSlackConsumerLock } from './slack-consumer-lock.js';
+import { startHiSmokeServer, HI_SMOKE_DEFAULT_PORT } from './hi-smoke-server.js';
 const VERSION = '0.0.8';
 
 const REQUIRED_ENV = ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_SIGNING_SECRET', 'SLACK_CHANNEL_ID'];
@@ -161,6 +162,19 @@ async function main(): Promise<void> {
   void client.ping();
   log('info', `slack-manager started (store=${managerHome})`);
 
+  // Opt-in, localhost-only hi-smoke hook. Slack does not reliably redeliver the
+  // app's own app_mention, so this loopback endpoint injects a `hi` mention
+  // through the ordinary planning-mention route to prove the live reply path.
+  const hiSmoke = await startHiSmokeServer({
+    enabled: !!process.env.INVOKER_SLACK_HI_SMOKE,
+    port: process.env.INVOKER_SLACK_HI_SMOKE_PORT ? Number(process.env.INVOKER_SLACK_HI_SMOKE_PORT) : HI_SMOKE_DEFAULT_PORT,
+    runHiSmoke: (opts) => slack.runHiSmoke(opts),
+    log,
+  }).catch((err) => {
+    log('error', `hi-smoke server failed to start: ${errMessage(err)}`);
+    return undefined;
+  });
+
   let shuttingDown = false;
   const shutdown = async (signal: string): Promise<void> => {
     if (shuttingDown) return;
@@ -169,6 +183,7 @@ async function main(): Promise<void> {
     watchdog.stop();
     stopEvents();
     await slack.stop().catch((err) => log('warn', `slack.stop failed: ${errMessage(err)}`));
+    await hiSmoke?.stop().catch((err) => log('warn', `hi-smoke stop failed: ${errMessage(err)}`));
     client.disconnect();
     adapter.close();
     consumerLock.release();

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -633,6 +633,29 @@ export class SlackSurface implements Surface {
     }
   }
 
+  /**
+   * Localhost-only smoke hook. Posts a real parent message to the lobby, then
+   * feeds `text` (default "hi") through the ordinary app_mention route so the
+   * normal Slack response path posts the LLM reply in that same thread. Only
+   * ever reached via the opt-in hi-smoke server bound to 127.0.0.1.
+   */
+  async runHiSmoke(opts: { text?: string; channel?: string } = {}): Promise<{ channel: string; parentTs: string }> {
+    const channel = opts.channel ?? this.lobbyChannelId;
+    const text = (opts.text ?? 'hi').trim() || 'hi';
+    const mention = this.botUserId ? `<@${this.botUserId}> ${text}` : text;
+    const parent = await this.app.client.chat.postMessage({ channel, text });
+    const parentTs = parent.ts;
+    if (!parentTs) throw new Error('hi-smoke parent post returned no ts');
+    this.log('slack', 'info', `[HI_SMOKE] injected parent channel=${channel} parent_ts=${parentTs} text="${text}"`);
+    const event: SlackMentionEvent = { text: mention, ts: parentTs, channel, user: 'hi-smoke' };
+    const say: SayFn = async (msg) => {
+      const ts = await this.postMessage({ text: msg.text, blocks: (msg.blocks ?? []) as SlackMessage['blocks'] }, channel, msg.thread_ts);
+      return { ts };
+    };
+    await this.dispatchAppMention(event, say);
+    return { channel, parentTs };
+  }
+
   async handleEvent(event: SurfaceEvent): Promise<void> {
     if (event.type === 'workflow_created') {
       await this.createWorkflowChannel(event);
@@ -905,20 +928,31 @@ export class SlackSurface implements Surface {
 
   private registerMentionHandler(): void {
     this.app.event('app_mention', async ({ event, say }) => {
-      const channel: string | undefined = event.channel;
-      const threadTs = event.thread_ts ?? event.ts;
-      this.log('slack', 'info', `[MENTION_RECEIVED] instance=${this.instanceId} event_ts=${event.ts} thread_ts=${threadTs} channel=${channel ?? 'unknown'} user=${event.user ?? 'unknown'}`);
-
-      const mapping = channel ? this.workflowChannelRepo?.getByChannelId(channel) : null;
-      if (mapping) {
-        this.log('slack', 'info', `[MENTION_ROUTE] instance=${this.instanceId} event_ts=${event.ts} route=workflow workflow=${mapping.workflowId}`);
-        await this.handleWorkflowAssistantMention(mapping, event, say);
-        return;
-      }
-
-      this.log('slack', 'info', `[MENTION_ROUTE] instance=${this.instanceId} event_ts=${event.ts} route=planning`);
-      await this.handlePlanningMention(event, say, channel ?? this.lobbyChannelId);
+      await this.dispatchAppMention(event, say);
     });
+  }
+
+  /**
+   * Route one `app_mention`-shaped event through the workflow/planning split.
+   * Factored out of the Bolt handler so the localhost-only hi-smoke hook can
+   * drive the exact same route — and emit the same [MENTION_RECEIVED] /
+   * [MENTION_ROUTE] journal evidence — as a real Slack mention. Slack does not
+   * reliably redeliver an app's own mention, so the smoke path injects here.
+   */
+  async dispatchAppMention(event: SlackMentionEvent, say: SayFn): Promise<void> {
+    const channel: string | undefined = event.channel;
+    const threadTs = event.thread_ts ?? event.ts;
+    this.log('slack', 'info', `[MENTION_RECEIVED] instance=${this.instanceId} event_ts=${event.ts} thread_ts=${threadTs} channel=${channel ?? 'unknown'} user=${event.user ?? 'unknown'}`);
+
+    const mapping = channel ? this.workflowChannelRepo?.getByChannelId(channel) : null;
+    if (mapping) {
+      this.log('slack', 'info', `[MENTION_ROUTE] instance=${this.instanceId} event_ts=${event.ts} route=workflow workflow=${mapping.workflowId}`);
+      await this.handleWorkflowAssistantMention(mapping, event, say);
+      return;
+    }
+
+    this.log('slack', 'info', `[MENTION_ROUTE] instance=${this.instanceId} event_ts=${event.ts} route=planning`);
+    await this.handlePlanningMention(event, say, channel ?? this.lobbyChannelId);
   }
 
   // ── Planning mention (lobby) ───────────────────────────


### PR DESCRIPTION
## Summary

Invoker's Slack manager now has a safe way to prove the live "hi" reply path end to end.

Slack does not deliver a bot's own mention back to itself, so a real self-mention cannot trigger the reply flow.

This adds a hook, reachable only from the same machine and only when opted in, that feeds a "hi" mention through the ordinary planning-mention route.

The normal Slack response path then posts the LLM greeting in that same thread, so the reply flow is exercised for real.

## Review Claim

Approve routing an opt-in localhost "hi" through the same live Slack mention-and-reply path a human mention takes, so the manager posts an LLM greeting or reports one human-only blocker.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The hook binds to 127.0.0.1 and starts only when `INVOKER_SLACK_HI_SMOKE` is set, so default behavior is unchanged. It touches only slack-manager and the Slack surface. It never modifies Mergify workers, PR labels, queues, merges, rebases, or real PR branches.

## Slice Rationale

The live reply-path behavior is the substance a reviewer approves here. The operator driver that calls this hook is kept in a separate follow-up slice so this diff stays one behavior unit.

## Non-goals

- No PR babysit, Mergify, queue, stack, merge, rebase, or force-push changes.
- No operator driver script; that lands in the next slice.
- No change to default runtime behavior when the smoke gate is unset.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/slack-manager test`
- [ ] `pnpm --filter @invoker/slack-manager exec vitest run src/__tests__/hi-smoke-server.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None; the hook is opt-in and off by default.
- Data migration? No

</details>
