### PR TITLE
Fix cross-stack starvation and the dead retry cap

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -98,6 +98,7 @@ def run_cycle(args: argparse.Namespace) -> bool:
         candidate_pr_numbers=sorted(pr_by_number),
     )
     should_poll = False
+    any_progress = False
     open_pr_numbers = set(pr_by_number)
     for stack in stacks:
         plan = plan_stack_execution(
@@ -138,7 +139,7 @@ def run_cycle(args: argparse.Namespace) -> bool:
                     if action.key.startswith("bot_review_thread:"):
                         thread_id = action.key.split(":", 1)[1]
                         outcome = repairer.repair_bot_thread(pr, thread_id, now)
-                        progressed = outcome.status in {"pushed", "prereq_created"}
+                        progressed = outcome.status in {"pushed", "prereq_created", "submitted"}
                     else:
                         check_name = action.key
                         workflow_id = resolve_workflow_for_pr(action.pr_number)
@@ -148,7 +149,7 @@ def run_cycle(args: argparse.Namespace) -> bool:
                             progressed = True
                         else:
                             outcome = repairer.repair_check(pr, check_name, now)
-                            progressed = outcome.status in {"pushed", "prereq_created"}
+                            progressed = outcome.status in {"pushed", "prereq_created", "submitted"}
                 except Exception as exc:
                     logger.trace(
                         "admin-bypass-repair-attempt-failed",
@@ -161,8 +162,9 @@ def run_cycle(args: argparse.Namespace) -> bool:
                     should_poll = True
                     continue
                 if progressed:
-                    return True
-                should_poll = True
+                    any_progress = True
+                else:
+                    should_poll = True
                 continue
             elif action.kind == "repair_conflict":
                 try:
@@ -173,7 +175,7 @@ def run_cycle(args: argparse.Namespace) -> bool:
                         progressed = True
                     else:
                         outcome = repairer.repair_conflict(pr, action.detail, now)
-                        progressed = outcome.status in {"pushed", "prereq_created"}
+                        progressed = outcome.status in {"pushed", "prereq_created", "submitted"}
                 except Exception as exc:
                     logger.trace(
                         "admin-bypass-repair-attempt-failed",
@@ -186,8 +188,9 @@ def run_cycle(args: argparse.Namespace) -> bool:
                     should_poll = True
                     continue
                 if progressed:
-                    return True
-                should_poll = True
+                    any_progress = True
+                else:
+                    should_poll = True
                 continue
             else:
                 performed = executor.execute(action, pr, now)
@@ -215,11 +218,11 @@ def run_cycle(args: argparse.Namespace) -> bool:
                             pr_number=pr.number,
                             check_name=queue_only_noop_check,
                         )
-            if action.kind not in {"comment_blocked", "comment_admin_bypass_nudge"}:
-                return True
+                if action.kind not in {"comment_blocked", "comment_admin_bypass_nudge"}:
+                    any_progress = True
     if not stacks:
         logger.trace("admin-bypass-scan-empty")
-    return should_poll
+    return any_progress or should_poll
 
 
 def run_once(args: argparse.Namespace) -> int:

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import Collection, Literal, Mapping
 
@@ -143,6 +144,39 @@ def cap_action(pr: PrSnapshot, blocker: Blocker, detail: str) -> Action:
     return Action("comment_blocked", pr.number, "capped", f"{detail}. The retry cap was reached for current head {pr.head_ref_oid}.")
 
 
+# An async repair submission (repairer.py's ledger.record(submit_kind, ...), written
+# only after a successful `headless_mutation run` submission) is "in flight" until a
+# same-kind "-settled" row lands with an equal-or-later epoch. The submitted plan's
+# `normalize` task writes that settle row unconditionally as its first action, so
+# reaching `normalize` at all -- pushed, no-op, prereq-created, or still-invalid --
+# frees this PR/blocker for its next tick. Only a crash before `normalize` ever runs
+# (the `repair` task itself dying) leaves no settle row; the TTL bounds that case so
+# a single wedged attempt can't block this (pr, headSha, blockerKey) forever.
+REPAIR_IN_FLIGHT_TTL_SECONDS = 5400
+
+
+def repair_in_flight(
+    ledger: Ledger,
+    pr_number: int,
+    head_sha: str,
+    submit_kind: str,
+    key: str,
+    now: int,
+    *,
+    ttl_seconds: int = REPAIR_IN_FLIGHT_TTL_SECONDS,
+) -> bool:
+    submitted = ledger.latest(submit_kind, pr_number, head_sha, key)
+    if submitted is None:
+        return False
+    submitted_epoch = int(submitted.get("epoch", 0) or 0)
+    settled = ledger.latest(f"{submit_kind}-settled", pr_number, head_sha, key)
+    if settled is not None and int(settled.get("epoch", 0) or 0) >= submitted_epoch:
+        return False
+    if now - submitted_epoch >= ttl_seconds:
+        return False
+    return True
+
+
 def mergify_condition_map(event: MergifyQueueEvent | None) -> dict[str, str]:
     return dict(event.condition_states) if event else {}
 
@@ -181,6 +215,8 @@ def effective_blockers(
 def mergify_failed_check_actions(
     pr: PrSnapshot,
     ledger: Ledger,
+    max_repair_attempts: int,
+    now: int,
     suppressed_failed_checks: Collection[str] = (),
 ) -> tuple[Action, ...]:
     suppressed = set(suppressed_failed_checks)
@@ -190,8 +226,10 @@ def mergify_failed_check_actions(
     for name in latest.failing_checks:
         if name in suppressed:
             continue
-        if ledger.count("repair-check", pr.number, pr.head_ref_oid, name) >= 3:
+        if ledger.count("repair-check", pr.number, pr.head_ref_oid, name) >= max_repair_attempts:
             return (cap_action(pr, Blocker(name, "failed_check", pr.number, f"Mergify queue check failed: {name}"), f"Mergify queue check failed: {name}"),)
+        if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-check", name, now):
+            continue
         return (Action("repair_check", pr.number, name, f"Mergify queue check failed: {name}"),)
     return ()
 
@@ -578,6 +616,25 @@ def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
     )
 
 
+# Kinds plan_direct_repairs/plan_bot_thread_repairs/mergify_failed_check_actions
+# normally turn into a repair action. When the one blocking such a kind is
+# in-flight, those planners skip it without producing an action -- correct for
+# "don't resubmit," but the blocker is still real. Without this check, the
+# ladder would fall through to plan_bottom_progress and requeue a PR whose
+# required check is still actually failing, just because this tick didn't
+# resubmit a repair for it.
+REPAIRABLE_BLOCKER_KINDS = frozenset({"failed_check", "conflict", "bot_review_thread", "outdated_bot_review_thread"})
+
+
+def _bottom_has_repairable_blocker(facts: StackFacts) -> bool:
+    if not facts.bottom:
+        return False
+    return any(
+        blocker.pr_number == facts.bottom.number and blocker.kind in REPAIRABLE_BLOCKER_KINDS
+        for blocker in facts.all_blockers
+    )
+
+
 def _candidate_prs(facts: StackFacts, pr_numbers: Collection[int] | None = None) -> tuple[PrSnapshot, ...]:
     if pr_numbers is None:
         return facts.stack.prs
@@ -589,15 +646,17 @@ def plan_mergify_queue_repairs(
     facts: StackFacts,
     ledger: Ledger,
     max_repair_attempts: int,
+    now: int,
     pr_numbers: Collection[int] | None = None,
 ) -> Action | None:
-    del max_repair_attempts
     for pr in _candidate_prs(facts, pr_numbers):
         if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
             continue
         if facts.upper_stack_needs_acceptance and facts.bottom and pr.number == facts.bottom.number:
             continue
-        actions = mergify_failed_check_actions(pr, ledger, facts.suppressed_failed_checks_by_pr.get(pr.number, ()))
+        actions = mergify_failed_check_actions(
+            pr, ledger, max_repair_attempts, now, facts.suppressed_failed_checks_by_pr.get(pr.number, ()),
+        )
         if actions:
             return actions[0]
     return None
@@ -607,6 +666,7 @@ def plan_direct_repairs(
     facts: StackFacts,
     ledger: Ledger,
     max_repair_attempts: int,
+    now: int,
     pr_numbers: Collection[int] | None = None,
 ) -> Action | None:
     for pr in _candidate_prs(facts, pr_numbers):
@@ -617,11 +677,15 @@ def plan_direct_repairs(
                 key = f"conflict:{pr.number}"
                 if ledger.count("conflict-repair", pr.number, pr.head_ref_oid, key) >= max_repair_attempts:
                     return cap_action(pr, blocker, blocker.detail)
+                if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "conflict-repair", key, now):
+                    continue
                 return Action("repair_conflict", pr.number, key, blocker.detail)
             if blocker.kind == "failed_check":
                 attempts = ledger.count("repair-check", pr.number, pr.head_ref_oid, blocker.key)
-                if attempts >= max_repair_attempts and ledger.latest("repair-evaluated", pr.number, pr.head_ref_oid, blocker.key) is not None:
+                if attempts >= max_repair_attempts:
                     return cap_action(pr, blocker, blocker.detail)
+                if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-check", blocker.key, now):
+                    continue
                 return Action("repair_check", pr.number, blocker.key, blocker.detail)
     return None
 
@@ -630,6 +694,7 @@ def plan_bot_thread_repairs(
     facts: StackFacts,
     ledger: Ledger,
     max_repair_attempts: int,
+    now: int,
     pr_numbers: Collection[int] | None = None,
 ) -> Action | None:
     for pr in _candidate_prs(facts, pr_numbers):
@@ -644,6 +709,8 @@ def plan_bot_thread_repairs(
                 return Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail)
             if ledger.count("repair-bot-thread", pr.number, pr.head_ref_oid, blocker.key) >= max_repair_attempts:
                 return cap_action(pr, blocker, blocker.detail)
+            if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-bot-thread", blocker.key, now):
+                continue
             return Action("repair_check", pr.number, "bot_review_thread:" + blocker.key, blocker.detail)
     return None
 
@@ -760,33 +827,34 @@ def plan_actions_from_facts(
     ledger: Ledger,
     max_requeue_attempts: int,
     max_repair_attempts: int,
+    now: int,
 ) -> tuple[Action, ...]:
     if facts.bottom:
         bottom_pr_numbers = (facts.bottom.number,)
-        action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts, bottom_pr_numbers)
+        action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts, now, bottom_pr_numbers)
         if action is not None:
             return (action,)
-        action = plan_direct_repairs(facts, ledger, max_repair_attempts, bottom_pr_numbers)
+        action = plan_direct_repairs(facts, ledger, max_repair_attempts, now, bottom_pr_numbers)
         if action is not None:
             return (action,)
-        action = plan_bot_thread_repairs(facts, ledger, max_repair_attempts, bottom_pr_numbers)
+        action = plan_bot_thread_repairs(facts, ledger, max_repair_attempts, now, bottom_pr_numbers)
         if action is not None:
             return (action,)
         action = plan_hard_blockers(facts, ledger, bottom_pr_numbers)
         if action is not None:
             return (action,)
-        if _bottom_has_pending_or_human_blocker(facts):
+        if _bottom_has_pending_or_human_blocker(facts) or _bottom_has_repairable_blocker(facts):
             return ()
         action = plan_bottom_progress(facts, ledger, max_requeue_attempts)
         if action is not None:
             return (action,)
-    action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts)
+    action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts, now)
     if action is not None:
         return (action,)
