### PR TITLE
[Owner-Ping Timeout Outliers](3) Widen the headless-client.ts owner-ping outliers to 1500ms

### DIFF
--- a/packages/app/src/__tests__/owner-ping-race.repro.test.ts
+++ b/packages/app/src/__tests__/owner-ping-race.repro.test.ts
@@ -44,7 +44,7 @@ describe('owner-ping timeout race', () => {
     ).toBeGreaterThanOrEqual(1000);
   });
 
-  it.fails('the two discoverOwner call sites in headless-client.ts do not use the 500ms outlier budget', () => {
+  it('the two discoverOwner call sites in headless-client.ts do not use the 500ms outlier budget', () => {
     const source = readFileSync(HEADLESS_CLIENT, 'utf8');
     const matches = [...source.matchAll(/discoverOwner\([^,]+,\s*(\d+)\)/g)];
     expect(matches.length, 'expected 2 discoverOwner(...) call sites in headless-client.ts').toBe(2);

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -548,7 +548,7 @@ async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void>
     let attempts = 0;
     while (Date.now() < deadline) {
       attempts += 1;
-      const owner = await discoverOwner(bus, 500);
+      const owner = await discoverOwner(bus, 1500);
       if (isStandaloneCapable(owner)) {
         delegationClientLog(
           `bootstrap owner ready attempts=${attempts} elapsedMs=${Date.now() - startedAt} ownerId=${owner.ownerId}`,
@@ -749,7 +749,7 @@ export async function runHeadlessClientCommand(
   }
 
   if (canAcknowledgeNoTrackTaskMutationWithoutDb(args, noTrack)) {
-    const owner = await discoverOwner(deps.messageBus, 500);
+    const owner = await discoverOwner(deps.messageBus, 1500);
     if (owner === null && tryAcknowledgeNoTrackTaskMutationWithoutDb(args, noTrack)) {
       return 0;
     }


### PR DESCRIPTION
## Summary

This is the second of two fix PRs for the owner-ping timeout outliers described in #7419 and #7420.

See #7420 for full context: a live owner's answer landing 501ms after a 500ms budget, in a real production log.

It widens the two call sites in `headless-client.ts` to 1500ms, matching every other place in the codebase that does the same ping.

The `main.ts` call site landed as the previous PR (#7420), a different review unit.

## Review Claim

`headless-client.ts:556` and `:757` both pass a 500ms budget to `discoverOwner`, an outlier next to every other caller of the same function (1000-2000ms elsewhere) for the same owner-discovery ping handshake.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only these two numeric literals change (500 → 1500). No other timing constant changes: not `tryPingHeadlessOwner`'s own default parameter, not the outer 2000ms discovery-loop deadline.

## Slice Rationale

`headless-client.ts` classifies under a different review unit than `main.ts` per this repo's review-unit rules, so they can't share a PR. This slice covers `headless-client.ts` only, landing after the `main.ts` slice (#7420).

## Non-goals

No refactor, no new fields, no unrelated cleanup, no doc edits, no change to the 2000ms outer discovery-loop deadline, no change to `main.ts` (previous PR).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- -t "owner-ping timeout race"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when connecting to the standalone owner during startup.
  * Reduced timeout-related failures while waiting for mutation acknowledgements.
  * Updated timeout handling so previously flaky scenarios now complete successfully.

* **Tests**
  * Added coverage confirming successful behavior when owner discovery takes longer than usual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->