### PR TITLE
[Admin-Bypass Repair](6) Make the stack-aware planner execute repairs itself, synchronously

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -13,14 +13,26 @@ try:
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Action, Ledger, PrSnapshot, load_mergify_rules
     from .mergify_admin_requeue_plan import plan_stack_execution
+    from .mergify_admin_requeue_repairer import AdminBypassRepairer
     from .mergify_admin_requeue_snapshot import GhClient
+    from .mergify_admin_requeue_workflow_fastpath import (
+        resolve_workflow_for_pr,
+        submit_rebase_recreate,
+        submit_repair_review_gate_ci,
+    )
 except ImportError:
     from mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from mergify_admin_requeue_loader import AdminBypassStackLoader
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Action, Ledger, PrSnapshot, load_mergify_rules
     from mergify_admin_requeue_plan import plan_stack_execution
+    from mergify_admin_requeue_repairer import AdminBypassRepairer
     from mergify_admin_requeue_snapshot import GhClient
+    from mergify_admin_requeue_workflow_fastpath import (
+        resolve_workflow_for_pr,
+        submit_rebase_recreate,
+        submit_repair_review_gate_ci,
+    )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -74,6 +86,7 @@ def run_cycle(args: argparse.Namespace) -> bool:
     ledger = Ledger(Path(args.state_file).expanduser())
     loader = AdminBypassStackLoader(gh)
     executor = AdminBypassGhExecutor(gh, ledger, logger, args.repo)
+    repairer = AdminBypassRepairer(gh, executor, logger, ledger, args.repo)
     loaded = loader.load(args.repo, args.author, args.pr, required_checks, trunk)
     stacks = loaded.stacks
     now = int(time.time())
@@ -121,26 +134,61 @@ def run_cycle(args: argparse.Namespace) -> bool:
             if pr is None:
                 raise RuntimeError(f"missing PR snapshot for #{action.pr_number}")
             if action.kind == "repair_check":
-                # Repair is delegated to the admin-bypass-queue Invoker worker
-                # (scripts/cron-admin-bypass-queue.sh), which submits a fast
-                # repair task instead of running an AI repair synchronously
-                # here while holding the shared PR-maintenance lock.
-                check_name = action.key.split(":", 1)[-1]
-                ledger.record("repair-delegated", action.pr_number, pr.head_ref_oid, check_name, now)
-                logger.trace(
-                    "admin-bypass-repair-delegated",
-                    repo=args.repo,
-                    pr_number=action.pr_number,
-                    check_name=check_name,
-                )
+                try:
+                    if action.key.startswith("bot_review_thread:"):
+                        thread_id = action.key.split(":", 1)[1]
+                        outcome = repairer.repair_bot_thread(pr, thread_id, now)
+                        progressed = outcome.status in {"pushed", "prereq_created"}
+                    else:
+                        check_name = action.key
+                        workflow_id = resolve_workflow_for_pr(action.pr_number)
+                        if workflow_id:
+                            submit_repair_review_gate_ci(action.pr_number)
+                            ledger.record("repair-check", action.pr_number, pr.head_ref_oid, check_name, now)
+                            progressed = True
+                        else:
+                            outcome = repairer.repair_check(pr, check_name, now)
+                            progressed = outcome.status in {"pushed", "prereq_created"}
+                except Exception as exc:
+                    logger.trace(
+                        "admin-bypass-repair-attempt-failed",
+                        repo=args.repo,
+                        pr_number=action.pr_number,
+                        action_kind=action.kind,
+                        key=action.key,
+                        error=str(exc),
+                    )
+                    should_poll = True
+                    continue
+                if progressed:
+                    return True
+                should_poll = True
+                continue
             elif action.kind == "repair_conflict":
-                ledger.record("repair-delegated", action.pr_number, pr.head_ref_oid, action.key, now)
-                logger.trace(
-                    "admin-bypass-repair-delegated",
-                    repo=args.repo,
-                    pr_number=action.pr_number,
-                    check_name=action.key,
-                )
+                try:
+                    workflow_id = resolve_workflow_for_pr(action.pr_number)
+                    if workflow_id:
+                        submit_rebase_recreate(workflow_id)
+                        ledger.record("conflict-repair", action.pr_number, pr.head_ref_oid, action.key, now)
+                        progressed = True
+                    else:
+                        outcome = repairer.repair_conflict(pr, action.detail, now)
+                        progressed = outcome.status in {"pushed", "prereq_created"}
+                except Exception as exc:
+                    logger.trace(
+                        "admin-bypass-repair-attempt-failed",
+                        repo=args.repo,
+                        pr_number=action.pr_number,
+                        action_kind=action.kind,
+                        key=action.key,
+                        error=str(exc),
+                    )
+                    should_poll = True
+                    continue
+                if progressed:
+                    return True
+                should_poll = True
+                continue
             else:
                 performed = executor.execute(action, pr, now)
                 if not performed:
