### PR TITLE
[PR-Body Squash Merge](1) Fix diff resolution for squash-merged stacked predecessors

### DIFF
--- a/scripts/fetch-pr-diff-metadata.sh
+++ b/scripts/fetch-pr-diff-metadata.sh
@@ -34,6 +34,30 @@ if [ -z "$merge_base" ]; then
   merge_base="$(git merge-base "origin/$BASE_REF" "$HEAD_SHA")"
 fi
 
+our_commits="$(git log --format=%H --reverse "$merge_base..$HEAD_SHA")"
+if [ -n "$our_commits" ]; then
+  cherry_marks="$(git cherry "origin/$BASE_REF" "$HEAD_SHA" "$merge_base")"
+  clean_split=1
+  landed_prefix_end=""
+  seen_new=0
+  for commit in $our_commits; do
+    mark="$(printf '%s\n' "$cherry_marks" | awk -v sha="$commit" '$2 == sha { print $1 }')"
+    if [ "$mark" = "-" ]; then
+      if [ "$seen_new" = "1" ]; then
+        clean_split=0
+        break
+      fi
+      landed_prefix_end="$commit"
+    elif [ "$mark" = "+" ]; then
+      seen_new=1
+    fi
+  done
+  if [ "$clean_split" = "1" ] && [ -n "$landed_prefix_end" ]; then
+    echo "Note: this branch's commits up to $landed_prefix_end already landed on origin/$BASE_REF via squash merge; using that commit as the diff base instead of the undershot merge-base ($merge_base)." >&2
+    merge_base="$landed_prefix_end"
+  fi
+fi
+
 if [ -n "$BASE_SHA" ] && [ "$merge_base" != "$BASE_SHA" ]; then
   echo "Note: event base.sha ($BASE_SHA) is not this PR's current merge-base; diffing against the live merge-base ($merge_base) instead." >&2
 fi


### PR DESCRIPTION
## Summary

When a stacked PR's predecessor lands by squash-merge, the predecessor's original commits never appear in master's history.

The PR-Body diff script resolved its base by merge-base alone, so those landed-but-rewritten commits leaked into the successor's changed-file list.

The successor's PR-Body check then judged files the predecessor already landed, failing PRs whose own diff was clean.

This teaches scripts/fetch-pr-diff-metadata.sh to detect landed-equivalent commits with git cherry and advance the diff base past them.

## Review Claim

Approve one inserted detection block: `git cherry` identifies predecessor commits already landed (squash-equivalent) on the base branch, and the diff base advances past exactly that landed prefix.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The new block only advances the base when `git cherry` marks a leading prefix of commits as landed-equivalent; when nothing is landed (the common case) the resolved base is byte-identical to today's, and the final `git diff` invocation is untouched.

## Slice Rationale

The behavior fix ships alone; its executable repro is the next slice in this stack so the defect/fix pair stays independently reviewable.

## Non-goals

No change to which checks consume the diff metadata, no change to merge-base deepen fallback behavior, and no change for non-stacked PRs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash -n scripts/fetch-pr-diff-metadata.sh`
- [ ] `bash scripts/repro/repro-pr-body-squash-merge-undershoot.sh` (lands in the next slice; run from that head)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
