### PR TITLE
[Bugfix: stale-generation worker responses must be discarded](1)[REFACTOR: Extract Function] Name worker generation guard

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { reconciliationNeedsInputWorkResponse } from './reconciliation-needs-input-shim.js';
 import { rid, sid } from './scoped-test-helpers.js';
-import { Orchestrator, PlanConflictError, descriptionForMergeNode } from '../orchestrator.js';
+import { Orchestrator, PlanConflictError, descriptionForMergeNode, isWorkerResponseGenerationValid } from '../orchestrator.js';
 import type { PlanDefinition, OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
 import { computeWorkflowRollup } from '../task-types.js';
 import type { TaskState, TaskDelta, TaskStateChanges, Attempt, ExternalDependency, ExternalDependencyChange } from '../task-types.js';
@@ -7323,9 +7323,13 @@ describe('Orchestrator', () => {
       orchestrator.retryWorkflow(orchestrator.getWorkflowIds()[0]!);
       const activeTask = orchestrator.getTask(taskId)!;
       const activeAttemptId = activeTask.execution.selectedAttemptId!;
+      const activeGeneration = activeTask.execution.generation ?? 0;
 
       expect(activeAttemptId).not.toBe(staleAttemptId);
       expect(activeTask.status).toBe('running');
+      expect(isWorkerResponseGenerationValid(makeResponse({ executionGeneration: activeGeneration }), activeGeneration)).toBe(true);
+      expect(isWorkerResponseGenerationValid(makeResponse({ executionGeneration: staleGeneration }), activeGeneration)).toBe(false);
+      expect(isWorkerResponseGenerationValid(makeResponse({ executionGeneration: undefined }), activeGeneration)).toBe(true);
 
       const staleAttemptResult = orchestrator.handleWorkerResponse(
         makeResponse({

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -207,6 +207,10 @@ function nextLeaseExpiry(from: Date): Date {
   return new Date(from.getTime() + ATTEMPT_LEASE_MS);
 }
 
+export function isWorkerResponseGenerationValid(response: WorkResponse, activeGeneration: number): boolean {
+  return response.executionGeneration === undefined || response.executionGeneration === activeGeneration;
+}
+
 // ── Errors ──────────────────────────────────────────────────
 
 export class PlanConflictError extends Error {
@@ -1529,10 +1533,7 @@ export class Orchestrator {
           return [];
         }
         const activeGeneration = this.getExecutionGeneration(earlyTask);
-        if (
-          response.executionGeneration !== undefined &&
-          response.executionGeneration !== activeGeneration
-        ) {
+        if (!isWorkerResponseGenerationValid(response, activeGeneration)) {
           this.logger.warn('[worker-response] STALE_GENERATION_REJECTED', {
             taskId: earlyTask.id,
             responseGeneration: response.executionGeneration,


### PR DESCRIPTION
## Summary

Worker replies already carry an execution generation.

The orchestrator already drops a reply when that value conflicts with the task's current generation.

This names the existing decision as `isWorkerResponseGenerationValid` and keeps the call site behavior unchanged.

The regression test now checks the named guard directly and still covers the full orchestrator path.

## Review Claim

Approve one named generation guard in the orchestrator response path with the same truth table as the prior inline check.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

The guard returns true exactly when the prior inline condition would have allowed the worker response to continue, including generationless responses.

## Slice Rationale

This slice only names the existing response-path decision so future callers and tests can use one shared oracle.

## Non-goals

No behavior change.

No new fields, no retry/reset/recreate behavior changes, and no changes to what happens after the response is discarded or applied.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-core && pnpm test -- -t "rejects stale attempt and generation responses after retry refreshes attempts"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
