### PR TITLE
[Mergify Repair Loop DO Routing](1) Route the repair loop to Cursor CLI (Grok 4.5) over SSH

### DIFF
--- a/scripts/cron-pr-admin-bypass-land.sh
+++ b/scripts/cron-pr-admin-bypass-land.sh
@@ -6,6 +6,16 @@ source "$(dirname "$0")/cron-pr-lib.sh"
 
 cron_lock
 
+# Route repair-agent invocations to Cursor CLI (Grok 4.5) on a DigitalOcean
+# droplet instead of local claude -p. See scripts/mergify_admin_requeue_repairer.py
+# run_remote_repair(). Uses remote_digital_ocean_2 so this loop doesn't contend
+# with the CI-repair worker's remote_digital_ocean_1 slot.
+export INVOKER_ADMIN_BYPASS_REPAIR_HOST="${INVOKER_ADMIN_BYPASS_REPAIR_HOST:-157.245.231.246}"
+export INVOKER_ADMIN_BYPASS_REPAIR_USER="${INVOKER_ADMIN_BYPASS_REPAIR_USER:-invoker}"
+export INVOKER_ADMIN_BYPASS_REPAIR_SSH_KEY="${INVOKER_ADMIN_BYPASS_REPAIR_SSH_KEY:-$HOME/.ssh/id_ed25519}"
+export INVOKER_ADMIN_BYPASS_REPAIR_AGENT="${INVOKER_ADMIN_BYPASS_REPAIR_AGENT:-cursor}"
+export INVOKER_ADMIN_BYPASS_REPAIR_MODEL="${INVOKER_ADMIN_BYPASS_REPAIR_MODEL:-grok-4.5}"
+
 args=(--once --repo "$TARGET_REPO" --author "$PR_AUTHOR")
 if [ "$DRY_RUN" = "1" ]; then
   args+=(--dry-run)

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import base64
 import json
 import os
+import shlex
 from pathlib import Path
 import subprocess
 import tempfile
@@ -389,9 +391,60 @@ class AdminBypassRepairer:
         return {"prNumber": prereq_number, "branch": branch_name, "title": title}
 
     def run_claude_repair(self, work_root: Path, prompt: str) -> None:
+        host = os.environ.get("INVOKER_ADMIN_BYPASS_REPAIR_HOST", "").strip()
+        user = os.environ.get("INVOKER_ADMIN_BYPASS_REPAIR_USER", "").strip()
+        ssh_key = os.environ.get("INVOKER_ADMIN_BYPASS_REPAIR_SSH_KEY", "").strip()
+        if host and user and ssh_key:
+            self.run_remote_repair(work_root, prompt, host=host, user=user, ssh_key=ssh_key)
+            return
         subprocess.run(
             ["claude", "-p", prompt, "--dangerously-skip-permissions"],
             cwd=str(work_root),
+            check=True,
+            text=True,
+        )
+
+    def run_remote_repair(
+        self,
+        work_root: Path,
+        prompt: str,
+        *,
+        host: str,
+        user: str,
+        ssh_key: str,
+    ) -> None:
+        agent = os.environ.get("INVOKER_ADMIN_BYPASS_REPAIR_AGENT", "cursor").strip() or "cursor"
+        if agent != "cursor":
+            raise ValueError(f"Unsupported remote repair agent: {agent!r} (only 'cursor' is implemented)")
+        model = os.environ.get("INVOKER_ADMIN_BYPASS_REPAIR_MODEL", "grok-4.5").strip() or "grok-4.5"
+        if not work_root.name.isdigit():
+            raise ValueError(f"Unexpected work_root name for remote repair: {work_root.name!r}")
+
+        # `~` (not $HOME) is used deliberately: it is expanded both by rsync's
+        # documented remote-path handling and by the remote login shell ssh
+        # invokes, so the same literal path string works in both contexts.
+        # Never shlex.quote it — quoting would suppress that expansion.
+        remote_work_root = f"~/.invoker/mergify-admin-requeue-work/{work_root.name}"
+        remote_prompt_path = f"{remote_work_root}/.repair-prompt.b64"
+        ssh_opts = ["-i", ssh_key, "-o", "StrictHostKeyChecking=accept-new", "-o", "BatchMode=yes"]
+        rsync_ssh = "ssh " + " ".join(shlex.quote(part) for part in ssh_opts)
+
+        subprocess.run(["ssh", *ssh_opts, f"{user}@{host}", f"mkdir -p {remote_work_root}"], check=True, text=True)
+        subprocess.run(
+            ["rsync", "-az", "-e", rsync_ssh, f"{work_root}/", f"{user}@{host}:{remote_work_root}/"],
+            check=True,
+            text=True,
+        )
+        encoded_prompt = base64.b64encode(prompt.encode("utf-8")).decode("ascii")
+        remote_cmd = (
+            f"printf '%s' {shlex.quote(encoded_prompt)} | base64 -d > {remote_prompt_path} && "
+            f"cd {remote_work_root} && "
+            f"cursor agent --print --trust --model {shlex.quote(model)} \"$(cat {remote_prompt_path})\"; "
+            f"rc=$?; rm -f {remote_prompt_path}; exit $rc"
+        )
+        subprocess.run(["ssh", *ssh_opts, f"{user}@{host}", remote_cmd], check=True, text=True)
+        subprocess.run(
+            ["rsync", "-az", "-e", rsync_ssh, f"{user}@{host}:{remote_work_root}/", f"{work_root}/"],
             check=True,
             text=True,
         )

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -361,6 +361,54 @@ Failing checks
             text=True,
         )
 
