### PR TITLE
[Bugfix: stale-generation worker responses must be discarded](1)[REFACTOR: Extract Function] Name worker generation guard

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { reconciliationNeedsInputWorkResponse } from './reconciliation-needs-input-shim.js';
 import { rid, sid } from './scoped-test-helpers.js';
-import { Orchestrator, PlanConflictError, descriptionForMergeNode } from '../orchestrator.js';
+import { Orchestrator, PlanConflictError, descriptionForMergeNode, isWorkerResponseGenerationValid } from '../orchestrator.js';
 import type { PlanDefinition, OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
 import { computeWorkflowRollup } from '../task-types.js';
 import type { TaskState, TaskDelta, TaskStateChanges, Attempt, ExternalDependency, ExternalDependencyChange } from '../task-types.js';
@@ -7305,6 +7305,13 @@ describe('Orchestrator', () => {
     });
 
     it('rejects stale attempt and generation responses after retry refreshes attempts', () => {
+      const generationlessResponse = makeResponse({});
+      delete generationlessResponse.executionGeneration;
+
+      expect(isWorkerResponseGenerationValid(makeResponse({ executionGeneration: 2 }), 2)).toBe(true);
+      expect(isWorkerResponseGenerationValid(makeResponse({ executionGeneration: 1 }), 2)).toBe(false);
+      expect(isWorkerResponseGenerationValid(generationlessResponse, 2)).toBe(true);
+
       orchestrator.loadPlan({
         name: 'retry-stale-response-rejection',
         tasks: [{ id: 't1', description: 'Task 1' }],

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -73,6 +73,10 @@ function isActiveForInvalidation(status: TaskStatus): boolean {
   );
 }
 
+export function isWorkerResponseGenerationValid(response: WorkResponse, activeGeneration: number): boolean {
+  return response.executionGeneration === undefined || response.executionGeneration === activeGeneration;
+}
+
 import { getTransitiveDependents } from '@invoker/workflow-graph';
 import { ActionGraph } from '@invoker/workflow-graph';
 import {
@@ -1529,10 +1533,7 @@ export class Orchestrator {
           return [];
         }
         const activeGeneration = this.getExecutionGeneration(earlyTask);
-        if (
-          response.executionGeneration !== undefined &&
-          response.executionGeneration !== activeGeneration
-        ) {
+        if (!isWorkerResponseGenerationValid(response, activeGeneration)) {
           this.logger.warn('[worker-response] STALE_GENERATION_REJECTED', {
             taskId: earlyTask.id,
             responseGeneration: response.executionGeneration,


### PR DESCRIPTION
Name the existing worker response generation guard and keep behavior unchanged.

The regression command remains: cd packages/workflow-core && pnpm test -- -t "rejects stale attempt and generation responses after retry refreshes attempts".