### PR TITLE
[EMBARGO] [Slack bug-scan package](1) Add layering rules for the new @invoker/slack-bug-scan package

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -120,14 +120,14 @@ module.exports = {
     {
       name: 'layer-0-no-deps',
       comment:
-        'Layer 0 packages (contracts, workflow-graph, transport, runtime-domain, runtime-service, shell, ui) should not depend on other workspace packages.',
+        'Layer 0 packages (contracts, workflow-graph, transport, runtime-domain, runtime-service, shell, ui, slack-bug-scan) should not depend on other workspace packages.',
       severity: 'error',
       from: {
-        path: '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+        path: '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|slack-bug-scan)/',
       },
       to: {
         path: '^packages/',
-        pathNot: '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+        pathNot: '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|slack-bug-scan)/',
       },
     },
     {
@@ -142,7 +142,7 @@ module.exports = {
         path: '^packages/',
         pathNot: [
           '^packages/(workflow-core|protocol|runtime-adapters|graph)/',
-          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|slack-bug-scan)/',
         ],
       },
     },
@@ -159,7 +159,7 @@ module.exports = {
         pathNot: [
           '^packages/(data-store|persistence|core)/',
           '^packages/(workflow-core|protocol|runtime-adapters|graph)/',
-          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|slack-bug-scan)/',
         ],
       },
     },
@@ -177,7 +177,7 @@ module.exports = {
           '^packages/(execution-engine|surfaces|planning-core)/',
           '^packages/(data-store|persistence|core)/',
           '^packages/(workflow-core|protocol|runtime-adapters|graph)/',
-          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|slack-bug-scan)/',
         ],
       },
     },
@@ -196,7 +196,7 @@ module.exports = {
           '^packages/(execution-engine|surfaces|planning-core)/',
           '^packages/(data-store|persistence|core)/',
           '^packages/(workflow-core|protocol|runtime-adapters|graph)/',
-          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|slack-bug-scan)/',
         ],
       },
     },

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -288,6 +288,10 @@ import {
   submitPlanningChatDraft,
 } from './in-app-planner.js';
 import { discoverOwner, isStandaloneCapable } from './owner-endpoint.js';
