### PR TITLE
Add pure classification for landed/duplicate PR detection

### DIFF
--- a/scripts/pr_duplicate_close_git_facts.py
+++ b/scripts/pr_duplicate_close_git_facts.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+class GitFactsClient:
+    """Local-git read-only facts. No `gh` calls, no mutation.
+
+    All three "landed" signals are independent and OR'd by the policy layer:
+    ancestry catches direct/rebase merges, empty-diff catches squash merges
+    (the merged commits are never ancestors of master), and
+    all_commits_equivalent catches per-commit reword/rebase onto master.
+    """
+
+    def __init__(self, cwd: Path | str | None = None):
+        self.cwd = str(cwd) if cwd is not None else None
+
+    def _run(self, args: list[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            args,
+            cwd=self.cwd,
+            text=True,
+            capture_output=True,
+        )
+
+    def fetch(self, remote: str = "origin", ref: str = "master") -> None:
+        subprocess.run(["git", "fetch", remote, ref], cwd=self.cwd, check=True, text=True, capture_output=True)
+
+    def merge_base(self, ref_a: str, ref_b: str) -> str | None:
+        completed = self._run(["git", "merge-base", ref_a, ref_b])
+        if completed.returncode != 0:
+            return None
+        return completed.stdout.strip() or None
+
+    def is_ancestor(self, sha: str, upstream: str = "origin/master") -> bool:
+        completed = self._run(["git", "merge-base", "--is-ancestor", sha, upstream])
+        return completed.returncode == 0
+
+    def is_empty_diff(self, head_sha: str, upstream: str = "origin/master") -> bool:
+        # Deliberately a direct two-ref tree comparison (no merge-base
+        # subtraction): `<merge-base>..<head>` is just the PR's own diff,
+        # which is never empty for a real PR. What signals a squash-merge is
+        # upstream's *current tip* already matching head's tree exactly.
+        completed = self._run(["git", "diff", "--quiet", upstream, head_sha])
+        return completed.returncode == 0
+
+    def all_commits_equivalent(self, head_sha: str, upstream: str = "origin/master") -> bool:
+        completed = self._run(["git", "cherry", upstream, head_sha])
+        if completed.returncode != 0:
+            return False
+        lines = [line for line in completed.stdout.splitlines() if line.strip()]
+        return len(lines) > 0 and all(line.startswith("-") for line in lines)
+
+    def patch_id(self, merge_base_sha: str, head_sha: str) -> str | None:
+        diff = self._run(["git", "diff", f"{merge_base_sha}..{head_sha}"])
+        if diff.returncode != 0 or not diff.stdout.strip():
+            return None
+        patch_id = subprocess.run(
+            ["git", "patch-id", "--stable"],
+            cwd=self.cwd,
+            input=diff.stdout,
+            text=True,
+            capture_output=True,
+        )
+        if patch_id.returncode != 0 or not patch_id.stdout.strip():
+            return None
+        return patch_id.stdout.split()[0]

--- a/scripts/pr_duplicate_close_git_facts.py
+++ b/scripts/pr_duplicate_close_git_facts.py
@@ -24,8 +24,15 @@ class GitFactsClient:
             capture_output=True,
         )
 
-    def fetch(self, remote: str = "origin", ref: str = "master") -> None:
-        subprocess.run(["git", "fetch", remote, ref], cwd=self.cwd, check=True, text=True, capture_output=True)
+    def fetch(self, remote: str = "origin", ref: str = "master", timeout: float = 30.0) -> None:
+        subprocess.run(
+            ["git", "fetch", remote, ref],
+            cwd=self.cwd,
+            check=True,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+        )
 
     def merge_base(self, ref_a: str, ref_b: str) -> str | None:
         completed = self._run(["git", "merge-base", ref_a, ref_b])

