### PR TITLE
Heal the owner split-brain: DB-lock holder must serve IPC, or recovery replaces it

### DIFF
--- a/packages/app/src/__tests__/owner-socket-sentinel.test.ts
+++ b/packages/app/src/__tests__/owner-socket-sentinel.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, rmSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { IpcBus } from '@invoker/transport';
+import { createOwnerSocketSentinel } from '../owner-socket-sentinel.js';
+
+function noopLog(): void {}
+
+describe('createOwnerSocketSentinel', () => {
+  it('does not re-serve while the probe succeeds', async () => {
+    let reserves = 0;
+    const sentinel = createOwnerSocketSentinel({
+      probe: () => Promise.resolve(true),
+      reserve: () => { reserves++; },
+      log: noopLog,
+    });
+    await sentinel.tick();
+    await sentinel.tick();
+    expect(reserves).toBe(0);
+  });
+
+  it('re-serves only after consecutive probe failures', async () => {
+    let reserves = 0;
+    let ok = false;
+    const sentinel = createOwnerSocketSentinel({
+      probe: () => Promise.resolve(ok),
+      reserve: () => { reserves++; },
+      log: noopLog,
+      failuresBeforeReserve: 2,
+    });
+    await sentinel.tick();
+    expect(reserves).toBe(0);
+    await sentinel.tick();
+    expect(reserves).toBe(1);
+    ok = true;
+    await sentinel.tick();
+    ok = false;
+    await sentinel.tick();
+    expect(reserves).toBe(1);
+    await sentinel.tick();
+    expect(reserves).toBe(2);
+  });
+
+  it('treats a throwing probe as a failure', async () => {
+    let reserves = 0;
+    const sentinel = createOwnerSocketSentinel({
+      probe: () => Promise.reject(new Error('boom')),
+      reserve: () => { reserves++; },
+      log: noopLog,
+      failuresBeforeReserve: 1,
+    });
+    await sentinel.tick();
+    expect(reserves).toBe(1);
+  });
+
+  it('logs recovery after the socket becomes reachable again', async () => {
+    const lines: string[] = [];
+    let ok = false;
+    const sentinel = createOwnerSocketSentinel({
+      probe: () => Promise.resolve(ok),
+      reserve: () => {},
+      log: (_level, message) => { lines.push(message); },
+      failuresBeforeReserve: 1,
+    });
+    await sentinel.tick();
+    ok = true;
+    await sentinel.tick();
+    expect(lines.some((line) => line.includes('reachable again'))).toBe(true);
+  });
+});
+
+describe('IpcBus.serveAsOwner socket reclaim', () => {
+  let dir: string;
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('re-binds the socket path after the socket file is deleted under a live server', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'sentinel-sock-'));
+    const socketPath = join(dir, 'ipc.sock');
+    const owner = new IpcBus(socketPath, { allowServe: true });
+    await owner.ready();
+    expect(owner.isServing()).toBe(true);
+    owner.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'me' }));
+
+    unlinkSync(socketPath);
+    const strandedClient = new IpcBus(socketPath, { allowServe: false, requestDeadlineMs: 300 });
+    await strandedClient.ready();
+    await expect(strandedClient.request('headless.owner-ping', {})).rejects.toThrow();
+    strandedClient.disconnect();
+
+    owner.serveAsOwner();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const client = new IpcBus(socketPath, { allowServe: false, requestDeadlineMs: 1_000 });
+    await client.ready();
+    await expect(client.request('headless.owner-ping', {})).resolves.toEqual({ ok: true, ownerId: 'me' });
+    client.disconnect();
+    owner.disconnect();
+  });
+});

