### PR TITLE
[Mergify Branch Lookup](1) Find published stack branch by SHA/Change-Id, not by name

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -744,6 +744,61 @@ function branchHasChangeId(baseRef) {
   }
 }
 
+function getHeadChangeId() {
+  const message = gitTextOrEmpty(['log', '-1', '--format=%B', 'HEAD']);
+  const match = message.match(/^Change-Id:\s*(\S+)/m);
+  return match ? match[1] : '';
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function stackAuthorSegment(branch) {
+  const [root, author] = branch.split('/');
+  return root === 'stack' && author ? author : '';
+}
+
+function fetchStackHeadsPrefix(prefix) {
+  gitTextOrEmpty(['fetch', '--quiet', '--prune', 'origin', `+refs/heads/${prefix}/*:refs/remotes/origin/${prefix}/*`]);
+}
+
+function listRemoteTrackingRefTips(prefix) {
+  const out = gitTextOrEmpty(['for-each-ref', '--format=%(refname) %(objectname)', `refs/remotes/origin/${prefix}`]);
+  if (!out) return [];
+  return out.split('\n').filter(Boolean).map((line) => {
+    const [refname, sha] = line.split(' ');
+    return { refname: refname.replace(/^refs\/remotes\//, ''), sha };
+  });
+}
+
+function refCommitHasChangeId(sha, changeId) {
+  const message = gitTextOrEmpty(['log', '-1', '--format=%B', sha]);
+  return new RegExp(`^Change-Id:\\s*${escapeRegExp(changeId)}\\s*$`, 'm').test(message);
+}
+
+function findMergifyPublishedRef(branch, headSha, headChangeId) {
+  const prefixes = [];
+  const author = stackAuthorSegment(branch);
+  if (author) prefixes.push(`stack/${author}`);
+  prefixes.push('stack');
+
+  for (const prefix of prefixes) {
+    fetchStackHeadsPrefix(prefix);
+    const tips = listRemoteTrackingRefTips(prefix);
+
+    const shaMatch = tips.find((tip) => tip.sha === headSha);
+    if (shaMatch) return shaMatch.refname;
+
+    if (headChangeId) {
+      const changeIdMatch = tips.find((tip) => refCommitHasChangeId(tip.sha, headChangeId));
+      if (changeIdMatch) return changeIdMatch.refname;
+    }
+  }
+
+  return '';
+}
+
 
 function getMergifyBranchState(branch = getCurrentBranch()) {
   if (!branch || ['main', 'master', 'develop'].includes(branch)) {
@@ -776,6 +831,15 @@ function assertPublishedMergifyBranch(branch, trackedBaseRef) {
   const originBranchRef = `origin/${branch}`;
   if ((!publishedRef || publishedRef === trackedBaseRef) && gitTextOrEmpty(['rev-parse', '--verify', originBranchRef])) {
     publishedRef = originBranchRef;
+  }
+
+  if (!publishedRef || publishedRef === trackedBaseRef) {
+    const headSha = resolveRev('HEAD');
+    const headChangeId = getHeadChangeId();
+    const matchedRef = findMergifyPublishedRef(branch, headSha, headChangeId);
+    if (matchedRef) {
+      publishedRef = matchedRef;
+    }
   }
 
   if (!publishedRef) {

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -160,6 +160,12 @@ function gitQuiet(cwd, ...args) {
   return execFileSync('git', ['-C', cwd, ...args], { stdio: 'ignore' });
 }
 
+function gitTextRefExists(cwd, ref) {
+  return spawnSync('git', ['-C', cwd, 'rev-parse', '--verify', ref], {
+    encoding: 'utf-8',
+  }).status === 0;
+}
+
 function writeExecutable(path, content) {
   writeFileSync(path, content, { mode: 0o755 });
 }
@@ -888,6 +894,117 @@ function testUnpublishedStackCommitsBlockUpdate() {
   }
 }
 
+function testNestedMergifyPublishedBranchRecognizedBySha() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    const branch = 'stack/EdbertChan/owner-shutdown-signals/catch-sigterm-sigint-in-owner-serve';
+    createTrackedBranch(work, branch);
+    commitFile(work, 'stack.txt', 'stack\n', 'catch sigterm and sigint\n\nChange-Id: Ishutdown0001');
+    setManagedBranchConfig(work, branch);
+
+    const nestedRemoteBranch =
+      'stack/EdbertChan/stack/EdbertChan/owner-shutdown-signals/catch-sigterm-sigint-in-owner-serve/catch-sigterm-sigint-owner-serve-process-instead--72172374';
+    gitQuiet(work, 'push', 'origin', `HEAD:refs/heads/${nestedRemoteBranch}`);
+
+    const result = runCreatePr(work, harness, [...stackTitleArgs(), '--update-existing'], {
+      GH_API_PULLS_JSON: JSON.stringify([
+        {
+          number: 77,
+          html_url: 'https://example.com/pull/77',
+          head: { ref: branch, repo: { full_name: 'owner/repo' } },
+        },
+      ]),
+      GH_PATCH_RESPONSE: JSON.stringify({ html_url: 'https://example.com/pull/77' }),
+    });
+
+    assert(
+      result.status === 0,
+      `nested mergify-published branch should be recognized by SHA match\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    assert(
+      !result.stderr.includes('unpublished local commits'),
+      `nested mergify-published branch should not report unpublished commits\nstderr:\n${result.stderr}`,
+    );
+    expectNoPush(harness, 'nested mergify-published branch update');
+
+    commitFile(work, 'stack.txt', 'stack\nmore\n', 'truly unpublished follow-up\n\nChange-Id: Ishutdown0002');
+    const secondResult = runCreatePr(work, harness, [...stackTitleArgs(), '--update-existing']);
+    assert(secondResult.status === 1, 'a genuinely unpublished follow-up commit should still be rejected');
+    assert(
+      secondResult.stderr.includes('unpublished local commits'),
+      `genuinely unpublished commit should still be reported\nstderr:\n${secondResult.stderr}`,
+    );
+    assert(
+      secondResult.stderr.includes('Run `mergify stack push` first'),
+      'genuinely unpublished commit should still require mergify stack push',
+    );
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testDeletedMergifyPublishedBranchPrunesStaleTrackingRef() {
+  const harness = createHarness();
+  try {
+    const { originBare, work } = createRepo(harness);
+    const branch = 'stack/EdbertChan/deleted-stack-ref/local-branch';
+    createTrackedBranch(work, branch);
+    commitFile(work, 'stack.txt', 'stack\n', 'deleted stack ref\n\nChange-Id: Ideletedref0001');
+    setManagedBranchConfig(work, branch);
+
+    const deletedRemoteBranch =
+      'stack/EdbertChan/stack/EdbertChan/deleted-stack-ref/local-branch/deleted-stack-ref--12345678';
+    gitQuiet(work, 'push', 'origin', `HEAD:refs/heads/${deletedRemoteBranch}`);
+    gitQuiet(
+      work,
+      'fetch',
+      'origin',
+      '+refs/heads/stack/EdbertChan/*:refs/remotes/origin/stack/EdbertChan/*',
+    );
+    gitQuiet(originBare, 'update-ref', '-d', `refs/heads/${deletedRemoteBranch}`);
+
+    const staleTrackingRef = `refs/remotes/origin/${deletedRemoteBranch}`;
+    assert(
+      git(work, 'rev-parse', '--verify', staleTrackingRef).trim(),
+      'test setup should leave a stale remote-tracking stack ref before create-pr runs',
+    );
+
+    const result = runCreatePr(work, harness, [...stackTitleArgs(), '--update-existing'], {
+      GH_API_PULLS_JSON: JSON.stringify([
+        {
+          number: 78,
+          html_url: 'https://example.com/pull/78',
+          head: { ref: branch, repo: { full_name: 'owner/repo' } },
+        },
+      ]),
+      GH_PATCH_RESPONSE: JSON.stringify({ html_url: 'https://example.com/pull/78' }),
+    });
+
+    assert(
+      result.status === 1,
+      `deleted remote stack branch should not be accepted through a stale remote-tracking ref\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    assert(
+      result.stderr.includes(`Current branch "${branch}" has unpublished local commits ahead of origin/master.`)
+        || result.stderr.includes(`Current branch "${branch}" has no published remote branch.`),
+      `deleted remote stack branch should be rejected as unpublished\nstderr:\n${result.stderr}`,
+    );
+    assert(
+      result.stderr.includes('Run `mergify stack push` first'),
+      `deleted remote stack branch should require republishing\nstderr:\n${result.stderr}`,
+    );
+    assert(
+      !gitTextRefExists(work, staleTrackingRef),
+      'create-pr should prune the stale remote-tracking stack ref before matching',
+    );
+    expectNoPush(harness, 'deleted stack ref update');
+    assert(readGhCalls(harness.ghLog).length === 0, 'deleted stack ref should fail before GitHub calls');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
 function testCurrentBranchPrLookupFailure() {
   const harness = createHarness();
   try {
@@ -1316,6 +1433,8 @@ const tests = [
   testNonRefactorLaneTitleWithTagRejected,
   testNonRefactorLanePlainTitleStillAccepted,
   testUnpublishedStackCommitsBlockUpdate,
+  testNestedMergifyPublishedBranchRecognizedBySha,
+  testDeletedMergifyPublishedBranchPrunesStaleTrackingRef,
   testCurrentBranchPrLookupFailure,
   testNonStackedUnrelatedAreasStayWarnings,
   testStackedDiffTitleRequiredForNonTrunkBase,


### PR DESCRIPTION
## Summary

When `mergify stack push` publishes a branch, it generates its own name for the remote ref -- a nested prefix plus a slug plus a hash.

That published name is not `origin/<local-branch-name>`. `scripts/create-pr.mjs` assumed the two would match.

When a local branch's upstream also happened to be `origin/master`, that assumption failed silently.

A genuinely-published commit then got reported as unpublished, blocking `--update-existing` on a branch that was actually fine.

This change looks up the real published branch by matching the local commit's SHA, or its Change-Id trailer, against remote refs under `refs/heads/stack/`.

The branch's own author segment is checked first, widening only if nothing matches there.

## Review Claim

Approve replacing a name-based guess with a content-based match (commit SHA, falling back to the Change-Id trailer) when looking up a branch's real published ref, since a name a tool generates for itself was never a safe thing to assume.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The original check's real purpose -- rejecting a branch with genuinely unpublished local commits -- still fires exactly as before whenever no remote ref carries the local HEAD commit or its Change-Id. The new lookup only ever widens what counts as "found," it never narrows it. Covered by a new case in `scripts/test-create-pr-stack-workflow.mjs` that reproduces the exact nested-name scenario, plus a companion case confirming a truly unpublished commit is still rejected.

## Slice Rationale

One self-contained change: the lookup function and its test land together, since the test is what proves the lookup actually solves the reported problem.

## Non-goals

Does not add a dependency on the `mergify` CLI's own query surface -- that talks to a remote API and would make this offline, git-native check network-dependent for no real benefit over what's already available locally. Does not widen the ref search beyond the `stack/` prefix.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-create-pr-stack-workflow.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of published stack branches, including nested branches and branches lacking standard upstream references.
  * Prevented updates from being published when their commits have not been published.

* **Tests**
  * Added regression coverage for identifying published branches by commit and correctly blocking unpublished updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->