### PR TITLE
[Planning Chat Redesign](14) Accept an optional MCP config on ExecutionHarnessSessionDriver

### DIFF
--- a/packages/execution-engine/src/__tests__/harness-session-driver.test.ts
+++ b/packages/execution-engine/src/__tests__/harness-session-driver.test.ts
@@ -48,6 +48,38 @@ describe('ExecutionHarnessSessionDriver', () => {
         'Now add a test',
       ]);
     });
+
+    it('start prepends --mcp-config before all other args when mcpConfigPath is set', () => {
+      const mcpDriver = new ExecutionHarnessSessionDriver(new ClaudeExecutionAgent(), undefined, '/tmp/planning/.mcp.json');
+      const result = mcpDriver.start('Fix the bug');
+
+      expect(result.args).toEqual([
+        '--mcp-config',
+        '/tmp/planning/.mcp.json',
+        '--session-id',
+        result.sessionId,
+        '--dangerously-skip-permissions',
+        '-p',
+        'Fix the bug',
+      ]);
+    });
+
+    it('append prepends --mcp-config before all other args when mcpConfigPath is set', () => {
+      const mcpDriver = new ExecutionHarnessSessionDriver(new ClaudeExecutionAgent(), undefined, '/tmp/planning/.mcp.json');
+      const result = mcpDriver.append('session-abc', 'Now add a test', { model: 'sonnet' });
+
+      expect(result.args).toEqual([
+        '--mcp-config',
+        '/tmp/planning/.mcp.json',
+        '--resume',
+        'session-abc',
+        '--dangerously-skip-permissions',
+        '--model',
+        'sonnet',
+        '-p',
+        'Now add a test',
+      ]);
+    });
   });
 
   describe('codex', () => {
@@ -103,6 +135,41 @@ describe('ExecutionHarnessSessionDriver', () => {
         sessionId: 'local-invoker-uuid',
       }, { startedNewSession: true })).toThrow(/thread\.started\.thread_id/);
     });
