### PR TITLE
Make the live-planner e2e proof drive Claude, not just Codex

### DIFF
--- a/packages/app/e2e/planning-terminal-live-model.proof.spec.ts
+++ b/packages/app/e2e/planning-terminal-live-model.proof.spec.ts
@@ -11,6 +11,7 @@ const MAIN_JS = path.resolve(__dirname, '..', 'dist', 'main.js');
 const E2E_BARE_REPO = process.env.INVOKER_E2E_BARE_REPO ?? '/tmp/invoker-e2e-repo.git';
 const E2E_REPO_URL = pathToFileURL(E2E_BARE_REPO).href;
 const LIVE_PROOF_ENABLED = process.env.INVOKER_E2E_LIVE_PLANNER === '1';
+const LIVE_PLANNER_TOOL = (process.env.INVOKER_E2E_LIVE_PLANNER_TOOL?.trim() || 'codex') as 'codex' | 'claude';
 const LIVE_PLANNER_MODEL = process.env.INVOKER_E2E_LIVE_PLANNER_MODEL?.trim();
 const LIVE_PLANNER_TIMEOUT_SECONDS = readPositiveIntEnv('INVOKER_E2E_LIVE_PLANNER_TIMEOUT_SECONDS', 300);
 const LIVE_PROOF_PLAN_NAME = 'Live planner black to pink proof';
@@ -23,10 +24,10 @@ function readPositiveIntEnv(name: string, fallback: number): number {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
 }
 
