### PR TITLE
Prove per-head CI regression watcher

### DIFF
--- a/scripts/cron-e2e-regression-watch.sh
+++ b/scripts/cron-e2e-regression-watch.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Cron entrypoint for the e2e master-regression watcher. Lock + log only;
+# Cron entrypoint for the default-branch CI regression watcher. Lock + log only;
 # all logic lives in scripts/e2e-regression-watch.mjs.
 set -euo pipefail
 
@@ -33,11 +33,11 @@ else
   trap 'rm -rf "'"$lockdir"'" 2>/dev/null || true' EXIT
 fi
 
-log_line "e2e-regression-watch sweep starting"
+log_line "ci-regression-watch sweep starting"
 if node "$REPO_ROOT/scripts/e2e-regression-watch.mjs"; then
-  log_line "e2e-regression-watch sweep finished"
+  log_line "ci-regression-watch sweep finished"
 else
   status=$?
-  log_line "e2e-regression-watch sweep failed (exit $status)"
+  log_line "ci-regression-watch sweep failed (exit $status)"
   exit "$status"
 fi

--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -1,168 +1,371 @@
 #!/usr/bin/env node
-// Watches the `playwright` job on master for new e2e regressions and files a
-// bug-fix Invoker plan for each one.
-//
-// Local state (~/.invoker/e2e-regression-watch/state.json) is a mutable
-// snapshot of "what's currently red and since when" — it is NOT a ledger of
-// fixes-in-flight. Whether a regression already has an open fix is always
-// answered by a live query against Invoker's workflow store
-// (liveQueryHasNonTerminalWork), never by anything cached here. GitHub
-// Actions has no "since when has this been red" API, so this state is the
-// only way to compute "is this a new regression" and "which commit did it
-// start at" — do not reach for cron-pr-lib.sh's ledger primitives here, they
-// solve a different problem (fix-in-flight dedup, which must stay live).
+// Watches default-branch `ci.yml` push runs and files one Invoker repair plan
+// per active (first-bad SHA, CI job) failure. Local state records observed HEAD
+// SHAs and job outcomes; live Invoker workflow state remains the dedup source
+// for repairs in flight.
 import { execFileSync, execSync } from 'node:child_process';
 import {
   existsSync,
   mkdirSync,
-  mkdtempSync,
-  readdirSync,
   readFileSync,
   writeFileSync,
   appendFileSync,
 } from 'node:fs';
