### PR TITLE
Fix review-unit misclassification: web-invoker-dispatch.ts as routing, not activation-surface

### DIFF
--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -315,6 +315,7 @@ export function classifyReviewUnitsForPath(filePath) {
     || path === 'packages/app/src/api-server.ts'
     || path === 'packages/app/src/workflow-actions.ts'
     || path === 'packages/app/src/workflow-mutation-facade.ts'
+    || path === 'packages/app/src/web/web-invoker-dispatch.ts'
     || path.startsWith('packages/app/src/ipc/')
   ) {
     return ['activation-surface'];

--- a/scripts/test-review-unit-classification.mjs
+++ b/scripts/test-review-unit-classification.mjs
@@ -72,4 +72,30 @@ assert.deepEqual(
   'a manifest-only change carries no review unit of its own',
 );
 
+const activationSurfaceCommandDispatchFiles = [
+  'packages/app/src/api-server.ts',
+  'packages/app/src/workflow-actions.ts',
+  'packages/app/src/web/web-invoker-dispatch.ts',
+];
+for (const path of activationSurfaceCommandDispatchFiles) {
+  assert.deepEqual(
+    classifyReviewUnitsForPath(path),
+    ['activation-surface'],
+    `command-dispatch file should classify as activation-surface: ${path}`,
+  );
+}
+
+const webTransportFiles = [
+  'packages/app/src/web/web-bridge-server.ts',
+  'packages/app/src/web/start-web-surface.ts',
+  'packages/app/src/web/task-graph-snapshot.ts',
+];
+for (const path of webTransportFiles) {
+  assert.deepEqual(
+    classifyReviewUnitsForPath(path),
+    ['routing'],
+    `HTTP transport file under packages/app/src/web/ should stay routing: ${path}`,
+  );
+}
+
 console.log('review-unit classification: all assertions passed');


### PR DESCRIPTION
scripts/review-unit-rules.mjs already has an explicit activation-surface
path check for command-dispatch files (api-server.ts, workflow-actions.ts,
everything under ipc/), but packages/app/src/web/web-invoker-dispatch.ts
plays the same role for the web control surface and had no such check, so
it fell through to the generic packages/app/src/* fallback and landed in
routing instead.

Confirmed live on PR #5933: its PR Body check failed because
web-invoker-dispatch.ts landed in a different bucket than the rest of that
same activation-surface change, alongside a genuine contract-file split
requirement that this fix does not touch.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Depends-On: #7042