### PR TITLE
[Refactor Title Tag](2) Flag refactor-lane diffs bundling multiple symbols

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -205,22 +205,40 @@ function parseArgs() {
 }
 
 const TRUNK_BRANCHES = new Set(['main', 'master', 'develop']);
-const STACK_PR_TITLE_PATTERN = /^\[[^\[\]\r\n]{3,80}\]\([1-9]\d*[a-z]?\)(?:\s+\S.*)?$/;
+const STACK_PR_TITLE_PATTERN = /^\[[^\[\]\r\n]{3,80}\]\([1-9]\d*[a-z]?\)(?:\[REFACTOR: [^\[\]\r\n]{2,80}\])?(?:\s+\S.*)?$/;
+const REFACTOR_TAG_PATTERN = /\[REFACTOR: [^\[\]\r\n]{2,80}\]/;
 
 function isStackedPrContext(baseBranch, mergifyState) {
   return mergifyState.managed || !TRUNK_BRANCHES.has(baseBranch);
 }
 
-function assertValidStackPrTitle(title) {
-  if (STACK_PR_TITLE_PATTERN.test(title.trim())) return;
-
-  throw new Error(
-    [
-      'Stack PR titles must start with a shared idea and exactly one slice index.',
-      'Use: [Graph Blanking](1) Preserve selected graph while loading',
-      'Use lettered replacements when one published slice must split: [Graph Blanking](3a) Split follow-up slice',
-    ].join('\n'),
-  );
+function assertValidStackPrTitle(title, reviewLane) {
+  const trimmed = title.trim();
+  if (!STACK_PR_TITLE_PATTERN.test(trimmed)) {
+    throw new Error(
+      [
+        'Stack PR titles must start with a shared idea and exactly one slice index.',
+        'Use: [Graph Blanking](1) Preserve selected graph while loading',
+        'Use lettered replacements when one published slice must split: [Graph Blanking](3a) Split follow-up slice',
+        'Refactor-lane PRs add a technique tag right after the slice index: [Graph Blanking](2)[REFACTOR: Move Method] git primitives -> repair_body.py',
+      ].join('\n'),
+    );
+  }
+  const hasRefactorTag = REFACTOR_TAG_PATTERN.test(trimmed);
+  if (reviewLane === 'refactor' && !hasRefactorTag) {
+    throw new Error(
+      [
+        'Review Lane is "refactor" but the title has no [REFACTOR: <Technique>] tag.',
+        'Name the technique from the catalog in the review-compression skill file\'s Naming the Technique section.',
+        'Example: [Graph Blanking](2)[REFACTOR: Move Method] git primitives -> repair_body.py',
+      ].join('\n'),
+    );
+  }
+  if (reviewLane !== 'refactor' && hasRefactorTag) {
+    throw new Error(
+      `Title has a [REFACTOR: ...] tag but Review Lane is "${reviewLane || '(missing)'}", not refactor. Either set Review Lane to refactor or drop the tag.`,
+    );
+  }
 }
 
 async function assertValidPrBody(body, options = {}) {
@@ -903,10 +921,11 @@ async function main() {
   if (mergifyState.managed && requestedUpdatePath) {
     assertPublishedMergifyBranch(currentBranch, mergifyState.trackedBaseRef);
   }
-  assertNoStackAtomicityBlockers(args.base, mergifyState, diffText, getReviewMetadata(body).reviewLane);
+  const reviewLane = getReviewMetadata(body).reviewLane;
+  assertNoStackAtomicityBlockers(args.base, mergifyState, diffText, reviewLane);
 
   if (isStackedPrContext(args.base, mergifyState)) {
-    assertValidStackPrTitle(args.title);
+    assertValidStackPrTitle(args.title, reviewLane);
   }
 
   if (!nwo) {

--- a/scripts/lint-pr-diff-atomicity.mjs
+++ b/scripts/lint-pr-diff-atomicity.mjs
@@ -47,6 +47,10 @@ const POLICY = {
     severity: 'warning',
     message: 'A refactor-lane PR adds a symbol with no reference anywhere else in the diff; confirm the extraction also re-pointed its call sites in this PR.',
   },
+  'refactor-multiple-symbols': {
+    severity: 'warning',
+    message: 'A refactor-lane PR touches more than one top-level symbol in this diff; confirm this is one cohesive move (see the dependency-cluster exception in the review-compression skill\'s Decomposition & Extraction Refactors section) or split into separate PRs.',
+  },
 };
 
 function stripPrefix(marker) {
@@ -299,7 +303,7 @@ function collectRefactorDeadSymbolCandidates(file) {
   return candidates;
 }
 
-function collectRefactorDeadSymbolFindings(files) {
+function collectRefactorFindings(files) {
   const candidates = files.flatMap((file) => collectRefactorDeadSymbolCandidates(file));
   if (candidates.length === 0) {
     return [];
@@ -310,6 +314,11 @@ function collectRefactorDeadSymbolFindings(files) {
     const occurrences = haystack.match(new RegExp(`\\b${candidate.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`, 'g'));
     if (!occurrences || occurrences.length <= 1) {
       findings.push(makeFinding('refactor-dead-symbol', candidate.path, candidate.line, candidate.source));
+    }
+  }
+  if (candidates.length > 1) {
+    for (const candidate of candidates) {
+      findings.push(makeFinding('refactor-multiple-symbols', candidate.path, candidate.line, candidate.source));
     }
   }
   return findings;
@@ -333,7 +342,7 @@ export function collectDiffAtomicityFindings(options = {}) {
   const findings = [];
 
   if (reviewLane === 'refactor') {
-    findings.push(...collectRefactorDeadSymbolFindings(files));
+    findings.push(...collectRefactorFindings(files));
   }
 
   const hasGenerated = files.some((file) => file.category === 'generated');

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -110,6 +110,35 @@ Keep app exposure separate from core runtime behavior.
 </details>
 `;
 
+const REFACTOR_BODY = `## Summary
+This branch moves one helper into its own module.
+## Review Claim
+Move the helper with no behavior change.
+## Review Lane
+- refactor
+## Review Unit
+- ownership-refactor
+## Safety Invariant
+Only this one helper moves; every call site is re-pointed in this same PR.
+## Slice Rationale
+One technique, one PR.
+## Non-goals
+- No behavior change.
+## Test Plan
+<details>
+<summary>Test Plan</summary>
+- [ ] \`node scripts/test-create-pr-stack-workflow.mjs\`
+</details>
+## Revert Plan
+<details>
+<summary>Revert Plan</summary>
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+</details>
+`;
+
 function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
@@ -692,6 +721,152 @@ function testMergifyManagedUpdateRejectsNestedTitle() {
   }
 }
 
+function testRefactorLaneTitleWithTagAccepted() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    const branch = 'stack/test-refactor-tag-accept';
+    createTrackedBranch(work, branch);
+    writeFileSync(join(work, 'pr-body-refactor.md'), REFACTOR_BODY);
+    commitFile(work, 'stack.txt', 'stack\n', 'stack update\n\nChange-Id: Irefactortag001');
+    gitQuiet(work, 'push', '-u', 'origin', branch);
+    setManagedBranchConfig(work, branch);
+
+    const result = runCreatePr(work, harness, [
+      '--title',
+      '[Test Stack](2)[REFACTOR: Move Method] move the helper',
+      '--base',
+      'master',
+      '--body-file',
+      'pr-body-refactor.md',
+      '--update-existing',
+    ], {
+      GH_API_PULLS_JSON: JSON.stringify([
+        {
+          number: 51,
+          html_url: 'https://example.com/pull/51',
+          head: { ref: branch, repo: { full_name: 'owner/repo' } },
+        },
+      ]),
+      GH_PATCH_RESPONSE: JSON.stringify({ html_url: 'https://example.com/pull/51' }),
+    });
+
+    assert(
+      result.status === 0,
+      `refactor lane with a [REFACTOR: ...] tag should be accepted\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    assert(
+      result.stdout.trim() === 'https://example.com/pull/51',
+      `refactor-tagged update should print the PR URL\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testRefactorLaneTitleWithoutTagRejected() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    const branch = 'stack/test-refactor-tag-missing';
+    createTrackedBranch(work, branch);
+    writeFileSync(join(work, 'pr-body-refactor.md'), REFACTOR_BODY);
+    commitFile(work, 'stack.txt', 'stack\n', 'stack update\n\nChange-Id: Irefactortag002');
+    gitQuiet(work, 'push', '-u', 'origin', branch);
+    setManagedBranchConfig(work, branch);
+
+    const result = runCreatePr(work, harness, [
+      '--title',
+      '[Test Stack](2) move the helper',
+      '--base',
+      'master',
+      '--body-file',
+      'pr-body-refactor.md',
+      '--update-existing',
+    ]);
+
+    assert(result.status === 1, `refactor lane without a [REFACTOR: ...] tag should be rejected\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert(result.stderr.includes('REFACTOR'), `missing refactor tag error should mention REFACTOR\nstderr:\n${result.stderr}`);
+    assert(result.stderr.includes('technique'), `missing refactor tag error should mention the technique catalog\nstderr:\n${result.stderr}`);
+    expectNoPush(harness, 'refactor lane missing tag rejection');
+    assert(readGhCalls(harness.ghLog).length === 0, 'refactor lane missing tag rejection should fail before GitHub calls');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testNonRefactorLaneTitleWithTagRejected() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    const branch = 'stack/test-refactor-tag-wrong-lane';
+    createTrackedBranch(work, branch);
+    commitFile(work, 'stack.txt', 'stack\n', 'stack update\n\nChange-Id: Irefactortag003');
+    gitQuiet(work, 'push', '-u', 'origin', branch);
+    setManagedBranchConfig(work, branch);
+
+    const result = runCreatePr(work, harness, [
+      '--title',
+      '[Test Stack](2)[REFACTOR: Move Method] move the helper',
+      '--base',
+      'master',
+      '--body-file',
+      'pr-body.md',
+      '--update-existing',
+    ]);
+
+    assert(result.status === 1, `non-refactor lane with a [REFACTOR: ...] tag should be rejected\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert(result.stderr.includes('not refactor'), `wrong-lane refactor tag error should say the lane is not refactor\nstderr:\n${result.stderr}`);
+    assert(result.stderr.includes('drop the tag'), `wrong-lane refactor tag error should suggest dropping the tag\nstderr:\n${result.stderr}`);
+    expectNoPush(harness, 'non-refactor lane tag rejection');
+    assert(readGhCalls(harness.ghLog).length === 0, 'non-refactor lane tag rejection should fail before GitHub calls');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testNonRefactorLanePlainTitleStillAccepted() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    const branch = 'stack/test-refactor-tag-plain';
+    createTrackedBranch(work, branch);
+    commitFile(work, 'stack.txt', 'stack\n', 'stack update\n\nChange-Id: Irefactortag004');
+    gitQuiet(work, 'push', '-u', 'origin', branch);
+    setManagedBranchConfig(work, branch);
+
+    const result = runCreatePr(work, harness, [
+      '--title',
+      '[Test Stack](2) move the helper',
+      '--base',
+      'master',
+      '--body-file',
+      'pr-body.md',
+      '--update-existing',
+    ], {
+      GH_API_PULLS_JSON: JSON.stringify([
+        {
+          number: 52,
+          html_url: 'https://example.com/pull/52',
+          head: { ref: branch, repo: { full_name: 'owner/repo' } },
+        },
+      ]),
+      GH_PATCH_RESPONSE: JSON.stringify({ html_url: 'https://example.com/pull/52' }),
+    });
+
+    assert(
+      result.status === 0,
+      `non-refactor lane with a plain title should stay accepted\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    assert(
+      result.stdout.trim() === 'https://example.com/pull/52',
+      `plain-title update should print the PR URL\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
 function testUnpublishedStackCommitsBlockUpdate() {
   const harness = createHarness();
   try {
@@ -1136,6 +1311,10 @@ const tests = [
   testMergifyManagedUpdateAcceptsLetteredTitle,
   testMergifyManagedUpdateRejectsPlainTitle,
   testMergifyManagedUpdateRejectsNestedTitle,
+  testRefactorLaneTitleWithTagAccepted,
+  testRefactorLaneTitleWithoutTagRejected,
+  testNonRefactorLaneTitleWithTagRejected,
+  testNonRefactorLanePlainTitleStillAccepted,
   testUnpublishedStackCommitsBlockUpdate,
   testCurrentBranchPrLookupFailure,
   testNonStackedUnrelatedAreasStayWarnings,

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -406,6 +406,31 @@ assert(
   'a .py extraction whose call site is re-pointed in the same diff should not warn',
 );
 
+const multipleSymbolsDiff = `diff --git a/scripts/repair_body.py b/scripts/repair_body.py
+--- a/scripts/repair_body.py
++++ b/scripts/repair_body.py
+@@ -0,0 +1,4 @@
++def helper_one(x):
++    return x
++
++def helper_two(y):
++    return y
+`;
+const multipleSymbolsBlockers = getPrAtomicityBlockers({ diffText: multipleSymbolsDiff, reviewLane: 'refactor' });
+assert(
+  multipleSymbolsBlockers.filter((warning) => warning.includes('refactor-multiple-symbols')).length === 2,
+  'a refactor-lane PR adding two unrelated top-level symbols should warn once per symbol',
+);
+const multipleSymbolsBehaviorLaneBlockers = getPrAtomicityBlockers({ diffText: multipleSymbolsDiff, reviewLane: 'behavior' });
+assert(
+  !multipleSymbolsBehaviorLaneBlockers.some((warning) => warning.includes('refactor-multiple-symbols')),
+  'the same multi-symbol diff outside refactor lane should not warn',
+);
+assert(
+  !reworkedExtractionBlockers.some((warning) => warning.includes('refactor-multiple-symbols')),
+  'a refactor-lane diff with exactly one top-level definition should not warn about multiple symbols',
+);
+
 const lightweightErrors = await validatePrBody(lightweight);
 assert(lightweightErrors.some((error) => error.includes('Unsupported section: ## Testing')), 'lightweight format should reject ## Testing');
 assert(lightweightErrors.some((error) => error.includes('Unsupported section: ## Notes')), 'lightweight format should reject ## Notes');


### PR DESCRIPTION
## Summary

A refactor-lane PR is supposed to carry exactly one named technique applied to one symbol.

The diff-atomicity lint already catches dead-symbol leftovers in refactor-lane diffs; it now also flags a diff that bundles several relocated symbols at once.

The finding points the author at carving the diff into one-symbol slices.

## Review Claim

Approve one additive branch in the existing refactor-lane diff check: when more than one relocated symbol appears in a single refactor-lane diff, emit a new finding naming them.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The new branch only adds a finding when the existing collector already sees more than one candidate symbol; single-symbol refactor diffs and every other lane produce byte-identical lint output, proven by the pre-existing cases in `node scripts/test-pr-body-validator.mjs` passing unchanged.

## Slice Rationale

Builds on the title-tag gate in the previous slice; title enforcement and diff-content enforcement stay separately revertable.

## Non-goals

No change to the dead-symbol finding, no change to any other lane's diff handling.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-pr-body-validator.mjs`
- [ ] `node scripts/test-pr-diff-atomicity.mjs`
- [ ] `node scripts/test-create-pr-stack-workflow.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
