### PR TITLE
[Repair PR 6976 Step 1: Terminal size contract](1) Add TerminalSpec size fields

### DIFF
--- a/packages/execution-engine/src/executor.ts
+++ b/packages/execution-engine/src/executor.ts
@@ -20,6 +20,10 @@ export interface TerminalSpec {
   args?: string[];
   /** Tail command for Linux terminal launch (e.g. 'exec_bash' or 'pause'). */
   linuxTerminalTail?: 'exec_bash' | 'pause';
+  /** Initial PTY column count. Defaults to 80 when omitted. */
+  cols?: number;
+  /** Initial PTY row count. Defaults to 24 when omitted. */
+  rows?: number;
 }
 
 export interface PersistedTaskMeta {


### PR DESCRIPTION
## Summary

Isolate PR #6976's terminal-size foundation before downstream app code uses it.

This adds dormant `cols` and `rows` fields to the execution-engine `TerminalSpec`.

IPC channels, manager behavior, renderer changes, and snapshot trimming stay out of this slice.

## Review Claim

Approve that `TerminalSpec` carries optional `cols` and `rows` fields with no caller behavior change.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Optional fields do not change any existing executor return value or terminal spawn default while no app code reads them in this slice.

## Slice Rationale

This slice isolates the dormant field addition from PR #6976 so later app-size consumption can be reviewed separately.

## Non-goals

No IPC channel, terminal manager behavior, renderer changes, app routing, contracts package edits, tests, or ANSI escape trimming fix.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine build`
- [x] `git diff --name-only origin/master...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 82c245a71ed203126149d9581a126fa243a16c50`
- Post-revert steps: None
- Data migration? No

</details>
