### PR TITLE
[Remove deprecated merge-mode and retry paths](2a) Route canonical merge-mode name through the web dispatch

### DIFF
--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -238,7 +238,7 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         );
       case 'invoker:resolve-conflict':
         return mutations.resolveConflict(String(args[0]), args[1] === undefined ? undefined : String(args[1]));
-      case 'invoker:set-merge-mode':
+      case 'invoker:set-workflow-merge-mode':
         return mutations.setWorkflowMergeMode(String(args[0]), String(args[1]));
       case 'invoker:detach-workflow':
         return deps.detachWorkflow(String(args[0]), String(args[1]));


### PR DESCRIPTION
## Summary

The web-transport dispatch table still matches requests by the legacy `set-merge-mode` channel name.

This slice switches that one case label to the canonical `set-workflow-merge-mode` name, matching the Electron IPC handler already updated in the prior slice.

No caller vocabulary changes are required here: the web client already derives its method names generically from the canonical channel registry.

## Review Claim

The web-transport dispatch (`buildWebInvokerDispatch`) now matches `invoker:set-workflow-merge-mode` instead of the legacy `invoker:set-merge-mode` name.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice changes exactly one case label in `packages/app/src/web/web-invoker-dispatch.ts`. It does not touch the Electron IPC handlers, the headless CLI, or the renderer bridge, so it is safe to review as an isolated one-line change.

## Slice Rationale

This file is a dedicated dispatch table, distinct from the file bucket changed in the prior slice. Keeping it in its own PR keeps each PR a single review unit.

## Non-goals

- No Electron IPC handler changes here (already landed in the prior slice).
- No renderer bridge changes here (see the dependent UI slice).
- No workflow-core lifecycle changes here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test -- src/__tests__/web-invoker-dispatch.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d46fe91212685d12a97e5c94590ebc062108374a`
- Post-revert steps: None
- Data migration? No

</details>

