### PR TITLE
[Read-only Delegated Viewer](2) Remove delegated viewer snapshot hydration

### DIFF
--- a/packages/app/src/__tests__/renderer-preload-storage-boundary.test.ts
+++ b/packages/app/src/__tests__/renderer-preload-storage-boundary.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { basename, join, relative, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+type Match = {
+  file: string;
+  line: number;
+  rule: string;
+  text: string;
+};
+
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const SOURCE_EXTENSIONS = /\.(ts|tsx|js|jsx)$/;
+const TEST_FILE_PATTERN = /\.(test|spec)\.(ts|tsx|js|jsx)$/;
+
+const FORBIDDEN_PATTERNS: Array<{ rule: string; pattern: RegExp }> = [
+  { rule: '@invoker/data-store import/reference', pattern: /@invoker\/data-store\b/ },
+  { rule: 'SQLiteAdapter reference', pattern: /\bSQLiteAdapter\b/ },
+  { rule: 'direct invoker.db reference', pattern: /\binvoker\.db\b/ },
+];
+
+function walkSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === '__tests__' || entry.name === 'node_modules' || entry.name === 'dist') {
+      continue;
+    }
+
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkSourceFiles(fullPath));
+      continue;
+    }
+
+    if (entry.isFile() && SOURCE_EXTENSIONS.test(entry.name) && !TEST_FILE_PATTERN.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function preloadSourceFiles(): string[] {
+  const appSourceDir = join(REPO_ROOT, 'packages', 'app', 'src');
+  return readdirSync(appSourceDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /^preload.*\.(ts|tsx|js|jsx)$/.test(entry.name))
+    .map((entry) => join(appSourceDir, entry.name));
+}
+
+function findForbiddenStorageReferences(files: string[]): Match[] {
+  const matches: Match[] = [];
+
+  for (const file of files) {
+    const lines = readFileSync(file, 'utf8').split('\n');
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+      for (const { rule, pattern } of FORBIDDEN_PATTERNS) {
+        if (pattern.test(line)) {
+          matches.push({
+            file: relative(REPO_ROOT, file),
+            line: index + 1,
+            rule,
+            text: line.trim(),
+          });
+        }
+      }
+    }
+  }
+
+  return matches;
+}
+
+describe('renderer/preload storage boundary', () => {
+  const uiSourceFiles = walkSourceFiles(join(REPO_ROOT, 'packages', 'ui', 'src'));
+  const preloadFiles = preloadSourceFiles();
+  const guardedFiles = [...uiSourceFiles, ...preloadFiles].sort();
+
+  it('covers the renderer package and Electron preload entrypoints', () => {
+    expect(guardedFiles.map((file) => relative(REPO_ROOT, file))).toContain('packages/ui/src/App.tsx');
+    expect(guardedFiles.map((file) => basename(file))).toContain('preload.ts');
+  });
+
+  it('keeps SQLite and data-store access out of renderer/preload-facing code', () => {
+    const matches = findForbiddenStorageReferences(guardedFiles);
+
+    if (matches.length > 0) {
+      const summary = matches
+        .map((match) => `  ${match.file}:${match.line}  [${match.rule}] ${match.text}`)
+        .join('\n');
+
+      throw new Error(
+        `Unexpected renderer/preload storage boundary violations:\n${summary}\n\n` +
+          'Renderer and preload-facing code must get task graph state through the IPC bridge. ' +
+          'Keep SQLite, @invoker/data-store, SQLiteAdapter, and invoker.db access in app main/server code.',
+      );
+    }
+
+    expect(matches).toEqual([]);
+  });
+});

--- a/packages/app/src/__tests__/viewer-cache-hydration.test.ts
+++ b/packages/app/src/__tests__/viewer-cache-hydration.test.ts
@@ -27,16 +27,16 @@ function ownerUpdateDelta(): TaskDelta {
   } as unknown as TaskDelta;
 }
 
