### PR TITLE
[Launch-Dispatch Stuck-Lease Storm](5) Prove a launch that never completes handoff retries forever

### DIFF
--- a/packages/app/e2e/launch-dispatch-stuck-lease-cap.spec.ts
+++ b/packages/app/e2e/launch-dispatch-stuck-lease-cap.spec.ts
@@ -1,0 +1,159 @@
+import { test as base, _electron as electron, expect, type ElectronApplication, type Page } from '@playwright/test';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { stringify as yamlStringify } from 'yaml';
+import { E2E_REPO_URL } from './fixtures/electron-app.js';
+import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
+
+/**
+ * e2e proof that a launch which genuinely never completes handoff (SSH
+ * hang, worktree setup hang, ...) stops retrying instead of retrying
+ * forever. This is the companion stopper to
+ * launch-dispatch-stuck-lease-storm.spec.ts, which proves the more common
+ * case (a healthy task that just runs long). Both matter: fixing only the
+ * healthy-task case still leaves a genuinely-stuck launch retrying forever
+ * on the same ~12-minute cadence the 2026-08-02 fix-ci storm showed.
+ *
+ * Uses INVOKER_E2E_HANG_LAUNCH_STARTUP_MS (worktree-executor.ts) to make
+ * executor.start() hang well past several shrunk stuck-launch windows,
+ * so the launch never reaches markTaskRunningAfterLaunch and acceptDispatch
+ * is never called -- the row stays genuinely "stuck in launch" the whole
+ * run, unlike the healthy-task test.
+ */
+
+const MAIN_JS = path.resolve(__dirname, '..', 'dist', 'main.js');
+
+function launchArgs(): string[] {
+  return [
+    ...(process.platform === 'linux'
+      ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-gpu-compositing', '--disable-gpu-sandbox', '--disable-software-rasterizer']
+      : []),
+    MAIN_JS,
+  ];
+}
+
+async function waitForInvoker(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10000 });
+}
+
+function findTask(tasks: Array<{ id: string; status: string }>, taskId: string) {
+  return tasks.find((task) => task.id === taskId || task.id.endsWith(`/${taskId}`));
+}
+
+base.describe('Launch-dispatch stuck-lease retry cap', () => {
+  // Expected to fail until the next slice in this stack lands the durable
+  // per-task retry cap: abandonStuckLeases has no stopper today, so a
+  // launch that never completes handoff retries forever instead of
+  // eventually giving up.
+  base.fail('eventually gives up on a launch that never completes handoff', async () => {
+    const LEASE_MS = 1500;
+    // Long enough to outlast MAX_STUCK_LEASE_RETRIES (5) reap cycles at
+    // ~LEASE_MS + one 2s poll tick each (worst case ~5 * 3.5s = 17.5s),
+    // short enough to keep the test fast.
+    const HANG_MS = 30_000;
+    const MAX_STUCK_LEASE_RETRIES = 5;
+
+    const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-stuck-launch-cap-'));
+    const configPath = path.join(testDir, 'e2e-config.json');
+    const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+    const electronUserDataDir = path.join(testDir, 'electron-user-data');
+    registerTrackedBrowserUserDataDir(electronUserDataDir);
+    writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0, disableAutoRunOnStartup: false }), 'utf8');
+    let app: ElectronApplication | undefined;
+
+    try {
+      app = await electron.launch({
+        args: [`--user-data-dir=${electronUserDataDir}`, ...launchArgs()],
+        env: {
+          ...process.env,
+          NODE_ENV: 'test',
+          INVOKER_TEST_WORKFLOW_IDS: '1',
+          INVOKER_GUI_OWNER_MODE: 'gui',
+          INVOKER_DB_DIR: testDir,
+          INVOKER_IPC_SOCKET: ipcSocketPath,
+          INVOKER_ALLOW_DELETE_ALL: '1',
+          INVOKER_REPO_CONFIG_PATH: configPath,
+          INVOKER_STARTUP_POLL_DELAY_MS: '0',
+          INVOKER_USER_DATA_DIR: electronUserDataDir,
+          INVOKER_LAUNCH_DISPATCH_LEASE_MS: String(LEASE_MS),
+          INVOKER_EXECUTOR_START_TIMEOUT_MS: String(HANG_MS * 2),
+          INVOKER_E2E_HANG_LAUNCH_STARTUP_MS: String(HANG_MS),
+        },
+      });
+      const page = await app.firstWindow();
+      await waitForInvoker(page);
+      await page.evaluate(() => window.invoker.reportUiPerf?.('startup_graph_visible', {}));
+      await page.evaluate(async () => {
+        await window.invoker.clear();
+        await window.invoker.deleteAllWorkflows();
+      });
+
+      const plan = {
+        name: 'Launch never completes handoff',
+        repoUrl: E2E_REPO_URL,
+        onFinish: 'none' as const,
+        tasks: [
+          {
+            id: 'stuck-launch-task',
+            description: 'executor.start() hangs -- launch handoff never completes',
+            command: 'echo unreachable',
+          },
+        ],
+      };
+      await page.evaluate((planYaml) => window.invoker.loadPlan(planYaml), yamlStringify(plan));
+
+      // Watch generation for well past the point where an unbounded reaper
+      // would have retried many times (5 cycles * ~3.5s ~= 17.5s), then
+      // confirm it has stopped growing and the exhaustion signal fired.
+      const watchDeadline = Date.now() + HANG_MS - 5_000;
+      let maxGenerationSeen = 0;
+      let sawExhaustedLog = false;
+      const generationSamples: number[] = [];
+      while (Date.now() < watchDeadline && !sawExhaustedLog) {
+        const snapshot = await page.evaluate(() => window.invoker.getTasks());
+        const tasks = Array.isArray(snapshot) ? snapshot : snapshot.tasks;
+        const current = findTask(tasks, 'stuck-launch-task');
+        const gen = current?.execution?.generation ?? 0;
+        if (gen !== maxGenerationSeen) {
+          maxGenerationSeen = gen;
+          generationSamples.push(gen);
+        }
+        const logs = await page.evaluate(() => window.invoker.getActivityLogs());
+        sawExhaustedLog = logs.some(
+          (entry: any) =>
+            typeof entry.message === 'string'
+            && entry.message.includes('stuck-lease retry budget exhausted'),
+        );
+        await page.waitForTimeout(300);
+      }
+
+      expect(sawExhaustedLog, `retry budget exhaustion signal should fire; generation samples seen: ${generationSamples.join(', ')}`).toBe(true);
+
+      // Once exhausted, the generation must not keep climbing. Confirm by
+      // sampling again after a further delay comfortably longer than one
+      // more reap cycle would take.
+      const generationAtExhaustion = maxGenerationSeen;
+      await page.waitForTimeout(LEASE_MS + 3_000);
+      const afterSnapshot = await page.evaluate(() => window.invoker.getTasks());
+      const afterTasks = Array.isArray(afterSnapshot) ? afterSnapshot : afterSnapshot.tasks;
+      const afterTask = findTask(afterTasks, 'stuck-launch-task');
+      expect(
+        afterTask?.execution?.generation ?? 0,
+        'generation must not climb further once the retry budget is exhausted',
+      ).toBe(generationAtExhaustion);
+
+      // The stopper is a hard cap on retries, not just "eventually stops
+      // *somewhere*" -- confirm it actually gave up at MAX_STUCK_LEASE_RETRIES,
+      // not some much larger number.
+      expect(generationAtExhaustion).toBeLessThanOrEqual(MAX_STUCK_LEASE_RETRIES + 1);
+      expect(generationAtExhaustion).toBeGreaterThan(0);
+    } finally {
+      await app?.close().catch(() => undefined);
+      if (process.env.INVOKER_E2E_KEEP_TMP !== '1') {
+        rmSync(testDir, { recursive: true, force: true });
+      }
+    }
+  });
+});

