### PR TITLE
[Continue babysit worker landing loop](22) Restack stale PR Body branches

### DIFF
--- a/scripts/mergify_admin_requeue_model.py
+++ b/scripts/mergify_admin_requeue_model.py
@@ -13,6 +13,7 @@ BOT_OR_SELF_AUTHORS = {"coderabbitai", "coderabbitai[bot]", "EdbertChan"}
 STACK_MARKER_RE = re.compile(r"<!--\s*mergify-stack-data:\s*(\{.*?\})\s*-->", re.DOTALL)
 SHA_RE = re.compile(r"`([0-9a-fA-F]{40})`")
 GH_ACTIONS_JOB_RE = re.compile(r"/actions/runs/\d+/job/(\d+)")
+STALE_STACK_RESTACK_UNAVAILABLE_ERROR = "worker could not mechanically restack this trunk PR Body failure; human stack split required"
 
 
 @dataclass(frozen=True)

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -12,6 +12,7 @@ try:
         MergifyQueueEvent,
         PrSnapshot,
         RepairPrereqStatus,
+        STALE_STACK_RESTACK_UNAVAILABLE_ERROR,
         StackExecutionPlan,
         StackGroup,
     )
@@ -24,6 +25,7 @@ except ImportError:
         MergifyQueueEvent,
         PrSnapshot,
         RepairPrereqStatus,
+        STALE_STACK_RESTACK_UNAVAILABLE_ERROR,
         StackExecutionPlan,
         StackGroup,
     )
@@ -337,6 +339,18 @@ def has_recorded_queue_command_inflight(bottom: PrSnapshot, ledger: Ledger) -> b
     return ledger.latest("requeue", bottom.number, bottom.head_ref_oid, key) is not None
 
 
+def stale_trunk_pr_body_restack_candidate(pr: PrSnapshot, blocker: Blocker, detail: str = "") -> bool:
+    if blocker.kind != "failed_check" or blocker.key != "PR Body":
+        return False
+    if pr.base_ref_name != TRUNK or pr.mergeable != "MERGEABLE" or pr.merge_state_status != "BLOCKED":
+        return False
+    if not pr.head_ref_name.startswith("stack/"):
+        return False
+    if STALE_STACK_RESTACK_UNAVAILABLE_ERROR in detail or "human stack split required" in detail:
+        return False
+    return "Split this into one Review Unit per PR." in detail
+
+
 def latest_repair_invalid_blocker(pr: PrSnapshot, blocker: Blocker, ledger: Ledger) -> Blocker | None:
     if blocker.kind not in {"failed_check", "conflict", "bot_review_thread"}:
         return None
@@ -348,6 +362,8 @@ def latest_repair_invalid_blocker(pr: PrSnapshot, blocker: Blocker, ledger: Ledg
     if isinstance(errors, list):
         detail = "\n".join(str(error) for error in errors if str(error))
         if detail:
+            if stale_trunk_pr_body_restack_candidate(pr, blocker, detail):
+                return None
             return Blocker(blocker.key, "human_decision", pr.number, detail)
     return Blocker(blocker.key, "human_decision", pr.number, blocker.detail)
 
@@ -365,6 +381,8 @@ def existing_split_stop_blocker(pr: PrSnapshot, blocker: Blocker) -> Blocker | N
         if not detail or not any(marker in detail for marker in MANUAL_SPLIT_STOP_MARKERS):
             continue
         if completed_at and comment.updated_at and comment.updated_at < completed_at:
+            continue
+        if stale_trunk_pr_body_restack_candidate(pr, blocker, detail):
             continue
         return Blocker(blocker.key, "human_decision", pr.number, detail)
     return None

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -11,12 +11,14 @@ try:
     from .mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
+    from .mergify_admin_requeue_model import STALE_STACK_RESTACK_UNAVAILABLE_ERROR
     from .mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
     from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head, run_logged
 except ImportError:
     from mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
+    from mergify_admin_requeue_model import STALE_STACK_RESTACK_UNAVAILABLE_ERROR
     from mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
     from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head, run_logged
 
@@ -80,6 +82,18 @@ class AdminBypassRepairer:
             capture_output=True,
         )
         return completed.returncode == 0
