### PR TITLE
Guard admin-bypass and orphan repair pushes against moved heads

### DIFF
--- a/scripts/cron-admin-bypass-queue.sh
+++ b/scripts/cron-admin-bypass-queue.sh
@@ -153,6 +153,11 @@ while IFS= read -r pr; do
   url="$(jq -r '.url' <<<"$pr")"
   head_ref="$(jq -r '.headRefName' <<<"$pr")"
   base_ref="$(jq -r '.baseRefName' <<<"$pr")"
+  q_head_ref="$(shell_quote "$head_ref")"
+  q_head_oid="$(shell_quote "$head_oid")"
+  q_state_file="$(shell_quote "$STATE_FILE")"
+  q_num="$(shell_quote "$num")"
+  q_fingerprint="$(shell_quote "$fingerprint")"
 
   plan_file="$PLAN_DIR/repair-pr-$num.yaml"
   {
@@ -175,14 +180,27 @@ while IFS= read -r pr; do
       printf '  git fetch origin %s && git checkout %s\n\n' "$head_ref" "$head_ref"
       printf 'Rules:\n'
       printf -- '- If this is a merge conflict, rebase onto origin/%s (or merge it) before anything else.\n' "$base_ref"
-      printf -- '- If checks are failing, reproduce and fix them locally before pushing.\n'
+      printf -- '- If checks are failing, reproduce and fix them locally.\n'
       printf -- '- If changes were requested, address the open feedback with real changes or a reasoned reply, never by dismissing.\n'
-      printf -- '- Push to the SAME branch (%s). NEVER open a new PR and NEVER force-push unless a rebase requires it.\n' "$head_ref"
+      printf -- '- Commit locally if changes are needed.\n'
+      printf -- '- Do not push, do not open a new PR, and do not force-push. The safe-push task owns publication.\n'
+    } | sed 's/^/      /'
+    printf '  - id: safe-push\n'
+    printf '    description: "Safely push PR #%s only if its head did not move"\n' "$num"
+    printf '    dependencies: [repair]\n'
+    printf '    command: |\n'
+    {
+      printf 'python3 scripts/pr_worker_safe_push.py \\\n'
+      printf '  --branch %s \\\n' "$q_head_ref"
+      printf '  --expected-head %s \\\n' "$q_head_oid"
+      printf '  --record-tsv-ledger %s \\\n' "$q_state_file"
+      printf '  --tsv-kind queue-attempt \\\n'
+      printf '  --tsv-key %s \\\n' "$q_num"
+      printf '  --tsv-marker %s\n' "$q_fingerprint"
     } | sed 's/^/      /'
   } > "$plan_file"
 
   if output="$(headless_mutation --no-track run "$plan_file" 2>&1)"; then
-    ledger_record queue-attempt "$num" "$fingerprint"
     ledger_record queue-submitted "$num" "$fingerprint"
     submitted=$((submitted + 1))
     log_line "PR #$num: submitted ad-hoc repair plan (category=$category, $fingerprint)"

--- a/scripts/cron-pr-lib.sh
+++ b/scripts/cron-pr-lib.sh
@@ -44,6 +44,11 @@ log_line() {
   printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"
 }
 
+shell_quote() {
+  # Single-quote a value for a generated shell command.
+  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
 # ---------------------------------------------------------------------------
 # Shared cross-job lock (decision 3): one PR cron operation at a time.
 # Exits 0 (clean no-op) when the other job holds the lock.

--- a/scripts/cron-pr-orphan-repair.sh
+++ b/scripts/cron-pr-orphan-repair.sh
@@ -118,6 +118,11 @@ while IFS= read -r pr; do
   head_ref="$(jq -r '.headRefName' <<<"$pr")"
   base_ref="$(jq -r '.baseRefName' <<<"$pr")"
   summary="$(printf '%s; ' "${blockers[@]}")"
+  q_head_ref="$(shell_quote "$head_ref")"
+  q_head_oid="$(shell_quote "$head_oid")"
+  q_state_file="$(shell_quote "$STATE_FILE")"
+  q_num="$(shell_quote "$num")"
+  q_fingerprint="$(shell_quote "$fingerprint")"
 
   plan_file="$PLAN_DIR/repair-pr-$num.yaml"
   {
@@ -142,9 +147,23 @@ while IFS= read -r pr; do
       done
       printf '\nRules:\n'
       printf -- '- Resolve the merge conflict by rebasing onto origin/%s (or merging it) before anything else.\n' "$base_ref"
-      printf -- '- Reproduce and fix the failing checks locally before pushing.\n'
+      printf -- '- Reproduce and fix the failing checks locally.\n'
       printf -- '- Address review feedback with real changes or a reasoned reply, never by dismissing.\n'
-      printf -- '- Push to the SAME branch (%s). NEVER open a new PR and NEVER force-push unless the rebase requires it.\n' "$head_ref"
+      printf -- '- Commit locally if changes are needed.\n'
+      printf -- '- Do not push, do not open a new PR, and do not force-push. The safe-push task owns publication.\n'
+    } | sed 's/^/      /'
+    printf '  - id: safe-push\n'
+    printf '    description: "Safely push PR #%s only if its head did not move"\n' "$num"
+    printf '    dependencies: [repair]\n'
+    printf '    command: |\n'
+    {
+      printf 'python3 scripts/pr_worker_safe_push.py \\\n'
+      printf '  --branch %s \\\n' "$q_head_ref"
+      printf '  --expected-head %s \\\n' "$q_head_oid"
+      printf '  --record-tsv-ledger %s \\\n' "$q_state_file"
+      printf '  --tsv-kind orphan-attempt \\\n'
+      printf '  --tsv-key %s \\\n' "$q_num"
+      printf '  --tsv-marker %s\n' "$q_fingerprint"
     } | sed 's/^/      /'
   } > "$plan_file"
 
@@ -154,7 +173,6 @@ while IFS= read -r pr; do
   fi
 
   if output="$(headless_mutation run "$plan_file" 2>&1)"; then
