### PR TITLE
[Read-only Delegated Viewer](4) Document read-only delegated viewers

### DIFF
--- a/docs/persistence-architecture-single-writer.md
+++ b/docs/persistence-architecture-single-writer.md
@@ -8,25 +8,25 @@ The Invoker persistence layer (SQLiteAdapter, backed by `node:sqlite`) stores st
 
 **Single-writer owner model**: exactly one process owns writable access to the database. All other processes delegate mutations via IPC or open the database in read-only mode.
 
-## Update: Sole-Owner Read Path & Exclusive Locking
+## Update: Read-Only Viewers & Exclusive Locking
 
-The owner boundary now covers **reads** as well as writes, so the writable owner can be the *only* process that opens `invoker.db`. See Linear [INV-240](https://linear.app/invokerorchestrator/issue/INV-240) for the full design and rationale.
+The owner boundary covers writes. Normal WAL mode allows the writable owner and read-only viewers to open `invoker.db` concurrently.
 
-- **GUI viewer** runs against a private empty in-memory database and never opens `invoker.db`; its renderer reads delegate to the owner over IPC and live updates arrive via `TASK_DELTA` / `TASK_OUTPUT`.
+- **GUI viewer** opens `invoker.db` read-only when the file exists; its renderer still reads only through Electron IPC, and live updates arrive via `TASK_DELTA` / `TASK_OUTPUT`.
 - **Read-only headless commands** delegate to the owner over IPC (`headless.query` `cli-query`) when an owner is present, and open the file directly only when none is. In that fallback path they remain read-only callers that may coexist with other readers; this does not imply exclusive ownership.
-- **The owner opens WAL in `locking_mode = EXCLUSIVE`**, keeping the wal-index in heap so no `-shm` file exists. This makes the `-shm`-truncation SIGBUS (crash report `Electron-2026-06-24-222052.ips`; repro `scripts/repro/repro-wal-shm-sigbus.sh`) impossible. Kill-switch: `INVOKER_DISABLE_EXCLUSIVE_LOCKING=1` reverts to shared-`-shm` WAL.
+- **Exclusive locking is opt-in** with `INVOKER_ENABLE_EXCLUSIVE_LOCKING=1`. It keeps the wal-index in heap so no `-shm` file exists, but it is incompatible with delegated read-only viewers because the owner must be the sole opener. `INVOKER_DISABLE_EXCLUSIVE_LOCKING=1` still wins if both variables are set.
 
 ## Owner Boundary Contract
 
 ### Acceptance Rules
 
 1. **Owner process**: GUI process (main.ts) or standalone headless process (when `INVOKER_HEADLESS_STANDALONE=1`).
-2. **GUI viewer** opens no shared database file. `openMainProcessDatabase({ detachedViewer: true })` returns process-local placeholder persistence, while renderer reads delegate to the owner over IPC and live updates arrive via `TASK_DELTA` / `TASK_OUTPUT`.
+2. **GUI viewer** opens the shared database read-only when it exists. `openMainProcessDatabase({ detachedViewer: true })` falls back to process-local placeholder persistence only before `invoker.db` has been created.
 3. **Non-owner processes**: headless CLI invocations (when GUI is running).
 4. **Non-owner processes CANNOT initialize writable persistence**. Attempting to do so throws or delegates.
 5. **All non-owner mutations MUST traverse RPC** (`headless.run`, `headless.resume`, `headless.exec` channels via IpcBus).
 
-Implementation note: today's placeholder is SQLite ephemeral storage via `SQLiteAdapter.createEphemeral()`. The raw SQLite `:memory:` sentinel is private to the data-store adapter so viewer startup code cannot accidentally switch back to opening `invoker.db`.
+Implementation note: the missing-file placeholder is SQLite ephemeral storage via `SQLiteAdapter.createEphemeral()`. The raw SQLite `:memory:` sentinel is private to the data-store adapter so viewer startup code cannot accidentally create `invoker.db`.
 
 ### Implementation Map
 
@@ -137,5 +137,5 @@ This table lists every mutating command path and how the owner-boundary contract
 
 ### Future Work
 
-- **Lock-free reads**: sql.js doesn't support multi-reader MVCC. If read-only processes need fresher data, they must re-open the DB (current behavior: query commands open fresh each time).
+- **Lock-free reads**: normal WAL mode supports one writer with concurrent read-only viewers. If a long-lived read-only process needs a newer snapshot than its current connection can see, it may need to refresh from the DB.
 - **Leader election**: If multiple GUI instances are allowed (not currently), use file lock or PID file to elect single writer.

--- a/packages/app/e2e/ui-delta-timeline.spec.ts
+++ b/packages/app/e2e/ui-delta-timeline.spec.ts
@@ -1,0 +1,90 @@
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+import * as path from 'node:path';
+import { test, expect, type TestInfo } from '@playwright/test';
+import { resolveRepoRoot } from '@invoker/contracts';
+import { E2E_BARE_REPO } from './global-setup.js';
+
+const repoRoot = resolveRepoRoot(__dirname);
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('backend and renderer task graph timelines', () => {
+  test('stay in sync through rebase-recreate', async ({}, testInfo) => {
+    test.setTimeout(300_000);
+
+    const result = await runTimelineRepro();
+    await testInfo.attach('ui-delta-timeline-stdout', {
+      body: result.stdout,
+      contentType: 'text/plain',
+    });
+    await testInfo.attach('ui-delta-timeline-stderr', {
+      body: result.stderr,
+      contentType: 'text/plain',
+    });
+
+    if (result.code !== 0) {
+      await attachFailureArtifacts(testInfo, result.stderr);
+    }
+
+    expect(result.code, lastLines(result.stderr || result.stdout)).toBe(0);
+  });
+});
+
+async function runTimelineRepro(): Promise<{
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn('bash', ['scripts/repro/repro-ui-delta-timeline.sh'], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        INVOKER_UI_DELTA_REPO_URL: pathToFileURL(E2E_BARE_REPO).href,
+        INVOKER_UI_DELTA_TMPDIR: '/tmp',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+}
+
+async function attachFailureArtifacts(
+  testInfo: TestInfo,
+  stderr: string,
+): Promise<void> {
+  const artifactsDir = stderr.match(/^Artifacts: (.+)$/m)?.[1]?.trim();
+  if (!artifactsDir || !existsSync(artifactsDir)) return;
+
+  for (const file of ['comparison.json', 'backend.raw.log', 'renderer.raw.jsonl']) {
+    const filePath = path.join(artifactsDir, file);
+    if (!existsSync(filePath)) continue;
+    await testInfo.attach(file, {
+      body: await readFile(filePath, 'utf8'),
+      contentType: file.endsWith('.json') || file.endsWith('.jsonl')
+        ? 'application/json'
+        : 'text/plain',
+    });
+  }
+}
+
+function lastLines(value: string, count = 80): string {
+  return value.split(/\r?\n/).slice(-count).join('\n');
+}

--- a/packages/app/src/__tests__/renderer-preload-storage-boundary.test.ts
+++ b/packages/app/src/__tests__/renderer-preload-storage-boundary.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { basename, join, relative, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+type Match = {
+  file: string;
+  line: number;
+  rule: string;
+  text: string;
+};
+
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const SOURCE_EXTENSIONS = /\.(ts|tsx|js|jsx)$/;
+const TEST_FILE_PATTERN = /\.(test|spec)\.(ts|tsx|js|jsx)$/;
+
+const FORBIDDEN_PATTERNS: Array<{ rule: string; pattern: RegExp }> = [
+  { rule: '@invoker/data-store import/reference', pattern: /@invoker\/data-store\b/ },
+  { rule: 'SQLiteAdapter reference', pattern: /\bSQLiteAdapter\b/ },
+  { rule: 'direct invoker.db reference', pattern: /\binvoker\.db\b/ },
+];
+
+function walkSourceFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === '__tests__' || entry.name === 'node_modules' || entry.name === 'dist') {
+      continue;
+    }
+
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkSourceFiles(fullPath));
+      continue;
+    }
+
+    if (entry.isFile() && SOURCE_EXTENSIONS.test(entry.name) && !TEST_FILE_PATTERN.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function preloadSourceFiles(): string[] {
+  const appSourceDir = join(REPO_ROOT, 'packages', 'app', 'src');
+  return readdirSync(appSourceDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /^preload.*\.(ts|tsx|js|jsx)$/.test(entry.name))
+    .map((entry) => join(appSourceDir, entry.name));
+}
+
+function findForbiddenStorageReferences(files: string[]): Match[] {
+  const matches: Match[] = [];
+
+  for (const file of files) {
+    const lines = readFileSync(file, 'utf8').split('\n');
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+      for (const { rule, pattern } of FORBIDDEN_PATTERNS) {
+        if (pattern.test(line)) {
+          matches.push({
+            file: relative(REPO_ROOT, file),
+            line: index + 1,
+            rule,
+            text: line.trim(),
+          });
+        }
+      }
+    }
+  }
+
+  return matches;
+}
+
+describe('renderer/preload storage boundary', () => {
+  const uiSourceFiles = walkSourceFiles(join(REPO_ROOT, 'packages', 'ui', 'src'));
+  const preloadFiles = preloadSourceFiles();
+  const guardedFiles = [...uiSourceFiles, ...preloadFiles].sort();
+
+  it('covers the renderer package and Electron preload entrypoints', () => {
+    expect(guardedFiles.map((file) => relative(REPO_ROOT, file))).toContain('packages/ui/src/App.tsx');
+    expect(guardedFiles.map((file) => basename(file))).toContain('preload.ts');
+  });
+
+  it('keeps SQLite and data-store access out of renderer/preload-facing code', () => {
+    const matches = findForbiddenStorageReferences(guardedFiles);
+
+    if (matches.length > 0) {
+      const summary = matches
+        .map((match) => `  ${match.file}:${match.line}  [${match.rule}] ${match.text}`)
+        .join('\n');
+
+      throw new Error(
+        `Unexpected renderer/preload storage boundary violations:\n${summary}\n\n` +
+          'Renderer and preload-facing code must get task graph state through the IPC bridge. ' +
+          'Keep SQLite, @invoker/data-store, SQLiteAdapter, and invoker.db access in app main/server code.',
+      );
+    }
+
+    expect(matches).toEqual([]);
+  });
+});

