### PR TITLE
[OAuth Infra Repair](2) Preserve the real cause when boot-reconcile force-fails orphans

### DIFF
--- a/packages/app/src/__tests__/reconcile-orphan-boot-reason.test.ts
+++ b/packages/app/src/__tests__/reconcile-orphan-boot-reason.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const mainSource = readFileSync(join(__dirname, '..', 'main.ts'), 'utf8');
+
+describe('boot-reconcile forced-stop reason in main.ts', () => {
+  it('passes OWNER_RESTART_REASON at both boot-reconcile call sites', () => {
+    const callSites = mainSource.match(/reconcileOrphanedInFlightTasksOnBoot\(\{[^}]*\}/g) ?? [];
+    expect(callSites).toHaveLength(2);
+    for (const callSite of callSites) {
+      expect(callSite).toContain('reason: OWNER_RESTART_REASON');
+    }
+  });
+
+  it('keeps the graceful-quit and headless-shutdown Application quit literals unchanged', () => {
+    const literalCount = (mainSource.match(/'Application quit'/g) ?? []).length;
+    expect(literalCount).toBe(4);
+  });
+});

--- a/packages/app/src/__tests__/reconcile-orphaned-running-tasks.test.ts
+++ b/packages/app/src/__tests__/reconcile-orphaned-running-tasks.test.ts
@@ -65,4 +65,29 @@ describe('reconcileOrphanedInFlightTasksOnBoot', () => {
     expect(String(appendTaskOutput.mock.calls[0]?.[1] ?? '')).toContain('Startup Orphan Diagnostic');
     expect(String(appendTaskOutput.mock.calls[0]?.[1] ?? '')).toContain('forcedStopReason=Application quit');
   });
+
+  it('preserves a recognizable infra failure line from the output tail as the coarse error', () => {
+    // Must stay byte-identical to the production SSH executor's failure text.
+    const OAUTH_EXPIRED_LINE = 'Failed to authenticate: OAuth session expired and could not be refreshed';
+    const running = makeTask('wf-1/slow-task', 'running');
+    const handleWorkerResponse = vi.fn();
+    const appendTaskOutput = vi.fn();
+    const getOutputTail = vi.fn(() => [{
+      data: `[SshExecutor] Running task payload...\n${OAUTH_EXPIRED_LINE}\n[SshExecutor] Recording task result and pushing branch on remote...`,
+    }]);
+
+    reconcileOrphanedInFlightTasksOnBoot({
+      orchestrator: {
+        getAllTasks: () => [running],
+        handleWorkerResponse,
+      },
+      persistence: { getOutputTail, appendTaskOutput },
+    });
+
+    expect(handleWorkerResponse).toHaveBeenCalledTimes(1);
+    expect(handleWorkerResponse).toHaveBeenCalledWith(expect.objectContaining({
+      outputs: { exitCode: 1, error: OAUTH_EXPIRED_LINE },
+    }));
+    expect(String(appendTaskOutput.mock.calls[0]?.[1] ?? '')).toContain('forcedStopReason=Application quit');
+  });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -201,6 +201,7 @@ import type { WorkflowMutationContext } from './persisted-workflow-mutation-coor
 import { LaunchDispatcher } from './launch-dispatcher.js';
 import {
   isTaskInFlightForForcedStop,
+  OWNER_RESTART_REASON,
   reconcileOrphanedInFlightTasksOnBoot,
 } from './reconcile-orphaned-running-tasks.js';
 import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.js';
