### PR TITLE
Fix admin-bypass repair publication and queue waits

### DIFF
--- a/packages/execution-engine/src/__tests__/auto-commit.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-commit.test.ts
@@ -55,8 +55,13 @@ class TestExecutor extends BaseExecutor<BaseEntry> {
     return this.syncFromRemote(cwd, executionId);
   }
 
-  async testPushBranchToRemote(cwd: string, branch: string, executionId?: string): Promise<string | undefined> {
-    return this.pushBranchToRemote(cwd, branch, executionId);
+  async testPushBranchToRemote(
+    cwd: string,
+    branch: string,
+    executionId?: string,
+    sourceCommitHash?: string,
+  ): Promise<string | undefined> {
+    return this.pushBranchToRemote(cwd, branch, executionId, undefined, sourceCommitHash);
   }
 
   async testHandleProcessExit(
@@ -2112,6 +2117,42 @@ describe('BaseExecutor.pushBranchToRemote', () => {
     expect(remoteSha).toBe(taskSha);
   });
 
+  it('pushes the recorded commit when current checkout is not the task branch', async () => {
+    const taskBranch = 'invoker/task-stale';
+    const prBranch = 'pr/head';
+
+    execSync(`git checkout -b ${taskBranch}`, { cwd: cloneDir });
+    writeFileSync(join(cloneDir, 'task.txt'), 'stale task branch\n');
+    execSync('git add -A && git commit -m "stale task commit"', { cwd: cloneDir });
+    const staleTaskSha = execSync('git rev-parse HEAD', { cwd: cloneDir }).toString().trim();
+    execSync(`git push origin HEAD:refs/heads/${taskBranch}`, { cwd: cloneDir });
+
+    execSync(`git checkout -b ${prBranch} master`, { cwd: cloneDir });
+    writeFileSync(join(cloneDir, 'pr.txt'), 'recorded repair commit\n');
+    execSync('git add -A && git commit -m "recorded repair commit"', { cwd: cloneDir });
+    const recordedSha = execSync('git rev-parse HEAD', { cwd: cloneDir }).toString().trim();
+
+    const pushErr = await executor.testPushBranchToRemote(cloneDir, taskBranch, undefined, recordedSha);
+    expect(pushErr).toBeUndefined();
+
+    const remoteSha = execSync(`git --git-dir="${originDir}" rev-parse "refs/heads/${taskBranch}"`)
+      .toString()
+      .trim();
+    expect(remoteSha).toBe(recordedSha);
+    expect(remoteSha).not.toBe(staleTaskSha);
+
+    const freshClone = mkdtempSync(join(tmpdir(), 'push-fresh-clone-'));
+    try {
+      execSync(`git clone ${originDir} .`, { cwd: freshClone });
+      const reachableSha = execSync(`git rev-parse --verify "${recordedSha}^{commit}"`, { cwd: freshClone })
+        .toString()
+        .trim();
+      expect(reachableSha).toBe(recordedSha);
+    } finally {
+      rmSync(freshClone, { recursive: true, force: true });
+    }
+  });
+
   it('returns an error message when branch does not exist on remote', async () => {
     const err = await executor.testPushBranchToRemote(cloneDir, 'nonexistent-branch');
     expect(err).toBeDefined();
@@ -2176,6 +2217,49 @@ describe('BaseExecutor.handleProcessExit push semantics', () => {
     rmSync(originDir, { recursive: true, force: true });
     rmSync(cloneDir, { recursive: true, force: true });
     vi.restoreAllMocks();
+  });
+
+  it('publishes the recorded process-exit commit when current checkout is not the task branch', async () => {
+    const taskBranch = 'invoker/admin-bypass-repair';
+    const prBranch = 'pr/head';
+
+    execSync(`git checkout -b ${taskBranch}`, { cwd: cloneDir });
+    writeFileSync(join(cloneDir, 'task.txt'), 'stale task branch\n');
+    execSync('git add -A && git commit -m "stale task commit"', { cwd: cloneDir });
+    const staleTaskSha = execSync('git rev-parse HEAD', { cwd: cloneDir }).toString().trim();
+    execSync(`git push origin HEAD:refs/heads/${taskBranch}`, { cwd: cloneDir });
+
+    execSync(`git checkout -b ${prBranch} master`, { cwd: cloneDir });
+    writeFileSync(join(cloneDir, 'repair.txt'), 'repair committed from pr checkout\n');
+
+    const req = makeRequest('admin-bypass-repair', { description: 'repair' });
+    const entry = executor.registerTestEntry('e-admin-bypass-repair', req);
+    let response: WorkResponse | undefined;
+    entry.completeListeners.add((r) => { response = r; });
+
+    await executor.testHandleProcessExit('e-admin-bypass-repair', req, cloneDir, 0, { branch: taskBranch });
+
+    expect(response?.status).toBe('completed');
+    const commitHash = response?.outputs.commitHash;
+    if (!commitHash) throw new Error('expected process exit to record a commit hash');
+    expect(commitHash).toMatch(/^[0-9a-f]{40}$/);
+
+    const remoteSha = execSync(`git --git-dir="${originDir}" rev-parse "refs/heads/${taskBranch}"`)
+      .toString()
+      .trim();
+    expect(remoteSha).toBe(commitHash);
+    expect(remoteSha).not.toBe(staleTaskSha);
+
+    const freshClone = mkdtempSync(join(tmpdir(), 'hpe-fresh-clone-'));
+    try {
+      execSync(`git clone ${originDir} .`, { cwd: freshClone });
+      const reachableSha = execSync(`git rev-parse --verify "${commitHash}^{commit}"`, { cwd: freshClone })
+        .toString()
+        .trim();
+      expect(reachableSha).toBe(commitHash);
+    } finally {
+      rmSync(freshClone, { recursive: true, force: true });
+    }
   });
 
   it('marks task failed when exit 0 but push fails', async () => {

--- a/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
@@ -287,7 +287,7 @@ describe('infra-repair worker', () => {
     expect(parseInfraRepairRecreateTaskMutationArgs(h.submissions[0]?.args ?? [])).toEqual({ taskId: 'wf-1/task-1' });
   });
 
-  it('recreates invalid-reference and no-saved-workspace failures', async () => {
+  it('recreates invalid branch-reference and no-saved-workspace failures', async () => {
     for (const error of [
       'fatal: invalid reference: refs/heads/feature/task-1',
       'Cannot apply a fix because this task has no saved workspace.',
@@ -302,6 +302,37 @@ describe('infra-repair worker', () => {
       expect(h.submissions[0]?.channel).toBe(INFRA_REPAIR_RECREATE_TASK_CHANNEL);
       expect(parseInfraRepairRecreateTaskMutationArgs(h.submissions[0]?.args ?? [])).toEqual({ taskId: 'wf-1/task-1' });
     }
+  });
+
+  it('does not recreate a task when invalid-reference points at a missing upstream commit', async () => {
+    const missingCommit = '0a9fa79519df5dbada79e06f9899e22b26549435';
+    const h = makeHarness([
+      makeTask({
+        execution: {
+          error: `fatal: invalid reference: ${missingCommit}`,
+        },
+      }),
+    ]);
+
+    await h.tick(POLL_CTX);
+
+    expect(h.submit).not.toHaveBeenCalled();
+    expect(workerActions(h.actions)).toEqual([expect.objectContaining({
+      workerKind: INFRA_REPAIR_WORKER_KIND,
+      actionType: 'repair-infra-failure',
+      taskId: 'wf-1/task-1',
+      status: 'completed',
+      payload: expect.objectContaining({
+        infraReason: 'ssh-invalid-reference',
+        invalidReference: missingCommit,
+        reason: 'upstream-commit-unreachable',
+      }),
+    })]);
+
+    await h.tick({ ...POLL_CTX, tickNumber: 2 });
+
+    expect(h.submit).not.toHaveBeenCalled();
+    expect(workerActions(h.actions)).toHaveLength(1);
   });
 
   it('suppresses a second target repair but still retries a later task after recent success', async () => {

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync, execSync } from 'node:child_process';
@@ -467,7 +467,8 @@ describe('buildRecordAndPushScript', () => {
     expect(script).toContain('git commit --allow-empty -F');
     expect(script).toContain('git commit -F');
     expect(script).toContain('HASH=$(git rev-parse HEAD)');
-    expect(script).toContain('git push origin "$BR:refs/heads/$BR"');
+    expect(script).toContain('REMOTE_EXPECTED=$(git ls-remote "$PUSH_REMOTE" "refs/heads/$BR"');
+    expect(script).toContain('git push --force-with-lease="refs/heads/$BR:$REMOTE_EXPECTED" "$PUSH_REMOTE" "$HASH:refs/heads/$BR"');
     expect(script).toContain('printf "%s" "$HASH"');
   });
 
@@ -497,7 +498,8 @@ describe('buildRecordAndPushScript', () => {
 
     expect(script).not.toContain('git remote set-url invoker-branches "$PUSH_URL"');
     expect(script).not.toContain('git remote add invoker-branches "$PUSH_URL"');
-    expect(script).toContain('git push "$PUSH_URL" "$BR:refs/heads/$BR"');
+    expect(script).toContain('PUSH_REMOTE="$PUSH_URL"');
+    expect(script).toContain('git push --force-with-lease="refs/heads/$BR:$REMOTE_EXPECTED" "$PUSH_REMOTE" "$HASH:refs/heads/$BR"');
   });
 
   it('commits and pushes successfully without preconfigured git identity', () => {
@@ -546,6 +548,74 @@ describe('buildRecordAndPushScript', () => {
     expect(authorName).toBe('Remote CI Bot');
     expect(authorEmail).toBe('remote-ci@example.com');
     expect(pushedHead).toBe(localHead);
+  });
+
+  it('pushes the recorded HEAD when the checkout branch differs from the target branch', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ssh-record-push-different-branch-'));
+    try {
+      const source = join(root, 'source');
+      const bare = join(root, 'remote.git');
+      const clone = join(root, 'clone');
+      const targetBranch = 'experiment/test-branch';
+
+      mkdirSync(source, { recursive: true });
+      execSync('git init -b master', { cwd: source, stdio: 'ignore' });
+      writeFileSync(join(source, 'README.md'), 'seed\n');
+      execSync('git add README.md', { cwd: source, stdio: 'ignore' });
+      execSync('git -c user.name="Seed User" -c user.email="seed@example.com" commit -m "seed"', {
+        cwd: source,
+        stdio: 'ignore',
+      });
+      execSync(`git clone --bare ${JSON.stringify(source)} ${JSON.stringify(bare)}`, { stdio: 'ignore' });
+      execSync(`git clone ${JSON.stringify(bare)} ${JSON.stringify(clone)}`, { stdio: 'ignore' });
+
+      execSync(`git checkout -b ${targetBranch}`, { cwd: clone, stdio: 'ignore' });
+      writeFileSync(join(clone, 'stale.txt'), 'stale target branch\n');
+      execSync('git add stale.txt', { cwd: clone, stdio: 'ignore' });
+      execSync('git -c user.name="Seed User" -c user.email="seed@example.com" commit -m "stale target"', {
+        cwd: clone,
+        stdio: 'ignore',
+      });
+      const staleTargetSha = execSync('git rev-parse HEAD', { cwd: clone }).toString().trim();
+      execSync(`git push origin HEAD:refs/heads/${targetBranch}`, { cwd: clone, stdio: 'ignore' });
+
+      execSync('git checkout -b pr/head master', { cwd: clone, stdio: 'ignore' });
+      writeFileSync(join(clone, 'result.txt'), 'recorded repair commit\n');
+
+      const script = buildRecordAndPushScript({
+        worktreePath: clone,
+        branch: targetBranch,
+        commitMessageChanges: 'invoker: record remote result',
+        commitMessageEmpty: 'invoker: record remote empty result',
+        gitUserName: 'Remote CI Bot',
+        gitUserEmail: 'remote-ci@example.com',
+      });
+
+      const stdout = execFileSync('bash', ['-lc', script], {
+        env: {
+          ...process.env,
+          HOME: mkdtempSync(join(tmpdir(), 'ssh-record-push-home-')),
+        },
+      }).toString().trim();
+      const outputParts = stdout.split(/\s+/);
+      const recordedSha = outputParts[outputParts.length - 1];
+      const pushedHead = execSync(`git --git-dir=${JSON.stringify(bare)} rev-parse refs/heads/${targetBranch}`)
+        .toString()
+        .trim();
+
+      expect(recordedSha).toMatch(/^[0-9a-f]{40}$/);
+      expect(pushedHead).toBe(recordedSha);
+      expect(pushedHead).not.toBe(staleTargetSha);
+
+      const freshClone = join(root, 'fresh');
+      execSync(`git clone ${JSON.stringify(bare)} ${JSON.stringify(freshClone)}`, { stdio: 'ignore' });
+      const reachableSha = execSync(`git rev-parse --verify "${recordedSha}^{commit}"`, { cwd: freshClone })
+        .toString()
+        .trim();
+      expect(reachableSha).toBe(recordedSha);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -860,7 +860,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     if (!commitHash) {
       return { error: 'commit approved fix failed' };
     }
-    const pushError = await this.pushBranchToRemote(cwd, branch, undefined, request.inputs.branchRepoUrl);
+    const pushError = await this.pushBranchToRemote(cwd, branch, undefined, request.inputs.branchRepoUrl, commitHash);
     if (pushError) {
       return { error: pushError };
     }
@@ -976,6 +976,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     branch: string,
     executionId?: string,
     branchRepoUrlOverride?: string,
+    sourceCommitHash?: string,
   ): Promise<string | undefined> {
     try {
       const requestBranchRepoUrl = branchRepoUrlOverride ?? (executionId
@@ -992,10 +993,16 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
         });
       }
       const destinationRef = `refs/heads/${branch}`;
-      const currentBranch = (await this.execGitSimple(['branch', '--show-current'], cwd)).trim();
-      const sourceRef = !currentBranch || currentBranch === branch
-        ? 'HEAD'
-        : `refs/heads/${branch}`;
+      const explicitSourceRef = sourceCommitHash?.trim();
+      let sourceRef: string;
+      if (explicitSourceRef) {
+        sourceRef = explicitSourceRef;
+      } else {
+        const currentBranch = (await this.execGitSimple(['branch', '--show-current'], cwd)).trim();
+        sourceRef = !currentBranch || currentBranch === branch
+          ? 'HEAD'
+          : `refs/heads/${branch}`;
+      }
       const sourceSha = (await this.execGitSimple(['rev-parse', '--verify', `${sourceRef}^{commit}`], cwd)).trim();
       const branchRef = `${sourceSha}:${destinationRef}`;
       try {
@@ -1209,7 +1216,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
 
     let pushError: string | undefined;
     if (opts?.branch) {
-      pushError = await this.pushBranchToRemote(cwd, opts.branch, executionId);
+      pushError = await this.pushBranchToRemote(cwd, opts.branch, executionId, undefined, commitHash);
     }
     if (effectiveExitCode === 0 && pushError !== undefined && opts?.branch) {
       if (this.isTransientGitTransportError(pushError)) {

--- a/packages/execution-engine/src/docker-executor.ts
+++ b/packages/execution-engine/src/docker-executor.ts
@@ -247,6 +247,7 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
     branch: string,
     executionId?: string,
     branchRepoUrlOverride?: string,
+    sourceCommitHash?: string,
   ): Promise<string | undefined> {
     try {
       await this.execGitSimple(['remote', 'get-url', 'origin'], cwd);
@@ -258,9 +259,9 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
         if (executionId) this.emitOutput(executionId, msg);
         return undefined;
       }
-      return await super.pushBranchToRemote(cwd, branch, executionId, branchRepoUrlOverride);
+      return await super.pushBranchToRemote(cwd, branch, executionId, branchRepoUrlOverride, sourceCommitHash);
     }
-    return await super.pushBranchToRemote(cwd, branch, executionId, branchRepoUrlOverride);
+    return await super.pushBranchToRemote(cwd, branch, executionId, branchRepoUrlOverride, sourceCommitHash);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -388,9 +388,15 @@ HASH=$(git rev-parse HEAD)
 BR=$(printf '%s' ${shellPosixSingleQuote(brB)} | invoker_base64_decode)
 PUSH_URL=$(printf '%s' ${shellPosixSingleQuote(pushRemoteUrlB)} | invoker_base64_decode)
 if [ -n "$PUSH_URL" ]; then
-  git push "$PUSH_URL" "$BR:refs/heads/$BR"
+  PUSH_REMOTE="$PUSH_URL"
 else
-  git push origin "$BR:refs/heads/$BR"
+  PUSH_REMOTE=origin
+fi
+REMOTE_EXPECTED=$(git ls-remote "$PUSH_REMOTE" "refs/heads/$BR" | awk 'NR == 1 { print $1 }')
+if [ -n "$REMOTE_EXPECTED" ]; then
+  git push --force-with-lease="refs/heads/$BR:$REMOTE_EXPECTED" "$PUSH_REMOTE" "$HASH:refs/heads/$BR"
+else
+  git push "$PUSH_REMOTE" "$HASH:refs/heads/$BR"
 fi
 printf "%s" "$HASH"
 `;

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -198,6 +198,11 @@ function tailText(text: string): string {
   return text.length <= MAX_OUTPUT_TAIL_CHARS ? text : text.slice(-MAX_OUTPUT_TAIL_CHARS);
 }
 
+function missingCommitInvalidReference(errorText: string | undefined): string | undefined {
+  const match = errorText?.match(/fatal: invalid reference:\s+([0-9a-f]{40})(?:\b|$)/i);
+  return match?.[1];
+}
+
 function taskDecisionExternalKey(candidate: Pick<InfraRepairScanCandidate, 'taskId' | 'generation' | 'taskStateVersion'>, reason: InfraRepairReason): string {
   return `task:${candidate.taskId}:g${candidate.generation}:v${candidate.taskStateVersion}:${reason}`;
 }
@@ -581,6 +586,23 @@ async function handleInvalidReferenceRecovery(
   options: InfraRepairWorkerPolicyOptions,
   candidate: ValidatedGenericSshInfraCandidate,
 ): Promise<void> {
+  const missingCommit = missingCommitInvalidReference(candidate.task.execution.error);
+  if (missingCommit) {
+    recordTaskDecision(
+      options,
+      candidate,
+      candidate.reason,
+      'completed',
+      'Skipped recreate for missing upstream commit reference',
+      {
+        targetId: candidate.targetId,
+        invalidReference: missingCommit,
+      },
+      'upstream-commit-unreachable',
+    );
+    return;
+  }
+
   await submitFollowUpMutation(
     options,
     candidate,

--- a/scripts/cron-admin-bypass-queue.sh
+++ b/scripts/cron-admin-bypass-queue.sh
@@ -158,6 +158,7 @@ while IFS= read -r pr; do
   q_state_file="$(shell_quote "$STATE_FILE")"
   q_num="$(shell_quote "$num")"
   q_fingerprint="$(shell_quote "$fingerprint")"
+  q_tsv_kind="$(shell_quote "queue-attempt")"
 
   plan_file="$PLAN_DIR/repair-pr-$num.yaml"
   {
@@ -190,13 +191,29 @@ while IFS= read -r pr; do
     printf '    dependencies: [repair]\n'
     printf '    command: |\n'
     {
-      printf 'python3 scripts/pr_worker_safe_push.py \\\n'
-      printf '  --branch %s \\\n' "$q_head_ref"
-      printf '  --expected-head %s \\\n' "$q_head_oid"
-      printf '  --record-tsv-ledger %s \\\n' "$q_state_file"
-      printf '  --tsv-kind queue-attempt \\\n'
-      printf '  --tsv-key %s \\\n' "$q_num"
-      printf '  --tsv-marker %s\n' "$q_fingerprint"
+      printf 'set -euo pipefail\n'
+      printf 'branch=%s\n' "$q_head_ref"
+      printf 'expected=%s\n' "$q_head_oid"
+      printf 'ledger=%s\n' "$q_state_file"
+      printf 'kind=%s\n' "$q_tsv_kind"
+      printf 'key=%s\n' "$q_num"
+      printf 'marker=%s\n' "$q_fingerprint"
+      printf 'ref="refs/heads/$branch"\n'
+      printf 'live="$(git ls-remote origin "$ref" | cut -f1)"\n'
+      printf 'if [ "$live" != "$expected" ]; then\n'
+      printf '  echo "stale-head: $ref is ${live:-missing}; expected $expected" >&2\n'
+      printf '  exit 20\n'
+      printf 'fi\n'
+      printf 'pushed="$(git rev-parse HEAD)"\n'
+      printf 'git push --force-with-lease="$ref:$expected" origin "HEAD:$ref"\n'
+      printf 'verified="$(git ls-remote origin "$ref" | cut -f1)"\n'
+      printf 'if [ "$verified" != "$pushed" ]; then\n'
+      printf '  echo "post-push verification failed: $ref is ${verified:-missing}; expected $pushed" >&2\n'
+      printf '  exit 22\n'
+      printf 'fi\n'
+      printf 'mkdir -p "$(dirname "$ledger")"\n'
+      printf 'printf '"'"'%%s\\t%%s\\t%%s\\t%%s\\n'"'"' "$kind" "$key" "$marker" "$(date +%%s)" >> "$ledger"\n'
+      printf 'echo "pr-worker-safe-push: pushed $ref to $pushed"\n'
     } | sed 's/^/      /'
   } > "$plan_file"
 

--- a/scripts/cron-pr-orphan-repair.sh
+++ b/scripts/cron-pr-orphan-repair.sh
@@ -123,6 +123,7 @@ while IFS= read -r pr; do
   q_state_file="$(shell_quote "$STATE_FILE")"
   q_num="$(shell_quote "$num")"
   q_fingerprint="$(shell_quote "$fingerprint")"
+  q_tsv_kind="$(shell_quote "orphan-attempt")"
 
   plan_file="$PLAN_DIR/repair-pr-$num.yaml"
   {
@@ -157,13 +158,29 @@ while IFS= read -r pr; do
     printf '    dependencies: [repair]\n'
     printf '    command: |\n'
     {
-      printf 'python3 scripts/pr_worker_safe_push.py \\\n'
-      printf '  --branch %s \\\n' "$q_head_ref"
-      printf '  --expected-head %s \\\n' "$q_head_oid"
-      printf '  --record-tsv-ledger %s \\\n' "$q_state_file"
-      printf '  --tsv-kind orphan-attempt \\\n'
-      printf '  --tsv-key %s \\\n' "$q_num"
-      printf '  --tsv-marker %s\n' "$q_fingerprint"
+      printf 'set -euo pipefail\n'
+      printf 'branch=%s\n' "$q_head_ref"
+      printf 'expected=%s\n' "$q_head_oid"
+      printf 'ledger=%s\n' "$q_state_file"
+      printf 'kind=%s\n' "$q_tsv_kind"
+      printf 'key=%s\n' "$q_num"
+      printf 'marker=%s\n' "$q_fingerprint"
+      printf 'ref="refs/heads/$branch"\n'
+      printf 'live="$(git ls-remote origin "$ref" | cut -f1)"\n'
+      printf 'if [ "$live" != "$expected" ]; then\n'
+      printf '  echo "stale-head: $ref is ${live:-missing}; expected $expected" >&2\n'
+      printf '  exit 20\n'
+      printf 'fi\n'
+      printf 'pushed="$(git rev-parse HEAD)"\n'
+      printf 'git push --force-with-lease="$ref:$expected" origin "HEAD:$ref"\n'
+      printf 'verified="$(git ls-remote origin "$ref" | cut -f1)"\n'
+      printf 'if [ "$verified" != "$pushed" ]; then\n'
+      printf '  echo "post-push verification failed: $ref is ${verified:-missing}; expected $pushed" >&2\n'
+      printf '  exit 22\n'
+      printf 'fi\n'
+      printf 'mkdir -p "$(dirname "$ledger")"\n'
+      printf 'printf '"'"'%%s\\t%%s\\t%%s\\t%%s\\n'"'"' "$kind" "$key" "$marker" "$(date +%%s)" >> "$ledger"\n'
+      printf 'echo "pr-worker-safe-push: pushed $ref to $pushed"\n'
     } | sed 's/^/      /'
   } > "$plan_file"
 

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -82,6 +82,17 @@ def is_queue_only_required_check(name: str) -> bool:
     return name in QUEUE_ONLY_REQUIRED_CHECKS
 
 
+def has_active_queue_event(pr: PrSnapshot) -> bool:
+    latest = pr.latest_mergify
+    if not latest or latest.queue_rule_name != "admin-bypass" or latest.state not in ACTIVE_QUEUE_STATES:
+        return False
+    if latest.head_sha == pr.head_ref_oid:
+        return True
+    if not latest.head_sha:
+        return True
+    return "queued" in pr.labels
+
+
 def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) -> tuple[Blocker, ...]:
     blockers: list[Blocker] = []
     if pr.state == "MERGED":
@@ -560,7 +571,7 @@ def wait_reason_for_facts(facts: StackFacts) -> str:
             return "repair-delegated"
         if HUMAN_BLOCKER_KINDS & blocker_kinds:
             return "blocked-needs-human"
-    if facts.bottom and facts.bottom.latest_mergify and facts.bottom.latest_mergify.state in {"queued", "merging"}:
+    if facts.bottom and has_active_queue_event(facts.bottom):
         return "bottom-already-queued"
     return "no-action"
 
@@ -726,7 +737,7 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
         return Action("comment_admin_bypass_nudge", bottom.number, "admin-bypass", "missing admin-bypass label")
     if facts.upper_stack_needs_acceptance:
         return None
-    if latest and latest.state in ACTIVE_QUEUE_STATES and (latest.head_sha == bottom.head_ref_oid or "queued" in bottom.labels):
+    if has_active_queue_event(bottom):
         return None
     requeue_reason = "eligible-when-ready"
     requeue_key = "ready"

--- a/scripts/repro/repro-admin-bypass-queue.sh
+++ b/scripts/repro/repro-admin-bypass-queue.sh
@@ -94,8 +94,8 @@ grep -q "^repoUrl: https://github.com/fake/repo.git$" "$plan902" \
 grep -q "^onFinish: none$" "$plan902" || fail "plan902: must not open its own PR" "$(cat "$plan902")"
 grep -q "Blocker category: failed_checks" "$plan902" || fail "plan902: wrong category" "$(cat "$plan902")"
 grep -q "id: safe-push" "$plan902" || fail "plan902: missing safe-push task" "$(cat "$plan902")"
-grep -q "python3 scripts/pr_worker_safe_push.py" "$plan902" || fail "plan902: missing safe-push helper command" "$(cat "$plan902")"
-grep -q -- "--tsv-kind queue-attempt" "$plan902" || fail "plan902: safe-push must own queue-attempt recording" "$(cat "$plan902")"
+grep -q "git push --force-with-lease" "$plan902" || fail "plan902: missing guarded safe-push command" "$(cat "$plan902")"
+grep -q "kind='queue-attempt'" "$plan902" || fail "plan902: safe-push must own queue-attempt recording" "$(cat "$plan902")"
 grep -q "Do not push" "$plan902" || fail "plan902: repair prompt must forbid direct pushes" "$(cat "$plan902")"
 
 plan903="$TMP/plans/repair-pr-903.yaml"

--- a/scripts/repro/repro-admin-bypass-safe-push-unreachable-commit.sh
+++ b/scripts/repro/repro-admin-bypass-safe-push-unreachable-commit.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reproduces the admin-bypass repair handoff failure with real git repos.
+#
+# The repair task prompt told the agent to check out the real PR head branch.
+# BaseExecutor then recorded HEAD from that PR branch, but pre-fix pushBranchToRemote
+# published refs/heads/$task_branch because the current branch was different.
+# A fresh downstream safe-push workspace cannot resolve the recorded commit.
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/admin-bypass-unreachable-commit.XXXXXX")"
+if [[ "${KEEP_TEMP:-0}" != "1" ]]; then
+  trap 'rm -rf "$tmp_dir"' EXIT
+else
+  trap 'printf "kept temp dir: %s\n" "$tmp_dir"' EXIT
+fi
+
+origin="$tmp_dir/origin.git"
+seed="$tmp_dir/seed"
+repair="$tmp_dir/repair"
+mirror="$tmp_dir/mirror"
+safe_push_worktree="$tmp_dir/safe-push-worktree"
+
+base_branch="stack/base"
+pr_branch="stack/pr-head"
+task_branch="experiment/wf-admin-bypass-repro/repair/g0.t0.a-deadbeef"
+safe_push_branch="experiment/wf-admin-bypass-repro/safe-push/g0.t0.a-cafebabe"
+
+git init --bare "$origin" >/dev/null 2>&1
+git clone "$origin" "$seed" >/dev/null 2>&1
+git -C "$seed" config user.email "repro@example.com"
+git -C "$seed" config user.name "Admin Bypass Repro"
+
+git -C "$seed" checkout -B master >/dev/null 2>&1
+printf 'base\n' >"$seed/file.txt"
+git -C "$seed" add file.txt
+git -C "$seed" commit -m "base" >/dev/null
+
+git -C "$seed" checkout -B "$base_branch" >/dev/null 2>&1
+base_sha="$(git -C "$seed" rev-parse HEAD)"
+git -C "$seed" push origin "$base_branch:refs/heads/$base_branch" >/dev/null 2>&1
+
+git -C "$seed" checkout -B "$pr_branch" "$base_branch" >/dev/null 2>&1
+printf 'pr head\n' >"$seed/pr.txt"
+git -C "$seed" add pr.txt
+git -C "$seed" commit -m "pr head" >/dev/null
+pr_sha="$(git -C "$seed" rev-parse HEAD)"
+git -C "$seed" push origin "$pr_branch:refs/heads/$pr_branch" >/dev/null 2>&1
+
+git -C "$seed" checkout -B "$task_branch" "$base_branch" >/dev/null 2>&1
+git -C "$seed" push origin "$task_branch:refs/heads/$task_branch" >/dev/null 2>&1
+
+git clone "$origin" "$repair" >/dev/null 2>&1
+git -C "$repair" config user.email "repro@example.com"
+git -C "$repair" config user.name "Admin Bypass Repro"
+git -C "$repair" fetch origin '+refs/heads/*:refs/remotes/origin/*' >/dev/null 2>&1
+git -C "$repair" checkout -B "$task_branch" "origin/$task_branch" >/dev/null 2>&1
+
+# Simulate the deployed admin-bypass repair prompt:
+#   git fetch origin <head_ref> && git checkout <head_ref>
+git -C "$repair" fetch origin "$pr_branch" >/dev/null 2>&1
+git -C "$repair" checkout -B "$pr_branch" "origin/$pr_branch" >/dev/null 2>&1
+printf 'repair commit made while on PR branch\n' >>"$repair/pr.txt"
+git -C "$repair" add pr.txt
+git -C "$repair" commit -m "repair on PR branch" >/dev/null
+recorded_commit="$(git -C "$repair" rev-parse HEAD)"
+
+# Simulate the pre-fix BaseExecutor.pushBranchToRemote source-ref selection:
+# if the worktree is not on the task branch, push refs/heads/$task_branch.
+current_branch="$(git -C "$repair" branch --show-current)"
+if [[ -z "$current_branch" || "$current_branch" == "$task_branch" ]]; then
+  source_ref="HEAD"
+else
+  source_ref="refs/heads/$task_branch"
+fi
+source_sha="$(git -C "$repair" rev-parse --verify "$source_ref^{commit}")"
+git -C "$repair" push --force-with-lease origin "$source_sha:refs/heads/$task_branch" >/dev/null 2>&1
+
+remote_task_sha="$(git --git-dir="$origin" rev-parse "refs/heads/$task_branch")"
+if [[ "$remote_task_sha" == "$recorded_commit" ]]; then
+  fail "task branch unexpectedly points at the recorded repair commit"
+fi
+
+git clone "$origin" "$mirror" >/dev/null 2>&1
+set +e
+startup_output="$(
+  git -C "$mirror" worktree add --no-track -B "$safe_push_branch" "$safe_push_worktree" "$recorded_commit" 2>&1
+)"
+startup_code=$?
+set -e
+
+if [[ "$startup_code" -eq 0 ]]; then
+  fail "fresh downstream workspace unexpectedly resolved the unpublished repair commit"
+fi
+
+if ! grep -Eqi 'invalid reference|not a valid object name|reference is not a tree|Needed a single revision|unknown revision|bad object|ambiguous argument' <<<"$startup_output"; then
+  printf '%s\n' "$startup_output" >&2
+  fail "downstream failed, but not with an unresolvable commit/reference error"
+fi
+
+printf 'base_sha=%s\n' "$base_sha"
+printf 'pr_sha=%s\n' "$pr_sha"
+printf 'recorded_repair_commit=%s\n' "$recorded_commit"
+printf 'published_task_branch_sha=%s\n' "$remote_task_sha"
+printf 'executor_source_ref=%s\n' "$source_ref"
+printf 'downstream_startup_status=%s\n' "$startup_code"
+printf 'downstream_startup_error=%s\n' "$(printf '%s' "$startup_output" | tail -n 1)"
+printf 'PASS: reproduced unreachable recorded repair commit for downstream safe-push task\n'

--- a/scripts/repro/repro-babysit-headless-queued-comment.sh
+++ b/scripts/repro/repro-babysit-headless-queued-comment.sh
@@ -45,7 +45,7 @@ state = {
     "prs": [
         {
             "number": 5805,
-            "title": "Already queued with headless Mergify status",
+            "title": "Already queued with headless Mergify status and no queued label",
             "body": "## Summary\n\nQueued PR repro.\n",
             "url": "https://github.com/fake/repo/pull/5805",
             "state": "OPEN",
@@ -55,7 +55,7 @@ state = {
             "headRefOid": head,
             "mergeStateStatus": "BLOCKED",
             "mergeable": "MERGEABLE",
-            "labels": ["admin-bypass", "queued"],
+            "labels": ["admin-bypass"],
             "reviewThreads": [],
             "checks": {"*": "SUCCESS"},
         }

--- a/scripts/repro/repro-pr-orphan-repair.sh
+++ b/scripts/repro/repro-pr-orphan-repair.sh
@@ -77,8 +77,8 @@ grep -q "2. failed_checks: Unit Tests" "$plan" || fail "plan: failing check must
 grep -q "3. changes_requested:" "$plan" || fail "plan: review feedback must be blocker #3" "$(cat "$plan")"
 grep -q "git fetch origin feature/orphan-801" "$plan" || fail "plan: must target the existing PR branch" "$(cat "$plan")"
 grep -q "id: safe-push" "$plan" || fail "plan: missing safe-push task" "$(cat "$plan")"
-grep -q "python3 scripts/pr_worker_safe_push.py" "$plan" || fail "plan: missing safe-push helper command" "$(cat "$plan")"
-grep -q -- "--tsv-kind orphan-attempt" "$plan" || fail "plan: safe-push must own orphan-attempt recording" "$(cat "$plan")"
+grep -q "git push --force-with-lease" "$plan" || fail "plan: missing guarded safe-push command" "$(cat "$plan")"
+grep -q "kind='orphan-attempt'" "$plan" || fail "plan: safe-push must own orphan-attempt recording" "$(cat "$plan")"
 grep -q "Do not push" "$plan" || fail "plan: repair prompt must forbid direct pushes" "$(cat "$plan")"
 awk -F '\t' '$1 == "orphan-attempt" && $2 == "801" { found=1 } END { exit found ? 0 : 1 }' "$TMP/ledger.tsv" \
   && fail "tick 1: submission must not record orphan-attempt" "$(cat "$TMP/ledger.tsv")"

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -509,6 +509,24 @@ class PlanStackActions(PlannerTestCase):
         actions = self._plan(snapshot)
         self.assertEqual(actions, ())
 
+    def test_headless_active_queue_event_waits_without_queued_label(self):
+        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="queued", head=""))
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            REQUIRED,
+            self._ledger(),
+            now_epoch=0,
+            open_pr_numbers={snapshot.number},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "bottom-already-queued")
+
+    def test_stale_active_queue_event_without_queued_label_requeues_current_head(self):
+        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="queued", head="b" * 40))
+        actions = self._plan(snapshot)
+        self.assertEqual((actions[0].kind, actions[0].detail), ("requeue", "eligible-when-ready"))
+
     def test_clean_bottom_queues_without_prior_dequeue(self):
         snapshot = pr(labels=frozenset({"admin-bypass"}))
         actions = self._plan(snapshot)


### PR DESCRIPTION
## Summary

- Publish the exact recorded repair commit when admin-bypass repair tasks leave the task branch and work directly on the PR branch.
- Treat active headless Mergify `queued`/`merging` comments with an empty head SHA as already queued for the current bottom PR, even when the transient `queued` label is absent.
- Add focused git and planner repro coverage for the unreachable repair commit and headless queued-comment cases.

## Review Claim

The admin-bypass worker no longer strands downstream safe-push tasks on unpublished commits, and it no longer requeues or caps bottom-stack PRs that Mergify has already accepted into the queue.

## Review Lane

behavior

## Review Unit

admin-bypass-worker

## Safety Invariant

Worker-owned recovery remains branch/head guarded: repair publication pushes only the recorded commit, stale non-empty queue events still requeue the current head, and no real target PR is manually rebased, relabeled, queued, merged, or force-pushed by this change.

## Slice Rationale

Both fixes are in the same admin-bypass landing path: repair publication creates the commit handoff, and bottom progress decides whether to queue or wait. Keeping them together preserves the live recovery path being tested on this branch.

## Non-goals

- No queue policy rewrite.
- No manual cleanup of stuck real PRs.
- No unrelated worker scheduling changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-admin-bypass-safe-push-unreachable-commit.sh`
- [x] `python3 scripts/test_mergify_admin_requeue_plan.py`
- [x] `bash scripts/repro/repro-babysit-headless-queued-comment.sh`
- [x] `pnpm --filter @invoker/execution-engine build`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/auto-commit.test.ts src/__tests__/ssh-git-exec.test.ts src/__tests__/infra-repair-worker.test.ts`
- [x] `pnpm --filter @invoker/app build`
- [x] `git diff --check`
- [ ] `bash ./loop-driver.sh` - still fails on existing legacy repros that expect inline repair execution after this worker path moved to delegated repairs; the targeted queued-comment repro now passes.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert bf7b26960`
- Post-revert steps: rerun `pnpm --filter @invoker/app build` and restart Invoker from the reverted branch
- Data migration? No

</details>

