### PR TITLE
[No-op Maintenance](5) Add start-ready exclude selector contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -638,6 +638,11 @@ export type StartReadyWorkflowOutcome =
       error: string;
     };
 
+export type StartReadyExcludeSelector = {
+  field: 'mergeMode';
+  value: 'no_op';
+};
+
 export interface StartReadyRequest {
   recreateFailed?: boolean;
   recreateFailedAndPending?: boolean;
@@ -646,6 +651,8 @@ export interface StartReadyRequest {
   recreateAll?: boolean;
   freshBaseScope?: StartReadyFreshBaseScope;
   dryRun?: boolean;
+  /** Typed selectors that remove matching workflows from bulk recreation. */
+  exclude?: StartReadyExcludeSelector[];
 }
 
 export interface StartReadyPreview {
@@ -671,6 +678,7 @@ export interface StartReadyResult {
   preview: StartReadyPreview;
   started: TaskState[];
   recreatedWorkflowIds: string[];
+  excludedWorkflowIds?: string[];
   freshBaseRecreatedWorkflowIds?: string[];
   workflowOutcomes?: StartReadyWorkflowOutcome[];
   partial?: boolean;


### PR DESCRIPTION
## Summary

Bulk recreate needs an explicit way to leave out finished maintenance workflows.

This slice adds an exclude selector field on the start-ready request payload.

Operators can later pass mergeMode:no_op without changing recreate-all defaults.

## Review Claim

The start-ready IPC payload accepts repeatable exclude selectors beginning with mergeMode:no_op.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Adding optional exclude fields does not change request defaults until a later consumer honors them.

## Slice Rationale

Shared request shapes must land before start-ready and downstream callers consume them.

## Non-goals

Does not implement filtering logic or flag handling.

Does not change recreate-all selection defaults.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Payload field is consumed by later start-ready and activation slices

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0bf3dda8c`
- Post-revert steps: None
- Data migration? No

</details>
