### PR TITLE
Provision a real isolated worktree per planning-chat session

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -608,6 +608,121 @@ describe('planning chat', () => {
     expect(sessions.get(result.sessionId)?.draftPlanText).toBeUndefined();
   });
 
+  it('keeps the retained draft when an ordinary critique reply coincidentally contains a fenced YAML plan', async () => {
+    const critiqueReplyWithYaml = `Sure, that step is optional if you already have the schema.
+
+\`\`\`yaml
+name: Coincidental Plan
+onFinish: none
+tasks:
+  - id: only
+    description: Only task
+    command: echo only
+\`\`\``;
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner')
+      .mockResolvedValueOnce(VALID_PLAN)
+      .mockResolvedValueOnce(critiqueReplyWithYaml);
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const conversationRepo = new ConversationRepository(adapter);
+      const sessions = createInAppPlanningChatSessions();
+
+      const first = await sendPlanningChatMessage({
+        message: 'draft the full plan',
+        presetKey: 'codex',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo,
+        planningSessionStore: adapter,
+      });
+      if (!first.ok) throw new Error(first.error);
+      expect(first).toMatchObject({ ok: true, draftPlanAvailable: true });
+      expect(sessions.get(first.sessionId)?.status).toBe('draft_ready');
+      const planA = sessions.get(first.sessionId)?.draftPlanText;
+      expect(planA).toContain('name: Mock Plan');
+
+      const second = await sendPlanningChatMessage({
+        sessionId: first.sessionId,
+        message: 'Can we skip the migration step?',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo,
+        planningSessionStore: adapter,
+      });
+      if (!second.ok) throw new Error(second.error);
+      expect(second.reply).toBe(critiqueReplyWithYaml);
+
+      expect(sessions.get(first.sessionId)?.draftPlanText).toBe(planA);
+      expect(sessions.get(first.sessionId)?.status).toBe('draft_ready');
+      expect(adapter.loadInAppPlanningSession(first.sessionId)?.draftPlanText).toBe(planA);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('overwrites the retained draft when the user explicitly asks to re-draft', async () => {
+    const redraftReply = `Here is the revised plan.
+
+\`\`\`yaml
+name: Revised Plan
+onFinish: none
+tasks:
+  - id: only
+    description: Only task
+    command: echo only
+\`\`\``;
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner')
+      .mockResolvedValueOnce(VALID_PLAN)
+      .mockResolvedValueOnce(redraftReply);
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const conversationRepo = new ConversationRepository(adapter);
+      const sessions = createInAppPlanningChatSessions();
+
+      const first = await sendPlanningChatMessage({
+        message: 'draft the full plan',
+        presetKey: 'codex',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo,
+        planningSessionStore: adapter,
+      });
+      if (!first.ok) throw new Error(first.error);
+      const planA = sessions.get(first.sessionId)?.draftPlanText;
+      expect(planA).toContain('name: Mock Plan');
+
+      const second = await sendPlanningChatMessage({
+        sessionId: first.sessionId,
+        message: 'draft it again with the migration step removed',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo,
+        planningSessionStore: adapter,
+      });
+      if (!second.ok) throw new Error(second.error);
+
+      const planB = sessions.get(first.sessionId)?.draftPlanText;
+      expect(planB).toContain('name: Revised Plan');
+      expect(planB).not.toBe(planA);
+      expect(sessions.get(first.sessionId)?.status).toBe('draft_ready');
+      expect(adapter.loadInAppPlanningSession(first.sessionId)?.draftPlanText).toBe(planB);
+    } finally {
+      adapter.close();
+    }
+  });
+
   it('returns a stacked workflow summary when the assistant drafts workflow bundles', async () => {
     vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(WORKERS_SURFACE_STACKED_PLAN);
     const sessions = createInAppPlanningChatSessions();

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { resolveInvokerHomeRoot } from '@invoker/contracts';
 import { PlanConversation } from '../../../surfaces/src/index.ts';
 import {
   PLANNING_TERMINAL_SUMMARY_BRIDGE_START,
@@ -9,6 +10,7 @@ import {
   createInAppPlanningChatSessions,
   createPlanningChatSession,
   createPlanningCommandBuilderFromRegistry,
+  discardPlanningChatDraft,
   listInAppPlanningPresets,
   listPlanningChatSessions,
   planFromGoal,
@@ -1046,6 +1048,7 @@ tasks:
       expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
       expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.not.stringContaining('```yaml'));
     } finally {
+      rmSync(join(resolveInvokerHomeRoot(), 'plan-drafts', 'planning-restored.yaml'), { force: true });
       adapter.close();
     }
   });
@@ -1299,6 +1302,163 @@ tasks:
 
     expect(resetPlanningChat({ sessionId: 'session-1' }, { sessions })).toEqual({ ok: true });
     expect(sessions.has('session-1')).toBe(false);
+  });
+});
+
+describe('plan draft sidecar mirror', () => {
+  const planningCommandBuilder = vi.fn(() => ({ command: 'planner', args: ['prompt'] }));
+
+  function sidecarPathFor(sessionId: string): string {
+    return join(resolveInvokerHomeRoot(), 'plan-drafts', `${sessionId}.yaml`);
+  }
+
+  it('writes the sidecar file to match the DB-persisted draft when a draft is approved', async () => {
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
+    const adapter = await SQLiteAdapter.create(':memory:');
+    let sessionId: string | undefined;
+    try {
+      const sessions = createInAppPlanningChatSessions();
+      const sent = await sendPlanningChatMessage({
+        message: 'draft',
+        presetKey: 'codex',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        planningSessionStore: adapter,
+      });
+      if (!sent.ok) throw new Error(sent.error);
+      sessionId = sent.sessionId;
+
+      const session = sessions.get(sessionId);
+      if (!session?.draftPlanText) throw new Error('expected a draft plan on the session');
+      const persistedDraftText = adapter.loadInAppPlanningSession(sessionId)?.draftPlanText;
+      expect(persistedDraftText).toBe(session.draftPlanText);
+
+      const sidecarPath = sidecarPathFor(sessionId);
+      expect(sidecarPath).toContain(join('.invoker', 'test', 'plan-drafts'));
+      expect(existsSync(sidecarPath)).toBe(true);
+      expect(readFileSync(sidecarPath, 'utf8')).toBe(persistedDraftText);
+    } finally {
+      if (sessionId) rmSync(sidecarPathFor(sessionId), { force: true });
+      adapter.close();
+    }
+  });
+
+  it('removes the sidecar file when a draft is discarded', async () => {
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
+    const adapter = await SQLiteAdapter.create(':memory:');
+    let sessionId: string | undefined;
+    try {
+      const sessions = createInAppPlanningChatSessions();
+      const sent = await sendPlanningChatMessage({
+        message: 'draft',
+        presetKey: 'codex',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        planningSessionStore: adapter,
+      });
+      if (!sent.ok) throw new Error(sent.error);
+      sessionId = sent.sessionId;
+      expect(existsSync(sidecarPathFor(sessionId))).toBe(true);
+
+      const discarded = discardPlanningChatDraft({ sessionId }, {
+        sessions,
+        planningSessionStore: adapter,
+      });
+      expect(discarded).toEqual({ ok: true });
+      expect(existsSync(sidecarPathFor(sessionId))).toBe(false);
+      expect(adapter.loadInAppPlanningSession(sessionId)?.draftPlanText).toBeUndefined();
+    } finally {
+      if (sessionId) rmSync(sidecarPathFor(sessionId), { force: true });
+      adapter.close();
+    }
+  });
+
+  it('reconstructs a missing sidecar file for a draft_ready session on restore', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    const sessionId = 'planning-sidecar-restore';
+    try {
+      const conversationRepo = new ConversationRepository(adapter);
+      const record: InAppPlanningSessionRecord = {
+        id: sessionId,
+        title: 'Restored draft with missing sidecar',
+        presetKey: 'codex',
+        status: 'draft_ready',
+        messages: [
+          { id: 1, role: 'user', text: 'Draft it', createdAt: '2026-07-07T00:00:01.000Z' },
+          { id: 2, role: 'assistant', text: VALID_PLAN, createdAt: '2026-07-07T00:00:02.000Z' },
+        ],
+        draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+        draftPlanText: VALID_PLAN_TEXT,
+        pendingResponse: false,
+        createdAt: '2026-07-07T00:00:00.000Z',
+        updatedAt: '2026-07-07T00:00:02.000Z',
+      };
+
+      expect(existsSync(sidecarPathFor(sessionId))).toBe(false);
+
+      const sessions = createInAppPlanningChatSessions();
+      await restorePlanningChatSessions([record], {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo,
+        planningSessionStore: adapter,
+      });
+
+      const sidecarPath = sidecarPathFor(sessionId);
+      expect(existsSync(sidecarPath)).toBe(true);
+      expect(readFileSync(sidecarPath, 'utf8')).toBe(VALID_PLAN_TEXT);
+    } finally {
+      rmSync(sidecarPathFor(sessionId), { force: true });
+      adapter.close();
+    }
+  });
+
+  it('removes the sidecar file when restore invalidates an unreadable draft', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    const sessionId = 'planning-sidecar-invalidated';
+    try {
+      const conversationRepo = new ConversationRepository(adapter);
+      const record: InAppPlanningSessionRecord = {
+        id: sessionId,
+        title: 'Restored draft that cannot be read',
+        presetKey: 'codex',
+        status: 'draft_ready',
+        messages: [
+          { id: 1, role: 'assistant', text: VALID_PLAN, createdAt: '2026-07-07T00:00:01.000Z' },
+        ],
+        pendingResponse: false,
+        createdAt: '2026-07-07T00:00:00.000Z',
+        updatedAt: '2026-07-07T00:00:01.000Z',
+      };
+
+      mkdirSync(dirname(sidecarPathFor(sessionId)), { recursive: true });
+      writeFileSync(sidecarPathFor(sessionId), 'stale sidecar contents', 'utf8');
+
+      const sessions = createInAppPlanningChatSessions();
+      await restorePlanningChatSessions([record], {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo,
+        planningSessionStore: adapter,
+      });
+
+      expect(sessions.get(sessionId)?.status).toBe('still_discussing');
+      expect(sessions.get(sessionId)?.draftPlanText).toBeUndefined();
+      expect(existsSync(sidecarPathFor(sessionId))).toBe(false);
+    } finally {
+      rmSync(sidecarPathFor(sessionId), { force: true });
+      adapter.close();
+    }
   });
 });
 

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -23,6 +23,7 @@ import {
   type InAppPlanningChatSession,
   type LoadedGeneratedPlan,
 } from '../in-app-planner.js';
