### PR TITLE
[Planning Terminal Resume](4) Pass planning registry session drivers in app planner

### DIFF
--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -23,6 +23,7 @@ import type {
   InAppPlanningStreamEvent,
   InAppPlanningSubmitRequest,
   InAppPlanningSubmitResponse,
+  Logger,
   PlanningConfirmationMode,
   PlanningTerminalMode,
   PlanningPresetOption,
@@ -64,8 +65,9 @@ export interface InAppPlannerDeps {
   loadGeneratedPlan: (planText: string) => LoadedGeneratedPlan | Promise<LoadedGeneratedPlan>;
   workingDir?: string;
   planningCommandBuilder?: PlanningCommandBuilder;
-  executionAgentRegistry?: Pick<AgentRegistry, 'get'>;
+  executionAgentRegistry?: Pick<AgentRegistry, 'get' | 'getSessionDriver'>;
   conversationRepo?: ConversationRepository;
+  logger?: Logger;
   plannerReplyOverride?: (formattedMessage: string) => Promise<string>;
   onRawPlannerOutput?: (event: InAppPlanningStreamEvent) => void;
 }
@@ -541,7 +543,7 @@ export function isDraftingAuthorizedByTurn(message: string, messagesBeforeTurn: 
 
 function planConversationConfig(
   preset: HarnessPreset,
-  deps: Pick<InAppPlannerDeps, 'config' | 'workingDir' | 'planningCommandBuilder' | 'executionAgentRegistry' | 'conversationRepo' | 'onRawPlannerOutput'>,
+  deps: Pick<InAppPlannerDeps, 'config' | 'workingDir' | 'planningCommandBuilder' | 'executionAgentRegistry' | 'conversationRepo' | 'logger' | 'onRawPlannerOutput'>,
   threadTs: string,
   selectHarnessSessionDriver: PlannerSurfacesModule['selectHarnessSessionDriver'],
   options: { conversationalPlanning?: boolean } = {},
@@ -567,6 +569,13 @@ function planConversationConfig(
     plannerRetryBaseDelayMs: deps.config.plannerRetryBaseDelayMs,
     onRawPlannerOutput: deps.onRawPlannerOutput
       ? (chunk) => deps.onRawPlannerOutput?.({ sessionId: threadTs, chunk })
+      : undefined,
+    log: deps.logger
+      ? (_source, level, message) => {
+        if (level === 'error') deps.logger?.error(message, { module: 'planning-chat' });
+        else if (level === 'warn') deps.logger?.warn(message, { module: 'planning-chat' });
+        else deps.logger?.info(message, { module: 'planning-chat' });
+      }
       : undefined,
   };
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1144,6 +1144,7 @@ function startHeadlessMode(): void {
         loadGeneratedPlan,
         conversationRepo: planningConversationRepo,
         planningSessionStore: readOnlyMode ? undefined : persistence,
+        logger,
       });
 
       let testPlanningChatResponse:
@@ -1199,6 +1200,7 @@ function startHeadlessMode(): void {
               loadGeneratedPlan,
               conversationRepo: planningConversationRepo,
               planningSessionStore: readOnlyMode ? undefined : persistence,
+              logger,
             });
           }
           case 'invoker:planning-chat-list': {
@@ -1226,6 +1228,7 @@ function startHeadlessMode(): void {
               loadGeneratedPlan,
               conversationRepo: planningConversationRepo,
               planningSessionStore: readOnlyMode ? undefined : persistence,
+              logger,
               plannerReplyOverride,
             });
           }

--- a/packages/execution-engine/src/__tests__/harness-session-driver.test.ts
+++ b/packages/execution-engine/src/__tests__/harness-session-driver.test.ts
@@ -69,6 +69,40 @@ describe('ExecutionHarnessSessionDriver', () => {
         'Continue the task',
       ]);
     });
