### PR TITLE
[Planning Chat Send Timeout](3) Fix planning-chat-send transport timeout on delegated owner requests

### DIFF
--- a/packages/app/e2e/planning-chat-send-long-deadline.spec.ts
+++ b/packages/app/e2e/planning-chat-send-long-deadline.spec.ts
@@ -1,0 +1,60 @@
+import { stringify as yamlStringify } from 'yaml';
+import { test, expect, E2E_REPO_URL } from './fixtures/electron-app';
+
+test.use({ guiOwnerMode: 'auto' });
+
+const PLAN_YAML = yamlStringify({
+  name: 'Long Deadline Proof Plan',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    {
+      id: 'capture-proof',
+      description: 'Capture the long-deadline proof',
+      command: 'echo long-deadline-proof',
+      dependencies: [],
+    },
+  ],
+});
+
+test('planning-chat-send survives a planner reply slower than the old 30s transport deadline', async ({ page }) => {
+  // This window is a delegate, not the owner: planningChatSend goes out over
+  // the real IPC socket transport (headless.gui-mutation), the exact path
+  // that used to hard-timeout at 30s regardless of how long the planner took.
+  const runtimeStatus = await page.evaluate(async () => window.invoker.getRuntimeStatus());
+  expect(runtimeStatus.mode).toBe('daemon-owner');
+
+  const created = await page.evaluate(async () => window.invoker.planningChatCreate());
+  expect(created.ok).toBe(true);
+  const sessionId = created.ok ? created.session.id : undefined;
+  expect(sessionId).toBeTruthy();
+
+  await page.evaluate(async (planYaml) => {
+    await window.invoker.setTestPlanningChatResponse({
+      planYaml,
+      planName: 'Long Deadline Proof Plan',
+      reply: 'Investigated why PR #6459 was not queued by the admin-bypass land worker.',
+      // Longer than the old hardcoded 30s transport deadline.
+      delayMs: 32_000,
+    });
+  }, PLAN_YAML);
+
+  const startedAt = Date.now();
+  const result = await page.evaluate(async (sid) => {
+    return window.invoker.planningChatSend({
+      sessionId: sid,
+      message: 'why was PR #6459 not queued by our PR Admin Bypass land worker?',
+      presetKey: 'codex',
+    });
+  }, sessionId);
+  const elapsedMs = Date.now() - startedAt;
+
+  expect(result.ok).toBe(true);
+  // Proves the send was not killed by the transport deadline: it only
+  // resolved after actually waiting out the artificial 32s planner delay.
+  expect(elapsedMs).toBeGreaterThanOrEqual(32_000);
+
+  await page.evaluate(async () => {
+    await window.invoker.setTestPlanningChatResponse(null);
+  });
+});

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1001,6 +1001,8 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
           channel: 'headless.exec',
           request: { args: ['replace-task', String(arg0), JSON.stringify(Array.isArray(arg1) ? arg1 : [])], noTrack: true },
         };
+      case 'invoker:set-test-planning-chat-response':
+        return { channel: 'headless.gui-mutation', request: payload };
       default:
         return null;
     }
@@ -1272,7 +1274,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   // given message. The error variant lets visual-proof specs render the
   // exhausted-retry error path without spawning a real planner subprocess.
   let testPlanningChatResponse:
-    | { planYaml: string; planName: string; reply?: string }
+    | { planYaml: string; planName: string; reply?: string; delayMs?: number }
     | { throwError: string }
     | null = null;
 
@@ -1312,6 +1314,9 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       ? async (): Promise<string> => {
         if ('throwError' in planningChatResponseOverride) {
           throw new Error(planningChatResponseOverride.throwError);
+        }
+        if (planningChatResponseOverride.delayMs) {
+          await new Promise((resolve) => setTimeout(resolve, planningChatResponseOverride.delayMs));
         }
         return `${planningChatResponseOverride.reply ?? 'Draft plan ready.'}\n\n\`\`\`yaml\n${planningChatResponseOverride.planYaml}\n\`\`\``;
       }
@@ -1399,16 +1404,13 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
         testPlanFromGoalResponse = response;
       },
     );
