### PR TITLE
[Reorg packageless PR workers (3) compat shims + docs](3) worker homes docs

### DIFF
--- a/docs/architecture/recovery-lifecycle-workers.md
+++ b/docs/architecture/recovery-lifecycle-workers.md
@@ -97,6 +97,11 @@ On owner boot `startAutoStartedWorkers()` starts two tiers of built-in workers
 Saved per-worker desired state (Workers tab / `worker start|stop`) overrides
 the auto-start default in both directions.
 
+Implementation ownership follows the package layout: admin-requeue lives in
+`packages/mergify-admin-requeue`, and PR-maintenance cron shells live under
+`packages/execution-engine/scripts/pr-maintenance/`. The old `scripts/` paths
+remain compatibility shims for existing operator commands and repro scripts.
+
 ## Worker Wakeups
 
 A lifecycle event should carry enough context to make wakeups efficient, such as workflow ID, task ID, transition type, and generation where available. That context is an optimization, not authority.


### PR DESCRIPTION
## Summary

The recovery lifecycle architecture note now names the admin-requeue package location.

It also names the nested PR-maintenance cron directory and explains that old `scripts/` paths stay as compatibility shims.

## Review Claim

`recovery-lifecycle-workers.md` states that admin-requeue lives in `packages/mergify-admin-requeue` and PR cron shells live under `packages/execution-engine/scripts/pr-maintenance/`.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Docs-only; no runtime path or behavior changes.

## Slice Rationale

One docs unit follows the product and shim slices so the architecture note names the current worker locations.

## Non-goals

- No product code edits.
- No scripts edits.
- No broad docs rewrite.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `rg -n 'packages/mergify-admin-requeue|packages/execution-engine/scripts/pr-maintenance' docs/architecture/recovery-lifecycle-workers.md`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-pr-bodies/reorg3-worker-homes-docs.md --changed-files-file /tmp/invoker-pr-bodies/reorg3-worker-homes-docs.files --diff-file /tmp/invoker-pr-bodies/reorg3-worker-homes-docs.diff`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/invoker-pr-bodies/reorg3-worker-homes-docs.md --base stack/EdbertChan/plan/reorg-packageless-pr-workers-3-compat-shims-docs/reorg-packageless-pr-workers-4-repro-path-refs--d21b8719`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
