### PR TITLE
[Continue babysit worker landing loop](17) Reproduce unaccepted upper stack blocker comments

### DIFF
--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -22,6 +22,7 @@ REPROS=(
   scripts/repro/repro-babysit-queue-repair-invalid-stop.sh
   scripts/repro/repro-babysit-conflict-repair-invalid-stop.sh
   scripts/repro/repro-babysit-conflict-repair-delegated-wait.sh
+  scripts/repro/repro-babysit-upper-stack-needs-acceptance-comment.sh
   scripts/repro/repro-babysit-stack-human-blocker-suppresses-repairs.sh
   scripts/repro/repro-babysit-no-current-bottom-comment.sh
   scripts/repro/repro-babysit-merged-pr-terminal.sh

--- a/scripts/repro/repro-babysit-upper-stack-needs-acceptance-comment.sh
+++ b/scripts/repro/repro-babysit-upper-stack-needs-acceptance-comment.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-upper-stack-needs-acceptance-comment.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+mkdir -p "$HOME" "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+BOTTOM_HEAD="64f62b48b0d4cda7d96e41a15bde509db4940b2a"
+UPPER_HEAD="09014c13dd772ceb22fd4f5e7771ea7ac8c83c78"
+OLD_QUEUE_HEAD="c1ae3d7b5826c62bdf00af9a5443aa8676f9152a"
+BOTTOM_BRANCH="experiment/wf-1785055720707-2/fix-planning-session-persistence-hot-path/g13.t22.a-aafe2ee02-c9d0cbac"
+UPPER_BRANCH="experiment/wf-1785055720707-2/gate-planning-send-responsiveness/g13.t22.a-a5074fabe-858826b7"
+export STATE_PATH LEDGER_PATH BOTTOM_HEAD UPPER_HEAD OLD_QUEUE_HEAD BOTTOM_BRANCH UPPER_BRANCH
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+bottom_head = os.environ["BOTTOM_HEAD"]
+upper_head = os.environ["UPPER_HEAD"]
+old_queue_head = os.environ["OLD_QUEUE_HEAD"]
+bottom_branch = os.environ["BOTTOM_BRANCH"]
+upper_branch = os.environ["UPPER_BRANCH"]
+state = {
+    "prs": [
+        {
+            "number": 6435,
+            "title": "[Planning Chat Beachball](2) Remove full planning transcript rewrites from send",
+            "body": "## Summary\n\nRemove full planning transcript rewrites from send.\n",
+            "url": "https://github.com/fake/repo/pull/6435",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": bottom_branch,
+            "headRefOid": bottom_head,
+            "mergeStateStatus": "BLOCKED",
+            "mergeable": "MERGEABLE",
+            "labels": ["admin-bypass"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS"},
+        },
+        {
+            "number": 6439,
+            "title": "[Planning Chat Beachball](3) Gate planning send responsiveness",
+            "body": "## Summary\n\nGate planning send responsiveness.\n",
+            "url": "https://github.com/fake/repo/pull/6439",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": bottom_branch,
+            "headRefName": upper_branch,
+            "headRefOid": upper_head,
+            "mergeStateStatus": "CLEAN",
+            "mergeable": "MERGEABLE",
+            "labels": [],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS"},
+        },
+    ],
+    "issue_comments": {
+        "6435": [
+            {
+                "id": "old-dequeue",
+                "user": {"login": "mergify"},
+                "updated_at": "2026-07-28T17:46:11Z",
+                "html_url": "https://github.com/fake/repo/pull/6435#issuecomment-1",
+                "body": (
+                    "-*- Mergify Payload -*-\n"
+                    "{\"version\":1,\"state\":\"dequeued\",\"queue_rule_name\":\"admin-bypass\"}\n\n"
+                    f"Left the queue at `{old_queue_head}`.\n"
+                ),
+            }
+        ],
+        "6439": [],
+    },
+    "job_logs": {},
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+Path(os.environ["LEDGER_PATH"]).write_text("", encoding="utf-8")
+PY
+
+if ! dry_out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6435 2>&1)"; then
+  fail 'worker dry-run failed' "$dry_out"
+fi
+
+echo "$dry_out" | grep -q 'BLOCK PR #6435' || fail 'worker did not surface upper-stack blocker' "$dry_out"
+echo "$dry_out" | grep -q '#6439 are open without `admin-bypass`' || fail 'exact upper-stack blocker reason missing' "$dry_out"
+! echo "$dry_out" | grep -q 'DRY-RUN requeue PR #6435' || fail 'worker requeued despite unaccepted upper PR' "$dry_out"
+
+if ! real_out="$(python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6435 2>&1)"; then
+  fail 'worker comment run failed' "$real_out"
+fi
+
+comment_count="$(python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+state = json.loads(Path(os.environ["STATE_PATH"]).read_text(encoding="utf-8"))
+needle = "Mergify repair stopped: PR #6435 is ready to land, but upper stack PR(s) #6439 are open without `admin-bypass`; a human must decide whether to include them in the admin-bypass landing stack or land them separately."
+print(sum(1 for comment in state["issue_comments"]["6435"] if comment.get("body") == needle))
+PY
+)"
+[ "$comment_count" = "1" ] || fail "expected one exact blocker comment, got $comment_count" "$(cat "$STATE_PATH")"
+
+if ! repeat_out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6435 2>&1)"; then
+  fail 'repeat dry-run failed' "$repeat_out"
+fi
+
+! echo "$repeat_out" | grep -q 'BLOCK PR #6435' || fail 'worker repeated upper-stack blocker after ledger record' "$repeat_out"
+! echo "$repeat_out" | grep -q 'DRY-RUN requeue PR #6435' || fail 'worker requeued after upper-stack blocker' "$repeat_out"
+echo "$repeat_out" | grep -q '"reason": "upper-stack-needs-acceptance"' || fail 'worker did not settle into upper-stack wait' "$repeat_out"
+
+echo '[repro] passed'

