### PR TITLE
[Refactor-lane title tag](1b) Mirror the bracket rule in the make-pr skill and add contract-test locks

### DIFF
--- a/scripts/test-make-pr-skill.sh
+++ b/scripts/test-make-pr-skill.sh
@@ -152,6 +152,12 @@ must_contain "$REVIEW_COMPRESSION_MD" "multiple distinct extractions from one fi
 # The new grain must NOT split the identical mechanical migration grouping.
 must_contain "$REVIEW_COMPRESSION_MD" "exact same mechanical migration across" "review-compression must keep grouping the same mechanical migration across files"
 
+# Refactor-lane PR titles carry the applied technique in a bracket.
+must_contain "$REVIEW_COMPRESSION_MD" "[Tag](N)[REFACTOR: <Technique>] <description>" "review-compression must document the refactor-lane title bracket format"
+must_contain "$REVIEW_COMPRESSION_MD" "required exactly when \`## Review Lane\` is \`refactor\`, and forbidden otherwise" "review-compression must state the bracket is required for refactor lane only"
+must_contain "$SKILL_MD" "### Refactor-lane title tag" "make-pr skill must document the refactor-lane title bracket subsection"
+must_contain "$SKILL_MD" "rejects a stacked refactor-lane title missing the bracket" "make-pr skill must state create-pr.mjs enforces the refactor title bracket"
+
 # Stale GitHub PR metadata after a branch update is a common landing failure.
 # The skill must both trigger on it and tell the author what to re-check.
 must_contain "$SKILL_MD" "whenever a branch/PR change means the GitHub PR" "make-pr skill must trigger when a branch change could stale GitHub PR metadata"

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -25,6 +25,17 @@ Order slices so a reviewer reads the evidence before the change it justifies (se
 - Keep each slice green for CI: write the proof to assert the current (buggy) behavior, or mark the unfixed expectation pending (`it.fails` / skip with a TODO); the fix slice then flips it to the corrected behavior.
 - Foundation (types, helpers, migrations, flags) precedes behavior; cleanup and docs come last.
 
+### Refactor-lane title tag
+
+A refactor-lane stacked PR title carries the applied technique in a
+bracket right after the slice index: `[Tag](N)[REFACTOR: <Technique>]
+<description>`, for example `[Admin-Bypass Async Repair](2)[REFACTOR:
+Move Method] git working-tree primitives -> repair_body.py`. See
+the review-compression skill file's Naming the Technique section for
+the technique catalog and the full rule. `node scripts/create-pr.mjs`
+rejects a stacked refactor-lane title missing the bracket, and rejects
+the bracket on any other lane.
+
 ## What this skill covers
 
 - PR title/body authoring for Invoker


### PR DESCRIPTION
## Summary

The make-pr skill now mirrors the refactor-lane title rule from (1a). A new "Refactor-lane title tag" subsection sits right after "Stack ordering" and shows the bracket shape: `[Tag](N)[REFACTOR: <Technique>] <description>`.

The subsection points at the review-compression skill for the technique catalog, and says `node scripts/create-pr.mjs` will turn away a bracket-less refactor-lane stacked title once enforcement lands.

Four new grep-based assertions in the make-pr test now lock the new lines in both skills, so dropping the bracket guidance from either skill breaks the test.

## Review Claim

Approve mirroring the refactor-lane bracket-title rule into the make-pr skill and locking the new lines in both skills with grep-based test assertions.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Additive only: one new subsection in `skills/make-pr/SKILL.md` and five new lines (one comment plus four `must_contain` assertions) in `scripts/test-make-pr-skill.sh`. No existing assertion or guidance line is edited, so nothing previously locked can regress. `bash scripts/test-make-pr-skill.sh` passed before and after this slice.

## Slice Rationale

This is the second half of slice (1): the repo's PR-unit checker keeps the review-compression skill in one unit and the make-pr skill plus its test in another, so the rule text landed in (1a) and the mirrored guidance with its test locks land here.

The new assertions cover both skills, so this slice must sit above (1a) to stay green.

## Non-goals

- No edits to `skills/review-compression/SKILL.md` here; its wording landed in (1a).
- No enforcement code: `scripts/create-pr.mjs` and `scripts/lint-pr-diff-atomicity.mjs` are untouched (they are workflows 2 and 3 of this chain).
- No changes to any existing assertion in `scripts/test-make-pr-skill.sh`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-make-pr-skill.sh`
- [x] `grep -qF "### Refactor-lane title tag" skills/make-pr/SKILL.md`
- [x] `grep -qF "rejects a stacked refactor-lane title missing the bracket" skills/make-pr/SKILL.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