-    action = plan_direct_repairs(facts, ledger, max_repair_attempts)
+    action = plan_direct_repairs(facts, ledger, max_repair_attempts, now)
     if action is not None:
         return (action,)
-    action = plan_bot_thread_repairs(facts, ledger, max_repair_attempts)
+    action = plan_bot_thread_repairs(facts, ledger, max_repair_attempts, now)
     if action is not None:
         return (action,)
     action = plan_hard_blockers(facts, ledger)
@@ -814,7 +882,6 @@ def plan_stack_actions(
     suppressed_failed_checks_by_pr: Mapping[int, Collection[str]] | None = None,
     open_pr_numbers_by_head: Mapping[str, Collection[int]] | None = None,
 ) -> tuple[Action, ...]:
-    del now_epoch
     del suppressed_failed_checks_by_pr
     facts = build_stack_facts(
         stack,
@@ -824,7 +891,7 @@ def plan_stack_actions(
         open_pr_numbers_by_head=open_pr_numbers_by_head or {},
         trunk=TRUNK,
     )
-    return plan_actions_from_facts(facts, ledger, max_requeue_attempts, max_repair_attempts)
+    return plan_actions_from_facts(facts, ledger, max_requeue_attempts, max_repair_attempts, now_epoch)
 
 
 def plan_stack_execution(
@@ -838,7 +905,6 @@ def plan_stack_execution(
     max_repair_attempts: int = 3,
     trunk: str = TRUNK,
 ) -> StackExecutionPlan:
-    del now_epoch
     facts = build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head, trunk)
     summary = summarize_stack(facts)
     if facts.prereq_status and facts.prereq_status.is_open:
@@ -849,7 +915,7 @@ def plan_stack_execution(
             prereq_status=facts.prereq_status,
             queue_only_noop_check=facts.queue_only_noop_check,
         )
-    actions = plan_actions_from_facts(facts, ledger, max_requeue_attempts, max_repair_attempts)
+    actions = plan_actions_from_facts(facts, ledger, max_requeue_attempts, max_repair_attempts, now_epoch)
     if actions:
         return StackExecutionPlan(
             summary=summary,

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -35,6 +35,7 @@ from scripts.mergify_admin_requeue_gh_executor import ADMIN_BYPASS_NUDGE_LEDGER_
 from scripts.mergify_admin_requeue_model import LoadedStacks, RepairOutcome
 from scripts.mergify_admin_requeue_loader import AdminBypassStackLoader
 from scripts.mergify_admin_requeue_logger import AdminBypassLogger
+from scripts.mergify_admin_requeue_plan import repair_in_flight
 from scripts.mergify_admin_requeue_repairer import AdminBypassRepairer
 
 REQUIRED = {"PR Body", "quality / TypeScript Types"}
@@ -273,17 +274,52 @@ Failing checks
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 2606, "PR Body")])
 