-    ipcMain.handle(
+    registerGuiMutationHandler(
       'invoker:set-test-planning-chat-response',
-      async (
-        _event,
-        response:
-          | { planYaml: string; planName: string; reply?: string }
+      async (responseArg: unknown) => {
+        testPlanningChatResponse = responseArg as
+          | { planYaml: string; planName: string; reply?: string; delayMs?: number }
           | { throwError: string }
-          | null,
-      ) => {
-        testPlanningChatResponse = response;
+          | null;
       },
     );
     registerGuiMutationHandler('invoker:seed-main-process-hitch-fixture', async () => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1145,8 +1145,19 @@ function startHeadlessMode(): void {
         planningSessionStore: readOnlyMode ? undefined : persistence,
       });
 
+      let testPlanningChatResponse:
+        | { planYaml: string; planName: string; reply?: string; delayMs?: number }
+        | { throwError: string }
+        | null = null;
+
       const executeStandaloneGuiMutation = async (payload: GuiMutationPayload): Promise<unknown> => {
         switch (payload.channel) {
+          case 'invoker:set-test-planning-chat-response': {
+            if (process.env.NODE_ENV === 'test') {
+              testPlanningChatResponse = payload.args[0] as typeof testPlanningChatResponse;
+            }
+            return undefined;
+          }
           case 'invoker:clear': {
             logger.info('clear — stopping all tasks and resetting daemon DAG', { module: 'ipc-delegate' });
             await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: undefined });
@@ -1193,6 +1204,18 @@ function startHeadlessMode(): void {
             return listPlanningChatSessions({ sessions: planningChatSessions });
           }
           case 'invoker:planning-chat-send': {
+            const planningChatResponseOverride = process.env.NODE_ENV === 'test' ? testPlanningChatResponse : null;
+            const plannerReplyOverride = planningChatResponseOverride
+              ? async (): Promise<string> => {
+                if ('throwError' in planningChatResponseOverride) {
+                  throw new Error(planningChatResponseOverride.throwError);
+                }
+                if (planningChatResponseOverride.delayMs) {
+                  await new Promise((resolve) => setTimeout(resolve, planningChatResponseOverride.delayMs));
+                }
+                return `${planningChatResponseOverride.reply ?? 'Draft plan ready.'}\n\n\`\`\`yaml\n${planningChatResponseOverride.planYaml}\n\`\`\``;
+              }
+              : undefined;
             return sendPlanningChatMessage(payload.args[0] as InAppPlanningChatRequest, {
               config: invokerConfig,
               workingDir: repoRoot,
@@ -1202,6 +1225,7 @@ function startHeadlessMode(): void {
               loadGeneratedPlan,
               conversationRepo: planningConversationRepo,
               planningSessionStore: readOnlyMode ? undefined : persistence,
+              plannerReplyOverride,
             });
           }
           case 'invoker:planning-chat-submit': {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1345,7 +1345,7 @@ export const IpcTestOnlyChannels = {
   'invoker:set-test-planning-chat-response': {} as {
     request: [
       response:
-        | { planYaml: string; planName: string; reply?: string }
+        | { planYaml: string; planName: string; reply?: string; delayMs?: number }
         | { throwError: string }
         | null,
     ];

--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -400,6 +400,38 @@ describe('IpcBus', () => {
     expect(result).toBe(42);
   });
 
+  it('REGRESSION: a slow invoker:planning-chat-send delegated over headless.gui-mutation is killed by the default deadline instead of getting the long-deadline protection headless.exec gets', async () => {
+    const sock = tempSocketPath();
+
+    const server = new IpcBus(sock, { requestDeadlineMs: 50 });
+    buses.push(server);
+    await server.ready();
+
+    // Simulates the planner subprocess still working on an investigative reply
+    // (e.g. "why wasn't PR #6459 queued by the admin-bypass land worker?") past
+    // the transport's default deadline.
+    server.onRequest('headless.gui-mutation', () => new Promise(() => {}));
+
+    const client = new IpcBus(sock, { requestDeadlineMs: 50 });
+    buses.push(client);
+    await client.ready();
+    await sleep(20);
+
+    const pending = client.request('headless.gui-mutation', {
+      channel: 'invoker:planning-chat-send',
+      args: [{ sessionId: 'session-1', message: 'why was PR #6459 not queued by the admin-bypass land worker?' }],
+    });
+
+    const stillPending = Symbol('still-pending');
+    const winner = await Promise.race([pending, sleep(300).then(() => stillPending)]);
+
+    // headless.exec is on LONG_REQUEST_DEADLINE_CHANNELS and survives a slow owner
+    // reply; headless.gui-mutation (which wraps invoker:planning-chat-send and
+    // invoker:plan-from-goal) is not on that list, so it should behave the same
+    // way but currently does not.
+    expect(winner).toBe(stillPending);
+  });
+
   it('disconnect rejects with DISCONNECTED, not REQUEST_TIMEOUT', async () => {
     const sock = tempSocketPath();
 

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -241,6 +241,7 @@ export const DEFAULT_SOCKET_PATH = resolveDefaultSocketPath();
  *  caller deadline so the responder is less likely to finish after the requester has given up. */
 const LONG_REQUEST_DEADLINE_CHANNELS = new Set([
   'invoker:plan-from-goal',
+  'invoker:planning-chat-send',
   // start-ready --recreate-all and other bulk mutations run inline on the owner.
   'headless.exec',
 ]);
@@ -661,7 +662,13 @@ export class IpcBus implements MessageBus {
     const env: ReqEnvelope = { kind: 'req', channel, body: message, reqId };
 
     return new Promise<Res>((resolve, reject) => {
-      const effectiveDeadlineMs = LONG_REQUEST_DEADLINE_CHANNELS.has(channel)
+      // Generic wrapper channels (e.g. headless.gui-mutation) carry the real
+      // operation name inside the message body, so a long-running operation
+      // delegated through one must be recognized there too.
+      const innerChannel = (message as { channel?: unknown } | null)?.channel;
+      const isLongRunning = LONG_REQUEST_DEADLINE_CHANNELS.has(channel)
+        || (typeof innerChannel === 'string' && LONG_REQUEST_DEADLINE_CHANNELS.has(innerChannel));
+      const effectiveDeadlineMs = isLongRunning
         ? Math.max(this.requestDeadlineMs, LONG_REQUEST_DEADLINE_MS)
         : this.requestDeadlineMs;
       const timer = setTimeout(() => {


### PR DESCRIPTION
## Summary

Sending a planning chat message could fail with a transport timeout error, even though the planner was still working on a valid reply.

This happened whenever the app window was not the daemon owner, so the send got delegated over a socket to a separate owner process.

The transport gives most requests 30 seconds, with a short allowlist of operations that get much longer. That allowlist only checked the outer wrapper channel name, never the real operation name carried inside the message.

Every planner-invoking call goes out under the same wrapper channel. The allowlist never matched, so it got killed at 30 seconds no matter how long the planner actually needed.

The fix adds `invoker:planning-chat-send` to the allowlist and checks the wrapped inner channel too, so it gets the same long-deadline protection two other operations already had.

## Review Claim

The transport no longer kills a delegated `invoker:planning-chat-send` request at 30 seconds when the planner is still legitimately working on a reply.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change only widens which requests are exempt from the default 30s deadline; it does not change any response payload, persistence behavior, or the deadline value itself (still 2 hours, unchanged). Every other channel's timeout behavior is untouched.

## Slice Rationale

Depends on the two prior slices in this stack, which added the `delayMs` test field and fixed the test hook's delegation so this fix could be proven end-to-end. This slice bundles the actual fix with its regression proof (unit test) and end-to-end proof (Playwright spec against the real daemon-owner delegation path), since they are one review claim.

## Non-goals

Does not change the 30s default deadline for any other channel.

Does not add per-call deadline configuration — reuses the existing allowlist mechanism.

Does not touch the unrelated `invoker:start-ready` work already on `master`.

## Architecture

### Before

```mermaid
graph TD
    A["renderer: window.invoker.planningChatSend()"] --> B["request('headless.gui-mutation', {channel: 'invoker:planning-chat-send'})"]
    B --> C{"is outer channel name long-running?"}
    C -->|"never matches: outer channel is always headless.gui-mutation"| D["30s default deadline"]
```

### After

```mermaid
graph TD
    A["renderer: window.invoker.planningChatSend()"] --> B["request('headless.gui-mutation', {channel: 'invoker:planning-chat-send'})"]
    B --> C{"is outer OR inner channel long-running?"}
    C -->|"inner channel matches invoker:planning-chat-send"| E["2h long-request deadline"]
```

## Visual Proof

Before — sending a message that takes the planner 32s to answer shows the real production error, in the planner's own words: "Error invoking remote method 'invoker:planning-chat-send': TransportError: Request on channel "headless.gui-mutation" timed out after 30000ms" and "Planning stopped. Try again when ready."

![before: waiting then error banner](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-7e1151/planning-chat-send-before.webm)

After — the same 32s reply now completes normally instead of erroring at 30s:

![after: waiting then successful reply](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-7e1151/planning-chat-send-after.webm)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/transport && pnpm test` — 47/47 pass, including the new regression test asserting a slow `invoker:planning-chat-send` delegated over `headless.gui-mutation` is not killed by the default deadline
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/gui-mutation-translation.test.ts src/__tests__/in-app-planner.test.ts` — 65/65 pass
- [x] `cd packages/app && pnpm exec playwright test e2e/planning-chat-send-long-deadline.spec.ts` — passes; drives a real daemon-owner delegation topology with a 32s artificial planner delay and confirms the send resolves instead of timing out. Verified this test fails with the pre-fix transport code (`TransportError: Request on channel "headless.gui-mutation" timed out after 30000ms`) and passes with the fix restored.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3f7ddca25`
- Post-revert steps: None
- Data migration? No

</details>
