### PR TITLE
[Queue chip live refresh](1) Add stale queue chip repro harness

### DIFF
--- a/packages/ui/src/__tests__/queue-status-stale-repro.test.tsx
+++ b/packages/ui/src/__tests__/queue-status-stale-repro.test.tsx
@@ -1,0 +1,381 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { WorkflowStatusChips } from '../components/WorkflowStatusChips.js';
+import { useQueueStatus } from '../hooks/useQueueStatus.js';
+import { useTasks } from '../hooks/useTasks.js';
+import type { QueueStatus, WorkflowMeta } from '../types.js';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.setConfig({ testTimeout: 20_000 });
+
+async function flushInitialQueuePoll(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function flushTaskAndWorkflowEvents(): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(100);
+  });
+}
+
+function QueueStatusProbe(): JSX.Element {
+  const { workflows } = useTasks();
+  const queueStatus = useQueueStatus();
+
+  return (
+    <WorkflowStatusChips
+      workflows={workflows}
+      activeFilters={new Set()}
+      onStatusClick={() => {}}
+      queueStatus={queueStatus}
+    />
+  );
+}
+
+describe('queue status can lag behind live workflow/task updates', () => {
+  let mock: MockInvoker;
+  let visibility: DocumentVisibilityState;
+  let queueStatus: QueueStatus;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    visibility = 'visible';
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => visibility,
+    });
+
+    queueStatus = {
+      maxConcurrency: 13,
+      runningCount: 0,
+      activeExecutionCount: 0,
+      launchingCount: 0,
+      running: [],
+      queued: [],
+    };
+
+    mock = createMockInvoker();
+    mock.api.getQueueStatus = vi.fn(async () => ({
+      maxConcurrency: queueStatus.maxConcurrency,
+      runningCount: queueStatus.runningCount,
+      activeExecutionCount: queueStatus.activeExecutionCount,
+      launchingCount: queueStatus.launchingCount,
+      running: [...queueStatus.running],
+      queued: [...queueStatus.queued],
+    }));
+    mock.install();
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [],
+      workflows: [],
+      streamSequence: 0,
+    };
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+    delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
+    vi.useRealTimers();
+  });
+
+  it('shows a running workflow while the queue chips still read 0/13 until the next queue poll', async () => {
+    render(<QueueStatusProbe />);
+    await flushInitialQueuePoll();
+
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (0/13)');
+
+    const workflow: WorkflowMeta = {
+      id: 'wf-ssh-stale',
+      name: 'CI Fix Step 3 - SSH Shard Stability',
+      status: 'running',
+    };
+    const runningTask = makeUITask({
+      id: 'wf-ssh-stale/implement-ssh-shard-fixes',
+      workflowId: 'wf-ssh-stale',
+      description: 'Resolve shard-30 and shard-31 SSH regressions in cross-executor case scripts',
+      status: 'running',
+      execution: { phase: 'executing' },
+      taskStateVersion: 1,
+    });
+
+    queueStatus = {
+      maxConcurrency: 13,
+      runningCount: 1,
+      activeExecutionCount: 1,
+      launchingCount: 0,
+      running: [{ taskId: runningTask.id, description: runningTask.description }],
+      queued: [],
+    };
+
+    await act(async () => {
+      mock.setTasks([runningTask], [workflow]);
+      await Promise.resolve();
+    });
+    await flushTaskAndWorkflowEvents();
+
+    expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('workflows running (1)');
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (0/13)');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_899);
+    });
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (0/13)');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (1/13)');
+  });
+
+  it('stays stale while a queue poll is in flight, because later ticks are skipped', async () => {
+    const slowPoll = Promise.withResolvers<QueueStatus>();
+    let pollCount = 0;
+    mock.api.getQueueStatus = vi.fn(async () => {
+      pollCount += 1;
+      if (pollCount === 1) {
+        return {
+          maxConcurrency: 13,
+          runningCount: 0,
+          activeExecutionCount: 0,
+          launchingCount: 0,
+          running: [],
+          queued: [],
+        };
+      }
+      if (pollCount === 2) {
+        return slowPoll.promise;
+      }
+      return {
+        maxConcurrency: queueStatus.maxConcurrency,
+        runningCount: queueStatus.runningCount,
+        activeExecutionCount: queueStatus.activeExecutionCount,
+        launchingCount: queueStatus.launchingCount,
+        running: [...queueStatus.running],
+        queued: [...queueStatus.queued],
+      };
+    });
+
+    render(<QueueStatusProbe />);
+    await flushInitialQueuePoll();
+
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (0/13)');
+
+    const workflow: WorkflowMeta = {
+      id: 'wf-slow-poll',
+      name: 'CI Fix Step 3 - SSH Shard Stability',
+      status: 'running',
+    };
+    const runningTask = makeUITask({
+      id: 'wf-slow-poll/implement-ssh-shard-fixes',
+      workflowId: 'wf-slow-poll',
+      description: 'Resolve shard-30 and shard-31 SSH regressions in cross-executor case scripts',
+      status: 'running',
+      execution: { phase: 'executing' },
+      taskStateVersion: 1,
+    });
+
+    queueStatus = {
+      maxConcurrency: 13,
+      runningCount: 1,
+      activeExecutionCount: 1,
+      launchingCount: 0,
+      running: [{ taskId: runningTask.id, description: runningTask.description }],
+      queued: [],
+    };
+
+    await act(async () => {
+      mock.setTasks([runningTask], [workflow]);
+      await Promise.resolve();
+    });
+    await flushTaskAndWorkflowEvents();
+
+    expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('workflows running (1)');
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_899);
+    });
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (0/13)');
+
+    await act(async () => {
+      slowPoll.resolve({
+        maxConcurrency: queueStatus.maxConcurrency,
+        runningCount: queueStatus.runningCount,
+        activeExecutionCount: queueStatus.activeExecutionCount,
+        launchingCount: queueStatus.launchingCount,
+        running: [...queueStatus.running],
+        queued: [...queueStatus.queued],
+      });
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (1/13)');
+  });
+
+  it('keeps the old queue numbers after a poll error until a later poll succeeds', async () => {
+    let pollCount = 0;
+    mock.api.getQueueStatus = vi.fn(async () => {
+      pollCount += 1;
+      if (pollCount === 1) {
+        return {
+          maxConcurrency: 13,
+          runningCount: 0,
+          activeExecutionCount: 0,
+          launchingCount: 0,
+          running: [],
+          queued: [],
+        };
+      }
+      if (pollCount === 2) {
+        throw new Error('queue read failed');
+      }
+      return {
+        maxConcurrency: queueStatus.maxConcurrency,
+        runningCount: queueStatus.runningCount,
+        activeExecutionCount: queueStatus.activeExecutionCount,
+        launchingCount: queueStatus.launchingCount,
+        running: [...queueStatus.running],
+        queued: [...queueStatus.queued],
+      };
+    });
+
+    render(<QueueStatusProbe />);
+    await flushInitialQueuePoll();
+
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (0/13)');
+
+    const workflow: WorkflowMeta = {
+      id: 'wf-poll-error',
+      name: 'CI Fix Step 3 - SSH Shard Stability',
+      status: 'running',
+    };
+    const runningTask = makeUITask({
+      id: 'wf-poll-error/implement-ssh-shard-fixes',
+      workflowId: 'wf-poll-error',
+      description: 'Resolve shard-30 and shard-31 SSH regressions in cross-executor case scripts',
+      status: 'running',
+      execution: { phase: 'executing' },
+      taskStateVersion: 1,
+    });
+
+    queueStatus = {
+      maxConcurrency: 13,
+      runningCount: 1,
+      activeExecutionCount: 1,
+      launchingCount: 0,
+      running: [{ taskId: runningTask.id, description: runningTask.description }],
+      queued: [],
+    };
+
+    await act(async () => {
+      mock.setTasks([runningTask], [workflow]);
+      await Promise.resolve();
+    });
+    await flushTaskAndWorkflowEvents();
+
+    expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('workflows running (1)');
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4_899);
+    });
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (0/13)');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+      await Promise.resolve();
+    });
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (1/13)');
+  });
+
+  it('stays stale while the window is hidden, then catches up on visibility restore', async () => {
+    render(<QueueStatusProbe />);
+    await flushInitialQueuePoll();
+
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (0/13)');
+
+    await act(async () => {
+      visibility = 'hidden';
+      document.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    const workflow: WorkflowMeta = {
+      id: 'wf-hidden-stale',
+      name: 'CI Fix Step 3 - SSH Shard Stability',
+      status: 'running',
+    };
+    const runningTask = makeUITask({
+      id: 'wf-hidden-stale/implement-ssh-shard-fixes',
+      workflowId: 'wf-hidden-stale',
+      description: 'Resolve shard-30 and shard-31 SSH regressions in cross-executor case scripts',
+      status: 'running',
+      execution: { phase: 'executing' },
+      taskStateVersion: 1,
+    });
+
+    queueStatus = {
+      maxConcurrency: 13,
+      runningCount: 1,
+      activeExecutionCount: 1,
+      launchingCount: 0,
+      running: [{ taskId: runningTask.id, description: runningTask.description }],
+      queued: [],
+    };
+
+    await act(async () => {
+      mock.setTasks([runningTask], [workflow]);
+      await Promise.resolve();
+    });
+    await flushTaskAndWorkflowEvents();
+
+    expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('workflows running (1)');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (0/13)');
+
+    await act(async () => {
+      visibility = 'visible';
+      document.dispatchEvent(new Event('visibilitychange'));
+      await vi.advanceTimersByTimeAsync(249);
+    });
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (0/13)');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (1/13)');
+  });
+});

