### PR TITLE
[E2E Master Regression Watcher](3) Add e2e-master-regression plan formula

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -730,8 +730,8 @@ jobs:
           INVOKER_PLAYWRIGHT_ARGS: --reporter=line
         run: bash scripts/test-suites/optional/40-playwright-app.sh
 
-      - name: Upload Playwright artifacts on failure
-        if: failure()
+      - name: Upload Playwright artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-artifacts-${{ matrix.name }}

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -6,6 +6,7 @@ import { E2E_BROWSER_REGISTRY_ENV } from './e2e/fixtures/browser-process-registr
 
 const workers = Number(process.env.INVOKER_PLAYWRIGHT_WORKERS ?? (process.env.CI ? '1' : '2'));
 const retries = Number(process.env.INVOKER_PLAYWRIGHT_RETRIES ?? (process.env.CI ? '2' : '0'));
+const jsonOutputFile = process.env.INVOKER_PLAYWRIGHT_JSON_OUTPUT;
 process.env[E2E_BROWSER_REGISTRY_ENV] ??= path.join(
   mkdtempSync(path.join(tmpdir(), 'invoker-e2e-browser-registry-')),
   'user-data-dirs.txt',
@@ -18,6 +19,7 @@ export default defineConfig({
   timeout: 120000,
   retries: Number.isInteger(retries) && retries >= 0 ? retries : 0,
   workers: Number.isFinite(workers) && workers > 0 ? workers : 1,
+  reporter: jsonOutputFile ? [['line'], ['json', { outputFile: jsonOutputFile }]] : [['line']],
   snapshotPathTemplate: '{testDir}/__screenshots__/{testFileName}/{arg}{ext}',
   use: {
     trace: 'on-first-retry',

--- a/scripts/cron-e2e-regression-watch.sh
+++ b/scripts/cron-e2e-regression-watch.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Cron entrypoint for the e2e master-regression watcher. Lock + log only;
+# all logic lives in scripts/e2e-regression-watch.mjs.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOCK="${INVOKER_E2E_WATCH_LOCK:-${TMPDIR:-/tmp}/invoker-e2e-regression-watch.lock}"
+
+log_line() {
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
+}
+
+if command -v flock >/dev/null 2>&1; then
+  exec 9>"$LOCK"
+  if ! flock -n 9; then
+    log_line "e2e-regression-watch already running; exiting"
+    exit 0
+  fi
+else
+  lockdir="${LOCK}.d"
+  if [ -d "$lockdir" ]; then
+    holder="$(cat "$lockdir/pid" 2>/dev/null || true)"
+    if [ -n "$holder" ] && ! kill -0 "$holder" 2>/dev/null; then
+      rm -rf "$lockdir" 2>/dev/null || true
+    fi
+  fi
+  if ! mkdir "$lockdir" 2>/dev/null; then
+    log_line "e2e-regression-watch already running; exiting"
+    exit 0
+  fi
+  printf '%s\n' "$$" > "$lockdir/pid"
+  # shellcheck disable=SC2064
+  trap 'rm -rf "'"$lockdir"'" 2>/dev/null || true' EXIT
+fi
+
+log_line "e2e-regression-watch sweep starting"
+if node "$REPO_ROOT/scripts/e2e-regression-watch.mjs"; then
+  log_line "e2e-regression-watch sweep finished"
+else
+  status=$?
+  log_line "e2e-regression-watch sweep failed (exit $status)"
+  exit "$status"
+fi

--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+// Watches the `playwright` job on master for new e2e regressions and files a
+// bug-fix Invoker plan for each one.
+//
+// Local state (~/.invoker/e2e-regression-watch/state.json) is a mutable
+// snapshot of "what's currently red and since when" — it is NOT a ledger of
+// fixes-in-flight. Whether a regression already has an open fix is always
+// answered by a live query against Invoker's workflow store
+// (liveQueryHasNonTerminalWork), never by anything cached here. GitHub
+// Actions has no "since when has this been red" API, so this state is the
+// only way to compute "is this a new regression" and "which commit did it
+// start at" — do not reach for cron-pr-lib.sh's ledger primitives here, they
+// solve a different problem (fix-in-flight dedup, which must stay live).
+import { execFileSync, execSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  appendFileSync,
+} from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = dirname(dirname(__filename));
+
+export const TARGET_REPO = process.env.INVOKER_GITHUB_TARGET_REPO ?? 'Neko-Catpital-Labs/Invoker';
+export const WORKFLOW_FILE = process.env.INVOKER_E2E_WATCH_WORKFLOW_FILE ?? 'ci.yml';
+export const CAP_PER_SWEEP = Number(process.env.INVOKER_E2E_WATCH_CAP ?? '3');
+export const FLAKY_DEBOUNCE_POLLS = 2;
+export const FLAKY_FILE_PATTERNS = [/-responsiveness\.spec\.ts$/, /visual.*\.spec\.ts$/, /^storm-scale-.*\.spec\.ts$/];
+export const TERMINAL_WORKFLOW_STATUSES = new Set(['completed', 'failed', 'closed']);
+export const MARKER_PREFIX = 'invoker-e2e-regression-watch: first-bad-sha=';
+
+const STATE_DIR = process.env.INVOKER_E2E_WATCH_STATE_DIR ?? join(homedir(), '.invoker', 'e2e-regression-watch');
+const STATE_FILE = join(STATE_DIR, 'state.json');
+const SWEEP_LOG_FILE = join(STATE_DIR, 'sweep-log.jsonl');
+
+// ---------------------------------------------------------------------------
+// Pure logic (no I/O) — exercised directly by scripts/repro/repro-e2e-regression-watch.mjs
+// ---------------------------------------------------------------------------
+
+export function isFlakyProneTest(file) {
+  const base = file.split('/').pop() ?? file;
+  return FLAKY_FILE_PATTERNS.some((re) => re.test(base));
+}
+
+export function buildTestId(file, titlePath) {
+  return `${file}::${titlePath.join(' > ')}`;
+}
+
+export function buildMarker(sha) {
+  return `${MARKER_PREFIX}${sha}`;
+}
+
+export function shortSha(sha) {
+  return sha.slice(0, 7);
+}
+
+// Playwright JSON reporter shape (verified against a real run of
+// packages/app's config): { config, suites[], errors[], stats }. Each
+// suites[] entry is a per-file suite; specs live either directly under it or
+// under nested suites[] (describe blocks). spec.tests[0].status is the
+// POST-RETRY outcome — 'expected' | 'unexpected' | 'flaky' | 'skipped' — not
+// the same as results[].status (per-attempt pass/fail/timedOut/...).
+// 'unexpected' is the only status that means "red after exhausting retries".
+export function parsePlaywrightJson(raw) {
+  const data = JSON.parse(raw);
+  const outcomes = new Map();
+  const walk = (suite, ancestorTitles) => {
+    for (const spec of suite.specs ?? []) {
+      const test = spec.tests?.[0];
+      if (!test) continue;
+      const titlePath = [...ancestorTitles, spec.title];
+      outcomes.set(buildTestId(spec.file, titlePath), {
+        file: spec.file,
+        line: spec.line,
+        title: spec.title,
+        status: test.status,
+      });
+    }
+    for (const child of suite.suites ?? []) {
+      walk(child, [...ancestorTitles, child.title]);
+    }
+  };
+  for (const suite of data.suites ?? []) walk(suite, []);
+  return outcomes;
+}
+
+export function loadEmptyState() {
+  return { schemaVersion: 1, lastProcessedRunId: 0, dayZero: null, failingTests: {} };
+}
+
+// Mutates and returns state.failingTests. Only reconciles testIds actually
+// present in `outcomes` this run — a test missing from outcomes (e.g. a
+// partial artifact download) is left untouched rather than assumed recovered.
+export function reconcileFailingSet(state, run, outcomes) {
+  const bootstrap = !state.dayZero;
+  if (bootstrap) {
+    state.dayZero = { establishedAtRunId: run.databaseId, establishedAt: run.createdAt };
+    state.failingTests = {};
+  }
+  for (const [testId, o] of outcomes) {
+    const failed = o.status === 'unexpected';
+    const existing = state.failingTests[testId];
+    if (failed) {
+      if (existing) {
+        existing.consecutiveFailingPolls += 1;
+      } else {
+        state.failingTests[testId] = {
+          file: o.file,
+          line: o.line,
+          firstBadSha: run.headSha,
+          firstBadRunId: run.databaseId,
+          consecutiveFailingPolls: 1,
+          origin: bootstrap ? 'day0-baseline' : 'regression',
+        };
+      }
+    } else if (existing) {
+      delete state.failingTests[testId];
+    }
+  }
+  return state.failingTests;
+}
+
+// Groups regression-origin failing tests by first-bad SHA (the root-cause
+// identity), applying the flaky-pattern debounce, sorted by blast radius desc.
+export function groupBySha(failingTests) {
+  const groups = new Map();
+  for (const [testId, info] of Object.entries(failingTests)) {
+    if (info.origin !== 'regression') continue;
+    if (isFlakyProneTest(info.file) && info.consecutiveFailingPolls < FLAKY_DEBOUNCE_POLLS) continue;
+    if (!groups.has(info.firstBadSha)) groups.set(info.firstBadSha, []);
+    groups.get(info.firstBadSha).push({ testId, ...info });
+  }
+  return Array.from(groups.entries())
+    .map(([sha, tests]) => ({ sha, tests }))
+    .sort((a, b) => b.tests.length - a.tests.length);
+}
+
+export function buildPlanVars(group, repoUrl) {
+  const sorted = [...group.tests].sort((a, b) => a.testId.localeCompare(b.testId));
+  const primary = sorted[0];
+  const short = shortSha(group.sha);
+  const primaryTitle = primary.testId.split('::')[1] ?? primary.testId;
+  const summary = sorted
+    .map((t) => `${t.file}:${t.line} - ${t.testId.split('::')[1] ?? t.testId}`)
+    .join('\n');
+  return {
+    repo_url: repoUrl,
+    base_branch: 'master',
+    sha: group.sha,
+    short_sha: short,
+    bug_slug: `e2e-regression-${short}`,
+    test_count: String(group.tests.length),
+    primary_file: primary.file,
+    primary_line: String(primary.line),
+    primary_title: primaryTitle,
+    verify_command: `pnpm --filter @invoker/app exec xvfb-run --auto-servernum playwright test ${primary.file}:${primary.line}`,
+    affected_tests_summary: summary,
+    marker: `<!-- ${buildMarker(group.sha)} -->`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// I/O
+// ---------------------------------------------------------------------------
+
+function runCommand(cmd, args, opts = {}) {
+  execFileSync(cmd, args, { stdio: 'inherit', cwd: REPO_ROOT, ...opts });
+}
+
+function ghJson(args) {
+  const raw = execFileSync('gh', args, { encoding: 'utf8', cwd: REPO_ROOT });
+  return JSON.parse(raw);
+}
+
+export function getRepoUrl() {
+  return execFileSync('git', ['remote', 'get-url', 'origin'], { encoding: 'utf8', cwd: REPO_ROOT }).trim();
+}
+
+export function listUnprocessedMasterRuns(lastProcessedRunId) {
+  const runs = ghJson([
+    'run', 'list', '--repo', TARGET_REPO, '--workflow', WORKFLOW_FILE,
+    '--branch', 'master', '--event', 'push', '--status', 'completed',
+    '--json', 'databaseId,headSha,createdAt', '--limit', '50',
+  ]);
+  return runs
+    .filter((r) => r.databaseId > lastProcessedRunId)
+    .sort((a, b) => a.databaseId - b.databaseId);
+}
+
+// Returns 'ran' (job completed, results expected), 'skipped' (upstream job
+// failed so playwright never ran), or 'missing' (job not found on this run).
+export function getPlaywrightJobConclusion(runId) {
+  const view = ghJson(['run', 'view', String(runId), '--repo', TARGET_REPO, '--json', 'jobs']);
+  const jobs = (view.jobs ?? []).filter((j) => typeof j.name === 'string' && j.name.startsWith('playwright /'));
+  if (jobs.length === 0) return 'missing';
+  if (jobs.some((j) => j.conclusion === 'skipped')) return 'skipped';
+  return 'ran';
+}
+
+function findResultsJsonFiles(root) {
+  const found = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else if (entry.name === 'results.json') found.push(p);
+    }
+  };
+  walk(root);
+  return found;
+}
+
+export function downloadAndParseShardResults(runId) {
+  const dir = mkdtempSync(join(tmpdir(), `invoker-e2e-watch-run-${runId}-`));
+  execFileSync('gh', ['run', 'download', String(runId), '--repo', TARGET_REPO, '--pattern', 'playwright-artifacts-*', '--dir', dir]);
+  const merged = new Map();
+  for (const file of findResultsJsonFiles(dir)) {
+    for (const [testId, outcome] of parsePlaywrightJson(readFileSync(file, 'utf8'))) {
+      merged.set(testId, outcome);
+    }
+  }
+  return merged;
+}
+
+function headlessQueryWorkflowsJson() {
+  return execSync(
+    `source "${join(REPO_ROOT, 'scripts', 'headless-lib.sh')}" && headless_query query workflows --output json`,
+    { shell: '/bin/bash', encoding: 'utf8', cwd: REPO_ROOT },
+  );
+}
+
+export function liveQueryHasNonTerminalWork(sha, queryFn = headlessQueryWorkflowsJson) {
+  const marker = buildMarker(sha);
+  const workflows = JSON.parse(queryFn());
+  return workflows.some(
+    (w) => !TERMINAL_WORKFLOW_STATUSES.has(w.status) && typeof w.description === 'string' && w.description.includes(marker),
+  );
+}
+
+export function fileBugfixPlan(group, opts = {}) {
+  const repoUrl = opts.repoUrl ?? getRepoUrl();
+  const vars = buildPlanVars(group, repoUrl);
+  const outDir = join(opts.outRoot ?? join(REPO_ROOT, 'plans', 'rendered'), vars.short_sha);
+  const varArgs = Object.entries(vars).flatMap(([k, v]) => ['--var', `${k}=${v}`]);
+  runCommand('bash', [join(REPO_ROOT, 'skills/plan-to-invoker/scripts/render-formula.sh'), 'e2e-master-regression', ...varArgs, '--out', outDir]);
+  const planPath = join(outDir, 'e2e-master-regression.yaml');
+  runCommand('bash', [join(REPO_ROOT, 'skills/plan-to-invoker/scripts/skill-doctor.sh'), planPath]);
+  runCommand('bash', [join(REPO_ROOT, 'submit-plan.sh'), planPath]);
+  return { planPath, vars };
+}
+
+export function loadState() {
+  if (!existsSync(STATE_FILE)) return loadEmptyState();
+  return JSON.parse(readFileSync(STATE_FILE, 'utf8'));
+}
+
+export function saveState(state) {
+  mkdirSync(STATE_DIR, { recursive: true });
+  writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+}
+
+export function appendSweepLog(entry) {
+  mkdirSync(STATE_DIR, { recursive: true });
+  appendFileSync(SWEEP_LOG_FILE, `${JSON.stringify({ ts: new Date().toISOString(), ...entry })}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+export async function main() {
+  const state = loadState();
+  const repoUrl = getRepoUrl();
+
+  const runs = listUnprocessedMasterRuns(state.lastProcessedRunId);
+  let runsProcessed = 0;
+  for (const run of runs) {
+    const conclusion = getPlaywrightJobConclusion(run.databaseId);
+    if (conclusion === 'ran') {
+      const outcomes = downloadAndParseShardResults(run.databaseId);
+      reconcileFailingSet(state, run, outcomes);
+      runsProcessed += 1;
+    }
+    state.lastProcessedRunId = run.databaseId;
+    saveState(state);
+  }
+
+  const groups = groupBySha(state.failingTests);
+  const toFile = [];
+  let groupsSkippedAlreadyAddressed = 0;
+  let groupsDeferredByCap = 0;
+  for (const group of groups) {
+    if (liveQueryHasNonTerminalWork(group.sha)) {
+      groupsSkippedAlreadyAddressed += 1;
+      continue;
+    }
+    if (toFile.length < CAP_PER_SWEEP) {
+      toFile.push(group);
+    } else {
+      groupsDeferredByCap += 1;
+    }
+  }
+
+  for (const group of toFile) {
+    fileBugfixPlan(group, { repoUrl });
+  }
+
+  appendSweepLog({
+    runsProcessed,
+    groupsFound: groups.length,
+    groupsFiled: toFile.length,
+    groupsSkippedAlreadyAddressed,
+    groupsDeferredByCap,
+  });
+}
+
+const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main().catch((err) => {
+    console.error('e2e-regression-watch: fatal error', err);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/install-e2e-regression-watch-cron.sh
+++ b/scripts/install-e2e-regression-watch-cron.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Install (or update) a cron job that runs every 15 minutes and watches the
+# playwright job on master for new e2e regressions.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORKER_SCRIPT="$REPO_ROOT/scripts/cron-e2e-regression-watch.sh"
+MARKER="# invoker-e2e-regression-watch"
+LOG_FILE="${HOME}/.invoker/e2e-regression-watch/cron.log"
+
+if [[ ! -x "$WORKER_SCRIPT" ]]; then
+  echo "ERROR: expected executable worker script at $WORKER_SCRIPT" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+CRON_LINE="*/15 * * * * bash '$WORKER_SCRIPT' >> '$LOG_FILE' 2>&1 $MARKER"
+
+TMP_CRON="$(mktemp -t invoker-cron.XXXXXX)"
+trap 'rm -f "$TMP_CRON"' EXIT
+
+if crontab -l >/dev/null 2>&1; then
+  crontab -l | grep -Fv "$MARKER" > "$TMP_CRON"
+else
+  : > "$TMP_CRON"
+fi
+
+printf '%s\n' "$CRON_LINE" >> "$TMP_CRON"
+crontab "$TMP_CRON"
+
+echo "Installed cron job:"
+echo "  $CRON_LINE"
+echo "Log file: $LOG_FILE"
+echo "Verify with: crontab -l | grep -F '$MARKER'"

--- a/scripts/test-suites/optional/40-playwright-app.sh
+++ b/scripts/test-suites/optional/40-playwright-app.sh
@@ -41,6 +41,7 @@ ARTIFACT_ROOT="$ROOT/.git/playwright-artifacts/$RUN_LABEL"
 mkdir -p "$ARTIFACT_ROOT"
 
 export INVOKER_E2E_BARE_REPO="${INVOKER_E2E_BARE_REPO:-/tmp/invoker-e2e-repo-${RUN_LABEL}.git}"
+export INVOKER_PLAYWRIGHT_JSON_OUTPUT="${INVOKER_PLAYWRIGHT_JSON_OUTPUT:-$ARTIFACT_ROOT/results.json}"
 
 exec pnpm --filter @invoker/app exec xvfb-run --auto-servernum playwright test \
   --output "$ARTIFACT_ROOT/test-results" \

--- a/scripts/uninstall-e2e-regression-watch-cron.sh
+++ b/scripts/uninstall-e2e-regression-watch-cron.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Remove the e2e master-regression watcher cron entry.
+set -euo pipefail
+
+MARKER="# invoker-e2e-regression-watch"
+TMP_CRON="$(mktemp -t invoker-cron-remove.XXXXXX)"
+trap 'rm -f "$TMP_CRON"' EXIT
+
+if crontab -l >/dev/null 2>&1; then
+  crontab -l | grep -Fv "$MARKER" > "$TMP_CRON"
+  crontab "$TMP_CRON"
+  echo "Removed cron entry (if present): $MARKER"
+else
+  echo "No crontab found for current user; nothing to remove."
+fi

--- a/skills/plan-to-invoker/formulas/e2e-master-regression/e2e-master-regression.workflow.yaml
+++ b/skills/plan-to-invoker/formulas/e2e-master-regression/e2e-master-regression.workflow.yaml
@@ -1,0 +1,83 @@
+name: "E2E regression: {{bug_slug}}"
+description: |
+  {{marker}}
+
+  {{test_count}} e2e test(s) first went red at master commit {{sha}}, all
+  grouped as one candidate root cause (highest blast-radius test:
+  {{primary_file}}:{{primary_line}} - {{primary_title}}). Full list:
+  {{affected_tests_summary}}
+
+  Filed automatically by the e2e master-regression watcher. The root cause is
+  not known at filing time; the fix task's prompt requires the executing
+  agent to reproduce, find the root cause, and only then implement the fix,
+  per CLAUDE.md's three-phase bug-fix policy.
+onFinish: pull_request
+mergeMode: external_review
+baseBranch: {{base_branch}}
+repoUrl: {{repo_url}}
+
+tasks:
+  - id: fix-{{bug_slug}}
+    description: |
+      Fix the e2e regression first observed at master commit {{sha}}.
+      Review claim: The change corrects the regression's root cause at its source, found during this task, with no unrelated edits.
+      Review lane: behavior
+      Safety invariant: All other behavior stays identical; only the path causing {{primary_file}}:{{primary_line}} to fail changes.
+      Slice rationale: One behavior slice: the regression's defect and its deterministic proof, nothing else.
+      Architectural effect: None expected; no new module boundaries or interfaces unless the root cause requires it.
+      Goal: Make `{{verify_command}}` pass by correcting the regression at its source.
+      Motivation: {{test_count}} previously-passing e2e test(s) started failing at commit {{sha}}; this is a real regression, not a pre-existing flake.
+      Alternative considerations: A local workaround in the test was rejected; the correction belongs at the source that regressed.
+      Implementation details: Root cause is unknown at filing time. Fix the defect once found; keep everything else identical.
+      Non-goals: No refactor, no new fields, no unrelated cleanup, no doc edits, no changes to {{primary_file}} itself unless the regression is in test setup.
+      Layer: app_regression
+      Feature state: active
+      Files:
+      - Unknown at filing time; determined during root-cause investigation below and reported before any file is modified.
+      Change types:
+      - Unknown at filing time: to be determined during root-cause investigation.
+      Acceptance criteria:
+      - `{{verify_command}}` exits 0 after the change.
+    prompt: |
+      Goal: Diagnose and fix a real e2e regression introduced at master commit
+      {{sha}}. {{test_count}} test(s) first went red at this exact commit,
+      grouped as one candidate root cause: {{affected_tests_summary}}
+      Review lane: behavior
+      Motivation: These tests passed before {{sha}} and started failing at
+      {{sha}}; this is a real regression that must be fixed at the root.
+      Alternative considerations: Do not edit the test to mask the symptom;
+      correct the root cause in product code unless the regression is
+      genuinely in test setup/fixtures.
+      Implementation details: Fix the root cause found in step 2 below; touch
+      nothing else.
+      Non-goals: No refactor, no new fields, no unrelated cleanup.
+      You are NOT given the root cause. Assume no prior context beyond this
+      task. Follow this repo's three-phase bug-fix policy (CLAUDE.md)
+      yourself, in order, and do not skip ahead. Step 1, reproduce: run
+      `{{verify_command}}` and confirm it currently fails; report the exact
+      observed vs. expected behavior. Step 2, debug and report: inspect what
+      changed at {{sha}} (`git show {{sha}}`, `git log {{sha}}~1..{{sha}}`)
+      and identify the root cause and the test gap that let it merge; report
+      both before touching code. Step 3, plan the fix: only after steps 1 and
+      2, implement the fix. Acceptance criteria: `{{verify_command}}` must
+      exit code 0 after your change; this is the expected pass condition.
+    dependencies: []
+
+  - id: verify-{{bug_slug}}
+    description: |
+      Run the shared repro/verify command proving the {{sha}} regression is fixed.
+      Review claim: `{{verify_command}}` passes only when the {{sha}} regression is fixed.
+      Review lane: proof
+      Safety invariant: The command is identical before and after the fix; it fails before and passes after.
+      Slice rationale: One proof slice: the deterministic verification only.
+      Architectural effect: None; adds no product behavior.
+      Goal: Deterministically prove the fix with a single command.
+      Motivation: A shared repro/verify guards against this regression recurring.
+      Alternative considerations: Manual verification was rejected as non-deterministic.
+      Implementation details: Execute `{{verify_command}}` as the terminal proof.
+      Non-goals: No product edits here; proof only.
+      Layer: e2e_regression
+      Feature state: active
+    command: "{{verify_command}}"
+    dependencies:
+      - fix-{{bug_slug}}

--- a/skills/plan-to-invoker/formulas/e2e-master-regression/formula.yaml
+++ b/skills/plan-to-invoker/formulas/e2e-master-regression/formula.yaml
@@ -1,0 +1,60 @@
+formula: e2e-master-regression
+version: 1
+description: >
+  File a bug-fix workflow for one or more e2e tests that all first went red at
+  the same master commit (one candidate root cause). Unlike the bugfix
+  formula, the filer does not supply a root-cause narrative: the fix task's
+  prompt instructs the executing agent to run CLAUDE.md's reproduce ->
+  debug/root-cause -> plan-the-fix policy itself before touching code.
+vars:
+  repo_url:
+    required: true
+    example: "git@github.com:Neko-Catpital-Labs/Invoker.git"
+    description: "Git remote for the repo where tasks run (git remote get-url origin)."
+  base_branch:
+    required: false
+    default: "master"
+    example: "master"
+    description: "Base branch for the workflow. Always current master, not the regressed SHA — the fix must land on top of today's code."
+  sha:
+    required: true
+    example: "abc123def456abc123def456abc123def456ab1"
+    description: "40-hex master commit where the regression first appeared. Investigative anchor for the agent (git show <sha>), not the worktree base."
+  short_sha:
+    required: true
+    example: "abc123d"
+    description: "Short form of sha, used in ids and file names."
+  bug_slug:
+    required: true
+    example: "e2e-regression-abc123d"
+    description: "Kebab-case identifier used in task ids and the plan name."
+  test_count:
+    required: true
+    example: "1"
+    description: "Number of tests that first went red at sha (one candidate root cause)."
+  primary_file:
+    required: true
+    example: "packages/app/e2e/foo.spec.ts"
+    description: "Repo-relative spec file of the highest-blast-radius affected test."
+  primary_line:
+    required: true
+    example: "12"
+    description: "Line number of the highest-blast-radius affected test within primary_file."
+  primary_title:
+    required: true
+    example: "does the thing"
+    description: "Test title of the highest-blast-radius affected test."
+  verify_command:
+    required: true
+    example: "pnpm --filter @invoker/app exec playwright test packages/app/e2e/foo.spec.ts:12"
+    description: "Shared repro/verify command; fails before the fix, passes after."
+  affected_tests_summary:
+    required: true
+    example: "packages/app/e2e/foo.spec.ts:12 - does the thing"
+    description: "Multi-line 'file:line - title' list, one per test in the group."
+  marker:
+    required: true
+    example: "<!-- invoker-e2e-regression-watch: first-bad-sha=abc123def456abc123def456abc123def456ab1 -->"
+    description: "Exact dedup marker line embedded as the first line of the plan description."
+workflows:
+  - e2e-master-regression.workflow.yaml


### PR DESCRIPTION
## Summary

The watcher added in slice 2 files a bug-fix Invoker plan for every new e2e regression it finds.

The existing `bugfix` formula assumes the author already knows the root cause, leaving `REPLACE_ME` lines for a human to fill in.

This slice adds a formula that does not assume a known root cause.

Its fix task's prompt requires the executing agent to reproduce, find the root cause, and only then implement the fix, per CLAUDE.md's three-phase bug-fix policy.

The existing `bugfix` formula is untouched.

## Review Claim

Approve the new `skills/plan-to-invoker/formulas/e2e-master-regression/` formula (`formula.yaml` + `e2e-master-regression.workflow.yaml`).

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This is a purely additive new directory under `skills/plan-to-invoker/formulas/`; it does not modify the existing `bugfix` formula or any other formula, and is not referenced by anything until the watcher (slice 2, already stacked below) calls it.

## Slice Rationale

This repo's PR body validator classifies `skills/**` files as the `docs` review unit, which cannot ship alongside `scripts/**`'s `tooling-policy` unit (slice 2) in the same PR.

## Non-goals

Does not modify the existing `bugfix` formula. Does not change `render-formula.mjs` or `skill-doctor.sh` themselves.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash skills/plan-to-invoker/scripts/render-formula.sh e2e-master-regression --example --out /tmp/e2e-formula-test && bash skills/plan-to-invoker/scripts/skill-doctor.sh /tmp/e2e-formula-test/e2e-master-regression.yaml` (all 6 checks pass, including strict-delegation atomicity lint and review-unit lint)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
