### PR TITLE
Add Cursor CLI (Grok 4.5) as an execution agent for CI-repair auto-fix

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -5,6 +5,7 @@ import { resolveInvokerConfigPath } from '@invoker/contracts';
 import {
   loadConfig,
   resolveAutoFixExecutionModel,
+  resolveAutoFixPoolId,
   resolveConfigFilePath,
   resolveDefaultExecutionAgent,
   resolveDefaultTaskExecutionSettings,
@@ -185,6 +186,24 @@ describe('loadConfig', () => {
       defaultExecutionAgent: 'omp',
       defaultExecutionModel: 'chatgpt-5.4',
     })).toBeUndefined();
+  });
+  it('prefers an explicit autoFixExecutionModel over the fleet default, scoped to auto-fix only', () => {
+    expect(resolveAutoFixExecutionModel({
+      autoFixAgent: 'cursor',
+      autoFixExecutionModel: 'grok-4.5',
+      defaultExecutionAgent: 'codex',
+      defaultExecutionModel: 'gpt-5.5',
+    })).toBe('grok-4.5');
+    // Fleet defaults are untouched — a task without autoFixAgent still resolves to codex/gpt-5.5.
+    expect(resolveDefaultTaskExecutionSettings({
+      defaultExecutionAgent: 'codex',
+      defaultExecutionModel: 'gpt-5.5',
+    })).toEqual({ executionAgent: 'codex', executionModel: 'gpt-5.5' });
+  });
+  it('resolves autoFixPoolId independently of defaultPoolId', () => {
+    expect(resolveAutoFixPoolId({ autoFixPoolId: 'remote_digital_ocean_1' })).toBe('remote_digital_ocean_1');
+    expect(resolveAutoFixPoolId({ autoFixPoolId: '  ' })).toBeUndefined();
+    expect(resolveAutoFixPoolId({})).toBeUndefined();
   });
 
   it('reads conflict resolution settings from user config', () => {

--- a/packages/app/src/__tests__/review-gate-ci-repair-workflow.test.ts
+++ b/packages/app/src/__tests__/review-gate-ci-repair-workflow.test.ts
@@ -83,6 +83,7 @@ function makeArgs(h: TestHarness, mergeId: string, workflowId: string): ReviewGa
     taskStateVersion: gate.taskStateVersion,
     agentName: 'codex',
     executionModel: 'openai/gpt-5.2',
+    poolId: 'remote_digital_ocean_1',
   };
 }
 