@@ -1005,6 +1006,7 @@ function startHeadlessMode(): void {
         const orphaned = reconcileOrphanedInFlightTasksOnBoot({
           orchestrator,
           persistence,
+          reason: OWNER_RESTART_REASON,
         });
         if (orphaned.length > 0) {
           logger.info(
@@ -3003,6 +3005,7 @@ startMainProcessBootstrap({
           const orphaned = reconcileOrphanedInFlightTasksOnBoot({
             orchestrator,
             persistence,
+            reason: OWNER_RESTART_REASON,
           });
           if (orphaned.length > 0) {
             logger.info(

--- a/packages/app/src/reconcile-orphaned-running-tasks.ts
+++ b/packages/app/src/reconcile-orphaned-running-tasks.ts
@@ -1,4 +1,4 @@
-import { isCrashPreservedExecution, type TaskState } from '@invoker/workflow-core';
+import { FailureClassifier, isCrashPreservedExecution, type TaskState } from '@invoker/workflow-core';
 
 import {
   persistShutdownDiagnostic,
@@ -30,6 +30,28 @@ export type ReconcileOrphanedInFlightTasksOptions = {
   reason?: string;
 };
 
+export const OWNER_RESTART_REASON = 'Owner restart';
+
+function deriveOrphanReason(
+  taskId: string,
+  persistence: ShutdownDiagnosticDb | null | undefined,
+  fallbackReason: string,
+): string {
+  if (!persistence) return fallbackReason;
+  try {
+    const tail = persistence.getOutputTail(taskId).map((chunk) => chunk.data).join('');
+    const lines = tail.split('\n');
+    for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i]?.trim();
+      if (!line) continue;
+      if (FailureClassifier.classifyError(line) !== undefined) return line;
+    }
+  } catch {
+    return fallbackReason;
+  }
+  return fallbackReason;
+}
+
 /**
  * Fail durable in-flight tasks left behind when a previous owner died without
  * before-quit cleanup (SIGKILL / crash). Mirrors graceful Application quit.
@@ -50,13 +72,14 @@ export function reconcileOrphanedInFlightTasksOnBoot(
       });
     }
 
+    const effectiveReason = deriveOrphanReason(task.id, options.persistence, reason);
     options.orchestrator.handleWorkerResponse({
       requestId: `boot-orphan-${task.id}`,
       actionId: task.id,
       attemptId: task.execution.selectedAttemptId,
       executionGeneration: task.execution.generation ?? 0,
       status: 'failed',
-      outputs: { exitCode: 1, error: reason },
+      outputs: { exitCode: 1, error: effectiveReason },
     });
     failed.push(task);
   }

--- a/packages/execution-engine/src/__tests__/fixtures/pr-6976-oauth-session-expired.ts
+++ b/packages/execution-engine/src/__tests__/fixtures/pr-6976-oauth-session-expired.ts
@@ -1,0 +1,4 @@
+/** Failure text from PR #6976 repair tasks on remote_digital_ocean_3, 2026-08-01. */
+export const PR_6976_OAUTH_SESSION_EXPIRED_ERROR = `[SshExecutor] Running task payload...
+Failed to authenticate: OAuth session expired and could not be refreshed
+[SshExecutor] Recording task result and pushing branch on remote...`;

--- a/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
@@ -7,6 +7,7 @@ import type {
 } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
 
+import { PR_6976_OAUTH_SESSION_EXPIRED_ERROR } from './fixtures/pr-6976-oauth-session-expired.js';
 import {
   buildRepoMirrorRepairScript,
   createInfraRepairTick,
@@ -442,6 +443,86 @@ describe('infra-repair worker', () => {
     const retrySubmissions = h.submissions.filter((submission) => submission.channel === INFRA_REPAIR_RETRY_TASK_CHANNEL);
     expect(retrySubmissions).toHaveLength(2);
     expect(parseInfraRepairRetryTaskMutationArgs(retrySubmissions[1]?.args ?? [])).toEqual({ taskId: 'wf-1/task-2' });
+  });
+
+  it('records an OAuth-session-expired alert without queueing any follow-up mutation', async () => {
+    const h = makeHarness([
+      makeTask({
+        execution: {
+          error: PR_6976_OAUTH_SESSION_EXPIRED_ERROR,
+        },
+      }),
+    ]);
+
+    await h.tick(POLL_CTX);
+
+    expect(h.submit).not.toHaveBeenCalled();
+    expect(h.runRemoteProvisionRepairFn).not.toHaveBeenCalled();
+    expect(h.runRepoMirrorRepairFn).not.toHaveBeenCalled();
+    expect(workerActions(h.actions)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        workerKind: INFRA_REPAIR_WORKER_KIND,
+        actionType: 'repair-target',
+        subjectType: 'infra-target',
+        subjectId: 'remote-1',
+        status: 'failed',
+        payload: expect.objectContaining({
+          infraReason: 'ssh-oauth-session-expired',
+        }),
+      }),
+      expect.objectContaining({
+        workerKind: INFRA_REPAIR_WORKER_KIND,
+        actionType: 'repair-infra-failure',
+        taskId: 'wf-1/task-1',
+        status: 'completed',
+        payload: expect.objectContaining({
+          infraReason: 'ssh-oauth-session-expired',
+        }),
+      }),
+    ]));
+  });
+
+  it('does not record a second OAuth-session-expired alert within the cooldown window', async () => {
+    const h = makeHarness([
+      makeTask({
+        execution: {
+          error: PR_6976_OAUTH_SESSION_EXPIRED_ERROR,
+        },
+      }),
+    ]);
+
+    await h.tick(POLL_CTX);
+
+    const targetActionWrites = () => h.actions.get(
+      `${INFRA_REPAIR_WORKER_KIND}:target:remote-1:repair:ssh-oauth-session-expired`,
+    );
+    const firstAlert = targetActionWrites();
+    expect(firstAlert?.status).toBe('failed');
+
+    h.tasks.set('wf-1/task-2', makeTask({
+      id: 'wf-1/task-2',
+      execution: {
+        error: PR_6976_OAUTH_SESSION_EXPIRED_ERROR,
+        branch: 'feature/task-2',
+        workspacePath: '~/.invoker/worktrees/repo/task-2',
+      },
+      taskStateVersion: 8,
+    }));
+
+    await h.tick({ ...POLL_CTX, tickNumber: 2 });
+
+    expect(h.submit).not.toHaveBeenCalled();
+    expect(targetActionWrites()).toEqual(firstAlert);
+    expect(workerActions(h.actions)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        actionType: 'repair-infra-failure',
+        taskId: 'wf-1/task-2',
+        status: 'skipped',
+        payload: expect.objectContaining({
+          reason: 'alert-cooldown',
+        }),
+      }),
+    ]));
   });
 
   it('records a failed action and submits nothing when remote repair fails', async () => {

--- a/packages/execution-engine/src/__tests__/oauth-session-expired-infra-repair.e2e.test.ts
+++ b/packages/execution-engine/src/__tests__/oauth-session-expired-infra-repair.e2e.test.ts
@@ -1,0 +1,308 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store';
+import { Orchestrator, computeWorkflowRollup, type TaskState } from '@invoker/workflow-core';
+import type { TaskStateChanges } from '@invoker/workflow-core';
+import { PR_6976_OAUTH_SESSION_EXPIRED_ERROR } from './fixtures/pr-6976-oauth-session-expired.js';
+import {
+  createInfraRepairTick,
+  INFRA_REPAIR_WORKER_KIND,
+} from '../workers/infra-repair-worker.js';
+
+type WorkflowRecord = {
+  id: string;
+  name: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  repoUrl?: string;
+  onFinish?: 'none' | 'merge' | 'pull_request';
+  baseBranch?: string;
+  featureBranch?: string;
+  mergeMode?: 'manual' | 'automatic' | 'external_review';
+};
+
+type TaskEventRecord = {
+  eventType: string;
+  payload?: string;
+};
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Invoker E2E',
+      GIT_AUTHOR_EMAIL: 'invoker-e2e@example.invalid',
+      GIT_COMMITTER_NAME: 'Invoker E2E',
+      GIT_COMMITTER_EMAIL: 'invoker-e2e@example.invalid',
+    },
+  }).trim();
+}
+
+class MemoryPersistence {
+  workflows = new Map<string, WorkflowRecord>();
+  tasks = new Map<string, { workflowId: string; task: TaskState }>();
+  attempts = new Map<string, unknown[]>();
+  events = new Map<string, TaskEventRecord[]>();
+
+  saveWorkflow(workflow: WorkflowRecord): void {
+    const now = new Date().toISOString();
+    this.workflows.set(workflow.id, {
+      ...workflow,
+      status: 'pending',
+      createdAt: workflow.createdAt ?? now,
+      updatedAt: workflow.updatedAt ?? now,
+    });
+  }
+
+  updateWorkflow(workflowId: string, changes: Partial<WorkflowRecord>): void {
+    const workflow = this.workflows.get(workflowId);
+    if (workflow) this.workflows.set(workflowId, { ...workflow, ...changes });
+  }
+
+  saveTask(workflowId: string, task: TaskState): void {
+    this.tasks.set(task.id, { workflowId, task });
+  }
+
+  updateTask(taskId: string, changes: TaskStateChanges): void {
+    const entry = this.tasks.get(taskId);
+    if (!entry) return;
+    entry.task = {
+      ...entry.task,
+      ...(changes.status !== undefined ? { status: changes.status } : {}),
+      ...(changes.dependencies !== undefined ? { dependencies: changes.dependencies } : {}),
+      config: { ...entry.task.config, ...(changes.config ?? {}) },
+      execution: { ...entry.task.execution, ...(changes.execution ?? {}) },
+      taskStateVersion: (entry.task.taskStateVersion ?? 1) + 1,
+    } as TaskState;
+  }
+
+  loadTasks(workflowId: string): TaskState[] {
+    return [...this.tasks.values()]
+      .filter((entry) => entry.workflowId === workflowId)
+      .map((entry) => entry.task);
+  }
+
+  private withRollup(workflow: WorkflowRecord): WorkflowRecord {
+    const rollup = computeWorkflowRollup(this.loadTasks(workflow.id));
+    return { ...workflow, status: rollup.status };
+  }
+
+  listWorkflows(): WorkflowRecord[] {
+    return [...this.workflows.values()].map((workflow) => this.withRollup(workflow));
+  }
+
+  loadWorkflow(workflowId: string): WorkflowRecord | undefined {
+    const workflow = this.workflows.get(workflowId);
+    return workflow ? this.withRollup(workflow) : undefined;
+  }
+
+  logEvent(taskId: string, eventType: string, payload?: unknown): void {
+    const list = this.events.get(taskId) ?? [];
+    list.push({
+      eventType,
+      payload: payload === undefined ? undefined : JSON.stringify(payload),
+    });
+    this.events.set(taskId, list);
+  }
+
+  getEvents(taskId: string): TaskEventRecord[] {
+    return this.events.get(taskId) ?? [];
+  }
+
+  saveAttempt(attempt: { nodeId: string }): void {
+    const list = this.attempts.get(attempt.nodeId) ?? [];
+    list.push(attempt);
+    this.attempts.set(attempt.nodeId, list);
+  }
+
+  loadAttempts(nodeId: string): unknown[] {
+    return this.attempts.get(nodeId) ?? [];
+  }
+
+  loadAttempt(attemptId: string): unknown | undefined {
+    for (const attempts of this.attempts.values()) {
+      const found = attempts.find((attempt) => {
+        return typeof attempt === 'object' && attempt !== null && 'id' in attempt && attempt.id === attemptId;
+      });
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  updateAttempt(attemptId: string, changes: Record<string, unknown>): void {
+    for (const [nodeId, attempts] of this.attempts.entries()) {
+      const index = attempts.findIndex((attempt) => {
+        return typeof attempt === 'object' && attempt !== null && 'id' in attempt && attempt.id === attemptId;
+      });
+      if (index >= 0) {
+        attempts[index] = { ...(attempts[index] as Record<string, unknown>), ...changes };
+        this.attempts.set(nodeId, attempts);
+        return;
+      }
+    }
+  }
+}
+
+function makeDummyRepo(tempRoot: string): { seed: string; repoUrl: string } {
+  const bare = join(tempRoot, 'dummy-origin.git');
+  const seed = join(tempRoot, 'dummy-seed');
+  mkdirSync(seed, { recursive: true });
+  git(tempRoot, ['init', '--bare', bare]);
+  git(seed, ['init']);
+  git(seed, ['config', 'user.name', 'Invoker E2E']);
+  git(seed, ['config', 'user.email', 'invoker-e2e@example.invalid']);
+  writeFileSync(join(seed, 'README.md'), '# dummy repo\n', 'utf8');
+  git(seed, ['add', 'README.md']);
+  git(seed, ['commit', '-m', 'Initial dummy repo']);
+  git(seed, ['branch', '-M', 'main']);
+  git(seed, ['remote', 'add', 'origin', pathToFileURL(bare).href]);
+  git(seed, ['push', '-u', 'origin', 'main']);
+  git(bare, ['symbolic-ref', 'HEAD', 'refs/heads/main']);
+  return { seed, repoUrl: pathToFileURL(bare).href };
+}
+
+const logger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+  child() { return this; },
+};
+
+describe('oauth-session-expired infra repair with a dummy repo', () => {
+  const tempRoots: string[] = [];
+
+  afterEach(() => {
+    while (tempRoots.length > 0) {
+      const dir = tempRoots.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('records exactly one operator alert and no follow-up mutation for a persisted OAuth-expiry failure', async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'invoker-oauth-expiry-e2e-'));
+    tempRoots.push(tempRoot);
+
+    const dummy = makeDummyRepo(tempRoot);
+    const persistence = new MemoryPersistence();
+    const orchestrator = new Orchestrator({
+      persistence: persistence as any,
+      messageBus: { publish() {} },
+      maxConcurrency: 2,
+      availablePoolIds: ['ssh-pool'],
+    });
+
+    orchestrator.loadPlan({
+      name: 'Dummy repo OAuth-session-expired proof',
+      repoUrl: dummy.repoUrl,
+      onFinish: 'none',
+      baseBranch: 'main',
+      tasks: [{
+        id: 'expired-task',
+        description: 'SSH task that fails with an expired OAuth session',
+        command: 'pnpm test',
+        dependencies: [],
+        poolId: 'ssh-pool',
+      }],
+    });
+    orchestrator.startExecution();
+
+    const task = orchestrator.getAllTasks().find((candidate) => !candidate.config.isMergeNode);
+    expect(task).toBeDefined();
+    if (!task) return;
+    expect(task.config.runnerKind).toBe('ssh');
+
+    persistence.logEvent(task.id, 'task.executor.selected', {
+      runnerKind: 'ssh',
+      poolMemberId: 'remote-1',
+    });
+
+    orchestrator.handleWorkerResponse({
+      requestId: 'fail-expired-task',
+      actionId: task.id,
+      executionGeneration: task.execution.generation ?? 0,
+      status: 'failed',
+      outputs: {
+        exitCode: 1,
+        error: PR_6976_OAUTH_SESSION_EXPIRED_ERROR,
+      },
+    });
+
+    const failed = orchestrator.getTask(task.id);
+    expect(failed?.status).toBe('failed');
+    expect(failed?.execution.failureClass).toBe('ssh-oauth-session-expired');
+
+    const actions = new Map<string, WorkerActionRecord>();
+    const submit = vi.fn(() => 1);
+    const tick = createInfraRepairTick({
+      store: {
+        listWorkflows: () => persistence.listWorkflows(),
+        loadTasks: (workflowId: string) => persistence.loadTasks(workflowId),
+        getEvents: (taskId: string) => persistence.getEvents(taskId) as never,
+        getWorkerAction: (workerKind: string, externalKey: string) =>
+          actions.get(`${workerKind}:${externalKey}`),
+        upsertWorkerAction: (write: WorkerActionWrite) => {
+          const key = `${write.workerKind}:${write.externalKey}`;
+          const existing = actions.get(key);
+          const now = new Date().toISOString();
+          const saved: WorkerActionRecord = {
+            ...write,
+            id: existing?.id ?? write.id ?? key,
+            attemptCount: write.attemptCount ?? 0,
+            createdAt: existing?.createdAt ?? now,
+            updatedAt: write.updatedAt ?? now,
+          };
+          actions.set(key, saved);
+          return saved;
+        },
+      },
+      submitter: { submit },
+      logger,
+      ownerRepoRoot: dummy.seed,
+      ownerInvokerHome: join(tempRoot, '.invoker'),
+      remoteTargets: {
+        'remote-1': {
+          host: '203.0.113.10',
+          user: 'invoker',
+          sshKeyPath: join(tempRoot, 'key'),
+        },
+      },
+    });
+
+    await tick({
+      identity: { kind: INFRA_REPAIR_WORKER_KIND, instanceId: 'e2e' },
+      reason: 'poll',
+      tickNumber: 1,
+      signal: new AbortController().signal,
+    });
+
+    expect(submit).not.toHaveBeenCalled();
+
+    const recorded = [...actions.values()];
+    const targetActions = recorded.filter((action) => action.actionType === 'repair-target');
+    expect(targetActions).toHaveLength(1);
+    expect(targetActions[0]).toEqual(expect.objectContaining({
+      workerKind: INFRA_REPAIR_WORKER_KIND,
+      subjectType: 'infra-target',
+      subjectId: 'remote-1',
+      status: 'failed',
+      payload: expect.objectContaining({ infraReason: 'ssh-oauth-session-expired' }),
+    }));
+
+    const taskDecisions = recorded.filter((action) => action.actionType === 'repair-infra-failure');
+    expect(taskDecisions).toHaveLength(1);
+    expect(taskDecisions[0]).toEqual(expect.objectContaining({
+      taskId: task.id,
+      status: 'completed',
+      payload: expect.objectContaining({ infraReason: 'ssh-oauth-session-expired' }),
+    }));
+  });
+});

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -728,6 +728,54 @@ async function handleInvalidReferenceRecovery(
   );
 }
 
