### PR TITLE
[Rehome vs decomposition skill fix](1) docs

### DIFF
--- a/skills/plan-to-invoker/fixtures/positive/09-package-rehome-atomic-move.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/09-package-rehome-atomic-move.yaml
@@ -1,0 +1,87 @@
+# Positive fixture: Atomic package rehome for an already-cohesive unit
+# Source: review-compression.md Rehome / Relocation Refactors
+# Pattern: move plus old-path removal in one slice, avoiding duplicate live logic
+
+name: "Package rehome atomic move"
+description: |
+  Demonstrates the corrected rehome pattern for an already-cohesive unit:
+  the old path is removed in the same task that creates the new home, rather
+  than being left as a separately editable duplicate for a later slice.
+onFinish: pull_request
+mergeMode: external_review
+repoUrl: git@github.com:example-org/acme-repo.git
+baseBranch: master
+featureBranch: plan/package-rehome-atomic-move
+
+tasks:
+  - id: rehome-legacy-widget-sync-into-package
+    description: |
+      Review claim:
+      - Move legacy widget sync from `scripts/legacy-widget-sync.py` to `packages/widget-sync/legacy_widget_sync.py`; no logic change.
+      Review lane:
+      - policy
+      Safety invariant:
+      - The slice leaves one source of truth for legacy widget sync logic, with the old path removed in the same task as the new package home.
+      Slice rationale:
+      - A pure rehome is one location transformation, so keeping create and removal together avoids a duplicate-logic drift window.
+      Architectural effect:
+      - Legacy widget sync lives under the package path while behavior and runtime architecture stay unchanged.
+      Goal:
+      - Rehome the already-cohesive legacy widget sync script into the widget-sync package atomically.
+      Motivation:
+      - Avoid silently losing a hotfix made to the old copy before a delayed removal slice lands.
+      Alternative considerations:
+      - Option A (chosen): land the atomic move in one slice, with the old script path removed and the package path created together.
+      - Option B (rejected): copy the script now and remove the old path later in a separate slice, because that risks silently losing a hotfix made to the old copy before deletion.
+      Implementation details:
+      - Use a git-mv-shaped relocation from the legacy script path to the package module path, preserving logic and making only import-path fixups required by the new location.
+      - Keep directly affected tests or fixture references with this same slice.
+      Non-goals:
+      - Do not split symbols into new modules, change behavior, add fields, or leave a forwarding shim because the caller set is small enough to repoint now.
+      Layer: docs
+      Feature state: active
+      Files:
+      - `scripts/legacy-widget-sync.py`
+      - `packages/widget-sync/legacy_widget_sync.py`
+      Change types:
+      - `scripts/legacy-widget-sync.py`: delete
+      - `packages/widget-sync/legacy_widget_sync.py`: create
+      Acceptance criteria:
+      - The old path and new path are changed in the same task, and no duplicate live implementation remains.
+      - Pass condition: the plan-level fixture validation exits 0.
+    prompt: |
+      Review claim:
+      - Move legacy widget sync from `scripts/legacy-widget-sync.py` to `packages/widget-sync/legacy_widget_sync.py`; no logic change.
+      Review lane:
+      - policy
+      Safety invariant:
+      - The slice leaves one source of truth for legacy widget sync logic, with the old path removed in the same task as the new package home.
+      Slice rationale:
+      - A pure rehome is one location transformation, so keeping create and removal together avoids a duplicate-logic drift window.
+      Architectural effect:
+      - Legacy widget sync lives under the package path while behavior and runtime architecture stay unchanged.
+      Goal:
+      - Rehome the already-cohesive legacy widget sync script into the widget-sync package atomically.
+      Motivation:
+      - Avoid silently losing a hotfix made to the old copy before a delayed removal slice lands.
+      Alternative considerations:
+      - Option A (chosen): land the atomic move in one slice, with the old script path removed and the package path created together.
+      - Option B (rejected): copy the script now and remove the old path later in a separate slice, because that risks silently losing a hotfix made to the old copy before deletion.
+      Implementation details:
+      - Assume no prior context. Rehome `scripts/legacy-widget-sync.py` to `packages/widget-sync/legacy_widget_sync.py` as one atomic move.
+      - Preserve the moved file's logic and make only import-path fixups required by the new location.
+      - Update directly affected tests or fixture references in the same slice.
+      Non-goals:
+      - Do not split symbols into new modules, change behavior, add fields, or leave a forwarding shim because the caller set is small enough to repoint now.
+      Layer: docs
+      Feature state: active
+      Files:
+      - `scripts/legacy-widget-sync.py`
+      - `packages/widget-sync/legacy_widget_sync.py`
+      Change types:
+      - `scripts/legacy-widget-sync.py`: delete
+      - `packages/widget-sync/legacy_widget_sync.py`: create
+      Acceptance criteria:
+      - The old path and new path are changed in the same task, and no duplicate live implementation remains.
+      - Pass condition: the plan-level fixture validation exits 0.
+    dependencies: []