-function requireCodexOnPath(): string {
-  const result = spawnSync('bash', ['-lc', 'command -v codex'], { encoding: 'utf8' });
+function requireCliOnPath(tool: 'codex' | 'claude'): string {
+  const result = spawnSync('bash', ['-lc', `command -v ${tool}`], { encoding: 'utf8' });
   if (result.status !== 0) {
-    throw new Error('INVOKER_E2E_LIVE_PLANNER=1 requires a real `codex` CLI on PATH.');
+    throw new Error(`INVOKER_E2E_LIVE_PLANNER=1 requires a real \`${tool}\` CLI on PATH.`);
   }
   return result.stdout.trim();
 }
@@ -52,7 +53,13 @@ async function launchLivePlannerApp(paths: {
   configPath: string;
 }): Promise<{ app: ElectronApplication; page: Page }> {
   registerTrackedBrowserUserDataDir(paths.userDataDir);
+  // Playwright's `use.video` option only applies to browser contexts, so the
+  // Electron walkthrough video must be requested at launch time.
+  const recordVideo = process.env.CAPTURE_VIDEO
+    ? { recordVideo: { dir: path.resolve(__dirname, 'test-results', 'videos') } }
+    : {};
   const app = await electron.launch({
+    ...recordVideo,
     args: [
       ...launchArgs().slice(0, -1),
       `--user-data-dir=${paths.userDataDir}`,
@@ -140,10 +147,10 @@ async function attachPlanningState(page: Page | undefined, testInfo: TestInfo, c
 base.describe('Planning terminal live model proof', () => {
   base.skip(!LIVE_PROOF_ENABLED, 'Set INVOKER_E2E_LIVE_PLANNER=1 to run the live model planning proof.');
 
-  base('continues a real Codex planning session, then drafts and submits a workflow', async ({}, testInfo) => {
+  base(`continues a real ${LIVE_PLANNER_TOOL} planning session, then drafts and submits a workflow`, async ({}, testInfo) => {
     base.setTimeout((LIVE_PLANNER_TIMEOUT_SECONDS * 2 + 120) * 1000);
 
-    const codexPath = requireCodexOnPath();
+    const codexPath = requireCliOnPath(LIVE_PLANNER_TOOL);
     const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-live-planner-'));
     const configPath = path.join(testDir, 'e2e-config.json');
     const userDataDir = path.join(testDir, 'electron-user-data');
@@ -157,7 +164,7 @@ base.describe('Planning terminal live model proof', () => {
       planningTimeoutSeconds: LIVE_PLANNER_TIMEOUT_SECONDS,
       slackHarnessPresets: {
         'live-codex': {
-          tool: 'codex',
+          tool: LIVE_PLANNER_TOOL,
           ...(LIVE_PLANNER_MODEL ? { model: LIVE_PLANNER_MODEL } : {}),
         },
       },
@@ -206,16 +213,21 @@ base.describe('Planning terminal live model proof', () => {
         'Draft ready',
         { timeout: (LIVE_PLANNER_TIMEOUT_SECONDS + 15) * 1000 },
       );
-      await expect.poll(async () => page.evaluate(async (sinceId) => {
-        const logs = await window.invoker.getActivityLogs(sinceId, 2000);
-        return logs
-          .filter((entry) => entry.message.includes('planner_session_id_promoted'))
-          .map((entry) => entry.message)
-          .join('\n');
-      }, activityLogWatermark), {
-        timeout: 10000,
-        message: 'activity log contains planner_session_id_promoted',
-      }).toContain('planner_session_id_promoted');
+      if (LIVE_PLANNER_TOOL === 'codex') {
+        // Codex starts a session with a provisional id and corrects it from
+        // stdout once the real thread id is known; Claude's session id is
+        // known upfront and never gets "promoted", so this check is codex-only.
+        await expect.poll(async () => page.evaluate(async (sinceId) => {
+          const logs = await window.invoker.getActivityLogs(sinceId, 2000);
+          return logs
+            .filter((entry) => entry.message.includes('planner_session_id_promoted'))
+            .map((entry) => entry.message)
+            .join('\n');
+        }, activityLogWatermark), {
+          timeout: 10000,
+          message: 'activity log contains planner_session_id_promoted',
+        }).toContain('planner_session_id_promoted');
+      }
       const activityLogs = await page.evaluate(async (sinceId) => window.invoker.getActivityLogs(sinceId, 2000), activityLogWatermark);
       await testInfo.attach('live-planning-activity-log.json', {
         body: Buffer.from(JSON.stringify(activityLogs, null, 2)),
@@ -249,7 +261,10 @@ base.describe('Planning terminal live model proof', () => {
       }
     } finally {
       await attachPlanningState(page, testInfo, codexPath).catch(() => undefined);
+      const videoPromise = page?.video()?.path().catch(() => undefined);
       if (app) await closeApp(app).catch(() => undefined);
+      const videoPath = await videoPromise;
+      if (videoPath) console.log(`LIVE_PROOF_VIDEO_PATH=${videoPath}`);
       if (process.env.INVOKER_E2E_KEEP_TMP !== '1') {
         rmSync(testDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
       }

--- a/packages/app/e2e/planning-terminal-live-model.proof.spec.ts
+++ b/packages/app/e2e/planning-terminal-live-model.proof.spec.ts
@@ -122,7 +122,7 @@ async function submitPlanningText(page: Page, text: string): Promise<void> {
   await page.getByTestId('invoker-terminal-input').press('Enter');
 }
 
-async function attachPlanningState(page: Page | undefined, testInfo: TestInfo, codexPath: string): Promise<void> {
+async function attachPlanningState(page: Page | undefined, testInfo: TestInfo, cliPath: string): Promise<void> {
   if (!page) return;
   const evidence = await page.evaluate(async () => {
     const planning = await window.invoker.planningChatList().catch((error: unknown) => ({
@@ -139,7 +139,7 @@ async function attachPlanningState(page: Page | undefined, testInfo: TestInfo, c
     workflows: { ok: false, error: error instanceof Error ? error.message : String(error) },
   }));
   await testInfo.attach('live-planning-state.json', {
-    body: Buffer.from(JSON.stringify({ codexPath, ...evidence }, null, 2)),
+    body: Buffer.from(JSON.stringify({ cliPath, ...evidence }, null, 2)),
     contentType: 'application/json',
   });
 }
@@ -150,7 +150,7 @@ base.describe('Planning terminal live model proof', () => {
   base(`continues a real ${LIVE_PLANNER_TOOL} planning session, then drafts and submits a workflow`, async ({}, testInfo) => {
     base.setTimeout((LIVE_PLANNER_TIMEOUT_SECONDS * 2 + 120) * 1000);
 
-    const codexPath = requireCliOnPath(LIVE_PLANNER_TOOL);
+    const cliPath = requireCliOnPath(LIVE_PLANNER_TOOL);
     const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-live-planner-'));
     const configPath = path.join(testDir, 'e2e-config.json');
     const userDataDir = path.join(testDir, 'electron-user-data');
@@ -260,7 +260,7 @@ base.describe('Planning terminal live model proof', () => {
         await page.screenshot({ path: LIVE_PROOF_SCREENSHOT, fullPage: true });
       }
     } finally {
-      await attachPlanningState(page, testInfo, codexPath).catch(() => undefined);
+      await attachPlanningState(page, testInfo, cliPath).catch(() => undefined);
       const videoPromise = page?.video()?.path().catch(() => undefined);
       if (app) await closeApp(app).catch(() => undefined);
       const videoPath = await videoPromise;


### PR DESCRIPTION
## Summary

The live-planner e2e proof only ever drove a real Codex CLI through the planning terminal UI. There was no way to run the same walkthrough against a real Claude session.

This adds an `INVOKER_E2E_LIVE_PLANNER_TOOL` env toggle (`codex` by default, unchanged) so the same test can drive Claude instead.

It also wires up `CAPTURE_VIDEO` for this spec, matching the other Electron e2e fixtures. The file had no way to record a walkthrough video before.

One assertion only ever fires for Codex: a log line from Codex correcting a provisional session id. Claude's id is known upfront, so it's now skipped for `claude`.

## Review Claim

Approve that the Codex-only session-id-promotion assertion is correctly scoped behind `LIVE_PLANNER_TOOL === 'codex'`, and that the tool toggle and video wiring don't change default (Codex) behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only file (`packages/app/e2e/planning-terminal-live-model.proof.spec.ts`); no product code changes. The guarded block is byte-identical to the prior unconditional code when `LIVE_PLANNER_TOOL` is left at its default (`codex`), so existing Codex proof runs are unaffected.

## Slice Rationale

Small, self-contained addition to one proof file. Not part of the in-progress UI/Backend Drift Harness stack, so it gets its own branch off master instead of riding along with unrelated work.

## Non-goals

Does not change any product code, the planning chat backend, or the Slack surface. Does not add a Slack equivalent of this live proof (tracked separately).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types` (repo-wide typecheck, clean)
- [x] `INVOKER_E2E_LIVE_PLANNER=1 INVOKER_E2E_LIVE_PLANNER_TOOL=claude CAPTURE_VIDEO=1 pnpm run test:e2e -- planning-terminal-live-model.proof.spec.ts` — first run failed on the (then-unguarded) Codex-only assertion, confirming it doesn't fire for Claude; after adding the guard, rerun passed: `1 passed (1.1m)`, exit code 0, with a real recorded video and a final screenshot proving the session reached `submitted` and the workflow appeared in the workflow list.
- [ ] `INVOKER_E2E_LIVE_PLANNER=1 pnpm run test:e2e -- planning-terminal-live-model.proof.spec.ts` (default Codex path) — not rerun in this session; the guarded block is unchanged for `codex`, so behavior is unaffected, but CI/reviewer should run this once to confirm.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a1bfdfc`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded live planning validation to support multiple supported command-line tools.
  * Added checks to confirm the selected tool is applied consistently during test runs.
  * Improved diagnostic output, including session details and optional video recordings for troubleshooting.
  * Added tool-specific validation where applicable to improve test accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->