### PR TITLE
Add per-head CI regression watcher

### DIFF
--- a/scripts/cron-e2e-regression-watch.sh
+++ b/scripts/cron-e2e-regression-watch.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Cron entrypoint for the e2e master-regression watcher. Lock + log only;
+# Cron entrypoint for the default-branch CI regression watcher. Lock + log only;
 # all logic lives in scripts/e2e-regression-watch.mjs.
 set -euo pipefail
 
@@ -33,11 +33,11 @@ else
   trap 'rm -rf "'"$lockdir"'" 2>/dev/null || true' EXIT
 fi
 
-log_line "e2e-regression-watch sweep starting"
+log_line "ci-regression-watch sweep starting"
 if node "$REPO_ROOT/scripts/e2e-regression-watch.mjs"; then
-  log_line "e2e-regression-watch sweep finished"
+  log_line "ci-regression-watch sweep finished"
 else
   status=$?
-  log_line "e2e-regression-watch sweep failed (exit $status)"
+  log_line "ci-regression-watch sweep failed (exit $status)"
   exit "$status"
 fi

--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -1,168 +1,371 @@
 #!/usr/bin/env node
-// Watches the `playwright` job on master for new e2e regressions and files a
-// bug-fix Invoker plan for each one.
-//
-// Local state (~/.invoker/e2e-regression-watch/state.json) is a mutable
-// snapshot of "what's currently red and since when" — it is NOT a ledger of
-// fixes-in-flight. Whether a regression already has an open fix is always
-// answered by a live query against Invoker's workflow store
-// (liveQueryHasNonTerminalWork), never by anything cached here. GitHub
-// Actions has no "since when has this been red" API, so this state is the
-// only way to compute "is this a new regression" and "which commit did it
-// start at" — do not reach for cron-pr-lib.sh's ledger primitives here, they
-// solve a different problem (fix-in-flight dedup, which must stay live).
+// Watches default-branch `ci.yml` push runs and files one Invoker repair plan
+// per active (first-bad SHA, CI job) failure. Local state records observed HEAD
+// SHAs and job outcomes; live Invoker workflow state remains the dedup source
+// for repairs in flight.
 import { execFileSync, execSync } from 'node:child_process';
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
-  readdirSync,
   readFileSync,
   writeFileSync,
   appendFileSync,
 } from 'node:fs';
