### PR TITLE
[Continue babysit worker landing loop](13) Reproduce conflict human blocker stops

### DIFF
--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -21,6 +21,7 @@ REPROS=(
   scripts/repro/repro-babysit-targeted-scan-light.sh
   scripts/repro/repro-babysit-queue-repair-invalid-stop.sh
   scripts/repro/repro-babysit-stack-human-blocker-suppresses-repairs.sh
+  scripts/repro/repro-babysit-conflict-human-blocker-stop.sh
   scripts/repro/repro-babysit-no-current-bottom-comment.sh
   scripts/repro/repro-babysit-merged-pr-terminal.sh
   scripts/repro/repro-babysit-merged-during-repair.sh

--- a/scripts/repro/repro-babysit-conflict-human-blocker-stop.sh
+++ b/scripts/repro/repro-babysit-conflict-human-blocker-stop.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-conflict-human-blocker-stop.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1"
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----"
+    echo "$2"
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+mkdir -p "$HOME" "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+HEAD="fed0e18de54f02b3ebd006a12ca3f2046dede28d"
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+EXACT_REASON="PR #6118 is a duplicate bottom PR of an already-partially-merged stack, and its pin-to-master behavior conflicts with already-merged remote-aware base-ref behavior from #6161. Resolving it requires a human to keep the pin or close this stack as superseded."
+export HEAD STATE_PATH LEDGER_PATH EXACT_REASON
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = os.environ["HEAD"]
+reason = os.environ["EXACT_REASON"]
+state = {
+    "prs": [
+        {
+            "number": 6118,
+            "title": "[Workflow Base Branch](1) Pin persisted workflow base branch to master",
+            "body": "## Summary\n\nPin persisted workflow base branch to master.\n",
+            "url": "https://github.com/fake/repo/pull/6118",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "stack/base-branch-master-docs/pin-persisted-workflow-base-branch-master",
+            "headRefOid": head,
+            "mergeStateStatus": "DIRTY",
+            "mergeable": "CONFLICTING",
+            "labels": ["admin-bypass"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS"},
+        }
+    ],
+    "issue_comments": {
+        "6118": [
+            {
+                "id": "fake-blocker",
+                "user": {"login": "EdbertChan"},
+                "updated_at": "2026-07-28T09:43:27Z",
+                "html_url": "https://github.com/fake/repo/pull/6118#issuecomment-1",
+                "body": f"Mergify repair stopped: {reason}",
+            }
+        ]
+    },
+    "job_logs": {},
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+rows = [
+    {
+        "epoch": 1785230434,
+        "headSha": head,
+        "key": "conflict:6118",
+        "kind": "conflict-repair",
+        "pr": 6118,
+    },
+    {
+        "epoch": 1785231704,
+        "headSha": head,
+        "key": "conflict:6118",
+        "kind": "conflict-repair",
+        "pr": 6118,
+    },
+    {
+        "epoch": 1785233030,
+        "headSha": head,
+        "key": "conflict:6118",
+        "kind": "conflict-repair",
+        "pr": 6118,
+    },
+    {
+        "epoch": 1785231704,
+        "headSha": head,
+        "key": "conflict",
+        "kind": "repair-evaluated",
+        "pr": 6118,
+    },
+    {
+        "epoch": 1785231704,
+        "headSha": head,
+        "key": "conflict",
+        "kind": "repair-invalid",
+        "meta": {"errors": [reason]},
+        "pr": 6118,
+    },
+    {
+        "epoch": 1785231704,
+        "headSha": head,
+        "key": f"repair-invalid:conflict:{head}",
+        "kind": "comment-blocked",
+        "pr": 6118,
+    },
+]
+Path(os.environ["LEDGER_PATH"]).write_text(
+    "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+    encoding="utf-8",
+)
+PY
+
+if ! out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6118 2>&1)"; then
+  fail 'targeted worker dry-run failed' "$out"
+fi
+
+! echo "$out" | grep -q 'repair-conflict PR #6118' || fail 'human-only conflict retried repair' "$out"
+! echo "$out" | grep -q 'retry cap was reached' || fail 'human-only conflict degraded to generic capped blocker' "$out"
+echo "$out" | grep -q 'blocked-needs-human' || fail 'human-only conflict did not become terminal wait state' "$out"
+echo "$out" | grep -q 'already-merged remote-aware base-ref behavior' || fail 'exact human-only reason was not preserved' "$out"
+
+echo '[repro] passed'


### PR DESCRIPTION
## Summary

This slice adds a deterministic repro script proving the worker stops re-attempting conflict repairs once a human blocker comment exists on a PR.

It registers the new repro in the shared repro loop, so this proof runs automatically alongside every other repro in this repo.

The repro seeds a ledger and a blocker comment, then checks the worker reports a terminal wait state instead of another repair attempt.

## Review Claim

Running this repro script produces a deterministic pass or fail result confirming the human-blocker conflict-stop behavior works as intended.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only edits local worker/repro tooling in this repo; it does not manually requeue, relabel, merge, split, rebase, or force-push the real target PR branches the worker operates on.

## Slice Rationale

Per this repo's review-compression convention, a behavior change and its proof land as separate slices so each diff carries one reviewable claim.

This repro is the proof slice for the immediately prior slice that taught the worker to stop conflict repairs after a human blocker appears. It gives reviewers a concrete, deterministic check without re-reviewing the earlier behavior change itself.

## Non-goals

- No manual real-PR cleanup.
- No unrelated refactors.
- No behavior changes to the worker itself (that landed in the prior slice).
- No metadata-only PR edits.
- No new repro scripts beyond the one added and registered here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-babysit-conflict-human-blocker-stop.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 53a0b1b9a`
- Post-revert steps: None
- Data migration? No

</details>
