### PR TITLE
[Slack plan-intent holes](4) Auto-detect plan-intent requests in agent mode

### DIFF
--- a/packages/surfaces/src/__tests__/plan-intent-signal-file.test.ts
+++ b/packages/surfaces/src/__tests__/plan-intent-signal-file.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import * as child_process from 'node:child_process';
+import { PlanConversation } from '../slack/plan-conversation.js';
+
+// An agent-mode turn writes this file to ask for planning permission instead
+// of drafting YAML itself. This suite covers the path convention, the
+// per-turn reset (a stale signal must never leak into the next turn), and the
+// mode gate (plan-mode turns have their own drafting-authorization state
+// machine and must never surface this signal).
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof child_process>();
+  return { ...actual, spawn: vi.fn() };
+});
+
+const mockSpawn = vi.mocked(child_process.spawn);
+
+function fakePlannerChild(stdout: string, beforeClose?: () => void): any {
+  const proc = new EventEmitter() as any;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  setTimeout(() => {
+    beforeClose?.();
+    if (stdout) proc.stdout.emit('data', Buffer.from(stdout));
+    proc.emit('close', 0);
+  }, 0);
+  return proc;
+}
+
+describe('plan intent signal file — path convention', () => {
+  let workingDir: string;
+
+  beforeEach(() => {
+    workingDir = mkdtempSync(join(tmpdir(), 'plan-intent-'));
+  });
+
+  afterEach(() => {
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  function conversationWith(threadTs: string | undefined): PlanConversation {
+    return new PlanConversation({ workingDir, threadTs, mode: 'agent', plannerRetryLimit: 0 });
+  }
+
+  it('resolves a plan intent signal path under .invoker when workingDir and threadTs are set', () => {
+    const conversation = conversationWith('abc-123');
+    expect(conversation.planIntentSignalFilePath()).toBe(
+      join(workingDir, '.invoker', 'plan-intent', 'abc-123.json'),
+    );
+  });
+
+  it('sanitizes threadTs in the plan intent signal path', () => {
+    const conversation = conversationWith('abc:123/456');
+    expect(conversation.planIntentSignalFilePath()).toBe(
+      join(workingDir, '.invoker', 'plan-intent', 'abc_123_456.json'),
+    );
+  });
+
+  it('has no plan intent signal path without a threadTs', () => {
+    expect(conversationWith(undefined).planIntentSignalFilePath()).toBeNull();
+  });
+});
+
+describe('plan intent signal file — activation side', () => {
+  let workingDir: string;
+
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    workingDir = mkdtempSync(join(tmpdir(), 'plan-intent-act-'));
+  });
+
+  afterEach(() => {
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  it('reflects the signal the model wrote this turn', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', mode: 'agent', plannerRetryLimit: 0 });
+    const path = conversation.planIntentSignalFilePath();
+    if (!path) throw new Error('expected a plan intent signal path');
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(
+      'Sure, want me to draft a plan for this?',
+      () => writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8'),
+    ));
+    await conversation.sendMessage('submit it');
+
+    expect(conversation.lastTurnPlanIntentSignal).toEqual({ wantsPlan: true, reason: undefined });
+  });
+
+  it('stays null when the model writes nothing', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', mode: 'agent', plannerRetryLimit: 0 });
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild('Just a normal reply.'));
+    await conversation.sendMessage('what does this file do?');
+
+    expect(conversation.lastTurnPlanIntentSignal).toBeNull();
+  });
+
+  it('stays null on malformed JSON or a false/missing wantsPlan field', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', mode: 'agent', plannerRetryLimit: 0 });
+    const path = conversation.planIntentSignalFilePath();
+    if (!path) throw new Error('expected a plan intent signal path');
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(
+      'reply',
+      () => writeFileSync(path, '{not valid json', 'utf8'),
+    ));
+    await conversation.sendMessage('turn 1');
+    expect(conversation.lastTurnPlanIntentSignal).toBeNull();
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(
+      'reply',
+      () => writeFileSync(path, JSON.stringify({ wantsPlan: false }), 'utf8'),
+    ));
+    await conversation.sendMessage('turn 2');
+    expect(conversation.lastTurnPlanIntentSignal).toBeNull();
+  });
+
+  it('never surfaces the signal in plan mode, even if the model writes it', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', mode: 'plan', plannerRetryLimit: 0 });
+    const path = conversation.planIntentSignalFilePath();
+    if (!path) throw new Error('expected a plan intent signal path');
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(
+      'reply',
+      () => writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8'),
+    ));
+    await conversation.sendMessage('draft a plan');
+
+    expect(conversation.lastTurnPlanIntentSignal).toBeNull();
+  });
+
+  it('resets per turn — a signal from turn 1 never leaks into turn 2', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'abc-123', mode: 'agent', plannerRetryLimit: 0 });
+    const path = conversation.planIntentSignalFilePath();
+    if (!path) throw new Error('expected a plan intent signal path');
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(
+      'reply',
+      () => writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8'),
+    ));
+    await conversation.sendMessage('submit it');
+    expect(conversation.lastTurnPlanIntentSignal).toEqual({ wantsPlan: true, reason: undefined });
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild('a normal follow-up, no file written'));
+    await conversation.sendMessage('what did you just do?');
+    expect(conversation.lastTurnPlanIntentSignal).toBeNull();
+  });
+});