@@ -136,6 +137,7 @@ describe('spawnReviewGateCiRepairWorkflow', () => {
         prompt: expect.stringContaining('git fetch origin feature/review-gate-ci && git checkout feature/review-gate-ci'),
         executionAgent: 'codex',
         executionModel: 'openai/gpt-5.2',
+        poolId: 'remote_digital_ocean_1',
       },
     });
 

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -144,6 +144,17 @@ export interface InvokerConfig {
    */
   autoFixAgent?: string;
   /**
+   * Explicit execution model for automatic fix retries, independent of
+   * defaultExecutionModel. Takes precedence over the equality-based
+   * derivation in resolveAutoFixExecutionModel.
+   */
+  autoFixExecutionModel?: string;
+  /**
+   * Execution pool or remote target used for automatic fix retries.
+   * When unset, auto-fix tasks fall back to defaultPoolId.
+   */
+  autoFixPoolId?: string;
+  /**
    * Preferred execution agent for resolve-conflict (git merge conflicts).
    * When unset, resolve-conflict uses the entry-point path default
    * (explicit CLI/UI agent, then defaultExecutionAgent / autoFixAgent).
@@ -429,10 +440,16 @@ export function resolveDefaultTaskExecutionSettings(config: InvokerConfig): Defa
   };
 }
 export function resolveAutoFixExecutionModel(config: InvokerConfig): string | undefined {
+  const explicit = config.autoFixExecutionModel?.trim();
+  if (explicit) return explicit;
   const autoFixAgent = config.autoFixAgent?.trim();
   if (!autoFixAgent) return undefined;
   const defaults = resolveDefaultTaskExecutionSettings(config);
   return autoFixAgent === defaults.executionAgent ? defaults.executionModel : undefined;
+}
+
+export function resolveAutoFixPoolId(config: InvokerConfig): string | undefined {
+  return config.autoFixPoolId?.trim() || undefined;
 }
 
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -106,6 +106,7 @@ import {
   DEFAULT_SLACK_HARNESS_PRESETS,
   loadConfig,
   resolveAutoFixExecutionModel,
+  resolveAutoFixPoolId,
   resolveConfigFileState,
   resolvePrMaintenanceWorkerConfig,
   type InvokerConfig,
@@ -336,6 +337,7 @@ function buildRegisteredOwnerWorkerDeps(
       attemptLedger: autoFixAttemptLedger,
       getAutoFixAgent: () => invokerConfig.autoFixAgent,
       getAutoFixExecutionModel: () => resolveAutoFixExecutionModel(invokerConfig),
+      getAutoFixPoolId: () => resolveAutoFixPoolId(invokerConfig),
     },
     requeue: {
       stallRequeueRetries: invokerConfig.stallRequeueRetries,

--- a/packages/app/src/review-gate-ci-repair-workflow.ts
+++ b/packages/app/src/review-gate-ci-repair-workflow.ts
@@ -178,6 +178,7 @@ export async function spawnReviewGateCiRepairWorkflow(
         prompt: buildRepairPrompt(args, branch, baseBranch),
         ...(args.agentName ? { executionAgent: args.agentName } : {}),
         ...(args.executionModel ? { executionModel: args.executionModel } : {}),
+        ...(args.poolId ? { poolId: args.poolId } : {}),
       },
     ],
   };

--- a/packages/execution-engine/src/__tests__/cursor-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/cursor-execution-agent.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { assertExecutionModelSupported } from '../agent.js';
+import { CursorExecutionAgent } from '../agents/cursor-execution-agent.js';
+
+describe('CursorExecutionAgent', () => {
+  it('builds prompt command with print/trust and model selector', () => {
+    const agent = new CursorExecutionAgent({ command: 'cursor-test' });
+    const spec = agent.buildCommand('prompt text', { executionModel: 'grok-4.5' });
+
+    expect(spec.cmd).toBe('cursor-test');
+    expect(spec.args).toEqual([
+      'agent',
+      '--print',
+      '--trust',
+      '--model',
+      'grok-4.5',
+      'prompt text',
+    ]);
+    expect(spec.sessionId).toBeDefined();
+    expect(spec.fullPrompt).toBe('prompt text');
+  });
+
+  it('builds fix command without full prompt echo', () => {
+    const agent = new CursorExecutionAgent({ command: 'cursor-test' });
+    const spec = agent.buildFixCommand('fix prompt', { executionModel: 'grok-4.5' });
+
+    expect(spec.cmd).toBe('cursor-test');
+    expect(spec.args).toEqual([
+      'agent',
+      '--print',
+      '--trust',
+      '--model',
+      'grok-4.5',
+      'fix prompt',
+    ]);
+    expect(spec).not.toHaveProperty('fullPrompt');
+  });
+
+  it('omits the model flag when no model is given', () => {
+    const agent = new CursorExecutionAgent({ command: 'cursor-test' });
+    expect(agent.buildCommand('prompt text').args).toEqual(['agent', '--print', '--trust', 'prompt text']);
+  });
+
+  it('supports grok-4.5 and rejects unknown models', () => {
+    const agent = new CursorExecutionAgent();
+    expect(() => assertExecutionModelSupported(agent, 'grok-4.5')).not.toThrow();
+    expect(() => assertExecutionModelSupported(agent, 'gpt-5-codex')).toThrow(
+      /not supported for execution agent "cursor"/,
+    );
+  });
+
+  it('uses agent --resume for resume args', () => {
+    const agent = new CursorExecutionAgent({ command: 'cursor-test' });
+    expect(agent.buildResumeArgs('session-123')).toEqual({
+      cmd: 'cursor-test',
+      args: ['agent', '--resume', 'session-123'],
+    });
+  });
+
+  it('defaults to the "cursor" command', () => {
+    const agent = new CursorExecutionAgent();
+    expect(agent.buildCommand('prompt').cmd).toBe('cursor');
+  });
+});

--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -189,6 +189,7 @@ describe('PR status and CI failure workers', () => {
       defaultAutoFixRetries: 2,
       getAutoFixAgent: () => 'codex',
       getAutoFixExecutionModel: () => 'openai/gpt-5.2',
+      getAutoFixPoolId: () => 'remote_digital_ocean_1',
       drainEvents: () => [event],
     });
 
@@ -216,6 +217,7 @@ describe('PR status and CI failure workers', () => {
       taskStateVersion: 10,
       agentName: 'codex',
       executionModel: 'openai/gpt-5.2',
+      poolId: 'remote_digital_ocean_1',
     })[0]);
     expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toMatchObject({
       workerKind: CI_FAILURE_WORKER_KIND,

--- a/packages/execution-engine/src/agents/cursor-execution-agent.ts
+++ b/packages/execution-engine/src/agents/cursor-execution-agent.ts
@@ -1,0 +1,60 @@
+import { randomUUID } from 'node:crypto';
+import type { AgentCommandBuildOptions, AgentCommandSpec, ExecutionAgent, ExecutionModelOption } from '../agent.js';
+
+export interface CursorExecutionAgentConfig {
+  command?: string;
+}
+
+const CURSOR_SUPPORTED_MODELS: readonly ExecutionModelOption[] = [
+  { id: 'grok-4.5', label: 'Grok 4.5' },
+];
+
+export class CursorExecutionAgent implements ExecutionAgent {
+  readonly name = 'cursor';
+  readonly stdinMode = 'ignore' as const;
+  readonly linuxTerminalTail = 'exec_bash' as const;
+  readonly supportedModels = CURSOR_SUPPORTED_MODELS;
+
+  private readonly command: string;
+
+  constructor(config: CursorExecutionAgentConfig = {}) {
+    this.command = config.command ?? process.env.INVOKER_CURSOR_COMMAND ?? 'cursor';
+  }
+
+  buildCommand(fullPrompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
+    const sessionId = randomUUID();
+    return {
+      cmd: this.command,
+      args: this.buildArgs(fullPrompt, options.executionModel),
+      sessionId,
+      fullPrompt,
+    };
+  }
+
+  buildFixCommand(prompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
+    const sessionId = randomUUID();
+    return {
+      cmd: this.command,
+      args: this.buildArgs(prompt, options.executionModel),
+      sessionId,
+    };
+  }
+
+  supportsModel(executionModel: string): boolean {
+    return executionModel.trim().toLowerCase() === 'grok-4.5';
+  }
+
+  buildResumeArgs(sessionId: string): { cmd: string; args: string[] } {
+    return { cmd: this.command, args: ['agent', '--resume', sessionId] };
+  }
+
+  private buildArgs(prompt: string, executionModel?: string): string[] {
+    return [
+      'agent',
+      '--print',
+      '--trust',
+      ...(executionModel ? ['--model', executionModel] : []),
+      prompt,
+    ];
+  }
+}

--- a/packages/execution-engine/src/agents/index.ts
+++ b/packages/execution-engine/src/agents/index.ts
@@ -7,6 +7,7 @@ export { CodexExecutionAgent, type CodexExecutionAgentConfig } from './codex-exe
 export { OmpExecutionAgent, type OmpExecutionAgentConfig } from './omp-execution-agent.js';
 export { KimiExecutionAgent, type KimiExecutionAgentConfig } from './kimi-execution-agent.js';
 export { QwenExecutionAgent, type QwenExecutionAgentConfig } from './qwen-execution-agent.js';
+export { CursorExecutionAgent, type CursorExecutionAgentConfig } from './cursor-execution-agent.js';
 export { CursorPlanningAgent, type CursorPlanningAgentConfig } from './cursor-planning-agent.js';
 export { OmpPlanningAgent, type OmpPlanningAgentConfig } from './omp-planning-agent.js';
 export { CodexPlanningAgent, type CodexPlanningAgentConfig } from './codex-planning-agent.js';
@@ -17,6 +18,7 @@ import { CodexExecutionAgent, type CodexExecutionAgentConfig } from './codex-exe
 import { OmpExecutionAgent, type OmpExecutionAgentConfig } from './omp-execution-agent.js';
 import { KimiExecutionAgent, type KimiExecutionAgentConfig } from './kimi-execution-agent.js';
 import { QwenExecutionAgent, type QwenExecutionAgentConfig } from './qwen-execution-agent.js';
+import { CursorExecutionAgent, type CursorExecutionAgentConfig } from './cursor-execution-agent.js';
 import { CursorPlanningAgent, type CursorPlanningAgentConfig } from './cursor-planning-agent.js';
 import { OmpPlanningAgent, type OmpPlanningAgentConfig } from './omp-planning-agent.js';
 import { CodexPlanningAgent, type CodexPlanningAgentConfig } from './codex-planning-agent.js';
@@ -33,6 +35,7 @@ export function registerBuiltinAgents(opts?: {
   omp?: OmpExecutionAgentConfig;
   kimi?: KimiExecutionAgentConfig;
   qwen?: QwenExecutionAgentConfig;
+  cursorExecution?: CursorExecutionAgentConfig;
   cursor?: CursorPlanningAgentConfig;
   ompPlanning?: OmpPlanningAgentConfig;
   codexPlanning?: CodexPlanningAgentConfig;
@@ -43,6 +46,7 @@ export function registerBuiltinAgents(opts?: {
   registry.registerExecution(new OmpExecutionAgent(opts?.omp), new OmpSessionDriver());
   registry.registerExecution(new KimiExecutionAgent(opts?.kimi));
   registry.registerExecution(new QwenExecutionAgent(opts?.qwen));
+  registry.registerExecution(new CursorExecutionAgent(opts?.cursorExecution));
   registry.registerPlanning(new CursorPlanningAgent(opts?.cursor));
   registry.registerPlanning(new OmpPlanningAgent(opts?.ompPlanning));
   registry.registerPlanning(new CodexPlanningAgent(opts?.codexPlanning));

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -83,6 +83,8 @@ export interface AutoFixWorkerConfig {
   getAutoFixAgent?: () => string | undefined;
   /** Resolves the execution model used by worker-submitted auto-fixes. */
   getAutoFixExecutionModel?: () => string | undefined;
+  /** Resolves the execution pool/target used by worker-submitted auto-fixes. */
+  getAutoFixPoolId?: () => string | undefined;
 }
 
 

