### PR TITLE
[Admin-Bypass Async Repair](2) Move Method: git working-tree primitives -> repair_body.py

### DIFF
--- a/scripts/mergify_admin_requeue_headless_shell.py
+++ b/scripts/mergify_admin_requeue_headless_shell.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HEADLESS_LIB = REPO_ROOT / "scripts" / "headless-lib.sh"
+
+# Sources scripts/headless-lib.sh directly (never scripts/cron-pr-lib.sh): by the
+# time any caller of this module runs, cron-pr-lib.sh's cron_lock is already held
+# by the calling bash script (scripts/cron-pr-admin-bypass-land.sh), so re-sourcing
+# it and calling cron_lock again would self-deadlock or silently no-op.
+_SOURCE_HEADLESS_LIB = 'set -euo pipefail\nsource "$1"\n'
+
+DEFAULT_TIMEOUT_SECONDS = 30
+
+
+def run_headless(command: str, *extra_args: str, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> subprocess.CompletedProcess[str]:
+    args = ["bash", "-c", _SOURCE_HEADLESS_LIB + command, "bash", str(HEADLESS_LIB), *extra_args]
+    try:
+        return subprocess.run(
+            args,
+            cwd=str(REPO_ROOT),
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired:
+        # A wedged owner-IPC connection (no reachable owner, a hung socket) must
+        # never block a cron tick indefinitely -- surface it as an ordinary
+        # non-zero CompletedProcess so every caller's existing "returncode != 0"
+        # handling raises a clear RuntimeError instead of hanging the process.
+        return subprocess.CompletedProcess(
+            args, returncode=124, stdout="", stderr=f"timed out after {timeout_seconds}s",
+        )

--- a/scripts/mergify_admin_requeue_repair_body.py
+++ b/scripts/mergify_admin_requeue_repair_body.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+try:
+    from .mergify_admin_requeue_snapshot import run_logged
+except ImportError:
+    from mergify_admin_requeue_snapshot import run_logged
+
+
+def git_output(cwd: Path, *args: str) -> str:
+    return run_logged(["git", *args], cwd=cwd)
+
+
+def git_lines(cwd: Path, *args: str) -> tuple[str, ...]:
+    return tuple(line.strip() for line in git_output(cwd, *args).splitlines() if line.strip())
+
+
+def hard_reset_work_root(cwd: Path, target: str) -> None:
+    git_output(cwd, "reset", "--hard", target)
+    git_output(cwd, "clean", "-fd")
+
+
+def is_ancestor(cwd: Path, ancestor: str, descendant: str) -> bool:
+    if not cwd.exists():
+        return True
+    completed = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        cwd=str(cwd),
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    return completed.returncode == 0

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -12,14 +12,16 @@ try:
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from .mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
-    from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head, run_logged
+    from .mergify_admin_requeue_repair_body import git_lines, git_output, hard_reset_work_root, is_ancestor
+    from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
     from .pr_worker_safe_push import SafePushError, safe_push
 except ImportError:
     from mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
-    from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head, run_logged
+    from mergify_admin_requeue_repair_body import git_lines, git_output, hard_reset_work_root, is_ancestor
+    from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
     from pr_worker_safe_push import SafePushError, safe_push
 
 
@@ -60,46 +62,24 @@ class AdminBypassRepairer:
         self.ledger = ledger
         self.repo = repo
 
-    def git_output(self, work_root: Path, *args: str) -> str:
-        return run_logged(["git", *args], cwd=work_root)
-
-    def git_lines(self, work_root: Path, *args: str) -> tuple[str, ...]:
-        return tuple(line.strip() for line in self.git_output(work_root, *args).splitlines() if line.strip())
-
-    def hard_reset_work_root(self, work_root: Path, target: str) -> None:
-        self.git_output(work_root, "reset", "--hard", target)
-        self.git_output(work_root, "clean", "-fd")
-
-    def is_ancestor(self, work_root: Path, ancestor: str, descendant: str) -> bool:
-        if not work_root.exists():
-            return True
-        completed = subprocess.run(
-            ["git", "merge-base", "--is-ancestor", ancestor, descendant],
-            cwd=str(work_root),
-            check=False,
-            text=True,
-            capture_output=True,
-        )
-        return completed.returncode == 0
-
     def normalize_repair_commit(self, work_root: Path, start_head: str, end_head: str, check_name: str) -> str:
-        if self.is_ancestor(work_root, start_head, end_head):
+        if is_ancestor(work_root, start_head, end_head):
             return end_head
-        diff = self.git_output(work_root, "diff", "--binary", start_head, end_head)
-        self.hard_reset_work_root(work_root, start_head)
+        diff = git_output(work_root, "diff", "--binary", start_head, end_head)
+        hard_reset_work_root(work_root, start_head)
         if not diff.strip():
             return start_head
         with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
             handle.write(diff)
             patch_path = Path(handle.name)
         try:
-            self.git_output(work_root, "apply", "--index", str(patch_path))
+            git_output(work_root, "apply", "--index", str(patch_path))
         finally:
             patch_path.unlink(missing_ok=True)
-        if not self.git_lines(work_root, "status", "--porcelain"):
+        if not git_lines(work_root, "status", "--porcelain"):
             return start_head
-        self.git_output(work_root, "commit", "-m", f"Repair {check_name}")
-        return self.git_output(work_root, "rev-parse", "HEAD").strip()
+        git_output(work_root, "commit", "-m", f"Repair {check_name}")
+        return git_output(work_root, "rev-parse", "HEAD").strip()
 
     def validate_local_pr_body(self, work_root: Path, body: str, base_branch: str) -> dict[str, object]:
         with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
@@ -134,9 +114,9 @@ class AdminBypassRepairer:
             body_path.unlink(missing_ok=True)
 
     def validate_pr_body_from_current_diff(self, work_root: Path, body: str, base_branch: str) -> dict[str, object]:
-        self.git_output(work_root, "fetch", "origin", f"+refs/heads/{base_branch}:refs/remotes/origin/{base_branch}")
-        changed_files = self.git_output(work_root, "diff", "--name-only", f"origin/{base_branch}...HEAD")
-        diff_text = self.git_output(work_root, "diff", "--no-ext-diff", f"origin/{base_branch}...HEAD")
+        git_output(work_root, "fetch", "origin", f"+refs/heads/{base_branch}:refs/remotes/origin/{base_branch}")
+        changed_files = git_output(work_root, "diff", "--name-only", f"origin/{base_branch}...HEAD")
+        diff_text = git_output(work_root, "diff", "--no-ext-diff", f"origin/{base_branch}...HEAD")
         with (
             tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as body_handle,
             tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as changed_handle,
@@ -354,7 +334,7 @@ class AdminBypassRepairer:
             start_head=start_head,
             end_head=end_head,
         )
-        self.hard_reset_work_root(work_root, start_head)
+        hard_reset_work_root(work_root, start_head)
         return self.blocked_outcome("noop", check_name, start_head, end_head)
 
     def create_repair_prerequisite(
@@ -369,10 +349,10 @@ class AdminBypassRepairer:
         branch_name = self.prerequisite_branch_name(pr, start_head)
         title = self.prerequisite_title(pr, check_name)
         body = self.prerequisite_body(pr, check_name)
-        self.git_output(work_root, "checkout", "-B", branch_name, f"origin/{TRUNK}")
-        self.git_output(work_root, "reset", "--hard", f"origin/{TRUNK}")
+        git_output(work_root, "checkout", "-B", branch_name, f"origin/{TRUNK}")
+        git_output(work_root, "reset", "--hard", f"origin/{TRUNK}")
         for commit in repair_commits:
-            self.git_output(work_root, "cherry-pick", commit)
+            git_output(work_root, "cherry-pick", commit)
         validation = self.validate_current_pr_body(work_root, body, TRUNK)
         if not validation.get("valid"):
             errors = [str(error) for error in validation.get("errors", [])]
@@ -439,7 +419,7 @@ class AdminBypassRepairer:
         work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
         work_root.parent.mkdir(parents=True, exist_ok=True)
         checkout_pr_head(self.repo, pr, work_root)
-        start_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
+        start_head = git_output(work_root, "rev-parse", "HEAD").strip()
         if queue_only and not details_url:
             return self.blocked_outcome(
                 "blocked_invalid",
@@ -507,8 +487,8 @@ class AdminBypassRepairer:
             head_sha=pr.head_ref_oid,
         )
         self.run_claude_repair(work_root, prompt)
-        end_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
-        status_lines = self.git_lines(work_root, "status", "--porcelain")
+        end_head = git_output(work_root, "rev-parse", "HEAD").strip()
+        status_lines = git_lines(work_root, "status", "--porcelain")
         terminal = self.terminal_repair_outcome(pr, check_name, start_head, end_head, work_root)
         if terminal:
             return terminal
@@ -524,7 +504,7 @@ class AdminBypassRepairer:
                 end_head,
             )
         if status_lines:
-            self.hard_reset_work_root(work_root, start_head)
+            hard_reset_work_root(work_root, start_head)
             return self.blocked_outcome(
                 "blocked_dirty",
                 check_name,
@@ -533,7 +513,7 @@ class AdminBypassRepairer:
                 status_lines=status_lines,
             )
         end_head = self.normalize_repair_commit(work_root, start_head, end_head, check_name)
-        repair_commits = self.git_lines(work_root, "rev-list", "--reverse", f"{start_head}..{end_head}")
+        repair_commits = git_lines(work_root, "rev-list", "--reverse", f"{start_head}..{end_head}")
         validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
         if validation.get("valid"):
             try:
@@ -558,8 +538,8 @@ class AdminBypassRepairer:
             try:
                 created = self.create_repair_prerequisite(pr, check_name, start_head, repair_commits, work_root, now)
             finally:
-                self.git_output(work_root, "checkout", "-B", pr.head_ref_name, start_head)
-                self.hard_reset_work_root(work_root, start_head)
+                git_output(work_root, "checkout", "-B", pr.head_ref_name, start_head)
+                hard_reset_work_root(work_root, start_head)
             return self.blocked_outcome(
                 "prereq_created",
                 check_name,
@@ -568,7 +548,7 @@ class AdminBypassRepairer:
                 repair_commits=repair_commits,
                 prereq=created,
             )
-        self.hard_reset_work_root(work_root, start_head)
+        hard_reset_work_root(work_root, start_head)
         return self.invalid_repair_outcome(
             pr,
             check_name,
@@ -584,7 +564,7 @@ class AdminBypassRepairer:
         work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
         work_root.parent.mkdir(parents=True, exist_ok=True)
         checkout_pr_head(self.repo, pr, work_root)
-        start_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
+        start_head = git_output(work_root, "rev-parse", "HEAD").strip()
         prompt = (
             f"This PR has a merge conflict blocking it from merging. Diagnose why, then fix it.\n\n"
             f"If rebasing the head branch onto its base branch (preserving the PR's intended changes) resolves it: "
@@ -608,11 +588,11 @@ class AdminBypassRepairer:
             head_sha=pr.head_ref_oid,
         )
         self.run_claude_repair(work_root, prompt)
-        end_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
-        status_lines = self.git_lines(work_root, "status", "--porcelain")
+        end_head = git_output(work_root, "rev-parse", "HEAD").strip()
+        status_lines = git_lines(work_root, "status", "--porcelain")
         if end_head == start_head or status_lines:
             if status_lines:
-                self.hard_reset_work_root(work_root, start_head)
+                hard_reset_work_root(work_root, start_head)
                 return self.blocked_outcome(
                     "blocked_dirty",
                     check_name,
@@ -638,7 +618,7 @@ class AdminBypassRepairer:
         work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
         work_root.parent.mkdir(parents=True, exist_ok=True)
         checkout_pr_head(self.repo, pr, work_root)
-        start_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
+        start_head = git_output(work_root, "rev-parse", "HEAD").strip()
         prompt = (
             f"Resolve the unresolved review thread {thread_id}. Address the reviewer's feedback with "
             f"real code changes, run the narrow proof for the fix, then commit locally. Do not push. "
@@ -654,11 +634,11 @@ class AdminBypassRepairer:
             head_sha=pr.head_ref_oid,
         )
         self.run_claude_repair(work_root, prompt)
-        end_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
-        status_lines = self.git_lines(work_root, "status", "--porcelain")
+        end_head = git_output(work_root, "rev-parse", "HEAD").strip()
+        status_lines = git_lines(work_root, "status", "--porcelain")
         if end_head == start_head or status_lines:
             if status_lines:
-                self.hard_reset_work_root(work_root, start_head)
+                hard_reset_work_root(work_root, start_head)
                 return self.blocked_outcome(
                     "blocked_dirty",
                     thread_id,

--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -1,27 +1,11 @@
 from __future__ import annotations
 
 import json
-import subprocess
-from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-HEADLESS_LIB = REPO_ROOT / "scripts" / "headless-lib.sh"
-
-# Sources scripts/headless-lib.sh directly (never scripts/cron-pr-lib.sh): by the
-# time this module runs, cron-pr-lib.sh's cron_lock is already held by the
-# calling bash script (scripts/cron-pr-admin-bypass-land.sh), so re-sourcing it
-# and calling cron_lock again would self-deadlock or silently no-op.
-_SOURCE_HEADLESS_LIB = 'set -euo pipefail\nsource "$1"\n'
-
-
-def _run_headless(command: str, *extra_args: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["bash", "-c", _SOURCE_HEADLESS_LIB + command, "bash", str(HEADLESS_LIB), *extra_args],
-        cwd=str(REPO_ROOT),
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+try:
+    from .mergify_admin_requeue_headless_shell import run_headless as _run_headless
+except ImportError:
+    from mergify_admin_requeue_headless_shell import run_headless as _run_headless
 
 
 def resolve_workflow_for_pr(pr_number: int) -> str | None:

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -10,6 +10,7 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import scripts.mergify_admin_requeue as requeue
 import scripts.mergify_admin_requeue_exec as exec_impl
+import scripts.mergify_admin_requeue_headless_shell as headless_shell
 import scripts.mergify_admin_requeue_workflow_fastpath as fastpath
 
 from scripts.mergify_admin_requeue import (
@@ -1117,7 +1118,7 @@ The merge conditions cannot be satisfied due to failing checks
 class WorkflowFastpathTests(unittest.TestCase):
     def test_resolve_workflow_for_pr_sources_headless_lib_and_parses_workflow_id(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout='{"workflowId": "wf-1-1"}\n', stderr="")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed) as run:
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed) as run:
             result = fastpath.resolve_workflow_for_pr(6579)
         self.assertEqual(result, "wf-1-1")
         args = run.call_args.args[0]
@@ -1130,19 +1131,19 @@ class WorkflowFastpathTests(unittest.TestCase):
 
     def test_resolve_workflow_for_pr_returns_none_on_genuine_miss(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}\n", stderr="")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed):
             result = fastpath.resolve_workflow_for_pr(6579)
         self.assertIsNone(result)
 
     def test_resolve_workflow_for_pr_raises_on_lookup_failure(self):
         completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed):
             with self.assertRaises(RuntimeError):
                 fastpath.resolve_workflow_for_pr(6579)
 
     def test_submit_rebase_recreate_command_shape(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed) as run:
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed) as run:
             fastpath.submit_rebase_recreate("wf-1-1")
         args = run.call_args.args[0]
         self.assertEqual(args[0], "bash")
@@ -1154,13 +1155,13 @@ class WorkflowFastpathTests(unittest.TestCase):
 
     def test_submit_rebase_recreate_raises_on_failure(self):
         completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed):
             with self.assertRaises(RuntimeError):
                 fastpath.submit_rebase_recreate("wf-1-1")
 
     def test_submit_repair_review_gate_ci_command_shape(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed) as run:
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed) as run:
             fastpath.submit_repair_review_gate_ci(6579)
         args = run.call_args.args[0]
         self.assertEqual(args[0], "bash")
@@ -1172,7 +1173,7 @@ class WorkflowFastpathTests(unittest.TestCase):
 
     def test_submit_repair_review_gate_ci_raises_on_failure(self):
         completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed):
             with self.assertRaises(RuntimeError):
                 fastpath.submit_repair_review_gate_ci(6579)
 

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -349,8 +349,8 @@ Failing checks
         prompts = []
         repairer = self.repairer(FakeGh(), ledger, "Neko-Catpital-Labs/Invoker")
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch.object(repairer, "git_output", return_value=HEAD):
-                with mock.patch.object(repairer, "git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                     with mock.patch.object(repairer, "run_claude_repair", side_effect=lambda _work_root, prompt: prompts.append(prompt)):
                         for epoch in range(3):
                             repairer.repair_conflict(item, "GitHub reports merge conflict", epoch)
@@ -367,8 +367,8 @@ Failing checks
         new_head = "b" * 40
         rev_parse = iter([HEAD, new_head])
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                with mock.patch.object(repairer, "git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(rev_parse) if args == ("rev-parse", "HEAD") else ""):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                     with mock.patch.object(repairer, "run_claude_repair"):
                         with mock.patch.object(repairer, "push_branch", return_value=new_head) as push_branch:
                             result = repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
@@ -385,8 +385,8 @@ Failing checks
         new_head = "c" * 40
         rev_parse = iter([HEAD, new_head])
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                with mock.patch.object(repairer, "git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(rev_parse) if args == ("rev-parse", "HEAD") else ""):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                     with mock.patch.object(repairer, "run_claude_repair"):
                         with mock.patch.object(repairer, "push_branch", side_effect=SafePushError("stale-head: refs/heads/x is deadbeef; expected " + HEAD)):
                             result = repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
@@ -400,8 +400,8 @@ Failing checks
         repairer = self.repairer(object(), ledger)
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
-                with mock.patch.object(repairer, "git_output", return_value=HEAD):
-                    with mock.patch.object(repairer, "git_lines", return_value=()):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
+                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                         with mock.patch.object(repairer, "run_claude_repair", side_effect=subprocess.CalledProcessError(1, ["claude"])):
                             with self.assertRaises(subprocess.CalledProcessError):
                                 repairer.repair_check(item, "PR Body", 1)
@@ -461,8 +461,8 @@ Failing checks
         git_rev_parse = iter([HEAD, HEAD])
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
-                with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                    with mock.patch.object(repairer, "git_lines", return_value=()):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
+                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                         with mock.patch.object(repairer, "run_claude_repair") as repair:
                             with mock.patch.object(repairer, "validate_current_pr_body", return_value={"valid": True, "errors": []}):
                                 with redirect_stderr(stderr):
@@ -501,8 +501,8 @@ Failing checks
         }
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
-                with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                    with mock.patch.object(repairer, "git_lines", return_value=()):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
+                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                         with mock.patch.object(repairer, "run_claude_repair"):
                             with mock.patch.object(repairer, "validate_current_pr_body", return_value=validation):
                                 result = repairer.repair_check(item, "PR Body")
@@ -535,8 +535,8 @@ Failing checks
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
                 with mock.patch.object(repairer, "job_log_has_evidence", return_value=True):
-                    with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                        with mock.patch.object(repairer, "git_lines", return_value=()):
+                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
+                        with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                             with mock.patch.object(repairer, "run_claude_repair") as repair:
                                 with redirect_stderr(stderr):
                                     result = repairer.repair_check(item, "required-fast / Guardrails")
@@ -564,7 +564,7 @@ Failing checks
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
                 with mock.patch.object(repairer, "job_log_has_evidence", return_value=False):
-                    with mock.patch.object(repairer, "git_output", return_value=HEAD):
+                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
                         with mock.patch.object(repairer, "run_claude_repair") as repair:
                             result = repairer.repair_check(item, "required-fast / Guardrails")
         checkout.assert_called_once()
@@ -577,7 +577,7 @@ Failing checks
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log") as download:
                 with mock.patch.object(repairer, "job_log_is_empty", return_value=True):
-                    with mock.patch.object(repairer, "git_output", return_value=HEAD):
+                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
                         with mock.patch.object(repairer, "validate_current_pr_body", return_value={"valid": True}):
                             with mock.patch.object(repairer, "run_claude_repair") as repair:
                                 result = repairer.repair_check(item, "PR Body")
@@ -750,11 +750,12 @@ Failing checks
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
                 with mock.patch.object(repairer, "run_claude_repair"):
-                    with mock.patch.object(repairer, "git_output", side_effect=fake_git_output):
-                        with mock.patch.object(repairer, "git_lines", side_effect=fake_git_lines):
-                            with mock.patch.object(repairer, "validate_local_pr_body", side_effect=lambda *_args: next(validator_results)):
-                                with mock.patch.object(repairer, "push_branch", return_value="pushed-sha") as push_branch:
-                                    result = repairer.repair_check(item, "PR Body", 123)
+                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=fake_git_output):
+                        with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", side_effect=fake_git_lines):
+                            with mock.patch("scripts.mergify_admin_requeue_repair_body.git_output", side_effect=fake_git_output):
+                                with mock.patch.object(repairer, "validate_local_pr_body", side_effect=lambda *_args: next(validator_results)):
+                                    with mock.patch.object(repairer, "push_branch", return_value="pushed-sha") as push_branch:
+                                        result = repairer.repair_check(item, "PR Body", 123)
 
         self.assertEqual(result.status, "prereq_created")
         push_branch.assert_called_once_with(mock.ANY, "stack/pr-babysit-prereq-5800-c2532d2", expect_missing=True)


### PR DESCRIPTION
## Summary

`AdminBypassRepairer` used four small git working-tree primitives directly
as bound methods: reading git output, splitting it into lines, hard-resetting
the work root, and checking ancestry.

This slice moves those four functions into the new
`mergify_admin_requeue_repair_body.py` module as free functions, and
re-points every existing call site (`self.git_output(...)` etc., used
directly by `repair_check`/`repair_conflict`/`repair_bot_thread`, not just
by later helpers) in this same commit.

## Review Claim

Approve moving `git_output`, `git_lines`, `hard_reset_work_root`, and
`is_ancestor` out of `AdminBypassRepairer` into `repair_body.py`, with every
call site re-pointed in the same commit and no behavior change.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

`repair_check`, `repair_conflict`, and `repair_bot_thread` still check out
unconditionally and still call `run_claude_repair` synchronously -- only
*where* these four helpers live changes, not when or how they're called.
The full existing test suite passes unchanged, with only mock-target
updates (`mock.patch("scripts.mergify_admin_requeue_repairer.git_output",
...)` instead of `mock.patch.object(repairer, "git_output", ...)`).

## Slice Rationale

These four are clustered into one slice rather than four separate PRs
because they're trivial and mutually-referencing (`git_lines` and
`hard_reset_work_root` both call `git_output`); splitting them into four
near-empty PRs would have no independent review value. Later slices in this
stack (PR-body checks, prerequisite-PR creation) depend on these
primitives already living in `repair_body.py`.

## Non-goals

No behavior change. Does not move `normalize_repair_commit` or any
validation/prerequisite logic -- those are later slices.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
