### PR TITLE
[Orphan Repair Admin Bypass Race](2) Exclude admin-bypass PRs from orphan-repair cron

### DIFF
--- a/scripts/cron-pr-orphan-repair.sh
+++ b/scripts/cron-pr-orphan-repair.sh
@@ -41,7 +41,7 @@ else
 fi
 
 prs_json="$(gh_json pr list --repo "$TARGET_REPO" --author "$PR_AUTHOR" --state open \
-  --json number,title,url,isDraft,baseRefName,headRefName,headRefOid,mergeable,mergeStateStatus,statusCheckRollup,reviewDecision \
+  --json number,title,url,isDraft,baseRefName,headRefName,headRefOid,mergeable,mergeStateStatus,statusCheckRollup,reviewDecision,labels \
   --limit 100)" || {
   log_line "could not list PRs; exiting"
   exit 0
@@ -53,6 +53,11 @@ while IFS= read -r pr; do
   num="$(jq -r '.number' <<<"$pr")"
 
   if [ "$(jq -r '.isDraft' <<<"$pr")" = "true" ]; then
+    continue
+  fi
+
+  if jq -e '.labels[]? | select(.name == "admin-bypass")' <<<"$pr" >/dev/null; then
+    log_line "PR #$num: admin-bypass labeled; admin-bypass-land owns it"
     continue
   fi
 

--- a/scripts/repro/fixtures/fake-gh/scenarios/pr-orphan-admin-bypass.json
+++ b/scripts/repro/fixtures/fake-gh/scenarios/pr-orphan-admin-bypass.json
@@ -1,0 +1,23 @@
+{
+  "prs": [
+    {
+      "number": 6106,
+      "title": "Admin-bypass PR that admin-bypass-land already owns",
+      "url": "https://github.com/fake/repo/pull/6106",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "master",
+      "headRefName": "stack/6106",
+      "headRefOid": "1111111111111111111111111111111111111111",
+      "mergeStateStatus": "BLOCKED",
+      "mergeable": "MERGEABLE",
+      "reviewDecision": "",
+      "labels": ["admin-bypass"],
+      "reviewThreads": [],
+      "checks": {"quality / TypeScript Types": "FAILURE", "Lint": "SUCCESS"}
+    }
+  ],
+  "issue_comments": {
+    "6106": []
+  }
+}

--- a/scripts/repro/repro-pr-orphan-admin-bypass-race.sh
+++ b/scripts/repro/repro-pr-orphan-admin-bypass-race.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Battle-test: an admin-bypass-labeled PR must be left ENTIRELY to
+# admin-bypass-land (scripts/cron-pr-admin-bypass-land.sh); orphan-repair must
+# not also act on it, even when it's unmapped and has a real failing required
+# check.
+#
+# Fixture pr-orphan-admin-bypass.json (#6106): open, non-draft, unmapped
+# (review-gate stub resolves nothing for it), admin-bypass labeled,
+# mergeable/mergeStateStatus clean, one failing required check
+# ("quality / TypeScript Types"). Without the admin-bypass skip, orphan-repair
+# classifies the failing check as a blocker and submits a repair task — racing
+# scripts/mergify_admin_requeue.py, which independently detects the same
+# failing check via its own `--label admin-bypass` query and produces a
+# `repair_check` action (see test_failed_check_triggers_repair in
+# scripts/test_mergify_admin_requeue_plan.py). This repro asserts orphan-repair
+# skips it and defers to admin-bypass-land instead.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-orphan-admin-bypass.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+mkdir -p "$TMP/bin" "$TMP/state" "$TMP/home" "$TMP/plans"
+export FAKE_GH_STATE_DIR="$TMP/state"
+cp "$ROOT/scripts/repro/fixtures/fake-gh/scenarios/pr-orphan-admin-bypass.json" "$FAKE_GH_STATE_DIR/state.json"
+
+ln -s "$ROOT/scripts/repro/fixtures/fake-gh/bin/gh" "$TMP/bin/gh"
+NODE_LOG="$TMP/node-calls.log"; : > "$NODE_LOG"
+cat > "$TMP/bin/node" <<EOF
+#!/usr/bin/env bash
+printf 'node %s\n' "\$*" >> "$NODE_LOG"
+exit 0
+EOF
+chmod +x "$TMP/bin/node"
+
+# Review-gate stub: #6106 is unmapped everywhere (admin-bypass-land owns it by
+# label alone, not by workflow mapping).
+cat > "$TMP/review-gate.sh" <<'RG'
+#!/usr/bin/env bash
+printf '{}\n'
+RG
+chmod +x "$TMP/review-gate.sh"
+
+run_cron() {
+  PATH="$TMP/bin:$PATH" \
+  HOME="$TMP/home" \
+  INVOKER_GITHUB_TARGET_REPO="fake/repo" \
+  INVOKER_PR_CRON_AUTHOR="fake-bot" \
+  INVOKER_PR_CRON_LOCK="$TMP/crons.lock" \
+  INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh" \
+  INVOKER_PR_ORPHAN_STATE_FILE="$TMP/ledger.tsv" \
+  INVOKER_PR_ORPHAN_PLAN_DIR="$TMP/plans" \
+  INVOKER_PR_ORPHAN_MAX_ATTEMPTS=3 \
+  bash "$ROOT/scripts/cron-pr-orphan-repair.sh" 2>&1
+}
+
+out="$(run_cron)" || fail "tick exited non-zero" "$out"
+echo "$out" | grep -q "PR #6106: admin-bypass labeled; admin-bypass-land owns it" \
+  || fail "expected orphan-repair to skip the admin-bypass labeled PR and defer to admin-bypass-land" "$out"
+echo "$out" | grep -q "PR #6106: submitted repair task" \
+  && fail "orphan-repair must NOT submit a repair task for an admin-bypass labeled PR" "$out"
+
+runs="$(grep -c "exec -- run " "$NODE_LOG" || true)"
+[ "$runs" -eq 0 ] || fail "expected zero repair-task submissions for #6106, got $runs" "$(cat "$NODE_LOG")"
+
+plan="$TMP/plans/repair-pr-6106.yaml"
+[ -f "$plan" ] && fail "orphan-repair must not generate a plan file for an admin-bypass labeled PR" "$(cat "$plan")"
+
+echo "[repro] passed"

--- a/scripts/test-suites/required/28-pr-babysit-harness.sh
+++ b/scripts/test-suites/required/28-pr-babysit-harness.sh
@@ -10,3 +10,4 @@ bash scripts/repro/repro-babysit-conflict-cron.sh
 bash scripts/repro/repro-babysit-ci-cron.sh
 bash scripts/repro/repro-babysit-land-dryrun.sh
 bash scripts/repro/repro-pr-orphan-repair.sh
+bash scripts/repro/repro-pr-orphan-admin-bypass-race.sh


### PR DESCRIPTION
## Summary

`scripts/cron-pr-orphan-repair.sh` repairs any open, unmapped PR with a blocker, with no awareness of the `admin-bypass` label.

`scripts/cron-pr-admin-bypass-land.sh` separately owns every `admin-bypass`-labeled PR, regardless of workflow mapping, and its `repair_check` action already fixes failing required checks.

For an unmapped, admin-bypass-labeled PR with one failing check, both cron jobs independently detect it and submit their own repair work on their own 5-minute cadence, with no lock or handoff.

This change makes orphan-repair skip any PR carrying the `admin-bypass` label, so admin-bypass-land is the sole owner of that PR going forward.

## Review Claim

Skip `admin-bypass`-labeled PRs in orphan-repair's classify-and-repair loop, since admin-bypass-land already owns them unconditionally.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change only narrows orphan-repair's scope: it adds one early-continue guard before blocker classification, so a PR that would previously get a repair task now gets skipped instead when (and only when) it carries the `admin-bypass` label. No other PR's classification, ledger, or repair-plan output changes. `scripts/cron-pr-admin-bypass-land.sh` and `scripts/mergify_admin_requeue*.py` are untouched, so admin-bypass-land's own coverage of these PRs is unaffected.

## Slice Rationale

Stacked on the proof slice (#6495), which adds the fixture and repro demonstrating the race. This slice is the fix itself plus wiring the now-passing repro into the required PR-babysit harness, kept separate from the proof slice per this repo's diff-atomicity policy (policy-kind script changes and proof-kind repro changes can't ship in the same PR).

## Non-goals

Does not change `scripts/cron-pr-admin-bypass-land.sh` or `scripts/mergify_admin_requeue*.py`. Does not add draft-PR exclusion to `mergify_admin_requeue.py`'s candidate query (it already classifies drafts as a separate downstream blocker, so there's no symmetry gap to fix there). Does not change orphan-repair's handling of any other blocker type (conflict, failing checks, changes-requested) for non-admin-bypass PRs. Does not add or edit any file under `scripts/repro/` (that landed in #6495).

## Test Plan

<details>
<summary>Test Plan</summary>

With this fix applied on top of the proof slice's fixture and repro (`scripts/repro/fixtures/fake-gh/scenarios/pr-orphan-admin-bypass.json`, `scripts/repro/repro-pr-orphan-admin-bypass-race.sh`, PR #6106: open, non-draft, unmapped, `admin-bypass` labeled, mergeable, one failing required check `quality / TypeScript Types`):

- [x] `bash scripts/repro/repro-pr-orphan-admin-bypass-race.sh`, which failed on the proof slice alone (see #6495's Test Plan), now passes:
  ```
  [repro] passed
  EXIT: 0
  ```
- [x] `bash scripts/repro/repro-pr-orphan-repair.sh` (existing mapped/draft/conflict/dedup/attempt-cap/dry-run scenarios, unmodified) still passes:
  ```
  [repro] passed
  EXIT: 0
  ```
- [x] `bash scripts/test-suites/required/12-mergify-admin-requeue.sh` (admin-bypass-land's own Python suite, untouched by this change) still passes: `Ran 48 tests in 0.081s` / `OK`, plus all constituent repro scripts print `[repro] passed`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
