### PR TITLE
[Launch-Dispatch Invariant Fixes](13) Prove a stalled-heartbeat lease on a live process gets released, not healed

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -1239,6 +1239,66 @@ describe('LaunchDispatcher', () => {
       expect(leases[0]?.resourceKey).toBe('ssh:live');
     });
 
+    it.fails('poll heals a stalled-heartbeat lease on a genuinely live process instead of releasing it', () => {
+      // Same runner instance, task still actively executing -- a stalled
+      // heartbeat here is not the same as an orphaned lease. Releasing it
+      // would let a different task claim the same SSH slot while this one
+      // is still using it.
+      expect(adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:stalled-heartbeat-live',
+        resourceType: 'ssh',
+        holderId: 'holder-live-task',
+        taskId: 'wf-r/still-running',
+        leaseMs: -1,
+        metadata: { runnerInstanceId: 'runner-1' },
+      })).toBe(true);
+      // True orphan: same runner instance, but no active execution for
+      // this task anymore (e.g. it already finished or crashed).
+      expect(adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:orphan-same-runner',
+        resourceType: 'ssh',
+        holderId: 'holder-orphan',
+        taskId: 'wf-r/no-longer-running',
+        leaseMs: -1,
+        metadata: { runnerInstanceId: 'runner-1' },
+      })).toBe(true);
+      // True orphan: a different runner instance entirely (crashed owner).
+      expect(adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:different-owner',
+        resourceType: 'ssh',
+        holderId: 'holder-other-owner',
+        taskId: 'wf-r/still-running',
+        leaseMs: -1,
+        metadata: { runnerInstanceId: 'runner-2-crashed' },
+      })).toBe(true);
+      // Stale holder from an abandoned attempt of the SAME task that now
+      // has a different, live attempt (and thus a different lease holder
+      // id) -- must not be healed just because the task itself is alive.
+      expect(adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:stale-attempt-same-task',
+        resourceType: 'ssh',
+        holderId: 'holder-old-attempt',
+        taskId: 'wf-r/still-running',
+        leaseMs: -1,
+        metadata: { runnerInstanceId: 'runner-1' },
+      })).toBe(true);
+
+      const hasActiveExecutionForLeaseHolder = vi.fn((holderId: string) => holderId === 'holder-live-task');
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-sweep-liveness',
+        taskRunnerProvider: () => ({
+          executeTask: vi.fn(),
+          runnerInstanceId: 'runner-1',
+          hasActiveExecutionForLeaseHolder,
+        }),
+      });
+      dispatcher.poll();
+
+      const remainingKeys = adapter.listExecutionResourceLeases().map((l) => l.resourceKey).sort();
+      expect(remainingKeys).toEqual(['ssh:stalled-heartbeat-live']);
+    });
+
     it('re-tops stranded ready work when free scheduler slots remain', () => {
       const strandedTask = {
         id: 'wf/ready',

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -35,6 +35,13 @@ export type LaunchDispatcherPersistence = Pick<
   | 'logEvent'
 > & {
   releaseExpiredExecutionResourceLeases?(nowIso?: string): number;
+  listExpiredExecutionResourceLeases?(nowIso?: string): Array<{
+    resourceKey: string;
+    holderId: string;
+    taskId?: string;
+    metadata?: unknown;
+  }>;
+  renewExecutionResourceLease?(resourceKey: string, holderId: string): boolean;
 };
 
 /**
@@ -70,6 +77,14 @@ export interface LaunchDispatcherTaskRunner {
     task: TaskState,
     dispatchOpts?: { dispatchId: number; launchOutbox: LaunchOutboxAck },
   ): Promise<void>;
+  /**
+   * Optional: lets the resource-lease sweep tell a stalled heartbeat on a
+   * live process apart from a true orphan. Checked by lease holder id (not
+   * task id alone) so a stale lease from an abandoned attempt isn't kept
+   * alive just because the task has since started a new attempt.
+   */
+  readonly runnerInstanceId?: string;
+  hasActiveExecutionForLeaseHolder?(holderId: string): boolean;
 }
 
 export interface LaunchDispatcherOptions {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3459,6 +3459,32 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return (this.db.getRowsModified?.() ?? 0) as number;
   }
 
+  /**
+   * Read-only variant of `releaseExpiredExecutionResourceLeases`: returns
+   * the rows that have expired instead of deleting them, so a caller can
+   * check whether the holder is actually still alive (a stalled heartbeat
+   * on a genuinely live process is not the same as an orphaned lease)
+   * before deciding to release vs. renew.
+   */
+  listExpiredExecutionResourceLeases(nowIso?: string): ExecutionResourceLease[] {
+    const cutoff = nowIso ?? new Date().toISOString();
+    return this.queryAll(
+      'SELECT * FROM execution_resource_leases WHERE lease_expires_at <= ? ORDER BY resource_key ASC, acquired_at ASC',
+      [cutoff],
+    ).map((row) => ({
+      resourceKey: String(row.resource_key),
+      resourceType: String(row.resource_type),
+      holderId: String(row.holder_id),
+      taskId: row.task_id ? String(row.task_id) : undefined,
+      poolId: row.pool_id ? String(row.pool_id) : undefined,
+      poolMemberId: row.pool_member_id ? String(row.pool_member_id) : undefined,
+      acquiredAt: String(row.acquired_at),
+      lastHeartbeatAt: String(row.last_heartbeat_at),
+      leaseExpiresAt: String(row.lease_expires_at),
+      metadata: row.metadata_json ? JSON.parse(String(row.metadata_json)) : undefined,
+    }));
+  }
+
   listExecutionResourceLeases(): ExecutionResourceLease[] {
     return this.queryAll(
       'SELECT * FROM execution_resource_leases ORDER BY resource_key ASC, acquired_at ASC',

--- a/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
@@ -343,7 +343,7 @@ describe('SSH pool member capacity', () => {
     );
   });
 
-  it.fails('killActiveExecution releases the resource lease only after executor.kill resolves', async () => {
+  it('killActiveExecution releases the resource lease only after executor.kill resolves', async () => {
     const task = makeTask('wf-1/task-lease-order');
     const order: string[] = [];
     let resolveKill: (() => void) | undefined;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -387,14 +387,17 @@ export class TaskRunner {
   async killActiveExecution(taskId: string): Promise<boolean> {
     const resolved = this.resolveActiveExecution(taskId);
     if (!resolved) return false;
-    this.activeExecutions.delete(resolved.attemptId);
-    if (resolved.entry.leaseResourceKey && resolved.entry.leaseHolderId) {
-      this.persistence.releaseExecutionResourceLease?.(resolved.entry.leaseResourceKey, resolved.entry.leaseHolderId);
-    }
+    // Kill first, release the lease only after: executor.kill() can take
+    // up to SIGKILL_TIMEOUT_MS before the process exits.
     try {
       await resolved.entry.executor.kill(resolved.entry.handle);
     } catch (killErr) {
       this.logger.warn(`[TaskRunner] killActiveExecution failed for task=${taskId}`, { err: killErr });
+    } finally {
+      this.activeExecutions.delete(resolved.attemptId);
+      if (resolved.entry.leaseResourceKey && resolved.entry.leaseHolderId) {
+        this.persistence.releaseExecutionResourceLease?.(resolved.entry.leaseResourceKey, resolved.entry.leaseHolderId);
+      }
     }
     return true;
   }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -382,6 +382,19 @@ export class TaskRunner {
   }
 
   /**
+   * True when some active execution's resource lease holder id matches
+   * `holderId`. Scoped by lease holder (not task id alone) so a stale
+   * lease from an abandoned attempt isn't mistaken for still-alive just
+   * because the task has since started a new attempt with a new lease.
+   */
+  hasActiveExecutionForLeaseHolder(holderId: string): boolean {
+    for (const entry of this.activeExecutions.values()) {
+      if (entry.leaseHolderId === holderId) return true;
+    }
+    return false;
+  }
+
+  /**
    * Stop the executor child for a task that is currently in-flight (after orchestrator.cancelTask).
    */
   async killActiveExecution(taskId: string): Promise<boolean> {

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -166,7 +166,7 @@ describe('applyInvalidation: cancel-first ordering (Hard Invariant)', () => {
 });
 
 describe('buildCancelInFlight: kill before release ordering', () => {
-  it.fails('kills every running task before invalidating (releasing resource leases/abandoning dispatch rows)', async () => {
+  it('kills every running task before invalidating (releasing resource leases/abandoning dispatch rows)', async () => {
     const order: string[] = [];
     const cancelTaskAwaitingKill = vi.fn(() => {
       order.push('cancelTaskAwaitingKill');

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -451,7 +451,7 @@ export interface InvalidationDepsOrchestrator {
   cancelTaskAwaitingKill?(taskId: string): { runningCancelled: string[]; toCancelIds: string[] };
   cancelWorkflowAwaitingKill?(workflowId: string): { runningCancelled: string[]; toCancelIds: string[] };
   /** Performs the deferred invalidation skipped above, once every running task has been killed. */
-  finalizeCancelInvalidation?(toCancelIds: readonly string[], reason: string): void | Promise<void>;
+  finalizeCancelInvalidation?(toCancelIds: readonly string[], reason: string): void;
   retryTask(taskId: string): TaskState[];
   recreateTask(taskId: string): TaskState[];
   recreateDownstream(taskId: string): TaskState[];
@@ -565,13 +565,43 @@ export function buildWorkflowInvalidationDeps(
 /**
  * Single cancel-in-flight implementation shared by the orchestrator-only
  * fallback and the production invalidation-deps builders. Tolerates
- * already-terminal targets (the rest of the pipeline still runs) and
- * fans out the optional executor-kill hook for every running task that
- * was cancelled.
+ * already-terminal targets and fans out the optional executor-kill hook
+ * for every running task that was cancelled.
+ *
+ * When a kill hook and the deferred-cancel methods are both available,
+ * kills every running task before invalidating; otherwise falls back to
+ * the immediate, non-deferred cancel.
  */
 export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlightFn {
+  const canDefer =
+    typeof deps.orchestrator.cancelTaskAwaitingKill === 'function'
+    && typeof deps.orchestrator.cancelWorkflowAwaitingKill === 'function'
+    && typeof deps.orchestrator.finalizeCancelInvalidation === 'function';
+
   return async (scope, id) => {
     if (scope === 'none') return;
+
+    if (deps.killActiveExecution && canDefer) {
+      let result: { runningCancelled: string[]; toCancelIds: string[] };
+      try {
+        result = scope === 'task'
+          ? deps.orchestrator.cancelTaskAwaitingKill!(id)
+          : deps.orchestrator.cancelWorkflowAwaitingKill!(id);
+      } catch (e) {
+        const code = (e as { code?: string })?.code;
+        if (code && TERMINAL_CANCEL_ERROR_CODES.has(code)) return;
+        throw e;
+      }
+      for (const runningId of result.runningCancelled) {
+        await deps.killActiveExecution(runningId);
+      }
+      deps.orchestrator.finalizeCancelInvalidation!(
+        result.toCancelIds,
+        scope === 'task' ? 'task cancellation' : 'workflow cancellation',
+      );
+      return;
+    }
+
     let result: { runningCancelled: string[] };
     try {
       result = scope === 'task'

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -112,6 +112,7 @@ import {
   cancelTaskImpl,
   cancelWorkflowImpl,
   deferTaskImpl,
+  finalizeCancelInvalidationImpl,
 } from './orchestrator/cancellation.js';
 import type { CancellationHost } from './orchestrator/cancellation.js';
 import {
@@ -3173,6 +3174,33 @@ export class Orchestrator {
    */
   cancelWorkflow(workflowId: string): { cancelled: string[]; runningCancelled: string[] } {
     return cancelWorkflowImpl(this as unknown as CancellationHost, workflowId);
+  }
+
+  /**
+   * Same as `cancelTask`, but does not release resource leases or abandon
+   * launch dispatch rows yet -- the caller must kill every id in
+   * `runningCancelled` first, then call `finalizeCancelInvalidation`.
+   */
+  cancelTaskAwaitingKill(
+    taskId: string,
+  ): { cancelled: string[]; runningCancelled: string[]; toCancelIds: string[] } {
+    return cancelTaskImpl(this as unknown as CancellationHost, taskId, { deferInvalidation: true });
+  }
+
+  /** Deferred-invalidation counterpart to `cancelWorkflow` -- see `cancelTaskAwaitingKill`. */
+  cancelWorkflowAwaitingKill(
+    workflowId: string,
+  ): { cancelled: string[]; runningCancelled: string[]; toCancelIds: string[] } {
+    return cancelWorkflowImpl(this as unknown as CancellationHost, workflowId, { deferInvalidation: true });
+  }
+
+  /**
+   * Releases resource leases and abandons launch dispatch rows for a set of
+   * cancelled tasks. Call after killing every `runningCancelled` id from
+   * `cancelTaskAwaitingKill`/`cancelWorkflowAwaitingKill`.
+   */
+  finalizeCancelInvalidation(toCancelIds: readonly string[], reason: string): void {
+    finalizeCancelInvalidationImpl(this as unknown as CancellationHost, toCancelIds, reason);
   }
 
   /**

--- a/packages/workflow-core/src/orchestrator/cancellation.ts
+++ b/packages/workflow-core/src/orchestrator/cancellation.ts
@@ -193,11 +193,17 @@ export function cancelActiveCandidatesImpl(
 /**
  * Cancel a task and cascade-cancel all downstream DAG dependents.
  * Returns cancelled task IDs and which were running (need process kill by caller).
+ *
+ * `deferInvalidation`: when true, skips `invalidateLaunchArtifactsForTasks`
+ * and returns `toCancelIds` instead, so the caller can kill the real
+ * process first and invalidate via `finalizeCancelInvalidationImpl`
+ * afterward. Defaults to false so existing callers are unaffected.
  */
 export function cancelTaskImpl(
   host: CancellationHost,
   taskId: string,
-): { cancelled: string[]; runningCancelled: string[] } {
+  opts?: { deferInvalidation?: boolean },
+): { cancelled: string[]; runningCancelled: string[]; toCancelIds: string[] } {
   host.refreshFromDb();
 
   const task = host.stateGetTask(taskId);
@@ -226,7 +232,9 @@ export function cancelTaskImpl(
   const toCancelIds = [rootId, ...descendantIds];
   const cancelled: string[] = [];
   const runningCancelled: string[] = [];
-  host.invalidateLaunchArtifactsForTasks(toCancelIds, 'task cancellation');
+  if (!opts?.deferInvalidation) {
+    host.invalidateLaunchArtifactsForTasks(toCancelIds, 'task cancellation');
+  }
 
   for (const id of toCancelIds) {
     const t = host.stateGetTask(id);
@@ -290,17 +298,20 @@ export function cancelTaskImpl(
   }
 
   host.checkWorkflowCompletion();
-  return { cancelled, runningCancelled };
+  return { cancelled, runningCancelled, toCancelIds };
 }
 
 /**
  * Cancel all active tasks in a workflow.
  * Terminal tasks (completed/stale) are preserved as-is.
+ *
+ * See `cancelTaskImpl` for what `deferInvalidation` does and why.
  */
 export function cancelWorkflowImpl(
   host: CancellationHost,
   workflowId: string,
-): { cancelled: string[]; runningCancelled: string[] } {
+  opts?: { deferInvalidation?: boolean },
+): { cancelled: string[]; runningCancelled: string[]; toCancelIds: string[] } {
   host.refreshWorkflowFromDb(workflowId);
 
   const allTasks = host.stateMachine.getAllTasks().filter(
@@ -323,10 +334,10 @@ export function cancelWorkflowImpl(
 
   const cancelled: string[] = [];
   const runningCancelled: string[] = [];
-  host.invalidateLaunchArtifactsForTasks(
-    allTasks.filter((task) => cancellable[task.status]).map((task) => task.id),
-    'workflow cancellation',
-  );
+  const toCancelIds = allTasks.filter((task) => cancellable[task.status]).map((task) => task.id);
+  if (!opts?.deferInvalidation) {
+    host.invalidateLaunchArtifactsForTasks(toCancelIds, 'workflow cancellation');
+  }
 
   for (const task of allTasks) {
     if (!cancellable[task.status]) continue;
@@ -359,7 +370,21 @@ export function cancelWorkflowImpl(
   }
 
   host.checkWorkflowCompletion();
-  return { cancelled, runningCancelled };
+  return { cancelled, runningCancelled, toCancelIds };
+}
+
+/**
+ * Companion to `cancelTaskImpl`/`cancelWorkflowImpl`'s `deferInvalidation`
+ * option: performs the artifact invalidation they skipped, after the
+ * caller has finished killing every id in `runningCancelled`.
+ */
+export function finalizeCancelInvalidationImpl(
+  host: CancellationHost,
+  toCancelIds: readonly string[],
+  reason: string,
+): void {
+  if (toCancelIds.length === 0) return;
+  host.invalidateLaunchArtifactsForTasks(toCancelIds, reason);
 }
 
 /**


### PR DESCRIPTION
## Summary

The resource-lease sweep still frees every expired lease unconditionally. A stalled heartbeat on a live process is treated the same as a true orphan.

This slice adds a test that drives the sweep against a live process, an orphan on the same owner, and an orphan on a different owner, and shows the live one still gets freed.

## Review Claim

Approve one `it.fails` test that reproduces the sweep freeing a still-alive process's lease against current code.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only file. Marked `it.fails`, so Vitest expects it to throw; CI stays green either way, and an unexpected pass would itself fail the suite, catching drift.

## Slice Rationale

Per this repo's stacking convention, the proof lands before the fix. This slice depends on the previous one for the liveness check and read-only accessor the test's stub provider uses.

## Non-goals

Does not change any production file. Does not yet change the sweep's behavior -- that is the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/launch-dispatcher.test.ts` (expected: 38/38 passed, including the it.fails case)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7249