-import { homedir, tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = dirname(dirname(__filename));
 
-export const TARGET_REPO = process.env.INVOKER_GITHUB_TARGET_REPO ?? 'Neko-Catpital-Labs/Invoker';
-export const WORKFLOW_FILE = process.env.INVOKER_E2E_WATCH_WORKFLOW_FILE ?? 'ci.yml';
-export const CAP_PER_SWEEP = Number(process.env.INVOKER_E2E_WATCH_CAP ?? '3');
-export const FLAKY_DEBOUNCE_POLLS = 2;
-export const FLAKY_FILE_PATTERNS = [/-responsiveness\.spec\.ts$/, /visual.*\.spec\.ts$/, /^storm-scale-.*\.spec\.ts$/];
-export const TERMINAL_WORKFLOW_STATUSES = new Set(['completed', 'failed', 'closed']);
-export const MARKER_PREFIX = 'invoker-e2e-regression-watch: first-bad-sha=';
+function resolveYamlModulePath() {
+  const localYamlPath = resolve(REPO_ROOT, 'packages/app/node_modules/yaml/dist/index.js');
+  if (existsSync(localYamlPath)) return localYamlPath;
+  return 'yaml';
+}
+const { parse: parseYaml } = await import(resolveYamlModulePath());
 
-const STATE_DIR = process.env.INVOKER_E2E_WATCH_STATE_DIR ?? join(homedir(), '.invoker', 'e2e-regression-watch');
+export const TARGET_REPO = process.env.INVOKER_GITHUB_TARGET_REPO ?? 'Neko-Catpital-Labs/Invoker';
+export const WORKFLOW_FILE = process.env.INVOKER_CI_WATCH_WORKFLOW_FILE
+  ?? process.env.INVOKER_E2E_WATCH_WORKFLOW_FILE
+  ?? 'ci.yml';
+export const WATCH_BRANCHES = (process.env.INVOKER_CI_WATCH_BRANCHES ?? 'master,main')
+  .split(',')
+  .map((branch) => branch.trim())
+  .filter(Boolean);
+export const RUN_LIST_LIMIT = Number(process.env.INVOKER_CI_WATCH_RUN_LIMIT ?? '50');
+export const CAP_PER_SWEEP = Number(process.env.INVOKER_CI_WATCH_CAP
+  ?? process.env.INVOKER_E2E_WATCH_CAP
+  ?? '0');
+export const TERMINAL_WORKFLOW_STATUSES = new Set(['completed', 'failed', 'closed', 'cancelled', 'stale']);
+export const BROKEN_JOB_CONCLUSIONS = new Set(['failure', 'timed_out', 'action_required']);
+export const IGNORED_JOB_CONCLUSIONS = new Set(['cancelled', 'skipped', 'neutral']);
+export const MARKER_PREFIX = 'invoker-ci-regression-watch: first-bad-sha=';
+export const STATE_SCHEMA_VERSION = 2;
+
+const STATE_DIR = process.env.INVOKER_CI_WATCH_STATE_DIR
+  ?? process.env.INVOKER_E2E_WATCH_STATE_DIR
+  ?? join(homedir(), '.invoker', 'e2e-regression-watch');
 const STATE_FILE = join(STATE_DIR, 'state.json');
 const SWEEP_LOG_FILE = join(STATE_DIR, 'sweep-log.jsonl');
+const WORKFLOW_PATH = join(REPO_ROOT, '.github', 'workflows', WORKFLOW_FILE);
+const BUILD_APP_COMMAND = [
+  'pnpm --filter @invoker/ui build',
+  'pnpm --filter @invoker/surfaces build',
+  'pnpm --filter @invoker/app build',
+].join(' && ');
 
 // ---------------------------------------------------------------------------
-// Pure logic (no I/O) — exercised directly by scripts/repro/repro-e2e-regression-watch.mjs
+// Pure logic
 // ---------------------------------------------------------------------------
-
-export function isFlakyProneTest(file) {
-  const base = file.split('/').pop() ?? file;
-  return FLAKY_FILE_PATTERNS.some((re) => re.test(base));
-}
-
-export function buildTestId(file, titlePath) {
-  return `${file}::${titlePath.join(' > ')}`;
-}
-
-export function buildMarker(sha) {
-  return `${MARKER_PREFIX}${sha}`;
-}
 
 export function shortSha(sha) {
-  return sha.slice(0, 7);
+  return String(sha).slice(0, 7);
 }
 
-// Playwright JSON reporter shape (verified against a real run of
-// packages/app's config): { config, suites[], errors[], stats }. Each
-// suites[] entry is a per-file suite; specs live either directly under it or
-// under nested suites[] (describe blocks). spec.tests[0].status is the
-// POST-RETRY outcome — 'expected' | 'unexpected' | 'flaky' | 'skipped' — not
-// the same as results[].status (per-attempt pass/fail/timedOut/...).
-// 'unexpected' is the only status that means "red after exhausting retries".
-export function parsePlaywrightJson(raw) {
-  const data = JSON.parse(raw);
-  const outcomes = new Map();
-  const walk = (suite, ancestorTitles) => {
-    for (const spec of suite.specs ?? []) {
-      const test = spec.tests?.[0];
-      if (!test) continue;
-      const titlePath = [...ancestorTitles, spec.title];
-      outcomes.set(buildTestId(spec.file, titlePath), {
-        file: spec.file,
-        line: spec.line,
-        title: spec.title,
-        status: test.status,
-      });
-    }
-    for (const child of suite.suites ?? []) {
-      walk(child, [...ancestorTitles, child.title]);
-    }
-  };
-  for (const suite of data.suites ?? []) walk(suite, []);
-  return outcomes;
+export function slugify(value, maxLength = 72) {
+  const slug = String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+  return (slug || 'ci-job').slice(0, maxLength).replace(/-+$/g, '') || 'ci-job';
+}
+
+export function buildMarker(sha, jobName) {
+  return `${MARKER_PREFIX}${sha}; job=${jobName}`;
+}
+
+export function buildMarkerComment(sha, jobName) {
+  return `<!-- ${buildMarker(sha, jobName)} -->`;
 }
 
 export function loadEmptyState() {
-  return { schemaVersion: 1, lastProcessedRunId: 0, dayZero: null, failingTests: {} };
+  return {
+    schemaVersion: STATE_SCHEMA_VERSION,
+    lastProcessedRunId: 0,
+    heads: {},
+    activeFailures: {},
+  };
 }
 
-// Mutates and returns state.failingTests. Only reconciles testIds actually
-// present in `outcomes` this run — a test missing from outcomes (e.g. a
-// partial artifact download) is left untouched rather than assumed recovered.
-export function reconcileFailingSet(state, run, outcomes) {
-  const bootstrap = !state.dayZero;
-  if (bootstrap) {
-    state.dayZero = { establishedAtRunId: run.databaseId, establishedAt: run.createdAt };
-    state.failingTests = {};
+export function normalizeState(raw) {
+  if (!raw || typeof raw !== 'object' || raw.schemaVersion !== STATE_SCHEMA_VERSION) {
+    return loadEmptyState();
   }
-  for (const [testId, o] of outcomes) {
-    const failed = o.status === 'unexpected';
-    const existing = state.failingTests[testId];
-    if (failed) {
+  return {
+    schemaVersion: STATE_SCHEMA_VERSION,
+    lastProcessedRunId: Number(raw.lastProcessedRunId ?? 0),
+    heads: raw.heads && typeof raw.heads === 'object' ? raw.heads : {},
+    activeFailures: raw.activeFailures && typeof raw.activeFailures === 'object' ? raw.activeFailures : {},
+  };
+}
+
+export function classifyJobConclusion(job) {
+  if (!job || job.status !== 'completed') return 'pending';
+  const conclusion = String(job.conclusion ?? '');
+  if (conclusion === 'success') return 'ok';
+  if (BROKEN_JOB_CONCLUSIONS.has(conclusion)) return 'broken';
+  if (IGNORED_JOB_CONCLUSIONS.has(conclusion)) return 'ignored';
+  return 'ignored';
+}
+
+export function reconcileCiRun(state, run) {
+  const normalized = normalizeState(state);
+  const sha = String(run.headSha ?? '').trim();
+  if (!sha) return { state: normalized, processedJobs: 0, brokenJobs: 0, okJobs: 0, ignoredJobs: 0 };
+
+  const headRecord = normalized.heads[sha] ?? {
+    sha,
+    branch: run.headBranch ?? '',
+    firstRunId: run.databaseId,
+    lastRunId: run.databaseId,
+    createdAt: run.createdAt ?? '',
+    jobs: {},
+  };
+  headRecord.branch = run.headBranch ?? headRecord.branch;
+  headRecord.lastRunId = run.databaseId ?? headRecord.lastRunId;
+  headRecord.updatedAt = new Date().toISOString();
+  normalized.heads[sha] = headRecord;
+
+  let processedJobs = 0;
+  let brokenJobs = 0;
+  let okJobs = 0;
+  let ignoredJobs = 0;
+
+  for (const job of run.jobs ?? []) {
+    const jobName = typeof job.name === 'string' ? job.name.trim() : '';
+    if (!jobName) continue;
+    const classification = classifyJobConclusion(job);
+    if (classification === 'pending') continue;
+    processedJobs += 1;
+
+    const baseObservation = {
+      jobName,
+      conclusion: job.conclusion ?? '',
+      runId: run.databaseId,
+      jobDatabaseId: job.databaseId,
+      url: job.url ?? '',
+      observedAt: job.completedAt ?? job.startedAt ?? run.createdAt ?? '',
+    };
+
+    if (classification === 'ok') {
+      okJobs += 1;
+      headRecord.jobs[jobName] = { ...baseObservation, state: 'ok' };
+      delete normalized.activeFailures[jobName];
+      continue;
+    }
+
+    if (classification === 'broken') {
+      brokenJobs += 1;
+      headRecord.jobs[jobName] = { ...baseObservation, state: 'broken' };
+      const existing = normalized.activeFailures[jobName];
       if (existing) {
-        existing.consecutiveFailingPolls += 1;
+        normalized.activeFailures[jobName] = {
+          ...existing,
+          lastBadSha: sha,
+          lastBadRunId: run.databaseId,
+          lastJobDatabaseId: job.databaseId,
+          lastJobUrl: job.url ?? '',
+          lastObservedAt: baseObservation.observedAt,
+          occurrences: Number(existing.occurrences ?? 1) + 1,
+        };
       } else {
-        state.failingTests[testId] = {
-          file: o.file,
-          line: o.line,
-          firstBadSha: run.headSha,
+        normalized.activeFailures[jobName] = {
+          jobName,
+          firstBadSha: sha,
           firstBadRunId: run.databaseId,
-          consecutiveFailingPolls: 1,
-          origin: bootstrap ? 'day0-baseline' : 'regression',
+          firstBadRunCreatedAt: run.createdAt ?? '',
+          firstJobDatabaseId: job.databaseId,
+          firstJobUrl: job.url ?? '',
+          lastBadSha: sha,
+          lastBadRunId: run.databaseId,
+          lastJobDatabaseId: job.databaseId,
+          lastJobUrl: job.url ?? '',
+          lastObservedAt: baseObservation.observedAt,
+          occurrences: 1,
         };
       }
-    } else if (existing) {
-      delete state.failingTests[testId];
+      continue;
+    }
+
+    ignoredJobs += 1;
+    if (!headRecord.jobs[jobName]) {
+      headRecord.jobs[jobName] = { ...baseObservation, state: 'ignored' };
     }
   }
-  return state.failingTests;
+
+  return { state: normalized, processedJobs, brokenJobs, okJobs, ignoredJobs };
 }
 
-// Groups regression-origin failing tests by first-bad SHA (the root-cause
-// identity), applying the flaky-pattern debounce, sorted by blast radius desc.
-export function groupBySha(failingTests) {
-  const groups = new Map();
-  for (const [testId, info] of Object.entries(failingTests)) {
-    if (info.origin !== 'regression') continue;
-    if (isFlakyProneTest(info.file) && info.consecutiveFailingPolls < FLAKY_DEBOUNCE_POLLS) continue;
-    if (!groups.has(info.firstBadSha)) groups.set(info.firstBadSha, []);
-    groups.get(info.firstBadSha).push({ testId, ...info });
+export function getActionableFailures(state) {
+  const normalized = normalizeState(state);
+  return Object.values(normalized.activeFailures)
+    .filter((failure) => failure && typeof failure.jobName === 'string' && typeof failure.firstBadSha === 'string')
+    .sort((a, b) => {
+      const runDelta = Number(a.firstBadRunId ?? 0) - Number(b.firstBadRunId ?? 0);
+      if (runDelta !== 0) return runDelta;
+      return a.jobName.localeCompare(b.jobName);
+    });
+}
+
+function shellSingleQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+function collapseShellLines(value) {
+  return String(value)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(' && ');
+}
+
+function renderGithubTemplate(value, matrix = {}) {
+  return String(value).replace(/\$\{\{\s*matrix\.([A-Za-z0-9_-]+)\s*\}\}/g, (_match, key) => {
+    const rendered = matrix[key];
+    return rendered == null ? '' : String(rendered);
+  });
+}
+
+function cartesianProduct(entries) {
+  return entries.reduce((acc, [key, values]) => {
+    const out = [];
+    for (const item of acc) {
+      for (const value of values) out.push({ ...item, [key]: value });
+    }
+    return out;
+  }, [{}]);
+}
+
+export function expandMatrix(matrix) {
+  if (!matrix || typeof matrix !== 'object') return [{}];
+  if (Array.isArray(matrix.include) && matrix.include.length > 0) {
+    return matrix.include.map((entry) => ({ ...entry }));
   }
-  return Array.from(groups.entries())
-    .map(([sha, tests]) => ({ sha, tests }))
-    .sort((a, b) => b.tests.length - a.tests.length);
+  const axes = Object.entries(matrix)
+    .filter(([key, value]) => key !== 'include' && Array.isArray(value))
+    .map(([key, value]) => [key, value]);
+  if (axes.length === 0) return [{}];
+  return cartesianProduct(axes);
 }
 
-export function buildPlanVars(group, repoUrl) {
-  const sorted = [...group.tests].sort((a, b) => a.testId.localeCompare(b.testId));
-  const primary = sorted[0];
-  const short = shortSha(group.sha);
-  const primaryTitle = primary.testId.split('::')[1] ?? primary.testId;
-  const summary = sorted
-    .map((t) => `${t.file}:${t.line} - ${t.testId.split('::')[1] ?? t.testId}`)
-    .join('\n');
+function jobDownloadsBuildArtifacts(job) {
+  return (job.steps ?? []).some((step) => {
+    const uses = typeof step.uses === 'string' ? step.uses : '';
+    return uses.includes('actions/download-artifact');
+  });
+}
+
+function withBuildPrefix(command, needsBuild) {
+  return needsBuild ? `${BUILD_APP_COMMAND} && ${command}` : command;
+}
+
+function commandForJob(jobId, job, matrix) {
+  const needsBuild = jobDownloadsBuildArtifacts(job);
+  if (jobId === 'build-artifacts') return BUILD_APP_COMMAND;
+  if (jobId === 'ui-vitest') return 'pnpm --filter @invoker/ui test';
+  if (jobId === 'playwright' || jobId === 'playwright-nightly-perf') {
+    const labelPrefix = jobId === 'playwright' ? 'ci-playwright' : 'ci-playwright-nightly-perf';
+    const command = [
+      'env',
+      `INVOKER_PLAYWRIGHT_RUN_LABEL=${shellSingleQuote(`${labelPrefix}-${matrix.name}`)}`,
+      'INVOKER_PLAYWRIGHT_WORKERS=1',
+      `INVOKER_PLAYWRIGHT_FILES=${shellSingleQuote(String(matrix.files ?? '').trim().replace(/\s+/g, ' '))}`,
+      `INVOKER_PLAYWRIGHT_ARGS=${shellSingleQuote('--reporter=line')}`,
+      'bash scripts/test-suites/optional/40-playwright-app.sh',
+    ].join(' ');
+    return withBuildPrefix(command, true);
+  }
+  if (jobId === 'e2e-proof') {
+    const command = [
+      'env',
+      'INVOKER_TEST_ALL_PROOF=1',
+      `INVOKER_TEST_ALL_SHARD_INDEX=${shellSingleQuote(String(matrix.shard))}`,
+      'INVOKER_TEST_ALL_SHARD_TOTAL=4',
+      'INVOKER_TEST_ALL_STATE_FILE=/tmp/invoker-ci-watch-proof-state.tsv',
+      'TMPDIR=/tmp/invoker-tmp',
+      'bash scripts/run-all-tests.sh',
+    ].join(' ');
+    return withBuildPrefix(command, true);
+  }
+  if (jobId === 'e2e-proof-aggregate') {
+    return withBuildPrefix(
+      'env INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_AGGREGATE=1 '
+        + 'INVOKER_TEST_ALL_STATE_FILE=/tmp/invoker-ci-watch-merged-proof-state.tsv bash scripts/run-all-tests.sh',
+      true,
+    );
+  }
+  if (jobId === 'ssh') return withBuildPrefix(`bash ${shellSingleQuote(matrix.suite)}`, true);
+  if (jobId === 'reset-rulebook-repro') {
+    return withBuildPrefix('bash scripts/test-suites/required/26-reset-rulebook-proof.sh', true);
+  }
+  if (jobId === 'scheduled-repros') {
+    return withBuildPrefix(
+      'bash scripts/test-suites/required/23-fix-intent-repros.sh '
+        + '&& pnpm --filter @invoker/app test --run src/__tests__/dispatch-capacity-invariants.test.ts',
+      true,
+    );
+  }
+  if (jobId === 'docker') {
+    return withBuildPrefix(
+      'bash scripts/build-agent-base-image.sh '
+        + '&& docker build -t invoker-agent:latest scripts/fixtures/hello-world-agent '
+        + '&& bash scripts/test-suites/dangerous/10-docker-comprehensive.sh',
+      true,
+    );
+  }
+  if (typeof matrix.command === 'string') return withBuildPrefix(collapseShellLines(matrix.command), needsBuild);
+
+  const runSteps = (job.steps ?? [])
+    .map((step) => (typeof step.run === 'string' ? renderGithubTemplate(step.run, matrix) : ''))
+    .map(collapseShellLines)
+    .filter(Boolean);
+  const lastRun = runSteps.at(-1);
+  if (lastRun) return withBuildPrefix(lastRun, needsBuild);
+  return '';
+}
+
+export function buildCiJobDefinitions(workflow = parseYaml(readFileSync(WORKFLOW_PATH, 'utf8'))) {
+  const definitions = new Map();
+  for (const [jobId, job] of Object.entries(workflow.jobs ?? {})) {
+    for (const matrix of expandMatrix(job.strategy?.matrix)) {
+      const jobName = renderGithubTemplate(job.name ?? jobId, matrix).trim();
+      if (!jobName) continue;
+      definitions.set(jobName, {
+        jobId,
+        jobName,
+        matrix,
+        verifyCommand: commandForJob(jobId, job, matrix),
+      });
+    }
+  }
+  return definitions;
+}
+
+export function fallbackVerifyCommand(jobName) {
+  return `bash -lc ${shellSingleQuote(`echo "No local verify command is mapped for CI job: ${jobName}" >&2; exit 1`)}`;
+}
+
+export function buildPlanVars(failure, repoUrl, jobDefinitions = buildCiJobDefinitions()) {
+  const definition = jobDefinitions.get(failure.jobName);
+  const short = shortSha(failure.firstBadSha);
+  const jobSlug = `${short}-${slugify(failure.jobName)}`;
+  const verifyCommand = definition?.verifyCommand?.trim() || fallbackVerifyCommand(failure.jobName);
   return {
     repo_url: repoUrl,
     base_branch: 'master',
-    sha: group.sha,
+    sha: failure.firstBadSha,
     short_sha: short,
-    bug_slug: `e2e-regression-${short}`,
-    test_count: String(group.tests.length),
-    primary_file: primary.file,
-    primary_line: String(primary.line),
-    primary_title: primaryTitle,
-    verify_command: `pnpm --filter @invoker/app exec xvfb-run --auto-servernum playwright test ${primary.file}:${primary.line}`,
-    affected_tests_summary: summary,
-    marker: `<!-- ${buildMarker(group.sha)} -->`,
+    job_name: failure.jobName,
+    job_slug: jobSlug,
+    run_id: String(failure.firstBadRunId ?? ''),
+    job_database_id: String(failure.firstJobDatabaseId ?? ''),
+    job_url: failure.firstJobUrl ?? '',
+    last_bad_sha: failure.lastBadSha ?? failure.firstBadSha,
+    last_bad_run_id: String(failure.lastBadRunId ?? failure.firstBadRunId ?? ''),
+    verify_command: verifyCommand,
+    marker: buildMarkerComment(failure.firstBadSha, failure.jobName),
   };
 }
 
@@ -183,50 +386,30 @@ export function getRepoUrl() {
   return execFileSync('git', ['remote', 'get-url', 'origin'], { encoding: 'utf8', cwd: REPO_ROOT }).trim();
 }
 
-export function listUnprocessedMasterRuns(lastProcessedRunId) {
-  const runs = ghJson([
-    'run', 'list', '--repo', TARGET_REPO, '--workflow', WORKFLOW_FILE,
-    '--branch', 'master', '--event', 'push', '--status', 'completed',
-    '--json', 'databaseId,headSha,createdAt', '--limit', '50',
-  ]);
-  return runs
-    .filter((r) => r.databaseId > lastProcessedRunId)
-    .sort((a, b) => a.databaseId - b.databaseId);
-}
-
-// Returns 'ran' (job completed, results expected), 'skipped' (upstream job
-// failed so playwright never ran), or 'missing' (job not found on this run).
-export function getPlaywrightJobConclusion(runId) {
-  const view = ghJson(['run', 'view', String(runId), '--repo', TARGET_REPO, '--json', 'jobs']);
-  const jobs = (view.jobs ?? []).filter((j) => typeof j.name === 'string' && j.name.startsWith('playwright /'));
-  if (jobs.length === 0) return 'missing';
-  if (jobs.some((j) => j.conclusion === 'skipped')) return 'skipped';
-  return 'ran';
-}
-
-function findResultsJsonFiles(root) {
-  const found = [];
-  const walk = (dir) => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const p = join(dir, entry.name);
-      if (entry.isDirectory()) walk(p);
-      else if (entry.name === 'results.json') found.push(p);
-    }
-  };
-  walk(root);
-  return found;
-}
-
-export function downloadAndParseShardResults(runId) {
-  const dir = mkdtempSync(join(tmpdir(), `invoker-e2e-watch-run-${runId}-`));
-  execFileSync('gh', ['run', 'download', String(runId), '--repo', TARGET_REPO, '--pattern', 'playwright-artifacts-*', '--dir', dir]);
-  const merged = new Map();
-  for (const file of findResultsJsonFiles(dir)) {
-    for (const [testId, outcome] of parsePlaywrightJson(readFileSync(file, 'utf8'))) {
-      merged.set(testId, outcome);
+export function listUnprocessedDefaultBranchRuns(
+  lastProcessedRunId,
+  { branches = WATCH_BRANCHES, limit = RUN_LIST_LIMIT } = {},
+) {
+  const byId = new Map();
+  for (const branch of branches) {
+    const runs = ghJson([
+      'run', 'list', '--repo', TARGET_REPO, '--workflow', WORKFLOW_FILE,
+      '--branch', branch, '--event', 'push', '--status', 'completed',
+      '--json', 'databaseId,headSha,headBranch,event,status,conclusion,createdAt,updatedAt',
+      '--limit', String(limit),
+    ]);
+    for (const run of runs) {
+      if (Number(run.databaseId) > Number(lastProcessedRunId)) byId.set(run.databaseId, run);
     }
   }
-  return merged;
+  return Array.from(byId.values()).sort((a, b) => Number(a.databaseId) - Number(b.databaseId));
+}
+
+export function getCiRun(runId) {
+  return ghJson([
+    'run', 'view', String(runId), '--repo', TARGET_REPO,
+    '--json', 'databaseId,headSha,headBranch,event,status,conclusion,createdAt,jobs',
+  ]);
 }
 
 function headlessQueryWorkflowsJson() {
@@ -236,34 +419,40 @@ function headlessQueryWorkflowsJson() {
   );
 }
 
-export function liveQueryHasNonTerminalWork(sha, queryFn = headlessQueryWorkflowsJson) {
-  const marker = buildMarker(sha);
+export function liveQueryHasNonTerminalWork(failureOrSha, jobName, queryFn = headlessQueryWorkflowsJson) {
+  const sha = typeof failureOrSha === 'object' ? failureOrSha.firstBadSha : failureOrSha;
+  const job = typeof failureOrSha === 'object' ? failureOrSha.jobName : jobName;
+  const marker = buildMarker(sha, job);
   const workflows = JSON.parse(queryFn());
-  return workflows.some(
-    (w) => !TERMINAL_WORKFLOW_STATUSES.has(w.status) && typeof w.description === 'string' && w.description.includes(marker),
+  const items = Array.isArray(workflows) ? workflows : workflows.items ?? [];
+  return items.some(
+    (w) => !TERMINAL_WORKFLOW_STATUSES.has(w.status)
+      && typeof w.description === 'string'
+      && w.description.includes(marker),
   );
 }
 
-export function fileBugfixPlan(group, opts = {}) {
+export function fileBugfixPlan(failure, opts = {}) {
   const repoUrl = opts.repoUrl ?? getRepoUrl();
-  const vars = buildPlanVars(group, repoUrl);
-  const outDir = join(opts.outRoot ?? join(REPO_ROOT, 'plans', 'rendered'), vars.short_sha);
+  const vars = buildPlanVars(failure, repoUrl, opts.jobDefinitions);
+  const outDir = join(opts.outRoot ?? join(REPO_ROOT, 'plans', 'rendered'), vars.job_slug);
   const varArgs = Object.entries(vars).flatMap(([k, v]) => ['--var', `${k}=${v}`]);
-  runCommand('bash', [join(REPO_ROOT, 'skills/plan-to-invoker/scripts/render-formula.sh'), 'e2e-master-regression', ...varArgs, '--out', outDir]);
-  const planPath = join(outDir, 'e2e-master-regression.yaml');
-  runCommand('bash', [join(REPO_ROOT, 'skills/plan-to-invoker/scripts/skill-doctor.sh'), planPath]);
-  runCommand('bash', [join(REPO_ROOT, 'submit-plan.sh'), planPath]);
-  return { planPath, vars };
+  const run = opts.runCommand ?? runCommand;
+  run('bash', [join(REPO_ROOT, 'skills/plan-to-invoker/scripts/render-formula.sh'), 'ci-regression-watch', ...varArgs, '--out', outDir]);
+  const planPath = join(outDir, 'ci-regression-watch.yaml');
+  run('bash', [join(REPO_ROOT, 'skills/plan-to-invoker/scripts/skill-doctor.sh'), planPath]);
+  if (!opts.dryRun) run('bash', [join(REPO_ROOT, 'submit-plan.sh'), planPath, '--no-track']);
+  return { planPath, vars, submitted: !opts.dryRun };
 }
 
 export function loadState() {
   if (!existsSync(STATE_FILE)) return loadEmptyState();
-  return JSON.parse(readFileSync(STATE_FILE, 'utf8'));
+  return normalizeState(JSON.parse(readFileSync(STATE_FILE, 'utf8')));
 }
 
 export function saveState(state) {
   mkdirSync(STATE_DIR, { recursive: true });
-  writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+  writeFileSync(STATE_FILE, JSON.stringify(normalizeState(state), null, 2));
 }
 
 export function appendSweepLog(entry) {
@@ -278,53 +467,66 @@ export function appendSweepLog(entry) {
 export async function main() {
   const state = loadState();
   const repoUrl = getRepoUrl();
+  const jobDefinitions = buildCiJobDefinitions();
+  const dryRun = process.env.INVOKER_CI_WATCH_DRY_RUN === '1'
+    || process.env.INVOKER_E2E_WATCH_DRY_RUN === '1';
 
-  const runs = listUnprocessedMasterRuns(state.lastProcessedRunId);
+  const runs = listUnprocessedDefaultBranchRuns(state.lastProcessedRunId);
   let runsProcessed = 0;
-  for (const run of runs) {
-    const conclusion = getPlaywrightJobConclusion(run.databaseId);
-    if (conclusion === 'ran') {
-      const outcomes = downloadAndParseShardResults(run.databaseId);
-      reconcileFailingSet(state, run, outcomes);
-      runsProcessed += 1;
-    }
-    state.lastProcessedRunId = run.databaseId;
+  let jobsProcessed = 0;
+  let jobsBroken = 0;
+  let jobsOk = 0;
+  let jobsIgnored = 0;
+  for (const runSummary of runs) {
+    const run = getCiRun(runSummary.databaseId);
+    const result = reconcileCiRun(state, run);
+    runsProcessed += 1;
+    jobsProcessed += result.processedJobs;
+    jobsBroken += result.brokenJobs;
+    jobsOk += result.okJobs;
+    jobsIgnored += result.ignoredJobs;
+    state.lastProcessedRunId = Math.max(Number(state.lastProcessedRunId), Number(run.databaseId));
     saveState(state);
   }
 
-  const groups = groupBySha(state.failingTests);
+  const failures = getActionableFailures(state);
   const toFile = [];
   let groupsSkippedAlreadyAddressed = 0;
   let groupsDeferredByCap = 0;
-  for (const group of groups) {
-    if (liveQueryHasNonTerminalWork(group.sha)) {
+  for (const failure of failures) {
+    if (liveQueryHasNonTerminalWork(failure)) {
       groupsSkippedAlreadyAddressed += 1;
       continue;
     }
-    if (toFile.length < CAP_PER_SWEEP) {
-      toFile.push(group);
+    if (CAP_PER_SWEEP <= 0 || toFile.length < CAP_PER_SWEEP) {
+      toFile.push(failure);
     } else {
       groupsDeferredByCap += 1;
     }
   }
 
-  for (const group of toFile) {
-    fileBugfixPlan(group, { repoUrl });
+  for (const failure of toFile) {
+    fileBugfixPlan(failure, { repoUrl, jobDefinitions, dryRun });
   }
 
   appendSweepLog({
     runsProcessed,
-    groupsFound: groups.length,
+    jobsProcessed,
+    jobsBroken,
+    jobsOk,
+    jobsIgnored,
+    groupsFound: failures.length,
     groupsFiled: toFile.length,
     groupsSkippedAlreadyAddressed,
     groupsDeferredByCap,
+    dryRun,
   });
 }
 
 const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
 if (isMain) {
   main().catch((err) => {
-    console.error('e2e-regression-watch: fatal error', err);
+    console.error('ci-regression-watch: fatal error', err);
     process.exitCode = 1;
   });
 }

--- a/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
+++ b/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
@@ -1,0 +1,84 @@
+name: "CI regression: {{job_slug}}"
+description: |
+  {{marker}}
+
+  CI job `{{job_name}}` first failed on default-branch push commit {{sha}}
+  in run {{run_id}}. It was most recently still red at {{last_bad_sha}}
+  in run {{last_bad_run_id}}.
+
+  First bad job: {{job_url}}
+onFinish: pull_request
+mergeMode: external_review
+baseBranch: {{base_branch}}
+repoUrl: {{repo_url}}
+
+tasks:
+  - id: fix-ci-{{job_slug}}
+    description: |
+      Fix CI job {{job_name}} first observed failing at {{sha}}.
+      Review claim: The change corrects the CI regression's root cause at its source, with no unrelated edits.
+      Review lane: behavior
+      Safety invariant: Other CI jobs and product behavior stay unchanged except for the corrected defect.
+      Slice rationale: One behavior slice: the failing CI job's root cause and deterministic proof.
+      Architectural effect: None expected; no new module boundaries unless the root cause requires it.
+      Goal: Make the CI job `{{job_name}}` pass on current master.
+      Motivation: This job first failed on default-branch commit {{sha}} and stayed red through {{last_bad_sha}}.
+      Alternative considerations: Re-running or weakening the test was rejected; fix the underlying defect.
+      Implementation details: Reproduce at {{sha}}, then implement on current master.
+      Non-goals: No refactor, no unrelated cleanup, no test weakening, no snapshot churn unless it is the reviewed expected output.
+      Layer: e2e_regression
+      Feature state: active
+      Files:
+      - Unknown at filing time; determined during root-cause investigation.
+      Change types:
+      - Unknown at filing time; determined during root-cause investigation.
+      Acceptance criteria:
+      - `{{verify_command}}` exits 0 after the change.
+    prompt: |
+      Goal: Diagnose and fix CI job `{{job_name}}`, first observed failing at
+      default-branch commit {{sha}}.
+      Review lane: behavior
+      Motivation: The per-HEAD CI watcher records this job as broken at
+      {{sha}} and still broken through {{last_bad_sha}}. This is keyed by the
+      CI job, not by a later duplicate HEAD, so avoid duplicate or unrelated
+      repair work.
+      Alternative considerations: Re-running, skipping, weakening tests, or
+      targeting a PR at the historical SHA was rejected; the fix must land on
+      current master.
+      Implementation details: Assume no prior context. Inspect
+      `.github/workflows/ci.yml`, the relevant `scripts/` suite entrypoint, and
+      the first failing GitHub job logs:
+      `gh run view {{run_id}} --repo Neko-Catpital-Labs/Invoker --job {{job_database_id}} --log`.
+      Inspect the introducing commit with `git show {{sha}}`. Reproduce against
+      the historical commit without doing final work there: use a detached
+      temporary worktree or clone at {{sha}}, then run `{{verify_command}}`.
+      Return to the current task branch based on master and implement the fix
+      there. If historical reproduction is blocked by external runner setup,
+      use the GitHub job logs as the historical evidence and still prove the
+      final fix locally.
+      Non-goals: Do not weaken, skip, or delete assertions; do not make broad
+      refactors; do not manually edit GitHub CI state; do not target a PR at
+      the historical SHA.
+      Acceptance criteria: `{{verify_command}}` must exit code 0 on the final
+      branch after the change.
+    dependencies: []
+
+  - id: verify-ci-{{job_slug}}
+    description: |
+      Run the local verification command for CI job {{job_name}}.
+      Review claim: The command passes only when the CI regression is fixed.
+      Review lane: proof
+      Safety invariant: The command is identical before and after the fix.
+      Slice rationale: One proof slice for the repaired CI job.
+      Architectural effect: None; adds no product behavior.
+      Goal: Prove the CI job repair locally.
+      Motivation: A shared command prevents the job-specific regression from recurring silently.
+      Alternative considerations: Manual verification was rejected as non-deterministic.
+      Implementation details: Execute the exact command below.
+      Non-goals: No product edits here; proof only.
+      Layer: e2e_regression
+      Feature state: active
+    command: |
+      {{verify_command}}
+    dependencies:
+      - fix-ci-{{job_slug}}

--- a/skills/plan-to-invoker/formulas/ci-regression-watch/formula.yaml
+++ b/skills/plan-to-invoker/formulas/ci-regression-watch/formula.yaml
@@ -1,0 +1,62 @@
+formula: ci-regression-watch
+version: 1
+description: >
+  File a bug-fix workflow for one CI job that first went red on a default-branch
+  push commit. The task reproduces against the observed commit, then ports the
+  fix to current master so the resulting PR is mergeable.
+vars:
+  repo_url:
+    required: true
+    example: "git@github.com:Neko-Catpital-Labs/Invoker.git"
+    description: "Git remote for the repo where tasks run."
+  base_branch:
+    required: false
+    default: "master"
+    example: "master"
+    description: "Current target branch for the repair PR."
+  sha:
+    required: true
+    example: "abc123def456abc123def456abc123def456ab1"
+    description: "Default-branch commit where this CI job first failed."
+  short_sha:
+    required: true
+    example: "abc123d"
+    description: "Short SHA used in ids."
+  job_name:
+    required: true
+    example: "playwright / 1-of-9"
+    description: "Exact GitHub Actions job name."
+  job_slug:
+    required: true
+    example: "abc123d-playwright-1-of-9"
+    description: "Kebab-case plan/task id suffix."
+  run_id:
+    required: true
+    example: "123456789"
+    description: "GitHub Actions run id for the first bad observation."
+  job_database_id:
+    required: true
+    example: "987654321"
+    description: "GitHub Actions job database id for log lookup."
+  job_url:
+    required: true
+    example: "https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/123/job/987"
+    description: "GitHub Actions job URL for the first bad observation."
+  last_bad_sha:
+    required: true
+    example: "def456def456def456def456def456def456def4"
+    description: "Most recent SHA where the job was still broken."
+  last_bad_run_id:
+    required: true
+    example: "123456799"
+    description: "Most recent run id where the job was still broken."
+  verify_command:
+    required: true
+    example: "bash scripts/test-suites/required/10-vitest-workspace.sh"
+    description: "Local command that should fail before and pass after the fix."
+  marker:
+    required: true
+    example: "<!-- invoker-ci-regression-watch: first-bad-sha=abc123def456abc123def456abc123def456ab1; job=playwright / 1-of-9 -->"
+    description: "Exact dedup marker embedded in the workflow description."
+workflows:
+  - ci-regression-watch.workflow.yaml

--- a/submit-plan.sh
+++ b/submit-plan.sh
@@ -2,15 +2,17 @@
 # Submit a plan YAML to Invoker and execute it (headless mode).
 # Uses the same Electron binary as the GUI to avoid ABI mismatches.
 #
-# Usage: ./submit-plan.sh <plan.yaml>
+# Usage: ./submit-plan.sh <plan.yaml> [headless-run-args...]
 set -e
 
 if [ -z "$1" ]; then
-  echo "Usage: ./submit-plan.sh <plan.yaml>"
+  echo "Usage: ./submit-plan.sh <plan.yaml> [headless-run-args...]"
   exit 1
 fi
 
 PLAN_FILE="$1"
+shift
+EXTRA_HEADLESS_RUN_ARGS=("$@")
 CALLER_PWD="$(pwd)"
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 cd "$REPO_ROOT"
@@ -52,4 +54,4 @@ if [ "$(uname)" = "Linux" ]; then
   )
 fi
 
-ELECTRON_ENABLE_LOGGING=1 exec ./scripts/electron.cjs "${electron_args[@]}" packages/app/dist/main.js --headless run "$PLAN_FILE"
+ELECTRON_ENABLE_LOGGING=1 exec ./scripts/electron.cjs "${electron_args[@]}" packages/app/dist/main.js --headless run "$PLAN_FILE" "${EXTRA_HEADLESS_RUN_ARGS[@]}"


### PR DESCRIPTION
## Summary
Adds the CI watcher script that observes default-branch job state and starts repair handoffs without tracking.

## Review Claim
The watcher converts each active CI job failure into a distinct repair formula render and delegates it in no-track mode.

## Review Lane
policy

## Review Unit
tooling-policy

## Safety Invariant
A matching active handoff marker prevents another handoff for the same first-bad SHA and job name.

## Slice Rationale
This tooling slice owns the scheduled script and shell handoff path; formula content and runtime registration stay separate.

## Non-goals
- No worker registry changes.
- No formula content changes in this slice.
- No test weakening.

## Test Plan
<details>
<summary>Test Plan</summary>

- node --check scripts/e2e-regression-watch.mjs
- bash -n submit-plan.sh scripts/cron-e2e-regression-watch.sh
- git diff --check

</details>

## Revert Plan
<details>
<summary>Revert Plan</summary>

Revert this PR to restore the previous watcher script and tracked plan runner behavior.

</details>
