### PR TITLE
Log every remote-command failure, not just the finalize step

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -1731,6 +1731,40 @@ describe('SshExecutor remote finalize retry/timeout', () => {
     expect(sshProcess.kill).toHaveBeenCalledWith('SIGTERM');
   });
 
+  it('logs any remote command failure (non-zero exit), not just the finalize step', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const pending = (ssh as any).execRemoteCapture('git worktree list --porcelain', 'list_worktrees');
+    const sshProcess = spawnedProcesses[spawnedProcesses.length - 1];
+    (sshProcess.stderr as any).emit('data', Buffer.from('fatal: not a git repository\n'));
+    sshProcess.emit('close', 128, null);
+    await expect(pending).rejects.toThrow();
+
+    const failureLogs = errorSpy.mock.calls
+      .map((call) => call[0])
+      .filter((line): line is string => typeof line === 'string' && line.includes('remote command failed'));
+    expect(failureLogs).toHaveLength(1);
+    expect(failureLogs[0]).toContain('phase=list_worktrees');
+    expect(failureLogs[0]).toContain('reason="exited with code 128"');
+    expect(failureLogs[0]).toContain('not a git repository');
+  });
+
+  it('logs a remote command spawn error the same way', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const pending = (ssh as any).execRemoteCapture('echo hi', 'detect_home');
+    const sshProcess = spawnedProcesses[spawnedProcesses.length - 1];
+    sshProcess.emit('error', new Error('spawn ssh ENOENT'));
+    await expect(pending).rejects.toThrow('spawn ssh ENOENT');
+
+    const failureLogs = errorSpy.mock.calls
+      .map((call) => call[0])
+      .filter((line): line is string => typeof line === 'string' && line.includes('remote command failed'));
+    expect(failureLogs).toHaveLength(1);
+    expect(failureLogs[0]).toContain('phase=detect_home');
+    expect(failureLogs[0]).toContain('spawn error: spawn ssh ENOENT');
+  });
+
   it('remoteGitRecordAndPush retries a hanging finalize step up to 3 times, then fails with the timeout reason logged', async () => {
     vi.useFakeTimers();
     const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -46,6 +46,34 @@ function remoteFinalizeTimeoutMs(): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_REMOTE_FINALIZE_TIMEOUT_MS;
 }
 
+const REMOTE_FAILURE_LOG_TAIL_CHARS = 500;
+
+function tailFor(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return '(empty)';
+  return trimmed.length > REMOTE_FAILURE_LOG_TAIL_CHARS
+    ? `...${trimmed.slice(-REMOTE_FAILURE_LOG_TAIL_CHARS)}`
+    : trimmed;
+}
+
+// Every remote-contact primitive (bootstrap, worktree list/cleanup, record-and-push,
+// etc.) funnels through execRemoteCapture, so logging failures here -- unconditionally,
+// unlike the bench() calls above which are opt-in -- covers all of them without each
+// caller having to remember to log its own failure.
+function logRemoteCommandFailure(
+  host: string,
+  user: string,
+  phase: string | undefined,
+  reason: string,
+  stderr = '',
+  stdout = '',
+): void {
+  console.error(
+    `[ssh-lifecycle] remote command failed host=${host} user=${user} phase=${phase ?? 'remote_capture'} ` +
+      `reason="${reason}" stderrTail=${JSON.stringify(tailFor(stderr))} stdoutTail=${JSON.stringify(tailFor(stdout))}`,
+  );
+}
+
 export interface SshExecutorConfig {
   host: string;
   user: string;
@@ -380,6 +408,7 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
       child.on('error', (error) => {
         finish(() => {
           bench('SshExecutor.execRemoteCapture.spawnError', { error: error.message });
+          logRemoteCommandFailure(this.host, this.user, phase, `spawn error: ${error.message}`);
           reject(error);
         });
       });
@@ -392,6 +421,7 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
           });
           if (code === 0) resolve(out);
           else {
+            logRemoteCommandFailure(this.host, this.user, phase, `exited with code ${code ?? 'null'}`, err, out);
             reject(createSshRemoteScriptError(code, out, err, phase));
           }
         });
@@ -400,6 +430,7 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
         timeoutTimer = setTimeout(() => {
           if (settled) return;
           bench('SshExecutor.execRemoteCapture.timedOut', { timeoutMs: opts.timeoutMs });
+          logRemoteCommandFailure(this.host, this.user, phase, `timed out after ${opts.timeoutMs}ms`, err, out);
           killProcessGroup(child, 'SIGTERM');
           killTimer = setTimeout(() => {
             if (!settled) killProcessGroup(child, 'SIGKILL');


### PR DESCRIPTION
## Summary

Every remote-contact call (bootstrap clone/fetch, the worktree helper functions, the record-and-push finalize step) funnels through the same `execRemoteCapture` primitive, but a failure there was invisible unless the opt-in bench/trace flag was enabled.

A non-zero exit, spawn error, or timeout all failed silently by default.

`execRemoteCapture` now unconditionally logs on all three failure paths, tagged with host/user/phase and a truncated stderr/stdout tail.

## Review Claim

Log every `execRemoteCapture` failure path unconditionally, not just when the opt-in trace flag is set, so a stuck remote operation has log evidence to investigate instead of a dead end.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This only adds logging on already-existing failure paths; it does not change any return value, timing, or control flow. Covered by new tests asserting each of the three failure paths now logs.

## Slice Rationale

This is its own slice because it applies to every caller of the shared `execRemoteCapture` primitive, not just the finalize-step timeout the previous slice bounded.

## Non-goals

This slice does not change what counts as a failure, only whether it gets logged. It does not touch the opt-in bench/trace flag's own behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm test -- ssh-executor` (packages/execution-engine) — 43 passed, 1 skipped

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
