### PR TITLE
[Terminal Garbling](4) Fix a third occurrence: the planning-bridge banner splice

### DIFF
--- a/packages/app/e2e/planning-surface-navigation-garble-repro.spec.ts
+++ b/packages/app/e2e/planning-surface-navigation-garble-repro.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Reproduces the SAME unmount-on-conditional-render bug as
+ * planning-terminal-chat-tmux-toggle-garble-repro.spec.ts, but triggered by
+ * navigating away from the Planning surface (Home) to the Workflow graph
+ * surface and back, instead of the internal Chat/Tmux toggle.
+ *
+ * Root cause: packages/ui/src/App.tsx has a top-level ternary keyed on
+ * `sidebarSurface` (~line 4998) that renders EITHER
+ * renderPlanningTerminalSurface() (contains InvokerTerminal/PlanningTmuxPane)
+ * OR the Workflow graph OR other surfaces -- never more than one at a time.
+ * That's a plain conditional render, not a persistent-mount + CSS-toggle, so
+ * switching sidebarSurface fully unmounts/remounts InvokerTerminal, which
+ * destroys the live xterm.js terminal exactly like the Chat/Tmux bug did
+ * before it was fixed. The Chat/Tmux fix only protects a component that
+ * stays mounted -- it can't help once the component's own parent stops
+ * rendering it.
+ */
+
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures/electron-app.js';
+
+async function openHome(page: Page): Promise<void> {
+  await page.getByTestId('sidebar-home').click();
+  await expect(page.getByTestId('invoker-terminal-input')).toBeVisible({ timeout: 10000 });
+}
+
+async function readOutputSnapshot(page: Page, sessionId: string): Promise<string> {
+  return page.evaluate(async (targetSessionId) => {
+    const sessions = await window.invoker.planningTerminalList();
+    return sessions.find((session) => session.sessionId === targetSessionId)?.outputSnapshot ?? '';
+  }, sessionId);
+}
+
+async function openPlanningTmux(page: Page): Promise<string> {
+  await page.getByTestId('invoker-terminal-mode-toggle').getByRole('tab', { name: 'Tmux' }).click();
+  const pane = page.getByTestId('invoker-terminal-tmux-pane');
+  await expect(pane).toBeVisible({ timeout: 10000 });
+  const sessionId = await pane.getAttribute('data-session-id');
+  expect(sessionId).toBeTruthy();
+  await expect.poll(async () => readOutputSnapshot(page, sessionId ?? ''), { timeout: 10000 }).toContain('Invoker planning tmux bridge');
+  return sessionId ?? '';
+}
+
+async function writeToTmux(page: Page, sessionId: string, data: string): Promise<void> {
+  const result = await page.evaluate(async ({ targetSessionId, payload }) => {
+    return window.invoker.planningTerminalWrite(targetSessionId, payload);
+  }, { targetSessionId: sessionId, payload: data });
+  expect(result).toMatchObject({ ok: true });
+}
+
+async function readTmuxBufferText(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const term = window.__INVOKER_TEST_ACTIVE_PLANNING_TMUX_TERMINAL__;
+    if (!term) return null;
+    const lines: string[] = [];
+    for (let row = 0; row < term.rows; row += 1) {
+      lines.push(term.buffer.active.getLine(row)?.translateToString(true) ?? '');
+    }
+    return lines.join('\n');
+  });
+}
+
+async function closePlanningTerminalSessions(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const sessions = await window.invoker.planningTerminalList();
+    await Promise.all(sessions.map((session) => window.invoker.planningTerminalClose(session.sessionId)));
+  }).catch(() => undefined);
+}
+
+const FRAME_MARKER = 'FULLSCREEN_FRAME_READY';
+const DRAW_FULL_SCREEN_FRAME =
+  "printf '\\033[2J\\033[H'" +
+  "; printf '\\033[3;5HTOP LEFT FRAME'" +
+  "; printf '\\033[10;20HBOTTOM RIGHT FRAME'" +
+  `; printf '\\033[24;1H${FRAME_MARKER}'` +
+  '\n';
+
+test.describe('Planning surface navigation garble repro', () => {
+  test('tmux pane keeps the same rendered content across a Planning -> Workflow graph -> Planning round trip', async ({ page }, testInfo) => {
+    let sessionId = '';
+    try {
+      await openHome(page);
+      sessionId = await openPlanningTmux(page);
+
+      await writeToTmux(page, sessionId, DRAW_FULL_SCREEN_FRAME);
+      await expect.poll(async () => readOutputSnapshot(page, sessionId), { timeout: 10000 }).toContain(FRAME_MARKER);
+      await page.waitForTimeout(300);
+
+      const renderedBefore = await readTmuxBufferText(page);
+      expect(renderedBefore, 'expected the test hook to expose the live xterm.js Terminal').not.toBeNull();
+      const beforeScreenshot = testInfo.outputPath('surface-nav-before.png');
+      await page.screenshot({ path: beforeScreenshot });
+      await testInfo.attach('before-nav', { path: beforeScreenshot, contentType: 'image/png' });
+      await testInfo.attach('rendered-buffer-before', { body: renderedBefore ?? '', contentType: 'text/plain' });
+
+      // Navigate away to the Workflow graph surface and back to Planning --
+      // no interaction with the terminal at all, just top-level nav. The
+      // Home surface now stays mounted (fixed), just CSS-hidden -- it no
+      // longer disappears from the DOM.
+      await page.getByTestId('sidebar-planning').click();
+      await expect(page.getByTestId('invoker-terminal-input')).not.toBeVisible();
+      await page.waitForTimeout(300);
+
+      // `mode` ('chat' vs 'tmux') is shared App-level state, not internal to
+      // InvokerTerminal, so it survives the remount and the pane comes back
+      // already in Tmux mode -- don't assume the chat input reappears.
+      await page.getByTestId('sidebar-home').click();
+      await expect(page.getByTestId('sidebar-home')).toHaveAttribute('aria-current', 'page', { timeout: 10000 });
+      const paneAfterNav = page.getByTestId('invoker-terminal-tmux-pane');
+      await expect(paneAfterNav).toBeVisible({ timeout: 10000 });
+      const sessionIdAfterNav = await paneAfterNav.getAttribute('data-session-id');
+      await page.waitForTimeout(300);
+
+      const renderedAfter = await readTmuxBufferText(page);
+      const afterScreenshot = testInfo.outputPath('surface-nav-after.png');
+      await page.screenshot({ path: afterScreenshot });
+      await testInfo.attach('after-nav', { path: afterScreenshot, contentType: 'image/png' });
+      await testInfo.attach('rendered-buffer-after', { body: renderedAfter ?? '', contentType: 'text/plain' });
+
+      expect(sessionIdAfterNav, 'the tmux pane must keep attaching to the same backend session after nav').toBe(sessionId);
+      expect(renderedAfter, 'the rendered terminal content must be identical before and after navigating Planning -> Workflow graph -> Planning').toBe(renderedBefore);
+    } finally {
+      if (sessionId) {
+        await closePlanningTerminalSessions(page);
+      }
+    }
+  });
+});

