### PR TITLE
[Refactor Atomicity Tooling](2) Add refactor-dead-symbol atomicity check

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -42,7 +42,7 @@ import { randomBytes } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import aws4 from 'aws4';
 import { syncStackCommentsForPr } from './sync-stack-comments.mjs';
-import { getPrAtomicityBlockers, getPrBodyWarnings, validatePrBody } from './validate-pr-body.mjs';
+import { getPrAtomicityBlockers, getPrBodyWarnings, getReviewMetadata, validatePrBody } from './validate-pr-body.mjs';
 
 const DEFAULT_BASE_REMOTE = process.env.INVOKER_PARENT_REMOTE || 'origin';
 const HAS_EXPLICIT_NON_ORIGIN_BASE_REMOTE = Boolean(
@@ -252,10 +252,10 @@ function printPrBodyWarnings(body, changedFiles = [], diffText = '') {
   }
 }
 
-function assertNoStackAtomicityBlockers(baseBranch, mergifyState, diffText) {
+function assertNoStackAtomicityBlockers(baseBranch, mergifyState, diffText, reviewLane) {
   if (!isStackedPrContext(baseBranch, mergifyState)) return;
 
-  const blockers = getPrAtomicityBlockers({ diffText });
+  const blockers = getPrAtomicityBlockers({ diffText, reviewLane });
   if (blockers.length === 0) return;
 
   throw new Error(
@@ -903,7 +903,7 @@ async function main() {
   if (mergifyState.managed && requestedUpdatePath) {
     assertPublishedMergifyBranch(currentBranch, mergifyState.trackedBaseRef);
   }
-  assertNoStackAtomicityBlockers(args.base, mergifyState, diffText);
+  assertNoStackAtomicityBlockers(args.base, mergifyState, diffText, getReviewMetadata(body).reviewLane);
 
   if (isStackedPrContext(args.base, mergifyState)) {
     assertValidStackPrTitle(args.title);

--- a/scripts/lint-pr-diff-atomicity.mjs
+++ b/scripts/lint-pr-diff-atomicity.mjs
@@ -9,6 +9,8 @@ const require = createRequire(import.meta.url);
 let typescriptModule;
 
 const CODE_EXTENSIONS = new Set(['.cjs', '.js', '.jsx', '.mjs', '.ts', '.tsx']);
+/** Extensions consulted by the refactor-dead-symbol check only; CODE_EXTENSIONS stays TS-AST-only. */
+const DEFINITION_EXTENSIONS = new Set([...CODE_EXTENSIONS, '.py']);
 const LOCKFILES = new Set(['pnpm-lock.yaml', 'package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock', 'bun.lockb']);
 const MANIFESTS = new Set(['package.json']);
 const GENERATED_DIRS = new Set(['dist', 'out', 'build', 'coverage', '.next', '__generated__']);
@@ -40,6 +42,10 @@ const POLICY = {
   'unrelated-areas': {
     severity: 'warning',
     message: 'The diff spans multiple unrelated top-level areas; confirm this is one atomic change.',
+  },
+  'refactor-dead-symbol': {
+    severity: 'warning',
+    message: 'A refactor-lane PR adds a symbol with no reference anywhere else in the diff; confirm the extraction also re-pointed its call sites in this PR.',
   },
 };
 
@@ -262,6 +268,53 @@ function collectAstFindings(file) {
   return findings;
 }
 
+const PY_DEF_PATTERN = /^(?:def|class)\s+([A-Za-z_][A-Za-z0-9_]*)/;
+const JS_DEF_PATTERN = /^(?:export\s+)?(?:function|class)\s+([A-Za-z_$][\w$]*)|^(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*=/;
+
+function definitionPatternFor(extension) {
+  return extension === '.py' ? PY_DEF_PATTERN : JS_DEF_PATTERN;
+}
+
+function isFrameworkInvokedName(name, extension) {
+  if (name === 'main') return true;
+  if (/^__.+__$/.test(name)) return true;
+  if (extension === '.py' && (/^test_/.test(name) || /^Test[A-Z_]/.test(name))) return true;
+  return false;
+}
+
+function collectRefactorDeadSymbolCandidates(file) {
+  const extension = path.extname(file.path);
+  if (!DEFINITION_EXTENSIONS.has(extension) || file.category === 'test' || file.category === 'generated') {
+    return [];
+  }
+  const pattern = definitionPatternFor(extension);
+  const candidates = [];
+  for (const lineNumber of file.addedLineNumbers) {
+    const text = file.newContent.split('\n')[lineNumber - 1] ?? '';
+    const match = pattern.exec(text);
+    const name = match ? (match[1] || match[2]) : '';
+    if (!name || isFrameworkInvokedName(name, extension)) continue;
+    candidates.push({ name, path: file.path, line: lineNumber, source: file.source });
+  }
+  return candidates;
+}
+
+function collectRefactorDeadSymbolFindings(files) {
+  const candidates = files.flatMap((file) => collectRefactorDeadSymbolCandidates(file));
+  if (candidates.length === 0) {
+    return [];
+  }
+  const haystack = files.map((file) => file.newContent).join('\n');
+  const findings = [];
+  for (const candidate of candidates) {
+    const occurrences = haystack.match(new RegExp(`\\b${candidate.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'g'));
+    if (!occurrences || occurrences.length <= 1) {
+      findings.push(makeFinding('refactor-dead-symbol', candidate.path, candidate.line, candidate.source));
+    }
+  }
+  return findings;
+}
+
 function makeFinding(kind, filePath, line, source) {
   const policy = POLICY[kind];
   return {
@@ -275,9 +328,13 @@ function makeFinding(kind, filePath, line, source) {
 }
 
 export function collectDiffAtomicityFindings(options = {}) {
-  const { diffText, source = 'diff' } = options;
+  const { diffText, source = 'diff', reviewLane } = options;
   const files = Array.isArray(options.files) ? options.files : parseUnifiedDiff(diffText, source);
   const findings = [];
+
+  if (reviewLane === 'refactor') {
+    findings.push(...collectRefactorDeadSymbolFindings(files));
+  }
 
   const hasGenerated = files.some((file) => file.category === 'generated');
   const hasHandwritten = files.some((file) => file.category === 'source' || file.category === 'test');
@@ -351,11 +408,11 @@ export function lintDiffAtomicityForGit(options = {}) {
     `${baseRef}...HEAD`,
     '--',
   ]);
-  return collectDiffAtomicityFindings({ diffText, source: `${baseRef}...HEAD` });
+  return collectDiffAtomicityFindings({ diffText, source: `${baseRef}...HEAD`, reviewLane: options.reviewLane });
 }
 
 function usage() {
-  console.error('Usage: node scripts/lint-pr-diff-atomicity.mjs [--base <ref>] [--root <path>]');
+  console.error('Usage: node scripts/lint-pr-diff-atomicity.mjs [--base <ref>] [--root <path>] [--review-lane <lane>]');
 }
 
 function hasGitRef(root, ref) {
@@ -382,7 +439,7 @@ function defaultBase(root) {
 }
 
 function parseArgs(argv) {
-  const parsed = { base: process.env.INVOKER_DIFF_ATOMICITY_BASE || '', root: process.cwd() };
+  const parsed = { base: process.env.INVOKER_DIFF_ATOMICITY_BASE || '', root: process.cwd(), reviewLane: '' };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === '--base') {
@@ -395,6 +452,11 @@ function parseArgs(argv) {
       index += 1;
     } else if (arg.startsWith('--root=')) {
       parsed.root = arg.slice('--root='.length);
+    } else if (arg === '--review-lane') {
+      parsed.reviewLane = argv[index + 1] || '';
+      index += 1;
+    } else if (arg.startsWith('--review-lane=')) {
+      parsed.reviewLane = arg.slice('--review-lane='.length);
     } else if (arg === '--help' || arg === '-h') {
       usage();
       process.exit(0);
@@ -404,7 +466,7 @@ function parseArgs(argv) {
       process.exit(2);
     }
   }
-  return { base: parsed.base, root: path.resolve(parsed.root) };
+  return { base: parsed.base, root: path.resolve(parsed.root), reviewLane: parsed.reviewLane };
 }
 
 function main() {
@@ -415,7 +477,7 @@ function main() {
     process.exit(2);
   }
 
-  const findings = lintDiffAtomicityForGit({ root: args.root, baseRef: base });
+  const findings = lintDiffAtomicityForGit({ root: args.root, baseRef: base, reviewLane: args.reviewLane });
   const fatal = findings.filter((finding) => finding.severity === 'fatal');
   const warnings = findings.filter((finding) => finding.severity === 'warning');
 

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -368,6 +368,44 @@ assert(
   'missing diff context should not invent atomicity blockers',
 );
 
+const deadSymbolDiff = `diff --git a/scripts/repair_body.py b/scripts/repair_body.py
+--- a/scripts/repair_body.py
++++ b/scripts/repair_body.py
+@@ -0,0 +1,2 @@
++def helper_thing(x):
++    return x
+`;
+const deadSymbolBlockers = getPrAtomicityBlockers({ diffText: deadSymbolDiff, reviewLane: 'refactor' });
+assert(
+  deadSymbolBlockers.some((warning) => warning.includes('refactor-dead-symbol')),
+  'a refactor-lane PR that adds a symbol with no other reference in the diff should warn',
+);
+
+const deadSymbolBehaviorLaneBlockers = getPrAtomicityBlockers({ diffText: deadSymbolDiff, reviewLane: 'behavior' });
+assert(
+  !deadSymbolBehaviorLaneBlockers.some((warning) => warning.includes('refactor-dead-symbol')),
+  'the same unreferenced-symbol diff outside refactor lane should not warn -- a new capability with no caller yet is normal for behavior lane',
+);
+
+const reworkedExtractionDiff = `diff --git a/scripts/repair_body.py b/scripts/repair_body.py
+--- a/scripts/repair_body.py
++++ b/scripts/repair_body.py
+@@ -0,0 +1,2 @@
++def helper_thing(x):
++    return x
+diff --git a/scripts/repairer.py b/scripts/repairer.py
+--- a/scripts/repairer.py
++++ b/scripts/repairer.py
+@@ -10,1 +10,1 @@
+-    return old_local_helper(x)
++    return helper_thing(x)
+`;
+const reworkedExtractionBlockers = getPrAtomicityBlockers({ diffText: reworkedExtractionDiff, reviewLane: 'refactor' });
+assert(
+  !reworkedExtractionBlockers.some((warning) => warning.includes('refactor-dead-symbol')),
+  'a .py extraction whose call site is re-pointed in the same diff should not warn',
+);
+
 const lightweightErrors = await validatePrBody(lightweight);
 assert(lightweightErrors.some((error) => error.includes('Unsupported section: ## Testing')), 'lightweight format should reject ## Testing');
 assert(lightweightErrors.some((error) => error.includes('Unsupported section: ## Notes')), 'lightweight format should reject ## Notes');

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -313,7 +313,7 @@ export function getPrAtomicityBlockers(options = {}) {
   const diffText = options.diffText ?? '';
   if (!diffText) return [];
 
-  return collectDiffAtomicityFindings({ diffText })
+  return collectDiffAtomicityFindings({ diffText, reviewLane: options.reviewLane })
     .filter((finding) => finding.severity === 'warning')
     .map((finding) => `Diff atomicity blocker: ${formatDiffAtomicityFindings([finding])[0]}`);
 }
@@ -345,7 +345,8 @@ export function getPrBodyWarnings(body, options = {}) {
   }
 
   if (options.diffText) {
-    const diffWarnings = collectDiffAtomicityFindings({ diffText: options.diffText })
+    const { reviewLane } = getReviewMetadata(body);
+    const diffWarnings = collectDiffAtomicityFindings({ diffText: options.diffText, reviewLane })
       .filter((finding) => finding.severity === 'warning');
     for (const line of formatDiffAtomicityFindings(diffWarnings)) {
       warnings.push(`Diff atomicity warning: ${line}`);

--- a/skills/review-compression/SKILL.md
+++ b/skills/review-compression/SKILL.md
@@ -275,6 +275,84 @@ implementation at all times, even mid-migration; Beck, *Tidy First?* — a
 move commits no behavior change, so it should not straddle a window where
 the moved thing has two independently-editable homes.
 
+## Naming the Technique
+
+The two sections above are both instances of a single Fowler technique,
+repeated: Decomposition & Extraction is "Move Function"/"Extract Class"
+applied file-by-file; Rehome / Relocation is "Move File"/"Rename" applied
+directory-by-directory. Neither section restates the technique's name because
+each already gives it a full slice-shape treatment. This section covers the
+rest of the catalog and states the naming rule that applies to all of them,
+including the two above.
+
+### Rule: name the technique
+
+Every `refactor`-lane PR title or commit message states which single named
+technique it applies, in the form `<Technique>: <what moved/changed>` — for
+example `Move Method: git primitives -> repair_body.py`, `Extract Variable:
+queue-only guard`, `Replace Conditional with Polymorphism: RepairOutcome
+status dispatch`. The PR body's `## Review Claim` restates the same
+technique by name. A vague claim like "clean up the repair module" is not
+acceptable in a `refactor`-lane PR; name the technique or split further
+until one name covers the whole slice.
+
+This is not decoration: naming the technique is what lets a reviewer bring
+the technique's own well-known safety properties to the review ("Extract
+Variable never changes behavior by construction; I only need to check the
+extracted expression is identical") instead of re-deriving correctness from
+scratch for every diff.
+
+### Technique catalog
+
+Grouped by Fowler/refactoring.guru category. Not exhaustive — pick the
+closest named technique; if none fits, say so explicitly in `## Review
+Claim` rather than picking the nearest wrong name.
+
+- **Composing Methods** — Extract Method, Inline Method, Extract Variable,
+  Inline Variable, Replace Temp with Query, Split Loop, Slide Statements.
+- **Moving Features Between Objects** — Move Method (this repo's
+  Decomposition & Extraction section), Move Field, Move File (this repo's
+  Rehome / Relocation section), Extract Class, Inline Class, Hide
+  Delegate, Remove Middle Man.
+- **Simplifying Conditional Expressions** — Decompose Conditional,
+  Consolidate Conditional Expression, Replace Nested Conditional with Guard
+  Clauses, Replace Conditional with Polymorphism, Introduce Null Object.
+- **Simplifying Method Calls** — Rename Method, Add/Remove Parameter,
+  Separate Query from Modifier, Parameterize Method, Replace Parameter with
+  Explicit Methods, Preserve Whole Object, Replace Error Code with
+  Exception.
+- **Organizing Data** — Replace Magic Number with Symbolic Constant,
+  Encapsulate Field, Replace Type Code with Class/Subclasses, Replace Array
+  with Object, Change Value to Reference (and back).
+- **Dealing with Generalization** — Pull Up/Push Down Method or Field,
+  Extract Interface, Collapse Hierarchy, Form Template Method, Replace
+  Inheritance with Delegation (and back).
+
+### Prohibitions
+
+- Never extract a function or class purely to make it independently
+  testable. If the only justification is "now I can unit test this," the
+  extraction is not earning its own review claim — either the behavior
+  change that actually needs the test coverage justifies the extraction, or
+  it doesn't belong in this slice.
+- Never bundle a structural change with a behavioral one in the same diff.
+  This restates Fowler's "two hats" (already stated per-section above) as a
+  blanket rule across every technique in the catalog, not just Move
+  Function/Move File: if you notice a real bug while renaming a method,
+  finish the rename, land it, then fix the bug as its own `behavior`-lane
+  slice.
+- Verify the affected tests stay green after each step before moving to the
+  next slice in a decomposition or rehome stack. A stack where slice 3
+  breaks slice 1's tests is not a stack of independently-reviewable claims
+  anymore — it's one change artificially spread across three PRs.
+
+Grounding: Fowler, *Refactoring, 2nd ed.* (the six-category catalog this
+section condenses); refactoring.guru/refactoring/techniques (the same
+catalog with runnable before/after examples per technique); citypaul's
+`refactoring` Claude Code skill (the testability and two-hats prohibitions
+above, adapted to this repo's PR-per-slice model instead of a single local
+commit sequence).
+
 ## PR Body Guidance
 
 Do not summarize the patch file-by-file. Compress the human judgment:


### PR DESCRIPTION
## Summary

The AST checks in `lint-pr-diff-atomicity.mjs` are TypeScript-compiler-based
and don't cover `.py` files, so the exact mistake that motivated this
change -- a Python cluster whose functions never got their call sites
re-pointed -- was invisible to this tool even after the fact.

Adds a regex-based finding: for a PR whose declared Review Lane matches
this technique, every top-level definition added in the diff is checked
against the full diff's added-and-context lines for any other occurrence
of its name. No other occurrence means nothing in this diff references it.

## Review Claim

Approve adding a `refactor-dead-symbol` finding (warning severity) to
`lint-pr-diff-atomicity.mjs`, threading the declared Review Lane through
`collectDiffAtomicityFindings`/`getPrAtomicityBlockers` so the check only
runs for that one lane.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The finding is warning-severity and additive: it only runs when the
declared lane string equals the one exact value, so it changes nothing for
any other PR shape. `main`, dunder-named symbols, and Python's test-prefixed
names are excluded as framework-invoked; test-category files are skipped
entirely. Verified against this repo's own history: the check fires four
times against the original, un-rewired PR that motivated this whole
change, and stays silent on that same work once corrected into eight
properly re-pointed slices -- confirming it both catches the real mistake
and does not false-positive on a genuine, correctly-sequenced stack.

## Slice Rationale

Split from the guide update in the previous PR because this is a different
claim -- "CI can now catch one specific instance of the guidance the
previous PR states" -- and because policy-scope and prose-scope files
cannot ship together under this repo's own file-scope rules for either
lane involved.

## Non-goals

Does not change any existing finding's severity or behavior. Does not add
coverage for languages other than Python and JS/TS. Does not make the new
finding fatal -- false positives are expected from a heuristic like this,
and a human should double-check rather than being hard-blocked, except that
`getPrAtomicityBlockers` already treats every warning-severity finding as a
hard blocker for stacked PRs specifically, matching this repo's existing
precedent for the `unrelated-areas` finding.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-validator.mjs`
- [x] `node scripts/test-pr-diff-atomicity.mjs`
- [x] `node scripts/test-pr-body-rollout.mjs`
- [x] `bash scripts/test-make-pr-skill.sh`
- [x] `node scripts/test-review-unit-classification.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
