### PR TITLE
[Planning tmux output survives Home/Planning switches](2) Preserve hidden tmux output snapshots

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -129,19 +129,22 @@ function planningTerminalSessionFromOutputEvent(
   event: TerminalOutputEvent,
   outputSnapshot: string,
 ): TerminalSessionDescriptor {
+  const existingTerminal = session.terminalSession?.sessionId === event.sessionId
+    ? session.terminalSession
+    : null;
   return {
-    sessionId: session.terminalSession?.sessionId ?? session.terminalSessionId ?? event.sessionId,
-    taskId: session.terminalSession?.taskId ?? event.taskId,
+    sessionId: event.sessionId,
+    taskId: event.taskId,
     kind: 'planning',
-    planningSessionId: session.id,
-    status: session.terminalSession?.status ?? session.terminalStatus ?? 'running',
-    exitCode: session.terminalSession?.exitCode ?? session.terminalExitCode,
-    cwd: session.terminalSession?.cwd,
-    command: session.terminalSession?.command,
-    args: session.terminalSession?.args,
-    mode: session.terminalSession?.mode ?? 'spawn',
-    attached: session.terminalSession?.attached ?? false,
-    createdAt: session.terminalSession?.createdAt ?? session.terminalUpdatedAt ?? session.updatedAt,
+    planningSessionId: event.planningSessionId ?? session.id,
+    status: existingTerminal?.status ?? 'running',
+    exitCode: existingTerminal?.exitCode,
+    cwd: existingTerminal?.cwd,
+    command: existingTerminal?.command,
+    args: existingTerminal?.args,
+    mode: existingTerminal?.mode ?? 'spawn',
+    attached: existingTerminal?.attached ?? false,
+    createdAt: existingTerminal?.createdAt ?? session.terminalUpdatedAt ?? session.updatedAt,
     outputSnapshot,
   };
 }
@@ -1341,21 +1344,27 @@ export function App() {
       if (event.kind !== 'planning' || typeof event.data !== 'string' || event.data.length === 0) return;
       setPlanningSessions((prev) =>
         prev.map((session) => {
-          const matchesSession =
-            session.terminalSession?.sessionId === event.sessionId
-            || session.terminalSessionId === event.sessionId
-            || (event.planningSessionId !== undefined && session.id === event.planningSessionId);
+          const matchesSession = event.planningSessionId
+            ? session.id === event.planningSessionId
+            : session.terminalSession?.sessionId === event.sessionId
+              || session.terminalSessionId === event.sessionId;
           if (!matchesSession) return session;
 
           const outputSnapshot = appendPlanningTerminalSnapshot(
             session.terminalSession?.outputSnapshot ?? session.terminalOutputSnapshot,
             event.data,
           );
+          const existingTerminal = session.terminalSession?.sessionId === event.sessionId
+            ? session.terminalSession
+            : null;
+          const terminalStatus = existingTerminal?.status ?? 'running';
           return {
             ...session,
             terminalMode: 'tmux',
-            terminalSessionId: session.terminalSession?.sessionId ?? session.terminalSessionId ?? event.sessionId,
-            terminalStatus: session.terminalSession?.status ?? session.terminalStatus ?? 'running',
+            terminalSessionId: event.sessionId,
+            terminalStatus,
+            terminalExitCode: terminalStatus === 'exited' ? existingTerminal?.exitCode ?? session.terminalExitCode : undefined,
+            terminalUpdatedAt: new Date().toISOString(),
             terminalOutputSnapshot: outputSnapshot,
             terminalSession: planningTerminalSessionFromOutputEvent(session, event, outputSnapshot),
           };


### PR DESCRIPTION
## Summary

Planning tmux output survives Home/Planning switches.

The renderer now keeps hidden planning tmux output attached to the live session that produced each output event.

When Home remounts after visiting Planning, it restores the same tmux session with the hidden output instead of blanking it or opening another pane.

## Review Claim

Preserve planning tmux scrollback across Home/Planning surface switches by caching hidden output on the live session descriptor that emitted it.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change stays inside the renderer planning-output path in `packages/ui/src/App.tsx`, and the focused regression plus Electron proof exercise the exact remount flow.

## Slice Rationale

This slice follows the proof slice so reviewers can approve the renderer state change against a concrete, already-demonstrated Home/Planning remount regression.

## Non-goals

- No backend tmux lifecycle or IPC contract changes.
- No chat transcript persistence changes.
- No changes to non-planning terminal panes.

## Architecture

### Before

```mermaid
graph TD
    A["Planning output event arrives"] --> B["planningSessionId can select the planning session even when blank"]
    B --> C["Append cached snapshot on the matched session"]
    C --> D["Keep older terminal descriptor ids when present"]
    D --> E["Home remount can miss hidden output or remount the wrong snapshot"]
```

### After

```mermaid
graph TD
    A["Planning output event arrives"] --> B["Only non-blank planningSessionId values select the planning session"]
    B --> C["Fallback matching uses the output event session id"]
    C --> D["Cache the snapshot on the live terminal descriptor from that event"]
    D --> E["Home remount restores the same tmux session with hidden output intact"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- --run planning-terminal-tmux.test.tsx`
- [x] `cd packages/app && CAPTURE_MODE=tmuxproof CAPTURE_VIDEO=1 npx playwright test e2e/visual-proof.spec.ts --grep "planning tmux history"`

</details>

## Visual Proof

These frames show the user-visible behavior restored by this slice.

Frame 1: Home surface open, tmux pane connected, sidebar highlight on Home, and the pre-switch marker visible: ![Frame 1: Home surface, tmux pane open](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-d70c48/01-planning-tmux-history-step-1-visible-before-switch.png)

Frame 2: Planning surface selected, sidebar highlight moved, Plan graph visible, and the tmux pane unmounted while output continues arriving: ![Frame 2: Planning surface, tmux pane hidden](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-d70c48/02-planning-tmux-history-step-2-hidden-on-plan-graph.png)

Frame 3: Home selected again, the same tmux session remounted, and the hidden output restored beside the earlier marker: ![Frame 3: Home surface restored, hidden output visible](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-d70c48/03-planning-tmux-history-restored.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7055293fc`
- Post-revert steps: None
- Data migration? No

</details>