--- a/packages/app/e2e/planning-terminal-expand-collapse-garble-repro.spec.ts
+++ b/packages/app/e2e/planning-terminal-expand-collapse-garble-repro.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * Reproduces a THIRD instance of the same underlying bug class, via a
+ * different mechanism than the other two repros in this directory.
+ *
+ * App.tsx renders TWO separate <InvokerTerminal> elements at two different
+ * JSX positions: an inline one (~App.tsx:4748) and a fixed-overlay one
+ * (~App.tsx:5083, only mounted while `planningTerminalExpanded` is true).
+ * The inline instance's `terminalActive` prop is `!planningTerminalExpanded`
+ * (App.tsx:4764) -- so expanding/collapsing the planning chat does not
+ * merely show/hide an overlay, it also flips the INLINE instance's
+ * `terminalActive` prop. PlanningTmuxPane's mount effect
+ * (InvokerTerminal.tsx) is keyed on `terminalActive` in its dependency
+ * array, so flipping it disposes the xterm.js Terminal and, when flipped
+ * back, creates a brand-new one reseeded from the raw output log -- the
+ * same garbling mechanism as the other two repros, triggered by the
+ * Expand/Close buttons instead of a mode toggle or surface navigation.
+ */
+
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures/electron-app.js';
+
+async function openHome(page: Page): Promise<void> {
+  await page.getByTestId('sidebar-home').click();
+  await expect(page.getByTestId('invoker-terminal-input')).toBeVisible({ timeout: 10000 });
+}
+
+async function readOutputSnapshot(page: Page, sessionId: string): Promise<string> {
+  return page.evaluate(async (targetSessionId) => {
+    const sessions = await window.invoker.planningTerminalList();
+    return sessions.find((session) => session.sessionId === targetSessionId)?.outputSnapshot ?? '';
+  }, sessionId);
+}
+
+async function openPlanningTmux(page: Page): Promise<string> {
+  await page.getByTestId('invoker-terminal-mode-toggle').getByRole('tab', { name: 'Tmux' }).click();
+  const pane = page.getByTestId('invoker-terminal-tmux-pane');
+  await expect(pane).toBeVisible({ timeout: 10000 });
+  const sessionId = await pane.getAttribute('data-session-id');
+  expect(sessionId).toBeTruthy();
+  await expect.poll(async () => readOutputSnapshot(page, sessionId ?? ''), { timeout: 10000 }).toContain('Invoker planning tmux bridge');
+  return sessionId ?? '';
+}
+
+async function writeToTmux(page: Page, sessionId: string, data: string): Promise<void> {
+  const result = await page.evaluate(async ({ targetSessionId, payload }) => {
+    return window.invoker.planningTerminalWrite(targetSessionId, payload);
+  }, { targetSessionId: sessionId, payload: data });
+  expect(result).toMatchObject({ ok: true });
+}
+
+async function readTmuxBufferText(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const term = window.__INVOKER_TEST_ACTIVE_PLANNING_TMUX_TERMINAL__;
+    if (!term) return null;
+    const lines: string[] = [];
+    for (let row = 0; row < term.rows; row += 1) {
+      lines.push(term.buffer.active.getLine(row)?.translateToString(true) ?? '');
+    }
+    return lines.join('\n');
+  });
+}
+
+/** Expanding to a fixed full-screen overlay legitimately gives xterm.js more
+ * rows to fill (a real resize, not corruption) -- trailing blank lines
+ * differ for that reason alone. Strip them so the comparison only catches
+ * actual content differences. */
+function trimTrailingBlankLines(text: string): string {
+  return text.replace(/(\n[ \t]*)+$/, '');
+}
+
+async function closePlanningTerminalSessions(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const sessions = await window.invoker.planningTerminalList();
+    await Promise.all(sessions.map((session) => window.invoker.planningTerminalClose(session.sessionId)));
+  }).catch(() => undefined);
+}
+
+const FRAME_MARKER = 'FULLSCREEN_FRAME_READY';
+const DRAW_FULL_SCREEN_FRAME =
+  "printf '\\033[2J\\033[H'" +
+  "; printf '\\033[3;5HTOP LEFT FRAME'" +
+  "; printf '\\033[10;20HBOTTOM RIGHT FRAME'" +
+  `; printf '\\033[24;1H${FRAME_MARKER}'` +
+  '\n';
+
+test.describe('Planning terminal Expand/Close garble repro', () => {
+  test('tmux pane keeps the same rendered content across an Expand -> Close round trip', async ({ page }, testInfo) => {
+    let sessionId = '';
+    try {
+      await openHome(page);
+      sessionId = await openPlanningTmux(page);
+
+      await writeToTmux(page, sessionId, DRAW_FULL_SCREEN_FRAME);
+      await expect.poll(async () => readOutputSnapshot(page, sessionId), { timeout: 10000 }).toContain(FRAME_MARKER);
+      await page.waitForTimeout(300);
+
+      const renderedBeforeExpand = await readTmuxBufferText(page);
+      expect(renderedBeforeExpand, 'expected the test hook to expose the live xterm.js Terminal').not.toBeNull();
+      await testInfo.attach('rendered-buffer-before-expand', { body: renderedBeforeExpand ?? '', contentType: 'text/plain' });
+
+      await page.getByRole('button', { name: 'Expand planning chat' }).click();
+      const overlay = page.getByTestId('invoker-terminal-expanded');
+      await expect(overlay).toBeVisible({ timeout: 10000 });
+      await expect(overlay.getByTestId('invoker-terminal-tmux-pane')).toBeVisible({ timeout: 10000 });
+      await page.waitForTimeout(500);
+
+      const renderedWhileExpanded = await readTmuxBufferText(page);
+      await testInfo.attach('rendered-buffer-while-expanded', { body: renderedWhileExpanded ?? '', contentType: 'text/plain' });
+      const expandedScreenshot = testInfo.outputPath('expand-collapse-expanded.png');
+      await page.screenshot({ path: expandedScreenshot });
+      await testInfo.attach('while-expanded', { path: expandedScreenshot, contentType: 'image/png' });
+
+      await overlay.getByRole('button', { name: 'Close planning chat' }).click();
+      await expect(overlay).toHaveCount(0);
+      await page.waitForTimeout(500);
+
+      const renderedAfterClose = await readTmuxBufferText(page);
+      const afterScreenshot = testInfo.outputPath('expand-collapse-after-close.png');
+      await page.screenshot({ path: afterScreenshot });
+      await testInfo.attach('after-close', { path: afterScreenshot, contentType: 'image/png' });
+      await testInfo.attach('rendered-buffer-after-close', { body: renderedAfterClose ?? '', contentType: 'text/plain' });
+
+      // Expanding genuinely resizes the pane (more rows in a fullscreen
+      // overlay), so compare ignoring trailing blank padding from that
+      // resize -- the actual content must still be untouched.
+      expect(
+        trimTrailingBlankLines(renderedWhileExpanded ?? ''),
+        'the rendered terminal content must be unchanged (aside from added blank rows from the legitimate resize) when first expanding the planning chat',
+      ).toBe(trimTrailingBlankLines(renderedBeforeExpand ?? ''));
+      // Closing returns to the exact same viewport size as before expanding,
+      // so this must be a byte-for-byte match, not just a trimmed one.
+      expect(renderedAfterClose, 'the rendered terminal content must be identical after an Expand -> Close round trip').toBe(renderedBeforeExpand);
+    } finally {
+      if (sessionId) {
+        await closePlanningTerminalSessions(page);
+      }
+    }
+  });
+});

