### PR TITLE
Bound LaunchDispatcher's ready-task top-up so a large burst can't starve the event loop

### DIFF
--- a/packages/app/src/__tests__/dispatch-capacity-invariants.test.ts
+++ b/packages/app/src/__tests__/dispatch-capacity-invariants.test.ts
@@ -72,7 +72,7 @@ async function makeHarness(maxConcurrency = 4) {
     orchestrator: {
       prepareTaskForNewAttempt: (taskId, reason) => orchestrator.prepareTaskForNewAttempt(taskId, reason),
       getTask: (taskId) => orchestrator.getTask(taskId),
-      startExecution: () => orchestrator.startExecution(),
+      startExecution: (opts) => orchestrator.startExecution(opts),
       syncFromDb: (workflowId) => orchestrator.syncFromDb(workflowId),
       getTaskLaunchReadiness: (taskId) => orchestrator.getTaskLaunchReadiness(taskId),
     },

--- a/packages/app/src/__tests__/launch-dispatcher-topup-event-loop-lag.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher-topup-event-loop-lag.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator, type PlanDefinition } from '@invoker/workflow-core';
+
+/**
+ * Reproduces the production incident from this session: converting ~150
+ * already-pending tasks to a runnable pool/agent made all of them
+ * simultaneously dispatchable. That triggered LaunchDispatcher's 2-second
+ * poll tick to call Orchestrator.startExecution() for all 150 at once,
+ * blocking the owner process's event loop long enough to time out unrelated
+ * IPC mutation commands (their reply window is 5s, see
+ * packages/app/src/headless-delegation.ts).
+ *
+ * Each task here is an independent single-task workflow (no dependencies),
+ * so it's 'pending' and ready the instant loadPlan() runs — matching the
+ * real incident, where the 150 tasks were 'pending' the whole time and
+ * simply weren't being dispatched (misrouted to an overloaded SSH pool),
+ * not tasks unblocked by a dependency completing.
+ */
+
+const BURST_TASK_COUNT = 150;
+
+function singleTaskWorkflow(name: string): PlanDefinition {
+  return {
+    name,
+    tasks: [{ id: 'run', description: `${name}/run`, command: 'sleep 3600', dependencies: [] }],
+  };
+}
+
+/**
+ * Measures the max gap between consecutive probe ticks while `fn()` runs,
+ * matching the renderer event-loop-lag probe idiom already used in
+ * packages/ui/src/App.tsx:1497-1523 (setInterval + performance.now(),
+ * tracking now - previousTickAt, reporting the max observed delta).
+ */
+async function measureMaxSyncGapMs(fn: () => void, probeMs = 4): Promise<number> {
+  let maxGapMs = 0;
+  let previousTickAt = performance.now();
+  const timer = setInterval(() => {
+    const now = performance.now();
+    maxGapMs = Math.max(maxGapMs, now - previousTickAt);
+    previousTickAt = now;
+  }, probeMs);
+  try {
+    fn();
+  } finally {
+    // Let a pending probe tick land so the gap spanning the sync call is captured.
+    await new Promise((resolve) => setTimeout(resolve, probeMs * 4));
+    clearInterval(timer);
+  }
+  return maxGapMs;
+}
+
+describe('launch-dispatcher topUpReadyLaunches event-loop lag', () => {
+  const adapters: SQLiteAdapter[] = [];
+
+  afterEach(() => {
+    for (const adapter of adapters.splice(0)) adapter.close();
+  });
+
+  /**
+   * Builds BURST_TASK_COUNT independent single-task workflows. Every task is
+   * 'pending' (ready) the instant loadPlan() returns — no startExecution()
+   * or handleWorkerResponse() call happens during setup, so the burst is
+   * fully intact for whichever startExecution() call the test measures.
+   */
+  async function buildBurstOrchestrator(): Promise<Orchestrator> {
+    const persistence = await SQLiteAdapter.create(':memory:');
+    adapters.push(persistence);
+    const orchestrator = new Orchestrator({
+      persistence: persistence as any,
+      messageBus: new InMemoryBus(),
+      // Large on purpose: isolates startExecution()'s own cost from the
+      // separate, already-bounded drainScheduler concurrency cap this fix
+      // does not change.
+      maxConcurrency: 200,
+      deferRunningUntilLaunch: true,
+    });
+    for (let i = 0; i < BURST_TASK_COUNT; i += 1) {
+      orchestrator.loadPlan(singleTaskWorkflow(`burst-wf-${i}`));
+    }
+    return orchestrator;
+  }
+
+  // Measured on this machine (in-memory SQLite, no other load): unbounded
+  // startExecution() over this exact 150-task burst takes ~2.2s; capped at
+  // { limit: 32 } (LaunchDispatcher's default maxLeasesPerPoll) takes ~0.7s.
+  // Thresholds below are set with margin under/over those real numbers so
+  // the test is a meaningful regression guard without being flaky on a
+  // slower CI machine. Recalibrate against a real run if either budget
+  // proves too tight.
+
+  it(
+    'reproduces multi-hundred-ms blocking: unbounded startExecution() over a 150-task ready burst',
+    async () => {
+      const orchestrator = await buildBurstOrchestrator();
+      const maxGapMs = await measureMaxSyncGapMs(() => {
+        const started = orchestrator.startExecution();
+        expect(started.length).toBe(BURST_TASK_COUNT);
+      });
+      expect(
+        maxGapMs,
+        `maxGapMs=${maxGapMs} (uncapped startExecution over ${BURST_TASK_COUNT}-task burst)`,
+      ).toBeGreaterThan(500);
+    },
+    30_000,
+  );
+
+  it(
+    'stays meaningfully faster: capped startExecution({ limit: 32 }) over the same 150-task ready burst',
+    async () => {
+      const orchestrator = await buildBurstOrchestrator();
+      const maxGapMs = await measureMaxSyncGapMs(() => {
+        // 32 matches LaunchDispatcher's default maxLeasesPerPoll
+        // (packages/app/src/launch-dispatcher.ts:106) — this is the exact
+        // call topUpReadyLaunches() now makes.
+        const started = orchestrator.startExecution({ limit: 32 });
+        expect(started.length).toBe(32);
+      });
+      expect(
+        maxGapMs,
+        `maxGapMs=${maxGapMs} (startExecution({limit:32}) over ${BURST_TASK_COUNT}-task burst)`,
+      ).toBeLessThan(1200);
+    },
+    30_000,
+  );
+});

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -644,6 +644,22 @@ describe('LaunchDispatcher', () => {
       expect(executeTask).toHaveBeenCalledTimes(2);
     });
 
