### PR TITLE
[Slack plan-intent holes](5) Fix the false auto-promotion claim, support bare /plan replies

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -1022,7 +1022,7 @@ describe('PlanConversation prompt construction', () => {
     expect(conv.buildCursorPrompt()).not.toContain('prefer a workflow stack');
   });
 
-  it('agent mode refuses Invoker YAML and redirects within the same thread', () => {
+  it('agent mode refuses Invoker YAML and redirects to /plan when there is no thread to signal from', () => {
     const conv = new PlanConversation({ mode: 'agent' });
     (conv as any).messages.push({ role: 'user', content: 'Make me an Invoker plan to add a REST API' });
     const prompt = conv.buildCursorPrompt();
@@ -1030,11 +1030,25 @@ describe('PlanConversation prompt construction', () => {
     // Never the plan-mode system prompt in an agent thread.
     expect(prompt).not.toContain('Invoker orchestrator');
     expect(prompt).toContain('Do NOT generate or submit Invoker YAML yourself');
-    expect(prompt).toContain('promotes planning requests');
-    expect(prompt).toContain('same thread');
-    expect(prompt).not.toContain('start a new plan thread');
+    // No auto-promotion claim: nothing implements that, and it's the bug this replaces.
+    expect(prompt).not.toContain('automatically');
+    expect(prompt).not.toContain('promotes planning requests');
+    expect(prompt).toContain('type `/plan <request>`');
     expect(prompt).toContain('only the final user-facing message');
     expect(prompt).not.toContain('unless the user explicitly asks');
+  });
+
+  it('agent mode tells the model to signal plan-intent via file when a thread is pinned', () => {
+    const conv = new PlanConversation({ mode: 'agent', workingDir: '/tmp/worktree', threadTs: 'thread-abc' });
+    (conv as any).messages.push({ role: 'user', content: 'submit it' });
+    const prompt = conv.buildCursorPrompt();
+
+    expect(prompt).not.toContain('automatically');
+    expect(prompt).not.toContain('promotes planning requests');
+    expect(prompt).toContain('wantsPlan');
+    expect(prompt).toContain(String(conv.planIntentSignalFilePath()));
+    expect(prompt).toContain('type `/plan <request>`');
+    expect(prompt).toContain('a false positive interrupts the conversation');
   });
 });
 

--- a/packages/surfaces/src/__tests__/slack-plan-intent-auto-detect-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-intent-auto-detect-repros.e2e.test.ts
@@ -256,6 +256,38 @@ describe('Slack plan-intent auto-detect repro', () => {
     createSpy.mockRestore();
   });
 
+  it('a bare /plan reply takes priority over an unrelated pending confirm instead of being swallowed by it', async () => {
+    seedContext(slackSessionRepo, 'thread-priority', workingDir);
+    const say = vi.fn().mockResolvedValue({ ts: 'msg-p1' });
+
+    // First /plan reply stages a pending plan_intent confirm.
+    await handler(surface, 'message')({
+      event: { text: '/plan add a REST endpoint', ts: 'msg-p1', thread_ts: 'thread-priority', user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+    expect(buttonValue(say, 'lobby_plan_for_execution')).toBeTruthy();
+    expect(slackSessionRepo.getPendingConfirmation('thread-priority')).not.toBeNull();
+    say.mockClear();
+
+    // A second /plan reply, before the first is answered, must reach the
+    // /plan handling (and get the "already pending" guard message) — not be
+    // silently swallowed by resolveConfirm's "not a yes/no" fallback, which
+    // would instead delete the pending confirm and say something unrelated.
+    await handler(surface, 'message')({
+      event: { text: '/plan actually add a different endpoint', ts: 'msg-p2', thread_ts: 'thread-priority', user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+
+    expect(say).not.toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('Dropped the pending approval'),
+    }));
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('already a pending confirmation'),
+    }));
+    // The original pending confirm must survive, not be dropped.
+    expect(slackSessionRepo.getPendingConfirmation('thread-priority')).not.toBeNull();
+  });
+
   it('skips detection for a bare in-thread reply with no pinned context yet', async () => {
     const say = vi.fn().mockResolvedValue({ ts: 'msg-4' });
     const path = intentSignalPath(workingDir, 'thread-4');
@@ -271,5 +303,33 @@ describe('Slack plan-intent auto-detect repro', () => {
     });
 
     expect(tryButtonValue(say, 'lobby_plan_for_execution')).toBeUndefined();
+  });
+
+  it('stages a plan question for a bare in-thread /plan reply, without re-mentioning the bot', async () => {
+    seedContext(slackSessionRepo, 'thread-5', workingDir);
+    const say = vi.fn().mockResolvedValue({ ts: 'msg-5' });
+
+    await handler(surface, 'message')({
+      event: { text: '/plan add a REST endpoint', ts: 'msg-5', thread_ts: 'thread-5', user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(buttonValue(say, 'lobby_plan_for_execution')).toBeTruthy();
+    expect(buttonValue(say, 'lobby_continue_conversation')).toBeTruthy();
+  });
+
+  it('tells the user to @mention first when a bare in-thread /plan has no pinned context', async () => {
+    const say = vi.fn().mockResolvedValue({ ts: 'msg-6' });
+
+    await handler(surface, 'message')({
+      event: { text: '/plan add a REST endpoint', ts: 'msg-6', thread_ts: 'thread-6', user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+
+    expect(tryButtonValue(say, 'lobby_plan_for_execution')).toBeUndefined();
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('@mention me first'),
+    }));
   });
 });

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -208,13 +208,17 @@ export const SLACK_LOCAL_REPRO_POLICY = `Execution boundary:
 - Never run anything that changes state outside your worktree: \`git push\`, \`gh pr create\`/\`edit\`/\`merge\`, \`gh\` label writes, \`mergify stack push\`, \`scripts/safe-stack-push.mjs\`, or \`scripts/land-stack.mjs --execute\`.
 - If the request needs any of those, stop and hand off: describe the change, post the plan, and ask the user to confirm. Do not perform it yourself and do not offer a manual workaround for it.`;
 
-function buildAgentSystemPrompt(): string {
+function buildAgentSystemPrompt(intentSignalFilePath?: string): string {
+  const planIntentGuidance = intentSignalFilePath
+    ? `- Do NOT generate or submit Invoker YAML yourself. If — and only if — the user's latest message is itself asking you to draft a plan, convert this work into an Invoker submission, or execute/submit what was just discussed, write \`{"wantsPlan": true}\` to \`${intentSignalFilePath}\` using your file-writing tool. The Slack host will then ask the user to confirm via Approve/No buttons. Do not write that file speculatively, or for a message that isn't itself a plan/execution ask — a false positive interrupts the conversation with an unwanted confirmation prompt.
+- If you are not confident the user wants a plan, do not write that file. Instead tell the user in your reply to type \`/plan <request>\` in this thread to start planning explicitly.`
+    : `- Do NOT generate or submit Invoker YAML yourself. If the user asks for a plan or to act on this work, tell them to type \`/plan <request>\` in this thread to start planning explicitly.`;
   return `You are a normal coding agent running in a git worktree for a Slack thread.
 
 Default behavior:
 - Treat the thread like an ordinary OMP/Codex coding session.
 - Answer questions, run local commands, inspect files, edit code, and run focused verification when useful.
-- Do NOT generate or submit Invoker YAML yourself. Slack routing promotes planning requests to a planning conversation automatically, where the user can submit the resulting draft in this same thread.
+${planIntentGuidance}
 - Keep Slack replies short and concrete: changed files, verification, and any remaining risk. Return only the final user-facing message; never include chain-of-thought, reasoning traces, tool output, or raw planner JSONL.
 - To share a generated file (screenshot, diagram, report), write it inside your worktree and link it by absolute path as a markdown link, e.g. \`[chart](/abs/path/in/worktree/chart.png)\`. Files linked that way are uploaded to the thread. Files written outside your worktree cannot be shared, so do not put artifacts in /tmp.
 
@@ -751,7 +755,7 @@ export class PlanConversation {
           preferStackedWorkflows: this.preferStackedWorkflows,
           planFilePath: this.planDraftFilePath() ?? undefined,
         })
-      : buildAgentSystemPrompt();
+      : buildAgentSystemPrompt(this.planIntentSignalFilePath() ?? undefined);
     const parts: string[] = [systemPrompt];
 
     if (this.messages.length > 1) {

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -2541,8 +2541,34 @@ ${text}`;
       if (msg.channel && this.workflowChannelRepo?.getByChannelId(msg.channel)) return;
 
       const text = (msg.text ?? '').replace(/<@[A-Z0-9]+>/g, '').trim();
-      if (text && (await this.resolveConfirm(msg.thread_ts, text, say, channel))) return;
       if (!text) return;
+
+      // /plan is a deterministic command and takes priority, mirroring the
+      // @mention handler's ordering: it must run before resolveConfirm, or a
+      // pending unrelated confirmation's "not a yes/no" fallback swallows it
+      // (deletes the pending confirm and replies instead of ever reaching
+      // this branch).
+      if (/^\/plan\s*$/i.test(text) || /^\/plan\s+.+/i.test(text)) {
+        const context = this.loadPlanningContext(msg.thread_ts);
+        if (!context) {
+          await say({ text: 'This thread has no pinned repository context yet. @mention me first to start planning.', thread_ts: msg.thread_ts });
+          return;
+        }
+        if (/^\/plan\s*$/i.test(text)) {
+          await this.handleExplicitPlanAction(channel, msg.thread_ts, msg.user ?? 'unknown', say);
+          return;
+        }
+        await this.stagePlanIntentConfirm(msg.thread_ts, channel, {
+          kind: 'plan_intent',
+          requestText: text.replace(/^\/plan\s+/i, ''),
+          userId: msg.user ?? 'unknown',
+          context,
+          channel,
+        }, say);
+        return;
+      }
+
+      if (await this.resolveConfirm(msg.thread_ts, text, say, channel)) return;
 
       const rebind = await this.maybeRebindThreadRepo(channel, msg.thread_ts, msg.user, text, say);
       if (rebind.rebound || rebind.blocked) return;


### PR DESCRIPTION
## Summary

This closes the original bug at its source: the agent-mode system prompt no longer claims a mechanism that doesn't exist.

The old prompt told the model that plain-English planning requests get promoted to a planning conversation automatically. Nothing ever implemented that. The new prompt describes the real thing: write the plan-intent signal file when confident, or tell the user to enter `/plan`.

That fallback needed one more fix to actually be true. `/plan` only worked inside the `@mention` handler, so a reply later in the same thread had no way to trigger it without re-tagging the bot.

`registerMessageHandler` now recognizes `/plan` the same way the mention handler already does, using whatever repository context is already pinned to the thread. A thread with nothing pinned yet gets a clear message instead of a guess.

The new `/plan` check runs before the existing yes/no confirmation resolver, matching the `@mention` handler's ordering. Otherwise, a pending unrelated confirmation would swallow the `/plan` reply through its "not a yes/no" fallback — deleting that confirmation and replying with something unrelated, so the `/plan` request never gets handled at all.

## Review Claim

Approve that the new prompt's `/plan` fallback is now accurate everywhere it's told to the model, that the bare-thread `/plan` path reuses the same pinned-context lookup the mention handler already uses, and that it can't be silently swallowed by an unrelated pending confirmation.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new `/plan` branch in `registerMessageHandler` only matches text starting with `/plan`, a shape nothing else in that handler currently claims. Moving it ahead of the confirmation resolver only changes behavior for messages that already start with `/plan` — every other message shape keeps the exact routing it had before. Full package suite (39 files / 522 tests) and `pnpm build` are green.

## Slice Rationale

Bundling the prompt fix with the bare-reply fix is deliberate: shipping the prompt fix alone would tell the model a fallback ("run /plan") that's still false for the common case of a reply later in the thread. They only become jointly true together.

## Non-goals

Does not add a real Slack slash command registration. `/plan` stays a text convention recognized inside both message handlers, matching the existing pattern rather than introducing a new one.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/surfaces test -- plan-conversation.test`
- [ ] `pnpm --filter @invoker/surfaces test -- slack-plan-intent-auto-detect-repros`
- [ ] `pnpm --filter @invoker/surfaces test`
- [ ] `pnpm --filter @invoker/surfaces build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7075