### PR TITLE
Bugfix: web-invoker-dispatch.ts misclassified as routing, not activation-surface (1/2) — fix path classification

### DIFF
--- a/scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs
+++ b/scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { classifyReviewUnitsForPath } from '../review-unit-rules.mjs';
+
+const path = 'packages/app/src/web/web-invoker-dispatch.ts';
+const result = classifyReviewUnitsForPath(path);
+
+console.log(JSON.stringify(result));
+
+if (JSON.stringify(result) !== '["activation-surface"]') {
+  process.exit(1);
+}

--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -314,6 +314,7 @@ export function classifyReviewUnitsForPath(filePath) {
     || /^packages\/app\/src\/headless-[^/]+\.ts$/.test(path)
     || path === 'packages/app/src/api-server.ts'
     || path === 'packages/app/src/workflow-actions.ts'
+    || path === 'packages/app/src/web/web-invoker-dispatch.ts'
     || path === 'packages/app/src/workflow-mutation-facade.ts'
     || path.startsWith('packages/app/src/ipc/')
   ) {


### PR DESCRIPTION
invoker: wf-1785592395384-158/fix-review-unit-web-dispatch-misclassified — Add an explicit activation-surface path check for
packages/app/src/web/web-invoker-dispatch.ts in
classifyReviewUnitsForPath(), and add the repro script that proves it.
Review claim: web-invoker-dispatch.ts is a command-name dispatch table like
gui-mutation-handlers.ts and workflow-actions.ts (both already have an
explicit activation-surface path check); it is missing the same explicit
check, which is the only reason it lands in a different bucket today.
Review lane: behavior
Safety invariant: Every other classifyReviewUnitsForPath() result stays
byte-for-byte identical; only the bucket for
packages/app/src/web/web-invoker-dispatch.ts changes. The bucket for
web-bridge-server.ts, start-web-surface.ts, and task-graph-snapshot.ts (all
also under packages/app/src/web/) is unchanged -- confirmed by the second
acceptance criterion below.
Slice rationale: One behavior slice: the single misclassified path plus its
deterministic proof, nothing else.
Architectural effect: None. No new categories, no new module boundaries, no
change to any other path's bucket.
Goal: Make `node scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs`
pass by correcting the defect at its source.
Motivation: The current gap produces false-positive PR-body CI failures on
any PR that legitimately touches both packages/app/src/ipc/gui-mutation-handlers.ts
and its required web-dispatch counterpart for the same command-name change,
as seen on PR #5933.
Alternative considerations: Changing the bucket for the whole
packages/app/src/web/ directory was rejected -- web-bridge-server.ts is
HTTP server/transport code, not command dispatch, so a directory-wide
change would be wrong for it. An explicit single-file path check, matching
the existing pattern for api-server.ts and workflow-actions.ts, is the
precise fix.
Implementation details: In scripts/review-unit-rules.mjs, inside
classifyReviewUnitsForPath(), find the chain of `||`-joined path-equality
conditions that already includes
`path === 'packages/app/src/api-server.ts'` and
`path === 'packages/app/src/workflow-actions.ts'` and returns
`['activation-surface']`. Add one more condition to that same chain:
`|| path === 'packages/app/src/web/web-invoker-dispatch.ts'`. Do not edit
any other condition. Add
scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs: a Node ESM
script that imports classifyReviewUnitsForPath from ../review-unit-rules.mjs,
calls it with 'packages/app/src/web/web-invoker-dispatch.ts', prints the
result, and calls process.exit(1) unless the result is exactly
['activation-surface']; otherwise exit 0.
Non-goals: No change to the structure of classifyReviewUnitsForPath, no new
categories, no change to any other path's bucket (including the routing
bucket that web-bridge-server.ts, start-web-surface.ts, and
task-graph-snapshot.ts stay in), no change to validate-pr-body.mjs.
Layer: domain
Feature state: active
Files: scripts/review-unit-rules.mjs, scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs
Change types:
- scripts/review-unit-rules.mjs: modify
- scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs: create
Acceptance criteria:
- `node scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs` exits 0 after the change.
- `node --input-type=module -e "import {classifyReviewUnitsForPath as c} from './scripts/review-unit-rules.mjs'; process.exit(JSON.stringify(c('packages/app/src/web/web-bridge-server.ts'))==='[\"routing\"]'?0:1)"` still exits 0 (sibling file unchanged).