-    ledger_record orphan-attempt "$num" "$fingerprint"
     ledger_record orphan-submitted "$num" "$fingerprint"
     submitted=$((submitted + 1))
     log_line "PR #$num: submitted repair task ($fingerprint; blockers: $summary)"

--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -126,8 +126,6 @@ def run_cycle(args: argparse.Namespace) -> bool:
                 # repair task instead of running an AI repair synchronously
                 # here while holding the shared PR-maintenance lock.
                 check_name = action.key.split(":", 1)[-1]
-                kind = "repair-bot-thread" if action.key.startswith("bot_review_thread:") else "repair-check"
-                ledger.record(kind, action.pr_number, pr.head_ref_oid, check_name, now)
                 ledger.record("repair-delegated", action.pr_number, pr.head_ref_oid, check_name, now)
                 logger.trace(
                     "admin-bypass-repair-delegated",
@@ -136,7 +134,6 @@ def run_cycle(args: argparse.Namespace) -> bool:
                     check_name=check_name,
                 )
             elif action.kind == "repair_conflict":
-                ledger.record("conflict-repair", action.pr_number, pr.head_ref_oid, action.key, now)
                 ledger.record("repair-delegated", action.pr_number, pr.head_ref_oid, action.key, now)
                 logger.trace(
                     "admin-bypass-repair-delegated",
@@ -145,7 +142,10 @@ def run_cycle(args: argparse.Namespace) -> bool:
                     check_name=action.key,
                 )
             else:
-                executor.execute(action, pr, now)
+                performed = executor.execute(action, pr, now)
+                if not performed:
+                    should_poll = True
+                    continue
                 if action.kind == "requeue":
                     if (
                         plan.prereq_status

--- a/scripts/mergify_admin_requeue_gh_executor.py
+++ b/scripts/mergify_admin_requeue_gh_executor.py
@@ -34,6 +34,26 @@ class AdminBypassGhExecutor:
         self.logger = logger
         self.repo = repo
 
+    def pr_head_is_current(self, pr: PrSnapshot, action_kind: str, key: str) -> bool:
+        if not pr.head_ref_oid or not hasattr(self.gh, "pr_detail"):
+            return True
+        detail = self.gh.pr_detail(self.repo, pr.number)
+        state = str(detail.get("state") or pr.state)
+        current = str(detail.get("headRefOid") or detail.get("head_ref_oid") or "")
+        if state == "OPEN" and current == pr.head_ref_oid:
+            return True
+        self.logger.trace(
+            "admin-bypass-stale-head-skip",
+            repo=self.repo,
+            pr_number=pr.number,
+            action_kind=action_kind,
+            key=key,
+            expected_head=pr.head_ref_oid,
+            current_head=current or None,
+            current_state=state,
+        )
+        return False
+
     def download_job_log(self, repo: str, details_url: str, pr_number: int, check_name: str) -> str:
         match = GH_ACTIONS_JOB_RE.search(details_url)
         if not match:
@@ -103,28 +123,38 @@ class AdminBypassGhExecutor:
             self.gh.comment(self.repo, pr.number, f"Mergify repair stopped: {detail}")
             self.ledger.record("comment-blocked", pr.number, pr.head_ref_oid, "no-current-bottom:exact", now)
 
-    def execute(self, action: Action, pr: PrSnapshot, now: int) -> None:
+    def execute(self, action: Action, pr: PrSnapshot, now: int) -> bool:
         self.logger.trace("admin-bypass-action-execute", action=self.logger.action_payload(action))
+        if action.kind in {
+            "requeue",
+            "restore_admin_bypass_label",
+            "retarget_base",
+            "comment_admin_bypass_nudge",
+            "remove_merge_hold",
+            "resolve_bot_threads",
+            "comment_blocked",
+        } and not self.pr_head_is_current(pr, action.kind, action.key):
+            return False
         if action.kind == "requeue":
             self.requeue(pr, action.key, now)
-            return
+            return True
         if action.kind == "restore_admin_bypass_label":
             self.restore_admin_bypass_label(pr, now)
-            return
+            return True
         if action.kind == "retarget_base":
             self.retarget_base(pr, action.key, now)
-            return
+            return True
         if action.kind == "comment_admin_bypass_nudge":
             self.comment_admin_bypass_nudge(pr, action.key, now)
-            return
+            return True
         if action.kind == "remove_merge_hold":
             self.remove_merge_hold(pr, now)
-            return
+            return True
         if action.kind == "resolve_bot_threads":
             self.resolve_bot_threads(action.key)
-            return
+            return True
         if action.kind == "comment_blocked":
             key = f"capped:{action.detail}" if action.key == "capped" else action.key
             self.comment_blocked(pr, action.detail, key, now)
-            return
+            return True
         raise ValueError(f"unsupported executor action: {action.kind}")

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -13,12 +13,14 @@ try:
     from .mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from .mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
     from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head, run_logged
+    from .pr_worker_safe_push import SafePushError, safe_push
 except ImportError:
     from mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
     from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head, run_logged
+    from pr_worker_safe_push import SafePushError, safe_push
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -314,8 +316,20 @@ class AdminBypassRepairer:
             prereq=prereq,
         )
 
