### PR TITLE
[Continue babysit worker landing loop](16) Surface unaccepted upper stack blockers

### DIFF
--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -21,6 +21,7 @@ REPROS=(
   scripts/repro/repro-babysit-targeted-scan-light.sh
   scripts/repro/repro-babysit-queue-repair-invalid-stop.sh
   scripts/repro/repro-babysit-conflict-repair-invalid-stop.sh
+  scripts/repro/repro-babysit-conflict-repair-delegated-wait.sh
   scripts/repro/repro-babysit-stack-human-blocker-suppresses-repairs.sh
   scripts/repro/repro-babysit-no-current-bottom-comment.sh
   scripts/repro/repro-babysit-merged-pr-terminal.sh

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -229,11 +229,18 @@ def classify_bottom_topology(
 
 
 
-def stack_has_unaccepted_upper_pr(stack: StackGroup, bottom: PrSnapshot | None) -> bool:
-    return bool(bottom) and any(
-        pr.state == "OPEN" and pr.number != bottom.number and "admin-bypass" not in pr.labels
+def unaccepted_upper_prs(stack: StackGroup, bottom: PrSnapshot | None) -> tuple[PrSnapshot, ...]:
+    if not bottom:
+        return ()
+    return tuple(
+        pr
         for pr in stack.prs
+        if pr.state == "OPEN" and pr.number != bottom.number and "admin-bypass" not in pr.labels
     )
+
+
+def stack_has_unaccepted_upper_pr(stack: StackGroup, bottom: PrSnapshot | None) -> bool:
+    return bool(unaccepted_upper_prs(stack, bottom))
 
 
 def latest_repair_prereq_status(
@@ -645,6 +652,24 @@ def plan_hard_blockers(facts: StackFacts, ledger: Ledger) -> Action | None:
     return None
 
 
+def plan_upper_stack_acceptance_blocker(facts: StackFacts, ledger: Ledger) -> Action | None:
+    if not facts.upper_stack_needs_acceptance or not facts.bottom or facts.all_blockers:
+        return None
+    upper_prs = unaccepted_upper_prs(facts.stack, facts.bottom)
+    if not upper_prs:
+        return None
+    key = "upper-stack-needs-acceptance"
+    if ledger.count("comment-blocked", facts.bottom.number, facts.bottom.head_ref_oid, key) > 0:
+        return None
+    upper_list = ", ".join(f"#{pr.number}" for pr in upper_prs)
+    return Action(
+        "comment_blocked",
+        facts.bottom.number,
+        key,
+        f"PR #{facts.bottom.number} is ready to land, but upper stack PR(s) {upper_list} are open without `admin-bypass`; a human must decide whether to include them in the admin-bypass landing stack or land them separately.",
+    )
+
+
 def plan_merge_hold_cleanup(facts: StackFacts, ledger: Ledger) -> Action | None:
     if _has_pending_or_human_blocker(facts) or not facts.bottom:
         return None
@@ -734,6 +759,9 @@ def plan_actions_from_facts(
     if action is not None:
         return (action,)
     action = plan_hard_blockers(facts, ledger)
+    if action is not None:
+        return (action,)
+    action = plan_upper_stack_acceptance_blocker(facts, ledger)
     if action is not None:
         return (action,)
     action = plan_merge_hold_cleanup(facts, ledger)

--- a/scripts/repro/repro-admin-bypass-non-landing-root-cause.py
+++ b/scripts/repro/repro-admin-bypass-non-landing-root-cause.py
@@ -12,7 +12,7 @@ from typing import Mapping
 DB_PATH = Path.home() / ".invoker" / "invoker.db"
 LEDGER_PATH = Path.home() / ".invoker" / "mergify-admin-requeue-state.jsonl"
 REPO = "Neko-Catpital-Labs/Invoker"
-TARGET_PRS = (6118, 6158)
+TARGET_PRS = (6118, 6158, 6435)
 WORKER_SOURCE = "pr-maintenance-worker"
 REPAIR_STOP_PREFIX = "Mergify repair stopped: "
 
@@ -88,6 +88,18 @@ def latest_row(rows: list[dict], kind: str, head: str, key: str | None = None) -
     return max(matches, key=lambda row: int(row.get("epoch", 0) or 0))
 
 
+def latest_row_any_head(rows: list[dict], kind: str, key: str | None = None) -> dict | None:
+    matches = [
+        row
+        for row in rows
+        if row.get("kind") == kind
+        and (key is None or row.get("key") == key)
+    ]
+    if not matches:
+        return None
+    return max(matches, key=lambda row: int(row.get("epoch", 0) or 0))
+
+
 def row_errors(row: Mapping[str, object]) -> list[str]:
     meta = row.get("meta") if isinstance(row.get("meta"), Mapping) else {}
     errors = meta.get("errors") if isinstance(meta, Mapping) else []
@@ -123,10 +135,21 @@ def require_stop_comment(snapshot: Mapping[str, object], fragment: str, label: s
 def summarize_6118(conn: sqlite3.Connection) -> tuple[dict, list[str]]:
     snapshot = gh_pr_snapshot(6118)
     head = str(snapshot["headRefOid"])
-    assert snapshot["state"] == "OPEN", "6118 is no longer open"
-    assert snapshot["mergeStateStatus"] == "DIRTY", "6118 is no longer dirty"
-
     rows = load_ledger_rows(6118)
+    if snapshot["state"] != "OPEN":
+        attempts = sum(1 for row in rows if row.get("kind") == "conflict-repair")
+        return {
+            "pr": 6118,
+            "state": snapshot["state"],
+            "merge_state": snapshot["mergeStateStatus"],
+            "labels": [label["name"] for label in snapshot["labels"]],
+            "head": head,
+            "attempts": attempts,
+            "resolved_at": "live state",
+            "root_cause": "no longer a stuck open target during this pass.",
+        }, check_names(snapshot)
+    assert snapshot["mergeStateStatus"] in {"DIRTY", "BLOCKED"}, "6118 is no longer blocked or dirty"
+
     invalid = latest_row(rows, "repair-invalid", head, "conflict")
     assert invalid is not None, "6118 missing conflict repair-invalid evidence"
     errors = row_errors(invalid)
@@ -187,15 +210,55 @@ def summarize_6158(conn: sqlite3.Connection) -> tuple[dict, list[str]]:
     }, check_names(snapshot)
 
 
+def summarize_6435(conn: sqlite3.Connection) -> tuple[dict, list[str]]:
+    snapshot = gh_pr_snapshot(6435)
+    current_head = str(snapshot["headRefOid"])
+
+    rows = load_ledger_rows(6435)
+    delegated = latest_row_any_head(rows, "repair-delegated", "conflict:6435")
+    assert delegated is not None, "6435 missing same-head repair-delegated evidence"
+    delegated_head = str(delegated.get("headSha") or "")
+    attempts = sum(1 for row in rows if row.get("kind") == "conflict-repair" and row.get("headSha") == delegated_head and row.get("key") == "conflict:6435")
+    assert attempts >= 3, "6435 missing repeated conflict-repair proof"
+    generic_cap = latest_row(rows, "comment-blocked", delegated_head)
+    assert generic_cap is not None, "6435 missing generic cap proof after delegated repair"
+
+    logs = fetch_worker_logs(conn, 6435)
+    delegated_log = require_line(logs, "admin-bypass-repair-delegated", "6435 delegated repair")
+    queue_log = require_line(logs, "PR #6435: repair already submitted for this head-state", "6435 queued repair wait")
+    cap_log = require_line(logs, "The retry cap was reached for current head " + delegated_head, "6435 bad generic cap")
+
+    return {
+        "pr": 6435,
+        "state": snapshot["state"],
+        "merge_state": snapshot["mergeStateStatus"],
+        "labels": [label["name"] for label in snapshot["labels"]],
+        "head": current_head if current_head == delegated_head else f"{delegated_head} -> {current_head}",
+        "attempts": attempts,
+        "delegated_at": delegated_log.timestamp,
+        "generic_cap_at": cap_log.timestamp,
+        "queue_wait_at": queue_log.timestamp,
+        "root_cause": "same-head conflict repair was delegated, but the landing planner ignored the repair-delegated marker and emitted a generic retry-cap blocker instead of waiting; the repair workflow later changed the head.",
+    }, check_names(snapshot)
+
+
 def print_summary(row: Mapping[str, object], names: list[str]) -> None:
     labels = ",".join(row["labels"]) if isinstance(row.get("labels"), list) else ""
     print(
         f"| {row['pr']} | {labels} | {row['state']} / {row['merge_state']} | {row['head']} | "
-        f"{row['attempts']} conflict attempts | exact stop at {row['exact_stop_at']} | "
-        f"generic cap at {row['generic_cap_at']} | {row['root_cause']} |"
+        f"{row['attempts']} conflict attempts | {row.get('exact_stop_at', row.get('delegated_at', ''))} | "
+        f"{row.get('generic_cap_at', row.get('queue_wait_at', ''))} | {row['root_cause']} |"
     )
-    print(f"  exact: {row['exact_comment']}")
-    print(f"  generic: {row['generic_comment']}")
+    if "exact_comment" in row:
+        print(f"  exact: {row['exact_comment']}")
+    if "generic_comment" in row:
+        print(f"  generic: {row['generic_comment']}")
+    if "delegated_at" in row:
+        print(f"  delegated: {row['delegated_at']}")
+    if "queue_wait_at" in row:
+        print(f"  queue wait: {row['queue_wait_at']}")
+    if "resolved_at" in row:
+        print(f"  resolved: {row['resolved_at']}")
     print("  checks:")
     for name in names:
         print(f"    - {name}")
@@ -206,6 +269,7 @@ def main() -> int:
     try:
         summary_6118, names_6118 = summarize_6118(conn)
         summary_6158, names_6158 = summarize_6158(conn)
+        summary_6435, names_6435 = summarize_6435(conn)
     finally:
         conn.close()
 
@@ -217,8 +281,9 @@ def main() -> int:
     print("|---|---|---|---|---|---|---|---|")
     print_summary(summary_6118, names_6118)
     print_summary(summary_6158, names_6158)
+    print_summary(summary_6435, names_6435)
     print()
-    print("Shared signature: exact human-only repair-invalid evidence exists, but subsequent planner passes treated the PR as repairable and emitted generic retry-cap blockers.")
+    print("Shared signature: durable stop/wait evidence exists, but subsequent planner passes treated the PR as repairable and could emit generic retry-cap blockers.")
     return 0
 
 

--- a/scripts/repro/repro-babysit-conflict-repair-delegated-wait.sh
+++ b/scripts/repro/repro-babysit-conflict-repair-delegated-wait.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-conflict-repair-delegated-wait.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+mkdir -p "$HOME" "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+HEAD="c1ae3d7b5826c62bdf00af9a5443aa8676f9152a"
+UPPER_HEAD="48a8cf4a2d1ba2f7c1c0f233408980ecce46e5ca"
+BOTTOM_BRANCH="experiment/wf-1785055720707-2/fix-planning-session-persistence-hot-path/g13.t22.a-aafe2ee02-c9d0cbac"
+UPPER_BRANCH="experiment/wf-1785055720707-2/gate-planning-send-responsiveness/g13.t22.a-a5074fabe-858826b7"
+export STATE_PATH LEDGER_PATH HEAD UPPER_HEAD BOTTOM_BRANCH UPPER_BRANCH
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+head = os.environ["HEAD"]
+upper_head = os.environ["UPPER_HEAD"]
+bottom_branch = os.environ["BOTTOM_BRANCH"]
+upper_branch = os.environ["UPPER_BRANCH"]
+state = {
+    "prs": [
+        {
+            "number": 6435,
+            "title": "[Planning Chat Beachball](2) Remove full planning transcript rewrites from send",
+            "body": "## Summary\n\nRemove full planning transcript rewrites from send.\n",
+            "url": "https://github.com/fake/repo/pull/6435",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": bottom_branch,
+            "headRefOid": head,
+            "mergeStateStatus": "DIRTY",
+            "mergeable": "CONFLICTING",
+            "labels": ["admin-bypass", "dequeued"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS", "PR Body": "FAILURE"},
+        },
+        {
+            "number": 6439,
+            "title": "[Planning Chat Beachball](3) Gate planning send responsiveness",
+            "body": "## Summary\n\nGate planning send responsiveness.\n",
+            "url": "https://github.com/fake/repo/pull/6439",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": bottom_branch,
+            "headRefName": upper_branch,
+            "headRefOid": upper_head,
+            "mergeStateStatus": "UNSTABLE",
+            "mergeable": "MERGEABLE",
+            "labels": [],
+            "reviewThreads": [],
+            "checks": {"UI Vitest": "PENDING"},
+        },
+    ],
+    "issue_comments": {
+        "6435": [
+            {
+                "id": "mergify-dequeue",
+                "user": {"login": "mergify"},
+                "updated_at": "2026-07-28T17:46:11Z",
+                "html_url": "https://github.com/fake/repo/pull/6435#issuecomment-1",
+                "body": (
+                    "<!---\nDO NOT EDIT\n-*- Mergify Payload -*-\n"
+                    "{\"version\":1,\"state\":\"dequeued\",\"queue_rule_name\":\"admin-bypass\","
+                    "\"queued_at\":\"2026-07-28T17:45:51.602557+00:00\"}\n"
+                    "-*- Mergify Payload End -*-\n-->\n\n"
+                    "Left the queue at `" + head + "`.\n\n"
+                    "Reason: The pull request conflicts with the base branch\n"
+                ),
+            }
+        ],
+        "6439": [],
+    },
+    "job_logs": {},
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+rows = [
+    {"epoch": 1785260977, "headSha": head, "key": "conflict:6435", "kind": "conflict-repair", "pr": 6435},
+    {"epoch": 1785261284, "headSha": head, "key": "conflict:6435", "kind": "conflict-repair", "pr": 6435},
+    {"epoch": 1785267037, "headSha": head, "key": "conflict:6435", "kind": "conflict-repair", "pr": 6435},
+    {"epoch": 1785267037, "headSha": head, "key": "conflict:6435", "kind": "repair-delegated", "pr": 6435},
+]
+Path(os.environ["LEDGER_PATH"]).write_text(
+    "".join(json.dumps(row, sort_keys=True) + "\n" for row in rows),
+    encoding="utf-8",
+)
+PY
+
+if ! out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6435 2>&1)"; then
+  fail 'targeted worker dry-run failed' "$out"
+fi
+
+! echo "$out" | grep -q 'repair-conflict PR #6435' || fail 'delegated conflict repair retried repair' "$out"
+! echo "$out" | grep -q 'repair-check PR #6435' || fail 'delegated conflict repair fell through to failed-check repair' "$out"
+! echo "$out" | grep -q 'BLOCK PR #6435' || fail 'delegated conflict repair emitted a blocker comment' "$out"
+! echo "$out" | grep -q 'retry cap was reached' || fail 'delegated conflict repair emitted generic cap' "$out"
+echo "$out" | grep -q '"reason": "repair-delegated"' || fail 'delegated conflict repair did not wait' "$out"
+echo "$out" | grep -q 'repair already delegated for current head' || fail 'delegated repair evidence was not preserved in summary' "$out"
+
+echo '[repro] passed'

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -239,7 +239,7 @@ Failing checks
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 2605, "PR Body")])
 
-    def test_unaccepted_upper_without_blockers_waits_instead_of_requeueing_bottom(self):
+    def test_unaccepted_upper_without_blockers_posts_exact_blocker_instead_of_requeueing_bottom(self):
         stack = StackGroup(
             "s",
             (
@@ -248,7 +248,9 @@ Failing checks
             ),
         )
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
-        self.assertEqual(actions, ())
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("comment_blocked", 2604, "upper-stack-needs-acceptance")])
+        self.assertIn("#2605", actions[0].detail)
+        self.assertIn("without `admin-bypass`", actions[0].detail)
 
     def test_missing_admin_bypass_label_on_current_bottom_nudges_human_first(self):
         stack = StackGroup("s", (pr(2604, labels={"dequeued"}, latest=mergify()),))
@@ -548,19 +550,25 @@ Failing checks
         self.assertIn('"failed_check"', log)
         self.assertIn('"pr_number": 2606', log)
 
-    def test_run_cycle_logs_wait_reason_for_unaccepted_upper_stack(self):
+    def test_run_cycle_blocks_once_for_unaccepted_upper_stack(self):
         args = requeue.parse_args(["--once", "--dry-run", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
         stack = StackGroup("s", (pr(2604, head="stack/a", latest=mergify()), pr(2605, base="stack/a", labels={"dequeued"})))
         stderr = io.StringIO()
+        stdout = io.StringIO()
         with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
             with mock.patch.object(exec_impl, "GhClient", return_value=object()):
                 with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
-                    with redirect_stderr(stderr):
+                    with redirect_stdout(stdout), redirect_stderr(stderr):
                         should_poll = exec_impl.run_cycle(args)
-        self.assertTrue(should_poll)
+        self.assertFalse(should_poll)
+        self.assertIn(
+            "BLOCK PR #2604 PR #2604 is ready to land, but upper stack PR(s) #2605 are open without `admin-bypass`",
+            stdout.getvalue(),
+        )
         log = stderr.getvalue()
-        self.assertIn('"event": "admin-bypass-stack-wait"', log)
-        self.assertIn('"reason": "upper-stack-needs-acceptance"', log)
+        self.assertIn('"event": "admin-bypass-stack-actions"', log)
+        self.assertIn('"kind": "comment_blocked"', log)
+        self.assertIn('"key": "upper-stack-needs-acceptance"', log)
         self.assertIn('"upper_stack_needs_acceptance": true', log)
 
     def test_repair_check_splits_tooling_policy_prerequisite(self):

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -418,6 +418,44 @@ class PlanStackActions(PlannerTestCase):
         self.assertEqual(blockers[0]["kind"], "repair_delegated")
         self.assertIn("repair already delegated for current head", blockers[0]["detail"])
 
+    def test_clean_unaccepted_upper_stack_posts_exact_human_blocker_once(self):
+        ledger = self._ledger()
+        bottom = pr(
+            number=6435,
+            labels=frozenset({"admin-bypass"}),
+            latest_mergify=event(state="dequeued", head="c" * 40, comment_id="old"),
+        )
+        upper = pr(
+            number=6439,
+            base_ref_name=bottom.head_ref_name,
+            head_ref_name="stack/top",
+            head_ref_oid="b" * 40,
+            labels=frozenset(),
+        )
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (bottom, upper)),
+            REQUIRED,
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={6435, 6439},
+            open_pr_numbers_by_head={bottom.head_ref_name: (6435,), upper.head_ref_name: (6439,)},
+        )
+        self.assertEqual([(action.kind, action.key, action.pr_number) for action in plan.actions], [("comment_blocked", "upper-stack-needs-acceptance", 6435)])
+        self.assertIn("#6439", plan.actions[0].detail)
+        self.assertIn("without `admin-bypass`", plan.actions[0].detail)
+
+        ledger.record("comment-blocked", 6435, HEAD, "upper-stack-needs-acceptance", 1)
+        repeated = p.plan_stack_execution(
+            m.StackGroup("s", (bottom, upper)),
+            REQUIRED,
+            ledger,
+            now_epoch=0,
+            open_pr_numbers={6435, 6439},
+            open_pr_numbers_by_head={bottom.head_ref_name: (6435,), upper.head_ref_name: (6439,)},
+        )
+        self.assertEqual(repeated.actions, ())
+        self.assertEqual(repeated.wait_reason, "upper-stack-needs-acceptance")
+
     def test_failed_check_triggers_repair(self):
         actions = self._plan(pr(checks={"build": check("failure")}))
         self.assertEqual((actions[0].kind, actions[0].key), ("repair_check", "build"))


### PR DESCRIPTION
## Summary

Ready bottom PRs now post one exact human blocker when upper stack PRs remain open without `admin-bypass`.

After that comment is recorded, repeat worker passes wait instead of requeueing the bottom PR again.

## Review Claim

The admin-bypass planner surfaces unaccepted upper stack PRs as a one-time human blocker before bottom requeue.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only changes local admin-requeue planner policy and directly affected tests; it does not manually relabel, requeue, or retarget real PRs.

## Slice Rationale

The upper-stack blocker is separate from delegated repair waits because it governs a clean-stack human decision path.

## Non-goals

- No manual real-PR cleanup.
- No queue-rule changes outside the admin-requeue planner.
- No repro registration in this slice.
- No UI, data migration, or workflow schema changes.

## Architecture

### Before

```mermaid
graph TD
    A["Bottom PR is ready"]
    A --> B["Upper PR lacks admin-bypass"]
    B --> C["Planner waits or requeues without an exact human stop"]
```

### After

```mermaid
graph TD
    A["Bottom PR is ready"]
    A --> B["Upper PR lacks admin-bypass"]
    B --> C["Planner posts upper-stack-needs-acceptance once"]
    C --> D["Later passes wait on the recorded blocker"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts/test_mergify_admin_requeue.py scripts/test_mergify_admin_requeue_plan.py`
- [x] `PYTHONDONTWRITEBYTECODE=1 bash ./loop-driver.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 22eac84`
- Post-revert steps: None
- Data migration? No

</details>