--- a/scripts/repro/repro-coderabbit-pr6638-vitest-run-direct-call.sh
+++ b/scripts/repro/repro-coderabbit-pr6638-vitest-run-direct-call.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repro for CodeRabbit PR #6638 finding:
+#   The queue-status stale repro script must run its focused test through the
+#   standard `pnpm test` script (packages/ui -> node scripts/run-vitest.mjs),
+#   which adds a missing-vitest auto-install fallback. Per CLAUDE.md, plan/repro
+#   task commands must NEVER invoke `vitest run` / `npx vitest run` directly.
+#
+# This proof FAILS (exit non-zero) if the target script contains a direct
+# vitest invocation, and PASSES once it goes through `pnpm ... test`.
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+TARGET="$REPO_ROOT/scripts/repro/repro-queue-status-stale.sh"
+
+if [[ ! -f "$TARGET" ]]; then
+  echo "[repro] FAIL: target script not found: $TARGET"
+  exit 1
+fi
+
+if grep -Eq 'vitest[[:space:]]+run' "$TARGET"; then
+  echo "[repro] FAIL: $TARGET invokes 'vitest run' directly; use the standard 'pnpm ... test' script instead."
+  grep -nE 'vitest[[:space:]]+run' "$TARGET"
+  exit 1
+fi
+
+if ! grep -Eq -- '--filter @invoker/ui test' "$TARGET"; then
+  echo "[repro] FAIL: $TARGET does not run the focused test through 'pnpm --filter @invoker/ui test'."
+  exit 1
+fi
+
+echo "[repro] PASS: queue-status stale repro runs its test through the standard 'pnpm test' script."
+exit 0