--- a/scripts/repro/repro-babysit-upper-stack-needs-acceptance-comment.sh
+++ b/scripts/repro/repro-babysit-upper-stack-needs-acceptance-comment.sh
@@ -16,6 +16,12 @@ fail() {
   exit 1
 }
 
+contains_output() {
+  local needle="$1"
+  local haystack="$2"
+  grep -Fq -- "$needle" <<<"$haystack"
+}
+
 export HOME="$TMP/home"
 mkdir -p "$HOME" "$TMP/state"
 export FAKE_GH_STATE_DIR="$TMP/state"
@@ -39,7 +45,8 @@ UPPER_HEAD="09014c13dd772ceb22fd4f5e7771ea7ac8c83c78"
 OLD_QUEUE_HEAD="c1ae3d7b5826c62bdf00af9a5443aa8676f9152a"
 BOTTOM_BRANCH="experiment/wf-1785055720707-2/fix-planning-session-persistence-hot-path/g13.t22.a-aafe2ee02-c9d0cbac"
 UPPER_BRANCH="experiment/wf-1785055720707-2/gate-planning-send-responsiveness/g13.t22.a-a5074fabe-858826b7"
-export STATE_PATH LEDGER_PATH BOTTOM_HEAD UPPER_HEAD OLD_QUEUE_HEAD BOTTOM_BRANCH UPPER_BRANCH
+BLOCKER_COMMENT="Mergify repair stopped: PR #6435 is ready to land, but upper stack PR(s) #6439 are open without \`admin-bypass\`; a human must decide whether to include them in the admin-bypass landing stack or land them separately."
+export STATE_PATH LEDGER_PATH BOTTOM_HEAD UPPER_HEAD OLD_QUEUE_HEAD BOTTOM_BRANCH UPPER_BRANCH BLOCKER_COMMENT
 
 python3 - <<'PY'
 import json
@@ -108,35 +115,55 @@ Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding=
 Path(os.environ["LEDGER_PATH"]).write_text("", encoding="utf-8")
 PY
 
+blocker_comment_count() {
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+state = json.loads(Path(os.environ["STATE_PATH"]).read_text(encoding="utf-8"))
+needle = os.environ["BLOCKER_COMMENT"]
+print(sum(1 for comment in state["issue_comments"]["6435"] if comment.get("body") == needle))
+PY
+}
+
 if ! dry_out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6435 2>&1)"; then
   fail 'worker dry-run failed' "$dry_out"
 fi
 
-echo "$dry_out" | grep -q 'BLOCK PR #6435' || fail 'worker did not surface upper-stack blocker' "$dry_out"
-echo "$dry_out" | grep -q '#6439 are open without `admin-bypass`' || fail 'exact upper-stack blocker reason missing' "$dry_out"
-! echo "$dry_out" | grep -q 'DRY-RUN requeue PR #6435' || fail 'worker requeued despite unaccepted upper PR' "$dry_out"
+contains_output 'BLOCK PR #6435' "$dry_out" || fail 'worker did not surface upper-stack blocker' "$dry_out"
+contains_output '#6439 are open without `admin-bypass`' "$dry_out" || fail 'exact upper-stack blocker reason missing' "$dry_out"
+if contains_output 'DRY-RUN requeue PR #6435' "$dry_out"; then
+  fail 'worker requeued despite unaccepted upper PR' "$dry_out"
+fi
 
 if ! real_out="$(python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6435 2>&1)"; then
   fail 'worker comment run failed' "$real_out"
 fi
 
