### PR TITLE
[Launch-Dispatch Stuck-Lease Storm](2) Add test-only timing and fault-injection knobs for the launch-dispatch reaper

### DIFF
--- a/packages/app/src/launch-dispatch-defaults.ts
+++ b/packages/app/src/launch-dispatch-defaults.ts
@@ -1,0 +1,13 @@
+/**
+ * Test-only override for DISPATCH_LEASE_MS / LAUNCH_STUCK_ABANDON_MS (both
+ * 12 minutes in production, see @invoker/contracts launch-timeouts.ts).
+ * Lets e2e tests exercise the stuck-launch reaper in seconds instead of
+ * real minutes, the same way INVOKER_EXECUTING_STALL_TIMEOUT_MS does for
+ * the separate executing-stall watchdog.
+ */
+export function resolveLaunchDispatchLeaseMsOverride(): number | undefined {
+  const raw = process.env.INVOKER_LAUNCH_DISPATCH_LEASE_MS;
+  if (!raw) return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -11,6 +11,7 @@ import type { SQLiteAdapter, TaskLaunchDispatch } from '@invoker/data-store';
 import type { LaunchOutboxAck } from '@invoker/execution-engine';
 import type { TaskLaunchReadiness, TaskState } from '@invoker/workflow-core';
 import { DISPATCH_MAX_ATTEMPTS, LAUNCH_STUCK_ABANDON_MS, type Logger } from '@invoker/contracts';
+import { resolveLaunchDispatchLeaseMsOverride } from './launch-dispatch-defaults.js';
 
 
 export type LaunchDispatcherPersistence = Pick<
@@ -80,6 +81,13 @@ export interface LaunchDispatcherOptions {
   maxAttempts?: number;
   maxLeasesPerPoll?: number;
   topUpReadyLaunchesEnabled?: () => boolean;
+  /**
+   * Overrides for DISPATCH_LEASE_MS / LAUNCH_STUCK_ABANDON_MS (both default
+   * to 12 minutes in production). Test-only knob so e2e tests can exercise
+   * the stuck-launch reaper in seconds instead of real minutes.
+   */
+  leaseMs?: number;
+  maxLaunchAgeMs?: number;
 }
 
 
@@ -92,6 +100,8 @@ export class LaunchDispatcher {
   private readonly maxAttempts: number;
   private readonly maxLeasesPerPoll: number;
   private readonly topUpReadyLaunchesEnabled?: () => boolean;
+  private readonly leaseMs?: number;
+  private readonly maxLaunchAgeMs: number;
 
   constructor(options: LaunchDispatcherOptions) {
     this.persistence = options.persistence;
@@ -101,6 +111,8 @@ export class LaunchDispatcher {
     this.logger = options.logger;
     this.maxAttempts = options.maxAttempts ?? DISPATCH_MAX_ATTEMPTS;
     this.topUpReadyLaunchesEnabled = options.topUpReadyLaunchesEnabled;
+    this.leaseMs = options.leaseMs ?? resolveLaunchDispatchLeaseMsOverride();
+    this.maxLaunchAgeMs = options.maxLaunchAgeMs ?? resolveLaunchDispatchLeaseMsOverride() ?? LAUNCH_STUCK_ABANDON_MS;
     // Bound a single poll's work so the dispatcher cannot starve other
     // owner-loop ticks; the leftover rows are picked up on the next tick.
     this.maxLeasesPerPoll = options.maxLeasesPerPoll ?? 32;
@@ -242,6 +254,7 @@ export class LaunchDispatcher {
     while (dispatched < this.maxLeasesPerPoll) {
       const leased = this.persistence.claimLaunchDispatchAtomic({
         ownerId: this.ownerId,
+        ...(this.leaseMs !== undefined ? { leaseMs: this.leaseMs } : {}),
       });
       if (!leased) break;
       dispatched += 1;
@@ -396,7 +409,7 @@ export class LaunchDispatcher {
     const candidates = this.persistence.listAbandonableLaunchDispatchLeases({
       nowIso,
       maxAttempts: this.maxAttempts,
-      maxLaunchAgeMs: LAUNCH_STUCK_ABANDON_MS,
+      maxLaunchAgeMs: this.maxLaunchAgeMs,
     });
     if (candidates.length === 0) return 0;
     let abandoned = 0;

--- a/packages/contracts/src/launch-timeouts.ts
+++ b/packages/contracts/src/launch-timeouts.ts
@@ -16,3 +16,17 @@ export const DISPATCH_LEASE_MS = 12 * 60 * 1000;
 export const LAUNCH_STUCK_ABANDON_MS = DISPATCH_LEASE_MS;
 
 export const DISPATCH_MAX_ATTEMPTS = 3;
+
+/**
+ * Hard cap on how many times `abandonStuckLeases` may prepare a fresh
+ * attempt for the SAME task before giving up instead of retrying again.
+ *
+ * `DISPATCH_MAX_ATTEMPTS` does not bound this loop: `prepareTaskForNewAttempt`
+ * creates a brand-new `task_launch_dispatch` row with `attempts_count` back
+ * at 0, so the per-row attempt budget never accumulates across cycles. If a
+ * task's real work legitimately runs longer than `LAUNCH_STUCK_ABANDON_MS`
+ * (e.g. waiting on a slow CI run), the age-based clause alone keeps firing
+ * forever with no other stopper (see incident 2026-08-02: one task retried
+ * 78 times in 24h on a fixed ~12-minute cadence because of this).
+ */
+export const MAX_STUCK_LEASE_RETRIES = 5;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3619,10 +3619,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
   claimLaunchDispatchAtomic(options: {
     ownerId: string;
     nowIso?: string;
+    leaseMs?: number;
   }): TaskLaunchDispatch | undefined {
     const now = options.nowIso ?? new Date().toISOString();
     const fencedUntil = new Date(
-      new Date(now).getTime() + DISPATCH_LEASE_MS,
+      new Date(now).getTime() + (options.leaseMs ?? DISPATCH_LEASE_MS),
     ).toISOString();
     return this.runTransaction(() => {
       while (true) {

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -118,6 +118,14 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
   }
 
   async start(request: WorkRequest): Promise<ExecutorHandle> {
+    // Test-only fault injection: hang before doing any real work, so e2e
+    // tests can exercise a launch that genuinely never completes handoff
+    // (mirrors INVOKER_E2E_BREAK_TERMINAL_SPAWN's pattern). Never set
+    // outside a controlled test process.
+    const hangMs = Number.parseInt(process.env.INVOKER_E2E_HANG_LAUNCH_STARTUP_MS ?? '', 10);
+    if (Number.isFinite(hangMs) && hangMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, hangMs));
+    }
     const repoUrl = request.inputs.repoUrl;
     if (!repoUrl) {
       throw new Error(


### PR DESCRIPTION
## Summary

Adds test-only knobs so tests can shrink the launch-dispatch reaper's 12-minute stuck-launch window to seconds, and make a task's executor startup hang on demand.

Both are dormant by default. `INVOKER_LAUNCH_DISPATCH_LEASE_MS` overrides the lease/stuck-launch duration only when set. `INVOKER_E2E_HANG_LAUNCH_STARTUP_MS` only delays `WorktreeExecutor.start()` when set, mirroring the existing `INVOKER_E2E_BREAK_TERMINAL_SPAWN` fault-injection pattern.

Real e2e proof of the actual bug needs the reaper's real 12-minute window compressed into a test-sized window. This slice lands that plumbing before any test uses it.

## Review Claim

Approve two dormant-by-default test knobs on the launch-dispatch reaper and the worktree executor's startup path.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`INVOKER_LAUNCH_DISPATCH_LEASE_MS` and `INVOKER_E2E_HANG_LAUNCH_STARTUP_MS` are read only from `process.env`; when unset (the case for every real deployment), `LaunchDispatcher.leaseMs` stays `undefined`, `maxLaunchAgeMs` still resolves to `LAUNCH_STUCK_ABANDON_MS`, and `WorktreeExecutor.start()` skips the hang branch entirely. No production code path changes.

## Slice Rationale

The e2e proofs later in this stack need these knobs to run in seconds instead of real minutes. Landing them as their own foundation slice keeps the proof and fix slices focused on their actual claims instead of mixing in test-harness plumbing.

## Non-goals

Does not change `LAUNCH_STUCK_ABANDON_MS`, `DISPATCH_LEASE_MS`, or any default timing value. Does not change `abandonStuckLeases`'s abandon logic -- `maxLaunchAgeMs` still evaluates to the same constant it always did unless a test sets the env var. Does not add any e2e test yet.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/execution-engine build`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/launch-dispatcher.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/worktree-executor.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7216