-    def push_branch(self, work_root: Path, branch_name: str) -> None:
-        self.git_output(work_root, "push", "origin", f"HEAD:{branch_name}")
+    def push_branch(
+        self,
+        work_root: Path,
+        branch_name: str,
+        *,
+        expected_head: str | None = None,
+        expect_missing: bool = False,
+    ) -> str:
+        return safe_push(
+            branch=branch_name,
+            expected_head=expected_head,
+            expect_missing=expect_missing,
+            cwd=work_root,
+        )
 
     def terminal_repair_outcome(
         self,
@@ -363,7 +377,7 @@ class AdminBypassRepairer:
         if not validation.get("valid"):
             errors = [str(error) for error in validation.get("errors", [])]
             raise RuntimeError("prerequisite PR body failed validation: " + "; ".join(errors))
-        self.push_branch(work_root, branch_name)
+        self.push_branch(work_root, branch_name, expect_missing=True)
         created = self.gh.create_pr(self.repo, title, body, branch_name, TRUNK)
         prereq_number = int(created.get("number") or 0)
         if prereq_number <= 0:
@@ -515,7 +529,17 @@ class AdminBypassRepairer:
         repair_commits = self.git_lines(work_root, "rev-list", "--reverse", f"{start_head}..{end_head}")
         validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
         if validation.get("valid"):
-            self.push_branch(work_root, pr.head_ref_name)
+            try:
+                self.push_branch(work_root, pr.head_ref_name, expected_head=pr.head_ref_oid)
+            except SafePushError as exc:
+                return self.blocked_outcome(
+                    "stale_head",
+                    check_name,
+                    start_head,
+                    end_head,
+                    repair_commits=repair_commits,
+                    errors=(str(exc),),
+                )
             return self.blocked_outcome(
                 "pushed",
                 check_name,
@@ -551,10 +575,11 @@ class AdminBypassRepairer:
         work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
         work_root.parent.mkdir(parents=True, exist_ok=True)
         checkout_pr_head(self.repo, pr, work_root)
+        start_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
         prompt = (
             f"Resolve only the merge conflict that keeps this PR from merging. "
             f"Rebase the PR head branch onto its base branch, preserve the PR's intended changes, "
-            f"run the narrow proof for the conflict resolution, then commit and push to the PR head branch. "
+            f"run the narrow proof for the conflict resolution, then commit locally. Do not push. "
             f"If the PR is already closed or merged, or the head branch no longer exists, make no commit and exit 0.\n\n"
             f"PR: #{pr.number}\nBase branch: {pr.base_ref_name}\nHead branch: {pr.head_ref_name}\n"
             f"Head SHA: {pr.head_ref_oid}\nReason: {reason}\n"
@@ -570,3 +595,6 @@ class AdminBypassRepairer:
             head_sha=pr.head_ref_oid,
         )
         self.run_claude_repair(work_root, prompt)
+        end_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
+        if end_head != start_head and not self.git_lines(work_root, "status", "--porcelain"):
+            self.push_branch(work_root, pr.head_ref_name, expected_head=pr.head_ref_oid)

--- a/scripts/pr_worker_safe_push.py
+++ b/scripts/pr_worker_safe_push.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Mapping, Sequence
+
+
+SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+class SafePushError(RuntimeError):
+    def __init__(self, message: str, *, exit_code: int = 1):
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+def run_git(args: Sequence[str], *, cwd: Path | str | None = None) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd) if cwd is not None else None,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if completed.returncode != 0:
+        details = "\n".join(part for part in (completed.stdout, completed.stderr) if part)
+        raise SafePushError(
+            f"git {' '.join(args)} failed with exit code {completed.returncode}"
+            + (f":\n{details}" if details else ""),
+            exit_code=completed.returncode,
+        )
+    return completed.stdout.strip()
+
+
+def normalize_branch(branch: str) -> str:
+    name = branch.removeprefix("refs/heads/").strip()
+    if not name:
+        raise SafePushError("branch is required")
+    try:
+        run_git(["check-ref-format", "--branch", name])
+    except SafePushError as exc:
+        raise SafePushError(f"invalid branch name {branch!r}: {exc}", exit_code=2) from exc
+    return name
+
+
+def validate_expected_head(expected_head: str) -> str:
+    value = expected_head.strip()
+    if not SHA_RE.fullmatch(value):
+        raise SafePushError(f"expected head must be a 40-character SHA, got {expected_head!r}", exit_code=2)
+    return value.lower()
+
+
+def remote_branch_sha(branch: str, *, remote: str = "origin", cwd: Path | str | None = None) -> str | None:
+    ref = f"refs/heads/{normalize_branch(branch)}"
+    out = run_git(["ls-remote", remote, ref], cwd=cwd)
+    if not out:
+        return None
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and parts[1] == ref:
+            return parts[0].lower()
+    return None
+
+
+def local_head(*, cwd: Path | str | None = None) -> str:
+    head = run_git(["rev-parse", "HEAD"], cwd=cwd).strip().lower()
+    if not SHA_RE.fullmatch(head):
+        raise SafePushError(f"local HEAD is not a 40-character SHA: {head!r}", exit_code=2)
+    return head
+
+
+def safe_push(
+    *,
+    branch: str,
+    expected_head: str | None = None,
+    expect_missing: bool = False,
+    remote: str = "origin",
+    cwd: Path | str | None = None,
+) -> str:
+    branch_name = normalize_branch(branch)
+    if expect_missing and expected_head is not None:
+        raise SafePushError("--expect-missing cannot be combined with --expected-head", exit_code=2)
+    expected = None if expect_missing else validate_expected_head(expected_head or "")
+    live = remote_branch_sha(branch_name, remote=remote, cwd=cwd)
+    if expect_missing:
+        if live is not None:
+            raise SafePushError(
+                f"stale-head: refs/heads/{branch_name} exists at {live}; expected it to be missing",
+                exit_code=20,
+            )
+        lease = f"refs/heads/{branch_name}:"
+    else:
+        if live != expected:
+            raise SafePushError(
+                f"stale-head: refs/heads/{branch_name} is {live or 'missing'}; expected {expected}",
+                exit_code=20,
+            )
+        lease = f"refs/heads/{branch_name}:{expected}"
+
+    pushed = local_head(cwd=cwd)
+    run_git([
+        "push",
+        f"--force-with-lease={lease}",
+        remote,
+        f"HEAD:refs/heads/{branch_name}",
+    ], cwd=cwd)
+
+    verified = remote_branch_sha(branch_name, remote=remote, cwd=cwd)
+    if verified != pushed:
+        raise SafePushError(
+            f"post-push verification failed: refs/heads/{branch_name} is {verified or 'missing'}; expected {pushed}",
+            exit_code=22,
+        )
+    return pushed
+
+
+def append_tsv_ledger(path: Path, *, kind: str, key: str, marker: str, epoch: int | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{kind}\t{key}\t{marker}\t{epoch if epoch is not None else int(time.time())}\n")
+
+
+def append_json_ledger(
+    path: Path,
+    *,
+    kind: str,
+    pr_number: int,
+    head_sha: str,
+    key: str,
+    epoch: int | None = None,
+    meta: Mapping[str, object] | None = None,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    row: dict[str, object] = {
+        "kind": kind,
+        "pr": pr_number,
+        "headSha": head_sha,
+        "key": key,
+        "epoch": epoch if epoch is not None else int(time.time()),
+    }
+    if meta:
+        row["meta"] = dict(meta)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Safely update a PR worker-owned branch only when its remote head matches the captured SHA.",
+    )
+    parser.add_argument("--branch", required=True, help="Branch name, without refs/heads/.")
+    expected = parser.add_mutually_exclusive_group(required=True)
+    expected.add_argument("--expected-head", help="Captured remote branch head SHA.")
+    expected.add_argument("--expect-missing", action="store_true", help="Require the remote branch to be absent before pushing.")
+    parser.add_argument("--remote", default="origin", help="Git remote name or URL. Default: origin.")
+    parser.add_argument("--cwd", default=".", help="Repository working directory. Default: current directory.")
+
+    parser.add_argument("--record-tsv-ledger", help="Append a TSV marker after successful push verification.")
+    parser.add_argument("--tsv-kind", help="TSV ledger kind.")
+    parser.add_argument("--tsv-key", help="TSV ledger key.")
+    parser.add_argument("--tsv-marker", help="TSV ledger marker.")
+
+    parser.add_argument("--record-json-ledger", help="Append a JSONL marker after successful push verification.")
+    parser.add_argument("--json-kind", help="JSONL ledger kind.")
+    parser.add_argument("--json-pr", type=int, help="JSONL PR number.")
+    parser.add_argument("--json-head-sha", help="JSONL head SHA.")
+    parser.add_argument("--json-key", help="JSONL ledger key.")
+    parser.add_argument("--json-meta", help="Optional JSON object stored as JSONL ledger meta.")
+    return parser.parse_args(argv)
+
+
+def require_all(label: str, values: Mapping[str, object | None]) -> None:
+    missing = [name for name, value in values.items() if value is None or value == ""]
+    if missing:
+        raise SafePushError(f"{label} requires {', '.join(missing)}", exit_code=2)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        pushed = safe_push(
+            branch=args.branch,
+            expected_head=args.expected_head,
+            expect_missing=args.expect_missing,
+            remote=args.remote,
+            cwd=Path(args.cwd),
+        )
+        if args.record_tsv_ledger:
+            require_all("TSV ledger recording", {
+                "--tsv-kind": args.tsv_kind,
+                "--tsv-key": args.tsv_key,
+                "--tsv-marker": args.tsv_marker,
+            })
+            append_tsv_ledger(
+                Path(args.record_tsv_ledger).expanduser(),
+                kind=args.tsv_kind,
+                key=args.tsv_key,
+                marker=args.tsv_marker,
+            )
+        if args.record_json_ledger:
+            require_all("JSONL ledger recording", {
+                "--json-kind": args.json_kind,
+                "--json-pr": args.json_pr,
+                "--json-head-sha": args.json_head_sha,
+                "--json-key": args.json_key,
+            })
+            meta = None
+            if args.json_meta:
+                decoded = json.loads(args.json_meta)
+                if not isinstance(decoded, dict):
+                    raise SafePushError("--json-meta must decode to a JSON object", exit_code=2)
+                meta = decoded
+            append_json_ledger(
+                Path(args.record_json_ledger).expanduser(),
+                kind=args.json_kind,
+                pr_number=args.json_pr,
+                head_sha=args.json_head_sha,
+                key=args.json_key,
+                meta=meta,
+            )
+        print(f"pr-worker-safe-push: pushed refs/heads/{normalize_branch(args.branch)} to {pushed}")
+        return 0
+    except SafePushError as exc:
+        print(f"pr-worker-safe-push: {exc}", file=sys.stderr)
+        return exc.exit_code or 1
+    except json.JSONDecodeError as exc:
+        print(f"pr-worker-safe-push: invalid --json-meta: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/repro/repro-admin-bypass-queue.sh
+++ b/scripts/repro/repro-admin-bypass-queue.sh
@@ -93,6 +93,10 @@ grep -q "^repoUrl: https://github.com/fake/repo.git$" "$plan902" \
   || fail "plan902: repoUrl must be set (parseRawPlan requires it)" "$(cat "$plan902")"
 grep -q "^onFinish: none$" "$plan902" || fail "plan902: must not open its own PR" "$(cat "$plan902")"
 grep -q "Blocker category: failed_checks" "$plan902" || fail "plan902: wrong category" "$(cat "$plan902")"
+grep -q "id: safe-push" "$plan902" || fail "plan902: missing safe-push task" "$(cat "$plan902")"
+grep -q "python3 scripts/pr_worker_safe_push.py" "$plan902" || fail "plan902: missing safe-push helper command" "$(cat "$plan902")"
+grep -q -- "--tsv-kind queue-attempt" "$plan902" || fail "plan902: safe-push must own queue-attempt recording" "$(cat "$plan902")"
+grep -q "Do not push" "$plan902" || fail "plan902: repair prompt must forbid direct pushes" "$(cat "$plan902")"
 
 plan903="$TMP/plans/repair-pr-903.yaml"
 [ -f "$plan903" ] || fail "tick 1: plan file missing for #903"
@@ -111,8 +115,9 @@ node_calls_after="$(wc -l < "$NODE_LOG")"
 # Tick 3: attempt cap -> one-time exhausted comment for #902.
 fp="$(awk -F '\t' '$1 == "queue-submitted" && $2 == "902" { print $3 }' "$TMP/ledger.tsv")"
 [ -n "$fp" ] || fail "could not read fingerprint from ledger for #902"
-grep -v "^queue-submitted	902	" "$TMP/ledger.tsv" > "$TMP/ledger2.tsv" && mv "$TMP/ledger2.tsv" "$TMP/ledger.tsv"
-for _ in 1 2; do printf 'queue-attempt\t902\t%s\t%s\n' "$fp" "$(date +%s)" >> "$TMP/ledger.tsv"; done
+awk -F '\t' '!( $1 == "queue-submitted" && $2 == "902" )' "$TMP/ledger.tsv" > "$TMP/ledger2.tsv"
+mv "$TMP/ledger2.tsv" "$TMP/ledger.tsv"
+for _ in 1 2 3; do printf 'queue-attempt\t902\t%s\t%s\n' "$fp" "$(date +%s)" >> "$TMP/ledger.tsv"; done
 out="$(run_cron)" || fail "tick 3 exited non-zero" "$out"
 echo "$out" | grep -q "PR #902: attempt cap reached" \
   || fail "tick 3: expected attempt cap to fire for #902" "$out"

--- a/scripts/repro/repro-babysit-pr-body-human-split.sh
+++ b/scripts/repro/repro-babysit-pr-body-human-split.sh
@@ -153,23 +153,16 @@ import os
 from pathlib import Path
 ledger_path = Path(os.environ['LEDGER_PATH'])
 rows = [json.loads(line) for line in ledger_path.read_text(encoding='utf-8').splitlines() if line.strip()]
-if not any(row.get('kind') == 'repair-check' and row.get('pr') == 5803 and row.get('key') == 'PR Body' for row in rows):
-    raise SystemExit('missing repair-check ledger row for PR #5803')
-invalid = next((row for row in rows if row.get('kind') == 'repair-invalid' and row.get('pr') == 5803 and row.get('key') == 'PR Body'), None)
-if invalid is None:
-    raise SystemExit('missing repair-invalid ledger row for PR #5803')
-errors = (invalid.get('meta') or {}).get('errors') or []
-if not any('human stack split required' in str(item) for item in errors):
-    raise SystemExit('repair-invalid row missing manual split note')
+if not any(row.get('kind') == 'repair-delegated' and row.get('pr') == 5803 and row.get('key') == 'PR Body' for row in rows):
+    raise SystemExit('missing repair-delegated ledger row for PR #5803')
+if any(row.get('kind') == 'repair-check' and row.get('pr') == 5803 and row.get('key') == 'PR Body' for row in rows):
+    raise SystemExit('repair-check attempt marker must not be recorded at delegation time')
+if any(row.get('kind') == 'repair-invalid' and row.get('pr') == 5803 and row.get('key') == 'PR Body' for row in rows):
+    raise SystemExit('repair-invalid must be produced by the delegated repair, not submission')
 state = json.loads(Path(os.environ['STATE_PATH']).read_text(encoding='utf-8'))
 comments = state.get('issue_comments', {}).get('5803', [])
-if len(comments) != 1:
-    raise SystemExit(f'expected exactly one stop comment, saw {len(comments)}')
-body = comments[0].get('body', '')
-if 'Split this into one Review Unit per PR.' not in body:
-    raise SystemExit('stop comment missing split guidance')
-if 'human stack split required' not in body:
-    raise SystemExit('stop comment missing manual split note')
+if comments:
+    raise SystemExit(f'delegation must not comment on the PR, saw {len(comments)} comment(s)')
 PY
 }
 
@@ -235,23 +228,9 @@ case "$out2" in
   *'repair-check PR #5803'*) fail 'tick 2: worker retried the same impossible PR Body fix' "$out2" ;;
 esac
 case "$out2" in
-  *'"reason": "blocked-needs-human"'*) ;;
-  *) fail 'tick 2: worker did not surface blocked-needs-human wait state' "$out2" ;;
+  *'"reason": "repair-delegated"'*) ;;
+  *) fail 'tick 2: worker did not surface repair-delegated wait state' "$out2" ;;
 esac
