### PR TITLE
[Queue chip live refresh](2) Fix home queue chips during queue poll lag

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -53,6 +53,7 @@ import { ChevronDownIcon, PlayIcon } from './components/icons/index.js';
 import { CommandPalette, COMMAND_PALETTE_MAX_ROWS } from './components/CommandPalette.js';
 import {
   getAttentionTaskEntries,
+  getLiveQueueCounts,
   getRunningTaskEntries,
   getSortedWorkflows,
   formatTaskStatus,
@@ -991,6 +992,16 @@ export function App() {
   );
   const invoker = useInvoker();
   const queueStatus = useQueueStatus();
+  const liveQueueCounts = useMemo(() => getLiveQueueCounts(tasks), [tasks]);
+  const queueChrome = useMemo(() => (
+    queueStatus
+      ? {
+          maxConcurrency: queueStatus.maxConcurrency,
+          queuedCount: queueStatus.queued.length,
+          ...liveQueueCounts,
+        }
+      : null
+  ), [liveQueueCounts, queueStatus]);
   const [workerStatus, refreshWorkerStatus] = useWorkerStatus();
   const handleStartWorker = useCallback(async (kind: string) => {
     await invoker.startWorker(kind);
@@ -4744,7 +4755,7 @@ export function App() {
           activeFilters={statusFilters}
           keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
           onStatusClick={handleStatusClick}
-          queueStatus={queueStatus}
+          queueChrome={queueChrome}
           onOpenRunningSurface={() => selectViewMode('queue')}
         />
       )}

--- a/packages/ui/src/__tests__/queue-status-stale-repro.test.tsx
+++ b/packages/ui/src/__tests__/queue-status-stale-repro.test.tsx
@@ -1,8 +1,10 @@
+import { useMemo } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen } from '@testing-library/react';
 import { WorkflowStatusChips } from '../components/WorkflowStatusChips.js';
 import { useQueueStatus } from '../hooks/useQueueStatus.js';
 import { useTasks } from '../hooks/useTasks.js';
+import { getLiveQueueCounts } from '../lib/workflow-progress-surfaces.js';
 import type { QueueStatus, WorkflowMeta } from '../types.js';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 
@@ -21,20 +23,30 @@ async function flushTaskAndWorkflowEvents(): Promise<void> {
 }
 
 function QueueStatusProbe(): JSX.Element {
-  const { workflows } = useTasks();
+  const { tasks, workflows } = useTasks();
   const queueStatus = useQueueStatus();
+  const liveQueueCounts = useMemo(() => getLiveQueueCounts(tasks), [tasks]);
+  const queueChrome = useMemo(() => (
+    queueStatus
+      ? {
+          maxConcurrency: queueStatus.maxConcurrency,
+          queuedCount: queueStatus.queued.length,
+          ...liveQueueCounts,
+        }
+      : null
+  ), [liveQueueCounts, queueStatus]);
 
   return (
     <WorkflowStatusChips
       workflows={workflows}
       activeFilters={new Set()}
       onStatusClick={() => {}}
-      queueStatus={queueStatus}
+      queueChrome={queueChrome}
     />
   );
 }
 
-describe('queue status can lag behind live workflow/task updates', () => {
+describe('queue chips stay live even when queue status polling lags', () => {
   let mock: MockInvoker;
   let visibility: DocumentVisibilityState;
   let queueStatus: QueueStatus;
@@ -79,7 +91,7 @@ describe('queue status can lag behind live workflow/task updates', () => {
     vi.useRealTimers();
   });
 
-  it('shows a running workflow while the queue chips still read 0/13 until the next queue poll', async () => {
+  it('keeps next-poll lag from freezing executing and slot counts', async () => {
     render(<QueueStatusProbe />);
     await flushInitialQueuePoll();
 
@@ -116,14 +128,14 @@ describe('queue status can lag behind live workflow/task updates', () => {
     await flushTaskAndWorkflowEvents();
 
     expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('workflows running (1)');
-    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
-    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (0/13)');
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (1/13)');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(4_899);
     });
-    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
-    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (0/13)');
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (1/13)');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1);
@@ -132,7 +144,7 @@ describe('queue status can lag behind live workflow/task updates', () => {
     expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (1/13)');
   });
 
-  it('stays stale while a queue poll is in flight, because later ticks are skipped', async () => {
+  it('keeps in-flight poll blocking from freezing executing and slot counts', async () => {
     const slowPoll = Promise.withResolvers<QueueStatus>();
     let pollCount = 0;
     mock.api.getQueueStatus = vi.fn(async () => {
@@ -196,24 +208,24 @@ describe('queue status can lag behind live workflow/task updates', () => {
     await flushTaskAndWorkflowEvents();
 
     expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('workflows running (1)');
-    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/13)');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(4_899);
     });
-    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/13)');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1);
       await Promise.resolve();
     });
-    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/13)');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(15_000);
     });
-    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
-    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (0/13)');
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (1/13)');
 
     await act(async () => {
       slowPoll.resolve({
@@ -230,7 +242,7 @@ describe('queue status can lag behind live workflow/task updates', () => {
     expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (1/13)');
   });
 
-  it('keeps the old queue numbers after a poll error until a later poll succeeds', async () => {
+  it('keeps poll error persistence from freezing executing and slot counts', async () => {
     let pollCount = 0;
     mock.api.getQueueStatus = vi.fn(async () => {
       pollCount += 1;
@@ -293,19 +305,19 @@ describe('queue status can lag behind live workflow/task updates', () => {
     await flushTaskAndWorkflowEvents();
 
     expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('workflows running (1)');
-    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/13)');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(4_899);
     });
-    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/13)');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1);
       await Promise.resolve();
     });
-    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
-    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (0/13)');
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (1/13)');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(5_000);
@@ -315,7 +327,7 @@ describe('queue status can lag behind live workflow/task updates', () => {
     expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (1/13)');
   });
 
-  it('stays stale while the window is hidden, then catches up on visibility restore', async () => {
+  it('keeps hidden-window pause from freezing executing and slot counts', async () => {
     render(<QueueStatusProbe />);
     await flushInitialQueuePoll();
 
@@ -357,20 +369,22 @@ describe('queue status can lag behind live workflow/task updates', () => {
     await flushTaskAndWorkflowEvents();
 
     expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('workflows running (1)');
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (1/13)');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(30_000);
     });
-    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
-    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (0/13)');
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (1/13)');
 
     await act(async () => {
       visibility = 'visible';
       document.dispatchEvent(new Event('visibilitychange'));
       await vi.advanceTimersByTimeAsync(249);
     });
-    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (0/13)');
-    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (0/13)');
+    expect(screen.getByTestId('queue-chip-running')).toHaveTextContent('Executing (1/13)');
+    expect(screen.getByTestId('queue-chip-slots')).toHaveTextContent('Slots (1/13)');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1);

--- a/packages/ui/src/__tests__/workflow-status-chips-queue.test.tsx
+++ b/packages/ui/src/__tests__/workflow-status-chips-queue.test.tsx
@@ -1,27 +1,19 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { WorkflowStatusChips } from '../components/WorkflowStatusChips.js';
-import type { QueueStatus, WorkflowMeta } from '../types.js';
+import type { WorkflowMeta } from '../types.js';
 
 describe('WorkflowStatusChips queue capacity', () => {
-  it('shows executing and queued counts from queue status on the home bottom chrome', () => {
+  it('shows executing and queued counts from queue chrome on the home bottom chrome', () => {
     const workflows = new Map<string, WorkflowMeta>([
       ['wf-1', { id: 'wf-1', name: 'One', status: 'running' }],
     ]);
-    const queueStatus: QueueStatus = {
+    const queueChrome = {
       maxConcurrency: 8,
       runningCount: 3,
       activeExecutionCount: 1,
       launchingCount: 2,
-      running: [
-        { taskId: 'a', description: 'a' },
-        { taskId: 'b', description: 'b' },
-        { taskId: 'c', description: 'c' },
-      ],
-      queued: [
-        { taskId: 'd', priority: 0, description: 'd' },
-        { taskId: 'e', priority: 0, description: 'e' },
-      ],
+      queuedCount: 2,
     };
     const onOpenRunningSurface = vi.fn();
 
@@ -30,7 +22,7 @@ describe('WorkflowStatusChips queue capacity', () => {
         workflows={workflows}
         activeFilters={new Set()}
         onStatusClick={() => {}}
-        queueStatus={queueStatus}
+        queueChrome={queueChrome}
         onOpenRunningSurface={onOpenRunningSurface}
       />,
     );

--- a/packages/ui/src/components/WorkflowStatusChips.tsx
+++ b/packages/ui/src/components/WorkflowStatusChips.tsx
@@ -1,13 +1,21 @@
 import type { MouseEvent } from 'react';
-import type { QueueStatus, WorkflowMeta, WorkflowStatus } from '../types.js';
+import type { WorkflowMeta, WorkflowStatus } from '../types.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
+
+interface WorkflowStatusChipsQueueChrome {
+  readonly maxConcurrency: number;
+  readonly runningCount: number;
+  readonly activeExecutionCount: number;
+  readonly launchingCount: number;
+  readonly queuedCount: number;
+}
 
 interface WorkflowStatusChipsProps {
   workflows: Map<string, WorkflowMeta>;
   activeFilters: Set<WorkflowStatus>;
   onStatusClick: (status: WorkflowStatus, event: MouseEvent<HTMLButtonElement>) => void;
   keyboardActiveKey?: WorkflowStatus | null;
-  queueStatus?: QueueStatus | null;
+  queueChrome?: WorkflowStatusChipsQueueChrome | null;
   onOpenRunningSurface?: () => void;
 }
 
@@ -29,7 +37,7 @@ export function WorkflowStatusChips({
   activeFilters,
   onStatusClick,
   keyboardActiveKey = null,
-  queueStatus = null,
+  queueChrome = null,
   onOpenRunningSurface,
 }: WorkflowStatusChipsProps): JSX.Element {
   const counts = new Map<WorkflowStatus, number>();
@@ -39,16 +47,16 @@ export function WorkflowStatusChips({
   }
 
   const hasFilters = activeFilters.size > 0;
-  const queueSlots = queueStatus?.runningCount ?? 0;
-  const queueExecuting = queueStatus?.activeExecutionCount ?? queueSlots;
-  const queueLaunching = queueStatus?.launchingCount
+  const queueSlots = queueChrome?.runningCount ?? 0;
+  const queueExecuting = queueChrome?.activeExecutionCount ?? queueSlots;
+  const queueLaunching = queueChrome?.launchingCount
     ?? Math.max(0, queueSlots - queueExecuting);
-  const queueMax = queueStatus?.maxConcurrency ?? 0;
-  const queueQueued = queueStatus?.queued.length ?? 0;
+  const queueMax = queueChrome?.maxConcurrency ?? 0;
+  const queueQueued = queueChrome?.queuedCount ?? 0;
 
   return (
     <div data-testid="workflow-status-chips" className="flex items-center gap-6 px-4 py-2 bg-secondary border-t border-border text-sm">
-      {queueStatus && (
+      {queueChrome && (
         <div data-testid="queue-capacity-chips" className="flex items-center gap-3 border-r border-border pr-6">
           <button
             type="button"

--- a/packages/ui/src/lib/workflow-progress-surfaces.ts
+++ b/packages/ui/src/lib/workflow-progress-surfaces.ts
@@ -75,6 +75,38 @@ export function isRunningTask(task: TaskState): boolean {
   return RUNNING_TASK_STATUS[task.status] === true;
 }
 
+export interface LiveQueueCounts {
+  readonly runningCount: number;
+  readonly activeExecutionCount: number;
+  readonly launchingCount: number;
+}
+
+export function getLiveQueueCounts(tasks: Map<string, TaskState>): LiveQueueCounts {
+  let activeExecutionCount = 0;
+  let launchingCount = 0;
+
+  for (const task of tasks.values()) {
+    if (task.execution.crashPreservedAt) continue;
+    if (task.status === 'running' || task.status === 'fixing_with_ai') {
+      activeExecutionCount += 1;
+      continue;
+    }
+    if (
+      (task.status === 'pending' || (task.status as string) === 'queued')
+      && task.execution.phase === 'launching'
+      && Boolean(task.execution.selectedAttemptId)
+    ) {
+      launchingCount += 1;
+    }
+  }
+
+  return {
+    runningCount: activeExecutionCount + launchingCount,
+    activeExecutionCount,
+    launchingCount,
+  };
+}
+
 export function getWorkflowTaskCounts(tasks: Map<string, TaskState>): Map<string, number> {
   const counts = new Map<string, number>();
   for (const task of tasks.values()) {

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -116,6 +116,7 @@ export interface TaskExecution {
   readonly launchStartedAt?: Date;
   readonly launchCompletedAt?: Date;
   readonly actionRequestId?: string;
+  readonly selectedAttemptId?: string;
   readonly branch?: string;
   readonly commit?: string;
   readonly agentSessionId?: string;
@@ -134,6 +135,10 @@ export interface TaskExecution {
   readonly reviewId?: string;
   readonly reviewStatus?: string;
   readonly reviewProviderId?: string;
+  readonly crashPreservedAt?: Date;
+  readonly crashPreservedOwnerPid?: number;
+  readonly crashPreservedReportPath?: string;
+  readonly crashPreservedDiagnosticSummary?: string;
   readonly mergeConflict?: {
     readonly failedBranch: string;
     readonly conflictFiles: readonly string[];

--- a/scripts/repro/repro-queue-status-stale.sh
+++ b/scripts/repro/repro-queue-status-stale.sh
@@ -1,30 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Repro: the home-bottom queue chips are polled, but workflow/task updates are
-# pushed live over a separate channel. This script proves four stale cases:
-#   1. running workflow/task state arrives before the next 5s queue poll
-#   2. a slow in-flight queue poll blocks later ticks
-#   3. a queue poll error leaves old numbers on screen
-#   4. a hidden window pauses queue polling until visibility returns
+# Regression guard: the home-bottom queue chips now derive active-slot counts
+# from the live task/workflow stream instead of the 5s queue poll. This script
+# covers the four stale windows we reproduced before the fix:
+#   1. live workflow/task state arriving before the next 5s queue poll
+#   2. a slow in-flight queue poll blocking later ticks
+#   3. a queue poll error leaving the old queue snapshot in place
+#   4. a hidden window pausing queue polling until visibility returns
 #
 # It does NOT claim the owner-side 2.5s cache is itself a user-visible stale
-# repro for the running/executing chips; that path needs a separate failing case
-# before we should count it.
+# repro for the running/executing chips; that path still needs a separate
+# failing case before we should count it.
 
 REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/invoker-queue-status-stale.XXXXXX.log")"
 trap 'rm -f "$LOG_FILE"' EXIT
 
-echo "[repro] queue chips can lag behind running workflow/task state."
+echo "[repro] queue chips stay live even when queue status polling lags."
 
 if pnpm -C "$REPO_ROOT" --filter @invoker/ui exec vitest run   src/__tests__/queue-status-stale-repro.test.tsx   >"$LOG_FILE" 2>&1; then
-  echo "[repro] PASS: the test reproduced four stale queue-chip cases, then showed the chips catch up after a later successful poll / visibility restore."
+  echo "[repro] PASS: the test kept four prior stale-window scenarios live through delayed polls, poll errors, and visibility pauses."
   cat "$LOG_FILE"
   exit 0
 else
   status=$?
-  echo "[repro] FAIL: the focused stale-queue repro did not hold."
+  echo "[repro] FAIL: the focused live-queue regression did not hold."
   cat "$LOG_FILE"
   exit "$status"
 fi


### PR DESCRIPTION
## Summary

Home queue chips now follow live task updates. They no longer wait for the next queue poll after a workflow has already started.

The bug came from mixing two data paths. Workflow and task state was live, but `Executing`, `Slots`, and `Launching` still came from the delayed queue poll.

This keeps `maxConcurrency` and `Queued` on the queue snapshot. It now reads the live activity counts from the same task stream the rest of the UI already trusts.

## Review Claim

Home bottom queue chips now stay in sync with live task updates even when queue polling lags.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the chip count source changes. Queue scheduling, queue ordering, and the owner queue API stay unchanged, and `maxConcurrency` plus `Queued` still come from `getQueueStatus()`.

## Slice Rationale

The proof branch already captures the lag windows. This branch only rewires the on-screen counts to the live task stream.

## Non-goals

- Changing queue scheduling
- Changing queue row ordering in `QueueView`
- Changing the owner-side 2.5 second cache

## Architecture

### Before

```mermaid
graph TD
    A["useTasks live stream"] --> B["workflow pills and task UI"]
    C["useQueueStatus 5s poll"] --> D["WorkflowStatusChips queue counts"]
```

### After

```mermaid
graph TD
    A["useTasks live stream"] --> B["getLiveQueueCounts(tasks)"]
    C["useQueueStatus poll"] --> D["queueChrome maxConcurrency + queuedCount"]
    B --> E["WorkflowStatusChips queueChrome"]
    D --> E
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm -C . --filter @invoker/ui exec vitest run src/__tests__/queue-status-stale-repro.test.tsx --reporter=verbose`
- [ ] `scripts/repro/repro-queue-status-stale.sh`
- [ ] `pnpm -C . --filter @invoker/ui exec vitest run src/__tests__/workflow-status-chips-queue.test.tsx --reporter=verbose`
- [ ] `pnpm -C packages/app run test:e2e -- e2e/queue-running-vs-queued.spec.ts`

</details>

## Visual Proof

Bottom chrome already shows `Executing (1/6)` and `Slots (1/6)` on the same frame as the workflow is running.

![Queue chips refresh from live task state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260729-0f23d7/queue-chip-live-refresh-after.png)

[Walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260729-0f23d7/queue-chip-live-refresh-after.webm)

A still image cannot show the pre-poll timing edge. The focused renderer regression `src/__tests__/queue-status-stale-repro.test.tsx` covers next-poll lag, in-flight poll blocking, poll-error persistence, and hidden-window pause.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 382ff143716fa69fd21407cf404ebc5c9d55b320`
- Post-revert steps: None
- Data migration? No

</details>
