### PR TITLE
[Remote Sync Step 2: Delta Exchange and Merge Engine](1) Add data-store delta exchange and merge engine

### DIFF
--- a/packages/data-store/src/__tests__/sync-merge.test.ts
+++ b/packages/data-store/src/__tests__/sync-merge.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Attempt, TaskState } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { WorkflowSaveInput } from '../adapter.js';
+import type { SqliteExecutor } from '../sqlite-executor.js';
+import { appendJournalEntry, getSyncCursor, readJournalSince } from '../sync-journal.js';
+import { exportDelta } from '../sync-delta.js';
+import { applyDelta } from '../sync-merge.js';
+
+const T0 = '2026-07-28T00:00:00.000Z';
+const T1 = '2026-07-28T00:00:01.000Z';
+const T2 = '2026-07-28T00:00:02.000Z';
+
+function executor(adapter: SQLiteAdapter): SqliteExecutor {
+  return (adapter as unknown as { executor: SqliteExecutor }).executor;
+}
+
+function makeWorkflow(id = 'wf-1'): WorkflowSaveInput {
+  return {
+    id,
+    name: `Workflow ${id}`,
+    createdAt: T0,
+    updatedAt: T0,
+  };
+}
+
+function makeTask(id = 'task-1', status: TaskState['status'] = 'pending'): TaskState {
+  return {
+    id,
+    description: `Task ${id}`,
+    status,
+    dependencies: [],
+    createdAt: new Date(T0),
+    config: {},
+    execution: { generation: 0 },
+    taskStateVersion: 1,
+  };
+}
+
+function makeAttempt(id: string, taskId: string, status: Attempt['status']): Attempt {
+  return {
+    id,
+    nodeId: taskId,
+    queuePriority: 0,
+    status,
+    upstreamAttemptIds: [],
+    createdAt: new Date(T1),
+  };
+}
+
+function seed(adapter: SQLiteAdapter, workflowId = 'wf-1', taskId = 'task-1'): void {
+  adapter.saveWorkflow(makeWorkflow(workflowId));
+  adapter.saveTask(workflowId, makeTask(taskId));
+}
+
+function latestRow(db: SqliteExecutor, table: string): Record<string, unknown> {
+  const row = db.queryOne(`SELECT * FROM ${table} ORDER BY id DESC LIMIT 1`);
+  if (!row) throw new Error(`No rows in ${table}`);
+  return row;
+}
+
+function insertEventAndJournal(adapter: SQLiteAdapter, taskId: string): void {
+  adapter.logEvent(taskId, 'task.progress', { step: 1 });
+  const row = latestRow(executor(adapter), 'events');
+  appendJournalEntry(executor(adapter), {
+    entityType: 'event',
+    entityId: String(row.id),
+    op: 'upsert',
+    payload: row,
+  });
+}
+
+function insertOutputAndJournal(adapter: SQLiteAdapter, taskId: string): void {
+  const db = executor(adapter);
+  db.execRun(
+    'INSERT INTO output_spool (id, task_id, offset, data, created_at) VALUES (?, ?, ?, ?, ?)',
+    [1, taskId, 0, 'hello\n', T1],
+  );
+  const row = latestRow(db, 'output_spool');
+  appendJournalEntry(db, {
+    entityType: 'output',
+    entityId: String(row.id),
+    op: 'upsert',
+    payload: row,
+  });
+}
+
+function exchange(from: SQLiteAdapter, to: SQLiteAdapter, peerId: string): void {
+  applyDelta(executor(to), exportDelta(executor(from), 0), peerId);
+}
+
+function tableRows(adapter: SQLiteAdapter, table: string): Record<string, unknown>[] {
+  return executor(adapter).queryAll(`SELECT * FROM ${table} ORDER BY id ASC`);
+}
+
+function graphState(adapter: SQLiteAdapter): Record<string, unknown> {
+  const db = executor(adapter);
+  return {
+    workflows: db.queryAll(
+      'SELECT id, name, deleted_at, created_at, updated_at FROM workflows ORDER BY id ASC',
+    ),
+    tasks: db.queryAll(
+      'SELECT id, workflow_id, description, status, dependencies, started_at, completed_at, task_state_version FROM tasks ORDER BY id ASC',
+    ),
+    attempts: db.queryAll(
+      'SELECT id, node_id, status, created_at, completed_at, exit_code, error FROM attempts ORDER BY id ASC',
+    ),
+    events: db.queryAll(
+      'SELECT id, task_id, event_type, payload, created_at FROM events ORDER BY id ASC',
+    ),
+    output: db.queryAll(
+      'SELECT id, task_id, offset, data, created_at FROM output_spool ORDER BY id ASC',
+    ),
+  };
+}
+
+describe('sync merge', () => {
+  let a: SQLiteAdapter;
+  let b: SQLiteAdapter;
+
+  beforeEach(async () => {
+    a = await SQLiteAdapter.create(':memory:');
+    b = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    a.close();
+    b.close();
+  });
+
+  it('converges divergent running vs completed task status to completed', () => {
+    seed(a);
+    seed(b);
+
+    a.updateTask('task-1', { status: 'running', execution: { startedAt: new Date(T1) } });
+    b.updateTask('task-1', { status: 'completed', execution: { completedAt: new Date(T2), exitCode: 0 } });
+
+    exchange(a, b, 'peer-a');
+    exchange(b, a, 'peer-b');
+
+    expect(a.loadTask('task-1')?.status).toBe('completed');
+    expect(b.loadTask('task-1')?.status).toBe('completed');
+    expect(a.loadWorkflow('wf-1')?.status).toBe('completed');
+    expect(b.loadWorkflow('wf-1')?.status).toBe('completed');
+  });
+
+  it('keeps completed ahead of a partitioned cancel/closed status', () => {
+    seed(a);
+    seed(b);
+
+    a.updateTask('task-1', { status: 'closed', execution: { completedAt: new Date(T1) } });
+    b.updateTask('task-1', { status: 'completed', execution: { completedAt: new Date(T2), exitCode: 0 } });
+
+    exchange(a, b, 'peer-a');
+    exchange(b, a, 'peer-b');
+
+    expect(a.loadTask('task-1')?.status).toBe('completed');
+    expect(b.loadTask('task-1')?.status).toBe('completed');
+  });
+
+  it('keeps tombstones while parking late progress under the soft-deleted workflow', () => {
+    seed(a, 'wf-delete', 'task-delete');
+    seed(b, 'wf-delete', 'task-delete');
+
+    a.deleteWorkflow('wf-delete');
+    b.updateTask('task-delete', { status: 'running', execution: { startedAt: new Date(T1) } });
+    b.saveAttempt(makeAttempt('attempt-delete-1', 'task-delete', 'running'));
+    insertEventAndJournal(b, 'task-delete');
+    insertOutputAndJournal(b, 'task-delete');
+
+    exchange(a, b, 'peer-a');
+    expect(b.loadWorkflow('wf-delete')).toBeUndefined();
+    expect(b.loadWorkflow('wf-delete', { includeDeleted: true })?.deletedAt).toEqual(expect.any(Number));
+    expect(b.loadTasks('wf-delete').map((task) => task.id)).toEqual(['task-delete']);
+
+    exchange(b, a, 'peer-b');
+    expect(a.loadWorkflow('wf-delete')).toBeUndefined();
+    expect(a.loadWorkflow('wf-delete', { includeDeleted: true })?.deletedAt).toEqual(expect.any(Number));
+    expect(a.loadTasks('wf-delete')[0]?.status).toBe('running');
+    expect(a.loadAttempts('task-delete').map((attempt) => attempt.id)).toEqual(['attempt-delete-1']);
+    expect(a.getEvents('task-delete').map((event) => event.eventType)).toEqual(['task.progress']);
+    expect(tableRows(a, 'output_spool')).toMatchObject([{ task_id: 'task-delete', offset: 0, data: 'hello\n' }]);
+
+    exchange(a, b, 'peer-a');
+    expect(b.loadWorkflow('wf-delete')).toBeUndefined();
+    expect(b.loadTasks('wf-delete')[0]?.status).toBe('running');
+    expect(b.getEvents('task-delete')).toHaveLength(1);
+  });
+
+  it('applies duplicate delivery idempotently', () => {
+    seed(a);
+    seed(b);
+    a.updateTask('task-1', { status: 'running', execution: { startedAt: new Date(T1) } });
+    insertEventAndJournal(a, 'task-1');
+
+    const batch = exportDelta(executor(a), 0);
+    const first = applyDelta(executor(b), batch, 'peer-a');
+    const second = applyDelta(executor(b), batch, 'peer-a');
+
+    expect(first.appliedEntries).toBeGreaterThan(0);
+    expect(second.appliedEntries).toBe(0);
+    expect(b.loadTask('task-1')?.status).toBe('running');
+    expect(b.getEvents('task-1')).toHaveLength(1);
+    expect(readJournalSince(executor(b), 0, 100).filter((entry) => entry.origin === 'peer-a')).toHaveLength(
+      first.appliedEntries,
+    );
+  });
+
+  it('exports only local-origin entries so imported rows are not echoed', () => {
+    seed(a);
+    seed(b);
+    a.updateTask('task-1', { status: 'running' });
+
+    applyDelta(executor(b), exportDelta(executor(a), 0), 'peer-a');
+
+    const echoed = exportDelta(executor(b), 0);
+    expect(echoed.entries).toEqual([]);
+    expect(echoed.highWaterSeq).toBeGreaterThan(0);
+    expect(readJournalSince(executor(b), 0, 100).map((entry) => entry.origin)).toEqual(['peer-a']);
+  });
+
+  it('rejects unsupported delta schema versions', () => {
+    seed(a);
+    seed(b);
+    a.updateTask('task-1', { status: 'running' });
+    const batch = exportDelta(executor(a), 0);
+
+    expect(() =>
+      applyDelta(executor(b), { ...batch, schemaVersion: 999 as 1 }, 'peer-a'),
+    ).toThrow(/Unsupported delta schema version 999/);
+    expect(getSyncCursor(executor(b), 'peer-a')).toBeUndefined();
+    expect(b.loadTask('task-1')?.status).toBe('pending');
+  });
+
+  it('updates the peer receive cursor atomically with the applied delta', () => {
+    seed(a);
+    seed(b);
+    a.updateTask('task-1', { status: 'running' });
+
+    const batch = exportDelta(executor(a), 0);
+    applyDelta(executor(b), batch, 'peer-a');
+
+    expect(getSyncCursor(executor(b), 'peer-a')?.lastReceivedSeq).toBe(batch.highWaterSeq);
+  });
+
+  it('round-trips A to B to A and converges both stores to identical graph state', () => {
+    seed(a);
+    seed(b);
+
+    a.updateTask('task-1', { status: 'running', execution: { startedAt: new Date(T1) } });
+    b.updateTask('task-1', { status: 'completed', execution: { completedAt: new Date(T2), exitCode: 0 } });
+    b.saveAttempt(makeAttempt('attempt-1', 'task-1', 'completed'));
+    insertEventAndJournal(b, 'task-1');
+    insertOutputAndJournal(b, 'task-1');
+
+    exchange(a, b, 'peer-a');
+    exchange(b, a, 'peer-b');
+
+    expect(graphState(a)).toEqual(graphState(b));
+  });
+});

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -8,3 +8,5 @@ export * from './slack-plan-draft-repository.js';
 export * from './sqlite-task-repository.js';
 export * from './workflow-channel-repository.js';
 export * from './sync-journal.js';
