### PR TITLE
[Planning tmux output survives Home/Planning switches](2) Preserve hidden tmux output snapshots

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -124,24 +124,39 @@ function appendPlanningTerminalSnapshot(snapshot: string | undefined, data: stri
   return next.slice(next.length - PLANNING_TERMINAL_OUTPUT_SNAPSHOT_CHARS);
 }
 
+function planningSessionMatchesTerminalOutputEvent(session: PlanningSessionView, event: TerminalOutputEvent): boolean {
+  const planningSessionId = typeof event.planningSessionId === 'string' ? event.planningSessionId.trim() : '';
+  if (planningSessionId) return session.id === planningSessionId;
+  return session.terminalSession?.sessionId === event.sessionId || session.terminalSessionId === event.sessionId;
+}
+
 function planningTerminalSessionFromOutputEvent(
   session: PlanningSessionView,
   event: TerminalOutputEvent,
   outputSnapshot: string,
 ): TerminalSessionDescriptor {
+  const planningSessionId = typeof event.planningSessionId === 'string' && event.planningSessionId.trim()
+    ? event.planningSessionId
+    : session.id;
+  const sameTerminalSession =
+    session.terminalSession?.sessionId === event.sessionId
+    || session.terminalSessionId === event.sessionId;
+  const previousTerminalSession = sameTerminalSession ? session.terminalSession : null;
   return {
-    sessionId: session.terminalSession?.sessionId ?? session.terminalSessionId ?? event.sessionId,
-    taskId: session.terminalSession?.taskId ?? event.taskId,
+    sessionId: event.sessionId,
+    taskId: event.taskId,
     kind: 'planning',
-    planningSessionId: session.id,
-    status: session.terminalSession?.status ?? session.terminalStatus ?? 'running',
-    exitCode: session.terminalSession?.exitCode ?? session.terminalExitCode,
-    cwd: session.terminalSession?.cwd,
-    command: session.terminalSession?.command,
-    args: session.terminalSession?.args,
-    mode: session.terminalSession?.mode ?? 'spawn',
-    attached: session.terminalSession?.attached ?? false,
-    createdAt: session.terminalSession?.createdAt ?? session.terminalUpdatedAt ?? session.updatedAt,
+    planningSessionId,
+    status: sameTerminalSession
+      ? previousTerminalSession?.status ?? session.terminalStatus ?? 'running'
+      : 'running',
+    exitCode: sameTerminalSession ? previousTerminalSession?.exitCode ?? session.terminalExitCode : undefined,
+    cwd: previousTerminalSession?.cwd,
+    command: previousTerminalSession?.command,
+    args: previousTerminalSession?.args,
+    mode: previousTerminalSession?.mode ?? 'spawn',
+    attached: previousTerminalSession?.attached ?? false,
+    createdAt: previousTerminalSession?.createdAt ?? session.terminalUpdatedAt ?? session.updatedAt,
     outputSnapshot,
   };
 }
@@ -1341,21 +1356,25 @@ export function App() {
       if (event.kind !== 'planning' || typeof event.data !== 'string' || event.data.length === 0) return;
       setPlanningSessions((prev) =>
         prev.map((session) => {
-          const matchesSession =
-            session.terminalSession?.sessionId === event.sessionId
-            || session.terminalSessionId === event.sessionId
-            || (event.planningSessionId !== undefined && session.id === event.planningSessionId);
-          if (!matchesSession) return session;
+          if (!planningSessionMatchesTerminalOutputEvent(session, event)) return session;
 
           const outputSnapshot = appendPlanningTerminalSnapshot(
             session.terminalSession?.outputSnapshot ?? session.terminalOutputSnapshot,
             event.data,
           );
+          const sameTerminalSession =
+            session.terminalSession?.sessionId === event.sessionId
+            || session.terminalSessionId === event.sessionId;
           return {
             ...session,
             terminalMode: 'tmux',
-            terminalSessionId: session.terminalSession?.sessionId ?? session.terminalSessionId ?? event.sessionId,
-            terminalStatus: session.terminalSession?.status ?? session.terminalStatus ?? 'running',
+            terminalSessionId: event.sessionId,
+            terminalStatus: sameTerminalSession
+              ? session.terminalSession?.status ?? session.terminalStatus ?? 'running'
+              : 'running',
+            terminalExitCode: sameTerminalSession
+              ? session.terminalSession?.exitCode ?? session.terminalExitCode
+              : undefined,
             terminalOutputSnapshot: outputSnapshot,
             terminalSession: planningTerminalSessionFromOutputEvent(session, event, outputSnapshot),
           };


### PR DESCRIPTION
## Summary

Planning tmux output survives Home/Planning switches.

The renderer now treats blank planning session ids as absent before matching planning terminal output.

Hidden output updates now keep the live tmux session descriptor aligned with the output event so remounts replay the cached scrollback.

## Review Claim

Preserve hidden planning tmux output by matching only non-blank planning-session ids and updating renderer snapshots from the actual terminal output event.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change only touches the planning-output event handler in the renderer. Non-planning terminal events still return before this path, and the focused regression covers the Home/Planning remount behavior.

## Slice Rationale

This slice lands after the surface-switch regression so the reviewer sees the remount expectation before reviewing the renderer matching and snapshot update.

## Non-goals

- No backend tmux lifecycle, IPC contract, or session-recreation changes.
- No chat transcript persistence changes.
- No changes to non-planning terminal panes.

## Architecture

### Before

```mermaid
graph TD
    A["Planning output event arrives"] --> B["Any defined planningSessionId can select the planning session"]
    B --> C["Append renderer snapshot for matching sessions"]
    C --> D["Preserve old terminal descriptor ids when available"]
    D --> E["Home remount replays the cached snapshot"]
```

### After

```mermaid
graph TD
    A["Planning output event arrives"] --> B["Only non-blank planningSessionId values select the planning session"]
    B --> C["Fallback matching uses terminal session ids"]
    C --> D["Store the event terminal ids with the cached snapshot"]
    D --> E["Home remount replays the cached snapshot"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- --run planning-terminal-tmux.test.tsx`

</details>

## Visual Proof

Real Electron visual proof for this stack's user-visible behavior: Home shows an active planning tmux pane, Planning hides it, and Home remounts it with hidden output preserved.

Frame 1: Home surface open, tmux pane connected, sidebar highlight on the Home icon: ![Frame 1: Home surface, tmux pane open](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-1e072a/01-home-tmux-open.png)

Frame 2: Planning surface selected, sidebar highlight moves and the tmux pane is unmounted while output continues arriving: ![Frame 2: Planning surface, tmux pane unmounted](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-1e072a/02-planning-surface-tmux-hidden.png)

Frame 3: Home surface selected again, pane remounts and shows `SURFACE_SWITCH_PROOF_OUTPUT_VISIBLE`, the line written while hidden: ![Frame 3: Home surface restored, hidden output visible](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-1e072a/03-home-surface-restored-output-visible.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 09f311809`
- Post-revert steps: None
- Data migration? No

</details>
