### PR TITLE
[Planning tmux blank guarded resize fix](2) Guard non-finite tmux resize geometry

### DIFF
--- a/packages/app/e2e/planning-tmux-blank-repro.spec.ts
+++ b/packages/app/e2e/planning-tmux-blank-repro.spec.ts
@@ -1,8 +1,9 @@
 import { writeFileSync } from 'node:fs';
-import type { ElectronApplication, Page } from '@playwright/test';
+import type { ElectronApplication, Page, TestInfo } from '@playwright/test';
 import { expect, test } from './fixtures/electron-app.js';
 
 type ReproMode = 'before' | 'after';
+type ResizeRecorderStrategy = 'page' | 'main-ipc';
 
 type ResizePayload = {
   sessionId: string;
@@ -15,53 +16,57 @@ type SttySizeSample = {
   rows: number;
   cols: number;
   raw: string;
+  tiny: boolean;
 };
 
 type ReproArtifact = {
   mode: ReproMode;
   sessionId: string;
+  resizeRecorderStrategy: ResizeRecorderStrategy;
   resizePayloads: ResizePayload[];
   outputSnapshotTail: string;
   sttySizeSamples: SttySizeSample[];
-  screenshotPaths: string[];
+  screenshotPaths: {
+    before: string;
+    after: string;
+  };
 };
 
-const MODE_ENV = 'INVOKER_PLANNING_TMUX_BLANK_EXPECT';
-const TINY_ROWS = 5;
-const TINY_COLS = 20;
-const OUTPUT_TAIL_CHARS = 5000;
+const MODE = parseMode(process.env.INVOKER_PLANNING_TMUX_BLANK_EXPECT);
+const TINY_ROW_LIMIT = 5;
+const TINY_COL_LIMIT = 20;
+const RESIZE_IPC_CHANNEL = 'invoker:planning-terminal-resize';
 
-function reproMode(): ReproMode {
-  const raw = process.env[MODE_ENV] ?? 'after';
-  if (raw === 'before' || raw === 'after') return raw;
-  throw new Error(`${MODE_ENV} must be "before" or "after"; received "${raw}"`);
+function parseMode(value: string | undefined): ReproMode {
+  if (value === undefined || value === '') return 'after';
+  if (value === 'before' || value === 'after') return value;
+  throw new Error(`INVOKER_PLANNING_TMUX_BLANK_EXPECT must be "before" or "after", got "${value}".`);
 }
 
-function isTinyResize(payload: Pick<ResizePayload, 'cols' | 'rows'>): boolean {
-  return payload.rows <= TINY_ROWS || payload.cols <= TINY_COLS;
-}
-
-function isTinySttySize(sample: Pick<SttySizeSample, 'cols' | 'rows'>): boolean {
-  return sample.rows <= TINY_ROWS || sample.cols <= TINY_COLS;
+function isTinyGeometry(size: Pick<ResizePayload, 'cols' | 'rows'>): boolean {
+  return size.rows <= TINY_ROW_LIMIT || size.cols <= TINY_COL_LIMIT;
 }
 
 function stripAnsi(value: string): string {
-  return value.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\))/g, '');
+  return value
+    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, '')
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '');
 }
 
