### PR TITLE
[PR-Body Squash Merge](2) Add repro proving the squash-merge undershoot fix

### DIFF
--- a/scripts/fetch-pr-diff-metadata.sh
+++ b/scripts/fetch-pr-diff-metadata.sh
@@ -34,6 +34,30 @@ if [ -z "$merge_base" ]; then
   merge_base="$(git merge-base "origin/$BASE_REF" "$HEAD_SHA")"
 fi
 
+our_commits="$(git log --format=%H --reverse "$merge_base..$HEAD_SHA")"
+if [ -n "$our_commits" ]; then
+  cherry_marks="$(git cherry "origin/$BASE_REF" "$HEAD_SHA" "$merge_base")"
+  clean_split=1
+  landed_prefix_end=""
+  seen_new=0
+  for commit in $our_commits; do
+    mark="$(printf '%s\n' "$cherry_marks" | awk -v sha="$commit" '$2 == sha { print $1 }')"
+    if [ "$mark" = "-" ]; then
+      if [ "$seen_new" = "1" ]; then
+        clean_split=0
+        break
+      fi
+      landed_prefix_end="$commit"
+    elif [ "$mark" = "+" ]; then
+      seen_new=1
+    fi
+  done
+  if [ "$clean_split" = "1" ] && [ -n "$landed_prefix_end" ]; then
+    echo "Note: this branch's commits up to $landed_prefix_end already landed on origin/$BASE_REF via squash merge; using that commit as the diff base instead of the undershot merge-base ($merge_base)." >&2
+    merge_base="$landed_prefix_end"
+  fi
+fi
+
 if [ -n "$BASE_SHA" ] && [ "$merge_base" != "$BASE_SHA" ]; then
   echo "Note: event base.sha ($BASE_SHA) is not this PR's current merge-base; diffing against the live merge-base ($merge_base) instead." >&2
 fi

--- a/scripts/repro/repro-pr-body-squash-merge-undershoot.sh
+++ b/scripts/repro/repro-pr-body-squash-merge-undershoot.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Repro: this repo's Mergify queues always squash-merge (.mergify.yml). When a
+# stacked PR's predecessor lands that way, the squashed commit on the base
+# branch has a different SHA/parents than this PR branch's own copy of that
+# commit, so git ancestry breaks. scripts/fetch-pr-diff-metadata.sh's live
+# merge-base resolution (added to fix stale base.sha, see
+# repro-pr-body-stale-base-sha.sh) then walks past the predecessor all the way
+# back to the original stack fork point, and the predecessor's own
+# already-landed file leaks back into this PR's diff -- tripping the
+# "single review unit per PR" rule on a PR that is otherwise correctly
+# scoped. Confirmed live on
+# https://github.com/Neko-Catpital-Labs/Invoker/pull/5933.
+#
+# This builds a small local repo reproducing that shape: a predecessor commit
+# on a PR branch, squash-merged onto the base branch as a new, unrelated
+# commit, with a successor commit stacked on top of the PR branch's original
+# (non-squashed) predecessor commit. It then runs
+# scripts/fetch-pr-diff-metadata.sh -- the actual script pr-body.yml calls --
+# and asserts the predecessor's own file does not leak into the diff while
+# the successor's real change is still present.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-pr-body-squash-undershoot.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+git init -q --bare "$TMP/origin.git"
+WORK="$TMP/work"
+git clone -q "$TMP/origin.git" "$WORK"
+cd "$WORK"
+git config user.email test@example.com
+git config user.name Test
+echo base > README.md
+git add README.md
+git commit -q -m "base: initial"
+git push -q origin HEAD:refs/heads/master
+# The stack forks here.
+git checkout -q -b pr-branch
+echo "predecessor change" > predecessor.txt
+git add predecessor.txt
+git commit -q -m "predecessor: add predecessor.txt"
+PREDECESSOR_SHA="$(git rev-parse HEAD)"
+echo "successor change" > successor.txt
+git add successor.txt
+git commit -q -m "successor: add successor.txt"
+HEAD_SHA="$(git rev-parse HEAD)"
+git push -q origin HEAD:refs/heads/pr-branch
+# The predecessor lands on master via squash merge -- a brand new commit with
+# identical content but a different SHA and parents than pr-branch's own
+# predecessor commit, breaking git ancestry between pr-branch and master.
+git checkout -q master
+git cherry-pick --no-commit "$PREDECESSOR_SHA"
+git commit -q -m "predecessor: add predecessor.txt (#0000)"
+BASE_SHA="$(git rev-parse HEAD)"
+git push -q origin HEAD:refs/heads/master
+CI="$TMP/ci-checkout"
+git clone -q "$TMP/origin.git" "$CI"
+cd "$CI"
+git fetch -q origin "+refs/heads/pr-branch:refs/remotes/pull/999/head"
+export BASE_REF=master
+export BASE_SHA="$BASE_SHA"
+export HEAD_SHA="$HEAD_SHA"
+bash "$ROOT/scripts/fetch-pr-diff-metadata.sh"
+echo "[repro] changed-files.txt:"
+sed 's/^/  /' changed-files.txt
+if grep -qx "predecessor.txt" changed-files.txt; then
+  echo "[repro] FAILED: predecessor.txt (already landed on master via squash merge) leaked into the diff" >&2
+  exit 1
+fi
+if ! grep -qx "successor.txt" changed-files.txt; then
+  echo "[repro] FAILED: successor.txt (the PR's real change) is missing from the diff" >&2
+  exit 1
+fi
+echo "[repro] passed: diff excluded the squash-merged predecessor's own file and kept the successor's real change"


### PR DESCRIPTION
## Summary

This adds the executable repro for the squash-merge undershoot fixed in the previous slice.

It builds a disposable bare origin, squash-merges a stacked predecessor, then runs the real fetch script against the successor.

It exits non-zero if the predecessor's files ever leak back into the successor's changed-file list.

## Review Claim

Approve one new self-contained repro script proving the squash-merged-predecessor fix, with no production change.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The script only creates and removes its own temp directories; nothing outside `scripts/repro/` changes, so this slice cannot alter runtime behavior.

## Slice Rationale

Kept separate from the fix so the proof is reviewable as its own unit and re-runnable as a regression guard.

## Non-goals

No production source changes; no CI wiring changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-pr-body-squash-merge-undershoot.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
