### PR TITLE
Wire the slack-bug-scan worker into main.ts's owner boot path

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -70,17 +70,9 @@ export interface PrMaintenanceConfig {
 }
 
 export interface SlackBugScanConfig {
-  /**
-   * Gate for auto-starting the Slack bug-scan worker at owner startup.
-   * Default: false. High blast-radius (auto-submits workflows from
-   * unstructured chat with no human approval gate) — opt-in only.
-   */
   enabled?: boolean;
-  /** Scan interval in milliseconds. Defaults to five minutes. */
   intervalMs?: number;
-  /** Max auto-submitted workflows per calendar day, across all channels. Defaults to 5. */
   maxAutoSubmissionsPerDay?: number;
-  /** Max auto-submitted workflows per single tick. Defaults to 1. */
   maxAutoSubmissionsPerTick?: number;
 }
 
@@ -392,11 +384,6 @@ export interface InvokerConfig {
    * PR-maintenance workers from this block.
    */
   prMaintenance?: PrMaintenanceConfig;
-  /**
-   * Owner-side Slack bug-scan worker config. Disabled by default; when
-   * `enabled` is true the owner auto-starts the worker that scans Slack
-   * threads and auto-files bug complaints as Invoker workflows.
-   */
   slackBugScan?: SlackBugScanConfig;
 }
 export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarnessPresets']> = {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -288,6 +288,10 @@ import {
   submitPlanningChatDraft,
 } from './in-app-planner.js';
 import { discoverOwner, isStandaloneCapable } from './owner-endpoint.js';
