### PR TITLE
Stop counting SSH/OAuth infra crashes against the admin-bypass retry cap

### DIFF
--- a/battle-loop.sh
+++ b/battle-loop.sh
@@ -36,7 +36,8 @@ fail=0
 
 echo "== stage 1: unit tests =="
 if python3 -m unittest scripts/test_mergify_admin_requeue.py scripts/test_mergify_admin_requeue_model.py \
-    scripts/test_mergify_admin_requeue_plan.py scripts/test_mergify_admin_requeue_snapshot.py; then
+    scripts/test_mergify_admin_requeue_plan.py scripts/test_mergify_admin_requeue_snapshot.py \
+    scripts/test_mergify_admin_requeue_infra_signal.py; then
   echo "PASS: unit tests"
 else
   echo "FAIL: unit tests"

--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -25,6 +25,22 @@ def _slugify(value: str, *, max_len: int = 40) -> str:
     return (slug or "check")[:max_len].strip("-") or "check"
 
 
+# Shared with mergify_admin_requeue_infra_signal.py, which needs the exact
+# plan_name a build_repair_*_plan call below already produced, to look up that
+# same submission's Invoker workflow by name before deciding whether to submit
+# another one.
+def repair_check_plan_name(pr_number: int, check_name: str, start_head: str) -> str:
+    return f"admin-bypass-repair-check-pr-{pr_number}-{_slugify(check_name)}-{start_head[:7]}"
+
+
+def repair_conflict_plan_name(pr_number: int, start_head: str) -> str:
+    return f"admin-bypass-repair-conflict-pr-{pr_number}-{start_head[:7]}"
+
+
+def repair_bot_thread_plan_name(pr_number: int, start_head: str) -> str:
+    return f"admin-bypass-repair-bot-thread-pr-{pr_number}-{start_head[:7]}"
+
+
 def _yaml_str(value: str) -> str:
     # JSON string encoding is a valid YAML flow scalar and, unlike naive shell
     # quoting, correctly escapes quotes/colons/backslashes in PR titles/branch
@@ -156,7 +172,7 @@ def build_repair_check_plan(
     start_head: str,
     state_file: Path,
 ) -> AsyncRepairPlan:
-    name = f"admin-bypass-repair-check-pr-{pr.number}-{_slugify(check_name)}-{start_head[:7]}"
+    name = repair_check_plan_name(pr.number, check_name, start_head)
     prompt = (
         "This PR's CI check is failing. Diagnose why it is failing, then fix it. Add or "
         "update a repro if the failure is reproducible.\n\n"
@@ -215,7 +231,7 @@ def build_repair_conflict_plan(
     start_head: str,
     state_file: Path,
 ) -> AsyncRepairPlan:
-    name = f"admin-bypass-repair-conflict-pr-{pr.number}-{start_head[:7]}"
+    name = repair_conflict_plan_name(pr.number, start_head)
     prompt = (
         "This PR has a merge conflict blocking it from merging. Diagnose why, then fix it.\n\n"
         "If rebasing the head branch onto its base branch (preserving the PR's intended changes) resolves it: "
@@ -253,7 +269,7 @@ def build_repair_bot_thread_plan(
     start_head: str,
     state_file: Path,
 ) -> AsyncRepairPlan:
-    name = f"admin-bypass-repair-bot-thread-pr-{pr.number}-{start_head[:7]}"
+    name = repair_bot_thread_plan_name(pr.number, start_head)
     prompt = (
         f"Resolve the unresolved review thread {thread_id}. Address the reviewer's feedback with "
         "real code changes, run the narrow proof for the fix, then commit locally. Do not push. "

--- a/scripts/mergify_admin_requeue_infra_signal.py
+++ b/scripts/mergify_admin_requeue_infra_signal.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+
+try:
+    from .mergify_admin_requeue_headless_shell import run_headless
+except ImportError:
+    from mergify_admin_requeue_headless_shell import run_headless
+
+# Captured verbatim from real SshExecutor crashes seen on PRs #5933, #6976,
+# #7012, and #7019 during the same admin-bypass cron tick: the coding agent
+# never launches, so no amount of retrying can produce a different repair
+# result until an operator refreshes that SSH pool member's credentials.
+SSH_OAUTH_INFRA_SIGNATURE = "Failed to authenticate: OAuth session expired and could not be refreshed"
+
+
+def find_latest_workflow_id(plan_name: str, *, run_headless_fn=run_headless) -> str | None:
+    completed = run_headless_fn('headless_query query workflows --output json')
+    if completed.returncode != 0:
+        return None
+    try:
+        workflows = json.loads(completed.stdout)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    matches = [w for w in workflows if isinstance(w, dict) and w.get("name") == plan_name]
+    if not matches:
+        return None
+    matches.sort(key=lambda w: str(w.get("createdAt", "")))
+    return matches[-1].get("id")
+
+
+def repair_task_crashed_on_infra(plan_name: str, *, run_headless_fn=run_headless) -> bool:
+    """True when plan_name's most recent Invoker workflow's `repair` task
+    crashed with the known SSH/OAuth infra signature -- a submission that
+    never gave the coding agent a chance to touch the PR at all."""
+    workflow_id = find_latest_workflow_id(plan_name, run_headless_fn=run_headless_fn)
+    if workflow_id is None:
+        return False
+    completed = run_headless_fn('headless_query query task-output "$2"', f"{workflow_id}/repair")
+    return completed.returncode == 0 and SSH_OAUTH_INFRA_SIGNATURE in completed.stdout

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -29,6 +29,27 @@ except ImportError:
         StackGroup,
     )
 
+try:
+    from .mergify_admin_requeue_async_repair import (
+        repair_bot_thread_plan_name,
+        repair_check_plan_name,
+        repair_conflict_plan_name,
+    )
+    from .mergify_admin_requeue_infra_signal import (
+        SSH_OAUTH_INFRA_SIGNATURE,
+        repair_task_crashed_on_infra,
+    )
+except ImportError:
+    from mergify_admin_requeue_async_repair import (
+        repair_bot_thread_plan_name,
+        repair_check_plan_name,
+        repair_conflict_plan_name,
+    )
+    from mergify_admin_requeue_infra_signal import (
+        SSH_OAUTH_INFRA_SIGNATURE,
+        repair_task_crashed_on_infra,
+    )
+
 
 TRUNK = "master"
 
@@ -144,6 +165,59 @@ def cap_action(pr: PrSnapshot, blocker: Blocker, detail: str) -> Action:
     return Action("comment_blocked", pr.number, "capped", f"{detail}. The retry cap was reached for current head {pr.head_ref_oid}.")
 
 
+# Distinct from repair_in_flight's TTL-bounded "still might be running" check:
+# once the submitted attempt's own Invoker workflow already shows the crash
+# text below, there is nothing to wait out -- the coding agent never launched,
+# so no further wait changes the outcome. Checked before repair_in_flight so a
+# confirmed infra crash stops silently eating retry-cap attempts well before
+# the TTL would otherwise expire. This module only adjusts what counts toward
+# the cap; deciding what (if anything) to do about a crashed pool member is
+# the autofix worker's job (packages/execution-engine/src/auto-fix-recovery.ts),
+# not this Python-side admin-bypass planner's.
+def repair_crash_reason(
+    ledger: Ledger,
+    pr_number: int,
+    head_sha: str,
+    submit_kind: str,
+    key: str,
+    plan_name: str,
+) -> str | None:
+    submitted = ledger.latest(submit_kind, pr_number, head_sha, key)
+    if submitted is None:
+        return None
+    settled = ledger.latest(f"{submit_kind}-settled", pr_number, head_sha, key)
+    if settled is not None and int(settled.get("epoch", 0) or 0) >= int(submitted.get("epoch", 0) or 0):
+        return None
+    # Named call (not a default-bound parameter) so tests can patch this
+    # module's `repair_task_crashed_on_infra` name directly instead of the
+    # real one, which shells out to a live Invoker instance.
+    if repair_task_crashed_on_infra(plan_name):
+        return SSH_OAUTH_INFRA_SIGNATURE
+    return None
+
+
+# The retry-cap count for (pr, head, submit_kind, key) minus one, when the
+# most recent unsettled attempt crashed on the known SSH/OAuth infra
+# signature -- that attempt never gave the coding agent a chance to touch the
+# PR, so it should not spend budget a real attempt would have used. Returns
+# the adjusted count and whether an infra crash was found (the caller skips
+# the repair_in_flight TTL wait in that case, since there is nothing left to
+# wait out).
+def repair_attempt_count_excluding_infra_crash(
+    ledger: Ledger,
+    pr_number: int,
+    head_sha: str,
+    submit_kind: str,
+    key: str,
+    plan_name: str,
+) -> tuple[int, bool]:
+    count = ledger.count(submit_kind, pr_number, head_sha, key)
+    crashed_on_infra = repair_crash_reason(ledger, pr_number, head_sha, submit_kind, key, plan_name) is not None
+    if crashed_on_infra:
+        count -= 1
+    return count, crashed_on_infra
+
+
 # An async repair submission (repairer.py's ledger.record(submit_kind, ...), written
 # only after a successful `headless_mutation run` submission) is "in flight" until a
 # same-kind "-settled" row lands with an equal-or-later epoch. The submitted plan's
@@ -226,11 +300,16 @@ def mergify_failed_check_actions(
     for name in latest.failing_checks:
         if name in suppressed:
             continue
-        if ledger.count("repair-check", pr.number, pr.head_ref_oid, name) >= max_repair_attempts:
-            return (cap_action(pr, Blocker(name, "failed_check", pr.number, f"Mergify queue check failed: {name}"), f"Mergify queue check failed: {name}"),)
-        if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-check", name, now):
+        detail = f"Mergify queue check failed: {name}"
+        count, crashed_on_infra = repair_attempt_count_excluding_infra_crash(
+            ledger, pr.number, pr.head_ref_oid, "repair-check", name,
+            repair_check_plan_name(pr.number, name, pr.head_ref_oid),
+        )
+        if count >= max_repair_attempts:
+            return (cap_action(pr, Blocker(name, "failed_check", pr.number, detail), detail),)
+        if not crashed_on_infra and repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-check", name, now):
             continue
-        return (Action("repair_check", pr.number, name, f"Mergify queue check failed: {name}"),)
+        return (Action("repair_check", pr.number, name, detail),)
     return ()
 
 
@@ -675,16 +754,23 @@ def plan_direct_repairs(
         for blocker in facts.blockers_by_pr[pr.number]:
             if blocker.kind == "conflict":
                 key = f"conflict:{pr.number}"
-                if ledger.count("conflict-repair", pr.number, pr.head_ref_oid, key) >= max_repair_attempts:
+                count, crashed_on_infra = repair_attempt_count_excluding_infra_crash(
+                    ledger, pr.number, pr.head_ref_oid, "conflict-repair", key,
+                    repair_conflict_plan_name(pr.number, pr.head_ref_oid),
+                )
+                if count >= max_repair_attempts:
                     return cap_action(pr, blocker, blocker.detail)
-                if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "conflict-repair", key, now):
+                if not crashed_on_infra and repair_in_flight(ledger, pr.number, pr.head_ref_oid, "conflict-repair", key, now):
                     continue
                 return Action("repair_conflict", pr.number, key, blocker.detail)
             if blocker.kind == "failed_check":
-                attempts = ledger.count("repair-check", pr.number, pr.head_ref_oid, blocker.key)
-                if attempts >= max_repair_attempts:
+                count, crashed_on_infra = repair_attempt_count_excluding_infra_crash(
+                    ledger, pr.number, pr.head_ref_oid, "repair-check", blocker.key,
+                    repair_check_plan_name(pr.number, blocker.key, pr.head_ref_oid),
+                )
+                if count >= max_repair_attempts:
                     return cap_action(pr, blocker, blocker.detail)
-                if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-check", blocker.key, now):
+                if not crashed_on_infra and repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-check", blocker.key, now):
                     continue
                 return Action("repair_check", pr.number, blocker.key, blocker.detail)
     return None
@@ -707,9 +793,13 @@ def plan_bot_thread_repairs(
                 continue
             if ledger.has_different_head("repair-bot-thread", pr.number, pr.head_ref_oid, blocker.key):
                 return Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail)
-            if ledger.count("repair-bot-thread", pr.number, pr.head_ref_oid, blocker.key) >= max_repair_attempts:
+            count, crashed_on_infra = repair_attempt_count_excluding_infra_crash(
+                ledger, pr.number, pr.head_ref_oid, "repair-bot-thread", blocker.key,
+                repair_bot_thread_plan_name(pr.number, pr.head_ref_oid),
+            )
+            if count >= max_repair_attempts:
                 return cap_action(pr, blocker, blocker.detail)
-            if repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-bot-thread", blocker.key, now):
+            if not crashed_on_infra and repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-bot-thread", blocker.key, now):
                 continue
             return Action("repair_check", pr.number, "bot_review_thread:" + blocker.key, blocker.detail)
     return None

--- a/scripts/test_mergify_admin_requeue_infra_signal.py
+++ b/scripts/test_mergify_admin_requeue_infra_signal.py
@@ -1,0 +1,104 @@
+"""Behavioural tests for ``mergify_admin_requeue_infra_signal``.
+
+Documentation-by-test: given a stubbed ``run_headless_fn`` standing in for the
+real Invoker headless CLI bridge, prove the two lookups this module performs
+-- find a workflow by its exact plan name, then check whether that workflow's
+`repair` task output contains the known SSH/OAuth infra crash signature.
+
+Run:  python3 scripts/test_mergify_admin_requeue_infra_signal.py
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import mergify_admin_requeue_infra_signal as s
+
+
+def completed(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args=["fake"], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def workflows_json(*rows):
+    return completed(stdout=json.dumps(list(rows)))
+
+
+class FindLatestWorkflowId(unittest.TestCase):
+    def test_none_when_command_fails(self):
+        calls = []
+        result = s.find_latest_workflow_id("plan-a", run_headless_fn=lambda *a: calls.append(a) or completed(returncode=1))
+        self.assertIsNone(result)
+        self.assertEqual(len(calls), 1)
+
+    def test_none_when_output_is_not_json(self):
+        result = s.find_latest_workflow_id("plan-a", run_headless_fn=lambda *a: completed(stdout="not json"))
+        self.assertIsNone(result)
+
+    def test_none_when_no_workflow_matches_the_name(self):
+        result = s.find_latest_workflow_id(
+            "plan-a",
+            run_headless_fn=lambda *a: workflows_json({"id": "wf-1", "name": "plan-b", "createdAt": "2026-01-01T00:00:00Z"}),
+        )
+        self.assertIsNone(result)
+
+    def test_returns_the_most_recently_created_match(self):
+        result = s.find_latest_workflow_id(
+            "plan-a",
+            run_headless_fn=lambda *a: workflows_json(
+                {"id": "wf-old", "name": "plan-a", "createdAt": "2026-01-01T00:00:00Z"},
+                {"id": "wf-new", "name": "plan-a", "createdAt": "2026-01-02T00:00:00Z"},
+                {"id": "wf-other", "name": "plan-b", "createdAt": "2026-01-03T00:00:00Z"},
+            ),
+        )
+        self.assertEqual(result, "wf-new")
+
+
+class RepairTaskCrashedOnInfra(unittest.TestCase):
+    def _run_headless_fn(self, workflows_result, task_output_result):
+        def run_headless_fn(command, *extra_args):
+            if "query workflows" in command:
+                return workflows_result
+            self.assertIn("task-output", command)
+            self.assertEqual(extra_args, ("wf-1/repair",))
+            return task_output_result
+        return run_headless_fn
+
+    def test_false_when_workflow_not_found(self):
+        result = s.repair_task_crashed_on_infra(
+            "plan-a", run_headless_fn=lambda *a: completed(returncode=1),
+        )
+        self.assertFalse(result)
+
+    def test_false_when_task_output_query_fails(self):
+        run_headless_fn = self._run_headless_fn(
+            workflows_json({"id": "wf-1", "name": "plan-a", "createdAt": "2026-01-01T00:00:00Z"}),
+            completed(returncode=1),
+        )
+        result = s.repair_task_crashed_on_infra("plan-a", run_headless_fn=run_headless_fn)
+        self.assertFalse(result)
+
+    def test_false_when_output_does_not_contain_the_signature(self):
+        run_headless_fn = self._run_headless_fn(
+            workflows_json({"id": "wf-1", "name": "plan-a", "createdAt": "2026-01-01T00:00:00Z"}),
+            completed(stdout="Done in 12s using pnpm\nsome ordinary failure\n"),
+        )
+        result = s.repair_task_crashed_on_infra("plan-a", run_headless_fn=run_headless_fn)
+        self.assertFalse(result)
+
+    def test_true_when_output_contains_the_exact_captured_signature(self):
+        run_headless_fn = self._run_headless_fn(
+            workflows_json({"id": "wf-1", "name": "plan-a", "createdAt": "2026-01-01T00:00:00Z"}),
+            completed(stdout="[SshExecutor] Running task payload...\n" + s.SSH_OAUTH_INFRA_SIGNATURE + "\n"),
+        )
+        result = s.repair_task_crashed_on_infra("plan-a", run_headless_fn=run_headless_fn)
+        self.assertTrue(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -14,6 +14,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -716,6 +717,131 @@ class PlanStackActions(PlannerTestCase):
             [(action.kind, action.pr_number, action.detail) for action in self._plan(after_land)],
             [("requeue", 11, "eligible-when-ready")],
         )
+
+
+class RepairCrashReason(PlannerTestCase):
+    """A submitted repair whose own Invoker workflow crashed with the known
+    SSH/OAuth infra signature (the coding agent never launched) must not be
+    silently treated the same as a normal failed repair attempt: it should
+    neither keep eating the retry cap nor resubmit forever waiting on the
+    in-flight TTL, since no amount of waiting changes an infra crash."""
+
+    def test_none_when_never_submitted(self):
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra") as crash_check:
+            result = p.repair_crash_reason(self._ledger(), 1, HEAD, "repair-check", "build", "plan-name")
+        self.assertIsNone(result)
+        crash_check.assert_not_called()
+
+    def test_none_when_already_settled(self):
+        ledger = self._ledger()
+        ledger.record("repair-check", 1, HEAD, "build", epoch=NOW - 100)
+        ledger.record("repair-check-settled", 1, HEAD, "build", epoch=NOW - 50)
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra") as crash_check:
+            result = p.repair_crash_reason(ledger, 1, HEAD, "repair-check", "build", "plan-name")
+        self.assertIsNone(result)
+        crash_check.assert_not_called()
+
+    def test_signature_returned_when_still_unsettled_and_workflow_crashed(self):
+        ledger = self._ledger()
+        ledger.record("repair-check", 1, HEAD, "build", epoch=NOW - 100)
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=True) as crash_check:
+            result = p.repair_crash_reason(ledger, 1, HEAD, "repair-check", "build", "plan-name")
+        self.assertEqual(result, p.SSH_OAUTH_INFRA_SIGNATURE)
+        crash_check.assert_called_once_with("plan-name")
+
+    def test_none_when_unsettled_but_workflow_did_not_crash_on_infra(self):
+        ledger = self._ledger()
+        ledger.record("repair-check", 1, HEAD, "build", epoch=NOW - 100)
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=False):
+            result = p.repair_crash_reason(ledger, 1, HEAD, "repair-check", "build", "plan-name")
+        self.assertIsNone(result)
+
+
+class InfraCrashDoesNotCountAgainstCap(PlannerTestCase):
+    """An attempt whose own Invoker workflow crashed with the known SSH/OAuth
+    infra signature never gave the coding agent a chance to touch the PR, so
+    it must not spend retry-cap budget a real attempt would have used --
+    and, since there is nothing left to wait out, a fresh attempt is
+    resubmitted immediately rather than waiting on the in-flight TTL. This
+    module only adjusts what counts; it never decides to stop, alert, or
+    otherwise act on the crash itself -- that is the autofix worker's job
+    (packages/execution-engine/src/auto-fix-recovery.ts), not this planner's."""
+
+    def test_plan_direct_repairs_failed_check_resubmits_instead_of_blocking(self):
+        ledger = self._ledger()
+        ledger.record("repair-check", 1, HEAD, "build", epoch=NOW - 100)
+        snapshot = pr(labels=frozenset({"admin-bypass"}), checks={"build": check("failure")})
+        facts, _ = self._facts(m.StackGroup("s", (snapshot,)), ledger=ledger)
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=True):
+            action = p.plan_direct_repairs(facts, ledger, max_repair_attempts=3, now=NOW)
+        # A fresh repair is submitted -- the crashed attempt is excluded from
+        # the cap and does not block on the in-flight TTL either.
+        self.assertEqual(action.kind, "repair_check")
+        self.assertEqual(action.key, "build")
+
+    def test_plan_direct_repairs_conflict_resubmits_instead_of_blocking(self):
+        ledger = self._ledger()
+        key = "conflict:1"
+        ledger.record("conflict-repair", 1, HEAD, key, epoch=NOW - 100)
+        snapshot = pr(labels=frozenset({"admin-bypass"}), merge_state_status="DIRTY", mergeable="CONFLICTING")
+        facts, _ = self._facts(m.StackGroup("s", (snapshot,)), ledger=ledger)
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=True):
+            action = p.plan_direct_repairs(facts, ledger, max_repair_attempts=3, now=NOW)
+        self.assertEqual((action.kind, action.key), ("repair_conflict", key))
+
+    def test_plan_bot_thread_repairs_resubmits_instead_of_blocking(self):
+        ledger = self._ledger()
+        ledger.record("repair-bot-thread", 10, HEAD, "PRRT_bot", epoch=NOW - 100)
+        snapshot = pr(
+            number=10,
+            labels=frozenset({"admin-bypass"}),
+            review_threads=(m.ReviewThread("PRRT_bot", False, ("coderabbitai[bot]",)),),
+        )
+        facts, _ = self._facts(m.StackGroup("s", (snapshot,)), ledger=ledger)
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=True):
+            action = p.plan_bot_thread_repairs(facts, ledger, max_repair_attempts=3, now=NOW)
+        self.assertEqual((action.kind, action.key), ("repair_check", "bot_review_thread:PRRT_bot"))
+
+    def test_mergify_failed_check_actions_resubmits_instead_of_blocking(self):
+        ledger = self._ledger()
+        ledger.record("repair-check", 1, HEAD, "build", epoch=NOW - 100)
+        snapshot = pr(
+            labels=frozenset({"admin-bypass"}),
+            latest_mergify=event(state="dequeued", failing=("build",)),
+        )
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=True):
+            actions = p.mergify_failed_check_actions(snapshot, ledger, max_repair_attempts=3, now=NOW)
+        self.assertEqual(len(actions), 1)
+        self.assertEqual((actions[0].kind, actions[0].key), ("repair_check", "build"))
+
+    def test_cap_still_applies_once_genuine_non_infra_attempts_reach_it(self):
+        # Three genuinely-attempted (not infra-crashed) repairs plus one more
+        # that crashed on infra: the cap must still fire on the three real
+        # attempts, since only the infra-crashed one is excluded.
+        ledger = self._ledger()
+        for i, epoch in enumerate((NOW - 400, NOW - 300, NOW - 200)):
+            ledger.record("repair-check", 1, HEAD, "build", epoch=epoch)
+            ledger.record("repair-check-settled", 1, HEAD, "build", epoch=epoch + 1)
+        ledger.record("repair-check", 1, HEAD, "build", epoch=NOW - 100)
+        snapshot = pr(labels=frozenset({"admin-bypass"}), checks={"build": check("failure")})
+        facts, _ = self._facts(m.StackGroup("s", (snapshot,)), ledger=ledger)
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=True):
+            action = p.plan_direct_repairs(facts, ledger, max_repair_attempts=3, now=NOW)
+        self.assertEqual((action.kind, action.key), ("comment_blocked", "capped"))
+
+    def test_real_infra_crash_does_not_block_a_genuinely_still_running_attempt(self):
+        # Regression guard: repair_task_crashed_on_infra is only consulted
+        # when the submission is not settled; if it returns False (a real
+        # workflow genuinely still running, or one that failed for an
+        # unrelated reason), normal repair_in_flight/TTL behavior must still
+        # apply unchanged.
+        ledger = self._ledger()
+        ledger.record("repair-check", 1, HEAD, "build", epoch=NOW - 100)
+        snapshot = pr(labels=frozenset({"admin-bypass"}), checks={"build": check("failure")})
+        facts, _ = self._facts(m.StackGroup("s", (snapshot,)), ledger=ledger)
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=False):
+            action = p.plan_direct_repairs(facts, ledger, max_repair_attempts=3, now=NOW)
+        self.assertIsNone(action)
 
 
 class PlanStackExecution(PlannerTestCase):


