### PR TITLE
[No-op Maintenance](7) Wire headless --exclude parsing

### DIFF
--- a/packages/app/src/__tests__/merge-mode.test.ts
+++ b/packages/app/src/__tests__/merge-mode.test.ts
@@ -6,9 +6,10 @@ describe('normalizeMergeModeForPersistence', () => {
     expect(normalizeMergeModeForPersistence('external_review')).toBe('external_review');
   });
 
-  it('passes through manual and automatic', () => {
+  it('passes through manual, automatic, and no_op', () => {
     expect(normalizeMergeModeForPersistence('manual')).toBe('manual');
     expect(normalizeMergeModeForPersistence('automatic')).toBe('automatic');
+    expect(normalizeMergeModeForPersistence('no_op')).toBe('no_op');
   });
 
   it('rejects unknown labels', () => {

--- a/packages/app/src/__tests__/metadata-setter.test.ts
+++ b/packages/app/src/__tests__/metadata-setter.test.ts
@@ -109,7 +109,7 @@ describe('metadata-setter', () => {
 
   it('rejects invalid enum and type values', async () => {
     const deps = makeDeps();
-    await expect(setWorkflowMetadata(deps, 'wf-1', 'mergeMode', 'sometimes')).rejects.toThrow(/manual, automatic, external_review/);
+    await expect(setWorkflowMetadata(deps, 'wf-1', 'mergeMode', 'sometimes')).rejects.toThrow(/manual, automatic, external_review, no_op/);
     await expect(setTaskMetadata(deps, 'task-1', 'dependencies', 'task-a')).rejects.toThrow(/array of strings/);
     await expect(setTaskMetadata(deps, 'task-1', 'config.requiresManualApproval', 'true')).rejects.toThrow(/boolean/);
   });

--- a/packages/app/src/__tests__/start-ready.test.ts
+++ b/packages/app/src/__tests__/start-ready.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { TaskState } from '@invoker/workflow-core';
 
-import { collectStartReadyPreview, runStartReady } from '../start-ready.js';
+import {
+  collectStartReadyPreview,
+  parseStartReadyExcludeSelector,
+  runStartReady,
+} from '../start-ready.js';
 
 function makeTask(
   id: string,
@@ -21,13 +25,19 @@ function makeTask(
   } as TaskState;
 }
 
-function harness(initialTasks: TaskState[], readyTasks: TaskState[], activeTaskIds: string[] = []) {
+function harness(
+  initialTasks: TaskState[],
+  readyTasks: TaskState[],
+  activeTaskIds: string[] = [],
+  mergeModes: Record<string, 'manual' | 'automatic' | 'external_review' | 'no_op' | undefined> = {},
+) {
   let tasks = [...initialTasks];
   const orchestrator = {
     syncAllFromDb: vi.fn(() => undefined),
     getAllTasks: vi.fn(() => tasks),
     getPersistedActiveTaskIds: vi.fn(() => new Set(activeTaskIds)),
     getExecutableReadyTasks: vi.fn(() => readyTasks),
+    getWorkflowMergeMode: vi.fn((workflowId: string) => mergeModes[workflowId]),
     prepareTaskForNewAttempt: vi.fn((taskId: string) => {
       tasks = tasks.map((task) => task.id === taskId
         ? { ...task, status: 'pending' as TaskState['status'], execution: {} }
@@ -322,5 +332,71 @@ describe('start-ready', () => {
     expect(result.preview.freshBase?.completedWorkflowIds).toEqual(['wf-2']);
     expect(result.freshBaseRecreatedWorkflowIds).toEqual(['wf-1', 'wf-2']);
     expect(result.partial).toBe(false);
+  });
+
+  it('excludes mergeMode:no_op workflows from recreate-all when requested', async () => {
+    const failed = makeTask('wf-1/failed', 'failed');
+    const completedNoOp = makeTask('wf-2/completed', 'completed');
+    const completedManual = makeTask('wf-3/completed', 'completed');
+    const orchestrator = harness(
+      [failed, completedNoOp, completedManual],
+      [],
+      [],
+      { 'wf-2': 'no_op', 'wf-3': 'manual' },
+    );
+
+    const result = await runStartReady(orchestrator, {
+      recreateAll: true,
+      exclude: [{ field: 'mergeMode', value: 'no_op' }],
+    });
+
+    expect(result.recreatedWorkflowIds).toEqual(['wf-1', 'wf-3']);
+    expect(result.excludedWorkflowIds).toEqual(['wf-2']);
+    expect(orchestrator.recreateWorkflow).not.toHaveBeenCalledWith('wf-2');
+  });
+
+  it('keeps recreate-all broad when exclude is omitted', async () => {
+    const completedNoOp = makeTask('wf-1/completed', 'completed');
+    const orchestrator = harness([completedNoOp], [], [], { 'wf-1': 'no_op' });
+
+    const result = await runStartReady(orchestrator, { recreateAll: true });
+
+    expect(result.recreatedWorkflowIds).toEqual(['wf-1']);
+    expect(result.excludedWorkflowIds).toEqual([]);
+  });
+
+  it('dry-run reports excluded no_op workflows without mutating', async () => {
+    const completedNoOp = makeTask('wf-1/completed', 'completed');
+    const completedManual = makeTask('wf-2/completed', 'completed');
+    const orchestrator = harness(
+      [completedNoOp, completedManual],
+      [],
+      [],
+      { 'wf-1': 'no_op', 'wf-2': 'manual' },
+    );
+
+    const result = await runStartReady(orchestrator, {
+      recreateAll: true,
+      dryRun: true,
+      exclude: [{ field: 'mergeMode', value: 'no_op' }],
+    });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.recreatedWorkflowIds).toEqual([]);
+    expect(result.excludedWorkflowIds).toEqual(['wf-1']);
+    expect(orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('accepts repeated mergeMode:no_op exclude selectors and rejects unsupported ones', () => {
+    expect(parseStartReadyExcludeSelector('mergeMode:no_op')).toEqual({
+      field: 'mergeMode',
+      value: 'no_op',
+    });
+    expect(parseStartReadyExcludeSelector(' mergeMode:no_op ')).toEqual({
+      field: 'mergeMode',
+      value: 'no_op',
+    });
+    expect(() => parseStartReadyExcludeSelector('mergeMode:manual')).toThrow(/Unsupported/);
+    expect(() => parseStartReadyExcludeSelector('namePrefix:pr-maintenance-')).toThrow(/Unsupported/);
   });
 });

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -57,7 +57,7 @@ import {
   preemptTaskSubgraph,
   preemptWorkflowExecution,
 } from './headless-shared.js';
-import { runStartReady } from './start-ready.js';
+import { parseStartReadyExcludeSelector, runStartReady } from './start-ready.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
 type StartReadyRequestExt = StartReadyRequest & {
   recreateFailedAndPending?: boolean;
@@ -82,7 +82,7 @@ type StartReadyPreviewExt = {
   };
 };
 
-const START_READY_USAGE = '--headless start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--recreate-all] [--fresh-base-failed] [--fresh-base-failed-and-pending] [--fresh-base-failed-pending-and-running] [--fresh-base-all] [--no-track]';
+const START_READY_USAGE = '--headless start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--recreate-all] [--exclude mergeMode:no_op]... [--fresh-base-failed] [--fresh-base-failed-and-pending] [--fresh-base-failed-pending-and-running] [--fresh-base-all] [--no-track]';
 
 const FRESH_BASE_MODE_LABELS: Record<StartReadyFreshBaseScope, string> = {
   failed: 'Start ready work and recreate failed workflows from fresh base',
@@ -448,7 +448,8 @@ function parseStartReadyArgs(args: string[], inheritedNoTrack: boolean | undefin
 } {
   const request: StartReadyRequestExt = {};
   let noTrack = inheritedNoTrack ?? false;
-  for (const arg of args) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
     switch (arg) {
       case '--dry-run':
         request.dryRun = true;
@@ -465,6 +466,15 @@ function parseStartReadyArgs(args: string[], inheritedNoTrack: boolean | undefin
       case '--recreate-all':
         request.recreateAll = true;
         break;
+      case '--exclude': {
+        const selector = args[++i];
+        if (!selector || selector.startsWith('--')) {
+          throw new Error(`Missing value for --exclude. Usage: ${START_READY_USAGE}`);
+        }
+        const parsed = parseStartReadyExcludeSelector(selector);
+        request.exclude = [...(request.exclude ?? []), parsed];
+        break;
+      }
       case '--fresh-base-failed':
         request.freshBaseScope = 'failed';
         break;
@@ -520,6 +530,9 @@ export async function headlessStartReady(args: string[], deps: HeadlessDeps): Pr
     printFreshBasePreview(preview, request.freshBaseScope);
   }
   process.stdout.write(`  recreated workflows: ${result.recreatedWorkflowIds.length}\n`);
+  if ((result.excludedWorkflowIds?.length ?? 0) > 0 || (request.exclude?.length ?? 0) > 0) {
+    process.stdout.write(`  excluded workflows: ${result.excludedWorkflowIds?.length ?? 0}\n`);
+  }
   printStartReadyOutcomeSummary(result, request);
   process.stdout.write(`  started: ${runnable.length}\n`);
 

--- a/packages/app/src/merge-mode.ts
+++ b/packages/app/src/merge-mode.ts
@@ -1,9 +1,9 @@
 /**
  * Canonical merge modes stored in persistence and consumed by the merge executor.
  */
-export type CanonicalMergeMode = 'manual' | 'automatic' | 'external_review';
+export type CanonicalMergeMode = 'manual' | 'automatic' | 'external_review' | 'no_op';
 
-const VALID_INPUT = new Set(['manual', 'automatic', 'external_review']);
+const VALID_INPUT = new Set(['manual', 'automatic', 'external_review', 'no_op']);
 
 /**
  * Normalize user-facing merge mode strings for workflow persistence.
@@ -17,5 +17,6 @@ export function normalizeMergeModeForPersistence(raw: string): CanonicalMergeMod
   }
   if (raw === 'external_review') return 'external_review';
   if (raw === 'automatic') return 'automatic';
+  if (raw === 'no_op') return 'no_op';
   return 'manual';
 }

--- a/packages/app/src/metadata-setter.ts
+++ b/packages/app/src/metadata-setter.ts
@@ -163,7 +163,7 @@ function validateWorkflowValue(fieldPath: string, value: unknown, raw: boolean):
     return { onFinish: enumValue<'none' | 'merge' | 'pull_request'>(path, value, ['none', 'merge', 'pull_request']) ?? undefined };
   }
   if (path === 'mergeMode') {
-    return { mergeMode: enumValue<'manual' | 'automatic' | 'external_review'>(path, value, ['manual', 'automatic', 'external_review']) ?? undefined };
+    return { mergeMode: enumValue<'manual' | 'automatic' | 'external_review' | 'no_op'>(path, value, ['manual', 'automatic', 'external_review', 'no_op']) ?? undefined };
   }
   if (path === 'baseBranch') {
     return { baseBranch: normalizeWorkflowBaseBranch(value == null ? null : String(value), 'master') };

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -334,7 +334,7 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
   }
   const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? 'pull_request';
 
-  const validMergeModes = ['manual', 'automatic', 'external_review'] as const;
+  const validMergeModes = ['manual', 'automatic', 'external_review', 'no_op'] as const;
   if (raw.mergeMode !== undefined && !validMergeModes.includes(raw.mergeMode as any)) {
     throw new PlanParseError(
       `"mergeMode" must be one of: ${validMergeModes.join(', ')}. Got: "${raw.mergeMode}"`,

--- a/packages/app/src/start-ready.ts
+++ b/packages/app/src/start-ready.ts
@@ -1,4 +1,5 @@
 import type {
+  StartReadyExcludeSelector,
   StartReadyFreshBasePreview,
   StartReadyFreshBaseScope,
   StartReadyPreview,
@@ -17,6 +18,7 @@ type StartReadyOrchestrator = Pick<
   | 'prepareTaskForNewAttempt'
   | 'recreateWorkflow'
   | 'startExecution'
+  | 'getWorkflowMergeMode'
 >;
 
 type StartReadyRequestExt = StartReadyRequest & {
@@ -38,6 +40,19 @@ type StartReadyPreviewExt = StartReadyPreview & {
     completedTasks: number;
   };
 };
+
+const SUPPORTED_EXCLUDE_SELECTORS = new Set(['mergeMode:no_op']);
+
+export function parseStartReadyExcludeSelector(raw: string): StartReadyExcludeSelector {
+  const trimmed = raw.trim();
+  if (!SUPPORTED_EXCLUDE_SELECTORS.has(trimmed)) {
+    throw new Error(
+      `Unsupported start-ready --exclude selector "${raw}". Expected one of: ${[...SUPPORTED_EXCLUDE_SELECTORS].join(', ')}`,
+    );
+  }
+  return { field: 'mergeMode', value: 'no_op' };
+}
+
 function collectRecoverableTasks(orchestrator: StartReadyOrchestrator): TaskState[] {
   const activeTaskIds = orchestrator.getPersistedActiveTaskIds();
   return orchestrator
@@ -96,6 +111,38 @@ function unionWorkflowIds(...groups: readonly (readonly string[])[]): string[] {
     for (const id of group) ids.add(id);
   }
   return Array.from(ids);
+}
+
+
+function matchesExcludeSelector(
+  orchestrator: StartReadyOrchestrator,
+  workflowId: string,
+  selector: StartReadyExcludeSelector,
+): boolean {
+  if (selector.field === 'mergeMode' && selector.value === 'no_op') {
+    return orchestrator.getWorkflowMergeMode(workflowId) === 'no_op';
+  }
+  return false;
+}
+
+function partitionExcludedWorkflowIds(
+  orchestrator: StartReadyOrchestrator,
+  workflowIds: readonly string[],
+  exclude: readonly StartReadyExcludeSelector[] | undefined,
+): { selected: string[]; excluded: string[] } {
+  if (!exclude || exclude.length === 0) {
+    return { selected: [...workflowIds], excluded: [] };
+  }
+  const selected: string[] = [];
+  const excluded: string[] = [];
+  for (const workflowId of workflowIds) {
+    if (exclude.some((selector) => matchesExcludeSelector(orchestrator, workflowId, selector))) {
+      excluded.push(workflowId);
+    } else {
+      selected.push(workflowId);
+    }
+  }
+  return { selected, excluded };
 }
 
 function workflowIdsToRecreate(
@@ -227,11 +274,21 @@ async function runStartReadyAsync(
   if (freshBasePreview) {
     preview.freshBase = freshBasePreview;
   }
+  const recreateCandidates = freshBasePreview
+    ? []
+    : workflowIdsToRecreate(extendedRequest, preview);
+  const { selected: selectedRecreateIds, excluded: excludedWorkflowIds } = partitionExcludedWorkflowIds(
+    orchestrator,
+    recreateCandidates,
+    extendedRequest.exclude,
+  );
+
   if (request.dryRun) {
     return {
       preview,
       started: [],
       recreatedWorkflowIds: [],
+      excludedWorkflowIds,
       dryRun: true,
     };
   }
@@ -266,7 +323,7 @@ async function runStartReadyAsync(
       }
     }
   } else {
-    for (const workflowId of workflowIdsToRecreate(extendedRequest, preview)) {
+    for (const workflowId of selectedRecreateIds) {
       started.push(...orchestrator.recreateWorkflow(workflowId));
       recreatedWorkflowIds.push(workflowId);
     }
@@ -283,6 +340,7 @@ async function runStartReadyAsync(
     preview,
     started: uniqueTasks(started),
     recreatedWorkflowIds,
+    excludedWorkflowIds,
     ...(freshBasePreview
       ? {
           freshBaseRecreatedWorkflowIds,

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -638,6 +638,11 @@ export type StartReadyWorkflowOutcome =
       error: string;
     };
 
+export type StartReadyExcludeSelector = {
+  field: 'mergeMode';
+  value: 'no_op';
+};
+
 export interface StartReadyRequest {
   recreateFailed?: boolean;
   recreateFailedAndPending?: boolean;
@@ -646,6 +651,8 @@ export interface StartReadyRequest {
   recreateAll?: boolean;
   freshBaseScope?: StartReadyFreshBaseScope;
   dryRun?: boolean;
+  /** Typed selectors that remove matching workflows from bulk recreation. */
+  exclude?: StartReadyExcludeSelector[];
 }
 
 export interface StartReadyPreview {
@@ -671,6 +678,7 @@ export interface StartReadyResult {
   preview: StartReadyPreview;
   started: TaskState[];
   recreatedWorkflowIds: string[];
+  excludedWorkflowIds?: string[];
   freshBaseRecreatedWorkflowIds?: string[];
   workflowOutcomes?: StartReadyWorkflowOutcome[];
   partial?: boolean;

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -117,7 +117,7 @@ export interface Workflow {
   onFinish?: 'none' | 'merge' | 'pull_request';
   baseBranch?: string;
   featureBranch?: string;
-  mergeMode?: 'manual' | 'automatic' | 'external_review';
+  mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
   reviewProvider?: string;
   externalDependencies?: ExternalDependency[];
   externalDependencyChanges?: ExternalDependencyChange[];

--- a/packages/execution-engine/src/__tests__/merge-gate-no-op.test.ts
+++ b/packages/execution-engine/src/__tests__/merge-gate-no-op.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TaskState } from '@invoker/workflow-core';
+import { runMergeGateActionImpl, type MergeRunnerHost } from '../merge-runner.js';
+
+const MERGE_TASK_ID = '__merge__wf-noop';
+
+function makeMergeTask(): TaskState {
+  return {
+    id: MERGE_TASK_ID,
+    description: 'No-op gate',
+    status: 'running',
+    dependencies: ['t1'],
+    createdAt: new Date(),
+    config: { isMergeNode: true, workflowId: 'wf-noop' } as TaskState['config'],
+    execution: { generation: 0 },
+  } as TaskState;
+}
+
+describe('merge gate no_op mode', () => {
+  it('completes without worktree, consolidate, or review publication', async () => {
+    const createMergeWorktree = vi.fn(async () => '/tmp/should-not-create');
+    const consolidateAndMerge = vi.fn(async () => undefined);
+    const createReview = vi.fn(async () => ({ url: 'https://example.invalid/pr/1', identifier: '1' }));
+
+    const host = {
+      cwd: '/tmp/host-repo',
+      defaultBranch: 'master',
+      persistence: {
+        loadWorkflow: () => ({
+          id: 'wf-noop',
+          onFinish: 'none',
+          mergeMode: 'no_op',
+          baseBranch: 'master',
+          featureBranch: 'plan/noop-feature',
+          name: 'No-op Workflow',
+        }),
+        updateTask: vi.fn(),
+        getWorkspacePath: () => null,
+      },
+      orchestrator: {
+        getTask: () => makeMergeTask(),
+        getAllTasks: () => [makeMergeTask()],
+        autoStartExternallyUnblockedReadyTasks: () => [],
+      },
+      createMergeWorktree,
+      consolidateAndMerge,
+      mergeGateProvider: { createReview },
+      async detectDefaultBranch() {
+        return 'master';
+      },
+      async buildMergeSummary() {
+        return '## Summary';
+      },
+    } as unknown as MergeRunnerHost;
+
+    const result = await runMergeGateActionImpl(host, makeMergeTask());
+
+    expect(result.response.status).toBe('completed');
+    expect(result.response.outputs.exitCode).toBe(0);
+    expect(createMergeWorktree).not.toHaveBeenCalled();
+    expect(consolidateAndMerge).not.toHaveBeenCalled();
+    expect(createReview).not.toHaveBeenCalled();
+  });
+});

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -59,10 +59,11 @@ function safeGetWorkspacePath(persistence: SQLiteAdapter, taskId: string): strin
     : undefined;
 }
 
-function canonicalMergeMode(mode: string | undefined): 'manual' | 'automatic' | 'external_review' {
+function canonicalMergeMode(mode: string | undefined): 'manual' | 'automatic' | 'external_review' | 'no_op' {
   const m = mode ?? 'manual';
   if (m === 'external_review') return 'external_review';
   if (m === 'automatic') return 'automatic';
+  if (m === 'no_op') return 'no_op';
   return 'manual';
 }
 
@@ -810,6 +811,19 @@ export async function runMergeGateActionImpl(
   const baseBranch = workflow?.baseBranch ?? host.defaultBranch ?? await host.detectDefaultBranch();
   const featureBranch = workflow?.featureBranch;
   const visualProof = workflow?.visualProof ?? false;
+
+  if (mergeMode === 'no_op') {
+    return {
+      response: {
+        requestId: `merge-${task.id}`,
+        actionId: task.id,
+        executionGeneration: task.execution.generation ?? 0,
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      },
+      taskChanges: {},
+    };
+  }
 
   let response: WorkResponse;
   let reviewUrl: string | undefined;

--- a/packages/test-kit/src/in-memory-persistence.ts
+++ b/packages/test-kit/src/in-memory-persistence.ts
@@ -10,7 +10,7 @@ export class InMemoryPersistence implements OrchestratorPersistence {
     id: string; name: string; status: string;
     createdAt: string; updatedAt: string;
     onFinish?: 'none' | 'merge' | 'pull_request'; baseBranch?: string; featureBranch?: string;
-    mergeMode?: 'manual' | 'automatic' | 'external_review';
+    mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     generation?: number;
@@ -22,7 +22,7 @@ export class InMemoryPersistence implements OrchestratorPersistence {
     id: string; name: string;
     createdAt: string; updatedAt: string;
     onFinish?: 'none' | 'merge' | 'pull_request'; baseBranch?: string; featureBranch?: string;
-    mergeMode?: 'manual' | 'automatic' | 'external_review';
+    mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     generation?: number;
@@ -36,7 +36,7 @@ export class InMemoryPersistence implements OrchestratorPersistence {
     });
   }
 
-  updateWorkflow(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review'; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[] }): void {
+  updateWorkflow(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op'; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[] }): void {
     const wf = this.workflows.get(workflowId);
     if (wf) {
       if (changes.updatedAt) wf.updatedAt = changes.updatedAt;
@@ -97,7 +97,7 @@ export class InMemoryPersistence implements OrchestratorPersistence {
     }
   }
 
-  listWorkflows(): Array<{ id: string; name: string; status: string; createdAt: string; updatedAt: string; baseBranch?: string; onFinish?: string; mergeMode?: 'manual' | 'automatic' | 'external_review'; generation?: number }> {
+  listWorkflows(): Array<{ id: string; name: string; status: string; createdAt: string; updatedAt: string; baseBranch?: string; onFinish?: string; mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op'; generation?: number }> {
     return Array.from(this.workflows.values()).map((workflow) => this.withDerivedStatus(workflow));
   }
 

--- a/packages/workflow-core/src/__tests__/plan-parser.test.ts
+++ b/packages/workflow-core/src/__tests__/plan-parser.test.ts
@@ -104,4 +104,21 @@ tasks:
     expect(() => parsePlan(yaml)).toThrow(PlanParseError);
     expect(() => parsePlan(yaml)).toThrow(/executionModel/);
   });
+
+  it('parses mergeMode no_op', () => {
+    const yaml = `
+name: No Op Plan
+repoUrl: git@github.com:test/repo.git
+baseBranch: main
+onFinish: none
+mergeMode: no_op
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+`;
+    const plan = parsePlan(yaml);
+    expect(plan.mergeMode).toBe('no_op');
+    expect(plan.onFinish).toBe('none');
+  });
 });

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -315,7 +315,7 @@ export class CommandService {
   async editTaskMergeMode(
     envelope: CommandEnvelope<{
       taskId: string;
-      mergeMode: 'manual' | 'automatic' | 'external_review';
+      mergeMode: 'manual' | 'automatic' | 'external_review' | 'no_op';
     }>,
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -258,12 +258,12 @@ export interface OrchestratorPersistence {
     onFinish?: string;
     baseBranch?: string;
     featureBranch?: string;
-    mergeMode?: 'manual' | 'automatic' | 'external_review';
+    mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     detachedExternalDependencies?: DetachedExternalDependency[];
   }): void;
-  updateWorkflow?(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review'; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[]; detachedExternalDependencies?: DetachedExternalDependency[] }): void;
+  updateWorkflow?(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op'; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[]; detachedExternalDependencies?: DetachedExternalDependency[] }): void;
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
   logEvent?(taskId: string, eventType: string, payload?: unknown): void;
@@ -276,7 +276,7 @@ export interface OrchestratorPersistence {
     repoUrl?: string;
     baseBranch?: string;
     onFinish?: string;
-    mergeMode?: 'manual' | 'automatic' | 'external_review';
+    mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     detachedExternalDependencies?: DetachedExternalDependency[];
@@ -293,7 +293,7 @@ export interface OrchestratorPersistence {
       repoUrl?: string;
       baseBranch?: string;
       onFinish?: string;
-      mergeMode?: 'manual' | 'automatic' | 'external_review';
+      mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
       externalDependencies?: ExternalDependency[];
       externalDependencyChanges?: ExternalDependencyChange[];
       detachedExternalDependencies?: DetachedExternalDependency[];
@@ -325,7 +325,7 @@ export interface OrchestratorPersistence {
     intermediateRepoUrl?: string;
     baseBranch?: string;
     featureBranch?: string;
-    mergeMode?: 'manual' | 'automatic' | 'external_review';
+    mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     detachedExternalDependencies?: DetachedExternalDependency[];
@@ -386,7 +386,7 @@ export interface PlanDefinition {
   onFinish?: 'none' | 'merge' | 'pull_request';
   baseBranch?: string;
   featureBranch?: string;
-  mergeMode?: 'manual' | 'automatic' | 'external_review';
+  mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
   reviewProvider?: string;
   repoUrl?: string;
   intermediateRepoUrl?: string;
@@ -2229,7 +2229,7 @@ export class Orchestrator {
 
   editTaskMergeMode(
     taskId: string,
-    mergeMode: 'manual' | 'automatic' | 'external_review',
+    mergeMode: 'manual' | 'automatic' | 'external_review' | 'no_op',
   ): TaskState[] {
     return editTaskMergeModeImpl(this as unknown as TaskEditHost, taskId, mergeMode);
   }
@@ -2386,7 +2386,12 @@ export class Orchestrator {
       if (typeof m.onFinish === 'string') baseSaveWf.onFinish = m.onFinish;
       if (typeof m.baseBranch === 'string') baseSaveWf.baseBranch = m.baseBranch;
       if (typeof m.featureBranch === 'string') baseSaveWf.featureBranch = m.featureBranch;
-      if (m.mergeMode === 'manual' || m.mergeMode === 'automatic' || m.mergeMode === 'external_review') {
+      if (
+        m.mergeMode === 'manual'
+        || m.mergeMode === 'automatic'
+        || m.mergeMode === 'external_review'
+        || m.mergeMode === 'no_op'
+      ) {
         baseSaveWf.mergeMode = m.mergeMode;
       }
       if (Array.isArray(m.externalDependencies)) {
@@ -3079,6 +3084,22 @@ export class Orchestrator {
 
   getWorkflowIds(): string[] {
     return Array.from(this.activeWorkflowIds);
+  }
+
+  /** Merge mode for a workflow, used by bulk start-ready exclusion selectors. */
+  getWorkflowMergeMode(workflowId: string): 'manual' | 'automatic' | 'external_review' | 'no_op' | undefined {
+    const workflow = this.persistence.loadWorkflow?.(workflowId)
+      ?? this.persistence.listWorkflows().find((candidate) => candidate.id === workflowId);
+    const mergeMode = workflow?.mergeMode;
+    if (
+      mergeMode === 'manual'
+      || mergeMode === 'automatic'
+      || mergeMode === 'external_review'
+      || mergeMode === 'no_op'
+    ) {
+      return mergeMode;
+    }
+    return undefined;
   }
 
   /**

--- a/packages/workflow-core/src/orchestrator/task-edits.ts
+++ b/packages/workflow-core/src/orchestrator/task-edits.ts
@@ -302,7 +302,7 @@ export function editTaskAgentImpl(host: TaskEditHost, taskId: string, agentName:
 export function editTaskMergeModeImpl(
   host: TaskEditHost,
   taskId: string,
-  mergeMode: 'manual' | 'automatic' | 'external_review',
+  mergeMode: 'manual' | 'automatic' | 'external_review' | 'no_op',
 ): TaskState[] {
   host.refreshFromDb();
   const task = host.stateGetTask(taskId);

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -173,7 +173,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
   }
   const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? 'pull_request';
 
-  const validMergeModes = ['manual', 'automatic', 'external_review'] as const;
+  const validMergeModes = ['manual', 'automatic', 'external_review', 'no_op'] as const;
   if (raw.mergeMode !== undefined && !validMergeModes.includes(raw.mergeMode as any)) {
     throw new PlanParseError(`"mergeMode" must be one of: ${validMergeModes.join(', ')}. Got: "${raw.mergeMode}"`);
   }

--- a/packages/workflow-core/src/task-repository.ts
+++ b/packages/workflow-core/src/task-repository.ts
@@ -26,7 +26,7 @@ export interface WorkflowRecord {
   onFinish?: 'none' | 'merge' | 'pull_request';
   baseBranch?: string;
   featureBranch?: string;
-  mergeMode?: 'manual' | 'automatic' | 'external_review';
+  mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
   externalDependencies?: ExternalDependency[];
   externalDependencyChanges?: ExternalDependencyChange[];
   detachedExternalDependencies?: DetachedExternalDependency[];
@@ -45,7 +45,7 @@ export interface WorkflowChanges {
   baseBranch?: string;
   featureBranch?: string;
   generation?: number;
-  mergeMode?: 'manual' | 'automatic' | 'external_review';
+  mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
   reviewProvider?: string;
   /**
    * Presence semantics: a key explicitly set to `undefined` clears the


### PR DESCRIPTION
## Summary

Headless operators need a flag to opt out of replaying finished no_op jobs.

This slice wires repeatable --exclude mergeMode:no_op into start-ready parsing and help text.

## Review Claim

Headless start-ready accepts repeatable --exclude mergeMode:no_op and surfaces excluded workflow counts.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Unsupported exclude selectors fail before any workflow mutation.

## Slice Rationale

CLI and help exposure are activation-surface concerns, kept apart from start-ready core filtering.

## Non-goals

Does not change PR-maintenance submit adapters.

Does not invent additional exclude fields beyond mergeMode:no_op.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && ./node_modules/.bin/vitest run src/__tests__/start-ready.test.ts`
- [x] Headless usage string includes `--exclude mergeMode:no_op`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 717382ed3`
- Post-revert steps: None
- Data migration? No

</details>