--- a/scripts/pr_duplicate_close_model.py
+++ b/scripts/pr_duplicate_close_model.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CandidatePr:
+    number: int
+    title: str
+    url: str
+    state: str
+    is_draft: bool
+    head_ref_name: str
+    base_ref_name: str
+    head_ref_oid: str
+
+
+@dataclass(frozen=True)
+class GitFacts:
+    # Always origin/master-relative (the "landed" signals). Same-diff
+    # duplicate comparison uses a separate, per-PR-base patch-id instead --
+    # see pr_duplicate_close_exec.py's _compute_patch_id.
+    merge_base_sha: str | None
+    is_ancestor: bool
+    is_empty_diff: bool
+    all_commits_equivalent: bool
+
+
+LANDED_ANCESTOR = "landed:ancestor"
+LANDED_EMPTY_DIFF = "landed:empty-diff"
+LANDED_PATCH_EQUIVALENT = "landed:patch-equivalent"
+DUPLICATE_SAME_BRANCH = "duplicate:same-branch"
+DUPLICATE_SAME_DIFF = "duplicate:same-diff"
+
+CLOSE_LANDED = "close_landed"
+CLOSE_DUPLICATE = "close_duplicate"
+
+
+@dataclass(frozen=True)
+class CloseAction:
+    kind: str  # CLOSE_LANDED | CLOSE_DUPLICATE
+    pr_number: int
+    expected_head_oid: str
+    reason: str  # one of the *_* signal constants above
+    evidence: str  # human-readable detail for the close comment
+    kept_pr_number: int | None = None  # set only for CLOSE_DUPLICATE
+
+
+@dataclass(frozen=True)
+class DuplicateGroup:
+    reason: str  # DUPLICATE_SAME_BRANCH | DUPLICATE_SAME_DIFF
+    kept_pr_number: int
+    closed_pr_numbers: tuple[int, ...]
+
+
+LEDGER_KIND_SUBMIT = "pr-duplicate-close-submit"
+
+
+def ledger_key(reason: str, kept_pr_number: int | None) -> str:
+    return f"{reason}:{kept_pr_number}" if kept_pr_number is not None else reason

