### PR TITLE
Publish recorded admin-bypass repair commits

### DIFF
--- a/packages/execution-engine/src/__tests__/auto-commit.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-commit.test.ts
@@ -55,8 +55,13 @@ class TestExecutor extends BaseExecutor<BaseEntry> {
     return this.syncFromRemote(cwd, executionId);
   }
 
-  async testPushBranchToRemote(cwd: string, branch: string, executionId?: string): Promise<string | undefined> {
-    return this.pushBranchToRemote(cwd, branch, executionId);
+  async testPushBranchToRemote(
+    cwd: string,
+    branch: string,
+    executionId?: string,
+    sourceCommitHash?: string,
+  ): Promise<string | undefined> {
+    return this.pushBranchToRemote(cwd, branch, executionId, undefined, sourceCommitHash);
   }
 
   async testHandleProcessExit(
@@ -2112,6 +2117,42 @@ describe('BaseExecutor.pushBranchToRemote', () => {
     expect(remoteSha).toBe(taskSha);
   });
 
+  it('pushes the recorded commit when current checkout is not the task branch', async () => {
+    const taskBranch = 'invoker/task-stale';
+    const prBranch = 'pr/head';
+
+    execSync(`git checkout -b ${taskBranch}`, { cwd: cloneDir });
+    writeFileSync(join(cloneDir, 'task.txt'), 'stale task branch\n');
+    execSync('git add -A && git commit -m "stale task commit"', { cwd: cloneDir });
+    const staleTaskSha = execSync('git rev-parse HEAD', { cwd: cloneDir }).toString().trim();
+    execSync(`git push origin HEAD:refs/heads/${taskBranch}`, { cwd: cloneDir });
+
+    execSync(`git checkout -b ${prBranch} master`, { cwd: cloneDir });
+    writeFileSync(join(cloneDir, 'pr.txt'), 'recorded repair commit\n');
+    execSync('git add -A && git commit -m "recorded repair commit"', { cwd: cloneDir });
+    const recordedSha = execSync('git rev-parse HEAD', { cwd: cloneDir }).toString().trim();
+
+    const pushErr = await executor.testPushBranchToRemote(cloneDir, taskBranch, undefined, recordedSha);
+    expect(pushErr).toBeUndefined();
+
+    const remoteSha = execSync(`git --git-dir="${originDir}" rev-parse "refs/heads/${taskBranch}"`)
+      .toString()
+      .trim();
+    expect(remoteSha).toBe(recordedSha);
+    expect(remoteSha).not.toBe(staleTaskSha);
+
+    const freshClone = mkdtempSync(join(tmpdir(), 'push-fresh-clone-'));
+    try {
+      execSync(`git clone ${originDir} .`, { cwd: freshClone });
+      const reachableSha = execSync(`git rev-parse --verify "${recordedSha}^{commit}"`, { cwd: freshClone })
+        .toString()
+        .trim();
+      expect(reachableSha).toBe(recordedSha);
+    } finally {
+      rmSync(freshClone, { recursive: true, force: true });
+    }
+  });
+
   it('returns an error message when branch does not exist on remote', async () => {
     const err = await executor.testPushBranchToRemote(cloneDir, 'nonexistent-branch');
     expect(err).toBeDefined();
@@ -2176,6 +2217,49 @@ describe('BaseExecutor.handleProcessExit push semantics', () => {
     rmSync(originDir, { recursive: true, force: true });
     rmSync(cloneDir, { recursive: true, force: true });
     vi.restoreAllMocks();
+  });
+
+  it('publishes the recorded process-exit commit when current checkout is not the task branch', async () => {
+    const taskBranch = 'invoker/admin-bypass-repair';
+    const prBranch = 'pr/head';
+
+    execSync(`git checkout -b ${taskBranch}`, { cwd: cloneDir });
+    writeFileSync(join(cloneDir, 'task.txt'), 'stale task branch\n');
+    execSync('git add -A && git commit -m "stale task commit"', { cwd: cloneDir });
+    const staleTaskSha = execSync('git rev-parse HEAD', { cwd: cloneDir }).toString().trim();
+    execSync(`git push origin HEAD:refs/heads/${taskBranch}`, { cwd: cloneDir });
+
+    execSync(`git checkout -b ${prBranch} master`, { cwd: cloneDir });
+    writeFileSync(join(cloneDir, 'repair.txt'), 'repair committed from pr checkout\n');
+
+    const req = makeRequest('admin-bypass-repair', { description: 'repair' });
+    const entry = executor.registerTestEntry('e-admin-bypass-repair', req);
+    let response: WorkResponse | undefined;
+    entry.completeListeners.add((r) => { response = r; });
+
+    await executor.testHandleProcessExit('e-admin-bypass-repair', req, cloneDir, 0, { branch: taskBranch });
+
+    expect(response?.status).toBe('completed');
+    const commitHash = response?.outputs.commitHash;
+    if (!commitHash) throw new Error('expected process exit to record a commit hash');
+    expect(commitHash).toMatch(/^[0-9a-f]{40}$/);
+
+    const remoteSha = execSync(`git --git-dir="${originDir}" rev-parse "refs/heads/${taskBranch}"`)
+      .toString()
+      .trim();
+    expect(remoteSha).toBe(commitHash);
+    expect(remoteSha).not.toBe(staleTaskSha);
+
+    const freshClone = mkdtempSync(join(tmpdir(), 'hpe-fresh-clone-'));
+    try {
+      execSync(`git clone ${originDir} .`, { cwd: freshClone });
+      const reachableSha = execSync(`git rev-parse --verify "${commitHash}^{commit}"`, { cwd: freshClone })
+        .toString()
+        .trim();
+      expect(reachableSha).toBe(commitHash);
+    } finally {
+      rmSync(freshClone, { recursive: true, force: true });
+    }
   });
 
   it('marks task failed when exit 0 but push fails', async () => {

--- a/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
@@ -287,7 +287,7 @@ describe('infra-repair worker', () => {
     expect(parseInfraRepairRecreateTaskMutationArgs(h.submissions[0]?.args ?? [])).toEqual({ taskId: 'wf-1/task-1' });
   });
 
-  it('recreates invalid-reference and no-saved-workspace failures', async () => {
+  it('recreates invalid branch-reference and no-saved-workspace failures', async () => {
     for (const error of [
       'fatal: invalid reference: refs/heads/feature/task-1',
       'Cannot apply a fix because this task has no saved workspace.',
@@ -302,6 +302,37 @@ describe('infra-repair worker', () => {
       expect(h.submissions[0]?.channel).toBe(INFRA_REPAIR_RECREATE_TASK_CHANNEL);
       expect(parseInfraRepairRecreateTaskMutationArgs(h.submissions[0]?.args ?? [])).toEqual({ taskId: 'wf-1/task-1' });
     }
+  });
+
+  it('does not recreate a task when invalid-reference points at a missing upstream commit', async () => {
+    const missingCommit = '0a9fa79519df5dbada79e06f9899e22b26549435';
+    const h = makeHarness([
+      makeTask({
+        execution: {
+          error: `fatal: invalid reference: ${missingCommit}`,
+        },
+      }),
+    ]);
+
+    await h.tick(POLL_CTX);
+
+    expect(h.submit).not.toHaveBeenCalled();
+    expect(workerActions(h.actions)).toEqual([expect.objectContaining({
+      workerKind: INFRA_REPAIR_WORKER_KIND,
+      actionType: 'repair-infra-failure',
+      taskId: 'wf-1/task-1',
+      status: 'completed',
+      payload: expect.objectContaining({
+        infraReason: 'ssh-invalid-reference',
+        invalidReference: missingCommit,
+        reason: 'upstream-commit-unreachable',
+      }),
+    })]);
+
+    await h.tick({ ...POLL_CTX, tickNumber: 2 });
+
+    expect(h.submit).not.toHaveBeenCalled();
+    expect(workerActions(h.actions)).toHaveLength(1);
   });
 
   it('suppresses a second target repair but still retries a later task after recent success', async () => {

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync, execSync } from 'node:child_process';
@@ -467,7 +467,8 @@ describe('buildRecordAndPushScript', () => {
     expect(script).toContain('git commit --allow-empty -F');
     expect(script).toContain('git commit -F');
     expect(script).toContain('HASH=$(git rev-parse HEAD)');
-    expect(script).toContain('git push origin "$BR:refs/heads/$BR"');
+    expect(script).toContain('REMOTE_EXPECTED=$(git ls-remote "$PUSH_REMOTE" "refs/heads/$BR"');
+    expect(script).toContain('git push --force-with-lease="refs/heads/$BR:$REMOTE_EXPECTED" "$PUSH_REMOTE" "$HASH:refs/heads/$BR"');
     expect(script).toContain('printf "%s" "$HASH"');
   });
 
@@ -497,7 +498,8 @@ describe('buildRecordAndPushScript', () => {
 
     expect(script).not.toContain('git remote set-url invoker-branches "$PUSH_URL"');
     expect(script).not.toContain('git remote add invoker-branches "$PUSH_URL"');
-    expect(script).toContain('git push "$PUSH_URL" "$BR:refs/heads/$BR"');
+    expect(script).toContain('PUSH_REMOTE="$PUSH_URL"');
+    expect(script).toContain('git push --force-with-lease="refs/heads/$BR:$REMOTE_EXPECTED" "$PUSH_REMOTE" "$HASH:refs/heads/$BR"');
   });
 
   it('commits and pushes successfully without preconfigured git identity', () => {
@@ -546,6 +548,74 @@ describe('buildRecordAndPushScript', () => {
     expect(authorName).toBe('Remote CI Bot');
     expect(authorEmail).toBe('remote-ci@example.com');
     expect(pushedHead).toBe(localHead);
+  });
+
+  it('pushes the recorded HEAD when the checkout branch differs from the target branch', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ssh-record-push-different-branch-'));
+    try {
+      const source = join(root, 'source');
+      const bare = join(root, 'remote.git');
+      const clone = join(root, 'clone');
+      const targetBranch = 'experiment/test-branch';
+
+      mkdirSync(source, { recursive: true });
+      execSync('git init -b master', { cwd: source, stdio: 'ignore' });
+      writeFileSync(join(source, 'README.md'), 'seed\n');
+      execSync('git add README.md', { cwd: source, stdio: 'ignore' });
+      execSync('git -c user.name="Seed User" -c user.email="seed@example.com" commit -m "seed"', {
+        cwd: source,
+        stdio: 'ignore',
+      });
+      execSync(`git clone --bare ${JSON.stringify(source)} ${JSON.stringify(bare)}`, { stdio: 'ignore' });
+      execSync(`git clone ${JSON.stringify(bare)} ${JSON.stringify(clone)}`, { stdio: 'ignore' });
+
+      execSync(`git checkout -b ${targetBranch}`, { cwd: clone, stdio: 'ignore' });
+      writeFileSync(join(clone, 'stale.txt'), 'stale target branch\n');
+      execSync('git add stale.txt', { cwd: clone, stdio: 'ignore' });
+      execSync('git -c user.name="Seed User" -c user.email="seed@example.com" commit -m "stale target"', {
+        cwd: clone,
+        stdio: 'ignore',
+      });
+      const staleTargetSha = execSync('git rev-parse HEAD', { cwd: clone }).toString().trim();
+      execSync(`git push origin HEAD:refs/heads/${targetBranch}`, { cwd: clone, stdio: 'ignore' });
+
+      execSync('git checkout -b pr/head master', { cwd: clone, stdio: 'ignore' });
+      writeFileSync(join(clone, 'result.txt'), 'recorded repair commit\n');
+
+      const script = buildRecordAndPushScript({
+        worktreePath: clone,
+        branch: targetBranch,
+        commitMessageChanges: 'invoker: record remote result',
+        commitMessageEmpty: 'invoker: record remote empty result',
+        gitUserName: 'Remote CI Bot',
+        gitUserEmail: 'remote-ci@example.com',
+      });
+
+      const stdout = execFileSync('bash', ['-lc', script], {
+        env: {
+          ...process.env,
+          HOME: mkdtempSync(join(tmpdir(), 'ssh-record-push-home-')),
+        },
+      }).toString().trim();
+      const outputParts = stdout.split(/\s+/);
+      const recordedSha = outputParts[outputParts.length - 1];
+      const pushedHead = execSync(`git --git-dir=${JSON.stringify(bare)} rev-parse refs/heads/${targetBranch}`)
+        .toString()
+        .trim();
+
+      expect(recordedSha).toMatch(/^[0-9a-f]{40}$/);
+      expect(pushedHead).toBe(recordedSha);
+      expect(pushedHead).not.toBe(staleTargetSha);
+
+      const freshClone = join(root, 'fresh');
+      execSync(`git clone ${JSON.stringify(bare)} ${JSON.stringify(freshClone)}`, { stdio: 'ignore' });
+      const reachableSha = execSync(`git rev-parse --verify "${recordedSha}^{commit}"`, { cwd: freshClone })
+        .toString()
+        .trim();
+      expect(reachableSha).toBe(recordedSha);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -860,7 +860,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     if (!commitHash) {
       return { error: 'commit approved fix failed' };
     }
-    const pushError = await this.pushBranchToRemote(cwd, branch, undefined, request.inputs.branchRepoUrl);
+    const pushError = await this.pushBranchToRemote(cwd, branch, undefined, request.inputs.branchRepoUrl, commitHash);
     if (pushError) {
       return { error: pushError };
     }
@@ -976,6 +976,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     branch: string,
     executionId?: string,
     branchRepoUrlOverride?: string,
+    sourceCommitHash?: string,
   ): Promise<string | undefined> {
     try {
       const requestBranchRepoUrl = branchRepoUrlOverride ?? (executionId
@@ -992,10 +993,16 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
         });
       }
       const destinationRef = `refs/heads/${branch}`;
-      const currentBranch = (await this.execGitSimple(['branch', '--show-current'], cwd)).trim();
-      const sourceRef = !currentBranch || currentBranch === branch
-        ? 'HEAD'
-        : `refs/heads/${branch}`;
+      const explicitSourceRef = sourceCommitHash?.trim();
+      let sourceRef: string;
+      if (explicitSourceRef) {
+        sourceRef = explicitSourceRef;
+      } else {
+        const currentBranch = (await this.execGitSimple(['branch', '--show-current'], cwd)).trim();
+        sourceRef = !currentBranch || currentBranch === branch
+          ? 'HEAD'
+          : `refs/heads/${branch}`;
+      }
       const sourceSha = (await this.execGitSimple(['rev-parse', '--verify', `${sourceRef}^{commit}`], cwd)).trim();
       const branchRef = `${sourceSha}:${destinationRef}`;
       try {
@@ -1209,7 +1216,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
 
     let pushError: string | undefined;
     if (opts?.branch) {
-      pushError = await this.pushBranchToRemote(cwd, opts.branch, executionId);
+      pushError = await this.pushBranchToRemote(cwd, opts.branch, executionId, undefined, commitHash);
     }
     if (effectiveExitCode === 0 && pushError !== undefined && opts?.branch) {
       if (this.isTransientGitTransportError(pushError)) {

--- a/packages/execution-engine/src/docker-executor.ts
+++ b/packages/execution-engine/src/docker-executor.ts
@@ -247,6 +247,7 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
     branch: string,
     executionId?: string,
     branchRepoUrlOverride?: string,
+    sourceCommitHash?: string,
   ): Promise<string | undefined> {
     try {
       await this.execGitSimple(['remote', 'get-url', 'origin'], cwd);
@@ -258,9 +259,9 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
         if (executionId) this.emitOutput(executionId, msg);
         return undefined;
       }
-      return await super.pushBranchToRemote(cwd, branch, executionId, branchRepoUrlOverride);
+      return await super.pushBranchToRemote(cwd, branch, executionId, branchRepoUrlOverride, sourceCommitHash);
     }
-    return await super.pushBranchToRemote(cwd, branch, executionId, branchRepoUrlOverride);
+    return await super.pushBranchToRemote(cwd, branch, executionId, branchRepoUrlOverride, sourceCommitHash);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -388,9 +388,15 @@ HASH=$(git rev-parse HEAD)
 BR=$(printf '%s' ${shellPosixSingleQuote(brB)} | invoker_base64_decode)
 PUSH_URL=$(printf '%s' ${shellPosixSingleQuote(pushRemoteUrlB)} | invoker_base64_decode)
 if [ -n "$PUSH_URL" ]; then
-  git push "$PUSH_URL" "$BR:refs/heads/$BR"
+  PUSH_REMOTE="$PUSH_URL"
 else
-  git push origin "$BR:refs/heads/$BR"
+  PUSH_REMOTE=origin
+fi
+REMOTE_EXPECTED=$(git ls-remote "$PUSH_REMOTE" "refs/heads/$BR" | awk 'NR == 1 { print $1 }')
+if [ -n "$REMOTE_EXPECTED" ]; then
+  git push --force-with-lease="refs/heads/$BR:$REMOTE_EXPECTED" "$PUSH_REMOTE" "$HASH:refs/heads/$BR"
+else
+  git push "$PUSH_REMOTE" "$HASH:refs/heads/$BR"
 fi
 printf "%s" "$HASH"
 `;

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -198,6 +198,11 @@ function tailText(text: string): string {
   return text.length <= MAX_OUTPUT_TAIL_CHARS ? text : text.slice(-MAX_OUTPUT_TAIL_CHARS);
 }
 
+function missingCommitInvalidReference(errorText: string | undefined): string | undefined {
+  const match = errorText?.match(/fatal: invalid reference:\s+([0-9a-f]{40})(?:\b|$)/i);
+  return match?.[1];
+}
+
 function taskDecisionExternalKey(candidate: Pick<InfraRepairScanCandidate, 'taskId' | 'generation' | 'taskStateVersion'>, reason: InfraRepairReason): string {
   return `task:${candidate.taskId}:g${candidate.generation}:v${candidate.taskStateVersion}:${reason}`;
 }
@@ -581,6 +586,23 @@ async function handleInvalidReferenceRecovery(
   options: InfraRepairWorkerPolicyOptions,
   candidate: ValidatedGenericSshInfraCandidate,
 ): Promise<void> {
+  const missingCommit = missingCommitInvalidReference(candidate.task.execution.error);
+  if (missingCommit) {
+    recordTaskDecision(
+      options,
+      candidate,
+      candidate.reason,
+      'completed',
+      'Skipped recreate for missing upstream commit reference',
+      {
+        targetId: candidate.targetId,
+        invalidReference: missingCommit,
+      },
+      'upstream-commit-unreachable',
+    );
+    return;
+  }
+
   await submitFollowUpMutation(
     options,
     candidate,


### PR DESCRIPTION
## Summary

Pushes the recorded repair commit object to the task branch.

Preserves existing branch-lease guards while publishing the object downstream tasks consume.

## Review Claim

Recorded repair commits are reachable from the remote task branch even when the repair process checked out another branch.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The publish path still uses force-with-lease and reports failures instead of silently changing unrelated branches.

## Slice Rationale

This is one branch handoff path: record a repair commit, publish that exact object, and classify missing upstream objects accurately.

## Non-goals

- No queue policy changes.
- No manual PR cleanup.
- No scheduler changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine build`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/auto-commit.test.ts src/__tests__/ssh-git-exec.test.ts src/__tests__/infra-repair-worker.test.ts`
- [x] `pnpm --filter @invoker/app build`
- [x] `git diff --check`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f3f408163`
- Post-revert steps: rebuild `@invoker/execution-engine` and `@invoker/app`
- Data migration? No

</details>
