### PR TITLE
[Terminal Garbling](2) Survive the Chat/Tmux toggle and confirm resizes before trusting them

### DIFF
--- a/packages/app/e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts
+++ b/packages/app/e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * Reproduces the exact manual repro: open a new planning chat, switch to
+ * Tmux, run a full-screen program, switch to Chat, switch back to Tmux, and
+ * confirm the tmux pane looks the same before and after.
+ *
+ * Root cause (see plans/nested-wobbling-seahorse.md and
+ * packages/ui/src/__tests__/invoker-terminal.test.tsx's
+ * "keeps the same xterm Terminal instance across a chat/tmux mode toggle"):
+ * the Chat/Tmux toggle in InvokerTerminal.tsx used to fully unmount
+ * PlanningTmuxPane, destroying its xterm.js Terminal, then rebuild a brand
+ * new one on switch-back and replay the raw output log into it. That fix
+ * was reverted in this worktree to investigate a separate resize/PTY-size
+ * bug first, so this spec is currently expected to FAIL again.
+ *
+ * A synthetic full-screen frame (absolute cursor-positioned ANSI writes) is
+ * used in place of a real `claude` session so the repro is deterministic
+ * and doesn't require live auth/network calls — it exercises the identical
+ * failure class: full-screen, cursor-addressed redraws are exactly what a
+ * real full-screen TUI like the Claude Code CLI produces.
+ */
+
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures/electron-app.js';
+
+async function openHome(page: Page): Promise<void> {
+  await page.getByTestId('sidebar-home').click();
+  await expect(page.getByTestId('invoker-terminal-input')).toBeVisible({ timeout: 10000 });
+}
+
+async function readOutputSnapshot(page: Page, sessionId: string): Promise<string> {
+  return page.evaluate(async (targetSessionId) => {
+    const sessions = await window.invoker.planningTerminalList();
+    return sessions.find((session) => session.sessionId === targetSessionId)?.outputSnapshot ?? '';
+  }, sessionId);
+}
+
+async function openPlanningTmux(page: Page): Promise<string> {
+  await page.getByTestId('invoker-terminal-mode-toggle').getByRole('tab', { name: 'Tmux' }).click();
+  const pane = page.getByTestId('invoker-terminal-tmux-pane');
+  await expect(pane).toBeVisible({ timeout: 10000 });
+  const sessionId = await pane.getAttribute('data-session-id');
+  expect(sessionId).toBeTruthy();
+  await expect.poll(async () => readOutputSnapshot(page, sessionId ?? ''), { timeout: 10000 }).toContain('Invoker planning tmux bridge');
+  return sessionId ?? '';
+}
+
+async function switchMode(page: Page, mode: 'Chat' | 'Tmux'): Promise<void> {
+  await page.getByTestId('invoker-terminal-mode-toggle').getByRole('tab', { name: mode }).click();
+}
+
+async function writeToTmux(page: Page, sessionId: string, data: string): Promise<void> {
+  const result = await page.evaluate(async ({ targetSessionId, payload }) => {
+    return window.invoker.planningTerminalWrite(targetSessionId, payload);
+  }, { targetSessionId: sessionId, payload: data });
+  expect(result).toMatchObject({ ok: true });
+}
+
+/** Tags the live terminal's root DOM node so we can tell, after a mode
+ * toggle, whether it's still the SAME node (fixed) or a freshly created one
+ * (bug: the pane was destroyed and rebuilt). */
+async function tagTerminalDomNode(page: Page): Promise<void> {
+  const tagged = await page.evaluate(() => {
+    const pane = document.querySelector('[data-testid="invoker-terminal-tmux-pane"]');
+    const xtermEl = pane?.querySelector('.xterm');
+    if (!xtermEl) return false;
+    xtermEl.setAttribute('data-repro-marker', 'still-here');
+    return true;
+  });
+  expect(tagged, 'expected a live .xterm DOM node inside the tmux pane to tag').toBe(true);
+}
+
+async function terminalDomNodeMarkerSurvived(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const pane = document.querySelector('[data-testid="invoker-terminal-tmux-pane"]');
+    const xtermEl = pane?.querySelector('.xterm');
+    return xtermEl?.getAttribute('data-repro-marker') === 'still-here';
+  });
+}
+
+/**
+ * Synthesizes the tmux pane's currently RENDERED state as a single string,
+ * reading every row straight from xterm.js's own buffer (not the DOM, which
+ * xterm.js paints to a <canvas> with no accessible text; not the backend's
+ * raw output log, which doesn't change on a UI-only toggle and so can't
+ * detect a bad replay). This is what the user actually sees on screen.
+ */
+async function readTmuxBufferText(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const term = window.__INVOKER_TEST_ACTIVE_PLANNING_TMUX_TERMINAL__;
+    if (!term) return null;
+    const lines: string[] = [];
+    for (let row = 0; row < term.rows; row += 1) {
+      lines.push(term.buffer.active.getLine(row)?.translateToString(true) ?? '');
+    }
+    return lines.join('\n');
+  });
+}
+
+async function closePlanningTerminalSessions(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const sessions = await window.invoker.planningTerminalList();
+    await Promise.all(sessions.map((session) => window.invoker.planningTerminalClose(session.sessionId)));
+  }).catch(() => undefined);
+}
+
+const FRAME_MARKER = 'FULLSCREEN_FRAME_READY';
+// Clears the screen, then writes text at absolute cursor positions -- the
+// same class of escape sequences a real full-screen TUI (the Claude Code
+// CLI included) uses to draw its UI.
+const DRAW_FULL_SCREEN_FRAME =
+  "printf '\\033[2J\\033[H'" +
+  "; printf '\\033[3;5HTOP LEFT FRAME'" +
+  "; printf '\\033[10;20HBOTTOM RIGHT FRAME'" +
+  `; printf '\\033[24;1H${FRAME_MARKER}'` +
+  '\n';
+
+test.describe('Planning terminal Chat/Tmux toggle garble repro', () => {
+  test('tmux pane keeps the same terminal instance and content across a Chat -> Tmux round trip', async ({ page }, testInfo) => {
+    let sessionId = '';
+    try {
+      await openHome(page);
+      sessionId = await openPlanningTmux(page);
+
+      await writeToTmux(page, sessionId, DRAW_FULL_SCREEN_FRAME);
+      await expect.poll(async () => readOutputSnapshot(page, sessionId), { timeout: 10000 }).toContain(FRAME_MARKER);
+      await page.waitForTimeout(300);
+
+      await tagTerminalDomNode(page);
+
+      const beforeScreenshot = testInfo.outputPath('chat-tmux-toggle-before.png');
+      await page.screenshot({ path: beforeScreenshot });
+      await testInfo.attach('before-toggle', { path: beforeScreenshot, contentType: 'image/png' });
+      const outputSnapshotBefore = await readOutputSnapshot(page, sessionId);
+      const renderedBefore = await readTmuxBufferText(page);
+      expect(renderedBefore, 'expected the test hook to expose the live xterm.js Terminal').not.toBeNull();
+      await testInfo.attach('rendered-buffer-before', { body: renderedBefore ?? '', contentType: 'text/plain' });
+
+      await switchMode(page, 'Chat');
+      await expect(page.getByTestId('invoker-terminal-input')).toBeVisible({ timeout: 10000 });
+      await switchMode(page, 'Tmux');
+      const paneAfterToggle = page.getByTestId('invoker-terminal-tmux-pane');
+      await expect(paneAfterToggle).toBeVisible({ timeout: 10000 });
+      await page.waitForTimeout(300);
+
+      const sessionIdAfterToggle = await paneAfterToggle.getAttribute('data-session-id');
+      const afterScreenshot = testInfo.outputPath('chat-tmux-toggle-after.png');
+      await page.screenshot({ path: afterScreenshot });
+      await testInfo.attach('after-toggle', { path: afterScreenshot, contentType: 'image/png' });
+      const outputSnapshotAfter = await readOutputSnapshot(page, sessionId);
+      const renderedAfter = await readTmuxBufferText(page);
+      await testInfo.attach('rendered-buffer-after', { body: renderedAfter ?? '', contentType: 'text/plain' });
+
+      // Same backend session throughout -- this is not testing whether a
+      // new PTY got spawned, only whether the UI's terminal survived.
+      expect(sessionIdAfterToggle, 'the tmux pane must keep attaching to the same backend session').toBe(sessionId);
+      expect(outputSnapshotAfter, "the main process's output log must be untouched by a UI-only mode toggle").toBe(outputSnapshotBefore);
+
+      // The actual bug: does the toggle destroy and rebuild the terminal?
+      expect(
+        await terminalDomNodeMarkerSurvived(page),
+        'the xterm terminal DOM node must be the SAME instance after switching Chat -> Tmux, not destroyed and recreated (this is the reported garbling bug)',
+      ).toBe(true);
+
+      // The direct test: synthesize the tmux pane's rendered state as a
+      // string before and after, and compare them exactly.
+      expect(renderedAfter, 'the rendered terminal content must be byte-for-byte identical before and after the Chat -> Tmux round trip').toBe(renderedBefore);
+    } finally {
+      if (sessionId) {
+        await closePlanningTerminalSessions(page);
+      }
+    }
+  });
+});

