### PR TITLE
[Master E2E CI Fixes](1) Keep PR body validation dependency-light

### DIFF
--- a/scripts/lint-pr-diff-atomicity.mjs
+++ b/scripts/lint-pr-diff-atomicity.mjs
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
-import ts from 'typescript';
+
+const require = createRequire(import.meta.url);
+let typescriptModule;
 
 const CODE_EXTENSIONS = new Set(['.cjs', '.js', '.jsx', '.mjs', '.ts', '.tsx']);
 const LOCKFILES = new Set(['pnpm-lock.yaml', 'package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock', 'bun.lockb']);
@@ -81,7 +84,14 @@ function classifyPath(filePath) {
   return 'other';
 }
 
-function scriptKindFor(filePath) {
+function getTypeScript() {
+  if (!typescriptModule) {
+    typescriptModule = require('typescript');
+  }
+  return typescriptModule;
+}
+
+function scriptKindFor(ts, filePath) {
   const extension = path.extname(filePath);
   if (extension === '.tsx') {
     return ts.ScriptKind.TSX;
@@ -213,7 +223,7 @@ export function parseUnifiedDiff(diffText, source = 'diff') {
   return files;
 }
 
-function rootIdentifier(node) {
+function rootIdentifier(ts, node) {
   let expression = node;
   while (ts.isPropertyAccessExpression(expression)) {
     expression = expression.expression;
@@ -225,8 +235,9 @@ function collectAstFindings(file) {
   if (!CODE_EXTENSIONS.has(path.extname(file.path)) || file.category === 'generated') {
     return [];
   }
+  const ts = getTypeScript();
   const findings = [];
-  const sourceFile = ts.createSourceFile(file.path, file.newContent, ts.ScriptTarget.Latest, true, scriptKindFor(file.path));
+  const sourceFile = ts.createSourceFile(file.path, file.newContent, ts.ScriptTarget.Latest, true, scriptKindFor(ts, file.path));
 
   const record = (kind, node) => {
     const lineNumber = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
@@ -240,7 +251,7 @@ function collectAstFindings(file) {
       record('debugger-statement', node);
     } else if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.name)) {
       const member = node.name.text;
-      if ((member === 'only' || member === 'skip') && TEST_FUNCTIONS.has(rootIdentifier(node.expression))) {
+      if ((member === 'only' || member === 'skip') && TEST_FUNCTIONS.has(rootIdentifier(ts, node.expression))) {
         record(member === 'only' ? 'focused-test' : 'skipped-test', node);
       }
     }

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -182,6 +182,36 @@ assert((await validatePrBody(validMinimal)).length === 0, 'valid minimal body sh
 assert((await validatePrBody(validArchitecture)).length === 0, 'valid architecture body should pass');
 assert(getPrBodyWarnings(validMinimal).length === 0, 'short summary should produce no warnings');
 
+const dependencyLiteTmp = mkdtempSync(join(tmpdir(), 'pr-body-validator-lite-'));
+try {
+  const bodyPath = join(dependencyLiteTmp, 'body.md');
+  const scriptsDir = join(dependencyLiteTmp, 'scripts');
+  mkdirSync(scriptsDir, { recursive: true });
+  for (const scriptName of [
+    'lint-pr-diff-atomicity.mjs',
+    'review-unit-rules.mjs',
+    'validate-pr-body.mjs',
+  ]) {
+    cpSync(join(repoRoot, 'scripts', scriptName), join(scriptsDir, scriptName));
+  }
+  writeFileSync(bodyPath, validMinimal);
+  const liteCli = spawnSync(
+    process.execPath,
+    ['scripts/validate-pr-body.mjs', '--body-file', bodyPath],
+    { cwd: dependencyLiteTmp, encoding: 'utf8' },
+  );
+  assert(
+    liteCli.status === 0,
+    `CLI validator should not require Mermaid render dependencies for a body without Mermaid blocks: ${liteCli.stderr}`,
+  );
+  assert(
+    liteCli.stdout.includes('PR body validation passed.'),
+    'dependency-light CLI validator should report success for a non-Mermaid body',
+  );
+} finally {
+  rmSync(dependencyLiteTmp, { recursive: true, force: true });
+}
+
 const hiddenMetadataErrors = await validatePrBody(`## Summary
 
 Small fix.

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { readFileSync } from 'node:fs';
-import { JSDOM } from 'jsdom';
 import { collectDiffAtomicityFindings, formatDiffAtomicityFindings } from './lint-pr-diff-atomicity.mjs';
 import {
   formatReviewUnits,
@@ -72,6 +71,7 @@ function summarizeMermaidError(error) {
 async function getMermaidApi() {
   if (!mermaidApiPromise) {
     mermaidApiPromise = (async () => {
+      const { JSDOM } = await import('jsdom');
       const { window } = new JSDOM('<body></body>', { pretendToBeVisual: true });
       globalThis.window = window;
       globalThis.document = window.document;


### PR DESCRIPTION
## Summary

Make `validate-pr-body.mjs` and `lint-pr-diff-atomicity.mjs` work without `jsdom` and `typescript` installed at import time. Both dependencies are now lazily loaded only when their functionality is needed (Mermaid rendering and AST-based diff linting respectively). This lets the PR Body CI check run with `pnpm install --no-frozen-lockfile --ignore-scripts` (no build step) without crashing on missing optional deps.

## Non-goals

- No changes to Mermaid validation logic or diff atomicity detection rules.
- Not removing the `jsdom` or `typescript` dependencies from `package.json`.

## Test Plan

<details><summary>Test Plan</summary>

- Added a dependency-light integration test in `test-pr-body-validator.mjs` that copies only the three validator scripts into a temp directory (no `node_modules`), runs the CLI validator, and asserts it exits 0 for a body without Mermaid blocks.
- Existing test suite (`node scripts/test-pr-body-validator.mjs`) continues to pass with full dependencies.

</details>

## Revert Plan

<details><summary>Revert Plan</summary>

`git revert <sha>` — restores top-level `import` of `jsdom` and `typescript`. No state changes.

</details>

## Review Claim

Lazy-load optional heavy dependencies so the validator works in minimal environments.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Mermaid and TypeScript-based checks still run when their dependencies are available; the lazy-load wrappers are transparent.

## Slice Rationale

Single concern: convert two eager imports to lazy imports, plus one test proving it works without them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request validation in environments where optional parsing or rendering tools are unavailable.
  * Preserved Mermaid diagram validation while loading its rendering support only when needed.

* **Tests**
  * Added coverage confirming pull request body validation works in a minimal, dependency-light environment.
  * Ensured temporary validation test resources are cleaned up reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
