### PR TITLE
[UI/Backend Drift Harness](5) Route fork-workflow through the shared mutation owner

### DIFF
--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -40,7 +40,7 @@ export const HEADLESS_COMMANDS = [
   { name: 'recreate-task', kind: 'write' },
   { name: 'recreate-downstream', kind: 'write' },
   { name: 'replace-task', kind: 'special' },
-  { name: 'fork-workflow', kind: 'special' },
+  { name: 'fork-workflow', kind: 'write' },
   { name: 'detach-workflow', kind: 'write' },
   { name: 'rebase-retry', kind: 'write' },
   { name: 'rebase-recreate', kind: 'write' },

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1919,6 +1919,32 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     }
   });
 
+  const traceRendererWorkflowEvents = process.env.INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS === '1';
+  const rendererWorkflowTracePath = join(homedir(), '.invoker', 'ui-workflow-events.jsonl');
+  let rendererWorkflowTraceWriteFailed = false;
+  ipcMain.handle('invoker:trace-renderer-workflow-event', (_event, workflows: unknown[]) => {
+    if (!traceRendererWorkflowEvents) return;
+    try {
+      mkdirSync(dirname(rendererWorkflowTracePath), { recursive: true });
+      appendFileSync(
+        rendererWorkflowTracePath,
+        JSON.stringify({
+          time: new Date().toISOString(),
+          source: 'renderer',
+          event: { type: 'workflows-changed', workflows },
+        }) + '\n',
+      );
+    } catch (err) {
+      if (!rendererWorkflowTraceWriteFailed) {
+        rendererWorkflowTraceWriteFailed = true;
+        logger.warn(
+          `renderer workflow trace write failed: ${err instanceof Error ? err.message : String(err)}`,
+          { module: 'ui' },
+        );
+      }
+    }
+  });
+
   ipcMain.handle('invoker:get-ui-perf-stats', () => ({
     ...getUiPerfStats(),
   }));

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2042,6 +2042,7 @@ startMainProcessBootstrap({
   let uiInteractive = false;
   let deferredStartupTriggered = false;
   const traceUiDeltaFlow = process.env.INVOKER_TRACE_UI_DELTA === '1';
+  const traceUiWorkflowDeltaFlow = process.env.INVOKER_TRACE_UI_WORKFLOW_DELTA === '1';
   const traceDbPollPerTask = process.env.INVOKER_TRACE_DB_POLL === '1';
   const traceTaskOutput = process.env.INVOKER_TRACE_TASK_OUTPUT === '1';
   const executingStallTimeoutMs = Number.parseInt(
@@ -2278,10 +2279,30 @@ startMainProcessBootstrap({
           { module: 'ui-backpressure', reasonCounts: stats.reasonCounts },
         );
       }
-      if (!mainWindow || mainWindow.isDestroyed() || !uiInteractive) {
+      const activeWindow = mainWindow && !mainWindow.isDestroyed() && uiInteractive ? mainWindow : null;
+      if (traceUiWorkflowDeltaFlow) {
+        logger.debug(
+          `workflow→ui: ${JSON.stringify({
+            dropped: !activeWindow,
+            coalescedRequests: stats.coalescedRequests,
+            reasonCounts: stats.reasonCounts,
+            workflows: workflows.map((workflow) => ({
+              id: workflow.id,
+              status: workflow.status,
+              mergeMode: workflow.mergeMode,
+              baseBranch: workflow.baseBranch,
+              externalDependencies: workflow.externalDependencies,
+              generation: workflow.generation,
+              updatedAt: workflow.updatedAt,
+            })),
+          })}`,
+          { module: 'ui' },
+        );
+      }
+      if (!activeWindow) {
         return;
       }
-      mainWindow.webContents.send('invoker:workflows-changed', workflows);
+      activeWindow.webContents.send('invoker:workflows-changed', workflows);
     },
   });
 

--- a/packages/app/src/preload.ts
+++ b/packages/app/src/preload.ts
@@ -114,6 +114,10 @@ contextBridge.exposeInMainWorld(
   '__INVOKER_TRACE_RENDERER_TASK_GRAPH__',
   process.env.INVOKER_TRACE_RENDERER_TASK_GRAPH === '1',
 );
+contextBridge.exposeInMainWorld(
+  '__INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS__',
+  process.env.INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS === '1',
+);
 
 setTimeout(() => {
   ipcRenderer.invoke('invoker:report-ui-perf', 'preload_bootstrap_sync', {

--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -181,10 +181,13 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
 
   const processIncomingTaskDelta = (delta: TaskDelta): void => {
     deps.uiPerfStats.mainDeltaToUi += 1;
-    if (deps.traceUiDeltaFlow) {
-      deps.logger.debug(`delta→ui: ${JSON.stringify(delta)}`, { module: 'ui' });
-    }
     for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(delta)) {
+      if (deps.traceUiDeltaFlow) {
+        // Trace what is actually published to the renderer (post gap-detect
+        // recovery), not the raw input -- recovery can expand one incoming
+        // delta into zero or more re-synthesized renderer deltas.
+        deps.logger.debug(`delta→ui: ${JSON.stringify(rendererDelta)}`, { module: 'ui' });
+      }
       publishTaskDeltaToRenderer(rendererDelta);
     }
   };

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -340,6 +340,7 @@ export function createMockInvoker(
     getActivityLogs: vi.fn(async () => []),
     reportUiPerf: vi.fn(async () => {}),
     traceRendererTaskGraphEvent: vi.fn(async () => {}),
+    traceRendererWorkflowEvent: vi.fn(async () => {}),
     getUiPerfStats: vi.fn(async () => ({})),
     getEvents: vi.fn(async (taskId: string, options?: { limit: number; sortBy?: 'asc' | 'desc'; beforeId?: number }) => {
       const events = [...(eventsByTask.get(taskId) ?? [])];

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -126,6 +126,9 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
   const traceRendererTaskGraphEvents =
     typeof window !== 'undefined' &&
     window.__INVOKER_TRACE_RENDERER_TASK_GRAPH__ === true;
+  const traceRendererWorkflowEvents =
+    typeof window !== 'undefined' &&
+    window.__INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS__ === true;
   const bootstrapState =
     typeof window !== 'undefined' ? window.__INVOKER_BOOTSTRAP__ : undefined;
   const [tasks, setTasks] = useState<Map<string, TaskState>>(() => {
@@ -516,6 +519,12 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
 
     const unsubWf = window.invoker.onWorkflowsChanged?.((wfList: any[]) => {
       invalidateStartupSnapshot();
+      if (traceRendererWorkflowEvents) {
+        const traceRendererWorkflowEvent = window.invoker.traceRendererWorkflowEvent;
+        if (traceRendererWorkflowEvent) {
+          void traceRendererWorkflowEvent(wfList).catch(() => undefined);
+        }
+      }
       if (Array.isArray(wfList)) {
         setWorkflows((previous) => {
           const nextWorkflows = replaceWorkflowMapPreservingTaskBackedEntries(
@@ -552,7 +561,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
       unsub();
       unsubWf?.();
     };
-  }, [invalidateStartupSnapshot, loadStartupSnapshot, onTaskGraphSnapshotApplied, refreshTaskGraph, refreshWorkflowMetadata, traceRendererTaskGraphEvents]);
+  }, [invalidateStartupSnapshot, loadStartupSnapshot, onTaskGraphSnapshotApplied, refreshTaskGraph, refreshWorkflowMetadata, traceRendererTaskGraphEvents, traceRendererWorkflowEvents]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !window.invoker) return;

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -358,6 +358,7 @@ declare global {
       streamSequence?: number;
     };
     __INVOKER_TRACE_RENDERER_TASK_GRAPH__?: boolean;
+    __INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS__?: boolean;
     __INVOKER_TEST_OPEN_TERMINAL__?: (taskId: string) => ReturnType<InvokerAPI['openTerminal']>;
     __INVOKER_TEST_ON_TERMINAL_OUTPUT__?: (cb: (event: TerminalOutputEvent) => void) => () => void;
   }


### PR DESCRIPTION
## Summary

`fork-workflow` was tagged `kind: 'special'` in the headless command registry, next to `replace-task`, instead of `kind: 'write'`.

`isHeadlessMutatingCommand()` only checks for `'write'`. So the headless client treated `fork-workflow` as read-only, and never took the path that delegates a mutating command to the already-running shared owner process.

Instead it opened its own local database connection and raced the live owner for the sqlite writer lock, failing with `[db-writer-lock] Cannot acquire writer lock`.

`fork-workflow` mutates persisted state and launches tasks exactly like `detach-workflow`, `recreate-task`, and every other entry tagged `'write'` right above it. This was a one-entry gap, not a design choice.

## Review Claim

Approve retagging `fork-workflow` from `kind: 'special'` to `kind: 'write'` in `HEADLESS_COMMANDS`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

One entry in a lookup table changes value. Every other call site that reads this table (`isHeadlessReadOnlyCommand`, `isHeadlessMutatingCommand`, `findHeadlessCommandDefinition`) is a pure lookup with no `fork-workflow`-specific branch, so the only observable effect is that `fork-workflow` now takes the same `'write'` code path every other mutating command already takes.

## Slice Rationale

A standalone, single-line classification correction; unrelated to the trace instrumentation added earlier in this stack, kept separate so it reads as its own claim.

## Non-goals

Does not add or change any headless command's behavior beyond how it is classified for delegation purposes. Does not touch `replace-task`, which stays `'special'` (it is intentionally disabled).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter app test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #6953