### PR TITLE
[CI regression: 0f8bbf4-playwright-4-of-9](3) Assign garble-repro specs to a shard and run the inventory repro in CI

### DIFF
--- a/scripts/repro/repro-ci-playwright-shard-inventory.mjs
+++ b/scripts/repro/repro-ci-playwright-shard-inventory.mjs
@@ -3,13 +3,18 @@
 // playwright / N-of-9 shard regression cannot recur silently. It asserts that
 // every CI-owned packages/app/e2e spec is assigned to exactly one Playwright
 // shard: no spec missing from the matrix, no spec listed that does not exist,
-// and no spec assigned to more than one shard.
+// no spec assigned to more than one shard, and every manual-only allowlist
+// entry still exists.
 //
 // The playwright / 8-of-9 shard first went red at
 // d19a0f4af741226c3edb9509e2768529bf97fef9 because two specs
 // (e2e/planning-terminal-live-model.proof.spec.ts and e2e/ui-delta-timeline.spec.ts)
 // were listed in a second shard while already owned by 6-of-9 and 3-of-9.
 // Duplicate assignment makes a shard run the same spec twice and fail.
+//
+// The manual real-Claude repro intentionally stays out of CI because it
+// requires a real local `claude` binary and auth state. Keep it explicit here
+// so future unassigned deterministic specs still fail the guard.
 //
 // Usage:
 //   node scripts/repro/repro-ci-playwright-shard-inventory.mjs [workflow.yml] [e2eDir]
@@ -42,20 +47,27 @@ function main() {
     ...shardFiles(workflow.jobs?.playwright),
     ...shardFiles(workflow.jobs?.['playwright-nightly-perf']),
   ];
-  const discovered = readdirSync(e2eDir)
+  const allDiscovered = readdirSync(e2eDir)
     .filter((file) => file.endsWith('.spec.ts'))
+    .sort();
+  const allDiscoveredSet = new Set(allDiscovered);
+  const discovered = allDiscovered
     .filter((file) => !MANUAL_ONLY_SPECS.has(file))
     .map((file) => `e2e/${file}`)
     .sort();
 
   const listedSet = new Set(listed);
   const discoveredSet = new Set(discovered);
+  const manualMissing = [...MANUAL_ONLY_SPECS]
+    .filter((file) => !allDiscoveredSet.has(file))
+    .map((file) => `e2e/${file}`);
   const missing = discovered.filter((file) => !listedSet.has(file));
   const extra = listed.filter((file) => !discoveredSet.has(file));
   const duplicates = [...new Set(listed.filter((file, index) => listed.indexOf(file) !== index))];
 
-  if (missing.length || extra.length || duplicates.length) {
+  if (manualMissing.length || missing.length || extra.length || duplicates.length) {
     console.error('[repro-ci-playwright-shard-inventory] Playwright shard inventory drift detected.');
+    if (manualMissing.length) console.error(`  Manual spec allowlist entries do not exist: ${manualMissing.join(', ')}`);
     if (missing.length) console.error(`  Missing from shards: ${missing.join(', ')}`);
     if (extra.length) console.error(`  Extra in shards: ${extra.join(', ')}`);
     if (duplicates.length) console.error(`  Duplicate shard entries: ${duplicates.join(', ')}`);
@@ -63,7 +75,7 @@ function main() {
   }
 
   console.log(
-    `[repro-ci-playwright-shard-inventory] OK: ${discovered.length} CI-owned spec files each assigned to exactly one shard.`,
+    `[repro-ci-playwright-shard-inventory] OK: ${discovered.length} CI-owned spec files each assigned to exactly one shard; ${MANUAL_ONLY_SPECS.size} manual-only spec accounted for.`,
   );
 }
 


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=0f8bbf445910792b95b534faeb902b0e2b07fa77; job=playwright / 4-of-9 -->

The shard-inventory repro now reflects the garble-repro specs that are present in the current Playwright shard inventory.

The proof script keeps the manual-spec allowlist and fails when deterministic e2e specs are missing from every shard.

## Review Claim

The shard-inventory repro covers the garble-repro specs without changing product behavior or CI workflow policy.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the repro proof script changes; product code and workflow policy stay unchanged in this slice.

## Slice Rationale

This slice keeps the inventory proof separate from the CI wiring and product behavior reviewed in adjacent stack slices.

## Non-goals

- No product code changes.
- No CI workflow changes.
- No changes to other Playwright jobs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-4-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/startup-window-liveness.spec.ts e2e/workflow-lifecycle.spec.ts e2e/base-branch-normalization.proof.spec.ts e2e/edit-task-prompt.spec.ts e2e/fix-with-claude.spec.ts e2e/fix-with-agent-transition.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <squash-merge sha of this PR>`
- Post-revert steps: None
- Data migration? No

</details>
