### PR TITLE
[CI regression: 1df7d59-required-fast-pr-babysit-harness](1) Fix admin-bypass queue stdin consumption bug

### DIFF
--- a/scripts/cron-admin-bypass-queue.sh
+++ b/scripts/cron-admin-bypass-queue.sh
@@ -82,7 +82,7 @@ prs_json="$(gh_json pr list --repo "$TARGET_REPO" --label "$LABEL" --state open 
 }
 
 submitted=0
-while IFS= read -r pr; do
+while IFS= read -r -u 3 pr; do
   [ -z "$pr" ] && continue
   num="$(jq -r '.number' <<<"$pr")"
 
@@ -263,6 +263,6 @@ while IFS= read -r pr; do
       log_line "PR #$num: plan submit failed: $line"
     done <<<"$output"
   fi
-done < <(jq -c '.[]' <<<"$prs_json")
+done 3< <(jq -c '.[]' <<<"$prs_json")
 
 log_line "admin-bypass queue scan complete; submitted $submitted repair task(s)"


### PR DESCRIPTION
## Summary

CI job `required-fast / PR Babysit Harness` started failing on master. The admin-bypass queue script stopped after handling only the first pull request.

A shell loop read pull requests from a here-string. An inner program drank the loop's standard input, so iteration ended after one item.

The fix hands the loop its own file descriptor 3. Inner programs can no longer steal the loop's input, so every pull request is handled.

## Review Claim

Approve giving the admin-bypass queue loop a dedicated file descriptor so it no longer stops after the first pull request.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only `scripts/cron-admin-bypass-queue.sh` changes, and only the two loop-input redirections. Other CI jobs and product runtime behavior are untouched.

## Slice Rationale

One tooling-policy slice touching a single CI harness script. No product or proof files ride along, so it reviews in isolation.

## Non-goals

- No change to which pull requests are selected or labeled.
- No change to the repair actions taken per pull request.
- No refactor, cleanup, or test weakening.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-suites/required/28-pr-babysit-harness.sh`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/28-pr-babysit-harness.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
