### PR TITLE
[PR Maintenance](1) Remove retired worker runtime surface

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -105,6 +105,28 @@ describe('headless-client', () => {
       rmSync(homeRoot, { recursive: true, force: true });
     }
   });
+  it('serves worker list locally without delegating or booting Electron', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const runElectronHeadless = vi.fn(async () => 23);
+    try {
+      const exitCode = await runHeadlessClientCommand(['worker', 'list'], {
+        messageBus: new LocalBus(),
+        ensureStandaloneOwner: vi.fn(async () => {}),
+        refreshMessageBus: vi.fn(async () => new LocalBus()),
+        runElectronHeadless,
+      });
+
+      const output = stdout.mock.calls.map(([chunk]) => String(chunk)).join('');
+      expect(exitCode).toBe(0);
+      expect(runElectronHeadless).not.toHaveBeenCalled();
+      expect(output).toContain('Worker kinds');
+      expect(output).toContain('pr-admin-bypass-land');
+      expect(output).toContain('pr-orphan-repair');
+    } finally {
+      stdout.mockRestore();
+    }
+  });
+
   it('falls back to direct execution for generic standalone reads when no owner exists', async () => {
     process.env.INVOKER_HEADLESS_STANDALONE = '1';
     const firstBus = new LocalBus();

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -5,8 +5,18 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { LocalBus } from '@invoker/transport';
+import {
+  PR_ADMIN_BYPASS_LAND_WORKER_KIND,
+  PR_ORPHAN_REPAIR_WORKER_KIND,
+} from '@invoker/execution-engine';
 
 import { SharedMutationOwnerTimeoutError, electronCommandArgs, runHeadlessClientCommand } from '../headless-client.js';
+
+const RETIRED_PR_MAINTENANCE_WORKER_KINDS = [
+  'coderabbit-address',
+  'pr-conflict-rebase',
+  'pr-ci-failure-scan',
+] as const;
 
 describe('headless-client', () => {
   const savedStandalone = process.env.INVOKER_HEADLESS_STANDALONE;
@@ -120,8 +130,11 @@ describe('headless-client', () => {
       expect(exitCode).toBe(0);
       expect(runElectronHeadless).not.toHaveBeenCalled();
       expect(output).toContain('Worker kinds');
-      expect(output).toContain('pr-admin-bypass-land');
-      expect(output).toContain('pr-orphan-repair');
+      expect(output).toContain(PR_ADMIN_BYPASS_LAND_WORKER_KIND);
+      expect(output).toContain(PR_ORPHAN_REPAIR_WORKER_KIND);
+      for (const workerKind of RETIRED_PR_MAINTENANCE_WORKER_KINDS) {
+        expect(output).not.toContain(workerKind);
+      }
     } finally {
       stdout.mockRestore();
     }

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -46,10 +46,10 @@ export interface DefaultExecutionConfig {
 /**
  * Owner-side PR-maintenance worker config.
  *
- * Disabled by default: the coderabbit-address and pr-conflict-rebase workers
- * only receive launch dependencies when `enabled` is true. The remaining fields
- * tune the shell entrypoint launch and fall back to the worker defaults when
- * omitted.
+ * Disabled by default: `enabled` is the gate for building launch dependencies
+ * for the surviving `pr-admin-bypass-land` and `pr-orphan-repair` worker
+ * paths. The remaining fields tune those shell entrypoints and fall back to
+ * the worker defaults when omitted.
  */
 export interface PrMaintenanceConfig {
   /**
@@ -373,8 +373,8 @@ export interface InvokerConfig {
   externalWorkers?: ExternalWorkerConfig[];
   /**
    * Owner-side PR-maintenance worker config. Disabled by default; when
-   * `enabled` is true the owner builds coderabbit-address and pr-conflict-rebase
-   * worker launch dependencies from this block.
+   * `enabled` is true the owner builds launch dependencies for the surviving
+   * PR-maintenance workers from this block.
    */
   prMaintenance?: PrMaintenanceConfig;
 }

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -46,10 +46,10 @@ export interface DefaultExecutionConfig {
 /**
  * Owner-side PR-maintenance worker config.
  *
- * Disabled by default: `enabled` is the gate for building launch dependencies
- * for the surviving `pr-admin-bypass-land` and `pr-orphan-repair` worker
- * paths. The remaining fields tune those shell entrypoints and fall back to
- * the worker defaults when omitted.
+ * Disabled by default: the coderabbit-address and pr-conflict-rebase workers
+ * only receive launch dependencies when `enabled` is true. The remaining fields
+ * tune the shell entrypoint launch and fall back to the worker defaults when
+ * omitted.
  */
 export interface PrMaintenanceConfig {
   /**
@@ -373,8 +373,8 @@ export interface InvokerConfig {
   externalWorkers?: ExternalWorkerConfig[];
   /**
    * Owner-side PR-maintenance worker config. Disabled by default; when
-   * `enabled` is true the owner builds launch dependencies for the surviving
-   * PR-maintenance workers from this block.
+   * `enabled` is true the owner builds coderabbit-address and pr-conflict-rebase
+   * worker launch dependencies from this block.
    */
   prMaintenance?: PrMaintenanceConfig;
 }

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -28,6 +28,7 @@ import {
   tryAcquireOwnerBootstrapLock,
 } from './headless-owner-bootstrap.js';
 import { loadConfig, type InvokerConfig } from './config.js';
+import { BOLD, RESET } from './headless-shared.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 import {
   discoverOwner,
@@ -50,7 +51,6 @@ import {
 import { printHeadlessUsage } from './headless-usage.js';
 
 const RED = '\x1b[31m';
-const RESET = '\x1b[0m';
 const repoRoot = resolveRepoRoot(__dirname);
 
 function delegationClientLog(message: string): void {
@@ -203,6 +203,9 @@ function isGenericDelegatableReadCommand(args: string[]): boolean {
   if (command === 'query') {
     const sub = args[1];
     return sub !== undefined && sub !== 'workers' && sub !== 'queue' && sub !== 'ui-perf' && sub !== 'action-graph';
+  }
+  if (command === 'worker') {
+    return (args[1] ?? 'list') === 'status';
   }
   return command !== undefined && GENERIC_DELEGATABLE_READ_COMMANDS.has(command);
 }
@@ -488,6 +491,20 @@ async function tryDelegateWorkersQuery(
   return true;
 }
 
+function isLocalWorkerListCommand(args: string[]): boolean {
+  return args[0] === 'worker' && (args[1] ?? 'list') === 'list';
+}
+
+function writeLocalWorkerList(invokerConfig: InvokerConfig): void {
+  const registry = registerExternalWorkersFromConfig(
+    invokerConfig.externalWorkers,
+    registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
+  );
+  process.stdout.write(`${BOLD}Worker kinds${RESET}\n`);
+  for (const worker of registry.list()) {
+    process.stdout.write(`  ${worker.kind} — available (${worker.note})\n`);
+  }
+}
 async function runLocalWorkersQuery(args: string[], invokerConfig: InvokerConfig): Promise<number> {
   const dbPath = join(resolveInvokerHomeRoot(), 'invoker.db');
   const persistence = await openMainProcessDatabase({
@@ -688,6 +705,11 @@ export async function runHeadlessClientCommand(
   if (!internalOwnerServe && await delegateWorkerControl(args, deps.messageBus, invokerConfig, deps.refreshMessageBus)) {
     const exitCode = process.exitCode;
     return typeof exitCode === 'number' ? exitCode : 0;
+  }
+
+  if (!internalOwnerServe && isLocalWorkerListCommand(args)) {
+    writeLocalWorkerList(invokerConfig);
+    return 0;
   }
 
   if (


### PR DESCRIPTION
## Summary

Retired PR-maintenance worker names no longer appear in the worker startup surface.

Worker status output now contains only supported PR-maintenance entries.

## Review Claim

Approve narrowing worker startup and status exposure to supported PR-maintenance workers.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Focused headless-client coverage checks the visible worker output.

## Slice Rationale

Later admin-bypass work assumes retired worker names are absent from the visible worker surface.

## Non-goals

No changes to surviving PR-maintenance execution logic.

No admin-bypass queue behavior is added here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-client.test.ts src/__tests__/headless-pr-maintenance.test.ts src/__tests__/registered-owner-workers.test.ts src/__tests__/worker-control.test.ts src/__tests__/ipc-read-handlers.test.ts src/__tests__/owner-read-query.test.ts`
- [x] `pnpm --filter @invoker/app build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 517591b69 6fb9a88b4`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for listing available worker kinds directly from the command line.
  - Added support for retrieving worker status through read-only command handling.

- **Bug Fixes**
  - Worker listings now display locally without launching the desktop application or delegating the request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
