### PR TITLE
[Workflow-Resume FK Race](1) Route internal worker mutation submits through the missing-workflow helper

### DIFF
--- a/packages/app/src/__tests__/workflow-mutation-submit.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-submit.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
 import { submitWorkflowMutationOrAcknowledgeDeleted } from '../workflow-mutation-submit.js';
+import { PersistedWorkflowMutationCoordinator } from '../persisted-workflow-mutation-coordinator.js';
 
 function makeForeignKeyError(): Error {
   const error = new Error('FOREIGN KEY constraint failed') as Error & { errcode?: number; errstr?: string };
@@ -265,5 +267,96 @@ describe('submitWorkflowMutationOrAcknowledgeDeleted', () => {
         workflowExists: () => false,
       },
     )).toThrow(error);
+  });
+
+  it('fixed: invoker:start-ready for a workflow deleted concurrently is accepted without queueing', () => {
+    const submit = vi.fn(() => 42);
+
+    const result = submitWorkflowMutationOrAcknowledgeDeleted(
+      'wf-resumed',
+      'normal',
+      'invoker:start-ready',
+      [{}],
+      {
+        coordinator: { submit },
+        workflowExists: () => false,
+      },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      accepted: true,
+      intentId: 0,
+      workflowId: 'wf-resumed',
+      channel: 'invoker:start-ready',
+    });
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  describe('workflow-resume wake tick vs. concurrent deleteWorkflow (repro)', () => {
+    const adapters: SQLiteAdapter[] = [];
+
+    afterEach(() => {
+      for (const adapter of adapters.splice(0)) {
+        adapter.close();
+      }
+    });
+
+    it('fixed: an internal-worker start-ready submit racing a real deleteWorkflow is a benign no-op', async () => {
+      const adapter = await SQLiteAdapter.create(':memory:');
+      adapters.push(adapter);
+      adapter.saveWorkflow({
+        id: 'wf-race',
+        name: 'wf-race',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+
+      const coordinator = new PersistedWorkflowMutationCoordinator(
+        adapter,
+        'owner-1',
+        async () => undefined,
+      );
+
+      adapter.deleteWorkflow('wf-race');
+
+      let result: unknown;
+      expect(() => {
+        result = submitWorkflowMutationOrAcknowledgeDeleted(
+          'wf-race',
+          'normal',
+          'invoker:start-ready',
+          [{}],
+          {
+            coordinator,
+            workflowExists: (id) => Boolean(adapter.loadWorkflow(id)),
+          },
+        );
+      }).not.toThrow();
+
+      expect(result).toEqual({
+        ok: true,
+        accepted: true,
+        intentId: 0,
+        workflowId: 'wf-race',
+        channel: 'invoker:start-ready',
+      });
+      expect(adapter.listWorkflowMutationIntents('wf-race')).toHaveLength(0);
+    });
+
+    it('repro: calling the coordinator directly (bypassing the helper) still throws the raw foreign-key error', async () => {
+      const adapter = await SQLiteAdapter.create(':memory:');
+      adapters.push(adapter);
+      adapter.saveWorkflow({
+        id: 'wf-race-2',
+        name: 'wf-race-2',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      adapter.deleteWorkflow('wf-race-2');
+
+      expect(() => adapter.enqueueWorkflowMutationIntent('wf-race-2', 'invoker:start-ready', [{}], 'normal'))
+        .toThrow(/FOREIGN KEY constraint failed/);
+    });
   });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -198,6 +198,7 @@ import { CoalescedWorkflowMetadataPublisher } from './workflow-metadata-invalida
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
 import type { WorkflowMutationContext } from './persisted-workflow-mutation-coordinator.js';
+import { submitWorkflowMutationOrAcknowledgeDeleted } from './workflow-mutation-submit.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
 import {
   isTaskInFlightForForcedStop,
@@ -318,7 +319,13 @@ function submitRegisteredOwnerWorkerMutation(
   if (!workflowMutationDispatcher.has(channel)) {
     throw new Error(`No workflow mutation dispatcher registered for ${channel}`);
   }
-  return workflowMutationCoordinator.submit(workflowId, priority, channel, mutationArgs, options);
+  const result = submitWorkflowMutationOrAcknowledgeDeleted(workflowId, priority, channel, mutationArgs, {
+    coordinator: workflowMutationCoordinator,
+    workflowExists: (id) => Boolean(persistence.loadWorkflow(id)),
+    logger,
+    deferDrain: options?.deferDrain,
+  });
+  return result.intentId;
 }
 const autoFixAttemptLedger = createAutoFixAttemptLedger();
 

--- a/packages/app/src/workflow-mutation-submit.ts
+++ b/packages/app/src/workflow-mutation-submit.ts
@@ -51,6 +51,9 @@ function isMissingWorkflowIdempotentMutation(channel: string, workflowId: string
   ) {
     return args[0] === workflowId;
   }
+  if (channel === 'invoker:start-ready') {
+    return true;
+  }
   if (channel !== 'headless.exec') {
     return false;
   }


### PR DESCRIPTION
## Summary

The workflow-resume worker's wake tick reads pending-task state, then hands that off through the internal worker mutation channel to run again shortly after.

If the workflow it read was gone a moment before that hand-off runs, the underlying insert hits a foreign key that no longer exists.

The tick throws an uncaught error every single time this race happens -- and it happens often enough to fill production logs all day.

Two other paths already treat a workflow that vanished mid-mutation as a benign no-op, through one shared function built for exactly that judgment call.

The internal worker channel bypassed that shared function and called the coordinator directly instead, so it never got the same protection.

This change routes the internal worker channel through the same shared function, and adds its channel name to the function's allowlist of cases where a missing workflow is expected, not an error.

## Review Claim

Approve routing the internal worker mutation channel through the same shared "missing workflow is a benign no-op" function two other channels already use, instead of leaving it as the one channel that calls the coordinator directly and has no protection against this race.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Every channel that already worked before this change behaves identically -- only the internal worker channel's call path changes, and only its behavior when a workflow has vanished changes (from an uncaught error to a benign no-op). Covered by a real repro in `workflow-mutation-submit.test.ts` using a real in-memory adapter and a real workflow deletion racing the mutation, plus a companion case proving the coordinator itself still throws the raw error when called directly, showing the race is genuine absent this fix.

## Slice Rationale

One self-contained change: the new call path and its allowlist entry land together with the test proving both are needed, since the fix isn't complete without either half.

## Non-goals

Does not add a second, local no-op judgment inside the workflow-resume tick itself -- every current and future internal worker shares the same mutation channel this fixes, so a local guard there would only cover one of them and would drift from the shared function over time.

## Visual Proof

`packages/app/src/main.ts` is flagged as UI-impacting by path alone, since it also owns window and menu creation. This diff only changes an internal mutation-submission call path; nothing under `packages/ui/` is touched. The GUI still renders normally with this diff applied:

![GUI renders normally with this diff applied](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260803-bc16fa/visual-proof-sigterm-sigint.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- workflow-mutation-submit`
- [ ] `cd packages/app && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