+import type { PlanningCommandBuilder } from '@invoker/surfaces';
+import { createRealSlackBugScanClient } from './slack-bug-scan-client.js';
+import { createSlackBugScanClassifier } from './slack-bug-scan-classifier.js';
+import { createSlackBugScanPlanner } from './slack-bug-scan-planner.js';
 import {
   killRunningTaskExecution,
   rebuildTaskRunner as rebuildTaskRunnerWiring,
@@ -322,9 +326,36 @@ function submitRegisteredOwnerWorkerMutation(
 const autoFixAttemptLedger = createAutoFixAttemptLedger();
 
 
+function buildSlackBugScanWorkerConfig(
+  planningCommandBuilder: PlanningCommandBuilder,
+  executionAgentRegistry: AgentRegistry,
+): WorkerRuntimeDependencies['slackBugScan'] {
+  if (!invokerConfig.slackBugScan?.enabled) return undefined;
+  const client = createRealSlackBugScanClient();
+  if (!client) return undefined;
+  return {
+    client,
+    classify: createSlackBugScanClassifier(),
+    draftAndSubmitPlan: createSlackBugScanPlanner({
+      config: invokerConfig,
+      repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
+      persistence,
+      orchestrator,
+      planningCommandBuilder,
+      executionAgentRegistry,
+      logger,
+    }),
+    intervalMs: invokerConfig.slackBugScan.intervalMs,
+    maxAutoSubmissionsPerDay: invokerConfig.slackBugScan.maxAutoSubmissionsPerDay,
+    maxAutoSubmissionsPerTick: invokerConfig.slackBugScan.maxAutoSubmissionsPerTick,
+  };
+}
+
 function buildRegisteredOwnerWorkerDeps(
   store: WorkerRuntimeDependencies['store'],
   checkMergeGateStatuses: NonNullable<WorkerRuntimeDependencies['reviewGate']>['checkMergeGateStatuses'],
+  planningCommandBuilder: PlanningCommandBuilder,
+  executionAgentRegistry: AgentRegistry,
 ): WorkerRuntimeDependencies {
   const remoteTargets = Object.entries(invokerConfig.remoteTargets ?? {}).map(([name, target]) => ({
     name,
@@ -385,6 +416,7 @@ function buildRegisteredOwnerWorkerDeps(
     autoApprove: {
       enabled: resolveAutoApproveAIFixes(invokerConfig),
     },
+    slackBugScan: buildSlackBugScanWorkerConfig(planningCommandBuilder, executionAgentRegistry),
   };
 }
 function createRegisteredWorkerRegistry(): WorkerRegistry<WorkerRuntimeDependencies> {
@@ -1857,6 +1889,8 @@ function startHeadlessMode(): void {
             async () => {
               await createStandaloneTaskExecutor().checkMergeGateStatuses();
             },
+            planningCommandBuilder,
+            agentRegistry,
           ),
           autoStartKinds: invokerConfig.e2eAutoFixEnabled
             ? [...autoStartedOwnerWorkerKindsForConfig(invokerConfig), E2E_AUTOFIX_WORKER_KIND]
@@ -2976,6 +3010,8 @@ startMainProcessBootstrap({
           async () => {
             await requireTaskExecutor().checkMergeGateStatuses();
           },
+          planningCommandBuilder,
+          agentRegistry,
         ),
         autoStartKinds: invokerConfig.e2eAutoFixEnabled
           ? [...autoStartedOwnerWorkerKindsForConfig(invokerConfig), E2E_AUTOFIX_WORKER_KIND]

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -44,7 +44,6 @@ export const PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS = [
   PR_ADMIN_BYPASS_LAND_WORKER_KIND,
 ] as const;
 
-/** Slack bug-scan worker kind auto-started only when `slackBugScan.enabled` is true. */
 export const SLACK_BUG_SCAN_AUTO_STARTED_WORKER_KINDS = [
   SLACK_BUG_SCAN_WORKER_KIND,
 ] as const;

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -69,6 +69,5 @@ export interface WorkerRuntimeDependencies {
   workflowResume?: WorkflowResumeWorkerConfig;
   /** e2e auto-fix/default-branch CI watcher configuration. */
   e2eAutoFix?: E2eAutoFixWorkerConfig;
-  /** Slack bug-scan worker configuration (Slack client, classifier, plan submitter). Off by default. */
   slackBugScan?: SlackBugScanWorkerConfig;
 }

--- a/packages/execution-engine/src/workers/slack-bug-scan-client.ts
+++ b/packages/execution-engine/src/workers/slack-bug-scan-client.ts
@@ -15,7 +15,6 @@ export interface SlackBugScanMessage {
 }
 
 export interface SlackBugScanClient {
-  /** Channels the bot is a member of, via users.conversations (never conversations.list + filter). */
   listMemberChannels(): Promise<SlackBugScanChannelSummary[]>;
   listHistorySince(channelId: string, oldestTs?: string): Promise<SlackBugScanMessage[]>;
   listReplies(channelId: string, threadTs: string): Promise<SlackBugScanMessage[]>;

--- a/packages/execution-engine/src/workers/slack-bug-scan-fingerprint.ts
+++ b/packages/execution-engine/src/workers/slack-bug-scan-fingerprint.ts
@@ -1,7 +1,5 @@
 import { createHash } from 'node:crypto';
 
-/** Normalizes Slack markup/links/whitespace before fingerprinting, mirroring the
- * existing complaint-scout discovery script's normalize_text(). */
 export function normalizeComplaintText(text: string): string {
   return text
     .replace(/<[^>]+>/g, ' ')
@@ -11,7 +9,6 @@ export function normalizeComplaintText(text: string): string {
     .toLowerCase();
 }
 
-/** First 16 hex chars of sha256(normalized text) — stable dedup key for a complaint. */
 export function issueFingerprint(text: string): string {
   return createHash('sha256').update(normalizeComplaintText(text)).digest('hex').slice(0, 16);
 }

--- a/packages/execution-engine/src/workers/slack-bug-scan-scanner.ts
+++ b/packages/execution-engine/src/workers/slack-bug-scan-scanner.ts
@@ -25,12 +25,6 @@ function isHumanMessage(message: SlackBugScanMessage): boolean {
   return !message.botId;
 }
 
-/**
- * Scans one channel for new bug-complaint candidates since its stored watermark,
- * advancing the watermark unconditionally so history is never re-walked. A
- * channel seen for the first time seeds its watermark to `nowTs` rather than
- * scanning full backlog (per confirmed decision — never auto-file from old history).
- */
 export async function scanChannelForCandidates(
   client: SlackBugScanClient,
   store: WorkerDecisionStore,

--- a/packages/execution-engine/src/workers/slack-bug-scan-worker.ts
+++ b/packages/execution-engine/src/workers/slack-bug-scan-worker.ts
@@ -97,6 +97,10 @@ function incrementDailyCount(store: WorkerDecisionStore, dateIso: string, curren
   });
 }
 
+function currentSlackTs(): string {
+  return (Date.now() / 1000).toFixed(6);
+}
+
 function threadTextFor(candidate: SlackBugScanCandidate): string {
   return candidate.threadMessages.map((m) => m.text).join('\n---\n');
 }
@@ -132,10 +136,7 @@ export function createSlackBugScanWorker(options: SlackBugScanWorkerOptions): Wo
       ctx.signal?.throwIfAborted();
 
       const nowIso = new Date().toISOString();
-      // Slack ts values are Unix epoch seconds with microsecond precision (e.g.
-      // "1712345678.123456"), not ISO 8601 — the watermark must match that format
-      // since it's fed straight into conversations.history's `oldest` param.
-      const nowSlackTs = (Date.now() / 1000).toFixed(6);
+      const nowSlackTs = currentSlackTs();
       const channels = await options.client.listMemberChannels();
       let submittedThisTick = 0;
 
@@ -156,7 +157,6 @@ export function createSlackBugScanWorker(options: SlackBugScanWorkerOptions): Wo
             continue;
           }
           if (submittedThisTick >= maxPerTick) {
-            // Deferred, not dropped: no ledger row written, so the same candidate is picked up next tick.
             continue;
           }
 
@@ -209,7 +209,6 @@ export function createSlackBugScanWorker(options: SlackBugScanWorkerOptions): Wo
   });
 }
 
-/** Register the built-in Slack bug-scan worker (off by default — see worker-control.ts). */
 export function registerSlackBugScanWorker(
   registry: WorkerRegistry<WorkerRuntimeDependencies>,
 ): WorkerRegistry<WorkerRuntimeDependencies> {

--- a/packages/execution-engine/src/workers/slack-bug-scan.ts
+++ b/packages/execution-engine/src/workers/slack-bug-scan.ts
@@ -9,17 +9,14 @@ function readPositiveInt(raw: string | undefined, fallback: number): number {
   return n;
 }
 
-/** Resolve the scan interval (ms) from `INVOKER_SLACK_BUG_SCAN_INTERVAL_MS`, default 5 min. */
 export function resolveSlackBugScanIntervalMs(env: NodeJS.ProcessEnv = process.env): number {
   return readPositiveInt(env.INVOKER_SLACK_BUG_SCAN_INTERVAL_MS, DEFAULT_SLACK_BUG_SCAN_INTERVAL_MS);
 }
 
-/** Resolve the daily auto-submission cap from `INVOKER_SLACK_BUG_SCAN_MAX_PER_DAY`, default 5. */
 export function resolveSlackBugScanMaxPerDay(env: NodeJS.ProcessEnv = process.env): number {
   return readPositiveInt(env.INVOKER_SLACK_BUG_SCAN_MAX_PER_DAY, DEFAULT_SLACK_BUG_SCAN_MAX_PER_DAY);
 }
 
-/** Resolve the per-tick auto-submission cap from `INVOKER_SLACK_BUG_SCAN_MAX_PER_TICK`, default 1. */
 export function resolveSlackBugScanMaxPerTick(env: NodeJS.ProcessEnv = process.env): number {
   return readPositiveInt(env.INVOKER_SLACK_BUG_SCAN_MAX_PER_TICK, DEFAULT_SLACK_BUG_SCAN_MAX_PER_TICK);
 }


### PR DESCRIPTION
Threads planningCommandBuilder and agentRegistry through
buildRegisteredOwnerWorkerDeps (both are locals inside the two owner
boot functions, not module-level, so they need explicit passing) and
constructs the real Slack client/classifier/planner only when
invokerConfig.slackBugScan.enabled is true -- mirroring
resolvePrMaintenanceWorkerConfig's existing gate-or-omit pattern.
buildRegisteredOwnerWorkerDeps runs at most once per process, so
constructing the Anthropic/Slack clients inline is safe.

Also strips the explanatory comments added across the prior three
commits -- this repo's check-added-comments gate is a strict
zero-new-comments check with no carve-out for docstrings on new
public API, even though CLAUDE.md's written policy allows that case.
The one comment that carried real information (Slack ts format is
epoch seconds, not ISO 8601) is now a named currentSlackTs() helper
instead.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Depends-On: #7008