### PR TITLE
[Fail Loud Agent Resolution](1) Raise on unresolvable execution agent instead of substituting claude

### DIFF
--- a/packages/execution-engine/src/__tests__/agent-executor-matrix.test.ts
+++ b/packages/execution-engine/src/__tests__/agent-executor-matrix.test.ts
@@ -14,6 +14,8 @@ import { randomUUID } from 'node:crypto';
 import type { WorkRequest } from '@invoker/contracts';
 import type { ExecutionAgent, AgentCommandSpec } from '../agent.js';
 import { AgentRegistry } from '../agent-registry.js';
+import { BaseExecutor, type BaseEntry } from '../base-executor.js';
+import type { ExecutorHandle, TerminalSpec } from '../executor.js';
 import { ClaudeExecutionAgent } from '../agents/claude-execution-agent.js';
 import { CodexExecutionAgent } from '../agents/codex-execution-agent.js';
 
@@ -58,6 +60,36 @@ function makeCommandRequest(command = 'echo hello'): WorkRequest {
     callbackUrl: '',
     timestamps: {},
   } as unknown as WorkRequest;
+}
+
+function makeAiTaskRequest(inputs: Record<string, unknown>): WorkRequest {
+  return {
+    requestId: randomUUID(),
+    actionId: randomUUID(),
+    taskId: `task-${randomUUID().slice(0, 8)}`,
+    actionType: 'ai_task',
+    inputs,
+    upstreamContext: [],
+    callbackUrl: '',
+    timestamps: {},
+  } as unknown as WorkRequest;
+}
+
+class CommandProbeExecutor extends BaseExecutor<BaseEntry> {
+  readonly type = 'command-probe';
+
+  async start(_request: WorkRequest): Promise<ExecutorHandle> {
+    throw new Error('Not implemented');
+  }
+  async kill(_handle: ExecutorHandle): Promise<void> {}
+  sendInput(_handle: ExecutorHandle, _input: string): void {}
+  getTerminalSpec(_handle: ExecutorHandle): TerminalSpec | null { return null; }
+  getRestoredTerminalSpec(): TerminalSpec { throw new Error('Not implemented'); }
+  async destroyAll(): Promise<void> { this.entries.clear(); }
+
+  build(request: WorkRequest, opts?: { claudeCommand?: string; agentRegistry?: AgentRegistry }) {
+    return this.buildCommandAndArgs(request, opts);
+  }
 }
 
 // ── Agent definitions for the matrix ─────────────────────────
@@ -268,6 +300,31 @@ describe('Agent × Executor matrix', () => {
       // We have at least one 'ignore' and one 'pipe'
       expect(modes).toContain('ignore');
       expect(modes).toContain('pipe');
+    });
+  });
+
+  describe('buildCommandAndArgs unresolvable agent', () => {
+    it('raises naming an explicitly requested agent when no agent registry is supplied', () => {
+      const executor = new CommandProbeExecutor();
+      const req = makeAiTaskRequest({ prompt: 'Do something', executionAgent: 'codex' });
+      expect(() => executor.build(req)).toThrow(/requested execution agent "codex"/);
+    });
+
+    it('still falls back to the claude session when no agent was requested at all', () => {
+      const executor = new CommandProbeExecutor();
+      const req = makeAiTaskRequest({ prompt: 'Do something' });
+      const result = executor.build(req, { claudeCommand: 'my-claude' });
+      expect(result.cmd).toBe('my-claude');
+      expect(result.agentSessionId).toBeDefined();
+    });
+
+    it('resolves an explicitly requested agent through a supplied registry', () => {
+      const executor = new CommandProbeExecutor();
+      const registry = new AgentRegistry();
+      registry.registerExecution(new CodexExecutionAgent({ command: 'codex-test' }));
+      const req = makeAiTaskRequest({ prompt: 'Do something', executionAgent: 'codex' });
+      const result = executor.build(req, { agentRegistry: registry });
+      expect(result.cmd).toBe('codex-test');
     });
   });
 });

--- a/packages/execution-engine/src/__tests__/conflict-resolver.test.ts
+++ b/packages/execution-engine/src/__tests__/conflict-resolver.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { buildFixPrompt, resolveConflictImpl, fixWithAgentImpl, spawnRemoteAgentFixImpl, remoteAgentShellInvocation } from '../conflict-resolver.js';
+import { buildFixPrompt, buildRemoteAgentCommand, resolveConflictImpl, fixWithAgentImpl, spawnRemoteAgentFixImpl, remoteAgentShellInvocation } from '../conflict-resolver.js';
 import type { ConflictResolverHost } from '../conflict-resolver.js';
 import type { Orchestrator } from '@invoker/workflow-core';
 import { registerBuiltinAgents } from '../agents/index.js';
