### PR TITLE
[E2E CI Shell](1) Fix shell harness recovery

### DIFF
--- a/scripts/e2e-dry-run/cases/case-1.1-success.sh
+++ b/scripts/e2e-dry-run/cases/case-1.1-success.sh
@@ -20,7 +20,7 @@ invoker_e2e_submit_plan "$INVOKER_E2E_REPO_ROOT/plans/e2e-dry-run/group1-single-
 ST=$(invoker_e2e_task_status e2e-g111-task)
 if [ "$ST" != "completed" ]; then
   echo "FAIL case 1.1: expected e2e-g111-task status=completed, got '$ST'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-1.2-failure.sh
+++ b/scripts/e2e-dry-run/cases/case-1.2-failure.sh
@@ -17,7 +17,7 @@ invoker_e2e_submit_plan "$INVOKER_E2E_REPO_ROOT/plans/e2e-dry-run/group1-single-
 if ! invoker_e2e_wait_task_status e2e-g112-task failed 60; then
   ST=$(invoker_e2e_task_status e2e-g112-task 2>/dev/null || true)
   echo "FAIL case 1.2: expected e2e-g112-task status=failed, got '$ST'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-1.3-cancel.sh
+++ b/scripts/e2e-dry-run/cases/case-1.3-cancel.sh
@@ -38,7 +38,7 @@ echo "==> case 1.3: wait for task to reach failed after cancel"
 if ! invoker_e2e_wait_task_status e2e-g113-task failed 180; then
   ST=$(invoker_e2e_task_status e2e-g113-task 2>/dev/null || true)
   echo "FAIL case 1.3: expected e2e-g113-task status=failed, got '$ST'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-1.4-edit-restart.sh
+++ b/scripts/e2e-dry-run/cases/case-1.4-edit-restart.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Group 1.4 — fail then edit+restart to success.
+# Group 1.4 — fail then set command + restart to success.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
@@ -24,14 +24,14 @@ if [ "$ST" != "failed" ]; then
 fi
 echo "==> case 1.4: confirmed intermediate status=failed"
 
-echo "==> case 1.4: edit command + restart"
-invoker_e2e_run_headless edit e2e-g114-task echo ok
+echo "==> case 1.4: set command + restart"
+invoker_e2e_run_headless set command e2e-g114-task echo ok
 
 ST=$(invoker_e2e_task_status e2e-g114-task)
 if [ "$ST" != "completed" ]; then
   echo "FAIL case 1.4: expected final status=completed, got '$ST'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 
-echo "PASS case 1.4 (e2e-g114-task edit+restart → completed)"
+echo "PASS case 1.4 (e2e-g114-task set command + restart → completed)"

--- a/scripts/e2e-dry-run/cases/case-1.5-fix-approve.sh
+++ b/scripts/e2e-dry-run/cases/case-1.5-fix-approve.sh
@@ -32,7 +32,7 @@ invoker_e2e_wait_settled e2e-g115-task
 ST=$(invoker_e2e_task_status e2e-g115-task)
 if [ "$ST" != "awaiting_approval" ]; then
   echo "FAIL case 1.5: expected status=awaiting_approval after fix, got '$ST'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 1.5: confirmed status=awaiting_approval"
@@ -44,7 +44,7 @@ invoker_e2e_wait_settled e2e-g115-task
 ST=$(invoker_e2e_task_status e2e-g115-task)
 if [ "$ST" != "completed" ]; then
   echo "FAIL case 1.5: expected status=completed after approve, got '$ST'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-1.6-fix-reject.sh
+++ b/scripts/e2e-dry-run/cases/case-1.6-fix-reject.sh
@@ -32,7 +32,7 @@ invoker_e2e_wait_settled e2e-g116-task
 ST=$(invoker_e2e_task_status e2e-g116-task)
 if [ "$ST" != "awaiting_approval" ]; then
   echo "FAIL case 1.6: expected status=awaiting_approval after fix, got '$ST'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 1.6: confirmed status=awaiting_approval"
@@ -44,7 +44,7 @@ invoker_e2e_wait_settled e2e-g116-task
 ST=$(invoker_e2e_task_status e2e-g116-task)
 if [ "$ST" != "failed" ]; then
   echo "FAIL case 1.6: expected status=failed after reject, got '$ST'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-1.7-manual-approve.sh
