### PR TITLE
[PR Maintenance Worker Fairness](2) Stagger worker start times to fix shared-lock starvation

### DIFF
--- a/packages/execution-engine/src/__tests__/worker-runtime-start-delay.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-runtime-start-delay.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWorkerRuntime } from '../worker-runtime.js';
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn(), child: vi.fn() };
+
+describe('createWorkerRuntime startDelayMs', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('defers the first tick and the poll interval until startDelayMs elapses', async () => {
+    const onTick = vi.fn();
+    const runtime = createWorkerRuntime({
+      kind: 'test',
+      logger,
+      onTick,
+      intervalMs: 100,
+      startDelayMs: 250,
+      tickOnStart: true,
+      installSignalHandlers: false,
+    });
+
+    runtime.start();
+    expect(onTick).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(onTick).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(onTick).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(onTick).toHaveBeenCalledTimes(2);
+
+    await runtime.stop();
+  });
+
+  it('ticks immediately with no startDelayMs (default 0, unchanged behavior)', async () => {
+    const onTick = vi.fn();
+    const runtime = createWorkerRuntime({
+      kind: 'test',
+      logger,
+      onTick,
+      intervalMs: 100,
+      tickOnStart: true,
+      installSignalHandlers: false,
+    });
+
+    runtime.start();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onTick).toHaveBeenCalledTimes(1);
+
+    await runtime.stop();
+  });
+
+  it('stop() before the start delay elapses cancels the pending timer cleanly', async () => {
+    const onTick = vi.fn();
+    const runtime = createWorkerRuntime({
+      kind: 'test',
+      logger,
+      onTick,
+      intervalMs: 100,
+      startDelayMs: 250,
+      tickOnStart: true,
+      installSignalHandlers: false,
+    });
+
+    runtime.start();
+    await runtime.stop();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(onTick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/execution-engine/src/worker-runtime.ts
+++ b/packages/execution-engine/src/worker-runtime.ts
@@ -57,6 +57,13 @@ export interface WorkerRuntimeOptions {
   onTick: WorkerTick;
   /** Periodic poll interval in ms. `<= 0` disables polling (wakeup-only). */
   intervalMs?: number;
+  /**
+   * Delay before the poll interval (and `tickOnStart`) begin, in ms. Default 0.
+   * Use to stagger multiple worker runtimes that share an external resource
+   * (e.g. a cross-process lock) and would otherwise all wake on the same
+   * `intervalMs` boundary every cycle.
+   */
+  startDelayMs?: number;
   /** Run a tick immediately when `start()` is called. Default `true`. */
   tickOnStart?: boolean;
   /** OS signals that trigger deterministic shutdown. Default `SIGINT`/`SIGTERM`. */
@@ -112,6 +119,7 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
     instanceId: options.instanceId ?? nextInstanceId(options.kind),
   };
   const intervalMs = options.intervalMs ?? 0;
+  const startDelayMs = options.startDelayMs ?? 0;
   const tickOnStart = options.tickOnStart ?? true;
   const shutdownSignals = options.shutdownSignals ?? DEFAULT_SHUTDOWN_SIGNALS;
   const installSignalHandlers = options.installSignalHandlers ?? true;
@@ -120,6 +128,7 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
   let started = false;
   let stopped = false;
   let interval: ReturnType<typeof setInterval> | null = null;
+  let startDelayTimer: ReturnType<typeof setTimeout> | null = null;
   let inFlight: Promise<void> | null = null;
   let pendingReason: WorkerTickReason | null = null;
   let tickNumber = 0;
@@ -196,6 +205,10 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
       clearInterval(interval);
       interval = null;
     }
+    if (startDelayTimer) {
+      clearTimeout(startDelayTimer);
+      startDelayTimer = null;
+    }
     for (const [signal, handler] of signalHandlers) {
       process.removeListener(signal, handler);
     }
@@ -227,7 +240,7 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
     if (started) return;
     started = true;
     options.logger.info(
-      `[worker:${identity.kind}] started intervalMs=${intervalMs} signals=${installSignalHandlers ? shutdownSignals.join(',') : 'none'}`,
+      `[worker:${identity.kind}] started intervalMs=${intervalMs} startDelayMs=${startDelayMs} signals=${installSignalHandlers ? shutdownSignals.join(',') : 'none'}`,
       logFields,
     );
 
@@ -242,12 +255,23 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
       }
     }
 