+
+    def has_merge_base(self, work_root: Path, left: str, right: str) -> bool:
+        if not work_root.exists():
+            return False
+        completed = subprocess.run(
+            ["git", "merge-base", left, right],
+            cwd=str(work_root),
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        return completed.returncode == 0 and bool(completed.stdout.strip())
 
     def normalize_repair_commit(self, work_root: Path, start_head: str, end_head: str, check_name: str) -> str:
         if self.is_ancestor(work_root, start_head, end_head):
@@ -318,6 +332,15 @@ class AdminBypassRepairer:
     def push_branch(self, work_root: Path, branch_name: str) -> None:
         self.git_output(work_root, "push", "origin", f"HEAD:{branch_name}")
 
+    def push_branch_force_with_lease(self, work_root: Path, branch_name: str, expected_head: str) -> None:
+        self.git_output(
+            work_root,
+            "push",
+            f"--force-with-lease=refs/heads/{branch_name}:{expected_head}",
+            "origin",
+            f"HEAD:refs/heads/{branch_name}",
+        )
+
     def terminal_repair_outcome(
         self,
         pr: PrSnapshot,
@@ -403,6 +426,139 @@ class AdminBypassRepairer:
         detail = self.gh.pr_detail(self.repo, pr.number)
         body = detail.get("body") if isinstance(detail, Mapping) else None
         return str(body) if body is not None else pr.body
+
+    def pr_body_stale_stack_restack_candidate(self, pr: PrSnapshot, value: Mapping[str, object]) -> bool:
+        return (
+            pr.base_ref_name == TRUNK
+            and pr.mergeable == "MERGEABLE"
+            and pr.merge_state_status == "BLOCKED"
+            and pr.head_ref_name.startswith("stack/")
+            and self.is_manual_split_validation(value)
+        )
+
+    def stale_stack_restack_unavailable_outcome(
+        self,
+        pr: PrSnapshot,
+        check_name: str,
+        start_head: str,
+        end_head: str,
+        value: Mapping[str, object],
+        reason: str,
+    ) -> RepairOutcome:
+        errors = self.invalid_repair_errors(value, pr)
+        detail = f"{STALE_STACK_RESTACK_UNAVAILABLE_ERROR}: {reason}"
+        if detail not in errors:
+            errors = [*errors, detail]
+        return self.blocked_outcome(
+            "blocked_invalid",
+            check_name,
+            start_head,
+            end_head,
+            errors=errors,
+        )
+
+    def try_restack_stale_pr_body(
+        self,
+        pr: PrSnapshot,
+        check_name: str,
+        work_root: Path,
+        start_head: str,
+        body: str,
+        validation: Mapping[str, object],
+    ) -> RepairOutcome | None:
+        if check_name != "PR Body" or not self.pr_body_stale_stack_restack_candidate(pr, validation):
+            return None
+        base_ref = f"origin/{pr.base_ref_name}"
+        self.git_output(work_root, "fetch", "origin", f"+refs/heads/{pr.base_ref_name}:refs/remotes/origin/{pr.base_ref_name}")
+        if self.is_ancestor(work_root, base_ref, "HEAD"):
+            return self.stale_stack_restack_unavailable_outcome(
+                pr,
+                check_name,
+                start_head,
+                start_head,
+                validation,
+                f"{pr.base_ref_name} is already an ancestor of the PR head",
+            )
+        parents = self.git_output(work_root, "rev-list", "--parents", "-n", "1", start_head).split()
+        if len(parents) != 2:
+            return self.stale_stack_restack_unavailable_outcome(
+                pr,
+                check_name,
+                start_head,
+                start_head,
+                validation,
+                "the PR head is not a single-parent commit",
+            )
+        status_lines = self.git_lines(work_root, "status", "--porcelain")
+        if status_lines:
+            return self.blocked_outcome(
+                "blocked_dirty",
+                check_name,
+                start_head,
+                start_head,
+                status_lines=status_lines,
+            )
+        self.logger.trace(
+            "admin-bypass-pr-body-stale-stack-restack-start",
+            repo=self.repo,
+            pr_number=pr.number,
+            check_name=check_name,
+            base_ref=pr.base_ref_name,
+            head_ref=pr.head_ref_name,
+            head_sha=start_head,
+        )
+        try:
+            self.git_output(work_root, "checkout", "-B", pr.head_ref_name, base_ref)
+            self.git_output(work_root, "cherry-pick", start_head)
+        except subprocess.CalledProcessError:
+            subprocess.run(
+                ["git", "cherry-pick", "--abort"],
+                cwd=str(work_root),
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+            self.git_output(work_root, "checkout", "-B", pr.head_ref_name, start_head)
+            self.hard_reset_work_root(work_root, start_head)
+            return self.stale_stack_restack_unavailable_outcome(
+                pr,
+                check_name,
+                start_head,
+                start_head,
+                validation,
+                f"the top commit could not be cherry-picked onto {pr.base_ref_name}",
+            )
+        end_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
+        restacked_validation = self.validate_current_pr_body(work_root, body, pr.base_ref_name)
+        if not restacked_validation.get("valid"):
+            self.git_output(work_root, "checkout", "-B", pr.head_ref_name, start_head)
+            self.hard_reset_work_root(work_root, start_head)
+            return self.stale_stack_restack_unavailable_outcome(
+                pr,
+                check_name,
+                start_head,
+                end_head,
+                restacked_validation,
+                "the restacked top commit still fails PR Body validation",
+            )
+        self.push_branch_force_with_lease(work_root, pr.head_ref_name, start_head)
+        self.logger.trace(
+            "admin-bypass-pr-body-stale-stack-restack-pushed",
+            repo=self.repo,
+            pr_number=pr.number,
+            check_name=check_name,
+            base_ref=pr.base_ref_name,
+            head_ref=pr.head_ref_name,
+            start_head=start_head,
+            end_head=end_head,
+        )
+        return self.blocked_outcome(
+            "pushed",
+            check_name,
+            start_head,
+            end_head,
+            repair_commits=(end_head,),
+        )
 
     def job_log_has_evidence(self, log_path: str) -> bool:
         if not log_path:
@@ -495,6 +651,40 @@ class AdminBypassRepairer:
                 start_head,
                 start_head,
             )
+        if check_name == "PR Body" and not queue_only:
+            base_ref = f"origin/{pr.base_ref_name}"
+            try:
+                self.git_output(work_root, "fetch", "origin", f"+refs/heads/{pr.base_ref_name}:refs/remotes/origin/{pr.base_ref_name}")
+                if not self.has_merge_base(work_root, base_ref, "HEAD"):
+                    self.logger.trace(
+                        "admin-bypass-pr-body-preflight-validation-skipped",
+                        repo=self.repo,
+                        pr_number=pr.number,
+                        check_name=check_name,
+                        head_sha=pr.head_ref_oid,
+                        reason=f"preflight skipped because {base_ref} and HEAD do not share an ancestor",
+                    )
+                else:
+                    validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
+                    stale_stack_restack = self.try_restack_stale_pr_body(
+                        pr,
+                        check_name,
+                        work_root,
+                        start_head,
+                        pr.body,
+                        validation,
+                    )
+                    if stale_stack_restack is not None:
+                        return stale_stack_restack
+            except (RuntimeError, subprocess.CalledProcessError) as exc:
+                self.logger.trace(
+                    "admin-bypass-pr-body-preflight-validation-skipped",
+                    repo=self.repo,
+                    pr_number=pr.number,
+                    check_name=check_name,
+                    head_sha=pr.head_ref_oid,
+                    reason=str(exc),
+                )
         queue_pr_number = latest.queue_pr_number if latest else 0
         prompt = (
             f"Fix only the failing check. Add or update a repro if the failure is reproducible. "
@@ -541,6 +731,16 @@ class AdminBypassRepairer:
             if not queue_only:
                 validation = self.validate_current_pr_body(work_root, body_after_repair, pr.base_ref_name)
                 if not validation.get("valid"):
+                    stale_stack_restack = self.try_restack_stale_pr_body(
+                        pr,
+                        check_name,
+                        work_root,
+                        start_head,
+                        body_after_repair,
+                        validation,
+                    )
+                    if stale_stack_restack is not None:
+                        return stale_stack_restack
                     return self.invalid_repair_outcome(pr, check_name, start_head, end_head, validation)
             return self.blocked_outcome(
                 "queue_only_noop" if queue_only else "noop",

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -1,5 +1,6 @@
 import io
 import os
+import subprocess
 import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
@@ -28,6 +29,7 @@ from scripts.mergify_admin_requeue import (
 )
 from scripts.mergify_admin_requeue_gh_executor import ADMIN_BYPASS_NUDGE_LEDGER_KIND, AdminBypassGhExecutor
 from scripts.mergify_admin_requeue_model import LoadedStacks, RepairOutcome
+from scripts.mergify_admin_requeue_model import STALE_STACK_RESTACK_UNAVAILABLE_ERROR
 from scripts.mergify_admin_requeue_loader import AdminBypassStackLoader
 from scripts.mergify_admin_requeue_logger import AdminBypassLogger
 from scripts.mergify_admin_requeue_repairer import (
@@ -605,10 +607,11 @@ This keeps the runtime routing change in its own review slice.
                     with mock.patch.object(repairer, "git_lines", return_value=()):
                         with mock.patch.object(repairer, "run_claude_repair", side_effect=update_body) as repair:
                             with mock.patch.object(repairer, "validate_current_pr_body", side_effect=validate_body):
-                                result = repairer.repair_check(item, "PR Body")
+                                with mock.patch.object(repairer, "has_merge_base", return_value=True):
+                                    result = repairer.repair_check(item, "PR Body")
 
         self.assertEqual(result.status, "noop")
-        self.assertEqual(validated_bodies, [fixed_body])
+        self.assertEqual(validated_bodies, [old_body, fixed_body])
         self.assertIn("update the pull request body on GitHub", repair.call_args.args[1])
         self.assertIn("--base master --json", repair.call_args.args[1])
 
@@ -643,6 +646,152 @@ This keeps the runtime routing change in its own review slice.
                                 result = repairer.repair_check(item, "PR Body")
         self.assertEqual(result.status, "blocked_invalid")
         self.assertIn(NON_TRUNK_MANUAL_SPLIT_ERROR, result.errors)
+
+    def test_repair_check_restacks_stale_trunk_pr_body_and_pushes(self):
+        validation_error = 'PR body Review Unit "contract" cannot ship with routing, activation-surface files in the same PR. Split this into one Review Unit per PR.'
+        body = "## Summary\n\nFailure classifier.\n"
+
+        def git(cwd: Path, *args: str) -> str:
+            completed = subprocess.run(
+                ["git", *args],
+                cwd=str(cwd),
+                check=True,
+                text=True,
+                capture_output=True,
+            )
+            return completed.stdout.strip()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            seed = root / "seed"
+            remote = root / "origin.git"
+            home = root / "home"
+            work_root = home / ".invoker" / "mergify-admin-requeue-work" / "6325"
+            log_path = root / "pr-body.log"
+            log_path.write_text("PR Body failed\n", encoding="utf-8")
+
+            seed.mkdir()
+            git(seed, "init")
+            git(seed, "config", "user.email", "repro@example.test")
+            git(seed, "config", "user.name", "Repro Bot")
+            git(seed, "checkout", "-B", "master")
+            (seed / "README.md").write_text("root\n", encoding="utf-8")
+            git(seed, "add", "README.md")
+            git(seed, "commit", "-m", "root")
+            git(seed, "init", "--bare", str(remote))
+            git(seed, "remote", "add", "publish", str(remote))
+            git(seed, "push", "publish", "master")
+            git(seed, "switch", "-c", "old-lower", "master")
+            lower = seed / "packages" / "app" / "src" / "headless.ts"
+            lower.parent.mkdir(parents=True)
+            lower.write_text("lower stack work\n", encoding="utf-8")
+            git(seed, "add", str(lower.relative_to(seed)))
+            git(seed, "commit", "-m", "lower stack commit")
+            git(seed, "switch", "master")
+            lower.parent.mkdir(parents=True, exist_ok=True)
+            lower.write_text("lower stack work\n", encoding="utf-8")
+            git(seed, "add", str(lower.relative_to(seed)))
+            git(seed, "commit", "-m", "squash lower stack")
+            git(seed, "push", "publish", "master")
+            git(seed, "switch", "-c", "stack/6325", "old-lower")
+            top = seed / "packages" / "workflow-graph" / "src" / "failure-classifier.ts"
+            top.parent.mkdir(parents=True)
+            top.write_text("export const failureClass = 'infra';\n", encoding="utf-8")
+            git(seed, "add", str(top.relative_to(seed)))
+            git(seed, "commit", "-m", "[Failure Class Unification](1) Add failure-class taxonomy")
+            start_head = git(seed, "rev-parse", "HEAD")
+            git(seed, "push", "publish", "stack/6325")
+
+            work_root.parent.mkdir(parents=True)
+            git(root, "clone", str(remote), str(work_root))
+            git(work_root, "config", "user.email", "repro@example.test")
+            git(work_root, "config", "user.name", "Repro Bot")
+
+            class FakeGh:
+                def pr_detail(self, _repo, _number):
+                    return {"state": "OPEN", "body": body}
+
+            item = pr(
+                6325,
+                base="master",
+                head="stack/6325",
+                body=body,
+                merge_state="BLOCKED",
+                mergeable="MERGEABLE",
+                checks={"PR Body": check("PR Body", "failure")},
+            )
+            object.__setattr__(item, "head_ref_oid", start_head)
+            repairer = self.repairer(FakeGh(), self.ledger())
+
+            def validate(work_root_arg: Path, _body: str, _base: str):
+                changed = git(work_root_arg, "diff", "--name-only", "origin/master...HEAD").splitlines()
+                if "packages/app/src/headless.ts" in changed:
+                    return {
+                        "valid": False,
+                        "errors": [validation_error],
+                        "reviewLane": "refactor",
+                        "reviewUnit": "contract",
+                        "reviewUnits": ["routing", "activation-surface"],
+                        "scopeKinds": ["product", "product-test"],
+                    }
+                return {
+                    "valid": True,
+                    "errors": [],
+                    "reviewLane": "refactor",
+                    "reviewUnit": "contract",
+                    "reviewUnits": ["contract"],
+                    "scopeKinds": ["product"],
+                }
+
+            with mock.patch.dict(os.environ, {"HOME": str(home)}):
+                with mock.patch.object(repairer.executor, "download_job_log", return_value=str(log_path)):
+                    with mock.patch.object(repairer, "run_claude_repair") as repair:
+                        with mock.patch.object(repairer, "validate_current_pr_body", side_effect=validate):
+                            result = repairer.repair_check(item, "PR Body")
+
+            pushed_head = git(remote, "rev-parse", "refs/heads/stack/6325")
+            changed_after = git(work_root, "diff", "--name-only", "origin/master...HEAD").splitlines()
+            repair.assert_not_called()
+            self.assertEqual(result.status, "pushed")
+            self.assertEqual(result.start_head, start_head)
+            self.assertEqual(result.end_head, pushed_head)
+            self.assertNotEqual(pushed_head, start_head)
+            self.assertEqual(changed_after, ["packages/workflow-graph/src/failure-classifier.ts"])
+            self.assertEqual(result.repair_commits, (pushed_head,))
+
+    def test_repair_check_stale_trunk_pr_body_unavailable_is_terminal(self):
+        validation_error = 'PR body Review Unit "contract" cannot ship with routing, activation-surface files in the same PR. Split this into one Review Unit per PR.'
+        validation = {
+            "valid": False,
+            "errors": [validation_error],
+            "reviewLane": "refactor",
+            "reviewUnit": "contract",
+            "reviewUnits": ["routing", "activation-surface"],
+            "scopeKinds": ["product", "product-test"],
+        }
+        item = pr(
+            6325,
+            base="master",
+            head="stack/6325",
+            body="## Summary\n\nStill mixed.\n",
+            merge_state="BLOCKED",
+            mergeable="MERGEABLE",
+            checks={"PR Body": check("PR Body", "failure")},
+        )
+        repairer = self.repairer(object(), self.ledger())
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(os.environ, {"HOME": tmp}):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
+                    with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
+                        with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: HEAD if args == ("rev-parse", "HEAD") else ""):
+                            with mock.patch.object(repairer, "is_ancestor", return_value=True):
+                                with mock.patch.object(repairer, "validate_current_pr_body", return_value=validation):
+                                    with mock.patch.object(repairer, "run_claude_repair") as repair:
+                                        with mock.patch.object(repairer, "has_merge_base", return_value=True):
+                                            result = repairer.repair_check(item, "PR Body")
+        repair.assert_not_called()
+        self.assertEqual(result.status, "blocked_invalid")
+        self.assertTrue(any(STALE_STACK_RESTACK_UNAVAILABLE_ERROR in error for error in result.errors))
 
     def test_plan_stack_actions_stop_retrying_after_repair_invalid(self):
         ledger = self.ledger()
@@ -850,6 +999,17 @@ This keeps the runtime routing change in its own review slice.
                 "scopeKinds": ["policy"],
             },
             {
+                "valid": False,
+                "errors": [
+                    PROOF_POLICY_LANE_ERROR,
+                    PROOF_TOOLING_POLICY_UNIT_ERROR,
+                ],
+                "reviewLane": "proof",
+                "reviewUnit": "proof",
+                "reviewUnits": ["tooling-policy"],
+                "scopeKinds": ["policy"],
+            },
+            {
                 "valid": True,
                 "errors": [],
                 "reviewLane": "policy",
@@ -865,7 +1025,8 @@ This keeps the runtime routing change in its own review slice.
                     with mock.patch.object(repairer, "git_output", side_effect=fake_git_output):
                         with mock.patch.object(repairer, "git_lines", side_effect=fake_git_lines):
                             with mock.patch.object(repairer, "validate_local_pr_body", side_effect=lambda *_args: next(validator_results)):
-                                result = repairer.repair_check(item, "PR Body", 123)
+                                with mock.patch.object(repairer, "has_merge_base", return_value=True):
+                                    result = repairer.repair_check(item, "PR Body", 123)
 
         self.assertEqual(result.status, "prereq_created")
         self.assertEqual(fake.created[0][0], "owner/repo")

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -772,6 +772,67 @@ class PlanStackExecution(PlannerTestCase):
         self.assertEqual(blockers[0]["kind"], "human_decision")
         self.assertIn("outside the PR head", blockers[0]["detail"])
 
+    def test_stale_trunk_pr_body_split_blocker_allows_one_restack_repair(self):
+        ledger = self._ledger()
+        detail = 'PR body Review Unit "contract" cannot ship with routing, activation-surface files in the same PR. Split this into one Review Unit per PR.'
+        ledger.record("repair-invalid", 6325, HEAD, "PR Body", 1, meta={"errors": [detail]})
+        snapshot = pr(
+            number=6325,
+            head_ref_name="stack/6325",
+            labels=frozenset({"admin-bypass"}),
+            checks={"build": check("success"), "PR Body": check("failure", "PR Body")},
+            repair_stop_comments=(
+                m.RepairStopComment(
+                    f"Mergify repair stopped: {detail}",
+                    "2026-07-07T05:02:00Z",
+                    "EdbertChan",
+                ),
+            ),
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            {"build", "PR Body"},
+            ledger,
+            now_epoch=2,
+            open_pr_numbers={6325},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual([(action.kind, action.key) for action in plan.actions], [("repair_check", "PR Body")])
+
+    def test_unavailable_stale_trunk_pr_body_restack_stops_retrying(self):
+        ledger = self._ledger()
+        detail = (
+            'PR body Review Unit "contract" cannot ship with routing, activation-surface files in the same PR. '
+            f"Split this into one Review Unit per PR.\n{m.STALE_STACK_RESTACK_UNAVAILABLE_ERROR}: master is already an ancestor"
+        )
+        ledger.record("repair-invalid", 6325, HEAD, "PR Body", 1, meta={"errors": [detail]})
+        snapshot = pr(
+            number=6325,
+            head_ref_name="stack/6325",
+            labels=frozenset({"admin-bypass"}),
+            checks={"build": check("success"), "PR Body": check("failure", "PR Body")},
+            repair_stop_comments=(
+                m.RepairStopComment(
+                    f"Mergify repair stopped: {detail}",
+                    "2026-07-07T05:02:00Z",
+                    "EdbertChan",
+                ),
+            ),
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            {"build", "PR Body"},
+            ledger,
+            now_epoch=2,
+            open_pr_numbers={6325},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "blocked-needs-human")
+        blockers = plan.summary["prs"][0]["blockers"]
+        self.assertEqual(blockers[0]["kind"], "human_decision")
+        self.assertIn(m.STALE_STACK_RESTACK_UNAVAILABLE_ERROR, blockers[0]["detail"])
+
     def test_repair_invalid_conflict_stops_retrying(self):
         ledger = self._ledger()
         reason = (


### PR DESCRIPTION
## Summary

Some `stack/*` PRs fail the PR Body check only because trunk has advanced past their merge base. The old commit still fails that stale check.

This slice adds a mechanical restack path: cherry-pick the PR's top commit onto current trunk, then re-check PR Body.

If the restack succeeds and PR Body now passes, the worker force-pushes with a lease. If not, it records a distinct stale-restack-unavailable error and stops retrying.

## Review Claim

The reviewer approves that a failing PR Body check caused only by a stale merge base can be mechanically repaired by restacking onto trunk, with a safe stop when restacking cannot clear it.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only edits local worker/repro tooling in this repo; it does not manually requeue, relabel, merge, split, rebase, or force-push the real target PR branches the worker operates on.

## Slice Rationale

This slice is the mechanical restack logic on its own. Its reproduction and test evidence live in the follow-up slice, per this repo's review-compression convention of separating logic from proof.

## Non-goals

- No manual real-PR cleanup.
- No unrelated refactors.
- No metadata-only PR edits.
- No queue-rule changes outside what this slice's tests require.
- No changes to how non-stale PR Body failures are repaired.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -m unittest scripts/test_mergify_admin_requeue.py`
- [ ] `python3 -m unittest scripts/test_mergify_admin_requeue_plan.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a9fb5d224`
- Post-revert steps: None
- Data migration? No

</details>