+    def test_claude_repair_routes_to_cursor_over_ssh_when_remote_configured(self):
+        repairer = self.repairer(object(), self.ledger())
+        env = {
+            "INVOKER_ADMIN_BYPASS_REPAIR_HOST": "157.245.231.246",
+            "INVOKER_ADMIN_BYPASS_REPAIR_USER": "invoker",
+            "INVOKER_ADMIN_BYPASS_REPAIR_SSH_KEY": "/home/user/.ssh/id_ed25519",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            with mock.patch("scripts.mergify_admin_requeue_repairer.subprocess.run") as run:
+                repairer.run_claude_repair(Path("/tmp/work/5803"), "repair this")
+
+        self.assertEqual(run.call_count, 4)
+        mkdir_call, push_call, ssh_call, pull_call = (call.args[0] for call in run.call_args_list)
+
+        self.assertEqual(
+            mkdir_call,
+            ["ssh", "-i", env["INVOKER_ADMIN_BYPASS_REPAIR_SSH_KEY"], "-o", "StrictHostKeyChecking=accept-new",
+             "-o", "BatchMode=yes", "invoker@157.245.231.246",
+             "mkdir -p ~/.invoker/mergify-admin-requeue-work/5803"],
+        )
+        self.assertEqual(push_call[0], "rsync")
+        self.assertEqual(push_call[-2:], ["/tmp/work/5803/", "invoker@157.245.231.246:~/.invoker/mergify-admin-requeue-work/5803/"])
+
+        self.assertEqual(ssh_call[0], "ssh")
+        self.assertEqual(ssh_call[-2], "invoker@157.245.231.246")
+        remote_cmd = ssh_call[-1]
+        self.assertIn("cursor agent --print --trust --model grok-4.5", remote_cmd)
+        self.assertIn("~/.invoker/mergify-admin-requeue-work/5803/.repair-prompt.b64", remote_cmd)
+
+        self.assertEqual(pull_call[0], "rsync")
+        self.assertEqual(
+            pull_call[-2:],
+            ["invoker@157.245.231.246:~/.invoker/mergify-admin-requeue-work/5803/", "/tmp/work/5803/"],
+        )
+
+    def test_claude_repair_rejects_unsupported_remote_agent(self):
+        repairer = self.repairer(object(), self.ledger())
+        env = {
+            "INVOKER_ADMIN_BYPASS_REPAIR_HOST": "157.245.231.246",
+            "INVOKER_ADMIN_BYPASS_REPAIR_USER": "invoker",
+            "INVOKER_ADMIN_BYPASS_REPAIR_SSH_KEY": "/home/user/.ssh/id_ed25519",
+            "INVOKER_ADMIN_BYPASS_REPAIR_AGENT": "not-cursor",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            with mock.patch("scripts.mergify_admin_requeue_repairer.subprocess.run"):
+                with self.assertRaises(ValueError):
+                    repairer.run_claude_repair(Path("/tmp/work/5803"), "repair this")
+
     def test_candidate_stack_includes_unlabeled_upper_prs(self):
         def raw(number, base, head, labels):
             return {


### PR DESCRIPTION
## Summary

The mergify admin-requeue repair loop always shelled out to a local `claude -p` process, with no way to run it elsewhere or with a different agent.

The repair call defaults to that exact same local behavior. When three env vars are set, it instead syncs the local checkout to a DigitalOcean droplet, runs `cursor agent --model grok-4.5` there, and syncs the result back.

The live 5-minute cron now sets those env vars by default. It targets a droplet slot separate from the CI-repair worker's, so the two automations don't share one SSH concurrency limit.

## Review Claim

Approve making the mergify admin-requeue repair subprocess swappable to Cursor CLI (grok-4.5) over SSH, defaulting to today's unchanged local `claude -p` behavior when unconfigured.

## Review Lane

- policy

## Review Unit

- tooling-policy

## Safety Invariant

With no `INVOKER_ADMIN_BYPASS_REPAIR_*` env vars set, `run_claude_repair` takes the exact same code path it did before (verified by an unchanged regression test). All git/validation logic in `AdminBypassRepairer` — checkout, diff, PR-body validation, push — stays local and untouched; only the edit-generating agent call itself moves to the droplet, via `rsync` push/pull around the remote `cursor agent` invocation.

## Slice Rationale

One coherent local claim: make this one Python method (`run_claude_repair`) swappable, and turn it on for the live cron. The CI-repair worker's separate Cursor execution-agent registration (a different subsystem, TypeScript, disjoint files) ships as its own PR.

## Non-goals

- Does not change how `checkout_pr_head`, PR-body validation, or branch pushing work.
- Does not move the polling/cron loop itself off the local machine — only the repair-agent subprocess call.
- Does not add remote execution to `repair_conflict`'s call site beyond reusing the same `run_claude_repair` method it already calls.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m pytest scripts/test_mergify_admin_requeue.py -v` (50 passed, including 2 new tests covering the remote-SSH path and the unsupported-agent guard)
- [x] `bash -n scripts/cron-pr-admin-bypass-land.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: none. If the env vars were also exported elsewhere (e.g. a shell profile), unset them so nothing tries to route to a droplet that no longer expects it.
- Data migration? No.

</details>
