### PR TITLE
[Continue babysit worker landing loop](18) Require conflict repairs to push

### DIFF
--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -604,6 +604,8 @@ class AdminBypassRepairer:
             f"Resolve only the merge conflict that keeps this PR from merging. "
             f"Rebase the PR head branch onto its base branch, preserve the PR's intended changes, "
             f"run the narrow proof for the conflict resolution, then commit and push to the PR head branch. "
+            f"Do not use background tasks, scheduled wakeups, monitors, detached processes, or deferred continuation; "
+            f"run proof commands synchronously and do not exit until the proof has finished and the push has completed. "
             f"If the PR is already closed or merged, or the head branch no longer exists, make no commit and exit 0. "
             f"If the conflict is human-only because resolving it would require choosing between this PR's intended behavior "
             f"and already-merged behavior, or because the PR/stack is superseded, do not push; write one exact human-only "
@@ -623,6 +625,13 @@ class AdminBypassRepairer:
         )
         self.run_claude_repair(work_root, prompt)
         end_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
+        live_head = ""
+        live_state = pr.state
+        if hasattr(self.gh, "pr_detail"):
+            detail = self.gh.pr_detail(self.repo, pr.number)
+            if isinstance(detail, Mapping):
+                live_head = str(detail.get("headRefOid") or "")
+                live_state = str(detail.get("state") or pr.state)
         if human_blocker_path.exists():
             detail = human_blocker_path.read_text(encoding="utf-8").strip()
             human_blocker_path.unlink(missing_ok=True)
@@ -642,4 +651,21 @@ class AdminBypassRepairer:
                     end_head,
                     errors=(detail,),
                 )
+        if live_state != "OPEN":
+            self.hard_reset_work_root(work_root, start_head)
+            return self.blocked_outcome("noop", "conflict", start_head, end_head)
+        if end_head != start_head and live_head == start_head:
+            self.logger.trace(
+                "admin-bypass-repair-conflict-incomplete",
+                repo=self.repo,
+                pr_number=pr.number,
+                start_head=start_head,
+                end_head=end_head,
+                head_ref=pr.head_ref_name,
+            )
+            self.hard_reset_work_root(work_root, start_head)
+            raise RuntimeError(
+                f"conflict repair for PR #{pr.number} ended at local head {end_head} "
+                f"without pushing to {pr.head_ref_name}"
+            )
         return None

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -361,6 +361,8 @@ Failing checks
             def fake_run_claude_repair(path, prompt):
                 self.assertEqual(path, work_root)
                 self.assertIn("write one exact human-only reason", prompt)
+                self.assertIn("Do not use background tasks", prompt)
+                self.assertIn("do not exit until the proof has finished and the push has completed", prompt)
                 blocker_dir = path / ".git"
                 blocker_dir.mkdir(parents=True, exist_ok=True)
                 (blocker_dir / "mergify-admin-requeue-human-blocker.txt").write_text(reason + "\n", encoding="utf-8")
@@ -382,6 +384,36 @@ Failing checks
             self.assertEqual(result.check_name, "conflict")
             self.assertEqual(result.errors, (reason,))
             self.assertFalse((work_root / ".git" / "mergify-admin-requeue-human-blocker.txt").exists())
+
+    def test_conflict_repair_rejects_unpushed_local_head(self):
+        class FakeGh:
+            def pr_detail(self, _repo, _number):
+                return {"state": "OPEN", "headRefOid": HEAD}
+
+        new_head = "b" * 40
+        item = pr(6327, merge_state="DIRTY", mergeable="CONFLICTING", latest=mergify())
+        repairer = self.repairer(FakeGh(), self.ledger(), "Neko-Catpital-Labs/Invoker")
+        with tempfile.TemporaryDirectory() as home:
+            work_root = Path(home) / ".invoker" / "mergify-admin-requeue-work" / str(item.number)
+            rev_parse = iter([HEAD, new_head])
+            reset_calls = []
+
+            def fake_git_output(_work_root, *args):
+                if args == ("rev-parse", "HEAD"):
+                    return next(rev_parse)
+                if args in {("reset", "--hard", HEAD), ("clean", "-fd")}:
+                    reset_calls.append(args)
+                    return ""
+                return ""
+
+            with mock.patch.dict(os.environ, {"HOME": home}):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
+                    with mock.patch.object(repairer, "git_output", side_effect=fake_git_output):
+                        with mock.patch.object(repairer, "run_claude_repair"):
+                            with self.assertRaisesRegex(RuntimeError, "without pushing"):
+                                repairer.repair_conflict(item, "GitHub reports merge conflict")
+        self.assertIn(("reset", "--hard", HEAD), reset_calls)
+        self.assertIn(("clean", "-fd"), reset_calls)
 
     def test_run_cycle_records_conflict_human_blocker(self):
         class FakeGh:


### PR DESCRIPTION
## Summary

Conflict repairs no longer count as done just because the local branch moved. The repairer now checks the live PR state and head ref on GitHub after each repair attempt.

If the PR closed mid-repair, the work root is reset and the repair reports a no-op, touching nothing further.

If the local commit changed but the remote head did not, that stale local commit is discarded, and the repair fails loudly instead of leaving unpushed work behind.

The repair prompt also now says not to use background tasks, scheduled timers, monitors, or detached processes, and to keep running until the proof and push both finish.

## Review Claim

A conflict repair is only accepted once its commit has actually reached the PR head branch on GitHub; otherwise the local commit is treated as stale and discarded.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only edits local worker/repro tooling in this repo; it does not manually requeue, relabel, merge, split, rebase, or force-push the real target PR branches the worker operates on.

## Slice Rationale

This slice lands the push-required policy change (fetch live head/state, discard stale local commits, forbid background execution in the repair prompt) on its own, kept separate from the reproduction test slice that follows it, per this repo's review-compression convention.

## Non-goals

- No manual real-PR cleanup.
- No unrelated refactors.
- No metadata-only PR edits.
- No queue-rule changes outside what this slice's tests require.
- No change to how conflicts are detected or resolved, only to how a finished repair attempt is checked before being accepted.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -m unittest scripts/test_mergify_admin_requeue.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8d2962aa6`
- Post-revert steps: None
- Data migration? No

</details>
