### PR TITLE
Allowlist complaint-scout-bridge.ts in the owner-boundary policy

### DIFF
--- a/scripts/check-owner-boundary.sh
+++ b/scripts/check-owner-boundary.sh
@@ -21,6 +21,7 @@ if command -v rg >/dev/null 2>&1; then
     --glob '!packages/cli/src/index.ts' \
     --glob '!packages/persistence/src/sqlite-adapter.ts' \
     --glob '!packages/slack-manager/src/index.ts' \
+    --glob '!packages/slack-manager/src/complaint-scout-bridge.ts' \
     --glob '!packages/data-store/src/sqlite-adapter.ts' || true)"
 
   # 2) Runtime value-imports of SQLiteAdapter must stay owner-only.
@@ -34,6 +35,7 @@ if command -v rg >/dev/null 2>&1; then
     --glob '!**/node_modules/**' \
     --glob '!packages/app/src/viewer-db-boundary.ts' \
     --glob '!packages/slack-manager/src/index.ts' \
+    --glob '!packages/slack-manager/src/complaint-scout-bridge.ts' \
     --glob '!packages/cli/src/index.ts' || true)"
 
   raw_memory_violations="$(rg -n "SQLiteAdapter\\.create\\(['\"]:memory:" packages \
@@ -69,6 +71,7 @@ else
     | grep -v '^packages/cli/src/index.ts:' \
     | grep -v '^packages/persistence/src/sqlite-adapter.ts:' \
     | grep -v '^packages/slack-manager/src/index.ts:' \
+    | grep -v '^packages/slack-manager/src/complaint-scout-bridge.ts:' \
     | grep -v '^packages/data-store/src/sqlite-adapter.ts:' || true)"
 
   value_import_violations="$(grep -RInE "import[[:space:]]+\\{[^}]*SQLiteAdapter[^}]*\\}[[:space:]]+from[[:space:]]+'@invoker/(persistence|data-store)'" packages \
@@ -80,6 +83,7 @@ else
     --exclude="*.test.ts" \
     | grep -v '^packages/app/src/viewer-db-boundary.ts:' \
     | grep -v '^packages/slack-manager/src/index.ts:' \
+    | grep -v '^packages/slack-manager/src/complaint-scout-bridge.ts:' \
     | grep -v '^packages/cli/src/index.ts:' || true)"
 
   raw_memory_violations="$(grep -RInE "SQLiteAdapter\\.create\\(['\"]:memory:" packages \


### PR DESCRIPTION
## Summary

`packages/slack-manager/src/complaint-scout-bridge.ts` opens its own SQLite connection with `ownerCapability: true` — the same pattern its sibling `index.ts` already uses.

The owner-boundary policy guard added to master doesn't know about this newer file yet, so it wrongly rejects it as a violation.

This adds the same exemption `index.ts` already has, for the same reason: both files legitimately act as the Slack manager's DB owner.

## Review Claim

Approve that `complaint-scout-bridge.ts` deserves the exact same owner-boundary exemption as `index.ts`, since it uses the identical `SQLiteAdapter.create(..., { ownerCapability: true })` pattern.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Widens an existing allowlist by exactly one file path, using the same justification already accepted for `index.ts` in the same package. No product code changes.

## Slice Rationale

Small, single-file, single-purpose fix, kept separate from the behavior change that needs it (the complaint-scout bridge PR) per this repo's rule against mixing policy and behavior files in one slice.

## Non-goals

Does not change the owner-boundary policy's rules, only its allowlist. Does not touch any product code.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/check-owner-boundary.sh` — passes locally
- [x] `bash scripts/test-suites/required/15-owner-boundary-policy.sh` — passes locally

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0e3af39b9`
- Post-revert steps: None
- Data migration? No

</details>
