### PR TITLE
[Bugfix: GUI start-ready timing out at the default 30s IPC deadline](1) Extend GUI start-ready IPC deadline

### DIFF
--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -432,6 +432,31 @@ describe('IpcBus', () => {
     expect(winner).toBe(stillPending);
   });
 
+  it('REGRESSION: a slow invoker:start-ready delegated over headless.gui-mutation is killed by the default deadline instead of getting the long-deadline protection headless.exec gets', async () => {
+    const sock = tempSocketPath();
+
+    const server = new IpcBus(sock, { requestDeadlineMs: 50 });
+    buses.push(server);
+    await server.ready();
+
+    server.onRequest('headless.gui-mutation', () => new Promise(() => {}));
+
+    const client = new IpcBus(sock, { requestDeadlineMs: 50 });
+    buses.push(client);
+    await client.ready();
+    await sleep(20);
+
+    const pending = client.request('headless.gui-mutation', {
+      channel: 'invoker:start-ready',
+      args: [],
+    });
+
+    const stillPending = Symbol('still-pending');
+    const winner = await Promise.race([pending, sleep(300).then(() => stillPending)]);
+
+    expect(winner).toBe(stillPending);
+  });
+
   it('disconnect rejects with DISCONNECTED, not REQUEST_TIMEOUT', async () => {
     const sock = tempSocketPath();
 

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -242,6 +242,7 @@ export const DEFAULT_SOCKET_PATH = resolveDefaultSocketPath();
 const LONG_REQUEST_DEADLINE_CHANNELS = new Set([
   'invoker:plan-from-goal',
   'invoker:planning-chat-send',
+  'invoker:start-ready',
   // start-ready --recreate-all and other bulk mutations run inline on the owner.
   'headless.exec',
 ]);


### PR DESCRIPTION
## Summary

GUI Start now gets the same long IPC deadline as the existing owner-side bulk mutation requests.

That keeps slow `invoker:start-ready` work from failing at the default 30s `headless.gui-mutation` timeout while the owner is still running.

The regression test sends `invoker:start-ready` through the GUI mutation wrapper and proves it remains pending past a shortened default deadline.

## Review Claim

`invoker:start-ready` delegated through `headless.gui-mutation` is now covered by `LONG_REQUEST_DEADLINE_CHANNELS`, so slow GUI Start requests use the existing 2-hour IPC deadline instead of the default 30s deadline.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

`LONG_REQUEST_DEADLINE_CHANNELS` only grows by one entry, `invoker:start-ready`; no other channel timeout behavior and no other `ipc-bus.ts` logic changes.

## Slice Rationale

This slice keeps the missing allowlist entry and its deterministic regression test together because the test directly proves the changed timeout handling.

## Non-goals

- No change to the default IPC deadline.
- No change to the start-ready implementation itself.
- No change to other channels' timeout behavior.
- No UI changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/transport && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 62b88474c`
- Post-revert steps: Re-run `cd packages/transport && pnpm test`.
- Data migration? No.

</details>
