### PR TITLE
Surface worktree bind status and draft-lock state in the planning UI

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -1469,6 +1469,12 @@ describe('planning chat worktree provisioning', () => {
     const sessionId = created.session.id;
     const expectedBranch = `invoker/planning/${sessionId}`;
 
+    expect(created.session.repoUrl).toBe('https://example.com/repo.git');
+    expect(created.session.baseBranch).toBe('main');
+    expect(created.session.baseCommit).toBe('fake-head-sha');
+    expect((created.session as { worktreePath?: string }).worktreePath).toBeUndefined();
+    expect((created.session as { worktreeBranch?: string }).worktreeBranch).toBeUndefined();
+
     expect(repoPool.ensureCloneThroughRepoQueue).toHaveBeenCalledWith('https://example.com/repo.git');
     expect(repoPool.resolveBaseCommit).toHaveBeenCalledWith('https://example.com/repo.git', 'main');
     expect(repoPool.acquireWorktree).toHaveBeenCalledWith(
@@ -1515,6 +1521,9 @@ describe('planning chat worktree provisioning', () => {
       expect(session?.worktreePath).toBeUndefined();
       expect(session?.worktreeBranch).toBeUndefined();
       expect(session?.conversation.workingDir).toBe(workingDir);
+      expect(created.session.repoUrl).toBeUndefined();
+      expect(created.session.baseBranch).toBeUndefined();
+      expect(created.session.baseCommit).toBeUndefined();
     } finally {
       rmSync(workingDir, { recursive: true, force: true });
     }
@@ -1889,6 +1898,11 @@ describe('rebindPlanningChatRepo', () => {
       expect(stored?.repoUrl).toBe('https://example.com/other-repo.git');
       expect(stored?.baseCommit).toBe('new-head-sha');
       expect(stored?.worktreePath).toBe(worktreePath);
+      const invalidateMessage = stored?.messages.at(-1);
+      expect(invalidateMessage?.text).toBe(
+        'The target repository changed. The previous draft was cleared — ask Invoker to draft it again.',
+      );
+      expect(invalidateMessage?.tone).toBe('error');
 
       const persisted = adapter.loadInAppPlanningSession(sessionId);
       expect(persisted?.draftPlanText).toBeUndefined();

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -452,6 +452,9 @@ function sessionToSummary(session: InAppPlanningChatSession): InAppPlanningSessi
     draftPlanAvailable: hasDraftPlan(session),
     draftPlanSummary: session.draftPlanSummary,
     draftPlanText: session.draftPlanText,
+    repoUrl: session.repoUrl,
+    baseBranch: session.baseBranch,
+    baseCommit: session.baseCommit,
     submittedWorkflowId: session.submittedWorkflowId,
     submittedPlanName: session.submittedPlanName,
     terminalMode: session.terminalMode ?? 'chat',
@@ -1166,6 +1169,7 @@ export async function rebindPlanningChatRepo(
         session,
         'system',
         'The target repository changed. The previous draft was cleared — ask Invoker to draft it again.',
+        'error',
       );
     }
 

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -484,6 +484,9 @@ export interface InAppPlanningSessionSummary {
   draftPlanAvailable: boolean;
   draftPlanSummary?: InAppPlanningPlanSummary;
   draftPlanText?: string;
+  repoUrl?: string;
+  baseBranch?: string;
+  baseCommit?: string;
   submittedWorkflowId?: string;
   submittedPlanName?: string;
   terminalMode?: PlanningTerminalMode;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -408,6 +408,18 @@ function planningNeedsAttention(status: InAppPlanningSessionStatus): boolean {
   return status === 'waiting_for_answer' || status === 'draft_ready';
 }
 
+function planningRepoLabel(repoUrl: string): string {
+  const trimmed = repoUrl.trim().replace(/\.git$/, '');
+  const segments = trimmed.split(/[/:]/).filter(Boolean);
+  return segments.length >= 2 ? segments.slice(-2).join('/') : (segments.at(-1) ?? trimmed);
+}
+
+function planningRepoStatusText(repoUrl: string | undefined, baseCommit: string | undefined): string {
+  if (!repoUrl) return 'No repository bound yet';
+  const label = planningRepoLabel(repoUrl);
+  return baseCommit ? `${label} @ ${baseCommit.slice(0, 7)}` : label;
+}
+
 function previewPlanningMessage(session: PlanningSessionView): string {
   const last = [...session.messages].reverse().find((line) => line.role !== 'system') ?? session.messages.at(-1);
   return last?.text.replace(/\s+/g, ' ').trim() || 'No messages yet';
@@ -4477,6 +4489,9 @@ export function App() {
         {!planningContextCollapsed && (
           reviewingDraft ? (
             <div className="space-y-4 p-4 text-sm">
+              <p data-testid="planning-draft-locked-note" className="text-xs text-muted-foreground">
+                This draft is locked — critique in chat, or ask Invoker to re-draft, to change it.
+              </p>
               {draftTaskGroups.map((group, groupIndex) => (
                 <section key={`${group.workflow ?? 'plan'}-${groupIndex}`} data-testid="draft-task-group">
                   {group.workflow && <h3 className="text-xs font-medium text-foreground">{group.workflow}</h3>}
@@ -4541,6 +4556,12 @@ export function App() {
                   {activePlanningSession.title === 'Untitled plan'
                     ? 'Describe a goal in the chat to begin drafting.'
                     : activePlanningSession.title}
+                </p>
+              </div>
+              <div data-testid="planning-repo-status">
+                <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Repo</div>
+                <p className="mt-1 text-foreground">
+                  {planningRepoStatusText(activePlanningSession.repoUrl, activePlanningSession.baseCommit)}
                 </p>
               </div>
               {draftPlanSummary && (

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1235,6 +1235,75 @@ describe('Invoker terminal (component)', () => {
     expect(mock.api.startReady).not.toHaveBeenCalled();
   });
 
+  it('shows the bound repo and short commit sha in the planning context sidebar', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'repo-bound-session',
+          title: 'Repo bound chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+          baseBranch: 'main',
+          baseCommit: 'a1b2c3d4e5f6',
+        }),
+      ],
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+    fireEvent.click(screen.getByTestId('planning-context-toggle'));
+
+    const repoStatus = await screen.findByTestId('planning-repo-status');
+    expect(repoStatus).toHaveTextContent('Neko-Catpital-Labs/Invoker @ a1b2c3d');
+  });
+
+  it('shows "No repository bound yet" when the planning session has no repo bound', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'no-repo-session',
+          title: 'No repo chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          repoUrl: undefined,
+          baseBranch: undefined,
+          baseCommit: undefined,
+        }),
+      ],
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+    fireEvent.click(screen.getByTestId('planning-context-toggle'));
+
+    const repoStatus = await screen.findByTestId('planning-repo-status');
+    expect(repoStatus).toHaveTextContent('No repository bound yet');
+  });
+
+  it('shows a locked-draft note in the sidebar while reviewing a draft', async () => {
+    mock.api.planningChatSend = vi.fn(async () => ({
+      ok: true,
+      sessionId: 'session-1',
+      reply: 'Here is the plan.',
+      draftPlanAvailable: true,
+      draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First', 'Second'] },
+      draftPlanText: 'name: Mock Plan\ntasks: []\n',
+    })) as any;
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft the full plan');
+
+    expect(await screen.findByTestId('planning-draft-locked-note')).toHaveTextContent(
+      'This draft is locked — critique in chat, or ask Invoker to re-draft, to change it.',
+    );
+  });
+
   it('submits a draft and starts ready work when the user types submit', async () => {
     mock.api.planningChatSend = vi.fn(async () => ({
       ok: true,


### PR DESCRIPTION
Purely additive rendering over state slices 3-11 already enforce
domain-side: expose repoUrl/baseBranch/baseCommit through
InAppPlanningSessionSummary and sessionToSummary (worktreePath and
worktreeBranch stay server-side only - a raw filesystem path is not
useful to show a user). The planning context sidebar now shows a
"Repo" section (shortened repo name + short commit sha, or "No
repository bound yet"), and a muted note while reviewing a draft
that it is locked until discard, re-draft, or submit. The rebind
invalidation system message (slice 8) now carries tone: 'error' so it
renders distinctly - no new UI component code needed for that part,
since InvokerTerminal.tsx already styles error-toned messages.

Fixed two new UI tests that initially timed out: the planning context
sidebar defaults to collapsed (planningContextCollapsed), so the tests
now click the existing planning-context-toggle button before asserting
on the new sidebar content, matching how a real user would reach it.

Part of the planning-chat redesign stack (slice 12/13).

Depends-On: #6538