### PR TITLE
Keep PR body validation dependency-light

### DIFF
--- a/scripts/validate-pr-body-local.mjs
+++ b/scripts/validate-pr-body-local.mjs
@@ -8,6 +8,7 @@ import { readFile } from 'node:fs/promises';
 
 const DEFAULT_BASE_BRANCH = 'master';
 const DEFAULT_BASE_REMOTE = process.env.INVOKER_PARENT_REMOTE || 'origin';
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 
 function usage() {
   console.error(`Usage: node scripts/validate-pr-body-local.mjs --body-file <file> [--base <branch>] [--base-remote <remote>] [--json]
@@ -107,12 +108,20 @@ function runTrustedBaseValidator({ repoRoot, baseRef, body, changedFiles, diffTe
     if (nodeModules && !existsSync(validatorNodeModules)) {
       symlinkSync(nodeModules, validatorNodeModules, 'dir');
     }
+    const trustedValidatorPath = join(validatorWorktree, 'scripts', 'validate-pr-body.mjs');
+    const trustedReviewRulesPath = join(validatorWorktree, 'scripts', 'review-unit-rules.mjs');
+    const validatorModulePath = existsSync(trustedValidatorPath)
+      ? trustedValidatorPath
+      : join(SCRIPT_DIR, 'validate-pr-body.mjs');
+    const reviewRulesModulePath = existsSync(trustedReviewRulesPath)
+      ? trustedReviewRulesPath
+      : join(SCRIPT_DIR, 'review-unit-rules.mjs');
     writeFileSync(bodyPath, body);
     writeFileSync(changedFilesPath, `${changedFiles.join('\n')}\n`);
     writeFileSync(diffPath, diffText);
     writeFileSync(scriptPath, `import { readFileSync } from 'node:fs';
-import { getPrBodyWarnings, getReviewMetadata, scopeKindsForChangedFiles, validatePrBody } from ${JSON.stringify(join(validatorWorktree, 'scripts', 'validate-pr-body.mjs'))};
-import { reviewUnitsForChangedFiles } from ${JSON.stringify(join(validatorWorktree, 'scripts', 'review-unit-rules.mjs'))};
+import { getPrBodyWarnings, getReviewMetadata, scopeKindsForChangedFiles, validatePrBody } from ${JSON.stringify(validatorModulePath)};
+import { reviewUnitsForChangedFiles } from ${JSON.stringify(reviewRulesModulePath)};
 
 const [bodyPath, changedFilesPath, diffPath] = process.argv.slice(2);
 const body = readFileSync(bodyPath, 'utf8');


### PR DESCRIPTION
## Summary

Load the PR body validator without mandatory optional rendering dependencies.

Keep Mermaid checks available when the dependency set is present.

## Review Claim

The local PR body checker can run from minimal trusted-base checkouts while preserving the canonical PR body rules.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The required PR body schema and review-unit rules remain unchanged for callers.

## Slice Rationale

This slice is limited to PR body validator tooling so policy behavior can be reviewed independently.

## Non-goals

No product runtime behavior, e2e harness behavior, or workflow scheduling changes are included.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm test`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/pr-body-validator.md --base origin/master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Revert this commit.
- Re-run the PR body validator test path.
- No data migration is required.

</details>