### PR TITLE
[Slack plan-intent holes](7) Serialize turns to close a per-thread file race

### DIFF
--- a/packages/surfaces/src/__tests__/plan-intent-signal-file.test.ts
+++ b/packages/surfaces/src/__tests__/plan-intent-signal-file.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import * as child_process from 'node:child_process';
@@ -150,5 +150,93 @@ describe('plan intent signal file — activation side', () => {
     mockSpawn.mockReturnValueOnce(fakePlannerChild('a normal follow-up, no file written'));
     await conversation.sendMessage('what did you just do?');
     expect(conversation.lastTurnPlanIntentSignal).toBeNull();
+  });
+});
+
+describe('plan intent signal file — concurrent turns are serialized', () => {
+  let workingDir: string;
+
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    workingDir = mkdtempSync(join(tmpdir(), 'plan-intent-race-'));
+  });
+
+  afterEach(() => {
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  // A manually-controlled child: unlike fakePlannerChild, nothing closes it
+  // automatically. The test decides exactly when each turn's model "finishes
+  // writing its file" and "exits", to construct a specific interleaving
+  // deterministically rather than relying on timer race luck.
+  function controlledChild(): { proc: any; close: (stdout: string) => void } {
+    const proc = new EventEmitter() as any;
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = vi.fn();
+    return {
+      proc,
+      close: (stdout: string) => {
+        proc.stdout.emit('data', Buffer.from(stdout));
+        proc.emit('close', 0);
+      },
+    };
+  }
+
+  // How many internal awaits sit between calling sendMessage and spawn()
+  // actually being invoked is an implementation detail (init(), retry setup,
+  // etc). Rather than hand-count microtask ticks, flush them until the
+  // condition we actually care about is true.
+  async function flushUntil(predicate: () => boolean, maxTicks = 50): Promise<void> {
+    for (let i = 0; i < maxTicks; i++) {
+      if (predicate()) return;
+      await Promise.resolve();
+    }
+    throw new Error('condition never became true within maxTicks microtask flushes');
+  }
+
+  it('does not let a second concurrent turn wipe a signal before the first turn reads it back', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'race-thread', mode: 'agent', plannerRetryLimit: 0 });
+    const path = conversation.planIntentSignalFilePath();
+    if (!path) throw new Error('expected a plan intent signal path');
+    mkdirSync(join(workingDir, '.invoker', 'plan-intent'), { recursive: true });
+
+    const a = controlledChild();
+    const b = controlledChild();
+    mockSpawn.mockImplementationOnce(() => a.proc);
+    mockSpawn.mockImplementationOnce(() => b.proc);
+
+    let signalWhenAResolved: unknown;
+    let signalWhenBResolved: unknown;
+    const sendA = conversation.sendMessage('submit it').then((reply) => {
+      signalWhenAResolved = conversation.lastTurnPlanIntentSignal;
+      return reply;
+    });
+    await flushUntil(() => mockSpawn.mock.calls.length >= 1); // let A reach spawn(A)
+
+    // A's model "writes its file" mid-turn (process is still open).
+    writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8');
+
+    // Before A's process has exited, a second turn is requested on the same
+    // conversation (e.g. two Slack events for this thread arriving close
+    // together). With serialization, B's own turn-setup reset is deferred
+    // until A fully finishes — it cannot race A's not-yet-executed read.
+    const sendB = conversation.sendMessage('what does this mean?').then((reply) => {
+      signalWhenBResolved = conversation.lastTurnPlanIntentSignal;
+      return reply;
+    });
+
+    a.close('sure, want me to draft one for that?');
+    await sendA;
+
+    await flushUntil(() => mockSpawn.mock.calls.length >= 2); // let B reach spawn(B)
+    b.close('just a normal reply, no file written');
+    await sendB;
+
+    // A must see its own signal — not have it wiped by B's concurrent turn.
+    expect(signalWhenAResolved).toEqual({ wantsPlan: true, reason: undefined });
+    // B's own turn wrote nothing, so once B's (serialized, later) turn runs
+    // its own reset+read, it correctly sees nothing.
+    expect(signalWhenBResolved).toBeNull();
   });
 });

