### PR TITLE
[Continue babysit worker landing loop](12) Stop conflict repairs after human blocker

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -196,7 +196,9 @@ def run_cycle(args: argparse.Namespace) -> bool:
                 handle_repair_outcome(executor, ledger, logger, args.repo, pr, outcome, now)
             elif action.kind == "repair_conflict":
                 ledger.record("conflict-repair", action.pr_number, pr.head_ref_oid, action.key, now)
-                repairer.repair_conflict(pr, action.detail)
+                outcome = repairer.repair_conflict(pr, action.detail)
+                if outcome is not None:
+                    handle_repair_outcome(executor, ledger, logger, args.repo, pr, outcome, now)
             else:
                 executor.execute(action, pr, now)
                 if action.kind == "requeue":

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -39,6 +39,7 @@ QUEUE_ONLY_REQUIRED_CHECKS = frozenset({
 ACTIVE_QUEUE_STATES = frozenset({"queued", "merging"})
 
 HUMAN_BLOCKER_KINDS = frozenset({"draft", "human_review_thread", "missing_check", "closed", "human_decision"})
+TERMINAL_BLOCKER_KINDS = frozenset({"terminal"})
 REPAIR_STOP_PREFIX = "Mergify repair stopped: "
 MANUAL_SPLIT_STOP_MARKERS = (
     "human stack split required",
@@ -81,6 +82,9 @@ def is_queue_only_required_check(name: str) -> bool:
 
 def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) -> tuple[Blocker, ...]:
     blockers: list[Blocker] = []
+    if pr.state == "MERGED":
+        blockers.append(Blocker("merged", "terminal", pr.number, "state=MERGED"))
+        return tuple(blockers)
     if pr.state != "OPEN":
         blockers.append(Blocker("closed", "closed", pr.number, f"state={pr.state}"))
         return tuple(blockers)
@@ -309,7 +313,7 @@ def latest_queue_only_noop_check(stack: StackGroup, ledger: Ledger, trunk: str) 
 
 
 def latest_repair_invalid_blocker(pr: PrSnapshot, blocker: Blocker, ledger: Ledger) -> Blocker | None:
-    if blocker.kind != "failed_check":
+    if blocker.kind not in {"failed_check", "conflict", "bot_review_thread"}:
         return None
     latest = ledger.latest("repair-invalid", pr.number, pr.head_ref_oid, blocker.key)
     if latest is None:
@@ -503,21 +507,32 @@ def summarize_stack(facts: StackFacts) -> dict[str, object]:
 def wait_reason_for_facts(facts: StackFacts) -> str:
     if facts.upper_stack_needs_acceptance:
         return "upper-stack-needs-acceptance"
-    if facts.bottom and facts.bottom.latest_mergify and facts.bottom.latest_mergify.state in {"queued", "merging"}:
-        return "bottom-already-queued"
     for pr in facts.stack.prs:
         blocker_kinds = {blocker.kind for blocker in facts.blockers_by_pr[pr.number]}
         if "pending_check" in blocker_kinds:
             return "pending-check"
         if "merge_hold" in blocker_kinds and len(blocker_kinds) == 1:
             return "merge-hold-only"
+        if TERMINAL_BLOCKER_KINDS & blocker_kinds:
+            return "terminal"
         if HUMAN_BLOCKER_KINDS & blocker_kinds:
             return "blocked-needs-human"
+    if facts.bottom and facts.bottom.latest_mergify and facts.bottom.latest_mergify.state in {"queued", "merging"}:
+        return "bottom-already-queued"
     return "no-action"
 
 
 def _has_pending_or_human_blocker(facts: StackFacts) -> bool:
-    return any(blocker.kind == "pending_check" or blocker.kind in HUMAN_BLOCKER_KINDS for blocker in facts.all_blockers)
+    return any(
+        blocker.kind == "pending_check"
+        or blocker.kind in HUMAN_BLOCKER_KINDS
+        or blocker.kind in TERMINAL_BLOCKER_KINDS
+        for blocker in facts.all_blockers
+    )
+
+
+def _pr_has_human_decision(facts: StackFacts, pr_number: int) -> bool:
+    return any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr_number])
 
 
 def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
