### PR TITLE
[Visual Proof Skill: reject stale proof assets](1) Classify skills/visual-proof/SKILL.md as tooling-policy

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -1058,6 +1058,54 @@ test.describe('Visual proof capture', () => {
     });
   });
 
+  test('planning chat busy state — indicator visible and wait cursor gone before reply arrives', async ({ page }) => {
+    // Regression proof for the chat-input-beachball bugfix (InvokerTerminal.tsx):
+    // the composer must not carry disabled:cursor-wait while busy, and a busy
+    // indicator must render immediately on send, before any streamed text
+    // arrives. delayMs holds the planner reply back so this window is
+    // screenshot-able instead of resolving before Playwright can observe it.
+    const busyStatePlanYaml = yamlStringify({
+      name: 'Busy State Visual Proof',
+      repoUrl: E2E_REPO_URL,
+      onFinish: 'none' as const,
+      tasks: [
+        { id: 'busy-state-proof', description: 'Busy state proof task', command: 'echo ok', dependencies: [] as string[] },
+      ],
+    });
+    await page.evaluate(async (planYaml) => {
+      await window.invoker.setTestPlanningChatResponse({
+        planYaml,
+        planName: 'Busy State Visual Proof',
+        reply: 'Busy state response.',
+        delayMs: 4000,
+      });
+    }, busyStatePlanYaml);
+
+    await page.getByTestId('sidebar-home').click();
+    await expect(page.getByRole('heading', { name: 'Planning chat' })).toBeVisible();
+    const input = page.getByTestId('invoker-terminal-input');
+    const sendButton = page.getByRole('button', { name: 'Send' });
+    await input.fill('Draft me an Invoker plan');
+    await sendButton.click();
+
+    const streamStatus = page.getByTestId('invoker-terminal-planner-stream');
+    await expect(streamStatus).toBeVisible();
+    await expect(streamStatus).toHaveAttribute('data-state', 'working');
+    await expect(streamStatus).toContainText('Working…');
+    await expect(input).toHaveClass(/disabled:cursor-not-allowed/);
+    await expect(input).not.toHaveClass(/cursor-wait/);
+    await expect(sendButton).toHaveClass(/disabled:cursor-not-allowed/);
+    await expect(sendButton).not.toHaveClass(/cursor-wait/);
+
+    await captureScreenshot(page, 'planning-chat-busy-state-immediate-indicator');
+
+    await expect(page.getByTestId('invoker-terminal-transcript')).toContainText('Busy state response.', { timeout: 8000 });
+
+    await page.evaluate(async () => {
+      await window.invoker.setTestPlanningChatResponse(null);
+    });
+  });
+
   test('planning chat long transcript — scrollable surface with follow pinned to bottom', async ({ page }) => {
     // Render a long planning transcript by sending several user messages and
     // returning a long assistant reply for each turn. This exercises the same

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -690,7 +690,9 @@ describe('Invoker terminal (component)', () => {
         presetKey: 'codex',
         confirmationMode: 'require',
       });
-      expect(screen.queryByTestId('invoker-terminal-planner-stream')).not.toBeInTheDocument();
+      const panel = screen.getByTestId('invoker-terminal-planner-stream');
+      expect(panel).toHaveAttribute('data-state', 'working');
+      expect(panel).toHaveTextContent('Working…');
     });
 
     await act(async () => {
@@ -863,7 +865,7 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
-  it('shows the wait cursor only while a planning request is busy', async () => {
+  it('never shows the wait cursor while a planning request is busy', async () => {
     let resolveSend: ((value: any) => void) | null = null;
     mock.api.planningChatSend = vi.fn(() => {
       return new Promise((resolve) => {
@@ -878,8 +880,8 @@ describe('Invoker terminal (component)', () => {
 
     const input = screen.getByTestId('invoker-terminal-input');
     await waitFor(() => expect(input).toBeDisabled());
-    expect(input).toHaveClass('disabled:cursor-wait');
-    expect(input).not.toHaveClass('disabled:cursor-not-allowed');
+    expect(input).toHaveClass('disabled:cursor-not-allowed');
+    expect(input).not.toHaveClass('disabled:cursor-wait');
 
     await act(async () => {
       resolveSend?.({ ok: true, sessionId: 'session-1', reply: 'Done.', draftPlanAvailable: false });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -688,7 +688,7 @@ export function InvokerTerminal({
           </div>
         );
       })}
-      {busy ? (
+      {busy || planningStream ? (
         <div
           data-testid="invoker-terminal-planner-stream"
           data-state={planningStream?.status ?? 'working'}

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -606,9 +606,9 @@ export function InvokerTerminal({
     inputRef.current?.focus();
   };
 
-  const composerDisabledCursorClass = busy ? 'disabled:cursor-wait' : readOnly ? 'disabled:cursor-not-allowed' : '';
+  const composerDisabledCursorClass = busy || readOnly ? 'disabled:cursor-not-allowed' : '';
   const sendButtonDisabled = busy || readOnly || !value.trim();
-  const sendButtonDisabledCursorClass = busy ? 'disabled:cursor-wait' : 'disabled:cursor-not-allowed';
+  const sendButtonDisabledCursorClass = 'disabled:cursor-not-allowed';
 
   const handleValueChange = (event: ChangeEvent<HTMLTextAreaElement>): void => {
     const startedAt = nowMs();
@@ -688,22 +688,25 @@ export function InvokerTerminal({
           </div>
         );
       })}
-      {planningStream && planningStream.text ? (
+      {busy ? (
         <div
           data-testid="invoker-terminal-planner-stream"
-          data-state={planningStream.status}
+          data-state={planningStream?.status ?? 'working'}
           className={`flex items-center gap-2 text-xs ${
-            planningStream.status === 'failed'
+            planningStream?.status === 'failed'
               ? 'text-destructive'
               : 'text-muted-foreground'
           }`}
         >
-          <span aria-hidden="true" className={planningStream.status === 'failed' ? '' : 'animate-pulse'}>●</span>
-          <span>{planningStream.status === 'failed' ? 'Planning stopped. Try again when ready.' : 'Drafting your plan…'}</span>
+          <span
+            aria-hidden="true"
+            className="inline-block h-2.5 w-2.5 shrink-0 animate-spin rounded-full border border-muted-foreground border-t-foreground"
+          />
+          <span>{planningStream ? (planningStream.status === 'failed' ? 'Planning stopped. Try again when ready.' : 'Drafting your plan…') : 'Working…'}</span>
         </div>
       ) : null}
     </>
-  ), [lines, planningStream]);
+  ), [busy, lines, planningStream]);
   return (
     <section className="flex h-full min-h-0 flex-col bg-background">
       <div className="flex items-center justify-end gap-2 border-b border-border bg-background px-4 py-2.5">
@@ -780,7 +783,7 @@ export function InvokerTerminal({
             onScroll={handleTranscriptScroll}
             className="min-h-0 flex-1 space-y-5 overflow-y-auto bg-background px-5 py-5 font-sans text-[13.5px] leading-6"
           >
-            {lines.length === 0 && !planningStream?.text ? (
+            {lines.length === 0 && !planningStream?.text && !busy ? (
               <div data-testid="invoker-terminal-empty-hero" className="flex h-full min-h-[220px] flex-col justify-center gap-4">
                 <div>
                   <h3 className="text-lg font-semibold tracking-tight text-foreground">What do you want to build?</h3>

--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -281,6 +281,7 @@ export function classifyReviewUnitsForPath(filePath) {
     path === 'skills/make-pr/SKILL.md'
     || path === 'skills/plan-to-invoker/SKILL.md'
     || path === 'skills/land-stack/SKILL.md'
+    || path === 'skills/visual-proof/SKILL.md'
   ) return ['tooling-policy'];
   if (path.startsWith('docs/') || path.startsWith('skills/') || path.endsWith('.md')) return ['docs'];
   if (path.startsWith('.github/')) return ['tooling-policy'];

--- a/scripts/test-review-unit-classification.mjs
+++ b/scripts/test-review-unit-classification.mjs
@@ -38,6 +38,7 @@ const stillToolingPolicy = [
   'skills/make-pr/SKILL.md',
   'skills/plan-to-invoker/SKILL.md',
   'skills/land-stack/SKILL.md',
+  'skills/visual-proof/SKILL.md',
 ];
 for (const path of stillToolingPolicy) {
   assert.deepEqual(


### PR DESCRIPTION
## Summary

A later change wants to add a new rule to `skills/visual-proof/SKILL.md`.

That file's path maps to a general default bucket by its extension, but three sibling process skills (`make-pr`, `plan-to-invoker`, `land-stack`) are already explicit exceptions, mapped to "tooling-policy" instead.

This adds `skills/visual-proof/SKILL.md` as a fourth exception, matching those three.

Landed on its own, ahead of the content change that needs it.

The PR-body checker runs against a PR's base ref, not its own head. A PR can't teach the checker a new rule and rely on that same rule inside the same PR.

## Review Claim

Approve adding one path to the existing tooling-policy exception set, matching the three sibling process skills already there.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Every other path's classification is untouched -- this only adds one new entry to an existing allow set, it doesn't change how any other path resolves. Covered by a new case in the existing classification check asserting the new path lands in the same bucket as its three siblings.

## Slice Rationale

Landed alone so its own base ref carries the rule by the time the content that depends on it opens against this branch, avoiding a checker-can't-approve-its-own-new-rule bootstrap problem.

## Non-goals

Does not touch `skills/visual-proof/SKILL.md` itself -- that content lands in the next slice, once this rule already exists on its base.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-review-unit-classification.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
