### PR TITLE
Wire a CAS-guarded executor and cron entrypoint for closing landed/duplicate PRs

### DIFF
--- a/scripts/cron-pr-duplicate-close.sh
+++ b/scripts/cron-pr-duplicate-close.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=scripts/cron-pr-lib.sh
+source "$(dirname "$0")/cron-pr-lib.sh"
+
+cron_lock
+
+args=(--once --repo "$TARGET_REPO" --author "$PR_AUTHOR")
+if [ "$DRY_RUN" = "1" ]; then
+  args+=(--dry-run)
+fi
+if [ -n "${INVOKER_PR_DUP_STATE_FILE:-}" ]; then
+  args+=(--state-file "$INVOKER_PR_DUP_STATE_FILE")
+fi
+if [ -n "${INVOKER_PR_DUP_GIT_CWD:-}" ]; then
+  args+=(--git-cwd "$INVOKER_PR_DUP_GIT_CWD")
+fi
+
+(
+  cd "$REPO_ROOT"
+  python3 scripts/pr_duplicate_close.py "${args[@]}"
+)

--- a/scripts/pr_duplicate_close.py
+++ b/scripts/pr_duplicate_close.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from typing import Sequence
+
+try:
+    from . import pr_duplicate_close_exec as exec_impl
+except ImportError:
+    import pr_duplicate_close_exec as exec_impl
+
+parse_args = exec_impl.parse_args
+run_once = exec_impl.run_once
+run_loop = exec_impl.run_loop
+REPO_ROOT = exec_impl.REPO_ROOT
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    return run_loop(args) if args.loop else run_once(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pr_duplicate_close_exec.py
+++ b/scripts/pr_duplicate_close_exec.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Sequence
+
+try:
+    from .mergify_admin_requeue_logger import AdminBypassLogger
+    from .mergify_admin_requeue_model import Ledger
+    from .mergify_admin_requeue_snapshot import GhClient
+    from .pr_duplicate_close_executor import PrDuplicateCloseExecutor
+    from .pr_duplicate_close_git_facts import GitFactsClient
+    from .pr_duplicate_close_model import CandidatePr, GitFacts
+    from .pr_duplicate_close_plan import plan_close_actions
+except ImportError:
+    from mergify_admin_requeue_logger import AdminBypassLogger
+    from mergify_admin_requeue_model import Ledger
+    from mergify_admin_requeue_snapshot import GhClient
+    from pr_duplicate_close_executor import PrDuplicateCloseExecutor
+    from pr_duplicate_close_git_facts import GitFactsClient
+    from pr_duplicate_close_model import CandidatePr, GitFacts
+    from pr_duplicate_close_plan import plan_close_actions
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _candidate_from_raw(item: dict) -> CandidatePr:
+    return CandidatePr(
+        number=int(item.get("number") or 0),
+        title=str(item.get("title") or ""),
+        url=str(item.get("url") or ""),
+        state=str(item.get("state") or ""),
+        is_draft=bool(item.get("isDraft")),
+        head_ref_name=str(item.get("headRefName") or ""),
+        base_ref_name=str(item.get("baseRefName") or ""),
+        head_ref_oid=str(item.get("headRefOid") or ""),
+    )
+
+
+def _compute_landed_facts(git_facts: GitFactsClient, head_sha: str) -> GitFacts:
+    merge_base_sha = git_facts.merge_base("origin/master", head_sha)
+    if merge_base_sha is None:
+        return GitFacts(
+            merge_base_sha=None, is_ancestor=False, is_empty_diff=False,
+            all_commits_equivalent=False,
+        )
+    return GitFacts(
+        merge_base_sha=merge_base_sha,
+        is_ancestor=git_facts.is_ancestor(head_sha),
+        is_empty_diff=git_facts.is_empty_diff(head_sha),
+        all_commits_equivalent=git_facts.all_commits_equivalent(head_sha),
+    )
+
+
+def _compute_patch_id(git_facts: GitFactsClient, pr: CandidatePr) -> str | None:
+    # Diff against the PR's own base, not always master: two duplicate PRs
+    # can be based on different branches (one stacked on another open PR),
+    # and diffing both against master would pull in whichever branch's own
+    # unrelated changes, making a real duplicate's patch-id fail to match.
+    upstream = f"origin/{pr.base_ref_name}" if pr.base_ref_name else "origin/master"
+    merge_base_sha = git_facts.merge_base(upstream, pr.head_ref_oid)
+    if merge_base_sha is None:
+        return None
+    return git_facts.patch_id(merge_base_sha, pr.head_ref_oid)
+
+
+def print_action(action, dry_run: bool) -> None:
+    prefix = "DRY-RUN " if dry_run else ""
+    kept = f" kept=#{action.kept_pr_number}" if action.kept_pr_number is not None else ""
+    print(f"{prefix}close PR #{action.pr_number} reason={action.reason}{kept} evidence={action.evidence}")
+
+
+def run_cycle(args: argparse.Namespace) -> bool:
+    logger = AdminBypassLogger()
+    gh = GhClient()
+    git_facts = GitFactsClient(cwd=args.git_cwd)
+    ledger = Ledger(Path(args.state_file).expanduser())
+    executor = PrDuplicateCloseExecutor(gh, ledger, logger, args.repo)
+
+    logger.trace(
+        "pr-duplicate-close-scan-start", repo=args.repo, author=args.author, dry_run=args.dry_run,
+    )
+
+    raw_prs = gh.list_open_prs(args.repo, args.author)
+    prs = tuple(_candidate_from_raw(item) for item in raw_prs)
+    if not prs:
+        logger.trace("pr-duplicate-close-scan-empty")
+        return False
+
+    git_facts.fetch()
+
+    eligible = [pr for pr in prs if pr.state == "OPEN" and not pr.is_draft and pr.head_ref_oid]
+    eligible_bases = sorted({pr.base_ref_name for pr in eligible if pr.base_ref_name and pr.base_ref_name != "master"})
+    for base in eligible_bases:
+        try:
+            git_facts.fetch(ref=base)
+        except subprocess.CalledProcessError as exc:
+            logger.trace(
+                "pr-duplicate-close-base-fetch-failed", repo=args.repo, base_ref_name=base, error=str(exc),
+            )
+
+    facts_by_pr: dict[int, GitFacts] = {}
+    patch_ids: dict[int, str | None] = {}
+    for pr in eligible:
+        facts_by_pr[pr.number] = _compute_landed_facts(git_facts, pr.head_ref_oid)
+        patch_ids[pr.number] = _compute_patch_id(git_facts, pr)
+
+    actions = plan_close_actions(prs, facts_by_pr, patch_ids, ledger)
+    logger.trace("pr-duplicate-close-scan-planned", repo=args.repo, action_count=len(actions))
+
+    submitted = 0
+    for action in actions:
+        print_action(action, args.dry_run)
+        if args.dry_run:
+            continue
+        if executor.execute(action):
+            submitted += 1
+
+    logger.trace("pr-duplicate-close-scan-complete", repo=args.repo, submitted=submitted, planned=len(actions))
+    return False
+
+
+def run_once(args: argparse.Namespace) -> int:
+    try:
+        run_cycle(args)
+    except RuntimeError:
+        return 2
+    return 0
+
+
+def run_loop(args: argparse.Namespace) -> int:
+    try:
+        while run_cycle(args):
+            time.sleep(args.poll_seconds)
+    except RuntimeError:
+        return 2
+    return 0
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Close PR_AUTHOR's open PRs that are already landed on master or duplicate an open PR.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--once", action="store_true", help="Run one scan/action cycle and exit. Cron uses this.")
+    mode.add_argument("--loop", action="store_true", help="Poll on an interval.")
+    parser.add_argument("--poll-seconds", type=float, default=300, help="Seconds to wait between loop scans. Default: 300.")
+    parser.add_argument("--dry-run", action="store_true", help="Print planned closes; submit nothing.")
+    parser.add_argument("--repo", default="Neko-Catpital-Labs/Invoker", help="Default: Neko-Catpital-Labs/Invoker.")
+    parser.add_argument("--author", help="Limit scan to one author. Default: all authors.")
+    parser.add_argument("--state-file", default=str(Path.home() / ".invoker" / "pr-duplicate-close-state.jsonl"), help="Ledger JSONL path.")
+    parser.add_argument("--git-cwd", default=str(REPO_ROOT), help="Working directory for local git fact-checks. Default: this repo.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv if argv is not None else sys.argv[1:])
+    return run_loop(args) if args.loop else run_once(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pr_duplicate_close_executor.py
+++ b/scripts/pr_duplicate_close_executor.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+try:
+    from .mergify_admin_requeue_snapshot import GhClient
+    from .mergify_admin_requeue_workflow_fastpath import submit_close_pr
+    from .pr_duplicate_close_model import CLOSE_DUPLICATE, LEDGER_KIND_SUBMIT, CloseAction, ledger_key
+except ImportError:
+    from mergify_admin_requeue_snapshot import GhClient
+    from mergify_admin_requeue_workflow_fastpath import submit_close_pr
+    from pr_duplicate_close_model import CLOSE_DUPLICATE, LEDGER_KIND_SUBMIT, CloseAction, ledger_key
+
+
+class PrDuplicateCloseExecutor:
+    """The only layer allowed to submit a close. Every action is CAS-guarded
+    against the state seen at scan time immediately before submission — see
+    the "Executor" invariants in the plan doc. `submit_close_pr`'s generated
+    task re-checks the same facts again right before the actual `gh pr close`,
+    since a task can sit queued for a while after this submission.
+    """
+
+    def __init__(self, gh: GhClient, ledger, logger, repo: str):
+        self.gh = gh
+        self.ledger = ledger
+        self.logger = logger
+        self.repo = repo
+
+    def _pr_state(self, pr_number: int) -> tuple[str, str]:
+        detail = self.gh.pr_detail(self.repo, pr_number)
+        state = str(detail.get("state") or "")
+        head_oid = str(detail.get("headRefOid") or detail.get("head_ref_oid") or "")
+        return state, head_oid
+
+    def execute(self, action: CloseAction) -> bool:
+        state, head_oid = self._pr_state(action.pr_number)
+        if state != "OPEN" or head_oid != action.expected_head_oid:
+            self.logger.trace(
+                "pr-duplicate-close-stale-head-skip",
+                repo=self.repo,
+                pr_number=action.pr_number,
+                reason=action.reason,
+                expected_head=action.expected_head_oid,
+                current_head=head_oid or None,
+                current_state=state,
+            )
+            return False
+
+        if action.kind == CLOSE_DUPLICATE:
+            kept_state, _ = self._pr_state(action.kept_pr_number) if action.kept_pr_number is not None else ("", "")
+            if kept_state != "OPEN":
+                self.logger.trace(
+                    "pr-duplicate-close-kept-pr-not-open-skip",
+                    repo=self.repo,
+                    pr_number=action.pr_number,
+                    kept_pr_number=action.kept_pr_number,
+                    kept_state=kept_state,
+                )
+                return False
+
+        try:
+            submit_close_pr(
+                pr_number=action.pr_number,
+                repo=self.repo,
+                reason=action.evidence,
+                expected_head_oid=action.expected_head_oid,
+                kept_pr_number=action.kept_pr_number,
+            )
+        except RuntimeError as exc:
+            self.logger.trace(
+                "pr-duplicate-close-submit-failed",
+                repo=self.repo,
+                pr_number=action.pr_number,
+                reason=action.reason,
+                error=str(exc),
+            )
+            return False
+
+        key = ledger_key(action.reason, action.kept_pr_number)
+        self.ledger.record(LEDGER_KIND_SUBMIT, action.pr_number, action.expected_head_oid, key)
+        self.logger.trace(
+            "pr-duplicate-close-submitted",
+            repo=self.repo,
+            pr_number=action.pr_number,
+            reason=action.reason,
+            kept_pr_number=action.kept_pr_number,
+        )
+        return True

--- a/scripts/test_pr_duplicate_close_exec.py
+++ b/scripts/test_pr_duplicate_close_exec.py
@@ -1,0 +1,139 @@
+"""Behavioural tests for pr_duplicate_close_exec's git-fact computation.
+
+Runs real `git` against a throwaway sandbox repo (same convention as
+test_pr_duplicate_close_git_facts.py), because this is exactly the
+distinction that was wrong before: a same-diff duplicate comparison must
+diff each PR against its own base, not always against master. See
+scripts/pr_duplicate_close_exec.py's _compute_patch_id.
+
+Run:  python3 scripts/test_pr_duplicate_close_exec.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from pr_duplicate_close_exec import _compute_patch_id
+from pr_duplicate_close_git_facts import GitFactsClient
+from pr_duplicate_close_model import CandidatePr
+
+
+def run(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, check=True, text=True, capture_output=True,
+    ).stdout.strip()
+
+
+def write_and_commit(repo: Path, filename: str, content: str, message: str) -> str:
+    (repo / filename).write_text(content, encoding="utf-8")
+    run(repo, "add", filename)
+    run(repo, "commit", "-m", message)
+    return run(repo, "rev-parse", "HEAD")
+
+
+def candidate(**kw) -> CandidatePr:
+    base = dict(
+        number=1, title="t", url="u", state="OPEN", is_draft=False,
+        head_ref_name="branch", base_ref_name="master", head_ref_oid="",
+    )
+    base.update(kw)
+    return CandidatePr(**base)
+
+
+class ComputePatchIdTestCase(unittest.TestCase):
+    def setUp(self):
+        self.repo = Path(tempfile.mkdtemp())
+        self.remote = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(self.repo, ignore_errors=True))
+        self.addCleanup(lambda: shutil.rmtree(self.remote, ignore_errors=True))
+        run(self.remote, "init", "-q", "--bare")
+        run(self.repo, "init", "-q", "-b", "master")
+        run(self.repo, "config", "user.email", "test@example.com")
+        run(self.repo, "config", "user.name", "Test")
+        run(self.repo, "remote", "add", "origin", str(self.remote))
+        write_and_commit(self.repo, "base.txt", "base\n", "base commit")
+        run(self.repo, "push", "-q", "origin", "master")
+        self.client = GitFactsClient(cwd=self.repo)
+
+    def push_base(self, branch: str) -> None:
+        run(self.repo, "push", "-q", "origin", branch)
+
+
+class MasterBasedPr(ComputePatchIdTestCase):
+    def test_matches_direct_master_diff(self):
+        run(self.repo, "checkout", "-q", "-b", "feature")
+        head = write_and_commit(self.repo, "change.txt", "content\n", "add change.txt")
+        pr = candidate(base_ref_name="master", head_ref_oid=head)
+
+        got = _compute_patch_id(self.client, pr)
+        want = self.client.patch_id(self.client.merge_base("origin/master", head), head)
+        self.assertEqual(got, want)
+        self.assertIsNotNone(got)
+
+
+class StackedBasePr(ComputePatchIdTestCase):
+    """Reproduces the real #4343-vs-#4277 shape: one PR is based directly on
+    master, the other is based on an unmerged intermediate branch that has
+    its own, unrelated commits. Diffing both against master directly (the
+    pre-fix behavior) makes their patch-ids diverge even though they carry
+    the identical local change; diffing each against its own base (the fix)
+    makes them match."""
+
+    def test_same_local_change_on_different_bases_produces_matching_patch_ids(self):
+        run(self.repo, "checkout", "-q", "-b", "integration")
+        write_and_commit(self.repo, "integration-only.txt", "unrelated\n", "integration: unrelated prior work")
+        self.push_base("integration")
+
+        run(self.repo, "checkout", "-q", "-b", "pr-stacked")
+        stacked_head = write_and_commit(self.repo, "shared.txt", "same-content\n", "pr-stacked: the actual change")
+        stacked_pr = candidate(number=4343, base_ref_name="integration", head_ref_oid=stacked_head)
+
+        run(self.repo, "checkout", "-q", "master")
+        run(self.repo, "checkout", "-q", "-b", "pr-master")
+        master_head = write_and_commit(self.repo, "shared.txt", "same-content\n", "pr-master: the identical change")
+        master_pr = candidate(number=4277, base_ref_name="master", head_ref_oid=master_head)
+
+        stacked_patch_id = _compute_patch_id(self.client, stacked_pr)
+        master_patch_id = _compute_patch_id(self.client, master_pr)
+
+        self.assertIsNotNone(stacked_patch_id)
+        self.assertEqual(stacked_patch_id, master_patch_id)
+
+    def test_diffing_the_stacked_pr_against_master_directly_would_have_diverged(self):
+        # Documents *why* the fix is needed: the old, wrong computation
+        # (always against master) does NOT match, even for the identical
+        # scenario the fix above proves now works correctly.
+        run(self.repo, "checkout", "-q", "-b", "integration")
+        write_and_commit(self.repo, "integration-only.txt", "unrelated\n", "integration: unrelated prior work")
+
+        run(self.repo, "checkout", "-q", "-b", "pr-stacked")
+        stacked_head = write_and_commit(self.repo, "shared.txt", "same-content\n", "pr-stacked: the actual change")
+
+        run(self.repo, "checkout", "-q", "master")
+        run(self.repo, "checkout", "-q", "-b", "pr-master")
+        master_head = write_and_commit(self.repo, "shared.txt", "same-content\n", "pr-master: the identical change")
+
+        old_stacked_patch_id = self.client.patch_id(self.client.merge_base("master", stacked_head), stacked_head)
+        old_master_patch_id = self.client.patch_id(self.client.merge_base("master", master_head), master_head)
+
+        self.assertNotEqual(old_stacked_patch_id, old_master_patch_id)
+
+
+class UnfetchableBase(ComputePatchIdTestCase):
+    def test_degrades_to_none_instead_of_raising(self):
+        run(self.repo, "checkout", "-q", "-b", "feature")
+        head = write_and_commit(self.repo, "change.txt", "content\n", "add change.txt")
+        pr = candidate(base_ref_name="this-branch-does-not-exist", head_ref_oid=head)
+
+        self.assertIsNone(_compute_patch_id(self.client, pr))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_pr_duplicate_close_executor.py
+++ b/scripts/test_pr_duplicate_close_executor.py
@@ -1,0 +1,169 @@
+"""Behavioural tests for ``pr_duplicate_close_executor``.
+
+The executor is the only layer allowed to submit a close, and every action
+is CAS-guarded (re-fetch state/headRefOid immediately before acting) against
+the value the policy layer decided on. These tests fake `GhClient` and the
+Invoker hand-off (`submit_close_pr`) so no real `gh`/`headless_mutation` call
+ever happens.
+
+Run:  python3 scripts/test_pr_duplicate_close_executor.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import mergify_admin_requeue_model as m
+import pr_duplicate_close_executor as ex
+import pr_duplicate_close_model as dm
+
+
+class FakeGh:
+    def __init__(self, states: dict[int, dict]):
+        self.states = states
+        self.calls: list[int] = []
+
+    def pr_detail(self, repo: str, number: int) -> dict:
+        self.calls.append(number)
+        return self.states[number]
+
+
+class FakeLogger:
+    def __init__(self):
+        self.events: list[tuple[str, dict]] = []
+
+    def trace(self, event: str, **fields: object) -> None:
+        self.events.append((event, fields))
+
+
+def landed_action(**kw) -> dm.CloseAction:
+    base = dict(
+        kind=dm.CLOSE_LANDED,
+        pr_number=1,
+        expected_head_oid="h1",
+        reason=dm.LANDED_ANCESTOR,
+        evidence="content already on origin/master",
+    )
+    base.update(kw)
+    return dm.CloseAction(**base)
+
+
+def duplicate_action(**kw) -> dm.CloseAction:
+    base = dict(
+        kind=dm.CLOSE_DUPLICATE,
+        pr_number=5,
+        expected_head_oid="h5",
+        reason=dm.DUPLICATE_SAME_BRANCH,
+        evidence="duplicate of open PR #9",
+        kept_pr_number=9,
+    )
+    base.update(kw)
+    return dm.CloseAction(**base)
+
+
+class ExecutorTestCase(unittest.TestCase):
+    def _ledger(self):
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(d, ignore_errors=True))
+        return m.Ledger(Path(d) / "ledger.jsonl")
+
+
+class CasGuards(ExecutorTestCase):
+    def test_aborts_when_own_head_moved(self):
+        gh = FakeGh({1: {"state": "OPEN", "headRefOid": "h1-moved"}})
+        ledger = self._ledger()
+        logger = FakeLogger()
+        executor = ex.PrDuplicateCloseExecutor(gh, ledger, logger, "owner/repo")
+
+        with patch.object(ex, "submit_close_pr") as submit:
+            performed = executor.execute(landed_action())
+
+        self.assertFalse(performed)
+        submit.assert_not_called()
+        self.assertEqual(ledger.count(dm.LEDGER_KIND_SUBMIT, 1, "h1", dm.ledger_key(dm.LANDED_ANCESTOR, None)), 0)
+        self.assertEqual(logger.events[0][0], "pr-duplicate-close-stale-head-skip")
+
+    def test_aborts_when_own_pr_no_longer_open(self):
+        gh = FakeGh({1: {"state": "CLOSED", "headRefOid": "h1"}})
+        executor = ex.PrDuplicateCloseExecutor(gh, self._ledger(), FakeLogger(), "owner/repo")
+
+        with patch.object(ex, "submit_close_pr") as submit:
+            performed = executor.execute(landed_action())
+
+        self.assertFalse(performed)
+        submit.assert_not_called()
+
+    def test_aborts_duplicate_close_when_kept_pr_no_longer_open(self):
+        gh = FakeGh({
+            5: {"state": "OPEN", "headRefOid": "h5"},
+            9: {"state": "CLOSED", "headRefOid": "h9"},
+        })
+        ledger = self._ledger()
+        logger = FakeLogger()
+        executor = ex.PrDuplicateCloseExecutor(gh, ledger, logger, "owner/repo")
+
+        with patch.object(ex, "submit_close_pr") as submit:
+            performed = executor.execute(duplicate_action())
+
+        self.assertFalse(performed)
+        submit.assert_not_called()
+        self.assertEqual(logger.events[-1][0], "pr-duplicate-close-kept-pr-not-open-skip")
+
+    def test_proceeds_when_own_head_and_kept_pr_both_current(self):
+        gh = FakeGh({
+            5: {"state": "OPEN", "headRefOid": "h5"},
+            9: {"state": "OPEN", "headRefOid": "h9"},
+        })
+        executor = ex.PrDuplicateCloseExecutor(gh, self._ledger(), FakeLogger(), "owner/repo")
+
+        with patch.object(ex, "submit_close_pr") as submit:
+            performed = executor.execute(duplicate_action())
+
+        self.assertTrue(performed)
+        submit.assert_called_once_with(
+            pr_number=5, repo="owner/repo", reason="duplicate of open PR #9",
+            expected_head_oid="h5", kept_pr_number=9,
+        )
+
+
+class SuccessfulHandoff(ExecutorTestCase):
+    def test_records_ledger_on_successful_submission(self):
+        gh = FakeGh({1: {"state": "OPEN", "headRefOid": "h1"}})
+        ledger = self._ledger()
+        executor = ex.PrDuplicateCloseExecutor(gh, ledger, FakeLogger(), "owner/repo")
+
+        with patch.object(ex, "submit_close_pr") as submit:
+            performed = executor.execute(landed_action())
+
+        self.assertTrue(performed)
+        submit.assert_called_once_with(
+            pr_number=1, repo="owner/repo", reason="content already on origin/master",
+            expected_head_oid="h1", kept_pr_number=None,
+        )
+        self.assertEqual(ledger.count(dm.LEDGER_KIND_SUBMIT, 1, "h1", dm.ledger_key(dm.LANDED_ANCESTOR, None)), 1)
+
+    def test_submission_failure_does_not_record_ledger_so_it_can_retry(self):
+        gh = FakeGh({1: {"state": "OPEN", "headRefOid": "h1"}})
+        ledger = self._ledger()
+        logger = FakeLogger()
+        executor = ex.PrDuplicateCloseExecutor(gh, ledger, logger, "owner/repo")
+
+        with patch.object(ex, "submit_close_pr", side_effect=RuntimeError("headless_mutation failed")):
+            performed = executor.execute(landed_action())
+
+        self.assertFalse(performed)
+        self.assertEqual(ledger.count(dm.LEDGER_KIND_SUBMIT, 1, "h1", dm.ledger_key(dm.LANDED_ANCESTOR, None)), 0)
+        event, fields = logger.events[-1]
+        self.assertEqual(event, "pr-duplicate-close-submit-failed")
+        self.assertIn("headless_mutation failed", fields["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR turns the previous slice's classification rules into something
runnable: an executor, a run loop, and the shell entrypoint the cron
scheduler will spawn.

The executor re-checks a PR's own state right before acting on it, since a
plan can sit queued a while before it runs. For a superseded PR, it also
re-checks that the PR replacing it is still open, so a pair never ends up
with nothing open.

Nothing here changes a live PR by itself: every close request goes through
Invoker's existing task-run path, which does its own final check right
before the actual close.

This is also where the previous slice's stable patch id actually gets
computed, one PR at a time. It's diffed against that PR's own starting
point rather than always master, since two PRs can start from different
places and comparing both to the wrong point would hide a real match.

## Review Claim

Approve the executor's compare-then-act guard and the shape of the
generated close request, plus the new CLI entrypoint and its shell wrapper.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Every close request is preceded by re-reading the exact PR (and, for a
paired close, the PR being kept) that the earlier decision depended on, and
is skipped outright if either no longer matches. Branch deletion is never
requested.

## Slice Rationale

This slice depends on both the shared helper additions and the
classification rules from the two prior slices, and is the smallest unit
that can be exercised end to end, which the next slice's proof scripts do.

## Non-goals

This PR does not register anything with the app's worker scheduler, so
nothing runs automatically yet. That is the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 scripts/test_pr_duplicate_close_executor.py`
- [ ] `python3 scripts/test_pr_duplicate_close_exec.py`
- [ ] `bash scripts/cron-pr-duplicate-close.sh` (with `INVOKER_PR_CRON_DRY_RUN=1` against a real repo/token)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
