### PR TITLE
[UI/Backend Drift Harness](6) Add drift-testing e2e harness for every mutating operation

### DIFF
--- a/packages/app/e2e/drift/battery-runner.ts
+++ b/packages/app/e2e/drift/battery-runner.ts
@@ -1,0 +1,113 @@
+/**
+ * Combinatorial/permutation coverage over the scenario catalog ("battery
+ * testing"). Full factorial permutation over ~20+ operations is
+ * combinatorially infeasible, so this scopes to:
+ *   - pairwise (2-wise) coverage: every ordered pair run concurrently
+ *   - randomized fuzz: seeded random subsets run concurrently, repeated
+ * mirroring the core/@nightly catalog-expansion pattern already used in
+ * scripts/e2e-chaos/run-overload.sh.
+ */
+import type { Page } from '@playwright/test';
+import { deleteAllWorkflowsFast } from '../fixtures/electron-app.js';
+import { scenarioById, type DriftScenario } from './scenario-catalog.js';
+import { compareDriftTimeline, type TimelineComparisonResult } from './trace-compare.js';
+
+export interface BatteryRunResult {
+  label: string;
+  scenarioIds: string[];
+  wallMs: number;
+  comparisons: Array<{ scenarioId: string; channel: DriftScenario['channel']; workflowId: string; comparison: TimelineComparisonResult }>;
+  ok: boolean;
+}
+
+/** Deterministic PRNG (mulberry32) so fuzz batteries are reproducible by default. */
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function seedFromString(seed: string): number {
+  let hash = 0;
+  for (let i = 0; i < seed.length; i += 1) {
+    hash = (Math.imul(31, hash) + seed.charCodeAt(i)) | 0;
+  }
+  return hash;
+}
+
+/** Every ordered pair (a, b) with a !== b -- full pairwise coverage of the catalog. */
+export function pairwiseCombinations(ids: readonly string[]): Array<[string, string]> {
+  const pairs: Array<[string, string]> = [];
+  for (const a of ids) {
+    for (const b of ids) {
+      if (a !== b) pairs.push([a, b]);
+    }
+  }
+  return pairs;
+}
+
+/** `count` random subsets of `size` distinct ids, seeded for reproducibility. */
+export function randomFuzzSubsets(ids: readonly string[], count: number, size: number, seed: number): string[][] {
+  const rng = mulberry32(seed);
+  const subsets: string[][] = [];
+  for (let i = 0; i < count; i += 1) {
+    const pool = [...ids];
+    const subset: string[] = [];
+    for (let k = 0; k < Math.min(size, pool.length); k += 1) {
+      const index = Math.floor(rng() * pool.length);
+      subset.push(pool.splice(index, 1)[0]);
+    }
+    subsets.push(subset);
+  }
+  return subsets;
+}
+
+/** Run one battery entry: set up every scenario, fire all their acts concurrently, compare all. */
+export async function runConcurrentBattery(
+  page: Page,
+  testDir: string,
+  scenarioIds: readonly string[],
+  label: string,
+): Promise<BatteryRunResult> {
+  // A battery runs many entries in one long-lived Electron session for cost
+  // reasons (see plan). The deterministic INVOKER_TEST_WORKFLOW_IDS=1 ids used
+  // in e2e tests are a small, reused id space (wf-test-1, wf-test-2, ...) --
+  // without clearing state between entries, a later entry's id can collide
+  // with an earlier entry's still-lingering workflow, corrupting its merge
+  // node. Starting from a clean slate avoids this test-fixture artifact.
+  await deleteAllWorkflowsFast(page);
+
+  const scenarios = scenarioIds.map(scenarioById);
+  const prepared: Array<{ scenario: DriftScenario; ctx: Awaited<ReturnType<DriftScenario['setup']>> }> = [];
+  for (const scenario of scenarios) {
+    prepared.push({ scenario, ctx: await scenario.setup(page, testDir) });
+  }
+
+  const startedAt = Date.now();
+  const results = await Promise.all(
+    prepared.map(({ scenario, ctx }) => scenario.act(ctx).then((result) => ({ scenario, result }))),
+  );
+  const wallMs = Date.now() - startedAt;
+
+  await page.waitForTimeout(2000);
+
+  const comparisons = results.map(({ scenario, result }) => ({
+    scenarioId: scenario.id,
+    channel: scenario.channel,
+    workflowId: result.workflowId,
+    comparison: compareDriftTimeline(scenario.channel, testDir, result.workflowId),
+  }));
+
+  return {
+    label,
+    scenarioIds: [...scenarioIds],
+    wallMs,
+    comparisons,
+    ok: comparisons.every((entry) => entry.comparison.ok),
+  };
+}

--- a/packages/app/e2e/drift/drift-battery.spec.ts
+++ b/packages/app/e2e/drift/drift-battery.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Combinatorial "battery" coverage over the drift scenario catalog.
+ *
+ * Default (no env var): pairwise coverage over a curated core subset, plus a
+ * handful of seeded random-fuzz subsets -- fast enough to run on demand.
+ * INVOKER_DRIFT_BATTERY_MODE=nightly: full pairwise coverage over every
+ * IPC-driven scenario in the catalog (excludes headless-CLI-driven scenarios,
+ * whose concurrent-process concerns are already covered by
+ * packages/app/e2e/headless-thundering-herd.spec.ts). This mirrors the
+ * core/@nightly catalog-expansion pattern in scripts/e2e-chaos/run-overload.sh.
+ *
+ * This harness stays opt-in / manually run, not wired into required CI.
+ */
+if (!process.env.INVOKER_TRACE_UI_DELTA) process.env.INVOKER_TRACE_UI_DELTA = '1';
+if (!process.env.INVOKER_TRACE_RENDERER_TASK_GRAPH) process.env.INVOKER_TRACE_RENDERER_TASK_GRAPH = '1';
+if (!process.env.INVOKER_TRACE_UI_WORKFLOW_DELTA) process.env.INVOKER_TRACE_UI_WORKFLOW_DELTA = '1';
+if (!process.env.INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS) process.env.INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS = '1';
+
+import { expect, test } from '../fixtures/electron-app.js';
+import { DRIFT_SCENARIOS } from './scenario-catalog.js';
+import { pairwiseCombinations, randomFuzzSubsets, runConcurrentBattery, seedFromString } from './battery-runner.js';
+
+const MODE = process.env.INVOKER_DRIFT_BATTERY_MODE === 'nightly' ? 'nightly' : 'core';
+const SEED = seedFromString(process.env.INVOKER_DRIFT_BATTERY_SEED ?? 'invoker-drift-battery-default-seed');
+const FUZZ_ITERATIONS = Number.parseInt(process.env.INVOKER_DRIFT_BATTERY_FUZZ_ITERATIONS ?? '5', 10);
+const FUZZ_SIZE = Number.parseInt(process.env.INVOKER_DRIFT_BATTERY_FUZZ_SIZE ?? '3', 10);
+
+// Excludes 'run': concurrently submitting a brand-new plan alongside
+// mutations on other workflows hits a separate, test-fixture-specific race in
+// the deterministic INVOKER_TEST_WORKFLOW_IDS=1 id counter (not a production
+// concern -- real ids are random); 'run' already has dedicated single-op
+// coverage in drift-single-op.spec.ts.
+// Excludes 'delete-all-workflows': it wipes every workflow in the shared test
+// DB, so pairing it with any concurrent sibling necessarily corrupts that
+// sibling's own workflow underneath it -- a scenario-composition artifact,
+// not a channel drift bug. Also covered individually in drift-single-op.spec.ts.
+const EXCLUDED_FROM_COMBINATORICS = new Set(['run', 'delete-all-workflows']);
+const IPC_DRIVEN_IDS = DRIFT_SCENARIOS
+  .filter((s) => s.driver === 'ipc' && !EXCLUDED_FROM_COMBINATORICS.has(s.id))
+  .map((s) => s.id);
+
+const CORE_BATTERY_IDS = [
+  'retry-task',
+  'cancel-task',
+  'approve',
+  'detach-workflow',
+  'delete-task',
+  'set-merge-mode',
+];
+
+const batteryIds = MODE === 'nightly' ? IPC_DRIVEN_IDS : CORE_BATTERY_IDS;
+
+test.describe(`UI/backend drift — combinatorial battery (${MODE})`, () => {
+  test('every pairwise combination of concurrent operations converges', async ({ page, testDir }) => {
+    test.setTimeout(MODE === 'nightly' ? 45 * 60_000 : 10 * 60_000);
+    const pairs = pairwiseCombinations(batteryIds);
+    const runs = [];
+    for (const [a, b] of pairs) {
+      runs.push(await runConcurrentBattery(page, testDir, [a, b], `${a} + ${b}`));
+    }
+
+    const failed = runs.filter((run) => !run.ok);
+    const evidence = {
+      mode: MODE,
+      pairCount: pairs.length,
+      failedCount: failed.length,
+      failed,
+    };
+    expect(failed.length, JSON.stringify(evidence, null, 2)).toBe(0);
+  });
+
+  test('random-fuzz subsets of concurrent operations converge', async ({ page, testDir }) => {
+    test.setTimeout(10 * 60_000);
+    const subsets = randomFuzzSubsets(IPC_DRIVEN_IDS, FUZZ_ITERATIONS, FUZZ_SIZE, SEED);
+    const runs = [];
+    for (const subset of subsets) {
+      runs.push(await runConcurrentBattery(page, testDir, subset, subset.join(' + ')));
+    }
+
+    const failed = runs.filter((run) => !run.ok);
+    const evidence = {
+      seed: SEED,
+      iterations: FUZZ_ITERATIONS,
+      size: FUZZ_SIZE,
+      failedCount: failed.length,
+      failed,
+    };
+    expect(failed.length, JSON.stringify(evidence, null, 2)).toBe(0);
+  });
+});

