### PR TITLE
Add async repair-plan submission plumbing (unused)

### DIFF
--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from .mergify_admin_requeue_headless_shell import run_headless
+    from .mergify_admin_requeue_model import MergifyQueueEvent, PrSnapshot
+except ImportError:
+    from mergify_admin_requeue_headless_shell import run_headless
+    from mergify_admin_requeue_model import MergifyQueueEvent, PrSnapshot
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(value: str, *, max_len: int = 40) -> str:
+    slug = _SLUG_RE.sub("-", value.lower()).strip("-")
+    return (slug or "check")[:max_len].strip("-") or "check"
+
+
+def _yaml_str(value: str) -> str:
+    # JSON string encoding is a valid YAML flow scalar and, unlike naive shell
+    # quoting, correctly escapes quotes/colons/backslashes in PR titles/branch
+    # names without a second layer of ad-hoc stripping.
+    return json.dumps(value)
+
+
+def _indent_block(text: str, spaces: int) -> str:
+    prefix = " " * spaces
+    lines = text.splitlines() or [""]
+    return "\n".join(prefix + line if line else prefix.rstrip() for line in lines)
+
+
+def _repo_url(repo: str) -> str:
+    return f"https://github.com/{repo}.git"
+
+
+@dataclass(frozen=True)
+class AsyncRepairPlan:
+    plan_name: str
+    yaml_text: str
+
+
+def _write_plan_header(*, name: str, base_branch: str, repo: str) -> str:
+    return (
+        f"name: {name}\n"
+        "onFinish: none\n"
+        "mergeMode: manual\n"
+        f"repoUrl: {_yaml_str(_repo_url(repo))}\n"
+        f"baseBranch: {_yaml_str(base_branch)}\n"
+        "tasks:\n"
+    )
+
+
+def _repair_task_yaml(*, description: str, prompt: str) -> str:
+    return (
+        "  - id: repair\n"
+        f"    description: {_yaml_str(description)}\n"
+        "    prompt: |\n"
+        f"{_indent_block(prompt, 6)}\n"
+    )
+
+
+def _safe_push_task_yaml(
+    *,
+    task_id: str,
+    description: str,
+    dependencies: str,
+    head_ref: str,
+    start_head: str,
+    state_file: Path,
+    json_kind: str,
+    pr_number: int,
+    json_key: str,
+    skip_if_prereq: bool,
+) -> str:
+    skip_guard = (
+        "if [ -f .invoker-repair-prereq-created ]; then\n"
+        "  echo \"prerequisite PR already published this attempt; nothing to push\"\n"
+        "  exit 0\n"
+        "fi\n"
+        if skip_if_prereq
+        else ""
+    )
+    command = (
+        "set -euo pipefail\n"
+        f"{skip_guard}"
+        "python3 scripts/pr_worker_safe_push.py \\\n"
+        f"  --branch {_shlex(head_ref)} --expected-head {_shlex(start_head)} --cwd . \\\n"
+        f"  --record-json-ledger {_shlex(str(state_file))} \\\n"
+        f"  --json-kind {_shlex(json_kind)} --json-pr {_shlex(str(pr_number))} \\\n"
+        f"  --json-head-sha {_shlex(start_head)} --json-key {_shlex(json_key)}\n"
+    )
+    return (
+        f"  - id: {task_id}\n"
+        f"    description: {_yaml_str(description)}\n"
+        f"    dependencies: [{dependencies}]\n"
+        "    command: |\n"
+        f"{_indent_block(command, 6)}\n"
+    )
+
+
+def _shlex(value: str) -> str:
+    # Minimal POSIX single-quote wrap; values here are SHAs, branch names, and
+    # our own ledger paths/kinds -- none contain single quotes in practice, but
+    # this keeps the generated command block safe regardless.
+    return "'" + value.replace("'", "'\\''") + "'"
+
+
+_RESTRUCTURE_ESCAPE_HATCH = (
+    "If the real fix requires restructuring this PR instead of editing it in place -- for example, splitting "
+    "unrelated files into their own PR because they can't ship together -- do not force that into a single "
+    "local commit here. Instead, submit an Invoker plan to do the restructuring, the same way a human would "
+    "via the plan-to-invoker skill (see skills/plan-to-invoker/SKILL.md and ./submit-plan.sh). Then make no "
+    "commit in this checkout and exit 0.\n"
+)
+
+
+def build_repair_check_plan(
+    pr: PrSnapshot,
+    check_name: str,
+    *,
+    repo: str,
+    details_url: str,
+    log_path: str,
+    queue_only: bool,
+    queue_pr_number: int,
+    latest: MergifyQueueEvent | None,
+    start_head: str,
+    state_file: Path,
+) -> AsyncRepairPlan:
+    name = f"admin-bypass-repair-check-pr-{pr.number}-{_slugify(check_name)}-{start_head[:7]}"
+    prompt = (
+        "This PR's CI check is failing. Diagnose why it is failing, then fix it. Add or "
+        "update a repro if the failure is reproducible.\n\n"
+        "If a code change fixes it: make the change in this checkout. Commit locally if "
+        "needed, do not push. If local proof shows the check is already green on the "
+        "current head, make no commit and exit 0.\n\n"
+        f"{_RESTRUCTURE_ESCAPE_HATCH}\n"
+        f"Repair the existing pull request #{pr.number} ({json.dumps(pr.title)}) on {repo}.\n"
+        f"PR URL: {pr.url}\n"
+        f"Head branch: {pr.head_ref_name} (at {start_head}), base branch: {pr.base_ref_name}\n\n"
+        "Work directly on its branch:\n"
+        f"  git fetch origin {pr.head_ref_name} && git checkout {pr.head_ref_name}\n\n"
+        f"Failed check: {check_name}\n"
+        f"Details URL: {details_url}\n"
+        f"Job log path: {log_path}\n"
+        f"Latest Mergify event: {json.dumps(dataclasses.asdict(latest) if latest else None, sort_keys=True)}\n"
+    )
+    if queue_only:
+        prompt += f"Queue draft PR: #{queue_pr_number}\nRepair the real PR head, using only evidence from the queue draft failure.\n"
+
+    yaml_text = _write_plan_header(name=name, base_branch=pr.base_ref_name, repo=repo)
+    yaml_text += _repair_task_yaml(description=f"Repair PR #{pr.number} (failed check {check_name})", prompt=prompt)
+    normalize_command = (
+        "set -euo pipefail\n"
+        "python3 scripts/mergify_admin_requeue_repair_normalize.py \\\n"
+        f"  --repo {_shlex(repo)} --pr {pr.number} --check {_shlex(check_name)} \\\n"
+        f"  --start-head {_shlex(start_head)} --base {_shlex(pr.base_ref_name)} --trunk master\n"
+    )
+    yaml_text += (
+        "  - id: normalize\n"
+        f"    description: {_yaml_str(f'Normalize PR #{pr.number} repair commit; split a prerequisite PR if required')}\n"
+        "    dependencies: [repair]\n"
+        "    command: |\n"
+        f"{_indent_block(normalize_command, 6)}\n"
+    )
+    yaml_text += _safe_push_task_yaml(
+        task_id="safe-push",
+        description=f"Safely push PR #{pr.number} only if its head did not move and no prerequisite was split",
+        dependencies="normalize",
+        head_ref=pr.head_ref_name,
+        start_head=start_head,
+        state_file=state_file,
+        json_kind="repair-check-settled",
+        pr_number=pr.number,
+        json_key=check_name,
+        skip_if_prereq=True,
+    )
+    return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
+
+
+def build_repair_conflict_plan(
+    pr: PrSnapshot,
+    reason: str,
+    *,
+    repo: str,
+    start_head: str,
+    state_file: Path,
+) -> AsyncRepairPlan:
+    name = f"admin-bypass-repair-conflict-pr-{pr.number}-{start_head[:7]}"
+    prompt = (
+        "This PR has a merge conflict blocking it from merging. Diagnose why, then fix it.\n\n"
+        "If rebasing the head branch onto its base branch (preserving the PR's intended changes) resolves it: "
+        "do that, run the narrow proof for the conflict resolution, then commit locally. Do not push.\n\n"
+        "If the real fix requires restructuring this PR instead of a straightforward rebase, do not force that "
+        "into a single local commit here. Instead, submit an Invoker plan to do the restructuring, the same way "
+        "a human would via the plan-to-invoker skill (see skills/plan-to-invoker/SKILL.md and ./submit-plan.sh). "
+        "Then make no commit in this checkout and exit 0.\n\n"
+        "If the PR is already closed or merged, or the head branch no longer exists, make no commit and exit 0.\n\n"
+        f"PR: #{pr.number}\nBase branch: {pr.base_ref_name}\nHead branch: {pr.head_ref_name}\n"
+        f"Head SHA: {start_head}\nReason: {reason}\n"
+    )
+    yaml_text = _write_plan_header(name=name, base_branch=pr.base_ref_name, repo=repo)
+    yaml_text += _repair_task_yaml(description=f"Repair merge conflict on PR #{pr.number}", prompt=prompt)
+    yaml_text += _safe_push_task_yaml(
+        task_id="safe-push",
+        description=f"Safely push PR #{pr.number} only if its head did not move",
+        dependencies="repair",
+        head_ref=pr.head_ref_name,
+        start_head=start_head,
+        state_file=state_file,
+        json_kind="conflict-repair-settled",
+        pr_number=pr.number,
+        json_key=f"conflict:{pr.number}",
+        skip_if_prereq=False,
+    )
+    return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
+
+
+def build_repair_bot_thread_plan(
+    pr: PrSnapshot,
+    thread_id: str,
+    *,
+    repo: str,
+    start_head: str,
+    state_file: Path,
+) -> AsyncRepairPlan:
+    name = f"admin-bypass-repair-bot-thread-pr-{pr.number}-{start_head[:7]}"
+    prompt = (
+        f"Resolve the unresolved review thread {thread_id}. Address the reviewer's feedback with "
+        "real code changes, run the narrow proof for the fix, then commit locally. Do not push. "
+        "If the thread is already resolved, or the PR is closed or merged, make no commit and exit 0.\n\n"
+        f"PR: #{pr.number}\nHead branch: {pr.head_ref_name}\nHead SHA: {start_head}\nThread: {thread_id}\n"
+    )
+    yaml_text = _write_plan_header(name=name, base_branch=pr.base_ref_name, repo=repo)
+    yaml_text += _repair_task_yaml(description=f"Resolve bot review thread on PR #{pr.number}", prompt=prompt)
+    yaml_text += _safe_push_task_yaml(
+        task_id="safe-push",
+        description=f"Safely push PR #{pr.number} only if its head did not move",
+        dependencies="repair",
+        head_ref=pr.head_ref_name,
+        start_head=start_head,
+        state_file=state_file,
+        json_kind="repair-bot-thread-settled",
+        pr_number=pr.number,
+        json_key=thread_id,
+        skip_if_prereq=False,
+    )
+    return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
+
+
+def submit_async_repair_plan(plan: AsyncRepairPlan) -> None:
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", suffix=".yaml", prefix=f"{plan.plan_name}-", delete=False
+    ) as handle:
+        handle.write(plan.yaml_text)
+        plan_path = Path(handle.name)
+    try:
+        completed = run_headless('headless_mutation --no-track run "$2"', str(plan_path))
+        if completed.returncode != 0:
+            raise RuntimeError(
+                f"submit_async_repair_plan failed for {plan.plan_name}: "
+                f"{completed.stderr.strip() or completed.stdout.strip()}"
+            )
+    finally:
+        plan_path.unlink(missing_ok=True)

