### PR TITLE
[Planning terminal continuity repair](1) Preserve planning chat continuity

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -400,6 +400,51 @@ function makeInitialPlanningSession(
   };
 }
 
+function isInitialPlanningSessionPlaceholder(session: PlanningSessionView | undefined): boolean {
+  if (!session) return false;
+  return session.id === 'local-planning-session-1'
+    && session.title === 'Untitled plan'
+    && session.input === ''
+    && !session.busy
+    && session.messages.length === 0
+    && !session.draftPlanAvailable
+    && !session.terminalSession
+    && !session.terminalBusy
+    && !session.terminalError;
+}
+
+function reconcileHydratedPlanningSessions(
+  currentSessions: PlanningSessionView[],
+  restoredSessions: PlanningSessionView[],
+): PlanningSessionView[] {
+  if (restoredSessions.length === 0) return currentSessions;
+  if (
+    currentSessions.length === 0
+    || (currentSessions.length === 1 && isInitialPlanningSessionPlaceholder(currentSessions[0]))
+  ) {
+    return restoredSessions;
+  }
+
+  const restoredById = new Map(restoredSessions.map((session) => [session.id, session]));
+  const currentIds = new Set(currentSessions.map((session) => session.id));
+  const mergedCurrentSessions = currentSessions.map((session) => {
+    const restored = restoredById.get(session.id);
+    if (!restored) return session;
+    return {
+      ...restored,
+      input: session.input,
+      busy: session.busy,
+      conversationKey: session.conversationKey,
+      mode: session.mode === 'tmux' || restored.mode === 'tmux' ? 'tmux' : restored.mode,
+      terminalSession: restored.terminalSession ?? session.terminalSession,
+      terminalBusy: restored.terminalSession ? false : session.terminalBusy,
+      terminalError: restored.terminalSession ? null : session.terminalError,
+    };
+  });
+  const newRestoredSessions = restoredSessions.filter((session) => !currentIds.has(session.id));
+  return [...mergedCurrentSessions, ...newRestoredSessions];
+}
+
 function planningSessionSummaryToView(session: InAppPlanningSessionSummary): PlanningSessionView {
   return planningSessionFromSummary(session);
 }
@@ -1218,19 +1263,24 @@ export function App() {
       .then((response) => {
         if (cancelled || !response.ok || response.sessions.length === 0) return;
         const currentSessions = planningSessionsRef.current;
-        const first = currentSessions[0];
-        const onlyInitialPlaceholder = currentSessions.length === 1
-          && first?.id === 'local-planning-session-1'
-          && first.input === ''
-          && first.messages.every((line) => line.role === 'system');
-        if (!onlyInitialPlaceholder) return;
         const restored = response.sessions.map(planningSessionSummaryToView);
+        const nextSessions = reconcileHydratedPlanningSessions(currentSessions, restored);
+        if (nextSessions === currentSessions) return;
         const maxLineId = Math.max(1, ...restored.flatMap((session) => session.messages.map((message) => message.id)));
         nextTerminalLineIdRef.current = Math.max(nextTerminalLineIdRef.current, maxLineId + 1);
-        setPlanningSessions(restored);
-        setActivePlanningSessionId(restored[0]?.id ?? 'local-planning-session-1');
-        setSelectedPlanningPresetKey((current) => current || restored[0]?.presetKey || current);
-        setSelectedPlanningConfirmationMode(restored[0]?.confirmationMode ?? 'require');
+        planningSessionsRef.current = nextSessions;
+        setPlanningSessions(nextSessions);
+        const currentSessionId = activePlanningSessionIdRef.current;
+        const nextActiveSessionId = nextSessions.some((session) => session.id === currentSessionId)
+          ? currentSessionId
+          : nextSessions[0]?.id ?? 'local-planning-session-1';
+        activePlanningSessionIdRef.current = nextActiveSessionId;
+        setActivePlanningSessionId(nextActiveSessionId);
+        const nextActiveSession = nextSessions.find((session) => session.id === nextActiveSessionId) ?? nextSessions[0];
+        if (nextActiveSession) {
+          setSelectedPlanningPresetKey((current) => current || nextActiveSession.presetKey || current);
+          setSelectedPlanningConfirmationMode(nextActiveSession.confirmationMode ?? 'require');
+        }
       })
       .catch(() => {});
     return () => {
@@ -1270,12 +1320,15 @@ export function App() {
             ? planningSessionFromSummary(summary, { terminalSession: liveTerminal })
             : planningSessionFromSummary(summary);
         });
-        setPlanningSessions(restored);
-        setActivePlanningSessionId((currentSessionId) => (
-          restored.some((session) => session.id === currentSessionId)
-            ? currentSessionId
-            : restored[0]?.id ?? currentSessionId
-        ));
+        const nextSessions = reconcileHydratedPlanningSessions(planningSessionsRef.current, restored);
+        planningSessionsRef.current = nextSessions;
+        setPlanningSessions(nextSessions);
+        const currentSessionId = activePlanningSessionIdRef.current;
+        const nextActiveSessionId = nextSessions.some((session) => session.id === currentSessionId)
+          ? currentSessionId
+          : nextSessions[0]?.id ?? currentSessionId;
+        activePlanningSessionIdRef.current = nextActiveSessionId;
+        setActivePlanningSessionId(nextActiveSessionId);
         const maxLineId = Math.max(1, ...restored.flatMap((session) => session.messages.map((message) => message.id)));
         nextTerminalLineIdRef.current = Math.max(nextTerminalLineIdRef.current, maxLineId + 1);
       } catch {

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -486,13 +486,19 @@ describe('Invoker terminal (component)', () => {
 
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledTimes(2);
+      expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
+        sessionId: 'session-1',
+        message: 'try again',
+        presetKey: 'codex',
+        confirmationMode: 'require',
+      });
       expect(screen.queryByTestId('invoker-terminal-planner-stream')).not.toBeInTheDocument();
     });
 
     await act(async () => {
       resolveSecondSend?.({
         ok: true,
-        sessionId: 'session-2',
+        sessionId: 'session-1',
         reply: 'Recovered.',
         draftPlanAvailable: false,
       });

--- a/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
@@ -61,6 +61,11 @@ describe('planning terminal failed first send session id persist repro', () => {
 
     submitPlanningText('draft a plan that fails before replying');
     expect(await screen.findByText('planner exited before producing a reply')).toBeInTheDocument();
+    expect(mock.api.planningChatSend).toHaveBeenNthCalledWith(1, {
+      message: 'draft a plan that fails before replying',
+      presetKey: 'codex',
+      confirmationMode: 'require',
+    });
 
     submitPlanningText('retry in the same chat');
 
@@ -73,5 +78,9 @@ describe('planning terminal failed first send session id persist repro', () => {
         confirmationMode: 'require',
       });
     });
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Recovered on the same session.');
+    });
+    expect(screen.queryByText('This planning chat lost its server session. Start a new chat to continue planning.')).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { InAppPlanningListSessionsResponse, TerminalSessionDescriptor } from '@invoker/contracts';
 import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
 
