### PR TITLE
[Bugfix: stale-generation worker responses must be discarded](1)[REFACTOR: Extract Method] Name worker response generation guard

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { reconciliationNeedsInputWorkResponse } from './reconciliation-needs-input-shim.js';
 import { rid, sid } from './scoped-test-helpers.js';
-import { Orchestrator, PlanConflictError, descriptionForMergeNode } from '../orchestrator.js';
+import { Orchestrator, PlanConflictError, descriptionForMergeNode, isWorkerResponseGenerationValid } from '../orchestrator.js';
 import type { PlanDefinition, OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
 import { computeWorkflowRollup } from '../task-types.js';
 import type { TaskState, TaskDelta, TaskStateChanges, Attempt, ExternalDependency, ExternalDependencyChange } from '../task-types.js';
@@ -7305,6 +7305,10 @@ describe('Orchestrator', () => {
     });
 
     it('rejects stale attempt and generation responses after retry refreshes attempts', () => {
+      expect(isWorkerResponseGenerationValid(makeResponse({ executionGeneration: 2 }), 2)).toBe(true);
+      expect(isWorkerResponseGenerationValid(makeResponse({ executionGeneration: 1 }), 2)).toBe(false);
+      expect(isWorkerResponseGenerationValid({ executionGeneration: undefined }, 2)).toBe(true);
+
       orchestrator.loadPlan({
         name: 'retry-stale-response-rejection',
         tasks: [{ id: 't1', description: 'Task 1' }],

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -64,6 +64,13 @@ export class OrchestratorError extends Error {
   }
 }
 
+export function isWorkerResponseGenerationValid(
+  response: { executionGeneration?: WorkResponse['executionGeneration'] },
+  activeGeneration: number,
+): boolean {
+  return response.executionGeneration === undefined || response.executionGeneration === activeGeneration;
+}
+
 function isActiveForInvalidation(status: TaskStatus): boolean {
   return (
     status === 'running' ||
@@ -1529,10 +1536,7 @@ export class Orchestrator {
           return [];
         }
         const activeGeneration = this.getExecutionGeneration(earlyTask);
-        if (
-          response.executionGeneration !== undefined &&
-          response.executionGeneration !== activeGeneration
-        ) {
+        if (!isWorkerResponseGenerationValid(response, activeGeneration)) {
           this.logger.warn('[worker-response] STALE_GENERATION_REJECTED', {
             taskId: earlyTask.id,
             responseGeneration: response.executionGeneration,


### PR DESCRIPTION
## Summary

The worker-response generation fence already exists. This slice names it as `isWorkerResponseGenerationValid` and keeps the same call-site behavior.

The regression test now also calls the guard directly, so future callers have a standalone oracle for the discard rule.

## Review Claim

The existing worker-response generation comparison now lives in a named exported guard, and the orchestrator still discards exactly the same mismatched responses.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

The guard returns the exact same boolean as the negated inline stale-generation condition for every response and active generation.

The only orchestrator call site still returns early on the same mismatched-generation cases as before.

## Slice Rationale

One routing slice keeps the invariant reviewable locally: name the generation fence, replace the one inline comparison, and add direct assertions beside the existing regression.

## Non-goals

No behavior change.

No changes to generation bumping, retry, recreate, attempt matching, stale-attempt handling, logging, or worker-response application after the guard passes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --dir packages/workflow-core test -- -t "rejects stale attempt and generation responses after retry refreshes attempts"` (passes; Vitest completed 39 files, 864 tests passed, 3 skipped)
- [x] `node scripts/validate-pr-body-local.mjs --body-file .pr-body-generation-fence.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5810fc44f`
- Post-revert steps: None
- Data migration? No

</details>
