### PR TITLE
[Continue babysit worker landing loop](24) Skip stale repair blockers

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 import sys
 import time
-from typing import Sequence
+from typing import Mapping, Sequence
 
 try:
     from .mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
@@ -82,6 +82,50 @@ def record_repair_outcome(
         )
 
 
+def stale_repair_outcome(
+    executor: AdminBypassGhExecutor,
+    logger: AdminBypassLogger,
+    repo: str,
+    pr: PrSnapshot,
+    outcome: RepairOutcome,
+) -> bool:
+    if outcome.status not in {"blocked_dirty", "blocked_invalid"}:
+        return False
+    if not hasattr(executor.gh, "pr_detail"):
+        return False
+    try:
+        detail = executor.gh.pr_detail(repo, pr.number)
+    except RuntimeError as exc:
+        logger.trace(
+            "admin-bypass-repair-outcome-live-check-failed",
+            repo=repo,
+            pr_number=pr.number,
+            check_name=outcome.check_name,
+            start_head=outcome.start_head,
+            snapshot_head=pr.head_ref_oid,
+            error=str(exc),
+        )
+        return False
+    if not isinstance(detail, Mapping):
+        return False
+    live_head = str(detail.get("headRefOid") or "")
+    live_state = str(detail.get("state") or pr.state)
+    if live_state == "OPEN" and (not live_head or live_head == outcome.start_head):
+        return False
+    logger.trace(
+        "admin-bypass-repair-outcome-stale",
+        repo=repo,
+        pr_number=pr.number,
+        check_name=outcome.check_name,
+        status=outcome.status,
+        start_head=outcome.start_head,
+        snapshot_head=pr.head_ref_oid,
+        live_head=live_head,
+        live_state=live_state,
+    )
+    return True
+
+
 def handle_repair_outcome(
     executor: AdminBypassGhExecutor,
     ledger: Ledger,
@@ -93,6 +137,16 @@ def handle_repair_outcome(
 ) -> None:
 
     ledger.record("repair-evaluated", pr.number, pr.head_ref_oid, outcome.check_name, now)
+    if stale_repair_outcome(executor, logger, repo, pr, outcome):
+        ledger.record(
+            "repair-stale",
+            pr.number,
+            pr.head_ref_oid,
+            outcome.check_name,
+            now,
+            meta={"status": outcome.status, "startHead": outcome.start_head, "endHead": outcome.end_head},
+        )
+        return
     if outcome.status == "blocked_dirty":
         executor.comment_blocked(
             pr,

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -452,6 +452,42 @@ Failing checks
         self.assertIsNotNone(recorded.latest("repair-invalid", 6118, HEAD, "conflict"))
         self.assertEqual(recorded.count("comment-blocked", 6118, HEAD, f"repair-invalid:conflict:{HEAD}"), 1)
 
+    def test_run_cycle_skips_stale_invalid_repair_comment_after_head_moves(self):
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+            def pr_detail(self, _repo, _number):
+                return {"state": "OPEN", "headRefOid": "b" * 40}
+
+        ledger = self.ledger()
+        args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(ledger.path)])
+        item = pr(6326, checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")})
+        stack = StackGroup("s", (item,))
+        outcome = exec_impl.RepairOutcome(
+            "blocked_invalid",
+            "PR Body",
+            HEAD,
+            HEAD,
+            errors=("human split based on stale PR Body failure",),
+        )
+        fake = FakeGh()
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=fake):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
+                    with mock.patch.object(AdminBypassRepairer, "repair_check", return_value=outcome):
+                        exec_impl.run_cycle(args)
+        self.assertEqual(fake.comments, [])
+        recorded = Ledger(ledger.path)
+        self.assertEqual(recorded.count("repair-check", 6326, HEAD, "PR Body"), 1)
+        self.assertIsNotNone(recorded.latest("repair-evaluated", 6326, HEAD, "PR Body"))
+        self.assertIsNotNone(recorded.latest("repair-stale", 6326, HEAD, "PR Body"))
+        self.assertIsNone(recorded.latest("repair-invalid", 6326, HEAD, "PR Body"))
+        self.assertEqual(recorded.count("comment-blocked", 6326, HEAD, f"repair-invalid:PR Body:{HEAD}"), 0)
+
     def test_claude_repair_uses_claude_cli(self):
         repairer = self.repairer(object(), self.ledger())
         with mock.patch("scripts.mergify_admin_requeue_repairer.subprocess.run") as run:


### PR DESCRIPTION
## Summary

The admin-bypass repair worker could act on a repair outcome even after the PR's live head or state no longer matched the head it was evaluated against.

This adds a live head check before acting on a blocked repair outcome. If the live head or state no longer matches, the outcome is treated as stale.

Stale outcomes are now recorded in the ledger and skipped instead of triggering a blocked comment on an already-updated PR.

## Review Claim

Reviewer approves that a blocked repair outcome is skipped, not acted on, when the live PR head or state no longer matches the head the outcome was evaluated against.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only edits local worker/repro tooling in this repo; it does not manually requeue, relabel, merge, split, rebase, or force-push the real target PR branches the worker operates on.

## Slice Rationale

This slice adds the staleness check and skip path on its own, kept separate from the reproduction that exercises it in the next slice, per this repo's review-compression convention of separating policy behavior from its proof.

## Non-goals

- No manual real-PR cleanup.
- No unrelated refactors.
- No metadata-only PR edits.
- No queue-rule changes outside what this slice's tests require.
- No change to which repair checks run or how eligibility for repair is decided.
- No change to the comment text posted for a genuinely blocked PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -m unittest scripts/test_mergify_admin_requeue.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 50675120c`
- Post-revert steps: None
- Data migration? No

</details>
