### PR TITLE
Quarantine the SSH pool member when a task finalizes as OAuth-session-expired

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
@@ -472,6 +472,124 @@ describe('execution-pool member circuit breaker', () => {
     expect(getPendingSelection(runner, 'wf-1/task-a').member.id).toBe('remote-b');
   });
 
+  it('takes a member out of rotation when a task finalizes as ssh-oauth-session-expired and routes the next task to a healthy member', async () => {
+    const failingTask = makeTask('wf-1/task-a');
+    const tasks = new Map([[failingTask.id, failingTask]]);
+    const completeByTaskId = new Map<string, (response: any) => void>();
+    const sshExecutor = {
+      type: 'ssh',
+      start: vi.fn(async (request: any) => ({
+        executionId: `exec-${request.actionId}`,
+        taskId: request.actionId,
+        workspacePath: `/remote/${request.actionId}`,
+      })),
+      onComplete: vi.fn((handle: any, cb: any) => {
+        completeByTaskId.set(handle.taskId, cb);
+      }),
+      onOutput: vi.fn(),
+      onHeartbeat: vi.fn(),
+      kill: vi.fn(),
+      destroyAll: vi.fn(),
+    };
+    const runner = makeRunner({
+      members: [
+        { id: 'remote-a', type: 'ssh', maxConcurrentTasks: 1 },
+        { id: 'remote-b', type: 'ssh', maxConcurrentTasks: 1 },
+      ],
+      sshExecutor,
+      orchestrator: {
+        getTask: (id: string) => tasks.get(id) ?? null,
+        getAllTasks: () => [...tasks.values()],
+        markTaskRunningAfterLaunch: () => true,
+        handleWorkerResponse: () => [],
+        deferTask: vi.fn(),
+      },
+      persistence: {
+        logEvent: vi.fn(),
+        updateTask: vi.fn(),
+        updateAttempt: vi.fn(),
+        appendTaskOutput: vi.fn(),
+      },
+    });
+
+    const run = runner.executeTask(failingTask);
+    await vi.waitFor(() => expect(completeByTaskId.has(failingTask.id)).toBe(true));
+
+    failingTask.execution = { ...failingTask.execution, failureClass: 'ssh-oauth-session-expired' };
+    completeByTaskId.get(failingTask.id)?.({
+      requestId: `fail-${failingTask.id}`,
+      actionId: failingTask.id,
+      attemptId: failingTask.execution.selectedAttemptId,
+      status: 'failed',
+      outputs: { exitCode: 1, error: 'Failed to authenticate: OAuth session expired and could not be refreshed' },
+    });
+    await run;
+
+    expect(runner.getPoolMemberHealthSnapshot().map((h) => h.memberKey)).toContain('ssh:remote-a');
+    const nextTask = makeTask('wf-2/task-b');
+    runner.selectExecutor(nextTask);
+    expect(getPendingSelection(runner, nextTask.id).member.id).toBe('remote-b');
+  });
+
+  it('does not quarantine the member when a task finalizes failed with a different or missing failure class', async () => {
+    const failingTask = makeTask('wf-1/task-a');
+    const tasks = new Map([[failingTask.id, failingTask]]);
+    const completeByTaskId = new Map<string, (response: any) => void>();
+    const sshExecutor = {
+      type: 'ssh',
+      start: vi.fn(async (request: any) => ({
+        executionId: `exec-${request.actionId}`,
+        taskId: request.actionId,
+        workspacePath: `/remote/${request.actionId}`,
+      })),
+      onComplete: vi.fn((handle: any, cb: any) => {
+        completeByTaskId.set(handle.taskId, cb);
+      }),
+      onOutput: vi.fn(),
+      onHeartbeat: vi.fn(),
+      kill: vi.fn(),
+      destroyAll: vi.fn(),
+    };
+    const runner = makeRunner({
+      members: [
+        { id: 'remote-a', type: 'ssh', maxConcurrentTasks: 1 },
+        { id: 'remote-b', type: 'ssh', maxConcurrentTasks: 1 },
+      ],
+      sshExecutor,
+      orchestrator: {
+        getTask: (id: string) => tasks.get(id) ?? null,
+        getAllTasks: () => [...tasks.values()],
+        markTaskRunningAfterLaunch: () => true,
+        handleWorkerResponse: () => [],
+        deferTask: vi.fn(),
+      },
+      persistence: {
+        logEvent: vi.fn(),
+        updateTask: vi.fn(),
+        updateAttempt: vi.fn(),
+        appendTaskOutput: vi.fn(),
+      },
+    });
+
+    const run = runner.executeTask(failingTask);
+    await vi.waitFor(() => expect(completeByTaskId.has(failingTask.id)).toBe(true));
+
+    failingTask.execution = { ...failingTask.execution, failureClass: 'ssh-worktree-missing' };
+    completeByTaskId.get(failingTask.id)?.({
+      requestId: `fail-${failingTask.id}`,
+      actionId: failingTask.id,
+      attemptId: failingTask.execution.selectedAttemptId,
+      status: 'failed',
+      outputs: { exitCode: 1, error: 'SSH remote script failed (exit=1, phase=run_task)' },
+    });
+    await run;
+
+    expect(runner.getPoolMemberHealthSnapshot()).toHaveLength(0);
+    const nextTask = makeTask('wf-2/task-b');
+    runner.selectExecutor(nextTask);
+    expect(getPendingSelection(runner, nextTask.id).member.id).toBe('remote-a');
+  });
+
   it('re-admits a member automatically once its cooldown expires', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-07-09T00:00:00Z'));

--- a/packages/execution-engine/src/task-runner-finalize.ts
+++ b/packages/execution-engine/src/task-runner-finalize.ts
@@ -98,6 +98,20 @@ export function wireCompletion(
             return;
           }
 
+          if (normalizedResponse.status === 'failed' && activeExecution?.poolMemberKey) {
+            try {
+              const finalized = host.orchestrator.getTask(task.id);
+              if (finalized?.execution.failureClass === 'ssh-oauth-session-expired') {
+                host.recordPoolMemberTransportFailure(
+                  activeExecution.poolMemberKey,
+                  new Error(normalizedResponse.outputs.error ?? 'ssh-oauth-session-expired'),
+                );
+              }
+            } catch (err) {
+              host.logger.error(`[TaskRunner] oauth-expiry pool member quarantine failed for task=${task.id}`, { err });
+            }
+          }
+
           try {
             host.callbacks.onComplete?.(task.id, normalizedResponse);
           } catch (err) {


### PR DESCRIPTION
## Summary

A task finalizing with the ssh-oauth-session-expired failure class now takes its pool member out of rotation, the same circuit-breaker path already used for transport failures.

The next task routes to a healthy member instead of landing on the same broken host and failing again for the same reason.

## Review Claim

Approve `task-runner-finalize.ts` calling the existing pool-member circuit breaker when a finalized task's failure class is ssh-oauth-session-expired, and leaving every other failure class untouched.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the `ssh-oauth-session-expired` class triggers quarantine; every other failure class (including other SSH infra classes) keeps its current pool-member health handling unchanged, proven by a case with a different failure class asserting zero health-snapshot entries. The quarantine call is wrapped in try/catch so a failure recording the quarantine cannot block the task's normal completion callback.

## Slice Rationale

Standalone: this is pool-member health/rotation, decided entirely at task finalization from the already-classified failureClass. It does not depend on how (or whether) the failure gets retried, so it lands independent of any requeue-worker behavior.

## Non-goals

Does not change requeue eligibility for any failure class. Does not change the infra-repair worker's existing alert-only handling of ssh-oauth-session-expired.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/ssh-pool-member-capacity.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8eb9a46ae`
- Post-revert steps: None
- Data migration? No

</details>
