### PR TITLE
[E2E Master Regression Watcher](1) Expose an env-gated Playwright JSON reporter

### DIFF
--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -6,6 +6,7 @@ import { E2E_BROWSER_REGISTRY_ENV } from './e2e/fixtures/browser-process-registr
 
 const workers = Number(process.env.INVOKER_PLAYWRIGHT_WORKERS ?? (process.env.CI ? '1' : '2'));
 const retries = Number(process.env.INVOKER_PLAYWRIGHT_RETRIES ?? (process.env.CI ? '2' : '0'));
+const jsonOutputFile = process.env.INVOKER_PLAYWRIGHT_JSON_OUTPUT;
 process.env[E2E_BROWSER_REGISTRY_ENV] ??= path.join(
   mkdtempSync(path.join(tmpdir(), 'invoker-e2e-browser-registry-')),
   'user-data-dirs.txt',
@@ -18,6 +19,7 @@ export default defineConfig({
   timeout: 120000,
   retries: Number.isInteger(retries) && retries >= 0 ? retries : 0,
   workers: Number.isFinite(workers) && workers > 0 ? workers : 1,
+  reporter: jsonOutputFile ? [['line'], ['json', { outputFile: jsonOutputFile }]] : [['line']],
   snapshotPathTemplate: '{testDir}/__screenshots__/{testFileName}/{arg}{ext}',
   use: {
     trace: 'on-first-retry',


### PR DESCRIPTION
## Summary

The heavy Playwright e2e suite runs on every master push but isn't a required merge-queue check, since it's known to have some red tests already.

Nobody was systematically watching it, so a real regression could sit unnoticed among the known-flaky noise.

A later slice in this stack adds a worker that watches that suite and needs structured per-test results to know what actually failed. Today the suite only emits plain text.

This slice exposes those structured results as an opt-in reporter output, without changing anything for existing runs.

## Review Claim

Approve exposing an env-gated JSON reporter (`INVOKER_PLAYWRIGHT_JSON_OUTPUT`) alongside the existing line reporter in `packages/app/playwright.config.ts`, defaulting to today's line-only behavior when the variable is unset.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The reporter array is only replaced when `INVOKER_PLAYWRIGHT_JSON_OUTPUT` is set; every existing caller (local dev, current CI) leaves it unset and keeps the exact same `[['line']]` reporter as before.

## Slice Rationale

This repo's PR body validator classifies any `packages/**` file outside test/benchmark paths as product scope, which cannot ship in the same PR as `scripts/**` policy changes. This is the smallest possible foundation slice: the flag, with nothing consuming it yet (slice 2 wires it into CI and a consumer).

## Non-goals

Does not wire this reporter into CI or any consumer. Does not change output for any existing run.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && INVOKER_PLAYWRIGHT_JSON_OUTPUT=/tmp/pw-check.json pnpm exec playwright test --output /tmp/pw-check-results e2e/command-palette-open.spec.ts && test -s /tmp/pw-check.json`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