+import type { PlanningRepoPool } from '../planning-chat-worktree.js';
 import { ConversationRepository, SQLiteAdapter, type InAppPlanningSessionRecord } from '@invoker/data-store';
 
 const VALID_PLAN = `Here is the plan.
@@ -1417,6 +1418,212 @@ tasks:
 
     expect(resetPlanningChat({ sessionId: 'session-1' }, { sessions })).toEqual({ ok: true });
     expect(sessions.has('session-1')).toBe(false);
+  });
+});
+
+describe('planning chat worktree provisioning', () => {
+  const planningCommandBuilder = vi.fn(() => ({ command: 'planner', args: ['prompt'] }));
+
+  function createFakeRepoPool(
+    worktreePath: string,
+  ): PlanningRepoPool & { release: ReturnType<typeof vi.fn>; softRelease: ReturnType<typeof vi.fn> } {
+    const release = vi.fn(async () => {});
+    const softRelease = vi.fn();
+    const acquireWorktree = vi.fn(async (_repoUrl: string, branch: string) => ({
+      clonePath: '/fake/clone',
+      worktreePath,
+      branch,
+      release,
+      softRelease,
+    }));
+    return {
+      ensureCloneThroughRepoQueue: vi.fn(async () => '/fake/clone'),
+      resolveBaseCommit: vi.fn(async () => 'fake-head-sha'),
+      acquireWorktree,
+      externalWorktreePath: vi.fn(() => worktreePath),
+      release,
+      softRelease,
+    };
+  }
+
+  it('provisions a worktree and persists the binding fields when repoPool + config.defaultRepoUrl are set', async () => {
+    const worktreePath = '/fake/worktree/create-session';
+    const repoPool = createFakeRepoPool(worktreePath);
+    const sessions = createInAppPlanningChatSessions();
+    const upsert = vi.fn();
+
+    const created = await createPlanningChatSession({}, {
+      config: { defaultRepoUrl: 'https://example.com/repo.git', defaultBranch: 'main' },
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+      repoPool,
+      planningSessionStore: {
+        upsertInAppPlanningSession: upsert,
+        updateInAppPlanningSession: vi.fn(),
+        deleteInAppPlanningSession: vi.fn(),
+      },
+    });
+    if (!created.ok) throw new Error(created.error);
+    const sessionId = created.session.id;
+    const expectedBranch = `invoker/planning/${sessionId}`;
+
+    expect(repoPool.ensureCloneThroughRepoQueue).toHaveBeenCalledWith('https://example.com/repo.git');
+    expect(repoPool.resolveBaseCommit).toHaveBeenCalledWith('https://example.com/repo.git', 'main');
+    expect(repoPool.acquireWorktree).toHaveBeenCalledWith(
+      'https://example.com/repo.git',
+      expectedBranch,
+      'fake-head-sha',
+      sessionId,
+    );
+    expect(repoPool.softRelease).toHaveBeenCalledTimes(1);
+
+    const session = sessions.get(sessionId);
+    expect(session?.repoUrl).toBe('https://example.com/repo.git');
+    expect(session?.baseBranch).toBe('main');
+    expect(session?.baseCommit).toBe('fake-head-sha');
+    expect(session?.worktreePath).toBe(worktreePath);
+    expect(session?.worktreeBranch).toBe(expectedBranch);
+    expect(session?.conversation.workingDir).toBe(worktreePath);
+
+    expect(upsert).toHaveBeenCalledWith(expect.objectContaining({
+      repoUrl: 'https://example.com/repo.git',
+      baseBranch: 'main',
+      baseCommit: 'fake-head-sha',
+      worktreePath,
+      worktreeBranch: expectedBranch,
+    }));
+  });
+
+  it('falls back to deps.workingDir exactly as before when no repoPool is supplied', async () => {
+    const workingDir = mkdtempSync(join(tmpdir(), 'in-app-no-repo-pool-'));
+    try {
+      const sessions = createInAppPlanningChatSessions();
+      const created = await createPlanningChatSession({}, {
+        config: { defaultRepoUrl: 'https://example.com/repo.git', defaultBranch: 'main' },
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        workingDir,
+      });
+      if (!created.ok) throw new Error(created.error);
+      const session = sessions.get(created.session.id);
+      expect(session?.repoUrl).toBeUndefined();
+      expect(session?.baseBranch).toBeUndefined();
+      expect(session?.baseCommit).toBeUndefined();
+      expect(session?.worktreePath).toBeUndefined();
+      expect(session?.worktreeBranch).toBeUndefined();
+      expect(session?.conversation.workingDir).toBe(workingDir);
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to deps.workingDir when repoPool is set but no defaultRepoUrl is configured', async () => {
+    const workingDir = mkdtempSync(join(tmpdir(), 'in-app-no-default-repo-'));
+    try {
+      const repoPool = createFakeRepoPool('/fake/should-not-be-used');
+      const sessions = createInAppPlanningChatSessions();
+      const created = await createPlanningChatSession({}, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        workingDir,
+        repoPool,
+      });
+      if (!created.ok) throw new Error(created.error);
+      expect(repoPool.acquireWorktree).not.toHaveBeenCalled();
+      const session = sessions.get(created.session.id);
+      expect(session?.worktreePath).toBeUndefined();
+      expect(session?.conversation.workingDir).toBe(workingDir);
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+    }
+  });
+
+  it('restore reconstructs a missing worktree for a session that has one recorded', async () => {
+    const worktreePath = '/fake/worktree/restore-missing';
+    const repoPool = createFakeRepoPool(worktreePath);
+    repoPool.externalWorktreePath = vi.fn(() => '/fake/worktree/restore-missing-nonexistent');
+
+    const record: InAppPlanningSessionRecord = {
+      id: 'planning-worktree-restore',
+      title: 'Restored plan with worktree',
+      presetKey: 'codex',
+      status: 'still_discussing',
+      confirmationMode: 'require',
+      repoUrl: 'https://example.com/repo.git',
+      baseBranch: 'main',
+      baseCommit: 'stored-base-commit',
+      worktreePath: '/fake/worktree/restore-missing-nonexistent',
+      worktreeBranch: 'invoker/planning/planning-worktree-restore',
+      messages: [],
+      pendingResponse: false,
+      createdAt: '2026-07-07T00:00:00.000Z',
+      updatedAt: '2026-07-07T00:00:00.000Z',
+    };
+
+    const sessions = createInAppPlanningChatSessions();
+    await restorePlanningChatSessions([record], {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+      repoPool,
+    });
+
+    expect(repoPool.acquireWorktree).toHaveBeenCalledWith(
+      'https://example.com/repo.git',
+      'invoker/planning/planning-worktree-restore',
+      'stored-base-commit',
+      'planning-worktree-restore',
+    );
+    expect(repoPool.resolveBaseCommit).not.toHaveBeenCalled();
+    const session = sessions.get('planning-worktree-restore');
+    expect(session?.worktreePath).toBe(worktreePath);
+    expect(session?.conversation.workingDir).toBe(worktreePath);
+  });
+
+  it('restore leaves worktreePath untouched when the recorded path already exists on disk', async () => {
+    const existingWorktreePath = mkdtempSync(join(tmpdir(), 'in-app-restore-present-'));
+    try {
+      const repoPool = createFakeRepoPool(existingWorktreePath);
+      repoPool.externalWorktreePath = vi.fn(() => existingWorktreePath);
+
+      const record: InAppPlanningSessionRecord = {
+        id: 'planning-worktree-present',
+        title: 'Restored plan with existing worktree',
+        presetKey: 'codex',
+        status: 'still_discussing',
+        confirmationMode: 'require',
+        repoUrl: 'https://example.com/repo.git',
+        baseBranch: 'main',
+        baseCommit: 'stored-base-commit',
+        worktreePath: existingWorktreePath,
+        worktreeBranch: 'invoker/planning/planning-worktree-present',
+        messages: [],
+        pendingResponse: false,
+        createdAt: '2026-07-07T00:00:00.000Z',
+        updatedAt: '2026-07-07T00:00:00.000Z',
+      };
+
+      const sessions = createInAppPlanningChatSessions();
+      await restorePlanningChatSessions([record], {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        repoPool,
+      });
+
+      expect(repoPool.acquireWorktree).not.toHaveBeenCalled();
+      const session = sessions.get('planning-worktree-present');
+      expect(session?.worktreePath).toBe(existingWorktreePath);
+      expect(session?.conversation.workingDir).toBe(existingWorktreePath);
+    } finally {
+      rmSync(existingWorktreePath, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/app/src/__tests__/planning-chat-worktree-repo-pool.test.ts
+++ b/packages/app/src/__tests__/planning-chat-worktree-repo-pool.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, writeFileSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execSync } from 'node:child_process';
+import { RepoPool } from '@invoker/execution-engine';
+import {
+  ensurePlanningWorktreeReady,
+  provisionPlanningWorktree,
+  resolvePlanningWorktreeBranch,
+} from '../planning-chat-worktree.js';
+
+function createTempRemoteRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'planning-worktree-remote-'));
+  execSync('git init', { cwd: dir });
+  execSync('git config user.email "test@test.com"', { cwd: dir });
+  execSync('git config user.name "Test"', { cwd: dir });
+  writeFileSync(join(dir, 'README.md'), '# Planning worktree test repo\n');
+  execSync('git add -A && git commit -m "initial"', { cwd: dir });
+  execSync('git branch -M main', { cwd: dir });
+  return realpathSync(dir);
+}
+
+describe('planning-chat-worktree against a real RepoPool', () => {
+  let cacheDir: string;
+  let worktreeBaseDir: string;
+  let remoteRepoUrl: string;
+  let pool: RepoPool;
+
+  beforeEach(() => {
+    cacheDir = realpathSync(mkdtempSync(join(tmpdir(), 'planning-worktree-cache-')));
+    worktreeBaseDir = realpathSync(mkdtempSync(join(tmpdir(), 'planning-worktree-base-')));
+    remoteRepoUrl = createTempRemoteRepo();
+    pool = new RepoPool({ cacheDir, worktreeBaseDir });
+  });
+
+  afterEach(async () => {
+    await pool.destroyAll();
+    rmSync(cacheDir, { recursive: true, force: true });
+    rmSync(worktreeBaseDir, { recursive: true, force: true });
+    rmSync(remoteRepoUrl, { recursive: true, force: true });
+  });
+
+  it('provisions a real worktree at the resolved HEAD commit, then recreates it after a disk-headroom-style wipe of both the clone cache and the worktree dir', async () => {
+    const sessionId = 'integration-session-1';
+    const branch = resolvePlanningWorktreeBranch(sessionId);
+
+    const provisioned = await provisionPlanningWorktree(pool, {
+      repoUrl: remoteRepoUrl,
+      baseBranch: 'main',
+      sessionId,
+    });
+
+    expect(provisioned.branch).toBe(branch);
+    expect(existsSync(provisioned.worktreePath)).toBe(true);
+    const headAfterProvision = execSync('git rev-parse HEAD', { cwd: provisioned.worktreePath }).toString().trim();
+    expect(headAfterProvision).toBe(provisioned.baseCommit);
+    const currentBranch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: provisioned.worktreePath }).toString().trim();
+    expect(currentBranch).toBe(branch);
+
+    const expectedPath = pool.externalWorktreePath(remoteRepoUrl, branch);
+    expect(realpathSync(provisioned.worktreePath)).toBe(realpathSync(expectedPath));
+
+    // Mirrors disk-headroom-reclaim.ts, which wholesale-wipes both the "repos"
+    // clone-cache dir and the "worktrees" dir together under disk pressure.
+    rmSync(pool.getClonePath(remoteRepoUrl), { recursive: true, force: true });
+    rmSync(provisioned.worktreePath, { recursive: true, force: true });
+    expect(existsSync(provisioned.worktreePath)).toBe(false);
+
+    const readyAfterWipe = await ensurePlanningWorktreeReady(pool, {
+      repoUrl: remoteRepoUrl,
+      baseCommit: provisioned.baseCommit,
+      sessionId,
+    });
+    expect(readyAfterWipe.recreated).toBe(true);
+    expect(realpathSync(readyAfterWipe.worktreePath)).toBe(realpathSync(expectedPath));
+    expect(existsSync(readyAfterWipe.worktreePath)).toBe(true);
+    const headAfterRecreate = execSync('git rev-parse HEAD', { cwd: readyAfterWipe.worktreePath }).toString().trim();
+    expect(headAfterRecreate).toBe(provisioned.baseCommit);
+    const branchAfterRecreate = execSync('git rev-parse --abbrev-ref HEAD', { cwd: readyAfterWipe.worktreePath }).toString().trim();
+    expect(branchAfterRecreate).toBe(branch);
+
+    const readyWhenPresent = await ensurePlanningWorktreeReady(pool, {
+      repoUrl: remoteRepoUrl,
+      baseCommit: provisioned.baseCommit,
+      sessionId,
+    });
+    expect(readyWhenPresent.recreated).toBe(false);
+    expect(realpathSync(readyWhenPresent.worktreePath)).toBe(realpathSync(expectedPath));
+  }, 30_000);
+
+  it('recreates at the original stored commit even if the remote branch has since advanced', async () => {
+    const sessionId = 'integration-session-2';
+    const branch = resolvePlanningWorktreeBranch(sessionId);
+
+    const provisioned = await provisionPlanningWorktree(pool, {
+      repoUrl: remoteRepoUrl,
+      baseBranch: 'main',
+      sessionId,
+    });
+    const originalCommit = provisioned.baseCommit;
+
+    writeFileSync(join(remoteRepoUrl, 'CHANGED.md'), 'advanced\n');
+    execSync('git add -A && git commit -m "advance main"', { cwd: remoteRepoUrl });
+    const advancedCommit = execSync('git rev-parse HEAD', { cwd: remoteRepoUrl }).toString().trim();
+    expect(advancedCommit).not.toBe(originalCommit);
+
+    rmSync(pool.getClonePath(remoteRepoUrl), { recursive: true, force: true });
+    rmSync(provisioned.worktreePath, { recursive: true, force: true });
+
+    const ready = await ensurePlanningWorktreeReady(pool, {
+      repoUrl: remoteRepoUrl,
+      baseCommit: originalCommit,
+      sessionId,
+    });
+    expect(ready.recreated).toBe(true);
+    const headAfterRecreate = execSync('git rev-parse HEAD', { cwd: ready.worktreePath }).toString().trim();
+    expect(headAfterRecreate).toBe(originalCommit);
+    expect(headAfterRecreate).not.toBe(advancedCommit);
+    const branchName = execSync('git rev-parse --abbrev-ref HEAD', { cwd: ready.worktreePath }).toString().trim();
+    expect(branchName).toBe(branch);
+  }, 30_000);
+});

--- a/packages/app/src/__tests__/planning-chat-worktree.test.ts
+++ b/packages/app/src/__tests__/planning-chat-worktree.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  ensurePlanningWorktreeReady,
+  provisionPlanningWorktree,
+  releasePlanningWorktree,
+  resolvePlanningWorktreeBranch,
+  type PlanningRepoPool,
+} from '../planning-chat-worktree.js';
+
+function createFakePool(overrides: Partial<Record<keyof PlanningRepoPool, unknown>> = {}) {
+  const release = vi.fn().mockResolvedValue(undefined);
+  const softRelease = vi.fn();
+  const ensureCloneThroughRepoQueue = vi.fn().mockResolvedValue('/clone/path');
+  const resolveBaseCommit = vi.fn().mockResolvedValue('resolved-head-sha');
+  const acquireWorktree = vi.fn().mockResolvedValue({
+    clonePath: '/clone/path',
+    worktreePath: '/worktrees/acquired',
+    branch: 'invoker/planning/session-1',
+    release,
+    softRelease,
+  });
+  const externalWorktreePath = vi.fn().mockReturnValue('/worktrees/deterministic');
+  return {
+    pool: {
+      ensureCloneThroughRepoQueue,
+      resolveBaseCommit,
+      acquireWorktree,
+      externalWorktreePath,
+      ...overrides,
+    } as unknown as PlanningRepoPool,
+    spies: { ensureCloneThroughRepoQueue, resolveBaseCommit, acquireWorktree, externalWorktreePath, release, softRelease },
+  };
+}
+
+describe('resolvePlanningWorktreeBranch', () => {
+  it('derives an invoker/-prefixed branch name from the session id', () => {
+    expect(resolvePlanningWorktreeBranch('session-1')).toBe('invoker/planning/session-1');
+  });
+});
+
+describe('provisionPlanningWorktree', () => {
+  let installSpy: ReturnType<typeof vi.fn> | undefined;
+
+  beforeEach(() => {
+    installSpy = undefined;
+  });
+
+  it('calls pool methods in order and returns the acquired worktree, calling softRelease', async () => {
+    const { pool, spies } = createFakePool();
+    const calls: string[] = [];
+    spies.ensureCloneThroughRepoQueue.mockImplementation(async (repoUrl: string) => {
+      calls.push('ensureCloneThroughRepoQueue');
+      return `/clone/${repoUrl}`;
+    });
+    spies.resolveBaseCommit.mockImplementation(async () => {
+      calls.push('resolveBaseCommit');
+      return 'resolved-head-sha';
+    });
+    spies.acquireWorktree.mockImplementation(async () => {
+      calls.push('acquireWorktree');
+      return {
+        clonePath: '/clone/path',
+        worktreePath: '/nonexistent/planning-worktree-path-for-test',
+        branch: 'invoker/planning/session-1',
+        release: spies.release,
+        softRelease: spies.softRelease,
+      };
+    });
+
+    const result = await provisionPlanningWorktree(pool, {
+      repoUrl: 'https://example.com/repo.git',
+      baseBranch: 'main',
+      sessionId: 'session-1',
+    });
+
+    expect(calls).toEqual(['ensureCloneThroughRepoQueue', 'resolveBaseCommit', 'acquireWorktree']);
+    expect(spies.acquireWorktree).toHaveBeenCalledWith(
+      'https://example.com/repo.git',
+      'invoker/planning/session-1',
+      'resolved-head-sha',
+      'session-1',
+    );
+    expect(result).toEqual({
+      worktreePath: '/nonexistent/planning-worktree-path-for-test',
+      baseCommit: 'resolved-head-sha',
+      branch: 'invoker/planning/session-1',
+    });
+    expect(spies.softRelease).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ensurePlanningWorktreeReady', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'planning-worktree-ready-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns recreated: false without acquiring when the worktree already exists on disk', async () => {
+    const { pool, spies } = createFakePool();
+    spies.externalWorktreePath.mockReturnValue(tmpDir);
+    expect(existsSync(tmpDir)).toBe(true);
+
+    const result = await ensurePlanningWorktreeReady(pool, {
+      repoUrl: 'https://example.com/repo.git',
+      baseCommit: 'stored-base-commit',
+      sessionId: 'session-1',
+    });
+
+    expect(result).toEqual({ worktreePath: tmpDir, recreated: false });
+    expect(spies.acquireWorktree).not.toHaveBeenCalled();
+    expect(spies.resolveBaseCommit).not.toHaveBeenCalled();
+    expect(spies.ensureCloneThroughRepoQueue).not.toHaveBeenCalled();
+  });
+
+  it('recreates using the stored baseCommit (never re-resolving HEAD) when the path is missing', async () => {
+    const missingPath = join(tmpDir, 'missing', 'worktree');
+    const { pool, spies } = createFakePool();
+    spies.externalWorktreePath.mockReturnValue(missingPath);
+    spies.acquireWorktree.mockResolvedValue({
+      clonePath: '/clone/path',
+      worktreePath: missingPath,
+      branch: 'invoker/planning/session-1',
+      release: spies.release,
+      softRelease: spies.softRelease,
+    });
+    expect(existsSync(missingPath)).toBe(false);
+
+    const result = await ensurePlanningWorktreeReady(pool, {
+      repoUrl: 'https://example.com/repo.git',
+      baseCommit: 'stored-base-commit',
+      sessionId: 'session-1',
+    });
+
+    expect(spies.resolveBaseCommit).not.toHaveBeenCalled();
+    expect(spies.ensureCloneThroughRepoQueue).toHaveBeenCalledWith('https://example.com/repo.git');
+    expect(spies.acquireWorktree).toHaveBeenCalledWith(
+      'https://example.com/repo.git',
+      'invoker/planning/session-1',
+      'stored-base-commit',
+      'session-1',
+    );
+    expect(result).toEqual({ worktreePath: missingPath, recreated: true });
+    expect(spies.softRelease).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('releasePlanningWorktree', () => {
+  it('re-acquires the deterministic worktree then calls release()', async () => {
+    const { pool, spies } = createFakePool();
+
+    await releasePlanningWorktree(pool, {
+      repoUrl: 'https://example.com/repo.git',
+      baseCommit: 'stored-base-commit',
+      sessionId: 'session-1',
+    });
+
+    expect(spies.acquireWorktree).toHaveBeenCalledWith(
+      'https://example.com/repo.git',
+      'invoker/planning/session-1',
+      'stored-base-commit',
+      'session-1',
+    );
+    expect(spies.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -48,6 +48,13 @@ import {
 } from '@invoker/planning-core';
 import type { HarnessPreset, PlanConversation, PlanConversationConfig, PlanningCommandBuilder } from '@invoker/surfaces';
 import type { InvokerConfig } from './config.js';
+import { ensurePlanningWorktreeReady, provisionPlanningWorktree, type PlanningRepoPool } from './planning-chat-worktree.js';
+
+function logPlanningWorktreeReadyError(sessionId: string, step: string, error: unknown): void {
+  console.error(`[planning-chat] ensurePlanningWorktreeReady ${step} failed session="${sessionId}": ${
+    error instanceof Error ? error.message : String(error)
+  }`);
+}
 
 export interface LoadedGeneratedPlan {
   planName: string;
@@ -81,6 +88,11 @@ export interface InAppPlanningChatSession {
   status: InAppPlanningSessionStatus;
   messages: InAppPlanningChatLine[];
   conversation: PlanConversation;
+  repoUrl?: string;
+  baseBranch?: string;
+  baseCommit?: string;
+  worktreePath?: string;
+  worktreeBranch?: string;
   draftPlanSummary?: InAppPlanningPlanSummary;
   draftPlanText?: string;
   submittedWorkflowId?: string;
@@ -398,6 +410,11 @@ function sessionToRecord(session: InAppPlanningChatSession, pendingResponse: boo
     presetKey: session.presetKey,
     status: session.status,
     confirmationMode: session.confirmationMode ?? 'require',
+    repoUrl: session.repoUrl,
+    baseBranch: session.baseBranch,
+    baseCommit: session.baseCommit,
+    worktreePath: session.worktreePath,
+    worktreeBranch: session.worktreeBranch,
     messages: session.messages,
     draftPlanSummary: session.draftPlanSummary,
     draftPlanText: session.draftPlanText,
@@ -593,6 +610,7 @@ async function createSession(
     sessions: InAppPlanningChatSessions;
     planningCommandBuilder: PlanningCommandBuilder;
     planningSessionStore?: InAppPlanningSessionStore;
+    repoPool?: PlanningRepoPool;
   },
 ): Promise<InAppPlanningChatSession | { error: string }> {
   const presets = await resolveHarnessPresets(deps.config);
@@ -612,6 +630,24 @@ async function createSession(
     request?.confirmationMode,
     resolveDefaultPlanningConfirmationMode(deps.config),
   );
+
+  const repoUrl = deps.config.defaultRepoUrl;
+  const baseBranch = deps.config.defaultBranch ?? 'main';
+  let worktreeBinding:
+    | { repoUrl: string; baseBranch: string; baseCommit: string; worktreePath: string; worktreeBranch: string }
+    | undefined;
+  if (deps.repoPool && typeof repoUrl === 'string' && repoUrl.trim()) {
+    const provisioned = await provisionPlanningWorktree(deps.repoPool, { repoUrl, baseBranch, sessionId: id });
+    worktreeBinding = {
+      repoUrl,
+      baseBranch,
+      baseCommit: provisioned.baseCommit,
+      worktreePath: provisioned.worktreePath,
+      worktreeBranch: provisioned.branch,
+    };
+  }
+  const conversationDeps = worktreeBinding ? { ...deps, workingDir: worktreeBinding.worktreePath } : deps;
+
   const session: InAppPlanningChatSession = {
     id,
     title: typeof request?.title === 'string' && request.title.trim() ? request.title.trim() : 'Untitled plan',
@@ -619,7 +655,12 @@ async function createSession(
     confirmationMode,
     status: 'still_discussing',
     messages: [],
-    conversation: new PlanConversation(planConversationConfig(preset, deps, id, selectHarnessSessionDriver, { conversationalPlanning: true })),
+    conversation: new PlanConversation(planConversationConfig(preset, conversationDeps, id, selectHarnessSessionDriver, { conversationalPlanning: true })),
+    repoUrl: worktreeBinding?.repoUrl,
+    baseBranch: worktreeBinding?.baseBranch,
+    baseCommit: worktreeBinding?.baseCommit,
+    worktreePath: worktreeBinding?.worktreePath,
+    worktreeBranch: worktreeBinding?.worktreeBranch,
     createdAt,
     updatedAt: createdAt,
     nextMessageId: 1,
@@ -699,6 +740,7 @@ export async function createPlanningChatSession(
     sessions: InAppPlanningChatSessions;
     planningCommandBuilder: PlanningCommandBuilder;
     planningSessionStore?: InAppPlanningSessionStore;
+    repoPool?: PlanningRepoPool;
   },
 ): Promise<InAppPlanningCreateSessionResponse> {
   try {
@@ -727,6 +769,7 @@ export async function sendPlanningChatMessage(
     sessions: InAppPlanningChatSessions;
     planningCommandBuilder: PlanningCommandBuilder;
     planningSessionStore?: InAppPlanningSessionStore;
+    repoPool?: PlanningRepoPool;
   },
 ): Promise<InAppPlanningChatResponse> {
   const rawRequest = request as Partial<InAppPlanningChatRequest> | null | undefined;
@@ -790,6 +833,18 @@ export async function sendPlanningChatMessage(
       try {
         const { extractYamlPlan } = await loadPlannerSurfaces();
         const formattedMessage = formatConversationalPlanningMessage(message);
+        if (deps.repoPool && activeSession.worktreePath && activeSession.repoUrl && activeSession.baseCommit) {
+          try {
+            await ensurePlanningWorktreeReady(deps.repoPool, {
+              repoUrl: activeSession.repoUrl,
+              baseCommit: activeSession.baseCommit,
+              sessionId: activeSession.id,
+              worktreePath: activeSession.worktreePath,
+            });
+          } catch (error) {
+            logPlanningWorktreeReadyError(activeSession.id, 'before-send', error);
+          }
+        }
         const reply = deps.plannerReplyOverride
           ? await deps.plannerReplyOverride(formattedMessage)
           : await activeSession.conversation.sendMessage(formattedMessage);
@@ -1057,6 +1112,7 @@ export async function restorePlanningChatSessions(
     sessions: InAppPlanningChatSessions;
     planningCommandBuilder: PlanningCommandBuilder;
     planningSessionStore?: InAppPlanningSessionStore;
+    repoPool?: PlanningRepoPool;
   },
 ): Promise<void> {
   // Nothing persisted → skip loading @invoker/surfaces. The built required-fast CI app
@@ -1069,7 +1125,23 @@ export async function restorePlanningChatSessions(
     const preset = presets[record.presetKey];
     if (!preset) continue;
 
-    const conversation = new PlanConversation(planConversationConfig(preset, deps, record.id, selectHarnessSessionDriver));
+    let restoredWorktreePath: string | undefined;
+    if (deps.repoPool && record.worktreePath && record.repoUrl && record.baseCommit) {
+      try {
+        const ready = await ensurePlanningWorktreeReady(deps.repoPool, {
+          repoUrl: record.repoUrl,
+          baseCommit: record.baseCommit,
+          sessionId: record.id,
+          worktreePath: record.worktreePath,
+        });
+        restoredWorktreePath = ready.worktreePath;
+      } catch (error) {
+        logPlanningWorktreeReadyError(record.id, 'restore', error);
+      }
+    }
+    const conversationDeps = restoredWorktreePath ? { ...deps, workingDir: restoredWorktreePath } : deps;
+
+    const conversation = new PlanConversation(planConversationConfig(preset, conversationDeps, record.id, selectHarnessSessionDriver));
     await conversation.init();
 
     const nextMessageId = Math.max(0, ...record.messages.map((message) => message.id)) + 1;
@@ -1081,6 +1153,11 @@ export async function restorePlanningChatSessions(
       status: record.status,
       messages: [...record.messages],
       conversation,
+      repoUrl: record.repoUrl,
+      baseBranch: record.baseBranch,
+      baseCommit: record.baseCommit,
+      worktreePath: restoredWorktreePath ?? record.worktreePath,
+      worktreeBranch: record.worktreeBranch,
       draftPlanSummary: record.draftPlanSummary,
       draftPlanText: record.draftPlanText,
       submittedWorkflowId: record.submittedWorkflowId,

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from 'node:crypto';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import type {
   InAppPlanRequest,
   InAppPlanResponse,
@@ -27,6 +29,7 @@ import type {
   PlanningTerminalMode,
   PlanningPresetOption,
 } from '@invoker/contracts';
+import { resolveInvokerHomeRoot } from '@invoker/contracts';
 import type {
   ConversationMessageEntry,
   ConversationRepository,
@@ -453,6 +456,42 @@ function assertPersistablePlanningSession(
   }
 }
 
+function planDraftSidecarPath(sessionId: string): string {
+  return join(resolveInvokerHomeRoot(), 'plan-drafts', `${sessionId}.yaml`);
+}
+
+function logPlanDraftSidecarError(sessionId: string, step: string, error: unknown): void {
+  console.error(`[planning-chat] plan draft sidecar ${step} failed session="${sessionId}": ${
+    error instanceof Error ? error.message : String(error)
+  }`);
+}
+
+function writePlanDraftSidecar(sessionId: string, planText: string): void {
+  try {
+    const sidecarPath = planDraftSidecarPath(sessionId);
+    mkdirSync(dirname(sidecarPath), { recursive: true });
+    writeFileSync(sidecarPath, planText, 'utf8');
+  } catch (error) {
+    logPlanDraftSidecarError(sessionId, 'write', error);
+  }
+}
+
+function removePlanDraftSidecarIfPresent(sessionId: string): void {
+  try {
+    rmSync(planDraftSidecarPath(sessionId), { force: true });
+  } catch (error) {
+    logPlanDraftSidecarError(sessionId, 'remove', error);
+  }
+}
+
+function syncPlanDraftSidecar(session: Pick<InAppPlanningChatSession, 'id' | 'draftPlanText'>): void {
+  if (session.draftPlanText && session.draftPlanText.trim()) {
+    writePlanDraftSidecar(session.id, session.draftPlanText);
+  } else {
+    removePlanDraftSidecarIfPresent(session.id);
+  }
+}
+
 function persistPlanningSession(
   session: InAppPlanningChatSession,
   store: InAppPlanningSessionStore | undefined,
@@ -461,6 +500,7 @@ function persistPlanningSession(
   if (!store) return;
   assertPersistablePlanningSession(session, pendingResponse);
   store.upsertInAppPlanningSession(sessionToRecord(session, pendingResponse));
+  syncPlanDraftSidecar(session);
 }
 
 function saveOverrideConversation(
@@ -1100,6 +1140,7 @@ export async function restorePlanningChatSessions(
     }
 
     deps.sessions.set(session.id, session);
+    syncPlanDraftSidecar(session);
     if (shouldPersist) {
       persistPlanningSession(session, deps.planningSessionStore, false);
     }

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -42,6 +42,7 @@ import {
 } from '../config.js';
 import { resolveAutoApproveAIFixes, resolveAutoFixRetries } from '../autofix-defaults.js';
 import { backupPlan } from '../plan-backup.js';
+import { loadPlanSubmissionBundle } from '../plan-submission-loader.js';
 import { runHeadless, resolveAgentSession } from '../headless.js';
 import type { HeadlessDeps } from '../headless.js';
 import { resolveRefreshTaskGraphSnapshot } from '../refresh-task-graph.js';
@@ -1199,57 +1200,16 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     planText: string,
     options?: { preserveTaskHandles?: boolean; logLabel?: string },
   ): Promise<{ planName: string; workflowId: string; workflowIds?: string[]; workflowCount?: number }> {
-    const { applyConfiguredPlanDefaults, parsePlanSubmissionBundle } = await import('../plan-parser.js');
-    const submission = parsePlanSubmissionBundle(planText);
-    const existingWorkflowIds = new Set(persistence.listWorkflows().map((workflow) => workflow.id));
-    const loadedWorkflowIds: string[] = [];
-    let upstream: { workflowId: string; featureBranch: string } | undefined;
-    logger.info(
-      `${options?.logLabel ?? 'plan-from-goal'}: loading "${submission.name}" (${submission.plans.length} workflow${submission.plans.length === 1 ? '' : 's'})`,
-      { module: 'ipc' },
-    );
-    if (!options?.preserveTaskHandles) {
-      taskHandles.clear();
-    }
-
-    for (const parsedPlan of submission.plans) {
-      let plan = applyConfiguredPlanDefaults(parsedPlan);
-      if (upstream) {
-        plan = {
-          ...plan,
-          baseBranch: upstream.featureBranch,
-          externalDependencies: [
-            ...(plan.externalDependencies ?? []),
-            {
-              workflowId: upstream.workflowId,
-              taskId: '__merge__',
-              requiredStatus: 'completed',
-              gatePolicy: 'review_ready',
-            } as const,
-          ],
-        };
-      }
-      backupPlan(plan, undefined, logger);
-      orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
-      const workflow = persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
-      if (!workflow) {
-        throw new Error('Loaded plan did not create a workflow.');
-      }
-      existingWorkflowIds.add(workflow.id);
-      loadedWorkflowIds.push(workflow.id);
-      upstream = { workflowId: workflow.id, featureBranch: workflow.featureBranch ?? plan.featureBranch ?? plan.baseBranch ?? 'main' };
-    }
-
-    const workflowId = loadedWorkflowIds[loadedWorkflowIds.length - 1];
-    if (!workflowId) {
-      throw new Error('Loaded plan did not create a workflow.');
-    }
-    return {
-      planName: submission.name,
-      workflowId,
-      workflowIds: loadedWorkflowIds,
-      workflowCount: loadedWorkflowIds.length,
-    };
+    return loadPlanSubmissionBundle(planText, {
+      persistence,
+      orchestrator,
+      allowGraphMutation: invokerConfig.allowGraphMutation,
+      logger,
+    }, {
+      logLabel: options?.logLabel ?? 'plan-from-goal',
+      preserveTaskHandles: options?.preserveTaskHandles,
+      taskHandles,
+    });
   }
 
   const planningConversationRepo = new ConversationRepository(persistence, {

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -31,6 +31,7 @@ import {
   parseSpawnRepairWorkflowMutationArgs,
   SPAWN_REPAIR_WORKFLOW_CHANNEL,
   submitRepairWorkflowFromCiFailure,
+  type WorktreeExecutor,
 } from '@invoker/execution-engine';
 import type { AgentRegistry, WorkerRegistry, WorkerRuntimeDependencies } from '@invoker/execution-engine';
 import {
@@ -1227,6 +1228,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     conversationRepo: planningConversationRepo,
     planningSessionStore: ownerMode ? persistence : undefined,
     onRawPlannerOutput: emitPlanningChatStream,
+    repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
   });
   let testPlanFromGoalResponse: { planYaml: string; planName: string } | null = null;
   // Two variants: (1) a successful override that returns a canned reply +
@@ -1263,6 +1265,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       conversationRepo: planningConversationRepo,
       planningSessionStore: ownerMode ? persistence : undefined,
       onRawPlannerOutput: emitPlanningChatStream,
+      repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
     });
   });
   registerGuiMutationHandler('invoker:planning-chat-list', async () => {
@@ -1292,6 +1295,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       planningSessionStore: ownerMode ? persistence : undefined,
       plannerReplyOverride,
       onRawPlannerOutput: emitPlanningChatStream,
+      repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
     });
   });
   registerGuiMutationHandler('invoker:planning-chat-submit', async (request: unknown) => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1105,6 +1105,7 @@ function startHeadlessMode(): void {
         loadGeneratedPlan,
         conversationRepo: planningConversationRepo,
         planningSessionStore: readOnlyMode ? undefined : persistence,
+        repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
       });
 
       const executeStandaloneGuiMutation = async (payload: GuiMutationPayload): Promise<unknown> => {
@@ -1149,6 +1150,7 @@ function startHeadlessMode(): void {
               loadGeneratedPlan,
               conversationRepo: planningConversationRepo,
               planningSessionStore: readOnlyMode ? undefined : persistence,
+              repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
             });
           }
           case 'invoker:planning-chat-list': {
@@ -1164,6 +1166,7 @@ function startHeadlessMode(): void {
               loadGeneratedPlan,
               conversationRepo: planningConversationRepo,
               planningSessionStore: readOnlyMode ? undefined : persistence,
+              repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
             });
           }
           case 'invoker:planning-chat-submit': {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -148,6 +148,7 @@ import {
   isRemovedHeadlessCommandAlias,
 } from './headless-command-registry.js';
 import { backupPlan } from './plan-backup.js';
+import { loadPlanSubmissionBundle } from './plan-submission-loader.js';
 import { startApiServer, type ApiServer } from './api-server.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import {
@@ -1081,53 +1082,14 @@ function startHeadlessMode(): void {
 
       const loadGeneratedPlan = async (
         planText: string,
-      ): Promise<{ planName: string; workflowId: string; workflowIds?: string[]; workflowCount?: number }> => {
-        const { applyConfiguredPlanDefaults, parsePlanSubmissionBundle } = await import('./plan-parser.js');
-        const submission = parsePlanSubmissionBundle(planText);
-        const existingWorkflowIds = new Set(persistence.listWorkflows().map((workflow) => workflow.id));
-        const loadedWorkflowIds: string[] = [];
-        let upstream: { workflowId: string; featureBranch: string } | undefined;
-
-        for (const parsedPlan of submission.plans) {
-          let plan = applyConfiguredPlanDefaults(parsedPlan);
-          if (upstream) {
-            plan = {
-              ...plan,
-              baseBranch: upstream.featureBranch,
-              externalDependencies: [
-                ...(plan.externalDependencies ?? []),
-                {
-                  workflowId: upstream.workflowId,
-                  taskId: '__merge__',
-                  requiredStatus: 'completed',
-                  gatePolicy: 'review_ready',
-                } as const,
-              ],
-            };
-          }
-          backupPlan(plan, undefined, logger);
-          orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
-          const workflow = persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
-          if (!workflow) {
-            throw new Error('Loaded plan did not create a workflow.');
-          }
-          existingWorkflowIds.add(workflow.id);
-          loadedWorkflowIds.push(workflow.id);
-          upstream = { workflowId: workflow.id, featureBranch: workflow.featureBranch ?? plan.featureBranch ?? plan.baseBranch ?? 'main' };
-        }
-
-        const workflowId = loadedWorkflowIds[loadedWorkflowIds.length - 1];
-        if (!workflowId) {
-          throw new Error('Loaded plan did not create a workflow.');
-        }
-
-        return {
-          planName: submission.name,
-          workflowId,
-          workflowIds: loadedWorkflowIds,
-          workflowCount: loadedWorkflowIds.length,
-        };
-      };
+      ): Promise<{ planName: string; workflowId: string; workflowIds?: string[]; workflowCount?: number }> => (
+        loadPlanSubmissionBundle(planText, {
+          persistence,
+          orchestrator,
+          allowGraphMutation: invokerConfig.allowGraphMutation,
+          logger,
+        })
+      );
 
       const planningConversationRepo = new ConversationRepository(persistence, {
         info: (message) => logger.info(message, { module: 'planning-chat' }),

--- a/packages/app/src/plan-submission-loader.ts
+++ b/packages/app/src/plan-submission-loader.ts
@@ -1,0 +1,84 @@
+import type { Logger } from '@invoker/contracts';
+import type { PlanDefinition } from '@invoker/workflow-core';
+import { backupPlan } from './plan-backup.js';
+
+export interface PlanSubmissionLoadResult {
+  planName: string;
+  workflowId: string;
+  workflowIds?: string[];
+  workflowCount?: number;
+}
+
+export interface PlanSubmissionLoadDeps {
+  persistence: { listWorkflows(): Array<{ id: string; featureBranch?: string }> };
+  orchestrator: { loadPlan(plan: PlanDefinition, opts: { allowGraphMutation?: boolean }): void };
+  allowGraphMutation?: boolean;
+  logger?: Logger;
+}
+
+export interface PlanSubmissionLoadOptions {
+  logLabel?: string;
+  preserveTaskHandles?: boolean;
+  taskHandles?: { clear(): void };
+}
+
+export async function loadPlanSubmissionBundle(
+  planText: string,
+  deps: PlanSubmissionLoadDeps,
+  options?: PlanSubmissionLoadOptions,
+): Promise<PlanSubmissionLoadResult> {
+  const { applyConfiguredPlanDefaults, parsePlanSubmissionBundle } = await import('./plan-parser.js');
+  const submission = parsePlanSubmissionBundle(planText);
+  const existingWorkflowIds = new Set(deps.persistence.listWorkflows().map((workflow) => workflow.id));
+  const loadedWorkflowIds: string[] = [];
+  let upstream: { workflowId: string; featureBranch: string } | undefined;
+
+  if (options?.logLabel) {
+    deps.logger?.info(
+      `${options.logLabel}: loading "${submission.name}" (${submission.plans.length} workflow${submission.plans.length === 1 ? '' : 's'})`,
+      { module: 'ipc' },
+    );
+  }
+  if (options?.taskHandles && !options.preserveTaskHandles) {
+    options.taskHandles.clear();
+  }
+
+  for (const parsedPlan of submission.plans) {
+    let plan = applyConfiguredPlanDefaults(parsedPlan);
+    if (upstream) {
+      plan = {
+        ...plan,
+        baseBranch: upstream.featureBranch,
+        externalDependencies: [
+          ...(plan.externalDependencies ?? []),
+          {
+            workflowId: upstream.workflowId,
+            taskId: '__merge__',
+            requiredStatus: 'completed',
+            gatePolicy: 'review_ready',
+          } as const,
+        ],
+      };
+    }
+    backupPlan(plan, undefined, deps.logger);
+    deps.orchestrator.loadPlan(plan, { allowGraphMutation: deps.allowGraphMutation });
+    const workflow = deps.persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
+    if (!workflow) {
+      throw new Error('Loaded plan did not create a workflow.');
+    }
+    existingWorkflowIds.add(workflow.id);
+    loadedWorkflowIds.push(workflow.id);
+    upstream = { workflowId: workflow.id, featureBranch: workflow.featureBranch ?? plan.featureBranch ?? plan.baseBranch ?? 'main' };
+  }
+
+  const workflowId = loadedWorkflowIds[loadedWorkflowIds.length - 1];
+  if (!workflowId) {
+    throw new Error('Loaded plan did not create a workflow.');
+  }
+  return {
+    planName: submission.name,
+    workflowId,
+    workflowIds: loadedWorkflowIds,
+    workflowCount: loadedWorkflowIds.length,
+  };
+}

--- a/packages/app/src/planning-chat-worktree.ts
+++ b/packages/app/src/planning-chat-worktree.ts
@@ -1,0 +1,103 @@
+import { existsSync } from 'node:fs';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { AcquiredWorktree, RepoPool } from '@invoker/execution-engine';
+
+const execFileAsync = promisify(execFile);
+
+const PLANNING_WORKTREE_INSTALL_TIMEOUT_MS = 120_000;
+
+export type PlanningRepoPool = Pick<
+  RepoPool,
+  'ensureCloneThroughRepoQueue' | 'resolveBaseCommit' | 'acquireWorktree' | 'externalWorktreePath'
+>;
+
+export function resolvePlanningWorktreeBranch(sessionId: string): string {
+  return `invoker/planning/${sessionId}`;
+}
+
+export interface PlanningWorktreeBinding {
+  repoUrl: string;
+  baseBranch: string;
+  sessionId: string;
+}
+
+export interface ProvisionedPlanningWorktree {
+  worktreePath: string;
+  baseCommit: string;
+  branch: string;
+}
+
+export interface PlanningWorktreeState {
+  repoUrl: string;
+  baseCommit: string;
+  sessionId: string;
+  worktreePath?: string;
+}
+
+async function runBestEffortInstall(worktreePath: string): Promise<void> {
+  try {
+    await execFileAsync('pnpm', ['install', '--frozen-lockfile'], {
+      cwd: worktreePath,
+      timeout: PLANNING_WORKTREE_INSTALL_TIMEOUT_MS,
+    });
+  } catch (error) {
+    console.warn(
+      `[planning-chat-worktree] pnpm install --frozen-lockfile failed in ${worktreePath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+async function acquireProvisionAndSoftRelease(
+  pool: Pick<PlanningRepoPool, 'acquireWorktree'>,
+  repoUrl: string,
+  branch: string,
+  baseCommit: string,
+  sessionId: string,
+): Promise<AcquiredWorktree> {
+  const acquired = await pool.acquireWorktree(repoUrl, branch, baseCommit, sessionId);
+  await runBestEffortInstall(acquired.worktreePath);
+  // A planning-chat worktree lives for the whole chat session, not a single task run,
+  // so it must not hold one of RepoPool's limited concurrent-worktree slots the whole time.
+  acquired.softRelease();
+  return acquired;
+}
+
+export async function provisionPlanningWorktree(
+  pool: PlanningRepoPool,
+  binding: PlanningWorktreeBinding,
+): Promise<ProvisionedPlanningWorktree> {
+  const { repoUrl, baseBranch, sessionId } = binding;
+  await pool.ensureCloneThroughRepoQueue(repoUrl);
+  const baseCommit = await pool.resolveBaseCommit(repoUrl, baseBranch);
+  const branch = resolvePlanningWorktreeBranch(sessionId);
+  const acquired = await acquireProvisionAndSoftRelease(pool, repoUrl, branch, baseCommit, sessionId);
+  return { worktreePath: acquired.worktreePath, baseCommit, branch };
+}
+
+export async function ensurePlanningWorktreeReady(
+  pool: PlanningRepoPool,
+  state: PlanningWorktreeState,
+): Promise<{ worktreePath: string; recreated: boolean }> {
+  const branch = resolvePlanningWorktreeBranch(state.sessionId);
+  const expectedPath = pool.externalWorktreePath(state.repoUrl, branch);
+  if (existsSync(expectedPath)) {
+    return { worktreePath: expectedPath, recreated: false };
+  }
+  await pool.ensureCloneThroughRepoQueue(state.repoUrl);
+  // Recreate at the previously-resolved commit, not a freshly resolved HEAD, so a
+  // disk-headroom wipe restores exactly what was there rather than silently rebasing.
+  const acquired = await acquireProvisionAndSoftRelease(pool, state.repoUrl, branch, state.baseCommit, state.sessionId);
+  return { worktreePath: acquired.worktreePath, recreated: true };
+}
+
+export async function releasePlanningWorktree(
+  pool: Pick<PlanningRepoPool, 'acquireWorktree'>,
+  state: { repoUrl: string; baseCommit: string; sessionId: string },
+): Promise<void> {
+  const branch = resolvePlanningWorktreeBranch(state.sessionId);
+  const acquired = await pool.acquireWorktree(state.repoUrl, branch, state.baseCommit, state.sessionId);
+  await acquired.release();
+}

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -477,6 +477,11 @@ describe('SQLiteAdapter', () => {
         'pending_response',
         'created_at',
         'updated_at',
+        'repo_url',
+        'base_branch',
+        'base_commit',
+        'worktree_path',
+        'worktree_branch',
       ]);
       expect(tableColumns(adapter, 'in_app_planning_messages')).toEqual([
         'session_id',
@@ -578,6 +583,56 @@ describe('SQLiteAdapter', () => {
       });
       expect(loaded?.draftPlanSummary).toBeUndefined();
       expect(loaded?.draftPlanText).toBeUndefined();
+    });
+
+    it('round-trips repo/HEAD/worktree binding columns when populated', () => {
+      adapter.upsertInAppPlanningSession(makePlanningSession('planning-binding', {
+        repoUrl: 'https://github.com/example/repo.git',
+        baseBranch: 'main',
+        baseCommit: 'abc1234',
+        worktreePath: '/tmp/invoker-worktrees/planning-binding',
+        worktreeBranch: 'plan/planning-binding',
+      }));
+
+      const loaded = adapter.loadInAppPlanningSession('planning-binding');
+      expect(loaded).toEqual(makePlanningSession('planning-binding', {
+        repoUrl: 'https://github.com/example/repo.git',
+        baseBranch: 'main',
+        baseCommit: 'abc1234',
+        worktreePath: '/tmp/invoker-worktrees/planning-binding',
+        worktreeBranch: 'plan/planning-binding',
+      }));
+    });
+
+    it('round-trips omitted repo/HEAD/worktree binding columns as undefined', () => {
+      adapter.upsertInAppPlanningSession(makePlanningSession('planning-1'));
+
+      const loaded = adapter.loadInAppPlanningSession('planning-1');
+      expect(loaded?.repoUrl).toBeUndefined();
+      expect(loaded?.baseBranch).toBeUndefined();
+      expect(loaded?.baseCommit).toBeUndefined();
+      expect(loaded?.worktreePath).toBeUndefined();
+      expect(loaded?.worktreeBranch).toBeUndefined();
+    });
+
+    it('patches repo/HEAD/worktree binding columns independently', () => {
+      adapter.upsertInAppPlanningSession(makePlanningSession('planning-1'));
+
+      adapter.updateInAppPlanningSession('planning-1', {
+        repoUrl: 'https://github.com/example/repo.git',
+        baseCommit: 'def5678',
+        worktreePath: '/tmp/invoker-worktrees/planning-1',
+      });
+
+      const loaded = adapter.loadInAppPlanningSession('planning-1');
+      expect(loaded).toMatchObject({
+        title: 'Planning planning-1',
+        repoUrl: 'https://github.com/example/repo.git',
+        baseCommit: 'def5678',
+        worktreePath: '/tmp/invoker-worktrees/planning-1',
+      });
+      expect(loaded?.baseBranch).toBeUndefined();
+      expect(loaded?.worktreeBranch).toBeUndefined();
     });
 
     it('deletes planning sessions and their visible messages', () => {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -293,6 +293,11 @@ export interface InAppPlanningSessionRecord {
   presetKey: string;
   status: InAppPlanningSessionStatus;
   confirmationMode: PlanningConfirmationMode;
+  repoUrl?: string;
+  baseBranch?: string;
+  baseCommit?: string;
+  worktreePath?: string;
+  worktreeBranch?: string;
   messages: InAppPlanningChatLine[];
   draftPlanSummary?: InAppPlanningPlanSummary;
   draftPlanText?: string;
@@ -314,6 +319,11 @@ export type InAppPlanningSessionPatch = Partial<Pick<
   | 'title'
   | 'status'
   | 'confirmationMode'
+  | 'repoUrl'
+  | 'baseBranch'
+  | 'baseCommit'
+  | 'worktreePath'
+  | 'worktreeBranch'
   | 'messages'
   | 'draftPlanSummary'
   | 'draftPlanText'

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -527,6 +527,11 @@ type InAppPlanningSessionRow = {
   preset_key?: unknown;
   status?: unknown;
   confirmation_mode?: unknown;
+  repo_url?: unknown;
+  base_branch?: unknown;
+  base_commit?: unknown;
+  worktree_path?: unknown;
+  worktree_branch?: unknown;
   draft_plan_summary_json?: unknown;
   draft_plan_text?: unknown;
   submitted_workflow_id?: unknown;
@@ -1215,6 +1220,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
           preset_key,
           status,
           confirmation_mode,
+          repo_url,
+          base_branch,
+          base_commit,
+          worktree_path,
+          worktree_branch,
           draft_plan_summary_json,
           draft_plan_text,
           submitted_workflow_id,
@@ -1228,12 +1238,17 @@ export class SQLiteAdapter implements PersistenceAdapter {
           pending_response,
           created_at,
           updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(session_id) DO UPDATE SET
           title = excluded.title,
           preset_key = excluded.preset_key,
           status = excluded.status,
           confirmation_mode = excluded.confirmation_mode,
+          repo_url = excluded.repo_url,
+          base_branch = excluded.base_branch,
+          base_commit = excluded.base_commit,
+          worktree_path = excluded.worktree_path,
+          worktree_branch = excluded.worktree_branch,
           draft_plan_summary_json = excluded.draft_plan_summary_json,
           draft_plan_text = excluded.draft_plan_text,
           submitted_workflow_id = excluded.submitted_workflow_id,
@@ -1253,6 +1268,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
           record.presetKey,
           record.status,
           record.confirmationMode ?? 'require',
+          record.repoUrl ?? null,
+          record.baseBranch ?? null,
+          record.baseCommit ?? null,
+          record.worktreePath ?? null,
+          record.worktreeBranch ?? null,
           record.draftPlanSummary ? JSON.stringify(record.draftPlanSummary) : null,
           record.draftPlanText ?? null,
           record.submittedWorkflowId ?? null,
@@ -1305,6 +1325,26 @@ export class SQLiteAdapter implements PersistenceAdapter {
       if (Object.hasOwn(patch, 'confirmationMode')) {
         setClauses.push('confirmation_mode = ?');
         values.push(patch.confirmationMode ?? 'require');
+      }
+      if (Object.hasOwn(patch, 'repoUrl')) {
+        setClauses.push('repo_url = ?');
+        values.push(patch.repoUrl ?? null);
+      }
+      if (Object.hasOwn(patch, 'baseBranch')) {
+        setClauses.push('base_branch = ?');
+        values.push(patch.baseBranch ?? null);
+      }
+      if (Object.hasOwn(patch, 'baseCommit')) {
+        setClauses.push('base_commit = ?');
+        values.push(patch.baseCommit ?? null);
+      }
+      if (Object.hasOwn(patch, 'worktreePath')) {
+        setClauses.push('worktree_path = ?');
+        values.push(patch.worktreePath ?? null);
+      }
+      if (Object.hasOwn(patch, 'worktreeBranch')) {
+        setClauses.push('worktree_branch = ?');
+        values.push(patch.worktreeBranch ?? null);
       }
       if (Object.hasOwn(patch, 'draftPlanSummary')) {
         setClauses.push('draft_plan_summary_json = ?');
@@ -2865,6 +2905,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
         presetKey,
         status: row.status,
         confirmationMode: row.confirmation_mode,
+        ...(typeof row.repo_url === 'string' ? { repoUrl: row.repo_url } : {}),
+        ...(typeof row.base_branch === 'string' ? { baseBranch: row.base_branch } : {}),
+        ...(typeof row.base_commit === 'string' ? { baseCommit: row.base_commit } : {}),
+        ...(typeof row.worktree_path === 'string' ? { worktreePath: row.worktree_path } : {}),
+        ...(typeof row.worktree_branch === 'string' ? { worktreeBranch: row.worktree_branch } : {}),
         messages,
         ...(draftPlanSummary ? { draftPlanSummary } : {}),
         ...(typeof row.draft_plan_text === 'string' ? { draftPlanText: row.draft_plan_text } : {}),

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -597,6 +597,11 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_exit_code INTEGER',
   "ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_output_snapshot TEXT NOT NULL DEFAULT ''",
   'ALTER TABLE in_app_planning_sessions ADD COLUMN terminal_updated_at TEXT',
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN repo_url TEXT',
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN base_branch TEXT',
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN base_commit TEXT',
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN worktree_path TEXT',
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN worktree_branch TEXT',
 ];
 
 /**

--- a/packages/planning-core/src/__tests__/lifecycle.test.ts
+++ b/packages/planning-core/src/__tests__/lifecycle.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
-  derivePlanningTurnResult,
   hasExplicitDraftIntent,
   isDraftingAuthorized,
-  PlanningSession,
-  SerializedPlanningTurns,
 } from '../lifecycle.js';
 
 describe('Planning Terminal lifecycle contract', () => {
@@ -16,36 +13,5 @@ describe('Planning Terminal lifecycle contract', () => {
     expect(isDraftingAuthorized('yes', [
       { role: 'assistant', content: 'Here is an explanation.' },
     ])).toBe(false);
-  });
-
-  it('does not expose an unapproved draft as draft_ready', () => {
-    expect(derivePlanningTurnResult('discuss options', [], {
-      hasDraft: true,
-      asksQuestion: false,
-      submitted: false,
-    })).toEqual({ state: 'discussing', draftingAuthorized: false });
-  });
-
-  it('serializes turns in arrival order', async () => {
-    const turns = new SerializedPlanningTurns();
-    const order: string[] = [];
-    await Promise.all([
-      turns.run(async () => { order.push('first'); }),
-      turns.run(async () => { order.push('second'); }),
-    ]);
-    expect(order).toEqual(['first', 'second']);
-  });
-
-  it('keeps an unapproved draft in the discussing state', async () => {
-    const runner = {
-      sendMessage: async () => '```yaml\nname: draft\ntasks:\n  - id: task\n    description: Draft\n```',
-      getDraftedPlan: () => 'name: draft\ntasks:\n  - id: task\n    description: Draft',
-      planSubmitted: false,
-    };
-    const session = new PlanningSession(runner);
-    await expect(session.send('What would this involve?')).resolves.toMatchObject({
-      state: 'discussing',
-      draftingAuthorized: false,
-    });
   });
 });

--- a/packages/planning-core/src/__tests__/worktree-binding.test.ts
+++ b/packages/planning-core/src/__tests__/worktree-binding.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { decideWorktreeBinding } from '../worktree-binding.js';
+
+describe('decideWorktreeBinding', () => {
+  it('provisions on first bind regardless of draft state', () => {
+    expect(decideWorktreeBinding({
+      requestedRepoUrl: 'https://example.com/repo.git',
+      requestedHeadSha: 'sha-a',
+      hasDraft: true,
+    }).action).toBe('provision');
+
+    expect(decideWorktreeBinding({
+      requestedRepoUrl: 'https://example.com/repo.git',
+      requestedHeadSha: 'sha-a',
+      hasDraft: false,
+    }).action).toBe('provision');
+  });
+
+  it('reuses when repo and commit are unchanged', () => {
+    expect(decideWorktreeBinding({
+      storedRepoUrl: 'https://example.com/repo.git',
+      storedHeadSha: 'sha-a',
+      requestedRepoUrl: 'https://example.com/repo.git',
+      requestedHeadSha: 'sha-a',
+      hasDraft: true,
+    }).action).toBe('reuse');
+
+    expect(decideWorktreeBinding({
+      storedRepoUrl: 'https://example.com/repo.git',
+      storedHeadSha: 'sha-a',
+      requestedRepoUrl: 'https://example.com/repo.git',
+      requestedHeadSha: 'sha-a',
+      hasDraft: false,
+    }).action).toBe('reuse');
+  });
+
+  it('invalidates and blocks submit when commit changes with a draft in flight', () => {
+    expect(decideWorktreeBinding({
+      storedRepoUrl: 'https://example.com/repo.git',
+      storedHeadSha: 'sha-a',
+      requestedRepoUrl: 'https://example.com/repo.git',
+      requestedHeadSha: 'sha-b',
+      hasDraft: true,
+    }).action).toBe('invalidate_and_block_submit');
+  });
+
+  it('provisions when commit changes with no draft in flight', () => {
+    expect(decideWorktreeBinding({
+      storedRepoUrl: 'https://example.com/repo.git',
+      storedHeadSha: 'sha-a',
+      requestedRepoUrl: 'https://example.com/repo.git',
+      requestedHeadSha: 'sha-b',
+      hasDraft: false,
+    }).action).toBe('provision');
+  });
+
+  it('invalidates and blocks submit when repo changes with same sha and a draft in flight', () => {
+    expect(decideWorktreeBinding({
+      storedRepoUrl: 'https://example.com/repo-one.git',
+      storedHeadSha: 'sha-a',
+      requestedRepoUrl: 'https://example.com/repo-two.git',
+      requestedHeadSha: 'sha-a',
+      hasDraft: true,
+    }).action).toBe('invalidate_and_block_submit');
+  });
+
+  it('provisions when repo changes with same sha and no draft in flight', () => {
+    expect(decideWorktreeBinding({
+      storedRepoUrl: 'https://example.com/repo-one.git',
+      storedHeadSha: 'sha-a',
+      requestedRepoUrl: 'https://example.com/repo-two.git',
+      requestedHeadSha: 'sha-a',
+      hasDraft: false,
+    }).action).toBe('provision');
+  });
+
+  it('invalidates and blocks submit when repo and commit both change with a draft in flight', () => {
+    expect(decideWorktreeBinding({
+      storedRepoUrl: 'https://example.com/repo-one.git',
+      storedHeadSha: 'sha-a',
+      requestedRepoUrl: 'https://example.com/repo-two.git',
+      requestedHeadSha: 'sha-b',
+      hasDraft: true,
+    }).action).toBe('invalidate_and_block_submit');
+  });
+
+  it('provisions when repo and commit both change with no draft in flight', () => {
+    expect(decideWorktreeBinding({
+      storedRepoUrl: 'https://example.com/repo-one.git',
+      storedHeadSha: 'sha-a',
+      requestedRepoUrl: 'https://example.com/repo-two.git',
+      requestedHeadSha: 'sha-b',
+      hasDraft: false,
+    }).action).toBe('provision');
+  });
+});

--- a/packages/planning-core/src/index.ts
+++ b/packages/planning-core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './lifecycle.js';
+export * from './worktree-binding.js';
 export * from './plan-summary.js';
 export * from './planning-turn.js';
 export * from './planning-review.js';

--- a/packages/planning-core/src/lifecycle.ts
+++ b/packages/planning-core/src/lifecycle.ts
@@ -5,13 +5,6 @@ export interface PlanningMessage {
   content: string;
 }
 
-export type PlanningState = 'discussing' | 'awaiting_answer' | 'draft_ready' | 'submitted';
-
-export interface PlanningTurnResult {
-  state: PlanningState;
-  draftingAuthorized: boolean;
-}
-
 function normalized(text: string): string {
   return text.trim().toLowerCase();
 }
@@ -68,67 +61,4 @@ export function previousAssistantAskedWhetherToDraft(messages: readonly Planning
 export function isDraftingAuthorized(message: string, messagesBeforeTurn: readonly PlanningMessage[]): boolean {
   return hasExplicitDraftIntent(message)
     || (isShortDraftConfirmation(message) && previousAssistantAskedWhetherToDraft(messagesBeforeTurn));
-}
-
-export function derivePlanningTurnResult(
-  message: string,
-  messagesBeforeTurn: readonly PlanningMessage[],
-  response: { hasDraft: boolean; asksQuestion: boolean; submitted: boolean },
-): PlanningTurnResult {
-  const draftingAuthorized = isDraftingAuthorized(message, messagesBeforeTurn);
-  if (response.submitted) return { state: 'submitted', draftingAuthorized };
-  if (response.hasDraft && draftingAuthorized) return { state: 'draft_ready', draftingAuthorized };
-  return {
-    state: response.asksQuestion ? 'awaiting_answer' : 'discussing',
-    draftingAuthorized,
-  };
-}
-
-export class SerializedPlanningTurns {
-  private pending: Promise<void> = Promise.resolve();
-
-  async run<T>(turn: () => Promise<T>): Promise<T> {
-    const next = this.pending.then(turn);
-    this.pending = next.then(() => undefined, () => undefined);
-    return await next;
-  }
-}
-
-export interface PlanningRunner {
-  sendMessage(message: string): Promise<string>;
-  getDraftedPlan(): string | null;
-  readonly planSubmitted: boolean;
-}
-
-export interface PlanningSessionTurn {
-  reply: string;
-  state: PlanningState;
-  draftingAuthorized: boolean;
-}
-
-export class PlanningSession {
-  private readonly turns = new SerializedPlanningTurns();
-  private readonly messages: PlanningMessage[] = [];
-
-  constructor(private readonly runner: PlanningRunner) {}
-
-  get history(): readonly PlanningMessage[] {
-    return this.messages;
-  }
-
-  async send(message: string): Promise<PlanningSessionTurn> {
-    return await this.turns.run(async () => {
-      const messagesBeforeTurn = [...this.messages];
-      const draftingAuthorized = isDraftingAuthorized(message, messagesBeforeTurn);
-      this.messages.push({ role: 'user', content: message });
-      const reply = await this.runner.sendMessage(message);
-      this.messages.push({ role: 'assistant', content: reply });
-      const result = derivePlanningTurnResult(message, messagesBeforeTurn, {
-        hasDraft: this.runner.getDraftedPlan() !== null,
-        asksQuestion: reply.includes('?'),
-        submitted: this.runner.planSubmitted,
-      });
-      return { reply, state: result.state, draftingAuthorized };
-    });
-  }
 }

--- a/packages/planning-core/src/worktree-binding.ts
+++ b/packages/planning-core/src/worktree-binding.ts
@@ -1,0 +1,34 @@
+export interface WorktreeBindingRequest {
+  storedRepoUrl?: string;
+  storedHeadSha?: string;
+  requestedRepoUrl: string;
+  requestedHeadSha: string;
+  hasDraft: boolean;
+}
+
+export type WorktreeBindingAction = 'reuse' | 'provision' | 'invalidate_and_block_submit';
+
+export type WorktreeBindingReason = 'no-prior-binding' | 'unchanged' | 'repo-changed' | 'commit-changed';
+
+export interface WorktreeBindingDecision {
+  action: WorktreeBindingAction;
+  reason: WorktreeBindingReason;
+}
+
+export function decideWorktreeBinding(request: WorktreeBindingRequest): WorktreeBindingDecision {
+  const { storedRepoUrl, storedHeadSha, requestedRepoUrl, requestedHeadSha, hasDraft } = request;
+
+  if (storedRepoUrl === undefined || storedHeadSha === undefined) {
+    return { action: 'provision', reason: 'no-prior-binding' };
+  }
+
+  if (storedRepoUrl === requestedRepoUrl && storedHeadSha === requestedHeadSha) {
+    return { action: 'reuse', reason: 'unchanged' };
+  }
+
+  const reason: WorktreeBindingReason = storedRepoUrl !== requestedRepoUrl ? 'repo-changed' : 'commit-changed';
+  return {
+    action: hasDraft ? 'invalidate_and_block_submit' : 'provision',
+    reason,
+  };
+}


### PR DESCRIPTION
Today the in-app Planning Chat harness (codex/claude) spawns as a real
CLI subprocess with cwd set to the live Invoker checkout itself -
there is no per-session isolation at all. Add planning-chat-worktree.ts,
reusing the same RepoPool the app's WorktreeExecutor already owns (not
a second pool, not WorktreeExecutor's task-shaped lifecycle): on
session create, clone/resolve HEAD/acquire a worktree on a deterministic
invoker/planning/<sessionId> branch, best-effort `pnpm install`, then
softRelease so a long-lived chat doesn't pin a pool slot. On restore
and before each send, ensurePlanningWorktreeReady recreates a missing
worktree at the *stored* commit (never a freshly resolved HEAD), which
matters because disk-headroom-reclaim.ts wholesale-wipes the worktree
(and clone-cache) dirs under disk pressure.

Provisioning is opt-in on (repoPool present + config.defaultRepoUrl
resolvable); every existing caller and test that lacks either falls
back to exactly today's behavior (deps.workingDir), so the "no repo
configured yet" state elsewhere in this codebase keeps working
unchanged. Wired into both the standalone/headless-owner dispatch
(main.ts) and the Electron GUI dispatch (gui-mutation-handlers.ts) for
create/restore/send only - plan-from-goal's ephemeral one-shot flow is
untouched.

Part of the planning-chat redesign stack (slice 7/13).

Depends-On: #6533