-    def test_failed_check_at_cap_gets_one_more_attempt_until_evaluated(self):
+    def test_failed_check_caps_after_max_repair_attempts(self):
         checks = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
         stack = StackGroup("s", (pr(2606, checks=checks, latest=mergify()),))
         ledger = self.ledger()
-        for epoch in range(3):
-            ledger.record("repair-check", 2606, HEAD, "PR Body", epoch)
-        actions = plan_stack_actions(stack, REQUIRED, ledger, 4)
+        # Two prior attempts, each submitted then settled, so neither is in-flight.
+        for epoch in range(2):
+            ledger.record("repair-check", 2606, HEAD, "PR Body", epoch * 2)
+            ledger.record("repair-check-settled", 2606, HEAD, "PR Body", epoch * 2 + 1)
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 10)
         self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 2606, "PR Body")])
-        ledger.record("repair-evaluated", 2606, HEAD, "PR Body", 4)
-        actions = plan_stack_actions(stack, REQUIRED, ledger, 5)
+        ledger.record("repair-check", 2606, HEAD, "PR Body", 10)
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 11)
         self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("comment_blocked", 2606, "capped")])
+
+    def test_plan_direct_repairs_skips_in_flight_blocker_but_tries_next_stack(self):
+        stuck_checks = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        stuck = pr(6951, checks=stuck_checks, latest=mergify())
+        ready_checks = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        ready = pr(5933, checks=ready_checks, latest=mergify())
+        ledger = self.ledger()
+        ledger.record("repair-check", 6951, HEAD, "PR Body", 1)
+        stuck_stack = StackGroup("s1", (stuck,))
+        ready_stack = StackGroup("s2", (ready,))
+        stuck_actions = plan_stack_actions(stuck_stack, REQUIRED, ledger, 2)
+        self.assertEqual(stuck_actions, ())
+        ready_actions = plan_stack_actions(ready_stack, REQUIRED, ledger, 2)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in ready_actions], [("repair_check", 5933, "PR Body")])
+
+    def test_repair_in_flight_frees_budget_when_head_changes(self):
+        ledger = self.ledger()
+        ledger.record("repair-check", 6951, OLD, "PR Body", 1)
+        self.assertTrue(repair_in_flight(ledger, 6951, OLD, "repair-check", "PR Body", 2))
+        self.assertFalse(repair_in_flight(ledger, 6951, HEAD, "repair-check", "PR Body", 2))
+
+    def test_repair_in_flight_settles_once_a_settle_row_lands(self):
+        ledger = self.ledger()
+        ledger.record("repair-check", 6951, HEAD, "PR Body", 1)
+        self.assertTrue(repair_in_flight(ledger, 6951, HEAD, "repair-check", "PR Body", 2))
+        ledger.record("repair-check-settled", 6951, HEAD, "PR Body", 3)
+        self.assertFalse(repair_in_flight(ledger, 6951, HEAD, "repair-check", "PR Body", 4))
+
+    def test_repair_in_flight_expires_after_ttl(self):
+        ledger = self.ledger()
+        ledger.record("repair-check", 6951, HEAD, "PR Body", 1000)
+        self.assertTrue(repair_in_flight(ledger, 6951, HEAD, "repair-check", "PR Body", 1000 + 5399, ttl_seconds=5400))
+        self.assertFalse(repair_in_flight(ledger, 6951, HEAD, "repair-check", "PR Body", 1000 + 5400, ttl_seconds=5400))
 
     def test_pending_check_waits(self):
         checks = {"PR Body": check("PR Body", "pending"), "quality / TypeScript Types": check("quality / TypeScript Types")}