--- a/scripts/pr_duplicate_close_plan.py
+++ b/scripts/pr_duplicate_close_plan.py
@@ -1,0 +1,157 @@
+"""Pure policy for the PR duplicate/landed-close worker.
+
+Every function here takes already-fetched state (CandidatePr, GitFacts,
+patch-ids, Ledger) and returns CloseAction objects. No `gh`/`git` calls, no
+mutation — this is what makes the classification cheap, deterministic, and
+directly unit-testable (see scripts/test_pr_duplicate_close_plan.py).
+"""
+
+from __future__ import annotations
+
+from typing import Mapping, Sequence
+
+try:
+    from .pr_duplicate_close_model import (
+        CLOSE_DUPLICATE,
+        CLOSE_LANDED,
+        DUPLICATE_SAME_BRANCH,
+        DUPLICATE_SAME_DIFF,
+        LANDED_ANCESTOR,
+        LANDED_EMPTY_DIFF,
+        LANDED_PATCH_EQUIVALENT,
+        LEDGER_KIND_SUBMIT,
+        CandidatePr,
+        CloseAction,
+        DuplicateGroup,
+        GitFacts,
+        ledger_key,
+    )
+except ImportError:
+    from pr_duplicate_close_model import (
+        CLOSE_DUPLICATE,
+        CLOSE_LANDED,
+        DUPLICATE_SAME_BRANCH,
+        DUPLICATE_SAME_DIFF,
+        LANDED_ANCESTOR,
+        LANDED_EMPTY_DIFF,
+        LANDED_PATCH_EQUIVALENT,
+        LEDGER_KIND_SUBMIT,
+        CandidatePr,
+        CloseAction,
+        DuplicateGroup,
+        GitFacts,
+        ledger_key,
+    )
+
+
+def classify_landed(pr: CandidatePr, facts: GitFacts | None) -> CloseAction | None:
+    if facts is None:
+        return None
+    signals: list[str] = []
+    if facts.is_ancestor:
+        signals.append(LANDED_ANCESTOR)
+    if facts.is_empty_diff:
+        signals.append(LANDED_EMPTY_DIFF)
+    if facts.all_commits_equivalent:
+        signals.append(LANDED_PATCH_EQUIVALENT)
+    if not signals:
+        return None
+    evidence = f"content already on origin/master ({', '.join(signals)}; head {pr.head_ref_oid})"
+    return CloseAction(
+        kind=CLOSE_LANDED,
+        pr_number=pr.number,
+        expected_head_oid=pr.head_ref_oid,
+        reason=signals[0],
+        evidence=evidence,
+    )
+
+
+def group_duplicates(
+    prs: Sequence[CandidatePr],
+    patch_ids: Mapping[int, str | None],
+) -> tuple[DuplicateGroup, ...]:
+    groups: list[DuplicateGroup] = []
+    covered: set[int] = set()
+
+    by_branch: dict[str, list[int]] = {}
+    for pr in prs:
+        if not pr.head_ref_name:
+            continue
+        by_branch.setdefault(pr.head_ref_name, []).append(pr.number)
+    for branch in sorted(by_branch):
+        numbers = sorted(by_branch[branch])
+        if len(numbers) < 2:
+            continue
+        groups.append(DuplicateGroup(
+            reason=DUPLICATE_SAME_BRANCH,
+            kept_pr_number=numbers[-1],
+            closed_pr_numbers=tuple(numbers[:-1]),
+        ))
+        covered.update(numbers)
+
+    by_patch: dict[str, list[int]] = {}
+    for pr in prs:
+        if pr.number in covered:
+            continue
+        patch_id = patch_ids.get(pr.number)
+        if not patch_id:
+            continue
+        by_patch.setdefault(patch_id, []).append(pr.number)
+    for patch_id in sorted(by_patch):
+        numbers = sorted(by_patch[patch_id])
+        if len(numbers) < 2:
+            continue
+        groups.append(DuplicateGroup(
+            reason=DUPLICATE_SAME_DIFF,
+            kept_pr_number=numbers[-1],
+            closed_pr_numbers=tuple(numbers[:-1]),
+        ))
+        covered.update(numbers)
+
+    return tuple(groups)
+
+
+def _already_submitted(ledger, pr_number: int, head_oid: str, reason: str, kept_pr_number: int | None) -> bool:
+    key = ledger_key(reason, kept_pr_number)
+    return ledger.count(LEDGER_KIND_SUBMIT, pr_number, head_oid, key) > 0
+
+
+def plan_close_actions(
+    prs: Sequence[CandidatePr],
+    facts_by_pr: Mapping[int, GitFacts],
+    patch_ids: Mapping[int, str | None],
+    ledger,
+) -> tuple[CloseAction, ...]:
+    actions: list[CloseAction] = []
+    eligible = [pr for pr in prs if pr.state == "OPEN" and not pr.is_draft]
+
+    landed_numbers: set[int] = set()
+    for pr in eligible:
+        action = classify_landed(pr, facts_by_pr.get(pr.number))
+        if action is None:
+            continue
+        landed_numbers.add(pr.number)
+        if _already_submitted(ledger, pr.number, pr.head_ref_oid, action.reason, None):
+            continue
+        actions.append(action)
+
+    remaining = [pr for pr in eligible if pr.number not in landed_numbers]
+    by_number = {pr.number: pr for pr in remaining}
+    for group in group_duplicates(remaining, patch_ids):
+        for closed_number in group.closed_pr_numbers:
+            pr = by_number.get(closed_number)
+            if pr is None:
+                continue
+            evidence = f"duplicate of open PR #{group.kept_pr_number} ({group.reason}; head {pr.head_ref_oid})"
+            if _already_submitted(ledger, pr.number, pr.head_ref_oid, group.reason, group.kept_pr_number):
+                continue
+            actions.append(CloseAction(
+                kind=CLOSE_DUPLICATE,
+                pr_number=pr.number,
+                expected_head_oid=pr.head_ref_oid,
+                reason=group.reason,
+                evidence=evidence,
+                kept_pr_number=group.kept_pr_number,
+            ))
+
+    return tuple(actions)

