### PR TITLE
Fix stale headless CLI command names breaking all SSH e2e tests (shard-30/31)

### DIFF
--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -488,7 +488,7 @@ PY
 # Usage: ST=$(invoker_e2e_task_status <taskId>)
 invoker_e2e_task_status() {
   local task_id="$1"
-  invoker_e2e_run_headless task-status "$task_id" 2>/dev/null \
+  invoker_e2e_run_headless query task "$task_id" 2>/dev/null \
     | sed 's/\x1b\[[0-9;]*m//g' \
     | grep -E '^(pending|running|completed|failed|blocked|awaiting_approval|review_ready|fixing_with_ai|closed|skipped)$' \
     | tail -1
@@ -518,7 +518,7 @@ invoker_e2e_wait_task_status() {
 # Extract the __merge__<workflowId> task ID from headless status output.
 # The merge gate task ID starts with "__merge__". Returns the first match.
 invoker_e2e_merge_gate_id() {
-  invoker_e2e_run_headless status 2>/dev/null \
+  invoker_e2e_run_headless query tasks --output label 2>/dev/null \
     | grep -oE '__merge__[^[:space:]]+' \
     | head -1 \
     | sed 's/\x1b\[[0-9;]*m//g'

--- a/scripts/e2e-ssh/cases/case-3.1-worktree-to-ssh.sh
+++ b/scripts/e2e-ssh/cases/case-3.1-worktree-to-ssh.sh
@@ -21,7 +21,7 @@ STA=$(invoker_e2e_task_status e2e-g331-taskA)
 STB=$(invoker_e2e_task_status e2e-g331-taskB)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ]; then
   echo "FAIL case 3.1: expected A=completed B=completed, got A='$STA' B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_run_headless query tasks 2>&1 || true
   exit 1
 fi
 

--- a/scripts/e2e-ssh/cases/case-3.2-fan-in-cross.sh
+++ b/scripts/e2e-ssh/cases/case-3.2-fan-in-cross.sh
@@ -22,7 +22,7 @@ STB=$(invoker_e2e_task_status e2e-g332-taskB)
 STC=$(invoker_e2e_task_status e2e-g332-taskC)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ] || [ "$STC" != "completed" ]; then
   echo "FAIL case 3.2: expected all completed, got A='$STA' B='$STB' C='$STC'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_run_headless query tasks 2>&1 || true
   exit 1
 fi
 

--- a/scripts/e2e-ssh/cases/case-3.3-fix-then-ssh.sh
+++ b/scripts/e2e-ssh/cases/case-3.3-fix-then-ssh.sh
@@ -22,7 +22,7 @@ STB=$(invoker_e2e_task_status e2e-g333-taskB)
 STC=$(invoker_e2e_task_status e2e-g333-taskC)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ] || [ "$STC" != "completed" ]; then
   echo "FAIL case 3.3: expected all completed, got A='$STA' B='$STB' C='$STC'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_run_headless query tasks 2>&1 || true
   exit 1
 fi
 

--- a/scripts/e2e-ssh/cases/case-3.4-cross-exec-fail.sh
+++ b/scripts/e2e-ssh/cases/case-3.4-cross-exec-fail.sh
@@ -22,7 +22,7 @@ STB=$(invoker_e2e_task_status e2e-g334-taskB)
 STC=$(invoker_e2e_task_status e2e-g334-taskC)
 if [ "$STA" != "completed" ] || [ "$STB" != "failed" ] || [ "$STC" != "pending" ]; then
   echo "FAIL case 3.4: expected A=completed B=failed C=pending, got A='$STA' B='$STB' C='$STC'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_run_headless query tasks 2>&1 || true
   exit 1
 fi
 

--- a/scripts/e2e-ssh/cases/case-3.5-cross-exec-fix.sh
+++ b/scripts/e2e-ssh/cases/case-3.5-cross-exec-fix.sh
@@ -22,7 +22,7 @@ STB=$(invoker_e2e_task_status e2e-g335-taskB)
 STC=$(invoker_e2e_task_status e2e-g335-taskC)
 if [ "$STA" != "completed" ] || [ "$STB" != "failed" ] || [ "$STC" != "pending" ]; then
   echo "FAIL case 3.5: expected A=completed B=failed C=pending, got A='$STA' B='$STB' C='$STC'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_run_headless query tasks 2>&1 || true
   exit 1
 fi
 echo "==> case 3.5: confirmed A=completed, B=failed, C=pending"
@@ -33,7 +33,7 @@ invoker_e2e_run_headless fix e2e-g335-taskB
 STB=$(invoker_e2e_task_status e2e-g335-taskB)
 if [ "$STB" != "awaiting_approval" ]; then
   echo "FAIL case 3.5: expected B=awaiting_approval after fix, got '$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_run_headless query tasks 2>&1 || true
   exit 1
 fi
 echo "==> case 3.5: confirmed B=awaiting_approval"
@@ -46,7 +46,7 @@ STB=$(invoker_e2e_task_status e2e-g335-taskB)
 STC=$(invoker_e2e_task_status e2e-g335-taskC)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ] || [ "$STC" != "completed" ]; then
   echo "FAIL case 3.5: expected all completed, got A='$STA' B='$STB' C='$STC'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_run_headless query tasks 2>&1 || true
   exit 1
 fi
 

