### PR TITLE
Extend shared PR-cron helpers: author-scoped PR listing and an Invoker close hand-off

### DIFF
--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -101,11 +101,14 @@ class GhClient:
 
         return [by_number[number] for number in ordered_numbers]
 
-    def list_open_prs(self, repo: str) -> list[dict]:
-        value = self._run_json([
+    def list_open_prs(self, repo: str, author: str | None = None) -> list[dict]:
+        args = [
             "gh", "pr", "list", "--repo", repo, "--state", "open", "--limit", "200", "--json",
             PR_LIST_FIELDS,
-        ])
+        ]
+        if author:
+            args[5:5] = ["--author", author]
+        value = self._run_json(args)
         return value if isinstance(value, list) else []
 
     def pr_detail(self, repo: str, number: int) -> dict:

--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import shlex
+import tempfile
+from pathlib import Path
 
 try:
     from .mergify_admin_requeue_headless_shell import run_headless as _run_headless
@@ -50,5 +53,79 @@ def submit_repair_review_gate_ci(pr_number: int) -> None:
     if completed.returncode != 0:
         raise RuntimeError(
             f"submit_repair_review_gate_ci failed for PR #{pr_number}: "
+            f"{completed.stderr.strip() or completed.stdout.strip()}"
+        )
+
+
+def _close_pr_command_script(pr_number: int, repo: str, reason: str, expected_head_oid: str, kept_pr_number: int | None) -> str:
+    # Belt-and-suspenders: the classification (landed/duplicate) already happened
+    # in the scan loop, but this task may sit queued for a while before it runs,
+    # so it re-checks the one fact that could invalidate the decision (this PR's
+    # own state/headRefOid, and — for a duplicate close — that the PR being kept
+    # is still open) immediately before mutating. Distinct exit codes make a
+    # deliberate skip visible in the task's run history instead of reading as a
+    # generic failure.
+    lines = [
+        "set -euo pipefail",
+        f"num={pr_number}",
+        f"repo={shlex.quote(repo)}",
+        f"expected={shlex.quote(expected_head_oid)}",
+        'current_json="$(gh pr view "$num" --repo "$repo" --json state,headRefOid)"',
+        'current_state="$(printf \'%s\' "$current_json" | jq -r \'.state\')"',
+        'current_head="$(printf \'%s\' "$current_json" | jq -r \'.headRefOid\')"',
+        'if [ "$current_state" != "OPEN" ] || [ "$current_head" != "$expected" ]; then',
+        '  echo "stale-pr: #$num is $current_state at $current_head; expected OPEN at $expected" >&2',
+        "  exit 20",
+        "fi",
+    ]
+    if kept_pr_number is not None:
+        lines += [
+            f"kept={kept_pr_number}",
+            'kept_state="$(gh pr view "$kept" --repo "$repo" --json state --jq \'.state\')"',
+            'if [ "$kept_state" != "OPEN" ]; then',
+            '  echo "stale-kept-pr: kept PR #$kept is $kept_state, not OPEN; refusing to close #$num" >&2',
+            "  exit 21",
+            "fi",
+        ]
+    lines += [
+        f"reason={shlex.quote(reason)}",
+        'gh pr comment "$num" --repo "$repo" --body "Invoker duplicate-close: $reason"',
+        'gh pr close "$num" --repo "$repo"',
+        'echo "pr-duplicate-close: closed #$num ($reason)"',
+    ]
+    return "\n".join(lines)
+
+
+def _close_pr_plan_yaml(pr_number: int, repo: str, reason: str, expected_head_oid: str, kept_pr_number: int | None) -> str:
+    command_script = _close_pr_command_script(pr_number, repo, reason, expected_head_oid, kept_pr_number)
+    indented_command = "\n".join(f"      {line}" if line else "" for line in command_script.splitlines())
+    safe_reason = reason.replace('"', "'").replace("\n", " ")
+    fingerprint_suffix = f"dup-{kept_pr_number}" if kept_pr_number is not None else "landed"
+    return (
+        f"name: close-pr-{pr_number}-{fingerprint_suffix}\n"
+        "onFinish: none\n"
+        "baseBranch: master\n"
+        "tasks:\n"
+        "  - id: close\n"
+        f'    description: "Close PR #{pr_number}: {safe_reason}"\n'
+        "    command: |\n"
+        f"{indented_command}\n"
+    )
+
+
+def submit_close_pr(pr_number: int, repo: str, reason: str, expected_head_oid: str, kept_pr_number: int | None = None) -> None:
+    plan_yaml = _close_pr_plan_yaml(pr_number, repo, reason, expected_head_oid, kept_pr_number)
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=f"-close-pr-{pr_number}.yaml", delete=False, encoding="utf-8",
+    ) as handle:
+        handle.write(plan_yaml)
+        plan_path = handle.name
+    try:
+        completed = _run_headless('headless_mutation run "$2"', plan_path)
+    finally:
+        Path(plan_path).unlink(missing_ok=True)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"submit_close_pr failed for PR #{pr_number}: "
             f"{completed.stderr.strip() or completed.stdout.strip()}"
         )

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -292,6 +292,22 @@ class GhClientLabelEdit(unittest.TestCase):
         self.assertNotIn("statusCheckRollup", fields)
         self.assertIn("headRefName", fields)
 
