### PR TITLE
[Planning Chat Redesign](9) Wire worktree provisioning into the Electron GUI dispatch path

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -23,6 +23,7 @@ import {
   type InAppPlanningChatSession,
   type LoadedGeneratedPlan,
 } from '../in-app-planner.js';
+import type { PlanningRepoPool } from '../planning-chat-worktree.js';
 import { ConversationRepository, SQLiteAdapter, type InAppPlanningSessionRecord } from '@invoker/data-store';
 
 const VALID_PLAN = `Here is the plan.
@@ -1417,6 +1418,212 @@ tasks:
 
     expect(resetPlanningChat({ sessionId: 'session-1' }, { sessions })).toEqual({ ok: true });
     expect(sessions.has('session-1')).toBe(false);
+  });
+});
+
+describe('planning chat worktree provisioning', () => {
+  const planningCommandBuilder = vi.fn(() => ({ command: 'planner', args: ['prompt'] }));
+
+  function createFakeRepoPool(
+    worktreePath: string,
+  ): PlanningRepoPool & { release: ReturnType<typeof vi.fn>; softRelease: ReturnType<typeof vi.fn> } {
+    const release = vi.fn(async () => {});
+    const softRelease = vi.fn();
+    const acquireWorktree = vi.fn(async (_repoUrl: string, branch: string) => ({
+      clonePath: '/fake/clone',
+      worktreePath,
+      branch,
+      release,
+      softRelease,
+    }));
+    return {
+      ensureCloneThroughRepoQueue: vi.fn(async () => '/fake/clone'),
+      resolveBaseCommit: vi.fn(async () => 'fake-head-sha'),
+      acquireWorktree,
+      externalWorktreePath: vi.fn(() => worktreePath),
+      release,
+      softRelease,
+    };
+  }
+
+  it('provisions a worktree and persists the binding fields when repoPool + config.defaultRepoUrl are set', async () => {
+    const worktreePath = '/fake/worktree/create-session';
+    const repoPool = createFakeRepoPool(worktreePath);
+    const sessions = createInAppPlanningChatSessions();
+    const upsert = vi.fn();
+
+    const created = await createPlanningChatSession({}, {
+      config: { defaultRepoUrl: 'https://example.com/repo.git', defaultBranch: 'main' },
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+      repoPool,
+      planningSessionStore: {
+        upsertInAppPlanningSession: upsert,
+        updateInAppPlanningSession: vi.fn(),
+        deleteInAppPlanningSession: vi.fn(),
+      },
+    });
+    if (!created.ok) throw new Error(created.error);
+    const sessionId = created.session.id;
+    const expectedBranch = `invoker/planning/${sessionId}`;
+
+    expect(repoPool.ensureCloneThroughRepoQueue).toHaveBeenCalledWith('https://example.com/repo.git');
+    expect(repoPool.resolveBaseCommit).toHaveBeenCalledWith('https://example.com/repo.git', 'main');
+    expect(repoPool.acquireWorktree).toHaveBeenCalledWith(
+      'https://example.com/repo.git',
+      expectedBranch,
+      'fake-head-sha',
+      sessionId,
+    );
+    expect(repoPool.softRelease).toHaveBeenCalledTimes(1);
+
+    const session = sessions.get(sessionId);
+    expect(session?.repoUrl).toBe('https://example.com/repo.git');
+    expect(session?.baseBranch).toBe('main');
+    expect(session?.baseCommit).toBe('fake-head-sha');
+    expect(session?.worktreePath).toBe(worktreePath);
+    expect(session?.worktreeBranch).toBe(expectedBranch);
+    expect(session?.conversation.workingDir).toBe(worktreePath);
+
+    expect(upsert).toHaveBeenCalledWith(expect.objectContaining({
+      repoUrl: 'https://example.com/repo.git',
+      baseBranch: 'main',
+      baseCommit: 'fake-head-sha',
+      worktreePath,
+      worktreeBranch: expectedBranch,
+    }));
+  });
+
+  it('falls back to deps.workingDir exactly as before when no repoPool is supplied', async () => {
+    const workingDir = mkdtempSync(join(tmpdir(), 'in-app-no-repo-pool-'));
+    try {
+      const sessions = createInAppPlanningChatSessions();
+      const created = await createPlanningChatSession({}, {
+        config: { defaultRepoUrl: 'https://example.com/repo.git', defaultBranch: 'main' },
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        workingDir,
+      });
+      if (!created.ok) throw new Error(created.error);
+      const session = sessions.get(created.session.id);
+      expect(session?.repoUrl).toBeUndefined();
+      expect(session?.baseBranch).toBeUndefined();
+      expect(session?.baseCommit).toBeUndefined();
+      expect(session?.worktreePath).toBeUndefined();
+      expect(session?.worktreeBranch).toBeUndefined();
+      expect(session?.conversation.workingDir).toBe(workingDir);
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to deps.workingDir when repoPool is set but no defaultRepoUrl is configured', async () => {
+    const workingDir = mkdtempSync(join(tmpdir(), 'in-app-no-default-repo-'));
+    try {
+      const repoPool = createFakeRepoPool('/fake/should-not-be-used');
+      const sessions = createInAppPlanningChatSessions();
+      const created = await createPlanningChatSession({}, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        workingDir,
+        repoPool,
+      });
+      if (!created.ok) throw new Error(created.error);
+      expect(repoPool.acquireWorktree).not.toHaveBeenCalled();
+      const session = sessions.get(created.session.id);
+      expect(session?.worktreePath).toBeUndefined();
+      expect(session?.conversation.workingDir).toBe(workingDir);
+    } finally {
+      rmSync(workingDir, { recursive: true, force: true });
+    }
+  });
+
+  it('restore reconstructs a missing worktree for a session that has one recorded', async () => {
+    const worktreePath = '/fake/worktree/restore-missing';
+    const repoPool = createFakeRepoPool(worktreePath);
+    repoPool.externalWorktreePath = vi.fn(() => '/fake/worktree/restore-missing-nonexistent');
+
+    const record: InAppPlanningSessionRecord = {
+      id: 'planning-worktree-restore',
+      title: 'Restored plan with worktree',
+      presetKey: 'codex',
+      status: 'still_discussing',
+      confirmationMode: 'require',
+      repoUrl: 'https://example.com/repo.git',
+      baseBranch: 'main',
+      baseCommit: 'stored-base-commit',
+      worktreePath: '/fake/worktree/restore-missing-nonexistent',
+      worktreeBranch: 'invoker/planning/planning-worktree-restore',
+      messages: [],
+      pendingResponse: false,
+      createdAt: '2026-07-07T00:00:00.000Z',
+      updatedAt: '2026-07-07T00:00:00.000Z',
+    };
+
+    const sessions = createInAppPlanningChatSessions();
+    await restorePlanningChatSessions([record], {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+      repoPool,
+    });
+
+    expect(repoPool.acquireWorktree).toHaveBeenCalledWith(
+      'https://example.com/repo.git',
+      'invoker/planning/planning-worktree-restore',
+      'stored-base-commit',
+      'planning-worktree-restore',
+    );
+    expect(repoPool.resolveBaseCommit).not.toHaveBeenCalled();
+    const session = sessions.get('planning-worktree-restore');
+    expect(session?.worktreePath).toBe(worktreePath);
+    expect(session?.conversation.workingDir).toBe(worktreePath);
+  });
+
+  it('restore leaves worktreePath untouched when the recorded path already exists on disk', async () => {
+    const existingWorktreePath = mkdtempSync(join(tmpdir(), 'in-app-restore-present-'));
+    try {
+      const repoPool = createFakeRepoPool(existingWorktreePath);
+      repoPool.externalWorktreePath = vi.fn(() => existingWorktreePath);
+
+      const record: InAppPlanningSessionRecord = {
+        id: 'planning-worktree-present',
+        title: 'Restored plan with existing worktree',
+        presetKey: 'codex',
+        status: 'still_discussing',
+        confirmationMode: 'require',
+        repoUrl: 'https://example.com/repo.git',
+        baseBranch: 'main',
+        baseCommit: 'stored-base-commit',
+        worktreePath: existingWorktreePath,
+        worktreeBranch: 'invoker/planning/planning-worktree-present',
+        messages: [],
+        pendingResponse: false,
+        createdAt: '2026-07-07T00:00:00.000Z',
+        updatedAt: '2026-07-07T00:00:00.000Z',
+      };
+
+      const sessions = createInAppPlanningChatSessions();
+      await restorePlanningChatSessions([record], {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        repoPool,
+      });
+
+      expect(repoPool.acquireWorktree).not.toHaveBeenCalled();
+      const session = sessions.get('planning-worktree-present');
+      expect(session?.worktreePath).toBe(existingWorktreePath);
+      expect(session?.conversation.workingDir).toBe(existingWorktreePath);
+    } finally {
+      rmSync(existingWorktreePath, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/app/src/__tests__/planning-chat-worktree-repo-pool.test.ts
+++ b/packages/app/src/__tests__/planning-chat-worktree-repo-pool.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, writeFileSync, realpathSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execSync } from 'node:child_process';
+import { RepoPool } from '@invoker/execution-engine';
+import {
+  ensurePlanningWorktreeReady,
+  provisionPlanningWorktree,
+  resolvePlanningWorktreeBranch,
+} from '../planning-chat-worktree.js';
+
+function createTempRemoteRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'planning-worktree-remote-'));
+  execSync('git init', { cwd: dir });
+  execSync('git config user.email "test@test.com"', { cwd: dir });
+  execSync('git config user.name "Test"', { cwd: dir });
+  writeFileSync(join(dir, 'README.md'), '# Planning worktree test repo\n');
+  execSync('git add -A && git commit -m "initial"', { cwd: dir });
+  execSync('git branch -M main', { cwd: dir });
+  return realpathSync(dir);
+}
+
+describe('planning-chat-worktree against a real RepoPool', () => {
+  let cacheDir: string;
+  let worktreeBaseDir: string;
+  let remoteRepoUrl: string;
+  let pool: RepoPool;
+
+  beforeEach(() => {
+    cacheDir = realpathSync(mkdtempSync(join(tmpdir(), 'planning-worktree-cache-')));
+    worktreeBaseDir = realpathSync(mkdtempSync(join(tmpdir(), 'planning-worktree-base-')));
+    remoteRepoUrl = createTempRemoteRepo();
+    pool = new RepoPool({ cacheDir, worktreeBaseDir });
+  });
+
+  afterEach(async () => {
+    await pool.destroyAll();
+    rmSync(cacheDir, { recursive: true, force: true });
+    rmSync(worktreeBaseDir, { recursive: true, force: true });
+    rmSync(remoteRepoUrl, { recursive: true, force: true });
+  });
+
+  it('provisions a real worktree at the resolved HEAD commit, then recreates it after a disk-headroom-style wipe of both the clone cache and the worktree dir', async () => {
+    const sessionId = 'integration-session-1';
+    const branch = resolvePlanningWorktreeBranch(sessionId);
+
+    const provisioned = await provisionPlanningWorktree(pool, {
+      repoUrl: remoteRepoUrl,
+      baseBranch: 'main',
+      sessionId,
+    });
+
+    expect(provisioned.branch).toBe(branch);
+    expect(existsSync(provisioned.worktreePath)).toBe(true);
+    const headAfterProvision = execSync('git rev-parse HEAD', { cwd: provisioned.worktreePath }).toString().trim();
+    expect(headAfterProvision).toBe(provisioned.baseCommit);
+    const currentBranch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: provisioned.worktreePath }).toString().trim();
+    expect(currentBranch).toBe(branch);
+
+    const expectedPath = pool.externalWorktreePath(remoteRepoUrl, branch);
+    expect(realpathSync(provisioned.worktreePath)).toBe(realpathSync(expectedPath));
+
+    // Mirrors disk-headroom-reclaim.ts, which wholesale-wipes both the "repos"
+    // clone-cache dir and the "worktrees" dir together under disk pressure.
+    rmSync(pool.getClonePath(remoteRepoUrl), { recursive: true, force: true });
+    rmSync(provisioned.worktreePath, { recursive: true, force: true });
+    expect(existsSync(provisioned.worktreePath)).toBe(false);
+
+    const readyAfterWipe = await ensurePlanningWorktreeReady(pool, {
+      repoUrl: remoteRepoUrl,
+      baseCommit: provisioned.baseCommit,
+      sessionId,
+    });
+    expect(readyAfterWipe.recreated).toBe(true);
+    expect(realpathSync(readyAfterWipe.worktreePath)).toBe(realpathSync(expectedPath));
+    expect(existsSync(readyAfterWipe.worktreePath)).toBe(true);
+    const headAfterRecreate = execSync('git rev-parse HEAD', { cwd: readyAfterWipe.worktreePath }).toString().trim();
+    expect(headAfterRecreate).toBe(provisioned.baseCommit);
+    const branchAfterRecreate = execSync('git rev-parse --abbrev-ref HEAD', { cwd: readyAfterWipe.worktreePath }).toString().trim();
+    expect(branchAfterRecreate).toBe(branch);
+
+    const readyWhenPresent = await ensurePlanningWorktreeReady(pool, {
+      repoUrl: remoteRepoUrl,
+      baseCommit: provisioned.baseCommit,
+      sessionId,
+    });
+    expect(readyWhenPresent.recreated).toBe(false);
+    expect(realpathSync(readyWhenPresent.worktreePath)).toBe(realpathSync(expectedPath));
+  }, 30_000);
+
+  it('recreates at the original stored commit even if the remote branch has since advanced', async () => {
+    const sessionId = 'integration-session-2';
+    const branch = resolvePlanningWorktreeBranch(sessionId);
+
+    const provisioned = await provisionPlanningWorktree(pool, {
+      repoUrl: remoteRepoUrl,
+      baseBranch: 'main',
+      sessionId,
+    });
+    const originalCommit = provisioned.baseCommit;
+
+    writeFileSync(join(remoteRepoUrl, 'CHANGED.md'), 'advanced\n');
+    execSync('git add -A && git commit -m "advance main"', { cwd: remoteRepoUrl });
+    const advancedCommit = execSync('git rev-parse HEAD', { cwd: remoteRepoUrl }).toString().trim();
+    expect(advancedCommit).not.toBe(originalCommit);
+
+    rmSync(pool.getClonePath(remoteRepoUrl), { recursive: true, force: true });
+    rmSync(provisioned.worktreePath, { recursive: true, force: true });
+
+    const ready = await ensurePlanningWorktreeReady(pool, {
+      repoUrl: remoteRepoUrl,
+      baseCommit: originalCommit,
+      sessionId,
+    });
+    expect(ready.recreated).toBe(true);
+    const headAfterRecreate = execSync('git rev-parse HEAD', { cwd: ready.worktreePath }).toString().trim();
+    expect(headAfterRecreate).toBe(originalCommit);
+    expect(headAfterRecreate).not.toBe(advancedCommit);
+    const branchName = execSync('git rev-parse --abbrev-ref HEAD', { cwd: ready.worktreePath }).toString().trim();
+    expect(branchName).toBe(branch);
+  }, 30_000);
+});

--- a/packages/app/src/__tests__/planning-chat-worktree.test.ts
+++ b/packages/app/src/__tests__/planning-chat-worktree.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  ensurePlanningWorktreeReady,
+  provisionPlanningWorktree,
+  releasePlanningWorktree,
+  resolvePlanningWorktreeBranch,
+  type PlanningRepoPool,
+} from '../planning-chat-worktree.js';
+
+function createFakePool(overrides: Partial<Record<keyof PlanningRepoPool, unknown>> = {}) {
+  const release = vi.fn().mockResolvedValue(undefined);
+  const softRelease = vi.fn();
+  const ensureCloneThroughRepoQueue = vi.fn().mockResolvedValue('/clone/path');
+  const resolveBaseCommit = vi.fn().mockResolvedValue('resolved-head-sha');
+  const acquireWorktree = vi.fn().mockResolvedValue({
+    clonePath: '/clone/path',
+    worktreePath: '/worktrees/acquired',
+    branch: 'invoker/planning/session-1',
+    release,
+    softRelease,
+  });
+  const externalWorktreePath = vi.fn().mockReturnValue('/worktrees/deterministic');
+  return {
+    pool: {
+      ensureCloneThroughRepoQueue,
+      resolveBaseCommit,
+      acquireWorktree,
+      externalWorktreePath,
+      ...overrides,
+    } as unknown as PlanningRepoPool,
+    spies: { ensureCloneThroughRepoQueue, resolveBaseCommit, acquireWorktree, externalWorktreePath, release, softRelease },
+  };
+}
+
+describe('resolvePlanningWorktreeBranch', () => {
+  it('derives an invoker/-prefixed branch name from the session id', () => {
+    expect(resolvePlanningWorktreeBranch('session-1')).toBe('invoker/planning/session-1');
+  });
+});
+
+describe('provisionPlanningWorktree', () => {
+  let installSpy: ReturnType<typeof vi.fn> | undefined;
+
+  beforeEach(() => {
+    installSpy = undefined;
+  });
+
+  it('calls pool methods in order and returns the acquired worktree, calling softRelease', async () => {
+    const { pool, spies } = createFakePool();
+    const calls: string[] = [];
+    spies.ensureCloneThroughRepoQueue.mockImplementation(async (repoUrl: string) => {
+      calls.push('ensureCloneThroughRepoQueue');
+      return `/clone/${repoUrl}`;
+    });
+    spies.resolveBaseCommit.mockImplementation(async () => {
+      calls.push('resolveBaseCommit');
+      return 'resolved-head-sha';
+    });
+    spies.acquireWorktree.mockImplementation(async () => {
+      calls.push('acquireWorktree');
+      return {
+        clonePath: '/clone/path',
+        worktreePath: '/nonexistent/planning-worktree-path-for-test',
+        branch: 'invoker/planning/session-1',
+        release: spies.release,
+        softRelease: spies.softRelease,
+      };
+    });
+
+    const result = await provisionPlanningWorktree(pool, {
+      repoUrl: 'https://example.com/repo.git',
+      baseBranch: 'main',
+      sessionId: 'session-1',
+    });
+
+    expect(calls).toEqual(['ensureCloneThroughRepoQueue', 'resolveBaseCommit', 'acquireWorktree']);
+    expect(spies.acquireWorktree).toHaveBeenCalledWith(
+      'https://example.com/repo.git',
+      'invoker/planning/session-1',
+      'resolved-head-sha',
+      'session-1',
+    );
+    expect(result).toEqual({
+      worktreePath: '/nonexistent/planning-worktree-path-for-test',
+      baseCommit: 'resolved-head-sha',
+      branch: 'invoker/planning/session-1',
+    });
+    expect(spies.softRelease).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ensurePlanningWorktreeReady', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'planning-worktree-ready-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns recreated: false without acquiring when the worktree already exists on disk', async () => {
+    const { pool, spies } = createFakePool();
+    spies.externalWorktreePath.mockReturnValue(tmpDir);
+    expect(existsSync(tmpDir)).toBe(true);
+
+    const result = await ensurePlanningWorktreeReady(pool, {
+      repoUrl: 'https://example.com/repo.git',
+      baseCommit: 'stored-base-commit',
+      sessionId: 'session-1',
+    });
+
+    expect(result).toEqual({ worktreePath: tmpDir, recreated: false });
+    expect(spies.acquireWorktree).not.toHaveBeenCalled();
+    expect(spies.resolveBaseCommit).not.toHaveBeenCalled();
+    expect(spies.ensureCloneThroughRepoQueue).not.toHaveBeenCalled();
+  });
+
+  it('recreates using the stored baseCommit (never re-resolving HEAD) when the path is missing', async () => {
+    const missingPath = join(tmpDir, 'missing', 'worktree');
+    const { pool, spies } = createFakePool();
+    spies.externalWorktreePath.mockReturnValue(missingPath);
+    spies.acquireWorktree.mockResolvedValue({
+      clonePath: '/clone/path',
+      worktreePath: missingPath,
+      branch: 'invoker/planning/session-1',
+      release: spies.release,
+      softRelease: spies.softRelease,
+    });
+    expect(existsSync(missingPath)).toBe(false);
+
+    const result = await ensurePlanningWorktreeReady(pool, {
+      repoUrl: 'https://example.com/repo.git',
+      baseCommit: 'stored-base-commit',
+      sessionId: 'session-1',
+    });
+
+    expect(spies.resolveBaseCommit).not.toHaveBeenCalled();
+    expect(spies.ensureCloneThroughRepoQueue).toHaveBeenCalledWith('https://example.com/repo.git');
+    expect(spies.acquireWorktree).toHaveBeenCalledWith(
+      'https://example.com/repo.git',
+      'invoker/planning/session-1',
+      'stored-base-commit',
+      'session-1',
+    );
+    expect(result).toEqual({ worktreePath: missingPath, recreated: true });
+    expect(spies.softRelease).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('releasePlanningWorktree', () => {
+  it('re-acquires the deterministic worktree then calls release()', async () => {
+    const { pool, spies } = createFakePool();
+
+    await releasePlanningWorktree(pool, {
+      repoUrl: 'https://example.com/repo.git',
+      baseCommit: 'stored-base-commit',
+      sessionId: 'session-1',
+    });
+
+    expect(spies.acquireWorktree).toHaveBeenCalledWith(
+      'https://example.com/repo.git',
+      'invoker/planning/session-1',
+      'stored-base-commit',
+      'session-1',
+    );
+    expect(spies.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -49,6 +49,13 @@ import {
 } from '@invoker/planning-core';
 import type { HarnessPreset, PlanConversation, PlanConversationConfig, PlanningCommandBuilder } from '@invoker/surfaces';
 import type { InvokerConfig } from './config.js';
+import { ensurePlanningWorktreeReady, provisionPlanningWorktree, type PlanningRepoPool } from './planning-chat-worktree.js';
+
+function logPlanningWorktreeReadyError(sessionId: string, step: string, error: unknown): void {
+  console.error(`[planning-chat] ensurePlanningWorktreeReady ${step} failed session="${sessionId}": ${
+    error instanceof Error ? error.message : String(error)
+  }`);
+}
 
 export interface LoadedGeneratedPlan {
   planName: string;
@@ -83,6 +90,11 @@ export interface InAppPlanningChatSession {
   status: InAppPlanningSessionStatus;
   messages: InAppPlanningChatLine[];
   conversation: PlanConversation;
+  repoUrl?: string;
+  baseBranch?: string;
+  baseCommit?: string;
+  worktreePath?: string;
+  worktreeBranch?: string;
   draftPlanSummary?: InAppPlanningPlanSummary;
   draftPlanText?: string;
   submittedWorkflowId?: string;
@@ -400,6 +412,11 @@ function sessionToRecord(session: InAppPlanningChatSession, pendingResponse: boo
     presetKey: session.presetKey,
     status: session.status,
     confirmationMode: session.confirmationMode ?? 'require',
+    repoUrl: session.repoUrl,
+    baseBranch: session.baseBranch,
+    baseCommit: session.baseCommit,
+    worktreePath: session.worktreePath,
+    worktreeBranch: session.worktreeBranch,
     messages: session.messages,
     draftPlanSummary: session.draftPlanSummary,
     draftPlanText: session.draftPlanText,
@@ -626,6 +643,7 @@ async function createSession(
     sessions: InAppPlanningChatSessions;
     planningCommandBuilder: PlanningCommandBuilder;
     planningSessionStore?: InAppPlanningSessionStore;
+    repoPool?: PlanningRepoPool;
   },
 ): Promise<InAppPlanningChatSession | { error: string }> {
   const presets = await resolveHarnessPresets(deps.config);
@@ -645,6 +663,24 @@ async function createSession(
     request?.confirmationMode,
     resolveDefaultPlanningConfirmationMode(deps.config),
   );
+
+  const repoUrl = deps.config.defaultRepoUrl;
+  const baseBranch = deps.config.defaultBranch ?? 'main';
+  let worktreeBinding:
+    | { repoUrl: string; baseBranch: string; baseCommit: string; worktreePath: string; worktreeBranch: string }
+    | undefined;
+  if (deps.repoPool && typeof repoUrl === 'string' && repoUrl.trim()) {
+    const provisioned = await provisionPlanningWorktree(deps.repoPool, { repoUrl, baseBranch, sessionId: id });
+    worktreeBinding = {
+      repoUrl,
+      baseBranch,
+      baseCommit: provisioned.baseCommit,
+      worktreePath: provisioned.worktreePath,
+      worktreeBranch: provisioned.branch,
+    };
+  }
+  const conversationDeps = worktreeBinding ? { ...deps, workingDir: worktreeBinding.worktreePath } : deps;
+
   const session: InAppPlanningChatSession = {
     id,
     title: typeof request?.title === 'string' && request.title.trim() ? request.title.trim() : 'Untitled plan',
@@ -652,7 +688,12 @@ async function createSession(
     confirmationMode,
     status: 'still_discussing',
     messages: [],
-    conversation: new PlanConversation(planConversationConfig(preset, deps, id, selectHarnessSessionDriver, { conversationalPlanning: true })),
+    conversation: new PlanConversation(planConversationConfig(preset, conversationDeps, id, selectHarnessSessionDriver, { conversationalPlanning: true })),
+    repoUrl: worktreeBinding?.repoUrl,
+    baseBranch: worktreeBinding?.baseBranch,
+    baseCommit: worktreeBinding?.baseCommit,
+    worktreePath: worktreeBinding?.worktreePath,
+    worktreeBranch: worktreeBinding?.worktreeBranch,
     createdAt,
     updatedAt: createdAt,
     nextMessageId: 1,
@@ -732,6 +773,7 @@ export async function createPlanningChatSession(
     sessions: InAppPlanningChatSessions;
     planningCommandBuilder: PlanningCommandBuilder;
     planningSessionStore?: InAppPlanningSessionStore;
+    repoPool?: PlanningRepoPool;
   },
 ): Promise<InAppPlanningCreateSessionResponse> {
   try {
@@ -760,6 +802,7 @@ export async function sendPlanningChatMessage(
     sessions: InAppPlanningChatSessions;
     planningCommandBuilder: PlanningCommandBuilder;
     planningSessionStore?: InAppPlanningSessionStore;
+    repoPool?: PlanningRepoPool;
   },
 ): Promise<InAppPlanningChatResponse> {
   const rawRequest = request as Partial<InAppPlanningChatRequest> | null | undefined;
@@ -823,6 +866,18 @@ export async function sendPlanningChatMessage(
       try {
         const { extractYamlPlan } = await loadPlannerSurfaces();
         const formattedMessage = formatConversationalPlanningMessage(message);
+        if (deps.repoPool && activeSession.worktreePath && activeSession.repoUrl && activeSession.baseCommit) {
+          try {
+            await ensurePlanningWorktreeReady(deps.repoPool, {
+              repoUrl: activeSession.repoUrl,
+              baseCommit: activeSession.baseCommit,
+              sessionId: activeSession.id,
+              worktreePath: activeSession.worktreePath,
+            });
+          } catch (error) {
+            logPlanningWorktreeReadyError(activeSession.id, 'before-send', error);
+          }
+        }
         const reply = deps.plannerReplyOverride
           ? await deps.plannerReplyOverride(formattedMessage)
           : await activeSession.conversation.sendMessage(formattedMessage);
@@ -1090,6 +1145,7 @@ export async function restorePlanningChatSessions(
     sessions: InAppPlanningChatSessions;
     planningCommandBuilder: PlanningCommandBuilder;
     planningSessionStore?: InAppPlanningSessionStore;
+    repoPool?: PlanningRepoPool;
   },
 ): Promise<void> {
   // Nothing persisted → skip loading @invoker/surfaces. The built required-fast CI app
@@ -1102,7 +1158,23 @@ export async function restorePlanningChatSessions(
     const preset = presets[record.presetKey];
     if (!preset) continue;
 
-    const conversation = new PlanConversation(planConversationConfig(preset, deps, record.id, selectHarnessSessionDriver));
+    let restoredWorktreePath: string | undefined;
+    if (deps.repoPool && record.worktreePath && record.repoUrl && record.baseCommit) {
+      try {
+        const ready = await ensurePlanningWorktreeReady(deps.repoPool, {
+          repoUrl: record.repoUrl,
+          baseCommit: record.baseCommit,
+          sessionId: record.id,
+          worktreePath: record.worktreePath,
+        });
+        restoredWorktreePath = ready.worktreePath;
+      } catch (error) {
+        logPlanningWorktreeReadyError(record.id, 'restore', error);
+      }
+    }
+    const conversationDeps = restoredWorktreePath ? { ...deps, workingDir: restoredWorktreePath } : deps;
+
+    const conversation = new PlanConversation(planConversationConfig(preset, conversationDeps, record.id, selectHarnessSessionDriver));
     await conversation.init();
 
     const nextMessageId = Math.max(0, ...record.messages.map((message) => message.id)) + 1;
@@ -1114,6 +1186,11 @@ export async function restorePlanningChatSessions(
       status: record.status,
       messages: [...record.messages],
       conversation,
+      repoUrl: record.repoUrl,
+      baseBranch: record.baseBranch,
+      baseCommit: record.baseCommit,
+      worktreePath: restoredWorktreePath ?? record.worktreePath,
+      worktreeBranch: record.worktreeBranch,
       draftPlanSummary: record.draftPlanSummary,
       draftPlanText: record.draftPlanText,
       submittedWorkflowId: record.submittedWorkflowId,

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -36,6 +36,7 @@ import {
   parseSpawnRepairWorkflowMutationArgs,
   SPAWN_REPAIR_WORKFLOW_CHANNEL,
   submitRepairWorkflowFromCiFailure,
+  type WorktreeExecutor,
 } from '@invoker/execution-engine';
 import type { AgentRegistry, WorkerRegistry, WorkerRuntimeDependencies } from '@invoker/execution-engine';
 import {
@@ -1271,6 +1272,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     planningSessionStore: ownerMode ? persistence : undefined,
     logger,
     onRawPlannerOutput: emitPlanningChatStream,
+    repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
   });
   let testPlanFromGoalResponse: { planYaml: string; planName: string } | null = null;
   // Two variants: (1) a successful override that returns a canned reply +
@@ -1308,6 +1310,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       planningSessionStore: ownerMode ? persistence : undefined,
       logger,
       onRawPlannerOutput: emitPlanningChatStream,
+      repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
     });
   });
   registerGuiMutationHandler('invoker:planning-chat-list', async () => {
@@ -1338,6 +1341,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       logger,
       plannerReplyOverride,
       onRawPlannerOutput: emitPlanningChatStream,
+      repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
     });
   });
   registerGuiMutationHandler('invoker:planning-chat-submit', async (request: unknown) => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1106,6 +1106,7 @@ function startHeadlessMode(): void {
         conversationRepo: planningConversationRepo,
         planningSessionStore: readOnlyMode ? undefined : persistence,
         logger,
+        repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
       });
 
       let testPlanningChatResponse:
@@ -1162,6 +1163,7 @@ function startHeadlessMode(): void {
               conversationRepo: planningConversationRepo,
               planningSessionStore: readOnlyMode ? undefined : persistence,
               logger,
+              repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
             });
           }
           case 'invoker:planning-chat-list': {
@@ -1191,6 +1193,7 @@ function startHeadlessMode(): void {
               planningSessionStore: readOnlyMode ? undefined : persistence,
               logger,
               plannerReplyOverride,
+              repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
             });
           }
           case 'invoker:planning-chat-submit': {

--- a/packages/app/src/planning-chat-worktree.ts
+++ b/packages/app/src/planning-chat-worktree.ts
@@ -1,0 +1,103 @@
+import { existsSync } from 'node:fs';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { AcquiredWorktree, RepoPool } from '@invoker/execution-engine';
+
+const execFileAsync = promisify(execFile);
+
+const PLANNING_WORKTREE_INSTALL_TIMEOUT_MS = 120_000;
+
+export type PlanningRepoPool = Pick<
+  RepoPool,
+  'ensureCloneThroughRepoQueue' | 'resolveBaseCommit' | 'acquireWorktree' | 'externalWorktreePath'
+>;
+
+export function resolvePlanningWorktreeBranch(sessionId: string): string {
+  return `invoker/planning/${sessionId}`;
+}
+
+export interface PlanningWorktreeBinding {
+  repoUrl: string;
+  baseBranch: string;
+  sessionId: string;
+}
+
+export interface ProvisionedPlanningWorktree {
+  worktreePath: string;
+  baseCommit: string;
+  branch: string;
+}
+
+export interface PlanningWorktreeState {
+  repoUrl: string;
+  baseCommit: string;
+  sessionId: string;
+  worktreePath?: string;
+}
+
+async function runBestEffortInstall(worktreePath: string): Promise<void> {
+  try {
+    await execFileAsync('pnpm', ['install', '--frozen-lockfile'], {
+      cwd: worktreePath,
+      timeout: PLANNING_WORKTREE_INSTALL_TIMEOUT_MS,
+    });
+  } catch (error) {
+    console.warn(
+      `[planning-chat-worktree] pnpm install --frozen-lockfile failed in ${worktreePath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
+async function acquireProvisionAndSoftRelease(
+  pool: Pick<PlanningRepoPool, 'acquireWorktree'>,
+  repoUrl: string,
+  branch: string,
+  baseCommit: string,
+  sessionId: string,
+): Promise<AcquiredWorktree> {
+  const acquired = await pool.acquireWorktree(repoUrl, branch, baseCommit, sessionId);
+  await runBestEffortInstall(acquired.worktreePath);
+  // A planning-chat worktree lives for the whole chat session, not a single task run,
+  // so it must not hold one of RepoPool's limited concurrent-worktree slots the whole time.
+  acquired.softRelease();
+  return acquired;
+}
+
+export async function provisionPlanningWorktree(
+  pool: PlanningRepoPool,
+  binding: PlanningWorktreeBinding,
+): Promise<ProvisionedPlanningWorktree> {
+  const { repoUrl, baseBranch, sessionId } = binding;
+  await pool.ensureCloneThroughRepoQueue(repoUrl);
+  const baseCommit = await pool.resolveBaseCommit(repoUrl, baseBranch);
+  const branch = resolvePlanningWorktreeBranch(sessionId);
+  const acquired = await acquireProvisionAndSoftRelease(pool, repoUrl, branch, baseCommit, sessionId);
+  return { worktreePath: acquired.worktreePath, baseCommit, branch };
+}
+
+export async function ensurePlanningWorktreeReady(
+  pool: PlanningRepoPool,
+  state: PlanningWorktreeState,
+): Promise<{ worktreePath: string; recreated: boolean }> {
+  const branch = resolvePlanningWorktreeBranch(state.sessionId);
+  const expectedPath = pool.externalWorktreePath(state.repoUrl, branch);
+  if (existsSync(expectedPath)) {
+    return { worktreePath: expectedPath, recreated: false };
+  }
+  await pool.ensureCloneThroughRepoQueue(state.repoUrl);
+  // Recreate at the previously-resolved commit, not a freshly resolved HEAD, so a
+  // disk-headroom wipe restores exactly what was there rather than silently rebasing.
+  const acquired = await acquireProvisionAndSoftRelease(pool, state.repoUrl, branch, state.baseCommit, state.sessionId);
+  return { worktreePath: acquired.worktreePath, recreated: true };
+}
+
+export async function releasePlanningWorktree(
+  pool: Pick<PlanningRepoPool, 'acquireWorktree'>,
+  state: { repoUrl: string; baseCommit: string; sessionId: string },
+): Promise<void> {
+  const branch = resolvePlanningWorktreeBranch(state.sessionId);
+  const acquired = await pool.acquireWorktree(state.repoUrl, branch, state.baseCommit, state.sessionId);
+  await acquired.release();
+}

--- a/packages/app/src/planning-chat-worktree.ts
+++ b/packages/app/src/planning-chat-worktree.ts
@@ -59,8 +59,6 @@ async function acquireProvisionAndSoftRelease(
 ): Promise<AcquiredWorktree> {
   const acquired = await pool.acquireWorktree(repoUrl, branch, baseCommit, sessionId);
   await runBestEffortInstall(acquired.worktreePath);
-  // A planning-chat worktree lives for the whole chat session, not a single task run,
-  // so it must not hold one of RepoPool's limited concurrent-worktree slots the whole time.
   acquired.softRelease();
   return acquired;
 }
@@ -87,8 +85,6 @@ export async function ensurePlanningWorktreeReady(
     return { worktreePath: expectedPath, recreated: false };
   }
   await pool.ensureCloneThroughRepoQueue(state.repoUrl);
-  // Recreate at the previously-resolved commit, not a freshly resolved HEAD, so a
-  // disk-headroom wipe restores exactly what was there rather than silently rebasing.
   const acquired = await acquireProvisionAndSoftRelease(pool, state.repoUrl, branch, state.baseCommit, state.sessionId);
   return { worktreePath: acquired.worktreePath, recreated: true };
 }


### PR DESCRIPTION
## Summary

Completes worktree provisioning: the Electron GUI-owner dispatch in `gui-mutation-handlers.ts` now passes `repoPool` the same way the standalone dispatch already does.

## Review Claim

Confirm the GUI dispatch path resolves `repoPool` identically to the standalone path.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Both dispatch paths now resolve `repoPool` from the same `executorRegistry.get('worktree')` source, so create/restore/send behave identically regardless of which owner mode is active.

## Slice Rationale

Kept separate from the provisioning core slice because this PR only wires the Electron GUI dispatch path.

## Non-goals

Does not change any provisioning logic itself. That landed in the previous slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts src/__tests__/gui-mutation-translation.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>