### PR TITLE
[Add-machine onboarding](2) CLI wizard

### DIFF
--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -233,6 +233,199 @@ describe('runSetup', () => {
       rmSync(home, { recursive: true, force: true });
     }
   });
+
+  function setupMachineTestEnv() {
+    const home = mkdtempSync(join(tmpdir(), 'invoker-setup-machines-'));
+    const saved = {
+      config: process.env.INVOKER_REPO_CONFIG_PATH,
+      mcp: process.env.INVOKER_MCP_CONFIG_PATH,
+    };
+    process.env.INVOKER_REPO_CONFIG_PATH = join(home, 'config.json');
+    process.env.INVOKER_MCP_CONFIG_PATH = join(home, 'mcp.json');
+    return {
+      home,
+      configPath: process.env.INVOKER_REPO_CONFIG_PATH,
+      restore: () => {
+        restoreEnv('INVOKER_REPO_CONFIG_PATH', saved.config);
+        restoreEnv('INVOKER_MCP_CONFIG_PATH', saved.mcp);
+        rmSync(home, { recursive: true, force: true });
+      },
+    };
+  }
+
+  function machineSetupDeps(overrides: SetupDeps = {}): SetupDeps {
+    return readySetupDeps({
+      remoteTargetConnectivity: async (target) => ({
+        reachable: true,
+        message: `ssh probe to ${target.user}@${target.host} succeeded`,
+      }),
+      ...overrides,
+    });
+  }
+
+  it('adds one machine through the interactive setup path', async () => {
+    const env = setupMachineTestEnv();
+    const prompts: string[] = [];
+    const answers = [
+      'build-a',
+      'build-a.example.test',
+      'deploy',
+      '/home/deploy/.ssh/id_ed25519',
+      '2222',
+      '3',
+      'pnpm install --frozen-lockfile',
+      'y',
+      'n',
+    ];
+    try {
+      const code = await runSetup(['machines'], {
+        print: () => {},
+        prompt: async (question) => {
+          prompts.push(question);
+          return answers.shift() ?? '';
+        },
+      }, machineSetupDeps());
+
+      expect(code).toBe(0);
+      expect(prompts).toContain('Machine name: ');
+      expect(JSON.parse(readFileSync(env.configPath, 'utf8')).remoteTargets).toEqual({
+        'build-a': {
+          host: 'build-a.example.test',
+          user: 'deploy',
+          sshKeyPath: '/home/deploy/.ssh/id_ed25519',
+          port: 2222,
+          maxConcurrentTasks: 3,
+          provisionCommand: 'pnpm install --frozen-lockfile',
+        },
+      });
+    } finally {
+      env.restore();
+    }
+  });
+
+  it('leaves config unchanged when the user declines to keep a passing machine', async () => {
+    const env = setupMachineTestEnv();
+    const originalConfig = { maxConcurrency: 4 };
+    writeFileSync(env.configPath, JSON.stringify(originalConfig));
+    const answers = [
+      'build-a',
+      'build-a.example.test',
+      'deploy',
+      '/home/deploy/.ssh/id_ed25519',
+      '22',
+      '1',
+      '',
+      'n',
+      'n',
+      'n',
+    ];
+    try {
+      const code = await runSetup(['machines'], {
+        print: () => {},
+        prompt: async () => answers.shift() ?? '',
+      }, machineSetupDeps());
+
+      expect(code).toBe(0);
+      expect(JSON.parse(readFileSync(env.configPath, 'utf8'))).toEqual(originalConfig);
+    } finally {
+      env.restore();
+    }
+  });
+
+  it('loops to add another machine and writes both entries', async () => {
+    const env = setupMachineTestEnv();
+    const answers = [
+      'build-a',
+      'build-a.example.test',
+      'deploy',
+      '/home/deploy/.ssh/id_a',
+      '22',
+      '2',
+      '',
+      'y',
+      'y',
+      'build-b',
+      'build-b.example.test',
+      'deploy',
+      '/home/deploy/.ssh/id_b',
+      '2223',
+      '4',
+      'bash scripts/provision.sh',
+      'y',
+      'n',
+    ];
+    try {
+      const code = await runSetup(['machines'], {
+        print: () => {},
+        prompt: async () => answers.shift() ?? '',
+      }, machineSetupDeps());
+
+      expect(code).toBe(0);
+      expect(JSON.parse(readFileSync(env.configPath, 'utf8')).remoteTargets).toEqual({
+        'build-a': {
+          host: 'build-a.example.test',
+          user: 'deploy',
+          sshKeyPath: '/home/deploy/.ssh/id_a',
+          port: 22,
+          maxConcurrentTasks: 2,
+        },
+        'build-b': {
+          host: 'build-b.example.test',
+          user: 'deploy',
+          sshKeyPath: '/home/deploy/.ssh/id_b',
+          port: 2223,
+          maxConcurrentTasks: 4,
+          provisionCommand: 'bash scripts/provision.sh',
+        },
+      });
+    } finally {
+      env.restore();
+    }
+  });
+
+  it('reads machines from stdin and prints one JSON result per input machine under --json', async () => {
+    const env = setupMachineTestEnv();
+    const lines: string[] = [];
+    const input = [
+      {
+        name: 'build-a',
+        host: 'build-a.example.test',
+        user: 'deploy',
+        sshKeyPath: '/home/deploy/.ssh/id_a',
+        port: 22,
+        maxConcurrentTasks: 2,
+      },
+      {
+        name: 'build-b',
+        host: 'build-b.example.test',
+        user: 'ci',
+        sshKeyPath: '/home/ci/.ssh/id_b',
+        port: 2222,
+        maxConcurrentTasks: 1,
+        provisionCommand: 'pnpm install --frozen-lockfile',
+      },
+    ];
+    try {
+      const code = await runSetup(['machines', '--json'], {
+        print: (line) => lines.push(line),
+        prompt: async () => { throw new Error('should not prompt in json mode'); },
+        readStdin: async () => JSON.stringify(input),
+        interactive: false,
+      }, machineSetupDeps());
+
+      expect(code).toBe(0);
+      expect(lines).toHaveLength(1);
+      const results = JSON.parse(lines[0]);
+      expect(results).toHaveLength(input.length);
+      expect(results.map((result: { name: string; written: boolean }) => [result.name, result.written])).toEqual([
+        ['build-a', true],
+        ['build-b', true],
+      ]);
+      expect(Object.keys(JSON.parse(readFileSync(env.configPath, 'utf8')).remoteTargets)).toEqual(['build-a', 'build-b']);
+    } finally {
+      env.restore();
+    }
+  });
 });
 
 

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -4,16 +4,22 @@ import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { createInterface } from 'node:readline/promises';
 import {
+  addRemoteTarget,
   assembleReadinessChecks,
   buildReport,
+  checkRemoteTargetConnectivity,
   DEFAULT_DRAFTER_MCP_PACKAGE_SPEC,
   DEFAULT_TOOL_REQUIREMENTS,
   EXTERNAL_DEPENDENCIES,
   formatReport,
+  readInvokerConfigFile,
+  type RemoteTargetConnectivityImpl,
+  type RemoteTargetInput,
   type IsInstalled,
   type PlanningPresetSpec,
   type PrerequisiteCheck,
   updateInvokerConfigFile,
+  writeInvokerConfigFile,
 } from '@invoker/contracts';
 import { parsePlanFile } from '@invoker/workflow-core';
 import { formatCaughtException, logCaughtException } from './logging.js';
