### PR TITLE
Register pr-duplicate-close as a third scheduled PR-maintenance worker

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts
@@ -14,6 +14,7 @@ const repoRoot = resolveRepoRoot(process.cwd());
 const PR_MAINTENANCE_ENTRYPOINTS = [
   { kind: 'pr-admin-bypass-land', scriptRelativePath: 'scripts/cron-pr-admin-bypass-land.sh' },
   { kind: 'pr-orphan-repair', scriptRelativePath: 'scripts/cron-pr-orphan-repair.sh' },
+  { kind: 'pr-duplicate-close', scriptRelativePath: 'scripts/cron-pr-duplicate-close.sh' },
 ] as const;
 
 describe('PR maintenance entrypoints bootstrap', () => {
@@ -101,6 +102,49 @@ describe('PR maintenance entrypoints bootstrap', () => {
     expect(readFileSync(capturePath, 'utf8')).toBe([
       `cwd=${repoRoot}`,
       'args=<scripts/mergify_admin_requeue.py><--once><--repo><owner/repo><--author><octocat><--dry-run>',
+      '',
+    ].join('\n'));
+  });
+
+  it('duplicate-close entrypoint forwards repo, author, and dry-run controls to Python', () => {
+    writeFileSync(join(stubBin, 'flock'), '#!/usr/bin/env bash\nexit 0\n', { mode: 0o755 });
+    const capturePath = join(stubBin, 'python-args.txt');
+    const pythonStub = join(stubBin, 'python3');
+    writeFileSync(
+      pythonStub,
+      [
+        '#!/usr/bin/env bash',
+        '{',
+        '  printf "cwd=%s\\n" "$PWD"',
+        '  printf "args="',
+        '  printf "<%s>" "$@"',
+        '  printf "\\n"',
+        '} > "$PYTHON_CAPTURE"',
+        'exit 0',
+        '',
+      ].join('\n'),
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync('bash', [resolve(repoRoot, 'scripts/cron-pr-duplicate-close.sh')], {
+      cwd: tmpdir(),
+      encoding: 'utf8',
+      timeout: 20_000,
+      env: {
+        ...process.env,
+        PATH: `${stubBin}:${process.env.PATH ?? ''}`,
+        INVOKER_GITHUB_TARGET_REPO: 'owner/repo',
+        INVOKER_PR_CRON_AUTHOR: 'octocat',
+        INVOKER_PR_CRON_DRY_RUN: '1',
+        INVOKER_PR_CRON_LOCK: lockPath,
+        PYTHON_CAPTURE: capturePath,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(capturePath, 'utf8')).toBe([
+      `cwd=${repoRoot}`,
+      'args=<scripts/pr_duplicate_close.py><--once><--repo><owner/repo><--author><octocat><--dry-run>',
       '',
     ].join('\n'));
   });

--- a/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
@@ -14,8 +14,11 @@ import type { WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store'
 import {
   DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS,
   PR_ADMIN_BYPASS_LAND_WORKER_KIND,
+  PR_DUPLICATE_CLOSE_WORKER_KIND,
+  PR_MAINTENANCE_WORKER_STAGGER_STEP_MS,
   PR_ORPHAN_REPAIR_WORKER_KIND,
   createPrAdminBypassLandWorker,
+  createPrDuplicateCloseWorker,
   createPrOrphanRepairWorker,
   type PrMaintenanceLockProbeOptions,
 } from '../workers/pr-maintenance-workers.js';
@@ -168,6 +171,59 @@ describe('PR maintenance workers', () => {
     }));
   });
 
+  it('spawns the duplicate-close shell entrypoint', async () => {
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness();
+    const worker = createPrDuplicateCloseWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => ({ held: false }),
+      installSignalHandlers: false,
+    });
+
+    await worker.tick();
+
+    expect(spawnHarness.calls[0]).toEqual(expect.objectContaining({
+      command: 'bash',
+      args: [resolve(repoRoot, 'scripts/cron-pr-duplicate-close.sh')],
+      options: expect.objectContaining({ cwd: repoRoot }),
+    }));
+  });
+
+  it('staggers the duplicate-close worker 2/3 of the interval after the other two', async () => {
+    vi.useFakeTimers();
+    expect(PR_MAINTENANCE_WORKER_STAGGER_STEP_MS).toBe(DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS / 3);
+
+    // createWorkerRuntime's beginPolling() sets an interval-cadence timer once
+    // startDelayMs elapses, so the *first* tick lands at startDelayMs +
+    // intervalMs, not at startDelayMs alone (verified against the existing
+    // "polls on the five-minute default interval" case above, where
+    // startDelayMs=0 and the first tick still lands at intervalMs).
+    const repoRoot = makeRepoRoot();
+    const spawnHarness = makeSpawnHarness();
+    const worker = createPrDuplicateCloseWorker({
+      logger: makeLogger(),
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => ({ held: false }),
+      installSignalHandlers: false,
+      startDelayMs: 2 * PR_MAINTENANCE_WORKER_STAGGER_STEP_MS,
+    });
+
+    worker.start();
+    expect(spawnHarness.calls).toEqual([]);
+
+    const firstTickAt = 2 * PR_MAINTENANCE_WORKER_STAGGER_STEP_MS + DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS;
+    await vi.advanceTimersByTimeAsync(firstTickAt - 1);
+    expect(spawnHarness.calls).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(spawnHarness.calls).toHaveLength(1);
+    await worker.stop();
+  });
+
   it('skips cleanly when the shared PR-maintenance lock is already held', async () => {
     const repoRoot = makeRepoRoot();
     const logger = makeLogger();
@@ -187,6 +243,30 @@ describe('PR maintenance workers', () => {
       `[worker:${PR_ORPHAN_REPAIR_WORKER_KIND}] shared PR maintenance lock held; skipping tick`,
       expect.objectContaining({
         worker: PR_ORPHAN_REPAIR_WORKER_KIND,
+        reason: 'test-lock-held',
+      }),
+    );
+  });
+
+  it('skips cleanly when the shared PR-maintenance lock is already held (duplicate-close)', async () => {
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness();
+    const worker = createPrDuplicateCloseWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => ({ held: true, reason: 'test-lock-held' }),
+      installSignalHandlers: false,
+    });
+
+    await worker.tick();
+
+    expect(spawnHarness.calls).toEqual([]);
+    expect(logger.info).toHaveBeenCalledWith(
+      `[worker:${PR_DUPLICATE_CLOSE_WORKER_KIND}] shared PR maintenance lock held; skipping tick`,
+      expect.objectContaining({
+        worker: PR_DUPLICATE_CLOSE_WORKER_KIND,
         reason: 'test-lock-held',
       }),
     );

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -13,6 +13,7 @@ import { createWorkerRegistry } from '../worker-registry.js';
 import { AUTO_APPROVE_WORKER_KIND } from '../workers/auto-approve-worker.js';
 import {
   PR_ADMIN_BYPASS_LAND_WORKER_KIND,
+  PR_DUPLICATE_CLOSE_WORKER_KIND,
   PR_ORPHAN_REPAIR_WORKER_KIND,
 } from '../workers/pr-maintenance-workers.js';
 import { PR_STATUS_WORKER_KIND } from '../workers/pr-status-worker.js';
@@ -76,6 +77,7 @@ describe('worker registry', () => {
       AUTO_APPROVE_WORKER_KIND,
       PR_ADMIN_BYPASS_LAND_WORKER_KIND,
       PR_ORPHAN_REPAIR_WORKER_KIND,
+      PR_DUPLICATE_CLOSE_WORKER_KIND,
       E2E_AUTOFIX_WORKER_KIND,
     ]);
     expect(registry.get(AUTO_FIX_WORKER_KIND)).toBeDefined();
@@ -115,5 +117,7 @@ describe('worker registry', () => {
       .toBe(PR_ADMIN_BYPASS_LAND_WORKER_KIND);
     expect(registry.get(PR_ORPHAN_REPAIR_WORKER_KIND)?.factory(deps()).identity.kind)
       .toBe(PR_ORPHAN_REPAIR_WORKER_KIND);
+    expect(registry.get(PR_DUPLICATE_CLOSE_WORKER_KIND)?.factory(deps()).identity.kind)
+      .toBe(PR_DUPLICATE_CLOSE_WORKER_KIND);
   });
 });

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -14,17 +14,19 @@ import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../wor
 
 export const PR_ADMIN_BYPASS_LAND_WORKER_KIND = 'pr-admin-bypass-land';
 export const PR_ORPHAN_REPAIR_WORKER_KIND = 'pr-orphan-repair';