@@ -167,7 +215,7 @@ def run_cycle(args: argparse.Namespace) -> bool:
                             pr_number=pr.number,
                             check_name=queue_only_noop_check,
                         )
-            if action.kind not in {"comment_blocked", "comment_admin_bypass_nudge", "repair_check", "repair_conflict"}:
+            if action.kind not in {"comment_blocked", "comment_admin_bypass_nudge"}:
                 return True
     if not stacks:
         logger.trace("admin-bypass-scan-empty")

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -40,7 +40,6 @@ ACTIVE_QUEUE_STATES = frozenset({"queued", "merging"})
 
 HUMAN_BLOCKER_KINDS = frozenset({"draft", "human_review_thread", "missing_check", "closed", "human_decision"})
 TERMINAL_BLOCKER_KINDS = frozenset({"merged"})
-IN_FLIGHT_REPAIR_BLOCKER_KINDS = frozenset({"repair_delegated"})
 REPAIR_INVALID_BLOCKER_KINDS = frozenset({"failed_check", "bot_review_thread", "conflict"})
 REPAIR_STOP_PREFIX = "Mergify repair stopped: "
 MANUAL_SPLIT_STOP_MARKERS = (
@@ -359,21 +358,6 @@ def latest_repair_invalid_blocker(pr: PrSnapshot, blocker: Blocker, ledger: Ledg
     return Blocker(blocker.key, "human_decision", pr.number, blocker.detail)
 
 
-def latest_repair_delegated_blocker(pr: PrSnapshot, blocker: Blocker, ledger: Ledger) -> Blocker | None:
-    if blocker.kind not in REPAIR_INVALID_BLOCKER_KINDS:
-        return None
-    latest = None
-    for key in repair_invalid_keys_for_blocker(pr, blocker):
-        row = ledger.latest("repair-delegated", pr.number, pr.head_ref_oid, key)
-        if row is None:
-            continue
-        if latest is None or int(row.get("epoch", 0) or 0) >= int(latest.get("epoch", 0) or 0):
-            latest = row
-    if latest is None:
-        return None
-    return Blocker(blocker.key, "repair_delegated", pr.number, f"{blocker.detail}; repair already delegated for current head")
-
-
 def existing_split_stop_blocker(pr: PrSnapshot, blocker: Blocker) -> Blocker | None:
     if blocker.kind != "failed_check":
         return None
@@ -483,7 +467,6 @@ def build_stack_facts(
         blockers = [
             latest_repair_invalid_blocker(pr, blocker, ledger)
             or existing_split_stop_blocker(pr, blocker)
-            or latest_repair_delegated_blocker(pr, blocker, ledger)
             or blocker
             for blocker in effective
         ]
@@ -555,8 +538,6 @@ def summarize_stack(facts: StackFacts) -> dict[str, object]:
 
 
 def wait_reason_for_facts(facts: StackFacts) -> str:
-    if any(blocker.kind in IN_FLIGHT_REPAIR_BLOCKER_KINDS for blocker in facts.all_blockers):
-        return "repair-delegated"
     if facts.upper_stack_needs_acceptance:
         return "upper-stack-needs-acceptance"
     for pr in facts.stack.prs:
@@ -567,8 +548,6 @@ def wait_reason_for_facts(facts: StackFacts) -> str:
             return "merge-hold-only"
         if TERMINAL_BLOCKER_KINDS & blocker_kinds:
             return "terminal-merged"
-        if IN_FLIGHT_REPAIR_BLOCKER_KINDS & blocker_kinds:
-            return "repair-delegated"
         if HUMAN_BLOCKER_KINDS & blocker_kinds:
             return "blocked-needs-human"
     if facts.bottom and has_active_queue_event(facts.bottom):
@@ -581,7 +560,6 @@ def _has_pending_or_human_blocker(facts: StackFacts) -> bool:
         blocker.kind == "pending_check"
         or blocker.kind in HUMAN_BLOCKER_KINDS
         or blocker.kind in TERMINAL_BLOCKER_KINDS
-        or blocker.kind in IN_FLIGHT_REPAIR_BLOCKER_KINDS
         for blocker in facts.all_blockers
     )
 
@@ -595,7 +573,6 @@ def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
             blocker.kind == "pending_check"
             or blocker.kind in HUMAN_BLOCKER_KINDS
             or blocker.kind in TERMINAL_BLOCKER_KINDS
-            or blocker.kind in IN_FLIGHT_REPAIR_BLOCKER_KINDS
         )
         for blocker in facts.all_blockers
     )