@@ -411,6 +417,7 @@ export interface SetupDeps {
   commandRunner?: CommandRunner;
   githubAuthCheck?: (runner: CommandRunner) => PrerequisiteCheck | Promise<PrerequisiteCheck>;
   smokePlanValidation?: () => Promise<PrerequisiteCheck>;
+  remoteTargetConnectivity?: RemoteTargetConnectivityImpl;
 }
 
 // ── Slack manifest ───────────────────────────────────────────
@@ -585,6 +592,7 @@ export function writeSlackEnv(creds: Required<Pick<SlackCredentials, 'botToken' 
 export interface SetupIO {
   print: (line: string) => void;
   prompt: (question: string) => Promise<string>;
+  readStdin?: () => Promise<string>;
   interactive?: boolean;
 }
 
@@ -593,7 +601,8 @@ export class NonInteractiveSetupError extends Error {
     super(
       `Cannot ask "${question.trim()}" because stdin is not a TTY.\n`
       + 'Re-run with --yes to accept the guided defaults, or use a non-interactive path: '
-      + '`invoker-cli setup planner`, or `invoker-cli setup slack --from-env` with SLACK_* set.',
+      + '`invoker-cli setup planner`, `invoker-cli setup machines --json`, or '
+      + '`invoker-cli setup slack --from-env` with SLACK_* set.',
     );
     this.name = 'NonInteractiveSetupError';
   }
@@ -612,6 +621,15 @@ function defaultIO(): SetupIO & { rl: ReturnType<typeof createInterface> } {
 function askLine(io: SetupIO, question: string): Promise<string> {
   if (io.interactive === false) throw new NonInteractiveSetupError(question);
   return io.prompt(question);
+}
+
+async function readAllStdin(io: SetupIO): Promise<string> {
+  if (io.readStdin) return io.readStdin();
+  let input = '';
+  for await (const chunk of process.stdin) {
+    input += String(chunk);
+  }
+  return input;
 }
 
 function manifestSteps(manifestPath: string): string {
@@ -667,7 +685,7 @@ export function loadInvokerEnv(): void {
   loadEnvFile(join(process.cwd(), '.env'));
 }
 
-type SetupSubcommand = 'slack' | 'planner';
+type SetupSubcommand = 'slack' | 'planner' | 'machines';
 
 interface ParsedSetupArgs {
   subcommand?: SetupSubcommand;
@@ -686,7 +704,7 @@ function parseSetupArgs(argv: string[]): ParsedSetupArgs {
   const parsed: ParsedSetupArgs = { checkOnly: false, json: false, uninstall: false, fromEnv: false, assumeYes: false };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
-    if (arg === 'slack' || arg === 'planner') {
+    if (arg === 'slack' || arg === 'planner' || arg === 'machines') {
       if (parsed.subcommand) throw new Error(`Unexpected setup argument: ${arg}`);
       parsed.subcommand = arg;
     } else if (arg === '--check') {
@@ -768,6 +786,246 @@ async function promptYes(io: SetupIO, question: string, assumeYes = false): Prom
   return answer === 'y' || answer === 'yes';
 }
 
+interface MachineSetupSuccessResult {
+  name: string;
+  reachable: boolean;
+  written: boolean;
+  message: string;
+}
+
+interface MachineSetupErrorResult {
+  name?: string;
+  reachable?: boolean;
+  written: false;
+  message: string;
+  error: {
+    code: string;
+    message: string;
+    conflictingTargetId?: string;
+  };
+}
+
+type MachineSetupResult = MachineSetupSuccessResult | MachineSetupErrorResult;
+
+function parseOptionalPositiveInteger(value: string, fieldName: string, max?: number): number | undefined {
+  const trimmed = value.trim();
+  if (trimmed === '') return undefined;
+  if (!/^\d+$/.test(trimmed)) throw new Error(`${fieldName} must be a positive integer`);
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || (max !== undefined && parsed > max)) {
+    throw new Error(`${fieldName} must be ${max === undefined ? 'a positive integer' : `between 1 and ${max}`}`);
+  }
+  return parsed;
+}
+
+function normalizeRemoteTargetInput(value: unknown): RemoteTargetInput {
+  if (!isJsonRecord(value)) throw new Error('machine must be an object');
+
+  const stringField = (field: keyof RemoteTargetInput): string => {
+    const raw = value[field];
+    if (typeof raw !== 'string' || raw.trim() === '') throw new Error(`${field} is required`);
+    return raw.trim();
+  };
+
+  const input: RemoteTargetInput = {
+    name: stringField('name'),
+    host: stringField('host'),
+    user: stringField('user'),
+    sshKeyPath: stringField('sshKeyPath'),
+  };
+
+  if (value.port !== undefined) {
+    if (typeof value.port !== 'number' || !Number.isSafeInteger(value.port) || value.port < 1 || value.port > 65535) {
+      throw new Error('port must be an integer between 1 and 65535');
+    }
+    input.port = value.port;
+  }
+  if (value.maxConcurrentTasks !== undefined) {
+    if (typeof value.maxConcurrentTasks !== 'number' || !Number.isSafeInteger(value.maxConcurrentTasks) || value.maxConcurrentTasks < 1) {
+      throw new Error('maxConcurrentTasks must be a positive integer');
+    }
+    input.maxConcurrentTasks = value.maxConcurrentTasks;
+  }
+  if (value.provisionCommand !== undefined) {
+    if (typeof value.provisionCommand !== 'string') throw new Error('provisionCommand must be a string');
+    const trimmed = value.provisionCommand.trim();
+    if (trimmed !== '') input.provisionCommand = trimmed;
+  }
+
+  return input;
+}
+
+async function askRemoteTargetInput(io: SetupIO): Promise<RemoteTargetInput> {
+  const name = await askLine(io, 'Machine name: ');
+  const host = await askLine(io, 'Host: ');
+  const user = await askLine(io, 'User: ');
+  const sshKeyPath = await askLine(io, 'SSH key path: ');
+  const port = parseOptionalPositiveInteger(await askLine(io, 'SSH port [22]: '), 'port', 65535);
+  const maxConcurrentTasks = parseOptionalPositiveInteger(
+    await askLine(io, 'Max concurrent tasks [1]: '),
+    'maxConcurrentTasks',
+  );
+  const provisionCommand = (await askLine(io, 'Provision command (optional): ')).trim();
+
+  return normalizeRemoteTargetInput({
+    name,
+    host,
+    user,
+    sshKeyPath,
+    ...(port !== undefined ? { port } : {}),
+    ...(maxConcurrentTasks !== undefined ? { maxConcurrentTasks } : {}),
+    ...(provisionCommand !== '' ? { provisionCommand } : {}),
+  });
+}
+
+async function checkAndMaybeWriteRemoteTarget(
+  input: RemoteTargetInput,
+  write: boolean,
+  options: SetupDeps,
+): Promise<MachineSetupResult> {
+  const connectivity = await checkRemoteTargetConnectivity(
+    {
+      host: input.host,
+      user: input.user,
+      sshKeyPath: input.sshKeyPath,
+      port: input.port,
+    },
+    { impl: options.remoteTargetConnectivity },
+  );
+
+  if (!connectivity.reachable) {
+    return {
+      name: input.name,
+      reachable: false,
+      written: false,
+      message: connectivity.message,
+      error: { code: 'connectivity-failed', message: connectivity.message },
+    };
+  }
+
+  if (!write) {
+    return {
+      name: input.name,
+      reachable: true,
+      written: false,
+      message: connectivity.message,
+    };
+  }
+
+  return writeRemoteTarget(input);
+}
+
+function writeRemoteTarget(input: RemoteTargetInput): MachineSetupResult {
+  const configPath = defaultConfigPath();
+  const addResult = addRemoteTarget(readInvokerConfigFile(configPath), input);
+  if (!addResult.ok) {
+    return {
+      name: input.name,
+      reachable: true,
+      written: false,
+      message: addResult.error.message,
+      error: addResult.error,
+    };
+  }
+
+  writeInvokerConfigFile(configPath, addResult.config);
+  return {
+    name: input.name,
+    reachable: true,
+    written: true,
+    message: `Wrote machine "${input.name}" to ${configPath}`,
+  };
+}
+
+function formatMachineConnectivity(result: MachineSetupResult): string {
+  if (result.reachable) return `Connectivity check passed: ${result.message}`;
+  return `Connectivity check failed: ${result.message}`;
+}
+
+async function runMachinesSetupInteractive(io: SetupIO, options: SetupDeps): Promise<void> {
+  let addAnother = true;
+  while (addAnother) {
+    let repeatThisMachine = true;
+    while (repeatThisMachine) {
+      let input: RemoteTargetInput;
+      try {
+        input = await askRemoteTargetInput(io);
+      } catch (error) {
+        io.print(`Invalid machine input: ${formatCaughtException(error)}`);
+        repeatThisMachine = await promptYes(io, 'Try this machine again? [y/N] ');
+        continue;
+      }
+
+      const checked = await checkAndMaybeWriteRemoteTarget(input, false, options);
+      io.print(formatMachineConnectivity(checked));
+
+      if (!checked.reachable) {
+        repeatThisMachine = await promptYes(io, 'Try this machine again? [y/N] ');
+        continue;
+      }
+
+      const keep = await promptYes(io, 'Keep this machine? [y/N] ');
+      if (!keep) {
+        io.print('Nothing written.');
+        repeatThisMachine = await promptYes(io, 'Try this machine again? [y/N] ');
+        continue;
+      }
+
+      const written = writeRemoteTarget(input);
+      if (written.written) {
+        io.print(written.message);
+      } else {
+        io.print(`Nothing written: ${written.message}`);
+      }
+      repeatThisMachine = false;
+    }
+
+    addAnother = await promptYes(io, 'Add another machine? [y/N] ');
+  }
+}
+
+async function runMachinesSetupJson(io: SetupIO, options: SetupDeps): Promise<number> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readAllStdin(io));
+  } catch (error) {
+    io.print(JSON.stringify([{
+      written: false,
+      message: `Invalid JSON input: ${formatCaughtException(error)}`,
+      error: { code: 'invalid-json', message: formatCaughtException(error) },
+    } satisfies MachineSetupErrorResult]));
+    return 1;
+  }
+
+  if (!Array.isArray(parsed)) {
+    io.print(JSON.stringify([{
+      written: false,
+      message: 'Invalid JSON input: expected an array',
+      error: { code: 'invalid-json', message: 'expected an array' },
+    } satisfies MachineSetupErrorResult]));
+    return 1;
+  }
+
+  const results: MachineSetupResult[] = [];
+  for (const item of parsed) {
+    let input: RemoteTargetInput;
+    try {
+      input = normalizeRemoteTargetInput(item);
+    } catch (error) {
+      results.push({
+        written: false,
+        message: `Invalid machine input: ${formatCaughtException(error)}`,
+        error: { code: 'invalid-input', message: formatCaughtException(error) },
+      });
+      continue;
+    }
+    results.push(await checkAndMaybeWriteRemoteTarget(input, true, options));
+  }
+
+  io.print(JSON.stringify(results));
+  return results.every((result) => result.written) ? 0 : 1;
+}
+
 function plannerMcpCheck(state: ExperimentalPlannerSetupState): PrerequisiteCheck {
   return {
     id: 'planner-mcp',
@@ -806,12 +1064,21 @@ export async function runSetup(
 ): Promise<number> {
   const parsed = parseSetupArgs(argv);
   const wantSlack = parsed.subcommand === 'slack';
+  const wantMachines = parsed.subcommand === 'machines';
   const fromEnv = parsed.fromEnv;
   const rl = (io as { rl?: { close: () => void } }).rl;
   const isInstalled = options.isInstalled ?? commandExists;
   try {
     if (parsed.subcommand === 'planner') {
       return await maybeInstallPlanner(parsed, io);
+    }
+
+    if (wantMachines && parsed.json) {
+      return await runMachinesSetupJson(io, options);
+    }
+
+    if (wantMachines && parsed.checkOnly) {
+      throw new Error('setup machines does not support --check');
     }
 
     if (parsed.checkOnly) {
@@ -837,14 +1104,14 @@ export async function runSetup(
     io.print('');
     checks.push(plannerMcpCheck(plannerState));
 
-    if (!wantSlack && !fromEnv && await promptYes(io, 'Enable the experimental planner now? [y/N] ', parsed.assumeYes)) {
+    if (!wantSlack && !wantMachines && !fromEnv && await promptYes(io, 'Enable the experimental planner now? [y/N] ', parsed.assumeYes)) {
       await maybeInstallPlanner(parsed, io);
       io.print('');
       checks.push(plannerMcpCheck(readExperimentalPlannerSetup({ targetPath: parsed.targetPath })));
     }
 
     let doSlack = wantSlack || fromEnv;
-    if (!wantSlack && !fromEnv) {
+    if (!wantSlack && !wantMachines && !fromEnv) {
       doSlack = parsed.assumeYes ? false : await promptYes(io, 'Set up the Slack integration now? [y/N] ');
     }
 
@@ -894,6 +1161,14 @@ export async function runSetup(
 
       const envPath = writeSlackEnv({ botToken, appToken, signingSecret, channelId });
       io.print(`\nWrote Slack credentials to ${envPath}. Restart Invoker (or it picks them up on next launch).`);
+    }
+
+    let doMachines = wantMachines;
+    if (!wantSlack && !wantMachines && !fromEnv) {
+      doMachines = parsed.assumeYes ? false : await promptYes(io, 'Set up remote machines now? [y/N] ');
+    }
+    if (doMachines) {
+      await runMachinesSetupInteractive(io, options);
     }
 
     const extras = await collectGithubAndSmokeChecks(options);

--- a/packages/contracts/src/__tests__/remote-target-onboarding.test.ts
+++ b/packages/contracts/src/__tests__/remote-target-onboarding.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  addRemoteTarget,
+  buildConnectivityProbeArgs,
+  checkRemoteTargetConnectivity,
+  type RemoteTargetInput,
+} from '../remote-target-onboarding.js';
+
+const baseInput: RemoteTargetInput = {
+  name: 'build-server-c',
+  host: '192.168.1.102',
+  user: 'deploy',
+  sshKeyPath: '/home/user/.ssh/id_build_c',
+  port: 22,
+  maxConcurrentTasks: 2,
+  provisionCommand: 'pnpm install --frozen-lockfile',
+};
+
+function existingConfig() {
+  return {
+    maxConcurrency: 6,
+    remoteTargets: {
+      'staging-server': {
+        host: '192.168.1.100',
+        user: 'deploy',
+        sshKeyPath: '/home/user/.ssh/id_staging',
+        port: 22,
+        maxConcurrentTasks: 1,
+        provisionCommand: 'pnpm install --frozen-lockfile',
+      },
+    },
+    executionPools: {
+      'mixed-local-ssh': {
+        members: [{ type: 'ssh', id: 'staging-server' }],
+        selectionStrategy: 'roundRobin',
+        maxConcurrentTasksPerMember: 1,
+      },
+    },
+    defaultPoolId: 'mixed-local-ssh',
+  };
+}
+
+describe('addRemoteTarget', () => {
+  it('appends the new target and leaves every existing field byte-for-byte unchanged', () => {
+    const config = existingConfig();
+    const before = JSON.stringify(config);
+
+    const result = addRemoteTarget(config, baseInput);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(JSON.stringify(config)).toBe(before);
+
+    const targets = result.config.remoteTargets as Record<string, unknown>;
+    expect(Object.keys(targets)).toEqual(['staging-server', 'build-server-c']);
+    expect(JSON.stringify(targets['staging-server'])).toBe(
+      JSON.stringify(existingConfig().remoteTargets['staging-server']),
+    );
+    expect(targets['build-server-c']).toEqual({
+      host: '192.168.1.102',
+      user: 'deploy',
+      sshKeyPath: '/home/user/.ssh/id_build_c',
+      port: 22,
+      maxConcurrentTasks: 2,
+      provisionCommand: 'pnpm install --frozen-lockfile',
+    });
+
+    expect(JSON.stringify(result.config.executionPools)).toBe(JSON.stringify(existingConfig().executionPools));
+    expect(result.config.maxConcurrency).toBe(6);
+    expect(result.config.defaultPoolId).toBe('mixed-local-ssh');
+  });
+
+  it('creates remoteTargets when the config has none', () => {
+    const result = addRemoteTarget({ maxConcurrency: 2 }, baseInput);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.config.maxConcurrency).toBe(2);
+    expect(Object.keys(result.config.remoteTargets as Record<string, unknown>)).toEqual(['build-server-c']);
+  });
+
+  it('omits optional fields that were not provided', () => {
+    const result = addRemoteTarget({}, {
+      name: 'minimal',
+      host: 'minimal.example',
+      user: 'ci',
+      sshKeyPath: '/home/ci/.ssh/id_ed25519',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const targets = result.config.remoteTargets as Record<string, unknown>;
+    expect(targets.minimal).toEqual({
+      host: 'minimal.example',
+      user: 'ci',
+      sshKeyPath: '/home/ci/.ssh/id_ed25519',
+    });
+  });
+
+  it('rejects a host that is already configured instead of adding a second entry', () => {
+    const config = existingConfig();
+    const before = JSON.stringify(config);
+
+    const result = addRemoteTarget(config, { ...baseInput, host: '192.168.1.100' });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('duplicate-host');
+    expect(result.error.conflictingTargetId).toBe('staging-server');
+    expect(JSON.stringify(config)).toBe(before);
+  });
+
+  it('rejects a target name that already exists instead of overwriting it', () => {
+    const result = addRemoteTarget(existingConfig(), { ...baseInput, name: 'staging-server' });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('duplicate-name');
+    expect(result.error.conflictingTargetId).toBe('staging-server');
+  });
+
+  it('rejects a malformed remoteTargets value', () => {
+    const result = addRemoteTarget({ remoteTargets: ['not-a-record'] }, baseInput);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('invalid-remote-targets');
+  });
+});
+
+describe('checkRemoteTargetConnectivity', () => {
+  const target = {
+    host: '192.168.1.102',
+    user: 'deploy',
+    sshKeyPath: '/home/user/.ssh/id_build_c',
+    port: 2222,
+  };
+
+  it('uses the injected impl instead of running a real SSH probe', async () => {
+    const impl = vi.fn().mockResolvedValue({ reachable: true, message: 'stubbed ok' });
+
+    const result = await checkRemoteTargetConnectivity(target, { impl });
+
+    expect(result).toEqual({ reachable: true, message: 'stubbed ok' });
+    expect(impl).toHaveBeenCalledTimes(1);
+    expect(impl).toHaveBeenCalledWith(target);
+  });
+
+  it('propagates an unreachable outcome from the injected impl', async () => {
+    const result = await checkRemoteTargetConnectivity(target, {
+      impl: () => ({ reachable: false, message: 'connection refused' }),
+    });
+
+    expect(result).toEqual({ reachable: false, message: 'connection refused' });
+  });
+
+  it('builds a batch-mode ssh probe from the target connection settings', () => {
+    expect(buildConnectivityProbeArgs(target, 5)).toEqual([
+      '-i', '/home/user/.ssh/id_build_c',
+      '-p', '2222',
+      '-o', 'BatchMode=yes',
+      '-o', 'StrictHostKeyChecking=accept-new',
+      '-o', 'ConnectTimeout=5',
+      'deploy@192.168.1.102',
+      'exit 0',
+    ]);
+  });
+
+  it('defaults the probe port to 22', () => {
+    const args = buildConnectivityProbeArgs({ host: 'h', user: 'u', sshKeyPath: '/k' });
+    expect(args).toContain('-p');
+    expect(args[args.indexOf('-p') + 1]).toBe('22');
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -12,6 +12,7 @@ export * from './invoker-home.ts';
 export * from './hourly-snapshot-retention.ts';
 export * from './invoker-config-io.ts';
 export * from './config-diagnostics.ts';
+export * from './remote-target-onboarding.ts';
 export * from './prerequisites.ts';
 export * from './headless-owner-launch.ts';
 export { EXTERNAL_DEPENDENCIES, DEFAULT_DRAFTER_MCP_PACKAGE_SPEC } from './external-dependencies.ts';

--- a/packages/contracts/src/remote-target-onboarding.ts
+++ b/packages/contracts/src/remote-target-onboarding.ts
@@ -1,0 +1,149 @@
+import { spawn } from 'node:child_process';
+
+import type { InvokerConfigRecord } from './invoker-config-io.ts';
+
+export interface RemoteTargetInput {
+  name: string;
+  host: string;
+  user: string;
+  sshKeyPath: string;
+  port?: number;
+  maxConcurrentTasks?: number;
+  provisionCommand?: string;
+}
+
+export type RemoteTargetOnboardingErrorCode = 'duplicate-host' | 'duplicate-name' | 'invalid-remote-targets';
+
+export interface RemoteTargetOnboardingError {
+  code: RemoteTargetOnboardingErrorCode;
+  message: string;
+  conflictingTargetId?: string;
+}
+
+export type AddRemoteTargetResult =
+  | { ok: true; config: InvokerConfigRecord }
+  | { ok: false; error: RemoteTargetOnboardingError };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function addRemoteTarget(config: InvokerConfigRecord, input: RemoteTargetInput): AddRemoteTargetResult {
+  const existing = config.remoteTargets;
+  if (existing !== undefined && !isRecord(existing)) {
+    return {
+      ok: false,
+      error: {
+        code: 'invalid-remote-targets',
+        message: 'remoteTargets must be an object keyed by target id',
+      },
+    };
+  }
+
+  const targets = existing ?? {};
+  if (Object.prototype.hasOwnProperty.call(targets, input.name)) {
+    return {
+      ok: false,
+      error: {
+        code: 'duplicate-name',
+        message: `remote target "${input.name}" already exists`,
+        conflictingTargetId: input.name,
+      },
+    };
+  }
+
+  for (const [id, target] of Object.entries(targets)) {
+    if (isRecord(target) && target.host === input.host) {
+      return {
+        ok: false,
+        error: {
+          code: 'duplicate-host',
+          message: `host "${input.host}" is already configured as remote target "${id}"`,
+          conflictingTargetId: id,
+        },
+      };
+    }
+  }
+
+  const entry: Record<string, unknown> = {
+    host: input.host,
+    user: input.user,
+    sshKeyPath: input.sshKeyPath,
+    ...(input.port !== undefined ? { port: input.port } : {}),
+    ...(input.maxConcurrentTasks !== undefined ? { maxConcurrentTasks: input.maxConcurrentTasks } : {}),
+    ...(input.provisionCommand !== undefined ? { provisionCommand: input.provisionCommand } : {}),
+  };
+
+  return {
+    ok: true,
+    config: { ...config, remoteTargets: { ...targets, [input.name]: entry } },
+  };
+}
+
+export interface RemoteTargetConnection {
+  host: string;
+  user: string;
+  sshKeyPath: string;
+  port?: number;
+}
+
+export interface RemoteTargetConnectivityResult {
+  reachable: boolean;
+  message: string;
+}
+
+export type RemoteTargetConnectivityImpl = (
+  target: RemoteTargetConnection,
+) => RemoteTargetConnectivityResult | Promise<RemoteTargetConnectivityResult>;
+
+export interface CheckRemoteTargetConnectivityOptions {
+  impl?: RemoteTargetConnectivityImpl;
+  connectTimeoutSeconds?: number;
+}
+
+const DEFAULT_PROBE_CONNECT_TIMEOUT_SECONDS = 10;
+
+export function buildConnectivityProbeArgs(
+  target: RemoteTargetConnection,
+  connectTimeoutSeconds: number = DEFAULT_PROBE_CONNECT_TIMEOUT_SECONDS,
+): string[] {
+  return [
+    '-i', target.sshKeyPath,
+    '-p', String(target.port ?? 22),
+    '-o', 'BatchMode=yes',
+    '-o', 'StrictHostKeyChecking=accept-new',
+    '-o', `ConnectTimeout=${connectTimeoutSeconds}`,
+    `${target.user}@${target.host}`,
+    'exit 0',
+  ];
+}
+
+export async function checkRemoteTargetConnectivity(
+  target: RemoteTargetConnection,
+  opts: CheckRemoteTargetConnectivityOptions = {},
+): Promise<RemoteTargetConnectivityResult> {
+  if (typeof opts.impl === 'function') {
+    return opts.impl(target);
+  }
+
+  return new Promise((resolve) => {
+    const child = spawn('ssh', buildConnectivityProbeArgs(target, opts.connectTimeoutSeconds), {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+
+    let stderr = '';
+    child.stderr?.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', (error) => {
+      resolve({ reachable: false, message: `failed to run ssh: ${error.message}` });
+    });
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ reachable: true, message: `ssh probe to ${target.user}@${target.host} succeeded` });
+        return;
+      }
+      resolve({ reachable: false, message: stderr.trim() || `ssh probe exited with code ${code}` });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds a machines step to the `invoker-cli setup` wizard, on top of the domain module from workflow (1).

The new step supports a guided "what machines would you like to add?" loop and a non-interactive `--json` mode for the later desktop bridge.

Each provided machine is checked before it is saved. Declined, failed, or in-progress entries are not persisted.

## Review Claim

Approve one new CLI setup wizard step that adds checked remote machines interactively or from structured JSON input.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

A machine is persisted only after its connectivity check succeeds and the person confirms it. Answering no, or stopping mid-loop, preserves every machine already saved earlier in the same run and saves nothing for the machine currently in progress.

## Slice Rationale

This slice only touches the setup wizard entry point. The desktop app's own wizard and the app-side bridge to this step are separate later workflows built on top of this one.

## Non-goals

- No changes to `packages/app` or `packages/ui`.
- No changes to the existing Slack setup step.
- No changes to the remote-target domain module's public shape.
- No desktop bridge for invoking the JSON mode yet.

## Architecture

### Before

`runSetup()` could guide prerequisite setup, planner setup, and Slack setup. Adding a remote machine still required hand-editing `~/.invoker/config.json`.

### After

`runSetup()` can enter a machines setup path. The interactive path prompts for machine fields, checks connectivity, asks for confirmation, and persists through the domain module.

The same setup path has a `--json` mode that reads machine inputs from stdin and prints one structured result per machine.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/cli && pnpm test`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/add-machine-onboarding-2-pr.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