+++ b/scripts/e2e-dry-run/cases/case-1.7-manual-approve.sh
@@ -20,7 +20,7 @@ invoker_e2e_submit_plan "$INVOKER_E2E_REPO_ROOT/plans/e2e-dry-run/group1-single-
 ST=$(invoker_e2e_task_status e2e-g117-task)
 if [ "$ST" != "awaiting_approval" ]; then
   echo "FAIL case 1.7: expected status=awaiting_approval after submit, got '$ST'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 1.7: confirmed status=awaiting_approval"
@@ -31,7 +31,7 @@ invoker_e2e_run_headless approve e2e-g117-task
 ST=$(invoker_e2e_task_status e2e-g117-task)
 if [ "$ST" != "completed" ]; then
   echo "FAIL case 1.7: expected status=completed after approve, got '$ST'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-1.8-manual-reject.sh
+++ b/scripts/e2e-dry-run/cases/case-1.8-manual-reject.sh
@@ -20,7 +20,7 @@ invoker_e2e_submit_plan "$INVOKER_E2E_REPO_ROOT/plans/e2e-dry-run/group1-single-
 ST=$(invoker_e2e_task_status e2e-g118-task)
 if [ "$ST" != "awaiting_approval" ]; then
   echo "FAIL case 1.8: expected status=awaiting_approval after submit, got '$ST'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 1.8: confirmed status=awaiting_approval"
@@ -31,7 +31,7 @@ invoker_e2e_run_headless reject e2e-g118-task
 ST=$(invoker_e2e_task_status e2e-g118-task)
 if [ "$ST" != "failed" ]; then
   echo "FAIL case 1.8: expected status=failed after reject, got '$ST'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-1.9-fix-codex-approve.sh
+++ b/scripts/e2e-dry-run/cases/case-1.9-fix-codex-approve.sh
@@ -32,7 +32,7 @@ invoker_e2e_wait_settled e2e-g119-task
 ST=$(invoker_e2e_task_status e2e-g119-task)
 if [ "$ST" != "awaiting_approval" ]; then
   echo "FAIL case 1.9: expected status=awaiting_approval after fix, got '$ST'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 1.9: confirmed status=awaiting_approval"
@@ -53,7 +53,7 @@ invoker_e2e_wait_settled e2e-g119-task
 ST=$(invoker_e2e_task_status e2e-g119-task)
 if [ "$ST" != "completed" ]; then
   echo "FAIL case 1.9: expected status=completed after approve, got '$ST'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-2.1-sequential-success.sh
+++ b/scripts/e2e-dry-run/cases/case-2.1-sequential-success.sh
@@ -21,7 +21,7 @@ STA=$(invoker_e2e_task_status e2e-g221-taskA)
 STB=$(invoker_e2e_task_status e2e-g221-taskB)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ]; then
   echo "FAIL case 2.1: expected taskA=completed taskB=completed, got A='$STA' B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-2.10-cancel-downstream.sh
+++ b/scripts/e2e-dry-run/cases/case-2.10-cancel-downstream.sh
@@ -38,7 +38,7 @@ echo "==> case 2.10: wait for task A to reach failed after cancel"
 if ! invoker_e2e_wait_task_status e2e-g2210-taskA failed 180; then
   STA=$(invoker_e2e_task_status e2e-g2210-taskA 2>/dev/null || true)
   echo "FAIL case 2.10: expected A=failed, got A='$STA'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 
@@ -47,7 +47,7 @@ STB=$(invoker_e2e_task_status e2e-g2210-taskB)
 # 'blocked' (#3473). 'pending' is valid if the cascade hasn't reached it yet.
 if [ "$STB" != "blocked" ] && [ "$STB" != "pending" ]; then
   echo "FAIL case 2.10: expected B=blocked|pending, got B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-2.11-edit-restart-downstream.sh
+++ b/scripts/e2e-dry-run/cases/case-2.11-edit-restart-downstream.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Group 2.11 — A fails, edit command to fix, B runs after restart succeeds.
+# Group 2.11 — A fails, set command to fix, B runs after restart succeeds.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
@@ -21,20 +21,20 @@ STA=$(invoker_e2e_task_status e2e-g2211-taskA)
 STB=$(invoker_e2e_task_status e2e-g2211-taskB)
 if [ "$STA" != "failed" ] || [ "$STB" != "pending" ]; then
   echo "FAIL case 2.11: expected A=failed B=pending, got A='$STA' B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 2.11: confirmed A=failed, B=pending"
 
-echo "==> case 2.11: edit A command + restart"
-invoker_e2e_run_headless edit e2e-g2211-taskA echo ok
+echo "==> case 2.11: set A command + restart"
+invoker_e2e_run_headless set command e2e-g2211-taskA echo ok
 
 STA=$(invoker_e2e_task_status e2e-g2211-taskA)
 STB=$(invoker_e2e_task_status e2e-g2211-taskB)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ]; then
   echo "FAIL case 2.11: expected A=completed B=completed, got A='$STA' B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 
