### PR TITLE
fix: classify and self-heal corrupt SSH repo mirrors as an infra failure

### DIFF
--- a/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
@@ -106,6 +106,7 @@ function makeHarness(tasksInput: TaskState[] = [makeTask()]) {
     logEvent: vi.fn(),
   };
   const runRemoteProvisionRepairFn = vi.fn(async () => 'remote repair ok');
+  const runRepoMirrorRepairFn = vi.fn(async () => 'mirror repair ok');
   const resolveRemoteBranchOwnerPathFn = vi.fn(async () => undefined as string | undefined);
   let nowMs = Date.parse('2026-01-01T00:00:00.000Z');
   const tick = createInfraRepairTick({
@@ -124,6 +125,7 @@ function makeHarness(tasksInput: TaskState[] = [makeTask()]) {
     },
     repairCooldownMs: 30 * 60 * 1000,
     runRemoteProvisionRepairFn,
+    runRepoMirrorRepairFn,
     resolveRemoteBranchOwnerPathFn,
     now: () => nowMs,
   });
@@ -136,6 +138,7 @@ function makeHarness(tasksInput: TaskState[] = [makeTask()]) {
     tick,
     updateTask,
     runRemoteProvisionRepairFn,
+    runRepoMirrorRepairFn,
     resolveRemoteBranchOwnerPathFn,
     setNow: (nextNowMs: number) => { nowMs = nextNowMs; },
   };
@@ -227,6 +230,65 @@ describe('infra-repair worker', () => {
         }),
       }),
     ]));
