### PR TITLE
[Reorg packageless PR workers (3) compat shims + docs](2) repro path references

### DIFF
--- a/scripts/repro/repro-babysit-no-current-bottom-comment.sh
+++ b/scripts/repro/repro-babysit-no-current-bottom-comment.sh
@@ -24,8 +24,8 @@ export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
 FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
 import sys
 from pathlib import Path
-sys.path.insert(0, 'scripts')
-from mergify_admin_requeue_model import load_mergify_rules
+sys.path.insert(0, 'packages/mergify-admin-requeue')
+from mergify_admin_requeue.model import load_mergify_rules
 _trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
 print('\n'.join(sorted(required)))
 PY

--- a/scripts/repro/repro-babysit-pr-body-human-split.sh
+++ b/scripts/repro/repro-babysit-pr-body-human-split.sh
@@ -25,8 +25,8 @@ export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
 FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
 import sys
 from pathlib import Path
-sys.path.insert(0, 'scripts')
-from mergify_admin_requeue_model import load_mergify_rules
+sys.path.insert(0, 'packages/mergify-admin-requeue')
+from mergify_admin_requeue.model import load_mergify_rules
 _trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
 print('\n'.join(sorted(required)))
 PY

--- a/scripts/repro/repro-babysit-retarget-stale-bottom-base.sh
+++ b/scripts/repro/repro-babysit-retarget-stale-bottom-base.sh
@@ -24,8 +24,8 @@ export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
 FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
 import sys
 from pathlib import Path
-sys.path.insert(0, 'scripts')
-from mergify_admin_requeue_model import load_mergify_rules
+sys.path.insert(0, 'packages/mergify-admin-requeue')
+from mergify_admin_requeue.model import load_mergify_rules
 _trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
 print('\n'.join(sorted(required)))
 PY

--- a/scripts/repro/repro-coderabbit-pr5251-mergify-admin-requeue-yaml-alias.sh
+++ b/scripts/repro/repro-coderabbit-pr5251-mergify-admin-requeue-yaml-alias.sh
@@ -5,9 +5,9 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
 echo "== repro: admin requeue loader resolves YAML anchors and aliases =="
-if python3 -m unittest \
-  scripts.test_mergify_admin_requeue.MergifyAdminRequeueTests.test_loads_admin_bypass_rule_from_mergify_yml \
-  scripts.test_mergify_admin_requeue_model.MergifyRuleLoading.test_reads_required_checks_from_yaml_alias
+if PYTHONPATH=packages/mergify-admin-requeue python3 -m unittest \
+  packages/mergify-admin-requeue/tests/test_mergify_admin_requeue.py \
+  packages/mergify-admin-requeue/tests/test_mergify_admin_requeue_model.py
 then
   echo "PASS: admin-bypass required checks still load from anchored Mergify config."
 else

--- a/scripts/repro/repro-pr-maintenance-worker-routing.sh
+++ b/scripts/repro/repro-pr-maintenance-worker-routing.sh
@@ -38,8 +38,8 @@ fi
 FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
 import sys
 from pathlib import Path
-sys.path.insert(0, "scripts")
-from mergify_admin_requeue_model import load_mergify_rules
+sys.path.insert(0, "packages/mergify-admin-requeue")
+from mergify_admin_requeue.model import load_mergify_rules
 _trunk, _labels, required = load_mergify_rules(Path(".mergify.yml"))
 print("\n".join(sorted(required)))
 PY

--- a/scripts/repro/worker-routing-driver.mjs
+++ b/scripts/repro/worker-routing-driver.mjs
@@ -120,7 +120,7 @@ const callsLog = (leg) => readFileSync(join(leg.state, 'calls.log'), 'utf8');
     INVOKER_PR_REBASE_CONFIRM_TIMEOUT: '0',
   }, 'pr-dirty.json');
   assert(leg, !err, `entrypoint completed cleanly${err ? ` (got: ${err.message})` : ''}`);
