### PR TITLE
[Launch-Dispatch Stuck-Lease Storm](4) Stop relaunching a task once its executor is confirmed live

### DIFF
--- a/packages/app/e2e/launch-dispatch-stuck-lease-storm.spec.ts
+++ b/packages/app/e2e/launch-dispatch-stuck-lease-storm.spec.ts
@@ -99,11 +99,7 @@ async function waitForTask(
 }
 
 base.describe('Launch-dispatch stuck-lease reaper', () => {
-  // Expected to fail until the next slice in this stack lands
-  // acceptDispatch(): completeDispatch() currently only fires once a
-  // task's WHOLE run finishes, so LAUNCH_STUCK_ABANDON_MS (shrunk here)
-  // wrongly treats a still-running, still-healthy task as stuck in launch.
-  base.fail('does not tear down a healthy task that outlives the stuck-launch window', async () => {
+  base('does not tear down a healthy task that outlives the stuck-launch window', async () => {
     // Shrunk to 3s (production default is 12 minutes) so the reaper's
     // 2s poll tick gets at least one real chance to misfire within the
     // test's window if the bug is present.

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -17,6 +17,7 @@ import { resolveLaunchDispatchLeaseMsOverride } from './launch-dispatch-defaults
 export type LaunchDispatcherPersistence = Pick<
   SQLiteAdapter,
   | 'loadLaunchDispatchById'
+  | 'markLaunchDispatchAccepted'
   | 'markLaunchDispatchCompleted'
   | 'markLaunchDispatchFailed'
   | 'markLaunchDispatchAbandoned'
@@ -550,10 +551,29 @@ export class LaunchDispatcher {
   }
 
   /**
-   * Transition a live dispatch row to completed. Called by the
-   * TaskRunner once {@link markTaskRunningAfterLaunch} has succeeded
-   * (the executor handle is live and the task is in the executing
-   * phase). Returns false when the row is already terminal.
+   * Record that the launch handoff succeeded. Called by the TaskRunner
+   * once {@link markTaskRunningAfterLaunch} has succeeded (the executor
+   * handle is live and the task is in the executing phase). This stops
+   * `abandonStuckLeases`'s age check from treating the row as stuck in
+   * launch -- it does NOT complete the row, since headless run/resume
+   * polls dispatch completion to mean the task's work is actually done.
+   * Returns false when the row is no longer leased (already terminal).
+   */
+  acceptDispatch(dispatchId: number): boolean {
+    const ok = this.persistence.markLaunchDispatchAccepted(dispatchId);
+    this.logger?.info?.('[launch-dispatcher] accepted', {
+      ownerId: this.ownerId,
+      dispatchId,
+      accepted: ok,
+      module: 'launch-dispatcher',
+    });
+    return ok;
+  }
+
+  /**
+   * Transition a live dispatch row to completed once the task's whole
+   * run finishes (called from TaskRunner's onComplete finalization).
+   * Returns false when the row is already terminal.
    */
   completeDispatch(dispatchId: number): boolean {
     const ok = this.persistence.markLaunchDispatchCompleted(dispatchId);

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3726,6 +3726,30 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return (this.db.getRowsModified?.() ?? 0) > 0;
   }
 
+  /**
+   * Record that the launch handoff for this row succeeded (the executor is
+   * confirmed live). Reuses the `acknowledged_at` column, which has been
+   * unused dead weight since the acknowledged-state removal in migration
+   * work (see sqlite-migrations.ts) -- no schema change needed.
+   *
+   * This is intentionally separate from markLaunchDispatchCompleted: that
+   * one only fires once the task's whole run finishes (needed by headless
+   * run/resume polling), so it cannot double as a "did launch succeed"
+   * signal. listAbandonableLaunchDispatchLeases uses acknowledged_at to
+   * stop treating a row as stuck-in-launch once it's actually launched.
+   */
+  markLaunchDispatchAccepted(id: number, nowIso?: string): boolean {
+    const now = nowIso ?? new Date().toISOString();
+    this.execRun(
+      `UPDATE task_launch_dispatch
+         SET acknowledged_at = COALESCE(acknowledged_at, ?)
+       WHERE id = ?
+         AND state = 'leased'`,
+      [now, id],
+    );
+    return (this.db.getRowsModified?.() ?? 0) > 0;
+  }
+
   markLaunchDispatchFailed(
     id: number,
     errorMessage: string,
@@ -3761,7 +3785,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
            AND fenced_until < ?
            AND (
              attempts_count >= ?
-             OR (? IS NOT NULL AND enqueued_at <= ?)
+             OR (acknowledged_at IS NULL AND ? IS NOT NULL AND enqueued_at <= ?)
            )
          ORDER BY id ASC`,
       [now, options.maxAttempts, ageCutoff, ageCutoff],

--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -126,14 +126,21 @@ function buildRunnerEnv(task: TaskState, options: {
 }
 
 function makeLaunchOutbox(): LaunchOutboxAck & {
+  acceptCalls: number[];
   completeCalls: number[];
   failCalls: Array<[number, unknown]>;
 } {
+  const acceptCalls: number[] = [];
   const completeCalls: number[] = [];
   const failCalls: Array<[number, unknown]> = [];
   return {
+    acceptCalls,
     completeCalls,
     failCalls,
+    acceptDispatch(id) {
+      acceptCalls.push(id);
+      return true;
+    },
     completeDispatch(id) {
       completeCalls.push(id);
       return true;

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1814,6 +1814,7 @@ describe('TaskRunner', () => {
       const completeCalls: number[] = [];
       const failCalls: Array<[number, unknown]> = [];
       const launchOutbox = {
+        acceptDispatch(_id: number) { return true; },
         completeDispatch(id: number) { completeCalls.push(id); return true; },
         failDispatch(id: number, err: unknown) { failCalls.push([id, err]); return true; },
       };

--- a/packages/execution-engine/src/task-runner-dispatch.ts
+++ b/packages/execution-engine/src/task-runner-dispatch.ts
@@ -283,6 +283,9 @@ export async function dispatchExecutor(
     return undefined;
   }
   bench('markTaskRunningAfterLaunch.accepted');
+  if (dispatchOpts) {
+    dispatchOpts.launchOutbox.acceptDispatch(dispatchOpts.dispatchId);
+  }
 
   // Persist execution metadata immediately at task start — all fields explicit
   {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -143,6 +143,15 @@ const NOOP_LOGGER: Logger = {
  * it as a benign race.
  */
 export interface LaunchOutboxAck {
+  /**
+   * Mark that the executor is confirmed live (markTaskRunningAfterLaunch
+   * accepted the launch). This is distinct from completeDispatch: it
+   * signals the LAUNCH HANDOFF succeeded, not that the task's work is done.
+   * Stops the stuck-launch age check (LAUNCH_STUCK_ABANDON_MS) from firing
+   * on this row -- that check exists to catch launches that never start,
+   * not tasks that legitimately run long after starting successfully.
+   */
+  acceptDispatch(dispatchId: number): boolean;
   completeDispatch(dispatchId: number): boolean;
   failDispatch(dispatchId: number, error: unknown): boolean;
 }


### PR DESCRIPTION
## Summary

Fixes the bug proven in `(3)`. A task whose real work outlives the launch-dispatch reaper's stuck-launch window used to get torn down and relaunched, even while it was still healthily running.

A 2026-07-27 commit changed `completeDispatch()` so it only fires once a task's whole run finishes, needed by a background run/resume watch loop. The stuck-launch age check was never meant to cover the whole run -- only the launch handoff itself.

This adds a separate `acceptDispatch()` signal, recorded the moment the executor is confirmed live. The age check now stops watching a row once that signal fires, instead of conflating "still launching" with "still working."

## Review Claim

Approve `acceptDispatch()` as the signal that stops the stuck-launch age check once a task's executor is confirmed live.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`acceptDispatch()` only sets a previously-dead `acknowledged_at` column and never changes `state`, `completed_at`, or any field `completeDispatch()`/headless polling reads. The age-check SQL change adds one extra `AND acknowledged_at IS NULL` clause to an existing `OR` branch, narrowing when it fires; it does not touch the `attempts_count >= maxAttempts` branch at all.

## Slice Rationale

This is the actual behavior fix for the bug proven in `(3)`, kept to exactly the files needed for that fix (the new `acceptDispatch` method, its one call site, the persistence method, the SQL change, and the dispatcher wiring) plus the test-double updates required for the same change to compile.

## Non-goals

Does not add the retry cap for launches that never accept at all -- that is a separate, later fix (`(6)`) for the case a healthy task can never hit. Does not change `completeDispatch()`'s own semantics or the headless polling behavior that depends on it.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && npx playwright test e2e/launch-dispatch-stuck-lease-storm.spec.ts --reporter=list` (now passes, un-marked from `(3)`'s `test.fail`)
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner-launch-dispatch.test.ts src/__tests__/task-runner.test.ts`
- [x] `pnpm --filter @invoker/data-store exec vitest run`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/launch-dispatcher.test.ts src/__tests__/reset-storm.duress.test.ts`
- [x] `cd packages/app && npx playwright test e2e/launching-stall-watchdog.spec.ts e2e/orphan-relaunch.spec.ts e2e/task-new-attempt-reset.spec.ts --reporter=list`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, together with `(3)` (reverting alone leaves `(3)`'s test failing for real instead of via `test.fail`)
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>