--- a/skills/plan-to-invoker/references/examples.md
+++ b/skills/plan-to-invoker/references/examples.md
@@ -60,6 +60,18 @@ Complex plan with diamond dependencies. Uses `onFinish: pull_request` for manual
 
 All anti-patterns are validated by `scripts/test-fixtures.sh` with deterministic error detection.
 
+**Narrative anti-pattern (no fixture — see rationale in
+review-compression's Rehome / Relocation Refactors section):**
+relocating an already-cohesive package by copying it into a new location in
+one PR (zero deletions), leaving the old copy live and independently
+editable, and deleting the old copy only in a much later, disconnected PR.
+This looks like a smaller version of the Decomposition & Extraction
+Refactors sequence but is a misapplication of it: nothing is being split,
+so there is no reason to defer the deletion, and doing so creates a window
+where a hotfix to the old copy can be silently lost when it is later
+deleted. Land the move (and its deletion, or a same-slice forwarding shim)
+atomically instead.
+
 ---
 
 ## 6. Delegation hints and bugfix repro

--- a/skills/plan-to-invoker/references/task-patterns.md
+++ b/skills/plan-to-invoker/references/task-patterns.md
@@ -110,7 +110,11 @@ surface stable; the next symbol is the next workflow. Move a private helper the
 symbol depends on only when splitting them would break the build. A file that
 yields six extracted symbols is six chained workflows, not one "extract phases"
 task. See the **Decomposition & Extraction Refactors** section of
-`../review-compression/SKILL.md`.
+`../review-compression/SKILL.md`. This applies to decomposition only. A pure
+rehome of an already-cohesive file or package — no splitting, no new modules —
+lands as one workflow: the move (and its deletion, or a same-workflow
+forwarding shim when callers can't all move at once) in the same slice. See the
+**Rehome / Relocation Refactors** section of `../review-compression/SKILL.md`.
 
 ### Cross-layer direction
 

--- a/skills/review-compression/SKILL.md
+++ b/skills/review-compression/SKILL.md
@@ -62,6 +62,9 @@ require user confirmation.
   later.
 - Activate one surface or path per diff.
 - Delete after migration, in a separate deletion slice as soon as safely unused.
+  Exception: a pure rehome/relocation of an already-cohesive unit (no
+  decomposition) deletes the old path in the SAME slice as the move — see
+  Rehome / Relocation Refactors.
 
 ## Boundary Rules
 
@@ -106,6 +109,14 @@ Split changes when they introduce a different claim:
 - multiple distinct extractions from one file (one top-level symbol move per slice)
 
 ## Decomposition & Extraction Refactors
+
+This section covers decomposition only: splitting ONE file's symbols across
+multiple NEW modules. If the work is instead relocating an already-cohesive,
+self-contained unit (a whole file, or a whole package/directory that is not
+being split further) to a new location with the content materially
+unchanged, skip to **Rehome / Relocation Refactors** below. Sequencing a pure
+move the way this section sequences decomposition creates a long-lived
+duplicate-logic drift window — see that section's rationale.
 
 When you split a large file by extracting units into new modules, do one
 refactor at a time: one PR moves exactly ONE top-level symbol. A function move
@@ -154,6 +165,115 @@ behavior-preserving steps (compile-test-commit each); Beck, *Tidy First?* —
 keep structural changes isolated from behavioral ones, each in its own
 PR/commit; industry guidance (Graphite, Artsy) — one module/class per PR keeps
 diffs near the 50–200 line review sweet spot.
+
+## Rehome / Relocation Refactors
+
+A rehome moves an already-cohesive unit — a whole file, or a whole
+package/directory that is not being split further — to a new location with
+its content materially unchanged: no new modules are created, no symbol is
+split out, and the change is git-mv-shaped (`git diff --stat` renders as a
+rename, not an unrelated add+delete pair). This is a different job from
+Decomposition & Extraction Refactors above: decomposition is N distinct
+transformations (N claims, N seams); a rehome is exactly ONE transformation
+(the location). Treating a rehome as a decomposition stack — copy now,
+repoint later, delete much later in a disconnected slice — is a
+misapplication of that guidance, not a smaller version of it.
+
+### Is it a rehome or a decomposition?
+
+Rehome (this section) when ALL of:
+
+- the moved unit keeps its existing internal structure; no top-level symbol
+  is being extracted into a module that didn't exist before
+- `git mv <old path> <new path>` (or the directory equivalent) produces the
+  diff — content is byte-for-byte identical apart from import-path fixups
+- exactly one new home is created, not several
+
+Decomposition (previous section) when ANY of:
+
+- the file's symbols are being split across two or more new modules
+- the move changes internal structure (function/class boundaries) beyond
+  import-path updates
+- there is no single git-mv-shaped diff that captures the change — the
+  change is inherently a rewrite, not a move
+
+### Core rule: land the move as one slice, not copy-then-delete-later
+
+Decomposition's `create → repoint → delete` sequence is safe because each
+step reviews a genuinely different transformation. A rehome has no such
+internal seam — the code itself hasn't changed, only its address. Splitting
+a rehome the same way creates two independently-editable copies of the same
+logic with only one of them live. If anyone hotfixes the old copy before the
+deletion slice lands, that fix is invisible in the new copy and is silently
+discarded when the old copy is later deleted — nothing re-diffs the two
+copies before deletion.
+
+Land the rehome as close to atomically as possible:
+
+- **Preferred:** add the new path and delete the old path in the SAME
+  PR/slice — a git-mv-shaped diff. Only deviate from this when the diff is
+  provably too large to review in one slice.
+- If repointing every caller in the same PR is genuinely too large, do not
+  leave the old path as an independently-maintained duplicate. Land the move
+  plus a thin forwarding shim at the old path in that same slice: the old
+  path re-exports/delegates to the new path, so there is only ever ONE
+  source of truth for the logic even though there are temporarily two
+  importable paths. Repoint callers in following slices; delete the shim
+  once the last caller is repointed, in its own final slice — that deletion
+  removes only dead re-export plumbing, never live logic.
+
+Slice shape for one rehome:
+
+- `Review claim:` "Move <unit> from <old path> to <new path>; no logic
+  change." (or, with a shim: "Move <unit> to <new path> and leave a
+  forwarding shim at <old path>; no logic change.")
+- git-mv-shaped diff: add at the new path, delete at the old path, in the
+  same slice — or, when callers can't all move at once, add at the new path
+  and replace the old path's body with a forwarding shim (re-export/delegate
+  only, never duplicated logic) in the same slice
+- update the moved unit's own internal imports so it is self-contained at
+  the new path
+- no logic change in a move slice (Fowler's "two hats" applies here too: a
+  move is not the place to also fix a bug or add a field)
+- keep directly affected tests with the move
+- a shim-removal slice depends only on the callers-repointed slice(s), not
+  unrelated work, and lands as soon as the last caller is repointed
+
+Sequence a rehome stack as:
+
+1. one slice: move the unit (git-mv-shaped) and, only if the full caller set
+   cannot be repointed in the same slice, leave a forwarding shim at the old
+   path in that SAME slice — never leave the old path holding
+   independently-maintained live logic
+2. re-point callers across following slices; the shim keeps them working
+   meanwhile
+3. delete the shim in its own slice once the last caller is repointed — this
+   deletes only re-export plumbing, so there is nothing to lose
+
+Contrast with the Decomposition sequence above: there, step 3 deletes the
+OLD, LIVE implementation — safe only because each extracted unit was
+reviewed as its own transformation first. In a rehome nothing has changed
+except location, so retiring the original must not be deferred past the
+slice that repoints its last caller.
+
+Repo-specific gotcha: `scripts/review-unit-rules.mjs` classifies paths by
+directory convention (for example `scripts/**` as `tooling-policy`), and
+`validateReviewUnitChangedFiles` (wired into `scripts/validate-pr-body.mjs`)
+rejects a PR whose changed files span more than the declared Review Unit.
+When rehoming a file whose old path has a classification, declare the
+Review Unit that matches the OLD path (commonly `tooling-policy` / Review
+lane `policy` for `scripts/**`) unless the new path is independently
+classified the same way — check `classifyReviewUnitsForPath` for both paths
+before authoring the PR body.
+
+Grounding: Fowler, *Refactoring* — "Move File"/"Rename" are catalogued as
+trivial, tool-supported, behavior-preserving moves, distinct from "Extract
+Function"/"Extract Class" (decomposition); Fowler / Newman — Branch by
+Abstraction and the Strangler Fig pattern, where a stable seam (the shim)
+sits in front of code being relocated so there is exactly one live
+implementation at all times, even mid-migration; Beck, *Tidy First?* — a
+move commits no behavior change, so it should not straddle a window where
+the moved thing has two independently-editable homes.
 
 ## PR Body Guidance
 


### PR DESCRIPTION
## Summary

Adds rehome-specific review-compression guidance so pure file/package relocations stop being planned like decomposition work.

The new guidance keeps one source of truth during a relocation through same-slice old-path retirement, or by using a forwarding shim.

It also adds a positive fixture and cross-links the plan-to-invoker references that describe the corrected shape.

## Review Claim

Teach the planning docs to distinguish a pure rehome from decomposition and prove the atomic relocation shape with one positive fixture.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

All changed files are skill docs or a positive fixture under `skills/`. No product code, validator script, CI file, or runtime path changes.

The fixture suite and focused atomicity lint both pass on this branch.

## Slice Rationale

This slice is one conceptual docs update: distinguish rehome from decomposition across the planner guidance and fixture examples.

The make-pr skill pointer is intentionally outside this slice because that file is classified as `tooling-policy`.

## Non-goals

- No product behavior changes.
- No validator or CI changes.
- No changes to `skills/make-pr/SKILL.md`.
- No executable negative fixture for copy-then-delete-later.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash skills/plan-to-invoker/scripts/test-fixtures.sh`
- [x] `bash skills/plan-to-invoker/scripts/lint-task-atomicity.sh skills/plan-to-invoker/fixtures/positive/09-package-rehome-atomic-move.yaml`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/rehome-relocation-skill-fix-docs-pr.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/rehome-relocation-skill-fix-docs-pr.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2a8b1d1e8`
- Post-revert steps: Rerun the fixture suite and focused atomicity lint.
- Data migration? No

</details>
