### PR TITLE
[Reorg packageless PR workers](1) admin-requeue package

### DIFF
--- a/packages/mergify-admin-requeue/mergify_admin_requeue/__init__.py
+++ b/packages/mergify-admin-requeue/mergify_admin_requeue/__init__.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from typing import Sequence
+
+from .gh_executor import AdminBypassGhExecutor
+from .loader import AdminBypassStackLoader
+from .logger import AdminBypassLogger
+from .model import Action, Blocker, CheckContext, Ledger, MergifyQueueEvent, PrSnapshot, ReviewThread, StackGroup, latest_contexts_by_required_check, load_mergify_rules
+from .plan import classify_pr, plan_stack_actions
+from .repairer import AdminBypassRepairer
+from .snapshot import group_stack_prs, parse_mergify_queue_event, parse_stack_metadata
+
+exec_impl = import_module(".exec", __name__)
+
+parse_args = exec_impl.parse_args
+run_once = exec_impl.run_once
+run_loop = exec_impl.run_loop
+REPO_ROOT = exec_impl.REPO_ROOT
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    return run_loop(args) if args.loop else run_once(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/mergify-admin-requeue/mergify_admin_requeue/__main__.py
+++ b/packages/mergify-admin-requeue/mergify_admin_requeue/__main__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from . import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/mergify-admin-requeue/mergify_admin_requeue/exec.py
+++ b/packages/mergify-admin-requeue/mergify_admin_requeue/exec.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+import time
+from typing import Sequence
+
+try:
+    from .gh_executor import AdminBypassGhExecutor
+    from .loader import AdminBypassStackLoader
+    from .logger import AdminBypassLogger
+    from .model import Action, Ledger, PrSnapshot, RepairOutcome, load_mergify_rules
+    from .plan import plan_stack_execution
+    from .repairer import AdminBypassRepairer
+    from .snapshot import GhClient
+except ImportError:
+    from gh_executor import AdminBypassGhExecutor
+    from loader import AdminBypassStackLoader
+    from logger import AdminBypassLogger
+    from model import Action, Ledger, PrSnapshot, RepairOutcome, load_mergify_rules
+    from plan import plan_stack_execution
+    from repairer import AdminBypassRepairer
+    from snapshot import GhClient
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def print_action(action: Action, pr: PrSnapshot | None, dry_run: bool, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(action.__dict__, sort_keys=True))
+        return
+    prefix = "DRY-RUN " if dry_run else ""
+    if action.kind == "requeue":
+        head = pr.head_ref_oid if pr else ""
+        print(f"{prefix}requeue PR #{action.pr_number} head={head} reason={action.detail}")
+    elif action.kind == "repair_check":
+        key = action.key.split(":", 1)[-1]
+        print(f"{prefix}repair-check PR #{action.pr_number} check={json.dumps(key)}")
+    elif action.kind == "comment_blocked":
+        print(f"BLOCK PR #{action.pr_number} {action.detail}")
+    elif action.kind == "comment_admin_bypass_nudge":
+        print(f"{prefix}comment-admin-bypass-nudge PR #{action.pr_number}")
+    elif action.kind == "restore_admin_bypass_label":
+        print(f"{prefix}restore-admin-bypass-label PR #{action.pr_number}")
+    elif action.kind == "retarget_base":
+        from_base = pr.base_ref_name if pr else ""
+        print(f"{prefix}retarget-base PR #{action.pr_number} from={from_base} to={action.key}")
+    elif action.kind == "remove_merge_hold":
+        print(f"{prefix}remove-merge-hold PR #{action.pr_number}")
+    elif action.kind == "resolve_bot_threads":
+        print(f"{prefix}resolve-bot-threads PR #{action.pr_number} thread={action.key}")
+    elif action.kind == "repair_conflict":
+        print(f"{prefix}repair-conflict PR #{action.pr_number} {action.detail}")
+
+
+def record_repair_outcome(
+    ledger: Ledger,
+    logger: AdminBypassLogger,
+    repo: str,
+    pr: PrSnapshot,
+    outcome: RepairOutcome,
+    now: int,
+) -> None:
+    if outcome.status == "queue_only_noop":
+        ledger.record("queue-only-noop", pr.number, pr.head_ref_oid, outcome.check_name, now)
+        logger.trace(
+            "admin-bypass-queue-only-noop",
+            repo=repo,
+            pr_number=pr.number,
+            check_name=outcome.check_name,
+            queue_pr_number=pr.latest_mergify.queue_pr_number if pr.latest_mergify else 0,
+        )
+    if outcome.status == "noop" and outcome.check_name == "PR Body":
+        ledger.record("repair-noop", pr.number, pr.head_ref_oid, outcome.check_name, now)
+        logger.trace(
+            "admin-bypass-repair-noop",
+            repo=repo,
+            pr_number=pr.number,
+            check_name=outcome.check_name,
+        )
+
+
+def handle_repair_outcome(
+    executor: AdminBypassGhExecutor,
+    ledger: Ledger,
+    logger: AdminBypassLogger,
+    repo: str,
+    pr: PrSnapshot,
+    outcome: RepairOutcome,
+    now: int,
+) -> None:
+
+    ledger.record("repair-evaluated", pr.number, pr.head_ref_oid, outcome.check_name, now)
+    if outcome.status == "blocked_dirty":
+        executor.comment_blocked(
+            pr,
+            "repair left uncommitted changes:\n" + "\n".join(outcome.status_lines),
+            f"repair-dirty:{outcome.check_name}:{outcome.start_head}",
+            now,
+        )
+        return
+    if outcome.status == "blocked_invalid":
+        ledger.record(
+            "repair-invalid",
+            pr.number,
+            pr.head_ref_oid,
+            outcome.check_name,
+            now,
+            meta={"errors": list(outcome.errors)},
+        )
+        executor.comment_blocked(
+            pr,
+            "\n".join(outcome.errors),
+            f"repair-invalid:{outcome.check_name}:{outcome.start_head}",
+            now,
+        )
+        return
+    record_repair_outcome(ledger, logger, repo, pr, outcome, now)
+
+
+def run_cycle(args: argparse.Namespace) -> bool:
+    rule_path = REPO_ROOT / ".mergify.yml"
+    try:
+        trunk, _labels, required_checks = load_mergify_rules(rule_path)
+    except ValueError as exc:
+        print("ERROR: failed to load admin-bypass Mergify rule", file=sys.stderr)
+        raise RuntimeError("failed to load admin-bypass Mergify rule") from exc
+
+    logger = AdminBypassLogger()
+    logger.trace(
+        "admin-bypass-scan-start",
+        repo=args.repo,
+        author=args.author,
+        pr_numbers=list(args.pr),
+        dry_run=args.dry_run,
+        json_output=args.json,
+    )
+    gh = GhClient()
+    ledger = Ledger(Path(args.state_file).expanduser())
+    loader = AdminBypassStackLoader(gh)
+    executor = AdminBypassGhExecutor(gh, ledger, logger, args.repo)
+    repairer = AdminBypassRepairer(gh, executor, logger, ledger, args.repo)
+    loaded = loader.load(args.repo, args.author, args.pr, required_checks, trunk)
+    stacks = loaded.stacks
+    now = int(time.time())
+    pr_by_number = {pr.number: pr for stack in stacks for pr in stack.prs}
+    logger.trace(
+        "admin-bypass-scan-loaded",
+        stack_count=len(stacks),
+        stack_ids=[stack.stack_id for stack in stacks],
+        candidate_pr_numbers=sorted(pr_by_number),
+    )
+    should_poll = False
+    open_pr_numbers = set(pr_by_number)
+    for stack in stacks:
+        plan = plan_stack_execution(
+            stack,
+            required_checks,
+            ledger,
+            now,
+            open_pr_numbers,
+            loaded.open_pr_numbers_by_head,
+            args.max_requeue_attempts,
+            args.max_repair_attempts,
+            trunk,
+        )
+        queue_only_noop_check = plan.queue_only_noop_check
+        logger.stack("admin-bypass-stack", plan.summary)
+        if not plan.actions:
+            should_poll = True
+            if plan.wait_reason == "repair-prereq-open" and plan.prereq_status:
+                logger.trace(
+                    "admin-bypass-repair-prereq-wait",
+                    repo=args.repo,
+                    pr_number=plan.summary.get("bottom_pr"),
+                    check_name=plan.prereq_status.check_name,
+                    prereq_pr_number=plan.prereq_status.prereq_pr_number,
+                )
+            logger.trace("admin-bypass-stack-wait", reason=plan.wait_reason, summary=plan.summary)
+            continue
+        logger.trace("admin-bypass-stack-actions", stack_id=stack.stack_id, actions=logger.stack_action_payload(plan.actions))
+        for action in plan.actions:
+            pr = pr_by_number.get(action.pr_number)
+            print_action(action, pr, args.dry_run, args.json)
+            if args.dry_run:
+                continue
+            if pr is None:
+                raise RuntimeError(f"missing PR snapshot for #{action.pr_number}")
+            if action.kind == "repair_check":
+                check_name = action.key.split(":", 1)[-1]
+                kind = "repair-bot-thread" if action.key.startswith("bot_review_thread:") else "repair-check"
+                ledger.record(kind, action.pr_number, pr.head_ref_oid, check_name, now)
+                outcome = repairer.repair_check(pr, check_name, now)
+                handle_repair_outcome(executor, ledger, logger, args.repo, pr, outcome, now)
+            elif action.kind == "repair_conflict":
+                ledger.record("conflict-repair", action.pr_number, pr.head_ref_oid, action.key, now)
+                repairer.repair_conflict(pr, action.detail)
+            else:
+                executor.execute(action, pr, now)
+                if action.kind == "requeue":
+                    if (
+                        plan.prereq_status
+                        and plan.prereq_status.needs_followup_requeue
+                        and action.pr_number == plan.summary.get("bottom_pr")
+                    ):
+                        ledger.record("repair-prereq-requeue", pr.number, pr.head_ref_oid, plan.prereq_status.check_name, now)
+                        logger.trace(
+                            "admin-bypass-repair-prereq-requeue",
+                            repo=args.repo,
+                            pr_number=pr.number,
+                            check_name=plan.prereq_status.check_name,
+                        )
+                    if queue_only_noop_check and action.pr_number == plan.summary.get("bottom_pr"):
+                        ledger.record("queue-only-requeue", pr.number, pr.head_ref_oid, queue_only_noop_check, now)
+                        logger.trace(
+                            "admin-bypass-queue-only-requeue",
+                            repo=args.repo,
+                            pr_number=pr.number,
+                            check_name=queue_only_noop_check,
+                        )
+            if action.kind not in {"comment_blocked", "comment_admin_bypass_nudge"}:
+                return True
+    if not stacks:
+        logger.trace("admin-bypass-scan-empty")
+    return should_poll
+
+
+def run_once(args: argparse.Namespace) -> int:
+    try:
+        run_cycle(args)
+    except RuntimeError:
+        return 2
+    return 0
+
+
+def run_loop(args: argparse.Namespace) -> int:
+    try:
+        while run_cycle(args):
+            time.sleep(args.poll_seconds)
+    except RuntimeError:
+        return 2
+    return 0
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Repair and queue open admin-bypass Mergify stacks.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--once", action="store_true", help="Run one scan/action cycle and exit. Cron uses this.")
+    mode.add_argument("--loop", action="store_true", help="Poll until no actionable stack remains.")
+    parser.add_argument("--poll-seconds", type=float, default=60, help="Seconds to wait between loop scans. Default: 60.")
+    parser.add_argument("--dry-run", action="store_true", help="Print planned actions; perform no GitHub mutations.")
+    parser.add_argument("--repo", default="Neko-Catpital-Labs/Invoker", help="Default: Neko-Catpital-Labs/Invoker.")
+    parser.add_argument("--author", help="Limit scan to one author. Default: all authors.")
+    parser.add_argument("--state-file", default=str(Path.home() / ".invoker" / "mergify-admin-requeue-state.jsonl"), help="Ledger JSONL path.")
+    parser.add_argument("--pr", type=int, action="append", default=[], help="Limit to a PR; repeatable.")
+    parser.add_argument("--max-requeue-attempts", type=int, default=2, help="Default: 2 per PR/head/dequeue event.")
+    parser.add_argument("--max-repair-attempts", type=int, default=3, help="Default: 3 per PR/head/blocker.")
+    parser.add_argument("--json", action="store_true", help="Emit one JSON object per decision/action.")
+    return parser.parse_args(argv)

--- a/packages/mergify-admin-requeue/mergify_admin_requeue/gh_executor.py
+++ b/packages/mergify-admin-requeue/mergify_admin_requeue/gh_executor.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+try:
+    from .logger import AdminBypassLogger
+    from .model import Action, GH_ACTIONS_JOB_RE, Ledger, PrSnapshot
+    from .snapshot import GhClient
+except ImportError:
+    from logger import AdminBypassLogger
+    from model import Action, GH_ACTIONS_JOB_RE, Ledger, PrSnapshot
+    from snapshot import GhClient
+
+
+ADMIN_BYPASS_NUDGE_LEDGER_KIND = "comment-admin-bypass-nudge"
+RESTORE_ADMIN_BYPASS_LABEL_LEDGER_KIND = "restore-admin-bypass-label"
+
+
+def admin_bypass_nudge_body() -> str:
+    return (
+        "Invoker Mergify babysitting is paused: this is the current bottom PR in the stack, "
+        "but it is missing the `admin-bypass` label. Please tag this PR with `admin-bypass` "
+        "before babysitting can continue."
+    )
+
+
+class AdminBypassGhExecutor:
+    def __init__(self, gh: GhClient, ledger: Ledger, logger: AdminBypassLogger, repo: str):
+        self.gh = gh
+        self.ledger = ledger
+        self.logger = logger
+        self.repo = repo
+
+    def download_job_log(self, repo: str, details_url: str, pr_number: int, check_name: str) -> str:
+        match = GH_ACTIONS_JOB_RE.search(details_url)
+        if not match:
+            return ""
+        tmp = Path(tempfile.mkdtemp(prefix=f"mergify-admin-requeue-{pr_number}-"))
+        path = tmp / (re.sub(r"[^A-Za-z0-9_.-]+", "-", check_name).strip("-") + ".log")
+        out = subprocess.run(
+            ["gh", "run", "view", "--repo", repo, "--job", match.group(1), "--log"],
+            check=True,
+            text=True,
+            capture_output=True,
+        ).stdout
+        path.write_text(out, encoding="utf-8")
+        return str(path)
+
+    def requeue(self, pr: PrSnapshot, key: str, now: int) -> None:
+        self.gh.comment(self.repo, pr.number, "@mergifyio queue")
+        self.ledger.record("requeue", pr.number, pr.head_ref_oid, key, now)
+
+    def restore_admin_bypass_label(self, pr: PrSnapshot, now: int) -> None:
+        if self.ledger.count(RESTORE_ADMIN_BYPASS_LABEL_LEDGER_KIND, pr.number, pr.head_ref_oid, "admin-bypass") == 0:
+            self.gh.edit_label(self.repo, pr.number, add="admin-bypass")
+            self.ledger.record(RESTORE_ADMIN_BYPASS_LABEL_LEDGER_KIND, pr.number, pr.head_ref_oid, "admin-bypass", now)
+
+    def retarget_base(self, pr: PrSnapshot, new_base: str, now: int) -> None:
+        self.gh.retarget_base(self.repo, pr.number, new_base)
+        self.ledger.record("retarget-base", pr.number, pr.head_ref_oid, f"{pr.base_ref_name}->{new_base}", now)
+
+    def comment_admin_bypass_nudge(self, pr: PrSnapshot, key: str, now: int) -> None:
+        if self.ledger.count(ADMIN_BYPASS_NUDGE_LEDGER_KIND, pr.number, pr.head_ref_oid, key) == 0:
+            self.gh.comment(self.repo, pr.number, admin_bypass_nudge_body())
+            self.ledger.record(ADMIN_BYPASS_NUDGE_LEDGER_KIND, pr.number, pr.head_ref_oid, key, now)
+
+    def remove_merge_hold(self, pr: PrSnapshot, now: int) -> None:
+        self.gh.edit_label(self.repo, pr.number, remove="merge-hold")
+        self.ledger.record("remove-merge-hold", pr.number, pr.head_ref_oid, "merge-hold", now)
+
+    def resolve_bot_threads(self, thread_id: str) -> None:
+        self.gh.resolve_review_thread(thread_id)
+
+    def has_blocked_comment(self, pr: PrSnapshot | int, body_or_detail: str) -> bool:
+        if not hasattr(self.gh, "issue_comments"):
+            return False
+        if isinstance(pr, PrSnapshot):
+            pr_number = pr.number
+            body = body_or_detail.strip()
+        else:
+            pr_number = pr
+            body = f"Mergify repair stopped: {body_or_detail}".strip()
+        for comment in self.gh.issue_comments(self.repo, pr_number):
+            if str(comment.get("body") or "").strip() == body:
+                return True
+        return False
+
+    def comment_blocked(self, pr: PrSnapshot, detail: str, key: str, now: int) -> None:
+        if self.ledger.count("comment-blocked", pr.number, pr.head_ref_oid, key) == 0:
+            body = f"Mergify repair stopped: {detail}"
+            if not self.has_blocked_comment(pr, body):
+                self.gh.comment(self.repo, pr.number, body)
+            self.ledger.record("comment-blocked", pr.number, pr.head_ref_oid, key, now)
+            return
+        if (
+            key == "no-current-bottom"
+            and detail != "no current bottom on master"
+            and not self.has_blocked_comment(pr.number, detail)
+        ):
+            self.gh.comment(self.repo, pr.number, f"Mergify repair stopped: {detail}")
+            self.ledger.record("comment-blocked", pr.number, pr.head_ref_oid, "no-current-bottom:exact", now)
+
+    def execute(self, action: Action, pr: PrSnapshot, now: int) -> None:
+        self.logger.trace("admin-bypass-action-execute", action=self.logger.action_payload(action))
+        if action.kind == "requeue":
+            self.requeue(pr, action.key, now)
+            return
+        if action.kind == "restore_admin_bypass_label":
+            self.restore_admin_bypass_label(pr, now)
+            return
+        if action.kind == "retarget_base":
+            self.retarget_base(pr, action.key, now)
+            return
+        if action.kind == "comment_admin_bypass_nudge":
+            self.comment_admin_bypass_nudge(pr, action.key, now)
+            return
+        if action.kind == "remove_merge_hold":
+            self.remove_merge_hold(pr, now)
+            return
+        if action.kind == "resolve_bot_threads":
+            self.resolve_bot_threads(action.key)
+            return
+        if action.kind == "comment_blocked":
+            key = f"capped:{action.detail}" if action.key == "capped" else action.key
+            self.comment_blocked(pr, action.detail, key, now)
+            return
+        raise ValueError(f"unsupported executor action: {action.kind}")

--- a/packages/mergify-admin-requeue/mergify_admin_requeue/loader.py
+++ b/packages/mergify-admin-requeue/mergify_admin_requeue/loader.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+try:
+    from .model import LoadedStacks, StackGroup
+    from .snapshot import GhClient, group_stack_prs, parse_stack_metadata, snapshot_from_detail
+except ImportError:
+    from model import LoadedStacks, StackGroup
+    from snapshot import GhClient, group_stack_prs, parse_stack_metadata, snapshot_from_detail
+
+
+class AdminBypassStackLoader:
+    def __init__(self, gh: GhClient):
+        self.gh = gh
+
+    def load(
+        self,
+        repo: str,
+        author: str | None,
+        pr_numbers: Sequence[int],
+        required_checks: Sequence[str],
+        trunk: str,
+    ) -> LoadedStacks:
+        candidates = self.gh.list_candidate_prs(repo, author, pr_numbers)
+        candidate_numbers = {int(pr.get("number") or 0) for pr in candidates}
+        if not candidate_numbers:
+            return LoadedStacks(stacks=(), open_pr_numbers_by_head={})
+
+        raw_by_number = {
+            int(pr.get("number") or 0): pr
+            for pr in self.gh.list_open_prs(repo)
+        }
+        raw_by_number.update({int(pr.get("number") or 0): pr for pr in candidates})
+        open_pr_numbers_by_head: dict[str, list[int]] = {}
+        for raw in raw_by_number.values():
+            if str(raw.get("state") or "").upper() != "OPEN":
+                continue
+            head_ref_name = str(raw.get("headRefName") or "")
+            number = int(raw.get("number") or 0)
+            if head_ref_name and number:
+                open_pr_numbers_by_head.setdefault(head_ref_name, []).append(number)
+
+
+        comments_cache: dict[int, list[dict]] = {}
+
+        def comments_for(number: int) -> list[dict]:
+            if number not in comments_cache:
+                comments_cache[number] = self.gh.issue_comments(repo, number)
+            return comments_cache[number]
+
+        lite_snapshots = [snapshot_from_detail(raw, [], required_checks) for raw in raw_by_number.values()]
+        lite_metadata: dict[int, tuple[str, tuple[int, ...]]] = {}
+        for number in candidate_numbers:
+            meta = parse_stack_metadata(comments_for(number))
+            if not meta:
+                continue
+            for pr_number in meta[1]:
+                lite_metadata[pr_number] = meta
+            lite_metadata[number] = meta
+
+        relevant_numbers: set[int] = set()
+        for stack in group_stack_prs(lite_snapshots, lite_metadata, trunk):
+            if any(pr.number in candidate_numbers for pr in stack.prs):
+                relevant_numbers.update(pr.number for pr in stack.prs)
+
+        details: list[tuple[Mapping[str, object], list[dict]]] = []
+        for number in sorted(relevant_numbers):
+            raw = raw_by_number.get(number)
+            detail = raw if raw is not None and "reviewThreads" in raw else self.gh.pr_detail(repo, number)
+            details.append((detail, comments_for(number)))
+
+        snapshots = [snapshot_from_detail(detail, comments, required_checks) for detail, comments in details]
+        metadata: dict[int, tuple[str, tuple[int, ...]]] = {}
+        for detail, comments in details:
+            number = int(detail.get("number") or 0)
+            meta = parse_stack_metadata(comments)
+            if not meta:
+                continue
+            for pr_number in meta[1]:
+                metadata[pr_number] = meta
+            metadata[number] = meta
+
+        return LoadedStacks(
+            stacks=tuple(
+                stack
+                for stack in group_stack_prs(snapshots, metadata, trunk)
+                if any(pr.number in candidate_numbers for pr in stack.prs)
+            ),
+            open_pr_numbers_by_head={
+                head_ref_name: tuple(sorted(numbers))
+                for head_ref_name, numbers in open_pr_numbers_by_head.items()
+            },
+        )

--- a/packages/mergify-admin-requeue/mergify_admin_requeue/logger.py
+++ b/packages/mergify-admin-requeue/mergify_admin_requeue/logger.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+import sys
+from typing import Mapping, Sequence
+
+try:
+    from .model import Action
+except ImportError:
+    from model import Action
+
+
+class AdminBypassLogger:
+    def trace(self, event: str, **fields: object) -> None:
+        payload = {"event": event, **fields}
+        print(f"TRACE {json.dumps(payload, sort_keys=True)}", file=sys.stderr)
+
+    def action_payload(self, action: Action) -> dict[str, object]:
+        return {
+            "kind": action.kind,
+            "pr_number": action.pr_number,
+            "key": action.key,
+            "detail": action.detail,
+        }
+
+    def stack_action_payload(self, actions: Sequence[Action]) -> list[dict[str, object]]:
+        return [self.action_payload(action) for action in actions]
+
+    def stack(self, event: str, summary: Mapping[str, object], **fields: object) -> None:
+        self.trace(event, **fields, summary=summary)

--- a/packages/mergify-admin-requeue/mergify_admin_requeue/model.py
+++ b/packages/mergify-admin-requeue/mergify_admin_requeue/model.py
@@ -1,0 +1,479 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import time
+from typing import Collection, Mapping
+
+
+SELF_CHECK_NAMES = {"Mergify Merge Queue", "Summary"}
+BOT_OR_SELF_AUTHORS = {"coderabbitai", "coderabbitai[bot]", "EdbertChan"}
+STACK_MARKER_RE = re.compile(r"<!--\s*mergify-stack-data:\s*(\{.*?\})\s*-->", re.DOTALL)
+SHA_RE = re.compile(r"`([0-9a-fA-F]{40})`")
+GH_ACTIONS_JOB_RE = re.compile(r"/actions/runs/\d+/job/(\d+)")
+
+
+@dataclass(frozen=True)
+class CheckContext:
+    name: str
+    state: str
+    details_url: str
+    head_sha: str
+    completed_at: str
+
+
+@dataclass(frozen=True)
+class ReviewThread:
+    id: str
+    is_resolved: bool
+    author_logins: tuple[str, ...]
+    is_outdated: bool = False
+
+
+@dataclass(frozen=True)
+class MergifyQueueEvent:
+    comment_id: str
+    state: str
+    queue_rule_name: str
+    queued_at: str
+    head_sha: str
+    waiting_for: tuple[str, ...]
+    failing_checks: tuple[str, ...]
+    comment_url: str
+    queue_pr_number: int = 0
+    failing_check_urls: tuple[tuple[str, tuple[str, ...]], ...] = ()
+    condition_states: tuple[tuple[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class RepairStopComment:
+    body: str
+    updated_at: str
+    author_login: str
+
+
+@dataclass(frozen=True)
+class PrSnapshot:
+    number: int
+    title: str
+    body: str
+    url: str
+    state: str
+    is_draft: bool
+    base_ref_name: str
+    head_ref_name: str
+    head_ref_oid: str
+    merge_state_status: str
+    mergeable: str
+    labels: frozenset[str]
+    checks: Mapping[str, CheckContext]
+    review_threads: tuple[ReviewThread, ...]
+    latest_mergify: MergifyQueueEvent | None
+    repair_stop_comments: tuple[RepairStopComment, ...] = ()
+
+@dataclass(frozen=True)
+class StackGroup:
+    stack_id: str
+    prs: tuple[PrSnapshot, ...]
+
+@dataclass(frozen=True)
+class LoadedStacks:
+    stacks: tuple[StackGroup, ...]
+    open_pr_numbers_by_head: Mapping[str, tuple[int, ...]]
+
+
+
+
+@dataclass(frozen=True)
+class Blocker:
+    key: str
+    kind: str
+    pr_number: int
+    detail: str
+
+
+@dataclass(frozen=True)
+class Action:
+    kind: str
+    pr_number: int
+    key: str
+    detail: str
+
+@dataclass(frozen=True)
+class RepairPrereqStatus:
+    check_name: str
+    prereq_pr_number: int
+    prereq_branch: str
+    is_open: bool
+    needs_followup_requeue: bool
+
+@dataclass(frozen=True)
+class RepairOutcome:
+    status: str
+    check_name: str
+    start_head: str
+    end_head: str
+    repair_commits: tuple[str, ...] = ()
+    status_lines: tuple[str, ...] = ()
+    errors: tuple[str, ...] = ()
+    prereq: Mapping[str, object] | None = None
+
+
+
+
+@dataclass(frozen=True)
+class StackExecutionPlan:
+    summary: Mapping[str, object]
+    actions: tuple[Action, ...]
+    wait_reason: str | None = None
+    prereq_status: RepairPrereqStatus | None = None
+    queue_only_noop_check: str | None = None
+
+class Ledger:
+    def __init__(self, path: Path):
+        self.path = path
+        self.rows: list[dict[str, object]] = []
+        if path.exists():
+            for line in path.read_text(encoding="utf-8").splitlines():
+                if not line.strip():
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict):
+                    self.rows.append(row)
+
+    def count(self, kind: str, pr: int, head_sha: str, key: str) -> int:
+        return sum(
+            1 for row in self.rows
+            if row.get("kind") == kind
+            and int(row.get("pr", -1)) == pr
+            and row.get("headSha") == head_sha
+            and row.get("key") == key
+        )
+
+    def latest(self, kind: str, pr: int, head_sha: str, key: str) -> dict[str, object] | None:
+        latest_row: dict[str, object] | None = None
+        latest_epoch = float("-inf")
+        for row in self.rows:
+            if row.get("kind") != kind:
+                continue
+            if int(row.get("pr", -1)) != pr:
+                continue
+            if row.get("headSha") != head_sha:
+                continue
+            if row.get("key") != key:
+                continue
+            epoch = int(row.get("epoch", 0) or 0)
+            if latest_row is None or epoch >= latest_epoch:
+                latest_row = row
+                latest_epoch = epoch
+        return latest_row
+
+    def has_different_head(self, kind: str, pr: int, current_head: str, key: str) -> bool:
+        for row in self.rows:
+            if row.get("kind") != kind:
+                continue
+            if int(row.get("pr", -1)) != pr:
+                continue
+            if row.get("key") != key:
+                continue
+            if row.get("headSha") and row.get("headSha") != current_head:
+                return True
+        return False
+
+    def record(self, kind: str, pr: int, head_sha: str, key: str, epoch: int | None = None, meta: Mapping[str, object] | None = None) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        row = {
+            "kind": kind,
+            "pr": pr,
+            "headSha": head_sha,
+            "key": key,
+            "epoch": epoch if epoch is not None else int(time.time()),
+        }
+        if meta:
+            row["meta"] = dict(meta)
+        with self.path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(row, sort_keys=True) + "\n")
+        self.rows.append(row)
+
+
+MERGE_CONDITIONS_HEADER_RE = re.compile(r"^(?P<indent>\s*)merge_conditions:(?:\s*&(?P<anchor>[\w-]+))?\s*$")
+MERGE_CONDITIONS_ALIAS_RE = re.compile(r"^(?P<indent>\s*)merge_conditions:\s*\*(?P<alias>[\w-]+)\s*$")
+
+
+def _collect_required_checks(lines: list[str], start: int, parent_indent: int) -> set[str]:
+    required: set[str] = set()
+    for raw in lines[start + 1:]:
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip())
+        if indent <= parent_indent:
+            break
+        if stripped.startswith("- check-success = "):
+            required.add(stripped.split("=", 1)[1].strip())
+    return required
+
+
+def _resolve_required_check_alias(lines: list[str], anchor_name: str) -> set[str]:
+    for i, raw in enumerate(lines):
+        match = MERGE_CONDITIONS_HEADER_RE.match(raw)
+        if not match or match.group("anchor") != anchor_name:
+            continue
+        return _collect_required_checks(lines, i, len(match.group("indent")))
+    return set()
+
+
+def load_mergify_rules(path: Path) -> tuple[str, frozenset[str], frozenset[str]]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        raise ValueError("failed to load admin-bypass Mergify rule")
+
+    start = -1
+    start_indent = 0
+    for i, line in enumerate(lines):
+        match = re.match(r"^(\s*)-\s+name:\s*admin-bypass\s*$", line)
+        if match:
+            start = i
+            start_indent = len(match.group(1))
+            break
+    if start < 0:
+        raise ValueError("failed to load admin-bypass Mergify rule")
+
+    block: list[str] = []
+    for line in lines[start + 1:]:
+        match = re.match(r"^(\s*)-\s+name:\s+", line)
+        if match and len(match.group(1)) <= start_indent:
+            break
+        block.append(line)
+
+    trunk = ""
+    labels: set[str] = set()
+    required: set[str] = set()
+    for i, raw in enumerate(block):
+        stripped = raw.strip()
+        alias_match = MERGE_CONDITIONS_ALIAS_RE.match(raw)
+        if alias_match:
+            required.update(_resolve_required_check_alias(lines, alias_match.group("alias")))
+            continue
+        header_match = MERGE_CONDITIONS_HEADER_RE.match(raw)
+        if header_match:
+            required.update(_collect_required_checks(block, i, len(header_match.group("indent"))))
+            continue
+        if stripped.startswith("- base="):
+            trunk = stripped.split("=", 1)[1].strip()
+        elif stripped.startswith("- label="):
+            labels.add(stripped.split("=", 1)[1].strip())
+
+    if not trunk or not labels or not required:
+        raise ValueError("failed to load admin-bypass Mergify rule")
+    return trunk, frozenset(labels), frozenset(required)
+
+
+def latest_contexts_by_required_check(raw_contexts: list[Mapping[str, object]], head_sha: str, required_checks: Collection[str]) -> dict[str, CheckContext]:
+    required = set(required_checks)
+    latest: dict[str, CheckContext] = {}
+    for node in raw_contexts:
+        name, state, url, sha, completed = norm_check_state(node)
+        if not name or name in SELF_CHECK_NAMES or name.startswith("Rule: "):
+            continue
+        if sha and sha != head_sha:
+            continue
+        if name not in required:
+            continue
+        ctx = CheckContext(name=name, state=state, details_url=url, head_sha=sha or head_sha, completed_at=completed)
+        old = latest.get(name)
+        if old is None or (old.completed_at, old.state) <= (ctx.completed_at, ctx.state):
+            latest[name] = ctx
+    return latest
+
+
+def extract_first_json_object(text: str) -> Mapping[str, object] | None:
+    start = text.find("{")
+    if start < 0:
+        return None
+    depth = 0
+    in_str = False
+    esc = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    value = json.loads(text[start:i + 1])
+                except json.JSONDecodeError:
+                    return None
+                return value if isinstance(value, Mapping) else None
+    return None
+
+
+def payload_state(payload: Mapping[str, object], body: str) -> str:
+    for key in ("state", "queue_state", "event", "action"):
+        value = str(payload.get(key) or "").lower()
+        if "dequeue" in value or value == "left":
+            return "dequeued"
+        if "queue" in value:
+            return "queued"
+    low = body.lower()
+    if "left the queue" in low or "dequeued" in low:
+        return "dequeued"
+    if "queued" in low or "entered the queue" in low:
+        return "queued"
+    return "unknown"
+
+
+def payload_rule(payload: Mapping[str, object], body: str) -> str:
+    candidates = ["queue_rule_name", "queue_rule", "rule", "queue"]
+    for key in candidates:
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+        if isinstance(value, Mapping):
+            nested = value.get("name")
+            if nested:
+                return str(nested)
+    match = re.search(r"queue rule [`']?([^`'\n]+)[`']?", body, re.I)
+    return match.group(1).strip() if match else ""
+
+
+def clean_markdown(text: str) -> str:
+    clean = re.sub(r"<[^>]+>", "", text)
+    clean = re.sub(r"[*_]", "", clean)
+    return clean.strip()
+
+
+def section_lines(body: str, heading: str) -> tuple[str, ...]:
+    lines = body.splitlines()
+    out: list[str] = []
+    in_section = False
+    known_headings = {"waiting for", "failing checks", "all conditions", "reason", "hint", "merge queue status"}
+    for line in lines:
+        clean = clean_markdown(line)
+        heading_text = re.sub(r"^#+\s*", "", clean).strip("` :")
+        heading_lower = heading_text.lower()
+        if heading_lower == heading.lower():
+            in_section = True
+            continue
+        if in_section and (clean.startswith("#") or (heading_lower in known_headings and heading_lower != heading.lower())):
+            break
+        if in_section and clean:
+            out.append(clean)
+    return tuple(out)
+
+
+def normalize_check_item(item: str) -> str:
+    link = re.search(r"\[([^\]]+)\]\([^)]+\)", item)
+    if link:
+        item = link.group(1)
+    item = re.sub(r"^[-*]\s*", "", item)
+    item = re.sub(r"^\[[ xX]\]\s*", "", item)
+    item = re.sub(r"^[^\w`]+", "", item)
+    item = item.strip("` ")
+    if item.startswith("check-success = "):
+        item = item.split(" = ", 1)[1].strip()
+    return item
+
+
+def section_items(body: str, heading: str) -> tuple[str, ...]:
+    out: list[str] = []
+    for line in section_lines(body, heading):
+        item = normalize_check_item(line)
+        if item:
+            out.append(item)
+    return tuple(out)
+
+
+def all_condition_states(body: str) -> tuple[tuple[str, str], ...]:
+    out: list[tuple[str, str]] = []
+    for line in section_lines(body, "All conditions"):
+        if "check-success = " not in line:
+            continue
+        state = "success" if re.search(r"\[[xX]\]", line) else "failure"
+        item = normalize_check_item(line)
+        if item:
+            out.append((item, state))
+    return tuple(out)
+
+
+def failing_check_urls(body: str) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    pairs: list[tuple[str, tuple[str, ...]]] = []
+    for line in section_lines(body, "Failing checks"):
+        name = normalize_check_item(line)
+        urls = tuple(re.findall(r"https://github\.com/[^)\s]+/actions/runs/\d+/job/\d+", line))
+        if name:
+            pairs.append((name, urls))
+    return tuple(pairs)
+
+
+def reason_failed_checks(body: str) -> tuple[str, ...]:
+    reason = section_lines(body, "Reason")
+    if not reason or not any("failing checks" in line.lower() for line in reason):
+        return ()
+    out: list[str] = []
+    for line in reason:
+        if not line.startswith("-"):
+            continue
+        item = normalize_check_item(line)
+        if item:
+            out.append(item)
+    return tuple(out)
+
+
+def norm_check_state(node: Mapping[str, object]) -> tuple[str, str, str, str, str]:
+    typename = str(node.get("__typename") or "")
+    if typename == "StatusContext" or "context" in node:
+        name = str(node.get("context") or "")
+        raw = str(node.get("state") or "").lower()
+        state = {
+            "success": "success",
+            "failure": "failure",
+            "error": "failure",
+            "pending": "pending",
+            "expected": "pending",
+        }.get(raw, "unknown")
+        url = str(node.get("targetUrl") or "")
+        commit = node.get("commit") if isinstance(node.get("commit"), Mapping) else {}
+        sha = str(commit.get("oid") or "")
+        return name, state, url, sha, ""
+
+    name = str(node.get("name") or "")
+    conclusion = str(node.get("conclusion") or "").upper()
+    status = str(node.get("status") or "").upper()
+    if conclusion in {"SUCCESS"}:
+        state = "success"
+    elif conclusion in {"FAILURE", "ACTION_REQUIRED", "TIMED_OUT", "CANCELLED", "STARTUP_FAILURE"}:
+        state = "failure"
+    elif conclusion == "SKIPPED":
+        state = "skipped"
+    elif conclusion == "NEUTRAL":
+        state = "neutral"
+    elif status and status != "COMPLETED":
+        state = "pending"
+    elif conclusion:
+        state = "unknown"
+    else:
+        state = "pending" if status else "unknown"
+    url = str(node.get("detailsUrl") or "")
+    suite = node.get("checkSuite") if isinstance(node.get("checkSuite"), Mapping) else {}
+    commit = suite.get("commit") if isinstance(suite.get("commit"), Mapping) else {}
+    sha = str(commit.get("oid") or "")
+    completed = str(node.get("completedAt") or node.get("startedAt") or "")
+    return name, state, url, sha, completed

