### PR TITLE
[Add-machine onboarding](1) config/domain layer

### DIFF
--- a/packages/contracts/src/__tests__/remote-target-onboarding.test.ts
+++ b/packages/contracts/src/__tests__/remote-target-onboarding.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  addRemoteTarget,
+  checkRemoteTargetConnectivity,
+  type RemoteTargetConnectionSpec,
+  type RemoteTargetInput,
+} from '../remote-target-onboarding.js';
+
+const stagingTarget = {
+  host: '192.168.1.100',
+  user: 'deploy',
+  sshKeyPath: '/home/user/.ssh/id_staging',
+  port: 22,
+  maxConcurrentTasks: 1,
+  provisionCommand: 'pnpm install --frozen-lockfile',
+};
+
+function makeConfig() {
+  return {
+    maxConcurrency: 6,
+    defaultExecutionAgent: 'codex',
+    remoteTargets: {
+      'staging-server': { ...stagingTarget },
+    },
+    executionPools: {
+      'mixed-local-ssh': {
+        members: [{ type: 'ssh', id: 'staging-server' }],
+        selectionStrategy: 'roundRobin',
+        maxConcurrentTasksPerMember: 1,
+      },
+    },
+  };
+}
+
+const newTarget: RemoteTargetInput = {
+  id: 'build-server-b',
+  host: '192.168.1.101',
+  user: 'deploy',
+  sshKeyPath: '/home/user/.ssh/id_build_b',
+  port: 2222,
+  maxConcurrentTasks: 2,
+  provisionCommand: 'pnpm install --frozen-lockfile',
+};
+
+describe('addRemoteTarget', () => {
+  it('appends the new target and leaves everything else byte-for-byte unchanged', () => {
+    const config = makeConfig();
+    const before = JSON.stringify(config);
+
+    const result = addRemoteTarget(config, newTarget);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(JSON.stringify(config)).toBe(before);
+
+    expect(result.config.remoteTargets).toEqual({
+      'staging-server': stagingTarget,
+      'build-server-b': {
+        host: '192.168.1.101',
+        user: 'deploy',
+        sshKeyPath: '/home/user/.ssh/id_build_b',
+        port: 2222,
+        maxConcurrentTasks: 2,
+        provisionCommand: 'pnpm install --frozen-lockfile',
+      },
+    });
+
+    const targets = result.config.remoteTargets as Record<string, unknown>;
+    expect(JSON.stringify(targets['staging-server'])).toBe(JSON.stringify(stagingTarget));
+    expect(result.config.executionPools).toBe(config.executionPools);
+    expect(result.config.maxConcurrency).toBe(6);
+    expect(result.config.defaultExecutionAgent).toBe('codex');
+  });
+
+  it('creates remoteTargets when the config has none', () => {
+    const result = addRemoteTarget({ maxConcurrency: 2 }, newTarget);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(Object.keys(result.config.remoteTargets as Record<string, unknown>)).toEqual(['build-server-b']);
+    expect(result.config.maxConcurrency).toBe(2);
+  });
+
+  it('omits optional fields that were not provided', () => {
+    const result = addRemoteTarget(
+      {},
+      { id: 'minimal', host: 'h', user: 'u', sshKeyPath: '/k' },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const targets = result.config.remoteTargets as Record<string, unknown>;
+    expect(targets.minimal).toEqual({ host: 'h', user: 'u', sshKeyPath: '/k' });
+  });
+
+  it('rejects a target whose host already exists instead of adding a second entry', () => {
+    const config = makeConfig();
+    const before = JSON.stringify(config);
+
+    const result = addRemoteTarget(config, { ...newTarget, id: 'staging-clone', host: '192.168.1.100' });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('duplicate-host');
+    expect(result.error.conflictingTargetId).toBe('staging-server');
+    expect(result.error.message).toContain('192.168.1.100');
+    expect(JSON.stringify(config)).toBe(before);
+  });
+
+  it('rejects a target whose id already exists', () => {
+    const result = addRemoteTarget(makeConfig(), { ...newTarget, id: 'staging-server' });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('duplicate-id');
+    expect(result.error.conflictingTargetId).toBe('staging-server');
+  });
+});
+
+describe('checkRemoteTargetConnectivity', () => {
+  const spec: RemoteTargetConnectionSpec = {
+    host: '192.168.1.101',
+    user: 'deploy',
+    sshKeyPath: '/home/user/.ssh/id_build_b',
+    port: 2222,
+  };
+
+  it('uses the injected impl instead of running a real SSH probe', async () => {
+    const calls: RemoteTargetConnectionSpec[] = [];
+    const result = await checkRemoteTargetConnectivity(spec, {
+      impl: (target) => {
+        calls.push(target);
+        return { reachable: true };
+      },
+    });
+
+    expect(result).toEqual({ reachable: true });
+    expect(calls).toEqual([spec]);
+  });
+
+  it('returns the injected impl failure outcome as-is', async () => {
+    const result = await checkRemoteTargetConnectivity(spec, {
+      impl: async () => ({ reachable: false, message: 'simulated auth failure' }),
+    });
+
+    expect(result).toEqual({ reachable: false, message: 'simulated auth failure' });
+  });
+
+  it('reports unreachable for a real probe against a closed local port', async () => {
+    const result = await checkRemoteTargetConnectivity(
+      { host: '127.0.0.1', user: 'nobody', sshKeyPath: '/nonexistent/key', port: 1 },
+      { timeoutMs: 5000 },
+    );
+
+    expect(result.reachable).toBe(false);
+    expect(result.message).toBeTruthy();
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -13,5 +13,6 @@ export * from './hourly-snapshot-retention.ts';
 export * from './invoker-config-io.ts';
 export * from './config-diagnostics.ts';
 export * from './prerequisites.ts';
+export * from './remote-target-onboarding.ts';
 export * from './headless-owner-launch.ts';
 export { EXTERNAL_DEPENDENCIES, DEFAULT_DRAFTER_MCP_PACKAGE_SPEC } from './external-dependencies.ts';

--- a/packages/contracts/src/remote-target-onboarding.ts
+++ b/packages/contracts/src/remote-target-onboarding.ts
@@ -1,0 +1,169 @@
+import type { InvokerConfigRecord } from './invoker-config-io.ts';
+
+export interface RemoteTargetInput {
+  id: string;
+  host: string;
+  user: string;
+  sshKeyPath: string;
+  port?: number;
+  maxConcurrentTasks?: number;
+  provisionCommand?: string;
+}
+
+export interface AddRemoteTargetError {
+  code: 'duplicate-id' | 'duplicate-host';
+  message: string;
+  conflictingTargetId: string;
+}
+
+export type AddRemoteTargetResult =
+  | { ok: true; config: InvokerConfigRecord }
+  | { ok: false; error: AddRemoteTargetError };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function existingRemoteTargets(config: InvokerConfigRecord): Record<string, unknown> {
+  return isRecord(config.remoteTargets) ? config.remoteTargets : {};
+}
+
+export function addRemoteTarget(config: InvokerConfigRecord, input: RemoteTargetInput): AddRemoteTargetResult {
+  const targets = existingRemoteTargets(config);
+
+  if (Object.prototype.hasOwnProperty.call(targets, input.id)) {
+    return {
+      ok: false,
+      error: {
+        code: 'duplicate-id',
+        message: `remoteTargets already contains a target with id "${input.id}"`,
+        conflictingTargetId: input.id,
+      },
+    };
+  }
+
+  for (const [id, target] of Object.entries(targets)) {
+    if (isRecord(target) && target.host === input.host) {
+      return {
+        ok: false,
+        error: {
+          code: 'duplicate-host',
+          message: `remoteTargets."${id}" already uses host "${input.host}"`,
+          conflictingTargetId: id,
+        },
+      };
+    }
+  }
+
+  const entry: Record<string, unknown> = {
+    host: input.host,
+    user: input.user,
+    sshKeyPath: input.sshKeyPath,
+  };
+  if (input.port !== undefined) entry.port = input.port;
+  if (input.maxConcurrentTasks !== undefined) entry.maxConcurrentTasks = input.maxConcurrentTasks;
+  if (input.provisionCommand !== undefined) entry.provisionCommand = input.provisionCommand;
+
+  return {
+    ok: true,
+    config: {
+      ...config,
+      remoteTargets: { ...targets, [input.id]: entry },
+    },
+  };
+}
+
+export interface RemoteTargetConnectionSpec {
+  host: string;
+  user: string;
+  sshKeyPath: string;
+  port?: number;
+}
+
+export interface RemoteTargetConnectivityResult {
+  reachable: boolean;
+  message?: string;
+}
+
+export type RemoteTargetConnectivityImpl = (
+  target: RemoteTargetConnectionSpec,
+) => RemoteTargetConnectivityResult | Promise<RemoteTargetConnectivityResult>;
+
+export interface CheckRemoteTargetConnectivityOptions {
+  impl?: RemoteTargetConnectivityImpl;
+  timeoutMs?: number;
+}
+
+const DEFAULT_PROBE_TIMEOUT_MS = 10_000;
+
+export async function checkRemoteTargetConnectivity(
+  target: RemoteTargetConnectionSpec,
+  opts?: CheckRemoteTargetConnectivityOptions,
+): Promise<RemoteTargetConnectivityResult> {
+  if (typeof opts?.impl === 'function') {
+    return await opts.impl(target);
+  }
+  return runSshProbe(target, opts?.timeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS);
+}
+
+async function runSshProbe(
+  target: RemoteTargetConnectionSpec,
+  timeoutMs: number,
+): Promise<RemoteTargetConnectivityResult> {
+  // Lazy import keeps this module browser-safe for the UI bundle (see prerequisites.ts).
+  const { spawn } = await import('node:child_process');
+  const connectTimeoutSeconds = Math.max(1, Math.floor(timeoutMs / 1000));
+
+  return new Promise((resolve) => {
+    const child = spawn(
+      'ssh',
+      [
+        '-i',
+        target.sshKeyPath,
+        '-p',
+        String(target.port ?? 22),
+        '-o',
+        'BatchMode=yes',
+        '-o',
+        `ConnectTimeout=${connectTimeoutSeconds}`,
+        '-o',
+        'StrictHostKeyChecking=accept-new',
+        `${target.user}@${target.host}`,
+        'exit 0',
+      ],
+      { stdio: ['ignore', 'ignore', 'pipe'] },
+    );
+
+    let stderr = '';
+    let settled = false;
+    const settle = (result: RemoteTargetConnectivityResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      settle({ reachable: false, message: `ssh probe timed out after ${timeoutMs}ms` });
+    }, timeoutMs);
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (error) => {
+      settle({ reachable: false, message: `failed to run ssh: ${error.message}` });
+    });
+    child.on('close', (code) => {
+      if (code === 0) {
+        settle({ reachable: true });
+        return;
+      }
+      const detail = stderr.trim();
+      settle({
+        reachable: false,
+        message: detail.length > 0 ? detail : `ssh exited with code ${code}`,
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds one new domain module for adding a machine to `~/.invoker/config.json` from a future guided wizard.

`addRemoteTarget()` appends a machine to config additively. `checkRemoteTargetConnectivity()` checks SSH reachability, with an injectable implementation for tests.

Today adding a machine means hand-editing `~/.invoker/config.json`. This module is the shared, testable prerequisite for any guided add-machine wizard.

No other package imports this module yet. CLI wizard, app bridge, and GUI wizard wiring land as separate later PRs in this stack.

## Review Claim

Approve one new domain module, `packages/contracts/src/remote-target-onboarding.ts`, exposing an additive-only config writer and an injectable connectivity check, with no other package wired to call it yet.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

`addRemoteTarget()` never mutates or drops any existing `remoteTargets`/`executionPools` entry. When input is rejected or a write is declined, it returns the input config object unchanged (same reference, no partial merge).

## Slice Rationale

This base module has zero callers in this stack. Every consumer (CLI wizard, app bridge, GUI wizard) lands as its own separate, later-reviewed PR so this module is reviewable in isolation.

## Non-goals

No CLI or GUI wiring in this PR. No config schema changes. No doctor changes. No test-stub wiring for consumers — that lands in later PRs in this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/contracts && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for onboarding remote targets with configurable connection and provisioning settings.
  * Added validation to prevent duplicate target IDs and hostnames.
  * Added remote-target connectivity checks with configurable timeouts and clear failure reporting.

* **Tests**
  * Added coverage for onboarding, validation, configuration handling, connectivity failures, and unreachable targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->