### PR TITLE
Add admin-bypass repair queue repros

### DIFF
--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -16,6 +16,7 @@ REPROS=(
   scripts/repro/repro-babysit-amended-repair-push.sh
   scripts/repro/repro-babysit-outdated-bot-thread.sh
   scripts/repro/repro-babysit-headless-queued-comment.sh
+  scripts/repro/repro-admin-bypass-queue-bot-thread.sh
   scripts/repro/repro-babysit-queue-only-empty-log.sh
   scripts/repro/repro-babysit-queue-only-missing-requeues.sh
   scripts/repro/repro-babysit-targeted-scan-light.sh

--- a/scripts/cron-admin-bypass-queue.sh
+++ b/scripts/cron-admin-bypass-queue.sh
@@ -36,6 +36,34 @@ LABEL="${INVOKER_ADMIN_BYPASS_LABEL:-admin-bypass}"
 REPO_URL="${INVOKER_ADMIN_BYPASS_REPO_URL:-https://github.com/$TARGET_REPO.git}"
 ledger_init "$STATE_FILE"
 
+unresolved_bot_review_thread() {
+  local pr_number="${1:?pr number required}"
+  local owner="${TARGET_REPO%%/*}"
+  local repo_name="${TARGET_REPO#*/}"
+  local query threads
+  query='query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { reviewThreads(first:100) { pageInfo { hasNextPage } nodes { id isResolved isOutdated comments(first:50) { nodes { author { login } } } } } } } }'
+  if ! threads="$(gh_json api graphql -f "owner=$owner" -f "name=$repo_name" -F "number=$pr_number" -f "query=$query")"; then
+    log_line "PR #$pr_number: could not load review threads; skipping review-thread classifier"
+    return 0
+  fi
+  jq -r '
+    .data.repository.pullRequest.reviewThreads as $threads
+    | if ($threads.pageInfo.hasNextPage // false) then empty else
+        $threads.nodes[]?
+        | select((.isResolved // false) == false)
+        | select((.isOutdated // false) == false)
+        | select(
+            [
+              .comments.nodes[]?.author.login // ""
+              | select(. != "" and . != "coderabbitai" and . != "coderabbitai[bot]" and . != "EdbertChan")
+            ]
+            | length == 0
+          )
+        | .id
+      end
+  ' <<<"$threads" | sed -n '1p'
+}
+
 # Repros pass INVOKER_ADMIN_BYPASS_QUEUE_PLAN_DIR to inspect submitted plans; a
 # caller-provided dir is never cleaned up here.
 if [ -n "${INVOKER_ADMIN_BYPASS_QUEUE_PLAN_DIR:-}" ]; then
@@ -84,6 +112,13 @@ while IFS= read -r pr; do
   if [ -z "$category" ] && [ "$(jq -r '.reviewDecision // ""' <<<"$pr")" = "CHANGES_REQUESTED" ]; then
     category="changes_requested"
     detail="a reviewer requested changes; address the open feedback"
+  fi
+  if [ -z "$category" ]; then
+    bot_thread="$(unresolved_bot_review_thread "$num")"
+    if [ -n "$bot_thread" ]; then
+      category="bot_review_thread"
+      detail="unresolved bot review thread $bot_thread"
+    fi
   fi
   if [ -z "$category" ]; then
     log_line "PR #$num: no actionable blocker found; skipping"
@@ -183,6 +218,7 @@ while IFS= read -r pr; do
       printf -- '- If this is a merge conflict, rebase onto origin/%s (or merge it) before anything else.\n' "$base_ref"
       printf -- '- If checks are failing, reproduce and fix them locally.\n'
       printf -- '- If changes were requested, address the open feedback with real changes or a reasoned reply, never by dismissing.\n'
+      printf -- '- If the blocker is a bot review thread, inspect the unresolved thread, address the feedback with code or tests, and leave it unresolved for the platform to reconcile after the push unless it is already outdated.\n'
       printf -- '- Commit locally if changes are needed.\n'
       printf -- '- Do not push, do not open a new PR, and do not force-push. The safe-push task owns publication.\n'
     } | sed 's/^/      /'

--- a/scripts/repro/repro-admin-bypass-queue-bot-thread.sh
+++ b/scripts/repro/repro-admin-bypass-queue-bot-thread.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-admin-bypass-queue-bot-thread.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+mkdir -p "$TMP/bin" "$TMP/home" "$TMP/plans" "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+
+ln -s "$ROOT/scripts/repro/fixtures/fake-gh/bin/gh" "$TMP/bin/gh"
+NODE_LOG="$TMP/node-calls.log"
+: > "$NODE_LOG"
+cat > "$TMP/bin/node" <<EOF
+#!/usr/bin/env bash
+printf 'node %s\n' "\$*" >> "$NODE_LOG"
+exit 0
+EOF
+chmod +x "$TMP/bin/node"
+
+cat > "$TMP/review-gate.sh" <<'RG'
+#!/usr/bin/env bash
+printf '{}\n'
+RG
+chmod +x "$TMP/review-gate.sh"
+
+python3 - "$TMP/state/state.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+head = "9fc81429638a8a0b62bf7b9b337cd60f38461c53"
+state = {
+    "prs": [
+        {
+            "number": 6575,
+            "title": "Provision a real isolated worktree for planning-chat sessions",
+            "body": "## Summary\n\nWorktree provisioning slice.\n",
+            "url": "https://github.com/fake/repo/pull/6575",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "stack/planning-chat-worktree",
+            "headRefOid": head,
+            "mergeStateStatus": "BLOCKED",
+            "mergeable": "MERGEABLE",
+            "labels": ["admin-bypass"],
+            "reviewDecision": "REVIEW_REQUIRED",
+            "reviewThreads": [
+                {
+                    "id": "PRRT_bot_6575",
+                    "isResolved": False,
+                    "isOutdated": False,
+                    "comments": {
+                        "nodes": [
+                            {"author": {"login": "coderabbitai[bot]"}},
+                            {"author": {"login": "EdbertChan"}},
+                        ]
+                    },
+                }
+            ],
+            "checks": {"*": "SUCCESS"},
+        }
+    ],
+    "issue_comments": {"6575": []},
+    "job_logs": {},
+}
+Path(sys.argv[1]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+
+run_cron() {
+  PATH="$TMP/bin:$PATH" \
+  HOME="$TMP/home" \
+  INVOKER_GITHUB_TARGET_REPO="fake/repo" \
+  INVOKER_PR_CRON_AUTHOR="fake-bot" \
+  INVOKER_PR_CRON_LOCK="$TMP/crons.lock" \
+  INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh" \
+  INVOKER_ADMIN_BYPASS_QUEUE_STATE_FILE="$TMP/admin-bypass-queue.tsv" \
+  INVOKER_ADMIN_BYPASS_QUEUE_PLAN_DIR="$TMP/plans" \
+  bash "$ROOT/scripts/cron-admin-bypass-queue.sh" 2>&1
+}
+
+out="$(run_cron)" || fail "cron exited non-zero" "$out"
+echo "$out" | grep -q "PR #6575: submitted ad-hoc repair plan (category=bot_review_thread" \
+  || fail "expected bot review thread to submit an ad-hoc repair plan" "$out"
+
+plan="$TMP/plans/repair-pr-6575.yaml"
+[ -f "$plan" ] || fail "expected repair plan file for #6575" "$out"
+grep -q "Blocker category: bot_review_thread" "$plan" \
+  || fail "plan did not preserve bot_review_thread category" "$(cat "$plan")"
+grep -q "unresolved bot review thread PRRT_bot_6575" "$plan" \
+  || fail "plan did not name the unresolved bot thread" "$(cat "$plan")"
+grep -q "bot review thread" "$plan" \
+  || fail "plan did not instruct the repair task how to handle bot threads" "$(cat "$plan")"
+
+grep -q "exec --no-track -- run .*repair-pr-6575.yaml" "$NODE_LOG" \
+  || fail "expected Invoker run submission through headless IPC" "$(cat "$NODE_LOG")"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-admin-bypass-safe-push-unreachable-commit.sh
+++ b/scripts/repro/repro-admin-bypass-safe-push-unreachable-commit.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reproduces the admin-bypass repair handoff failure with real git repos.
+#
+# The repair task prompt told the agent to check out the real PR head branch.
+# BaseExecutor then recorded HEAD from that PR branch, but pre-fix pushBranchToRemote
+# published refs/heads/$task_branch because the current branch was different.
+# A fresh downstream safe-push workspace cannot resolve the recorded commit.
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/admin-bypass-unreachable-commit.XXXXXX")"
+if [[ "${KEEP_TEMP:-0}" != "1" ]]; then
+  trap 'rm -rf "$tmp_dir"' EXIT
+else
+  trap 'printf "kept temp dir: %s\n" "$tmp_dir"' EXIT
+fi
+
+origin="$tmp_dir/origin.git"
+seed="$tmp_dir/seed"
+repair="$tmp_dir/repair"
+mirror="$tmp_dir/mirror"
+safe_push_worktree="$tmp_dir/safe-push-worktree"
+
+base_branch="stack/base"
+pr_branch="stack/pr-head"
+task_branch="experiment/wf-admin-bypass-repro/repair/g0.t0.a-deadbeef"
+safe_push_branch="experiment/wf-admin-bypass-repro/safe-push/g0.t0.a-cafebabe"
+
+git init --bare "$origin" >/dev/null 2>&1
+git clone "$origin" "$seed" >/dev/null 2>&1
+git -C "$seed" config user.email "repro@example.com"
+git -C "$seed" config user.name "Admin Bypass Repro"
+
+git -C "$seed" checkout -B master >/dev/null 2>&1
+printf 'base\n' >"$seed/file.txt"
+git -C "$seed" add file.txt
+git -C "$seed" commit -m "base" >/dev/null
+
+git -C "$seed" checkout -B "$base_branch" >/dev/null 2>&1
+base_sha="$(git -C "$seed" rev-parse HEAD)"
+git -C "$seed" push origin "$base_branch:refs/heads/$base_branch" >/dev/null 2>&1
+
+git -C "$seed" checkout -B "$pr_branch" "$base_branch" >/dev/null 2>&1
+printf 'pr head\n' >"$seed/pr.txt"
+git -C "$seed" add pr.txt
+git -C "$seed" commit -m "pr head" >/dev/null
+pr_sha="$(git -C "$seed" rev-parse HEAD)"
+git -C "$seed" push origin "$pr_branch:refs/heads/$pr_branch" >/dev/null 2>&1
+
+git -C "$seed" checkout -B "$task_branch" "$base_branch" >/dev/null 2>&1
+git -C "$seed" push origin "$task_branch:refs/heads/$task_branch" >/dev/null 2>&1
+
+git clone "$origin" "$repair" >/dev/null 2>&1
+git -C "$repair" config user.email "repro@example.com"
+git -C "$repair" config user.name "Admin Bypass Repro"
+git -C "$repair" fetch origin '+refs/heads/*:refs/remotes/origin/*' >/dev/null 2>&1
+git -C "$repair" checkout -B "$task_branch" "origin/$task_branch" >/dev/null 2>&1
+
+# Simulate the deployed admin-bypass repair prompt:
+#   git fetch origin <head_ref> && git checkout <head_ref>
+git -C "$repair" fetch origin "$pr_branch" >/dev/null 2>&1
+git -C "$repair" checkout -B "$pr_branch" "origin/$pr_branch" >/dev/null 2>&1
+printf 'repair commit made while on PR branch\n' >>"$repair/pr.txt"
+git -C "$repair" add pr.txt
+git -C "$repair" commit -m "repair on PR branch" >/dev/null
+recorded_commit="$(git -C "$repair" rev-parse HEAD)"
+
+# Simulate the pre-fix BaseExecutor.pushBranchToRemote source-ref selection:
+# if the worktree is not on the task branch, push refs/heads/$task_branch.
+current_branch="$(git -C "$repair" branch --show-current)"
+if [[ -z "$current_branch" || "$current_branch" == "$task_branch" ]]; then
+  source_ref="HEAD"
+else
+  source_ref="refs/heads/$task_branch"
+fi
+source_sha="$(git -C "$repair" rev-parse --verify "$source_ref^{commit}")"
+git -C "$repair" push --force-with-lease origin "$source_sha:refs/heads/$task_branch" >/dev/null 2>&1
+
+remote_task_sha="$(git --git-dir="$origin" rev-parse "refs/heads/$task_branch")"
+if [[ "$remote_task_sha" == "$recorded_commit" ]]; then
+  fail "task branch unexpectedly points at the recorded repair commit"
+fi
+
+git clone "$origin" "$mirror" >/dev/null 2>&1
+set +e
+startup_output="$(
+  git -C "$mirror" worktree add --no-track -B "$safe_push_branch" "$safe_push_worktree" "$recorded_commit" 2>&1
+)"
+startup_code=$?
+set -e
+
+if [[ "$startup_code" -eq 0 ]]; then
+  fail "fresh downstream workspace unexpectedly resolved the unpublished repair commit"
+fi
+
+if ! grep -Eqi 'invalid reference|not a valid object name|reference is not a tree|Needed a single revision|unknown revision|bad object|ambiguous argument' <<<"$startup_output"; then
+  printf '%s\n' "$startup_output" >&2
+  fail "downstream failed, but not with an unresolvable commit/reference error"
+fi
+
+printf 'base_sha=%s\n' "$base_sha"
+printf 'pr_sha=%s\n' "$pr_sha"
+printf 'recorded_repair_commit=%s\n' "$recorded_commit"
+printf 'published_task_branch_sha=%s\n' "$remote_task_sha"
+printf 'executor_source_ref=%s\n' "$source_ref"
+printf 'downstream_startup_status=%s\n' "$startup_code"
+printf 'downstream_startup_error=%s\n' "$(printf '%s' "$startup_output" | tail -n 1)"
+printf 'PASS: reproduced unreachable recorded repair commit for downstream safe-push task\n'

--- a/scripts/repro/repro-babysit-headless-queued-comment.sh
+++ b/scripts/repro/repro-babysit-headless-queued-comment.sh
@@ -45,7 +45,7 @@ state = {
     "prs": [
         {
             "number": 5805,
-            "title": "Already queued with headless Mergify status",
+            "title": "Already queued with headless Mergify status and no queued label",
             "body": "## Summary\n\nQueued PR repro.\n",
             "url": "https://github.com/fake/repo/pull/5805",
             "state": "OPEN",
@@ -55,7 +55,7 @@ state = {
             "headRefOid": head,
             "mergeStateStatus": "BLOCKED",
             "mergeable": "MERGEABLE",
-            "labels": ["admin-bypass", "queued"],
+            "labels": ["admin-bypass"],
             "reviewThreads": [],
             "checks": {"*": "SUCCESS"},
         }

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -219,14 +219,14 @@ Failing checks
         actions = plan_stack_actions(groups[0], REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number) for a in actions], [("comment_admin_bypass_nudge", 2604)])
 
-    def test_upper_stack_blocker_stops_bottom_requeue(self):
+    def test_upper_stack_blocker_does_not_stop_bottom_requeue(self):
         failed = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
         stack = StackGroup("s", (pr(2604, head="stack/a", latest=mergify()), pr(2605, base="stack/a", checks=failed)))
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
-        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("repair_check", 2605)])
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("requeue", 2604)])
         thread_stack = StackGroup("s", (pr(2604, head="stack/a", latest=mergify()), pr(2605, base="stack/a", threads=(ReviewThread("t1", False, ("alice",)),))))
         actions = plan_stack_actions(thread_stack, REQUIRED, self.ledger(), 1)
-        self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2605, "unresolved human review thread t1")])
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("requeue", 2604)])
     def test_unaccepted_upper_failed_check_repairs_upper_before_bottom(self):
         failed = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
         stack = StackGroup(


### PR DESCRIPTION
## Summary

Adds focused repros for the repair commit handoff, active queue status, and bot-review-thread repair loading cases.

Keeps proof files separate from behavior and policy changes.

## Review Claim

The repro suite covers unreachable recorded repair commits, active queue status, and CodeRabbit-thread-only admin-bypass PRs without relying on live PR edits.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

These scripts use isolated fake or temporary repositories and do not mutate production PR branches.

## Slice Rationale

This is one proof slice for the admin-bypass recovery cases fixed in the lower stack PRs.

## Non-goals

- No runtime behavior change.
- No policy script change.
- No live PR cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-admin-bypass-safe-push-unreachable-commit.sh`
- [x] `bash scripts/repro/repro-babysit-headless-queued-comment.sh`
- [x] `bash scripts/repro/repro-admin-bypass-queue-bot-thread.sh`
- [x] `git diff --check origin/fix/admin-bypass-bot-thread-loader..HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e2f2b8cc3 20ad4589c`
- Post-revert steps: none
- Data migration? No

</details>