### PR TITLE
[EMBARGO] [Slack bug-scan package](2) Reorganize the Slack bug-scan worker into its own package

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -120,14 +120,14 @@ module.exports = {
     {
       name: 'layer-0-no-deps',
       comment:
-        'Layer 0 packages (contracts, workflow-graph, transport, runtime-domain, runtime-service, shell, ui) should not depend on other workspace packages.',
+        'Layer 0 packages (contracts, workflow-graph, transport, runtime-domain, runtime-service, shell, ui, slack-bug-scan) should not depend on other workspace packages.',
       severity: 'error',
       from: {
-        path: '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+        path: '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|slack-bug-scan)/',
       },
       to: {
         path: '^packages/',
-        pathNot: '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+        pathNot: '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|slack-bug-scan)/',
       },
     },
     {
@@ -142,7 +142,7 @@ module.exports = {
         path: '^packages/',
         pathNot: [
           '^packages/(workflow-core|protocol|runtime-adapters|graph)/',
-          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|slack-bug-scan)/',
         ],
       },
     },
@@ -159,7 +159,7 @@ module.exports = {
         pathNot: [
           '^packages/(data-store|persistence|core)/',
           '^packages/(workflow-core|protocol|runtime-adapters|graph)/',
-          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|slack-bug-scan)/',
         ],
       },
     },
@@ -177,7 +177,7 @@ module.exports = {
           '^packages/(execution-engine|surfaces|planning-core)/',
           '^packages/(data-store|persistence|core)/',
           '^packages/(workflow-core|protocol|runtime-adapters|graph)/',
-          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|slack-bug-scan)/',
         ],
       },
     },
@@ -196,7 +196,7 @@ module.exports = {
           '^packages/(execution-engine|surfaces|planning-core)/',
           '^packages/(data-store|persistence|core)/',
           '^packages/(workflow-core|protocol|runtime-adapters|graph)/',
-          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|slack-bug-scan)/',
         ],
       },
     },


### PR DESCRIPTION
## Summary

Places the self-contained parts of the Slack bug-report feature into the new dedicated package added in the previous PR: the client/classifier/plan-submitter shapes, the fingerprint/prefilter/repo-url logic, the tuning env resolvers, and the concrete Slack and Anthropic pieces.

The worker's tick-loop wrapper and the app's plan drafter stay where they are, since both genuinely depend on their own layer's internals.

They now pull the relocated pieces from the dedicated package instead of local files.

Every relocated file keeps its prior content, aside from four small shape definitions that now sit alongside the client-facing surface they describe.

## Review Claim

Approve that each piece landed in the right place -- the new package for anything self-contained, the old locations for anything that genuinely needs its layer's internals -- and that nothing's behavior is any different from before.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

no behavior change -- every moved file keeps its prior logic; only import paths and one file's grouping of small type definitions changed. `@slack/web-api` also shifts from a runtime dependency of packages/app to a dev-only one there, since packages/app no longer imports it directly at runtime -- a later PR's test still needs it as a dev dependency to mock the module.

## Slice Rationale

This is the actual file reorganization, isolated from the policy rule that makes it legal (previous PR) and from what follows in the next two PRs, so a reviewer can check "did this preserve behavior" as its own question.

## Non-goals

Does not add new test coverage. Does not turn anything on or off. Behavior unchanged.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types` (repo-wide) -- clean
- [x] `pnpm run check:deps` -- 0 errors
- [x] `pnpm run check:comments` -- clean
- [x] `bash scripts/check-owner-boundary.sh` -- passes
- [x] `cd packages/execution-engine && pnpm test` -- 106/106 files, 1448/1449 tests pass (1 pre-existing skip)
- [x] `cd packages/app && pnpm test` -- 172/172 files, 1798/1799 tests pass (1 pre-existing skip)
- [x] `cd packages/slack-bug-scan && pnpm test` -- 5/5 files, 33/33 tests pass

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None
- Data migration? No

</details>