@@ -460,6 +460,28 @@ describe('agent dispatch — codex vs claude', () => {
         },
       });
     });
+  });
+});
+
+describe('buildRemoteAgentCommand unresolvable agent', () => {
+  it('raises naming the requested agent when no agent registry is available', () => {
+    expect(() => buildRemoteAgentCommand('fix it', undefined, 'codex')).toThrow(
+      /requested execution agent "codex"/,
+    );
+  });
+
+  it('raises naming the requested agent when the registry lacks that name', () => {
+    const registry = registerBuiltinAgents();
+    expect(() => buildRemoteAgentCommand('fix it', registry, 'no-such-agent')).toThrow(
+      /requested execution agent "no-such-agent"/,
+    );
+  });
+
+  it('still builds the command when the registry resolves the requested agent', () => {
+    const registry = registerBuiltinAgents();
+    const { shellCommand, sessionId } = buildRemoteAgentCommand('fix it', registry, 'codex');
+    expect(shellCommand).toContain('codex');
+    expect(sessionId).toBeTruthy();
   });
 });
 

--- a/packages/execution-engine/src/__tests__/remote-fix-process-output.test.ts
+++ b/packages/execution-engine/src/__tests__/remote-fix-process-output.test.ts
@@ -42,6 +42,13 @@ function mockSpawnChildWithStderr(stdoutData: string, stderrData: string, exitCo
   return child;
 }
 
