### PR TITLE
[Bugfix: main-process planner surfaces lazy-load](1) Defer planner surfaces load

### DIFF
--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -33,7 +33,7 @@ import type {
   InAppPlanningSessionPatch,
   InAppPlanningSessionRecord,
 } from '@invoker/data-store';
-import type { AgentRegistry } from '@invoker/execution-engine';
+import type { AgentRegistry, HarnessSessionDriver } from '@invoker/execution-engine';
 import {
   evaluatePlanningTurn,
   hasExplicitDraftIntent as hasCoreExplicitDraftIntent,
@@ -43,7 +43,6 @@ import {
   summarizePlanText,
   type PlanningMessage,
 } from '@invoker/planning-core';
-import type { HarnessPreset, PlanConversation, PlanConversationConfig, PlanningCommandBuilder } from '@invoker/surfaces';
 import type { InvokerConfig } from './config.js';
 
 export interface LoadedGeneratedPlan {
@@ -57,6 +56,43 @@ export interface InAppPlanningSessionStore {
   upsertInAppPlanningSession(record: InAppPlanningSessionRecord): void;
   updateInAppPlanningSession(sessionId: string, patch: InAppPlanningSessionPatch): void;
   deleteInAppPlanningSession(sessionId: string): void;
+}
+
+interface HarnessPreset {
+  tool: string;
+  model?: string;
+}
+
+export type PlanningCommandBuilder = (opts: {
+  tool: string;
+  model?: string;
+  prompt: string;
+}) => { command: string; args: string[] };
+
+interface PlanConversation {
+  sendMessage(message: string): Promise<string>;
+  init(): Promise<void>;
+  lastTurnReasoning: string[];
+  lastTurnDraftPlanText?: string | null;
+}
+
+interface PlanConversationConfig {
+  threadTs: string;
+  conversationRepo?: ConversationRepository;
+  tool?: string;
+  model?: string;
+  workingDir?: string;
+  timeoutMs: number;
+  defaultBranch?: string;
+  repoUrl?: string;
+  experimentalPlanner?: boolean;
+  conversationalPlanning: boolean;
+  preferStackedWorkflows: boolean;
+  planningCommandBuilder?: PlanningCommandBuilder;
+  harnessSessionDriver?: HarnessSessionDriver;
+  plannerRetryLimit?: number;
+  plannerRetryBaseDelayMs?: number;
+  onRawPlannerOutput?: (chunk: string) => void;
 }
 
 export interface InAppPlannerDeps {


### PR DESCRIPTION
## Summary

Desktop startup imports the in-app planner before any planning session exists.

The planner still resolved `@invoker/surfaces` during module evaluation, so a missing runtime dist entry could crash before the lazy fallback ran.

This change keeps runtime surfaces access behind `loadPlannerSurfaces()` and leaves startup free of the surfaces package.

## Review Claim

The planner module defers runtime surfaces resolution until `loadPlannerSurfaces()` runs, so desktop startup no longer crashes during module evaluation.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Session creation, restore, submit, and tmux state behavior stay unchanged except for deferring when the surfaces package is resolved.

## Slice Rationale

One behavior slice changes the runtime load boundary in `in-app-planner.ts`. The proof task edits no files, so its evidence belongs in Test Plan instead of another PR.

## Non-goals

No planning UX changes, no new preset behavior, no unrelated startup logging work, and no proof harness changes.

## Architecture

### Before

```mermaid
graph TD
    A["main.ts imports in-app-planner.js"] --> B["module evaluation resolves @invoker/surfaces"]
    B --> C["startup can fail before the lazy fallback runs"]
```

### After

```mermaid
graph TD
    A["main.ts imports in-app-planner.js"] --> B["planner module evaluates without surfaces runtime resolution"]
    B --> C["planning work calls loadPlannerSurfaces()"]
    C --> D["existing package, dist, or source fallback resolves surfaces"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `tmpdir=$(mktemp -d /tmp/in-app-planner-proof.XXXXXX); pnpm exec tsup packages/app/src/in-app-planner.ts --format cjs --platform node --target node20 --out-dir "$tmpdir" --external @invoker/surfaces --external electron; ! grep -q 'require("@invoker/surfaces")' "$tmpdir/in-app-planner.js"; node -e "require(process.argv[1]); console.log('bundle import ok')" "$tmpdir/in-app-planner.js"`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts -t "restores draft-ready sessions and submits from persisted approved draft text|restores persisted tmux mode and planning-owned terminal state|clears submitted pending-response state during restore"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-commit>`
- Post-revert steps: Rerun the focused planner startup proof before publishing a replacement.
- Data migration? No

</details>
