### PR TITLE
[Validator Word-Boundary Bugs](1) Fix unscoped regex alternation in visualProofNeedsAnimation

### DIFF
--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -6,7 +6,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { spawnSync } from 'node:child_process';
-import { getPrAtomicityBlockers, getPrBodyWarnings, getReviewMetadata, scopeKindsForChangedFiles, validatePrBody, validatePrScope } from './validate-pr-body.mjs';
+import { getPrAtomicityBlockers, getPrBodyWarnings, getReviewMetadata, scopeKindsForChangedFiles, validatePrBody, validatePrScope, visualProofNeedsAnimation } from './validate-pr-body.mjs';
 
 function assert(condition, message) {
   if (!condition) {
@@ -1267,5 +1267,48 @@ try {
 } finally {
   rmSync(localWrapperTmp, { recursive: true, force: true });
 }
+
+assert(
+  !visualProofNeedsAnimation('## Visual Proof\n\nThe preload script is unaffected.\n'),
+  'the word "preload" alone should not trigger the animation requirement (word-boundary regression)',
+);
+assert(
+  visualProofNeedsAnimation('## Visual Proof\n\nThe app will restart after this change.\n'),
+  'a standalone "restart" should still trigger the animation requirement',
+);
+assert(
+  visualProofNeedsAnimation('## Visual Proof\n\nSaved state survives after a reload.\n'),
+  'a standalone "reload" should still trigger the animation requirement',
+);
+assert(
+  visualProofNeedsAnimation('## Visual Proof\n\nUsers relaunch the app to see the fix.\n'),
+  'a standalone "relaunch" should still trigger the animation requirement',
+);
+assert(
+  visualProofNeedsAnimation('## Visual Proof\n\nThis view has a smooth transition between panels.\n'),
+  'a standalone "transition" should still trigger the animation requirement',
+);
+assert(
+  visualProofNeedsAnimation('## Visual Proof\n\nThere is a visible state change after saving.\n'),
+  'the phrase "state change" should still trigger the animation requirement',
+);
+assert(
+  !visualProofNeedsAnimation('## Visual Proof\n\nWe describe an understate change in copy only.\n'),
+  '"understate change" should not trigger the animation requirement (word-boundary regression)',
+);
+
+const preloadRegressionBody = `${validMinimal}
+
+## Visual Proof
+
+The preload script is unaffected.
+
+![screenshot](proof.png)
+`;
+const preloadRegressionErrors = await validatePrBody(preloadRegressionBody, { requiresVisualProof: true });
+assert(
+  preloadRegressionErrors.length === 0,
+  `a PR body whose Visual Proof section merely mentions "preload" should pass with a static screenshot: ${preloadRegressionErrors.join('; ')}`,
+);
 
 console.log('OK: PR body validator checks passed');

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -173,13 +173,13 @@ function hasAnimatedVisualProofMedia(body) {
     || /\bhttps?:\/\/\S+\.(?:gif|webm|mp4)\b/i.test(visualProof);
 }
 
-function visualProofNeedsAnimation(body) {
+export function visualProofNeedsAnimation(body) {
   const visualProof = getVisualProofBody(body);
   if (!visualProof) return false;
 
   return (
-    /\brestart|relaunch|reload\b/i.test(visualProof)
-    || /\btransition|state change\b/i.test(visualProof)
+    /\b(?:restart|relaunch|reload)\b/i.test(visualProof)
+    || /\b(?:transition|state change)\b/i.test(visualProof)
     || (/\bbefore\b/i.test(visualProof) && /\bafter\b/i.test(visualProof))
   );
 }


### PR DESCRIPTION
## Summary

`scripts/validate-pr-body.mjs` decides whether a Visual Proof section needs animated media instead of a static screenshot.

Two of its checks use a word-boundary regex with several options joined by `|`, without a wrapping group.

A boundary only binds to the first and last option, not every option in between.

One option is the bare word "reload". "Preload" contains "reload" as a substring, so the unwrapped pattern treats that substring as a real match.

A body that mentions a preload script in its Visual Proof text gets wrongly told it needs a gif or video.

This change wraps both patterns in a group so the boundary applies to the whole set, matching every other multi-word pattern already in this file and in `review-unit-rules.mjs`.

## Review Claim

Approve grouping two regex alternations so a word boundary binds to every option, not just the first and last, bringing them in line with the convention already used by every other pattern in this file and in `review-unit-rules.mjs`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Every word that already correctly triggered the animation requirement (a standalone "restart", "reload", "relaunch", "transition", or the phrase "state change") still triggers it after this change -- only the unintended substring match inside longer words like "preload" stops matching. Covered by a new case in `scripts/test-pr-body-validator.mjs`.

## Slice Rationale

One self-contained fix, landed as a single commit: both buggy patterns and their test coverage together, since they're the same bug in the same function.

## Non-goals

Does not touch any other pattern in this file or in `review-unit-rules.mjs` -- both were audited and every other multi-word pattern already wraps its alternation correctly.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-pr-body-validator.mjs`
- [ ] `bash scripts/test-suites/required/11-pr-authoring-guardrails.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