-  assert(leg, has(leg, '[worker:pr-conflict-rebase] spawning scripts/cron-pr-conflict-rebase.sh'),
+  assert(leg, has(leg, '[worker:pr-conflict-rebase] spawning packages/execution-engine/scripts/pr-maintenance/cron-pr-conflict-rebase.sh'),
     'worker spawned its own cron entrypoint');
   assert(leg, nodeLogText(leg).includes('rebase-recreate wf-routing-1'),
     'conflicted PR triggered a rebase-recreate dispatch');
@@ -143,7 +143,7 @@ const callsLog = (leg) => readFileSync(join(leg.state, 'calls.log'), 'utf8');
   const err = await tickWorker(leg, createPrCiFailureScanWorker, {
     INVOKER_PR_CRON_REVIEW_GATE_CMD: reviewGate,
   }, 'pr-ci-failed.json');
-  assert(leg, has(leg, '[worker:pr-ci-failure-scan] spawning packages/execution-engine/scripts/cron-pr-ci-failure.sh'),
+  assert(leg, has(leg, '[worker:pr-ci-failure-scan] spawning packages/execution-engine/scripts/pr-maintenance/cron-pr-ci-failure.sh'),
     'worker spawned its own cron entrypoint');
   assert(leg, !err, `entrypoint completed cleanly${err ? ` (got: ${err.message})` : ''}`);
   assert(leg, nodeLogText(leg).includes('repair-review-gate-ci 601'),
@@ -162,7 +162,7 @@ const callsLog = (leg) => readFileSync(join(leg.state, 'calls.log'), 'utf8');
     INVOKER_PR_CRON_DRY_RUN: '1',
     FAKE_GH_REQUIRED_CHECKS: process.env.FAKE_GH_REQUIRED_CHECKS ?? '',
   }, 'stack-landable.json');
-  assert(leg, has(leg, '[worker:pr-admin-bypass-land] spawning scripts/cron-pr-admin-bypass-land.sh'),
+  assert(leg, has(leg, '[worker:pr-admin-bypass-land] spawning packages/execution-engine/scripts/pr-maintenance/cron-pr-admin-bypass-land.sh'),
     'worker spawned its own cron entrypoint');
   assert(leg, !err, `entrypoint completed cleanly${err ? ` (got: ${err.message})` : ''}`);
   assert(leg, has(leg, 'DRY-RUN requeue PR #701'),
@@ -182,7 +182,7 @@ const callsLog = (leg) => readFileSync(join(leg.state, 'calls.log'), 'utf8');
   const leg = makeLeg('coderabbit-address');
   console.log('\n=== leg 4: review sweep (pr-dirty.json) -> coderabbit-address ===');
   const err = await tickWorker(leg, createCoderabbitAddressWorker, {}, 'pr-dirty.json');
-  assert(leg, has(leg, '[worker:coderabbit-address] spawning scripts/cron-coderabbit-address.sh'),
+  assert(leg, has(leg, '[worker:coderabbit-address] spawning packages/execution-engine/scripts/pr-maintenance/cron-coderabbit-address.sh'),
     'worker spawned its own cron entrypoint');
   assert(leg, !err, `entrypoint completed cleanly${err ? ` (got: ${err.message})` : ''}`);
   assert(leg, callsLog(leg).length > 0, 'sweep queried the fake GitHub');
@@ -205,7 +205,7 @@ const callsLog = (leg) => readFileSync(join(leg.state, 'calls.log'), 'utf8');
     INVOKER_PR_ORPHAN_STATE_FILE: join(leg.legDir, 'ledger.tsv'),
     INVOKER_PR_ORPHAN_PLAN_DIR: join(leg.legDir, 'plans'),
   }, 'pr-orphan-broken.json');
-  assert(leg, has(leg, '[worker:pr-orphan-repair] spawning scripts/cron-pr-orphan-repair.sh'),
+  assert(leg, has(leg, '[worker:pr-orphan-repair] spawning packages/execution-engine/scripts/pr-maintenance/cron-pr-orphan-repair.sh'),
     'worker spawned its own cron entrypoint');
   assert(leg, !err, `entrypoint completed cleanly${err ? ` (got: ${err.message})` : ''}`);
   assert(leg, /exec -- run .*repair-pr-801\.yaml/.test(nodeLogText(leg)),


### PR DESCRIPTION
## Summary

Babysit repros now point at the package-backed admin-requeue and PR-maintenance paths they exercise.

The worker-routing driver follows the nested cron location so path checks match the new home.

This slice is proof-only. It does not change runtime entrypoints.

## Review Claim

Babysit repro and worker-routing proof paths reference the package-owned admin-requeue and PR-maintenance homes without changing runtime behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Proof-only repro path edits; no runtime entrypoints or product code change in this slice.

## Slice Rationale

Keep repro-path evidence separate from the script shim policy slice so reviewers can inspect proof asset drift on its own.

## Non-goals

- No runtime script changes.
- No WorkerRuntime kind changes.
- No docs edits.
- No broad babysit repro rewrite beyond directly affected path references.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `rg -n 'packages/mergify-admin-requeue|packages/execution-engine/scripts/pr-maintenance' scripts/repro/repro-babysit-no-current-bottom-comment.sh scripts/repro/repro-babysit-pr-body-human-split.sh scripts/repro/repro-babysit-retarget-stale-bottom-base.sh scripts/repro/repro-coderabbit-pr5251-mergify-admin-requeue-yaml-alias.sh scripts/repro/repro-pr-maintenance-worker-routing.sh scripts/repro/worker-routing-driver.mjs`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-bodies/reorg3-repro-paths.md --changed-files-file /tmp/invoker-pr-bodies/reorg3-repro-paths.files --diff-file /tmp/invoker-pr-bodies/reorg3-repro-paths.diff`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/invoker-pr-bodies/reorg3-repro-paths.md --base stack/EdbertChan/plan/reorg-packageless-pr-workers-3-compat-shims-docs/reorg-packageless-pr-workers-3-compat-shims--02b2cf60`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
