### PR TITLE
[Disk Headroom Local Race](1) Guard local cleanup with task-state liveness, not process patterns

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
@@ -3,11 +3,15 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import type { TaskState } from '@invoker/workflow-core';
+
 import {
   buildInvokerHomeCleanupScript,
   cleanupLocalInvokerHome,
+  computeProtectedLocalPaths,
   DISK_RECLAIMABLE_DIRS,
   DiskCleanupCooldownTracker,
+  type DiskHeadroomWorkerStore,
   isSafeInvokerHome,
   isSafeRemoteInvokerHomePath,
   resolveDiskCleanupCooldownMs,
@@ -24,6 +28,35 @@ afterEach(() => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id: 'wf-1/task-1',
+    description: 'test task',
+    status: 'running',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: {
+      workflowId: 'wf-1',
+      command: 'pnpm test',
+      ...(config ?? {}),
+    },
+    execution: {
+      generation: 1,
+      ...(execution ?? {}),
+    },
+    taskStateVersion: 1,
+    ...rest,
+  } as TaskState;
+}
+
+function makeStore(workflows: Array<{ id: string; tasks: TaskState[] }>): DiskHeadroomWorkerStore {
+  return {
+    listWorkflows: () => workflows.map((w) => ({ id: w.id })),
+    loadTasks: (workflowId: string) => workflows.find((w) => w.id === workflowId)?.tasks ?? [],
+  };
+}
 
 describe('disk-headroom cleanup guards', () => {
   it('rejects unsafe invoker homes', () => {
@@ -199,5 +232,150 @@ describe('cleanupLocalInvokerHome', () => {
     });
     expect(result.ok).toBe(false);
     expect(result.reason).toBe('path-guard');
+  });
+});
+
+describe('computeProtectedLocalPaths', () => {
+  it('protects workspacePaths of non-terminal tasks only', () => {
+    const store = makeStore([
+      {
+        id: 'wf-1',
+        tasks: [
+          makeTask({ id: 'wf-1/running', status: 'running', execution: { workspacePath: '/home/u/.invoker/worktrees/running' } }),
+          makeTask({ id: 'wf-1/completed', status: 'completed', execution: { workspacePath: '/home/u/.invoker/worktrees/completed' } }),
+          makeTask({ id: 'wf-1/closed', status: 'closed', execution: { workspacePath: '/home/u/.invoker/worktrees/closed' } }),
+          makeTask({ id: 'wf-1/stale', status: 'stale', execution: { workspacePath: '/home/u/.invoker/worktrees/stale' } }),
+          makeTask({ id: 'wf-1/no-path', status: 'pending', execution: {} }),
+        ],
+      },
+    ]);
+
+    const protectedPaths = computeProtectedLocalPaths(store);
+    expect(protectedPaths.has('/home/u/.invoker/worktrees/running')).toBe(true);
+    expect(protectedPaths.has('/home/u/.invoker/worktrees/completed')).toBe(false);
+    expect(protectedPaths.has('/home/u/.invoker/worktrees/closed')).toBe(false);
+    expect(protectedPaths.has('/home/u/.invoker/worktrees/stale')).toBe(false);
+    expect(protectedPaths.size).toBe(1);
+  });
+
+  it('fails safe to an empty set when the store throws', () => {
+    const store: DiskHeadroomWorkerStore = {
+      listWorkflows: () => {
+        throw new Error('db unavailable');
+      },
+      loadTasks: () => [],
+    };
+    expect(computeProtectedLocalPaths(store)).toEqual(new Set());
+  });
+});
+
+describe('cleanupLocalInvokerHome DB-state liveness guard', () => {
+  it('protects only the in-use subpath under a reclaimable dir; sibling subpaths are still cleared', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'invoker-disk-cleanup-liveness-'));
+    tempDirs.push(root);
+    const home = join(root, '.invoker');
+    const userHome = root;
+    const activeDir = join(home, 'worktrees', 'active-task');
+    const staleDir = join(home, 'worktrees', 'stale-task');
+    mkdirSync(activeDir, { recursive: true });
+    writeFileSync(join(activeDir, 'file.txt'), 'x');
+    mkdirSync(staleDir, { recursive: true });
+    writeFileSync(join(staleDir, 'file.txt'), 'x');
+
+    const store = makeStore([
+      {
+        id: 'wf-1',
+        tasks: [
+          makeTask({ id: 'wf-1/active', status: 'running', execution: { workspacePath: activeDir } }),
+        ],
+      },
+    ]);
+
+    const result = await cleanupLocalInvokerHome({
+      invokerHome: home,
+      userHome,
+      store,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe('protected-path-in-use');
+    expect(existsSync(activeDir)).toBe(true);
+    expect(existsSync(join(activeDir, 'file.txt'))).toBe(true);
+    expect(existsSync(staleDir)).toBe(false);
+  });
+
+  it('does not protect a task workspacePath once the task reaches a terminal status', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'invoker-disk-cleanup-liveness-terminal-'));
+    tempDirs.push(root);
+    const home = join(root, '.invoker');
+    const userHome = root;
+    const completedDir = join(home, 'worktrees', 'completed-task');
+    mkdirSync(completedDir, { recursive: true });
+    writeFileSync(join(completedDir, 'file.txt'), 'x');
+
+    const store = makeStore([
+      {
+        id: 'wf-1',
+        tasks: [
+          makeTask({ id: 'wf-1/done', status: 'completed', execution: { workspacePath: completedDir } }),
+        ],
+      },
+    ]);
+
+    const result = await cleanupLocalInvokerHome({
+      invokerHome: home,
+      userHome,
+      store,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe('critical-cleanup');
+    expect(existsSync(completedDir)).toBe(false);
+  });
+
+  it('fails safe by clearing normally (protects nothing) when the store errors', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'invoker-disk-cleanup-liveness-error-'));
+    tempDirs.push(root);
+    const home = join(root, '.invoker');
+    const userHome = root;
+    const someDir = join(home, 'worktrees', 'some-task');
+    mkdirSync(someDir, { recursive: true });
+    writeFileSync(join(someDir, 'file.txt'), 'x');
+
+    const throwingStore: DiskHeadroomWorkerStore = {
+      listWorkflows: () => {
+        throw new Error('db unavailable');
+      },
+      loadTasks: () => [],
+    };
+
+    const result = await cleanupLocalInvokerHome({
+      invokerHome: home,
+      userHome,
+      store: throwingStore,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe('critical-cleanup');
+    expect(existsSync(someDir)).toBe(false);
+  });
+
+  it('behaves exactly as before (clears everything) when no store is provided', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'invoker-disk-cleanup-liveness-no-store-'));
+    tempDirs.push(root);
+    const home = join(root, '.invoker');
+    const userHome = root;
+    const someDir = join(home, 'worktrees', 'some-task');
+    mkdirSync(someDir, { recursive: true });
+    writeFileSync(join(someDir, 'file.txt'), 'x');
+
+    const result = await cleanupLocalInvokerHome({ invokerHome: home, userHome });
+
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe('critical-cleanup');
+    expect(existsSync(someDir)).toBe(false);
   });
 });

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -16,6 +16,7 @@ import type {
 import type { PrMaintenanceWorkerConfig } from './workers/pr-maintenance-workers.js';
 import type { E2eAutoFixWorkerConfig } from './workers/e2e-autofix-worker.js';
 import type { DiskHeadroomWorkerConfig } from './workers/disk-headroom-worker.js';
+import type { DiskHeadroomWorkerStore } from './workers/disk-headroom-reclaim.js';
 import type {
   InfraRepairWorkerConfig,
   InfraRepairWorkerStore,
@@ -36,7 +37,8 @@ export interface WorkerRuntimeDependencies {
     & ReviewGateCiRepairStore
     & AutoApproveWorkerStore
     & InfraRepairWorkerStore
-    & WorkflowResumeWorkerStore;
+    & WorkflowResumeWorkerStore
+    & DiskHeadroomWorkerStore;
   /** Action-output channel used to submit follow-up mutation intents. */
   submitter: AutoFixRecoverySubmitter
     & ReviewGateCiRepairSubmitter

--- a/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
@@ -7,9 +7,10 @@
 
 import { existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 
 import type { Logger } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-core';
 
 import { buildSshConnectionArgs } from '../ssh-transport-options.js';
 import { bashNormalizeTildePath, execRemoteCapture, shellPosixSingleQuote } from '../ssh-git-exec.js';
@@ -212,10 +213,83 @@ exit 0
 `;
 }
 
-function removeLocalDir(path: string, errors: string[]): void {
-  if (!existsSync(path)) return;
+const LOCAL_RM_MAX_RETRIES = 5;
+const LOCAL_RM_RETRY_DELAY_MS = 100;
+
+/**
+ * Read-only accessor for Invoker's own workflow/task state, used to derive
+ * which local paths are still in active use before the disk-headroom
+ * cleaner deletes anything. Mirrors WorkflowResumeWorkerStore's shape.
+ */
+export interface DiskHeadroomWorkerStore {
+  listWorkflows(): ReadonlyArray<{ id: string }>;
+  loadTasks(workflowId: string): TaskState[];
+}
+
+export const DISK_HEADROOM_TERMINAL_TASK_STATUSES = ['completed', 'closed', 'stale'] as const;
+
+const TERMINAL_TASK_STATUS_SET = new Set<string>(DISK_HEADROOM_TERMINAL_TASK_STATUSES);
+
+/**
+ * Resolved workspacePaths for every non-terminal task across all workflows.
+ * These are "in use" regardless of whether any OS process currently touches
+ * them, so the cleaner must never delete them. Fails safe to an empty set
+ * (protects nothing) on any store error -- see cleanupLocalInvokerHome for
+ * why that is the safer failure mode for this worker.
+ */
+export function computeProtectedLocalPaths(store: DiskHeadroomWorkerStore): Set<string> {
   try {
-    rmSync(path, { recursive: true, force: true });
+    const protectedPaths = new Set<string>();
+    for (const workflow of store.listWorkflows()) {
+      for (const task of store.loadTasks(workflow.id)) {
+        if (TERMINAL_TASK_STATUS_SET.has(task.status)) continue;
+        if (task.execution?.workspacePath) {
+          protectedPaths.add(resolve(task.execution.workspacePath));
+        }
+      }
+    }
+    return protectedPaths;
+  } catch {
+    return new Set();
+  }
+}
+
+function pathIsProtected(candidate: string, protectedPaths: ReadonlySet<string>): boolean {
+  if (protectedPaths.size === 0) return false;
+  const resolved = resolve(candidate);
+  for (const protectedPath of protectedPaths) {
+    if (resolved === protectedPath) return true;
+    if (resolved.startsWith(`${protectedPath}${sep}`)) return true;
+    if (protectedPath.startsWith(`${resolved}${sep}`)) return true;
+  }
+  return false;
+}
+
+async function removeLocalDir(
+  path: string,
+  errors: string[],
+  protectedSkips: string[],
+  protectedPaths: ReadonlySet<string>,
+  logger?: Logger,
+  targetKey?: string,
+): Promise<void> {
+  if (!existsSync(path)) return;
+  if (pathIsProtected(path, protectedPaths)) {
+    protectedSkips.push(path);
+    logger?.warn?.(`[disk-headroom-cleanup] skip ${path}: protected-path-in-use`, {
+      module: 'disk-headroom',
+      targetKey,
+      path,
+    });
+    return;
+  }
+  try {
+    rmSync(path, {
+      recursive: true,
+      force: true,
+      maxRetries: LOCAL_RM_MAX_RETRIES,
+      retryDelay: LOCAL_RM_RETRY_DELAY_MS,
+    });
   } catch (err) {
     errors.push(`${path}: ${err instanceof Error ? err.message : String(err)}`);
   }
@@ -229,7 +303,14 @@ function ensureLocalDir(path: string, errors: string[]): void {
   }
 }
 
-function sweepLocalDeletingOrphans(home: string, errors: string[]): void {
+async function sweepLocalDeletingOrphans(
+  home: string,
+  errors: string[],
+  protectedSkips: string[],
+  protectedPaths: ReadonlySet<string>,
+  logger?: Logger,
+  targetKey?: string,
+): Promise<void> {
   if (!existsSync(home)) return;
   let entries: string[];
   try {
@@ -240,7 +321,32 @@ function sweepLocalDeletingOrphans(home: string, errors: string[]): void {
   }
   for (const name of entries) {
     if (!isDeletingOrphanName(name)) continue;
-    removeLocalDir(join(home, name), errors);
+    await removeLocalDir(join(home, name), errors, protectedSkips, protectedPaths, logger, targetKey);
+  }
+}
+
+/**
+ * Sweeps a reclaimable top-level dir (e.g. `worktrees`) one child at a time
+ * so a single in-use subdirectory only protects itself, not its siblings.
+ */
+async function sweepReclaimableChildren(
+  dirPath: string,
+  errors: string[],
+  protectedSkips: string[],
+  protectedPaths: ReadonlySet<string>,
+  logger?: Logger,
+  targetKey?: string,
+): Promise<void> {
+  if (!existsSync(dirPath)) return;
+  let entries: string[];
+  try {
+    entries = readdirSync(dirPath);
+  } catch (err) {
+    errors.push(`readdir ${dirPath}: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+  for (const name of entries) {
+    await removeLocalDir(join(dirPath, name), errors, protectedSkips, protectedPaths, logger, targetKey);
   }
 }
 
@@ -249,6 +355,7 @@ export async function cleanupLocalInvokerHome(opts: {
   targetKey?: string;
   logger?: Logger;
   userHome?: string;
+  store?: DiskHeadroomWorkerStore;
 }): Promise<DiskCleanupResult> {
   const targetKey = opts.targetKey ?? `local ${opts.invokerHome}`;
   const userHome = opts.userHome ?? homedir();
@@ -262,10 +369,12 @@ export async function cleanupLocalInvokerHome(opts: {
     targetKey,
   });
 
+  const protectedPaths = opts.store ? computeProtectedLocalPaths(opts.store) : new Set<string>();
   const errors: string[] = [];
-  sweepLocalDeletingOrphans(home, errors);
+  const protectedSkips: string[] = [];
+  await sweepLocalDeletingOrphans(home, errors, protectedSkips, protectedPaths, opts.logger, targetKey);
   for (const name of DISK_RECLAIMABLE_DIRS) {
-    removeLocalDir(join(home, name), errors);
+    await sweepReclaimableChildren(join(home, name), errors, protectedSkips, protectedPaths, opts.logger, targetKey);
   }
   for (const name of DISK_RECLAIMABLE_DIRS) {
     ensureLocalDir(join(home, name), errors);
@@ -282,6 +391,20 @@ export async function cleanupLocalInvokerHome(opts: {
       ok: false,
       reason: 'cleanup-error',
       detail: errors.slice(0, 5).join('; '),
+    };
+  }
+
+  if (protectedSkips.length > 0) {
+    opts.logger?.warn?.(`[disk-headroom-cleanup] local skipped in-use paths`, {
+      module: 'disk-headroom',
+      targetKey,
+      protectedSkips,
+    });
+    return {
+      targetKey,
+      ok: true,
+      reason: 'protected-path-in-use',
+      detail: protectedSkips.slice(0, 5).join('; '),
     };
   }
 

--- a/packages/execution-engine/src/workers/disk-headroom-worker.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-worker.ts
@@ -19,6 +19,7 @@ import {
   resolveDiskCleanupCooldownMs,
   resolveDiskCleanupEnabled,
   type DiskCleanupResult,
+  type DiskHeadroomWorkerStore,
 } from './disk-headroom-reclaim.js';
 import {
   runDiskHeadroomCheck,
@@ -46,6 +47,8 @@ export interface DiskHeadroomWorkerConfig {
 
   /** Optional decision ledger for cleanup act/skip rows. */
   store?: WorkerDecisionStore;
+  /** Optional workflow/task state reader used to protect in-use local paths from cleanup. */
+  workflowStore?: DiskHeadroomWorkerStore;
   /** Optional activity-log sink (wired from owner persistence). */
   writeActivityLog?: (level: ActivityLogLevel, message: string) => void;
 
@@ -69,6 +72,7 @@ export interface DiskHeadroomWorkerOptions {
   cleanupEnabled?: boolean;
   cleanupCooldownMs?: number;
   store?: WorkerDecisionStore;
+  workflowStore?: DiskHeadroomWorkerStore;
   writeActivityLog?: (level: ActivityLogLevel, message: string) => void;
   runCheck?: (deps: DiskHeadroomMonitorDeps) => Promise<DiskHeadroomEvaluation[] | unknown>;
   cleanupLocal?: typeof cleanupLocalInvokerHome;
@@ -175,6 +179,7 @@ export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): Wo
             invokerHome: options.localPath,
             targetKey,
             logger: options.logger,
+            store: options.workflowStore,
           });
         }
 
@@ -214,6 +219,7 @@ export function registerDiskHeadroomWorker(
         cleanupEnabled: config?.cleanupEnabled,
         cleanupCooldownMs: config?.cleanupCooldownMs,
         store: config?.store ?? deps.store,
+        workflowStore: config?.workflowStore ?? deps.store,
         writeActivityLog: config?.writeActivityLog,
         runCheck: config?.runCheck as DiskHeadroomWorkerOptions['runCheck'],
         cleanupLocal: config?.cleanupLocal,


### PR DESCRIPTION
## Summary

The previous version of this change protected a directory from clearing by matching running processes' arguments against three known signatures.

That only covers exactly the tools it was written against -- any other provisioning step went unprotected, since it wasn't one of the three.

This replaces that guess entirely with a check against Invoker's own task state.

A directory is now protected only while some task's own record still points at it and that task is not yet finished.

That holds regardless of which tool, if any, happens to be running there at the moment, and it protects every kind of ongoing work, not just one setup step.

Protection is checked per directory entry, so one active task under a shared reclaimable directory only holds back its own subdirectory, not its siblings.

## Review Claim

Approve replacing a process-signature guess with a direct check against Invoker's own task state, so protection covers every kind of ongoing work by construction instead of only the specific tools someone happened to write a pattern for.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Every task whose status is not `completed`, `closed`, or `stale` -- the same terminal set already used elsewhere in this codebase for this exact judgment -- has its workspace path protected from clearing, checked at both an exact-path match and any ancestor/descendant relationship, so a directory holding an active task's path is never cleared regardless of what else is or isn't running. A store read failure protects nothing rather than everything, since this worker's only job is emergency relief on already-critical disk pressure; failing toward "protect everything" could leave a host critically full indefinitely over one transient read error, a worse outcome than occasionally reclaiming one task's own workspace, which it can recreate. Covered by tests for: an active task's subdirectory surviving while its siblings still clear, a finished task's path not being protected, and a throwing store falling back to the old clear-everything behavior instead of crashing the sweep.

## Slice Rationale

One self-contained change: the new state-based check replaces the process-signature guess entirely in the same commit, since leaving both in place would mean maintaining two different, sometimes-disagreeing answers to the same question.

## Non-goals

Does not change how any other worker reads task state -- this reuses the exact same read shape (`listWorkflows`/`loadTasks`) already declared by another worker in this codebase, added to the shared dependency surface rather than invented fresh.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test -- disk-headroom-reclaim`
- [ ] `cd packages/execution-engine && pnpm test`
- [ ] `cd packages/app && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
