### PR TITLE
Fix standalone owner start-ready routing

### DIFF
--- a/packages/app/e2e/start-ready-daemon-owner.spec.ts
+++ b/packages/app/e2e/start-ready-daemon-owner.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect, TEST_PLAN, loadPlan } from './fixtures/electron-app';
+
+test.use({ guiOwnerMode: 'auto' });
+
+test('startReady delegates to the daemon owner', async ({ page }) => {
+  const runtimeStatus = await page.evaluate(async () => window.invoker.getRuntimeStatus());
+  expect(runtimeStatus).toEqual({
+    ownerMode: false,
+    readOnly: false,
+    mode: 'daemon-owner',
+  });
+
+  await loadPlan(page, TEST_PLAN);
+
+  const result = await page.evaluate(async () => {
+    const response = await window.invoker.startReady();
+    return {
+      dryRun: response.dryRun,
+      readyTaskIds: response.preview.readyTaskIds,
+      started: response.started.map((task) => ({ id: task.id, status: task.status })),
+    };
+  });
+
+  expect(result.dryRun).toBe(false);
+  expect(result.readyTaskIds.some((taskId) => taskId.endsWith('task-alpha'))).toBe(true);
+  expect(result.started).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        id: expect.stringMatching(/task-alpha$/),
+      }),
+    ]),
+  );
+
+  await page.waitForFunction(async () => {
+    const tasksResult = await window.invoker.getTasks();
+    const tasks = Array.isArray(tasksResult) ? tasksResult : tasksResult.tasks;
+    return tasks.some((task) => task.id.endsWith('task-alpha') && task.status === 'running');
+  }, null, { timeout: 10_000 });
+});

--- a/packages/app/src/__tests__/gui-mutation-translation.test.ts
+++ b/packages/app/src/__tests__/gui-mutation-translation.test.ts
@@ -24,6 +24,14 @@ function getStandaloneClassifierSource(): string {
   return mainSource.slice(start, end);
 }
 
+function getStandaloneGuiMutationSource(): string {
+  const start = mainSource.indexOf('const executeStandaloneGuiMutation = async');
+  const end = mainSource.indexOf('      // In standalone owner mode, serve delegated requests from peer headless processes.', start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return mainSource.slice(start, end);
+}
+
 function getPerformDeleteWorkflowSource(): string {
   const start = guiMutationHandlersSource.indexOf('async function performDeleteWorkflow');
   const end = guiMutationHandlersSource.indexOf('  async function performDetachWorkflow', start);
@@ -97,6 +105,13 @@ describe('GUI mutation translation', () => {
     const classifierSource = getStandaloneClassifierSource();
     expect(classifierSource).toMatch(
       /case 'delete':\s*case 'delete-workflow':\s*case 'detach-workflow':\s*return \{ workflowId: arg0 === undefined \? undefined : String\(arg0\), priority: 'high' \};/,
+    );
+  });
+
+  it('handles start-ready in the standalone owner GUI mutation switch', () => {
+    const standaloneGuiMutationSource = getStandaloneGuiMutationSource();
+    expect(standaloneGuiMutationSource).toMatch(
+      /case 'invoker:start-ready':\s*\{[\s\S]*workflowMutationDispatcher\.get\('invoker:start-ready'\)[\s\S]*return handler\(payload\.args\[0\] as StartReadyRequest \| undefined\);/,
     );
   });
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1245,6 +1245,13 @@ function startHeadlessMode(): void {
             logger.info(`standalone startExecution returned ${started.length} tasks: [${started.map(t => t.id).join(', ')}]`, { module: 'ipc-delegate' });
             return started;
           }
+          case 'invoker:start-ready': {
+            const handler = workflowMutationDispatcher.get('invoker:start-ready');
+            if (!handler) {
+              throw new Error('No workflow mutation dispatcher registered for invoker:start-ready');
+            }
+            return handler(payload.args[0] as StartReadyRequest | undefined);
+          }
           case 'invoker:stop': {
             logger.info('stop — destroying all daemon executors', { module: 'ipc-delegate' });
             const failInFlightTasks = (): void => {


### PR DESCRIPTION
## Summary

Daemon-owner windows could send `invoker:start-ready` to the standalone owner, then hit the owner-side default error branch.

This routes that mutation through the existing start-ready handler instead.

The slice also adds a routing guard test and an Electron regression test for the daemon-owner path.

## Review Claim

Standalone-owner `startReady()` calls now use the existing owner handler instead of throwing `Unsupported internal mutation for standalone owner`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the standalone-owner `invoker:start-ready` routing branch changes. Local-owner start-ready execution, other GUI mutations, and launch-dispatch behavior stay on their existing paths.

## Slice Rationale

The bug was a missing owner-side route. The fix, routing guard, and daemon-owner regression test stay together because they cover the same path.

## Non-goals

- No change to local-owner `startReady()` behavior.
- No change to start-ready scheduling semantics after a task is accepted.
- No broader standalone-owner routing cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/gui-mutation-translation.test.ts`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/start-ready-daemon-owner.spec.ts`
- [x] `CAPTURE_VIDEO=1 pnpm --filter @invoker/app exec playwright test e2e/start-ready-daemon-owner.spec.ts`

</details>

## Visual Proof

Animated walkthrough showing `Start ready work`, the `Started 1 task` toast, and `task-alpha` selected with `queued` status instead of a remote-method error.

![Start-ready daemon-owner walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-41122a/start-ready-daemon-owner-proof.mp4)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
