### PR TITLE
[UI Task State](4) Keep detached task feed gaps visible

### DIFF
--- a/packages/app/src/__tests__/delta-merge.test.ts
+++ b/packages/app/src/__tests__/delta-merge.test.ts
@@ -17,6 +17,9 @@ import { describe, it, expect } from 'vitest';
 import {
   applyDelta,
   recoverQuarantinedTask,
+  recoveryFound,
+  recoveryMissing,
+  recoveryUnavailable,
   resolveQuarantine,
   TaskSnapshotCache,
 } from '../delta-merge.js';
@@ -420,8 +423,14 @@ function simulateMainProcessDeltaHandler(
   }
   for (const taskId of quarantined) {
     const { rendererDelta } = recoverQuarantinedTask(cache, taskId, {
-      loadTask: persistence.loadTask,
-      getMergeNode: orchestrator.getMergeNode,
+      loadTask: (id) => {
+        const task = persistence.loadTask(id);
+        return task ? recoveryFound(task) : recoveryMissing();
+      },
+      getMergeNode: (workflowId) => {
+        const task = orchestrator.getMergeNode(workflowId);
+        return task ? recoveryFound(task) : recoveryMissing();
+      },
     });
     if (rendererDelta) {
       rendererDeltas.push(rendererDelta);
@@ -483,6 +492,57 @@ describe('gap recovery: unknown task → quarantine + authoritative reload', () 
     const [first] = rendererDeltas;
     expect(first.type).toBe('removed');
     expect((first as { type: 'removed'; taskId: string }).taskId).toBe('ghost');
+  });
+
+  it('unknown task with unavailable local read does not emit removed', () => {
+    const cache = new TaskSnapshotCache();
+
+    const delta: TaskDelta = {
+      type: 'updated',
+      taskId: 'detached-task',
+      changes: { status: 'completed' },
+      taskStateVersion: 2,
+      previousTaskStateVersion: 1,
+    };
+
+    const { quarantined } = applyDelta(delta, cache);
+    expect(quarantined).toEqual(['detached-task']);
+
+    const recovery = recoverQuarantinedTask(cache, 'detached-task', {
+      loadTask: () => recoveryUnavailable('read-only-viewer'),
+      getMergeNode: () => recoveryUnavailable('read-only-viewer'),
+    });
+
+    expect(recovery.outcome).toBe('unavailable');
+    expect(recovery.rendererDelta).toBeUndefined();
+    expect(cache.has('detached-task')).toBe(false);
+  });
+
+  it('version gap with unavailable local read keeps stale entry quarantined', () => {
+    const cache = new TaskSnapshotCache();
+    cache.set('detached-task', JSON.stringify(makeTask('detached-task', {
+      status: 'running',
+      taskStateVersion: 2,
+    })));
+
+    const { quarantined } = applyDelta({
+      type: 'updated',
+      taskId: 'detached-task',
+      changes: { status: 'completed' },
+      taskStateVersion: 5,
+      previousTaskStateVersion: 4,
+    }, cache);
+    expect(quarantined).toEqual(['detached-task']);
+
+    const recovery = recoverQuarantinedTask(cache, 'detached-task', {
+      loadTask: () => recoveryUnavailable('read-only-viewer'),
+      getMergeNode: () => recoveryUnavailable('read-only-viewer'),
+    });
+
+    expect(recovery.outcome).toBe('unavailable');
+    expect(recovery.rendererDelta).toBeUndefined();
+    expect(cache.has('detached-task')).toBe(true);
+    expect(cache.isQuarantined('detached-task')).toBe(true);
   });
 });
 

--- a/packages/app/src/__tests__/dispatch-capacity-invariants.test.ts
+++ b/packages/app/src/__tests__/dispatch-capacity-invariants.test.ts
@@ -8,7 +8,13 @@ import { InMemoryBus } from '@invoker/test-kit';
 import { Orchestrator, type PlanDefinition, type TaskDelta, type TaskState } from '@invoker/workflow-core';
 import { LaunchDispatcher } from '../launch-dispatcher.js';
 import { taskNeedsExecutingStallCheck } from '../executing-stall.js';