--- a/packages/app/e2e/drift/drift-single-op.spec.ts
+++ b/packages/app/e2e/drift/drift-single-op.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * One drift check per catalog entry in scenario-catalog.ts. Some entries may
+ * fail until their underlying drift bug is fixed -- this harness is for
+ * reproducing and diagnosing drift, not a green-required CI gate.
+ * See docs/ui-backend-drift-tracing.md.
+ */
+if (!process.env.INVOKER_TRACE_UI_DELTA) process.env.INVOKER_TRACE_UI_DELTA = '1';
+if (!process.env.INVOKER_TRACE_RENDERER_TASK_GRAPH) process.env.INVOKER_TRACE_RENDERER_TASK_GRAPH = '1';
+if (!process.env.INVOKER_TRACE_UI_WORKFLOW_DELTA) process.env.INVOKER_TRACE_UI_WORKFLOW_DELTA = '1';
+if (!process.env.INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS) process.env.INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS = '1';
+
+import { expect, test } from '../fixtures/electron-app.js';
+import { DRIFT_SCENARIOS } from './scenario-catalog.js';
+import { compareDriftTimeline } from './trace-compare.js';
+
+test.describe('UI/backend drift — single operation', () => {
+  for (const scenario of DRIFT_SCENARIOS) {
+    test(`${scenario.id} (${scenario.channel}/${scenario.driver})`, async ({ page, testDir }) => {
+      const ctx = await scenario.setup(page, testDir);
+      const result = await scenario.act(ctx);
+      // Let the coalescing windows (25ms task-graph batch, 50ms workflow-metadata
+      // flush) settle before reading the trace files back.
+      await page.waitForTimeout(1000);
+
+      const comparison = compareDriftTimeline(scenario.channel, testDir, result.workflowId);
+      if (process.env.INVOKER_DRIFT_DEBUG_DUMP === '1') {
+        const fs = await import('node:fs');
+        const path = await import('node:path');
+        const home = path.join(testDir, 'home', '.invoker');
+        console.log('DEBUG workflowId', result.workflowId);
+        console.log('DEBUG invoker.log', fs.readFileSync(path.join(home, 'invoker.log'), 'utf8'));
+        console.log('DEBUG ui-task-graph-events.jsonl', fs.readFileSync(path.join(home, 'ui-task-graph-events.jsonl'), 'utf8'));
+      }
+      expect(comparison.ok, JSON.stringify({ scenario: scenario.id, ...comparison }, null, 2)).toBe(true);
+    });
+  }
+});

--- a/packages/app/e2e/drift/drift-thundering-herd.spec.ts
+++ b/packages/app/e2e/drift/drift-thundering-herd.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Dedicated UI/backend drift check under burst load: fires a mix of
+ * IPC-driven mutating operations (from scenario-catalog.ts) CONCURRENTLY
+ * across several workflows in one Electron session, then asserts every
+ * operation's effect eventually converges in the renderer.
+ *
+ * Scope is drift only -- this is not a general chaos/responsiveness test.
+ * For process-count/renderer-responsiveness under a headless-CLI retry burst,
+ * see packages/app/e2e/headless-thundering-herd.spec.ts. For broader failure
+ * modes, see scripts/e2e-chaos/run-overload.sh.
+ */
+if (!process.env.INVOKER_TRACE_UI_DELTA) process.env.INVOKER_TRACE_UI_DELTA = '1';
+if (!process.env.INVOKER_TRACE_RENDERER_TASK_GRAPH) process.env.INVOKER_TRACE_RENDERER_TASK_GRAPH = '1';
+if (!process.env.INVOKER_TRACE_UI_WORKFLOW_DELTA) process.env.INVOKER_TRACE_UI_WORKFLOW_DELTA = '1';
+if (!process.env.INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS) process.env.INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS = '1';
+
+import { expect, test } from '../fixtures/electron-app.js';
+import { scenarioById } from './scenario-catalog.js';
+import { compareDriftTimeline } from './trace-compare.js';
+
+// IPC-driven scenarios only (driver: 'ipc') -- headless-CLI-driven bursts are
+// a distinct, already-covered concern (headless-thundering-herd.spec.ts).
+// Excludes 'run': submitting a brand-new plan concurrently with mutations on
+// other workflows hits a separate, test-fixture-specific race in the
+// deterministic INVOKER_TEST_WORKFLOW_IDS=1 id counter (not a production
+// concern -- real ids are random) and 'run' already has dedicated single-op
+// coverage in drift-single-op.spec.ts.
+const BURST_SCENARIO_IDS = [
+  'retry-task',
+  'cancel-task',
+  'approve',
+  'reject',
+  'edit-task-command',
+  'detach-workflow',
+  'delete-task',
+  'set-merge-mode',
+  'set-merge-branch',
+];
+
+test.describe('UI/backend drift — thundering herd', () => {
+  test('a burst of concurrent operations across many workflows all eventually converge', async ({ page, testDir }) => {
+    const scenarios = BURST_SCENARIO_IDS.map(scenarioById);
+
+    // Setup phase runs sequentially -- each scenario builds its own
+    // workflow(s)/preconditions and this isn't itself the condition under
+    // test.
+    const prepared: Array<{ scenario: (typeof scenarios)[number]; ctx: Awaited<ReturnType<(typeof scenarios)[number]['setup']>> }> = [];
+    for (const scenario of scenarios) {
+      prepared.push({ scenario, ctx: await scenario.setup(page, testDir) });
+    }
+
+    // Burst phase: fire every operation's mutating IPC call concurrently.
+    // This is the actual thundering-herd condition -- many nearly-simultaneous
+    // invoker:* IPC calls landing on the same coalescing windows at once.
+    const burstStartedAt = Date.now();
+    const results = await Promise.all(
+      prepared.map(({ scenario, ctx }) => scenario.act(ctx).then((result) => ({ scenario, result }))),
+    );
+    const burstWallMs = Date.now() - burstStartedAt;
+
+    // Let both coalescing windows (25ms task-graph batch, 50ms
+    // workflow-metadata flush) settle well past their max before reading the
+    // trace files back.
+    await page.waitForTimeout(2000);
+
+    const comparisons = results.map(({ scenario, result }) => ({
+      scenario: scenario.id,
+      channel: scenario.channel,
+      workflowId: result.workflowId,
+      comparison: compareDriftTimeline(scenario.channel, testDir, result.workflowId),
+    }));
+
+    const failed = comparisons.filter((entry) => !entry.comparison.ok);
+    const evidence = {
+      burstWallMs,
+      scenarioCount: scenarios.length,
+      failedCount: failed.length,
+      failed,
+      all: comparisons,
+    };
+    expect(failed.length, JSON.stringify(evidence, null, 2)).toBe(0);
+  });
+});

