### PR TITLE
address review: guard the corrupt-mirror repair against an unsafe path

### DIFF
--- a/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
@@ -8,7 +8,9 @@ import type {
 import type { TaskState } from '@invoker/workflow-core';
 
 import {
+  buildRepoMirrorRepairScript,
   createInfraRepairTick,
+  extractCorruptMirrorPath,
   INFRA_REPAIR_RECREATE_TASK_CHANNEL,
   INFRA_REPAIR_RETRY_TASK_CHANNEL,
   INFRA_REPAIR_WORKER_KIND,
@@ -291,6 +293,23 @@ describe('infra-repair worker', () => {
     expect(h.submit).not.toHaveBeenCalled();
   });
 
+  it('refuses to act when the parsed mirror path is unsafe, even if something matched', async () => {
+    for (const unsafePath of ['/', '~', '.', '..', '', '/home/invoker/.invoker/worktrees/x']) {
+      const h = makeHarness([
+        makeTask({
+          execution: {
+            error: `SSH remote script failed (exit=128, phase=bootstrap_clone_fetch)\nSTDERR:\nfatal: not a git repository (or any of the parent directories): .git\n[WARNING] Git fetch failed for ${unsafePath}\n`,
+          },
+        }),
+      ]);
+
+      await h.tick(POLL_CTX);
+
+      expect(h.runRepoMirrorRepairFn, `path=${JSON.stringify(unsafePath)}`).not.toHaveBeenCalled();
+      expect(h.submit, `path=${JSON.stringify(unsafePath)}`).not.toHaveBeenCalled();
+    }
+  });
+
   it('reads the persisted failureClass subtype when the error text is opaque', async () => {
     const h = makeHarness([
       makeTask({
@@ -454,5 +473,31 @@ describe('infra-repair worker', () => {
         }),
       }),
     ]));
+  });
+});
+
+describe('extractCorruptMirrorPath', () => {
+  it('parses the mirror path out of the bootstrap script warning line', () => {
+    expect(extractCorruptMirrorPath(
+      '[WARNING] Git fetch failed for /home/invoker/.invoker/repos/647faa73e90e\n',
+    )).toBe('/home/invoker/.invoker/repos/647faa73e90e');
+  });
+
+  it('rejects paths that are missing, empty, or not shaped like a mirror path', () => {
+    expect(extractCorruptMirrorPath(undefined)).toBeUndefined();
+    expect(extractCorruptMirrorPath('no warning line here')).toBeUndefined();
+    expect(extractCorruptMirrorPath('[WARNING] Git fetch failed for /\n')).toBeUndefined();
+    expect(extractCorruptMirrorPath('[WARNING] Git fetch failed for ~\n')).toBeUndefined();
+    expect(extractCorruptMirrorPath('[WARNING] Git fetch failed for /home/invoker/.invoker/worktrees/x\n')).toBeUndefined();
+  });
+});
+
+describe('buildRepoMirrorRepairScript', () => {
+  it('embeds a guard that refuses unsafe paths before rm -rf, independent of the caller', () => {
+    const script = buildRepoMirrorRepairScript({ mirrorPath: '/home/invoker/.invoker/repos/647faa73e90e' });
+    expect(script).toContain('refusing to act on unsafe mirror path');
+    expect(script).toContain('rm -rf "$MIRROR_PATH"');
+    // The guard must run before the deletion, not after.
+    expect(script.indexOf('refusing to act on unsafe mirror path')).toBeLessThan(script.indexOf('rm -rf "$MIRROR_PATH"'));
   });
 });

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -436,10 +436,24 @@ export async function runRemoteProvisionRepair(options: {
  * line, so pull it out of the persisted error text rather than recomputing the
  * repo-URL hash here.
  */
+/**
+ * Mirror paths are always `<invokerHome>/repos/<repoHash>` (see
+ * buildMirrorCloneScript in ssh-git-exec.ts). Requiring that shape means a
+ * truncated, empty, or otherwise malformed match can never resolve to
+ * something broader -- `/`, `~`/`$HOME`, or an unrelated directory -- before
+ * it reaches a remote `rm -rf`.
+ */
+function isSafeMirrorPath(path: string | undefined): path is string {
+  if (!path) return false;
+  if (path === '/' || path === '~' || path === '.' || path === '..') return false;
+  return /\/repos\/[^/]+\/?$/.test(path);
+}
+
 export function extractCorruptMirrorPath(errorText: string | undefined): string | undefined {
   if (typeof errorText !== 'string') return undefined;
   const match = errorText.match(/Git fetch failed for (\S+)/);
-  return match?.[1];
+  const candidate = match?.[1];
+  return isSafeMirrorPath(candidate) ? candidate : undefined;
 }
 
 export function buildRepoMirrorRepairScript(options: { mirrorPath: string }): string {
@@ -448,6 +462,10 @@ export function buildRepoMirrorRepairScript(options: { mirrorPath: string }): st
 ${buildPortableBase64DecodeFunction()}
 MIRROR_PATH=$(printf '%s' ${shellPosixSingleQuote(mirrorPathB64)} | invoker_base64_decode)
 ${bashNormalizeTildePath('MIRROR_PATH')}
+if [[ -z "$MIRROR_PATH" || "$MIRROR_PATH" == "/" || "$MIRROR_PATH" == "$HOME" || "$MIRROR_PATH" != */repos/* ]]; then
+  echo "refusing to act on unsafe mirror path: '$MIRROR_PATH'" >&2
+  exit 1
+fi
 rm -rf "$MIRROR_PATH"
 `;
 }


### PR DESCRIPTION
## Summary

Follow-up to #6966 in this stack, addressing a review comment on that PR.

The parsed mirror path had no check that it was non-empty or shaped like a real mirror directory before the worker handed it to a remote `rm -rf`. A bad match, an empty string, `/`, or `~` (which resolves to `$HOME`) could have deleted far more than intended on the target host.

Mirror paths only ever look one way — `<invokerHome>/repos/<repoHash>` — so require that shape before acting, and refuse the same set of unsafe values a second time inside the remote script itself, independent of the check above it.

## Review Claim

The corrupt-mirror repair now refuses to run its remote deletion on any path that isn't shaped like a real mirror directory, checked twice — once before dispatch, once inside the remote script — so a parsing mistake can never reach a broad `rm -rf`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Both guards are conservative by construction: they only ever narrow which paths the worker is willing to act on, and a rejected path now produces a logged failed decision and zero host action, exactly like the existing "path could not be found" case this PR builds on.

## Slice Rationale

One safety-hardening commit on top of #6966, kept separate so the review comment it responds to stays scoped to exactly the lines it's about.

## Non-goals

Does not change the classification pattern or the retry-queueing behavior from #6966.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test -- infra-repair-worker`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration? No.

</details>