-assert_stop_comment_count 1
-
-: > "$LEDGER_PATH"
-if ! out3="$(run_worker)"; then
-  fail 'tick 3: worker failed after ledger loss' "$out3"
-fi
-printf '%s\n' "$out3"
-case "$out3" in
-  *'repair-check PR #5803'*) fail 'tick 3: worker retried existing split-only stop after ledger loss' "$out3" ;;
-esac
-case "$out3" in
-  *'"reason": "blocked-needs-human"'*) ;;
-  *) fail 'tick 3: worker did not keep blocked-needs-human wait state after ledger loss' "$out3" ;;
-esac
-assert_stop_comment_count 1
+assert_stop_comment_count 0
 
 echo '[repro] passed'

--- a/scripts/repro/repro-pr-orphan-repair.sh
+++ b/scripts/repro/repro-pr-orphan-repair.sh
@@ -76,6 +76,12 @@ grep -q "1. conflict:" "$plan" || fail "plan: conflict must be blocker #1" "$(ca
 grep -q "2. failed_checks: Unit Tests" "$plan" || fail "plan: failing check must be blocker #2" "$(cat "$plan")"
 grep -q "3. changes_requested:" "$plan" || fail "plan: review feedback must be blocker #3" "$(cat "$plan")"
 grep -q "git fetch origin feature/orphan-801" "$plan" || fail "plan: must target the existing PR branch" "$(cat "$plan")"
