### PR TITLE
Inline admin-bypass safe push plans

### DIFF
--- a/scripts/cron-admin-bypass-queue.sh
+++ b/scripts/cron-admin-bypass-queue.sh
@@ -158,6 +158,7 @@ while IFS= read -r pr; do
   q_state_file="$(shell_quote "$STATE_FILE")"
   q_num="$(shell_quote "$num")"
   q_fingerprint="$(shell_quote "$fingerprint")"
+  q_tsv_kind="$(shell_quote "queue-attempt")"
 
   plan_file="$PLAN_DIR/repair-pr-$num.yaml"
   {
@@ -190,13 +191,29 @@ while IFS= read -r pr; do
     printf '    dependencies: [repair]\n'
     printf '    command: |\n'
     {
-      printf 'python3 scripts/pr_worker_safe_push.py \\\n'
-      printf '  --branch %s \\\n' "$q_head_ref"
-      printf '  --expected-head %s \\\n' "$q_head_oid"
-      printf '  --record-tsv-ledger %s \\\n' "$q_state_file"
-      printf '  --tsv-kind queue-attempt \\\n'
-      printf '  --tsv-key %s \\\n' "$q_num"
-      printf '  --tsv-marker %s\n' "$q_fingerprint"
+      printf 'set -euo pipefail\n'
+      printf 'branch=%s\n' "$q_head_ref"
+      printf 'expected=%s\n' "$q_head_oid"
+      printf 'ledger=%s\n' "$q_state_file"
+      printf 'kind=%s\n' "$q_tsv_kind"
+      printf 'key=%s\n' "$q_num"
+      printf 'marker=%s\n' "$q_fingerprint"
+      printf 'ref="refs/heads/$branch"\n'
+      printf 'live="$(git ls-remote origin "$ref" | cut -f1)"\n'
+      printf 'if [ "$live" != "$expected" ]; then\n'
+      printf '  echo "stale-head: $ref is ${live:-missing}; expected $expected" >&2\n'
+      printf '  exit 20\n'
+      printf 'fi\n'
+      printf 'pushed="$(git rev-parse HEAD)"\n'
+      printf 'git push --force-with-lease="$ref:$expected" origin "HEAD:$ref"\n'
+      printf 'verified="$(git ls-remote origin "$ref" | cut -f1)"\n'
+      printf 'if [ "$verified" != "$pushed" ]; then\n'
+      printf '  echo "post-push verification failed: $ref is ${verified:-missing}; expected $pushed" >&2\n'
+      printf '  exit 22\n'
+      printf 'fi\n'
+      printf 'mkdir -p "$(dirname "$ledger")"\n'
+      printf 'printf '"'"'%%s\\t%%s\\t%%s\\t%%s\\n'"'"' "$kind" "$key" "$marker" "$(date +%%s)" >> "$ledger"\n'
+      printf 'echo "pr-worker-safe-push: pushed $ref to $pushed"\n'
     } | sed 's/^/      /'
   } > "$plan_file"
 

--- a/scripts/cron-pr-orphan-repair.sh
+++ b/scripts/cron-pr-orphan-repair.sh
@@ -123,6 +123,7 @@ while IFS= read -r pr; do
   q_state_file="$(shell_quote "$STATE_FILE")"
   q_num="$(shell_quote "$num")"
   q_fingerprint="$(shell_quote "$fingerprint")"
+  q_tsv_kind="$(shell_quote "orphan-attempt")"
 
   plan_file="$PLAN_DIR/repair-pr-$num.yaml"
   {
@@ -157,13 +158,29 @@ while IFS= read -r pr; do
     printf '    dependencies: [repair]\n'
     printf '    command: |\n'
     {
-      printf 'python3 scripts/pr_worker_safe_push.py \\\n'
-      printf '  --branch %s \\\n' "$q_head_ref"
-      printf '  --expected-head %s \\\n' "$q_head_oid"
-      printf '  --record-tsv-ledger %s \\\n' "$q_state_file"
-      printf '  --tsv-kind orphan-attempt \\\n'
-      printf '  --tsv-key %s \\\n' "$q_num"
-      printf '  --tsv-marker %s\n' "$q_fingerprint"
+      printf 'set -euo pipefail\n'
+      printf 'branch=%s\n' "$q_head_ref"
+      printf 'expected=%s\n' "$q_head_oid"
+      printf 'ledger=%s\n' "$q_state_file"
+      printf 'kind=%s\n' "$q_tsv_kind"
+      printf 'key=%s\n' "$q_num"
+      printf 'marker=%s\n' "$q_fingerprint"
+      printf 'ref="refs/heads/$branch"\n'
+      printf 'live="$(git ls-remote origin "$ref" | cut -f1)"\n'
+      printf 'if [ "$live" != "$expected" ]; then\n'
+      printf '  echo "stale-head: $ref is ${live:-missing}; expected $expected" >&2\n'
+      printf '  exit 20\n'
+      printf 'fi\n'
+      printf 'pushed="$(git rev-parse HEAD)"\n'
+      printf 'git push --force-with-lease="$ref:$expected" origin "HEAD:$ref"\n'
+      printf 'verified="$(git ls-remote origin "$ref" | cut -f1)"\n'
+      printf 'if [ "$verified" != "$pushed" ]; then\n'
+      printf '  echo "post-push verification failed: $ref is ${verified:-missing}; expected $pushed" >&2\n'
+      printf '  exit 22\n'
+      printf 'fi\n'
+      printf 'mkdir -p "$(dirname "$ledger")"\n'
+      printf 'printf '"'"'%%s\\t%%s\\t%%s\\t%%s\\n'"'"' "$kind" "$key" "$marker" "$(date +%%s)" >> "$ledger"\n'
+      printf 'echo "pr-worker-safe-push: pushed $ref to $pushed"\n'
     } | sed 's/^/      /'
   } > "$plan_file"
 

