### PR TITLE
[Admin-bypass infra resilience](1) Stop counting SSH/OAuth infra crashes against the retry cap

### DIFF
--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -36,7 +36,8 @@ fail=0
 
 echo "== stage 1: unit tests =="
 if python3 -m unittest scripts/test_mergify_admin_requeue.py scripts/test_mergify_admin_requeue_model.py \
-    scripts/test_mergify_admin_requeue_plan.py scripts/test_mergify_admin_requeue_snapshot.py; then
+    scripts/test_mergify_admin_requeue_plan.py scripts/test_mergify_admin_requeue_snapshot.py \
+    scripts/test_mergify_admin_requeue_infra_signal.py; then
   echo "PASS: unit tests"
 else
   echo "FAIL: unit tests"

--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from .mergify_admin_requeue_headless_shell import run_headless
+    from .mergify_admin_requeue_model import MergifyQueueEvent, PrSnapshot
+except ImportError:
+    from mergify_admin_requeue_headless_shell import run_headless
+    from mergify_admin_requeue_model import MergifyQueueEvent, PrSnapshot
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(value: str, *, max_len: int = 40) -> str:
+    slug = _SLUG_RE.sub("-", value.lower()).strip("-")
+    return (slug or "check")[:max_len].strip("-") or "check"
+
+
+def _yaml_str(value: str) -> str:
+    # JSON string encoding is a valid YAML flow scalar and, unlike naive shell
+    # quoting, correctly escapes quotes/colons/backslashes in PR titles/branch
+    # names without a second layer of ad-hoc stripping.
+    return json.dumps(value)
+
+
+def _indent_block(text: str, spaces: int) -> str:
+    prefix = " " * spaces
+    lines = text.splitlines() or [""]
+    return "\n".join(prefix + line if line else prefix.rstrip() for line in lines)
+
+
+def _repo_url(repo: str) -> str:
+    return f"https://github.com/{repo}.git"
+
+
+@dataclass(frozen=True)
+class AsyncRepairPlan:
+    plan_name: str
+    yaml_text: str
+
+
+def _write_plan_header(*, name: str, base_branch: str, repo: str) -> str:
+    return (
+        f"name: {name}\n"
+        "onFinish: none\n"
+        "mergeMode: manual\n"
+        f"repoUrl: {_yaml_str(_repo_url(repo))}\n"
+        f"baseBranch: {_yaml_str(base_branch)}\n"
+        "tasks:\n"
+    )
+
+
+def _repair_task_yaml(*, description: str, prompt: str) -> str:
+    return (
+        "  - id: repair\n"
+        f"    description: {_yaml_str(description)}\n"
+        "    prompt: |\n"
+        f"{_indent_block(prompt, 6)}\n"
+    )
+
+
+def _safe_push_task_yaml(
+    *,
+    task_id: str,
+    description: str,
+    dependencies: str,
+    head_ref: str,
+    start_head: str,
+    state_file: Path,
+    json_kind: str,
+    pr_number: int,
+    json_key: str,
+    skip_if_prereq: bool,
+) -> str:
+    skip_guard = (
+        "if [ -f .invoker-repair-prereq-created ]; then\n"
+        "  echo \"prerequisite PR already published this attempt; nothing to push\"\n"
+        "  exit 0\n"
+        "fi\n"
+        if skip_if_prereq
+        else ""
+    )
+    command = (
+        "set -euo pipefail\n"
+        f"{skip_guard}"
+        "python3 scripts/pr_worker_safe_push.py \\\n"
+        f"  --branch {_shlex(head_ref)} --expected-head {_shlex(start_head)} --cwd . \\\n"
+        f"  --record-json-ledger {_shlex(str(state_file))} \\\n"
+        f"  --json-kind {_shlex(json_kind)} --json-pr {_shlex(str(pr_number))} \\\n"
+        f"  --json-head-sha {_shlex(start_head)} --json-key {_shlex(json_key)}\n"
+    )
+    return (
+        f"  - id: {task_id}\n"
+        f"    description: {_yaml_str(description)}\n"
+        f"    dependencies: [{dependencies}]\n"
+        "    command: |\n"
+        f"{_indent_block(command, 6)}\n"
+    )
+
+
+def _shlex(value: str) -> str:
+    # Minimal POSIX single-quote wrap; values here are SHAs, branch names, and
+    # our own ledger paths/kinds -- none contain single quotes in practice, but
+    # this keeps the generated command block safe regardless.
+    return "'" + value.replace("'", "'\\''") + "'"
+
+
+_RESTRUCTURE_ESCAPE_HATCH = (
+    "If the real fix requires restructuring this PR instead of editing it in place -- for example, splitting "
+    "unrelated files into their own PR because they can't ship together -- do not force that into a single "
+    "local commit here. Instead, submit an Invoker plan to do the restructuring, the same way a human would "
+    "via the plan-to-invoker skill (see skills/plan-to-invoker/SKILL.md and ./submit-plan.sh). Then make no "
+    "commit in this checkout and exit 0.\n"
+)
+
+
+def build_repair_check_plan(
+    pr: PrSnapshot,
+    check_name: str,
+    *,
+    repo: str,
+    details_url: str,
+    log_path: str,
+    queue_only: bool,
+    queue_pr_number: int,
+    latest: MergifyQueueEvent | None,
+    start_head: str,
+    state_file: Path,
+) -> AsyncRepairPlan:
+    name = f"admin-bypass-repair-check-pr-{pr.number}-{_slugify(check_name)}-{start_head[:7]}"
+    prompt = (
+        "This PR's CI check is failing. Diagnose why it is failing, then fix it. Add or "
+        "update a repro if the failure is reproducible.\n\n"
+        "If a code change fixes it: make the change in this checkout. Commit locally if "
+        "needed, do not push. If local proof shows the check is already green on the "
+        "current head, make no commit and exit 0.\n\n"
+        f"{_RESTRUCTURE_ESCAPE_HATCH}\n"
+        f"Repair the existing pull request #{pr.number} ({json.dumps(pr.title)}) on {repo}.\n"
+        f"PR URL: {pr.url}\n"
+        f"Head branch: {pr.head_ref_name} (at {start_head}), base branch: {pr.base_ref_name}\n\n"
+        "Work directly on its branch:\n"
+        f"  git fetch origin {pr.head_ref_name} && git checkout {pr.head_ref_name}\n\n"
+        f"Failed check: {check_name}\n"
+        f"Details URL: {details_url}\n"
+        f"Job log path: {log_path}\n"
+        f"Latest Mergify event: {json.dumps(dataclasses.asdict(latest) if latest else None, sort_keys=True)}\n"
+    )
+    if queue_only:
+        prompt += f"Queue draft PR: #{queue_pr_number}\nRepair the real PR head, using only evidence from the queue draft failure.\n"
+
+    yaml_text = _write_plan_header(name=name, base_branch=pr.base_ref_name, repo=repo)
+    yaml_text += _repair_task_yaml(description=f"Repair PR #{pr.number} (failed check {check_name})", prompt=prompt)
+    normalize_command = (
+        "set -euo pipefail\n"
+        "python3 scripts/mergify_admin_requeue_repair_normalize.py \\\n"
+        f"  --repo {_shlex(repo)} --pr {pr.number} --check {_shlex(check_name)} \\\n"
+        f"  --start-head {_shlex(start_head)} --base {_shlex(pr.base_ref_name)} --trunk master\n"
+    )
+    yaml_text += (
+        "  - id: normalize\n"
+        f"    description: {_yaml_str(f'Normalize PR #{pr.number} repair commit; split a prerequisite PR if required')}\n"
+        "    dependencies: [repair]\n"
+        "    command: |\n"
+        f"{_indent_block(normalize_command, 6)}\n"
+    )
+    yaml_text += _safe_push_task_yaml(
+        task_id="safe-push",
+        description=f"Safely push PR #{pr.number} only if its head did not move and no prerequisite was split",
+        dependencies="normalize",
+        head_ref=pr.head_ref_name,
+        start_head=start_head,
+        state_file=state_file,
+        json_kind="repair-check-settled",
+        pr_number=pr.number,
+        json_key=check_name,
+        skip_if_prereq=True,
+    )
+    return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
+
+
+def build_repair_conflict_plan(
+    pr: PrSnapshot,
+    reason: str,
+    *,
+    repo: str,
+    start_head: str,
+    state_file: Path,
+) -> AsyncRepairPlan:
+    name = f"admin-bypass-repair-conflict-pr-{pr.number}-{start_head[:7]}"
+    prompt = (
+        "This PR has a merge conflict blocking it from merging. Diagnose why, then fix it.\n\n"
+        "If rebasing the head branch onto its base branch (preserving the PR's intended changes) resolves it: "
+        "do that, run the narrow proof for the conflict resolution, then commit locally. Do not push.\n\n"
+        "If the real fix requires restructuring this PR instead of a straightforward rebase, do not force that "
+        "into a single local commit here. Instead, submit an Invoker plan to do the restructuring, the same way "
+        "a human would via the plan-to-invoker skill (see skills/plan-to-invoker/SKILL.md and ./submit-plan.sh). "
+        "Then make no commit in this checkout and exit 0.\n\n"
+        "If the PR is already closed or merged, or the head branch no longer exists, make no commit and exit 0.\n\n"
+        f"PR: #{pr.number}\nBase branch: {pr.base_ref_name}\nHead branch: {pr.head_ref_name}\n"
+        f"Head SHA: {start_head}\nReason: {reason}\n"
+    )
+    yaml_text = _write_plan_header(name=name, base_branch=pr.base_ref_name, repo=repo)
+    yaml_text += _repair_task_yaml(description=f"Repair merge conflict on PR #{pr.number}", prompt=prompt)
+    yaml_text += _safe_push_task_yaml(
+        task_id="safe-push",
+        description=f"Safely push PR #{pr.number} only if its head did not move",
+        dependencies="repair",
+        head_ref=pr.head_ref_name,
+        start_head=start_head,
+        state_file=state_file,
+        json_kind="conflict-repair-settled",
+        pr_number=pr.number,
+        json_key=f"conflict:{pr.number}",
+        skip_if_prereq=False,
+    )
+    return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
+
+
+def build_repair_bot_thread_plan(
+    pr: PrSnapshot,
+    thread_id: str,
+    *,
+    repo: str,
+    start_head: str,
+    state_file: Path,
+) -> AsyncRepairPlan:
+    name = f"admin-bypass-repair-bot-thread-pr-{pr.number}-{start_head[:7]}"
+    prompt = (
+        f"Resolve the unresolved review thread {thread_id}. Address the reviewer's feedback with "
+        "real code changes, run the narrow proof for the fix, then commit locally. Do not push. "
+        "If the thread is already resolved, or the PR is closed or merged, make no commit and exit 0.\n\n"
+        f"PR: #{pr.number}\nHead branch: {pr.head_ref_name}\nHead SHA: {start_head}\nThread: {thread_id}\n"
+    )
+    yaml_text = _write_plan_header(name=name, base_branch=pr.base_ref_name, repo=repo)
+    yaml_text += _repair_task_yaml(description=f"Resolve bot review thread on PR #{pr.number}", prompt=prompt)
+    yaml_text += _safe_push_task_yaml(
+        task_id="safe-push",
+        description=f"Safely push PR #{pr.number} only if its head did not move",
+        dependencies="repair",
+        head_ref=pr.head_ref_name,
+        start_head=start_head,
+        state_file=state_file,
+        json_kind="repair-bot-thread-settled",
+        pr_number=pr.number,
+        json_key=thread_id,
+        skip_if_prereq=False,
+    )
+    return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
+
+
+def submit_async_repair_plan(plan: AsyncRepairPlan) -> None:
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", suffix=".yaml", prefix=f"{plan.plan_name}-", delete=False
+    ) as handle:
+        handle.write(plan.yaml_text)
+        plan_path = Path(handle.name)
+    try:
+        completed = run_headless('headless_mutation --no-track run "$2"', str(plan_path))
+        if completed.returncode != 0:
+            raise RuntimeError(
+                f"submit_async_repair_plan failed for {plan.plan_name}: "
+                f"{completed.stderr.strip() or completed.stdout.strip()}"
+            )
+    finally:
+        plan_path.unlink(missing_ok=True)

--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -25,6 +25,22 @@ def _slugify(value: str, *, max_len: int = 40) -> str:
     return (slug or "check")[:max_len].strip("-") or "check"
 
 
+# Shared with mergify_admin_requeue_infra_signal.py, which needs the exact
+# plan_name a build_repair_*_plan call below already produced, to look up that
+# same submission's Invoker workflow by name before deciding whether to submit
+# another one.
+def repair_check_plan_name(pr_number: int, check_name: str, start_head: str) -> str:
+    return f"admin-bypass-repair-check-pr-{pr_number}-{_slugify(check_name)}-{start_head[:7]}"
+
+
+def repair_conflict_plan_name(pr_number: int, start_head: str) -> str:
+    return f"admin-bypass-repair-conflict-pr-{pr_number}-{start_head[:7]}"
+
+
+def repair_bot_thread_plan_name(pr_number: int, start_head: str) -> str:
+    return f"admin-bypass-repair-bot-thread-pr-{pr_number}-{start_head[:7]}"
+
+
 def _yaml_str(value: str) -> str:
     # JSON string encoding is a valid YAML flow scalar and, unlike naive shell
     # quoting, correctly escapes quotes/colons/backslashes in PR titles/branch
@@ -136,7 +152,7 @@ def build_repair_check_plan(
     start_head: str,
     state_file: Path,
 ) -> AsyncRepairPlan:
