### PR TITLE
[Planning Chat Redesign](7) Pin the post-draft immutability invariant with a regression test

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -608,6 +608,121 @@ describe('planning chat', () => {
     expect(sessions.get(result.sessionId)?.draftPlanText).toBeUndefined();
   });
 
+  it('keeps the retained draft when an ordinary critique reply coincidentally contains a fenced YAML plan', async () => {
+    const critiqueReplyWithYaml = `Sure, that step is optional if you already have the schema.
+
+\`\`\`yaml
+name: Coincidental Plan
+onFinish: none
+tasks:
+  - id: only
+    description: Only task
+    command: echo only
+\`\`\``;
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner')
+      .mockResolvedValueOnce(VALID_PLAN)
+      .mockResolvedValueOnce(critiqueReplyWithYaml);
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const conversationRepo = new ConversationRepository(adapter);
+      const sessions = createInAppPlanningChatSessions();
+
+      const first = await sendPlanningChatMessage({
+        message: 'draft the full plan',
+        presetKey: 'codex',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo,
+        planningSessionStore: adapter,
+      });
+      if (!first.ok) throw new Error(first.error);
+      expect(first).toMatchObject({ ok: true, draftPlanAvailable: true });
+      expect(sessions.get(first.sessionId)?.status).toBe('draft_ready');
+      const planA = sessions.get(first.sessionId)?.draftPlanText;
+      expect(planA).toContain('name: Mock Plan');
+
+      const second = await sendPlanningChatMessage({
+        sessionId: first.sessionId,
+        message: 'Can we skip the migration step?',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo,
+        planningSessionStore: adapter,
+      });
+      if (!second.ok) throw new Error(second.error);
+      expect(second.reply).toBe(critiqueReplyWithYaml);
+
+      expect(sessions.get(first.sessionId)?.draftPlanText).toBe(planA);
+      expect(sessions.get(first.sessionId)?.status).toBe('draft_ready');
+      expect(adapter.loadInAppPlanningSession(first.sessionId)?.draftPlanText).toBe(planA);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('overwrites the retained draft when the user explicitly asks to re-draft', async () => {
+    const redraftReply = `Here is the revised plan.
+
+\`\`\`yaml
+name: Revised Plan
+onFinish: none
+tasks:
+  - id: only
+    description: Only task
+    command: echo only
+\`\`\``;
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner')
+      .mockResolvedValueOnce(VALID_PLAN)
+      .mockResolvedValueOnce(redraftReply);
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const conversationRepo = new ConversationRepository(adapter);
+      const sessions = createInAppPlanningChatSessions();
+
+      const first = await sendPlanningChatMessage({
+        message: 'draft the full plan',
+        presetKey: 'codex',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo,
+        planningSessionStore: adapter,
+      });
+      if (!first.ok) throw new Error(first.error);
+      const planA = sessions.get(first.sessionId)?.draftPlanText;
+      expect(planA).toContain('name: Mock Plan');
+
+      const second = await sendPlanningChatMessage({
+        sessionId: first.sessionId,
+        message: 'draft it again with the migration step removed',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo,
+        planningSessionStore: adapter,
+      });
+      if (!second.ok) throw new Error(second.error);
+
+      const planB = sessions.get(first.sessionId)?.draftPlanText;
+      expect(planB).toContain('name: Revised Plan');
+      expect(planB).not.toBe(planA);
+      expect(sessions.get(first.sessionId)?.status).toBe('draft_ready');
+      expect(adapter.loadInAppPlanningSession(first.sessionId)?.draftPlanText).toBe(planB);
+    } finally {
+      adapter.close();
+    }
+  });
+
   it('returns a stacked workflow summary when the assistant drafts workflow bundles', async () => {
     vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(WORKERS_SURFACE_STACKED_PLAN);
     const sessions = createInAppPlanningChatSessions();

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { resolveInvokerHomeRoot } from '@invoker/contracts';
 import { PlanConversation } from '../../../surfaces/src/index.ts';
 import {
   PLANNING_TERMINAL_SUMMARY_BRIDGE_START,
@@ -9,6 +10,7 @@ import {
   createInAppPlanningChatSessions,
   createPlanningChatSession,
   createPlanningCommandBuilderFromRegistry,
+  discardPlanningChatDraft,
   listInAppPlanningPresets,
   listPlanningChatSessions,
   planFromGoal,
@@ -1046,6 +1048,7 @@ tasks:
       expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
       expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.not.stringContaining('```yaml'));
     } finally {
+      rmSync(join(resolveInvokerHomeRoot(), 'plan-drafts', 'planning-restored.yaml'), { force: true });
       adapter.close();
     }
   });
@@ -1299,6 +1302,163 @@ tasks:
 
     expect(resetPlanningChat({ sessionId: 'session-1' }, { sessions })).toEqual({ ok: true });
     expect(sessions.has('session-1')).toBe(false);
+  });
+});
+
+describe('plan draft sidecar mirror', () => {
+  const planningCommandBuilder = vi.fn(() => ({ command: 'planner', args: ['prompt'] }));
+
+  function sidecarPathFor(sessionId: string): string {
+    return join(resolveInvokerHomeRoot(), 'plan-drafts', `${sessionId}.yaml`);
+  }
+
+  it('writes the sidecar file to match the DB-persisted draft when a draft is approved', async () => {
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
+    const adapter = await SQLiteAdapter.create(':memory:');
+    let sessionId: string | undefined;
+    try {
+      const sessions = createInAppPlanningChatSessions();
+      const sent = await sendPlanningChatMessage({
+        message: 'draft',
+        presetKey: 'codex',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        planningSessionStore: adapter,
+      });
+      if (!sent.ok) throw new Error(sent.error);
+      sessionId = sent.sessionId;
+
+      const session = sessions.get(sessionId);
+      if (!session?.draftPlanText) throw new Error('expected a draft plan on the session');
+      const persistedDraftText = adapter.loadInAppPlanningSession(sessionId)?.draftPlanText;
+      expect(persistedDraftText).toBe(session.draftPlanText);
+
+      const sidecarPath = sidecarPathFor(sessionId);
+      expect(sidecarPath).toContain(join('.invoker', 'test', 'plan-drafts'));
+      expect(existsSync(sidecarPath)).toBe(true);
+      expect(readFileSync(sidecarPath, 'utf8')).toBe(persistedDraftText);
+    } finally {
+      if (sessionId) rmSync(sidecarPathFor(sessionId), { force: true });
+      adapter.close();
+    }
+  });
+
+  it('removes the sidecar file when a draft is discarded', async () => {
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
+    const adapter = await SQLiteAdapter.create(':memory:');
+    let sessionId: string | undefined;
+    try {
+      const sessions = createInAppPlanningChatSessions();
+      const sent = await sendPlanningChatMessage({
+        message: 'draft',
+        presetKey: 'codex',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        planningSessionStore: adapter,
+      });
+      if (!sent.ok) throw new Error(sent.error);
+      sessionId = sent.sessionId;
+      expect(existsSync(sidecarPathFor(sessionId))).toBe(true);
+
+      const discarded = discardPlanningChatDraft({ sessionId }, {
+        sessions,
+        planningSessionStore: adapter,
+      });
+      expect(discarded).toEqual({ ok: true });
+      expect(existsSync(sidecarPathFor(sessionId))).toBe(false);
+      expect(adapter.loadInAppPlanningSession(sessionId)?.draftPlanText).toBeUndefined();
+    } finally {
+      if (sessionId) rmSync(sidecarPathFor(sessionId), { force: true });
+      adapter.close();
+    }
+  });
+
+  it('reconstructs a missing sidecar file for a draft_ready session on restore', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    const sessionId = 'planning-sidecar-restore';
+    try {
+      const conversationRepo = new ConversationRepository(adapter);
+      const record: InAppPlanningSessionRecord = {
+        id: sessionId,
+        title: 'Restored draft with missing sidecar',
+        presetKey: 'codex',
+        status: 'draft_ready',
+        messages: [
+          { id: 1, role: 'user', text: 'Draft it', createdAt: '2026-07-07T00:00:01.000Z' },
+          { id: 2, role: 'assistant', text: VALID_PLAN, createdAt: '2026-07-07T00:00:02.000Z' },
+        ],
+        draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+        draftPlanText: VALID_PLAN_TEXT,
+        pendingResponse: false,
+        createdAt: '2026-07-07T00:00:00.000Z',
+        updatedAt: '2026-07-07T00:00:02.000Z',
+      };
+
+      expect(existsSync(sidecarPathFor(sessionId))).toBe(false);
+
+      const sessions = createInAppPlanningChatSessions();
+      await restorePlanningChatSessions([record], {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo,
+        planningSessionStore: adapter,
+      });
+
+      const sidecarPath = sidecarPathFor(sessionId);
+      expect(existsSync(sidecarPath)).toBe(true);
+      expect(readFileSync(sidecarPath, 'utf8')).toBe(VALID_PLAN_TEXT);
+    } finally {
+      rmSync(sidecarPathFor(sessionId), { force: true });
+      adapter.close();
+    }
+  });
+
+  it('removes the sidecar file when restore invalidates an unreadable draft', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    const sessionId = 'planning-sidecar-invalidated';
+    try {
+      const conversationRepo = new ConversationRepository(adapter);
+      const record: InAppPlanningSessionRecord = {
+        id: sessionId,
+        title: 'Restored draft that cannot be read',
+        presetKey: 'codex',
+        status: 'draft_ready',
+        messages: [
+          { id: 1, role: 'assistant', text: VALID_PLAN, createdAt: '2026-07-07T00:00:01.000Z' },
+        ],
+        pendingResponse: false,
+        createdAt: '2026-07-07T00:00:00.000Z',
+        updatedAt: '2026-07-07T00:00:01.000Z',
+      };
+
+      mkdirSync(dirname(sidecarPathFor(sessionId)), { recursive: true });
+      writeFileSync(sidecarPathFor(sessionId), 'stale sidecar contents', 'utf8');
+
+      const sessions = createInAppPlanningChatSessions();
+      await restorePlanningChatSessions([record], {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo,
+        planningSessionStore: adapter,
+      });
+
+      expect(sessions.get(sessionId)?.status).toBe('still_discussing');
+      expect(sessions.get(sessionId)?.draftPlanText).toBeUndefined();
+      expect(existsSync(sidecarPathFor(sessionId))).toBe(false);
+    } finally {
+      rmSync(sidecarPathFor(sessionId), { force: true });
+      adapter.close();
+    }
   });
 });
 

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from 'node:crypto';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import type {
   InAppPlanRequest,
   InAppPlanResponse,
@@ -27,6 +29,7 @@ import type {
   PlanningTerminalMode,
   PlanningPresetOption,
 } from '@invoker/contracts';
+import { resolveInvokerHomeRoot } from '@invoker/contracts';
 import type {
   ConversationMessageEntry,
   ConversationRepository,
@@ -477,6 +480,42 @@ function assertPersistablePlanningSession(
   }
 }
 
+function planDraftSidecarPath(sessionId: string): string {
+  return join(resolveInvokerHomeRoot(), 'plan-drafts', `${sessionId}.yaml`);
+}
+
+function logPlanDraftSidecarError(sessionId: string, step: string, error: unknown): void {
+  console.error(`[planning-chat] plan draft sidecar ${step} failed session="${sessionId}": ${
+    error instanceof Error ? error.message : String(error)
+  }`);
+}
+
+function writePlanDraftSidecar(sessionId: string, planText: string): void {
+  try {
+    const sidecarPath = planDraftSidecarPath(sessionId);
+    mkdirSync(dirname(sidecarPath), { recursive: true });
+    writeFileSync(sidecarPath, planText, 'utf8');
+  } catch (error) {
+    logPlanDraftSidecarError(sessionId, 'write', error);
+  }
+}
+
+function removePlanDraftSidecarIfPresent(sessionId: string): void {
+  try {
+    rmSync(planDraftSidecarPath(sessionId), { force: true });
+  } catch (error) {
+    logPlanDraftSidecarError(sessionId, 'remove', error);
+  }
+}
+
+function syncPlanDraftSidecar(session: Pick<InAppPlanningChatSession, 'id' | 'draftPlanText'>): void {
+  if (session.draftPlanText && session.draftPlanText.trim()) {
+    writePlanDraftSidecar(session.id, session.draftPlanText);
+  } else {
+    removePlanDraftSidecarIfPresent(session.id);
+  }
+}
+
 function persistPlanningSession(
   session: InAppPlanningChatSession,
   store: InAppPlanningSessionStore | undefined,
@@ -485,6 +524,7 @@ function persistPlanningSession(
   if (!store) return;
   assertPersistablePlanningSession(session, pendingResponse);
   store.upsertInAppPlanningSession(sessionToRecord(session, pendingResponse));
+  syncPlanDraftSidecar(session);
 }
 
 function saveOverrideConversation(
@@ -1124,6 +1164,7 @@ export async function restorePlanningChatSessions(
     }
 
     deps.sessions.set(session.id, session);
+    syncPlanDraftSidecar(session);
     if (shouldPersist) {
       persistPlanningSession(session, deps.planningSessionStore, false);
     }

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -477,6 +477,11 @@ describe('SQLiteAdapter', () => {
         'pending_response',
         'created_at',
         'updated_at',
+        'repo_url',
+        'base_branch',
+        'base_commit',
+        'worktree_path',
+        'worktree_branch',
       ]);
       expect(tableColumns(adapter, 'in_app_planning_messages')).toEqual([
         'session_id',
@@ -694,6 +699,56 @@ describe('SQLiteAdapter', () => {
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }
+    });
+
+    it('round-trips repo/HEAD/worktree binding columns when populated', () => {
+      adapter.upsertInAppPlanningSession(makePlanningSession('planning-binding', {
+        repoUrl: 'https://github.com/example/repo.git',
+        baseBranch: 'main',
+        baseCommit: 'abc1234',
+        worktreePath: '/tmp/invoker-worktrees/planning-binding',
+        worktreeBranch: 'plan/planning-binding',
+      }));
+
+      const loaded = adapter.loadInAppPlanningSession('planning-binding');
+      expect(loaded).toEqual(makePlanningSession('planning-binding', {
+        repoUrl: 'https://github.com/example/repo.git',
+        baseBranch: 'main',
+        baseCommit: 'abc1234',
+        worktreePath: '/tmp/invoker-worktrees/planning-binding',
+        worktreeBranch: 'plan/planning-binding',
+      }));
+    });
+
+    it('round-trips omitted repo/HEAD/worktree binding columns as undefined', () => {
+      adapter.upsertInAppPlanningSession(makePlanningSession('planning-1'));
+
+      const loaded = adapter.loadInAppPlanningSession('planning-1');
+      expect(loaded?.repoUrl).toBeUndefined();
+      expect(loaded?.baseBranch).toBeUndefined();
+      expect(loaded?.baseCommit).toBeUndefined();
+      expect(loaded?.worktreePath).toBeUndefined();
+      expect(loaded?.worktreeBranch).toBeUndefined();
+    });
+
+    it('patches repo/HEAD/worktree binding columns independently', () => {
+      adapter.upsertInAppPlanningSession(makePlanningSession('planning-1'));
+
+      adapter.updateInAppPlanningSession('planning-1', {
+        repoUrl: 'https://github.com/example/repo.git',
+        baseCommit: 'def5678',
+        worktreePath: '/tmp/invoker-worktrees/planning-1',
+      });
+
+      const loaded = adapter.loadInAppPlanningSession('planning-1');
+      expect(loaded).toMatchObject({
+        title: 'Planning planning-1',
+        repoUrl: 'https://github.com/example/repo.git',
+        baseCommit: 'def5678',
+        worktreePath: '/tmp/invoker-worktrees/planning-1',
+      });
+      expect(loaded?.baseBranch).toBeUndefined();
+      expect(loaded?.worktreeBranch).toBeUndefined();
     });
 
     it('deletes planning sessions and their visible messages', () => {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -293,6 +293,11 @@ export interface InAppPlanningSessionRecord {
   presetKey: string;
   status: InAppPlanningSessionStatus;
   confirmationMode: PlanningConfirmationMode;
+  repoUrl?: string;
+  baseBranch?: string;
+  baseCommit?: string;
+  worktreePath?: string;
+  worktreeBranch?: string;
   messages: InAppPlanningChatLine[];
   draftPlanSummary?: InAppPlanningPlanSummary;
   draftPlanText?: string;
@@ -314,6 +319,11 @@ export type InAppPlanningSessionPatch = Partial<Pick<
   | 'title'
   | 'status'
   | 'confirmationMode'
+  | 'repoUrl'
+  | 'baseBranch'
+  | 'baseCommit'
+  | 'worktreePath'
+  | 'worktreeBranch'
   | 'messages'
   | 'draftPlanSummary'
   | 'draftPlanText'

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -527,6 +527,11 @@ type InAppPlanningSessionRow = {
   preset_key?: unknown;
   status?: unknown;
   confirmation_mode?: unknown;
+  repo_url?: unknown;
+  base_branch?: unknown;
+  base_commit?: unknown;
+  worktree_path?: unknown;
+  worktree_branch?: unknown;
   draft_plan_summary_json?: unknown;
   draft_plan_text?: unknown;
   submitted_workflow_id?: unknown;
@@ -1223,6 +1228,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
           preset_key,
           status,
           confirmation_mode,
+          repo_url,
+          base_branch,
+          base_commit,
+          worktree_path,
+          worktree_branch,
           draft_plan_summary_json,
           draft_plan_text,
           submitted_workflow_id,
@@ -1236,12 +1246,17 @@ export class SQLiteAdapter implements PersistenceAdapter {
           pending_response,
           created_at,
           updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(session_id) DO UPDATE SET
           title = excluded.title,
           preset_key = excluded.preset_key,
           status = excluded.status,
           confirmation_mode = excluded.confirmation_mode,
+          repo_url = excluded.repo_url,
+          base_branch = excluded.base_branch,
+          base_commit = excluded.base_commit,
+          worktree_path = excluded.worktree_path,
+          worktree_branch = excluded.worktree_branch,
           draft_plan_summary_json = excluded.draft_plan_summary_json,
           draft_plan_text = excluded.draft_plan_text,
           submitted_workflow_id = excluded.submitted_workflow_id,
@@ -1261,6 +1276,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
           record.presetKey,
           record.status,
           record.confirmationMode ?? 'require',
+          record.repoUrl ?? null,
+          record.baseBranch ?? null,
+          record.baseCommit ?? null,
+          record.worktreePath ?? null,
+          record.worktreeBranch ?? null,
           record.draftPlanSummary ? JSON.stringify(record.draftPlanSummary) : null,
           record.draftPlanText ?? null,
           record.submittedWorkflowId ?? null,
@@ -1313,6 +1333,26 @@ export class SQLiteAdapter implements PersistenceAdapter {
       if (Object.hasOwn(patch, 'confirmationMode')) {
         setClauses.push('confirmation_mode = ?');
         values.push(patch.confirmationMode ?? 'require');
+      }
+      if (Object.hasOwn(patch, 'repoUrl')) {
+        setClauses.push('repo_url = ?');
+        values.push(patch.repoUrl ?? null);
+      }
+      if (Object.hasOwn(patch, 'baseBranch')) {
+        setClauses.push('base_branch = ?');
+        values.push(patch.baseBranch ?? null);
+      }
+      if (Object.hasOwn(patch, 'baseCommit')) {
+        setClauses.push('base_commit = ?');
+        values.push(patch.baseCommit ?? null);
+      }
+      if (Object.hasOwn(patch, 'worktreePath')) {
+        setClauses.push('worktree_path = ?');
+        values.push(patch.worktreePath ?? null);
+      }
+      if (Object.hasOwn(patch, 'worktreeBranch')) {
+        setClauses.push('worktree_branch = ?');
+        values.push(patch.worktreeBranch ?? null);
       }
       if (Object.hasOwn(patch, 'draftPlanSummary')) {
         setClauses.push('draft_plan_summary_json = ?');
@@ -2971,6 +3011,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
         presetKey,
         status: row.status,
         confirmationMode: row.confirmation_mode,
+        ...(typeof row.repo_url === 'string' ? { repoUrl: row.repo_url } : {}),
+        ...(typeof row.base_branch === 'string' ? { baseBranch: row.base_branch } : {}),
+        ...(typeof row.base_commit === 'string' ? { baseCommit: row.base_commit } : {}),
+        ...(typeof row.worktree_path === 'string' ? { worktreePath: row.worktree_path } : {}),
+        ...(typeof row.worktree_branch === 'string' ? { worktreeBranch: row.worktree_branch } : {}),
         messages,
         ...(draftPlanSummary ? { draftPlanSummary } : {}),
         ...(typeof row.draft_plan_text === 'string' ? { draftPlanText: row.draft_plan_text } : {}),

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -597,6 +597,11 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN repo_url TEXT',
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN base_branch TEXT',
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN base_commit TEXT',
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN worktree_path TEXT',
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN worktree_branch TEXT',
 ];
 
 /**

--- a/packages/planning-core/src/__tests__/worktree-binding.test.ts
+++ b/packages/planning-core/src/__tests__/worktree-binding.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { decideWorktreeBinding } from '../worktree-binding.js';
+
+describe('decideWorktreeBinding', () => {
+  it('provisions on first bind regardless of draft state', () => {
+    expect(decideWorktreeBinding({
+      requestedRepoUrl: 'https://example.com/repo.git',
+      requestedHeadSha: 'sha-a',
+      hasDraft: true,
+    }).action).toBe('provision');
+
+    expect(decideWorktreeBinding({
+      requestedRepoUrl: 'https://example.com/repo.git',
+      requestedHeadSha: 'sha-a',
+      hasDraft: false,
+    }).action).toBe('provision');
+  });
+
+  it('reuses when repo and commit are unchanged', () => {
+    expect(decideWorktreeBinding({
+      storedRepoUrl: 'https://example.com/repo.git',
+      storedHeadSha: 'sha-a',
+      requestedRepoUrl: 'https://example.com/repo.git',
+      requestedHeadSha: 'sha-a',
+      hasDraft: true,
+    }).action).toBe('reuse');
+
+    expect(decideWorktreeBinding({
+      storedRepoUrl: 'https://example.com/repo.git',
+      storedHeadSha: 'sha-a',
+      requestedRepoUrl: 'https://example.com/repo.git',
+      requestedHeadSha: 'sha-a',
+      hasDraft: false,
+    }).action).toBe('reuse');
+  });
+
+  it('invalidates and blocks submit when commit changes with a draft in flight', () => {
+    expect(decideWorktreeBinding({
+      storedRepoUrl: 'https://example.com/repo.git',
+      storedHeadSha: 'sha-a',
+      requestedRepoUrl: 'https://example.com/repo.git',
+      requestedHeadSha: 'sha-b',
+      hasDraft: true,
+    }).action).toBe('invalidate_and_block_submit');
+  });
+
+  it('provisions when commit changes with no draft in flight', () => {
+    expect(decideWorktreeBinding({
+      storedRepoUrl: 'https://example.com/repo.git',
+      storedHeadSha: 'sha-a',
+      requestedRepoUrl: 'https://example.com/repo.git',
+      requestedHeadSha: 'sha-b',
+      hasDraft: false,
+    }).action).toBe('provision');
+  });
+
+  it('invalidates and blocks submit when repo changes with same sha and a draft in flight', () => {
+    expect(decideWorktreeBinding({
+      storedRepoUrl: 'https://example.com/repo-one.git',
+      storedHeadSha: 'sha-a',
+      requestedRepoUrl: 'https://example.com/repo-two.git',
+      requestedHeadSha: 'sha-a',
+      hasDraft: true,
+    }).action).toBe('invalidate_and_block_submit');
+  });
+
+  it('provisions when repo changes with same sha and no draft in flight', () => {
+    expect(decideWorktreeBinding({
+      storedRepoUrl: 'https://example.com/repo-one.git',
+      storedHeadSha: 'sha-a',
+      requestedRepoUrl: 'https://example.com/repo-two.git',
+      requestedHeadSha: 'sha-a',
+      hasDraft: false,
+    }).action).toBe('provision');
+  });
+
+  it('invalidates and blocks submit when repo and commit both change with a draft in flight', () => {
+    expect(decideWorktreeBinding({
+      storedRepoUrl: 'https://example.com/repo-one.git',
+      storedHeadSha: 'sha-a',
+      requestedRepoUrl: 'https://example.com/repo-two.git',
+      requestedHeadSha: 'sha-b',
+      hasDraft: true,
+    }).action).toBe('invalidate_and_block_submit');
+  });
+
+  it('provisions when repo and commit both change with no draft in flight', () => {
+    expect(decideWorktreeBinding({
+      storedRepoUrl: 'https://example.com/repo-one.git',
+      storedHeadSha: 'sha-a',
+      requestedRepoUrl: 'https://example.com/repo-two.git',
+      requestedHeadSha: 'sha-b',
+      hasDraft: false,
+    }).action).toBe('provision');
+  });
+});

--- a/packages/planning-core/src/index.ts
+++ b/packages/planning-core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lifecycle.js';
+export * from './worktree-binding.js';
 export * from './plan-summary.js';
 export * from './planning-turn.js';
 export * from './planning-review.js';

--- a/packages/planning-core/src/worktree-binding.ts
+++ b/packages/planning-core/src/worktree-binding.ts
@@ -1,0 +1,34 @@
+export interface WorktreeBindingRequest {
+  storedRepoUrl?: string;
+  storedHeadSha?: string;
+  requestedRepoUrl: string;
+  requestedHeadSha: string;
+  hasDraft: boolean;
+}
+
+export type WorktreeBindingAction = 'reuse' | 'provision' | 'invalidate_and_block_submit';
+
+export type WorktreeBindingReason = 'no-prior-binding' | 'unchanged' | 'repo-changed' | 'commit-changed';
+
+export interface WorktreeBindingDecision {
+  action: WorktreeBindingAction;
+  reason: WorktreeBindingReason;
+}
+
+export function decideWorktreeBinding(request: WorktreeBindingRequest): WorktreeBindingDecision {
+  const { storedRepoUrl, storedHeadSha, requestedRepoUrl, requestedHeadSha, hasDraft } = request;
+
+  if (storedRepoUrl === undefined || storedHeadSha === undefined) {
+    return { action: 'provision', reason: 'no-prior-binding' };
+  }
+
+  if (storedRepoUrl === requestedRepoUrl && storedHeadSha === requestedHeadSha) {
+    return { action: 'reuse', reason: 'unchanged' };
+  }
+
+  const reason: WorktreeBindingReason = storedRepoUrl !== requestedRepoUrl ? 'repo-changed' : 'commit-changed';
+  return {
+    action: hasDraft ? 'invalidate_and_block_submit' : 'provision',
+    reason,
+  };
+}


### PR DESCRIPTION
## Summary

A later slice in this stack asks whether a `draft_ready` planning session can have its draft silently overwritten by an ordinary follow-up chat message.

Tracing `evaluatePlanningTurn`'s contract shows the draft-producing branch already requires explicit draft intent on the *current* message, and the ordinary-message branch never touches `draftPlanText` at all — so an ordinary critique turn structurally cannot overwrite a retained draft today, even if the model's reply happens to contain a fenced YAML block.

No code guard was needed. This slice adds two tests that pin that invariant so a future refactor can't accidentally regress it: an ordinary critique leaves the draft untouched, while an explicit re-draft request still replaces it.

## Review Claim

Confirm the two new tests actually exercise the "already draft_ready, then an unrelated turn with coincidental YAML" scenario, and that they pass against the current, unmodified code.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

No product code changed in this slice — it is a regression-test-only addition, verified to pass against the code as it already stood.

## Slice Rationale

Split out on its own so the "no code change needed here" finding is visible and reviewable independently, rather than silently assumed while later slices build on top of it.

## Non-goals

Does not add a defensive code-level guard, since tracing the actual code confirmed the invariant already holds structurally.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
