### PR TITLE
[Bugfix: truthful planning draft readiness](1) Keep planner draft state explicit

### DIFF
--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -99,13 +99,17 @@ describe('plan draft file - activation side', () => {
     ));
     const firstReply = await conversation.sendMessage('Draft it');
     expect(firstReply).toContain(SUBMIT_REPLY_LINE);
+    expect(conversation.lastTurnDraftPlanText).toBe(VALID_PLAN_YAML.trim());
+    expect(conversation.history[conversation.history.length - 1]?.content).toContain(SUBMIT_REPLY_LINE);
 
     mockSpawn.mockReturnValueOnce(fakePlannerChild(`Drafted the plan. Summary: one step.\n\n${SUBMIT_REPLY_LINE}`));
     const followUpReply = await conversation.sendMessage('What does it do?');
 
     expect(existsSync(path)).toBe(false);
     expect(followUpReply).toBe('Drafted the plan. Summary: one step.');
+    expect(conversation.lastTurnDraftPlanText).toBeNull();
     expect(conversation.history[conversation.history.length - 1]?.content).toBe(followUpReply);
+    expect(conversation.history[conversation.history.length - 1]?.content).not.toContain(SUBMIT_REPLY_LINE);
     expect(conversation.getDraftedPlan()).toBe(VALID_PLAN_YAML.trim());
   });
 
@@ -118,6 +122,7 @@ describe('plan draft file - activation side', () => {
     expect(reply).toBe('Drafted the plan. Summary: one step.');
     expect(conversation.history[conversation.history.length - 1]?.content).toBe(reply);
     expect(reply).not.toContain(SUBMIT_REPLY_LINE);
+    expect(conversation.lastTurnDraftPlanText).toBeNull();
     expect(conversation.getDraftedPlan()).toBeNull();
   });
 
@@ -144,6 +149,8 @@ describe('plan draft file - activation side', () => {
     const reply = await conversation.sendMessage('Create the plan');
 
     expect(reply).toContain(SUBMIT_REPLY_LINE);
+    expect(conversation.lastTurnDraftPlanText).toBe(VALID_PLAN_YAML.trim());
+    expect(conversation.history[conversation.history.length - 1]?.content).toContain(SUBMIT_REPLY_LINE);
     expect(isConfirmation('submit')).toBe(true);
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     expect(conversation.planSubmitted).toBe(false);

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -551,9 +551,10 @@ export class PlanConversation {
     }
     const fileDraft = this.readPlanDraftFile();
     const inlineDraft = extractYamlPlan(message);
-    const nextDraft = fileDraft && summarizePlanText(fileDraft)
+    const validFileDraft = fileDraft && summarizePlanText(fileDraft)
       ? fileDraft
-      : inlineDraft;
+      : null;
+    const nextDraft = validFileDraft ?? inlineDraft;
     this._lastTurnDraftPlanText = nextDraft;
     if (nextDraft) this.lastKnownGoodPlanText = nextDraft;
     if (!nextDraft) {


### PR DESCRIPTION
## Summary

Planning replies now keep last-turn draft readiness tied to the draft captured in the current turn.

Replies with no current draft keep the older saved plan for conversation continuity, but their saved assistant text no longer looks ready.

## Review Claim

The standalone confirmation instruction only appears when the current turn has a real draft.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This stays in planner reply formatting and directly affected regression coverage; valid draft replies keep the same ready path.

## Slice Rationale

The misleading user-facing instruction is saved with the planner reply, so this slice fixes the surface where that text is persisted.

## Non-goals

- No in-app approval precondition changes.
- No terminal command behavior changes.
- No model or harness changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/plan-draft-file-activation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 4027d0c5d`
- Post-revert steps: Rerun the focused surfaces regression.
- Data migration? No.

</details>
