### PR TITLE
[Owner-Ping Timeout Outliers](1) Prove 3 discoverOwner call sites use a 500ms outlier budget

### DIFF
--- a/packages/app/src/__tests__/owner-ping-race.repro.test.ts
+++ b/packages/app/src/__tests__/owner-ping-race.repro.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+const MAIN = path.resolve(__dirname, '..', 'main.ts');
+const HEADLESS_CLIENT = path.resolve(__dirname, '..', 'headless-client.ts');
+
+/**
+ * Repro for a production log where a GUI process pinged a live standalone
+ * owner during startup:
+ *
+ *   [delegation] headless.owner-ping:10189:...:c00c96 send timeoutMs=500
+ *   [delegation] headless.owner-ping:10189:...:c00c96 response elapsedMs=501 ownerId=owner-10257... mode=standalone
+ *
+ * The response arrived 1ms past its own timeoutMs budget and happened to
+ * still win the Promise.race that day. A 500ms budget for a same-machine
+ * IPC round trip (right as a second Electron process is spinning up and
+ * competing for the event loop) is thin enough that ordinary jitter can
+ * just as easily cross it the other way: a live, responsive owner gets
+ * reported as unreachable, which can cascade into
+ * discoverStandaloneOwnerForGui/ensureStandaloneOwnerForGui believing no
+ * owner exists and spawning a redundant standalone owner process.
+ *
+ * discoverOwner's ping budget is passed as a literal at each call site
+ * rather than through an exported constant, so — matching this repo's
+ * existing pattern for asserting on logic embedded in main.ts (see
+ * standalone-owner-handler-ordering.test.ts) — this checks the literal
+ * values directly in source rather than exercising tryPingHeadlessOwner
+ * with a value the test invents itself.
+ *
+ * it.fails: these 3 call sites still use the 500ms outlier budget on
+ * master; this slice only proves the bug. The next slice widens them to
+ * 1500ms and flips these to plain `it`.
+ */
+describe('owner-ping timeout race', () => {
+  it.fails('discoverStandaloneOwnerForGui in main.ts does not use the 500ms outlier budget', () => {
+    const source = readFileSync(MAIN, 'utf8');
+    const match = source.match(/discoverOwner\(ownerBus,\s*(\d+)\)/);
+    expect(match, 'discoverOwner(ownerBus, ...) call site not found in main.ts').not.toBeNull();
+    const timeoutMs = Number(match![1]);
+    expect(
+      timeoutMs,
+      `discoverStandaloneOwnerForGui pings with ${timeoutMs}ms, an outlier next to every other discoverOwner call site (1000-2000ms elsewhere)`,
+    ).toBeGreaterThanOrEqual(1000);
+  });
+
+  it.fails('the two discoverOwner call sites in headless-client.ts do not use the 500ms outlier budget', () => {
+    const source = readFileSync(HEADLESS_CLIENT, 'utf8');
+    const matches = [...source.matchAll(/discoverOwner\([^,]+,\s*(\d+)\)/g)];
+    expect(matches.length, 'expected 2 discoverOwner(...) call sites in headless-client.ts').toBe(2);
+    for (const m of matches) {
+      const timeoutMs = Number(m[1]);
+      expect(
+        timeoutMs,
+        `discoverOwner call in headless-client.ts pings with ${timeoutMs}ms, an outlier next to every other discoverOwner call site (1000-2000ms elsewhere)`,
+      ).toBeGreaterThanOrEqual(1000);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Three places in Invoker's owner-discovery code ping a live daemon process to check it's there, waiting only 500ms for an answer.

Every other place in the codebase that does this same ping waits 1-2 seconds instead. 500ms is a leftover outlier.

This slice adds a test proving that outlier exists. It doesn't touch product code. It fails on purpose, marked `it.fails`, so CI stays green while the bug is documented.

## Review Claim

`main.ts:546`, `headless-client.ts:556`, and `headless-client.ts:757` all pass `500` to `discoverOwner`, while every other caller of the same function uses `1000-2000`.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change; no product code touched. The two new tests use `it.fails`, so they keep the suite green today while asserting the behavior the next slice will make true.

## Slice Rationale

Land the proof before the fix, so the bug is demonstrated before the change that corrects it is approved. The next PR in this stack flips these tests to plain `it` and makes them pass for real.

## Non-goals

No product code change in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- -t "owner-ping timeout race"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
