### PR TITLE
[UI Delta Timeline](2) Add web trace route fallback

### DIFF
--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -183,6 +183,8 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return {};
       case 'invoker:report-ui-perf':
         return undefined;
+      case 'invoker:trace-renderer-task-graph-event':
+        return undefined;
       case 'invoker:check-pr-statuses':
       case 'invoker:check-pr-status':
         await deps.checkPrStatuses?.();

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1266,6 +1266,10 @@ export const IpcChannels = {
     request: [metric: string, data?: Record<string, unknown>];
     response: void;
   },
+  'invoker:trace-renderer-task-graph-event': {} as {
+    request: [event: TaskGraphEvent];
+    response: void;
+  },
   'invoker:get-ui-perf-stats': {} as {
     request: [];
     response: Record<string, unknown>;


### PR DESCRIPTION
## Summary

This adds a web routing no-op for the renderer task graph trace channel.

The web surface now accepts the diagnostic call and returns without side effects.

## Review Claim

The web routing layer handles renderer task graph trace calls as a benign diagnostic no-op.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The handler returns `undefined` and does not read or mutate workflow state.

## Slice Rationale

This slice keeps web dispatch compatibility separate from the Electron renderer tracing path.

## Non-goals

- Does not activate renderer tracing.
- Does not write trace files.
- Does not change task graph event delivery.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app build`
- [ ] `pnpm --filter @invoker/app test -- src/__tests__/renderer-ui-perf.test.ts src/__tests__/ipc-registration.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 54f67c6ca`
- Post-revert steps: Revert dependent stack slices first if they have landed.
- Data migration? No

</details>
