### PR TITLE
[CI regression: 1df7d59-required-fast-pr-babysit-harness](2) Prove admin-bypass queue stdin fix

### DIFF
--- a/scripts/cron-admin-bypass-queue.sh
+++ b/scripts/cron-admin-bypass-queue.sh
@@ -82,7 +82,7 @@ prs_json="$(gh_json pr list --repo "$TARGET_REPO" --label "$LABEL" --state open 
 }
 
 submitted=0
-while IFS= read -r pr; do
+while IFS= read -r -u 3 pr; do
   [ -z "$pr" ] && continue
   num="$(jq -r '.number' <<<"$pr")"
 
@@ -263,6 +263,6 @@ while IFS= read -r pr; do
       log_line "PR #$num: plan submit failed: $line"
     done <<<"$output"
   fi
-done < <(jq -c '.[]' <<<"$prs_json")
+done 3< <(jq -c '.[]' <<<"$prs_json")
 
 log_line "admin-bypass queue scan complete; submitted $submitted repair task(s)"

--- a/scripts/repro/repro-admin-bypass-queue-stdin.sh
+++ b/scripts/repro/repro-admin-bypass-queue-stdin.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Regression proof for the admin-bypass queue stdin-consumption bug.
+#
+# scripts/cron-admin-bypass-queue.sh iterates open PRs with a `while read` loop
+# fed by a process substitution. Commands inside the loop (gh, jq, node via
+# headless_mutation) read stdin, so a loop reading from stdin is truncated to
+# its first item and every later PR is silently dropped. The fix reads the loop
+# over a dedicated file descriptor (fd 3).
+#
+# This proof fails on the buggy pattern and passes on the fixed pattern, and it
+# guards the real cron script so the fd-3 redirection cannot regress.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/cron-admin-bypass-queue.sh"
+fail() { echo "[repro] FAIL: $1"; exit 1; }
+
+# 1) Behavioral demonstration. An inner stdin-reading command drains a naive
+#    `while read < <(...)` loop after the first item, but cannot touch a loop
+#    that reads over fd 3.
+items=$'a\nb\nc'
+
+naive=0
+while IFS= read -r _; do
+  naive=$((naive + 1))
+  cat >/dev/null   # inner command that drains stdin, like gh/jq/node
+done < <(printf '%s\n' "$items")
+[ "$naive" -eq 1 ] || fail "naive stdin loop should process only 1 item, got $naive"
+
+fixed=0
+while IFS= read -r -u 3 _; do
+  fixed=$((fixed + 1))
+  cat >/dev/null
+done 3< <(printf '%s\n' "$items")
+[ "$fixed" -eq 3 ] || fail "fd-3 loop should process all 3 items, got $fixed"
+
+# 2) Regression guard. The real cron script must read its PR loop over fd 3, so
+#    an inner gh/jq/node call can never truncate the PR scan again.
+[ -f "$SCRIPT" ] || fail "cannot find $SCRIPT"
+grep -Eq 'while IFS= read -r -u 3 pr; do' "$SCRIPT" \
+  || fail "cron-admin-bypass-queue.sh must read the PR loop over fd 3 (read -r -u 3 pr)"
+grep -Eq 'done 3< <\(jq -c ' "$SCRIPT" \
+  || fail "cron-admin-bypass-queue.sh must feed the PR loop via fd 3 (done 3< <(jq ...))"
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

Adds a focused regression proof for the admin-bypass queue stdin fix.

The proof shows that an inner stdin-reading program drains a naive shell loop after one item, but never a loop bound to file descriptor 3.

It also guards the real cron script, failing if the fd-3 redirection is ever removed.

## Review Claim

Approve the deterministic proof that the admin-bypass queue keeps every pull request and that its fd-3 redirection stays in place.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Adds one self-contained repro under `scripts/repro/`. It runs no product code paths and changes no runtime behavior, so it is safe to review in isolation.

## Slice Rationale

Proof is a separate review lane from the behavior fix it defends, so it ships as its own slice stacked on the fix rather than bundled into it.

## Non-goals

Adds no product change. Does not touch the queue's classification or repair logic. Does not modify the babysit harness itself.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-admin-bypass-queue-stdin.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


Depends-On: #6875