--- a/packages/app/e2e/planning-terminal-chat-tmux-toggle-real-claude-repro.spec.ts
+++ b/packages/app/e2e/planning-terminal-chat-tmux-toggle-real-claude-repro.spec.ts
@@ -1,0 +1,189 @@
+/**
+ * Same repro as planning-terminal-chat-tmux-toggle-garble-repro.spec.ts, but
+ * driving the REAL `claude` CLI in the tmux pane instead of a synthetic
+ * full-screen frame -- this is what the user actually typed and observed.
+ *
+ * Not part of the deterministic regression suite: a live CLI's screen can
+ * legitimately differ run to run (spinners, token/cost counters, auth
+ * state), so this is a manual verification script, run on demand.
+ *
+ * The e2e fixture normally shadows `claude` on PATH with a no-op stub
+ * (electron-app.ts symlinks scripts/e2e-dry-run/fixtures/claude-marker.sh
+ * as `claude` in a prepended stub dir) so other tests don't hit the real
+ * network. This spec resolves and invokes the REAL binary by absolute path
+ * to bypass that shadow on purpose.
+ */
+
+import { execFileSync } from 'node:child_process';
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures/electron-app.js';
+
+function resolveRealClaudeBinary(): string {
+  const resolved = execFileSync('bash', ['-lc', 'command -v claude'], { encoding: 'utf8' }).trim();
+  if (!resolved) {
+    throw new Error('Could not resolve a real `claude` binary on PATH outside the e2e sandbox');
+  }
+  return resolved;
+}
+
+async function openHome(page: Page): Promise<void> {
+  await page.getByTestId('sidebar-home').click();
+  await expect(page.getByTestId('invoker-terminal-input')).toBeVisible({ timeout: 10000 });
+}
+
+async function readOutputSnapshot(page: Page, sessionId: string): Promise<string> {
+  return page.evaluate(async (targetSessionId) => {
+    const sessions = await window.invoker.planningTerminalList();
+    return sessions.find((session) => session.sessionId === targetSessionId)?.outputSnapshot ?? '';
+  }, sessionId);
+}
+
+async function openPlanningTmux(page: Page): Promise<string> {
+  await page.getByTestId('invoker-terminal-mode-toggle').getByRole('tab', { name: 'Tmux' }).click();
+  const pane = page.getByTestId('invoker-terminal-tmux-pane');
+  await expect(pane).toBeVisible({ timeout: 10000 });
+  const sessionId = await pane.getAttribute('data-session-id');
+  expect(sessionId).toBeTruthy();
+  await expect.poll(async () => readOutputSnapshot(page, sessionId ?? ''), { timeout: 10000 }).toContain('Invoker planning tmux bridge');
+  return sessionId ?? '';
+}
+
+async function switchMode(page: Page, mode: 'Chat' | 'Tmux'): Promise<void> {
+  await page.getByTestId('invoker-terminal-mode-toggle').getByRole('tab', { name: mode }).click();
+}
+
+async function writeToTmux(page: Page, sessionId: string, data: string): Promise<void> {
+  const result = await page.evaluate(async ({ targetSessionId, payload }) => {
+    return window.invoker.planningTerminalWrite(targetSessionId, payload);
+  }, { targetSessionId: sessionId, payload: data });
+  expect(result).toMatchObject({ ok: true });
+}
+
+async function readTmuxBufferText(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const term = window.__INVOKER_TEST_ACTIVE_PLANNING_TMUX_TERMINAL__;
+    if (!term) return null;
+    const lines: string[] = [];
+    for (let row = 0; row < term.rows; row += 1) {
+      lines.push(term.buffer.active.getLine(row)?.translateToString(true) ?? '');
+    }
+    return lines.join('\n');
+  });
+}
+
+async function terminalDomNodeMarkerSurvived(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const pane = document.querySelector('[data-testid="invoker-terminal-tmux-pane"]');
+    const xtermEl = pane?.querySelector('.xterm');
+    return xtermEl?.getAttribute('data-repro-marker') === 'still-here';
+  });
+}
+
+async function tagTerminalDomNode(page: Page): Promise<void> {
+  const tagged = await page.evaluate(() => {
+    const pane = document.querySelector('[data-testid="invoker-terminal-tmux-pane"]');
+    const xtermEl = pane?.querySelector('.xterm');
+    if (!xtermEl) return false;
+    xtermEl.setAttribute('data-repro-marker', 'still-here');
+    return true;
+  });
+  expect(tagged, 'expected a live .xterm DOM node inside the tmux pane to tag').toBe(true);
+}
+
+/** Waits until the session's output log stops growing for `quietMs`, so we
+ * don't snapshot the screen mid-startup-animation. */
+async function waitForOutputToStabilize(
+  page: Page,
+  sessionId: string,
+  { quietMs = 1200, timeoutMs = 20000, pollMs = 250 } = {},
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  let lastSnapshot = await readOutputSnapshot(page, sessionId);
+  let lastChangeAt = Date.now();
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+    const snapshot = await readOutputSnapshot(page, sessionId);
+    if (snapshot !== lastSnapshot) {
+      lastSnapshot = snapshot;
+      lastChangeAt = Date.now();
+      continue;
+    }
+    if (Date.now() - lastChangeAt >= quietMs) return lastSnapshot;
+  }
+  return lastSnapshot;
+}
+
+function firstDiffLine(before: string, after: string): string {
+  const beforeLines = before.split('\n');
+  const afterLines = after.split('\n');
+  const max = Math.max(beforeLines.length, afterLines.length);
+  for (let i = 0; i < max; i += 1) {
+    if (beforeLines[i] !== afterLines[i]) {
+      return `line ${i}:\n  before: ${JSON.stringify(beforeLines[i] ?? '<missing>')}\n  after:  ${JSON.stringify(afterLines[i] ?? '<missing>')}`;
+    }
+  }
+  return '(no differing line found, but strings are unequal -- length mismatch?)';
+}
+
+async function closePlanningTerminalSessions(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const sessions = await window.invoker.planningTerminalList();
+    await Promise.all(sessions.map((session) => window.invoker.planningTerminalClose(session.sessionId)));
+  }).catch(() => undefined);
+}
+
+test.describe('Planning terminal Chat/Tmux toggle garble repro (real claude session)', () => {
+  test('tmux pane renders the real claude CLI identically before and after a Chat -> Tmux round trip', async ({ page }, testInfo) => {
+    test.setTimeout(90000);
+    const claudeBinary = resolveRealClaudeBinary();
+    let sessionId = '';
+    try {
+      await openHome(page);
+      sessionId = await openPlanningTmux(page);
+
+      await writeToTmux(page, sessionId, `${claudeBinary}\n`);
+      // Real startup renders progressively (banner, then onboarding UI);
+      // don't gate on a brittle text match against raw escape-code output --
+      // wait for it to stop changing instead.
+      const stableOutput = await waitForOutputToStabilize(page, sessionId, { quietMs: 1500, timeoutMs: 45000 });
+      expect(stableOutput, 'expected the real claude CLI to have produced output').toContain('Claude');
+      await testInfo.attach('claude-startup-output', { body: stableOutput, contentType: 'text/plain' });
+
+      await tagTerminalDomNode(page);
+
+      const beforeScreenshot = testInfo.outputPath('real-claude-toggle-before.png');
+      await page.screenshot({ path: beforeScreenshot });
+      await testInfo.attach('before-toggle', { path: beforeScreenshot, contentType: 'image/png' });
+      const renderedBefore = await readTmuxBufferText(page);
+      expect(renderedBefore, 'expected the test hook to expose the live xterm.js Terminal').not.toBeNull();
+      await testInfo.attach('rendered-buffer-before', { body: renderedBefore ?? '', contentType: 'text/plain' });
+
+      await switchMode(page, 'Chat');
+      await expect(page.getByTestId('invoker-terminal-input')).toBeVisible({ timeout: 10000 });
+      await switchMode(page, 'Tmux');
+      const paneAfterToggle = page.getByTestId('invoker-terminal-tmux-pane');
+      await expect(paneAfterToggle).toBeVisible({ timeout: 10000 });
+      await page.waitForTimeout(500);
+
+      const afterScreenshot = testInfo.outputPath('real-claude-toggle-after.png');
+      await page.screenshot({ path: afterScreenshot });
+      await testInfo.attach('after-toggle', { path: afterScreenshot, contentType: 'image/png' });
+      const renderedAfter = await readTmuxBufferText(page);
+      await testInfo.attach('rendered-buffer-after', { body: renderedAfter ?? '', contentType: 'text/plain' });
+
+      expect(
+        await terminalDomNodeMarkerSurvived(page),
+        'the xterm terminal DOM node must be the SAME instance after switching Chat -> Tmux, not destroyed and recreated',
+      ).toBe(true);
+
+      if (renderedAfter !== renderedBefore) {
+        console.log('REAL_CLAUDE_REPRO_DIFF:\n' + firstDiffLine(renderedBefore ?? '', renderedAfter ?? ''));
+      }
+      expect(renderedAfter, 'the rendered claude CLI content must be identical before and after the Chat -> Tmux round trip').toBe(renderedBefore);
+    } finally {
+      if (sessionId) {
+        await closePlanningTerminalSessions(page);
+      }
+    }
+  });
+});

