### PR TITLE
[PR Maintenance](5) Require existing owner for headless submitters

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -21,10 +21,12 @@ const RETIRED_PR_MAINTENANCE_WORKER_KINDS = [
 
 describe('headless-client', () => {
   const savedStandalone = process.env.INVOKER_HEADLESS_STANDALONE;
+  const savedRequireExistingOwner = process.env.INVOKER_HEADLESS_REQUIRE_EXISTING_OWNER;
   const savedDbDir = process.env.INVOKER_DB_DIR;
   let dbDir: string;
   beforeEach(() => {
     delete process.env.INVOKER_HEADLESS_STANDALONE;
+    delete process.env.INVOKER_HEADLESS_REQUIRE_EXISTING_OWNER;
     // Isolate the resolved DB path so the owner-marker liveness check in
     // delegateGenericReadQuery cannot see a real ~/.invoker owner on the dev box.
     dbDir = mkdtempSync(join(tmpdir(), 'headless-client-'));
@@ -35,6 +37,11 @@ describe('headless-client', () => {
       delete process.env.INVOKER_HEADLESS_STANDALONE;
     } else {
       process.env.INVOKER_HEADLESS_STANDALONE = savedStandalone;
+    }
+    if (savedRequireExistingOwner === undefined) {
+      delete process.env.INVOKER_HEADLESS_REQUIRE_EXISTING_OWNER;
+    } else {
+      process.env.INVOKER_HEADLESS_REQUIRE_EXISTING_OWNER = savedRequireExistingOwner;
     }
     if (savedDbDir === undefined) {
       delete process.env.INVOKER_DB_DIR;
@@ -738,6 +745,23 @@ describe('headless-client', () => {
     expect(refreshMessageBus).toHaveBeenCalled();
     expect(firstExecHandler).not.toHaveBeenCalled();
     expect(secondExecHandler).toHaveBeenCalledTimes(1);
+  }, 15_000);
+
+  it('does not bootstrap a standalone owner when an existing mutation owner is required', async () => {
+    process.env.INVOKER_HEADLESS_REQUIRE_EXISTING_OWNER = '1';
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const runElectronHeadless = vi.fn(async () => 0);
+
+    const exitCode = await runHeadlessClientCommand(['rebase-recreate', 'wf-3', '--no-track'], {
+      messageBus: new LocalBus(),
+      ensureStandaloneOwner,
+      refreshMessageBus: vi.fn(async () => new LocalBus()),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    expect(runElectronHeadless).not.toHaveBeenCalled();
   }, 15_000);
 
   it('falls back to the host runtime for non-mutating commands', async () => {

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -99,12 +99,17 @@ const READ_ONLY_QUERY_REQUEST_TIMEOUT_MS = 15_000;
 const GENERIC_READ_OWNER_PING_TIMEOUT_MS = 10_000;
 const POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS = 3;
 const DEFAULT_STANDALONE_OWNER_BOOTSTRAP_TIMEOUT_MS = 60_000;
+const REQUIRE_EXISTING_OWNER_ENV = 'INVOKER_HEADLESS_REQUIRE_EXISTING_OWNER';
 
 function standaloneOwnerBootstrapTimeoutMs(): number {
   const raw = process.env.INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS;
   const parsed = raw ? Number.parseInt(raw, 10) : NaN;
   if (Number.isFinite(parsed) && parsed > 0) return parsed;
   return DEFAULT_STANDALONE_OWNER_BOOTSTRAP_TIMEOUT_MS;
+}
+
+function requireExistingSharedMutationOwner(): boolean {
+  return process.env[REQUIRE_EXISTING_OWNER_ENV] === '1';
 }
 
 export class SharedMutationOwnerTimeoutError extends Error {
@@ -612,12 +617,19 @@ async function resolveOwnerAndDelegate(
     const exitCode = process.exitCode;
     return typeof exitCode === 'number' ? exitCode : 0;
   };
+  const ensureStandaloneOwner = requireExistingSharedMutationOwner()
+    ? async () => {
+        const message = `Existing shared mutation owner is required; bootstrap disabled by ${REQUIRE_EXISTING_OWNER_ENV}=1`;
+        delegationClientLog(message);
+        throw new SharedMutationOwnerTimeoutError(message);
+      }
+    : deps.ensureStandaloneOwner;
 
   const resolver = createOwnerResolver(
     {
       messageBus: deps.messageBus,
       refreshMessageBus: deps.refreshMessageBus,
-      ensureStandaloneOwner: deps.ensureStandaloneOwner,
+      ensureStandaloneOwner,
       isRetryableBootstrapError: isSharedMutationOwnerTimeoutError,
     },
     {


### PR DESCRIPTION
## Summary

Headless mutation submitters can require an already running mutation owner.

When `INVOKER_HEADLESS_REQUIRE_EXISTING_OWNER=1` is set, bootstrap is disabled and mutating commands fail fast if no standalone-capable owner is reachable.

The default headless client path is unchanged.

## Review Claim

Approve the headless client mode that disables standalone owner startup when an existing owner is required.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The default client path is unchanged unless `INVOKER_HEADLESS_REQUIRE_EXISTING_OWNER=1` is set.

## Slice Rationale

This slice changes CLI activation policy before shell helpers depend on it.

## Non-goals

- No shell helper changes.
- No worker environment changes.
- No query output changes.

## Architecture

### Before

A mutating headless client could start a standalone owner after failing to find an existing shared owner.

### After

With `INVOKER_HEADLESS_REQUIRE_EXISTING_OWNER=1`, the client fails fast instead of starting a standalone owner.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- headless-client`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5d6dde56a`
- Post-revert steps: None
- Data migration? No

</details>
