### PR TITLE
[Admin-Bypass Async Repair](1) Extract shared repair-body logic and headless-shell helper

### DIFF
--- a/scripts/mergify_admin_requeue_headless_shell.py
+++ b/scripts/mergify_admin_requeue_headless_shell.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HEADLESS_LIB = REPO_ROOT / "scripts" / "headless-lib.sh"
+
+# Sources scripts/headless-lib.sh directly (never scripts/cron-pr-lib.sh): by the
+# time any caller of this module runs, cron-pr-lib.sh's cron_lock is already held
+# by the calling bash script (scripts/cron-pr-admin-bypass-land.sh), so re-sourcing
+# it and calling cron_lock again would self-deadlock or silently no-op.
+_SOURCE_HEADLESS_LIB = 'set -euo pipefail\nsource "$1"\n'
+
+
+DEFAULT_TIMEOUT_SECONDS = 30
+
+
+def run_headless(command: str, *extra_args: str, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> subprocess.CompletedProcess[str]:
+    args = ["bash", "-c", _SOURCE_HEADLESS_LIB + command, "bash", str(HEADLESS_LIB), *extra_args]
+    try:
+        return subprocess.run(
+            args,
+            cwd=str(REPO_ROOT),
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired:
+        # A wedged owner-IPC connection (no reachable owner, a hung socket) must
+        # never block a cron tick indefinitely -- surface it as an ordinary
+        # non-zero CompletedProcess so every caller's existing "returncode != 0"
+        # handling raises a clear RuntimeError instead of hanging the process.
+        return subprocess.CompletedProcess(
+            args, returncode=124, stdout="", stderr=f"timed out after {timeout_seconds}s",
+        )

--- a/scripts/mergify_admin_requeue_repair_body.py
+++ b/scripts/mergify_admin_requeue_repair_body.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Mapping, Sequence
+
+try:
+    from .mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
+    from .mergify_admin_requeue_logger import AdminBypassLogger
+    from .mergify_admin_requeue_model import Ledger
+    from .mergify_admin_requeue_plan import TRUNK
+    from .mergify_admin_requeue_snapshot import GhClient, run_logged
+    from .pr_worker_safe_push import safe_push
+except ImportError:
+    from mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
+    from mergify_admin_requeue_logger import AdminBypassLogger
+    from mergify_admin_requeue_model import Ledger
+    from mergify_admin_requeue_plan import TRUNK
+    from mergify_admin_requeue_snapshot import GhClient, run_logged
+    from pr_worker_safe_push import safe_push
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROOF_POLICY_LANE_ERROR = (
+    "Review lane proof cannot ship with policy files in the same PR. "
+    "Keep benchmarks, repros, and regression proof separate from behavior or policy changes."
+)
+PROOF_TOOLING_POLICY_UNIT_ERROR = (
+    'PR body Review Unit "proof" cannot ship with tooling-policy files in the same PR. '
+    "Split this into one Review Unit per PR."
+)
+NON_TRUNK_PREREQ_ERROR = "automatic tooling-policy split is only supported for base master"
+NON_TRUNK_MANUAL_SPLIT_ERROR = "worker cannot auto-split this PR on a non-trunk base; human stack split required"
+
+
+def git_output(cwd: Path, *args: str) -> str:
+    return run_logged(["git", *args], cwd=cwd)
+
+
+def git_lines(cwd: Path, *args: str) -> tuple[str, ...]:
+    return tuple(line.strip() for line in git_output(cwd, *args).splitlines() if line.strip())
+
+
+def hard_reset_work_root(cwd: Path, target: str) -> None:
+    git_output(cwd, "reset", "--hard", target)
+    git_output(cwd, "clean", "-fd")
+
+
+def is_ancestor(cwd: Path, ancestor: str, descendant: str) -> bool:
+    if not cwd.exists():
+        return True
+    completed = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        cwd=str(cwd),
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    return completed.returncode == 0
+
+
+def normalize_repair_commit(cwd: Path, start_head: str, end_head: str, check_name: str) -> str:
+    if is_ancestor(cwd, start_head, end_head):
+        return end_head
+    diff = git_output(cwd, "diff", "--binary", start_head, end_head)
+    hard_reset_work_root(cwd, start_head)
+    if not diff.strip():
+        return start_head
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+        handle.write(diff)
+        patch_path = Path(handle.name)
+    try:
+        git_output(cwd, "apply", "--index", str(patch_path))
+    finally:
+        patch_path.unlink(missing_ok=True)
+    if not git_lines(cwd, "status", "--porcelain"):
+        return start_head
+    git_output(cwd, "commit", "-m", f"Repair {check_name}")
+    return git_output(cwd, "rev-parse", "HEAD").strip()
+
+
+def validate_local_pr_body(cwd: Path, body: str, base_branch: str) -> dict[str, object]:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+        handle.write(body)
+        body_path = Path(handle.name)
+    try:
+        completed = subprocess.run(
+            [
+                "node",
+                str(REPO_ROOT / "scripts" / "validate-pr-body-local.mjs"),
+                "--body-file",
+                str(body_path),
+                "--base",
+                base_branch,
+                "--json",
+            ],
+            cwd=str(cwd),
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        stdout = completed.stdout.strip()
+        if completed.returncode not in {0, 1}:
+            raise RuntimeError(completed.stderr.strip() or stdout or "validate-pr-body-local failed")
+        if not stdout:
+            raise RuntimeError(completed.stderr.strip() or "validate-pr-body-local produced no JSON output")
+        value = json.loads(stdout)
+        if not isinstance(value, dict):
+            raise RuntimeError("validate-pr-body-local returned non-object JSON")
+        return value
+    finally:
+        body_path.unlink(missing_ok=True)
+
+
+def validate_pr_body_from_current_diff(cwd: Path, body: str, base_branch: str) -> dict[str, object]:
+    git_output(cwd, "fetch", "origin", f"+refs/heads/{base_branch}:refs/remotes/origin/{base_branch}")
+    changed_files = git_output(cwd, "diff", "--name-only", f"origin/{base_branch}...HEAD")
+    diff_text = git_output(cwd, "diff", "--no-ext-diff", f"origin/{base_branch}...HEAD")
+    with (
+        tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as body_handle,
+        tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as changed_handle,
+        tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as diff_handle,
+    ):
+        body_handle.write(body)
+        changed_handle.write(changed_files)
+        diff_handle.write(diff_text)
+        body_path = Path(body_handle.name)
+        changed_path = Path(changed_handle.name)
+        diff_path = Path(diff_handle.name)
+    script = (
+        "import { readFileSync } from 'node:fs';"
+        f"import {{ getReviewMetadata, scopeKindsForChangedFiles, validatePrBody }} from '{(REPO_ROOT / 'scripts' / 'validate-pr-body.mjs').as_posix()}';"
+        f"import {{ reviewUnitsForChangedFiles }} from '{(REPO_ROOT / 'scripts' / 'review-unit-rules.mjs').as_posix()}';"
+        "const body = readFileSync(process.argv[1], 'utf8');"
+        "const changedFiles = readFileSync(process.argv[2], 'utf8').split(/\\r?\\n/).filter(Boolean);"
+        "const diffText = readFileSync(process.argv[3], 'utf8');"
+        "const errors = await validatePrBody(body, { changedFiles, diffText });"
+        "const reviewMetadata = getReviewMetadata(body.trim());"
+        "console.log(JSON.stringify({"
+        "valid: errors.length === 0,"
+        "errors,"
+        "reviewLane: reviewMetadata.reviewLane,"
+        "reviewUnit: reviewMetadata.reviewUnit,"
+        "reviewUnits: reviewUnitsForChangedFiles(changedFiles),"
+        "scopeKinds: scopeKindsForChangedFiles(changedFiles),"
+        "}));"
+    )
+    try:
+        completed = subprocess.run(
+            ["node", "--input-type=module", "-e", script, str(body_path), str(changed_path), str(diff_path)],
+            cwd=str(cwd),
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        stdout = completed.stdout.strip()
+        if completed.returncode not in {0, 1}:
+            raise RuntimeError(completed.stderr.strip() or stdout or "validate-pr-body fallback failed")
+        if not stdout:
+            raise RuntimeError(completed.stderr.strip() or "validate-pr-body fallback produced no JSON output")
+        value = json.loads(stdout)
+        if not isinstance(value, dict):
+            raise RuntimeError("validate-pr-body fallback returned non-object JSON")
+        return value
+    finally:
+        body_path.unlink(missing_ok=True)
+        changed_path.unlink(missing_ok=True)
+        diff_path.unlink(missing_ok=True)
+
+
+def validate_current_pr_body(cwd: Path, body: str, base_branch: str) -> dict[str, object]:
+    try:
+        return validate_local_pr_body(cwd, body, base_branch)
+    except RuntimeError:
+        return validate_pr_body_from_current_diff(cwd, body, base_branch)
+
+
+def is_proof_tooling_policy_validation(value: Mapping[str, object]) -> bool:
+    errors = value.get("errors")
+    scope_kinds = value.get("scopeKinds")
+    review_units = value.get("reviewUnits")
+    if value.get("reviewLane") != "proof" or value.get("reviewUnit") != "proof":
+        return False
+    if review_units != ["tooling-policy"]:
+        return False
+    if scope_kinds not in ([], ["policy"]):
+        return False
+    if not isinstance(errors, list):
+        return False
+    return bool(errors) and set(errors).issubset({PROOF_POLICY_LANE_ERROR, PROOF_TOOLING_POLICY_UNIT_ERROR})
+
+
+def is_prereq_split_validation(value: Mapping[str, object], base_ref_name: str) -> bool:
+    return base_ref_name == TRUNK and is_proof_tooling_policy_validation(value)
+
+
+def is_manual_split_validation(value: Mapping[str, object]) -> bool:
+    errors = value.get("errors")
+    review_units = value.get("reviewUnits")
+    if not isinstance(errors, list) or not errors:
+        return False
+    if not isinstance(review_units, list):
+        return False
+    if len({str(unit) for unit in review_units}) < 2:
+        return False
+    joined = "\n".join(str(error) for error in errors)
+    return (
+        "multiple review units" in joined
+        or "Split this into one Review Unit per PR." in joined
+        or "cannot ship with policy, proof files" in joined
+        or "cannot ship with tooling-policy, proof files" in joined
+        or "cannot ship with proof files" in joined
+    )
+
+
+def invalid_repair_errors(value: Mapping[str, object], base_ref_name: str) -> list[str]:
+    errors = [str(error) for error in value.get("errors", [])]
+    if is_proof_tooling_policy_validation(value) and base_ref_name != TRUNK:
+        errors = [*errors, NON_TRUNK_PREREQ_ERROR]
+    if is_manual_split_validation(value) and base_ref_name != TRUNK:
+        errors = [*errors, NON_TRUNK_MANUAL_SPLIT_ERROR]
+    return errors
+
+
+def prerequisite_branch_name(pr_number: int, start_head: str) -> str:
+    return f"stack/pr-babysit-prereq-{pr_number}-{start_head[:7]}"
+
+
+def prerequisite_title(pr_number: int, check_name: str) -> str:
+    return f"[PR babysit] Tooling-policy repair prerequisite for #{pr_number}: {check_name}"
+
+
+def prerequisite_body(pr_number: int, check_name: str) -> str:
+    return (
+        "## Summary\n\n"
+        "Worker-generated tooling-policy repair.\n\n"
+        "## Review Claim\n\n"
+        f"This PR carries the worker-generated tooling-policy repair that unblocks {check_name} on #{pr_number}.\n\n"
+        "## Review Lane\n\n"
+        "- policy\n\n"
+        "## Review Unit\n\n"
+        "- tooling-policy\n\n"
+        "## Safety Invariant\n\n"
+        "Contains only the worker-generated repair commit; the original PR branch stays proof-only.\n\n"
+        "## Slice Rationale\n\n"
+        "The repair changed tooling-policy files that a proof PR body cannot carry, so the repair must land first.\n\n"
+        "## Non-goals\n\n"
+        "- No product behavior change.\n\n"
+        "## Test Plan\n\n"
+        "<details>\n"
+        "<summary>Test Plan</summary>\n\n"
+        f"- [ ] Let CI rerun {check_name}.\n\n"
+        "</details>\n\n"
+        "## Revert Plan\n\n"
+        "<details>\n"
+        "<summary>Revert Plan</summary>\n\n"
+        "- Safe to revert? Yes.\n"
+        "- Revert command: `git revert <sha>`\n"
+        "- Post-revert steps: None.\n"
+        "- Data migration? No.\n\n"
+        "</details>\n"
+    )
+
+
+def create_repair_prerequisite(
+    gh: GhClient,
+    ledger: Ledger,
+    logger: AdminBypassLogger,
+    repo: str,
+    cwd: Path,
+    pr_number: int,
+    head_sha: str,
+    check_name: str,
+    start_head: str,
+    repair_commits: Sequence[str],
+    now: int | None,
+) -> dict[str, object]:
+    branch_name = prerequisite_branch_name(pr_number, start_head)
+    title = prerequisite_title(pr_number, check_name)
+    body = prerequisite_body(pr_number, check_name)
+    git_output(cwd, "checkout", "-B", branch_name, f"origin/{TRUNK}")
+    git_output(cwd, "reset", "--hard", f"origin/{TRUNK}")
+    for commit in repair_commits:
+        git_output(cwd, "cherry-pick", commit)
+    validation = validate_current_pr_body(cwd, body, TRUNK)
+    if not validation.get("valid"):
+        errors = [str(error) for error in validation.get("errors", [])]
+        raise RuntimeError("prerequisite PR body failed validation: " + "; ".join(errors))
+    safe_push(branch=branch_name, expect_missing=True, cwd=cwd)
+    created = gh.create_pr(repo, title, body, branch_name, TRUNK)
+    prereq_number = int(created.get("number") or 0)
+    if prereq_number <= 0:
+        raise RuntimeError("GitHub did not return a prerequisite PR number")
+    gh.edit_label(repo, prereq_number, add="admin-bypass")
+    ledger.record(
+        "repair-prereq-created",
+        pr_number,
+        head_sha,
+        check_name,
+        now,
+        meta={"prNumber": prereq_number, "branch": branch_name},
+    )
+    logger.trace(
+        "admin-bypass-repair-prereq-created",
+        repo=repo,
+        pr_number=pr_number,
+        check_name=check_name,
+        prereq_pr_number=prereq_number,
+        prereq_branch=branch_name,
+        repair_commits=list(repair_commits),
+    )
+    return {"prNumber": prereq_number, "branch": branch_name, "title": title}

--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -1,27 +1,11 @@
 from __future__ import annotations
 
 import json
-import subprocess
-from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-HEADLESS_LIB = REPO_ROOT / "scripts" / "headless-lib.sh"
-
-# Sources scripts/headless-lib.sh directly (never scripts/cron-pr-lib.sh): by the
-# time this module runs, cron-pr-lib.sh's cron_lock is already held by the
-# calling bash script (scripts/cron-pr-admin-bypass-land.sh), so re-sourcing it
-# and calling cron_lock again would self-deadlock or silently no-op.
-_SOURCE_HEADLESS_LIB = 'set -euo pipefail\nsource "$1"\n'
-
-
-def _run_headless(command: str, *extra_args: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["bash", "-c", _SOURCE_HEADLESS_LIB + command, "bash", str(HEADLESS_LIB), *extra_args],
-        cwd=str(REPO_ROOT),
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+try:
+    from .mergify_admin_requeue_headless_shell import run_headless as _run_headless
+except ImportError:
+    from mergify_admin_requeue_headless_shell import run_headless as _run_headless
 
 
 def resolve_workflow_for_pr(pr_number: int) -> str | None:

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -10,6 +10,7 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import scripts.mergify_admin_requeue as requeue
 import scripts.mergify_admin_requeue_exec as exec_impl
+import scripts.mergify_admin_requeue_headless_shell as headless_shell
 import scripts.mergify_admin_requeue_workflow_fastpath as fastpath
 
 from scripts.mergify_admin_requeue import (
@@ -1117,7 +1118,7 @@ The merge conditions cannot be satisfied due to failing checks
 class WorkflowFastpathTests(unittest.TestCase):
     def test_resolve_workflow_for_pr_sources_headless_lib_and_parses_workflow_id(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout='{"workflowId": "wf-1-1"}\n', stderr="")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed) as run:
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed) as run:
             result = fastpath.resolve_workflow_for_pr(6579)
         self.assertEqual(result, "wf-1-1")
         args = run.call_args.args[0]
@@ -1130,19 +1131,19 @@ class WorkflowFastpathTests(unittest.TestCase):
 
     def test_resolve_workflow_for_pr_returns_none_on_genuine_miss(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}\n", stderr="")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed):
             result = fastpath.resolve_workflow_for_pr(6579)
         self.assertIsNone(result)
 
     def test_resolve_workflow_for_pr_raises_on_lookup_failure(self):
         completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed):
             with self.assertRaises(RuntimeError):
                 fastpath.resolve_workflow_for_pr(6579)
 
     def test_submit_rebase_recreate_command_shape(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed) as run:
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed) as run:
             fastpath.submit_rebase_recreate("wf-1-1")
         args = run.call_args.args[0]
         self.assertEqual(args[0], "bash")
@@ -1154,13 +1155,13 @@ class WorkflowFastpathTests(unittest.TestCase):
 
     def test_submit_rebase_recreate_raises_on_failure(self):
         completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed):
             with self.assertRaises(RuntimeError):
                 fastpath.submit_rebase_recreate("wf-1-1")
 
     def test_submit_repair_review_gate_ci_command_shape(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed) as run:
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed) as run:
             fastpath.submit_repair_review_gate_ci(6579)
         args = run.call_args.args[0]
         self.assertEqual(args[0], "bash")
