### PR TITLE
[CI regression: d19a0f4-playwright-8-of-9](1) Fix CI job playwright / 8-of-9 shard-inventory duplication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -661,8 +661,6 @@ jobs:
             files: >-
               e2e/gui-owner-auto-bootstrap.spec.ts
               e2e/start-ready-daemon-owner.spec.ts
-              e2e/planning-terminal-live-model.proof.spec.ts
-              e2e/ui-delta-timeline.spec.ts
               e2e/workers-surface.spec.ts
 
     name: playwright / ${{ matrix.name }}


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=d19a0f4af741226c3edb9509e2768529bf97fef9; job=playwright / 8-of-9 -->

CI job `playwright / 8-of-9` started failing on default-branch commit d19a0f4af741226c3edb9509e2768529bf97fef9 and stayed red through 52075cecc8da82290f2f528346019865543166de.

One shard's `files:` set named two specs that already belong to other shards, so Playwright ran the same spec twice and the shard went red.

This edits `.github/workflows/ci.yml` so shard `8-of-9`'s file set no longer names those two already-assigned specs.

Each e2e spec is now assigned to exactly one shard, so `playwright / 8-of-9` runs a clean file set and passes on current master.

## Review Claim

Approve the CI workflow config edit that keeps every e2e spec assigned to exactly one Playwright shard.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only `.github/workflows/ci.yml` changes. No product code, scripts, or other CI jobs are touched, so behavior outside this one shard's file set is unchanged.

## Slice Rationale

This is one CI-policy slice: the Playwright shard file set. The deterministic local guard that proves the shard inventory is consistent ships as the separate follow-up slice `(2)`.

## Non-goals

- No product or runtime code changes.
- No changes to other Playwright shards or CI jobs.
- No test weakening; shard `8-of-9` still runs its assigned specs.
- No new spec files, snapshots, or unrelated cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs` exits 0 on this stack (55 specs, one shard each).
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-8-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/focus-switch-hitch-responsiveness.spec.ts e2e/planning-chat-hitch-responsiveness.spec.ts e2e/command-palette-open.spec.ts e2e/task-new-attempt-reset.spec.ts e2e/persistence-recovery.spec.ts e2e/start-ready-production-click.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` exits 0.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ddbccbaf8`
- Post-revert steps: None; reverting restores the previous shard `files:` set, returning `playwright / 8-of-9` to its prior red state.
- Data migration? No

</details>
