### PR TITLE
Migrate AdminBypassRepairer to async plan submission

### DIFF
--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -123,6 +123,26 @@ _RESTRUCTURE_ESCAPE_HATCH = (
 )
 
 
+_JOB_LOG_EXCERPT_MAX_CHARS = 20000
+
+
+def _job_log_excerpt(log_path: str) -> str:
+    # log_path (from GhExecutor.download_job_log) is a local tempfile on the
+    # orchestrator's own machine. submit_async_repair_plan dispatches this
+    # prompt to Invoker's headless runner, which executes on a separate
+    # worker that does not share that filesystem, so the path itself would
+    # not resolve there -- inline the tail of the log content instead.
+    if not log_path:
+        return "(not available)"
+    try:
+        text = Path(log_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return "(not available)"
+    if not text:
+        return "(empty)"
+    return text[-_JOB_LOG_EXCERPT_MAX_CHARS:]
+
+
 def build_repair_check_plan(
     pr: PrSnapshot,
     check_name: str,
@@ -151,7 +171,7 @@ def build_repair_check_plan(
         f"  git fetch origin {pr.head_ref_name} && git checkout {pr.head_ref_name}\n\n"
         f"Failed check: {check_name}\n"
         f"Details URL: {details_url}\n"
-        f"Job log path: {log_path}\n"
+        f"Job log (tail):\n{_job_log_excerpt(log_path)}\n"
         f"Latest Mergify event: {json.dumps(dataclasses.asdict(latest) if latest else None, sort_keys=True)}\n"
     )
     if queue_only:

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -1,46 +1,25 @@
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
-import subprocess
-import tempfile
 from typing import Mapping, Sequence
 
 try:
+    from . import mergify_admin_requeue_async_repair as async_repair
     from .mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from .mergify_admin_requeue_plan import is_queue_only_required_check
-    from .mergify_admin_requeue_repair_body import (
-        create_repair_prerequisite,
-        git_lines,
-        git_output,
-        hard_reset_work_root,
-        invalid_repair_errors,
-        is_prereq_split_validation,
-        normalize_repair_commit,
-        validate_current_pr_body,
-    )
+    from .mergify_admin_requeue_repair_body import git_output, hard_reset_work_root, validate_current_pr_body
     from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
-    from .pr_worker_safe_push import SafePushError, safe_push
 except ImportError:
     from mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from mergify_admin_requeue_plan import is_queue_only_required_check
-    from mergify_admin_requeue_repair_body import (
-        create_repair_prerequisite,
-        git_lines,
-        git_output,
-        hard_reset_work_root,
-        invalid_repair_errors,
-        is_prereq_split_validation,
-        normalize_repair_commit,
-        validate_current_pr_body,
-    )
+    from mergify_admin_requeue_repair_body import git_output, hard_reset_work_root, validate_current_pr_body
     from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
-    from pr_worker_safe_push import SafePushError, safe_push
+    import mergify_admin_requeue_async_repair as async_repair
 
 
 def mergify_check_urls(event: MergifyQueueEvent | None, check_name: str) -> tuple[str, ...]:
@@ -67,25 +46,6 @@ class AdminBypassRepairer:
         self.ledger = ledger
         self.repo = repo
 
-    def invalid_repair_outcome(
-        self,
-        pr: PrSnapshot,
-        check_name: str,
-        start_head: str,
-        end_head: str,
-        value: Mapping[str, object],
-        *,
-        repair_commits: Sequence[str] = (),
-    ) -> RepairOutcome:
-        return self.blocked_outcome(
-            "blocked_invalid",
-            check_name,
-            start_head,
-            end_head,
-            repair_commits=repair_commits,
-            errors=invalid_repair_errors(value, pr.base_ref_name),
-        )
-
     def blocked_outcome(
         self,
         status: str,
@@ -109,28 +69,13 @@ class AdminBypassRepairer:
             prereq=prereq,
         )
 
-    def push_branch(
-        self,
-        work_root: Path,
-        branch_name: str,
-        *,
-        expected_head: str | None = None,
-        expect_missing: bool = False,
-    ) -> str:
-        return safe_push(
-            branch=branch_name,
-            expected_head=expected_head,
-            expect_missing=expect_missing,
-            cwd=work_root,
-        )
-
     def terminal_repair_outcome(
         self,
         pr: PrSnapshot,
         check_name: str,
         start_head: str,
         end_head: str,
-        work_root: Path,
+        work_root: Path | None,
     ) -> RepairOutcome | None:
         if not hasattr(self.gh, "pr_detail"):
             return None
@@ -147,16 +92,9 @@ class AdminBypassRepairer:
             start_head=start_head,
             end_head=end_head,
         )
-        hard_reset_work_root(work_root, start_head)
+        if work_root is not None:
+            hard_reset_work_root(work_root, start_head)
         return self.blocked_outcome("noop", check_name, start_head, end_head)
-
-    def run_claude_repair(self, work_root: Path, prompt: str) -> None:
-        subprocess.run(
-            ["claude", "-p", prompt, "--dangerously-skip-permissions"],
-            cwd=str(work_root),
-            check=True,
-            text=True,
-        )
 
     def job_log_has_evidence(self, log_path: str) -> bool:
         if not log_path:
@@ -178,16 +116,12 @@ class AdminBypassRepairer:
             return False
 
     def repair_check(self, pr: PrSnapshot, check_name: str, now: int | None = None) -> RepairOutcome:
-        self.ledger.record("repair-check", pr.number, pr.head_ref_oid, check_name, now)
         ctx = pr.checks.get(check_name)
         latest = pr.latest_mergify
         queue_only = ctx is None and is_queue_only_required_check(check_name)
         mergify_urls = mergify_check_urls(latest, check_name)
         details_url = (ctx.details_url if ctx and ctx.details_url else "") or (mergify_urls[0] if mergify_urls else "")
-        work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
-        work_root.parent.mkdir(parents=True, exist_ok=True)
-        checkout_pr_head(self.repo, pr, work_root)
-        start_head = git_output(work_root, "rev-parse", "HEAD").strip()
+        start_head = pr.head_ref_oid
         if queue_only and not details_url:
             return self.blocked_outcome(
                 "blocked_invalid",
@@ -197,8 +131,15 @@ class AdminBypassRepairer:
                 errors=(f"queue-only check {check_name} is missing a Mergify job URL",),
             )
         log_path = self.executor.download_job_log(self.repo, details_url, pr.number, check_name) if details_url else ""
+        # "PR Body" with an empty job log is the one check that still needs a
+        # local checkout before submitting anything: validate_current_pr_body
+        # has no API-only equivalent. Every other check name never checks out.
         if check_name == "PR Body" and self.job_log_is_empty(log_path):
-            terminal = self.terminal_repair_outcome(pr, check_name, start_head, start_head, work_root)
+            work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
+            work_root.parent.mkdir(parents=True, exist_ok=True)
+            checkout_pr_head(self.repo, pr, work_root)
+            checked_out_head = git_output(work_root, "rev-parse", "HEAD").strip()
+            terminal = self.terminal_repair_outcome(pr, check_name, checked_out_head, checked_out_head, work_root)
             if terminal:
                 return terminal
             validation = validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
@@ -213,7 +154,7 @@ class AdminBypassRepairer:
                     log_path=log_path,
                 )
                 return self.blocked_outcome("noop", check_name, start_head, start_head)
