### PR TITLE
[CI regression: e0053c7-playwright-6-of-9](1) Fix CI job playwright / 6-of-9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -659,6 +659,8 @@ jobs:
             files: >-
               e2e/gui-owner-auto-bootstrap.spec.ts
               e2e/start-ready-daemon-owner.spec.ts
+              e2e/planning-terminal-live-model.proof.spec.ts
+              e2e/ui-delta-timeline.spec.ts
               e2e/workers-surface.spec.ts
 
     name: playwright / ${{ matrix.name }}

--- a/scripts/test-suites/optional/40-playwright-app.sh
+++ b/scripts/test-suites/optional/40-playwright-app.sh
@@ -37,7 +37,7 @@ elif [ -n "${INVOKER_PLAYWRIGHT_SHARD_INDEX:-}" ] && [ -n "${INVOKER_PLAYWRIGHT_
 fi
 RUN_LABEL="$(sanitize_label "$RUN_LABEL")"
 
-ARTIFACT_ROOT="$ROOT/.git/playwright-artifacts/$RUN_LABEL"
+ARTIFACT_ROOT="$(git rev-parse --path-format=absolute --git-path "playwright-artifacts/$RUN_LABEL")"
 mkdir -p "$ARTIFACT_ROOT"
 
 export INVOKER_E2E_BARE_REPO="${INVOKER_E2E_BARE_REPO:-/tmp/invoker-e2e-repo-${RUN_LABEL}.git}"


### PR DESCRIPTION
## Summary

CI job `playwright / 6-of-9` first failed on default-branch push commit e0053c7a57a44675b10fcefcb27911b4f0364c13 in run 30487066189. It stayed red through 3fb48f1e6a0dbeb11a0ef0a8c293499c00dc9b23 in run 30611764074.

The job's "Verify Playwright shard inventory" step compares every `packages/app/e2e/*.spec.ts` file against the shard list in `.github/workflows/ci.yml`.

Two new spec files existed on disk but were not assigned to any shard. The inventory check failed before any test ran, on every `playwright / *` job, including `6-of-9`.

This PR assigns those two files to the `9-of-9` shard.

It also fixes a second latent break in the shared runner script. `scripts/test-suites/optional/40-playwright-app.sh` hardcoded `$ROOT/.git/playwright-artifacts`, which breaks under worktree checkouts where `.git` is a file, not a directory.

The script now resolves the artifact root with `git rev-parse --path-format=absolute --git-path`.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30487066189/job/90704476825

## Review Claim

The change corrects the CI regression's root cause at its source, with no unrelated edits.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect: the shard-inventory fix only adds the two missing files to an existing shard's file list, and the artifact-root fix only changes how a path is computed, not what is written to it.

## Slice Rationale

One policy slice for the failing CI job's root cause. The local verification proof is published as a separate, later PR so the fix can be reviewed independently of its evidence.

## Non-goals

No refactor, no unrelated cleanup, no test weakening, no snapshot churn, and no changes to any shard's test file list other than the two files that were missing from shard assignment.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-6-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/embedded-terminal-spawn-failure.spec.ts e2e/embedded-terminal-restart-persistence.spec.ts e2e/planning-terminal-restart-persistence.spec.ts e2e/planning-terminal-open-daemon-owner-repro.spec.ts e2e/planning-terminal-tmux-blank-repro.spec.ts e2e/planning-tmux-blank-repro.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
