### PR TITLE
[Bugfix: clicking empty background on the workflow graph dismisses mini-DAG](2) Add visual-proof e2e test for background-click no-op

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -1443,6 +1443,50 @@ test.describe('Visual proof capture', () => {
     await captureScreenshot(page, 'task-graph-keyboard-controls-selected');
   });
 
+  test('dag-bg-click-noop — clicking empty background on the workflow graph keeps the mini-DAG visible', async ({ page }) => {
+    await loadPlanAndSelectWorkflow(page, MENU_PROOF_PLAN);
+
+    const miniDag = page.getByTestId('selected-workflow-mini-dag');
+    const inspectorTitle = page.getByTestId('workflow-inspector-title');
+    await expect(miniDag).toBeVisible();
+    await expect(miniDag.locator('.react-flow__node[data-testid$="task-alpha"]')).toBeVisible();
+    await expect(inspectorTitle).toHaveText('Menu Proof Workflow');
+
+    await captureScreenshot(page, 'dag-bg-click-noop-before');
+
+    const graphSurface = page.getByTestId('workflow-graph-surface');
+    const pane = page.getByTestId('workflow-graph-content').locator('.react-flow__pane').first();
+    await expect(pane).toBeVisible();
+    const paneBox = await pane.boundingBox();
+    const workflowNodeBox = await graphSurface.locator('[data-testid^="workflow-node-"]').first().boundingBox();
+    const miniDagBox = await miniDag.boundingBox();
+    if (!paneBox) throw new Error('workflow graph pane has no bounding box');
+
+    const isInsideBox = (x: number, y: number, box: { x: number; y: number; width: number; height: number } | null) =>
+      !!box && x >= box.x && x <= box.x + box.width && y >= box.y && y <= box.y + box.height;
+
+    const candidates = [
+      { x: paneBox.x + 24, y: paneBox.y + paneBox.height - 24 },
+      { x: paneBox.x + paneBox.width - 24, y: paneBox.y + paneBox.height - 24 },
+      { x: paneBox.x + 24, y: paneBox.y + 24 },
+    ];
+    const clickPoint = candidates.find(
+      (point) => !isInsideBox(point.x, point.y, workflowNodeBox) && !isInsideBox(point.x, point.y, miniDagBox),
+    );
+    if (!clickPoint) throw new Error('could not find an empty background point to click');
+
+    // A real mouse click, not a locator .click() — the regression only reproduces
+    // with real click coordinates hitting the pane background.
+    await page.mouse.click(clickPoint.x, clickPoint.y);
+    await page.waitForTimeout(200);
+
+    await expect(miniDag).toBeVisible();
+    await expect(miniDag.locator('.react-flow__node[data-testid$="task-alpha"]')).toBeVisible();
+    await expect(inspectorTitle).toHaveText('Menu Proof Workflow');
+
+    await captureScreenshot(page, 'dag-bg-click-noop-after');
+  });
+
   test('graph-camera-lock-navigation — task graph remains usable after keyboard and manual camera moves', async ({ page }) => {
     await loadPlanAndSelectWorkflow(page, DAG_DETERMINISM_PLAN);
     await minimizeInspectorIfVisible(page);


### PR DESCRIPTION
## Summary

The previous PR in this stack restores the no-op background-click behavior on the workflow graph. This PR adds an automated end-to-end test for exactly that interaction.

The new Playwright test clicks a real screen coordinate on the graph's empty background. It confirms the mini-DAG panel and task inspector stay unchanged.

It also captures before/after screenshots and a walkthrough video.

Run against `master` (before the previous PR's fix), the same test fails: the mini-DAG panel disappears after the click. That failing run is included below as contrast.

## Review Claim

The new `dag-bg-click-noop` Playwright test in `packages/app/e2e/visual-proof.spec.ts` must pass on top of the previous PR's fix, and must fail against the pre-fix `master` behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This PR only adds one new Playwright test case to `packages/app/e2e/visual-proof.spec.ts`. It does not touch any product file and does not modify any existing test case, so it cannot change runtime behavior.

## Slice Rationale

Kept separate from the behavior fix PR because e2e/visual proof is reviewed as its own unit in this repo, distinct from the product change it proves.

## Non-goals

No product changes here — proof only. Does not modify `packages/ui/src/App.tsx` or any existing test.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && CAPTURE_MODE=after CAPTURE_VIDEO=1 npx playwright test visual-proof.spec.ts -g "dag-bg-click-noop"` — `1 passed`
- [x] Same command run against `master` (pre-fix) — `1 failed` (`selected-workflow-mini-dag` not found), confirming the test actually reproduces the regression

</details>

## Visual Proof

Fixed (this branch) — mini-DAG panel and task inspector unchanged after a real click on the graph background:

![dag-bg-click-noop-before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-17158a/dag-bg-click-noop-before.png)
![dag-bg-click-noop-after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-17158a/dag-bg-click-noop-after.png)
[dag-bg-click-noop-walkthrough.webm](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-17158a/dag-bg-click-noop-walkthrough.webm)

Buggy (`master`, same test, for contrast) — mini-DAG panel disappears and the inspector resets to "No task selected":

![dag-bg-click-noop-after-BUG-mini-dag-gone](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-17158a/dag-bg-click-noop-after-BUG-mini-dag-gone.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <squash-merge-sha>`
- Post-revert steps: None
- Data migration? No

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage confirming that clicking an empty area of the workflow graph preserves the selected workflow’s mini-DAG, inspector, graph, and title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->