--- a/packages/surfaces/src/__tests__/slack-plan-intent-auto-detect-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-intent-auto-detect-repros.e2e.test.ts
@@ -114,6 +114,35 @@ function intentSignalPath(workingDir: string, threadTs: string): string {
   return join(workingDir, '.invoker', 'plan-intent', `${safeId}.json`);
 }
 
+// A manually-controlled child: unlike processWith, nothing closes it
+// automatically. Used to construct a specific interleaving deterministically
+// rather than relying on timer race luck.
+function controlledChild(): { proc: any; close: (stdout: string) => void } {
+  const proc = new EventEmitter() as any;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  return {
+    proc,
+    close: (stdout: string) => {
+      proc.stdout.emit('data', Buffer.from(stdout));
+      proc.emit('close', 0);
+    },
+  };
+}
+
+// How many internal awaits sit between an @mention landing and spawn()
+// actually being invoked is an implementation detail. Rather than hand-count
+// microtask ticks, flush them until the condition we actually care about
+// is true.
+async function flushUntil(predicate: () => boolean, maxTicks = 50): Promise<void> {
+  for (let i = 0; i < maxTicks; i++) {
+    if (predicate()) return;
+    await Promise.resolve();
+  }
+  throw new Error('condition never became true within maxTicks microtask flushes');
+}
+
 describe('Slack plan-intent auto-detect repro', () => {
   let workingDir: string;
   let adapter: SQLiteAdapter;
@@ -331,5 +360,50 @@ describe('Slack plan-intent auto-detect repro', () => {
     expect(say).toHaveBeenCalledWith(expect.objectContaining({
       text: expect.stringContaining('@mention me first'),
     }));
+  });
+
+  it('does not let a second concurrent @mention on the same thread wipe the first turn\'s signal before it is read', async () => {
+    const threadTs = 'thread-race';
+    seedContext(slackSessionRepo, threadTs, workingDir);
+    const say = vi.fn().mockResolvedValue({ ts: 'msg-race' });
+    const path = intentSignalPath(workingDir, threadTs);
+    mkdirSync(join(workingDir, '.invoker', 'plan-intent'), { recursive: true });
+
+    const a = controlledChild();
+    const b = controlledChild();
+    mockSpawn.mockImplementationOnce(() => a.proc);
+    mockSpawn.mockImplementationOnce(() => b.proc);
+
+    // First Slack event for this thread: "submit it".
+    const replyA = handler(surface, 'app_mention')({
+      event: { text: '<@UBOT> submit it', ts: 'evt-a', thread_ts: threadTs, user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+    await flushUntil(() => mockSpawn.mock.calls.length >= 1);
+
+    // A's model "writes its file" mid-turn (process is still open).
+    writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8');
+
+    // A second Slack event for the SAME thread arrives before the first has
+    // finished — e.g. the user sent two messages in quick succession.
+    const replyB = handler(surface, 'app_mention')({
+      event: { text: '<@UBOT> actually never mind', ts: 'evt-b', thread_ts: threadTs, user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+
+    a.close('sure, want me to draft one for that?');
+    await replyA;
+
+    await flushUntil(() => mockSpawn.mock.calls.length >= 2);
+    b.close('ok, no plan then');
+    await replyB;
+
+    // The first turn's real signal must have produced the Approve/No
+    // buttons, keyed to its own request text — not lost to the second,
+    // concurrently-arriving turn's setup.
+    expect(buttonValue(say, 'lobby_plan_for_execution')).toBeTruthy();
+    const pending = slackSessionRepo.getPendingConfirmation(threadTs);
+    expect(pending).not.toBeNull();
+    expect((pending!.payload as { requestText?: string }).requestText).toBe('submit it');
   });
 });

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -451,6 +451,14 @@ export class PlanConversation {
   private onRawPlannerOutput?: RawPlannerOutputHandler;
   private plannerRetryLimit: number;
   private plannerRetryBaseDelayMs: number;
+  // Serializes turns on this conversation. Without this, two concurrent
+  // sendMessage calls (e.g. two Slack events for the same thread arriving
+  // close together) can interleave their per-turn side-channel files
+  // (plan-drafts, plan-intent): one turn's resetPlanDraftFile/
+  // resetPlanIntentSignalFile can wipe a file the other turn already wrote
+  // but hasn't read back yet.
+  private turnInFlight = false;
+  private turnQueue: Array<() => void> = [];
   private _initialized = false;
   private _lastTurnReasoning: string[] = [];
   private _lastTurnDraftPlanText: string | null = null;
@@ -528,8 +536,28 @@ export class PlanConversation {
    * Send a user message to the planner and return its reply. Pure conversation:
    * drafting a plan never auto-submits it — submission is an explicit step
    * driven by the surface (the `submit` verb), so a stray "yes" can't ship a plan.
+   *
+   * Turns on this conversation are serialized: a call queued while another is
+   * in flight waits for it to fully finish (including reading back its own
+   * per-turn side-channel files) before starting.
    */
   async sendMessage(userMessage: string): Promise<string> {
+    if (this.turnInFlight) {
+      await new Promise<void>((resolve) => this.turnQueue.push(resolve));
+    }
+    this.turnInFlight = true;
+    // No `await` here on purpose: chaining via .finally() keeps this call's
+    // returned promise settling in lockstep with sendMessageLocked's own
+    // promise, with no added microtask tick before the planner subprocess is
+    // spawned — callers/tests that synchronize on "the process was spawned"
+    // via a single microtask wait stay correct.
+    return this.sendMessageLocked(userMessage).finally(() => {
+      this.turnInFlight = false;
+      this.turnQueue.shift()?.();
+    });
+  }
+
+  private async sendMessageLocked(userMessage: string): Promise<string> {
     const t0 = Date.now();
     const turn = this.messages.filter(m => m.role === 'user').length + 1;
     this.log('plan-conversation', 'info', `[TRACE] sendMessage() start (threadTs=${this.threadTs}, initialized=${this._initialized}, msgCount=${this.messages.length}, turn=${turn})`);


### PR DESCRIPTION
## Summary

This closes the last known gap from this stack's own review: a race between two concurrent turns on the same thread.

Both the plan-drafts and plan-intent files are keyed per thread only, with nothing stopping two turns from running at once — say, two Slack events for one thread arriving close together. One turn's setup can wipe a file the other turn already has but hasn't read back yet.

A conversation now serializes its own turns: a call made while another is still running queues behind it instead of starting its own reset and spawn concurrently. The ordinary case, one call at a time, is unaffected — it still reaches the planner in the same microtask window as before.

## Review Claim

Approve that the queueing correctly waits for the prior turn's full read-back before starting the next one, and that it introduces no delay for the ordinary non-concurrent case.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

The fast (non-concurrent) path calls straight into the existing per-turn logic with no added microtask before the planner subprocess starts, so single-turn timing is unchanged — the full suite already depends on that timing and stays green. The queued path only activates when a second call genuinely arrives before the first settles. Full package suite (40 files / 525 tests) and `pnpm build` are green.

## Slice Rationale

This is a standalone fix independent of the rest of the stack's behavior changes, landed last since it was found during this stack's own adversarial review rather than being part of the original plan.

## Non-goals

Does not add the same protection to the pool of other per-thread state this bot keeps (only the two file-based side channels this stack touches). Does not change anything about single-turn conversations.

## Test Plan

Covered at both layers: a unit-level repro directly against the conversation object, and an e2e repro through the full Slack surface (two concurrent mention events for one thread). Both are shown failing without the fix and passing with it.

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/surfaces test -- plan-intent-signal-file`
- [ ] `pnpm --filter @invoker/surfaces test -- slack-plan-intent-auto-detect-repros`
- [ ] `pnpm --filter @invoker/surfaces test`
- [ ] `pnpm --filter @invoker/surfaces build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7082