### PR TITLE
[UI/Backend Drift Harness](1) Add trace-renderer-workflow-event IPC channel

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1291,6 +1291,10 @@ export const IpcChannels = {
     request: [event: TaskGraphEvent];
     response: void;
   },
+  'invoker:trace-renderer-workflow-event': {} as {
+    request: [workflows: unknown[]];
+    response: void;
+  },
   'invoker:get-ui-perf-stats': {} as {
     request: [];
     response: Record<string, unknown>;


### PR DESCRIPTION
## Summary

The workflow-metadata channel (detach, delete, set-merge-mode, ...) has no trace stream today. Only task deltas are traced.

This adds one new invoke channel the renderer will use to report each `onWorkflowsChanged` push back to main, so it can be logged for later diffing.

The channel by itself does nothing yet. It only becomes observable once the follow-up slices wire a handler and a call site to it.

## Review Claim

Approve adding `invoker:trace-renderer-workflow-event` to the IPC channel registry, typed as `request: [workflows: unknown[]]`.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This only adds a new entry to a const object. No existing channel, type, or runtime behavior changes. Nothing calls this channel yet, so there is no way for it to affect any currently running code path.

## Slice Rationale

The renderer-side handler (later slice) needs this channel's type to exist before it can call `window.invoker.traceRendererWorkflowEvent(...)`, since that method is derived automatically from this registry entry. Splitting it out keeps the contract change reviewable on its own, separate from the main-process and renderer wiring that consume it.

## Non-goals

Does not add the main-process handler for this channel. Does not add the renderer call site. Does not change any existing channel.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/contracts build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