@@ -784,8 +761,6 @@ def plan_actions_from_facts(
     max_requeue_attempts: int,
     max_repair_attempts: int,
 ) -> tuple[Action, ...]:
-    if any(blocker.kind in IN_FLIGHT_REPAIR_BLOCKER_KINDS for blocker in facts.all_blockers):
-        return ()
     if facts.bottom:
         bottom_pr_numbers = (facts.bottom.number,)
         action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts, bottom_pr_numbers)

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -430,6 +430,7 @@ class AdminBypassRepairer:
             return False
 
     def repair_check(self, pr: PrSnapshot, check_name: str, now: int | None = None) -> RepairOutcome:
+        self.ledger.record("repair-check", pr.number, pr.head_ref_oid, check_name, now)
         ctx = pr.checks.get(check_name)
         latest = pr.latest_mergify
         queue_only = ctx is None and is_queue_only_required_check(check_name)
@@ -571,7 +572,9 @@ class AdminBypassRepairer:
             repair_commits=repair_commits,
         )
 
-    def repair_conflict(self, pr: PrSnapshot, reason: str) -> None:
+    def repair_conflict(self, pr: PrSnapshot, reason: str, now: int | None = None) -> RepairOutcome:
+        check_name = "conflict"
+        self.ledger.record("conflict-repair", pr.number, pr.head_ref_oid, f"conflict:{pr.number}", now)
         work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
         work_root.parent.mkdir(parents=True, exist_ok=True)
         checkout_pr_head(self.repo, pr, work_root)
@@ -596,5 +599,72 @@ class AdminBypassRepairer:
         )
         self.run_claude_repair(work_root, prompt)
         end_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
-        if end_head != start_head and not self.git_lines(work_root, "status", "--porcelain"):
+        status_lines = self.git_lines(work_root, "status", "--porcelain")
+        if end_head == start_head or status_lines:
+            if status_lines:
+                self.hard_reset_work_root(work_root, start_head)
+                return self.blocked_outcome(
+                    "blocked_dirty",
+                    check_name,
+                    start_head,
+                    end_head,
+                    status_lines=status_lines,
+                )
+            return self.blocked_outcome("noop", check_name, start_head, end_head)
+        try:
             self.push_branch(work_root, pr.head_ref_name, expected_head=pr.head_ref_oid)
+        except SafePushError as exc:
+            return self.blocked_outcome(
+                "stale_head",
+                check_name,
+                start_head,
+                end_head,
+                errors=(str(exc),),
+            )
+        return self.blocked_outcome("pushed", check_name, start_head, end_head)
+
+    def repair_bot_thread(self, pr: PrSnapshot, thread_id: str, now: int | None = None) -> RepairOutcome:
+        self.ledger.record("repair-bot-thread", pr.number, pr.head_ref_oid, thread_id, now)
+        work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
+        work_root.parent.mkdir(parents=True, exist_ok=True)
+        checkout_pr_head(self.repo, pr, work_root)
+        start_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
+        prompt = (
+            f"Resolve the unresolved review thread {thread_id}. Address the reviewer's feedback with "
+            f"real code changes, run the narrow proof for the fix, then commit locally. Do not push. "
+            f"If the thread is already resolved, or the PR is closed or merged, make no commit and exit 0.\n\n"
+            f"PR: #{pr.number}\nHead branch: {pr.head_ref_name}\nHead SHA: {pr.head_ref_oid}\nThread: {thread_id}\n"
+        )
+        self.logger.trace(
+            "admin-bypass-repair-bot-thread-start",
+            repo=self.repo,
+            pr_number=pr.number,
+            thread_id=thread_id,
+            work_root=str(work_root),
+            head_sha=pr.head_ref_oid,
+        )
+        self.run_claude_repair(work_root, prompt)
+        end_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
+        status_lines = self.git_lines(work_root, "status", "--porcelain")
+        if end_head == start_head or status_lines:
+            if status_lines:
+                self.hard_reset_work_root(work_root, start_head)
+                return self.blocked_outcome(
+                    "blocked_dirty",
+                    thread_id,
+                    start_head,
+                    end_head,
+                    status_lines=status_lines,
+                )
+            return self.blocked_outcome("noop", thread_id, start_head, end_head)
+        try:
+            self.push_branch(work_root, pr.head_ref_name, expected_head=pr.head_ref_oid)
+        except SafePushError as exc:
+            return self.blocked_outcome(
+                "stale_head",
+                thread_id,
+                start_head,
+                end_head,
+                errors=(str(exc),),
+            )
+        return self.blocked_outcome("pushed", thread_id, start_head, end_head)

