### PR TITLE
[Add-machine onboarding](1) config/domain layer

### DIFF
--- a/packages/contracts/src/__tests__/remote-target-onboarding.test.ts
+++ b/packages/contracts/src/__tests__/remote-target-onboarding.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  addRemoteTarget,
+  checkRemoteTargetConnectivity,
+  type AddRemoteTargetInput,
+  type RemoteTargetSpec,
+} from '../remote-target-onboarding.js';
+
+const stagingTarget = {
+  host: '192.168.1.100',
+  user: 'deploy',
+  sshKeyPath: '/home/user/.ssh/id_staging',
+  port: 22,
+  maxConcurrentTasks: 1,
+  provisionCommand: 'pnpm install --frozen-lockfile',
+};
+
+function baseConfig() {
+  return {
+    maxConcurrency: 6,
+    defaultExecutionAgent: 'codex',
+    remoteTargets: {
+      'staging-server': { ...stagingTarget },
+    },
+    executionPools: {
+      'mixed-local-ssh': {
+        members: [{ type: 'ssh', id: 'staging-server' }],
+        selectionStrategy: 'roundRobin',
+      },
+    },
+  };
+}
+
+const newTarget: AddRemoteTargetInput = {
+  id: 'build-server-b',
+  host: '192.168.1.101',
+  user: 'deploy',
+  sshKeyPath: '/home/user/.ssh/id_build_b',
+  port: 2222,
+  maxConcurrentTasks: 2,
+  provisionCommand: 'pnpm install --frozen-lockfile',
+};
+
+describe('addRemoteTarget', () => {
+  it('appends the new target and keeps everything else byte-for-byte unchanged', () => {
+    const config = baseConfig();
+    const snapshot = JSON.stringify(config);
+
+    const result = addRemoteTarget(config, newTarget);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(JSON.stringify(config)).toBe(snapshot);
+    expect(result.config).not.toBe(config);
+
+    const targets = result.config.remoteTargets as Record<string, unknown>;
+    expect(Object.keys(targets)).toEqual(['staging-server', 'build-server-b']);
+    expect(targets['build-server-b']).toEqual({
+      host: '192.168.1.101',
+      user: 'deploy',
+      sshKeyPath: '/home/user/.ssh/id_build_b',
+      port: 2222,
+      maxConcurrentTasks: 2,
+      provisionCommand: 'pnpm install --frozen-lockfile',
+    });
+
+    expect(targets['staging-server']).toBe(config.remoteTargets['staging-server']);
+    expect(result.config.executionPools).toBe(config.executionPools);
+    expect(result.config.maxConcurrency).toBe(6);
+    expect(result.config.defaultExecutionAgent).toBe('codex');
+  });
+
+  it('creates remoteTargets when the config has none', () => {
+    const config = { maxConcurrency: 2 };
+
+    const result = addRemoteTarget(config, newTarget);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.config.remoteTargets).toEqual({
+      'build-server-b': {
+        host: '192.168.1.101',
+        user: 'deploy',
+        sshKeyPath: '/home/user/.ssh/id_build_b',
+        port: 2222,
+        maxConcurrentTasks: 2,
+        provisionCommand: 'pnpm install --frozen-lockfile',
+      },
+    });
+    expect(config).toEqual({ maxConcurrency: 2 });
+  });
+
+  it('rejects a target whose host already exists instead of appending a second entry', () => {
+    const config = baseConfig();
+    const snapshot = JSON.stringify(config);
+
+    const result = addRemoteTarget(config, { ...newTarget, host: '192.168.1.100' });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('duplicate-host');
+    expect(result.error.conflictingTargetId).toBe('staging-server');
+    expect(result.error.message).toContain('192.168.1.100');
+    expect(JSON.stringify(config)).toBe(snapshot);
+  });
+
+  it('rejects a target whose id already exists', () => {
+    const config = baseConfig();
+
+    const result = addRemoteTarget(config, { ...newTarget, id: 'staging-server' });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('duplicate-id');
+    expect(result.error.conflictingTargetId).toBe('staging-server');
+  });
+});
+
+describe('checkRemoteTargetConnectivity', () => {
+  const target: RemoteTargetSpec = {
+    host: '192.168.1.101',
+    user: 'deploy',
+    sshKeyPath: '/home/user/.ssh/id_build_b',
+    port: 2222,
+  };
+
+  it('uses the injected impl instead of the real SSH probe', async () => {
+    const impl = vi.fn().mockResolvedValue({ reachable: true, detail: 'stubbed ok' });
+
+    const result = await checkRemoteTargetConnectivity(target, { impl });
+
+    expect(result).toEqual({ reachable: true, detail: 'stubbed ok' });
+    expect(impl).toHaveBeenCalledTimes(1);
+    expect(impl).toHaveBeenCalledWith(target);
+  });
+
+  it('returns the injected unreachable outcome deterministically', async () => {
+    const result = await checkRemoteTargetConnectivity(target, {
+      impl: () => ({ reachable: false, detail: 'stubbed connection refused' }),
+    });
+
+    expect(result).toEqual({ reachable: false, detail: 'stubbed connection refused' });
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -14,4 +14,5 @@ export * from './invoker-config-io.ts';
 export * from './config-diagnostics.ts';
 export * from './prerequisites.ts';
 export * from './headless-owner-launch.ts';
+export * from './remote-target-onboarding.ts';
 export { EXTERNAL_DEPENDENCIES, DEFAULT_DRAFTER_MCP_PACKAGE_SPEC } from './external-dependencies.ts';

--- a/packages/contracts/src/remote-target-onboarding.ts
+++ b/packages/contracts/src/remote-target-onboarding.ts
@@ -1,0 +1,144 @@
+import { spawn } from 'node:child_process';
+
+import type { InvokerConfigRecord } from './invoker-config-io.ts';
+
+export interface RemoteTargetSpec {
+  host: string;
+  user: string;
+  sshKeyPath: string;
+  port?: number;
+  maxConcurrentTasks?: number;
+  provisionCommand?: string;
+  [extra: string]: unknown;
+}
+
+export interface AddRemoteTargetInput extends RemoteTargetSpec {
+  id: string;
+}
+
+export type AddRemoteTargetErrorCode = 'duplicate-host' | 'duplicate-id';
+
+export interface AddRemoteTargetError {
+  code: AddRemoteTargetErrorCode;
+  message: string;
+  conflictingTargetId: string;
+}
+
+export type AddRemoteTargetResult =
+  | { ok: true; config: InvokerConfigRecord }
+  | { ok: false; error: AddRemoteTargetError };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function failure(
+  code: AddRemoteTargetErrorCode,
+  conflictingTargetId: string,
+  message: string,
+): AddRemoteTargetResult {
+  return { ok: false, error: { code, message, conflictingTargetId } };
+}
+
+export function addRemoteTarget(
+  config: InvokerConfigRecord,
+  input: AddRemoteTargetInput,
+): AddRemoteTargetResult {
+  const existing = isRecord(config.remoteTargets) ? config.remoteTargets : {};
+
+  if (Object.prototype.hasOwnProperty.call(existing, input.id)) {
+    return failure(
+      'duplicate-id',
+      input.id,
+      `remoteTargets.${input.id} already exists; choose a different target id`,
+    );
+  }
+
+  for (const [id, target] of Object.entries(existing)) {
+    if (isRecord(target) && target.host === input.host) {
+      return failure(
+        'duplicate-host',
+        id,
+        `remoteTargets.${id} already uses host ${input.host}`,
+      );
+    }
+  }
+
+  const { id, ...targetFields } = input;
+  return {
+    ok: true,
+    config: {
+      ...config,
+      remoteTargets: { ...existing, [id]: targetFields },
+    },
+  };
+}
+
+export interface RemoteTargetConnectivityResult {
+  reachable: boolean;
+  detail: string;
+}
+
+export type RemoteTargetConnectivityImpl = (
+  target: RemoteTargetSpec,
+) => RemoteTargetConnectivityResult | Promise<RemoteTargetConnectivityResult>;
+
+export interface CheckRemoteTargetConnectivityOptions {
+  impl?: RemoteTargetConnectivityImpl;
+  connectTimeoutSeconds?: number;
+}
+
+const DEFAULT_PROBE_CONNECT_TIMEOUT_SECONDS = 10;
+
+export async function checkRemoteTargetConnectivity(
+  target: RemoteTargetSpec,
+  opts?: CheckRemoteTargetConnectivityOptions,
+): Promise<RemoteTargetConnectivityResult> {
+  if (typeof opts?.impl === 'function') {
+    return await opts.impl(target);
+  }
+  return runSshReachabilityProbe(
+    target,
+    opts?.connectTimeoutSeconds ?? DEFAULT_PROBE_CONNECT_TIMEOUT_SECONDS,
+  );
+}
+
+function runSshReachabilityProbe(
+  target: RemoteTargetSpec,
+  connectTimeoutSeconds: number,
+): Promise<RemoteTargetConnectivityResult> {
+  const destination = `${target.user}@${target.host}`;
+  const args = [
+    '-i', target.sshKeyPath,
+    '-p', String(target.port ?? 22),
+    '-o', 'BatchMode=yes',
+    '-o', 'StrictHostKeyChecking=accept-new',
+    '-o', `ConnectTimeout=${connectTimeoutSeconds}`,
+    destination,
+    'exit 0',
+  ];
+
+  return new Promise((resolve) => {
+    const child = spawn('ssh', args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    let stderr = '';
+    child.stderr.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', (error) => {
+      resolve({ reachable: false, detail: `failed to run ssh: ${error.message}` });
+    });
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ reachable: true, detail: `ssh probe to ${destination} succeeded` });
+        return;
+      }
+      const trimmed = stderr.trim();
+      resolve({
+        reachable: false,
+        detail: trimmed.length > 0
+          ? `ssh probe to ${destination} exited with code ${code}: ${trimmed}`
+          : `ssh probe to ${destination} exited with code ${code}`,
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds a small shared module that knows how to add one remote machine entry to the local `~/.invoker/config.json` file, and how to check whether that machine can be reached.

Today, adding a machine means hand-editing that config file by hand. This module is the first building block toward a guided add-machine flow.

Nothing else in the codebase calls this module yet, so no existing behavior changes.

## Review Claim

Approve one new module, `packages/contracts/src/remote-target-onboarding.ts`, that appends a machine entry to config and checks reachability, with no other package wired to call it yet.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

`addRemoteTarget()` never mutates or drops any existing `remoteTargets`/`executionPools` entry. When the input is declined, it returns the same config object, unchanged, rather than a partial merge.

## Slice Rationale

This module has zero callers today. Every future consumer, such as a guided onboarding flow, lands as its own later, independently reviewed piece of work, so this one stays reviewable on its own.

## Non-goals

- No wiring into any existing entry point, command surface, or window.
- No config schema changes.
- No changes to how the app checks prerequisites.
- This slice does not touch anything outside `packages/contracts`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/contracts && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
