### PR TITLE
[Fix headless delete bugs](1) Stop INVOKER_HEADLESS_STANDALONE leak

### DIFF
--- a/packages/execution-engine/src/__tests__/process-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/process-utils.test.ts
@@ -121,6 +121,27 @@ describe('process-utils shell environment resolution', () => {
     expect(mockedSpawn).toHaveBeenCalledTimes(1);
   });
 
+  it('strips INVOKER_HEADLESS_STANDALONE from the cleaned child env', async () => {
+    const originalHeadlessStandalone = process.env.INVOKER_HEADLESS_STANDALONE;
+    const originalMarker = process.env.INVOKER_TEST_UNRELATED_MARKER;
+    try {
+      process.env.INVOKER_HEADLESS_STANDALONE = '1';
+      process.env.INVOKER_TEST_UNRELATED_MARKER = 'keep-me';
+
+      const { processUtils } = await loadProcessUtils();
+      const clean = processUtils.cleanElectronEnv();
+
+      expect(clean).not.toHaveProperty('INVOKER_HEADLESS_STANDALONE');
+      expect(clean.INVOKER_TEST_UNRELATED_MARKER).toBe('keep-me');
+      expect(process.env.INVOKER_HEADLESS_STANDALONE).toBe('1');
+    } finally {
+      if (originalHeadlessStandalone === undefined) delete process.env.INVOKER_HEADLESS_STANDALONE;
+      else process.env.INVOKER_HEADLESS_STANDALONE = originalHeadlessStandalone;
+      if (originalMarker === undefined) delete process.env.INVOKER_TEST_UNRELATED_MARKER;
+      else process.env.INVOKER_TEST_UNRELATED_MARKER = originalMarker;
+    }
+  });
+
   it('removes Git repository-scoping variables while preserving transport env', async () => {
     const { processUtils } = await loadProcessUtils();
 

--- a/packages/execution-engine/src/process-utils.ts
+++ b/packages/execution-engine/src/process-utils.ts
@@ -258,6 +258,7 @@ export function cleanElectronEnv(): NodeJS.ProcessEnv {
   delete env.ELECTRON_NO_ASAR;
   delete env.ELECTRON_NO_ATTACH_CONSOLE;
   delete env.INVOKER_REPO_CONFIG_PATH;
+  delete env.INVOKER_HEADLESS_STANDALONE;
   env.PATH = getEffectivePath();
   return env;
 }


### PR DESCRIPTION
## Summary

`cleanElectronEnv()` strips several Electron-only variables from a copy of
`process.env` before a task's child process spawns. `INVOKER_HEADLESS_STANDALONE`
was missing from that set.

A parent process running in that mode leaked its own flag into every
spawned child, even children meant to run in the normal mode instead.

This change adds `INVOKER_HEADLESS_STANDALONE` to that same set of
variables `cleanElectronEnv()` already strips, so a spawned child's env no
longer carries the parent's standalone flag.

## Review Claim

Approve stripping `INVOKER_HEADLESS_STANDALONE` from the env object
returned by `cleanElectronEnv()`, with a regression test proving the flag
is absent from the stripped env while the parent's own `process.env` and
an unrelated var stay unchanged.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change is a single added `delete` statement on a key already handled by
the same deletion block as the other Electron-only variables, so it follows
an existing, already-reviewed pattern. `cleanElectronEnv()` still returns a
plain copy of `process.env`; the real `process.env.INVOKER_HEADLESS_STANDALONE`
in the parent process is left untouched, only the returned clone is affected.
The new test asserts both: the flag is absent from the clone, and the
parent's real env plus an unrelated var are unchanged.

## Slice Rationale

This is a single, atomic fix: one line added next to the other variables
`cleanElectronEnv()` already strips, together with the regression test
proving it, in the same file pair, with nothing else mixed in. Landing the
fix and its test in two slices would only add review overhead, not review
safety.

## Non-goals

Does not change any of the other variables `cleanElectronEnv()` already
strips (`ELECTRON_RUN_AS_NODE`, `ELECTRON_NO_ASAR`, `ELECTRON_NO_ATTACH_CONSOLE`,
`INVOKER_REPO_CONFIG_PATH`). Does not change `getEffectivePath()` or any other
env-resolution logic in `process-utils.ts`. Does not change how or when
`INVOKER_HEADLESS_STANDALONE` is set on the parent process itself.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- process-utils` (21/21 passed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