@@ -29,6 +29,23 @@ describe('planning terminal startup hydrate race repro', () => {
   afterEach(() => {
     mock.cleanup();
   });
+
+  async function openPlanningTerminal() {
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+    if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+    if (!screen.queryByTestId('invoker-terminal-harness')) {
+      fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+    }
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+    });
+  }
+
+  function submitPlanningText(text: string) {
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: text } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+  }
 
   it('keeps a live planning tmux session when chat-only hydrate resolves after terminal hydrate', async () => {
     const chatOnlyHydrate = deferred<InAppPlanningListSessionsResponse>();
@@ -98,5 +115,57 @@ describe('planning terminal startup hydrate race repro', () => {
       );
     });
     expect(mock.api.planningTerminalOpen).not.toHaveBeenCalled();
+  });
+
+  it('does not overwrite an already-edited local planning chat when startup hydrate resolves late', async () => {
+    const terminalAwareHydrate = deferred<InAppPlanningListSessionsResponse>();
+    const restoredChat = makePlanningSessionSummary({
+      id: 'restored-existing-chat',
+      title: 'Restored older planning chat',
+      status: 'still_discussing',
+      messages: [
+        {
+          id: 1,
+          role: 'assistant',
+          text: 'Restored planning chat from disk.',
+          createdAt: '2026-07-26T00:00:00.000Z',
+        },
+      ],
+      draftPlanAvailable: false,
+      updatedAt: '2026-07-26T00:00:01.000Z',
+    });
+
+    mock.api.planningChatList = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, sessions: [] })
+      .mockReturnValueOnce(terminalAwareHydrate.promise) as any;
+    mock.api.planningTerminalList = vi.fn(async () => []) as any;
+    mock.api.planningChatSend = vi.fn(() => new Promise(() => {}) as any) as any;
+
+    render(<App />);
+    await waitFor(() => {
+      expect(mock.api.planningChatList).toHaveBeenCalledTimes(2);
+    });
+    await openPlanningTerminal();
+
+    submitPlanningText('start a local plan before restore');
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        message: 'start a local plan before restore',
+        presetKey: 'codex',
+        confirmationMode: 'require',
+      });
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('start a local plan before restore');
+    });
+
+    await act(async () => {
+      terminalAwareHydrate.resolve({ ok: true, sessions: [restoredChat] });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('planning-session-rail')).toHaveTextContent('Restored older planning chat');
+    });
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('start a local plan before restore');
+    expect(screen.getByTestId('invoker-terminal-transcript')).not.toHaveTextContent('Restored planning chat from disk.');
   });
 });


### PR DESCRIPTION
## Summary

Preserve the active planning chat when delayed restore data arrives after local input.

Persist a backend `sessionId` even when the first send reports an error, so the next send continues the same conversation.

## Review Claim

The renderer keeps one planning conversation identity through late hydrate and failed first-send handoff.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change stays in the planning-terminal renderer and directly affected repro files; existing happy-path planning sends and restored-session editing stay covered.

## Slice Rationale

Combining hydrate merge and failed-send handoff keeps the ownership fix in one renderer slice without mixing preset or tmux behavior.

## Non-goals

No backend contract changes.

No harness or preset UX changes.

No tmux restore work.

No unrelated cleanup.

## Architecture

### Before

```mermaid
graph TD
    A["Late restore response"] --> B["Replace planningSessions"]
    C["Failed first send with sessionId"] --> D["Keep local id"]
```

### After

```mermaid
graph TD
    A["Late restore response"] --> B["Merge with active local chat"]
    C["Failed first send with sessionId"] --> D["Move active chat to backend id"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx src/__tests__/planning-terminal-session-id-persist-repro.test.tsx src/__tests__/invoker-terminal.test.tsx`

</details>

## Visual Proof

[Planning terminal restart walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-23fece/planning-terminal-restart.gif)

The walkthrough shows the planning terminal remains attached across a restart; the hidden identity handoff is covered by the focused renderer assertions.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f4818fdc2`
- Post-revert steps: rerun the focused renderer continuity command.
- Data migration? No

</details>
