### PR TITLE
[Orphan Repair Admin Bypass Race](1) Repro orphan-repair racing admin-bypass-land

### DIFF
--- a/scripts/repro/fixtures/fake-gh/scenarios/pr-orphan-admin-bypass.json
+++ b/scripts/repro/fixtures/fake-gh/scenarios/pr-orphan-admin-bypass.json
@@ -1,0 +1,23 @@
+{
+  "prs": [
+    {
+      "number": 6106,
+      "title": "Admin-bypass PR that admin-bypass-land already owns",
+      "url": "https://github.com/fake/repo/pull/6106",
+      "state": "OPEN",
+      "isDraft": false,
+      "baseRefName": "master",
+      "headRefName": "stack/6106",
+      "headRefOid": "1111111111111111111111111111111111111111",
+      "mergeStateStatus": "BLOCKED",
+      "mergeable": "MERGEABLE",
+      "reviewDecision": "",
+      "labels": ["admin-bypass"],
+      "reviewThreads": [],
+      "checks": {"quality / TypeScript Types": "FAILURE", "Lint": "SUCCESS"}
+    }
+  ],
+  "issue_comments": {
+    "6106": []
+  }
+}

--- a/scripts/repro/repro-pr-orphan-admin-bypass-race.sh
+++ b/scripts/repro/repro-pr-orphan-admin-bypass-race.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Battle-test: an admin-bypass-labeled PR must be left ENTIRELY to
+# admin-bypass-land (scripts/cron-pr-admin-bypass-land.sh); orphan-repair must
+# not also act on it, even when it's unmapped and has a real failing required
+# check.
+#
+# Fixture pr-orphan-admin-bypass.json (#6106): open, non-draft, unmapped
+# (review-gate stub resolves nothing for it), admin-bypass labeled,
+# mergeable/mergeStateStatus clean, one failing required check
+# ("quality / TypeScript Types"). Without the admin-bypass skip, orphan-repair
+# classifies the failing check as a blocker and submits a repair task — racing
+# scripts/mergify_admin_requeue.py, which independently detects the same
+# failing check via its own `--label admin-bypass` query and produces a
+# `repair_check` action (see test_failed_check_triggers_repair in
+# scripts/test_mergify_admin_requeue_plan.py). This repro asserts orphan-repair
+# skips it and defers to admin-bypass-land instead.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-orphan-admin-bypass.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" && echo "$2"; exit 1; }
+
+mkdir -p "$TMP/bin" "$TMP/state" "$TMP/home" "$TMP/plans"
+export FAKE_GH_STATE_DIR="$TMP/state"
+cp "$ROOT/scripts/repro/fixtures/fake-gh/scenarios/pr-orphan-admin-bypass.json" "$FAKE_GH_STATE_DIR/state.json"
+
+ln -s "$ROOT/scripts/repro/fixtures/fake-gh/bin/gh" "$TMP/bin/gh"
+NODE_LOG="$TMP/node-calls.log"; : > "$NODE_LOG"
+cat > "$TMP/bin/node" <<EOF
+#!/usr/bin/env bash
+printf 'node %s\n' "\$*" >> "$NODE_LOG"
+exit 0
+EOF
+chmod +x "$TMP/bin/node"
+
+# Review-gate stub: #6106 is unmapped everywhere (admin-bypass-land owns it by
+# label alone, not by workflow mapping).
+cat > "$TMP/review-gate.sh" <<'RG'
+#!/usr/bin/env bash
+printf '{}\n'
+RG
+chmod +x "$TMP/review-gate.sh"
+
+run_cron() {
+  PATH="$TMP/bin:$PATH" \
+  HOME="$TMP/home" \
+  INVOKER_GITHUB_TARGET_REPO="fake/repo" \
+  INVOKER_PR_CRON_AUTHOR="fake-bot" \
+  INVOKER_PR_CRON_LOCK="$TMP/crons.lock" \
+  INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh" \
+  INVOKER_PR_ORPHAN_STATE_FILE="$TMP/ledger.tsv" \
+  INVOKER_PR_ORPHAN_PLAN_DIR="$TMP/plans" \
+  INVOKER_PR_ORPHAN_MAX_ATTEMPTS=3 \
+  bash "$ROOT/scripts/cron-pr-orphan-repair.sh" 2>&1
+}
+
+out="$(run_cron)" || fail "tick exited non-zero" "$out"
+echo "$out" | grep -q "PR #6106: admin-bypass labeled; admin-bypass-land owns it" \
+  || fail "expected orphan-repair to skip the admin-bypass labeled PR and defer to admin-bypass-land" "$out"
+echo "$out" | grep -q "PR #6106: submitted repair task" \
+  && fail "orphan-repair must NOT submit a repair task for an admin-bypass labeled PR" "$out"
+
+runs="$(grep -c "exec -- run " "$NODE_LOG" || true)"
+[ "$runs" -eq 0 ] || fail "expected zero repair-task submissions for #6106, got $runs" "$(cat "$NODE_LOG")"
+
+plan="$TMP/plans/repair-pr-6106.yaml"
+[ -f "$plan" ] && fail "orphan-repair must not generate a plan file for an admin-bypass labeled PR" "$(cat "$plan")"
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

`scripts/cron-pr-orphan-repair.sh` repairs any open, unmapped PR with a blocker, with no awareness of the `admin-bypass` label.

`scripts/cron-pr-admin-bypass-land.sh` separately owns every `admin-bypass`-labeled PR unconditionally, and its `repair_check` action already fixes failing required checks (`test_failed_check_triggers_repair` in `scripts/test_mergify_admin_requeue_plan.py`).

For an unmapped, admin-bypass-labeled PR with a real failing check, both cron jobs currently detect it independently and race to submit repair work, with no lock or handoff.

This adds a fixture and repro script proving that race today. The next slice in this stack makes orphan-repair label-aware to fix it.

## Review Claim

Add a fake-gh fixture and repro script asserting orphan-repair defers admin-bypass-labeled PRs to admin-bypass-land; run today it fails, proving the race.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds a new fixture file and a new, unregistered repro script under `scripts/repro/`. It does not touch any production cron script or the required test-suite entrypoint, so it cannot change any cron job's runtime behavior or CI gating on its own.

## Slice Rationale

Evidence before change: this proves the race exists before the fix slice narrows orphan-repair's scope, so the fix is reviewed against a concrete, reproducible failure rather than a description of one.

## Non-goals

Does not change `scripts/cron-pr-orphan-repair.sh`, `scripts/cron-pr-admin-bypass-land.sh`, or `scripts/mergify_admin_requeue*.py`. Does not register this repro in `scripts/test-suites/required/28-pr-babysit-harness.sh` yet (that lands in the next slice, once the assertions match the fixed behavior).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-pr-orphan-admin-bypass-race.sh` fails on this slice alone, proving the bug (real output, PR #6106: open, non-draft, unmapped, `admin-bypass` labeled, mergeable, one failing required check `quality / TypeScript Types`):
  ```
  [repro] FAIL: expected orphan-repair to skip the admin-bypass labeled PR and defer to admin-bypass-land
  ----- output -----
  2026-07-28T18:05:36Z PR #6106: submitted repair task (5035b4151025f5fe; blockers: failed_checks: quality / TypeScript Types; )
  2026-07-28T18:05:36Z orphan-repair scan complete; submitted 1 repair task(s)
  EXIT CODE: 1
  ```
- [x] `scripts/test_mergify_admin_requeue_plan.py::test_failed_check_triggers_repair` shows the other half of the race: `mergify_admin_requeue.py` independently produces a `repair_check` action for the same shape of PR via its own `--label admin-bypass` query.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
