### PR TITLE
[Add Claude to Planning Chat](1) Register claude as a native planning preset

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -253,6 +253,7 @@ describe('listInAppPlanningPresets', () => {
       },
     })).resolves.toEqual(expect.arrayContaining([
       { key: 'codex', label: 'Codex', tool: 'codex', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },
+      { key: 'claude', label: 'Claude', tool: 'claude', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },
       { key: 'omp', label: 'OMP', tool: 'omp', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },
       { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude', isDefault: true, defaultConfirmationMode: 'require' },
       { key: 'custom', label: 'custom', tool: 'codex', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -168,6 +168,8 @@ function labelForPresetKey(key: string): string {
   switch (key) {
     case 'codex':
       return 'Codex';
+    case 'claude':
+      return 'Claude';
     case 'omp':
       return 'OMP';
     case 'omp+claude':

--- a/packages/app/src/planning-presets.ts
+++ b/packages/app/src/planning-presets.ts
@@ -7,6 +7,7 @@ export const BUILTIN_PLANNING_PRESETS: Record<string, PlanningPresetSpec> = {
   'omp+codex': { tool: 'omp', model: 'codex' },
   omp: { tool: 'omp' },
   codex: { tool: 'codex' },
+  claude: { tool: 'claude' },
 };
 
 export const DEFAULT_PLANNING_PRESET = 'cursor+claude';

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -147,6 +147,7 @@ export const BUILTIN_HARNESS_PRESETS: Record<string, HarnessPreset> = {
   'omp+codex': { tool: 'omp', model: 'codex' },
   omp: { tool: 'omp' },
   codex: { tool: 'codex' },
+  claude: { tool: 'claude' },
 };
 
 export const DEFAULT_HARNESS_PRESET = 'cursor+claude';


### PR DESCRIPTION
## Summary

Planning chat lets you pick which agent runs the conversation. Codex had its own option; Claude did not — it only existed nested inside a Cursor or Omp wrapper.

The process invocation for Claude already existed and was unused. `selectHarnessSessionDriver` resolves a preset's tool name to a registered execution agent first, and `ClaudeExecutionAgent` was already registered under the name "claude".

This adds the missing `claude` entry to the preset registries so it now shows up as its own agent choice.

## Review Claim

Approve registering `claude` as a bare planning preset entry that reuses the already-registered `ClaudeExecutionAgent`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The `claude` preset reuses the already-registered `ClaudeExecutionAgent`, so planning chat spawns `claude --session-id <id> --dangerously-skip-permissions -p <prompt>` in the repo working directory — the same auto-approve pattern planning chat already uses for Codex (`--full-auto`) and Omp (`--auto-approve`). No new permission model is introduced.

## Slice Rationale

Kept separate from the `packages/app/src/config.ts` preset map and the renderer logging fix because each lives in a different review unit; this slice is the minimal change that makes Claude choosable.

## Non-goals

Does not add a new `ClaudePlanningAgent` class — `selectHarnessSessionDriver` already resolves `tool: 'claude'` to the existing `ClaudeExecutionAgent`. Does not touch the `cursor+claude` / `omp+claude` wrapper presets, which stay as-is. Does not widen `packages/app/src/config.ts` (next slice in this stack) or touch the renderer error-handling fix (later slice).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`
- [ ] `cd packages/surfaces && pnpm test`

</details>

## Visual Proof

This changes what appears in the planning chat Agent dropdown at runtime, even though it touches no `packages/ui/**` files (the dropdown reads this preset set dynamically).

Baseline — unmodified `master`, planning chat Agent dropdown, default preset is `Cursor + Claude` (Claude only reachable through the Cursor wrapper), no standalone Claude option exists:

![Baseline: no standalone Claude option](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-b852b2/agent-dropdown-before-no-claude.png)

With this slice applied — same dropdown, `Claude` now appears and is selectable as its own agent:

![With this change: Claude selected as its own Agent option](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-b852b2/agent-dropdown-after-claude.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
