### PR TITLE
[UI Task State](1) Share runtime task status values

### DIFF
--- a/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
+++ b/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
@@ -15,6 +15,7 @@ describe('workflow rollup', () => {
   it.each([
     { name: 'no tasks', statuses: [], expected: 'pending' },
     { name: 'all pending', statuses: ['pending'], expected: 'pending' },
+    { name: 'queued task', statuses: ['queued'], expected: 'running' },
     { name: 'running task', statuses: ['pending', 'running'], expected: 'running' },
     { name: 'fixing task', statuses: ['running', 'fixing_with_ai'], expected: 'fixing_with_ai' },
     { name: 'awaiting approval', statuses: ['completed', 'awaiting_approval'], expected: 'awaiting_approval' },

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -7,19 +7,22 @@
 
 // ── Task Status FSM ─────────────────────────────────────────
 
-export type TaskStatus =
-  | 'pending'
-  | 'queued'
-  | 'running'
-  | 'fixing_with_ai'
-  | 'completed'
-  | 'failed'
-  | 'closed'
-  | 'needs_input'
-  | 'blocked'
-  | 'review_ready'
-  | 'awaiting_approval'
-  | 'stale';
+export const TASK_STATUSES = [
+  'pending',
+  'queued',
+  'running',
+  'fixing_with_ai',
+  'completed',
+  'failed',
+  'closed',
+  'needs_input',
+  'blocked',
+  'review_ready',
+  'awaiting_approval',
+  'stale',
+] as const;
+
+export type TaskStatus = typeof TASK_STATUSES[number];
 // ── Task Config (definition / spec) ────────────────────────
 // Copied wholesale when cloning/forking: clone.config = original.config
 

--- a/packages/workflow-graph/src/workflow-rollup.ts
+++ b/packages/workflow-graph/src/workflow-rollup.ts
@@ -1,4 +1,4 @@
-import type { TaskState, TaskStatus } from './types.js';
+import { TASK_STATUSES, type TaskState, type TaskStatus } from './types.js';
 
 export type WorkflowDerivedStatus =
   | 'pending'
@@ -57,20 +57,6 @@ export interface WorkflowRollupTaskSummary {
     isFixingWithAI?: boolean;
   };
 }
-
-export const TASK_STATUSES: readonly TaskStatus[] = [
-  'pending',
-  'running',
-  'fixing_with_ai',
-  'completed',
-  'failed',
-  'closed',
-  'needs_input',
-  'blocked',
-  'review_ready',
-  'awaiting_approval',
-  'stale',
-];
 
 export function createEmptyWorkflowTaskStatusCounts(): WorkflowTaskStatusCounts {
   return Object.fromEntries(TASK_STATUSES.map((status) => [status, 0])) as WorkflowTaskStatusCounts;


### PR DESCRIPTION
## Summary

Workflow graph now exports the runtime task status set next to the `TaskStatus` type.

`queued` is part of that set, so rollups allocate a numeric bucket for it.

## Review Claim

Approve the task status runtime contract used by workflow graph consumers.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The exported values match the existing status union plus `queued`. Rollup counts now initialize the queued bucket before any updates arrive.

## Slice Rationale

This lower package change lands first so downstream packages can import one runtime status source.

## Non-goals

- Does not change task scheduling.
- Does not change Electron or UI behavior.
- Does not change persistence.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-graph test -- src/__tests__/workflow-rollup.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 99b4add24`
- Post-revert steps: Revert dependent stack slices first if they have landed.
- Data migration? No

</details>
