### PR TITLE
[Headless CLI gap](1) Add set task-pool command

### DIFF
--- a/packages/app/src/__tests__/headless-set-task-pool.test.ts
+++ b/packages/app/src/__tests__/headless-set-task-pool.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { runHeadless } from '../headless.js';
+import type { HeadlessDeps } from '../headless-shared.js';
+import { LocalBus } from '@invoker/transport';
+import type { CommandService } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+
+describe('headless set task-pool', () => {
+  let mockDeps: HeadlessDeps;
+
+  beforeEach(() => {
+    const noopLogger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), child: vi.fn(() => noopLogger) };
+    mockDeps = {
+      logger: noopLogger as any,
+      orchestrator: { syncFromDb: vi.fn() } as any,
+      persistence: {
+        readOnly: false,
+        listWorkflows: vi.fn(() => [{ id: 'wf-1', name: 'test-workflow', generation: 0,
+          status: 'running' as const, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() }]),
+        loadTasks: vi.fn(() => [{ id: 'wf-1/task-1', status: 'pending',
+          config: { workflowId: 'wf-1' }, execution: {} } as any]),
+      } as unknown as SQLiteAdapter,
+      commandService: {
+        editTaskPool: vi.fn(async () => ({ ok: true as const, data: [] })),
+      } as unknown as CommandService,
+      executorRegistry: {} as any,
+      messageBus: new LocalBus() as any,
+      repoRoot: '/fake/repo',
+      invokerConfig: {} as any,
+      initServices: vi.fn(async () => {}),
+      noTrack: true,
+    } as HeadlessDeps;
+  });
+
+  it('calls commandService.editTaskPool with the resolved task id and poolId', async () => {
+    await runHeadless(['set', 'task-pool', 'wf-1/task-1', 'local-mac-only'], mockDeps);
+    expect(mockDeps.commandService.editTaskPool).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { taskId: 'wf-1/task-1', poolId: 'local-mac-only' } }),
+    );
+  });
+
+  it('throws a clear error when taskId or poolId is missing', async () => {
+    await expect(runHeadless(['set', 'task-pool', 'wf-1/task-1'], mockDeps)).rejects.toThrow(
+      'Missing arguments. Usage: --headless set task-pool <taskId> <poolId>',
+    );
+  });
+});

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -11,6 +11,7 @@ export const HEADLESS_SET_SUBCOMMANDS = [
   'pool',
   'executor',
   'agent',
+  'task-pool',
   'merge-mode',
   'fix-prompt',
   'fix-context',

--- a/packages/app/src/headless-usage.ts
+++ b/packages/app/src/headless-usage.ts
@@ -57,6 +57,7 @@ ${BOLD}Configure:${RESET}
   set command <taskId> <cmd>                          Edit task command and re-run
   set prompt <taskId> <text>                          Edit task prompt and re-run
   set pool <taskId> <type> [poolMemberId]           Change execution pool (worktree|docker|ssh)
+  set task-pool <taskId> <poolId>                     Change execution pool by poolId (from executionPools config)
   set agent <taskId> <agent>                          Change execution agent (claude|codex|omp)
   set merge-mode <workflowId> <mode>                  manual | automatic | external_review
   set fix-prompt <taskId> <text>                      Update fix-session prompt and retry

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -180,6 +180,9 @@ async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
     case 'agent':
       await headlessEditAgent(args[1], args[2], deps);
       break;
+    case 'task-pool':
+      await headlessEditTaskPool(args[1], args[2], deps);
+      break;
     case 'merge-mode':
       await headlessSetMergeMode(args[1], args[2], deps);
       break;
@@ -641,6 +644,34 @@ async function headlessEditAgent(taskId: string, agentName: string, deps: Headle
 
   if (deps.noTrack) {
     process.stdout.write('[headless] --no-track enabled: set agent accepted; exiting without tracking.\n');
+    return;
+  }
+  if (runnable.length === 0) {
+    return;
+  }
+  await trackHeadlessWorkflow(restored.workflowId, deps, {
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
+}
+
+async function headlessEditTaskPool(taskId: string, poolId: string, deps: HeadlessDeps): Promise<void> {
+  if (!taskId || !poolId) throw new Error('Missing arguments. Usage: --headless set task-pool <taskId> <poolId>');
+  const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'set task-pool');
+  if (!restored) return;
+  taskId = restored.resolvedTaskId;
+  const taskExecutor = createHeadlessExecutor(deps);
+
+  const envelope = makeEnvelope('edit-task-pool', 'headless', 'task', { taskId, poolId });
+  const result = await deps.commandService.editTaskPool(envelope);
+  if (!result.ok) throw new Error(result.error.message);
+  const runnable = result.data.filter(isDispatchableLaunch);
+  await dispatchHeadlessRunnableTasks(deps, taskExecutor, runnable, 'edit-task-pool');
+  process.stdout.write(`Edited task "${taskId}" pool → "${poolId}"\n`);
+
+  if (deps.noTrack) {
+    process.stdout.write('[headless] --no-track enabled: set task-pool accepted; exiting without tracking.\n');
     return;
   }
   if (runnable.length === 0) {


### PR DESCRIPTION
## Summary

There was no working way to change a task's execution pool from the CLI.

`set pool`/`set executor` only changes `runnerKind` through `editTaskType`. The scheduler ignores `runnerKind` whenever `poolId` is already set on the task, so that command silently does nothing for the common case.

This adds a new `set task-pool <taskId> <poolId>` headless command that calls the orchestrator's existing, already-tested `commandService.editTaskPool` directly, mirroring the existing `set agent` command.

## Review Claim

`./run.sh --headless set task-pool <taskId> <poolId>` now delegates to the owner, calls `orchestrator.editTaskPool` via `commandService.editTaskPool`, and dispatches any newly-runnable tasks, matching the existing `set agent`/`set command`/`set prompt` pattern.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This only adds a new CLI entry point to an orchestrator method (`editTaskPool`) that already exists and is already exercised elsewhere (command-service, UI). It does not change `editTaskPool` itself, `editTaskType`/`set pool`/`set executor`, any other `set` command, or pool-selection logic in `task-runner-pool.ts`.

## Slice Rationale

This is one behavior slice: wiring one missing CLI command to an existing orchestrator method. It is kept separate from the companion PR that fixes unrelated `set` subcommand classification, so each PR carries exactly one reviewable claim.

## Non-goals

No change to `editTaskPool`, `editTaskPoolImpl`, `editTaskType`, `set pool`/`set executor`, pool-selection logic in `task-runner-pool.ts`, or the UI's `invoker:edit-task-pool` IPC handler.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- headless-set-task-pool`
- [x] `cd packages/app && pnpm test -- headless-command-classification`
- [x] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
