### PR TITLE
[UI/Backend Drift Harness](2) Fix delta→ui: trace to log what is actually published

### DIFF
--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -181,10 +181,13 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
 
   const processIncomingTaskDelta = (delta: TaskDelta): void => {
     deps.uiPerfStats.mainDeltaToUi += 1;
-    if (deps.traceUiDeltaFlow) {
-      deps.logger.debug(`delta→ui: ${JSON.stringify(delta)}`, { module: 'ui' });
-    }
     for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(delta)) {
+      if (deps.traceUiDeltaFlow) {
+        // Trace what is actually published to the renderer (post gap-detect
+        // recovery), not the raw input -- recovery can expand one incoming
+        // delta into zero or more re-synthesized renderer deltas.
+        deps.logger.debug(`delta→ui: ${JSON.stringify(rendererDelta)}`, { module: 'ui' });
+      }
       publishTaskDeltaToRenderer(rendererDelta);
     }
   };


### PR DESCRIPTION
The delta→ui: trace point logged the raw incoming TaskDelta before owner-cache
gap-detect recovery ran, not what applyTaskDeltaToOwnerCacheOrRecover actually
sends to the renderer. Recovery can expand one incoming delta into zero or
more re-synthesized deltas, so the trace previously claimed something
different from what the renderer received -- producing false drift signals on
any scenario that hit the recovery path.

Move the trace log inside the loop over the recovered deltas so it reflects
the real publish.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Depends-On: #6945