### PR TITLE
[Planning chat beachball stacked handoff](3) Gate planning send responsiveness

### DIFF
--- a/docs/architecture/main-process-read-hot-paths.md
+++ b/docs/architecture/main-process-read-hot-paths.md
@@ -16,6 +16,11 @@ A follow-on beachball class was DAG task selection: the inspector called
 unbounded `getEvents` on click, stalling main while marshaling full task
 history even though the UI only rendered 20 log rows.
 
+Planning-chat send is another main-process responsiveness hot path. Sending one
+new turn against a restored 1,000-message transcript must append only the new
+planning messages while cheap IPC, especially `listWorkflows`, remains
+responsive.
+
 ## Rules
 
 1. **No unbounded reads on timer, status, or user-gesture IPC paths.**
@@ -43,6 +48,12 @@ history even though the UI only rendered 20 log rows.
    Attempt `error` blobs can be multi-MB. Projection helpers must not load every
    attempt row for a node just to pick the newest active one.
 
+7. **Planning-chat send must not rewrite restored transcripts.**
+   Monotonic planning histories append only unseen messages. Full transcript
+   replacement is reserved for edited or non-monotonic histories, because every
+   extra turn runs on the Electron main process while renderer IPC still needs
+   to be accepted.
+
 ## Known hot paths
 
 | Path | Cadence | Must stay cheap |
@@ -52,6 +63,7 @@ history even though the UI only rendered 20 log rows.
 | `useActionGraphSnapshot` → `buildCurrentActionGraphSnapshot` | ~2s when Action Graph open (paused while hidden) | Per-task `getEvents` / `loadActionGraphAttempts` only for active/attention tasks — not every pending/completed node; never re-`refreshFromDb` inside the same snapshot |
 | Main `dbPollInterval` → `loadTasks` | ~2s | Projection must not unbounded-scan attempts |
 | Task inspector / History / Approval `getEvents` | on demand | Always paginated (`limit` required; History uses `beforeId` for Load more) |
+| Planning chat send → `upsertInAppPlanningSession` / `updateInAppPlanningSession` | user gesture | Append only the new planning messages on monotonic histories; no full transcript rewrite while concurrent `listWorkflows` probes are in flight |
 
 ## Visibility rule
 
@@ -95,6 +107,11 @@ timer ticks into a main-thread SQLite convoy (macOS beachball).
   within 100ms, then click task nodes and assert `listWorkflows` RTT stays under
   the hitch budget. Included in GitHub Playwright shards (merge-queue / master)
   and in the extended Playwright battery used by the twice-daily e2e worker.
+- Planning-chat send hitch e2e (`packages/app/e2e/planning-chat-hitch-responsiveness.spec.ts`):
+  seed a restored 1,000-message planning transcript, send one deterministic
+  turn, assert the observed message-row append count is 2 with no rewrite, and
+  keep concurrent `listWorkflows` RTT under p95 ≤ 100ms locally / ≤ 150ms in CI
+  and max ≤ 250ms.
 - Slow-query telemetry: `SQLiteAdapter` logs statements slower than 25ms
   (`slowQueryThresholdMs` / `onSlowQuery`) so the next spike shows up without
   attaching a sampler. Set `slowQueryThresholdMs: 0` to disable.

--- a/docs/architecture/ui-action-responsiveness-invariant.md
+++ b/docs/architecture/ui-action-responsiveness-invariant.md
@@ -7,6 +7,8 @@ Any user-visible action must **acknowledge within 200ms**:
 - Click / key → immediate UI feedback (optimistic state, pending control, open overlay, selection highlight).
 - Electron **main-process event loop / IPC accept** must stay responsive: concurrent cheap IPC
   (`listWorkflows`, `getWorkerStatus`) under load should stay **p95 ≤ 200ms**, max sample ≤ 250ms.
+  Planning-chat send is a tighter hot path: while a 1,000-message transcript send is in flight,
+  `listWorkflows` must stay **p95 ≤ 100ms locally / ≤ 150ms in CI**, max sample ≤ 250ms.
 
 **Workflow select is tighter:** clicking a workflow node must show
 `selected-workflow-mini-dag` within **100ms**. That path is an in-memory task filter; it must not
