### PR TITLE
[Bugfix: main-process planner surfaces lazy-load](1) Defer planner surfaces load

### DIFF
--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -33,7 +33,7 @@ import type {
   InAppPlanningSessionPatch,
   InAppPlanningSessionRecord,
 } from '@invoker/data-store';
-import type { AgentRegistry } from '@invoker/execution-engine';
+import type { AgentRegistry, HarnessSessionDriver } from '@invoker/execution-engine';
 import {
   evaluatePlanningTurn,
   hasExplicitDraftIntent as hasCoreExplicitDraftIntent,
@@ -43,8 +43,49 @@ import {
   summarizePlanText,
   type PlanningMessage,
 } from '@invoker/planning-core';
-import type { HarnessPreset, PlanConversation, PlanConversationConfig, PlanningCommandBuilder } from '@invoker/surfaces';
 import type { InvokerConfig } from './config.js';
+
+interface HarnessPreset {
+  tool: string;
+  model?: string;
+}
+
+type PlanningCommandBuilder = (opts: {
+  tool: string;
+  model?: string;
+  prompt: string;
+}) => { command: string; args: string[] };
+
+interface PlanConversationConfig {
+  cursorCommand?: string;
+  tool?: string;
+  model?: string;
+  mode?: 'agent' | 'plan';
+  planningCommandBuilder?: PlanningCommandBuilder;
+  workingDir?: string;
+  timeoutMs?: number;
+  threadTs?: string;
+  conversationRepo?: ConversationRepository;
+  defaultBranch?: string;
+  repoUrl?: string;
+  experimentalPlanner?: boolean;
+  preferStackedWorkflows?: boolean;
+  onRawPlannerOutput?: (chunk: string) => void;
+  harnessSessionDriver?: HarnessSessionDriver;
+  harnessSessionId?: string;
+  onHarnessSessionId?: (sessionId: string) => void;
+  conversationalPlanning?: boolean;
+  log?: (message: string, ...args: unknown[]) => void;
+  plannerRetryLimit?: number;
+  plannerRetryBaseDelayMs?: number;
+}
+
+interface PlanConversation {
+  readonly lastTurnReasoning: string[];
+  readonly lastTurnDraftPlanText: string | null;
+  init(): Promise<void>;
+  sendMessage(message: string): Promise<string>;
+}
 
 export interface LoadedGeneratedPlan {
   planName: string;


### PR DESCRIPTION
## Summary

Desktop startup can import `in-app-planner.ts` without resolving `@invoker/surfaces`.

The module now keeps its planner surface shapes local and resolves runtime surfaces exports through `loadPlannerSurfaces()`.

That lets startup reach the existing lazy fallback before any planning session runs.

## Review Claim

The planning module no longer resolves `@invoker/surfaces` at module load, so desktop startup can reach the lazy fallback path instead of crashing first.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Session creation, restore, submit, and tmux state behavior stay unchanged except for deferring when the surfaces package is resolved.

## Slice Rationale

One routing slice moves the runtime load boundary in `in-app-planner.ts`. The downstream proof task ran commands only and has no file changes to publish.

## Non-goals

No planning UX changes.

No new preset behavior.

No unrelated startup logging work.

No proof harness files or product-test changes.

## Architecture

### Before

```mermaid
graph TD
    A["main.ts imports in-app-planner.js"] --> B["in-app-planner resolves @invoker/surfaces at module scope"]
    B --> C["startup can fail before lazy fallback runs"]
```

### After

```mermaid
graph TD
    A["main.ts imports in-app-planner.js"] --> B["module scope uses local planner surface shapes"]
    B --> C["planning-session paths call loadPlannerSurfaces()"]
    C --> D["lazy fallback handles package dist or source resolution"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `tmpdir="$(mktemp -d)"; pnpm exec tsup packages/app/src/in-app-planner.ts --format cjs --platform node --target node20 --out-dir "$tmpdir" --external electron --external better-sqlite3 --external node-pty >/tmp/in-app-planner-tsup.log 2>&1 && ! rg 'require\("@invoker/surfaces"\)' "$tmpdir/in-app-planner.js" && node -e 'import(process.argv[1]).then(() => console.log("import ok"))' "$tmpdir/in-app-planner.js"; rc=$?; cat /tmp/in-app-planner-tsup.log; rm -rf "$tmpdir"; exit "$rc"`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts -t "restores draft-ready sessions and submits from persisted approved draft text|restores persisted tmux mode and planning-owned terminal state|clears submitted pending-response state during restore"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 360cdcccbe0b2c751320760b8818fe50a7ffa478`
- Post-revert steps: Rerun the module-load proof and focused planner restore tests if reverting during release validation.
- Data migration? No

</details>
