### PR TITLE
[Disk Hygiene Reaper](2) Run the reclaim checks from an interval-driven reaper worker

### DIFF
--- a/packages/app/src/delete-all-snapshot.ts
+++ b/packages/app/src/delete-all-snapshot.ts
@@ -71,7 +71,7 @@ export async function createDeleteAllSnapshot(
 const DEFAULT_HOURLY_SNAPSHOT_RETENTION = 48;
 const HOURLY_SNAPSHOT_PREFIX = 'invoker.db.hourly-auto-';
 
-function hourlySnapshotRetention(): number {
+export function hourlySnapshotRetention(): number {
   const raw = process.env.INVOKER_HOURLY_BACKUP_RETENTION;
   // Treat empty/blank as unset: Number('') and Number('   ') are 0, which would
   // otherwise pass the >= 0 check and silently disable pruning (reintroducing the

--- a/packages/app/src/delete-all-snapshot.ts
+++ b/packages/app/src/delete-all-snapshot.ts
@@ -1,8 +1,12 @@
-import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
 import * as path from 'node:path';
-import { resolveInvokerHomeRoot } from '@invoker/contracts';
+import {
+  resolveInvokerHomeRoot,
+  hourlySnapshotRetention,
+  pruneHourlySnapshots,
+} from '@invoker/contracts';
 
-export { resolveInvokerHomeRoot };
+export { resolveInvokerHomeRoot, hourlySnapshotRetention, pruneHourlySnapshots };
 
 /**
  * Caller-supplied backup implementation, expected to write a fully
@@ -66,68 +70,6 @@ export async function createDeleteAllSnapshot(
   backup?: SnapshotBackupFn,
 ): Promise<string | null> {
   return createDbSnapshot('before-delete-all', invokerHomeRoot, backup);
-}
-
-const DEFAULT_HOURLY_SNAPSHOT_RETENTION = 48;
-const HOURLY_SNAPSHOT_PREFIX = 'invoker.db.hourly-auto-';
-
-export function hourlySnapshotRetention(): number {
-  const raw = process.env.INVOKER_HOURLY_BACKUP_RETENTION;
-  // Treat empty/blank as unset: Number('') and Number('   ') are 0, which would
-  // otherwise pass the >= 0 check and silently disable pruning (reintroducing the
-  // unbounded growth this guards against). `export VAR=` should fall back, not disable.
-  if (raw === undefined || raw.trim() === '') return DEFAULT_HOURLY_SNAPSHOT_RETENTION;
-  const parsed = Number(raw);
-  return Number.isFinite(parsed) && parsed >= 0
-    ? Math.floor(parsed)
-    : DEFAULT_HOURLY_SNAPSHOT_RETENTION;
-}
-
-/**
- * Delete the oldest `hourly-auto` snapshots (and any legacy `-wal`/`-shm`
- * sidecars left over from the pre-fix raw-copy era) so at most `retain`
- * remain. Without this the hourly backup grows without bound — a single
- * host accumulated 1,554 snapshots (~363 GB). `retain <= 0` disables
- * pruning. Only `hourly-auto` snapshots are pruned; manual and
- * pre-delete-all snapshots are left untouched. Returns the number of
- * snapshots removed.
- */
-export function pruneHourlySnapshots(backupDir: string, retain: number): number {
-  if (retain <= 0) return 0;
-  let entries: string[];
-  try {
-    entries = readdirSync(backupDir);
-  } catch {
-    return 0;
-  }
-  // Base snapshot files only; the timestamp suffix (YYYYMMDD-HHMMSS-mmmZ) sorts
-  // chronologically, so the oldest snapshots come first.
-  const snapshots = entries
-    .filter(
-      (name) =>
-        name.startsWith(HOURLY_SNAPSHOT_PREFIX) &&
-        !name.endsWith('-wal') &&
-        !name.endsWith('-shm'),
-    )
-    .sort();
-  const excess = snapshots.length - retain;
-  if (excess <= 0) return 0;
-  let removed = 0;
-  for (const name of snapshots.slice(0, excess)) {
-    for (const suffix of ['', '-wal', '-shm']) {
-      try {
-        rmSync(path.join(backupDir, `${name}${suffix}`), { force: true });
-      } catch (err) {
-        console.warn(
-          `[delete-all-snapshot] failed to prune snapshot file ${name}${suffix}: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        );
-      }
-    }
-    removed += 1;
-  }
-  return removed;
 }
 
 /**

--- a/packages/contracts/src/hourly-snapshot-retention.ts
+++ b/packages/contracts/src/hourly-snapshot-retention.ts
@@ -1,0 +1,64 @@
+import { readdirSync, rmSync } from 'node:fs';
+import * as path from 'node:path';
+
+const DEFAULT_HOURLY_SNAPSHOT_RETENTION = 48;
+const HOURLY_SNAPSHOT_PREFIX = 'invoker.db.hourly-auto-';
+
+export function hourlySnapshotRetention(): number {
+  const raw = process.env.INVOKER_HOURLY_BACKUP_RETENTION;
+  // Treat empty/blank as unset: Number('') and Number('   ') are 0, which would
+  // otherwise pass the >= 0 check and silently disable pruning (reintroducing the
+  // unbounded growth this guards against). `export VAR=` should fall back, not disable.
+  if (raw === undefined || raw.trim() === '') return DEFAULT_HOURLY_SNAPSHOT_RETENTION;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0
+    ? Math.floor(parsed)
+    : DEFAULT_HOURLY_SNAPSHOT_RETENTION;
+}
+
+/**
+ * Delete the oldest `hourly-auto` snapshots (and any legacy `-wal`/`-shm`
+ * sidecars left over from the pre-fix raw-copy era) so at most `retain`
+ * remain. Without this the hourly backup grows without bound — a single
+ * host accumulated 1,554 snapshots (~363 GB). `retain <= 0` disables
+ * pruning. Only `hourly-auto` snapshots are pruned; manual and
+ * pre-delete-all snapshots are left untouched. Returns the number of
+ * snapshots removed.
+ */
+export function pruneHourlySnapshots(backupDir: string, retain: number): number {
+  if (retain <= 0) return 0;
+  let entries: string[];
+  try {
+    entries = readdirSync(backupDir);
+  } catch {
+    return 0;
+  }
+  // Base snapshot files only; the timestamp suffix (YYYYMMDD-HHMMSS-mmmZ) sorts
+  // chronologically, so the oldest snapshots come first.
+  const snapshots = entries
+    .filter(
+      (name) =>
+        name.startsWith(HOURLY_SNAPSHOT_PREFIX) &&
+        !name.endsWith('-wal') &&
+        !name.endsWith('-shm'),
+    )
+    .sort();
+  const excess = snapshots.length - retain;
+  if (excess <= 0) return 0;
+  let removed = 0;
+  for (const name of snapshots.slice(0, excess)) {
+    for (const suffix of ['', '-wal', '-shm']) {
+      try {
+        rmSync(path.join(backupDir, `${name}${suffix}`), { force: true });
+      } catch (err) {
+        console.warn(
+          `[hourly-snapshot-retention] failed to prune snapshot file ${name}${suffix}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+    removed += 1;
+  }
+  return removed;
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9,6 +9,7 @@ export * from './repo-root.ts';
 export * from './cost-types.ts';
 export * from './launch-timeouts.ts';
 export * from './invoker-home.ts';
+export * from './hourly-snapshot-retention.ts';
 export * from './invoker-config-io.ts';
 export * from './config-diagnostics.ts';
 export * from './prerequisites.ts';

--- a/packages/execution-engine/src/__tests__/reaper-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/reaper-reclaim.test.ts
@@ -1,0 +1,218 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { RemoteDiskTarget } from '../workers/disk-headroom-monitor.js';
+import {
+  AUTOMATION_CHECKOUT_DIRS,
+  buildDeletingOrphanReapScript,
+  DELETING_ORPHAN_MIN_AGE_MINUTES,
+  enforceHourlySnapshotRetention,
+  reapDeletingOrphans,
+  reapStaleAutomationCheckouts,
+  trimOversizedLogs,
+} from '../workers/reaper-reclaim.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeHome(): { root: string; home: string } {
+  const root = mkdtempSync(join(tmpdir(), 'invoker-reaper-'));
+  tempDirs.push(root);
+  const home = join(root, '.invoker');
+  mkdirSync(home, { recursive: true });
+  return { root, home };
+}
+
+function backdate(path: string, ageMs: number): void {
+  const seconds = (Date.now() - ageMs) / 1000;
+  utimesSync(path, seconds, seconds);
+}
+
+describe('reapDeletingOrphans', () => {
+  it('removes a stale dot-deleting orphan locally and leaves a fresh one alone', async () => {
+    const { root, home } = makeHome();
+    mkdirSync(join(home, 'merge-clones.deleting.123', 'stale'), { recursive: true });
+    writeFileSync(join(home, 'merge-clones.deleting.123', 'stale', 'file.txt'), 'x');
+    backdate(join(home, 'merge-clones.deleting.123'), 40 * 60 * 1000);
+    mkdirSync(join(home, 'repos.deleting.999'), { recursive: true });
+    mkdirSync(join(home, 'worktrees', 'active'), { recursive: true });
+    writeFileSync(join(home, 'invoker.db'), 'keep-me');
+
+    const results = await reapDeletingOrphans({
+      invokerHome: home,
+      userHome: root,
+      remoteTargets: [],
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ ok: true, reason: 'reap-orphans', detail: 'removed 1' });
+    expect(existsSync(join(home, 'merge-clones.deleting.123'))).toBe(false);
+    expect(existsSync(join(home, 'repos.deleting.999'))).toBe(true);
+    expect(existsSync(join(home, 'worktrees', 'active'))).toBe(true);
+    expect(existsSync(join(home, 'invoker.db'))).toBe(true);
+  });
+
+  it('runs the age-gated orphan reap script on every configured remote target', async () => {
+    const { root, home } = makeHome();
+    const target: RemoteDiskTarget = {
+      name: 'remote-1',
+      connection: { host: 'h', user: 'u', sshKeyPath: '/k' },
+      remotePath: '~/.invoker',
+    };
+    const runRemoteScript = vi.fn(async () => 'ok');
+
+    const results = await reapDeletingOrphans({
+      invokerHome: home,
+      userHome: root,
+      remoteTargets: [target],
+      runRemoteScript,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[1]).toMatchObject({ ok: true, targetKey: 'ssh:remote-1 ~/.invoker' });
+    expect(runRemoteScript).toHaveBeenCalledTimes(1);
+    const script = runRemoteScript.mock.calls[0]?.[1] as unknown as string;
+    expect(script).toContain('Refusing unsafe INVOKER_HOME');
+    expect(script).toContain("-name '*.deleting.*'");
+    expect(script).toContain(`-mmin +${DELETING_ORPHAN_MIN_AGE_MINUTES}`);
+    expect(script).toContain('-maxdepth 1');
+    expect(script).not.toContain('pkill');
+  });
+
+  it('refuses unsafe local and remote homes without touching anything', async () => {
+    const runRemoteScript = vi.fn(async () => 'ok');
+    const results = await reapDeletingOrphans({
+      invokerHome: '/',
+      remoteTargets: [
+        { name: 'remote-1', connection: { host: 'h', user: 'u', sshKeyPath: '/k' }, remotePath: '~' },
+      ],
+      runRemoteScript,
+    });
+
+    expect(results[0]).toMatchObject({ ok: false, reason: 'path-guard' });
+    expect(results[1]).toMatchObject({ ok: false, reason: 'path-guard' });
+    expect(runRemoteScript).not.toHaveBeenCalled();
+  });
+
+  it('embeds only the narrow orphan glob in the remote script, not the reclaimable-dir wipe', () => {
+    const script = buildDeletingOrphanReapScript('~/.invoker');
+    expect(script).toContain("'*.deleting.*'");
+    expect(script).not.toContain('$INVOKER_HOME/worktrees');
+    expect(script).not.toContain('$INVOKER_HOME/repos');
+    expect(script).not.toContain('TMP_CLEAN');
+  });
+});
+
+describe('reapStaleAutomationCheckouts', () => {
+  it('removes children older than forty-eight hours and keeps fresh ones and the locations', () => {
+    const { root, home } = makeHome();
+    for (const dirName of AUTOMATION_CHECKOUT_DIRS) {
+      mkdirSync(join(home, dirName, 'old-item', 'checkout'), { recursive: true });
+      writeFileSync(join(home, dirName, 'old-item', 'checkout', 'file.txt'), 'x');
+      backdate(join(home, dirName, 'old-item'), 49 * 60 * 60 * 1000);
+      mkdirSync(join(home, dirName, 'fresh-item'), { recursive: true });
+    }
+
+    const removed = reapStaleAutomationCheckouts({ invokerHome: home, userHome: root });
+
+    expect(removed).toHaveLength(AUTOMATION_CHECKOUT_DIRS.length);
+    for (const dirName of AUTOMATION_CHECKOUT_DIRS) {
+      expect(existsSync(join(home, dirName))).toBe(true);
+      expect(existsSync(join(home, dirName, 'old-item'))).toBe(false);
+      expect(existsSync(join(home, dirName, 'fresh-item'))).toBe(true);
+    }
+  });
+
+  it('returns nothing when the locations are absent', () => {
+    const { root, home } = makeHome();
+    expect(reapStaleAutomationCheckouts({ invokerHome: home, userHome: root })).toEqual([]);
+  });
+});
+
+describe('enforceHourlySnapshotRetention', () => {
+  it('trims a pile larger than the configured limit to exactly that limit', () => {
+    vi.stubEnv('INVOKER_HOURLY_BACKUP_RETENTION', '2');
+    const { root, home } = makeHome();
+    const backupDir = join(home, 'db-backups');
+    mkdirSync(backupDir, { recursive: true });
+    for (let i = 1; i <= 4; i += 1) {
+      writeFileSync(join(backupDir, `invoker.db.hourly-auto-20260101-00000${i}-000Z`), `${i}`);
+    }
+    writeFileSync(join(backupDir, 'invoker.db.before-delete-all-20260101-000001-000Z'), 'manual');
+
+    const removed = enforceHourlySnapshotRetention(home, root);
+
+    expect(removed).toBe(2);
+    const remaining = readdirSync(backupDir).sort();
+    expect(remaining).toEqual([
+      'invoker.db.before-delete-all-20260101-000001-000Z',
+      'invoker.db.hourly-auto-20260101-000003-000Z',
+      'invoker.db.hourly-auto-20260101-000004-000Z',
+    ]);
+  });
+
+  it('leaves a pile within the configured limit alone', () => {
+    vi.stubEnv('INVOKER_HOURLY_BACKUP_RETENTION', '2');
+    const { root, home } = makeHome();
+    const backupDir = join(home, 'db-backups');
+    mkdirSync(backupDir, { recursive: true });
+    writeFileSync(join(backupDir, 'invoker.db.hourly-auto-20260101-000001-000Z'), '1');
+
+    expect(enforceHourlySnapshotRetention(home, root)).toBe(0);
+    expect(readdirSync(backupDir)).toEqual(['invoker.db.hourly-auto-20260101-000001-000Z']);
+  });
+});
+
+describe('trimOversizedLogs', () => {
+  it('rewrites an oversized log in place keeping only its most recent portion', () => {
+    const { root, home } = makeHome();
+    const big = 'a'.repeat(90) + '0123456789';
+    writeFileSync(join(home, 'invoker.log'), big);
+    writeFileSync(join(home, 'other-worker.log'), big);
+
+    const trimmed = trimOversizedLogs({
+      invokerHome: home,
+      userHome: root,
+      maxBytes: 50,
+      keepBytes: 10,
+    });
+
+    expect(trimmed.sort()).toEqual([join(home, 'invoker.log'), join(home, 'other-worker.log')]);
+    expect(readFileSync(join(home, 'invoker.log'), 'utf8')).toBe('0123456789');
+    expect(readFileSync(join(home, 'other-worker.log'), 'utf8')).toBe('0123456789');
+  });
+
+  it('leaves a small log and non-log files alone', () => {
+    const { root, home } = makeHome();
+    writeFileSync(join(home, 'gui.log'), 'small');
+    writeFileSync(join(home, 'invoker.db'), 'x'.repeat(100));
+
+    const trimmed = trimOversizedLogs({
+      invokerHome: home,
+      userHome: root,
+      maxBytes: 50,
+      keepBytes: 10,
+    });
+
+    expect(trimmed).toEqual([]);
+    expect(readFileSync(join(home, 'gui.log'), 'utf8')).toBe('small');
+    expect(readFileSync(join(home, 'invoker.db'), 'utf8')).toBe('x'.repeat(100));
+  });
+});

--- a/packages/execution-engine/src/__tests__/reaper-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/reaper-worker.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { registerBuiltinWorkers } from '../builtin-workers.js';
+import { createWorkerRegistry } from '../worker-registry.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+
+import type { DiskCleanupResult } from '../workers/disk-headroom-reclaim.js';
+import {
+  createReaperWorker,
+  REAPER_WORKER_KIND,
+  registerReaperWorker,
+} from '../workers/reaper-worker.js';
+
+function makeLogger() {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
+
+  logger.child.mockImplementation(() => logger as any);
+  return logger as any;
+}
+
+function okResult(targetKey: string): DiskCleanupResult {
+  return { targetKey, ok: true, reason: 'reap-orphans', detail: 'removed 1' };
+}
+
+describe('reaper worker', () => {
+  it('is registered among the built-in workers and builds a runtime from dependencies', () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerBuiltinWorkers(registry);
+
+    const definition = registry.get(REAPER_WORKER_KIND);
+    expect(definition).toBeTruthy();
+
+    const runtime = definition!.factory({
+      store: {} as any,
+      submitter: { submit: vi.fn() } as any,
+      logger: makeLogger(),
+      diskHeadroom: { localPath: '/tmp/invoker-home', remoteTargets: [] },
+    } satisfies WorkerRuntimeDependencies);
+    expect(runtime.identity.kind).toBe(REAPER_WORKER_KIND);
+  });
+
+  it('calls each of the four checks once per tick and writes one record-keeping entry', async () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerReaperWorker(registry);
+    expect(registry.get(REAPER_WORKER_KIND)).toBeTruthy();
+
+    const reapOrphans = vi.fn(async () => [okResult('local /tmp/invoker-home')]);
+    const reapCheckouts = vi.fn(() => ['/tmp/invoker-home/mergify-admin-requeue-work/old-item']);
+    const enforceRetention = vi.fn(() => 2);
+    const trimLogs = vi.fn(() => ['/tmp/invoker-home/invoker.log']);
+    const upsertWorkerAction = vi.fn((row: any) => row);
+
+    const runtime = createReaperWorker({
+      logger: makeLogger(),
+      invokerHome: '/tmp/invoker-home',
+      remoteTargets: [],
+      intervalMs: 0,
+      tickOnStart: false,
+      store: { upsertWorkerAction },
+      reapOrphans,
+      reapCheckouts,
+      enforceRetention,
+      trimLogs,
+    });
+
+    await runtime.tick('manual');
+
+    expect(reapOrphans).toHaveBeenCalledTimes(1);
+    expect(reapOrphans.mock.calls[0]?.[0]).toMatchObject({
+      invokerHome: '/tmp/invoker-home',
+      remoteTargets: [],
+    });
+    expect(reapCheckouts).toHaveBeenCalledTimes(1);
+    expect(reapCheckouts.mock.calls[0]?.[0]).toMatchObject({ invokerHome: '/tmp/invoker-home' });
+    expect(enforceRetention).toHaveBeenCalledTimes(1);
+    expect(enforceRetention.mock.calls[0]?.[0]).toBe('/tmp/invoker-home');
+    expect(trimLogs).toHaveBeenCalledTimes(1);
+    expect(trimLogs.mock.calls[0]?.[0]).toMatchObject({ invokerHome: '/tmp/invoker-home' });
+
+    expect(upsertWorkerAction).toHaveBeenCalledTimes(1);
+    expect(upsertWorkerAction.mock.calls[0]?.[0]).toMatchObject({
+      workerKind: REAPER_WORKER_KIND,
+      actionType: 'reaper-pass',
+      externalKey: 'pass',
+      subjectType: 'invoker-home',
+      subjectId: '/tmp/invoker-home',
+      status: 'completed',
+      attemptCount: 1,
+    });
+    expect(upsertWorkerAction.mock.calls[0]?.[0].summary).toContain('checkouts removed 1');
+    expect(upsertWorkerAction.mock.calls[0]?.[0].summary).toContain('snapshots pruned 2');
+    expect(upsertWorkerAction.mock.calls[0]?.[0].summary).toContain('logs trimmed 1');
+  });
+
+  it('records a failed pass when an orphan target fails', async () => {
+    const failedResult: DiskCleanupResult = {
+      targetKey: 'ssh:remote-1 ~/.invoker',
+      ok: false,
+      reason: 'cleanup-error',
+      detail: 'ssh timed out',
+    };
+    const upsertWorkerAction = vi.fn((row: any) => row);
+
+    const runtime = createReaperWorker({
+      logger: makeLogger(),
+      invokerHome: '/tmp/invoker-home',
+      intervalMs: 0,
+      tickOnStart: false,
+      store: { upsertWorkerAction },
+      reapOrphans: vi.fn(async () => [okResult('local /tmp/invoker-home'), failedResult]),
+      reapCheckouts: vi.fn(() => []),
+      enforceRetention: vi.fn(() => 0),
+      trimLogs: vi.fn(() => []),
+    });
+
+    await runtime.tick('manual');
+
+    expect(upsertWorkerAction).toHaveBeenCalledTimes(1);
+    expect(upsertWorkerAction.mock.calls[0]?.[0]).toMatchObject({
+      workerKind: REAPER_WORKER_KIND,
+      status: 'failed',
+    });
+    expect(upsertWorkerAction.mock.calls[0]?.[0].payload).toMatchObject({
+      reason: 'cleanup-error',
+    });
+  });
+});

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -7,6 +7,7 @@ import { registerDiskHeadroomWorker } from './workers/disk-headroom-worker.js';
 import { registerInfraRepairWorker } from './workers/infra-repair-worker.js';
 import { registerPrMaintenanceWorkers } from './workers/pr-maintenance-workers.js';
 import { registerPrStatusWorker } from './workers/pr-status-worker.js';
+import { registerReaperWorker } from './workers/reaper-worker.js';
 import { registerRequeueWorker } from './workers/requeue-worker.js';
 import { registerWorkflowResumeWorker } from './workers/workflow-resume-worker.js';
 
@@ -20,6 +21,7 @@ export function registerBuiltinWorkers(
   registerPrStatusWorker(registry);
   registerInfraRepairWorker(registry);
   registerDiskHeadroomWorker(registry);
+  registerReaperWorker(registry);
   registerAutoApproveWorker(registry);
   registerPrMaintenanceWorkers(registry);
   registerE2eAutoFixWorker(registry);

--- a/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
@@ -113,7 +113,7 @@ export function isSafeRemoteInvokerHomePath(remotePath: string): boolean {
   return true;
 }
 
-function isDeletingOrphanName(name: string): boolean {
+export function isDeletingOrphanName(name: string): boolean {
   return name.includes('.deleting.');
 }
 

--- a/packages/execution-engine/src/workers/reaper-reclaim.ts
+++ b/packages/execution-engine/src/workers/reaper-reclaim.ts
@@ -1,0 +1,280 @@
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readdirSync,
+  readSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import type { Logger } from '@invoker/contracts';
+
+import { hourlySnapshotRetention, pruneHourlySnapshots } from '../../../app/src/delete-all-snapshot.js';
+import { buildSshConnectionArgs } from '../ssh-transport-options.js';
+import { bashNormalizeTildePath, execRemoteCapture, shellPosixSingleQuote } from '../ssh-git-exec.js';
+
+import type { RemoteDiskTarget } from './disk-headroom-monitor.js';
+import {
+  expandTildeHome,
+  isDeletingOrphanName,
+  isSafeInvokerHome,
+  isSafeRemoteInvokerHomePath,
+  type DiskCleanupResult,
+} from './disk-headroom-reclaim.js';
+
+export const DELETING_ORPHAN_MIN_AGE_MINUTES = 30;
+
+export const AUTOMATION_CHECKOUT_DIRS = [
+  'mergify-admin-requeue-work',
+  'land-admin-bypass-work',
+] as const;
+
+export const AUTOMATION_CHECKOUT_MIN_AGE_HOURS = 48;
+
+export const LOG_TRIM_MAX_BYTES = 100 * 1024 * 1024;
+export const LOG_TRIM_KEEP_BYTES = 20 * 1024 * 1024;
+export const REAPER_LOG_SUFFIX = '.log';
+
+function errorDetail(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function entryAgeMs(path: string, nowMs: number): number | null {
+  try {
+    return nowMs - statSync(path).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+export function buildDeletingOrphanReapScript(invokerHome: string): string {
+  const homeQ = shellPosixSingleQuote(invokerHome);
+  return `set +e
+INVOKER_HOME=${homeQ}
+${bashNormalizeTildePath('INVOKER_HOME')}
+case "$INVOKER_HOME" in
+  ""|"/"|"$HOME"|"~")
+    echo "Refusing unsafe INVOKER_HOME: $INVOKER_HOME" >&2
+    exit 64
+    ;;
+esac
+find "$INVOKER_HOME" -mindepth 1 -maxdepth 1 -name '*.deleting.*' -mmin +${DELETING_ORPHAN_MIN_AGE_MINUTES} \\
+  -print0 2>/dev/null | while IFS= read -r -d '' entry; do
+  rm -rf "$entry" >/dev/null 2>&1
+done
+exit 0
+`;
+}
+
+export function reapLocalDeletingOrphans(opts: {
+  invokerHome: string;
+  logger?: Logger;
+  userHome?: string;
+  nowMs?: number;
+}): DiskCleanupResult {
+  const targetKey = `local ${opts.invokerHome}`;
+  const userHome = opts.userHome ?? homedir();
+  const home = expandTildeHome(opts.invokerHome, userHome);
+  if (!isSafeInvokerHome(home, userHome)) {
+    return { targetKey, ok: false, reason: 'path-guard', detail: home };
+  }
+  if (!existsSync(home)) {
+    return { targetKey, ok: true, reason: 'reap-orphans', detail: 'removed 0' };
+  }
+
+  const nowMs = opts.nowMs ?? Date.now();
+  const minAgeMs = DELETING_ORPHAN_MIN_AGE_MINUTES * 60 * 1000;
+  const errors: string[] = [];
+  let removed = 0;
+
+  let entries: string[] = [];
+  try {
+    entries = readdirSync(home);
+  } catch (err) {
+    errors.push(`readdir ${home}: ${errorDetail(err)}`);
+  }
+  for (const name of entries) {
+    if (!isDeletingOrphanName(name)) continue;
+    const path = join(home, name);
+    const ageMs = entryAgeMs(path, nowMs);
+    if (ageMs === null || ageMs < minAgeMs) continue;
+    try {
+      rmSync(path, { recursive: true, force: true });
+      removed += 1;
+      opts.logger?.info?.(`[reaper] removed orphan ${path}`, { module: 'reaper', targetKey });
+    } catch (err) {
+      errors.push(`${path}: ${errorDetail(err)}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    return { targetKey, ok: false, reason: 'cleanup-error', detail: errors.slice(0, 5).join('; ') };
+  }
+  return { targetKey, ok: true, reason: 'reap-orphans', detail: `removed ${removed}` };
+}
+
+export async function reapRemoteDeletingOrphans(opts: {
+  target: RemoteDiskTarget;
+  logger?: Logger;
+  runRemoteScript?: (target: RemoteDiskTarget, script: string) => Promise<string>;
+}): Promise<DiskCleanupResult> {
+  const targetKey = `ssh:${opts.target.name} ${opts.target.remotePath}`;
+  if (!isSafeRemoteInvokerHomePath(opts.target.remotePath)) {
+    return { targetKey, ok: false, reason: 'path-guard', detail: opts.target.remotePath };
+  }
+
+  const script = buildDeletingOrphanReapScript(opts.target.remotePath);
+  const run = opts.runRemoteScript ?? defaultRunRemoteReap;
+  try {
+    const output = await run(opts.target, script);
+    return { targetKey, ok: true, reason: 'reap-orphans', detail: output.slice(-400) };
+  } catch (err) {
+    const detail = errorDetail(err);
+    opts.logger?.error?.(`[reaper] remote orphan reap failed ${targetKey}: ${detail}`, {
+      module: 'reaper',
+      targetKey,
+    });
+    return { targetKey, ok: false, reason: 'cleanup-error', detail };
+  }
+}
+
+function defaultRunRemoteReap(target: RemoteDiskTarget, script: string): Promise<string> {
+  const sshArgs = buildSshConnectionArgs(target.connection, { batchMode: true });
+  return execRemoteCapture({
+    sshArgs,
+    script,
+    phase: `reaper-orphans:${target.name}`,
+  });
+}
+
+export async function reapDeletingOrphans(opts: {
+  invokerHome: string;
+  remoteTargets?: RemoteDiskTarget[];
+  logger?: Logger;
+  userHome?: string;
+  nowMs?: number;
+  runRemoteScript?: (target: RemoteDiskTarget, script: string) => Promise<string>;
+}): Promise<DiskCleanupResult[]> {
+  const results: DiskCleanupResult[] = [reapLocalDeletingOrphans(opts)];
+  for (const target of opts.remoteTargets ?? []) {
+    results.push(
+      await reapRemoteDeletingOrphans({
+        target,
+        logger: opts.logger,
+        runRemoteScript: opts.runRemoteScript,
+      }),
+    );
+  }
+  return results;
+}
+
+export function reapStaleAutomationCheckouts(opts: {
+  invokerHome: string;
+  logger?: Logger;
+  userHome?: string;
+  nowMs?: number;
+}): string[] {
+  const userHome = opts.userHome ?? homedir();
+  const home = expandTildeHome(opts.invokerHome, userHome);
+  if (!isSafeInvokerHome(home, userHome)) return [];
+
+  const nowMs = opts.nowMs ?? Date.now();
+  const minAgeMs = AUTOMATION_CHECKOUT_MIN_AGE_HOURS * 60 * 60 * 1000;
+  const removed: string[] = [];
+
+  for (const dirName of AUTOMATION_CHECKOUT_DIRS) {
+    const dir = join(home, dirName);
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      const path = join(dir, name);
+      const ageMs = entryAgeMs(path, nowMs);
+      if (ageMs === null || ageMs < minAgeMs) continue;
+      try {
+        rmSync(path, { recursive: true, force: true });
+        removed.push(path);
+        opts.logger?.info?.(`[reaper] removed stale checkout ${path}`, { module: 'reaper' });
+      } catch (err) {
+        opts.logger?.warn?.(`[reaper] failed to remove ${path}: ${errorDetail(err)}`, {
+          module: 'reaper',
+        });
+      }
+    }
+  }
+  return removed;
+}
+
+export function enforceHourlySnapshotRetention(
+  invokerHome: string,
+  userHome: string = homedir(),
+): number {
+  const home = expandTildeHome(invokerHome, userHome);
+  return pruneHourlySnapshots(join(home, 'db-backups'), hourlySnapshotRetention());
+}
+
+export function trimOversizedLogs(opts: {
+  invokerHome: string;
+  logger?: Logger;
+  userHome?: string;
+  maxBytes?: number;
+  keepBytes?: number;
+}): string[] {
+  const userHome = opts.userHome ?? homedir();
+  const home = expandTildeHome(opts.invokerHome, userHome);
+  if (!isSafeInvokerHome(home, userHome)) return [];
+
+  const maxBytes = opts.maxBytes ?? LOG_TRIM_MAX_BYTES;
+  const keepBytes = opts.keepBytes ?? LOG_TRIM_KEEP_BYTES;
+
+  let entries: string[];
+  try {
+    entries = readdirSync(home);
+  } catch {
+    return [];
+  }
+
+  const trimmed: string[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(REAPER_LOG_SUFFIX)) continue;
+    const path = join(home, name);
+    let size: number;
+    try {
+      const stat = statSync(path);
+      if (!stat.isFile()) continue;
+      size = stat.size;
+    } catch {
+      continue;
+    }
+    if (size <= maxBytes) continue;
+    try {
+      trimLogTail(path, size, keepBytes);
+      trimmed.push(path);
+      opts.logger?.info?.(`[reaper] trimmed log ${path} from ${size} bytes`, { module: 'reaper' });
+    } catch (err) {
+      opts.logger?.warn?.(`[reaper] failed to trim ${path}: ${errorDetail(err)}`, {
+        module: 'reaper',
+      });
+    }
+  }
+  return trimmed;
+}
+
+function trimLogTail(path: string, size: number, keepBytes: number): void {
+  const length = Math.min(keepBytes, size);
+  const tail = Buffer.alloc(length);
+  const fd = openSync(path, 'r');
+  try {
+    readSync(fd, tail, 0, length, size - length);
+  } finally {
+    closeSync(fd);
+  }
+  writeFileSync(path, tail);
+}

--- a/packages/execution-engine/src/workers/reaper-reclaim.ts
+++ b/packages/execution-engine/src/workers/reaper-reclaim.ts
@@ -11,9 +11,8 @@ import {
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-import type { Logger } from '@invoker/contracts';
+import { hourlySnapshotRetention, pruneHourlySnapshots, type Logger } from '@invoker/contracts';
 
-import { hourlySnapshotRetention, pruneHourlySnapshots } from '../../../app/src/delete-all-snapshot.js';
 import { buildSshConnectionArgs } from '../ssh-transport-options.js';
 import { bashNormalizeTildePath, execRemoteCapture, shellPosixSingleQuote } from '../ssh-git-exec.js';
 

--- a/packages/execution-engine/src/workers/reaper-worker.ts
+++ b/packages/execution-engine/src/workers/reaper-worker.ts
@@ -1,0 +1,127 @@
+import type { Logger } from '@invoker/contracts';
+
+import { resolveInvokerHomeRoot } from '../worker-lock.js';
+import { recordWorkerDecisionRow, type WorkerDecisionStore } from '../worker-decision-ledger.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+import type { RemoteDiskTarget } from './disk-headroom-monitor.js';
+import {
+  enforceHourlySnapshotRetention,
+  reapDeletingOrphans,
+  reapStaleAutomationCheckouts,
+  trimOversizedLogs,
+} from './reaper-reclaim.js';
+
+export const REAPER_WORKER_KIND = 'reaper';
+
+export const DEFAULT_REAPER_INTERVAL_MS = 60 * 60 * 1000;
+
+export function resolveReaperIntervalMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.INVOKER_REAPER_INTERVAL_MS;
+  if (!raw) return DEFAULT_REAPER_INTERVAL_MS;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_REAPER_INTERVAL_MS;
+  return n;
+}
+
+export interface ReaperWorkerOptions {
+  logger: Logger;
+  invokerHome: string;
+  remoteTargets?: RemoteDiskTarget[];
+  intervalMs?: number;
+  tickOnStart?: boolean;
+  store?: WorkerDecisionStore;
+  /** Test seam: override the orphaned dot-deleting reap. */
+  reapOrphans?: typeof reapDeletingOrphans;
+  /** Test seam: override the stale automation-checkout reap. */
+  reapCheckouts?: typeof reapStaleAutomationCheckouts;
+  /** Test seam: override snapshot-retention enforcement. */
+  enforceRetention?: typeof enforceHourlySnapshotRetention;
+  /** Test seam: override oversized-log trimming. */
+  trimLogs?: typeof trimOversizedLogs;
+  /** Test seam: wrap the worker tick for observability. */
+  onTick?: WorkerTick;
+}
+
+export function createReaperWorker(options: ReaperWorkerOptions): WorkerRuntime {
+  const reapOrphans = options.reapOrphans ?? reapDeletingOrphans;
+  const reapCheckouts = options.reapCheckouts ?? reapStaleAutomationCheckouts;
+  const enforceRetention = options.enforceRetention ?? enforceHourlySnapshotRetention;
+  const trimLogs = options.trimLogs ?? trimOversizedLogs;
+
+  return createWorkerRuntime({
+    kind: REAPER_WORKER_KIND,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? resolveReaperIntervalMs(),
+    tickOnStart: options.tickOnStart ?? true,
+    onTick: async (ctx) => {
+      ctx.signal?.throwIfAborted();
+      await options.onTick?.(ctx);
+      ctx.signal?.throwIfAborted();
+
+      const orphanResults = await reapOrphans({
+        invokerHome: options.invokerHome,
+        remoteTargets: options.remoteTargets ?? [],
+        logger: options.logger,
+      });
+      if (ctx.signal?.aborted) return;
+
+      const checkoutsRemoved = reapCheckouts({
+        invokerHome: options.invokerHome,
+        logger: options.logger,
+      });
+      const snapshotsPruned = enforceRetention(options.invokerHome);
+      const logsTrimmed = trimLogs({
+        invokerHome: options.invokerHome,
+        logger: options.logger,
+      });
+
+      const failed = orphanResults.filter((result) => !result.ok);
+      const summary =
+        `Reaper pass: orphan targets ${orphanResults.length - failed.length}/${orphanResults.length} ok, `
+        + `checkouts removed ${checkoutsRemoved.length}, snapshots pruned ${snapshotsPruned}, `
+        + `logs trimmed ${logsTrimmed.length}`;
+
+      if (options.store) {
+        recordWorkerDecisionRow(options.store, {
+          workerKind: REAPER_WORKER_KIND,
+          actionType: 'reaper-pass',
+          externalKey: 'pass',
+          subjectType: 'invoker-home',
+          subjectId: options.invokerHome,
+          status: failed.length > 0 ? 'failed' : 'completed',
+          summary,
+          ...(failed.length > 0 ? { reason: failed[0]?.reason } : {}),
+          payload: {
+            orphanResults,
+            checkoutsRemoved,
+            snapshotsPruned,
+            logsTrimmed,
+          },
+          incrementAttempt: true,
+        });
+      }
+      options.logger.info?.(`[reaper] ${summary}`, { module: 'reaper' });
+    },
+  });
+}
+
+/** Register the built-in reaper worker (interval-driven disk hygiene). */
+export function registerReaperWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: REAPER_WORKER_KIND,
+    note: 'Reaps orphaned .deleting dirs, stale automation checkouts, excess hourly snapshots, and oversized logs on an interval.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createReaperWorker({
+        logger: deps.logger,
+        invokerHome: deps.diskHeadroom?.localPath ?? resolveInvokerHomeRoot(),
+        remoteTargets: deps.diskHeadroom?.remoteTargets ?? [],
+        store: deps.store,
+      }),
+  });
+  return registry;
+}


### PR DESCRIPTION
## Summary

The four reclaim checks from the previous slice need something to run them.

This adds an interval-driven reaper worker in the same shape as the disk-headroom worker, registered in the built-in worker set.

Each wakeup runs the four checks once — locally and on the configured remote targets — and writes one record-keeping entry, with the interval defaulting to one hour.

## Review Claim

Approve one new background worker: same registration shape as the disk-headroom worker, calling the four reclaim checks per wakeup on an hourly default interval.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The worker only calls the four checks the previous slice introduced — seam-injected in its own coverage — and registration adds one entry to the built-in set without reordering the others.

## Slice Rationale

Scheduling ships separately from what gets reclaimed, so a revert of this slice stops the schedule without touching the checks.

## Non-goals

No new reclaim behavior; no change to the disk-headroom worker or its thresholds.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test src/__tests__/reaper-worker.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
