### PR TITLE
[Planning tmux output survives Home/Planning switches](1) Add surface-switch regression

### DIFF
--- a/packages/ui/src/__tests__/planning-terminal-tmux.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-tmux.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const xtermMock = vi.hoisted(() => {
+  type DataHandler = (data: string) => void;
+
+  const instances: MockTerminal[] = [];
+  const fitInstances: MockFitAddon[] = [];
+  const writeLog: string[] = [];
+
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    dataHandler: DataHandler | null = null;
+    loadAddon = vi.fn();
+    open = vi.fn((host: HTMLElement) => {
+      const terminalElement = document.createElement('div');
+      terminalElement.className = 'xterm';
+      terminalElement.textContent = 'mock terminal';
+      host.appendChild(terminalElement);
+    });
+    write = vi.fn((data: string) => {
+      writeLog.push(data);
+    });
+    onData = vi.fn((cb: DataHandler) => {
+      this.dataHandler = cb;
+      return { dispose: vi.fn() };
+    });
+    focus = vi.fn();
+    refresh = vi.fn();
+    dispose = vi.fn();
+
+    constructor() {
+      instances.push(this);
+    }
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+
+    constructor() {
+      fitInstances.push(this);
+    }
+  }
+
+  return {
+    Terminal: MockTerminal,
+    FitAddon: MockFitAddon,
+    instances,
+    fitInstances,
+    writeLog,
+    reset: () => {
+      instances.length = 0;
+      fitInstances.length = 0;
+      writeLog.length = 0;
+    },
+  };
+});
+
+vi.mock('xterm', () => ({ Terminal: xtermMock.Terminal }));
+vi.mock('xterm-addon-fit', () => ({ FitAddon: xtermMock.FitAddon }));
+
+const { App } = await import('../App.js');
+
+describe('planning terminal tmux history', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    xtermMock.reset();
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+    xtermMock.reset();
+  });
+
+  it('restores planning tmux output emitted while the planning terminal surface is hidden', async () => {
+    render(<App />);
+
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    fireEvent.click(await screen.findByRole('tab', { name: 'Tmux' }));
+
+    const terminalSessionId = 'mock-planning-terminal-session-1';
+    await waitFor(() => {
+      expect(mock.api.planningTerminalOpen).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('invoker-terminal-tmux-pane')).toHaveAttribute('data-session-id', terminalSessionId);
+    });
+
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+    await waitFor(() => {
+      expect(screen.getByTestId('sidebar-planning')).toHaveAttribute('aria-current', 'page');
+      expect(screen.queryByTestId('invoker-terminal-tmux-pane')).not.toBeInTheDocument();
+    });
+
+    xtermMock.writeLog.length = 0;
+    await act(async () => {
+      mock.fireTerminalOutput({
+        sessionId: terminalSessionId,
+        taskId: 'planning:session-1',
+        kind: 'planning',
+        planningSessionId: 'session-1',
+        data: 'HIDDEN_TMUX_OUTPUT\n',
+      });
+    });
+    expect(xtermMock.writeLog.join('')).not.toContain('HIDDEN_TMUX_OUTPUT');
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-tmux-pane')).toHaveAttribute('data-session-id', terminalSessionId);
+      expect(xtermMock.writeLog.join('')).toContain('HIDDEN_TMUX_OUTPUT\n');
+    });
+    expect(mock.api.planningTerminalOpen).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Planning tmux output survives Home/Planning switches.

This slice adds a renderer regression for output delivered while the planning tmux pane is hidden behind the Plan graph.

The test opens the tmux pane, switches to Planning, emits hidden output, and verifies Home remounts the cached scrollback without reopening tmux.

## Review Claim

Add a focused renderer regression proving planning tmux output emitted while the pane is unmounted is replayed when Home remounts it without reopening tmux.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice adds one new test file only; no runtime code changes ship here. The focused command below was run against this slice and passed.

## Slice Rationale

The regression lands before the renderer matching update so the reviewer can inspect the Home/Planning surface-switch expectation independently from the implementation.

## Non-goals

- No runtime planning terminal behavior changes ship in this slice.
- No IPC, persistence, or tmux lifecycle changes ship in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- --run planning-terminal-tmux.test.tsx`

</details>

## Visual Proof

The screenshots below show the user-visible behavior guarded by this stack: Home shows an active planning tmux pane, Planning hides it, and Home remounts it with hidden output preserved.

Frame 1: Home surface open, tmux pane connected, sidebar highlight on the Home icon: ![Frame 1: Home surface, tmux pane open](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-d3903b/01-home-tmux-open.png)

Frame 2: Planning surface selected, sidebar highlight moves and the tmux pane is unmounted while output continues arriving: ![Frame 2: Planning surface, tmux pane unmounted](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-d3903b/02-planning-surface-tmux-hidden.png)

Frame 3: Home surface selected again, pane remounts and shows `SURFACE_SWITCH_PROOF_OUTPUT_VISIBLE`, the line written while hidden: ![Frame 3: Home surface restored, hidden output visible](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-d3903b/03-home-surface-restored-output-visible.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 30d9bb763`
- Post-revert steps: None
- Data migration? No

</details>
