### PR TITLE
[Refactor-lane title tag](1a) State the refactor-lane title bracket rule in the review-compression skill

### DIFF
--- a/skills/review-compression/SKILL.md
+++ b/skills/review-compression/SKILL.md
@@ -287,14 +287,19 @@ including the two above.
 
 ### Rule: name the technique
 
-Every `refactor`-lane PR title or commit message states which single named
-technique it applies, in the form `<Technique>: <what moved/changed>` — for
-example `Move Method: git primitives -> repair_body.py`, `Extract Variable:
-queue-only guard`, `Replace Conditional with Polymorphism: RepairOutcome
-status dispatch`. The PR body's `## Review Claim` restates the same
-technique by name. A vague claim like "clean up the repair module" is not
-acceptable in a `refactor`-lane PR; name the technique or split further
-until one name covers the whole slice.
+Every `refactor`-lane PR title states which single named technique it
+applies, using this exact bracket format right after the stack slice index:
+    [Tag](N)[REFACTOR: <Technique>] <description>
+For example: `[Admin-Bypass Async Repair](2)[REFACTOR: Move Method] git
+working-tree primitives -> repair_body.py`. The bracket is required exactly when `## Review Lane` is `refactor`, and forbidden otherwise --
+`scripts/create-pr.mjs`'s `assertValidStackPrTitle` enforces this for
+stacked PRs by cross-referencing the title against the declared lane. The
+PR body's `## Review Claim` restates the same technique by name. A vague
+claim like "clean up the repair module" is not acceptable in a
+`refactor`-lane PR; name the technique or split further until one name
+covers the whole slice. This bracket format applies to the `refactor`
+lane only -- every other lane keeps the plain `[Tag](N) <description>`
+format.
 
 This is not decoration: naming the technique is what lets a reviewer bring
 the technique's own well-known safety properties to the review ("Extract


### PR DESCRIPTION
## Summary

The review-compression skill now spells out an exact title shape for refactor-lane stacked PRs. The technique bracket sits right after the stack slice index: `[Tag](N)[REFACTOR: <Technique>] <description>`.

Before this change, the rule asked for `<Technique>: <what changed>` with no bracket and no tie to the slice index.

The reworded paragraph also says the bracket belongs to the refactor lane alone; every other lane keeps the plain `[Tag](N) <description>` title.

A later stack will make `scripts/create-pr.mjs` enforce the bracket. This slice states the rule first so that enforcement can be reviewed against published guidance.

## Review Claim

Approve the reworded name-the-technique paragraph in the review-compression skill: a refactor-lane stacked PR title carries `[REFACTOR: <Technique>]` right after the slice index, and every other lane keeps the plain title shape.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Prose-only edit to one paragraph of `skills/review-compression/SKILL.md`. No script, test, or product code changes in this slice. The existing contract test `bash scripts/test-make-pr-skill.sh` passes unchanged on this slice, so nothing previously locked can regress.

## Slice Rationale

This stack could not ship as one PR: the repo's PR-unit checker keeps this skill file in a different unit than the make-pr skill and its test script, so the rule text lands here first and the mirrored guidance plus its test locks follow in (1b).

Stating the rule before enforcing it also keeps the later enforcement stacks reviewable against an already-published rule instead of a rule invented in the same diff.

## Non-goals

- No change to `skills/make-pr/SKILL.md` or `scripts/test-make-pr-skill.sh` in this slice; those land in (1b).
- No enforcement code: `scripts/create-pr.mjs` and `scripts/lint-pr-diff-atomicity.mjs` are untouched (they are workflows 2 and 3 of this chain).
- No change to the technique catalog, the prohibitions, or the grounding citation in the same section.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-make-pr-skill.sh`
- [x] `grep -qF "[Tag](N)[REFACTOR: <Technique>] <description>" skills/review-compression/SKILL.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated refactor-lane pull request title guidance to require an exact `[REFACTOR: <Technique>]` label after the stack slice index.
  * Documented title validation and alignment with the Review Claim section.
  * Clarified that other review lanes continue using the existing title format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->