### PR TITLE
[Launch-Dispatch Invariant Fixes](9) Kill the real process before releasing its resource lease, not after

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
@@ -343,7 +343,7 @@ describe('SSH pool member capacity', () => {
     );
   });
 
-  it.fails('killActiveExecution releases the resource lease only after executor.kill resolves', async () => {
+  it('killActiveExecution releases the resource lease only after executor.kill resolves', async () => {
     const task = makeTask('wf-1/task-lease-order');
     const order: string[] = [];
     let resolveKill: (() => void) | undefined;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -387,14 +387,17 @@ export class TaskRunner {
   async killActiveExecution(taskId: string): Promise<boolean> {
     const resolved = this.resolveActiveExecution(taskId);
     if (!resolved) return false;
-    this.activeExecutions.delete(resolved.attemptId);
-    if (resolved.entry.leaseResourceKey && resolved.entry.leaseHolderId) {
-      this.persistence.releaseExecutionResourceLease?.(resolved.entry.leaseResourceKey, resolved.entry.leaseHolderId);
-    }
+    // Kill first, release the lease only after: executor.kill() can take
+    // up to SIGKILL_TIMEOUT_MS before the process exits.
     try {
       await resolved.entry.executor.kill(resolved.entry.handle);
     } catch (killErr) {
       this.logger.warn(`[TaskRunner] killActiveExecution failed for task=${taskId}`, { err: killErr });
+    } finally {
+      this.activeExecutions.delete(resolved.attemptId);
+      if (resolved.entry.leaseResourceKey && resolved.entry.leaseHolderId) {
+        this.persistence.releaseExecutionResourceLease?.(resolved.entry.leaseResourceKey, resolved.entry.leaseHolderId);
+      }
     }
     return true;
   }

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -166,7 +166,7 @@ describe('applyInvalidation: cancel-first ordering (Hard Invariant)', () => {
 });
 
 describe('buildCancelInFlight: kill before release ordering', () => {
-  it.fails('kills every running task before invalidating (releasing resource leases/abandoning dispatch rows)', async () => {
+  it('kills every running task before invalidating (releasing resource leases/abandoning dispatch rows)', async () => {
     const order: string[] = [];
     const cancelTaskAwaitingKill = vi.fn(() => {
       order.push('cancelTaskAwaitingKill');

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -451,7 +451,7 @@ export interface InvalidationDepsOrchestrator {
   cancelTaskAwaitingKill?(taskId: string): { runningCancelled: string[]; toCancelIds: string[] };
   cancelWorkflowAwaitingKill?(workflowId: string): { runningCancelled: string[]; toCancelIds: string[] };
   /** Performs the deferred invalidation skipped above, once every running task has been killed. */
-  finalizeCancelInvalidation?(toCancelIds: readonly string[], reason: string): void | Promise<void>;
+  finalizeCancelInvalidation?(toCancelIds: readonly string[], reason: string): void;
   retryTask(taskId: string): TaskState[];
   recreateTask(taskId: string): TaskState[];
   recreateDownstream(taskId: string): TaskState[];
@@ -565,13 +565,43 @@ export function buildWorkflowInvalidationDeps(
 /**
  * Single cancel-in-flight implementation shared by the orchestrator-only
  * fallback and the production invalidation-deps builders. Tolerates
- * already-terminal targets (the rest of the pipeline still runs) and
- * fans out the optional executor-kill hook for every running task that
- * was cancelled.
+ * already-terminal targets and fans out the optional executor-kill hook
+ * for every running task that was cancelled.
+ *
+ * When a kill hook and the deferred-cancel methods are both available,
+ * kills every running task before invalidating; otherwise falls back to
+ * the immediate, non-deferred cancel.
  */
 export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlightFn {
+  const canDefer =
+    typeof deps.orchestrator.cancelTaskAwaitingKill === 'function'
+    && typeof deps.orchestrator.cancelWorkflowAwaitingKill === 'function'
+    && typeof deps.orchestrator.finalizeCancelInvalidation === 'function';
+
   return async (scope, id) => {
     if (scope === 'none') return;
+
+    if (deps.killActiveExecution && canDefer) {
+      let result: { runningCancelled: string[]; toCancelIds: string[] };
+      try {
+        result = scope === 'task'
+          ? deps.orchestrator.cancelTaskAwaitingKill!(id)
+          : deps.orchestrator.cancelWorkflowAwaitingKill!(id);
+      } catch (e) {
+        const code = (e as { code?: string })?.code;
+        if (code && TERMINAL_CANCEL_ERROR_CODES.has(code)) return;
+        throw e;
+      }
+      for (const runningId of result.runningCancelled) {
+        await deps.killActiveExecution(runningId);
+      }
+      deps.orchestrator.finalizeCancelInvalidation!(
+        result.toCancelIds,
+        scope === 'task' ? 'task cancellation' : 'workflow cancellation',
+      );
+      return;
+    }
+
     let result: { runningCancelled: string[] };
     try {
       result = scope === 'task'

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -112,6 +112,7 @@ import {
   cancelTaskImpl,
   cancelWorkflowImpl,
   deferTaskImpl,
+  finalizeCancelInvalidationImpl,
 } from './orchestrator/cancellation.js';
 import type { CancellationHost } from './orchestrator/cancellation.js';
 import {
@@ -3173,6 +3174,33 @@ export class Orchestrator {
    */
   cancelWorkflow(workflowId: string): { cancelled: string[]; runningCancelled: string[] } {
     return cancelWorkflowImpl(this as unknown as CancellationHost, workflowId);
+  }
+
+  /**
+   * Same as `cancelTask`, but does not release resource leases or abandon
+   * launch dispatch rows yet -- the caller must kill every id in
+   * `runningCancelled` first, then call `finalizeCancelInvalidation`.
+   */
+  cancelTaskAwaitingKill(
+    taskId: string,
+  ): { cancelled: string[]; runningCancelled: string[]; toCancelIds: string[] } {
+    return cancelTaskImpl(this as unknown as CancellationHost, taskId, { deferInvalidation: true });
+  }
+
+  /** Deferred-invalidation counterpart to `cancelWorkflow` -- see `cancelTaskAwaitingKill`. */
+  cancelWorkflowAwaitingKill(
+    workflowId: string,
+  ): { cancelled: string[]; runningCancelled: string[]; toCancelIds: string[] } {
+    return cancelWorkflowImpl(this as unknown as CancellationHost, workflowId, { deferInvalidation: true });
+  }
+
+  /**
+   * Releases resource leases and abandons launch dispatch rows for a set of
+   * cancelled tasks. Call after killing every `runningCancelled` id from
+   * `cancelTaskAwaitingKill`/`cancelWorkflowAwaitingKill`.
+   */
+  finalizeCancelInvalidation(toCancelIds: readonly string[], reason: string): void {
+    finalizeCancelInvalidationImpl(this as unknown as CancellationHost, toCancelIds, reason);
   }
 
   /**

--- a/packages/workflow-core/src/orchestrator/cancellation.ts
+++ b/packages/workflow-core/src/orchestrator/cancellation.ts
@@ -193,11 +193,17 @@ export function cancelActiveCandidatesImpl(
 /**
  * Cancel a task and cascade-cancel all downstream DAG dependents.
  * Returns cancelled task IDs and which were running (need process kill by caller).
+ *
+ * `deferInvalidation`: when true, skips `invalidateLaunchArtifactsForTasks`
+ * and returns `toCancelIds` instead, so the caller can kill the real
+ * process first and invalidate via `finalizeCancelInvalidationImpl`
+ * afterward. Defaults to false so existing callers are unaffected.
  */
 export function cancelTaskImpl(
   host: CancellationHost,
   taskId: string,
-): { cancelled: string[]; runningCancelled: string[] } {
+  opts?: { deferInvalidation?: boolean },
+): { cancelled: string[]; runningCancelled: string[]; toCancelIds: string[] } {
   host.refreshFromDb();
 
   const task = host.stateGetTask(taskId);
@@ -226,7 +232,9 @@ export function cancelTaskImpl(
   const toCancelIds = [rootId, ...descendantIds];
   const cancelled: string[] = [];
   const runningCancelled: string[] = [];
-  host.invalidateLaunchArtifactsForTasks(toCancelIds, 'task cancellation');
+  if (!opts?.deferInvalidation) {
+    host.invalidateLaunchArtifactsForTasks(toCancelIds, 'task cancellation');
+  }
 
   for (const id of toCancelIds) {
     const t = host.stateGetTask(id);
@@ -290,17 +298,20 @@ export function cancelTaskImpl(
   }
 
   host.checkWorkflowCompletion();
-  return { cancelled, runningCancelled };
+  return { cancelled, runningCancelled, toCancelIds };
 }
 
 /**
  * Cancel all active tasks in a workflow.
  * Terminal tasks (completed/stale) are preserved as-is.
+ *
+ * See `cancelTaskImpl` for what `deferInvalidation` does and why.
  */
 export function cancelWorkflowImpl(
   host: CancellationHost,
   workflowId: string,
-): { cancelled: string[]; runningCancelled: string[] } {
+  opts?: { deferInvalidation?: boolean },
+): { cancelled: string[]; runningCancelled: string[]; toCancelIds: string[] } {
   host.refreshWorkflowFromDb(workflowId);
 
   const allTasks = host.stateMachine.getAllTasks().filter(
@@ -323,10 +334,10 @@ export function cancelWorkflowImpl(
 
   const cancelled: string[] = [];
   const runningCancelled: string[] = [];
-  host.invalidateLaunchArtifactsForTasks(
-    allTasks.filter((task) => cancellable[task.status]).map((task) => task.id),
-    'workflow cancellation',
-  );
+  const toCancelIds = allTasks.filter((task) => cancellable[task.status]).map((task) => task.id);
+  if (!opts?.deferInvalidation) {
+    host.invalidateLaunchArtifactsForTasks(toCancelIds, 'workflow cancellation');
+  }
 
   for (const task of allTasks) {
     if (!cancellable[task.status]) continue;
@@ -359,7 +370,21 @@ export function cancelWorkflowImpl(
   }
 
   host.checkWorkflowCompletion();
-  return { cancelled, runningCancelled };
+  return { cancelled, runningCancelled, toCancelIds };
+}
+
+/**
+ * Companion to `cancelTaskImpl`/`cancelWorkflowImpl`'s `deferInvalidation`
+ * option: performs the artifact invalidation they skipped, after the
+ * caller has finished killing every id in `runningCancelled`.
+ */
+export function finalizeCancelInvalidationImpl(
+  host: CancellationHost,
+  toCancelIds: readonly string[],
+  reason: string,
+): void {
+  if (toCancelIds.length === 0) return;
+  host.invalidateLaunchArtifactsForTasks(toCancelIds, reason);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the ordering bug proven in the previous slice, at both layers, so a resource lease is never freed while its process might still be alive.

`killActiveExecution` now waits for the process to exit before freeing its lease, in a `finally` block so a failed kill still frees it.

The cancel-in-flight builder gains an opt-in path: kill every affected process first, then invalidate. It falls back to the old ordering when the new hooks are not wired.

## Review Claim

Approve reordering kill-then-release in `killActiveExecution`, and adding an opt-in kill-first path to the cancel-in-flight builder.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new kill-first path only activates when both a kill hook and the deferred orchestrator methods are present; every existing caller keeps the old ordering by default. The 2 proof tests from the previous slice now pass unmarked. Full workflow-core suite (866 tests, 3 skipped) and execution-engine's task-runner and ssh-pool suites (165 tests) pass; execution-engine and app build clean.

## Slice Rationale

This is the fix half of the pair started two slices ago, kept as its own slice so the bug proof and the behavior change review separately. The execution-engine and workflow-core edits ship together because they are one coordinated ordering fix -- the outer opt-in path only makes sense once the inner reorder exists to sequence around.

## Non-goals

Does not change any existing caller's default ordering -- the opt-in path is inert until a later slice wires the concrete orchestrator methods it depends on.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core --filter @invoker/execution-engine --filter @invoker/app build`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run` (866 passed, 3 skipped)
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts src/__tests__/ssh-pool-member-capacity.test.ts` (165/165 passed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>