### PR TITLE
[UI/Backend Drift Harness](3) Route fork-workflow through the shared mutation owner

### DIFF
--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -40,7 +40,7 @@ export const HEADLESS_COMMANDS = [
   { name: 'recreate-task', kind: 'write' },
   { name: 'recreate-downstream', kind: 'write' },
   { name: 'replace-task', kind: 'special' },
-  { name: 'fork-workflow', kind: 'special' },
+  { name: 'fork-workflow', kind: 'write' },
   { name: 'detach-workflow', kind: 'write' },
   { name: 'rebase-retry', kind: 'write' },
   { name: 'rebase-recreate', kind: 'write' },


### PR DESCRIPTION
fork-workflow was classified as kind: 'special' in the headless command
registry instead of 'write'. isHeadlessMutatingCommand() checks for 'write'
specifically, so shouldUseSharedMutationOwner() returned false for
fork-workflow -- the headless client skipped delegation to the shared owner
and opened its own local DB connection instead, racing the live owner for the
sqlite writer lock ("[db-writer-lock] Cannot acquire writer lock").

fork-workflow mutates persisted state and launches tasks exactly like the
other 'write' commands next to it (detach-workflow, recreate-task, ...); this
was a one-entry classification gap.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Depends-On: #6946