### PR TITLE
Dedupe loadGeneratedPlan / loadGeneratedPlanPreview

### DIFF
--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -42,6 +42,7 @@ import {
 } from '../config.js';
 import { resolveAutoApproveAIFixes, resolveAutoFixRetries } from '../autofix-defaults.js';
 import { backupPlan } from '../plan-backup.js';
+import { loadPlanSubmissionBundle } from '../plan-submission-loader.js';
 import { runHeadless, resolveAgentSession } from '../headless.js';
 import type { HeadlessDeps } from '../headless.js';
 import { resolveRefreshTaskGraphSnapshot } from '../refresh-task-graph.js';
@@ -1199,57 +1200,16 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     planText: string,
     options?: { preserveTaskHandles?: boolean; logLabel?: string },
   ): Promise<{ planName: string; workflowId: string; workflowIds?: string[]; workflowCount?: number }> {
-    const { applyConfiguredPlanDefaults, parsePlanSubmissionBundle } = await import('../plan-parser.js');
-    const submission = parsePlanSubmissionBundle(planText);
-    const existingWorkflowIds = new Set(persistence.listWorkflows().map((workflow) => workflow.id));
-    const loadedWorkflowIds: string[] = [];
-    let upstream: { workflowId: string; featureBranch: string } | undefined;
-    logger.info(
-      `${options?.logLabel ?? 'plan-from-goal'}: loading "${submission.name}" (${submission.plans.length} workflow${submission.plans.length === 1 ? '' : 's'})`,
-      { module: 'ipc' },
-    );
-    if (!options?.preserveTaskHandles) {
-      taskHandles.clear();
-    }
-
-    for (const parsedPlan of submission.plans) {
-      let plan = applyConfiguredPlanDefaults(parsedPlan);
-      if (upstream) {
-        plan = {
-          ...plan,
-          baseBranch: upstream.featureBranch,
-          externalDependencies: [
-            ...(plan.externalDependencies ?? []),
-            {
-              workflowId: upstream.workflowId,
-              taskId: '__merge__',
-              requiredStatus: 'completed',
-              gatePolicy: 'review_ready',
-            } as const,
-          ],
-        };
-      }
-      backupPlan(plan, undefined, logger);
-      orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
-      const workflow = persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
-      if (!workflow) {
-        throw new Error('Loaded plan did not create a workflow.');
-      }
-      existingWorkflowIds.add(workflow.id);
-      loadedWorkflowIds.push(workflow.id);
-      upstream = { workflowId: workflow.id, featureBranch: workflow.featureBranch ?? plan.featureBranch ?? plan.baseBranch ?? 'main' };
-    }
-
-    const workflowId = loadedWorkflowIds[loadedWorkflowIds.length - 1];
-    if (!workflowId) {
-      throw new Error('Loaded plan did not create a workflow.');
-    }
-    return {
-      planName: submission.name,
-      workflowId,
-      workflowIds: loadedWorkflowIds,
-      workflowCount: loadedWorkflowIds.length,
-    };
+    return loadPlanSubmissionBundle(planText, {
+      persistence,
+      orchestrator,
+      allowGraphMutation: invokerConfig.allowGraphMutation,
+      logger,
+    }, {
+      logLabel: options?.logLabel ?? 'plan-from-goal',
+      preserveTaskHandles: options?.preserveTaskHandles,
+      taskHandles,
+    });
   }
 
   const planningConversationRepo = new ConversationRepository(persistence, {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -148,6 +148,7 @@ import {
   isRemovedHeadlessCommandAlias,
 } from './headless-command-registry.js';
 import { backupPlan } from './plan-backup.js';
+import { loadPlanSubmissionBundle } from './plan-submission-loader.js';
 import { startApiServer, type ApiServer } from './api-server.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import {
@@ -1081,53 +1082,14 @@ function startHeadlessMode(): void {
 
       const loadGeneratedPlan = async (
         planText: string,
-      ): Promise<{ planName: string; workflowId: string; workflowIds?: string[]; workflowCount?: number }> => {
-        const { applyConfiguredPlanDefaults, parsePlanSubmissionBundle } = await import('./plan-parser.js');
-        const submission = parsePlanSubmissionBundle(planText);
-        const existingWorkflowIds = new Set(persistence.listWorkflows().map((workflow) => workflow.id));
-        const loadedWorkflowIds: string[] = [];
-        let upstream: { workflowId: string; featureBranch: string } | undefined;
-
-        for (const parsedPlan of submission.plans) {
-          let plan = applyConfiguredPlanDefaults(parsedPlan);
-          if (upstream) {
-            plan = {
-              ...plan,
-              baseBranch: upstream.featureBranch,
-              externalDependencies: [
-                ...(plan.externalDependencies ?? []),
-                {
-                  workflowId: upstream.workflowId,
-                  taskId: '__merge__',
-                  requiredStatus: 'completed',
-                  gatePolicy: 'review_ready',
-                } as const,
-              ],
-            };
-          }
-          backupPlan(plan, undefined, logger);
-          orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
-          const workflow = persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
-          if (!workflow) {
-            throw new Error('Loaded plan did not create a workflow.');
-          }
-          existingWorkflowIds.add(workflow.id);
-          loadedWorkflowIds.push(workflow.id);
-          upstream = { workflowId: workflow.id, featureBranch: workflow.featureBranch ?? plan.featureBranch ?? plan.baseBranch ?? 'main' };
-        }
-
-        const workflowId = loadedWorkflowIds[loadedWorkflowIds.length - 1];
-        if (!workflowId) {
-          throw new Error('Loaded plan did not create a workflow.');
-        }
-
-        return {
-          planName: submission.name,
-          workflowId,
-          workflowIds: loadedWorkflowIds,
-          workflowCount: loadedWorkflowIds.length,
-        };
-      };
+      ): Promise<{ planName: string; workflowId: string; workflowIds?: string[]; workflowCount?: number }> => (
+        loadPlanSubmissionBundle(planText, {
+          persistence,
+          orchestrator,
+          allowGraphMutation: invokerConfig.allowGraphMutation,
+          logger,
+        })
+      );
 
       const planningConversationRepo = new ConversationRepository(persistence, {
         info: (message) => logger.info(message, { module: 'planning-chat' }),

--- a/packages/app/src/plan-submission-loader.ts
+++ b/packages/app/src/plan-submission-loader.ts
@@ -1,0 +1,84 @@
+import type { Logger } from '@invoker/contracts';
+import type { PlanDefinition } from '@invoker/workflow-core';
+import { backupPlan } from './plan-backup.js';
+
+export interface PlanSubmissionLoadResult {
+  planName: string;
+  workflowId: string;
+  workflowIds?: string[];
+  workflowCount?: number;
+}
+
+export interface PlanSubmissionLoadDeps {
+  persistence: { listWorkflows(): Array<{ id: string; featureBranch?: string }> };
+  orchestrator: { loadPlan(plan: PlanDefinition, opts: { allowGraphMutation?: boolean }): void };
+  allowGraphMutation?: boolean;
+  logger?: Logger;
+}
+
+export interface PlanSubmissionLoadOptions {
+  logLabel?: string;
+  preserveTaskHandles?: boolean;
+  taskHandles?: { clear(): void };
+}
+
+export async function loadPlanSubmissionBundle(
+  planText: string,
+  deps: PlanSubmissionLoadDeps,
+  options?: PlanSubmissionLoadOptions,
+): Promise<PlanSubmissionLoadResult> {
+  const { applyConfiguredPlanDefaults, parsePlanSubmissionBundle } = await import('./plan-parser.js');
+  const submission = parsePlanSubmissionBundle(planText);
+  const existingWorkflowIds = new Set(deps.persistence.listWorkflows().map((workflow) => workflow.id));
+  const loadedWorkflowIds: string[] = [];
+  let upstream: { workflowId: string; featureBranch: string } | undefined;
+
+  if (options?.logLabel) {
+    deps.logger?.info(
+      `${options.logLabel}: loading "${submission.name}" (${submission.plans.length} workflow${submission.plans.length === 1 ? '' : 's'})`,
+      { module: 'ipc' },
+    );
+  }
+  if (options?.taskHandles && !options.preserveTaskHandles) {
+    options.taskHandles.clear();
+  }
+
+  for (const parsedPlan of submission.plans) {
+    let plan = applyConfiguredPlanDefaults(parsedPlan);
+    if (upstream) {
+      plan = {
+        ...plan,
+        baseBranch: upstream.featureBranch,
+        externalDependencies: [
+          ...(plan.externalDependencies ?? []),
+          {
+            workflowId: upstream.workflowId,
+            taskId: '__merge__',
+            requiredStatus: 'completed',
+            gatePolicy: 'review_ready',
+          } as const,
+        ],
+      };
+    }
+    backupPlan(plan, undefined, deps.logger);
+    deps.orchestrator.loadPlan(plan, { allowGraphMutation: deps.allowGraphMutation });
+    const workflow = deps.persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
+    if (!workflow) {
+      throw new Error('Loaded plan did not create a workflow.');
+    }
+    existingWorkflowIds.add(workflow.id);
+    loadedWorkflowIds.push(workflow.id);
+    upstream = { workflowId: workflow.id, featureBranch: workflow.featureBranch ?? plan.featureBranch ?? plan.baseBranch ?? 'main' };
+  }
+
+  const workflowId = loadedWorkflowIds[loadedWorkflowIds.length - 1];
+  if (!workflowId) {
+    throw new Error('Loaded plan did not create a workflow.');
+  }
+  return {
+    planName: submission.name,
+    workflowId,
+    workflowIds: loadedWorkflowIds,
+    workflowCount: loadedWorkflowIds.length,
+  };
+}

--- a/packages/planning-core/src/__tests__/lifecycle.test.ts
+++ b/packages/planning-core/src/__tests__/lifecycle.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
-  derivePlanningTurnResult,
   hasExplicitDraftIntent,
   isDraftingAuthorized,
-  PlanningSession,
-  SerializedPlanningTurns,
 } from '../lifecycle.js';
 
 describe('Planning Terminal lifecycle contract', () => {
@@ -16,36 +13,5 @@ describe('Planning Terminal lifecycle contract', () => {
     expect(isDraftingAuthorized('yes', [
       { role: 'assistant', content: 'Here is an explanation.' },
     ])).toBe(false);
-  });
-
-  it('does not expose an unapproved draft as draft_ready', () => {
-    expect(derivePlanningTurnResult('discuss options', [], {
-      hasDraft: true,
-      asksQuestion: false,
-      submitted: false,
-    })).toEqual({ state: 'discussing', draftingAuthorized: false });
-  });
-
-  it('serializes turns in arrival order', async () => {
-    const turns = new SerializedPlanningTurns();
-    const order: string[] = [];
-    await Promise.all([
-      turns.run(async () => { order.push('first'); }),
-      turns.run(async () => { order.push('second'); }),
-    ]);
-    expect(order).toEqual(['first', 'second']);
-  });
-
-  it('keeps an unapproved draft in the discussing state', async () => {
-    const runner = {
-      sendMessage: async () => '```yaml\nname: draft\ntasks:\n  - id: task\n    description: Draft\n```',
-      getDraftedPlan: () => 'name: draft\ntasks:\n  - id: task\n    description: Draft',
-      planSubmitted: false,
-    };
-    const session = new PlanningSession(runner);
-    await expect(session.send('What would this involve?')).resolves.toMatchObject({
-      state: 'discussing',
-      draftingAuthorized: false,
-    });
   });
 });

--- a/packages/planning-core/src/lifecycle.ts
+++ b/packages/planning-core/src/lifecycle.ts
@@ -5,13 +5,6 @@ export interface PlanningMessage {
   content: string;
 }
 
-export type PlanningState = 'discussing' | 'awaiting_answer' | 'draft_ready' | 'submitted';
-
-export interface PlanningTurnResult {
-  state: PlanningState;
-  draftingAuthorized: boolean;
-}
-
 function normalized(text: string): string {
   return text.trim().toLowerCase();
 }
@@ -68,67 +61,4 @@ export function previousAssistantAskedWhetherToDraft(messages: readonly Planning
 export function isDraftingAuthorized(message: string, messagesBeforeTurn: readonly PlanningMessage[]): boolean {
   return hasExplicitDraftIntent(message)
     || (isShortDraftConfirmation(message) && previousAssistantAskedWhetherToDraft(messagesBeforeTurn));
-}
-
-export function derivePlanningTurnResult(
-  message: string,
-  messagesBeforeTurn: readonly PlanningMessage[],
-  response: { hasDraft: boolean; asksQuestion: boolean; submitted: boolean },
-): PlanningTurnResult {
-  const draftingAuthorized = isDraftingAuthorized(message, messagesBeforeTurn);
-  if (response.submitted) return { state: 'submitted', draftingAuthorized };
-  if (response.hasDraft && draftingAuthorized) return { state: 'draft_ready', draftingAuthorized };
-  return {
-    state: response.asksQuestion ? 'awaiting_answer' : 'discussing',
-    draftingAuthorized,
-  };
-}
-
-export class SerializedPlanningTurns {
-  private pending: Promise<void> = Promise.resolve();
-
-  async run<T>(turn: () => Promise<T>): Promise<T> {
-    const next = this.pending.then(turn);
-    this.pending = next.then(() => undefined, () => undefined);
-    return await next;
-  }
-}
-
-export interface PlanningRunner {
-  sendMessage(message: string): Promise<string>;
-  getDraftedPlan(): string | null;
-  readonly planSubmitted: boolean;
-}
-
-export interface PlanningSessionTurn {
-  reply: string;
-  state: PlanningState;
-  draftingAuthorized: boolean;
-}
-
-export class PlanningSession {
-  private readonly turns = new SerializedPlanningTurns();
-  private readonly messages: PlanningMessage[] = [];
-
-  constructor(private readonly runner: PlanningRunner) {}
-
-  get history(): readonly PlanningMessage[] {
-    return this.messages;
-  }
-
-  async send(message: string): Promise<PlanningSessionTurn> {
-    return await this.turns.run(async () => {
-      const messagesBeforeTurn = [...this.messages];
-      const draftingAuthorized = isDraftingAuthorized(message, messagesBeforeTurn);
-      this.messages.push({ role: 'user', content: message });
-      const reply = await this.runner.sendMessage(message);
-      this.messages.push({ role: 'assistant', content: reply });
-      const result = derivePlanningTurnResult(message, messagesBeforeTurn, {
-        hasDraft: this.runner.getDraftedPlan() !== null,
-        asksQuestion: reply.includes('?'),
-        submitted: this.runner.planSubmitted,
-      });
-      return { reply, state: result.state, draftingAuthorized };
-    });
-  }
 }


### PR DESCRIPTION
main.ts's headless-owner dispatch and gui-mutation-handlers.ts's
Electron GUI dispatch each reimplemented the same plan-submission-bundle
loading logic (parse, apply defaults, wire stacked-workflow upstream
dependencies, backup, load into the orchestrator). Extracted the shared
logic into loadPlanSubmissionBundle, preserving each call site's exact
behavior: the headless path never logs and has no task handles to clear;
the GUI path always logs with a default label and clears task handles
unless told to preserve them.

Part of the planning-chat redesign stack (slice 2/13).

Depends-On: #6528