### PR TITLE
[Continue babysit worker landing loop](20) Wait after worker queue commands

### DIFF
--- a/scripts/mergify_admin_requeue_model.py
+++ b/scripts/mergify_admin_requeue_model.py
@@ -55,6 +55,14 @@ class RepairStopComment:
 
 
 @dataclass(frozen=True)
+class QueueCommandComment:
+    comment_id: str
+    body: str
+    updated_at: str
+    author_login: str
+
+
+@dataclass(frozen=True)
 class PrSnapshot:
     number: int
     title: str
@@ -71,6 +79,7 @@ class PrSnapshot:
     checks: Mapping[str, CheckContext]
     review_threads: tuple[ReviewThread, ...]
     latest_mergify: MergifyQueueEvent | None
+    latest_queue_command: QueueCommandComment | None = None
     repair_stop_comments: tuple[RepairStopComment, ...] = ()
 
 @dataclass(frozen=True)

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -69,6 +69,7 @@ class StackFacts:
     upper_stack_needs_acceptance: bool
     prereq_status: RepairPrereqStatus | None
     queue_only_noop_check: str | None
+    queue_command_inflight: bool
     suppressed_failed_checks_by_pr: Mapping[int, tuple[str, ...]]
     blockers_by_pr: Mapping[int, tuple[Blocker, ...]]
     all_blockers: tuple[Blocker, ...]
@@ -312,6 +313,30 @@ def latest_queue_only_noop_check(stack: StackGroup, ledger: Ledger, trunk: str) 
     return check_name
 
 
+def queue_command_is_after_latest_mergify(pr: PrSnapshot) -> bool:
+    command = pr.latest_queue_command
+    if command is None or not command.updated_at:
+        return False
+    latest = pr.latest_mergify
+    return latest is None or not latest.queued_at or command.updated_at > latest.queued_at
+
+
+def requeue_key_for_bottom(bottom: PrSnapshot) -> str:
+    latest = bottom.latest_mergify
+    if latest and latest.state == "dequeued":
+        return latest.comment_id or "manual"
+    if "dequeued" in bottom.labels:
+        return "ready"
+    return "ready"
+
+
+def has_recorded_queue_command_inflight(bottom: PrSnapshot, ledger: Ledger) -> bool:
+    if not queue_command_is_after_latest_mergify(bottom):
+        return False
+    key = requeue_key_for_bottom(bottom)
+    return ledger.latest("requeue", bottom.number, bottom.head_ref_oid, key) is not None
+
+
 def latest_repair_invalid_blocker(pr: PrSnapshot, blocker: Blocker, ledger: Ledger) -> Blocker | None:
     if blocker.kind not in {"failed_check", "conflict", "bot_review_thread"}:
         return None
@@ -401,6 +426,8 @@ def _assert_stack_facts_invariants(facts: StackFacts) -> None:
         assert latest.queue_rule_name == "admin-bypass", "queue-only noop requires the admin-bypass queue"
         assert latest.head_sha == facts.bottom.head_ref_oid, "queue-only noop requires a same-head Mergify event"
         assert facts.queue_only_noop_check in latest.failing_checks, "queue-only noop check must still be failing in Mergify"