-import { homedir, tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = dirname(dirname(__filename));
 
-export const TARGET_REPO = process.env.INVOKER_GITHUB_TARGET_REPO ?? 'Neko-Catpital-Labs/Invoker';
-export const WORKFLOW_FILE = process.env.INVOKER_E2E_WATCH_WORKFLOW_FILE ?? 'ci.yml';
-export const CAP_PER_SWEEP = Number(process.env.INVOKER_E2E_WATCH_CAP ?? '3');
-export const FLAKY_DEBOUNCE_POLLS = 2;
-export const FLAKY_FILE_PATTERNS = [/-responsiveness\.spec\.ts$/, /visual.*\.spec\.ts$/, /^storm-scale-.*\.spec\.ts$/];
-export const TERMINAL_WORKFLOW_STATUSES = new Set(['completed', 'failed', 'closed']);
-export const MARKER_PREFIX = 'invoker-e2e-regression-watch: first-bad-sha=';
+function resolveYamlModulePath() {
+  const localYamlPath = resolve(REPO_ROOT, 'packages/app/node_modules/yaml/dist/index.js');
+  if (existsSync(localYamlPath)) return localYamlPath;
+  return 'yaml';
+}
+const { parse: parseYaml } = await import(resolveYamlModulePath());
 
-const STATE_DIR = process.env.INVOKER_E2E_WATCH_STATE_DIR ?? join(homedir(), '.invoker', 'e2e-regression-watch');
+export const TARGET_REPO = process.env.INVOKER_GITHUB_TARGET_REPO ?? 'Neko-Catpital-Labs/Invoker';
+export const WORKFLOW_FILE = process.env.INVOKER_CI_WATCH_WORKFLOW_FILE
+  ?? process.env.INVOKER_E2E_WATCH_WORKFLOW_FILE
+  ?? 'ci.yml';
+export const WATCH_BRANCHES = (process.env.INVOKER_CI_WATCH_BRANCHES ?? 'master,main')
+  .split(',')
+  .map((branch) => branch.trim())
+  .filter(Boolean);
+export const RUN_LIST_LIMIT = Number(process.env.INVOKER_CI_WATCH_RUN_LIMIT ?? '50');
+export const CAP_PER_SWEEP = Number(process.env.INVOKER_CI_WATCH_CAP
+  ?? process.env.INVOKER_E2E_WATCH_CAP
+  ?? '0');
+export const TERMINAL_WORKFLOW_STATUSES = new Set(['completed', 'failed', 'closed', 'cancelled', 'stale']);
+export const BROKEN_JOB_CONCLUSIONS = new Set(['failure', 'timed_out', 'action_required']);
+export const IGNORED_JOB_CONCLUSIONS = new Set(['cancelled', 'skipped', 'neutral']);
+export const MARKER_PREFIX = 'invoker-ci-regression-watch: first-bad-sha=';
+export const STATE_SCHEMA_VERSION = 2;
+
+const STATE_DIR = process.env.INVOKER_CI_WATCH_STATE_DIR
+  ?? process.env.INVOKER_E2E_WATCH_STATE_DIR
+  ?? join(homedir(), '.invoker', 'e2e-regression-watch');
 const STATE_FILE = join(STATE_DIR, 'state.json');
 const SWEEP_LOG_FILE = join(STATE_DIR, 'sweep-log.jsonl');
+const WORKFLOW_PATH = join(REPO_ROOT, '.github', 'workflows', WORKFLOW_FILE);
+const BUILD_APP_COMMAND = [
+  'pnpm --filter @invoker/ui build',
+  'pnpm --filter @invoker/surfaces build',
+  'pnpm --filter @invoker/app build',
+].join(' && ');
 
 // ---------------------------------------------------------------------------
-// Pure logic (no I/O) — exercised directly by scripts/repro/repro-e2e-regression-watch.mjs
+// Pure logic
 // ---------------------------------------------------------------------------
-
-export function isFlakyProneTest(file) {
-  const base = file.split('/').pop() ?? file;
-  return FLAKY_FILE_PATTERNS.some((re) => re.test(base));
-}
-
-export function buildTestId(file, titlePath) {
-  return `${file}::${titlePath.join(' > ')}`;
-}
-
-export function buildMarker(sha) {
-  return `${MARKER_PREFIX}${sha}`;
-}
 
 export function shortSha(sha) {
-  return sha.slice(0, 7);
+  return String(sha).slice(0, 7);
 }
 
-// Playwright JSON reporter shape (verified against a real run of
-// packages/app's config): { config, suites[], errors[], stats }. Each
-// suites[] entry is a per-file suite; specs live either directly under it or
-// under nested suites[] (describe blocks). spec.tests[0].status is the
-// POST-RETRY outcome — 'expected' | 'unexpected' | 'flaky' | 'skipped' — not
-// the same as results[].status (per-attempt pass/fail/timedOut/...).
-// 'unexpected' is the only status that means "red after exhausting retries".
-export function parsePlaywrightJson(raw) {
-  const data = JSON.parse(raw);
-  const outcomes = new Map();
-  const walk = (suite, ancestorTitles) => {
-    for (const spec of suite.specs ?? []) {
-      const test = spec.tests?.[0];
-      if (!test) continue;
-      const titlePath = [...ancestorTitles, spec.title];
-      outcomes.set(buildTestId(spec.file, titlePath), {
-        file: spec.file,
-        line: spec.line,
-        title: spec.title,
-        status: test.status,
-      });
-    }
-    for (const child of suite.suites ?? []) {
-      walk(child, [...ancestorTitles, child.title]);
-    }
-  };
-  for (const suite of data.suites ?? []) walk(suite, []);
-  return outcomes;
+export function slugify(value, maxLength = 72) {
+  const slug = String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+  return (slug || 'ci-job').slice(0, maxLength).replace(/-+$/g, '') || 'ci-job';
+}
+
+export function buildMarker(sha, jobName) {
+  return `${MARKER_PREFIX}${sha}; job=${jobName}`;
+}
+
+export function buildMarkerComment(sha, jobName) {
+  return `<!-- ${buildMarker(sha, jobName)} -->`;
 }
 
 export function loadEmptyState() {
-  return { schemaVersion: 1, lastProcessedRunId: 0, dayZero: null, failingTests: {} };
+  return {
+    schemaVersion: STATE_SCHEMA_VERSION,
+    lastProcessedRunId: 0,
+    heads: {},
+    activeFailures: {},
+  };
 }
 
-// Mutates and returns state.failingTests. Only reconciles testIds actually
-// present in `outcomes` this run — a test missing from outcomes (e.g. a
-// partial artifact download) is left untouched rather than assumed recovered.
-export function reconcileFailingSet(state, run, outcomes) {
-  const bootstrap = !state.dayZero;
-  if (bootstrap) {
-    state.dayZero = { establishedAtRunId: run.databaseId, establishedAt: run.createdAt };
-    state.failingTests = {};
+export function normalizeState(raw) {
+  if (!raw || typeof raw !== 'object' || raw.schemaVersion !== STATE_SCHEMA_VERSION) {
+    return loadEmptyState();
   }
-  for (const [testId, o] of outcomes) {
-    const failed = o.status === 'unexpected';
-    const existing = state.failingTests[testId];
-    if (failed) {
+  return {
+    schemaVersion: STATE_SCHEMA_VERSION,
+    lastProcessedRunId: Number(raw.lastProcessedRunId ?? 0),
+    heads: raw.heads && typeof raw.heads === 'object' ? raw.heads : {},
+    activeFailures: raw.activeFailures && typeof raw.activeFailures === 'object' ? raw.activeFailures : {},
+  };
+}
+
+export function classifyJobConclusion(job) {
+  if (!job || job.status !== 'completed') return 'pending';
+  const conclusion = String(job.conclusion ?? '');
+  if (conclusion === 'success') return 'ok';
+  if (BROKEN_JOB_CONCLUSIONS.has(conclusion)) return 'broken';
+  if (IGNORED_JOB_CONCLUSIONS.has(conclusion)) return 'ignored';
+  return 'ignored';
+}
+
+export function reconcileCiRun(state, run) {
+  const normalized = normalizeState(state);
+  const sha = String(run.headSha ?? '').trim();
+  if (!sha) return { state: normalized, processedJobs: 0, brokenJobs: 0, okJobs: 0, ignoredJobs: 0 };
+
+  const headRecord = normalized.heads[sha] ?? {
+    sha,
+    branch: run.headBranch ?? '',
+    firstRunId: run.databaseId,
+    lastRunId: run.databaseId,
+    createdAt: run.createdAt ?? '',
+    jobs: {},
+  };
+  headRecord.branch = run.headBranch ?? headRecord.branch;
+  headRecord.lastRunId = run.databaseId ?? headRecord.lastRunId;
+  headRecord.updatedAt = new Date().toISOString();
+  normalized.heads[sha] = headRecord;
+
+  let processedJobs = 0;
+  let brokenJobs = 0;
+  let okJobs = 0;
+  let ignoredJobs = 0;
+
+  for (const job of run.jobs ?? []) {
+    const jobName = typeof job.name === 'string' ? job.name.trim() : '';
+    if (!jobName) continue;
+    const classification = classifyJobConclusion(job);
+    if (classification === 'pending') continue;
+    processedJobs += 1;
+
+    const baseObservation = {
+      jobName,
+      conclusion: job.conclusion ?? '',
+      runId: run.databaseId,
+      jobDatabaseId: job.databaseId,
+      url: job.url ?? '',
+      observedAt: job.completedAt ?? job.startedAt ?? run.createdAt ?? '',
+    };
+
+    if (classification === 'ok') {
+      okJobs += 1;
+      headRecord.jobs[jobName] = { ...baseObservation, state: 'ok' };
+      delete normalized.activeFailures[jobName];
+      continue;
+    }
+
+    if (classification === 'broken') {
+      brokenJobs += 1;
+      headRecord.jobs[jobName] = { ...baseObservation, state: 'broken' };
+      const existing = normalized.activeFailures[jobName];
       if (existing) {
-        existing.consecutiveFailingPolls += 1;
+        normalized.activeFailures[jobName] = {
+          ...existing,
+          lastBadSha: sha,
+          lastBadRunId: run.databaseId,
+          lastJobDatabaseId: job.databaseId,
+          lastJobUrl: job.url ?? '',
+          lastObservedAt: baseObservation.observedAt,
+          occurrences: Number(existing.occurrences ?? 1) + 1,
+        };
       } else {
-        state.failingTests[testId] = {
-          file: o.file,
-          line: o.line,
-          firstBadSha: run.headSha,
+        normalized.activeFailures[jobName] = {
+          jobName,
+          firstBadSha: sha,
           firstBadRunId: run.databaseId,
-          consecutiveFailingPolls: 1,
-          origin: bootstrap ? 'day0-baseline' : 'regression',
+          firstBadRunCreatedAt: run.createdAt ?? '',
+          firstJobDatabaseId: job.databaseId,
+          firstJobUrl: job.url ?? '',
+          lastBadSha: sha,
+          lastBadRunId: run.databaseId,
+          lastJobDatabaseId: job.databaseId,
+          lastJobUrl: job.url ?? '',
+          lastObservedAt: baseObservation.observedAt,
+          occurrences: 1,
         };
       }
-    } else if (existing) {
-      delete state.failingTests[testId];
+      continue;
+    }
+
+    ignoredJobs += 1;
+    if (!headRecord.jobs[jobName]) {
+      headRecord.jobs[jobName] = { ...baseObservation, state: 'ignored' };
     }
   }
-  return state.failingTests;
+
+  return { state: normalized, processedJobs, brokenJobs, okJobs, ignoredJobs };
 }
 
-// Groups regression-origin failing tests by first-bad SHA (the root-cause
-// identity), applying the flaky-pattern debounce, sorted by blast radius desc.
-export function groupBySha(failingTests) {
-  const groups = new Map();
-  for (const [testId, info] of Object.entries(failingTests)) {
-    if (info.origin !== 'regression') continue;
-    if (isFlakyProneTest(info.file) && info.consecutiveFailingPolls < FLAKY_DEBOUNCE_POLLS) continue;
-    if (!groups.has(info.firstBadSha)) groups.set(info.firstBadSha, []);
-    groups.get(info.firstBadSha).push({ testId, ...info });
+export function getActionableFailures(state) {
+  const normalized = normalizeState(state);
+  return Object.values(normalized.activeFailures)
+    .filter((failure) => failure && typeof failure.jobName === 'string' && typeof failure.firstBadSha === 'string')
+    .sort((a, b) => {
+      const runDelta = Number(a.firstBadRunId ?? 0) - Number(b.firstBadRunId ?? 0);
+      if (runDelta !== 0) return runDelta;
+      return a.jobName.localeCompare(b.jobName);
+    });
+}
+
+function shellSingleQuote(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+function collapseShellLines(value) {
+  return String(value)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(' && ');
+}
+
+function renderGithubTemplate(value, matrix = {}) {
+  return String(value).replace(/\$\{\{\s*matrix\.([A-Za-z0-9_-]+)\s*\}\}/g, (_match, key) => {
+    const rendered = matrix[key];
+    return rendered == null ? '' : String(rendered);
+  });
+}
+
+function cartesianProduct(entries) {
+  return entries.reduce((acc, [key, values]) => {
+    const out = [];
+    for (const item of acc) {
+      for (const value of values) out.push({ ...item, [key]: value });
+    }
+    return out;
+  }, [{}]);
+}
+
+export function expandMatrix(matrix) {
+  if (!matrix || typeof matrix !== 'object') return [{}];
+  if (Array.isArray(matrix.include) && matrix.include.length > 0) {
+    return matrix.include.map((entry) => ({ ...entry }));
   }
-  return Array.from(groups.entries())
-    .map(([sha, tests]) => ({ sha, tests }))
-    .sort((a, b) => b.tests.length - a.tests.length);
+  const axes = Object.entries(matrix)
+    .filter(([key, value]) => key !== 'include' && Array.isArray(value))
+    .map(([key, value]) => [key, value]);
+  if (axes.length === 0) return [{}];
+  return cartesianProduct(axes);
 }
 
-export function buildPlanVars(group, repoUrl) {
-  const sorted = [...group.tests].sort((a, b) => a.testId.localeCompare(b.testId));
-  const primary = sorted[0];
-  const short = shortSha(group.sha);
-  const primaryTitle = primary.testId.split('::')[1] ?? primary.testId;
-  const summary = sorted
-    .map((t) => `${t.file}:${t.line} - ${t.testId.split('::')[1] ?? t.testId}`)
-    .join('\n');
+function jobDownloadsBuildArtifacts(job) {
+  return (job.steps ?? []).some((step) => {
+    const uses = typeof step.uses === 'string' ? step.uses : '';
+    return uses.includes('actions/download-artifact');
+  });
+}
+
+function withBuildPrefix(command, needsBuild) {
+  return needsBuild ? `${BUILD_APP_COMMAND} && ${command}` : command;
+}
+
+function commandForJob(jobId, job, matrix) {
+  const needsBuild = jobDownloadsBuildArtifacts(job);
+  if (jobId === 'build-artifacts') return BUILD_APP_COMMAND;
+  if (jobId === 'ui-vitest') return 'pnpm --filter @invoker/ui test';
+  if (jobId === 'playwright' || jobId === 'playwright-nightly-perf') {
+    const labelPrefix = jobId === 'playwright' ? 'ci-playwright' : 'ci-playwright-nightly-perf';
+    const command = [
+      'env',
+      `INVOKER_PLAYWRIGHT_RUN_LABEL=${shellSingleQuote(`${labelPrefix}-${matrix.name}`)}`,
+      'INVOKER_PLAYWRIGHT_WORKERS=1',
+      `INVOKER_PLAYWRIGHT_FILES=${shellSingleQuote(String(matrix.files ?? '').trim().replace(/\s+/g, ' '))}`,
+      `INVOKER_PLAYWRIGHT_ARGS=${shellSingleQuote('--reporter=line')}`,
+      'bash scripts/test-suites/optional/40-playwright-app.sh',
+    ].join(' ');
+    return withBuildPrefix(command, true);
+  }
+  if (jobId === 'e2e-proof') {
+    const command = [
+      'env',
+      'INVOKER_TEST_ALL_PROOF=1',
+      `INVOKER_TEST_ALL_SHARD_INDEX=${shellSingleQuote(String(matrix.shard))}`,
+      'INVOKER_TEST_ALL_SHARD_TOTAL=4',
+      'INVOKER_TEST_ALL_STATE_FILE=/tmp/invoker-ci-watch-proof-state.tsv',
+      'TMPDIR=/tmp/invoker-tmp',
+      'bash scripts/run-all-tests.sh',
+    ].join(' ');
+    return withBuildPrefix(command, true);
+  }
+  if (jobId === 'e2e-proof-aggregate') {
+    return withBuildPrefix(
+      'env INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_AGGREGATE=1 '
+        + 'INVOKER_TEST_ALL_STATE_FILE=/tmp/invoker-ci-watch-merged-proof-state.tsv bash scripts/run-all-tests.sh',
+      true,
+    );
+  }
+  if (jobId === 'ssh') return withBuildPrefix(`bash ${shellSingleQuote(matrix.suite)}`, true);
+  if (jobId === 'reset-rulebook-repro') {
+    return withBuildPrefix('bash scripts/test-suites/required/26-reset-rulebook-proof.sh', true);
+  }
+  if (jobId === 'scheduled-repros') {
+    return withBuildPrefix(
+      'bash scripts/test-suites/required/23-fix-intent-repros.sh '
+        + '&& pnpm --filter @invoker/app test --run src/__tests__/dispatch-capacity-invariants.test.ts',
+      true,
+    );
+  }
+  if (jobId === 'docker') {
+    return withBuildPrefix(
+      'bash scripts/build-agent-base-image.sh '
+        + '&& docker build -t invoker-agent:latest scripts/fixtures/hello-world-agent '
+        + '&& bash scripts/test-suites/dangerous/10-docker-comprehensive.sh',
+      true,
+    );
+  }
+  if (typeof matrix.command === 'string') return withBuildPrefix(collapseShellLines(matrix.command), needsBuild);
+
+  const runSteps = (job.steps ?? [])
+    .map((step) => (typeof step.run === 'string' ? renderGithubTemplate(step.run, matrix) : ''))
+    .map(collapseShellLines)
+    .filter(Boolean);
+  const lastRun = runSteps.at(-1);
+  if (lastRun) return withBuildPrefix(lastRun, needsBuild);
+  return '';
+}
+
+export function buildCiJobDefinitions(workflow = parseYaml(readFileSync(WORKFLOW_PATH, 'utf8'))) {
+  const definitions = new Map();
+  for (const [jobId, job] of Object.entries(workflow.jobs ?? {})) {
+    for (const matrix of expandMatrix(job.strategy?.matrix)) {
+      const jobName = renderGithubTemplate(job.name ?? jobId, matrix).trim();
+      if (!jobName) continue;
+      definitions.set(jobName, {
+        jobId,
+        jobName,
+        matrix,
+        verifyCommand: commandForJob(jobId, job, matrix),
+      });
+    }
+  }
+  return definitions;
+}
+
+export function fallbackVerifyCommand(jobName) {
+  return `bash -lc ${shellSingleQuote(`echo "No local verify command is mapped for CI job: ${jobName}" >&2; exit 1`)}`;
+}
+
+export function buildPlanVars(failure, repoUrl, jobDefinitions = buildCiJobDefinitions()) {
+  const definition = jobDefinitions.get(failure.jobName);
+  const short = shortSha(failure.firstBadSha);
+  const jobSlug = `${short}-${slugify(failure.jobName)}`;
+  const verifyCommand = definition?.verifyCommand?.trim() || fallbackVerifyCommand(failure.jobName);
   return {
     repo_url: repoUrl,
     base_branch: 'master',
-    sha: group.sha,
+    sha: failure.firstBadSha,
     short_sha: short,
-    bug_slug: `e2e-regression-${short}`,
-    test_count: String(group.tests.length),
-    primary_file: primary.file,
-    primary_line: String(primary.line),
-    primary_title: primaryTitle,
-    verify_command: `pnpm --filter @invoker/app exec xvfb-run --auto-servernum playwright test ${primary.file}:${primary.line}`,
-    affected_tests_summary: summary,
-    marker: `<!-- ${buildMarker(group.sha)} -->`,
+    job_name: failure.jobName,
+    job_slug: jobSlug,
+    run_id: String(failure.firstBadRunId ?? ''),
+    job_database_id: String(failure.firstJobDatabaseId ?? ''),
+    job_url: failure.firstJobUrl ?? '',
+    last_bad_sha: failure.lastBadSha ?? failure.firstBadSha,
+    last_bad_run_id: String(failure.lastBadRunId ?? failure.firstBadRunId ?? ''),
+    verify_command: verifyCommand,
+    marker: buildMarkerComment(failure.firstBadSha, failure.jobName),
   };
 }
 
@@ -183,50 +386,30 @@ export function getRepoUrl() {
   return execFileSync('git', ['remote', 'get-url', 'origin'], { encoding: 'utf8', cwd: REPO_ROOT }).trim();
 }
 
-export function listUnprocessedMasterRuns(lastProcessedRunId) {
-  const runs = ghJson([
-    'run', 'list', '--repo', TARGET_REPO, '--workflow', WORKFLOW_FILE,
-    '--branch', 'master', '--event', 'push', '--status', 'completed',
-    '--json', 'databaseId,headSha,createdAt', '--limit', '50',
-  ]);
-  return runs
-    .filter((r) => r.databaseId > lastProcessedRunId)
-    .sort((a, b) => a.databaseId - b.databaseId);
-}
-
-// Returns 'ran' (job completed, results expected), 'skipped' (upstream job
-// failed so playwright never ran), or 'missing' (job not found on this run).
-export function getPlaywrightJobConclusion(runId) {
-  const view = ghJson(['run', 'view', String(runId), '--repo', TARGET_REPO, '--json', 'jobs']);
-  const jobs = (view.jobs ?? []).filter((j) => typeof j.name === 'string' && j.name.startsWith('playwright /'));
-  if (jobs.length === 0) return 'missing';
-  if (jobs.some((j) => j.conclusion === 'skipped')) return 'skipped';
-  return 'ran';
-}
-
-function findResultsJsonFiles(root) {
-  const found = [];
-  const walk = (dir) => {
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      const p = join(dir, entry.name);
-      if (entry.isDirectory()) walk(p);
-      else if (entry.name === 'results.json') found.push(p);
-    }
-  };
-  walk(root);
-  return found;
-}
-
-export function downloadAndParseShardResults(runId) {
-  const dir = mkdtempSync(join(tmpdir(), `invoker-e2e-watch-run-${runId}-`));
-  execFileSync('gh', ['run', 'download', String(runId), '--repo', TARGET_REPO, '--pattern', 'playwright-artifacts-*', '--dir', dir]);
-  const merged = new Map();
-  for (const file of findResultsJsonFiles(dir)) {
-    for (const [testId, outcome] of parsePlaywrightJson(readFileSync(file, 'utf8'))) {
-      merged.set(testId, outcome);
+export function listUnprocessedDefaultBranchRuns(
+  lastProcessedRunId,
+  { branches = WATCH_BRANCHES, limit = RUN_LIST_LIMIT } = {},
+) {
+  const byId = new Map();
+  for (const branch of branches) {
+    const runs = ghJson([
+      'run', 'list', '--repo', TARGET_REPO, '--workflow', WORKFLOW_FILE,
+      '--branch', branch, '--event', 'push', '--status', 'completed',
+      '--json', 'databaseId,headSha,headBranch,event,status,conclusion,createdAt,updatedAt',
+      '--limit', String(limit),
+    ]);
+    for (const run of runs) {
+      if (Number(run.databaseId) > Number(lastProcessedRunId)) byId.set(run.databaseId, run);
     }
   }
-  return merged;
+  return Array.from(byId.values()).sort((a, b) => Number(a.databaseId) - Number(b.databaseId));
+}
+
+export function getCiRun(runId) {
+  return ghJson([
+    'run', 'view', String(runId), '--repo', TARGET_REPO,
+    '--json', 'databaseId,headSha,headBranch,event,status,conclusion,createdAt,jobs',
+  ]);
 }
 
 function headlessQueryWorkflowsJson() {
@@ -236,34 +419,40 @@ function headlessQueryWorkflowsJson() {
   );
 }
 
-export function liveQueryHasNonTerminalWork(sha, queryFn = headlessQueryWorkflowsJson) {
-  const marker = buildMarker(sha);
+export function liveQueryHasNonTerminalWork(failureOrSha, jobName, queryFn = headlessQueryWorkflowsJson) {
+  const sha = typeof failureOrSha === 'object' ? failureOrSha.firstBadSha : failureOrSha;
+  const job = typeof failureOrSha === 'object' ? failureOrSha.jobName : jobName;
+  const marker = buildMarker(sha, job);
   const workflows = JSON.parse(queryFn());
-  return workflows.some(
-    (w) => !TERMINAL_WORKFLOW_STATUSES.has(w.status) && typeof w.description === 'string' && w.description.includes(marker),
+  const items = Array.isArray(workflows) ? workflows : workflows.items ?? [];
+  return items.some(
+    (w) => !TERMINAL_WORKFLOW_STATUSES.has(w.status)
+      && typeof w.description === 'string'
+      && w.description.includes(marker),
   );
 }
 
-export function fileBugfixPlan(group, opts = {}) {
+export function fileBugfixPlan(failure, opts = {}) {
   const repoUrl = opts.repoUrl ?? getRepoUrl();
-  const vars = buildPlanVars(group, repoUrl);
-  const outDir = join(opts.outRoot ?? join(REPO_ROOT, 'plans', 'rendered'), vars.short_sha);
+  const vars = buildPlanVars(failure, repoUrl, opts.jobDefinitions);
+  const outDir = join(opts.outRoot ?? join(REPO_ROOT, 'plans', 'rendered'), vars.job_slug);
   const varArgs = Object.entries(vars).flatMap(([k, v]) => ['--var', `${k}=${v}`]);
-  runCommand('bash', [join(REPO_ROOT, 'skills/plan-to-invoker/scripts/render-formula.sh'), 'e2e-master-regression', ...varArgs, '--out', outDir]);
-  const planPath = join(outDir, 'e2e-master-regression.yaml');
-  runCommand('bash', [join(REPO_ROOT, 'skills/plan-to-invoker/scripts/skill-doctor.sh'), planPath]);
-  runCommand('bash', [join(REPO_ROOT, 'submit-plan.sh'), planPath]);
-  return { planPath, vars };
+  const run = opts.runCommand ?? runCommand;
+  run('bash', [join(REPO_ROOT, 'skills/plan-to-invoker/scripts/render-formula.sh'), 'ci-regression-watch', ...varArgs, '--out', outDir]);
+  const planPath = join(outDir, 'ci-regression-watch.yaml');
+  run('bash', [join(REPO_ROOT, 'skills/plan-to-invoker/scripts/skill-doctor.sh'), planPath]);
+  if (!opts.dryRun) run('bash', [join(REPO_ROOT, 'submit-plan.sh'), planPath, '--no-track']);
+  return { planPath, vars, submitted: !opts.dryRun };
 }
 
 export function loadState() {
   if (!existsSync(STATE_FILE)) return loadEmptyState();
-  return JSON.parse(readFileSync(STATE_FILE, 'utf8'));
+  return normalizeState(JSON.parse(readFileSync(STATE_FILE, 'utf8')));
 }
 
 export function saveState(state) {
   mkdirSync(STATE_DIR, { recursive: true });
-  writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+  writeFileSync(STATE_FILE, JSON.stringify(normalizeState(state), null, 2));
 }
 
 export function appendSweepLog(entry) {
@@ -278,53 +467,66 @@ export function appendSweepLog(entry) {
 export async function main() {
   const state = loadState();
   const repoUrl = getRepoUrl();
+  const jobDefinitions = buildCiJobDefinitions();
+  const dryRun = process.env.INVOKER_CI_WATCH_DRY_RUN === '1'
+    || process.env.INVOKER_E2E_WATCH_DRY_RUN === '1';
 
-  const runs = listUnprocessedMasterRuns(state.lastProcessedRunId);
+  const runs = listUnprocessedDefaultBranchRuns(state.lastProcessedRunId);
   let runsProcessed = 0;
-  for (const run of runs) {
-    const conclusion = getPlaywrightJobConclusion(run.databaseId);
-    if (conclusion === 'ran') {
-      const outcomes = downloadAndParseShardResults(run.databaseId);
-      reconcileFailingSet(state, run, outcomes);
-      runsProcessed += 1;
-    }
-    state.lastProcessedRunId = run.databaseId;
+  let jobsProcessed = 0;
+  let jobsBroken = 0;
+  let jobsOk = 0;
+  let jobsIgnored = 0;
+  for (const runSummary of runs) {
+    const run = getCiRun(runSummary.databaseId);
+    const result = reconcileCiRun(state, run);
+    runsProcessed += 1;
+    jobsProcessed += result.processedJobs;
+    jobsBroken += result.brokenJobs;
+    jobsOk += result.okJobs;
+    jobsIgnored += result.ignoredJobs;
+    state.lastProcessedRunId = Math.max(Number(state.lastProcessedRunId), Number(run.databaseId));
     saveState(state);
   }
 
-  const groups = groupBySha(state.failingTests);
+  const failures = getActionableFailures(state);
   const toFile = [];
   let groupsSkippedAlreadyAddressed = 0;
   let groupsDeferredByCap = 0;
-  for (const group of groups) {
-    if (liveQueryHasNonTerminalWork(group.sha)) {
+  for (const failure of failures) {
+    if (liveQueryHasNonTerminalWork(failure)) {
       groupsSkippedAlreadyAddressed += 1;
       continue;
     }
-    if (toFile.length < CAP_PER_SWEEP) {
-      toFile.push(group);
+    if (CAP_PER_SWEEP <= 0 || toFile.length < CAP_PER_SWEEP) {
+      toFile.push(failure);
     } else {
       groupsDeferredByCap += 1;
     }
   }
 
-  for (const group of toFile) {
-    fileBugfixPlan(group, { repoUrl });
+  for (const failure of toFile) {
+    fileBugfixPlan(failure, { repoUrl, jobDefinitions, dryRun });
   }
 
   appendSweepLog({
     runsProcessed,
-    groupsFound: groups.length,
+    jobsProcessed,
+    jobsBroken,
+    jobsOk,
+    jobsIgnored,
+    groupsFound: failures.length,
     groupsFiled: toFile.length,
     groupsSkippedAlreadyAddressed,
     groupsDeferredByCap,
+    dryRun,
   });
 }
 
 const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
 if (isMain) {
   main().catch((err) => {
-    console.error('e2e-regression-watch: fatal error', err);
+    console.error('ci-regression-watch: fatal error', err);
     process.exitCode = 1;
   });
 }

--- a/scripts/repro/repro-e2e-regression-watch.mjs
+++ b/scripts/repro/repro-e2e-regression-watch.mjs
@@ -1,16 +1,23 @@
 #!/usr/bin/env node
-// Exercises scripts/e2e-regression-watch.mjs's pure logic (Playwright JSON
-// parsing, Day-0 baseline vs. new-regression reconciliation, SHA grouping
-// with flaky-pattern debounce, and live-dedup) against fabricated inputs, so
-// none of it needs a real CI run or a running Invoker instance to verify.
+// Exercises scripts/e2e-regression-watch.mjs's pure logic and dry-run formula
+// path. The optional live smoke uses real GitHub read APIs only when
+// INVOKER_E2E_REGRESSION_WATCH_LIVE=1 is set.
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import {
-  parsePlaywrightJson,
-  reconcileFailingSet,
-  groupBySha,
-  buildPlanVars,
-  liveQueryHasNonTerminalWork,
+  buildCiJobDefinitions,
   buildMarker,
+  buildPlanVars,
+  classifyJobConclusion,
+  fileBugfixPlan,
+  getActionableFailures,
+  getCiRun,
+  listUnprocessedDefaultBranchRuns,
+  liveQueryHasNonTerminalWork,
   loadEmptyState,
+  reconcileCiRun,
 } from '../e2e-regression-watch.mjs';
 
 function fail(message) {
@@ -23,189 +30,205 @@ function assertEqual(actual, expected, label) {
   if (a !== e) fail(`${label}: expected ${e}, got ${a}`);
 }
 
-// Mirrors the real shape verified by running packages/app's Playwright config
-// with INVOKER_PLAYWRIGHT_JSON_OUTPUT set: suites[] per file, nested
-// suites[] for describe blocks, specs[].tests[0].status is post-retry
-// ('expected' | 'unexpected' | 'flaky' | 'skipped').
-function fakeResultsJson(fileTitle, entries) {
-  return JSON.stringify({
-    config: {},
-    errors: [],
-    stats: {},
-    suites: [
-      {
-        title: fileTitle,
-        file: fileTitle,
-        suites: [
-          {
-            title: 'suite',
-            file: fileTitle,
-            specs: entries.map((e) => ({
-              title: e.title,
-              file: fileTitle,
-              line: e.line,
-              tests: [{ status: e.status }],
-            })),
-          },
-        ],
-        specs: [],
-      },
-    ],
-  });
-}
-
-function testParsePlaywrightJson() {
-  const raw = fakeResultsJson('e2e/foo.spec.ts', [
-    { title: 'does the thing', line: 10, status: 'unexpected' },
-    { title: 'does another thing', line: 20, status: 'expected' },
-  ]);
-  const outcomes = parsePlaywrightJson(raw);
-  assertEqual(outcomes.size, 2, 'parsePlaywrightJson: outcome count');
-  const failing = outcomes.get('e2e/foo.spec.ts::suite > does the thing');
-  if (!failing) fail('parsePlaywrightJson: missing expected testId (nested describe title not joined correctly)');
-  assertEqual(failing.status, 'unexpected', 'parsePlaywrightJson: failing test status');
-  const passing = outcomes.get('e2e/foo.spec.ts::suite > does another thing');
-  assertEqual(passing.status, 'expected', 'parsePlaywrightJson: passing test status');
-  console.log('[repro-e2e-regression-watch] parsePlaywrightJson: PASS');
-}
-
-function testDayZeroBootstrapNotActionable() {
-  const state = loadEmptyState();
-  const run = { databaseId: 100, headSha: 'sha-day0', createdAt: '2026-07-01T00:00:00Z' };
-  const outcomes = parsePlaywrightJson(
-    fakeResultsJson('e2e/known-red.spec.ts', [{ title: 'already broken', line: 5, status: 'unexpected' }]),
-  );
-  reconcileFailingSet(state, run, outcomes);
-  if (!state.dayZero) fail('reconcileFailingSet: dayZero not established on first run');
-  const entry = state.failingTests['e2e/known-red.spec.ts::suite > already broken'];
-  assertEqual(entry.origin, 'day0-baseline', 'reconcileFailingSet: bootstrap origin');
-  const groups = groupBySha(state.failingTests);
-  assertEqual(groups.length, 0, 'groupBySha: day0-baseline tests must not be actionable');
-  console.log('[repro-e2e-regression-watch] day0 bootstrap not actionable: PASS');
-  return state;
-}
-
-function testNewRegressionDetectedAndGrouped(stateAfterDayZero) {
-  const state = stateAfterDayZero;
-  const run = { databaseId: 101, headSha: 'sha-regression-1', createdAt: '2026-07-02T00:00:00Z' };
-  const outcomes = parsePlaywrightJson(
-    JSON.stringify({
-      suites: [
-        {
-          title: 'e2e/known-red.spec.ts',
-          suites: [{ title: 'suite', specs: [{ title: 'already broken', file: 'e2e/known-red.spec.ts', line: 5, tests: [{ status: 'unexpected' }] }] }],
-        },
-        {
-          title: 'e2e/a.spec.ts',
-          suites: [{ title: 'suite', specs: [{ title: 'new failure a', file: 'e2e/a.spec.ts', line: 1, tests: [{ status: 'unexpected' }] }] }],
-        },
-        {
-          title: 'e2e/b.spec.ts',
-          suites: [{ title: 'suite', specs: [{ title: 'new failure b', file: 'e2e/b.spec.ts', line: 2, tests: [{ status: 'unexpected' }] }] }],
-        },
-      ],
-    }),
-  );
-  reconcileFailingSet(state, run, outcomes);
-
-  const a = state.failingTests['e2e/a.spec.ts::suite > new failure a'];
-  const b = state.failingTests['e2e/b.spec.ts::suite > new failure b'];
-  assertEqual(a.origin, 'regression', 'reconcileFailingSet: new test origin');
-  assertEqual(a.firstBadSha, 'sha-regression-1', 'reconcileFailingSet: new test firstBadSha');
-  assertEqual(b.firstBadSha, 'sha-regression-1', 'reconcileFailingSet: second new test shares firstBadSha');
-
-  const groups = groupBySha(state.failingTests);
-  assertEqual(groups.length, 1, 'groupBySha: two tests sharing a SHA must form exactly one group');
-  assertEqual(groups[0].tests.length, 2, 'groupBySha: group blast radius');
-  console.log('[repro-e2e-regression-watch] new regression detected + grouped by SHA: PASS');
-  return state;
-}
-
-function testRecoverySkipsAndFlakyDebounce(stateAfterRegression) {
-  const state = stateAfterRegression;
-  const run = { databaseId: 102, headSha: 'sha-3', createdAt: '2026-07-03T00:00:00Z' };
-  const outcomes = parsePlaywrightJson(
-    JSON.stringify({
-      suites: [
-        {
-          title: 'e2e/a.spec.ts',
-          suites: [{ title: 'suite', specs: [{ title: 'new failure a', file: 'e2e/a.spec.ts', line: 1, tests: [{ status: 'expected' }] }] }],
-        },
-        {
-          title: 'e2e/dag-click-hitch-responsiveness.spec.ts',
-          suites: [{ title: 'suite', specs: [{ title: 'flaky-prone', file: 'e2e/dag-click-hitch-responsiveness.spec.ts', line: 1, tests: [{ status: 'unexpected' }] }] }],
-        },
-      ],
-    }),
-  );
-  reconcileFailingSet(state, run, outcomes);
-
-  if (state.failingTests['e2e/a.spec.ts::suite > new failure a']) {
-    fail('reconcileFailingSet: recovered test must be removed from failingTests');
-  }
-
-  const flakyKey = 'e2e/dag-click-hitch-responsiveness.spec.ts::suite > flaky-prone';
-  assertEqual(state.failingTests[flakyKey].consecutiveFailingPolls, 1, 'flaky test first poll count');
-  let groups = groupBySha(state.failingTests);
-  const flakyGroup = groups.find((g) => g.sha === 'sha-3');
-  if (flakyGroup) fail('groupBySha: flaky-pattern test with 1 consecutive failing poll must be debounced (excluded)');
-
-  const run2 = { databaseId: 103, headSha: 'sha-3', createdAt: '2026-07-04T00:00:00Z' };
-  const outcomes2 = parsePlaywrightJson(
-    JSON.stringify({
-      suites: [
-        {
-          title: 'e2e/dag-click-hitch-responsiveness.spec.ts',
-          suites: [{ title: 'suite', specs: [{ title: 'flaky-prone', file: 'e2e/dag-click-hitch-responsiveness.spec.ts', line: 1, tests: [{ status: 'unexpected' }] }] }],
-        },
-      ],
-    }),
-  );
-  reconcileFailingSet(state, run2, outcomes2);
-  assertEqual(state.failingTests[flakyKey].consecutiveFailingPolls, 2, 'flaky test second poll count');
-  groups = groupBySha(state.failingTests);
-  const flakyGroupAfterDebounce = groups.find((g) => g.sha === 'sha-3');
-  if (!flakyGroupAfterDebounce) fail('groupBySha: flaky-pattern test must become actionable after 2 consecutive failing polls');
-  console.log('[repro-e2e-regression-watch] recovery removal + flaky debounce: PASS');
-}
-
-function testLiveDedupIsAlwaysLive() {
-  const sha = 'sha-dedup-test';
-  const fakeNonTerminal = () => JSON.stringify([{ status: 'running', description: `<!-- ${buildMarker(sha)} -->\nsome plan body` }]);
-  const fakeTerminal = () => JSON.stringify([{ status: 'completed', description: `<!-- ${buildMarker(sha)} -->\nsome plan body` }]);
-  const fakeNoMatch = () => JSON.stringify([{ status: 'running', description: 'unrelated workflow' }]);
-
-  if (!liveQueryHasNonTerminalWork(sha, fakeNonTerminal)) fail('liveQueryHasNonTerminalWork: must return true for a non-terminal match');
-  if (liveQueryHasNonTerminalWork(sha, fakeTerminal)) fail('liveQueryHasNonTerminalWork: a completed workflow must not block re-filing');
-  if (liveQueryHasNonTerminalWork(sha, fakeNoMatch)) fail('liveQueryHasNonTerminalWork: must return false when no workflow carries the marker');
-  console.log('[repro-e2e-regression-watch] live dedup (non-cached) behavior: PASS');
-}
-
-function testBuildPlanVars() {
-  const group = {
-    sha: 'abc123def456abc123def456abc123def456ab1',
-    tests: [
-      { testId: 'e2e/b.spec.ts::suite > new failure b', file: 'e2e/b.spec.ts', line: 2 },
-      { testId: 'e2e/a.spec.ts::suite > new failure a', file: 'e2e/a.spec.ts', line: 1 },
-    ],
+function fakeJob(name, conclusion, id = 1) {
+  return {
+    name,
+    status: 'completed',
+    conclusion,
+    databaseId: id,
+    url: `https://example.test/job/${id}`,
+    completedAt: `2026-07-31T00:0${id}:00Z`,
   };
-  const vars = buildPlanVars(group, 'git@github.com:Neko-Catpital-Labs/Invoker.git');
-  assertEqual(vars.short_sha, 'abc123d', 'buildPlanVars: short_sha');
-  assertEqual(vars.bug_slug, 'e2e-regression-abc123d', 'buildPlanVars: bug_slug');
-  assertEqual(vars.primary_file, 'e2e/a.spec.ts', 'buildPlanVars: primary is lowest sorted testId');
-  assertEqual(vars.test_count, '2', 'buildPlanVars: test_count');
-  if (!vars.marker.includes(group.sha)) fail('buildPlanVars: marker must embed the SHA');
-  if (!vars.verify_command.includes('e2e/a.spec.ts:1')) fail('buildPlanVars: verify_command must target the primary test');
-  console.log('[repro-e2e-regression-watch] buildPlanVars: PASS');
+}
+
+function fakeRun(id, sha, jobs) {
+  return {
+    databaseId: id,
+    headSha: sha,
+    headBranch: 'master',
+    event: 'push',
+    status: 'completed',
+    conclusion: jobs.some((job) => job.conclusion === 'failure') ? 'failure' : 'success',
+    createdAt: `2026-07-31T00:${id}:00Z`,
+    jobs,
+  };
+}
+
+function testJobClassification() {
+  assertEqual(classifyJobConclusion(fakeJob('A', 'success')), 'ok', 'success is ok');
+  assertEqual(classifyJobConclusion(fakeJob('A', 'failure')), 'broken', 'failure is broken');
+  assertEqual(classifyJobConclusion(fakeJob('A', 'timed_out')), 'broken', 'timed_out is broken');
+  assertEqual(classifyJobConclusion(fakeJob('A', 'cancelled')), 'ignored', 'cancelled is ignored');
+  assertEqual(classifyJobConclusion(fakeJob('A', 'skipped')), 'ignored', 'skipped is ignored');
+  console.log('[repro-e2e-regression-watch] job classification: PASS');
+}
+
+function testPerHeadFailureDedupAndRecovery() {
+  const state = loadEmptyState();
+  reconcileCiRun(state, fakeRun(100, 'sha-x', [fakeJob('playwright / 1-of-9', 'failure', 10)]));
+  let failures = getActionableFailures(state);
+  assertEqual(failures.length, 1, 'first failure creates one actionable failure');
+  assertEqual(failures[0].firstBadSha, 'sha-x', 'first bad SHA is recorded');
+  assertEqual(state.heads['sha-x'].jobs['playwright / 1-of-9'].state, 'broken', 'head records broken job');
+
+  reconcileCiRun(state, fakeRun(101, 'sha-x-plus-1', [fakeJob('playwright / 1-of-9', 'failure', 11)]));
+  failures = getActionableFailures(state);
+  assertEqual(failures.length, 1, 'duplicate failing HEAD keeps one actionable failure');
+  assertEqual(failures[0].firstBadSha, 'sha-x', 'first bad SHA is stable across duplicates');
+  assertEqual(failures[0].lastBadSha, 'sha-x-plus-1', 'latest bad SHA advances');
+
+  reconcileCiRun(state, fakeRun(102, 'sha-x-plus-2', [fakeJob('playwright / 1-of-9', 'success', 12)]));
+  failures = getActionableFailures(state);
+  assertEqual(failures.length, 0, 'later successful HEAD clears active failure');
+  assertEqual(state.heads['sha-x-plus-2'].jobs['playwright / 1-of-9'].state, 'ok', 'success is recorded per head');
+  console.log('[repro-e2e-regression-watch] per-HEAD dedup + recovery: PASS');
+}
+
+function testCancelledAndSkippedDoNotClear() {
+  const state = loadEmptyState();
+  reconcileCiRun(state, fakeRun(200, 'sha-a', [fakeJob('required-fast / Vitest Workspace', 'failure', 20)]));
+  reconcileCiRun(state, fakeRun(201, 'sha-b', [fakeJob('required-fast / Vitest Workspace', 'cancelled', 21)]));
+  reconcileCiRun(state, fakeRun(202, 'sha-c', [fakeJob('required-fast / Vitest Workspace', 'skipped', 22)]));
+  const failures = getActionableFailures(state);
+  assertEqual(failures.length, 1, 'cancelled/skipped do not clear active failure');
+  assertEqual(failures[0].firstBadSha, 'sha-a', 'first bad SHA remains after ignored runs');
+  assertEqual(state.heads['sha-b'].jobs['required-fast / Vitest Workspace'].state, 'ignored', 'cancelled head is recorded ignored');
+  assertEqual(state.heads['sha-c'].jobs['required-fast / Vitest Workspace'].state, 'ignored', 'skipped head is recorded ignored');
+  console.log('[repro-e2e-regression-watch] cancelled/skipped behavior: PASS');
+}
+
+function testEveryFailedJobQueuesSeparately() {
+  const state = loadEmptyState();
+  reconcileCiRun(state, fakeRun(300, 'sha-many', [
+    fakeJob('playwright / 1-of-9', 'failure', 30),
+    fakeJob('playwright / 2-of-9', 'failure', 31),
+    fakeJob('build-artifacts', 'success', 32),
+  ]));
+  const failures = getActionableFailures(state);
+  assertEqual(failures.map((f) => f.jobName), ['playwright / 1-of-9', 'playwright / 2-of-9'], 'each failed job is actionable');
+  console.log('[repro-e2e-regression-watch] every failed job queues separately: PASS');
+}
+
+function testLiveDedupIsJobScoped() {
+  const sha = 'sha-dedup-test';
+  const job = 'playwright / 1-of-9';
+  const marker = buildMarker(sha, job);
+  const fakeNonTerminal = () => JSON.stringify([{ status: 'running', description: `<!-- ${marker} -->` }]);
+  const fakeTerminal = () => JSON.stringify([{ status: 'failed', description: `<!-- ${marker} -->` }]);
+  const fakeOtherJob = () => JSON.stringify([{ status: 'running', description: `<!-- ${buildMarker(sha, 'playwright / 2-of-9')} -->` }]);
+
+  if (!liveQueryHasNonTerminalWork(sha, job, fakeNonTerminal)) fail('non-terminal matching marker must dedupe');
+  if (liveQueryHasNonTerminalWork(sha, job, fakeTerminal)) fail('terminal matching marker must not dedupe');
+  if (liveQueryHasNonTerminalWork(sha, job, fakeOtherJob)) fail('same SHA but different job must not dedupe');
+  console.log('[repro-e2e-regression-watch] live dedup is job-scoped: PASS');
+}
+
+function testWorkflowCommandMapping() {
+  const defs = buildCiJobDefinitions();
+  const expected = [
+    'playwright / 1-of-9',
+    'playwright / 9-of-9',
+    'required-fast / Vitest Workspace',
+    'e2e-proof / shard 0',
+    'docker / comprehensive',
+  ];
+  for (const name of expected) {
+    const def = defs.get(name);
+    if (!def) fail(`missing CI job definition for ${name}`);
+    if (!def.verifyCommand) fail(`CI job definition lacks verify command for ${name}`);
+  }
+  if (!defs.get('playwright / 1-of-9').verifyCommand.includes('INVOKER_PLAYWRIGHT_FILES=')) {
+    fail('playwright shard command must include shard file list');
+  }
+  if (defs.get('required-fast / Vitest Workspace').verifyCommand !== 'pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/10-vitest-workspace.sh') {
+    fail('required-fast / Vitest Workspace command changed unexpectedly');
+  }
+  console.log('[repro-e2e-regression-watch] workflow command mapping: PASS');
+}
+
+function testPlanVarsAndDryRunRendering() {
+  const state = loadEmptyState();
+  reconcileCiRun(state, fakeRun(400, 'abc123def456abc123def456abc123def456ab1', [
+    fakeJob('required-fast / Vitest Workspace', 'failure', 40),
+  ]));
+  const [failure] = getActionableFailures(state);
+  const defs = buildCiJobDefinitions();
+  const vars = buildPlanVars(failure, 'git@github.com:Neko-Catpital-Labs/Invoker.git', defs);
+  if (!vars.marker.includes('job=required-fast / Vitest Workspace')) fail('marker must include job name');
+  if (!vars.verify_command.includes('10-vitest-workspace.sh')) fail('verify command must be job-specific');
+
+  const outRoot = mkdtempSync(join(tmpdir(), 'invoker-ci-watch-render-'));
+  try {
+    const rendered = fileBugfixPlan(failure, {
+      repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
+      jobDefinitions: defs,
+      outRoot,
+      dryRun: true,
+    });
+    if (!rendered.planPath.endsWith('ci-regression-watch.yaml')) fail('dry run did not render expected plan path');
+    if (rendered.submitted) fail('dry run must not submit');
+  } finally {
+    rmSync(outRoot, { recursive: true, force: true });
+  }
+  console.log('[repro-e2e-regression-watch] plan vars + dry-run rendering: PASS');
+}
+
+function testLiveSubmissionUsesNoTrack() {
+  const state = loadEmptyState();
+  reconcileCiRun(state, fakeRun(450, 'abc456def456abc123def456abc123def456ab2', [
+    fakeJob('playwright / 2-of-9', 'failure', 45),
+  ]));
+  const [failure] = getActionableFailures(state);
+  const calls = [];
+  const rendered = fileBugfixPlan(failure, {
+    repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
+    jobDefinitions: buildCiJobDefinitions(),
+    outRoot: join(tmpdir(), 'invoker-ci-watch-no-track-test'),
+    dryRun: false,
+    runCommand: (cmd, args) => calls.push([cmd, args]),
+  });
+
+  assertEqual(rendered.submitted, true, 'live filing reports submitted');
+  const submitCall = calls.find(([, args]) => args.some((arg) => String(arg).endsWith('/submit-plan.sh')));
+  if (!submitCall) fail('live filing did not invoke submit-plan.sh');
+  const [, submitArgs] = submitCall;
+  assertEqual(submitArgs.at(-1), '--no-track', 'live filing must submit without tracking');
+  assertEqual(submitArgs.at(-2), rendered.planPath, 'live filing passes rendered plan before --no-track');
+  console.log('[repro-e2e-regression-watch] live submission uses --no-track: PASS');
+}
+
+function testLiveGithubSmokeIfRequested() {
+  if (process.env.INVOKER_E2E_REGRESSION_WATCH_LIVE !== '1') {
+    console.log('[repro-e2e-regression-watch] live GitHub smoke: SKIP');
+    return;
+  }
+  const runs = listUnprocessedDefaultBranchRuns(0, { branches: ['master'], limit: 1 });
+  if (runs.length === 0) fail('live GitHub smoke found no completed master push runs');
+  let run = null;
+  for (const candidate of listUnprocessedDefaultBranchRuns(0, { branches: ['master'], limit: 10 })) {
+    const detail = getCiRun(candidate.databaseId);
+    if (detail.headSha && Array.isArray(detail.jobs) && detail.jobs.length > 0) {
+      run = detail;
+      break;
+    }
+  }
+  if (!run) fail('live GitHub smoke found no completed master push run with jobs');
+  const state = loadEmptyState();
+  reconcileCiRun(state, run);
+  if (!state.heads[run.headSha]) fail('live GitHub smoke did not record run HEAD');
+  console.log('[repro-e2e-regression-watch] live GitHub smoke: PASS');
 }
 
 function main() {
-  testParsePlaywrightJson();
-  const s1 = testDayZeroBootstrapNotActionable();
-  const s2 = testNewRegressionDetectedAndGrouped(s1);
-  testRecoverySkipsAndFlakyDebounce(s2);
-  testLiveDedupIsAlwaysLive();
-  testBuildPlanVars();
+  testJobClassification();
+  testPerHeadFailureDedupAndRecovery();
+  testCancelledAndSkippedDoNotClear();
+  testEveryFailedJobQueuesSeparately();
+  testLiveDedupIsJobScoped();
+  testWorkflowCommandMapping();
+  testPlanVarsAndDryRunRendering();
+  testLiveSubmissionUsesNoTrack();
+  testLiveGithubSmokeIfRequested();
   console.log('[repro-e2e-regression-watch] all checks passed');
 }
 

--- a/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
+++ b/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
@@ -1,0 +1,84 @@
+name: "CI regression: {{job_slug}}"
+description: |
+  {{marker}}
+
+  CI job `{{job_name}}` first failed on default-branch push commit {{sha}}
+  in run {{run_id}}. It was most recently still red at {{last_bad_sha}}
+  in run {{last_bad_run_id}}.
+
+  First bad job: {{job_url}}
+onFinish: pull_request
+mergeMode: external_review
+baseBranch: {{base_branch}}
+repoUrl: {{repo_url}}
+
+tasks:
+  - id: fix-ci-{{job_slug}}
+    description: |
+      Fix CI job {{job_name}} first observed failing at {{sha}}.
+      Review claim: The change corrects the CI regression's root cause at its source, with no unrelated edits.
+      Review lane: behavior
+      Safety invariant: Other CI jobs and product behavior stay unchanged except for the corrected defect.
+      Slice rationale: One behavior slice: the failing CI job's root cause and deterministic proof.
+      Architectural effect: None expected; no new module boundaries unless the root cause requires it.
+      Goal: Make the CI job `{{job_name}}` pass on current master.
+      Motivation: This job first failed on default-branch commit {{sha}} and stayed red through {{last_bad_sha}}.
+      Alternative considerations: Re-running or weakening the test was rejected; fix the underlying defect.
+      Implementation details: Reproduce at {{sha}}, then implement on current master.
+      Non-goals: No refactor, no unrelated cleanup, no test weakening, no snapshot churn unless it is the reviewed expected output.
+      Layer: e2e_regression
+      Feature state: active
+      Files:
+      - Unknown at filing time; determined during root-cause investigation.
+      Change types:
+      - Unknown at filing time; determined during root-cause investigation.
+      Acceptance criteria:
+      - `{{verify_command}}` exits 0 after the change.
+    prompt: |
+      Goal: Diagnose and fix CI job `{{job_name}}`, first observed failing at
+      default-branch commit {{sha}}.
+      Review lane: behavior
+      Motivation: The per-HEAD CI watcher records this job as broken at
+      {{sha}} and still broken through {{last_bad_sha}}. This is keyed by the
+      CI job, not by a later duplicate HEAD, so avoid duplicate or unrelated
+      repair work.
+      Alternative considerations: Re-running, skipping, weakening tests, or
+      targeting a PR at the historical SHA was rejected; the fix must land on
+      current master.
+      Implementation details: Assume no prior context. Inspect
+      `.github/workflows/ci.yml`, the relevant `scripts/` suite entrypoint, and
+      the first failing GitHub job logs:
+      `gh run view {{run_id}} --repo Neko-Catpital-Labs/Invoker --job {{job_database_id}} --log`.
+      Inspect the introducing commit with `git show {{sha}}`. Reproduce against
+      the historical commit without doing final work there: use a detached
+      temporary worktree or clone at {{sha}}, then run `{{verify_command}}`.
+      Return to the current task branch based on master and implement the fix
+      there. If historical reproduction is blocked by external runner setup,
+      use the GitHub job logs as the historical evidence and still prove the
+      final fix locally.
+      Non-goals: Do not weaken, skip, or delete assertions; do not make broad
+      refactors; do not manually edit GitHub CI state; do not target a PR at
+      the historical SHA.
+      Acceptance criteria: `{{verify_command}}` must exit code 0 on the final
+      branch after the change.
+    dependencies: []
+
+  - id: verify-ci-{{job_slug}}
+    description: |
+      Run the local verification command for CI job {{job_name}}.
+      Review claim: The command passes only when the CI regression is fixed.
+      Review lane: proof
+      Safety invariant: The command is identical before and after the fix.
+      Slice rationale: One proof slice for the repaired CI job.
+      Architectural effect: None; adds no product behavior.
+      Goal: Prove the CI job repair locally.
+      Motivation: A shared command prevents the job-specific regression from recurring silently.
+      Alternative considerations: Manual verification was rejected as non-deterministic.
+      Implementation details: Execute the exact command below.
+      Non-goals: No product edits here; proof only.
+      Layer: e2e_regression
+      Feature state: active
+    command: |
+      {{verify_command}}
+    dependencies:
+      - fix-ci-{{job_slug}}

--- a/skills/plan-to-invoker/formulas/ci-regression-watch/formula.yaml
+++ b/skills/plan-to-invoker/formulas/ci-regression-watch/formula.yaml
@@ -1,0 +1,62 @@
+formula: ci-regression-watch
+version: 1
+description: >
+  File a bug-fix workflow for one CI job that first went red on a default-branch
+  push commit. The task reproduces against the observed commit, then ports the
+  fix to current master so the resulting PR is mergeable.
+vars:
+  repo_url:
+    required: true
+    example: "git@github.com:Neko-Catpital-Labs/Invoker.git"
+    description: "Git remote for the repo where tasks run."
+  base_branch:
+    required: false
+    default: "master"
+    example: "master"
+    description: "Current target branch for the repair PR."
+  sha:
+    required: true
+    example: "abc123def456abc123def456abc123def456ab1"
+    description: "Default-branch commit where this CI job first failed."
+  short_sha:
+    required: true
+    example: "abc123d"
+    description: "Short SHA used in ids."
+  job_name:
+    required: true
+    example: "playwright / 1-of-9"
+    description: "Exact GitHub Actions job name."
+  job_slug:
+    required: true
+    example: "abc123d-playwright-1-of-9"
+    description: "Kebab-case plan/task id suffix."
+  run_id:
+    required: true
+    example: "123456789"
+    description: "GitHub Actions run id for the first bad observation."
+  job_database_id:
+    required: true
+    example: "987654321"
+    description: "GitHub Actions job database id for log lookup."
+  job_url:
+    required: true
+    example: "https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/123/job/987"
+    description: "GitHub Actions job URL for the first bad observation."
+  last_bad_sha:
+    required: true
+    example: "def456def456def456def456def456def456def4"
+    description: "Most recent SHA where the job was still broken."
+  last_bad_run_id:
+    required: true
+    example: "123456799"
+    description: "Most recent run id where the job was still broken."
+  verify_command:
+    required: true
+    example: "bash scripts/test-suites/required/10-vitest-workspace.sh"
+    description: "Local command that should fail before and pass after the fix."
+  marker:
+    required: true
+    example: "<!-- invoker-ci-regression-watch: first-bad-sha=abc123def456abc123def456abc123def456ab1; job=playwright / 1-of-9 -->"
+    description: "Exact dedup marker embedded in the workflow description."
+workflows:
+  - ci-regression-watch.workflow.yaml

--- a/submit-plan.sh
+++ b/submit-plan.sh
@@ -2,15 +2,17 @@
 # Submit a plan YAML to Invoker and execute it (headless mode).
 # Uses the same Electron binary as the GUI to avoid ABI mismatches.
 #
-# Usage: ./submit-plan.sh <plan.yaml>
+# Usage: ./submit-plan.sh <plan.yaml> [headless-run-args...]
 set -e
 
 if [ -z "$1" ]; then
-  echo "Usage: ./submit-plan.sh <plan.yaml>"
+  echo "Usage: ./submit-plan.sh <plan.yaml> [headless-run-args...]"
   exit 1
 fi
 
 PLAN_FILE="$1"
+shift
+EXTRA_HEADLESS_RUN_ARGS=("$@")
 CALLER_PWD="$(pwd)"
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
 cd "$REPO_ROOT"
@@ -52,4 +54,4 @@ if [ "$(uname)" = "Linux" ]; then
   )
 fi
 
-ELECTRON_ENABLE_LOGGING=1 exec ./scripts/electron.cjs "${electron_args[@]}" packages/app/dist/main.js --headless run "$PLAN_FILE"
+ELECTRON_ENABLE_LOGGING=1 exec ./scripts/electron.cjs "${electron_args[@]}" packages/app/dist/main.js --headless run "$PLAN_FILE" "${EXTRA_HEADLESS_RUN_ARGS[@]}"


### PR DESCRIPTION
## Summary
Adds focused repro coverage for the per-HEAD CI watcher behavior.

## Review Claim
The repro exercises job classification, first-bad SHA tracking, recovery, job-scoped handoff markers, command mapping, no-track handoff, and a live GitHub smoke path.

## Review Lane
proof

## Review Unit
proof

## Safety Invariant
The repro runs without changing production state unless the explicit live smoke environment variable is set, and the live smoke uses read-only GitHub queries.

## Slice Rationale
This proof slice covers the watcher behavior separately from the watcher implementation and worker registration.

## Non-goals
- No runtime behavior changes.
- No formula content changes.
- No local configuration changes.

## Test Plan
<details>
<summary>Test Plan</summary>

- node --check scripts/repro/repro-e2e-regression-watch.mjs
- node scripts/repro/repro-e2e-regression-watch.mjs
- INVOKER_E2E_REGRESSION_WATCH_LIVE=1 node scripts/repro/repro-e2e-regression-watch.mjs

</details>

## Revert Plan
<details>
<summary>Revert Plan</summary>

Revert this PR to restore the previous repro script.

</details>
