### PR TITLE
Fix headless delete bugs Step 1 - stop INVOKER_HEADLESS_STANDALONE leak

### DIFF
--- a/packages/execution-engine/src/__tests__/process-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/process-utils.test.ts
@@ -121,6 +121,24 @@ describe('process-utils shell environment resolution', () => {
     expect(mockedSpawn).toHaveBeenCalledTimes(1);
   });
 
+  it('strips INVOKER_HEADLESS_STANDALONE while preserving unrelated env vars', async () => {
+    const originalHeadlessStandalone = process.env.INVOKER_HEADLESS_STANDALONE;
+    const originalUnrelated = process.env.INVOKER_TEST_UNRELATED_VAR;
+    process.env.INVOKER_HEADLESS_STANDALONE = '1';
+    process.env.INVOKER_TEST_UNRELATED_VAR = 'kept';
+    try {
+      const { processUtils } = await loadProcessUtils();
+      const clean = processUtils.cleanElectronEnv();
+      expect(clean).not.toHaveProperty('INVOKER_HEADLESS_STANDALONE');
+      expect(clean.INVOKER_TEST_UNRELATED_VAR).toBe('kept');
+    } finally {
+      if (originalHeadlessStandalone === undefined) delete process.env.INVOKER_HEADLESS_STANDALONE;
+      else process.env.INVOKER_HEADLESS_STANDALONE = originalHeadlessStandalone;
+      if (originalUnrelated === undefined) delete process.env.INVOKER_TEST_UNRELATED_VAR;
+      else process.env.INVOKER_TEST_UNRELATED_VAR = originalUnrelated;
+    }
+  });
+
   it('removes Git repository-scoping variables while preserving transport env', async () => {
     const { processUtils } = await loadProcessUtils();
 

--- a/packages/execution-engine/src/process-utils.ts
+++ b/packages/execution-engine/src/process-utils.ts
@@ -258,6 +258,7 @@ export function cleanElectronEnv(): NodeJS.ProcessEnv {
   delete env.ELECTRON_NO_ASAR;
   delete env.ELECTRON_NO_ATTACH_CONSOLE;
   delete env.INVOKER_REPO_CONFIG_PATH;
+  delete env.INVOKER_HEADLESS_STANDALONE;
   env.PATH = getEffectivePath();
   return env;
 }


### PR DESCRIPTION
## Summary

Headless standalone runs set `INVOKER_HEADLESS_STANDALONE` in the process env so the app knows it is running without Electron.

`cleanElectronEnv()` builds the environment passed to every spawned child process (git, shell tasks, etc).

It stripped Electron-only variables but left `INVOKER_HEADLESS_STANDALONE` in place, so every child process inherited it even when the child itself should not see it.

This change adds one line to `cleanElectronEnv()` so it strips `INVOKER_HEADLESS_STANDALONE` from the returned env, alongside the other variables it already strips.

## Review Claim

Approve stripping `INVOKER_HEADLESS_STANDALONE` from the env object `cleanElectronEnv()` returns, so it no longer leaks into spawned child processes.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`cleanElectronEnv()` is a pure function: it clones `process.env`, strips a fixed list of keys, and returns the clone. Adding one more key to that strip list cannot affect any other key, and the accompanying test asserts an unrelated env var still survives the strip. Reviewable from the 1-line diff and its test alone.

## Slice Rationale

This is the entire fix: one property strip plus the regression test that proves it, bundled in the same commit so the change and its proof land together. There is no larger change to slice this out of.

## Non-goals

Does not change which variables `cleanElectronEnv()` strips besides `INVOKER_HEADLESS_STANDALONE`. Does not change how or when `INVOKER_HEADLESS_STANDALONE` is set. Does not touch any other env-cleaning path.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- process-utils`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
