### PR TITLE
[Planning Terminal Resume](2) Promote Codex thread ids in execution driver

### DIFF
--- a/packages/execution-engine/src/__tests__/harness-session-driver.test.ts
+++ b/packages/execution-engine/src/__tests__/harness-session-driver.test.ts
@@ -69,6 +69,40 @@ describe('ExecutionHarnessSessionDriver', () => {
         'Continue the task',
       ]);
     });
+
+    it('promotes the real Codex thread id from stdout for new sessions', () => {
+      const driver = new ExecutionHarnessSessionDriver(new CodexExecutionAgent(), {
+        extractSessionId: () => 'real-codex-thread-id',
+      });
+
+      expect(driver.resolveSessionId?.('', {
+        command: 'codex',
+        args: [],
+        sessionId: 'local-invoker-uuid',
+      }, { startedNewSession: true })).toBe('real-codex-thread-id');
+    });
+
+    it('rejects a new Codex session when stdout has no resumable thread id', () => {
+      const driver = new ExecutionHarnessSessionDriver(new CodexExecutionAgent(), {
+        extractSessionId: () => undefined,
+      });
+
+      expect(() => driver.resolveSessionId?.('', {
+        command: 'codex',
+        args: [],
+        sessionId: 'local-invoker-uuid',
+      }, { startedNewSession: true })).toThrow(/thread\.started\.thread_id/);
+    });
+
+    it('rejects a new Codex session when no session extractor is registered', () => {
+      const driver = new ExecutionHarnessSessionDriver(new CodexExecutionAgent());
+
+      expect(() => driver.resolveSessionId?.('', {
+        command: 'codex',
+        args: [],
+        sessionId: 'local-invoker-uuid',
+      }, { startedNewSession: true })).toThrow(/thread\.started\.thread_id/);
+    });
   });
 
   describe('omp', () => {

--- a/packages/execution-engine/src/harness-session-driver.ts
+++ b/packages/execution-engine/src/harness-session-driver.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { ExecutionAgent } from './agent.js';
+import type { SessionDriver } from './session-driver.js';
 
 export interface HarnessSessionCommand {
   command: string;
@@ -13,13 +14,21 @@ export interface HarnessSessionDriver {
   readonly supportsSessionContinuity: boolean;
   start(prompt: string, options?: { model?: string }): HarnessSessionCommand;
   append(sessionId: string, prompt: string, options?: { model?: string }): HarnessSessionCommand;
+  resolveSessionId?(
+    rawStdout: string,
+    command: HarnessSessionCommand,
+    options: { startedNewSession: boolean },
+  ): string | undefined;
 }
 
 export class ExecutionHarnessSessionDriver implements HarnessSessionDriver {
   readonly harness: string;
   readonly supportsSessionContinuity = true;
 
-  constructor(private readonly agent: ExecutionAgent) {
+  constructor(
+    private readonly agent: ExecutionAgent,
+    private readonly sessionDriver?: Pick<SessionDriver, 'extractSessionId'>,
+  ) {
     this.harness = agent.name;
   }
 
@@ -42,6 +51,22 @@ export class ExecutionHarnessSessionDriver implements HarnessSessionDriver {
       args: this.appendPromptArgs(resumed.args, prompt, options?.model),
       sessionId,
     };
+  }
+
+  resolveSessionId(
+    rawStdout: string,
+    command: HarnessSessionCommand,
+    options: { startedNewSession: boolean },
+  ): string | undefined {
+    const extracted = this.sessionDriver?.extractSessionId?.(rawStdout);
+    if (extracted) return extracted;
+    if (options.startedNewSession && this.agent.name === 'codex') {
+      throw new Error(
+        'Harness "codex" did not emit a resumable session id (thread.started.thread_id); '
+        + `refusing to persist provisional session id "${command.sessionId}".`,
+      );
+    }
+    return command.sessionId;
   }
 
   private appendPromptArgs(resumeArgs: string[], prompt: string, model?: string): string[] {

--- a/scripts/repro/repro-planning-codex-thread-resume.sh
+++ b/scripts/repro/repro-planning-codex-thread-resume.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-}"
+case "$MODE" in
+  --expect-bug)
+    EXPECT_MODE="bug"
+    ;;
+  --expect-fixed)
+    EXPECT_MODE="fixed"
+    ;;
+  *)
+    echo "usage: $0 --expect-bug|--expect-fixed" >&2
+    exit 64
+    ;;
+esac
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+SURFACES_DIR="$REPO_ROOT/packages/surfaces"
+VITEST="$SURFACES_DIR/node_modules/.bin/vitest"
+
+if [[ ! -x "$VITEST" ]]; then
+  echo "[repro] FAIL: no vitest binary at $VITEST; run 'pnpm install' at the repo root first." >&2
+  exit 1
+fi
+
+TEST_FILE="$SURFACES_DIR/src/__tests__/.repro-planning-codex-thread-resume.test.ts"
+LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/invoker-planning-codex-thread-resume.XXXXXX.log")"
+trap 'rm -f "$TEST_FILE" "$LOG_FILE"' EXIT
+
+cat > "$TEST_FILE" <<'TS'
+import { describe, it, expect, vi } from 'vitest';
+import * as childProcess from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PlanConversation } from '../slack/plan-conversation.js';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof childProcess>();
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+
+function createMockProcess(stdout: string): any {
+  const proc = new EventEmitter() as any;
+  const stdoutEmitter = new EventEmitter();
+  const stderrEmitter = new EventEmitter();
+  proc.stdout = stdoutEmitter;
+  proc.stderr = stderrEmitter;
+  proc.kill = vi.fn();
+
+  setTimeout(() => {
+    stdoutEmitter.emit('data', Buffer.from(stdout));
+    proc.emit('close', 0);
+  }, 0);
+
+  return proc;
+}
+
+describe('standalone planning Codex thread resume repro', () => {
+  it('uses the provider thread id, not Invoker provisional UUID, for the second turn', async () => {
+    const expectedMode = process.env.REPRO_EXPECT_MODE;
+    const provisionalSessionId = 'cbbd3ce4-28ba-4b3d-8c25-8bafddc41177';
+    const providerThreadId = '019d-real-codex-thread';
+
+    let started = false;
+    const driver = {
+      harness: 'codex',
+      supportsSessionContinuity: true,
+      start: vi.fn((_prompt: string) => {
+        started = true;
+        return {
+          command: 'fake-codex',
+          args: ['exec', '--json'],
+          sessionId: provisionalSessionId,
+        };
+      }),
+      append: vi.fn((sessionId: string, _prompt: string) => ({
+        command: 'fake-codex',
+        args: ['exec', 'resume', sessionId],
+        sessionId,
+      })),
+      resolveSessionId: vi.fn((rawStdout: string, command: { sessionId: string }, options: { startedNewSession: boolean }) => {
+        if (!options.startedNewSession) return command.sessionId;
+        const match = rawStdout.match(/"thread_id":"([^"]+)"/);
+        return match?.[1] ?? command.sessionId;
+      }),
+    };
+
+    const logs: string[] = [];
+    const conv = new PlanConversation({
+      harnessSessionDriver: driver,
+      log: (_source, _level, message) => logs.push(message),
+    });
+
+    mockSpawn.mockReturnValueOnce(createMockProcess([
+      JSON.stringify({ type: 'thread.started', thread_id: providerThreadId }),
+      JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'first turn ok' } }),
+      JSON.stringify({ type: 'turn.completed' }),
+    ].join('\n')));
+    await conv.sendMessage('first planning message');
+
+    expect(started).toBe(true);
+    expect(conv.harnessSessionId).toBe(expectedMode === 'bug' ? provisionalSessionId : providerThreadId);
+
+    mockSpawn.mockReturnValueOnce(createMockProcess('second turn ok'));
+    await conv.sendMessage('continue planning');
+
+    const resumedWith = driver.append.mock.calls[0]?.[0];
+    if (expectedMode === 'bug') {
+      expect(resumedWith).toBe(provisionalSessionId);
+      return;
+    }
+
+    expect(resumedWith).toBe(providerThreadId);
+    expect(resumedWith).not.toBe(provisionalSessionId);
+    expect(logs.some((line) => line.includes('planner_session_id_promoted'))).toBe(true);
+  });
+});
+TS
+
+set +e
+(
+  cd "$SURFACES_DIR"
+  REPRO_EXPECT_MODE="$EXPECT_MODE" "$VITEST" run --reporter=dot "src/__tests__/$(basename "$TEST_FILE")"
+) >"$LOG_FILE" 2>&1
+CODE=$?
+set -e
+
+if [[ "$CODE" -ne 0 ]]; then
+  echo "[repro] FAIL: planning Codex thread resume invariant did not match $MODE."
+  cat "$LOG_FILE"
+  exit "$CODE"
+fi
+
+if [[ "$EXPECT_MODE" == "bug" ]]; then
+  echo "[repro] PASS: reproduced bug; second turn resumed with the provisional Invoker UUID."
+else
+  echo "[repro] PASS: fixed; second turn resumed with the real Codex thread id."
+fi


### PR DESCRIPTION
## Summary

The execution harness can now resolve a real Codex thread id after a new planning run exits.

New Codex planning sessions fail closed when stdout does not contain a provider thread id.

## Review Claim

Execution harness session resolution routes Codex planning continuity through the provider thread id.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only execution-engine session id resolution changes. Existing command construction and non-Codex harness behavior remain covered by focused tests.

## Slice Rationale

The standalone repro is already in the previous slice. This slice adds the lower-level id resolution behavior before any caller uses it.

## Non-goals

This does not change planning conversation state storage.

This does not change the GUI planning terminal.

This does not change task terminal resume behavior.

## Architecture

### Before

```mermaid
graph TD
    A["Codex start command returns local UUID"] --> B["Caller stores command session id"]
```

### After

```mermaid
graph TD
    A["Codex stdout emits thread.started.thread_id"] --> B["SessionDriver extracts provider thread id"]
    B --> C["Harness resolution returns provider thread id"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/harness-session-driver.test.ts src/__tests__/codex-resume-e2e.test.ts --reporter=verbose`
- [x] `pnpm --filter @invoker/execution-engine build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4185c8fb7`
- Post-revert steps: None
- Data migration? No

</details>
