### PR TITLE
[Launch-Dispatch Invariant Fixes](6) Reset the stuck-lease abandon count when a task is recreated

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -235,7 +235,7 @@ describe('LaunchDispatcher', () => {
       expect(dispatcher.failDispatch(enqueued.id, 'too late')).toBe(false);
     });
 
-    it.fails('fail abandons an already-accepted row instead of silently re-enqueuing it', () => {
+    it('fail abandons an already-accepted row instead of silently re-enqueuing it', () => {
       seedWorkflowAndTask('attempt-fail-post-accept');
       const enqueued = adapter.enqueueLaunchDispatch({
         taskId: 'wf-1/t1',
@@ -322,7 +322,7 @@ describe('LaunchDispatcher', () => {
       expect(dispatcher.reapExpiredLeases()).toBe(0);
     });
 
-    it.fails('reapExpiredLeases does not reset an accepted row even past its fence (healthy long-running task)', () => {
+    it('reapExpiredLeases does not reset an accepted row even past its fence (healthy long-running task)', () => {
       seed();
       const row = adapter.enqueueLaunchDispatch({
         taskId: 'wf-r/t1',
@@ -381,7 +381,7 @@ describe('LaunchDispatcher', () => {
       });
     });
 
-    it.fails('abandonStuckLeases does not abandon an accepted row via attempts_count alone', () => {
+    it('abandonStuckLeases does not abandon an accepted row via attempts_count alone', () => {
       seed();
       const row = adapter.enqueueLaunchDispatch({
         taskId: 'wf-r/t1',

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1516,6 +1516,12 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       deferRunningUntilLaunch: true,
       onRecreateTasksReset: (taskIds) => {
         resetAutoFixBudgetForTasks(persistence, taskIds);
+        // A deliberate recreate is a fresh start -- past stuck-lease
+        // abandons for these tasks should not count against the new
+        // attempt's retry budget either.
+        for (const taskId of new Set(taskIds)) {
+          persistence.resetStuckLeaseAbandonCount(taskId);
+        }
       },
     });
     commandService = new CommandService(

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -620,9 +620,10 @@ export class LaunchDispatcher {
   }
 
   /**
-   * Record a launch failure. Normal failures are retried by re-enqueuing
-   * the row. A row that has already used its retry budget is abandoned
-   * instead. The TaskRunner still owns the task failure response, so this
+   * Record a launch failure. Re-enqueues the row unless it already used its
+   * retry budget or already reached `acceptDispatch` -- an accepted row is
+   * abandoned instead, since re-enqueuing it would look like it never
+   * launched. The TaskRunner still owns the task failure response, so this
    * path must not prepare a fresh attempt here.
    */
   failDispatch(dispatchId: number, error: unknown): boolean {
@@ -630,19 +631,25 @@ export class LaunchDispatcher {
       error instanceof Error ? error.message : String(error ?? 'unknown launch error');
     const row = this.persistence.loadLaunchDispatchById(dispatchId);
 
-    if (row && this.shouldAbandonAfterFastFailure(row)) {
-      const accepted = this.abandonDispatch(
-        row,
-        this.launchDispatchAbandonedMessage(row, message),
+    if (row && (this.shouldAbandonAfterFastFailure(row) || row.acknowledgedAt)) {
+      const reason = row.acknowledgedAt
+        ? `Post-accept launch failure (dispatch already running): ${message}`
+        : this.launchDispatchAbandonedMessage(row, message);
+      const accepted = this.abandonDispatch(row, reason);
+      this.logger?.warn?.(
+        row.acknowledgedAt
+          ? '[launch-dispatcher] abandoned a post-accept failure instead of re-enqueuing'
+          : '[launch-dispatcher] abandoned after fast failures',
+        {
+          ownerId: this.ownerId,
+          dispatchId,
+          attemptsCount: row.attemptsCount,
+          acknowledged: Boolean(row.acknowledgedAt),
+          error: message,
+          accepted,
+          module: 'launch-dispatcher',
+        },
       );
-      this.logger?.warn?.('[launch-dispatcher] abandoned after fast failures', {
-        ownerId: this.ownerId,
-        dispatchId,
-        attemptsCount: row.attemptsCount,
-        error: message,
-        accepted,
-        module: 'launch-dispatcher',
-      });
       return accepted;
     }
 

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -349,7 +349,7 @@ export class LaunchDispatcher {
     reason: string,
     details: Record<string, unknown> = {},
   ): void {
-    const accepted = this.persistence.markLaunchDispatchAbandoned(dispatch.id, message);
+    const accepted = this.persistence.markLaunchDispatchAbandoned(dispatch.id, message, undefined, reason);
     if (accepted) {
       this.releaseTaskResourceLeases(dispatch.taskId, dispatch.id, reason);
     }
@@ -425,7 +425,7 @@ export class LaunchDispatcher {
         row,
         row.lastError ?? 'no concrete error recorded',
       );
-      if (!this.abandonDispatch(row, message, nowIso)) continue;
+      if (!this.abandonDispatch(row, message, nowIso, 'stuck-lease')) continue;
       abandoned += 1;
       this.recordAbandonedStuckLease(row, message);
     }
@@ -453,8 +453,13 @@ export class LaunchDispatcher {
     return `Launch dispatch abandoned after ${row.attemptsCount} attempt(s); last error: ${lastError}`;
   }
 
-  private abandonDispatch(row: TaskLaunchDispatch, message: string, nowIso?: string): boolean {
-    const accepted = this.persistence.markLaunchDispatchAbandoned(row.id, message, nowIso);
+  private abandonDispatch(
+    row: TaskLaunchDispatch,
+    message: string,
+    nowIso?: string,
+    abandonReason?: string,
+  ): boolean {
+    const accepted = this.persistence.markLaunchDispatchAbandoned(row.id, message, nowIso, abandonReason);
     if (!accepted) return false;
 
     this.releaseTaskResourceLeases(row.taskId, row.id);
@@ -632,10 +637,11 @@ export class LaunchDispatcher {
     const row = this.persistence.loadLaunchDispatchById(dispatchId);
 
     if (row && (this.shouldAbandonAfterFastFailure(row) || row.acknowledgedAt)) {
-      const reason = row.acknowledgedAt
+      const detail = row.acknowledgedAt
         ? `Post-accept launch failure (dispatch already running): ${message}`
         : this.launchDispatchAbandonedMessage(row, message);
-      const accepted = this.abandonDispatch(row, reason);
+      const abandonReason = row.acknowledgedAt ? 'post-accept-failure' : 'fast-failure';
+      const accepted = this.abandonDispatch(row, detail, undefined, abandonReason);
       this.logger?.warn?.(
         row.acknowledgedAt
           ? '[launch-dispatcher] abandoned a post-accept failure instead of re-enqueuing'

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1842,7 +1842,7 @@ describe('SQLiteAdapter', () => {
       expect(adapter.loadLaunchDispatchById(unrelated.id)?.state).toBe('enqueued');
     });
 
-    it.fails('abandonLaunchDispatchesForTasks tags rows with abandon_reason=lifecycle-reset', () => {
+    it('abandonLaunchDispatchesForTasks tags rows with abandon_reason=lifecycle-reset', () => {
       adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
       saveLaunchTask('wf-launch', 'wf-launch/t1', 'attempt-reason-check');
       const row = adapter.enqueueLaunchDispatch({
@@ -1858,7 +1858,7 @@ describe('SQLiteAdapter', () => {
       expect(adapter.countAbandonedLaunchDispatchesForTask('wf-launch/t1')).toBe(0);
     });
 
-    it.fails('countAbandonedLaunchDispatchesForTask only counts stuck-lease abandons, and resetStuckLeaseAbandonCount clears them', () => {
+    it('countAbandonedLaunchDispatchesForTask only counts stuck-lease abandons, and resetStuckLeaseAbandonCount clears them', () => {
       adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
       saveLaunchTask('wf-launch', 'wf-launch/t1', 'attempt-mixed-1');
 

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1842,6 +1842,60 @@ describe('SQLiteAdapter', () => {
       expect(adapter.loadLaunchDispatchById(unrelated.id)?.state).toBe('enqueued');
     });
 
+    it.fails('abandonLaunchDispatchesForTasks tags rows with abandon_reason=lifecycle-reset', () => {
+      adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
+      saveLaunchTask('wf-launch', 'wf-launch/t1', 'attempt-reason-check');
+      const row = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-reason-check',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      adapter.abandonLaunchDispatchesForTasks(['wf-launch/t1'], 'workflow cancelled');
+      expect(adapter.loadLaunchDispatchById(row.id)?.abandonReason).toBe('lifecycle-reset');
+      // Lifecycle-reset abandons must not erode the stuck-lease retry
+      // budget -- they are unrelated, legitimate events.
+      expect(adapter.countAbandonedLaunchDispatchesForTask('wf-launch/t1')).toBe(0);
+    });
+
+    it.fails('countAbandonedLaunchDispatchesForTask only counts stuck-lease abandons, and resetStuckLeaseAbandonCount clears them', () => {
+      adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
+      saveLaunchTask('wf-launch', 'wf-launch/t1', 'attempt-mixed-1');
+
+      const stuck1 = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1', attemptId: 'attempt-mixed-1', workflowId: 'wf-launch', generation: 0,
+      });
+      adapter.markLaunchDispatchAbandoned(stuck1.id, 'looked stuck', undefined, 'stuck-lease');
+
+      const stuck2 = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1', attemptId: 'attempt-mixed-2', workflowId: 'wf-launch', generation: 1,
+      });
+      adapter.markLaunchDispatchAbandoned(stuck2.id, 'looked stuck again', undefined, 'stuck-lease');
+
+      const cancelled = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1', attemptId: 'attempt-mixed-3', workflowId: 'wf-launch', generation: 2,
+      });
+      adapter.markLaunchDispatchAbandoned(cancelled.id, 'user cancelled', undefined, 'lifecycle-reset');
+
+      const unlabelled = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1', attemptId: 'attempt-mixed-4', workflowId: 'wf-launch', generation: 3,
+      });
+      adapter.markLaunchDispatchAbandoned(unlabelled.id, 'no reason given');
+
+      // Only the two 'stuck-lease' rows count -- cancel and unlabelled abandons don't.
+      expect(adapter.countAbandonedLaunchDispatchesForTask('wf-launch/t1')).toBe(2);
+
+      const resetCount = adapter.resetStuckLeaseAbandonCount('wf-launch/t1');
+      expect(resetCount).toBe(2);
+      expect(adapter.countAbandonedLaunchDispatchesForTask('wf-launch/t1')).toBe(0);
+      // Relabelled, not deleted -- the row stays abandoned/auditable.
+      expect(adapter.loadLaunchDispatchById(stuck1.id)?.state).toBe('abandoned');
+      expect(adapter.loadLaunchDispatchById(stuck1.id)?.abandonReason).toBe('stuck-lease-reset');
+
+      // A second reset on an already-reset task is a no-op, not an error.
+      expect(adapter.resetStuckLeaseAbandonCount('wf-launch/t1')).toBe(0);
+    });
+
     it('releaseExecutionResourceLeasesForTasks releases only leases held by the selected task set', () => {
       adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
       saveLaunchTask('wf-launch', 'wf-launch/t1', 'attempt-lease-1');

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -506,6 +506,8 @@ export interface TaskLaunchDispatch {
   generation: number;
   /** Set once the executor is confirmed live (markLaunchDispatchAccepted). */
   acknowledgedAt?: string;
+  /** Category label for why an 'abandoned' row was abandoned. */
+  abandonReason?: string;
 }
 
 type TerminalSessionRow = {
@@ -3601,6 +3603,17 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return row ? Number(row.count) : 0;
   }
 
+  /** Relabels a task's stuck-lease abandons. Prep for a later slice that scopes the retry count to `abandon_reason`; has no effect on the current unscoped count. */
+  resetStuckLeaseAbandonCount(taskId: string): number {
+    this.execRun(
+      `UPDATE task_launch_dispatch
+         SET abandon_reason = 'stuck-lease-reset'
+       WHERE task_id = ? AND state = 'abandoned' AND abandon_reason = 'stuck-lease'`,
+      [taskId],
+    );
+    return this.db.getRowsModified?.() ?? 0;
+  }
+
   loadLaunchDispatchByAttempt(attemptId: string): TaskLaunchDispatch | undefined {
     const row = this.queryOne(
       `SELECT * FROM task_launch_dispatch
@@ -3693,7 +3706,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
                    completed_at = ?,
                    last_error = ?,
                    dispatch_owner = NULL,
-                   fenced_until = NULL
+                   fenced_until = NULL,
+                   abandon_reason = 'stale-claim'
              WHERE id = ?
                AND state = 'enqueued'`,
             [now, staleReason, candidateId],
@@ -3819,11 +3833,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
   /**
    * Terminal abandon: row leaves the live set. Returns false when the row
    * is already terminal so callers can treat a race as a no-op.
+   * `abandonReason` is a stable category label, separate from `errorMessage`.
    */
   markLaunchDispatchAbandoned(
     id: number,
     errorMessage: string,
     nowIso?: string,
+    abandonReason?: string,
   ): boolean {
     const now = nowIso ?? new Date().toISOString();
     this.execRun(
@@ -3832,10 +3848,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
              completed_at = ?,
              last_error = ?,
              dispatch_owner = NULL,
-             fenced_until = NULL
+             fenced_until = NULL,
+             abandon_reason = COALESCE(?, abandon_reason)
        WHERE id = ?
          AND state NOT IN ('completed', 'abandoned')`,
-      [now, errorMessage, id],
+      [now, errorMessage, abandonReason ?? null, id],
     );
     return (this.db.getRowsModified?.() ?? 0) > 0;
   }
@@ -3869,7 +3886,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
                 completed_at = ?,
                 last_error = ?,
                 dispatch_owner = NULL,
-                fenced_until = NULL
+                fenced_until = NULL,
+                abandon_reason = 'lifecycle-reset'
           WHERE id IN (${idPlaceholders})
             AND state IN ('enqueued', 'leased')`,
         [now, reason, ...rowIds],

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3590,14 +3590,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   /**
-   * Durable, generation-independent count of how many times a task's launch
-   * dispatch has been abandoned (any reason). Each `prepareTaskForNewAttempt`
-   * call creates a new row, so this is the only place the total survives
-   * across attempts -- used to cap `abandonStuckLeases` retries per task.
+   * Durable count of stuck-lease abandons for a task, used to cap
+   * `abandonStuckLeases` retries. Scoped to `abandon_reason = 'stuck-lease'`
+   * so cancel/retry/recreate abandons don't erode this budget.
    */
   countAbandonedLaunchDispatchesForTask(taskId: string): number {
     const row = this.queryOne(
-      `SELECT COUNT(*) as count FROM task_launch_dispatch WHERE task_id = ? AND state = 'abandoned'`,
+      `SELECT COUNT(*) as count FROM task_launch_dispatch WHERE task_id = ? AND state = 'abandoned' AND abandon_reason = 'stuck-lease'`,
       [taskId],
     );
     return row ? Number(row.count) : 0;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -504,6 +504,8 @@ export interface TaskLaunchDispatch {
   attemptsCount: number;
   lastError?: string;
   generation: number;
+  /** Set once the executor is confirmed live (markLaunchDispatchAccepted). */
+  acknowledgedAt?: string;
 }
 
 type TerminalSessionRow = {
@@ -3768,6 +3770,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return (this.db.getRowsModified?.() ?? 0) > 0;
   }
 
+  /** Guarded by `acknowledged_at IS NULL`: an accepted row must not be silently re-enqueued after a failure. */
   markLaunchDispatchFailed(
     id: number,
     errorMessage: string,
@@ -3780,7 +3783,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
              dispatch_owner = NULL,
              fenced_until = NULL
        WHERE id = ?
-         AND state NOT IN ('completed', 'abandoned')`,
+         AND state NOT IN ('completed', 'abandoned')
+         AND acknowledged_at IS NULL`,
       [errorMessage, id],
     );
     return (this.db.getRowsModified?.() ?? 0) > 0;
@@ -3801,9 +3805,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
          WHERE state = 'leased'
            AND fenced_until IS NOT NULL
            AND fenced_until < ?
+           AND acknowledged_at IS NULL
            AND (
              attempts_count >= ?
-             OR (acknowledged_at IS NULL AND ? IS NOT NULL AND enqueued_at <= ?)
+             OR (? IS NOT NULL AND enqueued_at <= ?)
            )
          ORDER BY id ASC`,
       [now, options.maxAttempts, ageCutoff, ageCutoff],
@@ -3881,6 +3886,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
     });
   }
 
+  /**
+   * Crash-recovery: a claim whose fence expired before launching is reset to
+   * 'enqueued'. Guarded by `acknowledged_at IS NULL` so a healthy task that
+   * just runs longer than its fence is never mistaken for a crashed claim.
+   */
   reapExpiredLaunchDispatchLeases(options: {
     nowIso?: string;
     maxAttempts?: number;
@@ -3893,7 +3903,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
            WHERE state = 'leased'
              AND fenced_until IS NOT NULL
              AND fenced_until < ?
-             AND attempts_count < ?`,
+             AND attempts_count < ?
+             AND acknowledged_at IS NULL`,
         [now, maxAttempts],
       );
       if (expired.length === 0) return [];
@@ -3905,7 +3916,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
          WHERE state = 'leased'
            AND fenced_until IS NOT NULL
            AND fenced_until < ?
-           AND attempts_count < ?`,
+           AND attempts_count < ?
+           AND acknowledged_at IS NULL`,
         [now, maxAttempts],
       );
       return expired.map((row) => {

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -188,6 +188,7 @@ export function mapRowToTaskLaunchDispatch(row: Record<string, unknown>): TaskLa
     lastError: row.last_error ? String(row.last_error) : undefined,
     generation: Number(row.generation ?? 0),
     acknowledgedAt: row.acknowledged_at ? String(row.acknowledged_at) : undefined,
+    abandonReason: row.abandon_reason ? String(row.abandon_reason) : undefined,
   };
 }
 

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -187,6 +187,7 @@ export function mapRowToTaskLaunchDispatch(row: Record<string, unknown>): TaskLa
     attemptsCount: Number(row.attempts_count ?? 0),
     lastError: row.last_error ? String(row.last_error) : undefined,
     generation: Number(row.generation ?? 0),
+    acknowledgedAt: row.acknowledged_at ? String(row.acknowledged_at) : undefined,
   };
 }
 

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -397,6 +397,7 @@ export const SCHEMA_DDL = `
         attempts_count INTEGER NOT NULL DEFAULT 0,
         last_error TEXT,
         generation INTEGER NOT NULL,
+        abandon_reason TEXT,
         FOREIGN KEY (task_id) REFERENCES tasks(id),
         FOREIGN KEY (workflow_id) REFERENCES workflows(id)
       );
@@ -602,6 +603,10 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE in_app_planning_sessions ADD COLUMN base_commit TEXT',
   'ALTER TABLE in_app_planning_sessions ADD COLUMN worktree_path TEXT',
   'ALTER TABLE in_app_planning_sessions ADD COLUMN worktree_branch TEXT',
+  // abandon_reason: why a launch dispatch row was abandoned (e.g.
+  // 'stuck-lease', 'lifecycle-reset', 'stale-claim'). Written now, read by
+  // a later slice's scoped retry count -- unused for now.
+  'ALTER TABLE task_launch_dispatch ADD COLUMN abandon_reason TEXT',
 ];
 
 /**


### PR DESCRIPTION
## Summary

A deliberately recreated task is a fresh start. It should not stay locked out of stuck-launch auto-recovery because of unrelated incidents from its prior attempts.

This slice wires the reset method added earlier in this stack into the same GUI recreate-task handler that already clears a task's auto-fix budget on recreate.

## Review Claim

Approve calling the stuck-launch abandon count reset for every task included in a GUI recreate-tasks mutation.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Adds one call inside an existing callback that already runs on every GUI recreate; the reset method itself only relabels rows, it does not delete or alter anything else. Existing gui-mutation-translation suite (23 tests) is unaffected; app package builds clean.

## Slice Rationale

This touches the IPC mutation-handler surface, a different review unit from the data-store/launch-dispatcher changes earlier in this stack, so it ships as its own slice.

## Non-goals

Does not change the count query itself -- landed two slices earlier. Does not add a reset hook anywhere outside the existing recreate-tasks handler.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/gui-mutation-translation.test.ts` (23/23 passed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7236