-        if queue_only and not self.job_log_has_evidence(log_path):
+        elif queue_only and not self.job_log_has_evidence(log_path):
             self.logger.trace(
                 "admin-bypass-queue-only-empty-log-noop",
                 repo=self.repo,
@@ -223,27 +164,25 @@ class AdminBypassRepairer:
                 log_path=log_path,
                 head_sha=pr.head_ref_oid,
             )
-            return self.blocked_outcome(
-                "queue_only_noop",
-                check_name,
-                start_head,
-                start_head,
-            )
+            return self.blocked_outcome("queue_only_noop", check_name, start_head, start_head)
+        else:
+            terminal = self.terminal_repair_outcome(pr, check_name, start_head, start_head, None)
+            if terminal:
+                return terminal
+
         queue_pr_number = latest.queue_pr_number if latest else 0
-        prompt = (
-            f"This PR's CI check is failing. Diagnose why it is failing, then fix it. Add or update a repro if the failure is reproducible.\n\n"
-            f"If a code change fixes it: make the change in this checkout. Commit locally if needed, do not push. "
-            f"If local proof shows the check is already green on the current head, make no commit and exit 0.\n\n"
-            f"If the real fix requires restructuring this PR instead of editing it in place -- for example, splitting "
-            f"unrelated files into their own PR because they can't ship together -- do not force that into a single "
-            f"local commit here. Instead, submit an Invoker plan to do the restructuring, the same way a human would "
-            f"via the plan-to-invoker skill (see skills/plan-to-invoker/SKILL.md and ./submit-plan.sh). Then make no "
-            f"commit in this checkout and exit 0.\n\n"
-            f"PR: #{pr.number}\nFailed check: {check_name}\nDetails URL: {details_url}\nJob log path: {log_path}\n"
-            f"Latest Mergify event: {json.dumps(latest.__dict__ if latest else None, sort_keys=True)}\n"
+        plan = async_repair.build_repair_check_plan(
+            pr,
+            check_name,
+            repo=self.repo,
+            details_url=details_url,
+            log_path=log_path,
+            queue_only=queue_only,
+            queue_pr_number=queue_pr_number,
+            latest=latest,
+            start_head=start_head,
+            state_file=self.ledger.path,
         )
-        if queue_only:
-            prompt += f"Queue draft PR: #{queue_pr_number}\nRepair the real PR head, using only evidence from the queue draft failure.\n"
         self.logger.trace(
             "admin-bypass-repair-check-start",
             repo=self.repo,
@@ -251,181 +190,46 @@ class AdminBypassRepairer:
             check_name=check_name,
             details_url=details_url,
             log_path=log_path,
-            work_root=str(work_root),
-            head_sha=pr.head_ref_oid,
+            head_sha=start_head,
+            plan_name=plan.plan_name,
         )
-        self.run_claude_repair(work_root, prompt)
-        end_head = git_output(work_root, "rev-parse", "HEAD").strip()
-        status_lines = git_lines(work_root, "status", "--porcelain")
-        terminal = self.terminal_repair_outcome(pr, check_name, start_head, end_head, work_root)
-        if terminal:
-            return terminal
-        if end_head == start_head and not status_lines:
-            if not queue_only:
-                validation = validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
-                if not validation.get("valid"):
-                    return self.invalid_repair_outcome(pr, check_name, start_head, end_head, validation)
-            return self.blocked_outcome(
-                "queue_only_noop" if queue_only else "noop",
-                check_name,
-                start_head,
-                end_head,
-            )
-        if status_lines:
-            hard_reset_work_root(work_root, start_head)
-            return self.blocked_outcome(
-                "blocked_dirty",
-                check_name,
-                start_head,
-                end_head,
-                status_lines=status_lines,
-            )
-        end_head = normalize_repair_commit(work_root, start_head, end_head, check_name)
-        repair_commits = git_lines(work_root, "rev-list", "--reverse", f"{start_head}..{end_head}")
-        validation = validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
-        if validation.get("valid"):
-            try:
-                self.push_branch(work_root, pr.head_ref_name, expected_head=pr.head_ref_oid)
-            except SafePushError as exc:
-                return self.blocked_outcome(
-                    "stale_head",
-                    check_name,
-                    start_head,
-                    end_head,
-                    repair_commits=repair_commits,
-                    errors=(str(exc),),
-                )
-            return self.blocked_outcome(
-                "pushed",
-                check_name,
-                start_head,
-                end_head,
-                repair_commits=repair_commits,
-            )
-        if is_prereq_split_validation(validation, pr.base_ref_name):
-            try:
-                created = create_repair_prerequisite(
-                    self.gh, self.ledger, self.logger, self.repo, work_root,
-                    pr.number, pr.head_ref_oid, check_name, start_head, repair_commits, now,
-                )
-            finally:
-                git_output(work_root, "checkout", "-B", pr.head_ref_name, start_head)
-                hard_reset_work_root(work_root, start_head)
-            return self.blocked_outcome(
-                "prereq_created",
-                check_name,
-                start_head,
-                end_head,
-                repair_commits=repair_commits,
-                prereq=created,
-            )
-        hard_reset_work_root(work_root, start_head)
-        return self.invalid_repair_outcome(
-            pr,
-            check_name,
-            start_head,
-            end_head,
-            validation,
-            repair_commits=repair_commits,
-        )
+        async_repair.submit_async_repair_plan(plan)
+        self.ledger.record("repair-check", pr.number, start_head, check_name, now)
+        return self.blocked_outcome("submitted", check_name, start_head, start_head)
 
     def repair_conflict(self, pr: PrSnapshot, reason: str, now: int | None = None) -> RepairOutcome:
         check_name = "conflict"
-        self.ledger.record("conflict-repair", pr.number, pr.head_ref_oid, f"conflict:{pr.number}", now)
-        work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
-        work_root.parent.mkdir(parents=True, exist_ok=True)
-        checkout_pr_head(self.repo, pr, work_root)
-        start_head = git_output(work_root, "rev-parse", "HEAD").strip()
-        prompt = (
-            f"This PR has a merge conflict blocking it from merging. Diagnose why, then fix it.\n\n"
-            f"If rebasing the head branch onto its base branch (preserving the PR's intended changes) resolves it: "
-            f"do that, run the narrow proof for the conflict resolution, then commit locally. Do not push.\n\n"
-            f"If the real fix requires restructuring this PR instead of a straightforward rebase, do not force that "
-            f"into a single local commit here. Instead, submit an Invoker plan to do the restructuring, the same way "
-            f"a human would via the plan-to-invoker skill (see skills/plan-to-invoker/SKILL.md and ./submit-plan.sh). "
-            f"Then make no commit in this checkout and exit 0.\n\n"
-            f"If the PR is already closed or merged, or the head branch no longer exists, make no commit and exit 0.\n\n"
-            f"PR: #{pr.number}\nBase branch: {pr.base_ref_name}\nHead branch: {pr.head_ref_name}\n"
-            f"Head SHA: {pr.head_ref_oid}\nReason: {reason}\n"
+        start_head = pr.head_ref_oid
+        plan = async_repair.build_repair_conflict_plan(
+            pr, reason, repo=self.repo, start_head=start_head, state_file=self.ledger.path,
         )
         self.logger.trace(
             "admin-bypass-repair-conflict-start",
             repo=self.repo,
             pr_number=pr.number,
             reason=reason,
-            work_root=str(work_root),
             base_ref=pr.base_ref_name,
             head_ref=pr.head_ref_name,
-            head_sha=pr.head_ref_oid,
+            head_sha=start_head,
+            plan_name=plan.plan_name,
         )
-        self.run_claude_repair(work_root, prompt)
-        end_head = git_output(work_root, "rev-parse", "HEAD").strip()
-        status_lines = git_lines(work_root, "status", "--porcelain")
-        if end_head == start_head or status_lines:
-            if status_lines:
-                hard_reset_work_root(work_root, start_head)
-                return self.blocked_outcome(
-                    "blocked_dirty",
-                    check_name,
-                    start_head,
-                    end_head,
-                    status_lines=status_lines,
-                )
-            return self.blocked_outcome("noop", check_name, start_head, end_head)
-        try:
-            self.push_branch(work_root, pr.head_ref_name, expected_head=pr.head_ref_oid)
-        except SafePushError as exc:
-            return self.blocked_outcome(
-                "stale_head",
-                check_name,
-                start_head,
-                end_head,
-                errors=(str(exc),),
-            )
-        return self.blocked_outcome("pushed", check_name, start_head, end_head)
+        async_repair.submit_async_repair_plan(plan)
+        self.ledger.record("conflict-repair", pr.number, start_head, f"conflict:{pr.number}", now)
+        return self.blocked_outcome("submitted", check_name, start_head, start_head)
 
     def repair_bot_thread(self, pr: PrSnapshot, thread_id: str, now: int | None = None) -> RepairOutcome:
-        self.ledger.record("repair-bot-thread", pr.number, pr.head_ref_oid, thread_id, now)
-        work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
-        work_root.parent.mkdir(parents=True, exist_ok=True)
-        checkout_pr_head(self.repo, pr, work_root)
-        start_head = git_output(work_root, "rev-parse", "HEAD").strip()
-        prompt = (
-            f"Resolve the unresolved review thread {thread_id}. Address the reviewer's feedback with "
-            f"real code changes, run the narrow proof for the fix, then commit locally. Do not push. "
-            f"If the thread is already resolved, or the PR is closed or merged, make no commit and exit 0.\n\n"
-            f"PR: #{pr.number}\nHead branch: {pr.head_ref_name}\nHead SHA: {pr.head_ref_oid}\nThread: {thread_id}\n"
+        start_head = pr.head_ref_oid
+        plan = async_repair.build_repair_bot_thread_plan(
+            pr, thread_id, repo=self.repo, start_head=start_head, state_file=self.ledger.path,
         )
         self.logger.trace(
             "admin-bypass-repair-bot-thread-start",
             repo=self.repo,
             pr_number=pr.number,
             thread_id=thread_id,
-            work_root=str(work_root),
-            head_sha=pr.head_ref_oid,
+            head_sha=start_head,
+            plan_name=plan.plan_name,
         )
-        self.run_claude_repair(work_root, prompt)
-        end_head = git_output(work_root, "rev-parse", "HEAD").strip()
-        status_lines = git_lines(work_root, "status", "--porcelain")
-        if end_head == start_head or status_lines:
-            if status_lines:
-                hard_reset_work_root(work_root, start_head)
-                return self.blocked_outcome(
-                    "blocked_dirty",
-                    thread_id,
-                    start_head,
-                    end_head,
-                    status_lines=status_lines,
-                )
-            return self.blocked_outcome("noop", thread_id, start_head, end_head)
-        try:
-            self.push_branch(work_root, pr.head_ref_name, expected_head=pr.head_ref_oid)
-        except SafePushError as exc:
-            return self.blocked_outcome(
-                "stale_head",
-                thread_id,
-                start_head,
-                end_head,
-                errors=(str(exc),),
-            )
-        return self.blocked_outcome("pushed", thread_id, start_head, end_head)
+        async_repair.submit_async_repair_plan(plan)
+        self.ledger.record("repair-bot-thread", pr.number, start_head, thread_id, now)
+        return self.blocked_outcome("submitted", thread_id, start_head, start_head)

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -35,13 +35,7 @@ from scripts.mergify_admin_requeue_gh_executor import ADMIN_BYPASS_NUDGE_LEDGER_
 from scripts.mergify_admin_requeue_model import LoadedStacks, RepairOutcome
 from scripts.mergify_admin_requeue_loader import AdminBypassStackLoader
 from scripts.mergify_admin_requeue_logger import AdminBypassLogger
-from scripts.mergify_admin_requeue_repair_body import (
-    NON_TRUNK_MANUAL_SPLIT_ERROR,
-    PROOF_POLICY_LANE_ERROR,
-    PROOF_TOOLING_POLICY_UNIT_ERROR,
-)
 from scripts.mergify_admin_requeue_repairer import AdminBypassRepairer
-from scripts.pr_worker_safe_push import SafePushError
 
 REQUIRED = {"PR Body", "quality / TypeScript Types"}
 HEAD = "c2532d229dbed2fd57419698c48d973001c78e9e"
@@ -335,87 +329,59 @@ Failing checks
         actions = plan_stack_actions(stack, REQUIRED, ledger, 4)
         self.assertEqual([(a.kind, a.key) for a in actions], [("comment_blocked", "capped")])
 
-    def test_conflict_repair_records_and_caps_without_invoker(self):
-        class FakeGh:
-            def __init__(self):
-                self.comments = []
-
-            def comment(self, repo, pr_number, body):
-                self.comments.append((repo, pr_number, body))
-
+    def test_conflict_repair_submits_plan_and_caps_without_invoker(self):
         ledger = self.ledger()
         item = pr(2647, merge_state="DIRTY", latest=mergify())
-        prompts = []
-        repairer = self.repairer(FakeGh(), ledger, "Neko-Catpital-Labs/Invoker")
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
-                with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
-                    with mock.patch.object(repairer, "run_claude_repair", side_effect=lambda _work_root, prompt: prompts.append(prompt)):
-                        for epoch in range(3):
-                            repairer.repair_conflict(item, "GitHub reports merge conflict", epoch)
+        submitted = []
+        repairer = self.repairer(object(), ledger, "Neko-Catpital-Labs/Invoker")
+        with mock.patch(
+            "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
+            side_effect=lambda plan: submitted.append(plan),
+        ):
+            for epoch in range(3):
+                repairer.repair_conflict(item, "GitHub reports merge conflict", epoch)
         self.assertEqual(ledger.count("conflict-repair", 2647, HEAD, "conflict:2647"), 3)
-        self.assertEqual(len(prompts), 3)
-        self.assertIn("commit locally. Do not push.", prompts[0])
+        self.assertEqual(len(submitted), 3)
+        self.assertIn("commit locally. Do not push.", submitted[0].yaml_text)
         actions = plan_stack_actions(StackGroup("s", (item,)), REQUIRED, ledger, 4)
         self.assertEqual([(a.kind, a.key) for a in actions], [("comment_blocked", "capped")])
 
-    def test_repair_conflict_pushes_on_successful_resolution(self):
+    def test_repair_conflict_returns_submitted_and_records_ledger(self):
         item = pr(2660, merge_state="DIRTY", latest=mergify())
         ledger = self.ledger()
         repairer = self.repairer(object(), ledger)
-        new_head = "b" * 40
-        rev_parse = iter([HEAD, new_head])
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
-                    with mock.patch.object(repairer, "run_claude_repair"):
-                        with mock.patch.object(repairer, "push_branch", return_value=new_head) as push_branch:
-                            result = repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
-        self.assertEqual(result.status, "pushed")
+        with mock.patch("scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan") as submit:
+            result = repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
+        submit.assert_called_once()
+        self.assertEqual(result.status, "submitted")
         self.assertEqual(result.start_head, HEAD)
-        self.assertEqual(result.end_head, new_head)
-        push_branch.assert_called_once_with(mock.ANY, item.head_ref_name, expected_head=item.head_ref_oid)
+        self.assertEqual(result.end_head, HEAD)
         self.assertEqual(ledger.count("conflict-repair", item.number, item.head_ref_oid, f"conflict:{item.number}"), 1)
 
-    def test_repair_conflict_returns_stale_head_without_raising(self):
+    def test_repair_conflict_does_not_record_ledger_when_submission_fails(self):
         item = pr(2661, merge_state="DIRTY", latest=mergify())
         ledger = self.ledger()
         repairer = self.repairer(object(), ledger)
-        new_head = "c" * 40
-        rev_parse = iter([HEAD, new_head])
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
-                    with mock.patch.object(repairer, "run_claude_repair"):
-                        with mock.patch.object(repairer, "push_branch", side_effect=SafePushError("stale-head: refs/heads/x is deadbeef; expected " + HEAD)):
-                            result = repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
-        self.assertEqual(result.status, "stale_head")
-        self.assertIn("stale-head", result.errors[0])
-        self.assertEqual(ledger.count("conflict-repair", item.number, item.head_ref_oid, f"conflict:{item.number}"), 1)
+        with mock.patch(
+            "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
+            side_effect=RuntimeError("submit failed"),
+        ):
+            with self.assertRaises(RuntimeError):
+                repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
+        self.assertEqual(ledger.count("conflict-repair", item.number, item.head_ref_oid, f"conflict:{item.number}"), 0)
 
-    def test_repair_check_ledger_row_written_before_run_claude_repair_raises(self):
+    def test_repair_check_ledger_row_not_written_when_submission_fails(self):
         item = pr(2662, latest=mergify())
         ledger = self.ledger()
         repairer = self.repairer(object(), ledger)
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
-                with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
-                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
-                        with mock.patch.object(repairer, "run_claude_repair", side_effect=subprocess.CalledProcessError(1, ["claude"])):
-                            with self.assertRaises(subprocess.CalledProcessError):
-                                repairer.repair_check(item, "PR Body", 1)
-        self.assertEqual(ledger.count("repair-check", item.number, item.head_ref_oid, "PR Body"), 1)
-
-    def test_claude_repair_uses_claude_cli(self):
-        repairer = self.repairer(object(), self.ledger())
-        with mock.patch("scripts.mergify_admin_requeue_repairer.subprocess.run") as run:
-            repairer.run_claude_repair(Path("/tmp/work"), "repair this")
-        run.assert_called_once_with(
-            ["claude", "-p", "repair this", "--dangerously-skip-permissions"],
-            cwd="/tmp/work",
-            check=True,
-            text=True,
-        )
+        with mock.patch.object(repairer.executor, "download_job_log", return_value=""):
+            with mock.patch(
+                "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
+                side_effect=RuntimeError("submit failed"),
+            ):
+                with self.assertRaises(RuntimeError):
+                    repairer.repair_check(item, "PR Body", 1)
+        self.assertEqual(ledger.count("repair-check", item.number, item.head_ref_oid, "PR Body"), 0)
 
     def test_candidate_stack_includes_unlabeled_upper_prs(self):
         def raw(number, base, head, labels):
@@ -457,56 +423,25 @@ Failing checks
         stderr = io.StringIO()
         item = pr(2647, latest=mergify())
         repairer = self.repairer(object(), self.ledger())
-        git_rev_parse = iter([HEAD, HEAD])
+        submitted = []
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
-                with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
-                        with mock.patch.object(repairer, "run_claude_repair") as repair:
-                            with mock.patch("scripts.mergify_admin_requeue_repairer.validate_current_pr_body", return_value={"valid": True, "errors": []}):
-                                with redirect_stderr(stderr):
-                                    result = repairer.repair_check(item, "PR Body")
-        checkout.assert_called_once()
-        repair.assert_called_once()
-        self.assertEqual(result.status, "noop")
-        self.assertIn("Commit locally if needed, do not push.", repair.call_args.args[1])
+                with mock.patch.object(repairer, "job_log_is_empty", return_value=False):
+                    with mock.patch(
+                        "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
+                        side_effect=lambda plan: submitted.append(plan),
+                    ):
+                        with redirect_stderr(stderr):
+                            result = repairer.repair_check(item, "PR Body")
+        checkout.assert_not_called()
+        self.assertEqual(len(submitted), 1)
+        self.assertEqual(result.status, "submitted")
+        self.assertIn("Commit locally if needed, do not push.", submitted[0].yaml_text)
         log = stderr.getvalue()
         self.assertIn('"event": "admin-bypass-repair-check-start"', log)
         self.assertIn('"check_name": "PR Body"', log)
         self.assertIn('"log_path": "/tmp/pr-body.log"', log)
         self.assertIn('"pr_number": 2647', log)
-
-
-    def test_repair_check_noop_invalid_non_trunk_blocks_human_split(self):
-        item = pr(
-            5803,
-            base="stack/base",
-            body="## Summary\n\nMixed slice.\n",
-            checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")},
-        )
-        repairer = self.repairer(object(), self.ledger())
-        git_rev_parse = iter([HEAD, HEAD])
-        validation = {
-            "valid": False,
-            "errors": [
-                "PR body mentions multiple review units (validation-policy, routing); split into one conceptual unit per diff/task.",
-                "Review lane behavior cannot ship with policy, proof files in the same PR. Split behavior or cleanup from docs, policy, repro, and benchmark slices.",
-                'PR body Review Unit \"routing\" cannot ship with tooling-policy, proof files in the same PR. Split this into one Review Unit per PR.',
-            ],
-            "reviewLane": "behavior",
-            "reviewUnit": "routing",
-            "reviewUnits": ["routing", "tooling-policy", "proof"],
-            "scopeKinds": ["product", "policy"],
-        }
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
-                with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
-                        with mock.patch.object(repairer, "run_claude_repair"):
-                            with mock.patch("scripts.mergify_admin_requeue_repairer.validate_current_pr_body", return_value=validation):
-                                result = repairer.repair_check(item, "PR Body")
-        self.assertEqual(result.status, "blocked_invalid")
-        self.assertIn(NON_TRUNK_MANUAL_SPLIT_ERROR, result.errors)
 
     def test_plan_stack_actions_stop_retrying_after_repair_invalid(self):
         ledger = self.ledger()
@@ -514,8 +449,8 @@ Failing checks
         stack = StackGroup("s", (pr(2606, labels={"admin-bypass"}, checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}),))
         actions = plan_stack_actions(stack, REQUIRED, ledger, 2)
         self.assertEqual(actions, ())
-    def test_queue_only_repair_uses_mergify_job_log_and_returns_noop(self):
-        stderr = io.StringIO()
+
+    def test_queue_only_repair_with_evidence_submits_async_plan(self):
         latest = MergifyQueueEvent(
             "m5811",
             "dequeued",
@@ -530,22 +465,20 @@ Failing checks
         )
         item = pr(5811, labels={"admin-bypass", "dequeued"}, checks={}, latest=latest)
         repairer = self.repairer(object(), self.ledger())
-        git_rev_parse = iter([HEAD, HEAD])
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
-            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
-                with mock.patch.object(repairer, "job_log_has_evidence", return_value=True):
-                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                        with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
-                            with mock.patch.object(repairer, "run_claude_repair") as repair:
-                                with redirect_stderr(stderr):
-                                    result = repairer.repair_check(item, "required-fast / Guardrails")
-        checkout.assert_called_once()
-        repair.assert_called_once()
-        self.assertEqual(result.status, "queue_only_noop")
-        self.assertIn("Queue draft PR: #5854", repair.call_args.args[1])
-        self.assertIn("Job log path: /tmp/guardrails.log", repair.call_args.args[1])
+        submitted = []
+        with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
+            with mock.patch.object(repairer, "job_log_has_evidence", return_value=True):
+                with mock.patch(
+                    "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
+                    side_effect=lambda plan: submitted.append(plan),
+                ):
+                    result = repairer.repair_check(item, "required-fast / Guardrails")
+        self.assertEqual(result.status, "submitted")
+        self.assertEqual(len(submitted), 1)
+        self.assertIn("Queue draft PR: #5854", submitted[0].yaml_text)
+        self.assertIn("Job log path: /tmp/guardrails.log", submitted[0].yaml_text)
 
-    def test_queue_only_repair_empty_job_log_returns_noop_without_claude(self):
+    def test_queue_only_repair_empty_job_log_returns_noop_without_submitting(self):
         latest = MergifyQueueEvent(
             "m5811",
             "dequeued",
@@ -560,17 +493,14 @@ Failing checks
         )
         item = pr(5811, labels={"dequeued"}, checks={}, latest=latest)
         repairer = self.repairer(object(), self.ledger())
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
-            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
-                with mock.patch.object(repairer, "job_log_has_evidence", return_value=False):
-                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
-                        with mock.patch.object(repairer, "run_claude_repair") as repair:
-                            result = repairer.repair_check(item, "required-fast / Guardrails")
-        checkout.assert_called_once()
-        repair.assert_not_called()
+        with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
+            with mock.patch.object(repairer, "job_log_has_evidence", return_value=False):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan") as submit:
+                    result = repairer.repair_check(item, "required-fast / Guardrails")
+        submit.assert_not_called()
         self.assertEqual(result.status, "queue_only_noop")
 
-    def test_pr_body_valid_local_repair_returns_noop_without_claude(self):
+    def test_pr_body_valid_local_repair_returns_noop_without_submitting(self):
         item = pr(5810, checks={"PR Body": check("PR Body", "failure")}, body=PROOF_BODY)
         repairer = self.repairer(object(), self.ledger())
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
@@ -578,12 +508,13 @@ Failing checks
                 with mock.patch.object(repairer, "job_log_is_empty", return_value=True):
                     with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
                         with mock.patch("scripts.mergify_admin_requeue_repairer.validate_current_pr_body", return_value={"valid": True}):
-                            with mock.patch.object(repairer, "run_claude_repair") as repair:
+                            with mock.patch("scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan") as submit:
                                 result = repairer.repair_check(item, "PR Body")
         checkout.assert_called_once()
         download.assert_called_once()
-        repair.assert_not_called()
+        submit.assert_not_called()
         self.assertEqual(result.status, "noop")
+
     def test_run_cycle_logs_selected_bottom_repair_context(self):
         args = requeue.parse_args(["--once", "--dry-run", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
         stack = StackGroup("s", (pr(2606, checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}, latest=mergify()),))
@@ -681,93 +612,6 @@ Failing checks
         self.assertEqual(repair_check.call_count, 1)
         self.assertEqual(fake_gh.comments, [("owner/repo", 6602, "@mergifyio queue")])
         self.assertTrue(should_poll)
-
-    def test_repair_check_splits_tooling_policy_prerequisite(self):
-        class FakeGh:
-            def __init__(self):
-                self.created = []
-                self.label_edits = []
-                self.comments = []
-
-            def create_pr(self, repo, title, body, head, base):
-                self.created.append((repo, title, body, head, base))
-                return {"number": 5801}
-
-            def edit_label(self, repo, pr_number, *, add=None, remove=None):
-                self.label_edits.append((repo, pr_number, add, remove))
-
-            def comment(self, repo, pr_number, body):
-                self.comments.append((repo, pr_number, body))
-
-        item = pr(
-            5800,
-            latest=mergify(),
-            body=PROOF_BODY,
-            checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")},
-        )
-        ledger = self.ledger()
-        fake = FakeGh()
-        repairer = self.repairer(fake, ledger)
-        rev_parse = iter([HEAD, "b" * 40])
-        git_commands = []
-
-        def fake_git_output(_work_root, *args):
-            git_commands.append(args)
-            if args == ("rev-parse", "HEAD"):
-                return next(rev_parse)
-            return ""
-
-        def fake_git_lines(_work_root, *args):
-            if args == ("status", "--porcelain"):
-                return ()
-            if args == ("rev-list", "--reverse", f"{HEAD}..{'b' * 40}"):
-                return ("commit-a",)
-            return ()
-
-        validator_results = iter([
-            {
-                "valid": False,
-                "errors": [
-                    PROOF_POLICY_LANE_ERROR,
-                    PROOF_TOOLING_POLICY_UNIT_ERROR,
-                ],
-                "reviewLane": "proof",
-                "reviewUnit": "proof",
-                "reviewUnits": ["tooling-policy"],
-                "scopeKinds": ["policy"],
-            },
-            {
-                "valid": True,
-                "errors": [],
-                "reviewLane": "policy",
-                "reviewUnit": "tooling-policy",
-                "reviewUnits": ["tooling-policy"],
-                "scopeKinds": ["policy"],
-            },
-        ])
-
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
-                with mock.patch.object(repairer, "run_claude_repair"):
-                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=fake_git_output):
-                        with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", side_effect=fake_git_lines):
-                            with mock.patch("scripts.mergify_admin_requeue_repair_body.git_output", side_effect=fake_git_output):
-                                with mock.patch("scripts.mergify_admin_requeue_repair_body.validate_local_pr_body", side_effect=lambda *_args: next(validator_results)):
-                                    with mock.patch("scripts.mergify_admin_requeue_repair_body.safe_push", return_value="pushed-sha") as safe_push_mock:
-                                        result = repairer.repair_check(item, "PR Body", 123)
-
-        self.assertEqual(result.status, "prereq_created")
-        safe_push_mock.assert_called_once_with(branch="stack/pr-babysit-prereq-5800-c2532d2", expect_missing=True, cwd=mock.ANY)
-        self.assertEqual(fake.created[0][0], "owner/repo")
-        self.assertIn("[PR babysit] Tooling-policy repair prerequisite for #5800: PR Body", fake.created[0][1])
-        self.assertEqual(fake.label_edits, [("owner/repo", 5801, "admin-bypass", None)])
-        latest = ledger.latest("repair-prereq-created", 5800, HEAD, "PR Body")
-        self.assertIsNotNone(latest)
-        self.assertEqual(latest["meta"]["prNumber"], 5801)
-        self.assertIn(("checkout", "-B", "stack/pr-babysit-prereq-5800-c2532d2", "origin/master"), git_commands)
-        self.assertIn(("checkout", "-B", item.head_ref_name, HEAD), git_commands)
-        self.assertIn(("reset", "--hard", HEAD), git_commands)
-        self.assertEqual(fake.comments, [])
 
     def test_run_cycle_waits_while_prerequisite_pr_is_open(self):
         ledger = self.ledger()

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -425,7 +425,7 @@ Failing checks
         repairer = self.repairer(object(), self.ledger())
         submitted = []
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
-            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
+            with mock.patch.object(repairer.executor, "download_job_log", return_value="job-log.txt"):
                 with mock.patch.object(repairer, "job_log_is_empty", return_value=False):
                     with mock.patch(
                         "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
@@ -440,7 +440,7 @@ Failing checks
         log = stderr.getvalue()
         self.assertIn('"event": "admin-bypass-repair-check-start"', log)
         self.assertIn('"check_name": "PR Body"', log)
-        self.assertIn('"log_path": "/tmp/pr-body.log"', log)
+        self.assertIn('"log_path": "job-log.txt"', log)
         self.assertIn('"pr_number": 2647', log)
 
     def test_plan_stack_actions_stop_retrying_after_repair_invalid(self):
@@ -466,7 +466,12 @@ Failing checks
         item = pr(5811, labels={"admin-bypass", "dequeued"}, checks={}, latest=latest)
         repairer = self.repairer(object(), self.ledger())
         submitted = []
-        with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
+        log_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(log_dir.cleanup)
+        log_path = os.path.join(log_dir.name, "guardrails.log")
+        with open(log_path, "w", encoding="utf-8") as handle:
+            handle.write("guardrails failure: something broke\n")
+        with mock.patch.object(repairer.executor, "download_job_log", return_value=log_path):
             with mock.patch.object(repairer, "job_log_has_evidence", return_value=True):
                 with mock.patch(
                     "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
@@ -476,7 +481,9 @@ Failing checks
         self.assertEqual(result.status, "submitted")
         self.assertEqual(len(submitted), 1)
         self.assertIn("Queue draft PR: #5854", submitted[0].yaml_text)
-        self.assertIn("Job log path: /tmp/guardrails.log", submitted[0].yaml_text)
+        self.assertIn("Job log (tail):", submitted[0].yaml_text)
+        self.assertIn("guardrails failure: something broke", submitted[0].yaml_text)
+        self.assertNotIn(log_path, submitted[0].yaml_text)
 
     def test_queue_only_repair_empty_job_log_returns_noop_without_submitting(self):
         latest = MergifyQueueEvent(
@@ -503,13 +510,16 @@ Failing checks
     def test_pr_body_valid_local_repair_returns_noop_without_submitting(self):
         item = pr(5810, checks={"PR Body": check("PR Body", "failure")}, body=PROOF_BODY)
         repairer = self.repairer(object(), self.ledger())
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
-            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log") as download:
-                with mock.patch.object(repairer, "job_log_is_empty", return_value=True):
-                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
-                        with mock.patch("scripts.mergify_admin_requeue_repairer.validate_current_pr_body", return_value={"valid": True}):
-                            with mock.patch("scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan") as submit:
-                                result = repairer.repair_check(item, "PR Body")
+        home = tempfile.TemporaryDirectory()
+        self.addCleanup(home.cleanup)
+        with mock.patch.dict(os.environ, {"HOME": home.name}):
+            with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
+                with mock.patch.object(repairer.executor, "download_job_log", return_value="job-log.txt") as download:
+                    with mock.patch.object(repairer, "job_log_is_empty", return_value=True):
+                        with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
+                            with mock.patch("scripts.mergify_admin_requeue_repairer.validate_current_pr_body", return_value={"valid": True}):
+                                with mock.patch("scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan") as submit:
+                                    result = repairer.repair_check(item, "PR Body")
         checkout.assert_called_once()
         download.assert_called_once()
         submit.assert_not_called()

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -92,6 +93,31 @@ class AsyncRepairPlanTests(unittest.TestCase):
         self.assertIn("Failed check: PR Body", plan.yaml_text)
         # PR titles with quotes/colons must not corrupt the YAML document.
         self.assertIn('Fix \\"quoted\\" title: with colons', plan.yaml_text)
+
+    def test_repair_check_plan_inlines_job_log_content_not_local_path(self):
+        # log_path is a tempfile on the orchestrator's own machine; the plan
+        # is dispatched to a separate headless worker that does not share
+        # that filesystem, so the prompt must carry the log content itself.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_path = str(Path(tmp_dir) / "pr-body.log")
+            Path(log_path).write_text("some failure detail\n", encoding="utf-8")
+            plan = async_repair.build_repair_check_plan(
+                pr(), "PR Body", repo="owner/repo", details_url="https://example.invalid/job",
+                log_path=log_path, queue_only=False, queue_pr_number=0, latest=None,
+                start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
+            )
+        self.assertIn("Job log (tail):", plan.yaml_text)
+        self.assertIn("some failure detail", plan.yaml_text)
+        self.assertNotIn(log_path, plan.yaml_text)
+
+    def test_repair_check_plan_job_log_missing_says_not_available(self):
+        plan = async_repair.build_repair_check_plan(
+            pr(), "PR Body", repo="owner/repo", details_url="https://example.invalid/job",
+            log_path="/does/not/exist/pr-body.log", queue_only=False, queue_pr_number=0, latest=None,
+            start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
+        )
+        self.assertIn("Job log (tail):", plan.yaml_text)
+        self.assertIn("(not available)", plan.yaml_text)
 
     def test_repair_check_plan_queue_only_appends_queue_pr_line(self):
         plan = async_repair.build_repair_check_plan(


### PR DESCRIPTION
## Summary

`run_claude_repair`, `push_branch`, and `terminal_repair_outcome`'s checkout-scoped branch drop out of `repairer.py` in this commit.

One exception stays synchronous: a "PR Body" check with an empty job log still needs a local checkout, since `validate_current_pr_body` has no API-only equivalent. Every other check name no longer checks out locally.

Prerequisite-PR handling is no longer inline in `repair_check`; that decision now happens one hop later, in the async normalize task, after the agent's commit lands.

## Review Claim

`repair_check`/`repair_conflict`/`repair_bot_thread` no longer run `claude -p` synchronously in the cron process. Each now builds an `AsyncRepairPlan` and submits it fire-and-forget through `submit_async_repair_plan`, returning a new "submitted" outcome immediately instead of blocking on the agent turn.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

`run_claude_repair`, `push_branch`, and `terminal_repair_outcome`'s checkout-scoped branch drop out of `repairer.py` entirely; the git/prerequisite logic they used already lives in `repair_body.py` as of the previous four slices, now only reachable from the async normalize task, not from the repairer directly. Test coverage for those synchronous paths lives in the normalize task's own tests from the previous slice, which already exercise the same logic at its new call site.

## Slice Rationale

This is the migration slice that flips the repairer over to the plumbing added in the previous two slices, closing out the async-repair-plan-submission stack.

## Non-goals

This slice does not change `repair_body.py`'s functions themselves, only how `repairer.py` calls into them. Prerequisite-PR-creation logic itself was already relocated in an earlier slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m pytest scripts/ -q -k "mergify_admin_requeue"` — 180 passed

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repair operations now submit asynchronous repair plans for checks, conflicts, and bot conversations.
  * Repair results are recorded only after successful submission.
* **Bug Fixes**
  * Improved handling of check logs, PR head revisions, and empty PR body scenarios.
  * Avoided unnecessary local checkouts and cleanup when they are not required.
* **Tests**
  * Updated coverage for asynchronous submissions, failures, queue-only repairs, and valid PR body handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->