### PR TITLE
fix: resolve PR-body diff against a live merge-base, not stale base.sha

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -74,19 +74,18 @@ jobs:
         if: steps.rollout.outputs.enabled == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          git fetch --no-tags --depth=1 origin "$BASE_SHA"
           git fetch --no-tags --depth=1 origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head"
           fetched_head_sha="$(git rev-parse "refs/remotes/pull/${PR_NUMBER}/head^{commit}")"
           if [ "$fetched_head_sha" != "$HEAD_SHA" ]; then
             echo "Fetched PR head ${fetched_head_sha} did not match event head ${HEAD_SHA}." >&2
             exit 1
           fi
-          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > changed-files.txt
-          git diff --find-renames --unified=200000 --diff-filter=ACMRTD "$BASE_SHA" "$HEAD_SHA" -- > pr.diff
+          bash scripts/fetch-pr-diff-metadata.sh
 
       - name: Validate PR body
         if: steps.rollout.outputs.enabled == 'true'

--- a/scripts/fetch-pr-diff-metadata.sh
+++ b/scripts/fetch-pr-diff-metadata.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Resolve a PR's true current merge-base against its base branch and write
+# changed-files.txt / pr.diff for scripts/validate-pr-body.mjs.
+#
+# The naive `git diff $BASE_SHA $HEAD_SHA` (where BASE_SHA is the GitHub
+# event's pull_request.base.sha) goes stale once base.sha is no longer this
+# PR's actual merge-base with its base branch -- e.g. after a stacked PR's
+# predecessor merges and the base auto-retargets. GitHub does not refresh
+# base.sha to track the live branch, and pushing new commits to the PR head
+# does not refresh it either, so a stale base.sha can pull unrelated files
+# into the diff indefinitely (see scripts/repro/repro-pr-body-stale-base-sha.sh).
+#
+# This resolves a live merge-base against the base branch instead, matching
+# what GitHub's own Files-changed view and validate_pr_body_from_current_diff
+# (scripts/mergify_admin_requeue_repairer.py) already do.
+#
+# Requires: run from a git checkout with an "origin" remote and HEAD_SHA
+# already fetched locally (the caller owns PR-head fetch/verification).
+# Env: BASE_REF (required), HEAD_SHA (required), BASE_SHA (optional, log only)
+# Writes: changed-files.txt, pr.diff (in $PWD)
+set -euo pipefail
+
+: "${BASE_REF:?BASE_REF is required}"
+: "${HEAD_SHA:?HEAD_SHA is required}"
+BASE_SHA="${BASE_SHA:-}"
+DEPTH="${FETCH_PR_DIFF_BASE_DEPTH:-1000}"
+
+git fetch --no-tags --depth="$DEPTH" origin "$BASE_REF"
+
+merge_base="$(git merge-base "origin/$BASE_REF" "$HEAD_SHA" 2>/dev/null || true)"
+if [ -z "$merge_base" ]; then
+  # Shallow depth didn't reach a common ancestor -- deepen once and retry.
+  git fetch --no-tags --deepen="$DEPTH" origin "$BASE_REF"
+  merge_base="$(git merge-base "origin/$BASE_REF" "$HEAD_SHA")"
+fi
+
+if [ -n "$BASE_SHA" ] && [ "$merge_base" != "$BASE_SHA" ]; then
+  echo "Note: event base.sha ($BASE_SHA) is not this PR's current merge-base; diffing against the live merge-base ($merge_base) instead." >&2
+fi
+
+git diff --name-only "$merge_base" "$HEAD_SHA" > changed-files.txt
+git diff --find-renames --unified=200000 --diff-filter=ACMRTD "$merge_base" "$HEAD_SHA" -- > pr.diff

