### PR TITLE
[CI regression: 0f8bbf4-playwright-4-of-9](1) Pin non-stack plan submissions to the workflow base branch

### DIFF
--- a/packages/app/src/__tests__/plan-submission-loader.test.ts
+++ b/packages/app/src/__tests__/plan-submission-loader.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PlanDefinition } from '@invoker/workflow-core';
+
+vi.mock('../plan-backup.js', () => ({
+  backupPlan: vi.fn(() => '/tmp/invoker-plan-backup.yaml'),
+}));
+
+import { loadPlanSubmissionBundle } from '../plan-submission-loader.js';
+
+function makeDeps() {
+  const workflows: Array<{ id: string; featureBranch?: string }> = [];
+  const loadedPlans: PlanDefinition[] = [];
+  return {
+    loadedPlans,
+    deps: {
+      persistence: {
+        listWorkflows: vi.fn(() => workflows.map((workflow) => ({ ...workflow }))),
+      },
+      orchestrator: {
+        loadPlan: vi.fn((plan: PlanDefinition, _opts: { allowGraphMutation?: boolean }) => {
+          loadedPlans.push(plan);
+          workflows.push({
+            id: `wf-${loadedPlans.length}`,
+            featureBranch: plan.featureBranch,
+          });
+        }),
+      },
+      allowGraphMutation: true,
+    },
+  };
+}
+
+describe('loadPlanSubmissionBundle', () => {
+  it('pins a single submitted workflow base branch to master', async () => {
+    const { deps, loadedPlans } = makeDeps();
+
+    await loadPlanSubmissionBundle(`
+name: Single Review Workflow
+repoUrl: git@github.com:test/repo.git
+baseBranch: release
+featureBranch: plan/single-review-workflow
+tasks:
+  - id: build
+    description: Build it
+`, deps);
+
+    expect(loadedPlans).toHaveLength(1);
+    expect(loadedPlans[0]?.baseBranch).toBe('master');
+  });
+
+  it('preserves stack bases while linking downstream workflows to the upstream feature branch', async () => {
+    const { deps, loadedPlans } = makeDeps();
+
+    await loadPlanSubmissionBundle(`
+name: Stack Review
+repoUrl: git@github.com:test/repo.git
+workflows:
+  - name: Upstream Step
+    baseBranch: release
+    featureBranch: plan/upstream-step
+    tasks:
+      - id: build-upstream
+        description: Build upstream
+  - name: Downstream Step
+    featureBranch: plan/downstream-step
+    tasks:
+      - id: build-downstream
+        description: Build downstream
+`, deps);
+
+    expect(loadedPlans).toHaveLength(2);
+    expect(loadedPlans[0]?.baseBranch).toBe('release');
+    expect(loadedPlans[1]?.baseBranch).toBe('plan/upstream-step');
+    expect(loadedPlans[1]?.externalDependencies).toContainEqual({
+      workflowId: 'wf-1',
+      taskId: '__merge__',
+      requiredStatus: 'completed',
+      gatePolicy: 'review_ready',
+    });
+  });
+});

--- a/packages/app/src/plan-submission-loader.ts
+++ b/packages/app/src/plan-submission-loader.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '@invoker/contracts';
-import type { PlanDefinition } from '@invoker/workflow-core';
+import { PINNED_WORKFLOW_BASE_BRANCH, type PlanDefinition } from '@invoker/workflow-core';
 import { backupPlan } from './plan-backup.js';
 
 export interface PlanSubmissionLoadResult {
@@ -45,6 +45,9 @@ export async function loadPlanSubmissionBundle(
 
   for (const parsedPlan of submission.plans) {
     let plan = applyConfiguredPlanDefaults(parsedPlan);
+    if (!submission.isStack) {
+      plan = { ...plan, baseBranch: PINNED_WORKFLOW_BASE_BRANCH };
+    }
     if (upstream) {
       plan = {
         ...plan,


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=0f8bbf445910792b95b534faeb902b0e2b07fa77; job=playwright / 4-of-9 -->

CI job `playwright / 4-of-9` first went red on default-branch push 0f8bbf445910792b95b534faeb902b0e2b07fa77 and stayed red through 6dcba8f76596b148a4bb437b5e3dbf2c9afbdb0d.

The shard's e2e specs expect a single-plan submission to build its workflow on the pinned base branch. The loader instead kept whatever base the plan file carried.

`loadPlanSubmissionBundle` now pins `baseBranch` to `PINNED_WORKFLOW_BASE_BRANCH` for non-stack submissions. Stack submissions keep their explicit bases.

A new unit test locks the pinned value for single-plan submissions.

## Review Claim

Non-stack plan submissions always build their workflow on the pinned base branch, which turns the `playwright / 4-of-9` e2e shard green.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Stack submissions are untouched; only single-plan submissions change, and other CI jobs plus product behavior stay as they were apart from the corrected defect.

## Slice Rationale

This slice carries only the product fix and its unit test. The shard inventory repro and the CI workflow wiring follow in the next two stack slices.

## Non-goals

- No `.github/workflows/ci.yml` changes.
- No `scripts/repro/` changes.
- No e2e spec edits, no test weakening, no unrelated cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test src/__tests__/plan-submission-loader.test.ts`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-4-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/startup-window-liveness.spec.ts e2e/workflow-lifecycle.spec.ts e2e/base-branch-normalization.proof.spec.ts e2e/edit-task-prompt.spec.ts e2e/fix-with-claude.spec.ts e2e/fix-with-agent-transition.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <squash-merge sha of this PR>`
- Post-revert steps: None
- Data migration? No

</details>
