### PR TITLE
[Visual Proof Skill: reject stale proof assets](1) Classify skills/visual-proof/SKILL.md as tooling-policy

### DIFF
--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -281,6 +281,7 @@ export function classifyReviewUnitsForPath(filePath) {
     path === 'skills/make-pr/SKILL.md'
     || path === 'skills/plan-to-invoker/SKILL.md'
     || path === 'skills/land-stack/SKILL.md'
+    || path === 'skills/visual-proof/SKILL.md'
   ) return ['tooling-policy'];
   if (path.startsWith('docs/') || path.startsWith('skills/') || path.endsWith('.md')) return ['docs'];
   if (path.startsWith('.github/')) return ['tooling-policy'];

--- a/scripts/test-review-unit-classification.mjs
+++ b/scripts/test-review-unit-classification.mjs
@@ -38,6 +38,7 @@ const stillToolingPolicy = [
   'skills/make-pr/SKILL.md',
   'skills/plan-to-invoker/SKILL.md',
   'skills/land-stack/SKILL.md',
+  'skills/visual-proof/SKILL.md',
 ];
 for (const path of stillToolingPolicy) {
   assert.deepEqual(


### PR DESCRIPTION
Split from the original combined PR: the classification rule lands
on its own first, so the guardrail-content PR that depends on it
(next slice) has a base ref where the rule already exists -- the
PR-body validator checks out the base ref specifically so a PR can't
modify its own grading rules, so a PR introducing both the rule and
its first use in one commit can never pass that check against itself.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Depends-On: #7376