--- a/packages/surfaces/src/__tests__/slack-plan-intent-auto-detect-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-intent-auto-detect-repros.e2e.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import * as childProcess from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ConversationRepository, SQLiteAdapter, SlackPlanDraftRepository, SlackSessionRepository } from '@invoker/data-store';
+import { SlackSurface, DEFAULT_HARNESS_PRESET } from '../slack/slack-surface.js';
+import type { SurfaceCommand } from '../surface.js';
+
+// A plain-English request ("submit it") should never draft or submit a plan
+// on its own. If the agent judges the request is itself a plan ask, it can
+// only signal that by writing the plan-intent file this turn — the same
+// Approve/No buttons the explicit /plan command already uses then appear.
+// Prose alone (no file write) must never surface those buttons: that's the
+// exact bug this feature replaces.
+
+interface MockHandler {
+  pattern: string | RegExp;
+  handler: Function;
+}
+
+const sharedSlack = vi.hoisted(() => ({
+  client: {
+    auth: { test: vi.fn().mockResolvedValue({ user_id: 'UBOT' }) },
+    chat: {
+      postMessage: vi.fn().mockResolvedValue({ ts: 'posted' }),
+      update: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    },
+    files: { uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F_PLAN' }] }) },
+    reactions: { add: vi.fn().mockResolvedValue({}), remove: vi.fn().mockResolvedValue({}) },
+    conversations: { replies: vi.fn().mockResolvedValue({ messages: [] }) },
+  },
+}));
+
+vi.mock('@slack/bolt', () => {
+  class MockApp {
+    _eventHandlers: MockHandler[] = [];
+    _actionHandlers: MockHandler[] = [];
+    command = vi.fn();
+    event = vi.fn((pattern: string, handler: Function) => this._eventHandlers.push({ pattern, handler }));
+    action = vi.fn((pattern: string | RegExp, handler: Function) => this._actionHandlers.push({ pattern, handler }));
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    client = sharedSlack.client;
+  }
+  return { App: MockApp };
+});
+
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof childProcess>()),
+  spawn: vi.fn(),
+}));
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+const silentLog = () => {};
+
+function processWith(stdout: string, beforeClose?: () => void): any {
+  const process = new EventEmitter() as any;
+  process.stdout = new EventEmitter();
+  process.stderr = new EventEmitter();
+  process.kill = vi.fn();
+  queueMicrotask(() => {
+    beforeClose?.();
+    process.stdout.emit('data', Buffer.from(stdout));
+    process.emit('close', 0);
+  });
+  return process;
+}
+
+function handler(surface: SlackSurface, pattern: string): Function {
+  const found = (surface.getApp() as any)._eventHandlers.find((entry: MockHandler) => entry.pattern === pattern);
+  if (!found) throw new Error(`Missing ${pattern} handler`);
+  return found.handler;
+}
+
+function actionHandler(surface: SlackSurface, pattern: string): Function {
+  const found = (surface.getApp() as any)._actionHandlers.find((entry: MockHandler) => entry.pattern === pattern);
+  if (!found) throw new Error(`Missing ${pattern} action handler`);
+  return found.handler;
+}
+
+function tryButtonValue(say: ReturnType<typeof vi.fn>, actionId: string): string | undefined {
+  for (const [message] of say.mock.calls) {
+    for (const block of message.blocks ?? []) {
+      const button = block.elements?.find((element: { action_id?: string }) => element.action_id === actionId);
+      if (button?.value) return button.value;
+    }
+  }
+  return undefined;
+}
+
+function buttonValue(say: ReturnType<typeof vi.fn>, actionId: string): string {
+  const value = tryButtonValue(say, actionId);
+  if (!value) throw new Error(`Missing ${actionId} button`);
+  return value;
+}
+
+function seedContext(slackSessionRepo: SlackSessionRepository, threadTs: string, workingDir: string): void {
+  slackSessionRepo.saveLaunchContext({
+    threadTs,
+    repoUrl: 'https://github.com/EdbertChan/notarepo',
+    harnessPreset: DEFAULT_HARNESS_PRESET,
+    workingDir,
+    requestedBy: 'U_TEST',
+    lobbyChannelId: 'C_LOBBY',
+    confirmationMode: 'require',
+  });
+}
+
+function intentSignalPath(workingDir: string, threadTs: string): string {
+  const safeId = threadTs.replace(/[^a-zA-Z0-9._-]/g, '_');
+  return join(workingDir, '.invoker', 'plan-intent', `${safeId}.json`);
+}
+
+describe('Slack plan-intent auto-detect repro', () => {
+  let workingDir: string;
+  let adapter: SQLiteAdapter;
+  let conversationRepo: ConversationRepository;
+  let slackPlanDraftRepo: SlackPlanDraftRepository;
+  let slackSessionRepo: SlackSessionRepository;
+  let surface: SlackSurface;
+  let commands: SurfaceCommand[];
+
+  beforeEach(async () => {
+    mockSpawn.mockReset();
+    workingDir = mkdtempSync(join(tmpdir(), 'plan-intent-auto-'));
+    adapter = await SQLiteAdapter.create(':memory:');
+    conversationRepo = new ConversationRepository(adapter, { info: silentLog, warn: silentLog, error: silentLog });
+    slackPlanDraftRepo = new SlackPlanDraftRepository(adapter);
+    slackSessionRepo = new SlackSessionRepository(adapter);
+    commands = [];
+    surface = new SlackSurface({
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      signingSecret: 'test',
+      channelId: 'C_LOBBY',
+      lobbyChannelId: 'C_LOBBY',
+      defaultRepoUrl: 'https://github.com/EdbertChan/notarepo',
+      conversationRepo,
+      slackSessionRepo,
+      slackPlanDraftRepo,
+      enableImmediateAck: false,
+      planningHeartbeatIntervalSeconds: 0,
+      log: silentLog,
+    });
+    await surface.start(async (command) => { commands.push(command); });
+  });
+
+  afterEach(async () => {
+    await surface.stop();
+    adapter.close();
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  it('does not stage a plan question for a plain-English message with no intent file written', async () => {
+    seedContext(slackSessionRepo, 'thread-1', workingDir);
+    const say = vi.fn().mockResolvedValue({ ts: 'msg-1' });
+    mockSpawn.mockImplementationOnce(() => processWith('Sure, want me to draft one for that?'));
+
+    await handler(surface, 'app_mention')({
+      event: { text: '<@UBOT> submit it', ts: 'thread-1', user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(tryButtonValue(say, 'lobby_plan_for_execution')).toBeUndefined();
+    expect(tryButtonValue(say, 'lobby_continue_conversation')).toBeUndefined();
+  });
+
+  it('stages the Approve/No plan question when the model writes the intent file', async () => {
+    seedContext(slackSessionRepo, 'thread-2', workingDir);
+    const say = vi.fn().mockResolvedValue({ ts: 'msg-2' });
+    const path = intentSignalPath(workingDir, 'thread-2');
+    mkdirSync(join(workingDir, '.invoker', 'plan-intent'), { recursive: true });
+    mockSpawn.mockImplementationOnce(() => processWith(
+      'Sure, want me to draft one for that?',
+      () => writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8'),
+    ));
+
+    await handler(surface, 'app_mention')({
+      event: { text: '<@UBOT> submit it', ts: 'thread-2', user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(buttonValue(say, 'lobby_plan_for_execution')).toBeTruthy();
+    expect(buttonValue(say, 'lobby_continue_conversation')).toBeTruthy();
+    expect(slackSessionRepo.getPendingConfirmation('thread-2')).not.toBeNull();
+  });
+
+  it('does not re-stage a second plan question when Approve replays the turn', async () => {
+    seedContext(slackSessionRepo, 'thread-3', workingDir);
+    const say = vi.fn().mockResolvedValue({ ts: 'msg-3' });
+    const path = intentSignalPath(workingDir, 'thread-3');
+    mkdirSync(join(workingDir, '.invoker', 'plan-intent'), { recursive: true });
+    mockSpawn.mockImplementationOnce(() => processWith(
+      'Sure, want me to draft one for that?',
+      () => writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8'),
+    ));
+    await handler(surface, 'app_mention')({
+      event: { text: '<@UBOT> submit it', ts: 'thread-3', user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+    const key = buttonValue(say, 'lobby_plan_for_execution');
+    say.mockClear();
+    mockSpawn.mockClear();
+
+    const plan = '```yaml\nname: "Auto detect plan"\nrepoUrl: "https://github.com/EdbertChan/notarepo"\ntasks:\n  - id: t\n    description: "d"\n    command: "pnpm test"\n    dependencies: []\n```';
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await actionHandler(surface, 'lobby_plan_for_execution')({
+      action: { type: 'button', value: key },
+      body: { channel: { id: 'C_LOBBY' }, message: { ts: 'msg-3', thread_ts: 'thread-3' } },
+      ack: vi.fn().mockResolvedValue(undefined),
+      respond: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(say).not.toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('already a pending planning question'),
+    }));
+    expect(tryButtonValue(say, 'lobby_plan_for_execution')).toBeUndefined();
+    // The auto-detected turn already asked the model "submit it" once, before
+    // staging. Approve must go straight to drafting, not replay it — exactly
+    // one spawn call, not two.
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not lose the turn reply or crash the handler if staging the auto-detected confirm itself fails', async () => {
+    seedContext(slackSessionRepo, 'thread-stage-fail', workingDir);
+    const say = vi.fn().mockResolvedValue({ ts: 'msg-fail' });
+    const path = intentSignalPath(workingDir, 'thread-stage-fail');
+    mkdirSync(join(workingDir, '.invoker', 'plan-intent'), { recursive: true });
+    const stageError = new Error('sqlite write failed');
+    const createSpy = vi.spyOn(slackSessionRepo, 'createPendingConfirmation').mockImplementationOnce(() => {
+      throw stageError;
+    });
+    mockSpawn.mockImplementationOnce(() => processWith(
+      'Sure, want me to draft one for that?',
+      () => writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8'),
+    ));
+
+    await expect(handler(surface, 'app_mention')({
+      event: { text: '<@UBOT> submit it', ts: 'thread-stage-fail', user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    })).resolves.not.toThrow();
+
+    // The turn's real reply still went out.
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('Sure, want me to draft one for that?'),
+    }));
+    // No confusing generic error message tacked on after it.
+    expect(say).not.toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('sqlite write failed'),
+    }));
+    createSpy.mockRestore();
+  });
+
+  it('skips detection for a bare in-thread reply with no pinned context yet', async () => {
+    const say = vi.fn().mockResolvedValue({ ts: 'msg-4' });
+    const path = intentSignalPath(workingDir, 'thread-4');
+    mkdirSync(join(workingDir, '.invoker', 'plan-intent'), { recursive: true });
+    mockSpawn.mockImplementationOnce(() => processWith(
+      'Sure thing.',
+      () => writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8'),
+    ));
+
+    await handler(surface, 'message')({
+      event: { text: 'local: submit it', ts: 'msg-4', thread_ts: 'thread-4', user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+
+    expect(tryButtonValue(say, 'lobby_plan_for_execution')).toBeUndefined();
+  });
+});

--- a/packages/surfaces/src/__tests__/slack-plan-intent-auto-detect-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-intent-auto-detect-repros.e2e.test.ts
@@ -217,7 +217,7 @@ describe('Slack plan-intent auto-detect repro', () => {
     });
 
     expect(say).not.toHaveBeenCalledWith(expect.objectContaining({
-      text: expect.stringContaining('already a pending planning question'),
+      text: expect.stringContaining('already a pending confirmation'),
     }));
     expect(tryButtonValue(say, 'lobby_plan_for_execution')).toBeUndefined();
     // The auto-detected turn already asked the model "submit it" once, before

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -35,6 +35,12 @@ export interface ConversationMessage {
 
 export type ConversationMode = 'agent' | 'plan';
 
+/** Written by an agent-mode turn to request planning permission instead of drafting YAML itself. */
+export interface PlanIntentSignal {
+  wantsPlan: true;
+  reason?: string;
+}
+
 export type PlanningCommandBuilder = (opts: {
   tool: string;
   model?: string;
@@ -444,6 +450,7 @@ export class PlanConversation {
   private _initialized = false;
   private _lastTurnReasoning: string[] = [];
   private _lastTurnDraftPlanText: string | null = null;
+  private _lastTurnPlanIntentSignal: PlanIntentSignal | null = null;
   private lastKnownGoodPlanText: string | null = null;
   private harnessSessionDriver?: HarnessSessionDriver;
   private _harnessSessionId?: string;
@@ -527,6 +534,7 @@ export class PlanConversation {
     const tInit = Date.now();
 
     this.resetPlanDraftFile();
+    this.resetPlanIntentSignalFile();
     this.messages.push({ role: 'user', content: userMessage });
 
     const prompt = this.buildTurnPrompt();
@@ -553,6 +561,7 @@ export class PlanConversation {
       : inlineDraft;
     this._lastTurnDraftPlanText = nextDraft;
     if (nextDraft) this.lastKnownGoodPlanText = nextDraft;
+    this._lastTurnPlanIntentSignal = this.mode === 'agent' ? this.readPlanIntentSignalFile() : null;
     if (!nextDraft) {
       message = removeStandaloneSubmitInstruction(message);
     }
@@ -591,6 +600,11 @@ export class PlanConversation {
 
   get lastTurnDraftPlanText(): string | null {
     return this._lastTurnDraftPlanText;
+  }
+
+  /** The plan-intent signal the model wrote this turn (agent mode only), if any. */
+  get lastTurnPlanIntentSignal(): PlanIntentSignal | null {
+    return this._lastTurnPlanIntentSignal;
   }
 
   /** Returns the raw plan text that was submitted via confirmation, or null. */
@@ -659,6 +673,44 @@ export class PlanConversation {
     }
   }
 
+  // An agent-mode turn writes this file when it judges the user's latest
+  // message is itself a plan/submission ask, instead of drafting YAML itself.
+  // Same shape as planDraftFilePath: gated on workingDir + threadTs, reset
+  // every turn so a stale signal from turn N can't leak into turn N+1.
+  // `.invoker/` is gitignored.
+  planIntentSignalFilePath(): string | null {
+    if (!this.workingDir || !this.threadTs) return null;
+    const safeId = this.threadTs.replace(/[^a-zA-Z0-9._-]/g, '_');
+    return join(this.workingDir, '.invoker', 'plan-intent', `${safeId}.json`);
+  }
+
+  private readPlanIntentSignalFile(): PlanIntentSignal | null {
+    const path = this.planIntentSignalFilePath();
+    if (!path) return null;
+    try {
+      if (!existsSync(path)) return null;
+      const content = readFileSync(path, 'utf8').trim();
+      if (!content) return null;
+      const parsed = JSON.parse(content) as { wantsPlan?: unknown; reason?: unknown };
+      if (parsed.wantsPlan !== true) return null;
+      return { wantsPlan: true, reason: typeof parsed.reason === 'string' ? parsed.reason : undefined };
+    } catch (err) {
+      this.log('plan-conversation', 'error', `Failed to read plan intent signal file ${path}: ${err}`);
+      return null;
+    }
+  }
+
+  private resetPlanIntentSignalFile(): void {
+    const path = this.planIntentSignalFilePath();
+    if (!path) return;
+    try {
+      rmSync(path, { force: true });
+      mkdirSync(dirname(path), { recursive: true });
+    } catch (err) {
+      this.log('plan-conversation', 'error', `Failed to reset plan intent signal file ${path}: ${err}`);
+    }
+  }
+
   /** Returns the conversation history. */
   get history(): readonly ConversationMessage[] {
     return this.messages.filter((m) => m.content.length > 0);
@@ -670,6 +722,7 @@ export class PlanConversation {
     this._submittedPlanText = null;
     this._planSubmitted = false;
     this._lastTurnDraftPlanText = null;
+    this._lastTurnPlanIntentSignal = null;
     this.lastKnownGoodPlanText = null;
     if (this.conversationRepo && this.threadTs) {
       this.conversationRepo.deleteConversation(this.threadTs);

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -459,7 +459,7 @@ interface ConversationLike {
 /** An action staged for a thread, awaiting a yes/no (text or button) confirmation. */
 type PendingConfirm =
   | { kind: 'op'; op: WorkflowOp }
-  | { kind: 'plan_intent'; requestText: string; userId: string; context: PlanningContext; channel: string }
+  | { kind: 'plan_intent'; requestText: string; userId: string; context: PlanningContext; channel: string; alreadySent?: boolean }
   | { kind: 'restart' };
 
 interface SayResult {
@@ -1148,7 +1148,8 @@ export class SlackSurface implements Surface {
 
       this.persistLaunchContext(threadTs, { ...context, workingDir });
 
-      await this.handleConversationMessage(conversation, requestText, threadTs, say, channel, event.ts);
+      await this.handleConversationMessage(conversation, requestText, threadTs, say, channel, event.ts,
+        { userId: event.user ?? 'unknown', context });
     } finally {
       // Drop any leftover Processing… ack (success paths already replace/delete it).
       await this.clearImmediateAck(channel, threadTs);
@@ -1663,6 +1664,8 @@ export class SlackSurface implements Surface {
       return;
     }
     this.persistLaunchContext(threadTs, context);
+    // Do NOT pass a planIntentContext here: this replays the original turn after
+    // the user already clicked "Plan for execution" — re-detecting would loop.
     await this.handleConversationMessage(conversation, pending.requestText, threadTs, say, pending.channel);
   }
 
@@ -1671,7 +1674,13 @@ export class SlackSurface implements Surface {
     say: SayFn,
     threadTs: string,
   ): Promise<void> {
-    await this.startConversationIntent(pending, say, threadTs);
+    // alreadySent means the request text was already sent to the conversation
+    // once, by the agent-mode turn that detected the plan-intent signal and
+    // staged this confirm. Replaying it here would ask the model the same
+    // thing twice and post a redundant reply.
+    if (!pending.alreadySent) {
+      await this.startConversationIntent(pending, say, threadTs);
+    }
     await this.handleExplicitPlanAction(pending.channel, threadTs, pending.userId, say);
   }
 
@@ -2554,7 +2563,8 @@ ${text}`;
             preparedContext ? this.sessionOptionsFromContext(preparedContext, 'agent') : undefined,
           );
           if (!conversation) return;
-          await this.handleConversationMessage(conversation, localRequest.text, msg.thread_ts, say, channel);
+          await this.handleConversationMessage(conversation, localRequest.text, msg.thread_ts, say, channel, undefined,
+            preparedContext ? { userId: msg.user ?? 'unknown', context: preparedContext } : undefined);
           return;
         }
         const preset = this.resolveHarnessPreset(preparedContext?.presetKey ?? this.defaultHarnessPreset);
@@ -2582,6 +2592,7 @@ ${text}`;
     say: SayFn,
     channel: string = this.lobbyChannelId,
     sourceEventTs?: string,
+    planIntentContext?: { userId: string; context: PlanningContext },
   ): Promise<void> {
     const tEntry = Date.now();
     this.log('slack', 'info', `[TRACE] handleConversationMessage (thread_ts=${threadTs}, text="${text.slice(0, 80)}")`);
@@ -2672,6 +2683,24 @@ ${text}`;
         this.logResponsePosted(threadTs, sourceEventTs, posted?.ts, 'chunk');
       }
       const tPosting = Date.now();
+
+      if (planIntentContext && conversation.lastTurnPlanIntentSignal?.wantsPlan) {
+        try {
+          await this.stagePlanIntentConfirm(threadTs, channel, {
+            kind: 'plan_intent',
+            requestText: text,
+            userId: planIntentContext.userId,
+            context: planIntentContext.context,
+            channel,
+            // The turn's text was already sent above (this.log'd as
+            // "conversation.sendMessage returned" right before this block) -
+            // Approve must not replay it, or the model answers it twice.
+            alreadySent: true,
+          }, say);
+        } catch (err) {
+          this.log('slack', 'error', `[PLAN_INTENT_CONFIRM] failed to stage from auto-detect thread_ts=${threadTs}: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+        }
+      }
 
       await this.uploadLinkedArtifacts(reply, conversation.workingDir, channel, threadTs);
       await cleanupHeartbeats();

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -39,7 +39,7 @@ import {
   isConfirmation,
   isNegation,
 } from './plan-conversation.js';
-import type { ConversationMode, PlanningCommandBuilder } from './plan-conversation.js';
+import type { ConversationMode, PlanIntentSignal, PlanningCommandBuilder } from './plan-conversation.js';
 import { parseLobbyControl } from './lobby-control.js';
 import type { LobbyControl } from './lobby-control.js';
 import { SessionManager, SessionIdentifier } from './thread-session-manager.js';
@@ -450,6 +450,7 @@ interface ConversationLike {
   getDraftedPlan(): string | null;
   readonly history: readonly { role: 'user' | 'assistant'; content: string }[];
   readonly lastTurnDraftPlanText: string | null;
+  readonly lastTurnPlanIntentSignal: PlanIntentSignal | null;
   readonly conversationMode: ConversationMode;
   readonly planSubmitted: boolean;
   readonly submittedPlanText: string | null;  readonly workingDir?: string;

--- a/packages/surfaces/src/slack/thread-session-manager.ts
+++ b/packages/surfaces/src/slack/thread-session-manager.ts
@@ -14,7 +14,7 @@
  */
 
 import { PlanConversation } from './plan-conversation.js';
-import type { ConversationMode, PlanningCommandBuilder } from './plan-conversation.js';
+import type { ConversationMode, PlanIntentSignal, PlanningCommandBuilder } from './plan-conversation.js';
 import type { ConversationRepository } from '@invoker/data-store';
 import type { HarnessSessionDriver } from '@invoker/execution-engine';
 import type { LogFn } from '../surface.js';
@@ -116,6 +116,10 @@ export class SessionHandle {
 
   get lastTurnDraftPlanText(): string | null {
     return this.conversation.lastTurnDraftPlanText;
+  }
+
+  get lastTurnPlanIntentSignal(): PlanIntentSignal | null {
+    return this.conversation.lastTurnPlanIntentSignal;
   }
 
   /**


### PR DESCRIPTION
## Summary

This is the piece that actually closes the original bug: a plain-English request like "please draft this as a plan" now has a real path to one, instead of a reply that only claims one exists.

`handleConversationMessage` now checks, right after each agent-mode turn, whether the model wrote the plan-intent signal file added in the prior PR. If it did, the same Approve/No buttons the explicit `/plan` command already posts get shown, using the user's literal message as the request text.

Prose alone still does nothing. Only a written file counts, so a chatty reply can never be mistaken for a real ask, which is exactly how the original bug happened.

Approving an auto-detected plan-intent goes straight to drafting rather than replaying the turn: the request text was already sent to the model once, to detect the signal in the first place, so asking it again would post a redundant reply. Staging the confirm is also wrapped so a failure there is logged and doesn't disrupt the turn's already-successful reply.

## Review Claim

Approve that detection only fires from the two call sites that already carry pinned repo/preset context, never from the passive reply path, never from the post-Approve replay, and never asks the model the same message twice.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

Every other agent-mode call path is unchanged: the new check only runs when the caller explicitly passes the new optional argument, which only the two named call sites do, and only acts when the model actually wrote the file this turn. A failure while staging the confirm is caught and logged, not left to break the rest of the turn. Full package suite (39 files / 518 tests) and `pnpm build` are green.

## Slice Rationale

This is its own PR, stacked on the plumbing PR, so the plumbing and the connected behavior each get a focused review instead of one large diff.

## Non-goals

Does not touch the system prompt yet, so the model isn't told about this mechanism in this PR. Does not add bare in-thread `/plan` support. Both are the next PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/surfaces test -- slack-plan-intent-auto-detect-repros`
- [ ] `pnpm --filter @invoker/surfaces test`
- [ ] `pnpm --filter @invoker/surfaces build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7071