+function makeDriverlessRegistry(name: string): AgentRegistry {
+  return {
+    get: () => ({ name, buildFixCommand: (p: string) => ({ cmd: name, args: ['-p', p] }) }),
+    getSessionDriver: () => undefined,
+  } as unknown as AgentRegistry;
+}
+
 describe('spawnRemoteAgentFixImpl processOutput', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -60,6 +67,7 @@ describe('spawnRemoteAgentFixImpl processOutput', () => {
         '/home/user/worktree',
         { host: '1.2.3.4', user: 'invoker', sshKeyPath: '/tmp/key' },
         'claude',
+        makeDriverlessRegistry('claude'),
       );
 
       const script = child.stdin.write.mock.calls[0][0] as string;
@@ -106,6 +114,7 @@ describe('spawnRemoteAgentFixImpl processOutput', () => {
           secretsFile,
         },
         'claude',
+        makeDriverlessRegistry('claude'),
       );
 
       const script = child.stdin.write.mock.calls[0][0] as string;
@@ -196,6 +205,8 @@ describe('spawnRemoteAgentFixImpl processOutput', () => {
       'fix the bug',
       '/home/user/worktree',
       { host: '1.2.3.4', user: 'invoker', sshKeyPath: '/tmp/key' },
+      'codex',
+      makeDriverlessRegistry('codex'),
     ).catch((e) => e as Error);
 
     expect(err).toBeInstanceOf(Error);
@@ -237,16 +248,18 @@ describe('spawnRemoteAgentFixImpl processOutput', () => {
     expect(result.sessionId).toBe('local-uuid-abc');
   });
 
-  it('skips processOutput when no registry is provided', async () => {
+  it('skips processOutput when the registry has no session driver', async () => {
     const { spawn } = await import('node:child_process');
 
     vi.mocked(spawn).mockReturnValueOnce(mockSpawnChild('output', 0) as any);
 
-    // No registry → no driver → no processOutput call
+    // No driver → no processOutput call
     const result = await spawnRemoteAgentFixImpl(
       'fix the bug',
       '/home/user/worktree',
       { host: '1.2.3.4', user: 'invoker', sshKeyPath: '/tmp/key' },
+      'claude',
+      makeDriverlessRegistry('claude'),
     );
 
     // Should still resolve with a UUID session ID

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -100,6 +100,21 @@ describe('SshExecutor pre-flight validation', () => {
     );
   });
 
+  it('raises naming the requested agent for ai_task when no agent registry is configured', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'root',
+      sshKeyPath: '/dev/null',
+    });
+    const req = makeRequest({
+      actionType: 'ai_task',
+      inputs: { prompt: 'do the task', description: 'test', executionAgent: 'codex' },
+    });
+    await expect(ssh.start(req)).rejects.toThrow(
+      /requested execution agent "codex"/,
+    );
+  });
+
   it('does not throw for reconciliation requests', async () => {
     const ssh = new SshExecutor({
       host: 'localhost',

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -1137,7 +1137,12 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
         const spec = agent.buildCommand(fullPrompt, { executionModel: request.inputs.executionModel });
         return { cmd: spec.cmd, args: spec.args, agentSessionId: spec.sessionId, fullPrompt: spec.fullPrompt };
       }
-      // Fallback: use prepareClaudeSession when no agent registry is available
+      const requestedAgent = request.inputs.executionAgent;
+      if (requestedAgent) {
+        throw new Error(
+          `Cannot resolve requested execution agent "${requestedAgent}": no configured agent set was supplied`,
+        );
+      }
       const claudeCommand = opts?.claudeCommand ?? 'claude';
       const session = this.prepareClaudeSession(request);
       return { cmd: claudeCommand, args: session.cliArgs, agentSessionId: session.sessionId, fullPrompt: session.fullPrompt };

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -283,31 +283,32 @@ export function remoteAgentShellInvocation(): string[] {
 }
 
 /**
- * Build the shell command to run an agent on a remote host.
- * Uses the agent registry when available; falls back to claude CLI.
+ * Build the shell command to run an agent on a remote host via the agent
+ * registry. Throws when the registry is missing or cannot resolve the
+ * requested agent, instead of substituting a different one.
  */
-function buildRemoteAgentCommand(
+export function buildRemoteAgentCommand(
   prompt: string,
   agentRegistry?: AgentRegistry,
   agentName?: string,
   executionModel?: string,
 ): { shellCommand: string; sessionId: string } {
   const name = agentName ?? DEFAULT_EXECUTION_AGENT;
-  if (agentRegistry) {
-    const agent = agentRegistry.get(name);
-    if (agent?.buildFixCommand) {
-      const spec = agent.buildFixCommand(prompt, { executionModel });
-      const sessionId = spec.sessionId ?? randomUUID();
-      const cmd = `${spec.cmd} ${spec.args.map(a => shellQuote(a)).join(' ')}`;
-      return { shellCommand: cmd, sessionId };
-    }
+  if (!agentRegistry) {
+    throw new Error(
+      `Cannot build remote command for requested execution agent "${name}": no configured agent set was available to resolve it`,
+    );
   }
-  // Fallback: claude-compatible CLI (for backwards compat without registry)
-  const sessionId = randomUUID();
-  return {
-    shellCommand: `claude --session-id ${shellQuote(sessionId)} -p ${shellQuote(prompt)} --dangerously-skip-permissions`,
-    sessionId,
-  };
+  const agent = agentRegistry.get(name);
+  if (!agent?.buildFixCommand) {
+    throw new Error(
+      `Cannot build remote command for requested execution agent "${name}": the configured agent set lacks that name or it does not support fix commands`,
+    );
+  }
+  const spec = agent.buildFixCommand(prompt, { executionModel });
+  const sessionId = spec.sessionId ?? randomUUID();
+  const cmd = `${spec.cmd} ${spec.args.map(a => shellQuote(a)).join(' ')}`;
+  return { shellCommand: cmd, sessionId };
 }
 
 export function resolveSelectedRemoteTargetId(host: ConflictResolverHost, taskId: string, task: ReturnType<Orchestrator['getTask']> & {}): string | undefined {

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -423,6 +423,11 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
     let payload: string;
     let agentSessionId: string | undefined;
     const executionAgent = request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
+    if (request.actionType === 'ai_task' && !this.agentRegistry && executionAgent !== 'claude') {
+      throw new Error(
+        `Cannot resolve requested execution agent "${executionAgent}": no configured agent set is available on this SSH executor`,
+      );
+    }
     const effectiveAgentName = request.actionType === 'ai_task'
       ? (this.agentRegistry ? executionAgent : 'claude')
       : undefined;


### PR DESCRIPTION
## Summary

When a task asked for an execution agent that could not be resolved on the target host, the runner silently fell back to claude.

Work then ran on the wrong agent, and the substitution was invisible in the task record — the recent codex-routing incident traced back to exactly this.

Building the remote agent invocation now raises when the requested agent cannot be resolved, so the task fails with the real reason instead of running on a substitute.

Truly-defaulted callers (no agent requested) keep today's fallback.

## Review Claim

Approve one behavior change in remote agent invocation construction: an explicitly requested but unresolvable agent raises instead of falling back, while the no-request default path is untouched.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Callers that never specify an agent take the exact old fallback path — the raise fires only when an explicit request cannot be resolved, proven by the pre-existing remote-fix-process-output cases updated only where they asserted the silent substitution.

## Slice Rationale

One claim, one commit: the fail-loud rule ships alone with its coverage.

## Non-goals

No new agent resolution sources; no change to which agents are installed on hosts.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
