### PR TITLE
[CI regression: e0053c7-playwright-6-of-9](1) Fix CI job playwright / 6-of-9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -659,6 +659,8 @@ jobs:
             files: >-
               e2e/gui-owner-auto-bootstrap.spec.ts
               e2e/start-ready-daemon-owner.spec.ts
+              e2e/planning-terminal-live-model.proof.spec.ts
+              e2e/ui-delta-timeline.spec.ts
               e2e/workers-surface.spec.ts
 
     name: playwright / ${{ matrix.name }}

--- a/scripts/test-suites/optional/40-playwright-app.sh
+++ b/scripts/test-suites/optional/40-playwright-app.sh
@@ -37,7 +37,7 @@ elif [ -n "${INVOKER_PLAYWRIGHT_SHARD_INDEX:-}" ] && [ -n "${INVOKER_PLAYWRIGHT_
 fi
 RUN_LABEL="$(sanitize_label "$RUN_LABEL")"
 
-ARTIFACT_ROOT="$ROOT/.git/playwright-artifacts/$RUN_LABEL"
+ARTIFACT_ROOT="$(git rev-parse --path-format=absolute --git-path "playwright-artifacts/$RUN_LABEL")"
 mkdir -p "$ARTIFACT_ROOT"
 
 export INVOKER_E2E_BARE_REPO="${INVOKER_E2E_BARE_REPO:-/tmp/invoker-e2e-repo-${RUN_LABEL}.git}"


### PR DESCRIPTION
## Summary

CI job `playwright / 6-of-9` was red on every run because a shared setup
step, `Verify Playwright shard inventory`, failed before any test ran.

That step checks every `*.spec.ts` file under `packages/app/e2e` is
declared in exactly one shard's `files:` block in `ci.yml`.

Two spec files, `planning-terminal-live-model.proof.spec.ts` and
`ui-delta-timeline.spec.ts`, existed on disk but appeared in no shard's
block, so the check failed for every `playwright / *` job, including
6-of-9.

This change adds both files to the `9-of-9` shard's `files:` block,
which is where they belong given their subject matter.

Separately, `40-playwright-app.sh` built its artifact directory as
`$ROOT/.git/playwright-artifacts/...`, assuming `.git` is a directory.

That assumption breaks in a git worktree, where `.git` is a file. This
change swaps in `git rev-parse --git-path`, which resolves correctly in
both cases.

## Review Claim

Confirm both changes are the actual root cause: the missing shard
entries explain the inventory-check failure, and the worktree-safe
artifact path is a real correctness fix rather than an unrelated
change.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Both edits are additive/corrective to CI tooling only: no product code
under `packages/*/src` changes, and no other shard's file list is
touched, so no other `playwright / *` job's test selection changes.

## Slice Rationale

Kept as one slice because both edits are needed together to make
`playwright / 6-of-9` pass locally and in CI, and both classify as the
same `tooling-policy` review unit in this repo's taxonomy. The visual
regression proof screenshots are kept in a separate follow-up PR since
image artifacts classify under a different review unit.

## Non-goals

Does not change any other shard's file list, does not change the tests
themselves, and does not refactor `40-playwright-app.sh` beyond the one
artifact-path line.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-6-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/embedded-terminal-spawn-failure.spec.ts e2e/embedded-terminal-restart-persistence.spec.ts e2e/planning-terminal-restart-persistence.spec.ts e2e/planning-terminal-open-daemon-owner-repro.spec.ts e2e/planning-terminal-tmux-blank-repro.spec.ts e2e/planning-tmux-blank-repro.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
