### PR TITLE
(D1) Add liveness-check plumbing for the resource-lease heartbeat sweep

### DIFF
--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -35,6 +35,13 @@ export type LaunchDispatcherPersistence = Pick<
   | 'logEvent'
 > & {
   releaseExpiredExecutionResourceLeases?(nowIso?: string): number;
+  listExpiredExecutionResourceLeases?(nowIso?: string): Array<{
+    resourceKey: string;
+    holderId: string;
+    taskId?: string;
+    metadata?: unknown;
+  }>;
+  renewExecutionResourceLease?(resourceKey: string, holderId: string): boolean;
 };
 
 /**
@@ -70,6 +77,13 @@ export interface LaunchDispatcherTaskRunner {
     task: TaskState,
     dispatchOpts?: { dispatchId: number; launchOutbox: LaunchOutboxAck },
   ): Promise<void>;
+  /**
+   * Optional: lets `sweepExpiredResourceLeases` tell a stalled-heartbeat
+   * lease on a genuinely live process apart from a true orphan before
+   * deciding whether to renew or release it.
+   */
+  readonly runnerInstanceId?: string;
+  hasActiveExecution?(taskId: string): boolean;
 }
 
 export interface LaunchDispatcherOptions {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3455,6 +3455,32 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return (this.db.getRowsModified?.() ?? 0) as number;
   }
 
+  /**
+   * Read-only variant of `releaseExpiredExecutionResourceLeases`: returns
+   * the rows that have expired instead of deleting them, so a caller can
+   * check whether the holder is actually still alive (a stalled heartbeat
+   * on a genuinely live process is not the same as an orphaned lease)
+   * before deciding to release vs. renew.
+   */
+  listExpiredExecutionResourceLeases(nowIso?: string): ExecutionResourceLease[] {
+    const cutoff = nowIso ?? new Date().toISOString();
+    return this.queryAll(
+      'SELECT * FROM execution_resource_leases WHERE lease_expires_at <= ? ORDER BY resource_key ASC, acquired_at ASC',
+      [cutoff],
+    ).map((row) => ({
+      resourceKey: String(row.resource_key),
+      resourceType: String(row.resource_type),
+      holderId: String(row.holder_id),
+      taskId: row.task_id ? String(row.task_id) : undefined,
+      poolId: row.pool_id ? String(row.pool_id) : undefined,
+      poolMemberId: row.pool_member_id ? String(row.pool_member_id) : undefined,
+      acquiredAt: String(row.acquired_at),
+      lastHeartbeatAt: String(row.last_heartbeat_at),
+      leaseExpiresAt: String(row.lease_expires_at),
+      metadata: row.metadata_json ? JSON.parse(String(row.metadata_json)) : undefined,
+    }));
+  }
+
   listExecutionResourceLeases(): ExecutionResourceLease[] {
     return this.queryAll(
       'SELECT * FROM execution_resource_leases ORDER BY resource_key ASC, acquired_at ASC',

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -382,6 +382,16 @@ export class TaskRunner {
   }
 
   /**
+   * True when this TaskRunner instance genuinely still has a live executor
+   * for `taskId`. Used to distinguish "the heartbeat stalled but the
+   * process is still alive" from "the process is actually gone" before
+   * treating a resource lease as safe to hand to a different task.
+   */
+  hasActiveExecution(taskId: string): boolean {
+    return this.resolveActiveExecution(taskId) !== undefined;
+  }
+
+  /**
    * Stop the executor child for a task that is currently in-flight (after orchestrator.cancelTask).
    */
   async killActiveExecution(taskId: string): Promise<boolean> {


### PR DESCRIPTION
Foundation for coupling the execution-resource-lease heartbeat clock to
real process liveness (next slices). Adds TaskRunner.hasActiveExecution,
a read-only listExpiredExecutionResourceLeases on the adapter, and
optional listExpiredExecutionResourceLeases/renewExecutionResourceLease/
runnerInstanceId/hasActiveExecution fields on the dispatcher's persistence
and task-runner dependency types.

Dormant by construction: sweepExpiredResourceLeases's logic is untouched,
so no observable behavior changes -- these are new capabilities nothing
calls yet. Full data-store suite (437 tests), app launch-dispatcher tests
(37 tests), and execution-engine's task-runner suite (147 tests) pass
unchanged; all three packages build clean.

Depends-On: #7240