@@ -1172,7 +1173,7 @@ class WorkflowFastpathTests(unittest.TestCase):
 
     def test_submit_repair_review_gate_ci_raises_on_failure(self):
         completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed):
             with self.assertRaises(RuntimeError):
                 fastpath.submit_repair_review_gate_ci(6579)
 


### PR DESCRIPTION
## Summary

PR repair used to block the cron process on a synchronous `claude -p ...` call.

Migrating that to async plan submission needs two files first: shared
git/PR-body helpers, and a shared IPC-shell subprocess helper.

This slice only extracts those. Nothing calls them differently yet.

## Review Claim

Approve extracting AdminBypassRepairer's git/PR-body-review/prerequisite-PR
helpers into free functions, and factoring the existing `_run_headless()`
subprocess helper into a shared module, with no behavior change.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

No behavior change. AdminBypassRepairer and workflow_fastpath.py call the
exact same logic through the extracted modules instead of through bound
methods or a locally duplicated helper. The full existing test suite
(`python3 -m unittest scripts.test_mergify_admin_requeue`) passes unchanged
at this commit.

## Slice Rationale

The next two PRs in this stack (async submission plumbing, then the
starvation/cap fix) both need these two modules to exist first. Splitting
this out means neither of those PRs also has to review a pure refactor.

## Non-goals

No behavior change. Does not wire the new modules into any different
runtime path -- AdminBypassRepairer.repair_check/repair_conflict/
repair_bot_thread still call the (still-present) synchronous `claude -p`
path in this PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue`
- [x] `python3 -c "import ast; ast.parse(open('scripts/mergify_admin_requeue_headless_shell.py').read())"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