+export * from './sync-delta.js';
+export * from './sync-merge.js';

--- a/packages/data-store/src/sync-delta.ts
+++ b/packages/data-store/src/sync-delta.ts
@@ -1,0 +1,55 @@
+import type { SqliteExecutor } from './sqlite-executor.js';
+import { LOCAL_SYNC_ORIGIN, type SyncJournalEntry } from './sync-journal.js';
+
+export const DELTA_BATCH_SCHEMA_VERSION = 1;
+
+export interface DeltaBatch {
+  schemaVersion: typeof DELTA_BATCH_SCHEMA_VERSION;
+  sinceSeq: number;
+  highWaterSeq: number;
+  entries: SyncJournalEntry[];
+}
+
+function asNonNegativeInteger(name: string, value: number): number {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function mapJournalRow(row: Record<string, unknown>): SyncJournalEntry {
+  return {
+    seq: Number(row.seq),
+    entityType: String(row.entity_type) as SyncJournalEntry['entityType'],
+    entityId: String(row.entity_id),
+    op: String(row.op) as SyncJournalEntry['op'],
+    payload: JSON.parse(String(row.payload ?? 'null')),
+    origin: String(row.origin),
+    createdAt: String(row.created_at),
+  };
+}
+
+export function exportDelta(db: SqliteExecutor, sinceSeq: number): DeltaBatch {
+  const cursor = asNonNegativeInteger('sinceSeq', Math.trunc(sinceSeq));
+  const highWaterRow = db.queryOne('SELECT COALESCE(MAX(seq), 0) AS seq FROM sync_journal') as
+    | { seq?: number }
+    | undefined;
+  const highWaterSeq = Math.max(cursor, Number(highWaterRow?.seq ?? 0));
+
+  const rows = db.queryAll(
+    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
+       FROM sync_journal
+      WHERE seq > ?
+        AND seq <= ?
+        AND origin = ?
+      ORDER BY seq ASC`,
+    [cursor, highWaterSeq, LOCAL_SYNC_ORIGIN],
+  );
+
+  return {
+    schemaVersion: DELTA_BATCH_SCHEMA_VERSION,
+    sinceSeq: cursor,
+    highWaterSeq,
+    entries: rows.map((row) => mapJournalRow(row)),
+  };
+}

--- a/packages/data-store/src/sync-merge.ts
+++ b/packages/data-store/src/sync-merge.ts
@@ -5,6 +5,7 @@ import {
   appendJournalEntry,
   getSyncCursor,
   setSyncCursor,
+  LOCAL_SYNC_ORIGIN,
   type SyncEntityType,
   type SyncJournalEntry,
 } from './sync-journal.js';
@@ -13,6 +14,18 @@ export interface ApplyDeltaResult {
   appliedEntries: number;
   skippedEntries: number;
   lastReceivedSeq: number;
+}
+
+interface ApplyEntryResult {
+  changed: boolean;
+  // True only when the persisted row now equals the incoming payload byte
+  // for byte (whether because it was just applied, or because it already
+  // matched). False when the local row instead won a real conflict against
+  // genuinely different incoming content — that local row is not yet known
+  // to the sender and must be kept exportable. Do not set this to `changed`
+  // — a losing incoming entry leaves `changed` false too, but its local row
+  // must still be retained, not purged.
+  incomingAuthoritative: boolean;
 }
 
 type RowPayload = Record<string, unknown>;
@@ -443,6 +456,18 @@ function chooseByStatusThenCanonical(
     : { ...local, [statusColumn]: localStatus };
 }
 
+function canonicalEquals(a: RowPayload, b: RowPayload): boolean {
+  return canonical(a) === canonical(b);
+}
+
+function purgeLocalOriginJournal(db: SqliteExecutor, entityType: SyncEntityType, entityId: string): void {
+  db.execRun('DELETE FROM sync_journal WHERE entity_type = ? AND entity_id = ? AND origin = ?', [
+    entityType,
+    entityId,
+    LOCAL_SYNC_ORIGIN,
+  ]);
+}
+
 function hasSamePersistedPayload(
   db: SqliteExecutor,
   table: string,
@@ -467,43 +492,51 @@ function hasSamePersistedPayload(
   });
 }
 
-function applyWorkflowUpsert(db: SqliteExecutor, entry: SyncJournalEntry, tombstone: boolean): boolean {
+function applyWorkflowUpsert(db: SqliteExecutor, entry: SyncJournalEntry, tombstone: boolean): ApplyEntryResult {
   const payload = asPayload(entry.payload, entry.entityType, entry.entityId);
   const id = requiredText(payload.id ?? entry.entityId, 'workflow id');
   const existing = db.queryOne('SELECT * FROM workflows WHERE id = ?', [id]);
   const incomingDeletedAt = integer(payload.deleted_at);
   const existingDeletedAt = integer(existing?.deleted_at);
   if (existingDeletedAt !== undefined && !tombstone && incomingDeletedAt === undefined) {
-    return false;
+    return { changed: false, incomingAuthoritative: false };
   }
   const deletedAt = tombstone
     ? incomingDeletedAt !== undefined && existingDeletedAt !== undefined
       ? Math.max(incomingDeletedAt, existingDeletedAt)
       : incomingDeletedAt ?? existingDeletedAt ?? Date.now()
     : existingDeletedAt ?? incomingDeletedAt;
+  const incomingCandidate = withDefaults(payload, defaultWorkflow(id, deletedAt));
+  const incomingNormalized = {
+    ...incomingCandidate,
+    status: normalizeWorkflowStatus(incomingCandidate.status),
+  };
   const statusWinner = chooseByStatusThenCanonical(
     existing,
-    withDefaults(payload, defaultWorkflow(id, deletedAt)),
+    incomingNormalized,
     'status',
     WORKFLOW_STATUS_RANK,
     (value) => normalizeWorkflowStatus(value),
   );
+  const incomingAuthoritative = canonicalEquals(statusWinner, incomingNormalized);
   const merged = {
     ...statusWinner,
     id,
     deleted_at: deletedAt ?? null,
     updated_at: text(statusWinner.updated_at) ?? (deletedAt ? new Date(deletedAt).toISOString() : nowIso()),
   };
-  if (hasSamePersistedPayload(db, 'workflows', 'id', id, merged, WORKFLOW_COLUMNS)) return false;
+  if (hasSamePersistedPayload(db, 'workflows', 'id', id, merged, WORKFLOW_COLUMNS)) {
+    return { changed: false, incomingAuthoritative };
+  }
   upsertPayloadRow(db, 'workflows', 'id', WORKFLOW_COLUMNS, merged);
-  return true;
+  return { changed: true, incomingAuthoritative };
 }
 
-function applyWorkflowTombstone(db: SqliteExecutor, entry: SyncJournalEntry): boolean {
+function applyWorkflowTombstone(db: SqliteExecutor, entry: SyncJournalEntry): ApplyEntryResult {
   return applyWorkflowUpsert(db, entry, true);
 }
 
-function applyTaskUpsert(db: SqliteExecutor, entry: SyncJournalEntry): boolean {
+function applyTaskUpsert(db: SqliteExecutor, entry: SyncJournalEntry): ApplyEntryResult {
   const payload = asPayload(entry.payload, entry.entityType, entry.entityId);
   const id = requiredText(payload.id ?? entry.entityId, 'task id');
   const workflowId = requiredText(payload.workflow_id, `task ${id} workflow_id`);
@@ -519,13 +552,15 @@ function applyTaskUpsert(db: SqliteExecutor, entry: SyncJournalEntry): boolean {
     execution_generation: 0,
     task_state_version: 1,
   });
+  const incomingNormalized = { ...incoming, status: normalizeTaskStatus(incoming.status) };
   const winner = chooseByStatusThenCanonical(
     existing,
-    { ...incoming, status: normalizeTaskStatus(incoming.status) },
+    incomingNormalized,
     'status',
     TASK_STATUS_RANK,
     (value) => normalizeTaskStatus(value),
   );
+  const incomingAuthoritative = canonicalEquals(winner, incomingNormalized);
   const mergedWorkflowId = text(winner.workflow_id) ?? workflowId;
   ensureWorkflow(db, mergedWorkflowId, workflowDeletedAt(db, mergedWorkflowId));
   const merged = {
@@ -533,12 +568,14 @@ function applyTaskUpsert(db: SqliteExecutor, entry: SyncJournalEntry): boolean {
     id,
     workflow_id: mergedWorkflowId,
   };
-  if (hasSamePersistedPayload(db, 'tasks', 'id', id, merged, TASK_COLUMNS)) return false;
+  if (hasSamePersistedPayload(db, 'tasks', 'id', id, merged, TASK_COLUMNS)) {
+    return { changed: false, incomingAuthoritative };
+  }
   upsertPayloadRow(db, 'tasks', 'id', TASK_COLUMNS, merged);
-  return true;
+  return { changed: true, incomingAuthoritative };
 }
 
-function applyAttemptUpsert(db: SqliteExecutor, entry: SyncJournalEntry): boolean {
+function applyAttemptUpsert(db: SqliteExecutor, entry: SyncJournalEntry): ApplyEntryResult {
   const payload = asPayload(entry.payload, entry.entityType, entry.entityId);
   const id = requiredText(payload.id ?? entry.entityId, 'attempt id');
   const nodeId = requiredText(payload.node_id, `attempt ${id} node_id`);
@@ -556,25 +593,29 @@ function applyAttemptUpsert(db: SqliteExecutor, entry: SyncJournalEntry): boolea
     upstream_attempt_ids: '[]',
     created_at: nowIso(),
   });
+  const incomingNormalized = { ...incoming, status: normalizeAttemptStatus(incoming.status) };
   const winner = chooseByStatusThenCanonical(
     existing,
-    { ...incoming, status: normalizeAttemptStatus(incoming.status) },
+    incomingNormalized,
     'status',
     ATTEMPT_STATUS_RANK,
     (value) => normalizeAttemptStatus(value),
   );
+  const incomingAuthoritative = canonicalEquals(winner, incomingNormalized);
   const mergedNodeId = text(winner.node_id) ?? nodeId;
   const merged = {
     ...winner,
     id,
     node_id: mergedNodeId,
   };
-  if (hasSamePersistedPayload(db, 'attempts', 'id', id, merged, ATTEMPT_COLUMNS)) return false;
+  if (hasSamePersistedPayload(db, 'attempts', 'id', id, merged, ATTEMPT_COLUMNS)) {
+    return { changed: false, incomingAuthoritative };
+  }
   upsertPayloadRow(db, 'attempts', 'id', ATTEMPT_COLUMNS, merged);
-  return true;
+  return { changed: true, incomingAuthoritative };
 }
 
-function applyEventUpsert(db: SqliteExecutor, entry: SyncJournalEntry): boolean {
+function applyEventUpsert(db: SqliteExecutor, entry: SyncJournalEntry): ApplyEntryResult {
   const payload = asPayload(entry.payload, entry.entityType, entry.entityId);
   const id = integer(payload.id ?? entry.entityId);
   if (id === undefined) throw new Error(`event ${entry.entityId} id must be an integer`);
@@ -589,10 +630,11 @@ function applyEventUpsert(db: SqliteExecutor, entry: SyncJournalEntry): boolean 
     event_type: 'sync.event',
     created_at: nowIso(),
   });
-  return insertAppendOnlyRow(db, 'events', 'id', EVENT_COLUMNS, row);
+  const changed = insertAppendOnlyRow(db, 'events', 'id', EVENT_COLUMNS, row);
+  return { changed, incomingAuthoritative: true };
 }
 
-function applyOutputUpsert(db: SqliteExecutor, entry: SyncJournalEntry): boolean {
+function applyOutputUpsert(db: SqliteExecutor, entry: SyncJournalEntry): ApplyEntryResult {
   const payload = asPayload(entry.payload, entry.entityType, entry.entityId);
   const id = integer(payload.id ?? entry.entityId);
   const taskId = requiredText(payload.task_id, `output ${entry.entityId} task_id`);
@@ -609,7 +651,8 @@ function applyOutputUpsert(db: SqliteExecutor, entry: SyncJournalEntry): boolean
       data: '',
       created_at: nowIso(),
     });
-    return insertAppendOnlyRow(db, 'output_spool', 'id', OUTPUT_COLUMNS, row);
+    const changed = insertAppendOnlyRow(db, 'output_spool', 'id', OUTPUT_COLUMNS, row);
+    return { changed, incomingAuthoritative: true };
   }
 
   const offset = integer(payload.offset);
@@ -620,7 +663,7 @@ function applyOutputUpsert(db: SqliteExecutor, entry: SyncJournalEntry): boolean
     'SELECT id FROM output_spool WHERE task_id = ? AND offset = ?',
     [taskId, offset],
   );
-  if (existing) return false;
+  if (existing) return { changed: false, incomingAuthoritative: true };
   const row = withDefaults(payload, {
     task_id: taskId,
     offset,
@@ -635,26 +678,26 @@ function applyOutputUpsert(db: SqliteExecutor, entry: SyncJournalEntry): boolean
      VALUES (${selected.columns.map(() => '?').join(', ')})`,
     selected.values,
   );
-  return true;
+  return { changed: true, incomingAuthoritative: true };
 }
 
-function applyEntry(db: SqliteExecutor, entry: SyncJournalEntry): boolean {
+function applyEntry(db: SqliteExecutor, entry: SyncJournalEntry): ApplyEntryResult {
   switch (entry.entityType) {
     case 'workflow':
       return entry.op === 'tombstone'
         ? applyWorkflowTombstone(db, entry)
         : applyWorkflowUpsert(db, entry, false);
     case 'task':
-      if (entry.op === 'tombstone') return false;
+      if (entry.op === 'tombstone') return { changed: false, incomingAuthoritative: false };
       return applyTaskUpsert(db, entry);
     case 'attempt':
-      if (entry.op === 'tombstone') return false;
+      if (entry.op === 'tombstone') return { changed: false, incomingAuthoritative: false };
       return applyAttemptUpsert(db, entry);
     case 'event':
-      if (entry.op === 'tombstone') return false;
+      if (entry.op === 'tombstone') return { changed: false, incomingAuthoritative: false };
       return applyEventUpsert(db, entry);
     case 'output':
-      if (entry.op === 'tombstone') return false;
+      if (entry.op === 'tombstone') return { changed: false, incomingAuthoritative: false };
       return applyOutputUpsert(db, entry);
     default:
       throw new Error(`Unsupported sync entity type ${(entry as { entityType?: unknown }).entityType}`);
@@ -675,8 +718,11 @@ export function applyDelta(db: SqliteExecutor, batch: DeltaBatch, peerId: string
     let skippedEntries = batch.entries.length - entries.length;
 
     for (const entry of entries) {
-      const changed = applyEntry(db, entry);
-      if (!changed) {
+      const result = applyEntry(db, entry);
+      if (result.incomingAuthoritative) {
+        purgeLocalOriginJournal(db, entry.entityType, entry.entityId);
+      }
+      if (!result.changed) {
         skippedEntries += 1;
         continue;
       }

--- a/packages/data-store/src/sync-merge.ts
+++ b/packages/data-store/src/sync-merge.ts
@@ -1,0 +1,708 @@
+import type { AttemptStatus, TaskStatus, WorkflowDerivedStatus } from '@invoker/workflow-core';
+import type { SqliteExecutor } from './sqlite-executor.js';
+import { DELTA_BATCH_SCHEMA_VERSION, type DeltaBatch } from './sync-delta.js';
+import {
+  appendJournalEntry,
+  getSyncCursor,
+  setSyncCursor,
+  type SyncEntityType,
+  type SyncJournalEntry,
+} from './sync-journal.js';
+
+export interface ApplyDeltaResult {
+  appliedEntries: number;
+  skippedEntries: number;
+  lastReceivedSeq: number;
+}
+
+type RowPayload = Record<string, unknown>;
+
+const WORKFLOW_COLUMNS = [
+  'id',
+  'name',
+  'description',
+  'visual_proof',
+  'plan_file',
+  'repo_url',
+  'intermediate_repo_url',
+  'branch',
+  'on_finish',
+  'base_branch',
+  'parent_remote',
+  'feature_branch',
+  'merge_mode',
+  'review_provider',
+  'external_dependencies',
+  'external_dependency_changes',
+  'detached_external_dependencies',
+  'generation',
+  'deleted_at',
+  'created_at',
+  'updated_at',
+] as const;
+
+const TASK_COLUMNS = [
+  'id',
+  'workflow_id',
+  'description',
+  'status',
+  'blocked_by',
+  'dependencies',
+  'command',
+  'prompt',
+  'experiment_prompt',
+  'exit_code',
+  'error',
+  'protocol_error_code',
+  'protocol_error_message',
+  'input_prompt',
+  'external_dependencies',
+  'summary',
+  'problem',
+  'approach',
+  'test_plan',
+  'repro_command',
+  'fix_prompt',
+  'fix_context',
+  'branch',
+  'commit_hash',
+  'fixed_integration_sha',
+  'fixed_integration_recorded_at',
+  'fixed_integration_source',
+  'parent_task',
+  'pivot',
+  'experiment_variants',
+  'is_reconciliation',
+  'selected_experiment',
+  'selected_experiments',
+  'experiment_results',
+  'requires_manual_approval',
+  'repo_url',
+  'feature_branch',
+  'is_merge_node',
+  'auto_fix',
+  'max_fix_attempts',
+  'runner_kind',
+  'pool_id',
+  'claude_session_id',
+  'agent_session_id',
+  'workspace_path',
+  'container_id',
+  'last_agent_session_id',
+  'last_agent_name',
+  'action_request_id',
+  'experiments',
+  'created_at',
+  'launch_phase',
+  'launch_started_at',
+  'launch_completed_at',
+  'started_at',
+  'completed_at',
+  'last_heartbeat_at',
+  'utilization',
+  'pending_fix_error',
+  'fix_session_entry_status',
+  'failure_class',
+  'review_url',
+  'review_id',
+  'review_status',
+  'review_provider_id',
+  'review_gate',
+  'is_fixing_with_ai',
+  'execution_generation',
+  'selected_attempt_id',
+  'pool_member_id',
+  'docker_image',
+  'execution_agent',
+  'execution_model',
+  'agent_name',
+  'task_state_version',
+] as const;
+
+const ATTEMPT_COLUMNS = [
+  'id',
+  'node_id',
+  'attempt_number',
+  'queue_priority',
+  'status',
+  'snapshot_commit',
+  'base_branch',
+  'upstream_attempt_ids',
+  'command_override',
+  'prompt_override',
+  'claimed_at',
+  'started_at',
+  'completed_at',
+  'exit_code',
+  'error',
+  'last_heartbeat_at',
+  'lease_expires_at',
+  'branch',
+  'commit_hash',
+  'summary',
+  'workspace_path',
+  'claude_session_id',
+  'agent_session_id',
+  'container_id',
+  'supersedes_attempt_id',
+  'created_at',
+  'merge_conflict',
+] as const;
+
+const EVENT_COLUMNS = ['id', 'task_id', 'event_type', 'payload', 'created_at'] as const;
+const OUTPUT_COLUMNS = ['id', 'task_id', 'offset', 'data', 'created_at'] as const;
+
+const JSON_COLUMNS = new Set<string>([
+  'dependencies',
+  'external_dependencies',
+  'external_dependency_changes',
+  'detached_external_dependencies',
+  'experiment_variants',
+  'selected_experiments',
+  'experiment_results',
+  'experiments',
+  'review_gate',
+  'upstream_attempt_ids',
+  'merge_conflict',
+  'payload',
+]);
+
+const BOOLEAN_COLUMNS = new Set<string>([
+  'visual_proof',
+  'pivot',
+  'is_reconciliation',
+  'requires_manual_approval',
+  'is_merge_node',
+  'auto_fix',
+  'is_fixing_with_ai',
+]);
+
+const TASK_STATUS_RANK: Record<string, number> = {
+  pending: 0,
+  queued: 1,
+  blocked: 1,
+  running: 2,
+  needs_input: 3,
+  awaiting_approval: 4,
+  review_ready: 5,
+  fixing_with_ai: 6,
+  failed: 7,
+  closed: 8,
+  cancelled: 8,
+  canceled: 8,
+  stale: 9,
+  completed: 10,
+};
+
+const WORKFLOW_STATUS_RANK: Record<string, number> = {
+  pending: 0,
+  blocked: 1,
+  running: 2,
+  awaiting_approval: 4,
+  review_ready: 5,
+  fixing_with_ai: 6,
+  failed: 7,
+  closed: 8,
+  cancelled: 8,
+  canceled: 8,
+  stale: 9,
+  completed: 10,
+};
+
+const ATTEMPT_STATUS_RANK: Record<string, number> = {
+  pending: 0,
+  claimed: 1,
+  running: 2,
+  needs_input: 3,
+  superseded: 4,
+  failed: 4,
+  cancelled: 4,
+  canceled: 4,
+  completed: 5,
+};
+
+function assertSupportedBatch(batch: DeltaBatch): void {
+  if (!batch || typeof batch !== 'object') {
+    throw new Error('Delta batch must be an object');
+  }
+  if (batch.schemaVersion !== DELTA_BATCH_SCHEMA_VERSION) {
+    throw new Error(`Unsupported delta schema version ${String(batch.schemaVersion)}`);
+  }
+  if (!Number.isInteger(batch.highWaterSeq) || batch.highWaterSeq < 0) {
+    throw new Error('Delta batch highWaterSeq must be a non-negative integer');
+  }
+  if (!Array.isArray(batch.entries)) {
+    throw new Error('Delta batch entries must be an array');
+  }
+  const maxEntrySeq = Math.max(0, ...batch.entries.map((entry) => entry.seq));
+  if (maxEntrySeq > batch.highWaterSeq) {
+    throw new Error('Delta batch contains entries beyond highWaterSeq');
+  }
+}
+
+function asPayload(value: unknown, entityType: SyncEntityType, entityId: string): RowPayload {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Delta ${entityType} ${entityId} payload must be an object`);
+  }
+  return value as RowPayload;
+}
+
+function text(value: unknown): string | undefined {
+  return value === null || value === undefined ? undefined : String(value);
+}
+
+function requiredText(value: unknown, name: string): string {
+  const out = text(value);
+  if (!out) throw new Error(`${name} is required`);
+  return out;
+}
+
+function integer(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === '') return undefined;
+  const out = Number(value);
+  return Number.isInteger(out) ? out : undefined;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function sqlIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function tableColumns(db: SqliteExecutor, table: string): Set<string> {
+  const rows = db.queryAll(`PRAGMA table_info(${sqlIdentifier(table)})`);
+  return new Set(rows.map((row) => String(row.name)));
+}
+
+function canonical(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonical(entry)).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const object = value as Record<string, unknown>;
+    return `{${Object.keys(object).sort().map((key) => `${JSON.stringify(key)}:${canonical(object[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function normalizeColumnValue(column: string, value: unknown): unknown {
+  if (value instanceof Date) return value.toISOString();
+  if (BOOLEAN_COLUMNS.has(column)) {
+    return value ? 1 : 0;
+  }
+  if (JSON_COLUMNS.has(column) && value !== null && value !== undefined && typeof value !== 'string') {
+    return JSON.stringify(value);
+  }
+  return value ?? null;
+}
+
+function withDefaults(payload: RowPayload, defaults: RowPayload): RowPayload {
+  return { ...defaults, ...payload };
+}
+
+function rowForColumns(
+  payload: RowPayload,
+  allowedColumns: readonly string[],
+  existingColumns: Set<string>,
+): { columns: string[]; values: unknown[] } {
+  const columns = allowedColumns.filter((column) => existingColumns.has(column) && column in payload);
+  return {
+    columns,
+    values: columns.map((column) => normalizeColumnValue(column, payload[column])),
+  };
+}
+
+function upsertPayloadRow(
+  db: SqliteExecutor,
+  table: string,
+  keyColumn: string,
+  allowedColumns: readonly string[],
+  payload: RowPayload,
+): void {
+  const existingColumns = tableColumns(db, table);
+  const { columns, values } = rowForColumns(payload, allowedColumns, existingColumns);
+  if (!columns.includes(keyColumn)) {
+    throw new Error(`Delta payload for ${table} is missing ${keyColumn}`);
+  }
+  const quotedColumns = columns.map(sqlIdentifier);
+  const updateColumns = columns.filter((column) => column !== keyColumn);
+  const updateSql = updateColumns
+    .map((column) => `${sqlIdentifier(column)} = excluded.${sqlIdentifier(column)}`)
+    .join(', ');
+  db.execRun(
+    `INSERT INTO ${sqlIdentifier(table)} (${quotedColumns.join(', ')})
+     VALUES (${columns.map(() => '?').join(', ')})
+     ON CONFLICT(${sqlIdentifier(keyColumn)}) DO ${updateSql ? `UPDATE SET ${updateSql}` : 'NOTHING'}`,
+    values,
+  );
+}
+
+function insertAppendOnlyRow(
+  db: SqliteExecutor,
+  table: string,
+  keyColumn: string,
+  allowedColumns: readonly string[],
+  payload: RowPayload,
+): boolean {
+  const existingColumns = tableColumns(db, table);
+  const { columns, values } = rowForColumns(payload, allowedColumns, existingColumns);
+  if (!columns.includes(keyColumn)) {
+    throw new Error(`Delta payload for ${table} is missing ${keyColumn}`);
+  }
+  const before = db.queryOne(
+    `SELECT ${sqlIdentifier(keyColumn)} FROM ${sqlIdentifier(table)} WHERE ${sqlIdentifier(keyColumn)} = ?`,
+    [payload[keyColumn]],
+  );
+  if (before) return false;
+  db.execRun(
+    `INSERT OR IGNORE INTO ${sqlIdentifier(table)} (${columns.map(sqlIdentifier).join(', ')})
+     VALUES (${columns.map(() => '?').join(', ')})`,
+    values,
+  );
+  return db.getRowsModified() > 0;
+}
+
+function defaultWorkflow(id: string, deletedAt?: number): RowPayload {
+  const createdAt = deletedAt ? new Date(deletedAt).toISOString() : nowIso();
+  return {
+    id,
+    name: id,
+    visual_proof: 0,
+    generation: 0,
+    deleted_at: deletedAt ?? null,
+    created_at: createdAt,
+    updated_at: createdAt,
+  };
+}
+
+function ensureWorkflow(db: SqliteExecutor, workflowId: string, deletedAt?: number): void {
+  const existing = db.queryOne('SELECT id, deleted_at FROM workflows WHERE id = ?', [workflowId]) as
+    | { id?: string; deleted_at?: unknown }
+    | undefined;
+  if (!existing) {
+    upsertPayloadRow(db, 'workflows', 'id', WORKFLOW_COLUMNS, defaultWorkflow(workflowId, deletedAt));
+    return;
+  }
+  if (deletedAt !== undefined && (existing.deleted_at === null || existing.deleted_at === undefined)) {
+    const updatedAt = new Date(deletedAt).toISOString();
+    db.execRun('UPDATE workflows SET deleted_at = ?, updated_at = ? WHERE id = ?', [
+      deletedAt,
+      updatedAt,
+      workflowId,
+    ]);
+  }
+}
+
+function workflowDeletedAt(db: SqliteExecutor, workflowId: string): number | undefined {
+  const row = db.queryOne('SELECT deleted_at FROM workflows WHERE id = ?', [workflowId]) as
+    | { deleted_at?: unknown }
+    | undefined;
+  return integer(row?.deleted_at);
+}
+
+function normalizeTaskStatus(value: unknown): TaskStatus | string {
+  const raw = String(value ?? 'pending');
+  if (raw === 'cancelled' || raw === 'canceled') return 'closed';
+  return raw;
+}
+
+function normalizeWorkflowStatus(value: unknown): WorkflowDerivedStatus | string {
+  const raw = String(value ?? 'pending');
+  if (raw === 'cancelled' || raw === 'canceled') return 'closed';
+  return raw;
+}
+
+function normalizeAttemptStatus(value: unknown): AttemptStatus | string {
+  const raw = String(value ?? 'pending');
+  if (raw === 'cancelled' || raw === 'canceled') return 'failed';
+  return raw;
+}
+
+function statusRank(status: unknown, ranks: Record<string, number>): number {
+  return ranks[String(status)] ?? -1;
+}
+
+function chooseByStatusThenCanonical(
+  local: RowPayload | undefined,
+  incoming: RowPayload,
+  statusColumn: string,
+  ranks: Record<string, number>,
+  normalizeStatus: (value: unknown) => string,
+): RowPayload {
+  if (!local) return incoming;
+  const localStatus = normalizeStatus(local[statusColumn]);
+  const incomingStatus = normalizeStatus(incoming[statusColumn]);
+  const localRank = statusRank(localStatus, ranks);
+  const incomingRank = statusRank(incomingStatus, ranks);
+  if (incomingRank > localRank) return { ...incoming, [statusColumn]: incomingStatus };
+  if (incomingRank < localRank) return { ...local, [statusColumn]: localStatus };
+  return canonical({ ...incoming, [statusColumn]: incomingStatus }) > canonical({ ...local, [statusColumn]: localStatus })
+    ? { ...incoming, [statusColumn]: incomingStatus }
+    : { ...local, [statusColumn]: localStatus };
+}
+
+function hasSamePersistedPayload(
+  db: SqliteExecutor,
+  table: string,
+  keyColumn: string,
+  keyValue: unknown,
+  payload: RowPayload,
+  allowedColumns: readonly string[],
+): boolean {
+  const existing = db.queryOne(
+    `SELECT * FROM ${sqlIdentifier(table)} WHERE ${sqlIdentifier(keyColumn)} = ?`,
+    [keyValue],
+  );
+  if (!existing) return false;
+  const existingColumns = tableColumns(db, table);
+  const comparableColumns = allowedColumns.filter(
+    (column) => existingColumns.has(column) && column in payload,
+  );
+  return comparableColumns.every((column) => {
+    const expected = normalizeColumnValue(column, payload[column]);
+    const actual = normalizeColumnValue(column, existing[column]);
+    return canonical(actual) === canonical(expected);
+  });
+}
+
+function applyWorkflowUpsert(db: SqliteExecutor, entry: SyncJournalEntry, tombstone: boolean): boolean {
+  const payload = asPayload(entry.payload, entry.entityType, entry.entityId);
+  const id = requiredText(payload.id ?? entry.entityId, 'workflow id');
+  const existing = db.queryOne('SELECT * FROM workflows WHERE id = ?', [id]);
+  const incomingDeletedAt = integer(payload.deleted_at);
+  const existingDeletedAt = integer(existing?.deleted_at);
+  if (existingDeletedAt !== undefined && !tombstone && incomingDeletedAt === undefined) {
+    return false;
+  }
+  const deletedAt = tombstone
+    ? incomingDeletedAt !== undefined && existingDeletedAt !== undefined
+      ? Math.max(incomingDeletedAt, existingDeletedAt)
+      : incomingDeletedAt ?? existingDeletedAt ?? Date.now()
+    : existingDeletedAt ?? incomingDeletedAt;
+  const statusWinner = chooseByStatusThenCanonical(
+    existing,
+    withDefaults(payload, defaultWorkflow(id, deletedAt)),
+    'status',
+    WORKFLOW_STATUS_RANK,
+    (value) => normalizeWorkflowStatus(value),
+  );
+  const merged = {
+    ...statusWinner,
+    id,
+    deleted_at: deletedAt ?? null,
+    updated_at: text(statusWinner.updated_at) ?? (deletedAt ? new Date(deletedAt).toISOString() : nowIso()),
+  };
+  if (hasSamePersistedPayload(db, 'workflows', 'id', id, merged, WORKFLOW_COLUMNS)) return false;
+  upsertPayloadRow(db, 'workflows', 'id', WORKFLOW_COLUMNS, merged);
+  return true;
+}
+
+function applyWorkflowTombstone(db: SqliteExecutor, entry: SyncJournalEntry): boolean {
+  return applyWorkflowUpsert(db, entry, true);
+}
+
+function applyTaskUpsert(db: SqliteExecutor, entry: SyncJournalEntry): boolean {
+  const payload = asPayload(entry.payload, entry.entityType, entry.entityId);
+  const id = requiredText(payload.id ?? entry.entityId, 'task id');
+  const workflowId = requiredText(payload.workflow_id, `task ${id} workflow_id`);
+  ensureWorkflow(db, workflowId, workflowDeletedAt(db, workflowId));
+  const existing = db.queryOne('SELECT * FROM tasks WHERE id = ?', [id]);
+  const incoming = withDefaults(payload, {
+    id,
+    workflow_id: workflowId,
+    description: id,
+    status: 'pending',
+    dependencies: '[]',
+    created_at: nowIso(),
+    execution_generation: 0,
+    task_state_version: 1,
+  });
+  const winner = chooseByStatusThenCanonical(
+    existing,
+    { ...incoming, status: normalizeTaskStatus(incoming.status) },
+    'status',
+    TASK_STATUS_RANK,
+    (value) => normalizeTaskStatus(value),
+  );
+  const mergedWorkflowId = text(winner.workflow_id) ?? workflowId;
+  ensureWorkflow(db, mergedWorkflowId, workflowDeletedAt(db, mergedWorkflowId));
+  const merged = {
+    ...winner,
+    id,
+    workflow_id: mergedWorkflowId,
+  };
+  if (hasSamePersistedPayload(db, 'tasks', 'id', id, merged, TASK_COLUMNS)) return false;
+  upsertPayloadRow(db, 'tasks', 'id', TASK_COLUMNS, merged);
+  return true;
+}
+
+function applyAttemptUpsert(db: SqliteExecutor, entry: SyncJournalEntry): boolean {
+  const payload = asPayload(entry.payload, entry.entityType, entry.entityId);
+  const id = requiredText(payload.id ?? entry.entityId, 'attempt id');
+  const nodeId = requiredText(payload.node_id, `attempt ${id} node_id`);
+  const existingTask = db.queryOne('SELECT id FROM tasks WHERE id = ?', [nodeId]);
+  if (!existingTask) {
+    throw new Error(`Cannot apply attempt ${id}: task ${nodeId} is missing`);
+  }
+  const existing = db.queryOne('SELECT * FROM attempts WHERE id = ?', [id]);
+  const incoming = withDefaults(payload, {
+    id,
+    node_id: nodeId,
+    attempt_number: 0,
+    queue_priority: 0,
+    status: 'pending',
+    upstream_attempt_ids: '[]',
+    created_at: nowIso(),
+  });
+  const winner = chooseByStatusThenCanonical(
+    existing,
+    { ...incoming, status: normalizeAttemptStatus(incoming.status) },
+    'status',
+    ATTEMPT_STATUS_RANK,
+    (value) => normalizeAttemptStatus(value),
+  );
+  const mergedNodeId = text(winner.node_id) ?? nodeId;
+  const merged = {
+    ...winner,
+    id,
+    node_id: mergedNodeId,
+  };
+  if (hasSamePersistedPayload(db, 'attempts', 'id', id, merged, ATTEMPT_COLUMNS)) return false;
+  upsertPayloadRow(db, 'attempts', 'id', ATTEMPT_COLUMNS, merged);
+  return true;
+}
+
+function applyEventUpsert(db: SqliteExecutor, entry: SyncJournalEntry): boolean {
+  const payload = asPayload(entry.payload, entry.entityType, entry.entityId);
+  const id = integer(payload.id ?? entry.entityId);
+  if (id === undefined) throw new Error(`event ${entry.entityId} id must be an integer`);
+  const taskId = requiredText(payload.task_id, `event ${id} task_id`);
+  const existingTask = db.queryOne('SELECT id FROM tasks WHERE id = ?', [taskId]);
+  if (!existingTask) {
+    throw new Error(`Cannot apply event ${id}: task ${taskId} is missing`);
+  }
+  const row = withDefaults(payload, {
+    id,
+    task_id: taskId,
+    event_type: 'sync.event',
+    created_at: nowIso(),
+  });
+  return insertAppendOnlyRow(db, 'events', 'id', EVENT_COLUMNS, row);
+}
+
+function applyOutputUpsert(db: SqliteExecutor, entry: SyncJournalEntry): boolean {
+  const payload = asPayload(entry.payload, entry.entityType, entry.entityId);
+  const id = integer(payload.id ?? entry.entityId);
+  const taskId = requiredText(payload.task_id, `output ${entry.entityId} task_id`);
+  const existingTask = db.queryOne('SELECT id FROM tasks WHERE id = ?', [taskId]);
+  if (!existingTask) {
+    throw new Error(`Cannot apply output ${entry.entityId}: task ${taskId} is missing`);
+  }
+
+  if (id !== undefined) {
+    const row = withDefaults(payload, {
+      id,
+      task_id: taskId,
+      offset: 0,
+      data: '',
+      created_at: nowIso(),
+    });
+    return insertAppendOnlyRow(db, 'output_spool', 'id', OUTPUT_COLUMNS, row);
+  }
+
+  const offset = integer(payload.offset);
+  if (offset === undefined) {
+    throw new Error(`output ${entry.entityId} requires an integer id or offset`);
+  }
+  const existing = db.queryOne(
+    'SELECT id FROM output_spool WHERE task_id = ? AND offset = ?',
+    [taskId, offset],
+  );
+  if (existing) return false;
+  const row = withDefaults(payload, {
+    task_id: taskId,
+    offset,
+    data: '',
+    created_at: nowIso(),
+  });
+  const columns = OUTPUT_COLUMNS.filter((column) => column !== 'id');
+  const existingColumns = tableColumns(db, 'output_spool');
+  const selected = rowForColumns(row, columns, existingColumns);
+  db.execRun(
+    `INSERT INTO output_spool (${selected.columns.map(sqlIdentifier).join(', ')})
+     VALUES (${selected.columns.map(() => '?').join(', ')})`,
+    selected.values,
+  );
+  return true;
+}
+
+function applyEntry(db: SqliteExecutor, entry: SyncJournalEntry): boolean {
+  switch (entry.entityType) {
+    case 'workflow':
+      return entry.op === 'tombstone'
+        ? applyWorkflowTombstone(db, entry)
+        : applyWorkflowUpsert(db, entry, false);
+    case 'task':
+      if (entry.op === 'tombstone') return false;
+      return applyTaskUpsert(db, entry);
+    case 'attempt':
+      if (entry.op === 'tombstone') return false;
+      return applyAttemptUpsert(db, entry);
+    case 'event':
+      if (entry.op === 'tombstone') return false;
+      return applyEventUpsert(db, entry);
+    case 'output':
+      if (entry.op === 'tombstone') return false;
+      return applyOutputUpsert(db, entry);
+    default:
+      throw new Error(`Unsupported sync entity type ${(entry as { entityType?: unknown }).entityType}`);
+  }
+}
+
+export function applyDelta(db: SqliteExecutor, batch: DeltaBatch, peerId: string): ApplyDeltaResult {
+  if (!peerId) throw new Error('peerId is required');
+  assertSupportedBatch(batch);
+
+  return db.runTransaction(() => {
+    const cursor = getSyncCursor(db, peerId);
+    const lastReceivedSeq = cursor?.lastReceivedSeq ?? 0;
+    const entries = batch.entries
+      .filter((entry) => entry.seq > lastReceivedSeq)
+      .sort((a, b) => a.seq - b.seq);
+    let appliedEntries = 0;
+    let skippedEntries = batch.entries.length - entries.length;
+
+    for (const entry of entries) {
+      const changed = applyEntry(db, entry);
+      if (!changed) {
+        skippedEntries += 1;
+        continue;
+      }
+      appendJournalEntry(db, {
+        entityType: entry.entityType,
+        entityId: entry.entityId,
+        op: entry.op,
+        payload: entry.payload,
+        origin: peerId,
+        createdAt: entry.createdAt,
+      });
+      appliedEntries += 1;
+    }
+
+    const nextReceivedSeq = Math.max(lastReceivedSeq, batch.highWaterSeq);
+    const saved = setSyncCursor(db, {
+      peerId,
+      lastReceivedSeq: nextReceivedSeq,
+      lastSentSeq: cursor?.lastSentSeq ?? 0,
+      updatedAt: nowIso(),
+    });
+
+    return {
+      appliedEntries,
+      skippedEntries,
+      lastReceivedSeq: saved.lastReceivedSeq,
+    };
+  });
+}


### PR DESCRIPTION
## Summary

Remote Sync Step 2: Delta Exchange and Merge Engine — 2 tasks completed, 0 failed, 0 closed, 0 sk&#105;pped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1784926077048-4/implement-merge-engine | Pure delta serialization and conflict-resolution merge logic | completed |
| wf-1784926077048-4/verify-merge-engine | Run data-store package tests covering delta export and merge | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1784926077048-4/implement-merge-engine — Pure delta serialization and conflict-resolution merge logic

### wf-1784926077048-4/verify-merge-engine — Run data-store package tests covering delta export and merge

</details>

Data-store can now export local journal deltas and apply peer batches without echoing imported entries.

Merge rules converge workflow, task, and attempt rows while preserving tombstones, append-only events, and output spool data.

## Review Claim

Approve the data-store delta batch contract and merge behavior for peer sync.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This stays inside data-store sync serialization, merge helpers, and directly affected tests. No remote transport, scheduler, UI, or headless command calls the merge path yet.

## Slice Rationale

The merge engine lands after the journal schema and before any remote transport or scheduler depends on it.

Keeping delta export, pure merge behavior, and directly affected tests together lets reviewers check one sync contract.

## Non-goals

- No remote transport implementation.
- No sync scheduler or background polling.
- No UI, headless, or Slack surface changes.
- No output spool transport beyond applying journal payloads.

## Architecture

### Before

SQLite data-store recorded local sync journal entries and peer cursors, but it had no delta batch export API.

Peer journal entries had no local apply path, so conflict resolution and cursor advancement were not modeled.

### After

SQLite data-store exports schema-versioned local delta batches from the sync journal high-water mark.

Applying a peer batch runs inside one transaction, records imported entries with the peer origin, and advances the receive cursor atomically.

Merge rules prefer forward progress for workflow, task, and attempt statuses while keeping tombstones durable and append-only rows idempotent.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store test -- sync-merge.test.ts` - passed, 26 test files and 444 tests.
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-bodies/remote-sync-step-2-merge-engine.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-bodies/remote-sync-step-2-merge-engine.md --base stack/EdbertChan/plan/remote-sync-step-1-schema-journal/remote-sync-step-1-sync-schema-change-journal-1--9977415a --json`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 9e81dfd38`
- Post-revert steps: Run `pnpm --filter @invoker/data-store test -- sync-merge.test.ts`.
- Data migration? No.

</details>
