### PR TITLE
[DAG background click no-op](1) Restore #4982 fix: stop clearing selection and dismissing the mini-DAG on background click

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2407,30 +2407,11 @@ export function App() {
   ]);
 
 
-  const handleDagSurfaceClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+  const handleDagSurfaceClick = useCallback(() => {
     if (contextMenu || workflowContextMenu) {
       setContextMenu(null);
       setWorkflowContextMenu(null);
-      return;
     }
-
-    if (suppressDagSurfaceDismissRef.current) {
-      return;
-    }
-
-    const target = event.target as HTMLElement;
-    if (
-      target.closest('[data-testid^="workflow-node-"]') ||
-      target.closest('[data-testid="selected-workflow-mini-dag"]') ||
-      target.closest('.react-flow__node') ||
-      target.closest('[role="menu"]')
-    ) {
-      return;
-    }
-
-    setSelectedTaskId(null);
-    setSelectedWorkflowId(null);
-    setWorkflowSelectionDismissed(true);
   }, [contextMenu, workflowContextMenu]);
 
   const handleRestartTask = useCallback(async (taskId: string) => {

--- a/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
+++ b/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
@@ -89,7 +89,7 @@ describe('Home workflow click mini-DAG dismiss race', () => {
 
     fireEvent.click(screen.getByTestId('workflow-graph-react-flow'));
     await waitFor(() => {
-      expect(screen.queryByTestId('selected-workflow-mini-dag')).not.toBeInTheDocument();
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByTestId('sidebar-workflows'));

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -232,7 +232,7 @@ describe('Task interaction (component)', () => {
     expect(screen.queryByLabelText('Maximize inspector')).not.toBeInTheDocument();
   });
 
-  it('clicking workflow graph background dismisses the selected mini DAG', async () => {
+  it('clicking workflow graph background keeps the selected mini DAG', async () => {
     render(<App />);
     fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha, beta], workflows));
@@ -249,7 +249,7 @@ describe('Task interaction (component)', () => {
     fireEvent.click(screen.getByTestId('workflow-graph-react-flow'));
 
     await waitFor(() => {
-      expect(screen.queryByTestId('selected-workflow-mini-dag')).not.toBeInTheDocument();
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
     });
   });
 


### PR DESCRIPTION
## Summary

Clicking empty background on the workflow graph used to clear the selected task and workflow, dismissing the mini-DAG panel.

PR #4982 fixed this on 2026-07-18 by shrinking `handleDagSurfaceClick` to a 5-line no-op (it only closes an open context menu).

PR #5067 (2026-07-20, "Make Planning the default home surface") rewrote the same handler back to its old 30-line form, even though #4982 was already an ancestor of that branch.

#5067 also flipped the regression test's assertion, so CI stayed green while the bug came back silently.

This PR restores the #4982 5-line handler and un-flips that test assertion back to asserting the mini-DAG panel survives a background click.

## Review Claim

`handleDagSurfaceClick` in `packages/ui/src/App.tsx` must close an open context menu on background click and otherwise be a no-op; it must not clear `selectedTaskId`, `selectedWorkflowId`, or set `workflowSelectionDismissed`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

All other behavior in `packages/ui/src/App.tsx` stays identical; only `handleDagSurfaceClick`'s body and the two previously-flipped test assertions change. Node/edge click handling and context-menu-close-on-background-click are unaffected.

## Slice Rationale

One behavior slice: the defect and its own regression test fix, nothing else. The verification run of the shared repro command is proof of this same slice, not a separate change, since it has no file diff of its own.

## Non-goals

No refactor, no new fields, no unrelated cleanup, no doc edits.

## Visual Proof

Before the fix (commit `d59dbc89d`), clicking empty workflow graph background wipes the mini-DAG panel and inspector selection:

![Selected workflow with mini-DAG panel visible, before any background click](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-d7c9eb/01-selected-with-minidag.png)

![BUGGY (before fix): after clicking empty graph background, the mini-DAG panel is gone and the inspector resets to "No task selected"](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-d7c9eb/02-before-bgclick-dismissed-BUGGY.png)

[Video walkthrough: buggy commit, background click dismisses the mini-DAG panel](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-d7c9eb/before-walkthrough.webm)

After the fix (commit `3fba6359b`), the identical background click leaves the mini-DAG panel and inspector selection untouched:

![FIXED (after fix): after clicking empty graph background, the mini-DAG panel and inspector selection are unchanged](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-d7c9eb/03-after-bgclick-still-visible-FIXED.png)

[Video walkthrough: fixed commit, background click is a no-op and the mini-DAG panel survives](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-d7c9eb/after-walkthrough.webm)

[Side-by-side video comparison: before (left) vs after (right)](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-d7c9eb/comparison-before-after.webm)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx src/__tests__/task-interaction.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