+import type { PlanningCommandBuilder } from '@invoker/surfaces';
+import { createRealSlackBugScanClient } from './slack-bug-scan-client.js';
+import { createSlackBugScanClassifier } from './slack-bug-scan-classifier.js';
+import { createSlackBugScanPlanner } from './slack-bug-scan-planner.js';
 import {
   killRunningTaskExecution,
   rebuildTaskRunner as rebuildTaskRunnerWiring,
@@ -322,9 +326,36 @@ function submitRegisteredOwnerWorkerMutation(
 const autoFixAttemptLedger = createAutoFixAttemptLedger();
 
 
+function buildSlackBugScanWorkerConfig(
+  planningCommandBuilder: PlanningCommandBuilder,
+  executionAgentRegistry: AgentRegistry,
+): WorkerRuntimeDependencies['slackBugScan'] {
+  if (!invokerConfig.slackBugScan?.enabled) return undefined;
+  const client = createRealSlackBugScanClient();
+  if (!client) return undefined;
+  return {
+    client,
+    classify: createSlackBugScanClassifier(),
+    draftAndSubmitPlan: createSlackBugScanPlanner({
+      config: invokerConfig,
+      repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
+      persistence,
+      orchestrator,
+      planningCommandBuilder,
+      executionAgentRegistry,
+      logger,
+    }),
+    intervalMs: invokerConfig.slackBugScan.intervalMs,
+    maxAutoSubmissionsPerDay: invokerConfig.slackBugScan.maxAutoSubmissionsPerDay,
+    maxAutoSubmissionsPerTick: invokerConfig.slackBugScan.maxAutoSubmissionsPerTick,
+  };
+}
+
 function buildRegisteredOwnerWorkerDeps(
   store: WorkerRuntimeDependencies['store'],
   checkMergeGateStatuses: NonNullable<WorkerRuntimeDependencies['reviewGate']>['checkMergeGateStatuses'],
+  planningCommandBuilder: PlanningCommandBuilder,
+  executionAgentRegistry: AgentRegistry,
 ): WorkerRuntimeDependencies {
   const remoteTargets = Object.entries(invokerConfig.remoteTargets ?? {}).map(([name, target]) => ({
     name,
@@ -385,6 +416,7 @@ function buildRegisteredOwnerWorkerDeps(
     autoApprove: {
       enabled: resolveAutoApproveAIFixes(invokerConfig),
     },
+    slackBugScan: buildSlackBugScanWorkerConfig(planningCommandBuilder, executionAgentRegistry),
   };
 }
 function createRegisteredWorkerRegistry(): WorkerRegistry<WorkerRuntimeDependencies> {
@@ -1857,6 +1889,8 @@ function startHeadlessMode(): void {
             async () => {
               await createStandaloneTaskExecutor().checkMergeGateStatuses();
             },
+            planningCommandBuilder,
+            agentRegistry,
           ),
           autoStartKinds: invokerConfig.e2eAutoFixEnabled
             ? [...autoStartedOwnerWorkerKindsForConfig(invokerConfig), E2E_AUTOFIX_WORKER_KIND]
@@ -2976,6 +3010,8 @@ startMainProcessBootstrap({
           async () => {
             await requireTaskExecutor().checkMergeGateStatuses();
           },
+          planningCommandBuilder,
+          agentRegistry,
         ),
         autoStartKinds: invokerConfig.e2eAutoFixEnabled
           ? [...autoStartedOwnerWorkerKindsForConfig(invokerConfig), E2E_AUTOFIX_WORKER_KIND]

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -22,6 +22,7 @@ import {
   PR_ORPHAN_REPAIR_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
   REQUEUE_WORKER_KIND,
+  SLACK_BUG_SCAN_WORKER_KIND,
   WORKFLOW_RESUME_WORKER_KIND,
   type WorkerRegistry,
   type WorkerRuntime,
@@ -43,23 +44,35 @@ export const PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS = [
   PR_ADMIN_BYPASS_LAND_WORKER_KIND,
 ] as const;
 
+export const SLACK_BUG_SCAN_AUTO_STARTED_WORKER_KINDS = [
+  SLACK_BUG_SCAN_WORKER_KIND,
+] as const;
+
 /**
  * Compute the owner worker kinds that auto-start on boot. The PR-maintenance
- * worker is gated on `prMaintenance.enabled` (matching the config docstring);
- * everything else always auto-starts. Saved per-worker desired state still
- * overrides in both directions.
+ * and Slack bug-scan workers are gated on their own `enabled` flags (matching
+ * their config docstrings); everything else always auto-starts. Saved
+ * per-worker desired state still overrides in both directions.
  */
-export function autoStartedOwnerWorkerKinds(options: { prMaintenanceEnabled: boolean }): readonly string[] {
-  return options.prMaintenanceEnabled
-    ? [...ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS, ...PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS]
-    : ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS;
+export function autoStartedOwnerWorkerKinds(options: {
+  prMaintenanceEnabled: boolean;
+  slackBugScanEnabled: boolean;
+}): readonly string[] {
+  return [
+    ...ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS,
+    ...(options.prMaintenanceEnabled ? PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS : []),
+    ...(options.slackBugScanEnabled ? SLACK_BUG_SCAN_AUTO_STARTED_WORKER_KINDS : []),
+  ];
 }
 
 /** Convenience wrapper: derive the auto-start list straight from Invoker config. */
 export function autoStartedOwnerWorkerKindsForConfig(
-  config?: { prMaintenance?: { enabled?: boolean } },
+  config?: { prMaintenance?: { enabled?: boolean }; slackBugScan?: { enabled?: boolean } },
 ): readonly string[] {
-  return autoStartedOwnerWorkerKinds({ prMaintenanceEnabled: Boolean(config?.prMaintenance?.enabled) });
+  return autoStartedOwnerWorkerKinds({
+    prMaintenanceEnabled: Boolean(config?.prMaintenance?.enabled),
+    slackBugScanEnabled: Boolean(config?.slackBugScan?.enabled),
+  });
 }
 
 export interface WorkerRuntimeController {
@@ -196,6 +209,7 @@ const BUILT_IN_WORKER_KINDS = new Set<string>([
   PR_ADMIN_BYPASS_LAND_WORKER_KIND,
   PR_ORPHAN_REPAIR_WORKER_KIND,
   WORKFLOW_RESUME_WORKER_KIND,
+  SLACK_BUG_SCAN_WORKER_KIND,
 ]);
 
 export function createWorkerRuntimeController(options: {


### PR DESCRIPTION
## Summary

Registers a new `@invoker/slack-bug-scan` package as a Layer 0 package (no workspace dependencies) in this repo's dependency-layering config.

Nothing imports it yet. The next PR in this stack adds the package and its callers.

## Review Claim

Approve that the new package belongs in the zero-workspace-dependency layering tier, alongside the small handful of other packages that any other layer can depend on.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Pure config addition. Nothing in the running app imports the package this rule describes yet, so this changes no runtime behavior by itself.

## Slice Rationale

The layering rule is reviewable on its own, before the package it describes exists -- keeping the next PR's file reorganization free of unrelated policy-file changes.

## Non-goals

Does not create the package. Does not change any other package's layer.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:deps` -- 0 errors, 79 pre-existing warnings (unchanged)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None
- Data migration? No

</details>