--- a/scripts/e2e-ssh/cases/case-3.6-ssh-merge-gate.sh
+++ b/scripts/e2e-ssh/cases/case-3.6-ssh-merge-gate.sh
@@ -21,7 +21,7 @@ STA=$(invoker_e2e_task_status e2e-g336-taskA)
 STB=$(invoker_e2e_task_status e2e-g336-taskB)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ]; then
   echo "FAIL case 3.6: expected A=completed B=completed, got A='$STA' B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_run_headless query tasks 2>&1 || true
   exit 1
 fi
 echo "==> case 3.6: confirmed A=completed, B=completed"
@@ -30,7 +30,7 @@ echo "==> case 3.6: confirmed A=completed, B=completed"
 MERGE_ID=$(invoker_e2e_merge_gate_id)
 if [ -z "$MERGE_ID" ]; then
   echo "FAIL case 3.6: could not find merge gate task ID"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_run_headless query tasks 2>&1 || true
   exit 1
 fi
 echo "==> case 3.6: merge gate ID=$MERGE_ID"
@@ -38,7 +38,7 @@ echo "==> case 3.6: merge gate ID=$MERGE_ID"
 STM=$(invoker_e2e_task_status "$MERGE_ID")
 if [ "$STM" != "review_ready" ]; then
   echo "FAIL case 3.6: expected merge gate=review_ready, got '$STM'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_run_headless query tasks 2>&1 || true
   exit 1
 fi
 echo "==> case 3.6: confirmed merge gate=review_ready"
@@ -83,7 +83,7 @@ done
 STM=$(invoker_e2e_task_status "$MERGE_ID")
 if [ "$STM" != "completed" ]; then
   echo "FAIL case 3.6: expected merge gate=completed after PR merge, got '$STM'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_run_headless query tasks 2>&1 || true
   exit 1
 fi
 

--- a/scripts/e2e-ssh/cases/case-3.7-ssh-target-provision.sh
+++ b/scripts/e2e-ssh/cases/case-3.7-ssh-target-provision.sh
@@ -27,7 +27,7 @@ invoker_e2e_submit_plan "$INVOKER_E2E_REPO_ROOT/plans/e2e-ssh/3.7-ssh-target-pro
 STA=$(invoker_e2e_task_status e2e-g337-taskA)
 if [ "$STA" != "completed" ]; then
   echo "FAIL case 3.7: expected SSH task=completed, got '$STA'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_run_headless query tasks 2>&1 || true
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

`ssh/shard-30` and `ssh/shard-31` have been failing on master despite 10 merged "CI Fix Step 3 - SSH Shard Stability" PRs. This PR fixes the actual cause: it isn't the SSH mechanics those PRs touched, it's a separate bug in the test harness itself that makes every SSH e2e case report failure regardless of whether the real work succeeded.

## Root cause

`scripts/e2e-ssh/cases/case-3.*.sh` check task completion via two helpers in `scripts/e2e-dry-run/lib/common.sh`:
- `invoker_e2e_task_status()` called `--headless task-status <id>`
- `invoker_e2e_merge_gate_id()` called `--headless status`

Neither subcommand exists anymore in `packages/app/src/headless.ts` — they were replaced at some point by `query task <id>` / `query tasks`. Confirmed directly:

```
$ ./run.sh --headless task-status some-id
Error: Unknown command: task-status. Run with --help for usage.

$ ./run.sh --headless query task some-id
Error: Task "some-id" not found in any workflow   # command exists, works correctly
```

Because each helper pipes its output through `grep -E '^(pending|running|completed|...)$'` and gets assigned via `VAR=$(...)`, the "Unknown command" error (which never matches that pattern) makes the pipeline exit non-zero under `pipefail`. Under `set -euo pipefail`, a plain assignment statement failing kills the script immediately — before it ever reaches its own `FAIL case X: ...` diagnostic branch. `bash -x` trace on a local repro shows exactly this:

```
+ STA=          # invoker_e2e_task_status returned empty (grep matched nothing)
+ invoker_e2e_ssh_full_cleanup   # trap fires immediately, no FAIL/PASS message ever printed
```

So the case scripts have been reporting "FAILED" with zero diagnostic information — even in CI runs where every task actually completed successfully (`Workflow: N total | N completed | 0 failed`).

## Evidence this was masking real successes

Real CI run (master, ssh/shard-30, run 30392596642): task A, B, C all show `[completed]` in the tracked output, `0 failed`, yet the case script still reports `FAILED` with no explanation — matching this bug exactly, not an actual SSH/provisioning defect.

## Fix

Update the two helpers (and the diagnostic fallback calls) to use the current `query task` / `query tasks` subcommands instead of the removed `task-status` / `status`.

## Verification

Ran the actual CI test suites locally end to end, before and after:

- Before fix: all 6 SSH cases fail identically to current CI (`0 passed, 6 failed`), same silent-death signature.
- After fix:
  - `bash scripts/test-suites/optional/30-e2e-ssh.sh` → `e2e-ssh: 3 passed, 0 failed (3 total)`
  - `bash scripts/test-suites/optional/31-e2e-ssh-merge.sh` → `e2e-ssh: 3 passed, 0 failed (3 total)`

## Test Plan

- [x] `bash scripts/test-suites/optional/30-e2e-ssh.sh` — 3 passed, 0 failed
- [x] `bash scripts/test-suites/optional/31-e2e-ssh-merge.sh` — 3 passed, 0 failed
- [x] `bash -n` on all 8 modified files

## Revert Plan

- Safe to revert? Yes — purely restores two string literals.
- Revert command: `git revert d322bf675`
- Post-revert steps: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)