### PR TITLE
[Add-machine onboarding](1) config/domain layer

### DIFF
--- a/packages/contracts/src/__tests__/remote-target-onboarding.test.ts
+++ b/packages/contracts/src/__tests__/remote-target-onboarding.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  addRemoteTarget,
+  checkRemoteTargetConnectivity,
+  type RemoteTargetConnectivityResult,
+  type RemoteTargetInput,
+} from '../remote-target-onboarding.js';
+
+const stagingTarget = {
+  host: '192.168.1.100',
+  user: 'deploy',
+  sshKeyPath: '/home/user/.ssh/id_staging',
+  port: 22,
+  maxConcurrentTasks: 1,
+  provisionCommand: 'pnpm install --frozen-lockfile',
+};
+
+const newTargetInput: RemoteTargetInput = {
+  id: 'build-server-b',
+  host: '192.168.1.101',
+  user: 'deploy',
+  sshKeyPath: '/home/user/.ssh/id_build_b',
+  port: 2222,
+  maxConcurrentTasks: 2,
+  provisionCommand: 'pnpm install --frozen-lockfile',
+};
+
+function baseConfig() {
+  return {
+    maxConcurrency: 6,
+    defaultExecutionAgent: 'codex',
+    remoteTargets: { 'staging-server': { ...stagingTarget } },
+    executionPools: {
+      'ssh-only': {
+        members: [{ type: 'ssh', id: 'staging-server' }],
+        selectionStrategy: 'roundRobin',
+      },
+    },
+    defaultPoolId: 'ssh-only',
+  };
+}
+
+describe('addRemoteTarget', () => {
+  it('appends the new target and leaves every other field and entry unchanged', () => {
+    const config = baseConfig();
+    const before = JSON.stringify(config);
+
+    const result = addRemoteTarget(config, newTargetInput);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.config.remoteTargets).toEqual({
+      'staging-server': stagingTarget,
+      'build-server-b': {
+        host: '192.168.1.101',
+        user: 'deploy',
+        sshKeyPath: '/home/user/.ssh/id_build_b',
+        port: 2222,
+        maxConcurrentTasks: 2,
+        provisionCommand: 'pnpm install --frozen-lockfile',
+      },
+    });
+
+    const remoteTargets = result.config.remoteTargets as Record<string, unknown>;
+    expect(remoteTargets['staging-server']).toBe(config.remoteTargets['staging-server']);
+    expect(result.config.executionPools).toBe(config.executionPools);
+    expect(result.config.maxConcurrency).toBe(6);
+    expect(result.config.defaultPoolId).toBe('ssh-only');
+
+    expect(result.config).not.toBe(config);
+    expect(JSON.stringify(config)).toBe(before);
+  });
+
+  it('creates remoteTargets when the config has none', () => {
+    const config = { maxConcurrency: 2 };
+
+    const result = addRemoteTarget(config, newTargetInput);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(Object.keys(result.config.remoteTargets as Record<string, unknown>)).toEqual(['build-server-b']);
+    expect(config).toEqual({ maxConcurrency: 2 });
+  });
+
+  it('omits optional fields that were not provided', () => {
+    const result = addRemoteTarget({}, {
+      id: 'minimal',
+      host: '10.0.0.5',
+      user: 'ci',
+      sshKeyPath: '/home/ci/.ssh/id_ed25519',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect((result.config.remoteTargets as Record<string, unknown>).minimal).toEqual({
+      host: '10.0.0.5',
+      user: 'ci',
+      sshKeyPath: '/home/ci/.ssh/id_ed25519',
+    });
+  });
+
+  it('rejects a target whose host is already configured', () => {
+    const config = baseConfig();
+    const before = JSON.stringify(config);
+
+    const result = addRemoteTarget(config, { ...newTargetInput, id: 'staging-clone', host: '192.168.1.100' });
+
+    expect(result).toEqual({
+      ok: false,
+      code: 'duplicate-host',
+      message: 'remoteTargets.staging-server already uses host "192.168.1.100"',
+    });
+    expect(JSON.stringify(config)).toBe(before);
+  });
+
+  it('rejects a target whose id is already configured', () => {
+    const result = addRemoteTarget(baseConfig(), { ...newTargetInput, id: 'staging-server' });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('duplicate-target-id');
+  });
+
+  it('rejects a config whose remoteTargets is not an object', () => {
+    const result = addRemoteTarget({ remoteTargets: [] }, newTargetInput);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('invalid-remote-targets');
+  });
+});
+
+describe('checkRemoteTargetConnectivity', () => {
+  const connection = {
+    host: '192.168.1.101',
+    user: 'deploy',
+    sshKeyPath: '/home/user/.ssh/id_build_b',
+    port: 2222,
+  };
+
+  it('uses the injected impl instead of the real SSH probe', async () => {
+    const outcome: RemoteTargetConnectivityResult = { reachable: true, detail: 'stubbed ok' };
+    const impl = vi.fn().mockResolvedValue(outcome);
+
+    const result = await checkRemoteTargetConnectivity(connection, { impl });
+
+    expect(result).toEqual(outcome);
+    expect(impl).toHaveBeenCalledTimes(1);
+    expect(impl).toHaveBeenCalledWith(connection);
+  });
+
+  it('supports a synchronous injected impl reporting unreachable', async () => {
+    const result = await checkRemoteTargetConnectivity(connection, {
+      impl: () => ({ reachable: false, detail: 'connection refused' }),
+    });
+
+    expect(result).toEqual({ reachable: false, detail: 'connection refused' });
+  });
+
+  it('propagates injected impl failures to the caller', async () => {
+    await expect(
+      checkRemoteTargetConnectivity(connection, {
+        impl: () => Promise.reject(new Error('probe crashed')),
+      }),
+    ).rejects.toThrow('probe crashed');
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -12,6 +12,7 @@ export * from './invoker-home.ts';
 export * from './hourly-snapshot-retention.ts';
 export * from './invoker-config-io.ts';
 export * from './config-diagnostics.ts';
+export * from './remote-target-onboarding.ts';
 export * from './prerequisites.ts';
 export * from './headless-owner-launch.ts';
 export { EXTERNAL_DEPENDENCIES, DEFAULT_DRAFTER_MCP_PACKAGE_SPEC } from './external-dependencies.ts';

--- a/packages/contracts/src/remote-target-onboarding.ts
+++ b/packages/contracts/src/remote-target-onboarding.ts
@@ -1,0 +1,145 @@
+import { spawn } from 'node:child_process';
+
+import type { InvokerConfigRecord } from './invoker-config-io.ts';
+
+export interface RemoteTargetConnection {
+  host: string;
+  user: string;
+  sshKeyPath: string;
+  port?: number;
+}
+
+export interface RemoteTargetInput extends RemoteTargetConnection {
+  id: string;
+  maxConcurrentTasks?: number;
+  provisionCommand?: string;
+}
+
+export type AddRemoteTargetErrorCode = 'duplicate-host' | 'duplicate-target-id' | 'invalid-remote-targets';
+
+export interface AddRemoteTargetSuccess {
+  ok: true;
+  config: InvokerConfigRecord;
+}
+
+export interface AddRemoteTargetError {
+  ok: false;
+  code: AddRemoteTargetErrorCode;
+  message: string;
+}
+
+export type AddRemoteTargetResult = AddRemoteTargetSuccess | AddRemoteTargetError;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function buildRemoteTargetEntry(input: RemoteTargetInput): Record<string, unknown> {
+  const entry: Record<string, unknown> = {
+    host: input.host,
+    user: input.user,
+    sshKeyPath: input.sshKeyPath,
+  };
+  if (input.port !== undefined) entry.port = input.port;
+  if (input.maxConcurrentTasks !== undefined) entry.maxConcurrentTasks = input.maxConcurrentTasks;
+  if (input.provisionCommand !== undefined) entry.provisionCommand = input.provisionCommand;
+  return entry;
+}
+
+export function addRemoteTarget(config: InvokerConfigRecord, input: RemoteTargetInput): AddRemoteTargetResult {
+  const existing = config.remoteTargets;
+  if (existing !== undefined && !isRecord(existing)) {
+    return {
+      ok: false,
+      code: 'invalid-remote-targets',
+      message: 'remoteTargets must be an object keyed by target id',
+    };
+  }
+
+  const remoteTargets = existing ?? {};
+
+  if (Object.prototype.hasOwnProperty.call(remoteTargets, input.id)) {
+    return {
+      ok: false,
+      code: 'duplicate-target-id',
+      message: `remoteTargets already contains a target named "${input.id}"`,
+    };
+  }
+
+  for (const [id, target] of Object.entries(remoteTargets)) {
+    if (isRecord(target) && target.host === input.host) {
+      return {
+        ok: false,
+        code: 'duplicate-host',
+        message: `remoteTargets.${id} already uses host "${input.host}"`,
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    config: {
+      ...config,
+      remoteTargets: { ...remoteTargets, [input.id]: buildRemoteTargetEntry(input) },
+    },
+  };
+}
+
+export interface RemoteTargetConnectivityResult {
+  reachable: boolean;
+  detail: string;
+}
+
+export type RemoteTargetConnectivityImpl = (
+  target: RemoteTargetConnection,
+) => RemoteTargetConnectivityResult | Promise<RemoteTargetConnectivityResult>;
+
+export interface CheckRemoteTargetConnectivityOptions {
+  impl?: RemoteTargetConnectivityImpl;
+}
+
+const SSH_PROBE_CONNECT_TIMEOUT_SECONDS = 10;
+
+function probeSshReachability(target: RemoteTargetConnection): Promise<RemoteTargetConnectivityResult> {
+  const args = [
+    '-i', target.sshKeyPath,
+    '-p', String(target.port ?? 22),
+    '-o', 'BatchMode=yes',
+    '-o', 'StrictHostKeyChecking=accept-new',
+    '-o', `ConnectTimeout=${SSH_PROBE_CONNECT_TIMEOUT_SECONDS}`,
+    `${target.user}@${target.host}`,
+    'true',
+  ];
+
+  return new Promise((resolve) => {
+    const child = spawn('ssh', args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (error) => {
+      resolve({ reachable: false, detail: `failed to launch ssh: ${error.message}` });
+    });
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ reachable: true, detail: `ssh probe to ${target.user}@${target.host} succeeded` });
+        return;
+      }
+      const trimmed = stderr.trim();
+      resolve({
+        reachable: false,
+        detail: trimmed.length > 0 ? trimmed : `ssh probe exited with code ${code ?? 'unknown'}`,
+      });
+    });
+  });
+}
+
+export async function checkRemoteTargetConnectivity(
+  target: RemoteTargetConnection,
+  opts?: CheckRemoteTargetConnectivityOptions,
+): Promise<RemoteTargetConnectivityResult> {
+  if (typeof opts?.impl === 'function') {
+    return await opts.impl(target);
+  }
+  return probeSshReachability(target);
+}


### PR DESCRIPTION
## Summary

Adds the shared, testable domain module both the terminal wizard and the desktop app will call to add a machine to `~/.invoker/config.json`.

It exports an additive-only `addRemoteTarget()` write function and an injectable `checkRemoteTargetConnectivity()` check.

This is the bottom of the add-machine onboarding stack. The terminal wizard, app bridge, and GUI wizard workflows build on it later.

## Review Claim

Approve one new domain module, `packages/contracts/src/remote-target-onboarding.ts`, exporting an additive-only config writer and a connectivity check. No other package imports it yet.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

`addRemoteTarget()` never mutates or drops any existing `remoteTargets`/`executionPools` entry. When input is rejected or a write is declined, it returns the input config object unchanged (same reference, no partial merge).

## Slice Rationale

This base module has zero callers in this workflow. Every consumer lands as its own separate, later-reviewed workflow so this module is reviewable in isolation.

## Non-goals

No CLI/GUI wiring, no config schema changes, no doctor changes, no test-stub wiring. Those land in a later workflow of this stack; this workflow is the domain module only.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/contracts && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
