### PR TITLE
[Playwright Inventory](1) Restore shard matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,6 +599,8 @@ jobs:
               e2e/launching-stall-watchdog.spec.ts
               e2e/embedded-terminal-pty.spec.ts
               e2e/keyboard-navigation.spec.ts
+              e2e/claude-planning-preset-visual-proof.spec.ts
+              e2e/planning-presets-load-failure.spec.ts
           - name: 2-of-7
             files: >-
               e2e/action-graph-visual-proof.spec.ts
@@ -615,6 +617,7 @@ jobs:
               e2e/queue-running-vs-queued.spec.ts
               e2e/startup-window-liveness.spec.ts
               e2e/workflow-lifecycle.spec.ts
+              e2e/base-branch-normalization.proof.spec.ts
           - name: 4-of-7
             files: >-
               e2e/edit-task-prompt.spec.ts
@@ -623,6 +626,7 @@ jobs:
               e2e/autofix-worker-ui.spec.ts
               e2e/orphan-relaunch.spec.ts
               e2e/gap-recovery-bench.spec.ts
+              e2e/planning-chat-send-long-deadline.spec.ts
           - name: 5-of-7
             files: >-
               e2e/system-setup-visual-proof.spec.ts
@@ -630,6 +634,9 @@ jobs:
               e2e/embedded-terminal-spawn-failure.spec.ts
               e2e/embedded-terminal-restart-persistence.spec.ts
               e2e/planning-terminal-restart-persistence.spec.ts
+              e2e/planning-terminal-open-daemon-owner-repro.spec.ts
+              e2e/planning-terminal-tmux-blank-repro.spec.ts
+              e2e/planning-tmux-blank-repro.spec.ts
               e2e/worker-tab-scroll.spec.ts
           - name: 6-of-7
             files: >-
@@ -639,12 +646,15 @@ jobs:
               e2e/terminal-upsert-hitch-responsiveness.spec.ts
               e2e/attention-click-hitch-responsiveness.spec.ts
               e2e/focus-switch-hitch-responsiveness.spec.ts
+              e2e/planning-chat-hitch-responsiveness.spec.ts
           - name: 7-of-7
             files: >-
               e2e/command-palette-open.spec.ts
               e2e/task-new-attempt-reset.spec.ts
               e2e/persistence-recovery.spec.ts
               e2e/start-ready-production-click.spec.ts
+              e2e/gui-owner-auto-bootstrap.spec.ts
+              e2e/start-ready-daemon-owner.spec.ts
               e2e/workers-surface.spec.ts
 
     name: playwright / ${{ matrix.name }}


### PR DESCRIPTION
## Summary

This restores the CI policy Playwright shard inventory to cover every current spec file.

The guard failed on master because ten spec files were absent from the matrix.

The missing files are assigned across the existing seven shards without changing the shard runner.

## Review Claim

Approve the CI policy matrix inventory update for Playwright shard coverage.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the workflow file list changes, so app code, spec bodies, and runtime data paths are untouched.

## Slice Rationale

This workflow-only branch is separate because it changes CI policy rather than shell scripts.

## Non-goals

- No app runtime behavior changes.
- No spec body changes.
- No shell harness changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] CI inventory guard:

```bash
node <<'NODE'
const fs = require('node:fs');
const YAML = require('yaml');

const workflow = YAML.parse(fs.readFileSync('.github/workflows/ci.yml', 'utf8'));
const perfJob = workflow.jobs['playwright-nightly-perf'];
const shards = [
  ...workflow.jobs.playwright.strategy.matrix.include,
  ...(perfJob ? perfJob.strategy.matrix.include : []),
];
const listed = shards.flatMap((shard) => String(shard.files).trim().split(/\s+/).filter(Boolean));
const discovered = fs.readdirSync('packages/app/e2e')
  .filter((file) => file.endsWith('.spec.ts'))
  .map((file) => `e2e/${file}`)
  .sort();

const listedSet = new Set(listed);
const discoveredSet = new Set(discovered);
const missing = discovered.filter((file) => !listedSet.has(file));
const extra = listed.filter((file) => !discoveredSet.has(file));
const duplicates = listed.filter((file, index) => listed.indexOf(file) !== index);

if (missing.length || extra.length || duplicates.length) {
  console.error('Playwright shard inventory drift detected.');
  if (missing.length) console.error(`Missing from shards: ${missing.join(', ')}`);
  if (extra.length) console.error(`Extra in shards: ${extra.join(', ')}`);
  if (duplicates.length) console.error(`Duplicate shard entries: ${[...new Set(duplicates)].join(', ')}`);
  process.exit(1);
}

console.log(`Playwright shard inventory matches ${discovered.length} spec files.`);
NODE
```

- [x] `git diff --cached --check`
- [x] `git diff --check origin/master...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 91d3980699`
- Post-revert steps: rerun the Playwright shard inventory guard before requeueing CI.
- Data migration? No.

</details>