--- a/packages/mergify-admin-requeue/mergify_admin_requeue/plan.py
+++ b/packages/mergify-admin-requeue/mergify_admin_requeue/plan.py
@@ -1,0 +1,748 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Collection, Literal, Mapping
+
+try:
+    from .model import (
+        Action,
+        BOT_OR_SELF_AUTHORS,
+        Blocker,
+        Ledger,
+        MergifyQueueEvent,
+        PrSnapshot,
+        RepairPrereqStatus,
+        StackExecutionPlan,
+        StackGroup,
+    )
+except ImportError:
+    from model import (
+        Action,
+        BOT_OR_SELF_AUTHORS,
+        Blocker,
+        Ledger,
+        MergifyQueueEvent,
+        PrSnapshot,
+        RepairPrereqStatus,
+        StackExecutionPlan,
+        StackGroup,
+    )
+
+
+TRUNK = "master"
+
+QUEUE_ONLY_REQUIRED_CHECKS = frozenset({
+    "required-fast / Guardrails",
+    "required-fast / Vitest Workspace",
+    "required-fast / Submit Workflow Chain",
+})
+ACTIVE_QUEUE_STATES = frozenset({"queued", "merging"})
+
+HUMAN_BLOCKER_KINDS = frozenset({"draft", "human_review_thread", "missing_check", "closed", "human_decision"})
+REPAIR_STOP_PREFIX = "Mergify repair stopped: "
+MANUAL_SPLIT_STOP_MARKERS = (
+    "human stack split required",
+    "Split this into one Review Unit per PR.",
+    "cannot auto-split",
+    "cannot ship with tooling-policy, proof files",
+    "cannot ship with policy, proof files",
+    "cannot ship with proof files",
+)
+
+
+@dataclass(frozen=True)
+class BottomTopology:
+    kind: Literal["current_bottom", "external_open_base", "stale_unowned_base"]
+    root: PrSnapshot
+    bottom: PrSnapshot | None
+    external_open_base_pr_numbers: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class StackFacts:
+    stack: StackGroup
+    required_checks: frozenset[str]
+    trunk: str
+    bottom_topology: BottomTopology
+    bottom: PrSnapshot | None
+    upper_stack_needs_acceptance: bool
+    prereq_status: RepairPrereqStatus | None
+    queue_only_noop_check: str | None
+    suppressed_failed_checks_by_pr: Mapping[int, tuple[str, ...]]
+    blockers_by_pr: Mapping[int, tuple[Blocker, ...]]
+    all_blockers: tuple[Blocker, ...]
+
+
+def is_queue_only_required_check(name: str) -> bool:
+    # .github/workflows/ci.yml:306-328 gates these required-fast matrix jobs to
+    # merge-queue heads, so they do not exist on ordinary PR heads.
+    return name in QUEUE_ONLY_REQUIRED_CHECKS
+
+
+def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) -> tuple[Blocker, ...]:
+    blockers: list[Blocker] = []
+    if pr.state != "OPEN":
+        blockers.append(Blocker("closed", "closed", pr.number, f"state={pr.state}"))
+        return tuple(blockers)
+    if pr.is_draft:
+        blockers.append(Blocker("draft", "draft", pr.number, "PR is draft"))
+        return tuple(blockers)
+    if "merge-hold" in pr.labels:
+        blockers.append(Blocker("merge-hold", "merge_hold", pr.number, "merge-hold label present"))
+
+    for thread in pr.review_threads:
+        if thread.is_resolved:
+            continue
+        authors = set(thread.author_logins)
+        if not authors or authors - BOT_OR_SELF_AUTHORS:
+            blockers.append(Blocker(thread.id, "human_review_thread", pr.number, f"unresolved human review thread {thread.id}"))
+        elif thread.is_outdated:
+            blockers.append(Blocker(thread.id, "outdated_bot_review_thread", pr.number, f"unresolved outdated bot review thread {thread.id}"))
+        else:
+            blockers.append(Blocker(thread.id, "bot_review_thread", pr.number, f"unresolved bot review thread {thread.id}"))
+
+    if pr.merge_state_status == "DIRTY" or pr.mergeable == "CONFLICTING":
+        blockers.append(Blocker("conflict", "conflict", pr.number, "GitHub reports merge conflict"))
+
+    for name in sorted(required_checks):
+        ctx = pr.checks.get(name)
+        if ctx is None:
+            if pr.base_ref_name == trunk and not is_queue_only_required_check(name):
+                blockers.append(Blocker(name, "missing_check", pr.number, f"missing required check {name}"))
+            continue
+        if ctx.state == "success":
+            continue
+        if ctx.state == "failure":
+            blockers.append(Blocker(name, "failed_check", pr.number, f"required check failed: {name}"))
+        elif ctx.state in {"pending", "unknown"}:
+            blockers.append(Blocker(name, "pending_check", pr.number, f"required check not green: {name}={ctx.state}"))
+    return tuple(blockers)
+
+
+def public_blocker_kind(kind: str) -> str:
+    return kind.replace("_", "-")
+
+
+def cap_action(pr: PrSnapshot, blocker: Blocker, detail: str) -> Action:
+    return Action("comment_blocked", pr.number, "capped", f"{detail}. The retry cap was reached for current head {pr.head_ref_oid}.")
+
+
+def mergify_condition_map(event: MergifyQueueEvent | None) -> dict[str, str]:
+    return dict(event.condition_states) if event else {}
+
+
+def effective_blockers(
+    pr: PrSnapshot,
+    required_checks: Collection[str],
+    trunk: str,
+    suppressed_failed_checks: Collection[str] = (),
+) -> tuple[Blocker, ...]:
+    suppressed = set(suppressed_failed_checks)
+    blockers = [
+        b for b in classify_pr(pr, required_checks, trunk)
+        if not (b.kind == "failed_check" and b.key in suppressed)
+    ]
+    latest = pr.latest_mergify
+    if not latest or latest.head_sha != pr.head_ref_oid:
+        return tuple(blockers)
+    conditions = mergify_condition_map(latest)
+    return tuple(
+        blocker for blocker in blockers
+        if not (
+            blocker.kind == "missing_check"
+            and (
+                conditions.get(blocker.key) == "success"
+                or (
+                    latest.state == "dequeued"
+                    and is_queue_only_required_check(blocker.key)
+                    and blocker.key in latest.failing_checks
+                )
+            )
+        )
+    )
+
+
+def mergify_failed_check_actions(
+    pr: PrSnapshot,
+    ledger: Ledger,
+    suppressed_failed_checks: Collection[str] = (),
+) -> tuple[Action, ...]:
+    suppressed = set(suppressed_failed_checks)
+    latest = pr.latest_mergify
+    if not latest or latest.state != "dequeued" or latest.head_sha != pr.head_ref_oid:
+        return ()
+    for name in latest.failing_checks:
+        if name in suppressed:
+            continue
+        if ledger.count("repair-check", pr.number, pr.head_ref_oid, name) >= 3:
+            return (cap_action(pr, Blocker(name, "failed_check", pr.number, f"Mergify queue check failed: {name}"), f"Mergify queue check failed: {name}"),)
+        return (Action("repair_check", pr.number, name, f"Mergify queue check failed: {name}"),)
+    return ()
+
+
+def current_bottom_pr(stack: StackGroup, trunk: str) -> PrSnapshot | None:
+    for pr in stack.prs:
+        if pr.state == "OPEN" and pr.base_ref_name == trunk:
+            return pr
+    return None
+
+def classify_bottom_topology(
+    stack: StackGroup,
+    trunk: str,
+    open_pr_numbers_by_head: Mapping[str, Collection[int]],
+) -> BottomTopology:
+    root = stack.prs[0]
+    bottom = current_bottom_pr(stack, trunk)
+    if bottom is not None:
+        return BottomTopology(
+            kind="current_bottom",
+            root=root,
+            bottom=bottom,
+            external_open_base_pr_numbers=(),
+        )
+    current_stack_numbers = {pr.number for pr in stack.prs}
+    external_open_base_pr_numbers = tuple(sorted(
+        number
+        for number in open_pr_numbers_by_head.get(root.base_ref_name, ())
+        if number not in current_stack_numbers
+    ))
+    if external_open_base_pr_numbers:
+        return BottomTopology(
+            kind="external_open_base",
+            root=root,
+            bottom=None,
+            external_open_base_pr_numbers=external_open_base_pr_numbers,
+        )
+    return BottomTopology(
+        kind="stale_unowned_base",
+        root=root,
+        bottom=None,
+        external_open_base_pr_numbers=(),
+    )
+
+
+
+
+def stack_has_unaccepted_upper_pr(stack: StackGroup, bottom: PrSnapshot | None) -> bool:
+    return bool(bottom) and any(
+        pr.state == "OPEN" and pr.number != bottom.number and "admin-bypass" not in pr.labels
+        for pr in stack.prs
+    )
+
+
+def latest_repair_prereq_status(
+    stack: StackGroup,
+    ledger: Ledger,
+    open_pr_numbers: Collection[int],
+    trunk: str,
+) -> RepairPrereqStatus | None:
+    bottom = current_bottom_pr(stack, trunk)
+    if not bottom:
+        return None
+    latest_row: dict[str, object] | None = None
+    latest_epoch = float("-inf")
+    for row in ledger.rows:
+        if row.get("kind") != "repair-prereq-created":
+            continue
+        if int(row.get("pr", -1)) != bottom.number:
+            continue
+        if row.get("headSha") != bottom.head_ref_oid:
+            continue
+        epoch = int(row.get("epoch", 0) or 0)
+        if latest_row is None or epoch >= latest_epoch:
+            latest_row = row
+            latest_epoch = epoch
+    if latest_row is None:
+        return None
+    meta = latest_row.get("meta") if isinstance(latest_row.get("meta"), Mapping) else {}
+    prereq_pr_number = int(meta.get("prNumber") or 0) if isinstance(meta, Mapping) else 0
+    check_name = str(latest_row.get("key") or "")
+    needs_followup_requeue = (
+        bool(check_name)
+        and ledger.latest("repair-prereq-requeue", bottom.number, bottom.head_ref_oid, check_name) is None
+    )
+    return RepairPrereqStatus(
+        check_name=check_name,
+        prereq_pr_number=prereq_pr_number,
+        prereq_branch=str(meta.get("branch") or "") if isinstance(meta, Mapping) else "",
+        is_open=prereq_pr_number in open_pr_numbers,
+        needs_followup_requeue=needs_followup_requeue,
+    )
+
+
+def latest_queue_only_noop_check(stack: StackGroup, ledger: Ledger, trunk: str) -> str | None:
+    bottom = current_bottom_pr(stack, trunk)
+    if not bottom:
+        return None
+    latest = bottom.latest_mergify
+    if (
+        not latest
+        or latest.state != "dequeued"
+        or latest.queue_rule_name != "admin-bypass"
+        or latest.head_sha != bottom.head_ref_oid
+    ):
+        return None
+    latest_row: dict[str, object] | None = None
+    latest_epoch = float("-inf")
+    for row in ledger.rows:
+        if row.get("kind") != "queue-only-noop":
+            continue
+        if int(row.get("pr", -1)) != bottom.number:
+            continue
+        if row.get("headSha") != bottom.head_ref_oid:
+            continue
+        epoch = int(row.get("epoch", 0) or 0)
+        if latest_row is None or epoch >= latest_epoch:
+            latest_row = row
+            latest_epoch = epoch
+    if latest_row is None:
+        return None
+    check_name = str(latest_row.get("key") or "")
+    if (
+        not check_name
+        or not is_queue_only_required_check(check_name)
+        or check_name not in latest.failing_checks
+        or ledger.latest("queue-only-requeue", bottom.number, bottom.head_ref_oid, check_name) is not None
+    ):
+        return None
+    return check_name
+
+
+def latest_repair_invalid_blocker(pr: PrSnapshot, blocker: Blocker, ledger: Ledger) -> Blocker | None:
+    if blocker.kind != "failed_check":
+        return None
+    latest = ledger.latest("repair-invalid", pr.number, pr.head_ref_oid, blocker.key)
+    if latest is None:
+        return None
+    meta = latest.get("meta") if isinstance(latest.get("meta"), Mapping) else {}
+    errors = meta.get("errors") if isinstance(meta, Mapping) else None
+    if isinstance(errors, list):
+        detail = "\n".join(str(error) for error in errors if str(error))
+        if detail:
+            return Blocker(blocker.key, "human_decision", pr.number, detail)
+    return Blocker(blocker.key, "human_decision", pr.number, blocker.detail)
+
+
+def existing_split_stop_blocker(pr: PrSnapshot, blocker: Blocker) -> Blocker | None:
+    if blocker.kind != "failed_check":
+        return None
+    ctx = pr.checks.get(blocker.key)
+    completed_at = ctx.completed_at if ctx else ""
+    for comment in pr.repair_stop_comments:
+        body = comment.body.strip()
+        if not body.startswith(REPAIR_STOP_PREFIX):
+            continue
+        detail = body[len(REPAIR_STOP_PREFIX):].strip()
+        if not detail or not any(marker in detail for marker in MANUAL_SPLIT_STOP_MARKERS):
+            continue
+        if completed_at and comment.updated_at and comment.updated_at < completed_at:
+            continue
+        return Blocker(blocker.key, "human_decision", pr.number, detail)
+    return None
+
+
+def latest_mergify_repair_invalid_blockers(
+    pr: PrSnapshot,
+    ledger: Ledger,
+    suppressed_failed_checks: Collection[str],
+) -> tuple[Blocker, ...]:
+    latest = pr.latest_mergify
+    if not latest or latest.state != "dequeued" or latest.head_sha != pr.head_ref_oid:
+        return ()
+    suppressed = set(suppressed_failed_checks)
+    blockers: list[Blocker] = []
+    for name in latest.failing_checks:
+        if name in suppressed:
+            continue
+        blocker = latest_repair_invalid_blocker(
+            pr,
+            Blocker(name, "failed_check", pr.number, f"Mergify queue check failed: {name}"),
+            ledger,
+        )
+        if blocker is not None:
+            blockers.append(blocker)
+    return tuple(blockers)
+
+
+def _assert_stack_facts_invariants(facts: StackFacts) -> None:
+    assert facts.stack.prs, "stack must contain at least one PR"
+    pr_numbers = tuple(pr.number for pr in facts.stack.prs)
+    assert len(pr_numbers) == len(set(pr_numbers)), "stack PR numbers must be unique"
+    assert set(facts.blockers_by_pr) == set(pr_numbers), "every PR must have blocker facts"
+    expected_all = tuple(
+        blocker
+        for pr in facts.stack.prs
+        for blocker in facts.blockers_by_pr[pr.number]
+    )
+    assert facts.all_blockers == expected_all, "all_blockers must flatten blockers_by_pr in stack order"
+    assert facts.bottom is facts.bottom_topology.bottom, "bottom mirror must track bottom topology"
+    assert (facts.bottom_topology.kind == "current_bottom") is (facts.bottom is not None), "current_bottom topology must match bottom presence"
+    assert (facts.bottom_topology.kind != "current_bottom") is (facts.bottom is None), "non-current topology must match missing bottom"
+    assert (facts.bottom_topology.kind == "external_open_base") is bool(facts.bottom_topology.external_open_base_pr_numbers), "external owners must only appear on external_open_base topology"
+    assert (
+        facts.bottom_topology.kind == "stale_unowned_base"
+    ) is (
+        facts.bottom is None and facts.bottom_topology.external_open_base_pr_numbers == ()
+    ), "stale_unowned_base must mean no bottom and no external owners"
+    if facts.suppressed_failed_checks_by_pr:
+        assert facts.bottom is not None, "suppression requires a current bottom PR"
+        assert set(facts.suppressed_failed_checks_by_pr) == {facts.bottom.number}, "derived suppression is bottom-only"
+    if facts.prereq_status is not None:
+        assert facts.bottom is not None, "prerequisite status requires a current bottom PR"
+    if facts.queue_only_noop_check is not None:
+        assert facts.bottom is not None, "queue-only noop requires a current bottom PR"
+        latest = facts.bottom.latest_mergify
+        assert latest is not None, "queue-only noop requires a Mergify event"
+        assert latest.state == "dequeued", "queue-only noop requires a dequeued Mergify event"
+        assert latest.queue_rule_name == "admin-bypass", "queue-only noop requires the admin-bypass queue"
+        assert latest.head_sha == facts.bottom.head_ref_oid, "queue-only noop requires a same-head Mergify event"
+        assert facts.queue_only_noop_check in latest.failing_checks, "queue-only noop check must still be failing in Mergify"
+
+
+def build_stack_facts(
+    stack: StackGroup,
+    required_checks: Collection[str],
+    ledger: Ledger,
+    open_pr_numbers: Collection[int],
+    open_pr_numbers_by_head: Mapping[str, Collection[int]],
+    trunk: str,
+) -> StackFacts:
+    required = frozenset(required_checks)
+    bottom_topology = classify_bottom_topology(stack, trunk, open_pr_numbers_by_head)
+    bottom = bottom_topology.bottom
+    upper_stack_needs_acceptance = stack_has_unaccepted_upper_pr(stack, bottom)
+    prereq_status = latest_repair_prereq_status(stack, ledger, open_pr_numbers, trunk)
+    queue_only_noop_check = latest_queue_only_noop_check(stack, ledger, trunk)
+
+    suppressed_failed_checks_by_pr: dict[int, tuple[str, ...]] = {}
+    if prereq_status and prereq_status.needs_followup_requeue and bottom:
+        suppressed_failed_checks_by_pr[bottom.number] = suppressed_failed_checks_by_pr.get(bottom.number, ()) + (prereq_status.check_name,)
+    if queue_only_noop_check and bottom:
+        suppressed_failed_checks_by_pr[bottom.number] = suppressed_failed_checks_by_pr.get(bottom.number, ()) + (queue_only_noop_check,)
+    if (
+        bottom
+        and "PR Body" in required
+        and ledger.latest("repair-noop", bottom.number, bottom.head_ref_oid, "PR Body") is not None
+    ):
+        suppressed_failed_checks_by_pr[bottom.number] = suppressed_failed_checks_by_pr.get(bottom.number, ()) + ("PR Body",)
+
+    blockers_by_pr: dict[int, tuple[Blocker, ...]] = {}
+    for pr in stack.prs:
+        effective = effective_blockers(pr, required, trunk, suppressed_failed_checks_by_pr.get(pr.number, ()))
+        blockers = [
+            latest_repair_invalid_blocker(pr, blocker, ledger) or existing_split_stop_blocker(pr, blocker) or blocker
+            for blocker in effective
+        ]
+        existing_keys = {blocker.key for blocker in blockers}
+        blockers.extend(
+            blocker for blocker in latest_mergify_repair_invalid_blockers(
+                pr,
+                ledger,
+                suppressed_failed_checks_by_pr.get(pr.number, ()),
+            )
+            if blocker.key not in existing_keys
+        )
+        blockers_by_pr[pr.number] = tuple(blockers)
+    facts = StackFacts(
+        stack=stack,
+        required_checks=required,
+        trunk=trunk,
+        bottom_topology=bottom_topology,
+        bottom=bottom,
+        upper_stack_needs_acceptance=upper_stack_needs_acceptance,
+        prereq_status=prereq_status,
+        queue_only_noop_check=queue_only_noop_check,
+        suppressed_failed_checks_by_pr=suppressed_failed_checks_by_pr,
+        blockers_by_pr=blockers_by_pr,
+        all_blockers=tuple(
+            blocker
+            for pr in stack.prs
+            for blocker in blockers_by_pr[pr.number]
+        ),
+    )
+    _assert_stack_facts_invariants(facts)
+    return facts
+
+
+
+
+def summarize_stack(facts: StackFacts) -> dict[str, object]:
+    return {
+        "stack_id": facts.stack.stack_id,
+        "bottom_topology": facts.bottom_topology.kind,
+        "bottom_pr": facts.bottom.number if facts.bottom else None,
+        "upper_stack_needs_acceptance": facts.upper_stack_needs_acceptance,
+        "prs": [
+            {
+                "number": pr.number,
+                "state": pr.state,
+                "base": pr.base_ref_name,
+                "head": pr.head_ref_name,
+                "head_sha": pr.head_ref_oid,
+                "labels": sorted(pr.labels),
+                "merge_state_status": pr.merge_state_status,
+                "mergeable": pr.mergeable,
+                "draft": pr.is_draft,
+                "latest_mergify": None if not pr.latest_mergify else {
+                    "state": pr.latest_mergify.state,
+                    "head_sha": pr.latest_mergify.head_sha,
+                    "comment_id": pr.latest_mergify.comment_id,
+                    "failing_checks": list(pr.latest_mergify.failing_checks),
+                    "waiting_for": list(pr.latest_mergify.waiting_for),
+                },
+                "blockers": [
+                    {"kind": blocker.kind, "key": blocker.key, "detail": blocker.detail}
+                    for blocker in facts.blockers_by_pr[pr.number]
+                ],
+            }
+            for pr in facts.stack.prs
+        ],
+    }
+
+
+def wait_reason_for_facts(facts: StackFacts) -> str:
+    if facts.upper_stack_needs_acceptance:
+        return "upper-stack-needs-acceptance"
+    if facts.bottom and facts.bottom.latest_mergify and facts.bottom.latest_mergify.state in {"queued", "merging"}:
+        return "bottom-already-queued"
+    for pr in facts.stack.prs:
+        blocker_kinds = {blocker.kind for blocker in facts.blockers_by_pr[pr.number]}
+        if "pending_check" in blocker_kinds:
+            return "pending-check"
+        if "merge_hold" in blocker_kinds and len(blocker_kinds) == 1:
+            return "merge-hold-only"
+        if HUMAN_BLOCKER_KINDS & blocker_kinds:
+            return "blocked-needs-human"
+    return "no-action"
+
+
+def _has_pending_or_human_blocker(facts: StackFacts) -> bool:
+    return any(blocker.kind == "pending_check" or blocker.kind in HUMAN_BLOCKER_KINDS for blocker in facts.all_blockers)
+
+
+def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
+    if not facts.bottom:
+        return _has_pending_or_human_blocker(facts)
+    return any(
+        blocker.pr_number == facts.bottom.number
+        and (blocker.kind == "pending_check" or blocker.kind in HUMAN_BLOCKER_KINDS)
+        for blocker in facts.all_blockers
+    )
+
+
+def plan_mergify_queue_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
+    del max_repair_attempts
+    for pr in facts.stack.prs:
+        if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
+            continue
+        if facts.upper_stack_needs_acceptance and facts.bottom and pr.number == facts.bottom.number:
+            continue
+        actions = mergify_failed_check_actions(pr, ledger, facts.suppressed_failed_checks_by_pr.get(pr.number, ()))
+        if actions:
+            return actions[0]
+    return None
+
+
+def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
+    for pr in facts.stack.prs:
+        for blocker in facts.blockers_by_pr[pr.number]:
+            if blocker.kind == "conflict":
+                key = f"conflict:{pr.number}"
+                if ledger.count("conflict-repair", pr.number, pr.head_ref_oid, key) >= max_repair_attempts:
+                    return cap_action(pr, blocker, blocker.detail)
+                return Action("repair_conflict", pr.number, key, blocker.detail)
+            if blocker.kind == "failed_check":
+                attempts = ledger.count("repair-check", pr.number, pr.head_ref_oid, blocker.key)
+                if attempts >= max_repair_attempts and ledger.latest("repair-evaluated", pr.number, pr.head_ref_oid, blocker.key) is not None:
+                    return cap_action(pr, blocker, blocker.detail)
+                return Action("repair_check", pr.number, blocker.key, blocker.detail)
+    return None
+
+
+def plan_bot_thread_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
+    for pr in facts.stack.prs:
+        for blocker in facts.blockers_by_pr[pr.number]:
+            if blocker.kind == "outdated_bot_review_thread":
+                return Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail)
+            if blocker.kind != "bot_review_thread":
+                continue
+            if ledger.has_different_head("repair-bot-thread", pr.number, pr.head_ref_oid, blocker.key):
+                return Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail)
+            if ledger.count("repair-bot-thread", pr.number, pr.head_ref_oid, blocker.key) >= max_repair_attempts:
+                return cap_action(pr, blocker, blocker.detail)
+            return Action("repair_check", pr.number, "bot_review_thread:" + blocker.key, blocker.detail)
+    return None
+
+
+def plan_hard_blockers(facts: StackFacts, ledger: Ledger) -> Action | None:
+    for pr in facts.stack.prs:
+        for blocker in facts.blockers_by_pr[pr.number]:
+            if blocker.kind == "pending_check":
+                return None
+            if blocker.kind == "human_decision":
+                return None
+            if blocker.kind in HUMAN_BLOCKER_KINDS:
+                if ledger.count("comment-blocked", pr.number, pr.head_ref_oid, blocker.key) > 0:
+                    return None
+                return Action("comment_blocked", pr.number, blocker.key, blocker.detail)
+    return None
+
+
+def plan_merge_hold_cleanup(facts: StackFacts, ledger: Ledger) -> Action | None:
+    if _has_pending_or_human_blocker(facts) or not facts.bottom:
+        return None
+    non_hold_blockers = [blocker for blocker in facts.all_blockers if blocker.kind != "merge_hold"]
+    hold_blockers = [blocker for blocker in facts.all_blockers if blocker.kind == "merge_hold"]
+    if hold_blockers and not non_hold_blockers:
+        blocker = hold_blockers[0]
+        pr = next(pr for pr in facts.stack.prs if pr.number == blocker.pr_number)
+        if ledger.count("remove-merge-hold", pr.number, pr.head_ref_oid, "merge-hold") >= 1:
+            return cap_action(pr, blocker, blocker.detail)
+        return Action("remove_merge_hold", pr.number, "merge-hold", blocker.detail)
+    return None
+
+
+def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts: int) -> Action | None:
+    if _bottom_has_pending_or_human_blocker(facts):
+        return None
+    if any(blocker.kind == "merge_hold" for blocker in facts.all_blockers):
+        return None
+    if not facts.bottom:
+        if facts.bottom_topology.kind == "current_bottom":
+            raise AssertionError("current_bottom topology reached no-bottom branch")
+        root = facts.bottom_topology.root
+        if facts.bottom_topology.kind == "external_open_base":
+            owners = ", ".join(f"#{number}" for number in facts.bottom_topology.external_open_base_pr_numbers)
+            return Action(
+                "comment_blocked",
+                root.number,
+                "external-open-base-pr",
+                f"lowest open stack PR #{root.number} is based on `{root.base_ref_name}`, which still belongs to open PR(s) {owners} outside this stack; leaving it alone to avoid dropping dependency changes",
+            )
+        return Action(
+            "retarget_base",
+            root.number,
+            facts.trunk,
+            f"retarget stack root from `{root.base_ref_name}` to `{facts.trunk}`",
+        )
+
+    bottom = facts.bottom
+    latest = bottom.latest_mergify
+    if "admin-bypass" not in bottom.labels:
+        if (
+            facts.queue_only_noop_check
+            and latest
+            and latest.queue_rule_name == "admin-bypass"
+            and latest.state == "dequeued"
+        ):
+            return Action(
+                "restore_admin_bypass_label",
+                bottom.number,
+                facts.queue_only_noop_check,
+                "restore admin-bypass label after queue-only noop",
+            )
+        return Action("comment_admin_bypass_nudge", bottom.number, "admin-bypass", "missing admin-bypass label")
+    if facts.upper_stack_needs_acceptance:
+        return None
+    if latest and latest.state in ACTIVE_QUEUE_STATES and (latest.head_sha == bottom.head_ref_oid or "queued" in bottom.labels):
+        return None
+    requeue_reason = "eligible-when-ready"
+    requeue_key = "ready"
+    if latest and latest.state == "dequeued":
+        requeue_reason = "eligible-after-dequeue"
+        requeue_key = latest.comment_id or "manual"
+    elif "dequeued" in bottom.labels:
+        requeue_reason = "eligible-after-dequeued-label"
+    attempts = ledger.count("requeue", bottom.number, bottom.head_ref_oid, requeue_key)
+    if attempts >= max_requeue_attempts:
+        return cap_action(bottom, Blocker(requeue_key, "capped", bottom.number, "requeue"), "requeue")
+    return Action("requeue", bottom.number, requeue_key, requeue_reason)
+
+
+def plan_actions_from_facts(
+    facts: StackFacts,
+    ledger: Ledger,
+    max_requeue_attempts: int,
+    max_repair_attempts: int,
+) -> tuple[Action, ...]:
+    action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts)
+    if action is not None:
+        return (action,)
+    action = plan_direct_repairs(facts, ledger, max_repair_attempts)
+    if action is not None:
+        return (action,)
+    action = plan_bot_thread_repairs(facts, ledger, max_repair_attempts)
+    if action is not None:
+        return (action,)
+    action = plan_hard_blockers(facts, ledger)
+    if action is not None:
+        return (action,)
+    action = plan_merge_hold_cleanup(facts, ledger)
+    if action is not None:
+        return (action,)
+    action = plan_bottom_progress(facts, ledger, max_requeue_attempts)
+    if action is not None:
+        return (action,)
+    return ()
+
+
+def plan_stack_actions(
+    stack: StackGroup,
+    required_checks: Collection[str],
+    ledger: Ledger,
+    now_epoch: int,
+    max_requeue_attempts: int = 2,
+    max_repair_attempts: int = 3,
+    suppressed_failed_checks_by_pr: Mapping[int, Collection[str]] | None = None,
+    open_pr_numbers_by_head: Mapping[str, Collection[int]] | None = None,
+) -> tuple[Action, ...]:
+    del now_epoch
+    del suppressed_failed_checks_by_pr
+    facts = build_stack_facts(
+        stack,
+        required_checks,
+        ledger,
+        open_pr_numbers=(),
+        open_pr_numbers_by_head=open_pr_numbers_by_head or {},
+        trunk=TRUNK,
+    )
+    return plan_actions_from_facts(facts, ledger, max_requeue_attempts, max_repair_attempts)
+
+
+def plan_stack_execution(
+    stack: StackGroup,
+    required_checks: Collection[str],
+    ledger: Ledger,
+    now_epoch: int,
+    open_pr_numbers: Collection[int],
+    open_pr_numbers_by_head: Mapping[str, Collection[int]],
+    max_requeue_attempts: int = 2,
+    max_repair_attempts: int = 3,
+    trunk: str = TRUNK,
+) -> StackExecutionPlan:
+    del now_epoch
+    facts = build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head, trunk)
+    summary = summarize_stack(facts)
+    if facts.prereq_status and facts.prereq_status.is_open:
+        return StackExecutionPlan(
+            summary=summary,
+            actions=(),
+            wait_reason="repair-prereq-open",
+            prereq_status=facts.prereq_status,
+            queue_only_noop_check=facts.queue_only_noop_check,
+        )
+    actions = plan_actions_from_facts(facts, ledger, max_requeue_attempts, max_repair_attempts)
+    if actions:
+        return StackExecutionPlan(
+            summary=summary,
+            actions=actions,
+            prereq_status=facts.prereq_status,
+            queue_only_noop_check=facts.queue_only_noop_check,
+        )
+    return StackExecutionPlan(
+        summary=summary,
+        actions=(),
+        wait_reason=wait_reason_for_facts(facts),
+        prereq_status=facts.prereq_status,
+        queue_only_noop_check=facts.queue_only_noop_check,
+    )

