### PR TITLE
[Planning Chat Send Timeout](1) Add delayMs to the test-only planning-chat-response override

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1345,7 +1345,7 @@ export const IpcTestOnlyChannels = {
   'invoker:set-test-planning-chat-response': {} as {
     request: [
       response:
-        | { planYaml: string; planName: string; reply?: string }
+        | { planYaml: string; planName: string; reply?: string; delayMs?: number }
         | { throwError: string }
         | null,
     ];


### PR DESCRIPTION
## Summary

The test-only hook that fakes a planning-chat planner reply could not simulate a slow reply.

That made it impossible to write an end-to-end test proving a real timeout bug: a planning-chat send that legitimately takes the planner a long time to answer.

This adds an optional `delayMs` field to that hook's request shape, so a later slice can make the fake reply wait before resolving.

## Review Claim

The `invoker:set-test-planning-chat-response` test-only channel's success payload now accepts an optional `delayMs` field.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Purely additive: an optional field on a `NODE_ENV === 'test'`-only IPC channel's TypeScript type. No production code reads this field yet, and no existing caller is required to set it.

## Slice Rationale

The consuming code (the delegate-to-owner fix and the actual delay handling) lands in the next two stacked slices. Landing the type first keeps each slice's diff scoped to one review unit, per this repo's PR policy.

## Non-goals

Does not change any runtime behavior — the field is unused until the next slice.

Does not touch any non-test IPC channel.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/contracts && pnpm run build` — builds clean with the new optional field

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c02d25d`
- Post-revert steps: None
- Data migration? No

</details>
