### PR TITLE
[Owner Shutdown Signals](1) Catch SIGTERM/SIGINT in the owner-serve process instead of dying silently

### DIFF
--- a/packages/app/src/__tests__/headless-termination-signal-handling.test.ts
+++ b/packages/app/src/__tests__/headless-termination-signal-handling.test.ts
@@ -53,4 +53,13 @@ describe('headless owner-serve SIGTERM/SIGINT handling', () => {
     );
     expect(finallyBlock).toContain("await runHeadlessShutdownCleanup('Application quit');");
   });
+
+  it('skips the normal-quit cleanup and exit when a signal handler already owns shutdown', () => {
+    const finallyBlock = mainTsSource.slice(
+      mainTsSource.indexOf('await runHeadless(cliArgs, headlessDeps);'),
+      mainTsSource.indexOf('process.exit(exitCode);'),
+    );
+    expect(finallyBlock).toContain('if (!headlessSignalShutdownInProgress) {');
+    expect(finallyBlock).toContain("headlessSignalShutdownInProgress = true;\n        await runHeadlessShutdownCleanup('Application quit');");
+  });
 });

--- a/packages/app/src/__tests__/headless-termination-signal-handling.test.ts
+++ b/packages/app/src/__tests__/headless-termination-signal-handling.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const mainTsSource = readFileSync(resolve(__dirname, '../main.ts'), 'utf8');
+
+function extractFunctionBody(source: string, startMarker: string): string {
+  const start = source.indexOf(startMarker);
+  if (start === -1) throw new Error(`marker not found: ${startMarker}`);
+  let depth = 0;
+  let i = source.indexOf('{', start);
+  const bodyStart = i;
+  for (; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(bodyStart, i + 1);
+    }
+  }
+  throw new Error(`unbalanced braces after marker: ${startMarker}`);
+}
+
+describe('headless owner-serve SIGTERM/SIGINT handling', () => {
+  it('registers explicit SIGTERM and SIGINT handlers, gated to the owner-serve process only', () => {
+    const registrationBlock = extractFunctionBody(mainTsSource, 'if (ownsHeadlessShutdown) {\n      const handleHeadlessTerminationSignal');
+    expect(registrationBlock).toContain("process.on('SIGTERM', handleHeadlessTerminationSignal)");
+    expect(registrationBlock).toContain("process.on('SIGINT', handleHeadlessTerminationSignal)");
+  });
+
+  it('runs the shared shutdown cleanup and exits with a signal-appropriate code instead of relying on the default OS disposition', () => {
+    const handlerBody = extractFunctionBody(mainTsSource, 'const handleHeadlessTerminationSignal = (signal: NodeJS.Signals): void =>');
+    expect(handlerBody).toContain('runHeadlessShutdownCleanup(`Received ${signal}`)');
+    expect(handlerBody).toContain("process.exit(signal === 'SIGINT' ? 130 : 143)");
+    // Guards against double-invocation if a second signal arrives mid-shutdown.
+    expect(handlerBody).toContain('if (headlessSignalShutdownInProgress) return;');
+  });
+
+  it('gives the signal-triggered shutdown a distinct reason from the existing graceful quit path', () => {
+    const cleanupFnBody = extractFunctionBody(mainTsSource, 'const runHeadlessShutdownCleanup = async (forcedStopReason: string): Promise<void> =>');
+    // The extracted cleanup function must use the caller-supplied reason
+    // everywhere a task or diagnostic reason is recorded -- not a
+    // hardcoded literal -- so the two call sites can stay distinguishable.
+    expect(cleanupFnBody).not.toContain("'Application quit'");
+    expect(cleanupFnBody).toContain('persistShutdownDiagnostic(task, persistence, { forcedStopReason });');
+    expect(cleanupFnBody).toContain('outputs: { exitCode: 1, error: forcedStopReason }');
+
+    // The existing graceful-exit path (headless CLI process finishing its
+    // own work) is unchanged: it still reports the literal 'Application quit'.
+    const finallyBlock = mainTsSource.slice(
+      mainTsSource.indexOf("await runHeadless(cliArgs, headlessDeps);"),
+      mainTsSource.indexOf('process.exit(exitCode);'),
+    );
+    expect(finallyBlock).toContain("await runHeadlessShutdownCleanup('Application quit');");
+  });
+});

