### PR TITLE
[Remote Sync Step 1: Sync Schema and Change Journal](1) Add data-store sync schema and journal

### DIFF
--- a/packages/data-store/src/__tests__/sync-journal.test.ts
+++ b/packages/data-store/src/__tests__/sync-journal.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createAttempt } from '@invoker/workflow-core';
+import type { TaskState } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { WorkflowSaveInput } from '../adapter.js';
+import type { SqliteExecutor } from '../sqlite-executor.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  readJournalSince,
+  setSyncCursor,
+} from '../sync-journal.js';
+
+describe('sync journal', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function executor(): SqliteExecutor {
+    return (adapter as any).executor as SqliteExecutor;
+  }
+
+  function makeWorkflow(id = 'wf-1', name = 'Workflow'): WorkflowSaveInput {
+    return {
+      id,
+      name,
+      createdAt: `2026-07-28T00:00:00.000Z`,
+      updatedAt: `2026-07-28T00:00:00.000Z`,
+    };
+  }
+
+  function makeTask(id = 'task-1', status: TaskState['status'] = 'pending'): TaskState {
+    return {
+      id,
+      description: `Task ${id}`,
+      status,
+      dependencies: [],
+      createdAt: new Date('2026-07-28T00:00:00.000Z'),
+      config: {},
+      execution: {},
+      taskStateVersion: 1,
+    };
+  }
+
+  it('rolls back a journal append with the enclosing mutation transaction', () => {
+    adapter.saveWorkflow(makeWorkflow());
+    adapter.saveTask('wf-1', makeTask());
+
+    expect(() =>
+      adapter.runInTransaction(() => {
+        adapter.updateTask('task-1', { status: 'running' });
+        throw new Error('rollback sentinel');
+      }),
+    ).toThrow(/rollback sentinel/);
+
+    expect(adapter.loadTask('task-1')?.status).toBe('pending');
+    expect(readJournalSince(executor(), 0, 10)).toEqual([]);
+  });
+
+  it('fails loudly and rolls back the mutation when the journal write fails', () => {
+    adapter.saveWorkflow(makeWorkflow());
+    adapter.saveTask('wf-1', makeTask());
+
+    const db = (adapter as any).db;
+    const originalRun = db.run.bind(db) as (sql: string, params?: unknown[]) => unknown;
+    db.run = (sql: string, params?: unknown[]) => {
+      if (sql.includes('INSERT INTO sync_journal')) {
+        throw new Error('simulated journal failure');
+      }
+      return originalRun(sql, params);
+    };
+
+    try {
+      expect(() => adapter.updateTask('task-1', { status: 'running' })).toThrow(/simulated journal failure/);
+    } finally {
+      db.run = originalRun;
+    }
+
+    expect(adapter.loadTask('task-1')?.status).toBe('pending');
+    expect(readJournalSince(executor(), 0, 10)).toEqual([]);
+  });
+
+  it('allocates strictly monotonic journal seq values', () => {
+    const first = appendJournalEntry(executor(), {
+      entityType: 'event',
+      entityId: 'event-1',
+      op: 'upsert',
+      payload: { id: 1 },
+    });
+    const second = appendJournalEntry(executor(), {
+      entityType: 'task',
+      entityId: 'task-1',
+      op: 'upsert',
+      payload: { id: 'task-1' },
+    });
+    const third = appendJournalEntry(executor(), {
+      entityType: 'attempt',
+      entityId: 'attempt-1',
+      op: 'upsert',
+      payload: { id: 'attempt-1' },
+    });
+
+    expect(second.seq).toBeGreaterThan(first.seq);
+    expect(third.seq).toBeGreaterThan(second.seq);
+    expect(readJournalSince(executor(), 0, 10).map((entry) => entry.seq)).toEqual([
+      first.seq,
+      second.seq,
+      third.seq,
+    ]);
+  });
+
+  it('reads journal rows after the cursor and stores per-peer cursor pairs', () => {
+    const first = appendJournalEntry(executor(), {
+      entityType: 'task',
+      entityId: 'task-1',
+      op: 'upsert',
+      payload: { id: 'task-1' },
+    });
+    const second = appendJournalEntry(executor(), {
+      entityType: 'task',
+      entityId: 'task-2',
+      op: 'upsert',
+      payload: { id: 'task-2' },
+    });
+    const third = appendJournalEntry(executor(), {
+      entityType: 'task',
+      entityId: 'task-3',
+      op: 'upsert',
+      payload: { id: 'task-3' },
+    });
+
+    expect(readJournalSince(executor(), first.seq, 10).map((entry) => entry.seq)).toEqual([
+      second.seq,
+      third.seq,
+    ]);
+    expect(readJournalSince(executor(), 0, 2).map((entry) => entry.seq)).toEqual([
+      first.seq,
+      second.seq,
+    ]);
+
+    const cursor = setSyncCursor(executor(), {
+      peerId: 'remote-1',
+      lastSentSeq: second.seq,
+      lastReceivedSeq: 7,
+      updatedAt: '2026-07-28T00:00:01.000Z',
+    });
+
+    expect(getSyncCursor(executor(), 'remote-1')).toEqual(cursor);
+    expect(readJournalSince(executor(), cursor.lastSentSeq, 10).map((entry) => entry.seq)).toEqual([
+      third.seq,
+    ]);
+  });
+
+  it('hides soft-deleted workflows by default and exposes them with includeDeleted', () => {
+    adapter.saveWorkflow(makeWorkflow('wf-delete', 'Deleted'));
+    adapter.saveWorkflow(makeWorkflow('wf-keep', 'Keep'));
+
+    adapter.deleteWorkflow('wf-delete');
+
+    expect(adapter.listWorkflows().map((workflow) => workflow.id)).toEqual(['wf-keep']);
+    expect(adapter.loadWorkflow('wf-delete')).toBeUndefined();
+
+    const deleted = adapter.loadWorkflow('wf-delete', { includeDeleted: true });
+    expect(deleted?.id).toBe('wf-delete');
+    expect(deleted?.deletedAt).toEqual(expect.any(Number));
+    expect(adapter.listWorkflows({ includeDeleted: true }).map((workflow) => workflow.id)).toContain('wf-delete');
+  });
+
+  it('writes a tombstone journal entry when deleting a workflow', () => {
+    adapter.saveWorkflow(makeWorkflow('wf-delete', 'Deleted'));
+
+    adapter.deleteWorkflow('wf-delete');
+
+    const entries = readJournalSince(executor(), 0, 10);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      entityType: 'workflow',
+      entityId: 'wf-delete',
+      op: 'tombstone',
+      origin: 'home',
+    });
+    expect(entries[0]?.payload).toMatchObject({
+      id: 'wf-delete',
+      deleted_at: expect.any(Number),
+    });
+  });
+
+  it('journals attempt creation and completion snapshots', () => {
+    adapter.saveWorkflow(makeWorkflow());
+    adapter.saveTask('wf-1', makeTask());
+    const attempt = createAttempt('task-1', { status: 'running' });
+
+    adapter.saveAttempt(attempt);
+    adapter.updateAttempt(attempt.id, {
+      status: 'completed',
+      completedAt: new Date('2026-07-28T00:00:02.000Z'),
+      exitCode: 0,
+    });
+
+    const entries = readJournalSince(executor(), 0, 10);
+    expect(entries.map((entry) => [entry.entityType, entry.entityId, entry.op])).toEqual([
+      ['attempt', attempt.id, 'upsert'],
+      ['attempt', attempt.id, 'upsert'],
+    ]);
+    expect(entries[1]?.payload).toMatchObject({
+      id: attempt.id,
+      status: 'completed',
+      exit_code: 0,
+    });
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -124,10 +124,14 @@ export interface Workflow {
   /** Read-only provenance for dependencies removed by `detachWorkflow`. Never re-read by scheduling. */
   detachedExternalDependencies?: DetachedExternalDependency[];
   generation?: number;
+  deletedAt?: number;
   createdAt: string;
   updatedAt: string;
 }
 export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup'>;
+export interface WorkflowReadOptions {
+  includeDeleted?: boolean;
+}
 
 /**
  * Result of resolving a published PR back to its Invoker workflow via the merge
@@ -333,8 +337,8 @@ export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
-  loadWorkflow(workflowId: string): Workflow | undefined;
-  listWorkflows(): Workflow[];
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined;
+  listWorkflows(options?: WorkflowReadOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];
   /** Resolve a GitHub PR number back to its Invoker workflow via the merge node. */
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined;
@@ -343,7 +347,7 @@ export interface PersistenceAdapter {
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
   loadTasks(workflowId: string): TaskState[];
-  loadWorkflowTaskSnapshot?(): WorkflowTaskSnapshot;
+  loadWorkflowTaskSnapshot?(options?: WorkflowReadOptions): WorkflowTaskSnapshot;
   /** Authoritative single-task read by ID, suitable for recovery workflows. */
   loadTask(taskId: string): TaskState | undefined;
   /** Delete one task and its task-owned rows. */

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -7,3 +7,4 @@ export * from './slack-session-repository.js';
 export * from './slack-plan-draft-repository.js';
 export * from './sqlite-task-repository.js';
 export * from './workflow-channel-repository.js';
+export * from './sync-journal.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -38,6 +38,7 @@ import type {
   PersistenceAdapter,
   ReviewGateLookup,
   Workflow,
+  WorkflowReadOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
   TaskEvent,
@@ -78,6 +79,7 @@ import type { SqliteExecutor } from './sqlite-executor.js';
 import * as migrations from './sqlite-migrations.js';
 import { SqliteTaskAttemptRepository } from './sqlite-task-attempt-repository.js';
 import { SqliteWorkflowRepository, type WorkflowMetadataChanges } from './sqlite-workflow-repository.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 function normalizeWorkerActionStatus(status: string): string {
   return status === 'canceled' ? 'cancelled' : status;
@@ -1054,12 +1056,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.workflowRepo.updateWorkflow(workflowId, changes);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    return this.workflowRepo.loadWorkflow(workflowId);
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined {
+    return this.workflowRepo.loadWorkflow(workflowId, options);
   }
 
-  listWorkflows(): Workflow[] {
-    return this.workflowRepo.listWorkflows();
+  listWorkflows(options?: WorkflowReadOptions): Workflow[] {
+    return this.workflowRepo.listWorkflows(options);
   }
 
   findReviewGateByPr(pr: string): ReviewGateLookup | undefined {
@@ -1070,8 +1072,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return this.workflowRepo.searchWorkflowsAndTasks(query, opts);
   }
 
-  loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
-    return this.workflowRepo.loadWorkflowTaskSnapshot();
+  loadWorkflowTaskSnapshot(options?: WorkflowReadOptions): WorkflowTaskSnapshot {
+    return this.workflowRepo.loadWorkflowTaskSnapshot(options);
   }
 
   getLastWorkflowTaskSnapshotStats(): Record<string, unknown> | null {
@@ -1550,6 +1552,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
       this.db.run('DELETE FROM terminal_sessions');
       this.db.run('DELETE FROM tasks');
       this.db.run('DELETE FROM workflows');
+      this.db.run('DELETE FROM sync_journal');
+      this.db.run('DELETE FROM sync_cursors');
     });
     this.removeOutputFiles(taskIds);
     this.outputTailCache.clear();
@@ -1557,6 +1561,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   deleteWorkflow(workflowId: string): void {
+    const existingWorkflow = this.queryOne(
+      'SELECT * FROM workflows WHERE id = ? AND deleted_at IS NULL',
+      [workflowId],
+    );
+    if (!existingWorkflow) return;
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
     this.runTransaction(() => {
       this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
@@ -1598,7 +1607,23 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
+      const deletedAt = Date.now();
+      const updatedAt = new Date(deletedAt).toISOString();
+      this.db.run('UPDATE workflows SET deleted_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL', [
+        deletedAt,
+        updatedAt,
+        workflowId,
+      ]);
+      const tombstonePayload = this.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+      if (!tombstonePayload) {
+        throw new Error(`Failed to load workflow ${workflowId} after soft delete for sync journal`);
+      }
+      appendJournalEntry(this.executor, {
+        entityType: 'workflow',
+        entityId: workflowId,
+        op: 'tombstone',
+        payload: tombstonePayload,
+      });
     });
     this.removeOutputFiles(taskIds);
   }

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -47,6 +47,7 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
     externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
     detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) as DetachedExternalDependency[] : undefined,
     generation: row.generation ?? 0,
+    deletedAt: row.deleted_at === null || row.deleted_at === undefined ? undefined : Number(row.deleted_at),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -27,6 +27,7 @@ export const SCHEMA_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       );
@@ -511,6 +512,26 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_terminal_sessions_status_updated
         ON terminal_sessions(status, updated_at);
 
+      CREATE TABLE IF NOT EXISTS sync_journal (
+        seq INTEGER PRIMARY KEY AUTOINCREMENT,
+        entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+        entity_id TEXT NOT NULL,
+        op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+        payload TEXT NOT NULL CHECK (json_valid(payload)),
+        origin TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_sync_journal_entity
+        ON sync_journal(entity_type, entity_id, seq);
+
+      CREATE TABLE IF NOT EXISTS sync_cursors (
+        peer_id TEXT PRIMARY KEY,
+        last_sent_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_sent_seq) = 'integer' AND last_sent_seq >= 0),
+        last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
     `;
 
 /** Idempotent `ALTER TABLE ... ADD COLUMN` migrations for older databases. */
@@ -597,6 +618,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
+  'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
 ];
 
 /**
@@ -628,6 +650,22 @@ export const POST_MIGRATION_STATEMENTS = [
   `UPDATE worker_actions SET status = 'cancelled' WHERE status = 'canceled'`,
   'CREATE TABLE IF NOT EXISTS task_crash_preservation (task_id TEXT PRIMARY KEY, preserved_at TEXT NOT NULL, owner_pid INTEGER, diagnostic_report_path TEXT, diagnostic_summary TEXT, FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE)',
   'CREATE INDEX IF NOT EXISTS idx_task_crash_preservation_preserved_at ON task_crash_preservation(preserved_at)',
+  `CREATE TABLE IF NOT EXISTS sync_journal (
+    seq INTEGER PRIMARY KEY AUTOINCREMENT,
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('workflow', 'task', 'attempt', 'event', 'output')),
+    entity_id TEXT NOT NULL,
+    op TEXT NOT NULL CHECK (op IN ('upsert', 'tombstone')),
+    payload TEXT NOT NULL CHECK (json_valid(payload)),
+    origin TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`,
+  'CREATE INDEX IF NOT EXISTS idx_sync_journal_entity ON sync_journal(entity_type, entity_id, seq)',
+  `CREATE TABLE IF NOT EXISTS sync_cursors (
+    peer_id TEXT PRIMARY KEY,
+    last_sent_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_sent_seq) = 'integer' AND last_sent_seq >= 0),
+    last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`,
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */
@@ -651,6 +689,7 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       )
@@ -662,12 +701,12 @@ export const WORKFLOWS_REBUILD_INSERT_DDL = `
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
         review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
