### PR TITLE
Add admin-bypass accountability loop submitter

### DIFF
--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -16,6 +16,7 @@ REPROS=(
   scripts/repro/repro-babysit-amended-repair-push.sh
   scripts/repro/repro-babysit-outdated-bot-thread.sh
   scripts/repro/repro-babysit-headless-queued-comment.sh
+  scripts/repro/repro-admin-bypass-queue-bot-thread.sh
   scripts/repro/repro-babysit-queue-only-empty-log.sh
   scripts/repro/repro-babysit-queue-only-missing-requeues.sh
   scripts/repro/repro-babysit-targeted-scan-light.sh

--- a/packages/execution-engine/src/__tests__/auto-commit.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-commit.test.ts
@@ -55,8 +55,13 @@ class TestExecutor extends BaseExecutor<BaseEntry> {
     return this.syncFromRemote(cwd, executionId);
   }
 
-  async testPushBranchToRemote(cwd: string, branch: string, executionId?: string): Promise<string | undefined> {
-    return this.pushBranchToRemote(cwd, branch, executionId);
+  async testPushBranchToRemote(
+    cwd: string,
+    branch: string,
+    executionId?: string,
+    sourceCommitHash?: string,
+  ): Promise<string | undefined> {
+    return this.pushBranchToRemote(cwd, branch, executionId, undefined, sourceCommitHash);
   }
 
   async testHandleProcessExit(
@@ -2112,6 +2117,42 @@ describe('BaseExecutor.pushBranchToRemote', () => {
     expect(remoteSha).toBe(taskSha);
   });
 
+  it('pushes the recorded commit when current checkout is not the task branch', async () => {
+    const taskBranch = 'invoker/task-stale';
+    const prBranch = 'pr/head';
+
+    execSync(`git checkout -b ${taskBranch}`, { cwd: cloneDir });
+    writeFileSync(join(cloneDir, 'task.txt'), 'stale task branch\n');
+    execSync('git add -A && git commit -m "stale task commit"', { cwd: cloneDir });
+    const staleTaskSha = execSync('git rev-parse HEAD', { cwd: cloneDir }).toString().trim();
+    execSync(`git push origin HEAD:refs/heads/${taskBranch}`, { cwd: cloneDir });
+
+    execSync(`git checkout -b ${prBranch} master`, { cwd: cloneDir });
+    writeFileSync(join(cloneDir, 'pr.txt'), 'recorded repair commit\n');
+    execSync('git add -A && git commit -m "recorded repair commit"', { cwd: cloneDir });
+    const recordedSha = execSync('git rev-parse HEAD', { cwd: cloneDir }).toString().trim();
+
+    const pushErr = await executor.testPushBranchToRemote(cloneDir, taskBranch, undefined, recordedSha);
+    expect(pushErr).toBeUndefined();
+
+    const remoteSha = execSync(`git --git-dir="${originDir}" rev-parse "refs/heads/${taskBranch}"`)
+      .toString()
+      .trim();
+    expect(remoteSha).toBe(recordedSha);
+    expect(remoteSha).not.toBe(staleTaskSha);
+
+    const freshClone = mkdtempSync(join(tmpdir(), 'push-fresh-clone-'));
+    try {
+      execSync(`git clone ${originDir} .`, { cwd: freshClone });
+      const reachableSha = execSync(`git rev-parse --verify "${recordedSha}^{commit}"`, { cwd: freshClone })
+        .toString()
+        .trim();
+      expect(reachableSha).toBe(recordedSha);
+    } finally {
+      rmSync(freshClone, { recursive: true, force: true });
+    }
+  });
+
   it('returns an error message when branch does not exist on remote', async () => {
     const err = await executor.testPushBranchToRemote(cloneDir, 'nonexistent-branch');
     expect(err).toBeDefined();
@@ -2176,6 +2217,49 @@ describe('BaseExecutor.handleProcessExit push semantics', () => {
     rmSync(originDir, { recursive: true, force: true });
     rmSync(cloneDir, { recursive: true, force: true });
     vi.restoreAllMocks();
+  });
+
+  it('publishes the recorded process-exit commit when current checkout is not the task branch', async () => {
+    const taskBranch = 'invoker/admin-bypass-repair';
+    const prBranch = 'pr/head';
+
+    execSync(`git checkout -b ${taskBranch}`, { cwd: cloneDir });
+    writeFileSync(join(cloneDir, 'task.txt'), 'stale task branch\n');
+    execSync('git add -A && git commit -m "stale task commit"', { cwd: cloneDir });
+    const staleTaskSha = execSync('git rev-parse HEAD', { cwd: cloneDir }).toString().trim();
+    execSync(`git push origin HEAD:refs/heads/${taskBranch}`, { cwd: cloneDir });
+
+    execSync(`git checkout -b ${prBranch} master`, { cwd: cloneDir });
+    writeFileSync(join(cloneDir, 'repair.txt'), 'repair committed from pr checkout\n');
+
+    const req = makeRequest('admin-bypass-repair', { description: 'repair' });
+    const entry = executor.registerTestEntry('e-admin-bypass-repair', req);
+    let response: WorkResponse | undefined;
+    entry.completeListeners.add((r) => { response = r; });
+
+    await executor.testHandleProcessExit('e-admin-bypass-repair', req, cloneDir, 0, { branch: taskBranch });
+
+    expect(response?.status).toBe('completed');
+    const commitHash = response?.outputs.commitHash;
+    if (!commitHash) throw new Error('expected process exit to record a commit hash');
+    expect(commitHash).toMatch(/^[0-9a-f]{40}$/);
+
+    const remoteSha = execSync(`git --git-dir="${originDir}" rev-parse "refs/heads/${taskBranch}"`)
+      .toString()
+      .trim();
+    expect(remoteSha).toBe(commitHash);
+    expect(remoteSha).not.toBe(staleTaskSha);
+
+    const freshClone = mkdtempSync(join(tmpdir(), 'hpe-fresh-clone-'));
+    try {
+      execSync(`git clone ${originDir} .`, { cwd: freshClone });
+      const reachableSha = execSync(`git rev-parse --verify "${commitHash}^{commit}"`, { cwd: freshClone })
+        .toString()
+        .trim();
+      expect(reachableSha).toBe(commitHash);
+    } finally {
+      rmSync(freshClone, { recursive: true, force: true });
+    }
   });
 
   it('marks task failed when exit 0 but push fails', async () => {

--- a/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
@@ -287,7 +287,7 @@ describe('infra-repair worker', () => {
     expect(parseInfraRepairRecreateTaskMutationArgs(h.submissions[0]?.args ?? [])).toEqual({ taskId: 'wf-1/task-1' });
   });
 
-  it('recreates invalid-reference and no-saved-workspace failures', async () => {
+  it('recreates invalid branch-reference and no-saved-workspace failures', async () => {
     for (const error of [
       'fatal: invalid reference: refs/heads/feature/task-1',
       'Cannot apply a fix because this task has no saved workspace.',
@@ -302,6 +302,37 @@ describe('infra-repair worker', () => {
       expect(h.submissions[0]?.channel).toBe(INFRA_REPAIR_RECREATE_TASK_CHANNEL);
       expect(parseInfraRepairRecreateTaskMutationArgs(h.submissions[0]?.args ?? [])).toEqual({ taskId: 'wf-1/task-1' });
     }
+  });
+
+  it('does not recreate a task when invalid-reference points at a missing upstream commit', async () => {
+    const missingCommit = '0a9fa79519df5dbada79e06f9899e22b26549435';
+    const h = makeHarness([
+      makeTask({
+        execution: {
+          error: `fatal: invalid reference: ${missingCommit}`,
+        },
+      }),
+    ]);
+
+    await h.tick(POLL_CTX);
+
+    expect(h.submit).not.toHaveBeenCalled();
+    expect(workerActions(h.actions)).toEqual([expect.objectContaining({
+      workerKind: INFRA_REPAIR_WORKER_KIND,
+      actionType: 'repair-infra-failure',
+      taskId: 'wf-1/task-1',
+      status: 'completed',
+      payload: expect.objectContaining({
+        infraReason: 'ssh-invalid-reference',
+        invalidReference: missingCommit,
+        reason: 'upstream-commit-unreachable',
+      }),
+    })]);
+
+    await h.tick({ ...POLL_CTX, tickNumber: 2 });
+
+    expect(h.submit).not.toHaveBeenCalled();
+    expect(workerActions(h.actions)).toHaveLength(1);
   });
 
   it('suppresses a second target repair but still retries a later task after recent success', async () => {

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { execFileSync, execSync } from 'node:child_process';
@@ -467,7 +467,8 @@ describe('buildRecordAndPushScript', () => {
     expect(script).toContain('git commit --allow-empty -F');
     expect(script).toContain('git commit -F');
     expect(script).toContain('HASH=$(git rev-parse HEAD)');
-    expect(script).toContain('git push origin "$BR:refs/heads/$BR"');
+    expect(script).toContain('REMOTE_EXPECTED=$(git ls-remote "$PUSH_REMOTE" "refs/heads/$BR"');
+    expect(script).toContain('git push --force-with-lease="refs/heads/$BR:$REMOTE_EXPECTED" "$PUSH_REMOTE" "$HASH:refs/heads/$BR"');
     expect(script).toContain('printf "%s" "$HASH"');
   });
 
@@ -497,7 +498,8 @@ describe('buildRecordAndPushScript', () => {
 
     expect(script).not.toContain('git remote set-url invoker-branches "$PUSH_URL"');
     expect(script).not.toContain('git remote add invoker-branches "$PUSH_URL"');
-    expect(script).toContain('git push "$PUSH_URL" "$BR:refs/heads/$BR"');
+    expect(script).toContain('PUSH_REMOTE="$PUSH_URL"');
+    expect(script).toContain('git push --force-with-lease="refs/heads/$BR:$REMOTE_EXPECTED" "$PUSH_REMOTE" "$HASH:refs/heads/$BR"');
   });
 
   it('commits and pushes successfully without preconfigured git identity', () => {
@@ -546,6 +548,74 @@ describe('buildRecordAndPushScript', () => {
     expect(authorName).toBe('Remote CI Bot');
     expect(authorEmail).toBe('remote-ci@example.com');
     expect(pushedHead).toBe(localHead);
+  });
+
+  it('pushes the recorded HEAD when the checkout branch differs from the target branch', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ssh-record-push-different-branch-'));
+    try {
+      const source = join(root, 'source');
+      const bare = join(root, 'remote.git');
+      const clone = join(root, 'clone');
+      const targetBranch = 'experiment/test-branch';
+
+      mkdirSync(source, { recursive: true });
+      execSync('git init -b master', { cwd: source, stdio: 'ignore' });
+      writeFileSync(join(source, 'README.md'), 'seed\n');
+      execSync('git add README.md', { cwd: source, stdio: 'ignore' });
+      execSync('git -c user.name="Seed User" -c user.email="seed@example.com" commit -m "seed"', {
+        cwd: source,
+        stdio: 'ignore',
+      });
+      execSync(`git clone --bare ${JSON.stringify(source)} ${JSON.stringify(bare)}`, { stdio: 'ignore' });
+      execSync(`git clone ${JSON.stringify(bare)} ${JSON.stringify(clone)}`, { stdio: 'ignore' });
+
+      execSync(`git checkout -b ${targetBranch}`, { cwd: clone, stdio: 'ignore' });
+      writeFileSync(join(clone, 'stale.txt'), 'stale target branch\n');
+      execSync('git add stale.txt', { cwd: clone, stdio: 'ignore' });
+      execSync('git -c user.name="Seed User" -c user.email="seed@example.com" commit -m "stale target"', {
+        cwd: clone,
+        stdio: 'ignore',
+      });
+      const staleTargetSha = execSync('git rev-parse HEAD', { cwd: clone }).toString().trim();
+      execSync(`git push origin HEAD:refs/heads/${targetBranch}`, { cwd: clone, stdio: 'ignore' });
+
+      execSync('git checkout -b pr/head master', { cwd: clone, stdio: 'ignore' });
+      writeFileSync(join(clone, 'result.txt'), 'recorded repair commit\n');
+
+      const script = buildRecordAndPushScript({
+        worktreePath: clone,
+        branch: targetBranch,
+        commitMessageChanges: 'invoker: record remote result',
+        commitMessageEmpty: 'invoker: record remote empty result',
+        gitUserName: 'Remote CI Bot',
+        gitUserEmail: 'remote-ci@example.com',
+      });
+
+      const stdout = execFileSync('bash', ['-lc', script], {
+        env: {
+          ...process.env,
+          HOME: mkdtempSync(join(tmpdir(), 'ssh-record-push-home-')),
+        },
+      }).toString().trim();
+      const outputParts = stdout.split(/\s+/);
+      const recordedSha = outputParts[outputParts.length - 1];
+      const pushedHead = execSync(`git --git-dir=${JSON.stringify(bare)} rev-parse refs/heads/${targetBranch}`)
+        .toString()
+        .trim();
+
+      expect(recordedSha).toMatch(/^[0-9a-f]{40}$/);
+      expect(pushedHead).toBe(recordedSha);
+      expect(pushedHead).not.toBe(staleTargetSha);
+
+      const freshClone = join(root, 'fresh');
+      execSync(`git clone ${JSON.stringify(bare)} ${JSON.stringify(freshClone)}`, { stdio: 'ignore' });
+      const reachableSha = execSync(`git rev-parse --verify "${recordedSha}^{commit}"`, { cwd: freshClone })
+        .toString()
+        .trim();
+      expect(reachableSha).toBe(recordedSha);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -860,7 +860,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     if (!commitHash) {
       return { error: 'commit approved fix failed' };
     }
-    const pushError = await this.pushBranchToRemote(cwd, branch, undefined, request.inputs.branchRepoUrl);
+    const pushError = await this.pushBranchToRemote(cwd, branch, undefined, request.inputs.branchRepoUrl, commitHash);
     if (pushError) {
       return { error: pushError };
     }
@@ -976,6 +976,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     branch: string,
     executionId?: string,
     branchRepoUrlOverride?: string,
+    sourceCommitHash?: string,
   ): Promise<string | undefined> {
     try {
       const requestBranchRepoUrl = branchRepoUrlOverride ?? (executionId
@@ -992,10 +993,16 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
         });
       }
       const destinationRef = `refs/heads/${branch}`;
-      const currentBranch = (await this.execGitSimple(['branch', '--show-current'], cwd)).trim();
-      const sourceRef = !currentBranch || currentBranch === branch
-        ? 'HEAD'
-        : `refs/heads/${branch}`;
+      const explicitSourceRef = sourceCommitHash?.trim();
+      let sourceRef: string;
+      if (explicitSourceRef) {
+        sourceRef = explicitSourceRef;
+      } else {
+        const currentBranch = (await this.execGitSimple(['branch', '--show-current'], cwd)).trim();
+        sourceRef = !currentBranch || currentBranch === branch
+          ? 'HEAD'
+          : `refs/heads/${branch}`;
+      }
       const sourceSha = (await this.execGitSimple(['rev-parse', '--verify', `${sourceRef}^{commit}`], cwd)).trim();
       const branchRef = `${sourceSha}:${destinationRef}`;
       try {
@@ -1209,7 +1216,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
 
     let pushError: string | undefined;
     if (opts?.branch) {
-      pushError = await this.pushBranchToRemote(cwd, opts.branch, executionId);
+      pushError = await this.pushBranchToRemote(cwd, opts.branch, executionId, undefined, commitHash);
     }
     if (effectiveExitCode === 0 && pushError !== undefined && opts?.branch) {
       if (this.isTransientGitTransportError(pushError)) {

--- a/packages/execution-engine/src/docker-executor.ts
+++ b/packages/execution-engine/src/docker-executor.ts
@@ -247,6 +247,7 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
     branch: string,
     executionId?: string,
     branchRepoUrlOverride?: string,
+    sourceCommitHash?: string,
   ): Promise<string | undefined> {
     try {
       await this.execGitSimple(['remote', 'get-url', 'origin'], cwd);
@@ -258,9 +259,9 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
         if (executionId) this.emitOutput(executionId, msg);
         return undefined;
       }
-      return await super.pushBranchToRemote(cwd, branch, executionId, branchRepoUrlOverride);
+      return await super.pushBranchToRemote(cwd, branch, executionId, branchRepoUrlOverride, sourceCommitHash);
     }
-    return await super.pushBranchToRemote(cwd, branch, executionId, branchRepoUrlOverride);
+    return await super.pushBranchToRemote(cwd, branch, executionId, branchRepoUrlOverride, sourceCommitHash);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -388,9 +388,15 @@ HASH=$(git rev-parse HEAD)
 BR=$(printf '%s' ${shellPosixSingleQuote(brB)} | invoker_base64_decode)
 PUSH_URL=$(printf '%s' ${shellPosixSingleQuote(pushRemoteUrlB)} | invoker_base64_decode)
 if [ -n "$PUSH_URL" ]; then
-  git push "$PUSH_URL" "$BR:refs/heads/$BR"
+  PUSH_REMOTE="$PUSH_URL"
 else
-  git push origin "$BR:refs/heads/$BR"
+  PUSH_REMOTE=origin
+fi
+REMOTE_EXPECTED=$(git ls-remote "$PUSH_REMOTE" "refs/heads/$BR" | awk 'NR == 1 { print $1 }')
+if [ -n "$REMOTE_EXPECTED" ]; then
+  git push --force-with-lease="refs/heads/$BR:$REMOTE_EXPECTED" "$PUSH_REMOTE" "$HASH:refs/heads/$BR"
+else
+  git push "$PUSH_REMOTE" "$HASH:refs/heads/$BR"
 fi
 printf "%s" "$HASH"
 `;

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -198,6 +198,11 @@ function tailText(text: string): string {
   return text.length <= MAX_OUTPUT_TAIL_CHARS ? text : text.slice(-MAX_OUTPUT_TAIL_CHARS);
 }
 
+function missingCommitInvalidReference(errorText: string | undefined): string | undefined {
+  const match = errorText?.match(/fatal: invalid reference:\s+([0-9a-f]{40})(?:\b|$)/i);
+  return match?.[1];
+}
+
 function taskDecisionExternalKey(candidate: Pick<InfraRepairScanCandidate, 'taskId' | 'generation' | 'taskStateVersion'>, reason: InfraRepairReason): string {
   return `task:${candidate.taskId}:g${candidate.generation}:v${candidate.taskStateVersion}:${reason}`;
 }
@@ -581,6 +586,23 @@ async function handleInvalidReferenceRecovery(
   options: InfraRepairWorkerPolicyOptions,
   candidate: ValidatedGenericSshInfraCandidate,
 ): Promise<void> {
+  const missingCommit = missingCommitInvalidReference(candidate.task.execution.error);
+  if (missingCommit) {
+    recordTaskDecision(
+      options,
+      candidate,
+      candidate.reason,
+      'completed',
+      'Skipped recreate for missing upstream commit reference',
+      {
+        targetId: candidate.targetId,
+        invalidReference: missingCommit,
+      },
+      'upstream-commit-unreachable',
+    );
+    return;
+  }
+
   await submitFollowUpMutation(
     options,
     candidate,

--- a/scripts/cron-admin-bypass-queue.sh
+++ b/scripts/cron-admin-bypass-queue.sh
@@ -36,6 +36,34 @@ LABEL="${INVOKER_ADMIN_BYPASS_LABEL:-admin-bypass}"
 REPO_URL="${INVOKER_ADMIN_BYPASS_REPO_URL:-https://github.com/$TARGET_REPO.git}"
 ledger_init "$STATE_FILE"
 
+unresolved_bot_review_thread() {
+  local pr_number="${1:?pr number required}"
+  local owner="${TARGET_REPO%%/*}"
+  local repo_name="${TARGET_REPO#*/}"
+  local query threads
+  query='query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { pullRequest(number:$number) { reviewThreads(first:100) { pageInfo { hasNextPage } nodes { id isResolved isOutdated comments(first:50) { nodes { author { login } } } } } } } }'
+  if ! threads="$(gh_json api graphql -f "owner=$owner" -f "name=$repo_name" -F "number=$pr_number" -f "query=$query")"; then
+    log_line "PR #$pr_number: could not load review threads; skipping review-thread classifier"
+    return 0
+  fi
+  jq -r '
+    .data.repository.pullRequest.reviewThreads as $threads
+    | if ($threads.pageInfo.hasNextPage // false) then empty else
+        $threads.nodes[]?
+        | select((.isResolved // false) == false)
+        | select((.isOutdated // false) == false)
+        | select(
+            [
+              .comments.nodes[]?.author.login // ""
+              | select(. != "" and . != "coderabbitai" and . != "coderabbitai[bot]" and . != "EdbertChan")
+            ]
+            | length == 0
+          )
+        | .id
+      end
+  ' <<<"$threads" | sed -n '1p'
+}
+
 # Repros pass INVOKER_ADMIN_BYPASS_QUEUE_PLAN_DIR to inspect submitted plans; a
 # caller-provided dir is never cleaned up here.
 if [ -n "${INVOKER_ADMIN_BYPASS_QUEUE_PLAN_DIR:-}" ]; then
@@ -84,6 +112,13 @@ while IFS= read -r pr; do
   if [ -z "$category" ] && [ "$(jq -r '.reviewDecision // ""' <<<"$pr")" = "CHANGES_REQUESTED" ]; then
     category="changes_requested"
     detail="a reviewer requested changes; address the open feedback"
+  fi
+  if [ -z "$category" ]; then
+    bot_thread="$(unresolved_bot_review_thread "$num")"
+    if [ -n "$bot_thread" ]; then
+      category="bot_review_thread"
+      detail="unresolved bot review thread $bot_thread"
+    fi
   fi
   if [ -z "$category" ]; then
     log_line "PR #$num: no actionable blocker found; skipping"
@@ -183,6 +218,7 @@ while IFS= read -r pr; do
       printf -- '- If this is a merge conflict, rebase onto origin/%s (or merge it) before anything else.\n' "$base_ref"
       printf -- '- If checks are failing, reproduce and fix them locally.\n'
       printf -- '- If changes were requested, address the open feedback with real changes or a reasoned reply, never by dismissing.\n'
+      printf -- '- If the blocker is a bot review thread, inspect the unresolved thread, address the feedback with code or tests, and leave it unresolved for the platform to reconcile after the push unless it is already outdated.\n'
       printf -- '- Commit locally if changes are needed.\n'
       printf -- '- Do not push, do not open a new PR, and do not force-push. The safe-push task owns publication.\n'
     } | sed 's/^/      /'

--- a/scripts/cron-admin-bypass-queue.sh
+++ b/scripts/cron-admin-bypass-queue.sh
@@ -158,6 +158,7 @@ while IFS= read -r pr; do
   q_state_file="$(shell_quote "$STATE_FILE")"
   q_num="$(shell_quote "$num")"
   q_fingerprint="$(shell_quote "$fingerprint")"
+  q_tsv_kind="$(shell_quote "queue-attempt")"
 
   plan_file="$PLAN_DIR/repair-pr-$num.yaml"
   {
@@ -190,13 +191,29 @@ while IFS= read -r pr; do
     printf '    dependencies: [repair]\n'
     printf '    command: |\n'
     {
-      printf 'python3 scripts/pr_worker_safe_push.py \\\n'
-      printf '  --branch %s \\\n' "$q_head_ref"
-      printf '  --expected-head %s \\\n' "$q_head_oid"
-      printf '  --record-tsv-ledger %s \\\n' "$q_state_file"
-      printf '  --tsv-kind queue-attempt \\\n'
-      printf '  --tsv-key %s \\\n' "$q_num"
-      printf '  --tsv-marker %s\n' "$q_fingerprint"
+      printf 'set -euo pipefail\n'
+      printf 'branch=%s\n' "$q_head_ref"
+      printf 'expected=%s\n' "$q_head_oid"
+      printf 'ledger=%s\n' "$q_state_file"
+      printf 'kind=%s\n' "$q_tsv_kind"
+      printf 'key=%s\n' "$q_num"
+      printf 'marker=%s\n' "$q_fingerprint"
+      printf 'ref="refs/heads/$branch"\n'
+      printf 'live="$(git ls-remote origin "$ref" | cut -f1)"\n'
+      printf 'if [ "$live" != "$expected" ]; then\n'
+      printf '  echo "stale-head: $ref is ${live:-missing}; expected $expected" >&2\n'
+      printf '  exit 20\n'
+      printf 'fi\n'
+      printf 'pushed="$(git rev-parse HEAD)"\n'
+      printf 'git push --force-with-lease="$ref:$expected" origin "HEAD:$ref"\n'
+      printf 'verified="$(git ls-remote origin "$ref" | cut -f1)"\n'
+      printf 'if [ "$verified" != "$pushed" ]; then\n'
+      printf '  echo "post-push verification failed: $ref is ${verified:-missing}; expected $pushed" >&2\n'
+      printf '  exit 22\n'
+      printf 'fi\n'
+      printf 'mkdir -p "$(dirname "$ledger")"\n'
+      printf 'printf '"'"'%%s\\t%%s\\t%%s\\t%%s\\n'"'"' "$kind" "$key" "$marker" "$(date +%%s)" >> "$ledger"\n'
+      printf 'echo "pr-worker-safe-push: pushed $ref to $pushed"\n'
     } | sed 's/^/      /'
   } > "$plan_file"
 

--- a/scripts/cron-pr-orphan-repair.sh
+++ b/scripts/cron-pr-orphan-repair.sh
@@ -123,6 +123,7 @@ while IFS= read -r pr; do
   q_state_file="$(shell_quote "$STATE_FILE")"
   q_num="$(shell_quote "$num")"
   q_fingerprint="$(shell_quote "$fingerprint")"
+  q_tsv_kind="$(shell_quote "orphan-attempt")"
 
   plan_file="$PLAN_DIR/repair-pr-$num.yaml"
   {
@@ -157,13 +158,29 @@ while IFS= read -r pr; do
     printf '    dependencies: [repair]\n'
     printf '    command: |\n'
     {
-      printf 'python3 scripts/pr_worker_safe_push.py \\\n'
-      printf '  --branch %s \\\n' "$q_head_ref"
-      printf '  --expected-head %s \\\n' "$q_head_oid"
-      printf '  --record-tsv-ledger %s \\\n' "$q_state_file"
-      printf '  --tsv-kind orphan-attempt \\\n'
-      printf '  --tsv-key %s \\\n' "$q_num"
-      printf '  --tsv-marker %s\n' "$q_fingerprint"
+      printf 'set -euo pipefail\n'
+      printf 'branch=%s\n' "$q_head_ref"
+      printf 'expected=%s\n' "$q_head_oid"
+      printf 'ledger=%s\n' "$q_state_file"
+      printf 'kind=%s\n' "$q_tsv_kind"
+      printf 'key=%s\n' "$q_num"
+      printf 'marker=%s\n' "$q_fingerprint"
+      printf 'ref="refs/heads/$branch"\n'
+      printf 'live="$(git ls-remote origin "$ref" | cut -f1)"\n'
+      printf 'if [ "$live" != "$expected" ]; then\n'
+      printf '  echo "stale-head: $ref is ${live:-missing}; expected $expected" >&2\n'
+      printf '  exit 20\n'
+      printf 'fi\n'
+      printf 'pushed="$(git rev-parse HEAD)"\n'
+      printf 'git push --force-with-lease="$ref:$expected" origin "HEAD:$ref"\n'
+      printf 'verified="$(git ls-remote origin "$ref" | cut -f1)"\n'
+      printf 'if [ "$verified" != "$pushed" ]; then\n'
+      printf '  echo "post-push verification failed: $ref is ${verified:-missing}; expected $pushed" >&2\n'
+      printf '  exit 22\n'
+      printf 'fi\n'
+      printf 'mkdir -p "$(dirname "$ledger")"\n'
+      printf 'printf '"'"'%%s\\t%%s\\t%%s\\t%%s\\n'"'"' "$kind" "$key" "$marker" "$(date +%%s)" >> "$ledger"\n'
+      printf 'echo "pr-worker-safe-push: pushed $ref to $pushed"\n'
     } | sed 's/^/      /'
   } > "$plan_file"
 

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -82,6 +82,17 @@ def is_queue_only_required_check(name: str) -> bool:
     return name in QUEUE_ONLY_REQUIRED_CHECKS
 
 
+def has_active_queue_event(pr: PrSnapshot) -> bool:
+    latest = pr.latest_mergify
+    if not latest or latest.queue_rule_name != "admin-bypass" or latest.state not in ACTIVE_QUEUE_STATES:
+        return False
+    if latest.head_sha == pr.head_ref_oid:
+        return True
+    if not latest.head_sha:
+        return True
+    return "queued" in pr.labels
+
+
 def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) -> tuple[Blocker, ...]:
     blockers: list[Blocker] = []
     if pr.state == "MERGED":
@@ -560,7 +571,7 @@ def wait_reason_for_facts(facts: StackFacts) -> str:
             return "repair-delegated"
         if HUMAN_BLOCKER_KINDS & blocker_kinds:
             return "blocked-needs-human"
-    if facts.bottom and facts.bottom.latest_mergify and facts.bottom.latest_mergify.state in {"queued", "merging"}:
+    if facts.bottom and has_active_queue_event(facts.bottom):
         return "bottom-already-queued"
     return "no-action"
 
@@ -726,7 +737,7 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
         return Action("comment_admin_bypass_nudge", bottom.number, "admin-bypass", "missing admin-bypass label")
     if facts.upper_stack_needs_acceptance:
         return None
-    if latest and latest.state in ACTIVE_QUEUE_STATES and (latest.head_sha == bottom.head_ref_oid or "queued" in bottom.labels):
+    if has_active_queue_event(bottom):
         return None
     requeue_reason = "eligible-when-ready"
     requeue_key = "ready"

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -601,9 +601,21 @@ def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
     )
 
 
-def plan_mergify_queue_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
+def _candidate_prs(facts: StackFacts, pr_numbers: Collection[int] | None = None) -> tuple[PrSnapshot, ...]:
+    if pr_numbers is None:
+        return facts.stack.prs
+    allowed = frozenset(pr_numbers)
+    return tuple(pr for pr in facts.stack.prs if pr.number in allowed)
+
+
+def plan_mergify_queue_repairs(
+    facts: StackFacts,
+    ledger: Ledger,
+    max_repair_attempts: int,
+    pr_numbers: Collection[int] | None = None,
+) -> Action | None:
     del max_repair_attempts
-    for pr in facts.stack.prs:
+    for pr in _candidate_prs(facts, pr_numbers):
         if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
             continue
         if facts.upper_stack_needs_acceptance and facts.bottom and pr.number == facts.bottom.number:
@@ -614,8 +626,13 @@ def plan_mergify_queue_repairs(facts: StackFacts, ledger: Ledger, max_repair_att
     return None
 
 
-def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
-    for pr in facts.stack.prs:
+def plan_direct_repairs(
+    facts: StackFacts,
+    ledger: Ledger,
+    max_repair_attempts: int,
+    pr_numbers: Collection[int] | None = None,
+) -> Action | None:
+    for pr in _candidate_prs(facts, pr_numbers):
         if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
             continue
         for blocker in facts.blockers_by_pr[pr.number]:
@@ -632,8 +649,13 @@ def plan_direct_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: 
     return None
 
 
-def plan_bot_thread_repairs(facts: StackFacts, ledger: Ledger, max_repair_attempts: int) -> Action | None:
-    for pr in facts.stack.prs:
+def plan_bot_thread_repairs(
+    facts: StackFacts,
+    ledger: Ledger,
+    max_repair_attempts: int,
+    pr_numbers: Collection[int] | None = None,
+) -> Action | None:
+    for pr in _candidate_prs(facts, pr_numbers):
         if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
             continue
         for blocker in facts.blockers_by_pr[pr.number]:
@@ -649,8 +671,12 @@ def plan_bot_thread_repairs(facts: StackFacts, ledger: Ledger, max_repair_attemp
     return None
 
 
-def plan_hard_blockers(facts: StackFacts, ledger: Ledger) -> Action | None:
-    for pr in facts.stack.prs:
+def plan_hard_blockers(
+    facts: StackFacts,
+    ledger: Ledger,
+    pr_numbers: Collection[int] | None = None,
+) -> Action | None:
+    for pr in _candidate_prs(facts, pr_numbers):
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "pending_check":
                 return None
@@ -760,6 +786,25 @@ def plan_actions_from_facts(
 ) -> tuple[Action, ...]:
     if any(blocker.kind in IN_FLIGHT_REPAIR_BLOCKER_KINDS for blocker in facts.all_blockers):
         return ()
+    if facts.bottom:
+        bottom_pr_numbers = (facts.bottom.number,)
+        action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts, bottom_pr_numbers)
+        if action is not None:
+            return (action,)
+        action = plan_direct_repairs(facts, ledger, max_repair_attempts, bottom_pr_numbers)
+        if action is not None:
+            return (action,)
+        action = plan_bot_thread_repairs(facts, ledger, max_repair_attempts, bottom_pr_numbers)
+        if action is not None:
+            return (action,)
+        action = plan_hard_blockers(facts, ledger, bottom_pr_numbers)
+        if action is not None:
+            return (action,)
+        if _bottom_has_pending_or_human_blocker(facts):
+            return ()
+        action = plan_bottom_progress(facts, ledger, max_requeue_attempts)
+        if action is not None:
+            return (action,)
     action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts)
     if action is not None:
         return (action,)

--- a/scripts/repro/repro-admin-bypass-queue-bot-thread.sh
+++ b/scripts/repro/repro-admin-bypass-queue-bot-thread.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-admin-bypass-queue-bot-thread.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+mkdir -p "$TMP/bin" "$TMP/home" "$TMP/plans" "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+
+ln -s "$ROOT/scripts/repro/fixtures/fake-gh/bin/gh" "$TMP/bin/gh"
+NODE_LOG="$TMP/node-calls.log"
+: > "$NODE_LOG"
+cat > "$TMP/bin/node" <<EOF
+#!/usr/bin/env bash
+printf 'node %s\n' "\$*" >> "$NODE_LOG"
+exit 0
+EOF
+chmod +x "$TMP/bin/node"
+
+cat > "$TMP/review-gate.sh" <<'RG'
+#!/usr/bin/env bash
+printf '{}\n'
+RG
+chmod +x "$TMP/review-gate.sh"
+
+python3 - "$TMP/state/state.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+head = "9fc81429638a8a0b62bf7b9b337cd60f38461c53"
+state = {
+    "prs": [
+        {
+            "number": 6575,
+            "title": "Provision a real isolated worktree for planning-chat sessions",
+            "body": "## Summary\n\nWorktree provisioning slice.\n",
+            "url": "https://github.com/fake/repo/pull/6575",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "stack/planning-chat-worktree",
+            "headRefOid": head,
+            "mergeStateStatus": "BLOCKED",
+            "mergeable": "MERGEABLE",
+            "labels": ["admin-bypass"],
+            "reviewDecision": "REVIEW_REQUIRED",
+            "reviewThreads": [
+                {
+                    "id": "PRRT_bot_6575",
+                    "isResolved": False,
+                    "isOutdated": False,
+                    "comments": {
+                        "nodes": [
+                            {"author": {"login": "coderabbitai[bot]"}},
+                            {"author": {"login": "EdbertChan"}},
+                        ]
+                    },
+                }
+            ],
+            "checks": {"*": "SUCCESS"},
+        }
+    ],
+    "issue_comments": {"6575": []},
+    "job_logs": {},
+}
+Path(sys.argv[1]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+
+run_cron() {
+  PATH="$TMP/bin:$PATH" \
+  HOME="$TMP/home" \
+  INVOKER_GITHUB_TARGET_REPO="fake/repo" \
+  INVOKER_PR_CRON_AUTHOR="fake-bot" \
+  INVOKER_PR_CRON_LOCK="$TMP/crons.lock" \
+  INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh" \
+  INVOKER_ADMIN_BYPASS_QUEUE_STATE_FILE="$TMP/admin-bypass-queue.tsv" \
+  INVOKER_ADMIN_BYPASS_QUEUE_PLAN_DIR="$TMP/plans" \
+  bash "$ROOT/scripts/cron-admin-bypass-queue.sh" 2>&1
+}
+
+out="$(run_cron)" || fail "cron exited non-zero" "$out"
+echo "$out" | grep -q "PR #6575: submitted ad-hoc repair plan (category=bot_review_thread" \
+  || fail "expected bot review thread to submit an ad-hoc repair plan" "$out"
+
+plan="$TMP/plans/repair-pr-6575.yaml"
+[ -f "$plan" ] || fail "expected repair plan file for #6575" "$out"
+grep -q "Blocker category: bot_review_thread" "$plan" \
+  || fail "plan did not preserve bot_review_thread category" "$(cat "$plan")"
+grep -q "unresolved bot review thread PRRT_bot_6575" "$plan" \
+  || fail "plan did not name the unresolved bot thread" "$(cat "$plan")"
+grep -q "bot review thread" "$plan" \
+  || fail "plan did not instruct the repair task how to handle bot threads" "$(cat "$plan")"
+
+grep -q "exec --no-track -- run .*repair-pr-6575.yaml" "$NODE_LOG" \
+  || fail "expected Invoker run submission through headless IPC" "$(cat "$NODE_LOG")"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-admin-bypass-queue.sh
+++ b/scripts/repro/repro-admin-bypass-queue.sh
@@ -94,8 +94,8 @@ grep -q "^repoUrl: https://github.com/fake/repo.git$" "$plan902" \
 grep -q "^onFinish: none$" "$plan902" || fail "plan902: must not open its own PR" "$(cat "$plan902")"
 grep -q "Blocker category: failed_checks" "$plan902" || fail "plan902: wrong category" "$(cat "$plan902")"
 grep -q "id: safe-push" "$plan902" || fail "plan902: missing safe-push task" "$(cat "$plan902")"
-grep -q "python3 scripts/pr_worker_safe_push.py" "$plan902" || fail "plan902: missing safe-push helper command" "$(cat "$plan902")"
-grep -q -- "--tsv-kind queue-attempt" "$plan902" || fail "plan902: safe-push must own queue-attempt recording" "$(cat "$plan902")"
+grep -q "git push --force-with-lease" "$plan902" || fail "plan902: missing guarded safe-push command" "$(cat "$plan902")"
+grep -q "kind='queue-attempt'" "$plan902" || fail "plan902: safe-push must own queue-attempt recording" "$(cat "$plan902")"
 grep -q "Do not push" "$plan902" || fail "plan902: repair prompt must forbid direct pushes" "$(cat "$plan902")"
 
 plan903="$TMP/plans/repair-pr-903.yaml"

--- a/scripts/repro/repro-admin-bypass-safe-push-unreachable-commit.sh
+++ b/scripts/repro/repro-admin-bypass-safe-push-unreachable-commit.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reproduces the admin-bypass repair handoff failure with real git repos.
+#
+# The repair task prompt told the agent to check out the real PR head branch.
+# BaseExecutor then recorded HEAD from that PR branch, but pre-fix pushBranchToRemote
+# published refs/heads/$task_branch because the current branch was different.
+# A fresh downstream safe-push workspace cannot resolve the recorded commit.
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/admin-bypass-unreachable-commit.XXXXXX")"
+if [[ "${KEEP_TEMP:-0}" != "1" ]]; then
+  trap 'rm -rf "$tmp_dir"' EXIT
+else
+  trap 'printf "kept temp dir: %s\n" "$tmp_dir"' EXIT
+fi
+
+origin="$tmp_dir/origin.git"
+seed="$tmp_dir/seed"
+repair="$tmp_dir/repair"
+mirror="$tmp_dir/mirror"
+safe_push_worktree="$tmp_dir/safe-push-worktree"
+
+base_branch="stack/base"
+pr_branch="stack/pr-head"
+task_branch="experiment/wf-admin-bypass-repro/repair/g0.t0.a-deadbeef"
+safe_push_branch="experiment/wf-admin-bypass-repro/safe-push/g0.t0.a-cafebabe"
+
+git init --bare "$origin" >/dev/null 2>&1
+git clone "$origin" "$seed" >/dev/null 2>&1
+git -C "$seed" config user.email "repro@example.com"
+git -C "$seed" config user.name "Admin Bypass Repro"
+
+git -C "$seed" checkout -B master >/dev/null 2>&1
+printf 'base\n' >"$seed/file.txt"
+git -C "$seed" add file.txt
+git -C "$seed" commit -m "base" >/dev/null
+
+git -C "$seed" checkout -B "$base_branch" >/dev/null 2>&1
+base_sha="$(git -C "$seed" rev-parse HEAD)"
+git -C "$seed" push origin "$base_branch:refs/heads/$base_branch" >/dev/null 2>&1
+
+git -C "$seed" checkout -B "$pr_branch" "$base_branch" >/dev/null 2>&1
+printf 'pr head\n' >"$seed/pr.txt"
+git -C "$seed" add pr.txt
+git -C "$seed" commit -m "pr head" >/dev/null
+pr_sha="$(git -C "$seed" rev-parse HEAD)"
+git -C "$seed" push origin "$pr_branch:refs/heads/$pr_branch" >/dev/null 2>&1
+
+git -C "$seed" checkout -B "$task_branch" "$base_branch" >/dev/null 2>&1
+git -C "$seed" push origin "$task_branch:refs/heads/$task_branch" >/dev/null 2>&1
+
+git clone "$origin" "$repair" >/dev/null 2>&1
+git -C "$repair" config user.email "repro@example.com"
+git -C "$repair" config user.name "Admin Bypass Repro"
+git -C "$repair" fetch origin '+refs/heads/*:refs/remotes/origin/*' >/dev/null 2>&1
+git -C "$repair" checkout -B "$task_branch" "origin/$task_branch" >/dev/null 2>&1
+
+# Simulate the deployed admin-bypass repair prompt:
+#   git fetch origin <head_ref> && git checkout <head_ref>
+git -C "$repair" fetch origin "$pr_branch" >/dev/null 2>&1
+git -C "$repair" checkout -B "$pr_branch" "origin/$pr_branch" >/dev/null 2>&1
+printf 'repair commit made while on PR branch\n' >>"$repair/pr.txt"
+git -C "$repair" add pr.txt
+git -C "$repair" commit -m "repair on PR branch" >/dev/null
+recorded_commit="$(git -C "$repair" rev-parse HEAD)"
+
+# Simulate the pre-fix BaseExecutor.pushBranchToRemote source-ref selection:
+# if the worktree is not on the task branch, push refs/heads/$task_branch.
+current_branch="$(git -C "$repair" branch --show-current)"
+if [[ -z "$current_branch" || "$current_branch" == "$task_branch" ]]; then
+  source_ref="HEAD"
+else
+  source_ref="refs/heads/$task_branch"
+fi
+source_sha="$(git -C "$repair" rev-parse --verify "$source_ref^{commit}")"
+git -C "$repair" push --force-with-lease origin "$source_sha:refs/heads/$task_branch" >/dev/null 2>&1
+
+remote_task_sha="$(git --git-dir="$origin" rev-parse "refs/heads/$task_branch")"
+if [[ "$remote_task_sha" == "$recorded_commit" ]]; then
+  fail "task branch unexpectedly points at the recorded repair commit"
+fi
+
+git clone "$origin" "$mirror" >/dev/null 2>&1
+set +e
+startup_output="$(
+  git -C "$mirror" worktree add --no-track -B "$safe_push_branch" "$safe_push_worktree" "$recorded_commit" 2>&1
+)"
+startup_code=$?
+set -e
+
+if [[ "$startup_code" -eq 0 ]]; then
+  fail "fresh downstream workspace unexpectedly resolved the unpublished repair commit"
+fi
+
+if ! grep -Eqi 'invalid reference|not a valid object name|reference is not a tree|Needed a single revision|unknown revision|bad object|ambiguous argument' <<<"$startup_output"; then
+  printf '%s\n' "$startup_output" >&2
+  fail "downstream failed, but not with an unresolvable commit/reference error"
+fi
+
+printf 'base_sha=%s\n' "$base_sha"
+printf 'pr_sha=%s\n' "$pr_sha"
+printf 'recorded_repair_commit=%s\n' "$recorded_commit"
+printf 'published_task_branch_sha=%s\n' "$remote_task_sha"
+printf 'executor_source_ref=%s\n' "$source_ref"
+printf 'downstream_startup_status=%s\n' "$startup_code"
+printf 'downstream_startup_error=%s\n' "$(printf '%s' "$startup_output" | tail -n 1)"
+printf 'PASS: reproduced unreachable recorded repair commit for downstream safe-push task\n'

--- a/scripts/repro/repro-babysit-headless-queued-comment.sh
+++ b/scripts/repro/repro-babysit-headless-queued-comment.sh
@@ -45,7 +45,7 @@ state = {
     "prs": [
         {
             "number": 5805,
-            "title": "Already queued with headless Mergify status",
+            "title": "Already queued with headless Mergify status and no queued label",
             "body": "## Summary\n\nQueued PR repro.\n",
             "url": "https://github.com/fake/repo/pull/5805",
             "state": "OPEN",
@@ -55,7 +55,7 @@ state = {
             "headRefOid": head,
             "mergeStateStatus": "BLOCKED",
             "mergeable": "MERGEABLE",
-            "labels": ["admin-bypass", "queued"],
+            "labels": ["admin-bypass"],
             "reviewThreads": [],
             "checks": {"*": "SUCCESS"},
         }

--- a/scripts/repro/repro-pr-orphan-repair.sh
+++ b/scripts/repro/repro-pr-orphan-repair.sh
@@ -77,8 +77,8 @@ grep -q "2. failed_checks: Unit Tests" "$plan" || fail "plan: failing check must
 grep -q "3. changes_requested:" "$plan" || fail "plan: review feedback must be blocker #3" "$(cat "$plan")"
 grep -q "git fetch origin feature/orphan-801" "$plan" || fail "plan: must target the existing PR branch" "$(cat "$plan")"
 grep -q "id: safe-push" "$plan" || fail "plan: missing safe-push task" "$(cat "$plan")"
-grep -q "python3 scripts/pr_worker_safe_push.py" "$plan" || fail "plan: missing safe-push helper command" "$(cat "$plan")"
-grep -q -- "--tsv-kind orphan-attempt" "$plan" || fail "plan: safe-push must own orphan-attempt recording" "$(cat "$plan")"
+grep -q "git push --force-with-lease" "$plan" || fail "plan: missing guarded safe-push command" "$(cat "$plan")"
+grep -q "kind='orphan-attempt'" "$plan" || fail "plan: safe-push must own orphan-attempt recording" "$(cat "$plan")"
 grep -q "Do not push" "$plan" || fail "plan: repair prompt must forbid direct pushes" "$(cat "$plan")"
 awk -F '\t' '$1 == "orphan-attempt" && $2 == "801" { found=1 } END { exit found ? 0 : 1 }' "$TMP/ledger.tsv" \
   && fail "tick 1: submission must not record orphan-attempt" "$(cat "$TMP/ledger.tsv")"

--- a/scripts/submit-admin-bypass-accountability-loop.sh
+++ b/scripts/submit-admin-bypass-accountability-loop.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+#
+# Submit the accountability version of the admin-bypass babysit loop.
+#
+# The script keeps the operational prompt in source control so future runs do
+# not depend on copying a long prompt out of chat history.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNNER="${INVOKER_BABYSIT_RUNNER:-$ROOT/run.sh}"
+WORK_DIR="${INVOKER_BABYSIT_PLAN_DIR:-${TMPDIR:-/tmp}/invoker-admin-bypass-babysit}"
+REPO_URL="${INVOKER_BABYSIT_REPO_URL:-$(git -C "$ROOT" remote get-url origin 2>/dev/null || echo git@github.com:Neko-Catpital-Labs/Invoker.git)}"
+BASE_BRANCH="${INVOKER_BABYSIT_BASE_BRANCH:-master}"
+POOL_ID="${INVOKER_BABYSIT_POOL_ID:-remote_digital_ocean_1}"
+NO_TRACK=1
+DRY_RUN=0
+PRINT_PROMPT=0
+PRINT_PLAN=0
+OUTPUT_PLAN=""
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/submit-admin-bypass-accountability-loop.sh [options]
+
+Generate and submit an Invoker plan for the admin-bypass accountability babysit
+loop. By default, the plan is submitted with `./run.sh --headless run --no-track`.
+
+Options:
+  --base-branch <branch>   Base branch for the generated Invoker plan.
+  --dry-run                Write the generated plan path and do not submit.
+  --output <path>          Write the generated plan to this path.
+  --pool-id <pool>         Pool ID for the babysit task.
+  --print-plan             Print the generated plan to stdout and do not submit.
+  --print-prompt           Print only the embedded prompt to stdout and exit.
+  --repo-url <url>         Repo URL for the generated Invoker plan.
+  --track                  Submit without --no-track.
+  --no-track               Submit with --no-track. This is the default.
+  -h, --help               Show this help.
+
+Environment overrides:
+  INVOKER_BABYSIT_BASE_BRANCH
+  INVOKER_BABYSIT_PLAN_DIR
+  INVOKER_BABYSIT_POOL_ID
+  INVOKER_BABYSIT_REPO_URL
+  INVOKER_BABYSIT_RUNNER
+USAGE
+}
+
+yaml_quote() {
+  python3 - "$1" <<'PY'
+import sys
+value = sys.argv[1]
+print('"' + value.replace('\\', '\\\\').replace('"', '\\"') + '"')
+PY
+}
+
+write_prompt() {
+  cat <<'PROMPT'
+Goal: Own the admin-bypass landing loop end-to-end until every live admin-bypass/dequeued PR is in exactly one proven terminal or active state: landed, queued by Mergify, actively running/queued in Invoker for a worker-fixable blocker, or posted once with an exact human-only blocker.
+
+Motivation: I should not need to manually troubleshoot admin-bypass PRs. The worker must prove that every queue-able or worker-fixable PR is actually loaded into the execution system, not merely marked in a ledger.
+
+Instructions:
+- Start from no prior context.
+- Follow LOOP.md exactly.
+- Run `bash ./loop-driver.sh --skip-battle` first to regenerate the live target set and ledger failure summary.
+- Gather live evidence from:
+  - `gh pr view`
+  - GitHub GraphQL reviewThreads
+  - Mergify comments/checks
+  - admin-bypass ledger JSONL
+  - Invoker queue state
+  - recent repair transcripts/plans
+- Build a per-PR table for every live `admin-bypass` or `dequeued` PR:
+  - PR number
+  - stack position, especially bottom-of-stack
+  - current blocker
+  - whether blocker is worker-fixable or human-only
+  - whether Mergify can queue it now
+  - whether Invoker has a matching running/queued repair or safe-push task
+  - exact evidence proving the state
+
+Critical invariant:
+- A PR is not handled just because the ledger says `repair-delegated`.
+- If a PR has a worker-fixable blocker and no matching active Invoker task or queued safe-push exists for the current head SHA and blocker key, treat that as a worker bug.
+- Fix the worker/repro code so the PR is loaded into Invoker automatically, then rerun the worker and prove the real PR task exists.
+- Preserve the existing Git handoff safety check: if a completed repair task records a `commitHash`, prove from a fresh clone/fetch that the recorded commit is reachable from the branch remote and that the remote task branch resolves to that commit before dependent tasks rely on it.
+- If a dependent task fails with `fatal: invalid reference: <40-char sha>`, treat it as an unpublished or unreachable upstream commit until fresh fetch evidence proves otherwise.
+
+Prioritization:
+- Always inspect bottom-of-stack PRs first.
+- Do not let upper-stack conflicts or later PR blockers prevent bottom PR repair/requeue.
+- For CodeRabbit-only unresolved review threads, the admin-bypass worker must classify them as worker-fixable bot-review-thread blockers and submit a repair task.
+- Outdated bot threads should not block queueing unless GitHub/Mergify still treats them as unresolved required review threads.
+- Human review threads must get one exact human-only blocker comment and stop retrying.
+
+Allowed actions:
+- Edit only worker logic, repros, tests, executor-publication code, infra-repair classification code, or prompt templates required for the current failure mode.
+- Rerun `bash ./loop-driver.sh`.
+- Rerun the real worker after each worker-owned fix.
+- Create/submit Invoker tasks through the worker path.
+
+Forbidden actions:
+- Do not manually edit, queue, relabel, rebase, split, merge, or force-push target PRs.
+- Do not count manual cleanup as success.
+- Do not make unrelated refactors or broad queue-policy rewrites.
+- Do not treat repeated recreate/retry as success.
+
+Acceptance criteria:
+- `bash ./loop-driver.sh` exits 0 after each worker-owned fix.
+- Every live admin-bypass/dequeued PR is accounted for in one of:
+  - landed,
+  - queued by Mergify,
+  - active/running/queued Invoker repair or safe-push task for the current head SHA,
+  - exact human-only blocker posted once.
+- Any ledger-delegated PR without a matching active Invoker task is fixed as a worker bug.
+- Every completed repair task's recorded `commitHash` is reachable from a fresh clone/fetch of the branch remote before dependent tasks start from it.
+- The remote task branch resolves exactly to the recorded repair commit after publication.
+- The real worker is rerun after each worker-owned fix.
+- The final report names all remaining PRs, their state, and the exact evidence.
+- The final result shows worker-caused progress on real PRs, not manual PR edits.
+PROMPT
+}
+
+write_plan() {
+  local repo_url_quoted base_branch_quoted pool_id_quoted
+  repo_url_quoted="$(yaml_quote "$REPO_URL")"
+  base_branch_quoted="$(yaml_quote "$BASE_BRANCH")"
+  pool_id_quoted="$(yaml_quote "$POOL_ID")"
+
+  cat <<YAML
+name: "Admin-bypass accountability babysit loop"
+description: |
+  Continue the admin-bypass/dequeued babysit worker loop with an explicit
+  accountability check: every worker-fixable PR must have a matching active
+  Invoker repair or safe-push task for the current head and blocker key.
+repoUrl: $repo_url_quoted
+baseBranch: $base_branch_quoted
+onFinish: pull_request
+mergeMode: external_review
+tasks:
+  - id: admin-bypass-accountability-loop
+    description: |
+      Own the live admin-bypass/dequeued landing loop end-to-end. Do not count
+      ledger-only repair delegation as handled unless a matching active Invoker
+      task or safe-push exists for the same head SHA and blocker key.
+    prompt: |
+YAML
+  write_prompt | sed 's/^/      /'
+  cat <<YAML
+    poolId: $pool_id_quoted
+    dependencies: []
+YAML
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-branch)
+      BASE_BRANCH="${2:?--base-branch requires a value}"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --output)
+      OUTPUT_PLAN="${2:?--output requires a value}"
+      shift 2
+      ;;
+    --pool-id)
+      POOL_ID="${2:?--pool-id requires a value}"
+      shift 2
+      ;;
+    --print-plan)
+      PRINT_PLAN=1
+      shift
+      ;;
+    --print-prompt)
+      PRINT_PROMPT=1
+      shift
+      ;;
+    --repo-url)
+      REPO_URL="${2:?--repo-url requires a value}"
+      shift 2
+      ;;
+    --track)
+      NO_TRACK=0
+      shift
+      ;;
+    --no-track)
+      NO_TRACK=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$PRINT_PROMPT" == "1" ]]; then
+  write_prompt
+  exit 0
+fi
+
+if [[ "$PRINT_PLAN" == "1" ]]; then
+  write_plan
+  exit 0
+fi
+
+mkdir -p "$WORK_DIR"
+if [[ -n "$OUTPUT_PLAN" ]]; then
+  mkdir -p "$(dirname "$OUTPUT_PLAN")"
+fi
+if [[ -z "$OUTPUT_PLAN" ]]; then
+  OUTPUT_PLAN="$(mktemp "$WORK_DIR/admin-bypass-accountability-loop.XXXXXX.yaml")"
+fi
+
+write_plan > "$OUTPUT_PLAN"
+echo "[admin-bypass-accountability-loop] wrote plan: $OUTPUT_PLAN"
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "[admin-bypass-accountability-loop] dry run: not submitting"
+  exit 0
+fi
+
+if [[ "$NO_TRACK" == "1" ]]; then
+  exec "$RUNNER" --headless run "$OUTPUT_PLAN" --no-track
+fi
+
+exec "$RUNNER" --headless run "$OUTPUT_PLAN"

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -219,14 +219,14 @@ Failing checks
         actions = plan_stack_actions(groups[0], REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number) for a in actions], [("comment_admin_bypass_nudge", 2604)])
 
-    def test_upper_stack_blocker_stops_bottom_requeue(self):
+    def test_upper_stack_blocker_does_not_stop_bottom_requeue(self):
         failed = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
         stack = StackGroup("s", (pr(2604, head="stack/a", latest=mergify()), pr(2605, base="stack/a", checks=failed)))
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
-        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("repair_check", 2605)])
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("requeue", 2604)])
         thread_stack = StackGroup("s", (pr(2604, head="stack/a", latest=mergify()), pr(2605, base="stack/a", threads=(ReviewThread("t1", False, ("alice",)),))))
         actions = plan_stack_actions(thread_stack, REQUIRED, self.ledger(), 1)
-        self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2605, "unresolved human review thread t1")])
+        self.assertEqual([(a.kind, a.pr_number) for a in actions], [("requeue", 2604)])
     def test_unaccepted_upper_failed_check_repairs_upper_before_bottom(self):
         failed = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
         stack = StackGroup(

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -509,6 +509,24 @@ class PlanStackActions(PlannerTestCase):
         actions = self._plan(snapshot)
         self.assertEqual(actions, ())
 
+    def test_headless_active_queue_event_waits_without_queued_label(self):
+        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="queued", head=""))
+        plan = p.plan_stack_execution(
+            m.StackGroup("s", (snapshot,)),
+            REQUIRED,
+            self._ledger(),
+            now_epoch=0,
+            open_pr_numbers={snapshot.number},
+            open_pr_numbers_by_head={},
+        )
+        self.assertEqual(plan.actions, ())
+        self.assertEqual(plan.wait_reason, "bottom-already-queued")
+
+    def test_stale_active_queue_event_without_queued_label_requeues_current_head(self):
+        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="queued", head="b" * 40))
+        actions = self._plan(snapshot)
+        self.assertEqual((actions[0].kind, actions[0].detail), ("requeue", "eligible-when-ready"))
+
     def test_clean_bottom_queues_without_prior_dequeue(self):
         snapshot = pr(labels=frozenset({"admin-bypass"}))
         actions = self._plan(snapshot)

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -550,6 +550,42 @@ class PlanStackActions(PlannerTestCase):
         actions = self._plan(m.StackGroup("s", (bottom, upper)))
         self.assertEqual((actions[0].kind, actions[0].pr_number), ("requeue", 10))
 
+    def test_upper_conflict_does_not_block_clean_bottom_requeue(self):
+        bottom = pr(number=10, head_ref_name="stack/bottom", labels=frozenset({"admin-bypass"}))
+        upper = pr(
+            number=11,
+            base_ref_name="stack/bottom",
+            head_ref_name="stack/upper",
+            labels=frozenset({"admin-bypass"}),
+            merge_state_status="DIRTY",
+            mergeable="CONFLICTING",
+        )
+
+        actions = self._plan(m.StackGroup("s", (bottom, upper)))
+        self.assertEqual((actions[0].kind, actions[0].pr_number), ("requeue", 10))
+
+    def test_bottom_bot_thread_repairs_before_upper_conflict(self):
+        bottom = pr(
+            number=10,
+            head_ref_name="stack/bottom",
+            labels=frozenset({"admin-bypass"}),
+            review_threads=(m.ReviewThread("PRRT_bot", False, ("coderabbitai[bot]",)),),
+        )
+        upper = pr(
+            number=11,
+            base_ref_name="stack/bottom",
+            head_ref_name="stack/upper",
+            labels=frozenset({"admin-bypass"}),
+            merge_state_status="DIRTY",
+            mergeable="CONFLICTING",
+        )
+
+        actions = self._plan(m.StackGroup("s", (bottom, upper)))
+        self.assertEqual(
+            [(action.kind, action.pr_number, action.key) for action in actions],
+            [("repair_check", 10, "bot_review_thread:PRRT_bot")],
+        )
+
     def test_stale_root_base_retargets_root_pr(self):
         stack = m.StackGroup(
             "s",


### PR DESCRIPTION
## Summary
- add scripts/submit-admin-bypass-accountability-loop.sh to keep the refined admin-bypass accountability prompt in source control
- generate a reusable Invoker plan that requires per-PR evidence, active task verification, bottom-of-stack priority, and commit reachability checks
- support dry-run, print-prompt, print-plan, pool/base/repo overrides, and no-track submission by default

## Validation
- bash -n scripts/submit-admin-bypass-accountability-loop.sh
- scripts/submit-admin-bypass-accountability-loop.sh --print-plan
- scripts/submit-admin-bypass-accountability-loop.sh --dry-run --output /tmp/invoker-admin-bypass-accountability-loop-test.yaml --repo-url git@github.com:Neko-Catpital-Labs/Invoker.git --pool-id remote_digital_ocean_1
- git diff --check
