### PR TITLE
fix: let the repair agent submit an Invoker plan when a fix needs restructuring

### DIFF
--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -483,8 +483,14 @@ class AdminBypassRepairer:
             )
         queue_pr_number = latest.queue_pr_number if latest else 0
         prompt = (
-            f"Fix only the failing check. Add or update a repro if the failure is reproducible. "
-            f"Commit locally if needed, do not push. If local proof shows the check is already green on the current head, make no commit and exit 0.\n\n"
+            f"This PR's CI check is failing. Diagnose why it is failing, then fix it. Add or update a repro if the failure is reproducible.\n\n"
+            f"If a code change fixes it: make the change in this checkout. Commit locally if needed, do not push. "
+            f"If local proof shows the check is already green on the current head, make no commit and exit 0.\n\n"
+            f"If the real fix requires restructuring this PR instead of editing it in place -- for example, splitting "
+            f"unrelated files into their own PR because they can't ship together -- do not force that into a single "
+            f"local commit here. Instead, submit an Invoker plan to do the restructuring, the same way a human would "
+            f"via the plan-to-invoker skill (see skills/plan-to-invoker/SKILL.md and ./submit-plan.sh). Then make no "
+            f"commit in this checkout and exit 0.\n\n"
             f"PR: #{pr.number}\nFailed check: {check_name}\nDetails URL: {details_url}\nJob log path: {log_path}\n"
             f"Latest Mergify event: {json.dumps(latest.__dict__ if latest else None, sort_keys=True)}\n"
         )
@@ -580,9 +586,13 @@ class AdminBypassRepairer:
         checkout_pr_head(self.repo, pr, work_root)
         start_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
         prompt = (
-            f"Resolve only the merge conflict that keeps this PR from merging. "
-            f"Rebase the PR head branch onto its base branch, preserve the PR's intended changes, "
-            f"run the narrow proof for the conflict resolution, then commit locally. Do not push. "
+            f"This PR has a merge conflict blocking it from merging. Diagnose why, then fix it.\n\n"
+            f"If rebasing the head branch onto its base branch (preserving the PR's intended changes) resolves it: "
+            f"do that, run the narrow proof for the conflict resolution, then commit locally. Do not push.\n\n"
+            f"If the real fix requires restructuring this PR instead of a straightforward rebase, do not force that "
+            f"into a single local commit here. Instead, submit an Invoker plan to do the restructuring, the same way "
+            f"a human would via the plan-to-invoker skill (see skills/plan-to-invoker/SKILL.md and ./submit-plan.sh). "
+            f"Then make no commit in this checkout and exit 0.\n\n"
             f"If the PR is already closed or merged, or the head branch no longer exists, make no commit and exit 0.\n\n"
             f"PR: #{pr.number}\nBase branch: {pr.base_ref_name}\nHead branch: {pr.head_ref_name}\n"
             f"Head SHA: {pr.head_ref_oid}\nReason: {reason}\n"


### PR DESCRIPTION
## Summary

The admin-bypass repair agent's prompts were scoped to one outcome: fix the problem with a single local commit. That's right when the fix is a content edit.

It broke down on PR #5933, which mixed review units (`activation-surface` + `contract` + `routing`) that this repo requires to ship as separate PRs. No local commit can fix that — the PR itself needs restructuring. The agent had no path to that, so it just gave up.

There's already a narrow version of this idea: `create_repair_prerequisite` auto-handles one specific mismatch (proof + tooling-policy) by opening a prerequisite PR. Rather than hardcode every other mismatch shape the same way, this opens up the prompts instead.

Both `repair_check` and `repair_conflict` now tell the agent: fix it locally if that's the real fix, or open an Invoker plan (the same `plan-to-invoker` path a human would use) if the fix requires restructuring the PR. The agent decides which applies per failure, instead of Python code pre-deciding it per failure-shape.

## Review Claim

The repair agent can now choose to open an Invoker plan instead of a local commit when a CI failure or merge conflict genuinely requires restructuring the PR, without changing how the surrounding code interprets its outcome.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

No control-flow change: both functions still inspect `end_head`/`status_lines` afterward exactly as before. An agent that opens a plan and makes no local commit still resolves to the existing `noop`/`blocked_invalid` outcome path — there's no new state the surrounding code has to understand, and no new push path added.

## Slice Rationale

One prompt-text slice covering both existing repair prompts (CI-check and merge-conflict), since they share the same "local fix vs. needs restructuring" shape. Does not touch the narrow existing prerequisite mechanism, which stays as-is.

## Non-goals

Does not change `create_repair_prerequisite`, the review-unit classification rules, or any control-flow/branching logic in `mergify_admin_requeue_repairer.py`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -m unittest scripts.test_pr_worker_safe_push scripts.test_mergify_admin_requeue` — 66 tests pass, including one that asserts the CI-failure prompt still contains "Commit locally if needed, do not push."
- [ ] `bash scripts/repro/repro-mergify-admin-requeue.sh && bash scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh && bash scripts/repro/repro-mergify-rejected-pr.sh && bash scripts/repro/repro-mergify-closed-pr-guard.sh` — all pass.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
