### PR TITLE
[Bugfix: truthful planning draft readiness] Reject stale pending submits

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -1173,6 +1173,31 @@ tasks:
     expect(loadGeneratedPlan).not.toHaveBeenCalled();
   });
 
+  it('rejects submit before reusing a stale pending submit when the session is not draft-ready', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    sessions.set('stale-pending-submit', planningSession({
+      id: 'stale-pending-submit',
+      title: 'Stale pending submit',
+      status: 'still_discussing',
+      draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+      draftPlanText: VALID_PLAN_TEXT,
+      pendingSubmit: Promise.resolve({
+        ok: true,
+        planName: 'Mock Plan',
+        workflowId: 'wf-1',
+      }),
+    }));
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(submitPlanningChatDraft({
+      sessionId: 'stale-pending-submit',
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: NO_COMPLETE_PLAN_DRAFTED_ERROR });
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
   it('rejects submit when draft-ready state has empty draft text', async () => {
     const sessions = createInAppPlanningChatSessions();
     sessions.set('empty-draft-ready', planningSession({

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -1006,11 +1006,11 @@ export async function submitPlanningChatDraft(
   if (session.status === 'submitted') {
     return { ok: false, error: 'This planning session was already submitted.' };
   }
-  if (session.pendingSubmit) {
-    return session.pendingSubmit;
-  }
   if (session.status !== 'draft_ready' || !session.draftPlanText?.trim()) {
     return { ok: false, error: NO_COMPLETE_PLAN_DRAFTED_ERROR };
+  }
+  if (session.pendingSubmit) {
+    return session.pendingSubmit;
   }
 
   const submitAttempt = (async (): Promise<InAppPlanningSubmitResponse> => {


### PR DESCRIPTION
## Summary

The in-app planner routing now checks draft-ready state before returning an existing pending approval.

An old pending approval on a still-discussing session returns the existing no-draft error instead of reusing old work.

## Review Claim

`submitPlanningChatDraft()` checks draft-ready state before reusing a pending approval.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This stays in the in-app planner handler and directly affected regression coverage; valid draft-ready sessions keep the same approval path.

## Slice Rationale

Landed standalone directly on master: the two earlier attempts at a related but unrelated no-op refactor in this same idea's step 1 were closed as redundant (their tests already passed on unmodified master with no code change), so this fix no longer needs a step-1 base and was rebased off it.

## Non-goals

- No planner reply text changes.
- No terminal command behavior changes.
- No model or harness changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert efb147ae3`
- Post-revert steps: Rerun the focused app regression.
- Data migration? No.

</details>