+grep -q "id: safe-push" "$plan" || fail "plan: missing safe-push task" "$(cat "$plan")"
+grep -q "python3 scripts/pr_worker_safe_push.py" "$plan" || fail "plan: missing safe-push helper command" "$(cat "$plan")"
+grep -q -- "--tsv-kind orphan-attempt" "$plan" || fail "plan: safe-push must own orphan-attempt recording" "$(cat "$plan")"
+grep -q "Do not push" "$plan" || fail "plan: repair prompt must forbid direct pushes" "$(cat "$plan")"
+awk -F '\t' '$1 == "orphan-attempt" && $2 == "801" { found=1 } END { exit found ? 0 : 1 }' "$TMP/ledger.tsv" \
+  && fail "tick 1: submission must not record orphan-attempt" "$(cat "$TMP/ledger.tsv")"
 grep -q "repair-pr-802" "$NODE_LOG" && fail "healthy PR #802 got a repair plan"
 grep -q "repair-pr-803" "$NODE_LOG" && fail "mapped PR #803 got a repair plan"
 
@@ -89,8 +95,9 @@ runs="$(grep -c "exec -- run " "$NODE_LOG" || true)"
 # ── Tick 3: attempt cap -> one-time exhausted comment ──
 fp="$(awk -F '\t' '$1 == "orphan-submitted" && $2 == "801" { print $3 }' "$TMP/ledger.tsv")"
 [ -n "$fp" ] || fail "could not read fingerprint from ledger"
