### PR TITLE
[Refactor Atomicity Tooling](1) Add a technique-naming section to skills/review-compression

### DIFF
--- a/skills/review-compression/SKILL.md
+++ b/skills/review-compression/SKILL.md
@@ -275,6 +275,84 @@ implementation at all times, even mid-migration; Beck, *Tidy First?* — a
 move commits no behavior change, so it should not straddle a window where
 the moved thing has two independently-editable homes.
 
+## Naming the Technique
+
+The two sections above are both instances of a single Fowler technique,
+repeated: Decomposition & Extraction is "Move Function"/"Extract Class"
+applied file-by-file; Rehome / Relocation is "Move File"/"Rename" applied
+directory-by-directory. Neither section restates the technique's name because
+each already gives it a full slice-shape treatment. This section covers the
+rest of the catalog and states the naming rule that applies to all of them,
+including the two above.
+
+### Rule: name the technique
+
+Every `refactor`-lane PR title or commit message states which single named
+technique it applies, in the form `<Technique>: <what moved/changed>` — for
+example `Move Method: git primitives -> repair_body.py`, `Extract Variable:
+queue-only guard`, `Replace Conditional with Polymorphism: RepairOutcome
+status dispatch`. The PR body's `## Review Claim` restates the same
+technique by name. A vague claim like "clean up the repair module" is not
+acceptable in a `refactor`-lane PR; name the technique or split further
+until one name covers the whole slice.
+
+This is not decoration: naming the technique is what lets a reviewer bring
+the technique's own well-known safety properties to the review ("Extract
+Variable never changes behavior by construction; I only need to check the
+extracted expression is identical") instead of re-deriving correctness from
+scratch for every diff.
+
+### Technique catalog
+
+Grouped by Fowler/refactoring.guru category. Not exhaustive — pick the
+closest named technique; if none fits, say so explicitly in `## Review
+Claim` rather than picking the nearest wrong name.
+
+- **Composing Methods** — Extract Method, Inline Method, Extract Variable,
+  Inline Variable, Replace Temp with Query, Split Loop, Slide Statements.
+- **Moving Features Between Objects** — Move Method (this repo's
+  Decomposition & Extraction section), Move Field, Move File (this repo's
+  Rehome / Relocation section), Extract Class, Inline Class, Hide
+  Delegate, Remove Middle Man.
+- **Simplifying Conditional Expressions** — Decompose Conditional,
+  Consolidate Conditional Expression, Replace Nested Conditional with Guard
+  Clauses, Replace Conditional with Polymorphism, Introduce Null Object.
+- **Simplifying Method Calls** — Rename Method, Add/Remove Parameter,
+  Separate Query from Modifier, Parameterize Method, Replace Parameter with
+  Explicit Methods, Preserve Whole Object, Replace Error Code with
+  Exception.
+- **Organizing Data** — Replace Magic Number with Symbolic Constant,
+  Encapsulate Field, Replace Type Code with Class/Subclasses, Replace Array
+  with Object, Change Value to Reference (and back).
+- **Dealing with Generalization** — Pull Up/Push Down Method or Field,
+  Extract Interface, Collapse Hierarchy, Form Template Method, Replace
+  Inheritance with Delegation (and back).
+
+### Prohibitions
+
+- Never extract a function or class purely to make it independently
+  testable. If the only justification is "now I can unit test this," the
+  extraction is not earning its own review claim — either the behavior
+  change that actually needs the test coverage justifies the extraction, or
+  it doesn't belong in this slice.
+- Never bundle a structural change with a behavioral one in the same diff.
+  This restates Fowler's "two hats" (already stated per-section above) as a
+  blanket rule across every technique in the catalog, not just Move
+  Function/Move File: if you notice a real bug while renaming a method,
+  finish the rename, land it, then fix the bug as its own `behavior`-lane
+  slice.
+- Verify the affected tests stay green after each step before moving to the
+  next slice in a decomposition or rehome stack. A stack where slice 3
+  breaks slice 1's tests is not a stack of independently-reviewable claims
+  anymore — it's one change artificially spread across three PRs.
+
+Grounding: Fowler, *Refactoring, 2nd ed.* (the six-category catalog this
+section condenses); refactoring.guru/refactoring/techniques (the same
+catalog with runnable before/after examples per technique); citypaul's
+`refactoring` Claude Code skill (the testability and two-hats prohibitions
+above, adapted to this repo's PR-per-slice model instead of a single local
+commit sequence).
+
 ## PR Body Guidance
 
 Do not summarize the patch file-by-file. Compress the human judgment:


### PR DESCRIPTION
## Summary

The review-compression planning guide already covers the two refactor
shapes this repo hits most often, in detail: splitting one file's symbols
into new modules, and relocating an already-cohesive unit to a new path.
Neither of those sections names the wider catalog those two techniques
are drawn from, and nothing states that a refactor-lane PR should name
its technique at all.

This adds a new section that names the catalog and states that rule,
without touching either existing section's content.

## Review Claim

Approve adding a "## Naming the Technique" section to the review-
compression planning guide: a condensed Fowler/refactoring.guru
technique catalog, the rule that refactor-lane PRs name their technique in
the title and Review Claim, and generalized testability/two-hats
prohibitions.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Purely additive: the new section is appended after the existing Rehome /
Relocation section and before PR Body Guidance, and does not edit a single
line of the two existing sections it cross-references. No other skill or
script reads this file's prose programmatically, so there is no runtime
behavior this change could affect.

## Slice Rationale

Split from the enforcement change (the next PR in this stack) because they
have different review claims: this one is "the guide names the
technique," the next is "CI can now catch one specific violation of it."
The two also cannot ship in the same PR under this repo's own file-scope
rules for this Review Lane.

## Non-goals

Does not change the existing Decomposition & Extraction or Rehome /
Relocation sections' content or headings. Does not add any new
enforcement -- that is the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-make-pr-skill.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
