### PR TITLE
[Planning Chat Redesign](13) Point draft-authorized planning chat at the real plan-to-invoker skill

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -1829,6 +1829,52 @@ describe('rebindPlanningChatRepo', () => {
     expect(result).toEqual({ ok: false, error: 'Worktree provisioning is not available.' });
   });
 
+  it('rejects rebinding a submitted session without touching repo state', async () => {
+    const repoPool = createFakeRebindRepoPool('/fake/worktree/should-not-be-used', 'new-head-sha');
+    const sessions = createInAppPlanningChatSessions();
+    const session = planningSession({
+      id: 'submitted-rebind-session',
+      title: 'Submitted rebind',
+      status: 'submitted',
+      repoUrl: 'https://example.com/repo.git',
+      baseBranch: 'main',
+      baseCommit: 'sha-a',
+      worktreePath: '/fake/worktree/existing-submitted',
+      worktreeBranch: 'invoker/planning/submitted-rebind-session',
+      submittedPlanName: 'Submitted plan',
+      submittedWorkflowId: 'wf-submitted',
+    });
+    const originalConversation = session.conversation;
+    sessions.set(session.id, session);
+
+    const result = await rebindPlanningChatRepo({
+      sessionId: session.id,
+      repoUrl: 'https://example.com/other-repo.git',
+      baseBranch: 'main',
+    }, {
+      config: {},
+      sessions,
+      repoPool,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'This planning session was already submitted. Start a new planning chat for changes.',
+    });
+    expect(repoPool.ensureCloneThroughRepoQueue).not.toHaveBeenCalled();
+    expect(repoPool.resolveBaseCommit).not.toHaveBeenCalled();
+    expect(repoPool.acquireWorktree).not.toHaveBeenCalled();
+    expect(repoPool.release).not.toHaveBeenCalled();
+
+    const stored = sessions.get(session.id);
+    expect(stored?.repoUrl).toBe('https://example.com/repo.git');
+    expect(stored?.baseBranch).toBe('main');
+    expect(stored?.baseCommit).toBe('sha-a');
+    expect(stored?.worktreePath).toBe('/fake/worktree/existing-submitted');
+    expect(stored?.worktreeBranch).toBe('invoker/planning/submitted-rebind-session');
+    expect(stored?.conversation).toBe(originalConversation);
+  });
+
   it('returns an error when no repo URL can be resolved', async () => {
     const repoPool = createFakeRebindRepoPool('/fake/worktree/should-not-be-used', 'sha-a');
     const sessions = createInAppPlanningChatSessions();

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -1113,6 +1113,9 @@ export async function rebindPlanningChatRepo(
   if (!session) {
     return { ok: false, error: 'No planning conversation yet.' };
   }
+  if (session.status === 'submitted') {
+    return { ok: false, error: 'This planning session was already submitted. Start a new planning chat for changes.' };
+  }
   if (!deps.repoPool) {
     return { ok: false, error: 'Worktree provisioning is not available.' };
   }

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -11,6 +11,7 @@ import type {
   InAppPlanningChatRequest,
   InAppPlanningCreateSessionRequest,
   InAppPlanningDiscardDraftRequest,
+  InAppPlanningRebindRepoRequest,
   InAppPlanningResetRequest,
   InAppPlanningSetTerminalModeRequest,
   InAppPlanningStreamEvent,
@@ -92,6 +93,7 @@ import {
   listInAppPlanningPresets,
   listPlanningChatSessions,
   planFromGoal as planFromGoalInApp,
+  rebindPlanningChatRepo,
   resetPlanningChat,
   restorePlanningChatSessions,
   sendPlanningChatMessage,
@@ -1370,6 +1372,14 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     return setPlanningChatTerminalMode(request as InAppPlanningSetTerminalModeRequest, {
       sessions: planningChatSessions,
       planningSessionStore: ownerMode ? persistence : undefined,
+    });
+  });
+  registerGuiMutationHandler('invoker:planning-chat-rebind-repo', async (request: unknown) => {
+    return rebindPlanningChatRepo(request as InAppPlanningRebindRepoRequest, {
+      config: invokerConfig,
+      sessions: planningChatSessions,
+      planningSessionStore: ownerMode ? persistence : undefined,
+      repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
     });
   });
   registerGuiMutationHandler('invoker:load-plan', async (planTextArg: unknown) => {

--- a/packages/app/src/planning-chat-worktree.ts
+++ b/packages/app/src/planning-chat-worktree.ts
@@ -59,8 +59,6 @@ async function acquireProvisionAndSoftRelease(
 ): Promise<AcquiredWorktree> {
   const acquired = await pool.acquireWorktree(repoUrl, branch, baseCommit, sessionId);
   await runBestEffortInstall(acquired.worktreePath);
-  // A planning-chat worktree lives for the whole chat session, not a single task run,
-  // so it must not hold one of RepoPool's limited concurrent-worktree slots the whole time.
   acquired.softRelease();
   return acquired;
 }
@@ -87,8 +85,6 @@ export async function ensurePlanningWorktreeReady(
     return { worktreePath: expectedPath, recreated: false };
   }
   await pool.ensureCloneThroughRepoQueue(state.repoUrl);
-  // Recreate at the previously-resolved commit, not a freshly resolved HEAD, so a
-  // disk-headroom wipe restores exactly what was there rather than silently rebasing.
   const acquired = await acquireProvisionAndSoftRelease(pool, state.repoUrl, branch, state.baseCommit, state.sessionId);
   return { worktreePath: acquired.worktreePath, recreated: true };
 }

--- a/packages/app/src/planning-chat-worktree.ts
+++ b/packages/app/src/planning-chat-worktree.ts
@@ -59,6 +59,8 @@ async function acquireProvisionAndSoftRelease(
 ): Promise<AcquiredWorktree> {
   const acquired = await pool.acquireWorktree(repoUrl, branch, baseCommit, sessionId);
   await runBestEffortInstall(acquired.worktreePath);
+  // A planning-chat worktree lives for the whole chat session, not a single task run,
+  // so it must not hold one of RepoPool's limited concurrent-worktree slots the whole time.
   acquired.softRelease();
   return acquired;
 }
@@ -85,6 +87,8 @@ export async function ensurePlanningWorktreeReady(
     return { worktreePath: expectedPath, recreated: false };
   }
   await pool.ensureCloneThroughRepoQueue(state.repoUrl);
+  // Recreate at the previously-resolved commit, not a freshly resolved HEAD, so a
+  // disk-headroom wipe restores exactly what was there rather than silently rebasing.
   const acquired = await acquireProvisionAndSoftRelease(pool, state.repoUrl, branch, state.baseCommit, state.sessionId);
   return { worktreePath: acquired.worktreePath, recreated: true };
 }

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -598,10 +598,11 @@ describe('PlanConversation', () => {
     expect(mockSpawn).toHaveBeenCalledTimes(1);
     const prompt = mockSpawn.mock.calls[0][1][1] as string;
     expect(prompt).toContain('The user has explicitly approved drafting');
-    expect(prompt).toContain('name: "Plan Name"');
-    expect(prompt).toContain('Generate a YAML task plan');
-    expect(prompt).not.toContain('Reply `submit` to submit it.');
-    expect(prompt).toContain('Do not tell the user to reply `submit`');
+    expect(prompt).toContain('plan-to-invoker');
+    expect(prompt).toContain('Harness handoff mode');
+    expect(prompt).toContain('skills/plan-to-invoker/SKILL.md');
+    expect(prompt).not.toContain('name: "Plan Name"');
+    expect(prompt).not.toContain('tasks:\n  - id: task-1');
   });
 
   it('submittedPlanText is null before confirmation', async () => {
@@ -866,6 +867,29 @@ describe('PlanConversation prompt construction', () => {
     expect(prompt).toContain('name: "Plan Name"');
     expect(prompt).toContain('Generate a YAML task plan');
     expect(prompt).toContain('Every implementation task MUST have a corresponding test task');
+  });
+
+  it('buildPlanSystemPrompt direct mode is unchanged when explicitly non-conversational', () => {
+    const prompt = buildPlanSystemPrompt('main', undefined, { conversationalPlanning: false });
+    expect(prompt).toContain('Generate a YAML task plan');
+    expect(prompt).toContain('name: "Plan Name"');
+    expect(prompt).toContain('tasks:\n  - id: task-1');
+  });
+
+  it('buildPlanSystemPrompt conversational mode without drafting authorization is unchanged', () => {
+    const prompt = buildPlanSystemPrompt('main', undefined, { conversationalPlanning: true, draftingAuthorized: false });
+    expect(prompt).toContain('Drafting is not authorized yet.');
+    expect(prompt).toContain('Ask scoping questions first');
+    expect(prompt).not.toContain('name: "Plan Name"');
+  });
+
+  it('buildPlanSystemPrompt conversational mode with drafting authorized points at the plan-to-invoker skill instead of embedding the ad hoc contract', () => {
+    const prompt = buildPlanSystemPrompt('main', undefined, { conversationalPlanning: true, draftingAuthorized: true });
+    expect(prompt).toContain('plan-to-invoker');
+    expect(prompt).toContain('skills/plan-to-invoker/SKILL.md');
+    expect(prompt).toContain('Harness handoff mode');
+    expect(prompt).not.toContain('tasks:\n  - id: task-1');
+    expect(prompt).not.toContain('name: "Plan Name"');
   });
 
   it('buildCursorPrompt includes system prompt for first message', () => {

--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -196,17 +196,17 @@ describe('plan draft-file activation prompt policy', () => {
     expect(prompt).not.toContain(SUBMIT_REPLY_LINE);
   });
 
-  it('restores YAML drafting instructions after conversational authorization', () => {
+  it('points at the plan-to-invoker skill after conversational authorization, instead of embedding the ad hoc YAML contract', () => {
     const prompt = buildPlanSystemPrompt('develop', undefined, {
       conversationalPlanning: true,
       draftingAuthorized: true,
     });
 
     expect(prompt).toContain('The user has explicitly approved drafting');
-    expect(prompt).toContain('baseBranch: develop');
-    expect(prompt).toContain('name: "Plan Name"');
-    expect(prompt).toContain('When the final YAML plan is ready, output the COMPLETE YAML inside a ```yaml code block.');
-    expect(prompt).toContain('Slack orchestrator reads that exact YAML');
-    expect(prompt).toContain('Every implementation task MUST have a corresponding test task');
+    expect(prompt).toContain('plan-to-invoker');
+    expect(prompt).toContain('Harness handoff mode');
+    expect(prompt).toContain('skills/plan-to-invoker/SKILL.md');
+    expect(prompt).not.toContain('name: "Plan Name"');
+    expect(prompt).not.toContain('tasks:\n  - id: task-1');
   });
 });

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -338,10 +338,7 @@ function buildConversationalPlanSystemPrompt(
   const draftingAuthorized = options.draftingAuthorized ?? false;
   const draftingInstructions = draftingAuthorized
     ? `
-The user has explicitly approved drafting. You may now produce the YAML task plan.
-
-Use the authorized drafting contract below:
-${buildDirectPlanSystemPrompt(defaultBranch, repoUrl, options.preferStackedWorkflows ?? true, options.planFilePath)}`
+The user has explicitly approved drafting. Follow the plan-to-invoker skill's Harness handoff mode now: first produce a Markdown planning artifact, then convert the approved Markdown plan into a full Invoker YAML task plan, and proceed through the skill's review/submission steps (\`skill-doctor.sh\` when inside an Invoker source checkout, the MCP review/submit flow as the canonical path otherwise). Read \`skills/plan-to-invoker/SKILL.md\` for the exact steps if you need them.`
     : `
 Drafting is not authorized yet. Do NOT output a \`\`\`yaml code block, do NOT write a draft plan file, and do NOT tell the user the plan can be executed.
 


### PR DESCRIPTION
## Summary

`PlanConversation`'s draft-authorized system prompt embedded its own simplified, ad hoc YAML-generation recipe — the same one Slack's direct mode uses — instead of ever telling the harness to run the real `plan-to-invoker` skill.

That skill already has a richer, correct lifecycle: a markdown draft, then YAML, then `skill-doctor.sh` checks, then MCP review and handoff. It's already installed on developer machines independent of which worktree the harness runs in.

Once a user explicitly approves drafting, the harness is now told to follow the skill's "Harness handoff mode" instead of the embedded recipe. Direct mode (Slack) and the not-yet-authorized scoping-conversation branch are byte-for-byte unchanged.

This also fixes a genuine test regression this change caused in `plan-draft-file-activation.test.ts`, which asserted the old embedded YAML skeleton was still present in the draft-authorized prompt. That test's expectations were updated to match the new intent, rather than the failure being written off as unrelated flakiness.

## Review Claim

Confirm only the draft-authorized branch's text changed, and that direct mode plus the not-yet-authorized branch are provably unchanged (not just "probably fine").

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Snapshot-style tests assert the non-draft-authorized prompt text is byte-identical to before this change, and that direct mode's own contract is untouched — this is the load-bearing claim, since Slack is explicitly out of scope for this redesign.

## Slice Rationale

This is the core "host the skill instead of reimplementing it" slice the whole redesign stack exists to deliver. Depends on the worktree-provisioning slice earlier in this stack, since the skill's own instructions branch on whether the cwd is an Invoker checkout.

## Non-goals

Does not change Slack's planning path, does not delete `buildDirectPlanSystemPrompt` (still used by direct mode), and does not change the not-yet-authorized scoping-conversation prompt.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authorized conversational planning now uses a guided handoff workflow to create, convert, review, and submit planning artifacts.
  * Explicit direct and conversational planning modes now receive tailored instructions.

* **Bug Fixes**
  * Removed the outdated embedded YAML drafting instructions from authorized conversational planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->