### PR TITLE
[No-op Maintenance](6) Filter recreate-all by exclude selectors

### DIFF
--- a/packages/app/src/__tests__/start-ready.test.ts
+++ b/packages/app/src/__tests__/start-ready.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { TaskState } from '@invoker/workflow-core';
 
-import { collectStartReadyPreview, runStartReady } from '../start-ready.js';
+import {
+  collectStartReadyPreview,
+  parseStartReadyExcludeSelector,
+  runStartReady,
+} from '../start-ready.js';
 
 function makeTask(
   id: string,
@@ -21,13 +25,19 @@ function makeTask(
   } as TaskState;
 }
 
-function harness(initialTasks: TaskState[], readyTasks: TaskState[], activeTaskIds: string[] = []) {
+function harness(
+  initialTasks: TaskState[],
+  readyTasks: TaskState[],
+  activeTaskIds: string[] = [],
+  mergeModes: Record<string, 'manual' | 'automatic' | 'external_review' | 'no_op' | undefined> = {},
+) {
   let tasks = [...initialTasks];
   const orchestrator = {
     syncAllFromDb: vi.fn(() => undefined),
     getAllTasks: vi.fn(() => tasks),
     getPersistedActiveTaskIds: vi.fn(() => new Set(activeTaskIds)),
     getExecutableReadyTasks: vi.fn(() => readyTasks),
+    getWorkflowMergeMode: vi.fn((workflowId: string) => mergeModes[workflowId]),
     prepareTaskForNewAttempt: vi.fn((taskId: string) => {
       tasks = tasks.map((task) => task.id === taskId
         ? { ...task, status: 'pending' as TaskState['status'], execution: {} }
@@ -322,5 +332,71 @@ describe('start-ready', () => {
     expect(result.preview.freshBase?.completedWorkflowIds).toEqual(['wf-2']);
     expect(result.freshBaseRecreatedWorkflowIds).toEqual(['wf-1', 'wf-2']);
     expect(result.partial).toBe(false);
+  });
+
+  it('excludes mergeMode:no_op workflows from recreate-all when requested', async () => {
+    const failed = makeTask('wf-1/failed', 'failed');
+    const completedNoOp = makeTask('wf-2/completed', 'completed');
+    const completedManual = makeTask('wf-3/completed', 'completed');
+    const orchestrator = harness(
+      [failed, completedNoOp, completedManual],
+      [],
+      [],
+      { 'wf-2': 'no_op', 'wf-3': 'manual' },
+    );
+
+    const result = await runStartReady(orchestrator, {
+      recreateAll: true,
+      exclude: [{ field: 'mergeMode', value: 'no_op' }],
+    });
+
+    expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-3']);
+    expect(result.excludedWorkflowIds).toEqual(['wf-2']);
+    expect(orchestrator.recreateWorkflow).not.toHaveBeenCalledWith('wf-2');
+  });
+
+  it('keeps recreate-all broad when exclude is omitted', async () => {
+    const completedNoOp = makeTask('wf-1/completed', 'completed');
+    const orchestrator = harness([completedNoOp], [], [], { 'wf-1': 'no_op' });
+
+    const result = await runStartReady(orchestrator, { recreateAll: true });
+
+    expect(result.recreatedWorkflowIds).toEqual(['wf-1']);
+    expect(result.excludedWorkflowIds).toEqual([]);
+  });
+
+  it('dry-run reports excluded no_op workflows without mutating', async () => {
+    const completedNoOp = makeTask('wf-1/completed', 'completed');
+    const completedManual = makeTask('wf-2/completed', 'completed');
+    const orchestrator = harness(
+      [completedNoOp, completedManual],
+      [],
+      [],
+      { 'wf-1': 'no_op', 'wf-2': 'manual' },
+    );
+
+    const result = await runStartReady(orchestrator, {
+      recreateAll: true,
+      dryRun: true,
+      exclude: [{ field: 'mergeMode', value: 'no_op' }],
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.recreatedWorkflowIds).toEqual([]);
+    expect(result.excludedWorkflowIds).toEqual(['wf-1']);
+    expect(orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('accepts repeated mergeMode:no_op exclude selectors and rejects unsupported ones', () => {
+    expect(parseStartReadyExcludeSelector('mergeMode:no_op')).toEqual({
+      field: 'mergeMode',
+      value: 'no_op',
+    });
+    expect(parseStartReadyExcludeSelector(' mergeMode:no_op ')).toEqual({
+      field: 'mergeMode',
+      value: 'no_op',
+    });
+    expect(() => parseStartReadyExcludeSelector('mergeMode:manual')).toThrow(/Unsupported/);
+    expect(() => parseStartReadyExcludeSelector('namePrefix:pr-maintenance-')).toThrow(/Unsupported/);
   });
 });

--- a/packages/app/src/start-ready.ts
+++ b/packages/app/src/start-ready.ts
@@ -1,4 +1,5 @@
 import type {
+  StartReadyExcludeSelector,
   StartReadyFreshBasePreview,
   StartReadyFreshBaseScope,
   StartReadyPreview,
@@ -17,6 +18,7 @@ type StartReadyOrchestrator = Pick<
   | 'prepareTaskForNewAttempt'
   | 'recreateWorkflow'
   | 'startExecution'
+  | 'getWorkflowMergeMode'
 >;
 
 type StartReadyRequestExt = StartReadyRequest & {
@@ -38,6 +40,19 @@ type StartReadyPreviewExt = StartReadyPreview & {
     completedTasks: number;
   };
 };
+
+const SUPPORTED_EXCLUDE_SELECTORS = new Set(['mergeMode:no_op']);
+
+export function parseStartReadyExcludeSelector(raw: string): StartReadyExcludeSelector {
+  const trimmed = raw.trim();
+  if (!SUPPORTED_EXCLUDE_SELECTORS.has(trimmed)) {
+    throw new Error(
+      `Unsupported start-ready --exclude selector "${raw}". Expected one of: ${[...SUPPORTED_EXCLUDE_SELECTORS].join(', ')}`,
+    );
+  }
+  return { field: 'mergeMode', value: 'no_op' };
+}
+
 function collectRecoverableTasks(orchestrator: StartReadyOrchestrator): TaskState[] {
   const activeTaskIds = orchestrator.getPersistedActiveTaskIds();
   return orchestrator
@@ -96,6 +111,38 @@ function unionWorkflowIds(...groups: readonly (readonly string[])[]): string[] {
     for (const id of group) ids.add(id);
   }
   return Array.from(ids);
+}
+
+
+function matchesExcludeSelector(
+  orchestrator: StartReadyOrchestrator,
+  workflowId: string,
+  selector: StartReadyExcludeSelector,
+): boolean {
+  if (selector.field === 'mergeMode' && selector.value === 'no_op') {
+    return orchestrator.getWorkflowMergeMode(workflowId) === 'no_op';
+  }
+  return false;
+}
+
+function partitionExcludedWorkflowIds(
+  orchestrator: StartReadyOrchestrator,
+  workflowIds: readonly string[],
+  exclude: readonly StartReadyExcludeSelector[] | undefined,
+): { selected: string[]; excluded: string[] } {
+  if (!exclude || exclude.length === 0) {
+    return { selected: [...workflowIds], excluded: [] };
+  }
+  const selected: string[] = [];
+  const excluded: string[] = [];
+  for (const workflowId of workflowIds) {
+    if (exclude.some((selector) => matchesExcludeSelector(orchestrator, workflowId, selector))) {
+      excluded.push(workflowId);
+    } else {
+      selected.push(workflowId);
+    }
+  }
+  return { selected, excluded };
 }
 
 function workflowIdsToRecreate(
@@ -227,11 +274,21 @@ async function runStartReadyAsync(
   if (freshBasePreview) {
     preview.freshBase = freshBasePreview;
   }
+  const recreateCandidates = freshBasePreview
+    ? []
+    : workflowIdsToRecreate(extendedRequest, preview);
+  const { selected: selectedRecreateIds, excluded: excludedWorkflowIds } = partitionExcludedWorkflowIds(
+    orchestrator,
+    recreateCandidates,
+    extendedRequest.exclude,
+  );
+
   if (request.dryRun) {
     return {
       preview,
       started: [],
       recreatedWorkflowIds: [],
+      excludedWorkflowIds,
       dryRun: true,
     };
   }
@@ -266,7 +323,7 @@ async function runStartReadyAsync(
       }
     }
   } else {
-    for (const workflowId of workflowIdsToRecreate(extendedRequest, preview)) {
+    for (const workflowId of selectedRecreateIds) {
       started.push(...orchestrator.recreateWorkflow(workflowId));
       recreatedWorkflowIds.push(workflowId);
     }
@@ -283,6 +340,7 @@ async function runStartReadyAsync(
     preview,
     started: uniqueTasks(started),
     recreatedWorkflowIds,
+    excludedWorkflowIds,
     ...(freshBasePreview
       ? {
           freshBaseRecreatedWorkflowIds,


### PR DESCRIPTION
## Summary

Operators still need recreate-all to stay broad by default.

This slice applies exclude selectors when choosing workflows to recreate.

Passing exclude mergeMode:no_op keeps finished no_op maintenance jobs out of the recreate set.

## Review Claim

Bulk recreation remains broad by default but can deliberately exclude workflows matching a typed selector.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Omitting exclude preserves current recreate-all behavior that includes completed workflows.

## Slice Rationale

Filtering belongs in start-ready once the shared request shape exists, separate from activation-surface arg handling.

## Non-goals

Does not handle CLI flags.

Does not auto-delete workflows or change fresh-base recreate scopes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && ./node_modules/.bin/vitest run src/__tests__/start-ready.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e5c845fe8`
- Post-revert steps: None
- Data migration? No

</details>