--- a/packages/app/src/__tests__/owner-split-brain.test.ts
+++ b/packages/app/src/__tests__/owner-split-brain.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  OWNER_SPLIT_BRAIN_PREFIX,
+  isWriterLockHeldError,
+  parseWriterLockHolderPid,
+  probeLockHolderOwner,
+  resolveOwnerServeLockFailure,
+  type ProbeBus,
+} from '../owner-split-brain.js';
+
+const HELD_ERROR = new Error(
+  '[db-writer-lock] Cannot acquire writer lock for /home/x/.invoker/invoker.db — '
+  + 'already held by PID 266663. requested by caller=main:initServices pid=274106. '
+  + 'If the previous process crashed, remove /home/x/.invoker/invoker.db.lock manually.',
+);
+
+function busWith(overrides: Partial<ProbeBus>): ProbeBus {
+  return {
+    ready: () => Promise.resolve(),
+    request: () => Promise.reject(new Error('No request handler registered for channel: headless.owner-ping')),
+    disconnect: () => {},
+    ...overrides,
+  };
+}
+
+describe('isWriterLockHeldError', () => {
+  it('matches the live-holder writer lock error', () => {
+    expect(isWriterLockHeldError(HELD_ERROR)).toBe(true);
+  });
+
+  it('rejects unrelated errors and non-errors', () => {
+    expect(isWriterLockHeldError(new Error('EACCES: permission denied'))).toBe(false);
+    expect(isWriterLockHeldError('[db-writer-lock] already held by PID 5')).toBe(false);
+  });
+});
+
+describe('parseWriterLockHolderPid', () => {
+  it('extracts the holder pid from the lock error message', () => {
+    expect(parseWriterLockHolderPid(HELD_ERROR)).toBe(266663);
+  });
+
+  it('returns null when no pid is present', () => {
+    expect(parseWriterLockHolderPid(new Error('[db-writer-lock] already held by PID unknown.'))).toBeNull();
+  });
+});
+
+describe('probeLockHolderOwner', () => {
+  it('reports owner-alive when the holder answers owner-ping', async () => {
+    const bus = busWith({
+      request: () => Promise.resolve({ ok: true, ownerId: 'owner-1', mode: 'gui' } as never),
+    });
+    await expect(probeLockHolderOwner({ createBus: () => bus })).resolves.toEqual({
+      kind: 'owner-alive',
+      ownerId: 'owner-1',
+      mode: 'gui',
+    });
+  });
+
+  it('reports split-brain when no handler answers the ping', async () => {
+    await expect(probeLockHolderOwner({ createBus: () => busWith({}) })).resolves.toEqual({
+      kind: 'split-brain',
+    });
+  });
+
+  it('reports split-brain when the ping answer is not ok', async () => {
+    const bus = busWith({ request: () => Promise.resolve({ ok: false } as never) });
+    await expect(probeLockHolderOwner({ createBus: () => bus })).resolves.toEqual({ kind: 'split-brain' });
+  });
+
+  it('reports split-brain when the probe hangs past the timeout', async () => {
+    const bus = busWith({ request: () => new Promise(() => {}) });
+    await expect(probeLockHolderOwner({ createBus: () => bus, timeoutMs: 20 })).resolves.toEqual({
+      kind: 'split-brain',
+    });
+  });
+
+  it('disconnects the probe bus in every outcome', async () => {
+    let disconnects = 0;
+    const alive = busWith({
+      request: () => Promise.resolve({ ok: true } as never),
+      disconnect: () => { disconnects++; },
+    });
+    const dead = busWith({ disconnect: () => { disconnects++; } });
+    await probeLockHolderOwner({ createBus: () => alive });
+    await probeLockHolderOwner({ createBus: () => dead });
+    expect(disconnects).toBe(2);
+  });
+});
+
+describe('resolveOwnerServeLockFailure', () => {
+  it('exits 0 without taking over when an owner already answers IPC', async () => {
+    const bus = busWith({ request: () => Promise.resolve({ ok: true, ownerId: 'o', mode: 'gui' } as never) });
+    const resolution = await resolveOwnerServeLockFailure(HELD_ERROR, '/tmp/ipc.sock', { createBus: () => bus });
+    expect(resolution.exitCode).toBe(0);
+    expect(resolution.message).toContain('already answers IPC');
+    expect(resolution.message).toContain('ownerId=o');
+  });
+
+  it('exits 1 with a distinct split-brain error naming the holder pid', async () => {
+    const resolution = await resolveOwnerServeLockFailure(HELD_ERROR, '/tmp/ipc.sock', {
+      createBus: () => busWith({}),
+    });
+    expect(resolution.exitCode).toBe(1);
+    expect(resolution.message).toContain(OWNER_SPLIT_BRAIN_PREFIX);
+    expect(resolution.message).toContain('PID 266663');
+    expect(resolution.message).toContain('/tmp/ipc.sock');
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -194,6 +194,7 @@ import {
 import { resolveBundledCliPath } from './cli-helper.js';
 import { buildAppMenuTemplate } from './app-menu.js';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
+import { isWriterLockHeldError, resolveOwnerServeLockFailure } from './owner-split-brain.js';
 import { CoalescedWorkflowMetadataPublisher } from './workflow-metadata-invalidation.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
@@ -2000,8 +2001,18 @@ function startHeadlessMode(): void {
 
       await runHeadless(cliArgs, headlessDeps);
     } catch (err) {
-      process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
-      exitCode = 1;
+      if (command === 'owner-serve' && isWriterLockHeldError(err)) {
+        const resolution = await resolveOwnerServeLockFailure(err, resolveInvokerIpcSocketPath());
+        process.stderr.write(
+          resolution.exitCode === 0
+            ? `${resolution.message}\n`
+            : `${RED}Error:${RESET} ${resolution.message}\n`,
+        );
+        exitCode = resolution.exitCode;
+      } else {
+        process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
+        exitCode = 1;
+      }
     } finally {
       if (!headlessSignalShutdownInProgress) {
         headlessSignalShutdownInProgress = true;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -195,6 +195,7 @@ import { resolveBundledCliPath } from './cli-helper.js';
 import { buildAppMenuTemplate } from './app-menu.js';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
 import { isWriterLockHeldError, resolveOwnerServeLockFailure } from './owner-split-brain.js';
+import { createOwnerSocketSentinel, type OwnerSocketSentinel } from './owner-socket-sentinel.js';
 import { CoalescedWorkflowMetadataPublisher } from './workflow-metadata-invalidation.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
@@ -496,7 +497,23 @@ const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promi
 let activeMutationContext: WorkflowMutationContext | undefined;
 let hourlyBackupInterval: ReturnType<typeof setInterval> | null = null;
 let writerLock: DbWriterLockResult | null = null;
+let ownerSocketSentinel: OwnerSocketSentinel | null = null;
 const workflowMutationOwnerId = `owner-${process.pid}-${Date.now()}`;
+
+function startOwnerSocketSentinelForBus(bus: MessageBus | undefined): void {
+  ownerSocketSentinel?.stop();
+  ownerSocketSentinel = null;
+  if (!(bus instanceof IpcBus)) return;
+  ownerSocketSentinel = createOwnerSocketSentinel({
+    reserve: () => bus.serveAsOwner(),
+    expectedOwnerId: workflowMutationOwnerId,
+    log: (level, message) => {
+      if (level === 'warn') logger.warn(message, { module: 'owner-socket-sentinel' });
+      else logger.info(message, { module: 'owner-socket-sentinel' });
+    },
+  });
+  ownerSocketSentinel.start();
+}
 const appProcessStartedAt = Date.now();
 
 let logger: Logger = new FileAndDbLogger({ module: 'main' });
@@ -1005,6 +1022,7 @@ function startHeadlessMode(): void {
     let headlessWebBridge: WebBridge | null = null;
 
     const runHeadlessShutdownCleanup = async (forcedStopReason: string): Promise<void> => {
+      ownerSocketSentinel?.stop();
       await headlessWebBridge?.close();
       standaloneLaunchDispatcherController?.stop();
       lifecycleEventBridge?.stop();
@@ -1988,6 +2006,7 @@ function startHeadlessMode(): void {
             },
             apiServerDeps,
           );
+          startOwnerSocketSentinelForBus(messageBus);
         }
 
         void recoverWorkflowMutationsOnStartup({
@@ -3023,6 +3042,7 @@ startMainProcessBootstrap({
       });
       logger.info(`owner-ipc-ready ownerId=${workflowMutationOwnerId}`, { module: 'ipc-delegate' });
       recordStartupMark('owner-ipc-ready');
+      startOwnerSocketSentinelForBus(messageBus);
     }
 
     if (ownerMode) {
@@ -3400,6 +3420,7 @@ startMainProcessBootstrap({
         }
         guiInstanceLock?.release();
         guiInstanceLock = null;
+        ownerSocketSentinel?.stop();
         if (writerLock) writerLock.release();
         if (messageBus) messageBus.disconnect();
       } finally {

--- a/packages/app/src/owner-socket-sentinel.ts
+++ b/packages/app/src/owner-socket-sentinel.ts
@@ -22,12 +22,9 @@ export interface OwnerSocketSentinel {
 }
 
 export interface OwnerSocketSentinelDeps {
-  /** Re-bind the socket as the rightful owner (IpcBus.serveAsOwner). */
   reserve: () => void;
   log: (level: string, message: string) => void;
-  /** Owner id the socket must answer with; a foreign id counts as unreachable. */
   expectedOwnerId?: string;
-  /** Returns true when the socket answers as the expected owner. Injectable for tests. */
   probe?: () => Promise<boolean>;
   intervalMs?: number;
   failuresBeforeReserve?: number;

--- a/packages/app/src/owner-socket-sentinel.ts
+++ b/packages/app/src/owner-socket-sentinel.ts
@@ -1,0 +1,98 @@
+/**
+ * Owner socket sentinel — enforces "the DB writer-lock holder serves the IPC
+ * socket". A lock-holding owner periodically pings its own socket path with a
+ * fresh client connection; after consecutive failures (socket file deleted,
+ * lost serve takeover, or a foreign process answering with a different
+ * ownerId) it authoritatively re-serves the socket. Without this, an owner can
+ * hold the database while being unreachable — the split-brain that strands
+ * every relaunch attempt.
+ */
+
+import { probeLockHolderOwner } from './owner-split-brain.js';
+
+const DEFAULT_INTERVAL_MS = 15_000;
+const DEFAULT_FAILURES_BEFORE_RESERVE = 2;
+const DEFAULT_PROBE_TIMEOUT_MS = 2_000;
+
+export interface OwnerSocketSentinel {
+  start(): void;
+  stop(): void;
+  /** Run one probe/re-serve cycle. Exposed for tests. */
+  tick(): Promise<void>;
+}
+
+export interface OwnerSocketSentinelDeps {
+  /** Re-bind the socket as the rightful owner (IpcBus.serveAsOwner). */
+  reserve: () => void;
+  log: (level: string, message: string) => void;
+  /** Owner id the socket must answer with; a foreign id counts as unreachable. */
+  expectedOwnerId?: string;
+  /** Returns true when the socket answers as the expected owner. Injectable for tests. */
+  probe?: () => Promise<boolean>;
+  intervalMs?: number;
+  failuresBeforeReserve?: number;
+  probeTimeoutMs?: number;
+}
+
+export function createOwnerSocketSentinel(deps: OwnerSocketSentinelDeps): OwnerSocketSentinel {
+  const intervalMs = deps.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const failuresBeforeReserve = deps.failuresBeforeReserve ?? DEFAULT_FAILURES_BEFORE_RESERVE;
+  const probeTimeoutMs = deps.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+  const probe = deps.probe ?? (async () => {
+    const result = await probeLockHolderOwner({ timeoutMs: probeTimeoutMs });
+    if (result.kind !== 'owner-alive') return false;
+    return deps.expectedOwnerId === undefined || result.ownerId === deps.expectedOwnerId;
+  });
+
+  let consecutiveFailures = 0;
+  let busy = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  const tick = async (): Promise<void> => {
+    if (busy) return;
+    busy = true;
+    try {
+      let reachable = false;
+      try {
+        reachable = await probe();
+      } catch {
+        reachable = false;
+      }
+      if (reachable) {
+        if (consecutiveFailures >= failuresBeforeReserve) {
+          deps.log('info', '[owner-socket-sentinel] owner socket is reachable again');
+        }
+        consecutiveFailures = 0;
+        return;
+      }
+      consecutiveFailures++;
+      if (consecutiveFailures < failuresBeforeReserve) {
+        deps.log(
+          'warn',
+          `[owner-socket-sentinel] owner socket probe failed (${consecutiveFailures}/${failuresBeforeReserve})`,
+        );
+        return;
+      }
+      deps.log(
+        'warn',
+        `[owner-socket-sentinel] owner socket unreachable ${consecutiveFailures} consecutive times — re-serving as writer-lock holder`,
+      );
+      deps.reserve();
+    } finally {
+      busy = false;
+    }
+  };
+
+  return {
+    tick,
+    start() {
+      if (timer) return;
+      timer = setInterval(() => void tick(), intervalMs);
+      timer.unref?.();
+    },
+    stop() {
+      clearInterval(timer);
+      timer = undefined;
+    },
+  };
+}

--- a/packages/app/src/owner-split-brain.ts
+++ b/packages/app/src/owner-split-brain.ts
@@ -1,0 +1,120 @@
+/**
+ * Split-brain handling for owner-serve startup.
+ *
+ * When a spawned owner loses the DB writer lock to a live PID, the holder is
+ * either a healthy owner already answering IPC (spawn is redundant — exit 0),
+ * or a process holding the database without serving the socket (split-brain —
+ * exit 1 with a distinct, actionable error). Probing before dying is what lets
+ * supervisors (slack-manager watchdog) distinguish "owner already running"
+ * from "recovery is impossible until PID X dies".
+ */
+
+import { IpcBus } from '@invoker/transport';
+
+export const OWNER_SPLIT_BRAIN_PREFIX = '[owner-split-brain]';
+
+const DEFAULT_PROBE_TIMEOUT_MS = 2_000;
+
+export interface OwnerPingAnswer {
+  ok?: boolean;
+  ownerId?: string;
+  mode?: string;
+}
+
+export interface ProbeBus {
+  ready(): Promise<void>;
+  request<Req, Res>(channel: string, message: Req): Promise<Res>;
+  disconnect(): void;
+}
+
+export type LockHolderProbeResult =
+  | { kind: 'owner-alive'; ownerId?: string; mode?: string }
+  | { kind: 'split-brain' };
+
+export interface OwnerServeLockFailureResolution {
+  exitCode: 0 | 1;
+  message: string;
+}
+
+export function isWriterLockHeldError(err: unknown): boolean {
+  return err instanceof Error
+    && err.message.includes('[db-writer-lock]')
+    && err.message.includes('already held by PID');
+}
+
+export function parseWriterLockHolderPid(err: unknown): number | null {
+  if (!(err instanceof Error)) return null;
+  const match = /already held by PID (\d+)/.exec(err.message);
+  if (!match) return null;
+  const pid = Number.parseInt(match[1], 10);
+  return Number.isFinite(pid) ? pid : null;
+}
+
+function raceTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`owner-ping probe timed out after ${ms}ms`)), ms);
+    timer.unref?.();
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+export async function probeLockHolderOwner(options: {
+  createBus?: () => ProbeBus;
+  timeoutMs?: number;
+} = {}): Promise<LockHolderProbeResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+  const createBus = options.createBus
+    ?? (() => new IpcBus(undefined, { allowServe: false, requestDeadlineMs: timeoutMs }));
+  const bus = createBus();
+  try {
+    await raceTimeout(bus.ready(), timeoutMs);
+    const res = await raceTimeout(
+      bus.request<Record<string, never>, OwnerPingAnswer>('headless.owner-ping', {}),
+      timeoutMs,
+    );
+    if (res?.ok) {
+      return { kind: 'owner-alive', ownerId: res.ownerId, mode: res.mode };
+    }
+    return { kind: 'split-brain' };
+  } catch {
+    return { kind: 'split-brain' };
+  } finally {
+    bus.disconnect();
+  }
+}
+
+export async function resolveOwnerServeLockFailure(
+  err: unknown,
+  socketPath: string,
+  options: { createBus?: () => ProbeBus; timeoutMs?: number } = {},
+): Promise<OwnerServeLockFailureResolution> {
+  const probe = await probeLockHolderOwner(options);
+  if (probe.kind === 'owner-alive') {
+    const identity = [
+      probe.ownerId ? `ownerId=${probe.ownerId}` : null,
+      probe.mode ? `mode=${probe.mode}` : null,
+    ].filter(Boolean).join(' ');
+    return {
+      exitCode: 0,
+      message: `owner-serve: an owner already answers IPC${identity ? ` (${identity})` : ''}; exiting without taking over.`,
+    };
+  }
+  const holderPid = parseWriterLockHolderPid(err);
+  const holder = holderPid === null ? 'an unknown PID' : `PID ${holderPid}`;
+  return {
+    exitCode: 1,
+    message:
+      `${OWNER_SPLIT_BRAIN_PREFIX} DB writer lock is held by ${holder}, but no owner answers `
+      + `headless.owner-ping at ${socketPath}. A live process holds the database without serving IPC; `
+      + `relaunching cannot succeed until it exits. Stop ${holder} (e.g. close a stray Invoker GUI), then retry.`,
+  };
+}

--- a/packages/slack-manager/src/__tests__/invoker-client.test.ts
+++ b/packages/slack-manager/src/__tests__/invoker-client.test.ts
@@ -52,8 +52,8 @@ describe('IpcInvokerClient', () => {
 
     const [a, b] = await Promise.all([client.launch(), client.launch()]);
     expect(spawnInvoker).toHaveBeenCalledTimes(1);
-    expect(a).toBe(true);
-    expect(b).toBe(true);
+    expect(a.healthy).toBe(true);
+    expect(b.healthy).toBe(true);
   });
 
   it('throttles a second (non-forced) launch within the min interval', async () => {
@@ -67,13 +67,14 @@ describe('IpcInvokerClient', () => {
       sleep: async (ms) => { nowMs += ms; },
       healthPollIntervalMs: 2, launchHealthTimeoutMs: 10,
       minLaunchIntervalMs: 60_000, httpHealthCheck: async () => false,
+      readLockHolderPid: () => null,
     });
 
-    expect(await client.launch()).toBe(false);
+    expect(await client.launch()).toEqual({ healthy: false, cause: 'unhealthy' });
     expect(spawnInvoker).toHaveBeenCalledTimes(1);
 
     nowMs += 1_000; // inside the window
-    expect(await client.launch()).toBe(false);
+    expect(await client.launch()).toEqual({ healthy: false, cause: 'throttled' });
     expect(spawnInvoker).toHaveBeenCalledTimes(1);
 
     nowMs += 60_000; // past the window
@@ -97,6 +98,91 @@ describe('IpcInvokerClient', () => {
     expect(reconnect).toHaveBeenCalledTimes(1);
     expect(buses).toHaveLength(1);
     expect(buses[0].subscribe).toHaveBeenCalledWith('surface.event', expect.any(Function));
+  });
+
+  it('reports split-brain when relaunch fails and a live pid holds the writer lock', async () => {
+    const client = new IpcInvokerClient({
+      spawnInvoker: vi.fn(), log: () => {},
+      busFactory: () => makeFakeBus(() => false),
+      sleep: async () => {}, healthPollIntervalMs: 2, launchHealthTimeoutMs: 10,
+      httpHealthCheck: async () => false,
+      readLockHolderPid: () => 4242,
+      isPidAlive: () => true,
+    });
+
+    expect(await client.launch()).toEqual({ healthy: false, cause: 'split-brain', holderPid: 4242 });
+  });
+
+  it('does not report split-brain when the lock holder pid is dead', async () => {
+    const client = new IpcInvokerClient({
+      spawnInvoker: vi.fn(), log: () => {},
+      busFactory: () => makeFakeBus(() => false),
+      sleep: async () => {}, healthPollIntervalMs: 2, launchHealthTimeoutMs: 10,
+      httpHealthCheck: async () => false,
+      readLockHolderPid: () => 4242,
+      isPidAlive: () => false,
+    });
+
+    expect(await client.launch()).toEqual({ healthy: false, cause: 'unhealthy' });
+  });
+
+  it('withRecovery propagates the launch failure cause on the thrown InvokerDownError', async () => {
+    const client = new IpcInvokerClient({
+      spawnInvoker: vi.fn(), log: () => {},
+      busFactory: () => makeFakeBus(() => false),
+      sleep: async () => {}, healthPollIntervalMs: 2, launchHealthTimeoutMs: 10,
+      httpHealthCheck: async () => false,
+      readLockHolderPid: () => 4242,
+      isPidAlive: () => true,
+    });
+
+    const err = await client.withRecovery(async () => { throw new InvokerDownError('down'); }).catch((e) => e);
+    expect(err).toBeInstanceOf(InvokerDownError);
+    expect((err as InvokerDownError).failureCause).toBe('split-brain');
+    expect((err as InvokerDownError).holderPid).toBe(4242);
+  });
+
+  it('force launch SIGTERMs a re-confirmed unreachable lock holder before respawning', async () => {
+    let ownerUp = false;
+    let holderAlive = true;
+    const terminatePid = vi.fn((pid: number) => {
+      expect(pid).toBe(4242);
+      holderAlive = false;
+    });
+    const spawnInvoker = vi.fn(() => { ownerUp = true; });
+    const client = new IpcInvokerClient({
+      spawnInvoker, log: () => {},
+      busFactory: () => makeFakeBus(() => ownerUp),
+      sleep: async () => {}, healthPollIntervalMs: 1, launchHealthTimeoutMs: 1_000,
+      httpHealthCheck: async () => false,
+      readLockHolderPid: () => 4242,
+      isPidAlive: () => holderAlive,
+      terminatePid,
+    });
+
+    const result = await client.launch({ force: true });
+    expect(terminatePid).toHaveBeenCalledTimes(1);
+    expect(spawnInvoker).toHaveBeenCalledTimes(1);
+    expect(result.healthy).toBe(true);
+  });
+
+  it('force launch never kills the holder while an owner still answers IPC', async () => {
+    const terminatePid = vi.fn();
+    let ownerUp = true;
+    const spawnInvoker = vi.fn(() => { ownerUp = true; });
+    const client = new IpcInvokerClient({
+      spawnInvoker, log: () => {},
+      busFactory: () => makeFakeBus(() => ownerUp),
+      sleep: async () => {}, healthPollIntervalMs: 1, launchHealthTimeoutMs: 1_000,
+      httpHealthCheck: async () => false,
+      readLockHolderPid: () => 4242,
+      isPidAlive: () => true,
+      terminatePid,
+    });
+
+    const result = await client.launch({ force: true });
+    expect(terminatePid).not.toHaveBeenCalled();
+    expect(result.healthy).toBe(true);
   });
 
   it('re-subscribes on a fresh bus after the owner dies and returns', async () => {

--- a/packages/slack-manager/src/__tests__/watchdog.test.ts
+++ b/packages/slack-manager/src/__tests__/watchdog.test.ts
@@ -1,15 +1,16 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createWatchdog } from '../watchdog.js';
+import type { LaunchResult } from '../invoker-client.js';
 
 interface HealthLaunch {
   isHealthy: () => Promise<boolean>;
-  launch: () => Promise<boolean>;
+  launch: () => Promise<LaunchResult>;
 }
 
 describe('createWatchdog', () => {
   it('relaunches after the failure threshold and not more than once per backoff window', async () => {
     let nowMs = 1_000_000;
-    const launch = vi.fn(async () => false); // Invoker stays down
+    const launch = vi.fn(async (): Promise<LaunchResult> => ({ healthy: false, cause: 'unhealthy' })); // Invoker stays down
     const client: HealthLaunch = { isHealthy: vi.fn(async () => false), launch };
     const wd = createWatchdog({
       client, log: () => {}, alert: vi.fn(),
@@ -33,7 +34,7 @@ describe('createWatchdog', () => {
 
   it('gives up and alerts after maxAttempts, then stops auto-restarting', async () => {
     let nowMs = 0;
-    const launch = vi.fn(async () => false);
+    const launch = vi.fn(async (): Promise<LaunchResult> => ({ healthy: false, cause: 'unhealthy' }));
     const alert = vi.fn();
     const wd = createWatchdog({
       client: { isHealthy: vi.fn(async () => false), launch },
@@ -57,9 +58,9 @@ describe('createWatchdog', () => {
   it('keeps attempt state after a successful relaunch until health is stable', async () => {
     let nowMs = 0;
     let healthy = false;
-    const launch = vi.fn(async () => {
+    const launch = vi.fn(async (): Promise<LaunchResult> => {
       healthy = true;
-      return true;
+      return { healthy: true };
     });
     const wd = createWatchdog({
       client: { isHealthy: vi.fn(async () => healthy), launch },
@@ -80,7 +81,7 @@ describe('createWatchdog', () => {
   it('resets only after enough consecutive healthy polls', async () => {
     let nowMs = 0;
     let healthy = false;
-    const launch = vi.fn(async () => false);
+    const launch = vi.fn(async (): Promise<LaunchResult> => ({ healthy: false, cause: 'unhealthy' }));
     const wd = createWatchdog({
       client: { isHealthy: vi.fn(async () => healthy), launch },
       log: () => {}, alert: vi.fn(),
@@ -105,9 +106,27 @@ describe('createWatchdog', () => {
     expect(launch).toHaveBeenCalledTimes(3);
   });
 
+  it('names the unreachable lock holder in the give-up alert on split-brain', async () => {
+    let nowMs = 0;
+    const launch = vi.fn(async (): Promise<LaunchResult> => ({ healthy: false, cause: 'split-brain', holderPid: 4242 }));
+    const alert = vi.fn();
+    const wd = createWatchdog({
+      client: { isHealthy: vi.fn(async () => false), launch },
+      log: () => {}, alert,
+      failuresBeforeRelaunch: 1, maxAttempts: 1, baseBackoffMs: 1_000, maxBackoffMs: 1_000,
+      now: () => nowMs,
+    });
+
+    await wd.tick();
+    expect(alert).toHaveBeenCalledTimes(1);
+    const message = (alert.mock.calls[0] as string[])[0];
+    expect(message).toContain('PID 4242');
+    expect(message).toContain('`@Invoker restart`');
+  });
+
   it('rate-limits repeated give-up alerts while Invoker stays down', async () => {
     let nowMs = 0;
-    const launch = vi.fn(async () => false);
+    const launch = vi.fn(async (): Promise<LaunchResult> => ({ healthy: false, cause: 'unhealthy' }));
     const alert = vi.fn();
     const wd = createWatchdog({
       client: { isHealthy: vi.fn(async () => false), launch },

--- a/packages/slack-manager/src/__tests__/workflow-ops.test.ts
+++ b/packages/slack-manager/src/__tests__/workflow-ops.test.ts
@@ -89,4 +89,28 @@ describe('createRunWorkflowOp', () => {
     expect(res.summary).toContain('@Invoker restart');
     expect(res.summary).not.toMatch(/Reply `restart`/);
   });
+
+  it('reports the split-brain holder pid when relaunch is impossible', async () => {
+    const client = makeClient({
+      withRecovery: vi.fn(async () => {
+        throw new InvokerDownError('down', 'split-brain', 4242);
+      }) as InvokerClient['withRecovery'],
+    });
+    const res = await createRunWorkflowOp(client, noop)({ operation: 'recreate', target: { all: true } });
+    expect(res.ok).toBe(false);
+    expect(res.summary).toContain('PID 4242');
+    expect(res.summary).toContain('@Invoker restart');
+  });
+
+  it('says a throttled relaunch was not attempted instead of claiming failure', async () => {
+    const client = makeClient({
+      withRecovery: vi.fn(async () => {
+        throw new InvokerDownError('down', 'throttled');
+      }) as InvokerClient['withRecovery'],
+    });
+    const res = await createRunWorkflowOp(client, noop)({ operation: 'recreate', target: { all: true } });
+    expect(res.ok).toBe(false);
+    expect(res.summary).toContain('did not start another one');
+    expect(res.summary).not.toContain('could not bring it back');
+  });
 });

--- a/packages/slack-manager/src/command-handler.ts
+++ b/packages/slack-manager/src/command-handler.ts
@@ -7,7 +7,7 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import type { CommandHandler, SurfaceCommand, SurfaceEvent } from '@invoker/surfaces';
-import { InvokerDownError, type InvokerClient } from './invoker-client.js';
+import { InvokerDownError, describeInvokerDown, type InvokerClient } from './invoker-client.js';
 import { errMessage } from './util.js';
 
 export interface CommandHandlerDeps {
@@ -17,8 +17,6 @@ export interface CommandHandlerDeps {
   plansDir: string;
   log: (level: string, message: string) => void;
 }
-
-const DOWN_MESSAGE = 'Invoker is down and I could not bring it back. Reply `@Invoker restart` to retry.';
 
 export class SlackCommandError extends Error {
   constructor(message: string) {
@@ -34,7 +32,7 @@ export function createCommandHandler(deps: CommandHandlerDeps): CommandHandler {
       return await deps.client.withRecovery(() => dispatch(deps, command, startedPlans));
     } catch (err) {
       const message = err instanceof InvokerDownError
-        ? DOWN_MESSAGE
+        ? describeInvokerDown(err)
         : `Command \`${command.type}\` failed: ${errMessage(err)}`;
       deps.log('error', message);
       throw err instanceof SlackCommandError ? err : new SlackCommandError(message);

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -150,8 +150,10 @@ async function main(): Promise<void> {
     runWorkflowOp,
     gatherWorkflowContext,
     onRestartInvoker: async () => {
-      const healthy = await client.launch({ force: true });
-      if (!healthy) throw new Error('Invoker did not become healthy after relaunch');
+      const result = await client.launch({ force: true });
+      if (!result.healthy) {
+        throw new Error(`Invoker did not become healthy after relaunch (${result.cause ?? 'unhealthy'})`);
+      }
     },
     log: logFn,
   };

--- a/packages/slack-manager/src/invoker-client.ts
+++ b/packages/slack-manager/src/invoker-client.ts
@@ -354,11 +354,6 @@ export class IpcInvokerClient implements InvokerClient {
     return { healthy: false, cause: 'unhealthy' };
   }
 
-  /**
-   * Split-brain: the writer-lock pidfile names a live process, yet nobody
-   * answers owner-ping. Only meaningful right after a failed health wait —
-   * during a healthy boot the lock is legitimately held.
-   */
   private detectUnreachableLockHolder(): number | null {
     const holderPid = this.readLockHolderPid();
     if (holderPid === null || holderPid === process.pid) return null;
@@ -366,9 +361,9 @@ export class IpcInvokerClient implements InvokerClient {
   }
 
   /**
-   * Force restarts only (explicit `@Invoker restart`): stop a lock holder that
-   * is re-confirmed unreachable at kill time, so the respawn can take the DB.
-   * SIGTERM (not SIGKILL) — the holder's release() and shutdown cleanup run.
+   * Safety invariant: only explicit force restarts reach here, the holder is
+   * re-confirmed unreachable after a fresh ping, and the signal is SIGTERM so
+   * the holder's lock release() and shutdown cleanup still run.
    */
   private async forceReclaimSplitBrainHolder(): Promise<void> {
     if (await this.ping()) return;

--- a/packages/slack-manager/src/invoker-client.ts
+++ b/packages/slack-manager/src/invoker-client.ts
@@ -15,6 +15,8 @@
  * connects to a live owner.
  */
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   IpcBus,
   TransportError,
@@ -23,7 +25,7 @@ import {
   type MessageHandler,
   type Unsubscribe,
 } from '@invoker/transport';
-import { resolveInvokerIpcSocketPath } from '@invoker/contracts';
+import { resolveInvokerHomeRoot, resolveInvokerIpcSocketPath } from '@invoker/contracts';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkflowStatus } from '@invoker/surfaces';
 
@@ -32,11 +34,40 @@ export interface ConnectableBus extends MessageBus {
   ready(): Promise<void>;
 }
 
+/** Why a (re)launch did not produce a healthy owner. */
+export type LaunchFailureCause = 'throttled' | 'unhealthy' | 'split-brain';
+
+export interface LaunchResult {
+  healthy: boolean;
+  cause?: LaunchFailureCause;
+  /** PID holding the DB writer lock while unreachable over IPC (split-brain only). */
+  holderPid?: number;
+}
+
 /** Thrown when an operation cannot reach the Invoker owner (transport-level down). */
 export class InvokerDownError extends Error {
-  constructor(message: string) {
+  constructor(
+    message: string,
+    readonly failureCause?: LaunchFailureCause,
+    readonly holderPid?: number,
+  ) {
     super(message);
     this.name = 'InvokerDownError';
+  }
+}
+
+/** Operator-facing description of a down state, specific to the launch failure cause. */
+export function describeInvokerDown(err: InvokerDownError): string {
+  switch (err.failureCause) {
+    case 'throttled':
+      return 'Invoker is down. A relaunch was attempted less than a minute ago and the watchdog is still '
+        + 'retrying, so I did not start another one. Try again shortly, or reply `@Invoker restart` to force a relaunch now.';
+    case 'split-brain':
+      return `Invoker cannot be relaunched: its database is locked by PID ${err.holderPid ?? '<unknown>'}, `
+        + 'which is alive but not answering IPC (often a stray Invoker GUI). Reply `@Invoker restart` to force '
+        + `recovery (this stops PID ${err.holderPid ?? '<unknown>'}), or stop that process manually.`;
+    default:
+      return 'Invoker is down and I could not bring it back. Reply `@Invoker restart` to retry.';
   }
 }
 
@@ -65,8 +96,8 @@ export interface InvokerClient {
   exec(args: string[]): Promise<void>;
   /** Submit a plan file; resolves to the created workflow id(s). `workflowIds` covers stacked plans in submission order. */
   run(planPath: string): Promise<{ workflowId: string; workflowIds: string[] }>;
-  /** (Re)launch Invoker. Resolves true once healthy over IPC, false on timeout/throttle. */
-  launch(opts?: { force?: boolean }): Promise<boolean>;
+  /** (Re)launch Invoker. `healthy: false` results carry the failure cause (throttle, timeout, split-brain). */
+  launch(opts?: { force?: boolean }): Promise<LaunchResult>;
   /** Runs `fn`; on `InvokerDownError`, launches Invoker and retries once. Rethrows if still down. */
   withRecovery<T>(fn: () => Promise<T>): Promise<T>;
   /** Subscribe to a broadcast channel; survives reconnects (re-applied on a fresh bus). */
@@ -96,6 +127,9 @@ export interface InvokerClientOptions {
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
   httpHealthCheck?: () => Promise<boolean>;
+  readLockHolderPid?: () => number | null;
+  isPidAlive?: (pid: number) => boolean;
+  terminatePid?: (pid: number) => void;
 }
 
 interface SubscriptionEntry {
@@ -141,6 +175,25 @@ function errMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+function defaultReadLockHolderPid(): number | null {
+  try {
+    const raw = readFileSync(join(resolveInvokerHomeRoot(), 'invoker.db.lock', 'pid'), 'utf8').trim();
+    const pid = Number.parseInt(raw, 10);
+    return Number.isFinite(pid) ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultIsPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
 export class IpcInvokerClient implements InvokerClient {
   private readonly socketPath: string;
   private readonly healthUrl: string;
@@ -154,11 +207,14 @@ export class IpcInvokerClient implements InvokerClient {
   private readonly now: () => number;
   private readonly sleep: (ms: number) => Promise<void>;
   private readonly httpHealthCheck: () => Promise<boolean>;
+  private readonly readLockHolderPid: () => number | null;
+  private readonly isPidAlive: (pid: number) => boolean;
+  private readonly terminatePid: (pid: number) => void;
 
   private bus: ConnectableBus | null = null;
   private healthy = false;
   private lastLaunchAt = 0;
-  private launchInFlight: Promise<boolean> | null = null;
+  private launchInFlight: Promise<LaunchResult> | null = null;
   private readonly subs = new Set<SubscriptionEntry>();
   private readonly reconnectHandlers = new Set<() => void>();
 
@@ -176,6 +232,9 @@ export class IpcInvokerClient implements InvokerClient {
     this.now = options.now ?? (() => Date.now());
     this.sleep = options.sleep ?? defaultSleep;
     this.httpHealthCheck = options.httpHealthCheck ?? (() => this.defaultHttpHealth());
+    this.readLockHolderPid = options.readLockHolderPid ?? defaultReadLockHolderPid;
+    this.isPidAlive = options.isPidAlive ?? defaultIsPidAlive;
+    this.terminatePid = options.terminatePid ?? ((pid) => process.kill(pid, 'SIGTERM'));
   }
 
   async ping(): Promise<boolean> {
@@ -252,13 +311,19 @@ export class IpcInvokerClient implements InvokerClient {
     } catch (err) {
       if (!(err instanceof InvokerDownError)) throw err;
       this.log('warn', `Invoker appears down (${err.message}); attempting relaunch`);
-      const healthy = await this.launch();
-      if (!healthy) throw new InvokerDownError('Invoker is down and could not be relaunched');
+      const result = await this.launch();
+      if (!result.healthy) {
+        throw new InvokerDownError(
+          `Invoker is down and could not be relaunched (${result.cause ?? 'unhealthy'})`,
+          result.cause,
+          result.holderPid,
+        );
+      }
       return fn();
     }
   }
 
-  async launch(opts?: { force?: boolean }): Promise<boolean> {
+  async launch(opts?: { force?: boolean }): Promise<LaunchResult> {
     // Coalesce concurrent callers (watchdog + command recovery) onto one launch.
     if (this.launchInFlight) return this.launchInFlight;
     this.launchInFlight = this.runLaunch(opts?.force ?? false);
@@ -269,16 +334,59 @@ export class IpcInvokerClient implements InvokerClient {
     }
   }
 
-  private async runLaunch(force: boolean): Promise<boolean> {
+  private async runLaunch(force: boolean): Promise<LaunchResult> {
     if (!force) {
-      if (await this.ping()) return true;
+      if (await this.ping()) return { healthy: true };
       const sinceLast = this.now() - this.lastLaunchAt;
       if (sinceLast < this.minLaunchIntervalMs) {
         this.log('warn', `launch throttled — only ${Math.round(sinceLast / 1000)}s since last launch`);
-        return false;
+        return { healthy: false, cause: 'throttled' };
       }
+    } else {
+      await this.forceReclaimSplitBrainHolder();
     }
-    return this.doLaunch();
+    if (await this.doLaunch()) return { healthy: true };
+    const holderPid = this.detectUnreachableLockHolder();
+    if (holderPid !== null) {
+      this.log('error', `relaunch failed: DB writer lock held by live, IPC-unreachable PID ${holderPid} (split-brain)`);
+      return { healthy: false, cause: 'split-brain', holderPid };
+    }
+    return { healthy: false, cause: 'unhealthy' };
+  }
+
+  /**
+   * Split-brain: the writer-lock pidfile names a live process, yet nobody
+   * answers owner-ping. Only meaningful right after a failed health wait —
+   * during a healthy boot the lock is legitimately held.
+   */
+  private detectUnreachableLockHolder(): number | null {
+    const holderPid = this.readLockHolderPid();
+    if (holderPid === null || holderPid === process.pid) return null;
+    return this.isPidAlive(holderPid) ? holderPid : null;
+  }
+
+  /**
+   * Force restarts only (explicit `@Invoker restart`): stop a lock holder that
+   * is re-confirmed unreachable at kill time, so the respawn can take the DB.
+   * SIGTERM (not SIGKILL) — the holder's release() and shutdown cleanup run.
+   */
+  private async forceReclaimSplitBrainHolder(): Promise<void> {
+    if (await this.ping()) return;
+    const holderPid = this.detectUnreachableLockHolder();
+    if (holderPid === null) return;
+    this.log('warn', `force restart: writer lock held by unreachable PID ${holderPid} — sending SIGTERM`);
+    try {
+      this.terminatePid(holderPid);
+    } catch {
+      return;
+    }
+    const deadline = this.now() + 10_000;
+    while (this.now() < deadline && this.isPidAlive(holderPid)) {
+      await this.sleep(200);
+    }
+    if (this.isPidAlive(holderPid)) {
+      this.log('error', `force restart: PID ${holderPid} did not exit within 10s of SIGTERM`);
+    }
   }
 
   subscribe(channel: string, handler: (message: unknown) => void): () => void {

--- a/packages/slack-manager/src/watchdog.ts
+++ b/packages/slack-manager/src/watchdog.ts
@@ -14,7 +14,7 @@
  * host does not spam the Slack lobby.
  */
 
-import type { InvokerClient } from './invoker-client.js';
+import type { InvokerClient, LaunchResult } from './invoker-client.js';
 import { errMessage } from './util.js';
 
 export interface WatchdogDeps {
@@ -58,8 +58,16 @@ export function createWatchdog(deps: WatchdogDeps): Watchdog {
   let nextAttemptAt = 0;
   let gaveUp = false;
   let lastAlertAt: number | null = null;
+  let lastLaunchFailure: LaunchResult | null = null;
   let busy = false;
   let timer: ReturnType<typeof setInterval> | undefined;
+
+  const splitBrainDetail = (): string =>
+    lastLaunchFailure?.cause === 'split-brain'
+      ? ` The database is locked by PID ${lastLaunchFailure.holderPid ?? '<unknown>'}, which is alive but not `
+        + 'answering IPC (often a stray Invoker GUI) — auto-relaunch cannot succeed while it runs. '
+        + 'Replying `@Invoker restart` will stop that process and take over.'
+      : '';
 
   const reset = (): void => {
     consecutiveFailures = 0;
@@ -109,7 +117,7 @@ export function createWatchdog(deps: WatchdogDeps): Watchdog {
         if (canAlert()) {
           lastAlertAt = now();
           await deps.alert(
-            `:rotating_light: Invoker is still down after ${maxAttempts} relaunch attempts. Reply \`@Invoker restart\` to retry.`,
+            `:rotating_light: Invoker is still down after ${maxAttempts} relaunch attempts.${splitBrainDetail()} Reply \`@Invoker restart\` to retry.`,
           );
         }
         return;
@@ -119,21 +127,23 @@ export function createWatchdog(deps: WatchdogDeps): Watchdog {
 
       attempts++;
       deps.log('warn', `Invoker is down — relaunch attempt ${attempts}/${maxAttempts}`);
-      const ok = await deps.client.launch();
-      if (ok) {
+      const result = await deps.client.launch();
+      if (result.healthy) {
         // Launch claimed success, but keep attempt state until health is stable.
         consecutiveFailures = 0;
         consecutiveHealthy = 0;
         nextAttemptAt = 0;
+        lastLaunchFailure = null;
         deps.log('info', 'watchdog relaunch succeeded — confirming stable health');
         return;
       }
+      lastLaunchFailure = result;
       if (attempts >= maxAttempts) {
         gaveUp = true;
         if (canAlert()) {
           lastAlertAt = now();
           await deps.alert(
-            `:rotating_light: Invoker is down and I could not bring it back after ${maxAttempts} attempts. Reply \`@Invoker restart\` to retry.`,
+            `:rotating_light: Invoker is down and I could not bring it back after ${maxAttempts} attempts.${splitBrainDetail()} Reply \`@Invoker restart\` to retry.`,
           );
         } else {
           deps.log('warn', 'Invoker still down after max relaunch attempts — alert suppressed by cooldown');

--- a/packages/slack-manager/src/workflow-ops.ts
+++ b/packages/slack-manager/src/workflow-ops.ts
@@ -9,15 +9,13 @@
  */
 
 import type { WorkflowOp, WorkflowOpName, WorkflowOpProgress, WorkflowOpResult } from '@invoker/surfaces';
-import { InvokerDownError, type InvokerClient } from './invoker-client.js';
+import { InvokerDownError, describeInvokerDown, type InvokerClient } from './invoker-client.js';
 import { errMessage } from './util.js';
 
 export type RunWorkflowOp = (
   op: WorkflowOp,
   onProgress?: (p: WorkflowOpProgress) => void,
 ) => Promise<WorkflowOpResult>;
-
-const DOWN_SUMMARY = 'Invoker is down and I could not bring it back. Reply `@Invoker restart` to retry.';
 
 /** Workflow-op verb → delegated headless `exec` command (workflow id appended). `cancel` is workflow-scoped. */
 const MUTATION_COMMAND: Partial<Record<WorkflowOpName, string>> = {
@@ -36,7 +34,7 @@ export function createRunWorkflowOp(
     try {
       return await client.withRecovery(() => runOnce(client, op, onProgress));
     } catch (err) {
-      if (err instanceof InvokerDownError) return { ok: false, summary: DOWN_SUMMARY };
+      if (err instanceof InvokerDownError) return { ok: false, summary: describeInvokerDown(err) };
       log('error', `workflow op ${op.operation} failed: ${errMessage(err)}`);
       return { ok: false, summary: `Operation failed: ${errMessage(err)}` };
     }

--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { join, dirname } from 'node:path';
-import { existsSync, mkdtempSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -522,6 +522,60 @@ describe('IpcBus', () => {
     busA.subscribe('ch', (msg: string) => received.push(msg));
     busA.publish('ch', 'ok');
     expect(received).toEqual(['ok']);
+  });
+
+  it('never unlinks a live server socket when connect fails with an unexpected error', async () => {
+    const sock = tempSocketPath();
+
+    const server = createBus(sock);
+    await server.ready();
+    server.onRequest<string, string>('echo', (value) => `owner:${value}`);
+
+    chmodSync(sock, 0o000);
+    const blocked = createBus(sock);
+    await blocked.ready();
+    await sleep(100);
+
+    expect(existsSync(sock)).toBe(true);
+    expect(server.isServing()).toBe(true);
+
+    chmodSync(sock, 0o777);
+    await waitFor(() => !blocked.isServing(), 2000);
+    await sleep(200);
+
+    expect(server.isServing()).toBe(true);
+    expect(blocked.isServing()).toBe(false);
+    const result = await blocked.request<string, string>('echo', 'ok');
+    expect(result).toBe('owner:ok');
+  });
+
+  it('still reclaims a stale socket file left behind by a crashed server', async () => {
+    const sock = tempSocketPath();
+
+    const crashed = spawn(process.execPath, [
+      '-e',
+      "const s = require('node:net').createServer(() => {}); s.listen(process.argv[1], () => process.stdout.write('ready'));",
+      sock,
+    ]);
+    await new Promise<void>((resolve) => {
+      crashed.stdout.on('data', (chunk: Buffer) => {
+        if (chunk.toString().includes('ready')) resolve();
+      });
+    });
+    crashed.kill('SIGKILL');
+    await new Promise<void>((resolve) => crashed.on('exit', () => resolve()));
+    expect(existsSync(sock)).toBe(true);
+
+    const owner = createBus(sock);
+    await owner.ready();
+    await waitFor(() => owner.isServing(), 2000);
+    owner.onRequest<string, string>('echo', (value) => `owner:${value}`);
+
+    const client = new IpcBus(sock, { allowServe: false });
+    buses.push(client);
+    await client.ready();
+    const result = await client.request<string, string>('echo', 'ok');
+    expect(result).toBe('owner:ok');
   });
 
   it('surviving client reclaims the socket after the original server disappears', async () => {

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -331,33 +331,36 @@ export class IpcBus implements MessageBus {
     });
 
     sock.on('error', (err: NodeJS.ErrnoException) => {
-      if (err.code === 'ECONNREFUSED' || err.code === 'ENOENT') {
-        if (!this.allowServe) {
-          this.resolveReady();
-          return;
-        }
-        // No server yet — try to become the server.
-        this.tryServe();
+      if (!this.allowServe) {
+        this.resolveReady();
+        return;
+      }
+      if (err.code === 'ECONNREFUSED') {
+        // A socket file exists but nothing accepts on it — confirmed stale,
+        // safe to reclaim.
+        this.tryServe(true);
+      } else if (err.code === 'ENOENT') {
+        // No socket file at all — serve fresh.
+        this.tryServe(false);
       } else {
-        if (!this.allowServe) {
-          this.resolveReady();
-          return;
-        }
-        // Unexpected error — still try to serve.
-        this.tryServe();
+        // Unexpected error (EACCES, EAGAIN, …): the server may be alive, so
+        // never unlink its socket out from under it — retry connecting instead.
+        this.resolveReady();
+        this.scheduleRecovery();
       }
     });
   }
 
-  private tryServe(): void {
+  private tryServe(reclaimStale: boolean): void {
     // Ensure directory exists.
     mkdirSync(dirname(this.socketPath), { recursive: true });
 
-    // Clean stale socket file before binding.
-    try {
-      unlinkSync(this.socketPath);
-    } catch {
-      // File may not exist — fine.
+    if (reclaimStale) {
+      try {
+        unlinkSync(this.socketPath);
+      } catch {
+        // File may not exist — fine.
+      }
     }
 
     const srv = createServer((client) => {
@@ -387,14 +390,19 @@ export class IpcBus implements MessageBus {
 
     sock.on('error', () => {
       if (this.allowServe) {
-        this.scheduleServeRecovery();
+        this.scheduleRecovery();
       }
       // Nothing else we can do synchronously — resolve ready so callers don't hang forever.
       this.resolveReady();
     });
   }
 
-  private scheduleServeRecovery(): void {
+  /**
+   * Recover by reconnecting first: only a connect that fails ECONNREFUSED
+   * proves the socket file is dead, so takeover can never unlink a live
+   * server's socket.
+   */
+  private scheduleRecovery(): void {
     if (this.disconnected || !this.allowServe || this.server || this.peers.size > 0 || this.serveRetryScheduled) {
       return;
     }
@@ -404,7 +412,7 @@ export class IpcBus implements MessageBus {
       if (this.disconnected || !this.allowServe || this.server || this.peers.size > 0) {
         return;
       }
-      this.tryServe();
+      this.tryConnect();
     }, 25).unref?.();
   }
 
@@ -425,12 +433,12 @@ export class IpcBus implements MessageBus {
     sock.on('data', (chunk: Buffer) => decoder.push(chunk));
     sock.on('close', () => {
       this.peers.delete(sock);
-      this.scheduleServeRecovery();
+      this.scheduleRecovery();
     });
     sock.on('error', () => {
       sock.destroy();
       this.peers.delete(sock);
-      this.scheduleServeRecovery();
+      this.scheduleRecovery();
     });
   }
 
@@ -718,7 +726,7 @@ export class IpcBus implements MessageBus {
       this.server.close();
       this.server = null;
     }
-    this.tryServe();
+    this.tryServe(true);
   }
 
   disconnect(): void {

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -697,6 +697,30 @@ export class IpcBus implements MessageBus {
     return this.readyPromise;
   }
 
+  /** True when this bus currently owns the listening socket. */
+  isServing(): boolean {
+    return this.server !== null;
+  }
+
+  /**
+   * Authoritatively (re)bind the socket. Only for a process that holds the DB
+   * writer lock: it drops any client peers, closes a stale server, and serves
+   * fresh — reclaiming a socket path that was deleted or taken while this
+   * process remained the rightful owner.
+   */
+  serveAsOwner(): void {
+    if (this.disconnected || !this.allowServe) return;
+    for (const peer of this.peers) {
+      peer.destroy();
+    }
+    this.peers.clear();
+    if (this.server) {
+      this.server.close();
+      this.server = null;
+    }
+    this.tryServe();
+  }
+
   disconnect(): void {
     this.disconnected = true;
     this.subscribers.clear();

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -336,15 +336,14 @@ export class IpcBus implements MessageBus {
         return;
       }
       if (err.code === 'ECONNREFUSED') {
-        // A socket file exists but nothing accepts on it — confirmed stale,
-        // safe to reclaim.
+        // Safety invariant: only a refused connect proves the socket file is
+        // dead, so this is the sole path allowed to reclaim (unlink) it.
         this.tryServe(true);
       } else if (err.code === 'ENOENT') {
-        // No socket file at all — serve fresh.
         this.tryServe(false);
       } else {
-        // Unexpected error (EACCES, EAGAIN, …): the server may be alive, so
-        // never unlink its socket out from under it — retry connecting instead.
+        // Safety invariant: on any other error the server may be alive —
+        // never unlink its socket; retry connecting instead.
         this.resolveReady();
         this.scheduleRecovery();
       }
@@ -397,11 +396,6 @@ export class IpcBus implements MessageBus {
     });
   }
 
-  /**
-   * Recover by reconnecting first: only a connect that fails ECONNREFUSED
-   * proves the socket file is dead, so takeover can never unlink a live
-   * server's socket.
-   */
   private scheduleRecovery(): void {
     if (this.disconnected || !this.allowServe || this.server || this.peers.size > 0 || this.serveRetryScheduled) {
       return;


### PR DESCRIPTION
## Summary

On Aug 4 the Slack bot answered everything with "Invoker is down" for 15+ minutes. Invoker was not gone: a GUI instance held the database.

That GUI held the DB writer lock but never served the IPC socket. The bot could not reach it, and every owner it spawned died on the held lock.

Nothing recovered from this state. Relaunches failed forever, the launch throttle made the bot claim failure without attempting anything, and doomed spawns could unlink the live socket file.

This PR makes the state self-healing and self-diagnosing. A spawned owner that loses the lock now pings the holder over the socket first.

A healthy owner answers and the spawn exits cleanly. Silence means the lock-holder deadlock is reported with the holder PID.

Lock-holding owners run a sentinel that pings their own socket path and re-serves it if it vanishes.

The transport layer only unlinks a socket file after a refused connect proves it dead.

The Slack manager reports launch outcomes truthfully: throttled, failed, or deadlocked with the holder PID. An explicit `@Invoker restart` may SIGTERM a re-confirmed-unreachable holder; the automatic watchdog never kills anything.

## Review Claim

A process holding the Invoker DB writer lock is always reachable on the message bus or gets replaced: the spawn-side ping, the owner-side socket sentinel, the transport-side unlink guard, and truthful supervisor escalation close the lock-holder deadlock from every side.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The writer lock is never stolen: dead/recycled-PID reclaim is untouched, probes are read-only pings, and the sentinel re-serves the socket only inside the process that already holds the lock. Only an explicit human `@Invoker restart` may SIGTERM a holder, only after a fresh failed ping, never its own process, and stale-socket reclaim still requires a refused connect as proof of death.

## Slice Rationale

All five commits close one incident class from its different sides — app owner startup, owner self-check, supervisor messaging, transport socket handling — so they ship as one reviewable stack. Slice 1 defines the tri-state spawn exit, slice 2 enforces the invariant it diagnoses, slice 3 consumes it in the supervisor, slice 4 closes the socket-unlink entry path, slice 5 trims comments only.

## Non-goals

No change to the `cleanElectronEnv` / `INVOKER_HEADLESS_STANDALONE` env leak (in-flight separately), no change to Slack workflow-op semantics, no new headless commands, and no change to single-owner election on a healthy boot.

## Architecture

### Before

```mermaid
graph TD
    B["slack-manager watchdog"] -->|"spawn owner-serve"| S["spawned owner"]
    S -->|"writer lock held by live PID"| X["fatal exit, no diagnosis"]
    G["GUI owner (holds DB lock, socket lost)"] -.->|"unreachable over IPC"| B
    B -->|"throttled or failed"| M["'could not bring it back' (forever)"]
```

### After

```mermaid
graph TD
    B["slack-manager watchdog"] -->|"spawn owner-serve"| S["spawned owner"]
    S -->|"lock lost: probe owner-ping"| P{"holder answers?"}
    P -->|"yes"| OK["exit 0: owner already running"]
    P -->|"no"| SB["exit 1: owner-split-brain + holder PID"]
    G["lock-holding owner"] -->|"socket sentinel: self-ping, re-serve if lost"| G
    B -->|"throttled / failed / split-brain reported truthfully"| U["operator"]
    U -->|"explicit @Invoker restart"| K["SIGTERM re-confirmed-unreachable holder, respawn"]
```

## Visual Proof

This change has no window/UI behavior (main.ts edits are headless owner-serve wiring only); the observable surface is terminal output. Captures show the incident repro (writer lock held by a live, IPC-silent PID in an isolated `INVOKER_DB_DIR`) run against the real binary on origin/master and on this branch.

![origin/master build: generic writer-lock fatal with no diagnosis](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260804-37db96/master-build.png)

![this branch: distinct owner-split-brain error naming the live unreachable holder PID](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260804-37db96/branch-build.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test` (1851 passed; the 2 failures are pre-existing on origin/master, verified in a clean worktree)
- [x] `cd packages/slack-manager && pnpm test` (46 passed; 1 pre-existing failure on origin/master)
- [x] `cd packages/transport && pnpm test` (50 passed)
- [x] `pnpm run check:types`
- [x] `pnpm build`
- [x] Incident repro against an isolated `INVOKER_DB_DIR`: hold `invoker.db.lock` with a live dummy PID and run `node scripts/electron.cjs packages/app/dist/main.js --headless owner-serve` — before: generic writer-lock fatal; after: `[owner-split-brain]` naming the holder PID

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8ede903c4 1e34f2c47 7392494f9 7bf9eb86b 181c3a11a`
- Post-revert steps: restart the slack-manager daemon so it returns to the boolean launch() result
- Data migration? No

</details>