-echo "PASS case 2.11 (edit A → restart → A=completed, B=completed)"
+echo "PASS case 2.11 (set A command → restart → A=completed, B=completed)"

--- a/scripts/e2e-dry-run/cases/case-2.12-manual-approve-downstream.sh
+++ b/scripts/e2e-dry-run/cases/case-2.12-manual-approve-downstream.sh
@@ -21,7 +21,7 @@ STA=$(invoker_e2e_task_status e2e-g2212-taskA)
 STB=$(invoker_e2e_task_status e2e-g2212-taskB)
 if [ "$STA" != "awaiting_approval" ] || [ "$STB" != "pending" ]; then
   echo "FAIL case 2.12: expected A=awaiting_approval B=pending, got A='$STA' B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 2.12: confirmed A=awaiting_approval, B=pending"
@@ -33,7 +33,7 @@ STA=$(invoker_e2e_task_status e2e-g2212-taskA)
 STB=$(invoker_e2e_task_status e2e-g2212-taskB)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ]; then
   echo "FAIL case 2.12: expected A=completed B=completed, got A='$STA' B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-2.13-rebase-recreate-coalesced.sh
+++ b/scripts/e2e-dry-run/cases/case-2.13-rebase-recreate-coalesced.sh
@@ -25,7 +25,7 @@ STA=$(invoker_e2e_task_status e2e-g2213-taskA)
 STB=$(invoker_e2e_task_status e2e-g2213-taskB)
 if [ "$STA" != "failed" ] || [ "$STB" != "pending" ]; then
   echo "FAIL case 2.13: expected A=failed B=pending, got A='$STA' B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 
@@ -33,7 +33,7 @@ WF_ID="$(invoker_e2e_run_headless query workflows --output label | grep -E '^wf-
 TASK_ID="$(invoker_e2e_run_headless query tasks --workflow "$WF_ID" --no-merge --output label | grep '/' | head -1)"
 if [ -z "${WF_ID:-}" ] || [ -z "${TASK_ID:-}" ]; then
   echo "FAIL case 2.13: could not resolve workflow/task ids"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 
@@ -89,7 +89,7 @@ if [ "$DELTA" -lt 1 ]; then
     echo "--- recreate $i output ---"
     sed -n '1,40p' "$TMP_DIR/recreate-$i.out" || true
   done
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-2.14-standalone-timeout-deadlock-guard.sh
+++ b/scripts/e2e-dry-run/cases/case-2.14-standalone-timeout-deadlock-guard.sh
@@ -34,7 +34,7 @@ fi
 STA="$(invoker_e2e_task_status e2e-g2214-taskA)"
 if [ "$STA" != "failed" ]; then
   echo "FAIL case 2.14: expected taskA=failed, got '$STA'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 
@@ -111,7 +111,7 @@ for line in sys.stdin:
 if [ -n "$STALE_RUNNING" ]; then
   echo "FAIL case 2.14: found stale running task(s) after guarded rebase-retry-all"
   echo "$STALE_RUNNING"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-2.15-recreate-preempt-attempt-refresh.sh
+++ b/scripts/e2e-dry-run/cases/case-2.15-recreate-preempt-attempt-refresh.sh
@@ -31,7 +31,7 @@ invoker_e2e_submit_plan_no_track_capture "$PLAN_PATH" "$SUBMIT_LOG"
 WF_ID="$(invoker_e2e_extract_workflow_id_from_log "$SUBMIT_LOG")"
 if [ -z "$WF_ID" ]; then
   echo "FAIL case 2.15: could not resolve workflow id"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 
@@ -60,7 +60,7 @@ done
 
 if [ "$IN_FLIGHT" != "yes" ]; then
   echo "FAIL case 2.15: task did not become in-flight before recreate"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 
@@ -98,7 +98,7 @@ fi
 
 if [ "$STATUS_AFTER" != "running" ] && [ "$STATUS_AFTER" != "pending" ] && [ "$STATUS_AFTER" != "queued" ] && [ "$STATUS_AFTER" != "completed" ]; then
   echo "FAIL case 2.15: expected task to be queued|pending|running after recreate, got '$STATUS_AFTER'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh
+++ b/scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh
@@ -94,7 +94,7 @@ KEEP_ST="$(invoker_e2e_task_status "$KEEP_TASK_ID" 2>/dev/null || true)"
 FAIL_ST="$(invoker_e2e_task_status "$FAIL_TASK_ID" 2>/dev/null || true)"
 if [ "$KEEP_ST" != "completed" ] || [ "$FAIL_ST" != "failed" ]; then
   echo "FAIL case 2.16: expected seed states completed+failed, got keep=$KEEP_ST fail=$FAIL_ST"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 
@@ -125,7 +125,7 @@ esac
 
 if [ "$retry_fail_left_failed" -ne 1 ]; then
   echo "FAIL case 2.16: retry did not move failed task out of failed within 5s"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 
@@ -195,7 +195,7 @@ fi
 
 if [ "$recreate_snapshot_has_reset_state" -ne 1 ]; then
   echo "FAIL case 2.16: recreate did not show pending or queued state in first 5s snapshots"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-2.2-sequential-upstream-fail.sh
+++ b/scripts/e2e-dry-run/cases/case-2.2-sequential-upstream-fail.sh
@@ -21,7 +21,7 @@ STA=$(invoker_e2e_task_status e2e-g222-taskA)
 STB=$(invoker_e2e_task_status e2e-g222-taskB)
 if [ "$STA" != "failed" ] || [ "$STB" != "pending" ]; then
   echo "FAIL case 2.2: expected taskA=failed taskB=pending, got A='$STA' B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-2.3-parallel-success.sh
+++ b/scripts/e2e-dry-run/cases/case-2.3-parallel-success.sh
@@ -21,7 +21,7 @@ STA=$(invoker_e2e_task_status e2e-g223-taskA)
 STB=$(invoker_e2e_task_status e2e-g223-taskB)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ]; then
   echo "FAIL case 2.3: expected taskA=completed taskB=completed, got A='$STA' B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-2.4-fan-in-success.sh
+++ b/scripts/e2e-dry-run/cases/case-2.4-fan-in-success.sh
@@ -22,7 +22,7 @@ STB=$(invoker_e2e_task_status e2e-g224-taskB)
 STC=$(invoker_e2e_task_status e2e-g224-taskC)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ] || [ "$STC" != "completed" ]; then
   echo "FAIL case 2.4: expected all completed, got A='$STA' B='$STB' C='$STC'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-2.5-fan-in-partial-fail.sh
+++ b/scripts/e2e-dry-run/cases/case-2.5-fan-in-partial-fail.sh
@@ -22,7 +22,7 @@ STB=$(invoker_e2e_task_status e2e-g225-taskB)
 STC=$(invoker_e2e_task_status e2e-g225-taskC)
 if [ "$STA" != "completed" ] || [ "$STB" != "failed" ] || [ "$STC" != "pending" ]; then
   echo "FAIL case 2.5: expected A=completed B=failed C=pending, got A='$STA' B='$STB' C='$STC'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-2.6-diamond-success.sh
+++ b/scripts/e2e-dry-run/cases/case-2.6-diamond-success.sh
@@ -23,7 +23,7 @@ STC=$(invoker_e2e_task_status e2e-g226-taskC)
 STD=$(invoker_e2e_task_status e2e-g226-taskD)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ] || [ "$STC" != "completed" ] || [ "$STD" != "completed" ]; then
   echo "FAIL case 2.6: expected all completed, got A='$STA' B='$STB' C='$STC' D='$STD'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-2.7-fan-in-fix.sh
+++ b/scripts/e2e-dry-run/cases/case-2.7-fan-in-fix.sh
@@ -22,7 +22,7 @@ STB=$(invoker_e2e_task_status e2e-g227-taskB)
 STC=$(invoker_e2e_task_status e2e-g227-taskC)
 if [ "$STA" != "failed" ] || [ "$STB" != "completed" ] || [ "$STC" != "pending" ]; then
   echo "FAIL case 2.7: expected A=failed B=completed C=pending, got A='$STA' B='$STB' C='$STC'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 2.7: confirmed A=failed, B=completed, C=pending"
@@ -33,7 +33,7 @@ invoker_e2e_run_headless fix e2e-g227-taskA
 STA=$(invoker_e2e_task_status e2e-g227-taskA)
 if [ "$STA" != "awaiting_approval" ]; then
   echo "FAIL case 2.7: expected A=awaiting_approval after fix, got '$STA'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 2.7: confirmed A=awaiting_approval"
@@ -46,7 +46,7 @@ STB=$(invoker_e2e_task_status e2e-g227-taskB)
 STC=$(invoker_e2e_task_status e2e-g227-taskC)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ] || [ "$STC" != "completed" ]; then
   echo "FAIL case 2.7: expected all completed, got A='$STA' B='$STB' C='$STC'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-2.8-fix-reject-downstream.sh