--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HEADLESS_LIB = REPO_ROOT / "scripts" / "headless-lib.sh"
+
+# Sources scripts/headless-lib.sh directly (never scripts/cron-pr-lib.sh): by the
+# time this module runs, cron-pr-lib.sh's cron_lock is already held by the
+# calling bash script (scripts/cron-pr-admin-bypass-land.sh), so re-sourcing it
+# and calling cron_lock again would self-deadlock or silently no-op.
+_SOURCE_HEADLESS_LIB = 'set -euo pipefail\nsource "$1"\n'
+
+
+def _run_headless(command: str, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", "-c", _SOURCE_HEADLESS_LIB + command, "bash", str(HEADLESS_LIB), *extra_args],
+        cwd=str(REPO_ROOT),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def resolve_workflow_for_pr(pr_number: int) -> str | None:
+    # See cron-pr-lib.sh's resolve_workflow_for_pr comment: review-gate exits 0
+    # with `{}` for a genuine miss (no local workflow mapping). A non-zero exit
+    # means the lookup mechanism itself is broken, which must propagate as an
+    # exception rather than silently falling back to ad-hoc repair.
+    completed = _run_headless('headless_query query review-gate "$2" --output json', str(pr_number))
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"resolve_workflow_for_pr failed for PR #{pr_number}: "
+            f"{completed.stderr.strip() or completed.stdout.strip()}"
+        )
+    stdout = completed.stdout.strip()
+    if not stdout:
+        return None
+    try:
+        record = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"resolve_workflow_for_pr produced invalid JSON for PR #{pr_number}: {stdout!r}") from exc
+    if not isinstance(record, dict):
+        raise RuntimeError(f"resolve_workflow_for_pr produced non-object JSON for PR #{pr_number}: {stdout!r}")
+    workflow_id = record.get("workflowId")
+    return str(workflow_id) if workflow_id else None
+
+
+# Known accepted limitation: no debounce against re-submitting the fast-path
+# mutation on every cron tick while a previous submission converges.
+
+
+def submit_rebase_recreate(workflow_id: str) -> None:
+    completed = _run_headless('headless_mutation --no-track rebase-recreate "$2"', workflow_id)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"submit_rebase_recreate failed for workflow {workflow_id}: "
+            f"{completed.stderr.strip() or completed.stdout.strip()}"
+        )
+
+
+def submit_repair_review_gate_ci(pr_number: int) -> None:
+    completed = _run_headless('headless_mutation --no-track repair-review-gate-ci "$2"', str(pr_number))
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"submit_repair_review_gate_ci failed for PR #{pr_number}: "
+            f"{completed.stderr.strip() or completed.stdout.strip()}"
+        )

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -1,5 +1,6 @@
 import io
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -9,6 +10,7 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import scripts.mergify_admin_requeue as requeue
 import scripts.mergify_admin_requeue_exec as exec_impl
