### PR TITLE
[Refactor Title Tag](1) Enforce the refactor-lane technique-tag title bracket in create-pr.mjs

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -205,22 +205,40 @@ function parseArgs() {
 }
 
 const TRUNK_BRANCHES = new Set(['main', 'master', 'develop']);
-const STACK_PR_TITLE_PATTERN = /^\[[^\[\]\r\n]{3,80}\]\([1-9]\d*[a-z]?\)(?:\s+\S.*)?$/;
+const STACK_PR_TITLE_PATTERN = /^\[[^\[\]\r\n]{3,80}\]\([1-9]\d*[a-z]?\)(?:\[REFACTOR: [^\[\]\r\n]{2,80}\])?(?:\s+\S.*)?$/;
+const REFACTOR_TAG_PATTERN = /\[REFACTOR: [^\[\]\r\n]{2,80}\]/;
 
 function isStackedPrContext(baseBranch, mergifyState) {
   return mergifyState.managed || !TRUNK_BRANCHES.has(baseBranch);
 }
 
-function assertValidStackPrTitle(title) {
-  if (STACK_PR_TITLE_PATTERN.test(title.trim())) return;
-
-  throw new Error(
-    [
-      'Stack PR titles must start with a shared idea and exactly one slice index.',
-      'Use: [Graph Blanking](1) Preserve selected graph while loading',
-      'Use lettered replacements when one published slice must split: [Graph Blanking](3a) Split follow-up slice',
-    ].join('\n'),
-  );
+function assertValidStackPrTitle(title, reviewLane) {
+  const trimmed = title.trim();
+  if (!STACK_PR_TITLE_PATTERN.test(trimmed)) {
+    throw new Error(
+      [
+        'Stack PR titles must start with a shared idea and exactly one slice index.',
+        'Use: [Graph Blanking](1) Preserve selected graph while loading',
+        'Use lettered replacements when one published slice must split: [Graph Blanking](3a) Split follow-up slice',
+        'Refactor-lane PRs add a technique tag right after the slice index: [Graph Blanking](2)[REFACTOR: Move Method] git primitives -> repair_body.py',
+      ].join('\n'),
+    );
+  }
+  const hasRefactorTag = REFACTOR_TAG_PATTERN.test(trimmed);
+  if (reviewLane === 'refactor' && !hasRefactorTag) {
+    throw new Error(
+      [
+        'Review Lane is "refactor" but the title has no [REFACTOR: <Technique>] tag.',
+        'Name the technique from the catalog in the review-compression skill file\'s Naming the Technique section.',
+        'Example: [Graph Blanking](2)[REFACTOR: Move Method] git primitives -> repair_body.py',
+      ].join('\n'),
+    );
+  }
+  if (reviewLane !== 'refactor' && hasRefactorTag) {
+    throw new Error(
+      `Title has a [REFACTOR: ...] tag but Review Lane is "${reviewLane || '(missing)'}", not refactor. Either set Review Lane to refactor or drop the tag.`,
+    );
+  }
 }
 
 async function assertValidPrBody(body, options = {}) {
@@ -903,10 +921,11 @@ async function main() {
   if (mergifyState.managed && requestedUpdatePath) {
     assertPublishedMergifyBranch(currentBranch, mergifyState.trackedBaseRef);
   }
-  assertNoStackAtomicityBlockers(args.base, mergifyState, diffText, getReviewMetadata(body).reviewLane);
+  const reviewLane = getReviewMetadata(body).reviewLane;
+  assertNoStackAtomicityBlockers(args.base, mergifyState, diffText, reviewLane);
 
   if (isStackedPrContext(args.base, mergifyState)) {
-    assertValidStackPrTitle(args.title);
+    assertValidStackPrTitle(args.title, reviewLane);
   }
 
   if (!nwo) {

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -110,6 +110,35 @@ Keep app exposure separate from core runtime behavior.
 </details>
 `;
 
+const REFACTOR_BODY = `## Summary
+This branch moves one helper into its own module.
+## Review Claim
+Move the helper with no behavior change.
+## Review Lane
+- refactor
+## Review Unit
+- ownership-refactor
+## Safety Invariant
+Only this one helper moves; every call site is re-pointed in this same PR.
+## Slice Rationale
+One technique, one PR.
+## Non-goals
+- No behavior change.
+## Test Plan
+<details>
+<summary>Test Plan</summary>
+- [ ] \`node scripts/test-create-pr-stack-workflow.mjs\`
+</details>
+## Revert Plan
+<details>
+<summary>Revert Plan</summary>
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+</details>
+`;
+
 function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
@@ -692,6 +721,152 @@ function testMergifyManagedUpdateRejectsNestedTitle() {
   }
 }
 
+function testRefactorLaneTitleWithTagAccepted() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    const branch = 'stack/test-refactor-tag-accept';
+    createTrackedBranch(work, branch);
+    writeFileSync(join(work, 'pr-body-refactor.md'), REFACTOR_BODY);
+    commitFile(work, 'stack.txt', 'stack\n', 'stack update\n\nChange-Id: Irefactortag001');
+    gitQuiet(work, 'push', '-u', 'origin', branch);
+    setManagedBranchConfig(work, branch);
+
+    const result = runCreatePr(work, harness, [
+      '--title',
+      '[Test Stack](2)[REFACTOR: Move Method] move the helper',
+      '--base',
+      'master',
+      '--body-file',
+      'pr-body-refactor.md',
+      '--update-existing',
+    ], {
+      GH_API_PULLS_JSON: JSON.stringify([
+        {
+          number: 51,
+          html_url: 'https://example.com/pull/51',
+          head: { ref: branch, repo: { full_name: 'owner/repo' } },
+        },
+      ]),
+      GH_PATCH_RESPONSE: JSON.stringify({ html_url: 'https://example.com/pull/51' }),
+    });
+
+    assert(
+      result.status === 0,
+      `refactor lane with a [REFACTOR: ...] tag should be accepted\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    assert(
+      result.stdout.trim() === 'https://example.com/pull/51',
+      `refactor-tagged update should print the PR URL\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testRefactorLaneTitleWithoutTagRejected() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    const branch = 'stack/test-refactor-tag-missing';
+    createTrackedBranch(work, branch);
+    writeFileSync(join(work, 'pr-body-refactor.md'), REFACTOR_BODY);
+    commitFile(work, 'stack.txt', 'stack\n', 'stack update\n\nChange-Id: Irefactortag002');
+    gitQuiet(work, 'push', '-u', 'origin', branch);
+    setManagedBranchConfig(work, branch);
+
+    const result = runCreatePr(work, harness, [
+      '--title',
+      '[Test Stack](2) move the helper',
+      '--base',
+      'master',
+      '--body-file',
+      'pr-body-refactor.md',
+      '--update-existing',
+    ]);
+
+    assert(result.status === 1, `refactor lane without a [REFACTOR: ...] tag should be rejected\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert(result.stderr.includes('REFACTOR'), `missing refactor tag error should mention REFACTOR\nstderr:\n${result.stderr}`);
+    assert(result.stderr.includes('technique'), `missing refactor tag error should mention the technique catalog\nstderr:\n${result.stderr}`);
+    expectNoPush(harness, 'refactor lane missing tag rejection');
+    assert(readGhCalls(harness.ghLog).length === 0, 'refactor lane missing tag rejection should fail before GitHub calls');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testNonRefactorLaneTitleWithTagRejected() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    const branch = 'stack/test-refactor-tag-wrong-lane';
+    createTrackedBranch(work, branch);
+    commitFile(work, 'stack.txt', 'stack\n', 'stack update\n\nChange-Id: Irefactortag003');
+    gitQuiet(work, 'push', '-u', 'origin', branch);
+    setManagedBranchConfig(work, branch);
+
+    const result = runCreatePr(work, harness, [
+      '--title',
+      '[Test Stack](2)[REFACTOR: Move Method] move the helper',
+      '--base',
+      'master',
+      '--body-file',
+      'pr-body.md',
+      '--update-existing',
+    ]);
+
+    assert(result.status === 1, `non-refactor lane with a [REFACTOR: ...] tag should be rejected\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert(result.stderr.includes('not refactor'), `wrong-lane refactor tag error should say the lane is not refactor\nstderr:\n${result.stderr}`);
+    assert(result.stderr.includes('drop the tag'), `wrong-lane refactor tag error should suggest dropping the tag\nstderr:\n${result.stderr}`);
+    expectNoPush(harness, 'non-refactor lane tag rejection');
+    assert(readGhCalls(harness.ghLog).length === 0, 'non-refactor lane tag rejection should fail before GitHub calls');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testNonRefactorLanePlainTitleStillAccepted() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    const branch = 'stack/test-refactor-tag-plain';
+    createTrackedBranch(work, branch);
+    commitFile(work, 'stack.txt', 'stack\n', 'stack update\n\nChange-Id: Irefactortag004');
+    gitQuiet(work, 'push', '-u', 'origin', branch);
+    setManagedBranchConfig(work, branch);
+
+    const result = runCreatePr(work, harness, [
+      '--title',
+      '[Test Stack](2) move the helper',
+      '--base',
+      'master',
+      '--body-file',
+      'pr-body.md',
+      '--update-existing',
+    ], {
+      GH_API_PULLS_JSON: JSON.stringify([
+        {
+          number: 52,
+          html_url: 'https://example.com/pull/52',
+          head: { ref: branch, repo: { full_name: 'owner/repo' } },
+        },
+      ]),
+      GH_PATCH_RESPONSE: JSON.stringify({ html_url: 'https://example.com/pull/52' }),
+    });
+
+    assert(
+      result.status === 0,
+      `non-refactor lane with a plain title should stay accepted\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    assert(
+      result.stdout.trim() === 'https://example.com/pull/52',
+      `plain-title update should print the PR URL\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
 function testUnpublishedStackCommitsBlockUpdate() {
   const harness = createHarness();
   try {
@@ -1136,6 +1311,10 @@ const tests = [
   testMergifyManagedUpdateAcceptsLetteredTitle,
   testMergifyManagedUpdateRejectsPlainTitle,
   testMergifyManagedUpdateRejectsNestedTitle,
+  testRefactorLaneTitleWithTagAccepted,
+  testRefactorLaneTitleWithoutTagRejected,
+  testNonRefactorLaneTitleWithTagRejected,
+  testNonRefactorLanePlainTitleStillAccepted,
   testUnpublishedStackCommitsBlockUpdate,
   testCurrentBranchPrLookupFailure,
   testNonStackedUnrelatedAreasStayWarnings,


### PR DESCRIPTION
## Summary

The refactor lane's title convention (a technique tag right after the slice index) was documented earlier but never enforced.

Stacked PR creation already gates on title shape, so the gate now cross-checks the declared Review Lane.

A refactor-lane PR without the technique tag is turned away with a pointer to the technique catalog; any other lane carrying the tag is turned away too.

Titles for the other five lanes keep matching exactly as before.

## Review Claim

Approve extending the stack title pattern with an optional technique-tag group and giving the title check a second parameter (the declared Review Lane) so the tag is required exactly when the lane is refactor, never otherwise.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The added group is optional, so every title accepted today still matches; the new semantic check only fires when the declared lane is exactly refactor, and `node scripts/test-create-pr-stack-workflow.mjs` proves the pre-existing title cases pass unchanged alongside the four new lane cases.

## Slice Rationale

Title-format enforcement and diff-content enforcement are different review claims; the diff-side check is the next slice in this stack.

## Non-goals

No enforcement for non-stacked, direct-to-trunk PRs (today's scope is preserved). The tag content stays free text, not an enum.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-create-pr-stack-workflow.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