@@ -611,6 +647,29 @@ Failing checks
                             should_poll = exec_impl.run_cycle(args)
         self.assertEqual(repair_check.call_count, 1)
         self.assertEqual(fake_gh.comments, [("owner/repo", 6602, "@mergifyio queue")])
+        self.assertTrue(should_poll)
+
+    def test_run_cycle_attempts_every_independent_stack_in_one_tick(self):
+        # Direct regression test for the starvation bug: PR #5933's stuck check
+        # used to consume the single action slot every tick, so PR #6951 (a
+        # different, independent stack) was never even attempted. Async
+        # submission means both stacks should get a repair attempt in one tick.
+        args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
+        checks_a = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        checks_b = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        stuck = pr(5933, checks=checks_a, latest=mergify())
+        starved = pr(6951, checks=checks_b, latest=mergify())
+        stacks = (StackGroup("s1", (stuck,)), StackGroup("s2", (starved,)))
+        outcome = RepairOutcome(status="submitted", check_name="PR Body", start_head=HEAD, end_head=HEAD)
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=object()):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=stacks, open_pr_numbers_by_head={})):
+                    with mock.patch.object(exec_impl, "resolve_workflow_for_pr", return_value=None):
+                        with mock.patch.object(AdminBypassRepairer, "repair_check", return_value=outcome) as repair_check:
+                            should_poll = exec_impl.run_cycle(args)
+        self.assertEqual(repair_check.call_count, 2)
+        called_prs = sorted(call.args[0].number for call in repair_check.call_args_list)
+        self.assertEqual(called_prs, [5933, 6951])
         self.assertTrue(should_poll)
 
     def test_run_cycle_waits_while_prerequisite_pr_is_open(self):

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -25,6 +25,7 @@ import mergify_admin_requeue_plan as p
 HEAD = "a" * 40
 REQUIRED = {"build"}
 QUEUE_ONLY_CHECK = "required-fast / Guardrails"