-    if (intervalMs > 0) {
-      interval = setInterval(() => wake('poll'), intervalMs);
-      interval.unref?.();
-    }
+    const beginPolling = (): void => {
+      if (intervalMs > 0) {
+        interval = setInterval(() => wake('poll'), intervalMs);
+        interval.unref?.();
+      }
+      if (tickOnStart) wake('startup');
+    };
 
-    if (tickOnStart) wake('startup');
+    if (startDelayMs > 0) {
+      startDelayTimer = setTimeout(() => {
+        startDelayTimer = null;
+        if (!stopped) beginPolling();
+      }, startDelayMs);
+      startDelayTimer.unref?.();
+    } else {
+      beginPolling();
+    }
   };
 
   const stop = async (stopOptions?: WorkerRuntimeStopOptions): Promise<void> => {

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -18,6 +18,12 @@ export const PR_CI_FAILURE_SCAN_WORKER_KIND = 'pr-ci-failure-scan';
 export const PR_ADMIN_BYPASS_LAND_WORKER_KIND = 'pr-admin-bypass-land';
 export const PR_ORPHAN_REPAIR_WORKER_KIND = 'pr-orphan-repair';
 export const DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS = 5 * 60_000;
+/**
+ * Even spacing between each PR-maintenance worker's first tick, so the 5
+ * workers sharing the cron lock (scripts/cron-pr-lib.sh) don't all wake on
+ * the same intervalMs boundary and race for it every cycle.
+ */
+export const PR_MAINTENANCE_WORKER_STAGGER_STEP_MS = DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS / 5;
 
 export type PrMaintenanceWorkerKind =
   | typeof CODERABBIT_ADDRESS_WORKER_KIND
@@ -68,6 +74,15 @@ export interface PrMaintenanceWorkerConfig {
   env?: EnvOverrides;
   /** Poll cadence for PR-maintenance workers. Defaults to five minutes. */
   intervalMs?: number;
+  /**
+   * Delay before this worker's first tick/poll begins, in ms. Default 0.
+   * Every PR-maintenance worker shares one intervalMs with zero stagger by
+   * default, so without this they all wake on the same boundary every cycle
+   * and race for the shared cron lock — the same worker (typically whichever
+   * registers first) wins almost every time, starving the others. Each
+   * registerXWorker call below assigns a distinct offset to fix this.
+   */
+  startDelayMs?: number;
   /** Shared cron lock path. Defaults to the shell script's `INVOKER_PR_CRON_LOCK` behavior. */
   lockPath?: string;
   /** Shell executable used to run the existing entrypoint. Defaults to `bash`. */
@@ -130,6 +145,7 @@ export function registerCoderabbitAddressWorker(
         logger: deps.logger,
         ...deps.prMaintenance,
         store: deps.store,
+        startDelayMs: 0 * PR_MAINTENANCE_WORKER_STAGGER_STEP_MS,
       }),
   });
   return registry;
@@ -146,6 +162,7 @@ export function registerPrConflictRebaseWorker(
         logger: deps.logger,
         ...deps.prMaintenance,
         store: deps.store,
+        startDelayMs: 1 * PR_MAINTENANCE_WORKER_STAGGER_STEP_MS,
       }),
   });
   return registry;
@@ -161,6 +178,7 @@ export function registerPrCiFailureScanWorker(
         logger: deps.logger,
         ...deps.prMaintenance,
         store: deps.store,
+        startDelayMs: 2 * PR_MAINTENANCE_WORKER_STAGGER_STEP_MS,
       }),
   });
   return registry;