--- a/packages/execution-engine/src/review-gate-ci-repair.ts
+++ b/packages/execution-engine/src/review-gate-ci-repair.ts
@@ -69,6 +69,7 @@ export interface ReviewGateCiRepairPolicyOptions {
   defaultAutoFixRetries?: number;
   getAutoFixAgent?: () => string | undefined;
   getAutoFixExecutionModel?: () => string | undefined;
+  getAutoFixPoolId?: () => string | undefined;
   attemptLedger: AutoFixAttemptLedger;
   getRetryBudget?: (task: TaskState) => number;
   /** Optional failed-check log fetcher used to skip non-fixable infra failures. */
@@ -90,6 +91,7 @@ export interface ReviewGateCiRepairWorkflowMutationArgs {
   readonly taskStateVersion: number;
   readonly agentName?: string;
   readonly executionModel?: string;
+  readonly poolId?: string;
 }
 
 export function buildReviewGateCiRepairWorkflowMutationArgs(
@@ -119,6 +121,7 @@ export function parseReviewGateCiRepairWorkflowMutationArgs(args: unknown[]): Re
     taskStateVersion,
     agentName,
     executionModel,
+    poolId,
   } = candidate;
   if (
     typeof sourceWorkflowId !== 'string'
@@ -149,6 +152,7 @@ export function parseReviewGateCiRepairWorkflowMutationArgs(args: unknown[]): Re
     taskStateVersion,
     ...(typeof agentName === 'string' ? { agentName } : {}),
     ...(typeof executionModel === 'string' ? { executionModel } : {}),
+    ...(typeof poolId === 'string' ? { poolId } : {}),
   };
 }
 