+  });
+
+  it('classifies a corrupt repo mirror, removes it remotely, and queues retry-task', async () => {
+    // Repro: SSH bootstrap_clone_fetch hits a mirror whose .git/ exists but is
+    // corrupt (present but missing HEAD/config/objects) -- git's own fetch
+    // fails with "not a git repository" because buildMirrorCloneScript only
+    // checks directory existence, not repo validity, before skipping clone.
+    const h = makeHarness([
+      makeTask({
+        execution: {
+          error: 'Executor startup failed (ssh): SSH remote script failed (exit=128, phase=bootstrap_clone_fetch)\n'
+            + 'STDERR:\n'
+            + 'fatal: not a git repository (or any of the parent directories): .git\n'
+            + '[WARNING] Git fetch failed for /home/invoker/.invoker/repos/647faa73e90e\n'
+            + '[WARNING] Continuing with existing refs. Tasks may use stale commits.\n'
+            + "ERROR: base ref 'master' not found and fallback 'origin/master' also missing\n",
+        },
+      }),
+    ]);
+
+    await h.tick(POLL_CTX);
+
+    expect(h.runRepoMirrorRepairFn).toHaveBeenCalledTimes(1);
+    expect(h.runRepoMirrorRepairFn).toHaveBeenCalledWith(expect.objectContaining({
+      mirrorPath: '/home/invoker/.invoker/repos/647faa73e90e',
+    }));
+    expect(h.runRemoteProvisionRepairFn).not.toHaveBeenCalled();
+    expect(h.submit).toHaveBeenCalledTimes(1);
+    expect(h.submissions[0]?.channel).toBe(INFRA_REPAIR_RETRY_TASK_CHANNEL);
+    expect(parseInfraRepairRetryTaskMutationArgs(h.submissions[0]?.args ?? [])).toEqual({ taskId: 'wf-1/task-1' });
+    expect(workerActions(h.actions)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        workerKind: INFRA_REPAIR_WORKER_KIND,
+        actionType: 'repair-infra-failure',
+        taskId: 'wf-1/task-1',
+        status: 'completed',
+        payload: expect.objectContaining({
+          infraReason: 'ssh-repo-mirror-corrupt',
+          channel: INFRA_REPAIR_RETRY_TASK_CHANNEL,
+        }),
+      }),
+    ]));
+  });
+
+  it('fails cleanly when the corrupt mirror path cannot be parsed from the error', async () => {
+    const h = makeHarness([
+      makeTask({
+        execution: {
+          error: 'SSH remote script failed (exit=128, phase=bootstrap_clone_fetch)\n'
+            + 'STDERR:\n'
+            + 'fatal: not a git repository (or any of the parent directories): .git\n',
+        },
+      }),
+    ]);
+
+    await h.tick(POLL_CTX);
+
+    expect(h.runRepoMirrorRepairFn).not.toHaveBeenCalled();
+    expect(h.submit).not.toHaveBeenCalled();
   });
 
   it('reads the persisted failureClass subtype when the error text is opaque', async () => {

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -126,6 +126,7 @@ export interface InfraRepairWorkerPolicyOptions {
   drainWakeupHints?: () => RecoveryWorkerWakeupHint[];
   resolveRemoteBranchOwnerPathFn?: typeof resolveRemoteBranchOwnerPath;
   runRemoteProvisionRepairFn?: typeof runRemoteProvisionRepair;
+  runRepoMirrorRepairFn?: typeof runRepoMirrorRepair;
 }
 
 export interface InfraRepairWorkerOptions {
@@ -426,6 +427,45 @@ export async function runRemoteProvisionRepair(options: {
   });
 }
 
+/**
+ * The mirror-clone bootstrap script (buildMirrorCloneScript in ssh-git-exec.ts)
+ * only checks `[ ! -d "$CLONE/.git" ]` before deciding whether to (re)clone, so
+ * a corrupted mirror (`.git/` present but missing HEAD/config/objects) is never
+ * repaired by the bootstrap itself -- it fails the same way every attempt. The
+ * mirror path is embedded in its own `[WARNING] Git fetch failed for <path>`
+ * line, so pull it out of the persisted error text rather than recomputing the
+ * repo-URL hash here.
+ */
+export function extractCorruptMirrorPath(errorText: string | undefined): string | undefined {
+  if (typeof errorText !== 'string') return undefined;
+  const match = errorText.match(/Git fetch failed for (\S+)/);
+  return match?.[1];
+}
+
+export function buildRepoMirrorRepairScript(options: { mirrorPath: string }): string {
+  const mirrorPathB64 = base64Encode(options.mirrorPath);
+  return `set -euo pipefail
+${buildPortableBase64DecodeFunction()}
+MIRROR_PATH=$(printf '%s' ${shellPosixSingleQuote(mirrorPathB64)} | invoker_base64_decode)
+${bashNormalizeTildePath('MIRROR_PATH')}
+rm -rf "$MIRROR_PATH"
+`;
+}
+
+export async function runRepoMirrorRepair(options: {
+  target: InfraRepairRemoteTargetConfig;
+  mirrorPath: string;
+  targetKey?: string;
+  runRemoteScript?: typeof execRemoteCapture;
+}): Promise<string> {
+  const sshArgs = buildSshConnectionArgs(options.target, { batchMode: true });
+  return (options.runRemoteScript ?? execRemoteCapture)({
+    sshArgs,
+    script: buildRepoMirrorRepairScript({ mirrorPath: options.mirrorPath }),
+    phase: `infra-repair:${options.targetKey ?? options.target.host}`,
+  });
+}
+
 async function runTargetRepairWithCooldown(
   options: InfraRepairWorkerPolicyOptions,
   args: {
@@ -521,6 +561,60 @@ async function handleRemoteProvisionRecovery(
       reusedRecentRepair: repair.kind === 'reused-success',
     },
     'Queued retry-task after remote infra repair',
+  );
+}
+
+async function handleRepoMirrorCorruptRecovery(
+  options: InfraRepairWorkerPolicyOptions,
+  candidate: ValidatedGenericSshInfraCandidate,
+): Promise<void> {
+  const mirrorPath = extractCorruptMirrorPath(candidate.task.execution.error);
+  if (!mirrorPath) {
+    recordTaskDecision(options, candidate, candidate.reason, 'failed', 'Could not determine the corrupt mirror path from the task error', {
+      targetId: candidate.targetId,
+    }, 'mirror-path-unresolved');
+    return;
+  }
+
+  const repair = await runTargetRepairWithCooldown(options, {
+    targetKey: `${candidate.targetId}:${mirrorPath}`,
+    reason: candidate.reason,
+    execute: () => (options.runRepoMirrorRepairFn ?? runRepoMirrorRepair)({
+      target: candidate.target,
+      mirrorPath,
+      targetKey: candidate.targetId,
+    }),
+  });
+
+  if (repair.kind === 'cooldown-skip') {
+    recordTaskDecision(options, candidate, candidate.reason, 'skipped', 'Skipped infra repair because target cooldown is active', {
+      targetId: candidate.targetId,
+      mirrorPath,
+      repairStatus: repair.action.status,
+    }, 'repair-cooldown');
+    return;
+  }
+  if (repair.kind === 'failed') {
+    recordTaskDecision(options, candidate, candidate.reason, 'failed', `Infra repair failed: ${firstLine(repair.errorMessage) ?? 'unknown error'}`, {
+      targetId: candidate.targetId,
+      mirrorPath,
+      error: repair.errorMessage,
+    }, 'repair-failed');
+    return;
+  }
+
+  await submitFollowUpMutation(
+    options,
+    candidate,
+    candidate.reason,
+    INFRA_REPAIR_RETRY_TASK_CHANNEL,
+    buildInfraRepairRetryTaskMutationArgs(candidate.taskId),
+    {
+      targetId: candidate.targetId,
+      mirrorPath,
+      reusedRecentRepair: repair.kind === 'reused-success',
+    },
+    'Queued retry-task after removing the corrupt repo mirror (bootstrap re-clones on next attempt)',
   );
 }
 
@@ -634,6 +728,10 @@ async function handleValidatedGenericSshInfraCandidate(
   }
   if (candidate.reason === 'ssh-worktree-missing') {
     await handleMissingWorktreeRecovery(options, candidate);
+    return;
+  }
+  if (candidate.reason === 'ssh-repo-mirror-corrupt') {
+    await handleRepoMirrorCorruptRecovery(options, candidate);
     return;
   }
   await handleInvalidReferenceRecovery(options, candidate);

--- a/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
+++ b/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
@@ -20,6 +20,23 @@ describe('FailureClassifier.classifyError', () => {
       .toBe('ssh-invalid-reference');
   });
 
+  it('classifies the corrupt-repo-mirror signature', () => {
+    expect(FailureClassifier.classifyError(
+      'SSH remote script failed (exit=128, phase=bootstrap_clone_fetch)\n'
+      + 'STDERR:\n'
+      + 'fatal: not a git repository (or any of the parent directories): .git\n'
+      + '[WARNING] Git fetch failed for /home/invoker/.invoker/repos/647faa73e90e\n'
+      + '[WARNING] Continuing with existing refs. Tasks may use stale commits.\n'
+      + "ERROR: base ref 'master' not found and fallback 'origin/master' also missing\n",
+    )).toBe('ssh-repo-mirror-corrupt');
+  });
+
+  it('does not classify a bare "not a git repository" outside the bootstrap-clone phase', () => {
+    expect(FailureClassifier.classifyError(
+      'fatal: not a git repository (or any of the parent directories): .git',
+    )).toBeUndefined();
+  });
+
   it('returns undefined for ordinary code failures and non-strings', () => {
     expect(FailureClassifier.classifyError('AssertionError: expected 1 to be 2')).toBeUndefined();
     expect(FailureClassifier.classifyError(undefined)).toBeUndefined();

--- a/packages/workflow-graph/src/failure-classifier.ts
+++ b/packages/workflow-graph/src/failure-classifier.ts
@@ -18,6 +18,7 @@ export const SSH_INFRA_FAILURE_CLASSES: readonly SshInfraFailureClass[] = [
   'ssh-env-invalid-export',
   'ssh-worktree-missing',
   'ssh-invalid-reference',
+  'ssh-repo-mirror-corrupt',
 ];
 
 export class FailureClassifier {
@@ -40,6 +41,12 @@ export class FailureClassifier {
       || errorText.includes('Cannot apply a fix because this task has no saved workspace.')
     ) {
       return 'ssh-invalid-reference';
+    }
+    if (
+      errorText.includes('phase=bootstrap_clone_fetch')
+      && errorText.includes('fatal: not a git repository (or any of the parent directories): .git')
+    ) {
+      return 'ssh-repo-mirror-corrupt';
     }
     return undefined;
   }

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -190,7 +190,8 @@ export interface ReviewGateState {
 export type SshInfraFailureClass =
   | 'ssh-env-invalid-export'
   | 'ssh-worktree-missing'
-  | 'ssh-invalid-reference';
+  | 'ssh-invalid-reference'
+  | 'ssh-repo-mirror-corrupt';
 
 export type FailureClass = 'liveness_stall' | SshInfraFailureClass;
 


### PR DESCRIPTION
## Summary

The SSH mirror-clone bootstrap only checks whether the mirror directory is present before deciding whether to clone into it, not whether the contents are a working repo.

A broken mirror (`.git/` present but missing `HEAD`/`config`/`objects`, e.g. from a concurrent-provisioning race) passes that check. The bootstrap then goes straight to `git fetch` against it, which fails with "fatal: not a git repository" on every task sent to that host afterward. This blocked CI-regression-watch and admin-bypass-repair work on one remote pool member until it was found and fixed by hand over SSH.

`FailureClassifier` had no pattern for this error text, so the infra-repair worker never logged a decision for it at all — the failure looked exactly like an ordinary code failure and sat there indefinitely.

## Review Claim

`FailureClassifier` now recognizes a broken SSH repo mirror as a machine-owned infra bucket, and the infra-repair worker clears the broken mirror over SSH and queues a fresh attempt of the task through Invoker's own mutation path, following the same classify-then-repair-then-requeue shape as the three existing SSH infra buckets.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new repair step only ever acts on the one mirror directory path parsed out of the failing task's own recorded error text (the `[WARNING] Git fetch failed for <path>` line the bootstrap script already writes there) — never an arbitrary or guessed path. If that path can't be found in the error text, the worker logs a failed decision and takes no host action at all. The bootstrap script picks the directory back up cleanly on the next attempt using its existing, unmodified clone logic — nothing about that logic changed here.

## Slice Rationale

One classifier pattern plus one repair handler, mirroring the shape already used for the three existing SSH infra buckets in the same file. Leaves the bootstrap script's own directory-presence check as-is; a narrower change to that script is a separate concern.

## Non-goals

Does not change `buildMirrorCloneScript`'s directory-presence check itself (the root reason a broken mirror goes unnoticed at bootstrap time) — that's a separate, narrower change. Does not touch the three existing SSH infra buckets or their repair behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/workflow-graph && pnpm test`
- [ ] `cd packages/execution-engine && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic recovery for corrupted SSH repository mirrors.
  * Affected tasks can now clean up the invalid mirror and retry automatically.
  * Improved detection of repository-mirror corruption during bootstrap cloning and fetching.
  * Repair actions now respect cooldowns and record recovery metadata.
  * Failures without an identifiable mirror path are handled safely without triggering repair.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->