### PR TITLE
[Bugfix: truthful planning draft readiness](1) Keep planner submit text draft-backed

### DIFF
--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import * as child_process from 'node:child_process';
 import { buildPlanSystemPrompt, PlanConversation, isConfirmation } from '../slack/plan-conversation.js';
+import type { ConversationRepository } from '@invoker/data-store';
 
 // Activation side: the planner is told to write the full plan to the draft file
 // and reply with a summary, and each turn starts from a cleared file so a prior
@@ -29,6 +30,16 @@ function fakePlannerChild(stdout: string, beforeClose?: () => void): any {
     proc.emit('close', 0);
   }, 0);
   return proc;
+}
+
+function fakeConversationRepo() {
+  const saveConversation = vi.fn();
+  const repo = {
+    loadConversation: vi.fn(() => null),
+    saveConversation,
+    deleteConversation: vi.fn(),
+  } as unknown as ConversationRepository;
+  return { repo, saveConversation };
 }
 
 const VALID_PLAN_YAML = `name: "Draft Activation"
@@ -121,6 +132,26 @@ describe('plan draft file - activation side', () => {
     expect(conversation.getDraftedPlan()).toBeNull();
   });
 
+  it('saves no-draft assistant text without the standalone submit line', async () => {
+    const { repo, saveConversation } = fakeConversationRepo();
+    const conversation = new PlanConversation({
+      workingDir,
+      threadTs: 'no-draft-save',
+      conversationRepo: repo,
+      plannerRetryLimit: 0,
+    });
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(`Drafted the plan. Summary: one step.\n\n${SUBMIT_REPLY_LINE}`));
+    const reply = await conversation.sendMessage('Draft it');
+
+    expect(reply).toBe('Drafted the plan. Summary: one step.');
+    expect(saveConversation).toHaveBeenCalled();
+    const savedMessages = saveConversation.mock.calls.at(-1)?.[1] as Array<{ role: string; content: string }>;
+    const savedAssistantText = savedMessages[savedMessages.length - 1]?.content;
+    expect(savedAssistantText).toBe(reply);
+    expect(savedAssistantText).not.toContain(SUBMIT_REPLY_LINE);
+  });
+
   it('routes approval through the review flow instead of a submit reply', () => {
     const conversation = new PlanConversation({});
     (conversation as any).messages.push({ role: 'user', content: 'Draft a plan' });
@@ -153,6 +184,31 @@ describe('plan draft file - activation side', () => {
     expect(draftedPlan).not.toBeNull();
     const parsedDraft = parseYaml(draftedPlan!) as Record<string, unknown>;
     expect(parsedDraft.name).toBe('Draft Activation');
+  });
+
+  it('saves real-draft assistant text with the standalone submit line', async () => {
+    const { repo, saveConversation } = fakeConversationRepo();
+    const conversation = new PlanConversation({
+      workingDir,
+      threadTs: 'real-draft-save',
+      conversationRepo: repo,
+      plannerRetryLimit: 0,
+    });
+    const path = conversation.planDraftFilePath();
+    if (!path) throw new Error('expected a plan draft path');
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(
+      `Drafted the plan.\n\n${SUBMIT_REPLY_LINE}`,
+      () => writeFileSync(path, VALID_PLAN_YAML, 'utf8'),
+    ));
+    const reply = await conversation.sendMessage('Create the plan');
+
+    expect(reply).toContain(SUBMIT_REPLY_LINE);
+    expect(saveConversation).toHaveBeenCalled();
+    const savedMessages = saveConversation.mock.calls.at(-1)?.[1] as Array<{ role: string; content: string }>;
+    const savedAssistantText = savedMessages[savedMessages.length - 1]?.content;
+    expect(savedAssistantText).toBe(reply);
+    expect(savedAssistantText).toContain(SUBMIT_REPLY_LINE);
   });
 
   it('falls back to the latest inline plan when no draft file path exists', async () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -556,9 +556,7 @@ export class PlanConversation {
       : inlineDraft;
     this._lastTurnDraftPlanText = nextDraft;
     if (nextDraft) this.lastKnownGoodPlanText = nextDraft;
-    if (!nextDraft) {
-      message = removeStandaloneSubmitInstruction(message);
-    }
+    message = nextDraft ? message : removeStandaloneSubmitInstruction(message);
     this._lastTurnReasoning = formatted.reasoning;
     this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: responseLen=${response.length}, messageLen=${message.length}, reasoningParts=${formatted.reasoning.length}, responsePreview="${message.slice(0, 500).replace(/\n/g, '\\n')}"`);
 


### PR DESCRIPTION
## Summary

Planner replies now strip the standalone submit instruction before the assistant message is saved when the current turn has no draft.

Real draft turns still save and show the same submit instruction.

## Review Claim

The saved assistant reply includes the standalone `submit` instruction only when the current turn produced a real draft.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

This stays in Slack planner reply formatting and directly affected draft-capture regressions; valid drafted replies keep the same ready-to-submit behavior.

## Slice Rationale

The false readiness text is created while formatting and saving the planner reply, so this slice fixes that surface without changing approval or terminal routing.

## Non-goals

- No in-app approval precondition changes.
- No terminal command dispatch changes.
- No workflow submission behavior changes.
- No model, harness, or unrelated planner cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/plan-draft-file-activation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 82f2d2b10`
- Post-revert steps: Rerun the focused surfaces regression.
- Data migration? No.

</details>