--- a/scripts/repro/repro-queue-status-stale.sh
+++ b/scripts/repro/repro-queue-status-stale.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repro: the home-bottom queue chips are polled, but workflow/task updates are
+# pushed live over a separate channel. This script proves four stale cases:
+#   1. running workflow/task state arrives before the next 5s queue poll
+#   2. a slow in-flight queue poll blocks later ticks
+#   3. a queue poll error leaves old numbers on screen
+#   4. a hidden window pauses queue polling until visibility returns
+#
+# It does NOT claim the owner-side 2.5s cache is itself a user-visible stale
+# repro for the running/executing chips; that path needs a separate failing case
+# before we should count it.
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/invoker-queue-status-stale.XXXXXX.log")"
+trap 'rm -f "$LOG_FILE"' EXIT
+
+echo "[repro] queue chips can lag behind running workflow/task state."
+
+if pnpm -C "$REPO_ROOT" --filter @invoker/ui exec vitest run   src/__tests__/queue-status-stale-repro.test.tsx   >"$LOG_FILE" 2>&1; then
+  echo "[repro] PASS: the test reproduced four stale queue-chip cases, then showed the chips catch up after a later successful poll / visibility restore."
+  cat "$LOG_FILE"
+  exit 0
+else
+  status=$?
+  echo "[repro] FAIL: the focused stale-queue repro did not hold."
+  cat "$LOG_FILE"
+  exit "$status"
+fi

