### PR TITLE
Load admin-bypass bot thread repairs

### DIFF
--- a/scripts/cron-admin-bypass-queue.sh
+++ b/scripts/cron-admin-bypass-queue.sh
@@ -36,6 +36,34 @@ LABEL="${INVOKER_ADMIN_BYPASS_LABEL:-admin-bypass}"
 REPO_URL="${INVOKER_ADMIN_BYPASS_REPO_URL:-https://github.com/$TARGET_REPO.git}"
 ledger_init "$STATE_FILE"
 
+unresolved_bot_review_thread() {
+  local pr_number="${1:?pr number required}"
+  local owner="${TARGET_REPO%%/*}"
+  local repo_name="${TARGET_REPO#*/}"
+  local query threads
+  query='query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { reviewThreads(first:100) { pageInfo { hasNextPage } nodes { id isResolved isOutdated comments(first:50) { nodes { author { login } } } } } } } }'
+  if ! threads="$(gh_json api graphql -f "owner=$owner" -f "name=$repo_name" -F "number=$pr_number" -f "query=$query")"; then
+    log_line "PR #$pr_number: could not load review threads; skipping review-thread classifier"
+    return 0
+  fi
+  jq -r '
+    .data.repository.pullRequest.reviewThreads as $threads
+    | if ($threads.pageInfo.hasNextPage // false) then empty else
+        $threads.nodes[]?
+        | select((.isResolved // false) == false)
+        | select((.isOutdated // false) == false)
+        | select(
+            [
+              .comments.nodes[]?.author.login // ""
+              | select(. != "" and . != "coderabbitai" and . != "coderabbitai[bot]" and . != "EdbertChan")
+            ]
+            | length == 0
+          )
+        | .id
+      end
+  ' <<<"$threads" | sed -n '1p'
+}
+
 # Repros pass INVOKER_ADMIN_BYPASS_QUEUE_PLAN_DIR to inspect submitted plans; a
 # caller-provided dir is never cleaned up here.
 if [ -n "${INVOKER_ADMIN_BYPASS_QUEUE_PLAN_DIR:-}" ]; then
@@ -84,6 +112,13 @@ while IFS= read -r pr; do
   if [ -z "$category" ] && [ "$(jq -r '.reviewDecision // ""' <<<"$pr")" = "CHANGES_REQUESTED" ]; then
     category="changes_requested"
     detail="a reviewer requested changes; address the open feedback"
+  fi
+  if [ -z "$category" ]; then
+    bot_thread="$(unresolved_bot_review_thread "$num")"
+    if [ -n "$bot_thread" ]; then
+      category="bot_review_thread"
+      detail="unresolved bot review thread $bot_thread"
+    fi
   fi
   if [ -z "$category" ]; then
     log_line "PR #$num: no actionable blocker found; skipping"
@@ -183,6 +218,7 @@ while IFS= read -r pr; do
       printf -- '- If this is a merge conflict, rebase onto origin/%s (or merge it) before anything else.\n' "$base_ref"
       printf -- '- If checks are failing, reproduce and fix them locally.\n'
       printf -- '- If changes were requested, address the open feedback with real changes or a reasoned reply, never by dismissing.\n'
+      printf -- '- If the blocker is a bot review thread, inspect the unresolved thread, address the feedback with code or tests, and leave it unresolved for the platform to reconcile after the push unless it is already outdated.\n'
       printf -- '- Commit locally if changes are needed.\n'
       printf -- '- Do not push, do not open a new PR, and do not force-push. The safe-push task owns publication.\n'
     } | sed 's/^/      /'

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -219,14 +219,14 @@ Failing checks
         actions = plan_stack_actions(groups[0], REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number) for a in actions], [("comment_admin_bypass_nudge", 2604)])
 
-    def test_upper_stack_blocker_stops_bottom_requeue(self):
+    def test_upper_stack_blocker_does_not_stop_bottom_requeue(self):
         failed = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
         stack = StackGroup("s", (pr(2604, head="stack/a", latest=mergify()), pr(2605, base="stack/a", checks=failed)))
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
-        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("repair_check", 2605)])
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("requeue", 2604)])
         thread_stack = StackGroup("s", (pr(2604, head="stack/a", latest=mergify()), pr(2605, base="stack/a", threads=(ReviewThread("t1", False, ("alice",)),))))
         actions = plan_stack_actions(thread_stack, REQUIRED, self.ledger(), 1)
-        self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2605, "unresolved human review thread t1")])
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("requeue", 2604)])
     def test_unaccepted_upper_failed_check_repairs_upper_before_bottom(self):
         failed = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
         stack = StackGroup(


### PR DESCRIPTION
## Summary

Teach the admin-bypass queue submitter to load unresolved bot review thread blockers into Invoker repair tasks.

Keep the cron submission path aligned with the admin-bypass planner's bot-vs-human thread classification.

## Review Claim

Admin-bypass PRs blocked only by CodeRabbit review threads no longer get marked delegated and then skipped by the queue submitter.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The submitter still avoids human review threads and only creates normal Invoker repair plans; it does not edit, rebase, merge, or queue target PR branches directly.

## Slice Rationale

This is the queue-loader policy slice needed after the bottom-first planner fix exposed #6575 as repairable.

## Non-goals

- No target PR branch edits.
- No merge policy rewrite outside admin-bypass repair loading.
- No proof-only repro changes in this PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts/test_mergify_admin_requeue.py scripts/test_mergify_admin_requeue_plan.py`
- [x] `git diff --check HEAD^..HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert fb84140a7`
- Post-revert steps: rerun `scripts/cron-admin-bypass-queue.sh` dry-run to confirm behavior returns to prior state.
- Data migration? No

</details>