### PR TITLE
[Launch-Dispatch Invariant Fixes](5) Scope the stuck-lease retry cap to stuck-lease abandons only

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1842,7 +1842,7 @@ describe('SQLiteAdapter', () => {
       expect(adapter.loadLaunchDispatchById(unrelated.id)?.state).toBe('enqueued');
     });
 
-    it.fails('abandonLaunchDispatchesForTasks tags rows with abandon_reason=lifecycle-reset', () => {
+    it('abandonLaunchDispatchesForTasks tags rows with abandon_reason=lifecycle-reset', () => {
       adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
       saveLaunchTask('wf-launch', 'wf-launch/t1', 'attempt-reason-check');
       const row = adapter.enqueueLaunchDispatch({
@@ -1858,7 +1858,7 @@ describe('SQLiteAdapter', () => {
       expect(adapter.countAbandonedLaunchDispatchesForTask('wf-launch/t1')).toBe(0);
     });
 
-    it.fails('countAbandonedLaunchDispatchesForTask only counts stuck-lease abandons, and resetStuckLeaseAbandonCount clears them', () => {
+    it('countAbandonedLaunchDispatchesForTask only counts stuck-lease abandons, and resetStuckLeaseAbandonCount clears them', () => {
       adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
       saveLaunchTask('wf-launch', 'wf-launch/t1', 'attempt-mixed-1');
 

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3590,14 +3590,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   /**
-   * Durable, generation-independent count of how many times a task's launch
-   * dispatch has been abandoned (any reason). Each `prepareTaskForNewAttempt`
-   * call creates a new row, so this is the only place the total survives
-   * across attempts -- used to cap `abandonStuckLeases` retries per task.
+   * Durable count of stuck-lease abandons for a task, used to cap
+   * `abandonStuckLeases` retries. Scoped to `abandon_reason = 'stuck-lease'`
+   * so cancel/retry/recreate abandons don't erode this budget.
    */
   countAbandonedLaunchDispatchesForTask(taskId: string): number {
     const row = this.queryOne(
-      `SELECT COUNT(*) as count FROM task_launch_dispatch WHERE task_id = ? AND state = 'abandoned'`,
+      `SELECT COUNT(*) as count FROM task_launch_dispatch WHERE task_id = ? AND state = 'abandoned' AND abandon_reason = 'stuck-lease'`,
       [taskId],
     );
     return row ? Number(row.count) : 0;


### PR DESCRIPTION
## Summary

Fixes the over-counting bug proven in the previous slice: the stuck-launch abandon count now filters on `abandon_reason = 'stuck-lease'`.

Cancel and recreate abandons no longer erode the same budget as a genuine stuck-launch abandon. Those events are legitimate and unrelated.

## Review Claim

Approve narrowing the stuck-launch abandon count to only count `abandon_reason = 'stuck-lease'` rows.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Only the WHERE clause of one read-only count query changes; every write site already sets the reason column from the previous slice. The 2 proof tests from the previous slice now pass unmarked, and the full data-store suite (437 tests) passes.

## Slice Rationale

This is the fix half of the pair started in the previous slice, kept as its own slice so the bug proof and the behavior change review separately.

## Non-goals

Does not add the hook that clears a task's count on a fresh attempt -- that is the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/data-store build`
- [x] `pnpm --filter @invoker/data-store exec vitest run` (437/437 passed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7235