--- a/packages/app/e2e/drift/scenario-catalog.ts
+++ b/packages/app/e2e/drift/scenario-catalog.ts
@@ -1,0 +1,575 @@
+/**
+ * Catalog of every UI/backend-mutating operation used by the drift-testing
+ * harness in this directory. See docs/ui-backend-drift-tracing.md for the
+ * two channels these operations travel over.
+ */
+import type { Page } from '@playwright/test';
+import { E2E_REPO_URL, injectTaskStates, loadPlan, startPlan } from '../fixtures/electron-app.js';
+import { runHeadlessClient } from '../fixtures/headless-client.js';
+
+export type DriftChannel = 'task-delta' | 'workflow-metadata';
+export type ScenarioDriver = 'ipc' | 'headless-cli';
+
+export interface ScenarioContext {
+  page: Page;
+  testDir: string;
+  workflowId: string;
+  taskId: string;
+  upstreamWorkflowId?: string;
+}
+
+export interface ScenarioResult {
+  workflowId: string;
+  taskId?: string;
+}
+
+export interface DriftScenario {
+  id: string;
+  channel: DriftChannel;
+  driver: ScenarioDriver;
+  description: string;
+  /** Establish preconditions: load a plan, inject task state, link workflows, etc. */
+  setup(page: Page, testDir: string): Promise<ScenarioContext>;
+  /** Perform the mutating operation under test. Returns the ids to scope the drift comparison to. */
+  act(ctx: ScenarioContext): Promise<ScenarioResult>;
+}
+
+function plan(name: string, taskOverrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    name,
+    repoUrl: E2E_REPO_URL,
+    onFinish: 'none' as const,
+    tasks: [
+      {
+        id: 'task-alpha',
+        description: 'First test task',
+        command: 'sleep 5 && echo hello-alpha',
+        dependencies: [],
+        ...taskOverrides,
+      },
+      {
+        id: 'task-beta',
+        description: 'Second test task depending on alpha',
+        command: 'sleep 3 && echo hello-beta',
+        dependencies: ['task-alpha'],
+      },
+    ],
+  };
+}
+
+async function listWorkflowIds(page: Page): Promise<Set<string>> {
+  const workflows = await page.evaluate(() => window.invoker.listWorkflows());
+  return new Set(workflows.map((workflow: { id: string }) => workflow.id));
+}
+
+async function loadPlanAndGetWorkflowId(page: Page, testPlan: ReturnType<typeof plan>): Promise<string> {
+  const before = await listWorkflowIds(page);
+  await loadPlan(page, testPlan);
+  const after = await page.evaluate(() => window.invoker.listWorkflows());
+  const created = after.find((workflow: { id: string }) => !before.has(workflow.id));
+  const workflowId = created?.id ?? after[after.length - 1]?.id;
+  if (!workflowId) throw new Error('loadPlanAndGetWorkflowId: no workflow found after loadPlan');
+  return workflowId;
+}
+
+async function resolvedTaskId(page: Page, taskId: string): Promise<string> {
+  const result = await page.evaluate(() => window.invoker.getTasks());
+  const tasks = Array.isArray(result) ? result : result.tasks;
+  const found = tasks.find((task: { id: string }) => task.id === taskId || task.id.endsWith(`/${taskId}`));
+  if (!found) throw new Error(`resolvedTaskId: task "${taskId}" not found`);
+  return found.id;
+}
+
+/** Standard two-task plan, task-alpha injected straight into a terminal/gate status (no real command runs). */
+async function setupWithInjectedTaskStatus(
+  page: Page,
+  testDir: string,
+  status: string,
+  extraChanges: Record<string, unknown> = {},
+): Promise<ScenarioContext> {
+  const workflowId = await loadPlanAndGetWorkflowId(page, plan(`drift scenario ${status}`));
+  await injectTaskStates(page, [{ taskId: 'task-alpha', changes: { status: status as never, ...extraChanges } }]);
+  const taskId = await resolvedTaskId(page, 'task-alpha');
+  return { page, testDir, workflowId, taskId };
+}
+
+const runScenario: DriftScenario = {
+  id: 'run',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Submit a new plan (add workflow)',
+  async setup(page, testDir) {
+    return { page, testDir, workflowId: '', taskId: '' };
+  },
+  async act(ctx) {
+    const workflowId = await loadPlanAndGetWorkflowId(ctx.page, plan('drift scenario run'));
+    await startPlan(ctx.page);
+    return { workflowId };
+  },
+};
+
+const retryTaskScenario: DriftScenario = {
+  id: 'retry-task',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Retry a single failed task',
+  setup: (page, testDir) => setupWithInjectedTaskStatus(page, testDir, 'failed', { execution: { exitCode: 1 } }),
+  async act(ctx) {
+    await ctx.page.evaluate((taskId) => window.invoker.retryTask(taskId), ctx.taskId);
+    return { workflowId: ctx.workflowId, taskId: ctx.taskId };
+  },
+};
+
+const retryWorkflowScenario: DriftScenario = {
+  id: 'retry-workflow',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Retry an entire failed workflow',
+  setup: (page, testDir) => setupWithInjectedTaskStatus(page, testDir, 'failed', { execution: { exitCode: 1 } }),
+  async act(ctx) {
+    await ctx.page.evaluate((workflowId) => window.invoker.retryWorkflow(workflowId), ctx.workflowId);
+    return { workflowId: ctx.workflowId };
+  },
+};
+
+const recreateTaskScenario: DriftScenario = {
+  id: 'recreate-task',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Recreate a single completed task from a fresh base',
+  setup: (page, testDir) => setupWithInjectedTaskStatus(page, testDir, 'completed'),
+  async act(ctx) {
+    await ctx.page.evaluate((taskId) => window.invoker.recreateTask(taskId), ctx.taskId);
+    return { workflowId: ctx.workflowId, taskId: ctx.taskId };
+  },
+};
+
+const recreateWorkflowScenario: DriftScenario = {
+  id: 'recreate-workflow',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Recreate an entire workflow from a fresh base',
+  setup: (page, testDir) => setupWithInjectedTaskStatus(page, testDir, 'completed'),
+  async act(ctx) {
+    await ctx.page.evaluate((workflowId) => window.invoker.recreateWorkflow(workflowId), ctx.workflowId);
+    return { workflowId: ctx.workflowId };
+  },
+};
+
+const recreateDownstreamScenario: DriftScenario = {
+  id: 'recreate-downstream',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Recreate everything downstream of a task',
+  setup: (page, testDir) => setupWithInjectedTaskStatus(page, testDir, 'completed'),
+  async act(ctx) {
+    await ctx.page.evaluate((taskId) => window.invoker.recreateDownstream(taskId), ctx.taskId);
+    return { workflowId: ctx.workflowId, taskId: ctx.taskId };
+  },
+};
+
+const rebaseRetryScenario: DriftScenario = {
+  id: 'rebase-retry',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Rebase onto latest base branch, then retry',
+  setup: (page, testDir) => setupWithInjectedTaskStatus(page, testDir, 'failed', { execution: { exitCode: 1 } }),
+  async act(ctx) {
+    await ctx.page.evaluate((target) => window.invoker.rebaseRetry(target), ctx.workflowId);
+    return { workflowId: ctx.workflowId };
+  },
+};
+
+const rebaseRecreateScenario: DriftScenario = {
+  id: 'rebase-recreate',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Rebase onto latest base branch, then recreate (existing baseline coverage)',
+  setup: (page, testDir) => setupWithInjectedTaskStatus(page, testDir, 'failed', { execution: { exitCode: 1 } }),
+  async act(ctx) {
+    await ctx.page.evaluate((target) => window.invoker.rebaseRecreate(target), ctx.workflowId);
+    return { workflowId: ctx.workflowId };
+  },
+};
+
+const cancelTaskScenario: DriftScenario = {
+  id: 'cancel-task',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Cancel a single running task',
+  setup: (page, testDir) => setupWithInjectedTaskStatus(page, testDir, 'running', { execution: { phase: 'running' } }),
+  async act(ctx) {
+    await ctx.page.evaluate((taskId) => window.invoker.cancelTask(taskId), ctx.taskId);
+    return { workflowId: ctx.workflowId, taskId: ctx.taskId };
+  },
+};
+
+const cancelWorkflowScenario: DriftScenario = {
+  id: 'cancel-workflow',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Cancel an entire running workflow',
+  setup: (page, testDir) => setupWithInjectedTaskStatus(page, testDir, 'running', { execution: { phase: 'running' } }),
+  async act(ctx) {
+    await ctx.page.evaluate((workflowId) => window.invoker.cancelWorkflow(workflowId), ctx.workflowId);
+    return { workflowId: ctx.workflowId };
+  },
+};
+
+const approveScenario: DriftScenario = {
+  id: 'approve',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Approve a task awaiting manual approval',
+  setup: (page, testDir) => setupWithInjectedTaskStatus(page, testDir, 'awaiting_approval'),
+  async act(ctx) {
+    await ctx.page.evaluate((taskId) => window.invoker.approve(taskId), ctx.taskId);
+    return { workflowId: ctx.workflowId, taskId: ctx.taskId };
+  },
+};
+
+const rejectScenario: DriftScenario = {
+  id: 'reject',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Reject a task awaiting manual approval',
+  setup: (page, testDir) => setupWithInjectedTaskStatus(page, testDir, 'awaiting_approval'),
+  async act(ctx) {
+    await ctx.page.evaluate((taskId) => window.invoker.reject(taskId, 'drift-scenario-reject'), ctx.taskId);
+    return { workflowId: ctx.workflowId, taskId: ctx.taskId };
+  },
+};
+
+const provideInputScenario: DriftScenario = {
+  id: 'provide-input',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Provide input to a task waiting on it',
+  setup: (page, testDir) => setupWithInjectedTaskStatus(page, testDir, 'needs_input'),
+  async act(ctx) {
+    await ctx.page.evaluate((taskId) => window.invoker.provideInput(taskId, 'drift-scenario-input'), ctx.taskId);
+    return { workflowId: ctx.workflowId, taskId: ctx.taskId };
+  },
+};
+
+const selectExperimentScenario: DriftScenario = {
+  id: 'select-experiment',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Select an experiment variant on a task with pending variants',
+  async setup(page, testDir) {
+    const experimentPlan = {
+      name: 'drift scenario select-experiment',
+      repoUrl: E2E_REPO_URL,
+      onFinish: 'none' as const,
+      tasks: [
+        {
+          id: 'task-gamma',
+          description: 'Reconciliation task',
+          command: 'echo gamma',
+          dependencies: [],
+          experimentVariants: [
+            { id: 'variant-a', description: 'Variant A', command: 'echo A' },
+            { id: 'variant-b', description: 'Variant B', command: 'echo B' },
+          ],
+        },
+      ],
+    };
+    const workflowId = await loadPlanAndGetWorkflowId(page, experimentPlan);
+    await injectTaskStates(page, [{ taskId: 'task-gamma', changes: { status: 'needs_input' as never } }]);
+    const taskId = await resolvedTaskId(page, 'task-gamma');
+    return { page, testDir, workflowId, taskId };
+  },
+  async act(ctx) {
+    await ctx.page.evaluate((taskId) => window.invoker.selectExperiment(taskId, 'variant-a'), ctx.taskId);
+    return { workflowId: ctx.workflowId, taskId: ctx.taskId };
+  },
+};
+
+const editTaskCommandScenario: DriftScenario = {
+  id: 'edit-task-command',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Edit a pending task\'s command',
+  async setup(page, testDir) {
+    const workflowId = await loadPlanAndGetWorkflowId(page, plan('drift scenario edit-command'));
+    const taskId = await resolvedTaskId(page, 'task-alpha');
+    return { page, testDir, workflowId, taskId };
+  },
+  async act(ctx) {
+    await ctx.page.evaluate((taskId) => window.invoker.editTaskCommand(taskId, 'echo edited'), ctx.taskId);
+    return { workflowId: ctx.workflowId, taskId: ctx.taskId };
+  },
+};
+
+const editTaskPromptScenario: DriftScenario = {
+  id: 'edit-task-prompt',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Edit a pending task\'s prompt',
+  async setup(page, testDir) {
+    const workflowId = await loadPlanAndGetWorkflowId(page, plan('drift scenario edit-prompt'));
+    const taskId = await resolvedTaskId(page, 'task-alpha');
+    return { page, testDir, workflowId, taskId };
+  },
+  async act(ctx) {
+    await ctx.page.evaluate((taskId) => window.invoker.editTaskPrompt(taskId, 'edited prompt'), ctx.taskId);
+    return { workflowId: ctx.workflowId, taskId: ctx.taskId };
+  },
+};
+
+const resolveConflictScenario: DriftScenario = {
+  id: 'resolve-conflict',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Resolve a merge conflict on a failed task',
+  setup: (page, testDir) => setupWithInjectedTaskStatus(page, testDir, 'failed', { execution: { exitCode: 1 } }),
+  async act(ctx) {
+    await ctx.page.evaluate((taskId) => window.invoker.resolveConflict(taskId), ctx.taskId);
+    return { workflowId: ctx.workflowId, taskId: ctx.taskId };
+  },
+};
+
+const fixWithAgentScenario: DriftScenario = {
+  id: 'fix-with-agent',
+  channel: 'task-delta',
+  driver: 'ipc',
+  description: 'Fix a failed task with an agent',
+  setup: (page, testDir) => setupWithInjectedTaskStatus(page, testDir, 'failed', { execution: { exitCode: 1 } }),
+  async act(ctx) {
+    await ctx.page.evaluate((taskId) => window.invoker.fixWithAgent(taskId), ctx.taskId);
+    return { workflowId: ctx.workflowId, taskId: ctx.taskId };
+  },
+};
+
+// ── Workflow-metadata channel (GUI-IPC driven) ──────────────
+
+const detachWorkflowScenario: DriftScenario = {
+  id: 'detach-workflow',
+  channel: 'workflow-metadata',
+  driver: 'ipc',
+  description: 'Detach a downstream workflow from its upstream external dependency (the flagship reported bug)',
+  async setup(page, testDir) {
+    const upstreamWorkflowId = await loadPlanAndGetWorkflowId(page, plan('drift scenario detach upstream'));
+    const downstreamPlan = {
+      ...plan('drift scenario detach downstream'),
+      externalDependencies: [{ workflowId: upstreamWorkflowId, gatePolicy: 'review_ready' as const }],
+    };
+    const workflowId = await loadPlanAndGetWorkflowId(page, downstreamPlan);
+    return { page, testDir, workflowId, taskId: '', upstreamWorkflowId };
+  },
+  async act(ctx) {
+    if (!ctx.upstreamWorkflowId) throw new Error('detach-workflow scenario missing upstreamWorkflowId');
+    await ctx.page.evaluate(
+      ({ workflowId, upstreamWorkflowId }) => window.invoker.detachWorkflow(workflowId, upstreamWorkflowId),
+      { workflowId: ctx.workflowId, upstreamWorkflowId: ctx.upstreamWorkflowId },
+    );
+    return { workflowId: ctx.workflowId };
+  },
+};
+
+const deleteWorkflowScenario: DriftScenario = {
+  id: 'delete-workflow',
+  channel: 'workflow-metadata',
+  driver: 'ipc',
+  description: 'Delete an entire workflow',
+  async setup(page, testDir) {
+    const workflowId = await loadPlanAndGetWorkflowId(page, plan('drift scenario delete-workflow'));
+    return { page, testDir, workflowId, taskId: '' };
+  },
+  async act(ctx) {
+    await ctx.page.evaluate((workflowId) => window.invoker.deleteWorkflow(workflowId), ctx.workflowId);
+    return { workflowId: ctx.workflowId };
+  },
+};
+
+const deleteTaskScenario: DriftScenario = {
+  id: 'delete-task',
+  channel: 'workflow-metadata',
+  driver: 'ipc',
+  description: 'Delete a single task',
+  async setup(page, testDir) {
+    const workflowId = await loadPlanAndGetWorkflowId(page, plan('drift scenario delete-task'));
+    const taskId = await resolvedTaskId(page, 'task-beta');
+    return { page, testDir, workflowId, taskId };
+  },
+  async act(ctx) {
+    await ctx.page.evaluate((taskId) => window.invoker.deleteTask(taskId), ctx.taskId);
+    return { workflowId: ctx.workflowId, taskId: ctx.taskId };
+  },
+};
+
+const deleteAllWorkflowsScenario: DriftScenario = {
+  id: 'delete-all-workflows',
+  channel: 'workflow-metadata',
+  driver: 'ipc',
+  description: 'Delete every workflow at once',
+  async setup(page, testDir) {
+    const workflowId = await loadPlanAndGetWorkflowId(page, plan('drift scenario delete-all'));
+    return { page, testDir, workflowId, taskId: '' };
+  },
+  async act(ctx) {
+    await ctx.page.evaluate(() => window.invoker.deleteAllWorkflows());
+    return { workflowId: ctx.workflowId };
+  },
+};
+
+const setMergeModeScenario: DriftScenario = {
+  id: 'set-merge-mode',
+  channel: 'workflow-metadata',
+  driver: 'ipc',
+  description: 'Change a workflow\'s merge mode',
+  async setup(page, testDir) {
+    const workflowId = await loadPlanAndGetWorkflowId(page, plan('drift scenario set-merge-mode'));
+    return { page, testDir, workflowId, taskId: '' };
+  },
+  async act(ctx) {
+    await ctx.page.evaluate((workflowId) => window.invoker.setMergeMode(workflowId, 'automatic'), ctx.workflowId);
+    return { workflowId: ctx.workflowId };
+  },
+};
+
+const setMergeBranchScenario: DriftScenario = {
+  id: 'set-merge-branch',
+  channel: 'workflow-metadata',
+  driver: 'ipc',
+  description: 'Change a workflow\'s base branch',
+  async setup(page, testDir) {
+    const workflowId = await loadPlanAndGetWorkflowId(page, plan('drift scenario set-merge-branch'));
+    return { page, testDir, workflowId, taskId: '' };
+  },
+  async act(ctx) {
+    await ctx.page.evaluate((workflowId) => window.invoker.setMergeBranch(workflowId, 'main'), ctx.workflowId);
+    return { workflowId: ctx.workflowId };
+  },
+};
+
+// ── Workflow-metadata channel (headless-CLI only — no GUI IPC handler exists) ──
+
+const forkWorkflowScenario: DriftScenario = {
+  id: 'fork-workflow',
+  channel: 'workflow-metadata',
+  driver: 'headless-cli',
+  description: 'Fork a workflow into a new one (headless-only, no GUI button)',
+  async setup(page, testDir) {
+    const workflowId = await loadPlanAndGetWorkflowId(page, plan('drift scenario fork-workflow'));
+    return { page, testDir, workflowId, taskId: '' };
+  },
+  async act(ctx) {
+    const before = await listWorkflowIds(ctx.page);
+    await runHeadlessClient(ctx.testDir, ['fork-workflow', ctx.workflowId]);
+    const after = await ctx.page.evaluate(() => window.invoker.listWorkflows());
+    const forked = after.find((workflow: { id: string }) => !before.has(workflow.id));
+    return { workflowId: forked?.id ?? ctx.workflowId };
+  },
+};
+
+const setWorkflowMetadataScenario: DriftScenario = {
+  id: 'set-workflow-metadata',
+  channel: 'workflow-metadata',
+  driver: 'headless-cli',
+  description: 'Set an arbitrary workflow metadata field (headless-only, no GUI button)',
+  async setup(page, testDir) {
+    const workflowId = await loadPlanAndGetWorkflowId(page, plan('drift scenario set-workflow-metadata'));
+    return { page, testDir, workflowId, taskId: '' };
+  },
+  async act(ctx) {
+    await runHeadlessClient(ctx.testDir, ['set', 'workflow', ctx.workflowId, 'baseBranch', 'main']);
+    return { workflowId: ctx.workflowId };
+  },
+};
+
+const setTaskMetadataScenario: DriftScenario = {
+  id: 'set-task-metadata',
+  channel: 'workflow-metadata',
+  driver: 'headless-cli',
+  description: 'Set an arbitrary task metadata field (headless-only, no GUI button)',
+  async setup(page, testDir) {
+    const workflowId = await loadPlanAndGetWorkflowId(page, plan('drift scenario set-task-metadata'));
+    const taskId = await resolvedTaskId(page, 'task-alpha');
+    return { page, testDir, workflowId, taskId };
+  },
+  async act(ctx) {
+    await runHeadlessClient(ctx.testDir, ['set', 'task', ctx.taskId, 'description', 'edited via headless']);
+    return { workflowId: ctx.workflowId, taskId: ctx.taskId };
+  },
+};
+
+const setGatePolicyScenario: DriftScenario = {
+  id: 'set-gate-policy',
+  channel: 'workflow-metadata',
+  driver: 'headless-cli',
+  description: 'Set an external gate policy on a task\'s upstream dependency (headless-only, no GUI button)',
+  async setup(page, testDir) {
+    // set-gate-policy operates on an existing external dependency: `<taskId>
+    // <upstreamWorkflowId> <policy>` updates how `taskId` gates on
+    // `upstreamWorkflowId`'s merge node. Needs the same upstream/downstream
+    // link as detach-workflow.
+    const upstreamWorkflowId = await loadPlanAndGetWorkflowId(page, plan('drift scenario set-gate-policy upstream'));
+    const downstreamPlan = {
+      ...plan('drift scenario set-gate-policy downstream'),
+      externalDependencies: [{ workflowId: upstreamWorkflowId, gatePolicy: 'review_ready' as const }],
+    };
+    const workflowId = await loadPlanAndGetWorkflowId(page, downstreamPlan);
+    const taskId = await resolvedTaskId(page, `__merge__${workflowId}`);
+    return { page, testDir, workflowId, taskId, upstreamWorkflowId };
+  },
+  async act(ctx) {
+    if (!ctx.upstreamWorkflowId) throw new Error('set-gate-policy scenario missing upstreamWorkflowId');
+    // 'ci_failed' can never be immediately satisfied by the still-pending
+    // upstream, unlike 'completed'/'review_ready' -- avoids triggering a real
+    // task dispatch as a side effect of the metadata edit under test.
+    await runHeadlessClient(ctx.testDir, ['set', 'gate-policy', ctx.taskId, ctx.upstreamWorkflowId, 'ci_failed']);
+    return { workflowId: ctx.workflowId, taskId: ctx.taskId };
+  },
+};
+
+const setFixPromptScenario: DriftScenario = {
+  id: 'set-fix-prompt',
+  channel: 'workflow-metadata',
+  driver: 'headless-cli',
+  description: 'Set a task\'s fix prompt (headless-only, no GUI button)',
+  setup: (page, testDir) => setupWithInjectedTaskStatus(page, testDir, 'failed', { execution: { exitCode: 1 } }),
+  async act(ctx) {
+    await runHeadlessClient(ctx.testDir, ['set', 'fix-prompt', ctx.taskId, 'edited fix prompt', '--no-track']);
+    return { workflowId: ctx.workflowId, taskId: ctx.taskId };
+  },
+};
+
+export const DRIFT_SCENARIOS: readonly DriftScenario[] = [
+  runScenario,
+  retryTaskScenario,
+  retryWorkflowScenario,
+  recreateTaskScenario,
+  recreateWorkflowScenario,
+  recreateDownstreamScenario,
+  rebaseRetryScenario,
+  rebaseRecreateScenario,
+  cancelTaskScenario,
+  cancelWorkflowScenario,
+  approveScenario,
+  rejectScenario,
+  provideInputScenario,
+  selectExperimentScenario,
+  editTaskCommandScenario,
+  editTaskPromptScenario,
+  resolveConflictScenario,
+  fixWithAgentScenario,
+  detachWorkflowScenario,
+  deleteWorkflowScenario,
+  deleteTaskScenario,
+  deleteAllWorkflowsScenario,
+  setMergeModeScenario,
+  setMergeBranchScenario,
+  forkWorkflowScenario,
+  setWorkflowMetadataScenario,
+  setTaskMetadataScenario,
+  setGatePolicyScenario,
+  setFixPromptScenario,
+];
+
+export function scenarioById(id: string): DriftScenario {
+  const found = DRIFT_SCENARIOS.find((scenario) => scenario.id === id);
+  if (!found) throw new Error(`Unknown drift scenario id "${id}"`);
+  return found;
+}