+NOW = 2_000_000_000
 
 
 def check(state, name="build"):
@@ -307,7 +308,7 @@ class BuildStackFacts(PlannerTestCase):
         )
         self.assertEqual(facts.suppressed_failed_checks_by_pr, {10: (QUEUE_ONLY_CHECK, "PR Body")})
         self.assertEqual(facts.blockers_by_pr[10], ())
-        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3, now=NOW)
         self.assertEqual([(action.kind, action.key) for action in actions], [("restore_admin_bypass_label", QUEUE_ONLY_CHECK)])
 
     def test_detects_bottom_and_unaccepted_upper(self):
@@ -331,7 +332,7 @@ class PlanStackActions(PlannerTestCase):
         ledger = ledger or self._ledger()
         stack = stack_or_snapshot if isinstance(stack_or_snapshot, m.StackGroup) else m.StackGroup("s", (stack_or_snapshot,))
         facts = p.build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head or {}, "master")
-        return p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        return p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3, now=NOW)
 
     def test_pending_check_means_wait_do_nothing(self):
         self.assertEqual(self._plan(pr(checks={"build": check("pending")})), ())
@@ -597,7 +598,7 @@ class PlanStackActions(PlannerTestCase):
         )
         facts, ledger = self._facts(stack, open_pr_numbers_by_head={})
         self.assertEqual(facts.bottom_topology.kind, "stale_unowned_base")