### PR DESCRIPTION
## Summary

Every repair attempt across every currently-stuck admin-bypass PR has been crashing before the coding agent ever launches, with the identical SSH executor pool signature: "Failed to authenticate: OAuth session expired and could not be refreshed."

The worker had no way to tell that crash apart from a real failed attempt. It silently burned retry-cap budget on doomed infra attempts and, after 3, posted a comment implying the PR's own content needs a human decision, when the real cause is unrelated SSH pool credentials.

`mergify_admin_requeue_infra_signal.py` adds `repair_task_crashed_on_infra()`, a read-only check that looks up the submitted repair's own Invoker workflow and checks its `repair` task's output for the known signature.

## Review Claim

Stop counting an SSH/OAuth infra crash against the admin-bypass repair-attempt cap; only a genuine attempt (one where the coding agent actually ran) still counts.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This planner only adjusts what counts toward the cap; it makes no decision about the infra crash itself. `repair_attempt_count_excluding_infra_crash()` excludes a confirmed infra-crashed attempt from the cap tally and skips the in-flight wait for it, so a fresh attempt goes out on the next tick. Genuine attempts still count and still hit the cap exactly as before, covered by new tests.

## Slice Rationale

Detecting or acting on the broken SSH pool member itself belongs to the autofix worker (`packages/execution-engine/src/auto-fix-recovery.ts`), not this Python-side cap-accounting logic, so this slice only touches the counting decision.

## Non-goals

This slice does not fix the underlying broken SSH pool member or its OAuth session. It does not change the cap threshold itself.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m pytest scripts/ -q -k "mergify_admin_requeue"` — 203 passed

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
