### PR TITLE
[Continue babysit worker landing loop](14) Handle stale green queue failures

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -72,7 +72,7 @@ def record_repair_outcome(
             check_name=outcome.check_name,
             queue_pr_number=pr.latest_mergify.queue_pr_number if pr.latest_mergify else 0,
         )
-    if outcome.status == "noop" and outcome.check_name == "PR Body":
+    if outcome.status == "noop":
         ledger.record("repair-noop", pr.number, pr.head_ref_oid, outcome.check_name, now)
         logger.trace(
             "admin-bypass-repair-noop",

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -423,12 +423,13 @@ def build_stack_facts(
         suppressed_failed_checks_by_pr[bottom.number] = suppressed_failed_checks_by_pr.get(bottom.number, ()) + (prereq_status.check_name,)
     if queue_only_noop_check and bottom:
         suppressed_failed_checks_by_pr[bottom.number] = suppressed_failed_checks_by_pr.get(bottom.number, ()) + (queue_only_noop_check,)
-    if (
-        bottom
-        and "PR Body" in required
-        and ledger.latest("repair-noop", bottom.number, bottom.head_ref_oid, "PR Body") is not None
-    ):
-        suppressed_failed_checks_by_pr[bottom.number] = suppressed_failed_checks_by_pr.get(bottom.number, ()) + ("PR Body",)
+    if bottom:
+        for name, ctx in sorted(bottom.checks.items()):
+            if ledger.latest("repair-noop", bottom.number, bottom.head_ref_oid, name) is None:
+                continue
+            if name != "PR Body" and ctx.state != "success":
+                continue
+            suppressed_failed_checks_by_pr[bottom.number] = suppressed_failed_checks_by_pr.get(bottom.number, ()) + (name,)
 
     blockers_by_pr: dict[int, tuple[Blocker, ...]] = {}
     for pr in stack.prs:

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -420,8 +420,18 @@ class AdminBypassRepairer:
         ctx = pr.checks.get(check_name)
         latest = pr.latest_mergify
         queue_only = ctx is None and is_queue_only_required_check(check_name)
+        mergify_failure = bool(
+            latest
+            and latest.state == "dequeued"
+            and latest.head_sha == pr.head_ref_oid
+            and check_name in latest.failing_checks
+        )
         mergify_urls = mergify_check_urls(latest, check_name)
-        details_url = (ctx.details_url if ctx and ctx.details_url else "") or (mergify_urls[0] if mergify_urls else "")
+        details_url = (
+            (mergify_urls[0] if mergify_failure and mergify_urls else "")
+            or (ctx.details_url if ctx and ctx.details_url else "")
+            or (mergify_urls[0] if mergify_urls else "")
+        )
         work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
         work_root.parent.mkdir(parents=True, exist_ok=True)
         checkout_pr_head(self.repo, pr, work_root)
@@ -435,6 +445,17 @@ class AdminBypassRepairer:
                 errors=(f"queue-only check {check_name} is missing a Mergify job URL",),
             )
         log_path = self.executor.download_job_log(self.repo, details_url, pr.number, check_name) if details_url else ""
+        if mergify_failure and ctx and ctx.state == "success" and (not log_path or self.job_log_is_empty(log_path)):
+            self.logger.trace(
+                "admin-bypass-stale-queue-check-noop",
+                repo=self.repo,
+                pr_number=pr.number,
+                check_name=check_name,
+                details_url=details_url,
+                log_path=log_path,
+                head_sha=pr.head_ref_oid,
+            )
+            return self.blocked_outcome("noop", check_name, start_head, start_head)
         if check_name == "PR Body" and self.job_log_is_empty(log_path):
             terminal = self.terminal_repair_outcome(pr, check_name, start_head, start_head, work_root)
             if terminal:

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -27,7 +27,7 @@ from scripts.mergify_admin_requeue import (
     plan_stack_actions,
 )
 from scripts.mergify_admin_requeue_gh_executor import ADMIN_BYPASS_NUDGE_LEDGER_KIND, AdminBypassGhExecutor
-from scripts.mergify_admin_requeue_model import LoadedStacks
+from scripts.mergify_admin_requeue_model import LoadedStacks, RepairOutcome
 from scripts.mergify_admin_requeue_loader import AdminBypassStackLoader
 from scripts.mergify_admin_requeue_logger import AdminBypassLogger
 from scripts.mergify_admin_requeue_repairer import (
@@ -596,6 +596,48 @@ Failing checks
         download.assert_called_once()
         repair.assert_not_called()
         self.assertEqual(result.status, "noop")
+
+    def test_green_mergify_failure_empty_log_noops_without_claude(self):
+        queue_url = "https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/9/job/99"
+        latest = MergifyQueueEvent(
+            "m6163",
+            "dequeued",
+            "admin-bypass",
+            "2026-07-03T06:13:00Z",
+            HEAD,
+            (),
+            ("UI Vitest",),
+            "https://github.com/Neko-Catpital-Labs/Invoker/pull/6163#issuecomment-1",
+            6395,
+            (("UI Vitest", (queue_url,)),),
+        )
+        item = pr(6163, checks={"UI Vitest": check("UI Vitest", "success")}, latest=latest)
+        repairer = self.repairer(object(), self.ledger())
+        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
+            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/ui.log") as download:
+                with mock.patch.object(repairer, "job_log_is_empty", return_value=True):
+                    with mock.patch.object(repairer, "git_output", return_value=HEAD):
+                        with mock.patch.object(repairer, "run_claude_repair") as repair:
+                            result = repairer.repair_check(item, "UI Vitest")
+        checkout.assert_called_once()
+        download.assert_called_once()
+        self.assertEqual(download.call_args.args[1], queue_url)
+        repair.assert_not_called()
+        self.assertEqual(result.status, "noop")
+
+    def test_record_repair_outcome_records_generic_noop(self):
+        ledger = self.ledger()
+        item = pr(6163, checks={"UI Vitest": check("UI Vitest", "success")})
+        exec_impl.record_repair_outcome(
+            ledger,
+            AdminBypassLogger(),
+            "owner/repo",
+            item,
+            RepairOutcome("noop", "UI Vitest", HEAD, HEAD),
+            1,
+        )
+        self.assertIsNotNone(ledger.latest("repair-noop", 6163, HEAD, "UI Vitest"))
+
     def test_run_cycle_logs_selected_bottom_repair_context(self):
         args = requeue.parse_args(["--once", "--dry-run", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
         stack = StackGroup("s", (pr(2606, checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}, latest=mergify()),))

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -310,6 +310,30 @@ class BuildStackFacts(PlannerTestCase):
         actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
         self.assertEqual([(action.kind, action.key) for action in actions], [("restore_admin_bypass_label", QUEUE_ONLY_CHECK)])
 
+    def test_green_check_noop_suppresses_stale_mergify_failure(self):
+        ledger = self._ledger()
+        ledger.record("repair-noop", 6163, HEAD, "UI Vitest", 2)
+        snapshot = pr(
+            number=6163,
+            labels=frozenset({"admin-bypass", "dequeued"}),
+            checks={"UI Vitest": check("success", "UI Vitest")},
+            latest_mergify=event(
+                state="dequeued",
+                comment_id="cm6163",
+                failing=("UI Vitest",),
+            ),
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            {"UI Vitest"},
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={6163},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(plan.summary["prs"][0]["blockers"], [])
+        self.assertEqual([(action.kind, action.key) for action in plan.actions], [("requeue", "cm6163")])
+
     def test_detects_bottom_and_unaccepted_upper(self):
         facts, _ledger = self._facts(
             m.StackGroup(


### PR DESCRIPTION
## Summary

The worker used to only record a repair-noop ledger entry when the "PR Body" check no-opped. Now it records repair-noop for any check that no-ops.

Suppressed failed checks now cover any check the ledger shows as a recorded no-op, not just "PR Body".

The worker now also detects a stale green Mergify failure: Mergify reports a check as failing while GitHub's live state for that head is success with an empty log.

In that case the worker treats it as a noop and skips the repair agent instead of retrying pointlessly.

## Review Claim

This slice broadens repair-noop tracking and check suppression from just the "PR Body" check to any check, and adds detection for stale green Mergify failures so the worker skips repair instead of retrying pointlessly.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only edits local worker/repro tooling in this repo; it does not manually requeue, relabel, merge, split, rebase, or force-push the real target PR branches the worker operates on.

## Slice Rationale

This is kept as its own slice because it changes only the worker's repair-noop and stale-check suppression logic. The scenario that exercises the stale green queue case is kept in a separate slice that follows, per this repo's review-compression convention of separating behavior from its proof.

## Non-goals

- No manual real-PR cleanup.
- No unrelated refactors.
- No metadata-only PR edits.
- No queue-rule changes outside what this slice's tests require.
- No changes to repair behavior for checks that are genuinely still failing.
- No changes to how the worker selects which PR in a stack to repair.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -m unittest scripts/test_mergify_admin_requeue.py`
- [ ] `python3 -m unittest scripts/test_mergify_admin_requeue_plan.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5f859c615`
- Post-revert steps: None
- Data migration? No

</details>
