### PR TITLE
[Slack plan-intent holes](3) Add the plan-intent signal file convention

### DIFF
--- a/packages/surfaces/src/__tests__/plan-intent-signal-file.test.ts
+++ b/packages/surfaces/src/__tests__/plan-intent-signal-file.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as child_process from 'node:child_process';
+import { PlanConversation } from '../slack/plan-conversation.js';
+
+// An agent-mode turn writes this file to ask for planning permission instead
+// of drafting YAML itself. This suite covers the path convention, the
+// per-turn reset (a stale signal must never leak into the next turn), and the
+// mode gate (plan-mode turns have their own drafting-authorization state
+// machine and must never surface this signal).
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof child_process>();
+  return { ...actual, spawn: vi.fn() };
+});
+
+const mockSpawn = vi.mocked(child_process.spawn);
+
+function fakePlannerChild(stdout: string, beforeClose?: () => void): any {
+  const proc = new EventEmitter() as any;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  setTimeout(() => {
+    beforeClose?.();
+    if (stdout) proc.stdout.emit('data', Buffer.from(stdout));
+    proc.emit('close', 0);
+  }, 0);
+  return proc;
+}
+
+describe('plan intent signal file — path convention', () => {
+  let workingDir: string;
+
+  beforeEach(() => {
+    workingDir = mkdtempSync(join(tmpdir(), 'plan-intent-'));
+  });
+
+  afterEach(() => {
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  function conversationWith(threadTs: string | undefined): PlanConversation {
+    return new PlanConversation({ workingDir, threadTs, mode: 'agent', plannerRetryLimit: 0 });
+  }
+
+  it('resolves a plan intent signal path under .invoker when workingDir and threadTs are set', () => {
+    const conversation = conversationWith('abc-123');
+    expect(conversation.planIntentSignalFilePath()).toBe(
+      join(workingDir, '.invoker', 'plan-intent', 'abc-123.json'),
+    );
+  });
+
+  it('sanitizes threadTs in the plan intent signal path', () => {
+    const conversation = conversationWith('abc:123/456');
+    expect(conversation.planIntentSignalFilePath()).toBe(
+      join(workingDir, '.invoker', 'plan-intent', 'abc_123_456.json'),
+    );
+  });
+
+  it('has no plan intent signal path without a threadTs', () => {
+    expect(conversationWith(undefined).planIntentSignalFilePath()).toBeNull();
+  });
+});
+
+describe('plan intent signal file — activation side', () => {
+  let workingDir: string;
+
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    workingDir = mkdtempSync(join(tmpdir(), 'plan-intent-act-'));
+  });
+
+  afterEach(() => {
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  it('reflects the signal the model wrote this turn', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', mode: 'agent', plannerRetryLimit: 0 });
+    const path = conversation.planIntentSignalFilePath();
+    if (!path) throw new Error('expected a plan intent signal path');
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(
+      'Sure, want me to draft a plan for this?',
+      () => writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8'),
+    ));
+    await conversation.sendMessage('submit it');
+
+    expect(conversation.lastTurnPlanIntentSignal).toEqual({ wantsPlan: true, reason: undefined });
+  });
+
+  it('stays null when the model writes nothing', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', mode: 'agent', plannerRetryLimit: 0 });
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild('Just a normal reply.'));
+    await conversation.sendMessage('what does this file do?');
+
+    expect(conversation.lastTurnPlanIntentSignal).toBeNull();
+  });
+
+  it('stays null on malformed JSON or a false/missing wantsPlan field', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', mode: 'agent', plannerRetryLimit: 0 });
+    const path = conversation.planIntentSignalFilePath();
+    if (!path) throw new Error('expected a plan intent signal path');
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(
+      'reply',
+      () => writeFileSync(path, '{not valid json', 'utf8'),
+    ));
+    await conversation.sendMessage('turn 1');
+    expect(conversation.lastTurnPlanIntentSignal).toBeNull();
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(
+      'reply',
+      () => writeFileSync(path, JSON.stringify({ wantsPlan: false }), 'utf8'),
+    ));
+    await conversation.sendMessage('turn 2');
+    expect(conversation.lastTurnPlanIntentSignal).toBeNull();
+  });
+
+  it('never surfaces the signal in plan mode, even if the model writes it', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', mode: 'plan', plannerRetryLimit: 0 });
+    const path = conversation.planIntentSignalFilePath();
+    if (!path) throw new Error('expected a plan intent signal path');
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(
+      'reply',
+      () => writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8'),
+    ));
+    await conversation.sendMessage('draft a plan');
+
+    expect(conversation.lastTurnPlanIntentSignal).toBeNull();
+  });
+
+  it('resets per turn — a signal from turn 1 never leaks into turn 2', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', mode: 'agent', plannerRetryLimit: 0 });
+    const path = conversation.planIntentSignalFilePath();
+    if (!path) throw new Error('expected a plan intent signal path');
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(
+      'reply',
+      () => writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8'),
+    ));
+    await conversation.sendMessage('submit it');
+    expect(conversation.lastTurnPlanIntentSignal).toEqual({ wantsPlan: true, reason: undefined });
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild('a normal follow-up, no file written'));
+    await conversation.sendMessage('what did you just do?');
+    expect(conversation.lastTurnPlanIntentSignal).toBeNull();
+  });
+});

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -35,6 +35,12 @@ export interface ConversationMessage {
 
 export type ConversationMode = 'agent' | 'plan';
 
+/** Written by an agent-mode turn to request planning permission instead of drafting YAML itself. */
+export interface PlanIntentSignal {
+  wantsPlan: true;
+  reason?: string;
+}
+
 export type PlanningCommandBuilder = (opts: {
   tool: string;
   model?: string;
@@ -444,6 +450,7 @@ export class PlanConversation {
   private _initialized = false;
   private _lastTurnReasoning: string[] = [];
   private _lastTurnDraftPlanText: string | null = null;
+  private _lastTurnPlanIntentSignal: PlanIntentSignal | null = null;
   private lastKnownGoodPlanText: string | null = null;
   private harnessSessionDriver?: HarnessSessionDriver;
   private _harnessSessionId?: string;
@@ -527,6 +534,7 @@ export class PlanConversation {
     const tInit = Date.now();
 
     this.resetPlanDraftFile();
+    this.resetPlanIntentSignalFile();
     this.messages.push({ role: 'user', content: userMessage });
 
     const prompt = this.buildTurnPrompt();
@@ -553,6 +561,7 @@ export class PlanConversation {
       : inlineDraft;
     this._lastTurnDraftPlanText = nextDraft;
     if (nextDraft) this.lastKnownGoodPlanText = nextDraft;
+    this._lastTurnPlanIntentSignal = this.mode === 'agent' ? this.readPlanIntentSignalFile() : null;
     if (!nextDraft) {
       message = removeStandaloneSubmitInstruction(message);
     }
@@ -591,6 +600,11 @@ export class PlanConversation {
 
   get lastTurnDraftPlanText(): string | null {
     return this._lastTurnDraftPlanText;
+  }
+
+  /** The plan-intent signal the model wrote this turn (agent mode only), if any. */
+  get lastTurnPlanIntentSignal(): PlanIntentSignal | null {
+    return this._lastTurnPlanIntentSignal;
   }
 
   /** Returns the raw plan text that was submitted via confirmation, or null. */
@@ -659,6 +673,44 @@ export class PlanConversation {
     }
   }
 
+  // An agent-mode turn writes this file when it judges the user's latest
+  // message is itself a plan/submission ask, instead of drafting YAML itself.
+  // Same shape as planDraftFilePath: gated on workingDir + threadTs, reset
+  // every turn so a stale signal from turn N can't leak into turn N+1.
+  // `.invoker/` is gitignored.
+  planIntentSignalFilePath(): string | null {
+    if (!this.workingDir || !this.threadTs) return null;
+    const safeId = this.threadTs.replace(/[^a-zA-Z0-9._-]/g, '_');
+    return join(this.workingDir, '.invoker', 'plan-intent', `${safeId}.json`);
+  }
+
+  private readPlanIntentSignalFile(): PlanIntentSignal | null {
+    const path = this.planIntentSignalFilePath();
+    if (!path) return null;
+    try {
+      if (!existsSync(path)) return null;
+      const content = readFileSync(path, 'utf8').trim();
+      if (!content) return null;
+      const parsed = JSON.parse(content) as { wantsPlan?: unknown; reason?: unknown };
+      if (parsed.wantsPlan !== true) return null;
+      return { wantsPlan: true, reason: typeof parsed.reason === 'string' ? parsed.reason : undefined };
+    } catch (err) {
+      this.log('plan-conversation', 'error', `Failed to read plan intent signal file ${path}: ${err}`);
+      return null;
+    }
+  }
+
+  private resetPlanIntentSignalFile(): void {
+    const path = this.planIntentSignalFilePath();
+    if (!path) return;
+    try {
+      rmSync(path, { force: true });
+      mkdirSync(dirname(path), { recursive: true });
+    } catch (err) {
+      this.log('plan-conversation', 'error', `Failed to reset plan intent signal file ${path}: ${err}`);
+    }
+  }
+
   /** Returns the conversation history. */
   get history(): readonly ConversationMessage[] {
     return this.messages.filter((m) => m.content.length > 0);
@@ -670,6 +722,7 @@ export class PlanConversation {
     this._submittedPlanText = null;
     this._planSubmitted = false;
     this._lastTurnDraftPlanText = null;
+    this._lastTurnPlanIntentSignal = null;
     this.lastKnownGoodPlanText = null;
     if (this.conversationRepo && this.threadTs) {
       this.conversationRepo.deleteConversation(this.threadTs);

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -39,7 +39,7 @@ import {
   isConfirmation,
   isNegation,
 } from './plan-conversation.js';
-import type { ConversationMode, PlanningCommandBuilder } from './plan-conversation.js';
+import type { ConversationMode, PlanIntentSignal, PlanningCommandBuilder } from './plan-conversation.js';
 import { parseLobbyControl } from './lobby-control.js';
 import type { LobbyControl } from './lobby-control.js';
 import { SessionManager, SessionIdentifier } from './thread-session-manager.js';
@@ -450,6 +450,7 @@ interface ConversationLike {
   getDraftedPlan(): string | null;
   readonly history: readonly { role: 'user' | 'assistant'; content: string }[];
   readonly lastTurnDraftPlanText: string | null;
+  readonly lastTurnPlanIntentSignal: PlanIntentSignal | null;
   readonly conversationMode: ConversationMode;
   readonly planSubmitted: boolean;
   readonly submittedPlanText: string | null;  readonly workingDir?: string;

--- a/packages/surfaces/src/slack/thread-session-manager.ts
+++ b/packages/surfaces/src/slack/thread-session-manager.ts
@@ -14,7 +14,7 @@
  */
 
 import { PlanConversation } from './plan-conversation.js';
-import type { ConversationMode, PlanningCommandBuilder } from './plan-conversation.js';
+import type { ConversationMode, PlanIntentSignal, PlanningCommandBuilder } from './plan-conversation.js';
 import type { ConversationRepository } from '@invoker/data-store';
 import type { HarnessSessionDriver } from '@invoker/execution-engine';
 import type { LogFn } from '../surface.js';
@@ -116,6 +116,10 @@ export class SessionHandle {
 
   get lastTurnDraftPlanText(): string | null {
     return this.conversation.lastTurnDraftPlanText;
+  }
+
+  get lastTurnPlanIntentSignal(): PlanIntentSignal | null {
+    return this.conversation.lastTurnPlanIntentSignal;
   }
 
   /**


### PR DESCRIPTION
## Summary

This is foundation work for a feature: letting the Slack bot's coding agent ask permission to draft a plan, instead of only reacting to explicitly typing `/plan`.

The agent talks to the host through a single opaque text reply per turn, so there's no built-in way for it to signal "I want to propose a plan" separately from its chat reply.

This adds a small per-thread file the model can write when it wants that: `.invoker/plan-intent/<thread>.json`. It mirrors the existing plan-drafts file the planner already uses to hand off YAML without pasting it into chat.

The file is reset before every turn and only read back in agent mode, so a leftover or misplaced signal can never carry over to the next turn or leak into plan-mode's own drafting flow.

Nothing reads the new getter outside this PR's own tests yet, so there is no way for this to change what a user sees.

## Review Claim

Approve that the file path, read, and reset logic correctly mirror the existing plan-draft-file pattern, and that the mode gate and per-turn reset are both covered by tests.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

Nothing outside this PR's own test file calls the new getter, so no other code path can observe a behavior change from this PR. Full package suite (38 files / 513 tests) and `pnpm build` are green.

## Slice Rationale

This is its own PR, stacked on the two holes-fix PRs, so the plumbing lands and gets reviewed before the next PR connects it to a user-visible message handler.

## Non-goals

Does not connect anything into the Slack message-handling path. Does not change the system prompt. No user-visible behavior changes in this PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/surfaces test -- plan-intent-signal-file`
- [ ] `pnpm --filter @invoker/surfaces test`
- [ ] `pnpm --filter @invoker/surfaces build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7069