-        generation, created_at, updated_at
+        generation, deleted_at, created_at, updated_at
       FROM workflows
     `;

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -8,15 +8,17 @@
  * transactions. Row mapping keeps coming from sqlite-row-mappers.ts; the
  * adapter retains one-line delegates for every method here.
  */
-import type { TaskState, TaskStateChanges, Attempt, TaskExecution } from '@invoker/workflow-core';
+import type { TaskState, TaskStateChanges, Attempt, TaskExecution, WorkflowDerivedStatus, WorkflowRollupTaskSummary } from '@invoker/workflow-core';
 import {
   assertTaskConsistent,
+  computeWorkflowRollupFromSummaries,
   isDiscardedAttempt,
   normalizeRunnerKind,
 } from '@invoker/workflow-core';
 import { mapRowToTask, mapRowToAttempt } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
+import { appendJournalEntry } from './sync-journal.js';
 
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
@@ -43,6 +45,57 @@ export class SqliteTaskAttemptRepository {
   ) {}
 
   private hasCrashPreservationTableCache: boolean | null = null;
+
+  private loadTaskJournalPayload(taskId: string): Record<string, unknown> | undefined {
+    return this.exec.queryOne('SELECT * FROM tasks WHERE id = ?', [taskId]);
+  }
+
+  private loadAttemptJournalPayload(attemptId: string): Record<string, unknown> | undefined {
+    return this.exec.queryOne('SELECT * FROM attempts WHERE id = ?', [attemptId]);
+  }
+
+  private loadWorkflowJournalPayload(workflowId: string): { payload: Record<string, unknown>; status: WorkflowDerivedStatus } | undefined {
+    const workflow = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+    if (!workflow) return undefined;
+
+    const taskRows = this.exec.queryAll(
+      `SELECT id, workflow_id, description, status, dependencies, error, protocol_error_code, protocol_error_message,
+              pending_fix_error, exit_code, completed_at, agent_session_id, agent_name,
+              review_url, input_prompt, is_fixing_with_ai
+         FROM tasks
+        WHERE workflow_id = ?
+        ORDER BY id ASC`,
+      [workflowId],
+    );
+    const summaries = taskRows.map((row) => ({
+      id: String(row.id),
+      description: String(row.description),
+      status: row.status as WorkflowRollupTaskSummary['status'],
+      dependencies: JSON.parse(String(row.dependencies || '[]')),
+      execution: {
+        error: row.error ?? undefined,
+        protocolErrorCode: row.protocol_error_code ?? undefined,
+        protocolErrorMessage: row.protocol_error_message ?? undefined,
+        pendingFixError: row.pending_fix_error ?? undefined,
+        exitCode: row.exit_code ?? undefined,
+        completedAt: row.completed_at ?? undefined,
+        agentSessionId: row.agent_session_id ?? undefined,
+        agentName: row.agent_name ?? undefined,
+        reviewUrl: row.review_url ?? undefined,
+        inputPrompt: row.input_prompt ?? undefined,
+        isFixingWithAI: row.is_fixing_with_ai === 1,
+      },
+    })) satisfies WorkflowRollupTaskSummary[];
+    const rollup = computeWorkflowRollupFromSummaries(summaries);
+    return {
+      payload: {
+        ...workflow,
+        status: rollup.status,
+        rollup,
+      },
+      status: rollup.status,
+    };
+  }
 
   private hasCrashPreservationTable(): boolean {
     if (this.hasCrashPreservationTableCache !== null) return this.hasCrashPreservationTableCache;
@@ -417,7 +470,41 @@ export class SqliteTaskAttemptRepository {
       const cols = setClauses.map((c) => c.split(/\s*=\s*/)[0]!.trim()).join(', ');
       console.log(`[persist-sql] taskId=${taskId} columns=[${cols}]`);
     }
-    this.exec.execRun(`UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    const statusChanged = changes.status !== undefined && changes.status !== beforeTask.status;
+    const workflowId = beforeTask.config.workflowId;
+    const beforeWorkflow = statusChanged && workflowId
+      ? this.loadWorkflowJournalPayload(workflowId)
+      : undefined;
+    const updateSql = `UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ?`;
+
+    if (!statusChanged) {
+      this.exec.execRun(updateSql, values);
+      return;
+    }
+
+    this.exec.runTransaction(() => {
+      this.exec.execRun(updateSql, values);
+      const taskPayload = this.loadTaskJournalPayload(taskId);
+      if (!taskPayload) {
+        throw new Error(`Failed to load task ${taskId} after status update for sync journal`);
+      }
+      appendJournalEntry(this.exec, {
+        entityType: 'task',
+        entityId: taskId,
+        op: 'upsert',
+        payload: taskPayload,
+      });
+
+      if (!workflowId) return;
+      const afterWorkflow = this.loadWorkflowJournalPayload(workflowId);
+      if (!afterWorkflow || beforeWorkflow?.status === afterWorkflow.status) return;
+      appendJournalEntry(this.exec, {
+        entityType: 'workflow',
+        entityId: workflowId,
+        op: 'upsert',
+        payload: afterWorkflow.payload,
+      });
+    });
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -594,40 +681,52 @@ export class SqliteTaskAttemptRepository {
   // ── Attempt CRUD ─────────────────────────────────────────
 
   saveAttempt(attempt: Attempt): void {
-    this.exec.execRun(`
-      INSERT OR REPLACE INTO attempts (
-        id, node_id, attempt_number, queue_priority, status,
-        snapshot_commit, base_branch, upstream_attempt_ids,
-        command_override, prompt_override,
-        claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
-        branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
-        supersedes_attempt_id, created_at, merge_conflict
-      ) VALUES (
-        ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?,
-        ?, ?,
-        ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?, ?,
-        ?, ?, ?
-      )
-    `, [
-      attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
-      attempt.snapshotCommit ?? null, attempt.baseBranch ?? null,
-      JSON.stringify(attempt.upstreamAttemptIds),
-      attempt.commandOverride ?? null, attempt.promptOverride ?? null,
-      attempt.claimedAt?.toISOString() ?? null,
-      attempt.startedAt?.toISOString() ?? null,
-      attempt.completedAt?.toISOString() ?? null,
-      attempt.exitCode ?? null, attempt.error ?? null,
-      attempt.lastHeartbeatAt?.toISOString() ?? null,
-      attempt.leaseExpiresAt?.toISOString() ?? null,
-      attempt.branch ?? null, attempt.commit ?? null, attempt.summary ?? null,
-      attempt.workspacePath ?? null, attempt.agentSessionId ?? null,
-      attempt.containerId ?? null,
-      attempt.supersedesAttemptId ?? null,
-      attempt.createdAt.toISOString(),
-      attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
-    ]);
+    this.exec.runTransaction(() => {
+      this.exec.execRun(`
+        INSERT OR REPLACE INTO attempts (
+          id, node_id, attempt_number, queue_priority, status,
+          snapshot_commit, base_branch, upstream_attempt_ids,
+          command_override, prompt_override,
+          claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
+          branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
+          supersedes_attempt_id, created_at, merge_conflict
+        ) VALUES (
+          ?, ?, ?, ?, ?, ?, ?,
+          ?, ?, ?,
+          ?, ?,
+          ?, ?, ?, ?, ?,
+          ?, ?, ?, ?, ?, ?,
+          ?, ?, ?
+        )
+      `, [
+        attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
+        attempt.snapshotCommit ?? null, attempt.baseBranch ?? null,
+        JSON.stringify(attempt.upstreamAttemptIds),
+        attempt.commandOverride ?? null, attempt.promptOverride ?? null,
+        attempt.claimedAt?.toISOString() ?? null,
+        attempt.startedAt?.toISOString() ?? null,
+        attempt.completedAt?.toISOString() ?? null,
+        attempt.exitCode ?? null, attempt.error ?? null,
+        attempt.lastHeartbeatAt?.toISOString() ?? null,
+        attempt.leaseExpiresAt?.toISOString() ?? null,
+        attempt.branch ?? null, attempt.commit ?? null, attempt.summary ?? null,
+        attempt.workspacePath ?? null, attempt.agentSessionId ?? null,
+        attempt.containerId ?? null,
+        attempt.supersedesAttemptId ?? null,
+        attempt.createdAt.toISOString(),
+        attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
+      ]);
+      const payload = this.loadAttemptJournalPayload(attempt.id);
+      if (!payload) {
+        throw new Error(`Failed to load attempt ${attempt.id} after insert for sync journal`);
+      }
+      appendJournalEntry(this.exec, {
+        entityType: 'attempt',
+        entityId: attempt.id,
+        op: 'upsert',
+        payload,
+      });
+    });
   }
 
   loadAttempts(nodeId: string): Attempt[] {
@@ -710,8 +809,30 @@ export class SqliteTaskAttemptRepository {
     if (changes.mergeConflict !== undefined) { setClauses.push('merge_conflict = ?'); values.push(changes.mergeConflict ? JSON.stringify(changes.mergeConflict) : null); }
 
     if (setClauses.length === 0) return;
+    const shouldJournalCompletion =
+      changes.status === 'completed'
+      || changes.status === 'failed'
+      || changes.completedAt !== undefined;
     values.push(attemptId);
-    this.exec.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
+    const updateSql = `UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`;
+    if (!shouldJournalCompletion) {
+      this.exec.execRun(updateSql, values);
+      return;
+    }
+
+    this.exec.runTransaction(() => {
+      this.exec.execRun(updateSql, values);
+      const payload = this.loadAttemptJournalPayload(attemptId);
+      if (!payload) {
+        throw new Error(`Failed to load attempt ${attemptId} after completion update for sync journal`);
+      }
+      appendJournalEntry(this.exec, {
+        entityType: 'attempt',
+        entityId: attemptId,
+        op: 'upsert',
+        payload,
+      });
+    });
   }
 
   claimAttemptForLaunch(

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -27,6 +27,7 @@ import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type {
   ReviewGateLookup,
   Workflow,
+  WorkflowReadOptions,
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
 } from './adapter.js';
@@ -89,8 +90,8 @@ export class SqliteWorkflowRepository {
   saveWorkflow(workflow: WorkflowSaveInput): void {
     assertWorkflowConsistent(workflow);
     this.exec.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, deleted_at, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       workflow.id, workflow.name,
       workflow.description ?? null,
@@ -103,6 +104,7 @@ export class SqliteWorkflowRepository {
       workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
       workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
       workflow.generation ?? 0,
+      workflow.deletedAt ?? null,
       workflow.createdAt, workflow.updatedAt,
     ]);
   }
@@ -174,16 +176,21 @@ export class SqliteWorkflowRepository {
     this.exec.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
   }
 
-  loadWorkflow(workflowId: string): Workflow | undefined {
-    const row = this.exec.queryOne('SELECT * FROM workflows WHERE id = ?', [workflowId]);
+  loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined {
+    const row = this.exec.queryOne(
+      `SELECT * FROM workflows WHERE id = ?${options?.includeDeleted ? '' : ' AND deleted_at IS NULL'}`,
+      [workflowId],
+    );
     if (!row) return undefined;
     const rollup = this.loadWorkflowRollups([workflowId]).get(workflowId);
     return this.rowToWorkflow(row, rollup);
   }
 
-  listWorkflows(): Workflow[] {
+  listWorkflows(options?: WorkflowReadOptions): Workflow[] {
     const rows = this.exec.queryAll(
-      'SELECT * FROM workflows ORDER BY created_at DESC',
+      `SELECT * FROM workflows
+        ${options?.includeDeleted ? '' : 'WHERE deleted_at IS NULL'}
+        ORDER BY created_at DESC`,
     );
     const workflowIds = rows.map((row) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
@@ -205,7 +212,9 @@ export class SqliteWorkflowRepository {
               w.base_branch AS baseBranch
          FROM tasks t
          JOIN workflows w ON w.id = t.workflow_id
-        WHERE t.is_merge_node = 1 AND (t.review_id = ? OR t.review_url LIKE ?)`,
+        WHERE w.deleted_at IS NULL
+          AND t.is_merge_node = 1
+          AND (t.review_id = ? OR t.review_url LIKE ?)`,
       [pr, `%/pull/${pr}`],
     );
     if (rows.length === 0) return undefined;
@@ -257,7 +266,8 @@ export class SqliteWorkflowRepository {
     if (type === 'workflows' || type === 'all') {
       const workflows = this.exec.queryAll(
         `SELECT id, name, description, plan_file, repo_url, branch, created_at FROM workflows 
-         WHERE name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ? 
+         WHERE deleted_at IS NULL
+           AND (name LIKE ? OR description LIKE ? OR plan_file LIKE ? OR repo_url LIKE ? OR branch LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{ id: string; name?: string | null; created_at: string }>;
@@ -281,8 +291,11 @@ export class SqliteWorkflowRepository {
     
     if (type === 'tasks' || type === 'all') {
       const tasks = this.exec.queryAll(
-        `SELECT id, workflow_id, description, command, prompt, summary, problem, approach, test_plan, repro_command, status, created_at FROM tasks 
-         WHERE description LIKE ? OR command LIKE ? OR prompt LIKE ? OR summary LIKE ? OR problem LIKE ? OR approach LIKE ? OR test_plan LIKE ? OR repro_command LIKE ? 
+        `SELECT t.id, t.workflow_id, t.description, t.command, t.prompt, t.summary, t.problem, t.approach, t.test_plan, t.repro_command, t.status, t.created_at
+         FROM tasks t
+         JOIN workflows w ON w.id = t.workflow_id
+         WHERE w.deleted_at IS NULL
+           AND (t.description LIKE ? OR t.command LIKE ? OR t.prompt LIKE ? OR t.summary LIKE ? OR t.problem LIKE ? OR t.approach LIKE ? OR t.test_plan LIKE ? OR t.repro_command LIKE ?)
          LIMIT ? OFFSET ?`,
         [safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, safeQuery, limit, offset]
       ) as Array<{
@@ -298,7 +311,7 @@ export class SqliteWorkflowRepository {
       if (workflowIds.length > 0) {
         const placeholders = workflowIds.map(() => '?').join(',');
         const workflowRows = this.exec.queryAll(
-          `SELECT id, name FROM workflows WHERE id IN (${placeholders})`,
+          `SELECT id, name FROM workflows WHERE deleted_at IS NULL AND id IN (${placeholders})`,
           workflowIds
         ) as Array<{ id: string; name?: string | null }>;
         for (const wf of workflowRows) {
@@ -323,16 +336,27 @@ export class SqliteWorkflowRepository {
     return results;
   }
 
-  loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
+  loadWorkflowTaskSnapshot(options?: WorkflowReadOptions): WorkflowTaskSnapshot {
     const totalStartedAt = Date.now();
     const workflowQueryStartedAt = Date.now();
-    const workflowRows = this.exec.queryAll('SELECT * FROM workflows ORDER BY created_at DESC');
+    const workflowRows = this.exec.queryAll(
+      `SELECT * FROM workflows
+        ${options?.includeDeleted ? '' : 'WHERE deleted_at IS NULL'}
+        ORDER BY created_at DESC`,
+    );
     const workflowMetadataQueryMs = Date.now() - workflowQueryStartedAt;
     const taskQueryStartedAt = Date.now();
-    const taskRows = this.exec.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC');
-    const taskQueryMs = Date.now() - taskQueryStartedAt;
     const tasksByWorkflowId = new Map<string, TaskState[]>();
     const workflowIds = workflowRows.map((row) => String(row.id));
+    const taskRows = workflowIds.length === 0
+      ? []
+      : this.exec.queryAll(
+          `SELECT * FROM tasks
+            WHERE workflow_id IN (${workflowIds.map(() => '?').join(', ')})
+            ORDER BY workflow_id ASC, id ASC`,
+          workflowIds,
+        );
+    const taskQueryMs = Date.now() - taskQueryStartedAt;
     const rollupStartedAt = Date.now();
     const rollups = this.computeWorkflowRollupsFromRows(workflowIds, taskRows);
     const rollupComputationMs = Date.now() - rollupStartedAt;

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -1,0 +1,202 @@
+import type { SqliteExecutor } from './sqlite-executor.js';
+
+export const LOCAL_SYNC_ORIGIN = 'home';
+
+export const SYNC_ENTITY_TYPES = [
+  'workflow',
+  'task',
+  'attempt',
+  'event',
+  // Reserved for future output sync. output_spool rows are intentionally not
+  // journaled yet because they are high-volume streaming data.
+  'output',
+] as const;
+
+export type SyncEntityType = typeof SYNC_ENTITY_TYPES[number];
+export type SyncJournalOp = 'upsert' | 'tombstone';
+
+export interface SyncJournalEntryInput {
+  entityType?: SyncEntityType;
+  entityId?: string;
+  entity_type?: SyncEntityType;
+  entity_id?: string;
+  op: SyncJournalOp;
+  payload: unknown;
+  origin?: string;
+  createdAt?: string;
+  created_at?: string;
+}
+
+export interface SyncJournalEntry {
+  seq: number;
+  entityType: SyncEntityType;
+  entityId: string;
+  op: SyncJournalOp;
+  payload: unknown;
+  origin: string;
+  createdAt: string;
+}
+
+export interface SyncCursor {
+  peerId: string;
+  lastSentSeq: number;
+  lastReceivedSeq: number;
+  updatedAt: string;
+}
+
+export interface SyncCursorUpdate {
+  peerId?: string;
+  lastSentSeq?: number;
+  lastReceivedSeq?: number;
+  updatedAt?: string;
+  peer_id?: string;
+  last_sent_seq?: number;
+  last_received_seq?: number;
+  updated_at?: string;
+}
+
+function asNonNegativeInteger(name: string, value: number): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function mapJournalRow(row: Record<string, unknown>): SyncJournalEntry {
+  return {
+    seq: Number(row.seq),
+    entityType: String(row.entity_type) as SyncEntityType,
+    entityId: String(row.entity_id),
+    op: String(row.op) as SyncJournalOp,
+    payload: JSON.parse(String(row.payload ?? 'null')),
+    origin: String(row.origin),
+    createdAt: String(row.created_at),
+  };
+}
+
+function mapCursorRow(row: Record<string, unknown>): SyncCursor {
+  return {
+    peerId: String(row.peer_id),
+    lastSentSeq: Number(row.last_sent_seq ?? 0),
+    lastReceivedSeq: Number(row.last_received_seq ?? 0),
+    updatedAt: String(row.updated_at),
+  };
+}
+
+export function appendJournalEntry(
+  db: SqliteExecutor,
+  entry: SyncJournalEntryInput,
+): SyncJournalEntry {
+  const entityType = entry.entityType ?? entry.entity_type;
+  const entityId = entry.entityId ?? entry.entity_id;
+  if (!entityType) throw new Error('sync journal entry requires entityType');
+  if (!entityId) throw new Error('sync journal entry requires entityId');
+  const createdAt = entry.createdAt ?? entry.created_at ?? new Date().toISOString();
+  const origin = entry.origin ?? LOCAL_SYNC_ORIGIN;
+  const payload = JSON.stringify(entry.payload ?? null);
+
+  db.execRun(
+    `INSERT INTO sync_journal (entity_type, entity_id, op, payload, origin, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [entityType, entityId, entry.op, payload, origin, createdAt],
+  );
+
+  const inserted = db.queryOne('SELECT last_insert_rowid() AS seq') as { seq?: number } | undefined;
+  const seq = Number(inserted?.seq);
+  const row = db.queryOne(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq = ?`,
+    [seq],
+  );
+  if (!row) {
+    throw new Error(`Failed to load sync journal entry ${seq} after insert`);
+  }
+  return mapJournalRow(row);
+}
+
+export function readJournalSince(
+  db: SqliteExecutor,
+  seq: number,
+  limit = 100,
+): SyncJournalEntry[] {
+  const cursor = asNonNegativeInteger('seq', Math.trunc(seq));
+  const cappedLimit = asNonNegativeInteger('limit', Math.trunc(limit));
+  if (cappedLimit === 0) return [];
+
+  const rows = db.queryAll(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq > ?
+      ORDER BY seq ASC
+      LIMIT ?`,
+    [cursor, cappedLimit],
+  );
+  return rows.map((row) => mapJournalRow(row));
+}
+
+export function getSyncCursor(db: SqliteExecutor, peerId: string): SyncCursor | undefined {
+  const row = db.queryOne(
+    `SELECT peer_id, last_sent_seq, last_received_seq, updated_at
+       FROM sync_cursors
+      WHERE peer_id = ?`,
+    [peerId],
+  );
+  return row ? mapCursorRow(row) : undefined;
+}
+
+export function setSyncCursor(db: SqliteExecutor, cursor: SyncCursorUpdate): SyncCursor;
+export function setSyncCursor(
+  db: SqliteExecutor,
+  peerId: string,
+  lastSentSeq: number,
+  lastReceivedSeq: number,
+  updatedAt?: string,
+): SyncCursor;
+export function setSyncCursor(
+  db: SqliteExecutor,
+  cursorOrPeerId: SyncCursorUpdate | string,
+  lastSentSeqArg?: number,
+  lastReceivedSeqArg?: number,
+  updatedAtArg?: string,
+): SyncCursor {
+  const cursor = typeof cursorOrPeerId === 'string'
+    ? {
+        peerId: cursorOrPeerId,
+        lastSentSeq: lastSentSeqArg,
+        lastReceivedSeq: lastReceivedSeqArg,
+        updatedAt: updatedAtArg,
+      }
+    : cursorOrPeerId;
+  const peerId = cursor.peerId ?? cursor.peer_id;
+  if (!peerId) throw new Error('sync cursor requires peerId');
+  const existing = getSyncCursor(db, peerId);
+  const lastSentSeq = asNonNegativeInteger(
+    'lastSentSeq',
+    Math.trunc(cursor.lastSentSeq ?? cursor.last_sent_seq ?? existing?.lastSentSeq ?? 0),
+  );
+  const lastReceivedSeq = asNonNegativeInteger(
+    'lastReceivedSeq',
+    Math.trunc(cursor.lastReceivedSeq ?? cursor.last_received_seq ?? existing?.lastReceivedSeq ?? 0),
+  );
+  const updatedAt = cursor.updatedAt ?? cursor.updated_at ?? new Date().toISOString();
+
+  db.execRun(
+    `INSERT INTO sync_cursors (peer_id, last_sent_seq, last_received_seq, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(peer_id) DO UPDATE SET
+       last_sent_seq = excluded.last_sent_seq,
+       last_received_seq = excluded.last_received_seq,
+       updated_at = excluded.updated_at`,
+    [peerId, lastSentSeq, lastReceivedSeq, updatedAt],
+  );
+
+  const saved = getSyncCursor(db, peerId);
+  if (!saved) {
+    throw new Error(`Failed to load sync cursor for peer ${peerId} after upsert`);
+  }
+  return saved;
+}
+
+export const getCursor = getSyncCursor;
+export const setCursor = setSyncCursor;


### PR DESCRIPTION
## Summary

Remote Sync Step 1: Sync Schema and Change Journal — 2 tasks completed, 0 failed, 0 closed, 0 skipped<!-- no task -->

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926077035-3/implement-sync-schema | Add sync journal, cursor, and tombstone schema to data-store | completed |
| wf-1784926077035-3/verify-sync-schema | Run data-store package tests covering the new schema and journal | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784926077035-3/implement-sync-schema — Add sync journal, cursor, and tombstone schema to data-store

### wf-1784926077035-3/verify-sync-schema — Run data-store package tests covering the new schema and journal

</details>

## Review Claim

Approve the data-store sync schema foundation: journal entries, peer cursors, and workflow tombstones persist through SQLite.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Existing workflow and task reads hide tombstoned workflows by default, and journal rows share the same SQLite transaction as their source mutation.

## Slice Rationale

This lands the remote sync schema foundation before any transport or peer application path consumes it.

## Non-goals

- No remote transport, peer-to-peer protocol, sync scheduler, or UI exposure.
- No output sync beyond reserving the entity type for a later slice.
- No historical row backfill beyond creating the new tables and workflow tombstone column.

## Architecture

### Before

Workflow, task, and attempt mutations only updated their primary SQLite tables. There was no durable sequence for later remote sync readers to consume.

### After

Selected mutations append `sync_journal` rows in the same transaction, peer progress persists in `sync_cursors`, and workflow tombstones remain queryable when sync readers opt in.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sync-journal.test.ts`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/remote-sync-step-1-pr-body.md --base master`
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/remote-sync-step-1-pr-body.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert c48e4e038f29bfdddd46d20ec5243f6e37daa8fa`
- Post-revert steps: Re-run the data-store sync journal test.
- Data migration? The `sync_journal`, `sync_cursors`, and `workflows.deleted_at` schema additions stay in existing SQLite files unless a follow-up migration removes them.

</details>