+++ b/scripts/e2e-dry-run/cases/case-2.8-fix-reject-downstream.sh
@@ -21,7 +21,7 @@ STA=$(invoker_e2e_task_status e2e-g228-taskA)
 STB=$(invoker_e2e_task_status e2e-g228-taskB)
 if [ "$STA" != "failed" ] || [ "$STB" != "pending" ]; then
   echo "FAIL case 2.8: expected A=failed B=pending, got A='$STA' B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 2.8: confirmed A=failed, B=pending"
@@ -32,7 +32,7 @@ invoker_e2e_run_headless fix e2e-g228-taskA
 STA=$(invoker_e2e_task_status e2e-g228-taskA)
 if [ "$STA" != "awaiting_approval" ]; then
   echo "FAIL case 2.8: expected A=awaiting_approval after fix, got '$STA'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 2.8: confirmed A=awaiting_approval"
@@ -44,7 +44,7 @@ STA=$(invoker_e2e_task_status e2e-g228-taskA)
 STB=$(invoker_e2e_task_status e2e-g228-taskB)
 if [ "$STA" != "failed" ] || [ "$STB" != "pending" ]; then
   echo "FAIL case 2.8: expected A=failed B=pending after reject, got A='$STA' B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-2.9-diamond-fail.sh
+++ b/scripts/e2e-dry-run/cases/case-2.9-diamond-fail.sh
@@ -44,7 +44,7 @@ STC=$(invoker_e2e_task_status e2e-g229-taskC)
 STD=$(invoker_e2e_task_status e2e-g229-taskD)
 if [ "$STA" != "completed" ] || [ "$STB" != "failed" ] || { [ "$STC" != "pending" ] && [ "$STC" != "completed" ]; } || [ "$STD" != "pending" ] || [ "$WF_STATUS" != "failed" ]; then
   echo "FAIL case 2.9: expected workflow=failed A=completed B=failed C=pending|completed D=pending, got workflow='$WF_STATUS' A='$STA' B='$STB' C='$STC' D='$STD'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-4.1-fix-downstream.sh
+++ b/scripts/e2e-dry-run/cases/case-4.1-fix-downstream.sh
@@ -37,7 +37,7 @@ invoker_e2e_run_headless fix e2e-g441-taskA
 STA=$(invoker_e2e_task_status e2e-g441-taskA)
 if [ "$STA" != "awaiting_approval" ]; then
   echo "FAIL case 4.1: expected A=awaiting_approval after fix, got '$STA'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 4.1: confirmed A=awaiting_approval"
@@ -49,7 +49,7 @@ STA=$(invoker_e2e_task_status e2e-g441-taskA)
 STB=$(invoker_e2e_task_status e2e-g441-taskB)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ]; then
   echo "FAIL case 4.1: expected A=completed B=completed, got A='$STA' B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-4.2-github-pr.sh
+++ b/scripts/e2e-dry-run/cases/case-4.2-github-pr.sh
@@ -21,7 +21,7 @@ STA=$(invoker_e2e_task_status e2e-g442-taskA)
 STB=$(invoker_e2e_task_status e2e-g442-taskB)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ]; then
   echo "FAIL case 4.2: expected A=completed B=completed, got A='$STA' B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 4.2: confirmed A=completed, B=completed"
@@ -31,7 +31,7 @@ echo "==> case 4.2: confirmed A=completed, B=completed"
 MERGE_ID=$(invoker_e2e_merge_gate_id)
 if [ -z "$MERGE_ID" ]; then
   echo "FAIL case 4.2: could not find merge gate task ID"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 4.2: merge gate ID=$MERGE_ID"
@@ -39,7 +39,7 @@ echo "==> case 4.2: merge gate ID=$MERGE_ID"
 STM=$(invoker_e2e_task_status "$MERGE_ID")
 if [ "$STM" != "awaiting_approval" ] && [ "$STM" != "review_ready" ]; then
   echo "FAIL case 4.2: expected merge gate=awaiting_approval|review_ready, got '$STM'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 4.2: confirmed merge gate status=$STM"
@@ -83,7 +83,7 @@ done
 
 if [ "$STM" != "completed" ]; then
   echo "FAIL case 4.2: expected merge gate=completed after PR merge, got '$STM'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 

--- a/scripts/e2e-dry-run/cases/case-4.3-fix-then-pr.sh
+++ b/scripts/e2e-dry-run/cases/case-4.3-fix-then-pr.sh
@@ -32,7 +32,7 @@ invoker_e2e_case43_dump_state() {
   fi
 
   echo "DIAG case 4.3: headless status begin"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   echo "DIAG case 4.3: headless status end"
 }
 