--- a/scripts/repro/repro-pr-body-stale-base-sha.sh
+++ b/scripts/repro/repro-pr-body-stale-base-sha.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Repro: a PR's recorded base.sha can go stale relative to its real
+# merge-base with the base branch -- e.g. GitHub freezes base.sha at the
+# moment a stacked PR auto-retargets onto its predecessor's merge commit,
+# and never refreshes it as the base branch (or the PR branch, via a later
+# stack rebase) keeps moving. Pushing new commits to the PR head does not
+# refresh it either. Confirmed live on
+# https://github.com/Neko-Catpital-Labs/Invoker/pull/6583, where pr-body.yml
+# diffed against a stale base.sha and picked up 6 unrelated scripts/ files
+# that were never part of the PR, tripping the "behavior can't ship with
+# tooling-policy files" review-unit rule.
+#
+# This builds a small local repo reproducing that shape: a base branch that
+# advances after the PR forks, and a PR branch whose *true* merge-base with
+# the base branch (after picking up that later commit, same as a stack
+# rebase would) is newer than the stale base.sha the event would report.
+# It then runs scripts/fetch-pr-diff-metadata.sh -- the actual script
+# pr-body.yml calls -- and asserts the phantom file does not leak into the
+# diff while the PR's real change is still present.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-pr-body-stale-base.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+git init -q --bare "$TMP/origin.git"
+
+WORK="$TMP/work"
+git clone -q "$TMP/origin.git" "$WORK"
+cd "$WORK"
+git config user.email test@example.com
+git config user.name Test
+
+echo base > README.md
+git add README.md
+git commit -q -m "base: initial"
+git push -q origin HEAD:refs/heads/master
+
+# The PR forks here. This is what the (stale) event base.sha will point at.
+STALE_BASE_SHA="$(git rev-parse HEAD)"
+git checkout -q -b pr-branch
+echo "pr change" > feature.txt
+git add feature.txt
+git commit -q -m "pr: add feature"
+git push -q origin HEAD:refs/heads/pr-branch
+
+# Master advances -- simulates a stacked predecessor PR merging after the
+# fork point.
+git checkout -q master
+echo "unrelated master change" > unrelated.txt
+git add unrelated.txt
+git commit -q -m "master: unrelated change that lands after the PR forked"
+git push -q origin HEAD:refs/heads/master
+
+# The PR branch later picks up that master commit (e.g. a Mergify stack
+# rebase), so its TRUE merge-base with master becomes this later commit --
+# not STALE_BASE_SHA.
+git checkout -q pr-branch
+git merge -q master -m "pr: pick up later master (stack rebase)"
+HEAD_SHA="$(git rev-parse HEAD)"
+git push -q -f origin HEAD:refs/heads/pr-branch
+
+CI="$TMP/ci-checkout"
+git clone -q "$TMP/origin.git" "$CI"
+cd "$CI"
+git fetch -q origin "+refs/heads/pr-branch:refs/remotes/pull/999/head"
+
+export BASE_REF=master
+export BASE_SHA="$STALE_BASE_SHA"
+export HEAD_SHA="$HEAD_SHA"
+bash "$ROOT/scripts/fetch-pr-diff-metadata.sh"
+
+echo "[repro] changed-files.txt:"
+sed 's/^/  /' changed-files.txt
+
+if grep -qx "unrelated.txt" changed-files.txt; then
+  echo "[repro] FAILED: unrelated.txt (only reachable via the stale base.sha gap) leaked into the diff" >&2
+  exit 1
+fi
+if ! grep -qx "feature.txt" changed-files.txt; then
+  echo "[repro] FAILED: feature.txt (the PR's real change) is missing from the diff" >&2
+  exit 1
+fi
+echo "[repro] passed: diff resolved against the live merge-base, not the stale base.sha"

--- a/scripts/test-suites/required/11-pr-authoring-guardrails.sh
+++ b/scripts/test-suites/required/11-pr-authoring-guardrails.sh
@@ -5,3 +5,4 @@ cd "$ROOT"
 node scripts/test-pr-diff-atomicity.mjs
 node scripts/test-pr-body-validator.mjs
 node scripts/test-create-pr-visual-proof.mjs
+bash scripts/repro/repro-pr-body-stale-base-sha.sh


### PR DESCRIPTION
## Summary

The `PR Body` CI check diffs a PR against `github.event.pull_request.base.sha`. That field can go stale relative to the PR's real merge-base with its base branch, and nothing refreshes it once it drifts.

This was caught live on #6583: `base.sha` was frozen at an old commit no longer on master's line. The diff picked up 6 unrelated `scripts/mergify_admin_requeue_*.py` files that were never part of that PR, and the check failed for mixing behavior and tooling-policy files that don't actually exist in the PR's real diff.

Pushing new commits to the PR head does not refresh `base.sha`, so once a PR hits this, the check can never go green on its own — only a rebase or a workflow-level fix can un-stick it.

The fix resolves a live merge-base against the base branch instead of trusting the frozen SHA, which is what GitHub's own Files-changed view and the admin-bypass repair bot's own local validator already do correctly.

## Review Claim

The `PR Body` check now diffs a PR against a freshly resolved merge-base with its base branch, not the (possibly stale) event `base.sha`, without weakening the trusted-base security posture of the `pull_request_target` checkout.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

The initial "Checkout trusted base" step still pins to `base.sha`, unchanged — that's what prevents a malicious PR from tampering with the validator scripts themselves under `pull_request_target`'s elevated permissions. Only the *comparison* diff changed, and it's always resolved against `git merge-base` with the live base branch (a real ancestor relationship), never against an untrusted PR-controlled ref.

## Slice Rationale

One behavior slice: fix the stale-base diff computation and add a regression repro for it. No unrelated CI or validator-logic changes bundled in.

## Non-goals

Does not change `scripts/validate-pr-body.mjs`'s validation rules, the review-unit classification logic, or the initial trusted-base checkout step.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-pr-body-stale-base-sha.sh` — deterministic, network-free repro: builds a local git repo where a PR branch's true merge-base with its base branch has moved past a simulated stale `base.sha` (mirrors #6583's shape), and asserts the fix excludes the phantom file while keeping the PR's real change.
- [ ] `bash scripts/test-suites/required/11-pr-authoring-guardrails.sh` — full PR-authoring guardrail suite, including the new repro, passes.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
