### PR TITLE
[Web-invoker-dispatch activation-surface fix](1) Fix review-unit misclassification

### DIFF
--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -315,6 +315,7 @@ export function classifyReviewUnitsForPath(filePath) {
     || path === 'packages/app/src/api-server.ts'
     || path === 'packages/app/src/workflow-actions.ts'
     || path === 'packages/app/src/workflow-mutation-facade.ts'
+    || path === 'packages/app/src/web/web-invoker-dispatch.ts'
     || path.startsWith('packages/app/src/ipc/')
   ) {
     return ['activation-surface'];

--- a/scripts/test-review-unit-classification.mjs
+++ b/scripts/test-review-unit-classification.mjs
@@ -72,4 +72,30 @@ assert.deepEqual(
   'a manifest-only change carries no review unit of its own',
 );
 
+const activationSurfaceCommandDispatchFiles = [
+  'packages/app/src/api-server.ts',
+  'packages/app/src/workflow-actions.ts',
+  'packages/app/src/web/web-invoker-dispatch.ts',
+];
+for (const path of activationSurfaceCommandDispatchFiles) {
+  assert.deepEqual(
+    classifyReviewUnitsForPath(path),
+    ['activation-surface'],
+    `command-dispatch file should classify as activation-surface: ${path}`,
+  );
+}
+
+const webTransportFiles = [
+  'packages/app/src/web/web-bridge-server.ts',
+  'packages/app/src/web/start-web-surface.ts',
+  'packages/app/src/web/task-graph-snapshot.ts',
+];
+for (const path of webTransportFiles) {
+  assert.deepEqual(
+    classifyReviewUnitsForPath(path),
+    ['routing'],
+    `HTTP transport file under packages/app/src/web/ should stay routing: ${path}`,
+  );
+}
+
 console.log('review-unit classification: all assertions passed');


### PR DESCRIPTION
## Summary

`scripts/review-unit-rules.mjs` sorts changed files into review buckets so the PR Body check can flag an unfocused diff.

Four existing command-name dispatch files already get an explicit check for one particular bucket: `api-server.ts`, `workflow-actions.ts`, and everything under `packages/app/src/ipc/`.

`packages/app/src/web/web-invoker-dispatch.ts` serves the identical purpose for the web control surface, but was not covered by that same explicit check, so it fell through to a generic fallback bucket instead.

This causes a false PR-body failure whenever a PR legitimately combines an already-covered file with this one for the same change.

Confirmed live on PR #5933, whose PR Body check failed because this file's bucket did not match the rest of that same change.

That failure also included a second, unrelated bucket mismatch this fix does not address. Only that mismatch remains open on #5933 afterward. See Non-goals below.

The repro proving this fix is a separate, stacked PR, since a code fix and its `scripts/repro/` proof are two different Review Units here.

## Review Claim

Approve one additional path check in `classifyReviewUnitsForPath()`, added the same way its four existing sibling entries already are.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Every other `classifyReviewUnitsForPath()` result stays byte-for-byte identical. Only the bucket for `packages/app/src/web/web-invoker-dispatch.ts` changes. Verified the sibling files under `packages/app/src/web/` (`web-bridge-server.ts`, `start-web-surface.ts`, `task-graph-snapshot.ts`) are unaffected and keep their current bucket.

## Slice Rationale

Kept separate from its own proof, since this repo's own review-unit rule forbids mixing a `tooling-policy` file with a `scripts/repro/` (`proof`) file in one PR; the repro is a second, stacked PR on top of this one.

## Non-goals

Does not fix PR #5933's remaining `contract`-vs-`activation-surface` split requirement (a separate, genuine human-shaped decision: it touches `packages/contracts/src/ipc-channels.ts` alongside its `activation-surface` files). Only the false-positive `routing` collision from this bug is removed. Does not touch `scripts/mergify_admin_requeue_plan.py`'s retry-cap logic. No change to any other path's bucket.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-review-unit-classification.mjs`
- [ ] `node scripts/test-pr-body-validator.mjs`
- [ ] `gh pr view 5933 --repo Neko-Catpital-Labs/Invoker --json body -q .body > /tmp/pr5933-body.md && gh pr diff 5933 --repo Neko-Catpital-Labs/Invoker --name-only > /tmp/pr5933-changed-files.txt && node scripts/validate-pr-body.mjs --body-file /tmp/pr5933-body.md --changed-files-file /tmp/pr5933-changed-files.txt` (error no longer mentions `routing`)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`.
- Post-revert steps: None.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for review-unit classification of command-dispatch and web transport files.
  * Updated classification for a web invocation dispatch file to identify it as an activation surface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->