### PR TITLE
[Web-invoker-dispatch activation-surface fix](2) Add repro proving the fix

### DIFF
--- a/scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs
+++ b/scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs
@@ -1,0 +1,10 @@
+import { classifyReviewUnitsForPath } from '../review-unit-rules.mjs';
+
+const path = 'packages/app/src/web/web-invoker-dispatch.ts';
+const result = classifyReviewUnitsForPath(path);
+console.log(path, '->', JSON.stringify(result));
+if (JSON.stringify(result) !== JSON.stringify(['activation-surface'])) {
+  console.error(`FAIL: expected ["activation-surface"], got ${JSON.stringify(result)}`);
+  process.exit(1);
+}
+process.exit(0);


### PR DESCRIPTION
## Summary

Adds a shared, deterministic repro proving the previous slice's classifier fix.

`node scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs` calls the classifier directly on the one path that was fixed and asserts the exact expected bucket.

It fails before that fix (wrong bucket) and passes after it (right bucket). No production code changes here.

## Review Claim

Approve one new, isolated repro file that proves the previous slice's classifier fix.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The file is new, calls only the existing classifier function, and asserts its output. It changes no production behavior on its own.

## Slice Rationale

Kept separate from the classifier fix itself: this repo's own review-unit rule forbids mixing a `tooling-policy` file with a `scripts/repro/` (`proof`) file in one PR.

## Non-goals

No production source changes. No new assertions beyond the one path this stack's fix touched.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/repro/repro-review-unit-web-dispatch-misclassified.mjs` (exits 0)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`.
- Post-revert steps: None.
- Data migration? No.

</details>
