### PR TITLE
[Owner-Ping Timeout Outliers](2) Widen the main.ts owner-ping outlier to 1500ms

### DIFF
--- a/packages/app/src/__tests__/owner-ping-race.repro.test.ts
+++ b/packages/app/src/__tests__/owner-ping-race.repro.test.ts
@@ -33,7 +33,7 @@ const HEADLESS_CLIENT = path.resolve(__dirname, '..', 'headless-client.ts');
  * 1500ms and flips these to plain `it`.
  */
 describe('owner-ping timeout race', () => {
-  it.fails('discoverStandaloneOwnerForGui in main.ts does not use the 500ms outlier budget', () => {
+  it('discoverStandaloneOwnerForGui in main.ts does not use the 500ms outlier budget', () => {
     const source = readFileSync(MAIN, 'utf8');
     const match = source.match(/discoverOwner\(ownerBus,\s*(\d+)\)/);
     expect(match, 'discoverOwner(ownerBus, ...) call site not found in main.ts').not.toBeNull();

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -543,7 +543,7 @@ async function discoverStandaloneOwnerForGui(waitMs: number): Promise<boolean> {
     await ownerBus.ready();
     const deadline = Date.now() + waitMs;
     while (Date.now() < deadline) {
-      const owner = await discoverOwner(ownerBus, 500);
+      const owner = await discoverOwner(ownerBus, 1500);
       if (isStandaloneCapable(owner)) {
         logger.info(`daemon owner ready ownerId=${owner.ownerId}`, { module: 'init' });
         return true;


### PR DESCRIPTION
## Summary

`main.ts:546`, inside `discoverStandaloneOwnerForGui`, passes a 500ms budget to `discoverOwner`.

Every other caller of the same function in this codebase uses 1000-2000ms for the identical owner-ping handshake.

A GUI process polling for a live standalone owner during startup can misreport it as unreachable on ordinary scheduling jitter.

That risks it concluding no owner exists and spawning a redundant one.

This slice widens the `main.ts` call site to 1500ms, matching every other place in the codebase that does the same ping.

It also flips the corresponding proof test from #7419 to a real, passing assertion.

`headless-client.ts`'s two call sites land as a separate slice, since they classify under a different review unit.

## Review Claim

`main.ts:546` (inside `discoverStandaloneOwnerForGui`) passes a 500ms budget to `discoverOwner`, an outlier next to every other caller of the same function in this codebase (1000-2000ms elsewhere) for the identical owner-ping handshake.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only this one numeric literal changes (500 -> 1500). No other timing constant changes: not `tryPingHeadlessOwner`'s own default parameter, not the outer 2000ms discovery-loop deadline in `discoverStandaloneOwnerForGui`/`ensureStandaloneOwnerForGui`.

## Slice Rationale

`main.ts` classifies as review unit `routing` while `headless-client.ts` classifies as `activation-surface` per this repo's review-unit rules, so the two files cannot share a PR. This slice covers `main.ts` only; the `headless-client.ts` call sites land as a separate slice (#7422).

## Non-goals

No refactor, no new fields, no unrelated cleanup, no doc edits, no change to the 2000ms outer discovery-loop deadline, no change to `headless-client.ts` (separate slice).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- -t "owner-ping timeout race"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
