### PR TITLE
[Admin-Bypass Async Repair](1) Move Method: _run_headless -> mergify_admin_requeue_headless_shell.py

### DIFF
--- a/scripts/mergify_admin_requeue_headless_shell.py
+++ b/scripts/mergify_admin_requeue_headless_shell.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HEADLESS_LIB = REPO_ROOT / "scripts" / "headless-lib.sh"
+
+# Sources scripts/headless-lib.sh directly (never scripts/cron-pr-lib.sh): by the
+# time any caller of this module runs, cron-pr-lib.sh's cron_lock is already held
+# by the calling bash script (scripts/cron-pr-admin-bypass-land.sh), so re-sourcing
+# it and calling cron_lock again would self-deadlock or silently no-op.
+_SOURCE_HEADLESS_LIB = 'set -euo pipefail\nsource "$1"\n'
+
+DEFAULT_TIMEOUT_SECONDS = 30
+
+
+def run_headless(command: str, *extra_args: str, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> subprocess.CompletedProcess[str]:
+    args = ["bash", "-c", _SOURCE_HEADLESS_LIB + command, "bash", str(HEADLESS_LIB), *extra_args]
+    try:
+        return subprocess.run(
+            args,
+            cwd=str(REPO_ROOT),
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired:
+        # A wedged owner-IPC connection (no reachable owner, a hung socket) must
+        # never block a cron tick indefinitely -- surface it as an ordinary
+        # non-zero CompletedProcess so every caller's existing "returncode != 0"
+        # handling raises a clear RuntimeError instead of hanging the process.
+        return subprocess.CompletedProcess(
+            args, returncode=124, stdout="", stderr=f"timed out after {timeout_seconds}s",
+        )

--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -1,27 +1,11 @@
 from __future__ import annotations
 
 import json
-import subprocess
-from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-HEADLESS_LIB = REPO_ROOT / "scripts" / "headless-lib.sh"
-
-# Sources scripts/headless-lib.sh directly (never scripts/cron-pr-lib.sh): by the
-# time this module runs, cron-pr-lib.sh's cron_lock is already held by the
-# calling bash script (scripts/cron-pr-admin-bypass-land.sh), so re-sourcing it
-# and calling cron_lock again would self-deadlock or silently no-op.
-_SOURCE_HEADLESS_LIB = 'set -euo pipefail\nsource "$1"\n'
-
-
-def _run_headless(command: str, *extra_args: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["bash", "-c", _SOURCE_HEADLESS_LIB + command, "bash", str(HEADLESS_LIB), *extra_args],
-        cwd=str(REPO_ROOT),
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+try:
+    from .mergify_admin_requeue_headless_shell import run_headless as _run_headless
+except ImportError:
+    from mergify_admin_requeue_headless_shell import run_headless as _run_headless
 
 
 def resolve_workflow_for_pr(pr_number: int) -> str | None:

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -10,6 +10,7 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import scripts.mergify_admin_requeue as requeue
 import scripts.mergify_admin_requeue_exec as exec_impl
+import scripts.mergify_admin_requeue_headless_shell as headless_shell
 import scripts.mergify_admin_requeue_workflow_fastpath as fastpath
 
 from scripts.mergify_admin_requeue import (
@@ -1117,7 +1118,7 @@ The merge conditions cannot be satisfied due to failing checks
 class WorkflowFastpathTests(unittest.TestCase):
     def test_resolve_workflow_for_pr_sources_headless_lib_and_parses_workflow_id(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout='{"workflowId": "wf-1-1"}\n', stderr="")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed) as run:
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed) as run:
             result = fastpath.resolve_workflow_for_pr(6579)
         self.assertEqual(result, "wf-1-1")
         args = run.call_args.args[0]
@@ -1130,19 +1131,19 @@ class WorkflowFastpathTests(unittest.TestCase):
 
     def test_resolve_workflow_for_pr_returns_none_on_genuine_miss(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}\n", stderr="")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed):
             result = fastpath.resolve_workflow_for_pr(6579)
         self.assertIsNone(result)
 
     def test_resolve_workflow_for_pr_raises_on_lookup_failure(self):
         completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed):
             with self.assertRaises(RuntimeError):
                 fastpath.resolve_workflow_for_pr(6579)
 
     def test_submit_rebase_recreate_command_shape(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed) as run:
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed) as run:
             fastpath.submit_rebase_recreate("wf-1-1")
         args = run.call_args.args[0]
         self.assertEqual(args[0], "bash")
@@ -1154,13 +1155,13 @@ class WorkflowFastpathTests(unittest.TestCase):
 
     def test_submit_rebase_recreate_raises_on_failure(self):
         completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed):
             with self.assertRaises(RuntimeError):
                 fastpath.submit_rebase_recreate("wf-1-1")
 
     def test_submit_repair_review_gate_ci_command_shape(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed) as run:
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed) as run:
             fastpath.submit_repair_review_gate_ci(6579)
         args = run.call_args.args[0]
         self.assertEqual(args[0], "bash")
@@ -1172,7 +1173,7 @@ class WorkflowFastpathTests(unittest.TestCase):
 
     def test_submit_repair_review_gate_ci_raises_on_failure(self):
         completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed):
             with self.assertRaises(RuntimeError):
                 fastpath.submit_repair_review_gate_ci(6579)
 


### PR DESCRIPTION
## Summary

PR repair used to block the cron process on a synchronous `claude -p ...`
subprocess call. Migrating that to async plan submission needs a shared
IPC-shell subprocess helper first, since more than one module will need to
call `headless_mutation` the same way.

This slice moves `workflow_fastpath.py`'s `_run_headless` helper into a new
`mergify_admin_requeue_headless_shell.py` module, and adds a bounded 30s
timeout on the subprocess call so a wedged owner-IPC connection can never
hang a cron tick indefinitely.

## Review Claim

Approve moving `_run_headless` out of `workflow_fastpath.py` into a new
shared module, re-pointing its three call sites in the same commit, with no
behavior change beyond the new timeout.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

`resolve_workflow_for_pr`, `submit_rebase_recreate`, and
`submit_repair_review_gate_ci` call the exact same subprocess logic through
the new module instead of a locally defined helper. The full existing test
suite passes unchanged at this commit, with only mock-target updates
(`fastpath.subprocess` -> `headless_shell.subprocess`).

## Slice Rationale

This is the first of several extraction slices preparing for async plan
submission; a later slice in this stack needs this same shared IPC-shell
helper. Each subsequent slice moves one more cohesive unit out of
`AdminBypassRepairer`, one slice at a time, per this repo's
decomposition-refactor convention.

## Non-goals

No behavior change other than the bounded timeout. Does not touch
`AdminBypassRepairer` or any git/PR-body/prerequisite logic -- those are
later slices in this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