-import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from '../delta-merge.js';
+import {
+  applyDelta,
+  recoverQuarantinedTask,
+  recoveryFound,
+  recoveryMissing,
+  TaskSnapshotCache,
+} from '../delta-merge.js';
 import { WorkflowRollupProjection } from '../workflow-rollup-projection.js';
 
 function makeTask(
@@ -273,11 +279,15 @@ describe('dispatch capacity invariants', () => {
     expect(removePatches).toHaveLength(1);
 
     const recovery = recoverQuarantinedTask(cache, 'wf-2/b', {
-      loadTask: (taskId) => persisted.get(taskId),
-      getMergeNode: () => undefined,
+      loadTask: (taskId) => {
+        const task = persisted.get(taskId);
+        return task ? recoveryFound(task) : recoveryMissing();
+      },
+      getMergeNode: () => recoveryMissing(),
     });
     expect(recovery.rendererDelta).toEqual({ type: 'created', task: persisted.get('wf-2/b')! });
-    const recoveryPatches = projection.applyDelta(recovery.rendererDelta);
+    expect(recovery.rendererDelta).toBeDefined();
+    const recoveryPatches = projection.applyDelta(recovery.rendererDelta!);
     expect(recoveryPatches).toHaveLength(1);
     expect(cache.isQuarantined('wf-2/b')).toBe(false);
 

--- a/packages/app/src/__tests__/lifecycle-events.test.ts
+++ b/packages/app/src/__tests__/lifecycle-events.test.ts
@@ -105,6 +105,23 @@ describe('lifecycle event helpers', () => {
     expectRecoveryWakeup(event, { reason: 'task_lifecycle' });
   });
 
+  it('accepts queued as a valid task lifecycle status', () => {
+    const event = buildTaskUpdatedLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-a',
+      status: 'queued',
+      previousStatus: 'pending',
+      taskStateVersion: 2,
+      generation: 4,
+      attemptId: 'attempt-2',
+      createdAt: CREATED_AT_DATE,
+    });
+
+    expect(event.kind).toBe('task.updated');
+    expect(isWorkflowLifecycleEvent(event)).toBe(true);
+    expectRecoveryWakeup(event, { reason: 'task_lifecycle' });
+  });
+
   it('maps completed and failed status updates to worker lifecycle kinds', () => {
     expect(lifecycleEventKindForTaskStatus('completed')).toBe('task.completed');
     expect(lifecycleEventKindForTaskStatus('failed')).toBe('task.failed');

--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -152,6 +152,7 @@ describe('buildOwnerReadQueryHandlers', () => {
         getQueueStatus: () => ({ q: 1 }),
         getWorkflowStatus: () => ({ w: 1 }),
         getAllTasks: () => [{ id: 't' }],
+        getMergeNode: (workflowId: string) => ({ id: `__merge__${workflowId}` }),
         syncAllFromDb: vi.fn(),
         syncFromDb: vi.fn(),
       },
@@ -205,6 +206,22 @@ describe('buildOwnerReadQueryHandlers', () => {
       limit: 1,
       offset: 2,
       hasMore: false,
+    });
+  });
+
+  it('resolves synthetic merge nodes from orchestrator memory', () => {
+    const h = build({
+      getAllTasks: () => [],
+      getMergeNode: (workflowId: string) => (
+        workflowId === 'wf-1' ? { id: '__merge__wf-1', config: { workflowId, isMergeNode: true } } : undefined
+      ),
+    }, {
+      loadTask: () => undefined,
+    });
+
+    expect(h.getTaskById('__merge__wf-1')).toEqual({
+      id: '__merge__wf-1',
+      config: { workflowId: 'wf-1', isMergeNode: true },
     });
   });
 

--- a/packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts
+++ b/packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts
@@ -39,6 +39,8 @@ import { describe, it, expect } from 'vitest';
 import {
   applyDelta,
   recoverQuarantinedTask,
+  recoveryFound,
+  recoveryMissing,
   TaskSnapshotCache,
   type RecoveryLoaders,
 } from '../delta-merge.js';
@@ -114,9 +116,9 @@ function seedCacheWithMergeNode(version: number): TaskSnapshotCache {
   return cache;
 }
 
-function loadTaskNeverReturnsSynthetic(_id: string): TaskState | undefined {
+function loadTaskNeverReturnsSynthetic(_id: string) {
   // Persistence never holds synthetic merge nodes.
-  return undefined;
+  return recoveryMissing();
 }
 
 function copyCache(source: TaskSnapshotCache): TaskSnapshotCache {
@@ -136,7 +138,7 @@ describe('synthetic __merge__ quarantine-loop repro (graph-blank root cause)', (
     const authoritative = makeMergeNode(WORKFLOW_ID, 4);
     const loaders: RecoveryLoaders = {
       loadTask: loadTaskNeverReturnsSynthetic,
-      getMergeNode: (workflowId) => (workflowId === WORKFLOW_ID ? authoritative : undefined),
+      getMergeNode: (workflowId) => (workflowId === WORKFLOW_ID ? recoveryFound(authoritative) : recoveryMissing()),
     };
 
     const delta: TaskDelta = {
@@ -162,7 +164,7 @@ describe('synthetic __merge__ quarantine-loop repro (graph-blank root cause)', (
     const cache = seedCacheWithMergeNode(2);
     const loaders: RecoveryLoaders = {
       loadTask: loadTaskNeverReturnsSynthetic,
-      getMergeNode: (_workflowId) => undefined,
+      getMergeNode: (_workflowId) => recoveryMissing(),
     };
 
     const delta: TaskDelta = {
@@ -190,7 +192,7 @@ describe('synthetic __merge__ quarantine-loop repro (graph-blank root cause)', (
     const loaders: RecoveryLoaders = {
       loadTask: loadTaskNeverReturnsSynthetic,
       getMergeNode: (workflowId) =>
-        workflowId === WORKFLOW_ID ? makeMergeNode(WORKFLOW_ID, 10) : undefined,
+        workflowId === WORKFLOW_ID ? recoveryFound(makeMergeNode(WORKFLOW_ID, 10)) : recoveryMissing(),
     };
 
     const allRendererDeltas: TaskDelta[] = [];
@@ -240,8 +242,8 @@ describe('synthetic __merge__ quarantine-loop repro (graph-blank root cause)', (
     // removed delta so the renderer's stale entry is cleared.
     const cache = new TaskSnapshotCache();
     const loaders: RecoveryLoaders = {
-      loadTask: (_id) => undefined,
-      getMergeNode: (_workflowId) => undefined,
+      loadTask: (_id) => recoveryMissing(),
+      getMergeNode: (_workflowId) => recoveryMissing(),
     };
 
     const delta: TaskDelta = {

--- a/packages/app/src/delta-merge.ts
+++ b/packages/app/src/delta-merge.ts
@@ -23,10 +23,27 @@ export interface CacheEntry {
   quarantined: boolean;
 }
 
-// ── Authoritative loader (persistence by id) ────────────────
+// ── Authoritative loader (persistence / owner by id) ────────
 
 export interface AuthoritativeTaskLoader {
   loadTask(taskId: string): TaskState | undefined;
+}
+
+export type RecoveryLookupResult =
+  | { kind: 'found'; task: TaskState }
+  | { kind: 'missing' }
+  | { kind: 'unavailable'; reason?: string };
+
+export function recoveryFound(task: TaskState): RecoveryLookupResult {
+  return { kind: 'found', task };
+}
+
+export function recoveryMissing(): RecoveryLookupResult {
+  return { kind: 'missing' };
+}
+
+export function recoveryUnavailable(reason?: string): RecoveryLookupResult {
+  return reason ? { kind: 'unavailable', reason } : { kind: 'unavailable' };
 }
 
 // ── Snapshot cache ───────────────────────────────────────────
@@ -210,23 +227,26 @@ export function resolveQuarantine(
  * Loaders the recovery loop consults to find an authoritative snapshot
  * for a quarantined task id.
  *
- * - `loadTask`: persistence by id. Returns `undefined` for ids that have
- *   never been persisted (notably synthetic merge nodes).
+ * - `loadTask`: persistence/owner lookup by id. `missing` means an
+ *   authoritative owner proved the task is gone; `unavailable` means the caller
+ *   cannot prove existence either way.
  * - `getMergeNode`: orchestrator in-memory lookup by workflowId. Authoritative
  *   source for synthetic `__merge__${workflowId}` ids, which are not stored
  *   in persistence but are tracked in `Orchestrator.stateMachine`.
  */
 export interface RecoveryLoaders {
-  loadTask: (taskId: string) => TaskState | undefined;
-  getMergeNode: (workflowId: string) => TaskState | undefined;
+  loadTask: (taskId: string) => RecoveryLookupResult;
+  getMergeNode: (workflowId: string) => RecoveryLookupResult;
 }
 
 export interface RecoveryResult {
+  outcome: RecoveryLookupResult['kind'];
+  reason?: string;
   /**
    * Renderer-bound delta the caller MUST forward to keep the renderer in
-   * sync with the owner cache. `undefined` only when no cache mutation
-   * happened (currently never — every branch either restores from an
-   * authoritative source or emits `removed`).
+   * sync with the owner cache. `undefined` means no authoritative answer was
+   * available, so the cache was left quarantined instead of deleting a task on
+   * a local/read-only miss.
    */
   rendererDelta?: TaskDelta;
 }
@@ -237,11 +257,13 @@ const SYNTHETIC_MERGE_PREFIX = '__merge__';
  * Single source of truth for the main-process quarantine-recovery loop.
  *
  * Contract — no implicit message drops:
- * - If persistence has the task → restore from persistence, emit `created`.
+ * - If persistence/owner has the task → restore from that source, emit `created`.
  * - Else if it's a synthetic merge id and the orchestrator has it in memory
  *   → restore from orchestrator, emit `created`.
- * - Else (truly absent) → delete the cache entry, emit `removed` so the
- *   renderer drops its stale copy too.
+ * - Else if an authoritative owner proves the task is absent → delete the cache
+ *   entry, emit `removed` so the renderer drops its stale copy too.
+ * - Else → leave the cache quarantined and emit nothing. A local/read-only miss
+ *   is not proof of deletion.
  *
  * This replaces the legacy `if (authoritative) { sendTaskDeltaToRenderer(...) }`
  * pattern that silently dropped the recovery message whenever
@@ -255,23 +277,31 @@ export function recoverQuarantinedTask(
   loaders: RecoveryLoaders,
 ): RecoveryResult {
   const persisted = loaders.loadTask(taskId);
-  if (persisted) {
-    resolveQuarantine(cache, taskId, persisted);
-    return { rendererDelta: { type: 'created', task: persisted } };
+  if (persisted.kind === 'found') {
+    resolveQuarantine(cache, taskId, persisted.task);
+    return { outcome: 'found', rendererDelta: { type: 'created', task: persisted.task } };
   }
 
   if (taskId.startsWith(SYNTHETIC_MERGE_PREFIX)) {
     const workflowId = taskId.slice(SYNTHETIC_MERGE_PREFIX.length);
     const synthetic = loaders.getMergeNode(workflowId);
-    if (synthetic) {
-      resolveQuarantine(cache, taskId, synthetic);
-      return { rendererDelta: { type: 'created', task: synthetic } };
+    if (synthetic.kind === 'found') {
+      resolveQuarantine(cache, taskId, synthetic.task);
+      return { outcome: 'found', rendererDelta: { type: 'created', task: synthetic.task } };
     }
+    if (synthetic.kind === 'unavailable') {
+      return { outcome: 'unavailable', reason: synthetic.reason };
+    }
+  }
+
+  if (persisted.kind === 'unavailable') {
+    return { outcome: 'unavailable', reason: persisted.reason };
   }
 
   const previousTaskStateVersion = cache.getEntry(taskId)?.taskStateVersion ?? 0;
   resolveQuarantine(cache, taskId, undefined);
   return {
+    outcome: 'missing',
     rendererDelta: { type: 'removed', taskId, previousTaskStateVersion },
   };
 }

--- a/packages/app/src/delta-merge.ts
+++ b/packages/app/src/delta-merge.ts
@@ -34,6 +34,8 @@ export type RecoveryLookupResult =
   | { kind: 'missing' }
   | { kind: 'unavailable'; reason?: string };
 
+export type RecoveryLookupValue = TaskState | undefined | RecoveryLookupResult;
+
 export function recoveryFound(task: TaskState): RecoveryLookupResult {
   return { kind: 'found', task };
 }
@@ -44,6 +46,18 @@ export function recoveryMissing(): RecoveryLookupResult {
 
 export function recoveryUnavailable(reason?: string): RecoveryLookupResult {
   return reason ? { kind: 'unavailable', reason } : { kind: 'unavailable' };
+}
+
+function isRecoveryLookupResult(value: RecoveryLookupValue): value is RecoveryLookupResult {
+  return Boolean(value)
+    && typeof value === 'object'
+    && 'kind' in value
+    && (value.kind === 'found' || value.kind === 'missing' || value.kind === 'unavailable');
+}
+
+function normalizeRecoveryLookupResult(value: RecoveryLookupValue): RecoveryLookupResult {
+  if (isRecoveryLookupResult(value)) return value;
+  return value ? recoveryFound(value) : recoveryMissing();
 }
 
 // ── Snapshot cache ───────────────────────────────────────────
@@ -227,16 +241,16 @@ export function resolveQuarantine(
  * Loaders the recovery loop consults to find an authoritative snapshot
  * for a quarantined task id.
  *
- * - `loadTask`: persistence/owner lookup by id. `missing` means an
- *   authoritative owner proved the task is gone; `unavailable` means the caller
- *   cannot prove existence either way.
+ * - `loadTask`: persistence/owner lookup by id. Plain `undefined` and `missing`
+ *   mean an authoritative owner proved the task is gone; `unavailable` means
+ *   the caller cannot prove existence either way.
  * - `getMergeNode`: orchestrator in-memory lookup by workflowId. Authoritative
  *   source for synthetic `__merge__${workflowId}` ids, which are not stored
  *   in persistence but are tracked in `Orchestrator.stateMachine`.
  */
 export interface RecoveryLoaders {
-  loadTask: (taskId: string) => RecoveryLookupResult;
-  getMergeNode: (workflowId: string) => RecoveryLookupResult;
+  loadTask: (taskId: string) => RecoveryLookupValue;
+  getMergeNode: (workflowId: string) => RecoveryLookupValue;
 }
 
 export interface RecoveryResult {
@@ -276,7 +290,7 @@ export function recoverQuarantinedTask(
   taskId: string,
   loaders: RecoveryLoaders,
 ): RecoveryResult {
-  const persisted = loaders.loadTask(taskId);
+  const persisted = normalizeRecoveryLookupResult(loaders.loadTask(taskId));
   if (persisted.kind === 'found') {
     resolveQuarantine(cache, taskId, persisted.task);
     return { outcome: 'found', rendererDelta: { type: 'created', task: persisted.task } };
@@ -284,7 +298,7 @@ export function recoverQuarantinedTask(
 
   if (taskId.startsWith(SYNTHETIC_MERGE_PREFIX)) {
     const workflowId = taskId.slice(SYNTHETIC_MERGE_PREFIX.length);
-    const synthetic = loaders.getMergeNode(workflowId);
+    const synthetic = normalizeRecoveryLookupResult(loaders.getMergeNode(workflowId));
     if (synthetic.kind === 'found') {
       resolveQuarantine(cache, taskId, synthetic.task);
       return { outcome: 'found', rendererDelta: { type: 'created', task: synthetic.task } };

--- a/packages/app/src/lifecycle-events.ts
+++ b/packages/app/src/lifecycle-events.ts
@@ -1,8 +1,9 @@
-import type {
-  TaskDelta,
-  TaskState,
-  TaskStatus,
-  WorkflowDerivedStatus,
+import {
+  TASK_STATUSES,
+  type TaskDelta,
+  type TaskState,
+  type TaskStatus,
+  type WorkflowDerivedStatus,
 } from '@invoker/workflow-core';
 import {
   WORKFLOW_LIFECYCLE_EVENT_KINDS,
@@ -94,21 +95,8 @@ export interface WorkflowWakeupLifecycleEventInput {
   readonly createdAt?: Date;
 }
 
-const STATUS_VALUES: readonly WorkflowLifecycleStatus[] = [
-  'pending',
-  'running',
-  'fixing_with_ai',
-  'completed',
-  'failed',
-  'closed',
-  'needs_input',
-  'blocked',
-  'review_ready',
-  'awaiting_approval',
-  'stale',
-];
-
 const EVENT_KIND_SET = new Set<string>(WORKFLOW_LIFECYCLE_EVENT_KINDS);
+const STATUS_VALUES = TASK_STATUSES satisfies readonly WorkflowLifecycleStatus[];
 const STATUS_SET = new Set<string>(STATUS_VALUES);
 
 export function lifecycleEventKindForTaskStatus(status: TaskStatus): TaskLifecycleEvent['kind'] {

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -188,7 +188,7 @@ export async function answerOwnerHeadlessQuery(
 
 type ReadOrchestrator = Pick<
   Orchestrator,
-  'getQueueStatus' | 'getWorkflowStatus' | 'getAllTasks' | 'syncAllFromDb' | 'syncFromDb'
+  'getQueueStatus' | 'getWorkflowStatus' | 'getAllTasks' | 'getMergeNode' | 'syncAllFromDb' | 'syncFromDb'
 >;
 type ReadPersistence = Pick<
   SQLiteAdapter,
@@ -260,7 +260,16 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     },
     getEvents: (taskId: string, options: GetEventsOptions) =>
       getEventsPage(persistence, taskId, options),
-    getTaskById: (taskId: string) => persistence.loadTask(taskId),
+    getTaskById: (taskId: string) => {
+      const inMemory = orchestrator.getAllTasks().find((task) => task.id === taskId);
+      if (inMemory) return inMemory;
+      const persisted = persistence.loadTask(taskId);
+      if (persisted) return persisted;
+      if (taskId.startsWith('__merge__')) {
+        return orchestrator.getMergeNode(taskId.slice('__merge__'.length));
+      }
+      return undefined;
+    },
     getTaskOutput: (taskId: string) => persistence.getTaskOutput(taskId),
     getOutputChunks: (taskId: string) => persistence.getOutputChunks(taskId),
     getOutputTail: (taskId: string) => persistence.getOutputTail(taskId),

--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -3,7 +3,7 @@ import type { Logger, WorkResponse } from '@invoker/contracts';
 import type { Workflow } from '@invoker/data-store';
 import { Channels, type MessageBus } from '@invoker/transport';
 import type { TaskDelta, TaskState } from '@invoker/workflow-core';
-import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from '../delta-merge.js';
+import { applyDelta, recoverQuarantinedTask, recoveryFound, recoveryMissing, TaskSnapshotCache } from '../delta-merge.js';
 import { evaluateExecutingStall, taskNeedsExecutingStallCheck } from '../executing-stall.js';
 import { persistShutdownDiagnostic, type ShutdownDiagnosticDb } from '../shutdown-diagnostic.js';
 import type { TaskGraphEventPublisher } from '../task-graph-event-publisher.js';
@@ -158,8 +158,14 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
     for (const taskId of quarantined) {
       deps.logger.info(`[gap-detect] quarantined task="${taskId}" — triggering authoritative reload`, { module: 'delta-merge' });
       const { rendererDelta } = recoverQuarantinedTask(lastKnownTaskStates, taskId, {
-        loadTask: (recoveryTaskId) => deps.persistence.loadTask(recoveryTaskId),
-        getMergeNode: (workflowId) => deps.getOrchestrator().getMergeNode(workflowId),
+        loadTask: (recoveryTaskId) => {
+          const task = deps.persistence.loadTask(recoveryTaskId);
+          return task ? recoveryFound(task) : recoveryMissing();
+        },
+        getMergeNode: (workflowId) => {
+          const task = deps.getOrchestrator().getMergeNode(workflowId);
+          return task ? recoveryFound(task) : recoveryMissing();
+        },
       });
       if (rendererDelta) {
         rendererDeltas.push(rendererDelta);

--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -3,7 +3,7 @@ import type { Logger, WorkResponse } from '@invoker/contracts';
 import type { Workflow } from '@invoker/data-store';
 import { Channels, type MessageBus } from '@invoker/transport';
 import type { TaskDelta, TaskState } from '@invoker/workflow-core';
-import { applyDelta, recoverQuarantinedTask, recoveryFound, recoveryMissing, TaskSnapshotCache } from '../delta-merge.js';
+import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from '../delta-merge.js';
 import { evaluateExecutingStall, taskNeedsExecutingStallCheck } from '../executing-stall.js';
 import { persistShutdownDiagnostic, type ShutdownDiagnosticDb } from '../shutdown-diagnostic.js';
 import type { TaskGraphEventPublisher } from '../task-graph-event-publisher.js';
@@ -158,14 +158,8 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
     for (const taskId of quarantined) {
       deps.logger.info(`[gap-detect] quarantined task="${taskId}" — triggering authoritative reload`, { module: 'delta-merge' });
       const { rendererDelta } = recoverQuarantinedTask(lastKnownTaskStates, taskId, {
-        loadTask: (recoveryTaskId) => {
-          const task = deps.persistence.loadTask(recoveryTaskId);
-          return task ? recoveryFound(task) : recoveryMissing();
-        },
-        getMergeNode: (workflowId) => {
-          const task = deps.getOrchestrator().getMergeNode(workflowId);
-          return task ? recoveryFound(task) : recoveryMissing();
-        },
+        loadTask: (recoveryTaskId) => deps.persistence.loadTask(recoveryTaskId),
+        getMergeNode: (workflowId) => deps.getOrchestrator().getMergeNode(workflowId),
       });
       if (rendererDelta) {
         rendererDeltas.push(rendererDelta);

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -450,6 +450,7 @@ export function descriptionForMergeNode(plan: Pick<PlanDefinition, 'name' | 'onF
  */
 const LIVE_TASK_STATUSES = new Set<string>([
   'pending',
+  'queued',
   'running',
   'fixing_with_ai',
   'needs_input',

--- a/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
+++ b/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
@@ -15,6 +15,7 @@ describe('workflow rollup', () => {
   it.each([
     { name: 'no tasks', statuses: [], expected: 'pending' },
     { name: 'all pending', statuses: ['pending'], expected: 'pending' },
+    { name: 'queued task', statuses: ['queued'], expected: 'running' },
     { name: 'running task', statuses: ['pending', 'running'], expected: 'running' },
     { name: 'fixing task', statuses: ['running', 'fixing_with_ai'], expected: 'fixing_with_ai' },
     { name: 'awaiting approval', statuses: ['completed', 'awaiting_approval'], expected: 'awaiting_approval' },

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -7,19 +7,22 @@
 
 // ── Task Status FSM ─────────────────────────────────────────
 
-export type TaskStatus =
-  | 'pending'
-  | 'queued'
-  | 'running'
-  | 'fixing_with_ai'
-  | 'completed'
-  | 'failed'
-  | 'closed'
-  | 'needs_input'
-  | 'blocked'
-  | 'review_ready'
-  | 'awaiting_approval'
-  | 'stale';
+export const TASK_STATUSES = [
+  'pending',
+  'queued',
+  'running',
+  'fixing_with_ai',
+  'completed',
+  'failed',
+  'closed',
+  'needs_input',
+  'blocked',
+  'review_ready',
+  'awaiting_approval',
+  'stale',
+] as const;
+
+export type TaskStatus = typeof TASK_STATUSES[number];
 // ── Task Config (definition / spec) ────────────────────────
 // Copied wholesale when cloning/forking: clone.config = original.config
 

--- a/packages/workflow-graph/src/workflow-rollup.ts
+++ b/packages/workflow-graph/src/workflow-rollup.ts
@@ -1,4 +1,4 @@
-import type { TaskState, TaskStatus } from './types.js';
+import { TASK_STATUSES, type TaskState, type TaskStatus } from './types.js';
 
 export type WorkflowDerivedStatus =
   | 'pending'
@@ -57,20 +57,6 @@ export interface WorkflowRollupTaskSummary {
     isFixingWithAI?: boolean;
   };
 }
-
-export const TASK_STATUSES: readonly TaskStatus[] = [
-  'pending',
-  'running',
-  'fixing_with_ai',
-  'completed',
-  'failed',
-  'closed',
-  'needs_input',
-  'blocked',
-  'review_ready',
-  'awaiting_approval',
-  'stale',
-];
 
 export function createEmptyWorkflowTaskStatusCounts(): WorkflowTaskStatusCounts {
   return Object.fromEntries(TASK_STATUSES.map((status) => [status, 0])) as WorkflowTaskStatusCounts;


### PR DESCRIPTION
## Summary

Detached windows keep quarantined task nodes visible instead of turning local misses into prunes.

The UI imports the shared task status set and renders `queued` with a running-like visual treatment.

## Review Claim

Approve the visible task-feed and UI handling for quarantined task gaps and `queued` status display.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The detached behavior is gated behind the new optional viewer predicate. Existing owner windows keep the same local recovery path by default.

## Slice Rationale

This sits above app recovery and keeps user-facing rendering separate from main-process wiring.

## Non-goals

- Does not change backend task mutation behavior.
- Does not change workflow creation or deletion semantics.
- Does not enable detached mode by itself.

## Architecture

### Before

```mermaid
graph TD
    A["Detached task feed sees local miss"] --> B["Recovery emits removed"]
    B --> C["Task node disappears"]
```

### After

```mermaid
graph TD
    A["Detached task feed sees local miss"] --> B["Recovery reports unavailable"]
    B --> C["Task node remains quarantined"]
    C --> D["Owner result later creates or removes"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/colors.test.ts src/__tests__/use-tasks.test.tsx src/__tests__/workflow-blank-storm-repro.test.tsx src/__tests__/workflow-graph.test.tsx`
- [x] `pnpm run check:types`
- [x] `scripts/repro/repro-ui-delta-timeline.sh synthetic`

</details>

## Visual Proof

![Standalone UI delta timeline proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260731-6f7c55/invoker-ui-task-state-reconciliation-proof.png)

The proof shows detached local gaps emit no `removed` renderer deltas, owner recovery recreates authoritative tasks, and `queued` contributes a finite rollup count.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ca0faa4a0`
- Post-revert steps: None
- Data migration? No

</details>
