### PR TITLE
[UI Task State](2) Treat queued tasks as live

### DIFF
--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -450,6 +450,7 @@ export function descriptionForMergeNode(plan: Pick<PlanDefinition, 'name' | 'onF
  */
 const LIVE_TASK_STATUSES = new Set<string>([
   'pending',
+  'queued',
   'running',
   'fixing_with_ai',
   'needs_input',

--- a/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
+++ b/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
@@ -15,6 +15,7 @@ describe('workflow rollup', () => {
   it.each([
     { name: 'no tasks', statuses: [], expected: 'pending' },
     { name: 'all pending', statuses: ['pending'], expected: 'pending' },
+    { name: 'queued task', statuses: ['queued'], expected: 'running' },
     { name: 'running task', statuses: ['pending', 'running'], expected: 'running' },
     { name: 'fixing task', statuses: ['running', 'fixing_with_ai'], expected: 'fixing_with_ai' },
     { name: 'awaiting approval', statuses: ['completed', 'awaiting_approval'], expected: 'awaiting_approval' },

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -7,19 +7,22 @@
 
 // ── Task Status FSM ─────────────────────────────────────────
 
-export type TaskStatus =
-  | 'pending'
-  | 'queued'
-  | 'running'
-  | 'fixing_with_ai'
-  | 'completed'
-  | 'failed'
-  | 'closed'
-  | 'needs_input'
-  | 'blocked'
-  | 'review_ready'
-  | 'awaiting_approval'
-  | 'stale';
+export const TASK_STATUSES = [
+  'pending',
+  'queued',
+  'running',
+  'fixing_with_ai',
+  'completed',
+  'failed',
+  'closed',
+  'needs_input',
+  'blocked',
+  'review_ready',
+  'awaiting_approval',
+  'stale',
+] as const;
+
+export type TaskStatus = typeof TASK_STATUSES[number];
 // ── Task Config (definition / spec) ────────────────────────
 // Copied wholesale when cloning/forking: clone.config = original.config
 

--- a/packages/workflow-graph/src/workflow-rollup.ts
+++ b/packages/workflow-graph/src/workflow-rollup.ts
@@ -1,4 +1,4 @@
-import type { TaskState, TaskStatus } from './types.js';
+import { TASK_STATUSES, type TaskState, type TaskStatus } from './types.js';
 
 export type WorkflowDerivedStatus =
   | 'pending'
@@ -57,20 +57,6 @@ export interface WorkflowRollupTaskSummary {
     isFixingWithAI?: boolean;
   };
 }
-
-export const TASK_STATUSES: readonly TaskStatus[] = [
-  'pending',
-  'running',
-  'fixing_with_ai',
-  'completed',
-  'failed',
-  'closed',
-  'needs_input',
-  'blocked',
-  'review_ready',
-  'awaiting_approval',
-  'stale',
-];
 
 export function createEmptyWorkflowTaskStatusCounts(): WorkflowTaskStatusCounts {
   return Object.fromEntries(TASK_STATUSES.map((status) => [status, 0])) as WorkflowTaskStatusCounts;


### PR DESCRIPTION
## Summary

The orchestrator now treats `queued` as live work when checking active task state.

That keeps queued tasks from being ignored by live-task predicates.

## Review Claim

Approve the routing update that treats `queued` tasks as active work.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This only adds one status to the live-task set. Existing live statuses keep the same behavior.

## Slice Rationale

This depends on the shared status foundation and stays separate from app recovery behavior.

## Non-goals

- Does not change queue ordering.
- Does not change task mutation behavior.
- Does not change UI rendering.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2c780299f`
- Post-revert steps: None
- Data migration? No

</details>
