### PR TITLE
[Launch-Dispatch Invariant Fixes](3) Add abandon_reason column and thread it through every abandon write site

### DIFF
--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -349,7 +349,7 @@ export class LaunchDispatcher {
     reason: string,
     details: Record<string, unknown> = {},
   ): void {
-    const accepted = this.persistence.markLaunchDispatchAbandoned(dispatch.id, message);
+    const accepted = this.persistence.markLaunchDispatchAbandoned(dispatch.id, message, undefined, reason);
     if (accepted) {
       this.releaseTaskResourceLeases(dispatch.taskId, dispatch.id, reason);
     }
@@ -425,7 +425,7 @@ export class LaunchDispatcher {
         row,
         row.lastError ?? 'no concrete error recorded',
       );
-      if (!this.abandonDispatch(row, message, nowIso)) continue;
+      if (!this.abandonDispatch(row, message, nowIso, 'stuck-lease')) continue;
       abandoned += 1;
       this.recordAbandonedStuckLease(row, message);
     }
@@ -453,8 +453,13 @@ export class LaunchDispatcher {
     return `Launch dispatch abandoned after ${row.attemptsCount} attempt(s); last error: ${lastError}`;
   }
 
-  private abandonDispatch(row: TaskLaunchDispatch, message: string, nowIso?: string): boolean {
-    const accepted = this.persistence.markLaunchDispatchAbandoned(row.id, message, nowIso);
+  private abandonDispatch(
+    row: TaskLaunchDispatch,
+    message: string,
+    nowIso?: string,
+    abandonReason?: string,
+  ): boolean {
+    const accepted = this.persistence.markLaunchDispatchAbandoned(row.id, message, nowIso, abandonReason);
     if (!accepted) return false;
 
     this.releaseTaskResourceLeases(row.taskId, row.id);
@@ -632,10 +637,11 @@ export class LaunchDispatcher {
     const row = this.persistence.loadLaunchDispatchById(dispatchId);
 
     if (row && (this.shouldAbandonAfterFastFailure(row) || row.acknowledgedAt)) {
-      const reason = row.acknowledgedAt
+      const detail = row.acknowledgedAt
         ? `Post-accept launch failure (dispatch already running): ${message}`
         : this.launchDispatchAbandonedMessage(row, message);
-      const accepted = this.abandonDispatch(row, reason);
+      const abandonReason = row.acknowledgedAt ? 'post-accept-failure' : 'fast-failure';
+      const accepted = this.abandonDispatch(row, detail, undefined, abandonReason);
       this.logger?.warn?.(
         row.acknowledgedAt
           ? '[launch-dispatcher] abandoned a post-accept failure instead of re-enqueuing'

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -506,6 +506,8 @@ export interface TaskLaunchDispatch {
   generation: number;
   /** Set once the executor is confirmed live (markLaunchDispatchAccepted). */
   acknowledgedAt?: string;
+  /** Category label for why an 'abandoned' row was abandoned. */
+  abandonReason?: string;
 }
 
 type TerminalSessionRow = {
@@ -3601,6 +3603,17 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return row ? Number(row.count) : 0;
   }
 
+  /** Relabels a task's stuck-lease abandons. Prep for a later slice that scopes the retry count to `abandon_reason`; has no effect on the current unscoped count. */
+  resetStuckLeaseAbandonCount(taskId: string): number {
+    this.execRun(
+      `UPDATE task_launch_dispatch
+         SET abandon_reason = 'stuck-lease-reset'
+       WHERE task_id = ? AND state = 'abandoned' AND abandon_reason = 'stuck-lease'`,
+      [taskId],
+    );
+    return this.db.getRowsModified?.() ?? 0;
+  }
+
   loadLaunchDispatchByAttempt(attemptId: string): TaskLaunchDispatch | undefined {
     const row = this.queryOne(
       `SELECT * FROM task_launch_dispatch
@@ -3693,7 +3706,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
                    completed_at = ?,
                    last_error = ?,
                    dispatch_owner = NULL,
-                   fenced_until = NULL
+                   fenced_until = NULL,
+                   abandon_reason = 'stale-claim'
              WHERE id = ?
                AND state = 'enqueued'`,
             [now, staleReason, candidateId],
@@ -3819,11 +3833,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
   /**
    * Terminal abandon: row leaves the live set. Returns false when the row
    * is already terminal so callers can treat a race as a no-op.
+   * `abandonReason` is a stable category label, separate from `errorMessage`.
    */
   markLaunchDispatchAbandoned(
     id: number,
     errorMessage: string,
     nowIso?: string,
+    abandonReason?: string,
   ): boolean {
     const now = nowIso ?? new Date().toISOString();
     this.execRun(
@@ -3832,10 +3848,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
              completed_at = ?,
              last_error = ?,
              dispatch_owner = NULL,
-             fenced_until = NULL
+             fenced_until = NULL,
+             abandon_reason = COALESCE(?, abandon_reason)
        WHERE id = ?
          AND state NOT IN ('completed', 'abandoned')`,
-      [now, errorMessage, id],
+      [now, errorMessage, abandonReason ?? null, id],
     );
     return (this.db.getRowsModified?.() ?? 0) > 0;
   }
@@ -3869,7 +3886,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
                 completed_at = ?,
                 last_error = ?,
                 dispatch_owner = NULL,
-                fenced_until = NULL
+                fenced_until = NULL,
+                abandon_reason = 'lifecycle-reset'
           WHERE id IN (${idPlaceholders})
             AND state IN ('enqueued', 'leased')`,
         [now, reason, ...rowIds],

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -188,6 +188,7 @@ export function mapRowToTaskLaunchDispatch(row: Record<string, unknown>): TaskLa
     lastError: row.last_error ? String(row.last_error) : undefined,
     generation: Number(row.generation ?? 0),
     acknowledgedAt: row.acknowledged_at ? String(row.acknowledged_at) : undefined,
+    abandonReason: row.abandon_reason ? String(row.abandon_reason) : undefined,
   };
 }
 

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -397,6 +397,7 @@ export const SCHEMA_DDL = `
         attempts_count INTEGER NOT NULL DEFAULT 0,
         last_error TEXT,
         generation INTEGER NOT NULL,
+        abandon_reason TEXT,
         FOREIGN KEY (task_id) REFERENCES tasks(id),
         FOREIGN KEY (workflow_id) REFERENCES workflows(id)
       );
@@ -602,6 +603,10 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN base_commit TEXT',
   'ALTER TABLE in_app_planning_sessions ADD COLUMN worktree_path TEXT',
   'ALTER TABLE in_app_planning_sessions ADD COLUMN worktree_branch TEXT',
+  // abandon_reason: why a launch dispatch row was abandoned (e.g.
+  // 'stuck-lease', 'lifecycle-reset', 'stale-claim'). Written now, read by
+  // a later slice's scoped retry count -- unused for now.
+  'ALTER TABLE task_launch_dispatch ADD COLUMN abandon_reason TEXT',
 ];
 
 /**


### PR DESCRIPTION
## Summary

Today, a task's stuck-launch abandon budget is eroded by cancel and recreate events, not just genuine stuck-launch abandons.

This slice lays the groundwork to fix that: a new column records why a launch dispatch row left the live set, and every write site now sets it.

Nothing reads this new column for decisions yet, so behavior is unchanged. The next slices use it to narrow the abandon budget and add a reset hook.

## Review Claim

Approve a new `abandon_reason` column, written by every abandon call site, with no behavior change yet.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The one query that could observe this column (the stuck-lease count) is left unscoped in this slice, so it still counts every abandon reason exactly as before. Full data-store suite (435 tests) and app launch-dispatcher suite (37 tests) pass unchanged; both packages build clean.

## Slice Rationale

The proof in the next slice needs this column and its write sites to exist so the assertions can compile and run. Landing it as a dormant foundation slice keeps that proof focused on its actual claim.

## Non-goals

Does not change what `countAbandonedLaunchDispatchesForTask` counts. Does not add the reset hook for a fresh task attempt -- later slices.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store --filter @invoker/app build`
- [x] `pnpm --filter @invoker/data-store exec vitest run` (435/435 passed)
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/launch-dispatcher.test.ts` (37/37 passed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No (column stays, unused, on revert)

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launch dispatch recovery by recording specific abandonment reasons.
  * Stale lease recoveries can now be reset without counting toward retry limits.
  * Preserved existing abandonment messages and cleanup behavior while improving lifecycle tracking.
* **Data Improvements**
  * Existing databases are migrated automatically to store dispatch abandonment details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #7233