-    name = f"admin-bypass-repair-check-pr-{pr.number}-{_slugify(check_name)}-{start_head[:7]}"
+    name = repair_check_plan_name(pr.number, check_name, start_head)
     prompt = (
         "This PR's CI check is failing. Diagnose why it is failing, then fix it. Add or "
         "update a repro if the failure is reproducible.\n\n"
@@ -195,7 +211,7 @@ def build_repair_conflict_plan(
     start_head: str,
     state_file: Path,
 ) -> AsyncRepairPlan:
-    name = f"admin-bypass-repair-conflict-pr-{pr.number}-{start_head[:7]}"
+    name = repair_conflict_plan_name(pr.number, start_head)
     prompt = (
         "This PR has a merge conflict blocking it from merging. Diagnose why, then fix it.\n\n"
         "If rebasing the head branch onto its base branch (preserving the PR's intended changes) resolves it: "
@@ -233,7 +249,7 @@ def build_repair_bot_thread_plan(
     start_head: str,
     state_file: Path,
 ) -> AsyncRepairPlan:
-    name = f"admin-bypass-repair-bot-thread-pr-{pr.number}-{start_head[:7]}"
+    name = repair_bot_thread_plan_name(pr.number, start_head)
     prompt = (
         f"Resolve the unresolved review thread {thread_id}. Address the reviewer's feedback with "
         "real code changes, run the narrow proof for the fix, then commit locally. Do not push. "

--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -98,6 +98,7 @@ def run_cycle(args: argparse.Namespace) -> bool:
         candidate_pr_numbers=sorted(pr_by_number),
     )
     should_poll = False
+    any_progress = False
     open_pr_numbers = set(pr_by_number)
     for stack in stacks:
         plan = plan_stack_execution(
@@ -138,7 +139,7 @@ def run_cycle(args: argparse.Namespace) -> bool:
                     if action.key.startswith("bot_review_thread:"):
                         thread_id = action.key.split(":", 1)[1]
                         outcome = repairer.repair_bot_thread(pr, thread_id, now)
-                        progressed = outcome.status in {"pushed", "prereq_created"}
+                        progressed = outcome.status in {"pushed", "prereq_created", "submitted"}
                     else:
                         check_name = action.key
                         workflow_id = resolve_workflow_for_pr(action.pr_number)
@@ -148,7 +149,7 @@ def run_cycle(args: argparse.Namespace) -> bool:
                             progressed = True
                         else:
                             outcome = repairer.repair_check(pr, check_name, now)
-                            progressed = outcome.status in {"pushed", "prereq_created"}
+                            progressed = outcome.status in {"pushed", "prereq_created", "submitted"}
                 except Exception as exc:
                     logger.trace(
                         "admin-bypass-repair-attempt-failed",
@@ -161,8 +162,9 @@ def run_cycle(args: argparse.Namespace) -> bool:
                     should_poll = True
                     continue
                 if progressed:
-                    return True
-                should_poll = True
+                    any_progress = True
+                else:
+                    should_poll = True
                 continue
             elif action.kind == "repair_conflict":
                 try:
@@ -173,7 +175,7 @@ def run_cycle(args: argparse.Namespace) -> bool:
                         progressed = True
                     else:
                         outcome = repairer.repair_conflict(pr, action.detail, now)
-                        progressed = outcome.status in {"pushed", "prereq_created"}
+                        progressed = outcome.status in {"pushed", "prereq_created", "submitted"}
                 except Exception as exc:
                     logger.trace(
                         "admin-bypass-repair-attempt-failed",
@@ -186,8 +188,9 @@ def run_cycle(args: argparse.Namespace) -> bool:
                     should_poll = True
                     continue
                 if progressed:
-                    return True
-                should_poll = True
+                    any_progress = True
+                else:
+                    should_poll = True
                 continue
             else:
                 performed = executor.execute(action, pr, now)
@@ -215,11 +218,11 @@ def run_cycle(args: argparse.Namespace) -> bool:
                             pr_number=pr.number,
                             check_name=queue_only_noop_check,
                         )
-            if action.kind not in {"comment_blocked", "comment_admin_bypass_nudge"}:
-                return True
+                if action.kind not in {"comment_blocked", "comment_admin_bypass_nudge"}:
+                    any_progress = True
     if not stacks:
         logger.trace("admin-bypass-scan-empty")
-    return should_poll
+    return any_progress or should_poll
 
 
 def run_once(args: argparse.Namespace) -> int:

--- a/scripts/mergify_admin_requeue_headless_shell.py
+++ b/scripts/mergify_admin_requeue_headless_shell.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HEADLESS_LIB = REPO_ROOT / "scripts" / "headless-lib.sh"
+
+# Sources scripts/headless-lib.sh directly (never scripts/cron-pr-lib.sh): by the
+# time any caller of this module runs, cron-pr-lib.sh's cron_lock is already held
+# by the calling bash script (scripts/cron-pr-admin-bypass-land.sh), so re-sourcing
+# it and calling cron_lock again would self-deadlock or silently no-op.
+_SOURCE_HEADLESS_LIB = 'set -euo pipefail\nsource "$1"\n'
+
+DEFAULT_TIMEOUT_SECONDS = 30
+
+
+def run_headless(command: str, *extra_args: str, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS) -> subprocess.CompletedProcess[str]:
+    args = ["bash", "-c", _SOURCE_HEADLESS_LIB + command, "bash", str(HEADLESS_LIB), *extra_args]
+    try:
+        return subprocess.run(
+            args,
+            cwd=str(REPO_ROOT),
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired:
+        # A wedged owner-IPC connection (no reachable owner, a hung socket) must
+        # never block a cron tick indefinitely -- surface it as an ordinary
+        # non-zero CompletedProcess so every caller's existing "returncode != 0"
+        # handling raises a clear RuntimeError instead of hanging the process.
+        return subprocess.CompletedProcess(
+            args, returncode=124, stdout="", stderr=f"timed out after {timeout_seconds}s",
+        )

--- a/scripts/mergify_admin_requeue_infra_signal.py
+++ b/scripts/mergify_admin_requeue_infra_signal.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+
+try:
+    from .mergify_admin_requeue_headless_shell import run_headless
+except ImportError:
+    from mergify_admin_requeue_headless_shell import run_headless
+
+# Captured verbatim from real SshExecutor crashes seen on PRs #5933, #6976,
+# #7012, and #7019 during the same admin-bypass cron tick: the coding agent
+# never launches, so no amount of retrying can produce a different repair
+# result until an operator refreshes that SSH pool member's credentials.
+SSH_OAUTH_INFRA_SIGNATURE = "Failed to authenticate: OAuth session expired and could not be refreshed"
+
+
+def find_latest_workflow_id(plan_name: str, *, run_headless_fn=run_headless) -> str | None:
+    completed = run_headless_fn('headless_query query workflows --output json')
+    if completed.returncode != 0:
+        return None
+    try:
+        workflows = json.loads(completed.stdout)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    matches = [w for w in workflows if isinstance(w, dict) and w.get("name") == plan_name]
+    if not matches:
+        return None
+    matches.sort(key=lambda w: str(w.get("createdAt", "")))
+    return matches[-1].get("id")
+
+
+def repair_task_crashed_on_infra(plan_name: str, *, run_headless_fn=run_headless) -> bool:
+    """True when plan_name's most recent Invoker workflow's `repair` task
+    crashed with the known SSH/OAuth infra signature -- a submission that
+    never gave the coding agent a chance to touch the PR at all."""
+    workflow_id = find_latest_workflow_id(plan_name, run_headless_fn=run_headless_fn)
+    if workflow_id is None:
+        return False
+    completed = run_headless_fn('headless_query query task-output "$2"', f"{workflow_id}/repair")
+    return completed.returncode == 0 and SSH_OAUTH_INFRA_SIGNATURE in completed.stdout

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import Collection, Literal, Mapping
 
@@ -143,6 +144,39 @@ def cap_action(pr: PrSnapshot, blocker: Blocker, detail: str) -> Action:
     return Action("comment_blocked", pr.number, "capped", f"{detail}. The retry cap was reached for current head {pr.head_ref_oid}.")
 
 
+# An async repair submission (repairer.py's ledger.record(submit_kind, ...), written
+# only after a successful `headless_mutation run` submission) is "in flight" until a
+# same-kind "-settled" row lands with an equal-or-later epoch. The submitted plan's
+# `normalize` task writes that settle row unconditionally as its first action, so
+# reaching `normalize` at all -- pushed, no-op, prereq-created, or still-invalid --
+# frees this PR/blocker for its next tick. Only a crash before `normalize` ever runs
+# (the `repair` task itself dying) leaves no settle row; the TTL bounds that case so
+# a single wedged attempt can't block this (pr, headSha, blockerKey) forever.
+REPAIR_IN_FLIGHT_TTL_SECONDS = 5400
+
+
+def repair_in_flight(
+    ledger: Ledger,
+    pr_number: int,
+    head_sha: str,
+    submit_kind: str,
+    key: str,
+    now: int,
+    *,
+    ttl_seconds: int = REPAIR_IN_FLIGHT_TTL_SECONDS,
+) -> bool:
+    submitted = ledger.latest(submit_kind, pr_number, head_sha, key)
+    if submitted is None:
+        return False
+    submitted_epoch = int(submitted.get("epoch", 0) or 0)
+    settled = ledger.latest(f"{submit_kind}-settled", pr_number, head_sha, key)
+    if settled is not None and int(settled.get("epoch", 0) or 0) >= submitted_epoch:
+        return False
+    if now - submitted_epoch >= ttl_seconds:
+        return False
+    return True
+
+
 def mergify_condition_map(event: MergifyQueueEvent | None) -> dict[str, str]:
     return dict(event.condition_states) if event else {}
 
@@ -181,6 +215,8 @@ def effective_blockers(
 def mergify_failed_check_actions(
     pr: PrSnapshot,
     ledger: Ledger,
+    max_repair_attempts: int,
+    now: int,
     suppressed_failed_checks: Collection[str] = (),
 ) -> tuple[Action, ...]:
     suppressed = set(suppressed_failed_checks)
@@ -190,8 +226,10 @@ def mergify_failed_check_actions(
     for name in latest.failing_checks:
         if name in suppressed:
             continue
-        if ledger.count("repair-check", pr.number, pr.head_ref_oid, name) >= 3:
+        if ledger.count("repair-check", pr.number, pr.head_ref_oid, name) >= max_repair_attempts:
             return (cap_action(pr, Blocker(name, "failed_check", pr.number, f"Mergify queue check failed: {name}"), f"Mergify queue check failed: {name}"),)
+        if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-check", name, now):
+            continue
         return (Action("repair_check", pr.number, name, f"Mergify queue check failed: {name}"),)
     return ()
 
@@ -578,6 +616,25 @@ def _bottom_has_pending_or_human_blocker(facts: StackFacts) -> bool:
     )
 
 
+# Kinds plan_direct_repairs/plan_bot_thread_repairs/mergify_failed_check_actions
+# normally turn into a repair action. When the one blocking such a kind is
+# in-flight, those planners skip it without producing an action -- correct for
+# "don't resubmit," but the blocker is still real. Without this check, the
+# ladder would fall through to plan_bottom_progress and requeue a PR whose
+# required check is still actually failing, just because this tick didn't
+# resubmit a repair for it.
+REPAIRABLE_BLOCKER_KINDS = frozenset({"failed_check", "conflict", "bot_review_thread", "outdated_bot_review_thread"})
+
+
+def _bottom_has_repairable_blocker(facts: StackFacts) -> bool:
+    if not facts.bottom:
+        return False
+    return any(
+        blocker.pr_number == facts.bottom.number and blocker.kind in REPAIRABLE_BLOCKER_KINDS
+        for blocker in facts.all_blockers
+    )
+
+
 def _candidate_prs(facts: StackFacts, pr_numbers: Collection[int] | None = None) -> tuple[PrSnapshot, ...]:
     if pr_numbers is None:
         return facts.stack.prs
@@ -589,15 +646,17 @@ def plan_mergify_queue_repairs(
     facts: StackFacts,
     ledger: Ledger,
     max_repair_attempts: int,
+    now: int,
     pr_numbers: Collection[int] | None = None,
 ) -> Action | None:
-    del max_repair_attempts
     for pr in _candidate_prs(facts, pr_numbers):
         if any(blocker.kind == "human_decision" for blocker in facts.blockers_by_pr[pr.number]):
             continue
         if facts.upper_stack_needs_acceptance and facts.bottom and pr.number == facts.bottom.number:
             continue
-        actions = mergify_failed_check_actions(pr, ledger, facts.suppressed_failed_checks_by_pr.get(pr.number, ()))
+        actions = mergify_failed_check_actions(
+            pr, ledger, max_repair_attempts, now, facts.suppressed_failed_checks_by_pr.get(pr.number, ()),
+        )
         if actions:
             return actions[0]
     return None
@@ -607,6 +666,7 @@ def plan_direct_repairs(
     facts: StackFacts,
     ledger: Ledger,
     max_repair_attempts: int,
+    now: int,
     pr_numbers: Collection[int] | None = None,
 ) -> Action | None:
     for pr in _candidate_prs(facts, pr_numbers):
@@ -617,11 +677,15 @@ def plan_direct_repairs(
                 key = f"conflict:{pr.number}"
                 if ledger.count("conflict-repair", pr.number, pr.head_ref_oid, key) >= max_repair_attempts:
                     return cap_action(pr, blocker, blocker.detail)
+                if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "conflict-repair", key, now):
+                    continue
                 return Action("repair_conflict", pr.number, key, blocker.detail)
             if blocker.kind == "failed_check":
                 attempts = ledger.count("repair-check", pr.number, pr.head_ref_oid, blocker.key)
-                if attempts >= max_repair_attempts and ledger.latest("repair-evaluated", pr.number, pr.head_ref_oid, blocker.key) is not None:
+                if attempts >= max_repair_attempts:
                     return cap_action(pr, blocker, blocker.detail)
+                if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-check", blocker.key, now):
+                    continue
                 return Action("repair_check", pr.number, blocker.key, blocker.detail)
     return None
 
@@ -630,6 +694,7 @@ def plan_bot_thread_repairs(
     facts: StackFacts,
     ledger: Ledger,
     max_repair_attempts: int,
+    now: int,
     pr_numbers: Collection[int] | None = None,
 ) -> Action | None:
     for pr in _candidate_prs(facts, pr_numbers):
@@ -644,6 +709,8 @@ def plan_bot_thread_repairs(
                 return Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail)
             if ledger.count("repair-bot-thread", pr.number, pr.head_ref_oid, blocker.key) >= max_repair_attempts:
                 return cap_action(pr, blocker, blocker.detail)
+            if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-bot-thread", blocker.key, now):
+                continue
             return Action("repair_check", pr.number, "bot_review_thread:" + blocker.key, blocker.detail)
     return None
 
@@ -760,33 +827,34 @@ def plan_actions_from_facts(
     ledger: Ledger,
     max_requeue_attempts: int,
     max_repair_attempts: int,
+    now: int,
 ) -> tuple[Action, ...]:
     if facts.bottom:
         bottom_pr_numbers = (facts.bottom.number,)
-        action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts, bottom_pr_numbers)
+        action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts, now, bottom_pr_numbers)
         if action is not None:
             return (action,)
-        action = plan_direct_repairs(facts, ledger, max_repair_attempts, bottom_pr_numbers)
+        action = plan_direct_repairs(facts, ledger, max_repair_attempts, now, bottom_pr_numbers)
         if action is not None:
             return (action,)
-        action = plan_bot_thread_repairs(facts, ledger, max_repair_attempts, bottom_pr_numbers)
+        action = plan_bot_thread_repairs(facts, ledger, max_repair_attempts, now, bottom_pr_numbers)
         if action is not None:
             return (action,)
         action = plan_hard_blockers(facts, ledger, bottom_pr_numbers)
         if action is not None:
             return (action,)
-        if _bottom_has_pending_or_human_blocker(facts):
+        if _bottom_has_pending_or_human_blocker(facts) or _bottom_has_repairable_blocker(facts):
             return ()
         action = plan_bottom_progress(facts, ledger, max_requeue_attempts)
         if action is not None:
             return (action,)
-    action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts)
+    action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts, now)
     if action is not None:
         return (action,)
-    action = plan_direct_repairs(facts, ledger, max_repair_attempts)
+    action = plan_direct_repairs(facts, ledger, max_repair_attempts, now)
     if action is not None:
         return (action,)
-    action = plan_bot_thread_repairs(facts, ledger, max_repair_attempts)
+    action = plan_bot_thread_repairs(facts, ledger, max_repair_attempts, now)
     if action is not None:
         return (action,)
     action = plan_hard_blockers(facts, ledger)
@@ -814,7 +882,6 @@ def plan_stack_actions(
     suppressed_failed_checks_by_pr: Mapping[int, Collection[str]] | None = None,
     open_pr_numbers_by_head: Mapping[str, Collection[int]] | None = None,
 ) -> tuple[Action, ...]:
-    del now_epoch
     del suppressed_failed_checks_by_pr
     facts = build_stack_facts(
         stack,
@@ -824,7 +891,7 @@ def plan_stack_actions(
         open_pr_numbers_by_head=open_pr_numbers_by_head or {},
         trunk=TRUNK,
     )
-    return plan_actions_from_facts(facts, ledger, max_requeue_attempts, max_repair_attempts)
+    return plan_actions_from_facts(facts, ledger, max_requeue_attempts, max_repair_attempts, now_epoch)
 
 
 def plan_stack_execution(
@@ -838,7 +905,6 @@ def plan_stack_execution(
     max_repair_attempts: int = 3,
     trunk: str = TRUNK,
 ) -> StackExecutionPlan:
-    del now_epoch
     facts = build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head, trunk)
     summary = summarize_stack(facts)
     if facts.prereq_status and facts.prereq_status.is_open:
@@ -849,7 +915,7 @@ def plan_stack_execution(
             prereq_status=facts.prereq_status,
             queue_only_noop_check=facts.queue_only_noop_check,
         )
-    actions = plan_actions_from_facts(facts, ledger, max_requeue_attempts, max_repair_attempts)
+    actions = plan_actions_from_facts(facts, ledger, max_requeue_attempts, max_repair_attempts, now_epoch)
     if actions:
         return StackExecutionPlan(
             summary=summary,

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -29,6 +29,27 @@ except ImportError:
         StackGroup,
     )
 
+try:
+    from .mergify_admin_requeue_async_repair import (
+        repair_bot_thread_plan_name,
+        repair_check_plan_name,
+        repair_conflict_plan_name,
+    )
+    from .mergify_admin_requeue_infra_signal import (
+        SSH_OAUTH_INFRA_SIGNATURE,
+        repair_task_crashed_on_infra,
+    )
+except ImportError:
+    from mergify_admin_requeue_async_repair import (
+        repair_bot_thread_plan_name,
+        repair_check_plan_name,
+        repair_conflict_plan_name,
+    )
+    from mergify_admin_requeue_infra_signal import (
+        SSH_OAUTH_INFRA_SIGNATURE,
+        repair_task_crashed_on_infra,
+    )
+
 
 TRUNK = "master"
 
@@ -144,6 +165,45 @@ def cap_action(pr: PrSnapshot, blocker: Blocker, detail: str) -> Action:
     return Action("comment_blocked", pr.number, "capped", f"{detail}. The retry cap was reached for current head {pr.head_ref_oid}.")
 
 
+def infra_blocked_action(pr: PrSnapshot, key: str, detail: str, reason: str) -> Action:
+    return Action(
+        "comment_blocked",
+        pr.number,
+        f"infra-blocked:{key}",
+        f'{detail}. Repeated repair attempts crashed with an SSH execution-pool infra failure '
+        f'("{reason}"), not a problem with this PR\'s content. An operator needs to refresh that '
+        f'pool member\'s credentials before this can retry.',
+    )
+
+
+# Distinct from repair_in_flight's TTL-bounded "still might be running" check:
+# once the submitted attempt's own Invoker workflow already shows the crash
+# text below, there is nothing to wait out -- the coding agent never launched,
+# so no further wait changes the outcome. Checked before repair_in_flight so a
+# confirmed infra crash is reported accurately (and does not keep silently
+# eating retry-cap attempts) well before the TTL would otherwise expire.
+def repair_crash_reason(
+    ledger: Ledger,
+    pr_number: int,
+    head_sha: str,
+    submit_kind: str,
+    key: str,
+    plan_name: str,
+) -> str | None:
+    submitted = ledger.latest(submit_kind, pr_number, head_sha, key)
+    if submitted is None:
+        return None
+    settled = ledger.latest(f"{submit_kind}-settled", pr_number, head_sha, key)
+    if settled is not None and int(settled.get("epoch", 0) or 0) >= int(submitted.get("epoch", 0) or 0):
+        return None
+    # Named call (not a default-bound parameter) so tests can patch this
+    # module's `repair_task_crashed_on_infra` name directly instead of the
+    # real one, which shells out to a live Invoker instance.
+    if repair_task_crashed_on_infra(plan_name):
+        return SSH_OAUTH_INFRA_SIGNATURE
+    return None
+
+
 # An async repair submission (repairer.py's ledger.record(submit_kind, ...), written
 # only after a successful `headless_mutation run` submission) is "in flight" until a
 # same-kind "-settled" row lands with an equal-or-later epoch. The submitted plan's
@@ -226,11 +286,18 @@ def mergify_failed_check_actions(
     for name in latest.failing_checks:
         if name in suppressed:
             continue
+        detail = f"Mergify queue check failed: {name}"
         if ledger.count("repair-check", pr.number, pr.head_ref_oid, name) >= max_repair_attempts:
-            return (cap_action(pr, Blocker(name, "failed_check", pr.number, f"Mergify queue check failed: {name}"), f"Mergify queue check failed: {name}"),)
+            return (cap_action(pr, Blocker(name, "failed_check", pr.number, detail), detail),)
+        crash_reason = repair_crash_reason(
+            ledger, pr.number, pr.head_ref_oid, "repair-check", name,
+            repair_check_plan_name(pr.number, name, pr.head_ref_oid),
+        )
+        if crash_reason is not None:
+            return (infra_blocked_action(pr, name, detail, crash_reason),)
         if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-check", name, now):
             continue
-        return (Action("repair_check", pr.number, name, f"Mergify queue check failed: {name}"),)
+        return (Action("repair_check", pr.number, name, detail),)
     return ()
 
 
@@ -677,6 +744,12 @@ def plan_direct_repairs(
                 key = f"conflict:{pr.number}"
                 if ledger.count("conflict-repair", pr.number, pr.head_ref_oid, key) >= max_repair_attempts:
                     return cap_action(pr, blocker, blocker.detail)
+                crash_reason = repair_crash_reason(
+                    ledger, pr.number, pr.head_ref_oid, "conflict-repair", key,
+                    repair_conflict_plan_name(pr.number, pr.head_ref_oid),
+                )
+                if crash_reason is not None:
+                    return infra_blocked_action(pr, key, blocker.detail, crash_reason)
                 if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "conflict-repair", key, now):
                     continue
                 return Action("repair_conflict", pr.number, key, blocker.detail)
@@ -684,6 +757,12 @@ def plan_direct_repairs(
                 attempts = ledger.count("repair-check", pr.number, pr.head_ref_oid, blocker.key)
                 if attempts >= max_repair_attempts:
                     return cap_action(pr, blocker, blocker.detail)
+                crash_reason = repair_crash_reason(
+                    ledger, pr.number, pr.head_ref_oid, "repair-check", blocker.key,
+                    repair_check_plan_name(pr.number, blocker.key, pr.head_ref_oid),
+                )
+                if crash_reason is not None:
+                    return infra_blocked_action(pr, blocker.key, blocker.detail, crash_reason)
                 if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-check", blocker.key, now):
                     continue
                 return Action("repair_check", pr.number, blocker.key, blocker.detail)
@@ -709,6 +788,12 @@ def plan_bot_thread_repairs(
                 return Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail)
             if ledger.count("repair-bot-thread", pr.number, pr.head_ref_oid, blocker.key) >= max_repair_attempts:
                 return cap_action(pr, blocker, blocker.detail)
+            crash_reason = repair_crash_reason(
+                ledger, pr.number, pr.head_ref_oid, "repair-bot-thread", blocker.key,
+                repair_bot_thread_plan_name(pr.number, pr.head_ref_oid),
+            )
+            if crash_reason is not None:
+                return infra_blocked_action(pr, blocker.key, blocker.detail, crash_reason)
             if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-bot-thread", blocker.key, now):
                 continue
             return Action("repair_check", pr.number, "bot_review_thread:" + blocker.key, blocker.detail)

--- a/scripts/mergify_admin_requeue_repair_body.py
+++ b/scripts/mergify_admin_requeue_repair_body.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import tempfile
 from pathlib import Path
 
 try:
@@ -33,3 +34,23 @@ def is_ancestor(cwd: Path, ancestor: str, descendant: str) -> bool:
         capture_output=True,
     )
     return completed.returncode == 0
+
+
+def normalize_repair_commit(cwd: Path, start_head: str, end_head: str, check_name: str) -> str:
+    if is_ancestor(cwd, start_head, end_head):
+        return end_head
+    diff = git_output(cwd, "diff", "--binary", start_head, end_head)
+    hard_reset_work_root(cwd, start_head)
+    if not diff.strip():
+        return start_head
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+        handle.write(diff)
+        patch_path = Path(handle.name)
+    try:
+        git_output(cwd, "apply", "--index", str(patch_path))
+    finally:
+        patch_path.unlink(missing_ok=True)
+    if not git_lines(cwd, "status", "--porcelain"):
+        return start_head
+    git_output(cwd, "commit", "-m", f"Repair {check_name}")
+    return git_output(cwd, "rev-parse", "HEAD").strip()

--- a/scripts/mergify_admin_requeue_repair_body.py
+++ b/scripts/mergify_admin_requeue_repair_body.py
@@ -1,13 +1,32 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import Mapping
 
 try:
+    from .mergify_admin_requeue_model import PrSnapshot
+    from .mergify_admin_requeue_plan import TRUNK
     from .mergify_admin_requeue_snapshot import run_logged
 except ImportError:
+    from mergify_admin_requeue_model import PrSnapshot
+    from mergify_admin_requeue_plan import TRUNK
     from mergify_admin_requeue_snapshot import run_logged
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROOF_POLICY_LANE_ERROR = (
+    "Review lane proof cannot ship with policy files in the same PR. "
+    "Keep benchmarks, repros, and regression proof separate from behavior or policy changes."
+)
+PROOF_TOOLING_POLICY_UNIT_ERROR = (
+    'PR body Review Unit "proof" cannot ship with tooling-policy files in the same PR. '
+    "Split this into one Review Unit per PR."
+)
+NON_TRUNK_PREREQ_ERROR = "automatic tooling-policy split is only supported for base master"
+NON_TRUNK_MANUAL_SPLIT_ERROR = "worker cannot auto-split this PR on a non-trunk base; human stack split required"
 
 
 def git_output(cwd: Path, *args: str) -> str:
@@ -54,3 +73,146 @@ def normalize_repair_commit(cwd: Path, start_head: str, end_head: str, check_nam
         return start_head
     git_output(cwd, "commit", "-m", f"Repair {check_name}")
     return git_output(cwd, "rev-parse", "HEAD").strip()
+
+
+def validate_local_pr_body(cwd: Path, body: str, base_branch: str) -> dict[str, object]:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+        handle.write(body)
+        body_path = Path(handle.name)
+    try:
+        completed = subprocess.run(
+            [
+                "node",
+                str(REPO_ROOT / "scripts" / "validate-pr-body-local.mjs"),
+                "--body-file",
+                str(body_path),
+                "--base",
+                base_branch,
+                "--json",
+            ],
+            cwd=str(cwd),
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        stdout = completed.stdout.strip()
+        if completed.returncode not in {0, 1}:
+            raise RuntimeError(completed.stderr.strip() or stdout or "validate-pr-body-local failed")
+        if not stdout:
+            raise RuntimeError(completed.stderr.strip() or "validate-pr-body-local produced no JSON output")
+        value = json.loads(stdout)
+        if not isinstance(value, dict):
+            raise RuntimeError("validate-pr-body-local returned non-object JSON")
+        return value
+    finally:
+        body_path.unlink(missing_ok=True)
+
+
+def validate_pr_body_from_current_diff(cwd: Path, body: str, base_branch: str) -> dict[str, object]:
+    git_output(cwd, "fetch", "origin", f"+refs/heads/{base_branch}:refs/remotes/origin/{base_branch}")
+    changed_files = git_output(cwd, "diff", "--name-only", f"origin/{base_branch}...HEAD")
+    diff_text = git_output(cwd, "diff", "--no-ext-diff", f"origin/{base_branch}...HEAD")
+    with (
+        tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as body_handle,
+        tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as changed_handle,
+        tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as diff_handle,
+    ):
+        body_handle.write(body)
+        changed_handle.write(changed_files)
+        diff_handle.write(diff_text)
+        body_path = Path(body_handle.name)
+        changed_path = Path(changed_handle.name)
+        diff_path = Path(diff_handle.name)
+    script = (
+        "import { readFileSync } from 'node:fs';"
+        f"import {{ getReviewMetadata, scopeKindsForChangedFiles, validatePrBody }} from '{(REPO_ROOT / 'scripts' / 'validate-pr-body.mjs').as_posix()}';"
+        f"import {{ reviewUnitsForChangedFiles }} from '{(REPO_ROOT / 'scripts' / 'review-unit-rules.mjs').as_posix()}';"
+        "const body = readFileSync(process.argv[1], 'utf8');"
+        "const changedFiles = readFileSync(process.argv[2], 'utf8').split(/\\r?\\n/).filter(Boolean);"
+        "const diffText = readFileSync(process.argv[3], 'utf8');"
+        "const errors = await validatePrBody(body, { changedFiles, diffText });"
+        "const reviewMetadata = getReviewMetadata(body.trim());"
+        "console.log(JSON.stringify({"
+        "valid: errors.length === 0,"
+        "errors,"
+        "reviewLane: reviewMetadata.reviewLane,"
+        "reviewUnit: reviewMetadata.reviewUnit,"
+        "reviewUnits: reviewUnitsForChangedFiles(changedFiles),"
+        "scopeKinds: scopeKindsForChangedFiles(changedFiles),"
+        "}));"
+    )
+    try:
+        completed = subprocess.run(
+            ["node", "--input-type=module", "-e", script, str(body_path), str(changed_path), str(diff_path)],
+            cwd=str(cwd),
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        stdout = completed.stdout.strip()
+        if completed.returncode not in {0, 1}:
+            raise RuntimeError(completed.stderr.strip() or stdout or "validate-pr-body fallback failed")
+        if not stdout:
+            raise RuntimeError(completed.stderr.strip() or "validate-pr-body fallback produced no JSON output")
+        value = json.loads(stdout)
+        if not isinstance(value, dict):
+            raise RuntimeError("validate-pr-body fallback returned non-object JSON")
+        return value
+    finally:
+        body_path.unlink(missing_ok=True)
+        changed_path.unlink(missing_ok=True)
+        diff_path.unlink(missing_ok=True)
+
+
+def validate_current_pr_body(cwd: Path, body: str, base_branch: str) -> dict[str, object]:
+    try:
+        return validate_local_pr_body(cwd, body, base_branch)
+    except RuntimeError:
+        return validate_pr_body_from_current_diff(cwd, body, base_branch)
+
+
+def is_proof_tooling_policy_validation(value: Mapping[str, object]) -> bool:
+    errors = value.get("errors")
+    scope_kinds = value.get("scopeKinds")
+    review_units = value.get("reviewUnits")
+    if value.get("reviewLane") != "proof" or value.get("reviewUnit") != "proof":
+        return False
+    if review_units != ["tooling-policy"]:
+        return False
+    if scope_kinds not in ([], ["policy"]):
+        return False
+    if not isinstance(errors, list):
+        return False
+    return bool(errors) and set(errors).issubset({PROOF_POLICY_LANE_ERROR, PROOF_TOOLING_POLICY_UNIT_ERROR})
+
+
+def is_prereq_split_validation(value: Mapping[str, object], pr: PrSnapshot) -> bool:
+    return pr.base_ref_name == TRUNK and is_proof_tooling_policy_validation(value)
+
+
+def is_manual_split_validation(value: Mapping[str, object]) -> bool:
+    errors = value.get("errors")
+    review_units = value.get("reviewUnits")
+    if not isinstance(errors, list) or not errors:
+        return False
+    if not isinstance(review_units, list):
+        return False
+    if len({str(unit) for unit in review_units}) < 2:
+        return False
+    joined = "\n".join(str(error) for error in errors)
+    return (
+        "multiple review units" in joined
+        or "Split this into one Review Unit per PR." in joined
+        or "cannot ship with policy, proof files" in joined
+        or "cannot ship with tooling-policy, proof files" in joined
+        or "cannot ship with proof files" in joined
+    )
+
+
+def invalid_repair_errors(value: Mapping[str, object], pr: PrSnapshot) -> list[str]:
+    errors = [str(error) for error in value.get("errors", [])]
+    if is_proof_tooling_policy_validation(value) and pr.base_ref_name != TRUNK:
+        errors = [*errors, NON_TRUNK_PREREQ_ERROR]
+    if is_manual_split_validation(value) and pr.base_ref_name != TRUNK:
+        errors = [*errors, NON_TRUNK_MANUAL_SPLIT_ERROR]
+    return errors

--- a/scripts/mergify_admin_requeue_repair_body.py
+++ b/scripts/mergify_admin_requeue_repair_body.py
@@ -4,16 +4,20 @@ import json
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Mapping
+from typing import Mapping, Sequence
 
 try:
-    from .mergify_admin_requeue_model import PrSnapshot
+    from .mergify_admin_requeue_logger import AdminBypassLogger
+    from .mergify_admin_requeue_model import Ledger, PrSnapshot
     from .mergify_admin_requeue_plan import TRUNK
-    from .mergify_admin_requeue_snapshot import run_logged
+    from .mergify_admin_requeue_snapshot import GhClient, run_logged
+    from .pr_worker_safe_push import safe_push
 except ImportError:
-    from mergify_admin_requeue_model import PrSnapshot
+    from mergify_admin_requeue_logger import AdminBypassLogger
+    from mergify_admin_requeue_model import Ledger, PrSnapshot
     from mergify_admin_requeue_plan import TRUNK
-    from mergify_admin_requeue_snapshot import run_logged
+    from mergify_admin_requeue_snapshot import GhClient, run_logged
+    from pr_worker_safe_push import safe_push
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -216,3 +220,92 @@ def invalid_repair_errors(value: Mapping[str, object], pr: PrSnapshot) -> list[s
     if is_manual_split_validation(value) and pr.base_ref_name != TRUNK:
         errors = [*errors, NON_TRUNK_MANUAL_SPLIT_ERROR]
     return errors
+
+
+def prerequisite_branch_name(pr: PrSnapshot, start_head: str) -> str:
+    return f"stack/pr-babysit-prereq-{pr.number}-{start_head[:7]}"
+
+
+def prerequisite_title(pr: PrSnapshot, check_name: str) -> str:
+    return f"[PR babysit] Tooling-policy repair prerequisite for #{pr.number}: {check_name}"
+
+
+def prerequisite_body(pr: PrSnapshot, check_name: str) -> str:
+    return (
+        "## Summary\n\n"
+        "Worker-generated tooling-policy repair.\n\n"
+        "## Review Claim\n\n"
+        f"This PR carries the worker-generated tooling-policy repair that unblocks {check_name} on #{pr.number}.\n\n"
+        "## Review Lane\n\n"
+        "- policy\n\n"
+        "## Review Unit\n\n"
+        "- tooling-policy\n\n"
+        "## Safety Invariant\n\n"
+        "Contains only the worker-generated repair commit; the original PR branch stays proof-only.\n\n"
+        "## Slice Rationale\n\n"
+        "The repair changed tooling-policy files that a proof PR body cannot carry, so the repair must land first.\n\n"
+        "## Non-goals\n\n"
+        "- No product behavior change.\n\n"
+        "## Test Plan\n\n"
+        "<details>\n"
+        "<summary>Test Plan</summary>\n\n"
+        f"- [ ] Let CI rerun {check_name}.\n\n"
+        "</details>\n\n"
+        "## Revert Plan\n\n"
+        "<details>\n"
+        "<summary>Revert Plan</summary>\n\n"
+        "- Safe to revert? Yes.\n"
+        "- Revert command: `git revert <sha>`\n"
+        "- Post-revert steps: None.\n"
+        "- Data migration? No.\n\n"
+        "</details>\n"
+    )
+
+
+def create_repair_prerequisite(
+    gh: GhClient,
+    ledger: Ledger,
+    logger: AdminBypassLogger,
+    repo: str,
+    cwd: Path,
+    pr: PrSnapshot,
+    check_name: str,
+    start_head: str,
+    repair_commits: Sequence[str],
+    now: int | None,
+) -> dict[str, object]:
+    branch_name = prerequisite_branch_name(pr, start_head)
+    title = prerequisite_title(pr, check_name)
+    body = prerequisite_body(pr, check_name)
+    git_output(cwd, "checkout", "-B", branch_name, f"origin/{TRUNK}")
+    git_output(cwd, "reset", "--hard", f"origin/{TRUNK}")
+    for commit in repair_commits:
+        git_output(cwd, "cherry-pick", commit)
+    validation = validate_current_pr_body(cwd, body, TRUNK)
+    if not validation.get("valid"):
+        errors = [str(error) for error in validation.get("errors", [])]
+        raise RuntimeError("prerequisite PR body failed validation: " + "; ".join(errors))
+    safe_push(branch=branch_name, expect_missing=True, cwd=cwd)
+    created = gh.create_pr(repo, title, body, branch_name, TRUNK)
+    prereq_number = int(created.get("number") or 0)
+    if prereq_number <= 0:
+        raise RuntimeError("GitHub did not return a prerequisite PR number")
+    gh.edit_label(repo, prereq_number, add="admin-bypass")
+    ledger.record(
+        "repair-prereq-created",
+        pr.number,
+        pr.head_ref_oid,
+        check_name,
+        now,
+        meta={"prNumber": prereq_number, "branch": branch_name},
+    )
+    logger.trace(
+        "admin-bypass-repair-prereq-created",
+        repo=repo,
+        pr_number=pr.number,
+        check_name=check_name,
+        prereq_pr_number=prereq_number,
+        prereq_branch=branch_name,
+        repair_commits=list(repair_commits),
+    )
+    return {"prNumber": prereq_number, "branch": branch_name, "title": title}

--- a/scripts/mergify_admin_requeue_repair_body.py
+++ b/scripts/mergify_admin_requeue_repair_body.py
@@ -8,13 +8,13 @@ from typing import Mapping, Sequence
 
 try:
     from .mergify_admin_requeue_logger import AdminBypassLogger
-    from .mergify_admin_requeue_model import Ledger, PrSnapshot
+    from .mergify_admin_requeue_model import Ledger
     from .mergify_admin_requeue_plan import TRUNK
     from .mergify_admin_requeue_snapshot import GhClient, run_logged
     from .pr_worker_safe_push import safe_push
 except ImportError:
     from mergify_admin_requeue_logger import AdminBypassLogger
-    from mergify_admin_requeue_model import Ledger, PrSnapshot
+    from mergify_admin_requeue_model import Ledger
     from mergify_admin_requeue_plan import TRUNK
     from mergify_admin_requeue_snapshot import GhClient, run_logged
     from pr_worker_safe_push import safe_push
@@ -190,8 +190,8 @@ def is_proof_tooling_policy_validation(value: Mapping[str, object]) -> bool:
     return bool(errors) and set(errors).issubset({PROOF_POLICY_LANE_ERROR, PROOF_TOOLING_POLICY_UNIT_ERROR})
 
 
-def is_prereq_split_validation(value: Mapping[str, object], pr: PrSnapshot) -> bool:
-    return pr.base_ref_name == TRUNK and is_proof_tooling_policy_validation(value)
+def is_prereq_split_validation(value: Mapping[str, object], base_ref_name: str) -> bool:
+    return base_ref_name == TRUNK and is_proof_tooling_policy_validation(value)
 
 
 def is_manual_split_validation(value: Mapping[str, object]) -> bool:
@@ -213,29 +213,29 @@ def is_manual_split_validation(value: Mapping[str, object]) -> bool:
     )
 
 
-def invalid_repair_errors(value: Mapping[str, object], pr: PrSnapshot) -> list[str]:
+def invalid_repair_errors(value: Mapping[str, object], base_ref_name: str) -> list[str]:
     errors = [str(error) for error in value.get("errors", [])]
-    if is_proof_tooling_policy_validation(value) and pr.base_ref_name != TRUNK:
+    if is_proof_tooling_policy_validation(value) and base_ref_name != TRUNK:
         errors = [*errors, NON_TRUNK_PREREQ_ERROR]
-    if is_manual_split_validation(value) and pr.base_ref_name != TRUNK:
+    if is_manual_split_validation(value) and base_ref_name != TRUNK:
         errors = [*errors, NON_TRUNK_MANUAL_SPLIT_ERROR]
     return errors
 
 
-def prerequisite_branch_name(pr: PrSnapshot, start_head: str) -> str:
-    return f"stack/pr-babysit-prereq-{pr.number}-{start_head[:7]}"
+def prerequisite_branch_name(pr_number: int, start_head: str) -> str:
+    return f"stack/pr-babysit-prereq-{pr_number}-{start_head[:7]}"
 
 
-def prerequisite_title(pr: PrSnapshot, check_name: str) -> str:
-    return f"[PR babysit] Tooling-policy repair prerequisite for #{pr.number}: {check_name}"
+def prerequisite_title(pr_number: int, check_name: str) -> str:
+    return f"[PR babysit] Tooling-policy repair prerequisite for #{pr_number}: {check_name}"
 
 
-def prerequisite_body(pr: PrSnapshot, check_name: str) -> str:
+def prerequisite_body(pr_number: int, check_name: str) -> str:
     return (
         "## Summary\n\n"
         "Worker-generated tooling-policy repair.\n\n"
         "## Review Claim\n\n"
-        f"This PR carries the worker-generated tooling-policy repair that unblocks {check_name} on #{pr.number}.\n\n"
+        f"This PR carries the worker-generated tooling-policy repair that unblocks {check_name} on #{pr_number}.\n\n"
         "## Review Lane\n\n"
         "- policy\n\n"
         "## Review Unit\n\n"
@@ -268,15 +268,16 @@ def create_repair_prerequisite(
     logger: AdminBypassLogger,
     repo: str,
     cwd: Path,
-    pr: PrSnapshot,
+    pr_number: int,
+    head_sha: str,
     check_name: str,
     start_head: str,
     repair_commits: Sequence[str],
     now: int | None,
 ) -> dict[str, object]:
-    branch_name = prerequisite_branch_name(pr, start_head)
-    title = prerequisite_title(pr, check_name)
-    body = prerequisite_body(pr, check_name)
+    branch_name = prerequisite_branch_name(pr_number, start_head)
+    title = prerequisite_title(pr_number, check_name)
+    body = prerequisite_body(pr_number, check_name)
     git_output(cwd, "checkout", "-B", branch_name, f"origin/{TRUNK}")
     git_output(cwd, "reset", "--hard", f"origin/{TRUNK}")
     for commit in repair_commits:
@@ -293,8 +294,8 @@ def create_repair_prerequisite(
     gh.edit_label(repo, prereq_number, add="admin-bypass")
     ledger.record(
         "repair-prereq-created",
-        pr.number,
-        pr.head_ref_oid,
+        pr_number,
+        head_sha,
         check_name,
         now,
         meta={"prNumber": prereq_number, "branch": branch_name},
@@ -302,7 +303,7 @@ def create_repair_prerequisite(
     logger.trace(
         "admin-bypass-repair-prereq-created",
         repo=repo,
-        pr_number=pr.number,
+        pr_number=pr_number,
         check_name=check_name,
         prereq_pr_number=prereq_number,
         prereq_branch=branch_name,

--- a/scripts/mergify_admin_requeue_repair_body.py
+++ b/scripts/mergify_admin_requeue_repair_body.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+try:
+    from .mergify_admin_requeue_snapshot import run_logged
+except ImportError:
+    from mergify_admin_requeue_snapshot import run_logged
+
+
+def git_output(cwd: Path, *args: str) -> str:
+    return run_logged(["git", *args], cwd=cwd)
+
+
+def git_lines(cwd: Path, *args: str) -> tuple[str, ...]:
+    return tuple(line.strip() for line in git_output(cwd, *args).splitlines() if line.strip())
+
+
+def hard_reset_work_root(cwd: Path, target: str) -> None:
+    git_output(cwd, "reset", "--hard", target)
+    git_output(cwd, "clean", "-fd")
+
+
+def is_ancestor(cwd: Path, ancestor: str, descendant: str) -> bool:
+    if not cwd.exists():
+        return True
+    completed = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        cwd=str(cwd),
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    return completed.returncode == 0

--- a/scripts/mergify_admin_requeue_repair_normalize.py
+++ b/scripts/mergify_admin_requeue_repair_normalize.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Sequence
+
+try:
+    from .mergify_admin_requeue_logger import AdminBypassLogger
+    from .mergify_admin_requeue_model import Ledger
+    from .mergify_admin_requeue_repair_body import (
+        create_repair_prerequisite,
+        git_lines,
+        git_output,
+        hard_reset_work_root,
+        invalid_repair_errors,
+        is_prereq_split_validation,
+        normalize_repair_commit,
+        validate_current_pr_body,
+    )
+    from .mergify_admin_requeue_snapshot import GhClient
+except ImportError:
+    from mergify_admin_requeue_logger import AdminBypassLogger
+    from mergify_admin_requeue_model import Ledger
+    from mergify_admin_requeue_repair_body import (
+        create_repair_prerequisite,
+        git_lines,
+        git_output,
+        hard_reset_work_root,
+        invalid_repair_errors,
+        is_prereq_split_validation,
+        normalize_repair_commit,
+        validate_current_pr_body,
+    )
+    from mergify_admin_requeue_snapshot import GhClient
+
+# Runs inside the Invoker `normalize` task's own checkout, one hop after the
+# `repair` task's agent turn -- this is the async replacement for the local
+# post-run_claude_repair inspection AdminBypassRepairer.repair_check used to do
+# synchronously in the cron process. It re-implements: dirty-check/reset,
+# normalize_repair_commit (rebase-shaped diff handling), PR-body
+# re-validation, and -- if the fix needs restructuring -- create_repair_prerequisite
+# (a small prerequisite PR) instead of letting `safe-push` push directly.
+
+PREREQ_SENTINEL = Path(".invoker-repair-prereq-created")
+
+# Written unconditionally as this task's first action: reaching `normalize` at
+# all means the submitted repair attempt concluded (successfully, as a noop, or
+# as a still-invalid fix), which is what frees plan.py's repair_in_flight check
+# for this (pr, headSha, blockerKey) -- regardless of what happens below. Only
+# a crash before `normalize` even starts (the `repair` task itself dying) skips
+# this write, and that's exactly the case the in-flight TTL exists to bound.
+def _record_settle_marker(state_file: Path, pr_number: int, start_head: str, check_name: str) -> None:
+    Ledger(state_file).record("repair-check-settled", pr_number, start_head, check_name)
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Normalize an async admin-bypass repair commit before safe-push.")
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--pr", type=int, required=True)
+    parser.add_argument("--check", required=True)
+    parser.add_argument("--start-head", required=True)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--trunk", default="master")
+    parser.add_argument(
+        "--state-file",
+        default=str(Path.home() / ".invoker" / "mergify-admin-requeue-state.jsonl"),
+        help="Ledger JSONL path. Default: ~/.invoker/mergify-admin-requeue-state.jsonl.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    cwd = Path.cwd()
+    start_head = args.start_head
+    state_file = Path(args.state_file).expanduser()
+
+    _record_settle_marker(state_file, args.pr, start_head, args.check)
+
+    if git_lines(cwd, "status", "--porcelain"):
+        hard_reset_work_root(cwd, start_head)
+        print("blocked_dirty: repair left the working tree dirty", file=sys.stderr)
+        return 1
+
+    end_head = git_output(cwd, "rev-parse", "HEAD").strip()
+    if end_head == start_head:
+        print("noop: repair task made no commit")
+        return 0
+
+    end_head = normalize_repair_commit(cwd, start_head, end_head, args.check)
+    if end_head == start_head:
+        print("noop: repair diff was empty after normalization")
+        return 0
+
+    gh = GhClient()
+    detail = gh.pr_detail(args.repo, args.pr)
+    body = str(detail.get("body") or "")
+    validation = validate_current_pr_body(cwd, body, args.base)
+    if validation.get("valid"):
+        print(f"repair commit normalized to {end_head}; ready for safe-push")
+        return 0
+
+    if is_prereq_split_validation(validation, args.base):
+        repair_commits = git_lines(cwd, "rev-list", "--reverse", f"{start_head}..{end_head}")
+        ledger = Ledger(state_file)
+        logger = AdminBypassLogger()
+        try:
+            create_repair_prerequisite(
+                gh, ledger, logger, args.repo, cwd,
+                args.pr, start_head, args.check, start_head, repair_commits, None,
+            )
+        finally:
+            hard_reset_work_root(cwd, start_head)
+        PREREQ_SENTINEL.write_text("1", encoding="utf-8")
+        print("prerequisite PR created; original PR left unchanged for this attempt")
+        return 0
+
+    hard_reset_work_root(cwd, start_head)
+    errors = invalid_repair_errors(validation, args.base)
+    print("blocked_invalid: " + "; ".join(errors), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -83,7 +83,7 @@ class AdminBypassRepairer:
             start_head,
             end_head,
             repair_commits=repair_commits,
-            errors=invalid_repair_errors(value, pr),
+            errors=invalid_repair_errors(value, pr.base_ref_name),
         )
 
     def blocked_outcome(
@@ -302,11 +302,11 @@ class AdminBypassRepairer:
                 end_head,
                 repair_commits=repair_commits,
             )
-        if is_prereq_split_validation(validation, pr):
+        if is_prereq_split_validation(validation, pr.base_ref_name):
             try:
                 created = create_repair_prerequisite(
                     self.gh, self.ledger, self.logger, self.repo, work_root,
-                    pr, check_name, start_head, repair_commits, now,
+                    pr.number, pr.head_ref_oid, check_name, start_head, repair_commits, now,
                 )
             finally:
                 git_output(work_root, "checkout", "-B", pr.head_ref_name, start_head)

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -11,8 +11,9 @@ try:
     from .mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
-    from .mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
+    from .mergify_admin_requeue_plan import is_queue_only_required_check
     from .mergify_admin_requeue_repair_body import (
+        create_repair_prerequisite,
         git_lines,
         git_output,
         hard_reset_work_root,
@@ -27,8 +28,9 @@ except ImportError:
     from mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
-    from mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
+    from mergify_admin_requeue_plan import is_queue_only_required_check
     from mergify_admin_requeue_repair_body import (
+        create_repair_prerequisite,
         git_lines,
         git_output,
         hard_reset_work_root,
@@ -82,43 +84,6 @@ class AdminBypassRepairer:
             end_head,
             repair_commits=repair_commits,
             errors=invalid_repair_errors(value, pr),
-        )
-
-    def prerequisite_branch_name(self, pr: PrSnapshot, start_head: str) -> str:
-        return f"stack/pr-babysit-prereq-{pr.number}-{start_head[:7]}"
-
-    def prerequisite_title(self, pr: PrSnapshot, check_name: str) -> str:
-        return f"[PR babysit] Tooling-policy repair prerequisite for #{pr.number}: {check_name}"
-
-    def prerequisite_body(self, pr: PrSnapshot, check_name: str) -> str:
-        return (
-            "## Summary\n\n"
-            "Worker-generated tooling-policy repair.\n\n"
-            "## Review Claim\n\n"
-            f"This PR carries the worker-generated tooling-policy repair that unblocks {check_name} on #{pr.number}.\n\n"
-            "## Review Lane\n\n"
-            "- policy\n\n"
-            "## Review Unit\n\n"
-            "- tooling-policy\n\n"
-            "## Safety Invariant\n\n"
-            "Contains only the worker-generated repair commit; the original PR branch stays proof-only.\n\n"
-            "## Slice Rationale\n\n"
-            "The repair changed tooling-policy files that a proof PR body cannot carry, so the repair must land first.\n\n"
-            "## Non-goals\n\n"
-            "- No product behavior change.\n\n"
-            "## Test Plan\n\n"
-            "<details>\n"
-            "<summary>Test Plan</summary>\n\n"
-            f"- [ ] Let CI rerun {check_name}.\n\n"
-            "</details>\n\n"
-            "## Revert Plan\n\n"
-            "<details>\n"
-            "<summary>Revert Plan</summary>\n\n"
-            "- Safe to revert? Yes.\n"
-            "- Revert command: `git revert <sha>`\n"
-            "- Post-revert steps: None.\n"
-            "- Data migration? No.\n\n"
-            "</details>\n"
         )
 
     def blocked_outcome(
@@ -184,51 +149,6 @@ class AdminBypassRepairer:
         )
         hard_reset_work_root(work_root, start_head)
         return self.blocked_outcome("noop", check_name, start_head, end_head)
-
-    def create_repair_prerequisite(
-        self,
-        pr: PrSnapshot,
-        check_name: str,
-        start_head: str,
-        repair_commits: Sequence[str],
-        work_root: Path,
-        now: int | None,
-    ) -> dict[str, object]:
-        branch_name = self.prerequisite_branch_name(pr, start_head)
-        title = self.prerequisite_title(pr, check_name)
-        body = self.prerequisite_body(pr, check_name)
-        git_output(work_root, "checkout", "-B", branch_name, f"origin/{TRUNK}")
-        git_output(work_root, "reset", "--hard", f"origin/{TRUNK}")
-        for commit in repair_commits:
-            git_output(work_root, "cherry-pick", commit)
-        validation = validate_current_pr_body(work_root, body, TRUNK)
-        if not validation.get("valid"):
-            errors = [str(error) for error in validation.get("errors", [])]
-            raise RuntimeError("prerequisite PR body failed validation: " + "; ".join(errors))
-        self.push_branch(work_root, branch_name, expect_missing=True)
-        created = self.gh.create_pr(self.repo, title, body, branch_name, TRUNK)
-        prereq_number = int(created.get("number") or 0)
-        if prereq_number <= 0:
-            raise RuntimeError("GitHub did not return a prerequisite PR number")
-        self.gh.edit_label(self.repo, prereq_number, add="admin-bypass")
-        self.ledger.record(
-            "repair-prereq-created",
-            pr.number,
-            pr.head_ref_oid,
-            check_name,
-            now,
-            meta={"prNumber": prereq_number, "branch": branch_name},
-        )
-        self.logger.trace(
-            "admin-bypass-repair-prereq-created",
-            repo=self.repo,
-            pr_number=pr.number,
-            check_name=check_name,
-            prereq_pr_number=prereq_number,
-            prereq_branch=branch_name,
-            repair_commits=list(repair_commits),
-        )
-        return {"prNumber": prereq_number, "branch": branch_name, "title": title}
 
     def run_claude_repair(self, work_root: Path, prompt: str) -> None:
         subprocess.run(
@@ -384,7 +304,10 @@ class AdminBypassRepairer:
             )
         if is_prereq_split_validation(validation, pr):
             try:
-                created = self.create_repair_prerequisite(pr, check_name, start_head, repair_commits, work_root, now)
+                created = create_repair_prerequisite(
+                    self.gh, self.ledger, self.logger, self.repo, work_root,
+                    pr, check_name, start_head, repair_commits, now,
+                )
             finally:
                 git_output(work_root, "checkout", "-B", pr.head_ref_name, start_head)
                 hard_reset_work_root(work_root, start_head)

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -12,7 +12,15 @@ try:
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from .mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
-    from .mergify_admin_requeue_repair_body import git_lines, git_output, hard_reset_work_root, normalize_repair_commit
+    from .mergify_admin_requeue_repair_body import (
+        git_lines,
+        git_output,
+        hard_reset_work_root,
+        invalid_repair_errors,
+        is_prereq_split_validation,
+        normalize_repair_commit,
+        validate_current_pr_body,
+    )
     from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
     from .pr_worker_safe_push import SafePushError, safe_push
 except ImportError:
@@ -20,22 +28,17 @@ except ImportError:
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
-    from mergify_admin_requeue_repair_body import git_lines, git_output, hard_reset_work_root, normalize_repair_commit
+    from mergify_admin_requeue_repair_body import (
+        git_lines,
+        git_output,
+        hard_reset_work_root,
+        invalid_repair_errors,
+        is_prereq_split_validation,
+        normalize_repair_commit,
+        validate_current_pr_body,
+    )
     from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
     from pr_worker_safe_push import SafePushError, safe_push
-
-
-REPO_ROOT = Path(__file__).resolve().parents[1]
-PROOF_POLICY_LANE_ERROR = (
-    "Review lane proof cannot ship with policy files in the same PR. "
-    "Keep benchmarks, repros, and regression proof separate from behavior or policy changes."
-)
-PROOF_TOOLING_POLICY_UNIT_ERROR = (
-    'PR body Review Unit "proof" cannot ship with tooling-policy files in the same PR. '
-    "Split this into one Review Unit per PR."
-)
-NON_TRUNK_PREREQ_ERROR = "automatic tooling-policy split is only supported for base master"
-NON_TRUNK_MANUAL_SPLIT_ERROR = "worker cannot auto-split this PR on a non-trunk base; human stack split required"
 
 
 def mergify_check_urls(event: MergifyQueueEvent | None, check_name: str) -> tuple[str, ...]:
@@ -62,142 +65,6 @@ class AdminBypassRepairer:
         self.ledger = ledger
         self.repo = repo
 
-    def validate_local_pr_body(self, work_root: Path, body: str, base_branch: str) -> dict[str, object]:
-        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
-            handle.write(body)
-            body_path = Path(handle.name)
-        try:
-            completed = subprocess.run(
-                [
-                    "node",
-                    str(REPO_ROOT / "scripts" / "validate-pr-body-local.mjs"),
-                    "--body-file",
-                    str(body_path),
-                    "--base",
-                    base_branch,
-                    "--json",
-                ],
-                cwd=str(work_root),
-                check=False,
-                text=True,
-                capture_output=True,
-            )
-            stdout = completed.stdout.strip()
-            if completed.returncode not in {0, 1}:
-                raise RuntimeError(completed.stderr.strip() or stdout or "validate-pr-body-local failed")
-            if not stdout:
-                raise RuntimeError(completed.stderr.strip() or "validate-pr-body-local produced no JSON output")
-            value = json.loads(stdout)
-            if not isinstance(value, dict):
-                raise RuntimeError("validate-pr-body-local returned non-object JSON")
-            return value
-        finally:
-            body_path.unlink(missing_ok=True)
-
-    def validate_pr_body_from_current_diff(self, work_root: Path, body: str, base_branch: str) -> dict[str, object]:
-        git_output(work_root, "fetch", "origin", f"+refs/heads/{base_branch}:refs/remotes/origin/{base_branch}")
-        changed_files = git_output(work_root, "diff", "--name-only", f"origin/{base_branch}...HEAD")
-        diff_text = git_output(work_root, "diff", "--no-ext-diff", f"origin/{base_branch}...HEAD")
-        with (
-            tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as body_handle,
-            tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as changed_handle,
-            tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as diff_handle,
-        ):
-            body_handle.write(body)
-            changed_handle.write(changed_files)
-            diff_handle.write(diff_text)
-            body_path = Path(body_handle.name)
-            changed_path = Path(changed_handle.name)
-            diff_path = Path(diff_handle.name)
-        script = (
-            "import { readFileSync } from 'node:fs';"
-            f"import {{ getReviewMetadata, scopeKindsForChangedFiles, validatePrBody }} from '{(REPO_ROOT / 'scripts' / 'validate-pr-body.mjs').as_posix()}';"
-            f"import {{ reviewUnitsForChangedFiles }} from '{(REPO_ROOT / 'scripts' / 'review-unit-rules.mjs').as_posix()}';"
-            "const body = readFileSync(process.argv[1], 'utf8');"
-            "const changedFiles = readFileSync(process.argv[2], 'utf8').split(/\\r?\\n/).filter(Boolean);"
-            "const diffText = readFileSync(process.argv[3], 'utf8');"
-            "const errors = await validatePrBody(body, { changedFiles, diffText });"
-            "const reviewMetadata = getReviewMetadata(body.trim());"
-            "console.log(JSON.stringify({"
-            "valid: errors.length === 0,"
-            "errors,"
-            "reviewLane: reviewMetadata.reviewLane,"
-            "reviewUnit: reviewMetadata.reviewUnit,"
-            "reviewUnits: reviewUnitsForChangedFiles(changedFiles),"
-            "scopeKinds: scopeKindsForChangedFiles(changedFiles),"
-            "}));"
-        )
-        try:
-            completed = subprocess.run(
-                ["node", "--input-type=module", "-e", script, str(body_path), str(changed_path), str(diff_path)],
-                cwd=str(work_root),
-                check=False,
-                text=True,
-                capture_output=True,
-            )
-            stdout = completed.stdout.strip()
-            if completed.returncode not in {0, 1}:
-                raise RuntimeError(completed.stderr.strip() or stdout or "validate-pr-body fallback failed")
-            if not stdout:
-                raise RuntimeError(completed.stderr.strip() or "validate-pr-body fallback produced no JSON output")
-            value = json.loads(stdout)
-            if not isinstance(value, dict):
-                raise RuntimeError("validate-pr-body fallback returned non-object JSON")
-            return value
-        finally:
-            body_path.unlink(missing_ok=True)
-            changed_path.unlink(missing_ok=True)
-            diff_path.unlink(missing_ok=True)
-
-    def validate_current_pr_body(self, work_root: Path, body: str, base_branch: str) -> dict[str, object]:
-        try:
-            return self.validate_local_pr_body(work_root, body, base_branch)
-        except RuntimeError:
-            return self.validate_pr_body_from_current_diff(work_root, body, base_branch)
-
-    def is_proof_tooling_policy_validation(self, value: Mapping[str, object]) -> bool:
-        errors = value.get("errors")
-        scope_kinds = value.get("scopeKinds")
-        review_units = value.get("reviewUnits")
-        if value.get("reviewLane") != "proof" or value.get("reviewUnit") != "proof":
-            return False
-        if review_units != ["tooling-policy"]:
-            return False
-        if scope_kinds not in ([], ["policy"]):
-            return False
-        if not isinstance(errors, list):
-            return False
-        return bool(errors) and set(errors).issubset({PROOF_POLICY_LANE_ERROR, PROOF_TOOLING_POLICY_UNIT_ERROR})
-
-    def is_prereq_split_validation(self, value: Mapping[str, object], pr: PrSnapshot) -> bool:
-        return pr.base_ref_name == TRUNK and self.is_proof_tooling_policy_validation(value)
-
-    def is_manual_split_validation(self, value: Mapping[str, object]) -> bool:
-        errors = value.get("errors")
-        review_units = value.get("reviewUnits")
-        if not isinstance(errors, list) or not errors:
-            return False
-        if not isinstance(review_units, list):
-            return False
-        if len({str(unit) for unit in review_units}) < 2:
-            return False
-        joined = "\n".join(str(error) for error in errors)
-        return (
-            "multiple review units" in joined
-            or "Split this into one Review Unit per PR." in joined
-            or "cannot ship with policy, proof files" in joined
-            or "cannot ship with tooling-policy, proof files" in joined
-            or "cannot ship with proof files" in joined
-        )
-
-    def invalid_repair_errors(self, value: Mapping[str, object], pr: PrSnapshot) -> list[str]:
-        errors = [str(error) for error in value.get("errors", [])]
-        if self.is_proof_tooling_policy_validation(value) and pr.base_ref_name != TRUNK:
-            errors = [*errors, NON_TRUNK_PREREQ_ERROR]
-        if self.is_manual_split_validation(value) and pr.base_ref_name != TRUNK:
-            errors = [*errors, NON_TRUNK_MANUAL_SPLIT_ERROR]
-        return errors
-
     def invalid_repair_outcome(
         self,
         pr: PrSnapshot,
@@ -214,7 +81,7 @@ class AdminBypassRepairer:
             start_head,
             end_head,
             repair_commits=repair_commits,
-            errors=self.invalid_repair_errors(value, pr),
+            errors=invalid_repair_errors(value, pr),
         )
 
     def prerequisite_branch_name(self, pr: PrSnapshot, start_head: str) -> str:
@@ -334,7 +201,7 @@ class AdminBypassRepairer:
         git_output(work_root, "reset", "--hard", f"origin/{TRUNK}")
         for commit in repair_commits:
             git_output(work_root, "cherry-pick", commit)
-        validation = self.validate_current_pr_body(work_root, body, TRUNK)
+        validation = validate_current_pr_body(work_root, body, TRUNK)
         if not validation.get("valid"):
             errors = [str(error) for error in validation.get("errors", [])]
             raise RuntimeError("prerequisite PR body failed validation: " + "; ".join(errors))
@@ -414,7 +281,7 @@ class AdminBypassRepairer:
             terminal = self.terminal_repair_outcome(pr, check_name, start_head, start_head, work_root)
             if terminal:
                 return terminal
-            validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
+            validation = validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
             if validation.get("valid"):
                 self.logger.trace(
                     "admin-bypass-pr-body-valid-noop",
@@ -475,7 +342,7 @@ class AdminBypassRepairer:
             return terminal
         if end_head == start_head and not status_lines:
             if not queue_only:
-                validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
+                validation = validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
                 if not validation.get("valid"):
                     return self.invalid_repair_outcome(pr, check_name, start_head, end_head, validation)
             return self.blocked_outcome(
@@ -495,7 +362,7 @@ class AdminBypassRepairer:
             )
         end_head = normalize_repair_commit(work_root, start_head, end_head, check_name)
         repair_commits = git_lines(work_root, "rev-list", "--reverse", f"{start_head}..{end_head}")
-        validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
+        validation = validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
         if validation.get("valid"):
             try:
                 self.push_branch(work_root, pr.head_ref_name, expected_head=pr.head_ref_oid)
@@ -515,7 +382,7 @@ class AdminBypassRepairer:
                 end_head,
                 repair_commits=repair_commits,
             )
-        if self.is_prereq_split_validation(validation, pr):
+        if is_prereq_split_validation(validation, pr):
             try:
                 created = self.create_repair_prerequisite(pr, check_name, start_head, repair_commits, work_root, now)
             finally:

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -12,7 +12,7 @@ try:
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from .mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
-    from .mergify_admin_requeue_repair_body import git_lines, git_output, hard_reset_work_root, is_ancestor
+    from .mergify_admin_requeue_repair_body import git_lines, git_output, hard_reset_work_root, normalize_repair_commit
     from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
     from .pr_worker_safe_push import SafePushError, safe_push
 except ImportError:
@@ -20,7 +20,7 @@ except ImportError:
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
-    from mergify_admin_requeue_repair_body import git_lines, git_output, hard_reset_work_root, is_ancestor
+    from mergify_admin_requeue_repair_body import git_lines, git_output, hard_reset_work_root, normalize_repair_commit
     from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
     from pr_worker_safe_push import SafePushError, safe_push
 
@@ -61,25 +61,6 @@ class AdminBypassRepairer:
         self.logger = logger
         self.ledger = ledger
         self.repo = repo
-
-    def normalize_repair_commit(self, work_root: Path, start_head: str, end_head: str, check_name: str) -> str:
-        if is_ancestor(work_root, start_head, end_head):
-            return end_head
-        diff = git_output(work_root, "diff", "--binary", start_head, end_head)
-        hard_reset_work_root(work_root, start_head)
-        if not diff.strip():
-            return start_head
-        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
-            handle.write(diff)
-            patch_path = Path(handle.name)
-        try:
-            git_output(work_root, "apply", "--index", str(patch_path))
-        finally:
-            patch_path.unlink(missing_ok=True)
-        if not git_lines(work_root, "status", "--porcelain"):
-            return start_head
-        git_output(work_root, "commit", "-m", f"Repair {check_name}")
-        return git_output(work_root, "rev-parse", "HEAD").strip()
 
     def validate_local_pr_body(self, work_root: Path, body: str, base_branch: str) -> dict[str, object]:
         with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
@@ -512,7 +493,7 @@ class AdminBypassRepairer:
                 end_head,
                 status_lines=status_lines,
             )
-        end_head = self.normalize_repair_commit(work_root, start_head, end_head, check_name)
+        end_head = normalize_repair_commit(work_root, start_head, end_head, check_name)
         repair_commits = git_lines(work_root, "rev-list", "--reverse", f"{start_head}..{end_head}")
         validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
         if validation.get("valid"):

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -1,46 +1,25 @@
 from __future__ import annotations
 
-import json
 import os
 from pathlib import Path
-import subprocess
-import tempfile
 from typing import Mapping, Sequence
 
 try:
+    from . import mergify_admin_requeue_async_repair as async_repair
     from .mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from .mergify_admin_requeue_plan import is_queue_only_required_check
-    from .mergify_admin_requeue_repair_body import (
-        create_repair_prerequisite,
-        git_lines,
-        git_output,
-        hard_reset_work_root,
-        invalid_repair_errors,
-        is_prereq_split_validation,
-        normalize_repair_commit,
-        validate_current_pr_body,
-    )
+    from .mergify_admin_requeue_repair_body import git_output, hard_reset_work_root, validate_current_pr_body
     from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
-    from .pr_worker_safe_push import SafePushError, safe_push
 except ImportError:
     from mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from mergify_admin_requeue_plan import is_queue_only_required_check
-    from mergify_admin_requeue_repair_body import (
-        create_repair_prerequisite,
-        git_lines,
-        git_output,
-        hard_reset_work_root,
-        invalid_repair_errors,
-        is_prereq_split_validation,
-        normalize_repair_commit,
-        validate_current_pr_body,
-    )
+    from mergify_admin_requeue_repair_body import git_output, hard_reset_work_root, validate_current_pr_body
     from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
-    from pr_worker_safe_push import SafePushError, safe_push
+    import mergify_admin_requeue_async_repair as async_repair
 
 
 def mergify_check_urls(event: MergifyQueueEvent | None, check_name: str) -> tuple[str, ...]:
@@ -67,25 +46,6 @@ class AdminBypassRepairer:
         self.ledger = ledger
         self.repo = repo
 
-    def invalid_repair_outcome(
-        self,
-        pr: PrSnapshot,
-        check_name: str,
-        start_head: str,
-        end_head: str,
-        value: Mapping[str, object],
-        *,
-        repair_commits: Sequence[str] = (),
-    ) -> RepairOutcome:
-        return self.blocked_outcome(
-            "blocked_invalid",
-            check_name,
-            start_head,
-            end_head,
-            repair_commits=repair_commits,
-            errors=invalid_repair_errors(value, pr.base_ref_name),
-        )
-
     def blocked_outcome(
         self,
         status: str,
@@ -109,28 +69,13 @@ class AdminBypassRepairer:
             prereq=prereq,
         )
 
-    def push_branch(
-        self,
-        work_root: Path,
-        branch_name: str,
-        *,
-        expected_head: str | None = None,
-        expect_missing: bool = False,
-    ) -> str:
-        return safe_push(
-            branch=branch_name,
-            expected_head=expected_head,
-            expect_missing=expect_missing,
-            cwd=work_root,
-        )
-
     def terminal_repair_outcome(
         self,
         pr: PrSnapshot,
         check_name: str,
         start_head: str,
         end_head: str,
-        work_root: Path,
+        work_root: Path | None,
     ) -> RepairOutcome | None:
         if not hasattr(self.gh, "pr_detail"):
             return None
@@ -147,16 +92,9 @@ class AdminBypassRepairer:
             start_head=start_head,
             end_head=end_head,
         )
-        hard_reset_work_root(work_root, start_head)
+        if work_root is not None:
+            hard_reset_work_root(work_root, start_head)
         return self.blocked_outcome("noop", check_name, start_head, end_head)
-
-    def run_claude_repair(self, work_root: Path, prompt: str) -> None:
-        subprocess.run(
-            ["claude", "-p", prompt, "--dangerously-skip-permissions"],
-            cwd=str(work_root),
-            check=True,
-            text=True,
-        )
 
     def job_log_has_evidence(self, log_path: str) -> bool:
         if not log_path:
@@ -178,16 +116,12 @@ class AdminBypassRepairer:
             return False
 
     def repair_check(self, pr: PrSnapshot, check_name: str, now: int | None = None) -> RepairOutcome:
-        self.ledger.record("repair-check", pr.number, pr.head_ref_oid, check_name, now)
         ctx = pr.checks.get(check_name)
         latest = pr.latest_mergify
         queue_only = ctx is None and is_queue_only_required_check(check_name)
         mergify_urls = mergify_check_urls(latest, check_name)
         details_url = (ctx.details_url if ctx and ctx.details_url else "") or (mergify_urls[0] if mergify_urls else "")
-        work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
-        work_root.parent.mkdir(parents=True, exist_ok=True)
-        checkout_pr_head(self.repo, pr, work_root)
-        start_head = git_output(work_root, "rev-parse", "HEAD").strip()
+        start_head = pr.head_ref_oid
         if queue_only and not details_url:
             return self.blocked_outcome(
                 "blocked_invalid",
@@ -197,8 +131,15 @@ class AdminBypassRepairer:
                 errors=(f"queue-only check {check_name} is missing a Mergify job URL",),
             )
         log_path = self.executor.download_job_log(self.repo, details_url, pr.number, check_name) if details_url else ""
+        # "PR Body" with an empty job log is the one check that still needs a
+        # local checkout before submitting anything: validate_current_pr_body
+        # has no API-only equivalent. Every other check name never checks out.
         if check_name == "PR Body" and self.job_log_is_empty(log_path):
-            terminal = self.terminal_repair_outcome(pr, check_name, start_head, start_head, work_root)
+            work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
+            work_root.parent.mkdir(parents=True, exist_ok=True)
+            checkout_pr_head(self.repo, pr, work_root)
+            checked_out_head = git_output(work_root, "rev-parse", "HEAD").strip()
+            terminal = self.terminal_repair_outcome(pr, check_name, checked_out_head, checked_out_head, work_root)
             if terminal:
                 return terminal
             validation = validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
@@ -213,7 +154,7 @@ class AdminBypassRepairer:
                     log_path=log_path,
                 )
                 return self.blocked_outcome("noop", check_name, start_head, start_head)
-        if queue_only and not self.job_log_has_evidence(log_path):
+        elif queue_only and not self.job_log_has_evidence(log_path):
             self.logger.trace(
                 "admin-bypass-queue-only-empty-log-noop",
                 repo=self.repo,
@@ -223,27 +164,25 @@ class AdminBypassRepairer:
                 log_path=log_path,
                 head_sha=pr.head_ref_oid,
             )
-            return self.blocked_outcome(
-                "queue_only_noop",
-                check_name,
-                start_head,
-                start_head,
-            )
+            return self.blocked_outcome("queue_only_noop", check_name, start_head, start_head)
+        else:
+            terminal = self.terminal_repair_outcome(pr, check_name, start_head, start_head, None)
+            if terminal:
+                return terminal
+
         queue_pr_number = latest.queue_pr_number if latest else 0
-        prompt = (
-            f"This PR's CI check is failing. Diagnose why it is failing, then fix it. Add or update a repro if the failure is reproducible.\n\n"
-            f"If a code change fixes it: make the change in this checkout. Commit locally if needed, do not push. "
-            f"If local proof shows the check is already green on the current head, make no commit and exit 0.\n\n"
-            f"If the real fix requires restructuring this PR instead of editing it in place -- for example, splitting "
-            f"unrelated files into their own PR because they can't ship together -- do not force that into a single "
-            f"local commit here. Instead, submit an Invoker plan to do the restructuring, the same way a human would "
-            f"via the plan-to-invoker skill (see skills/plan-to-invoker/SKILL.md and ./submit-plan.sh). Then make no "
-            f"commit in this checkout and exit 0.\n\n"
-            f"PR: #{pr.number}\nFailed check: {check_name}\nDetails URL: {details_url}\nJob log path: {log_path}\n"
-            f"Latest Mergify event: {json.dumps(latest.__dict__ if latest else None, sort_keys=True)}\n"
+        plan = async_repair.build_repair_check_plan(
+            pr,
+            check_name,
+            repo=self.repo,
+            details_url=details_url,
+            log_path=log_path,
+            queue_only=queue_only,
+            queue_pr_number=queue_pr_number,
+            latest=latest,
+            start_head=start_head,
+            state_file=self.ledger.path,
         )
-        if queue_only:
-            prompt += f"Queue draft PR: #{queue_pr_number}\nRepair the real PR head, using only evidence from the queue draft failure.\n"
         self.logger.trace(
             "admin-bypass-repair-check-start",
             repo=self.repo,
@@ -251,181 +190,46 @@ class AdminBypassRepairer:
             check_name=check_name,
             details_url=details_url,
             log_path=log_path,
-            work_root=str(work_root),
-            head_sha=pr.head_ref_oid,
+            head_sha=start_head,
+            plan_name=plan.plan_name,
         )
-        self.run_claude_repair(work_root, prompt)
-        end_head = git_output(work_root, "rev-parse", "HEAD").strip()
-        status_lines = git_lines(work_root, "status", "--porcelain")
-        terminal = self.terminal_repair_outcome(pr, check_name, start_head, end_head, work_root)
-        if terminal:
-            return terminal
-        if end_head == start_head and not status_lines:
-            if not queue_only:
-                validation = validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
-                if not validation.get("valid"):
-                    return self.invalid_repair_outcome(pr, check_name, start_head, end_head, validation)
-            return self.blocked_outcome(
-                "queue_only_noop" if queue_only else "noop",
-                check_name,
-                start_head,
-                end_head,
-            )
-        if status_lines:
-            hard_reset_work_root(work_root, start_head)
-            return self.blocked_outcome(
-                "blocked_dirty",
-                check_name,
-                start_head,
-                end_head,
-                status_lines=status_lines,
-            )
-        end_head = normalize_repair_commit(work_root, start_head, end_head, check_name)
-        repair_commits = git_lines(work_root, "rev-list", "--reverse", f"{start_head}..{end_head}")
-        validation = validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
-        if validation.get("valid"):
-            try:
-                self.push_branch(work_root, pr.head_ref_name, expected_head=pr.head_ref_oid)
-            except SafePushError as exc:
-                return self.blocked_outcome(
-                    "stale_head",
-                    check_name,
-                    start_head,
-                    end_head,
-                    repair_commits=repair_commits,
-                    errors=(str(exc),),
-                )
-            return self.blocked_outcome(
-                "pushed",
-                check_name,
-                start_head,
-                end_head,
-                repair_commits=repair_commits,
-            )
-        if is_prereq_split_validation(validation, pr.base_ref_name):
-            try:
-                created = create_repair_prerequisite(
-                    self.gh, self.ledger, self.logger, self.repo, work_root,
-                    pr.number, pr.head_ref_oid, check_name, start_head, repair_commits, now,
-                )
-            finally:
-                git_output(work_root, "checkout", "-B", pr.head_ref_name, start_head)
-                hard_reset_work_root(work_root, start_head)
-            return self.blocked_outcome(
-                "prereq_created",
-                check_name,
-                start_head,
-                end_head,
-                repair_commits=repair_commits,
-                prereq=created,
-            )
-        hard_reset_work_root(work_root, start_head)
-        return self.invalid_repair_outcome(
-            pr,
-            check_name,
-            start_head,
-            end_head,
-            validation,
-            repair_commits=repair_commits,
-        )
+        async_repair.submit_async_repair_plan(plan)
+        self.ledger.record("repair-check", pr.number, start_head, check_name, now)
+        return self.blocked_outcome("submitted", check_name, start_head, start_head)
 
     def repair_conflict(self, pr: PrSnapshot, reason: str, now: int | None = None) -> RepairOutcome:
         check_name = "conflict"
-        self.ledger.record("conflict-repair", pr.number, pr.head_ref_oid, f"conflict:{pr.number}", now)
-        work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
-        work_root.parent.mkdir(parents=True, exist_ok=True)
-        checkout_pr_head(self.repo, pr, work_root)
-        start_head = git_output(work_root, "rev-parse", "HEAD").strip()
-        prompt = (
-            f"This PR has a merge conflict blocking it from merging. Diagnose why, then fix it.\n\n"
-            f"If rebasing the head branch onto its base branch (preserving the PR's intended changes) resolves it: "
-            f"do that, run the narrow proof for the conflict resolution, then commit locally. Do not push.\n\n"
-            f"If the real fix requires restructuring this PR instead of a straightforward rebase, do not force that "
-            f"into a single local commit here. Instead, submit an Invoker plan to do the restructuring, the same way "
-            f"a human would via the plan-to-invoker skill (see skills/plan-to-invoker/SKILL.md and ./submit-plan.sh). "
-            f"Then make no commit in this checkout and exit 0.\n\n"
-            f"If the PR is already closed or merged, or the head branch no longer exists, make no commit and exit 0.\n\n"
-            f"PR: #{pr.number}\nBase branch: {pr.base_ref_name}\nHead branch: {pr.head_ref_name}\n"
-            f"Head SHA: {pr.head_ref_oid}\nReason: {reason}\n"
+        start_head = pr.head_ref_oid
+        plan = async_repair.build_repair_conflict_plan(
+            pr, reason, repo=self.repo, start_head=start_head, state_file=self.ledger.path,
         )
         self.logger.trace(
             "admin-bypass-repair-conflict-start",
             repo=self.repo,
             pr_number=pr.number,
             reason=reason,
-            work_root=str(work_root),
             base_ref=pr.base_ref_name,
             head_ref=pr.head_ref_name,
-            head_sha=pr.head_ref_oid,
+            head_sha=start_head,
+            plan_name=plan.plan_name,
         )
-        self.run_claude_repair(work_root, prompt)
-        end_head = git_output(work_root, "rev-parse", "HEAD").strip()
-        status_lines = git_lines(work_root, "status", "--porcelain")
-        if end_head == start_head or status_lines:
-            if status_lines:
-                hard_reset_work_root(work_root, start_head)
-                return self.blocked_outcome(
-                    "blocked_dirty",
-                    check_name,
-                    start_head,
-                    end_head,
-                    status_lines=status_lines,
-                )
-            return self.blocked_outcome("noop", check_name, start_head, end_head)
-        try:
-            self.push_branch(work_root, pr.head_ref_name, expected_head=pr.head_ref_oid)
-        except SafePushError as exc:
-            return self.blocked_outcome(
-                "stale_head",
-                check_name,
-                start_head,
-                end_head,
-                errors=(str(exc),),
-            )
-        return self.blocked_outcome("pushed", check_name, start_head, end_head)
+        async_repair.submit_async_repair_plan(plan)
+        self.ledger.record("conflict-repair", pr.number, start_head, f"conflict:{pr.number}", now)
+        return self.blocked_outcome("submitted", check_name, start_head, start_head)
 
     def repair_bot_thread(self, pr: PrSnapshot, thread_id: str, now: int | None = None) -> RepairOutcome:
-        self.ledger.record("repair-bot-thread", pr.number, pr.head_ref_oid, thread_id, now)
-        work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
-        work_root.parent.mkdir(parents=True, exist_ok=True)
-        checkout_pr_head(self.repo, pr, work_root)
-        start_head = git_output(work_root, "rev-parse", "HEAD").strip()
-        prompt = (
-            f"Resolve the unresolved review thread {thread_id}. Address the reviewer's feedback with "
-            f"real code changes, run the narrow proof for the fix, then commit locally. Do not push. "
-            f"If the thread is already resolved, or the PR is closed or merged, make no commit and exit 0.\n\n"
-            f"PR: #{pr.number}\nHead branch: {pr.head_ref_name}\nHead SHA: {pr.head_ref_oid}\nThread: {thread_id}\n"
+        start_head = pr.head_ref_oid
+        plan = async_repair.build_repair_bot_thread_plan(
+            pr, thread_id, repo=self.repo, start_head=start_head, state_file=self.ledger.path,
         )
         self.logger.trace(
             "admin-bypass-repair-bot-thread-start",
             repo=self.repo,
             pr_number=pr.number,
             thread_id=thread_id,
-            work_root=str(work_root),
-            head_sha=pr.head_ref_oid,
+            head_sha=start_head,
+            plan_name=plan.plan_name,
         )
-        self.run_claude_repair(work_root, prompt)
-        end_head = git_output(work_root, "rev-parse", "HEAD").strip()
-        status_lines = git_lines(work_root, "status", "--porcelain")
-        if end_head == start_head or status_lines:
-            if status_lines:
-                hard_reset_work_root(work_root, start_head)
-                return self.blocked_outcome(
-                    "blocked_dirty",
-                    thread_id,
-                    start_head,
-                    end_head,
-                    status_lines=status_lines,
-                )
-            return self.blocked_outcome("noop", thread_id, start_head, end_head)
-        try:
-            self.push_branch(work_root, pr.head_ref_name, expected_head=pr.head_ref_oid)
-        except SafePushError as exc:
-            return self.blocked_outcome(
-                "stale_head",
-                thread_id,
-                start_head,
-                end_head,
-                errors=(str(exc),),
-            )
-        return self.blocked_outcome("pushed", thread_id, start_head, end_head)
+        async_repair.submit_async_repair_plan(plan)
+        self.ledger.record("repair-bot-thread", pr.number, start_head, thread_id, now)
+        return self.blocked_outcome("submitted", thread_id, start_head, start_head)

--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -12,14 +12,16 @@ try:
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from .mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
-    from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head, run_logged
+    from .mergify_admin_requeue_repair_body import git_lines, git_output, hard_reset_work_root, is_ancestor
+    from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
     from .pr_worker_safe_push import SafePushError, safe_push
 except ImportError:
     from mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Ledger, MergifyQueueEvent, PrSnapshot, RepairOutcome
     from mergify_admin_requeue_plan import TRUNK, is_queue_only_required_check
-    from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head, run_logged
+    from mergify_admin_requeue_repair_body import git_lines, git_output, hard_reset_work_root, is_ancestor
+    from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
     from pr_worker_safe_push import SafePushError, safe_push
 
 
@@ -60,46 +62,24 @@ class AdminBypassRepairer:
         self.ledger = ledger
         self.repo = repo
 
-    def git_output(self, work_root: Path, *args: str) -> str:
-        return run_logged(["git", *args], cwd=work_root)
-
-    def git_lines(self, work_root: Path, *args: str) -> tuple[str, ...]:
-        return tuple(line.strip() for line in self.git_output(work_root, *args).splitlines() if line.strip())
-
-    def hard_reset_work_root(self, work_root: Path, target: str) -> None:
-        self.git_output(work_root, "reset", "--hard", target)
-        self.git_output(work_root, "clean", "-fd")
-
-    def is_ancestor(self, work_root: Path, ancestor: str, descendant: str) -> bool:
-        if not work_root.exists():
-            return True
-        completed = subprocess.run(
-            ["git", "merge-base", "--is-ancestor", ancestor, descendant],
-            cwd=str(work_root),
-            check=False,
-            text=True,
-            capture_output=True,
-        )
-        return completed.returncode == 0
-
     def normalize_repair_commit(self, work_root: Path, start_head: str, end_head: str, check_name: str) -> str:
-        if self.is_ancestor(work_root, start_head, end_head):
+        if is_ancestor(work_root, start_head, end_head):
             return end_head
-        diff = self.git_output(work_root, "diff", "--binary", start_head, end_head)
-        self.hard_reset_work_root(work_root, start_head)
+        diff = git_output(work_root, "diff", "--binary", start_head, end_head)
+        hard_reset_work_root(work_root, start_head)
         if not diff.strip():
             return start_head
         with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
             handle.write(diff)
             patch_path = Path(handle.name)
         try:
-            self.git_output(work_root, "apply", "--index", str(patch_path))
+            git_output(work_root, "apply", "--index", str(patch_path))
         finally:
             patch_path.unlink(missing_ok=True)
-        if not self.git_lines(work_root, "status", "--porcelain"):
+        if not git_lines(work_root, "status", "--porcelain"):
             return start_head
-        self.git_output(work_root, "commit", "-m", f"Repair {check_name}")
-        return self.git_output(work_root, "rev-parse", "HEAD").strip()
+        git_output(work_root, "commit", "-m", f"Repair {check_name}")
+        return git_output(work_root, "rev-parse", "HEAD").strip()
 
     def validate_local_pr_body(self, work_root: Path, body: str, base_branch: str) -> dict[str, object]:
         with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
@@ -134,9 +114,9 @@ class AdminBypassRepairer:
             body_path.unlink(missing_ok=True)
 
     def validate_pr_body_from_current_diff(self, work_root: Path, body: str, base_branch: str) -> dict[str, object]:
-        self.git_output(work_root, "fetch", "origin", f"+refs/heads/{base_branch}:refs/remotes/origin/{base_branch}")
-        changed_files = self.git_output(work_root, "diff", "--name-only", f"origin/{base_branch}...HEAD")
-        diff_text = self.git_output(work_root, "diff", "--no-ext-diff", f"origin/{base_branch}...HEAD")
+        git_output(work_root, "fetch", "origin", f"+refs/heads/{base_branch}:refs/remotes/origin/{base_branch}")
+        changed_files = git_output(work_root, "diff", "--name-only", f"origin/{base_branch}...HEAD")
+        diff_text = git_output(work_root, "diff", "--no-ext-diff", f"origin/{base_branch}...HEAD")
         with (
             tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as body_handle,
             tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as changed_handle,
@@ -354,7 +334,7 @@ class AdminBypassRepairer:
             start_head=start_head,
             end_head=end_head,
         )
-        self.hard_reset_work_root(work_root, start_head)
+        hard_reset_work_root(work_root, start_head)
         return self.blocked_outcome("noop", check_name, start_head, end_head)
 
     def create_repair_prerequisite(
@@ -369,10 +349,10 @@ class AdminBypassRepairer:
         branch_name = self.prerequisite_branch_name(pr, start_head)
         title = self.prerequisite_title(pr, check_name)
         body = self.prerequisite_body(pr, check_name)
-        self.git_output(work_root, "checkout", "-B", branch_name, f"origin/{TRUNK}")
-        self.git_output(work_root, "reset", "--hard", f"origin/{TRUNK}")
+        git_output(work_root, "checkout", "-B", branch_name, f"origin/{TRUNK}")
+        git_output(work_root, "reset", "--hard", f"origin/{TRUNK}")
         for commit in repair_commits:
-            self.git_output(work_root, "cherry-pick", commit)
+            git_output(work_root, "cherry-pick", commit)
         validation = self.validate_current_pr_body(work_root, body, TRUNK)
         if not validation.get("valid"):
             errors = [str(error) for error in validation.get("errors", [])]
@@ -439,7 +419,7 @@ class AdminBypassRepairer:
         work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
         work_root.parent.mkdir(parents=True, exist_ok=True)
         checkout_pr_head(self.repo, pr, work_root)
-        start_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
+        start_head = git_output(work_root, "rev-parse", "HEAD").strip()
         if queue_only and not details_url:
             return self.blocked_outcome(
                 "blocked_invalid",
@@ -507,8 +487,8 @@ class AdminBypassRepairer:
             head_sha=pr.head_ref_oid,
         )
         self.run_claude_repair(work_root, prompt)
-        end_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
-        status_lines = self.git_lines(work_root, "status", "--porcelain")
+        end_head = git_output(work_root, "rev-parse", "HEAD").strip()
+        status_lines = git_lines(work_root, "status", "--porcelain")
         terminal = self.terminal_repair_outcome(pr, check_name, start_head, end_head, work_root)
         if terminal:
             return terminal
@@ -524,7 +504,7 @@ class AdminBypassRepairer:
                 end_head,
             )
         if status_lines:
-            self.hard_reset_work_root(work_root, start_head)
+            hard_reset_work_root(work_root, start_head)
             return self.blocked_outcome(
                 "blocked_dirty",
                 check_name,
@@ -533,7 +513,7 @@ class AdminBypassRepairer:
                 status_lines=status_lines,
             )
         end_head = self.normalize_repair_commit(work_root, start_head, end_head, check_name)
-        repair_commits = self.git_lines(work_root, "rev-list", "--reverse", f"{start_head}..{end_head}")
+        repair_commits = git_lines(work_root, "rev-list", "--reverse", f"{start_head}..{end_head}")
         validation = self.validate_current_pr_body(work_root, pr.body, pr.base_ref_name)
         if validation.get("valid"):
             try:
@@ -558,8 +538,8 @@ class AdminBypassRepairer:
             try:
                 created = self.create_repair_prerequisite(pr, check_name, start_head, repair_commits, work_root, now)
             finally:
-                self.git_output(work_root, "checkout", "-B", pr.head_ref_name, start_head)
-                self.hard_reset_work_root(work_root, start_head)
+                git_output(work_root, "checkout", "-B", pr.head_ref_name, start_head)
+                hard_reset_work_root(work_root, start_head)
             return self.blocked_outcome(
                 "prereq_created",
                 check_name,
@@ -568,7 +548,7 @@ class AdminBypassRepairer:
                 repair_commits=repair_commits,
                 prereq=created,
             )
-        self.hard_reset_work_root(work_root, start_head)
+        hard_reset_work_root(work_root, start_head)
         return self.invalid_repair_outcome(
             pr,
             check_name,
@@ -584,7 +564,7 @@ class AdminBypassRepairer:
         work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
         work_root.parent.mkdir(parents=True, exist_ok=True)
         checkout_pr_head(self.repo, pr, work_root)
-        start_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
+        start_head = git_output(work_root, "rev-parse", "HEAD").strip()
         prompt = (
             f"This PR has a merge conflict blocking it from merging. Diagnose why, then fix it.\n\n"
             f"If rebasing the head branch onto its base branch (preserving the PR's intended changes) resolves it: "
@@ -608,11 +588,11 @@ class AdminBypassRepairer:
             head_sha=pr.head_ref_oid,
         )
         self.run_claude_repair(work_root, prompt)
-        end_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
-        status_lines = self.git_lines(work_root, "status", "--porcelain")
+        end_head = git_output(work_root, "rev-parse", "HEAD").strip()
+        status_lines = git_lines(work_root, "status", "--porcelain")
         if end_head == start_head or status_lines:
             if status_lines:
-                self.hard_reset_work_root(work_root, start_head)
+                hard_reset_work_root(work_root, start_head)
                 return self.blocked_outcome(
                     "blocked_dirty",
                     check_name,
@@ -638,7 +618,7 @@ class AdminBypassRepairer:
         work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
         work_root.parent.mkdir(parents=True, exist_ok=True)
         checkout_pr_head(self.repo, pr, work_root)
-        start_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
+        start_head = git_output(work_root, "rev-parse", "HEAD").strip()
         prompt = (
             f"Resolve the unresolved review thread {thread_id}. Address the reviewer's feedback with "
             f"real code changes, run the narrow proof for the fix, then commit locally. Do not push. "
@@ -654,11 +634,11 @@ class AdminBypassRepairer:
             head_sha=pr.head_ref_oid,
         )
         self.run_claude_repair(work_root, prompt)
-        end_head = self.git_output(work_root, "rev-parse", "HEAD").strip()
-        status_lines = self.git_lines(work_root, "status", "--porcelain")
+        end_head = git_output(work_root, "rev-parse", "HEAD").strip()
+        status_lines = git_lines(work_root, "status", "--porcelain")
         if end_head == start_head or status_lines:
             if status_lines:
-                self.hard_reset_work_root(work_root, start_head)
+                hard_reset_work_root(work_root, start_head)
                 return self.blocked_outcome(
                     "blocked_dirty",
                     thread_id,

--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -1,27 +1,11 @@
 from __future__ import annotations
 
 import json
-import subprocess
-from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-HEADLESS_LIB = REPO_ROOT / "scripts" / "headless-lib.sh"
-
-# Sources scripts/headless-lib.sh directly (never scripts/cron-pr-lib.sh): by the
-# time this module runs, cron-pr-lib.sh's cron_lock is already held by the
-# calling bash script (scripts/cron-pr-admin-bypass-land.sh), so re-sourcing it
-# and calling cron_lock again would self-deadlock or silently no-op.
-_SOURCE_HEADLESS_LIB = 'set -euo pipefail\nsource "$1"\n'
-
-
-def _run_headless(command: str, *extra_args: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        ["bash", "-c", _SOURCE_HEADLESS_LIB + command, "bash", str(HEADLESS_LIB), *extra_args],
-        cwd=str(REPO_ROOT),
-        text=True,
-        capture_output=True,
-        check=False,
-    )
+try:
+    from .mergify_admin_requeue_headless_shell import run_headless as _run_headless
+except ImportError:
+    from mergify_admin_requeue_headless_shell import run_headless as _run_headless
 
 
 def resolve_workflow_for_pr(pr_number: int) -> str | None:

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -35,6 +35,7 @@ from scripts.mergify_admin_requeue_gh_executor import ADMIN_BYPASS_NUDGE_LEDGER_
 from scripts.mergify_admin_requeue_model import LoadedStacks, RepairOutcome
 from scripts.mergify_admin_requeue_loader import AdminBypassStackLoader
 from scripts.mergify_admin_requeue_logger import AdminBypassLogger
+from scripts.mergify_admin_requeue_plan import repair_in_flight
 from scripts.mergify_admin_requeue_repairer import AdminBypassRepairer
 
 REQUIRED = {"PR Body", "quality / TypeScript Types"}
@@ -273,17 +274,52 @@ Failing checks
         actions = plan_stack_actions(stack, REQUIRED, self.ledger(), 1)
         self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 2606, "PR Body")])
 
-    def test_failed_check_at_cap_gets_one_more_attempt_until_evaluated(self):
+    def test_failed_check_caps_after_max_repair_attempts(self):
         checks = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
         stack = StackGroup("s", (pr(2606, checks=checks, latest=mergify()),))
         ledger = self.ledger()
-        for epoch in range(3):
-            ledger.record("repair-check", 2606, HEAD, "PR Body", epoch)
-        actions = plan_stack_actions(stack, REQUIRED, ledger, 4)
+        # Two prior attempts, each submitted then settled, so neither is in-flight.
+        for epoch in range(2):
+            ledger.record("repair-check", 2606, HEAD, "PR Body", epoch * 2)
+            ledger.record("repair-check-settled", 2606, HEAD, "PR Body", epoch * 2 + 1)
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 10)
         self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("repair_check", 2606, "PR Body")])
-        ledger.record("repair-evaluated", 2606, HEAD, "PR Body", 4)
-        actions = plan_stack_actions(stack, REQUIRED, ledger, 5)
+        ledger.record("repair-check", 2606, HEAD, "PR Body", 10)
+        actions = plan_stack_actions(stack, REQUIRED, ledger, 11)
         self.assertEqual([(a.kind, a.pr_number, a.key) for a in actions], [("comment_blocked", 2606, "capped")])
+
+    def test_plan_direct_repairs_skips_in_flight_blocker_but_tries_next_stack(self):
+        stuck_checks = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        stuck = pr(6951, checks=stuck_checks, latest=mergify())
+        ready_checks = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        ready = pr(5933, checks=ready_checks, latest=mergify())
+        ledger = self.ledger()
+        ledger.record("repair-check", 6951, HEAD, "PR Body", 1)
+        stuck_stack = StackGroup("s1", (stuck,))
+        ready_stack = StackGroup("s2", (ready,))
+        stuck_actions = plan_stack_actions(stuck_stack, REQUIRED, ledger, 2)
+        self.assertEqual(stuck_actions, ())
+        ready_actions = plan_stack_actions(ready_stack, REQUIRED, ledger, 2)
+        self.assertEqual([(a.kind, a.pr_number, a.key) for a in ready_actions], [("repair_check", 5933, "PR Body")])
+
+    def test_repair_in_flight_frees_budget_when_head_changes(self):
+        ledger = self.ledger()
+        ledger.record("repair-check", 6951, OLD, "PR Body", 1)
+        self.assertTrue(repair_in_flight(ledger, 6951, OLD, "repair-check", "PR Body", 2))
+        self.assertFalse(repair_in_flight(ledger, 6951, HEAD, "repair-check", "PR Body", 2))
+
+    def test_repair_in_flight_settles_once_a_settle_row_lands(self):
+        ledger = self.ledger()
+        ledger.record("repair-check", 6951, HEAD, "PR Body", 1)
+        self.assertTrue(repair_in_flight(ledger, 6951, HEAD, "repair-check", "PR Body", 2))
+        ledger.record("repair-check-settled", 6951, HEAD, "PR Body", 3)
+        self.assertFalse(repair_in_flight(ledger, 6951, HEAD, "repair-check", "PR Body", 4))
+
+    def test_repair_in_flight_expires_after_ttl(self):
+        ledger = self.ledger()
+        ledger.record("repair-check", 6951, HEAD, "PR Body", 1000)
+        self.assertTrue(repair_in_flight(ledger, 6951, HEAD, "repair-check", "PR Body", 1000 + 5399, ttl_seconds=5400))
+        self.assertFalse(repair_in_flight(ledger, 6951, HEAD, "repair-check", "PR Body", 1000 + 5400, ttl_seconds=5400))
 
     def test_pending_check_waits(self):
         checks = {"PR Body": check("PR Body", "pending"), "quality / TypeScript Types": check("quality / TypeScript Types")}
@@ -611,6 +647,29 @@ Failing checks
                             should_poll = exec_impl.run_cycle(args)
         self.assertEqual(repair_check.call_count, 1)
         self.assertEqual(fake_gh.comments, [("owner/repo", 6602, "@mergifyio queue")])
+        self.assertTrue(should_poll)
+
+    def test_run_cycle_attempts_every_independent_stack_in_one_tick(self):
+        # Direct regression test for the starvation bug: PR #5933's stuck check
+        # used to consume the single action slot every tick, so PR #6951 (a
+        # different, independent stack) was never even attempted. Async
+        # submission means both stacks should get a repair attempt in one tick.
+        args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
+        checks_a = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        checks_b = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        stuck = pr(5933, checks=checks_a, latest=mergify())
+        starved = pr(6951, checks=checks_b, latest=mergify())
+        stacks = (StackGroup("s1", (stuck,)), StackGroup("s2", (starved,)))
+        outcome = RepairOutcome(status="submitted", check_name="PR Body", start_head=HEAD, end_head=HEAD)
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=object()):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=stacks, open_pr_numbers_by_head={})):
+                    with mock.patch.object(exec_impl, "resolve_workflow_for_pr", return_value=None):
+                        with mock.patch.object(AdminBypassRepairer, "repair_check", return_value=outcome) as repair_check:
+                            should_poll = exec_impl.run_cycle(args)
+        self.assertEqual(repair_check.call_count, 2)
+        called_prs = sorted(call.args[0].number for call in repair_check.call_args_list)
+        self.assertEqual(called_prs, [5933, 6951])
         self.assertTrue(should_poll)
 
     def test_run_cycle_waits_while_prerequisite_pr_is_open(self):

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -35,13 +35,12 @@ from scripts.mergify_admin_requeue_gh_executor import ADMIN_BYPASS_NUDGE_LEDGER_
 from scripts.mergify_admin_requeue_model import LoadedStacks, RepairOutcome
 from scripts.mergify_admin_requeue_loader import AdminBypassStackLoader
 from scripts.mergify_admin_requeue_logger import AdminBypassLogger
-from scripts.mergify_admin_requeue_repairer import (
+from scripts.mergify_admin_requeue_repair_body import (
     NON_TRUNK_MANUAL_SPLIT_ERROR,
-    NON_TRUNK_PREREQ_ERROR,
     PROOF_POLICY_LANE_ERROR,
     PROOF_TOOLING_POLICY_UNIT_ERROR,
-    AdminBypassRepairer,
 )
+from scripts.mergify_admin_requeue_repairer import AdminBypassRepairer
 from scripts.pr_worker_safe_push import SafePushError
 
 REQUIRED = {"PR Body", "quality / TypeScript Types"}
@@ -464,7 +463,7 @@ Failing checks
                 with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
                     with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                         with mock.patch.object(repairer, "run_claude_repair") as repair:
-                            with mock.patch.object(repairer, "validate_current_pr_body", return_value={"valid": True, "errors": []}):
+                            with mock.patch("scripts.mergify_admin_requeue_repairer.validate_current_pr_body", return_value={"valid": True, "errors": []}):
                                 with redirect_stderr(stderr):
                                     result = repairer.repair_check(item, "PR Body")
         checkout.assert_called_once()
@@ -504,7 +503,7 @@ Failing checks
                 with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
                     with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                         with mock.patch.object(repairer, "run_claude_repair"):
-                            with mock.patch.object(repairer, "validate_current_pr_body", return_value=validation):
+                            with mock.patch("scripts.mergify_admin_requeue_repairer.validate_current_pr_body", return_value=validation):
                                 result = repairer.repair_check(item, "PR Body")
         self.assertEqual(result.status, "blocked_invalid")
         self.assertIn(NON_TRUNK_MANUAL_SPLIT_ERROR, result.errors)
@@ -578,7 +577,7 @@ Failing checks
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log") as download:
                 with mock.patch.object(repairer, "job_log_is_empty", return_value=True):
                     with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
-                        with mock.patch.object(repairer, "validate_current_pr_body", return_value={"valid": True}):
+                        with mock.patch("scripts.mergify_admin_requeue_repairer.validate_current_pr_body", return_value={"valid": True}):
                             with mock.patch.object(repairer, "run_claude_repair") as repair:
                                 result = repairer.repair_check(item, "PR Body")
         checkout.assert_called_once()
@@ -753,7 +752,7 @@ Failing checks
                     with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=fake_git_output):
                         with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", side_effect=fake_git_lines):
                             with mock.patch("scripts.mergify_admin_requeue_repair_body.git_output", side_effect=fake_git_output):
-                                with mock.patch.object(repairer, "validate_local_pr_body", side_effect=lambda *_args: next(validator_results)):
+                                with mock.patch("scripts.mergify_admin_requeue_repair_body.validate_local_pr_body", side_effect=lambda *_args: next(validator_results)):
                                     with mock.patch.object(repairer, "push_branch", return_value="pushed-sha") as push_branch:
                                         result = repairer.repair_check(item, "PR Body", 123)
 

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -35,13 +35,7 @@ from scripts.mergify_admin_requeue_gh_executor import ADMIN_BYPASS_NUDGE_LEDGER_
 from scripts.mergify_admin_requeue_model import LoadedStacks, RepairOutcome
 from scripts.mergify_admin_requeue_loader import AdminBypassStackLoader
 from scripts.mergify_admin_requeue_logger import AdminBypassLogger
-from scripts.mergify_admin_requeue_repair_body import (
-    NON_TRUNK_MANUAL_SPLIT_ERROR,
-    PROOF_POLICY_LANE_ERROR,
-    PROOF_TOOLING_POLICY_UNIT_ERROR,
-)
 from scripts.mergify_admin_requeue_repairer import AdminBypassRepairer
-from scripts.pr_worker_safe_push import SafePushError
 
 REQUIRED = {"PR Body", "quality / TypeScript Types"}
 HEAD = "c2532d229dbed2fd57419698c48d973001c78e9e"
@@ -335,87 +329,59 @@ Failing checks
         actions = plan_stack_actions(stack, REQUIRED, ledger, 4)
         self.assertEqual([(a.kind, a.key) for a in actions], [("comment_blocked", "capped")])
 
-    def test_conflict_repair_records_and_caps_without_invoker(self):
-        class FakeGh:
-            def __init__(self):
-                self.comments = []
-
-            def comment(self, repo, pr_number, body):
-                self.comments.append((repo, pr_number, body))
-
+    def test_conflict_repair_submits_plan_and_caps_without_invoker(self):
         ledger = self.ledger()
         item = pr(2647, merge_state="DIRTY", latest=mergify())
-        prompts = []
-        repairer = self.repairer(FakeGh(), ledger, "Neko-Catpital-Labs/Invoker")
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
-                with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
-                    with mock.patch.object(repairer, "run_claude_repair", side_effect=lambda _work_root, prompt: prompts.append(prompt)):
-                        for epoch in range(3):
-                            repairer.repair_conflict(item, "GitHub reports merge conflict", epoch)
+        submitted = []
+        repairer = self.repairer(object(), ledger, "Neko-Catpital-Labs/Invoker")
+        with mock.patch(
+            "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
+            side_effect=lambda plan: submitted.append(plan),
+        ):
+            for epoch in range(3):
+                repairer.repair_conflict(item, "GitHub reports merge conflict", epoch)
         self.assertEqual(ledger.count("conflict-repair", 2647, HEAD, "conflict:2647"), 3)
-        self.assertEqual(len(prompts), 3)
-        self.assertIn("commit locally. Do not push.", prompts[0])
+        self.assertEqual(len(submitted), 3)
+        self.assertIn("commit locally. Do not push.", submitted[0].yaml_text)
         actions = plan_stack_actions(StackGroup("s", (item,)), REQUIRED, ledger, 4)
         self.assertEqual([(a.kind, a.key) for a in actions], [("comment_blocked", "capped")])
 
-    def test_repair_conflict_pushes_on_successful_resolution(self):
+    def test_repair_conflict_returns_submitted_and_records_ledger(self):
         item = pr(2660, merge_state="DIRTY", latest=mergify())
         ledger = self.ledger()
         repairer = self.repairer(object(), ledger)
-        new_head = "b" * 40
-        rev_parse = iter([HEAD, new_head])
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
-                    with mock.patch.object(repairer, "run_claude_repair"):
-                        with mock.patch.object(repairer, "push_branch", return_value=new_head) as push_branch:
-                            result = repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
-        self.assertEqual(result.status, "pushed")
+        with mock.patch("scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan") as submit:
+            result = repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
+        submit.assert_called_once()
+        self.assertEqual(result.status, "submitted")
         self.assertEqual(result.start_head, HEAD)
-        self.assertEqual(result.end_head, new_head)
-        push_branch.assert_called_once_with(mock.ANY, item.head_ref_name, expected_head=item.head_ref_oid)
+        self.assertEqual(result.end_head, HEAD)
         self.assertEqual(ledger.count("conflict-repair", item.number, item.head_ref_oid, f"conflict:{item.number}"), 1)
 
-    def test_repair_conflict_returns_stale_head_without_raising(self):
+    def test_repair_conflict_does_not_record_ledger_when_submission_fails(self):
         item = pr(2661, merge_state="DIRTY", latest=mergify())
         ledger = self.ledger()
         repairer = self.repairer(object(), ledger)
-        new_head = "c" * 40
-        rev_parse = iter([HEAD, new_head])
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
-                    with mock.patch.object(repairer, "run_claude_repair"):
-                        with mock.patch.object(repairer, "push_branch", side_effect=SafePushError("stale-head: refs/heads/x is deadbeef; expected " + HEAD)):
-                            result = repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
-        self.assertEqual(result.status, "stale_head")
-        self.assertIn("stale-head", result.errors[0])
-        self.assertEqual(ledger.count("conflict-repair", item.number, item.head_ref_oid, f"conflict:{item.number}"), 1)
+        with mock.patch(
+            "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
+            side_effect=RuntimeError("submit failed"),
+        ):
+            with self.assertRaises(RuntimeError):
+                repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
+        self.assertEqual(ledger.count("conflict-repair", item.number, item.head_ref_oid, f"conflict:{item.number}"), 0)
 
-    def test_repair_check_ledger_row_written_before_run_claude_repair_raises(self):
+    def test_repair_check_ledger_row_not_written_when_submission_fails(self):
         item = pr(2662, latest=mergify())
         ledger = self.ledger()
         repairer = self.repairer(object(), ledger)
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
-                with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
-                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
-                        with mock.patch.object(repairer, "run_claude_repair", side_effect=subprocess.CalledProcessError(1, ["claude"])):
-                            with self.assertRaises(subprocess.CalledProcessError):
-                                repairer.repair_check(item, "PR Body", 1)
-        self.assertEqual(ledger.count("repair-check", item.number, item.head_ref_oid, "PR Body"), 1)
-
-    def test_claude_repair_uses_claude_cli(self):
-        repairer = self.repairer(object(), self.ledger())
-        with mock.patch("scripts.mergify_admin_requeue_repairer.subprocess.run") as run:
-            repairer.run_claude_repair(Path("/tmp/work"), "repair this")
-        run.assert_called_once_with(
-            ["claude", "-p", "repair this", "--dangerously-skip-permissions"],
-            cwd="/tmp/work",
-            check=True,
-            text=True,
-        )
+        with mock.patch.object(repairer.executor, "download_job_log", return_value=""):
+            with mock.patch(
+                "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
+                side_effect=RuntimeError("submit failed"),
+            ):
+                with self.assertRaises(RuntimeError):
+                    repairer.repair_check(item, "PR Body", 1)
+        self.assertEqual(ledger.count("repair-check", item.number, item.head_ref_oid, "PR Body"), 0)
 
     def test_candidate_stack_includes_unlabeled_upper_prs(self):
         def raw(number, base, head, labels):
@@ -457,56 +423,25 @@ Failing checks
         stderr = io.StringIO()
         item = pr(2647, latest=mergify())
         repairer = self.repairer(object(), self.ledger())
-        git_rev_parse = iter([HEAD, HEAD])
+        submitted = []
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
-                with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
-                        with mock.patch.object(repairer, "run_claude_repair") as repair:
-                            with mock.patch("scripts.mergify_admin_requeue_repairer.validate_current_pr_body", return_value={"valid": True, "errors": []}):
-                                with redirect_stderr(stderr):
-                                    result = repairer.repair_check(item, "PR Body")
-        checkout.assert_called_once()
-        repair.assert_called_once()
-        self.assertEqual(result.status, "noop")
-        self.assertIn("Commit locally if needed, do not push.", repair.call_args.args[1])
+                with mock.patch.object(repairer, "job_log_is_empty", return_value=False):
+                    with mock.patch(
+                        "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
+                        side_effect=lambda plan: submitted.append(plan),
+                    ):
+                        with redirect_stderr(stderr):
+                            result = repairer.repair_check(item, "PR Body")
+        checkout.assert_not_called()
+        self.assertEqual(len(submitted), 1)
+        self.assertEqual(result.status, "submitted")
+        self.assertIn("Commit locally if needed, do not push.", submitted[0].yaml_text)
         log = stderr.getvalue()
         self.assertIn('"event": "admin-bypass-repair-check-start"', log)
         self.assertIn('"check_name": "PR Body"', log)
         self.assertIn('"log_path": "/tmp/pr-body.log"', log)
         self.assertIn('"pr_number": 2647', log)
-
-
-    def test_repair_check_noop_invalid_non_trunk_blocks_human_split(self):
-        item = pr(
-            5803,
-            base="stack/base",
-            body="## Summary\n\nMixed slice.\n",
-            checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")},
-        )
-        repairer = self.repairer(object(), self.ledger())
-        git_rev_parse = iter([HEAD, HEAD])
-        validation = {
-            "valid": False,
-            "errors": [
-                "PR body mentions multiple review units (validation-policy, routing); split into one conceptual unit per diff/task.",
-                "Review lane behavior cannot ship with policy, proof files in the same PR. Split behavior or cleanup from docs, policy, repro, and benchmark slices.",
-                'PR body Review Unit \"routing\" cannot ship with tooling-policy, proof files in the same PR. Split this into one Review Unit per PR.',
-            ],
-            "reviewLane": "behavior",
-            "reviewUnit": "routing",
-            "reviewUnits": ["routing", "tooling-policy", "proof"],
-            "scopeKinds": ["product", "policy"],
-        }
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
-                with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
-                        with mock.patch.object(repairer, "run_claude_repair"):
-                            with mock.patch("scripts.mergify_admin_requeue_repairer.validate_current_pr_body", return_value=validation):
-                                result = repairer.repair_check(item, "PR Body")
-        self.assertEqual(result.status, "blocked_invalid")
-        self.assertIn(NON_TRUNK_MANUAL_SPLIT_ERROR, result.errors)
 
     def test_plan_stack_actions_stop_retrying_after_repair_invalid(self):
         ledger = self.ledger()
@@ -514,8 +449,8 @@ Failing checks
         stack = StackGroup("s", (pr(2606, labels={"admin-bypass"}, checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}),))
         actions = plan_stack_actions(stack, REQUIRED, ledger, 2)
         self.assertEqual(actions, ())
-    def test_queue_only_repair_uses_mergify_job_log_and_returns_noop(self):
-        stderr = io.StringIO()
+
+    def test_queue_only_repair_with_evidence_submits_async_plan(self):
         latest = MergifyQueueEvent(
             "m5811",
             "dequeued",
@@ -530,22 +465,20 @@ Failing checks
         )
         item = pr(5811, labels={"admin-bypass", "dequeued"}, checks={}, latest=latest)
         repairer = self.repairer(object(), self.ledger())
-        git_rev_parse = iter([HEAD, HEAD])
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
-            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
-                with mock.patch.object(repairer, "job_log_has_evidence", return_value=True):
-                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                        with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
-                            with mock.patch.object(repairer, "run_claude_repair") as repair:
-                                with redirect_stderr(stderr):
-                                    result = repairer.repair_check(item, "required-fast / Guardrails")
-        checkout.assert_called_once()
-        repair.assert_called_once()
-        self.assertEqual(result.status, "queue_only_noop")
-        self.assertIn("Queue draft PR: #5854", repair.call_args.args[1])
-        self.assertIn("Job log path: /tmp/guardrails.log", repair.call_args.args[1])
+        submitted = []
+        with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
+            with mock.patch.object(repairer, "job_log_has_evidence", return_value=True):
+                with mock.patch(
+                    "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
+                    side_effect=lambda plan: submitted.append(plan),
+                ):
+                    result = repairer.repair_check(item, "required-fast / Guardrails")
+        self.assertEqual(result.status, "submitted")
+        self.assertEqual(len(submitted), 1)
+        self.assertIn("Queue draft PR: #5854", submitted[0].yaml_text)
+        self.assertIn("Job log path: /tmp/guardrails.log", submitted[0].yaml_text)
 
-    def test_queue_only_repair_empty_job_log_returns_noop_without_claude(self):
+    def test_queue_only_repair_empty_job_log_returns_noop_without_submitting(self):
         latest = MergifyQueueEvent(
             "m5811",
             "dequeued",
@@ -560,17 +493,14 @@ Failing checks
         )
         item = pr(5811, labels={"dequeued"}, checks={}, latest=latest)
         repairer = self.repairer(object(), self.ledger())
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
-            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
-                with mock.patch.object(repairer, "job_log_has_evidence", return_value=False):
-                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
-                        with mock.patch.object(repairer, "run_claude_repair") as repair:
-                            result = repairer.repair_check(item, "required-fast / Guardrails")
-        checkout.assert_called_once()
-        repair.assert_not_called()
+        with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
+            with mock.patch.object(repairer, "job_log_has_evidence", return_value=False):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan") as submit:
+                    result = repairer.repair_check(item, "required-fast / Guardrails")
+        submit.assert_not_called()
         self.assertEqual(result.status, "queue_only_noop")
 
-    def test_pr_body_valid_local_repair_returns_noop_without_claude(self):
+    def test_pr_body_valid_local_repair_returns_noop_without_submitting(self):
         item = pr(5810, checks={"PR Body": check("PR Body", "failure")}, body=PROOF_BODY)
         repairer = self.repairer(object(), self.ledger())
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
@@ -578,12 +508,13 @@ Failing checks
                 with mock.patch.object(repairer, "job_log_is_empty", return_value=True):
                     with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
                         with mock.patch("scripts.mergify_admin_requeue_repairer.validate_current_pr_body", return_value={"valid": True}):
-                            with mock.patch.object(repairer, "run_claude_repair") as repair:
+                            with mock.patch("scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan") as submit:
                                 result = repairer.repair_check(item, "PR Body")
         checkout.assert_called_once()
         download.assert_called_once()
-        repair.assert_not_called()
+        submit.assert_not_called()
         self.assertEqual(result.status, "noop")
+
     def test_run_cycle_logs_selected_bottom_repair_context(self):
         args = requeue.parse_args(["--once", "--dry-run", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
         stack = StackGroup("s", (pr(2606, checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}, latest=mergify()),))
@@ -681,93 +612,6 @@ Failing checks
         self.assertEqual(repair_check.call_count, 1)
         self.assertEqual(fake_gh.comments, [("owner/repo", 6602, "@mergifyio queue")])
         self.assertTrue(should_poll)
-
-    def test_repair_check_splits_tooling_policy_prerequisite(self):
-        class FakeGh:
-            def __init__(self):
-                self.created = []
-                self.label_edits = []
-                self.comments = []
-
-            def create_pr(self, repo, title, body, head, base):
-                self.created.append((repo, title, body, head, base))
-                return {"number": 5801}
-
-            def edit_label(self, repo, pr_number, *, add=None, remove=None):
-                self.label_edits.append((repo, pr_number, add, remove))
-
-            def comment(self, repo, pr_number, body):
-                self.comments.append((repo, pr_number, body))
-
-        item = pr(
-            5800,
-            latest=mergify(),
-            body=PROOF_BODY,
-            checks={"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")},
-        )
-        ledger = self.ledger()
-        fake = FakeGh()
-        repairer = self.repairer(fake, ledger)
-        rev_parse = iter([HEAD, "b" * 40])
-        git_commands = []
-
-        def fake_git_output(_work_root, *args):
-            git_commands.append(args)
-            if args == ("rev-parse", "HEAD"):
-                return next(rev_parse)
-            return ""
-
-        def fake_git_lines(_work_root, *args):
-            if args == ("status", "--porcelain"):
-                return ()
-            if args == ("rev-list", "--reverse", f"{HEAD}..{'b' * 40}"):
-                return ("commit-a",)
-            return ()
-
-        validator_results = iter([
-            {
-                "valid": False,
-                "errors": [
-                    PROOF_POLICY_LANE_ERROR,
-                    PROOF_TOOLING_POLICY_UNIT_ERROR,
-                ],
-                "reviewLane": "proof",
-                "reviewUnit": "proof",
-                "reviewUnits": ["tooling-policy"],
-                "scopeKinds": ["policy"],
-            },
-            {
-                "valid": True,
-                "errors": [],
-                "reviewLane": "policy",
-                "reviewUnit": "tooling-policy",
-                "reviewUnits": ["tooling-policy"],
-                "scopeKinds": ["policy"],
-            },
-        ])
-
-        with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
-                with mock.patch.object(repairer, "run_claude_repair"):
-                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=fake_git_output):
-                        with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", side_effect=fake_git_lines):
-                            with mock.patch("scripts.mergify_admin_requeue_repair_body.git_output", side_effect=fake_git_output):
-                                with mock.patch("scripts.mergify_admin_requeue_repair_body.validate_local_pr_body", side_effect=lambda *_args: next(validator_results)):
-                                    with mock.patch("scripts.mergify_admin_requeue_repair_body.safe_push", return_value="pushed-sha") as safe_push_mock:
-                                        result = repairer.repair_check(item, "PR Body", 123)
-
-        self.assertEqual(result.status, "prereq_created")
-        safe_push_mock.assert_called_once_with(branch="stack/pr-babysit-prereq-5800-c2532d2", expect_missing=True, cwd=mock.ANY)
-        self.assertEqual(fake.created[0][0], "owner/repo")
-        self.assertIn("[PR babysit] Tooling-policy repair prerequisite for #5800: PR Body", fake.created[0][1])
-        self.assertEqual(fake.label_edits, [("owner/repo", 5801, "admin-bypass", None)])
-        latest = ledger.latest("repair-prereq-created", 5800, HEAD, "PR Body")
-        self.assertIsNotNone(latest)
-        self.assertEqual(latest["meta"]["prNumber"], 5801)
-        self.assertIn(("checkout", "-B", "stack/pr-babysit-prereq-5800-c2532d2", "origin/master"), git_commands)
-        self.assertIn(("checkout", "-B", item.head_ref_name, HEAD), git_commands)
-        self.assertIn(("reset", "--hard", HEAD), git_commands)
-        self.assertEqual(fake.comments, [])
 
     def test_run_cycle_waits_while_prerequisite_pr_is_open(self):
         ledger = self.ledger()

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -753,11 +753,11 @@ Failing checks
                         with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", side_effect=fake_git_lines):
                             with mock.patch("scripts.mergify_admin_requeue_repair_body.git_output", side_effect=fake_git_output):
                                 with mock.patch("scripts.mergify_admin_requeue_repair_body.validate_local_pr_body", side_effect=lambda *_args: next(validator_results)):
-                                    with mock.patch.object(repairer, "push_branch", return_value="pushed-sha") as push_branch:
+                                    with mock.patch("scripts.mergify_admin_requeue_repair_body.safe_push", return_value="pushed-sha") as safe_push_mock:
                                         result = repairer.repair_check(item, "PR Body", 123)
 
         self.assertEqual(result.status, "prereq_created")
-        push_branch.assert_called_once_with(mock.ANY, "stack/pr-babysit-prereq-5800-c2532d2", expect_missing=True)
+        safe_push_mock.assert_called_once_with(branch="stack/pr-babysit-prereq-5800-c2532d2", expect_missing=True, cwd=mock.ANY)
         self.assertEqual(fake.created[0][0], "owner/repo")
         self.assertIn("[PR babysit] Tooling-policy repair prerequisite for #5800: PR Body", fake.created[0][1])
         self.assertEqual(fake.label_edits, [("owner/repo", 5801, "admin-bypass", None)])

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -10,6 +10,7 @@ from unittest import mock
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import scripts.mergify_admin_requeue as requeue
 import scripts.mergify_admin_requeue_exec as exec_impl
+import scripts.mergify_admin_requeue_headless_shell as headless_shell
 import scripts.mergify_admin_requeue_workflow_fastpath as fastpath
 
 from scripts.mergify_admin_requeue import (
@@ -1117,7 +1118,7 @@ The merge conditions cannot be satisfied due to failing checks
 class WorkflowFastpathTests(unittest.TestCase):
     def test_resolve_workflow_for_pr_sources_headless_lib_and_parses_workflow_id(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout='{"workflowId": "wf-1-1"}\n', stderr="")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed) as run:
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed) as run:
             result = fastpath.resolve_workflow_for_pr(6579)
         self.assertEqual(result, "wf-1-1")
         args = run.call_args.args[0]
@@ -1130,19 +1131,19 @@ class WorkflowFastpathTests(unittest.TestCase):
 
     def test_resolve_workflow_for_pr_returns_none_on_genuine_miss(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}\n", stderr="")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed):
             result = fastpath.resolve_workflow_for_pr(6579)
         self.assertIsNone(result)
 
     def test_resolve_workflow_for_pr_raises_on_lookup_failure(self):
         completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed):
             with self.assertRaises(RuntimeError):
                 fastpath.resolve_workflow_for_pr(6579)
 
     def test_submit_rebase_recreate_command_shape(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed) as run:
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed) as run:
             fastpath.submit_rebase_recreate("wf-1-1")
         args = run.call_args.args[0]
         self.assertEqual(args[0], "bash")
@@ -1154,13 +1155,13 @@ class WorkflowFastpathTests(unittest.TestCase):
 
     def test_submit_rebase_recreate_raises_on_failure(self):
         completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed):
             with self.assertRaises(RuntimeError):
                 fastpath.submit_rebase_recreate("wf-1-1")
 
     def test_submit_repair_review_gate_ci_command_shape(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed) as run:
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed) as run:
             fastpath.submit_repair_review_gate_ci(6579)
         args = run.call_args.args[0]
         self.assertEqual(args[0], "bash")
@@ -1172,7 +1173,7 @@ class WorkflowFastpathTests(unittest.TestCase):
 
     def test_submit_repair_review_gate_ci_raises_on_failure(self):
         completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
-        with mock.patch.object(fastpath.subprocess, "run", return_value=completed):
+        with mock.patch.object(headless_shell.subprocess, "run", return_value=completed):
             with self.assertRaises(RuntimeError):
                 fastpath.submit_repair_review_gate_ci(6579)
 

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -349,8 +349,8 @@ Failing checks
         prompts = []
         repairer = self.repairer(FakeGh(), ledger, "Neko-Catpital-Labs/Invoker")
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch.object(repairer, "git_output", return_value=HEAD):
-                with mock.patch.object(repairer, "git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                     with mock.patch.object(repairer, "run_claude_repair", side_effect=lambda _work_root, prompt: prompts.append(prompt)):
                         for epoch in range(3):
                             repairer.repair_conflict(item, "GitHub reports merge conflict", epoch)
@@ -367,8 +367,8 @@ Failing checks
         new_head = "b" * 40
         rev_parse = iter([HEAD, new_head])
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                with mock.patch.object(repairer, "git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(rev_parse) if args == ("rev-parse", "HEAD") else ""):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                     with mock.patch.object(repairer, "run_claude_repair"):
                         with mock.patch.object(repairer, "push_branch", return_value=new_head) as push_branch:
                             result = repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
@@ -385,8 +385,8 @@ Failing checks
         new_head = "c" * 40
         rev_parse = iter([HEAD, new_head])
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
-            with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                with mock.patch.object(repairer, "git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(rev_parse) if args == ("rev-parse", "HEAD") else ""):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                     with mock.patch.object(repairer, "run_claude_repair"):
                         with mock.patch.object(repairer, "push_branch", side_effect=SafePushError("stale-head: refs/heads/x is deadbeef; expected " + HEAD)):
                             result = repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
@@ -400,8 +400,8 @@ Failing checks
         repairer = self.repairer(object(), ledger)
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
-                with mock.patch.object(repairer, "git_output", return_value=HEAD):
-                    with mock.patch.object(repairer, "git_lines", return_value=()):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
+                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                         with mock.patch.object(repairer, "run_claude_repair", side_effect=subprocess.CalledProcessError(1, ["claude"])):
                             with self.assertRaises(subprocess.CalledProcessError):
                                 repairer.repair_check(item, "PR Body", 1)
@@ -461,8 +461,8 @@ Failing checks
         git_rev_parse = iter([HEAD, HEAD])
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
-                with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                    with mock.patch.object(repairer, "git_lines", return_value=()):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
+                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                         with mock.patch.object(repairer, "run_claude_repair") as repair:
                             with mock.patch.object(repairer, "validate_current_pr_body", return_value={"valid": True, "errors": []}):
                                 with redirect_stderr(stderr):
@@ -501,8 +501,8 @@ Failing checks
         }
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
-                with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                    with mock.patch.object(repairer, "git_lines", return_value=()):
+                with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
+                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                         with mock.patch.object(repairer, "run_claude_repair"):
                             with mock.patch.object(repairer, "validate_current_pr_body", return_value=validation):
                                 result = repairer.repair_check(item, "PR Body")
@@ -535,8 +535,8 @@ Failing checks
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
                 with mock.patch.object(repairer, "job_log_has_evidence", return_value=True):
-                    with mock.patch.object(repairer, "git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
-                        with mock.patch.object(repairer, "git_lines", return_value=()):
+                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=lambda _work_root, *args: next(git_rev_parse) if args == ("rev-parse", "HEAD") else ""):
+                        with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", return_value=()):
                             with mock.patch.object(repairer, "run_claude_repair") as repair:
                                 with redirect_stderr(stderr):
                                     result = repairer.repair_check(item, "required-fast / Guardrails")
@@ -564,7 +564,7 @@ Failing checks
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/guardrails.log"):
                 with mock.patch.object(repairer, "job_log_has_evidence", return_value=False):
-                    with mock.patch.object(repairer, "git_output", return_value=HEAD):
+                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
                         with mock.patch.object(repairer, "run_claude_repair") as repair:
                             result = repairer.repair_check(item, "required-fast / Guardrails")
         checkout.assert_called_once()
@@ -577,7 +577,7 @@ Failing checks
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head") as checkout:
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log") as download:
                 with mock.patch.object(repairer, "job_log_is_empty", return_value=True):
-                    with mock.patch.object(repairer, "git_output", return_value=HEAD):
+                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", return_value=HEAD):
                         with mock.patch.object(repairer, "validate_current_pr_body", return_value={"valid": True}):
                             with mock.patch.object(repairer, "run_claude_repair") as repair:
                                 result = repairer.repair_check(item, "PR Body")
@@ -750,11 +750,12 @@ Failing checks
         with mock.patch("scripts.mergify_admin_requeue_repairer.checkout_pr_head"):
             with mock.patch.object(repairer.executor, "download_job_log", return_value="/tmp/pr-body.log"):
                 with mock.patch.object(repairer, "run_claude_repair"):
-                    with mock.patch.object(repairer, "git_output", side_effect=fake_git_output):
-                        with mock.patch.object(repairer, "git_lines", side_effect=fake_git_lines):
-                            with mock.patch.object(repairer, "validate_local_pr_body", side_effect=lambda *_args: next(validator_results)):
-                                with mock.patch.object(repairer, "push_branch", return_value="pushed-sha") as push_branch:
-                                    result = repairer.repair_check(item, "PR Body", 123)
+                    with mock.patch("scripts.mergify_admin_requeue_repairer.git_output", side_effect=fake_git_output):
+                        with mock.patch("scripts.mergify_admin_requeue_repairer.git_lines", side_effect=fake_git_lines):
+                            with mock.patch("scripts.mergify_admin_requeue_repair_body.git_output", side_effect=fake_git_output):
+                                with mock.patch.object(repairer, "validate_local_pr_body", side_effect=lambda *_args: next(validator_results)):
+                                    with mock.patch.object(repairer, "push_branch", return_value="pushed-sha") as push_branch:
+                                        result = repairer.repair_check(item, "PR Body", 123)
 
         self.assertEqual(result.status, "prereq_created")
         push_branch.assert_called_once_with(mock.ANY, "stack/pr-babysit-prereq-5800-c2532d2", expect_missing=True)

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -1,0 +1,155 @@
+"""Behavioural tests for mergify_admin_requeue_async_repair's plan builders.
+
+Run:  python3 scripts/test_mergify_admin_requeue_async_repair.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import scripts.mergify_admin_requeue_async_repair as async_repair
+import scripts.mergify_admin_requeue_model as m
+
+HEAD = "c2532d229dbed2fd57419698c48d973001c78e9e"
+
+
+def pr(**kw):
+    base = dict(
+        number=2647,
+        title='Fix "quoted" title: with colons',
+        body="",
+        url="https://github.com/owner/repo/pull/2647",
+        state="OPEN",
+        is_draft=False,
+        base_ref_name="master",
+        head_ref_name="stack/2647",
+        head_ref_oid=HEAD,
+        merge_state_status="CLEAN",
+        mergeable="MERGEABLE",
+        labels=frozenset({"admin-bypass"}),
+        checks={},
+        review_threads=(),
+        latest_mergify=None,
+    )
+    base.update(kw)
+    return m.PrSnapshot(**base)
+
+
+class AsyncRepairPlanTests(unittest.TestCase):
+    def test_all_three_plan_kinds_produce_parseable_yaml_with_expected_task_ids(self):
+        checks_plan = async_repair.build_repair_check_plan(
+            pr(), "PR Body", repo="owner/repo", details_url="https://example.invalid/job",
+            log_path="/tmp/pr-body.log", queue_only=False, queue_pr_number=0, latest=None,
+            start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
+        )
+        conflict_plan = async_repair.build_repair_conflict_plan(
+            pr(), "GitHub reports merge conflict", repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
+        )
+        bot_thread_plan = async_repair.build_repair_bot_thread_plan(
+            pr(), "tbot", repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
+        )
+        for plan, expected_task_ids in (
+            (checks_plan, ["repair", "normalize", "safe-push"]),
+            (conflict_plan, ["repair", "safe-push"]),
+            (bot_thread_plan, ["repair", "safe-push"]),
+        ):
+            with self.subTest(plan=plan.plan_name):
+                doc = yaml.safe_load(plan.yaml_text)
+                self.assertEqual(doc["onFinish"], "none")
+                self.assertEqual(doc["repoUrl"], "https://github.com/owner/repo.git")
+                self.assertEqual([task["id"] for task in doc["tasks"]], expected_task_ids)
+                for task, expected_id in zip(doc["tasks"][1:], expected_task_ids[1:]):
+                    self.assertEqual(task["dependencies"], [expected_task_ids[expected_task_ids.index(expected_id) - 1]])
+
+    def test_repair_check_plan_includes_three_tasks_in_dependency_order(self):
+        plan = async_repair.build_repair_check_plan(
+            pr(),
+            "PR Body",
+            repo="owner/repo",
+            details_url="https://example.invalid/job",
+            log_path="/tmp/pr-body.log",
+            queue_only=False,
+            queue_pr_number=0,
+            latest=None,
+            start_head=HEAD,
+            state_file=Path("/tmp/ledger.jsonl"),
+        )
+        self.assertIn("id: repair", plan.yaml_text)
+        self.assertIn("id: normalize", plan.yaml_text)
+        self.assertIn("id: safe-push", plan.yaml_text)
+        self.assertIn("dependencies: [repair]", plan.yaml_text)
+        self.assertIn("dependencies: [normalize]", plan.yaml_text)
+        self.assertIn("mergify_admin_requeue_repair_normalize.py", plan.yaml_text)
+        self.assertIn("--json-kind 'repair-check-settled'", plan.yaml_text)
+        self.assertIn("Failed check: PR Body", plan.yaml_text)
+        # PR titles with quotes/colons must not corrupt the YAML document.
+        self.assertIn('Fix \\"quoted\\" title: with colons', plan.yaml_text)
+
+    def test_repair_check_plan_queue_only_appends_queue_pr_line(self):
+        plan = async_repair.build_repair_check_plan(
+            pr(checks={}),
+            "required-fast / Guardrails",
+            repo="owner/repo",
+            details_url="https://example.invalid/job",
+            log_path="/tmp/guardrails.log",
+            queue_only=True,
+            queue_pr_number=5854,
+            latest=None,
+            start_head=HEAD,
+            state_file=Path("/tmp/ledger.jsonl"),
+        )
+        self.assertIn("Queue draft PR: #5854", plan.yaml_text)
+
+    def test_repair_conflict_plan_has_two_tasks_and_conflict_key(self):
+        plan = async_repair.build_repair_conflict_plan(
+            pr(), "GitHub reports merge conflict", repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
+        )
+        self.assertIn("id: repair", plan.yaml_text)
+        self.assertIn("id: safe-push", plan.yaml_text)
+        self.assertNotIn("id: normalize", plan.yaml_text)
+        self.assertIn("--json-kind 'conflict-repair-settled'", plan.yaml_text)
+        self.assertIn("--json-key 'conflict:2647'", plan.yaml_text)
+        self.assertIn("commit locally. Do not push.", plan.yaml_text)
+
+    def test_repair_bot_thread_plan_uses_thread_id_as_key(self):
+        plan = async_repair.build_repair_bot_thread_plan(
+            pr(), "tbot", repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
+        )
+        self.assertIn("--json-kind 'repair-bot-thread-settled'", plan.yaml_text)
+        self.assertIn("--json-key 'tbot'", plan.yaml_text)
+        self.assertIn("Thread: tbot", plan.yaml_text)
+
+    def test_submit_async_repair_plan_calls_headless_run_and_cleans_up_temp_file(self):
+        plan = async_repair.AsyncRepairPlan(plan_name="admin-bypass-repair-check-pr-1-abc", yaml_text="name: x\n")
+        completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}\n", stderr="")
+        written_paths = []
+
+        def fake_run_headless(command, *extra_args):
+            written_paths.append(Path(extra_args[0]))
+            self.assertTrue(written_paths[-1].exists())
+            self.assertEqual(written_paths[-1].read_text(encoding="utf-8"), "name: x\n")
+            return completed
+
+        with mock.patch("scripts.mergify_admin_requeue_async_repair.run_headless", side_effect=fake_run_headless) as run:
+            async_repair.submit_async_repair_plan(plan)
+        run.assert_called_once()
+        self.assertFalse(written_paths[0].exists())
+
+    def test_submit_async_repair_plan_raises_on_failure(self):
+        plan = async_repair.AsyncRepairPlan(plan_name="p", yaml_text="name: x\n")
+        completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")
+        with mock.patch("scripts.mergify_admin_requeue_async_repair.run_headless", return_value=completed):
+            with self.assertRaises(RuntimeError):
+                async_repair.submit_async_repair_plan(plan)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_mergify_admin_requeue_infra_signal.py
+++ b/scripts/test_mergify_admin_requeue_infra_signal.py
@@ -1,0 +1,104 @@
+"""Behavioural tests for ``mergify_admin_requeue_infra_signal``.
+
+Documentation-by-test: given a stubbed ``run_headless_fn`` standing in for the
+real Invoker headless CLI bridge, prove the two lookups this module performs
+-- find a workflow by its exact plan name, then check whether that workflow's
+`repair` task output contains the known SSH/OAuth infra crash signature.
+
+Run:  python3 scripts/test_mergify_admin_requeue_infra_signal.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import mergify_admin_requeue_infra_signal as s
+
+
+def completed(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args=["fake"], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def workflows_json(*rows):
+    return completed(stdout=json.dumps(list(rows)))
+
+
+class FindLatestWorkflowId(unittest.TestCase):
+    def test_none_when_command_fails(self):
+        calls = []
+        result = s.find_latest_workflow_id("plan-a", run_headless_fn=lambda *a: calls.append(a) or completed(returncode=1))
+        self.assertIsNone(result)
+        self.assertEqual(len(calls), 1)
+
+    def test_none_when_output_is_not_json(self):
+        result = s.find_latest_workflow_id("plan-a", run_headless_fn=lambda *a: completed(stdout="not json"))
+        self.assertIsNone(result)
+
+    def test_none_when_no_workflow_matches_the_name(self):
+        result = s.find_latest_workflow_id(
+            "plan-a",
+            run_headless_fn=lambda *a: workflows_json({"id": "wf-1", "name": "plan-b", "createdAt": "2026-01-01T00:00:00Z"}),
+        )
+        self.assertIsNone(result)
+
+    def test_returns_the_most_recently_created_match(self):
+        result = s.find_latest_workflow_id(
+            "plan-a",
+            run_headless_fn=lambda *a: workflows_json(
+                {"id": "wf-old", "name": "plan-a", "createdAt": "2026-01-01T00:00:00Z"},
+                {"id": "wf-new", "name": "plan-a", "createdAt": "2026-01-02T00:00:00Z"},
+                {"id": "wf-other", "name": "plan-b", "createdAt": "2026-01-03T00:00:00Z"},
+            ),
+        )
+        self.assertEqual(result, "wf-new")
+
+
+class RepairTaskCrashedOnInfra(unittest.TestCase):
+    def _run_headless_fn(self, workflows_result, task_output_result):
+        def run_headless_fn(command, *extra_args):
+            if "query workflows" in command:
+                return workflows_result
+            self.assertIn("task-output", command)
+            self.assertEqual(extra_args, ("wf-1/repair",))
+            return task_output_result
+        return run_headless_fn
+
+    def test_false_when_workflow_not_found(self):
+        result = s.repair_task_crashed_on_infra(
+            "plan-a", run_headless_fn=lambda *a: completed(returncode=1),
+        )
+        self.assertFalse(result)
+
+    def test_false_when_task_output_query_fails(self):
+        run_headless_fn = self._run_headless_fn(
+            workflows_json({"id": "wf-1", "name": "plan-a", "createdAt": "2026-01-01T00:00:00Z"}),
+            completed(returncode=1),
+        )
+        result = s.repair_task_crashed_on_infra("plan-a", run_headless_fn=run_headless_fn)
+        self.assertFalse(result)
+
+    def test_false_when_output_does_not_contain_the_signature(self):
+        run_headless_fn = self._run_headless_fn(
+            workflows_json({"id": "wf-1", "name": "plan-a", "createdAt": "2026-01-01T00:00:00Z"}),
+            completed(stdout="Done in 12s using pnpm\nsome ordinary failure\n"),
+        )
+        result = s.repair_task_crashed_on_infra("plan-a", run_headless_fn=run_headless_fn)
+        self.assertFalse(result)
+
+    def test_true_when_output_contains_the_exact_captured_signature(self):
+        run_headless_fn = self._run_headless_fn(
+            workflows_json({"id": "wf-1", "name": "plan-a", "createdAt": "2026-01-01T00:00:00Z"}),
+            completed(stdout="[SshExecutor] Running task payload...\n" + s.SSH_OAUTH_INFRA_SIGNATURE + "\n"),
+        )
+        result = s.repair_task_crashed_on_infra("plan-a", run_headless_fn=run_headless_fn)
+        self.assertTrue(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -25,6 +25,7 @@ import mergify_admin_requeue_plan as p
 HEAD = "a" * 40
 REQUIRED = {"build"}
 QUEUE_ONLY_CHECK = "required-fast / Guardrails"
+NOW = 2_000_000_000
 
 
 def check(state, name="build"):
@@ -307,7 +308,7 @@ class BuildStackFacts(PlannerTestCase):
         )
         self.assertEqual(facts.suppressed_failed_checks_by_pr, {10: (QUEUE_ONLY_CHECK, "PR Body")})
         self.assertEqual(facts.blockers_by_pr[10], ())
-        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3, now=NOW)
         self.assertEqual([(action.kind, action.key) for action in actions], [("restore_admin_bypass_label", QUEUE_ONLY_CHECK)])
 
     def test_detects_bottom_and_unaccepted_upper(self):
@@ -331,7 +332,7 @@ class PlanStackActions(PlannerTestCase):
         ledger = ledger or self._ledger()
         stack = stack_or_snapshot if isinstance(stack_or_snapshot, m.StackGroup) else m.StackGroup("s", (stack_or_snapshot,))
         facts = p.build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head or {}, "master")
-        return p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        return p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3, now=NOW)
 
     def test_pending_check_means_wait_do_nothing(self):
         self.assertEqual(self._plan(pr(checks={"build": check("pending")})), ())
@@ -597,7 +598,7 @@ class PlanStackActions(PlannerTestCase):
         )
         facts, ledger = self._facts(stack, open_pr_numbers_by_head={})
         self.assertEqual(facts.bottom_topology.kind, "stale_unowned_base")