@@ -86,7 +86,7 @@ invoker_e2e_wait_settled e2e-g443-taskA
 STA=$(invoker_e2e_case43_task_status e2e-g443-taskA)
 if [ "$STA" != "awaiting_approval" ]; then
   echo "FAIL case 4.3: expected A=awaiting_approval after fix, got '$STA'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 4.3: confirmed A=awaiting_approval"
@@ -106,7 +106,7 @@ STA=$(invoker_e2e_case43_task_status e2e-g443-taskA)
 STB=$(invoker_e2e_case43_task_status e2e-g443-taskB)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ]; then
   echo "FAIL case 4.3: expected A=completed B=completed, got A='$STA' B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 4.3: confirmed A=completed, B=completed"
@@ -115,7 +115,7 @@ echo "==> case 4.3: confirmed A=completed, B=completed"
 MERGE_ID=$(invoker_e2e_merge_gate_id)
 if [ -z "$MERGE_ID" ]; then
   echo "FAIL case 4.3: could not find merge gate task ID"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 4.3: merge gate ID=$MERGE_ID"
@@ -147,7 +147,7 @@ done
 
 if [ "$STM" != "awaiting_approval" ] && [ "$STM" != "review_ready" ]; then
   echo "FAIL case 4.3: expected merge gate=awaiting_approval|review_ready, got '$STM'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> case 4.3: confirmed merge gate status=$STM"

--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -277,6 +277,95 @@ invoker_e2e_ensure_workspace_dependencies() {
   )
 }
 