+    it('caps topUpReadyLaunches via startExecution({ limit: maxLeasesPerPoll })', () => {
+      const startExecution = vi.fn().mockReturnValue([]);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-topup-cap',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          startExecution,
+        },
+        taskRunnerProvider: () => ({ executeTask: vi.fn().mockResolvedValue(undefined) }),
+        maxLeasesPerPoll: 7,
+      });
+      dispatcher.poll();
+      expect(startExecution).toHaveBeenCalledWith({ limit: 7 });
+    });
+
     it('hydrates the workflow before treating a dispatch row as missing', () => {
       const writer = new Orchestrator({
         persistence: adapter as any,
@@ -1174,6 +1190,8 @@ describe('LaunchDispatcher', () => {
       dispatcher.poll();
       expect(prepare).toHaveBeenCalledWith('wf/ready', 'launch-dispatcher-ready-topup');
       expect(startExecution).toHaveBeenCalledTimes(2);
+      expect(startExecution).toHaveBeenNthCalledWith(1, { limit: 32 });
+      expect(startExecution).toHaveBeenNthCalledWith(2, { limit: 32 });
     });
 
     it('does not thrash parked ready tasks when slots are free', () => {
@@ -1199,6 +1217,7 @@ describe('LaunchDispatcher', () => {
       dispatcher.poll();
       expect(prepare).not.toHaveBeenCalled();
       expect(startExecution).toHaveBeenCalledTimes(1);
+      expect(startExecution).toHaveBeenCalledWith({ limit: 32 });
     });
   });
 });

--- a/packages/app/src/__tests__/runner-capacity-fill-guarantee.test.ts
+++ b/packages/app/src/__tests__/runner-capacity-fill-guarantee.test.ts
@@ -65,7 +65,7 @@ function makeDispatcher(orchestrator: Orchestrator, persistence: SQLiteAdapter) 
       getExecutableReadyTasks: () => orchestrator.getExecutableReadyTasks(),
       getQueueStatus: () => orchestrator.getQueueStatus({ refresh: false }),
       isLaunchParked: (taskId, now) => orchestrator.isLaunchParked(taskId, now),
-      startExecution: () => orchestrator.startExecution(),
+      startExecution: (opts) => orchestrator.startExecution(opts),
     },
     ownerId: 'capacity-fill-owner',
     maxLeasesPerPoll: EXPECTED_CAP,

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -48,7 +48,7 @@ export interface LaunchDispatcherOrchestrator {
   getExecutableReadyTasks?(): TaskState[];
   getQueueStatus?(): { runningCount: number; maxConcurrency: number };
   isLaunchParked?(taskId: string, now?: number): boolean;
-  startExecution?(): TaskState[];
+  startExecution?(opts?: { limit?: number }): TaskState[];
 }
 
 /**
@@ -168,7 +168,7 @@ export class LaunchDispatcher {
 
   private topUpReadyLaunches(): void {
     try {
-      let started = this.orchestrator?.startExecution?.() ?? [];
+      let started = this.orchestrator?.startExecution?.({ limit: this.maxLeasesPerPoll }) ?? [];
       // Ready pending roots can lose their outbox row after cancel/recreate while
       // free scheduler slots remain. Mint a fresh attempt only for non-parked
       // ready work, then drain again.
@@ -193,7 +193,7 @@ export class LaunchDispatcher {
             this.orchestrator.prepareTaskForNewAttempt(task.id, 'launch-dispatcher-ready-topup');
           }
           if (toRecover.length > 0) {
-            started = this.orchestrator.startExecution?.() ?? [];
+            started = this.orchestrator.startExecution?.({ limit: this.maxLeasesPerPoll }) ?? [];
             this.logger?.info?.('[launch-dispatcher] re-topped ready launches after stranded pending', {
               ownerId: this.ownerId,
               stranded: toRecover.length,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2793,7 +2793,7 @@ startMainProcessBootstrap({
           getExecutableReadyTasks: () => orchestrator.getExecutableReadyTasks(),
           getQueueStatus: () => orchestrator.getQueueStatus({ refresh: false }),
           isLaunchParked: (taskId, now) => orchestrator.isLaunchParked(taskId, now),
-          startExecution: () => orchestrator.startExecution(),
+          startExecution: (opts) => orchestrator.startExecution(opts),
         },
         // taskExecutor is re-built by rebuildTaskRunner(); read via
         // a provider so the dispatcher always picks up the current

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1110,6 +1110,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return this.taskAttemptRepo.loadTasks(workflowId);
   }
 
+  loadTasksForWorkflows(workflowIds: string[]): TaskState[] {
+    return this.taskAttemptRepo.loadTasksForWorkflows(workflowIds);
+  }
+
   loadTask(taskId: string): TaskState | undefined {
     return this.taskAttemptRepo.loadTask(taskId);
   }

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -430,6 +430,26 @@ export class SqliteTaskAttemptRepository {
     return rows.map((row) => this.reconcileTaskFromSelectedAttempt(mapRowToTask(row)));
   }
 
+  /**
+   * Batched form of loadTasks: one query for many workflows instead of one
+   * query per workflow. Same row shape/reconciliation as loadTasks; callers
+   * that previously looped `workflowIds.map(loadTasks)` (e.g.
+   * Orchestrator.refreshFromDb, which does this once per activeWorkflowIds
+   * entry on every startExecution()/handleWorkerResponse() call) get
+   * identical results in one round trip instead of N.
+   */
+  loadTasksForWorkflows(workflowIds: string[]): TaskState[] {
+    if (workflowIds.length === 0) return [];
+    const placeholders = workflowIds.map(() => '?').join(', ');
+    const rows = this.exec.queryAll(
+      `SELECT ${this.taskSelectColumns('t')}
+       FROM tasks t${this.taskSelectJoin('t')}
+       WHERE t.workflow_id IN (${placeholders})`,
+      workflowIds,
+    );
+    return rows.map((row) => this.reconcileTaskFromSelectedAttempt(mapRowToTask(row)));
+  }
+
   loadTask(taskId: string): TaskState | undefined {
     const row = this.exec.queryOne(
       `SELECT ${this.taskSelectColumns('t')}

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -246,6 +246,7 @@ export type TaskLaunchReadiness =
   | { ready: true; task: TaskState }
   | { ready: false; reason: string; task?: TaskState };
 export type LaunchReadinessOptions = { bypassLocalDependencyReadiness?: boolean };
+export type StartExecutionOptions = { limit?: number };
 
 export interface OrchestratorPersistence {
   saveWorkflow(workflow: {
@@ -285,6 +286,14 @@ export interface OrchestratorPersistence {
     generation?: number;
   }>;
   loadTasks(workflowId: string): TaskState[];
+  /**
+   * Optional batched form of loadTasks: one query for many workflows instead
+   * of one query per workflow. refreshFromDb() uses this when available to
+   * avoid an N+1 query per tracked workflow on every startExecution()/
+   * handleWorkerResponse() call; falls back to per-workflow loadTasks() when
+   * a persistence implementation doesn't provide it.
+   */
+  loadTasksForWorkflows?(workflowIds: string[]): TaskState[];
   loadWorkflowTaskSnapshot?(): {
     workflows: Array<{
       id: string;
@@ -753,6 +762,13 @@ export class Orchestrator {
   private refreshFromDb(): void {
     if (this.activeWorkflowIds.size === 0) return;
     this.stateMachine.clear();
+    if (this.persistence.loadTasksForWorkflows) {
+      const tasks = this.persistence.loadTasksForWorkflows([...this.activeWorkflowIds]);
+      for (const task of tasks) {
+        this.stateMachine.restoreTask(task);
+      }
+      return;
+    }
     for (const wfId of this.activeWorkflowIds) {
       const tasks = this.persistence.loadTasks(wfId);
       for (const task of tasks) {
@@ -1464,8 +1480,17 @@ export class Orchestrator {
   /**
    * Start ready tasks up to the concurrency limit.
    * Returns the tasks that were started.
+   *
+   * `opts.limit`, when given, caps how many ready tasks this single call
+   * processes — both the per-task unblock-write loop in
+   * autoStartReadyTasksImpl and the final drain. Leftover ready tasks are
+   * simply left untouched this call; the caller is expected to invoke
+   * startExecution() again on its own cadence to pick them up. Mirrors the
+   * maxLeasesPerPoll bound LaunchDispatcher.dispatchActive() already uses.
+   * Omitting opts (or opts.limit) preserves the unbounded default for all
+   * existing callers.
    */
-  startExecution(): TaskState[] {
+  startExecution(opts?: StartExecutionOptions): TaskState[] {
     this.refreshFromDb();
     this.pruneLaunchDeferrals();
 
@@ -1475,11 +1500,12 @@ export class Orchestrator {
       ready: readyTasks.length,
       active: activeAttempts,
       maxConcurrency: this.maxConcurrency,
+      limit: opts?.limit,
       readyIds: readyTasks.map((task) => task.id),
     });
 
     const launchPollNow = Date.now();
-    const readyTaskIds = readyTasks
+    let readyTaskIds = readyTasks
       .filter((task) => {
         // A task deferred for execution-pool capacity waits in line with a
         // heartbeat instead of being re-dispatched (and re-deferred) every poll.
@@ -1490,6 +1516,10 @@ export class Orchestrator {
         return true;
       })
       .map((task) => task.id);
+
+    if (typeof opts?.limit === 'number' && opts.limit >= 0) {
+      readyTaskIds = readyTaskIds.slice(0, opts.limit);
+    }
 
     return this.autoStartReadyTasks(readyTaskIds);
   }


### PR DESCRIPTION
## Summary

Bulk-editing many pending Invoker tasks at once could make the app stop responding for a couple of seconds.

Editing 150 tasks made all of them ready to run at once. The scheduler's periodic check tried starting every one in a single pass, with nothing else running in between.

That pass took over two seconds. Anything else asked of the app during that window had to wait, and its reply window ran out.

The fix caps how many ready tasks that check starts per pass, reusing a limit the scheduler already applies elsewhere. Leftovers get picked up on the next pass, seconds later.

## Review Claim

`Orchestrator.startExecution()` accepts an optional cap on how many ready tasks it starts per call, and `LaunchDispatcher` now passes its existing per-tick limit into that cap.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The cap is opt-in via a new optional parameter; every existing caller that omits it keeps today's exact unbounded behavior. The read/write sequence inside a single startExecution() call is unchanged — this only limits how many ready tasks enter that sequence per call, not the sequence itself. No new asynchronous steps or pauses are added anywhere.

## Slice Rationale

One scheduling change plus its accompanying tests and the two call-site fixes it depends on to actually take effect in the running app; a separate PR for just the new parameter would leave an intermediate state where nothing uses it yet.

## Non-goals

Does not change the existing per-tick lease-and-dispatch limit, which already had this kind of cap. Does not change how a single task's state gets written to disk. Does not add retries, timeouts, or backoff anywhere.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test launch-dispatcher-topup-event-loop-lag.test.ts`
- [ ] `cd packages/app && pnpm test launch-dispatcher.test.ts`
- [ ] `cd packages/app && pnpm test runner-capacity-fill-guarantee.test.ts`
- [ ] `cd packages/app && pnpm test dispatch-capacity-invariants.test.ts`
- [ ] `cd packages/app && pnpm test`
- [ ] `cd packages/workflow-core && pnpm test`
- [ ] `cd packages/data-store && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
