### PR TITLE
[Start Ready recreate+rebase expansion](1) Clarify fresh-base headless help

### DIFF
--- a/packages/app/src/__tests__/acknowledge-no-track-start-ready.test.ts
+++ b/packages/app/src/__tests__/acknowledge-no-track-start-ready.test.ts
@@ -89,6 +89,12 @@ describe('acknowledgeNoTrackHeadlessExec start-ready', () => {
     expect(output).toContain('[--fresh-base-failed-pending-and-running]');
     expect(output).toContain('[--fresh-base-all]');
     expect(output).toContain('Fresh-base flags recreate selected workflows from a refreshed base');
+    expect(output).toContain('--fresh-base-failed: failed workflows');
+    expect(output).toContain('--fresh-base-failed-and-pending: failed and pending workflows');
+    expect(output).toContain(
+      '--fresh-base-failed-pending-and-running: failed, pending, and running workflows',
+    );
+    expect(output).toContain('--fresh-base-all: failed, pending, running, and completed workflows');
   });
 
   it.each([

--- a/packages/app/src/headless-usage.ts
+++ b/packages/app/src/headless-usage.ts
@@ -32,7 +32,11 @@ ${BOLD}Execute:${RESET}
   start-ready [--dry-run] [--recreate-failed] [--recreate-failed-and-pending] [--recreate-failed-pending-and-running] [--recreate-all]
               [--fresh-base-failed] [--fresh-base-failed-and-pending] [--fresh-base-failed-pending-and-running] [--fresh-base-all] [--no-track]
                                                       Start pending work that is ready to execute
-                                                      Fresh-base flags recreate selected workflows from a refreshed base
+                                                      Fresh-base flags recreate selected workflows from a refreshed base:
+                                                      --fresh-base-failed: failed workflows
+                                                      --fresh-base-failed-and-pending: failed and pending workflows
+                                                      --fresh-base-failed-pending-and-running: failed, pending, and running workflows
+                                                      --fresh-base-all: failed, pending, running, and completed workflows
   resume <id>                                         Resume incomplete workflow
   retry <workflowId>                                  Retry workflow: rerun failed, keep completed
   retry-task <taskId>                                 Retry a single failed/stuck task


### PR DESCRIPTION
## Summary

Headless Start Ready help now names what each fresh-base scope includes.

This makes the new flags readable without guessing from the long option names.

## Review Claim

Clarify the headless Start Ready fresh-base usage text with explicit scope descriptions.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The edit stays in headless usage copy and the direct no-track help regression.

## Slice Rationale

The fresh-base execution path already exists; this slice only tightens the headless activation surface copy that describes it.

## Non-goals

- No Start Ready execution changes.
- No fresh-base scope selection changes.
- No rail UI behavior changes.
- No delegation timeout changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/acknowledge-no-track-start-ready.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a712d1b7d`
- Post-revert steps: Re-run the focused headless help regression.
- Data migration? No

</details>