-grep -v "^orphan-submitted	801	" "$TMP/ledger.tsv" > "$TMP/ledger2.tsv" && mv "$TMP/ledger2.tsv" "$TMP/ledger.tsv"
-for _ in 1 2; do printf 'orphan-attempt\t801\t%s\t%s\n' "$fp" "$(date +%s)" >> "$TMP/ledger.tsv"; done
+awk -F '\t' '!( $1 == "orphan-submitted" && $2 == "801" )' "$TMP/ledger.tsv" > "$TMP/ledger2.tsv"
+mv "$TMP/ledger2.tsv" "$TMP/ledger.tsv"
+for _ in 1 2 3; do printf 'orphan-attempt\t801\t%s\t%s\n' "$fp" "$(date +%s)" >> "$TMP/ledger.tsv"; done
 out="$(run_cron)" || fail "tick 3 exited non-zero" "$out"
 echo "$out" | grep -q "PR #801: attempt cap reached" \
   || fail "tick 3: expected the attempt cap to fire" "$out"

--- a/scripts/test-suites/required/12-mergify-admin-requeue.sh
+++ b/scripts/test-suites/required/12-mergify-admin-requeue.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
+python3 -m unittest scripts/test_pr_worker_safe_push.py
 python3 -m unittest scripts/test_mergify_admin_requeue.py
 bash scripts/repro/repro-mergify-admin-requeue.sh
 bash scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -342,15 +342,18 @@ Failing checks
 
         ledger = self.ledger()
         item = pr(2647, merge_state="DIRTY", latest=mergify())
-        repairs = []
+        prompts = []
         repairer = self.repairer(FakeGh(), ledger, "Neko-Catpital-Labs/Invoker")
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch.object(repairer, "run_claude_repair", side_effect=lambda _work_root, _prompt: repairs.append(item.number)):
-                for epoch in range(3):
-                    ledger.record("conflict-repair", item.number, item.head_ref_oid, "conflict:2647", epoch)
-                    repairer.repair_conflict(item, "GitHub reports merge conflict")
+            with mock.patch.object(repairer, "git_output", return_value=HEAD):
+                with mock.patch.object(repairer, "git_lines", return_value=()):
+                    with mock.patch.object(repairer, "run_claude_repair", side_effect=lambda _work_root, prompt: prompts.append(prompt)):
+                        for epoch in range(3):
+                            ledger.record("conflict-repair", item.number, item.head_ref_oid, "conflict:2647", epoch)
+                            repairer.repair_conflict(item, "GitHub reports merge conflict")
         self.assertEqual(ledger.count("conflict-repair", 2647, HEAD, "conflict:2647"), 3)
-        self.assertEqual(repairs, [2647, 2647, 2647])
+        self.assertEqual(len(prompts), 3)
+        self.assertIn("commit locally. Do not push.", prompts[0])
         actions = plan_stack_actions(StackGroup("s", (item,)), REQUIRED, ledger, 4)
         self.assertEqual([(a.kind, a.key) for a in actions], [("comment_blocked", "capped")])
 
@@ -571,6 +574,39 @@ Failing checks
         self.assertIn('"key": "upper-stack-needs-acceptance"', log)
         self.assertIn('"upper_stack_needs_acceptance": true', log)
 
+    def test_run_cycle_delegated_repair_does_not_consume_attempt_cap_marker(self):
+        ledger = self.ledger()
+        args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(ledger.path)])
+        stack = StackGroup("s", (pr(2606, checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}, latest=mergify()),))
+        stdout = io.StringIO()
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=object()):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
+                    with redirect_stdout(stdout):
+                        should_poll = exec_impl.run_cycle(args)
+        self.assertFalse(should_poll)
+        self.assertIn('repair-check PR #2606 check="PR Body"', stdout.getvalue())
+        refreshed = Ledger(ledger.path)
+        self.assertEqual(refreshed.count("repair-delegated", 2606, HEAD, "PR Body"), 1)
+        self.assertEqual(refreshed.count("repair-check", 2606, HEAD, "PR Body"), 0)
+
+    def test_run_cycle_delegated_conflict_repair_does_not_consume_attempt_cap_marker(self):
+        ledger = self.ledger()
+        args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(ledger.path)])
+        item = pr(2609, merge_state="DIRTY", latest=mergify())
+        stack = StackGroup("s", (item,))
+        stdout = io.StringIO()
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=object()):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
+                    with redirect_stdout(stdout):
+                        should_poll = exec_impl.run_cycle(args)
+        self.assertFalse(should_poll)
+        self.assertIn("repair-conflict PR #2609", stdout.getvalue())
+        refreshed = Ledger(ledger.path)
+        self.assertEqual(refreshed.count("repair-delegated", 2609, HEAD, "conflict:2609"), 1)
+        self.assertEqual(refreshed.count("conflict-repair", 2609, HEAD, "conflict:2609"), 0)
+
     def test_repair_check_splits_tooling_policy_prerequisite(self):
         class FakeGh:
             def __init__(self):
