### PR TITLE
Move Method: prerequisite-PR-creation cluster -> repair_body.py

### DIFF
--- a/scripts/mergify_admin_requeue_repair_body.py
+++ b/scripts/mergify_admin_requeue_repair_body.py
@@ -4,16 +4,20 @@ import json
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Mapping
+from typing import Mapping, Sequence
 
 try:
-    from .mergify_admin_requeue_model import PrSnapshot
+    from .mergify_admin_requeue_logger import AdminBypassLogger
+    from .mergify_admin_requeue_model import Ledger, PrSnapshot
     from .mergify_admin_requeue_plan import TRUNK
-    from .mergify_admin_requeue_snapshot import run_logged
+    from .mergify_admin_requeue_snapshot import GhClient, run_logged
+    from .pr_worker_safe_push import safe_push
 except ImportError:
-    from mergify_admin_requeue_model import PrSnapshot
+    from mergify_admin_requeue_logger import AdminBypassLogger
+    from mergify_admin_requeue_model import Ledger, PrSnapshot
     from mergify_admin_requeue_plan import TRUNK
-    from mergify_admin_requeue_snapshot import run_logged
+    from mergify_admin_requeue_snapshot import GhClient, run_logged
+    from pr_worker_safe_push import safe_push
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -216,3 +220,92 @@ def invalid_repair_errors(value: Mapping[str, object], pr: PrSnapshot) -> list[s
     if is_manual_split_validation(value) and pr.base_ref_name != TRUNK:
         errors = [*errors, NON_TRUNK_MANUAL_SPLIT_ERROR]
     return errors
+
+
+def prerequisite_branch_name(pr: PrSnapshot, start_head: str) -> str:
+    return f"stack/pr-babysit-prereq-{pr.number}-{start_head[:7]}"
+
+
+def prerequisite_title(pr: PrSnapshot, check_name: str) -> str:
+    return f"[PR babysit] Tooling-policy repair prerequisite for #{pr.number}: {check_name}"
+
+
+def prerequisite_body(pr: PrSnapshot, check_name: str) -> str:
+    return (
+        "## Summary\n\n"
+        "Worker-generated tooling-policy repair.\n\n"
+        "## Review Claim\n\n"
+        f"This PR carries the worker-generated tooling-policy repair that unblocks {check_name} on #{pr.number}.\n\n"
+        "## Review Lane\n\n"
+        "- policy\n\n"
+        "## Review Unit\n\n"
+        "- tooling-policy\n\n"
+        "## Safety Invariant\n\n"
+        "Contains only the worker-generated repair commit; the original PR branch stays proof-only.\n\n"
+        "## Slice Rationale\n\n"
+        "The repair changed tooling-policy files that a proof PR body cannot carry, so the repair must land first.\n\n"
+        "## Non-goals\n\n"
+        "- No product behavior change.\n\n"
+        "## Test Plan\n\n"
+        "<details>\n"
+        "<summary>Test Plan</summary>\n\n"
+        f"- [ ] Let CI rerun {check_name}.\n\n"
+        "</details>\n\n"
+        "## Revert Plan\n\n"
+        "<details>\n"
+        "<summary>Revert Plan</summary>\n\n"
+        "- Safe to revert? Yes.\n"
+        "- Revert command: `git revert <sha>`\n"
+        "- Post-revert steps: None.\n"
+        "- Data migration? No.\n\n"
+        "</details>\n"
+    )
+
+
+def create_repair_prerequisite(
+    gh: GhClient,
+    ledger: Ledger,
+    logger: AdminBypassLogger,
+    repo: str,
+    cwd: Path,
+    pr: PrSnapshot,
+    check_name: str,
+    start_head: str,
+    repair_commits: Sequence[str],
+    now: int | None,
+) -> dict[str, object]:
+    branch_name = prerequisite_branch_name(pr, start_head)
+    title = prerequisite_title(pr, check_name)
+    body = prerequisite_body(pr, check_name)
+    git_output(cwd, "checkout", "-B", branch_name, f"origin/{TRUNK}")
+    git_output(cwd, "reset", "--hard", f"origin/{TRUNK}")
+    for commit in repair_commits:
+        git_output(cwd, "cherry-pick", commit)
+    validation = validate_current_pr_body(cwd, body, TRUNK)
+    if not validation.get("valid"):
+        errors = [str(error) for error in validation.get("errors", [])]
+        raise RuntimeError("prerequisite PR body failed validation: " + "; ".join(errors))
+    safe_push(branch=branch_name, expect_missing=True, cwd=cwd)
+    created = gh.create_pr(repo, title, body, branch_name, TRUNK)
+    prereq_number = int(created.get("number") or 0)
+    if prereq_number <= 0:
+        raise RuntimeError("GitHub did not return a prerequisite PR number")
+    gh.edit_label(repo, prereq_number, add="admin-bypass")
+    ledger.record(
+        "repair-prereq-created",
+        pr.number,
+        pr.head_ref_oid,
+        check_name,
+        now,
+        meta={"prNumber": prereq_number, "branch": branch_name},
+    )
+    logger.trace(
+        "admin-bypass-repair-prereq-created",
+        repo=repo,
+        pr_number=pr.number,
+        check_name=check_name,
+        prereq_pr_number=prereq_number,
+        prereq_branch=branch_name,
+        repair_commits=list(repair_commits),
+    )
+    return {"prNumber": prereq_number, "branch": branch_name, "title": title}

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -11,8 +11,9 @@ try:
     from .mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
-    from .mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
+    from .mergify_admin_requeue_plan import is_queue_only_required_check
     from .mergify_admin_requeue_repair_body import (
+        create_repair_prerequisite,
         git_lines,
         git_output,
         hard_reset_work_root,
@@ -27,8 +28,9 @@ except ImportError:
     from mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
-    from mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
+    from mergify_admin_requeue_plan import is_queue_only_required_check
     from mergify_admin_requeue_repair_body import (
+        create_repair_prerequisite,
         git_lines,
         git_output,
         hard_reset_work_root,
@@ -82,43 +84,6 @@ class AdminBypassRepairer:
             end_head,
             repair_commits=repair_commits,
             errors=invalid_repair_errors(value, pr),
-        )
-
-    def prerequisite_branch_name(self, pr: PrSnapshot, start_head: str) -> str:
-        return f"stack/pr-babysit-prereq-{pr.number}-{start_head[:7]}"
-
-    def prerequisite_title(self, pr: PrSnapshot, check_name: str) -> str:
-        return f"[PR babysit] Tooling-policy repair prerequisite for #{pr.number}: {check_name}"
-
-    def prerequisite_body(self, pr: PrSnapshot, check_name: str) -> str:
-        return (
-            "## Summary\n\n"
-            "Worker-generated tooling-policy repair.\n\n"
-            "## Review Claim\n\n"
-            f"This PR carries the worker-generated tooling-policy repair that unblocks {check_name} on #{pr.number}.\n\n"
-            "## Review Lane\n\n"
-            "- policy\n\n"
-            "## Review Unit\n\n"
-            "- tooling-policy\n\n"
-            "## Safety Invariant\n\n"
-            "Contains only the worker-generated repair commit; the original PR branch stays proof-only.\n\n"
-            "## Slice Rationale\n\n"
-            "The repair changed tooling-policy files that a proof PR body cannot carry, so the repair must land first.\n\n"
-            "## Non-goals\n\n"
-            "- No product behavior change.\n\n"
-            "## Test Plan\n\n"
-            "<details>\n"
-            "<summary>Test Plan</summary>\n\n"
-            f"- [ ] Let CI rerun {check_name}.\n\n"
-            "</details>\n\n"
-            "## Revert Plan\n\n"
-            "<details>\n"
-            "<summary>Revert Plan</summary>\n\n"
-            "- Safe to revert? Yes.\n"
-            "- Revert command: `git revert <sha>`\n"
-            "- Post-revert steps: None.\n"
-            "- Data migration? No.\n\n"
-            "</details>\n"
         )
 
     def blocked_outcome(
@@ -184,51 +149,6 @@ class AdminBypassRepairer:
         )
         hard_reset_work_root(work_root, start_head)
         return self.blocked_outcome("noop", check_name, start_head, end_head)
-
-    def create_repair_prerequisite(
-        self,
-        pr: PrSnapshot,
-        check_name: str,
-        start_head: str,
-        repair_commits: Sequence[str],
-        work_root: Path,
-        now: int | None,
-    ) -> dict[str, object]:
-        branch_name = self.prerequisite_branch_name(pr, start_head)
-        title = self.prerequisite_title(pr, check_name)
-        body = self.prerequisite_body(pr, check_name)
-        git_output(work_root, "checkout", "-B", branch_name, f"origin/{TRUNK}")
-        git_output(work_root, "reset", "--hard", f"origin/{TRUNK}")
-        for commit in repair_commits:
-            git_output(work_root, "cherry-pick", commit)
-        validation = validate_current_pr_body(work_root, body, TRUNK)
-        if not validation.get("valid"):
-            errors = [str(error) for error in validation.get("errors", [])]
-            raise RuntimeError("prerequisite PR body failed validation: " + "; ".join(errors))
-        self.push_branch(work_root, branch_name, expect_missing=True)
-        created = self.gh.create_pr(self.repo, title, body, branch_name, TRUNK)
-        prereq_number = int(created.get("number") or 0)
-        if prereq_number <= 0:
-            raise RuntimeError("GitHub did not return a prerequisite PR number")
-        self.gh.edit_label(self.repo, prereq_number, add="admin-bypass")
-        self.ledger.record(
-            "repair-prereq-created",
-            pr.number,
-            pr.head_ref_oid,
-            check_name,
-            now,
-            meta={"prNumber": prereq_number, "branch": branch_name},
-        )
-        self.logger.trace(
-            "admin-bypass-repair-prereq-created",
-            repo=self.repo,
-            pr_number=pr.number,
-            check_name=check_name,
-            prereq_pr_number=prereq_number,
-            prereq_branch=branch_name,
-            repair_commits=list(repair_commits),
-        )
-        return {"prNumber": prereq_number, "branch": branch_name, "title": title}
 
     def run_claude_repair(self, work_root: Path, prompt: str) -> None:
         subprocess.run(
@@ -384,7 +304,10 @@ class AdminBypassRepairer:
             )
         if is_prereq_split_validation(validation, pr):
             try:
-                created = self.create_repair_prerequisite(pr, check_name, start_head, repair_commits, work_root, now)
+                created = create_repair_prerequisite(
+                    self.gh, self.ledger, self.logger, self.repo, work_root,
+                    pr, check_name, start_head, repair_commits, now,
+                )
             finally:
                 git_output(work_root, "checkout", "-B", pr.head_ref_name, start_head)
                 hard_reset_work_root(work_root, start_head)

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -753,11 +753,11 @@ Failing checks
                         with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", side_effect=fake_git_lines):
                             with mock.patch("scripts.mergify_admin_requeue_repair_body.git_output", side_effect=fake_git_output):
                                 with mock.patch("scripts.mergify_admin_requeue_repair_body.validate_local_pr_body", side_effect=lambda *_args: next(validator_results)):
-                                    with mock.patch.object(repairer, "push_branch", return_value="pushed-sha") as push_branch:
+                                    with mock.patch("scripts.mergify_admin_requeue_repair_body.safe_push", return_value="pushed-sha") as safe_push_mock:
                                         result = repairer.repair_check(item, "PR Body", 123)
 
         self.assertEqual(result.status, "prereq_created")
-        push_branch.assert_called_once_with(mock.ANY, "stack/pr-babysit-prereq-5800-c2532d2", expect_missing=True)
+        safe_push_mock.assert_called_once_with(branch="stack/pr-babysit-prereq-5800-c2532d2", expect_missing=True, cwd=mock.ANY)
         self.assertEqual(fake.created[0][0], "owner/repo")
         self.assertIn("[PR babysit] Tooling-policy repair prerequisite for #5800: PR Body", fake.created[0][1])
         self.assertEqual(fake.label_edits, [("owner/repo", 5801, "admin-bypass", None)])


### PR DESCRIPTION
prerequisite_branch_name, prerequisite_title, prerequisite_body, and
create_repair_prerequisite move out of AdminBypassRepairer into
repair_body.py. repair_check's one call site is re-pointed in this same
commit, passing self.gh/self.ledger/self.logger/self.repo explicitly now
that they're no longer available implicitly through self.

Clustered as one slice: the three naming helpers have no caller except
create_repair_prerequisite. Depends on the two previous slices
(create_repair_prerequisite calls git_output/hard_reset_work_root and
validate_current_pr_body). push_branch's one call site inside
create_repair_prerequisite is inlined to call safe_push directly (the
same underlying call push_branch already made, since push_branch itself
stays a thin method on AdminBypassRepairer and isn't moving).

No behavior change, verified by the full existing test suite passing with
only mechanical mock-target updates.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Depends-On: #7038