### PR TITLE
[Planning Tmux Daemon Owner](2) Fix planning tmux tab in daemon-owner mode

### DIFF
--- a/packages/app/e2e/planning-terminal-open-daemon-owner-repro.spec.ts
+++ b/packages/app/e2e/planning-terminal-open-daemon-owner-repro.spec.ts
@@ -11,10 +11,6 @@ async function readTerminalOutputSnapshot(page: import('@playwright/test').Page,
   }, sessionId);
 }
 
-// Fixed by the next stack slice: today the local viewer never learns about a
-// planning chat created on the daemon owner, so opening its tmux tab reports
-// "not found"; even once opened, writes are rejected as read-only.
-test.fail();
 test('planning tmux tab opens and stays writable for a session created while running as a daemon-owner delegate', async ({ page }) => {
   const runtimeStatus = await page.evaluate(async () => window.invoker.getRuntimeStatus());
   expect(runtimeStatus.mode).toBe('daemon-owner');

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -412,6 +412,38 @@ function sessionToRecord(session: InAppPlanningChatSession, pendingResponse: boo
   };
 }
 
+/**
+ * Rebuilds a usable local session record from a summary fetched from a remote
+ * owner (daemon-owner delegate mode), for the planning-terminal IPC handlers
+ * only. `conversation` is an inert stand-in, never a real harness session:
+ * every planning-chat mutation channel (send/submit/discard-draft/etc.) is
+ * delegated straight to the owner in that mode and never reads this field
+ * locally, so it is safe to leave unusable here.
+ */
+export function hydrateRemotePlanningTerminalSession(summary: InAppPlanningSessionSummary): InAppPlanningChatSession {
+  return {
+    id: summary.id,
+    title: summary.title,
+    presetKey: summary.presetKey,
+    confirmationMode: summary.confirmationMode,
+    status: summary.status,
+    messages: summary.messages,
+    conversation: null as unknown as PlanConversation,
+    draftPlanSummary: summary.draftPlanSummary,
+    submittedWorkflowId: summary.submittedWorkflowId,
+    submittedPlanName: summary.submittedPlanName,
+    terminalMode: summary.terminalMode,
+    terminalSessionId: summary.terminalSessionId,
+    terminalStatus: summary.terminalStatus,
+    terminalExitCode: summary.terminalExitCode,
+    terminalOutputSnapshot: summary.terminalOutputSnapshot,
+    terminalUpdatedAt: summary.terminalUpdatedAt,
+    createdAt: summary.createdAt,
+    updatedAt: summary.updatedAt,
+    nextMessageId: summary.messages.length + 1,
+  };
+}
+
 function sessionToSummary(session: InAppPlanningChatSession): InAppPlanningSessionSummary {
   return {
     id: session.id,

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -412,14 +412,6 @@ function sessionToRecord(session: InAppPlanningChatSession, pendingResponse: boo
   };
 }
 
-/**
- * Rebuilds a usable local session record from a summary fetched from a remote
- * owner (daemon-owner delegate mode), for the planning-terminal IPC handlers
- * only. `conversation` is an inert stand-in, never a real harness session:
- * every planning-chat mutation channel (send/submit/discard-draft/etc.) is
- * delegated straight to the owner in that mode and never reads this field
- * locally, so it is safe to leave unusable here.
- */
 export function hydrateRemotePlanningTerminalSession(summary: InAppPlanningSessionSummary): InAppPlanningChatSession {
   return {
     id: summary.id,

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -425,7 +425,7 @@ export function hydrateRemotePlanningTerminalSession(summary: InAppPlanningSessi
     id: summary.id,
     title: summary.title,
     presetKey: summary.presetKey,
-    confirmationMode: summary.confirmationMode,
+    confirmationMode: summary.confirmationMode ?? 'require',
     status: summary.status,
     messages: summary.messages,
     conversation: null as unknown as PlanConversation,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -65,6 +65,7 @@ import type {
   InAppPlanningChatRequest,
   InAppPlanningDeleteRequest,
   InAppPlanningDiscardDraftRequest,
+  InAppPlanningListSessionsResponse,
   InAppPlanningResetRequest,
   InAppPlanningSubmitRequest,
   Logger,
@@ -3173,6 +3174,26 @@ startMainProcessBootstrap({
       planningChatSessions,
       getPlanningSessionStore: () => (ownerMode ? persistence : undefined),
       repoRoot,
+      isPlanningTerminalWriteAllowed: () =>
+        !computeGuiRuntimeStatus({ ownerMode, guiUsingDaemonOwner, connectionLost: guiDaemonOwnerConnectionLost }).readOnly,
+      resolveRemotePlanningSession: guiUsingDaemonOwner
+        ? async (planningSessionId: string) => {
+          try {
+            const response = await messageBus.request('headless.gui-mutation', {
+              channel: 'invoker:planning-chat-list',
+              args: [],
+            }) as InAppPlanningListSessionsResponse;
+            return response.ok ? response.sessions.find((session) => session.id === planningSessionId) : undefined;
+          } catch (err) {
+            if (isMutationOwnerUnavailableError(err)) markDaemonOwnerUnavailable(err instanceof Error ? err.message : String(err));
+            logger.warn(
+              `planning-terminal-open remote session lookup failed: ${err instanceof Error ? err.message : String(err)}`,
+              { module: 'planning-terminal' },
+            );
+            return undefined;
+          }
+        }
+        : undefined,
     });
 
     registerTerminalSessionIpcHandlers({

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -13,10 +13,12 @@ import {
 } from './terminal-ui-perf.js';
 import {
   ensurePlanningTerminalSummaryBridge,
+  hydrateRemotePlanningTerminalSession,
   updatePlanningChatTerminalState,
   type InAppPlanningChatSessions,
   type InAppPlanningSessionStore,
 } from './in-app-planner.js';
+import type { InAppPlanningSessionSummary } from '@invoker/contracts';
 
 /** Coalesce running-session snapshot upserts so PTY output does not 1:1 SQLite-write on main. */
 export const TERMINAL_SESSION_UPSERT_COALESCE_MS = 250;
@@ -368,12 +370,12 @@ function planningTerminalOnly(
 function planningTerminalWritable(
   embeddedTerminalManager: EmbeddedTerminalManager,
   planningChatSessions: InAppPlanningChatSessions,
-  getPlanningSessionStore: PlanningSessionStoreGetter,
+  isPlanningTerminalWriteAllowed: () => boolean,
   sessionId: string,
 ): { ok: true } | { ok: false; reason: string } {
   const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
   if (!allowed.ok) return allowed;
-  if (!getPlanningSessionStore()) {
+  if (!isPlanningTerminalWriteAllowed()) {
     return { ok: false, reason: 'Planning terminal is read-only in this window.' };
   }
   const planningSession = planningChatSessions.get(allowed.planningSessionId);
@@ -482,6 +484,10 @@ export function registerPlanningTerminalSessionIpcHandlers(deps: {
   planningChatSessions: InAppPlanningChatSessions;
   getPlanningSessionStore: PlanningSessionStoreGetter;
   repoRoot: string;
+  /** Daemon-owner delegate mode only: fetches a session the owner created that this window's local map hasn't seen yet. */
+  resolveRemotePlanningSession?: (planningSessionId: string) => Promise<InAppPlanningSessionSummary | undefined>;
+  /** Whether this window may type into its own local planning PTYs (distinct from DB-write ownership). Defaults to the getPlanningSessionStore check for callers that don't distinguish the two. */
+  isPlanningTerminalWriteAllowed?: () => boolean;
 }): void {
   const {
     ipcMain,
@@ -490,6 +496,8 @@ export function registerPlanningTerminalSessionIpcHandlers(deps: {
     planningChatSessions,
     getPlanningSessionStore,
     repoRoot,
+    resolveRemotePlanningSession,
+    isPlanningTerminalWriteAllowed = () => Boolean(getPlanningSessionStore()),
   } = deps;
 
   ipcMain.handle('invoker:planning-terminal-open', async (_event, planningSessionIdArg: string) => {
@@ -497,7 +505,14 @@ export function registerPlanningTerminalSessionIpcHandlers(deps: {
     if (!planningSessionId) {
       return { opened: false, reason: 'Planning session id is required.' };
     }
-    const planningSession = planningChatSessions.get(planningSessionId);
+    let planningSession = planningChatSessions.get(planningSessionId);
+    if (!planningSession && resolveRemotePlanningSession) {
+      const remoteSummary = await resolveRemotePlanningSession(planningSessionId);
+      if (remoteSummary) {
+        planningSession = hydrateRemotePlanningTerminalSession(remoteSummary);
+        planningChatSessions.set(planningSessionId, planningSession);
+      }
+    }
     if (!planningSession) {
       return { opened: false, reason: 'Planning conversation was not found.' };
     }
@@ -546,7 +561,7 @@ export function registerPlanningTerminalSessionIpcHandlers(deps: {
     const allowed = planningTerminalWritable(
       embeddedTerminalManager,
       planningChatSessions,
-      getPlanningSessionStore,
+      isPlanningTerminalWriteAllowed,
       sessionId,
     );
     if (!allowed.ok) return allowed;

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -484,9 +484,7 @@ export function registerPlanningTerminalSessionIpcHandlers(deps: {
   planningChatSessions: InAppPlanningChatSessions;
   getPlanningSessionStore: PlanningSessionStoreGetter;
   repoRoot: string;
-  /** Daemon-owner delegate mode only: fetches a session the owner created that this window's local map hasn't seen yet. */
   resolveRemotePlanningSession?: (planningSessionId: string) => Promise<InAppPlanningSessionSummary | undefined>;
-  /** Whether this window may type into its own local planning PTYs (distinct from DB-write ownership). Defaults to the getPlanningSessionStore check for callers that don't distinguish the two. */
   isPlanningTerminalWriteAllowed?: () => boolean;
 }): void {
   const {


### PR DESCRIPTION
## Summary

The planning Tmux tab now works when Invoker runs with a separate background owner process holding the real state.

Opening the tab for a chat that was just created now finds it, instead of reporting "not found."

Typing into the tab also works now. It was blocked as read-only by a check that was really about database writes, not this window's own local terminal.

## Review Claim

Approve routing the tab-open lookup through the owner when a chat is not found locally, and approve replacing the old write check with one that reflects the true read-only state instead of which process owns the database.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Both changes only add optional fallbacks with the prior behavior as the default: the local lookup still runs first, and every existing caller that does not supply the new options keeps behaving exactly as before. Which process may write to the database is untouched.

## Slice Rationale

This is one connected behavior fix (the tab must both open and accept keystrokes to be usable), landed after the slice that already proved both failures with a failing-on-purpose test.

## Non-goals

- No change to which process owns database writes.
- No new IPC channel; the owner lookup reuses an existing delegation path.
- No UI changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/planning-terminal-open-daemon-owner-repro.spec.ts --reporter=list` (now passes for real, including a real echoed marker from a live shell)
- [x] `pnpm --filter @invoker/app exec vitest run` (163 files, 1744 passed, 1 pre-existing skip)

</details>

## Visual Proof

Walkthrough (same daemon-owner window, three steps, two seconds each): the Tmux tab first shows the literal "Planning conversation was not found." error with no terminal, then opens a live shell, then echoes real output from a command typed into that shell.

![Walkthrough: tmux tab goes from "Planning conversation was not found." to a live shell that echoes a typed command](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-ceedc4/daemon-owner-tmux-walkthrough.gif)

Individual frames, for reference:

Before: the Tmux tab for a chat created after startup shows the literal user-facing error, with no terminal at all.

![Before: tmux tab shows "Planning conversation was not found."](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-ceedc4/daemon-owner-tmux-open-before.png)

After: the same walkthrough now opens a live shell.

![After: tmux tab opens a live shell instead of the error](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-ceedc4/daemon-owner-tmux-open-after.png)

After: a real command typed into that shell echoes real output back, proving the write path works too.

![After: typed command echoes DAEMON_OWNER_TMUX_PROOF_OK from a live shell](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-ceedc4/daemon-owner-tmux-typed.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