+import scripts.mergify_admin_requeue_workflow_fastpath as fastpath
 
 from scripts.mergify_admin_requeue import (
     Action,
@@ -29,7 +31,7 @@ from scripts.mergify_admin_requeue import (
     plan_stack_actions,
 )
 from scripts.mergify_admin_requeue_gh_executor import ADMIN_BYPASS_NUDGE_LEDGER_KIND, AdminBypassGhExecutor
-from scripts.mergify_admin_requeue_model import LoadedStacks
+from scripts.mergify_admin_requeue_model import LoadedStacks, RepairOutcome
 from scripts.mergify_admin_requeue_loader import AdminBypassStackLoader
 from scripts.mergify_admin_requeue_logger import AdminBypassLogger
 from scripts.mergify_admin_requeue_repairer import (
@@ -39,6 +41,7 @@ from scripts.mergify_admin_requeue_repairer import (
     PROOF_TOOLING_POLICY_UNIT_ERROR,
     AdminBypassRepairer,
 )
+from scripts.pr_worker_safe_push import SafePushError
 
 REQUIRED = {"PR Body", "quality / TypeScript Types"}
 HEAD = "c2532d229dbed2fd57419698c48d973001c78e9e"
@@ -349,13 +352,59 @@ Failing checks
                 with mock.patch.object(repairer, "git_lines", return_value=()):
                     with mock.patch.object(repairer, "run_claude_repair", side_effect=lambda _work_root, prompt: prompts.append(prompt)):
                         for epoch in range(3):
-                            ledger.record("conflict-repair", item.number, item.head_ref_oid, "conflict:2647", epoch)
-                            repairer.repair_conflict(item, "GitHub reports merge conflict")
+                            repairer.repair_conflict(item, "GitHub reports merge conflict", epoch)
         self.assertEqual(ledger.count("conflict-repair", 2647, HEAD, "conflict:2647"), 3)
         self.assertEqual(len(prompts), 3)
         self.assertIn("commit locally. Do not push.", prompts[0])
         actions = plan_stack_actions(StackGroup("s", (item,)), REQUIRED, ledger, 4)
         self.assertEqual([(a.kind, a.key) for a in actions], [("comment_blocked", "capped")])
+
+    def test_repair_conflict_pushes_on_successful_resolution(self):
+        item = pr(2660, merge_state="DIRTY", latest=mergify())
+        ledger = self.ledger()
+        repairer = self.repairer(object(), ledger)
+        new_head = "b" * 40
+        rev_parse = iter([HEAD, new_head])
+        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
+            with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(rev_parse) if args == ("rev-parse", "HEAD") else ""):
+                with mock.patch.object(repairer, "git_lines", return_value=()):
+                    with mock.patch.object(repairer, "run_claude_repair"):
+                        with mock.patch.object(repairer, "push_branch", return_value=new_head) as push_branch:
+                            result = repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
+        self.assertEqual(result.status, "pushed")
+        self.assertEqual(result.start_head, HEAD)
+        self.assertEqual(result.end_head, new_head)
+        push_branch.assert_called_once_with(mock.ANY, item.head_ref_name, expected_head=item.head_ref_oid)
+        self.assertEqual(ledger.count("conflict-repair", item.number, item.head_ref_oid, f"conflict:{item.number}"), 1)
+
+    def test_repair_conflict_returns_stale_head_without_raising(self):
+        item = pr(2661, merge_state="DIRTY", latest=mergify())
+        ledger = self.ledger()
+        repairer = self.repairer(object(), ledger)
+        new_head = "c" * 40
+        rev_parse = iter([HEAD, new_head])
+        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
+            with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(rev_parse) if args == ("rev-parse", "HEAD") else ""):
+                with mock.patch.object(repairer, "git_lines", return_value=()):
+                    with mock.patch.object(repairer, "run_claude_repair"):
+                        with mock.patch.object(repairer, "push_branch", side_effect=SafePushError("stale-head: refs/heads/x is deadbeef; expected " + HEAD)):
+                            result = repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
+        self.assertEqual(result.status, "stale_head")
+        self.assertIn("stale-head", result.errors[0])
+        self.assertEqual(ledger.count("conflict-repair", item.number, item.head_ref_oid, f"conflict:{item.number}"), 1)
+
+    def test_repair_check_ledger_row_written_before_run_claude_repair_raises(self):
+        item = pr(2662, latest=mergify())
+        ledger = self.ledger()
+        repairer = self.repairer(object(), ledger)
+        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
+            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
+                with mock.patch.object(repairer, "git_output", return_value=HEAD):
+                    with mock.patch.object(repairer, "git_lines", return_value=()):
+                        with mock.patch.object(repairer, "run_claude_repair", side_effect=subprocess.CalledProcessError(1, ["claude"])):
+                            with self.assertRaises(subprocess.CalledProcessError):
+                                repairer.repair_check(item, "PR Body", 1)
+        self.assertEqual(ledger.count("repair-check", item.number, item.head_ref_oid, "PR Body"), 1)
 
     def test_claude_repair_uses_claude_cli(self):
         repairer = self.repairer(object(), self.ledger())
@@ -574,38 +623,64 @@ Failing checks
         self.assertIn('"key": "upper-stack-needs-acceptance"', log)
         self.assertIn('"upper_stack_needs_acceptance": true', log)
 
-    def test_run_cycle_delegated_repair_does_not_consume_attempt_cap_marker(self):
-        ledger = self.ledger()
-        args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(ledger.path)])
-        stack = StackGroup("s", (pr(2606, checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}, latest=mergify()),))
-        stdout = io.StringIO()
+    def test_run_cycle_repairs_only_lower_pr_when_upper_has_no_own_blocker(self):
+        # Regression coverage for #6536/#6579: a clean-looking upper PR must
+        # never be touched while its base (the lower PR) is still unconverged.
+        args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
+        lower = pr(6536, head="stack/lower", checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}, latest=mergify())
+        upper = pr(6579, base="stack/lower", head="stack/upper")
+        stack = StackGroup("s", (lower, upper))
+        outcome = RepairOutcome(status="noop", check_name="PR Body", start_head=HEAD, end_head=HEAD)
         with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
             with mock.patch.object(exec_impl, "GhClient", return_value=object()):
                 with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
-                    with redirect_stdout(stdout):
-                        should_poll = exec_impl.run_cycle(args)
-        self.assertFalse(should_poll)
-        self.assertIn('repair-check PR #2606 check="PR Body"', stdout.getvalue())
-        refreshed = Ledger(ledger.path)
-        self.assertEqual(refreshed.count("repair-delegated", 2606, HEAD, "PR Body"), 1)
-        self.assertEqual(refreshed.count("repair-check", 2606, HEAD, "PR Body"), 0)
+                    with mock.patch.object(exec_impl, "resolve_workflow_for_pr", return_value=None):
+                        with mock.patch.object(AdminBypassRepairer, "repair_check", return_value=outcome) as repair_check:
+                            exec_impl.run_cycle(args)
+        self.assertEqual(repair_check.call_count, 1)
+        called_prs = [call.args[0].number for call in repair_check.call_args_list]
+        self.assertEqual(called_prs, [6536])
+        self.assertNotIn(6579, called_prs)
 