@@ -545,6 +560,8 @@ def plan_mergify_queue_repairs(facts: StackFacts, ledger: Ledger, max_repair_att
 
 def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     for pr in facts.stack.prs:
+        if _pr_has_human_decision(facts, pr.number):
+            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "conflict":
                 key = f"conflict:{pr.number}"
@@ -561,6 +578,8 @@ def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: 
 
 def plan_bot_thread_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     for pr in facts.stack.prs:
+        if _pr_has_human_decision(facts, pr.number):
+            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "outdated_bot_review_thread":
                 return Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail)

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -32,6 +32,7 @@ PROOF_TOOLING_POLICY_UNIT_ERROR = (
 )
 NON_TRUNK_PREREQ_ERROR = "automatic tooling-policy split is only supported for base master"
 NON_TRUNK_MANUAL_SPLIT_ERROR = "worker cannot auto-split this PR on a non-trunk base; human stack split required"
+HUMAN_BLOCKER_FILE = "mergify-admin-requeue-human-blocker.txt"
 
 
 def mergify_check_urls(event: MergifyQueueEvent | None, check_name: str) -> tuple[str, ...]:
@@ -547,15 +548,21 @@ class AdminBypassRepairer:
             repair_commits=repair_commits,
         )
 
-    def repair_conflict(self, pr: PrSnapshot, reason: str) -> None:
+    def repair_conflict(self, pr: PrSnapshot, reason: str) -> RepairOutcome | None:
         work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
         work_root.parent.mkdir(parents=True, exist_ok=True)
         checkout_pr_head(self.repo, pr, work_root)
+        start_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
+        human_blocker_path = work_root / ".git" / HUMAN_BLOCKER_FILE
+        human_blocker_path.unlink(missing_ok=True)
         prompt = (
             f"Resolve only the merge conflict that keeps this PR from merging. "
             f"Rebase the PR head branch onto its base branch, preserve the PR's intended changes, "
             f"run the narrow proof for the conflict resolution, then commit and push to the PR head branch. "
-            f"If the PR is already closed or merged, or the head branch no longer exists, make no commit and exit 0.\n\n"
+            f"If the PR is already closed or merged, or the head branch no longer exists, make no commit and exit 0. "
+            f"If the conflict is human-only because resolving it would require choosing between this PR's intended behavior "
+            f"and already-merged behavior, or because the PR/stack is superseded, do not push; write one exact human-only "
+            f"reason to .git/{HUMAN_BLOCKER_FILE} and exit 0.\n\n"
             f"PR: #{pr.number}\nBase branch: {pr.base_ref_name}\nHead branch: {pr.head_ref_name}\n"
             f"Head SHA: {pr.head_ref_oid}\nReason: {reason}\n"
         )
@@ -570,3 +577,24 @@ class AdminBypassRepairer:
             head_sha=pr.head_ref_oid,
         )
         self.run_claude_repair(work_root, prompt)
+        end_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
+        if human_blocker_path.exists():
+            detail = human_blocker_path.read_text(encoding="utf-8").strip()
+            human_blocker_path.unlink(missing_ok=True)
+            if detail:
+                subprocess.run(
+                    ["git", "rebase", "--abort"],
+                    cwd=str(work_root),
+                    check=False,
+                    text=True,
+                    capture_output=True,
+                )
+                self.hard_reset_work_root(work_root, start_head)
+                return self.blocked_outcome(
+                    "blocked_invalid",
+                    "conflict",
+                    start_head,
+                    end_head,
+                    errors=(detail,),
+                )
+        return None

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -341,14 +341,82 @@ Failing checks
         repairs = []
         repairer = self.repairer(FakeGh(), ledger, "Neko-Catpital-Labs/Invoker")
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch.object(repairer, "run_claude_repair", side_effect=lambda _work_root, _prompt: repairs.append(item.number)):
-                for epoch in range(3):
-                    ledger.record("conflict-repair", item.number, item.head_ref_oid, "conflict:2647", epoch)
-                    repairer.repair_conflict(item, "GitHub reports merge conflict")
+            with mock.patch.object(repairer, "git_output", return_value=HEAD):
+                with mock.patch.object(repairer, "run_claude_repair", side_effect=lambda _work_root, _prompt: repairs.append(item.number)):
+                    for epoch in range(3):
+                        ledger.record("conflict-repair", item.number, item.head_ref_oid, "conflict:2647", epoch)
+                        repairer.repair_conflict(item, "GitHub reports merge conflict")
         self.assertEqual(ledger.count("conflict-repair", 2647, HEAD, "conflict:2647"), 3)
         self.assertEqual(repairs, [2647, 2647, 2647])
         actions = plan_stack_actions(StackGroup("s", (item,)), REQUIRED, ledger, 4)
         self.assertEqual([(a.kind, a.key) for a in actions], [("comment_blocked", "capped")])
