### PR TITLE
[Remove deprecated merge-mode and retry paths](1) Remove deprecated headless aliases

### DIFF
--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1429,10 +1429,8 @@ describe('headless delegation enforcement', () => {
       // matrix at the headless surface in a single block. Each
       // cell asserts that the explicit verb routes to its
       // matching commandService method or orchestrator
-      // primitive, and ONLY that method (no legacy `restartTask`
-      // path, no cross-collapse, and no in-place re-routing
-      // through the deprecated `restart` shim — Step 13
-      // removed it from the headless verb table).
+      // primitive, and ONLY that method (no cross-collapse and
+      // no in-place re-routing through a removed alias).
       describe('Step 17: 5-cell canonical lifecycle matrix', () => {
         function seedHappyPath(): {
           preemptWorkflowExecution: ReturnType<typeof vi.fn>;
@@ -1489,7 +1487,6 @@ describe('headless delegation enforcement', () => {
           ) as any;
           mockDeps.orchestrator.cancelWorkflow = vi.fn(() => ({ cancelled: [], runningCancelled: [] }));
           mockDeps.orchestrator.cascadeInvalidationToDownstream = vi.fn(() => []);
-          (mockDeps.orchestrator as any).restartTask = vi.fn(() => []);
           mockDeps.commandService.retryTask = vi.fn(async () => ({ ok: true as const, data: [] }));
           mockDeps.commandService.retryWorkflow = vi.fn(async () => ({ ok: true as const, data: [] }));
           (mockDeps.commandService as any).recreateTask = vi.fn(async () => ({ ok: true as const, data: [] }));
@@ -1519,7 +1516,6 @@ describe('headless delegation enforcement', () => {
           expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
-          expect((mockDeps.orchestrator as any).restartTask).not.toHaveBeenCalled();
           preparePoolSpy.mockRestore();
         });
 
@@ -1539,7 +1535,6 @@ describe('headless delegation enforcement', () => {
           expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
-          expect((mockDeps.orchestrator as any).restartTask).not.toHaveBeenCalled();
           preparePoolSpy.mockRestore();
         });
 
@@ -1558,7 +1553,6 @@ describe('headless delegation enforcement', () => {
           expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
-          expect((mockDeps.orchestrator as any).restartTask).not.toHaveBeenCalled();
           preparePoolSpy.mockRestore();
         });
 
@@ -1578,7 +1572,6 @@ describe('headless delegation enforcement', () => {
           expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
-          expect((mockDeps.orchestrator as any).restartTask).not.toHaveBeenCalled();
           preparePoolSpy.mockRestore();
         });
 
@@ -1603,7 +1596,6 @@ describe('headless delegation enforcement', () => {
           expect(mockDeps.commandService.retryWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
-          expect((mockDeps.orchestrator as any).restartTask).not.toHaveBeenCalled();
           preparePoolSpy.mockRestore();
         });
 
@@ -1627,7 +1619,6 @@ describe('headless delegation enforcement', () => {
           expect(mockDeps.commandService.retryWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
-          expect((mockDeps.orchestrator as any).restartTask).not.toHaveBeenCalled();
           preparePoolSpy.mockRestore();
         });
       });

--- a/packages/app/src/__tests__/headless-query-capture.test.ts
+++ b/packages/app/src/__tests__/headless-query-capture.test.ts
@@ -56,13 +56,6 @@ describe('runReadOnlyHeadlessQueryToString', () => {
     }
   });
 
-  it('rejects the removed list alias instead of mapping it to query workflows', async () => {
-    const deps = makeQueryDeps(() => [{ id: 'wf-9' }]);
-    await expect(
-      runReadOnlyHeadlessQueryToString(['list', '--output', 'label'], deps),
-    ).rejects.toThrow('Command "list" is not a delegatable read-only query');
-  });
-
   it('uses configured default agent when session task has no persisted agent name', async () => {
     const task = {
       id: 'wf-1/task-1',

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -69,8 +69,8 @@ export function isHeadlessHelpCommand(command: string | undefined): boolean {
   return command === undefined || command === '--help' || command === '-h';
 }
 
-export function isRemovedHeadlessCommandAlias(command: string | undefined): boolean {
-  return command === 'set-merge-mode';
+export function isRemovedHeadlessCommandAlias(_command: string | undefined): boolean {
+  return false;
 }
 
 export function isMutatingSetSubcommand(subcommand: string | undefined): boolean {

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -811,7 +811,7 @@ export async function resolveAgentSession(
 }
 
 export async function headlessSession(taskId: string | undefined, deps: Pick<HeadlessDeps, 'orchestrator' | 'persistence' | 'executionAgentRegistry' | 'invokerConfig'>): Promise<void> {
-  if (!taskId) throw new Error('Usage: --headless session <taskId>');
+  if (!taskId) throw new Error('Usage: --headless query session <taskId>');
   taskId = restoreWorkflowForTask(taskId, deps).resolvedTaskId;
   const task = deps.orchestrator.getTask(taskId);
   if (!task) throw new Error(`Task "${taskId}" not found`);

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -45,7 +45,6 @@ import { LaunchDispatcher } from './launch-dispatcher.js';
 import {
   formatHeadlessSetSubcommands,
   isHeadlessHelpCommand,
-  isRemovedHeadlessCommandAlias,
 } from './headless-command-registry.js';
 import { printHeadlessUsage } from './headless-usage.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
@@ -244,10 +243,6 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
   if (isHeadlessHelpCommand(command)) {
     printHeadlessUsage();
     return;
-  }
-
-  if (isRemovedHeadlessCommandAlias(command)) {
-    throw new Error(`Unknown command: ${command}. Run with --help for usage.`);
   }
 
   switch (command) {


### PR DESCRIPTION
## Summary

Deprecated headless aliases now reach the normal unknown-command path.

The canonical query and set shapes still stay on the existing parser paths.

The directly affected regression checks now match that canonical surface.

## Review Claim

Deprecated headless aliases now reach the normal unknown-command path while canonical subcommands still parse.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice stays in the headless parser and directly affected regression tests.

## Slice Rationale

This isolates the command surface cutover from transport, HTTP, and prose updates.

## Non-goals

No IPC transport rename, no HTTP route change, and no documentation rewrite.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] pnpm --filter @invoker/app test -- src/__tests__/headless-delegation.test.ts src/__tests__/headless-query-capture.test.ts
- [x] gh pr view 6556 --json body --jq .body | node scripts/validate-pr-body.mjs --body-file /dev/stdin

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert HEAD` from this PR branch.
- Post-revert steps: rerun the headless app tests listed above.
- Data migration? No.

</details>