-        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3, now=NOW)
         self.assertEqual((actions[0].kind, actions[0].pr_number, actions[0].key), ("retarget_base", 5885, "master"))
         self.assertIn("`pr/babysit-prereq-split`", actions[0].detail)
         self.assertIn("`master`", actions[0].detail)
@@ -620,7 +621,7 @@ class PlanStackActions(PlannerTestCase):
         )
         facts, ledger = self._facts(stack, open_pr_numbers_by_head={"pr/babysit-prereq-split": (7001,)})
         self.assertEqual(facts.bottom_topology.kind, "external_open_base")
-        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3, now=NOW)
         self.assertEqual((actions[0].kind, actions[0].pr_number, actions[0].key), ("comment_blocked", 5885, "external-open-base-pr"))
         self.assertIn("#7001", actions[0].detail)
 
@@ -644,7 +645,7 @@ class PlanStackActions(PlannerTestCase):
         )
         facts, ledger = self._facts(stale_stack, open_pr_numbers_by_head={})
         self.assertEqual(facts.bottom_topology.kind, "stale_unowned_base")
-        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3)
+        actions = p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3, now=NOW)
         self.assertEqual([(action.kind, action.pr_number) for action in actions], [("retarget_base", 5885)])
 
     def test_stale_root_failed_check_repairs_before_retarget(self):

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -14,6 +14,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -716,6 +717,115 @@ class PlanStackActions(PlannerTestCase):
             [(action.kind, action.pr_number, action.detail) for action in self._plan(after_land)],
             [("requeue", 11, "eligible-when-ready")],
         )
