### PR TITLE
[Reorg packageless PR workers](2) PR-maintenance cron nest

### DIFF
--- a/packages/app/src/__tests__/headless-pr-maintenance.test.ts
+++ b/packages/app/src/__tests__/headless-pr-maintenance.test.ts
@@ -7,6 +7,7 @@ import {
   PR_CI_FAILURE_SCAN_WORKER_KIND,
   PR_ADMIN_BYPASS_LAND_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
+  PR_ORPHAN_REPAIR_WORKER_KIND,
 } from '@invoker/execution-engine';
 import { runHeadless } from '../headless.js';
 
@@ -74,7 +75,11 @@ describe('headless worker PR-maintenance', () => {
   });
 
   it('runs the coderabbit-address worker one-shot with the threaded config', async () => {
-    writeCronScript(repoRoot, 'scripts/cron-coderabbit-address.sh', 'coderabbit.marker');
+    writeCronScript(
+      repoRoot,
+      'packages/execution-engine/scripts/pr-maintenance/cron-coderabbit-address.sh',
+      'coderabbit.marker',
+    );
 
     await runHeadless(['worker', CODERABBIT_ADDRESS_WORKER_KIND], makeWorkerDeps(repoRoot, 'cr-token') as never);
 
@@ -85,7 +90,11 @@ describe('headless worker PR-maintenance', () => {
   });
 
   it('runs the pr-conflict-rebase worker one-shot with the threaded config', async () => {
-    writeCronScript(repoRoot, 'scripts/cron-pr-conflict-rebase.sh', 'rebase.marker');
+    writeCronScript(
+      repoRoot,
+      'packages/execution-engine/scripts/pr-maintenance/cron-pr-conflict-rebase.sh',
+      'rebase.marker',
+    );
 
     await runHeadless(['worker', PR_CONFLICT_REBASE_WORKER_KIND], makeWorkerDeps(repoRoot, 'rebase-token') as never);
 
@@ -93,7 +102,11 @@ describe('headless worker PR-maintenance', () => {
     expect(stdout).toContain(`${PR_CONFLICT_REBASE_WORKER_KIND} worker scan completed.`);
   });
   it('runs the pr-ci-failure-scan worker one-shot with the threaded config', async () => {
-    writeCronScript(repoRoot, 'packages/execution-engine/scripts/cron-pr-ci-failure.sh', 'pr-ci.marker');
+    writeCronScript(
+      repoRoot,
+      'packages/execution-engine/scripts/pr-maintenance/cron-pr-ci-failure.sh',
+      'pr-ci.marker',
+    );
 
     await runHeadless(['worker', PR_CI_FAILURE_SCAN_WORKER_KIND], makeWorkerDeps(repoRoot, 'scan-token') as never);
 
@@ -102,7 +115,11 @@ describe('headless worker PR-maintenance', () => {
   });
 
   it('runs the pr-admin-bypass-land worker one-shot with the threaded config', async () => {
-    writeCronScript(repoRoot, 'scripts/cron-pr-admin-bypass-land.sh', 'land.marker');
+    writeCronScript(
+      repoRoot,
+      'packages/execution-engine/scripts/pr-maintenance/cron-pr-admin-bypass-land.sh',
+      'land.marker',
+    );
 
     await runHeadless(['worker', PR_ADMIN_BYPASS_LAND_WORKER_KIND], makeWorkerDeps(repoRoot, 'land-token') as never);
 
@@ -110,6 +127,18 @@ describe('headless worker PR-maintenance', () => {
     expect(stdout).toContain(`${PR_ADMIN_BYPASS_LAND_WORKER_KIND} worker scan completed.`);
   });
 
+  it('runs the pr-orphan-repair worker one-shot with the threaded config', async () => {
+    writeCronScript(
+      repoRoot,
+      'packages/execution-engine/scripts/pr-maintenance/cron-pr-orphan-repair.sh',
+      'orphan.marker',
+    );
+
+    await runHeadless(['worker', PR_ORPHAN_REPAIR_WORKER_KIND], makeWorkerDeps(repoRoot, 'orphan-token') as never);
+
+    expect(readFileSync(join(repoRoot, 'orphan.marker'), 'utf8')).toBe('orphan-token');
+    expect(stdout).toContain(`${PR_ORPHAN_REPAIR_WORKER_KIND} worker scan completed.`);
+  });
 
   it('lists all PR-maintenance worker kinds from the manual entrypoint', async () => {
     await runHeadless(['worker', 'list'], { invokerConfig: {} } as never);
@@ -119,5 +148,6 @@ describe('headless worker PR-maintenance', () => {
     expect(stdout).toContain(PR_CONFLICT_REBASE_WORKER_KIND);
     expect(stdout).toContain(PR_CI_FAILURE_SCAN_WORKER_KIND);
     expect(stdout).toContain(PR_ADMIN_BYPASS_LAND_WORKER_KIND);
+    expect(stdout).toContain(PR_ORPHAN_REPAIR_WORKER_KIND);
   });
 });

--- a/packages/execution-engine/scripts/cron-pr-ci-failure.sh
+++ b/packages/execution-engine/scripts/cron-pr-ci-failure.sh
@@ -1,56 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# shellcheck source=../../../scripts/cron-pr-lib.sh
-source "$(cd "$(dirname "$0")/../../.." && pwd)/scripts/cron-pr-lib.sh"
-
-cron_lock
-
-prs_json="$(gh_json pr list --repo "$TARGET_REPO" --state open \
-  --json number,mergeable,mergeStateStatus --limit 100)" || {
-  log_line "could not list PRs; exiting"
-  exit 0
-}
-
-failures=0
-processed=0
-while IFS= read -r pr; do
-  [ -z "$pr" ] && continue
-  num="$(jq -r '.number' <<<"$pr")"
-  mergeable="$(jq -r '.mergeable // ""' <<<"$pr")"
-  merge_state="$(jq -r '.mergeStateStatus // ""' <<<"$pr")"
-
-  if [ "$merge_state" = "DIRTY" ] || [ "$mergeable" = "CONFLICTING" ]; then
-    log_line "PR #$num: skip conflicted PR; rebase worker owns it"
-    continue
-  fi
-
-  # Unmapped PRs belong to the orphan-repair worker, which submits one
-  # combined repair task. Only a clean no-workflow miss skips; a broken
-  # lookup falls through so the owner-side repair path reports it.
-  if rec="$(resolve_workflow_for_pr "$num")"; then
-    wf="$(jq -r '.workflowId // empty' <<<"$rec" 2>/dev/null || true)"
-    if [ -z "$wf" ]; then
-      log_line "PR #$num: no Invoker workflow; orphan-repair owns it"
-      continue
-    fi
-  fi
-
-  if ! output="$(headless_mutation repair-review-gate-ci "$num" 2>&1)"; then
-    failures=1
-    while IFS= read -r line; do
-      [ -n "$line" ] || continue
-      log_line "PR #$num: $line"
-    done <<<"$output"
-    continue
-  fi
-
-  processed=$((processed + 1))
-  while IFS= read -r line; do
-    [ -n "$line" ] || continue
-    log_line "PR #$num: $line"
-  done <<<"$output"
-done < <(jq -c '.[]' <<<"$prs_json")
-
-log_line "PR CI scan processed $processed open PRs"
-[ "$failures" -eq 0 ]
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec bash "$SCRIPT_DIR/pr-maintenance/cron-pr-ci-failure.sh" "$@"

--- a/packages/execution-engine/scripts/pr-maintenance/cron-coderabbit-address.sh
+++ b/packages/execution-engine/scripts/pr-maintenance/cron-coderabbit-address.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=cron-pr-lib.sh
+source "$(dirname "$0")/cron-pr-lib.sh"
+
+MAX_CODERABBIT_ATTEMPTS="${INVOKER_PR_CODERABBIT_MAX_ATTEMPTS:-3}"
+STATE_FILE="${INVOKER_PR_CODERABBIT_STATE_FILE:-${HOME}/.invoker/coderabbit-address-submissions.tsv}"
+WORKDIR="${INVOKER_PR_CRON_WORKDIR:-${HOME}/.invoker/pr-cron-work}"
+WORKDIR_MAX_AGE_DAYS="${INVOKER_PR_CRON_WORKDIR_MAX_AGE_DAYS:-7}"
+SUBMIT_CMD="${INVOKER_PR_CODERABBIT_SUBMIT_CMD:-$REPO_ROOT/submit-plan.sh}"
+REPO_URL="${INVOKER_PR_CODERABBIT_REPO_URL:-$(git remote get-url origin 2>/dev/null || echo .)}"
+
+cron_lock
+ledger_init "$STATE_FILE"
+prune_stale_pr_workdirs "$WORKDIR" "$WORKDIR_MAX_AGE_DAYS"
+
+# Fetch one comments endpoint, normalizing gh's per-page arrays into one array.
+fetch_cr_endpoint() {
+  local endpoint="$1" raw
+  raw="$(gh_json api "$endpoint" --paginate 2>/dev/null || true)"
+  printf '%s' "$raw" | jq -s 'add // []' 2>/dev/null || printf '[]'
+}
+
+# Collect CodeRabbit (inline + summary) comments for a PR as a JSON array of
+# {body, updated_at, path, html_url}.
+collect_coderabbit() {
+  local num="$1" inline summary
+  inline="$(fetch_cr_endpoint "repos/$TARGET_REPO/pulls/$num/comments")"
+  summary="$(fetch_cr_endpoint "repos/$TARGET_REPO/issues/$num/comments")"
+  jq -n --argjson inline "$inline" --argjson summary "$summary" --arg login "$CODERABBIT_LOGIN" '
+    ($inline + $summary)
+    | map(select(.user.login == $login))
+    | map({body, updated_at, path: (.path // null), html_url: (.html_url // null)})
+  '
+}
+
+# Build a JSON string literal that is safe to embed directly in YAML.
+json_quote() {
+  jq -nr --arg v "$1" '$v'
+}
+
+slugify_marker() {
+  printf '%s' "$1" \
+    | tr '[:upper:]' '[:lower:]' \
+    | tr -cs 'a-z0-9' '-' \
+    | sed -e 's/^-*//' -e 's/-*$//'
+}
+
+build_prompt() {
+  # build_prompt <num> <base_branch> <head_branch> <ctx_json>
+  local num="$1" base="$2" head="$3" ctx_json="$4"
+  cat <<EOF
+You are addressing CodeRabbit review feedback on GitHub PR #$num in repository $TARGET_REPO.
+Invoker created a dedicated repair workflow for this feedback batch. You are working on the
+PR head branch ($head) inside an Invoker task; when this workflow succeeds, Invoker's merge
+gate will push the merged result back to that PR branch. Do not open, retitle, or edit the
+GitHub PR yourself, and do not run 'git push' manually.
+
+Context JSON for this PR:
+$ctx_json
+
+Do this:
+1. Read the CodeRabbit comments in the JSON context. Also read the actual change under review:
+   'git log origin/$base..HEAD' and 'git diff origin/$base...HEAD', plus the Invoker task list.
+2. For EACH distinct CodeRabbit concern, decide whether it is genuinely valid (a real bug,
+   correctness, or safety issue) — not style noise or a false positive.
+3. For each concern you judge VALID:
+   a. Add a bash repro at scripts/repro/repro-coderabbit-pr$num-<slug>.sh that reproduces the
+      finding and exits NON-ZERO on the buggy behavior (follow scripts/repro/ convention:
+      'set -euo pipefail', derive the repo root, print a clear PASS/FAIL).
+   b. Implement the minimal fix so the repro passes.
+4. For concerns you judge NOT valid, take no code action.
+5. If NO concern is valid, make no code changes and explain that in your task summary.
+
+Constraints: change ONLY what the valid concerns require. Do NOT reformat unrelated code, bump
+versions, or touch files outside a concern's scope. Leave the branch ready for Invoker's merge
+gate to publish the fix back to the PR branch.
+EOF
+}
+
+write_repair_plan() {
+  # write_repair_plan <path> <name> <description> <head_branch> <task_id> <task_description> <prompt>
+  #
+  # Both baseBranch and featureBranch are the PR head branch on purpose. The
+  # repair must layer its fix on TOP of the PR's existing commits and push the
+  # result back to that same branch. If baseBranch were the PR base, Invoker's
+  # merge gate would rebuild the head branch from base + the fix and force-push
+  # that, discarding the PR author's own commits. Manual mergeMode means the
+  # gate parks at review_ready after pushing the head branch and never
+  # squash-merges to base, so base == feature is safe here.
+  local plan_path="$1" plan_name="$2" plan_description="$3" head_branch="$4"
+  local task_id="$5" task_description="$6" prompt="$7"
+  {
+    printf 'name: %s\n' "$(json_quote "$plan_name")"
+    printf 'description: %s\n' "$(json_quote "$plan_description")"
+    printf 'repoUrl: %s\n' "$(json_quote "$REPO_URL")"
+    printf 'baseBranch: %s\n' "$(json_quote "$head_branch")"
+    printf 'featureBranch: %s\n' "$(json_quote "$head_branch")"
+    printf 'onFinish: merge\n'
+    printf 'mergeMode: manual\n'
+    printf 'tasks:\n'
+    printf '  - id: %s\n' "$(json_quote "$task_id")"
+    printf '    description: %s\n' "$(json_quote "$task_description")"
+    printf '    executionAgent: omp\n'
+    if [ -n "${INVOKER_PR_CRON_OMP_MODEL:-}" ]; then
+      printf '    executionModel: %s\n' "$(json_quote "$INVOKER_PR_CRON_OMP_MODEL")"
+    fi
+    printf '    prompt: |\n'
+    printf '%s\n' "$prompt" | sed 's/^/      /'
+  } > "$plan_path"
+}
+
+submit_repair_workflow() {
+  # submit_repair_workflow <num> <pr_title> <head_branch> <base_branch>; exits the script.
+  local num="$1" pr_title="$2" head_branch="$3" base_branch="$4"
+
+  # Count every real attempt (not just successes) so repeated submit failures hit the
+  # cap instead of retrying forever; dedup still keys off the success marker.
+  ledger_record coderabbit-attempt "$num" "$LATEST_MARKER"
+
+  local rec="" wf="" tasks="null"
+  if rec="$(resolve_workflow_for_pr "$num")"; then
+    wf="$(jq -r '.workflowId // empty' <<<"$rec" 2>/dev/null || true)"
+    if [ -n "$wf" ]; then
+      tasks="$("$RUNNER" --headless query tasks --workflow "$wf" --output json 2>/dev/null || printf 'null')"
+      printf '%s' "$tasks" | jq empty 2>/dev/null || tasks="null"
+    else
+      log_line "PR #$num: no local Invoker workflow; proceeding without task context"
+    fi
+  else
+    log_line "PR #$num: review-gate lookup failed; proceeding without task context"
+  fi
+
+  local pr_view pr_body ctx_json marker_slug plan_path prompt workflow_id="" submit_output=""
+  pr_view="$(gh_json pr view "$num" --repo "$TARGET_REPO" --json title,body,headRefName,baseRefName || printf '{}')"
+  pr_body="$(jq -r '.body // ""' <<<"$pr_view")"
+  ctx_json="$(jq -n --arg pr "$num" --arg title "$pr_title" --arg body "$pr_body" \
+        --arg head "$head_branch" --arg base "$base_branch" \
+        --argjson comments "$COLLECTED_COMMENTS" --argjson tasks "$tasks" '
+    { pr: ($pr | tonumber), prTitle: $title, prBody: $body,
+      headBranch: $head, baseBranch: $base,
+      coderabbitComments: $comments, invokerTasks: $tasks }
+  ')"
+
+  mkdir -p "$WORKDIR"
+  marker_slug="$(slugify_marker "$LATEST_MARKER")"
+  plan_path="$WORKDIR/coderabbit-pr-${num}-${marker_slug}.yaml"
+  prompt="$(build_prompt "$num" "$base_branch" "$head_branch" "$ctx_json")"
+  write_repair_plan \
+    "$plan_path" \
+    "CodeRabbit repair PR #$num @ $LATEST_MARKER" \
+    "Address CodeRabbit feedback batch from $LATEST_MARKER on PR #$num through a dedicated Invoker repair workflow." \
+    "$head_branch" \
+    "coderabbit-repair-pr-$num" \
+    "Address CodeRabbit review feedback for PR #$num" \
+    "$prompt"
+
+  if [ "$DRY_RUN" = "1" ]; then
+    log_line "PR #$num: would submit repair workflow $plan_path for new CodeRabbit activity at $LATEST_MARKER"
+    exit 0
+  fi
+
+  log_line "PR #$num: submitting repair workflow $plan_path"
+  if submit_output="$("$SUBMIT_CMD" "$plan_path" 2>&1)"; then
+    [ -n "$submit_output" ] && printf '%s\n' "$submit_output"
+    ledger_record coderabbit "$num" "$LATEST_MARKER"
+    workflow_id="$(printf '%s\n' "$submit_output" | sed -n 's/^Workflow ID: //p' | sed -n '1p')"
+    if [ -n "$workflow_id" ]; then
+      log_line "PR #$num: submitted CodeRabbit repair workflow $workflow_id; recorded marker $LATEST_MARKER"
+    else
+      log_line "PR #$num: submitted CodeRabbit repair workflow; recorded marker $LATEST_MARKER"
+    fi
+    exit 0
+  fi
+
+  [ -n "$submit_output" ] && printf '%s\n' "$submit_output" >&2
+  log_line "PR #$num: repair workflow submit failed; not recording (retry next tick)"
+  exit 1
+}
+
+# Unmapped PRs that are also conflicted or failing CI belong to the
+# orphan-repair worker, which folds review feedback into its combined repair
+# task. Skipping here avoids two agents pushing to the same branch. Returns 0
+# (skip) only on a confirmed broken state plus a clean no-workflow miss; the
+# cheap gh view runs first so healthy PRs never pay the workflow lookup.
+orphan_repair_owns_pr() {
+  local num="$1" rec wf view
+  view="$(gh_json pr view "$num" --repo "$TARGET_REPO" \
+    --json mergeable,mergeStateStatus,statusCheckRollup)" || return 1
+  jq -e '
+    (.mergeable == "CONFLICTING") or (.mergeStateStatus == "DIRTY")
+    or ([.statusCheckRollup[]? | select((.conclusion // "") as $c
+        | $c == "FAILURE" or $c == "ERROR" or $c == "TIMED_OUT" or $c == "CANCELLED")] | length > 0)
+  ' <<<"$view" >/dev/null 2>&1 || return 1
+  rec="$(resolve_workflow_for_pr "$num")" || return 1
+  wf="$(jq -r '.workflowId // empty' <<<"$rec" 2>/dev/null || true)"
+  [ -z "$wf" ]
+}
+
+prs_json="$(gh_json pr list --repo "$TARGET_REPO" --author "$PR_AUTHOR" --state open \
+  --json number,url,headRefName,baseRefName,title --limit 100)" || {
+  log_line "could not list PRs; exiting"
+  exit 0
+}
+
+while IFS= read -r pr; do
+  [ -z "$pr" ] && continue
+  num="$(jq -r '.number' <<<"$pr")"
+  head_branch="$(jq -r '.headRefName' <<<"$pr")"
+  base_branch="$(jq -r '.baseRefName' <<<"$pr")"
+  pr_title="$(jq -r '.title' <<<"$pr")"
+
+  COLLECTED_COMMENTS="$(collect_coderabbit "$num")"
+  LATEST_MARKER="$(jq -r 'map(.updated_at) | max // empty' <<<"$COLLECTED_COMMENTS")"
+  if [ -z "$LATEST_MARKER" ]; then
+    continue
+  fi
+
+  # new-since-last-run dedup (robust to deleted comments lowering the max).
+  seen_max="$(ledger_max_marker coderabbit "$num")"
+  if [ -n "$seen_max" ] && [[ ! "$LATEST_MARKER" > "$seen_max" ]]; then
+    log_line "PR #$num: no new CodeRabbit comments since $seen_max; skip"
+    continue
+  fi
+
+  # Per-feedback-batch attempt cap: counts attempts for THIS comment marker
+  # (incl. failed submit runs), so repeated failures on the same feedback stop
+  # but genuinely new CodeRabbit comments still get a fresh budget.
+  if [ "$(ledger_count coderabbit-attempt "$num" "$LATEST_MARKER")" -ge "$MAX_CODERABBIT_ATTEMPTS" ]; then
+    log_line "PR #$num: CodeRabbit address hit cap of $MAX_CODERABBIT_ATTEMPTS; skip"
+    continue
+  fi
+
+  if orphan_repair_owns_pr "$num"; then
+    log_line "PR #$num: unmapped and broken; orphan-repair owns it this tick"
+    continue
+  fi
+
+  submit_repair_workflow "$num" "$pr_title" "$head_branch" "$base_branch"
+done < <(jq -c '.[]' <<<"$prs_json")
+
+log_line "no PRs with new CodeRabbit feedback this tick"

--- a/packages/execution-engine/scripts/pr-maintenance/cron-pr-admin-bypass-land.sh
+++ b/packages/execution-engine/scripts/pr-maintenance/cron-pr-admin-bypass-land.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=cron-pr-lib.sh
+source "$(dirname "$0")/cron-pr-lib.sh"
+
+cron_lock
+
+args=(--once --repo "$TARGET_REPO" --author "$PR_AUTHOR")
+if [ "$DRY_RUN" = "1" ]; then
+  args+=(--dry-run)
+fi
+
+(
+  cd "$REPO_ROOT"
+  PYTHONPATH=packages/mergify-admin-requeue python3 -m mergify_admin_requeue "${args[@]}"
+)

--- a/packages/execution-engine/scripts/pr-maintenance/cron-pr-ci-failure.sh
+++ b/packages/execution-engine/scripts/pr-maintenance/cron-pr-ci-failure.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=cron-pr-lib.sh
+source "$(dirname "$0")/cron-pr-lib.sh"
+
+cron_lock
+
+prs_json="$(gh_json pr list --repo "$TARGET_REPO" --state open \
+  --json number,mergeable,mergeStateStatus --limit 100)" || {
+  log_line "could not list PRs; exiting"
+  exit 0
+}
+
+failures=0
+processed=0
+while IFS= read -r pr; do
+  [ -z "$pr" ] && continue
+  num="$(jq -r '.number' <<<"$pr")"
+  mergeable="$(jq -r '.mergeable // ""' <<<"$pr")"
+  merge_state="$(jq -r '.mergeStateStatus // ""' <<<"$pr")"
+
+  if [ "$merge_state" = "DIRTY" ] || [ "$mergeable" = "CONFLICTING" ]; then
+    log_line "PR #$num: skip conflicted PR; rebase worker owns it"
+    continue
+  fi
+
+  # Unmapped PRs belong to the orphan-repair worker, which submits one
+  # combined repair task. Only a clean no-workflow miss skips; a broken
+  # lookup falls through so the owner-side repair path reports it.
+  if rec="$(resolve_workflow_for_pr "$num")"; then
+    wf="$(jq -r '.workflowId // empty' <<<"$rec" 2>/dev/null || true)"
+    if [ -z "$wf" ]; then
+      log_line "PR #$num: no Invoker workflow; orphan-repair owns it"
+      continue
+    fi
+  fi
+
+  if ! output="$(headless_mutation repair-review-gate-ci "$num" 2>&1)"; then
+    failures=1
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      log_line "PR #$num: $line"
+    done <<<"$output"
+    continue
+  fi
+
+  processed=$((processed + 1))
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    log_line "PR #$num: $line"
+  done <<<"$output"
+done < <(jq -c '.[]' <<<"$prs_json")
+
+log_line "PR CI scan processed $processed open PRs"
+[ "$failures" -eq 0 ]

--- a/packages/execution-engine/scripts/pr-maintenance/cron-pr-conflict-rebase.sh
+++ b/packages/execution-engine/scripts/pr-maintenance/cron-pr-conflict-rebase.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=cron-pr-lib.sh
+source "$(dirname "$0")/cron-pr-lib.sh"
+
+MAX_REBASE_ATTEMPTS="${INVOKER_PR_REBASE_MAX_ATTEMPTS:-3}"
+CONFIRM_TIMEOUT="${INVOKER_PR_REBASE_CONFIRM_TIMEOUT:-120}"
+STATE_FILE="${INVOKER_PR_CONFLICT_STATE_FILE:-${HOME}/.invoker/pr-conflict-rebase-submissions.tsv}"
+
+cron_lock
+ledger_init "$STATE_FILE"
+
+flag_exhausted() {
+  # flag_exhausted <prNumber> <workflowId>
+  local num="$1" wf="$2"
+  ledger_marker_seen rebase-recreate-flagged "$wf" exhausted && return 0
+  local body="Invoker conflict-rebase cron gave up after ${MAX_REBASE_ATTEMPTS} rebase-recreate attempts; this PR still conflicts and needs manual attention."
+  if [ "$DRY_RUN" = "1" ]; then
+    log_line "PR #$num: would post 'exhausted' comment and flag workflow $wf"
+    return 0
+  fi
+  # Only record the one-time flag if the comment actually posted; otherwise a
+  # transient GitHub failure would permanently suppress the manual-attention ping.
+  if gh_json pr comment "$num" --repo "$TARGET_REPO" --body "$body" >/dev/null; then
+    ledger_record rebase-recreate-flagged "$wf" exhausted
+  else
+    log_line "PR #$num: exhausted-comment post failed (non-fatal); will retry the flag next tick"
+  fi
+}
+
+dispatch_rebase_recreate() {
+  # dispatch_rebase_recreate <prNumber> <workflowId> <generation>; exits the script.
+  local num="$1" wf="$2" gen="$3"
+  if [ "$DRY_RUN" = "1" ]; then
+    log_line "PR #$num: would rebase-recreate $wf (generation $gen)"
+    exit 0
+  fi
+
+  log_line "PR #$num: rebase-recreate $wf (generation $gen)"
+  if ! node "$IPC_HELPER" exec -- rebase-recreate "$wf"; then
+    log_line "PR #$num: rebase-recreate dispatch failed; retry next tick"
+    exit 1
+  fi
+  # Count the accepted dispatch so a non-idempotent rebase-recreate that is
+  # accepted but never advances generation still hits the cap, instead of
+  # re-firing every tick. The cap below counts attempts, not just confirmations.
+  ledger_record rebase-recreate-attempt "$wf" "$gen"
+
+  # Confirm the recreate actually landed: generation must advance past $gen.
+  local deadline newgen
+  deadline="$(( $(date +%s) + CONFIRM_TIMEOUT ))"
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    # Tolerate a transient query/jq failure (set -e would otherwise abort the
+    # whole worker mid-confirmation); just keep polling until the deadline.
+    newgen="$("$RUNNER" --headless query workflow "$wf" --output json 2>/dev/null | jq -r '.generation // empty' 2>/dev/null || true)"
+    if [ -n "$newgen" ] && [ "$newgen" -gt "$gen" ]; then
+      ledger_record rebase-recreate "$wf" "$gen"
+      log_line "PR #$num: rebase-recreate confirmed (generation $gen -> $newgen)"
+      exit 0
+    fi
+    sleep 5
+  done
+  log_line "PR #$num: rebase-recreate not confirmed within ${CONFIRM_TIMEOUT}s; not recording (retry next tick)"
+  exit 1
+}
+
+prs_json="$(gh_json pr list --repo "$TARGET_REPO" --author "$PR_AUTHOR" --state open \
+  --json number,headRefName,mergeable,mergeStateStatus --limit 100)" || {
+  log_line "could not list PRs; exiting"
+  exit 0
+}
+
+# Process substitution (not a pipe) keeps the loop in this shell so `exit`
+# after the single per-tick operation terminates the script.
+while IFS= read -r pr; do
+  [ -z "$pr" ] && continue
+  num="$(jq -r '.number' <<<"$pr")"
+
+  if ! rec="$(resolve_workflow_for_pr "$num")"; then
+    log_line "PR #$num: review-gate lookup failed; skip (retry next tick)"
+    continue
+  fi
+  wf="$(jq -r '.workflowId // empty' <<<"$rec" 2>/dev/null || true)"
+  if [ -z "$wf" ]; then
+    log_line "PR #$num: no local workflow; skip"
+    continue
+  fi
+  gen="$(jq -r '.workflowGeneration // 0' <<<"$rec")"
+
+  # (c) per-(workflow, generation) dedup.
+  if ledger_marker_seen rebase-recreate "$wf" "$gen"; then
+    log_line "PR #$num: rebase-recreate already fired for generation $gen; skip"
+    continue
+  fi
+
+  # (e) per-generation attempt cap + one-time GitHub flag. Counts accepted
+  # dispatches for THIS generation (rebase-recreate-attempt), so a dispatch that
+  # is accepted but never confirms still counts toward the cap instead of
+  # re-firing forever, while a genuinely new conflict (new generation) gets a
+  # fresh budget.
+  if [ "$(ledger_count rebase-recreate-attempt "$wf" "$gen")" -ge "$MAX_REBASE_ATTEMPTS" ]; then
+    log_line "PR #$num: giving up — rebase-recreate hit cap of $MAX_REBASE_ATTEMPTS for workflow $wf"
+    flag_exhausted "$num" "$wf"
+    continue
+  fi
+
+  # (f) dispatch the single operation for this tick, then exit.
+  dispatch_rebase_recreate "$num" "$wf" "$gen"
+done < <(jq -c '.[] | select(.mergeStateStatus == "DIRTY" or .mergeable == "CONFLICTING")' <<<"$prs_json")
+
+log_line "no actionable conflicting PRs this tick"

--- a/packages/execution-engine/scripts/pr-maintenance/cron-pr-lib.sh
+++ b/packages/execution-engine/scripts/pr-maintenance/cron-pr-lib.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# Shared helpers for PR-maintenance cron jobs that run co-located with the
+# Invoker owner:
+#
+#   packages/execution-engine/scripts/pr-maintenance/cron-coderabbit-address.sh
+#   packages/execution-engine/scripts/pr-maintenance/cron-pr-conflict-rebase.sh
+#   packages/execution-engine/scripts/pr-maintenance/cron-pr-ci-failure.sh
+#   packages/execution-engine/scripts/pr-maintenance/cron-pr-admin-bypass-land.sh
+#   packages/execution-engine/scripts/pr-maintenance/cron-pr-orphan-repair.sh
+#
+# Source this AFTER `set -euo pipefail`:
+#   source "$(dirname "$0")/cron-pr-lib.sh"
+#
+# Provides:
+#   Variables: REPO_ROOT, RUNNER, IPC_HELPER (from headless-lib.sh),
+#              TARGET_REPO, PR_AUTHOR, CODERABBIT_LOGIN, CRON_LOCK, DRY_RUN
+#   Functions: log_line, cron_lock, ledger_init, ledger_record, ledger_count,
+#              ledger_marker_seen, ledger_max_marker, gh_json,
+#              resolve_workflow_for_pr, prune_stale_pr_workdirs
+#
+# Both jobs run their mutating operation SYNCHRONOUSLY while holding a single
+# shared lock, so only one PR cron operation runs at a time (the other exits
+# this tick and retries in 5 min). The lock prefers flock (Linux owner host)
+# and falls back to an atomic mkdir lock where flock is absent (e.g. macOS).
+
+# headless-lib.sh: REPO_ROOT, RUNNER, IPC_HELPER, headless_query, ... It keys
+# off ${BASH_SOURCE[0]} so it resolves correctly no matter the caller's cwd.
+_PR_MAINTENANCE_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+# shellcheck source=scripts/headless-lib.sh
+source "$_PR_MAINTENANCE_REPO_ROOT/scripts/headless-lib.sh"
+unset _PR_MAINTENANCE_REPO_ROOT
+
+# ---------------------------------------------------------------------------
+# Configuration (all overridable via env)
+# ---------------------------------------------------------------------------
+
+TARGET_REPO="${INVOKER_GITHUB_TARGET_REPO:-Neko-Catpital-Labs/Invoker}"
+PR_AUTHOR="${INVOKER_PR_CRON_AUTHOR:-EdbertChan}"
+CODERABBIT_LOGIN="${INVOKER_CODERABBIT_LOGIN:-coderabbitai[bot]}"
+CRON_LOCK="${INVOKER_PR_CRON_LOCK:-${TMPDIR:-/tmp}/invoker-pr-crons.lock}"
+DRY_RUN="${INVOKER_PR_CRON_DRY_RUN:-0}"
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+log_line() {
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+# ---------------------------------------------------------------------------
+# Shared cross-job lock (decision 3): one PR cron operation at a time.
+# Exits 0 (clean no-op) when the other job holds the lock.
+# ---------------------------------------------------------------------------
+
+_cron_lock_reap_stale() {
+  # Steal a mkdir lock only when its holder is gone. The holder records its PID
+  # in the lock dir; we reap on a dead PID and NEVER on age alone, so a healthy
+  # long run keeps the lock no matter how long it takes (age-based reaping would
+  # break mutual exclusion once a run crossed the threshold). flock has no such
+  # risk (the kernel releases the fd), so this only applies to the mkdir path.
+  local lockdir="$1"
+  local pid_file="$lockdir/pid"
+  local holder=""
+  [ -f "$pid_file" ] && holder="$(cat "$pid_file" 2>/dev/null || true)"
+  if [ -n "$holder" ]; then
+    kill -0 "$holder" 2>/dev/null && return 0   # holder alive — do not reap
+    rm -rf "$lockdir" 2>/dev/null || true
+    return 0
+  fi
+  # No PID recorded (a pre-PID or garbled lock): fall back to an age threshold so
+  # a crashed legacy holder is still cleaned up eventually.
+  local max_age now mtime
+  max_age="${INVOKER_PR_CRON_LOCK_STALE_SECS:-3600}"
+  now="$(date +%s)"
+  mtime="$(stat -f %m "$lockdir" 2>/dev/null || stat -c %Y "$lockdir" 2>/dev/null || echo "$now")"
+  if [ "$((now - mtime))" -ge "$max_age" ]; then
+    rm -rf "$lockdir" 2>/dev/null || true
+  fi
+}
+
+cron_lock() {
+  if command -v flock >/dev/null 2>&1; then
+    exec 9>"$CRON_LOCK"
+    if ! flock -n 9; then
+      log_line "another PR cron operation in progress; exiting"
+      exit 0
+    fi
+    return 0
+  fi
+
+  # Portable fallback: atomic mkdir lock, reaped only on a dead holder PID.
+  local lockdir="${CRON_LOCK}.d"
+  [ -d "$lockdir" ] && _cron_lock_reap_stale "$lockdir"
+  if ! mkdir "$lockdir" 2>/dev/null; then
+    log_line "another PR cron operation in progress; exiting"
+    exit 0
+  fi
+  printf '%s\n' "$$" > "$lockdir/pid"
+  CRON_LOCK_DIR="$lockdir"
+  # shellcheck disable=SC2064
+  trap 'rm -rf "'"$lockdir"'" 2>/dev/null || true' EXIT
+}
+
+# ---------------------------------------------------------------------------
+# Durable attempt ledger (append-only TSV: kind \t key \t marker \t epoch).
+# One file per job; both under ~/.invoker. Markers are opaque strings:
+#   Job 1 records a comment's ISO-8601 updated_at; Job 2 records a generation.
+# ---------------------------------------------------------------------------
+
+LEDGER=""
+
+ledger_init() {
+  LEDGER="${1:?ledger path required}"
+  mkdir -p "$(dirname "$LEDGER")"
+  touch "$LEDGER"
+}
+
+ledger_record() {
+  # ledger_record <kind> <key> <marker>
+  printf '%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$(date +%s)" >> "$LEDGER"
+}
+
+ledger_count() {
+  # ledger_count <kind> <key> [marker] -> rows matching kind+key, and the marker
+  # too when given. The marker scope keeps an attempt cap per feedback-batch
+  # (comment timestamp / workflow generation) instead of per-PR-lifetime, so a
+  # newer batch gets a fresh budget while repeats of the same batch stay capped.
+  awk -F '\t' -v k="$1" -v key="$2" -v m="${3-}" -v has_m="${3+1}" \
+    '$1 == k && $2 == key && (has_m == "" || $3 == m) { c++ } END { print c + 0 }' "$LEDGER"
+}
+
+ledger_marker_seen() {
+  # ledger_marker_seen <kind> <key> <marker> -> exit 0 if that exact marker recorded
+  awk -F '\t' -v k="$1" -v key="$2" -v m="$3" \
+    '$1 == k && $2 == key && $3 == m { f = 1 } END { exit f ? 0 : 1 }' "$LEDGER"
+}
+
+ledger_max_marker() {
+  # ledger_max_marker <kind> <key> -> the lexical/numeric max marker recorded
+  # (empty when none). ISO-8601 timestamps sort lexically == chronologically.
+  awk -F '\t' -v k="$1" -v key="$2" \
+    '$1 == k && $2 == key { if (m == "" || $3 > m) m = $3 } END { print m }' "$LEDGER"
+}
+
+# ---------------------------------------------------------------------------
+# GitHub helper: run `gh` with one retry on transient failure. Callers pass
+# `--repo "$TARGET_REPO"` (gh pr ...) or embed the repo in the api path.
+# ---------------------------------------------------------------------------
+
+gh_json() {
+  local out code
+  set +e
+  out="$(gh "$@" 2>&1)"
+  code=$?
+  if [ "$code" -ne 0 ]; then
+    sleep 2
+    out="$(gh "$@" 2>&1)"
+    code=$?
+  fi
+  set -e
+  if [ "$code" -ne 0 ]; then
+    log_line "gh failed (gh $*): $out" >&2
+    return "$code"
+  fi
+  printf '%s' "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Resolve a PR number to its Invoker workflow via the read-only review-gate
+# query (Step 1). On success it echoes the JSON record, or `{}` for a genuine
+# miss (review-gate exits 0 with `{}` when no workflow matches). A real
+# lookup/runtime failure propagates a NON-ZERO exit so callers can tell
+# "no local workflow" apart from "the lookup path is broken" instead of
+# silently skipping eligible PRs. A test seam (INVOKER_PR_CRON_REVIEW_GATE_CMD)
+# lets repros stub it without a built dist.
+# ---------------------------------------------------------------------------
+
+resolve_workflow_for_pr() {
+  local pr="$1"
+  if [ -n "${INVOKER_PR_CRON_REVIEW_GATE_CMD:-}" ]; then
+    "$INVOKER_PR_CRON_REVIEW_GATE_CMD" "$pr"
+    return
+  fi
+  headless_query query review-gate "$pr" --output json
+}
+
+# ---------------------------------------------------------------------------
+# Local disk guardrail: prune stale PR checkout workdirs.
+# This is only used by Job 1 (cron-coderabbit-address) today, but lives here so
+# both jobs share the same policy when/if Job 2 needs checkouts later.
+# ---------------------------------------------------------------------------
+
+PR_CRON_WORKDIR_STAMP_NAME=".invoker-pr-cron-last-used"
+
+_stat_mtime_epoch() {
+  local path="${1:?path required}"
+  if stat -c %Y "$path" >/dev/null 2>&1; then
+    stat -c %Y "$path"
+    return
+  fi
+  stat -f %m "$path"
+}
+
+prune_stale_pr_workdirs() {
+  # prune_stale_pr_workdirs <root> <max_age_days>
+  local root="${1:?workdir root required}"
+  local max_age_days="${2:-7}"
+
+  if [ -z "$root" ] || [ "$root" = "/" ] || [ "$root" = "$HOME" ]; then
+    log_line "prune: refusing to prune unsafe root \"$root\"" >&2
+    return 1
+  fi
+
+  if [[ ! "$max_age_days" =~ ^[0-9]+$ ]]; then
+    log_line "prune: invalid max age days \"$max_age_days\" (expected integer)" >&2
+    return 1
+  fi
+
+  [ -d "$root" ] || return 0
+
+  local now cutoff
+  now="$(date +%s)"
+  cutoff="$(( now - max_age_days * 24 * 60 * 60 ))"
+
+  shopt -s nullglob
+  local dir name stamp mtime
+  for dir in "$root"/*; do
+    [ -d "$dir" ] || continue
+    name="$(basename "$dir")"
+    [[ "$name" =~ ^[0-9]+$ ]] || continue
+
+    stamp="$dir/$PR_CRON_WORKDIR_STAMP_NAME"
+    if [ -e "$stamp" ]; then
+      mtime="$(_stat_mtime_epoch "$stamp" 2>/dev/null || true)"
+    else
+      mtime="$(_stat_mtime_epoch "$dir" 2>/dev/null || true)"
+    fi
+
+    [ -n "${mtime:-}" ] || continue
+    [[ "$mtime" =~ ^[0-9]+$ ]] || continue
+
+    if [ "$mtime" -lt "$cutoff" ]; then
+      if [ "$DRY_RUN" = "1" ]; then
+        log_line "prune: would remove stale pr workdir \"$dir\" (mtime=$mtime cutoff=$cutoff age_days=$max_age_days)"
+      else
+        rm -rf "$dir"
+        log_line "prune: removed stale pr workdir \"$dir\" (age_days=$max_age_days)"
+      fi
+    fi
+  done
+  shopt -u nullglob
+}

--- a/packages/execution-engine/scripts/pr-maintenance/cron-pr-orphan-repair.sh
+++ b/packages/execution-engine/scripts/pr-maintenance/cron-pr-orphan-repair.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Orphan-PR repair cron (Job 5) — owns open PRs that have NO Invoker workflow
+# mapping. The mapped-PR workers (conflict-rebase, ci-failure-scan,
+# coderabbit-address, admin-bypass-land) skip unmapped PRs; this job is their
+# counterpart: it classifies EVERYTHING blocking an unmapped PR (merge
+# conflict, failing required checks, changes-requested review) into one
+# combined brief and submits ONE real Invoker repair task via the owner's
+# `run` command. One task per broken head-state: the ledger fingerprints
+# (headOid + blockers) so a tick never re-submits the same breakage, and an
+# attempt cap posts a single "gave up" PR comment before going quiet.
+#
+# Coordination contract:
+#   - mapped PRs      -> skipped here (existing workers own them)
+#   - unmapped broken -> owned here; coderabbit/ci crons skip them
+#   - unmapped clean  -> nobody's business
+#
+# Env (all optional):
+#   INVOKER_PR_ORPHAN_STATE_FILE    ledger path   (default ~/.invoker/pr-orphan-repair.tsv)
+#   INVOKER_PR_ORPHAN_MAX_ATTEMPTS  attempt cap per fingerprint (default 3)
+#   INVOKER_PR_CRON_DRY_RUN=1       log the plan instead of submitting
+
+# shellcheck source=cron-pr-lib.sh
+source "$(dirname "$0")/cron-pr-lib.sh"
+
+cron_lock
+
+STATE_FILE="${INVOKER_PR_ORPHAN_STATE_FILE:-$HOME/.invoker/pr-orphan-repair.tsv}"
+MAX_ATTEMPTS="${INVOKER_PR_ORPHAN_MAX_ATTEMPTS:-3}"
+ledger_init "$STATE_FILE"
+
+# Repros pass INVOKER_PR_ORPHAN_PLAN_DIR to inspect submitted plans; a
+# caller-provided dir is never cleaned up here.
+if [ -n "${INVOKER_PR_ORPHAN_PLAN_DIR:-}" ]; then
+  PLAN_DIR="$INVOKER_PR_ORPHAN_PLAN_DIR"
+  mkdir -p "$PLAN_DIR"
+else
+  PLAN_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-orphan-plans.XXXXXX")"
+  trap 'rm -rf "$PLAN_DIR"' EXIT
+fi
+
+prs_json="$(gh_json pr list --repo "$TARGET_REPO" --author "$PR_AUTHOR" --state open \
+  --json number,title,url,isDraft,baseRefName,headRefName,headRefOid,mergeable,mergeStateStatus,statusCheckRollup,reviewDecision \
+  --limit 100)" || {
+  log_line "could not list PRs; exiting"
+  exit 0
+}
+
+submitted=0
+while IFS= read -r pr; do
+  [ -z "$pr" ] && continue
+  num="$(jq -r '.number' <<<"$pr")"
+
+  if [ "$(jq -r '.isDraft' <<<"$pr")" = "true" ]; then
+    continue
+  fi
+
+  # Mapped PRs belong to the existing per-symptom workers.
+  wf=""
+  if rec="$(resolve_workflow_for_pr "$num")"; then
+    wf="$(jq -r '.workflowId // empty' <<<"$rec" 2>/dev/null || true)"
+  fi
+  if [ -n "$wf" ]; then
+    log_line "PR #$num: mapped to workflow $wf; existing workers own it"
+    continue
+  fi
+
+  # ── Classify blockers (conflict first, then CI, then review) ──
+  blockers=()
+  mergeable="$(jq -r '.mergeable // ""' <<<"$pr")"
+  merge_state="$(jq -r '.mergeStateStatus // ""' <<<"$pr")"
+  if [ "$mergeable" = "CONFLICTING" ] || [ "$merge_state" = "DIRTY" ]; then
+    blockers+=("conflict: GitHub reports a merge conflict against $(jq -r '.baseRefName' <<<"$pr")")
+  fi
+  failed_checks="$(jq -r '[.statusCheckRollup[]? | select((.conclusion // "") as $c
+    | $c == "FAILURE" or $c == "ERROR" or $c == "TIMED_OUT" or $c == "CANCELLED")
+    | .name] | unique | join(", ")' <<<"$pr")"
+  if [ -n "$failed_checks" ]; then
+    blockers+=("failed_checks: $failed_checks")
+  fi
+  if [ "$(jq -r '.reviewDecision // ""' <<<"$pr")" = "CHANGES_REQUESTED" ]; then
+    blockers+=("changes_requested: a reviewer requested changes; address the open feedback")
+  fi
+  if [ "${#blockers[@]}" -eq 0 ]; then
+    continue
+  fi
+
+  head_oid="$(jq -r '.headRefOid' <<<"$pr")"
+  fingerprint="$(printf '%s|%s' "$head_oid" "$(printf '%s;' "${blockers[@]}")" \
+    | shasum -a 256 2>/dev/null || printf '%s|%s' "$head_oid" "$(printf '%s;' "${blockers[@]}")" | sha256sum)"
+  fingerprint="${fingerprint%% *}"
+  fingerprint="${fingerprint:0:16}"
+
+  if ledger_marker_seen orphan-submitted "$num" "$fingerprint"; then
+    log_line "PR #$num: repair already submitted for this head-state ($fingerprint); waiting"
+    continue
+  fi
+  if [ "$(ledger_count orphan-attempt "$num" "$fingerprint")" -ge "$MAX_ATTEMPTS" ]; then
+    if ! ledger_marker_seen orphan-exhausted "$num" "$fingerprint"; then
+      ledger_record orphan-exhausted "$num" "$fingerprint"
+      gh pr comment "$num" --repo "$TARGET_REPO" \
+        --body "Invoker orphan-repair gave up after $MAX_ATTEMPTS repair-task attempts for this head state. Blockers: $(printf '%s; ' "${blockers[@]}")" \
+        >/dev/null 2>&1 || true
+      log_line "PR #$num: attempt cap reached ($MAX_ATTEMPTS); posted exhausted comment"
+    fi
+    continue
+  fi
+
+  title="$(jq -r '.title' <<<"$pr")"
+  url="$(jq -r '.url' <<<"$pr")"
+  head_ref="$(jq -r '.headRefName' <<<"$pr")"
+  base_ref="$(jq -r '.baseRefName' <<<"$pr")"
+  summary="$(printf '%s; ' "${blockers[@]}")"
+
+  plan_file="$PLAN_DIR/repair-pr-$num.yaml"
+  {
+    printf 'name: repair-pr-%s-%s\n' "$num" "$fingerprint"
+    printf 'onFinish: none\n'
+    printf 'baseBranch: %s\n' "$base_ref"
+    printf 'tasks:\n'
+    printf '  - id: repair\n'
+    printf '    description: "Repair PR #%s: %s"\n' "$num" "$(printf '%s' "$summary" | tr '"' "'")"
+    printf '    prompt: |\n'
+    {
+      printf 'Repair the existing pull request #%s ("%s") on %s.\n' "$num" "$title" "$TARGET_REPO"
+      printf 'PR URL: %s\n' "$url"
+      printf 'Head branch: %s (at %s), base branch: %s\n\n' "$head_ref" "$head_oid" "$base_ref"
+      printf 'This PR has no Invoker workflow; work directly on its branch:\n'
+      printf '  git fetch origin %s && git checkout %s\n\n' "$head_ref" "$head_ref"
+      printf 'Blockers to clear, strictly in this order:\n'
+      i=1
+      for b in "${blockers[@]}"; do
+        printf '  %d. %s\n' "$i" "$b"
+        i=$((i + 1))
+      done
+      printf '\nRules:\n'
+      printf -- '- Resolve the merge conflict by rebasing onto origin/%s (or merging it) before anything else.\n' "$base_ref"
+      printf -- '- Reproduce and fix the failing checks locally before pushing.\n'
+      printf -- '- Address review feedback with real changes or a reasoned reply, never by dismissing.\n'
+      printf -- '- Push to the SAME branch (%s). NEVER open a new PR and NEVER force-push unless the rebase requires it.\n' "$head_ref"
+    } | sed 's/^/      /'
+  } > "$plan_file"
+
+  if [ "$DRY_RUN" = "1" ]; then
+    log_line "PR #$num: DRY-RUN would submit repair task (blockers: $summary)"
+    continue
+  fi
+
+  ledger_record orphan-attempt "$num" "$fingerprint"
+  if output="$(headless_mutation run "$plan_file" 2>&1)"; then
+    ledger_record orphan-submitted "$num" "$fingerprint"
+    submitted=$((submitted + 1))
+    log_line "PR #$num: submitted repair task ($fingerprint; blockers: $summary)"
+  else
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      log_line "PR #$num: submit failed: $line"
+    done <<<"$output"
+  fi
+done < <(jq -c '.[]' <<<"$prs_json")
+
+log_line "orphan-repair scan complete; submitted $submitted repair task(s)"

--- a/packages/execution-engine/src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts
@@ -12,11 +12,26 @@ const repoRoot = resolveRepoRoot(process.cwd());
 // Every registered PR-maintenance cron entrypoint. Add a new worker's script
 // here so this guard proves the script can source its shared library.
 const PR_MAINTENANCE_ENTRYPOINTS = [
-  { kind: 'coderabbit-address', scriptRelativePath: 'scripts/cron-coderabbit-address.sh' },
-  { kind: 'pr-conflict-rebase', scriptRelativePath: 'scripts/cron-pr-conflict-rebase.sh' },
-  { kind: 'pr-ci-failure-scan', scriptRelativePath: 'packages/execution-engine/scripts/cron-pr-ci-failure.sh' },
-  { kind: 'pr-admin-bypass-land', scriptRelativePath: 'scripts/cron-pr-admin-bypass-land.sh' },
-  { kind: 'pr-orphan-repair', scriptRelativePath: 'scripts/cron-pr-orphan-repair.sh' },
+  {
+    kind: 'coderabbit-address',
+    scriptRelativePath: 'packages/execution-engine/scripts/pr-maintenance/cron-coderabbit-address.sh',
+  },
+  {
+    kind: 'pr-conflict-rebase',
+    scriptRelativePath: 'packages/execution-engine/scripts/pr-maintenance/cron-pr-conflict-rebase.sh',
+  },
+  {
+    kind: 'pr-ci-failure-scan',
+    scriptRelativePath: 'packages/execution-engine/scripts/pr-maintenance/cron-pr-ci-failure.sh',
+  },
+  {
+    kind: 'pr-admin-bypass-land',
+    scriptRelativePath: 'packages/execution-engine/scripts/pr-maintenance/cron-pr-admin-bypass-land.sh',
+  },
+  {
+    kind: 'pr-orphan-repair',
+    scriptRelativePath: 'packages/execution-engine/scripts/pr-maintenance/cron-pr-orphan-repair.sh',
+  },
 ] as const;
 
 describe('PR maintenance entrypoints bootstrap', () => {
@@ -75,6 +90,7 @@ describe('PR maintenance entrypoints bootstrap', () => {
         '#!/usr/bin/env bash',
         '{',
         '  printf "cwd=%s\\n" "$PWD"',
+        '  printf "pythonpath=%s\\n" "$PYTHONPATH"',
         '  printf "args="',
         '  printf "<%s>" "$@"',
         '  printf "\\n"',
@@ -85,25 +101,30 @@ describe('PR maintenance entrypoints bootstrap', () => {
       { mode: 0o755 },
     );
 
-    const result = spawnSync('bash', [resolve(repoRoot, 'scripts/cron-pr-admin-bypass-land.sh')], {
-      cwd: tmpdir(),
-      encoding: 'utf8',
-      timeout: 20_000,
-      env: {
-        ...process.env,
-        PATH: `${stubBin}:${process.env.PATH ?? ''}`,
-        INVOKER_GITHUB_TARGET_REPO: 'owner/repo',
-        INVOKER_PR_CRON_AUTHOR: 'octocat',
-        INVOKER_PR_CRON_DRY_RUN: '1',
-        INVOKER_PR_CRON_LOCK: lockPath,
-        PYTHON_CAPTURE: capturePath,
+    const result = spawnSync(
+      'bash',
+      [resolve(repoRoot, 'packages/execution-engine/scripts/pr-maintenance/cron-pr-admin-bypass-land.sh')],
+      {
+        cwd: tmpdir(),
+        encoding: 'utf8',
+        timeout: 20_000,
+        env: {
+          ...process.env,
+          PATH: `${stubBin}:${process.env.PATH ?? ''}`,
+          INVOKER_GITHUB_TARGET_REPO: 'owner/repo',
+          INVOKER_PR_CRON_AUTHOR: 'octocat',
+          INVOKER_PR_CRON_DRY_RUN: '1',
+          INVOKER_PR_CRON_LOCK: lockPath,
+          PYTHON_CAPTURE: capturePath,
+        },
       },
-    });
+    );
 
     expect(result.status).toBe(0);
     expect(readFileSync(capturePath, 'utf8')).toBe([
       `cwd=${repoRoot}`,
-      'args=<scripts/mergify_admin_requeue.py><--once><--repo><owner/repo><--author><octocat><--dry-run>',
+      'pythonpath=packages/mergify-admin-requeue',
+      'args=<-m><mergify_admin_requeue><--once><--repo><owner/repo><--author><octocat><--dry-run>',
       '',
     ].join('\n'));
   });

--- a/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
@@ -16,10 +16,12 @@ import {
   DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS,
   PR_ADMIN_BYPASS_LAND_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
+  PR_ORPHAN_REPAIR_WORKER_KIND,
   createPrAdminBypassLandWorker,
   createCoderabbitAddressWorker,
   createPrCiFailureScanWorker,
   createPrConflictRebaseWorker,
+  createPrOrphanRepairWorker,
   type PrMaintenanceLockProbeOptions,
 } from '../workers/pr-maintenance-workers.js';
 
@@ -127,7 +129,7 @@ describe('PR maintenance workers', () => {
     expect(spawnHarness.calls).toEqual([
       expect.objectContaining({
         command: 'bash',
-        args: [resolve(repoRoot, 'scripts/cron-coderabbit-address.sh')],
+        args: [resolve(repoRoot, 'packages/execution-engine/scripts/pr-maintenance/cron-coderabbit-address.sh')],
         options: expect.objectContaining({
           cwd: repoRoot,
           stdio: ['ignore', 'pipe', 'pipe'],
@@ -166,7 +168,7 @@ describe('PR maintenance workers', () => {
 
     expect(spawnHarness.calls[0]).toEqual(expect.objectContaining({
       command: 'bash',
-      args: [resolve(repoRoot, 'scripts/cron-pr-conflict-rebase.sh')],
+      args: [resolve(repoRoot, 'packages/execution-engine/scripts/pr-maintenance/cron-pr-conflict-rebase.sh')],
       options: expect.objectContaining({ cwd: repoRoot }),
     }));
   });
@@ -186,7 +188,7 @@ describe('PR maintenance workers', () => {
 
     expect(spawnHarness.calls[0]).toEqual(expect.objectContaining({
       command: 'bash',
-      args: [resolve(repoRoot, 'packages/execution-engine/scripts/cron-pr-ci-failure.sh')],
+      args: [resolve(repoRoot, 'packages/execution-engine/scripts/pr-maintenance/cron-pr-ci-failure.sh')],
       options: expect.objectContaining({ cwd: repoRoot }),
     }));
   });
@@ -207,10 +209,32 @@ describe('PR maintenance workers', () => {
 
     expect(spawnHarness.calls[0]).toEqual(expect.objectContaining({
       command: 'bash',
-      args: [resolve(repoRoot, 'scripts/cron-pr-admin-bypass-land.sh')],
+      args: [resolve(repoRoot, 'packages/execution-engine/scripts/pr-maintenance/cron-pr-admin-bypass-land.sh')],
       options: expect.objectContaining({ cwd: repoRoot }),
     }));
     expect(worker.identity.kind).toBe(PR_ADMIN_BYPASS_LAND_WORKER_KIND);
+  });
+
+  it('spawns the orphan-repair shell entrypoint', async () => {
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness();
+    const worker = createPrOrphanRepairWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => ({ held: false }),
+      installSignalHandlers: false,
+    });
+
+    await worker.tick();
+
+    expect(spawnHarness.calls[0]).toEqual(expect.objectContaining({
+      command: 'bash',
+      args: [resolve(repoRoot, 'packages/execution-engine/scripts/pr-maintenance/cron-pr-orphan-repair.sh')],
+      options: expect.objectContaining({ cwd: repoRoot }),
+    }));
+    expect(worker.identity.kind).toBe(PR_ORPHAN_REPAIR_WORKER_KIND);
   });
 
   it('skips cleanly when the shared PR-maintenance lock is already held', async () => {

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -20,7 +20,8 @@ export const PR_ORPHAN_REPAIR_WORKER_KIND = 'pr-orphan-repair';
 export const DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS = 5 * 60_000;
 /**
  * Even spacing between each PR-maintenance worker's first tick, so the 5
- * workers sharing the cron lock (scripts/cron-pr-lib.sh) don't all wake on
+ * workers sharing the cron lock
+ * (packages/execution-engine/scripts/pr-maintenance/cron-pr-lib.sh) don't all wake on
  * the same intervalMs boundary and race for it every cycle.
  */
 export const PR_MAINTENANCE_WORKER_STAGGER_STEP_MS = DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS / 5;
@@ -42,28 +43,28 @@ export interface PrMaintenanceEntrypoint {
 
 const CODERABBIT_ADDRESS_ENTRYPOINT: PrMaintenanceEntrypoint = {
   kind: CODERABBIT_ADDRESS_WORKER_KIND,
-  scriptRelativePath: 'scripts/cron-coderabbit-address.sh',
+  scriptRelativePath: 'packages/execution-engine/scripts/pr-maintenance/cron-coderabbit-address.sh',
   note: 'Runs the CodeRabbit review-address cron entrypoint under worker scheduling.',
 };
 
 const PR_CONFLICT_REBASE_ENTRYPOINT: PrMaintenanceEntrypoint = {
   kind: PR_CONFLICT_REBASE_WORKER_KIND,
-  scriptRelativePath: 'scripts/cron-pr-conflict-rebase.sh',
+  scriptRelativePath: 'packages/execution-engine/scripts/pr-maintenance/cron-pr-conflict-rebase.sh',
   note: 'Runs the PR conflict rebase-recreate cron entrypoint under worker scheduling.',
 };
 const PR_CI_FAILURE_SCAN_ENTRYPOINT: PrMaintenanceEntrypoint = {
   kind: PR_CI_FAILURE_SCAN_WORKER_KIND,
-  scriptRelativePath: 'packages/execution-engine/scripts/cron-pr-ci-failure.sh',
+  scriptRelativePath: 'packages/execution-engine/scripts/pr-maintenance/cron-pr-ci-failure.sh',
   note: 'Runs the mapped-PR CI scan cron entrypoint under worker scheduling.',
 };
 const PR_ADMIN_BYPASS_LAND_ENTRYPOINT: PrMaintenanceEntrypoint = {
   kind: PR_ADMIN_BYPASS_LAND_WORKER_KIND,
-  scriptRelativePath: 'scripts/cron-pr-admin-bypass-land.sh',
+  scriptRelativePath: 'packages/execution-engine/scripts/pr-maintenance/cron-pr-admin-bypass-land.sh',
   note: 'Runs the admin-bypass land babysitting cron entrypoint under worker scheduling.',
 };
 const PR_ORPHAN_REPAIR_ENTRYPOINT: PrMaintenanceEntrypoint = {
   kind: PR_ORPHAN_REPAIR_WORKER_KIND,
-  scriptRelativePath: 'scripts/cron-pr-orphan-repair.sh',
+  scriptRelativePath: 'packages/execution-engine/scripts/pr-maintenance/cron-pr-orphan-repair.sh',
   note: 'Classifies unmapped broken PRs and submits one combined Invoker repair task per PR.',
 };
 


### PR DESCRIPTION
## Summary

Places the PR-maintenance cron entrypoints under `packages/execution-engine/scripts/pr-maintenance/`.

WorkerRuntime path wiring now points at that package-local directory.

Scheduling behavior is unchanged. Worker kinds, cadence, locks, ledgers, and spawn semantics stay the same.

Focused tests cover bootstrap path resolution and the app pr-maintenance guard.

Facts verified on 2026-07-27: entrypoints are declared in `packages/execution-engine/src/workers/pr-maintenance-workers.ts`.

Bootstrap paths are duplicated in `packages/execution-engine/src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts`.

Only `cron-pr-ci-failure.sh` already lived under `packages/execution-engine/scripts/`.

## Review Claim

PR-maintenance cron entrypoints plus `cron-pr-lib.sh` live under `packages/execution-engine/scripts/pr-maintenance/`, and WorkerRuntime path routing points there with behavior unchanged.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

Behavior unchanged: worker kinds, scheduling cadence, lock/ledger behavior, and spawn semantics stay identical. Only filesystem paths change, and the focused pr-maintenance unit files pass.

## Slice Rationale

One routing slice updates the cron shell path boundary owned by PR-maintenance workers. `scripts/` shims and the architecture note stay for the next slice.

## Non-goals

- Behavior unchanged.
- No `scripts/` shim edits.
- No architecture-note edits.
- No WorkerRuntime kind renames.
- No admin-requeue classification changes.
- No broad `scripts/` taxonomy.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `PYTHONDONTWRITEBYTECODE=1 pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts src/__tests__/pr-maintenance-workers.test.ts`
- [x] `PYTHONDONTWRITEBYTECODE=1 pnpm --filter @invoker/app exec vitest run src/__tests__/headless-pr-maintenance.test.ts`
- [x] `rg -n 'scripts/headless-lib\.sh|headless-lib\.sh' packages/execution-engine/scripts/pr-maintenance/cron-pr-lib.sh`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-maintenance-cron-nest-pr.md --changed-files-file /tmp/pr-maintenance-cron-nest-files.txt --diff-file /tmp/pr-maintenance-cron-nest.diff`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/pr-maintenance-cron-nest-pr.md --base stack/EdbertChan/plan/reorg-packageless-pr-workers-1-admin-requeue-package/reorg-packageless-pr-workers-1-admin-requeue-pkg--f8b7a7b7`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
