### PR TITLE
[Daily Full Release Cuts](1) Document daily prerelease cuts in local macOS release build guide

### DIFF
--- a/docs/local-macos-release-build.md
+++ b/docs/local-macos-release-build.md
@@ -105,3 +105,23 @@ Credentials: `~/.invoker/.slack-owner.env` (see `invoker-cli setup slack` and
 `packages/slack-manager/deploy/install.sh`.
 
 For a public release, prefer the tagged GitHub Release workflow so users get the standard release assets and checksums.
+
+## Daily prereleases
+
+GitHub Actions also cuts a **full** multi-platform prerelease once per day from
+`master` (workflow `Daily release`, tag `daily-YYYYMMDD` in UTC). Daily cuts:
+
+- Build the same CLI, Slack, and desktop asset set as a tagged `v*` release
+- Publish as a GitHub **prerelease** (so `/releases/latest` and default
+  `scripts/install.sh` installs stay on the latest stable `v*` release)
+- Do **not** bump package versions, roll `CHANGELOG.md`, or publish npm
+
+Install a specific daily cut:
+
+```bash
+bash scripts/install.sh --version daily-20260728
+```
+
+Use this local macOS script when you need an unsigned handoff build before the
+next daily or tagged cut exists. Real versioned releases still use
+`node scripts/bump-version.mjs <semver>`, commit, and push a `v*` tag.


### PR DESCRIPTION
## Summary

Documents the new "Daily release" GitHub Actions workflow in the existing local macOS release build guide. It explains that a full multi-platform prerelease now cuts from `master` once a day.

It also covers how a daily prerelease differs from a tagged release: no version bump, no CHANGELOG update, no npm publish, plus how to install a daily cut by name.

## Review Claim

Approve the added section describing the new daily prerelease cadence in the existing build guide.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This only changes `docs/local-macos-release-build.md`; nothing here executes or is imported anywhere, so there is no behavior to break.

## Slice Rationale

This ships as its own PR because the repository's PR checker requires documentation changes to stay in their own slice, separate from the companion GitHub Actions workflow change that introduces the feature being documented. The workflow PR is stacked on top of this one so both stay green together.

## Non-goals

- Does not add or change any workflow, script, or CI behavior — that lives in the companion implementation PR.
- Does not change how the existing tagged `v*` release process is documented above this section.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `grep -q 'daily-YYYYMMDD' docs/local-macos-release-build.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f8b5bfd57`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for daily prereleases generated from the master branch.
  * Documented included assets, publishing behavior, and installation commands for specific daily builds.
  * Clarified the distinction between local macOS unsigned builds and versioned releases.
  * Documented that daily prereleases do not update package versions, changelogs, or npm releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->