+
+
+class RepairCrashReason(PlannerTestCase):
+    """A submitted repair whose own Invoker workflow crashed with the known
+    SSH/OAuth infra signature (the coding agent never launched) must not be
+    silently treated the same as a normal failed repair attempt: it should
+    neither keep eating the retry cap nor resubmit forever waiting on the
+    in-flight TTL, since no amount of waiting changes an infra crash."""
+
+    def test_none_when_never_submitted(self):
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra") as crash_check:
+            result = p.repair_crash_reason(self._ledger(), 1, HEAD, "repair-check", "build", "plan-name")
+        self.assertIsNone(result)
+        crash_check.assert_not_called()
+
+    def test_none_when_already_settled(self):
+        ledger = self._ledger()
+        ledger.record("repair-check", 1, HEAD, "build", epoch=NOW - 100)
+        ledger.record("repair-check-settled", 1, HEAD, "build", epoch=NOW - 50)
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra") as crash_check:
+            result = p.repair_crash_reason(ledger, 1, HEAD, "repair-check", "build", "plan-name")
+        self.assertIsNone(result)
+        crash_check.assert_not_called()
+
+    def test_signature_returned_when_still_unsettled_and_workflow_crashed(self):
+        ledger = self._ledger()
+        ledger.record("repair-check", 1, HEAD, "build", epoch=NOW - 100)
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=True) as crash_check:
+            result = p.repair_crash_reason(ledger, 1, HEAD, "repair-check", "build", "plan-name")
+        self.assertEqual(result, p.SSH_OAUTH_INFRA_SIGNATURE)
+        crash_check.assert_called_once_with("plan-name")
+
+    def test_none_when_unsettled_but_workflow_did_not_crash_on_infra(self):
+        ledger = self._ledger()
+        ledger.record("repair-check", 1, HEAD, "build", epoch=NOW - 100)
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=False):
+            result = p.repair_crash_reason(ledger, 1, HEAD, "repair-check", "build", "plan-name")
+        self.assertIsNone(result)
+
+
+class InfraCrashStopsResubmission(PlannerTestCase):
+    """Each of the three repair call sites must report the infra crash once
+    and stop, instead of resubmitting, when the previously submitted repair
+    for the same (pr, head, kind, key) crashed on the SSH/OAuth signature."""
+
+    def test_plan_direct_repairs_failed_check(self):
+        ledger = self._ledger()
+        ledger.record("repair-check", 1, HEAD, "build", epoch=NOW - 100)
+        snapshot = pr(labels=frozenset({"admin-bypass"}), checks={"build": check("failure")})
+        facts, _ = self._facts(m.StackGroup("s", (snapshot,)), ledger=ledger)
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=True):
+            action = p.plan_direct_repairs(facts, ledger, max_repair_attempts=3, now=NOW)
+        self.assertEqual(action.kind, "comment_blocked")
+        self.assertEqual(action.key, "infra-blocked:build")
+        self.assertIn(p.SSH_OAUTH_INFRA_SIGNATURE, action.detail)
+        # The crashed attempt is not retried, and the cap is not spent on it.
+        self.assertEqual(ledger.count("repair-check", 1, HEAD, "build"), 1)
+
+    def test_plan_direct_repairs_conflict(self):
+        ledger = self._ledger()
+        key = "conflict:1"
+        ledger.record("conflict-repair", 1, HEAD, key, epoch=NOW - 100)
+        snapshot = pr(labels=frozenset({"admin-bypass"}), merge_state_status="DIRTY", mergeable="CONFLICTING")
+        facts, _ = self._facts(m.StackGroup("s", (snapshot,)), ledger=ledger)
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=True):
+            action = p.plan_direct_repairs(facts, ledger, max_repair_attempts=3, now=NOW)
+        self.assertEqual((action.kind, action.key), ("comment_blocked", f"infra-blocked:{key}"))
+        self.assertEqual(ledger.count("conflict-repair", 1, HEAD, key), 1)
+
+    def test_plan_bot_thread_repairs(self):
+        ledger = self._ledger()
+        ledger.record("repair-bot-thread", 10, HEAD, "PRRT_bot", epoch=NOW - 100)
+        snapshot = pr(
+            number=10,
+            labels=frozenset({"admin-bypass"}),
+            review_threads=(m.ReviewThread("PRRT_bot", False, ("coderabbitai[bot]",)),),
+        )
+        facts, _ = self._facts(m.StackGroup("s", (snapshot,)), ledger=ledger)
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=True):
+            action = p.plan_bot_thread_repairs(facts, ledger, max_repair_attempts=3, now=NOW)
+        self.assertEqual((action.kind, action.key), ("comment_blocked", "infra-blocked:PRRT_bot"))
+        self.assertEqual(ledger.count("repair-bot-thread", 10, HEAD, "PRRT_bot"), 1)
+
+    def test_mergify_failed_check_actions(self):
+        ledger = self._ledger()
+        ledger.record("repair-check", 1, HEAD, "build", epoch=NOW - 100)
+        snapshot = pr(
+            labels=frozenset({"admin-bypass"}),
+            latest_mergify=event(state="dequeued", failing=("build",)),
+        )
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=True):
+            actions = p.mergify_failed_check_actions(snapshot, ledger, max_repair_attempts=3, now=NOW)
+        self.assertEqual(len(actions), 1)
+        self.assertEqual((actions[0].kind, actions[0].key), ("comment_blocked", "infra-blocked:build"))
+        self.assertEqual(ledger.count("repair-check", 1, HEAD, "build"), 1)
+
+    def test_real_infra_crash_does_not_block_a_genuinely_still_running_attempt(self):
+        # Regression guard: repair_task_crashed_on_infra is only consulted
+        # when the submission is not settled; if it returns False (a real
+        # workflow genuinely still running, or one that failed for an
+        # unrelated reason), normal repair_in_flight/TTL behavior must still
+        # apply unchanged.
+        ledger = self._ledger()
+        ledger.record("repair-check", 1, HEAD, "build", epoch=NOW - 100)
+        snapshot = pr(labels=frozenset({"admin-bypass"}), checks={"build": check("failure")})
+        facts, _ = self._facts(m.StackGroup("s", (snapshot,)), ledger=ledger)
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=False):
+            action = p.plan_direct_repairs(facts, ledger, max_repair_attempts=3, now=NOW)
+        self.assertIsNone(action)
 
 
 class PlanStackExecution(PlannerTestCase):