--- a/packages/app/src/__tests__/reconcile-orphan-boot-reason.test.ts
+++ b/packages/app/src/__tests__/reconcile-orphan-boot-reason.test.ts
@@ -15,6 +15,6 @@ describe('boot-reconcile forced-stop reason in main.ts', () => {
 
   it('keeps the graceful-quit and headless-shutdown Application quit literals unchanged', () => {
     const literalCount = (mainSource.match(/'Application quit'/g) ?? []).length;
-    expect(literalCount).toBe(4);
+    expect(literalCount).toBe(3);
   });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -995,6 +995,68 @@ function startHeadlessMode(): void {
     let lifecycleEventBridge: LifecycleEventBridge | null = null;
     let standaloneLaunchDispatcherController: StandaloneLaunchDispatcherController | null = null;
     let headlessWebBridge: WebBridge | null = null;
+
+    const runHeadlessShutdownCleanup = async (forcedStopReason: string): Promise<void> => {
+      await headlessWebBridge?.close();
+      standaloneLaunchDispatcherController?.stop();
+      lifecycleEventBridge?.stop();
+      await workerRuntimeController?.stopAll();
+      if (ownsHeadlessShutdown && executorRegistry) {
+        await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
+      }
+      if (ownsHeadlessShutdown && orchestrator) {
+        for (const task of orchestrator.getAllTasks()) {
+          if (isTaskInFlightForForcedStop(task)) {
+            if (persistence) {
+              persistShutdownDiagnostic(task, persistence, { forcedStopReason });
+            }
+            orchestrator.handleWorkerResponse({
+              requestId: `quit-${task.id}`,
+              actionId: task.id,
+              attemptId: task.execution.selectedAttemptId,
+              executionGeneration: task.execution.generation ?? 0,
+              status: 'failed',
+              outputs: { exitCode: 1, error: forcedStopReason },
+            });
+          }
+        }
+      }
+      if (ownsHeadlessShutdown && persistence) {
+        persistence.requeueRunningWorkflowMutationIntents();
+      }
+      if (persistence) persistence.close();
+      if (writerLock) writerLock.release();
+      if (messageBus) messageBus.disconnect();
+    };
+
+    // Unhandled SIGTERM/SIGINT terminate the process immediately with no
+    // cleanup and no log line -- registering a handler is what lets us run
+    // the same in-flight task diagnostics as a normal quit instead of
+    // leaving tasks to be silently discovered as orphaned on the next boot.
+    // Only registered for the long-lived owner-serve process: one-shot
+    // delegate CLI invocations keep their existing default signal behavior.
+    let headlessSignalShutdownInProgress = false;
+    if (ownsHeadlessShutdown) {
+      const handleHeadlessTerminationSignal = (signal: NodeJS.Signals): void => {
+        if (headlessSignalShutdownInProgress) return;
+        headlessSignalShutdownInProgress = true;
+        logger.info(`received ${signal}, shutting down gracefully`, { module: 'process', signal });
+        void runHeadlessShutdownCleanup(`Received ${signal}`)
+          .catch((err) => {
+            logger.error(`shutdown cleanup after ${signal} failed`, {
+              module: 'process',
+              signal,
+              err: err instanceof Error ? err.stack ?? err.message : String(err),
+            });
+          })
+          .finally(() => {
+            process.exit(signal === 'SIGINT' ? 130 : 143);
+          });
+      };
+      process.on('SIGTERM', handleHeadlessTerminationSignal);
+      process.on('SIGINT', handleHeadlessTerminationSignal);
+    }
+
     try {
       // Standalone mode: initialize services and run headless
       await initServices({
@@ -1917,36 +1979,8 @@ function startHeadlessMode(): void {
       process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
       exitCode = 1;
     } finally {
-      await headlessWebBridge?.close();
-      standaloneLaunchDispatcherController?.stop();
-      lifecycleEventBridge?.stop();
-      await workerRuntimeController?.stopAll();
-      if (ownsHeadlessShutdown && executorRegistry) {
-        await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
-      }
-      if (ownsHeadlessShutdown && orchestrator) {
-        for (const task of orchestrator.getAllTasks()) {
-          if (isTaskInFlightForForcedStop(task)) {
-            if (persistence) {
-              persistShutdownDiagnostic(task, persistence, { forcedStopReason: 'Application quit' });
-            }
-            orchestrator.handleWorkerResponse({
-              requestId: `quit-${task.id}`,
-              actionId: task.id,
-              attemptId: task.execution.selectedAttemptId,
-              executionGeneration: task.execution.generation ?? 0,
-              status: 'failed',
-              outputs: { exitCode: 1, error: 'Application quit' },
-            });
-          }
-        }
-      }
-      if (ownsHeadlessShutdown && persistence) {
-        persistence.requeueRunningWorkflowMutationIntents();
-      }
-      if (persistence) persistence.close();
-      if (writerLock) writerLock.release();
-      if (messageBus) messageBus.disconnect();
+      headlessSignalShutdownInProgress = true;
+      await runHeadlessShutdownCleanup('Application quit');
     }
     process.exit(exitCode);
   };

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1979,10 +1979,12 @@ function startHeadlessMode(): void {
       process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
       exitCode = 1;
     } finally {
-      headlessSignalShutdownInProgress = true;
-      await runHeadlessShutdownCleanup('Application quit');
+      if (!headlessSignalShutdownInProgress) {
+        headlessSignalShutdownInProgress = true;
+        await runHeadlessShutdownCleanup('Application quit');
+        process.exit(exitCode);
+      }
     }
-    process.exit(exitCode);
   };
 
   runElectronReadyBootstrap({


### PR DESCRIPTION
## Summary

The owner-serve process never registered a handler for SIGTERM or SIGINT.

Node's default behavior for an unhandled termination signal is immediate exit, with no teardown step and no log line at all.

That meant a deliberate restart looked identical to a real crash. A deploy, a manual kill, or an orchestrator's SIGTERM all left the same evidence as a segfault: none.

Any task still marked running at that moment was left stuck in the database.

The next startup's orphan-reconcile pass had nothing to go on, since nothing was ever written before the process disappeared.

This change registers those two signals for the owner-serve process only.

On receipt, it logs which signal arrived, runs the same in-flight-task shutdown steps the existing graceful exit path already runs, then exits itself with a matching code.

## Architecture

### Before

```mermaid
sequenceDiagram
    participant OS
    participant Owner as owner-serve process
    OS->>Owner: SIGTERM
    Note over Owner: no handler registered<br/>default disposition: immediate exit
    Owner--xOwner: process dies, zero log output,<br/>in-flight tasks stay "running" in DB
```

### After

```mermaid
sequenceDiagram
    participant OS
    participant Owner as owner-serve process
    participant DB
    OS->>Owner: SIGTERM
    Owner->>Owner: log "received SIGTERM"
    Owner->>DB: shutdown steps run with reason "Received SIGTERM"
    Note over DB: in-flight tasks finalized now,<br/>with a real, distinct reason
    Owner->>OS: process.exit(143)
```

## Review Claim

Approve registering SIGTERM/SIGINT handlers for the owner-serve process, reusing the existing graceful-exit step sequence with a distinct reason string, scoped so no other invocation changes behavior.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The existing graceful-exit path (the owner-serve process finishing its own work normally) is byte-identical in behavior: its finally block now calls the same shared step sequence it always ran, in the same order, still passing the literal `'Application quit'`. Every other `--headless` invocation (everything except the `owner-serve` process) never registers a signal handler at all, so its existing default OS signal behavior is unchanged. Covered by `headless-termination-signal-handling.test.ts` and the full `packages/app` package suite.

## Slice Rationale

This is one self-contained change, landed as a single commit: the new signal handlers and the shared step sequence they depend on are wired together, not staged separately.

## Non-goals

Does not touch the GUI `before-quit` handler (Electron's own lifecycle already covers that path). Does not add any new diagnostic-capture mechanism beyond what already exists (`persistShutdownDiagnostic`, already shipped). Does not address truly untrappable process death (SIGKILL, OOM-kill, power loss) -- those remain fundamentally undetectable from inside the dying process; the already-merged `Owner restart` relabeling (#7134) is the correct honest fallback for that case, unchanged here.

## Visual Proof

`packages/app/src/main.ts` is flagged as UI-impacting by path alone, since it also owns window and menu creation. This diff only changes owner-serve signal handling; nothing under `packages/ui/` is touched. The GUI still renders normally with this diff applied:

![GUI renders normally with this diff applied](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-e2e526/sigterm-sigint-no-ui-impact.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- headless-termination-signal-handling`
- [ ] `cd packages/app && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