--- a/scripts/repro/repro-admin-bypass-queue.sh
+++ b/scripts/repro/repro-admin-bypass-queue.sh
@@ -94,8 +94,8 @@ grep -q "^repoUrl: https://github.com/fake/repo.git$" "$plan902" \
 grep -q "^onFinish: none$" "$plan902" || fail "plan902: must not open its own PR" "$(cat "$plan902")"
 grep -q "Blocker category: failed_checks" "$plan902" || fail "plan902: wrong category" "$(cat "$plan902")"
 grep -q "id: safe-push" "$plan902" || fail "plan902: missing safe-push task" "$(cat "$plan902")"
-grep -q "python3 scripts/pr_worker_safe_push.py" "$plan902" || fail "plan902: missing safe-push helper command" "$(cat "$plan902")"
-grep -q -- "--tsv-kind queue-attempt" "$plan902" || fail "plan902: safe-push must own queue-attempt recording" "$(cat "$plan902")"
+grep -q "git push --force-with-lease" "$plan902" || fail "plan902: missing guarded safe-push command" "$(cat "$plan902")"
+grep -q "kind='queue-attempt'" "$plan902" || fail "plan902: safe-push must own queue-attempt recording" "$(cat "$plan902")"
 grep -q "Do not push" "$plan902" || fail "plan902: repair prompt must forbid direct pushes" "$(cat "$plan902")"
 
 plan903="$TMP/plans/repair-pr-903.yaml"

--- a/scripts/repro/repro-pr-orphan-repair.sh
+++ b/scripts/repro/repro-pr-orphan-repair.sh
@@ -77,8 +77,8 @@ grep -q "2. failed_checks: Unit Tests" "$plan" || fail "plan: failing check must
 grep -q "3. changes_requested:" "$plan" || fail "plan: review feedback must be blocker #3" "$(cat "$plan")"
 grep -q "git fetch origin feature/orphan-801" "$plan" || fail "plan: must target the existing PR branch" "$(cat "$plan")"
 grep -q "id: safe-push" "$plan" || fail "plan: missing safe-push task" "$(cat "$plan")"
-grep -q "python3 scripts/pr_worker_safe_push.py" "$plan" || fail "plan: missing safe-push helper command" "$(cat "$plan")"
-grep -q -- "--tsv-kind orphan-attempt" "$plan" || fail "plan: safe-push must own orphan-attempt recording" "$(cat "$plan")"
+grep -q "git push --force-with-lease" "$plan" || fail "plan: missing guarded safe-push command" "$(cat "$plan")"
+grep -q "kind='orphan-attempt'" "$plan" || fail "plan: safe-push must own orphan-attempt recording" "$(cat "$plan")"
 grep -q "Do not push" "$plan" || fail "plan: repair prompt must forbid direct pushes" "$(cat "$plan")"
 awk -F '\t' '$1 == "orphan-attempt" && $2 == "801" { found=1 } END { exit found ? 0 : 1 }' "$TMP/ledger.tsv" \
   && fail "tick 1: submission must not record orphan-attempt" "$(cat "$TMP/ledger.tsv")"


### PR DESCRIPTION
## Summary
- make admin-bypass and orphan repair safe-push tasks self-contained
- keep the existing force-with-lease and post-push verification guards
- update focused repro assertions for the inline guarded push command

## Tests
- bash scripts/repro/repro-admin-bypass-queue.sh
- bash scripts/repro/repro-pr-orphan-repair.sh
- git diff --check -- scripts/cron-admin-bypass-queue.sh scripts/cron-pr-orphan-repair.sh scripts/repro/repro-admin-bypass-queue.sh scripts/repro/repro-pr-orphan-repair.sh