--- a/packages/app/e2e/task-terminal-drawer-minimize-garble-repro.spec.ts
+++ b/packages/app/e2e/task-terminal-drawer-minimize-garble-repro.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Reproduces the same bug class one more time: TerminalDrawer.tsx used to
+ * unmount its entire body (every open task terminal, not just one) whenever
+ * the drawer was minimized (`{showBody && (...)}`, showBody = state !==
+ * 'minimized'). Minimizing then restoring the drawer destroyed and
+ * recreated every xterm.js Terminal, replaying each session's raw output
+ * log into a fresh instance.
+ *
+ * Fixed by keeping the body always mounted and toggling `display: none`
+ * instead (mirroring the fix already applied to the planning terminal and
+ * the App.tsx surface router). This spec proves it the same rigorous way:
+ * capture the terminal's actual rendered buffer text, minimize/restore,
+ * compare.
+ */
+
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+import type { Page } from '@playwright/test';
+import { E2E_REPO_URL, expect, injectTaskStates, loadPlan, test } from './fixtures/electron-app.js';
+
+const SCROLLBACK_PLAN = {
+  name: 'Task Terminal Drawer Minimize Repro',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    {
+      id: 'drawer-minimize-task',
+      description: 'Completed task for drawer minimize repro',
+      command: 'echo unused',
+      dependencies: [],
+    },
+  ],
+};
+
+async function readTaskTerminalBufferText(page: Page, sessionId: string): Promise<string | null> {
+  return page.evaluate((targetSessionId) => {
+    const term = window.__INVOKER_TEST_TASK_TERMINALS__?.get(targetSessionId);
+    if (!term) return null;
+    const lines: string[] = [];
+    for (let row = 0; row < term.rows; row += 1) {
+      lines.push(term.buffer.active.getLine(row)?.translateToString(true) ?? '');
+    }
+    return lines.join('\n');
+  }, sessionId);
+}
+
+async function readOutputSnapshot(page: Page, sessionId: string): Promise<string> {
+  return page.evaluate(async (targetSessionId) => {
+    const sessions = await window.invoker.terminalList();
+    return sessions.find((session) => session.sessionId === targetSessionId)?.outputSnapshot ?? '';
+  }, sessionId);
+}
+
+async function writeToTerminal(page: Page, sessionId: string, data: string): Promise<void> {
+  const result = await page.evaluate(async ({ targetSessionId, payload }) => {
+    return window.invoker.terminalWrite(targetSessionId, payload);
+  }, { targetSessionId: sessionId, payload: data });
+  expect(result).toMatchObject({ ok: true });
+}
+
+const FRAME_MARKER = 'FULLSCREEN_FRAME_READY';
+const DRAW_FULL_SCREEN_FRAME =
+  "printf '\\033[2J\\033[H'" +
+  "; printf '\\033[3;5HTOP LEFT FRAME'" +
+  "; printf '\\033[10;20HBOTTOM RIGHT FRAME'" +
+  `; printf '\\033[24;1H${FRAME_MARKER}'` +
+  '\n';
+
+test.describe('Task terminal drawer minimize garble repro', () => {
+  test('task terminal keeps the same rendered content across a minimize -> restore round trip', async ({ page, testDir }) => {
+    await loadPlan(page, SCROLLBACK_PLAN);
+    const workspacePath = path.join(testDir, 'drawer-minimize-workspace');
+    mkdirSync(workspacePath, { recursive: true });
+
+    await injectTaskStates(page, [
+      {
+        taskId: 'drawer-minimize-task',
+        changes: {
+          status: 'completed',
+          execution: { workspacePath, completedAt: new Date('2025-01-01T00:00:00.000Z') },
+        },
+      },
+    ]);
+
+    const tasksResult = await page.evaluate(() => window.invoker.getTasks());
+    const tasks = Array.isArray(tasksResult) ? tasksResult : tasksResult.tasks;
+    const task = tasks.find((candidate) => candidate.id.endsWith('/drawer-minimize-task'));
+    const fullTaskId = task?.id;
+    expect(fullTaskId).toBeTruthy();
+
+    const taskNode = page
+      .getByTestId('selected-workflow-mini-dag')
+      .locator('.react-flow__node[data-testid$="drawer-minimize-task"]')
+      .first();
+    const box = await taskNode.boundingBox();
+    if (!box) throw new Error('drawer-minimize-task node has no bounding box');
+    await taskNode.locator('> div').dispatchEvent('dblclick', {
+      bubbles: true,
+      cancelable: true,
+      clientX: box.x + box.width / 2,
+      clientY: box.y + box.height / 2,
+    });
+
+    await expect(page.getByTestId('terminal-drawer-body')).toBeVisible({ timeout: 10000 });
+    const terminalPane = page.getByTestId(`terminal-pane-${fullTaskId}`);
+    await expect(terminalPane).toBeVisible({ timeout: 10000 });
+    const sessionId = await terminalPane.getAttribute('data-session-id');
+    expect(sessionId).toBeTruthy();
+
+    await writeToTerminal(page, sessionId!, DRAW_FULL_SCREEN_FRAME);
+    await expect.poll(async () => readOutputSnapshot(page, sessionId!), { timeout: 10000 }).toContain(FRAME_MARKER);
+    await page.waitForTimeout(300);
+
+    const renderedBefore = await readTaskTerminalBufferText(page, sessionId!);
+    expect(renderedBefore, 'expected the test hook to expose the live task terminal').not.toBeNull();
+
+    // The single cycle button only goes minimized -> partial -> maximized ->
+    // minimized; from the initial 'partial' state, reach 'minimized' via
+    // 'maximized' first. This used to unmount the terminal body entirely.
+    await page.getByRole('button', { name: 'Maximize terminal drawer' }).click();
+    await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'maximized');
+    await page.getByRole('button', { name: 'Minimize terminal drawer' }).click();
+    await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'minimized');
+    await page.waitForTimeout(300);
+
+    // Restore it.
+    await page.getByRole('button', { name: 'Partial terminal drawer' }).click();
+    await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
+    await expect(terminalPane).toBeVisible({ timeout: 10000 });
+    await page.waitForTimeout(300);
+
+    const sessionIdAfter = await terminalPane.getAttribute('data-session-id');
+    const renderedAfter = await readTaskTerminalBufferText(page, sessionId!);
+
+    expect(sessionIdAfter, 'the drawer must keep attaching to the same backend session after minimize/restore').toBe(sessionId);
+    expect(renderedAfter, 'the rendered terminal content must be identical after a minimize -> restore round trip').toBe(renderedBefore);
+  });
+});

