### PR TITLE
Add repro proving the web-invoker-dispatch.ts classification fix

### DIFF
--- a/scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs
+++ b/scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs
@@ -1,0 +1,10 @@
+import { classifyReviewUnitsForPath } from '../review-unit-rules.mjs';
+
+const path = 'packages/app/src/web/web-invoker-dispatch.ts';
+const result = classifyReviewUnitsForPath(path);
+console.log(path, '->', JSON.stringify(result));
+if (JSON.stringify(result) !== JSON.stringify(['activation-surface'])) {
+  console.error(`FAIL: expected ["activation-surface"], got ${JSON.stringify(result)}`);
+  process.exit(1);
+}
+process.exit(0);


### PR DESCRIPTION
node scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs fails
before the classifier fix (returns ["routing"]) and passes after (returns
["activation-surface"]).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>