### PR TITLE
[Planning terminal adverse proof harness](2) Add deterministic adverse-loop runner

### DIFF
--- a/scripts/run-planning-terminal-adverse-loop.sh
+++ b/scripts/run-planning-terminal-adverse-loop.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Focused proof loop for planning-terminal adverse lifecycle repros.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+pnpm --filter @invoker/ui exec vitest run \
+  src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx \
+  src/__tests__/planning-terminal-session-id-persist-repro.test.tsx \
+  src/__tests__/planning-terminal-preset-switch-repro.test.tsx
+
+pnpm --filter @invoker/app exec vitest run \
+  src/__tests__/planning-terminal-restore-invariants.repro.test.ts


### PR DESCRIPTION
## Summary

Adds `scripts/run-planning-terminal-adverse-loop.sh`, one deterministic command that runs only the planning-terminal repro tests added in (1).

Without this script, exercising the full adverse matrix means copying four separate commands by hand, which drifts out of sync as tests are added or renamed.

The script changes no product code and no other test file.

## Review Claim

Approve adding one runner script that wraps the exact acceptance commands for the planning-terminal repro tests from (1), with no other changes.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The script only invokes existing `pnpm --filter ... exec vitest run` commands against the repro files added in (1). It adds no new product code path and cannot run outside CI or a developer's own shell.

## Slice Rationale

Keeps the tooling-policy runner script in its own PR, on top of (1), so the proof-lane test files and this policy-lane wrapper each carry one review unit.

## Non-goals

- No test file additions or changes in this PR - those are in (1).
- No product-code changes.
- No change to how CI selects or runs the broader test suite.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/run-planning-terminal-adverse-loop.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