+async function handleOauthSessionExpiredRecovery(
+  options: InfraRepairWorkerPolicyOptions,
+  candidate: ValidatedGenericSshInfraCandidate,
+): Promise<void> {
+  const cooldownMs = options.repairCooldownMs ?? DEFAULT_INFRA_REPAIR_COOLDOWN_MS;
+  const existing = options.store.getWorkerAction?.(
+    INFRA_REPAIR_WORKER_KIND,
+    targetRepairExternalKey(candidate.targetId, candidate.reason),
+  );
+  const nowMs = options.now?.() ?? Date.now();
+  if (existing && isRecentTargetActionWithinCooldown(existing, nowMs, cooldownMs)) {
+    recordTaskDecision(
+      options,
+      candidate,
+      candidate.reason,
+      'skipped',
+      `An OAuth-session-expired alert already exists for pool member ${candidate.targetId}`,
+      {
+        targetId: candidate.targetId,
+        alertStatus: existing.status,
+      },
+      'alert-cooldown',
+    );
+    return;
+  }
+
+  recordTargetRepairAction(
+    options,
+    candidate.targetId,
+    candidate.reason,
+    'failed',
+    `OAuth session expired on ${candidate.targetId} and cannot be refreshed automatically: an operator must re-authenticate that host or switch it to a non-interactive credential mode`,
+    {},
+    true,
+  );
+  recordTaskDecision(
+    options,
+    candidate,
+    candidate.reason,
+    'completed',
+    `Recorded OAuth-session-expired alert for ${candidate.targetId}; this failure will not be acted on again until an operator refreshes credentials`,
+    {
+      targetId: candidate.targetId,
+    },
+    'oauth-session-expired-alert',
+  );
+}
+
 async function handleValidatedGenericSshInfraCandidate(
   options: InfraRepairWorkerPolicyOptions,
   candidate: ValidatedGenericSshInfraCandidate,
@@ -750,6 +798,10 @@ async function handleValidatedGenericSshInfraCandidate(
   }
   if (candidate.reason === 'ssh-repo-mirror-corrupt') {
     await handleRepoMirrorCorruptRecovery(options, candidate);
+    return;
+  }
+  if (candidate.reason === 'ssh-oauth-session-expired') {
+    await handleOauthSessionExpiredRecovery(options, candidate);
     return;
   }
   await handleInvalidReferenceRecovery(options, candidate);

--- a/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
+++ b/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { PR_6976_OAUTH_SESSION_EXPIRED_ERROR } from '../../../execution-engine/src/__tests__/fixtures/pr-6976-oauth-session-expired.js';
 import { FailureClassifier, SSH_INFRA_FAILURE_CLASSES } from '../failure-classifier.js';
 
 describe('FailureClassifier.classifyError', () => {
@@ -29,6 +30,11 @@ describe('FailureClassifier.classifyError', () => {
       + '[WARNING] Continuing with existing refs. Tasks may use stale commits.\n'
       + "ERROR: base ref 'master' not found and fallback 'origin/master' also missing\n",
     )).toBe('ssh-repo-mirror-corrupt');
+  });
+
+  it('classifies the OAuth-session-expired signature', () => {
+    expect(FailureClassifier.classifyError(PR_6976_OAUTH_SESSION_EXPIRED_ERROR))
+      .toBe('ssh-oauth-session-expired');
   });
 
   it('does not classify a bare "not a git repository" outside the bootstrap-clone phase', () => {

--- a/packages/workflow-graph/src/failure-classifier.ts
+++ b/packages/workflow-graph/src/failure-classifier.ts
@@ -19,6 +19,7 @@ export const SSH_INFRA_FAILURE_CLASSES: readonly SshInfraFailureClass[] = [
   'ssh-worktree-missing',
   'ssh-invalid-reference',
   'ssh-repo-mirror-corrupt',
+  'ssh-oauth-session-expired',
 ];
 
 export class FailureClassifier {
@@ -47,6 +48,9 @@ export class FailureClassifier {
       && errorText.includes('fatal: not a git repository (or any of the parent directories): .git')
     ) {
       return 'ssh-repo-mirror-corrupt';
+    }
+    if (errorText.includes('Failed to authenticate: OAuth session expired and could not be refreshed')) {
+      return 'ssh-oauth-session-expired';
     }
     return undefined;
   }

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -191,7 +191,8 @@ export type SshInfraFailureClass =
   | 'ssh-env-invalid-export'
   | 'ssh-worktree-missing'
   | 'ssh-invalid-reference'
-  | 'ssh-repo-mirror-corrupt';
+  | 'ssh-repo-mirror-corrupt'
+  | 'ssh-oauth-session-expired';
 
 export type FailureClass = 'liveness_stall' | SshInfraFailureClass;
 


### PR DESCRIPTION
## Summary

When the owner relaunches after a crash, boot-reconcile force-fails every in-flight task with a hard-coded "Application quit" reason.

That string overwrote the task's real error, hiding what actually went wrong across every machine at once.

Boot-reconcile now reads the task's captured output tail and preserves the real cause, labeling crash orphans "Owner restart" only when no cause is recoverable.

The graceful-quit path keeps today's label.

## Review Claim

Approve boot-reconcile carrying forward each orphaned task's recorded cause instead of stamping the hard-coded reason, with "Owner restart" only as the no-cause fallback.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The graceful shutdown path still writes today's exact reason string, and force-fail still transitions every orphan to failed — only the reason text changes, proven by the pre-existing reconcile cases passing unchanged.

## Slice Rationale

Builds on the infra class from the previous slice; requeue and quarantine decisions in later slices need the true cause preserved here.

## Non-goals

No change to which tasks boot-reconcile selects, and no retry behavior in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`

</details>

## Visual Proof

Captured with the repo's e2e Playwright harness (`packages/app/e2e/orphan-boot-reason.proof.spec.ts`): tasks orphaned as pending+launching by a dead owner, then the app relaunched against the same database — unpatched vs. patched builds, identical scenario.

Before (unpatched): the orphan whose output recorded a real OAuth failure still shows the hard-coded label.

![before: orphaned task shows Application quit](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-852f3c/orphan-before-application-quit.png)

After (patched): the same orphan shows its preserved cause from the output tail.

![after: orphaned task shows the preserved OAuth-session-expired cause](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-852f3c/orphan-after-oauth-cause.png)

After (patched), no recorded cause: the fallback label.

![after: orphan with no recorded cause shows Owner restart](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-852f3c/orphan-after-owner-restart.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