--- a/scripts/test_mergify_admin_requeue_repair_normalize.py
+++ b/scripts/test_mergify_admin_requeue_repair_normalize.py
@@ -1,0 +1,164 @@
+"""Behavioural tests for mergify_admin_requeue_repair_normalize's CLI.
+
+This is the async replacement for the local post-run_claude_repair inspection
+AdminBypassRepairer.repair_check used to do synchronously: dirty-check/reset,
+normalize_repair_commit, PR-body re-validation, and (on a restructuring-needed
+verdict) create_repair_prerequisite instead of a direct push.
+
+Run:  python3 scripts/test_mergify_admin_requeue_repair_normalize.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import scripts.mergify_admin_requeue_repair_normalize as normalize
+
+HEAD = "c2532d229dbed2fd57419698c48d973001c78e9e"
+NEW_HEAD = "b" * 40
+
+PROOF_TOOLING_POLICY_VALIDATION = {
+    "valid": False,
+    "errors": [
+        "Review lane proof cannot ship with policy files in the same PR. "
+        "Keep benchmarks, repros, and regression proof separate from behavior or policy changes.",
+        'PR body Review Unit "proof" cannot ship with tooling-policy files in the same PR. '
+        "Split this into one Review Unit per PR.",
+    ],
+    "reviewLane": "proof",
+    "reviewUnit": "proof",
+    "reviewUnits": ["tooling-policy"],
+    "scopeKinds": ["policy"],
+}
+
+MANUAL_SPLIT_VALIDATION = {
+    "valid": False,
+    "errors": [
+        "PR body mentions multiple review units (validation-policy, routing); split into one conceptual unit per diff/task.",
+        'PR body Review Unit "routing" cannot ship with tooling-policy, proof files in the same PR. '
+        "Split this into one Review Unit per PR.",
+    ],
+    "reviewLane": "behavior",
+    "reviewUnit": "routing",
+    "reviewUnits": ["routing", "tooling-policy", "proof"],
+    "scopeKinds": ["product", "policy"],
+}
+
+
+class RepairNormalizeTests(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.cwd = os.getcwd()
+        os.chdir(tmp.name)
+        self.addCleanup(os.chdir, self.cwd)
+        self.state_file = Path(tmp.name) / "ledger.jsonl"
+
+    def argv(self, **overrides):
+        base = {
+            "--repo": "owner/repo",
+            "--pr": "2647",
+            "--check": "PR Body",
+            "--start-head": HEAD,
+            "--base": "master",
+            "--trunk": "master",
+            "--state-file": str(self.state_file),
+        }
+        base.update(overrides)
+        out = []
+        for key, value in base.items():
+            out += [key, value]
+        return out
+
+    def settled_rows(self):
+        if not self.state_file.exists():
+            return []
+        return [line for line in self.state_file.read_text(encoding="utf-8").splitlines() if '"repair-check-settled"' in line]
+
+    def test_records_settle_marker_first_regardless_of_outcome(self):
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=("M file.py",)):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.hard_reset_work_root"):
+                code = normalize.main(self.argv())
+        self.assertEqual(code, 1)
+        self.assertEqual(len(self.settled_rows()), 1)
+
+    def test_dirty_working_tree_resets_and_fails(self):
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=("M file.py",)):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.hard_reset_work_root") as reset:
+                code = normalize.main(self.argv())
+        self.assertEqual(code, 1)
+        reset.assert_called_once_with(Path.cwd(), HEAD)
+
+    def test_no_commit_returns_zero_without_further_work(self):
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
+                    code = normalize.main(self.argv())
+        self.assertEqual(code, 0)
+        gh_cls.assert_not_called()
+
+    def test_valid_body_ready_for_push_returns_zero(self):
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=NEW_HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.normalize_repair_commit", return_value=NEW_HEAD):
+                    with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
+                        gh_cls.return_value.pr_detail.return_value = {"body": "## Summary\n\nok\n"}
+                        with mock.patch(
+                            "scripts.mergify_admin_requeue_repair_normalize.validate_current_pr_body",
+                            return_value={"valid": True, "errors": []},
+                        ):
+                            code = normalize.main(self.argv())
+        self.assertEqual(code, 0)
+        self.assertFalse(normalize.PREREQ_SENTINEL.exists())
+
+    def test_prereq_split_creates_prerequisite_and_writes_sentinel(self):
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=("commit-a",)) as git_lines:
+            git_lines.side_effect = lambda cwd, *args: ("commit-a",) if args[:1] == ("rev-list",) else ()
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=NEW_HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.normalize_repair_commit", return_value=NEW_HEAD):
+                    with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
+                        gh_cls.return_value.pr_detail.return_value = {"body": "## Summary\n\nmixed\n"}
+                        with mock.patch(
+                            "scripts.mergify_admin_requeue_repair_normalize.validate_current_pr_body",
+                            return_value=PROOF_TOOLING_POLICY_VALIDATION,
+                        ):
+                            with mock.patch(
+                                "scripts.mergify_admin_requeue_repair_normalize.create_repair_prerequisite",
+                                return_value={"prNumber": 5801, "branch": "stack/pr-babysit-prereq-2647-c2532d2"},
+                            ) as create_prereq:
+                                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.hard_reset_work_root"):
+                                    code = normalize.main(self.argv())
+        self.addCleanup(lambda: normalize.PREREQ_SENTINEL.unlink(missing_ok=True))
+        self.assertEqual(code, 0)
+        create_prereq.assert_called_once()
+        call_kwargs = create_prereq.call_args
+        self.assertEqual(call_kwargs.args[5], 2647)
+        self.assertEqual(call_kwargs.args[6], HEAD)
+        self.assertEqual(call_kwargs.args[7], "PR Body")
+        self.assertTrue(normalize.PREREQ_SENTINEL.exists())
+
+    def test_invalid_non_trunk_blocks_human_split(self):
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=NEW_HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.normalize_repair_commit", return_value=NEW_HEAD):
+                    with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
+                        gh_cls.return_value.pr_detail.return_value = {"body": "## Summary\n\nmixed\n"}
+                        with mock.patch(
+                            "scripts.mergify_admin_requeue_repair_normalize.validate_current_pr_body",
+                            return_value=MANUAL_SPLIT_VALIDATION,
+                        ):
+                            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.hard_reset_work_root") as reset:
+                                code = normalize.main(self.argv(**{"--base": "stack/base"}))
+        self.assertEqual(code, 1)
+        reset.assert_called_once_with(Path.cwd(), HEAD)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Every repair attempt across every currently-stuck admin-bypass PR has been dying before the coding agent ever starts, with the identical SSH executor pool message: `Failed to authenticate: OAuth session expired and could not be refreshed`.

The worker had no way to tell that crash apart from a genuinely bad repair. It kept using up its limited attempt budget on doomed infra failures.

Once that budget ran out, it posted a generic comment implying the PR's own content needed a human look, when the real cause is unrelated SSH pool credentials.

`mergify_admin_requeue_infra_signal.py` adds a lookup: given one attempt's plan name, find its Invoker workflow and check the crashed task's own output for the known message text, using the same bridge this codebase already uses elsewhere to talk to Invoker.

The four repair decision points in `mergify_admin_requeue_plan.py` now check this before trying again. When the prior attempt for that exact PR/head/check is still pending and its own workflow already shows the infra message, the worker reports that clearly a single time and holds off, rather than trying again and rather than spending more of its limited attempt budget on it.

Confirmed live against real PRs, not just tests: #7012 and #6976 both correctly got the accurate "SSH infra failure, not a content issue" comment, and neither PR's attempt count changed afterward.

## Review Claim

Approve a new infra-crash detector, wired into the four existing repair decision points so a confirmed SSH/OAuth infra crash is reported one time instead of quietly using up attempt budget.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The new check only fires when an attempt is pending and its own crashed workflow shows the exact captured message text; every other planning outcome (already resolved, genuinely still working, or a real unrelated failure) is unchanged. A test confirms normal timeout-based behavior still applies when the check comes back negative.

## Slice Rationale

One policy slice: the detector, its wiring into the four decision points, and its own tests. Routing repairs through a different coding agent so they stop dying at all is a separate, stacked PR, since it touches a different part of the same file for a different reason.

## Non-goals

Does not change the attempt-budget number or any other cap value. Does not touch the six pre-existing, unrelated `battle-loop.sh` local-proxy failures (confirmed they fail the exact same way against the unmodified code in this sandbox).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -m unittest scripts.test_mergify_admin_requeue scripts.test_mergify_admin_requeue_model scripts.test_mergify_admin_requeue_plan scripts.test_mergify_admin_requeue_snapshot scripts.test_mergify_admin_requeue_infra_signal`
- [ ] `bash ./loop-driver.sh --skip-battle`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`.
- Post-revert steps: None.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Detects expired SSH/OAuth infrastructure failures during repair workflows.
  - Marks affected repairs as infrastructure-blocked instead of retrying or using retry capacity.
  - Applies consistently across failed checks, conflicts, and bot-thread repairs.

- **Tests**
  - Added coverage for workflow detection, invalid responses, signature matching, and repair handling.
  - Expanded the stage 1 test command to include infrastructure-signal validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->