--- a/scripts/mergify_admin_requeue_repair_body.py
+++ b/scripts/mergify_admin_requeue_repair_body.py
@@ -8,13 +8,13 @@ from typing import Mapping, Sequence
 
 try:
     from .mergify_admin_requeue_logger import AdminBypassLogger
-    from .mergify_admin_requeue_model import Ledger, PrSnapshot
+    from .mergify_admin_requeue_model import Ledger
     from .mergify_admin_requeue_plan import TRUNK
     from .mergify_admin_requeue_snapshot import GhClient, run_logged
     from .pr_worker_safe_push import safe_push
 except ImportError:
     from mergify_admin_requeue_logger import AdminBypassLogger
-    from mergify_admin_requeue_model import Ledger, PrSnapshot
+    from mergify_admin_requeue_model import Ledger
     from mergify_admin_requeue_plan import TRUNK
     from mergify_admin_requeue_snapshot import GhClient, run_logged
     from pr_worker_safe_push import safe_push
@@ -190,8 +190,8 @@ def is_proof_tooling_policy_validation(value: Mapping[str, object]) -> bool:
     return bool(errors) and set(errors).issubset({PROOF_POLICY_LANE_ERROR, PROOF_TOOLING_POLICY_UNIT_ERROR})
 
 
-def is_prereq_split_validation(value: Mapping[str, object], pr: PrSnapshot) -> bool:
-    return pr.base_ref_name == TRUNK and is_proof_tooling_policy_validation(value)
+def is_prereq_split_validation(value: Mapping[str, object], base_ref_name: str) -> bool:
+    return base_ref_name == TRUNK and is_proof_tooling_policy_validation(value)
 
 
 def is_manual_split_validation(value: Mapping[str, object]) -> bool:
@@ -213,29 +213,29 @@ def is_manual_split_validation(value: Mapping[str, object]) -> bool:
     )
 
 
-def invalid_repair_errors(value: Mapping[str, object], pr: PrSnapshot) -> list[str]:
+def invalid_repair_errors(value: Mapping[str, object], base_ref_name: str) -> list[str]:
     errors = [str(error) for error in value.get("errors", [])]
-    if is_proof_tooling_policy_validation(value) and pr.base_ref_name != TRUNK:
+    if is_proof_tooling_policy_validation(value) and base_ref_name != TRUNK:
         errors = [*errors, NON_TRUNK_PREREQ_ERROR]
-    if is_manual_split_validation(value) and pr.base_ref_name != TRUNK:
+    if is_manual_split_validation(value) and base_ref_name != TRUNK:
         errors = [*errors, NON_TRUNK_MANUAL_SPLIT_ERROR]
     return errors
 
 
-def prerequisite_branch_name(pr: PrSnapshot, start_head: str) -> str:
-    return f"stack/pr-babysit-prereq-{pr.number}-{start_head[:7]}"
+def prerequisite_branch_name(pr_number: int, start_head: str) -> str:
+    return f"stack/pr-babysit-prereq-{pr_number}-{start_head[:7]}"
 
 
-def prerequisite_title(pr: PrSnapshot, check_name: str) -> str:
-    return f"[PR babysit] Tooling-policy repair prerequisite for #{pr.number}: {check_name}"
+def prerequisite_title(pr_number: int, check_name: str) -> str:
+    return f"[PR babysit] Tooling-policy repair prerequisite for #{pr_number}: {check_name}"
 
 
-def prerequisite_body(pr: PrSnapshot, check_name: str) -> str:
+def prerequisite_body(pr_number: int, check_name: str) -> str:
     return (
         "## Summary\n\n"
         "Worker-generated tooling-policy repair.\n\n"
         "## Review Claim\n\n"
-        f"This PR carries the worker-generated tooling-policy repair that unblocks {check_name} on #{pr.number}.\n\n"
+        f"This PR carries the worker-generated tooling-policy repair that unblocks {check_name} on #{pr_number}.\n\n"
         "## Review Lane\n\n"
         "- policy\n\n"
         "## Review Unit\n\n"
@@ -268,15 +268,16 @@ def create_repair_prerequisite(
     logger: AdminBypassLogger,
     repo: str,
     cwd: Path,
-    pr: PrSnapshot,
+    pr_number: int,
+    head_sha: str,
     check_name: str,
     start_head: str,
     repair_commits: Sequence[str],
     now: int | None,
 ) -> dict[str, object]:
-    branch_name = prerequisite_branch_name(pr, start_head)
-    title = prerequisite_title(pr, check_name)
-    body = prerequisite_body(pr, check_name)
+    branch_name = prerequisite_branch_name(pr_number, start_head)
+    title = prerequisite_title(pr_number, check_name)
+    body = prerequisite_body(pr_number, check_name)
     git_output(cwd, "checkout", "-B", branch_name, f"origin/{TRUNK}")
     git_output(cwd, "reset", "--hard", f"origin/{TRUNK}")
     for commit in repair_commits:
@@ -293,8 +294,8 @@ def create_repair_prerequisite(
     gh.edit_label(repo, prereq_number, add="admin-bypass")
     ledger.record(
         "repair-prereq-created",
-        pr.number,
-        pr.head_ref_oid,
+        pr_number,
+        head_sha,
         check_name,
         now,
         meta={"prNumber": prereq_number, "branch": branch_name},
@@ -302,7 +303,7 @@ def create_repair_prerequisite(
     logger.trace(
         "admin-bypass-repair-prereq-created",
         repo=repo,
-        pr_number=pr.number,
+        pr_number=pr_number,
         check_name=check_name,
         prereq_pr_number=prereq_number,
         prereq_branch=branch_name,

--- a/scripts/mergify_admin_requeue_repair_normalize.py
+++ b/scripts/mergify_admin_requeue_repair_normalize.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+try:
+    from .mergify_admin_requeue_logger import AdminBypassLogger
+    from .mergify_admin_requeue_model import Ledger
+    from .mergify_admin_requeue_repair_body import (
+        create_repair_prerequisite,
+        git_lines,
+        git_output,
+        hard_reset_work_root,
+        invalid_repair_errors,
+        is_prereq_split_validation,
+        normalize_repair_commit,
+        validate_current_pr_body,
+    )
+    from .mergify_admin_requeue_snapshot import GhClient
+except ImportError:
+    from mergify_admin_requeue_logger import AdminBypassLogger
+    from mergify_admin_requeue_model import Ledger
+    from mergify_admin_requeue_repair_body import (
+        create_repair_prerequisite,
+        git_lines,
+        git_output,
+        hard_reset_work_root,
+        invalid_repair_errors,
+        is_prereq_split_validation,
+        normalize_repair_commit,
+        validate_current_pr_body,
+    )
+    from mergify_admin_requeue_snapshot import GhClient
+
+# Runs inside the Invoker `normalize` task's own checkout, one hop after the
+# `repair` task's agent turn -- this is the async replacement for the local
+# post-run_claude_repair inspection AdminBypassRepairer.repair_check used to do
+# synchronously in the cron process. It re-implements: dirty-check/reset,
+# normalize_repair_commit (rebase-shaped diff handling), PR-body
+# re-validation, and -- if the fix needs restructuring -- create_repair_prerequisite
+# (a small prerequisite PR) instead of letting `safe-push` push directly.
+
+PREREQ_SENTINEL = Path(".invoker-repair-prereq-created")
+
+# Written unconditionally as this task's first action: reaching `normalize` at
+# all means the submitted repair attempt concluded (successfully, as a noop, or
+# as a still-invalid fix), which is what frees plan.py's repair_in_flight check
+# for this (pr, headSha, blockerKey) -- regardless of what happens below. Only
+# a crash before `normalize` even starts (the `repair` task itself dying) skips
+# this write, and that's exactly the case the in-flight TTL exists to bound.
+def _record_settle_marker(state_file: Path, pr_number: int, start_head: str, check_name: str) -> None:
+    Ledger(state_file).record("repair-check-settled", pr_number, start_head, check_name)
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Normalize an async admin-bypass repair commit before safe-push.")
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument("--check", required=True)
+    parser.add_argument("--start-head", required=True)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--trunk", default="master")
+    parser.add_argument(
+        "--state-file",
+        default=str(Path.home() / ".invoker" / "mergify-admin-requeue-state.jsonl"),
+        help="Ledger JSONL path. Default: ~/.invoker/mergify-admin-requeue-state.jsonl.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    cwd = Path.cwd()
+    start_head = args.start_head
+    state_file = Path(args.state_file).expanduser()
+
+    _record_settle_marker(state_file, args.pr, start_head, args.check)
+
+    if git_lines(cwd, "status", "--porcelain"):
+        hard_reset_work_root(cwd, start_head)
+        print("blocked_dirty: repair left the working tree dirty", file=sys.stderr)
+        return 1
+
+    end_head = git_output(cwd, "rev-parse", "HEAD").strip()
+    if end_head == start_head:
+        print("noop: repair task made no commit")
+        return 0
+
+    end_head = normalize_repair_commit(cwd, start_head, end_head, args.check)
+    if end_head == start_head:
+        print("noop: repair diff was empty after normalization")
+        return 0
+
+    gh = GhClient()
+    detail = gh.pr_detail(args.repo, args.pr)
+    body = str(detail.get("body") or "")
+    validation = validate_current_pr_body(cwd, body, args.base)
+    if validation.get("valid"):
+        print(f"repair commit normalized to {end_head}; ready for safe-push")
+        return 0
+
+    if is_prereq_split_validation(validation, args.base):
+        repair_commits = git_lines(cwd, "rev-list", "--reverse", f"{start_head}..{end_head}")
+        ledger = Ledger(state_file)
+        logger = AdminBypassLogger()
+        try:
+            create_repair_prerequisite(
+                gh, ledger, logger, args.repo, cwd,
+                args.pr, start_head, args.check, start_head, repair_commits, None,
+            )
+        finally:
+            hard_reset_work_root(cwd, start_head)
+        PREREQ_SENTINEL.write_text("1", encoding="utf-8")
+        print("prerequisite PR created; original PR left unchanged for this attempt")
+        return 0
+
+    hard_reset_work_root(cwd, start_head)
+    errors = invalid_repair_errors(validation, args.base)
+    print("blocked_invalid: " + "; ".join(errors), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -83,7 +83,7 @@ class AdminBypassRepairer:
             start_head,
             end_head,
             repair_commits=repair_commits,
-            errors=invalid_repair_errors(value, pr),
+            errors=invalid_repair_errors(value, pr.base_ref_name),
         )
 
     def blocked_outcome(
@@ -302,11 +302,11 @@ class AdminBypassRepairer:
                 end_head,
                 repair_commits=repair_commits,
             )
-        if is_prereq_split_validation(validation, pr):
+        if is_prereq_split_validation(validation, pr.base_ref_name):
             try:
                 created = create_repair_prerequisite(
                     self.gh, self.ledger, self.logger, self.repo, work_root,
-                    pr, check_name, start_head, repair_commits, now,
+                    pr.number, pr.head_ref_oid, check_name, start_head, repair_commits, now,
                 )
             finally:
                 git_output(work_root, "checkout", "-B", pr.head_ref_name, start_head)

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -1,0 +1,155 @@
+"""Behavioural tests for mergify_admin_requeue_async_repair's plan builders.
+
+Run:  python3 scripts/test_mergify_admin_requeue_async_repair.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import scripts.mergify_admin_requeue_async_repair as async_repair
+import scripts.mergify_admin_requeue_model as m
+
+HEAD = "c2532d229dbed2fd57419698c48d973001c78e9e"
+
+
+def pr(**kw):
+    base = dict(
+        number=2647,
+        title='Fix "quoted" title: with colons',
+        body="",
+        url="https://github.com/owner/repo/pull/2647",
+        state="OPEN",
+        is_draft=False,
+        base_ref_name="master",
+        head_ref_name="stack/2647",
+        head_ref_oid=HEAD,
+        merge_state_status="CLEAN",
+        mergeable="MERGEABLE",
+        labels=frozenset({"admin-bypass"}),
+        checks={},
+        review_threads=(),
+        latest_mergify=None,
+    )
+    base.update(kw)
+    return m.PrSnapshot(**base)
+
+
+class AsyncRepairPlanTests(unittest.TestCase):
+    def test_all_three_plan_kinds_produce_parseable_yaml_with_expected_task_ids(self):
+        checks_plan = async_repair.build_repair_check_plan(
+            pr(), "PR Body", repo="owner/repo", details_url="https://example.invalid/job",
+            log_path="/tmp/pr-body.log", queue_only=False, queue_pr_number=0, latest=None,
+            start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
+        )
+        conflict_plan = async_repair.build_repair_conflict_plan(
+            pr(), "GitHub reports merge conflict", repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
+        )
+        bot_thread_plan = async_repair.build_repair_bot_thread_plan(
+            pr(), "tbot", repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
+        )
+        for plan, expected_task_ids in (
+            (checks_plan, ["repair", "normalize", "safe-push"]),
+            (conflict_plan, ["repair", "safe-push"]),
+            (bot_thread_plan, ["repair", "safe-push"]),
+        ):
+            with self.subTest(plan=plan.plan_name):
+                doc = yaml.safe_load(plan.yaml_text)
+                self.assertEqual(doc["onFinish"], "none")
+                self.assertEqual(doc["repoUrl"], "https://github.com/owner/repo.git")
+                self.assertEqual([task["id"] for task in doc["tasks"]], expected_task_ids)
+                for task, expected_id in zip(doc["tasks"][1:], expected_task_ids[1:]):
+                    self.assertEqual(task["dependencies"], [expected_task_ids[expected_task_ids.index(expected_id) - 1]])
+
+    def test_repair_check_plan_includes_three_tasks_in_dependency_order(self):
+        plan = async_repair.build_repair_check_plan(
+            pr(),
+            "PR Body",
+            repo="owner/repo",
+            details_url="https://example.invalid/job",
+            log_path="/tmp/pr-body.log",
+            queue_only=False,
+            queue_pr_number=0,
+            latest=None,
+            start_head=HEAD,
+            state_file=Path("/tmp/ledger.jsonl"),
+        )
+        self.assertIn("id: repair", plan.yaml_text)
+        self.assertIn("id: normalize", plan.yaml_text)
+        self.assertIn("id: safe-push", plan.yaml_text)
+        self.assertIn("dependencies: [repair]", plan.yaml_text)
+        self.assertIn("dependencies: [normalize]", plan.yaml_text)
+        self.assertIn("mergify_admin_requeue_repair_normalize.py", plan.yaml_text)
+        self.assertIn("--json-kind 'repair-check-settled'", plan.yaml_text)
+        self.assertIn("Failed check: PR Body", plan.yaml_text)
+        # PR titles with quotes/colons must not corrupt the YAML document.
+        self.assertIn('Fix \\"quoted\\" title: with colons', plan.yaml_text)
+
+    def test_repair_check_plan_queue_only_appends_queue_pr_line(self):
+        plan = async_repair.build_repair_check_plan(
+            pr(checks={}),
+            "required-fast / Guardrails",
+            repo="owner/repo",
+            details_url="https://example.invalid/job",
+            log_path="/tmp/guardrails.log",
+            queue_only=True,
+            queue_pr_number=5854,
+            latest=None,
+            start_head=HEAD,
+            state_file=Path("/tmp/ledger.jsonl"),
+        )
+        self.assertIn("Queue draft PR: #5854", plan.yaml_text)
+
+    def test_repair_conflict_plan_has_two_tasks_and_conflict_key(self):
+        plan = async_repair.build_repair_conflict_plan(
+            pr(), "GitHub reports merge conflict", repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
+        )
+        self.assertIn("id: repair", plan.yaml_text)
+        self.assertIn("id: safe-push", plan.yaml_text)
+        self.assertNotIn("id: normalize", plan.yaml_text)
+        self.assertIn("--json-kind 'conflict-repair-settled'", plan.yaml_text)
+        self.assertIn("--json-key 'conflict:2647'", plan.yaml_text)
+        self.assertIn("commit locally. Do not push.", plan.yaml_text)
+
+    def test_repair_bot_thread_plan_uses_thread_id_as_key(self):
+        plan = async_repair.build_repair_bot_thread_plan(
+            pr(), "tbot", repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
+        )
+        self.assertIn("--json-kind 'repair-bot-thread-settled'", plan.yaml_text)
+        self.assertIn("--json-key 'tbot'", plan.yaml_text)
+        self.assertIn("Thread: tbot", plan.yaml_text)
+
+    def test_submit_async_repair_plan_calls_headless_run_and_cleans_up_temp_file(self):
+        plan = async_repair.AsyncRepairPlan(plan_name="admin-bypass-repair-check-pr-1-abc", yaml_text="name: x\n")
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}\n", stderr="")
+        written_paths = []
+
+        def fake_run_headless(command, *extra_args):
+            written_paths.append(Path(extra_args[0]))
+            self.assertTrue(written_paths[-1].exists())
+            self.assertEqual(written_paths[-1].read_text(encoding="utf-8"), "name: x\n")
+            return completed
+
+        with mock.patch("scripts.mergify_admin_requeue_async_repair.run_headless", side_effect=fake_run_headless) as run:
+            async_repair.submit_async_repair_plan(plan)
+        run.assert_called_once()
+        self.assertFalse(written_paths[0].exists())
+
+    def test_submit_async_repair_plan_raises_on_failure(self):
+        plan = async_repair.AsyncRepairPlan(plan_name="p", yaml_text="name: x\n")
+        completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
+        with mock.patch("scripts.mergify_admin_requeue_async_repair.run_headless", return_value=completed):
+            with self.assertRaises(RuntimeError):
+                async_repair.submit_async_repair_plan(plan)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_mergify_admin_requeue_repair_normalize.py
+++ b/scripts/test_mergify_admin_requeue_repair_normalize.py
@@ -1,0 +1,164 @@
+"""Behavioural tests for mergify_admin_requeue_repair_normalize's CLI.
+
+This is the async replacement for the local post-run_claude_repair inspection
+AdminBypassRepairer.repair_check used to do synchronously: dirty-check/reset,
+normalize_repair_commit, PR-body re-validation, and (on a restructuring-needed
+verdict) create_repair_prerequisite instead of a direct push.
+
+Run:  python3 scripts/test_mergify_admin_requeue_repair_normalize.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import scripts.mergify_admin_requeue_repair_normalize as normalize
+
+HEAD = "c2532d229dbed2fd57419698c48d973001c78e9e"
+NEW_HEAD = "b" * 40
+
+PROOF_TOOLING_POLICY_VALIDATION = {
+    "valid": False,
+    "errors": [
+        "Review lane proof cannot ship with policy files in the same PR. "
+        "Keep benchmarks, repros, and regression proof separate from behavior or policy changes.",
+        'PR body Review Unit "proof" cannot ship with tooling-policy files in the same PR. '
+        "Split this into one Review Unit per PR.",
+    ],
+    "reviewLane": "proof",
+    "reviewUnit": "proof",
+    "reviewUnits": ["tooling-policy"],
+    "scopeKinds": ["policy"],
+}
+
+MANUAL_SPLIT_VALIDATION = {
+    "valid": False,
+    "errors": [
+        "PR body mentions multiple review units (validation-policy, routing); split into one conceptual unit per diff/task.",
+        'PR body Review Unit "routing" cannot ship with tooling-policy, proof files in the same PR. '
+        "Split this into one Review Unit per PR.",
+    ],
+    "reviewLane": "behavior",
+    "reviewUnit": "routing",
+    "reviewUnits": ["routing", "tooling-policy", "proof"],
+    "scopeKinds": ["product", "policy"],
+}
+
+
+class RepairNormalizeTests(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.cwd = os.getcwd()
+        os.chdir(tmp.name)
+        self.addCleanup(os.chdir, self.cwd)
+        self.state_file = Path(tmp.name) / "ledger.jsonl"
+
+    def argv(self, **overrides):
+        base = {
+            "--repo": "owner/repo",
+            "--pr": "2647",
+            "--check": "PR Body",
+            "--start-head": HEAD,
+            "--base": "master",
+            "--trunk": "master",
+            "--state-file": str(self.state_file),
+        }
+        base.update(overrides)
+        out = []
+        for key, value in base.items():
+            out += [key, value]
+        return out
+
+    def settled_rows(self):
+        if not self.state_file.exists():
+            return []
+        return [line for line in self.state_file.read_text(encoding="utf-8").splitlines() if '"repair-check-settled"' in line]
+
+    def test_records_settle_marker_first_regardless_of_outcome(self):
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=("M file.py",)):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.hard_reset_work_root"):
+                code = normalize.main(self.argv())
+        self.assertEqual(code, 1)
+        self.assertEqual(len(self.settled_rows()), 1)
+
+    def test_dirty_working_tree_resets_and_fails(self):
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=("M file.py",)):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.hard_reset_work_root") as reset:
+                code = normalize.main(self.argv())
+        self.assertEqual(code, 1)
+        reset.assert_called_once_with(Path.cwd(), HEAD)
+
+    def test_no_commit_returns_zero_without_further_work(self):
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
+                    code = normalize.main(self.argv())
+        self.assertEqual(code, 0)
+        gh_cls.assert_not_called()
+
+    def test_valid_body_ready_for_push_returns_zero(self):
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=NEW_HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.normalize_repair_commit", return_value=NEW_HEAD):
+                    with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
+                        gh_cls.return_value.pr_detail.return_value = {"body": "## Summary\n\nok\n"}
+                        with mock.patch(
+                            "scripts.mergify_admin_requeue_repair_normalize.validate_current_pr_body",
+                            return_value={"valid": True, "errors": []},
+                        ):
+                            code = normalize.main(self.argv())
+        self.assertEqual(code, 0)
+        self.assertFalse(normalize.PREREQ_SENTINEL.exists())
+
+    def test_prereq_split_creates_prerequisite_and_writes_sentinel(self):
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=("commit-a",)) as git_lines:
+            git_lines.side_effect = lambda cwd, *args: ("commit-a",) if args[:1] == ("rev-list",) else ()
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=NEW_HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.normalize_repair_commit", return_value=NEW_HEAD):
+                    with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
+                        gh_cls.return_value.pr_detail.return_value = {"body": "## Summary\n\nmixed\n"}
+                        with mock.patch(
+                            "scripts.mergify_admin_requeue_repair_normalize.validate_current_pr_body",
+                            return_value=PROOF_TOOLING_POLICY_VALIDATION,
+                        ):
+                            with mock.patch(
+                                "scripts.mergify_admin_requeue_repair_normalize.create_repair_prerequisite",
+                                return_value={"prNumber": 5801, "branch": "stack/pr-babysit-prereq-2647-c2532d2"},
+                            ) as create_prereq:
+                                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.hard_reset_work_root"):
+                                    code = normalize.main(self.argv())
+        self.addCleanup(lambda: normalize.PREREQ_SENTINEL.unlink(missing_ok=True))
+        self.assertEqual(code, 0)
+        create_prereq.assert_called_once()
+        call_kwargs = create_prereq.call_args
+        self.assertEqual(call_kwargs.args[5], 2647)
+        self.assertEqual(call_kwargs.args[6], HEAD)
+        self.assertEqual(call_kwargs.args[7], "PR Body")
+        self.assertTrue(normalize.PREREQ_SENTINEL.exists())
+
+    def test_invalid_non_trunk_blocks_human_split(self):
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=NEW_HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.normalize_repair_commit", return_value=NEW_HEAD):
+                    with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
+                        gh_cls.return_value.pr_detail.return_value = {"body": "## Summary\n\nmixed\n"}
+                        with mock.patch(
+                            "scripts.mergify_admin_requeue_repair_normalize.validate_current_pr_body",
+                            return_value=MANUAL_SPLIT_VALIDATION,
+                        ):
+                            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.hard_reset_work_root") as reset:
+                                code = normalize.main(self.argv(**{"--base": "stack/base"}))
+        self.assertEqual(code, 1)
+        reset.assert_called_once_with(Path.cwd(), HEAD)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
New scripts/mergify_admin_requeue_async_repair.py builds Invoker plan
YAML for the three repair shapes (failed check, merge conflict, bot
review thread) and submits it fire-and-forget via headless_mutation run.
New scripts/mergify_admin_requeue_repair_normalize.py is the `normalize`
task's CLI entry point: it runs one hop after the plan's `repair` task
and re-implements the post-repair inspection AdminBypassRepairer.repair_check
does synchronously today -- dirty-check/reset, normalize_repair_commit,
PR-body re-validation, and (on a restructuring-needed verdict)
create_repair_prerequisite instead of a direct push. Neither file is
wired into AdminBypassRepairer yet; that's the next slice.

repair_normalize.py's CLI only has scalar argparse args available (--pr,
--start-head, --base), not a full PrSnapshot, so introducing it as a
caller requires repair_body.py's is_prereq_split_validation,
invalid_repair_errors, prerequisite_branch_name, prerequisite_title,
prerequisite_body, and create_repair_prerequisite to take scalar
base_ref_name/pr_number/head_sha parameters instead of a PrSnapshot.
Bundled into this commit rather than its own slice: splitting the
signature change out first would leave repair_body.py accepting
parameters no caller in the diff actually needs yet, and splitting it
after would force repair_normalize.py to wrap PrSnapshot construction
around scalar CLI args as a throwaway shim just to satisfy the old
signature for one commit. repairer.py's three call sites are re-pointed
in this same commit to pass pr.base_ref_name / pr.number, pr.head_ref_oid
explicitly; repair_check itself stays fully synchronous.

No behavior change to repair_check/repair_conflict/repair_bot_thread,
verified by the full existing test suite passing unmodified. The two new
files are covered by their own new test files.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Depends-On: #7039