@@ -546,6 +550,8 @@ export async function queueReviewGateCiRepair(
   const executionModel = configuredExecutionModel && configuredExecutionModel.length > 0
     ? configuredExecutionModel
     : undefined;
+  const configuredPoolId = options.getAutoFixPoolId?.()?.trim();
+  const poolId = configuredPoolId && configuredPoolId.length > 0 ? configuredPoolId : undefined;
   const args = buildReviewGateCiRepairWorkflowMutationArgs({
     sourceWorkflowId: event.workflowId,
     sourceTaskId: event.taskId,
@@ -561,6 +567,7 @@ export async function queueReviewGateCiRepair(
     taskStateVersion: event.taskStateVersion ?? task.taskStateVersion,
     ...(selectedAgent ? { agentName: selectedAgent } : {}),
     ...(executionModel ? { executionModel } : {}),
+    ...(poolId ? { poolId } : {}),
   });
   const intentId = options.submitter.submit(
     event.workflowId,

--- a/packages/execution-engine/src/workers/ci-failure-worker.ts
+++ b/packages/execution-engine/src/workers/ci-failure-worker.ts
@@ -63,6 +63,7 @@ export function registerCiFailureWorker(
           getAutoFixAgent: deps.autoFix?.getAutoFixAgent,
           attemptLedger: deps.autoFix?.attemptLedger,
           getAutoFixExecutionModel: deps.autoFix?.getAutoFixExecutionModel,
+          getAutoFixPoolId: deps.autoFix?.getAutoFixPoolId,
           fetchFailedCheckLogs: createFailedCheckLogFetcher({
             cwd: deps.prMaintenance?.repoRoot,
           }),


### PR DESCRIPTION
Registers a real Cursor execution agent (grok-4.5) and threads a dedicated
autoFixExecutionModel/autoFixPoolId config path through the CI-repair
worker, scoped so the fleet-wide default execution agent/model never
changes for any other task.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>