+    def test_list_open_prs_omits_author_by_default(self):
+        client = s.GhClient()
+        with mock.patch.object(client, "_run_json", return_value=[]) as run_json:
+            client.list_open_prs("Neko-Catpital-Labs/Invoker")
+
+        args = run_json.call_args.args[0]
+        self.assertNotIn("--author", args)
+
+    def test_list_open_prs_includes_explicit_author(self):
+        client = s.GhClient()
+        with mock.patch.object(client, "_run_json", return_value=[]) as run_json:
+            client.list_open_prs("Neko-Catpital-Labs/Invoker", "EdbertChan")
+
+        args = run_json.call_args.args[0]
+        self.assertEqual(args[args.index("--author") + 1], "EdbertChan")
+
     def test_add_label_uses_rest_issue_labels_endpoint(self):
         client = s.GhClient()
         with mock.patch("mergify_admin_requeue_snapshot.subprocess.run") as run:

--- a/scripts/test_mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/test_mergify_admin_requeue_workflow_fastpath.py
@@ -1,0 +1,112 @@
+"""Tests for the `submit_close_pr` Invoker hand-off added to
+``mergify_admin_requeue_workflow_fastpath`` for the PR duplicate-close worker.
+
+Run:  python3 scripts/test_mergify_admin_requeue_workflow_fastpath.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import mergify_admin_requeue_workflow_fastpath as f
+
+
+class ClosePrCommandScript(unittest.TestCase):
+    def test_landed_close_has_no_kept_pr_check(self):
+        script = f._close_pr_command_script(1, "owner/repo", "landed on master", "h1", None)
+        self.assertNotIn("kept_state", script)
+        self.assertIn("gh pr view \"$num\" --repo \"$repo\" --json state,headRefOid", script)
+        self.assertIn("gh pr comment \"$num\" --repo \"$repo\"", script)
+        self.assertIn("gh pr close \"$num\" --repo \"$repo\"", script)
+        self.assertNotIn("--delete-branch", script)
+
+    def test_duplicate_close_checks_kept_pr_is_still_open(self):
+        script = f._close_pr_command_script(5, "owner/repo", "duplicate of #9", "h5", 9)
+        self.assertIn("kept=9", script)
+        self.assertIn("kept_state", script)
+        self.assertIn('if [ "$kept_state" != "OPEN" ]; then', script)
+
+    def test_stale_head_check_precedes_any_mutation(self):
+        script = f._close_pr_command_script(1, "owner/repo", "r", "h1", None)
+        self.assertLess(script.index("exit 20"), script.index("gh pr comment"))
+        self.assertLess(script.index("exit 20"), script.index("gh pr close"))
+
+    def test_reason_is_shell_quoted(self):
+        script = f._close_pr_command_script(1, "owner/repo", "it's a \"test\"", "h1", None)
+        self.assertIn("reason=", script)
+        # shlex.quote of a string containing a single quote wraps in '"'"' form;
+        # the important invariant is the raw quote character is never left
+        # unescaped where it could break out of the surrounding shell string.
+        reason_line = next(line for line in script.splitlines() if line.startswith("reason="))
+        subprocess.run(["bash", "-c", f'{reason_line}\necho "$reason"'], check=True, capture_output=True, text=True)
+
+
+class ClosePrPlanYaml(unittest.TestCase):
+    def test_plan_has_no_llm_prompt_task_only_a_command(self):
+        plan = f._close_pr_plan_yaml(1, "owner/repo", "reason", "h1", None)
+        self.assertIn("onFinish: none\n", plan)
+        self.assertIn("- id: close\n", plan)
+        self.assertIn("command: |\n", plan)
+        self.assertNotIn("prompt:", plan)
+
+    def test_kept_pr_number_changes_the_fingerprint_suffix(self):
+        landed = f._close_pr_plan_yaml(1, "owner/repo", "r", "h1", None)
+        duplicate = f._close_pr_plan_yaml(1, "owner/repo", "r", "h1", 9)
+        self.assertIn("name: close-pr-1-landed\n", landed)
+        self.assertIn("name: close-pr-1-dup-9\n", duplicate)
+
+    def test_double_quotes_in_reason_are_sanitized_for_the_yaml_scalar(self):
+        plan = f._close_pr_plan_yaml(1, "owner/repo", 'reason with "quotes"', "h1", None)
+        self.assertIn("description: \"Close PR #1: reason with 'quotes'\"\n", plan)
+
+
+class SubmitClosePr(unittest.TestCase):
+    def test_raises_on_nonzero_exit_and_cleans_up_the_plan_file(self):
+        written_paths: list[str] = []
+
+        def fake_run(args, **kwargs):
+            written_paths.append(args[-1])
+            self.assertTrue(Path(args[-1]).exists())
+            return subprocess.CompletedProcess(args, returncode=1, stdout="", stderr="boom")
+
+        with mock.patch.object(subprocess, "run", side_effect=fake_run):
+            with self.assertRaises(RuntimeError) as ctx:
+                f.submit_close_pr(1, "owner/repo", "reason", "h1")
+
+        self.assertIn("boom", str(ctx.exception))
+        self.assertFalse(Path(written_paths[0]).exists())
+
+    def test_cleans_up_the_plan_file_on_success_too(self):
+        written_paths: list[str] = []
+
+        def fake_run(args, **kwargs):
+            written_paths.append(args[-1])
+            return subprocess.CompletedProcess(args, returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(subprocess, "run", side_effect=fake_run):
+            f.submit_close_pr(1, "owner/repo", "reason", "h1")
+
+        self.assertFalse(Path(written_paths[0]).exists())
+
+    def test_forwards_run_command_to_headless_mutation(self):
+        captured = {}
+
+        def fake_run(args, **kwargs):
+            captured["args"] = args
+            return subprocess.CompletedProcess(args, returncode=0, stdout="", stderr="")
+
+        with mock.patch.object(subprocess, "run", side_effect=fake_run):
+            f.submit_close_pr(1, "owner/repo", "reason", "h1")
+
+        script = captured["args"][2]
+        self.assertIn('headless_mutation run "$2"', script)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two of the repo's shared PR-cron helpers gain small, additive capabilities.

`GhClient` can now read open PRs for a single author, not only every
open PR in a repo. The default (no author) reads exactly as before.

Invoker's task-run path gains one more request shape: request that
an already-open PR be closed with a comment, guarded by a final
state re-check right before the close.

Neither addition has a caller yet. They exist so a later change can wire an
automated PR-closing worker on top of them, reusing tested plumbing instead
of duplicating it.

## Review Claim

Approve two small, tested additions to existing PR-cron helper modules, with
no behavior change for any existing caller.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Both additions are dead code from the running system's point of view: the
author-scoped read defaults to the old behavior, and the close hand-off has
no caller anywhere in this diff. Nothing in the deployed worker set changes
until a later slice wires them in.

## Slice Rationale

Landing the shared plumbing on its own, ahead of the worker that will use
it, keeps this diff small and lets the next slice's review focus entirely
on the new classification logic instead of also reviewing helper code.

## Non-goals

This PR does not add any new worker, cron entrypoint, or classification
logic. It does not change behavior for `mergify_admin_requeue.py`'s existing
run loop.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 scripts/test_mergify_admin_requeue_snapshot.py`
- [ ] `python3 scripts/test_mergify_admin_requeue_workflow_fastpath.py`
- [ ] `python3 scripts/test_mergify_admin_requeue.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
