### PR TITLE
[Terminal Garbling](2b) Confirm a terminal resize actually stuck before trusting it

### DIFF
--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -63,12 +63,16 @@ function createFakeChild() {
   return ee;
 }
 
-function createFakePty() {
-  const ee = new EventEmitter() as EventEmitter & PtyLike & {
+function createFakePty(initialSize: { cols: number; rows: number } = { cols: 80, rows: 24 }) {
+  const ee = new EventEmitter() as EventEmitter & Omit<PtyLike, 'cols' | 'rows'> & {
+    cols: number;
+    rows: number;
     __written: string[];
     __resized: Array<{ cols: number; rows: number }>;
     killed: boolean;
   };
+  ee.cols = initialSize.cols;
+  ee.rows = initialSize.rows;
   ee.__written = [];
   ee.__resized = [];
   ee.killed = false;
@@ -85,6 +89,8 @@ function createFakePty() {
   };
   ee.resize = (cols: number, rows: number) => {
     ee.__resized.push({ cols, rows });
+    ee.cols = cols;
+    ee.rows = rows;
   };
   ee.kill = () => {
     ee.killed = true;
@@ -569,6 +575,85 @@ describe('EmbeddedTerminalManager', () => {
     );
     expect(res.ok).toBe(true);
     expect(pty.__resized).toEqual([{ cols: 120, rows: 40 }]);
+  });
+
+  it('threads TerminalSpec cols/rows into the PTY spawn call instead of the hardcoded 80x24 default', () => {
+    const pty = createFakePty({ cols: 160, rows: 50 });
+    const ptySpawnFn = vi.fn(() => pty) as unknown as PtySpawnFn;
+    const mgr = new EmbeddedTerminalManager({
+      backend: createPtyTerminalBackend({ spawnFn: ptySpawnFn }),
+    });
+
+    mgr.openOrReuse({
+      taskId: 't',
+      spec: { command: 'claude', cwd: '/tmp', cols: 160, rows: 50 },
+      cwd: '/tmp',
+    });
+
+    expect(ptySpawnFn).toHaveBeenCalledWith(
+      'claude',
+      [],
+      expect.objectContaining({ cols: 160, rows: 50 }),
+    );
+  });
+
+  it('falls back to 80x24 when a TerminalSpec omits cols/rows, unchanged from today', () => {
+    const pty = createFakePty();
+    const ptySpawnFn = vi.fn(() => pty) as unknown as PtySpawnFn;
+    const mgr = new EmbeddedTerminalManager({
+      backend: createPtyTerminalBackend({ spawnFn: ptySpawnFn }),
+    });
+
+    mgr.openOrReuse({ taskId: 't', spec: { command: 'claude', cwd: '/tmp' }, cwd: '/tmp' });
+
+    expect(ptySpawnFn).toHaveBeenCalledWith(
+      'claude',
+      [],
+      expect.objectContaining({ cols: 80, rows: 24 }),
+    );
+  });
+
+  it('getAppliedSize reads the PTY back directly, exposing a resize that silently did not stick', () => {
+    const pty = createFakePty({ cols: 80, rows: 24 });
+    // Simulate a real-world dropped resize: the call is recorded but the
+    // underlying winsize never actually changes.
+    pty.resize = (cols: number, rows: number) => {
+      pty.__resized.push({ cols, rows });
+    };
+    const ptySpawnFn = vi.fn(() => pty) as unknown as PtySpawnFn;
+    const mgr = new EmbeddedTerminalManager({
+      backend: createPtyTerminalBackend({ spawnFn: ptySpawnFn }),
+    });
+    const session = mgr.openOrReuse({ taskId: 't', spec: { cwd: '/tmp' }, cwd: '/tmp' });
+
+    const res = mgr.resize(session.sessionId, 120, 40);
+
+    expect(res.ok).toBe(true);
+    expect(mgr.getAppliedSize(session.sessionId)).toEqual({ cols: 80, rows: 24 });
+  });
+
+  it('getAppliedSize reflects a resize that actually applied', () => {
+    const pty = createFakePty({ cols: 80, rows: 24 });
+    const ptySpawnFn = vi.fn(() => pty) as unknown as PtySpawnFn;
+    const mgr = new EmbeddedTerminalManager({
+      backend: createPtyTerminalBackend({ spawnFn: ptySpawnFn }),
+    });
+    const session = mgr.openOrReuse({ taskId: 't', spec: { cwd: '/tmp' }, cwd: '/tmp' });
+
+    mgr.resize(session.sessionId, 120, 40);
+
+    expect(mgr.getAppliedSize(session.sessionId)).toEqual({ cols: 120, rows: 40 });
+  });
+
+  it('getAppliedSize returns null for the pipe-backed bash backend, which has no real TTY size', () => {
+    const child = createFakeChild();
+    const bashSpawnFn = vi.fn(() => child) as unknown as BashSpawnFn;
+    const mgr = new EmbeddedTerminalManager({
+      backend: createBashTerminalBackend({ spawnFn: bashSpawnFn }),
+    });
+    const session = mgr.openOrReuse({ taskId: 't', spec: { cwd: '/tmp' }, cwd: '/tmp' });
+
+    expect(mgr.getAppliedSize(session.sessionId)).toBeNull();
   });
 
   it('emits exit and removes session when the bash child exits', () => {

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -36,6 +36,8 @@ export interface PtyForkOptionsLike {
 }
 
 export interface PtyLike {
+  readonly cols: number;
+  readonly rows: number;
   onData(listener: (data: string) => void): { dispose: () => void };
   onExit(listener: (event: { exitCode: number }) => void): { dispose: () => void };
   write(data: string): void;
@@ -61,6 +63,8 @@ export interface SpawnedTerminalProcess {
   write(data: string): void;
   resize(cols: number, rows: number): void;
   close(): void;
+  /** Authoritative applied size, read back from the real process. Null when the backend has no TTY (e.g. pipe-backed). */
+  getAppliedSize(): { cols: number; rows: number } | null;
 }
 
 export interface EmbeddedTerminalBackend {
@@ -215,6 +219,10 @@ class BashTerminalBackend implements EmbeddedTerminalBackend {
       resize() {
         // Pipe-backed child processes are not TTYs; resize is a no-op.
       },
+      getAppliedSize() {
+        // Pipes have no real terminal size to read back.
+        return null;
+      },
       close() {
         try {
           if (!child.killed) child.kill();
@@ -245,8 +253,8 @@ class PtyTerminalBackend implements EmbeddedTerminalBackend {
     const args = opts.spec.command ? opts.spec.args ?? [] : [];
     const pty = this.spawnFn(command, args, {
       name: 'xterm-256color',
-      cols: 80,
-      rows: 24,
+      cols: opts.spec.cols ?? 80,
+      rows: opts.spec.rows ?? 24,
       cwd: opts.cwd,
       env: { ...process.env, TERM: process.env.TERM ?? 'xterm-256color' },
     });
@@ -259,6 +267,9 @@ class PtyTerminalBackend implements EmbeddedTerminalBackend {
       },
       resize(cols: number, rows: number) {
         pty.resize(cols, rows);
+      },
+      getAppliedSize() {
+        return { cols: pty.cols, rows: pty.rows };
       },
       close() {
         try {
@@ -446,6 +457,12 @@ export class EmbeddedTerminalManager extends EventEmitter {
     } catch (err) {
       return { ok: false, reason: err instanceof Error ? err.message : String(err) };
     }
+  }
+
+  getAppliedSize(sessionId: string): { cols: number; rows: number } | null {
+    const state = this.sessions.get(sessionId);
+    if (!state || state.mode === 'attached') return null;
+    return state.process.getAppliedSize();
   }
 
   close(sessionId: string): { ok: boolean; reason?: string } {

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -570,6 +570,10 @@ export class EmbeddedTerminalManager extends EventEmitter {
       resize() {
         // Resize before the backend returns a process handle is ignored.
       },
+      getAppliedSize() {
+        // No process handle yet, so there is no real size to read back.
+        return null;
+      },
       close() {
         // There is no process handle to close yet.
       },

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -572,6 +572,12 @@ export function registerPlanningTerminalSessionIpcHandlers(deps: {
     return embeddedTerminalManager.resize(sessionId, cols, rows);
   });
 
+  ipcMain.handle('invoker:planning-terminal-applied-size', async (_event, sessionId: string) => {
+    const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
+    if (!allowed.ok) return null;
+    return embeddedTerminalManager.getAppliedSize(sessionId);
+  });
+
   ipcMain.handle('invoker:planning-terminal-close', async (_event, sessionId: string) => {
     const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
     if (!allowed.ok) return allowed;

--- a/packages/execution-engine/src/executor.ts
+++ b/packages/execution-engine/src/executor.ts
@@ -20,6 +20,10 @@ export interface TerminalSpec {
   args?: string[];
   /** Tail command for Linux terminal launch (e.g. 'exec_bash' or 'pause'). */
   linuxTerminalTail?: 'exec_bash' | 'pause';
+  /** Initial PTY column count. Defaults to 80 when omitted. */
+  cols?: number;
+  /** Initial PTY row count. Defaults to 24 when omitted. */
+  rows?: number;
 }
 
 export interface PersistedTaskMeta {


### PR DESCRIPTION
## Summary

The embedded terminal always spawned pretending to be 80x24, then its real size arrived a moment later.

That real size came from a resize call the renderer never checked the result of.

A single dropped resize left the terminal permanently out of sync with whatever program was running inside it.

This slice adds plumbing two later fixes need: spawning at a real initial size, and reading back the size a terminal actually has right now.

## Review Claim

Approve that `TerminalSpec.cols`/`rows` flow through to the real PTY spawn call (falling back to 80x24 exactly as before when omitted), and that `EmbeddedTerminalManager.getAppliedSize` returns the PTY's live, authoritative size.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

Every existing caller omits `cols`/`rows`, so every existing session still spawns at exactly 80x24 -- this is additive plumbing, not a default change.

## Slice Rationale

Kept apart from the renderer-side fix (next slice) so this backend piece can be reviewed and tested on its own before anything depends on it.

## Non-goals

No behavior change: nothing in the renderer calls the new applied-size channel yet, and no existing session's initial size changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #6975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring initial terminal dimensions, with an 80×24 default.
  * Added terminal size reporting so clients can verify the dimensions applied to a session.
  * Added safe handling for unavailable sizes, including pipe-backed sessions and invalid or unattached sessions.

* **Bug Fixes**
  * Improved detection and reporting when terminal resize operations are not applied successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->