### PR TITLE
[No-op Maintenance](3) Accept no_op merge mode in app parsers

### DIFF
--- a/packages/app/src/__tests__/merge-mode.test.ts
+++ b/packages/app/src/__tests__/merge-mode.test.ts
@@ -6,9 +6,10 @@ describe('normalizeMergeModeForPersistence', () => {
     expect(normalizeMergeModeForPersistence('external_review')).toBe('external_review');
   });
 
-  it('passes through manual and automatic', () => {
+  it('passes through manual, automatic, and no_op', () => {
     expect(normalizeMergeModeForPersistence('manual')).toBe('manual');
     expect(normalizeMergeModeForPersistence('automatic')).toBe('automatic');
+    expect(normalizeMergeModeForPersistence('no_op')).toBe('no_op');
   });
 
   it('rejects unknown labels', () => {

--- a/packages/app/src/__tests__/metadata-setter.test.ts
+++ b/packages/app/src/__tests__/metadata-setter.test.ts
@@ -109,7 +109,7 @@ describe('metadata-setter', () => {
 
   it('rejects invalid enum and type values', async () => {
     const deps = makeDeps();
-    await expect(setWorkflowMetadata(deps, 'wf-1', 'mergeMode', 'sometimes')).rejects.toThrow(/manual, automatic, external_review/);
+    await expect(setWorkflowMetadata(deps, 'wf-1', 'mergeMode', 'sometimes')).rejects.toThrow(/manual, automatic, external_review, no_op/);
     await expect(setTaskMetadata(deps, 'task-1', 'dependencies', 'task-a')).rejects.toThrow(/array of strings/);
     await expect(setTaskMetadata(deps, 'task-1', 'config.requiresManualApproval', 'true')).rejects.toThrow(/boolean/);
   });

--- a/packages/app/src/merge-mode.ts
+++ b/packages/app/src/merge-mode.ts
@@ -1,9 +1,9 @@
 /**
  * Canonical merge modes stored in persistence and consumed by the merge executor.
  */
-export type CanonicalMergeMode = 'manual' | 'automatic' | 'external_review';
+export type CanonicalMergeMode = 'manual' | 'automatic' | 'external_review' | 'no_op';
 
-const VALID_INPUT = new Set(['manual', 'automatic', 'external_review']);
+const VALID_INPUT = new Set(['manual', 'automatic', 'external_review', 'no_op']);
 
 /**
  * Normalize user-facing merge mode strings for workflow persistence.
@@ -17,5 +17,6 @@ export function normalizeMergeModeForPersistence(raw: string): CanonicalMergeMod
   }
   if (raw === 'external_review') return 'external_review';
   if (raw === 'automatic') return 'automatic';
+  if (raw === 'no_op') return 'no_op';
   return 'manual';
 }

--- a/packages/app/src/metadata-setter.ts
+++ b/packages/app/src/metadata-setter.ts
@@ -163,7 +163,7 @@ function validateWorkflowValue(fieldPath: string, value: unknown, raw: boolean):
     return { onFinish: enumValue<'none' | 'merge' | 'pull_request'>(path, value, ['none', 'merge', 'pull_request']) ?? undefined };
   }
   if (path === 'mergeMode') {
-    return { mergeMode: enumValue<'manual' | 'automatic' | 'external_review'>(path, value, ['manual', 'automatic', 'external_review']) ?? undefined };
+    return { mergeMode: enumValue<'manual' | 'automatic' | 'external_review' | 'no_op'>(path, value, ['manual', 'automatic', 'external_review', 'no_op']) ?? undefined };
   }
   if (path === 'baseBranch') {
     return { baseBranch: normalizeWorkflowBaseBranch(value == null ? null : String(value), 'master') };

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -334,7 +334,7 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
   }
   const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? 'pull_request';
 
-  const validMergeModes = ['manual', 'automatic', 'external_review'] as const;
+  const validMergeModes = ['manual', 'automatic', 'external_review', 'no_op'] as const;
   if (raw.mergeMode !== undefined && !validMergeModes.includes(raw.mergeMode as any)) {
     throw new PlanParseError(
       `"mergeMode" must be one of: ${validMergeModes.join(', ')}. Got: "${raw.mergeMode}"`,

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -117,7 +117,7 @@ export interface Workflow {
   onFinish?: 'none' | 'merge' | 'pull_request';
   baseBranch?: string;
   featureBranch?: string;
-  mergeMode?: 'manual' | 'automatic' | 'external_review';
+  mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
   reviewProvider?: string;
   externalDependencies?: ExternalDependency[];
   externalDependencyChanges?: ExternalDependencyChange[];

--- a/packages/test-kit/src/in-memory-persistence.ts
+++ b/packages/test-kit/src/in-memory-persistence.ts
@@ -10,7 +10,7 @@ export class InMemoryPersistence implements OrchestratorPersistence {
     id: string; name: string; status: string;
     createdAt: string; updatedAt: string;
     onFinish?: 'none' | 'merge' | 'pull_request'; baseBranch?: string; featureBranch?: string;
-    mergeMode?: 'manual' | 'automatic' | 'external_review';
+    mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     generation?: number;
@@ -22,7 +22,7 @@ export class InMemoryPersistence implements OrchestratorPersistence {
     id: string; name: string;
     createdAt: string; updatedAt: string;
     onFinish?: 'none' | 'merge' | 'pull_request'; baseBranch?: string; featureBranch?: string;
-    mergeMode?: 'manual' | 'automatic' | 'external_review';
+    mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     generation?: number;
@@ -36,7 +36,7 @@ export class InMemoryPersistence implements OrchestratorPersistence {
     });
   }
 
-  updateWorkflow(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review'; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[] }): void {
+  updateWorkflow(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op'; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[] }): void {
     const wf = this.workflows.get(workflowId);
     if (wf) {
       if (changes.updatedAt) wf.updatedAt = changes.updatedAt;
@@ -97,7 +97,7 @@ export class InMemoryPersistence implements OrchestratorPersistence {
     }
   }
 
-  listWorkflows(): Array<{ id: string; name: string; status: string; createdAt: string; updatedAt: string; baseBranch?: string; onFinish?: string; mergeMode?: 'manual' | 'automatic' | 'external_review'; generation?: number }> {
+  listWorkflows(): Array<{ id: string; name: string; status: string; createdAt: string; updatedAt: string; baseBranch?: string; onFinish?: string; mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op'; generation?: number }> {
     return Array.from(this.workflows.values()).map((workflow) => this.withDerivedStatus(workflow));
   }
 

--- a/packages/workflow-core/src/__tests__/plan-parser.test.ts
+++ b/packages/workflow-core/src/__tests__/plan-parser.test.ts
@@ -104,4 +104,21 @@ tasks:
     expect(() => parsePlan(yaml)).toThrow(PlanParseError);
     expect(() => parsePlan(yaml)).toThrow(/executionModel/);
   });
+
+  it('parses mergeMode no_op', () => {
+    const yaml = `
+name: No Op Plan
+repoUrl: git@github.com:test/repo.git
+baseBranch: main
+onFinish: none
+mergeMode: no_op
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+`;
+    const plan = parsePlan(yaml);
+    expect(plan.mergeMode).toBe('no_op');
+    expect(plan.onFinish).toBe('none');
+  });
 });

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -315,7 +315,7 @@ export class CommandService {
   async editTaskMergeMode(
     envelope: CommandEnvelope<{
       taskId: string;
-      mergeMode: 'manual' | 'automatic' | 'external_review';
+      mergeMode: 'manual' | 'automatic' | 'external_review' | 'no_op';
     }>,
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -258,12 +258,12 @@ export interface OrchestratorPersistence {
     onFinish?: string;
     baseBranch?: string;
     featureBranch?: string;
-    mergeMode?: 'manual' | 'automatic' | 'external_review';
+    mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     detachedExternalDependencies?: DetachedExternalDependency[];
   }): void;
-  updateWorkflow?(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review'; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[]; detachedExternalDependencies?: DetachedExternalDependency[] }): void;
+  updateWorkflow?(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op'; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[]; detachedExternalDependencies?: DetachedExternalDependency[] }): void;
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
   logEvent?(taskId: string, eventType: string, payload?: unknown): void;
@@ -276,7 +276,7 @@ export interface OrchestratorPersistence {
     repoUrl?: string;
     baseBranch?: string;
     onFinish?: string;
-    mergeMode?: 'manual' | 'automatic' | 'external_review';
+    mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     detachedExternalDependencies?: DetachedExternalDependency[];
@@ -293,7 +293,7 @@ export interface OrchestratorPersistence {
       repoUrl?: string;
       baseBranch?: string;
       onFinish?: string;
-      mergeMode?: 'manual' | 'automatic' | 'external_review';
+      mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
       externalDependencies?: ExternalDependency[];
       externalDependencyChanges?: ExternalDependencyChange[];
       detachedExternalDependencies?: DetachedExternalDependency[];
@@ -325,7 +325,7 @@ export interface OrchestratorPersistence {
     intermediateRepoUrl?: string;
     baseBranch?: string;
     featureBranch?: string;
-    mergeMode?: 'manual' | 'automatic' | 'external_review';
+    mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     detachedExternalDependencies?: DetachedExternalDependency[];
@@ -386,7 +386,7 @@ export interface PlanDefinition {
   onFinish?: 'none' | 'merge' | 'pull_request';
   baseBranch?: string;
   featureBranch?: string;
-  mergeMode?: 'manual' | 'automatic' | 'external_review';
+  mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
   reviewProvider?: string;
   repoUrl?: string;
   intermediateRepoUrl?: string;
@@ -2229,7 +2229,7 @@ export class Orchestrator {
 
   editTaskMergeMode(
     taskId: string,
-    mergeMode: 'manual' | 'automatic' | 'external_review',
+    mergeMode: 'manual' | 'automatic' | 'external_review' | 'no_op',
   ): TaskState[] {
     return editTaskMergeModeImpl(this as unknown as TaskEditHost, taskId, mergeMode);
   }
@@ -2386,7 +2386,12 @@ export class Orchestrator {
       if (typeof m.onFinish === 'string') baseSaveWf.onFinish = m.onFinish;
       if (typeof m.baseBranch === 'string') baseSaveWf.baseBranch = m.baseBranch;
       if (typeof m.featureBranch === 'string') baseSaveWf.featureBranch = m.featureBranch;
-      if (m.mergeMode === 'manual' || m.mergeMode === 'automatic' || m.mergeMode === 'external_review') {
+      if (
+        m.mergeMode === 'manual'
+        || m.mergeMode === 'automatic'
+        || m.mergeMode === 'external_review'
+        || m.mergeMode === 'no_op'
+      ) {
         baseSaveWf.mergeMode = m.mergeMode;
       }
       if (Array.isArray(m.externalDependencies)) {
@@ -3079,6 +3084,22 @@ export class Orchestrator {
 
   getWorkflowIds(): string[] {
     return Array.from(this.activeWorkflowIds);
+  }
+
+  /** Merge mode for a workflow, used by bulk start-ready exclusion selectors. */
+  getWorkflowMergeMode(workflowId: string): 'manual' | 'automatic' | 'external_review' | 'no_op' | undefined {
+    const workflow = this.persistence.loadWorkflow?.(workflowId)
+      ?? this.persistence.listWorkflows().find((candidate) => candidate.id === workflowId);
+    const mergeMode = workflow?.mergeMode;
+    if (
+      mergeMode === 'manual'
+      || mergeMode === 'automatic'
+      || mergeMode === 'external_review'
+      || mergeMode === 'no_op'
+    ) {
+      return mergeMode;
+    }
+    return undefined;
   }
 
   /**

--- a/packages/workflow-core/src/orchestrator/task-edits.ts
+++ b/packages/workflow-core/src/orchestrator/task-edits.ts
@@ -302,7 +302,7 @@ export function editTaskAgentImpl(host: TaskEditHost, taskId: string, agentName:
 export function editTaskMergeModeImpl(
   host: TaskEditHost,
   taskId: string,
-  mergeMode: 'manual' | 'automatic' | 'external_review',
+  mergeMode: 'manual' | 'automatic' | 'external_review' | 'no_op',
 ): TaskState[] {
   host.refreshFromDb();
   const task = host.stateGetTask(taskId);

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -173,7 +173,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
   }
   const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? 'pull_request';
 
-  const validMergeModes = ['manual', 'automatic', 'external_review'] as const;
+  const validMergeModes = ['manual', 'automatic', 'external_review', 'no_op'] as const;
   if (raw.mergeMode !== undefined && !validMergeModes.includes(raw.mergeMode as any)) {
     throw new PlanParseError(`"mergeMode" must be one of: ${validMergeModes.join(', ')}. Got: "${raw.mergeMode}"`);
   }

--- a/packages/workflow-core/src/task-repository.ts
+++ b/packages/workflow-core/src/task-repository.ts
@@ -26,7 +26,7 @@ export interface WorkflowRecord {
   onFinish?: 'none' | 'merge' | 'pull_request';
   baseBranch?: string;
   featureBranch?: string;
-  mergeMode?: 'manual' | 'automatic' | 'external_review';
+  mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
   externalDependencies?: ExternalDependency[];
   externalDependencyChanges?: ExternalDependencyChange[];
   detachedExternalDependencies?: DetachedExternalDependency[];
@@ -45,7 +45,7 @@ export interface WorkflowChanges {
   baseBranch?: string;
   featureBranch?: string;
   generation?: number;
-  mergeMode?: 'manual' | 'automatic' | 'external_review';
+  mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
   reviewProvider?: string;
   /**
    * Presence semantics: a key explicitly set to `undefined` clears the


### PR DESCRIPTION
## Summary

App plan parsing and metadata edits must accept the same no_op label.

This slice updates merge-mode normalization and plan/metadata parsing in app.

## Review Claim

App merge-mode normalization and plan/metadata parsing accept no_op.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Parser acceptance alone does not complete merge gates or alter recreate-all.

## Slice Rationale

App-facing parse paths stay with app package boundaries after core acceptance.

## Non-goals

Does not change merge-runner completion or headless flags.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && ./node_modules/.bin/vitest run src/__tests__/merge-mode.test.ts src/__tests__/metadata-setter.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert eeb5396d5`
- Post-revert steps: None
- Data migration? No

</details>