-describe('detached viewer cache hydration', () => {
-  it('repro: an empty viewer cache quarantines (drops) an owner task update', () => {
-    // A detached viewer backed by an empty in-memory DB has an empty cache.
+describe('viewer cache hydration', () => {
+  it('repro: an empty viewer cache quarantines (drops) a task update', () => {
+    // A viewer that has not loaded an initial DB snapshot has an empty cache.
     const cache = new TaskSnapshotCache();
     const { quarantined, accepted } = applyDelta(ownerUpdateDelta(), cache);
     expect(accepted).toBe(false);
     expect(quarantined).toEqual(['wf-1/task-1']); // the live update is lost
   });
 
-  it('hydrating the caches from the owner snapshot lets the same update apply', () => {
+  it('hydrating the caches from an authoritative DB snapshot lets the same update apply', () => {
     const lastKnownTaskStates = new TaskSnapshotCache();
     const workflowRollupProjection = new WorkflowRollupProjection();
     seedTaskCachesFromSnapshot([ownerTask(1)], { lastKnownTaskStates, workflowRollupProjection });
@@ -49,7 +49,7 @@ describe('detached viewer cache hydration', () => {
     expect(merged.taskStateVersion).toBe(2);
   });
 
-  it('hydrates and clears the workflow rollup projection from the owner snapshot', () => {
+  it('hydrates and clears the workflow rollup projection from a DB snapshot', () => {
     const lastKnownTaskStates = new TaskSnapshotCache();
     const workflowRollupProjection = new WorkflowRollupProjection();
     seedTaskCachesFromSnapshot([ownerTask(1)], { lastKnownTaskStates, workflowRollupProjection });

--- a/packages/app/src/__tests__/viewer-detached-db.test.ts
+++ b/packages/app/src/__tests__/viewer-detached-db.test.ts
@@ -1,14 +1,15 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, readdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { SQLiteAdapter } from '@invoker/data-store';
 import { openMainProcessDatabase, openDetachedViewerDatabase } from '../viewer-db-boundary.js';
 import type { Workflow } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
 
 /**
- * Detached GUI viewers must never open the shared `invoker.db` file. They use
- * process-local placeholder persistence while renderer reads delegate to the
- * owner over IPC.
+ * Detached GUI viewers may open the shared `invoker.db` file read-only. React
+ * still crosses only the IPC bridge; this boundary belongs to Electron main.
  */
 
 const dirs: string[] = [];
@@ -28,6 +29,29 @@ const wf: Workflow = {
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
 };
+
+function task(id: string): TaskState {
+  return {
+    id,
+    description: id,
+    status: 'running',
+    dependencies: [],
+    createdAt: new Date('2026-07-29T00:00:00.000Z'),
+    config: { workflowId: wf.id, command: 'echo hello' },
+    execution: { phase: 'executing' },
+    taskStateVersion: 2,
+  } as TaskState;
+}
+
+async function seedDb(dbPath: string): Promise<void> {
+  const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+  try {
+    owner.saveWorkflow(wf);
+    owner.saveTask(wf.id, task('wf-1/hello-world'));
+  } finally {
+    owner.close();
+  }
+}
 
 describe('detached viewer persistence boundary', () => {
   it('uses empty in-memory persistence for read-only startup when the db file is absent', async () => {
@@ -49,45 +73,64 @@ describe('detached viewer persistence boundary', () => {
     }
   });
 
-  it('ignores the real db path and opens no database file (no -shm to truncate)', async () => {
+  it('opens the real database read-only when it exists', async () => {
     const dir = makeDir();
-    const probeDbPath = join(dir, 'invoker.db');
-    const previousCwd = process.cwd();
-    process.chdir(dir);
-    try {
-      const adapter = await openMainProcessDatabase({
-        dbPath: probeDbPath,
-        detachedViewer: true,
-        readOnly: true,
-        exclusiveLocking: true,
-      });
-      try {
-        // Fully functional: schema is present and writes/reads work in memory.
-        expect(adapter.listWorkflows()).toEqual([]);
-        adapter.saveWorkflow(wf);
-        expect(adapter.listWorkflows().map((w) => w.id)).toEqual(['wf-1']);
-        // Telemetry writes the viewer's logger attempts must not throw in memory.
-        expect(() => adapter.writeActivityLog('viewer', 'info', 'hello')).not.toThrow();
+    const dbPath = join(dir, 'invoker.db');
+    await seedDb(dbPath);
 
-        // The immunity property: no file, no -wal, no -shm anywhere.
-        expect(existsSync(probeDbPath)).toBe(false);
-        expect(existsSync(`${probeDbPath}-shm`)).toBe(false);
-        expect(existsSync(`${probeDbPath}-wal`)).toBe(false);
-        expect(readdirSync(dir)).toEqual([]);
-      } finally {
-        adapter.close();
-      }
+    const adapter = await openMainProcessDatabase({
+      dbPath,
+      detachedViewer: true,
+      readOnly: true,
+      exclusiveLocking: true,
+    });
+    try {
+      expect(adapter.listWorkflows().map((item) => item.id)).toEqual(['wf-1']);
+      expect(adapter.loadTasks(wf.id).map((item) => item.id)).toEqual(['wf-1/hello-world']);
+      expect(adapter.loadTask('wf-1/hello-world')?.status).toBe('running');
     } finally {
-      process.chdir(previousCwd);
+      adapter.close();
     }
   });
 
-  it('does not require owner capability (it never touches the shared file)', async () => {
+  it('rejects detached viewer writes when the real database exists', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    await seedDb(dbPath);
+
+    const adapter = await openMainProcessDatabase({
+      dbPath,
+      detachedViewer: true,
+      readOnly: true,
+      exclusiveLocking: false,
+    });
+    try {
+      expect(() => adapter.updateTask('wf-1/hello-world', { status: 'completed' })).toThrow(/read-only/i);
+      expect(() => adapter.saveWorkflow({ ...wf, id: 'wf-2' })).toThrow(/read-only/i);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('keeps an explicit ephemeral placeholder helper for absent databases', async () => {
     const adapter = await openDetachedViewerDatabase();
     try {
       expect(adapter).toBeDefined();
     } finally {
       adapter.close();
     }
+  });
+
+  it('does not silently fall back to empty persistence when read-only open fails', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    writeFileSync(dbPath, 'not sqlite', 'utf-8');
+
+    await expect(openMainProcessDatabase({
+      dbPath,
+      detachedViewer: true,
+      readOnly: true,
+      exclusiveLocking: false,
+    })).rejects.toThrow();
   });
 });

--- a/packages/app/src/headless-no-track-fallback.ts
+++ b/packages/app/src/headless-no-track-fallback.ts
@@ -41,7 +41,8 @@ function writeAcceptedNoTrackResult(result: WorkflowMutationAcceptedResult): voi
 }
 
 function fallbackExclusiveLockingEnabled(): boolean {
-  return process.env.INVOKER_DISABLE_EXCLUSIVE_LOCKING !== '1'
+  return process.env.INVOKER_ENABLE_EXCLUSIVE_LOCKING === '1'
+    && process.env.INVOKER_DISABLE_EXCLUSIVE_LOCKING !== '1'
     && process.env.INVOKER_UNSAFE_DISABLE_DB_WRITER_LOCK !== '1';
 }
 

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -908,7 +908,7 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
       case 'invoker:stop-worker':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resume-workflow': {
-        const workflows = rendererTaskFeed.getDetachedViewerWorkflows() ?? persistence.listWorkflows();
+        const workflows = persistence.listWorkflows();
         const firstWorkflow = workflows[0] as { id?: unknown } | undefined;
         const workflowId = context.getStartupWorkflowId()
           ?? (typeof firstWorkflow?.id === 'string' ? firstWorkflow.id : undefined);

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1,4 +1,7 @@
 import type { App, BrowserWindow, IpcMain } from 'electron';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { Orchestrator, CommandService, OrchestratorErrorCode, normalizeWorkflowBaseBranch } from '@invoker/workflow-core';
 import type { TaskDelta, TaskReplacementDef, TaskState, TaskStateChanges } from '@invoker/workflow-core';
 import { CommandError, IpcChannels, makeEnvelope } from '@invoker/contracts';
@@ -15,6 +18,7 @@ import type {
   Logger,
   StartReadyRequest,
   StartReadyResult,
+  TaskGraphEvent,
   WorkflowMutationAcceptedResult,
 } from '@invoker/contracts';
 import { ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
@@ -1870,6 +1874,32 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       persistence.writeActivityLog('ui-perf', 'info', JSON.stringify(payload));
     } catch {
       // DB might be locked
+    }
+  });
+
+  const traceRendererTaskGraphEvents = process.env.INVOKER_TRACE_RENDERER_TASK_GRAPH === '1';
+  const rendererTaskGraphTracePath = join(homedir(), '.invoker', 'ui-task-graph-events.jsonl');
+  let rendererTaskGraphTraceWriteFailed = false;
+  ipcMain.handle('invoker:trace-renderer-task-graph-event', (_event, event: TaskGraphEvent) => {
+    if (!traceRendererTaskGraphEvents) return;
+    try {
+      mkdirSync(dirname(rendererTaskGraphTracePath), { recursive: true });
+      appendFileSync(
+        rendererTaskGraphTracePath,
+        JSON.stringify({
+          time: new Date().toISOString(),
+          source: 'renderer',
+          event,
+        }) + '\n',
+      );
+    } catch (err) {
+      if (!rendererTaskGraphTraceWriteFailed) {
+        rendererTaskGraphTraceWriteFailed = true;
+        logger.warn(
+          `renderer task graph trace write failed: ${err instanceof Error ? err.message : String(err)}`,
+          { module: 'ui' },
+        );
+      }
     }
   });
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -657,12 +657,10 @@ function assertDeleteAllEnabled(): void {
 interface InitServicesOptions {
   readOnly?: boolean;
   /**
-   * GUI viewer mode: never open `invoker.db`. A writable owner is always present
-   * in this mode, so the renderer's reads delegate to the owner over IPC and
-   * live updates arrive via TASK_DELTA/TASK_OUTPUT. We back the in-process
-   * services with a private empty in-memory database so no `-shm` is mapped on
-   * the real file — that is what lets the owner run WAL exclusive locking and be
-   * immune to the `-shm` truncation SIGBUS. Implies non-owner (readOnly) semantics.
+   * GUI viewer mode: opens `invoker.db` read-only when it exists, so renderer
+   * bootstrap and gap recovery use the same database as the owner while all
+   * mutations still delegate over IPC. If the file is absent, startup uses a
+   * private empty placeholder. Implies non-owner (readOnly) semantics.
    */
   detachedViewer?: boolean;
   executionAgentRegistry?: AgentRegistry;
@@ -737,7 +735,8 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     dbPath,
     detachedViewer,
     readOnly,
-    exclusiveLocking: process.env.INVOKER_DISABLE_EXCLUSIVE_LOCKING !== '1'
+    exclusiveLocking: process.env.INVOKER_ENABLE_EXCLUSIVE_LOCKING === '1'
+      && process.env.INVOKER_DISABLE_EXCLUSIVE_LOCKING !== '1'
       && process.env.INVOKER_UNSAFE_DISABLE_DB_WRITER_LOCK !== '1',
   });
   // Upgrade root logger with DB persistence now that SQLiteAdapter is ready.
@@ -3010,9 +3009,6 @@ startMainProcessBootstrap({
     logger.info('Effective configuration', { config: getSafeInvokerConfigForLogging(invokerConfig), module: 'startup' });
     recordStartupMark('startup.ready-for-window');
 
-    if (!ownerMode) {
-      requireRendererTaskFeed().beginDetachedViewerBuffering();
-    }
     messageBus.subscribe(Channels.TASK_DELTA, (delta: unknown) => {
       requireRendererTaskFeed().receiveTaskDelta(delta as TaskDelta);
     });
@@ -3039,9 +3035,7 @@ startMainProcessBootstrap({
     registerBootstrapStateIpc({
       ipcMain,
       getTasks: () => (ownerMode ? orchestrator.getAllTasks() : requireRendererTaskFeed().getDetachedViewerTasks()),
-      getWorkflows: () =>
-        requireRendererTaskFeed().getDetachedViewerWorkflows()
-          ?? startupWorkflowCache.takeOrLoad(listWorkflowsByStartupRecency),
+      getWorkflows: () => startupWorkflowCache.takeOrLoad(listWorkflowsByStartupRecency),
       getInitialWorkflowId: () => startupWorkflowId,
       appStartedAtEpochMs: appProcessStartedAt,
       getTaskDeltaStreamSequence,
@@ -3214,11 +3208,10 @@ startMainProcessBootstrap({
       ),
     );
 
-    if (ownerMode) {
-      requireRendererTaskFeed().seedUiSnapshotCache();
-    } else {
-      await requireRendererTaskFeed().hydrateDetachedViewerFromOwner();
+    if (!ownerMode) {
+      bootstrapInitialWorkflowState();
     }
+    requireRendererTaskFeed().seedUiSnapshotCache();
     createWindow();
     recordStartupMark('createWindow.end');
 

--- a/packages/app/src/preload.ts
+++ b/packages/app/src/preload.ts
@@ -110,6 +110,10 @@ for (const channel of Object.keys(IpcEventChannels)) {
 
 contextBridge.exposeInMainWorld('invoker', api as InvokerAPI);
 contextBridge.exposeInMainWorld('__INVOKER_BOOTSTRAP__', bootstrapState ?? { tasks: [], workflows: [] });
+contextBridge.exposeInMainWorld(
+  '__INVOKER_TRACE_RENDERER_TASK_GRAPH__',
+  process.env.INVOKER_TRACE_RENDERER_TASK_GRAPH === '1',
+);
 
 setTimeout(() => {
   ipcRenderer.invoke('invoker:report-ui-perf', 'preload_bootstrap_sync', {

--- a/packages/app/src/viewer-cache-hydration.ts
+++ b/packages/app/src/viewer-cache-hydration.ts
@@ -11,10 +11,10 @@ export interface ViewerTaskCaches {
  * Replace the main-process delta caches with an authoritative task list.
  *
  * Shared by the owner's local seeding (`seedUiSnapshotCache`,
- * `publishOrchestratorSnapshotToRenderer`) and by the detached viewer, which
- * seeds from the owner's delegated snapshot. Seeding the cache is what gives
- * incoming `updated` deltas a base entry; without it every delta for a task the
- * viewer has not seen is quarantined and effectively dropped.
+ * `publishOrchestratorSnapshotToRenderer`) and by detached viewers, which seed
+ * from their read-only main-process database snapshot. Seeding the cache is what
+ * gives incoming `updated` deltas a base entry; without it every delta for a task
+ * the viewer has not seen is quarantined and effectively dropped.
  */
 export function seedTaskCachesFromSnapshot(tasks: readonly TaskState[], caches: ViewerTaskCaches): void {
   caches.lastKnownTaskStates.clear();

--- a/packages/app/src/viewer-db-boundary.ts
+++ b/packages/app/src/viewer-db-boundary.ts
@@ -10,7 +10,15 @@ export interface MainProcessDatabaseOptions {
 
 export async function openMainProcessDatabase(options: MainProcessDatabaseOptions): Promise<SQLiteAdapter> {
   if (options.detachedViewer) {
-    return openDetachedViewerDatabase();
+    if (!existsSync(options.dbPath)) {
+      return openDetachedViewerDatabase();
+    }
+
+    return SQLiteAdapter.create(options.dbPath, {
+      readOnly: true,
+      ownerCapability: false,
+      exclusiveLocking: false,
+    });
   }
 
   // Read-only headless snapshots should report an empty store before the first

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -183,6 +183,8 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return {};
       case 'invoker:report-ui-perf':
         return undefined;
+      case 'invoker:trace-renderer-task-graph-event':
+        return undefined;
       case 'invoker:check-pr-statuses':
       case 'invoker:check-pr-status':
         await deps.checkPrStatuses?.();

--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -62,7 +62,7 @@ export interface RendererTaskFeedUiPerfStats {
 export interface RendererTaskFeedDeps {
   logger: Logger;
   persistence: RendererTaskFeedPersistence;
-  messageBus: Pick<MessageBus, 'publish' | 'request'>;
+  messageBus: Pick<MessageBus, 'publish'>;
   getOrchestrator: () => RendererTaskFeedOrchestrator;
   taskHandles: { has(taskId: string): boolean };
   taskGraphEventPublisher: Pick<TaskGraphEventPublisher, 'publishDelta'>;
@@ -83,9 +83,7 @@ export interface RendererTaskFeed {
   enqueueTaskOutput(taskId: string, data: string): void;
   flushTaskOutput(taskId: string): void;
   seedUiSnapshotCache(): void;
-  hydrateDetachedViewerFromOwner(): Promise<void>;
   getDetachedViewerTasks(): TaskState[];
-  getDetachedViewerWorkflows(): unknown[] | null;
   publishTaskDeltaToRenderer(delta: TaskDelta): void;
   getLastKnownWorkflowCount(): number;
   setLastKnownWorkflowCount(count: number): void;
@@ -95,7 +93,6 @@ export interface RendererTaskFeed {
   replaceWorkflowRollups(tasks: TaskState[]): void;
   rememberTaskState(task: TaskState): void;
   resetSnapshotState(): void;
-  beginDetachedViewerBuffering(): void;
   receiveTaskDelta(delta: TaskDelta): void;
   startDbPolling(): RendererTaskFeedStopHandle;
   startActivityPolling(): RendererTaskFeedStopHandle;
@@ -107,8 +104,6 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
   const pendingOutputBuffers = new Map<string, string[]>();
   const outputFlushTimers = new Map<string, RendererTaskFeedTimer>();
   let lastKnownWorkflowCount = 0;
-  let detachedViewerWorkflows: unknown[] | null = null;
-  let detachedDeltaBuffer: TaskDelta[] | null = null;
 
   const flushTaskOutput = (taskId: string): void => {
     const timer = outputFlushTimers.get(taskId);
@@ -178,54 +173,12 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
     seedTaskCachesFromSnapshot(deps.getOrchestrator().getAllTasks(), { lastKnownTaskStates, workflowRollupProjection });
   };
 
-  // Detached viewer: the local DB is empty, so seed the delta caches and
-  // bootstrap snapshot from the owner. Without this, the empty cache quarantines
-  // every `updated` delta for a task the viewer has not seen (dropping live
-  // updates), and bootstrap getters return nothing. Failures are non-fatal — the
-  // renderer's delegated reads still populate the view.
-  const hydrateDetachedViewerFromOwner = async (): Promise<void> => {
-    try {
-      const snapshot = await deps.messageBus.request<{ kind: string }, { tasks?: TaskState[]; workflows?: unknown[] }>(
-        'headless.query',
-        { kind: 'tasks' },
-      );
-      const tasks = Array.isArray(snapshot?.tasks) ? snapshot.tasks : [];
-      const workflows = Array.isArray(snapshot?.workflows) ? snapshot.workflows : [];
-      detachedViewerWorkflows = workflows;
-      seedTaskCachesFromSnapshot(tasks, { lastKnownTaskStates, workflowRollupProjection });
-      lastKnownWorkflowCount = workflows.length;
-      deps.setStartupWorkflowId(
-        [...workflows]
-          .map((wf) => wf as { id?: string; updatedAt?: string; createdAt?: string })
-          .sort((left, right) => (Date.parse(right.updatedAt ?? '') || 0) - (Date.parse(left.updatedAt ?? '') || 0))[0]?.id ?? null,
-      );
-      deps.logger.info(
-        `[init] Hydrated detached viewer from owner: ${tasks.length} tasks across ${workflows.length} workflows`,
-        { module: 'init' },
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      deps.logger.warn(`detached viewer hydration from owner failed; relying on delegated reads: ${message}`, { module: 'init' });
-    } finally {
-      // Resume direct delta processing and replay anything buffered during
-      // hydration (in arrival order). Always runs, so a hydration failure can
-      // never leave deltas buffered forever.
-      const buffered = detachedDeltaBuffer ?? [];
-      detachedDeltaBuffer = null;
-      for (const delta of buffered) processIncomingTaskDelta(delta);
-    }
-  };
-
   // Current task states for the detached viewer's bootstrap getter, derived from
-  // the live delta cache so a renderer reload never sees the stale hydration
-  // snapshot.
+  // the same cache owner mode uses for delta gap recovery.
   const getDetachedViewerTasks = (): TaskState[] => [...lastKnownTaskStates.keys()].map(
     (taskId) => JSON.parse(lastKnownTaskStates.get(taskId) ?? '{}') as TaskState,
   );
 
-  // Apply one owner task delta to the local cache and forward results to the
-  // renderer. Extracted so the detached viewer can replay deltas that were
-  // buffered during hydration.
   const processIncomingTaskDelta = (delta: TaskDelta): void => {
     deps.uiPerfStats.mainDeltaToUi += 1;
     if (deps.traceUiDeltaFlow) {
@@ -445,9 +398,7 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
     enqueueTaskOutput,
     flushTaskOutput,
     seedUiSnapshotCache,
-    hydrateDetachedViewerFromOwner,
     getDetachedViewerTasks,
-    getDetachedViewerWorkflows: () => detachedViewerWorkflows,
     publishTaskDeltaToRenderer,
     getLastKnownWorkflowCount: () => lastKnownWorkflowCount,
     setLastKnownWorkflowCount: (count) => { lastKnownWorkflowCount = count; },
@@ -461,14 +412,7 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
       workflowRollupProjection.clear();
       lastKnownWorkflowCount = 0;
     },
-    beginDetachedViewerBuffering: () => { detachedDeltaBuffer = []; },
-    receiveTaskDelta: (delta) => {
-      if (detachedDeltaBuffer) {
-        detachedDeltaBuffer.push(delta);
-        return;
-      }
-      processIncomingTaskDelta(delta);
-    },
+    receiveTaskDelta: processIncomingTaskDelta,
     startDbPolling,
     startActivityPolling,
   };

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1266,6 +1266,10 @@ export const IpcChannels = {
     request: [metric: string, data?: Record<string, unknown>];
     response: void;
   },
+  'invoker:trace-renderer-task-graph-event': {} as {
+    request: [event: TaskGraphEvent];
+    response: void;
+  },
   'invoker:get-ui-perf-stats': {} as {
     request: [];
     response: Record<string, unknown>;

--- a/packages/data-store/src/__tests__/exclusive-locking.test.ts
+++ b/packages/data-store/src/__tests__/exclusive-locking.test.ts
@@ -57,7 +57,7 @@ describe('SQLiteAdapter exclusiveLocking', () => {
     }
   });
 
-  it('rejects read-only file-backed opens while live WAL sidecars exist', async () => {
+  it('allows read-only file-backed opens while a normal WAL owner is live', async () => {
     const dir = makeDir();
     const dbPath = join(dir, 'invoker.db');
     const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
@@ -65,13 +65,32 @@ describe('SQLiteAdapter exclusiveLocking', () => {
       owner.saveWorkflow(wf);
       expect(existsSync(`${dbPath}-shm`)).toBe(true);
       expect(existsSync(`${dbPath}.owner`)).toBe(true);
-      await expect(
-        SQLiteAdapter.create(dbPath, { readOnly: true }),
-      ).rejects.toThrow(/writable owner PID \d+ holds live WAL sidecars/i);
+      const reader = await SQLiteAdapter.create(dbPath, { readOnly: true });
+      try {
+        expect(reader.listWorkflows().map((w) => w.id)).toEqual(['wf-1']);
+      } finally {
+        reader.close();
+      }
     } finally {
       owner.close();
     }
     expect(existsSync(`${dbPath}.owner`)).toBe(false);
+  });
+
+  it('rejects read-only viewers while an exclusive-locking owner is live', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true, exclusiveLocking: true });
+    try {
+      owner.saveWorkflow(wf);
+      expect(existsSync(`${dbPath}-wal`)).toBe(true);
+      expect(existsSync(`${dbPath}-shm`)).toBe(false);
+      await expect(
+        SQLiteAdapter.create(dbPath, { readOnly: true }),
+      ).rejects.toThrow(/exclusive locking.*read-only viewers/i);
+    } finally {
+      owner.close();
+    }
   });
 
   it('read-only opens are still allowed after a clean close', async () => {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -174,7 +174,9 @@ interface SQLiteAdapterOptions {
    * Open WAL in exclusive locking mode: the wal-index lives in heap memory and
    * no `-shm` file is created, making the process immune to the SIGBUS that a
    * truncated memory-mapped `-shm` causes. Requires this process to be the SOLE
-   * opener of the database file — a concurrent open is rejected with SQLITE_BUSY.
+   * opener of the database file and is incompatible with delegated read-only
+   * viewers. Normal WAL mode is the default and supports one writer with
+   * concurrent read-only viewers.
    */
   exclusiveLocking?: boolean;
   slowQueryThresholdMs?: number;
@@ -740,17 +742,20 @@ export class SQLiteAdapter implements PersistenceAdapter {
       );
     }
 
-    // Sidecar files alone cannot prove a writable owner is live: opening a
-    // WAL-mode database read-only creates -wal/-shm itself, and a read-only
-    // connection has no write access to checkpoint them away on close. Gating
-    // on mere existence therefore lets the first reader wedge every reader
-    // after it. Only a live owner may turn a reader away.
-    if (isFile && options?.readOnly === true && (existsSync(`${dbPath}-wal`) || existsSync(`${dbPath}-shm`))) {
+    // In normal WAL mode, read-only viewers are allowed to coexist with the
+    // writable owner. Exclusive locking is the opt-in exception: it keeps the
+    // wal-index in heap memory and requires the owner to be the sole opener.
+    if (
+      isFile
+      && options?.readOnly === true
+      && existsSync(`${dbPath}-wal`)
+      && !existsSync(`${dbPath}-shm`)
+    ) {
       const ownerPid = readLiveOwnerPid(dbPath);
       if (ownerPid !== null) {
         throw new Error(
-          `Cannot open SQLite database read-only while writable owner PID ${ownerPid} holds live WAL sidecars for ${dbPath}. ` +
-          'Close the writable owner cleanly before opening a file-backed read-only adapter.',
+          `Cannot open SQLite database read-only while writable owner PID ${ownerPid} is using exclusive locking for ${dbPath}. ` +
+          'exclusiveLocking is incompatible with delegated read-only viewers; restart the owner in normal WAL mode.',
         );
       }
     }

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -339,6 +339,7 @@ export function createMockInvoker(
     replaceTask: vi.fn(async () => accepted('invoker:replace-task')),
     getActivityLogs: vi.fn(async () => []),
     reportUiPerf: vi.fn(async () => {}),
+    traceRendererTaskGraphEvent: vi.fn(async () => {}),
     getUiPerfStats: vi.fn(async () => ({})),
     getEvents: vi.fn(async (taskId: string, options?: { limit: number; sortBy?: 'asc' | 'desc'; beforeId?: number }) => {
       const events = [...(eventsByTask.get(taskId) ?? [])];

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -123,6 +123,9 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
   const traceTaskDeltas =
     typeof window !== 'undefined' &&
     window.location.search.includes('traceTaskDeltas=1');
+  const traceRendererTaskGraphEvents =
+    typeof window !== 'undefined' &&
+    window.__INVOKER_TRACE_RENDERER_TASK_GRAPH__ === true;
   const bootstrapState =
     typeof window !== 'undefined' ? window.__INVOKER_BOOTSTRAP__ : undefined;
   const [tasks, setTasks] = useState<Map<string, TaskState>>(() => {
@@ -442,6 +445,12 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
 
     const handleTaskGraphEvent = (event: TaskGraphEvent) => {
       invalidateStartupSnapshot();
+      if (traceRendererTaskGraphEvents) {
+        const traceRendererTaskGraphEvent = window.invoker.traceRendererTaskGraphEvent;
+        if (traceRendererTaskGraphEvent) {
+          void traceRendererTaskGraphEvent(event).catch(() => undefined);
+        }
+      }
       deltaPerfRef.current.received += 1;
       if (event.type === 'snapshot') {
         const snapshotStreamSequence = event.streamSequence;
@@ -543,7 +552,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
       unsub();
       unsubWf?.();
     };
-  }, [invalidateStartupSnapshot, loadStartupSnapshot, onTaskGraphSnapshotApplied, refreshTaskGraph, refreshWorkflowMetadata]);
+  }, [invalidateStartupSnapshot, loadStartupSnapshot, onTaskGraphSnapshotApplied, refreshTaskGraph, refreshWorkflowMetadata, traceRendererTaskGraphEvents]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !window.invoker) return;

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -357,6 +357,7 @@ declare global {
       appStartedAtEpochMs?: number;
       streamSequence?: number;
     };
+    __INVOKER_TRACE_RENDERER_TASK_GRAPH__?: boolean;
     __INVOKER_TEST_OPEN_TERMINAL__?: (taskId: string) => ReturnType<InvokerAPI['openTerminal']>;
     __INVOKER_TEST_ON_TERMINAL_OUTPUT__?: (cb: (event: TerminalOutputEvent) => void) => () => void;
   }

--- a/scripts/repro/repro-ui-delta-timeline.sh
+++ b/scripts/repro/repro-ui-delta-timeline.sh
@@ -1,0 +1,469 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/run.sh"
+TIMEOUT_SEC="${INVOKER_UI_DELTA_TIMELINE_TIMEOUT_SEC:-240}"
+OWNER_PROBE_TIMEOUT_SEC="${INVOKER_UI_DELTA_OWNER_PROBE_TIMEOUT_SEC:-5}"
+KEEP_TMP="${INVOKER_UI_DELTA_KEEP_TMP:-0}"
+
+TMP_BASE="${INVOKER_UI_DELTA_TMPDIR:-/tmp}"
+TMP_ROOT="$(mktemp -d "$TMP_BASE/invoker-ui-delta-timeline.XXXXXX")"
+HOME_DIR="$TMP_ROOT/home"
+DB_DIR="$HOME_DIR/.invoker"
+LOG_DIR="$TMP_ROOT/logs"
+PLAN_PATH="$TMP_ROOT/hello-world.yaml"
+CONFIG_PATH="$TMP_ROOT/config.json"
+IPC_SOCKET="$TMP_ROOT/i.sock"
+FEATURE_BRANCH="plan/ui-delta-timeline-$(date +%s)-$$"
+REPO_URL="${INVOKER_UI_DELTA_REPO_URL:-}"
+
+GUI_LOG="$LOG_DIR/gui-launch.log"
+RUN_STDOUT="$LOG_DIR/run.stdout.log"
+RUN_STDERR="$LOG_DIR/run.stderr.log"
+REBASE_STDOUT="$LOG_DIR/rebase-recreate.stdout.log"
+REBASE_STDERR="$LOG_DIR/rebase-recreate.stderr.log"
+WORKFLOWS_JSON="$LOG_DIR/workflows.json"
+WORKFLOW_STATUS_JSON="$LOG_DIR/workflow-status.json"
+BACKEND_SOURCE="$DB_DIR/invoker.log"
+RENDERER_SOURCE="$DB_DIR/ui-task-graph-events.jsonl"
+BACKEND_RAW="$LOG_DIR/backend.raw.log"
+RENDERER_RAW="$LOG_DIR/renderer.raw.jsonl"
+COMPARISON_JSON="$LOG_DIR/comparison.json"
+
+GUI_PID=""
+BACKEND_FOLLOW_PID=""
+RENDERER_FOLLOW_PID=""
+
+log() {
+  printf '==> %s\n' "$*" >&2
+}
+
+fail() {
+  KEEP_TMP=1
+  printf 'FAIL: %s\n' "$*" >&2
+  printf 'Artifacts: %s\n' "$LOG_DIR" >&2
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "$BACKEND_FOLLOW_PID" ]] && kill -0 "$BACKEND_FOLLOW_PID" >/dev/null 2>&1; then
+    kill "$BACKEND_FOLLOW_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$RENDERER_FOLLOW_PID" ]] && kill -0 "$RENDERER_FOLLOW_PID" >/dev/null 2>&1; then
+    kill "$RENDERER_FOLLOW_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$GUI_PID" ]] && kill -0 "$GUI_PID" >/dev/null 2>&1; then
+    kill "$GUI_PID" >/dev/null 2>&1 || true
+    wait "$GUI_PID" >/dev/null 2>&1 || true
+  fi
+  rm -f "$IPC_SOCKET"
+  if [[ "$KEEP_TMP" = "1" ]]; then
+    printf 'Kept temp repro dir: %s\n' "$TMP_ROOT" >&2
+  else
+    rm -rf "$TMP_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+COMMON_ENV=(
+  HOME="$HOME_DIR"
+  INVOKER_DB_DIR="$DB_DIR"
+  INVOKER_IPC_SOCKET="$IPC_SOCKET"
+  INVOKER_REPO_CONFIG_PATH="$CONFIG_PATH"
+  INVOKER_GUI_OWNER_MODE=gui
+  INVOKER_DISABLE_SLACK=1
+  INVOKER_TRACE_UI_DELTA=1
+  INVOKER_TRACE_RENDERER_TASK_GRAPH=1
+)
+
+run_headless() {
+  env "${COMMON_ENV[@]}" "$RUNNER" --headless "$@"
+}
+
+run_headless_logged_with_timeout() {
+  local timeout_sec="$1"
+  local stdout_file="$2"
+  local stderr_file="$3"
+  shift 3
+
+  env "${COMMON_ENV[@]}" python3 - "$timeout_sec" "$stdout_file" "$stderr_file" "$RUNNER" --headless "$@" <<'PY'
+import os
+import signal
+import subprocess
+import sys
+
+timeout_sec = float(sys.argv[1])
+stdout_file = sys.argv[2]
+stderr_file = sys.argv[3]
+command = sys.argv[4:]
+
+with open(stdout_file, "w", encoding="utf-8") as stdout, open(stderr_file, "w", encoding="utf-8") as stderr:
+    child = subprocess.Popen(
+        command,
+        stdout=stdout,
+        stderr=stderr,
+        start_new_session=True,
+    )
+    try:
+        raise SystemExit(child.wait(timeout=timeout_sec))
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(child.pid, signal.SIGTERM)
+            child.wait(timeout=2)
+        except Exception:
+            try:
+                os.killpg(child.pid, signal.SIGKILL)
+            except Exception:
+                pass
+            child.wait()
+        raise SystemExit(124)
+PY
+}
+
+run_headless_logged() {
+  run_headless_logged_with_timeout "$TIMEOUT_SEC" "$@"
+}
+
+wait_for_gui_ready() {
+  local deadline=$((SECONDS + TIMEOUT_SEC))
+  while (( SECONDS < deadline )); do
+    if [[ -n "$GUI_PID" ]] && ! kill -0 "$GUI_PID" >/dev/null 2>&1; then
+      tail -n 120 "$GUI_LOG" >&2 || true
+      fail "GUI process exited before owner startup completed"
+    fi
+
+    local owner_pid=""
+    if [[ -f "$DB_DIR/invoker.db.lock/pid" ]]; then
+      owner_pid="$(cat "$DB_DIR/invoker.db.lock/pid" 2>/dev/null || true)"
+    fi
+    if [[ -n "$owner_pid" ]] \
+      && kill -0 "$owner_pid" >/dev/null 2>&1 \
+      && { [[ -S "$IPC_SOCKET" ]] || [[ -e "$IPC_SOCKET" ]]; } \
+      && grep -q 'owner-ipc-ready' "$BACKEND_SOURCE" 2>/dev/null \
+      && grep -q 'startup phase ui.interactive' "$BACKEND_SOURCE" 2>/dev/null; then
+      return 0
+    fi
+
+    sleep 1
+  done
+  tail -n 120 "$GUI_LOG" >&2 || true
+  fail "timed out waiting for GUI owner startup"
+}
+
+start_log_followers() {
+  touch "$BACKEND_SOURCE" "$RENDERER_SOURCE"
+
+tail -n0 -F "$BACKEND_SOURCE" 2>/dev/null | python3 -u -c '
+import json, sys
+marker = "delta\u2192ui:"
+for raw in sys.stdin:
+    try:
+        row = json.loads(raw)
+    except Exception:
+        continue
+    msg = row.get("msg", "")
+    if row.get("module") == "ui" and marker in msg:
+        print("[backend delta-ui] " + msg.split(marker, 1)[1].strip(), flush=True)
+' &
+  BACKEND_FOLLOW_PID="$!"
+
+  tail -n0 -F "$RENDERER_SOURCE" 2>/dev/null | python3 -u -c '
+import json, sys
+for raw in sys.stdin:
+    try:
+        row = json.loads(raw)
+    except Exception:
+        continue
+    event = row.get("event", {})
+    if event.get("type") != "delta":
+        continue
+    print("[renderer task-graph-event] " + json.dumps(event.get("delta", {}), separators=(",", ":")), flush=True)
+' &
+  RENDERER_FOLLOW_PID="$!"
+}
+
+parse_workflow_id_from_stdout() {
+  local stdout_file="$1"
+  sed -nE \
+    -e 's/^Workflow ID: (wf-[^[:space:]]+).*/\1/p' \
+    -e 's/^Delegated to owner .* workflow: (wf-[^[:space:]]+).*/\1/p' \
+    "$stdout_file" | tail -n1
+}
+
+discover_workflow_id() {
+  local stdout_file="$1"
+  local parsed
+  parsed="$(parse_workflow_id_from_stdout "$stdout_file")"
+  if [[ -n "$parsed" ]]; then
+    printf '%s\n' "$parsed"
+    return 0
+  fi
+
+  run_headless_logged "$WORKFLOWS_JSON" "$LOG_DIR/workflows.stderr.log" query workflows --output json
+  python3 - "$WORKFLOWS_JSON" <<'PY'
+import json, pathlib, sys
+text = pathlib.Path(sys.argv[1]).read_text(errors='ignore')
+start = text.find('[')
+if start < 0:
+    raise SystemExit(1)
+workflows = json.loads(text[start:])
+matches = [wf for wf in workflows if wf.get('name') == 'UI Delta Timeline Hello World']
+if not matches:
+    raise SystemExit(1)
+matches.sort(key=lambda wf: wf.get('createdAt') or wf.get('updatedAt') or '')
+print(matches[-1]['id'])
+PY
+}
+
+wait_for_workflow_completed() {
+  local workflow_id="$1"
+  local deadline=$((SECONDS + TIMEOUT_SEC))
+  local last_status=""
+
+  while (( SECONDS < deadline )); do
+    if run_headless_logged_with_timeout \
+      "$OWNER_PROBE_TIMEOUT_SEC" \
+      "$WORKFLOW_STATUS_JSON" \
+      "$LOG_DIR/workflow-status.stderr.log" \
+      query workflows --output json; then
+      local result
+      result="$(python3 - "$WORKFLOW_STATUS_JSON" "$workflow_id" <<'PY'
+import json
+import pathlib
+import sys
+
+path, workflow_id = sys.argv[1:3]
+text = pathlib.Path(path).read_text(errors="ignore")
+start = text.find("[")
+if start < 0:
+    raise SystemExit(1)
+workflows = json.loads(text[start:])
+workflow = next((item for item in workflows if item.get("id") == workflow_id), None)
+if workflow is None:
+    raise SystemExit(2)
+status = workflow.get("status") or "unknown"
+if status in {"completed", "review_ready"}:
+    state = "completed"
+elif status in {"failed", "closed", "blocked", "needs_input", "awaiting_approval"}:
+    state = "terminal"
+else:
+    state = "waiting"
+print(f"{state}\t{status}")
+PY
+)"
+
+      local state="${result%%$'\t'*}"
+      local status="${result#*$'\t'}"
+      if [[ "$status" != "$last_status" ]]; then
+        log "workflow status: $status"
+        last_status="$status"
+      fi
+      case "$state" in
+        completed)
+          return 0
+          ;;
+        terminal)
+          fail "workflow $workflow_id finished with status: $status"
+          ;;
+      esac
+    fi
+    sleep 1
+  done
+
+  fail "timed out waiting for workflow $workflow_id to complete"
+}
+
+copy_trace_artifacts() {
+  sleep 1
+  cp "$BACKEND_SOURCE" "$BACKEND_RAW" 2>/dev/null || : >"$BACKEND_RAW"
+  cp "$RENDERER_SOURCE" "$RENDERER_RAW" 2>/dev/null || : >"$RENDERER_RAW"
+}
+
+compare_timelines() {
+  local workflow_id="$1"
+  python3 - "$workflow_id" "$BACKEND_RAW" "$RENDERER_RAW" "$COMPARISON_JSON" <<'PY'
+import copy
+import json
+import pathlib
+import sys
+
+workflow_id, backend_path, renderer_path, comparison_path = sys.argv[1:5]
+merge_id = f"__merge__{workflow_id}"
+
+def belongs(delta):
+    if not isinstance(delta, dict):
+        return False
+    if delta.get("type") == "created":
+        task = delta.get("task") or {}
+        task_id = task.get("id")
+        task_workflow = (task.get("config") or {}).get("workflowId")
+        return task_id == merge_id or task_id == workflow_id or task_workflow == workflow_id or str(task_id or "").startswith(f"{workflow_id}/")
+    task_id = str(delta.get("taskId") or "")
+    return task_id == merge_id or task_id.startswith(f"{workflow_id}/")
+
+def scrub(value):
+    if isinstance(value, dict):
+        return {k: scrub(v) for k, v in value.items() if k != "streamSequence"}
+    if isinstance(value, list):
+        return [scrub(v) for v in value]
+    return value
+
+def load_backend(path):
+    marker = "delta\u2192ui:"
+    records = []
+    for line_no, raw in enumerate(pathlib.Path(path).read_text(errors="ignore").splitlines(), 1):
+        try:
+            row = json.loads(raw)
+        except Exception:
+            continue
+        msg = row.get("msg", "")
+        if row.get("module") != "ui" or marker not in msg:
+            continue
+        try:
+            delta = json.loads(msg.split(marker, 1)[1].strip())
+        except Exception:
+            continue
+        if belongs(delta):
+            records.append({
+                "line": line_no,
+                "time": row.get("time"),
+                "delta": delta,
+                "canonical": scrub(copy.deepcopy(delta)),
+            })
+    return records
+
+def load_renderer(path):
+    records = []
+    for line_no, raw in enumerate(pathlib.Path(path).read_text(errors="ignore").splitlines(), 1):
+        try:
+            row = json.loads(raw)
+        except Exception:
+            continue
+        event = row.get("event") or {}
+        if event.get("type") != "delta":
+            continue
+        delta = event.get("delta")
+        if belongs(delta):
+            records.append({
+                "line": line_no,
+                "time": row.get("time"),
+                "delta": delta,
+                "canonical": scrub(copy.deepcopy(delta)),
+            })
+    return records
+
+backend = load_backend(backend_path)
+renderer = load_renderer(renderer_path)
+backend_canonical = [record["canonical"] for record in backend]
+renderer_canonical = [record["canonical"] for record in renderer]
+
+first_mismatch = None
+for index, (left, right) in enumerate(zip(backend_canonical, renderer_canonical)):
+    if left != right:
+        first_mismatch = {
+            "index": index,
+            "backend": backend[index],
+            "renderer": renderer[index],
+        }
+        break
+
+if first_mismatch is None and len(backend_canonical) != len(renderer_canonical):
+    index = min(len(backend_canonical), len(renderer_canonical))
+    first_mismatch = {
+        "index": index,
+        "backend": backend[index] if index < len(backend) else None,
+        "renderer": renderer[index] if index < len(renderer) else None,
+    }
+
+result = {
+    "ok": first_mismatch is None,
+    "workflowId": workflow_id,
+    "backendCount": len(backend),
+    "rendererCount": len(renderer),
+    "firstMismatch": first_mismatch,
+    "backendLog": backend_path,
+    "rendererLog": renderer_path,
+}
+pathlib.Path(comparison_path).write_text(json.dumps(result, indent=2) + "\n")
+
+if first_mismatch is not None:
+    print(json.dumps(result, indent=2), file=sys.stderr)
+    raise SystemExit(1)
+
+print(json.dumps(result, indent=2))
+PY
+}
+
+mkdir -p "$DB_DIR" "$LOG_DIR"
+: >"$BACKEND_SOURCE"
+: >"$RENDERER_SOURCE"
+
+if [[ -z "$REPO_URL" ]]; then
+  REPO_URL="$(git -C "$ROOT_DIR" config --get remote.origin.url || true)"
+fi
+[[ -n "$REPO_URL" ]] || fail "could not determine repo URL; set INVOKER_UI_DELTA_REPO_URL"
+
+cat >"$CONFIG_PATH" <<'JSON'
+{
+  "allowGraphMutation": true,
+  "disableAutoRunOnStartup": true,
+  "maxConcurrency": 1,
+  "autoFixRetries": 0
+}
+JSON
+
+cat >"$PLAN_PATH" <<YAML
+name: UI Delta Timeline Hello World
+description: Repro fixture for backend-vs-renderer task graph event timelines.
+repoUrl: "$REPO_URL"
+featureBranch: "$FEATURE_BRANCH"
+onFinish: none
+tasks:
+  - id: hello-world
+    description: hello world
+    command: echo hello world
+    dependencies: []
+YAML
+
+[[ -x "$RUNNER" ]] || fail "missing executable runner at $RUNNER"
+
+cd "$ROOT_DIR"
+log "temp repro dir: $TMP_ROOT"
+log "starting traced GUI with isolated state; ./run.sh may stop existing Invoker Electron processes"
+env "${COMMON_ENV[@]}" "$RUNNER" . >"$GUI_LOG" 2>&1 &
+GUI_PID="$!"
+
+wait_for_gui_ready
+log "GUI owner is reachable"
+
+start_log_followers
+
+log "loading and running hello-world plan"
+if ! run_headless_logged "$RUN_STDOUT" "$RUN_STDERR" run "$PLAN_PATH"; then
+  tail -n 120 "$RUN_STDERR" >&2 || true
+  fail "hello-world run failed"
+fi
+
+WORKFLOW_ID="$(discover_workflow_id "$RUN_STDOUT")"
+[[ -n "$WORKFLOW_ID" ]] || fail "could not discover workflow id"
+log "workflow id: $WORKFLOW_ID"
+
+log "running rebase-recreate and following until settled"
+if ! run_headless_logged "$REBASE_STDOUT" "$REBASE_STDERR" rebase-recreate "$WORKFLOW_ID"; then
+  tail -n 160 "$REBASE_STDERR" >&2 || true
+  fail "rebase-recreate failed"
+fi
+wait_for_workflow_completed "$WORKFLOW_ID"
+
+copy_trace_artifacts
+log "comparing backend delta-ui timeline with renderer task-graph-event timeline"
+if ! compare_timelines "$WORKFLOW_ID"; then
+  fail "backend and renderer task-delta timelines diverged"
+fi
+
+log "timeline comparison passed"
+printf 'workflow: %s\n' "$WORKFLOW_ID"
+printf 'comparison: %s\n' "$COMPARISON_JSON"
+printf 'backend log: %s\n' "$BACKEND_RAW"
+printf 'renderer log: %s\n' "$RENDERER_RAW"


### PR DESCRIPTION
## Summary

Detached viewer startup now seeds from its local main-process database snapshot.

The old owner snapshot request and delta buffering hooks are no longer active.

No-track fallback exclusive locking now uses the same opt-in flag as app startup.

## Review Claim

Approve retiring the delegated viewer snapshot activation path after the read-only database source exists.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Renderer updates still flow through the existing task delta IPC channel.

The compatibility dependency parameter remains in place, so this slice only removes unused activation hooks.

## Slice Rationale

This follows slice 1 so the detached viewer already has an authoritative local snapshot before the old snapshot request path is retired.

## Non-goals

This does not change renderer storage access.

This does not change task delta semantics.

This does not change which process may write to SQLite.

## Architecture

### Before

```mermaid
graph TD
    A["Detached viewer"] --> B["Request owner task snapshot"]
    B --> C["Buffer incoming deltas"]
    C --> D["Replay after hydration"]
```

### After

```mermaid
graph TD
    A["Detached viewer"] --> B["Seed from local read-only DB snapshot"]
    B --> C["Process incoming deltas directly"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/viewer-detached-db.test.ts src/__tests__/viewer-cache-hydration.test.ts src/__tests__/renderer-preload-storage-boundary.test.ts --reporter=dot`
- [ ] `pnpm run check:types`
- [ ] `pnpm --filter @invoker/app test:e2e -- e2e/ui-delta-timeline.spec.ts --workers=1`

</details>

## Visual Proof

![Read-only mode banner](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260729-a9a8ee/read-only-mode-banner.png)

The screenshot shows the existing read-only viewer surface. Stack slice 3 exercises the visible UI path and fails if backend and renderer timelines diverge.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e757fb234`
- Post-revert steps: None
- Data migration? No

</details>