--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -63,12 +63,16 @@ function createFakeChild() {
   return ee;
 }
 
-function createFakePty() {
-  const ee = new EventEmitter() as EventEmitter & PtyLike & {
+function createFakePty(initialSize: { cols: number; rows: number } = { cols: 80, rows: 24 }) {
+  const ee = new EventEmitter() as EventEmitter & Omit<PtyLike, 'cols' | 'rows'> & {
+    cols: number;
+    rows: number;
     __written: string[];
     __resized: Array<{ cols: number; rows: number }>;
     killed: boolean;
   };
+  ee.cols = initialSize.cols;
+  ee.rows = initialSize.rows;
   ee.__written = [];
   ee.__resized = [];
   ee.killed = false;
@@ -85,6 +89,8 @@ function createFakePty() {
   };
   ee.resize = (cols: number, rows: number) => {
     ee.__resized.push({ cols, rows });
+    ee.cols = cols;
+    ee.rows = rows;
   };
   ee.kill = () => {
     ee.killed = true;
@@ -569,6 +575,85 @@ describe('EmbeddedTerminalManager', () => {
     );
     expect(res.ok).toBe(true);
     expect(pty.__resized).toEqual([{ cols: 120, rows: 40 }]);
+  });
+
+  it('threads TerminalSpec cols/rows into the PTY spawn call instead of the hardcoded 80x24 default', () => {
+    const pty = createFakePty({ cols: 160, rows: 50 });
+    const ptySpawnFn = vi.fn(() => pty) as unknown as PtySpawnFn;
+    const mgr = new EmbeddedTerminalManager({
+      backend: createPtyTerminalBackend({ spawnFn: ptySpawnFn }),
+    });
+
+    mgr.openOrReuse({
+      taskId: 't',
+      spec: { command: 'claude', cwd: '/tmp', cols: 160, rows: 50 },
+      cwd: '/tmp',
+    });
+
+    expect(ptySpawnFn).toHaveBeenCalledWith(
+      'claude',
+      [],
+      expect.objectContaining({ cols: 160, rows: 50 }),
+    );
+  });
+
+  it('falls back to 80x24 when a TerminalSpec omits cols/rows, unchanged from today', () => {
+    const pty = createFakePty();
+    const ptySpawnFn = vi.fn(() => pty) as unknown as PtySpawnFn;
+    const mgr = new EmbeddedTerminalManager({
+      backend: createPtyTerminalBackend({ spawnFn: ptySpawnFn }),
+    });
+
+    mgr.openOrReuse({ taskId: 't', spec: { command: 'claude', cwd: '/tmp' }, cwd: '/tmp' });
+
+    expect(ptySpawnFn).toHaveBeenCalledWith(
+      'claude',
+      [],
+      expect.objectContaining({ cols: 80, rows: 24 }),
+    );
+  });
+
+  it('getAppliedSize reads the PTY back directly, exposing a resize that silently did not stick', () => {
+    const pty = createFakePty({ cols: 80, rows: 24 });
+    // Simulate a real-world dropped resize: the call is recorded but the
+    // underlying winsize never actually changes.
+    pty.resize = (cols: number, rows: number) => {
+      pty.__resized.push({ cols, rows });
+    };
+    const ptySpawnFn = vi.fn(() => pty) as unknown as PtySpawnFn;
+    const mgr = new EmbeddedTerminalManager({
+      backend: createPtyTerminalBackend({ spawnFn: ptySpawnFn }),
+    });
+    const session = mgr.openOrReuse({ taskId: 't', spec: { cwd: '/tmp' }, cwd: '/tmp' });
+
+    const res = mgr.resize(session.sessionId, 120, 40);
+
+    expect(res.ok).toBe(true);
+    expect(mgr.getAppliedSize(session.sessionId)).toEqual({ cols: 80, rows: 24 });
+  });
+
+  it('getAppliedSize reflects a resize that actually applied', () => {
+    const pty = createFakePty({ cols: 80, rows: 24 });
+    const ptySpawnFn = vi.fn(() => pty) as unknown as PtySpawnFn;
+    const mgr = new EmbeddedTerminalManager({
+      backend: createPtyTerminalBackend({ spawnFn: ptySpawnFn }),
+    });
+    const session = mgr.openOrReuse({ taskId: 't', spec: { cwd: '/tmp' }, cwd: '/tmp' });
+
+    mgr.resize(session.sessionId, 120, 40);
+
+    expect(mgr.getAppliedSize(session.sessionId)).toEqual({ cols: 120, rows: 40 });
+  });
+
+  it('getAppliedSize returns null for the pipe-backed bash backend, which has no real TTY size', () => {
+    const child = createFakeChild();
+    const bashSpawnFn = vi.fn(() => child) as unknown as BashSpawnFn;
+    const mgr = new EmbeddedTerminalManager({
+      backend: createBashTerminalBackend({ spawnFn: bashSpawnFn }),
+    });
+    const session = mgr.openOrReuse({ taskId: 't', spec: { cwd: '/tmp' }, cwd: '/tmp' });
+
+    expect(mgr.getAppliedSize(session.sessionId)).toBeNull();
   });
 
   it('emits exit and removes session when the bash child exits', () => {

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -36,6 +36,8 @@ export interface PtyForkOptionsLike {
 }
 
 export interface PtyLike {
+  readonly cols: number;
+  readonly rows: number;
   onData(listener: (data: string) => void): { dispose: () => void };
   onExit(listener: (event: { exitCode: number }) => void): { dispose: () => void };
   write(data: string): void;
@@ -61,6 +63,8 @@ export interface SpawnedTerminalProcess {
   write(data: string): void;
   resize(cols: number, rows: number): void;
   close(): void;
+  /** Authoritative applied size, read back from the real process. Null when the backend has no TTY (e.g. pipe-backed). */
+  getAppliedSize(): { cols: number; rows: number } | null;
 }
 
 export interface EmbeddedTerminalBackend {
@@ -215,6 +219,10 @@ class BashTerminalBackend implements EmbeddedTerminalBackend {
       resize() {
         // Pipe-backed child processes are not TTYs; resize is a no-op.
       },
+      getAppliedSize() {
+        // Pipes have no real terminal size to read back.
+        return null;
+      },
       close() {
         try {
           if (!child.killed) child.kill();
@@ -245,8 +253,8 @@ class PtyTerminalBackend implements EmbeddedTerminalBackend {
     const args = opts.spec.command ? opts.spec.args ?? [] : [];
     const pty = this.spawnFn(command, args, {
       name: 'xterm-256color',
-      cols: 80,
-      rows: 24,
+      cols: opts.spec.cols ?? 80,
+      rows: opts.spec.rows ?? 24,
       cwd: opts.cwd,
       env: { ...process.env, TERM: process.env.TERM ?? 'xterm-256color' },
     });
@@ -259,6 +267,9 @@ class PtyTerminalBackend implements EmbeddedTerminalBackend {
       },
       resize(cols: number, rows: number) {
         pty.resize(cols, rows);
+      },
+      getAppliedSize() {
+        return { cols: pty.cols, rows: pty.rows };
       },
       close() {
         try {
@@ -446,6 +457,12 @@ export class EmbeddedTerminalManager extends EventEmitter {
     } catch (err) {
       return { ok: false, reason: err instanceof Error ? err.message : String(err) };
     }
+  }
+
+  getAppliedSize(sessionId: string): { cols: number; rows: number } | null {
+    const state = this.sessions.get(sessionId);
+    if (!state || state.mode === 'attached') return null;
+    return state.process.getAppliedSize();
   }
 
   close(sessionId: string): { ok: boolean; reason?: string } {

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -572,6 +572,12 @@ export function registerPlanningTerminalSessionIpcHandlers(deps: {
     return embeddedTerminalManager.resize(sessionId, cols, rows);
   });
 
+  ipcMain.handle('invoker:planning-terminal-applied-size', async (_event, sessionId: string) => {
+    const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
+    if (!allowed.ok) return null;
+    return embeddedTerminalManager.getAppliedSize(sessionId);
+  });
+
   ipcMain.handle('invoker:planning-terminal-close', async (_event, sessionId: string) => {
     const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
     if (!allowed.ok) return allowed;

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -989,6 +989,10 @@ export const IpcChannels = {
     request: [sessionId: string, cols: number, rows: number];
     response: { ok: boolean; reason?: string };
   },
+  'invoker:planning-terminal-applied-size': {} as {
+    request: [sessionId: string];
+    response: { cols: number; rows: number } | null;
+  },
   'invoker:planning-terminal-close': {} as {
     request: [sessionId: string];
     response: { ok: boolean; reason?: string };

--- a/packages/execution-engine/src/executor.ts
+++ b/packages/execution-engine/src/executor.ts
@@ -20,6 +20,10 @@ export interface TerminalSpec {
   args?: string[];
   /** Tail command for Linux terminal launch (e.g. 'exec_bash' or 'pause'). */
   linuxTerminalTail?: 'exec_bash' | 'pause';
+  /** Initial PTY column count. Defaults to 80 when omitted. */
+  cols?: number;
+  /** Initial PTY row count. Defaults to 24 when omitted. */
+  rows?: number;
 }
 
 export interface PersistedTaskMeta {

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -247,6 +247,7 @@ export function createMockInvoker(
     planningTerminalList: vi.fn(async () => []),
     planningTerminalWrite: vi.fn(async () => ({ ok: true })),
     planningTerminalResize: vi.fn(async () => ({ ok: true })),
+    planningTerminalAppliedSize: vi.fn(async () => null),
     planningTerminalClose: vi.fn(async () => ({ ok: true })),
     getPlanningPresets: vi.fn(async () => [
       { key: 'codex', label: 'Codex', tool: 'codex', isDefault: true, defaultConfirmationMode: 'require' },

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -365,6 +365,12 @@ describe('Invoker terminal (component)', () => {
     }
   }
 
+  async function waitRealMs(ms: number): Promise<void> {
+    await act(async () => {
+      await new Promise<void>((resolve) => setTimeout(resolve, ms));
+    });
+  }
+
   it('does not mount planning tmux xterm or resize while inactive', async () => {
     render(<InvokerTerminal
       {...terminalProps({
@@ -382,6 +388,37 @@ describe('Invoker terminal (component)', () => {
     expect(xtermMock.fitInstances).toHaveLength(0);
     expect(mock.api.onTerminalOutput).not.toHaveBeenCalled();
     expect(mock.api.planningTerminalResize).not.toHaveBeenCalled();
+  });
+
+  it('keeps the same xterm Terminal instance across a chat/tmux mode toggle', async () => {
+    const rectSpy = mockElementRect(640, 400);
+
+    try {
+      const props = terminalProps({
+        mode: 'tmux' as const,
+        terminalSession: makePlanningTerminalSession(),
+      });
+      const { rerender } = render(<InvokerTerminal {...props} />);
+      await flushPlanningTerminalFit();
+
+      expect(xtermMock.instances).toHaveLength(1);
+      const firstInstance = xtermMock.instances[0];
+
+      rerender(<InvokerTerminal {...props} mode="chat" />);
+      await flushPlanningTerminalFit();
+
+      expect(xtermMock.instances).toHaveLength(1);
+      expect(firstInstance?.dispose).not.toHaveBeenCalled();
+
+      rerender(<InvokerTerminal {...props} mode="tmux" />);
+      await flushPlanningTerminalFit();
+
+      expect(xtermMock.instances).toHaveLength(1);
+      expect(xtermMock.instances[0]).toBe(firstInstance);
+      expect(firstInstance?.dispose).not.toHaveBeenCalled();
+    } finally {
+      rectSpy.mockRestore();
+    }
   });
 
   it('skips planning tmux fit and resize when proposed dimensions are tiny', async () => {
@@ -455,6 +492,110 @@ describe('Invoker terminal (component)', () => {
       rectSpy.mockRestore();
     }
   });
+
+  it('never retries a planning tmux resize the main process failed to apply', async () => {
+    const rectSpy = mockElementRect(640, 400);
+    xtermMock.setNextProposedDimensions({ cols: 100, rows: 30 });
+    vi.mocked(mock.api.planningTerminalResize).mockResolvedValueOnce({ ok: false, reason: 'session-not-found' });
+
+    try {
+      render(<InvokerTerminal
+        {...terminalProps({
+          mode: 'tmux',
+          terminalSession: makePlanningTerminalSession(),
+        })}
+      />);
+
+      await flushPlanningTerminalFit();
+      expect(mock.api.planningTerminalResize).toHaveBeenCalledTimes(1);
+
+      // The container's real size never changed, but nothing else has
+      // caused the renderer to distinguish "size we tried to send" from
+      // "size the PTY actually confirmed" — a window focus event re-fits
+      // to the same 100x30 and should retry, since the PTY never got it.
+      act(() => {
+        window.dispatchEvent(new Event('focus'));
+      });
+      await flushPlanningTerminalFit();
+
+      // This is the bug: the renderer treats its own failed attempt as
+      // success and never resends the same dimensions, so the PTY is
+      // left running at its stale/default size indefinitely.
+      expect(mock.api.planningTerminalResize).toHaveBeenCalledTimes(2);
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('retries a resize the main process falsely reported as applied, using a readback check', async () => {
+    const rectSpy = mockElementRect(640, 400);
+    xtermMock.setNextProposedDimensions({ cols: 100, rows: 30 });
+
+    let appliedSizeCalls = 0;
+    vi.mocked(mock.api.planningTerminalAppliedSize).mockImplementation(async () => {
+      appliedSizeCalls += 1;
+      // First readback proves the "successful" resize never actually
+      // stuck; second readback (after the forced retry) shows it caught up.
+      return appliedSizeCalls === 1 ? { cols: 80, rows: 24 } : { cols: 100, rows: 30 };
+    });
+
+    try {
+      render(<InvokerTerminal
+        {...terminalProps({
+          mode: 'tmux',
+          terminalSession: makePlanningTerminalSession(),
+        })}
+      />);
+
+      await flushPlanningTerminalFit();
+      expect(mock.api.planningTerminalResize).toHaveBeenCalledTimes(1);
+
+      // The main process claimed { ok: true } for that first resize, but a
+      // readback a moment later shows the PTY never actually adopted it —
+      // the reconcile loop must force a resend rather than trust the lie.
+      await waitRealMs(700);
+
+      expect(mock.api.planningTerminalAppliedSize).toHaveBeenCalledWith('planning-terminal-1');
+      expect(mock.api.planningTerminalResize).toHaveBeenCalledTimes(2);
+
+      // Once the readback confirms the retry actually stuck, the loop must
+      // stop — no further resize calls should appear after another round.
+      const callsAfterRetry = mock.api.planningTerminalResize.mock.calls.length;
+      await waitRealMs(700);
+      expect(mock.api.planningTerminalResize.mock.calls.length).toBe(callsAfterRetry);
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+
+  it('gives up after a bounded number of reconcile attempts against a persistently wrong size', async () => {
+    const rectSpy = mockElementRect(640, 400);
+    xtermMock.setNextProposedDimensions({ cols: 100, rows: 30 });
+
+    // The main process always claims success, but the readback never
+    // matches — this must not retry forever.
+    vi.mocked(mock.api.planningTerminalAppliedSize).mockResolvedValue({ cols: 80, rows: 24 });
+
+    try {
+      render(<InvokerTerminal
+        {...terminalProps({
+          mode: 'tmux',
+          terminalSession: makePlanningTerminalSession(),
+        })}
+      />);
+
+      await flushPlanningTerminalFit();
+      await waitRealMs(4500);
+
+      const totalResizeCalls = mock.api.planningTerminalResize.mock.calls.length;
+      expect(totalResizeCalls).toBeGreaterThan(1);
+
+      await waitRealMs(700);
+      expect(mock.api.planningTerminalResize.mock.calls.length).toBe(totalResizeCalls);
+    } finally {
+      rectSpy.mockRestore();
+    }
+  }, 12000);
 
   it('generates a planning reply from plain language', async () => {
     render(<App />);

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -29,6 +29,8 @@ const TRANSCRIPT_BOTTOM_TOLERANCE_PX = 32;
 const MIN_PLANNING_TMUX_COLS = 20;
 const MIN_PLANNING_TMUX_ROWS = 5;
 const PLANNING_TMUX_FIT_SETTLE_FRAMES = 2;
+const PLANNING_TMUX_RECONCILE_MAX_ATTEMPTS = 6;
+const PLANNING_TMUX_RECONCILE_INTERVAL_MS = 500;
 
 function isTranscriptNearBottom(element: HTMLDivElement): boolean {
   return element.scrollHeight - element.scrollTop - element.clientHeight <= TRANSCRIPT_BOTTOM_TOLERANCE_PX;
@@ -187,13 +189,16 @@ interface PlanningTmuxPaneProps {
   error?: string | null;
   readOnly?: boolean;
   terminalActive?: boolean;
+  /** Whether this pane is the visible one in the chat/tmux toggle (CSS-hidden, not unmounted, when false). */
+  visible?: boolean;
 }
 
-function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActive = true }: PlanningTmuxPaneProps): JSX.Element {
+function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActive = true, visible = true }: PlanningTmuxPaneProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<XTermTerminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const seededSnapshotRef = useRef<SeededOutputSnapshot | null>(null);
+  const scheduleFitRef = useRef<((opts?: { focus?: boolean }) => void) | null>(null);
 
   useEffect(() => {
     const host = containerRef.current;
@@ -218,6 +223,7 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActi
     }
     termRef.current = term;
     fitRef.current = fit;
+    window.__INVOKER_TEST_ACTIVE_PLANNING_TMUX_TERMINAL__ = term;
 
     seedTerminalOutputSnapshot(term, session, seededSnapshotRef);
 
@@ -241,6 +247,49 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActi
     let scheduledFitKind: 'raf' | 'timeout' | null = null;
     let pendingFocus = false;
     let lastSentSize: { cols: number; rows: number } | null = null;
+    let reconcileTimeoutHandle: number | null = null;
+
+    const cancelReconcile = () => {
+      if (reconcileTimeoutHandle === null) return;
+      window.clearTimeout(reconcileTimeoutHandle);
+      reconcileTimeoutHandle = null;
+    };
+
+    // A resize the main process reported as applied may still not have
+    // stuck (e.g. it raced another in-flight resize, or the report itself
+    // was wrong). Re-check the PTY's own authoritative size for a bounded
+    // number of attempts and retry if it drifted, rather than trusting a
+    // single confirmation forever. The attempt counter is owned entirely by
+    // this loop — a "successful" retry must not reset it, or a main process
+    // that always claims success without the size actually sticking would
+    // retry every interval forever instead of eventually giving up.
+    const runReconcileCheck = async (attempt: number): Promise<void> => {
+      if (disposed || attempt >= PLANNING_TMUX_RECONCILE_MAX_ATTEMPTS) return;
+      const applied = await window.invoker?.planningTerminalAppliedSize?.(session.sessionId);
+      if (disposed || !applied || !lastSentSize) return;
+      if (applied.cols === lastSentSize.cols && applied.rows === lastSentSize.rows) return;
+
+      // The PTY's real size doesn't match what we believe was confirmed —
+      // force a resend rather than relying on tryFit's own dedupe, which is
+      // keyed on the very value that just proved unreliable. Skip having
+      // tryFit reschedule its own fresh reconcile window; this loop keeps
+      // governing the bounded cadence itself.
+      lastSentSize = null;
+      tryFit(false, { skipReconcileSchedule: true });
+      reconcileTimeoutHandle = window.setTimeout(() => {
+        reconcileTimeoutHandle = null;
+        void runReconcileCheck(attempt + 1);
+      }, PLANNING_TMUX_RECONCILE_INTERVAL_MS);
+    };
+
+    const scheduleReconcileCheck = () => {
+      if (disposed) return;
+      cancelReconcile();
+      reconcileTimeoutHandle = window.setTimeout(() => {
+        reconcileTimeoutHandle = null;
+        void runReconcileCheck(0);
+      }, PLANNING_TMUX_RECONCILE_INTERVAL_MS);
+    };
 
     const cancelScheduledFit = () => {
       if (scheduledFitHandle === null) return;
@@ -253,7 +302,7 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActi
       scheduledFitKind = null;
     };
 
-    const tryFit = (focusAfterFit: boolean): boolean => {
+    const tryFit = (focusAfterFit: boolean, options: { skipReconcileSchedule?: boolean } = {}): boolean => {
       try {
         if (disposed || !host.isConnected) return false;
         if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return false;
@@ -274,8 +323,16 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActi
         }
         const nextSize = { cols: term.cols, rows: term.rows };
         if (!lastSentSize || lastSentSize.cols !== nextSize.cols || lastSentSize.rows !== nextSize.rows) {
-          lastSentSize = nextSize;
-          void window.invoker?.planningTerminalResize?.(session.sessionId, nextSize.cols, nextSize.rows);
+          const resizeCall = window.invoker?.planningTerminalResize?.(session.sessionId, nextSize.cols, nextSize.rows);
+          void resizeCall
+            ?.then((result) => {
+              if (disposed || !result?.ok) return;
+              lastSentSize = nextSize;
+              if (!options.skipReconcileSchedule) scheduleReconcileCheck();
+            })
+            .catch(() => {
+              /* leave lastSentSize unset so the next fit opportunity retries the same size */
+            });
         }
         if (focusAfterFit) term.focus();
         return true;
@@ -337,11 +394,13 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActi
 
     document.addEventListener('visibilitychange', handleVisibilityChange);
     window.addEventListener('focus', handleWindowFocus);
+    scheduleFitRef.current = scheduleFit;
     scheduleFit({ focus: true });
 
     return () => {
       disposed = true;
       cancelScheduledFit();
+      cancelReconcile();
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       window.removeEventListener('focus', handleWindowFocus);
       resizeObserver?.disconnect();
@@ -354,8 +413,17 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActi
       }
       termRef.current = null;
       fitRef.current = null;
+      scheduleFitRef.current = null;
+      if (window.__INVOKER_TEST_ACTIVE_PLANNING_TMUX_TERMINAL__ === term) {
+        window.__INVOKER_TEST_ACTIVE_PLANNING_TMUX_TERMINAL__ = null;
+      }
     };
   }, [readOnly, session?.sessionId, terminalActive]);
+
+  useEffect(() => {
+    if (!visible) return;
+    scheduleFitRef.current?.({ focus: true });
+  }, [visible]);
 
   useEffect(() => {
     if (!terminalActive) return;
@@ -689,16 +757,23 @@ export function InvokerTerminal({
         </div>
       </div>
 
-      {mode === 'tmux' ? (
+      <div
+        className="flex min-h-0 flex-1 flex-col"
+        style={{ display: mode === 'tmux' ? 'flex' : 'none' }}
+      >
         <PlanningTmuxPane
           session={terminalSession}
           busy={terminalBusy}
           error={terminalError}
           readOnly={readOnly}
           terminalActive={terminalActive}
+          visible={mode === 'tmux'}
         />
-      ) : (
-        <>
+      </div>
+      <div
+        className="flex min-h-0 flex-1 flex-col"
+        style={{ display: mode === 'tmux' ? 'none' : 'flex' }}
+      >
           <div
             ref={transcriptRef}
             data-testid="invoker-terminal-transcript"
@@ -860,8 +935,7 @@ export function InvokerTerminal({
               </div>
             </div>
           </form>
-        </>
-      )}
+      </div>
     </section>
   );
 }

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -360,5 +360,10 @@ declare global {
     __INVOKER_TRACE_RENDERER_TASK_GRAPH__?: boolean;
     __INVOKER_TEST_OPEN_TERMINAL__?: (taskId: string) => ReturnType<InvokerAPI['openTerminal']>;
     __INVOKER_TEST_ON_TERMINAL_OUTPUT__?: (cb: (event: TerminalOutputEvent) => void) => () => void;
+    /** The live xterm.js Terminal instance backing the planning Tmux pane, when one is mounted. Test-only. */
+    __INVOKER_TEST_ACTIVE_PLANNING_TMUX_TERMINAL__?: {
+      rows: number;
+      buffer: { active: { getLine(n: number): { translateToString(trimRight?: boolean): string } | undefined } };
+    } | null;
   }
 }


### PR DESCRIPTION
Switching the planning terminal between Chat and Tmux mode fully unmounted
the xterm.js Terminal for the inactive side and rebuilt it from scratch on
switch-back, replaying the raw output log into a brand-new instance. Fixed
by keeping both sides mounted and toggling CSS visibility instead of the
render branch itself.

Separately, the terminal always spawned pretending to be 80x24, then a
correct size arrived a moment later over a fire-and-forget resize call the
renderer never checked -- so a single dropped resize meant a permanent
column-width mismatch with whatever program was running inside (e.g. a
CLI's box-drawing UI landing in the wrong columns). The resize is now
awaited and only trusted once confirmed applied, an optional real initial
size can be threaded through TerminalSpec instead of the 80x24 guess, and a
bounded post-resize readback (modeled on a similar mitigation in a
comparable Electron app, Orca) catches and retries a resize that silently
never stuck even after a false "success".

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Depends-On: #6972