### PR TITLE
[Lease-aware disk-headroom reaper](1) liveness module

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-headroom-liveness.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-liveness.test.ts
@@ -1,0 +1,54 @@
+import { resolve } from 'node:path';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { computeRepoCacheHash } from '../git-utils.js';
+import {
+  computeProtectedInvokerPaths,
+  type DiskHeadroomLivenessStore,
+} from '../workers/disk-headroom-liveness.js';
+
+describe('computeProtectedInvokerPaths', () => {
+  it('protects repo cache and workspace paths for failed tasks', () => {
+    const repoUrl = 'https://github.com/example/invoker-fixture.git';
+    const workspacePath = 'relative/worktree/path';
+    const store = {
+      listWorkflows: () => [{ id: 'wf-live', repoUrl }],
+      loadTasks: () => [{ status: 'failed', execution: { workspacePath } }],
+    } satisfies DiskHeadroomLivenessStore;
+
+    const result = computeProtectedInvokerPaths(store);
+
+    expect(result.protectedRepoHashes).toEqual(new Set([computeRepoCacheHash(repoUrl)]));
+    expect(result.protectedWorkspacePaths).toEqual(new Set([resolve(workspacePath)]));
+  });
+
+  it('does not protect paths for workflows whose only task is completed', () => {
+    const store = {
+      listWorkflows: () => [{ id: 'wf-complete', repoUrl: 'https://github.com/example/complete.git' }],
+      loadTasks: () => [{ status: 'completed', execution: { workspacePath: '/tmp/completed-worktree' } }],
+    } satisfies DiskHeadroomLivenessStore;
+
+    const result = computeProtectedInvokerPaths(store);
+
+    expect(result.protectedRepoHashes).toEqual(new Set());
+    expect(result.protectedWorkspacePaths).toEqual(new Set());
+  });
+
+  it('returns empty sets when workflow listing throws', () => {
+    const error = new Error('store unavailable');
+    const logger = { warn: vi.fn() };
+    const store = {
+      listWorkflows: () => {
+        throw error;
+      },
+      loadTasks: () => [{ status: 'failed' }],
+    } satisfies DiskHeadroomLivenessStore;
+
+    const result = computeProtectedInvokerPaths(store, { logger });
+
+    expect(result.protectedRepoHashes).toEqual(new Set());
+    expect(result.protectedWorkspacePaths).toEqual(new Set());
+    expect(logger.warn).toHaveBeenCalledWith('Failed to compute disk-headroom liveness paths', error);
+  });
+});

--- a/packages/execution-engine/src/workers/disk-headroom-liveness.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-liveness.ts
@@ -1,0 +1,46 @@
+import { resolve } from 'node:path';
+
+import { computeRepoCacheHash } from '../git-utils.js';
+
+export interface DiskHeadroomLivenessStore {
+  listWorkflows(): ReadonlyArray<{ id: string; repoUrl?: string }>;
+  loadTasks(workflowId: string): ReadonlyArray<{
+    status: string;
+    execution?: { workspacePath?: string };
+  }>;
+}
+
+export const TERMINAL_TASK_STATUSES = ['completed', 'closed', 'stale'] as const;
+
+const TERMINAL_TASK_STATUS_SET = new Set<string>(TERMINAL_TASK_STATUSES);
+
+export function computeProtectedInvokerPaths(
+  store: DiskHeadroomLivenessStore,
+  opts?: { logger?: { warn?: (msg: string, meta?: unknown) => void } },
+): { protectedRepoHashes: Set<string>; protectedWorkspacePaths: Set<string> } {
+  try {
+    const protectedRepoHashes = new Set<string>();
+    const protectedWorkspacePaths = new Set<string>();
+
+    for (const workflow of store.listWorkflows()) {
+      for (const task of store.loadTasks(workflow.id)) {
+        if (TERMINAL_TASK_STATUS_SET.has(task.status)) {
+          continue;
+        }
+
+        if (workflow.repoUrl) {
+          protectedRepoHashes.add(computeRepoCacheHash(workflow.repoUrl));
+        }
+
+        if (task.execution?.workspacePath) {
+          protectedWorkspacePaths.add(resolve(task.execution.workspacePath));
+        }
+      }
+    }
+
+    return { protectedRepoHashes, protectedWorkspacePaths };
+  } catch (err) {
+    opts?.logger?.warn?.('Failed to compute disk-headroom liveness paths', err);
+    return { protectedRepoHashes: new Set(), protectedWorkspacePaths: new Set() };
+  }
+}


### PR DESCRIPTION
## Summary

Adds a pure liveness module for the disk-headroom reaper.

Future reaper slices can ask it which Invoker repo caches and workspaces are still active.

Nothing calls the module yet, so this slice does not change reaper behavior.

## Review Claim

Add `computeProtectedInvokerPaths` as a dormant, side-effect-free liveness calculation for Invoker repo caches and workspaces.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Pure function only. It performs no filesystem, process, or network work, and no reaper code calls it in this slice.

## Slice Rationale

This isolates the liveness answer from the later local and remote reaper wiring, so reviewers can check the rule before any caller uses it.

## Non-goals

- No filesystem access.
- No child process or network access.
- No changes to `disk-headroom-reclaim.ts`, `disk-headroom-worker.ts`, or remote SSH reaper behavior.
- No changes to existing store types or worker dependency wiring.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/disk-headroom-liveness.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert a020c2de4`
- Post-revert steps: None.
- Data migration? No.

</details>
