### PR TITLE
[Bugfix: truthful planning draft readiness](1) Persist truthful draft replies

### DIFF
--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -121,6 +121,28 @@ describe('plan draft file - activation side', () => {
     expect(conversation.getDraftedPlan()).toBeNull();
   });
 
+  it('persists no-draft replies without the standalone submit line', async () => {
+    const repo = {
+      loadConversation: vi.fn().mockReturnValue(null),
+      saveConversation: vi.fn(),
+    };
+    const conversation = new PlanConversation({
+      workingDir,
+      threadTs: 'persist-no-draft',
+      conversationRepo: repo as any,
+      plannerRetryLimit: 0,
+    });
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(`Drafted the plan. Summary: one step.\n\n${SUBMIT_REPLY_LINE}`));
+    await conversation.sendMessage('Draft it');
+
+    expect(repo.saveConversation).toHaveBeenCalledOnce();
+    const savedMessages = repo.saveConversation.mock.calls[0]?.[1] as Array<{ role: string; content: string }>;
+    const savedReply = savedMessages[savedMessages.length - 1]?.content;
+    expect(savedReply).toBe('Drafted the plan. Summary: one step.');
+    expect(savedReply).not.toContain(SUBMIT_REPLY_LINE);
+  });
+
   it('routes approval through the review flow instead of a submit reply', () => {
     const conversation = new PlanConversation({});
     (conversation as any).messages.push({ role: 'user', content: 'Draft a plan' });
@@ -153,6 +175,32 @@ describe('plan draft file - activation side', () => {
     expect(draftedPlan).not.toBeNull();
     const parsedDraft = parseYaml(draftedPlan!) as Record<string, unknown>;
     expect(parsedDraft.name).toBe('Draft Activation');
+  });
+
+  it('persists real drafted replies with the standalone submit line', async () => {
+    const repo = {
+      loadConversation: vi.fn().mockReturnValue(null),
+      saveConversation: vi.fn(),
+    };
+    const conversation = new PlanConversation({
+      workingDir,
+      threadTs: 'persist-draft',
+      conversationRepo: repo as any,
+      plannerRetryLimit: 0,
+    });
+    const path = conversation.planDraftFilePath();
+    if (!path) throw new Error('expected a plan draft path');
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(
+      `Drafted the plan.\n\n${SUBMIT_REPLY_LINE}`,
+      () => writeFileSync(path, VALID_PLAN_YAML, 'utf8'),
+    ));
+    const reply = await conversation.sendMessage('Create the plan');
+
+    expect(reply).toContain(SUBMIT_REPLY_LINE);
+    expect(repo.saveConversation).toHaveBeenCalledOnce();
+    const savedMessages = repo.saveConversation.mock.calls[0]?.[1] as Array<{ role: string; content: string }>;
+    expect(savedMessages[savedMessages.length - 1]?.content).toContain(SUBMIT_REPLY_LINE);
   });
 
   it('falls back to the latest inline plan when no draft file path exists', async () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -555,8 +555,10 @@ export class PlanConversation {
       ? fileDraft
       : inlineDraft;
     this._lastTurnDraftPlanText = nextDraft;
-    if (nextDraft) this.lastKnownGoodPlanText = nextDraft;
-    if (!nextDraft) {
+    const hasCurrentTurnDraft = nextDraft !== null;
+    if (hasCurrentTurnDraft) {
+      this.lastKnownGoodPlanText = nextDraft;
+    } else {
       message = removeStandaloneSubmitInstruction(message);
     }
     this._lastTurnReasoning = formatted.reasoning;


### PR DESCRIPTION
## Summary

Planning replies now persist assistant text after draft readiness has been resolved for the current turn.

No-draft turns drop the standalone confirmation instruction before the conversation is saved. Real draft turns still save that instruction.

## Review Claim

No-draft planning turns persist without the standalone confirmation instruction, while real draft turns still persist it.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This stays in planner reply formatting and directly affected regression coverage; valid drafted replies keep the same ready behavior.

## Slice Rationale

The misleading user-facing instruction is saved with the planner reply, so this slice fixes the persistence point where that text is stored.

## Non-goals

- No backend approval guard changes.
- No terminal command routing changes.
- No harness or model changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/plan-draft-file-activation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert dd9e7e566`
- Post-revert steps: Rerun the focused surfaces regression.
- Data migration? No.

</details>
