### PR TITLE
[Planning Chat Send Timeout](2) Delegate the planning-chat-response test hook to the daemon owner

### DIFF
--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1001,6 +1001,8 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
           channel: 'headless.exec',
           request: { args: ['replace-task', String(arg0), JSON.stringify(Array.isArray(arg1) ? arg1 : [])], noTrack: true },
         };
+      case 'invoker:set-test-planning-chat-response':
+        return { channel: 'headless.gui-mutation', request: payload };
       default:
         return null;
     }
@@ -1272,7 +1274,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   // given message. The error variant lets visual-proof specs render the
   // exhausted-retry error path without spawning a real planner subprocess.
   let testPlanningChatResponse:
-    | { planYaml: string; planName: string; reply?: string }
+    | { planYaml: string; planName: string; reply?: string; delayMs?: number }
     | { throwError: string }
     | null = null;
 
@@ -1312,6 +1314,9 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       ? async (): Promise<string> => {
         if ('throwError' in planningChatResponseOverride) {
           throw new Error(planningChatResponseOverride.throwError);
+        }
+        if (planningChatResponseOverride.delayMs) {
+          await new Promise((resolve) => setTimeout(resolve, planningChatResponseOverride.delayMs));
         }
         return `${planningChatResponseOverride.reply ?? 'Draft plan ready.'}\n\n\`\`\`yaml\n${planningChatResponseOverride.planYaml}\n\`\`\``;
       }
@@ -1399,16 +1404,13 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
         testPlanFromGoalResponse = response;
       },
     );
-    ipcMain.handle(
+    registerGuiMutationHandler(
       'invoker:set-test-planning-chat-response',
-      async (
-        _event,
-        response:
-          | { planYaml: string; planName: string; reply?: string }
+      async (responseArg: unknown) => {
+        testPlanningChatResponse = responseArg as
+          | { planYaml: string; planName: string; reply?: string; delayMs?: number }
           | { throwError: string }
-          | null,
-      ) => {
-        testPlanningChatResponse = response;
+          | null;
       },
     );
     registerGuiMutationHandler('invoker:seed-main-process-hitch-fixture', async () => {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1345,7 +1345,7 @@ export const IpcTestOnlyChannels = {
   'invoker:set-test-planning-chat-response': {} as {
     request: [
       response:
-        | { planYaml: string; planName: string; reply?: string }
+        | { planYaml: string; planName: string; reply?: string; delayMs?: number }
         | { throwError: string }
         | null,
     ];


### PR DESCRIPTION
## Summary

The test-only hook for faking a planning-chat reply only ever set state in whichever process handled the IPC call.

In daemon-owner mode, that is the delegate window, not the separate owner process that actually runs `invoker:planning-chat-send`. The override silently never applied.

This sends the hook through the same delegation path every other GUI mutation already uses, so it reaches the real owner.

It also makes the fake reply honor the `delayMs` field added in the previous slice.

## Review Claim

`invoker:set-test-planning-chat-response` now reaches the daemon-owner process instead of only the local window, and honors `delayMs`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only touches a `NODE_ENV === 'test'`-gated test hook and its delegation wiring. `registerGuiMutationHandler` is the same delegation path every production GUI mutation already relies on, so this reuses an already-proven code path rather than adding a new one.

## Slice Rationale

Depends on the `delayMs` field from the previous slice. The actual production timeout fix and its proof land in the next slice; this one only makes the proof possible by fixing the test infrastructure gap.

## Non-goals

Does not change any production (non-test) IPC channel's delegation behavior.

Does not fix the underlying transport timeout — that's the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm run build` — builds clean
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/gui-mutation-translation.test.ts` — 22/22 pass, unaffected

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a2ab868`
- Post-revert steps: None
- Data migration? No

</details>