@@ -641,9 +677,11 @@ Failing checks
                     with mock.patch.object(repairer, "git_output", side_effect=fake_git_output):
                         with mock.patch.object(repairer, "git_lines", side_effect=fake_git_lines):
                             with mock.patch.object(repairer, "validate_local_pr_body", side_effect=lambda *_args: next(validator_results)):
-                                result = repairer.repair_check(item, "PR Body", 123)
+                                with mock.patch.object(repairer, "push_branch", return_value="pushed-sha") as push_branch:
+                                    result = repairer.repair_check(item, "PR Body", 123)
 
         self.assertEqual(result.status, "prereq_created")
+        push_branch.assert_called_once_with(mock.ANY, "stack/pr-babysit-prereq-5800-c2532d2", expect_missing=True)
         self.assertEqual(fake.created[0][0], "owner/repo")
         self.assertIn("[PR babysit] Tooling-policy repair prerequisite for #5800: PR Body", fake.created[0][1])
         self.assertEqual(fake.label_edits, [("owner/repo", 5801, "admin-bypass", None)])
@@ -904,6 +942,33 @@ Failing checks
         self.assertIn("tag this PR with `admin-bypass`", fake.comments[0][2])
         self.assertEqual(fake.label_edits, [])
         self.assertEqual(ledger.count(ADMIN_BYPASS_NUDGE_LEDGER_KIND, 2647, HEAD, "admin-bypass"), 1)
+
+    def test_stale_direct_mutation_skips_comment_and_ledger(self):
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+
+            def pr_detail(self, repo, number):
+                return {"number": number, "state": "OPEN", "headRefOid": OLD}
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+            def issue_comments(self, repo, pr_number):
+                return []
+
+        action = Action("comment_blocked", 2647, "human-thread", "unresolved human review thread")
+        ledger = self.ledger()
+        item = pr(2647, latest=mergify())
+        fake = FakeGh()
+        executor = self.executor(fake, ledger, "owner/repo")
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            performed = executor.execute(action, item, 1)
+        self.assertFalse(performed)
+        self.assertEqual(fake.comments, [])
+        self.assertEqual(ledger.count("comment-blocked", 2647, HEAD, "human-thread"), 0)
+        self.assertIn('"event": "admin-bypass-stale-head-skip"', stderr.getvalue())
 
     def test_restore_admin_bypass_label_edits_once_per_head(self):
         class FakeGh:

--- a/scripts/test_pr_worker_safe_push.py
+++ b/scripts/test_pr_worker_safe_push.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from scripts import pr_worker_safe_push as safe_push
+
+
+REAL_GIT = shutil.which("git") or "git"
+
+
+def git(cwd: Path, *args: str, env: dict[str, str] | None = None) -> str:
+    completed = subprocess.run(
+        [REAL_GIT, *args],
+        cwd=str(cwd),
+        check=True,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    return completed.stdout.strip()
+
+
+class SafePushTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.remote = self.root / "remote.git"
+        self.repo = self.root / "repo"
+        self.other = self.root / "other"
+        git(self.root, "init", "--bare", str(self.remote))
+        git(self.root, "clone", str(self.remote), str(self.repo))
+        for clone in (self.repo,):
+            git(clone, "config", "user.email", "worker@example.invalid")
+            git(clone, "config", "user.name", "Worker Test")
+        git(self.repo, "checkout", "-B", "main")
+        (self.repo / "file.txt").write_text("base\n", encoding="utf-8")
+        git(self.repo, "add", "file.txt")
+        git(self.repo, "commit", "-m", "base")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/main")
+        self.expected = git(self.repo, "rev-parse", "HEAD")
+
+    def commit(self, repo: Path, message: str, content: str = "change\n") -> str:
+        target = repo / "file.txt"
+        target.write_text(target.read_text(encoding="utf-8") + content, encoding="utf-8")
+        git(repo, "add", "file.txt")
+        git(repo, "commit", "-m", message)
+        return git(repo, "rev-parse", "HEAD")
+
+    def clone_other(self) -> None:
+        git(self.root, "clone", str(self.remote), str(self.other))
+        git(self.other, "checkout", "main")
+        git(self.other, "config", "user.email", "other@example.invalid")
+        git(self.other, "config", "user.name", "Other Test")
+
+    def remote_head(self, branch: str = "main") -> str:
+        return safe_push.remote_branch_sha(branch, remote="origin", cwd=self.repo) or ""
+
+    def invoke_helper(self, *args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+        command = ["python3", str(Path(__file__).with_name("pr_worker_safe_push.py")), *args]
+        merged_env = {**os.environ, **(env or {})}
+        return subprocess.run(
+            command,
+            cwd=str(self.repo),
+            check=False,
+            text=True,
+            capture_output=True,
+            env=merged_env,
+        )
+
+    def test_matching_expected_sha_pushes_and_records_attempt_marker(self) -> None:
+        pushed = self.commit(self.repo, "repair")
+        ledger = self.root / "ledger.tsv"
+        result = self.invoke_helper(
+            "--branch", "main",
+            "--expected-head", self.expected,
+            "--record-tsv-ledger", str(ledger),
+            "--tsv-kind", "queue-attempt",
+            "--tsv-key", "123",
+            "--tsv-marker", "fp1",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.remote_head(), pushed)
+        self.assertEqual(ledger.read_text(encoding="utf-8").split("\t")[:3], ["queue-attempt", "123", "fp1"])
+
+    def test_moved_remote_head_exits_nonzero_leaves_remote_unchanged_and_records_no_attempt(self) -> None:
+        self.clone_other()
+        remote_after_race = self.commit(self.other, "race", "race\n")
+        git(self.other, "push", "origin", "HEAD:refs/heads/main")
+        self.commit(self.repo, "repair")
+        ledger = self.root / "ledger.tsv"
+
+        result = self.invoke_helper(
+            "--branch", "main",
+            "--expected-head", self.expected,
+            "--record-tsv-ledger", str(ledger),
+            "--tsv-kind", "queue-attempt",
+            "--tsv-key", "123",
+            "--tsv-marker", "fp1",
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("stale-head", result.stderr)
+        self.assertEqual(safe_push.remote_branch_sha("main", remote="origin", cwd=self.other), remote_after_race)
+        self.assertFalse(ledger.exists())
+
+    def test_push_lease_failure_records_no_attempt(self) -> None:
+        self.clone_other()
+        pushed = self.commit(self.repo, "repair")
+        del pushed
+        ledger = self.root / "ledger.tsv"
+        marker = self.root / "race-done"
+        wrapper_dir = self.root / "bin"
+        wrapper_dir.mkdir()
+        wrapper = wrapper_dir / "git"
+        wrapper.write_text(
+            textwrap.dedent(
+                f"""\
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [ "${{1:-}}" = "push" ] && [ ! -e {str(marker)!r} ]; then
+                  touch {str(marker)!r}
+                  printf 'lease-race\\n' >> {str(self.other / "file.txt")!r}
+                  {REAL_GIT!r} -C {str(self.other)!r} add file.txt
+                  {REAL_GIT!r} -C {str(self.other)!r} commit -m lease-race >/dev/null
+                  {REAL_GIT!r} -C {str(self.other)!r} push origin HEAD:refs/heads/main >/dev/null
+                fi
+                exec {REAL_GIT!r} "$@"
+                """
+            ),
+            encoding="utf-8",
+        )
+        wrapper.chmod(0o755)
+
+        result = self.invoke_helper(
+            "--branch", "main",
+            "--expected-head", self.expected,
+            "--record-tsv-ledger", str(ledger),
+            "--tsv-kind", "queue-attempt",
+            "--tsv-key", "123",
+            "--tsv-marker", "fp1",
+            env={"PATH": f"{wrapper_dir}:{os.environ['PATH']}"},
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("git push", result.stderr)
+        self.assertFalse(ledger.exists())
+
+    def test_new_prerequisite_branch_succeeds_only_when_remote_branch_is_absent(self) -> None:
+        git(self.repo, "checkout", "-B", "stack/prereq")
+        first = self.commit(self.repo, "prereq", "prereq\n")
+        result = self.invoke_helper("--branch", "stack/prereq", "--expect-missing")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.remote_head("stack/prereq"), first)
+
+        second = self.commit(self.repo, "prereq-again", "again\n")
+        del second
+        result = self.invoke_helper("--branch", "stack/prereq", "--expect-missing")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("expected it to be missing", result.stderr)
+        self.assertEqual(self.remote_head("stack/prereq"), first)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Admin-bypass ad-hoc repairs and orphan repairs now keep local repair work separate from branch publication.

Repair tasks commit locally. A safe-push command compares the live remote branch with the captured PR head before updating it.

Ledger markers are written only after verified publication, and outdated admin-bypass GitHub actions exit without comments or alerts.

## Review Claim

Approve the captured-head publication guard for admin-bypass and orphan-repair worker paths.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Admin-bypass and orphan-repair worker publication now goes through an exact-lease helper. Changed remote heads exit before remote updates or ledger-marker writes.

## Slice Rationale

This PR covers only script-owned admin-bypass and orphan-repair paths. Review-gate workflow generation and execution-engine generic repair publishing are deferred to a follow-up ticket.

## Non-goals

- No change to review-gate CI or stack repair workflow generation.
- No change to execution-engine generic repair workflow publishing.
- No change to normal user branch publication outside these worker scripts.

## Architecture

### Before

```mermaid
flowchart TD
    A["Worker scans PR at captured head"] --> B["Repair task edits and may push"]
    B --> C["Attempt marker can be recorded at submission"]
```

### After

```mermaid
flowchart TD
    A["Worker scans PR at captured head"] --> B["Repair task edits and commits locally"]
    B --> C["safe-push reads live remote head"]
    C --> D{"Remote still equals captured head?"}
    D -- "yes" --> E["force-with-lease push"]
    E --> F["verify remote equals local HEAD"]
    F --> G["record attempt marker"]
    D -- "no" --> H["exit without push or marker"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m py_compile scripts/pr_worker_safe_push.py scripts/mergify_admin_requeue_repairer.py scripts/mergify_admin_requeue_gh_executor.py scripts/mergify_admin_requeue_exec.py`
- [x] `bash -n scripts/cron-admin-bypass-queue.sh scripts/cron-pr-orphan-repair.sh scripts/cron-pr-lib.sh`
- [x] `python3 -m unittest scripts/test_pr_worker_safe_push.py scripts/test_mergify_admin_requeue.py`
- [x] `bash scripts/repro/repro-admin-bypass-queue.sh`
- [x] `bash scripts/repro/repro-pr-orphan-repair.sh`
- [x] `bash scripts/test-suites/required/12-mergify-admin-requeue.sh`
- [x] `git diff --check origin/master`
- [x] `bash /tmp/live-safe-push-e2e.sh` (live GitHub E2E on disposable draft PR #6806: matching-head push advanced the PR branch, moved-head push exited 20 without changing the remote or writing a stale ledger marker, and `--expect-missing` succeeded once then exited 20 on the existing branch.)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 25152e162`
- Post-revert steps: None.
- Data migration? No.

</details>

## Validator Note

`node scripts/validate-pr-body-local.mjs --body-file /tmp/stale-head-guard-pr.md --base master --json` rejects this single branch because the required shell repro updates are classified as `proof` while the worker script changes are classified as `tooling-policy`. Product `packages/*` changes have been removed from this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guarded branch publishing that verifies the remote branch has not changed before pushing.
  * Added support for safely creating prerequisite branches only when they are absent.
  * Added ledger tracking for successful publishing and delegated repair actions.

* **Bug Fixes**
  * Prevented stale pull request updates from triggering comments, repairs, or labels.
  * Improved repair handling when branch changes race with automated actions.
  * Standardized delegation tracking and polling behavior.

* **Tests**
  * Expanded coverage for safe publishing, stale updates, repair delegation, and retry limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->