### PR TITLE
[Cursor Grok DO Routing](1) Add autoFixExecutionModel and autoFixPoolId config fields

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -5,6 +5,7 @@ import { resolveInvokerConfigPath } from '@invoker/contracts';
 import {
   loadConfig,
   resolveAutoFixExecutionModel,
+  resolveAutoFixPoolId,
   resolveConfigFilePath,
   resolveDefaultExecutionAgent,
   resolveDefaultTaskExecutionSettings,
@@ -185,6 +186,24 @@ describe('loadConfig', () => {
       defaultExecutionAgent: 'omp',
       defaultExecutionModel: 'chatgpt-5.4',
     })).toBeUndefined();
+  });
+  it('prefers an explicit autoFixExecutionModel over the fleet default, scoped to auto-fix only', () => {
+    expect(resolveAutoFixExecutionModel({
+      autoFixAgent: 'cursor',
+      autoFixExecutionModel: 'grok-4.5',
+      defaultExecutionAgent: 'codex',
+      defaultExecutionModel: 'gpt-5.5',
+    })).toBe('grok-4.5');
+    // Fleet defaults are untouched — a task without autoFixAgent still resolves to codex/gpt-5.5.
+    expect(resolveDefaultTaskExecutionSettings({
+      defaultExecutionAgent: 'codex',
+      defaultExecutionModel: 'gpt-5.5',
+    })).toEqual({ executionAgent: 'codex', executionModel: 'gpt-5.5' });
+  });
+  it('resolves autoFixPoolId independently of defaultPoolId', () => {
+    expect(resolveAutoFixPoolId({ autoFixPoolId: 'remote_digital_ocean_1' })).toBe('remote_digital_ocean_1');
+    expect(resolveAutoFixPoolId({ autoFixPoolId: '  ' })).toBeUndefined();
+    expect(resolveAutoFixPoolId({})).toBeUndefined();
   });
 
   it('reads conflict resolution settings from user config', () => {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -144,6 +144,17 @@ export interface InvokerConfig {
    */
   autoFixAgent?: string;
   /**
+   * Explicit execution model for automatic fix retries, independent of
+   * defaultExecutionModel. Takes precedence over the equality-based
+   * derivation in resolveAutoFixExecutionModel.
+   */
+  autoFixExecutionModel?: string;
+  /**
+   * Execution pool or remote target used for automatic fix retries.
+   * When unset, auto-fix tasks fall back to defaultPoolId.
+   */
+  autoFixPoolId?: string;
+  /**
    * Preferred execution agent for resolve-conflict (git merge conflicts).
    * When unset, resolve-conflict uses the entry-point path default
    * (explicit CLI/UI agent, then defaultExecutionAgent / autoFixAgent).
@@ -429,10 +440,16 @@ export function resolveDefaultTaskExecutionSettings(config: InvokerConfig): Defa
   };
 }
 export function resolveAutoFixExecutionModel(config: InvokerConfig): string | undefined {
+  const explicit = config.autoFixExecutionModel?.trim();
+  if (explicit) return explicit;
   const autoFixAgent = config.autoFixAgent?.trim();
   if (!autoFixAgent) return undefined;
   const defaults = resolveDefaultTaskExecutionSettings(config);
   return autoFixAgent === defaults.executionAgent ? defaults.executionModel : undefined;
+}
+
+export function resolveAutoFixPoolId(config: InvokerConfig): string | undefined {
+  return config.autoFixPoolId?.trim() || undefined;
 }
 
 


### PR DESCRIPTION
## Summary

Auto-fix could only reuse the fleet-wide default execution model, and only when the auto-fix agent happened to match the fleet-wide default agent.

Two new config fields, `autoFixExecutionModel` and `autoFixPoolId`, let auto-fix pin a model and execution pool explicitly, independent of the fleet default used by every other task.

## Review Claim

Approve two new, additive config fields for auto-fix, with `resolveAutoFixExecutionModel` preferring the explicit field and falling back to the existing behavior otherwise.

## Review Lane

- behavior

## Review Unit

- validation-policy

## Safety Invariant

`resolveAutoFixExecutionModel` checks the new `autoFixExecutionModel` field first; only when it is unset does it fall back to the pre-existing equality-derived logic, byte-for-byte unchanged. `resolveAutoFixPoolId` is a brand-new function with no prior behavior. Neither field is consumed anywhere yet in this PR, so this slice cannot change any running behavior on its own.

## Slice Rationale

This is the foundation slice: the config surface auto-fix needs, landed before anything reads it. The follow-up PR wires `getAutoFixPoolId` into the CI-repair worker and adds the Cursor execution agent that actually uses these fields.

## Non-goals

- Does not register any new execution agent.
- Does not consume `poolId` inside the CI-repair worker (follow-up PR).
- Does not flip the live `~/.invoker/config.json` switch.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test`
- [x] `cd packages/app && pnpm build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: none — these fields aren't read anywhere yet.
- Data migration? No.

</details>
