### PR TITLE
[Launch-Dispatch Stuck-Lease Storm](6) Cap stuck-launch retries so a truly stuck launch gives up

### DIFF
--- a/packages/app/e2e/launch-dispatch-stuck-lease-cap.spec.ts
+++ b/packages/app/e2e/launch-dispatch-stuck-lease-cap.spec.ts
@@ -43,11 +43,7 @@ function findTask(tasks: Array<{ id: string; status: string }>, taskId: string) 
 }
 
 base.describe('Launch-dispatch stuck-lease retry cap', () => {
-  // Expected to fail until the next slice in this stack lands the durable
-  // per-task retry cap: abandonStuckLeases has no stopper today, so a
-  // launch that never completes handoff retries forever instead of
-  // eventually giving up.
-  base.fail('eventually gives up on a launch that never completes handoff', async () => {
+  base('eventually gives up on a launch that never completes handoff', async () => {
     const LEASE_MS = 1500;
     // Long enough to outlast MAX_STUCK_LEASE_RETRIES (5) reap cycles at
     // ~LEASE_MS + one 2s poll tick each (worst case ~5 * 3.5s = 17.5s),

--- a/packages/app/src/__tests__/launch-dispatch-stuck-lease-retry-storm-repro.test.ts
+++ b/packages/app/src/__tests__/launch-dispatch-stuck-lease-retry-storm-repro.test.ts
@@ -62,10 +62,7 @@ describe('launch-dispatcher stuck-lease retry storm', () => {
     };
   }
 
-  // Expected to fail until the next slice in this stack lands the durable
-  // per-task retry cap: abandonStuckLeases has no stopper today, so this
-  // currently retries every single cycle, unbounded.
-  it.fails('does not retry a task whose launch dispatch never completes forever', () => {
+  it('does not retry a task whose launch dispatch never completes forever', () => {
     adapter.saveWorkflow({
       id: 'wf-storm',
       name: 'wf-storm',

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -10,7 +10,12 @@
 import type { SQLiteAdapter, TaskLaunchDispatch } from '@invoker/data-store';
 import type { LaunchOutboxAck } from '@invoker/execution-engine';
 import type { TaskLaunchReadiness, TaskState } from '@invoker/workflow-core';
-import { DISPATCH_MAX_ATTEMPTS, LAUNCH_STUCK_ABANDON_MS, type Logger } from '@invoker/contracts';
+import {
+  DISPATCH_MAX_ATTEMPTS,
+  LAUNCH_STUCK_ABANDON_MS,
+  MAX_STUCK_LEASE_RETRIES,
+  type Logger,
+} from '@invoker/contracts';
 import { resolveLaunchDispatchLeaseMsOverride } from './launch-dispatch-defaults.js';
 
 
@@ -26,6 +31,7 @@ export type LaunchDispatcherPersistence = Pick<
   | 'claimLaunchDispatchAtomic'
   | 'listExecutionResourceLeasesByTask'
   | 'releaseExecutionResourceLease'
+  | 'countAbandonedLaunchDispatchesForTask'
   | 'logEvent'
 > & {
   releaseExpiredExecutionResourceLeases?(nowIso?: string): number;
@@ -463,6 +469,33 @@ export class LaunchDispatcher {
       attemptsCount: row.attemptsCount,
       error: message,
     });
+
+    // Durable, per-task stopper: each prepareTaskForNewAttempt() mints a
+    // fresh task_launch_dispatch row starting at attempts_count 0, so
+    // DISPATCH_MAX_ATTEMPTS never accumulates across stuck-lease cycles on
+    // its own. Count abandons directly from the durable table (survives
+    // restarts and generation bumps) so a task whose real work legitimately
+    // outlives LAUNCH_STUCK_ABANDON_MS eventually stops being relaunched
+    // instead of retrying forever.
+    const abandonedSoFar = this.persistence.countAbandonedLaunchDispatchesForTask(row.taskId);
+    if (abandonedSoFar > MAX_STUCK_LEASE_RETRIES) {
+      this.persistence.logEvent?.(row.taskId, 'task.launch_dispatch_retry_budget_exhausted', {
+        dispatchId: row.id,
+        attemptId: row.attemptId,
+        abandonedCount: abandonedSoFar,
+        maxStuckLeaseRetries: MAX_STUCK_LEASE_RETRIES,
+      });
+      this.logger?.error?.('[launch-dispatcher] stuck-lease retry budget exhausted; not preparing another attempt', {
+        ownerId: this.ownerId,
+        taskId: row.taskId,
+        dispatchId: row.id,
+        abandonedCount: abandonedSoFar,
+        maxStuckLeaseRetries: MAX_STUCK_LEASE_RETRIES,
+        module: 'launch-dispatcher',
+      });
+      return;
+    }
+
     this.prepareTaskForNewAttempt(row.taskId, row.id);
   }
 

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3585,6 +3585,20 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return row ? this.rowToTaskLaunchDispatch(row) : undefined;
   }
 
+  /**
+   * Durable, generation-independent count of how many times a task's launch
+   * dispatch has been abandoned (any reason). Each `prepareTaskForNewAttempt`
+   * call creates a new row, so this is the only place the total survives
+   * across attempts -- used to cap `abandonStuckLeases` retries per task.
+   */
+  countAbandonedLaunchDispatchesForTask(taskId: string): number {
+    const row = this.queryOne(
+      `SELECT COUNT(*) as count FROM task_launch_dispatch WHERE task_id = ? AND state = 'abandoned'`,
+      [taskId],
+    );
+    return row ? Number(row.count) : 0;
+  }
+
   loadLaunchDispatchByAttempt(attemptId: string): TaskLaunchDispatch | undefined {
     const row = this.queryOne(
       `SELECT * FROM task_launch_dispatch


### PR DESCRIPTION
## Summary

Fixes the bug proven in `(5)`. A launch that genuinely never completes handoff used to relaunch forever, with no cap.

`abandonStuckLeases` counts how many times a task's launch dispatch has already been abandoned, using a durable count that survives restarts and generation bumps (each relaunch mints a new row, so a per-row counter alone cannot see the total). Past `MAX_STUCK_LEASE_RETRIES`, it stops preparing a new attempt and logs why instead.

## Review Claim

Approve capping `abandonStuckLeases` relaunch attempts per task at `MAX_STUCK_LEASE_RETRIES`, using a durable count of the task's own abandoned dispatch rows.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The cap only changes behavior once a task has already been abandoned more than `MAX_STUCK_LEASE_RETRIES` (5) times -- every task's first 5 stuck-lease cycles behave exactly as before. `countAbandonedLaunchDispatchesForTask` is a read-only `COUNT(*)` scoped to one task's own rows; it does not touch any other task's state.

## Slice Rationale

This is the actual behavior fix for the bug proven in `(5)`, landed after `(4)` so the age-based abandon path it caps only fires for genuinely-stuck launches, not the common healthy-long-task case `(4)` already fixed.

## Non-goals

Does not change `DISPATCH_MAX_ATTEMPTS`'s existing per-row retry budget. Does not mark the task permanently failed when the cap is hit -- it stops retrying and logs `task.launch_dispatch_retry_budget_exhausted`; the task is left in whatever state the last abandon left it in, visible for a human or another recovery path to act on.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/launch-dispatch-stuck-lease-retry-storm-repro.test.ts` (now passes, un-marked from `(5)`'s `it.fails`)
- [x] `cd packages/app && npx playwright test e2e/launch-dispatch-stuck-lease-cap.spec.ts --reporter=list` (now passes, un-marked from `(5)`'s `test.fail`)
- [x] `pnpm --filter @invoker/data-store exec vitest run`
- [x] `pnpm --filter @invoker/contracts exec vitest run`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/launch-dispatcher.test.ts src/__tests__/launch-claim-orphan-regression.test.ts src/__tests__/runner-capacity-fill-guarantee.test.ts src/__tests__/dispatch-capacity-invariants.test.ts src/__tests__/launch-dispatch-resource-defer-churn-repro.test.ts src/__tests__/reset-storm.duress.test.ts src/__tests__/launch-pool-deferral-outbox-repro.test.ts`
- [x] `cd packages/app && npx playwright test e2e/launch-dispatch-stuck-lease-storm.spec.ts e2e/launching-stall-watchdog.spec.ts e2e/orphan-relaunch.spec.ts e2e/task-new-attempt-reset.spec.ts --reporter=list`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, together with `(5)` (reverting alone leaves `(5)`'s tests failing for real instead of via `test.fail`/`it.fails`)
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>