-function parseSttySizeSamples(output: string): SttySizeSample[] {
-  const normalized = stripAnsi(output).replace(/\r/g, '\n');
+function parseSttySizeSamples(outputSnapshot: string): SttySizeSample[] {
+  const cleaned = stripAnsi(outputSnapshot).replace(/\r/g, '');
   const samples: SttySizeSample[] = [];
   const pattern = /TMUX_SIZE\s+(before|after)\s+(\d+)\s+(\d+)/g;
-  for (const match of normalized.matchAll(pattern)) {
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(cleaned)) !== null) {
     const rows = Number(match[2]);
     const cols = Number(match[3]);
-    if (!Number.isFinite(rows) || !Number.isFinite(cols)) continue;
     samples.push({
       label: match[1] as 'before' | 'after',
       rows,
       cols,
       raw: match[0],
+      tiny: isTinyGeometry({ rows, cols }),
     });
   }
   return samples;
@@ -72,68 +77,133 @@ async function openHome(page: Page): Promise<void> {
   await expect(page.getByTestId('invoker-terminal-input')).toBeVisible({ timeout: 10000 });
 }
 
-async function installResizeRecorder(electronApp: ElectronApplication): Promise<void> {
-  const installed = await electronApp.evaluate(({ ipcMain }) => {
-    type RecorderGlobal = typeof globalThis & {
-      __INVOKER_PLANNING_TMUX_BLANK_RESIZES__?: ResizePayload[];
-      __INVOKER_PLANNING_TMUX_BLANK_ORIGINAL_RESIZE_HANDLER__?: (
-        event: unknown,
-        sessionId: string,
-        cols: number,
-        rows: number,
-      ) => unknown;
-    };
-    const recorderGlobal = globalThis as RecorderGlobal;
-    const channel = 'invoker:planning-terminal-resize';
-    // contextBridge exposes window.invoker as immutable, so record the same payloads at the IPC boundary.
-    const invokeHandlers = (ipcMain as unknown as {
-      _invokeHandlers?: Map<string, (
-        event: unknown,
-        sessionId: string,
-        cols: number,
-        rows: number,
-      ) => unknown>;
-    })._invokeHandlers;
-    const original = recorderGlobal.__INVOKER_PLANNING_TMUX_BLANK_ORIGINAL_RESIZE_HANDLER__
-      ?? invokeHandlers?.get(channel);
-    if (!original) {
-      return { ok: false, reason: `No IPC handler registered for ${channel}` };
-    }
-
-    recorderGlobal.__INVOKER_PLANNING_TMUX_BLANK_RESIZES__ = [];
-    recorderGlobal.__INVOKER_PLANNING_TMUX_BLANK_ORIGINAL_RESIZE_HANDLER__ = original;
-    ipcMain.removeHandler(channel);
-    ipcMain.handle(channel, async (event, sessionId: string, cols: number, rows: number) => {
-      recorderGlobal.__INVOKER_PLANNING_TMUX_BLANK_RESIZES__?.push({
-        sessionId: String(sessionId),
-        cols: Number(cols),
-        rows: Number(rows),
-      });
-      return original(event, sessionId, cols, rows);
-    });
-
-    return { ok: true };
-  });
-  expect(installed, 'planning terminal resize IPC recorder must be installed').toMatchObject({ ok: true });
-}
-
-async function getResizePayloads(electronApp: ElectronApplication): Promise<ResizePayload[]> {
-  return electronApp.evaluate(() => {
-    const recorderGlobal = globalThis as typeof globalThis & {
-      __INVOKER_PLANNING_TMUX_BLANK_RESIZES__?: ResizePayload[];
-    };
-    return recorderGlobal.__INVOKER_PLANNING_TMUX_BLANK_RESIZES__ ?? [];
-  });
-}
-
-async function openPlanningTmux(page: Page): Promise<string> {
-  await page.getByTestId('invoker-terminal-mode-toggle').getByRole('tab', { name: 'Tmux' }).click();
+async function switchPlanningTerminalToTmux(page: Page): Promise<string> {
+  await page.getByTestId('invoker-terminal-mode-toggle').getByRole('tab', { name: /tmux/i }).click();
   const pane = page.getByTestId('invoker-terminal-tmux-pane');
   await expect(pane).toBeVisible({ timeout: 10000 });
   const sessionId = await pane.getAttribute('data-session-id');
   expect(sessionId).toBeTruthy();
   await expect.poll(async () => readOutputSnapshot(page, sessionId ?? ''), { timeout: 10000 }).toContain('Invoker planning tmux bridge');
   return sessionId ?? '';
+}
+
+async function installResizeRecorder(page: Page, electronApp: ElectronApplication): Promise<ResizeRecorderStrategy> {
+  const pageResult = await page.evaluate(() => {
+    const targetWindow = window as Window & {
+      __INVOKER_PLANNING_TMUX_BLANK_RESIZES__?: ResizePayload[];
+      __INVOKER_PLANNING_TMUX_BLANK_ORIGINAL_RESIZE__?: Window['invoker']['planningTerminalResize'];
+    };
+    const originalApi = window.invoker;
+    const original = originalApi.planningTerminalResize;
+    if (typeof original !== 'function') return { installed: false, strategy: 'missing-method' };
+    targetWindow.__INVOKER_PLANNING_TMUX_BLANK_RESIZES__ = [];
+    targetWindow.__INVOKER_PLANNING_TMUX_BLANK_ORIGINAL_RESIZE__ = original;
+    const wrapped = async (sessionId: string, cols: number, rows: number) => {
+      targetWindow.__INVOKER_PLANNING_TMUX_BLANK_RESIZES__?.push({ sessionId, cols, rows });
+      return original.call(originalApi, sessionId, cols, rows);
+    };
+    try {
+      window.invoker.planningTerminalResize = wrapped;
+      if (window.invoker.planningTerminalResize !== original) return { installed: true, strategy: 'method' };
+    } catch {
+      /* contextBridge freezes nested API members; fall back to replacing the top-level bridge. */
+    }
+
+    const windowDescriptor = Object.getOwnPropertyDescriptor(window, 'invoker');
+    const replacement = new Proxy(originalApi, {
+      get(target, prop, receiver) {
+        if (prop === 'planningTerminalResize') return wrapped;
+        return Reflect.get(target, prop, receiver);
+      },
+    }) as Window['invoker'];
+    try {
+      if (!windowDescriptor || windowDescriptor.configurable) {
+        Object.defineProperty(window, 'invoker', {
+          configurable: windowDescriptor?.configurable ?? true,
+          enumerable: windowDescriptor?.enumerable ?? true,
+          writable: true,
+          value: replacement,
+        });
+      } else if (windowDescriptor.writable) {
+        window.invoker = replacement;
+      }
+    } catch {
+      return {
+        installed: false,
+        strategy: 'failed',
+        windowDescriptor: windowDescriptor
+          ? {
+              configurable: windowDescriptor.configurable,
+              enumerable: windowDescriptor.enumerable,
+              writable: windowDescriptor.writable,
+            }
+          : null,
+        invokerFrozen: Object.isFrozen(originalApi),
+      };
+    }
+
+    return {
+      installed: window.invoker.planningTerminalResize !== original,
+      strategy: 'window-proxy',
+      windowDescriptor: windowDescriptor
+        ? {
+            configurable: windowDescriptor.configurable,
+            enumerable: windowDescriptor.enumerable,
+            writable: windowDescriptor.writable,
+          }
+        : null,
+      invokerFrozen: Object.isFrozen(originalApi),
+    };
+  });
+  if (pageResult.installed) return 'page';
+
+  const mainResult = await electronApp.evaluate(({ ipcMain }, channel) => {
+    const handlers = (ipcMain as unknown as { _invokeHandlers?: Map<string, unknown> })._invokeHandlers;
+    if (!(handlers instanceof Map)) {
+      return { installed: false, reason: 'ipcMain invoke handler map was not available' };
+    }
+    const original = handlers.get(channel);
+    if (typeof original !== 'function') {
+      return { installed: false, reason: `no invoke handler registered for ${channel}` };
+    }
+    const recorderGlobal = globalThis as typeof globalThis & {
+      __INVOKER_PLANNING_TMUX_BLANK_RESIZES__?: ResizePayload[];
+    };
+    recorderGlobal.__INVOKER_PLANNING_TMUX_BLANK_RESIZES__ = [];
+    ipcMain.removeHandler(channel);
+    ipcMain.handle(channel, async (event, sessionId: string, cols: number, rows: number) => {
+      recorderGlobal.__INVOKER_PLANNING_TMUX_BLANK_RESIZES__?.push({ sessionId, cols, rows });
+      return original(event, sessionId, cols, rows);
+    });
+    return { installed: true };
+  }, RESIZE_IPC_CHANNEL);
+
+  expect(
+    mainResult.installed,
+    `planningTerminalResize must be wrapped so the repro records IPC payloads: ${JSON.stringify({ pageResult, mainResult })}`,
+  ).toBe(true);
+  return 'main-ipc';
+}
+
+async function resizePayloads(
+  page: Page,
+  electronApp: ElectronApplication,
+  strategy: ResizeRecorderStrategy,
+): Promise<ResizePayload[]> {
+  if (strategy === 'main-ipc') {
+    return electronApp.evaluate(() => {
+      const recorderGlobal = globalThis as typeof globalThis & {
+        __INVOKER_PLANNING_TMUX_BLANK_RESIZES__?: ResizePayload[];
+      };
+      return recorderGlobal.__INVOKER_PLANNING_TMUX_BLANK_RESIZES__ ?? [];
+    });
+  }
+  return page.evaluate(() => {
+    const targetWindow = window as Window & {
+      __INVOKER_PLANNING_TMUX_BLANK_RESIZES__?: ResizePayload[];
+    };
+    return targetWindow.__INVOKER_PLANNING_TMUX_BLANK_RESIZES__ ?? [];
+  });
 }
 
 async function readOutputSnapshot(page: Page, sessionId: string): Promise<string> {
@@ -143,48 +213,60 @@ async function readOutputSnapshot(page: Page, sessionId: string): Promise<string
   }, sessionId);
 }
 