@@ -177,6 +195,7 @@ export function registerPrAdminBypassLandWorker(
         logger: deps.logger,
         ...deps.prMaintenance,
         store: deps.store,
+        startDelayMs: 3 * PR_MAINTENANCE_WORKER_STAGGER_STEP_MS,
       }),
   });
   return registry;
@@ -193,6 +212,7 @@ export function registerPrOrphanRepairWorker(
         logger: deps.logger,
         ...deps.prMaintenance,
         store: deps.store,
+        startDelayMs: 4 * PR_MAINTENANCE_WORKER_STAGGER_STEP_MS,
       }),
   });
   return registry;
@@ -264,6 +284,7 @@ function createPrMaintenanceWorker(
     instanceId: options.instanceId,
     logger: options.logger,
     intervalMs: options.intervalMs ?? DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS,
+    startDelayMs: options.startDelayMs,
     tickOnStart: options.tickOnStart ?? false,
     installSignalHandlers: options.installSignalHandlers,
     onTick: options.onTick ?? createPrMaintenanceTick({

--- a/scripts/repro/repro-pr-maintenance-lock-starvation.sh
+++ b/scripts/repro/repro-pr-maintenance-lock-starvation.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Root-cause repro: the 5 PR-maintenance workers (coderabbit-address,
+# pr-conflict-rebase, pr-ci-failure-scan, pr-admin-bypass-land,
+# pr-orphan-repair) all share one intervalMs
+# (DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS) with zero jitter, and
+# registerPrMaintenanceWorkers() starts them in a fixed order. Node fires
+# same-tick setInterval callbacks in registration order, so whichever worker
+# registers first tends to win the shared cron lock almost every cycle,
+# starving workers registered later — especially pr-admin-bypass-land, 4th of 5.
+#
+# Drives the REAL production worker runtimes (createCoderabbitAddressWorker
+# etc., the same factories registerPrMaintenanceWorkers uses), with only the
+# leaf shell entrypoint swapped for a lightweight stand-in that holds the real
+# shared flock for a simulated work duration and records who actually got to
+# run. Everything else — intervalMs, registration order, the real
+# probePrMaintenanceLock probe, the real spawn+await path — is untouched
+# production code.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-pr-starvation.XXXXXX")"
+RESULTS="$TMP/results.jsonl"
+: > "$RESULTS"
+FAKE_SCRIPT="$TMP/fake-entrypoint.sh"
+PROOF_TEST="$ROOT/packages/execution-engine/src/__pr_maintenance_starvation_repro_$$.test.ts"
+
+cleanup() {
+  rm -f "$PROOF_TEST"
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+cat > "$FAKE_SCRIPT" <<SH
+#!/usr/bin/env bash
+set -euo pipefail
+# Mirrors cron-pr-lib.sh's cron_lock(): acquire+hold the SAME shared lock for
+# the simulated work duration. The TS-level probePrMaintenanceLock only does a
+# fast acquire-then-release check; the real held-lock window happens here,
+# inside the spawned leaf script, same as the production shell entrypoints.
+# Uses flock when available (Linux, e.g. the real droplet host), falling back
+# to the same portable mkdir lock cron-pr-lib.sh uses when it isn't (macOS).
+if command -v flock >/dev/null 2>&1; then
+  exec 9>"$TMP/crons.lock"
+  flock -n 9 || exit 0
+else
+  lockdir="$TMP/crons.lock.d"
+  if ! mkdir "\$lockdir" 2>/dev/null; then
+    exit 0
+  fi
+  printf '%s\n' "\$\$" > "\$lockdir/pid"
+  trap 'rm -rf "'"\$lockdir"'" 2>/dev/null || true' EXIT
+fi
+echo "\$(date +%s%3N) \${INVOKER_PR_MAINTENANCE_KIND:-unknown}" >> "$RESULTS"
+sleep 0.15
+SH
+chmod +x "$FAKE_SCRIPT"
+
+ensure_execution_engine_vitest() {
+  pnpm --filter @invoker/execution-engine exec vitest --version >/dev/null 2>&1 && return 0
+  echo "[repro] installing workspace dependencies for @invoker/execution-engine vitest"
+  pnpm install --frozen-lockfile
+  pnpm --filter @invoker/execution-engine exec vitest --version >/dev/null 2>&1
+}
+
+cat > "$PROOF_TEST" <<TS
+import { describe, it } from 'vitest';
+import {
+  createCoderabbitAddressWorker,
+  createPrConflictRebaseWorker,
+  createPrCiFailureScanWorker,
+  createPrAdminBypassLandWorker,
+  createPrOrphanRepairWorker,
+  CODERABBIT_ADDRESS_WORKER_KIND,
+  PR_CONFLICT_REBASE_WORKER_KIND,
+  PR_CI_FAILURE_SCAN_WORKER_KIND,
+  PR_ADMIN_BYPASS_LAND_WORKER_KIND,
+  PR_ORPHAN_REPAIR_WORKER_KIND,
+} from './workers/pr-maintenance-workers.js';
+
+// Real registration order, from registerPrMaintenanceWorkers() in
+// packages/execution-engine/src/workers/pr-maintenance-workers.ts:111-119.
+const FACTORIES = [
+  { kind: CODERABBIT_ADDRESS_WORKER_KIND, create: createCoderabbitAddressWorker },
+  { kind: PR_CONFLICT_REBASE_WORKER_KIND, create: createPrConflictRebaseWorker },
+  { kind: PR_CI_FAILURE_SCAN_WORKER_KIND, create: createPrCiFailureScanWorker },
+  { kind: PR_ADMIN_BYPASS_LAND_WORKER_KIND, create: createPrAdminBypassLandWorker },
+  { kind: PR_ORPHAN_REPAIR_WORKER_KIND, create: createPrOrphanRepairWorker },
+];
+
+const logger = { info: () => {}, warn: () => {}, error: (...a: unknown[]) => console.error('[worker error]', ...a), debug: () => {}, trace: () => {}, child: () => logger };
+
+describe('PR-maintenance shared-lock starvation repro', () => {
+  it('runs all 5 real worker runtimes with zero jitter and records who wins the shared lock', async () => {
+    const workers = FACTORIES.map(({ kind, create }) =>
+      (create as (options: unknown) => { start: () => void; stop: () => Promise<void> })({
+        logger,
+        repoRoot: '$ROOT',
+        lockPath: '$TMP/crons.lock',
+        shell: '$FAKE_SCRIPT',
+        intervalMs: 400,
+        env: { INVOKER_PR_MAINTENANCE_KIND: kind, INVOKER_PR_CRON_LOCK: '$TMP/crons.lock' },
+      }),
+    );
+
+    for (const worker of workers) worker.start();
+    await new Promise((resolve) => setTimeout(resolve, 20_000));
+    await Promise.all(workers.map((w) => w.stop()));
+  }, 30_000);
+});
+TS
+
+ensure_execution_engine_vitest
+echo "[repro] starting 5 real PR-maintenance worker runtimes, intervalMs=400ms, no jitter (matches production)"
+set +e
+vitest_out="$(pnpm --filter @invoker/execution-engine exec vitest run "src/$(basename "$PROOF_TEST")" 2>&1)"
+code=$?
+set -e
+[ "$code" -eq 0 ] || fail "repro test run failed" "$vitest_out"
+
+echo "$vitest_out" | grep -i 'worker error' && fail "a worker runtime logged an error" "$vitest_out"
+
+TOTAL=$(wc -l < "$RESULTS" | tr -d ' ')
+echo ""
+echo "[repro] $TOTAL total successful lock acquisitions across 5 workers over 20s:"
+echo ""
+FAIRSHARE=$(awk -v t="$TOTAL" 'BEGIN { printf "%.1f", t / 5 }')
+MAX_RUNS=0
+ZERO_COUNT=0
+for kind in coderabbit-address pr-conflict-rebase pr-ci-failure-scan pr-admin-bypass-land pr-orphan-repair; do
+  n=$(awk -v k="$kind" '$2 == k { c++ } END { print c + 0 }' "$RESULTS")
+  pct=$(awk -v n="$n" -v t="$TOTAL" 'BEGIN { print (t > 0) ? (n / t * 100) : 0 }')
+  printf '  %-28s %4d runs  (%.1f%%)\n' "$kind" "$n" "$pct"
+  [ "$n" -gt "$MAX_RUNS" ] && MAX_RUNS="$n"
+  [ "$n" -eq 0 ] && ZERO_COUNT=$((ZERO_COUNT + 1))
+done
+
+echo ""
+# Starvation signal: one worker alone takes at least twice its fair share
+# (fair share for 5 workers is 20% each, so >=40% for one worker). Which
+# specific worker dominates varies run to run — Node's same-tick setInterval
+# ordering isn't perfectly deterministic across process restarts — but this
+# severe a skew has reproduced on every run observed while developing this repro.
+DOMINANT_SHARE=$(awk -v m="$MAX_RUNS" -v t="$TOTAL" 'BEGIN { print (t > 0) ? (m / t) : 0 }')
+DOMINANT_PCT=$(awk -v s="$DOMINANT_SHARE" 'BEGIN { printf "%.1f", s * 100 }')
+if awk -v s="$DOMINANT_SHARE" 'BEGIN { exit !(s >= 0.4) }'; then
+  echo "[repro] STARVATION CONFIRMED: one worker alone got $MAX_RUNS of $TOTAL runs (${DOMINANT_PCT}%, fair share is 20%), and $ZERO_COUNT of 5 workers got ZERO runs in 20s."
+  echo "[repro] Root cause: every PR-maintenance worker shares one intervalMs with zero jitter"
+  echo "[repro] (packages/execution-engine/src/workers/pr-maintenance-workers.ts:20,266), and"
+  echo "[repro] setInterval (packages/execution-engine/src/worker-runtime.ts:246) fires same-tick"
+  echo "[repro] callbacks in registration order, so registerPrMaintenanceWorkers()'s fixed order"
+  echo "[repro] (pr-maintenance-workers.ts:111-119) systematically favors earlier-registered workers"
+  echo "[repro] for the shared cron lock (cron-pr-lib.sh / probePrMaintenanceLock)."
+  exit 1
+else
+  echo "[repro] No significant starvation observed this run (distribution looked roughly fair)."
+  exit 0
+fi


### PR DESCRIPTION
## Summary

The previous PR in this stack proved five background jobs share one timer with no stagger, so they wake up together and race for one lock. One job usually wins nearly every cycle; the others can go hours without a turn.

Each of the five now gets its own fixed start delay, spread evenly across the 5-minute window, so they stop waking up at the same instant.

## Review Claim

Approve adding a `startDelayMs` option to the shared worker runtime and giving each of the 5 PR-maintenance workers a distinct offset, fixing the starvation the previous slice proved.

## Review Lane

- behavior

## Review Unit

- routing

## Safety Invariant

`startDelayMs` defaults to 0, so every other worker runtime in the codebase (all of which omit this option) is byte-for-byte unaffected. None of the 5 workers' own repair logic, lock probing, or mutation dispatch changes — only when their first tick fires.

## Slice Rationale

Builds directly on the repro from the previous PR. The next PR in this stack updates that same repro script with the new offsets to prove this fix actually restores a fair distribution — kept separate since a proof-lane file can't ship in a behavior-lane PR.

## Non-goals

- Does not change what any of the 5 workers actually does when it runs.
- Does not remove the shared cron lock — still needed since the 5 workers still share it.
- Does not touch the larger categorize/route/submit-task redesign (separate, ongoing effort).
- Does not itself re-verify the fix with the repro script (next slice).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test` (same pre-existing unrelated failures as origin/master, confirmed via stash comparison; zero new failures)
- [x] `cd packages/execution-engine && pnpm build`
- [x] `cd packages/execution-engine && npx vitest run src/__tests__/worker-runtime-start-delay.test.ts` — new unit test covering `startDelayMs` deferral, immediate-tick default behavior, and clean cancellation on `stop()` before the delay elapses.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: none.
- Data migration? No.

</details>
