### PR TITLE
[Planning Tmux Daemon Owner](1) Repro planning tmux tab break in daemon-owner mode

### DIFF
--- a/packages/app/e2e/planning-terminal-open-daemon-owner-repro.spec.ts
+++ b/packages/app/e2e/planning-terminal-open-daemon-owner-repro.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from './fixtures/electron-app';
+
+test.use({ guiOwnerMode: 'auto' });
+
+const WRITE_MARKER = 'DAEMON_OWNER_WRITE_OK';
+
+async function readTerminalOutputSnapshot(page: import('@playwright/test').Page, sessionId: string): Promise<string> {
+  return page.evaluate(async (targetSessionId) => {
+    const sessions = await window.invoker.planningTerminalList();
+    return sessions.find((session) => session.sessionId === targetSessionId)?.outputSnapshot ?? '';
+  }, sessionId);
+}
+
+// Fixed by the next stack slice: today the local viewer never learns about a
+// planning chat created on the daemon owner, so opening its tmux tab reports
+// "not found"; even once opened, writes are rejected as read-only.
+test.fail();
+test('planning tmux tab opens and stays writable for a session created while running as a daemon-owner delegate', async ({ page }) => {
+  const runtimeStatus = await page.evaluate(async () => window.invoker.getRuntimeStatus());
+  expect(runtimeStatus.mode).toBe('daemon-owner');
+
+  const created = await page.evaluate(async () => window.invoker.planningChatCreate());
+  expect(created.ok).toBe(true);
+  const sessionId = created.ok ? created.session.id : undefined;
+  expect(sessionId).toBeTruthy();
+
+  const result = await page.evaluate(async (sid) => window.invoker.planningTerminalOpen(sid), sessionId);
+  expect(result.opened, `reason: ${(result as { reason?: string }).reason}`).toBe(true);
+  const terminalSessionId = result.opened ? result.session.sessionId : undefined;
+  expect(terminalSessionId).toBeTruthy();
+
+  const writeResult = await page.evaluate(async ({ tsid, marker }) => {
+    return window.invoker.planningTerminalWrite(tsid, `printf '${marker}'\n`);
+  }, { tsid: terminalSessionId, marker: WRITE_MARKER });
+  expect(writeResult, `writeResult: ${JSON.stringify(writeResult)}`).toMatchObject({ ok: true });
+
+  await expect
+    .poll(async () => readTerminalOutputSnapshot(page, terminalSessionId ?? ''), { timeout: 10000 })
+    .toContain(WRITE_MARKER);
+});


### PR DESCRIPTION
## Summary

Opening the Tmux tab for a planning chat can report "not found," even for a chat you just created.

This shows up when Invoker runs with a separate background owner process holding the real state.

This slice adds one test that proves both failures: the tab reports "not found," and even when opened it refuses keystrokes as read-only.

The test is marked expected-to-fail on purpose, so it stays green in CI while still asserting the correct end state.

The next slice flips it to a normal passing test.

## Review Claim

Approve this failing-on-purpose test as an accurate, reproducible statement of the bug before any fix lands.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds a new spec file under `packages/app/e2e/`; it touches no product code and cannot change app behavior.

## Slice Rationale

The bug must be demonstrated before the fix is approved, so the evidence lands as its own reviewable slice ahead of the behavior change.

## Non-goals

- No product code changes.
- No fix for either failure described above.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/planning-terminal-open-daemon-owner-repro.spec.ts --reporter=list` (reports "1 passed" because the failure is expected)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


