### PR TITLE
[Planning Chat Redesign](16) Add a session-scoped planning-chat-session read kind and env var

### DIFF
--- a/packages/app/src/__tests__/owner-headless-query.test.ts
+++ b/packages/app/src/__tests__/owner-headless-query.test.ts
@@ -21,6 +21,7 @@ function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQuer
     listWorkflows: vi.fn(() => []),
     loadWorkflowBundle: vi.fn(() => ({ workflow: null, tasks: [] })),
     getReviewGate: vi.fn(() => null),
+    getPlanningChatSession: vi.fn(() => null),
     getEvents: vi.fn(() => []),
     getTaskById: vi.fn(() => null),
     getTaskOutput: vi.fn(() => ''),

--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -32,6 +32,7 @@ function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQuer
     listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
     loadWorkflowBundle: vi.fn((id: string) => ({ workflow: { id }, tasks: [] })),
     getReviewGate: vi.fn(() => ({ gate: true })),
+    getPlanningChatSession: vi.fn(() => ({ status: 'draft_ready' })),
     getEvents: vi.fn(() => [{ e: 1 }]),
     getTaskById: vi.fn((id: string) => ({ id })),
     getTaskOutput: vi.fn(() => 'output-text'),
@@ -91,6 +92,8 @@ describe('answerOwnerReadQuery', () => {
     expect(answerOwnerReadQuery({ kind: 'workflow', workflowId: 'wf-9' }, h)).toEqual({ workflow: { id: 'wf-9' }, tasks: [] });
     expect(h.loadWorkflowBundle).toHaveBeenCalledWith('wf-9');
     expect(answerOwnerReadQuery({ kind: 'review-gate', workflowId: 'wf-9' }, h)).toEqual({ reviewGate: { gate: true } });
+    expect(answerOwnerReadQuery({ kind: 'planning-chat-session', sessionId: 'sess-1' }, h)).toEqual({ session: { status: 'draft_ready' } });
+    expect(h.getPlanningChatSession).toHaveBeenCalledWith('sess-1');
     expect(answerOwnerReadQuery({ kind: 'events', taskId: 't-1', limit: 50, sortBy: 'desc' }, h)).toEqual({
       events: [{ e: 1 }],
     });
@@ -113,10 +116,12 @@ describe('answerOwnerReadQuery', () => {
       getTaskById: vi.fn(() => undefined),
       getReviewGate: vi.fn(() => undefined),
       getOutputTail: vi.fn(() => undefined),
+      getPlanningChatSession: vi.fn(() => undefined),
     });
     expect(answerOwnerReadQuery({ kind: 'task-by-id', taskId: 'x' }, h)).toEqual({ task: null });
     expect(answerOwnerReadQuery({ kind: 'review-gate', workflowId: 'x' }, h)).toEqual({ reviewGate: null });
     expect(answerOwnerReadQuery({ kind: 'output-tail', taskId: 'x' }, h)).toEqual({ tail: null });
+    expect(answerOwnerReadQuery({ kind: 'planning-chat-session', sessionId: 'x' }, h)).toEqual({ session: null });
   });
 
   it('calls onActivity once per query and rejects unknown kinds', () => {
@@ -134,6 +139,8 @@ describe('answerOwnerReadQuery', () => {
     expect(() => answerOwnerReadQuery({ kind: 'workflow' }, h)).toThrow(/workflowId/);
     expect(h.loadWorkflowBundle).not.toHaveBeenCalled();
     expect(() => answerOwnerReadQuery({ kind: 'review-gate' }, h)).toThrow(/workflowId/);
+    expect(() => answerOwnerReadQuery({ kind: 'planning-chat-session' }, h)).toThrow(/sessionId/);
+    expect(h.getPlanningChatSession).not.toHaveBeenCalled();
     expect(() => answerOwnerReadQuery({ kind: 'events' }, h)).toThrow(/taskId/);
     expect(() => answerOwnerReadQuery({ kind: 'task-by-id' }, h)).toThrow(/taskId/);
     expect(h.getEvents).not.toHaveBeenCalled();
@@ -185,6 +192,7 @@ describe('buildOwnerReadQueryHandlers', () => {
       orchestrator: { ...f.orchestrator, ...orch } as never,
       persistence: { ...f.persistence, ...persist } as never,
       getActionGraphSnapshot: () => ({ ag: 1 }),
+      getPlanningChatSession: (sessionId: string) => ({ sessionId }),
     });
   }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1771,6 +1771,16 @@ function startHeadlessMode(): void {
             persistence,
             getActionGraphSnapshot: () =>
               buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig }) as unknown as Record<string, unknown>,
+            getPlanningChatSession: (sessionId: string) => {
+              const session = planningChatSessions.get(sessionId);
+              if (!session) return null;
+              return {
+                draftPlanText: session.draftPlanText,
+                draftPlanSummary: session.draftPlanSummary,
+                confirmationMode: session.confirmationMode,
+                status: session.status,
+              };
+            },
           }), {
             orchestrator,
             persistence,
@@ -2816,6 +2826,16 @@ startMainProcessBootstrap({
           persistence,
           getActionGraphSnapshot: () =>
             buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig }) as unknown as Record<string, unknown>,
+          getPlanningChatSession: (sessionId: string) => {
+            const session = planningChatSessions.get(sessionId);
+            if (!session) return null;
+            return {
+              draftPlanText: session.draftPlanText,
+              draftPlanSummary: session.draftPlanSummary,
+              confirmationMode: session.confirmationMode,
+              status: session.status,
+            };
+          },
         }), {
           orchestrator,
           persistence,

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -47,6 +47,7 @@ export interface OwnerReadQueryHandlers {
   listWorkflows: () => unknown[];
   loadWorkflowBundle: (workflowId: string) => Record<string, unknown>;
   getReviewGate: (workflowId: string) => unknown;
+  getPlanningChatSession: (sessionId: string) => unknown;
   getEvents: (taskId: string, options: GetEventsOptions) => unknown[];
   getTaskById: (taskId: string) => unknown;
   getTaskOutput: (taskId: string) => string;
@@ -66,6 +67,7 @@ export function answerOwnerReadQuery(
     reset?: boolean;
     workflowId?: string;
     taskId?: string;
+    sessionId?: string;
     fromOffset?: number;
     workerKind?: string;
     decision?: string;
@@ -133,6 +135,8 @@ export function answerOwnerReadQuery(
       return handlers.loadWorkflowBundle(requiredString(body.workflowId, 'workflowId'));
     case 'review-gate':
       return { reviewGate: handlers.getReviewGate(requiredString(body.workflowId, 'workflowId')) ?? null };
+    case 'planning-chat-session':
+      return { session: handlers.getPlanningChatSession(requiredString(body.sessionId, 'sessionId')) ?? null };
     case 'events': {
       const options: GetEventsOptions = body.options ?? {
         limit: body.limit as number,
@@ -219,6 +223,7 @@ export interface OwnerReadQueryDeps {
   persistence: ReadPersistence;
   /** App-level action-graph projection (needs invokerConfig, which lives in the app). */
   getActionGraphSnapshot: () => Record<string, unknown>;
+  getPlanningChatSession: (sessionId: string) => unknown;
 }
 
 /** Build the handler set both owners pass to {@link answerOwnerReadQuery}. */
@@ -258,6 +263,7 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
       if (!workflow) return null;
       return buildReviewGateQueryResponse({ workflowId, workflow, tasks: persistence.loadTasks(workflowId) });
     },
+    getPlanningChatSession: deps.getPlanningChatSession,
     getEvents: (taskId: string, options: GetEventsOptions) =>
       getEventsPage(persistence, taskId, options),
     getTaskById: (taskId: string) => {

--- a/packages/app/src/planning-chat-worktree.ts
+++ b/packages/app/src/planning-chat-worktree.ts
@@ -55,11 +55,16 @@ export function planningMcpConfigPath(worktreePath: string): string {
   return join(worktreePath, '.mcp.json');
 }
 
-export function writePlanningMcpConfig(worktreePath: string): void {
+export function writePlanningMcpConfig(worktreePath: string, sessionId: string): void {
   try {
     writeFileSync(planningMcpConfigPath(worktreePath), JSON.stringify({
       mcpServers: {
-        invoker: { type: 'stdio', command: 'invoker-cli', args: ['mcp'] },
+        invoker: {
+          type: 'stdio',
+          command: 'invoker-cli',
+          args: ['mcp'],
+          env: { INVOKER_PLANNING_SESSION_ID: sessionId },
+        },
       },
     }, null, 2), 'utf8');
   } catch (error) {
@@ -80,7 +85,7 @@ async function acquireProvisionAndSoftRelease(
 ): Promise<AcquiredWorktree> {
   const acquired = await pool.acquireWorktree(repoUrl, branch, baseCommit, sessionId);
   await runBestEffortInstall(acquired.worktreePath);
-  writePlanningMcpConfig(acquired.worktreePath);
+  writePlanningMcpConfig(acquired.worktreePath, sessionId);
   // A planning-chat worktree lives for the whole chat session, not a single task run,
   // so it must not hold one of RepoPool's limited concurrent-worktree slots the whole time.
   acquired.softRelease();


### PR DESCRIPTION
## Summary

`invoker_prepare_plan_review`/`invoker_submit_plan` (a later slice) need a way to read a planning-chat session's current draft state without opening the database directly.

This slice adds `getPlanningChatSession` and a new `planning-chat-session` read kind to the shared cross-process query dispatcher, returning the session's draft text, summary, confirmation mode, and status.

## Review Claim

Confirm the new read kind returns exactly the fields the MCP tools (next slice) need, sourced from the same in-memory session map every other planning-chat dispatch already uses.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Read-only; adds one new `case` to an existing switch and one new handler function, following the exact pattern already used by every sibling read kind.

## Slice Rationale

Kept separate from the MCP tool implementation (next slice) because the two packages involved classify under different review units in this repo's own taxonomy.

## Non-goals

Does not add the MCP tools that will call this read kind — that's the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Visual Proof

No visible UI change — this is a backend read-path addition. Screenshot below is regression proof from the same live-app capture run used elsewhere in this stack, confirming the planning terminal still renders and functions normally after this change:

![Planning terminal functions normally after this change](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-b520da/terminal-planned-conversation.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
