### PR TITLE
Fix standalone owner rejecting invoker:edit-task-pool with TransportError

### DIFF
--- a/packages/app/src/__tests__/gui-mutation-translation.test.ts
+++ b/packages/app/src/__tests__/gui-mutation-translation.test.ts
@@ -123,6 +123,13 @@ describe('GUI mutation translation', () => {
     );
   });
 
+  it('handles edit-task-pool in the standalone owner GUI mutation switch', () => {
+    const standaloneGuiMutationSource = getStandaloneGuiMutationSource();
+    expect(standaloneGuiMutationSource).toMatch(
+      /case 'invoker:edit-task-pool':\s*\{[\s\S]*commandService\.editTaskPool\(envelope\)[\s\S]*dispatchStartedTasksWithGlobalTopup\(/,
+    );
+  });
+
   it('publishes workflow metadata after every successful workflow delete', () => {
     const deleteSource = getPerformDeleteWorkflowSource();
     expect(deleteSource).toMatch(

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1390,6 +1390,23 @@ function startHeadlessMode(): void {
             if (!result.ok) throw new Error(result.error.message);
             return undefined;
           }
+          case 'invoker:edit-task-pool': {
+            const taskId = String(payload.args[0]);
+            const poolId = String(payload.args[1]);
+            const executor = createStandaloneTaskExecutor();
+            const envelope = makeEnvelope('edit-task-pool', 'ui', 'task', { taskId, poolId });
+            const result = await commandService.editTaskPool(envelope);
+            if (!result.ok) throw new Error(result.error.message);
+            await dispatchStartedTasksWithGlobalTopup({
+              orchestrator,
+              taskExecutor: executor,
+              logger,
+              context: 'standalone.edit-task-pool',
+              started: result.data,
+              scopedTaskIds: [taskId],
+            });
+            return undefined;
+          }
           default:
             throw new Error(`Unsupported internal mutation for standalone owner: ${payload.channel}`);
         }


### PR DESCRIPTION
## Summary

Moving a task to a different execution pool from the app threw an error and did nothing.

The app's mutation handler for that action already existed and was correct.

But the code path that runs mutations for the app's background process never learned about it, so every call hit a fallback that raises an error.

This adds the missing case, using the exact same call the existing, already-tested handler uses.

## Review Claim

The standalone owner's mutation switch now handles `invoker:edit-task-pool` instead of throwing on every call, calling `editTaskPool` the same way its sibling cases in the same switch already do.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new case only calls the existing, already-exercised `commandService.editTaskPool`, does not change that method or any other case in the switch, and only affects the `invoker:edit-task-pool` channel.

## Slice Rationale

One case added to fix one reported error, plus the regression test that proves it; nothing else in this switch changes.

## Non-goals

Does not add the other similarly-named `edit-task-*` cases in this same switch; each has its own reported gap, if any, and would be its own separate slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm build`
- [ ] `cd packages/app && pnpm vitest run src/__tests__/gui-mutation-translation.test.ts`
- [ ] `cd packages/app && pnpm vitest run src/__tests__/persisted-workflow-mutation-coordinator.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