--- a/packages/app/e2e/drift/trace-compare.ts
+++ b/packages/app/e2e/drift/trace-compare.ts
@@ -1,0 +1,387 @@
+/**
+ * Backend-vs-renderer drift comparator, generalized from the Python
+ * compare_timelines() logic in scripts/repro/repro-ui-delta-timeline.sh to
+ * cover both trace channels documented in docs/ui-backend-drift-tracing.md.
+ */
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+export interface AcceptanceFailure {
+  kind: string;
+  message: string;
+  /**
+   * Whether this finding alone should fail the drift check. Non-blocking
+   * findings (e.g. a duplicate re-send by the DB-polling reconciliation
+   * safety net, renderer-task-feed.ts:335-355) are reported for diagnostic
+   * value but don't indicate visible drift by themselves -- only a wrong
+   * *final* state, or the renderer never seeing something at all, does.
+   */
+  blocking: boolean;
+  [key: string]: unknown;
+}
+
+export interface TimelineComparisonResult {
+  ok: boolean;
+  acceptanceFailures: AcceptanceFailure[];
+  backendCount: number;
+  rendererCount: number;
+}
+
+export function traceHomeDir(testDir: string): string {
+  return path.join(testDir, 'home', '.invoker');
+}
+
+function readJsonLines(filePath: string): Record<string, unknown>[] {
+  let text: string;
+  try {
+    text = readFileSync(filePath, 'utf8');
+  } catch {
+    return [];
+  }
+  const rows: Record<string, unknown>[] = [];
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      rows.push(JSON.parse(line));
+    } catch {
+      continue;
+    }
+  }
+  return rows;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      return Object.keys(val).sort().reduce((acc: Record<string, unknown>, key) => {
+        acc[key] = (val as Record<string, unknown>)[key];
+        return acc;
+      }, {});
+    }
+    return val;
+  });
+}
+
+// ── Task-delta channel ──────────────────────────────────────
+
+interface TaskDeltaRecord {
+  time?: string;
+  delta: Record<string, unknown>;
+}
+
+function taskIdFor(delta: Record<string, unknown>): string | undefined {
+  if (delta.type === 'created') {
+    const task = (delta.task ?? {}) as Record<string, unknown>;
+    return task.id as string | undefined;
+  }
+  return delta.taskId as string | undefined;
+}
+
+function belongsToWorkflow(delta: unknown, workflowId: string): boolean {
+  if (!delta || typeof delta !== 'object') return false;
+  const record = delta as Record<string, unknown>;
+  const mergeId = `__merge__${workflowId}`;
+  if (record.type === 'created') {
+    const task = (record.task ?? {}) as Record<string, unknown>;
+    const taskId = String(task.id ?? '');
+    const config = (task.config ?? {}) as Record<string, unknown>;
+    return (
+      taskId === mergeId ||
+      taskId === workflowId ||
+      config.workflowId === workflowId ||
+      taskId.startsWith(`${workflowId}/`)
+    );
+  }
+  const taskId = String(record.taskId ?? '');
+  return taskId === mergeId || taskId === workflowId || taskId.startsWith(`${workflowId}/`);
+}
+
+function scrub(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(scrub);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      if (key === 'streamSequence') continue;
+      out[key] = scrub(val);
+    }
+    return out;
+  }
+  return value;
+}
+
+function readBackendTaskDeltas(testDir: string, workflowId: string): TaskDeltaRecord[] {
+  const logPath = path.join(traceHomeDir(testDir), 'invoker.log');
+  const marker = 'delta→ui:';
+  const records: TaskDeltaRecord[] = [];
+  for (const row of readJsonLines(logPath)) {
+    const msg = String(row.msg ?? '');
+    if (row.module !== 'ui' || !msg.includes(marker)) continue;
+    const raw = msg.slice(msg.indexOf(marker) + marker.length).trim();
+    let delta: Record<string, unknown>;
+    try {
+      delta = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    if (belongsToWorkflow(delta, workflowId)) {
+      records.push({ time: row.time as string | undefined, delta });
+    }
+  }
+  return records;
+}
+
+function readRendererTaskDeltas(testDir: string, workflowId: string): TaskDeltaRecord[] {
+  const jsonlPath = path.join(traceHomeDir(testDir), 'ui-task-graph-events.jsonl');
+  const records: TaskDeltaRecord[] = [];
+  for (const row of readJsonLines(jsonlPath)) {
+    const event = (row.event ?? {}) as Record<string, unknown>;
+    if (event.type !== 'delta') continue;
+    const delta = event.delta as Record<string, unknown>;
+    if (belongsToWorkflow(delta, workflowId)) {
+      records.push({ time: row.time as string | undefined, delta });
+    }
+  }
+  return records;
+}
+
+function finalTaskState(records: TaskDeltaRecord[]): Map<string, Record<string, unknown>> {
+  const tasks = new Map<string, Record<string, unknown>>();
+  for (const { delta } of records) {
+    const id = taskIdFor(delta);
+    if (!id) continue;
+    if (delta.type === 'created') {
+      tasks.set(id, delta.task as Record<string, unknown>);
+    } else if (delta.type === 'removed') {
+      tasks.delete(id);
+    } else if (delta.type === 'updated') {
+      const previous = tasks.get(id) ?? {};
+      const changes = (delta.changes ?? {}) as Record<string, unknown>;
+      tasks.set(id, { ...previous, ...changes, taskStateVersion: delta.taskStateVersion });
+    }
+  }
+  return tasks;
+}
+
+function summarizeTasks(tasks: Map<string, Record<string, unknown>>): Record<string, { status?: unknown; phase?: unknown }> {
+  const out: Record<string, { status?: unknown; phase?: unknown }> = {};
+  for (const [id, task] of tasks) {
+    const execution = (task.execution ?? {}) as Record<string, unknown>;
+    out[id] = { status: task.status, phase: execution.phase };
+  }
+  return out;
+}
+
+/** Diffs the task-delta channel (delta→ui: / ui-task-graph-events.jsonl) for one workflow. */
+export function compareTaskDeltaTimeline(testDir: string, workflowId: string): TimelineComparisonResult {
+  const backend = readBackendTaskDeltas(testDir, workflowId);
+  const renderer = readRendererTaskDeltas(testDir, workflowId);
+  const backendCanonical = backend.map((r) => scrub(r.delta));
+  const rendererCanonical = renderer.map((r) => scrub(r.delta));
+
+  const acceptanceFailures: AcceptanceFailure[] = [];
+  const minLen = Math.min(backendCanonical.length, rendererCanonical.length);
+  for (let i = 0; i < minLen; i += 1) {
+    if (stableStringify(backendCanonical[i]) !== stableStringify(rendererCanonical[i])) {
+      // Informational only: the DB-polling reconciliation safety net
+      // (renderer-task-feed.ts:335-355) can independently re-publish a
+      // duplicate `type: 'created'` for a task the renderer already knows
+      // about (most often triggered by test-only shortcuts like
+      // injectTaskStates that write the DB directly). That reorders/pads the
+      // raw sequence without changing the converged final state, so it
+      // doesn't indicate drift by itself -- see the final-state check below.
+      acceptanceFailures.push({
+        kind: 'sequence-mismatch',
+        message: `backend and renderer task-delta timelines diverge at index ${i}`,
+        blocking: false,
+        index: i,
+        backend: backend[i],
+        renderer: renderer[i],
+      });
+      break;
+    }
+  }
+  if (backendCanonical.length !== rendererCanonical.length) {
+    const rendererHasFewer = backendCanonical.length > rendererCanonical.length;
+    acceptanceFailures.push({
+      kind: rendererHasFewer ? 'missing-renderer-event' : 'renderer-extra-event',
+      message: `backend emitted ${backendCanonical.length} task delta(s), renderer recorded ${rendererCanonical.length}`,
+      // Renderer receiving fewer events than the backend sent is the real
+      // signature of drift; renderer receiving *more* (harmless duplicate
+      // resends) is not, on its own.
+      blocking: rendererHasFewer,
+      backendCount: backendCanonical.length,
+      rendererCount: rendererCanonical.length,
+    });
+  }
+
+  const backendFinal = summarizeTasks(finalTaskState(backend));
+  const rendererFinal = summarizeTasks(finalTaskState(renderer));
+  if (stableStringify(backendFinal) !== stableStringify(rendererFinal)) {
+    acceptanceFailures.push({
+      kind: 'final-task-state-mismatch',
+      message: 'final backend and renderer task states disagree',
+      blocking: true,
+      backend: backendFinal,
+      renderer: rendererFinal,
+    });
+  }
+
+  return {
+    ok: !acceptanceFailures.some((failure) => failure.blocking),
+    acceptanceFailures,
+    backendCount: backendCanonical.length,
+    rendererCount: rendererCanonical.length,
+  };
+}
+
+// ── Workflow-metadata channel ───────────────────────────────
+
+interface WorkflowMetadataRecord {
+  time?: string;
+  dropped?: boolean;
+  coalescedRequests?: number;
+  reasonCounts?: Record<string, number>;
+  workflows: Array<Record<string, unknown>>;
+}
+
+interface WorkflowSnapshotFields {
+  id: unknown;
+  status?: unknown;
+  mergeMode?: unknown;
+  baseBranch?: unknown;
+  externalDependencies?: unknown;
+  generation?: unknown;
+}
+
+function pickWorkflowFields(workflow: Record<string, unknown> | undefined): WorkflowSnapshotFields {
+  return {
+    id: workflow?.id,
+    status: workflow?.status,
+    mergeMode: workflow?.mergeMode,
+    baseBranch: workflow?.baseBranch,
+    externalDependencies: workflow?.externalDependencies,
+    generation: workflow?.generation,
+  };
+}
+
+function readBackendWorkflowMetadataEvents(testDir: string): WorkflowMetadataRecord[] {
+  const logPath = path.join(traceHomeDir(testDir), 'invoker.log');
+  const marker = 'workflow→ui:';
+  const records: WorkflowMetadataRecord[] = [];
+  for (const row of readJsonLines(logPath)) {
+    const msg = String(row.msg ?? '');
+    if (row.module !== 'ui' || !msg.includes(marker)) continue;
+    const raw = msg.slice(msg.indexOf(marker) + marker.length).trim();
+    let payload: Record<string, unknown>;
+    try {
+      payload = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    records.push({
+      time: row.time as string | undefined,
+      dropped: payload.dropped as boolean | undefined,
+      coalescedRequests: payload.coalescedRequests as number | undefined,
+      reasonCounts: payload.reasonCounts as Record<string, number> | undefined,
+      workflows: (payload.workflows as Array<Record<string, unknown>>) ?? [],
+    });
+  }
+  return records;
+}
+
+function readRendererWorkflowMetadataEvents(testDir: string): WorkflowMetadataRecord[] {
+  const jsonlPath = path.join(traceHomeDir(testDir), 'ui-workflow-events.jsonl');
+  const records: WorkflowMetadataRecord[] = [];
+  for (const row of readJsonLines(jsonlPath)) {
+    const event = (row.event ?? {}) as Record<string, unknown>;
+    if (event.type !== 'workflows-changed') continue;
+    records.push({
+      time: row.time as string | undefined,
+      workflows: (event.workflows as Array<Record<string, unknown>>) ?? [],
+    });
+  }
+  return records;
+}
+
+/** Diffs the workflow-metadata channel (workflow→ui: / ui-workflow-events.jsonl) for one workflow. */
+export function compareWorkflowMetadataTimeline(testDir: string, workflowId: string): TimelineComparisonResult {
+  const backend = readBackendWorkflowMetadataEvents(testDir);
+  const renderer = readRendererWorkflowMetadataEvents(testDir);
+  const acceptanceFailures: AcceptanceFailure[] = [];
+
+  const backendRows = backend.filter((row) => row.workflows.some((w) => w?.id === workflowId));
+  const rendererRows = renderer.filter((row) => row.workflows.some((w) => w?.id === workflowId));
+
+  if (backendRows.length === 0) {
+    // Every scenario tagged 'workflow-metadata' is expected to trigger a publish
+    // attempt for its workflow. Zero rows means the mutation path never called
+    // requestWorkflowMetadataPublish at all (e.g. the headless CLI dispatch gap
+    // documented in docs/ui-backend-drift-tracing.md) -- that is itself a drift
+    // finding, not something to pass silently.
+    return {
+      ok: false,
+      acceptanceFailures: [{
+        kind: 'workflow-metadata-publish-never-triggered',
+        message: `no workflow→ui: publish was observed for ${workflowId} at all after a workflow-metadata-channel operation`,
+        blocking: true,
+      }],
+      backendCount: 0,
+      rendererCount: renderer.filter((row) => row.workflows.some((w) => w?.id === workflowId)).length,
+    };
+  }
+
+  const lastBackendRow = backendRows[backendRows.length - 1];
+  const lastNonDroppedBackendRow = [...backendRows].reverse().find((row) => row.dropped !== true);
+
+  if (rendererRows.length === 0) {
+    acceptanceFailures.push({
+      kind: 'workflow-metadata-never-republished',
+      message: `backend published ${backendRows.length} workflow-metadata event(s) for ${workflowId} but the renderer never received onWorkflowsChanged for it`,
+      blocking: true,
+      backendCount: backendRows.length,
+    });
+  }
+
+  if (lastBackendRow.dropped === true) {
+    acceptanceFailures.push({
+      kind: 'workflow-publish-dropped-noninteractive',
+      message: `last workflow-metadata publish for ${workflowId} was dropped (window not interactive); no retry exists today`,
+      blocking: true,
+      coalescedRequests: lastBackendRow.coalescedRequests,
+      reasonCounts: lastBackendRow.reasonCounts,
+    });
+  }
+
+  if (lastNonDroppedBackendRow && rendererRows.length > 0) {
+    const backendWorkflow = pickWorkflowFields(lastNonDroppedBackendRow.workflows.find((w) => w?.id === workflowId));
+    const lastRendererRow = rendererRows[rendererRows.length - 1];
+    const rendererWorkflow = pickWorkflowFields(lastRendererRow.workflows.find((w) => w?.id === workflowId));
+    if (stableStringify(backendWorkflow) !== stableStringify(rendererWorkflow)) {
+      acceptanceFailures.push({
+        kind: 'stale-workflow-field-after-op',
+        message: `renderer's workflow fields for ${workflowId} disagree with the last successfully published backend state`,
+        blocking: true,
+        backend: backendWorkflow,
+        renderer: rendererWorkflow,
+      });
+    }
+  }
+
+  return {
+    ok: !acceptanceFailures.some((failure) => failure.blocking),
+    acceptanceFailures,
+    backendCount: backendRows.length,
+    rendererCount: rendererRows.length,
+  };
+}
+
+/** Dispatches to the right comparator for a scenario's channel. */
+export function compareDriftTimeline(
+  channel: 'task-delta' | 'workflow-metadata',
+  testDir: string,
+  workflowId: string,
+): TimelineComparisonResult {
+  return channel === 'task-delta'
+    ? compareTaskDeltaTimeline(testDir, workflowId)
+    : compareWorkflowMetadataTimeline(testDir, workflowId);
+}

--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -50,7 +50,7 @@ async function removeTestDir(dir: string): Promise<void> {
   throw lastError;
 }
 
-async function deleteAllWorkflowsFast(page: Page): Promise<void> {
+export async function deleteAllWorkflowsFast(page: Page): Promise<void> {
   await page.evaluate(async () => {
     const invoker = window.invoker as typeof window.invoker & {
       deleteAllWorkflowsBulk?: () => Promise<unknown>;

--- a/packages/app/e2e/fixtures/headless-client.ts
+++ b/packages/app/e2e/fixtures/headless-client.ts
@@ -1,0 +1,56 @@
+import { execFile } from 'node:child_process';
+import * as path from 'node:path';
+import { writeFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
+import { resolveRepoRoot } from '@invoker/contracts';
+
+const execFileAsync = promisify(execFile);
+const repoRoot = resolveRepoRoot(__dirname);
+
+export async function ensureHeadlessTestConfig(testDir: string): Promise<void> {
+  await writeFile(path.join(testDir, 'e2e-config.json'), JSON.stringify({ autoFixRetries: 0 }), 'utf8');
+}
+
+export function headlessTestEnv(testDir: string): NodeJS.ProcessEnv {
+  const configPath = path.join(testDir, 'e2e-config.json');
+  const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+  return {
+    ...process.env,
+    NODE_ENV: 'test',
+    INVOKER_TEST_WORKFLOW_IDS: '1',
+    TZ: 'UTC',
+    INVOKER_DB_DIR: testDir,
+    INVOKER_IPC_SOCKET: ipcSocketPath,
+    INVOKER_REPO_CONFIG_PATH: configPath,
+  };
+}
+
+export async function runHeadlessClient(testDir: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  await ensureHeadlessTestConfig(testDir);
+  const clientPath = path.join(repoRoot, 'packages', 'app', 'dist', 'headless-client.js');
+  return await execFileAsync('node', [clientPath, ...args], {
+    cwd: repoRoot,
+    env: headlessTestEnv(testDir),
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}
+
+export function parseWorkflowId(stdout: string): string {
+  const delegated = stdout.match(/Delegated to owner — workflow: (wf-[^\s]+)/);
+  if (delegated?.[1]) return delegated[1];
+  const direct = stdout.match(/Workflow ID: (wf-[^\s]+)/);
+  if (direct?.[1]) return direct[1];
+  throw new Error(`No workflow id found in stdout:\n${stdout}`);
+}
+
+export function expectDelegated(stdout: string): void {
+  if (!stdout.includes('Delegated to owner')) {
+    throw new Error(`Expected headless command to delegate to owner, got stdout:\n${stdout}`);
+  }
+}
+
+export function parseJsonStdout(stdout: string): Record<string, unknown> {
+  const line = stdout.split(/\r?\n/).map((entry) => entry.trim()).find((entry) => entry.startsWith('{'));
+  if (!line) throw new Error(`No JSON object found in stdout:\n${stdout}`);
+  return JSON.parse(line) as Record<string, unknown>;
+}

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -1,7 +1,5 @@
-import { execFile } from 'node:child_process';
 import { mkdir, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
-import { promisify } from 'node:util';
 import { _electron as electron, type Page } from '@playwright/test';
 import { resolveRepoRoot } from '@invoker/contracts';
 import { stringify as yamlStringify } from 'yaml';
@@ -20,10 +18,17 @@ import {
   numberOrZero,
   uiPerfPayloadsSince,
 } from './fixtures/ui-perf.js';
+import {
+  ensureHeadlessTestConfig,
+  expectDelegated,
+  headlessTestEnv,
+  parseJsonStdout,
+  parseWorkflowId,
+  runHeadlessClient,
+} from './fixtures/headless-client.js';
 
 test.use({ guiOwnerMode: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'daemon' });
 
-const execFileAsync = promisify(execFile);
 const repoRoot = resolveRepoRoot(__dirname);
 const RESPONSIVE_INTERACTION_TIMEOUT_MS = 15000;
 const MAX_INSPECTOR_TOGGLE_MS = 5000;
@@ -55,52 +60,6 @@ const HEADLESS_HERD_UI_PLAN = {
     },
   ],
 };
-
-async function ensureHeadlessTestConfig(testDir: string): Promise<void> {
-  await writeFile(path.join(testDir, 'e2e-config.json'), JSON.stringify({ autoFixRetries: 0 }), 'utf8');
-}
-
-function headlessTestEnv(testDir: string): NodeJS.ProcessEnv {
-  const configPath = path.join(testDir, 'e2e-config.json');
-  const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
-  return {
-    ...process.env,
-    NODE_ENV: 'test',
-    INVOKER_TEST_WORKFLOW_IDS: '1',
-    TZ: 'UTC',
-    INVOKER_DB_DIR: testDir,
-    INVOKER_IPC_SOCKET: ipcSocketPath,
-    INVOKER_REPO_CONFIG_PATH: configPath,
-  };
-}
-
-async function runHeadlessClient(testDir: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
-  await ensureHeadlessTestConfig(testDir);
-  const clientPath = path.join(repoRoot, 'packages', 'app', 'dist', 'headless-client.js');
-  return await execFileAsync('node', [clientPath, ...args], {
-    cwd: repoRoot,
-    env: headlessTestEnv(testDir),
-    maxBuffer: 10 * 1024 * 1024,
-  });
-}
-
-function parseWorkflowId(stdout: string): string {
-  const delegated = stdout.match(/Delegated to owner — workflow: (wf-[^\s]+)/);
-  if (delegated?.[1]) return delegated[1];
-  const direct = stdout.match(/Workflow ID: (wf-[^\s]+)/);
-  if (direct?.[1]) return direct[1];
-  throw new Error(`No workflow id found in stdout:\n${stdout}`);
-}
-
-function expectDelegated(stdout: string): void {
-  expect(stdout).toContain('Delegated to owner');
-}
-
-function parseJsonStdout(stdout: string): Record<string, unknown> {
-  const line = stdout.split(/\r?\n/).map((entry) => entry.trim()).find((entry) => entry.startsWith('{'));
-  if (!line) throw new Error(`No JSON object found in stdout:\n${stdout}`);
-  return JSON.parse(line) as Record<string, unknown>;
-}
 
 async function measureInspectorToggleResponsive(page: Page, timeoutMs: number, label: string): Promise<number> {
   const sidebarToggle = page.getByTestId('sidebar-collapse-toggle');

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -40,7 +40,7 @@ export const HEADLESS_COMMANDS = [
   { name: 'recreate-task', kind: 'write' },
   { name: 'recreate-downstream', kind: 'write' },
   { name: 'replace-task', kind: 'special' },
-  { name: 'fork-workflow', kind: 'special' },
+  { name: 'fork-workflow', kind: 'write' },
   { name: 'detach-workflow', kind: 'write' },
   { name: 'rebase-retry', kind: 'write' },
   { name: 'rebase-recreate', kind: 'write' },

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1919,6 +1919,32 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     }
   });
 
+  const traceRendererWorkflowEvents = process.env.INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS === '1';
+  const rendererWorkflowTracePath = join(homedir(), '.invoker', 'ui-workflow-events.jsonl');
+  let rendererWorkflowTraceWriteFailed = false;
+  ipcMain.handle('invoker:trace-renderer-workflow-event', (_event, workflows: unknown[]) => {
+    if (!traceRendererWorkflowEvents) return;
+    try {
+      mkdirSync(dirname(rendererWorkflowTracePath), { recursive: true });
+      appendFileSync(
+        rendererWorkflowTracePath,
+        JSON.stringify({
+          time: new Date().toISOString(),
+          source: 'renderer',
+          event: { type: 'workflows-changed', workflows },
+        }) + '\n',
+      );
+    } catch (err) {
+      if (!rendererWorkflowTraceWriteFailed) {
+        rendererWorkflowTraceWriteFailed = true;
+        logger.warn(
+          `renderer workflow trace write failed: ${err instanceof Error ? err.message : String(err)}`,
+          { module: 'ui' },
+        );
+      }
+    }
+  });
+
   ipcMain.handle('invoker:get-ui-perf-stats', () => ({
     ...getUiPerfStats(),
   }));

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2042,6 +2042,7 @@ startMainProcessBootstrap({
   let uiInteractive = false;
   let deferredStartupTriggered = false;
   const traceUiDeltaFlow = process.env.INVOKER_TRACE_UI_DELTA === '1';
+  const traceUiWorkflowDeltaFlow = process.env.INVOKER_TRACE_UI_WORKFLOW_DELTA === '1';
   const traceDbPollPerTask = process.env.INVOKER_TRACE_DB_POLL === '1';
   const traceTaskOutput = process.env.INVOKER_TRACE_TASK_OUTPUT === '1';
   const executingStallTimeoutMs = Number.parseInt(
@@ -2278,10 +2279,30 @@ startMainProcessBootstrap({
           { module: 'ui-backpressure', reasonCounts: stats.reasonCounts },
         );
       }
-      if (!mainWindow || mainWindow.isDestroyed() || !uiInteractive) {
+      const activeWindow = mainWindow && !mainWindow.isDestroyed() && uiInteractive ? mainWindow : null;
+      if (traceUiWorkflowDeltaFlow) {
+        logger.debug(
+          `workflow→ui: ${JSON.stringify({
+            dropped: !activeWindow,
+            coalescedRequests: stats.coalescedRequests,
+            reasonCounts: stats.reasonCounts,
+            workflows: workflows.map((workflow) => ({
+              id: workflow.id,
+              status: workflow.status,
+              mergeMode: workflow.mergeMode,
+              baseBranch: workflow.baseBranch,
+              externalDependencies: workflow.externalDependencies,
+              generation: workflow.generation,
+              updatedAt: workflow.updatedAt,
+            })),
+          })}`,
+          { module: 'ui' },
+        );
+      }
+      if (!activeWindow) {
         return;
       }
-      mainWindow.webContents.send('invoker:workflows-changed', workflows);
+      activeWindow.webContents.send('invoker:workflows-changed', workflows);
     },
   });
 

--- a/packages/app/src/preload.ts
+++ b/packages/app/src/preload.ts
@@ -114,6 +114,10 @@ contextBridge.exposeInMainWorld(
   '__INVOKER_TRACE_RENDERER_TASK_GRAPH__',
   process.env.INVOKER_TRACE_RENDERER_TASK_GRAPH === '1',
 );
+contextBridge.exposeInMainWorld(
+  '__INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS__',
+  process.env.INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS === '1',
+);
 
 setTimeout(() => {
   ipcRenderer.invoke('invoker:report-ui-perf', 'preload_bootstrap_sync', {

--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -181,10 +181,13 @@ export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTask
 
   const processIncomingTaskDelta = (delta: TaskDelta): void => {
     deps.uiPerfStats.mainDeltaToUi += 1;
-    if (deps.traceUiDeltaFlow) {
-      deps.logger.debug(`delta→ui: ${JSON.stringify(delta)}`, { module: 'ui' });
-    }
     for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(delta)) {
+      if (deps.traceUiDeltaFlow) {
+        // Trace what is actually published to the renderer (post gap-detect
+        // recovery), not the raw input -- recovery can expand one incoming
+        // delta into zero or more re-synthesized renderer deltas.
+        deps.logger.debug(`delta→ui: ${JSON.stringify(rendererDelta)}`, { module: 'ui' });
+      }
       publishTaskDeltaToRenderer(rendererDelta);
     }
   };

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -340,6 +340,7 @@ export function createMockInvoker(
     getActivityLogs: vi.fn(async () => []),
     reportUiPerf: vi.fn(async () => {}),
     traceRendererTaskGraphEvent: vi.fn(async () => {}),
+    traceRendererWorkflowEvent: vi.fn(async () => {}),
     getUiPerfStats: vi.fn(async () => ({})),
     getEvents: vi.fn(async (taskId: string, options?: { limit: number; sortBy?: 'asc' | 'desc'; beforeId?: number }) => {
       const events = [...(eventsByTask.get(taskId) ?? [])];

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -126,6 +126,9 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
   const traceRendererTaskGraphEvents =
     typeof window !== 'undefined' &&
     window.__INVOKER_TRACE_RENDERER_TASK_GRAPH__ === true;
+  const traceRendererWorkflowEvents =
+    typeof window !== 'undefined' &&
+    window.__INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS__ === true;
   const bootstrapState =
     typeof window !== 'undefined' ? window.__INVOKER_BOOTSTRAP__ : undefined;
   const [tasks, setTasks] = useState<Map<string, TaskState>>(() => {
@@ -516,6 +519,12 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
 
     const unsubWf = window.invoker.onWorkflowsChanged?.((wfList: any[]) => {
       invalidateStartupSnapshot();
+      if (traceRendererWorkflowEvents) {
+        const traceRendererWorkflowEvent = window.invoker.traceRendererWorkflowEvent;
+        if (traceRendererWorkflowEvent) {
+          void traceRendererWorkflowEvent(wfList).catch(() => undefined);
+        }
+      }
       if (Array.isArray(wfList)) {
         setWorkflows((previous) => {
           const nextWorkflows = replaceWorkflowMapPreservingTaskBackedEntries(
@@ -552,7 +561,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
       unsub();
       unsubWf?.();
     };
-  }, [invalidateStartupSnapshot, loadStartupSnapshot, onTaskGraphSnapshotApplied, refreshTaskGraph, refreshWorkflowMetadata, traceRendererTaskGraphEvents]);
+  }, [invalidateStartupSnapshot, loadStartupSnapshot, onTaskGraphSnapshotApplied, refreshTaskGraph, refreshWorkflowMetadata, traceRendererTaskGraphEvents, traceRendererWorkflowEvents]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !window.invoker) return;

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -358,6 +358,7 @@ declare global {
       streamSequence?: number;
     };
     __INVOKER_TRACE_RENDERER_TASK_GRAPH__?: boolean;
+    __INVOKER_TRACE_RENDERER_WORKFLOW_EVENTS__?: boolean;
     __INVOKER_TEST_OPEN_TERMINAL__?: (taskId: string) => ReturnType<InvokerAPI['openTerminal']>;
     __INVOKER_TEST_ON_TERMINAL_OUTPUT__?: (cb: (event: TerminalOutputEvent) => void) => () => void;
   }


### PR DESCRIPTION
## Summary

`scripts/repro/repro-ui-delta-timeline.sh` proves the renderer stays in sync with the backend for one scenario: load a plan, then rebase-recreate it.

Everything else -- retry, cancel, approve, a merge-mode change, forking a workflow -- has no coverage. One of those, detaching a workflow, is the case a user recently hit: the graph stayed stale until refreshed by hand.

This adds a Playwright harness under `packages/app/e2e/drift/`. It drives 29 of these operations against a real running app and checks each one against what the renderer actually shows.

Detach-style operations need a live Electron app, not the headless CLI. The headless dispatch path never tells the renderer a workflow changed, so a headless-only check would miss the real bug.

28 of 29 checks pass. The failure is real: forking a workflow never tells the renderer about it. Left failing on purpose, as evidence for a follow-up fix.

## Review Claim

Approve the new `packages/app/e2e/drift/` test harness (scenario catalog, timeline comparator, three spec files) as a self-contained addition, plus the small test-fixture changes it needed (one function now `export`ed, one small file added to hold logic shared between two specs) to avoid duplicating existing e2e code.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Every changed or added file here is test-only: `packages/app/e2e/**` and one small file under `packages/app/e2e/fixtures/**`. Nothing under `packages/app/src`, `packages/ui/src`, or `packages/contracts/src` changes in this slice, so there is no product-code behavior to review here, only whether the checks themselves are sound.

## Slice Rationale

Depends on the four prior slices in this stack (the new trace streams, and both bug fixes) to run cleanly; kept as its own slice so the test harness is reviewed apart from the product changes it exercises.

## Non-goals

Does not fix the one scenario left failing (forking a workflow never publishes to the renderer's workflow list) -- that is real product behavior to change, tracked as follow-up work, not something to fix inside a test-only PR. Does not wire any of these specs into required CI; they stay manually run.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter app build && pnpm --filter @invoker/ui build`
- [ ] `cd packages/app && npx playwright test e2e/drift/drift-single-op.spec.ts --reporter=list` (28/29 pass; `fork-workflow` fails on purpose)
- [ ] `cd packages/app && npx playwright test e2e/drift/drift-thundering-herd.spec.ts --reporter=list`
- [ ] `cd packages/app && npx playwright test e2e/drift/drift-battery.spec.ts --reporter=list`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #6954