+export const PR_DUPLICATE_CLOSE_WORKER_KIND = 'pr-duplicate-close';
 export const DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS = 5 * 60_000;
 /**
- * Even spacing between each PR-maintenance worker's first tick, so the 2
+ * Even spacing between each PR-maintenance worker's first tick, so the 3
  * workers sharing the cron lock (scripts/cron-pr-lib.sh) don't all wake on
  * the same intervalMs boundary and race for it every cycle.
  */
-export const PR_MAINTENANCE_WORKER_STAGGER_STEP_MS = DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS / 2;
+export const PR_MAINTENANCE_WORKER_STAGGER_STEP_MS = DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS / 3;
 
 export type PrMaintenanceWorkerKind =
   | typeof PR_ADMIN_BYPASS_LAND_WORKER_KIND
-  | typeof PR_ORPHAN_REPAIR_WORKER_KIND;
+  | typeof PR_ORPHAN_REPAIR_WORKER_KIND
+  | typeof PR_DUPLICATE_CLOSE_WORKER_KIND;
 
 type EnvOverrides = Record<string, string | undefined>;
 
@@ -43,6 +45,11 @@ const PR_ORPHAN_REPAIR_ENTRYPOINT: PrMaintenanceEntrypoint = {
   kind: PR_ORPHAN_REPAIR_WORKER_KIND,
   scriptRelativePath: 'scripts/cron-pr-orphan-repair.sh',
   note: 'Classifies unmapped broken PRs and submits one combined Invoker repair task per PR.',
+};
+const PR_DUPLICATE_CLOSE_ENTRYPOINT: PrMaintenanceEntrypoint = {
+  kind: PR_DUPLICATE_CLOSE_WORKER_KIND,
+  scriptRelativePath: 'scripts/cron-pr-duplicate-close.sh',
+  note: 'Closes open PRs already landed on master or duplicating another open PR, via one Invoker close task per PR.',
 };
 
 export interface PrMaintenanceWorkerConfig {
@@ -106,6 +113,7 @@ export function registerPrMaintenanceWorkers(
 ): WorkerRegistry<WorkerRuntimeDependencies> {
   registerPrAdminBypassLandWorker(registry);
   registerPrOrphanRepairWorker(registry);
+  registerPrDuplicateCloseWorker(registry);
   return registry;
 }
 
@@ -143,12 +151,33 @@ export function registerPrOrphanRepairWorker(
   return registry;
 }
 
+export function registerPrDuplicateCloseWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: PR_DUPLICATE_CLOSE_WORKER_KIND,
+    note: PR_DUPLICATE_CLOSE_ENTRYPOINT.note,
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createPrDuplicateCloseWorker({
+        logger: deps.logger,
+        ...deps.prMaintenance,
+        store: deps.store,
+        startDelayMs: 2 * PR_MAINTENANCE_WORKER_STAGGER_STEP_MS,
+      }),
+  });
+  return registry;
+}
+
 export function createPrAdminBypassLandWorker(options: PrMaintenanceWorkerOptions): WorkerRuntime {
   return createPrMaintenanceWorker(PR_ADMIN_BYPASS_LAND_ENTRYPOINT, options);
 }
 
 export function createPrOrphanRepairWorker(options: PrMaintenanceWorkerOptions): WorkerRuntime {
   return createPrMaintenanceWorker(PR_ORPHAN_REPAIR_ENTRYPOINT, options);
+}
+
+export function createPrDuplicateCloseWorker(options: PrMaintenanceWorkerOptions): WorkerRuntime {
+  return createPrMaintenanceWorker(PR_DUPLICATE_CLOSE_ENTRYPOINT, options);
 }
 
 


### PR DESCRIPTION
## Summary

This PR turns the previous slice's shell entrypoint into a third scheduled
worker, alongside the two existing PR-maintenance workers.

All three share one lock file, so only one runs at a time. Their first-tick
timing is spread apart so they never wake on the same boundary and fight
over that lock. A spacing scheme sized for two workers needed recomputing
for three.

## Review Claim

Approve registering the new worker and the corrected first-tick spacing for
all three workers that now share the lock.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The corrected spacing is covered by a test that starts the new worker with
fake timers and asserts its first tick lands at the expected offset, not
one interval early or late; the existing two workers' own spacing tests are
unchanged and still pass.

## Slice Rationale

This slice only changes how the app schedules and spaces workers, not what
any worker does, so it is reviewable independently of the classification
and executor logic in the two prior slices, which it depends on only for
the shell entrypoint's file path.

## Non-goals

This PR does not change what the two existing workers do, and does not add
end-to-end proof against a real repository. That is the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test -- src/__tests__/pr-maintenance-workers.test.ts src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts src/__tests__/worker-registry.test.ts`
- [ ] `pnpm test` (full execution-engine package)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7014