### PR TITLE
[DAG background click no-op](1) Bugfix: clicking empty background on the workflow graph clears the selection and dismisses the mini-DAG again (regression reintroduced after PR #4982)

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2407,30 +2407,11 @@ export function App() {
   ]);
 
 
-  const handleDagSurfaceClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+  const handleDagSurfaceClick = useCallback(() => {
     if (contextMenu || workflowContextMenu) {
       setContextMenu(null);
       setWorkflowContextMenu(null);
-      return;
     }
-
-    if (suppressDagSurfaceDismissRef.current) {
-      return;
-    }
-
-    const target = event.target as HTMLElement;
-    if (
-      target.closest('[data-testid^="workflow-node-"]') ||
-      target.closest('[data-testid="selected-workflow-mini-dag"]') ||
-      target.closest('.react-flow__node') ||
-      target.closest('[role="menu"]')
-    ) {
-      return;
-    }
-
-    setSelectedTaskId(null);
-    setSelectedWorkflowId(null);
-    setWorkflowSelectionDismissed(true);
   }, [contextMenu, workflowContextMenu]);
 
   const handleRestartTask = useCallback(async (taskId: string) => {

--- a/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
+++ b/packages/ui/src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx
@@ -89,7 +89,7 @@ describe('Home workflow click mini-DAG dismiss race', () => {
 
     fireEvent.click(screen.getByTestId('workflow-graph-react-flow'));
     await waitFor(() => {
-      expect(screen.queryByTestId('selected-workflow-mini-dag')).not.toBeInTheDocument();
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toBeInTheDocument();
     });
 
     fireEvent.click(screen.getByTestId('sidebar-workflows'));

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -232,7 +232,7 @@ describe('Task interaction (component)', () => {
     expect(screen.queryByLabelText('Maximize inspector')).not.toBeInTheDocument();
   });
 
-  it('clicking workflow graph background dismisses the selected mini DAG', async () => {
+  it('clicking workflow graph background keeps the selected mini DAG', async () => {
     render(<App />);
     fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([alpha, beta], workflows));
@@ -249,7 +249,7 @@ describe('Task interaction (component)', () => {
     fireEvent.click(screen.getByTestId('workflow-graph-react-flow'));
 
     await waitFor(() => {
-      expect(screen.queryByTestId('selected-workflow-mini-dag')).not.toBeInTheDocument();
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
     });
   });
 


### PR DESCRIPTION
## Summary

Clicking empty background on the workflow graph used to clear your selection and hide the mini-DAG panel again.

PR #4982 fixed this once: background clicks only close an open context menu and otherwise do nothing.

PR #5067 (Planning became the default home surface) silently rewrote the same handler back to its old behavior, and flipped the one test that would have caught it.

This PR restores the #4982 no-op handler and un-flips that test back to asserting the mini-DAG survives a background click.

## Review Claim

`handleDagSurfaceClick` in `packages/ui/src/App.tsx` must close an open context menu on background click and otherwise be a no-op. It must never clear `selectedTaskId`, `selectedWorkflowId`, or dismiss the selected workflow's mini-DAG panel.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only `handleDagSurfaceClick`'s body changes in `packages/ui/src/App.tsx`, plus the two test assertions that encoded the regression. Node/edge click handling and context-menu-close-on-background-click are unaffected, so this is safe to review as a single small, local diff.

## Slice Rationale

The defect, its fix, and the deterministic test that proves it are one inseparable review unit: shipping the fix without un-flipping the test would leave CI green on a re-broken handler again, which is exactly how this regression escaped last time.

## Non-goals

No refactor of `handleDagSurfaceClick` beyond restoring the #4982 form. No new fields, no unrelated cleanup, no doc edits, and no new e2e/Playwright coverage — the existing unit tests are the proof surface for this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- src/__tests__/home-workflow-click-mini-dag-dismiss-repro.test.tsx src/__tests__/task-interaction.test.tsx` — `2 files passed (14 tests)`

</details>

## Visual Proof

Before fix (buggy): selecting a workflow shows the mini-DAG panel and inspector —

![selected-with-minidag](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-7b28a9/01-selected-with-minidag.png)

Before fix (buggy): clicking empty graph background dismisses the mini-DAG panel and resets the inspector to "No task selected" —

![before-bgclick-dismissed-buggy](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-7b28a9/02-before-bgclick-dismissed-BUGGY.png)

After fix: the same background click leaves the mini-DAG panel and inspector unchanged —

![after-bgclick-still-visible-fixed](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-7b28a9/03-after-bgclick-still-visible-FIXED.png)

Walkthrough video (buggy vs. fixed click behavior, side by side) —

![comparison-before-after-walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-7b28a9/comparison-before-after.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 79455012e`
- Post-revert steps: None
- Data migration? No

</details>