+
+    def test_conflict_repair_human_blocker_file_returns_invalid_outcome(self):
+        reason = "exact conflict reason requiring a human decision"
+        item = pr(6118, merge_state="DIRTY", mergeable="CONFLICTING", latest=mergify())
+        repairer = self.repairer(object(), self.ledger(), "Neko-Catpital-Labs/Invoker")
+        with tempfile.TemporaryDirectory() as home:
+            work_root = Path(home) / ".invoker" / "mergify-admin-requeue-work" / str(item.number)
+
+            def fake_run_claude_repair(path, prompt):
+                self.assertEqual(path, work_root)
+                self.assertIn("write one exact human-only reason", prompt)
+                blocker_dir = path / ".git"
+                blocker_dir.mkdir(parents=True, exist_ok=True)
+                (blocker_dir / "mergify-admin-requeue-human-blocker.txt").write_text(reason + "\n", encoding="utf-8")
+
+            rev_parse = iter([HEAD, HEAD])
+
+            def fake_git_output(_work_root, *args):
+                if args == ("rev-parse", "HEAD"):
+                    return next(rev_parse)
+                return ""
+
+            with mock.patch.dict(os.environ, {"HOME": home}):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
+                    with mock.patch.object(repairer, "git_output", side_effect=fake_git_output):
+                        with mock.patch.object(repairer, "run_claude_repair", side_effect=fake_run_claude_repair):
+                            result = repairer.repair_conflict(item, "GitHub reports merge conflict")
+            self.assertIsNotNone(result)
+            self.assertEqual(result.status, "blocked_invalid")
+            self.assertEqual(result.check_name, "conflict")
+            self.assertEqual(result.errors, (reason,))
+            self.assertFalse((work_root / ".git" / "mergify-admin-requeue-human-blocker.txt").exists())
+
+    def test_run_cycle_records_conflict_human_blocker(self):
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+            def issue_comments(self, repo, pr_number):
+                return [{"body": body} for _repo, _pr_number, body in self.comments]
+
+        ledger = self.ledger()
+        args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(ledger.path)])
+        item = pr(6118, merge_state="DIRTY", mergeable="CONFLICTING", latest=mergify())
+        stack = StackGroup("s", (item,))
+        outcome = exec_impl.RepairOutcome(
+            "blocked_invalid",
+            "conflict",
+            HEAD,
+            HEAD,
+            errors=("exact conflict reason",),
+        )
+        fake = FakeGh()
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=fake):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
+                    with mock.patch.object(AdminBypassRepairer, "repair_conflict", return_value=outcome):
+                        exec_impl.run_cycle(args)
+        self.assertEqual(len(fake.comments), 1)
+        self.assertIn("Mergify repair stopped: exact conflict reason", fake.comments[0][2])
+        recorded = Ledger(ledger.path)
+        self.assertEqual(recorded.count("conflict-repair", 6118, HEAD, "conflict:6118"), 1)
+        self.assertIsNotNone(recorded.latest("repair-invalid", 6118, HEAD, "conflict"))
+        self.assertEqual(recorded.count("comment-blocked", 6118, HEAD, f"repair-invalid:conflict:{HEAD}"), 1)
 
     def test_claude_repair_uses_claude_cli(self):
         repairer = self.repairer(object(), self.ledger())

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -93,6 +93,9 @@ class ClassifyPr(unittest.TestCase):
     def test_closed_short_circuits(self):
         self.assertEqual(self._kinds(pr(state="CLOSED")), {"closed"})
 
