### PR TITLE
Preserve explicit workflow base branches for stacks

### DIFF
--- a/packages/app/src/__tests__/metadata-setter.test.ts
+++ b/packages/app/src/__tests__/metadata-setter.test.ts
@@ -68,12 +68,12 @@ describe('metadata-setter', () => {
     expect(deps.orchestrator.syncFromDb).toHaveBeenCalledWith('wf-1');
   });
 
-  it('pins workflow baseBranch metadata writes to master', async () => {
+  it('preserves explicit workflow baseBranch metadata writes', async () => {
     const deps = makeDeps();
     await setWorkflowMetadata(deps, 'wf-1', 'baseBranch', 'release');
 
     expect(deps.persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', {
-      baseBranch: 'master',
+      baseBranch: 'release',
     });
   });
 

--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -30,7 +30,7 @@ describe('applyPlanDefinitionDefaults', () => {
     expect(plan.baseBranch).toBe('master');
   });
 
-  it('pins the workflow baseBranch to master even when the plan asks for another branch', () => {
+  it('preserves explicit workflow baseBranch values for stacked workflows', () => {
     const plan = applyPlanDefinitionDefaults({
       name: 'X',
       baseBranch: 'upstream/develop',
@@ -38,7 +38,7 @@ describe('applyPlanDefinitionDefaults', () => {
       onFinish: 'merge',
       tasks: [{ id: 'a', description: 'd', command: 'echo' }],
     });
-    expect(plan.baseBranch).toBe('master');
+    expect(plan.baseBranch).toBe('upstream/develop');
     expect(plan.featureBranch).toBe('feat/x');
     expect(plan.onFinish).toBe('merge');
   });
@@ -881,7 +881,7 @@ tasks:
   });
 
   describe('onFinish parsing', () => {
-    it('parses plan with onFinish: merge and still pins baseBranch to master', () => {
+    it('parses plan with onFinish: merge and preserves explicit baseBranch', () => {
       const yaml = `
 name: Merge Plan
 repoUrl: git@github.com:test/repo.git
@@ -894,7 +894,7 @@ tasks:
 `;
       const plan = parsePlan(yaml);
       expect(plan.onFinish).toBe('merge');
-      expect(plan.baseBranch).toBe('master');
+      expect(plan.baseBranch).toBe('upstream/develop');
       expect(plan.featureBranch).toBe('feat/x');
     });
 
@@ -943,7 +943,7 @@ tasks:
       loadConfigSpy.mockRestore();
     });
 
-    it('ignores an explicit baseBranch override and still pins to master', () => {
+    it('preserves an explicit baseBranch override', () => {
       const yaml = `
 name: Explicit Base
 repoUrl: git@github.com:test/repo.git
@@ -955,7 +955,35 @@ tasks:
     description: Build the project
 `;
       const plan = parsePlan(yaml);
-      expect(plan.baseBranch).toBe('master');
+      expect(plan.baseBranch).toBe('origin/release');
+    });
+
+    it('preserves stacked workflow baseBranch with externalDependencies', () => {
+      const yaml = `
+name: Stacked Child
+repoUrl: git@github.com:test/repo.git
+onFinish: pull_request
+baseBranch: plan/upstream-step
+featureBranch: plan/downstream-step
+externalDependencies:
+  - workflowId: wf-upstream
+    taskId: "__merge__"
+    requiredStatus: completed
+    gatePolicy: review_ready
+tasks:
+  - id: build
+    description: Build the project
+`;
+      const plan = parsePlan(yaml);
+      expect(plan.baseBranch).toBe('plan/upstream-step');
+      expect(plan.externalDependencies).toEqual([
+        {
+          workflowId: 'wf-upstream',
+          taskId: '__merge__',
+          requiredStatus: 'completed',
+          gatePolicy: 'review_ready',
+        },
+      ]);
     });
 
     it('rejects invalid onFinish value', () => {

--- a/packages/app/src/__tests__/workflow-base-branch-normalizer.test.ts
+++ b/packages/app/src/__tests__/workflow-base-branch-normalizer.test.ts
@@ -9,10 +9,11 @@ function makePersistence(workflows: Array<{ id: string; baseBranch?: string }>) 
 }
 
 describe('normalizePersistedWorkflowBaseBranches', () => {
-  it('rewrites every non-master workflow base branch to master', () => {
+  it('defaults missing workflow base branches without rewriting explicit stack bases', () => {
     const persistence = makePersistence([
       { id: 'wf-master', baseBranch: 'master' },
       { id: 'wf-main', baseBranch: 'main' },
+      { id: 'wf-stack', baseBranch: 'plan/upstream-step' },
       { id: 'wf-empty', baseBranch: '' },
       { id: 'wf-missing' },
     ]);
@@ -20,14 +21,13 @@ describe('normalizePersistedWorkflowBaseBranches', () => {
 
     const updated = normalizePersistedWorkflowBaseBranches(persistence, logger);
 
-    expect(updated).toBe(3);
-    expect(persistence.updateWorkflow).toHaveBeenCalledTimes(3);
-    expect(persistence.updateWorkflow).toHaveBeenNthCalledWith(1, 'wf-main', { baseBranch: 'master' });
-    expect(persistence.updateWorkflow).toHaveBeenNthCalledWith(2, 'wf-empty', { baseBranch: 'master' });
-    expect(persistence.updateWorkflow).toHaveBeenNthCalledWith(3, 'wf-missing', { baseBranch: 'master' });
+    expect(updated).toBe(2);
+    expect(persistence.updateWorkflow).toHaveBeenCalledTimes(2);
+    expect(persistence.updateWorkflow).toHaveBeenNthCalledWith(1, 'wf-empty', { baseBranch: 'master' });
+    expect(persistence.updateWorkflow).toHaveBeenNthCalledWith(2, 'wf-missing', { baseBranch: 'master' });
     expect(logger.info).toHaveBeenCalledWith(
-      '[init] normalized 3 workflow base branches to master',
-      { module: 'init', workflowCount: 3, baseBranch: 'master' },
+      '[init] defaulted 2 missing workflow base branches to master',
+      { module: 'init', workflowCount: 2, baseBranch: 'master' },
     );
   });
 

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -14,7 +14,7 @@ import { normalizeWorkflowBaseBranch } from '@invoker/workflow-core';
 import { loadConfig, resolveDefaultExecutionAgent } from './config.js';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 
-/** Workflow base branches are pinned to master, regardless of YAML/config input. */
+/** Workflow base branches default to master, while explicit stack bases are preserved. */
 function resolveDefaultBaseBranch(plan: PlanDefinition): string {
   return normalizeWorkflowBaseBranch(plan.baseBranch);
 }

--- a/packages/app/src/workflow-base-branch-normalizer.ts
+++ b/packages/app/src/workflow-base-branch-normalizer.ts
@@ -19,7 +19,7 @@ export function normalizePersistedWorkflowBaseBranches(
   }
   if (updated > 0) {
     logger?.info?.(
-      `[init] normalized ${updated} workflow base branch${updated === 1 ? '' : 'es'} to ${PINNED_WORKFLOW_BASE_BRANCH}`,
+      `[init] defaulted ${updated} missing workflow base branch${updated === 1 ? '' : 'es'} to ${PINNED_WORKFLOW_BASE_BRANCH}`,
       { module: 'init', workflowCount: updated, baseBranch: PINNED_WORKFLOW_BASE_BRANCH },
     );
   }

--- a/packages/workflow-core/src/__tests__/plan-parser.test.ts
+++ b/packages/workflow-core/src/__tests__/plan-parser.test.ts
@@ -19,7 +19,7 @@ tasks:
     expect(plan.tasks.map((t) => t.id)).toEqual(['build', 'deploy']);
   });
 
-  it('pins baseBranch to master even when YAML asks for another branch', () => {
+  it('preserves explicit baseBranch values for stacked workflows', () => {
     const yaml = `
 name: Base Branch Policy
 repoUrl: git@github.com:test/repo.git
@@ -30,7 +30,7 @@ tasks:
     command: echo "build"
 `;
     const plan = parsePlan(yaml);
-    expect(plan.baseBranch).toBe('master');
+    expect(plan.baseBranch).toBe('release');
   });
 
   it('rejects plans with duplicate task ids', () => {

--- a/packages/workflow-core/src/__tests__/repo-default-branch.test.ts
+++ b/packages/workflow-core/src/__tests__/repo-default-branch.test.ts
@@ -16,6 +16,15 @@ describe('repo-default-branch', () => {
     vi.restoreAllMocks();
   });
 
+  it('preserves explicit workflow base branches and defaults blank values to master', () => {
+    expect(repoDefaultBranch.normalizeWorkflowBaseBranch('plan/upstream-step')).toBe('plan/upstream-step');
+    expect(repoDefaultBranch.normalizeWorkflowBaseBranch('  release  ')).toBe('release');
+    expect(repoDefaultBranch.normalizeWorkflowBaseBranch('')).toBe('master');
+    expect(repoDefaultBranch.normalizeWorkflowBaseBranch(undefined)).toBe('master');
+    expect(repoDefaultBranch.workflowBaseBranchNeedsMigration('plan/upstream-step')).toBe(false);
+    expect(repoDefaultBranch.workflowBaseBranchNeedsMigration('')).toBe(true);
+  });
+
   it('passes a dash-prefixed repo path after --', () => {
     execFileSyncMock.mockReturnValue('ref: refs/heads/main HEAD\n');
 

--- a/packages/workflow-core/src/repo-default-branch.ts
+++ b/packages/workflow-core/src/repo-default-branch.ts
@@ -2,12 +2,14 @@ import { execFileSync } from 'node:child_process';
 
 export const PINNED_WORKFLOW_BASE_BRANCH = 'master';
 
-export function normalizeWorkflowBaseBranch(_branch?: string | null): string {
+export function normalizeWorkflowBaseBranch(branch?: string | null): string {
+  const trimmed = branch?.trim();
+  if (trimmed) return trimmed;
   return PINNED_WORKFLOW_BASE_BRANCH;
 }
 
 export function workflowBaseBranchNeedsMigration(branch?: string | null): boolean {
-  return (branch?.trim() ?? '') !== PINNED_WORKFLOW_BASE_BRANCH;
+  return (branch?.trim() ?? '') === '';
 }
 
 
@@ -32,4 +34,3 @@ export function requireDefaultBranchRemote(repoUrl: string): string {
   if (branch) return branch;
   throw new Error('Unable to resolve default branch for repo. Make the remote HEAD readable.');
 }
-


### PR DESCRIPTION
## Summary

Workflow YAML can now keep an explicit `baseBranch` instead of being forced back to `master`.

This lets stacked child plans stay based on the previous workflow feature branch.

Blank or missing base branches still default to `master`.

## Review Claim

Explicit workflow base branches survive parsing, metadata updates, and startup normalization.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Missing or blank base branches still normalize to `master`, so ordinary single-workflow plans keep the old default.

## Slice Rationale

This is one parser/defaulting behavior change with regression tests; no UI or publication-script changes are bundled.

## Non-goals

This does not resubmit existing workflows, change external dependency gating, or alter Mergify publication.

## Architecture

### Before

YAML parsing, metadata updates, and startup normalization flowed through `normalizeWorkflowBaseBranch()`.

That helper returned `master` for every input, so a stacked plan's explicit branch was discarded.

### After

The helper trims and preserves explicit branch names.

Only blank or missing branch values default to `master`, and startup normalization only repairs those missing values.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/repo-default-branch.test.ts src/__tests__/plan-parser.test.ts`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/plan-parser.test.ts src/__tests__/workflow-base-branch-normalizer.test.ts src/__tests__/metadata-setter.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: Existing stacked workflow submissions will again need manual base-branch repair or resubmission after a replacement fix.
- Data migration? No.

</details>
