### PR TITLE
Share forced manual refresh publishing

### DIFF
--- a/packages/app/src/__tests__/refresh-task-graph.test.ts
+++ b/packages/app/src/__tests__/refresh-task-graph.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from 'vitest';
-import { resolveRefreshTaskGraphSnapshot } from '../refresh-task-graph.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  publishForcedRefreshTaskGraphSnapshot,
+  resolveRefreshTaskGraphSnapshot,
+} from '../refresh-task-graph.js';
 
 function makeTask(id: string) {
   return {
@@ -27,6 +30,28 @@ function makeLogger() {
     warnings,
   };
 }
+
+describe('publishForcedRefreshTaskGraphSnapshot', () => {
+  it('always publishes the refresh snapshot as forced', () => {
+    const publisher = {
+      publishSnapshot: vi.fn(),
+    };
+    const task = makeTask('wf-1/task-1');
+    const workflow = { id: 'wf-1', name: 'Workflow 1', status: 'running' };
+
+    publishForcedRefreshTaskGraphSnapshot(publisher, 'refresh-task-graph', {
+      tasks: [task],
+      workflows: [workflow],
+    });
+
+    expect(publisher.publishSnapshot).toHaveBeenCalledWith(
+      'refresh-task-graph',
+      [task],
+      [workflow],
+      true,
+    );
+  });
+});
 
 describe('resolveRefreshTaskGraphSnapshot fallback', () => {
   it('falls back to the local snapshot when owner delegation disappears', async () => {

--- a/packages/app/src/__tests__/start-web-surface.test.ts
+++ b/packages/app/src/__tests__/start-web-surface.test.ts
@@ -159,6 +159,61 @@ describe('startHeadlessWebSurface', () => {
     expect(mocks.startWebBridge).not.toHaveBeenCalled();
   });
 
+  it('publishes a forced snapshot when the web refresh route runs', async () => {
+    const tasks = [
+      {
+        id: 'wf-1/task-1',
+        description: 'task 1',
+        status: 'running',
+        dependencies: [],
+        createdAt: new Date('2026-01-01'),
+        config: {},
+        execution: {},
+      },
+    ];
+    const workflows = [{ id: 'wf-1', name: 'Workflow 1', status: 'running' }];
+    const deps = makeDeps({
+      config: { webToken: 'secret' },
+      orchestrator: {
+        syncAllFromDb: vi.fn(),
+        getAllTasks: vi.fn(() => tasks),
+      } as unknown as Orchestrator,
+      persistence: {
+        listWorkflows: vi.fn(() => workflows),
+        getActivityLogs: vi.fn(() => []),
+        writeActivityLog: vi.fn(),
+        listTerminalSessions: vi.fn(() => []),
+        loadTask: vi.fn(() => undefined),
+        deleteTerminalSession: vi.fn(),
+        updateTerminalSession: vi.fn(),
+        upsertTerminalSession: vi.fn(),
+      } as unknown as SQLiteAdapter,
+    });
+
+    const result = startHeadlessWebSurface(deps);
+    const dispatch = mocks.startWebBridge.mock.calls[0]?.[0].dispatch as (
+      channel: string,
+      args: unknown[],
+    ) => Promise<unknown>;
+
+    await expect(dispatch('invoker:refresh-task-graph', [])).resolves.toBeUndefined();
+    expect(deps.orchestrator.syncAllFromDb).toHaveBeenCalledTimes(1);
+    expect(deps.orchestrator.getAllTasks).toHaveBeenCalledTimes(1);
+    expect(deps.persistence.listWorkflows).toHaveBeenCalledTimes(1);
+    expect(mocks.bridgeBroadcast).toHaveBeenCalledWith(
+      'invoker:task-graph-event',
+      expect.objectContaining({
+        type: 'snapshot',
+        reason: 'refresh-task-graph',
+        tasks,
+        workflows,
+        forced: true,
+      }),
+    );
+
+    await result?.close();
+  });
+
   it('keeps browser task terminals disabled when terminal deps are absent', async () => {
     const deps = makeDeps({ config: { webToken: 'secret' } });
 

--- a/packages/app/src/refresh-task-graph.ts
+++ b/packages/app/src/refresh-task-graph.ts
@@ -22,6 +22,10 @@ export interface ResolveRefreshTaskGraphSnapshotDeps {
   persistence: Pick<SQLiteAdapter, 'listWorkflows'>;
   logger: Logger;
 }
+export interface RefreshTaskGraphSnapshotPublisher {
+  publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[], forced?: boolean): void;
+}
+
 
 function parseDelegatedRefreshTaskGraphSnapshot(
   value: unknown,
@@ -81,4 +85,11 @@ export async function resolveRefreshTaskGraphSnapshot(
     );
     return readLocalSnapshot();
   }
+}
+export function publishForcedRefreshTaskGraphSnapshot(
+  publisher: RefreshTaskGraphSnapshotPublisher,
+  reason: string,
+  snapshot: RefreshTaskGraphSnapshot,
+): void {
+  publisher.publishSnapshot(reason, snapshot.tasks, snapshot.workflows, true);
 }

--- a/packages/app/src/web/start-web-surface.ts
+++ b/packages/app/src/web/start-web-surface.ts
@@ -15,7 +15,6 @@
 import type {
   BundledSkillsStatus,
   Logger,
-  WorkflowMeta,
 } from '@invoker/contracts';
 import { Channels, type MessageBus } from '@invoker/transport';
 import type { SQLiteAdapter } from '@invoker/data-store';
@@ -40,6 +39,7 @@ import {
 } from '../task-terminal-adapter.js';
 import { createTaskGraphEventPublisher } from '../task-graph-event-publisher.js';
 import { createTaskDeltaStreamSequence } from '../task-delta-stream-sequence.js';
+import { publishForcedRefreshTaskGraphSnapshot } from '../refresh-task-graph.js';
 import {
   createTerminalUiPerfCounters,
   createTerminalUiPerfReporter,
@@ -181,13 +181,12 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
   const refreshTaskGraph = async (): Promise<void> => {
     deps.orchestrator.syncAllFromDb();
     const tasks = deps.orchestrator.getAllTasks();
+    const workflows = deps.persistence.listWorkflows();
     projection.replaceAll(tasks);
-    publisher.publishSnapshot(
-      'refresh-task-graph',
+    publishForcedRefreshTaskGraphSnapshot(publisher, 'refresh-task-graph', {
       tasks,
-      deps.persistence.listWorkflows() as WorkflowMeta[],
-      true,
-    );
+      workflows,
+    });
   };
 
   const dispatch = buildWebInvokerDispatch({


### PR DESCRIPTION
## Summary

Manual Refresh now routes web refresh publishing through one forced-snapshot helper.

That keeps forced manual refresh events consistent before other surfaces reuse the helper.

This standalone master slice carries the focused app change from #6620.

## Review Claim

The web manual-refresh route now emits forced task-graph snapshots through the shared helper.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only user-initiated refresh snapshots get the forced flag. Live delta ordering, automatic snapshots, and queue semantics stay unchanged.

## Slice Rationale

The helper and web refresh route are the shared foundation for follow-up desktop refresh wiring, so they land as one routing slice.

## Non-goals

- No desktop IPC refresh changes.
- No scheduler or task-execution changes.
- No change to automatic task-graph snapshots or delta batching.

## Architecture

### Before

Manual web refresh called the task-graph publisher directly and passed the forced flag inline.

### After

Manual web refresh publishes through `publishForcedRefreshTaskGraphSnapshot`, which centralizes the forced snapshot call.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/refresh-task-graph.test.ts src/__tests__/start-web-surface.test.ts`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .pr-body-6809.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 25d9c2c5b7c207c6b7dc847e8791a07ba09b4042`
- Post-revert steps: None
- Data migration? No

</details>
