### PR TITLE
[Requeue Worker Ownership Boundary](1) Enforce the requeue worker never claims an infra-repair-owned failure class

### DIFF
--- a/packages/execution-engine/src/__tests__/requeue-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/requeue-worker.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { WorkflowMutationIntent, WorkflowMutationPriority } from '@invoker/data-store';
-import type { TaskState } from '@invoker/workflow-core';
+import { SSH_INFRA_FAILURE_CLASSES, type TaskState } from '@invoker/workflow-core';
 
 import { createRequeueAttemptLedger } from '../requeue-attempt-ledger.js';
 import {
@@ -135,6 +135,28 @@ describe('requeue worker tick', () => {
     const h = harness(makeTask({ execution: { failureClass: undefined, error: 'real bug', generation: 2 } }));
     await h.tick(POLL_CTX);
     expect(h.submit).not.toHaveBeenCalled();
+  });
+
+  it('never lists an infra-repair-owned SSH failure class as a requeue candidate', () => {
+    // Ownership boundary: SSH infra failures (worktree-missing, oauth-expired,
+    // repo-mirror-corrupt, ...) are the infra-repair worker's job to alert on,
+    // not the requeue worker's job to blindly resubmit. Retrying a task whose
+    // failure is an environment/credential problem just re-fails it and burns
+    // the requeue budget before an operator ever sees it. This runs against
+    // every class the classifier currently knows about, so a future SSH infra
+    // class added to that list is covered automatically.
+    for (const failureClass of SSH_INFRA_FAILURE_CLASSES) {
+      const infraTask = makeTask({
+        id: `wf-1/${failureClass}`,
+        execution: { failureClass, error: `simulated ${failureClass}`, generation: 1 },
+      });
+      const candidates = listRequeueScanCandidates({
+        listWorkflows: () => [{ id: 'wf-1' }],
+        loadTasks: () => [infraTask],
+        listWorkflowMutationIntents: () => [],
+      });
+      expect(candidates).toEqual([]);
+    }
   });
 
   it('ignores a task that is no longer failed', async () => {


### PR DESCRIPTION
## Summary

The requeue worker and the infra-repair worker keep separate failure classes: liveness_stall belongs to the requeue worker, every SSH infra class belongs to the infra-repair worker.

A PR widening the requeue worker's candidate set to include ssh-oauth-session-expired was closed in review. Trying again after an expired credential just fails the same way and spends down the requeue budget first.

This adds a regression test that locks in that boundary so it can't quietly change again.

## Review Claim

Approve one new test in requeue-worker.test.ts: `listRequeueScanCandidates` never returns a task whose failure class is in the exported `SSH_INFRA_FAILURE_CLASSES` array.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Purely additive to a test file; no product code changes, so nothing can change at runtime from this PR itself. The test runs against the classifier's exported class array rather than one hardcoded name, so a new SSH infra class added later is covered automatically.

## Slice Rationale

Standalone: this locks in a boundary that already exists in the code (`FailureClassifier.isLiveness` / `isSshInfra`), independent of any other in-flight change.

## Non-goals

Does not change requeue-worker.ts, auto-fix-gating.ts, or the failure classifier. Does not add infra-repair-worker coverage (already covered elsewhere).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/requeue-worker.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7d2de512e`
- Post-revert steps: None
- Data migration? No

</details>
