### PR TITLE
[Continue babysit worker landing loop](13) Reproduce repair-invalid human blocker stops

### DIFF
--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -20,6 +20,7 @@ REPROS=(
   scripts/repro/repro-babysit-queue-only-missing-requeues.sh
   scripts/repro/repro-babysit-targeted-scan-light.sh
   scripts/repro/repro-babysit-queue-repair-invalid-stop.sh
+  scripts/repro/repro-babysit-conflict-repair-invalid-stop.sh
   scripts/repro/repro-babysit-stack-human-blocker-suppresses-repairs.sh
   scripts/repro/repro-babysit-no-current-bottom-comment.sh
   scripts/repro/repro-babysit-merged-pr-terminal.sh

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -39,6 +39,8 @@ QUEUE_ONLY_REQUIRED_CHECKS = frozenset({
 ACTIVE_QUEUE_STATES = frozenset({"queued", "merging"})
 
 HUMAN_BLOCKER_KINDS = frozenset({"draft", "human_review_thread", "missing_check", "closed", "human_decision"})
+TERMINAL_BLOCKER_KINDS = frozenset({"merged"})
+REPAIR_INVALID_BLOCKER_KINDS = frozenset({"failed_check", "bot_review_thread", "conflict"})
 REPAIR_STOP_PREFIX = "Mergify repair stopped: "
 MANUAL_SPLIT_STOP_MARKERS = (
     "human stack split required",
@@ -81,6 +83,9 @@ def is_queue_only_required_check(name: str) -> bool:
 
 def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) -> tuple[Blocker, ...]:
     blockers: list[Blocker] = []
+    if pr.state == "MERGED":
+        blockers.append(Blocker("merged", "merged", pr.number, "state=MERGED"))
+        return tuple(blockers)
     if pr.state != "OPEN":
         blockers.append(Blocker("closed", "closed", pr.number, f"state={pr.state}"))
         return tuple(blockers)
@@ -308,10 +313,22 @@ def latest_queue_only_noop_check(stack: StackGroup, ledger: Ledger, trunk: str) 
     return check_name
 
 
+def repair_invalid_keys_for_blocker(pr: PrSnapshot, blocker: Blocker) -> tuple[str, ...]:
+    if blocker.kind == "conflict":
+        return ("conflict", f"conflict:{pr.number}")
+    return (blocker.key,)
+
+
 def latest_repair_invalid_blocker(pr: PrSnapshot, blocker: Blocker, ledger: Ledger) -> Blocker | None:
-    if blocker.kind != "failed_check":
+    if blocker.kind not in REPAIR_INVALID_BLOCKER_KINDS:
         return None
-    latest = ledger.latest("repair-invalid", pr.number, pr.head_ref_oid, blocker.key)
+    latest = None
+    for key in repair_invalid_keys_for_blocker(pr, blocker):
+        row = ledger.latest("repair-invalid", pr.number, pr.head_ref_oid, key)
+        if row is None:
+            continue
+        if latest is None or int(row.get("epoch", 0) or 0) >= int(latest.get("epoch", 0) or 0):
+            latest = row
     if latest is None:
         return None
     meta = latest.get("meta") if isinstance(latest.get("meta"), Mapping) else {}
@@ -503,21 +520,28 @@ def summarize_stack(facts: StackFacts) -> dict[str, object]:
 def wait_reason_for_facts(facts: StackFacts) -> str:
     if facts.upper_stack_needs_acceptance:
         return "upper-stack-needs-acceptance"
-    if facts.bottom and facts.bottom.latest_mergify and facts.bottom.latest_mergify.state in {"queued", "merging"}:
-        return "bottom-already-queued"
     for pr in facts.stack.prs:
         blocker_kinds = {blocker.kind for blocker in facts.blockers_by_pr[pr.number]}
         if "pending_check" in blocker_kinds:
             return "pending-check"
         if "merge_hold" in blocker_kinds and len(blocker_kinds) == 1:
             return "merge-hold-only"
+        if TERMINAL_BLOCKER_KINDS & blocker_kinds:
+            return "terminal-merged"
         if HUMAN_BLOCKER_KINDS & blocker_kinds:
             return "blocked-needs-human"
+    if facts.bottom and facts.bottom.latest_mergify and facts.bottom.latest_mergify.state in {"queued", "merging"}:
+        return "bottom-already-queued"
     return "no-action"
 
 
 def _has_pending_or_human_blocker(facts: StackFacts) -> bool:
-    return any(blocker.kind == "pending_check" or blocker.kind in HUMAN_BLOCKER_KINDS for blocker in facts.all_blockers)
+    return any(
+        blocker.kind == "pending_check"
+        or blocker.kind in HUMAN_BLOCKER_KINDS
+        or blocker.kind in TERMINAL_BLOCKER_KINDS
+        for blocker in facts.all_blockers
+    )
 
 
 def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
@@ -525,7 +549,11 @@ def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
         return _has_pending_or_human_blocker(facts)
     return any(
         blocker.pr_number == facts.bottom.number
-        and (blocker.kind == "pending_check" or blocker.kind in HUMAN_BLOCKER_KINDS)
+        and (
+            blocker.kind == "pending_check"
+            or blocker.kind in HUMAN_BLOCKER_KINDS
+            or blocker.kind in TERMINAL_BLOCKER_KINDS
+        )
         for blocker in facts.all_blockers
     )
 
@@ -545,6 +573,8 @@ def plan_mergify_queue_repairs(facts: StackFacts, ledger: Ledger, max_repair_att
 
 def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     for pr in facts.stack.prs:
+        if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
+            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "conflict":
                 key = f"conflict:{pr.number}"
@@ -561,6 +591,8 @@ def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: 
 
 def plan_bot_thread_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
     for pr in facts.stack.prs:
+        if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
+            continue
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "outdated_bot_review_thread":
                 return Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail)

--- a/scripts/repro/repro-admin-bypass-non-landing-root-cause.py
+++ b/scripts/repro/repro-admin-bypass-non-landing-root-cause.py
@@ -7,13 +7,14 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Mapping
 
-DB_PATH = Path.home() / '.invoker' / 'invoker.db'
-REPO = 'Neko-Catpital-Labs/Invoker'
-TARGET_PRS = (5801, 5811)
-WORKER_SOURCE = 'pr-maintenance-worker'
-WORKER_TAG = '[worker:pr-admin-bypass-land]'
-PLACEHOLDER_REQUIRED_FAST = 'required-fast / ${{ matrix.name }}'
+DB_PATH = Path.home() / ".invoker" / "invoker.db"
+LEDGER_PATH = Path.home() / ".invoker" / "mergify-admin-requeue-state.jsonl"
+REPO = "Neko-Catpital-Labs/Invoker"
+TARGET_PRS = (6118, 6158)
+WORKER_SOURCE = "pr-maintenance-worker"
+REPAIR_STOP_PREFIX = "Mergify repair stopped: "
 
 
 @dataclass(frozen=True)
@@ -24,14 +25,14 @@ class LogEvidence:
 
 
 def run_gh_json(args: list[str]) -> dict:
-    completed = subprocess.run(['gh', *args], text=True, capture_output=True, check=True)
+    completed = subprocess.run(["gh", *args], text=True, capture_output=True, check=True)
     return json.loads(completed.stdout)
 
 
 def connect_db() -> sqlite3.Connection:
     if not DB_PATH.exists():
-        raise SystemExit(f'missing invoker db: {DB_PATH}')
-    uri = f'file:{DB_PATH}?mode=ro&immutable=1'
+        raise SystemExit(f"missing invoker db: {DB_PATH}")
+    uri = f"file:{DB_PATH}?mode=ro&immutable=1"
     conn = sqlite3.connect(uri, uri=True)
     conn.row_factory = sqlite3.Row
     return conn
@@ -40,117 +41,190 @@ def connect_db() -> sqlite3.Connection:
 def fetch_worker_logs(conn: sqlite3.Connection, pr_number: int) -> list[LogEvidence]:
     cur = conn.cursor()
     cur.execute(
-        '''
+        """
         select timestamp, level, message
         from activity_log
         where source = ? and message like ?
         order by datetime(timestamp) asc, id asc
-        ''',
-        (WORKER_SOURCE, f'%{pr_number}%'),
+        """,
+        (WORKER_SOURCE, f"%{pr_number}%"),
     )
-    return [LogEvidence(str(row['timestamp']), str(row['level']), str(row['message'])) for row in cur.fetchall()]
+    return [LogEvidence(str(row["timestamp"]), str(row["level"]), str(row["message"])) for row in cur.fetchall()]
 
 
 def require_line(logs: list[LogEvidence], needle: str, label: str) -> LogEvidence:
     for row in logs:
         if needle in row.message:
             return row
-    raise AssertionError(f'missing {label}: {needle}')
+    raise AssertionError(f"missing {label}: {needle}")
+
+
+def load_ledger_rows(pr_number: int) -> list[dict]:
+    if not LEDGER_PATH.exists():
+        raise SystemExit(f"missing ledger: {LEDGER_PATH}")
+    rows: list[dict] = []
+    for raw in LEDGER_PATH.read_text(encoding="utf-8").splitlines():
+        if not raw.strip():
+            continue
+        try:
+            row = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if row.get("pr") == pr_number:
+            rows.append(row)
+    return rows
+
+
+def latest_row(rows: list[dict], kind: str, head: str, key: str | None = None) -> dict | None:
+    matches = [
+        row
+        for row in rows
+        if row.get("kind") == kind
+        and row.get("headSha") == head
+        and (key is None or row.get("key") == key)
+    ]
+    if not matches:
+        return None
+    return max(matches, key=lambda row: int(row.get("epoch", 0) or 0))
+
+
+def row_errors(row: Mapping[str, object]) -> list[str]:
+    meta = row.get("meta") if isinstance(row.get("meta"), Mapping) else {}
+    errors = meta.get("errors") if isinstance(meta, Mapping) else []
+    return [str(error) for error in errors] if isinstance(errors, list) else []
 
 
 def gh_pr_snapshot(pr_number: int) -> dict:
     return run_gh_json([
-        'pr', 'view', str(pr_number), '--repo', REPO,
-        '--json', 'number,title,state,labels,headRefOid,statusCheckRollup',
+        "pr", "view", str(pr_number), "--repo", REPO, "--comments",
+        "--json", "number,title,state,labels,headRefOid,mergeStateStatus,comments,statusCheckRollup",
     ])
 
 
 def check_names(snapshot: dict) -> list[str]:
-    return [node.get('name') or node.get('context') or '' for node in snapshot.get('statusCheckRollup') or []]
+    return [node.get("name") or node.get("context") or "" for node in snapshot.get("statusCheckRollup") or []]
 
 
-def summarize_5801(conn: sqlite3.Connection) -> tuple[dict, list[str]]:
-    logs = fetch_worker_logs(conn, 5801)
-    ts_repair = require_line(logs, 'repair-check PR #5801 check="quality / TypeScript Types"', '5801 repair check')
-    ts_pushed = require_line(logs, "Pushed to PR #5801's head branch (`871f16fb6`).", '5801 push')
-    ts_conflict = require_line(logs, 'repair-conflict PR #5801 GitHub reports merge conflict', '5801 conflict repair')
-    ts_fixed = require_line(logs, 'Force-pushed the rebased branch to the PR head.', '5801 fixed note')
-    ts_stalled = require_line(logs, '"kind": "comment_blocked", "pr_number": 5803', '5801 stack blocked by 5803')
-    snapshot = gh_pr_snapshot(5801)
-    names = check_names(snapshot)
-    assert 'required-fast / Guardrails' not in names, '5801 unexpectedly has required-fast / Guardrails'
-    assert 'required-fast / Submit Workflow Chain' not in names, '5801 unexpectedly has required-fast / Submit Workflow Chain'
-    assert PLACEHOLDER_REQUIRED_FAST in names, '5801 missing placeholder required-fast check name'
+def stop_comments(snapshot: Mapping[str, object]) -> list[str]:
+    comments = snapshot.get("comments")
+    if not isinstance(comments, list):
+        return []
+    bodies = [str(comment.get("body") or "") for comment in comments if isinstance(comment, Mapping)]
+    return [body for body in bodies if body.startswith(REPAIR_STOP_PREFIX)]
+
+
+def require_stop_comment(snapshot: Mapping[str, object], fragment: str, label: str) -> str:
+    for body in stop_comments(snapshot):
+        if fragment in body:
+            return body
+    raise AssertionError(f"missing {label} stop comment fragment: {fragment}")
+
+
+def summarize_6118(conn: sqlite3.Connection) -> tuple[dict, list[str]]:
+    snapshot = gh_pr_snapshot(6118)
+    head = str(snapshot["headRefOid"])
+    assert snapshot["state"] == "OPEN", "6118 is no longer open"
+    assert snapshot["mergeStateStatus"] == "DIRTY", "6118 is no longer dirty"
+
+    rows = load_ledger_rows(6118)
+    invalid = latest_row(rows, "repair-invalid", head, "conflict")
+    assert invalid is not None, "6118 missing conflict repair-invalid evidence"
+    errors = row_errors(invalid)
+    assert any("duplicate bottom PR" in error for error in errors), "6118 repair-invalid missing duplicate-stack proof"
+    assert any("requires a human to decide" in error for error in errors), "6118 repair-invalid missing human-decision proof"
+    exact_stop = require_stop_comment(snapshot, "requires a human to decide", "6118 exact")
+    generic_stop = require_stop_comment(snapshot, "The retry cap was reached", "6118 generic cap")
+
+    logs = fetch_worker_logs(conn, 6118)
+    cap_log = require_line(logs, "The retry cap was reached for current head " + head, "6118 generic cap retry")
+    attempts = sum(1 for row in rows if row.get("kind") == "conflict-repair" and row.get("headSha") == head and row.get("key") == "conflict:6118")
+
     return {
-        'pr': 5801,
-        'state': snapshot['state'],
-        'labels': [label['name'] for label in snapshot['labels']],
-        'head': snapshot['headRefOid'],
-        'repair_started_at': ts_repair.timestamp,
-        'repair_pushed_at': ts_pushed.timestamp,
-        'conflict_repaired_at': ts_conflict.timestamp,
-        'fixed_note_at': ts_fixed.timestamp,
-        'stalled_on_stack_at': ts_stalled.timestamp,
-        'root_cause': '5801 was repaired, then rebased, but its head still lacked the required-fast check contexts and the worker kept prioritizing capped PR #5803 in the same stack.',
-    }, names
+        "pr": 6118,
+        "state": snapshot["state"],
+        "merge_state": snapshot["mergeStateStatus"],
+        "labels": [label["name"] for label in snapshot["labels"]],
+        "head": head,
+        "attempts": attempts,
+        "exact_stop_at": str(invalid.get("epoch") or ""),
+        "generic_cap_at": cap_log.timestamp,
+        "exact_comment": exact_stop[len(REPAIR_STOP_PREFIX):],
+        "generic_comment": generic_stop[len(REPAIR_STOP_PREFIX):],
+        "root_cause": "conflict repair-invalid evidence was recorded, but the planner did not promote conflict blockers to human_decision and later emitted a generic retry-cap blocker.",
+    }, check_names(snapshot)
 
 
-def summarize_5811(conn: sqlite3.Connection) -> tuple[dict, list[str]]:
-    logs = fetch_worker_logs(conn, 5811)
-    ts_dequeued = require_line(logs, '"latest_mergify": {"comment_id": "5078148864", "failing_checks": ["required-fast / Guardrails"]', '5811 dequeued trace')
-    ts_block = require_line(logs, 'BLOCK PR #5811 missing-check', '5811 blocked comment')
-    repair_lines = [row for row in logs if 'repair-check PR #5811' in row.message or 'admin-bypass-repair-check-start' in row.message and '"pr_number": 5811' in row.message]
-    if repair_lines:
-        raise AssertionError('5811 unexpectedly has a repair-check execution in live logs')
-    snapshot = gh_pr_snapshot(5811)
-    names = check_names(snapshot)
-    assert 'required-fast / Guardrails' not in names, '5811 unexpectedly has required-fast / Guardrails'
-    assert PLACEHOLDER_REQUIRED_FAST in names, '5811 missing placeholder required-fast check name'
+def summarize_6158(conn: sqlite3.Connection) -> tuple[dict, list[str]]:
+    snapshot = gh_pr_snapshot(6158)
+    head = str(snapshot["headRefOid"])
+    assert snapshot["state"] == "OPEN", "6158 is no longer open"
+    assert snapshot["mergeStateStatus"] == "DIRTY", "6158 is no longer dirty"
+
+    rows = load_ledger_rows(6158)
+    invalid = latest_row(rows, "repair-invalid", head, "PRRT_kwDOSFkSDM6T97v9")
+    assert invalid is not None, "6158 missing bot-thread repair-invalid evidence"
+    errors = row_errors(invalid)
+    assert any("activation-surface files" in error for error in errors), "6158 repair-invalid missing review-unit split proof"
+    exact_stop = require_stop_comment(snapshot, "activation-surface files in the same PR", "6158 exact")
+    generic_stop = require_stop_comment(snapshot, "The retry cap was reached", "6158 generic cap")
+
+    logs = fetch_worker_logs(conn, 6158)
+    cap_log = require_line(logs, "The retry cap was reached for current head " + head, "6158 generic cap retry")
+    attempts = sum(1 for row in rows if row.get("kind") == "conflict-repair" and row.get("headSha") == head and row.get("key") == "conflict:6158")
+
     return {
-        'pr': 5811,
-        'state': snapshot['state'],
-        'labels': [label['name'] for label in snapshot['labels']],
-        'head': snapshot['headRefOid'],
-        'dequeued_trace_at': ts_dequeued.timestamp,
-        'blocked_at': ts_block.timestamp,
-        'root_cause': '5811 left the queue on a merge-queue Guardrails failure, but the original PR head never had that required-fast check context, so the worker only emitted missing-check blocks and never repaired or requeued it.',
-    }, names
+        "pr": 6158,
+        "state": snapshot["state"],
+        "merge_state": snapshot["mergeStateStatus"],
+        "labels": [label["name"] for label in snapshot["labels"]],
+        "head": head,
+        "attempts": attempts,
+        "exact_stop_at": str(invalid.get("epoch") or ""),
+        "generic_cap_at": cap_log.timestamp,
+        "exact_comment": exact_stop[len(REPAIR_STOP_PREFIX):],
+        "generic_comment": generic_stop[len(REPAIR_STOP_PREFIX):],
+        "root_cause": "a bot-thread repair-invalid human split blocker existed on the PR, but later repair passes still retried the conflict path and emitted a generic retry-cap blocker.",
+    }, check_names(snapshot)
+
+
+def print_summary(row: Mapping[str, object], names: list[str]) -> None:
+    labels = ",".join(row["labels"]) if isinstance(row.get("labels"), list) else ""
+    print(
+        f"| {row['pr']} | {labels} | {row['state']} / {row['merge_state']} | {row['head']} | "
+        f"{row['attempts']} conflict attempts | exact stop at {row['exact_stop_at']} | "
+        f"generic cap at {row['generic_cap_at']} | {row['root_cause']} |"
+    )
+    print(f"  exact: {row['exact_comment']}")
+    print(f"  generic: {row['generic_comment']}")
+    print("  checks:")
+    for name in names:
+        print(f"    - {name}")
 
 
 def main() -> int:
     conn = connect_db()
     try:
-        summary_5801, names_5801 = summarize_5801(conn)
-        summary_5811, names_5811 = summarize_5811(conn)
+        summary_6118, names_6118 = summarize_6118(conn)
+        summary_6158, names_6158 = summarize_6158(conn)
     finally:
         conn.close()
 
-    print('Admin-bypass non-landing root cause repro')
-    print(f'DB: {DB_PATH}')
+    print("Admin-bypass non-landing root cause repro")
+    print(f"DB: {DB_PATH}")
+    print(f"Ledger: {LEDGER_PATH}")
     print()
-    print('| PR | labels | live proof of worker handling | live proof of fix | live blocker after fix | root cause |')
-    print('|---|---|---|---|---|---|')
-    print(
-        f"| 5801 | {','.join(summary_5801['labels'])} | repair-check at {summary_5801['repair_started_at']} | pushed at {summary_5801['repair_pushed_at']}; rebased/fixed at {summary_5801['fixed_note_at']} | stack blocked at {summary_5801['stalled_on_stack_at']} while required-fast checks were absent on head {summary_5801['head']} | {summary_5801['root_cause']} |"
-    )
-    print(
-        f"| 5811 | {','.join(summary_5811['labels'])} | dequeued failing-check trace at {summary_5811['dequeued_trace_at']} | none in worker logs | repeated missing-check block at {summary_5811['blocked_at']} while required-fast check was absent on head {summary_5811['head']} | {summary_5811['root_cause']} |"
-    )
+    print("| PR | labels | live state | head | conflict attempts | exact proof | later bad retry | root cause |")
+    print("|---|---|---|---|---|---|---|---|")
+    print_summary(summary_6118, names_6118)
+    print_summary(summary_6158, names_6158)
     print()
-    print('5801 check names:')
-    for name in names_5801:
-        print(f'  - {name}')
-    print('5811 check names:')
-    for name in names_5811:
-        print(f'  - {name}')
-    print()
-    print('Shared signature: both PR heads are missing the exact required-fast check names that Mergify requires; only placeholder skipped check names remain on the PR heads.')
+    print("Shared signature: exact human-only repair-invalid evidence exists, but subsequent planner passes treated the PR as repairable and emitted generic retry-cap blockers.")
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     try:
         raise SystemExit(main())
     except AssertionError as exc:
-        print(f'REPRO FAILED: {exc}', file=sys.stderr)
+        print(f"REPRO FAILED: {exc}", file=sys.stderr)
         raise SystemExit(1)

--- a/scripts/repro/repro-babysit-conflict-repair-invalid-stop.sh
+++ b/scripts/repro/repro-babysit-conflict-repair-invalid-stop.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-conflict-repair-invalid-stop.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+mkdir -p "$HOME" "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+HEAD="fed0e18de54f02b3ebd006a12ca3f2046dede28d"
+EXACT_REASON='PR #6118 is a stale duplicate of an already-partially-merged workflow base-ref stack. Resolving the conflict requires a human to decide whether to keep the pin-to-master behavior or treat this stack as superseded; this is not a mechanical rebase.'
+export STATE_PATH LEDGER_PATH HEAD EXACT_REASON
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = os.environ["HEAD"]
+reason = os.environ["EXACT_REASON"]
+state = {
+    "prs": [
+        {
+            "number": 6118,
+            "title": "[Workflow Base Branch](1) Pin persisted workflow base branch to master",
+            "body": "## Summary\n\nPin persisted workflow base branch to master.\n",
+            "url": "https://github.com/fake/repo/pull/6118",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "stack/base-branch-master-docs-1",
+            "headRefOid": head,
+            "mergeStateStatus": "DIRTY",
+            "mergeable": "CONFLICTING",
+            "labels": ["admin-bypass"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS"},
+        }
+    ],
+    "issue_comments": {
+        "6118": [
+            {
+                "id": "exact-stop",
+                "user": {"login": "EdbertChan"},
+                "updated_at": "2026-07-28T09:43:27Z",
+                "html_url": "https://github.com/fake/repo/pull/6118#issuecomment-1",
+                "body": f"Mergify repair stopped: {reason}",
+            },
+            {
+                "id": "generic-cap",
+                "user": {"login": "EdbertChan"},
+                "updated_at": "2026-07-28T10:18:14Z",
+                "html_url": "https://github.com/fake/repo/pull/6118#issuecomment-2",
+                "body": f"Mergify repair stopped: GitHub reports merge conflict. The retry cap was reached for current head {head}.",
+            },
+        ]
+    },
+    "job_logs": {},
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+rows = [
+    {"epoch": 1785230434, "headSha": head, "key": "conflict:6118", "kind": "conflict-repair", "pr": 6118},
+    {"epoch": 1785231704, "headSha": head, "key": "conflict:6118", "kind": "conflict-repair", "pr": 6118},
+    {"epoch": 1785231704, "headSha": head, "key": "conflict", "kind": "repair-evaluated", "pr": 6118},
+    {"epoch": 1785231704, "headSha": head, "key": "conflict", "kind": "repair-invalid", "meta": {"errors": [reason]}, "pr": 6118},
+    {"epoch": 1785231704, "headSha": head, "key": f"repair-invalid:conflict:{head}", "kind": "comment-blocked", "pr": 6118},
+    {"epoch": 1785233030, "headSha": head, "key": "conflict:6118", "kind": "conflict-repair", "pr": 6118},
+    {"epoch": 1785233893, "headSha": head, "key": f"capped:GitHub reports merge conflict. The retry cap was reached for current head {head}.", "kind": "comment-blocked", "pr": 6118},
+]
+Path(os.environ["LEDGER_PATH"]).write_text(
+    "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+    encoding="utf-8",
+)
+PY
+
+if ! out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6118 2>&1)"; then
+  fail 'targeted worker dry-run failed' "$out"
+fi
+
+! echo "$out" | grep -q 'repair-conflict PR #6118' || fail 'conflict repair-invalid retried repair' "$out"
+! echo "$out" | grep -q 'retry cap was reached' || fail 'conflict repair-invalid emitted generic cap' "$out"
+echo "$out" | grep -q '"reason": "blocked-needs-human"' || fail 'conflict repair-invalid did not become terminal human blocker' "$out"
+echo "$out" | grep -q 'stale duplicate of an already-partially-merged workflow base-ref stack' || fail 'exact human-only reason was not preserved' "$out"
+
+echo '[repro] passed'

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -93,6 +93,9 @@ class ClassifyPr(unittest.TestCase):
     def test_closed_short_circuits(self):
         self.assertEqual(self._kinds(pr(state="CLOSED")), {"closed"})
 
+    def test_merged_short_circuits(self):
+        self.assertEqual(self._kinds(pr(state="MERGED")), {"merged"})
+
     def test_failed_required_check(self):
         self.assertEqual(self._kinds(pr(checks={"build": check("failure")})), {"failed_check"})
 
@@ -333,13 +336,86 @@ class PlanStackActions(PlannerTestCase):
     def test_pending_check_means_wait_do_nothing(self):
         self.assertEqual(self._plan(pr(checks={"build": check("pending")})), ())
 
+    def test_merged_pr_is_terminal_noop(self):
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (pr(number=6108, state="MERGED", labels=frozenset({"admin-bypass"})),)),
+            REQUIRED,
+            self._ledger(),
+            now_epoch=0,
+            open_pr_numbers=set(),
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "terminal-merged")
+
     def test_conflict_triggers_claude_repair(self):
         actions = self._plan(pr(merge_state_status="DIRTY"))
         self.assertEqual((actions[0].kind, actions[0].pr_number), ("repair_conflict", 1))
 
+    def test_repair_invalid_conflict_stops_retrying(self):
+        ledger = self._ledger()
+        ledger.record(
+            "repair-invalid",
+            6118,
+            HEAD,
+            "conflict",
+            1,
+            meta={"errors": ["requires a human to decide whether this stale duplicate stack is superseded"]},
+        )
+        snapshot = pr(
+            number=6118,
+            labels=frozenset({"admin-bypass"}),
+            merge_state_status="DIRTY",
+            mergeable="CONFLICTING",
+            latest_mergify=event(state="queued", head=""),
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            REQUIRED,
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={6118},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "blocked-needs-human")
+        blockers = plan.summary["prs"][0]["blockers"]
+        self.assertEqual(blockers[0]["kind"], "human_decision")
+        self.assertIn("stale duplicate stack", blockers[0]["detail"])
+
     def test_failed_check_triggers_repair(self):
         actions = self._plan(pr(checks={"build": check("failure")}))
         self.assertEqual((actions[0].kind, actions[0].key), ("repair_check", "build"))
+
+    def test_repair_invalid_bot_thread_suppresses_other_repairs_on_same_pr(self):
+        ledger = self._ledger()
+        ledger.record(
+            "repair-invalid",
+            6158,
+            HEAD,
+            "PRRT_kwDOSFkSDM6T97v9",
+            1,
+            meta={"errors": ['PR body Review Unit "routing" cannot ship with activation-surface files in the same PR. Split this into one Review Unit per PR.']},
+        )
+        snapshot = pr(
+            number=6158,
+            labels=frozenset({"admin-bypass"}),
+            checks={"build": check("failure")},
+            review_threads=(m.ReviewThread("PRRT_kwDOSFkSDM6T97v9", False, ("coderabbitai[bot]",)),),
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            REQUIRED,
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={6158},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "blocked-needs-human")
+        blockers = plan.summary["prs"][0]["blockers"]
+        self.assertEqual(blockers[0]["kind"], "human_decision")
+        self.assertEqual(blockers[1]["kind"], "failed_check")
 
     def test_mergify_dequeue_with_failing_check_repairs_first(self):
         # A Mergify dequeue naming a failing check outranks everything else.


### PR DESCRIPTION
## Summary

The live evidence repro now examines PRs #6118 and #6158, where exact repair-invalid stop comments later regressed into generic retry caps.

A new fake-gh repro seeds that conflict state and fails if the worker retries repair or loses the exact human-only reason.

The babysit loop now runs the new repro with the existing admin-requeue checks.

## Review Claim

The repro surface proves repair-invalid human blockers stay terminal and preserve their exact reason during later worker passes.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds and registers local repro scripts; it does not write to GitHub or mutate real PR branches.

## Slice Rationale

This proof slice follows the planner policy change because the new repro asserts the corrected terminal behavior.

## Non-goals

- No planner policy changes in this slice.
- No manual real-PR cleanup.
- No queue-rule changes.
- No UI, data migration, or workflow schema changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `PYTHONDONTWRITEBYTECODE=1 bash scripts/repro/repro-babysit-conflict-repair-invalid-stop.sh`
- [x] `PYTHONDONTWRITEBYTECODE=1 bash ./loop-driver.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 69e79e9ac`
- Post-revert steps: None
- Data migration? No

</details>