-comment_count="$(python3 - <<'PY'
-import json
-import os
-from pathlib import Path
-state = json.loads(Path(os.environ["STATE_PATH"]).read_text(encoding="utf-8"))
-needle = "Mergify repair stopped: PR #6435 is ready to land, but upper stack PR(s) #6439 are open without `admin-bypass`; a human must decide whether to include them in the admin-bypass landing stack or land them separately."
-print(sum(1 for comment in state["issue_comments"]["6435"] if comment.get("body") == needle))
-PY
-)"
+comment_count="$(blocker_comment_count)"
 [ "$comment_count" = "1" ] || fail "expected one exact blocker comment, got $comment_count" "$(cat "$STATE_PATH")"
+state_after_first="$(cat "$STATE_PATH")"
+ledger_after_first="$(cat "$LEDGER_PATH")"
+
+if ! repeat_real_out="$(python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6435 2>&1)"; then
+  fail 'repeat comment run failed' "$repeat_real_out"
+fi
+
+repeat_comment_count="$(blocker_comment_count)"
+[ "$repeat_comment_count" = "1" ] || fail "expected repeat real run to keep one exact blocker comment, got $repeat_comment_count" "$(cat "$STATE_PATH")"
+[ "$(cat "$STATE_PATH")" = "$state_after_first" ] || fail 'repeat real run changed fake GitHub state' "$(cat "$STATE_PATH")"
+[ "$(cat "$LEDGER_PATH")" = "$ledger_after_first" ] || fail 'repeat real run changed ledger state' "$(cat "$LEDGER_PATH")"
 
 if ! repeat_out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6435 2>&1)"; then
   fail 'repeat dry-run failed' "$repeat_out"
 fi
 
-! echo "$repeat_out" | grep -q 'BLOCK PR #6435' || fail 'worker repeated upper-stack blocker after ledger record' "$repeat_out"
-! echo "$repeat_out" | grep -q 'DRY-RUN requeue PR #6435' || fail 'worker requeued after upper-stack blocker' "$repeat_out"
-echo "$repeat_out" | grep -q '"reason": "upper-stack-needs-acceptance"' || fail 'worker did not settle into upper-stack wait' "$repeat_out"
+if contains_output 'BLOCK PR #6435' "$repeat_out"; then
+  fail 'worker repeated upper-stack blocker after ledger record' "$repeat_out"
+fi
+if contains_output 'DRY-RUN requeue PR #6435' "$repeat_out"; then
+  fail 'worker requeued after upper-stack blocker' "$repeat_out"
+fi
+contains_output '"reason": "upper-stack-needs-acceptance"' "$repeat_out" || fail 'worker did not settle into upper-stack wait' "$repeat_out"
 
 echo '[repro] passed'


### PR DESCRIPTION
## Summary

The loop now covers the clean upper-stack acceptance case with a fake-gh stack.

The repro proves the worker comments once, preserves the exact reason, and then settles into a wait.

## Review Claim

The repro surface proves unaccepted upper stack PRs produce one exact human blocker and no repeated requeue.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds and registers a local fake-gh repro; it does not write to GitHub or mutate real PR branches.

## Slice Rationale

This proof follows the upper-stack planner policy slice because it asserts the corrected comment-and-wait behavior.

## Non-goals

- No planner policy changes in this slice.
- No manual real-PR cleanup.
- No queue-rule changes.
- No UI, data migration, or workflow schema changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `PYTHONDONTWRITEBYTECODE=1 bash scripts/repro/repro-babysit-upper-stack-needs-acceptance-comment.sh`
- [x] `PYTHONDONTWRITEBYTECODE=1 bash ./loop-driver.sh`
- [x] `gh pr view 6550 --repo Neko-Catpital-Labs/Invoker --json body --jq .body > /tmp/pr-6550-body.md && node scripts/validate-pr-body-local.mjs --body-file /tmp/pr-6550-body.md --base stack/EdbertChan/plan/continue-babysit-worker-landing-loop/continue-babysit-worker-landing-loop-16-surface--6b062fe0`
- [x] `pnpm run check:deps`
- [x] `pnpm run check:types`
- [x] `pnpm run check:required-builds`
- [x] `pnpm run check:large-files`
- [x] `pnpm run check:versions`
- [x] `pnpm --filter @invoker/ui test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None
- Data migration? No

</details>






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for stacked pull requests where an upper-level pull request still requires acceptance.
  * Verified the system blocks requeueing, adds an explanatory comment, and avoids posting duplicate comments.
  * Included the scenario in the stage 3 reproduction test suite by adding a new repro script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->