### PR TITLE
[Launch-Dispatch Invariant Fixes](14) Heal a stalled-heartbeat lease on a live process instead of releasing it

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -1239,7 +1239,7 @@ describe('LaunchDispatcher', () => {
       expect(leases[0]?.resourceKey).toBe('ssh:live');
     });
 
-    it.fails('poll heals a stalled-heartbeat lease on a genuinely live process instead of releasing it', () => {
+    it('poll heals a stalled-heartbeat lease on a genuinely live process instead of releasing it', () => {
       // Same runner instance, task still actively executing -- a stalled
       // heartbeat here is not the same as an orphaned lease. Releasing it
       // would let a different task claim the same SSH slot while this one

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -179,7 +179,58 @@ export class LaunchDispatcher {
     }
   }
 
+  /**
+   * A resource lease expires on a heartbeat clock independent of
+   * task_launch_dispatch. A same-owner, still-alive lease is healed
+   * (renewed) instead of released; true orphans are still released.
+   */
   private sweepExpiredResourceLeases(): void {
+    const list = this.persistence.listExpiredExecutionResourceLeases;
+    const renew = this.persistence.renewExecutionResourceLease;
+    const runner = this.taskRunnerProvider?.();
+    if (
+      typeof list !== 'function'
+      || typeof renew !== 'function'
+      || !runner?.runnerInstanceId
+      || typeof runner.hasActiveExecutionForLeaseHolder !== 'function'
+    ) {
+      this.sweepExpiredResourceLeasesUnconditionally();
+      return;
+    }
+    try {
+      const expired = list.call(this.persistence);
+      let released = 0;
+      let healed = 0;
+      for (const row of expired) {
+        const sameOwner = (row.metadata as { runnerInstanceId?: string } | undefined)?.runnerInstanceId === runner.runnerInstanceId;
+        const stillAlive = sameOwner && runner.hasActiveExecutionForLeaseHolder!(row.holderId);
+        if (stillAlive) {
+          renew.call(this.persistence, row.resourceKey, row.holderId);
+          healed += 1;
+        } else {
+          this.persistence.releaseExecutionResourceLease(row.resourceKey, row.holderId);
+          released += 1;
+        }
+      }
+      if (healed > 0 || released > 0) {
+        this.logger?.info?.('[launch-dispatcher] swept expired execution resource leases', {
+          ownerId: this.ownerId,
+          released,
+          healed,
+          module: 'launch-dispatcher',
+        });
+      }
+    } catch (err) {
+      this.logger?.warn?.('[launch-dispatcher] expired execution resource lease sweep failed', {
+        ownerId: this.ownerId,
+        error: err instanceof Error ? err.message : String(err),
+        module: 'launch-dispatcher',
+      });
+    }
+  }
+
+  /** Fallback when the liveness-aware sweep isn't wired: old, blunt behavior. */
+  private sweepExpiredResourceLeasesUnconditionally(): void {
     const sweep = this.persistence.releaseExpiredExecutionResourceLeases;
     if (typeof sweep !== 'function') return;
     try {


### PR DESCRIPTION
## Summary

Fixes the bug proven in the previous slice: the resource-lease sweep now checks, per expired row, whether it belongs to this runner instance and that task still has a live execution.

A same-owner, still-alive lease is renewed instead of freed. A true orphan (crashed owner, different owner, or no live execution) is still freed, which stays correct for crash recovery.

## Review Claim

Approve renewing a same-owner, still-alive lease in the sweep instead of unconditionally freeing every expired row.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Falls back to the old unconditional behavior whenever the liveness-aware pieces are not wired, so no existing caller changes. The proof test from the previous slice now passes unmarked. Full data-store suite (437 tests), app launch-dispatcher suite (38 tests), and execution-engine's task-runner/worktree/ssh suites (233 tests) pass.

## Slice Rationale

This is the fix half of the pair started in the previous slice, kept as its own slice so the bug proof and the behavior change review separately.

## Non-goals

Does not change how a true orphan is handled -- that path is unchanged crash-recovery behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/data-store exec vitest run` (437/437 passed)
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/launch-dispatcher.test.ts` (38/38 passed)
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts src/__tests__/worktree-executor.test.ts src/__tests__/ssh-pool-member-capacity.test.ts` (233/233 passed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of stalled execution leases using available runner and lease-holder activity.
  * Active leases owned by the current runner are renewed, while inactive or expired leases are released.
  * Added a fallback for environments without activity tracking.
* **Tests**
  * Enabled coverage for stalled-heartbeat lease recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->