-        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3, now=NOW)
         self.assertEqual((actions[0].kind, actions[0].pr_number, actions[0].key), ("retarget_base", 5885, "master"))
         self.assertIn("`pr/babysit-prereq-split`", actions[0].detail)
         self.assertIn("`master`", actions[0].detail)
@@ -620,7 +621,7 @@ class PlanStackActions(PlannerTestCase):
         )
         facts, ledger = self._facts(stack, open_pr_numbers_by_head={"pr/babysit-prereq-split": (7001,)})
         self.assertEqual(facts.bottom_topology.kind, "external_open_base")
-        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3, now=NOW)
         self.assertEqual((actions[0].kind, actions[0].pr_number, actions[0].key), ("comment_blocked", 5885, "external-open-base-pr"))
         self.assertIn("#7001", actions[0].detail)
 
@@ -644,7 +645,7 @@ class PlanStackActions(PlannerTestCase):
         )
         facts, ledger = self._facts(stale_stack, open_pr_numbers_by_head={})
         self.assertEqual(facts.bottom_topology.kind, "stale_unowned_base")
-        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3, now=NOW)
         self.assertEqual([(action.kind, action.pr_number) for action in actions], [("retarget_base", 5885)])
 
     def test_stale_root_failed_check_repairs_before_retarget(self):


### PR DESCRIPTION
Two production bugs converged to strand real PRs (#6951 never picked up
for repair; #5933 retried forever): run_cycle acted on exactly one action
per tick then returned, so a stuck stack starved every other independent
stack in the queue; and mergify_failed_check_actions' cap only fired
after a "repair-evaluated" ledger row that nothing in this codebase ever
writes, so a PR could hit max_repair_attempts and keep retrying anyway.

run_cycle: replace every early `return True` with an `any_progress`
accumulator that keeps iterating remaining stacks/actions, returning
`any_progress or should_poll` at the end. Async submission (previous
slice) is what makes this safe -- each repair attempt is a fast,
bounded IPC call, not a blocking `claude -p` subprocess, so attempting
every stack in one tick no longer risks a multi-minute cron tick.
"submitted" joins "pushed"/"prereq_created" as a progressed outcome.

mergify_failed_check_actions: drop the dead `repair-evaluated` check;
the ledger count alone against max_repair_attempts now caps correctly.

New repair_in_flight(ledger, pr, head_sha, submit_kind, key, now): an
async submission is in flight from its ledger row until a same-kind
"-settled" row (written unconditionally by the `normalize` task's first
action, regardless of outcome) lands with an equal-or-later epoch, or a
5400s TTL elapses (bounding the one case with no settle row: the `repair`
task itself crashing before `normalize` runs). plan_direct_repairs,
plan_bot_thread_repairs, and mergify_failed_check_actions skip an
in-flight blocker without producing an action, so a submitted-but-not-
yet-settled repair isn't resubmitted every tick; plan_bottom_progress
gains a matching guard so it doesn't requeue a bottom PR whose required
check is still actually failing just because this tick's repair kinds
skipped it as in-flight.

Verified against real production ledger state: PR #5933's stuck "PR
Body" check now correctly caps and stops retrying; PR #6951, previously
starved every tick by #5933 consuming the single action slot, now gets
its own repair attempt in the same tick. New regression test
test_run_cycle_attempts_every_independent_stack_in_one_tick asserts both
stacks' repair_check is called once each in a single run_cycle call.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Depends-On: #7041