### PR TITLE
Add CI regression watch formula

### DIFF
--- a/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
+++ b/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
@@ -1,0 +1,84 @@
+name: "CI regression: {{job_slug}}"
+description: |
+  {{marker}}
+
+  CI job `{{job_name}}` first failed on default-branch push commit {{sha}}
+  in run {{run_id}}. It was most recently still red at {{last_bad_sha}}
+  in run {{last_bad_run_id}}.
+
+  First bad job: {{job_url}}
+onFinish: pull_request
+mergeMode: external_review
+baseBranch: {{base_branch}}
+repoUrl: {{repo_url}}
+
+tasks:
+  - id: fix-ci-{{job_slug}}
+    description: |
+      Fix CI job {{job_name}} first observed failing at {{sha}}.
+      Review claim: The change corrects the CI regression's root cause at its source, with no unrelated edits.
+      Review lane: behavior
+      Safety invariant: Other CI jobs and product behavior stay unchanged except for the corrected defect.
+      Slice rationale: One behavior slice: the failing CI job's root cause and deterministic proof.
+      Architectural effect: None expected; no new module boundaries unless the root cause requires it.
+      Goal: Make the CI job `{{job_name}}` pass on current master.
+      Motivation: This job first failed on default-branch commit {{sha}} and stayed red through {{last_bad_sha}}.
+      Alternative considerations: Re-running or weakening the test was rejected; fix the underlying defect.
+      Implementation details: Reproduce at {{sha}}, then implement on current master.
+      Non-goals: No refactor, no unrelated cleanup, no test weakening, no snapshot churn unless it is the reviewed expected output.
+      Layer: e2e_regression
+      Feature state: active
+      Files:
+      - Unknown at filing time; determined during root-cause investigation.
+      Change types:
+      - Unknown at filing time; determined during root-cause investigation.
+      Acceptance criteria:
+      - `{{verify_command}}` exits 0 after the change.
+    prompt: |
+      Goal: Diagnose and fix CI job `{{job_name}}`, first observed failing at
+      default-branch commit {{sha}}.
+      Review lane: behavior
+      Motivation: The per-HEAD CI watcher records this job as broken at
+      {{sha}} and still broken through {{last_bad_sha}}. This is keyed by the
+      CI job, not by a later duplicate HEAD, so avoid duplicate or unrelated
+      repair work.
+      Alternative considerations: Re-running, skipping, weakening tests, or
+      targeting a PR at the historical SHA was rejected; the fix must land on
+      current master.
+      Implementation details: Assume no prior context. Inspect
+      `.github/workflows/ci.yml`, the relevant `scripts/` suite entrypoint, and
+      the first failing GitHub job logs:
+      `gh run view {{run_id}} --repo Neko-Catpital-Labs/Invoker --job {{job_database_id}} --log`.
+      Inspect the introducing commit with `git show {{sha}}`. Reproduce against
+      the historical commit without doing final work there: use a detached
+      temporary worktree or clone at {{sha}}, then run `{{verify_command}}`.
+      Return to the current task branch based on master and implement the fix
+      there. If historical reproduction is blocked by external runner setup,
+      use the GitHub job logs as the historical evidence and still prove the
+      final fix locally.
+      Non-goals: Do not weaken, skip, or delete assertions; do not make broad
+      refactors; do not manually edit GitHub CI state; do not target a PR at
+      the historical SHA.
+      Acceptance criteria: `{{verify_command}}` must exit code 0 on the final
+      branch after the change.
+    dependencies: []
+
+  - id: verify-ci-{{job_slug}}
+    description: |
+      Run the local verification command for CI job {{job_name}}.
+      Review claim: The command passes only when the CI regression is fixed.
+      Review lane: proof
+      Safety invariant: The command is identical before and after the fix.
+      Slice rationale: One proof slice for the repaired CI job.
+      Architectural effect: None; adds no product behavior.
+      Goal: Prove the CI job repair locally.
+      Motivation: A shared command prevents the job-specific regression from recurring silently.
+      Alternative considerations: Manual verification was rejected as non-deterministic.
+      Implementation details: Execute the exact command below.
+      Non-goals: No product edits here; proof only.
+      Layer: e2e_regression
+      Feature state: active
+    command: |
+      {{verify_command}}
+    dependencies:
+      - fix-ci-{{job_slug}}

--- a/skills/plan-to-invoker/formulas/ci-regression-watch/formula.yaml
+++ b/skills/plan-to-invoker/formulas/ci-regression-watch/formula.yaml
@@ -1,0 +1,62 @@
+formula: ci-regression-watch
+version: 1
+description: >
+  File a bug-fix workflow for one CI job that first went red on a default-branch
+  push commit. The task reproduces against the observed commit, then ports the
+  fix to current master so the resulting PR is mergeable.
+vars:
+  repo_url:
+    required: true
+    example: "git@github.com:Neko-Catpital-Labs/Invoker.git"
+    description: "Git remote for the repo where tasks run."
+  base_branch:
+    required: false
+    default: "master"
+    example: "master"
+    description: "Current target branch for the repair PR."
+  sha:
+    required: true
+    example: "abc123def456abc123def456abc123def456ab1"
+    description: "Default-branch commit where this CI job first failed."
+  short_sha:
+    required: true
+    example: "abc123d"
+    description: "Short SHA used in ids."
+  job_name:
+    required: true
+    example: "playwright / 1-of-9"
+    description: "Exact GitHub Actions job name."
+  job_slug:
+    required: true
+    example: "abc123d-playwright-1-of-9"
+    description: "Kebab-case plan/task id suffix."
+  run_id:
+    required: true
+    example: "123456789"
+    description: "GitHub Actions run id for the first bad observation."
+  job_database_id:
+    required: true
+    example: "987654321"
+    description: "GitHub Actions job database id for log lookup."
+  job_url:
+    required: true
+    example: "https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/123/job/987"
+    description: "GitHub Actions job URL for the first bad observation."
+  last_bad_sha:
+    required: true
+    example: "def456def456def456def456def456def456def4"
+    description: "Most recent SHA where the job was still broken."
+  last_bad_run_id:
+    required: true
+    example: "123456799"
+    description: "Most recent run id where the job was still broken."
+  verify_command:
+    required: true
+    example: "bash scripts/test-suites/required/10-vitest-workspace.sh"
+    description: "Local command that should fail before and pass after the fix."
+  marker:
+    required: true
+    example: "<!-- invoker-ci-regression-watch: first-bad-sha=abc123def456abc123def456abc123def456ab1; job=playwright / 1-of-9 -->"
+    description: "Exact dedup marker embedded in the workflow description."
+workflows:
+  - ci-regression-watch.workflow.yaml


### PR DESCRIPTION
## Summary
Adds the formula files used by the CI repair watcher.

## Review Claim
The new formula files render the CI repair handoff with the required task metadata and verification command slots.

## Review Lane
docs

## Review Unit
docs

## Safety Invariant
The files only add a new formula; existing formulas remain unchanged.

## Slice Rationale
This slice adds the formula content separately from the watcher code that calls it.

## Non-goals
- No watcher runtime changes.
- No existing formula edits.
- No local configuration changes.

## Test Plan
<details>
<summary>Test Plan</summary>

- bash skills/plan-to-invoker/scripts/render-formula.sh ci-regression-watch --example --out /tmp/invoker-ci-regression-watch-example
- bash skills/plan-to-invoker/scripts/skill-doctor.sh /tmp/invoker-ci-regression-watch-example/ci-regression-watch.yaml

</details>

## Revert Plan
<details>
<summary>Revert Plan</summary>

Revert this PR to remove the added formula files.

</details>