--- a/packages/mergify-admin-requeue/mergify_admin_requeue/repairer.py
+++ b/packages/mergify-admin-requeue/mergify_admin_requeue/repairer.py
@@ -1,0 +1,572 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+from typing import Mapping, Sequence
+
+try:
+    from .gh_executor import AdminBypassGhExecutor
+    from .logger import AdminBypassLogger
+    from .model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
+    from .plan import TRUNK, is_queue_only_required_check
+    from .snapshot import GhClient, checkout_pr_head, run_logged
+except ImportError:
+    from gh_executor import AdminBypassGhExecutor
+    from logger import AdminBypassLogger
+    from model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
+    from plan import TRUNK, is_queue_only_required_check
+    from snapshot import GhClient, checkout_pr_head, run_logged
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PROOF_POLICY_LANE_ERROR = (
+    "Review lane proof cannot ship with policy files in the same PR. "
+    "Keep benchmarks, repros, and regression proof separate from behavior or policy changes."
+)
+PROOF_TOOLING_POLICY_UNIT_ERROR = (
+    'PR body Review Unit "proof" cannot ship with tooling-policy files in the same PR. '
+    "Split this into one Review Unit per PR."
+)
+NON_TRUNK_PREREQ_ERROR = "automatic tooling-policy split is only supported for base master"
+NON_TRUNK_MANUAL_SPLIT_ERROR = "worker cannot auto-split this PR on a non-trunk base; human stack split required"
+
+
+def mergify_check_urls(event: MergifyQueueEvent | None, check_name: str) -> tuple[str, ...]:
+    if not event:
+        return ()
+    for name, urls in event.failing_check_urls:
+        if name == check_name:
+            return urls
+    return ()
+
+
+class AdminBypassRepairer:
+    def __init__(
+        self,
+        gh: GhClient,
+        executor: AdminBypassGhExecutor,
+        logger: AdminBypassLogger,
+        ledger: Ledger,
+        repo: str,
+    ):
+        self.gh = gh
+        self.executor = executor
+        self.logger = logger
+        self.ledger = ledger
+        self.repo = repo
+
+    def git_output(self, work_root: Path, *args: str) -> str:
+        return run_logged(["git", *args], cwd=work_root)
+
+    def git_lines(self, work_root: Path, *args: str) -> tuple[str, ...]:
+        return tuple(line.strip() for line in self.git_output(work_root, *args).splitlines() if line.strip())
+
+    def hard_reset_work_root(self, work_root: Path, target: str) -> None:
+        self.git_output(work_root, "reset", "--hard", target)
+        self.git_output(work_root, "clean", "-fd")
+
+    def is_ancestor(self, work_root: Path, ancestor: str, descendant: str) -> bool:
+        if not work_root.exists():
+            return True
+        completed = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+            cwd=str(work_root),
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        return completed.returncode == 0
+
+    def normalize_repair_commit(self, work_root: Path, start_head: str, end_head: str, check_name: str) -> str:
+        if self.is_ancestor(work_root, start_head, end_head):
+            return end_head
+        diff = self.git_output(work_root, "diff", "--binary", start_head, end_head)
+        self.hard_reset_work_root(work_root, start_head)
+        if not diff.strip():
+            return start_head
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+            handle.write(diff)
+            patch_path = Path(handle.name)
+        try:
+            self.git_output(work_root, "apply", "--index", str(patch_path))
+        finally:
+            patch_path.unlink(missing_ok=True)
+        if not self.git_lines(work_root, "status", "--porcelain"):
+            return start_head
+        self.git_output(work_root, "commit", "-m", f"Repair {check_name}")
+        return self.git_output(work_root, "rev-parse", "HEAD").strip()
+
+    def validate_local_pr_body(self, work_root: Path, body: str, base_branch: str) -> dict[str, object]:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+            handle.write(body)
+            body_path = Path(handle.name)
+        try:
+            completed = subprocess.run(
+                [
+                    "node",
+                    str(REPO_ROOT / "scripts" / "validate-pr-body-local.mjs"),
+                    "--body-file",
+                    str(body_path),
+                    "--base",
+                    base_branch,
+                    "--json",
+                ],
+                cwd=str(work_root),
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+            stdout = completed.stdout.strip()
+            if completed.returncode not in {0, 1}:
+                raise RuntimeError(completed.stderr.strip() or stdout or "validate-pr-body-local failed")
+            if not stdout:
+                raise RuntimeError(completed.stderr.strip() or "validate-pr-body-local produced no JSON output")
+            value = json.loads(stdout)
+            if not isinstance(value, dict):
+                raise RuntimeError("validate-pr-body-local returned non-object JSON")
+            return value
+        finally:
+            body_path.unlink(missing_ok=True)
+
+    def validate_pr_body_from_current_diff(self, work_root: Path, body: str, base_branch: str) -> dict[str, object]:
+        self.git_output(work_root, "fetch", "origin", f"+refs/heads/{base_branch}:refs/remotes/origin/{base_branch}")
+        changed_files = self.git_output(work_root, "diff", "--name-only", f"origin/{base_branch}...HEAD")
+        diff_text = self.git_output(work_root, "diff", "--no-ext-diff", f"origin/{base_branch}...HEAD")
+        with (
+            tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as body_handle,
+            tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as changed_handle,
+            tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as diff_handle,
+        ):
+            body_handle.write(body)
+            changed_handle.write(changed_files)
+            diff_handle.write(diff_text)
+            body_path = Path(body_handle.name)
+            changed_path = Path(changed_handle.name)
+            diff_path = Path(diff_handle.name)
+        script = (
+            "import { readFileSync } from 'node:fs';"
+            f"import {{ getReviewMetadata, scopeKindsForChangedFiles, validatePrBody }} from '{(REPO_ROOT / 'scripts' / 'validate-pr-body.mjs').as_posix()}';"
+            f"import {{ reviewUnitsForChangedFiles }} from '{(REPO_ROOT / 'scripts' / 'review-unit-rules.mjs').as_posix()}';"
+            "const body = readFileSync(process.argv[1], 'utf8');"
+            "const changedFiles = readFileSync(process.argv[2], 'utf8').split(/\\r?\\n/).filter(Boolean);"
+            "const diffText = readFileSync(process.argv[3], 'utf8');"
+            "const errors = await validatePrBody(body, { changedFiles, diffText });"
+            "const reviewMetadata = getReviewMetadata(body.trim());"
+            "console.log(JSON.stringify({"
+            "valid: errors.length === 0,"
+            "errors,"
+            "reviewLane: reviewMetadata.reviewLane,"
+            "reviewUnit: reviewMetadata.reviewUnit,"
+            "reviewUnits: reviewUnitsForChangedFiles(changedFiles),"
+            "scopeKinds: scopeKindsForChangedFiles(changedFiles),"
+            "}));"
+        )
+        try:
+            completed = subprocess.run(
+                ["node", "--input-type=module", "-e", script, str(body_path), str(changed_path), str(diff_path)],
+                cwd=str(work_root),
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+            stdout = completed.stdout.strip()
+            if completed.returncode not in {0, 1}:
+                raise RuntimeError(completed.stderr.strip() or stdout or "validate-pr-body fallback failed")
+            if not stdout:
+                raise RuntimeError(completed.stderr.strip() or "validate-pr-body fallback produced no JSON output")
+            value = json.loads(stdout)
+            if not isinstance(value, dict):
+                raise RuntimeError("validate-pr-body fallback returned non-object JSON")
+            return value
+        finally:
+            body_path.unlink(missing_ok=True)
+            changed_path.unlink(missing_ok=True)
+            diff_path.unlink(missing_ok=True)
+
+    def validate_current_pr_body(self, work_root: Path, body: str, base_branch: str) -> dict[str, object]:
+        try:
+            return self.validate_local_pr_body(work_root, body, base_branch)
+        except RuntimeError:
+            return self.validate_pr_body_from_current_diff(work_root, body, base_branch)
+
+    def is_proof_tooling_policy_validation(self, value: Mapping[str, object]) -> bool:
+        errors = value.get("errors")
+        scope_kinds = value.get("scopeKinds")
+        review_units = value.get("reviewUnits")
+        if value.get("reviewLane") != "proof" or value.get("reviewUnit") != "proof":
+            return False
+        if review_units != ["tooling-policy"]:
+            return False
+        if scope_kinds not in ([], ["policy"]):
+            return False
+        if not isinstance(errors, list):
+            return False
+        return bool(errors) and set(errors).issubset({PROOF_POLICY_LANE_ERROR, PROOF_TOOLING_POLICY_UNIT_ERROR})
+
+    def is_prereq_split_validation(self, value: Mapping[str, object], pr: PrSnapshot) -> bool:
+        return pr.base_ref_name == TRUNK and self.is_proof_tooling_policy_validation(value)
+
+    def is_manual_split_validation(self, value: Mapping[str, object]) -> bool:
+        errors = value.get("errors")
+        review_units = value.get("reviewUnits")
+        if not isinstance(errors, list) or not errors:
+            return False
+        if not isinstance(review_units, list):
+            return False
+        if len({str(unit) for unit in review_units}) < 2:
+            return False
+        joined = "\n".join(str(error) for error in errors)
+        return (
+            "multiple review units" in joined
+            or "Split this into one Review Unit per PR." in joined
+            or "cannot ship with policy, proof files" in joined
+            or "cannot ship with tooling-policy, proof files" in joined
+            or "cannot ship with proof files" in joined
+        )
+
+    def invalid_repair_errors(self, value: Mapping[str, object], pr: PrSnapshot) -> list[str]:
+        errors = [str(error) for error in value.get("errors", [])]
+        if self.is_proof_tooling_policy_validation(value) and pr.base_ref_name != TRUNK:
+            errors = [*errors, NON_TRUNK_PREREQ_ERROR]
+        if self.is_manual_split_validation(value) and pr.base_ref_name != TRUNK:
+            errors = [*errors, NON_TRUNK_MANUAL_SPLIT_ERROR]
+        return errors
+
+    def invalid_repair_outcome(
+        self,
+        pr: PrSnapshot,
+        check_name: str,
+        start_head: str,
+        end_head: str,
+        value: Mapping[str, object],
+        *,
+        repair_commits: Sequence[str] = (),
+    ) -> RepairOutcome:
+        return self.blocked_outcome(
+            "blocked_invalid",
+            check_name,
+            start_head,
+            end_head,
+            repair_commits=repair_commits,
+            errors=self.invalid_repair_errors(value, pr),
+        )
+
+    def prerequisite_branch_name(self, pr: PrSnapshot, start_head: str) -> str:
+        return f"stack/pr-babysit-prereq-{pr.number}-{start_head[:7]}"
+
+    def prerequisite_title(self, pr: PrSnapshot, check_name: str) -> str:
+        return f"[PR babysit] Tooling-policy repair prerequisite for #{pr.number}: {check_name}"
+
+    def prerequisite_body(self, pr: PrSnapshot, check_name: str) -> str:
+        return (
+            "## Summary\n\n"
+            "Worker-generated tooling-policy repair.\n\n"
+            "## Review Claim\n\n"
+            f"This PR carries the worker-generated tooling-policy repair that unblocks {check_name} on #{pr.number}.\n\n"
+            "## Review Lane\n\n"
+            "- policy\n\n"
+            "## Review Unit\n\n"
+            "- tooling-policy\n\n"
+            "## Safety Invariant\n\n"
+            "Contains only the worker-generated repair commit; the original PR branch stays proof-only.\n\n"
+            "## Slice Rationale\n\n"
+            "The repair changed tooling-policy files that a proof PR body cannot carry, so the repair must land first.\n\n"
+            "## Non-goals\n\n"
+            "- No product behavior change.\n\n"
+            "## Test Plan\n\n"
+            "<details>\n"
+            "<summary>Test Plan</summary>\n\n"
+            f"- [ ] Let CI rerun {check_name}.\n\n"
+            "</details>\n\n"
+            "## Revert Plan\n\n"
+            "<details>\n"
+            "<summary>Revert Plan</summary>\n\n"
+            "- Safe to revert? Yes.\n"
+            "- Revert command: `git revert <sha>`\n"
+            "- Post-revert steps: None.\n"
+            "- Data migration? No.\n\n"
+            "</details>\n"
+        )
+
+    def blocked_outcome(
+        self,
+        status: str,
+        check_name: str,
+        start_head: str,
+        end_head: str,
+        *,
+        repair_commits: Sequence[str] = (),
+        status_lines: Sequence[str] = (),
+        errors: Sequence[str] = (),
+        prereq: Mapping[str, object] | None = None,
+    ) -> RepairOutcome:
+        return RepairOutcome(
+            status=status,
+            check_name=check_name,
+            start_head=start_head,
+            end_head=end_head,
+            repair_commits=tuple(repair_commits),
+            status_lines=tuple(status_lines),
+            errors=tuple(errors),
+            prereq=prereq,
+        )
+
+    def push_branch(self, work_root: Path, branch_name: str) -> None:
+        self.git_output(work_root, "push", "origin", f"HEAD:{branch_name}")
+
+    def terminal_repair_outcome(
+        self,
+        pr: PrSnapshot,
+        check_name: str,
+        start_head: str,
+        end_head: str,
+        work_root: Path,
+    ) -> RepairOutcome | None:
+        if not hasattr(self.gh, "pr_detail"):
+            return None
+        detail = self.gh.pr_detail(self.repo, pr.number)
+        state = str(detail.get("state") or pr.state)
+        if state == "OPEN":
+            return None
+        self.logger.trace(
+            "admin-bypass-repair-check-terminal",
+            repo=self.repo,
+            pr_number=pr.number,
+            check_name=check_name,
+            state=state,
+            start_head=start_head,
+            end_head=end_head,
+        )
+        self.hard_reset_work_root(work_root, start_head)
+        return self.blocked_outcome("noop", check_name, start_head, end_head)
+
+    def create_repair_prerequisite(
+        self,
+        pr: PrSnapshot,
+        check_name: str,
+        start_head: str,
+        repair_commits: Sequence[str],
+        work_root: Path,
+        now: int | None,
+    ) -> dict[str, object]:
+        branch_name = self.prerequisite_branch_name(pr, start_head)
+        title = self.prerequisite_title(pr, check_name)
+        body = self.prerequisite_body(pr, check_name)
+        self.git_output(work_root, "checkout", "-B", branch_name, f"origin/{TRUNK}")
+        self.git_output(work_root, "reset", "--hard", f"origin/{TRUNK}")
+        for commit in repair_commits:
+            self.git_output(work_root, "cherry-pick", commit)
+        validation = self.validate_current_pr_body(work_root, body, TRUNK)
+        if not validation.get("valid"):
+            errors = [str(error) for error in validation.get("errors", [])]
+            raise RuntimeError("prerequisite PR body failed validation: " + "; ".join(errors))
+        self.push_branch(work_root, branch_name)
+        created = self.gh.create_pr(self.repo, title, body, branch_name, TRUNK)
+        prereq_number = int(created.get("number") or 0)
+        if prereq_number <= 0:
+            raise RuntimeError("GitHub did not return a prerequisite PR number")
+        self.gh.edit_label(self.repo, prereq_number, add="admin-bypass")
+        self.ledger.record(
+            "repair-prereq-created",
+            pr.number,
+            pr.head_ref_oid,
+            check_name,
+            now,
+            meta={"prNumber": prereq_number, "branch": branch_name},
+        )
+        self.logger.trace(
+            "admin-bypass-repair-prereq-created",
+            repo=self.repo,
+            pr_number=pr.number,
+            check_name=check_name,
+            prereq_pr_number=prereq_number,
+            prereq_branch=branch_name,
+            repair_commits=list(repair_commits),
+        )
+        return {"prNumber": prereq_number, "branch": branch_name, "title": title}
+
+    def run_claude_repair(self, work_root: Path, prompt: str) -> None:
+        subprocess.run(
+            ["claude", "-p", prompt, "--dangerously-skip-permissions"],
+            cwd=str(work_root),
+            check=True,
+            text=True,
+        )
+
+    def job_log_has_evidence(self, log_path: str) -> bool:
+        if not log_path:
+            return False
+        try:
+            return bool(Path(log_path).read_text(encoding="utf-8").strip())
+        except OSError:
+            return False
+
+    def job_log_is_empty(self, log_path: str) -> bool:
+        if not log_path:
+            return False
+        path = Path(log_path)
+        if not path.exists():
+            return False
+        try:
+            return not path.read_text(encoding="utf-8").strip()
+        except OSError:
+            return False
+
+    def repair_check(self, pr: PrSnapshot, check_name: str, now: int | None = None) -> RepairOutcome:
+        ctx = pr.checks.get(check_name)
+        latest = pr.latest_mergify
+        queue_only = ctx is None and is_queue_only_required_check(check_name)
+        mergify_urls = mergify_check_urls(latest, check_name)
+        details_url = (ctx.details_url if ctx and ctx.details_url else "") or (mergify_urls[0] if mergify_urls else "")
+        work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
+        work_root.parent.mkdir(parents=True, exist_ok=True)
+        checkout_pr_head(self.repo, pr, work_root)
+        start_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
+        if queue_only and not details_url:
+            return self.blocked_outcome(
+                "blocked_invalid",
+                check_name,
+                start_head,
+                start_head,
+                errors=(f"queue-only check {check_name} is missing a Mergify job URL",),
+            )
+        log_path = self.executor.download_job_log(self.repo, details_url, pr.number, check_name) if details_url else ""
+        if check_name == "PR Body" and self.job_log_is_empty(log_path):
+            terminal = self.terminal_repair_outcome(pr, check_name, start_head, start_head, work_root)
+            if terminal:
+                return terminal
+            validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
+            if validation.get("valid"):
+                self.logger.trace(
+                    "admin-bypass-pr-body-valid-noop",
+                    repo=self.repo,
+                    pr_number=pr.number,
+                    check_name=check_name,
+                    head_sha=pr.head_ref_oid,
+                    details_url=details_url,
+                    log_path=log_path,
+                )
+                return self.blocked_outcome("noop", check_name, start_head, start_head)
+        if queue_only and not self.job_log_has_evidence(log_path):
+            self.logger.trace(
+                "admin-bypass-queue-only-empty-log-noop",
+                repo=self.repo,
+                pr_number=pr.number,
+                check_name=check_name,
+                details_url=details_url,
+                log_path=log_path,
+                head_sha=pr.head_ref_oid,
+            )
+            return self.blocked_outcome(
+                "queue_only_noop",
+                check_name,
+                start_head,
+                start_head,
+            )
+        queue_pr_number = latest.queue_pr_number if latest else 0
+        prompt = (
+            f"Fix only the failing check. Add or update a repro if the failure is reproducible. "
+            f"Commit locally if needed, do not push. If local proof shows the check is already green on the current head, make no commit and exit 0.\n\n"
+            f"PR: #{pr.number}\nFailed check: {check_name}\nDetails URL: {details_url}\nJob log path: {log_path}\n"
+            f"Latest Mergify event: {json.dumps(latest.__dict__ if latest else None, sort_keys=True)}\n"
+        )
+        if queue_only:
+            prompt += f"Queue draft PR: #{queue_pr_number}\nRepair the real PR head, using only evidence from the queue draft failure.\n"
+        self.logger.trace(
+            "admin-bypass-repair-check-start",
+            repo=self.repo,
+            pr_number=pr.number,
+            check_name=check_name,
+            details_url=details_url,
+            log_path=log_path,
+            work_root=str(work_root),
+            head_sha=pr.head_ref_oid,
+        )
+        self.run_claude_repair(work_root, prompt)
+        end_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
+        status_lines = self.git_lines(work_root, "status", "--porcelain")
+        terminal = self.terminal_repair_outcome(pr, check_name, start_head, end_head, work_root)
+        if terminal:
+            return terminal
+        if end_head == start_head and not status_lines:
+            if not queue_only:
+                validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
+                if not validation.get("valid"):
+                    return self.invalid_repair_outcome(pr, check_name, start_head, end_head, validation)
+            return self.blocked_outcome(
+                "queue_only_noop" if queue_only else "noop",
+                check_name,
+                start_head,
+                end_head,
+            )
+        if status_lines:
+            self.hard_reset_work_root(work_root, start_head)
+            return self.blocked_outcome(
+                "blocked_dirty",
+                check_name,
+                start_head,
+                end_head,
+                status_lines=status_lines,
+            )
+        end_head = self.normalize_repair_commit(work_root, start_head, end_head, check_name)
+        repair_commits = self.git_lines(work_root, "rev-list", "--reverse", f"{start_head}..{end_head}")
+        validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
+        if validation.get("valid"):
+            self.push_branch(work_root, pr.head_ref_name)
+            return self.blocked_outcome(
+                "pushed",
+                check_name,
+                start_head,
+                end_head,
+                repair_commits=repair_commits,
+            )
+        if self.is_prereq_split_validation(validation, pr):
+            try:
+                created = self.create_repair_prerequisite(pr, check_name, start_head, repair_commits, work_root, now)
+            finally:
+                self.git_output(work_root, "checkout", "-B", pr.head_ref_name, start_head)
+                self.hard_reset_work_root(work_root, start_head)
+            return self.blocked_outcome(
+                "prereq_created",
+                check_name,
+                start_head,
+                end_head,
+                repair_commits=repair_commits,
+                prereq=created,
+            )
+        self.hard_reset_work_root(work_root, start_head)
+        return self.invalid_repair_outcome(
+            pr,
+            check_name,
+            start_head,
+            end_head,
+            validation,
+            repair_commits=repair_commits,
+        )
+
+    def repair_conflict(self, pr: PrSnapshot, reason: str) -> None:
+        work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
+        work_root.parent.mkdir(parents=True, exist_ok=True)
+        checkout_pr_head(self.repo, pr, work_root)
+        prompt = (
+            f"Resolve only the merge conflict that keeps this PR from merging. "
+            f"Rebase the PR head branch onto its base branch, preserve the PR's intended changes, "
+            f"run the narrow proof for the conflict resolution, then commit and push to the PR head branch. "
+            f"If the PR is already closed or merged, or the head branch no longer exists, make no commit and exit 0.\n\n"
+            f"PR: #{pr.number}\nBase branch: {pr.base_ref_name}\nHead branch: {pr.head_ref_name}\n"
+            f"Head SHA: {pr.head_ref_oid}\nReason: {reason}\n"
+        )
+        self.logger.trace(
+            "admin-bypass-repair-conflict-start",
+            repo=self.repo,
+            pr_number=pr.number,
+            reason=reason,
+            work_root=str(work_root),
+            base_ref=pr.base_ref_name,
+            head_ref=pr.head_ref_name,
+            head_sha=pr.head_ref_oid,
+        )
+        self.run_claude_repair(work_root, prompt)

--- a/packages/mergify-admin-requeue/mergify_admin_requeue/snapshot.py
+++ b/packages/mergify-admin-requeue/mergify_admin_requeue/snapshot.py
@@ -1,0 +1,413 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Mapping, Sequence
+from urllib.parse import quote
+
+PR_LIST_FIELDS = (
+    "number,title,url,headRefName,headRefOid,baseRefName,state,isDraft,"
+    "labels,mergeStateStatus,mergeable,reviewDecision"
+)
+PR_CANDIDATE_FIELDS = PR_LIST_FIELDS + ",statusCheckRollup"
+
+try:
+    from .model import (
+        MergifyQueueEvent,
+        PrSnapshot,
+        RepairStopComment,
+        ReviewThread,
+        STACK_MARKER_RE,
+        StackGroup,
+        all_condition_states,
+        extract_first_json_object,
+        failing_check_urls,
+        latest_contexts_by_required_check,
+        payload_rule,
+        payload_state,
+        reason_failed_checks,
+        section_items,
+    )
+except ImportError:
+    from model import (
+        MergifyQueueEvent,
+        PrSnapshot,
+        RepairStopComment,
+        ReviewThread,
+        STACK_MARKER_RE,
+        StackGroup,
+        all_condition_states,
+        extract_first_json_object,
+        failing_check_urls,
+        latest_contexts_by_required_check,
+        payload_rule,
+        payload_state,
+        reason_failed_checks,
+        section_items,
+    )
+
+
+class GhClient:
+    def _run_json(self, args: Sequence[str]) -> object:
+        out = self._run(args)
+        return json.loads(out) if out.strip() else None
+
+    def _run(self, args: Sequence[str]) -> str:
+        return run_logged(args)
+
+    def list_candidate_prs(self, repo: str, author: str | None, pr_numbers: Sequence[int]) -> list[dict]:
+        if pr_numbers:
+            return [self.pr_detail(repo, number) for number in pr_numbers]
+        args = [
+            "gh", "pr", "list", "--repo", repo, "--state", "open",
+            "--label", "admin-bypass", "--limit", "200", "--json",
+            PR_CANDIDATE_FIELDS,
+        ]
+        if author:
+            args[5:5] = ["--author", author]
+        value = self._run_json(args)
+        seeds = value if isinstance(value, list) else []
+        by_number: dict[int, dict] = {}
+        ordered_numbers: list[int] = []
+
+        def remember(number: int, detail: dict) -> None:
+            if number not in by_number:
+                ordered_numbers.append(number)
+            by_number[number] = detail
+
+        for item in seeds:
+            if not isinstance(item, dict):
+                continue
+            number = int(item.get("number") or 0)
+            if number:
+                remember(number, item)
+
+        queued_stack_numbers: list[int] = []
+        queued_stack_number_set: set[int] = set()
+        for number in list(ordered_numbers):
+            meta = parse_stack_metadata(self.issue_comments(repo, number))
+            if not meta:
+                continue
+            for stack_number in meta[1]:
+                if stack_number not in by_number and stack_number not in queued_stack_number_set:
+                    queued_stack_number_set.add(stack_number)
+                    queued_stack_numbers.append(stack_number)
+
+        for number in queued_stack_numbers:
+            remember(number, self.pr_detail(repo, number))
+
+        return [by_number[number] for number in ordered_numbers]
+
+    def list_open_prs(self, repo: str) -> list[dict]:
+        value = self._run_json([
+            "gh", "pr", "list", "--repo", repo, "--state", "open", "--limit", "200", "--json",
+            PR_LIST_FIELDS,
+        ])
+        return value if isinstance(value, list) else []
+
+    def pr_detail(self, repo: str, number: int) -> dict:
+        owner, name = repo.split("/", 1)
+        query = (
+            "query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { "
+            "pullRequest(number:$number) { number title body url isDraft state baseRefName headRefName headRefOid "
+            "mergeStateStatus mergeable labels(first:50) { nodes { name } } "
+            "reviewThreads(first:100) { pageInfo { hasNextPage } nodes { id isResolved isOutdated comments(first:50) { nodes { author { login } body url } } } } "
+            "statusCheckRollup { contexts(first:100) { nodes { __typename ... on CheckRun { name conclusion status completedAt startedAt detailsUrl checkSuite { commit { oid } } } "
+            "... on StatusContext { context state targetUrl commit { oid } } } } } } } }"
+        )
+        value = self._run_json([
+            "gh", "api", "graphql", "-f", f"owner={owner}", "-f", f"name={name}", "-F", f"number={number}", "-f", f"query={query}",
+        ])
+        if not isinstance(value, dict):
+            raise RuntimeError("empty GraphQL response")
+        pr = value.get("data", {}).get("repository", {}).get("pullRequest")
+        if not isinstance(pr, dict):
+            raise RuntimeError(f"missing PR #{number}")
+        return pr
+
+    def create_pr(self, repo: str, title: str, body: str, head: str, base: str) -> dict:
+        payload = json.dumps({"title": title, "body": body, "head": head, "base": base})
+        completed = subprocess.run(
+            ["gh", "api", f"repos/{repo}/pulls", "--method", "POST", "--input", "-"],
+            check=True,
+            text=True,
+            input=payload,
+            capture_output=True,
+        )
+        value = json.loads(completed.stdout) if completed.stdout.strip() else None
+        if not isinstance(value, dict):
+            raise RuntimeError("empty PR create response")
+        return value
+
+    def issue_comments(self, repo: str, number: int) -> list[dict]:
+        value = self._run_json(["gh", "api", f"repos/{repo}/issues/{number}/comments", "--paginate"])
+        return value if isinstance(value, list) else []
+
+    def comment(self, repo: str, number: int, body: str) -> None:
+        subprocess.run(["gh", "pr", "comment", str(number), "--repo", repo, "--body", body], check=True, text=True, capture_output=True)
+
+    def edit_label(self, repo: str, number: int, add: str | None = None, remove: str | None = None) -> None:
+        if add:
+            subprocess.run(
+                ["gh", "api", "--method", "POST", f"repos/{repo}/issues/{number}/labels", "-f", f"labels[]={add}"],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+        if remove:
+            subprocess.run(
+                ["gh", "api", "--method", "DELETE", f"repos/{repo}/issues/{number}/labels/{quote(remove, safe='')}"],
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+
+    def retarget_base(self, repo: str, number: int, base: str) -> None:
+        subprocess.run(
+            ["gh", "api", "--method", "PATCH", f"repos/{repo}/pulls/{number}", "-f", f"base={base}"],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+    def resolve_review_thread(self, thread_id: str) -> None:
+        query = "mutation($threadId:ID!) { resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } } }"
+        subprocess.run(["gh", "api", "graphql", "-f", f"threadId={thread_id}", "-f", f"query={query}"], check=True, text=True, capture_output=True)
+
+
+def run_logged(args: Sequence[str], *, cwd: Path | str | None = None, capture: bool = True) -> str:
+    try:
+        completed = subprocess.run(
+            list(args),
+            cwd=str(cwd) if cwd is not None else None,
+            check=True,
+            text=True,
+            capture_output=capture,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: command failed: {' '.join(str(part) for part in args)}", file=sys.stderr)
+        if exc.stdout:
+            print(exc.stdout, file=sys.stderr, end="" if exc.stdout.endswith("\n") else "\n")
+        if exc.stderr:
+            print(exc.stderr, file=sys.stderr, end="" if exc.stderr.endswith("\n") else "\n")
+        if is_github_rate_limit_error(exc):
+            raise RuntimeError("GitHub API rate limit exceeded while loading PR snapshots") from exc
+        raise
+    return completed.stdout or ""
+
+
+def is_github_rate_limit_error(exc: subprocess.CalledProcessError) -> bool:
+    text = "\n".join(str(part or "") for part in (exc.stdout, exc.stderr))
+    lowered = text.lower()
+    return "rate_limit" in text or "rate limit" in lowered
+
+
+def checkout_pr_head(repo: str, pr: PrSnapshot, work_root: Path) -> None:
+    if not work_root.exists():
+        run_logged(["gh", "repo", "clone", repo, str(work_root)])
+    refspec = f"+refs/heads/{pr.head_ref_name}:refs/remotes/origin/{pr.head_ref_name}"
+    remote_ref = f"refs/remotes/origin/{pr.head_ref_name}"
+    run_logged(["git", "fetch", "origin", refspec], cwd=work_root)
+    run_logged(["git", "checkout", "-B", pr.head_ref_name, remote_ref], cwd=work_root)
+    run_logged(["git", "reset", "--hard", remote_ref], cwd=work_root)
+    run_logged(["git", "clean", "-fd"], cwd=work_root)
+
+
+def parse_mergify_queue_event(comment: Mapping[str, object]) -> MergifyQueueEvent | None:
+    author = comment.get("user") if isinstance(comment.get("user"), Mapping) else comment.get("author")
+    login = ""
+    if isinstance(author, Mapping):
+        login = str(author.get("login") or "")
+    elif isinstance(author, str):
+        login = author
+    if login not in {"mergify[bot]", "mergify"}:
+        return None
+    body = str(comment.get("body") or "")
+    if "-*- Mergify Payload -*-" not in body:
+        return None
+    payload = extract_first_json_object(body[body.find("-*- Mergify Payload -*-"):]) or {}
+    sha_match = re.search(r"Left the queue.*?`([0-9a-fA-F]{40})`", body, re.I | re.S)
+    head_sha = sha_match.group(1) if sha_match else ""
+    queue_pr_match = re.search(r"on draft #(\d+)", body, re.I)
+    queue_pr_number = int(queue_pr_match.group(1)) if queue_pr_match else 0
+    failing_checks = section_items(body, "Failing checks")
+    return MergifyQueueEvent(
+        comment_id=str(comment.get("id") or comment.get("databaseId") or ""),
+        state=payload_state(payload, body),
+        queue_rule_name=payload_rule(payload, body),
+        queued_at=str(comment.get("updated_at") or comment.get("created_at") or ""),
+        head_sha=head_sha,
+        waiting_for=section_items(body, "Waiting for"),
+        failing_checks=failing_checks or reason_failed_checks(body),
+        comment_url=str(comment.get("html_url") or comment.get("url") or ""),
+        queue_pr_number=queue_pr_number,
+        failing_check_urls=failing_check_urls(body),
+        condition_states=all_condition_states(body),
+    )
+
+
+def parse_repair_stop_comment(comment: Mapping[str, object]) -> RepairStopComment | None:
+    author = comment.get("user") if isinstance(comment.get("user"), Mapping) else comment.get("author")
+    login = ""
+    if isinstance(author, Mapping):
+        login = str(author.get("login") or "")
+    elif isinstance(author, str):
+        login = author
+    body = str(comment.get("body") or "")
+    if not body.startswith("Mergify repair stopped: "):
+        return None
+    return RepairStopComment(
+        body=body,
+        updated_at=str(comment.get("updated_at") or comment.get("created_at") or comment.get("createdAt") or ""),
+        author_login=login,
+    )
+
+
+def parse_stack_metadata(comments: Sequence[Mapping[str, object]]) -> tuple[str, tuple[int, ...]] | None:
+    ordered = sorted(comments, key=lambda c: str(c.get("updated_at") or c.get("created_at") or ""), reverse=True)
+    for comment in ordered:
+        body = str(comment.get("body") or "")
+        match = STACK_MARKER_RE.search(body)
+        if not match:
+            continue
+        try:
+            payload = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            continue
+        stack_id = str(payload.get("stack_id") or payload.get("stackId") or payload.get("id") or "")
+        numbers = payload.get("pull_numbers_bottom_to_top") or payload.get("pullNumbersBottomToTop") or payload.get("prs") or payload.get("pulls")
+        if stack_id and isinstance(numbers, Sequence) and not isinstance(numbers, (str, bytes)):
+            try:
+                return stack_id, tuple(int(n) for n in numbers)
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def group_stack_prs(prs: Sequence[PrSnapshot], stack_metadata: Mapping[int, tuple[str, tuple[int, ...]]], trunk: str) -> tuple[StackGroup, ...]:
+    by_number = {pr.number: pr for pr in prs}
+    used: set[int] = set()
+    groups: list[StackGroup] = []
+    seen_meta: set[tuple[str, tuple[int, ...]]] = set()
+    for pr in prs:
+        meta = stack_metadata.get(pr.number)
+        if not meta or meta in seen_meta:
+            continue
+        seen_meta.add(meta)
+        stack_id, numbers = meta
+        present = tuple(by_number[n] for n in numbers if n in by_number)
+        for item in present:
+            used.add(item.number)
+        if present:
+            groups.append(StackGroup(stack_id=stack_id, prs=present))
+
+    remaining = [pr for pr in prs if pr.number not in used]
+    by_head = {pr.head_ref_name: pr for pr in remaining if pr.state == "OPEN" and pr.head_ref_name}
+    children_by_base: dict[str, list[PrSnapshot]] = {}
+    for pr in remaining:
+        children_by_base.setdefault(pr.base_ref_name, []).append(pr)
+
+    roots = [pr for pr in remaining if pr.base_ref_name == trunk or pr.base_ref_name not in by_head]
+    for root in sorted(roots, key=lambda p: p.number):
+        if root.number in used:
+            continue
+        stack = [root]
+        used.add(root.number)
+        top = root
+        while True:
+            children = [child for child in children_by_base.get(top.head_ref_name, []) if child.number not in used]
+            if len(children) != 1:
+                break
+            child = children[0]
+            stack.append(child)
+            used.add(child.number)
+            top = child
+        groups.append(StackGroup(stack_id="branch:" + str(stack[0].number), prs=tuple(stack)))
+
+    for pr in remaining:
+        if pr.number not in used:
+            groups.append(StackGroup(stack_id="single:" + str(pr.number), prs=(pr,)))
+    return tuple(groups)
+
+
+def labels_from_nodes(value: object) -> frozenset[str]:
+    if isinstance(value, Mapping):
+        nodes = value.get("nodes")
+    else:
+        nodes = value
+    labels: set[str] = set()
+    if isinstance(nodes, Sequence) and not isinstance(nodes, (str, bytes)):
+        for item in nodes:
+            if isinstance(item, Mapping):
+                name = item.get("name")
+            else:
+                name = item
+            if name:
+                labels.add(str(name))
+    return frozenset(labels)
+
+
+def review_threads(value: object) -> tuple[ReviewThread, ...]:
+    if not isinstance(value, Mapping):
+        return ()
+    page = value.get("pageInfo") if isinstance(value.get("pageInfo"), Mapping) else {}
+    if page.get("hasNextPage"):
+        return (ReviewThread("review-thread-pagination-not-implemented", False, ("human",)),)
+    threads: list[ReviewThread] = []
+    nodes = value.get("nodes") if isinstance(value.get("nodes"), Sequence) else []
+    for node in nodes:
+        if not isinstance(node, Mapping):
+            continue
+        authors: list[str] = []
+        comments = node.get("comments") if isinstance(node.get("comments"), Mapping) else {}
+        comment_nodes = comments.get("nodes") if isinstance(comments.get("nodes"), Sequence) else []
+        for comment in comment_nodes:
+            if not isinstance(comment, Mapping):
+                continue
+            author = comment.get("author") if isinstance(comment.get("author"), Mapping) else {}
+            login = author.get("login") if isinstance(author, Mapping) else None
+            if login:
+                authors.append(str(login))
+        threads.append(ReviewThread(
+            str(node.get("id") or ""),
+            bool(node.get("isResolved")),
+            tuple(authors),
+            bool(node.get("isOutdated")),
+        ))
+    return tuple(threads)
+
+
+def raw_contexts(pr: Mapping[str, object]) -> list[Mapping[str, object]]:
+    rollup = pr.get("statusCheckRollup")
+    contexts = rollup.get("contexts") if isinstance(rollup, Mapping) else {}
+    nodes = contexts.get("nodes") if isinstance(contexts, Mapping) else []
+    return [node for node in nodes if isinstance(node, Mapping)] if isinstance(nodes, list) else []
+
+
+def snapshot_from_detail(detail: Mapping[str, object], comments: Sequence[Mapping[str, object]], required_checks: Sequence[str]) -> PrSnapshot:
+    head = str(detail.get("headRefOid") or detail.get("head_ref_oid") or "")
+    events = [event for comment in comments for event in [parse_mergify_queue_event(comment)] if event]
+    events.sort(key=lambda event: event.queued_at, reverse=True)
+    stop_comments = [stop for comment in comments for stop in [parse_repair_stop_comment(comment)] if stop]
+    stop_comments.sort(key=lambda comment: comment.updated_at, reverse=True)
+    return PrSnapshot(
+        number=int(detail.get("number") or 0),
+        title=str(detail.get("title") or ""),
+        body=str(detail.get("body") or ""),
+        url=str(detail.get("url") or ""),
+        state=str(detail.get("state") or ""),
+        is_draft=bool(detail.get("isDraft") or detail.get("is_draft")),
+        base_ref_name=str(detail.get("baseRefName") or detail.get("base_ref_name") or ""),
+        head_ref_name=str(detail.get("headRefName") or detail.get("head_ref_name") or ""),
+        head_ref_oid=head,
+        merge_state_status=str(detail.get("mergeStateStatus") or detail.get("merge_state_status") or ""),
+        mergeable=str(detail.get("mergeable") or ""),
+        labels=labels_from_nodes(detail.get("labels")),
+        checks=latest_contexts_by_required_check(raw_contexts(detail), head, required_checks),
+        review_threads=review_threads(detail.get("reviewThreads")),
+        latest_mergify=events[0] if events else None,
+        repair_stop_comments=tuple(stop_comments),
+    )

--- a/packages/mergify-admin-requeue/package.json
+++ b/packages/mergify-admin-requeue/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@invoker/mergify-admin-requeue",
+  "private": true,
+  "scripts": {
+    "test": "cd ../.. && PYTHONPATH=packages/mergify-admin-requeue python3 -m unittest discover -s packages/mergify-admin-requeue/tests"
+  }
+}

--- a/packages/mergify-admin-requeue/tests/test_mergify_admin_requeue.py
+++ b/packages/mergify-admin-requeue/tests/test_mergify_admin_requeue.py
@@ -1,0 +1,974 @@
+import io
+import importlib
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import mergify_admin_requeue as requeue
+
+exec_impl = importlib.import_module("mergify_admin_requeue.exec")
+
+from mergify_admin_requeue import (
+    Action,
+    Blocker,
+    CheckContext,
+    Ledger,
+    MergifyQueueEvent,
+    PrSnapshot,
+    ReviewThread,
+    StackGroup,
+    classify_pr,
+    group_stack_prs,
+    REPO_ROOT,
+    latest_contexts_by_required_check,
+    load_mergify_rules,
+    parse_mergify_queue_event,
+    parse_stack_metadata,
+    plan_stack_actions,
+)
+from mergify_admin_requeue.gh_executor import ADMIN_BYPASS_NUDGE_LEDGER_KIND, AdminBypassGhExecutor
+from mergify_admin_requeue.model import LoadedStacks
+from mergify_admin_requeue.loader import AdminBypassStackLoader
+from mergify_admin_requeue.logger import AdminBypassLogger
+from mergify_admin_requeue.repairer import (
+    NON_TRUNK_MANUAL_SPLIT_ERROR,
+    NON_TRUNK_PREREQ_ERROR,
+    PROOF_POLICY_LANE_ERROR,
+    PROOF_TOOLING_POLICY_UNIT_ERROR,
+    AdminBypassRepairer,
+)
+
+REQUIRED = {"PR Body", "quality / TypeScript Types"}
+HEAD = "c2532d229dbed2fd57419698c48d973001c78e9e"
+OLD = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+
+def check(name, state="success", sha=HEAD):
+    return CheckContext(name, state, "https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/1/job/2", sha, "2026-07-03T00:00:00Z")
+
+
+def mergify(state="dequeued", comment_id="m1", sha=HEAD):
+    return MergifyQueueEvent(comment_id, state, "admin-bypass", "2026-07-03T00:00:00Z", sha, (), (), "https://example.invalid/comment")
+
+
+def pr(number, *, base="master", head=None, labels=None, checks=None, threads=(), latest=None, merge_state="CLEAN", mergeable="MERGEABLE", state="OPEN", draft=False, body=""):
+    return PrSnapshot(
+        number=number,
+        title=f"PR {number}",
+        body=body,
+        url=f"https://github.com/Neko-Catpital-Labs/Invoker/pull/{number}",
+        state=state,
+        is_draft=draft,
+        base_ref_name=base,
+        head_ref_name=head or f"stack/{number}",
+        head_ref_oid=HEAD,
+        merge_state_status=merge_state,
+        mergeable=mergeable,
+        labels=frozenset(labels if labels is not None else {"admin-bypass", "dequeued"}),
+        checks=checks if checks is not None else {name: check(name) for name in REQUIRED},
+        review_threads=tuple(threads),
+        latest_mergify=latest,
+    )
+
+PROOF_BODY = """## Summary
+
+Worker proof slice.
+
+## Review Claim
+
+Show the failing proof-only slice.
+
+## Review Lane
+
+- proof
+
+## Review Unit
+
+- proof
+
+## Safety Invariant
+
+Proof-only body.
+
+## Slice Rationale
+
+Keep proof separate.
+
+## Non-goals
+
+- No product behavior change.
+
+## Test Plan
+
+<details>
+<summary>Test Plan</summary>
+
+- [ ] `pnpm test`
+
+</details>
+
+## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
+
+- Safe to revert? Yes
+- Data migration? No
+
+</details>
+"""
+
+
+class MergifyAdminRequeueTests(unittest.TestCase):
+    def ledger(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        return Ledger(Path(tmp.name) / "ledger.jsonl")
+
+    def executor(self, gh, ledger, repo="owner/repo"):
+        return AdminBypassGhExecutor(gh, ledger, AdminBypassLogger(), repo)
+
+    def repairer(self, gh, ledger, repo="owner/repo"):
+        logger = AdminBypassLogger()
+        executor = AdminBypassGhExecutor(gh, ledger, logger, repo)
+        return AdminBypassRepairer(gh, executor, logger, ledger, repo)
+
+    def test_loads_admin_bypass_rule_from_mergify_yml(self):
+        trunk, labels, required = load_mergify_rules(Path(".mergify.yml"))
+        self.assertEqual(trunk, "master")
+        self.assertIn("admin-bypass", labels)
+        self.assertEqual(required, frozenset({
+            "build-artifacts",
+            "quality / Dependency Cruise",
+            "PR Body",
+            "quality / TypeScript Types",
+            "required-fast / Guardrails",
+            "required-fast / Submit Workflow Chain",
+            "UI Vitest",
+        }))
+
+    def test_loads_admin_bypass_rule_from_any_working_directory(self):
+        cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                os.chdir(tmp)
+                trunk, labels, required = load_mergify_rules(REPO_ROOT / ".mergify.yml")
+            finally:
+                os.chdir(cwd)
+        self.assertEqual(trunk, "master")
+        self.assertIn("admin-bypass", labels)
+        self.assertIn("PR Body", required)
+
+
+    def test_latest_contexts_ignores_old_sha_and_mergify_self_checks(self):
+        raw = [
+            {"__typename": "CheckRun", "name": "PR Body", "conclusion": "FAILURE", "status": "COMPLETED", "detailsUrl": "old", "completedAt": "2026-07-02T00:00:00Z", "checkSuite": {"commit": {"oid": OLD}}},
+            {"__typename": "CheckRun", "name": "PR Body", "conclusion": "SUCCESS", "status": "COMPLETED", "detailsUrl": "new", "completedAt": "2026-07-03T00:00:00Z", "checkSuite": {"commit": {"oid": HEAD}}},
+            {"__typename": "CheckRun", "name": "Rule: autoqueue admin-bypass PRs to master", "conclusion": "FAILURE", "status": "COMPLETED", "detailsUrl": "bad", "completedAt": "2026-07-03T00:00:00Z", "checkSuite": {"commit": {"oid": HEAD}}},
+        ]
+        latest = latest_contexts_by_required_check(raw, HEAD, {"PR Body", "Rule: autoqueue admin-bypass PRs to master"})
+        self.assertEqual(set(latest), {"PR Body"})
+        self.assertEqual(latest["PR Body"].state, "success")
+        self.assertEqual(latest["PR Body"].details_url, "new")
+
+    def test_parses_latest_mergify_dequeued_event(self):
+        comment = {
+            "id": 123,
+            "user": {"login": "mergify[bot]"},
+            "updated_at": "2026-07-03T00:00:00Z",
+            "html_url": "https://github.invalid/comment/123",
+            "body": """
+Left the queue `admin-bypass` at `c2532d229dbed2fd57419698c48d973001c78e9e`.
+-*- Mergify Payload -*-
+{"state":"dequeued","queue_rule_name":"admin-bypass"}
+
+Waiting for
+- PR Body
+
+Failing checks
+- quality / TypeScript Types
+""",
+        }
+        event = parse_mergify_queue_event(comment)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.state, "dequeued")
+        self.assertEqual(event.queue_rule_name, "admin-bypass")
+        self.assertEqual(event.failing_checks, ("quality / TypeScript Types",))
+        self.assertEqual(event.waiting_for, ("PR Body",))
+        self.assertEqual(event.head_sha, HEAD)
+
+    def test_stack_metadata_orders_bottom_to_top(self):
+        comments = [{"created_at": "2026-07-03T00:00:00Z", "body": '<!-- mergify-stack-data: {"stack_id":"s1","pull_numbers_bottom_to_top":[2604,2605,2601]} -->'}]
+        self.assertEqual(parse_stack_metadata(comments), ("s1", (2604, 2605, 2601)))
+
+    def test_whole_stack_requeues_only_current_bottom(self):
+        stack = StackGroup("s", (pr(2604, head="stack/a", latest=mergify()), pr(2605, base="stack/a", head="stack/b"), pr(2601, base="stack/b")))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("requeue", 2604)])
+
+    def test_labeled_upper_stack_member_allows_unlabeled_bottom_nudge(self):
+        snapshots = [
+            pr(2605, base="stack/a", head="stack/b", labels={"admin-bypass", "dequeued"}),
+            pr(2604, head="stack/a", labels={"dequeued"}, latest=mergify()),
+        ]
+        meta = {2604: ("s", (2604, 2605)), 2605: ("s", (2604, 2605))}
+        groups = group_stack_prs(snapshots, meta, "master")
+        self.assertEqual([tuple(item.number for item in group.prs) for group in groups], [(2604, 2605)])
+        actions = plan_stack_actions(groups[0], REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("comment_admin_bypass_nudge", 2604)])
+
+    def test_upper_stack_blocker_stops_bottom_requeue(self):
+        failed = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        stack = StackGroup("s", (pr(2604, head="stack/a", latest=mergify()), pr(2605, base="stack/a", checks=failed)))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("repair_check", 2605)])
+        thread_stack = StackGroup("s", (pr(2604, head="stack/a", latest=mergify()), pr(2605, base="stack/a", threads=(ReviewThread("t1", False, ("alice",)),))))
+        actions = plan_stack_actions(thread_stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2605, "unresolved human review thread t1")])
+    def test_unaccepted_upper_failed_check_repairs_upper_before_bottom(self):
+        failed = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        stack = StackGroup(
+            "s",
+            (
+                pr(2604, head="stack/a", latest=mergify()),
+                pr(2605, base="stack/a", labels={"dequeued"}, checks=failed),
+            ),
+        )
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 2605, "PR Body")])
+
+    def test_unaccepted_upper_without_blockers_waits_instead_of_requeueing_bottom(self):
+        stack = StackGroup(
+            "s",
+            (
+                pr(2604, head="stack/a", latest=mergify()),
+                pr(2605, base="stack/a", labels={"dequeued"}),
+            ),
+        )
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual(actions, ())
+
+    def test_missing_admin_bypass_label_on_current_bottom_nudges_human_first(self):
+        stack = StackGroup("s", (pr(2604, labels={"dequeued"}, latest=mergify()),))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("comment_admin_bypass_nudge", 2604)])
+
+    def test_dequeued_green_same_sha_requeues_once(self):
+        stack = StackGroup("s", (pr(2605, latest=mergify(sha=HEAD)),))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("requeue", 2605, "m1")])
+
+    def test_requeue_same_dequeue_event_hits_cap(self):
+        ledger = self.ledger()
+        ledger.record("requeue", 2605, HEAD, "m1", 1)
+        ledger.record("requeue", 2605, HEAD, "m1", 2)
+        stack = StackGroup("s", (pr(2605, latest=mergify(comment_id="m1")),))
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 3)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("comment_blocked", 2605, "capped")])
+
+    def test_failed_check_repairs_before_requeue(self):
+        checks = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        stack = StackGroup("s", (pr(2606, checks=checks, latest=mergify()),))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 2606, "PR Body")])
+
+    def test_failed_check_at_cap_gets_one_more_attempt_until_evaluated(self):
+        checks = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        stack = StackGroup("s", (pr(2606, checks=checks, latest=mergify()),))
+        ledger = self.ledger()
+        for epoch in range(3):
+            ledger.record("repair-check", 2606, HEAD, "PR Body", epoch)
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 4)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 2606, "PR Body")])
+        ledger.record("repair-evaluated", 2606, HEAD, "PR Body", 4)
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 5)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("comment_blocked", 2606, "capped")])
+
+    def test_pending_check_waits(self):
+        checks = {"PR Body": check("PR Body", "pending"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        stack = StackGroup("s", (pr(2606, checks=checks, latest=mergify()),))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual(actions, ())
+
+    def test_merge_hold_removed_only_when_sole_blocker(self):
+        stack = StackGroup("s", (pr(2606, labels={"admin-bypass", "merge-hold", "dequeued"}, latest=mergify()),))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("remove_merge_hold", 2606)])
+        checks = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        stack = StackGroup("s", (pr(2606, labels={"admin-bypass", "merge-hold", "dequeued"}, checks=checks, latest=mergify()),))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.key) for a in actions], [("repair_check", "PR Body")])
+
+    def test_human_review_thread_blocks(self):
+        stack = StackGroup("s", (pr(2607, threads=(ReviewThread("t1", False, ("alice",)),), latest=mergify()),))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.detail) for a in actions], [("comment_blocked", "unresolved human review thread t1")])
+
+    def test_bot_thread_repairs_then_resolves(self):
+        stack = StackGroup("s", (pr(2608, threads=(ReviewThread("tbot", False, ("coderabbitai[bot]",)),), latest=mergify()),))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.key) for a in actions], [("repair_check", "bot_review_thread:tbot")])
+        ledger = self.ledger()
+        ledger.record("repair-bot-thread", 2608, OLD, "tbot", 1)
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 2)
+        self.assertEqual([(a.kind, a.key) for a in actions], [("resolve_bot_threads", "tbot")])
+
+    def test_outdated_bot_thread_resolves_without_repair(self):
+        stack = StackGroup("s", (pr(2608, threads=(ReviewThread("tbot", False, ("coderabbitai[bot]",), True),), latest=mergify()),))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.key) for a in actions], [("resolve_bot_threads", "tbot")])
+
+    def test_conflict_uses_claude_repair_cap(self):
+        stack = StackGroup("s", (pr(2609, merge_state="DIRTY", latest=mergify()),))
+        ledger = self.ledger()
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 1)
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("repair_conflict", 2609)])
+        for epoch in range(3):
+            ledger.record("conflict-repair", 2609, HEAD, "conflict:2609", epoch)
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 4)
+        self.assertEqual([(a.kind, a.key) for a in actions], [("comment_blocked", "capped")])
+
+    def test_conflict_repair_records_and_caps_without_invoker(self):
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+        ledger = self.ledger()
+        item = pr(2647, merge_state="DIRTY", latest=mergify())
+        repairs = []
+        repairer = self.repairer(FakeGh(), ledger, "Neko-Catpital-Labs/Invoker")
+        with mock.patch("mergify_admin_requeue.repairer.checkout_pr_head"):
+            with mock.patch.object(repairer, "run_claude_repair", side_effect=lambda _work_root, _prompt: repairs.append(item.number)):
+                for epoch in range(3):
+                    ledger.record("conflict-repair", item.number, item.head_ref_oid, "conflict:2647", epoch)
+                    repairer.repair_conflict(item, "GitHub reports merge conflict")
+        self.assertEqual(ledger.count("conflict-repair", 2647, HEAD, "conflict:2647"), 3)
+        self.assertEqual(repairs, [2647, 2647, 2647])
+        actions = plan_stack_actions(StackGroup("s", (item,)), REQUIRED, ledger, 4)
+        self.assertEqual([(a.kind, a.key) for a in actions], [("comment_blocked", "capped")])
+
+    def test_claude_repair_uses_claude_cli(self):
+        repairer = self.repairer(object(), self.ledger())
+        with mock.patch("mergify_admin_requeue.repairer.subprocess.run") as run:
+            repairer.run_claude_repair(Path("/tmp/work"), "repair this")
+        run.assert_called_once_with(
+            ["claude", "-p", "repair this", "--dangerously-skip-permissions"],
+            cwd="/tmp/work",
+            check=True,
+            text=True,
+        )
+
+    def test_candidate_stack_includes_unlabeled_upper_prs(self):
+        def raw(number, base, head, labels):
+            return {
+                "number": number,
+                "title": f"PR {number}",
+                "body": "",
+                "url": f"https://example.invalid/{number}",
+                "state": "OPEN",
+                "isDraft": False,
+                "baseRefName": base,
+                "headRefName": head,
+                "headRefOid": HEAD,
+                "mergeStateStatus": "CLEAN",
+                "mergeable": "MERGEABLE",
+                "labels": {"nodes": [{"name": label} for label in labels]},
+                "reviewThreads": {"pageInfo": {"hasNextPage": False}, "nodes": []},
+                "statusCheckRollup": {"contexts": {"nodes": []}},
+            }
+
+        bottom = raw(1, "master", "stack/one", {"admin-bypass"})
+        upper = raw(2, "stack/one", "stack/two", set())
+
+        class FakeGh:
+            def list_candidate_prs(self, repo, author, pr_numbers):
+                return [bottom]
+
+            def list_open_prs(self, repo):
+                return [bottom, upper]
+
+            def issue_comments(self, repo, number):
+                return []
+
+        loaded = AdminBypassStackLoader(FakeGh()).load("owner/repo", None, [], REQUIRED, "master")
+        self.assertEqual(len(loaded.stacks), 1)
+        self.assertEqual([item.number for item in loaded.stacks[0].prs], [1, 2])
+
+    def test_repair_check_logs_work_context(self):
+        stderr = io.StringIO()
+        item = pr(2647, latest=mergify())
+        repairer = self.repairer(object(), self.ledger())
+        git_rev_parse = iter([HEAD, HEAD])
+        with mock.patch("mergify_admin_requeue.repairer.checkout_pr_head") as checkout:
+            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
+                with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
+                    with mock.patch.object(repairer, "git_lines", return_value=()):
+                        with mock.patch.object(repairer, "run_claude_repair") as repair:
+                            with mock.patch.object(repairer, "validate_current_pr_body", return_value={"valid": True, "errors": []}):
+                                with redirect_stderr(stderr):
+                                    result = repairer.repair_check(item, "PR Body")
+        checkout.assert_called_once()
+        repair.assert_called_once()
+        self.assertEqual(result.status, "noop")
+        self.assertIn("Commit locally if needed, do not push.", repair.call_args.args[1])
+        log = stderr.getvalue()
+        self.assertIn('"event": "admin-bypass-repair-check-start"', log)
+        self.assertIn('"check_name": "PR Body"', log)
+        self.assertIn('"log_path": "/tmp/pr-body.log"', log)
+        self.assertIn('"pr_number": 2647', log)
+
+
+    def test_repair_check_noop_invalid_non_trunk_blocks_human_split(self):
+        item = pr(
+            5803,
+            base="stack/base",
+            body="## Summary\n\nMixed slice.\n",
+            checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")},
+        )
+        repairer = self.repairer(object(), self.ledger())
+        git_rev_parse = iter([HEAD, HEAD])
+        validation = {
+            "valid": False,
+            "errors": [
+                "PR body mentions multiple review units (validation-policy, routing); split into one conceptual unit per diff/task.",
+                "Review lane behavior cannot ship with policy, proof files in the same PR. Split behavior or cleanup from docs, policy, repro, and benchmark slices.",
+                'PR body Review Unit \"routing\" cannot ship with tooling-policy, proof files in the same PR. Split this into one Review Unit per PR.',
+            ],
+            "reviewLane": "behavior",
+            "reviewUnit": "routing",
+            "reviewUnits": ["routing", "tooling-policy", "proof"],
+            "scopeKinds": ["product", "policy"],
+        }
+        with mock.patch("mergify_admin_requeue.repairer.checkout_pr_head"):
+            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
+                with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
+                    with mock.patch.object(repairer, "git_lines", return_value=()):
+                        with mock.patch.object(repairer, "run_claude_repair"):
+                            with mock.patch.object(repairer, "validate_current_pr_body", return_value=validation):
+                                result = repairer.repair_check(item, "PR Body")
+        self.assertEqual(result.status, "blocked_invalid")
+        self.assertIn(NON_TRUNK_MANUAL_SPLIT_ERROR, result.errors)
+
+    def test_plan_stack_actions_stop_retrying_after_repair_invalid(self):
+        ledger = self.ledger()
+        ledger.record("repair-invalid", 2606, HEAD, "PR Body", 1, meta={"errors": ["human stack split required"]})
+        stack = StackGroup("s", (pr(2606, labels={"admin-bypass"}, checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}),))
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 2)
+        self.assertEqual(actions, ())
+    def test_queue_only_repair_uses_mergify_job_log_and_returns_noop(self):
+        stderr = io.StringIO()
+        latest = MergifyQueueEvent(
+            "m5811",
+            "dequeued",
+            "admin-bypass",
+            "2026-07-03T06:13:00Z",
+            HEAD,
+            (),
+            ("required-fast / Guardrails",),
+            "https://github.com/Neko-Catpital-Labs/Invoker/pull/5811#issuecomment-1",
+            5854,
+            (("required-fast / Guardrails", ("https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/1/job/2",)),),
+        )
+        item = pr(5811, labels={"admin-bypass", "dequeued"}, checks={}, latest=latest)
+        repairer = self.repairer(object(), self.ledger())
+        git_rev_parse = iter([HEAD, HEAD])
+        with mock.patch("mergify_admin_requeue.repairer.checkout_pr_head") as checkout:
+            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
+                with mock.patch.object(repairer, "job_log_has_evidence", return_value=True):
+                    with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
+                        with mock.patch.object(repairer, "git_lines", return_value=()):
+                            with mock.patch.object(repairer, "run_claude_repair") as repair:
+                                with redirect_stderr(stderr):
+                                    result = repairer.repair_check(item, "required-fast / Guardrails")
+        checkout.assert_called_once()
+        repair.assert_called_once()
+        self.assertEqual(result.status, "queue_only_noop")
+        self.assertIn("Queue draft PR: #5854", repair.call_args.args[1])
+        self.assertIn("Job log path: /tmp/guardrails.log", repair.call_args.args[1])
+
+    def test_queue_only_repair_empty_job_log_returns_noop_without_claude(self):
+        latest = MergifyQueueEvent(
+            "m5811",
+            "dequeued",
+            "admin-bypass",
+            "2026-07-03T06:13:00Z",
+            HEAD,
+            (),
+            ("required-fast / Guardrails",),
+            "https://github.com/Neko-Catpital-Labs/Invoker/pull/5811#issuecomment-1",
+            5854,
+            (("required-fast / Guardrails", ("https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/1/job/2",)),),
+        )
+        item = pr(5811, labels={"dequeued"}, checks={}, latest=latest)
+        repairer = self.repairer(object(), self.ledger())
+        with mock.patch("mergify_admin_requeue.repairer.checkout_pr_head") as checkout:
+            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
+                with mock.patch.object(repairer, "job_log_has_evidence", return_value=False):
+                    with mock.patch.object(repairer, "git_output", return_value=HEAD):
+                        with mock.patch.object(repairer, "run_claude_repair") as repair:
+                            result = repairer.repair_check(item, "required-fast / Guardrails")
+        checkout.assert_called_once()
+        repair.assert_not_called()
+        self.assertEqual(result.status, "queue_only_noop")
+
+    def test_pr_body_valid_local_repair_returns_noop_without_claude(self):
+        item = pr(5810, checks={"PR Body": check("PR Body", "failure")}, body=PROOF_BODY)
+        repairer = self.repairer(object(), self.ledger())
+        with mock.patch("mergify_admin_requeue.repairer.checkout_pr_head") as checkout:
+            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log") as download:
+                with mock.patch.object(repairer, "job_log_is_empty", return_value=True):
+                    with mock.patch.object(repairer, "git_output", return_value=HEAD):
+                        with mock.patch.object(repairer, "validate_current_pr_body", return_value={"valid": True}):
+                            with mock.patch.object(repairer, "run_claude_repair") as repair:
+                                result = repairer.repair_check(item, "PR Body")
+        checkout.assert_called_once()
+        download.assert_called_once()
+        repair.assert_not_called()
+        self.assertEqual(result.status, "noop")
+    def test_run_cycle_logs_selected_bottom_repair_context(self):
+        args = requeue.parse_args(["--once", "--dry-run", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
+        stack = StackGroup("s", (pr(2606, checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}, latest=mergify()),))
+        stderr = io.StringIO()
+        stdout = io.StringIO()
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=object()):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
+                    with redirect_stdout(stdout), redirect_stderr(stderr):
+                        should_poll = exec_impl.run_cycle(args)
+        self.assertFalse(should_poll)
+        log = stderr.getvalue()
+        self.assertIn('"event": "admin-bypass-stack"', log)
+        self.assertIn('"event": "admin-bypass-stack-actions"', log)
+        self.assertIn('"kind": "repair_check"', log)
+        self.assertIn('"failed_check"', log)
+        self.assertIn('"pr_number": 2606', log)
+
+    def test_run_cycle_logs_wait_reason_for_unaccepted_upper_stack(self):
+        args = requeue.parse_args(["--once", "--dry-run", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
+        stack = StackGroup("s", (pr(2604, head="stack/a", latest=mergify()), pr(2605, base="stack/a", labels={"dequeued"})))
+        stderr = io.StringIO()
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=object()):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
+                    with redirect_stderr(stderr):
+                        should_poll = exec_impl.run_cycle(args)
+        self.assertTrue(should_poll)
+        log = stderr.getvalue()
+        self.assertIn('"event": "admin-bypass-stack-wait"', log)
+        self.assertIn('"reason": "upper-stack-needs-acceptance"', log)
+        self.assertIn('"upper_stack_needs_acceptance": true', log)
+
+    def test_repair_check_splits_tooling_policy_prerequisite(self):
+        class FakeGh:
+            def __init__(self):
+                self.created = []
+                self.label_edits = []
+                self.comments = []
+
+            def create_pr(self, repo, title, body, head, base):
+                self.created.append((repo, title, body, head, base))
+                return {"number": 5801}
+
+            def edit_label(self, repo, pr_number, *, add=None, remove=None):
+                self.label_edits.append((repo, pr_number, add, remove))
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+        item = pr(
+            5800,
+            latest=mergify(),
+            body=PROOF_BODY,
+            checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")},
+        )
+        ledger = self.ledger()
+        fake = FakeGh()
+        repairer = self.repairer(fake, ledger)
+        rev_parse = iter([HEAD, "b" * 40])
+        git_commands = []
+
+        def fake_git_output(_work_root, *args):
+            git_commands.append(args)
+            if args == ("rev-parse", "HEAD"):
+                return next(rev_parse)
+            return ""
+
+        def fake_git_lines(_work_root, *args):
+            if args == ("status", "--porcelain"):
+                return ()
+            if args == ("rev-list", "--reverse", f"{HEAD}..{'b' * 40}"):
+                return ("commit-a",)
+            return ()
+
+        validator_results = iter([
+            {
+                "valid": False,
+                "errors": [
+                    PROOF_POLICY_LANE_ERROR,
+                    PROOF_TOOLING_POLICY_UNIT_ERROR,
+                ],
+                "reviewLane": "proof",
+                "reviewUnit": "proof",
+                "reviewUnits": ["tooling-policy"],
+                "scopeKinds": ["policy"],
+            },
+            {
+                "valid": True,
+                "errors": [],
+                "reviewLane": "policy",
+                "reviewUnit": "tooling-policy",
+                "reviewUnits": ["tooling-policy"],
+                "scopeKinds": ["policy"],
+            },
+        ])
+
+        with mock.patch("mergify_admin_requeue.repairer.checkout_pr_head"):
+            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
+                with mock.patch.object(repairer, "run_claude_repair"):
+                    with mock.patch.object(repairer, "git_output", side_effect=fake_git_output):
+                        with mock.patch.object(repairer, "git_lines", side_effect=fake_git_lines):
+                            with mock.patch.object(repairer, "validate_local_pr_body", side_effect=lambda *_args: next(validator_results)):
+                                result = repairer.repair_check(item, "PR Body", 123)
+
+        self.assertEqual(result.status, "prereq_created")
+        self.assertEqual(fake.created[0][0], "owner/repo")
+        self.assertIn("[PR babysit] Tooling-policy repair prerequisite for #5800: PR Body", fake.created[0][1])
+        self.assertEqual(fake.label_edits, [("owner/repo", 5801, "admin-bypass", None)])
+        latest = ledger.latest("repair-prereq-created", 5800, HEAD, "PR Body")
+        self.assertIsNotNone(latest)
+        self.assertEqual(latest["meta"]["prNumber"], 5801)
+        self.assertIn(("checkout", "-B", "stack/pr-babysit-prereq-5800-c2532d2", "origin/master"), git_commands)
+        self.assertIn(("checkout", "-B", item.head_ref_name, HEAD), git_commands)
+        self.assertIn(("reset", "--hard", HEAD), git_commands)
+        self.assertEqual(fake.comments, [])
+
+    def test_run_cycle_waits_while_prerequisite_pr_is_open(self):
+        ledger = self.ledger()
+        args = requeue.parse_args(["--once", "--dry-run", "--repo", "owner/repo", "--state-file", str(ledger.path)])
+        ledger.record("repair-prereq-created", 2604, HEAD, "PR Body", 1, meta={"prNumber": 2999, "branch": "stack/pr-babysit-prereq-2604-c2532d2"})
+        original = StackGroup("orig", (pr(2604, latest=mergify(), checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}),))
+        prereq = StackGroup("prereq", (pr(2999, latest=mergify(state="queued")),))
+        stderr = io.StringIO()
+        stdout = io.StringIO()
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=object()):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(original, prereq), open_pr_numbers_by_head={})):
+                    with redirect_stdout(stdout), redirect_stderr(stderr):
+                        should_poll = exec_impl.run_cycle(args)
+        self.assertTrue(should_poll)
+        self.assertNotIn("repair-check PR #2604", stdout.getvalue())
+        log = stderr.getvalue()
+        self.assertIn('"event": "admin-bypass-repair-prereq-wait"', log)
+        self.assertIn('"reason": "repair-prereq-open"', log)
+
+    def test_run_cycle_requeues_once_after_prerequisite_pr_closes(self):
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+        ledger = self.ledger()
+        ledger.record("repair-prereq-created", 2604, HEAD, "PR Body", 1, meta={"prNumber": 2999, "branch": "stack/pr-babysit-prereq-2604-c2532d2"})
+        stack = StackGroup("orig", (pr(2604, latest=mergify(), checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}),))
+        stderr = io.StringIO()
+        stdout = io.StringIO()
+        fake_gh = FakeGh()
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=fake_gh):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
+                    with redirect_stdout(stdout), redirect_stderr(stderr):
+                        should_poll = exec_impl.run_cycle(requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(ledger.path)]))
+        self.assertTrue(should_poll)
+        self.assertIn(("owner/repo", 2604, "@mergifyio queue"), fake_gh.comments)
+        refreshed = Ledger(ledger.path)
+        self.assertEqual(refreshed.count("repair-prereq-requeue", 2604, HEAD, "PR Body"), 1)
+        self.assertIn("requeue PR #2604", stdout.getvalue())
+        self.assertIn("eligible-after-dequeue", stdout.getvalue())
+
+    def test_run_cycle_restores_label_then_requeues_after_queue_only_noop(self):
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+                self.label_edits = []
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+            def edit_label(self, repo, pr_number, *, add=None, remove=None):
+                self.label_edits.append((repo, pr_number, add, remove))
+
+        ledger = self.ledger()
+        ledger.record("queue-only-noop", 5811, HEAD, "required-fast / Guardrails", 1)
+        latest = MergifyQueueEvent(
+            "m5811",
+            "dequeued",
+            "admin-bypass",
+            "2026-07-03T06:13:00Z",
+            HEAD,
+            (),
+            ("required-fast / Guardrails",),
+            "https://github.com/Neko-Catpital-Labs/Invoker/pull/5811#issuecomment-1",
+            5854,
+            (("required-fast / Guardrails", ("https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/1/job/2",)),),
+        )
+        fake_gh = FakeGh()
+        stderr = io.StringIO()
+        stdout = io.StringIO()
+        first_stack = StackGroup("orig", (pr(5811, labels={"dequeued"}, checks={}, latest=latest),))
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), {"required-fast / Guardrails"})):
+            with mock.patch.object(exec_impl, "GhClient", return_value=fake_gh):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(first_stack,), open_pr_numbers_by_head={})):
+                    with redirect_stdout(stdout), redirect_stderr(stderr):
+                        should_poll = exec_impl.run_cycle(requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(ledger.path)]))
+        self.assertTrue(should_poll)
+        self.assertEqual(fake_gh.label_edits, [("owner/repo", 5811, "admin-bypass", None)])
+        self.assertNotIn("BLOCK PR #5811 missing-check", stdout.getvalue())
+
+        second_stack = StackGroup("orig", (pr(5811, labels={"admin-bypass", "dequeued"}, checks={}, latest=latest),))
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), {"required-fast / Guardrails"})):
+            with mock.patch.object(exec_impl, "GhClient", return_value=fake_gh):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(second_stack,), open_pr_numbers_by_head={})):
+                    with redirect_stdout(stdout), redirect_stderr(stderr):
+                        should_poll = exec_impl.run_cycle(requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(ledger.path)]))
+        self.assertTrue(should_poll)
+        self.assertIn(("owner/repo", 5811, "@mergifyio queue"), fake_gh.comments)
+        refreshed = Ledger(ledger.path)
+        self.assertEqual(refreshed.count("queue-only-requeue", 5811, HEAD, "required-fast / Guardrails"), 1)
+
+    def test_run_cycle_stops_suppressing_after_prereq_requeue(self):
+        ledger = self.ledger()
+        args = requeue.parse_args(["--once", "--dry-run", "--repo", "owner/repo", "--state-file", str(ledger.path)])
+        ledger.record("repair-prereq-created", 2604, HEAD, "PR Body", 1, meta={"prNumber": 2999, "branch": "stack/pr-babysit-prereq-2604-c2532d2"})
+        ledger.record("repair-prereq-requeue", 2604, HEAD, "PR Body", 2)
+        stack = StackGroup("orig", (pr(2604, latest=mergify(), checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}),))
+        stderr = io.StringIO()
+        stdout = io.StringIO()
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=object()):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
+                    with redirect_stdout(stdout), redirect_stderr(stderr):
+                        should_poll = exec_impl.run_cycle(args)
+        self.assertFalse(should_poll)
+        self.assertIn('DRY-RUN repair-check PR #2604 check="PR Body"', stdout.getvalue())
+        self.assertNotIn("requeue PR #2604", stdout.getvalue())
+
+    def test_loop_rescans_after_action_then_stops(self):
+        args = requeue.parse_args(["--loop", "--poll-seconds", "0"])
+        with mock.patch.object(exec_impl, "run_cycle", side_effect=[True, False]) as cycle:
+            with mock.patch.object(exec_impl.time, "sleep") as sleep:
+                self.assertEqual(requeue.run_loop(args), 0)
+        self.assertEqual(cycle.call_count, 2)
+        sleep.assert_called_once_with(0.0)
+
+    def test_capped_comment_records_once(self):
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+        ledger = self.ledger()
+        item = pr(2647, merge_state="DIRTY", latest=mergify())
+        action = Action("comment_blocked", 2647, "capped", "GitHub reports merge conflict. The retry cap was reached for current head " + HEAD + ".")
+        fake = FakeGh()
+        executor = self.executor(fake, ledger, "Neko-Catpital-Labs/Invoker")
+        executor.execute(action, item, 1)
+        executor.execute(action, item, 2)
+        self.assertEqual(len(fake.comments), 1)
+
+    def test_retarget_base_executes_once_and_records_ledger(self):
+        class FakeGh:
+            def __init__(self):
+                self.retargets = []
+
+            def retarget_base(self, repo, pr_number, base):
+                self.retargets.append((repo, pr_number, base))
+
+        ledger = self.ledger()
+        item = pr(5811, base="pr/babysit-prereq-split", labels={"admin-bypass"}, latest=mergify())
+        action = Action("retarget_base", 5811, "master", "retarget stack root from `pr/babysit-prereq-split` to `master`")
+        fake = FakeGh()
+        executor = self.executor(fake, ledger, "owner/repo")
+        executor.execute(action, item, 1)
+        self.assertEqual(fake.retargets, [("owner/repo", 5811, "master")])
+        self.assertEqual(ledger.count("retarget-base", 5811, HEAD, "pr/babysit-prereq-split->master"), 1)
+
+    def test_human_blocker_comment_records_once(self):
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+            def issue_comments(self, repo, pr_number):
+                return [{"body": body} for _repo, _pr_number, body in self.comments]
+
+        ledger = self.ledger()
+        item = pr(2647)
+        action = Action("comment_blocked", 2647, "no-current-bottom", "no current bottom on master: lowest open stack PR #2647 is based on `feature/base`, not `master`; land or retarget that base before babysitting can queue this stack")
+        fake = FakeGh()
+        executor = self.executor(fake, ledger, "Neko-Catpital-Labs/Invoker")
+        executor.execute(action, item, 1)
+        executor.execute(action, item, 2)
+        self.assertEqual(len(fake.comments), 1)
+        self.assertIn("lowest open stack PR #2647", fake.comments[0][2])
+        self.assertEqual(ledger.count("comment-blocked", 2647, HEAD, "no-current-bottom"), 1)
+
+    def test_no_current_bottom_upgrades_legacy_generic_comment_once(self):
+        class FakeGh:
+            def __init__(self):
+                self.comments = [{
+                    "body": "Mergify repair stopped: no current bottom on master",
+                }]
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append({"body": body})
+
+            def issue_comments(self, repo, pr_number):
+                return list(self.comments)
+
+        ledger = self.ledger()
+        ledger.record("comment-blocked", 2647, HEAD, "no-current-bottom", 1)
+        item = pr(2647)
+        detail = "no current bottom on master: lowest open stack PR #2647 is based on `feature/base`, not `master`; land or retarget that base before babysitting can queue this stack"
+        action = Action("comment_blocked", 2647, "no-current-bottom", detail)
+        fake = FakeGh()
+        executor = self.executor(fake, ledger, "Neko-Catpital-Labs/Invoker")
+        executor.execute(action, item, 2)
+        executor.execute(action, item, 3)
+        self.assertEqual([comment["body"] for comment in fake.comments].count(f"Mergify repair stopped: {detail}"), 1)
+        self.assertEqual(ledger.count("comment-blocked", 2647, HEAD, "no-current-bottom:exact"), 1)
+
+    def test_human_block_comment_records_once_then_waits(self):
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+        ledger = self.ledger()
+        item = pr(5885, threads=(ReviewThread("PRRT_kwDOSFkSDM6T5EJA", False, ("reviewer",)),), latest=mergify())
+        stack = StackGroup("s", (item,))
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 1)
+        self.assertEqual(
+            [(a.kind, a.key, a.detail) for a in actions],
+            [("comment_blocked", "PRRT_kwDOSFkSDM6T5EJA", "unresolved human review thread PRRT_kwDOSFkSDM6T5EJA")],
+        )
+        fake = FakeGh()
+        executor = self.executor(fake, ledger, "Neko-Catpital-Labs/Invoker")
+        executor.execute(actions[0], item, 1)
+        executor.execute(actions[0], item, 2)
+        self.assertEqual(len(fake.comments), 1)
+        self.assertIn("unresolved human review thread PRRT_kwDOSFkSDM6T5EJA", fake.comments[0][2])
+        self.assertEqual(ledger.count("comment-blocked", 5885, HEAD, "PRRT_kwDOSFkSDM6T5EJA"), 1)
+        self.assertEqual(plan_stack_actions(stack, REQUIRED, ledger, 3), ())
+
+    def test_missing_admin_bypass_nudge_comments_once_without_label_edit(self):
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+                self.label_edits = []
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+            def edit_label(self, repo, pr_number, *, add=None, remove=None):
+                self.label_edits.append((repo, pr_number, add, remove))
+
+        action = Action("comment_admin_bypass_nudge", 2647, "admin-bypass", "missing admin-bypass label")
+        ledger = self.ledger()
+        item = pr(2647, labels={"dequeued"}, latest=mergify())
+        fake = FakeGh()
+        executor = self.executor(fake, ledger, "Neko-Catpital-Labs/Invoker")
+        executor.execute(action, item, 1)
+        executor.execute(action, item, 2)
+        self.assertEqual(len(fake.comments), 1)
+        self.assertIn("tag this PR with `admin-bypass`", fake.comments[0][2])
+        self.assertEqual(fake.label_edits, [])
+        self.assertEqual(ledger.count(ADMIN_BYPASS_NUDGE_LEDGER_KIND, 2647, HEAD, "admin-bypass"), 1)
+
+    def test_restore_admin_bypass_label_edits_once_per_head(self):
+        class FakeGh:
+            def __init__(self):
+                self.label_edits = []
+
+            def edit_label(self, repo, pr_number, *, add=None, remove=None):
+                self.label_edits.append((repo, pr_number, add, remove))
+
+        action = Action("restore_admin_bypass_label", 5811, "required-fast / Guardrails", "restore admin-bypass label after queue-only noop")
+        ledger = self.ledger()
+        item = pr(5811, labels={"dequeued"}, latest=mergify())
+        fake = FakeGh()
+        executor = self.executor(fake, ledger, "owner/repo")
+        executor.execute(action, item, 1)
+        executor.execute(action, item, 2)
+        self.assertEqual(fake.label_edits, [("owner/repo", 5811, "admin-bypass", None)])
+        self.assertEqual(ledger.count("restore-admin-bypass-label", 5811, HEAD, "admin-bypass"), 1)
+
+    def test_mergify_queue_failure_repairs_even_when_current_required_check_is_missing(self):
+        latest = MergifyQueueEvent(
+            "m2969",
+            "dequeued",
+            "admin-bypass",
+            "2026-07-03T06:13:00Z",
+            HEAD,
+            ("e2e-proof / aggregate",),
+            ("PR Body",),
+            "https://github.com/Neko-Catpital-Labs/Invoker/pull/2969#issuecomment-4872966494",
+            2985,
+            (("PR Body", ("https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/28641642476/job/84938961337",)),),
+            (("optional / Visual Proof Validate", "success"), ("PR Body", "success")),
+        )
+        checks = {"PR Body": check("PR Body"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        stack = StackGroup("s", (pr(2969, checks=checks, latest=latest),))
+        actions = plan_stack_actions(stack, REQUIRED | {"optional / Visual Proof Validate"}, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number, a.key, a.detail) for a in actions], [("repair_check", 2969, "PR Body", "Mergify queue check failed: PR Body")])
+
+    def test_mergify_reason_failure_repairs_without_failing_checks_section(self):
+        comment = {
+            "id": "m1814",
+            "user": {"login": "mergify"},
+            "updated_at": "2026-07-03T00:58:00Z",
+            "body": """
+-*- Mergify Payload -*-
+{"state":"dequeued","queue_rule_name":"admin-bypass"}
+
+- ❌ **Checks failed** · on draft #2967
+- 🚫 **Left the queue** — `2026-07-03 00:58 UTC` · at `c2532d229dbed2fd57419698c48d973001c78e9e`
+
+## Reason
+
+The merge conditions cannot be satisfied due to failing checks
+
+- `e2e-proof / aggregate`
+""",
+        }
+        event = parse_mergify_queue_event(comment)
+        self.assertIsNotNone(event)
+        self.assertEqual(event.failing_checks, ("e2e-proof / aggregate",))
+        stack = StackGroup("s", (pr(1814, latest=event),))
+        actions = plan_stack_actions(stack, REQUIRED | {"e2e-proof / aggregate"}, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 1814, "e2e-proof / aggregate")])
+
+    def test_closed_pr_never_requeues_even_when_manually_requested(self):
+        stack = StackGroup("s", (pr(2999, state="CLOSED", latest=mergify()),))
+        actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
+        self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2999, "state=CLOSED")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/mergify-admin-requeue/tests/test_mergify_admin_requeue_model.py
+++ b/packages/mergify-admin-requeue/tests/test_mergify_admin_requeue_model.py
@@ -1,0 +1,361 @@
+"""Behavioural tests for ``mergify_admin_requeue_model``.
+
+These tests double as documentation. The requeue worker has to reconstruct the
+*real* state of a PR from two messy sources:
+
+  1. Mergify's merge-queue **status comment** — free-text Markdown, no API.
+  2. GitHub's **checks** — returned in two different GraphQL shapes.
+
+Every test below feeds a realistic slice of that raw input to one function and
+pins the structured value it produces, so a reader can see exactly what each
+parser is for and why it exists.
+
+Run:  python3 -m unittest packages/mergify-admin-requeue/tests/test_mergify_admin_requeue_model.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import mergify_admin_requeue.model as m
+
+
+# --------------------------------------------------------------------------- #
+# A realistic Mergify merge-queue status comment.
+#
+# This is the kind of comment Mergify posts on a PR that is queued but blocked.
+# There is no API for "why won't this merge" — the answer only lives here, as
+# prose under Markdown headings. The section parsers below all read this body.
+# --------------------------------------------------------------------------- #
+MERGIFY_COMMENT = """\
+## Merge Queue status
+
+The pull request is embarked in the merge queue.
+
+### Waiting for
+
+- all queue conditions to match
+
+### Failing checks
+
+- [ ] [build (ubuntu-latest)](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/123/job/456)
+- [ ] [test:all](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/123/job/789)
+
+### All conditions
+
+- [X] check-success = lint
+- [ ] check-success = build (ubuntu-latest)
+- [ ] check-success = test:all
+- [X] base = master
+
+### Reason
+
+The merge is blocked by failing checks:
+- build (ubuntu-latest)
+- test:all
+
+<!-- mergify-stack-data: {"stack_id":"stack/demo","pulls":[{"number":3221,"head_sha":"0c55361"}]} -->
+"""
+
+
+class SectionExtraction(unittest.TestCase):
+    """Turning headed Markdown prose into per-section lines/items."""
+
+    def test_section_lines_is_scoped_to_one_heading(self):
+        # "Waiting for" must yield ONLY its own line, not bleed into the next
+        # "### Failing checks" section. Section boundaries = Markdown headings.
+        self.assertEqual(
+            m.section_lines(MERGIFY_COMMENT, "Waiting for"),
+            ("- all queue conditions to match",),
+        )
+
+    def test_failing_checks_become_clean_check_names(self):
+        # The raw lines are checkbox bullets wrapping Markdown links. We want the
+        # bare check names the worker can match against required checks.
+        self.assertEqual(
+            m.section_items(MERGIFY_COMMENT, "Failing checks"),
+            ("build (ubuntu-latest)", "test:all"),
+        )
+
+    def test_all_conditions_are_parsed_with_pass_fail_state(self):
+        # The "All conditions" checklist is the ground truth for which required
+        # checks passed ([X]) vs failed ([ ]). Non check-success rows (base=...)
+        # are ignored because they are not checks.
+        self.assertEqual(
+            m.all_condition_states(MERGIFY_COMMENT),
+            (
+                ("lint", "success"),
+                ("build (ubuntu-latest)", "failure"),
+                ("test:all", "failure"),
+            ),
+        )
+
+    def test_failing_check_urls_pairs_name_with_job_links(self):
+        # So a human (or a later step) can jump straight to the failing GitHub
+        # Actions job. Each failing check keeps its own run/job URL(s).
+        self.assertEqual(
+            m.failing_check_urls(MERGIFY_COMMENT),
+            (
+                (
+                    "build (ubuntu-latest)",
+                    ("https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/123/job/456",),
+                ),
+                (
+                    "test:all",
+                    ("https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/123/job/789",),
+                ),
+            ),
+        )
+
+    def test_reason_failed_checks_only_fires_when_reason_blames_checks(self):
+        # The "Reason" section is only mined for check names when it actually
+        # says the block is due to failing checks; otherwise we don't guess.
+        self.assertEqual(
+            m.reason_failed_checks(MERGIFY_COMMENT),
+            ("build (ubuntu-latest)", "test:all"),
+        )
+        no_check_reason = "### Reason\n\nThe base branch was updated.\n- rebase me\n"
+        self.assertEqual(m.reason_failed_checks(no_check_reason), ())
+
+
+class ItemNormalisation(unittest.TestCase):
+    """`normalize_check_item` strips the many bullet/link/checkbox wrappers."""
+
+    def test_strips_markdown_link_to_inner_text(self):
+        self.assertEqual(m.normalize_check_item("[build](https://x/y)"), "build")
+
+    def test_strips_checkbox_and_bullet(self):
+        self.assertEqual(m.normalize_check_item("- [x] lint"), "lint")
+
+    def test_unwraps_check_success_condition(self):
+        self.assertEqual(
+            m.normalize_check_item("- [ ] check-success = test:all"), "test:all"
+        )
+
+    def test_clean_markdown_drops_html_and_emphasis(self):
+        self.assertEqual(
+            m.clean_markdown("<sub>**bold** _x_</sub>"), "bold x"
+        )
+
+
+class QueueStateAndRule(unittest.TestCase):
+    """Reading queued/dequeued and the queue rule from payload or body."""
+
+    def test_state_from_structured_payload(self):
+        self.assertEqual(m.payload_state({"state": "dequeued"}, ""), "dequeued")
+        self.assertEqual(m.payload_state({"event": "queued"}, ""), "queued")
+
+    def test_state_falls_back_to_comment_text(self):
+        # Older Mergify comments carry no machine payload — only prose.
+        self.assertEqual(m.payload_state({}, "The PR left the queue."), "dequeued")
+        self.assertEqual(m.payload_state({}, "It entered the queue."), "queued")
+        self.assertEqual(m.payload_state({}, "nothing relevant"), "unknown")
+
+    def test_rule_from_payload_then_body(self):
+        self.assertEqual(m.payload_rule({"queue_rule_name": "default"}, ""), "default")
+        self.assertEqual(m.payload_rule({"queue": {"name": "hotfix"}}, ""), "hotfix")
+        self.assertEqual(
+            m.payload_rule({}, "removed from the queue rule `admin-bypass` now"),
+            "admin-bypass",
+        )
+
+
+class StackMarker(unittest.TestCase):
+    """Pulling the hidden stack metadata out of the comment."""
+
+    def test_stack_marker_regex_captures_embedded_json(self):
+        match = m.STACK_MARKER_RE.search(MERGIFY_COMMENT)
+        self.assertIsNotNone(match)
+        import json
+
+        data = json.loads(match.group(1))
+        self.assertEqual(data["stack_id"], "stack/demo")
+        self.assertEqual(data["pulls"][0]["number"], 3221)
+
+    def test_extract_first_json_object_handles_braces_inside_strings(self):
+        # The brace/quote state machine must not be fooled by "}" inside a
+        # string value, and must stop at the first *balanced* object.
+        text = 'noise {"a": "x}y", "b": {"c": 1}} trailing {"d": 2}'
+        self.assertEqual(
+            m.extract_first_json_object(text), {"a": "x}y", "b": {"c": 1}}
+        )
+        self.assertIsNone(m.extract_first_json_object("no json here"))
+
+
+class CheckNormalisation(unittest.TestCase):
+    """GitHub returns checks in two shapes; both must flatten to one."""
+
+    def test_check_run_shape(self):
+        node = {
+            "name": "build",
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS",
+            "detailsUrl": "https://x/run",
+            "checkSuite": {"commit": {"oid": "a" * 40}},
+            "completedAt": "2026-01-02T00:00:00Z",
+        }
+        name, state, url, sha, completed = m.norm_check_state(node)
+        self.assertEqual(
+            (name, state, url, sha, completed),
+            ("build", "success", "https://x/run", "a" * 40, "2026-01-02T00:00:00Z"),
+        )
+
+    def test_status_context_legacy_shape(self):
+        node = {
+            "__typename": "StatusContext",
+            "context": "ci/legacy",
+            "state": "FAILURE",
+            "targetUrl": "https://x/legacy",
+            "commit": {"oid": "b" * 40},
+        }
+        name, state, url, sha, _ = m.norm_check_state(node)
+        self.assertEqual(
+            (name, state, url, sha), ("ci/legacy", "failure", "https://x/legacy", "b" * 40)
+        )
+
+    def test_conclusion_word_mapping(self):
+        def state(conclusion, status="COMPLETED"):
+            return m.norm_check_state(
+                {"name": "c", "status": status, "conclusion": conclusion}
+            )[1]
+
+        self.assertEqual(state("TIMED_OUT"), "failure")
+        self.assertEqual(state("SKIPPED"), "skipped")
+        self.assertEqual(state("NEUTRAL"), "neutral")
+        self.assertEqual(state("", status="IN_PROGRESS"), "pending")
+
+    def test_latest_contexts_keeps_newest_required_only(self):
+        head = "a" * 40
+        contexts = [
+            # required "build": an old pass, then a newer fail -> newest wins.
+            {"name": "build", "status": "COMPLETED", "conclusion": "SUCCESS",
+             "checkSuite": {"commit": {"oid": head}}, "completedAt": "2026-01-01T00:00:00Z"},
+            {"name": "build", "status": "COMPLETED", "conclusion": "FAILURE",
+             "checkSuite": {"commit": {"oid": head}}, "completedAt": "2026-01-02T00:00:00Z"},
+            # required "test:all" via the legacy status shape.
+            {"__typename": "StatusContext", "context": "test:all", "state": "SUCCESS",
+             "commit": {"oid": head}},
+            # noise that must be dropped:
+            {"name": "Summary", "status": "COMPLETED", "conclusion": "SUCCESS",
+             "checkSuite": {"commit": {"oid": head}}},          # self check
+            {"name": "Rule: admin-bypass", "status": "COMPLETED", "conclusion": "SUCCESS",
+             "checkSuite": {"commit": {"oid": head}}},           # mergify rule row
+            {"name": "codecov", "status": "COMPLETED", "conclusion": "FAILURE",
+             "checkSuite": {"commit": {"oid": head}}},           # not required
+            {"name": "build", "status": "COMPLETED", "conclusion": "SUCCESS",
+             "checkSuite": {"commit": {"oid": "z" * 40}}},        # wrong commit
+        ]
+        latest = m.latest_contexts_by_required_check(
+            contexts, head, required_checks={"build", "test:all", "lint"}
+        )
+        self.assertEqual(set(latest), {"build", "test:all"})  # "lint" simply absent
+        self.assertEqual(latest["build"].state, "failure")    # newest run wins
+        self.assertEqual(latest["test:all"].state, "success")
+
+
+MERGIFY_YML = """\
+pull_request_rules:
+  - name: admin-bypass
+    conditions:
+      - base=master
+      - label=admin-bypass
+    merge_conditions:
+      - check-success = lint
+      - check-success = build (ubuntu-latest)
+    actions:
+      queue:
+        name: default
+  - name: some-other-rule
+    conditions:
+      - base=master
+"""
+MERGIFY_YML_WITH_ALIAS = """\
+queue_rules:
+  - name: default
+    merge_conditions: &required_checks
+      - check-success = lint
+      - check-success = build (ubuntu-latest)
+  - name: admin-bypass
+    queue_conditions:
+      - base=master
+      - label=admin-bypass
+    merge_conditions: *required_checks
+"""
+
+
+
+class MergifyRuleLoading(unittest.TestCase):
+    """`load_mergify_rules` reads what 'green + landable' means from config."""
+
+    def _write(self, text):
+        fd, path = tempfile.mkstemp(suffix=".yml")
+        os.close(fd)
+        Path(path).write_text(text, encoding="utf-8")
+        self.addCleanup(os.unlink, path)
+        return Path(path)
+
+    def test_reads_trunk_label_and_required_checks(self):
+        trunk, labels, required = m.load_mergify_rules(self._write(MERGIFY_YML))
+        self.assertEqual(trunk, "master")
+        self.assertEqual(labels, frozenset({"admin-bypass"}))
+        self.assertEqual(required, frozenset({"lint", "build (ubuntu-latest)"}))
+
+    def test_reads_required_checks_from_yaml_alias(self):
+        trunk, labels, required = m.load_mergify_rules(self._write(MERGIFY_YML_WITH_ALIAS))
+        self.assertEqual(trunk, "master")
+        self.assertEqual(labels, frozenset({"admin-bypass"}))
+        self.assertEqual(required, frozenset({"lint", "build (ubuntu-latest)"}))
+
+    def test_missing_admin_bypass_rule_is_an_error(self):
+        with self.assertRaises(ValueError):
+            m.load_mergify_rules(self._write("pull_request_rules:\n  - name: other\n"))
+
+
+class LedgerIdempotency(unittest.TestCase):
+    """The ledger stops the worker repeating an action on the same commit."""
+
+    def _ledger_path(self):
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        return Path(d) / "ledger.jsonl"
+
+    def test_record_then_count_and_reload(self):
+        path = self._ledger_path()
+        led = m.Ledger(path)
+        self.assertEqual(led.count("requeue", 3221, "sha1", "flaky"), 0)
+        led.record("requeue", 3221, "sha1", "flaky")
+        self.assertEqual(led.count("requeue", 3221, "sha1", "flaky"), 1)
+        # A different key is a different action -> not counted.
+        self.assertEqual(led.count("requeue", 3221, "sha1", "other"), 0)
+        # Persisted: a fresh Ledger reads the same row back from disk.
+        self.assertEqual(m.Ledger(path).count("requeue", 3221, "sha1", "flaky"), 1)
+
+    def test_has_different_head_detects_new_commit(self):
+        path = self._ledger_path()
+        led = m.Ledger(path)
+        led.record("requeue", 3221, "sha1", "flaky")
+        # Same commit -> already handled, do not act again.
+        self.assertFalse(led.has_different_head("requeue", 3221, "sha1", "flaky"))
+        # New commit pushed -> prior action is stale, acting again is allowed.
+        self.assertTrue(led.has_different_head("requeue", 3221, "sha2", "flaky"))
+
+    def test_malformed_ledger_lines_are_skipped(self):
+        path = self._ledger_path()
+        path.write_text(
+            'not json\n'
+            '[1, 2, 3]\n'  # valid json, wrong type
+            '{"kind": "requeue", "pr": 3221, "headSha": "sha1", "key": "flaky"}\n',
+            encoding="utf-8",
+        )
+        led = m.Ledger(path)
+        self.assertEqual(led.count("requeue", 3221, "sha1", "flaky"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/packages/mergify-admin-requeue/tests/test_mergify_admin_requeue_plan.py
+++ b/packages/mergify-admin-requeue/tests/test_mergify_admin_requeue_plan.py
@@ -1,0 +1,700 @@
+"""Behavioural tests for ``mergify_admin_requeue_plan``.
+
+Documentation-by-test for the staged planner. This layer first classifies raw PR
+state, then builds immutable stack facts, then runs named planning passes to
+pick exactly one next ``Action`` from the priority ladder. The ``Ledger`` caps
+how often the same repair repeats on the same commit.
+
+Run:  python3 -m unittest packages/mergify-admin-requeue/tests/test_mergify_admin_requeue_plan.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import mergify_admin_requeue.model as m
+import mergify_admin_requeue.plan as p
+
+
+HEAD = "a" * 40
+REQUIRED = {"build"}
+QUEUE_ONLY_CHECK = "required-fast / Guardrails"
+
+
+def check(state, name="build"):
+    return m.CheckContext(name=name, state=state, details_url="", head_sha=HEAD, completed_at="")
+
+
+def event(state="dequeued", head=HEAD, comment_id="cm1", failing=(), conditions=(), queue_rule_name="admin-bypass"):
+    return m.MergifyQueueEvent(
+        comment_id=comment_id,
+        state=state,
+        queue_rule_name=queue_rule_name,
+        queued_at="2026-07-07T05:00:00Z",
+        head_sha=head,
+        waiting_for=(),
+        failing_checks=failing,
+        comment_url="u",
+        condition_states=conditions,
+    )
+
+
+def pr(**kw):
+    base = dict(
+        number=1,
+        title="t",
+        body="",
+        url="u",
+        state="OPEN",
+        is_draft=False,
+        base_ref_name="master",
+        head_ref_name="branch",
+        head_ref_oid=HEAD,
+        merge_state_status="BLOCKED",
+        mergeable="MERGEABLE",
+        labels=frozenset(),
+        checks={"build": check("success")},
+        review_threads=(),
+        latest_mergify=None,
+    )
+    base.update(kw)
+    return m.PrSnapshot(**base)
+
+
+class PlannerTestCase(unittest.TestCase):
+    def _ledger(self):
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(d, ignore_errors=True))
+        return m.Ledger(Path(d) / "ledger.jsonl")
+
+    def _facts(self, stack, required_checks=REQUIRED, ledger=None, open_pr_numbers=(), open_pr_numbers_by_head=None, trunk="master"):
+        ledger = ledger or self._ledger()
+        return p.build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head or {}, trunk), ledger
+
+
+class ClassifyPr(unittest.TestCase):
+    """Reading a PR's state into blocker reasons."""
+
+    def _kinds(self, snapshot):
+        return {b.kind for b in p.classify_pr(snapshot, REQUIRED, trunk="master")}
+
+    def test_green_pr_has_no_blockers(self):
+        self.assertEqual(self._kinds(pr()), set())
+
+    def test_draft_short_circuits(self):
+        self.assertEqual(self._kinds(pr(is_draft=True)), {"draft"})
+
+    def test_closed_short_circuits(self):
+        self.assertEqual(self._kinds(pr(state="CLOSED")), {"closed"})
+
+    def test_failed_required_check(self):
+        self.assertEqual(self._kinds(pr(checks={"build": check("failure")})), {"failed_check"})
+
+    def test_missing_required_check_only_on_bottom(self):
+        # Missing check counts as a blocker only when the PR sits on trunk.
+        self.assertEqual(self._kinds(pr(checks={})), {"missing_check"})
+        self.assertEqual(self._kinds(pr(checks={}, base_ref_name="other")), set())
+
+    def test_conflict_from_git_state(self):
+        self.assertIn("conflict", self._kinds(pr(merge_state_status="DIRTY")))
+        self.assertIn("conflict", self._kinds(pr(mergeable="CONFLICTING")))
+
+    def test_human_vs_bot_review_threads(self):
+        human = pr(review_threads=(m.ReviewThread("t", False, ("alice",)),))
+        bot = pr(review_threads=(m.ReviewThread("t", False, ("coderabbitai[bot]",)),))
+        outdated = pr(review_threads=(m.ReviewThread("t", False, ("coderabbitai[bot]",), True),))
+        self.assertIn("human_review_thread", self._kinds(human))
+        self.assertIn("bot_review_thread", self._kinds(bot))
+        self.assertIn("outdated_bot_review_thread", self._kinds(outdated))
+
+    def test_merge_hold_label(self):
+        self.assertIn("merge_hold", self._kinds(pr(labels=frozenset({"merge-hold"}))))
+
+
+class EffectiveBlockers(unittest.TestCase):
+    def test_queue_only_missing_check_is_not_pr_head_blocker(self):
+        snapshot = pr(checks={})
+        kinds = {
+            b.kind for b in p.effective_blockers(
+                snapshot,
+                {QUEUE_ONLY_CHECK},
+                trunk="master",
+            )
+        }
+        self.assertNotIn("missing_check", kinds)
+
+    def test_mergify_success_condition_clears_missing_check(self):
+        # classify_pr flags "build" as missing, but the current Mergify event
+        # says that condition passed -> the loader-derived blocker is dropped.
+        snapshot = pr(checks={}, latest_mergify=event(conditions=(("build", "success"),)))
+        kinds = {b.kind for b in p.effective_blockers(snapshot, REQUIRED, trunk="master")}
+        self.assertNotIn("missing_check", kinds)
+
+    def test_dequeued_queue_only_failure_clears_missing_check(self):
+        snapshot = pr(
+            checks={},
+            latest_mergify=event(
+                failing=(QUEUE_ONLY_CHECK,),
+            ),
+        )
+        kinds = {
+            b.kind for b in p.effective_blockers(
+                snapshot,
+                {QUEUE_ONLY_CHECK},
+                trunk="master",
+            )
+        }
+        self.assertNotIn("missing_check", kinds)
+
+
+
+class ClassifyBottomTopology(unittest.TestCase):
+    def test_open_trunk_root_is_current_bottom(self):
+        stack = m.StackGroup("s", (pr(number=10),))
+        topology = p.classify_bottom_topology(stack, "master", {})
+        self.assertEqual(topology.kind, "current_bottom")
+        self.assertEqual(topology.root.number, 10)
+        self.assertEqual(topology.bottom.number, 10)
+        self.assertEqual(topology.external_open_base_pr_numbers, ())
+
+    def test_stale_root_with_outside_owner_is_external_open_base(self):
+        stack = m.StackGroup(
+            "s",
+            (
+                pr(number=10, base_ref_name="pr/babysit-prereq-split"),
+                pr(number=11, base_ref_name="stack/a"),
+            ),
+        )
+        topology = p.classify_bottom_topology(stack, "master", {"pr/babysit-prereq-split": (7001,)})
+        self.assertEqual(topology.kind, "external_open_base")
+        self.assertIsNone(topology.bottom)
+        self.assertEqual(topology.external_open_base_pr_numbers, (7001,))
+
+    def test_stale_root_with_no_outside_owner_is_stale_unowned_base(self):
+        stack = m.StackGroup(
+            "s",
+            (
+                pr(number=10, base_ref_name="pr/babysit-prereq-split"),
+                pr(number=11, base_ref_name="stack/a"),
+            ),
+        )
+        topology = p.classify_bottom_topology(stack, "master", {})
+        self.assertEqual(topology.kind, "stale_unowned_base")
+        self.assertIsNone(topology.bottom)
+        self.assertEqual(topology.external_open_base_pr_numbers, ())
+
+    def test_same_stack_parent_owner_is_not_treated_as_external(self):
+        stack = m.StackGroup(
+            "s",
+            (
+                pr(number=10, base_ref_name="stack/shared-parent", head_ref_name="stack/child"),
+                pr(number=11, base_ref_name="stack/child", head_ref_name="stack/shared-parent"),
+            ),
+        )
+        topology = p.classify_bottom_topology(stack, "master", {"stack/shared-parent": (11,)})
+        self.assertEqual(topology.kind, "stale_unowned_base")
+        self.assertIsNone(topology.bottom)
+        self.assertEqual(topology.external_open_base_pr_numbers, ())
+
+
+class BuildStackFacts(PlannerTestCase):
+    """Derived stack facts stay stable and enforce planner invariants."""
+
+    def test_queue_only_missing_check_suppressed_from_blockers(self):
+        facts, _ledger = self._facts(
+            m.StackGroup(
+                "s",
+                (
+                    pr(
+                        checks={},
+                        latest_mergify=event(failing=(QUEUE_ONLY_CHECK,)),
+                    ),
+                ),
+            ),
+            required_checks={QUEUE_ONLY_CHECK},
+        )
+        self.assertEqual(facts.blockers_by_pr[1], ())
+        self.assertIsNone(facts.queue_only_noop_check)
+
+    def test_prerequisite_created_suppresses_one_followup_requeue(self):
+        ledger = self._ledger()
+        ledger.record(
+            "repair-prereq-created",
+            10,
+            HEAD,
+            "build",
+            1,
+            meta={"prNumber": 99, "branch": "stack/pr-babysit-prereq-10-aaaaaaa"},
+        )
+        facts, _ = self._facts(
+            m.StackGroup(
+                "s",
+                (
+                    pr(
+                        number=10,
+                        labels=frozenset({"admin-bypass"}),
+                        checks={"build": check("failure")},
+                        latest_mergify=event(state="dequeued", comment_id="cm10"),
+                    ),
+                ),
+            ),
+            ledger=ledger,
+            open_pr_numbers={10},
+        )
+        self.assertEqual(facts.suppressed_failed_checks_by_pr, {10: ("build",)})
+        self.assertEqual(facts.blockers_by_pr[10], ())
+        self.assertTrue(facts.prereq_status.needs_followup_requeue)
+
+    def test_queue_only_noop_suppresses_one_followup_requeue(self):
+        ledger = self._ledger()
+        ledger.record("queue-only-noop", 10, HEAD, QUEUE_ONLY_CHECK, 1)
+        facts, _ = self._facts(
+            m.StackGroup(
+                "s",
+                (
+                    pr(
+                        number=10,
+                        labels=frozenset({"admin-bypass", "dequeued"}),
+                        checks={},
+                        latest_mergify=event(
+                            state="dequeued",
+                            comment_id="cm10",
+                            failing=(QUEUE_ONLY_CHECK,),
+                        ),
+                    ),
+                ),
+            ),
+            required_checks={QUEUE_ONLY_CHECK},
+            ledger=ledger,
+            open_pr_numbers={10},
+        )
+        self.assertEqual(facts.queue_only_noop_check, QUEUE_ONLY_CHECK)
+        self.assertEqual(facts.suppressed_failed_checks_by_pr, {10: (QUEUE_ONLY_CHECK,)})
+        self.assertEqual(facts.blockers_by_pr[10], ())
+
+    def test_pr_body_noop_suppresses_stale_failed_check_on_bottom(self):
+        ledger = self._ledger()
+        ledger.record("queue-only-noop", 10, HEAD, QUEUE_ONLY_CHECK, 1)
+        ledger.record("repair-noop", 10, HEAD, "PR Body", 2)
+        facts, _ = self._facts(
+            m.StackGroup(
+                "s",
+                (
+                    pr(
+                        number=10,
+                        labels=frozenset({"dequeued"}),
+                        checks={"PR Body": check("failure", "PR Body")},
+                        latest_mergify=event(
+                            state="dequeued",
+                            comment_id="cm10",
+                            failing=(QUEUE_ONLY_CHECK,),
+                        ),
+                    ),
+                ),
+            ),
+            required_checks={"PR Body", QUEUE_ONLY_CHECK},
+            ledger=ledger,
+            open_pr_numbers={10},
+        )
+        self.assertEqual(facts.suppressed_failed_checks_by_pr, {10: (QUEUE_ONLY_CHECK, "PR Body")})
+        self.assertEqual(facts.blockers_by_pr[10], ())
+        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        self.assertEqual([(action.kind, action.key) for action in actions], [("restore_admin_bypass_label", QUEUE_ONLY_CHECK)])
+
+    def test_detects_bottom_and_unaccepted_upper(self):
+        facts, _ledger = self._facts(
+            m.StackGroup(
+                "s",
+                (
+                    pr(number=10, head_ref_name="stack/a", labels=frozenset({"admin-bypass"})),
+                    pr(number=11, base_ref_name="stack/a", labels=frozenset({"dequeued"})),
+                ),
+            ),
+        )
+        self.assertEqual(facts.bottom.number, 10)
+        self.assertTrue(facts.upper_stack_needs_acceptance)
+
+
+class PlanStackActions(PlannerTestCase):
+    """Named planning passes over prebuilt facts still honor the same ladder."""
+
+    def _plan(self, stack_or_snapshot, ledger=None, required_checks=REQUIRED, open_pr_numbers=(), open_pr_numbers_by_head=None):
+        ledger = ledger or self._ledger()
+        stack = stack_or_snapshot if isinstance(stack_or_snapshot, m.StackGroup) else m.StackGroup("s", (stack_or_snapshot,))
+        facts = p.build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head or {}, "master")
+        return p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+
+    def test_pending_check_means_wait_do_nothing(self):
+        self.assertEqual(self._plan(pr(checks={"build": check("pending")})), ())
+
+    def test_conflict_triggers_claude_repair(self):
+        actions = self._plan(pr(merge_state_status="DIRTY"))
+        self.assertEqual((actions[0].kind, actions[0].pr_number), ("repair_conflict", 1))
+
+    def test_failed_check_triggers_repair(self):
+        actions = self._plan(pr(checks={"build": check("failure")}))
+        self.assertEqual((actions[0].kind, actions[0].key), ("repair_check", "build"))
+
+    def test_mergify_dequeue_with_failing_check_repairs_first(self):
+        # A Mergify dequeue naming a failing check outranks everything else.
+        actions = self._plan(pr(latest_mergify=event(failing=("build",))))
+        self.assertEqual(actions[0].kind, "repair_check")
+
+    def test_clean_bottom_missing_label_nudges_human(self):
+        actions = self._plan(pr())  # green, no admin-bypass label
+        self.assertEqual((actions[0].kind, actions[0].key), ("comment_admin_bypass_nudge", "admin-bypass"))
+
+    def test_clean_bottom_dequeued_gets_requeued(self):
+        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued"))
+        actions = self._plan(snapshot)
+        self.assertEqual((actions[0].kind, actions[0].detail), ("requeue", "eligible-after-dequeue"))
+
+    def test_queued_label_with_headless_active_queue_event_waits(self):
+        snapshot = pr(labels=frozenset({"admin-bypass", "queued"}), latest_mergify=event(state="queued", head=""))
+        actions = self._plan(snapshot)
+        self.assertEqual(actions, ())
+
+    def test_clean_bottom_queues_without_prior_dequeue(self):
+        snapshot = pr(labels=frozenset({"admin-bypass"}))
+        actions = self._plan(snapshot)
+        self.assertEqual((actions[0].kind, actions[0].detail), ("requeue", "eligible-when-ready"))
+
+    def test_upper_human_decision_does_not_block_clean_bottom_requeue(self):
+        bottom = pr(number=10, head_ref_name="stack/bottom", labels=frozenset({"admin-bypass"}))
+        upper = pr(
+            number=11,
+            base_ref_name="stack/bottom",
+            labels=frozenset({"admin-bypass"}),
+            checks={"build": check("failure")},
+            repair_stop_comments=(
+                m.RepairStopComment(
+                    "Mergify repair stopped: worker cannot auto-split this PR on a non-trunk base; human stack split required",
+                    "2026-07-20T00:00:00Z",
+                    "EdbertChan",
+                ),
+            ),
+        )
+        actions = self._plan(m.StackGroup("s", (bottom, upper)))
+        self.assertEqual((actions[0].kind, actions[0].pr_number), ("requeue", 10))
+
+    def test_stale_root_base_retargets_root_pr(self):
+        stack = m.StackGroup(
+            "s",
+            (
+                pr(
+                    number=5885,
+                    base_ref_name="pr/babysit-prereq-split",
+                    labels=frozenset({"admin-bypass"}),
+                ),
+                pr(
+                    number=5886,
+                    base_ref_name="stack/slack-routing",
+                    labels=frozenset({"admin-bypass"}),
+                ),
+            ),
+        )
+        facts, ledger = self._facts(stack, open_pr_numbers_by_head={})
+        self.assertEqual(facts.bottom_topology.kind, "stale_unowned_base")
+        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        self.assertEqual((actions[0].kind, actions[0].pr_number, actions[0].key), ("retarget_base", 5885, "master"))
+        self.assertIn("`pr/babysit-prereq-split`", actions[0].detail)
+        self.assertIn("`master`", actions[0].detail)
+
+    def test_external_open_base_owner_blocks_instead_of_retargeting(self):
+        stack = m.StackGroup(
+            "s",
+            (
+                pr(
+                    number=5885,
+                    base_ref_name="pr/babysit-prereq-split",
+                    labels=frozenset({"admin-bypass"}),
+                ),
+                pr(
+                    number=5886,
+                    base_ref_name="stack/slack-routing",
+                    labels=frozenset({"admin-bypass"}),
+                ),
+            ),
+        )
+        facts, ledger = self._facts(stack, open_pr_numbers_by_head={"pr/babysit-prereq-split": (7001,)})
+        self.assertEqual(facts.bottom_topology.kind, "external_open_base")
+        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        self.assertEqual((actions[0].kind, actions[0].pr_number, actions[0].key), ("comment_blocked", 5885, "external-open-base-pr"))
+        self.assertIn("#7001", actions[0].detail)
+
+    def test_stale_root_retarget_ignores_unrelated_stack(self):
+        stale_stack = m.StackGroup(
+            "stack-a",
+            (
+                pr(
+                    number=5885,
+                    base_ref_name="pr/babysit-prereq-split",
+                    head_ref_name="stack/slack-routing-1",
+                    labels=frozenset({"admin-bypass"}),
+                ),
+                pr(
+                    number=5886,
+                    base_ref_name="stack/slack-routing-1",
+                    head_ref_name="stack/slack-routing-2",
+                    labels=frozenset({"admin-bypass"}),
+                ),
+            ),
+        )
+        facts, ledger = self._facts(stale_stack, open_pr_numbers_by_head={})
+        self.assertEqual(facts.bottom_topology.kind, "stale_unowned_base")
+        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        self.assertEqual([(action.kind, action.pr_number) for action in actions], [("retarget_base", 5885)])
+
+    def test_stale_root_failed_check_repairs_before_retarget(self):
+        stack = m.StackGroup(
+            "s",
+            (
+                pr(
+                    number=5885,
+                    base_ref_name="pr/babysit-prereq-split",
+                    labels=frozenset({"admin-bypass"}),
+                    checks={"build": check("failure")},
+                ),
+                pr(
+                    number=5886,
+                    base_ref_name="stack/slack-routing",
+                    labels=frozenset({"admin-bypass"}),
+                ),
+            ),
+        )
+        facts, _ledger = self._facts(stack, open_pr_numbers_by_head={})
+        self.assertEqual(facts.bottom_topology.kind, "stale_unowned_base")
+        actions = p.plan_stack_actions(stack, REQUIRED, self._ledger(), now_epoch=0, open_pr_numbers_by_head={})
+        self.assertEqual([(action.kind, action.key) for action in actions], [("repair_check", "build")])
+
+    def test_requeue_is_capped_after_repeated_attempts(self):
+        ledger = self._ledger()
+        # Two prior requeue attempts on this head+key -> the third is capped.
+        ledger.record("requeue", 1, HEAD, "cm1")
+        ledger.record("requeue", 1, HEAD, "cm1")
+        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued", comment_id="cm1"))
+        actions = self._plan(snapshot, ledger)
+        self.assertEqual((actions[0].kind, actions[0].key), ("comment_blocked", "capped"))
+
+    def test_queue_only_missing_head_check_repairs_from_mergify_failure(self):
+        snapshot = pr(
+            checks={},
+            labels=frozenset({"admin-bypass", "dequeued"}),
+            latest_mergify=event(
+                failing=(QUEUE_ONLY_CHECK,),
+                conditions=((QUEUE_ONLY_CHECK, "failure"),),
+            ),
+        )
+        actions = self._plan(snapshot, required_checks={QUEUE_ONLY_CHECK})
+        self.assertEqual(
+            [(action.kind, action.key) for action in actions],
+            [("repair_check", QUEUE_ONLY_CHECK)],
+        )
+
+    def test_admin_bypass_stack_members_progress_as_they_become_bottom(self):
+        before_land = m.StackGroup(
+            "s",
+            (
+                pr(number=10, head_ref_name="stack/a", labels=frozenset({"admin-bypass"})),
+                pr(number=11, base_ref_name="stack/a", labels=frozenset({"admin-bypass"})),
+            ),
+        )
+        after_land = m.StackGroup(
+            "s",
+            (
+                pr(number=11, labels=frozenset({"admin-bypass"})),
+            ),
+        )
+        self.assertEqual(
+            [(action.kind, action.pr_number, action.detail) for action in self._plan(before_land)],
+            [("requeue", 10, "eligible-when-ready")],
+        )
+        self.assertEqual(
+            [(action.kind, action.pr_number, action.detail) for action in self._plan(after_land)],
+            [("requeue", 11, "eligible-when-ready")],
+        )
+
+
+class PlanStackExecution(PlannerTestCase):
+    def test_open_prerequisite_forces_wait_plan(self):
+        ledger = self._ledger()
+        bottom = pr(
+            number=10,
+            labels=frozenset({"admin-bypass"}),
+            checks={"build": check("failure")},
+            latest_mergify=event(state="dequeued"),
+        )
+        ledger.record(
+            "repair-prereq-created",
+            10,
+            HEAD,
+            "build",
+            1,
+            meta={"prNumber": 99, "branch": "stack/pr-babysit-prereq-10-aaaaaaa"},
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (bottom,)),
+            REQUIRED,
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={10, 99},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(plan.wait_reason, "repair-prereq-open")
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.prereq_status.prereq_pr_number, 99)
+        self.assertTrue(plan.prereq_status.is_open)
+        self.assertIsNone(plan.queue_only_noop_check)
+
+    def test_closed_prerequisite_suppresses_one_failed_check_for_requeue(self):
+        ledger = self._ledger()
+        bottom = pr(
+            number=10,
+            labels=frozenset({"admin-bypass"}),
+            checks={"build": check("failure")},
+            latest_mergify=event(state="dequeued", comment_id="cm1"),
+        )
+        ledger.record(
+            "repair-prereq-created",
+            10,
+            HEAD,
+            "build",
+            1,
+            meta={"prNumber": 99, "branch": "stack/pr-babysit-prereq-10-aaaaaaa"},
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (bottom,)),
+            REQUIRED,
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={10},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(plan.actions[0].kind, "requeue")
+        self.assertTrue(plan.prereq_status.needs_followup_requeue)
+
+    def test_queue_only_noop_restores_label_then_requeues_then_retries_normally(self):
+        ledger = self._ledger()
+        bottom = pr(
+            number=10,
+            checks={},
+            labels=frozenset({"dequeued"}),
+            latest_mergify=event(
+                state="dequeued",
+                comment_id="cm10",
+                failing=(QUEUE_ONLY_CHECK,),
+            ),
+        )
+        ledger.record("queue-only-noop", 10, HEAD, QUEUE_ONLY_CHECK, 1)
+        restore = p.plan_stack_execution(
+            m.StackGroup("s", (bottom,)),
+            {QUEUE_ONLY_CHECK},
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={10},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(
+            [(action.kind, action.key) for action in restore.actions],
+            [("restore_admin_bypass_label", QUEUE_ONLY_CHECK)],
+        )
+        self.assertEqual(restore.queue_only_noop_check, QUEUE_ONLY_CHECK)
+
+        requeue = p.plan_stack_execution(
+            m.StackGroup(
+                "s",
+                (
+                    pr(
+                        number=10,
+                        checks={},
+                        labels=frozenset({"admin-bypass", "dequeued"}),
+                        latest_mergify=event(
+                            state="dequeued",
+                            comment_id="cm10",
+                            failing=(QUEUE_ONLY_CHECK,),
+                        ),
+                    ),
+                ),
+            ),
+            {QUEUE_ONLY_CHECK},
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={10},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(
+            [(action.kind, action.key) for action in requeue.actions],
+            [("requeue", "cm10")],
+        )
+
+        ledger.record("queue-only-requeue", 10, HEAD, QUEUE_ONLY_CHECK, 2)
+        retry = p.plan_stack_execution(
+            m.StackGroup(
+                "s",
+                (
+                    pr(
+                        number=10,
+                        checks={},
+                        labels=frozenset({"admin-bypass", "dequeued"}),
+                        latest_mergify=event(
+                            state="dequeued",
+                            comment_id="cm10",
+                            failing=(QUEUE_ONLY_CHECK,),
+                        ),
+                    ),
+                ),
+            ),
+            {QUEUE_ONLY_CHECK},
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={10},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(
+            [(action.kind, action.key) for action in retry.actions],
+            [("repair_check", QUEUE_ONLY_CHECK)],
+        )
+
+    def test_repair_invalid_queue_failure_stops_retrying(self):
+        ledger = self._ledger()
+        ledger.record(
+            "repair-invalid",
+            5873,
+            HEAD,
+            "UI Vitest",
+            1,
+            meta={
+                "errors": [
+                    "merge-queue run failed outside the PR head: fix queue CI runner/tooling outside this PR and requeue."
+                ],
+            },
+        )
+        snapshot = pr(
+            number=5873,
+            labels=frozenset({"admin-bypass", "dequeued"}),
+            checks={"build": check("success"), "UI Vitest": check("success", "UI Vitest")},
+            latest_mergify=event(failing=("UI Vitest",)),
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            {"build"},
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={5873},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "blocked-needs-human")
+        blockers = plan.summary["prs"][0]["blockers"]
+        self.assertEqual(blockers[0]["kind"], "human_decision")
+        self.assertIn("outside the PR head", blockers[0]["detail"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/packages/mergify-admin-requeue/tests/test_mergify_admin_requeue_snapshot.py
+++ b/packages/mergify-admin-requeue/tests/test_mergify_admin_requeue_snapshot.py
@@ -1,0 +1,334 @@
+"""Behavioural tests for ``mergify_admin_requeue_snapshot``.
+
+Documentation-by-test for the loader. This layer takes the *raw* shapes GitHub's
+`gh` CLI returns — issue comments, GraphQL PR detail, status-check rollups,
+review threads — and folds them into the typed ``PrSnapshot`` the planner reads.
+
+Most tests feed one realistic raw shape and pin what gets parsed out of it and
+why. Subprocess coverage stays limited to GitHub CLI error classification.
+
+Run:  python3 -m unittest packages/mergify-admin-requeue/tests/test_mergify_admin_requeue_snapshot.py
+"""
+
+from __future__ import annotations
+
+import sys
+import subprocess
+import unittest
+from unittest import mock
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import mergify_admin_requeue.model as m
+import mergify_admin_requeue.snapshot as s
+
+
+HEAD = "a" * 40
+
+# A real Mergify "dequeued" comment: prose plus the hidden `-*- Mergify Payload
+# -*-` blob. The loader only trusts comments authored by mergify[bot].
+MERGIFY_DEQUEUE_COMMENT = {
+    "user": {"login": "mergify[bot]"},
+    "id": "c-9001",
+    "updated_at": "2026-07-07T05:00:00Z",
+    "html_url": "https://github.com/o/r/pull/4242#issuecomment-9001",
+    "body": """\
+## Merge Queue status
+
+The pull request has been dequeued. Left the queue for head `%s`.
+
+on draft #4242
+
+### Failing checks
+
+- [ ] [build (ubuntu-latest)](https://github.com/o/r/actions/runs/1/job/2)
+
+### Waiting for
+
+- all queue conditions to match
+
+<!-- -*- Mergify Payload -*-
+{"state": "dequeued", "queue_rule_name": "default"}
+-*- Mergify Payload -*- -->
+""" % HEAD,
+}
+
+
+class ParseMergifyQueueEvent(unittest.TestCase):
+    def test_ignores_comments_not_from_mergify(self):
+        # Only Mergify's own comments describe the queue; a human/bot comment
+        # that happens to look similar must be ignored.
+        self.assertIsNone(
+            s.parse_mergify_queue_event({"user": {"login": "coderabbitai[bot]"},
+                                         "body": "Left the queue `%s`" % HEAD})
+        )
+
+    def test_ignores_mergify_comment_without_payload_marker(self):
+        self.assertIsNone(
+            s.parse_mergify_queue_event({"user": {"login": "mergify[bot]"},
+                                         "body": "some chatter, no payload"})
+        )
+
+    def test_parses_dequeue_comment_into_event(self):
+        event = s.parse_mergify_queue_event(MERGIFY_DEQUEUE_COMMENT)
+        assert event is not None
+        self.assertEqual(event.state, "dequeued")
+        self.assertEqual(event.queue_rule_name, "default")
+        self.assertEqual(event.head_sha, HEAD)          # from "Left the queue ... `sha`"
+        self.assertEqual(event.queue_pr_number, 4242)   # from "on draft #4242"
+        self.assertEqual(event.failing_checks, ("build (ubuntu-latest)",))
+        self.assertEqual(event.comment_id, "c-9001")
+        self.assertEqual(event.queued_at, "2026-07-07T05:00:00Z")
+
+
+class GhCommandFailures(unittest.TestCase):
+    def test_graphql_rate_limit_becomes_controlled_runtime_error(self):
+        error = subprocess.CalledProcessError(
+            1,
+            ["gh", "api", "graphql"],
+            stderr='{"errors":[{"type":"RATE_LIMIT","code":"graphql_rate_limit","message":"API rate limit already exceeded"}]}',
+        )
+        with mock.patch("mergify_admin_requeue.snapshot.subprocess.run", side_effect=error):
+            with self.assertRaisesRegex(RuntimeError, "GitHub API rate limit exceeded"):
+                s.run_logged(["gh", "api", "graphql"])
+
+
+class ParseStackMetadata(unittest.TestCase):
+    def test_newest_comment_with_marker_wins(self):
+        old = {"updated_at": "2026-07-01T00:00:00Z",
+               "body": '<!-- mergify-stack-data: {"stack_id":"old","pull_numbers_bottom_to_top":[1,2]} -->'}
+        new = {"updated_at": "2026-07-07T00:00:00Z",
+               "body": '<!-- mergify-stack-data: {"stack_id":"new","pull_numbers_bottom_to_top":[10,11,12]} -->'}
+        self.assertEqual(s.parse_stack_metadata([old, new]), ("new", (10, 11, 12)))
+
+    def test_no_marker_returns_none(self):
+        self.assertIsNone(s.parse_stack_metadata([{"body": "nothing here"}]))
+
+
+class LabelsFromNodes(unittest.TestCase):
+    def test_graphql_nodes_shape(self):
+        self.assertEqual(
+            s.labels_from_nodes({"nodes": [{"name": "admin-bypass"}, {"name": "x"}]}),
+            frozenset({"admin-bypass", "x"}),
+        )
+
+    def test_plain_list_and_strings(self):
+        self.assertEqual(s.labels_from_nodes([{"name": "y"}]), frozenset({"y"}))
+        self.assertEqual(s.labels_from_nodes(["z"]), frozenset({"z"}))
+
+    def test_missing_is_empty(self):
+        self.assertEqual(s.labels_from_nodes(None), frozenset())
+
+
+class ReviewThreadsParsing(unittest.TestCase):
+    def test_collects_thread_id_resolution_and_authors(self):
+        value = {
+            "pageInfo": {"hasNextPage": False},
+            "nodes": [
+                {"id": "t1", "isResolved": False,
+                 "isOutdated": True,
+                 "comments": {"nodes": [{"author": {"login": "coderabbitai[bot]"}}]}},
+                {"id": "t2", "isResolved": True, "comments": {"nodes": []}},
+            ],
+        }
+        self.assertEqual(
+            s.review_threads(value),
+            (m.ReviewThread("t1", False, ("coderabbitai[bot]",), True),
+             m.ReviewThread("t2", True, ())),
+        )
+
+    def test_pagination_is_flagged_conservatively(self):
+        # If threads paginate, we can't be sure they're all resolved, so the
+        # loader emits a sentinel unresolved-by-a-human thread to stay safe.
+        threads = s.review_threads({"pageInfo": {"hasNextPage": True}})
+        self.assertEqual(len(threads), 1)
+        self.assertFalse(threads[0].is_resolved)
+
+
+class RawContexts(unittest.TestCase):
+    def test_digs_through_status_check_rollup(self):
+        pr = {"statusCheckRollup": {"contexts": {"nodes": [{"name": "build"}]}}}
+        self.assertEqual(s.raw_contexts(pr), [{"name": "build"}])
+
+    def test_missing_rollup_is_empty(self):
+        self.assertEqual(s.raw_contexts({}), [])
+
+
+class GroupStackPrs(unittest.TestCase):
+    def _pr(self, number, base, head, state="OPEN"):
+        return m.PrSnapshot(
+            number=number, title="t", body="", url="u", state=state, is_draft=False,
+            base_ref_name=base, head_ref_name=head, head_ref_oid=HEAD,
+            merge_state_status="BLOCKED", mergeable="MERGEABLE",
+            labels=frozenset(), checks={}, review_threads=(), latest_mergify=None,
+        )
+
+    def test_groups_by_declared_stack_metadata(self):
+        prs = [self._pr(10, "master", "b10"), self._pr(11, "b10", "b11"), self._pr(12, "b11", "b12")]
+        meta = {n: ("declared", (10, 11, 12)) for n in (10, 11, 12)}
+        groups = s.group_stack_prs(prs, meta, trunk="master")
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].stack_id, "declared")
+        self.assertEqual(tuple(pr.number for pr in groups[0].prs), (10, 11, 12))
+
+    def test_falls_back_to_branch_chain_when_no_metadata(self):
+        # No stack comment: reconstruct the chain from base->head links.
+        prs = [self._pr(1, "master", "brA"), self._pr(2, "brA", "brB")]
+        groups = s.group_stack_prs(prs, {}, trunk="master")
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].stack_id, "branch:1")
+        self.assertEqual(tuple(pr.number for pr in groups[0].prs), (1, 2))
+
+
+class SnapshotFromDetail(unittest.TestCase):
+    """End-to-end: raw `gh` PR detail + comments -> one typed PrSnapshot."""
+
+    def test_builds_full_snapshot(self):
+        detail = {
+            "number": 3221, "title": "Add model", "body": "## Summary\n\nBody.\n", "url": "https://x/3221",
+            "state": "OPEN", "isDraft": False,
+            "baseRefName": "master", "headRefName": "stack/x", "headRefOid": HEAD,
+            "mergeStateStatus": "BLOCKED", "mergeable": "MERGEABLE",
+            "labels": {"nodes": [{"name": "admin-bypass"}]},
+            "statusCheckRollup": {"contexts": {"nodes": [
+                {"name": "build", "status": "COMPLETED", "conclusion": "FAILURE",
+                 "checkSuite": {"commit": {"oid": HEAD}}, "completedAt": "2026-01-02T00:00:00Z"},
+                {"__typename": "StatusContext", "context": "lint", "state": "SUCCESS",
+                 "commit": {"oid": HEAD}},
+            ]}},
+            "reviewThreads": {"pageInfo": {"hasNextPage": False},
+                              "nodes": [{"id": "t1", "isResolved": True, "comments": {"nodes": []}}]},
+        }
+        snap = s.snapshot_from_detail(detail, [MERGIFY_DEQUEUE_COMMENT], required_checks=["build", "lint"])
+        self.assertEqual(snap.number, 3221)
+        self.assertEqual(snap.state, "OPEN")
+        self.assertEqual(snap.base_ref_name, "master")
+        self.assertEqual(snap.labels, frozenset({"admin-bypass"}))
+        # only required checks, on the current head, flattened from both shapes:
+        self.assertEqual(set(snap.checks), {"build", "lint"})
+        self.assertEqual(snap.checks["build"].state, "failure")
+        self.assertEqual(snap.checks["lint"].state, "success")
+        self.assertEqual(snap.review_threads, (m.ReviewThread("t1", True, ()),))
+        # the Mergify comment is attached as the latest queue event:
+        assert snap.latest_mergify is not None
+        self.assertEqual(snap.latest_mergify.state, "dequeued")
+        self.assertEqual(snap.latest_mergify.head_sha, HEAD)
+
+
+class GhClientCandidateDiscovery(unittest.TestCase):
+    def test_label_seed_expands_stack_metadata_to_unlabeled_bottom(self):
+        bottom = {
+            "number": 100,
+            "title": "bottom",
+            "labels": {"nodes": [{"name": "dequeued"}]},
+        }
+        upper = {
+            "number": 101,
+            "title": "upper",
+            "labels": {"nodes": [{"name": "admin-bypass"}]},
+        }
+        comments = {
+            101: [{
+                "created_at": "2026-07-19T00:00:00Z",
+                "body": '<!-- mergify-stack-data: {"stack_id":"s","pull_numbers_bottom_to_top":[100,101]} -->',
+            }],
+        }
+
+        class FakeGh(s.GhClient):
+            def __init__(self):
+                self.list_args = []
+                self.detail_calls = []
+                self.comment_calls = []
+
+            def _run_json(self, args):
+                self.list_args = list(args)
+                return [upper]
+
+            def pr_detail(self, repo, number):
+                self.detail_calls.append((repo, number))
+                return bottom if number == 100 else upper
+
+            def issue_comments(self, repo, number):
+                self.comment_calls.append((repo, number))
+                return comments.get(number, [])
+
+        client = FakeGh()
+        found = client.list_candidate_prs("Neko-Catpital-Labs/Invoker", "EdbertChan", [])
+
+        self.assertIn("--label", client.list_args)
+        self.assertIn("admin-bypass", client.list_args)
+        self.assertEqual([pr["number"] for pr in found], [101, 100])
+        self.assertEqual(client.detail_calls, [("Neko-Catpital-Labs/Invoker", 100)])
+        self.assertEqual(client.comment_calls, [("Neko-Catpital-Labs/Invoker", 101)])
+
+
+class GhClientLabelEdit(unittest.TestCase):
+    def test_candidate_scan_omits_author_by_default(self):
+        client = s.GhClient()
+        with mock.patch.object(client, "_run_json", return_value=[]) as run_json:
+            client.list_candidate_prs("Neko-Catpital-Labs/Invoker", None, [])
+
+        args = run_json.call_args.args[0]
+        self.assertIn("--label", args)
+        self.assertNotIn("--author", args)
+
+    def test_candidate_scan_includes_explicit_author(self):
+        client = s.GhClient()
+        with mock.patch.object(client, "_run_json", return_value=[]) as run_json:
+            client.list_candidate_prs("Neko-Catpital-Labs/Invoker", "EdbertChan", [])
+
+        args = run_json.call_args.args[0]
+        self.assertEqual(args[args.index("--author") + 1], "EdbertChan")
+
+    def test_list_open_prs_has_no_label_filter(self):
+        client = s.GhClient()
+        with mock.patch.object(client, "_run_json", return_value=[]) as run_json:
+            client.list_open_prs("Neko-Catpital-Labs/Invoker")
+
+        args = run_json.call_args.args[0]
+        self.assertNotIn("--label", args)
+        fields = args[args.index("--json") + 1]
+        self.assertNotIn("statusCheckRollup", fields)
+        self.assertIn("headRefName", fields)
+
+    def test_add_label_uses_rest_issue_labels_endpoint(self):
+        client = s.GhClient()
+        with mock.patch("mergify_admin_requeue.snapshot.subprocess.run") as run:
+            client.edit_label("Neko-Catpital-Labs/Invoker", 4157, add="admin-bypass")
+
+        run.assert_called_once_with(
+            [
+                "gh",
+                "api",
+                "--method",
+                "POST",
+                "repos/Neko-Catpital-Labs/Invoker/issues/4157/labels",
+                "-f",
+                "labels[]=admin-bypass",
+            ],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_remove_label_uses_rest_issue_labels_endpoint(self):
+        client = s.GhClient()
+        with mock.patch("mergify_admin_requeue.snapshot.subprocess.run") as run:
+            client.edit_label("Neko-Catpital-Labs/Invoker", 4157, remove="merge-hold")
+
+        run.assert_called_once_with(
+            [
+                "gh",
+                "api",
+                "--method",
+                "DELETE",
+                "repos/Neko-Catpital-Labs/Invoker/issues/4157/labels/merge-hold",
+            ],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,6 +266,8 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
 
+  packages/mergify-admin-requeue: {}
+
   packages/npm-cli: {}
 
   packages/npm-slack: {}


### PR DESCRIPTION
## Summary

Rehomes the flat admin-requeue modules into `packages/mergify-admin-requeue`.

The new package keeps the same `python3 -m mergify_admin_requeue` entry point and owns its unit coverage beside the code.

Behavior is unchanged. Existing `scripts/` callers and cron wiring stay untouched for later compatibility slices.

## Review Claim

Admin-requeue logic lives in `packages/mergify-admin-requeue` as an importable package with a `python3 -m` entry point and package-local unit files, with behavior unchanged.

## Review Lane

refactor

## Review Unit

ownership-refactor

## Safety Invariant

Behavior unchanged: same flags, exit codes, and dry-run classification outcomes as the flat `scripts/` modules. `pnpm --filter @invoker/mergify-admin-requeue test` exits 0, and `PYTHONPATH=packages/mergify-admin-requeue python3 -m mergify_admin_requeue --help` prints usage including `--once` and `--dry-run`.

## Slice Rationale

This is one ownership-refactor unit that only creates the package tree. Rewiring `scripts/` callers, cron paths, shims, and deletion stay for later slices.

## Non-goals

Behavior unchanged.

- No edits to `scripts/` callers.
- No cron path changes.
- No `WorkerRuntime` edits.
- No docs edits.
- No compatibility shims.
- No deletion of the flat `scripts/mergify_admin_requeue*.py` modules.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/mergify-admin-requeue test`
- [x] `PYTHONPATH=packages/mergify-admin-requeue python3 -m mergify_admin_requeue --help`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
