### PR TITLE
[CI regression: d19a0f4-playwright-7-of-9](1) Drop duplicated specs from playwright shard 7-of-9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -661,8 +661,6 @@ jobs:
             files: >-
               e2e/gui-owner-auto-bootstrap.spec.ts
               e2e/start-ready-daemon-owner.spec.ts
-              e2e/planning-terminal-live-model.proof.spec.ts
-              e2e/ui-delta-timeline.spec.ts
               e2e/workers-surface.spec.ts
 
     name: playwright / ${{ matrix.name }}


### PR DESCRIPTION
## Summary

Shard 7-of-9 of the playwright CI job also ran two spec files that other shards already run. Running the same spec twice across parallel shards caused shard 7-of-9 to fail.

The fix drops those two entries from shard 7-of-9's file set in ci.yml, so each spec now runs in one shard only.

## Review Claim

Reviewers are asked to confirm that dropping the two cross-shard spec entries from playwright shard 7-of-9 in ci.yml is safe and does not affect coverage elsewhere.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the CI workflow configuration changes; no application or test code is edited. The two specs keep running via their existing shards (3-of-9 and 6-of-9), so total coverage is unchanged.

## Slice Rationale

This is filed as its own CI-workflow-config slice because it only edits the shard file set in ci.yml and carries no product code changes.

## Non-goals

This slice does not touch application code, product behavior, or any other CI shard's file set beyond removing the two duplicate entries from shard 7-of-9.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-7-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/worker-tab-scroll.spec.ts e2e/workflow-delete-latency.spec.ts e2e/main-process-hitch-responsiveness.spec.ts e2e/dag-click-hitch-responsiveness.spec.ts e2e/terminal-upsert-hitch-responsiveness.spec.ts e2e/attention-click-hitch-responsiveness.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
