### PR TITLE
Keep the failed-planning panel visible when busy re-clears it

### DIFF
--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -690,7 +690,9 @@ describe('Invoker terminal (component)', () => {
         presetKey: 'codex',
         confirmationMode: 'require',
       });
-      expect(screen.queryByTestId('invoker-terminal-planner-stream')).not.toBeInTheDocument();
+      const panel = screen.getByTestId('invoker-terminal-planner-stream');
+      expect(panel).toHaveAttribute('data-state', 'working');
+      expect(panel).toHaveTextContent('Working…');
     });
 
     await act(async () => {
@@ -863,7 +865,7 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
-  it('shows the wait cursor only while a planning request is busy', async () => {
+  it('never shows the wait cursor while a planning request is busy', async () => {
     let resolveSend: ((value: any) => void) | null = null;
     mock.api.planningChatSend = vi.fn(() => {
       return new Promise((resolve) => {
@@ -878,8 +880,8 @@ describe('Invoker terminal (component)', () => {
 
     const input = screen.getByTestId('invoker-terminal-input');
     await waitFor(() => expect(input).toBeDisabled());
-    expect(input).toHaveClass('disabled:cursor-wait');
-    expect(input).not.toHaveClass('disabled:cursor-not-allowed');
+    expect(input).toHaveClass('disabled:cursor-not-allowed');
+    expect(input).not.toHaveClass('disabled:cursor-wait');
 
     await act(async () => {
       resolveSend?.({ ok: true, sessionId: 'session-1', reply: 'Done.', draftPlanAvailable: false });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -688,7 +688,7 @@ export function InvokerTerminal({
           </div>
         );
       })}
-      {busy ? (
+      {busy || planningStream ? (
         <div
           data-testid="invoker-terminal-planner-stream"
           data-state={planningStream?.status ?? 'working'}


### PR DESCRIPTION
The panel's render condition was busy-only, so once a failed send
resolved (busy: false), the kept-failure message this codebase
deliberately preserves (keepPlanningStreamFailureForSessionIds)
never rendered -- losing the persisted failure text this component
already had a mechanism for. Broadened to busy || planningStream so
a settled failure still shows, and a retry starting (which clears
that failure and sets busy again in the same render) shows the
busy indicator, not a mid-transition gap.

Also updates two pre-existing unit tests that still asserted the
removed cursor-wait styling and the old must-be-absent gap this PR's
own e2e regression test (busy-indicator PR (2)) already proves is no
longer correct.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Depends-On: #7374