### PR TITLE
[Continue babysit worker landing loop](12) Stop retrying repair-invalid human blockers

### DIFF
--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -39,6 +39,8 @@ QUEUE_ONLY_REQUIRED_CHECKS = frozenset({
 ACTIVE_QUEUE_STATES = frozenset({"queued", "merging"})
 
 HUMAN_BLOCKER_KINDS = frozenset({"draft", "human_review_thread", "missing_check", "closed", "human_decision"})
+TERMINAL_BLOCKER_KINDS = frozenset({"merged"})
+REPAIR_INVALID_BLOCKER_KINDS = frozenset({"failed_check", "bot_review_thread", "conflict"})
 REPAIR_STOP_PREFIX = "Mergify repair stopped: "
 MANUAL_SPLIT_STOP_MARKERS = (
     "human stack split required",
@@ -81,6 +83,9 @@ def is_queue_only_required_check(name: str) -> bool:
 
 def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) -> tuple[Blocker, ...]:
     blockers: list[Blocker] = []
+    if pr.state == "MERGED":
+        blockers.append(Blocker("merged", "merged", pr.number, "state=MERGED"))
+        return tuple(blockers)
     if pr.state != "OPEN":
         blockers.append(Blocker("closed", "closed", pr.number, f"state={pr.state}"))
         return tuple(blockers)
@@ -308,10 +313,22 @@ def latest_queue_only_noop_check(stack: StackGroup, ledger: Ledger, trunk: str) 
     return check_name
 
 
+def repair_invalid_keys_for_blocker(pr: PrSnapshot, blocker: Blocker) -> tuple[str, ...]:
+    if blocker.kind == "conflict":
+        return ("conflict", f"conflict:{pr.number}")
+    return (blocker.key,)
+
+
 def latest_repair_invalid_blocker(pr: PrSnapshot, blocker: Blocker, ledger: Ledger) -> Blocker | None:
-    if blocker.kind != "failed_check":
+    if blocker.kind not in REPAIR_INVALID_BLOCKER_KINDS:
         return None
-    latest = ledger.latest("repair-invalid", pr.number, pr.head_ref_oid, blocker.key)
+    latest = None
+    for key in repair_invalid_keys_for_blocker(pr, blocker):
+        row = ledger.latest("repair-invalid", pr.number, pr.head_ref_oid, key)
+        if row is None:
+            continue
+        if latest is None or int(row.get("epoch", 0) or 0) >= int(latest.get("epoch", 0) or 0):
+            latest = row
     if latest is None:
         return None
     meta = latest.get("meta") if isinstance(latest.get("meta"), Mapping) else {}
@@ -503,21 +520,28 @@ def summarize_stack(facts: StackFacts) -> dict[str, object]:
 def wait_reason_for_facts(facts: StackFacts) -> str:
     if facts.upper_stack_needs_acceptance:
         return "upper-stack-needs-acceptance"
-    if facts.bottom and facts.bottom.latest_mergify and facts.bottom.latest_mergify.state in {"queued", "merging"}:
-        return "bottom-already-queued"
     for pr in facts.stack.prs:
         blocker_kinds = {blocker.kind for blocker in facts.blockers_by_pr[pr.number]}
         if "pending_check" in blocker_kinds:
             return "pending-check"
         if "merge_hold" in blocker_kinds and len(blocker_kinds) == 1:
             return "merge-hold-only"
+        if TERMINAL_BLOCKER_KINDS & blocker_kinds:
+            return "terminal-merged"
         if HUMAN_BLOCKER_KINDS & blocker_kinds:
             return "blocked-needs-human"
+    if facts.bottom and facts.bottom.latest_mergify and facts.bottom.latest_mergify.state in {"queued", "merging"}:
+        return "bottom-already-queued"
     return "no-action"
 
 
 def _has_pending_or_human_blocker(facts: StackFacts) -> bool:
-    return any(blocker.kind == "pending_check" or blocker.kind in HUMAN_BLOCKER_KINDS for blocker in facts.all_blockers)
+    return any(
+        blocker.kind == "pending_check"
+        or blocker.kind in HUMAN_BLOCKER_KINDS
+        or blocker.kind in TERMINAL_BLOCKER_KINDS
+        for blocker in facts.all_blockers
+    )
 
 
 def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
@@ -525,7 +549,11 @@ def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
         return _has_pending_or_human_blocker(facts)
     return any(
         blocker.pr_number == facts.bottom.number
-        and (blocker.kind == "pending_check" or blocker.kind in HUMAN_BLOCKER_KINDS)
+        and (
+            blocker.kind == "pending_check"
+            or blocker.kind in HUMAN_BLOCKER_KINDS
+            or blocker.kind in TERMINAL_BLOCKER_KINDS
+        )
         for blocker in facts.all_blockers
     )
 
@@ -545,6 +573,8 @@ def plan_mergify_queue_repairs(facts: StackFacts, ledger: Ledger, max_repair_att
 
 def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     for pr in facts.stack.prs:
+        if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
+            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "conflict":
                 key = f"conflict:{pr.number}"
@@ -561,6 +591,8 @@ def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: 
 
 def plan_bot_thread_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     for pr in facts.stack.prs:
+        if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
+            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "outdated_bot_review_thread":
                 return Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail)

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -93,6 +93,9 @@ class ClassifyPr(unittest.TestCase):
     def test_closed_short_circuits(self):
         self.assertEqual(self._kinds(pr(state="CLOSED")), {"closed"})
 
+    def test_merged_short_circuits(self):
+        self.assertEqual(self._kinds(pr(state="MERGED")), {"merged"})
+
     def test_failed_required_check(self):
         self.assertEqual(self._kinds(pr(checks={"build": check("failure")})), {"failed_check"})
 
@@ -333,13 +336,86 @@ class PlanStackActions(PlannerTestCase):
     def test_pending_check_means_wait_do_nothing(self):
         self.assertEqual(self._plan(pr(checks={"build": check("pending")})), ())
 
+    def test_merged_pr_is_terminal_noop(self):
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (pr(number=6108, state="MERGED", labels=frozenset({"admin-bypass"})),)),
+            REQUIRED,
+            self._ledger(),
+            now_epoch=0,
+            open_pr_numbers=set(),
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "terminal-merged")
+
     def test_conflict_triggers_claude_repair(self):
         actions = self._plan(pr(merge_state_status="DIRTY"))
         self.assertEqual((actions[0].kind, actions[0].pr_number), ("repair_conflict", 1))
 