-    def test_run_cycle_delegated_conflict_repair_does_not_consume_attempt_cap_marker(self):
-        ledger = self.ledger()
-        args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(ledger.path)])
-        item = pr(2609, merge_state="DIRTY", latest=mergify())
-        stack = StackGroup("s", (item,))
-        stdout = io.StringIO()
+    def test_run_cycle_prefers_fast_path_workflow_mutation_over_repairer(self):
+        args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
+        stack = StackGroup("s", (pr(2670, checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}, latest=mergify()),))
         with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
             with mock.patch.object(exec_impl, "GhClient", return_value=object()):
                 with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
-                    with redirect_stdout(stdout):
-                        should_poll = exec_impl.run_cycle(args)
-        self.assertFalse(should_poll)
-        self.assertIn("repair-conflict PR #2609", stdout.getvalue())
-        refreshed = Ledger(ledger.path)
-        self.assertEqual(refreshed.count("repair-delegated", 2609, HEAD, "conflict:2609"), 1)
-        self.assertEqual(refreshed.count("conflict-repair", 2609, HEAD, "conflict:2609"), 0)
+                    with mock.patch.object(exec_impl, "resolve_workflow_for_pr", return_value="wf-1-1") as resolve:
+                        with mock.patch.object(exec_impl, "submit_repair_review_gate_ci") as submit:
+                            with mock.patch.object(AdminBypassRepairer, "repair_check") as repair_check:
+                                should_poll = exec_impl.run_cycle(args)
+        self.assertTrue(resolve.called)
+        submit.assert_called_once_with(2670)
+        repair_check.assert_not_called()
+        self.assertTrue(should_poll)
+
+    def test_run_cycle_repairer_exception_does_not_abort_other_stacks(self):
+        ledger = self.ledger()
+        args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(ledger.path)])
+        broken = pr(6601, checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}, latest=mergify())
+        healthy = pr(6602, latest=None)
+        stacks = (StackGroup("s1", (broken,)), StackGroup("s2", (healthy,)))
+
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+        fake_gh = FakeGh()
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=fake_gh):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=stacks, open_pr_numbers_by_head={})):
+                    with mock.patch.object(exec_impl, "resolve_workflow_for_pr", return_value=None):
+                        with mock.patch.object(AdminBypassRepairer, "repair_check", side_effect=subprocess.CalledProcessError(1, ["claude"])) as repair_check:
+                            should_poll = exec_impl.run_cycle(args)
+        self.assertEqual(repair_check.call_count, 1)
+        self.assertEqual(fake_gh.comments, [("owner/repo", 6602, "@mergifyio queue")])
+        self.assertTrue(should_poll)
 
     def test_repair_check_splits_tooling_policy_prerequisite(self):
         class FakeGh:
@@ -1037,6 +1112,69 @@ The merge conditions cannot be satisfied due to failing checks
         stack = StackGroup("s", (pr(2999, state="CLOSED", latest=mergify()),))
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number, a.detail) for a in actions], [("comment_blocked", 2999, "state=CLOSED")])
+
+
+class WorkflowFastpathTests(unittest.TestCase):
+    def test_resolve_workflow_for_pr_sources_headless_lib_and_parses_workflow_id(self):
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout='{"workflowId": "wf-1-1"}\n', stderr="")
+        with mock.patch.object(fastpath.subprocess, "run", return_value=completed) as run:
+            result = fastpath.resolve_workflow_for_pr(6579)
+        self.assertEqual(result, "wf-1-1")
+        args = run.call_args.args[0]
+        self.assertEqual(args[0], "bash")
+        self.assertEqual(args[1], "-c")
+        self.assertIn("headless-lib.sh", " ".join(str(part) for part in args))
+        self.assertNotIn("cron-pr-lib.sh", " ".join(str(part) for part in args))
+        self.assertIn("headless_query query review-gate", args[2])
+        self.assertIn("6579", args)
+
+    def test_resolve_workflow_for_pr_returns_none_on_genuine_miss(self):
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}\n", stderr="")
+        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+            result = fastpath.resolve_workflow_for_pr(6579)
+        self.assertIsNone(result)
+
+    def test_resolve_workflow_for_pr_raises_on_lookup_failure(self):
+        completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
+        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+            with self.assertRaises(RuntimeError):
+                fastpath.resolve_workflow_for_pr(6579)
+
+    def test_submit_rebase_recreate_command_shape(self):
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with mock.patch.object(fastpath.subprocess, "run", return_value=completed) as run:
+            fastpath.submit_rebase_recreate("wf-1-1")
+        args = run.call_args.args[0]
+        self.assertEqual(args[0], "bash")
+        self.assertEqual(args[1], "-c")
+        self.assertIn("headless-lib.sh", " ".join(str(part) for part in args))
+        self.assertNotIn("cron-pr-lib.sh", " ".join(str(part) for part in args))
+        self.assertIn("headless_mutation --no-track rebase-recreate", args[2])
+        self.assertIn("wf-1-1", args)
+
+    def test_submit_rebase_recreate_raises_on_failure(self):
+        completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
+        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+            with self.assertRaises(RuntimeError):
+                fastpath.submit_rebase_recreate("wf-1-1")
+
+    def test_submit_repair_review_gate_ci_command_shape(self):
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+        with mock.patch.object(fastpath.subprocess, "run", return_value=completed) as run:
+            fastpath.submit_repair_review_gate_ci(6579)
+        args = run.call_args.args[0]
+        self.assertEqual(args[0], "bash")
+        self.assertEqual(args[1], "-c")
+        self.assertIn("headless-lib.sh", " ".join(str(part) for part in args))
+        self.assertNotIn("cron-pr-lib.sh", " ".join(str(part) for part in args))
+        self.assertIn("headless_mutation --no-track repair-review-gate-ci", args[2])
+        self.assertIn("6579", args)
+
+    def test_submit_repair_review_gate_ci_raises_on_failure(self):
+        completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
+        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+            with self.assertRaises(RuntimeError):
+                fastpath.submit_repair_review_gate_ci(6579)
 
 
 if __name__ == "__main__":

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -383,41 +383,6 @@ class PlanStackActions(PlannerTestCase):
         self.assertEqual(blockers[0]["kind"], "human_decision")
         self.assertIn("stale duplicate stack", blockers[0]["detail"])
 
-    def test_delegated_conflict_repair_waits_without_capping_or_retrying(self):
-        ledger = self._ledger()
-        for epoch in range(1, 4):
-            ledger.record("conflict-repair", 6435, HEAD, "conflict:6435", epoch)
-        ledger.record("repair-delegated", 6435, HEAD, "conflict:6435", 4)
-        bottom = pr(
-            number=6435,
-            labels=frozenset({"admin-bypass", "dequeued"}),
-            merge_state_status="DIRTY",
-            mergeable="CONFLICTING",
-            checks={"build": check("failure")},
-            latest_mergify=event(state="dequeued", comment_id="m6435"),
-        )
-        upper = pr(
-            number=6439,
-            base_ref_name=bottom.head_ref_name,
-            head_ref_name="stack/top",
-            head_ref_oid="b" * 40,
-            labels=frozenset(),
-            checks={"build": check("pending")},
-        )
-        plan = p.plan_stack_execution(
-            m.StackGroup("s", (bottom, upper)),
-            REQUIRED,
-            ledger,
-            now_epoch=0,
-            open_pr_numbers={6435, 6439},
-            open_pr_numbers_by_head={bottom.head_ref_name: (6435,), upper.head_ref_name: (6439,)},
-        )
-        self.assertEqual(plan.actions, ())
-        self.assertEqual(plan.wait_reason, "repair-delegated")
-        blockers = plan.summary["prs"][0]["blockers"]
-        self.assertEqual(blockers[0]["kind"], "repair_delegated")
-        self.assertIn("repair already delegated for current head", blockers[0]["detail"])
-
     def test_clean_unaccepted_upper_stack_posts_exact_human_blocker_once(self):
         ledger = self._ledger()
         bottom = pr(
@@ -585,6 +550,34 @@ class PlanStackActions(PlannerTestCase):
             [(action.kind, action.pr_number, action.key) for action in actions],
             [("repair_check", 10, "bot_review_thread:PRRT_bot")],
         )
