### PR TITLE
[CI regression: 1df7d59-required-fast-pr-babysit-harness](1) Fix admin-bypass queue stdin consumption

### DIFF
--- a/scripts/cron-admin-bypass-queue.sh
+++ b/scripts/cron-admin-bypass-queue.sh
@@ -82,7 +82,7 @@ prs_json="$(gh_json pr list --repo "$TARGET_REPO" --label "$LABEL" --state open 
 }
 
 submitted=0
-while IFS= read -r pr; do
+while IFS= read -r -u 3 pr; do
   [ -z "$pr" ] && continue
   num="$(jq -r '.number' <<<"$pr")"
 
@@ -263,6 +263,6 @@ while IFS= read -r pr; do
       log_line "PR #$num: plan submit failed: $line"
     done <<<"$output"
   fi
-done < <(jq -c '.[]' <<<"$prs_json")
+done 3< <(jq -c '.[]' <<<"$prs_json")
 
 log_line "admin-bypass queue scan complete; submitted $submitted repair task(s)"


### PR DESCRIPTION
## Summary

The admin-bypass queue reads open pull requests in a shell loop fed by a process substitution.

Programs called inside the loop, such as `gh` and `node`, read the same input stream and drain it after the first pull request.

Every later pull request was then dropped, which is what turned the `required-fast / PR Babysit Harness` job red.

This change reads the loop over a dedicated file descriptor so inner programs can no longer truncate it.

## Review Claim

Approve reading the admin-bypass queue's pull-request loop over file descriptor 3 so inner programs cannot truncate it.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the loop's input redirection changes. Classification, routing, dedup, and repair-task submission logic are byte-for-byte identical, so every other cron path behaves exactly as before.

## Slice Rationale

This is one tooling-policy slice: the queue script's loop redirection only. The regression proof that defends it lives in its own slice stacked on top.

## Non-goals

Does not change how PRs are classified, routed, deduped, or repaired. No behavior change to task submission. No test weakening and no unrelated cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-admin-bypass-queue.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
