### PR TITLE
Add native Claude planning-chat preset

### DIFF
--- a/packages/app/e2e/claude-planning-preset-visual-proof.spec.ts
+++ b/packages/app/e2e/claude-planning-preset-visual-proof.spec.ts
@@ -1,0 +1,22 @@
+import * as path from 'node:path';
+import { test, expect } from './fixtures/electron-app.js';
+
+const SHOT_DIR = process.env.CLAUDE_PRESET_SHOT_DIR ?? path.resolve(__dirname, '..', 'visual-proof', 'claude-preset');
+
+test('planning chat Agent dropdown lists Claude', async ({ page }) => {
+  await page.getByTestId('sidebar-home').click();
+  await expect(page.getByTestId('invoker-terminal-input')).toBeVisible({ timeout: 10000 });
+
+  await page.getByRole('button', { name: 'Options' }).click();
+
+  const harnessSelect = page.getByTestId('invoker-terminal-harness');
+  await expect(harnessSelect).toBeVisible({ timeout: 10000 });
+
+  const optionLabels = await harnessSelect.locator('option').allTextContents();
+  expect(optionLabels).toContain('Claude');
+
+  await harnessSelect.selectOption({ label: 'Claude' });
+  await expect(harnessSelect).toHaveValue('claude');
+
+  await page.screenshot({ path: path.join(SHOT_DIR, 'claude-selected.png') });
+});

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -253,6 +253,7 @@ describe('listInAppPlanningPresets', () => {
       },
     })).resolves.toEqual(expect.arrayContaining([
       { key: 'codex', label: 'Codex', tool: 'codex', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },
+      { key: 'claude', label: 'Claude', tool: 'claude', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },
       { key: 'omp', label: 'OMP', tool: 'omp', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },
       { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude', isDefault: true, defaultConfirmationMode: 'require' },
       { key: 'custom', label: 'custom', tool: 'codex', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -207,7 +207,7 @@ export interface InvokerConfig {
    */
   plannerRetryBaseDelayMs?: number;
   /** Named Slack planning harness presets: preset key → {tool, model}; built-ins apply when omitted. */
-  slackHarnessPresets?: Record<string, { tool: 'cursor' | 'omp' | 'codex'; model?: string }>;
+  slackHarnessPresets?: Record<string, { tool: 'cursor' | 'omp' | 'codex' | 'claude'; model?: string }>;
   /** Default harness preset key when the message carries no `[preset]` tag. Default: 'cursor+claude'. */
   defaultSlackHarnessPreset?: string;
   /** Slack repo aliases: alias → git URL, resolved from a `[repo:<alias>]` tag. */
@@ -385,6 +385,7 @@ export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarn
   'omp+codex': { tool: 'omp', model: 'codex' },
   omp: { tool: 'omp' },
   codex: { tool: 'codex' },
+  claude: { tool: 'claude' },
 };
 
 function readJsonSafe(path: string): InvokerConfig {

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -168,6 +168,8 @@ function labelForPresetKey(key: string): string {
   switch (key) {
     case 'codex':
       return 'Codex';
+    case 'claude':
+      return 'Claude';
     case 'omp':
       return 'OMP';
     case 'omp+claude':

--- a/packages/app/src/planning-presets.ts
+++ b/packages/app/src/planning-presets.ts
@@ -7,6 +7,7 @@ export const BUILTIN_PLANNING_PRESETS: Record<string, PlanningPresetSpec> = {
   'omp+codex': { tool: 'omp', model: 'codex' },
   omp: { tool: 'omp' },
   codex: { tool: 'codex' },
+  claude: { tool: 'claude' },
 };
 
 export const DEFAULT_PLANNING_PRESET = 'cursor+claude';

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -147,6 +147,7 @@ export const BUILTIN_HARNESS_PRESETS: Record<string, HarnessPreset> = {
   'omp+codex': { tool: 'omp', model: 'codex' },
   omp: { tool: 'omp' },
   codex: { tool: 'codex' },
+  claude: { tool: 'claude' },
 };
 
 export const DEFAULT_HARNESS_PRESET = 'cursor+claude';

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1197,7 +1197,8 @@ export function App() {
         setSelectedPlanningPresetKey(resolved.find((option) => option.isDefault)?.key ?? resolved[0]?.key ?? 'codex');
         setSelectedPlanningConfirmationMode(resolved.find((option) => option.isDefault)?.defaultConfirmationMode ?? resolved[0]?.defaultConfirmationMode ?? 'require');
       })
-      .catch(() => {
+      .catch((err) => {
+        console.error('Failed to load planning presets', err);
         setPlanningPresetOptions([{ key: 'codex', label: 'Codex', isDefault: true, defaultConfirmationMode: 'require' }]);
         setSelectedPlanningPresetKey('codex');
         setSelectedPlanningConfirmationMode('require');

--- a/packages/ui/src/__tests__/planning-presets-load-failure-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-presets-load-failure-repro.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+describe('planning presets load failure repro', () => {
+  let mock: MockInvoker;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    mock.cleanup();
+  });
+
+  it('logs the underlying error instead of silently falling back to Codex only', async () => {
+    const loadError = new Error('boom: getPlanningPresets IPC failed');
+    mock.api.getPlanningPresets = vi.fn(async () => {
+      throw loadError;
+    }) as any;
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to load planning presets', loadError);
+    });
+  });
+});


### PR DESCRIPTION
Claude was only reachable via cursor+claude/omp+claude wrapper
presets, never as its own tool, unlike Codex. selectHarnessSessionDriver
already had full support for a bare `claude` preset (it resolves to the
already-registered ClaudeExecutionAgent), so this just registers the
missing entry across the three duplicated preset maps and fixes a
silent-swallow bug in the planning-presets loader that masked failures
as a fake "Codex only" fallback.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>