--- a/scripts/test_pr_duplicate_close_git_facts.py
+++ b/scripts/test_pr_duplicate_close_git_facts.py
@@ -1,0 +1,136 @@
+"""Behavioural tests for ``pr_duplicate_close_git_facts.GitFactsClient``.
+
+Runs real `git` against a throwaway sandbox repo (mkdtemp + git init, per the
+project's testing convention for git-touching code) rather than mocking git
+output — these are exactly the plumbing commands (merge-base, diff, cherry,
+patch-id) where a hand-rolled fake would risk drifting from real behavior.
+
+Run:  python3 scripts/test_pr_duplicate_close_git_facts.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from pr_duplicate_close_git_facts import GitFactsClient
+
+
+def run(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, text=True, capture_output=True,
+    ).stdout.strip()
+
+
+def write_and_commit(repo: Path, filename: str, content: str, message: str) -> str:
+    (repo / filename).write_text(content, encoding="utf-8")
+    run(repo, "add", filename)
+    run(repo, "commit", "-m", message)
+    return run(repo, "rev-parse", "HEAD")
+
+
+class GitFactsTestCase(unittest.TestCase):
+    def setUp(self):
+        self.repo = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(self.repo, ignore_errors=True))
+        run(self.repo, "init", "-q", "-b", "master")
+        run(self.repo, "config", "user.email", "test@example.com")
+        run(self.repo, "config", "user.name", "Test")
+        self.base_sha = write_and_commit(self.repo, "base.txt", "base\n", "base commit")
+        self.client = GitFactsClient(cwd=self.repo)
+
+
+class IsAncestor(GitFactsTestCase):
+    def test_true_when_head_has_no_new_commits(self):
+        run(self.repo, "branch", "feature")
+        feature_sha = run(self.repo, "rev-parse", "feature")
+        self.assertTrue(self.client.is_ancestor(feature_sha, "master"))
+
+    def test_false_before_merge_true_after(self):
+        run(self.repo, "checkout", "-q", "-b", "feature")
+        feature_sha = write_and_commit(self.repo, "feature.txt", "feature\n", "feature commit")
+        run(self.repo, "checkout", "-q", "master")
+
+        self.assertFalse(self.client.is_ancestor(feature_sha, "master"))
+
+        run(self.repo, "merge", "-q", "--no-ff", "feature", "-m", "merge feature")
+        self.assertTrue(self.client.is_ancestor(feature_sha, "master"))
+
+
+class IsEmptyDiff(GitFactsTestCase):
+    def test_true_for_squash_equivalent_content(self):
+        # Simulates a squash-merge: feature's commit is never an ancestor of
+        # master, but master independently ends up with a tree identical to
+        # feature's tree (the squash commit reproduces the same net change).
+        run(self.repo, "checkout", "-q", "-b", "feature")
+        feature_sha = write_and_commit(self.repo, "squash.txt", "same content\n", "feature commit")
+        run(self.repo, "checkout", "-q", "master")
+        write_and_commit(self.repo, "squash.txt", "same content\n", "squash-merged equivalent")
+
+        self.assertFalse(self.client.is_ancestor(feature_sha, "master"))
+        self.assertTrue(self.client.is_empty_diff(feature_sha, "master"))
+
+    def test_false_when_content_differs(self):
+        run(self.repo, "checkout", "-q", "-b", "feature")
+        feature_sha = write_and_commit(self.repo, "diverge.txt", "feature content\n", "feature commit")
+        self.assertFalse(self.client.is_empty_diff(feature_sha, "master"))
+
+    def test_true_when_head_has_no_new_commits(self):
+        run(self.repo, "branch", "feature")
+        feature_sha = run(self.repo, "rev-parse", "feature")
+        self.assertTrue(self.client.is_empty_diff(feature_sha, "master"))
+
+
+class AllCommitsEquivalent(GitFactsTestCase):
+    def test_true_when_master_has_an_equivalent_commit(self):
+        run(self.repo, "checkout", "-q", "-b", "feature")
+        feature_sha = write_and_commit(self.repo, "reword.txt", "identical patch\n", "feature: add file")
+        run(self.repo, "checkout", "-q", "master")
+        write_and_commit(self.repo, "reword.txt", "identical patch\n", "master: reworded add file")
+
+        self.assertTrue(self.client.all_commits_equivalent(feature_sha, "master"))
+
+    def test_false_when_a_commit_is_genuinely_new(self):
+        run(self.repo, "checkout", "-q", "-b", "feature")
+        feature_sha = write_and_commit(self.repo, "new.txt", "brand new\n", "feature: genuinely new change")
+
+        self.assertFalse(self.client.all_commits_equivalent(feature_sha, "master"))
+
+
+class PatchId(GitFactsTestCase):
+    def test_identical_diffs_produce_the_same_patch_id(self):
+        run(self.repo, "checkout", "-q", "-b", "branch-a")
+        sha_a = write_and_commit(self.repo, "same.txt", "identical\n", "branch a change")
+        run(self.repo, "checkout", "-q", "master")
+        run(self.repo, "checkout", "-q", "-b", "branch-b")
+        sha_b = write_and_commit(self.repo, "same.txt", "identical\n", "branch b change, same content")
+
+        base_a = self.client.merge_base("master", sha_a)
+        base_b = self.client.merge_base("master", sha_b)
+        self.assertEqual(self.client.patch_id(base_a, sha_a), self.client.patch_id(base_b, sha_b))
+
+    def test_different_diffs_produce_different_patch_ids(self):
+        run(self.repo, "checkout", "-q", "-b", "branch-a")
+        sha_a = write_and_commit(self.repo, "a.txt", "content a\n", "branch a change")
+        run(self.repo, "checkout", "-q", "master")
+        run(self.repo, "checkout", "-q", "-b", "branch-b")
+        sha_b = write_and_commit(self.repo, "b.txt", "content b\n", "branch b change")
+
+        base_a = self.client.merge_base("master", sha_a)
+        base_b = self.client.merge_base("master", sha_b)
+        self.assertNotEqual(self.client.patch_id(base_a, sha_a), self.client.patch_id(base_b, sha_b))
+
+    def test_none_for_an_empty_diff(self):
+        run(self.repo, "branch", "feature")
+        feature_sha = run(self.repo, "rev-parse", "feature")
+        self.assertIsNone(self.client.patch_id(self.base_sha, feature_sha))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_pr_duplicate_close_plan.py
+++ b/scripts/test_pr_duplicate_close_plan.py
@@ -1,0 +1,203 @@
+"""Behavioural tests for ``pr_duplicate_close_plan``.
+
+Documentation-by-test for the pure policy layer: classification (landed) and
+grouping (duplicate) are plain functions over already-fetched state, so these
+tests construct that state directly and never shell out to `gh`/`git`.
+
+Run:  python3 scripts/test_pr_duplicate_close_plan.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import mergify_admin_requeue_model as m
+import pr_duplicate_close_model as dm
+import pr_duplicate_close_plan as p
+
+
+def candidate(**kw):
+    base = dict(
+        number=1,
+        title="t",
+        url="u",
+        state="OPEN",
+        is_draft=False,
+        head_ref_name="branch-1",
+        base_ref_name="master",
+        head_ref_oid="a" * 40,
+    )
+    base.update(kw)
+    return dm.CandidatePr(**base)
+
+
+def facts(**kw):
+    base = dict(
+        merge_base_sha="base" * 10,
+        is_ancestor=False,
+        is_empty_diff=False,
+        all_commits_equivalent=False,
+    )
+    base.update(kw)
+    return dm.GitFacts(**base)
+
+
+class DuplicateCloseTestCase(unittest.TestCase):
+    def _ledger(self):
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(d, ignore_errors=True))
+        return m.Ledger(Path(d) / "ledger.jsonl")
+
+
+class ClassifyLanded(DuplicateCloseTestCase):
+    def test_no_facts_is_not_landed(self):
+        self.assertIsNone(p.classify_landed(candidate(), None))
+
+    def test_no_signal_is_not_landed(self):
+        self.assertIsNone(p.classify_landed(candidate(), facts()))
+
+    def test_ancestor_signal_wins_priority(self):
+        action = p.classify_landed(candidate(), facts(is_ancestor=True, is_empty_diff=True))
+        self.assertEqual(action.kind, dm.CLOSE_LANDED)
+        self.assertEqual(action.reason, dm.LANDED_ANCESTOR)
+
+    def test_empty_diff_signal_alone(self):
+        action = p.classify_landed(candidate(), facts(is_empty_diff=True))
+        self.assertEqual(action.reason, dm.LANDED_EMPTY_DIFF)
+
+    def test_patch_equivalent_signal_alone(self):
+        action = p.classify_landed(candidate(), facts(all_commits_equivalent=True))
+        self.assertEqual(action.reason, dm.LANDED_PATCH_EQUIVALENT)
+
+    def test_landed_action_carries_expected_head(self):
+        pr = candidate(number=42, head_ref_oid="deadbeef")
+        action = p.classify_landed(pr, facts(is_ancestor=True))
+        self.assertEqual(action.pr_number, 42)
+        self.assertEqual(action.expected_head_oid, "deadbeef")
+        self.assertIsNone(action.kept_pr_number)
+
+
+class GroupDuplicates(unittest.TestCase):
+    def test_two_prs_same_branch_keeps_newest(self):
+        prs = [candidate(number=5, head_ref_name="stack/x"), candidate(number=9, head_ref_name="stack/x")]
+        groups = p.group_duplicates(prs, {})
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].reason, dm.DUPLICATE_SAME_BRANCH)
+        self.assertEqual(groups[0].kept_pr_number, 9)
+        self.assertEqual(groups[0].closed_pr_numbers, (5,))
+
+    def test_three_prs_same_branch_closes_all_but_newest(self):
+        prs = [candidate(number=n, head_ref_name="stack/x") for n in (3, 7, 5)]
+        groups = p.group_duplicates(prs, {})
+        self.assertEqual(groups[0].kept_pr_number, 7)
+        self.assertEqual(sorted(groups[0].closed_pr_numbers), [3, 5])
+
+    def test_single_pr_on_a_branch_is_not_a_duplicate(self):
+        prs = [candidate(number=1, head_ref_name="solo")]
+        self.assertEqual(p.group_duplicates(prs, {}), ())
+
+    def test_empty_head_ref_name_never_groups(self):
+        prs = [candidate(number=1, head_ref_name=""), candidate(number=2, head_ref_name="")]
+        self.assertEqual(p.group_duplicates(prs, {}), ())
+
+    def test_same_patch_id_on_different_branches_groups(self):
+        prs = [
+            candidate(number=11, head_ref_name="a"),
+            candidate(number=12, head_ref_name="b"),
+        ]
+        groups = p.group_duplicates(prs, {11: "pid-1", 12: "pid-1"})
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].reason, dm.DUPLICATE_SAME_DIFF)
+        self.assertEqual(groups[0].kept_pr_number, 12)
+        self.assertEqual(groups[0].closed_pr_numbers, (11,))
+
+    def test_missing_patch_id_never_groups(self):
+        prs = [candidate(number=1, head_ref_name="a"), candidate(number=2, head_ref_name="b")]
+        self.assertEqual(p.group_duplicates(prs, {1: None, 2: None}), ())
+
+    def test_branch_group_excludes_members_from_diff_grouping(self):
+        # #1/#2 share a branch (grouped first); #2/#3 also share a patch-id,
+        # but #2 is already covered by the branch group, so it can't also
+        # anchor a diff group with #3 (that would double-close it).
+        prs = [
+            candidate(number=1, head_ref_name="stack/x"),
+            candidate(number=2, head_ref_name="stack/x"),
+            candidate(number=3, head_ref_name="stack/y"),
+        ]
+        groups = p.group_duplicates(prs, {2: "pid-1", 3: "pid-1"})
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].reason, dm.DUPLICATE_SAME_BRANCH)
+
+
+class PlanCloseActions(DuplicateCloseTestCase):
+    def test_landed_pr_is_closed_and_excluded_from_duplicate_grouping(self):
+        # #1 and #2 share a branch (would normally duplicate-close #1), but #1
+        # is also independently landed — it must be closed once, for the
+        # landed reason, never counted as a duplicate too.
+        prs = [
+            candidate(number=1, head_ref_name="stack/x", head_ref_oid="h1"),
+            candidate(number=2, head_ref_name="stack/x", head_ref_oid="h2"),
+        ]
+        facts_by_pr = {1: facts(is_ancestor=True)}
+        actions = p.plan_close_actions(prs, facts_by_pr, {}, self._ledger())
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(actions[0].kind, dm.CLOSE_LANDED)
+        self.assertEqual(actions[0].pr_number, 1)
+
+    def test_draft_prs_are_never_planned(self):
+        prs = [candidate(number=1, is_draft=True, head_ref_oid="h1")]
+        actions = p.plan_close_actions(prs, {1: facts(is_ancestor=True)}, {}, self._ledger())
+        self.assertEqual(actions, ())
+
+    def test_closed_prs_are_never_planned(self):
+        prs = [candidate(number=1, state="CLOSED", head_ref_oid="h1")]
+        actions = p.plan_close_actions(prs, {1: facts(is_ancestor=True)}, {}, self._ledger())
+        self.assertEqual(actions, ())
+
+    def test_duplicate_group_produces_one_action_per_closed_pr(self):
+        prs = [
+            candidate(number=5, head_ref_name="stack/x", head_ref_oid="h5"),
+            candidate(number=9, head_ref_name="stack/x", head_ref_oid="h9"),
+        ]
+        actions = p.plan_close_actions(prs, {}, {}, self._ledger())
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(actions[0].kind, dm.CLOSE_DUPLICATE)
+        self.assertEqual(actions[0].pr_number, 5)
+        self.assertEqual(actions[0].kept_pr_number, 9)
+
+    def test_already_submitted_landed_action_is_not_replanned(self):
+        prs = [candidate(number=1, head_ref_oid="h1")]
+        ledger = self._ledger()
+        ledger.record(dm.LEDGER_KIND_SUBMIT, 1, "h1", dm.ledger_key(dm.LANDED_ANCESTOR, None))
+        actions = p.plan_close_actions(prs, {1: facts(is_ancestor=True)}, {}, ledger)
+        self.assertEqual(actions, ())
+
+    def test_already_submitted_duplicate_action_is_not_replanned(self):
+        prs = [
+            candidate(number=5, head_ref_name="stack/x", head_ref_oid="h5"),
+            candidate(number=9, head_ref_name="stack/x", head_ref_oid="h9"),
+        ]
+        ledger = self._ledger()
+        ledger.record(dm.LEDGER_KIND_SUBMIT, 5, "h5", dm.ledger_key(dm.DUPLICATE_SAME_BRANCH, 9))
+        actions = p.plan_close_actions(prs, {}, {}, ledger)
+        self.assertEqual(actions, ())
+
+    def test_a_new_head_oid_gets_a_fresh_ledger_key_and_replans(self):
+        # A different head_ref_oid means a genuinely new PR state (e.g. it was
+        # pushed to again after an earlier submission for the old head) —
+        # the ledger key is scoped by head_sha, so this must plan again.
+        prs = [candidate(number=1, head_ref_oid="h1-new")]
+        ledger = self._ledger()
+        ledger.record(dm.LEDGER_KIND_SUBMIT, 1, "h1-old", dm.ledger_key(dm.LANDED_ANCESTOR, None))
+        actions = p.plan_close_actions(prs, {1: facts(is_ancestor=True)}, {}, ledger)
+        self.assertEqual(len(actions), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

New, self-contained modules decide two things about an open PR: is its
content already on master, and does it share a branch or a net change
with another open PR.

Three signals answer the first question, any one of which is enough: the
head is an ancestor of master, master's tip tree already matches the
head's tree, or every commit has a patch-equivalent already on master.

The second question groups PRs by branch name or by a stable patch id
(computed elsewhere, from whatever reference point is correct for a given
PR) and picks the highest PR number in each group as the one to keep.

Everything here is a plain function or a thin, read-only wrapper around
local git commands. Nothing calls GitHub, and nothing runs on a schedule yet.

## Review Claim

Approve the classification rules on their own terms, independent of how or
when they eventually run.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

No git or GitHub command here can change any state: the local-git wrapper
only reads (merge-base, diff, cherry, patch-id), and the plan functions
take already-fetched data and a decision log as input and return plain
records, never performing an action themselves.

## Slice Rationale

This is the one part of the whole change that benefits from review in
isolation, since correctness here is subtle and easy to test without any
of the surrounding plumbing. Landing it separately keeps the next slice's
diff focused on wiring rather than on these rules.

## Non-goals

This PR does not read PRs from GitHub, does not close anything, and does
not add a runnable entrypoint. Those come in the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 scripts/test_pr_duplicate_close_plan.py`
- [ ] `python3 scripts/test_pr_duplicate_close_git_facts.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated detection of landed and duplicate pull requests.
  * Identifies duplicates by source branch or equivalent changes.
  * Plans safe, repeatable closure actions while excluding drafts and already-processed items.

* **Tests**
  * Added coverage for commit ancestry, empty changes, equivalent histories, patch comparisons, duplicate grouping, and repeatable closure planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->