### PR TITLE
Route session-scoped MCP submit/review through the same DB-canonical draft

### DIFF
--- a/packages/app/src/__tests__/owner-headless-query.test.ts
+++ b/packages/app/src/__tests__/owner-headless-query.test.ts
@@ -21,6 +21,7 @@ function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQuer
     listWorkflows: vi.fn(() => []),
     loadWorkflowBundle: vi.fn(() => ({ workflow: null, tasks: [] })),
     getReviewGate: vi.fn(() => null),
+    getPlanningChatSession: vi.fn(() => null),
     getEvents: vi.fn(() => []),
     getTaskById: vi.fn(() => null),
     getTaskOutput: vi.fn(() => ''),

--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -32,6 +32,7 @@ function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQuer
     listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
     loadWorkflowBundle: vi.fn((id: string) => ({ workflow: { id }, tasks: [] })),
     getReviewGate: vi.fn(() => ({ gate: true })),
+    getPlanningChatSession: vi.fn(() => ({ status: 'draft_ready' })),
     getEvents: vi.fn(() => [{ e: 1 }]),
     getTaskById: vi.fn((id: string) => ({ id })),
     getTaskOutput: vi.fn(() => 'output-text'),
@@ -91,6 +92,8 @@ describe('answerOwnerReadQuery', () => {
     expect(answerOwnerReadQuery({ kind: 'workflow', workflowId: 'wf-9' }, h)).toEqual({ workflow: { id: 'wf-9' }, tasks: [] });
     expect(h.loadWorkflowBundle).toHaveBeenCalledWith('wf-9');
     expect(answerOwnerReadQuery({ kind: 'review-gate', workflowId: 'wf-9' }, h)).toEqual({ reviewGate: { gate: true } });
+    expect(answerOwnerReadQuery({ kind: 'planning-chat-session', sessionId: 'sess-1' }, h)).toEqual({ session: { status: 'draft_ready' } });
+    expect(h.getPlanningChatSession).toHaveBeenCalledWith('sess-1');
     expect(answerOwnerReadQuery({ kind: 'events', taskId: 't-1', limit: 50, sortBy: 'desc' }, h)).toEqual({
       events: [{ e: 1 }],
     });
@@ -113,10 +116,12 @@ describe('answerOwnerReadQuery', () => {
       getTaskById: vi.fn(() => undefined),
       getReviewGate: vi.fn(() => undefined),
       getOutputTail: vi.fn(() => undefined),
+      getPlanningChatSession: vi.fn(() => undefined),
     });
     expect(answerOwnerReadQuery({ kind: 'task-by-id', taskId: 'x' }, h)).toEqual({ task: null });
     expect(answerOwnerReadQuery({ kind: 'review-gate', workflowId: 'x' }, h)).toEqual({ reviewGate: null });
     expect(answerOwnerReadQuery({ kind: 'output-tail', taskId: 'x' }, h)).toEqual({ tail: null });
+    expect(answerOwnerReadQuery({ kind: 'planning-chat-session', sessionId: 'x' }, h)).toEqual({ session: null });
   });
 
   it('calls onActivity once per query and rejects unknown kinds', () => {
@@ -134,6 +139,8 @@ describe('answerOwnerReadQuery', () => {
     expect(() => answerOwnerReadQuery({ kind: 'workflow' }, h)).toThrow(/workflowId/);
     expect(h.loadWorkflowBundle).not.toHaveBeenCalled();
     expect(() => answerOwnerReadQuery({ kind: 'review-gate' }, h)).toThrow(/workflowId/);
+    expect(() => answerOwnerReadQuery({ kind: 'planning-chat-session' }, h)).toThrow(/sessionId/);
+    expect(h.getPlanningChatSession).not.toHaveBeenCalled();
     expect(() => answerOwnerReadQuery({ kind: 'events' }, h)).toThrow(/taskId/);
     expect(() => answerOwnerReadQuery({ kind: 'task-by-id' }, h)).toThrow(/taskId/);
     expect(h.getEvents).not.toHaveBeenCalled();
@@ -184,6 +191,7 @@ describe('buildOwnerReadQueryHandlers', () => {
       orchestrator: { ...f.orchestrator, ...orch } as never,
       persistence: { ...f.persistence, ...persist } as never,
       getActionGraphSnapshot: () => ({ ag: 1 }),
+      getPlanningChatSession: (sessionId: string) => ({ sessionId }),
     });
   }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1744,6 +1744,16 @@ function startHeadlessMode(): void {
             persistence,
             getActionGraphSnapshot: () =>
               buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig }) as unknown as Record<string, unknown>,
+            getPlanningChatSession: (sessionId: string) => {
+              const session = planningChatSessions.get(sessionId);
+              if (!session) return null;
+              return {
+                draftPlanText: session.draftPlanText,
+                draftPlanSummary: session.draftPlanSummary,
+                confirmationMode: session.confirmationMode,
+                status: session.status,
+              };
+            },
           }), {
             orchestrator,
             persistence,
@@ -2787,6 +2797,16 @@ startMainProcessBootstrap({
           persistence,
           getActionGraphSnapshot: () =>
             buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig }) as unknown as Record<string, unknown>,
+          getPlanningChatSession: (sessionId: string) => {
+            const session = planningChatSessions.get(sessionId);
+            if (!session) return null;
+            return {
+              draftPlanText: session.draftPlanText,
+              draftPlanSummary: session.draftPlanSummary,
+              confirmationMode: session.confirmationMode,
+              status: session.status,
+            };
+          },
         }), {
           orchestrator,
           persistence,

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -47,6 +47,7 @@ export interface OwnerReadQueryHandlers {
   listWorkflows: () => unknown[];
   loadWorkflowBundle: (workflowId: string) => Record<string, unknown>;
   getReviewGate: (workflowId: string) => unknown;
+  getPlanningChatSession: (sessionId: string) => unknown;
   getEvents: (taskId: string, options: GetEventsOptions) => unknown[];
   getTaskById: (taskId: string) => unknown;
   getTaskOutput: (taskId: string) => string;
@@ -66,6 +67,7 @@ export function answerOwnerReadQuery(
     reset?: boolean;
     workflowId?: string;
     taskId?: string;
+    sessionId?: string;
     fromOffset?: number;
     workerKind?: string;
     decision?: string;
@@ -133,6 +135,8 @@ export function answerOwnerReadQuery(
       return handlers.loadWorkflowBundle(requiredString(body.workflowId, 'workflowId'));
     case 'review-gate':
       return { reviewGate: handlers.getReviewGate(requiredString(body.workflowId, 'workflowId')) ?? null };
+    case 'planning-chat-session':
+      return { session: handlers.getPlanningChatSession(requiredString(body.sessionId, 'sessionId')) ?? null };
     case 'events': {
       const options: GetEventsOptions = body.options ?? {
         limit: body.limit as number,
@@ -219,6 +223,7 @@ export interface OwnerReadQueryDeps {
   persistence: ReadPersistence;
   /** App-level action-graph projection (needs invokerConfig, which lives in the app). */
   getActionGraphSnapshot: () => Record<string, unknown>;
+  getPlanningChatSession: (sessionId: string) => unknown;
 }
 
 /** Build the handler set both owners pass to {@link answerOwnerReadQuery}. */
@@ -258,6 +263,7 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
       if (!workflow) return null;
       return buildReviewGateQueryResponse({ workflowId, workflow, tasks: persistence.loadTasks(workflowId) });
     },
+    getPlanningChatSession: deps.getPlanningChatSession,
     getEvents: (taskId: string, options: GetEventsOptions) =>
       getEventsPage(persistence, taskId, options),
     getTaskById: (taskId: string) => persistence.loadTask(taskId),

--- a/packages/app/src/planning-chat-worktree.ts
+++ b/packages/app/src/planning-chat-worktree.ts
@@ -55,11 +55,16 @@ export function planningMcpConfigPath(worktreePath: string): string {
   return join(worktreePath, '.mcp.json');
 }
 
-export function writePlanningMcpConfig(worktreePath: string): void {
+export function writePlanningMcpConfig(worktreePath: string, sessionId: string): void {
   try {
     writeFileSync(planningMcpConfigPath(worktreePath), JSON.stringify({
       mcpServers: {
-        invoker: { type: 'stdio', command: 'invoker-cli', args: ['mcp'] },
+        invoker: {
+          type: 'stdio',
+          command: 'invoker-cli',
+          args: ['mcp'],
+          env: { INVOKER_PLANNING_SESSION_ID: sessionId },
+        },
       },
     }, null, 2), 'utf8');
   } catch (error) {
@@ -80,7 +85,7 @@ async function acquireProvisionAndSoftRelease(
 ): Promise<AcquiredWorktree> {
   const acquired = await pool.acquireWorktree(repoUrl, branch, baseCommit, sessionId);
   await runBestEffortInstall(acquired.worktreePath);
-  writePlanningMcpConfig(acquired.worktreePath);
+  writePlanningMcpConfig(acquired.worktreePath, sessionId);
   // A planning-chat worktree lives for the whole chat session, not a single task run,
   // so it must not hold one of RepoPool's limited concurrent-worktree slots the whole time.
   acquired.softRelease();

--- a/packages/cli/src/__tests__/mcp-server-session.test.ts
+++ b/packages/cli/src/__tests__/mcp-server-session.test.ts
@@ -1,0 +1,251 @@
+import { resolve } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { LocalBus, type MessageBus } from '@invoker/transport';
+
+import { createMcpServer, type McpServerOptions } from '../mcp-server.js';
+
+const repoRoot = resolve(__dirname, '../../../..');
+const fixturePlan = resolve(repoRoot, 'plans/fixtures/hello-world.yaml');
+
+async function connectMcpClient(options: McpServerOptions) {
+  const server = createMcpServer(options);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'invoker-cli-test-client', version: '0.0.0' });
+  await Promise.all([
+    client.connect(clientTransport),
+    server.connect(serverTransport),
+  ]);
+  return {
+    client,
+    async close() {
+      await client.close();
+      await server.close();
+    },
+  };
+}
+
+function refusingCreateMessageBus(): () => Promise<MessageBus> {
+  return () => {
+    throw new Error('createMessageBus should not be called without an effective session id');
+  };
+}
+
+describe('mcp-server session-scoped tools', () => {
+  const previousEnv = process.env.INVOKER_PLANNING_SESSION_ID;
+
+  afterEach(() => {
+    if (previousEnv === undefined) {
+      delete process.env.INVOKER_PLANNING_SESSION_ID;
+    } else {
+      process.env.INVOKER_PLANNING_SESSION_ID = previousEnv;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('leaves the file-path invoker_prepare_plan_review behavior unchanged with no sessionId and no env var', async () => {
+    delete process.env.INVOKER_PLANNING_SESSION_ID;
+    const { client, close } = await connectMcpClient({
+      createMessageBus: refusingCreateMessageBus(),
+    });
+    try {
+      const result = await client.callTool({
+        name: 'invoker_prepare_plan_review',
+        arguments: { planPath: fixturePlan },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0]!.text);
+      expect(parsed).toMatchObject({
+        planText: expect.any(String),
+        summary: { name: 'Hello World CLI', taskCount: 1 },
+        confirmationMode: 'require',
+        confirmationText: 'Approve to submit this exact YAML. Cancel keeps the draft. Discard removes it.',
+      });
+    } finally {
+      await close();
+    }
+  });
+
+  it('leaves the file-path invoker_submit_plan behavior unchanged with no sessionId and no env var', async () => {
+    delete process.env.INVOKER_PLANNING_SESSION_ID;
+    const runner = {
+      run: vi.fn(async () => ({ exitCode: 0, stdout: '{"workflow":{"id":"wf-file-path"}}\n', stderr: '' })),
+    };
+    const { client, close } = await connectMcpClient({
+      runner,
+      createMessageBus: refusingCreateMessageBus(),
+    });
+    try {
+      const result = await client.callTool({
+        name: 'invoker_submit_plan',
+        arguments: { planPath: fixturePlan },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(runner.run).toHaveBeenCalledTimes(1);
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content[0]!.text).toContain('wf-file-path');
+    } finally {
+      await close();
+    }
+  });
+
+  it('errors clearly and never touches the runner or file path when no live owner answers a session', async () => {
+    const bus = new LocalBus();
+    const runner = { run: vi.fn(async () => ({ exitCode: 0, stdout: '', stderr: '' })) };
+    const { client, close } = await connectMcpClient({
+      runner,
+      createMessageBus: async () => bus,
+    });
+    try {
+      const result = await client.callTool({
+        name: 'invoker_prepare_plan_review',
+        arguments: { planPath: '/nonexistent/plan.yaml', sessionId: 'sess-no-owner' },
+      });
+
+      expect(result.isError).toBe(true);
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content[0]!.text).toBe('No live Invoker app is running to answer this planning session.');
+      expect(runner.run).not.toHaveBeenCalled();
+    } finally {
+      await close();
+    }
+  });
+
+  it('returns the session draft as a PlanningReviewDraft when the owner has one ready', async () => {
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    bus.onRequest('headless.query', async (req: unknown) => {
+      expect(req).toEqual({ kind: 'planning-chat-session', sessionId: 'sess-with-draft' });
+      return {
+        session: {
+          draftPlanText: 'name: Session Plan\nonFinish: none\ntasks: []\n',
+          draftPlanSummary: { name: 'Session Plan', taskCount: 0, taskGroups: [] },
+          confirmationMode: 'require',
+          status: 'draft_ready',
+        },
+      };
+    });
+    const { client, close } = await connectMcpClient({ createMessageBus: async () => bus });
+    try {
+      const result = await client.callTool({
+        name: 'invoker_prepare_plan_review',
+        arguments: { planPath: '/nonexistent/plan.yaml', sessionId: 'sess-with-draft' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0]!.text);
+      expect(parsed).toEqual({
+        planText: 'name: Session Plan\nonFinish: none\ntasks: []\n',
+        summary: { name: 'Session Plan', taskCount: 0, taskGroups: [] },
+        confirmationMode: 'require',
+        confirmationText: 'Approve to submit this exact YAML. Cancel keeps the draft. Discard removes it.',
+      });
+    } finally {
+      await close();
+    }
+  });
+
+  it('returns a clear error when the session id is unknown to the owner', async () => {
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    bus.onRequest('headless.query', async () => ({ session: null }));
+    const { client, close } = await connectMcpClient({ createMessageBus: async () => bus });
+    try {
+      const result = await client.callTool({
+        name: 'invoker_prepare_plan_review',
+        arguments: { planPath: '/nonexistent/plan.yaml', sessionId: 'sess-missing' },
+      });
+
+      expect(result.isError).toBe(true);
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content[0]!.text).toBe('Unknown planning session "sess-missing". It may have been deleted or never existed.');
+    } finally {
+      await close();
+    }
+  });
+
+  it('dispatches invoker_submit_plan through headless.gui-mutation and maps an ok response', async () => {
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    const guiMutation = vi.fn(async (req: unknown) => {
+      expect(req).toEqual({
+        channel: 'invoker:planning-chat-submit',
+        args: [{ sessionId: 'sess-submit-ok' }],
+      });
+      return { ok: true, planName: 'Session Plan', workflowId: 'wf-session-1' };
+    });
+    bus.onRequest('headless.gui-mutation', guiMutation);
+    const { client, close } = await connectMcpClient({ createMessageBus: async () => bus });
+    try {
+      const result = await client.callTool({
+        name: 'invoker_submit_plan',
+        arguments: { planPath: '/nonexistent/plan.yaml', sessionId: 'sess-submit-ok' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(guiMutation).toHaveBeenCalledTimes(1);
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content[0]!.text).toBe('Submitted Invoker plan. Workflow id: wf-session-1.');
+    } finally {
+      await close();
+    }
+  });
+
+  it('maps a failed headless.gui-mutation response to an MCP error result', async () => {
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    bus.onRequest('headless.gui-mutation', async () => ({ ok: false, error: 'This planning session was already submitted.' }));
+    const { client, close } = await connectMcpClient({ createMessageBus: async () => bus });
+    try {
+      const result = await client.callTool({
+        name: 'invoker_submit_plan',
+        arguments: { planPath: '/nonexistent/plan.yaml', sessionId: 'sess-submit-fail' },
+      });
+
+      expect(result.isError).toBe(true);
+      const content = result.content as Array<{ type: string; text: string }>;
+      expect(content[0]!.text).toBe('This planning session was already submitted.');
+    } finally {
+      await close();
+    }
+  });
+
+  it('honors INVOKER_PLANNING_SESSION_ID as a fallback when no explicit sessionId argument is given', async () => {
+    process.env.INVOKER_PLANNING_SESSION_ID = 'sess-from-env';
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    const query = vi.fn(async (req: unknown) => {
+      expect(req).toEqual({ kind: 'planning-chat-session', sessionId: 'sess-from-env' });
+      return {
+        session: {
+          draftPlanText: 'name: Env Session Plan\nonFinish: none\ntasks: []\n',
+          draftPlanSummary: { name: 'Env Session Plan', taskCount: 0, taskGroups: [] },
+          confirmationMode: 'auto_submit',
+          status: 'draft_ready',
+        },
+      };
+    });
+    bus.onRequest('headless.query', query);
+    const { client, close } = await connectMcpClient({ createMessageBus: async () => bus });
+    try {
+      const result = await client.callTool({
+        name: 'invoker_prepare_plan_review',
+        arguments: { planPath: '/nonexistent/plan.yaml' },
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(query).toHaveBeenCalledTimes(1);
+      const content = result.content as Array<{ type: string; text: string }>;
+      const parsed = JSON.parse(content[0]!.text);
+      expect(parsed.confirmationMode).toBe('auto_submit');
+      expect(parsed.confirmationText).toBe('Auto-submit is enabled. Submit this exact YAML now.');
+    } finally {
+      await close();
+    }
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -31,12 +31,7 @@ import {
   type WorkerRuntime,
   type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
-import {
-  IpcBus,
-  TransportError,
-  TransportErrorCode,
-  type MessageBus,
-} from '@invoker/transport';
+import { type MessageBus } from '@invoker/transport';
 import {
   Orchestrator,
   parsePlanFile,
@@ -45,6 +40,13 @@ import {
   type TaskState,
 } from '@invoker/workflow-core';
 import { logCaughtException } from './logging.js';
+import {
+  createDefaultMessageBus,
+  createTraceId,
+  discoverLiveOwner,
+  withTimeout,
+  type LiveOwnerInfo,
+} from './live-owner-bus.js';
 import { runMcpServer } from './mcp-server.js';
 import { runDoctor, runSetup } from './onboarding.js';
 
@@ -63,11 +65,6 @@ type RunResult = {
   completedTasks: number;
   failedTasks: number;
   mode: 'standalone' | 'live';
-};
-
-type LiveOwnerInfo = {
-  ownerId: string;
-  mode: string;
 };
 
 type LiveSubmissionResult = {
@@ -217,57 +214,6 @@ function parseArgs(argv: string[]): { command?: string; planPath?: string; optio
     planPath: positional[1],
     options,
   };
-}
-
-function createTraceId(channel: string): string {
-  return `${channel}:${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2, 8)}`;
-}
-
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  const TIMEOUT = Symbol('timeout');
-  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<typeof TIMEOUT>((resolveTimeout) => {
-    timeoutHandle = setTimeout(() => resolveTimeout(TIMEOUT), timeoutMs);
-    timeoutHandle.unref?.();
-  });
-  try {
-    const result = await Promise.race([promise, timeout]);
-    if (result === TIMEOUT) {
-      throw new Error(`Timed out after ${timeoutMs}ms`);
-    }
-    return result as T;
-  } finally {
-    if (timeoutHandle) clearTimeout(timeoutHandle);
-  }
-}
-
-async function discoverLiveOwner(bus: MessageBus, timeoutMs = 10_000): Promise<LiveOwnerInfo | null> {
-  try {
-    const raw = await withTimeout(
-      bus.request('headless.owner-ping', {}),
-      timeoutMs,
-    );
-    if (!raw || typeof raw !== 'object') return null;
-    const response = raw as Record<string, unknown>;
-    if (typeof response.mode !== 'string' || response.mode.length === 0) {
-      return null;
-    }
-    return {
-      ownerId: typeof response.ownerId === 'string' ? response.ownerId : '',
-      mode: response.mode,
-    };
-  } catch (err) {
-    if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
-      logCaughtException('Live owner discovery has no handler; falling back to standalone mode', err);
-      return null;
-    }
-    if (err instanceof Error && err.message.startsWith('Timed out after ')) {
-      logCaughtException('Live owner discovery timed out; falling back to standalone mode', err);
-      return null;
-    }
-    logCaughtException('Live owner discovery failed; falling back to standalone mode', err);
-    return null;
-  }
 }
 
 function validateLiveSubmissionResponse(raw: unknown): LiveSubmissionResult {
@@ -478,12 +424,6 @@ function printRunResult(result: RunResult, json: boolean): void {
   } else if (result.mode === 'live') {
     process.stdout.write(`Delegated to live owner - workflow: ${result.workflowId}\n`);
   }
-}
-
-async function createDefaultMessageBus(): Promise<MessageBus> {
-  const bus = new IpcBus(undefined, { allowServe: false });
-  await bus.ready();
-  return bus;
 }
 
 /**

--- a/packages/cli/src/live-owner-bus.ts
+++ b/packages/cli/src/live-owner-bus.ts
@@ -1,0 +1,69 @@
+import {
+  IpcBus,
+  TransportError,
+  TransportErrorCode,
+  type MessageBus,
+} from '@invoker/transport';
+import { logCaughtException } from './logging.js';
+
+export type LiveOwnerInfo = {
+  ownerId: string;
+  mode: string;
+};
+
+export function createTraceId(channel: string): string {
+  return `${channel}:${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2, 8)}`;
+}
+
+export async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  const TIMEOUT = Symbol('timeout');
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<typeof TIMEOUT>((resolveTimeout) => {
+    timeoutHandle = setTimeout(() => resolveTimeout(TIMEOUT), timeoutMs);
+    timeoutHandle.unref?.();
+  });
+  try {
+    const result = await Promise.race([promise, timeout]);
+    if (result === TIMEOUT) {
+      throw new Error(`Timed out after ${timeoutMs}ms`);
+    }
+    return result as T;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+  }
+}
+
+export async function discoverLiveOwner(bus: MessageBus, timeoutMs = 10_000): Promise<LiveOwnerInfo | null> {
+  try {
+    const raw = await withTimeout(
+      bus.request('headless.owner-ping', {}),
+      timeoutMs,
+    );
+    if (!raw || typeof raw !== 'object') return null;
+    const response = raw as Record<string, unknown>;
+    if (typeof response.mode !== 'string' || response.mode.length === 0) {
+      return null;
+    }
+    return {
+      ownerId: typeof response.ownerId === 'string' ? response.ownerId : '',
+      mode: response.mode,
+    };
+  } catch (err) {
+    if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
+      logCaughtException('Live owner discovery has no handler; falling back to standalone mode', err);
+      return null;
+    }
+    if (err instanceof Error && err.message.startsWith('Timed out after ')) {
+      logCaughtException('Live owner discovery timed out; falling back to standalone mode', err);
+      return null;
+    }
+    logCaughtException('Live owner discovery failed; falling back to standalone mode', err);
+    return null;
+  }
+}
+
+export async function createDefaultMessageBus(): Promise<MessageBus> {
+  const bus = new IpcBus(undefined, { allowServe: false });
+  await bus.ready();
+  return bus;
+}

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -4,11 +4,15 @@ import { resolve } from 'node:path';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { InAppPlanningSubmitResponse } from '@invoker/contracts';
+import type { MessageBus } from '@invoker/transport';
 import type { PlanningConfirmationMode, PlanningReviewDraft } from '../../planning-core/src/planning-review.js';
 import { buildPlanningHandoffInstructions } from '../../planning-core/src/planning-handoff-prompt.js';
-import { preparePlanningReview } from '../../planning-core/src/planning-review.js';
+import { confirmationTextForMode, preparePlanningReview } from '../../planning-core/src/planning-review.js';
+import type { PlanSummary } from '../../planning-core/src/plan-summary.js';
 import { parsePlanFile } from '@invoker/workflow-core';
 import { z } from 'zod';
+import { createDefaultMessageBus, discoverLiveOwner } from './live-owner-bus.js';
 
 export type McpSubmitMode = 'live' | 'auto' | 'standalone';
 
@@ -17,6 +21,83 @@ export interface McpCliRunner {
 }
 
 export const HANDOFF_PROMPT_DESCRIPTION = 'Plan a requested change, trigger PR skills for PR/stack work, convert it to Invoker YAML, review the canonical ordered steps, and submit it live.';
+
+const NO_COMPLETE_PLAN_DRAFTED_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
+const NO_LIVE_OWNER_ERROR = 'No live Invoker app is running to answer this planning session.';
+
+interface PlanningChatSessionSnapshot {
+  draftPlanText?: string;
+  draftPlanSummary?: PlanSummary;
+  confirmationMode: PlanningConfirmationMode;
+  status: string;
+}
+
+type McpToolErrorResult = { content: [{ type: 'text'; text: string }]; isError: true };
+
+function mcpError(text: string): McpToolErrorResult {
+  return { content: [{ type: 'text', text }], isError: true };
+}
+
+function resolveEffectiveSessionId(sessionId: string | undefined): string | undefined {
+  if (sessionId) return sessionId;
+  const envSessionId = process.env.INVOKER_PLANNING_SESSION_ID;
+  return envSessionId && envSessionId.length > 0 ? envSessionId : undefined;
+}
+
+export async function preparePlanReviewForSession(
+  sessionId: string,
+  createBus: () => Promise<MessageBus> = createDefaultMessageBus,
+): Promise<PlanningReviewDraft | McpToolErrorResult> {
+  const bus = await createBus();
+  try {
+    const owner = await discoverLiveOwner(bus);
+    if (!owner) {
+      return mcpError(NO_LIVE_OWNER_ERROR);
+    }
+    const response = await bus.request<{ kind: string; sessionId: string }, { session: PlanningChatSessionSnapshot | null }>(
+      'headless.query',
+      { kind: 'planning-chat-session', sessionId },
+    );
+    const session = response.session;
+    if (!session) {
+      return mcpError(`Unknown planning session "${sessionId}". It may have been deleted or never existed.`);
+    }
+    if (!session.draftPlanText) {
+      return mcpError(NO_COMPLETE_PLAN_DRAFTED_ERROR);
+    }
+    return {
+      planText: session.draftPlanText,
+      summary: session.draftPlanSummary as PlanSummary,
+      confirmationMode: session.confirmationMode,
+      confirmationText: confirmationTextForMode(session.confirmationMode),
+    };
+  } finally {
+    bus.disconnect();
+  }
+}
+
+export async function submitPlanForSession(
+  sessionId: string,
+  createBus: () => Promise<MessageBus> = createDefaultMessageBus,
+): Promise<{ ok: true; workflowId: string } | McpToolErrorResult> {
+  const bus = await createBus();
+  try {
+    const owner = await discoverLiveOwner(bus);
+    if (!owner) {
+      return mcpError(NO_LIVE_OWNER_ERROR);
+    }
+    const response = await bus.request<{ channel: string; args: unknown[] }, InAppPlanningSubmitResponse>(
+      'headless.gui-mutation',
+      { channel: 'invoker:planning-chat-submit', args: [{ sessionId }] },
+    );
+    if (!response.ok) {
+      return mcpError(response.error);
+    }
+    return { ok: true, workflowId: response.workflowId };
+  } finally {
+    bus.disconnect();
+  }
+}
 
 type SubmitSuccess = { ok: true; workflowId: string; stdout: string };
 type SubmitFailure = { ok: false; exitCode: number; stdout: string; stderr: string; error?: string };
@@ -166,8 +247,15 @@ export function handoffPrompt(request: string): string {
   ].join('\n');
 }
 
-export async function runMcpServer(options: { runner?: McpCliRunner; cliPath?: string } = {}): Promise<void> {
+export interface McpServerOptions {
+  runner?: McpCliRunner;
+  cliPath?: string;
+  createMessageBus?: () => Promise<MessageBus>;
+}
+
+export function createMcpServer(options: McpServerOptions = {}): McpServer {
   const runner = options.runner ?? createProcessRunner(options.cliPath);
+  const createBus = options.createMessageBus ?? createDefaultMessageBus;
   const server = new McpServer({ name: 'invoker', version: '0.0.5' });
 
   server.registerTool(
@@ -201,9 +289,25 @@ export async function runMcpServer(options: { runner?: McpCliRunner; cliPath?: s
       inputSchema: {
         planPath: z.string(),
         confirmationMode: z.enum(['require', 'auto_submit']).optional(),
+        sessionId: z.string().optional(),
       },
     },
-    async ({ planPath, confirmationMode }) => {
+    async ({ planPath, confirmationMode, sessionId }) => {
+      const effectiveSessionId = resolveEffectiveSessionId(sessionId);
+      if (effectiveSessionId) {
+        const sessionResult = await preparePlanReviewForSession(effectiveSessionId, createBus);
+        if ('isError' in sessionResult) {
+          return sessionResult;
+        }
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(sessionResult, null, 2),
+            },
+          ],
+        };
+      }
       const result = await preparePlanReviewForMcp(planPath, confirmationMode ?? 'require');
       if ('ok' in result && result.ok === false) {
         return {
@@ -229,9 +333,25 @@ export async function runMcpServer(options: { runner?: McpCliRunner; cliPath?: s
       inputSchema: {
         planPath: z.string(),
         mode: z.enum(['live', 'auto', 'standalone']).optional(),
+        sessionId: z.string().optional(),
       },
     },
-    async ({ planPath, mode }) => {
+    async ({ planPath, mode, sessionId }) => {
+      const effectiveSessionId = resolveEffectiveSessionId(sessionId);
+      if (effectiveSessionId) {
+        const sessionResult = await submitPlanForSession(effectiveSessionId, createBus);
+        if ('isError' in sessionResult) {
+          return sessionResult;
+        }
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Submitted Invoker plan. Workflow id: ${sessionResult.workflowId}.`,
+            },
+          ],
+        };
+      }
       const result = await submitPlanForMcp(planPath, mode ?? 'live', runner);
       if (!result.ok) {
         return {
@@ -267,5 +387,10 @@ export async function runMcpServer(options: { runner?: McpCliRunner; cliPath?: s
     }),
   );
 
+  return server;
+}
+
+export async function runMcpServer(options: McpServerOptions = {}): Promise<void> {
+  const server = createMcpServer(options);
   await server.connect(new StdioServerTransport());
 }


### PR DESCRIPTION
invoker_prepare_plan_review/invoker_submit_plan were file-path-based and
fully disconnected from planning-chat session state: a naive submit
could create a workflow with no session linkage via headless.run, or
fall through to a fully separate standalone ~/.invoker-cli/invoker.db
invisible to the app UI. Both tools now accept an optional sessionId
(falling back to an INVOKER_PLANNING_SESSION_ID env var, threaded via
the .mcp.json env field written into each provisioned worktree) and,
when present, route through the exact bridge the UI Confirm button and
chat submit command already use: headless.query
{kind:'planning-chat-session'} for review, headless.gui-mutation
{channel:'invoker:planning-chat-submit'} for submit. No live owner
found is an explicit error, never a silent fallback to a disconnected
DB. Absent both sessionId and the env var, behavior is unchanged for
external terminal users - verified by a regression test asserting the
message bus is never even constructed in that case.

Extracted discoverLiveOwner/withTimeout/createTraceId/LiveOwnerInfo out
of cli/index.ts into a shared live-owner-bus.ts (pure refactor) so both
the CLI's own --live path and the new MCP tools use one implementation.

Part of the planning-chat redesign stack (slice 11/13).

Depends-On: #6537