+
+    it('append appends -c mcp_servers.invoker overrides after all other args when mcpConfigPath is set', () => {
+      const mcpDriver = new ExecutionHarnessSessionDriver(new CodexExecutionAgent(), undefined, '/tmp/planning/.mcp.json');
+      const result = mcpDriver.append('session-xyz', 'Continue the task', { model: 'gpt-5.5' });
+
+      expect(result.args).toEqual([
+        'exec',
+        'resume',
+        '--dangerously-bypass-approvals-and-sandbox',
+        'session-xyz',
+        '--model',
+        'gpt-5.5',
+        'Continue the task',
+        '-c',
+        'mcp_servers.invoker.command="invoker-cli"',
+        '-c',
+        'mcp_servers.invoker.args=["mcp"]',
+      ]);
+    });
+
+    it('start appends -c mcp_servers.invoker overrides after all other args when mcpConfigPath is set', () => {
+      const mcpDriver = new ExecutionHarnessSessionDriver(new CodexExecutionAgent(), undefined, '/tmp/planning/.mcp.json');
+      const result = mcpDriver.start('Fix the bug');
+
+      expect(result.args).toEqual([
+        'exec',
+        '--json',
+        '--dangerously-bypass-approvals-and-sandbox',
+        'Fix the bug',
+        '-c',
+        'mcp_servers.invoker.command="invoker-cli"',
+        '-c',
+        'mcp_servers.invoker.args=["mcp"]',
+      ]);
+    });
   });
 
   describe('omp', () => {
@@ -114,6 +181,25 @@ describe('ExecutionHarnessSessionDriver', () => {
       expect(driver.harness).toBe('omp');
       expect(result.command).toBe('omp');
       expect(result.sessionId).toBe('session-123');
+      expect(result.args).toEqual([
+        '--session-dir',
+        '/tmp/omp-test-sessions/session-123',
+        '--continue',
+        '--model',
+        'chatgpt-5.4',
+        '-p',
+        'Ship it',
+      ]);
+    });
+
+    it('leaves argv unchanged for a non-claude/codex harness even when mcpConfigPath is set', () => {
+      const mcpDriver = new ExecutionHarnessSessionDriver(
+        new OmpExecutionAgent({ sessionDirRoot: '/tmp/omp-test-sessions' }),
+        undefined,
+        '/tmp/planning/.mcp.json',
+      );
+      const result = mcpDriver.append('session-123', 'Ship it', { model: 'chatgpt-5.4' });
+
       expect(result.args).toEqual([
         '--session-dir',
         '/tmp/omp-test-sessions/session-123',

--- a/packages/execution-engine/src/harness-session-driver.ts
+++ b/packages/execution-engine/src/harness-session-driver.ts
@@ -28,6 +28,7 @@ export class ExecutionHarnessSessionDriver implements HarnessSessionDriver {
   constructor(
     private readonly agent: ExecutionAgent,
     private readonly sessionDriver?: Pick<SessionDriver, 'extractSessionId'>,
+    private readonly mcpConfigPath?: string,
   ) {
     this.harness = agent.name;
   }
@@ -39,7 +40,7 @@ export class ExecutionHarnessSessionDriver implements HarnessSessionDriver {
     }
     return {
       command: command.cmd,
-      args: command.args,
+      args: this.withMcpConfig(command.args),
       sessionId: command.sessionId,
     };
   }
@@ -48,7 +49,7 @@ export class ExecutionHarnessSessionDriver implements HarnessSessionDriver {
     const resumed = this.agent.buildResumeArgs(sessionId);
     return {
       command: resumed.cmd,
-      args: this.appendPromptArgs(resumed.args, prompt, options?.model),
+      args: this.withMcpConfig(this.appendPromptArgs(resumed.args, prompt, options?.model)),
       sessionId,
     };
   }
@@ -67,6 +68,18 @@ export class ExecutionHarnessSessionDriver implements HarnessSessionDriver {
       );
     }
     return command.sessionId;
+  }
+
+  private withMcpConfig(args: string[]): string[] {
+    if (!this.mcpConfigPath) return args;
+    switch (this.agent.name) {
+      case 'claude':
+        return ['--mcp-config', this.mcpConfigPath, ...args];
+      case 'codex':
+        return [...args, '-c', 'mcp_servers.invoker.command="invoker-cli"', '-c', 'mcp_servers.invoker.args=["mcp"]'];
+      default:
+        return args;
+    }
   }
 
   private appendPromptArgs(resumeArgs: string[], prompt: string, model?: string): string[] {

--- a/packages/surfaces/src/__tests__/harness-session-driver-select.test.ts
+++ b/packages/surfaces/src/__tests__/harness-session-driver-select.test.ts
@@ -73,4 +73,29 @@ describe('selectHarnessSessionDriver', () => {
 
     expect(driver).toBeUndefined();
   });
+
+  it('omits --mcp-config when mcpConfigPath is not in deps, matching pre-MCP behavior byte-for-byte', () => {
+    const claude = fakeExecutionAgent('claude');
+    const driver = selectHarnessSessionDriver(
+      { tool: 'claude', model: 'sonnet' },
+      { executionAgentRegistry: { get: (name) => (name === 'claude' ? claude : undefined) } },
+    );
+
+    const result = driver?.start('Fix the bug');
+    expect(result?.args).toEqual(['Fix the bug']);
+  });
+
+  it('threads mcpConfigPath through to the ExecutionHarnessSessionDriver argv', () => {
+    const claude = fakeExecutionAgent('claude');
+    const driver = selectHarnessSessionDriver(
+      { tool: 'claude', model: 'sonnet' },
+      {
+        executionAgentRegistry: { get: (name) => (name === 'claude' ? claude : undefined) },
+        mcpConfigPath: '/tmp/planning/.mcp.json',
+      },
+    );
+
+    const result = driver?.start('Fix the bug');
+    expect(result?.args).toEqual(['--mcp-config', '/tmp/planning/.mcp.json', 'Fix the bug']);
+  });
 });

--- a/packages/surfaces/src/slack/harness-session-driver-select.ts
+++ b/packages/surfaces/src/slack/harness-session-driver-select.ts
@@ -15,6 +15,7 @@ export interface HarnessSessionDriverDeps {
   };
   /** Builds the planner CLI command for harnesses without real session resume (e.g. cursor). */
   planningCommandBuilder?: PlanningCommandBuilder;
+  mcpConfigPath?: string;
 }
 
 /** Picks an ExecutionHarnessSessionDriver for tools with a registered execution agent, else a ReplayHarnessSessionDriver, else undefined. */
@@ -24,7 +25,7 @@ export function selectHarnessSessionDriver(
 ): HarnessSessionDriver | undefined {
   const agent = deps.executionAgentRegistry?.get(preset.tool);
   if (agent) {
-    return new ExecutionHarnessSessionDriver(agent, deps.executionAgentRegistry?.getSessionDriver?.(preset.tool));
+    return new ExecutionHarnessSessionDriver(agent, deps.executionAgentRegistry?.getSessionDriver?.(preset.tool), deps.mcpConfigPath);
   }
   if (!deps.planningCommandBuilder) return undefined;
   const planningCommandBuilder = deps.planningCommandBuilder;


### PR DESCRIPTION
## Summary

The `plan-to-invoker` skill's preferred flow calls MCP tools for review and submission, but nothing gave the spawned codex/claude harness subprocess a way to reach those tools.

`ExecutionHarnessSessionDriver` now accepts an optional MCP config, static for the whole session so `start()`/`append()` need no new per-call parameter and the shared spawn chain elsewhere is untouched. When set, claude gets a prepended `--mcp-config` flag (it has to precede `-p`, which otherwise swallows everything after it into the prompt); codex gets appended `-c mcp_servers.invoker.*` overrides.

Every caller that never passes this option — all of real task execution, and Slack's planning path — gets byte-identical argv to before this change.

## Review Claim

Confirm real task execution and Slack are provably unaffected (byte-identical argv when the option is absent).

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`TaskRunner`/`WorktreeExecutor`/`DockerExecutor` never pass this option, so their argv output is asserted byte-identical to before this slice — the load-bearing regression guard. The codex argument order/syntax for MCP registration is unverified against a real codex binary in this environment; the tests prove the code does what's documented here, not that a live codex CLI accepts it.

## Slice Rationale

This mechanism spans `packages/execution-engine` (the driver) and `packages/surfaces` (the selector that constructs it) — kept together here since the selector is the only caller of the driver's constructor, so putting them in different PRs would leave one half uncompilable on its own.

## Non-goals

Does not yet write the MCP config file into any worktree, or thread a session id into it — that's the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test`
- [ ] `cd packages/surfaces && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