--- a/packages/app/e2e/launch-dispatch-stuck-lease-storm.spec.ts
+++ b/packages/app/e2e/launch-dispatch-stuck-lease-storm.spec.ts
@@ -99,11 +99,7 @@ async function waitForTask(
 }
 
 base.describe('Launch-dispatch stuck-lease reaper', () => {
-  // Expected to fail until the next slice in this stack lands
-  // acceptDispatch(): completeDispatch() currently only fires once a
-  // task's WHOLE run finishes, so LAUNCH_STUCK_ABANDON_MS (shrunk here)
-  // wrongly treats a still-running, still-healthy task as stuck in launch.
-  base.fail('does not tear down a healthy task that outlives the stuck-launch window', async () => {
+  base('does not tear down a healthy task that outlives the stuck-launch window', async () => {
     // Shrunk to 3s (production default is 12 minutes) so the reaper's
     // 2s poll tick gets at least one real chance to misfire within the
     // test's window if the bug is present.

--- a/packages/app/src/__tests__/launch-dispatch-stuck-lease-retry-storm-repro.test.ts
+++ b/packages/app/src/__tests__/launch-dispatch-stuck-lease-retry-storm-repro.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import {
+  DISPATCH_LEASE_MS,
+  LAUNCH_STUCK_ABANDON_MS,
+  MAX_STUCK_LEASE_RETRIES,
+  type Logger,
+} from '@invoker/contracts';
+import { LaunchDispatcher } from '../launch-dispatcher.js';
+
+/**
+ * Repro for the 2026-08 fix-ci retry storm (~$1,032 in one 24h window, one
+ * task retried 78 times on the same unresolved commit).
+ *
+ * Root cause, in two parts:
+ *
+ * 1. Commit 3623f6a96 ("Complete dispatch after executor finish", #6210,
+ *    2026-07-27) moved `completeDispatch()` out of the launch-accepted path
+ *    and into the executor's `onComplete` handler
+ *    (packages/execution-engine/src/task-runner-finalize.ts:118-121). A
+ *    launch-dispatch row now stays "leased" for the task's ENTIRE runtime,
+ *    not just its launch handoff.
+ * 2. `LAUNCH_STUCK_ABANDON_MS` (packages/contracts/src/launch-timeouts.ts)
+ *    is only 12 minutes, and was only ever meant to catch a launch that
+ *    hangs before the executor starts. `abandonStuckLeases()` runs every
+ *    poll tick and abandons + calls `prepareTaskForNewAttempt` for ANY row
+ *    older than that, with no cap on repeats: each fresh attempt gets a
+ *    brand-new `task_launch_dispatch` row with `attempts_count` back at 0,
+ *    so `DISPATCH_MAX_ATTEMPTS` (3) never accumulates across cycles.
+ *
+ * Net effect: a task whose real work legitimately takes longer than 12
+ * minutes (e.g. waiting on a slow Playwright CI run) gets torn down and
+ * relaunched from scratch forever, on a fixed ~12-minute cadence, with no
+ * stopper anywhere in the loop.
+ *
+ * This test simulates exactly that: a task that is claimed and never
+ * completes (mirrors the fix-ci codex sessions, most of which ended in
+ * `turn_aborted` after ~700-720s in the real session logs) is put through
+ * repeated 12-minute stuck-lease cycles. It asserts the launch-dispatcher
+ * must stop retrying after a bounded number of cycles.
+ */
+describe('launch-dispatcher stuck-lease retry storm', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function makeLogger(): Logger {
+    return {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      child(): Logger {
+        return this;
+      },
+    };
+  }
+
+  // Expected to fail until the next slice in this stack lands the durable
+  // per-task retry cap: abandonStuckLeases has no stopper today, so this
+  // currently retries every single cycle, unbounded.
+  it.fails('does not retry a task whose launch dispatch never completes forever', () => {
+    adapter.saveWorkflow({
+      id: 'wf-storm',
+      name: 'wf-storm',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    adapter.saveTask('wf-storm', {
+      id: 'wf-storm/fix-ci',
+      description: 'Diagnose and fix CI job `playwright / 1-of-9`',
+      status: 'pending',
+      dependencies: [],
+      createdAt: new Date(),
+      config: { workflowId: 'wf-storm' },
+      execution: {},
+      taskStateVersion: 1,
+    });
+
+    const prepare = vi.fn();
+    const dispatcher = new LaunchDispatcher({
+      persistence: adapter,
+      orchestrator: { prepareTaskForNewAttempt: prepare },
+      ownerId: 'owner-test',
+      logger: makeLogger(),
+    });
+
+    // Simulate 10 twelve-minute cycles (~2 hours) of: the task launches
+    // successfully, the agent is still legitimately working when the
+    // 12-minute stuck-launch window closes, completeDispatch was never
+    // called (because it now only fires on full task completion), so the
+    // reaper abandons the lease and prepares a brand new attempt. Repeat.
+    const CYCLES = 10;
+    let simNow = Date.parse('2026-08-02T05:48:00.000Z');
+
+    for (let i = 0; i < CYCLES; i += 1) {
+      const row = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-storm/fix-ci',
+        attemptId: `attempt-cycle-${i}`,
+        workflowId: 'wf-storm',
+        generation: i,
+      });
+      const claimedIso = new Date(simNow).toISOString();
+      const fencedUntilIso = new Date(simNow + DISPATCH_LEASE_MS - 1_000).toISOString();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch
+           SET state = 'leased', dispatch_owner = 'owner-test',
+               enqueued_at = ?, fenced_until = ?
+         WHERE id = ?`,
+        [claimedIso, fencedUntilIso, row.id],
+      );
+
+      // Advance the clock past both the fence and the stuck-launch age
+      // cutoff, exactly like the real ~12-minute retry cadence observed in
+      // the fleet cost data.
+      simNow += LAUNCH_STUCK_ABANDON_MS + 60_000;
+      dispatcher.abandonStuckLeases(new Date(simNow).toISOString());
+    }
+
+    // A task that is still legitimately running (never completes) must
+    // eventually stop being torn down and relaunched. Without a cap this
+    // fires once per cycle, unbounded -- exactly the $760 fix-ci retry
+    // storm observed in production.
+    expect(prepare.mock.calls.length).toBeLessThanOrEqual(MAX_STUCK_LEASE_RETRIES);
+    expect(prepare.mock.calls.length).toBeLessThan(CYCLES);
+  });
+});

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -17,6 +17,7 @@ import { resolveLaunchDispatchLeaseMsOverride } from './launch-dispatch-defaults
 export type LaunchDispatcherPersistence = Pick<
   SQLiteAdapter,
   | 'loadLaunchDispatchById'
+  | 'markLaunchDispatchAccepted'
   | 'markLaunchDispatchCompleted'
   | 'markLaunchDispatchFailed'
   | 'markLaunchDispatchAbandoned'
@@ -550,10 +551,29 @@ export class LaunchDispatcher {
   }
 
   /**
-   * Transition a live dispatch row to completed. Called by the
-   * TaskRunner once {@link markTaskRunningAfterLaunch} has succeeded
-   * (the executor handle is live and the task is in the executing
-   * phase). Returns false when the row is already terminal.
+   * Record that the launch handoff succeeded. Called by the TaskRunner
+   * once {@link markTaskRunningAfterLaunch} has succeeded (the executor
+   * handle is live and the task is in the executing phase). This stops
+   * `abandonStuckLeases`'s age check from treating the row as stuck in
+   * launch -- it does NOT complete the row, since headless run/resume
+   * polls dispatch completion to mean the task's work is actually done.
+   * Returns false when the row is no longer leased (already terminal).
+   */
+  acceptDispatch(dispatchId: number): boolean {
+    const ok = this.persistence.markLaunchDispatchAccepted(dispatchId);
+    this.logger?.info?.('[launch-dispatcher] accepted', {
+      ownerId: this.ownerId,
+      dispatchId,
+      accepted: ok,
+      module: 'launch-dispatcher',
+    });
+    return ok;
+  }
+
+  /**
+   * Transition a live dispatch row to completed once the task's whole
+   * run finishes (called from TaskRunner's onComplete finalization).
+   * Returns false when the row is already terminal.
    */
   completeDispatch(dispatchId: number): boolean {
     const ok = this.persistence.markLaunchDispatchCompleted(dispatchId);

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3726,6 +3726,30 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return (this.db.getRowsModified?.() ?? 0) > 0;
   }
 
+  /**
+   * Record that the launch handoff for this row succeeded (the executor is
+   * confirmed live). Reuses the `acknowledged_at` column, which has been
+   * unused dead weight since the acknowledged-state removal in migration
+   * work (see sqlite-migrations.ts) -- no schema change needed.
+   *
+   * This is intentionally separate from markLaunchDispatchCompleted: that
+   * one only fires once the task's whole run finishes (needed by headless
+   * run/resume polling), so it cannot double as a "did launch succeed"
+   * signal. listAbandonableLaunchDispatchLeases uses acknowledged_at to
+   * stop treating a row as stuck-in-launch once it's actually launched.
+   */
+  markLaunchDispatchAccepted(id: number, nowIso?: string): boolean {
+    const now = nowIso ?? new Date().toISOString();
+    this.execRun(
+      `UPDATE task_launch_dispatch
+         SET acknowledged_at = COALESCE(acknowledged_at, ?)
+       WHERE id = ?
+         AND state = 'leased'`,
+      [now, id],
+    );
+    return (this.db.getRowsModified?.() ?? 0) > 0;
+  }
+
   markLaunchDispatchFailed(
     id: number,
     errorMessage: string,
@@ -3761,7 +3785,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
            AND fenced_until < ?
            AND (
              attempts_count >= ?
-             OR (? IS NOT NULL AND enqueued_at <= ?)
+             OR (acknowledged_at IS NULL AND ? IS NOT NULL AND enqueued_at <= ?)
            )
          ORDER BY id ASC`,
       [now, options.maxAttempts, ageCutoff, ageCutoff],

--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -126,14 +126,21 @@ function buildRunnerEnv(task: TaskState, options: {
 }
 
 function makeLaunchOutbox(): LaunchOutboxAck & {
+  acceptCalls: number[];
   completeCalls: number[];
   failCalls: Array<[number, unknown]>;
 } {
+  const acceptCalls: number[] = [];
   const completeCalls: number[] = [];
   const failCalls: Array<[number, unknown]> = [];
   return {
+    acceptCalls,
     completeCalls,
     failCalls,
+    acceptDispatch(id) {
+      acceptCalls.push(id);
+      return true;
+    },
     completeDispatch(id) {
       completeCalls.push(id);
       return true;

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1814,6 +1814,7 @@ describe('TaskRunner', () => {
       const completeCalls: number[] = [];
       const failCalls: Array<[number, unknown]> = [];
       const launchOutbox = {
+        acceptDispatch(_id: number) { return true; },
         completeDispatch(id: number) { completeCalls.push(id); return true; },
         failDispatch(id: number, err: unknown) { failCalls.push([id, err]); return true; },
       };

--- a/packages/execution-engine/src/task-runner-dispatch.ts
+++ b/packages/execution-engine/src/task-runner-dispatch.ts
@@ -283,6 +283,9 @@ export async function dispatchExecutor(
     return undefined;
   }
   bench('markTaskRunningAfterLaunch.accepted');
+  if (dispatchOpts) {
+    dispatchOpts.launchOutbox.acceptDispatch(dispatchOpts.dispatchId);
+  }
 
   // Persist execution metadata immediately at task start — all fields explicit
   {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -143,6 +143,15 @@ const NOOP_LOGGER: Logger = {
  * it as a benign race.
  */
 export interface LaunchOutboxAck {
+  /**
+   * Mark that the executor is confirmed live (markTaskRunningAfterLaunch
+   * accepted the launch). This is distinct from completeDispatch: it
+   * signals the LAUNCH HANDOFF succeeded, not that the task's work is done.
+   * Stops the stuck-launch age check (LAUNCH_STUCK_ABANDON_MS) from firing
+   * on this row -- that check exists to catch launches that never start,
+   * not tasks that legitimately run long after starting successfully.
+   */
+  acceptDispatch(dispatchId: number): boolean;
   completeDispatch(dispatchId: number): boolean;
   failDispatch(dispatchId: number, error: unknown): boolean;
 }


### PR DESCRIPTION
## Summary

Adds a unit repro and an e2e test proving a second, separate bug: a launch that genuinely never completes handoff (SSH hang, worktree setup hang) retries forever, with no cap.

`(4)` fixed the common case (a healthy task that just runs long). This proves the remaining case still has no stopper: `DISPATCH_MAX_ATTEMPTS` never bounds it, because every retry mints a fresh dispatch row starting its own attempt count back at 0.

Both tests are marked as expected-to-fail (`it.fails` / `test.fail`) because the cap does not exist yet. The next slice adds it and un-marks both.

## Review Claim

Approve two expected-to-fail tests that reproduce the unbounded stuck-launch retry loop.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only files. Both marked expected-to-fail, so CI stays green either way; an unexpected pass would itself fail the suite.

## Slice Rationale

Per this repo's stacking convention, proof lands before the fix. This is a second, independent proof/fix pair rather than folded into `(3)`/`(4)` because it is a distinct claim: `(3)`/`(4)` is about a task that launches successfully and just runs long; this is about a launch that never successfully launches at all. Landing `(4)` first isolates this proof to exactly that remaining case.

## Non-goals

Does not change any production file. Does not yet add the retry cap -- that is slice `(6)`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/launch-dispatch-stuck-lease-retry-storm-repro.test.ts` (expected: reported as a passing expected-failure)
- [x] `cd packages/app && npx playwright test e2e/launch-dispatch-stuck-lease-cap.spec.ts --reporter=list` (expected: reported as a passing expected-failure)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7219