+invoker_e2e_lock_mtime_epoch() {
+  local path="$1"
+  stat -c %Y "$path" 2>/dev/null || stat -f %m "$path" 2>/dev/null || printf '0'
+}
+
+invoker_e2e_build_lock_pid() {
+  local owner_file="$1/owner"
+  if [ -r "$owner_file" ]; then
+    sed -n 's/^pid=//p' "$owner_file" 2>/dev/null | head -1
+  fi
+}
+
+invoker_e2e_describe_build_lock() {
+  local lock_dir="$1"
+  if [ -r "$lock_dir/owner" ]; then
+    sed 's/^/  /' "$lock_dir/owner" >&2
+  elif [ -d "$lock_dir" ]; then
+    ls -ld "$lock_dir" >&2 || true
+  else
+    echo "  <lock no longer exists>" >&2
+  fi
+}
+
+invoker_e2e_write_build_lock_owner() {
+  local lock_dir="$1"
+  {
+    printf 'pid=%s\n' "${BASHPID:-$$}"
+    printf 'host=%s\n' "$(hostname 2>/dev/null || printf unknown)"
+    printf 'started_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf 'repo=%s\n' "$INVOKER_E2E_REPO_ROOT"
+  } > "$lock_dir/owner"
+}
+
+invoker_e2e_try_acquire_build_lock() {
+  local lock_dir="$1"
+  if mkdir "$lock_dir" 2>/dev/null; then
+    invoker_e2e_write_build_lock_owner "$lock_dir"
+    return 0
+  fi
+  return 1
+}
+
+invoker_e2e_release_build_lock() {
+  local lock_dir="$1"
+  local owner_pid=""
+  owner_pid="$(invoker_e2e_build_lock_pid "$lock_dir")"
+  if [ -n "$owner_pid" ] && [ "$owner_pid" != "${BASHPID:-$$}" ]; then
+    echo "WARN: not removing shared app/ui build lock owned by pid=$owner_pid" >&2
+    return 0
+  fi
+  rm -f "$lock_dir/owner" 2>/dev/null || true
+  rmdir "$lock_dir" 2>/dev/null || true
+}
+
+invoker_e2e_reclaim_stale_build_lock() {
+  local lock_dir="$1"
+  local stale_after_secs="$2"
+  local owner_pid=""
+  local mtime_epoch=0
+  local now_epoch=0
+  local age_secs=0
+  local reason=""
+
+  [ -d "$lock_dir" ] || return 1
+  [ "$(basename "$lock_dir")" = "invoker-e2e-build.lock" ] || return 1
+
+  owner_pid="$(invoker_e2e_build_lock_pid "$lock_dir")"
+  if [ -n "$owner_pid" ] && ! kill -0 "$owner_pid" 2>/dev/null; then
+    reason="owner pid $owner_pid is no longer running"
+  fi
+
+  if [ -z "$reason" ]; then
+    mtime_epoch="$(invoker_e2e_lock_mtime_epoch "$lock_dir")"
+    now_epoch="$(date +%s)"
+    if [ "$mtime_epoch" -gt 0 ] 2>/dev/null; then
+      age_secs=$((now_epoch - mtime_epoch))
+      if [ "$age_secs" -ge "$stale_after_secs" ]; then
+        reason="lock age ${age_secs}s exceeded ${stale_after_secs}s"
+      fi
+    fi
+  fi
+
+  [ -n "$reason" ] || return 1
+  echo "WARN: reclaiming stale shared app/ui build lock: $reason" >&2
+  invoker_e2e_describe_build_lock "$lock_dir"
+  rm -f "$lock_dir/owner" 2>/dev/null || true
+  rmdir "$lock_dir" 2>/dev/null
+}
+
 invoker_e2e_ensure_app_built() {
   # Containerized CI steps can lose checkout's temporary safe.directory config
   # before this helper runs, so re-establish it before the first git call.
@@ -284,13 +373,15 @@ invoker_e2e_ensure_app_built() {
   local git_dir
   git_dir="$(git -C "$INVOKER_E2E_REPO_ROOT" rev-parse --git-dir)"
   local build_lock_dir="$git_dir/invoker-e2e-build.lock"
+  local build_lock_stale_secs="${INVOKER_E2E_BUILD_LOCK_STALE_SECS:-600}"
   local wait_secs=0
+  local acquired_build_lock=0
   if [ "${INVOKER_E2E_FORCE_BUILD:-0}" != "1" ] && invoker_e2e_workspace_dependencies_are_ready && invoker_e2e_app_ui_build_is_fresh; then
     echo "==> e2e: reusing existing app/ui build artifacts"
     return 0
   fi
-  if mkdir "$build_lock_dir" 2>/dev/null; then
-    trap 'rmdir "$build_lock_dir" 2>/dev/null || true' RETURN
+  if invoker_e2e_try_acquire_build_lock "$build_lock_dir"; then
+    acquired_build_lock=1
   else
     echo "==> e2e: waiting for shared app/ui build lock"
     while [ -d "$build_lock_dir" ]; do
@@ -298,23 +389,31 @@ invoker_e2e_ensure_app_built() {
         echo "==> e2e: shared build completed by another shard"
         return 0
       fi
+      if invoker_e2e_reclaim_stale_build_lock "$build_lock_dir" "$build_lock_stale_secs"; then
+        if invoker_e2e_try_acquire_build_lock "$build_lock_dir"; then
+          acquired_build_lock=1
+          break
+        fi
+      fi
       sleep 1
       wait_secs=$((wait_secs + 1))
       if [ "$wait_secs" -ge 300 ]; then
         echo "ERROR: timed out waiting for shared app/ui build lock" >&2
+        invoker_e2e_describe_build_lock "$build_lock_dir"
         return 1
       fi
     done
-    if [ "${INVOKER_E2E_FORCE_BUILD:-0}" != "1" ] && invoker_e2e_workspace_dependencies_are_ready && invoker_e2e_app_ui_build_is_fresh; then
+    if [ "$acquired_build_lock" != "1" ] && [ "${INVOKER_E2E_FORCE_BUILD:-0}" != "1" ] && invoker_e2e_workspace_dependencies_are_ready && invoker_e2e_app_ui_build_is_fresh; then
       echo "==> e2e: shared build completed by another shard"
       return 0
     fi
-    if ! mkdir "$build_lock_dir" 2>/dev/null; then
+    if [ "$acquired_build_lock" != "1" ] && ! invoker_e2e_try_acquire_build_lock "$build_lock_dir"; then
       echo "ERROR: unable to acquire shared app/ui build lock" >&2
+      invoker_e2e_describe_build_lock "$build_lock_dir"
       return 1
     fi
-    trap 'rmdir "$build_lock_dir" 2>/dev/null || true' RETURN
   fi
+  trap 'invoker_e2e_release_build_lock "$build_lock_dir"' RETURN
   invoker_e2e_ensure_workspace_dependencies
   echo "==> e2e: building @invoker/ui and @invoker/app"
   (
@@ -494,6 +593,10 @@ invoker_e2e_task_status() {
     | tail -1
 }
 
+invoker_e2e_dump_tasks() {
+  invoker_e2e_run_headless query tasks --output label 2>&1 || true
+}
+
 # Poll until task status equals expected (1s interval). Use after cancel/restart
 # where a fixed sleep is flaky under load or without GNU timeout(1) on macOS.
 # Usage: invoker_e2e_wait_task_status <taskId> <expectedStatus> [maxSeconds]
@@ -635,7 +738,7 @@ invoker_e2e_assert_no_stale_running_tasks() {
   if [ -n "$stale" ]; then
     echo "FAIL: found stale running task(s) older than ${threshold_secs}s" >&2
     echo "$stale" >&2
-    invoker_e2e_run_headless status 2>&1 || true
+    invoker_e2e_dump_tasks
     return 1
   fi
 }

--- a/scripts/monkey-run/headless-forced-kill-repro.sh
+++ b/scripts/monkey-run/headless-forced-kill-repro.sh
@@ -227,7 +227,7 @@ for _ in $(seq 1 40); do
 done
 if [[ -z "$RESOLVED_ID" ]]; then
   echo "repro: task never entered running" >&2
-  invoker_e2e_run_headless status >&2 || true
+  invoker_e2e_dump_tasks >&2
   exit 1
 fi
 echo "stage: task running as $RESOLVED_ID"

--- a/scripts/verify-pr-authoring-fallback-headless.sh
+++ b/scripts/verify-pr-authoring-fallback-headless.sh
@@ -42,7 +42,7 @@ STA=$(invoker_e2e_task_status verify-pr-fallback-taskA)
 STB=$(invoker_e2e_task_status verify-pr-fallback-taskB)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ]; then
   echo "FAIL: expected taskA=completed taskB=completed, got A='$STA' B='$STB'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "PASS: both command tasks completed (A=$STA, B=$STB)"
@@ -52,7 +52,7 @@ echo "PASS: both command tasks completed (A=$STA, B=$STB)"
 MERGE_ID=$(invoker_e2e_merge_gate_id)
 if [ -z "$MERGE_ID" ]; then
   echo "FAIL: could not find merge gate task ID"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "==> merge gate ID=$MERGE_ID"
@@ -60,7 +60,7 @@ echo "==> merge gate ID=$MERGE_ID"
 STM=$(invoker_e2e_task_status "$MERGE_ID")
 if [ "$STM" != "awaiting_approval" ] && [ "$STM" != "review_ready" ]; then
   echo "FAIL: expected merge gate=awaiting_approval|review_ready, got '$STM'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_dump_tasks
   exit 1
 fi
 echo "PASS: merge gate status=$STM"


### PR DESCRIPTION
## Summary

This updates the CI policy shell harness that drives e2e dry-run coverage.

Restart cases now use the supported task update flow before rerunning their jobs.

The shared app/UI build lock records ownership, reports holders, and reclaims abandoned lock directories.

## Review Claim

Approve the CI policy shell harness repair for e2e dry-run restart cases and shared build locking.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only shell harness files under `scripts/` change, so product runtime code and persisted data paths are untouched.

## Slice Rationale

The restart case repair and build-lock repair both unblock the same e2e CI policy shards.

## Non-goals

- No application runtime behavior changes.
- No Playwright shard inventory changes.
- No repro-only script changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `mkdir -p /tmp/invoker-tmp && chmod 1777 /tmp/invoker-tmp && INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_STATE_FILE=/tmp/invoker-local-proof-state-after-ff.tsv TMPDIR=/tmp/invoker-tmp bash scripts/run-all-tests.sh`
- [x] `TMPDIR=/tmp/invoker-tmp INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_SHARD_INDEX=2 INVOKER_TEST_ALL_SHARD_TOTAL=4 INVOKER_TEST_ALL_STATE_FILE=/tmp/invoker-local-proof-shard2-after-fixes.tsv bash scripts/run-all-tests.sh`
- [x] `TMPDIR=/tmp/invoker-tmp bash scripts/test-suites/optional/30-e2e-ssh.sh`
- [x] `TMPDIR=/tmp/invoker-tmp bash scripts/test-suites/optional/31-e2e-ssh-merge.sh`
- [x] `TMPDIR=/tmp/invoker-tmp bash scripts/e2e-dry-run/cases/case-1.4-edit-restart.sh`
- [x] `TMPDIR=/tmp/invoker-tmp bash scripts/e2e-dry-run/cases/case-2.11-edit-restart-downstream.sh`
- [x] `bash -lc 'git diff --name-only -- "*.sh" | xargs -r bash -n'`
- [x] `git diff --check`
- [x] `rg -n "invoker_e2e_run_headless edit\b|invoker_e2e_run_headless status\b" scripts/e2e-dry-run scripts/repro scripts/verify-pr-authoring-fallback-headless.sh scripts/monkey-run/headless-forced-kill-repro.sh || true`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert cf1390c07f`
- Post-revert steps: rerun the required e2e proof shard before requeueing CI.
- Data migration? No.

</details>