--- a/packages/app/src/__tests__/planning-terminal-bridge-truncated-escape-garble-repro.test.ts
+++ b/packages/app/src/__tests__/planning-terminal-bridge-truncated-escape-garble-repro.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Reproduces a THIRD occurrence of the same bug class already fixed once in
+ * embedded-terminal-manager.ts's trimOutputSnapshot: raw PTY output gets
+ * trimmed to a byte-count budget with zero awareness of ANSI escape
+ * sequences, so the cut can land mid-sequence and produce a dangling
+ * fragment that a terminal renders as garbled literal text / a corrupted
+ * cursor position.
+ *
+ * Root cause: in-app-planner.ts's ensurePlanningTerminalSummaryBridge splices
+ * a plain-text status banner into the live output snapshot, then -- when the
+ * combined length exceeds maxLength -- trims the *surrounding real PTY
+ * output* with a blind `rest.slice(rest.length - keepableRestLength)`. That
+ * surrounding output is a real shell session's raw bytes (prompt themes,
+ * cursor positioning, etc.), so the same escape-sequence-safety gap that
+ * trimOutputSnapshot had applies here too.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ensurePlanningTerminalSummaryBridge,
+  buildPlanningTerminalSummaryBridge,
+  type InAppPlanningChatSession,
+} from '../in-app-planner.js';
+import { PlanConversation } from '@invoker/surfaces';
+
+function makeSession(): InAppPlanningChatSession {
+  return {
+    id: 'planning-bridge-trim-repro',
+    title: 'Untitled plan',
+    presetKey: 'codex',
+    confirmationMode: 'require',
+    status: 'still_discussing',
+    messages: [],
+    conversation: new PlanConversation({}),
+    createdAt: '2026-07-07T00:00:00.000Z',
+    updatedAt: '2026-07-07T00:00:00.000Z',
+    nextMessageId: 1,
+  };
+}
+
+describe('ensurePlanningTerminalSummaryBridge truncated-escape garble repro', () => {
+  it('does not cut a raw ANSI escape sequence in half when trimming surrounding output to fit maxLength', () => {
+    const session = makeSession();
+    const bridge = buildPlanningTerminalSummaryBridge(session);
+
+    const ESC = '\x1b';
+    const escSeq = `${ESC}[24;1H`; // 7 chars: ESC [ 2 4 ; 1 H (cursor-position sequence)
+    const cutIndex = 2; // naive cut drops "ESC [", keeping only the dangling "24;1H"
+    const escSeqPrefix = escSeq.slice(0, cutIndex);
+    const escSeqSuffix = escSeq.slice(cutIndex);
+
+    const maxLength = 400;
+    const keepableRestLength = maxLength - bridge.length;
+    const marker = 'CLEAN_TAIL_AFTER_ESCAPE';
+    const restTail = escSeqSuffix + marker.padEnd(keepableRestLength - escSeqSuffix.length, 'z');
+    // No existing bridge markers in this snapshot, so prefix='' and
+    // suffix=snapshot -- `rest` inside the function is this whole string.
+    const droppedPadding = 'a'.repeat(500) + escSeqPrefix;
+    const fullSnapshot = droppedPadding + restTail;
+    expect(fullSnapshot.length).toBeGreaterThan(maxLength);
+
+    const result = ensurePlanningTerminalSummaryBridge(session, fullSnapshot, maxLength);
+    expect(result.startsWith(bridge)).toBe(true);
+    const trimmedRest = result.slice(bridge.length);
+
+    // The full escape sequence must survive intact, not be sliced in half.
+    expect(trimmedRest.startsWith(escSeq)).toBe(true);
+    expect(trimmedRest.startsWith(escSeqSuffix) && !trimmedRest.startsWith(escSeq)).toBe(false);
+  });
+});

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -720,10 +720,21 @@ function findSafeTrimStart(snapshot: string, naiveCutIndex: number): number {
   return cutIsInsideSequence ? escapeIndex : naiveCutIndex;
 }
 
