### PR TITLE
[Continue babysit worker landing loop](14) Wait on delegated conflict repairs

### DIFF
--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -40,6 +40,7 @@ ACTIVE_QUEUE_STATES = frozenset({"queued", "merging"})
 
 HUMAN_BLOCKER_KINDS = frozenset({"draft", "human_review_thread", "missing_check", "closed", "human_decision"})
 TERMINAL_BLOCKER_KINDS = frozenset({"merged"})
+IN_FLIGHT_REPAIR_BLOCKER_KINDS = frozenset({"repair_delegated"})
 REPAIR_INVALID_BLOCKER_KINDS = frozenset({"failed_check", "bot_review_thread", "conflict"})
 REPAIR_STOP_PREFIX = "Mergify repair stopped: "
 MANUAL_SPLIT_STOP_MARKERS = (
@@ -340,6 +341,21 @@ def latest_repair_invalid_blocker(pr: PrSnapshot, blocker: Blocker, ledger: Ledg
     return Blocker(blocker.key, "human_decision", pr.number, blocker.detail)
 
 
+def latest_repair_delegated_blocker(pr: PrSnapshot, blocker: Blocker, ledger: Ledger) -> Blocker | None:
+    if blocker.kind not in REPAIR_INVALID_BLOCKER_KINDS:
+        return None
+    latest = None
+    for key in repair_invalid_keys_for_blocker(pr, blocker):
+        row = ledger.latest("repair-delegated", pr.number, pr.head_ref_oid, key)
+        if row is None:
+            continue
+        if latest is None or int(row.get("epoch", 0) or 0) >= int(latest.get("epoch", 0) or 0):
+            latest = row
+    if latest is None:
+        return None
+    return Blocker(blocker.key, "repair_delegated", pr.number, f"{blocker.detail}; repair already delegated for current head")
+
+
 def existing_split_stop_blocker(pr: PrSnapshot, blocker: Blocker) -> Blocker | None:
     if blocker.kind != "failed_check":
         return None
@@ -447,7 +463,10 @@ def build_stack_facts(
     for pr in stack.prs:
         effective = effective_blockers(pr, required, trunk, suppressed_failed_checks_by_pr.get(pr.number, ()))
         blockers = [
-            latest_repair_invalid_blocker(pr, blocker, ledger) or existing_split_stop_blocker(pr, blocker) or blocker
+            latest_repair_invalid_blocker(pr, blocker, ledger)
+            or existing_split_stop_blocker(pr, blocker)
+            or latest_repair_delegated_blocker(pr, blocker, ledger)
+            or blocker
             for blocker in effective
         ]
         existing_keys = {blocker.key for blocker in blockers}
@@ -518,6 +537,8 @@ def summarize_stack(facts: StackFacts) -> dict[str, object]:
 
 
 def wait_reason_for_facts(facts: StackFacts) -> str:
+    if any(blocker.kind in IN_FLIGHT_REPAIR_BLOCKER_KINDS for blocker in facts.all_blockers):
+        return "repair-delegated"
     if facts.upper_stack_needs_acceptance:
         return "upper-stack-needs-acceptance"
     for pr in facts.stack.prs:
@@ -528,6 +549,8 @@ def wait_reason_for_facts(facts: StackFacts) -> str:
             return "merge-hold-only"
         if TERMINAL_BLOCKER_KINDS & blocker_kinds:
             return "terminal-merged"
+        if IN_FLIGHT_REPAIR_BLOCKER_KINDS & blocker_kinds:
+            return "repair-delegated"
         if HUMAN_BLOCKER_KINDS & blocker_kinds:
             return "blocked-needs-human"
     if facts.bottom and facts.bottom.latest_mergify and facts.bottom.latest_mergify.state in {"queued", "merging"}:
@@ -540,6 +563,7 @@ def _has_pending_or_human_blocker(facts: StackFacts) -> bool:
         blocker.kind == "pending_check"
         or blocker.kind in HUMAN_BLOCKER_KINDS
         or blocker.kind in TERMINAL_BLOCKER_KINDS
+        or blocker.kind in IN_FLIGHT_REPAIR_BLOCKER_KINDS
         for blocker in facts.all_blockers
     )
 
@@ -553,6 +577,7 @@ def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
             blocker.kind == "pending_check"
             or blocker.kind in HUMAN_BLOCKER_KINDS
             or blocker.kind in TERMINAL_BLOCKER_KINDS
+            or blocker.kind in IN_FLIGHT_REPAIR_BLOCKER_KINDS
         )
         for blocker in facts.all_blockers
     )
