### PR TITLE
[UI Delta Timeline](1) Add renderer task graph trace IPC contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1266,6 +1266,10 @@ export const IpcChannels = {
     request: [metric: string, data?: Record<string, unknown>];
     response: void;
   },
+  'invoker:trace-renderer-task-graph-event': {} as {
+    request: [event: TaskGraphEvent];
+    response: void;
+  },
   'invoker:get-ui-perf-stats': {} as {
     request: [];
     response: Record<string, unknown>;


### PR DESCRIPTION
## Summary

This adds the typed IPC channel for renderer task graph tracing.

The channel carries the same task graph event payload that the UI receives.

## Review Claim

The shared IPC contract now includes a typed renderer task graph trace event channel.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This slice only extends the IPC channel registry; no caller uses the channel until the next slice.

## Slice Rationale

The contract lands separately so the renderer and main-process wiring can compile against a stable channel name.

## Non-goals

- Does not register a handler.
- Does not change UI state handling.
- Does not write trace output.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/contracts build`
- [ ] `pnpm --filter @invoker/ui test`
- [ ] `pnpm --filter @invoker/app test -- src/__tests__/renderer-ui-perf.test.ts src/__tests__/ipc-registration.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b815900d3`
- Post-revert steps: Revert dependent stack slices first if they have landed.
- Data migration? No

</details>
