### PR TITLE
[UI/Backend Drift Harness](2) Trace workflow-metadata publish attempts in main

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2042,6 +2042,7 @@ startMainProcessBootstrap({
   let uiInteractive = false;
   let deferredStartupTriggered = false;
   const traceUiDeltaFlow = process.env.INVOKER_TRACE_UI_DELTA === '1';
+  const traceUiWorkflowDeltaFlow = process.env.INVOKER_TRACE_UI_WORKFLOW_DELTA === '1';
   const traceDbPollPerTask = process.env.INVOKER_TRACE_DB_POLL === '1';
   const traceTaskOutput = process.env.INVOKER_TRACE_TASK_OUTPUT === '1';
   const executingStallTimeoutMs = Number.parseInt(
@@ -2278,10 +2279,30 @@ startMainProcessBootstrap({
           { module: 'ui-backpressure', reasonCounts: stats.reasonCounts },
         );
       }
-      if (!mainWindow || mainWindow.isDestroyed() || !uiInteractive) {
+      const activeWindow = mainWindow && !mainWindow.isDestroyed() && uiInteractive ? mainWindow : null;
+      if (traceUiWorkflowDeltaFlow) {
+        logger.debug(
+          `workflow→ui: ${JSON.stringify({
+            dropped: !activeWindow,
+            coalescedRequests: stats.coalescedRequests,
+            reasonCounts: stats.reasonCounts,
+            workflows: workflows.map((workflow) => ({
+              id: workflow.id,
+              status: workflow.status,
+              mergeMode: workflow.mergeMode,
+              baseBranch: workflow.baseBranch,
+              externalDependencies: workflow.externalDependencies,
+              generation: workflow.generation,
+              updatedAt: workflow.updatedAt,
+            })),
+          })}`,
+          { module: 'ui' },
+        );
+      }
+      if (!activeWindow) {
         return;
       }
-      mainWindow.webContents.send('invoker:workflows-changed', workflows);
+      activeWindow.webContents.send('invoker:workflows-changed', workflows);
     },
   });
 


### PR DESCRIPTION
## Summary

Only task-level changes are traced today. A detach or merge-mode change never shows up in any trace at all.

Add `INVOKER_TRACE_UI_WORKFLOW_DELTA`. When set, every flush of the workflow-metadata publisher logs a `workflow→ui:` line.

Each line includes whether the push was dropped (window not interactive) and the coalescing stats that produced it. This makes a previously invisible drop visible for the first time.

## Review Claim

Approve logging a `workflow→ui:` debug line inside the existing `CoalescedWorkflowMetadataPublisher` publish callback in `main.ts`, gated by the new env flag.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new code path is entirely inside an `if (traceUiWorkflowDeltaFlow)` block, off by default. The one line moved outside that guard is `const dropped = ...`, which is a pure boolean computation with no side effect, previously inlined into the `if` condition below it. Behavior for anyone not setting the new env var is unchanged.

## Slice Rationale

This is the backend half of the workflow-metadata trace pair; the renderer half (handler + call site) is a separate slice so each can be reviewed against its own file set.

## Non-goals

Does not add the renderer-side trace. Does not change what gets published to the renderer, only what gets logged about it.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter app test`
- [ ] `INVOKER_TRACE_UI_WORKFLOW_DELTA=1 ./run.sh`, detach a workflow, confirm a `workflow→ui:` line appears in `~/.invoker/invoker.log`

</details>

## Visual Proof

This touches `packages/app/src/main.ts`, which this repo's tooling treats as UI-impacting by path even though the change is a backend log line with no rendered UI difference. The proof below is the actual new log output, captured from a real e2e run in this repo, rather than an app screenshot -- there is no pixel difference to show.

![New workflow→ui: trace line, captured from a real detach-workflow e2e run](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260801-b287ee/pr2-workflow-ui-trace.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>