### PR TITLE
[Planning Chat Redesign](20) Surface worktree bind status and draft-lock state in the planning UI

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -453,6 +453,18 @@ function planningNeedsAttention(status: InAppPlanningSessionStatus): boolean {
   return status === 'waiting_for_answer' || status === 'draft_ready';
 }
 
+function planningRepoLabel(repoUrl: string): string {
+  const trimmed = repoUrl.trim().replace(/\.git$/, '');
+  const segments = trimmed.split(/[/:]/).filter(Boolean);
+  return segments.length >= 2 ? segments.slice(-2).join('/') : (segments.at(-1) ?? trimmed);
+}
+
+function planningRepoStatusText(repoUrl: string | undefined, baseCommit: string | undefined): string {
+  if (!repoUrl) return 'No repository bound yet';
+  const label = planningRepoLabel(repoUrl);
+  return baseCommit ? `${label} @ ${baseCommit.slice(0, 7)}` : label;
+}
+
 function previewPlanningMessage(session: PlanningSessionView): string {
   const last = [...session.messages].reverse().find((line) => line.role !== 'system') ?? session.messages.at(-1);
   return last?.text.replace(/\s+/g, ' ').trim() || 'No messages yet';
@@ -4531,6 +4543,9 @@ export function App() {
         {!planningContextCollapsed && (
           reviewingDraft ? (
             <div className="space-y-4 p-4 text-sm">
+              <p data-testid="planning-draft-locked-note" className="text-xs text-muted-foreground">
+                This draft is locked — critique in chat, or ask Invoker to re-draft, to change it.
+              </p>
               {draftTaskGroups.map((group, groupIndex) => (
                 <section key={`${group.workflow ?? 'plan'}-${groupIndex}`} data-testid="draft-task-group">
                   {group.workflow && <h3 className="text-xs font-medium text-foreground">{group.workflow}</h3>}
@@ -4595,6 +4610,12 @@ export function App() {
                   {activePlanningSession.title === 'Untitled plan'
                     ? 'Describe a goal in the chat to begin drafting.'
                     : activePlanningSession.title}
+                </p>
+              </div>
+              <div data-testid="planning-repo-status">
+                <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Repo</div>
+                <p className="mt-1 text-foreground">
+                  {planningRepoStatusText(activePlanningSession.repoUrl, activePlanningSession.baseCommit)}
                 </p>
               </div>
               {draftPlanSummary && (

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1298,6 +1298,75 @@ describe('Invoker terminal (component)', () => {
     expect(mock.api.startReady).not.toHaveBeenCalled();
   });
 
+  it('shows the bound repo and short commit sha in the planning context sidebar', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'repo-bound-session',
+          title: 'Repo bound chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+          baseBranch: 'main',
+          baseCommit: 'a1b2c3d4e5f6',
+        }),
+      ],
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+    fireEvent.click(screen.getByTestId('planning-context-toggle'));
+
+    const repoStatus = await screen.findByTestId('planning-repo-status');
+    expect(repoStatus).toHaveTextContent('Neko-Catpital-Labs/Invoker @ a1b2c3d');
+  });
+
+  it('shows "No repository bound yet" when the planning session has no repo bound', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'no-repo-session',
+          title: 'No repo chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          repoUrl: undefined,
+          baseBranch: undefined,
+          baseCommit: undefined,
+        }),
+      ],
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+    fireEvent.click(screen.getByTestId('planning-context-toggle'));
+
+    const repoStatus = await screen.findByTestId('planning-repo-status');
+    expect(repoStatus).toHaveTextContent('No repository bound yet');
+  });
+
+  it('shows a locked-draft note in the sidebar while reviewing a draft', async () => {
+    mock.api.planningChatSend = vi.fn(async () => ({
+      ok: true,
+      sessionId: 'session-1',
+      reply: 'Here is the plan.',
+      draftPlanAvailable: true,
+      draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First', 'Second'] },
+      draftPlanText: 'name: Mock Plan\ntasks: []\n',
+    })) as any;
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft the full plan');
+
+    expect(await screen.findByTestId('planning-draft-locked-note')).toHaveTextContent(
+      'This draft is locked — critique in chat, or ask Invoker to re-draft, to change it.',
+    );
+  });
+
   it('submits a draft and starts ready work when the user types submit', async () => {
     mock.api.planningChatSend = vi.fn(async () => ({
       ok: true,


### PR DESCRIPTION
## Summary

Every safety invariant in this stack (worktree isolation, draft immutability, repo-switch invalidation) is already enforced entirely in the app and domain layers, with no UI involved.

This slice only renders state that already exists: a "Repo" section in the planning context sidebar showing the bound repo name and short commit sha, or "No repository bound yet"; and a muted note while reviewing a draft that it's locked until discard, re-draft, or submit.

## Review Claim

Confirm the two new sidebar elements render the right content for both states (repo bound / not bound, reviewing a draft / not), and that a UI bug here cannot itself violate a safety invariant, since none of the actual enforcement lives in this layer.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Purely additive rendering over already-enforced domain state (populated in the previous slice). A bug here can misrepresent what the sidebar shows, but cannot itself let an ordinary chat turn mutate a draft or let a stale worktree binding survive a repo switch.

## Slice Rationale

Depends on the previous slice (the summary fields this renders); kept on its own because `packages/ui` classifies as its own review unit in this repo's taxonomy.

## Non-goals

Does not add any new domain logic, IPC call, or event handler — everything rendered here was already available on the session object once the previous slice landed.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Visual Proof

Real screenshots from a live Electron build via Playwright (`packages/app/e2e/visual-proof.spec.ts`), comparing this branch's rendering against `origin/master`'s for the same UI state. This is a static comparison of a newly-added element, not a multi-step flow.

**Repo bind status** — the sidebar's "REPO" section, absent on `origin/master`, showing "No repository bound yet" on this branch:

Prior state (`origin/master`, no Repo section):
![No Repo section on master](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-54458a/planning-repo-status-prior.png)

This branch — new "REPO" section reading "No repository bound yet":
![No Repo section on this branch](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-54458a/planning-repo-status-current.png)

**Draft-locked note** — the "Review draft" panel, with no lock notice on `origin/master`, and the new muted lock caption at the top on this branch:

Prior state (`origin/master`, no lock caption):
![No locked-draft note on master](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-54458a/planning-draft-locked-prior.png)

This branch — new caption "This draft is locked — critique in chat, or ask Invoker to re-draft, to change it.":
![Locked-draft note on this branch](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-54458a/planning-draft-locked-current.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added repository details to the planning context panel, including a readable repository name and shortened base commit.
  * Added a notice indicating when a draft plan is locked.
  * Added an empty state when no repository is connected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->