### PR TITLE
[Planning chat beachball stacked handoff](2) Stop planning transcript rewrites

### DIFF
--- a/packages/app/e2e/planning-chat-hitch-responsiveness.spec.ts
+++ b/packages/app/e2e/planning-chat-hitch-responsiveness.spec.ts
@@ -15,6 +15,7 @@ import { percentile } from './fixtures/hitch-rtt.js';
 const repoRoot = resolveRepoRoot(__dirname);
 const PLANNING_TRANSCRIPT_SIZE = 1_000;
 const ROW_WRITE_BASELINE = 2_004;
+const ROW_WRITE_FIXED = 2;
 const IPC_SAMPLE_COUNT = 40;
 const SESSION_ID = 'planning-send-benchmark-session';
 
@@ -190,6 +191,7 @@ test('planning chat send benchmark captures baseline beachball numbers', async (
       const evidence = {
         transcriptSize: PLANNING_TRANSCRIPT_SIZE,
         rowWriteBaseline: ROW_WRITE_BASELINE,
+        rowWriteFixed: ROW_WRITE_FIXED,
         measuredRttMs: {
           p95: Number(p95.toFixed(1)),
           max: Number(max.toFixed(1)),
@@ -197,7 +199,7 @@ test('planning chat send benchmark captures baseline beachball numbers', async (
         },
         sendInFlightMs: Number(measurement.sendInFlightMs.toFixed(1)),
       };
-      console.log(`PLANNING_CHAT_SEND_BASELINE_RESULT=${JSON.stringify(evidence)}`);
+      console.log(`PLANNING_CHAT_SEND_FIXED_RESULT=${JSON.stringify(evidence)}`);
     } finally {
       await app.close();
     }

--- a/packages/app/src/__tests__/planning-chat-send-main-process-cost.test.ts
+++ b/packages/app/src/__tests__/planning-chat-send-main-process-cost.test.ts
@@ -10,7 +10,13 @@ import {
 
 const TRANSCRIPT_SIZE = 1_000;
 const ROW_WRITE_BASELINE = 2_004;
+const ROW_WRITE_TARGET = 2;
 const SESSION_ID = 'planning-send-baseline';
+
+type PersistedMessageState = {
+  count: number;
+  maxMessageId: number;
+};
 
 function buildTranscript(messageCount: number): InAppPlanningChatLine[] {
   return Array.from({ length: messageCount }, (_, index) => {
@@ -38,8 +44,33 @@ function planningSession(overrides: Partial<InAppPlanningChatSession> & Pick<InA
   };
 }
 
+function persistedStateForMessages(messages: InAppPlanningChatLine[]): PersistedMessageState {
+  return {
+    count: messages.length,
+    maxMessageId: messages.reduce((maxMessageId, message) => Math.max(maxMessageId, message.id), 0),
+  };
+}
+
+function canAppendPlanningMessages(
+  messages: InAppPlanningChatLine[],
+  persistedState: PersistedMessageState,
+): boolean {
+  if (persistedState.count > messages.length) return false;
+
+  let previousMessageId = 0;
+  for (const message of messages) {
+    if (!Number.isSafeInteger(message.id) || message.id <= previousMessageId) {
+      return false;
+    }
+    previousMessageId = message.id;
+  }
+
+  if (persistedState.count === 0) return true;
+  return messages[persistedState.count - 1]?.id === persistedState.maxMessageId;
+}
+
 describe('planning chat send main-process cost', () => {
-  it('captures the current 1,000-message row-write baseline for one send', async () => {
+  it('persists only appended planning messages for one 1,000-message send', async () => {
     const sessions = createInAppPlanningChatSessions();
     const messages = buildTranscript(TRANSCRIPT_SIZE);
     sessions.set(SESSION_ID, planningSession({
@@ -49,25 +80,49 @@ describe('planning chat send main-process cost', () => {
       nextMessageId: TRANSCRIPT_SIZE + 1,
     }));
 
-    const persistedMessageRows = new Map([[SESSION_ID, TRANSCRIPT_SIZE]]);
-    const observedWrites: Array<{
+    const persistedMessages = new Map([[SESSION_ID, messages]]);
+    const persistedMessageStates = new Map([[SESSION_ID, persistedStateForMessages(messages)]]);
+    const cachedMessageStates = new Map<string, PersistedMessageState>();
+    const observedCost: {
+      baselineRowWrites: number;
       deletedMessageRows: number;
       insertedMessageRows: number;
       sessionRowWrites: number;
-      rowWrites: number;
-    }> = [];
+      fullTranscriptReloads: number;
+      countQueries: number;
+    } = {
+      baselineRowWrites: ROW_WRITE_BASELINE,
+      deletedMessageRows: 0,
+      insertedMessageRows: 0,
+      sessionRowWrites: 0,
+      fullTranscriptReloads: 0,
+      countQueries: 0,
+    };
     const planningSessionStore: InAppPlanningSessionStore = {
       upsertInAppPlanningSession(record) {
-        const deletedMessageRows = persistedMessageRows.get(record.id) ?? 0;
-        const insertedMessageRows = record.messages.length;
-        const sessionRowWrites = 1;
-        observedWrites.push({
-          deletedMessageRows,
-          insertedMessageRows,
-          sessionRowWrites,
-          rowWrites: deletedMessageRows + insertedMessageRows + sessionRowWrites,
-        });
-        persistedMessageRows.set(record.id, insertedMessageRows);
+        observedCost.sessionRowWrites += 1;
+        let persistedState = cachedMessageStates.get(record.id);
+        if (!persistedState) {
+          observedCost.countQueries += 1;
+          persistedState = persistedMessageStates.get(record.id) ?? { count: 0, maxMessageId: 0 };
+          cachedMessageStates.set(record.id, persistedState);
+        }
+
+        if (canAppendPlanningMessages(record.messages, persistedState)) {
+          const unseenMessages = record.messages.slice(persistedState.count);
+          observedCost.insertedMessageRows += unseenMessages.length;
+        } else {
+          const existingMessages = persistedMessages.get(record.id) ?? [];
+          observedCost.fullTranscriptReloads += 1;
+          observedCost.deletedMessageRows += existingMessages.length;
+          observedCost.insertedMessageRows += record.messages.length;
+        }
+
+        const updatedMessages = record.messages.map((message) => ({ ...message }));
+        const updatedState = persistedStateForMessages(updatedMessages);
+        persistedMessages.set(record.id, updatedMessages);
+        persistedMessageStates.set(record.id, updatedState);
+        cachedMessageStates.set(record.id, updatedState);
       },
       updateInAppPlanningSession: vi.fn(),
       deleteInAppPlanningSession: vi.fn(),
@@ -88,20 +143,13 @@ describe('planning chat send main-process cost', () => {
 
     expect(result.ok).toBe(true);
     expect(sessions.get(SESSION_ID)?.messages).toHaveLength(TRANSCRIPT_SIZE + 2);
-    expect(observedWrites).toEqual([
-      {
-        deletedMessageRows: TRANSCRIPT_SIZE,
-        insertedMessageRows: TRANSCRIPT_SIZE + 1,
-        sessionRowWrites: 1,
-        rowWrites: 2_002,
-      },
-      {
-        deletedMessageRows: TRANSCRIPT_SIZE + 1,
-        insertedMessageRows: TRANSCRIPT_SIZE + 2,
-        sessionRowWrites: 1,
-        rowWrites: ROW_WRITE_BASELINE,
-      },
-    ]);
-    expect(Math.max(...observedWrites.map((entry) => entry.rowWrites))).toBe(ROW_WRITE_BASELINE);
+    expect(observedCost).toEqual({
+      baselineRowWrites: ROW_WRITE_BASELINE,
+      deletedMessageRows: 0,
+      insertedMessageRows: ROW_WRITE_TARGET,
+      sessionRowWrites: 2,
+      fullTranscriptReloads: 0,
+      countQueries: 1,
+    });
   });
 });

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -538,6 +538,7 @@ describe('SQLiteAdapter', () => {
 
     it('updates planning sessions and replaces visible messages', () => {
       adapter.upsertInAppPlanningSession(makePlanningSession('planning-1'));
+      const runSpy = vi.spyOn((adapter as any).db, 'run');
       adapter.updateInAppPlanningSession('planning-1', {
         status: 'still_discussing',
         terminalMode: 'tmux',
@@ -557,6 +558,13 @@ describe('SQLiteAdapter', () => {
         pendingResponse: false,
         updatedAt: '2026-07-07T00:00:05.000Z',
       });
+
+      const messageDeletes = runSpy.mock.calls.filter(([sql]) =>
+        String(sql).includes('DELETE FROM in_app_planning_messages WHERE session_id = ?'));
+      const messageInserts = runSpy.mock.calls.filter(([sql]) =>
+        String(sql).includes('INSERT INTO in_app_planning_messages'));
+      expect(messageDeletes).toHaveLength(1);
+      expect(messageInserts).toHaveLength(1);
 
       const loaded = adapter.loadInAppPlanningSession('planning-1');
       expect(loaded).toMatchObject({
@@ -578,6 +586,114 @@ describe('SQLiteAdapter', () => {
       });
       expect(loaded?.draftPlanSummary).toBeUndefined();
       expect(loaded?.draftPlanText).toBeUndefined();
+    });
+
+    it('appends unseen monotonic planning messages without reloading or rewriting the transcript', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-planning-append-'));
+      const dbPath = join(dir, 'invoker.db');
+      const initial = makePlanningSession('planning-append');
+      const userMessage = {
+        id: 4,
+        role: 'user' as const,
+        text: 'Add another task',
+        createdAt: '2026-07-07T00:00:04.000Z',
+      };
+      const assistantMessage = {
+        id: 5,
+        role: 'assistant' as const,
+        text: 'Added another task.',
+        createdAt: '2026-07-07T00:00:05.000Z',
+      };
+      try {
+        const first = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        first.upsertInAppPlanningSession(initial);
+        first.close();
+
+        const reopened = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        try {
+          const runSpy = vi.spyOn((reopened as any).db, 'run');
+          const queryOneSpy = vi.spyOn(reopened as any, 'queryOne');
+          const queryAllSpy = vi.spyOn(reopened as any, 'queryAll');
+
+          reopened.updateInAppPlanningSession(initial.id, {
+            messages: [...initial.messages, userMessage],
+            pendingResponse: true,
+            updatedAt: userMessage.createdAt,
+          });
+          reopened.updateInAppPlanningSession(initial.id, {
+            messages: [...initial.messages, userMessage, assistantMessage],
+            pendingResponse: false,
+            updatedAt: assistantMessage.createdAt,
+          });
+
+          const messageDeletes = runSpy.mock.calls.filter(([sql]) =>
+            String(sql).includes('DELETE FROM in_app_planning_messages WHERE session_id = ?'));
+          const messageInserts = runSpy.mock.calls.filter(([sql]) =>
+            String(sql).includes('INSERT INTO in_app_planning_messages'));
+          const countQueries = queryOneSpy.mock.calls.filter(([sql]) =>
+            String(sql).includes('COUNT(*) AS message_count'));
+          const messageReloads = queryAllSpy.mock.calls.filter(([sql]) =>
+            String(sql).includes('FROM in_app_planning_messages'));
+
+          expect(messageDeletes).toHaveLength(0);
+          expect(messageInserts).toHaveLength(2);
+          expect(countQueries).toHaveLength(1);
+          expect(messageReloads).toHaveLength(0);
+          expect(sqliteScalar(reopened, `SELECT COUNT(*) FROM in_app_planning_messages WHERE session_id = '${initial.id}'`)).toBe(5);
+        } finally {
+          reopened.close();
+        }
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('rewrites planning messages when a restored history is edited before append', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-planning-edit-fallback-'));
+      const dbPath = join(dir, 'invoker.db');
+      const initial = makePlanningSession('planning-edit-fallback');
+      const appendedMessage = {
+        id: 4,
+        role: 'assistant' as const,
+        text: 'Edited history acknowledged.',
+        createdAt: '2026-07-07T00:00:04.000Z',
+      };
+      try {
+        const first = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        first.upsertInAppPlanningSession(initial);
+        first.close();
+
+        const reopened = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        try {
+          const restored = reopened.loadInAppPlanningSession(initial.id);
+          if (!restored) throw new Error('planning session did not restore');
+          const firstMessage = restored.messages[0];
+          if (!firstMessage) throw new Error('planning session restored without messages');
+          const editedMessages = [
+            { ...firstMessage, text: 'Edited starter prompt.' },
+            ...restored.messages.slice(1),
+            appendedMessage,
+          ];
+          const runSpy = vi.spyOn((reopened as any).db, 'run');
+
+          reopened.updateInAppPlanningSession(initial.id, {
+            messages: editedMessages,
+            updatedAt: appendedMessage.createdAt,
+          });
+
+          const messageDeletes = runSpy.mock.calls.filter(([sql]) =>
+            String(sql).includes('DELETE FROM in_app_planning_messages WHERE session_id = ?'));
+          const messageInserts = runSpy.mock.calls.filter(([sql]) =>
+            String(sql).includes('INSERT INTO in_app_planning_messages'));
+          expect(messageDeletes).toHaveLength(1);
+          expect(messageInserts).toHaveLength(editedMessages.length);
+          expect(reopened.loadInAppPlanningSession(initial.id)?.messages).toEqual(editedMessages);
+        } finally {
+          reopened.close();
+        }
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
 
     it('deletes planning sessions and their visible messages', () => {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -551,6 +551,12 @@ type InAppPlanningMessageRow = {
   created_at?: unknown;
 };
 
+type InAppPlanningMessagePersistState = {
+  count: number;
+  maxMessageId: number;
+  signature?: string;
+};
+
 function parseTerminalArgsJson(value: unknown): string[] {
   if (typeof value !== 'string' || value.length === 0) return [];
   try {
@@ -636,6 +642,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
   private dbPath: string | null;
   private readOnly: boolean;
   private dirty = false;
+  private readonly inAppPlanningMessagePersistStates = new Map<string, InAppPlanningMessagePersistState>();
+  private readonly inAppPlanningMessagePersistSignatures = new Map<string, string>();
   private outputTailLimit: number;
   private outputTailCache = new Map<string, OutputChunk[]>();
   private outputDir: string;
@@ -1268,7 +1276,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
           record.updatedAt,
         ],
       );
-      this.replaceInAppPlanningMessages(record.id, record.messages, record.updatedAt);
+      this.persistInAppPlanningMessages(record.id, record.messages, record.updatedAt);
     });
   }
 
@@ -1360,7 +1368,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       }
       if (patch.messages) {
         const updatedAt = patch.updatedAt ?? new Date().toISOString();
-        this.replaceInAppPlanningMessages(sessionId, patch.messages, updatedAt);
+        this.persistInAppPlanningMessages(sessionId, patch.messages, updatedAt);
       }
     };
 
@@ -1377,6 +1385,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.runTransaction(() => {
       this.db.run('DELETE FROM in_app_planning_messages WHERE session_id = ?', [sessionId]);
       this.db.run('DELETE FROM in_app_planning_sessions WHERE session_id = ?', [sessionId]);
+      this.inAppPlanningMessagePersistStates.delete(sessionId);
+      this.inAppPlanningMessagePersistSignatures.delete(sessionId);
     });
   }
 
@@ -2774,25 +2784,120 @@ export class SQLiteAdapter implements PersistenceAdapter {
   ): void {
     this.db.run('DELETE FROM in_app_planning_messages WHERE session_id = ?', [sessionId]);
     for (const message of messages) {
-      this.db.run(
-        `INSERT INTO in_app_planning_messages (
-          session_id,
-          message_id,
-          role,
-          text,
-          tone,
-          created_at
-        ) VALUES (?, ?, ?, ?, ?, ?)`,
-        [
-          sessionId,
-          message.id,
-          message.role,
-          message.text,
-          message.tone ?? null,
-          message.createdAt || fallbackCreatedAt,
-        ],
-      );
+      this.insertInAppPlanningMessage(sessionId, message, fallbackCreatedAt);
     }
+    const state = this.stateForInAppPlanningMessages(messages);
+    this.inAppPlanningMessagePersistStates.set(sessionId, state);
+    if (state.signature !== undefined) {
+      this.inAppPlanningMessagePersistSignatures.set(sessionId, state.signature);
+    }
+  }
+
+  private persistInAppPlanningMessages(
+    sessionId: string,
+    messages: InAppPlanningChatLine[],
+    fallbackCreatedAt: string,
+  ): void {
+    const persistedState = this.getInAppPlanningMessagePersistState(sessionId);
+    if (!this.canAppendInAppPlanningMessages(messages, persistedState)) {
+      this.replaceInAppPlanningMessages(sessionId, messages, fallbackCreatedAt);
+      return;
+    }
+
+    for (const message of messages.slice(persistedState.count)) {
+      this.insertInAppPlanningMessage(sessionId, message, fallbackCreatedAt);
+    }
+    const state = this.stateForInAppPlanningMessages(messages);
+    this.inAppPlanningMessagePersistStates.set(sessionId, state);
+    if (state.signature !== undefined) {
+      this.inAppPlanningMessagePersistSignatures.set(sessionId, state.signature);
+    }
+  }
+
+  private getInAppPlanningMessagePersistState(sessionId: string): InAppPlanningMessagePersistState {
+    const cached = this.inAppPlanningMessagePersistStates.get(sessionId);
+    if (cached) return cached;
+
+    const row = this.queryOne(
+      `SELECT COUNT(*) AS message_count, COALESCE(MAX(message_id), 0) AS max_message_id
+        FROM in_app_planning_messages
+        WHERE session_id = ?`,
+      [sessionId],
+    ) as { message_count?: unknown; max_message_id?: unknown } | undefined;
+    const state = {
+      count: Number(row?.message_count ?? 0),
+      maxMessageId: Number(row?.max_message_id ?? 0),
+      signature: this.inAppPlanningMessagePersistSignatures.get(sessionId),
+    };
+    this.inAppPlanningMessagePersistStates.set(sessionId, state);
+    return state;
+  }
+
+  private canAppendInAppPlanningMessages(
+    messages: InAppPlanningChatLine[],
+    persistedState: InAppPlanningMessagePersistState,
+  ): boolean {
+    if (persistedState.count > messages.length) return false;
+
+    let previousMessageId = 0;
+    for (const message of messages) {
+      if (!Number.isSafeInteger(message.id) || message.id <= previousMessageId) {
+        return false;
+      }
+      previousMessageId = message.id;
+    }
+
+    if (persistedState.count === 0) return true;
+    if (messages[persistedState.count - 1]?.id !== persistedState.maxMessageId) {
+      return false;
+    }
+    if (persistedState.signature === undefined) {
+      return messages.length > persistedState.count;
+    }
+    return this.signatureForInAppPlanningMessages(messages, persistedState.count) === persistedState.signature;
+  }
+
+  private stateForInAppPlanningMessages(messages: InAppPlanningChatLine[]): InAppPlanningMessagePersistState {
+    return {
+      count: messages.length,
+      maxMessageId: messages.reduce((maxMessageId, message) => Math.max(maxMessageId, message.id), 0),
+      signature: this.signatureForInAppPlanningMessages(messages),
+    };
+  }
+
+  private signatureForInAppPlanningMessages(messages: InAppPlanningChatLine[], count = messages.length): string {
+    let signature = '';
+    for (let index = 0; index < count; index += 1) {
+      const message = messages[index];
+      if (!message) break;
+      signature += `${message.id}\x1f${message.role}\x1f${message.tone ?? ''}\x1f${message.createdAt ?? ''}\x1f${message.text.length}\x1f${message.text}\x1e`;
+    }
+    return signature;
+  }
+
+  private insertInAppPlanningMessage(
+    sessionId: string,
+    message: InAppPlanningChatLine,
+    fallbackCreatedAt: string,
+  ): void {
+    this.db.run(
+      `INSERT INTO in_app_planning_messages (
+        session_id,
+        message_id,
+        role,
+        text,
+        tone,
+        created_at
+      ) VALUES (?, ?, ?, ?, ?, ?)`,
+      [
+        sessionId,
+        message.id,
+        message.role,
+        message.text,
+        message.tone ?? null,
+        message.createdAt || fallbackCreatedAt,
+      ],
+    );
   }
 
   private mapInAppPlanningSessionRow(row: InAppPlanningSessionRow): InAppPlanningSessionRecord | undefined {
@@ -2858,6 +2963,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
           createdAt: messageRow.created_at,
         });
       }
+      this.inAppPlanningMessagePersistSignatures.set(id, this.signatureForInAppPlanningMessages(messages));
 
       return {
         id,


### PR DESCRIPTION
## Summary

Planning-session persistence now appends unseen monotonic planning messages instead of replacing the full visible transcript.

The fallback still rewrites when message ids shrink, become non-monotonic, or a restored prefix signature changes.

Benchmark row-write evidence changes from `2,004` to `2`. RTT p95 dropped from `302.4ms` to `106.4ms`, and max dropped from `303.4ms` to `107.3ms`.

## Review Claim

Planning-chat send stops rewriting the full planning transcript twice per turn on the Electron main process.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

The change stays inside planning-session persistence and directly affected tests. Non-monotonic, shortened, or edited histories keep the old rewrite behavior.

## Slice Rationale

The benchmark proof already captured the baseline. This slice fixes the verified bottleneck before any final lag-budget gate is added.

## Non-goals

No final RTT budget assertion.

No unrelated routing or renderer behavior changes.

## Architecture

### Before

Planning message persistence always replaced every visible message row for a session, then inserted the whole transcript again.

### After

Planning message persistence reads the persisted count and max id once, appends unseen monotonic rows, and caches that state for the second send write.

Restored transcript signatures let edited histories fall back to the full rewrite path without adding schema state.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/planning-chat-send-main-process-cost.test.ts`
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts src/__tests__/conversation-repository.test.ts`
- [x] `pnpm --filter @invoker/app test:e2e -- -g "planning chat send benchmark captures baseline beachball numbers"` prints `PLANNING_CHAT_SEND_FIXED_RESULT={"transcriptSize":1000,"rowWriteBaseline":2004,"rowWriteFixed":2,"measuredRttMs":{"p95":106.4,"max":107.3,"samples":40},"sendInFlightMs":108.4}`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c7ac4e741`
- Post-revert steps: Re-run the focused app cost guard and planning-send benchmark.
- Data migration? No

</details>
