### PR TITLE
Move Method: PR-body validation cluster -> repair_body.py

### DIFF
--- a/scripts/mergify_admin_requeue_repair_body.py
+++ b/scripts/mergify_admin_requeue_repair_body.py
@@ -1,13 +1,32 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import Mapping
 
 try:
+    from .mergify_admin_requeue_model import PrSnapshot
+    from .mergify_admin_requeue_plan import TRUNK
     from .mergify_admin_requeue_snapshot import run_logged
 except ImportError:
+    from mergify_admin_requeue_model import PrSnapshot
+    from mergify_admin_requeue_plan import TRUNK
     from mergify_admin_requeue_snapshot import run_logged
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROOF_POLICY_LANE_ERROR = (
+    "Review lane proof cannot ship with policy files in the same PR. "
+    "Keep benchmarks, repros, and regression proof separate from behavior or policy changes."
+)
+PROOF_TOOLING_POLICY_UNIT_ERROR = (
+    'PR body Review Unit "proof" cannot ship with tooling-policy files in the same PR. '
+    "Split this into one Review Unit per PR."
+)
+NON_TRUNK_PREREQ_ERROR = "automatic tooling-policy split is only supported for base master"
+NON_TRUNK_MANUAL_SPLIT_ERROR = "worker cannot auto-split this PR on a non-trunk base; human stack split required"
 
 
 def git_output(cwd: Path, *args: str) -> str:
@@ -54,3 +73,146 @@ def normalize_repair_commit(cwd: Path, start_head: str, end_head: str, check_nam
         return start_head
     git_output(cwd, "commit", "-m", f"Repair {check_name}")
     return git_output(cwd, "rev-parse", "HEAD").strip()
+
+
+def validate_local_pr_body(cwd: Path, body: str, base_branch: str) -> dict[str, object]:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+        handle.write(body)
+        body_path = Path(handle.name)
+    try:
+        completed = subprocess.run(
+            [
+                "node",
+                str(REPO_ROOT / "scripts" / "validate-pr-body-local.mjs"),
+                "--body-file",
+                str(body_path),
+                "--base",
+                base_branch,
+                "--json",
+            ],
+            cwd=str(cwd),
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        stdout = completed.stdout.strip()
+        if completed.returncode not in {0, 1}:
+            raise RuntimeError(completed.stderr.strip() or stdout or "validate-pr-body-local failed")
+        if not stdout:
+            raise RuntimeError(completed.stderr.strip() or "validate-pr-body-local produced no JSON output")
+        value = json.loads(stdout)
+        if not isinstance(value, dict):
+            raise RuntimeError("validate-pr-body-local returned non-object JSON")
+        return value
+    finally:
+        body_path.unlink(missing_ok=True)
+
+
+def validate_pr_body_from_current_diff(cwd: Path, body: str, base_branch: str) -> dict[str, object]:
+    git_output(cwd, "fetch", "origin", f"+refs/heads/{base_branch}:refs/remotes/origin/{base_branch}")
+    changed_files = git_output(cwd, "diff", "--name-only", f"origin/{base_branch}...HEAD")
+    diff_text = git_output(cwd, "diff", "--no-ext-diff", f"origin/{base_branch}...HEAD")
+    with (
+        tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as body_handle,
+        tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as changed_handle,
+        tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as diff_handle,
+    ):
+        body_handle.write(body)
+        changed_handle.write(changed_files)
+        diff_handle.write(diff_text)
+        body_path = Path(body_handle.name)
+        changed_path = Path(changed_handle.name)
+        diff_path = Path(diff_handle.name)
+    script = (
+        "import { readFileSync } from 'node:fs';"
+        f"import {{ getReviewMetadata, scopeKindsForChangedFiles, validatePrBody }} from '{(REPO_ROOT / 'scripts' / 'validate-pr-body.mjs').as_posix()}';"
+        f"import {{ reviewUnitsForChangedFiles }} from '{(REPO_ROOT / 'scripts' / 'review-unit-rules.mjs').as_posix()}';"
+        "const body = readFileSync(process.argv[1], 'utf8');"
+        "const changedFiles = readFileSync(process.argv[2], 'utf8').split(/\\r?\\n/).filter(Boolean);"
+        "const diffText = readFileSync(process.argv[3], 'utf8');"
+        "const errors = await validatePrBody(body, { changedFiles, diffText });"
+        "const reviewMetadata = getReviewMetadata(body.trim());"
+        "console.log(JSON.stringify({"
+        "valid: errors.length === 0,"
+        "errors,"
+        "reviewLane: reviewMetadata.reviewLane,"
+        "reviewUnit: reviewMetadata.reviewUnit,"
+        "reviewUnits: reviewUnitsForChangedFiles(changedFiles),"
+        "scopeKinds: scopeKindsForChangedFiles(changedFiles),"
+        "}));"
+    )
+    try:
+        completed = subprocess.run(
+            ["node", "--input-type=module", "-e", script, str(body_path), str(changed_path), str(diff_path)],
+            cwd=str(cwd),
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        stdout = completed.stdout.strip()
+        if completed.returncode not in {0, 1}:
+            raise RuntimeError(completed.stderr.strip() or stdout or "validate-pr-body fallback failed")
+        if not stdout:
+            raise RuntimeError(completed.stderr.strip() or "validate-pr-body fallback produced no JSON output")
+        value = json.loads(stdout)
+        if not isinstance(value, dict):
+            raise RuntimeError("validate-pr-body fallback returned non-object JSON")
+        return value
+    finally:
+        body_path.unlink(missing_ok=True)
+        changed_path.unlink(missing_ok=True)
+        diff_path.unlink(missing_ok=True)
+
+
+def validate_current_pr_body(cwd: Path, body: str, base_branch: str) -> dict[str, object]:
+    try:
+        return validate_local_pr_body(cwd, body, base_branch)
+    except RuntimeError:
+        return validate_pr_body_from_current_diff(cwd, body, base_branch)
+
+
+def is_proof_tooling_policy_validation(value: Mapping[str, object]) -> bool:
+    errors = value.get("errors")
+    scope_kinds = value.get("scopeKinds")
+    review_units = value.get("reviewUnits")
+    if value.get("reviewLane") != "proof" or value.get("reviewUnit") != "proof":
+        return False
+    if review_units != ["tooling-policy"]:
+        return False
+    if scope_kinds not in ([], ["policy"]):
+        return False
+    if not isinstance(errors, list):
+        return False
+    return bool(errors) and set(errors).issubset({PROOF_POLICY_LANE_ERROR, PROOF_TOOLING_POLICY_UNIT_ERROR})
+
+
+def is_prereq_split_validation(value: Mapping[str, object], pr: PrSnapshot) -> bool:
+    return pr.base_ref_name == TRUNK and is_proof_tooling_policy_validation(value)
+
+
+def is_manual_split_validation(value: Mapping[str, object]) -> bool:
+    errors = value.get("errors")
+    review_units = value.get("reviewUnits")
+    if not isinstance(errors, list) or not errors:
+        return False
+    if not isinstance(review_units, list):
+        return False
+    if len({str(unit) for unit in review_units}) < 2:
+        return False
+    joined = "\n".join(str(error) for error in errors)
+    return (
+        "multiple review units" in joined
+        or "Split this into one Review Unit per PR." in joined
+        or "cannot ship with policy, proof files" in joined
+        or "cannot ship with tooling-policy, proof files" in joined
+        or "cannot ship with proof files" in joined
+    )
+
+
+def invalid_repair_errors(value: Mapping[str, object], pr: PrSnapshot) -> list[str]:
+    errors = [str(error) for error in value.get("errors", [])]
+    if is_proof_tooling_policy_validation(value) and pr.base_ref_name != TRUNK:
+        errors = [*errors, NON_TRUNK_PREREQ_ERROR]
+    if is_manual_split_validation(value) and pr.base_ref_name != TRUNK:
+        errors = [*errors, NON_TRUNK_MANUAL_SPLIT_ERROR]
+    return errors

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -12,7 +12,15 @@ try:
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from .mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
-    from .mergify_admin_requeue_repair_body import git_lines, git_output, hard_reset_work_root, normalize_repair_commit
+    from .mergify_admin_requeue_repair_body import (
+        git_lines,
+        git_output,
+        hard_reset_work_root,
+        invalid_repair_errors,
+        is_prereq_split_validation,
+        normalize_repair_commit,
+        validate_current_pr_body,
+    )
     from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
     from .pr_worker_safe_push import SafePushError, safe_push
 except ImportError:
@@ -20,22 +28,17 @@ except ImportError:
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
-    from mergify_admin_requeue_repair_body import git_lines, git_output, hard_reset_work_root, normalize_repair_commit
+    from mergify_admin_requeue_repair_body import (
+        git_lines,
+        git_output,
+        hard_reset_work_root,
+        invalid_repair_errors,
+        is_prereq_split_validation,
+        normalize_repair_commit,
+        validate_current_pr_body,
+    )
     from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
     from pr_worker_safe_push import SafePushError, safe_push
-
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-PROOF_POLICY_LANE_ERROR = (
-    "Review lane proof cannot ship with policy files in the same PR. "
-    "Keep benchmarks, repros, and regression proof separate from behavior or policy changes."
-)
-PROOF_TOOLING_POLICY_UNIT_ERROR = (
-    'PR body Review Unit "proof" cannot ship with tooling-policy files in the same PR. '
-    "Split this into one Review Unit per PR."
-)
-NON_TRUNK_PREREQ_ERROR = "automatic tooling-policy split is only supported for base master"
-NON_TRUNK_MANUAL_SPLIT_ERROR = "worker cannot auto-split this PR on a non-trunk base; human stack split required"
 
 
 def mergify_check_urls(event: MergifyQueueEvent | None, check_name: str) -> tuple[str, ...]:
@@ -62,142 +65,6 @@ class AdminBypassRepairer:
         self.ledger = ledger
         self.repo = repo
 
-    def validate_local_pr_body(self, work_root: Path, body: str, base_branch: str) -> dict[str, object]:
-        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
-            handle.write(body)
-            body_path = Path(handle.name)
-        try:
-            completed = subprocess.run(
-                [
-                    "node",
-                    str(REPO_ROOT / "scripts" / "validate-pr-body-local.mjs"),
-                    "--body-file",
-                    str(body_path),
-                    "--base",
-                    base_branch,
-                    "--json",
-                ],
-                cwd=str(work_root),
-                check=False,
-                text=True,
-                capture_output=True,
-            )
-            stdout = completed.stdout.strip()
-            if completed.returncode not in {0, 1}:
-                raise RuntimeError(completed.stderr.strip() or stdout or "validate-pr-body-local failed")
-            if not stdout:
-                raise RuntimeError(completed.stderr.strip() or "validate-pr-body-local produced no JSON output")
-            value = json.loads(stdout)
-            if not isinstance(value, dict):
-                raise RuntimeError("validate-pr-body-local returned non-object JSON")
-            return value
-        finally:
-            body_path.unlink(missing_ok=True)
-
-    def validate_pr_body_from_current_diff(self, work_root: Path, body: str, base_branch: str) -> dict[str, object]:
-        git_output(work_root, "fetch", "origin", f"+refs/heads/{base_branch}:refs/remotes/origin/{base_branch}")
-        changed_files = git_output(work_root, "diff", "--name-only", f"origin/{base_branch}...HEAD")
-        diff_text = git_output(work_root, "diff", "--no-ext-diff", f"origin/{base_branch}...HEAD")
-        with (
-            tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as body_handle,
-            tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as changed_handle,
-            tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as diff_handle,
-        ):
-            body_handle.write(body)
-            changed_handle.write(changed_files)
-            diff_handle.write(diff_text)
-            body_path = Path(body_handle.name)
-            changed_path = Path(changed_handle.name)
-            diff_path = Path(diff_handle.name)
-        script = (
-            "import { readFileSync } from 'node:fs';"
-            f"import {{ getReviewMetadata, scopeKindsForChangedFiles, validatePrBody }} from '{(REPO_ROOT / 'scripts' / 'validate-pr-body.mjs').as_posix()}';"
-            f"import {{ reviewUnitsForChangedFiles }} from '{(REPO_ROOT / 'scripts' / 'review-unit-rules.mjs').as_posix()}';"
-            "const body = readFileSync(process.argv[1], 'utf8');"
-            "const changedFiles = readFileSync(process.argv[2], 'utf8').split(/\\r?\\n/).filter(Boolean);"
-            "const diffText = readFileSync(process.argv[3], 'utf8');"
-            "const errors = await validatePrBody(body, { changedFiles, diffText });"
-            "const reviewMetadata = getReviewMetadata(body.trim());"
-            "console.log(JSON.stringify({"
-            "valid: errors.length === 0,"
-            "errors,"
-            "reviewLane: reviewMetadata.reviewLane,"
-            "reviewUnit: reviewMetadata.reviewUnit,"
-            "reviewUnits: reviewUnitsForChangedFiles(changedFiles),"
-            "scopeKinds: scopeKindsForChangedFiles(changedFiles),"
-            "}));"
-        )
-        try:
-            completed = subprocess.run(
-                ["node", "--input-type=module", "-e", script, str(body_path), str(changed_path), str(diff_path)],
-                cwd=str(work_root),
-                check=False,
-                text=True,
-                capture_output=True,
-            )
-            stdout = completed.stdout.strip()
-            if completed.returncode not in {0, 1}:
-                raise RuntimeError(completed.stderr.strip() or stdout or "validate-pr-body fallback failed")
-            if not stdout:
-                raise RuntimeError(completed.stderr.strip() or "validate-pr-body fallback produced no JSON output")
-            value = json.loads(stdout)
-            if not isinstance(value, dict):
-                raise RuntimeError("validate-pr-body fallback returned non-object JSON")
-            return value
-        finally:
-            body_path.unlink(missing_ok=True)
-            changed_path.unlink(missing_ok=True)
-            diff_path.unlink(missing_ok=True)
-
-    def validate_current_pr_body(self, work_root: Path, body: str, base_branch: str) -> dict[str, object]:
-        try:
-            return self.validate_local_pr_body(work_root, body, base_branch)
-        except RuntimeError:
-            return self.validate_pr_body_from_current_diff(work_root, body, base_branch)
-
-    def is_proof_tooling_policy_validation(self, value: Mapping[str, object]) -> bool:
-        errors = value.get("errors")
-        scope_kinds = value.get("scopeKinds")
-        review_units = value.get("reviewUnits")
-        if value.get("reviewLane") != "proof" or value.get("reviewUnit") != "proof":
-            return False
-        if review_units != ["tooling-policy"]:
-            return False
-        if scope_kinds not in ([], ["policy"]):
-            return False
-        if not isinstance(errors, list):
-            return False
-        return bool(errors) and set(errors).issubset({PROOF_POLICY_LANE_ERROR, PROOF_TOOLING_POLICY_UNIT_ERROR})
-
-    def is_prereq_split_validation(self, value: Mapping[str, object], pr: PrSnapshot) -> bool:
-        return pr.base_ref_name == TRUNK and self.is_proof_tooling_policy_validation(value)
-
-    def is_manual_split_validation(self, value: Mapping[str, object]) -> bool:
-        errors = value.get("errors")
-        review_units = value.get("reviewUnits")
-        if not isinstance(errors, list) or not errors:
-            return False
-        if not isinstance(review_units, list):
-            return False
-        if len({str(unit) for unit in review_units}) < 2:
-            return False
-        joined = "\n".join(str(error) for error in errors)
-        return (
-            "multiple review units" in joined
-            or "Split this into one Review Unit per PR." in joined
-            or "cannot ship with policy, proof files" in joined
-            or "cannot ship with tooling-policy, proof files" in joined
-            or "cannot ship with proof files" in joined
-        )
-
-    def invalid_repair_errors(self, value: Mapping[str, object], pr: PrSnapshot) -> list[str]:
-        errors = [str(error) for error in value.get("errors", [])]
-        if self.is_proof_tooling_policy_validation(value) and pr.base_ref_name != TRUNK:
-            errors = [*errors, NON_TRUNK_PREREQ_ERROR]
-        if self.is_manual_split_validation(value) and pr.base_ref_name != TRUNK:
-            errors = [*errors, NON_TRUNK_MANUAL_SPLIT_ERROR]
-        return errors
-
     def invalid_repair_outcome(
         self,
         pr: PrSnapshot,
@@ -214,7 +81,7 @@ class AdminBypassRepairer:
             start_head,
             end_head,
             repair_commits=repair_commits,
-            errors=self.invalid_repair_errors(value, pr),
+            errors=invalid_repair_errors(value, pr),
         )
 
     def prerequisite_branch_name(self, pr: PrSnapshot, start_head: str) -> str:
@@ -334,7 +201,7 @@ class AdminBypassRepairer:
         git_output(work_root, "reset", "--hard", f"origin/{TRUNK}")
         for commit in repair_commits:
             git_output(work_root, "cherry-pick", commit)
-        validation = self.validate_current_pr_body(work_root, body, TRUNK)
+        validation = validate_current_pr_body(work_root, body, TRUNK)
         if not validation.get("valid"):
             errors = [str(error) for error in validation.get("errors", [])]
             raise RuntimeError("prerequisite PR body failed validation: " + "; ".join(errors))
@@ -414,7 +281,7 @@ class AdminBypassRepairer:
             terminal = self.terminal_repair_outcome(pr, check_name, start_head, start_head, work_root)
             if terminal:
                 return terminal
-            validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
+            validation = validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
             if validation.get("valid"):
                 self.logger.trace(
                     "admin-bypass-pr-body-valid-noop",
@@ -475,7 +342,7 @@ class AdminBypassRepairer:
             return terminal
         if end_head == start_head and not status_lines:
             if not queue_only:
-                validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
+                validation = validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
                 if not validation.get("valid"):
                     return self.invalid_repair_outcome(pr, check_name, start_head, end_head, validation)
             return self.blocked_outcome(
@@ -495,7 +362,7 @@ class AdminBypassRepairer:
             )
         end_head = normalize_repair_commit(work_root, start_head, end_head, check_name)
         repair_commits = git_lines(work_root, "rev-list", "--reverse", f"{start_head}..{end_head}")
-        validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
+        validation = validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
         if validation.get("valid"):
             try:
                 self.push_branch(work_root, pr.head_ref_name, expected_head=pr.head_ref_oid)
@@ -515,7 +382,7 @@ class AdminBypassRepairer:
                 end_head,
                 repair_commits=repair_commits,
             )
-        if self.is_prereq_split_validation(validation, pr):
+        if is_prereq_split_validation(validation, pr):
             try:
                 created = self.create_repair_prerequisite(pr, check_name, start_head, repair_commits, work_root, now)
             finally:

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -35,13 +35,12 @@ from scripts.mergify_admin_requeue_gh_executor import ADMIN_BYPASS_NUDGE_LEDGER_
 from scripts.mergify_admin_requeue_model import LoadedStacks, RepairOutcome
 from scripts.mergify_admin_requeue_loader import AdminBypassStackLoader
 from scripts.mergify_admin_requeue_logger import AdminBypassLogger
-from scripts.mergify_admin_requeue_repairer import (
+from scripts.mergify_admin_requeue_repair_body import (
     NON_TRUNK_MANUAL_SPLIT_ERROR,
-    NON_TRUNK_PREREQ_ERROR,
     PROOF_POLICY_LANE_ERROR,
     PROOF_TOOLING_POLICY_UNIT_ERROR,
-    AdminBypassRepairer,
 )
+from scripts.mergify_admin_requeue_repairer import AdminBypassRepairer
 from scripts.pr_worker_safe_push import SafePushError
 
 REQUIRED = {"PR Body", "quality / TypeScript Types"}
@@ -464,7 +463,7 @@ Failing checks
                 with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
                     with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                         with mock.patch.object(repairer, "run_claude_repair") as repair:
-                            with mock.patch.object(repairer, "validate_current_pr_body", return_value={"valid": True, "errors": []}):
+                            with mock.patch("scripts.mergify_admin_requeue_repairer.validate_current_pr_body", return_value={"valid": True, "errors": []}):
                                 with redirect_stderr(stderr):
                                     result = repairer.repair_check(item, "PR Body")
         checkout.assert_called_once()
@@ -504,7 +503,7 @@ Failing checks
                 with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
                     with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                         with mock.patch.object(repairer, "run_claude_repair"):
-                            with mock.patch.object(repairer, "validate_current_pr_body", return_value=validation):
+                            with mock.patch("scripts.mergify_admin_requeue_repairer.validate_current_pr_body", return_value=validation):
                                 result = repairer.repair_check(item, "PR Body")
         self.assertEqual(result.status, "blocked_invalid")
         self.assertIn(NON_TRUNK_MANUAL_SPLIT_ERROR, result.errors)
@@ -578,7 +577,7 @@ Failing checks
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log") as download:
                 with mock.patch.object(repairer, "job_log_is_empty", return_value=True):
                     with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
-                        with mock.patch.object(repairer, "validate_current_pr_body", return_value={"valid": True}):
+                        with mock.patch("scripts.mergify_admin_requeue_repairer.validate_current_pr_body", return_value={"valid": True}):
                             with mock.patch.object(repairer, "run_claude_repair") as repair:
                                 result = repairer.repair_check(item, "PR Body")
         checkout.assert_called_once()
@@ -753,7 +752,7 @@ Failing checks
                     with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=fake_git_output):
                         with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", side_effect=fake_git_lines):
                             with mock.patch("scripts.mergify_admin_requeue_repair_body.git_output", side_effect=fake_git_output):
-                                with mock.patch.object(repairer, "validate_local_pr_body", side_effect=lambda *_args: next(validator_results)):
+                                with mock.patch("scripts.mergify_admin_requeue_repair_body.validate_local_pr_body", side_effect=lambda *_args: next(validator_results)):
                                     with mock.patch.object(repairer, "push_branch", return_value="pushed-sha") as push_branch:
                                         result = repairer.repair_check(item, "PR Body", 123)
 


### PR DESCRIPTION
validate_local_pr_body, validate_pr_body_from_current_diff,
validate_current_pr_body, is_proof_tooling_policy_validation,
is_prereq_split_validation, is_manual_split_validation, and
invalid_repair_errors move out of AdminBypassRepairer into repair_body.py.
Every call site in repairer.py (repair_check's three validation calls,
create_repair_prerequisite's own body validation, invalid_repair_outcome)
is re-pointed in this same commit.

Clustered as one slice: validate_current_pr_body directly calls the other
two validate_* functions as its two-stage fallback, and the is_*/
invalid_repair_errors predicates only exist to interpret a validation
result, always consumed together by the same callers. Depends on the
git-primitives slice (validate_pr_body_from_current_diff calls git_output
for the base-branch diff fetch).

No behavior change, verified by the full existing test suite passing with
only mechanical mock-target updates.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Depends-On: #7037