### PR TITLE
[GUI Before-Quit Read-Only](1) Gate the requeue call on ownerMode

### DIFF
--- a/packages/app/src/__tests__/gui-before-quit-readonly-requeue.test.ts
+++ b/packages/app/src/__tests__/gui-before-quit-readonly-requeue.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+
+const mainTsSource = readFileSync(resolve(__dirname, '../main.ts'), 'utf8');
+
+function extractBlock(source: string, startMarker: string, fromIndex = 0): string {
+  const start = source.indexOf(startMarker, fromIndex);
+  if (start === -1) throw new Error(`marker not found: ${startMarker}`);
+  let depth = 0;
+  let i = source.indexOf('{', start);
+  const bodyStart = i;
+  for (; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(bodyStart, i + 1);
+    }
+  }
+  throw new Error(`unbalanced braces after marker: ${startMarker}`);
+}
+
+describe('GUI onBeforeQuit requeueRunningWorkflowMutationIntents guard', () => {
+  it('gates the requeue call on ownerMode, matching the existing owner-only persistence idiom in this function', () => {
+    const onBeforeQuitBody = extractBlock(mainTsSource, 'onBeforeQuit: async (event) => {');
+
+    const requeueIdx = onBeforeQuitBody.indexOf('persistence.requeueRunningWorkflowMutationIntents();');
+    expect(requeueIdx, 'requeueRunningWorkflowMutationIntents call not found in onBeforeQuit').toBeGreaterThan(-1);
+
+    const persistenceGuardStart = onBeforeQuitBody.lastIndexOf('if (persistence) {', requeueIdx);
+    expect(persistenceGuardStart, 'enclosing if (persistence) guard not found').toBeGreaterThan(-1);
+
+    const persistenceBlock = extractBlock(onBeforeQuitBody, 'if (persistence) {', persistenceGuardStart);
+    const ownerModeMarkerIdx = persistenceBlock.indexOf('if (ownerMode) {');
+    expect(ownerModeMarkerIdx, 'if (ownerMode) guard not found around the requeue call').toBeGreaterThan(-1);
+
+    const ownerModeBlock = extractBlock(persistenceBlock, 'if (ownerMode) {');
+    expect(ownerModeBlock).toContain('persistence.requeueRunningWorkflowMutationIntents();');
+
+    const ownerModeBodyStart = persistenceBlock.indexOf('{', ownerModeMarkerIdx);
+    const ownerModeBlockEnd = ownerModeBodyStart + ownerModeBlock.length;
+
+    const closeIdx = persistenceBlock.indexOf('persistence.close();');
+    expect(closeIdx, 'persistence.close() not found alongside the requeue call').toBeGreaterThan(-1);
+    expect(closeIdx).toBeGreaterThanOrEqual(ownerModeBlockEnd);
+  });
+
+  it('confirms the underlying guard is real: a read-only SQLiteAdapter throws when requeueRunningWorkflowMutationIntents is called directly', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'gui-before-quit-readonly-'));
+    const dbPath = join(tmpDir, 'test.db');
+    try {
+      const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+      owner.close();
+
+      const reader = await SQLiteAdapter.create(dbPath, { readOnly: true });
+      expect(() => reader.requeueRunningWorkflowMutationIntents()).toThrow(/read-only/i);
+      reader.close();
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3339,7 +3339,9 @@ startMainProcessBootstrap({
           }
         }
         if (persistence) {
-          persistence.requeueRunningWorkflowMutationIntents();
+          if (ownerMode) {
+            persistence.requeueRunningWorkflowMutationIntents();
+          }
           persistence.close();
         }
         guiInstanceLock?.release();


### PR DESCRIPTION
## Summary

The GUI's `onBeforeQuit` handler calls a database write unconditionally, with no check for whether this window actually owns the database.

A detached-viewer window connects to an already-running daemon and opens its own database handle read-only.

On quit, that write throws. The surrounding block has no catch, so the throw surfaces as an unhandled rejection instead of an expected, caught condition.

The same handler already wraps other owner-only database writes behind one `ownerMode` check, right next to this call.

This change wraps the one write that was missing it in the same check, matching the pattern already used beside it.

## Review Claim

Approve wrapping one database write inside `onBeforeQuit` in the same `ownerMode` check the handler already uses for its other owner-only writes, instead of leaving it as the one call with no guard.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Owner windows are completely unaffected -- `ownerMode` is always true for them, so the wrapped call still runs exactly as before. Only a detached-viewer window's quit path changes, from an unhandled rejection to simply skipping a write it was never able to make anyway. Covered by a test that confirms the guard's shape directly in `onBeforeQuit`, plus a companion case proving a read-only database handle genuinely throws when that same method is called without the guard -- showing the underlying condition this prevents is real, not hypothetical.

## Slice Rationale

One narrow change: only the single call site that was missing the existing guard is touched, scoped separately from the broader question of whether the rest of the block should also gain a catch.

## Non-goals

Does not add a catch around the rest of the `onBeforeQuit` block -- any other call in that block that might someday throw is a separate, broader concern with its own risk profile, not part of this one guard.

## Visual Proof

`packages/app/src/main.ts` is flagged as UI-impacting by path alone, since it also owns window and menu creation. This diff only wraps one existing database call in an existing conditional; nothing under `packages/ui/` is touched. The GUI still renders normally with this diff applied:

![GUI renders normally with this diff applied](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260804-899747/visual-proof-sigterm-sigint.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- gui-before-quit-readonly-requeue`
- [ ] `cd packages/app && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GUI shutdown handling so only the owning process requeues in-progress workflow changes.
  * Prevented follower or read-only processes from modifying saved workflow state while closing.
* **Tests**
  * Added coverage for shutdown persistence safeguards and read-only database behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->