### PR TITLE
[Slack plan-intent holes](8) Extend unit coverage for the shared turn-lock and session-proxy paths

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -851,6 +851,170 @@ tasks:
     await expect(second).resolves.toEqual({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
   });
 
+  it('coalesces concurrent chat turns for one session — a later turn does not start until the earlier one finishes', async () => {
+    // End-to-end: the real conversation path (pendingSend chaining plus
+    // PlanConversation's own turn lock, both active) never lets two chat
+    // turns' planner calls run at once. See the plannerReplyOverride test
+    // below for a version that isolates pendingSend specifically.
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValueOnce('turn 1 reply');
+    const sessions = createInAppPlanningChatSessions();
+    const first = await sendPlanningChatMessage({
+      message: 'draft',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    if (!first.ok) throw new Error(first.error);
+
+    const spawnSpy = vi.spyOn(PlanConversation.prototype, 'spawnPlanner');
+    let resolveTurn2: ((value: string) => void) | undefined;
+    spawnSpy.mockImplementationOnce(() => new Promise<string>((resolve) => { resolveTurn2 = resolve; }));
+    spawnSpy.mockResolvedValueOnce('turn 3 reply');
+    const callsBefore = spawnSpy.mock.calls.length;
+
+    const second = sendPlanningChatMessage({
+      sessionId: first.sessionId,
+      message: 'turn 2',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    const third = sendPlanningChatMessage({
+      sessionId: first.sessionId,
+      message: 'turn 3',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+
+    // Give the event loop plenty of chances to let turn 3 start if it were
+    // going to run concurrently with turn 2. With pendingSend serializing
+    // chat turns, only turn 2's planner call can have happened by now.
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    expect(spawnSpy.mock.calls.length).toBe(callsBefore + 1);
+
+    resolveTurn2?.('turn 2 reply');
+    const secondResult = await second;
+    const thirdResult = await third;
+
+    expect(secondResult.ok && secondResult.reply).toBe('turn 2 reply');
+    expect(thirdResult.ok && thirdResult.reply).toBe('turn 3 reply');
+  });
+
+  it('pendingSend alone serializes chat turns when the planner call bypasses PlanConversation entirely', async () => {
+    // The previous test exercises the real PlanConversation.sendMessage path,
+    // which now has its own turn-serialization lock — so it can't tell
+    // apart "pendingSend serializes turns" from "PlanConversation's lock
+    // serializes turns underneath it; pendingSend just rides along". The
+    // plannerReplyOverride dependency skips conversation.sendMessage
+    // entirely, isolating pendingSend as the only thing that could possibly
+    // be serializing these calls.
+    const sessions = createInAppPlanningChatSessions();
+    const first = await sendPlanningChatMessage({
+      message: 'draft',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+      plannerReplyOverride: async () => 'turn 1 reply',
+    });
+    if (!first.ok) throw new Error(first.error);
+
+    let resolveTurn2: ((value: string) => void) | undefined;
+    const overrideCalls: string[] = [];
+    const plannerReplyOverride = vi.fn((formattedMessage: string) => {
+      overrideCalls.push(formattedMessage);
+      if (overrideCalls.length === 1) {
+        return new Promise<string>((resolve) => { resolveTurn2 = resolve; });
+      }
+      return Promise.resolve('turn 3 reply');
+    });
+
+    const second = sendPlanningChatMessage({
+      sessionId: first.sessionId,
+      message: 'turn 2',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+      plannerReplyOverride,
+    });
+    const third = sendPlanningChatMessage({
+      sessionId: first.sessionId,
+      message: 'turn 3',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+      plannerReplyOverride,
+    });
+
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    expect(overrideCalls.length).toBe(1); // only turn 2's override call has fired so far
+
+    resolveTurn2?.('turn 2 reply');
+    const secondResult = await second;
+    const thirdResult = await third;
+
+    expect(secondResult.ok && secondResult.reply).toBe('turn 2 reply');
+    expect(thirdResult.ok && thirdResult.reply).toBe('turn 3 reply');
+    expect(overrideCalls.length).toBe(2);
+  });
+
+  it('never constructs a session in mode: agent (createSession and planFromGoal paths)', async () => {
+    // The single shared config builder every terminal PlanConversation goes
+    // through never sets `mode` at all, so every terminal session defaults
+    // to 'plan' — the agent-mode system prompt (and the plan-intent
+    // auto-detect wiring that currently only Slack connects) is unreachable
+    // here. If someone later wires agent mode into the terminal, this test
+    // breaks, forcing a conscious decision about whether plan-intent
+    // detection needs to come along too, instead of a silent half-wire.
+    let createSessionPrompt = '';
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockImplementationOnce((prompt: string) => {
+      createSessionPrompt = prompt;
+      return Promise.resolve('turn 1 reply');
+    });
+    const sessions = createInAppPlanningChatSessions();
+    const created = await sendPlanningChatMessage({
+      message: 'draft',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    if (!created.ok) throw new Error(created.error);
+    expect(sessions.get(created.sessionId)?.conversation.conversationMode).toBe('plan');
+    expect(createSessionPrompt).not.toContain('You are a normal coding agent');
+    expect(createSessionPrompt).not.toContain('wantsPlan');
+
+    let goalPrompt = '';
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockImplementationOnce((prompt: string) => {
+      goalPrompt = prompt;
+      return Promise.resolve(VALID_PLAN);
+    });
+    const goalResult = await planFromGoal({ goal: 'build a REST API' }, {
+      config: {},
+      loadGeneratedPlan: vi.fn().mockResolvedValue({ planName: 'Mock Plan', workflowId: 'wf-1' }),
+      planningCommandBuilder,
+    });
+    expect(goalResult.ok).toBe(true);
+    expect(goalPrompt).not.toContain('You are a normal coding agent');
+    expect(goalPrompt).not.toContain('wantsPlan');
+  });
+
   it('returns load and parse failures as submit errors', async () => {
     vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
     const sessions = createInAppPlanningChatSessions();

--- a/packages/surfaces/src/__tests__/plan-intent-signal-file.test.ts
+++ b/packages/surfaces/src/__tests__/plan-intent-signal-file.test.ts
@@ -239,4 +239,106 @@ describe('plan intent signal file — concurrent turns are serialized', () => {
     // its own reset+read, it correctly sees nothing.
     expect(signalWhenBResolved).toBeNull();
   });
+
+  it('processes 3 concurrent calls in strict FIFO (call) order, not close order', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'race-thread-3', mode: 'agent', plannerRetryLimit: 0 });
+
+    const a = controlledChild();
+    const b = controlledChild();
+    const c = controlledChild();
+    mockSpawn.mockImplementationOnce(() => a.proc);
+    mockSpawn.mockImplementationOnce(() => b.proc);
+    mockSpawn.mockImplementationOnce(() => c.proc);
+
+    const resolutionOrder: string[] = [];
+    const sendA = conversation.sendMessage('A').then((r) => { resolutionOrder.push('A'); return r; });
+    await flushUntil(() => mockSpawn.mock.calls.length >= 1);
+
+    // B and C both queue behind A, in call order, before A has finished.
+    const sendB = conversation.sendMessage('B').then((r) => { resolutionOrder.push('B'); return r; });
+    const sendC = conversation.sendMessage('C').then((r) => { resolutionOrder.push('C'); return r; });
+
+    // Give the event loop plenty of chances to let B/C's own turn-setup run
+    // if it were going to happen concurrently with A. With serialization,
+    // neither can reach spawn() until A finishes, no matter how many ticks
+    // pass — this is the direct, unambiguous proof (not just resolution
+    // order, which close-timing games alone don't reliably discriminate).
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    expect(mockSpawn.mock.calls.length).toBe(1);
+
+    a.close('a reply');
+    await sendA;
+    await flushUntil(() => mockSpawn.mock.calls.length >= 2);
+
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    expect(mockSpawn.mock.calls.length).toBe(2); // B started, C still queued behind it
+
+    b.close('b reply');
+    await sendB;
+    await flushUntil(() => mockSpawn.mock.calls.length >= 3);
+    c.close('c reply');
+    await sendC;
+
+    // Regardless of any close-timing games, the queue releases in the order
+    // calls arrived — never something else.
+    expect(resolutionOrder).toEqual(['A', 'B', 'C']);
+  });
+
+  it('does not corrupt the queue when a queued turn fails — the next turn still runs', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'race-thread-fail', mode: 'agent', plannerRetryLimit: 0 });
+
+    const a = controlledChild();
+    const b = controlledChild();
+    mockSpawn.mockImplementationOnce(() => a.proc);
+    mockSpawn.mockImplementationOnce(() => b.proc);
+
+    const sendA = conversation.sendMessage('A');
+    await flushUntil(() => mockSpawn.mock.calls.length >= 1);
+
+    // B queues behind A before A fails.
+    const sendB = conversation.sendMessage('B');
+
+    // While A is still in flight, B must not have reached spawn() yet — the
+    // lock has to hold even though A is about to fail, not just when A
+    // succeeds. (Without this check, A and B would just run independently
+    // and this test would pass whether or not the lock exists at all.)
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    expect(mockSpawn.mock.calls.length).toBe(1);
+
+    // A fails: non-zero exit.
+    a.proc.stderr.emit('data', Buffer.from('boom'));
+    a.proc.emit('close', 1);
+    await expect(sendA).rejects.toThrow();
+
+    // The lock must still release on failure (via .finally()) — B runs next,
+    // not stuck behind a permanently-held lock.
+    await flushUntil(() => mockSpawn.mock.calls.length >= 2);
+    b.close('b reply, after a failed');
+    await expect(sendB).resolves.toBe('b reply, after a failed');
+  });
+
+  it('does not block a different conversation instance (the lock is per-instance, not shared)', async () => {
+    const conversationX = new PlanConversation({ workingDir, threadTs: 'thread-x', mode: 'agent', plannerRetryLimit: 0 });
+    const conversationY = new PlanConversation({ workingDir, threadTs: 'thread-y', mode: 'agent', plannerRetryLimit: 0 });
+
+    const x = controlledChild();
+    const y = controlledChild();
+    mockSpawn.mockImplementationOnce(() => x.proc);
+    mockSpawn.mockImplementationOnce(() => y.proc);
+
+    // X starts and does NOT finish (its process stays open).
+    const sendX = conversationX.sendMessage('for X');
+    await flushUntil(() => mockSpawn.mock.calls.length >= 1);
+
+    // Y, on a DIFFERENT conversation instance, must still reach spawn()
+    // immediately — it must not wait behind X's still-open turn.
+    const sendY = conversationY.sendMessage('for Y');
+    await flushUntil(() => mockSpawn.mock.calls.length >= 2);
+
+    y.close('y reply');
+    await expect(sendY).resolves.toBe('y reply');
+
+    x.close('x reply');
+    await expect(sendX).resolves.toBe('x reply');
+  });
 });

--- a/packages/surfaces/src/__tests__/thread-session-manager.test.ts
+++ b/packages/surfaces/src/__tests__/thread-session-manager.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SessionManager, SessionIdentifier, SessionHandle } from '../slack/thread-session-manager.js';
 import * as child_process from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 // ── Mock child_process.spawn ────────────────────────────────
 
@@ -370,5 +373,90 @@ describe('SessionManager', () => {
 
     // Sending a message after dispose should throw
     await expect(handle!.sendMessage('test')).rejects.toThrow('disposed');
+  });
+});
+
+// SessionHandle.lastTurnPlanIntentSignal / lastTurnDraftPlanText are pure
+// proxy getters onto the wrapped PlanConversation. Every other test in this
+// file either stops short of reading them or (elsewhere in the package)
+// exercises PlanConversation directly, bypassing SessionHandle/SessionManager
+// entirely. These prove the proxy through the real pooling path production
+// Slack traffic takes: getOrCreateSession -> sendMessage -> getter.
+describe('SessionHandle real-conversation proxy getters', () => {
+  let workingDir: string;
+  let manager: SessionManager;
+  let mockRepo: ReturnType<typeof createMockRepo>;
+
+  beforeEach(() => {
+    workingDir = mkdtempSync(join(tmpdir(), 'session-handle-proxy-'));
+    mockRepo = createMockRepo();
+    // No `mode` override: SessionManager defaults fresh sessions to 'agent'
+    // (thread-session-manager.ts:279,401), which is what gates
+    // lastTurnPlanIntentSignal open.
+    manager = new SessionManager({
+      cursorCommand: 'cursor',
+      workingDir,
+      conversationRepo: mockRepo as any,
+      evictionIntervalMs: 60_000,
+    });
+    manager.start();
+  });
+
+  afterEach(() => {
+    manager.stop();
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  function mockChildThatWrites(write: () => void, stdout: string): void {
+    mockSpawn.mockImplementationOnce(() => {
+      const { EventEmitter } = require('node:events');
+      const proc = new EventEmitter();
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      proc.kill = vi.fn();
+      setTimeout(() => {
+        write();
+        proc.stdout.emit('data', Buffer.from(stdout));
+        proc.emit('close', 0);
+      }, 0);
+      return proc;
+    });
+  }
+
+  it('proxies lastTurnPlanIntentSignal through a real getOrCreateSession -> sendMessage -> getter path', async () => {
+    const id = new SessionIdentifier('C123', 'thread-proxy-intent');
+    const handle = await manager.getOrCreateSession(id, 'U001');
+    expect(handle).not.toBeNull();
+
+    const signalDir = join(workingDir, '.invoker', 'plan-intent');
+    mkdirSync(signalDir, { recursive: true });
+    const signalPath = join(signalDir, 'thread-proxy-intent.json');
+    mockChildThatWrites(
+      () => writeFileSync(signalPath, JSON.stringify({ wantsPlan: true }), 'utf8'),
+      'sure, want me to draft one for that?',
+    );
+
+    await handle!.sendMessage('submit it');
+
+    expect(handle!.lastTurnPlanIntentSignal).toEqual({ wantsPlan: true, reason: undefined });
+  });
+
+  it('proxies lastTurnDraftPlanText through a real getOrCreateSession -> sendMessage -> getter path', async () => {
+    const id = new SessionIdentifier('C123', 'thread-proxy-draft');
+    const handle = await manager.getOrCreateSession(id, 'U001');
+    expect(handle).not.toBeNull();
+
+    const draftDir = join(workingDir, '.invoker', 'plan-drafts');
+    mkdirSync(draftDir, { recursive: true });
+    const draftPath = join(draftDir, 'thread-proxy-draft.yaml');
+    const plan = 'name: "Proxy Plan"\nonFinish: none\ntasks:\n  - id: t\n    description: "d"\n    command: "pnpm test"\n    dependencies: []\n';
+    mockChildThatWrites(
+      () => writeFileSync(draftPath, plan, 'utf8'),
+      'drafted the plan, see file',
+    );
+
+    await handle!.sendMessage('draft a plan');
+
+    expect(handle!.lastTurnDraftPlanText).toBe(plan.trim());
   });
 });


### PR DESCRIPTION
## Summary

The Slack turn-lock stack fixed a real race but left two paths untested end to end. SessionHandle's proxy getters were never exercised through a real pooled session.

The in-app planning terminal's own pendingSend chain is conceptually parallel to the new turn-lock, but had no test proving it coalesces concurrent chat turns.

This slice closes both gaps, extends turn-lock coverage past the 2-concurrent-call case, and adds a guard-rail test documenting the terminal never constructs a session in agent mode today.

## Review Claim

Approve four additive unit-test extensions: SessionHandle proxy coverage through a real pooled session, PlanConversation turn-lock edge cases (3+ concurrent calls, a failing turn, cross-instance isolation), in-app-planner chat-turn coalescing, and a guard-rail that the terminal stays in plan mode.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

These changes only add and extend test files; no product code changes. A test can be flaky or wrong, but it cannot regress runtime behavior, since nothing outside `__tests__` directories is touched.

## Slice Rationale

Bundled as one slice because all four items are pure test additions with no dependency on each other, discovered together during the same coverage audit, and reviewable as one "did the audit find real gaps" claim. Split from the M1/M2 monkey-test slice because those are a different kind of test (randomized/property) with their own separate stability verification.

## Non-goals

Does not change PlanConversation, thread-session-manager, or in-app-planner product code. Does not add monkey/randomized tests (see the next slice in this stack).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm test`
- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/in-app-planner.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ff5f83a`
- Post-revert steps: None
- Data migration? No

</details>
