### PR TITLE
[Planning Chat Redesign](1) Delete orphaned PlanningState lifecycle dead code

### DIFF
--- a/packages/planning-core/src/__tests__/lifecycle.test.ts
+++ b/packages/planning-core/src/__tests__/lifecycle.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
-  derivePlanningTurnResult,
   hasExplicitDraftIntent,
   isDraftingAuthorized,
-  PlanningSession,
-  SerializedPlanningTurns,
 } from '../lifecycle.js';
 
 describe('Planning Terminal lifecycle contract', () => {
@@ -16,36 +13,5 @@ describe('Planning Terminal lifecycle contract', () => {
     expect(isDraftingAuthorized('yes', [
       { role: 'assistant', content: 'Here is an explanation.' },
     ])).toBe(false);
-  });
-
-  it('does not expose an unapproved draft as draft_ready', () => {
-    expect(derivePlanningTurnResult('discuss options', [], {
-      hasDraft: true,
-      asksQuestion: false,
-      submitted: false,
-    })).toEqual({ state: 'discussing', draftingAuthorized: false });
-  });
-
-  it('serializes turns in arrival order', async () => {
-    const turns = new SerializedPlanningTurns();
-    const order: string[] = [];
-    await Promise.all([
-      turns.run(async () => { order.push('first'); }),
-      turns.run(async () => { order.push('second'); }),
-    ]);
-    expect(order).toEqual(['first', 'second']);
-  });
-
-  it('keeps an unapproved draft in the discussing state', async () => {
-    const runner = {
-      sendMessage: async () => '```yaml\nname: draft\ntasks:\n  - id: task\n    description: Draft\n```',
-      getDraftedPlan: () => 'name: draft\ntasks:\n  - id: task\n    description: Draft',
-      planSubmitted: false,
-    };
-    const session = new PlanningSession(runner);
-    await expect(session.send('What would this involve?')).resolves.toMatchObject({
-      state: 'discussing',
-      draftingAuthorized: false,
-    });
   });
 });

--- a/packages/planning-core/src/lifecycle.ts
+++ b/packages/planning-core/src/lifecycle.ts
@@ -5,13 +5,6 @@ export interface PlanningMessage {
   content: string;
 }
 
-export type PlanningState = 'discussing' | 'awaiting_answer' | 'draft_ready' | 'submitted';
-
-export interface PlanningTurnResult {
-  state: PlanningState;
-  draftingAuthorized: boolean;
-}
-
 function normalized(text: string): string {
   return text.trim().toLowerCase();
 }
@@ -68,67 +61,4 @@ export function previousAssistantAskedWhetherToDraft(messages: readonly Planning
 export function isDraftingAuthorized(message: string, messagesBeforeTurn: readonly PlanningMessage[]): boolean {
   return hasExplicitDraftIntent(message)
     || (isShortDraftConfirmation(message) && previousAssistantAskedWhetherToDraft(messagesBeforeTurn));
-}
-
-export function derivePlanningTurnResult(
-  message: string,
-  messagesBeforeTurn: readonly PlanningMessage[],
-  response: { hasDraft: boolean; asksQuestion: boolean; submitted: boolean },
-): PlanningTurnResult {
-  const draftingAuthorized = isDraftingAuthorized(message, messagesBeforeTurn);
-  if (response.submitted) return { state: 'submitted', draftingAuthorized };
-  if (response.hasDraft && draftingAuthorized) return { state: 'draft_ready', draftingAuthorized };
-  return {
-    state: response.asksQuestion ? 'awaiting_answer' : 'discussing',
-    draftingAuthorized,
-  };
-}
-
-export class SerializedPlanningTurns {
-  private pending: Promise<void> = Promise.resolve();
-
-  async run<T>(turn: () => Promise<T>): Promise<T> {
-    const next = this.pending.then(turn);
-    this.pending = next.then(() => undefined, () => undefined);
-    return await next;
-  }
-}
-
-export interface PlanningRunner {
-  sendMessage(message: string): Promise<string>;
-  getDraftedPlan(): string | null;
-  readonly planSubmitted: boolean;
-}
-
-export interface PlanningSessionTurn {
-  reply: string;
-  state: PlanningState;
-  draftingAuthorized: boolean;
-}
-
-export class PlanningSession {
-  private readonly turns = new SerializedPlanningTurns();
-  private readonly messages: PlanningMessage[] = [];
-
-  constructor(private readonly runner: PlanningRunner) {}
-
-  get history(): readonly PlanningMessage[] {
-    return this.messages;
-  }
-
-  async send(message: string): Promise<PlanningSessionTurn> {
-    return await this.turns.run(async () => {
-      const messagesBeforeTurn = [...this.messages];
-      const draftingAuthorized = isDraftingAuthorized(message, messagesBeforeTurn);
-      this.messages.push({ role: 'user', content: message });
-      const reply = await this.runner.sendMessage(message);
-      this.messages.push({ role: 'assistant', content: reply });
-      const result = derivePlanningTurnResult(message, messagesBeforeTurn, {
-        hasDraft: this.runner.getDraftedPlan() !== null,
-        asksQuestion: reply.includes('?'),
-        submitted: this.runner.planSubmitted,
-      });
-      return { reply, state: result.state, draftingAuthorized };
-    });
-  }
 }


### PR DESCRIPTION
## Summary

`PlanningState`, `PlanningSession`, and `derivePlanningTurnResult` in `planning-core/src/lifecycle.ts` were a dead, unused twin of the live `InAppPlanningSessionStatus` enum.

They used different string literals (`discussing`/`awaiting_answer` vs the real `still_discussing`/`waiting_for_answer`) and were referenced only by themselves and their own test.

This is the first slice of a larger planning-chat redesign stack. Removing the dead code first avoids anyone building new lifecycle work on top of the wrong foundation.

`hasExplicitDraftIntent` and `isDraftingAuthorized`, which are still live and used by `in-app-planner.ts`, keep their existing test coverage — only the dead trio was removed.

## Review Claim

Confirm the removed symbols (`PlanningState`, `PlanningSession`, `derivePlanningTurnResult`, `SerializedPlanningTurns`) have zero external references before deletion, and that live-function test coverage was preserved.

## Review Lane

cleanup

## Review Unit

cleanup

## Safety Invariant

A repo-wide grep for the removed symbol names returns no hits outside this diff, confirmed before deletion.

## Slice Rationale

Landed first, ahead of the worktree-binding and immutability work later in this stack, so nobody mistakes the dead `PlanningState` enum for the canonical one while reading later diffs.

## Non-goals

Does not touch the live `InAppPlanningSessionStatus` enum, `hasExplicitDraftIntent`, or `isDraftingAuthorized`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/planning-core && pnpm test`
- [ ] `git grep -n "PlanningState\|derivePlanningTurnResult" packages` (expect no hits outside history)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