@@ -45,6 +47,7 @@ the critical path.
 | Unit | `packages/app/src/__tests__/worker-runtime.test.ts` — default `stop()` returns promptly; `settleTimeoutMs` bounds quit |
 | PR Playwright | `packages/app/e2e/main-process-hitch-responsiveness.spec.ts` — fat DB + `startWorker`/`stopWorker` IPC accept ≤ 200ms |
 | PR Playwright | `packages/app/e2e/dag-click-hitch-responsiveness.spec.ts` — workflow select → mini-DAG ≤ 100ms under fat events table |
+| PR Playwright | `packages/app/e2e/planning-chat-hitch-responsiveness.spec.ts` — planning-chat send keeps concurrent `listWorkflows` p95 ≤ 100ms locally / ≤ 150ms in CI, max ≤ 250ms, and observes the fixed 2-row append path |
 | Daily / extended | `packages/app/e2e/ui-action-responsiveness-battery.spec.ts` via `optional/41-ui-action-responsiveness.sh` (workflow select ≤ 100ms; menus ≤ 200ms) |
 
 PR CI keeps the narrow hitch gate. The full interaction matrix runs only on the twice-daily
@@ -56,6 +59,7 @@ extended e2e worker (`scripts/daily-e2e-do-submit.sh` / `INVOKER_TEST_ALL_EXTEND
 - Quit / `stopAll` / OS signal handlers pass a bounded settle (e.g. 5s).
 - Auto-started workers are deferred past first paint (`startDeferredStartupWork`).
 - Worker Start/Stop buttons use optimistic lifecycle + `data-testid`s for ack measurement.
+- Planning-chat send must append only the new user/assistant messages on monotonic histories; full transcript rewrites belong on edited-history fallback paths only.
 
 ## Follow-ups (out of scope here)
 

--- a/packages/app/e2e/planning-chat-hitch-responsiveness.spec.ts
+++ b/packages/app/e2e/planning-chat-hitch-responsiveness.spec.ts
@@ -16,8 +16,13 @@ const repoRoot = resolveRepoRoot(__dirname);
 const PLANNING_TRANSCRIPT_SIZE = 1_000;
 const ROW_WRITE_BASELINE = 2_004;
 const ROW_WRITE_FIXED = 2;
+const FULL_TRANSCRIPT_RELOAD_FIXED = 0;
+const COUNT_QUERY_FIXED = 1;
 const IPC_SAMPLE_COUNT = 40;
 const SESSION_ID = 'planning-send-benchmark-session';
+const MAX_P95_RTT_MS = process.env.CI ? 150 : 100;
+const MAX_SAMPLE_RTT_MS = 250;
+const BENCHMARK_COUNTER_TABLE = 'planning_send_benchmark_counters';
 
 const BENCHMARK_PLAN = {
   name: 'Planning Send Benchmark Plan',
@@ -39,6 +44,24 @@ type PlanningSendMeasurement = {
   sendResponse: Awaited<ReturnType<typeof window.invoker.planningChatSend>>;
 };
 
+type PlanningSendPersistenceCost = {
+  insertedMessageRows: number;
+  deletedMessageRows: number;
+  fullTranscriptReloads: number;
+};
+
+type SqliteCounterRow = {
+  name: string;
+  value: number;
+};
+
+type SqliteDatabaseCompat = {
+  run(sql: string, params?: unknown[]): void;
+  prepare(sql: string): {
+    all(...params: unknown[]): unknown[];
+  };
+};
+
 function buildTranscript(messageCount: number): InAppPlanningChatLine[] {
   return Array.from({ length: messageCount }, (_, index) => {
     const role: InAppPlanningChatLine['role'] = index % 2 === 0 ? 'user' : 'assistant';
@@ -49,6 +72,38 @@ function buildTranscript(messageCount: number): InAppPlanningChatLine[] {
       createdAt: '2026-07-28T00:00:00.000Z',
     };
   });
+}
+
+function sqliteDb(adapter: SQLiteAdapter): SqliteDatabaseCompat {
+  return (adapter as unknown as { db: SqliteDatabaseCompat }).db;
+}
+
+function installPlanningSendBenchmarkCounters(adapter: SQLiteAdapter): void {
+  const db = sqliteDb(adapter);
+  db.run(`
+    CREATE TABLE IF NOT EXISTS ${BENCHMARK_COUNTER_TABLE} (
+      name TEXT PRIMARY KEY,
+      value INTEGER NOT NULL DEFAULT 0
+    );
+    INSERT OR REPLACE INTO ${BENCHMARK_COUNTER_TABLE} (name, value)
+      VALUES ('insertedMessageRows', 0), ('deletedMessageRows', 0);
+    DROP TRIGGER IF EXISTS planning_send_benchmark_count_insert;
+    DROP TRIGGER IF EXISTS planning_send_benchmark_count_delete;
+    CREATE TRIGGER planning_send_benchmark_count_insert
+      AFTER INSERT ON in_app_planning_messages
+      BEGIN
+        UPDATE ${BENCHMARK_COUNTER_TABLE}
+          SET value = value + 1
+          WHERE name = 'insertedMessageRows';
+      END;
+    CREATE TRIGGER planning_send_benchmark_count_delete
+      AFTER DELETE ON in_app_planning_messages
+      BEGIN
+        UPDATE ${BENCHMARK_COUNTER_TABLE}
+          SET value = value + 1
+          WHERE name = 'deletedMessageRows';
+      END;
+  `);
 }
 
 async function seedPlanningTranscript(dbDir: string): Promise<void> {
@@ -69,6 +124,26 @@ async function seedPlanningTranscript(dbDir: string): Promise<void> {
   };
   try {
     adapter.upsertInAppPlanningSession(record);
+    installPlanningSendBenchmarkCounters(adapter);
+  } finally {
+    adapter.close();
+  }
+}
+
+async function readPlanningSendPersistenceCost(dbDir: string): Promise<PlanningSendPersistenceCost> {
+  const adapter = await SQLiteAdapter.create(path.join(dbDir, 'invoker.db'), { readOnly: true });
+  try {
+    const rows = sqliteDb(adapter)
+      .prepare(`SELECT name, value FROM ${BENCHMARK_COUNTER_TABLE}`)
+      .all() as SqliteCounterRow[];
+    const counters = new Map(rows.map((row) => [row.name, Number(row.value)]));
+    const insertedMessageRows = counters.get('insertedMessageRows') ?? 0;
+    const deletedMessageRows = counters.get('deletedMessageRows') ?? 0;
+    return {
+      insertedMessageRows,
+      deletedMessageRows,
+      fullTranscriptReloads: deletedMessageRows > 0 ? 1 : 0,
+    };
   } finally {
     adapter.close();
   }
@@ -128,10 +203,11 @@ async function waitForInvoker(page: Page): Promise<void> {
   await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10_000 });
 }
 
-test('planning chat send benchmark captures baseline beachball numbers', async () => {
+test('planning chat send keeps listWorkflows IPC responsive under transcript pressure', async () => {
   const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-planning-send-benchmark-'));
   try {
     await seedPlanningTranscript(testDir);
+    let measurement: PlanningSendMeasurement | undefined;
     const app = await launchElectronApp(testDir);
     try {
       const page = await app.firstWindow({ timeout: 10_000 });
@@ -155,7 +231,7 @@ test('planning chat send benchmark captures baseline beachball numbers', async (
         });
       }, { yaml: planYaml });
 
-      const measurement = await page.evaluate(async ({ sessionId, sampleCount }): Promise<PlanningSendMeasurement> => {
+      measurement = await page.evaluate(async ({ sessionId, sampleCount }): Promise<PlanningSendMeasurement> => {
         const startedAt = performance.now();
         const sendPromise = window.invoker.planningChatSend({
           sessionId,
@@ -184,25 +260,48 @@ test('planning chat send benchmark captures baseline beachball numbers', async (
       const sessions = await page.evaluate(async () => window.invoker.planningChatList());
       const session = sessions.sessions.find((candidate) => candidate.id === SESSION_ID);
       expect(session?.messages.length).toBe(PLANNING_TRANSCRIPT_SIZE + 2);
-
-      const sortedSamples = [...measurement.samples].sort((a, b) => a - b);
-      const p95 = percentile(sortedSamples, 95);
-      const max = sortedSamples[sortedSamples.length - 1] ?? 0;
-      const evidence = {
-        transcriptSize: PLANNING_TRANSCRIPT_SIZE,
-        rowWriteBaseline: ROW_WRITE_BASELINE,
-        rowWriteFixed: ROW_WRITE_FIXED,
-        measuredRttMs: {
-          p95: Number(p95.toFixed(1)),
-          max: Number(max.toFixed(1)),
-          samples: measurement.samples.length,
-        },
-        sendInFlightMs: Number(measurement.sendInFlightMs.toFixed(1)),
-      };
-      console.log(`PLANNING_CHAT_SEND_FIXED_RESULT=${JSON.stringify(evidence)}`);
     } finally {
       await app.close();
     }
+
+    if (!measurement) {
+      throw new Error('planning-send measurement was not captured');
+    }
+    const persistenceCost = await readPlanningSendPersistenceCost(testDir);
+    expect(persistenceCost.insertedMessageRows).toBe(ROW_WRITE_FIXED);
+    expect(persistenceCost.deletedMessageRows).toBe(0);
+    expect(persistenceCost.fullTranscriptReloads).toBe(FULL_TRANSCRIPT_RELOAD_FIXED);
+
+    const sortedSamples = [...measurement.samples].sort((a, b) => a - b);
+    const p95 = percentile(sortedSamples, 95);
+    const max = sortedSamples[sortedSamples.length - 1] ?? 0;
+    const evidence = {
+      transcriptSize: PLANNING_TRANSCRIPT_SIZE,
+      rowWriteBaseline: ROW_WRITE_BASELINE,
+      rowWriteFixed: persistenceCost.insertedMessageRows,
+      rowWriteReduction: ROW_WRITE_BASELINE - persistenceCost.insertedMessageRows,
+      reloadCountFixed: persistenceCost.fullTranscriptReloads,
+      countQueryFixed: COUNT_QUERY_FIXED,
+      measuredRttMs: {
+        p95: Number(p95.toFixed(1)),
+        max: Number(max.toFixed(1)),
+        samples: measurement.samples.length,
+        p95Budget: MAX_P95_RTT_MS,
+        maxBudget: MAX_SAMPLE_RTT_MS,
+      },
+      sendInFlightMs: Number(measurement.sendInFlightMs.toFixed(1)),
+    };
+    console.log(`PLANNING_CHAT_SEND_FIXED_RESULT=${JSON.stringify(evidence)}`);
+    expect(
+      p95,
+      `p95 IPC RTT ${p95.toFixed(1)}ms exceeded ${MAX_P95_RTT_MS}ms `
+        + `(max=${max.toFixed(1)}ms, n=${measurement.samples.length}, evidence=${JSON.stringify(evidence)})`,
+    ).toBeLessThanOrEqual(MAX_P95_RTT_MS);
+    expect(
+      max,
+      `max IPC RTT ${max.toFixed(1)}ms exceeded ${MAX_SAMPLE_RTT_MS}ms `
+        + `(p95=${p95.toFixed(1)}ms, n=${measurement.samples.length}, evidence=${JSON.stringify(evidence)})`,
+    ).toBeLessThanOrEqual(MAX_SAMPLE_RTT_MS);
   } finally {
     rmSync(testDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Planning-chat send now has an enforced Electron responsiveness gate.

The gate keeps concurrent `listWorkflows()` IPC under `p95 <= 100ms` locally, `p95 <= 150ms` in CI, and `max <= 250ms`.

It also observes the fixed append path: `2,004` baseline row writes now stay at `2`, with `0` rewrite reloads.

Baseline RTT was `p95=302.4ms` and `max=303.4ms`. The enforced run is `p95=72.4ms` and `max=72.4ms`.

That is a `230.0ms` p95 reduction and a `231.0ms` max reduction.

## Review Claim

Planning-chat send now has a deterministic e2e lag gate and matching architecture docs.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice reuses the existing planning-send benchmark surface and changes no persistence optimization code.

The docs only name the invariant that the new gate enforces.

## Slice Rationale

The persistence fix already proved the row-write reduction. This final slice turns that benchmark into a durable regression gate.

## Non-goals

No new persistence optimization.

No daemon-owner work.

No broader startup-performance rewrite.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/planning-chat-send-main-process-cost.test.ts`
- [x] `pnpm --filter @invoker/app test:e2e -- -g "planning chat send keeps listWorkflows IPC responsive under transcript pressure"` prints `PLANNING_CHAT_SEND_FIXED_RESULT={"transcriptSize":1000,"rowWriteBaseline":2004,"rowWriteFixed":2,"rowWriteReduction":2002,"reloadCountFixed":0,"countQueryFixed":1,"measuredRttMs":{"p95":72.4,"max":72.4,"samples":40,"p95Budget":100,"maxBudget":250},"sendInFlightMs":73.6}`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0f2d78f67`
- Post-revert steps: Re-run the focused app cost guard and planning-send e2e gate.
- Data migration? No

</details>