+    def test_repair_invalid_conflict_stops_retrying(self):
+        ledger = self._ledger()
+        ledger.record(
+            "repair-invalid",
+            6118,
+            HEAD,
+            "conflict",
+            1,
+            meta={"errors": ["requires a human to decide whether this stale duplicate stack is superseded"]},
+        )
+        snapshot = pr(
+            number=6118,
+            labels=frozenset({"admin-bypass"}),
+            merge_state_status="DIRTY",
+            mergeable="CONFLICTING",
+            latest_mergify=event(state="queued", head=""),
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            REQUIRED,
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={6118},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "blocked-needs-human")
+        blockers = plan.summary["prs"][0]["blockers"]
+        self.assertEqual(blockers[0]["kind"], "human_decision")
+        self.assertIn("stale duplicate stack", blockers[0]["detail"])
+
     def test_failed_check_triggers_repair(self):
         actions = self._plan(pr(checks={"build": check("failure")}))
         self.assertEqual((actions[0].kind, actions[0].key), ("repair_check", "build"))
+
+    def test_repair_invalid_bot_thread_suppresses_other_repairs_on_same_pr(self):
+        ledger = self._ledger()
+        ledger.record(
+            "repair-invalid",
+            6158,
+            HEAD,
+            "PRRT_kwDOSFkSDM6T97v9",
+            1,
+            meta={"errors": ['PR body Review Unit "routing" cannot ship with activation-surface files in the same PR. Split this into one Review Unit per PR.']},
+        )
+        snapshot = pr(
+            number=6158,
+            labels=frozenset({"admin-bypass"}),
+            checks={"build": check("failure")},
+            review_threads=(m.ReviewThread("PRRT_kwDOSFkSDM6T97v9", False, ("coderabbitai[bot]",)),),
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            REQUIRED,
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={6158},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "blocked-needs-human")
+        blockers = plan.summary["prs"][0]["blockers"]
+        self.assertEqual(blockers[0]["kind"], "human_decision")
+        self.assertEqual(blockers[1]["kind"], "failed_check")
 
     def test_mergify_dequeue_with_failing_check_repairs_first(self):
         # A Mergify dequeue naming a failing check outranks everything else.


### PR DESCRIPTION
## Summary

Repair-invalid conflict and bot-thread evidence now becomes a human_decision blocker before the worker plans another repair.

Merged pull requests now short-circuit as terminal work, so the worker stops treating already-landed targets as repair candidates.

Planner tests cover both blocker paths and the merged-PR terminal wait.

## Review Claim

The worker planner treats repair-invalid conflict and bot-thread evidence, plus merged PRs, as terminal human-only or done states instead of retryable work.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only changes local admin-requeue planner policy and its unit tests; it does not run worker write actions against real PR branches.

## Slice Rationale

This slice is separated from the next script-only check so reviewers can inspect the planner contract by itself.

## Non-goals

- No manual real-PR cleanup.
- No queue-rule changes outside the admin-requeue planner.
- No new repro registration in this slice.
- No UI, data migration, or workflow schema changes.

## Architecture

### Before

```mermaid
graph TD
    A["PR has repair-invalid conflict evidence"] --> B["Planner sees a conflict blocker"]
    B --> C["Planner retries repair or emits a generic cap"]
```

### After

```mermaid
graph TD
    A["PR has repair-invalid conflict or bot-thread evidence"] --> B["Planner converts it to human_decision"]
    B --> C["Worker waits with the exact human-only reason"]
    D["PR state is MERGED"] --> E["Planner returns a terminal merged blocker"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/test_mergify_admin_requeue_plan.py`
- [x] `PYTHONDONTWRITEBYTECODE=1 bash ./loop-driver.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e9f291a1d`
- Post-revert steps: None
- Data migration? No

</details>