--- a/scripts/repro/repro-queue-status-stale.sh
+++ b/scripts/repro/repro-queue-status-stale.sh
@@ -18,7 +18,7 @@ trap 'rm -f "$LOG_FILE"' EXIT
 
 echo "[repro] queue chips can lag behind running workflow/task state."
 
-if pnpm -C "$REPO_ROOT" --filter @invoker/ui exec vitest run   src/__tests__/queue-status-stale-repro.test.tsx   >"$LOG_FILE" 2>&1; then
+if pnpm -C "$REPO_ROOT" --filter @invoker/ui test -- src/__tests__/queue-status-stale-repro.test.tsx >"$LOG_FILE" 2>&1; then
   echo "[repro] PASS: the test reproduced four stale queue-chip cases, then showed the chips catch up after a later successful poll / visibility restore."
   cat "$LOG_FILE"
   exit 0


### PR DESCRIPTION
## Summary

This adds a permanent renderer repro for the stale home queue chips.

It covers the four lag windows we can reproduce today: next-poll delay, in-flight poll blocking, poll-error persistence, and hidden-window pause.

The shell wrapper gives one command reviewers can run without hunting for the test file.

## Review Claim

This PR adds a focused proof harness for the stale queue-chip lag cases, with no product behavior change.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes only test and repro files. Product behavior, queue scheduling, and renderer logic stay untouched.

## Slice Rationale

Evidence lands first so the later behavior PR can be judged against a real failing window instead of a story.

## Non-goals

- Fixing the stale chips
- Changing queue polling
- Changing queue drawer or row behavior

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm -C . --filter @invoker/ui exec vitest run src/__tests__/queue-status-stale-repro.test.tsx --reporter=verbose`
- [ ] `scripts/repro/repro-queue-status-stale.sh`

</details>

## Visual Proof

On the proof branch, the workflow is already running while the bottom chrome still reads `Executing (0/6)` and `Slots (0/6)`.

![Queue chips still lag on the proof branch](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260729-01ce03/queue-chip-live-refresh-before.png)

[Walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260729-01ce03/queue-chip-live-refresh-before.webm)

A still image cannot show the later catch-up after the poll. The focused renderer regression and shell wrapper in the Test Plan cover that timing edge.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d6a0a8047be341d8f49b5843c54c78d0ccc348e7`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage that verifies queue status chips stay “stale” during rapid live workflow/task updates, including in-flight polling, poll errors, and browser visibility changes.
* **Chores**
  * Added a focused reproduction harness script to help diagnose the stale queue status UI behavior.
  * Added a script to ensure the repro harness runs the intended Vitest command and avoids direct full test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->