@@ -697,6 +722,8 @@ def plan_actions_from_facts(
     max_requeue_attempts: int,
     max_repair_attempts: int,
 ) -> tuple[Action, ...]:
+    if any(blocker.kind in IN_FLIGHT_REPAIR_BLOCKER_KINDS for blocker in facts.all_blockers):
+        return ()
     action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts)
     if action is not None:
         return (action,)

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -383,6 +383,41 @@ class PlanStackActions(PlannerTestCase):
         self.assertEqual(blockers[0]["kind"], "human_decision")
         self.assertIn("stale duplicate stack", blockers[0]["detail"])
 
+    def test_delegated_conflict_repair_waits_without_capping_or_retrying(self):
+        ledger = self._ledger()
+        for epoch in range(1, 4):
+            ledger.record("conflict-repair", 6435, HEAD, "conflict:6435", epoch)
+        ledger.record("repair-delegated", 6435, HEAD, "conflict:6435", 4)
+        bottom = pr(
+            number=6435,
+            labels=frozenset({"admin-bypass", "dequeued"}),
+            merge_state_status="DIRTY",
+            mergeable="CONFLICTING",
+            checks={"build": check("failure")},
+            latest_mergify=event(state="dequeued", comment_id="m6435"),
+        )
+        upper = pr(
+            number=6439,
+            base_ref_name=bottom.head_ref_name,
+            head_ref_name="stack/top",
+            head_ref_oid="b" * 40,
+            labels=frozenset(),
+            checks={"build": check("pending")},
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (bottom, upper)),
+            REQUIRED,
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={6435, 6439},
+            open_pr_numbers_by_head={bottom.head_ref_name: (6435,), upper.head_ref_name: (6439,)},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "repair-delegated")
+        blockers = plan.summary["prs"][0]["blockers"]
+        self.assertEqual(blockers[0]["kind"], "repair_delegated")
+        self.assertIn("repair already delegated for current head", blockers[0]["detail"])
+
     def test_failed_check_triggers_repair(self):
         actions = self._plan(pr(checks={"build": check("failure")}))
         self.assertEqual((actions[0].kind, actions[0].key), ("repair_check", "build"))


### PR DESCRIPTION
## Summary

Delegated conflict repairs now pause the babysit planner for the current head instead of retrying the same repair.

The wait reason stays explicit, so the worker does not replace in-flight repair evidence with a generic retry cap.

## Review Claim

The admin-bypass planner treats same-head repair-delegated evidence as an in-flight wait state.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only changes local admin-requeue planner policy and planner unit tests; it does not write to GitHub or mutate real PR branches.

## Slice Rationale

The delegated repair wait is separate from the repro registration so reviewers can inspect the planner contract before the loop proof.

## Non-goals

- No manual real-PR cleanup.
- No queue-rule changes outside the admin-requeue planner.
- No new repro registration in this slice.
- No UI, data migration, or workflow schema changes.

## Architecture

### Before

```mermaid
graph TD
    A["Planner sees same-head repair-delegated evidence"] --> B["Failed conflict blocker remains retryable"]
    B --> C["Worker may repair again or emit generic cap"]
```

### After

```mermaid
graph TD
    A["Planner sees same-head repair-delegated evidence"] --> B["Blocker becomes repair_delegated"]
    B --> C["Worker waits with reason repair-delegated"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/test_mergify_admin_requeue_plan.py`
- [x] `PYTHONDONTWRITEBYTECODE=1 bash ./loop-driver.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f7c624e`
- Post-revert steps: None
- Data migration? No

</details>
