### PR TITLE
[Bugfix: truthful planning draft readiness](1) Persist sanitized no-draft replies

### DIFF
--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -121,6 +121,34 @@ describe('plan draft file - activation side', () => {
     expect(conversation.getDraftedPlan()).toBeNull();
   });
 
+  it('persists sanitized assistant text when a turn has no current draft', async () => {
+    const saveConversation = vi.fn();
+    const conversationRepo = {
+      loadConversation: vi.fn(() => null),
+      saveConversation,
+      deleteConversation: vi.fn(),
+    };
+    const conversation = new PlanConversation({
+      workingDir,
+      threadTs: 'abc-123',
+      conversationRepo: conversationRepo as any,
+      plannerRetryLimit: 0,
+    });
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(`Drafted the plan. Summary: one step.\n\n${SUBMIT_REPLY_LINE}`));
+    const reply = await conversation.sendMessage('Draft it');
+
+    expect(reply).toBe('Drafted the plan. Summary: one step.');
+    expect(saveConversation).toHaveBeenCalledTimes(1);
+
+    const savedMessages = saveConversation.mock.calls[0]?.[1] as Array<{ role: string; content: string }>;
+    expect(savedMessages[savedMessages.length - 1]).toEqual({
+      role: 'assistant',
+      content: 'Drafted the plan. Summary: one step.',
+    });
+    expect(savedMessages[savedMessages.length - 1]?.content).not.toContain(SUBMIT_REPLY_LINE);
+  });
+
   it('routes approval through the review flow instead of a submit reply', () => {
     const conversation = new PlanConversation({});
     (conversation as any).messages.push({ role: 'user', content: 'Draft a plan' });


### PR DESCRIPTION
## Summary

The surfaces regression now checks that saved no-draft assistant replies do not keep the submit instruction.

This preserves the already-fixed user-visible reply behavior at the conversation persistence boundary.

## Review Claim

The focused surfaces regression proves no-draft planning replies are saved without the standalone submit instruction.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds directly affected regression coverage for the existing planner reply behavior.

## Slice Rationale

The behavior fix is already on master; this proof slice locks the persistence case without bundling another product change.

## Non-goals

- No planner reply formatting changes.
- No backend approval guard changes.
- No terminal command routing changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/plan-draft-file-activation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 30a2810b5`
- Post-revert steps: Rerun the focused surfaces regression.
- Data migration? No.

</details>