+    if facts.queue_command_inflight:
+        assert facts.bottom is not None, "queue command in flight requires a current bottom PR"
 
 
 def build_stack_facts(
@@ -417,6 +444,7 @@ def build_stack_facts(
     upper_stack_needs_acceptance = stack_has_unaccepted_upper_pr(stack, bottom)
     prereq_status = latest_repair_prereq_status(stack, ledger, open_pr_numbers, trunk)
     queue_only_noop_check = latest_queue_only_noop_check(stack, ledger, trunk)
+    queue_command_inflight = bool(bottom and has_recorded_queue_command_inflight(bottom, ledger))
 
     suppressed_failed_checks_by_pr: dict[int, tuple[str, ...]] = {}
     if prereq_status and prereq_status.needs_followup_requeue and bottom:
@@ -457,6 +485,7 @@ def build_stack_facts(
         upper_stack_needs_acceptance=upper_stack_needs_acceptance,
         prereq_status=prereq_status,
         queue_only_noop_check=queue_only_noop_check,
+        queue_command_inflight=queue_command_inflight,
         suppressed_failed_checks_by_pr=suppressed_failed_checks_by_pr,
         blockers_by_pr=blockers_by_pr,
         all_blockers=tuple(
@@ -495,6 +524,11 @@ def summarize_stack(facts: StackFacts) -> dict[str, object]:
                     "failing_checks": list(pr.latest_mergify.failing_checks),
                     "waiting_for": list(pr.latest_mergify.waiting_for),
                 },
+                "latest_queue_command": None if not pr.latest_queue_command else {
+                    "comment_id": pr.latest_queue_command.comment_id,
+                    "updated_at": pr.latest_queue_command.updated_at,
+                    "author": pr.latest_queue_command.author_login,
+                },
                 "blockers": [
                     {"kind": blocker.kind, "key": blocker.key, "detail": blocker.detail}
                     for blocker in facts.blockers_by_pr[pr.number]
@@ -519,6 +553,8 @@ def wait_reason_for_facts(facts: StackFacts) -> str:
         if HUMAN_BLOCKER_KINDS & blocker_kinds:
             return "blocked-needs-human"
     if facts.bottom and facts.bottom.latest_mergify and facts.bottom.latest_mergify.state in {"queued", "merging"}:
+        return "bottom-already-queued"
+    if facts.queue_command_inflight:
         return "bottom-already-queued"
     return "no-action"
 
@@ -665,6 +701,8 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
     if facts.upper_stack_needs_acceptance:
         return None
     if latest and latest.state in ACTIVE_QUEUE_STATES and (latest.head_sha == bottom.head_ref_oid or "queued" in bottom.labels):
+        return None
+    if facts.queue_command_inflight:
         return None
     requeue_reason = "eligible-when-ready"
     requeue_key = "ready"

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -18,6 +18,7 @@ try:
     from .mergify_admin_requeue_model import (
         MergifyQueueEvent,
         PrSnapshot,
+        QueueCommandComment,
         RepairStopComment,
         ReviewThread,
         STACK_MARKER_RE,
@@ -35,6 +36,7 @@ except ImportError:
     from mergify_admin_requeue_model import (
         MergifyQueueEvent,
         PrSnapshot,
+        QueueCommandComment,
         RepairStopComment,
         ReviewThread,
         STACK_MARKER_RE,
@@ -266,6 +268,24 @@ def parse_repair_stop_comment(comment: Mapping[str, object]) -> RepairStopCommen
     )
 
 
+def parse_queue_command_comment(comment: Mapping[str, object]) -> QueueCommandComment | None:
+    body = str(comment.get("body") or "").strip()
+    if not any(line.strip().lower() == "@mergifyio queue" for line in body.splitlines()):
+        return None
+    author = comment.get("user") if isinstance(comment.get("user"), Mapping) else comment.get("author")
+    login = ""
+    if isinstance(author, Mapping):
+        login = str(author.get("login") or "")
+    elif isinstance(author, str):
+        login = author
+    return QueueCommandComment(
+        comment_id=str(comment.get("id") or comment.get("databaseId") or ""),
+        body=body,
+        updated_at=str(comment.get("updated_at") or comment.get("created_at") or comment.get("createdAt") or ""),
+        author_login=login,
+    )
+
+
 def parse_stack_metadata(comments: Sequence[Mapping[str, object]]) -> tuple[str, tuple[int, ...]] | None:
     ordered = sorted(comments, key=lambda c: str(c.get("updated_at") or c.get("created_at") or ""), reverse=True)
     for comment in ordered:
@@ -391,6 +411,8 @@ def snapshot_from_detail(detail: Mapping[str, object], comments: Sequence[Mappin
     head = str(detail.get("headRefOid") or detail.get("head_ref_oid") or "")
     events = [event for comment in comments for event in [parse_mergify_queue_event(comment)] if event]
     events.sort(key=lambda event: event.queued_at, reverse=True)
+    queue_commands = [command for comment in comments for command in [parse_queue_command_comment(comment)] if command]
+    queue_commands.sort(key=lambda command: command.updated_at, reverse=True)
     stop_comments = [stop for comment in comments for stop in [parse_repair_stop_comment(comment)] if stop]
     stop_comments.sort(key=lambda comment: comment.updated_at, reverse=True)
     return PrSnapshot(
@@ -409,5 +431,6 @@ def snapshot_from_detail(detail: Mapping[str, object], comments: Sequence[Mappin
         checks=latest_contexts_by_required_check(raw_contexts(detail), head, required_checks),
         review_threads=review_threads(detail.get("reviewThreads")),
         latest_mergify=events[0] if events else None,
+        latest_queue_command=queue_commands[0] if queue_commands else None,
         repair_stop_comments=tuple(stop_comments),
     )

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -45,6 +45,15 @@ def event(state="dequeued", head=HEAD, comment_id="cm1", failing=(), conditions=
     )
 
 
+def queue_command(updated_at="2026-07-07T05:01:00Z"):
+    return m.QueueCommandComment(
+        comment_id="q1",
+        body="@mergifyio queue",
+        updated_at=updated_at,
+        author_login="EdbertChan",
+    )
+
+
 def pr(**kw):
     base = dict(
         number=1,
@@ -76,6 +85,47 @@ class PlannerTestCase(unittest.TestCase):
     def _facts(self, stack, required_checks=REQUIRED, ledger=None, open_pr_numbers=(), open_pr_numbers_by_head=None, trunk="master"):
         ledger = ledger or self._ledger()
         return p.build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head or {}, trunk), ledger
+
+
+class QueueCommandInFlight(PlannerTestCase):
+    def test_recorded_queue_command_after_dequeue_waits(self):
+        ledger = self._ledger()
+        snapshot = pr(
+            labels=frozenset({"admin-bypass"}),
+            latest_mergify=event(comment_id="cm1"),
+            latest_queue_command=queue_command(),
+        )
+        ledger.record("requeue", snapshot.number, snapshot.head_ref_oid, "cm1", epoch=1)
+
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            REQUIRED,
+            ledger,
+            now_epoch=2,
+            open_pr_numbers=(snapshot.number,),
+            open_pr_numbers_by_head={},
+        )
+
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "bottom-already-queued")
+
+    def test_newer_dequeue_event_after_queue_command_can_requeue(self):
+        ledger = self._ledger()
+        snapshot = pr(
+            labels=frozenset({"admin-bypass"}),
+            latest_mergify=event(comment_id="cm2"),
+            latest_queue_command=queue_command(updated_at="2026-07-07T04:59:00Z"),
+        )
+        ledger.record("requeue", snapshot.number, snapshot.head_ref_oid, "cm1", epoch=1)
+
+        action = p.plan_bottom_progress(
+            self._facts(m.StackGroup("s", (snapshot,)), ledger=ledger)[0],
+            ledger,
+            max_requeue_attempts=2,
+        )
+
+        assert action is not None
+        self.assertEqual((action.kind, action.key), ("requeue", "cm2"))
 
 
 class ClassifyPr(unittest.TestCase):

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -82,6 +82,24 @@ class ParseMergifyQueueEvent(unittest.TestCase):
         self.assertEqual(event.queued_at, "2026-07-07T05:00:00Z")
 
 
+class ParseQueueCommandComment(unittest.TestCase):
+    def test_parses_exact_queue_command(self):
+        command = s.parse_queue_command_comment({
+            "user": {"login": "EdbertChan"},
+            "id": "q1",
+            "updated_at": "2026-07-07T05:01:00Z",
+            "body": "@mergifyio queue",
+        })
+
+        assert command is not None
+        self.assertEqual(command.comment_id, "q1")
+        self.assertEqual(command.updated_at, "2026-07-07T05:01:00Z")
+        self.assertEqual(command.author_login, "EdbertChan")
+
+    def test_ignores_non_queue_chatter(self):
+        self.assertIsNone(s.parse_queue_command_comment({"body": "@mergifyio status"}))
+
+
 class GhCommandFailures(unittest.TestCase):
     def test_graphql_rate_limit_becomes_controlled_runtime_error(self):
         error = subprocess.CalledProcessError(
@@ -214,6 +232,33 @@ class SnapshotFromDetail(unittest.TestCase):
         assert snap.latest_mergify is not None
         self.assertEqual(snap.latest_mergify.state, "dequeued")
         self.assertEqual(snap.latest_mergify.head_sha, HEAD)
+        self.assertIsNone(snap.latest_queue_command)
+
+    def test_attaches_latest_queue_command(self):
+        detail = {
+            "number": 3221, "title": "Add model", "body": "", "url": "https://x/3221",
+            "state": "OPEN", "isDraft": False,
+            "baseRefName": "master", "headRefName": "stack/x", "headRefOid": HEAD,
+            "mergeStateStatus": "BLOCKED", "mergeable": "MERGEABLE",
+            "labels": {"nodes": [{"name": "admin-bypass"}]},
+            "statusCheckRollup": {"contexts": {"nodes": []}},
+            "reviewThreads": {"pageInfo": {"hasNextPage": False}, "nodes": []},
+        }
+        comments = [
+            {**MERGIFY_DEQUEUE_COMMENT},
+            {
+                "user": {"login": "EdbertChan"},
+                "id": "q1",
+                "updated_at": "2026-07-07T05:01:00Z",
+                "body": "@mergifyio queue",
+            },
+        ]
+
+        snap = s.snapshot_from_detail(detail, comments, required_checks=[])
+
+        assert snap.latest_queue_command is not None
+        self.assertEqual(snap.latest_queue_command.comment_id, "q1")
+        self.assertEqual(snap.latest_queue_command.updated_at, "2026-07-07T05:01:00Z")
 
 
 class GhClientCandidateDiscovery(unittest.TestCase):


### PR DESCRIPTION
## Summary

The worker now remembers the last "@mergifyio queue" command comment on a PR and when it was posted.

When that comment is newer than Mergify's own last update, the planner treats the bottom PR as covered and waits for Mergify to respond before posting another queue comment.

This closes a window where the worker could post a second queue comment while Mergify was still processing the first one.

## Review Claim

The planner waits when a queue command comment for the bottom PR is newer than Mergify's last event, instead of posting another one.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only edits local worker/repro tooling in this repo; it does not manually requeue, relabel, merge, split, rebase, or force-push the real target PR branches the worker operates on.

## Slice Rationale

This slice adds the queue command comment tracking and wait behavior together with focused unit coverage for the new parsing and planning logic; the end-to-end reproduction script that exercises the real worker CLI lands in the next slice, per this repo's review-compression convention.

## Non-goals

- No manual real-PR cleanup.
- No unrelated refactors.
- No metadata-only PR edits.
- No queue-rule changes outside what this slice's tests require.
- No changes to the end-to-end reproduction script, which ships separately.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -m unittest scripts/test_mergify_admin_requeue_plan.py`
- [ ] `python3 -m unittest scripts/test_mergify_admin_requeue_snapshot.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert aa1c56332`
- Post-revert steps: None
- Data migration? No

</details>
