### PR TITLE
[Planning tmux output survives Home/Planning switches](2) Preserve hidden tmux output snapshots

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -123,6 +123,17 @@ function appendPlanningTerminalSnapshot(snapshot: string | undefined, data: stri
   return next.slice(next.length - PLANNING_TERMINAL_OUTPUT_SNAPSHOT_CHARS);
 }
 
+function planningTerminalOutputMatchesSession(
+  session: PlanningSessionView,
+  event: TerminalOutputEvent,
+): boolean {
+  if (event.planningSessionId) {
+    return session.id === event.planningSessionId;
+  }
+  return session.terminalSession?.sessionId === event.sessionId
+    || session.terminalSessionId === event.sessionId;
+}
+
 function planningTerminalSessionFromOutputEvent(
   session: PlanningSessionView,
   event: TerminalOutputEvent,
@@ -1338,14 +1349,12 @@ export function App() {
   useEffect(() => {
     const unsubscribe = window.invoker?.onTerminalOutput?.((event) => {
       if (event.kind !== 'planning' || typeof event.data !== 'string' || event.data.length === 0) return;
-      setPlanningSessions((prev) =>
-        prev.map((session) => {
-          const matchesSession =
-            session.terminalSession?.sessionId === event.sessionId
-            || session.terminalSessionId === event.sessionId
-            || (event.planningSessionId !== undefined && session.id === event.planningSessionId);
-          if (!matchesSession) return session;
+      setPlanningSessions((prev) => {
+        let changed = false;
+        const next = prev.map((session) => {
+          if (!planningTerminalOutputMatchesSession(session, event)) return session;
 
+          changed = true;
           const outputSnapshot = appendPlanningTerminalSnapshot(
             session.terminalSession?.outputSnapshot ?? session.terminalOutputSnapshot,
             event.data,
@@ -1358,8 +1367,9 @@ export function App() {
             terminalOutputSnapshot: outputSnapshot,
             terminalSession: planningTerminalSessionFromOutputEvent(session, event, outputSnapshot),
           };
-        }),
-      );
+        });
+        return changed ? next : prev;
+      });
     });
     return () => { unsubscribe?.(); };
   }, []);

--- a/packages/ui/src/__tests__/planning-terminal-tmux.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-tmux.test.tsx
@@ -81,7 +81,7 @@ describe('planning terminal tmux', () => {
     xtermMock.reset();
   });
 
-  it.fails('restores planning tmux output emitted while the planning terminal surface is hidden', async () => {
+  it('restores planning tmux output emitted while the planning terminal surface is hidden', async () => {
     mock.api.planningChatList = vi.fn(async () => ({
       ok: true,
       sessions: [


### PR DESCRIPTION
## Summary

This keeps hidden planning tmux output attached to the planning session that emitted it.

Events with a planning session id no longer update other sessions that happen to share the event terminal id.

Hidden output now remounts with the correct scrollback after Home and Planning surface switches.

## Review Claim

Approve the renderer-state matching change that preserves hidden Planning tmux output without leaking it across sessions.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice only changes renderer handling for planning terminal output events and the paired regression; backend tmux lifecycle and IPC payloads stay unchanged.

## Slice Rationale

The earlier slice captures the scenario first. This slice changes only the matching behavior needed to make that scenario pass.

## Non-goals

- Do not change terminal process creation or tmux attach behavior.
- Do not change task terminal output handling.
- Do not change Planning graph navigation.

## Architecture

### Before

```mermaid
graph TD
    A["Planning output event arrives"]
    B["Match by terminal id"]
    C["Also match by planning session id"]
    D["Every matched session appends output"]
    A --> B --> D
    A --> C --> D
```

### After

```mermaid
graph TD
    A["Planning output event arrives"]
    B{"Has planning session id?"}
    C["Match only that planning session"]
    D["Fall back to terminal id"]
    E["One owning session appends output"]
    A --> B
    B -->|yes| C --> E
    B -->|no| D --> E
```

## Visual Proof

![Walkthrough: Planning tmux pane replays output that arrived while hidden across a Home to Planning to Home switch](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260726-67fbfa/planning-tmux-hidden-output-restored-walkthrough.gif)

The animation shows the Planning tmux pane remounting with hidden output restored after switching surfaces. The session-collision guard is covered by the focused renderer test.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/planning-terminal-tmux.test.tsx`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/planning-tmux-pr2.md --base stack/EdbertChan/plan/planning-tmux-history-surface-switch/wf-1784340495515-7-impl-planning-tmux-history--465043c7`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/planning-tmux-pr2.md --require-visual-proof`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a0dfa1811`
- Post-revert steps: rerun `pnpm --filter @invoker/ui exec vitest run src/__tests__/planning-terminal-tmux.test.tsx`
- Data migration? No

</details>

## Workflow Summary

Planning tmux output survives Home/Planning switches - 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784340495515-7/implement-planning-tmux-history-sync | Keep planning tmux output snapshot in renderer state while the Planning surface is hidden, so remount restores scrollback/history | completed |
| wf-1784340495515-7/verify-planning-tmux-surface-switch-regression | Run focused UI regression test for planning tmux history across sidebar surface switches | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784340495515-7/implement-planning-tmux-history-sync - Keep planning tmux output snapshot in renderer state while the Planning surface is hidden, so remount restores scrollback/history

packages/ui/src/App.tsx | 28 +++--

### wf-1784340495515-7/verify-planning-tmux-surface-switch-regression - Run focused UI regression test for planning tmux history across sidebar surface switches

packages/ui/src/__tests__/planning-terminal-tmux.test.tsx | 177 +++++++++++++++++++++

</details>
