### PR TITLE
Route admin-bypass repair tasks through codex, not claude

### DIFF
--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -79,6 +79,9 @@ def _repair_task_yaml(*, description: str, prompt: str) -> str:
     return (
         "  - id: repair\n"
         f"    description: {_yaml_str(description)}\n"
+        # codex reaches every SSH pool member; the default claude agent's
+        # session is broken on most of them right now.
+        "    executionAgent: codex\n"
         "    prompt: |\n"
         f"{_indent_block(prompt, 6)}\n"
     )

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -91,6 +91,7 @@ class AsyncRepairPlanTests(unittest.TestCase):
         self.assertIn("mergify_admin_requeue_repair_normalize.py", plan.yaml_text)
         self.assertIn("--json-kind 'repair-check-settled'", plan.yaml_text)
         self.assertIn("Failed check: PR Body", plan.yaml_text)
+        self.assertIn("executionAgent: codex", plan.yaml_text)
         # PR titles with quotes/colons must not corrupt the YAML document.
         self.assertIn('Fix \\"quoted\\" title: with colons', plan.yaml_text)
 
@@ -144,6 +145,7 @@ class AsyncRepairPlanTests(unittest.TestCase):
         self.assertIn("--json-kind 'conflict-repair-settled'", plan.yaml_text)
         self.assertIn("--json-key 'conflict:2647'", plan.yaml_text)
         self.assertIn("commit locally. Do not push.", plan.yaml_text)
+        self.assertIn("executionAgent: codex", plan.yaml_text)
 
     def test_repair_bot_thread_plan_uses_thread_id_as_key(self):
         plan = async_repair.build_repair_bot_thread_plan(
@@ -152,6 +154,7 @@ class AsyncRepairPlanTests(unittest.TestCase):
         self.assertIn("--json-kind 'repair-bot-thread-settled'", plan.yaml_text)
         self.assertIn("--json-key 'tbot'", plan.yaml_text)
         self.assertIn("Thread: tbot", plan.yaml_text)
+        self.assertIn("executionAgent: codex", plan.yaml_text)
 
     def test_submit_async_repair_plan_calls_headless_run_and_cleans_up_temp_file(self):
         plan = async_repair.AsyncRepairPlan(plan_name="admin-bypass-repair-check-pr-1-abc", yaml_text="name: x\n")


### PR DESCRIPTION
## Summary

Every repair attempt has been crashing on the SSH pool's broken claude OAuth session (see the previous slice). Direct testing confirms codex reaches every pool member right now, including the ones claude can't authenticate on.

This sets `executionAgent: codex` on the generated `repair` task in all three `build_repair_*_plan` functions.

Verified live against real stuck PRs: #7012's conflict-repair and #6976's build-artifacts repair-check both now actually run (real git/gh investigation, no OAuth crash) instead of dying before the coding agent launches.

## Review Claim

Point admin-bypass repair tasks at codex instead of claude, since the SSH pool's claude OAuth session is currently broken on most pool members.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This only changes which agent the generated `repair` task requests; it does not change the task's shape or the plan-submission path. Verified against two real, currently-stuck production PRs.

## Slice Rationale

This is the immediate mitigation for the crash the previous slice detects: once an infra crash is correctly excluded from the attempt cap, the next attempt needs an agent that can actually authenticate, or it will crash again and burn the cap regardless.

## Non-goals

This slice does not fix the broken claude OAuth session itself. It does not change any other task's execution agent outside the three `build_repair_*_plan` functions.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m pytest scripts/ -q -k "mergify_admin_requeue"` — 203 passed

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repair tasks now explicitly use the Codex execution agent for check, conflict, and bot-thread plans.
  * Added validation to ensure repair plans consistently select the intended execution agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->