### PR TITLE
[Add Claude to Planning Chat](3) Log planning-preset load failures instead of hiding them

### DIFF
--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -23,6 +23,8 @@ export type ElectronFixtures = {
   guiOwnerMode: string;
   /** When true, the app's embedded terminal backend throws on spawn (fault injection). */
   breakTerminalSpawn: boolean;
+  /** When true, the invoker:get-planning-presets IPC handler throws (fault injection). */
+  breakPlanningPresets: boolean;
   repoConfig: Partial<InvokerConfig>;
   page: Page;
   testDir: string;
@@ -51,6 +53,7 @@ async function removeTestDir(dir: string): Promise<void> {
 export const test = base.extend<ElectronFixtures>({
   guiOwnerMode: [process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui', { option: true }],
   breakTerminalSpawn: [false, { option: true }],
+  breakPlanningPresets: [false, { option: true }],
   repoConfig: [{ autoFixRetries: 0 }, { option: true }],
 
   testDir: async ({}, use) => {
@@ -61,7 +64,7 @@ export const test = base.extend<ElectronFixtures>({
     }
   },
 
-  electronApp: async ({ guiOwnerMode, breakTerminalSpawn, repoConfig, testDir }, use) => {
+  electronApp: async ({ guiOwnerMode, breakTerminalSpawn, breakPlanningPresets, repoConfig, testDir }, use) => {
     // Dummy `claude` on PATH + fix command — same as scripts/e2e-dry-run (no real CLI).
     const claudeMarker = path.join(repoRoot, 'scripts', 'e2e-dry-run', 'fixtures', 'claude-marker.sh');
     const stubDir = path.join(testDir, 'claude-stub');
@@ -188,6 +191,7 @@ exit 64
           ? { INVOKER_E2E_CODEX_DEMO_RENDERER: process.env.INVOKER_E2E_CODEX_DEMO_RENDERER }
           : {}),
         ...(breakTerminalSpawn ? { INVOKER_E2E_BREAK_TERMINAL_SPAWN: '1' } : {}),
+        ...(breakPlanningPresets ? { INVOKER_E2E_BREAK_PLANNING_PRESETS: '1' } : {}),
         ...(forceReadOnlyStatus ? { INVOKER_E2E_FORCE_READ_ONLY_STATUS: '1' } : {}),
         ...(forceConnectionLostStatus ? { INVOKER_E2E_FORCE_CONNECTION_LOST_STATUS: '1' } : {}),
         PATH: pathEnv,

--- a/packages/app/e2e/planning-presets-load-failure.spec.ts
+++ b/packages/app/e2e/planning-presets-load-failure.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect, captureScreenshot } from './fixtures/electron-app.js';
+
+test.describe('planning presets load failure', () => {
+  test.use({ breakPlanningPresets: true });
+
+  test('logs the real console.error instead of silently falling back to Codex, and captures it as visual proof', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    await page.reload();
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10000 });
+
+    await expect
+      .poll(() => consoleErrors.some((line) => line.includes('Failed to load planning presets')), { timeout: 10000 })
+      .toBe(true);
+
+    const capturedLine = consoleErrors.find((line) => line.includes('Failed to load planning presets'));
+    if (!capturedLine) throw new Error('expected a captured console.error line');
+    expect(capturedLine).toContain('simulated getPlanningPresets IPC failure');
+
+    await page.evaluate((text) => {
+      const overlay = document.createElement('div');
+      overlay.setAttribute('data-testid', 'console-proof-overlay');
+      overlay.textContent = text;
+      overlay.style.cssText =
+        'position:fixed;inset:0;z-index:99999;background:#111;color:#0f0;font:14px monospace;padding:24px;white-space:pre-wrap;';
+      document.body.appendChild(overlay);
+    }, capturedLine);
+
+    await captureScreenshot(page, 'planning-presets-load-failure');
+  });
+});

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -2540,7 +2540,12 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     return agentRegistry.listExecutionHarnesses();
   });
 
-  ipcMain.handle('invoker:get-planning-presets', () => listInAppPlanningPresets(loadConfig()));
+  ipcMain.handle('invoker:get-planning-presets', () => {
+    if (process.env.INVOKER_E2E_BREAK_PLANNING_PRESETS === '1') {
+      throw new Error('simulated getPlanningPresets IPC failure (injected by INVOKER_E2E_BREAK_PLANNING_PRESETS)');
+    }
+    return listInAppPlanningPresets(loadConfig());
+  });
 
   ipcMain.handle('invoker:get-execution-defaults', () => {
     return resolveDefaultTaskExecutionSettings(loadConfig());

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1197,7 +1197,8 @@ export function App() {
         setSelectedPlanningPresetKey(resolved.find((option) => option.isDefault)?.key ?? resolved[0]?.key ?? 'codex');
         setSelectedPlanningConfirmationMode(resolved.find((option) => option.isDefault)?.defaultConfirmationMode ?? resolved[0]?.defaultConfirmationMode ?? 'require');
       })
-      .catch(() => {
+      .catch((err) => {
+        console.error('Failed to load planning presets', err);
         setPlanningPresetOptions([{ key: 'codex', label: 'Codex', isDefault: true, defaultConfirmationMode: 'require' }]);
         setSelectedPlanningPresetKey('codex');
         setSelectedPlanningConfirmationMode('require');

--- a/packages/ui/src/__tests__/planning-presets-load-failure-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-presets-load-failure-repro.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+describe('planning presets load failure repro', () => {
+  let mock: MockInvoker;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    mock.cleanup();
+  });
+
+  it('logs the underlying error instead of silently falling back to Codex only', async () => {
+    const loadError = new Error('boom: getPlanningPresets IPC failed');
+    mock.api.getPlanningPresets = vi.fn(async () => {
+      throw loadError;
+    }) as any;
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to load planning presets', loadError);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

When the planning-chat preset set failed to load, the renderer silently fell back to one hardcoded 'Codex' entry and logged nothing. Claude looked unavailable.

This logs the real error before falling back, so a future regression is visible instead of silently pretending to be a missing feature.

## Review Claim

Approve logging the caught error in the planning-preset load-failure path before the existing Codex-only fallback runs.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Purely additive logging inside a catch handler that already ran; the fallback UI behavior is byte-for-byte unchanged, so this cannot regress the existing happy or failure path.

## Slice Rationale

Independent fix found while investigating why Claude did not show up; kept separate because it touches the renderer, a different review unit from the preset-registry slices.

## Non-goals

Does not change the fallback UI shown to the user. Does not add retry or backoff behavior. Does not touch the preset registries themselves (earlier slices in this stack).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test` — includes the new `planning-presets-load-failure-repro.test.tsx`, which fails on the pre-fix code (times out waiting for `console.error`) and passes after this change
- [ ] `cd packages/app && CAPTURE_MODE=after npx playwright test planning-presets-load-failure.spec.ts` — real Electron e2e test; fails on the pre-fix code (same timeout) and passes after this change

</details>

## Visual Proof

This edits a `packages/ui/**` file, but the actual change is one added `console.error` call inside an existing catch block — there is no pixel difference in the app itself, so a screenshot of the app cannot show it.

Electron's native DevTools console panel is also a separate `webContents` outside the app page's own paint tree, so Playwright's `page.screenshot()` cannot capture it directly either (confirmed by trying it).

Instead, this adds a real e2e test (`packages/app/e2e/planning-presets-load-failure.spec.ts`) plus a `breakPlanningPresets` fixture flag that makes the `invoker:get-planning-presets` IPC handler throw via `INVOKER_E2E_BREAK_PLANNING_PRESETS`. The test launches the real Electron app with the handler broken, reloads, captures the actual `console.error` text via Playwright's console listener, asserts it contains `"Failed to load planning presets"`, then renders that captured string as an on-page overlay for the screenshot below — so the pixels below are the real string the running app logged:

![Actual captured console.error text from the real Electron app: "Failed to load planning presets Error: Error invoking remote method 'invoker:get-planning-presets': Error: simulated getPlanningPresets IPC failure (injected by INVOKER_E2E_BREAK_PLANNING_PRESETS)"](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-711bd1/planning-presets-load-failure.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


