### PR TITLE
Add repo-switch/rebind policy for planning-chat sessions

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -14,6 +14,7 @@ import {
   listInAppPlanningPresets,
   listPlanningChatSessions,
   planFromGoal,
+  rebindPlanningChatRepo,
   resetPlanningChat,
   restorePlanningChatSessions,
   sendPlanningChatMessage,
@@ -1624,6 +1625,224 @@ describe('planning chat worktree provisioning', () => {
     } finally {
       rmSync(existingWorktreePath, { recursive: true, force: true });
     }
+  });
+});
+
+describe('rebindPlanningChatRepo', () => {
+  function sidecarPathFor(sessionId: string): string {
+    return join(resolveInvokerHomeRoot(), 'plan-drafts', `${sessionId}.yaml`);
+  }
+
+  function createFakeRebindRepoPool(
+    worktreePath: string,
+    headSha: string,
+  ): PlanningRepoPool & { release: ReturnType<typeof vi.fn>; softRelease: ReturnType<typeof vi.fn> } {
+    const release = vi.fn(async () => {});
+    const softRelease = vi.fn();
+    const acquireWorktree = vi.fn(async (_repoUrl: string, branch: string) => ({
+      clonePath: '/fake/clone',
+      worktreePath,
+      branch,
+      release,
+      softRelease,
+    }));
+    return {
+      ensureCloneThroughRepoQueue: vi.fn(async () => '/fake/clone'),
+      resolveBaseCommit: vi.fn(async () => headSha),
+      acquireWorktree,
+      externalWorktreePath: vi.fn(() => worktreePath),
+      release,
+      softRelease,
+    };
+  }
+
+  it('returns reuse and leaves the session untouched when the requested binding is unchanged', async () => {
+    const repoPool = createFakeRebindRepoPool('/fake/worktree/should-not-be-used', 'sha-a');
+    const sessions = createInAppPlanningChatSessions();
+    const session = planningSession({
+      id: 'reuse-session',
+      title: 'Reuse test',
+      repoUrl: 'https://example.com/repo.git',
+      baseBranch: 'main',
+      baseCommit: 'sha-a',
+      worktreePath: '/fake/worktree/existing-reuse',
+      worktreeBranch: 'invoker/planning/reuse-session',
+    });
+    const originalConversation = session.conversation;
+    sessions.set(session.id, session);
+
+    const result = await rebindPlanningChatRepo({
+      sessionId: session.id,
+      repoUrl: 'https://example.com/repo.git',
+      baseBranch: 'main',
+    }, {
+      config: {},
+      sessions,
+      repoPool,
+    });
+
+    expect(result).toEqual({ ok: true, action: 'reuse' });
+    expect(repoPool.acquireWorktree).not.toHaveBeenCalled();
+    const stored = sessions.get(session.id);
+    expect(stored?.repoUrl).toBe('https://example.com/repo.git');
+    expect(stored?.baseBranch).toBe('main');
+    expect(stored?.baseCommit).toBe('sha-a');
+    expect(stored?.worktreePath).toBe('/fake/worktree/existing-reuse');
+    expect(stored?.worktreeBranch).toBe('invoker/planning/reuse-session');
+    expect(stored?.conversation).toBe(originalConversation);
+  });
+
+  it('provisions a new worktree and constructs a fresh conversation when there is no prior binding', async () => {
+    const worktreePath = '/fake/worktree/provision-session';
+    const repoPool = createFakeRebindRepoPool(worktreePath, 'new-head-sha');
+    const sessions = createInAppPlanningChatSessions();
+    const session = planningSession({
+      id: 'provision-session',
+      title: 'Provision test',
+    });
+    const originalConversation = session.conversation;
+    sessions.set(session.id, session);
+
+    const result = await rebindPlanningChatRepo({
+      sessionId: session.id,
+      repoUrl: 'https://example.com/new-repo.git',
+      baseBranch: 'main',
+    }, {
+      config: {},
+      sessions,
+      repoPool,
+    });
+
+    expect(result).toEqual({ ok: true, action: 'provision' });
+    expect(repoPool.acquireWorktree).toHaveBeenCalledWith(
+      'https://example.com/new-repo.git',
+      'invoker/planning/provision-session',
+      'new-head-sha',
+      'provision-session',
+    );
+    const stored = sessions.get(session.id);
+    expect(stored?.repoUrl).toBe('https://example.com/new-repo.git');
+    expect(stored?.baseBranch).toBe('main');
+    expect(stored?.baseCommit).toBe('new-head-sha');
+    expect(stored?.worktreePath).toBe(worktreePath);
+    expect(stored?.worktreeBranch).toBe('invoker/planning/provision-session');
+    expect(stored?.conversation).not.toBe(originalConversation);
+    expect(stored?.conversation.workingDir).toBe(worktreePath);
+  });
+
+  it('invalidates and clears a draft (session, DB, and sidecar) when rebinding to a different repo', async () => {
+    const worktreePath = '/fake/worktree/invalidate-session';
+    const repoPool = createFakeRebindRepoPool(worktreePath, 'new-head-sha');
+    const sessions = createInAppPlanningChatSessions();
+    const adapter = await SQLiteAdapter.create(':memory:');
+    const sessionId = 'invalidate-session';
+    try {
+      const session = planningSession({
+        id: sessionId,
+        title: 'Invalidate test',
+        status: 'draft_ready',
+        repoUrl: 'https://example.com/repo.git',
+        baseBranch: 'main',
+        baseCommit: 'sha-a',
+        worktreePath: '/fake/worktree/existing-invalidate',
+        worktreeBranch: `invoker/planning/${sessionId}`,
+        draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+        draftPlanText: VALID_PLAN_TEXT,
+      });
+      sessions.set(sessionId, session);
+
+      adapter.upsertInAppPlanningSession({
+        id: sessionId,
+        title: session.title,
+        presetKey: session.presetKey,
+        status: session.status,
+        confirmationMode: session.confirmationMode,
+        repoUrl: session.repoUrl,
+        baseBranch: session.baseBranch,
+        baseCommit: session.baseCommit,
+        worktreePath: session.worktreePath,
+        worktreeBranch: session.worktreeBranch,
+        messages: session.messages,
+        draftPlanSummary: session.draftPlanSummary,
+        draftPlanText: session.draftPlanText,
+        pendingResponse: false,
+        createdAt: session.createdAt,
+        updatedAt: session.updatedAt,
+      });
+
+      mkdirSync(dirname(sidecarPathFor(sessionId)), { recursive: true });
+      writeFileSync(sidecarPathFor(sessionId), VALID_PLAN_TEXT, 'utf8');
+      expect(existsSync(sidecarPathFor(sessionId))).toBe(true);
+
+      const result = await rebindPlanningChatRepo({
+        sessionId,
+        repoUrl: 'https://example.com/other-repo.git',
+        baseBranch: 'main',
+      }, {
+        config: {},
+        sessions,
+        planningSessionStore: adapter,
+        repoPool,
+      });
+
+      expect(result).toEqual({ ok: true, action: 'invalidate_and_block_submit' });
+      const stored = sessions.get(sessionId);
+      expect(stored?.draftPlanText).toBeUndefined();
+      expect(stored?.draftPlanSummary).toBeUndefined();
+      expect(stored?.status).toBe('still_discussing');
+      expect(stored?.repoUrl).toBe('https://example.com/other-repo.git');
+      expect(stored?.baseCommit).toBe('new-head-sha');
+      expect(stored?.worktreePath).toBe(worktreePath);
+
+      const persisted = adapter.loadInAppPlanningSession(sessionId);
+      expect(persisted?.draftPlanText).toBeUndefined();
+      expect(existsSync(sidecarPathFor(sessionId))).toBe(false);
+    } finally {
+      rmSync(sidecarPathFor(sessionId), { force: true });
+      adapter.close();
+    }
+  });
+
+  it('returns an error when the session is missing', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    const repoPool = createFakeRebindRepoPool('/fake/worktree/should-not-be-used', 'sha-a');
+
+    const result = await rebindPlanningChatRepo({ sessionId: 'does-not-exist' }, {
+      config: {},
+      sessions,
+      repoPool,
+    });
+
+    expect(result).toEqual({ ok: false, error: 'No planning conversation yet.' });
+  });
+
+  it('returns an error when no repoPool is configured', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    const session = planningSession({ id: 'no-pool-session', title: 'No pool' });
+    sessions.set(session.id, session);
+
+    const result = await rebindPlanningChatRepo({ sessionId: session.id }, {
+      config: {},
+      sessions,
+    });
+
+    expect(result).toEqual({ ok: false, error: 'Worktree provisioning is not available.' });
+  });
+
+  it('returns an error when no repo URL can be resolved', async () => {
+    const repoPool = createFakeRebindRepoPool('/fake/worktree/should-not-be-used', 'sha-a');
+    const sessions = createInAppPlanningChatSessions();
+    const session = planningSession({ id: 'no-repo-session', title: 'No repo' });
+    sessions.set(session.id, session);
+
+    const result = await rebindPlanningChatRepo({ sessionId: session.id }, {
+      config: {},
+      sessions,
+      repoPool,
+    });
+
+    expect(result).toEqual({ ok: false, error: 'No repository specified.' });
+    expect(repoPool.ensureCloneThroughRepoQueue).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -16,6 +16,8 @@ import type {
   InAppPlanningDiscardDraftResponse,
   InAppPlanningListSessionsResponse,
   InAppPlanningPlanSummary,
+  InAppPlanningRebindRepoRequest,
+  InAppPlanningRebindRepoResponse,
   InAppPlanningResetRequest,
   InAppPlanningResetResponse,
   InAppPlanningSetTerminalModeRequest,
@@ -38,6 +40,7 @@ import type {
 } from '@invoker/data-store';
 import type { AgentRegistry } from '@invoker/execution-engine';
 import {
+  decideWorktreeBinding,
   evaluatePlanningTurn,
   hasExplicitDraftIntent as hasCoreExplicitDraftIntent,
   isDraftingAuthorized,
@@ -48,7 +51,12 @@ import {
 } from '@invoker/planning-core';
 import type { HarnessPreset, PlanConversation, PlanConversationConfig, PlanningCommandBuilder } from '@invoker/surfaces';
 import type { InvokerConfig } from './config.js';
-import { ensurePlanningWorktreeReady, provisionPlanningWorktree, type PlanningRepoPool } from './planning-chat-worktree.js';
+import {
+  ensurePlanningWorktreeReady,
+  provisionPlanningWorktree,
+  releasePlanningWorktree,
+  type PlanningRepoPool,
+} from './planning-chat-worktree.js';
 
 function logPlanningWorktreeReadyError(sessionId: string, step: string, error: unknown): void {
   console.error(`[planning-chat] ensurePlanningWorktreeReady ${step} failed session="${sessionId}": ${
@@ -1055,6 +1063,109 @@ export function setPlanningChatTerminalMode(
     updatedAt,
   });
   return { ok: true };
+}
+
+export async function rebindPlanningChatRepo(
+  request: InAppPlanningRebindRepoRequest,
+  deps: {
+    config: InvokerConfig;
+    sessions: InAppPlanningChatSessions;
+    planningSessionStore?: InAppPlanningSessionStore;
+    repoPool?: PlanningRepoPool;
+  },
+): Promise<InAppPlanningRebindRepoResponse> {
+  const rawRequest = request as Partial<InAppPlanningRebindRepoRequest> | null | undefined;
+  const sessionId = typeof rawRequest?.sessionId === 'string' ? rawRequest.sessionId.trim() : '';
+  const session = sessionId ? deps.sessions.get(sessionId) : undefined;
+  if (!session) {
+    return { ok: false, error: 'No planning conversation yet.' };
+  }
+  if (!deps.repoPool) {
+    return { ok: false, error: 'Worktree provisioning is not available.' };
+  }
+  const repoPool = deps.repoPool;
+
+  const requestedRepoUrl = rawRequest?.repoUrl?.trim() || deps.config.defaultRepoUrl;
+  if (!requestedRepoUrl) {
+    return { ok: false, error: 'No repository specified.' };
+  }
+  const requestedBaseBranch = rawRequest?.baseBranch?.trim() || deps.config.defaultBranch || 'main';
+
+  try {
+    await repoPool.ensureCloneThroughRepoQueue(requestedRepoUrl);
+    const requestedHeadSha = await repoPool.resolveBaseCommit(requestedRepoUrl, requestedBaseBranch);
+
+    const decision = decideWorktreeBinding({
+      storedRepoUrl: session.repoUrl,
+      storedHeadSha: session.baseCommit,
+      requestedRepoUrl,
+      requestedHeadSha,
+      hasDraft: hasDraftPlan(session),
+    });
+
+    if (decision.action === 'reuse') {
+      return { ok: true, action: 'reuse' };
+    }
+
+    if (session.repoUrl && session.baseCommit && session.worktreePath) {
+      try {
+        await releasePlanningWorktree(repoPool, {
+          repoUrl: session.repoUrl,
+          baseCommit: session.baseCommit,
+          sessionId: session.id,
+        });
+      } catch (error) {
+        logPlanningWorktreeReadyError(session.id, 'rebind-release', error);
+      }
+    }
+
+    const provisioned = await provisionPlanningWorktree(repoPool, {
+      repoUrl: requestedRepoUrl,
+      baseBranch: requestedBaseBranch,
+      sessionId: session.id,
+    });
+
+    const presets = await resolveHarnessPresets(deps.config);
+    const preset = presets[session.presetKey];
+    if (!preset) {
+      return { ok: false, error: `Unknown planner preset "${session.presetKey}".` };
+    }
+    const { PlanConversation, selectHarnessSessionDriver } = await loadPlannerSurfaces();
+    const conversationDeps = { ...deps, workingDir: provisioned.worktreePath };
+    const conversation = new PlanConversation(planConversationConfig(
+      preset,
+      conversationDeps,
+      session.id,
+      selectHarnessSessionDriver,
+      { conversationalPlanning: true },
+    ));
+    await conversation.init();
+
+    session.repoUrl = requestedRepoUrl;
+    session.baseBranch = requestedBaseBranch;
+    session.baseCommit = provisioned.baseCommit;
+    session.worktreePath = provisioned.worktreePath;
+    session.worktreeBranch = provisioned.branch;
+    session.conversation = conversation;
+
+    if (decision.action === 'invalidate_and_block_submit') {
+      session.draftPlanSummary = undefined;
+      session.draftPlanText = undefined;
+      if (session.status === 'draft_ready') {
+        session.status = 'still_discussing';
+      }
+      appendSessionMessage(
+        session,
+        'system',
+        'The target repository changed. The previous draft was cleared — ask Invoker to draft it again.',
+      );
+    }
+
+    persistPlanningSession(session, deps.planningSessionStore, false);
+    return { ok: true, action: decision.action };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
 }
 
 export interface PlanningChatTerminalStatePatch {

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -8,6 +8,7 @@ import type {
   InAppPlanningChatRequest,
   InAppPlanningCreateSessionRequest,
   InAppPlanningDiscardDraftRequest,
+  InAppPlanningRebindRepoRequest,
   InAppPlanningResetRequest,
   InAppPlanningSetTerminalModeRequest,
   InAppPlanningStreamEvent,
@@ -87,6 +88,7 @@ import {
   listInAppPlanningPresets,
   listPlanningChatSessions,
   planFromGoal as planFromGoalInApp,
+  rebindPlanningChatRepo,
   resetPlanningChat,
   restorePlanningChatSessions,
   sendPlanningChatMessage,
@@ -1324,6 +1326,14 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     return setPlanningChatTerminalMode(request as InAppPlanningSetTerminalModeRequest, {
       sessions: planningChatSessions,
       planningSessionStore: ownerMode ? persistence : undefined,
+    });
+  });
+  registerGuiMutationHandler('invoker:planning-chat-rebind-repo', async (request: unknown) => {
+    return rebindPlanningChatRepo(request as InAppPlanningRebindRepoRequest, {
+      config: invokerConfig,
+      sessions: planningChatSessions,
+      planningSessionStore: ownerMode ? persistence : undefined,
+      repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
     });
   });
   registerGuiMutationHandler('invoker:load-plan', async (planTextArg: unknown) => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -65,6 +65,7 @@ import type {
   InAppPlanningChatRequest,
   InAppPlanningDeleteRequest,
   InAppPlanningDiscardDraftRequest,
+  InAppPlanningRebindRepoRequest,
   InAppPlanningResetRequest,
   InAppPlanningSubmitRequest,
   Logger,
@@ -279,6 +280,7 @@ import {
   discardPlanningChatDraft,
   listPlanningChatSessions,
   planFromGoal as planFromGoalInApp,
+  rebindPlanningChatRepo,
   resetPlanningChat,
   restorePlanningChatSessions,
   sendPlanningChatMessage,
@@ -1186,6 +1188,14 @@ function startHeadlessMode(): void {
             return resetPlanningChat(payload.args[0] as InAppPlanningResetRequest, {
               sessions: planningChatSessions,
               planningSessionStore: readOnlyMode ? undefined : persistence,
+            });
+          }
+          case 'invoker:planning-chat-rebind-repo': {
+            return rebindPlanningChatRepo(payload.args[0] as InAppPlanningRebindRepoRequest, {
+              config: invokerConfig,
+              sessions: planningChatSessions,
+              planningSessionStore: readOnlyMode ? undefined : persistence,
+              repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
             });
           }
           case 'invoker:planning-chat-delete': {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -584,6 +584,16 @@ export type InAppPlanningSetTerminalModeResponse =
   | { ok: true }
   | { ok: false; error: string };
 
+export interface InAppPlanningRebindRepoRequest {
+  sessionId: string;
+  repoUrl?: string;
+  baseBranch?: string;
+}
+
+export type InAppPlanningRebindRepoResponse =
+  | { ok: true; action: 'reuse' | 'provision' | 'invalidate_and_block_submit' }
+  | { ok: false; error: string };
+
 
 
 export interface WorkflowListEntry {
@@ -955,6 +965,10 @@ export const IpcChannels = {
   'invoker:planning-chat-set-terminal-mode': {} as {
     request: [request: InAppPlanningSetTerminalModeRequest];
     response: InAppPlanningSetTerminalModeResponse;
+  },
+  'invoker:planning-chat-rebind-repo': {} as {
+    request: [request: InAppPlanningRebindRepoRequest];
+    response: InAppPlanningRebindRepoResponse;
   },
   'invoker:planning-terminal-open': {} as {
     request: [planningSessionId: string];


### PR DESCRIPTION
New rebindPlanningChatRepo mutation wires the (already-committed, until
now unused) decideWorktreeBinding decision function into a real entry
point: rebinding a session to a repo/branch that resolves to the same
identity is a no-op reuse; rebinding to a genuinely different repo or
commit provisions a fresh worktree and, if a draft existed, clears it
(DB, sidecar, and in-memory) and drops the session back to
still_discussing rather than silently carrying a now-stale draft
forward. Since PlanConversation.workingDir is readonly, a real rebind
reconstructs the harness conversation against the new worktree instead
of mutating the existing one.

Part of the planning-chat redesign stack (slice 8/13).

Depends-On: #6534