--- a/packages/app/src/__tests__/viewer-cache-hydration.test.ts
+++ b/packages/app/src/__tests__/viewer-cache-hydration.test.ts
@@ -27,16 +27,16 @@ function ownerUpdateDelta(): TaskDelta {
   } as unknown as TaskDelta;
 }
 
-describe('detached viewer cache hydration', () => {
-  it('repro: an empty viewer cache quarantines (drops) an owner task update', () => {
-    // A detached viewer backed by an empty in-memory DB has an empty cache.
+describe('viewer cache hydration', () => {
+  it('repro: an empty viewer cache quarantines (drops) a task update', () => {
+    // A viewer that has not loaded an initial DB snapshot has an empty cache.
     const cache = new TaskSnapshotCache();
     const { quarantined, accepted } = applyDelta(ownerUpdateDelta(), cache);
     expect(accepted).toBe(false);
     expect(quarantined).toEqual(['wf-1/task-1']); // the live update is lost
   });
 
-  it('hydrating the caches from the owner snapshot lets the same update apply', () => {
+  it('hydrating the caches from an authoritative DB snapshot lets the same update apply', () => {
     const lastKnownTaskStates = new TaskSnapshotCache();
     const workflowRollupProjection = new WorkflowRollupProjection();
     seedTaskCachesFromSnapshot([ownerTask(1)], { lastKnownTaskStates, workflowRollupProjection });
@@ -49,7 +49,7 @@ describe('detached viewer cache hydration', () => {
     expect(merged.taskStateVersion).toBe(2);
   });
 
-  it('hydrates and clears the workflow rollup projection from the owner snapshot', () => {
+  it('hydrates and clears the workflow rollup projection from a DB snapshot', () => {
     const lastKnownTaskStates = new TaskSnapshotCache();
     const workflowRollupProjection = new WorkflowRollupProjection();
     seedTaskCachesFromSnapshot([ownerTask(1)], { lastKnownTaskStates, workflowRollupProjection });

--- a/packages/app/src/__tests__/viewer-detached-db.test.ts
+++ b/packages/app/src/__tests__/viewer-detached-db.test.ts
@@ -1,14 +1,15 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, readdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { SQLiteAdapter } from '@invoker/data-store';
 import { openMainProcessDatabase, openDetachedViewerDatabase } from '../viewer-db-boundary.js';
 import type { Workflow } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
 
 /**
- * Detached GUI viewers must never open the shared `invoker.db` file. They use
- * process-local placeholder persistence while renderer reads delegate to the
- * owner over IPC.
+ * Detached GUI viewers may open the shared `invoker.db` file read-only. React
+ * still crosses only the IPC bridge; this boundary belongs to Electron main.
  */
 
 const dirs: string[] = [];
@@ -28,6 +29,29 @@ const wf: Workflow = {
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
 };
+
+function task(id: string): TaskState {
+  return {
+    id,
+    description: id,
+    status: 'running',
+    dependencies: [],
+    createdAt: new Date('2026-07-29T00:00:00.000Z'),
+    config: { workflowId: wf.id, command: 'echo hello' },
+    execution: { phase: 'executing' },
+    taskStateVersion: 2,
+  } as TaskState;
+}
+
+async function seedDb(dbPath: string): Promise<void> {
+  const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+  try {
+    owner.saveWorkflow(wf);
+    owner.saveTask(wf.id, task('wf-1/hello-world'));
+  } finally {
+    owner.close();
+  }
+}
 
 describe('detached viewer persistence boundary', () => {
   it('uses empty in-memory persistence for read-only startup when the db file is absent', async () => {
@@ -49,45 +73,64 @@ describe('detached viewer persistence boundary', () => {
     }
   });
 
-  it('ignores the real db path and opens no database file (no -shm to truncate)', async () => {
+  it('opens the real database read-only when it exists', async () => {
     const dir = makeDir();
-    const probeDbPath = join(dir, 'invoker.db');
-    const previousCwd = process.cwd();
-    process.chdir(dir);
-    try {
-      const adapter = await openMainProcessDatabase({
-        dbPath: probeDbPath,
-        detachedViewer: true,
-        readOnly: true,
-        exclusiveLocking: true,
-      });
-      try {
-        // Fully functional: schema is present and writes/reads work in memory.
-        expect(adapter.listWorkflows()).toEqual([]);
-        adapter.saveWorkflow(wf);
-        expect(adapter.listWorkflows().map((w) => w.id)).toEqual(['wf-1']);
-        // Telemetry writes the viewer's logger attempts must not throw in memory.
-        expect(() => adapter.writeActivityLog('viewer', 'info', 'hello')).not.toThrow();
+    const dbPath = join(dir, 'invoker.db');
+    await seedDb(dbPath);
 
-        // The immunity property: no file, no -wal, no -shm anywhere.
-        expect(existsSync(probeDbPath)).toBe(false);
-        expect(existsSync(`${probeDbPath}-shm`)).toBe(false);
-        expect(existsSync(`${probeDbPath}-wal`)).toBe(false);
-        expect(readdirSync(dir)).toEqual([]);
-      } finally {
-        adapter.close();
-      }
+    const adapter = await openMainProcessDatabase({
+      dbPath,
+      detachedViewer: true,
+      readOnly: true,
+      exclusiveLocking: true,
+    });
+    try {
+      expect(adapter.listWorkflows().map((item) => item.id)).toEqual(['wf-1']);
+      expect(adapter.loadTasks(wf.id).map((item) => item.id)).toEqual(['wf-1/hello-world']);
+      expect(adapter.loadTask('wf-1/hello-world')?.status).toBe('running');
     } finally {
-      process.chdir(previousCwd);
+      adapter.close();
     }
   });
 
-  it('does not require owner capability (it never touches the shared file)', async () => {
+  it('rejects detached viewer writes when the real database exists', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    await seedDb(dbPath);
+
+    const adapter = await openMainProcessDatabase({
+      dbPath,
+      detachedViewer: true,
+      readOnly: true,
+      exclusiveLocking: false,
+    });
+    try {
+      expect(() => adapter.updateTask('wf-1/hello-world', { status: 'completed' })).toThrow(/read-only/i);
+      expect(() => adapter.saveWorkflow({ ...wf, id: 'wf-2' })).toThrow(/read-only/i);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('keeps an explicit ephemeral placeholder helper for absent databases', async () => {
     const adapter = await openDetachedViewerDatabase();
     try {
       expect(adapter).toBeDefined();
     } finally {
       adapter.close();
     }
+  });
+
+  it('does not silently fall back to empty persistence when read-only open fails', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    writeFileSync(dbPath, 'not sqlite', 'utf-8');
+
+    await expect(openMainProcessDatabase({
+      dbPath,
+      detachedViewer: true,
+      readOnly: true,
+      exclusiveLocking: false,
+    })).rejects.toThrow();
   });
 });

--- a/packages/app/src/headless-no-track-fallback.ts
+++ b/packages/app/src/headless-no-track-fallback.ts
@@ -41,7 +41,8 @@ function writeAcceptedNoTrackResult(result: WorkflowMutationAcceptedResult): voi
 }
 
 function fallbackExclusiveLockingEnabled(): boolean {
-  return process.env.INVOKER_DISABLE_EXCLUSIVE_LOCKING !== '1'
+  return process.env.INVOKER_ENABLE_EXCLUSIVE_LOCKING === '1'
+    && process.env.INVOKER_DISABLE_EXCLUSIVE_LOCKING !== '1'
     && process.env.INVOKER_UNSAFE_DISABLE_DB_WRITER_LOCK !== '1';
 }
 

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -908,7 +908,7 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
       case 'invoker:stop-worker':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resume-workflow': {
-        const workflows = rendererTaskFeed.getDetachedViewerWorkflows() ?? persistence.listWorkflows();
+        const workflows = persistence.listWorkflows();
         const firstWorkflow = workflows[0] as { id?: unknown } | undefined;
         const workflowId = context.getStartupWorkflowId()
           ?? (typeof firstWorkflow?.id === 'string' ? firstWorkflow.id : undefined);

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1,4 +1,7 @@
 import type { App, BrowserWindow, IpcMain } from 'electron';
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { Orchestrator, CommandService, OrchestratorErrorCode, normalizeWorkflowBaseBranch } from '@invoker/workflow-core';
 import type { TaskDelta, TaskReplacementDef, TaskState, TaskStateChanges } from '@invoker/workflow-core';
 import { CommandError, IpcChannels, makeEnvelope } from '@invoker/contracts';
@@ -15,6 +18,7 @@ import type {
   Logger,
   StartReadyRequest,
   StartReadyResult,
+  TaskGraphEvent,
   WorkflowMutationAcceptedResult,
 } from '@invoker/contracts';
 import { ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
@@ -1870,6 +1874,32 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       persistence.writeActivityLog('ui-perf', 'info', JSON.stringify(payload));
     } catch {
       // DB might be locked
+    }
+  });
+
+  const traceRendererTaskGraphEvents = process.env.INVOKER_TRACE_RENDERER_TASK_GRAPH === '1';
+  const rendererTaskGraphTracePath = join(homedir(), '.invoker', 'ui-task-graph-events.jsonl');
+  let rendererTaskGraphTraceWriteFailed = false;
+  ipcMain.handle('invoker:trace-renderer-task-graph-event', (_event, event: TaskGraphEvent) => {
+    if (!traceRendererTaskGraphEvents) return;
+    try {
+      mkdirSync(dirname(rendererTaskGraphTracePath), { recursive: true });
+      appendFileSync(
+        rendererTaskGraphTracePath,
+        JSON.stringify({
+          time: new Date().toISOString(),
+          source: 'renderer',
+          event,
+        }) + '\n',
+      );
+    } catch (err) {
+      if (!rendererTaskGraphTraceWriteFailed) {
+        rendererTaskGraphTraceWriteFailed = true;
+        logger.warn(
+          `renderer task graph trace write failed: ${err instanceof Error ? err.message : String(err)}`,
+          { module: 'ui' },
+        );
+      }
     }
   });
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -657,12 +657,10 @@ function assertDeleteAllEnabled(): void {
 interface InitServicesOptions {
   readOnly?: boolean;
   /**
-   * GUI viewer mode: never open `invoker.db`. A writable owner is always present
-   * in this mode, so the renderer's reads delegate to the owner over IPC and
-   * live updates arrive via TASK_DELTA/TASK_OUTPUT. We back the in-process
-   * services with a private empty in-memory database so no `-shm` is mapped on
-   * the real file — that is what lets the owner run WAL exclusive locking and be
-   * immune to the `-shm` truncation SIGBUS. Implies non-owner (readOnly) semantics.
+   * GUI viewer mode: opens `invoker.db` read-only when it exists, so renderer
+   * bootstrap and gap recovery use the same database as the owner while all
+   * mutations still delegate over IPC. If the file is absent, startup uses a
+   * private empty placeholder. Implies non-owner (readOnly) semantics.
    */
   detachedViewer?: boolean;
   executionAgentRegistry?: AgentRegistry;
@@ -737,7 +735,8 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     dbPath,
     detachedViewer,
     readOnly,
-    exclusiveLocking: process.env.INVOKER_DISABLE_EXCLUSIVE_LOCKING !== '1'
+    exclusiveLocking: process.env.INVOKER_ENABLE_EXCLUSIVE_LOCKING === '1'
+      && process.env.INVOKER_DISABLE_EXCLUSIVE_LOCKING !== '1'
       && process.env.INVOKER_UNSAFE_DISABLE_DB_WRITER_LOCK !== '1',
   });
   // Upgrade root logger with DB persistence now that SQLiteAdapter is ready.
@@ -3010,9 +3009,6 @@ startMainProcessBootstrap({
     logger.info('Effective configuration', { config: getSafeInvokerConfigForLogging(invokerConfig), module: 'startup' });
     recordStartupMark('startup.ready-for-window');
 
-    if (!ownerMode) {
-      requireRendererTaskFeed().beginDetachedViewerBuffering();
-    }
     messageBus.subscribe(Channels.TASK_DELTA, (delta: unknown) => {
       requireRendererTaskFeed().receiveTaskDelta(delta as TaskDelta);
     });
@@ -3039,9 +3035,7 @@ startMainProcessBootstrap({
     registerBootstrapStateIpc({
       ipcMain,
       getTasks: () => (ownerMode ? orchestrator.getAllTasks() : requireRendererTaskFeed().getDetachedViewerTasks()),
-      getWorkflows: () =>
-        requireRendererTaskFeed().getDetachedViewerWorkflows()
-          ?? startupWorkflowCache.takeOrLoad(listWorkflowsByStartupRecency),
+      getWorkflows: () => startupWorkflowCache.takeOrLoad(listWorkflowsByStartupRecency),
       getInitialWorkflowId: () => startupWorkflowId,
       appStartedAtEpochMs: appProcessStartedAt,
       getTaskDeltaStreamSequence,
@@ -3214,11 +3208,10 @@ startMainProcessBootstrap({
       ),
     );
 
-    if (ownerMode) {
-      requireRendererTaskFeed().seedUiSnapshotCache();
-    } else {
-      await requireRendererTaskFeed().hydrateDetachedViewerFromOwner();
+    if (!ownerMode) {
+      bootstrapInitialWorkflowState();
     }
+    requireRendererTaskFeed().seedUiSnapshotCache();
     createWindow();
     recordStartupMark('createWindow.end');
 

--- a/packages/app/src/preload.ts
+++ b/packages/app/src/preload.ts
@@ -110,6 +110,10 @@ for (const channel of Object.keys(IpcEventChannels)) {
 
 contextBridge.exposeInMainWorld('invoker', api as InvokerAPI);
 contextBridge.exposeInMainWorld('__INVOKER_BOOTSTRAP__', bootstrapState ?? { tasks: [], workflows: [] });
+contextBridge.exposeInMainWorld(
+  '__INVOKER_TRACE_RENDERER_TASK_GRAPH__',
+  process.env.INVOKER_TRACE_RENDERER_TASK_GRAPH === '1',
+);
 
 setTimeout(() => {
   ipcRenderer.invoke('invoker:report-ui-perf', 'preload_bootstrap_sync', {

--- a/packages/app/src/viewer-cache-hydration.ts
+++ b/packages/app/src/viewer-cache-hydration.ts
@@ -11,10 +11,10 @@ export interface ViewerTaskCaches {
  * Replace the main-process delta caches with an authoritative task list.
  *
  * Shared by the owner's local seeding (`seedUiSnapshotCache`,
- * `publishOrchestratorSnapshotToRenderer`) and by the detached viewer, which
- * seeds from the owner's delegated snapshot. Seeding the cache is what gives
- * incoming `updated` deltas a base entry; without it every delta for a task the
- * viewer has not seen is quarantined and effectively dropped.
+ * `publishOrchestratorSnapshotToRenderer`) and by detached viewers, which seed
+ * from their read-only main-process database snapshot. Seeding the cache is what
+ * gives incoming `updated` deltas a base entry; without it every delta for a task
+ * the viewer has not seen is quarantined and effectively dropped.
  */
 export function seedTaskCachesFromSnapshot(tasks: readonly TaskState[], caches: ViewerTaskCaches): void {
   caches.lastKnownTaskStates.clear();

--- a/packages/app/src/viewer-db-boundary.ts
+++ b/packages/app/src/viewer-db-boundary.ts
@@ -10,7 +10,15 @@ export interface MainProcessDatabaseOptions {
 
 export async function openMainProcessDatabase(options: MainProcessDatabaseOptions): Promise<SQLiteAdapter> {
   if (options.detachedViewer) {
-    return openDetachedViewerDatabase();
+    if (!existsSync(options.dbPath)) {
+      return openDetachedViewerDatabase();
+    }
+
+    return SQLiteAdapter.create(options.dbPath, {
+      readOnly: true,
+      ownerCapability: false,
+      exclusiveLocking: false,
+    });
   }
 
   // Read-only headless snapshots should report an empty store before the first

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -183,6 +183,8 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return {};
       case 'invoker:report-ui-perf':
         return undefined;
+      case 'invoker:trace-renderer-task-graph-event':
+        return undefined;
       case 'invoker:check-pr-statuses':
       case 'invoker:check-pr-status':
         await deps.checkPrStatuses?.();

--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -62,7 +62,7 @@ export interface RendererTaskFeedUiPerfStats {
 export interface RendererTaskFeedDeps {
   logger: Logger;
   persistence: RendererTaskFeedPersistence;
-  messageBus: Pick<MessageBus, 'publish' | 'request'>;
+  messageBus: Pick<MessageBus, 'publish'>;
   getOrchestrator: () => RendererTaskFeedOrchestrator;
   taskHandles: { has(taskId: string): boolean };
   taskGraphEventPublisher: Pick<TaskGraphEventPublisher, 'publishDelta'>;
@@ -83,9 +83,7 @@ export interface RendererTaskFeed {
   enqueueTaskOutput(taskId: string, data: string): void;
   flushTaskOutput(taskId: string): void;
   seedUiSnapshotCache(): void;
-  hydrateDetachedViewerFromOwner(): Promise<void>;
   getDetachedViewerTasks(): TaskState[];
-  getDetachedViewerWorkflows(): unknown[] | null;
   publishTaskDeltaToRenderer(delta: TaskDelta): void;
   getLastKnownWorkflowCount(): number;
   setLastKnownWorkflowCount(count: number): void;
@@ -95,7 +93,6 @@ export interface RendererTaskFeed {
   replaceWorkflowRollups(tasks: TaskState[]): void;
   rememberTaskState(task: TaskState): void;
   resetSnapshotState(): void;
-  beginDetachedViewerBuffering(): void;
   receiveTaskDelta(delta: TaskDelta): void;
   startDbPolling(): RendererTaskFeedStopHandle;
   startActivityPolling(): RendererTaskFeedStopHandle;
@@ -107,8 +104,6 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
   const pendingOutputBuffers = new Map<string, string[]>();
   const outputFlushTimers = new Map<string, RendererTaskFeedTimer>();
   let lastKnownWorkflowCount = 0;
-  let detachedViewerWorkflows: unknown[] | null = null;
-  let detachedDeltaBuffer: TaskDelta[] | null = null;
 
   const flushTaskOutput = (taskId: string): void => {
     const timer = outputFlushTimers.get(taskId);
@@ -178,54 +173,12 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
     seedTaskCachesFromSnapshot(deps.getOrchestrator().getAllTasks(), { lastKnownTaskStates, workflowRollupProjection });
   };
 
-  // Detached viewer: the local DB is empty, so seed the delta caches and
-  // bootstrap snapshot from the owner. Without this, the empty cache quarantines
-  // every `updated` delta for a task the viewer has not seen (dropping live
-  // updates), and bootstrap getters return nothing. Failures are non-fatal — the
-  // renderer's delegated reads still populate the view.
-  const hydrateDetachedViewerFromOwner = async (): Promise<void> => {
-    try {
-      const snapshot = await deps.messageBus.request<{ kind: string }, { tasks?: TaskState[]; workflows?: unknown[] }>(
-        'headless.query',
-        { kind: 'tasks' },
-      );
-      const tasks = Array.isArray(snapshot?.tasks) ? snapshot.tasks : [];
-      const workflows = Array.isArray(snapshot?.workflows) ? snapshot.workflows : [];
-      detachedViewerWorkflows = workflows;
-      seedTaskCachesFromSnapshot(tasks, { lastKnownTaskStates, workflowRollupProjection });
-      lastKnownWorkflowCount = workflows.length;
-      deps.setStartupWorkflowId(
-        [...workflows]
-          .map((wf) => wf as { id?: string; updatedAt?: string; createdAt?: string })
-          .sort((left, right) => (Date.parse(right.updatedAt ?? '') || 0) - (Date.parse(left.updatedAt ?? '') || 0))[0]?.id ?? null,
-      );
-      deps.logger.info(
-        `[init] Hydrated detached viewer from owner: ${tasks.length} tasks across ${workflows.length} workflows`,
-        { module: 'init' },
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      deps.logger.warn(`detached viewer hydration from owner failed; relying on delegated reads: ${message}`, { module: 'init' });
-    } finally {
-      // Resume direct delta processing and replay anything buffered during
-      // hydration (in arrival order). Always runs, so a hydration failure can
-      // never leave deltas buffered forever.
-      const buffered = detachedDeltaBuffer ?? [];
-      detachedDeltaBuffer = null;
-      for (const delta of buffered) processIncomingTaskDelta(delta);
-    }
-  };
-
   // Current task states for the detached viewer's bootstrap getter, derived from
-  // the live delta cache so a renderer reload never sees the stale hydration
-  // snapshot.
+  // the same cache owner mode uses for delta gap recovery.
   const getDetachedViewerTasks = (): TaskState[] => [...lastKnownTaskStates.keys()].map(
     (taskId) => JSON.parse(lastKnownTaskStates.get(taskId) ?? '{}') as TaskState,
   );
 
-  // Apply one owner task delta to the local cache and forward results to the
-  // renderer. Extracted so the detached viewer can replay deltas that were
-  // buffered during hydration.
   const processIncomingTaskDelta = (delta: TaskDelta): void => {
     deps.uiPerfStats.mainDeltaToUi += 1;
     if (deps.traceUiDeltaFlow) {
@@ -445,9 +398,7 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
     enqueueTaskOutput,
     flushTaskOutput,
     seedUiSnapshotCache,
-    hydrateDetachedViewerFromOwner,
     getDetachedViewerTasks,
-    getDetachedViewerWorkflows: () => detachedViewerWorkflows,
     publishTaskDeltaToRenderer,
     getLastKnownWorkflowCount: () => lastKnownWorkflowCount,
     setLastKnownWorkflowCount: (count) => { lastKnownWorkflowCount = count; },
@@ -461,14 +412,7 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
       workflowRollupProjection.clear();
       lastKnownWorkflowCount = 0;
     },
-    beginDetachedViewerBuffering: () => { detachedDeltaBuffer = []; },
-    receiveTaskDelta: (delta) => {
-      if (detachedDeltaBuffer) {
-        detachedDeltaBuffer.push(delta);
-        return;
-      }
-      processIncomingTaskDelta(delta);
-    },
+    receiveTaskDelta: processIncomingTaskDelta,
     startDbPolling,
     startActivityPolling,
   };

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1266,6 +1266,10 @@ export const IpcChannels = {
     request: [metric: string, data?: Record<string, unknown>];
     response: void;
   },
+  'invoker:trace-renderer-task-graph-event': {} as {
+    request: [event: TaskGraphEvent];
+    response: void;
+  },
   'invoker:get-ui-perf-stats': {} as {
     request: [];
     response: Record<string, unknown>;

--- a/packages/data-store/src/__tests__/exclusive-locking.test.ts
+++ b/packages/data-store/src/__tests__/exclusive-locking.test.ts
@@ -57,7 +57,7 @@ describe('SQLiteAdapter exclusiveLocking', () => {
     }
   });
 
-  it('rejects read-only file-backed opens while live WAL sidecars exist', async () => {
+  it('allows read-only file-backed opens while a normal WAL owner is live', async () => {
     const dir = makeDir();
     const dbPath = join(dir, 'invoker.db');
     const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
@@ -65,13 +65,32 @@ describe('SQLiteAdapter exclusiveLocking', () => {
       owner.saveWorkflow(wf);
       expect(existsSync(`${dbPath}-shm`)).toBe(true);
       expect(existsSync(`${dbPath}.owner`)).toBe(true);
-      await expect(
-        SQLiteAdapter.create(dbPath, { readOnly: true }),
-      ).rejects.toThrow(/writable owner PID \d+ holds live WAL sidecars/i);
+      const reader = await SQLiteAdapter.create(dbPath, { readOnly: true });
+      try {
+        expect(reader.listWorkflows().map((w) => w.id)).toEqual(['wf-1']);
+      } finally {
+        reader.close();
+      }
     } finally {
       owner.close();
     }
     expect(existsSync(`${dbPath}.owner`)).toBe(false);
+  });
+
+  it('rejects read-only viewers while an exclusive-locking owner is live', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true, exclusiveLocking: true });
+    try {
+      owner.saveWorkflow(wf);
+      expect(existsSync(`${dbPath}-wal`)).toBe(true);
+      expect(existsSync(`${dbPath}-shm`)).toBe(false);
+      await expect(
+        SQLiteAdapter.create(dbPath, { readOnly: true }),
+      ).rejects.toThrow(/exclusive locking.*read-only viewers/i);
+    } finally {
+      owner.close();
+    }
   });
 
   it('read-only opens are still allowed after a clean close', async () => {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -174,7 +174,9 @@ interface SQLiteAdapterOptions {
    * Open WAL in exclusive locking mode: the wal-index lives in heap memory and
    * no `-shm` file is created, making the process immune to the SIGBUS that a
    * truncated memory-mapped `-shm` causes. Requires this process to be the SOLE
-   * opener of the database file — a concurrent open is rejected with SQLITE_BUSY.
+   * opener of the database file and is incompatible with delegated read-only
+   * viewers. Normal WAL mode is the default and supports one writer with
+   * concurrent read-only viewers.
    */
   exclusiveLocking?: boolean;
   slowQueryThresholdMs?: number;
@@ -740,17 +742,20 @@ export class SQLiteAdapter implements PersistenceAdapter {
       );
     }
 
-    // Sidecar files alone cannot prove a writable owner is live: opening a
-    // WAL-mode database read-only creates -wal/-shm itself, and a read-only
-    // connection has no write access to checkpoint them away on close. Gating
-    // on mere existence therefore lets the first reader wedge every reader
-    // after it. Only a live owner may turn a reader away.
-    if (isFile && options?.readOnly === true && (existsSync(`${dbPath}-wal`) || existsSync(`${dbPath}-shm`))) {
+    // In normal WAL mode, read-only viewers are allowed to coexist with the
+    // writable owner. Exclusive locking is the opt-in exception: it keeps the
+    // wal-index in heap memory and requires the owner to be the sole opener.
+    if (
+      isFile
+      && options?.readOnly === true
+      && existsSync(`${dbPath}-wal`)
+      && !existsSync(`${dbPath}-shm`)
+    ) {
       const ownerPid = readLiveOwnerPid(dbPath);
       if (ownerPid !== null) {
         throw new Error(
-          `Cannot open SQLite database read-only while writable owner PID ${ownerPid} holds live WAL sidecars for ${dbPath}. ` +
-          'Close the writable owner cleanly before opening a file-backed read-only adapter.',
+          `Cannot open SQLite database read-only while writable owner PID ${ownerPid} is using exclusive locking for ${dbPath}. ` +
+          'exclusiveLocking is incompatible with delegated read-only viewers; restart the owner in normal WAL mode.',
         );
       }
     }

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -339,6 +339,7 @@ export function createMockInvoker(
     replaceTask: vi.fn(async () => accepted('invoker:replace-task')),
     getActivityLogs: vi.fn(async () => []),
     reportUiPerf: vi.fn(async () => {}),
+    traceRendererTaskGraphEvent: vi.fn(async () => {}),
     getUiPerfStats: vi.fn(async () => ({})),
     getEvents: vi.fn(async (taskId: string, options?: { limit: number; sortBy?: 'asc' | 'desc'; beforeId?: number }) => {
       const events = [...(eventsByTask.get(taskId) ?? [])];

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -123,6 +123,9 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
   const traceTaskDeltas =
     typeof window !== 'undefined' &&
     window.location.search.includes('traceTaskDeltas=1');
+  const traceRendererTaskGraphEvents =
+    typeof window !== 'undefined' &&
+    window.__INVOKER_TRACE_RENDERER_TASK_GRAPH__ === true;
   const bootstrapState =
     typeof window !== 'undefined' ? window.__INVOKER_BOOTSTRAP__ : undefined;
   const [tasks, setTasks] = useState<Map<string, TaskState>>(() => {
@@ -442,6 +445,12 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
 
     const handleTaskGraphEvent = (event: TaskGraphEvent) => {
       invalidateStartupSnapshot();
+      if (traceRendererTaskGraphEvents) {
+        const traceRendererTaskGraphEvent = window.invoker.traceRendererTaskGraphEvent;
+        if (traceRendererTaskGraphEvent) {
+          void traceRendererTaskGraphEvent(event).catch(() => undefined);
+        }
+      }
       deltaPerfRef.current.received += 1;
       if (event.type === 'snapshot') {
         const snapshotStreamSequence = event.streamSequence;
@@ -543,7 +552,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
       unsub();
       unsubWf?.();
     };
-  }, [invalidateStartupSnapshot, loadStartupSnapshot, onTaskGraphSnapshotApplied, refreshTaskGraph, refreshWorkflowMetadata]);
+  }, [invalidateStartupSnapshot, loadStartupSnapshot, onTaskGraphSnapshotApplied, refreshTaskGraph, refreshWorkflowMetadata, traceRendererTaskGraphEvents]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !window.invoker) return;

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -357,6 +357,7 @@ declare global {
       appStartedAtEpochMs?: number;
       streamSequence?: number;
     };
+    __INVOKER_TRACE_RENDERER_TASK_GRAPH__?: boolean;
     __INVOKER_TEST_OPEN_TERMINAL__?: (taskId: string) => ReturnType<InvokerAPI['openTerminal']>;
     __INVOKER_TEST_ON_TERMINAL_OUTPUT__?: (cb: (event: TerminalOutputEvent) => void) => () => void;
   }

--- a/scripts/repro/repro-readonly-follower-live-wal.sh
+++ b/scripts/repro/repro-readonly-follower-live-wal.sh
@@ -4,12 +4,6 @@ set -euo pipefail
 ROOT="${ROOT_OVERRIDE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
 cd "$ROOT"
 
-EXPECT_PATCHED_GUARD="${EXPECT_PATCHED_GUARD:-1}"
-if [[ "$EXPECT_PATCHED_GUARD" != "0" && "$EXPECT_PATCHED_GUARD" != "1" ]]; then
-  echo "EXPECT_PATCHED_GUARD must be 0 or 1" >&2
-  exit 1
-fi
-
 pnpm --filter @invoker/data-store build >/dev/null
 
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-live-wal-repro.XXXXXX")"
@@ -17,7 +11,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 DB_PATH="$TMP_DIR/invoker.db"
 
 export REPRO_DB_PATH="$DB_PATH"
-export ROOT EXPECT_PATCHED_GUARD
+export ROOT
 
 node --input-type=module <<'NODE'
 import { existsSync } from 'node:fs';
@@ -45,35 +39,18 @@ if (!whileOwnerOpen.wal || !whileOwnerOpen.shm) {
 }
 console.log(`[repro] live owner open sidecars wal=${whileOwnerOpen.wal} shm=${whileOwnerOpen.shm}`);
 
-// This is the old unsafe follower path: a second process opens the live DB directly.
-const unsafeFollower = new DatabaseSync(dbPath, { readOnly: true });
-const rows = unsafeFollower.prepare('SELECT id FROM workflows').all();
-unsafeFollower.close();
-console.log(`[repro] old follower path can read live DB directly rows=${rows.length}`);
+const rawFollower = new DatabaseSync(dbPath, { readOnly: true });
+const rows = rawFollower.prepare('SELECT id FROM workflows').all();
+rawFollower.close();
+console.log(`[repro] raw read-only follower can read live DB directly rows=${rows.length}`);
 
-const expectPatchedGuard = process.env.EXPECT_PATCHED_GUARD === '1';
-let patchedReaderRows = null;
-let blocked = false;
-try {
-  const reader = await SQLiteAdapter.create(dbPath, { readOnly: true });
-  patchedReaderRows = reader.listWorkflows().length;
-  reader.close();
-} catch (error) {
-  blocked = /WAL sidecars exist/i.test(String(error));
-  console.log(`[repro] adapter read-only open result: ${String(error)}`);
+const reader = await SQLiteAdapter.create(dbPath, { readOnly: true });
+const adapterRows = reader.listWorkflows().length;
+reader.close();
+if (adapterRows !== 1) {
+  throw new Error(`expected adapter read-only follower to see one workflow, got ${adapterRows}`);
 }
-
-if (expectPatchedGuard) {
-  if (!blocked) {
-    throw new Error('patched adapter did not reject read-only open while live WAL sidecars existed');
-  }
-  console.log('[repro] patched guard blocked the live follower path');
-} else {
-  if (blocked || patchedReaderRows !== 1) {
-    throw new Error(`pre-fix branch no longer reproduces the unsafe follower path (blocked=${blocked} rows=${patchedReaderRows})`);
-  }
-  console.log(`[repro] pre-fix branch allowed live follower attach rows=${patchedReaderRows}`);
-}
+console.log(`[repro] adapter read-only follower can coexist with normal WAL owner rows=${adapterRows}`);
 
 owner.close();
 const afterOwnerClose = sidecars();

--- a/scripts/repro/repro-ui-delta-timeline.sh
+++ b/scripts/repro/repro-ui-delta-timeline.sh
@@ -1,0 +1,469 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="$ROOT_DIR/run.sh"
+TIMEOUT_SEC="${INVOKER_UI_DELTA_TIMELINE_TIMEOUT_SEC:-240}"
+OWNER_PROBE_TIMEOUT_SEC="${INVOKER_UI_DELTA_OWNER_PROBE_TIMEOUT_SEC:-5}"
+KEEP_TMP="${INVOKER_UI_DELTA_KEEP_TMP:-0}"
+
+TMP_BASE="${INVOKER_UI_DELTA_TMPDIR:-/tmp}"
+TMP_ROOT="$(mktemp -d "$TMP_BASE/invoker-ui-delta-timeline.XXXXXX")"
+HOME_DIR="$TMP_ROOT/home"
+DB_DIR="$HOME_DIR/.invoker"
+LOG_DIR="$TMP_ROOT/logs"
+PLAN_PATH="$TMP_ROOT/hello-world.yaml"
+CONFIG_PATH="$TMP_ROOT/config.json"
+IPC_SOCKET="$TMP_ROOT/i.sock"
+FEATURE_BRANCH="plan/ui-delta-timeline-$(date +%s)-$$"
+REPO_URL="${INVOKER_UI_DELTA_REPO_URL:-}"
+
+GUI_LOG="$LOG_DIR/gui-launch.log"
+RUN_STDOUT="$LOG_DIR/run.stdout.log"
+RUN_STDERR="$LOG_DIR/run.stderr.log"
+REBASE_STDOUT="$LOG_DIR/rebase-recreate.stdout.log"
+REBASE_STDERR="$LOG_DIR/rebase-recreate.stderr.log"
+WORKFLOWS_JSON="$LOG_DIR/workflows.json"
+WORKFLOW_STATUS_JSON="$LOG_DIR/workflow-status.json"
+BACKEND_SOURCE="$DB_DIR/invoker.log"
+RENDERER_SOURCE="$DB_DIR/ui-task-graph-events.jsonl"
+BACKEND_RAW="$LOG_DIR/backend.raw.log"
+RENDERER_RAW="$LOG_DIR/renderer.raw.jsonl"
+COMPARISON_JSON="$LOG_DIR/comparison.json"
+
+GUI_PID=""
+BACKEND_FOLLOW_PID=""
+RENDERER_FOLLOW_PID=""
+
+log() {
+  printf '==> %s\n' "$*" >&2
+}
+
+fail() {
+  KEEP_TMP=1
+  printf 'FAIL: %s\n' "$*" >&2
+  printf 'Artifacts: %s\n' "$LOG_DIR" >&2
+  exit 1
+}
+
+cleanup() {
+  if [[ -n "$BACKEND_FOLLOW_PID" ]] && kill -0 "$BACKEND_FOLLOW_PID" >/dev/null 2>&1; then
+    kill "$BACKEND_FOLLOW_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$RENDERER_FOLLOW_PID" ]] && kill -0 "$RENDERER_FOLLOW_PID" >/dev/null 2>&1; then
+    kill "$RENDERER_FOLLOW_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$GUI_PID" ]] && kill -0 "$GUI_PID" >/dev/null 2>&1; then
+    kill "$GUI_PID" >/dev/null 2>&1 || true
+    wait "$GUI_PID" >/dev/null 2>&1 || true
+  fi
+  rm -f "$IPC_SOCKET"
+  if [[ "$KEEP_TMP" = "1" ]]; then
+    printf 'Kept temp repro dir: %s\n' "$TMP_ROOT" >&2
+  else
+    rm -rf "$TMP_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+COMMON_ENV=(
+  HOME="$HOME_DIR"
+  INVOKER_DB_DIR="$DB_DIR"
+  INVOKER_IPC_SOCKET="$IPC_SOCKET"
+  INVOKER_REPO_CONFIG_PATH="$CONFIG_PATH"
+  INVOKER_GUI_OWNER_MODE=gui
+  INVOKER_DISABLE_SLACK=1
+  INVOKER_TRACE_UI_DELTA=1
+  INVOKER_TRACE_RENDERER_TASK_GRAPH=1
+)
+
+run_headless() {
+  env "${COMMON_ENV[@]}" "$RUNNER" --headless "$@"
+}
+
+run_headless_logged_with_timeout() {
+  local timeout_sec="$1"
+  local stdout_file="$2"
+  local stderr_file="$3"
+  shift 3
+
+  env "${COMMON_ENV[@]}" python3 - "$timeout_sec" "$stdout_file" "$stderr_file" "$RUNNER" --headless "$@" <<'PY'
+import os
+import signal
+import subprocess
+import sys
+
+timeout_sec = float(sys.argv[1])
+stdout_file = sys.argv[2]
+stderr_file = sys.argv[3]
+command = sys.argv[4:]
+
+with open(stdout_file, "w", encoding="utf-8") as stdout, open(stderr_file, "w", encoding="utf-8") as stderr:
+    child = subprocess.Popen(
+        command,
+        stdout=stdout,
+        stderr=stderr,
+        start_new_session=True,
+    )
+    try:
+        raise SystemExit(child.wait(timeout=timeout_sec))
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(child.pid, signal.SIGTERM)
+            child.wait(timeout=2)
+        except Exception:
+            try:
+                os.killpg(child.pid, signal.SIGKILL)
+            except Exception:
+                pass
+            child.wait()
+        raise SystemExit(124)
+PY
+}
+
+run_headless_logged() {
+  run_headless_logged_with_timeout "$TIMEOUT_SEC" "$@"
+}
+
+wait_for_gui_ready() {
+  local deadline=$((SECONDS + TIMEOUT_SEC))
+  while (( SECONDS < deadline )); do
+    if [[ -n "$GUI_PID" ]] && ! kill -0 "$GUI_PID" >/dev/null 2>&1; then
+      tail -n 120 "$GUI_LOG" >&2 || true
+      fail "GUI process exited before owner startup completed"
+    fi
+
+    local owner_pid=""
+    if [[ -f "$DB_DIR/invoker.db.lock/pid" ]]; then
+      owner_pid="$(cat "$DB_DIR/invoker.db.lock/pid" 2>/dev/null || true)"
+    fi
+    if [[ -n "$owner_pid" ]] \
+      && kill -0 "$owner_pid" >/dev/null 2>&1 \
+      && { [[ -S "$IPC_SOCKET" ]] || [[ -e "$IPC_SOCKET" ]]; } \
+      && grep -q 'owner-ipc-ready' "$BACKEND_SOURCE" 2>/dev/null \
+      && grep -q 'startup phase ui.interactive' "$BACKEND_SOURCE" 2>/dev/null; then
+      return 0
+    fi
+
+    sleep 1
+  done
+  tail -n 120 "$GUI_LOG" >&2 || true
+  fail "timed out waiting for GUI owner startup"
+}
+
+start_log_followers() {
+  touch "$BACKEND_SOURCE" "$RENDERER_SOURCE"
+
+tail -n0 -F "$BACKEND_SOURCE" 2>/dev/null | python3 -u -c '
+import json, sys
+marker = "delta\u2192ui:"
+for raw in sys.stdin:
+    try:
+        row = json.loads(raw)
+    except Exception:
+        continue
+    msg = row.get("msg", "")
+    if row.get("module") == "ui" and marker in msg:
+        print("[backend delta-ui] " + msg.split(marker, 1)[1].strip(), flush=True)
+' &
+  BACKEND_FOLLOW_PID="$!"
+
+  tail -n0 -F "$RENDERER_SOURCE" 2>/dev/null | python3 -u -c '
+import json, sys
+for raw in sys.stdin:
+    try:
+        row = json.loads(raw)
+    except Exception:
+        continue
+    event = row.get("event", {})
+    if event.get("type") != "delta":
+        continue
+    print("[renderer task-graph-event] " + json.dumps(event.get("delta", {}), separators=(",", ":")), flush=True)
+' &
+  RENDERER_FOLLOW_PID="$!"
+}
+
+parse_workflow_id_from_stdout() {
+  local stdout_file="$1"
+  sed -nE \
+    -e 's/^Workflow ID: (wf-[^[:space:]]+).*/\1/p' \
+    -e 's/^Delegated to owner .* workflow: (wf-[^[:space:]]+).*/\1/p' \
+    "$stdout_file" | tail -n1
+}
+
+discover_workflow_id() {
+  local stdout_file="$1"
+  local parsed
+  parsed="$(parse_workflow_id_from_stdout "$stdout_file")"
+  if [[ -n "$parsed" ]]; then
+    printf '%s\n' "$parsed"
+    return 0
+  fi
+
+  run_headless_logged "$WORKFLOWS_JSON" "$LOG_DIR/workflows.stderr.log" query workflows --output json
+  python3 - "$WORKFLOWS_JSON" <<'PY'
+import json, pathlib, sys
+text = pathlib.Path(sys.argv[1]).read_text(errors='ignore')
+start = text.find('[')
+if start < 0:
+    raise SystemExit(1)
+workflows = json.loads(text[start:])
+matches = [wf for wf in workflows if wf.get('name') == 'UI Delta Timeline Hello World']
+if not matches:
+    raise SystemExit(1)
+matches.sort(key=lambda wf: wf.get('createdAt') or wf.get('updatedAt') or '')
+print(matches[-1]['id'])
+PY
+}
+
+wait_for_workflow_completed() {
+  local workflow_id="$1"
+  local deadline=$((SECONDS + TIMEOUT_SEC))
+  local last_status=""
+
+  while (( SECONDS < deadline )); do
+    if run_headless_logged_with_timeout \
+      "$OWNER_PROBE_TIMEOUT_SEC" \
+      "$WORKFLOW_STATUS_JSON" \
+      "$LOG_DIR/workflow-status.stderr.log" \
+      query workflows --output json; then
+      local result
+      result="$(python3 - "$WORKFLOW_STATUS_JSON" "$workflow_id" <<'PY'
+import json
+import pathlib
+import sys
+
+path, workflow_id = sys.argv[1:3]
+text = pathlib.Path(path).read_text(errors="ignore")
+start = text.find("[")
+if start < 0:
+    raise SystemExit(1)
+workflows = json.loads(text[start:])
+workflow = next((item for item in workflows if item.get("id") == workflow_id), None)
+if workflow is None:
+    raise SystemExit(2)
+status = workflow.get("status") or "unknown"
+if status in {"completed", "review_ready"}:
+    state = "completed"
+elif status in {"failed", "closed", "blocked", "needs_input", "awaiting_approval"}:
+    state = "terminal"
+else:
+    state = "waiting"
+print(f"{state}\t{status}")
+PY
+)"
+
+      local state="${result%%$'\t'*}"
+      local status="${result#*$'\t'}"
+      if [[ "$status" != "$last_status" ]]; then
+        log "workflow status: $status"
+        last_status="$status"
+      fi
+      case "$state" in
+        completed)
+          return 0
+          ;;
+        terminal)
+          fail "workflow $workflow_id finished with status: $status"
+          ;;
+      esac
+    fi
+    sleep 1
+  done
+
+  fail "timed out waiting for workflow $workflow_id to complete"
+}
+
+copy_trace_artifacts() {
+  sleep 1
+  cp "$BACKEND_SOURCE" "$BACKEND_RAW" 2>/dev/null || : >"$BACKEND_RAW"
+  cp "$RENDERER_SOURCE" "$RENDERER_RAW" 2>/dev/null || : >"$RENDERER_RAW"
+}
+
+compare_timelines() {
+  local workflow_id="$1"
+  python3 - "$workflow_id" "$BACKEND_RAW" "$RENDERER_RAW" "$COMPARISON_JSON" <<'PY'
+import copy
+import json
+import pathlib
+import sys
+
+workflow_id, backend_path, renderer_path, comparison_path = sys.argv[1:5]
+merge_id = f"__merge__{workflow_id}"
+
+def belongs(delta):
+    if not isinstance(delta, dict):
+        return False
+    if delta.get("type") == "created":
+        task = delta.get("task") or {}
+        task_id = task.get("id")
+        task_workflow = (task.get("config") or {}).get("workflowId")
+        return task_id == merge_id or task_id == workflow_id or task_workflow == workflow_id or str(task_id or "").startswith(f"{workflow_id}/")
+    task_id = str(delta.get("taskId") or "")
+    return task_id == merge_id or task_id.startswith(f"{workflow_id}/")
+
+def scrub(value):
+    if isinstance(value, dict):
+        return {k: scrub(v) for k, v in value.items() if k != "streamSequence"}
+    if isinstance(value, list):
+        return [scrub(v) for v in value]
+    return value
+
+def load_backend(path):
+    marker = "delta\u2192ui:"
+    records = []
+    for line_no, raw in enumerate(pathlib.Path(path).read_text(errors="ignore").splitlines(), 1):
+        try:
+            row = json.loads(raw)
+        except Exception:
+            continue
+        msg = row.get("msg", "")
+        if row.get("module") != "ui" or marker not in msg:
+            continue
+        try:
+            delta = json.loads(msg.split(marker, 1)[1].strip())
+        except Exception:
+            continue
+        if belongs(delta):
+            records.append({
+                "line": line_no,
+                "time": row.get("time"),
+                "delta": delta,
+                "canonical": scrub(copy.deepcopy(delta)),
+            })
+    return records
+
+def load_renderer(path):
+    records = []
+    for line_no, raw in enumerate(pathlib.Path(path).read_text(errors="ignore").splitlines(), 1):
+        try:
+            row = json.loads(raw)
+        except Exception:
+            continue
+        event = row.get("event") or {}
+        if event.get("type") != "delta":
+            continue
+        delta = event.get("delta")
+        if belongs(delta):
+            records.append({
+                "line": line_no,
+                "time": row.get("time"),
+                "delta": delta,
+                "canonical": scrub(copy.deepcopy(delta)),
+            })
+    return records
+
+backend = load_backend(backend_path)
+renderer = load_renderer(renderer_path)
+backend_canonical = [record["canonical"] for record in backend]
+renderer_canonical = [record["canonical"] for record in renderer]
+
+first_mismatch = None
+for index, (left, right) in enumerate(zip(backend_canonical, renderer_canonical)):
+    if left != right:
+        first_mismatch = {
+            "index": index,
+            "backend": backend[index],
+            "renderer": renderer[index],
+        }
+        break
+
+if first_mismatch is None and len(backend_canonical) != len(renderer_canonical):
+    index = min(len(backend_canonical), len(renderer_canonical))
+    first_mismatch = {
+        "index": index,
+        "backend": backend[index] if index < len(backend) else None,
+        "renderer": renderer[index] if index < len(renderer) else None,
+    }
+
+result = {
+    "ok": first_mismatch is None,
+    "workflowId": workflow_id,
+    "backendCount": len(backend),
+    "rendererCount": len(renderer),
+    "firstMismatch": first_mismatch,
+    "backendLog": backend_path,
+    "rendererLog": renderer_path,
+}
+pathlib.Path(comparison_path).write_text(json.dumps(result, indent=2) + "\n")
+
+if first_mismatch is not None:
+    print(json.dumps(result, indent=2), file=sys.stderr)
+    raise SystemExit(1)
+
+print(json.dumps(result, indent=2))
+PY
+}
+
+mkdir -p "$DB_DIR" "$LOG_DIR"
+: >"$BACKEND_SOURCE"
+: >"$RENDERER_SOURCE"
+
+if [[ -z "$REPO_URL" ]]; then
+  REPO_URL="$(git -C "$ROOT_DIR" config --get remote.origin.url || true)"
+fi
+[[ -n "$REPO_URL" ]] || fail "could not determine repo URL; set INVOKER_UI_DELTA_REPO_URL"
+
+cat >"$CONFIG_PATH" <<'JSON'
+{
+  "allowGraphMutation": true,
+  "disableAutoRunOnStartup": true,
+  "maxConcurrency": 1,
+  "autoFixRetries": 0
+}
+JSON
+
+cat >"$PLAN_PATH" <<YAML
+name: UI Delta Timeline Hello World
+description: Repro fixture for backend-vs-renderer task graph event timelines.
+repoUrl: "$REPO_URL"
+featureBranch: "$FEATURE_BRANCH"
+onFinish: none
+tasks:
+  - id: hello-world
+    description: hello world
+    command: echo hello world
+    dependencies: []
+YAML
+
+[[ -x "$RUNNER" ]] || fail "missing executable runner at $RUNNER"
+
+cd "$ROOT_DIR"
+log "temp repro dir: $TMP_ROOT"
+log "starting traced GUI with isolated state; ./run.sh may stop existing Invoker Electron processes"
+env "${COMMON_ENV[@]}" "$RUNNER" . >"$GUI_LOG" 2>&1 &
+GUI_PID="$!"
+
+wait_for_gui_ready
+log "GUI owner is reachable"
+
+start_log_followers
+
+log "loading and running hello-world plan"
+if ! run_headless_logged "$RUN_STDOUT" "$RUN_STDERR" run "$PLAN_PATH"; then
+  tail -n 120 "$RUN_STDERR" >&2 || true
+  fail "hello-world run failed"
+fi
+
+WORKFLOW_ID="$(discover_workflow_id "$RUN_STDOUT")"
+[[ -n "$WORKFLOW_ID" ]] || fail "could not discover workflow id"
+log "workflow id: $WORKFLOW_ID"
+
+log "running rebase-recreate and following until settled"
+if ! run_headless_logged "$REBASE_STDOUT" "$REBASE_STDERR" rebase-recreate "$WORKFLOW_ID"; then
+  tail -n 160 "$REBASE_STDERR" >&2 || true
+  fail "rebase-recreate failed"
+fi
+wait_for_workflow_completed "$WORKFLOW_ID"
+
+copy_trace_artifacts
+log "comparing backend delta-ui timeline with renderer task-graph-event timeline"
+if ! compare_timelines "$WORKFLOW_ID"; then
+  fail "backend and renderer task-delta timelines diverged"
+fi
+
+log "timeline comparison passed"
+printf 'workflow: %s\n' "$WORKFLOW_ID"
+printf 'comparison: %s\n' "$COMPARISON_JSON"
+printf 'backend log: %s\n' "$BACKEND_RAW"
+printf 'renderer log: %s\n' "$RENDERER_RAW"

--- a/scripts/repro/repro-ui-delta-timeline.sh
+++ b/scripts/repro/repro-ui-delta-timeline.sh
@@ -282,14 +282,15 @@ copy_trace_artifacts() {
 
 compare_timelines() {
   local workflow_id="$1"
-  python3 - "$workflow_id" "$BACKEND_RAW" "$RENDERER_RAW" "$COMPARISON_JSON" <<'PY'
+  python3 - "$workflow_id" "$BACKEND_RAW" "$RENDERER_RAW" "$WORKFLOW_STATUS_JSON" "$COMPARISON_JSON" <<'PY'
 import copy
 import json
 import pathlib
 import sys
 
-workflow_id, backend_path, renderer_path, comparison_path = sys.argv[1:5]
+workflow_id, backend_path, renderer_path, workflow_status_path, comparison_path = sys.argv[1:6]
 merge_id = f"__merge__{workflow_id}"
+hello_suffix = "/hello-world"
 
 def belongs(delta):
     if not isinstance(delta, dict):
@@ -302,12 +303,65 @@ def belongs(delta):
     task_id = str(delta.get("taskId") or "")
     return task_id == merge_id or task_id.startswith(f"{workflow_id}/")
 
+def task_id_for(delta):
+    if not isinstance(delta, dict):
+        return None
+    if delta.get("type") == "created":
+        task = delta.get("task") or {}
+        task_id = task.get("id")
+        return str(task_id) if task_id else None
+    task_id = delta.get("taskId")
+    return str(task_id) if task_id else None
+
+def is_hello_task_id(task_id):
+    return task_id == "hello-world" or str(task_id or "").endswith(hello_suffix)
+
+def nested_get(value, *keys):
+    current = value
+    for key in keys:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
 def scrub(value):
     if isinstance(value, dict):
         return {k: scrub(v) for k, v in value.items() if k != "streamSequence"}
     if isinstance(value, list):
         return [scrub(v) for v in value]
     return value
+
+def summarize_delta(delta):
+    task_id = task_id_for(delta)
+    if not isinstance(delta, dict):
+        return None
+    if delta.get("type") == "created":
+        task = delta.get("task") or {}
+        status = task.get("status")
+        phase = nested_get(task, "execution", "phase")
+        version = task.get("taskStateVersion")
+    elif delta.get("type") == "updated":
+        changes = delta.get("changes") or {}
+        status = changes.get("status")
+        phase = nested_get(changes, "execution", "phase")
+        version = delta.get("taskStateVersion")
+    elif delta.get("type") == "removed":
+        status = "removed"
+        phase = None
+        version = None
+    else:
+        status = None
+        phase = None
+        version = None
+    return {
+        "type": delta.get("type"),
+        "taskId": task_id,
+        "status": status,
+        "phase": phase,
+        "taskStateVersion": version,
+        "previousTaskStateVersion": delta.get("previousTaskStateVersion"),
+        "streamSequence": delta.get("streamSequence"),
+    }
 
 def load_backend(path):
     marker = "delta\u2192ui:"
@@ -329,6 +383,7 @@ def load_backend(path):
                 "line": line_no,
                 "time": row.get("time"),
                 "delta": delta,
+                "summary": summarize_delta(delta),
                 "canonical": scrub(copy.deepcopy(delta)),
             })
     return records
@@ -349,9 +404,162 @@ def load_renderer(path):
                 "line": line_no,
                 "time": row.get("time"),
                 "delta": delta,
+                "workflowRollups": event.get("workflowRollups") or [],
+                "summary": summarize_delta(delta),
                 "canonical": scrub(copy.deepcopy(delta)),
             })
     return records
+
+def merge_task(previous, delta):
+    if delta.get("type") == "created":
+        task = copy.deepcopy(delta.get("task") or {})
+        task_id = task.get("id")
+        return str(task_id) if task_id else None, task
+    task_id = task_id_for(delta)
+    if not task_id:
+        return None, None
+    if delta.get("type") == "removed":
+        return task_id, None
+    previous_task = copy.deepcopy(previous.get(task_id) or {"id": task_id, "config": {}, "execution": {}})
+    changes = copy.deepcopy(delta.get("changes") or {})
+    config_changes = changes.pop("config", None)
+    execution_changes = changes.pop("execution", None)
+    previous_task.update(changes)
+    if config_changes is not None:
+        previous_task["config"] = {**(previous_task.get("config") or {}), **config_changes}
+    if execution_changes is not None:
+        previous_task["execution"] = {**(previous_task.get("execution") or {}), **execution_changes}
+    if "taskStateVersion" in delta:
+        previous_task["taskStateVersion"] = delta.get("taskStateVersion")
+    return task_id, previous_task
+
+def final_task_state(records):
+    tasks = {}
+    last_seen = {}
+    for record in records:
+        task_id, task = merge_task(tasks, record["delta"])
+        if not task_id:
+            continue
+        last_seen[task_id] = record["summary"]
+        if task is None:
+            tasks.pop(task_id, None)
+        else:
+            tasks[task_id] = task
+    return tasks, last_seen
+
+def summarize_task(task, last_seen):
+    return {
+        "status": task.get("status"),
+        "phase": nested_get(task, "execution", "phase"),
+        "taskStateVersion": task.get("taskStateVersion"),
+        "generation": nested_get(task, "execution", "generation"),
+        "workflowId": nested_get(task, "config", "workflowId"),
+        "lastStreamSequence": (last_seen or {}).get("streamSequence"),
+    }
+
+def summarize_tasks(tasks, last_seen):
+    return {
+        task_id: summarize_task(task, last_seen.get(task_id))
+        for task_id, task in sorted(tasks.items())
+    }
+
+def comparable_tasks(summary):
+    return {
+        task_id: {key: value for key, value in task.items() if key != "lastStreamSequence"}
+        for task_id, task in summary.items()
+    }
+
+def infer_workflow(tasks):
+    statuses = [task.get("status") for task in tasks.values()]
+    if not statuses:
+        status = "empty"
+    elif any(status in {"failed", "blocked"} for status in statuses):
+        status = "failed"
+    elif any(status in {"running", "fixing_with_ai"} for status in statuses):
+        status = "running"
+    elif any(status in {"pending", "queued"} for status in statuses):
+        status = "pending"
+    elif all(status in {"completed", "review_ready", "skipped"} for status in statuses):
+        status = "completed"
+    else:
+        status = "unknown"
+    counts = {}
+    for status_value in statuses:
+        counts[status_value or "unknown"] = counts.get(status_value or "unknown", 0) + 1
+    return {"status": status, "countsByStatus": counts, "taskCount": len(statuses)}
+
+def load_backend_workflow(path):
+    text = pathlib.Path(path).read_text(errors="ignore")
+    start = text.find("[")
+    if start < 0:
+        return None
+    workflows = json.loads(text[start:])
+    workflow = next((item for item in workflows if item.get("id") == workflow_id), None)
+    if not workflow:
+        return None
+    return {
+        "source": "headless query workflows",
+        "id": workflow.get("id"),
+        "status": workflow.get("status"),
+        "generation": workflow.get("generation"),
+        "updatedAt": workflow.get("updatedAt"),
+    }
+
+def renderer_workflow_rollup(records):
+    latest = None
+    for record in records:
+        for patch in record.get("workflowRollups") or []:
+            if patch.get("workflowId") == workflow_id:
+                latest = patch
+    if latest is None:
+        return None
+    rollup = latest.get("rollup") or {}
+    return {
+        "source": "renderer workflowRollups",
+        "id": workflow_id,
+        "status": latest.get("status"),
+        "removed": latest.get("removed") is True,
+        "countsByStatus": rollup.get("countsByStatus"),
+    }
+
+def comparable_workflow(state):
+    return {
+        "status": state.get("status") if isinstance(state, dict) else None,
+        "removed": bool(state.get("removed") is True) if isinstance(state, dict) else False,
+    }
+
+def delta_has_status(record, status):
+    summary = record.get("summary") or {}
+    task_id = summary.get("taskId")
+    return is_hello_task_id(task_id) and summary.get("status") == status
+
+def removed_hello_ids(records):
+    return {
+        (record.get("summary") or {}).get("taskId")
+        for record in records
+        if (record.get("summary") or {}).get("type") == "removed"
+        and is_hello_task_id((record.get("summary") or {}).get("taskId"))
+    }
+
+def compact_record(record):
+    if record is None:
+        return None
+    return {
+        "line": record.get("line"),
+        "time": record.get("time"),
+        **(record.get("summary") or {}),
+    }
+
+def compare_compact(left, right):
+    if left is None and right is None:
+        return None
+    if left is None:
+        return "renderer has extra event"
+    if right is None:
+        return "backend has extra event"
+    fields = ["type", "taskId", "status", "phase", "taskStateVersion", "previousTaskStateVersion"]
+    mismatched = [field for field in fields if left.get(field) != right.get(field)]
+    return ", ".join(mismatched) if mismatched else None
 
 backend = load_backend(backend_path)
 renderer = load_renderer(renderer_path)
@@ -376,18 +584,89 @@ if first_mismatch is None and len(backend_canonical) != len(renderer_canonical):
         "renderer": renderer[index] if index < len(renderer) else None,
     }
 
+backend_tasks, backend_last_seen = final_task_state(backend)
+renderer_tasks, renderer_last_seen = final_task_state(renderer)
+backend_summary = summarize_tasks(backend_tasks, backend_last_seen)
+renderer_summary = summarize_tasks(renderer_tasks, renderer_last_seen)
+backend_workflow = load_backend_workflow(workflow_status_path) or {
+    "source": "inferred from backend task deltas",
+    **infer_workflow(backend_tasks),
+}
+renderer_workflow = renderer_workflow_rollup(renderer) or {
+    "source": "inferred from renderer task deltas",
+    **infer_workflow(renderer_tasks),
+}
+reasons = []
+
+backend_sent_running = any(delta_has_status(record, "running") for record in backend)
+renderer_observed_running = any(delta_has_status(record, "running") for record in renderer)
+if backend_sent_running and not renderer_observed_running:
+    reasons.append({
+        "kind": "missing-renderer-running",
+        "message": "backend sent hello-world -> running but renderer never observed running",
+        "backendRunningEvents": [compact_record(record) for record in backend if delta_has_status(record, "running")],
+    })
+
+backend_removed = removed_hello_ids(backend)
+for task_id in sorted(removed_hello_ids(renderer)):
+    if task_id not in backend_removed:
+        reasons.append({
+            "kind": "renderer-removed-without-backend-remove",
+            "message": f"renderer emitted removed for {task_id} without a backend remove/delete",
+            "taskId": task_id,
+        })
+
+if comparable_tasks(backend_summary) != comparable_tasks(renderer_summary):
+    reasons.append({
+        "kind": "final-task-state-mismatch",
+        "message": "final backend and renderer task states disagree",
+        "backend": backend_summary,
+        "renderer": renderer_summary,
+    })
+
+if comparable_workflow(backend_workflow) != comparable_workflow(renderer_workflow):
+    reasons.append({
+        "kind": "final-workflow-state-mismatch",
+        "message": "final backend and renderer workflow states disagree",
+        "backend": backend_workflow,
+        "renderer": renderer_workflow,
+    })
+
+timeline = []
+for index in range(max(len(backend), len(renderer))):
+    left = compact_record(backend[index]) if index < len(backend) else None
+    right = compact_record(renderer[index]) if index < len(renderer) else None
+    timeline.append({
+        "index": index,
+        "backend": left,
+        "renderer": right,
+        "mismatchReason": compare_compact(left, right),
+    })
+
 result = {
-    "ok": first_mismatch is None,
+    "ok": len(reasons) == 0,
     "workflowId": workflow_id,
     "backendCount": len(backend),
     "rendererCount": len(renderer),
-    "firstMismatch": first_mismatch,
+    "acceptanceFailures": reasons,
+    "sequenceFirstMismatch": first_mismatch,
+    "finalState": {
+        "tasks": {
+            "backend": backend_summary,
+            "renderer": renderer_summary,
+        },
+        "workflow": {
+            "backend": backend_workflow,
+            "renderer": renderer_workflow,
+        },
+    },
+    "timeline": timeline,
     "backendLog": backend_path,
     "rendererLog": renderer_path,
 }
 pathlib.Path(comparison_path).write_text(json.dumps(result, indent=2) + "\n")
 
-if first_mismatch is not None:
+if reasons:
     print(json.dumps(result, indent=2), file=sys.stderr)
     raise SystemExit(1)
 


### PR DESCRIPTION
## Summary

The persistence architecture document now describes read-only delegated viewers.

It also marks exclusive locking as opt-in and incompatible with delegated read-only viewers.

## Review Claim

Approve the persistence architecture documentation update for the new delegated viewer model.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice changes documentation only.

The behavior and proof changes are in earlier stack slices.

## Slice Rationale

Docs sit at the top of the stack so they describe the final behavior after the code and proof are reviewable.

## Non-goals

This does not change runtime behavior.

This does not modify tests or tooling.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `git diff --check @{u}...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert cf4de50ac`
- Post-revert steps: None
- Data migration? No

</details>