Solution:
  Add an explicit activation-surface path check for
packages/app/src/web/web-invoker-dispatch.ts in
classifyReviewUnitsForPath(), and add the repro script that proves it.
Review claim: web-invoker-dispatch.ts is a command-name dispatch table like
gui-mutation-handlers.ts and workflow-actions.ts (both already have an
explicit activation-surface path check); it is missing the same explicit
check, which is the only reason it lands in a different bucket today.
Review lane: behavior
Safety invariant: Every other classifyReviewUnitsForPath() result stays
byte-for-byte identical; only the bucket for
packages/app/src/web/web-invoker-dispatch.ts changes. The bucket for
web-bridge-server.ts, start-web-surface.ts, and task-graph-snapshot.ts (all
also under packages/app/src/web/) is unchanged -- confirmed by the second
acceptance criterion below.
Slice rationale: One behavior slice: the single misclassified path plus its
deterministic proof, nothing else.
Architectural effect: None. No new categories, no new module boundaries, no
change to any other path's bucket.
Goal: Make `node scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs`
pass by correcting the defect at its source.
Motivation: The current gap produces false-positive PR-body CI failures on
any PR that legitimately touches both packages/app/src/ipc/gui-mutation-handlers.ts
and its required web-dispatch counterpart for the same command-name change,
as seen on PR #5933.
Alternative considerations: Changing the bucket for the whole
packages/app/src/web/ directory was rejected -- web-bridge-server.ts is
HTTP server/transport code, not command dispatch, so a directory-wide
change would be wrong for it. An explicit single-file path check, matching
the existing pattern for api-server.ts and workflow-actions.ts, is the
precise fix.
Implementation details: In scripts/review-unit-rules.mjs, inside
classifyReviewUnitsForPath(), find the chain of `||`-joined path-equality
conditions that already includes
`path === 'packages/app/src/api-server.ts'` and
`path === 'packages/app/src/workflow-actions.ts'` and returns
`['activation-surface']`. Add one more condition to that same chain:
`|| path === 'packages/app/src/web/web-invoker-dispatch.ts'`. Do not edit
any other condition. Add
scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs: a Node ESM
script that imports classifyReviewUnitsForPath from ../review-unit-rules.mjs,
calls it with 'packages/app/src/web/web-invoker-dispatch.ts', prints the
result, and calls process.exit(1) unless the result is exactly
['activation-surface']; otherwise exit 0.
Non-goals: No change to the structure of classifyReviewUnitsForPath, no new
categories, no change to any other path's bucket (including the routing
bucket that web-bridge-server.ts, start-web-surface.ts, and
task-graph-snapshot.ts stay in), no change to validate-pr-body.mjs.
Layer: domain
Feature state: active
Files: scripts/review-unit-rules.mjs, scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs
Change types:
- scripts/review-unit-rules.mjs: modify
- scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs: create
Acceptance criteria:
- `node scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs` exits 0 after the change.
- `node --input-type=module -e "import {classifyReviewUnitsForPath as c} from './scripts/review-unit-rules.mjs'; process.exit(JSON.stringify(c('packages/app/src/web/web-bridge-server.ts'))==='[\"routing\"]'?0:1)"` still exits 0 (sibling file unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved classification of web dispatch changes to ensure they are reviewed under the appropriate activation-related category.

- **Tests**
  - Added automated validation to verify that web dispatch files receive the expected classification.

- **Impact**
  - No changes to end-user functionality or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->