+
+    it('promotes the real Codex thread id from stdout for new sessions', () => {
+      const driver = new ExecutionHarnessSessionDriver(new CodexExecutionAgent(), {
+        extractSessionId: () => 'real-codex-thread-id',
+      });
+
+      expect(driver.resolveSessionId?.('', {
+        command: 'codex',
+        args: [],
+        sessionId: 'local-invoker-uuid',
+      }, { startedNewSession: true })).toBe('real-codex-thread-id');
+    });
+
+    it('rejects a new Codex session when stdout has no resumable thread id', () => {
+      const driver = new ExecutionHarnessSessionDriver(new CodexExecutionAgent(), {
+        extractSessionId: () => undefined,
+      });
+
+      expect(() => driver.resolveSessionId?.('', {
+        command: 'codex',
+        args: [],
+        sessionId: 'local-invoker-uuid',
+      }, { startedNewSession: true })).toThrow(/thread\.started\.thread_id/);
+    });
+
+    it('rejects a new Codex session when no session extractor is registered', () => {
+      const driver = new ExecutionHarnessSessionDriver(new CodexExecutionAgent());
+
+      expect(() => driver.resolveSessionId?.('', {
+        command: 'codex',
+        args: [],
+        sessionId: 'local-invoker-uuid',
+      }, { startedNewSession: true })).toThrow(/thread\.started\.thread_id/);
+    });
   });
 
   describe('omp', () => {

--- a/packages/execution-engine/src/harness-session-driver.ts
+++ b/packages/execution-engine/src/harness-session-driver.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { ExecutionAgent } from './agent.js';
+import type { SessionDriver } from './session-driver.js';
 
 export interface HarnessSessionCommand {
   command: string;
@@ -13,13 +14,21 @@ export interface HarnessSessionDriver {
   readonly supportsSessionContinuity: boolean;
   start(prompt: string, options?: { model?: string }): HarnessSessionCommand;
   append(sessionId: string, prompt: string, options?: { model?: string }): HarnessSessionCommand;
+  resolveSessionId?(
+    rawStdout: string,
+    command: HarnessSessionCommand,
+    options: { startedNewSession: boolean },
+  ): string | undefined;
 }
 
 export class ExecutionHarnessSessionDriver implements HarnessSessionDriver {
   readonly harness: string;
   readonly supportsSessionContinuity = true;
 
-  constructor(private readonly agent: ExecutionAgent) {
+  constructor(
+    private readonly agent: ExecutionAgent,
+    private readonly sessionDriver?: Pick<SessionDriver, 'extractSessionId'>,
+  ) {
     this.harness = agent.name;
   }
 
@@ -42,6 +51,22 @@ export class ExecutionHarnessSessionDriver implements HarnessSessionDriver {
       args: this.appendPromptArgs(resumed.args, prompt, options?.model),
       sessionId,
     };
+  }
+
+  resolveSessionId(
+    rawStdout: string,
+    command: HarnessSessionCommand,
+    options: { startedNewSession: boolean },
+  ): string | undefined {
+    const extracted = this.sessionDriver?.extractSessionId?.(rawStdout);
+    if (extracted) return extracted;
+    if (options.startedNewSession && this.agent.name === 'codex') {
+      throw new Error(
+        'Harness "codex" did not emit a resumable session id (thread.started.thread_id); '
+        + `refusing to persist provisional session id "${command.sessionId}".`,
+      );
+    }
+    return command.sessionId;
   }
 
   private appendPromptArgs(resumeArgs: string[], prompt: string, model?: string): string[] {

--- a/packages/surfaces/src/__tests__/harness-session-driver-select.test.ts
+++ b/packages/surfaces/src/__tests__/harness-session-driver-select.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { ExecutionHarnessSessionDriver, ReplayHarnessSessionDriver } from '@invoker/execution-engine';
-import type { ExecutionAgent } from '@invoker/execution-engine';
+import type { ExecutionAgent, SessionDriver } from '@invoker/execution-engine';
 import { selectHarnessSessionDriver } from '../slack/harness-session-driver-select.js';
 
 function fakeExecutionAgent(name: string): ExecutionAgent {
@@ -23,6 +23,29 @@ describe('selectHarnessSessionDriver', () => {
     expect(driver).toBeInstanceOf(ExecutionHarnessSessionDriver);
     expect(driver?.supportsSessionContinuity).toBe(true);
     expect(driver?.harness).toBe('claude');
+  });
+
+  it('passes the registered session driver into execution-backed planning drivers', () => {
+    const codex = fakeExecutionAgent('codex');
+    const sessionDriver: SessionDriver = {
+      processOutput: () => '',
+      loadSession: () => null,
+      parseSession: () => [],
+      inspectSession: () => ({ state: 'finished' }),
+      extractSessionId: () => 'real-codex-thread-id',
+    };
+    const driver = selectHarnessSessionDriver(
+      { tool: 'codex' },
+      {
+        executionAgentRegistry: {
+          get: (name) => (name === 'codex' ? codex : undefined),
+          getSessionDriver: (name) => (name === 'codex' ? sessionDriver : undefined),
+        },
+      },
+    );
+
+    const started = driver?.start('Plan the change');
+    expect(driver?.resolveSessionId?.('', started!, { startedNewSession: true })).toBe('real-codex-thread-id');
   });
 
   it('falls back to a ReplayHarnessSessionDriver when no execution agent matches the preset tool', () => {

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -1063,6 +1063,58 @@ describe('PlanConversation harness session driver', () => {
     expect(secondSpawnArgs).toEqual(['append', 'session-1']);
   });
 
+  it('promotes the provider session id before appending later turns', async () => {
+    const resolveSessionId = vi.fn((raw: string, command: { sessionId: string }, options: { startedNewSession: boolean }) => {
+      if (!options.startedNewSession) return command.sessionId;
+      const match = raw.match(/"thread_id":"([^"]+)"/);
+      return match?.[1] ?? command.sessionId;
+    });
+    const driver = {
+      ...createMockDriver({ supportsSessionContinuity: true }),
+      harness: 'codex',
+      resolveSessionId,
+    };
+    const onHarnessSessionId = vi.fn();
+    const log = vi.fn();
+    const conv = new PlanConversation({ harnessSessionDriver: driver, onHarnessSessionId, log });
+
+    mockCursorResponse([
+      JSON.stringify({ type: 'thread.started', thread_id: 'real-codex-thread-id' }),
+      JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'Turn one reply' } }),
+      JSON.stringify({ type: 'turn.completed' }),
+    ].join('\n'));
+    await conv.sendMessage('First message');
+
+    expect(conv.harnessSessionId).toBe('real-codex-thread-id');
+    expect(onHarnessSessionId).toHaveBeenCalledWith('real-codex-thread-id');
+    expect(log.mock.calls.some((call) => String(call[2]).includes('planner_session_id_promoted'))).toBe(true);
+
+    mockCursorResponse('Turn two reply');
+    await conv.sendMessage('Second message');
+
+    expect(driver.append).toHaveBeenCalledTimes(1);
+    expect(driver.append.mock.calls[0][0]).toBe('real-codex-thread-id');
+    expect(driver.append.mock.calls[0][1]).toBe('Second message');
+  });
+
+  it('does not persist a provisional session id when session resolution rejects it', async () => {
+    const driver = {
+      ...createMockDriver({ supportsSessionContinuity: true }),
+      harness: 'codex',
+      resolveSessionId: vi.fn(() => {
+        throw new Error('missing thread.started.thread_id');
+      }),
+    };
+    const onHarnessSessionId = vi.fn();
+    const conv = new PlanConversation({ harnessSessionDriver: driver, onHarnessSessionId });
+
+    mockCursorResponse('Turn one reply');
+    await expect(conv.sendMessage('First message')).rejects.toThrow(/thread\.started\.thread_id/);
+
+    expect(conv.harnessSessionId).toBeUndefined();
+    expect(onHarnessSessionId).not.toHaveBeenCalled();
+  });
+
   it('fires onHarnessSessionId once when a new session id is established', async () => {
     const driver = createMockDriver({ supportsSessionContinuity: true });
     const onHarnessSessionId = vi.fn();

--- a/packages/surfaces/src/slack/harness-session-driver-select.ts
+++ b/packages/surfaces/src/slack/harness-session-driver-select.ts
@@ -1,5 +1,5 @@
 import { ExecutionHarnessSessionDriver, ReplayHarnessSessionDriver } from '@invoker/execution-engine';
-import type { ExecutionAgent, HarnessSessionDriver } from '@invoker/execution-engine';
+import type { ExecutionAgent, HarnessSessionDriver, SessionDriver } from '@invoker/execution-engine';
 import type { PlanningCommandBuilder } from './plan-conversation.js';
 
 export interface HarnessPresetLike {
@@ -9,7 +9,10 @@ export interface HarnessPresetLike {
 
 export interface HarnessSessionDriverDeps {
   /** Looks up a registered execution agent (claude/codex/omp) by harness tool name. */
-  executionAgentRegistry?: { get(name: string): ExecutionAgent | undefined };
+  executionAgentRegistry?: {
+    get(name: string): ExecutionAgent | undefined;
+    getSessionDriver?(name: string): SessionDriver | undefined;
+  };
   /** Builds the planner CLI command for harnesses without real session resume (e.g. cursor). */
   planningCommandBuilder?: PlanningCommandBuilder;
 }
@@ -21,7 +24,7 @@ export function selectHarnessSessionDriver(
 ): HarnessSessionDriver | undefined {
   const agent = deps.executionAgentRegistry?.get(preset.tool);
   if (agent) {
-    return new ExecutionHarnessSessionDriver(agent);
+    return new ExecutionHarnessSessionDriver(agent, deps.executionAgentRegistry?.getSessionDriver?.(preset.tool));
   }
   if (!deps.planningCommandBuilder) return undefined;
   const planningCommandBuilder = deps.planningCommandBuilder;

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -539,7 +539,7 @@ export class PlanConversation {
     const repoStateBefore = this.mode === 'agent'
       ? await captureRepoState(this.workingDir)
       : null;
-    const response = await this.spawnPlanner(prompt);
+    const response = await this.spawnPlanner(prompt, turn);
     const tCursor = Date.now();
     const formatted = formatCodexPlannerStdout(response);
     let message = formatted.message;
@@ -736,9 +736,9 @@ export class PlanConversation {
 
   // ── Planner CLI Subprocess ─────────────────────────────
 
-  async spawnPlanner(prompt: string): Promise<string> {
+  async spawnPlanner(prompt: string, turn?: number): Promise<string> {
     if (this.harnessSessionDriver) {
-      return this.spawnPlannerWithDriver(prompt, this.harnessSessionDriver);
+      return this.spawnPlannerWithDriver(prompt, this.harnessSessionDriver, turn);
     }
 
     const requiresRegisteredBuilder = this.tool === 'omp' || this.tool === 'codex';
@@ -755,13 +755,22 @@ export class PlanConversation {
     return this.runSpawnWithRetry(prompt, command, args, plannerLabel);
   }
 
-  private async spawnPlannerWithDriver(prompt: string, driver: HarnessSessionDriver): Promise<string> {
+  private async spawnPlannerWithDriver(prompt: string, driver: HarnessSessionDriver, turn?: number): Promise<string> {
     const priorSessionId = this._harnessSessionId;
+    const startedNewSession = !priorSessionId;
     const built = priorSessionId
       ? driver.append(priorSessionId, prompt, { model: this.model })
       : driver.start(prompt, { model: this.model });
     const reply = await this.runSpawnWithRetry(prompt, built.command, built.args, driver.harness);
-    this.setHarnessSessionId(built.sessionId);
+    const resolvedSessionId = driver.resolveSessionId?.(reply, built, { startedNewSession }) ?? built.sessionId;
+    if (resolvedSessionId !== built.sessionId) {
+      this.log(
+        'plan-conversation',
+        'info',
+        `[TRACE] planner_session_id_promoted planner=${driver.harness} turn=${turn ?? 'unknown'} source=stdout provisionalSessionId=${built.sessionId} resolvedSessionId=${resolvedSessionId}`,
+      );
+    }
+    this.setHarnessSessionId(resolvedSessionId);
     return reply;
   }
 

--- a/scripts/repro/repro-planning-codex-thread-resume.sh
+++ b/scripts/repro/repro-planning-codex-thread-resume.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-}"
+case "$MODE" in
+  --expect-bug)
+    EXPECT_MODE="bug"
+    ;;
+  --expect-fixed)
+    EXPECT_MODE="fixed"
+    ;;
+  *)
+    echo "usage: $0 --expect-bug|--expect-fixed" >&2
+    exit 64
+    ;;
+esac
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+SURFACES_DIR="$REPO_ROOT/packages/surfaces"
+VITEST="$SURFACES_DIR/node_modules/.bin/vitest"
+
+if [[ ! -x "$VITEST" ]]; then
+  echo "[repro] FAIL: no vitest binary at $VITEST; run 'pnpm install' at the repo root first." >&2
+  exit 1
+fi
+
+TEST_FILE="$SURFACES_DIR/src/__tests__/.repro-planning-codex-thread-resume.test.ts"
+LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/invoker-planning-codex-thread-resume.XXXXXX.log")"
+trap 'rm -f "$TEST_FILE" "$LOG_FILE"' EXIT
+
+cat > "$TEST_FILE" <<'TS'
+import { describe, it, expect, vi } from 'vitest';
+import * as childProcess from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PlanConversation } from '../slack/plan-conversation.js';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof childProcess>();
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+
+function createMockProcess(stdout: string): any {
+  const proc = new EventEmitter() as any;
+  const stdoutEmitter = new EventEmitter();
+  const stderrEmitter = new EventEmitter();
+  proc.stdout = stdoutEmitter;
+  proc.stderr = stderrEmitter;
+  proc.kill = vi.fn();
+
+  setTimeout(() => {
+    stdoutEmitter.emit('data', Buffer.from(stdout));
+    proc.emit('close', 0);
+  }, 0);
+
+  return proc;
+}
+
+describe('standalone planning Codex thread resume repro', () => {
+  it('uses the provider thread id, not Invoker provisional UUID, for the second turn', async () => {
+    const expectedMode = process.env.REPRO_EXPECT_MODE;
+    const provisionalSessionId = 'cbbd3ce4-28ba-4b3d-8c25-8bafddc41177';
+    const providerThreadId = '019d-real-codex-thread';
+
+    let started = false;
+    const driver = {
+      harness: 'codex',
+      supportsSessionContinuity: true,
+      start: vi.fn((_prompt: string) => {
+        started = true;
+        return {
+          command: 'fake-codex',
+          args: ['exec', '--json'],
+          sessionId: provisionalSessionId,
+        };
+      }),
+      append: vi.fn((sessionId: string, _prompt: string) => ({
+        command: 'fake-codex',
+        args: ['exec', 'resume', sessionId],
+        sessionId,
+      })),
+      resolveSessionId: vi.fn((rawStdout: string, command: { sessionId: string }, options: { startedNewSession: boolean }) => {
+        if (!options.startedNewSession) return command.sessionId;
+        const match = rawStdout.match(/"thread_id":"([^"]+)"/);
+        return match?.[1] ?? command.sessionId;
+      }),
+    };
+
+    const logs: string[] = [];
+    const conv = new PlanConversation({
+      harnessSessionDriver: driver,
+      log: (_source, _level, message) => logs.push(message),
+    });
+
+    mockSpawn.mockReturnValueOnce(createMockProcess([
+      JSON.stringify({ type: 'thread.started', thread_id: providerThreadId }),
+      JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'first turn ok' } }),
+      JSON.stringify({ type: 'turn.completed' }),
+    ].join('\n')));
+    await conv.sendMessage('first planning message');
+
+    expect(started).toBe(true);
+    expect(conv.harnessSessionId).toBe(expectedMode === 'bug' ? provisionalSessionId : providerThreadId);
+
+    mockSpawn.mockReturnValueOnce(createMockProcess('second turn ok'));
+    await conv.sendMessage('continue planning');
+
+    const resumedWith = driver.append.mock.calls[0]?.[0];
+    if (expectedMode === 'bug') {
+      expect(resumedWith).toBe(provisionalSessionId);
+      return;
+    }
+
+    expect(resumedWith).toBe(providerThreadId);
+    expect(resumedWith).not.toBe(provisionalSessionId);
+    expect(logs.some((line) => line.includes('planner_session_id_promoted'))).toBe(true);
+  });
+});
+TS
+
+set +e
+(
+  cd "$SURFACES_DIR"
+  REPRO_EXPECT_MODE="$EXPECT_MODE" "$VITEST" run --reporter=dot "src/__tests__/$(basename "$TEST_FILE")"
+) >"$LOG_FILE" 2>&1
+CODE=$?
+set -e
+
+if [[ "$CODE" -ne 0 ]]; then
+  echo "[repro] FAIL: planning Codex thread resume invariant did not match $MODE."
+  cat "$LOG_FILE"
+  exit "$CODE"
+fi
+
+if [[ "$EXPECT_MODE" == "bug" ]]; then
+  echo "[repro] PASS: reproduced bug; second turn resumed with the provisional Invoker UUID."
+else
+  echo "[repro] PASS: fixed; second turn resumed with the real Codex thread id."
+fi


### PR DESCRIPTION
## Summary

App planning setup now carries the registry session driver into planning conversations.

The standalone planning path also passes the app logger, so durable traces use the same planner boundary.

## Review Claim

App planning routing passes session-driver and logger dependencies into `PlanConversation`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new app dependencies are optional. Existing tests cover planning sessions that do not provide a logger.

## Slice Rationale

This slice prepares the planner routing boundary before GUI IPC passes its concrete logger.

## Non-goals

This does not change GUI IPC handlers.

This does not add live E2E coverage.

This does not change submitted workflow state.

## Architecture

### Before

```mermaid
graph TD
    A["App planner config"] --> B["PlanConversation receives execution agent lookup only"]
```

### After

```mermaid
graph TD
    A["App planner config"] --> B["PlanConversation receives execution agent lookup"]
    A --> C["PlanConversation receives session-driver lookup"]
    A --> D["PlanConversation receives optional app logger"]
    E["Standalone planning path"] --> D
```

## Visual Proof

![Planning terminal submitted state with current plan panel and submitted system line](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260729-ddf3aa/planning-terminal-live-submitted.png)

The screenshot shows the planning terminal still reaches its submitted state on the final stack. The durable trace itself is asserted by the live proof test.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts src/__tests__/planning-chat-send-main-process-cost.test.ts --reporter=verbose`
- [x] `pnpm --filter @invoker/app build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 361efe273`
- Post-revert steps: None
- Data migration? No

</details>
