### PR TITLE
[Bugfix: planning chat busy indicator](2) Add regression proof for the busy-state spinner and wait-cursor removal

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -1058,6 +1058,54 @@ test.describe('Visual proof capture', () => {
     });
   });
 
+  test('planning chat busy state — indicator visible and wait cursor gone before reply arrives', async ({ page }) => {
+    // Regression proof for the chat-input-beachball bugfix (InvokerTerminal.tsx):
+    // the composer must not carry disabled:cursor-wait while busy, and a busy
+    // indicator must render immediately on send, before any streamed text
+    // arrives. delayMs holds the planner reply back so this window is
+    // screenshot-able instead of resolving before Playwright can observe it.
+    const busyStatePlanYaml = yamlStringify({
+      name: 'Busy State Visual Proof',
+      repoUrl: E2E_REPO_URL,
+      onFinish: 'none' as const,
+      tasks: [
+        { id: 'busy-state-proof', description: 'Busy state proof task', command: 'echo ok', dependencies: [] as string[] },
+      ],
+    });
+    await page.evaluate(async (planYaml) => {
+      await window.invoker.setTestPlanningChatResponse({
+        planYaml,
+        planName: 'Busy State Visual Proof',
+        reply: 'Busy state response.',
+        delayMs: 4000,
+      });
+    }, busyStatePlanYaml);
+
+    await page.getByTestId('sidebar-home').click();
+    await expect(page.getByRole('heading', { name: 'Planning chat' })).toBeVisible();
+    const input = page.getByTestId('invoker-terminal-input');
+    const sendButton = page.getByRole('button', { name: 'Send' });
+    await input.fill('Draft me an Invoker plan');
+    await sendButton.click();
+
+    const streamStatus = page.getByTestId('invoker-terminal-planner-stream');
+    await expect(streamStatus).toBeVisible();
+    await expect(streamStatus).toHaveAttribute('data-state', 'working');
+    await expect(streamStatus).toContainText('Working…');
+    await expect(input).toHaveClass(/disabled:cursor-not-allowed/);
+    await expect(input).not.toHaveClass(/cursor-wait/);
+    await expect(sendButton).toHaveClass(/disabled:cursor-not-allowed/);
+    await expect(sendButton).not.toHaveClass(/cursor-wait/);
+
+    await captureScreenshot(page, 'planning-chat-busy-state-immediate-indicator');
+
+    await expect(page.getByTestId('invoker-terminal-transcript')).toContainText('Busy state response.', { timeout: 8000 });
+
+    await page.evaluate(async () => {
+      await window.invoker.setTestPlanningChatResponse(null);
+    });
+  });
+
   test('planning chat long transcript — scrollable surface with follow pinned to bottom', async ({ page }) => {
     // Render a long planning transcript by sending several user messages and
     // returning a long assistant reply for each turn. This exercises the same


### PR DESCRIPTION
## Summary

The planning-chat busy state was fixed in #7215 but had no test coverage and no real screenshot.

This adds a Playwright case that holds the planner reply open long enough to observe the busy state.

It asserts the spinner and "Working…" text appear immediately, and the wait cursor never comes back.

## Review Claim

A new e2e test proves both halves of the #7215 fix: the immediate busy indicator and the removed wait cursor.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only adds one new test case to `packages/app/e2e/visual-proof.spec.ts`; no product code changes.

## Slice Rationale

Proof and behavior are different review units and must ship separately; this slice adds the regression coverage that #7215 shipped without.

## Non-goals

No changes to `InvokerTerminal.tsx` or any other product code, no changes to other test cases in this spec file.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && npx playwright test visual-proof.spec.ts -g "planning chat busy state"`

</details>

## Visual Proof

This PR's own test captures the proof: the composer sends a message, a 4s `delayMs` holds the planner
reply back, and the screenshot below is taken during that busy window.

![Planning chat shows a spinner immediately on send, before the reply streams in](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-a6c654/planning-chat-busy-state-immediate-indicator.png)

The same test also asserts (not screenshot-provable) that the composer input and Send button carry
`disabled:cursor-not-allowed` and never `cursor-wait` while busy.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-commit>`
- Post-revert steps: None
- Data migration? No

</details>