-async function writeSttyMarker(
-  page: Page,
-  sessionId: string,
-  label: 'before' | 'after',
-): Promise<void> {
-  const result = await page.evaluate(async ({ targetSessionId, markerLabel }) => {
-    return window.invoker.planningTerminalWrite(
-      targetSessionId,
-      `printf 'TMUX_SIZE ${markerLabel} '; stty size\n`,
-    );
-  }, { targetSessionId: sessionId, markerLabel: label });
+async function writePlanningTerminalCommand(page: Page, sessionId: string, command: string): Promise<void> {
+  const result = await page.evaluate(async ({ targetSessionId, data }) => {
+    return window.invoker.planningTerminalWrite(targetSessionId, data);
+  }, { targetSessionId: sessionId, data: `${command}\n` });
   expect(result).toMatchObject({ ok: true });
-  await expect.poll(async () => {
-    const output = await readOutputSnapshot(page, sessionId);
-    return parseSttySizeSamples(output).some((sample) => sample.label === label);
-  }, { timeout: 10000 }).toBe(true);
 }
 
-async function forceZeroSizeHost(page: Page): Promise<void> {
-  const observedResize = await page.evaluate(async () => {
-    const host = document.querySelector('[data-testid="invoker-terminal-tmux-pane"]');
-    if (!host) throw new Error('planning tmux pane was not found');
+async function waitForSttySample(page: Page, sessionId: string, label: 'before' | 'after'): Promise<void> {
+  const deadline = Date.now() + 10000;
+  while (Date.now() < deadline) {
+    const snapshot = await readOutputSnapshot(page, sessionId);
+    const samples = parseSttySizeSamples(snapshot);
+    if (samples.some((sample) => sample.label === label)) return;
+    await page.waitForTimeout(250);
+  }
+}
 
-    let resolveObserved: (value: boolean) => void = () => undefined;
-    const observedPromise = new Promise<boolean>((resolve) => {
-      resolveObserved = resolve;
-    });
-    let observer: ResizeObserver | null = null;
-    const timeout = window.setTimeout(() => {
-      observer?.disconnect();
-      resolveObserved(false);
-    }, 1000);
+async function waitForTinyResizePayload(
+  page: Page,
+  electronApp: ElectronApplication,
+  strategy: ResizeRecorderStrategy,
+  sessionId: string,
+): Promise<void> {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    const payloads = await resizePayloads(page, electronApp, strategy);
+    if (payloads.some((payload) => payload.sessionId === sessionId && isTinyGeometry(payload))) return;
+    await page.waitForTimeout(100);
+  }
+}
 
-    observer = new ResizeObserver(() => {
-      window.clearTimeout(timeout);
-      observer?.disconnect();
-      resolveObserved(true);
+async function forceZeroSizedTmuxHost(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const pane = document.querySelector<HTMLElement>('[data-testid="invoker-terminal-tmux-pane"]');
+    if (!pane) throw new Error('planning tmux pane was not mounted');
+
+    let resizeObserved = false;
+    const resizeObservedPromise = new Promise<void>((resolve) => {
+      const observer = new ResizeObserver(() => {
+        resizeObserved = true;
+        observer.disconnect();
+        requestAnimationFrame(() => resolve());
+      });
+      observer.observe(pane);
+      setTimeout(() => {
+        if (!resizeObserved) {
+          observer.disconnect();
+          resolve();
+        }
+      }, 500);
     });
-    observer.observe(host);
 
     const style = document.createElement('style');
-    style.setAttribute('data-testid', 'planning-tmux-zero-size-repro-style');
+    style.setAttribute('data-invoker-planning-tmux-blank-repro', 'zero-host');
     style.textContent = `
       [data-testid="invoker-terminal-tmux-pane"] {
         bottom: auto !important;
@@ -199,19 +281,47 @@ async function forceZeroSizeHost(page: Page): Promise<void> {
       }
     `;
     document.head.appendChild(style);
+    void pane.getBoundingClientRect();
 
     await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
-    const observed = await observedPromise;
+    await resizeObservedPromise;
     await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
-
-    const rect = host.getBoundingClientRect();
-    if (rect.width !== 0 || rect.height !== 0) {
-      throw new Error(`planning tmux pane did not collapse to 0x0; got ${rect.width}x${rect.height}`);
-    }
-    return observed;
   });
-  expect(observedResize, 'test ResizeObserver must observe the zero-size host transition').toBe(true);
-  await page.waitForTimeout(250);
+}
+
+async function screenshot(page: Page, testInfo: TestInfo, name: string): Promise<string> {
+  const screenshotPath = testInfo.outputPath(`${name}.png`);
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  await testInfo.attach(`${name}-screenshot`, { path: screenshotPath, contentType: 'image/png' });
+  return screenshotPath;
+}
+
+async function buildArtifact(
+  page: Page,
+  electronApp: ElectronApplication,
+  testInfo: TestInfo,
+  mode: ReproMode,
+  sessionId: string,
+  resizeRecorderStrategy: ResizeRecorderStrategy,
+  screenshotPaths: ReproArtifact['screenshotPaths'],
+): Promise<ReproArtifact> {
+  const outputSnapshot = await readOutputSnapshot(page, sessionId);
+  const artifact: ReproArtifact = {
+    mode,
+    sessionId,
+    resizeRecorderStrategy,
+    resizePayloads: await resizePayloads(page, electronApp, resizeRecorderStrategy),
+    outputSnapshotTail: stripAnsi(outputSnapshot).slice(-8000),
+    sttySizeSamples: parseSttySizeSamples(outputSnapshot),
+    screenshotPaths,
+  };
+  const artifactPath = testInfo.outputPath(`planning-tmux-blank-${mode}.json`);
+  writeFileSync(artifactPath, JSON.stringify(artifact, null, 2), 'utf8');
+  await testInfo.attach(`planning-tmux-blank-${mode}`, {
+    path: artifactPath,
+    contentType: 'application/json',
+  });
+  return artifact;
 }
 
 async function closePlanningTerminalSessions(page: Page): Promise<void> {
@@ -222,70 +332,63 @@ async function closePlanningTerminalSessions(page: Page): Promise<void> {
 }
 
 test.describe('Planning tmux blank geometry repro', () => {
-  test('records resize IPC and live PTY geometry across a zero-size planning tmux host', async ({ electronApp, page }, testInfo) => {
-    const mode = reproMode();
-    const screenshotPaths: string[] = [];
+  test('checks planning tmux resize IPC and PTY geometry during a zero-size host transition', async ({ electronApp, page }, testInfo) => {
+    let artifact: ReproArtifact | null = null;
     let sessionId = '';
-
+    let resizeRecorderStrategy: ResizeRecorderStrategy = 'page';
     try {
       await openHome(page);
-      await installResizeRecorder(electronApp);
-      sessionId = await openPlanningTmux(page);
+      sessionId = await switchPlanningTerminalToTmux(page);
+      resizeRecorderStrategy = await installResizeRecorder(page, electronApp);
 
-      const initialScreenshotPath = testInfo.outputPath(`planning-tmux-${mode}-initial.png`);
-      await page.screenshot({ path: initialScreenshotPath, fullPage: true });
-      screenshotPaths.push(initialScreenshotPath);
-      await testInfo.attach('planning-tmux-initial', { path: initialScreenshotPath, contentType: 'image/png' });
+      await writePlanningTerminalCommand(page, sessionId, "printf 'TMUX_SIZE before '; stty size");
+      await waitForSttySample(page, sessionId, 'before');
+      const beforeScreenshotPath = await screenshot(page, testInfo, 'planning-tmux-before-zero-host');
 
-      await writeSttyMarker(page, sessionId, 'before');
-      await forceZeroSizeHost(page);
-
-      if (mode === 'before') {
-        await expect.poll(async () => {
-          const payloads = await getResizePayloads(electronApp);
-          return payloads.filter((payload) => payload.sessionId === sessionId && isTinyResize(payload)).length;
-        }, { timeout: 10000 }).toBeGreaterThan(0);
-        await page.waitForTimeout(250);
+      await forceZeroSizedTmuxHost(page);
+      if (MODE === 'before') {
+        await waitForTinyResizePayload(page, electronApp, resizeRecorderStrategy, sessionId);
+      } else {
+        await page.waitForTimeout(750);
       }
 
-      const zeroSizeScreenshotPath = testInfo.outputPath(`planning-tmux-${mode}-zero-size.png`);
-      await page.screenshot({ path: zeroSizeScreenshotPath, fullPage: true });
-      screenshotPaths.push(zeroSizeScreenshotPath);
-      await testInfo.attach('planning-tmux-zero-size', { path: zeroSizeScreenshotPath, contentType: 'image/png' });
+      await writePlanningTerminalCommand(page, sessionId, "printf 'TMUX_SIZE after '; stty size");
+      await waitForSttySample(page, sessionId, 'after');
+      const afterScreenshotPath = await screenshot(page, testInfo, 'planning-tmux-after-zero-host');
 
-      await writeSttyMarker(page, sessionId, 'after');
-      await page.waitForTimeout(500);
+      artifact = await buildArtifact(page, electronApp, testInfo, MODE, sessionId, resizeRecorderStrategy, {
+        before: beforeScreenshotPath,
+        after: afterScreenshotPath,
+      });
 
-      const outputSnapshot = await readOutputSnapshot(page, sessionId);
-      const artifact: ReproArtifact = {
-        mode,
-        sessionId,
-        resizePayloads: await getResizePayloads(electronApp),
-        outputSnapshotTail: outputSnapshot.slice(-OUTPUT_TAIL_CHARS),
-        sttySizeSamples: parseSttySizeSamples(outputSnapshot),
-        screenshotPaths,
-      };
-      const artifactPath = testInfo.outputPath(`planning-tmux-blank-${mode}.json`);
-      writeFileSync(artifactPath, JSON.stringify(artifact, null, 2), 'utf8');
-      await testInfo.attach('planning-tmux-blank-artifact', { path: artifactPath, contentType: 'application/json' });
+      const relevantResizePayloads = artifact.resizePayloads.filter((payload) => payload.sessionId === sessionId);
+      const tinyResizePayloads = relevantResizePayloads.filter(isTinyGeometry);
+      const beforeSamples = artifact.sttySizeSamples.filter((sample) => sample.label === 'before');
+      const afterSamples = artifact.sttySizeSamples.filter((sample) => sample.label === 'after');
+      const tinySttySamples = artifact.sttySizeSamples.filter((sample) => sample.tiny);
+      const artifactJson = JSON.stringify(artifact);
 
-      const sessionResizePayloads = artifact.resizePayloads.filter((payload) => payload.sessionId === sessionId);
-      const tinyResizePayloads = sessionResizePayloads.filter(isTinyResize);
-      const tinySttySamples = artifact.sttySizeSamples.filter(isTinySttySize);
-      const tinyAfterSttySamples = artifact.sttySizeSamples.filter((sample) => sample.label === 'after' && isTinySttySize(sample));
+      expect(beforeSamples.length, artifactJson).toBeGreaterThan(0);
+      expect(afterSamples.length, artifactJson).toBeGreaterThan(0);
 
-      if (mode === 'before') {
-        expect(tinyResizePayloads, 'before mode must observe a tiny planningTerminalResize payload').not.toEqual([]);
-        expect(tinyAfterSttySamples, 'before mode must observe tiny live PTY geometry after host collapse').not.toEqual([]);
-        console.log(`BUG_REPRODUCED=${JSON.stringify(artifact)}`);
+      if (MODE === 'before') {
+        expect(relevantResizePayloads.length, artifactJson).toBeGreaterThan(0);
+        expect(tinyResizePayloads.length, artifactJson).toBeGreaterThan(0);
+        expect(afterSamples.some((sample) => sample.tiny), artifactJson).toBe(true);
+        console.log(`BUG_REPRODUCED=${artifactJson}`);
       } else {
-        expect(tinyResizePayloads, 'after mode must not send tiny planningTerminalResize payloads').toEqual([]);
-        expect(tinySttySamples, 'after mode must not observe tiny live PTY stty samples').toEqual([]);
-        console.log(`FIX_VERIFIED=${JSON.stringify(artifact)}`);
+        expect(tinyResizePayloads, artifactJson).toHaveLength(0);
+        expect(tinySttySamples, artifactJson).toHaveLength(0);
+        console.log(`FIX_VERIFIED=${artifactJson}`);
       }
     } finally {
-      if (sessionId) {
-        await closePlanningTerminalSessions(page);
+      await closePlanningTerminalSessions(page);
+      if (!artifact && sessionId) {
+        const fallbackScreenshotPath = await screenshot(page, testInfo, 'planning-tmux-fallback-evidence').catch(() => '');
+        await buildArtifact(page, electronApp, testInfo, MODE, sessionId, resizeRecorderStrategy, {
+          before: fallbackScreenshotPath,
+          after: fallbackScreenshotPath,
+        }).catch(() => undefined);
       }
     }
   });

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -407,6 +407,28 @@ describe('Invoker terminal (component)', () => {
     }
   });
 
+  it('skips planning tmux fit and resize when proposed dimensions are not finite', async () => {
+    const rectSpy = mockElementRect(640, 400);
+    xtermMock.setNextProposedDimensions({ cols: Number.NaN, rows: 24 });
+
+    try {
+      render(<InvokerTerminal
+        {...terminalProps({
+          mode: 'tmux',
+          terminalSession: makePlanningTerminalSession(),
+        })}
+      />);
+
+      await flushPlanningTerminalFit();
+
+      expect(xtermMock.fitInstances[0]?.proposeDimensions).toHaveBeenCalled();
+      expect(xtermMock.fitInstances[0]?.fit).not.toHaveBeenCalled();
+      expect(mock.api.planningTerminalResize).not.toHaveBeenCalled();
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
   it('sends planning tmux resize when proposed dimensions are sane', async () => {
     const rectSpy = mockElementRect(640, 400);
     xtermMock.setNextProposedDimensions({ cols: 100, rows: 30 });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -262,6 +262,8 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActi
         const proposedDimensions = fit.proposeDimensions();
         if (
           !proposedDimensions ||
+          !Number.isFinite(proposedDimensions.cols) ||
+          !Number.isFinite(proposedDimensions.rows) ||
           proposedDimensions.cols < MIN_PLANNING_TMUX_COLS ||
           proposedDimensions.rows < MIN_PLANNING_TMUX_ROWS
         ) {

--- a/scripts/repro/repro-planning-tmux-blank.sh
+++ b/scripts/repro/repro-planning-tmux-blank.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Repro: a hidden/zero-sized planning tmux host must not resize the live PTY
+# down to tiny geometry. In before mode, this proves the pre-fix defect by
+# requiring both resize IPC and `stty size` evidence of tiny geometry.
 set -euo pipefail
 
 MODE="${1:-after}"


### PR DESCRIPTION
## Summary

Planning tmux already stopped forwarding a resize when the proposed terminal size was too small.

It did not check whether `FitAddon.proposeDimensions()` returned a non-finite `cols` or `rows` value, so a `NaN` proposal could still fit the terminal and reach the resize call.

This slice adds an explicit finite check next to the existing minimum-size check in `InvokerTerminal.tsx`, so a non-finite proposal is treated the same as a too-small one.

## Review Claim

Approve the two `Number.isFinite` checks added to the planning tmux fit path and the matching component test.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change only adds two more conditions to an existing early-return branch; when both dimensions are finite and already within range, the fit-and-resize path behaves exactly as before.

## Slice Rationale

This ships apart from the repro-evidence slice below it in the stack because the repo's diff-atomicity check keeps `packages/ui/**` behavior changes and `scripts/repro/**` evidence changes in separate review units.

## Non-goals

The existing minimum-size thresholds are unchanged. The active-view mount behavior for planning tmux views is unchanged. No IPC changes here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- src/__tests__/invoker-terminal.test.tsx` (51 passed)

</details>

## Visual Proof

This change only adds a `Number.isFinite` guard around an internal `FitAddon.proposeDimensions()` result. A real user never drives the terminal into a non-finite proposal; it only happens through test mocking, so there is no distinct screen state a screenshot can show for this specific guard.

The screenshot below is a plain regression check: planning tmux still renders its normal content under the current code, which includes this guard, so the change introduced no visible regression.

![Planning tmux renders normally with the guard in place](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260728-14e025/planning-tmux-resize-guard-baseline.png)

The real proof that the new guard skips the fit/resize call on a non-finite proposal is the focused component test added in this slice: `packages/ui/src/__tests__/invoker-terminal.test.tsx` — `'skips planning tmux fit and resize when proposed dimensions are not finite'`, run in the Test Plan below.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b46b9dbad`
- Post-revert steps: None
- Data migration? No

</details>
