### PR TITLE
[CI regression: d19a0f4-playwright-5-of-9](1) Map the app window early under the e2e compositor

### DIFF
--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -14,6 +14,7 @@ import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { setTimeout as delay } from 'node:timers/promises';
 import { pathToFileURL } from 'node:url';
 import { stringify as yamlStringify } from 'yaml';
 import { registerTrackedBrowserUserDataDir } from './browser-process-registry.js';
@@ -25,12 +26,14 @@ export type ElectronFixtures = {
   breakTerminalSpawn: boolean;
   /** When true, the invoker:get-planning-presets IPC handler throws (fault injection). */
   breakPlanningPresets: boolean;
+  standaloneOwnerIdleTimeoutMs: string;
   repoConfig: Partial<InvokerConfig>;
   page: Page;
   testDir: string;
 };
 
 const repoRoot = resolveRepoRoot(__dirname);
+type RuntimeMode = 'local-owner' | 'daemon-owner' | 'read-only' | 'connection-lost';
 
 async function removeTestDir(dir: string): Promise<void> {
   let lastError: unknown;
@@ -63,10 +66,62 @@ export async function deleteAllWorkflowsFast(page: Page): Promise<void> {
   });
 }
 
+export async function waitForInvokerBridge(page: Page, timeoutMs = 15_000): Promise<void> {
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: timeoutMs });
+}
+
+export async function waitForRuntimeMode(page: Page, mode: RuntimeMode, timeoutMs = 15_000): Promise<void> {
+  await waitForInvokerBridge(page, timeoutMs);
+  await expect
+    .poll(async () => {
+      const runtimeStatus = await page.evaluate(async () => window.invoker.getRuntimeStatus());
+      return runtimeStatus.mode;
+    }, { timeout: timeoutMs })
+    .toBe(mode);
+}
+
+export async function closeElectronApp(app: ElectronApplication): Promise<void> {
+  const child = app.process();
+  let childExited = child.exitCode !== null || child.signalCode !== null;
+  const childExitPromise = new Promise<void>((resolve) => {
+    if (childExited) {
+      resolve();
+      return;
+    }
+    const markChildExited = () => {
+      childExited = true;
+      resolve();
+    };
+    child.once('exit', markChildExited);
+    child.once('close', markChildExited);
+  });
+  const closePromise = app.close().catch(() => undefined);
+  const timedOut = await Promise.race([
+    closePromise.then(() => false),
+    delay(5_000).then(() => true),
+  ]);
+  if (!timedOut) return;
+
+  if (!childExited) {
+    child.kill('SIGTERM');
+    if (child.pid && process.platform !== 'win32') {
+      try {
+        process.kill(-child.pid, 'SIGTERM');
+      } catch {
+        // Process group may already be gone.
+      }
+    }
+    await Promise.race([closePromise, childExitPromise, delay(2_000)]);
+    if (!childExited) child.kill('SIGKILL');
+  }
+}
+
 export const test = base.extend<ElectronFixtures>({
   guiOwnerMode: [process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui', { option: true }],
   breakTerminalSpawn: [false, { option: true }],
   breakPlanningPresets: [false, { option: true }],
+  standaloneOwnerIdleTimeoutMs: [process.env.INVOKER_E2E_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '10000', { option: true }],
   repoConfig: [{ autoFixRetries: 0 }, { option: true }],
 
   testDir: async ({}, use) => {
@@ -77,7 +132,7 @@ export const test = base.extend<ElectronFixtures>({
     }
   },
 
-  electronApp: async ({ guiOwnerMode, breakTerminalSpawn, breakPlanningPresets, repoConfig, testDir }, use) => {
+  electronApp: async ({ guiOwnerMode, breakTerminalSpawn, breakPlanningPresets, standaloneOwnerIdleTimeoutMs, repoConfig, testDir }, use) => {
     // Dummy `claude` on PATH + fix command — same as scripts/e2e-dry-run (no real CLI).
     const claudeMarker = path.join(repoRoot, 'scripts', 'e2e-dry-run', 'fixtures', 'claude-marker.sh');
     const stubDir = path.join(testDir, 'claude-stub');
@@ -185,8 +240,7 @@ exit 64
         INVOKER_ALLOW_DELETE_ALL: '1',
         INVOKER_E2E_ENABLE_COMPOSITOR: '1',
         INVOKER_REPO_CONFIG_PATH: configPath,
-        INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS:
-          process.env.INVOKER_E2E_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '10000',
+        INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS: standaloneOwnerIdleTimeoutMs,
         INVOKER_EMBEDDED_TERMINAL_BACKEND:
           process.env.INVOKER_E2E_EMBEDDED_TERMINAL_BACKEND ?? 'pty',
         INVOKER_E2E_MARKER_ROOT: markerRoot,
@@ -215,13 +269,15 @@ exit 64
       },
     });
     await use(app);
-    await app.close();
+    await closeElectronApp(app);
   },
 
-  page: async ({ electronApp }, use) => {
+  page: async ({ electronApp, guiOwnerMode }, use) => {
     const page = await electronApp.firstWindow();
-    await page.waitForLoadState('domcontentloaded');
-    await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10000 });
+    await waitForInvokerBridge(page);
+    if (guiOwnerMode === 'auto' || guiOwnerMode === 'daemon') {
+      await waitForRuntimeMode(page, 'daemon-owner', 30_000);
+    }
 
     // Clear state from previous runs and reload for clean React state
     await page.evaluate(async () => {
@@ -229,8 +285,10 @@ exit 64
     });
     await deleteAllWorkflowsFast(page);
     await page.reload();
-    await page.waitForLoadState('domcontentloaded');
-    await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10000 });
+    await waitForInvokerBridge(page);
+    if (guiOwnerMode === 'auto' || guiOwnerMode === 'daemon') {
+      await waitForRuntimeMode(page, 'daemon-owner', 30_000);
+    }
 
     await use(page);
     try {

--- a/packages/app/e2e/gap-recovery-bench.spec.ts
+++ b/packages/app/e2e/gap-recovery-bench.spec.ts
@@ -7,7 +7,7 @@ import { tmpdir } from 'node:os';
 import { stringify as yamlStringify } from 'yaml';
 import type { ElectronApplication, Page } from '@playwright/test';
 
-import { E2E_REPO_URL } from './fixtures/electron-app.js';
+import { closeElectronApp, E2E_REPO_URL, waitForInvokerBridge } from './fixtures/electron-app.js';
 import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
 
 const repoRoot = resolveRepoRoot(__dirname);
@@ -193,9 +193,8 @@ test('gap-recovery bench: 5 iterations of synthetic-gap → resync at 30 workflo
   try {
     const seedApp = await launchElectronApp(testDir);
     try {
-      const page = await seedApp.firstWindow({ timeout: 5000 });
-      await page.waitForLoadState('domcontentloaded');
-      await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 5000 });
+      const page = await seedApp.firstWindow({ timeout: 30_000 });
+      await waitForInvokerBridge(page);
 
       for (let index = 0; index < WORKFLOW_COUNT; index += 1) {
         const planYaml = yamlStringify(buildPlan(index));
@@ -208,7 +207,7 @@ test('gap-recovery bench: 5 iterations of synthetic-gap → resync at 30 workflo
       const seededTasks = Array.isArray(seeded) ? seeded : seeded.tasks;
       expect(seededTasks.length).toBe(expectedTaskCount);
     } finally {
-      await seedApp.close();
+      await closeElectronApp(seedApp);
     }
 
     const app = await launchElectronApp(testDir, {
@@ -216,8 +215,7 @@ test('gap-recovery bench: 5 iterations of synthetic-gap → resync at 30 workflo
     });
     try {
       const page = await app.firstWindow({ timeout: 60_000 });
-      await page.waitForLoadState('domcontentloaded');
-      await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 5000 });
+      await waitForInvokerBridge(page);
       await waitForWorkflowGraphVisible(page, 10000);
 
       await page.waitForTimeout(150);
@@ -269,7 +267,7 @@ test('gap-recovery bench: 5 iterations of synthetic-gap → resync at 30 workflo
 
       expect(iterations.length).toBe(ITERATIONS);
     } finally {
-      await app.close();
+      await closeElectronApp(app);
     }
   } finally {
     try {

--- a/packages/app/e2e/planning-chat-send-long-deadline.spec.ts
+++ b/packages/app/e2e/planning-chat-send-long-deadline.spec.ts
@@ -1,7 +1,7 @@
 import { stringify as yamlStringify } from 'yaml';
-import { test, expect, E2E_REPO_URL } from './fixtures/electron-app';
+import { test, expect, E2E_REPO_URL, waitForRuntimeMode } from './fixtures/electron-app';
 
-test.use({ guiOwnerMode: 'auto' });
+test.use({ guiOwnerMode: 'auto', standaloneOwnerIdleTimeoutMs: '90000' });
 
 const PLAN_YAML = yamlStringify({
   name: 'Long Deadline Proof Plan',
@@ -21,6 +21,7 @@ test('planning-chat-send survives a planner reply slower than the old 30s transp
   // This window is a delegate, not the owner: planningChatSend goes out over
   // the real IPC socket transport (headless.gui-mutation), the exact path
   // that used to hard-timeout at 30s regardless of how long the planner took.
+  await waitForRuntimeMode(page, 'daemon-owner', 30_000);
   const runtimeStatus = await page.evaluate(async () => window.invoker.getRuntimeStatus());
   expect(runtimeStatus.mode).toBe('daemon-owner');
 

--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -7,7 +7,7 @@ import { tmpdir } from 'node:os';
 import { stringify as yamlStringify } from 'yaml';
 import type { Page } from '@playwright/test';
 
-import { E2E_REPO_URL } from './fixtures/electron-app.js';
+import { closeElectronApp, E2E_REPO_URL, waitForInvokerBridge } from './fixtures/electron-app.js';
 import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
 import {
   activityLogWatermark,
@@ -146,9 +146,8 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
   try {
     const seedApp = await launchElectronApp(testDir);
     try {
-      const page = await seedApp.firstWindow({ timeout: 5000 });
-      await page.waitForLoadState('domcontentloaded');
-      await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 15_000 });
+      const page = await seedApp.firstWindow({ timeout: 30_000 });
+      await waitForInvokerBridge(page, 30_000);
 
       for (let index = 0; index < workflowCount; index += 1) {
         const planYaml = yamlStringify(buildPlan(index));
@@ -161,7 +160,7 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
       const seededTasks = Array.isArray(seeded) ? seeded : seeded.tasks;
       expect(seededTasks.length).toBe(expectedTaskCount);
     } finally {
-      await seedApp.close();
+      await closeElectronApp(seedApp);
     }
 
     const startedAt = Date.now();
@@ -169,12 +168,10 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
       INVOKER_TEST_RESUME_PENDING_DELAY_MS: '15000',
     });
     try {
-      const page = await app.firstWindow({ timeout: STARTUP_BUDGET_MS });
+      const page = await app.firstWindow({ timeout: 60_000 });
       const elapsedMs = Date.now() - startedAt;
-      await page.waitForLoadState('domcontentloaded');
-      await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10_000 });
-
-      await page.getByTestId('sidebar-planning').click();
+      await page.getByTestId('sidebar-planning').dispatchEvent('click', { bubbles: true, cancelable: true });
+      await waitForInvokerBridge(page, 30_000);
       await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible({ timeout: 10_000 });
       await waitForWorkflowGraphVisible(page, 5000);
       await dragGraphAndAssertViewportMoves(page);
@@ -263,7 +260,7 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
       expect(result.taskCount, startupEvidenceMessage).toBe(expectedTaskCount);
       expect(result.perf.dbPollCreated, startupEvidenceMessage).toBe(0);
     } finally {
-      await app.close();
+      await closeElectronApp(app);
     }
   } finally {
     rmSync(testDir, { recursive: true, force: true });
@@ -277,9 +274,8 @@ test('planning chat typing stays responsive with a large restored transcript', a
       INVOKER_TEST_RESUME_PENDING_DELAY_MS: '15000',
     });
     try {
-      const page = await app.firstWindow({ timeout: STARTUP_BUDGET_MS });
-      await page.waitForLoadState('domcontentloaded');
-      await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10_000 });
+      const page = await app.firstWindow({ timeout: 30_000 });
+      await waitForInvokerBridge(page, 30_000);
       await page.evaluate(async () => {
         await window.invoker.clear();
         await window.invoker.deleteAllWorkflows();
@@ -313,8 +309,7 @@ test('planning chat typing stays responsive with a large restored transcript', a
       expect(sessionId).toBeTruthy();
 
       await page.reload();
-      await page.waitForLoadState('domcontentloaded');
-      await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10_000 });
+      await waitForInvokerBridge(page, 30_000);
       await page.getByTestId('sidebar-home').click();
       await expect(page.getByTestId('invoker-terminal-input')).toBeVisible({ timeout: 10000 });
       await expect(page.getByTestId('invoker-terminal-transcript')).toContainText(
@@ -390,7 +385,7 @@ test('planning chat typing stays responsive with a large restored transcript', a
       expect(maxPayloadNumber(payloads, 'renderer_event_loop_lag', 'lagMs'), planningEvidenceMessage).toBeLessThanOrEqual(MAX_PLANNING_RENDERER_EVENT_LOOP_LAG_MS);
       expect(maxPayloadNumber(payloads, 'renderer_long_task', 'durationMs'), planningEvidenceMessage).toBeLessThanOrEqual(MAX_PLANNING_RENDERER_LONG_TASK_MS);
     } finally {
-      await app.close();
+      await closeElectronApp(app);
     }
   } finally {
     rmSync(testDir, { recursive: true, force: true });

--- a/packages/app/src/__tests__/window-lifecycle.test.ts
+++ b/packages/app/src/__tests__/window-lifecycle.test.ts
@@ -160,6 +160,10 @@ describe('window-lifecycle', () => {
     expect(options.skipTaskbar).toBe(true);
     expect(options.x).toBeUndefined();
     expect(options.y).toBeUndefined();
+    expect(electronMock.fakeWindow.show).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.focus).toHaveBeenCalledTimes(1);
+    expect(setUiInteractive).not.toHaveBeenCalled();
+    expect(recordStartupMark).toHaveBeenCalledWith('window.mapped');
 
     const readyHandler = electronMock.fakeWindow.once.mock.calls.find(([eventName]) => eventName === 'ready-to-show')?.[1];
     expect(readyHandler).toBeDefined();

--- a/packages/app/src/window/window-lifecycle.ts
+++ b/packages/app/src/window/window-lifecycle.ts
@@ -133,25 +133,50 @@ export function createMainWindow(deps: MainWindowLifecycleDeps): BrowserWindow {
 
   const shouldShowWindow = process.env.NODE_ENV !== 'test' || deps.enableTestCompositor;
   if (shouldShowWindow) {
+    let windowMapped = false;
     let showTriggered = false;
-    const showWindow = (): void => {
-      if (mainWindow.isDestroyed() || showTriggered) return;
-      showTriggered = true;
-      deps.logger.info(keepE2eWindowHidden ? 'main window ready while hidden' : 'main window show()', { module: 'window' });
-      deps.recordStartupMark(keepE2eWindowHidden ? 'window.hidden-ready' : 'window.show');
+    let showFallbackTimer: ReturnType<typeof setTimeout> | null = null;
+    const mapWindow = (): void => {
+      if (mainWindow.isDestroyed() || windowMapped) return;
+      windowMapped = true;
       if (keepE2eWindowHidden && deps.enableTestCompositor) {
         mainWindow.showInactive();
       } else if (!keepE2eWindowHidden) {
         mainWindow.show();
         mainWindow.focus();
       }
+    };
+    const recordWindowReady = (): void => {
+      deps.logger.info(keepE2eWindowHidden ? 'main window ready while hidden' : 'main window show()', { module: 'window' });
+      deps.recordStartupMark(keepE2eWindowHidden ? 'window.hidden-ready' : 'window.show');
+      mapWindow();
+    };
+    const showWindow = (): void => {
+      if (mainWindow.isDestroyed() || showTriggered) return;
+      showTriggered = true;
+      if (showFallbackTimer) {
+        clearTimeout(showFallbackTimer);
+        showFallbackTimer = null;
+      }
+      recordWindowReady();
       deps.setUiInteractive(true);
       deps.recordStartupMark('ui.interactive');
       deps.startDeferredStartupWork();
     };
 
+    if (deps.enableTestCompositor && !keepE2eWindowHidden) {
+      deps.logger.info('main window mapped early for e2e compositor', { module: 'window' });
+      deps.recordStartupMark('window.mapped');
+      mapWindow();
+    }
     mainWindow.once('ready-to-show', showWindow);
-    setTimeout(showWindow, 1500).unref?.();
+    showFallbackTimer = setTimeout(showWindow, 1500);
+    mainWindow.on('closed', () => {
+      if (showFallbackTimer) {
+        clearTimeout(showFallbackTimer);
+        showFallbackTimer = null;
+      }
+    });
   } else {
     deps.setUiInteractive(true);
     deps.recordStartupMark('ui.interactive');


### PR DESCRIPTION
## Summary

CI job `playwright / 5-of-9` first went red at default-branch push d19a0f4af741226c3edb9509e2768529bf97fef9. Its Electron specs timed out waiting for the app's first window.

Under the e2e compositor the main window now maps as soon as it is created, without waiting for `ready-to-show`, so Playwright's `firstWindow` resolves promptly.

The e2e fixture gains shared helpers that wait for the preload bridge and for daemon-owner mode, giving every spec the same generous startup waits.

App shutdown in e2e now escalates from `app.close()` to SIGTERM and then SIGKILL, and the 1500 ms show-fallback timer is cleared when the window closes.

## Review Claim

Under the e2e compositor the app window maps early and e2e startup waits are uniform; window behavior outside e2e runs is unchanged.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

When `enableTestCompositor` is off, `showWindow` still runs exactly once on `ready-to-show` or the 1500 ms fallback, with the same startup marks and ordering as before; the early map path exists only for e2e runs.

## Slice Rationale

One review unit per PR: this slice carries the window-map fix plus the e2e harness hardening that exercises it; the CI shard matrix edit follows in the next PR.

## Non-goals

- No change to window show timing outside the e2e compositor.
- No edits to `.github/workflows/ci.yml` in this PR; the shard matrix change is the next slice.
- No weakening of assertions; startup waits were made uniform, not removed.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-5-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/autofix-worker-ui.spec.ts e2e/orphan-relaunch.spec.ts e2e/gap-recovery-bench.spec.ts e2e/planning-chat-send-long-deadline.spec.ts e2e/system-setup-visual-proof.spec.ts e2e/startup-nonempty-responsiveness.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` (exit 0, run by workflow task `wf-1785689145355-6/verify-ci-d19a0f4-playwright-5-of-9`)

</details>

## Visual Proof

The app window mapped under the e2e compositor on this branch, captured by `system-setup-visual-proof.spec.ts` reaching the System Setup surface:

![System Setup surface visible in the mapped e2e window](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260802-736508/system-setup-handoff-helper-modal.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <squash-sha-of-this-pr>`
- Post-revert steps: None
- Data migration? No

</details>