+
+    def test_clean_upper_pr_with_only_a_false_positive_base_signal_is_never_touched(self):
+        # Regression coverage for #6536/#6579: the upper PR has zero blocker
+        # signal of its own -- clean checks, no review threads -- and only
+        # "looks" blocked because its base branch (the lower PR's head) is
+        # still moving. The planner must target the lower PR only.
+        bottom = pr(
+            number=10,
+            head_ref_name="stack/bottom",
+            labels=frozenset({"admin-bypass"}),
+            checks={"build": check("failure")},
+        )
+        upper = pr(
+            number=11,
+            base_ref_name="stack/bottom",
+            head_ref_name="stack/upper",
+            labels=frozenset({"admin-bypass"}),
+        )
+
+        facts, _ledger = self._facts(m.StackGroup("s", (bottom, upper)))
+        self.assertEqual(facts.blockers_by_pr[11], ())
+
+        actions = self._plan(m.StackGroup("s", (bottom, upper)))
+        self.assertEqual(
+            [(action.kind, action.pr_number, action.key) for action in actions],
+            [("repair_check", 10, "build")],
+        )
+        self.assertTrue(all(action.pr_number != 11 for action in actions))
 
     def test_stale_root_base_retargets_root_pr(self):
         stack = m.StackGroup(


### PR DESCRIPTION
## Summary

`run_cycle` already computes the correct, stack-aware repair decision: `plan_direct_repairs` walks each Mergify stack bottom-to-top and returns an action for the first PR that actually needs repair, correctly leaving downstream PRs alone when their only problem is an unconverged base.

It just never acted on that decision. For `repair_check` and `repair_conflict` actions it only logged `"repair-delegated"` and trusted a separate script, gone by this point in the stack, to do the real work. That script had no stack awareness, so it repaired PR #6536 while #6536's real blocker, PR #6579, was still broken.

This slice makes `run_cycle` execute the repair itself, synchronously, via the existing (previously unused) `AdminBypassRepairer`. Along the way it fixes real gaps that class had: `repair_conflict` returned `None` instead of a result and had an unguarded push that would crash the whole cycle if the remote head had moved out from under it; neither repair method wrote the attempt-cap ledger rows the planner already reads, so caps silently never took effect. It adds a `repair_bot_thread` method so CodeRabbit-thread-blocked PRs keep getting repaired now that the bash fallback is gone, and a mapped-workflow fast path (ported to Python) so PRs already owned by an existing Invoker workflow keep using that workflow's dedicated repair mutation instead of a fresh ad-hoc AI prompt.

Each repair attempt is wrapped in its own exception boundary, so one PR's failed AI turn can't abort every other stack in the same cycle. The `"repair-delegated"` / in-flight-wait concept is retired, not rewired: with synchronous execution a repair is fully resolved by the time `run_cycle` returns, so there's no in-flight state left to represent.

## Review Claim

Confirm the new tests prove the actual production bug can't recur: a stack where the upper PR has no blocker of its own but its base points at a still-broken lower PR is repaired at the bottom only, both at the planner level and the full `run_cycle` level.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Every repair attempt records its attempt-cap ledger row *before* any git/subprocess work runs, so a crash mid-repair still consumes the retry budget instead of enabling unbounded retries. Every repairer/fast-path call for one PR is wrapped in its own `try/except Exception`, so a `claude` CLI failure for one PR logs and moves on to the next stack rather than aborting the whole cycle.

## Slice Rationale

This is the actual behavior change the whole stack exists to deliver; everything before it in the stack only took the old, buggy path out of the way so this one could stand in its place cleanly.

## Non-goals

Does not add a debounce against re-submitting the mapped-workflow fast path on every cron tick while a previous submission is still converging, and does not solve `pr-admin-bypass-land` contending for the shared `cron_lock` with `pr-orphan-repair` during a slow synchronous repair. Both are known, accepted follow-ups.

Does not port `changes_requested` (human review feedback) auto-repair — the Python system's existing philosophy already treats human feedback as a hard blocker for a human, not an AI, and that's intentionally preserved rather than replicating the old script's behavior here.

## Architecture

### Before

```mermaid
graph TD
    A["run_cycle: plan_stack_execution picks bottom-most blocked PR"] --> B{"action.kind"}
    B -->|"repair_check / repair_conflict"| C["log 'repair-delegated'\n(no actual repair)"]
    C --> D["separate cron-admin-bypass-queue.sh\n(stack-blind, scans all PRs independently)"]
    D --> E["may repair the wrong PR\nif base is unconverged"]
```

### After

```mermaid
graph TD
    A["run_cycle: plan_stack_execution picks bottom-most blocked PR"] --> B{"action.kind"}
    B -->|"repair_check / repair_conflict"| C{"mapped to an\nInvoker workflow?"}
    C -->|"yes"| D["submit dedicated mutation\n(rebase-recreate / repair-review-gate-ci)"]
    C -->|"no"| E["AdminBypassRepairer\n(repair_check / repair_conflict / repair_bot_thread)"]
    E --> F["push, or record blocked outcome"]
    D --> G["ledger attempt-cap row written"]
    F --> G
    G -->|"exception at any step"| H["log + continue to next stack\n(this stack only, cycle continues)"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -m unittest scripts/test_mergify_admin_requeue.py scripts/test_mergify_admin_requeue_plan.py scripts/test_mergify_admin_requeue_model.py scripts/test_mergify_admin_requeue_snapshot.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, but only together with reverting the rest of this stack (the deleted `cron-admin-bypass-queue.sh` is what this slice replaces)
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
