### PR TITLE
Add the slack-bug-scan worker (execution-engine layer)

### DIFF
--- a/packages/execution-engine/src/__tests__/slack-bug-scan-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/slack-bug-scan-worker.test.ts
@@ -62,9 +62,10 @@ function makeClient(channels: SlackBugScanChannelSummary[], messagesByChannel: M
 const CHANNEL_WITH_REPO: SlackBugScanChannelSummary = {
   id: 'C1',
   name: 'general',
-  topic: 'repo: git@github.com:acme/widgets.git',
+  topic: 'repo: https://github.com/acme/widgets.git',
 };
 const CHANNEL_NO_REPO: SlackBugScanChannelSummary = { id: 'C2', name: 'random' };
+const ALLOWED_REPO_HOSTS = ['github.com'] as const;
 
 // The worker seeds a channel's watermark to a real wall-clock Slack ts (epoch
 // seconds) on first sight, so test fixture messages must use realistic
@@ -100,6 +101,7 @@ describe('slack-bug-scan worker', () => {
         store,
         classify,
         draftAndSubmitPlan,
+        allowedRepoHosts: ALLOWED_REPO_HOSTS,
         intervalMs: 0,
         tickOnStart: false,
       },
@@ -125,6 +127,7 @@ describe('slack-bug-scan worker', () => {
         store,
         classify,
         draftAndSubmitPlan,
+        allowedRepoHosts: ALLOWED_REPO_HOSTS,
         intervalMs: 0,
         tickOnStart: false,
       },
@@ -132,6 +135,19 @@ describe('slack-bug-scan worker', () => {
 
     expect(runtime.identity.kind).toBe(SLACK_BUG_SCAN_WORKER_KIND);
     expect(runtime.isRunning()).toBe(false);
+  });
+
+  it('does not create a runtime without configured repo hosts', () => {
+    const store = makeStore();
+    const { client } = makeClient([CHANNEL_WITH_REPO], new Map());
+    const classify: SlackBugScanClassifier = vi.fn(async () => ({ isBugComplaint: true }));
+    const draftAndSubmitPlan: SlackBugScanPlanSubmitter = vi.fn(async () => ({ planName: 'P', workflowId: 'wf-1' }));
+
+    expect(() => createSlackBugScanWorker({
+      logger: makeLogger(), client, store, classify, draftAndSubmitPlan,
+      allowedRepoHosts: [],
+      intervalMs: 0, tickOnStart: false,
+    })).toThrow(/requires at least one allowed repo host/);
   });
 
   it('skips a channel with no parseable repo url in topic/purpose', async () => {
@@ -143,12 +159,38 @@ describe('slack-bug-scan worker', () => {
 
     const runtime = createSlackBugScanWorker({
       logger: makeLogger(), client, store, classify, draftAndSubmitPlan,
+      allowedRepoHosts: ALLOWED_REPO_HOSTS,
       intervalMs: 0, tickOnStart: false,
     });
     await runtime.tick('manual');
     await runtime.tick('manual'); // second tick so watermark seeding doesn't mask the assertion
 
     expect(classify).not.toHaveBeenCalled();
+  });
+
+  it('skips a channel with an untrusted repo host in topic/purpose', async () => {
+    const store = makeStore();
+    const channel: SlackBugScanChannelSummary = {
+      id: 'C3',
+      name: 'supply-chain',
+      topic: 'repo: https://evil.example/acme/widgets.git',
+      purpose: 'repo: http://github.com/acme/widgets.git',
+    };
+    const messages = new Map([[channel.id, [bugMessage(1)]]]);
+    const { client } = makeClient([channel], messages);
+    const classify = vi.fn();
+    const draftAndSubmitPlan = vi.fn();
+
+    const runtime = createSlackBugScanWorker({
+      logger: makeLogger(), client, store, classify, draftAndSubmitPlan,
+      allowedRepoHosts: ALLOWED_REPO_HOSTS,
+      intervalMs: 0, tickOnStart: false,
+    });
+    await runtime.tick('manual');
+    await runtime.tick('manual');
+
+    expect(classify).not.toHaveBeenCalled();
+    expect(draftAndSubmitPlan).not.toHaveBeenCalled();
   });
 
   it('seeds the watermark to now on first sight and does not scan backlog', async () => {
@@ -160,6 +202,7 @@ describe('slack-bug-scan worker', () => {
 
     const runtime = createSlackBugScanWorker({
       logger: makeLogger(), client, store, classify, draftAndSubmitPlan,
+      allowedRepoHosts: ALLOWED_REPO_HOSTS,
       intervalMs: 0, tickOnStart: false,
     });
     await runtime.tick('manual'); // first sight: seeds watermark, does not scan the pre-existing message
@@ -176,6 +219,7 @@ describe('slack-bug-scan worker', () => {
 
     const runtime = createSlackBugScanWorker({
       logger: makeLogger(), client, store, classify, draftAndSubmitPlan,
+      allowedRepoHosts: ALLOWED_REPO_HOSTS,
       intervalMs: 0, tickOnStart: false,
     });
     await runtime.tick('manual'); // seed watermark
@@ -184,7 +228,7 @@ describe('slack-bug-scan worker', () => {
     await runtime.tick('manual');
 
     expect(classify).toHaveBeenCalledTimes(1);
-    expect(classify).toHaveBeenCalledWith(expect.objectContaining({ repoUrl: 'git@github.com:acme/widgets.git' }));
+    expect(classify).toHaveBeenCalledWith(expect.objectContaining({ repoUrl: 'https://github.com/acme/widgets.git' }));
     expect(draftAndSubmitPlan).toHaveBeenCalledTimes(1);
     expect(posted).toHaveLength(1);
     expect(posted[0]?.text).toContain('wf-1');
@@ -199,6 +243,7 @@ describe('slack-bug-scan worker', () => {
 
     const runtime = createSlackBugScanWorker({
       logger: makeLogger(), client, store, classify, draftAndSubmitPlan,
+      allowedRepoHosts: ALLOWED_REPO_HOSTS,
       intervalMs: 0, tickOnStart: false,
     });
     await runtime.tick('manual');
@@ -220,6 +265,7 @@ describe('slack-bug-scan worker', () => {
 
     const runtime = createSlackBugScanWorker({
       logger: makeLogger(), client, store, classify, draftAndSubmitPlan,
+      allowedRepoHosts: ALLOWED_REPO_HOSTS,
       intervalMs: 0, tickOnStart: false,
     });
     await runtime.tick('manual'); // seed
@@ -243,6 +289,7 @@ describe('slack-bug-scan worker', () => {
 
     const runtime = createSlackBugScanWorker({
       logger: makeLogger(), client, store, classify, draftAndSubmitPlan,
+      allowedRepoHosts: ALLOWED_REPO_HOSTS,
       intervalMs: 0, tickOnStart: false,
     });
     await runtime.tick('manual'); // seed
@@ -270,6 +317,7 @@ describe('slack-bug-scan worker', () => {
 
     const runtime = createSlackBugScanWorker({
       logger: makeLogger(), client, store, classify, draftAndSubmitPlan,
+      allowedRepoHosts: ALLOWED_REPO_HOSTS,
       intervalMs: 0, tickOnStart: false,
     });
     await runtime.tick('manual');
@@ -289,6 +337,7 @@ describe('slack-bug-scan worker', () => {
 
     const runtime = createSlackBugScanWorker({
       logger: makeLogger(), client, store, classify, draftAndSubmitPlan,
+      allowedRepoHosts: ALLOWED_REPO_HOSTS,
       intervalMs: 0, tickOnStart: false,
     });
     await runtime.tick('manual');
@@ -303,7 +352,7 @@ describe('slack-bug-scan worker', () => {
 
   it('enforces the per-tick submission cap, deferring rather than dropping candidates', async () => {
     const store = makeStore();
-    const channelB: SlackBugScanChannelSummary = { id: 'C3', name: 'ops', topic: 'repo: git@github.com:acme/ops.git' };
+    const channelB: SlackBugScanChannelSummary = { id: 'C3', name: 'ops', topic: 'repo: https://github.com/acme/ops.git' };
     const messages = new Map<string, SlackBugScanMessage[]>([[CHANNEL_WITH_REPO.id, []], [channelB.id, []]]);
     const { client } = makeClient([CHANNEL_WITH_REPO, channelB], messages);
     const classify: SlackBugScanClassifier = vi.fn(async () => ({ isBugComplaint: true, problemStatement: 'x' }));
@@ -311,6 +360,7 @@ describe('slack-bug-scan worker', () => {
 
     const runtime = createSlackBugScanWorker({
       logger: makeLogger(), client, store, classify, draftAndSubmitPlan,
+      allowedRepoHosts: ALLOWED_REPO_HOSTS,
       intervalMs: 0, tickOnStart: false, maxAutoSubmissionsPerTick: 1,
     });
     await runtime.tick('manual'); // seed both channels
@@ -331,6 +381,7 @@ describe('slack-bug-scan worker', () => {
 
     const runtime = createSlackBugScanWorker({
       logger: makeLogger(), client, store, classify, draftAndSubmitPlan,
+      allowedRepoHosts: ALLOWED_REPO_HOSTS,
       intervalMs: 0, tickOnStart: false, maxAutoSubmissionsPerDay: 1, maxAutoSubmissionsPerTick: 5,
     });
     await runtime.tick('manual'); // seed

--- a/packages/execution-engine/src/__tests__/slack-bug-scan-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/slack-bug-scan-worker.test.ts
@@ -81,6 +81,59 @@ describe('slack-bug-scan worker', () => {
     expect(registry.get(SLACK_BUG_SCAN_WORKER_KIND)).toBeTruthy();
   });
 
+  it('does not create a registered runtime when config is disabled', () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerSlackBugScanWorker(registry);
+
+    const store = makeStore();
+    const { client } = makeClient([CHANNEL_WITH_REPO], new Map());
+    const classify: SlackBugScanClassifier = vi.fn(async () => ({ isBugComplaint: true }));
+    const draftAndSubmitPlan: SlackBugScanPlanSubmitter = vi.fn(async () => ({ planName: 'P', workflowId: 'wf-1' }));
+
+    expect(() => registry.get(SLACK_BUG_SCAN_WORKER_KIND)!.factory({
+      logger: makeLogger(),
+      store: store as any,
+      submitter: {} as any,
+      slackBugScan: {
+        enabled: false,
+        client,
+        store,
+        classify,
+        draftAndSubmitPlan,
+        intervalMs: 0,
+        tickOnStart: false,
+      },
+    })).toThrow(/slack-bug-scan worker is disabled/);
+  });
+
+  it('creates a registered runtime when config is explicitly enabled', () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerSlackBugScanWorker(registry);
+
+    const store = makeStore();
+    const { client } = makeClient([CHANNEL_WITH_REPO], new Map());
+    const classify: SlackBugScanClassifier = vi.fn(async () => ({ isBugComplaint: true }));
+    const draftAndSubmitPlan: SlackBugScanPlanSubmitter = vi.fn(async () => ({ planName: 'P', workflowId: 'wf-1' }));
+
+    const runtime = registry.get(SLACK_BUG_SCAN_WORKER_KIND)!.factory({
+      logger: makeLogger(),
+      store: store as any,
+      submitter: {} as any,
+      slackBugScan: {
+        enabled: true,
+        client,
+        store,
+        classify,
+        draftAndSubmitPlan,
+        intervalMs: 0,
+        tickOnStart: false,
+      },
+    });
+
+    expect(runtime.identity.kind).toBe(SLACK_BUG_SCAN_WORKER_KIND);
+    expect(runtime.isRunning()).toBe(false);
+  });
+
   it('skips a channel with no parseable repo url in topic/purpose', async () => {
     const store = makeStore();
     const messages = new Map([[CHANNEL_NO_REPO.id, [bugMessage(1)]]]);

--- a/packages/execution-engine/src/workers/slack-bug-scan-worker.ts
+++ b/packages/execution-engine/src/workers/slack-bug-scan-worker.ts
@@ -1,6 +1,8 @@
 import type { Logger } from '@invoker/contracts';
 import {
+  normalizeAllowedRepoHosts,
   resolveChannelRepoUrl,
+  resolveSlackBugScanAllowedRepoHosts,
   resolveSlackBugScanIntervalMs,
   resolveSlackBugScanMaxPerDay,
   resolveSlackBugScanMaxPerTick,
@@ -40,6 +42,7 @@ export interface SlackBugScanWorkerConfig {
   store?: WorkerDecisionStore;
   classify?: SlackBugScanClassifier;
   draftAndSubmitPlan?: SlackBugScanPlanSubmitter;
+  allowedRepoHosts?: readonly string[];
   maxAutoSubmissionsPerDay?: number;
   maxAutoSubmissionsPerTick?: number;
   onTick?: WorkerTick;
@@ -51,6 +54,7 @@ export interface SlackBugScanWorkerOptions {
   store: WorkerDecisionStore;
   classify: SlackBugScanClassifier;
   draftAndSubmitPlan: SlackBugScanPlanSubmitter;
+  allowedRepoHosts?: readonly string[];
   intervalMs?: number;
   tickOnStart?: boolean;
   startDelayMs?: number;
@@ -108,6 +112,10 @@ async function postOutcome(
 export function createSlackBugScanWorker(options: SlackBugScanWorkerOptions): WorkerRuntime {
   const maxPerDay = options.maxAutoSubmissionsPerDay ?? resolveSlackBugScanMaxPerDay();
   const maxPerTick = options.maxAutoSubmissionsPerTick ?? resolveSlackBugScanMaxPerTick();
+  const allowedRepoHosts = normalizeAllowedRepoHosts(options.allowedRepoHosts ?? resolveSlackBugScanAllowedRepoHosts());
+  if (allowedRepoHosts.length === 0) {
+    throw new Error('slack-bug-scan worker requires at least one allowed repo host to be configured.');
+  }
 
   return createWorkerRuntime({
     kind: SLACK_BUG_SCAN_WORKER_KIND,
@@ -127,7 +135,7 @@ export function createSlackBugScanWorker(options: SlackBugScanWorkerOptions): Wo
 
       for (const channel of channels) {
         if (ctx.signal?.aborted) return;
-        const repoUrl = resolveChannelRepoUrl(channel.topic, channel.purpose);
+        const repoUrl = resolveChannelRepoUrl(channel.topic, channel.purpose, allowedRepoHosts);
         if (!repoUrl) continue;
 
         const candidates = await scanChannelForCandidates(options.client, options.store, channel.id, nowSlackTs);
@@ -214,6 +222,7 @@ export function registerSlackBugScanWorker(
         store: config.store ?? deps.store,
         classify: config.classify,
         draftAndSubmitPlan: config.draftAndSubmitPlan,
+        allowedRepoHosts: config.allowedRepoHosts,
         intervalMs: config.intervalMs,
         tickOnStart: config.tickOnStart,
         startDelayMs: config.startDelayMs,

--- a/packages/execution-engine/src/workers/slack-bug-scan-worker.ts
+++ b/packages/execution-engine/src/workers/slack-bug-scan-worker.ts
@@ -202,6 +202,9 @@ export function registerSlackBugScanWorker(
     note: 'Scans Slack threads across all member channels, LLM-classifies bug complaints, and auto-submits an Invoker plan with no human approval gate. High blast-radius — off by default.',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime => {
       const config = deps.slackBugScan;
+      if (config?.enabled !== true) {
+        throw new Error('slack-bug-scan worker is disabled; set slackBugScan.enabled to true to start it.');
+      }
       if (!config?.client || !config.classify || !config.draftAndSubmitPlan) {
         throw new Error('slack-bug-scan worker requires client, classify, and draftAndSubmitPlan to be configured.');
       }

--- a/packages/slack-bug-scan/src/__tests__/fingerprint.test.ts
+++ b/packages/slack-bug-scan/src/__tests__/fingerprint.test.ts
@@ -15,6 +15,13 @@ describe('normalizeComplaintText', () => {
   it('collapses whitespace and lowercases', () => {
     expect(normalizeComplaintText('  The   Login  Button\nIs Broken  ')).toBe('the login button is broken');
   });
+
+  it('does not backtrack catastrophically on a long run of unmatched "<"', () => {
+    const adversarial = '<'.repeat(60_000);
+    const start = Date.now();
+    normalizeComplaintText(adversarial);
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
 });
 
 describe('issueFingerprint', () => {

--- a/packages/slack-bug-scan/src/__tests__/repo-url.test.ts
+++ b/packages/slack-bug-scan/src/__tests__/repo-url.test.ts
@@ -1,36 +1,58 @@
 import { describe, expect, it } from 'vitest';
-import { extractRepoUrlFromText, resolveChannelRepoUrl } from '../repo-url.js';
+import { extractRepoUrlFromText, isAllowedRepoUrl, normalizeAllowedRepoHosts, resolveChannelRepoUrl } from '../repo-url.js';
 
 describe('slack-bug-scan repo url extraction', () => {
-  it('extracts an ssh-style git url', () => {
-    expect(extractRepoUrlFromText('repo: git@github.com:acme/widgets.git')).toBe('git@github.com:acme/widgets.git');
+  const allowedHosts = ['github.com'];
+
+  it('normalizes configured allowed hosts', () => {
+    expect(normalizeAllowedRepoHosts([' GitHub.com ', 'github.com', '', 'gitlab.com']))
+      .toEqual(['github.com', 'gitlab.com']);
   });
 
-  it('extracts an https-style git url', () => {
-    expect(extractRepoUrlFromText('see https://github.com/acme/widgets for source')).toBe('https://github.com/acme/widgets');
+  it('rejects an ssh-style git url', () => {
+    expect(extractRepoUrlFromText('repo: git@github.com:acme/widgets.git', allowedHosts)).toBeUndefined();
+  });
+
+  it('extracts an allowed https-style git url', () => {
+    expect(extractRepoUrlFromText('see https://github.com/acme/widgets for source', allowedHosts)).toBe('https://github.com/acme/widgets');
+  });
+
+  it('rejects plaintext http repo urls', () => {
+    expect(extractRepoUrlFromText('see http://github.com/acme/widgets for source', allowedHosts)).toBeUndefined();
+    expect(isAllowedRepoUrl('http://github.com/acme/widgets', allowedHosts)).toBe(false);
+  });
+
+  it('rejects repo urls from untrusted hosts', () => {
+    expect(extractRepoUrlFromText('see https://evil.example/acme/widgets for source', allowedHosts)).toBeUndefined();
+    expect(isAllowedRepoUrl('https://evil.example/acme/widgets', allowedHosts)).toBe(false);
   });
 
   it('returns undefined when no url is present', () => {
-    expect(extractRepoUrlFromText('just a random channel about snacks')).toBeUndefined();
-    expect(extractRepoUrlFromText(undefined)).toBeUndefined();
+    expect(extractRepoUrlFromText('just a random channel about snacks', allowedHosts)).toBeUndefined();
+    expect(extractRepoUrlFromText(undefined, allowedHosts)).toBeUndefined();
   });
 
-  it('picks the first match when multiple urls are present', () => {
-    expect(extractRepoUrlFromText('git@github.com:acme/one.git and git@github.com:acme/two.git'))
-      .toBe('git@github.com:acme/one.git');
+  it('picks the first allowed https match when multiple urls are present', () => {
+    expect(extractRepoUrlFromText('https://evil.example/acme/one.git and https://github.com/acme/two.git', allowedHosts))
+      .toBe('https://github.com/acme/two.git');
   });
 
   it('resolveChannelRepoUrl prefers topic over purpose', () => {
-    expect(resolveChannelRepoUrl('git@github.com:acme/topic-repo.git', 'https://github.com/acme/purpose-repo'))
-      .toBe('git@github.com:acme/topic-repo.git');
+    expect(resolveChannelRepoUrl('https://github.com/acme/topic-repo.git', 'https://github.com/acme/purpose-repo', allowedHosts))
+      .toBe('https://github.com/acme/topic-repo.git');
   });
 
   it('resolveChannelRepoUrl falls back to purpose when topic has no url', () => {
-    expect(resolveChannelRepoUrl('no url here', 'https://github.com/acme/purpose-repo'))
+    expect(resolveChannelRepoUrl('no url here', 'https://github.com/acme/purpose-repo', allowedHosts))
+      .toBe('https://github.com/acme/purpose-repo');
+  });
+
+  it('resolveChannelRepoUrl falls back to purpose when topic has no allowed url', () => {
+    expect(resolveChannelRepoUrl('repo: http://github.com/acme/topic-repo', 'https://github.com/acme/purpose-repo', allowedHosts))
       .toBe('https://github.com/acme/purpose-repo');
   });
 
   it('resolveChannelRepoUrl returns undefined when neither has a url', () => {
-    expect(resolveChannelRepoUrl('no url', 'also no url')).toBeUndefined();
+    expect(resolveChannelRepoUrl('no url', 'also no url', allowedHosts)).toBeUndefined();
   });
 });

--- a/packages/slack-bug-scan/src/fingerprint.ts
+++ b/packages/slack-bug-scan/src/fingerprint.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 
 export function normalizeComplaintText(text: string): string {
   return text
-    .replace(/<[^>]+>/g, ' ')
+    .replace(/<[^<>]+>/g, ' ')
     .replace(/https?:\/\/\S+/g, ' ')
     .replace(/\s+/g, ' ')
     .trim()

--- a/packages/slack-bug-scan/src/limits.ts
+++ b/packages/slack-bug-scan/src/limits.ts
@@ -20,3 +20,10 @@ export function resolveSlackBugScanMaxPerDay(env: NodeJS.ProcessEnv = process.en
 export function resolveSlackBugScanMaxPerTick(env: NodeJS.ProcessEnv = process.env): number {
   return readPositiveInt(env.INVOKER_SLACK_BUG_SCAN_MAX_PER_TICK, DEFAULT_SLACK_BUG_SCAN_MAX_PER_TICK);
 }
+
+export function resolveSlackBugScanAllowedRepoHosts(env: NodeJS.ProcessEnv = process.env): string[] {
+  return (env.INVOKER_SLACK_BUG_SCAN_ALLOWED_REPO_HOSTS ?? '')
+    .split(',')
+    .map((host) => host.trim().toLowerCase())
+    .filter(Boolean);
+}

--- a/packages/slack-bug-scan/src/repo-url.ts
+++ b/packages/slack-bug-scan/src/repo-url.ts
@@ -1,11 +1,36 @@
-const GIT_URL_PATTERN = /(?:git@[\w.-]+:[\w.-]+\/[\w.-]+(?:\.git)?|https?:\/\/[\w.-]+\/[\w.-]+\/[\w.-]+(?:\.git)?)/;
+const GIT_URL_PATTERN = /https?:\/\/[\w.-]+\/[\w.-]+\/[\w.-]+(?:\.git)?/g;
 
-export function extractRepoUrlFromText(text: string | undefined): string | undefined {
-  if (!text) return undefined;
-  const match = GIT_URL_PATTERN.exec(text);
-  return match ? match[0] : undefined;
+export function normalizeAllowedRepoHosts(allowedHosts: readonly string[]): string[] {
+  return [...new Set(allowedHosts.map((host) => host.trim().toLowerCase()).filter(Boolean))];
 }
 
-export function resolveChannelRepoUrl(topic: string | undefined, purpose: string | undefined): string | undefined {
-  return extractRepoUrlFromText(topic) ?? extractRepoUrlFromText(purpose);
+export function isAllowedRepoUrl(repoUrl: string, allowedHosts: readonly string[]): boolean {
+  const normalizedAllowedHosts = normalizeAllowedRepoHosts(allowedHosts);
+  if (normalizedAllowedHosts.length === 0) return false;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(repoUrl);
+  } catch {
+    return false;
+  }
+
+  return parsed.protocol === 'https:' && normalizedAllowedHosts.includes(parsed.hostname.toLowerCase());
+}
+
+export function extractRepoUrlFromText(text: string | undefined, allowedHosts: readonly string[]): string | undefined {
+  if (!text) return undefined;
+  for (const match of text.matchAll(GIT_URL_PATTERN)) {
+    const candidate = match[0];
+    if (isAllowedRepoUrl(candidate, allowedHosts)) return candidate;
+  }
+  return undefined;
+}
+
+export function resolveChannelRepoUrl(
+  topic: string | undefined,
+  purpose: string | undefined,
+  allowedHosts: readonly string[],
+): string | undefined {
+  return extractRepoUrlFromText(topic, allowedHosts) ?? extractRepoUrlFromText(purpose, allowedHosts);
 }


### PR DESCRIPTION
## Summary

Adds a new periodic worker that watches Slack threads across every channel the bot belongs to, decides which ones are real bug reports, and can open an Invoker workflow with no human in the loop.

This part is the core decision logic only: watching for new activity, a watermark, a content-based repeat-check, and per-tick/per-day caps.

It takes an injected Slack client, decision-maker, and plan opener, so it's fully testable with fakes.

Nothing runs in production from this alone. No real client exists until a later PR, and even then it stays off unless a human turns it on.

## Review Claim

Approve that the watch-then-decide-then-open pipeline, its caps, and its always-post-something feedback are correct on their own, independent of the concrete Slack/LLM pieces that plug into it.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Cannot do anything in production yet: it needs a real client, decision-maker, and plan opener injected before a tick means anything, and those don't exist until later PRs. Even wired up, it stays off by default -- this opens real workflows from raw chat with nobody approving first, which is a bigger deal than any other always-on piece in this repo.

## Slice Rationale

Keeping the decision logic apart from its concrete Slack/LLM pieces means each can stand on its own: this PR is logic plus fakes, the next is the real API pieces, and the ones after that turn it on for real.

## Non-goals

Does not touch a real Slack workspace. Does not call a real LLM. Does not open a real workflow. Does not change behavior for any other worker in this repo. Does not turn anything on in the running app.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test` -- 1457/1457 pass, including 20 new cases covering repeat-complaint handling, per-tick/per-day cap enforcement, first-sight watermark behavior, and always-post-something on failure
- [x] `pnpm run check:types` (repo-wide) -- clean
- [x] `pnpm run check:comments` -- clean

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None
- Data migration? No

</details>