### PR TITLE
[Bugfix: clicking empty background on the workflow graph dismisses mini-DAG](1) Restore no-op background click handler (regression reintroduced after PR #4982)

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2407,30 +2407,11 @@ export function App() {
   ]);
 
 
-  const handleDagSurfaceClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+  const handleDagSurfaceClick = useCallback(() => {
     if (contextMenu || workflowContextMenu) {
       setContextMenu(null);
       setWorkflowContextMenu(null);
-      return;
     }
-
-    if (suppressDagSurfaceDismissRef.current) {
-      return;
-    }
-
-    const target = event.target as HTMLElement;
-    if (
-      target.closest('[data-testid^="workflow-node-"]') ||
-      target.closest('[data-testid="selected-workflow-mini-dag"]') ||
-      target.closest('.react-flow__node') ||
-      target.closest('[role="menu"]')
-    ) {
-      return;
-    }
-
-    setSelectedTaskId(null);
-    setSelectedWorkflowId(null);
-    setWorkflowSelectionDismissed(true);
   }, [contextMenu, workflowContextMenu]);
 
   const handleRestartTask = useCallback(async (taskId: string) => {

--- a/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
+++ b/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
@@ -89,7 +89,7 @@ describe('Home workflow click mini-DAG dismiss race', () => {
 
     fireEvent.click(screen.getByTestId('workflow-graph-react-flow'));
     await waitFor(() => {
-      expect(screen.queryByTestId('selected-workflow-mini-dag')).not.toBeInTheDocument();
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByTestId('sidebar-workflows'));

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -2038,7 +2038,22 @@ describe('Invoker terminal submit context (component)', () => {
       expect(screen.getByTestId('selected-workflow-mini-dag')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByTestId('workflow-graph-surface'));
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      fireEvent.click(screen.getByTestId('rf__node-task-a'));
+      await waitFor(() => {
+        expect(
+          screen
+            .getByTestId('selected-workflow-mini-dag')
+            .querySelector('[data-keyboard-region="taskGraph"]'),
+        ).toHaveAttribute('data-keyboard-active', 'true');
+      });
+      await flushFrames(2);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+      await flushFrames(2);
+
+      if (screen.queryByTestId('selected-workflow-mini-dag') === null) break;
+    }
 
     await waitFor(() => {
       expect(screen.queryByTestId('selected-workflow-mini-dag')).not.toBeInTheDocument();

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -232,7 +232,7 @@ describe('Task interaction (component)', () => {
     expect(screen.queryByLabelText('Maximize inspector')).not.toBeInTheDocument();
   });
 
-  it('clicking workflow graph background dismisses the selected mini DAG', async () => {
+  it('clicking workflow graph background keeps the selected mini DAG', async () => {
     render(<App />);
     fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha, beta], workflows));
@@ -249,7 +249,7 @@ describe('Task interaction (component)', () => {
     fireEvent.click(screen.getByTestId('workflow-graph-react-flow'));
 
     await waitFor(() => {
-      expect(screen.queryByTestId('selected-workflow-mini-dag')).not.toBeInTheDocument();
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
     });
   });
 


### PR DESCRIPTION
## Summary

Clicking on empty background in the workflow graph used to clear your selected task and workflow. It also dismissed the mini-DAG panel for the selected workflow.

PR #4982 fixed this: background clicks became a no-op except for closing an open context menu.

PR #5067 silently reverted that fix two days later, and flipped the one test that would have caught it.

This PR restores the #4982 no-op behavior and un-flips that test back to asserting the mini-DAG panel survives a background click.

CI also caught a second existing test, `invoker-terminal.test.tsx`. It used a background click to set up a "cleared selection" scenario.

That setup step no longer works once background click is a no-op. This PR updates it: select a task node directly, then dismiss via Escape.

## Review Claim

`handleDagSurfaceClick` in `packages/ui/src/App.tsx` must close an open context menu on background click and otherwise be a no-op. It must not clear `selectedTaskId`, `selectedWorkflowId`, or set `workflowSelectionDismissed`. Separately, `invoker-terminal.test.tsx`'s "preserves a cleared graph selection" test must clear selection without relying on background click, and still pass.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

All other behavior in `packages/ui/src/App.tsx` stays identical; only `handleDagSurfaceClick`'s body changes. Node/edge click handling and context-menu-close-on-background-click are unaffected. The three touched tests only update assertions and setup steps to match the restored no-op behavior; none of them add new product behavior.

## Slice Rationale

One behavior slice: the click handler defect and the three existing tests that cover it, nothing else. An automated end-to-end visual-proof test for this exact interaction ships as the next PR in this stack, since e2e/visual proof is reviewed as its own unit separate from the product change it proves.

## Non-goals

No refactor, no new fields, no unrelated cleanup, no doc edits. Does not change context-menu-close-on-background-click behavior, node/edge click handling, or any other click handler.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx src/__tests__/task-interaction.test.tsx src/__tests__/invoker-terminal.test.tsx`
- [x] `cd packages/ui && pnpm test` — `830 passed` (full Vitest suite, 88 files, 0 failed)

</details>

## Visual Proof

Real mouse click on the workflow graph's empty background, captured via Playwright on this branch (fixed) and on `master` (bug still present, for contrast). The automated test that produced these captures ships in the next PR in this stack.

Fixed (this branch) — mini-DAG panel and task inspector title are unchanged before and after the click:

![dag-bg-click-noop-before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-8ba09b/dag-bg-click-noop-before.png)
![dag-bg-click-noop-after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-8ba09b/dag-bg-click-noop-after.png)

Walkthrough video (fixed behavior — mini-DAG stays open through the click):

[dag-bg-click-noop-walkthrough.webm](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-8ba09b/dag-bg-click-noop-walkthrough.webm)

Buggy (master, for contrast) — same click, mini-DAG panel disappears and the inspector resets to "No task selected":

![dag-bg-click-noop-after-BUG-mini-dag-gone](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-8ba09b/dag-bg-click-noop-after-BUG-mini-dag-gone.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <squash-merge-sha>`
- Post-revert steps: None
- Data migration? No

</details>
