### PR TITLE
[Planning Chat Redesign](22) Add e2e visual-proof coverage for the planning-chat UI slice

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -834,6 +834,15 @@ test.describe('Visual proof capture', () => {
     await page.getByRole('button', { name: 'Review draft' }).click();
     await expect(page.getByRole('heading', { name: 'Review draft' })).toBeVisible();
     await expect(page.getByTestId('draft-raw-yaml')).toContainText('name: Terminal Planned Flow');
+    // planning-draft-locked-note is a net-new element; this spec also runs
+    // against the pre-change base branch for before/after visual proof, where
+    // the testid does not exist yet.
+    const lockedNote = page.getByTestId('planning-draft-locked-note');
+    if (await lockedNote.count() > 0) {
+      await expect(lockedNote).toContainText(
+        'This draft is locked — critique in chat, or ask Invoker to re-draft, to change it.',
+      );
+    }
     await captureScreenshot(page, 'terminal-planned-draft-review');
     await page.getByTestId('planning-create-workflow').click();
 
@@ -848,6 +857,26 @@ test.describe('Visual proof capture', () => {
     await page.evaluate(async () => {
       await window.invoker.setTestPlanningChatResponse(null);
     });
+  });
+
+  test('planning context sidebar shows repo bind status', async ({ page }) => {
+    await page.getByTestId('sidebar-home').click();
+    await page.getByRole('button', { name: 'Options' }).click();
+    await expect(page.getByRole('heading', { name: 'Planning chat' })).toBeVisible();
+    await page.getByTestId('invoker-terminal-input').fill('What does this repo do?');
+    await page.getByRole('button', { name: 'Send' }).click();
+    await expect(page.getByTestId('invoker-terminal-transcript')).toContainText('What does this repo do?');
+
+    await page.getByTestId('planning-context-toggle').click();
+    // planning-repo-status is a net-new element; this spec also runs against
+    // the pre-change base branch for before/after visual proof, where the
+    // testid does not exist yet.
+    const repoStatus = page.getByTestId('planning-repo-status');
+    if (await repoStatus.count() > 0) {
+      await expect(repoStatus).toBeVisible();
+      await expect(repoStatus).toContainText('No repository bound yet');
+    }
+    await captureScreenshot(page, 'planning-context-no-repo-bound');
   });
 
   test('planning rail — per-row delete and clear-submitted controls', async ({ page }) => {


### PR DESCRIPTION
## Summary

The UI activation slice earlier in this stack needed real visual proof, not just component-level jsdom coverage.

This extends the existing planning-terminal Playwright spec with checks and screenshot captures for the two new sidebar elements it added.

Both checks are soft — they only assert content when the element is present — so the same spec file drives a clean before/after comparison against the pre-change base branch, where those elements don't exist yet.

## Review Claim

Confirm the new assertions genuinely target the new elements, and that they degrade gracefully (no hard failure) when run against code that predates them.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

No product code changes in this slice — test-only, and the soft assertion pattern was verified against both this branch and `origin/master` while producing the before/after visual proof for the previous slice.

## Slice Rationale

Landed as its own slice, appended after the rest of the stack, since it exists specifically to generate and back the visual proof used in the UI activation slice's PR body.

## Non-goals

Does not add coverage for the "repo bound with a real commit sha" sidebar state — that would need a real git repo configured in the e2e test environment, which is a heavier lift than this slice's proof needs justify; that specific rendering path is already covered by a jsdom component test in the UI activation slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/ui-visual-proof.sh capture-after`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