+/**
+ * Trims `text` to at most `maxChars`, backing the cut point up to the start
+ * of any ANSI/VT escape sequence it would otherwise slice through. Shared
+ * by any code path that trims raw PTY-originated text to a length budget --
+ * blindly slicing such text by character count risks leaving a dangling
+ * escape-sequence fragment that a terminal renders as garbled literal text.
+ */
+export function trimPreservingEscapeSequences(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const naiveCutIndex = text.length - maxChars;
+  return text.slice(findSafeTrimStart(text, naiveCutIndex));
+}
+
 function trimOutputSnapshot(snapshot: string): string {
-  if (snapshot.length <= MAX_OUTPUT_SNAPSHOT_CHARS) return snapshot;
-  const naiveCutIndex = snapshot.length - MAX_OUTPUT_SNAPSHOT_CHARS;
-  return snapshot.slice(findSafeTrimStart(snapshot, naiveCutIndex));
+  return trimPreservingEscapeSequences(snapshot, MAX_OUTPUT_SNAPSHOT_CHARS);
 }
 
 function resolveBackend(options: EmbeddedTerminalManagerOptions): EmbeddedTerminalBackend {

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { trimPreservingEscapeSequences } from './embedded-terminal-manager.js';
 import type {
   InAppPlanRequest,
   InAppPlanResponse,
@@ -345,9 +346,7 @@ export function ensurePlanningTerminalSummaryBridge(
   // out immediately; trim the older raw output instead of the freshly composed bridge.
   const rest = `${prefix}${suffix}`;
   const keepableRestLength = Math.max(0, maxLength - bridge.length);
-  const trimmedRest = rest.length <= keepableRestLength
-    ? rest
-    : rest.slice(rest.length - keepableRestLength);
+  const trimmedRest = trimPreservingEscapeSequences(rest, keepableRestLength);
   return `${bridge}${trimmedRest}`;
 }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -42,6 +42,7 @@ import { groupWorkflowCoreActivity } from './lib/workflow-core-activity.js';
 import { ActionGraphView } from './components/ActionGraphView.js';
 import { WorkflowStatusChips } from './components/WorkflowStatusChips.js';
 import { TerminalDrawer, type TerminalDrawerState } from './components/TerminalDrawer.js';
+import { KeepMounted } from './components/KeepMounted.js';
 import { LeftStatusColumn } from './components/LeftStatusColumn.js';
 import { BrowserTaskRow, BrowserWorkflowRow } from './components/BrowserListRows.js';
 import { useTheme } from './lib/theme.js';
@@ -4744,7 +4745,13 @@ export function App() {
             )}
           </div>
         </div>
-        <div className="min-h-0 flex-1 overflow-hidden bg-background">
+        <div
+          className={planningTerminalExpanded ? 'fixed inset-0 z-50 flex flex-col bg-card' : 'min-h-0 flex-1 overflow-hidden bg-background'}
+          data-testid={planningTerminalExpanded ? 'invoker-terminal-expanded' : undefined}
+          role={planningTerminalExpanded ? 'dialog' : undefined}
+          aria-modal={planningTerminalExpanded ? true : undefined}
+          aria-label={planningTerminalExpanded ? 'Planning chat' : undefined}
+        >
           <InvokerTerminal
             activeConversationKey={activePlanningConversationKey}
             lines={terminalLines}
@@ -4757,11 +4764,11 @@ export function App() {
             draftPlanSummary={draftPlanSummary}
             planningStream={activePlanningStream}
             readOnly={activePlanningReadOnly}
+            expanded={planningTerminalExpanded}
             mode={activePlanningMode}
             terminalSession={activePlanningTerminalSession}
             terminalBusy={activePlanningTerminalBusy}
             terminalError={activePlanningTerminalError}
-            terminalActive={!planningTerminalExpanded}
             submittedPlanName={activePlanningSession.submittedPlanName}
             onValueChange={setPlanningInput}
             onSubmit={() => void handlePlanningSubmit()}
@@ -4769,8 +4776,13 @@ export function App() {
             onConfirmationModeChange={handlePlanningConfirmationModeChange}
             onModeChange={(mode) => void handlePlanningModeChange(mode)}
             onExpand={() => setPlanningTerminalExpanded(true)}
-            onOpenGraph={() => navigatePlanGraphPreservingViewport('planning-open-graph')}
+            onCloseExpanded={() => setPlanningTerminalExpanded(false)}
+            onOpenGraph={() => {
+              setPlanningTerminalExpanded(false);
+              navigatePlanGraphPreservingViewport('planning-open-graph');
+            }}
             onReviewDraft={() => {
+              setPlanningTerminalExpanded(false);
               setReviewDraftSessionId(activePlanningSession.id);
               setPlanningContextCollapsed(false);
             }}
@@ -4872,7 +4884,6 @@ export function App() {
       <div className="min-h-0 flex-1 flex flex-col overflow-hidden">
         {renderGraphCanvas()}
       </div>
-      {viewMode === 'dag' && renderGraphTerminalChrome()}
     </div>
   );
 
@@ -4995,20 +5006,25 @@ export function App() {
 
         <div className="flex min-h-0 flex-1 overflow-hidden">
           <main className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
-            {sidebarSurface === 'home' ? (
-              renderPlanningTerminalSurface()
-            ) : sidebarSurface === 'planning' ? (
+            <KeepMounted active={sidebarSurface === 'home'} className="flex min-h-0 flex-1 flex-col overflow-hidden">
+              {renderPlanningTerminalSurface()}
+            </KeepMounted>
+            {sidebarSurface === 'planning' ? (
               renderGraphWorkspace('Plan graph', homeSubtitle, true)
             ) : sidebarSurface === 'workers' ? (
               renderWorkersSurface()
-            ) : (
+            ) : sidebarSurface !== 'home' ? (
               <div className="flex min-h-0 flex-1 overflow-hidden">
                 {renderBrowserRail()}
                 {renderBrowserDetailWorkspace()}
               </div>
-            )}
+            ) : null}
 
-            {sidebarSurface === 'planning' && viewMode === 'dag' && renderGraphTerminalChrome()}
+            <KeepMounted
+              active={viewMode === 'dag' && (sidebarSurface === 'planning' || sidebarSurface === 'workflows' || sidebarSurface === 'attention')}
+            >
+              {renderGraphTerminalChrome()}
+            </KeepMounted>
           </main>
 
           {sidebarSurface !== 'home' && sidebarSurface !== 'workers' && (
@@ -5071,53 +5087,6 @@ export function App() {
         </div>
       </div>
 
-
-      {planningTerminalExpanded && (
-        <div
-          data-testid="invoker-terminal-expanded"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Planning chat"
-          className="fixed inset-0 z-50 flex flex-col bg-card"
-        >
-          <InvokerTerminal
-            activeConversationKey={activePlanningConversationKey}
-            lines={terminalLines}
-            busy={activePlanningSessionBusy}
-            value={planningInput}
-            selectedPresetKey={selectedPlanningPresetKey}
-            presetOptions={planningPresetOptions}
-            selectedConfirmationMode={selectedPlanningConfirmationMode}
-            draftPlanAvailable={draftPlanAvailable}
-            draftPlanSummary={draftPlanSummary}
-            planningStream={activePlanningStream}
-            expanded
-            mode={activePlanningMode}
-            terminalSession={activePlanningTerminalSession}
-            terminalBusy={activePlanningTerminalBusy}
-            terminalError={activePlanningTerminalError}
-            terminalActive
-            submittedPlanName={activePlanningSession.submittedPlanName}
-            onValueChange={setPlanningInput}
-            readOnly={activePlanningReadOnly}
-            onSubmit={() => void handlePlanningSubmit()}
-            onPresetChange={handlePlanningPresetChange}
-            onConfirmationModeChange={handlePlanningConfirmationModeChange}
-            onModeChange={(mode) => void handlePlanningModeChange(mode)}
-            onExpand={() => setPlanningTerminalExpanded(true)}
-            onCloseExpanded={() => setPlanningTerminalExpanded(false)}
-            onOpenGraph={() => {
-              setPlanningTerminalExpanded(false);
-              navigatePlanGraphPreservingViewport('planning-expanded-open-graph');
-            }}
-            onReviewDraft={() => {
-              setPlanningTerminalExpanded(false);
-              setReviewDraftSessionId(activePlanningSession.id);
-              setPlanningContextCollapsed(false);
-            }}
-          />
-        </div>
-      )}
 
       {graphMaximized && (
         <div

--- a/packages/ui/src/__tests__/keep-mounted.test.tsx
+++ b/packages/ui/src/__tests__/keep-mounted.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { useRef } from 'react';
+import { KeepMounted } from '../components/KeepMounted.js';
+
+function MountCounter({ onMount }: { onMount: () => void }): JSX.Element {
+  const mountedRef = useRef(false);
+  if (!mountedRef.current) {
+    mountedRef.current = true;
+    onMount();
+  }
+  return <div data-testid="mount-counter-child">child</div>;
+}
+
+describe('KeepMounted', () => {
+  it('renders nothing before the first activation', () => {
+    const { container } = render(
+      <KeepMounted active={false}>
+        <div data-testid="content">content</div>
+      </KeepMounted>,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('mounts children once activated', () => {
+    const { queryByTestId, rerender } = render(
+      <KeepMounted active={false}>
+        <div data-testid="content">content</div>
+      </KeepMounted>,
+    );
+    expect(queryByTestId('content')).not.toBeInTheDocument();
+
+    rerender(
+      <KeepMounted active={true}>
+        <div data-testid="content">content</div>
+      </KeepMounted>,
+    );
+    expect(queryByTestId('content')).toBeInTheDocument();
+  });
+
+  it('never unmounts children again after deactivating, only hides them with CSS', () => {
+    const onMount = vi.fn();
+    const { queryByTestId, getByTestId, rerender } = render(
+      <KeepMounted active={true}>
+        <MountCounter onMount={onMount} />
+      </KeepMounted>,
+    );
+    expect(onMount).toHaveBeenCalledTimes(1);
+    expect(getByTestId('mount-counter-child')).toBeInTheDocument();
+
+    rerender(
+      <KeepMounted active={false}>
+        <MountCounter onMount={onMount} />
+      </KeepMounted>,
+    );
+    // Still present in the DOM (not unmounted) -- just hidden.
+    const child = queryByTestId('mount-counter-child');
+    expect(child).toBeInTheDocument();
+    expect(child?.parentElement).toHaveStyle({ display: 'none' });
+    // A real unmount+remount would call onMount a second time.
+    expect(onMount).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <KeepMounted active={true}>
+        <MountCounter onMount={onMount} />
+      </KeepMounted>,
+    );
+    expect(getByTestId('mount-counter-child').parentElement).not.toHaveStyle({ display: 'none' });
+    expect(onMount).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the given className while active without an inline display override', () => {
+    const { container } = render(
+      <KeepMounted active={true} className="flex min-h-0 flex-1 flex-col">
+        <div>content</div>
+      </KeepMounted>,
+    );
+    const wrapper = container.firstElementChild;
+    expect(wrapper).toHaveClass('flex', 'min-h-0', 'flex-1', 'flex-col');
+    expect(wrapper).not.toHaveStyle({ display: 'none' });
+  });
+});

--- a/packages/ui/src/__tests__/keyboard-controls.test.tsx
+++ b/packages/ui/src/__tests__/keyboard-controls.test.tsx
@@ -367,7 +367,7 @@ describe('Side rail controls (component)', () => {
 
     key('ArrowDown');
     await waitFor(() => {
-      expect(screen.queryByTestId('terminal-drawer-body')).not.toBeInTheDocument();
+      expect(screen.getByTestId('terminal-drawer-body')).not.toBeVisible();
     });
   });
 

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -158,7 +158,7 @@ describe('Terminal drawer (component)', () => {
     vi.restoreAllMocks();
   });
 
-  it('starts minimized: header is shown but no terminal body', async () => {
+  it('starts minimized: header is shown but the terminal body is hidden, not unmounted', async () => {
     render(<App />);
     fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await waitFor(() => {
@@ -166,7 +166,8 @@ describe('Terminal drawer (component)', () => {
       expect(screen.getByRole('button', { name: 'Partial terminal drawer' })).toBeInTheDocument();
     });
     expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'minimized');
-    expect(screen.queryByTestId('terminal-drawer-body')).not.toBeInTheDocument();
+    // Stays mounted (CSS-hidden) so open task terminals aren't disposed by minimizing.
+    expect(screen.getByTestId('terminal-drawer-body')).not.toBeVisible();
   });
 
   it('restores persisted terminal sessions from startup terminalList', async () => {
@@ -203,7 +204,7 @@ describe('Terminal drawer (component)', () => {
 
     const { rerender } = render(<TerminalDrawer state="minimized" {...props} />);
     expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'minimized');
-    expect(screen.queryByTestId('terminal-drawer-body')).not.toBeInTheDocument();
+    expect(screen.getByTestId('terminal-drawer-body')).not.toBeVisible();
 
     rerender(<TerminalDrawer state="partial" {...props} />);
     expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
@@ -302,10 +303,10 @@ describe('Terminal drawer (component)', () => {
     expect(drawer).toHaveClass('fixed');
     expect(screen.getByTestId('terminal-drawer-body')).toBeInTheDocument();
 
-    // maximized → minimized: body flattens away.
+    // maximized → minimized: body hides (CSS), stays mounted.
     fireEvent.click(screen.getByRole('button', { name: 'Minimize terminal drawer' }));
     expect(drawer).toHaveAttribute('data-state', 'minimized');
-    expect(screen.queryByTestId('terminal-drawer-body')).not.toBeInTheDocument();
+    expect(screen.getByTestId('terminal-drawer-body')).not.toBeVisible();
   });
 
   it('bounds the maximized terminal body so xterm owns scrollback', () => {

--- a/packages/ui/src/components/KeepMounted.tsx
+++ b/packages/ui/src/components/KeepMounted.tsx
@@ -1,0 +1,30 @@
+/**
+ * KeepMounted — mounts its children the first time `active` becomes true,
+ * then never unmounts them again; only toggles CSS visibility after that.
+ *
+ * For stateful children (a live xterm.js terminal backed by a real PTY,
+ * for example) a plain `active ? <X/> : null` conditional destroys and
+ * recreates the child every time `active` flips, losing all live state.
+ * This mirrors the display-toggle pattern already used correctly by
+ * TerminalDrawer's own per-session panes (TerminalDrawer.tsx).
+ */
+
+import { useRef, type ReactNode } from 'react';
+
+interface KeepMountedProps {
+  active: boolean;
+  className?: string;
+  children: ReactNode;
+}
+
+export function KeepMounted({ active, className, children }: KeepMountedProps): JSX.Element | null {
+  const hasActivatedRef = useRef(active);
+  if (active) hasActivatedRef.current = true;
+  if (!hasActivatedRef.current) return null;
+
+  return (
+    <div className={className} style={active ? undefined : { display: 'none' }}>
+      {children}
+    </div>
+  );
+}

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -231,6 +231,7 @@ function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: Term
     }
     termRef.current = term;
     fitRef.current = fit;
+    (window.__INVOKER_TEST_TASK_TERMINALS__ ??= new Map()).set(session.sessionId, term);
 
     seedTerminalOutputSnapshot(term, session, seededSnapshotRef, 'attach');
 
@@ -319,6 +320,9 @@ function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: Term
       }
       termRef.current = null;
       fitRef.current = null;
+      if (window.__INVOKER_TEST_TASK_TERMINALS__?.get(session.sessionId) === term) {
+        window.__INVOKER_TEST_TASK_TERMINALS__.delete(session.sessionId);
+      }
     };
   }, [clearScheduledFit, fitVisibleTerminal, scheduleFit, session.sessionId]);
 
@@ -441,11 +445,13 @@ export function TerminalDrawer({
           {cycleLabel}
         </button>
       </div>
-      {showBody && (
-        <div
+      <div
           data-testid="terminal-drawer-body"
           className={isMaximized ? 'relative min-h-0 flex-1 overflow-hidden bg-black' : 'relative shrink-0 overflow-hidden bg-black'}
-          style={isMaximized ? undefined : { height: DRAWER_BODY_HEIGHT_PX }}
+          style={{
+            ...(isMaximized ? {} : { height: DRAWER_BODY_HEIGHT_PX }),
+            display: showBody ? undefined : 'none',
+          }}
         >
           {sessions.length === 0 && (
             <div className="absolute inset-0 flex items-center justify-center px-3 text-xs text-muted-foreground">
@@ -473,7 +479,6 @@ export function TerminalDrawer({
             />
           ))}
         </div>
-      )}
     </div>
   );
 }

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -366,5 +366,10 @@ declare global {
       rows: number;
       buffer: { active: { getLine(n: number): { translateToString(trimRight?: boolean): string } | undefined } };
     } | null;
+    /** Live xterm.js Terminal instances backing open task terminals in the drawer, keyed by sessionId. Test-only. */
+    __INVOKER_TEST_TASK_TERMINALS__?: Map<string, {
+      rows: number;
+      buffer: { active: { getLine(n: number): { translateToString(trimRight?: boolean): string } | undefined } };
+    }>;
   }
 }


### PR DESCRIPTION
## Summary

Reported as garbled, staggered text inside the "Invoker planning tmux bridge" banner itself -- lines pushed progressively further right on screen.

The banner-splice function trims the surrounding real shell output to a length budget with a blind character-count cut.

That is the exact same gap (1) already fixed once, just in a second call site. A mid-sequence cut here corrupts the terminal's cursor position for everything printed afterward.

## Review Claim

Approve that trimming the output surrounding the planning-bridge banner reuses the escape-safe trim from (1) instead of a blind byte-count slice.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The shared trim helper is already covered by (1)'s test; this slice's own test proves the second call site (the banner splice) now goes through it too and never starts with a dangling escape fragment.

## Slice Rationale

Kept separate from (1) because it's a different call site discovered later, from a different symptom report (the banner text itself looked garbled, not a remounted terminal).

## Non-goals

Does not change what the banner says or when it appears -- only how the surrounding output is trimmed to make room for it.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`

</details>

## Visual Proof

Not practically capturable as a screenshot or short recording -- the corruption only appears once a real shell session's raw output (with its own escape sequences from prompt themes, etc.) happens to straddle the trim boundary at the exact wrong byte. Proof is a focused unit test instead: `packages/app/src/__tests__/planning-terminal-bridge-truncated-escape-garble-repro.test.ts` engineers a cursor-position escape sequence to straddle the boundary and asserts it survives intact.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal output truncation to preserve complete ANSI escape sequences.
  - Prevented planning terminal summaries from displaying garbled output when content is trimmed.
  - Added regression coverage for truncated cursor-position sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->