### PR TITLE
[Add Claude to Planning Chat](2) Allow claude as a planning-preset tool in config

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -253,6 +253,7 @@ describe('listInAppPlanningPresets', () => {
       },
     })).resolves.toEqual(expect.arrayContaining([
       { key: 'codex', label: 'Codex', tool: 'codex', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },
+      { key: 'claude', label: 'Claude', tool: 'claude', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },
       { key: 'omp', label: 'OMP', tool: 'omp', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },
       { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude', isDefault: true, defaultConfirmationMode: 'require' },
       { key: 'custom', label: 'custom', tool: 'codex', model: undefined, isDefault: false, defaultConfirmationMode: 'require' },

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -207,7 +207,7 @@ export interface InvokerConfig {
    */
   plannerRetryBaseDelayMs?: number;
   /** Named Slack planning harness presets: preset key → {tool, model}; built-ins apply when omitted. */
-  slackHarnessPresets?: Record<string, { tool: 'cursor' | 'omp' | 'codex'; model?: string }>;
+  slackHarnessPresets?: Record<string, { tool: 'cursor' | 'omp' | 'codex' | 'claude'; model?: string }>;
   /** Default harness preset key when the message carries no `[preset]` tag. Default: 'cursor+claude'. */
   defaultSlackHarnessPreset?: string;
   /** Slack repo aliases: alias → git URL, resolved from a `[repo:<alias>]` tag. */
@@ -385,6 +385,7 @@ export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarn
   'omp+codex': { tool: 'omp', model: 'codex' },
   omp: { tool: 'omp' },
   codex: { tool: 'codex' },
+  claude: { tool: 'claude' },
 };
 
 function readJsonSafe(path: string): InvokerConfig {

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -168,6 +168,8 @@ function labelForPresetKey(key: string): string {
   switch (key) {
     case 'codex':
       return 'Codex';
+    case 'claude':
+      return 'Claude';
     case 'omp':
       return 'OMP';
     case 'omp+claude':

--- a/packages/app/src/planning-presets.ts
+++ b/packages/app/src/planning-presets.ts
@@ -7,6 +7,7 @@ export const BUILTIN_PLANNING_PRESETS: Record<string, PlanningPresetSpec> = {
   'omp+codex': { tool: 'omp', model: 'codex' },
   omp: { tool: 'omp' },
   codex: { tool: 'codex' },
+  claude: { tool: 'claude' },
 };
 
 export const DEFAULT_PLANNING_PRESET = 'cursor+claude';

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -147,6 +147,7 @@ export const BUILTIN_HARNESS_PRESETS: Record<string, HarnessPreset> = {
   'omp+codex': { tool: 'omp', model: 'codex' },
   omp: { tool: 'omp' },
   codex: { tool: 'codex' },
+  claude: { tool: 'claude' },
 };
 
 export const DEFAULT_HARNESS_PRESET = 'cursor+claude';


### PR DESCRIPTION
## Summary

The Slack planning surface reads its own default preset map from `packages/app/src/config.ts`, a duplicate of the map touched in the previous slice.

This widens the preset tool option set and default map so the two stay consistent.

## Review Claim

Approve widening the `slackHarnessPresets` tool option set and default preset map to include `claude`.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Purely additive to a type union and a plain data map; a mistake here surfaces as a compile error or an unreachable preset key, never a runtime failure, since this file only feeds the Slack surface's config-driven preset resolution.

## Slice Rationale

This preset-map duplicate is its own review unit, separate from the previous slice, so it lands on its own.

## Non-goals

Does not change how presets are resolved or selected. Does not touch the in-app planning chat dropdown (previous slice) or the renderer error-handling fix (later slice).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
