### PR TITLE
[Launch-Dispatch Stuck-Lease Storm](1) Add MAX_STUCK_LEASE_RETRIES contract constant

### DIFF
--- a/packages/contracts/src/launch-timeouts.ts
+++ b/packages/contracts/src/launch-timeouts.ts
@@ -16,3 +16,17 @@ export const DISPATCH_LEASE_MS = 12 * 60 * 1000;
 export const LAUNCH_STUCK_ABANDON_MS = DISPATCH_LEASE_MS;
 
 export const DISPATCH_MAX_ATTEMPTS = 3;
+
+/**
+ * Hard cap on how many times `abandonStuckLeases` may prepare a fresh
+ * attempt for the SAME task before giving up instead of retrying again.
+ *
+ * `DISPATCH_MAX_ATTEMPTS` does not bound this loop: `prepareTaskForNewAttempt`
+ * creates a brand-new `task_launch_dispatch` row with `attempts_count` back
+ * at 0, so the per-row attempt budget never accumulates across cycles. If a
+ * task's real work legitimately runs longer than `LAUNCH_STUCK_ABANDON_MS`
+ * (e.g. waiting on a slow CI run), the age-based clause alone keeps firing
+ * forever with no other stopper (see incident 2026-08-02: one task retried
+ * 78 times in 24h on a fixed ~12-minute cadence because of this).
+ */
+export const MAX_STUCK_LEASE_RETRIES = 5;


### PR DESCRIPTION
## Summary

Adds `MAX_STUCK_LEASE_RETRIES`, a new constant capping how many times the launch-dispatch reaper may relaunch a task before giving up.

No code reads this constant yet. It lands first so the fix that consumes it, later in this stack, is a small and reviewable diff.

## Review Claim

Approve adding an unused, documented constant to `@invoker/contracts`.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Nothing imports or reads this constant yet, so this slice cannot change any runtime behavior.

## Slice Rationale

The relaunch-cap fix later in this stack needs this constant. Landing it separately keeps that fix's diff limited to the actual cap-enforcement logic, and keeps this contract-only change reviewable on its own.

## Non-goals

Does not wire the constant into `abandonStuckLeases` or any other caller. Does not change `DISPATCH_MAX_ATTEMPTS`, `DISPATCH_LEASE_MS`, or `LAUNCH_STUCK_ABANDON_MS`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/contracts build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>