+    def test_merged_short_circuits_as_terminal(self):
+        self.assertEqual(self._kinds(pr(state="MERGED")), {"terminal"})
+
     def test_failed_required_check(self):
         self.assertEqual(self._kinds(pr(checks={"build": check("failure")})), {"failed_check"})
 
@@ -694,6 +697,74 @@ class PlanStackExecution(PlannerTestCase):
         blockers = plan.summary["prs"][0]["blockers"]
         self.assertEqual(blockers[0]["kind"], "human_decision")
         self.assertIn("outside the PR head", blockers[0]["detail"])
+
+    def test_repair_invalid_conflict_stops_retrying(self):
+        ledger = self._ledger()
+        reason = (
+            "PR #6118 is superseded by already-merged remote-aware base-ref behavior; "
+            "resolving the conflict requires a human product decision."
+        )
+        for epoch in range(3):
+            ledger.record("conflict-repair", 6118, HEAD, "conflict:6118", epoch)
+        ledger.record("repair-invalid", 6118, HEAD, "conflict", 4, meta={"errors": [reason]})
+        ledger.record("comment-blocked", 6118, HEAD, f"repair-invalid:conflict:{HEAD}", 4)
+        snapshot = pr(
+            number=6118,
+            labels=frozenset({"admin-bypass"}),
+            merge_state_status="DIRTY",
+            mergeable="CONFLICTING",
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            {"build"},
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={6118},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "blocked-needs-human")
+        blockers = plan.summary["prs"][0]["blockers"]
+        self.assertEqual(blockers[0]["kind"], "human_decision")
+        self.assertEqual(blockers[0]["detail"], reason)
+
+    def test_human_decision_suppresses_other_repairs_on_same_pr(self):
+        ledger = self._ledger()
+        reason = "human-only decision already recorded"
+        ledger.record("repair-invalid", 6163, HEAD, "UI Vitest", 1, meta={"errors": [reason]})
+        snapshot = pr(
+            number=6163,
+            labels=frozenset({"admin-bypass"}),
+            merge_state_status="UNSTABLE",
+            checks={
+                "build": check("success"),
+                "UI Vitest": check("failure", "UI Vitest"),
+                "quality / TypeScript Types": check("failure", "quality / TypeScript Types"),
+            },
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            {"build", "UI Vitest", "quality / TypeScript Types"},
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={6163},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "blocked-needs-human")
+
+    def test_merged_pr_is_terminal_noop(self):
+        snapshot = pr(number=6108, state="MERGED", merge_state_status="UNKNOWN", mergeable="UNKNOWN")
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            {"build"},
+            self._ledger(),
+            now_epoch=0,
+            open_pr_numbers=set(),
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "terminal")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The babysit worker's conflict repairer can now return a structured outcome instead of always returning None, so blocked conflicts get recorded like other repair failures.

A new terminal blocker kind marks already-merged pull requests as done, so the worker stops treating merged PRs as open work needing repair.

Invalid-repair tracking now also covers conflict and bot-thread blockers, not just failed checks, so those repeated failures get suppressed the same way.

Direct and bot-thread repairs are skipped for any PR that already has a human_decision blocker, so the worker stops retrying once a human has weighed in.

## Review Claim

The reviewer approves that the worker now records a terminal blocker for merged PRs, and that conflict and bot-thread repairs stay suppressed for any PR that already has a human_decision blocker.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only edits local worker/repro tooling in this repo; it does not manually requeue, relabel, merge, split, rebase, or force-push the real target PR branches the worker operates on.

## Slice Rationale

This is its own slice: one policy change to how the worker classifies terminal and human-only blockers and stops repair loops on them.

It is kept separate from the reproduction/proof commit that follows it, per this repo's review-compression convention of landing proof as its own slice.

## Non-goals

- No manual real-PR cleanup.
- No unrelated refactors.
- No metadata-only PR edits.
- No queue-rule changes outside what this slice's tests require.
- No changes to how queue-only or pending-check blockers are handled.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -m unittest scripts/test_mergify_admin_requeue.py`
- [ ] `python3 -m unittest scripts/test_mergify_admin_requeue_plan.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ca05ba984`
- Post-revert steps: None
- Data migration? No

</details>
