### PR TITLE
[Slack plan-intent holes](9) Add bounded monkey tests over both plan-intent surfaces

### DIFF
--- a/packages/app/src/__tests__/in-app-planner-monkey.test.ts
+++ b/packages/app/src/__tests__/in-app-planner-monkey.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createInAppPlanningChatSessions,
+  sendPlanningChatMessage,
+} from '../in-app-planner.js';
+
+// A bounded, seeded random ("monkey") pass over the planning terminal's chat
+// path — not to prove any one specific behavior (in-app-planner.test.ts
+// already does that), but to shake out anything a hand-written scenario
+// didn't think to ask, by firing randomized sequences of chat turns at one
+// session, with one turn per run deliberately deferred and overlapped with
+// the next, and checking pendingSend never lets a later turn's planner call
+// start before the deferred one is released.
+//
+// Uses a single SHARED plannerReplyOverride (bypassing PlanConversation
+// entirely, so PlanConversation's own turn lock can't mask a broken
+// pendingSend) that records invocation order as calls actually reach it —
+// not one fixed override per call. An earlier version of this test gave
+// each call its own pre-assigned reply closure; since nothing was shared
+// between calls, there was nothing that COULD get swapped regardless of
+// serialization, so it passed even with pendingSend deleted. Recording
+// real invocation order against a shared log is what actually discriminates.
+
+// ── Tiny seeded PRNG (mulberry32) — no new dependency, reproducible runs ──
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+async function flushUntil(predicate: () => boolean, maxTicks = 2000): Promise<void> {
+  for (let i = 0; i < maxTicks; i++) {
+    if (predicate()) return;
+    await Promise.resolve();
+  }
+  throw new Error('condition never became true within maxTicks microtask flushes');
+}
+
+const RUN_COUNT = 30;
+const SEED = 424242;
+
+describe('in-app-planner monkey pass', () => {
+  it(`survives ${RUN_COUNT} randomized chat-turn sequences (one deliberately-deferred, overlapped turn per run) without letting a later turn start early`, async () => {
+    const rng = mulberry32(SEED);
+    const errors: unknown[] = [];
+    const planningCommandBuilder = vi.fn(() => ({ command: 'planner', args: ['prompt'] }));
+
+    for (let run = 0; run < RUN_COUNT; run++) {
+      const sessions = createInAppPlanningChatSessions();
+      const invocationOrder: string[] = [];
+
+      const first = await sendPlanningChatMessage({
+        message: 'seed',
+        presetKey: 'codex',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        plannerReplyOverride: async (formattedMessage) => {
+          invocationOrder.push(formattedMessage);
+          return 'reply-seed';
+        },
+      });
+      if (!first.ok) {
+        errors.push({ run, kind: 'seed-failed', error: first.error });
+        continue;
+      }
+
+      const turnCount = 3 + Math.floor(rng() * 4); // 3..6 follow-up turns
+      const deferAt = 1 + Math.floor(rng() * turnCount); // which turn (1-indexed) to defer this run
+      let resolveDeferred: (() => void) | undefined;
+      const sharedOverride = (i: number) => async (formattedMessage: string): Promise<string> => {
+        if (i === deferAt) {
+          return new Promise<string>((resolve) => {
+            resolveDeferred = () => {
+              invocationOrder.push(formattedMessage);
+              resolve(`reply-${i}`);
+            };
+          });
+        }
+        invocationOrder.push(formattedMessage);
+        return `reply-${i}`;
+      };
+
+      const calls: Promise<unknown>[] = [];
+      for (let i = 1; i <= turnCount; i++) {
+        const call = sendPlanningChatMessage({
+          sessionId: first.sessionId,
+          message: `msg-${i}`,
+        }, {
+          config: {},
+          loadGeneratedPlan: vi.fn(),
+          sessions,
+          planningCommandBuilder,
+          plannerReplyOverride: sharedOverride(i),
+        });
+        calls.push(call);
+      }
+
+      // While the deferred turn is still pending, no LATER turn's message
+      // should have reached the override yet — pendingSend must hold every
+      // subsequent call behind it, not let them run ahead.
+      await flushUntil(() => resolveDeferred !== undefined);
+      const invokedWhileDeferredPending = [...invocationOrder];
+      const laterTurnLeaked = invokedWhileDeferredPending.some((m) => {
+        const match = /msg-(\d+)/.exec(m);
+        return match && Number(match[1]) > deferAt;
+      });
+      if (laterTurnLeaked) {
+        errors.push({ run, kind: 'later-turn-started-before-deferred-released', deferAt, invokedWhileDeferredPending });
+      }
+
+      resolveDeferred?.();
+      const settled = await Promise.all(calls);
+
+      settled.forEach((raw, idx) => {
+        const result = raw as { ok: boolean; reply?: string; error?: string };
+        const expected = `reply-${idx + 1}`;
+        if (!result.ok || result.reply !== expected) {
+          errors.push({ run, turn: idx + 1, deferAt, expected, got: result });
+        }
+      });
+
+      const session = sessions.get(first.sessionId);
+      const userMessages = session?.messages.filter((m) => m.role === 'user').map((m) => m.text) ?? [];
+      const expectedUserMessages = ['seed', ...Array.from({ length: turnCount }, (_, i) => `msg-${i + 1}`)];
+      if (JSON.stringify(userMessages) !== JSON.stringify(expectedUserMessages)) {
+        errors.push({ run, kind: 'history-order-mismatch', deferAt, userMessages, expectedUserMessages });
+      }
+    }
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -851,6 +851,170 @@ tasks:
     await expect(second).resolves.toEqual({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
   });
 
+  it('coalesces concurrent chat turns for one session — a later turn does not start until the earlier one finishes', async () => {
+    // End-to-end: the real conversation path (pendingSend chaining plus
+    // PlanConversation's own turn lock, both active) never lets two chat
+    // turns' planner calls run at once. See the plannerReplyOverride test
+    // below for a version that isolates pendingSend specifically.
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValueOnce('turn 1 reply');
+    const sessions = createInAppPlanningChatSessions();
+    const first = await sendPlanningChatMessage({
+      message: 'draft',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    if (!first.ok) throw new Error(first.error);
+
+    const spawnSpy = vi.spyOn(PlanConversation.prototype, 'spawnPlanner');
+    let resolveTurn2: ((value: string) => void) | undefined;
+    spawnSpy.mockImplementationOnce(() => new Promise<string>((resolve) => { resolveTurn2 = resolve; }));
+    spawnSpy.mockResolvedValueOnce('turn 3 reply');
+    const callsBefore = spawnSpy.mock.calls.length;
+
+    const second = sendPlanningChatMessage({
+      sessionId: first.sessionId,
+      message: 'turn 2',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    const third = sendPlanningChatMessage({
+      sessionId: first.sessionId,
+      message: 'turn 3',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+
+    // Give the event loop plenty of chances to let turn 3 start if it were
+    // going to run concurrently with turn 2. With pendingSend serializing
+    // chat turns, only turn 2's planner call can have happened by now.
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    expect(spawnSpy.mock.calls.length).toBe(callsBefore + 1);
+
+    resolveTurn2?.('turn 2 reply');
+    const secondResult = await second;
+    const thirdResult = await third;
+
+    expect(secondResult.ok && secondResult.reply).toBe('turn 2 reply');
+    expect(thirdResult.ok && thirdResult.reply).toBe('turn 3 reply');
+  });
+
+  it('pendingSend alone serializes chat turns when the planner call bypasses PlanConversation entirely', async () => {
+    // The previous test exercises the real PlanConversation.sendMessage path,
+    // which now has its own turn-serialization lock — so it can't tell
+    // apart "pendingSend serializes turns" from "PlanConversation's lock
+    // serializes turns underneath it; pendingSend just rides along". The
+    // plannerReplyOverride dependency skips conversation.sendMessage
+    // entirely, isolating pendingSend as the only thing that could possibly
+    // be serializing these calls.
+    const sessions = createInAppPlanningChatSessions();
+    const first = await sendPlanningChatMessage({
+      message: 'draft',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+      plannerReplyOverride: async () => 'turn 1 reply',
+    });
+    if (!first.ok) throw new Error(first.error);
+
+    let resolveTurn2: ((value: string) => void) | undefined;
+    const overrideCalls: string[] = [];
+    const plannerReplyOverride = vi.fn((formattedMessage: string) => {
+      overrideCalls.push(formattedMessage);
+      if (overrideCalls.length === 1) {
+        return new Promise<string>((resolve) => { resolveTurn2 = resolve; });
+      }
+      return Promise.resolve('turn 3 reply');
+    });
+
+    const second = sendPlanningChatMessage({
+      sessionId: first.sessionId,
+      message: 'turn 2',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+      plannerReplyOverride,
+    });
+    const third = sendPlanningChatMessage({
+      sessionId: first.sessionId,
+      message: 'turn 3',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+      plannerReplyOverride,
+    });
+
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    expect(overrideCalls.length).toBe(1); // only turn 2's override call has fired so far
+
+    resolveTurn2?.('turn 2 reply');
+    const secondResult = await second;
+    const thirdResult = await third;
+
+    expect(secondResult.ok && secondResult.reply).toBe('turn 2 reply');
+    expect(thirdResult.ok && thirdResult.reply).toBe('turn 3 reply');
+    expect(overrideCalls.length).toBe(2);
+  });
+
+  it('never constructs a session in mode: agent (createSession and planFromGoal paths)', async () => {
+    // The single shared config builder every terminal PlanConversation goes
+    // through never sets `mode` at all, so every terminal session defaults
+    // to 'plan' — the agent-mode system prompt (and the plan-intent
+    // auto-detect wiring that currently only Slack connects) is unreachable
+    // here. If someone later wires agent mode into the terminal, this test
+    // breaks, forcing a conscious decision about whether plan-intent
+    // detection needs to come along too, instead of a silent half-wire.
+    let createSessionPrompt = '';
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockImplementationOnce((prompt: string) => {
+      createSessionPrompt = prompt;
+      return Promise.resolve('turn 1 reply');
+    });
+    const sessions = createInAppPlanningChatSessions();
+    const created = await sendPlanningChatMessage({
+      message: 'draft',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    if (!created.ok) throw new Error(created.error);
+    expect(sessions.get(created.sessionId)?.conversation.conversationMode).toBe('plan');
+    expect(createSessionPrompt).not.toContain('You are a normal coding agent');
+    expect(createSessionPrompt).not.toContain('wantsPlan');
+
+    let goalPrompt = '';
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockImplementationOnce((prompt: string) => {
+      goalPrompt = prompt;
+      return Promise.resolve(VALID_PLAN);
+    });
+    const goalResult = await planFromGoal({ goal: 'build a REST API' }, {
+      config: {},
+      loadGeneratedPlan: vi.fn().mockResolvedValue({ planName: 'Mock Plan', workflowId: 'wf-1' }),
+      planningCommandBuilder,
+    });
+    expect(goalResult.ok).toBe(true);
+    expect(goalPrompt).not.toContain('You are a normal coding agent');
+    expect(goalPrompt).not.toContain('wantsPlan');
+  });
+
   it('returns load and parse failures as submit errors', async () => {
     vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
     const sessions = createInAppPlanningChatSessions();

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -1022,7 +1022,7 @@ describe('PlanConversation prompt construction', () => {
     expect(conv.buildCursorPrompt()).not.toContain('prefer a workflow stack');
   });
 
-  it('agent mode refuses Invoker YAML and redirects within the same thread', () => {
+  it('agent mode refuses Invoker YAML and redirects to /plan when there is no thread to signal from', () => {
     const conv = new PlanConversation({ mode: 'agent' });
     (conv as any).messages.push({ role: 'user', content: 'Make me an Invoker plan to add a REST API' });
     const prompt = conv.buildCursorPrompt();
@@ -1030,11 +1030,25 @@ describe('PlanConversation prompt construction', () => {
     // Never the plan-mode system prompt in an agent thread.
     expect(prompt).not.toContain('Invoker orchestrator');
     expect(prompt).toContain('Do NOT generate or submit Invoker YAML yourself');
-    expect(prompt).toContain('promotes planning requests');
-    expect(prompt).toContain('same thread');
-    expect(prompt).not.toContain('start a new plan thread');
+    // No auto-promotion claim: nothing implements that, and it's the bug this replaces.
+    expect(prompt).not.toContain('automatically');
+    expect(prompt).not.toContain('promotes planning requests');
+    expect(prompt).toContain('type `/plan <request>`');
     expect(prompt).toContain('only the final user-facing message');
     expect(prompt).not.toContain('unless the user explicitly asks');
+  });
+
+  it('agent mode tells the model to signal plan-intent via file when a thread is pinned', () => {
+    const conv = new PlanConversation({ mode: 'agent', workingDir: '/tmp/worktree', threadTs: 'thread-abc' });
+    (conv as any).messages.push({ role: 'user', content: 'submit it' });
+    const prompt = conv.buildCursorPrompt();
+
+    expect(prompt).not.toContain('automatically');
+    expect(prompt).not.toContain('promotes planning requests');
+    expect(prompt).toContain('wantsPlan');
+    expect(prompt).toContain(String(conv.planIntentSignalFilePath()));
+    expect(prompt).toContain('type `/plan <request>`');
+    expect(prompt).toContain('a false positive interrupts the conversation');
   });
 });
 

--- a/packages/surfaces/src/__tests__/plan-intent-signal-file.test.ts
+++ b/packages/surfaces/src/__tests__/plan-intent-signal-file.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import * as child_process from 'node:child_process';
@@ -150,5 +150,93 @@ describe('plan intent signal file — activation side', () => {
     mockSpawn.mockReturnValueOnce(fakePlannerChild('a normal follow-up, no file written'));
     await conversation.sendMessage('what did you just do?');
     expect(conversation.lastTurnPlanIntentSignal).toBeNull();
+  });
+});
+
+describe('plan intent signal file — concurrent turns are serialized', () => {
+  let workingDir: string;
+
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    workingDir = mkdtempSync(join(tmpdir(), 'plan-intent-race-'));
+  });
+
+  afterEach(() => {
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  // A manually-controlled child: unlike fakePlannerChild, nothing closes it
+  // automatically. The test decides exactly when each turn's model "finishes
+  // writing its file" and "exits", to construct a specific interleaving
+  // deterministically rather than relying on timer race luck.
+  function controlledChild(): { proc: any; close: (stdout: string) => void } {
+    const proc = new EventEmitter() as any;
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = vi.fn();
+    return {
+      proc,
+      close: (stdout: string) => {
+        proc.stdout.emit('data', Buffer.from(stdout));
+        proc.emit('close', 0);
+      },
+    };
+  }
+
+  // How many internal awaits sit between calling sendMessage and spawn()
+  // actually being invoked is an implementation detail (init(), retry setup,
+  // etc). Rather than hand-count microtask ticks, flush them until the
+  // condition we actually care about is true.
+  async function flushUntil(predicate: () => boolean, maxTicks = 50): Promise<void> {
+    for (let i = 0; i < maxTicks; i++) {
+      if (predicate()) return;
+      await Promise.resolve();
+    }
+    throw new Error('condition never became true within maxTicks microtask flushes');
+  }
+
+  it('does not let a second concurrent turn wipe a signal before the first turn reads it back', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'race-thread', mode: 'agent', plannerRetryLimit: 0 });
+    const path = conversation.planIntentSignalFilePath();
+    if (!path) throw new Error('expected a plan intent signal path');
+    mkdirSync(join(workingDir, '.invoker', 'plan-intent'), { recursive: true });
+
+    const a = controlledChild();
+    const b = controlledChild();
+    mockSpawn.mockImplementationOnce(() => a.proc);
+    mockSpawn.mockImplementationOnce(() => b.proc);
+
+    let signalWhenAResolved: unknown;
+    let signalWhenBResolved: unknown;
+    const sendA = conversation.sendMessage('submit it').then((reply) => {
+      signalWhenAResolved = conversation.lastTurnPlanIntentSignal;
+      return reply;
+    });
+    await flushUntil(() => mockSpawn.mock.calls.length >= 1); // let A reach spawn(A)
+
+    // A's model "writes its file" mid-turn (process is still open).
+    writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8');
+
+    // Before A's process has exited, a second turn is requested on the same
+    // conversation (e.g. two Slack events for this thread arriving close
+    // together). With serialization, B's own turn-setup reset is deferred
+    // until A fully finishes — it cannot race A's not-yet-executed read.
+    const sendB = conversation.sendMessage('what does this mean?').then((reply) => {
+      signalWhenBResolved = conversation.lastTurnPlanIntentSignal;
+      return reply;
+    });
+
+    a.close('sure, want me to draft one for that?');
+    await sendA;
+
+    await flushUntil(() => mockSpawn.mock.calls.length >= 2); // let B reach spawn(B)
+    b.close('just a normal reply, no file written');
+    await sendB;
+
+    // A must see its own signal — not have it wiped by B's concurrent turn.
+    expect(signalWhenAResolved).toEqual({ wantsPlan: true, reason: undefined });
+    // B's own turn wrote nothing, so once B's (serialized, later) turn runs
+    // its own reset+read, it correctly sees nothing.
+    expect(signalWhenBResolved).toBeNull();
   });
 });

--- a/packages/surfaces/src/__tests__/plan-intent-signal-file.test.ts
+++ b/packages/surfaces/src/__tests__/plan-intent-signal-file.test.ts
@@ -239,4 +239,106 @@ describe('plan intent signal file — concurrent turns are serialized', () => {
     // its own reset+read, it correctly sees nothing.
     expect(signalWhenBResolved).toBeNull();
   });
+
+  it('processes 3 concurrent calls in strict FIFO (call) order, not close order', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'race-thread-3', mode: 'agent', plannerRetryLimit: 0 });
+
+    const a = controlledChild();
+    const b = controlledChild();
+    const c = controlledChild();
+    mockSpawn.mockImplementationOnce(() => a.proc);
+    mockSpawn.mockImplementationOnce(() => b.proc);
+    mockSpawn.mockImplementationOnce(() => c.proc);
+
+    const resolutionOrder: string[] = [];
+    const sendA = conversation.sendMessage('A').then((r) => { resolutionOrder.push('A'); return r; });
+    await flushUntil(() => mockSpawn.mock.calls.length >= 1);
+
+    // B and C both queue behind A, in call order, before A has finished.
+    const sendB = conversation.sendMessage('B').then((r) => { resolutionOrder.push('B'); return r; });
+    const sendC = conversation.sendMessage('C').then((r) => { resolutionOrder.push('C'); return r; });
+
+    // Give the event loop plenty of chances to let B/C's own turn-setup run
+    // if it were going to happen concurrently with A. With serialization,
+    // neither can reach spawn() until A finishes, no matter how many ticks
+    // pass — this is the direct, unambiguous proof (not just resolution
+    // order, which close-timing games alone don't reliably discriminate).
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    expect(mockSpawn.mock.calls.length).toBe(1);
+
+    a.close('a reply');
+    await sendA;
+    await flushUntil(() => mockSpawn.mock.calls.length >= 2);
+
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    expect(mockSpawn.mock.calls.length).toBe(2); // B started, C still queued behind it
+
+    b.close('b reply');
+    await sendB;
+    await flushUntil(() => mockSpawn.mock.calls.length >= 3);
+    c.close('c reply');
+    await sendC;
+
+    // Regardless of any close-timing games, the queue releases in the order
+    // calls arrived — never something else.
+    expect(resolutionOrder).toEqual(['A', 'B', 'C']);
+  });
+
+  it('does not corrupt the queue when a queued turn fails — the next turn still runs', async () => {
+    const conversation = new PlanConversation({ workingDir, threadTs: 'race-thread-fail', mode: 'agent', plannerRetryLimit: 0 });
+
+    const a = controlledChild();
+    const b = controlledChild();
+    mockSpawn.mockImplementationOnce(() => a.proc);
+    mockSpawn.mockImplementationOnce(() => b.proc);
+
+    const sendA = conversation.sendMessage('A');
+    await flushUntil(() => mockSpawn.mock.calls.length >= 1);
+
+    // B queues behind A before A fails.
+    const sendB = conversation.sendMessage('B');
+
+    // While A is still in flight, B must not have reached spawn() yet — the
+    // lock has to hold even though A is about to fail, not just when A
+    // succeeds. (Without this check, A and B would just run independently
+    // and this test would pass whether or not the lock exists at all.)
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    expect(mockSpawn.mock.calls.length).toBe(1);
+
+    // A fails: non-zero exit.
+    a.proc.stderr.emit('data', Buffer.from('boom'));
+    a.proc.emit('close', 1);
+    await expect(sendA).rejects.toThrow();
+
+    // The lock must still release on failure (via .finally()) — B runs next,
+    // not stuck behind a permanently-held lock.
+    await flushUntil(() => mockSpawn.mock.calls.length >= 2);
+    b.close('b reply, after a failed');
+    await expect(sendB).resolves.toBe('b reply, after a failed');
+  });
+
+  it('does not block a different conversation instance (the lock is per-instance, not shared)', async () => {
+    const conversationX = new PlanConversation({ workingDir, threadTs: 'thread-x', mode: 'agent', plannerRetryLimit: 0 });
+    const conversationY = new PlanConversation({ workingDir, threadTs: 'thread-y', mode: 'agent', plannerRetryLimit: 0 });
+
+    const x = controlledChild();
+    const y = controlledChild();
+    mockSpawn.mockImplementationOnce(() => x.proc);
+    mockSpawn.mockImplementationOnce(() => y.proc);
+
+    // X starts and does NOT finish (its process stays open).
+    const sendX = conversationX.sendMessage('for X');
+    await flushUntil(() => mockSpawn.mock.calls.length >= 1);
+
+    // Y, on a DIFFERENT conversation instance, must still reach spawn()
+    // immediately — it must not wait behind X's still-open turn.
+    const sendY = conversationY.sendMessage('for Y');
+    await flushUntil(() => mockSpawn.mock.calls.length >= 2);
+
+    y.close('y reply');
+    await expect(sendY).resolves.toBe('y reply');
+
+    x.close('x reply');
+    await expect(sendX).resolves.toBe('x reply');
+  });
 });

--- a/packages/surfaces/src/__tests__/slack-plan-intent-auto-detect-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-intent-auto-detect-repros.e2e.test.ts
@@ -114,6 +114,35 @@ function intentSignalPath(workingDir: string, threadTs: string): string {
   return join(workingDir, '.invoker', 'plan-intent', `${safeId}.json`);
 }
 
+// A manually-controlled child: unlike processWith, nothing closes it
+// automatically. Used to construct a specific interleaving deterministically
+// rather than relying on timer race luck.
+function controlledChild(): { proc: any; close: (stdout: string) => void } {
+  const proc = new EventEmitter() as any;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  return {
+    proc,
+    close: (stdout: string) => {
+      proc.stdout.emit('data', Buffer.from(stdout));
+      proc.emit('close', 0);
+    },
+  };
+}
+
+// How many internal awaits sit between an @mention landing and spawn()
+// actually being invoked is an implementation detail. Rather than hand-count
+// microtask ticks, flush them until the condition we actually care about
+// is true.
+async function flushUntil(predicate: () => boolean, maxTicks = 50): Promise<void> {
+  for (let i = 0; i < maxTicks; i++) {
+    if (predicate()) return;
+    await Promise.resolve();
+  }
+  throw new Error('condition never became true within maxTicks microtask flushes');
+}
+
 describe('Slack plan-intent auto-detect repro', () => {
   let workingDir: string;
   let adapter: SQLiteAdapter;
@@ -331,5 +360,50 @@ describe('Slack plan-intent auto-detect repro', () => {
     expect(say).toHaveBeenCalledWith(expect.objectContaining({
       text: expect.stringContaining('@mention me first'),
     }));
+  });
+
+  it('does not let a second concurrent @mention on the same thread wipe the first turn\'s signal before it is read', async () => {
+    const threadTs = 'thread-race';
+    seedContext(slackSessionRepo, threadTs, workingDir);
+    const say = vi.fn().mockResolvedValue({ ts: 'msg-race' });
+    const path = intentSignalPath(workingDir, threadTs);
+    mkdirSync(join(workingDir, '.invoker', 'plan-intent'), { recursive: true });
+
+    const a = controlledChild();
+    const b = controlledChild();
+    mockSpawn.mockImplementationOnce(() => a.proc);
+    mockSpawn.mockImplementationOnce(() => b.proc);
+
+    // First Slack event for this thread: "submit it".
+    const replyA = handler(surface, 'app_mention')({
+      event: { text: '<@UBOT> submit it', ts: 'evt-a', thread_ts: threadTs, user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+    await flushUntil(() => mockSpawn.mock.calls.length >= 1);
+
+    // A's model "writes its file" mid-turn (process is still open).
+    writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8');
+
+    // A second Slack event for the SAME thread arrives before the first has
+    // finished — e.g. the user sent two messages in quick succession.
+    const replyB = handler(surface, 'app_mention')({
+      event: { text: '<@UBOT> actually never mind', ts: 'evt-b', thread_ts: threadTs, user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+
+    a.close('sure, want me to draft one for that?');
+    await replyA;
+
+    await flushUntil(() => mockSpawn.mock.calls.length >= 2);
+    b.close('ok, no plan then');
+    await replyB;
+
+    // The first turn's real signal must have produced the Approve/No
+    // buttons, keyed to its own request text — not lost to the second,
+    // concurrently-arriving turn's setup.
+    expect(buttonValue(say, 'lobby_plan_for_execution')).toBeTruthy();
+    const pending = slackSessionRepo.getPendingConfirmation(threadTs);
+    expect(pending).not.toBeNull();
+    expect((pending!.payload as { requestText?: string }).requestText).toBe('submit it');
   });
 });

--- a/packages/surfaces/src/__tests__/slack-plan-intent-auto-detect-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-intent-auto-detect-repros.e2e.test.ts
@@ -256,6 +256,38 @@ describe('Slack plan-intent auto-detect repro', () => {
     createSpy.mockRestore();
   });
 
+  it('a bare /plan reply takes priority over an unrelated pending confirm instead of being swallowed by it', async () => {
+    seedContext(slackSessionRepo, 'thread-priority', workingDir);
+    const say = vi.fn().mockResolvedValue({ ts: 'msg-p1' });
+
+    // First /plan reply stages a pending plan_intent confirm.
+    await handler(surface, 'message')({
+      event: { text: '/plan add a REST endpoint', ts: 'msg-p1', thread_ts: 'thread-priority', user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+    expect(buttonValue(say, 'lobby_plan_for_execution')).toBeTruthy();
+    expect(slackSessionRepo.getPendingConfirmation('thread-priority')).not.toBeNull();
+    say.mockClear();
+
+    // A second /plan reply, before the first is answered, must reach the
+    // /plan handling (and get the "already pending" guard message) — not be
+    // silently swallowed by resolveConfirm's "not a yes/no" fallback, which
+    // would instead delete the pending confirm and say something unrelated.
+    await handler(surface, 'message')({
+      event: { text: '/plan actually add a different endpoint', ts: 'msg-p2', thread_ts: 'thread-priority', user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+
+    expect(say).not.toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('Dropped the pending approval'),
+    }));
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('already a pending confirmation'),
+    }));
+    // The original pending confirm must survive, not be dropped.
+    expect(slackSessionRepo.getPendingConfirmation('thread-priority')).not.toBeNull();
+  });
+
   it('skips detection for a bare in-thread reply with no pinned context yet', async () => {
     const say = vi.fn().mockResolvedValue({ ts: 'msg-4' });
     const path = intentSignalPath(workingDir, 'thread-4');
@@ -271,5 +303,33 @@ describe('Slack plan-intent auto-detect repro', () => {
     });
 
     expect(tryButtonValue(say, 'lobby_plan_for_execution')).toBeUndefined();
+  });
+
+  it('stages a plan question for a bare in-thread /plan reply, without re-mentioning the bot', async () => {
+    seedContext(slackSessionRepo, 'thread-5', workingDir);
+    const say = vi.fn().mockResolvedValue({ ts: 'msg-5' });
+
+    await handler(surface, 'message')({
+      event: { text: '/plan add a REST endpoint', ts: 'msg-5', thread_ts: 'thread-5', user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(buttonValue(say, 'lobby_plan_for_execution')).toBeTruthy();
+    expect(buttonValue(say, 'lobby_continue_conversation')).toBeTruthy();
+  });
+
+  it('tells the user to @mention first when a bare in-thread /plan has no pinned context', async () => {
+    const say = vi.fn().mockResolvedValue({ ts: 'msg-6' });
+
+    await handler(surface, 'message')({
+      event: { text: '/plan add a REST endpoint', ts: 'msg-6', thread_ts: 'thread-6', user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+
+    expect(tryButtonValue(say, 'lobby_plan_for_execution')).toBeUndefined();
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('@mention me first'),
+    }));
   });
 });

--- a/packages/surfaces/src/__tests__/slack-plan-intent-monkey.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-intent-monkey.e2e.test.ts
@@ -1,0 +1,333 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import * as childProcess from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ConversationRepository, SQLiteAdapter, SlackPlanDraftRepository, SlackSessionRepository } from '@invoker/data-store';
+import { SlackSurface, DEFAULT_HARNESS_PRESET } from '../slack/slack-surface.js';
+import type { SurfaceCommand } from '../surface.js';
+
+// A bounded, seeded random ("monkey") pass over the Slack plan-intent flow —
+// not to prove any one specific behavior (the targeted repro suites already
+// do that), but to shake out anything a hand-written scenario didn't think
+// to ask, by throwing randomized sequences of messages and button clicks at
+// the real SlackSurface event handlers. Runs are seeded for reproducibility
+// and bounded so this stays fast in CI, not a fuzzing framework.
+
+interface MockHandler {
+  pattern: string | RegExp;
+  handler: Function;
+}
+
+const sharedSlack = vi.hoisted(() => ({
+  client: {
+    auth: { test: vi.fn().mockResolvedValue({ user_id: 'UBOT' }) },
+    chat: {
+      postMessage: vi.fn().mockResolvedValue({ ts: 'posted' }),
+      update: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    },
+    files: { uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F_PLAN' }] }) },
+    reactions: { add: vi.fn().mockResolvedValue({}), remove: vi.fn().mockResolvedValue({}) },
+    conversations: { replies: vi.fn().mockResolvedValue({ messages: [] }) },
+  },
+}));
+
+vi.mock('@slack/bolt', () => {
+  class MockApp {
+    _eventHandlers: MockHandler[] = [];
+    _actionHandlers: MockHandler[] = [];
+    command = vi.fn();
+    event = vi.fn((pattern: string, handler: Function) => this._eventHandlers.push({ pattern, handler }));
+    action = vi.fn((pattern: string | RegExp, handler: Function) => this._actionHandlers.push({ pattern, handler }));
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    client = sharedSlack.client;
+  }
+  return { App: MockApp };
+});
+
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof childProcess>()),
+  spawn: vi.fn(),
+}));
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+const silentLog = () => {};
+
+// ── Tiny seeded PRNG (mulberry32) — no new dependency, reproducible runs ──
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0; a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pick<T>(rng: () => number, items: readonly T[]): T {
+  return items[Math.floor(rng() * items.length)];
+}
+
+function processWith(stdout: string, beforeClose?: () => void): any {
+  const process = new EventEmitter() as any;
+  process.stdout = new EventEmitter();
+  process.stderr = new EventEmitter();
+  process.kill = vi.fn();
+  queueMicrotask(() => {
+    beforeClose?.();
+    process.stdout.emit('data', Buffer.from(stdout));
+    process.emit('close', 0);
+  });
+  return process;
+}
+
+function handler(surface: SlackSurface, pattern: string): Function {
+  const found = (surface.getApp() as any)._eventHandlers.find((entry: MockHandler) => entry.pattern === pattern);
+  if (!found) throw new Error(`Missing ${pattern} handler`);
+  return found.handler;
+}
+
+function actionHandler(surface: SlackSurface, pattern: string): Function {
+  const found = (surface.getApp() as any)._actionHandlers.find((entry: MockHandler) => entry.pattern === pattern);
+  if (!found) throw new Error(`Missing ${pattern} action handler`);
+  return found.handler;
+}
+
+function seedContext(slackSessionRepo: SlackSessionRepository, threadTs: string, workingDir: string): void {
+  slackSessionRepo.saveLaunchContext({
+    threadTs,
+    repoUrl: 'https://github.com/EdbertChan/notarepo',
+    harnessPreset: DEFAULT_HARNESS_PRESET,
+    workingDir,
+    requestedBy: 'U_TEST',
+    lobbyChannelId: 'C_LOBBY',
+    confirmationMode: 'require',
+  });
+}
+
+function intentSignalPath(workingDir: string, threadTs: string): string {
+  const safeId = threadTs.replace(/[^a-zA-Z0-9._-]/g, '_');
+  return join(workingDir, '.invoker', 'plan-intent', `${safeId}.json`);
+}
+
+const PLAIN_MESSAGES = [
+  'why did so many fail',
+  'for every issue create a repro script',
+  'plan out how to fix this',
+  'submit it',
+  'convert this to Invoker',
+  'actually never mind',
+  'what does that mean',
+] as const;
+
+const GARBAGE_REPLIES = ['yes', 'no', 'ok', 'nope', 'ship it', 'asdkjfh', '', '   ', '/plan', '/plan fix the bug'] as const;
+
+const RUN_COUNT = 30;
+const STEPS_PER_RUN = 6;
+const SEED = 424242;
+
+describe('Slack plan-intent monkey pass', () => {
+  let workingDir: string;
+  let adapter: SQLiteAdapter;
+  let conversationRepo: ConversationRepository;
+  let slackPlanDraftRepo: SlackPlanDraftRepository;
+  let slackSessionRepo: SlackSessionRepository;
+  let surface: SlackSurface;
+  let commands: SurfaceCommand[];
+
+  beforeEach(async () => {
+    mockSpawn.mockReset();
+    // A monkey run can't predict exactly which random actions will spawn a
+    // planner (that depends on state built up by earlier random steps), so
+    // give every call a safe fallback reply. Steps that care about a
+    // specific reply (e.g. writing the intent signal) still layer a
+    // mockImplementationOnce on top for that one call.
+    mockSpawn.mockImplementation(() => processWith('monkey default reply'));
+    workingDir = mkdtempSync(join(tmpdir(), 'plan-intent-monkey-'));
+    mkdirSync(join(workingDir, '.invoker', 'plan-intent'), { recursive: true });
+    adapter = await SQLiteAdapter.create(':memory:');
+    conversationRepo = new ConversationRepository(adapter, { info: silentLog, warn: silentLog, error: silentLog });
+    slackPlanDraftRepo = new SlackPlanDraftRepository(adapter);
+    slackSessionRepo = new SlackSessionRepository(adapter);
+    commands = [];
+    surface = new SlackSurface({
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      signingSecret: 'test',
+      channelId: 'C_LOBBY',
+      lobbyChannelId: 'C_LOBBY',
+      defaultRepoUrl: 'https://github.com/EdbertChan/notarepo',
+      conversationRepo,
+      slackSessionRepo,
+      slackPlanDraftRepo,
+      enableImmediateAck: false,
+      planningHeartbeatIntervalSeconds: 0,
+      log: silentLog,
+    });
+    await surface.start(async (command) => { commands.push(command); });
+  });
+
+  afterEach(async () => {
+    await surface.stop();
+    adapter.close();
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  it(`survives ${RUN_COUNT} randomized ${STEPS_PER_RUN}-step sequences without an unhandled error, an empty say(), or a runaway spawn loop`, async () => {
+    const rng = mulberry32(SEED);
+    const errors: unknown[] = [];
+    const emptySayTexts: unknown[] = [];
+
+    for (let run = 0; run < RUN_COUNT; run++) {
+      const threadTs = `monkey-thread-${run}`;
+      seedContext(slackSessionRepo, threadTs, workingDir);
+      const say = vi.fn().mockImplementation((msg: { text?: unknown }) => {
+        if (!msg?.text || (typeof msg.text === 'string' && msg.text.trim() === '')) {
+          emptySayTexts.push({ run, msg });
+        }
+        return Promise.resolve({ ts: `posted-${run}` });
+      });
+
+      let lastApproveKey: string | undefined;
+      let lastNoKey: string | undefined;
+      const pendingCalls: Array<Promise<unknown>> = [];
+
+      for (let step = 0; step < STEPS_PER_RUN; step++) {
+        const writesSignal = rng() < 0.4;
+        const action = pick(rng, [
+          'mention_plain',
+          'mention_bare_plan',
+          'mention_plan_text',
+          'bare_reply_garbage',
+          'click_approve',
+          'click_no',
+          'click_stale',
+        ] as const);
+
+        const runStep = async (): Promise<void> => {
+          const callsBefore = say.mock.calls.length;
+          const isPlanCommand = (t: string) => /^\/plan\b/i.test(t.trim());
+          let stepText: string | undefined;
+          try {
+            switch (action) {
+              case 'mention_plain': {
+                const text = pick(rng, PLAIN_MESSAGES);
+                const path = intentSignalPath(workingDir, threadTs);
+                mockSpawn.mockImplementationOnce(() => processWith(
+                  'a normal reply',
+                  writesSignal ? () => writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8') : undefined,
+                ));
+                await handler(surface, 'app_mention')({
+                  event: { text: `<@UBOT> ${text}`, ts: `evt-${run}-${step}`, thread_ts: threadTs, user: 'U_TEST', channel: 'C_LOBBY' },
+                  say,
+                });
+                break;
+              }
+              case 'mention_bare_plan': {
+                stepText = '/plan';
+                await handler(surface, 'app_mention')({
+                  event: { text: '<@UBOT> /plan', ts: `evt-${run}-${step}`, thread_ts: threadTs, user: 'U_TEST', channel: 'C_LOBBY' },
+                  say,
+                });
+                break;
+              }
+              case 'mention_plan_text': {
+                stepText = '/plan add a REST endpoint';
+                await handler(surface, 'app_mention')({
+                  event: { text: '<@UBOT> /plan add a REST endpoint', ts: `evt-${run}-${step}`, thread_ts: threadTs, user: 'U_TEST', channel: 'C_LOBBY' },
+                  say,
+                });
+                break;
+              }
+              case 'bare_reply_garbage': {
+                const text = pick(rng, GARBAGE_REPLIES);
+                stepText = text;
+                await handler(surface, 'message')({
+                  event: { text, ts: `evt-${run}-${step}`, thread_ts: threadTs, user: 'U_TEST', channel: 'C_LOBBY' },
+                  say,
+                });
+                break;
+              }
+              case 'click_approve': {
+                for (const [msg] of say.mock.calls) {
+                  const button = msg.blocks?.[1]?.elements?.find((el: any) => el.action_id === 'lobby_plan_for_execution');
+                  if (button?.value) lastApproveKey = button.value;
+                }
+                if (!lastApproveKey) return;
+                mockSpawn.mockImplementationOnce(() => processWith('continuing'));
+                await actionHandler(surface, 'lobby_plan_for_execution')({
+                  action: { type: 'button', value: lastApproveKey },
+                  body: { channel: { id: 'C_LOBBY' }, message: { ts: `posted-${run}`, thread_ts: threadTs } },
+                  ack: vi.fn().mockResolvedValue(undefined),
+                  respond: vi.fn().mockResolvedValue(undefined),
+                });
+                break;
+              }
+              case 'click_no': {
+                for (const [msg] of say.mock.calls) {
+                  const button = msg.blocks?.[1]?.elements?.find((el: any) => el.action_id === 'lobby_continue_conversation');
+                  if (button?.value) lastNoKey = button.value;
+                }
+                if (!lastNoKey) return;
+                mockSpawn.mockImplementationOnce(() => processWith('ok, continuing'));
+                await actionHandler(surface, 'lobby_continue_conversation')({
+                  action: { type: 'button', value: lastNoKey },
+                  body: { channel: { id: 'C_LOBBY' }, message: { ts: `posted-${run}`, thread_ts: threadTs } },
+                  ack: vi.fn().mockResolvedValue(undefined),
+                  respond: vi.fn().mockResolvedValue(undefined),
+                });
+                break;
+              }
+              case 'click_stale': {
+                // A key that was never staged — proves the "expired" path
+                // never throws, regardless of what else is going on.
+                await actionHandler(surface, 'lobby_plan_for_execution')({
+                  action: { type: 'button', value: `stale-${run}-${step}` },
+                  body: { channel: { id: 'C_LOBBY' }, message: { ts: `posted-${run}`, thread_ts: threadTs } },
+                  ack: vi.fn().mockResolvedValue(undefined),
+                  respond: vi.fn().mockResolvedValue(undefined),
+                });
+                break;
+              }
+            }
+            // A message that is itself a /plan command must never resolve as
+            // a failed yes/no confirmation — that's a routing bug (the
+            // command got swallowed by an unrelated pending confirm instead
+            // of being handled), not a crash, so it needs its own check.
+            if (stepText && isPlanCommand(stepText)) {
+              const newCalls = say.mock.calls.slice(callsBefore);
+              const droppedApproval = newCalls.find(([msg]) =>
+                typeof msg?.text === 'string' && msg.text.includes('Dropped the pending approval'));
+              if (droppedApproval) {
+                errors.push({ run, step, action, err: new Error(`"${stepText}" was swallowed by resolveConfirm's fallback instead of being routed as /plan`) });
+              }
+            }
+          } catch (err) {
+            errors.push({ run, step, action, err });
+          }
+        };
+
+        // Occasionally fire this step without waiting for the previous one
+        // to settle first, to exercise some real overlap.
+        if (rng() < 0.25 && pendingCalls.length > 0) {
+          pendingCalls.push(runStep());
+        } else {
+          await Promise.all(pendingCalls.splice(0));
+          await runStep();
+        }
+      }
+      await Promise.all(pendingCalls.splice(0));
+    }
+
+    expect(errors).toEqual([]);
+    expect(emptySayTexts).toEqual([]);
+    // Sanity bound: no run should have triggered a runaway spawn loop. Each
+    // step spawns at most once (mention/plan/approve/no), so the ceiling is
+    // generous on purpose — this is a smoke check, not a tight budget.
+    expect(mockSpawn.mock.calls.length).toBeLessThan(RUN_COUNT * STEPS_PER_RUN * 2);
+  });
+});

--- a/packages/surfaces/src/__tests__/slack-plan-intent-real-thread-repro.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-intent-real-thread-repro.e2e.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import * as childProcess from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ConversationRepository, SQLiteAdapter, SlackPlanDraftRepository, SlackSessionRepository } from '@invoker/data-store';
+import { SlackSurface, DEFAULT_HARNESS_PRESET } from '../slack/slack-surface.js';
+import type { SurfaceCommand } from '../surface.js';
+
+// Replays the real Slack thread that motivated this feature: a long
+// multi-turn investigation ("why did so many fail" -> repro scripts -> a
+// fix-stack design), followed by "submit it" and later "convert this to
+// Invoker". In the original incident, both of
+// those got a reply that CLAIMED submission was being routed to a planner,
+// and nothing happened. This proves the fixed thread: every investigative
+// turn stays silent (no buttons, no drafting), and only a turn where the
+// model actually signals intent produces the Approve/No buttons — using the
+// user's literal message, not a summary of the whole conversation.
+
+interface MockHandler {
+  pattern: string | RegExp;
+  handler: Function;
+}
+
+const sharedSlack = vi.hoisted(() => ({
+  client: {
+    auth: { test: vi.fn().mockResolvedValue({ user_id: 'UBOT' }) },
+    chat: {
+      postMessage: vi.fn().mockResolvedValue({ ts: 'posted' }),
+      update: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    },
+    files: { uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F_PLAN' }] }) },
+    reactions: { add: vi.fn().mockResolvedValue({}), remove: vi.fn().mockResolvedValue({}) },
+    conversations: { replies: vi.fn().mockResolvedValue({ messages: [] }) },
+  },
+}));
+
+vi.mock('@slack/bolt', () => {
+  class MockApp {
+    _eventHandlers: MockHandler[] = [];
+    _actionHandlers: MockHandler[] = [];
+    command = vi.fn();
+    event = vi.fn((pattern: string, handler: Function) => this._eventHandlers.push({ pattern, handler }));
+    action = vi.fn((pattern: string | RegExp, handler: Function) => this._actionHandlers.push({ pattern, handler }));
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    client = sharedSlack.client;
+  }
+  return { App: MockApp };
+});
+
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof childProcess>()),
+  spawn: vi.fn(),
+}));
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+const silentLog = () => {};
+
+function processWith(stdout: string, beforeClose?: () => void): any {
+  const process = new EventEmitter() as any;
+  process.stdout = new EventEmitter();
+  process.stderr = new EventEmitter();
+  process.kill = vi.fn();
+  queueMicrotask(() => {
+    beforeClose?.();
+    process.stdout.emit('data', Buffer.from(stdout));
+    process.emit('close', 0);
+  });
+  return process;
+}
+
+function handler(surface: SlackSurface, pattern: string): Function {
+  const found = (surface.getApp() as any)._eventHandlers.find((entry: MockHandler) => entry.pattern === pattern);
+  if (!found) throw new Error(`Missing ${pattern} handler`);
+  return found.handler;
+}
+
+function actionHandler(surface: SlackSurface, pattern: string): Function {
+  const found = (surface.getApp() as any)._actionHandlers.find((entry: MockHandler) => entry.pattern === pattern);
+  if (!found) throw new Error(`Missing ${pattern} action handler`);
+  return found.handler;
+}
+
+function tryButtonValue(say: ReturnType<typeof vi.fn>, actionId: string): string | undefined {
+  for (const [message] of say.mock.calls) {
+    for (const block of message.blocks ?? []) {
+      const button = block.elements?.find((element: { action_id?: string }) => element.action_id === actionId);
+      if (button?.value) return button.value;
+    }
+  }
+  return undefined;
+}
+
+function buttonValue(say: ReturnType<typeof vi.fn>, actionId: string): string {
+  const value = tryButtonValue(say, actionId);
+  if (!value) throw new Error(`Missing ${actionId} button`);
+  return value;
+}
+
+function seedContext(slackSessionRepo: SlackSessionRepository, threadTs: string, workingDir: string): void {
+  slackSessionRepo.saveLaunchContext({
+    threadTs,
+    repoUrl: 'https://github.com/EdbertChan/notarepo',
+    harnessPreset: DEFAULT_HARNESS_PRESET,
+    workingDir,
+    requestedBy: 'U_TEST',
+    lobbyChannelId: 'C_LOBBY',
+    confirmationMode: 'require',
+  });
+}
+
+function intentSignalPath(workingDir: string, threadTs: string): string {
+  const safeId = threadTs.replace(/[^a-zA-Z0-9._-]/g, '_');
+  return join(workingDir, '.invoker', 'plan-intent', `${safeId}.json`);
+}
+
+describe('Slack real-thread replay: the original "submit it" incident', () => {
+  let workingDir: string;
+  let adapter: SQLiteAdapter;
+  let conversationRepo: ConversationRepository;
+  let slackPlanDraftRepo: SlackPlanDraftRepository;
+  let slackSessionRepo: SlackSessionRepository;
+  let surface: SlackSurface;
+  let commands: SurfaceCommand[];
+
+  beforeEach(async () => {
+    mockSpawn.mockReset();
+    workingDir = mkdtempSync(join(tmpdir(), 'plan-intent-real-thread-'));
+    mkdirSync(join(workingDir, '.invoker', 'plan-intent'), { recursive: true });
+    adapter = await SQLiteAdapter.create(':memory:');
+    conversationRepo = new ConversationRepository(adapter, { info: silentLog, warn: silentLog, error: silentLog });
+    slackPlanDraftRepo = new SlackPlanDraftRepository(adapter);
+    slackSessionRepo = new SlackSessionRepository(adapter);
+    commands = [];
+    surface = new SlackSurface({
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      signingSecret: 'test',
+      channelId: 'C_LOBBY',
+      lobbyChannelId: 'C_LOBBY',
+      defaultRepoUrl: 'https://github.com/EdbertChan/notarepo',
+      conversationRepo,
+      slackSessionRepo,
+      slackPlanDraftRepo,
+      enableImmediateAck: false,
+      planningHeartbeatIntervalSeconds: 0,
+      log: silentLog,
+    });
+    await surface.start(async (command) => { commands.push(command); });
+  });
+
+  afterEach(async () => {
+    await surface.stop();
+    adapter.close();
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  it('stays silent through a long investigation, then stages a plan on "submit it" using the literal message', async () => {
+    const threadTs = 'real-thread-1';
+    seedContext(slackSessionRepo, threadTs, workingDir);
+    const say = vi.fn().mockResolvedValue({ ts: 'msg' });
+
+    // Turn 1: "why did so many fail" — investigation, no plan ask. (The real
+    // thread's opening "how are our workflows running" is a natural-language
+    // status-query command, an entirely separate pre-existing code path —
+    // not representative of an agent-mode conversational turn, so it's not
+    // replayed here.)
+    mockSpawn.mockImplementationOnce(() => processWith(
+      'Not individual task bugs — it is a mass force-fail from app restarts...',
+    ));
+    await handler(surface, 'app_mention')({
+      event: { text: '<@UBOT> why did so many fail', ts: 't1', thread_ts: threadTs, user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+
+    // Turn 2: asks to build repro scripts — still investigation, no plan ask.
+    mockSpawn.mockImplementationOnce(() => processWith(
+      'Built a runnable repro per issue — all 5 confirm.',
+    ));
+    await handler(surface, 'app_mention')({
+      event: { text: '<@UBOT> for every issue and crash create a repro script to prove you are correct', ts: 't2', thread_ts: threadTs, user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+
+    // Turn 3: asks for a fix-stack design — this is a planning DISCUSSION,
+    // not yet a submission ask, so it must not trigger the signal either.
+    mockSpawn.mockImplementationOnce(() => processWith(
+      'Here is the fix stack at a glance: S0 proof, S1 foundation, S2 behavior...',
+    ));
+    await handler(surface, 'app_mention')({
+      event: { text: '<@UBOT> plan out how to fix this with a stacked workflow for all these issues', ts: 't3', thread_ts: threadTs, user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+
+    // None of the investigative/design turns should have staged anything.
+    expect(mockSpawn).toHaveBeenCalledTimes(3);
+    expect(tryButtonValue(say, 'lobby_plan_for_execution')).toBeUndefined();
+    expect(slackSessionRepo.getPendingConfirmation(threadTs)).toBeNull();
+
+    // Turn 4: "submit it" — the exact phrase from the original incident.
+    // This time the model recognizes it as a real ask and signals intent.
+    const path = intentSignalPath(workingDir, threadTs);
+    mockSpawn.mockImplementationOnce(() => processWith(
+      'Got it — let me confirm before drafting anything.',
+      () => writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8'),
+    ));
+    await handler(surface, 'app_mention')({
+      event: { text: '<@UBOT> submit it', ts: 't4', thread_ts: threadTs, user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+
+    // Now — and only now — the real Approve/No buttons appear, and the
+    // question is about the literal "submit it" message, not a paraphrase
+    // of the whole prior conversation.
+    expect(mockSpawn).toHaveBeenCalledTimes(4);
+    const key = buttonValue(say, 'lobby_plan_for_execution');
+    expect(buttonValue(say, 'lobby_continue_conversation')).toBeTruthy();
+    const pending = slackSessionRepo.getPendingConfirmation(threadTs);
+    expect(pending).not.toBeNull();
+    expect((pending!.payload as { requestText?: string }).requestText).toBe('submit it');
+
+    // Clicking Approve actually drafts a plan — the original incident's
+    // missing half. It goes straight to drafting: "submit it" was already
+    // sent to the model once (to detect the signal above), so Approve must
+    // not ask it again — one more spawn call, not two.
+    const plan = '```yaml\nname: "Stop counting SSH OAuth infra crashes"\nrepoUrl: "https://github.com/EdbertChan/notarepo"\ntasks:\n  - id: classify\n    description: "classify ssh-auth-expired as infra"\n    command: "pnpm test"\n    dependencies: []\n```';
+    mockSpawn.mockImplementationOnce(() => processWith(plan));
+    await actionHandler(surface, 'lobby_plan_for_execution')({
+      action: { type: 'button', value: key },
+      body: { channel: { id: 'C_LOBBY' }, message: { ts: 'msg', thread_ts: threadTs } },
+      ack: vi.fn().mockResolvedValue(undefined),
+      respond: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(5);
+    expect(commands).not.toContainEqual(expect.objectContaining({ type: 'start_plan' }));
+    expect(slackPlanDraftRepo.getReady('C_LOBBY', threadTs)).toBeDefined();
+  });
+
+  it('also stages a plan for "convert this to Invoker" — the mechanism is not tied to one exact phrase', async () => {
+    const threadTs = 'real-thread-2';
+    seedContext(slackSessionRepo, threadTs, workingDir);
+    const say = vi.fn().mockResolvedValue({ ts: 'msg' });
+
+    const path = intentSignalPath(workingDir, threadTs);
+    mockSpawn.mockImplementationOnce(() => processWith(
+      'Got it — that is the planning request. Confirm before I draft anything.',
+      () => writeFileSync(path, JSON.stringify({ wantsPlan: true }), 'utf8'),
+    ));
+    await handler(surface, 'app_mention')({
+      event: { text: '<@UBOT> convert this to Invoker', ts: 't1', thread_ts: threadTs, user: 'U_TEST', channel: 'C_LOBBY' },
+      say,
+    });
+
+    expect(buttonValue(say, 'lobby_plan_for_execution')).toBeTruthy();
+    const pending = slackSessionRepo.getPendingConfirmation(threadTs);
+    expect((pending!.payload as { requestText?: string }).requestText).toBe('convert this to Invoker');
+  });
+});

--- a/packages/surfaces/src/__tests__/thread-session-manager.test.ts
+++ b/packages/surfaces/src/__tests__/thread-session-manager.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SessionManager, SessionIdentifier, SessionHandle } from '../slack/thread-session-manager.js';
 import * as child_process from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 // ── Mock child_process.spawn ────────────────────────────────
 
@@ -370,5 +373,90 @@ describe('SessionManager', () => {
 
     // Sending a message after dispose should throw
     await expect(handle!.sendMessage('test')).rejects.toThrow('disposed');
+  });
+});
+
+// SessionHandle.lastTurnPlanIntentSignal / lastTurnDraftPlanText are pure
+// proxy getters onto the wrapped PlanConversation. Every other test in this
+// file either stops short of reading them or (elsewhere in the package)
+// exercises PlanConversation directly, bypassing SessionHandle/SessionManager
+// entirely. These prove the proxy through the real pooling path production
+// Slack traffic takes: getOrCreateSession -> sendMessage -> getter.
+describe('SessionHandle real-conversation proxy getters', () => {
+  let workingDir: string;
+  let manager: SessionManager;
+  let mockRepo: ReturnType<typeof createMockRepo>;
+
+  beforeEach(() => {
+    workingDir = mkdtempSync(join(tmpdir(), 'session-handle-proxy-'));
+    mockRepo = createMockRepo();
+    // No `mode` override: SessionManager defaults fresh sessions to 'agent'
+    // (thread-session-manager.ts:279,401), which is what gates
+    // lastTurnPlanIntentSignal open.
+    manager = new SessionManager({
+      cursorCommand: 'cursor',
+      workingDir,
+      conversationRepo: mockRepo as any,
+      evictionIntervalMs: 60_000,
+    });
+    manager.start();
+  });
+
+  afterEach(() => {
+    manager.stop();
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  function mockChildThatWrites(write: () => void, stdout: string): void {
+    mockSpawn.mockImplementationOnce(() => {
+      const { EventEmitter } = require('node:events');
+      const proc = new EventEmitter();
+      proc.stdout = new EventEmitter();
+      proc.stderr = new EventEmitter();
+      proc.kill = vi.fn();
+      setTimeout(() => {
+        write();
+        proc.stdout.emit('data', Buffer.from(stdout));
+        proc.emit('close', 0);
+      }, 0);
+      return proc;
+    });
+  }
+
+  it('proxies lastTurnPlanIntentSignal through a real getOrCreateSession -> sendMessage -> getter path', async () => {
+    const id = new SessionIdentifier('C123', 'thread-proxy-intent');
+    const handle = await manager.getOrCreateSession(id, 'U001');
+    expect(handle).not.toBeNull();
+
+    const signalDir = join(workingDir, '.invoker', 'plan-intent');
+    mkdirSync(signalDir, { recursive: true });
+    const signalPath = join(signalDir, 'thread-proxy-intent.json');
+    mockChildThatWrites(
+      () => writeFileSync(signalPath, JSON.stringify({ wantsPlan: true }), 'utf8'),
+      'sure, want me to draft one for that?',
+    );
+
+    await handle!.sendMessage('submit it');
+
+    expect(handle!.lastTurnPlanIntentSignal).toEqual({ wantsPlan: true, reason: undefined });
+  });
+
+  it('proxies lastTurnDraftPlanText through a real getOrCreateSession -> sendMessage -> getter path', async () => {
+    const id = new SessionIdentifier('C123', 'thread-proxy-draft');
+    const handle = await manager.getOrCreateSession(id, 'U001');
+    expect(handle).not.toBeNull();
+
+    const draftDir = join(workingDir, '.invoker', 'plan-drafts');
+    mkdirSync(draftDir, { recursive: true });
+    const draftPath = join(draftDir, 'thread-proxy-draft.yaml');
+    const plan = 'name: "Proxy Plan"\nonFinish: none\ntasks:\n  - id: t\n    description: "d"\n    command: "pnpm test"\n    dependencies: []\n';
+    mockChildThatWrites(
+      () => writeFileSync(draftPath, plan, 'utf8'),
+      'drafted the plan, see file',
+    );
+
+    await handle!.sendMessage('draft a plan');
+
+    expect(handle!.lastTurnDraftPlanText).toBe(plan.trim());
   });
 });

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -208,13 +208,17 @@ export const SLACK_LOCAL_REPRO_POLICY = `Execution boundary:
 - Never run anything that changes state outside your worktree: \`git push\`, \`gh pr create\`/\`edit\`/\`merge\`, \`gh\` label writes, \`mergify stack push\`, \`scripts/safe-stack-push.mjs\`, or \`scripts/land-stack.mjs --execute\`.
 - If the request needs any of those, stop and hand off: describe the change, post the plan, and ask the user to confirm. Do not perform it yourself and do not offer a manual workaround for it.`;
 
-function buildAgentSystemPrompt(): string {
+function buildAgentSystemPrompt(intentSignalFilePath?: string): string {
+  const planIntentGuidance = intentSignalFilePath
+    ? `- Do NOT generate or submit Invoker YAML yourself. If — and only if — the user's latest message is itself asking you to draft a plan, convert this work into an Invoker submission, or execute/submit what was just discussed, write \`{"wantsPlan": true}\` to \`${intentSignalFilePath}\` using your file-writing tool. The Slack host will then ask the user to confirm via Approve/No buttons. Do not write that file speculatively, or for a message that isn't itself a plan/execution ask — a false positive interrupts the conversation with an unwanted confirmation prompt.
+- If you are not confident the user wants a plan, do not write that file. Instead tell the user in your reply to type \`/plan <request>\` in this thread to start planning explicitly.`
+    : `- Do NOT generate or submit Invoker YAML yourself. If the user asks for a plan or to act on this work, tell them to type \`/plan <request>\` in this thread to start planning explicitly.`;
   return `You are a normal coding agent running in a git worktree for a Slack thread.
 
 Default behavior:
 - Treat the thread like an ordinary OMP/Codex coding session.
 - Answer questions, run local commands, inspect files, edit code, and run focused verification when useful.
-- Do NOT generate or submit Invoker YAML yourself. Slack routing promotes planning requests to a planning conversation automatically, where the user can submit the resulting draft in this same thread.
+${planIntentGuidance}
 - Keep Slack replies short and concrete: changed files, verification, and any remaining risk. Return only the final user-facing message; never include chain-of-thought, reasoning traces, tool output, or raw planner JSONL.
 - To share a generated file (screenshot, diagram, report), write it inside your worktree and link it by absolute path as a markdown link, e.g. \`[chart](/abs/path/in/worktree/chart.png)\`. Files linked that way are uploaded to the thread. Files written outside your worktree cannot be shared, so do not put artifacts in /tmp.
 
@@ -751,7 +755,7 @@ export class PlanConversation {
           preferStackedWorkflows: this.preferStackedWorkflows,
           planFilePath: this.planDraftFilePath() ?? undefined,
         })
-      : buildAgentSystemPrompt();
+      : buildAgentSystemPrompt(this.planIntentSignalFilePath() ?? undefined);
     const parts: string[] = [systemPrompt];
 
     if (this.messages.length > 1) {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -451,6 +451,14 @@ export class PlanConversation {
   private onRawPlannerOutput?: RawPlannerOutputHandler;
   private plannerRetryLimit: number;
   private plannerRetryBaseDelayMs: number;
+  // Serializes turns on this conversation. Without this, two concurrent
+  // sendMessage calls (e.g. two Slack events for the same thread arriving
+  // close together) can interleave their per-turn side-channel files
+  // (plan-drafts, plan-intent): one turn's resetPlanDraftFile/
+  // resetPlanIntentSignalFile can wipe a file the other turn already wrote
+  // but hasn't read back yet.
+  private turnInFlight = false;
+  private turnQueue: Array<() => void> = [];
   private _initialized = false;
   private _lastTurnReasoning: string[] = [];
   private _lastTurnDraftPlanText: string | null = null;
@@ -528,8 +536,28 @@ export class PlanConversation {
    * Send a user message to the planner and return its reply. Pure conversation:
    * drafting a plan never auto-submits it — submission is an explicit step
    * driven by the surface (the `submit` verb), so a stray "yes" can't ship a plan.
+   *
+   * Turns on this conversation are serialized: a call queued while another is
+   * in flight waits for it to fully finish (including reading back its own
+   * per-turn side-channel files) before starting.
    */
   async sendMessage(userMessage: string): Promise<string> {
+    if (this.turnInFlight) {
+      await new Promise<void>((resolve) => this.turnQueue.push(resolve));
+    }
+    this.turnInFlight = true;
+    // No `await` here on purpose: chaining via .finally() keeps this call's
+    // returned promise settling in lockstep with sendMessageLocked's own
+    // promise, with no added microtask tick before the planner subprocess is
+    // spawned — callers/tests that synchronize on "the process was spawned"
+    // via a single microtask wait stay correct.
+    return this.sendMessageLocked(userMessage).finally(() => {
+      this.turnInFlight = false;
+      this.turnQueue.shift()?.();
+    });
+  }
+
+  private async sendMessageLocked(userMessage: string): Promise<string> {
     const t0 = Date.now();
     const turn = this.messages.filter(m => m.role === 'user').length + 1;
     this.log('plan-conversation', 'info', `[TRACE] sendMessage() start (threadTs=${this.threadTs}, initialized=${this._initialized}, msgCount=${this.messages.length}, turn=${turn})`);

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -2541,8 +2541,34 @@ ${text}`;
       if (msg.channel && this.workflowChannelRepo?.getByChannelId(msg.channel)) return;
 
       const text = (msg.text ?? '').replace(/<@[A-Z0-9]+>/g, '').trim();
-      if (text && (await this.resolveConfirm(msg.thread_ts, text, say, channel))) return;
       if (!text) return;
+
+      // /plan is a deterministic command and takes priority, mirroring the
+      // @mention handler's ordering: it must run before resolveConfirm, or a
+      // pending unrelated confirmation's "not a yes/no" fallback swallows it
+      // (deletes the pending confirm and replies instead of ever reaching
+      // this branch).
+      if (/^\/plan\s*$/i.test(text) || /^\/plan\s+.+/i.test(text)) {
+        const context = this.loadPlanningContext(msg.thread_ts);
+        if (!context) {
+          await say({ text: 'This thread has no pinned repository context yet. @mention me first to start planning.', thread_ts: msg.thread_ts });
+          return;
+        }
+        if (/^\/plan\s*$/i.test(text)) {
+          await this.handleExplicitPlanAction(channel, msg.thread_ts, msg.user ?? 'unknown', say);
+          return;
+        }
+        await this.stagePlanIntentConfirm(msg.thread_ts, channel, {
+          kind: 'plan_intent',
+          requestText: text.replace(/^\/plan\s+/i, ''),
+          userId: msg.user ?? 'unknown',
+          context,
+          channel,
+        }, say);
+        return;
+      }
+
+      if (await this.resolveConfirm(msg.thread_ts, text, say, channel)) return;
 
       const rebind = await this.maybeRebindThreadRepo(channel, msg.thread_ts, msg.user, text, say);
       if (rebind.rebound || rebind.blocked) return;


### PR DESCRIPTION
## Summary

Adds a bounded seeded-random ("monkey") test pass over both surfaces that reuse the plan-intent core: the Slack bot and the in-app planning terminal.

The goal is to shake out anything the hand-written tests in this stack didn't think to ask, on top of already-correct behavior, not to prove any one specific claim.

Each test uses a small inline mulberry32 PRNG with a fixed seed, so runs stay reproducible in CI while still varying the input sequence.

## Review Claim

Approve two new randomized test files: one driving randomized Slack mention/command/button sequences, one driving randomized overlapping chat turns in the planning terminal, each checking invariants rather than exact transcripts.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Purely additive test files with no product code changes, so nothing outside the two new `__tests__` files can regress runtime behavior. Each test is bounded (fixed run/step counts) so it cannot hang or grow CI time unboundedly.

## Slice Rationale

Kept separate from the unit-coverage slice earlier in this stack because randomized tests need their own stability verification (multi-seed sanity pass) and are a distinct kind of proof from targeted unit tests.

## Non-goals

Does not change PlanConversation, Slack surface, or in-app-planner product code. Does not replace the targeted unit tests from the prior slice; it supplements them.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm test`
- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/in-app-planner-monkey.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e915617`
- Post-revert steps: None
- Data migration? No

</details>
