### PR TITLE
[Owner Split-Brain Recovery](1) Probe the lock holder over IPC before owner-serve dies

### DIFF
--- a/packages/app/src/__tests__/owner-split-brain.test.ts
+++ b/packages/app/src/__tests__/owner-split-brain.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  OWNER_SPLIT_BRAIN_PREFIX,
+  isWriterLockHeldError,
+  parseWriterLockHolderPid,
+  probeLockHolderOwner,
+  resolveOwnerServeLockFailure,
+  type ProbeBus,
+} from '../owner-split-brain.js';
+
+const HELD_ERROR = new Error(
+  '[db-writer-lock] Cannot acquire writer lock for /home/x/.invoker/invoker.db — '
+  + 'already held by PID 266663. requested by caller=main:initServices pid=274106. '
+  + 'If the previous process crashed, remove /home/x/.invoker/invoker.db.lock manually.',
+);
+
+function busWith(overrides: Partial<ProbeBus>): ProbeBus {
+  return {
+    ready: () => Promise.resolve(),
+    request: () => Promise.reject(new Error('No request handler registered for channel: headless.owner-ping')),
+    disconnect: () => {},
+    ...overrides,
+  };
+}
+
+describe('isWriterLockHeldError', () => {
+  it('matches the live-holder writer lock error', () => {
+    expect(isWriterLockHeldError(HELD_ERROR)).toBe(true);
+  });
+
+  it('rejects unrelated errors and non-errors', () => {
+    expect(isWriterLockHeldError(new Error('EACCES: permission denied'))).toBe(false);
+    expect(isWriterLockHeldError('[db-writer-lock] already held by PID 5')).toBe(false);
+  });
+});
+
+describe('parseWriterLockHolderPid', () => {
+  it('extracts the holder pid from the lock error message', () => {
+    expect(parseWriterLockHolderPid(HELD_ERROR)).toBe(266663);
+  });
+
+  it('returns null when no pid is present', () => {
+    expect(parseWriterLockHolderPid(new Error('[db-writer-lock] already held by PID unknown.'))).toBeNull();
+  });
+});
+
+describe('probeLockHolderOwner', () => {
+  it('reports owner-alive when the holder answers owner-ping', async () => {
+    const bus = busWith({
+      request: () => Promise.resolve({ ok: true, ownerId: 'owner-1', mode: 'gui' } as never),
+    });
+    await expect(probeLockHolderOwner({ createBus: () => bus })).resolves.toEqual({
+      kind: 'owner-alive',
+      ownerId: 'owner-1',
+      mode: 'gui',
+    });
+  });
+
+  it('reports split-brain when no handler answers the ping', async () => {
+    await expect(probeLockHolderOwner({ createBus: () => busWith({}) })).resolves.toEqual({
+      kind: 'split-brain',
+    });
+  });
+
+  it('reports split-brain when the ping answer is not ok', async () => {
+    const bus = busWith({ request: () => Promise.resolve({ ok: false } as never) });
+    await expect(probeLockHolderOwner({ createBus: () => bus })).resolves.toEqual({ kind: 'split-brain' });
+  });
+
+  it('reports split-brain when the probe hangs past the timeout', async () => {
+    const bus = busWith({ request: () => new Promise(() => {}) });
+    await expect(probeLockHolderOwner({ createBus: () => bus, timeoutMs: 20 })).resolves.toEqual({
+      kind: 'split-brain',
+    });
+  });
+
+  it('disconnects the probe bus in every outcome', async () => {
+    let disconnects = 0;
+    const alive = busWith({
+      request: () => Promise.resolve({ ok: true } as never),
+      disconnect: () => { disconnects++; },
+    });
+    const dead = busWith({ disconnect: () => { disconnects++; } });
+    await probeLockHolderOwner({ createBus: () => alive });
+    await probeLockHolderOwner({ createBus: () => dead });
+    expect(disconnects).toBe(2);
+  });
+});
+
+describe('resolveOwnerServeLockFailure', () => {
+  it('exits 0 without taking over when an owner already answers IPC', async () => {
+    const bus = busWith({ request: () => Promise.resolve({ ok: true, ownerId: 'o', mode: 'gui' } as never) });
+    const resolution = await resolveOwnerServeLockFailure(HELD_ERROR, '/tmp/ipc.sock', { createBus: () => bus });
+    expect(resolution.exitCode).toBe(0);
+    expect(resolution.message).toContain('already answers IPC');
+    expect(resolution.message).toContain('ownerId=o');
+  });
+
+  it('exits 1 with a distinct split-brain error naming the holder pid', async () => {
+    const resolution = await resolveOwnerServeLockFailure(HELD_ERROR, '/tmp/ipc.sock', {
+      createBus: () => busWith({}),
+    });
+    expect(resolution.exitCode).toBe(1);
+    expect(resolution.message).toContain(OWNER_SPLIT_BRAIN_PREFIX);
+    expect(resolution.message).toContain('PID 266663');
+    expect(resolution.message).toContain('/tmp/ipc.sock');
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -194,6 +194,7 @@ import {
 import { resolveBundledCliPath } from './cli-helper.js';
 import { buildAppMenuTemplate } from './app-menu.js';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
+import { isWriterLockHeldError, resolveOwnerServeLockFailure } from './owner-split-brain.js';
 import { CoalescedWorkflowMetadataPublisher } from './workflow-metadata-invalidation.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
@@ -2000,8 +2001,18 @@ function startHeadlessMode(): void {
 
       await runHeadless(cliArgs, headlessDeps);
     } catch (err) {
-      process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
-      exitCode = 1;
+      if (command === 'owner-serve' && isWriterLockHeldError(err)) {
+        const resolution = await resolveOwnerServeLockFailure(err, resolveInvokerIpcSocketPath());
+        process.stderr.write(
+          resolution.exitCode === 0
+            ? `${resolution.message}\n`
+            : `${RED}Error:${RESET} ${resolution.message}\n`,
+        );
+        exitCode = resolution.exitCode;
+      } else {
+        process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
+        exitCode = 1;
+      }
     } finally {
       if (!headlessSignalShutdownInProgress) {
         headlessSignalShutdownInProgress = true;

--- a/packages/app/src/owner-split-brain.ts
+++ b/packages/app/src/owner-split-brain.ts
@@ -1,0 +1,120 @@
+/**
+ * Split-brain handling for owner-serve startup.
+ *
+ * When a spawned owner loses the DB writer lock to a live PID, the holder is
+ * either a healthy owner already answering IPC (spawn is redundant — exit 0),
+ * or a process holding the database without serving the socket (split-brain —
+ * exit 1 with a distinct, actionable error). Probing before dying is what lets
+ * supervisors (slack-manager watchdog) distinguish "owner already running"
+ * from "recovery is impossible until PID X dies".
+ */
+
+import { IpcBus } from '@invoker/transport';
+
+export const OWNER_SPLIT_BRAIN_PREFIX = '[owner-split-brain]';
+
+const DEFAULT_PROBE_TIMEOUT_MS = 2_000;
+
+export interface OwnerPingAnswer {
+  ok?: boolean;
+  ownerId?: string;
+  mode?: string;
+}
+
+export interface ProbeBus {
+  ready(): Promise<void>;
+  request<Req, Res>(channel: string, message: Req): Promise<Res>;
+  disconnect(): void;
+}
+
+export type LockHolderProbeResult =
+  | { kind: 'owner-alive'; ownerId?: string; mode?: string }
+  | { kind: 'split-brain' };
+
+export interface OwnerServeLockFailureResolution {
+  exitCode: 0 | 1;
+  message: string;
+}
+
+export function isWriterLockHeldError(err: unknown): boolean {
+  return err instanceof Error
+    && err.message.includes('[db-writer-lock]')
+    && err.message.includes('already held by PID');
+}
+
+export function parseWriterLockHolderPid(err: unknown): number | null {
+  if (!(err instanceof Error)) return null;
+  const match = /already held by PID (\d+)/.exec(err.message);
+  if (!match) return null;
+  const pid = Number.parseInt(match[1], 10);
+  return Number.isFinite(pid) ? pid : null;
+}
+
+function raceTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`owner-ping probe timed out after ${ms}ms`)), ms);
+    timer.unref?.();
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+export async function probeLockHolderOwner(options: {
+  createBus?: () => ProbeBus;
+  timeoutMs?: number;
+} = {}): Promise<LockHolderProbeResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+  const createBus = options.createBus
+    ?? (() => new IpcBus(undefined, { allowServe: false, requestDeadlineMs: timeoutMs }));
+  const bus = createBus();
+  try {
+    await raceTimeout(bus.ready(), timeoutMs);
+    const res = await raceTimeout(
+      bus.request<Record<string, never>, OwnerPingAnswer>('headless.owner-ping', {}),
+      timeoutMs,
+    );
+    if (res?.ok) {
+      return { kind: 'owner-alive', ownerId: res.ownerId, mode: res.mode };
+    }
+    return { kind: 'split-brain' };
+  } catch {
+    return { kind: 'split-brain' };
+  } finally {
+    bus.disconnect();
+  }
+}
+
+export async function resolveOwnerServeLockFailure(
+  err: unknown,
+  socketPath: string,
+  options: { createBus?: () => ProbeBus; timeoutMs?: number } = {},
+): Promise<OwnerServeLockFailureResolution> {
+  const probe = await probeLockHolderOwner(options);
+  if (probe.kind === 'owner-alive') {
+    const identity = [
+      probe.ownerId ? `ownerId=${probe.ownerId}` : null,
+      probe.mode ? `mode=${probe.mode}` : null,
+    ].filter(Boolean).join(' ');
+    return {
+      exitCode: 0,
+      message: `owner-serve: an owner already answers IPC${identity ? ` (${identity})` : ''}; exiting without taking over.`,
+    };
+  }
+  const holderPid = parseWriterLockHolderPid(err);
+  const holder = holderPid === null ? 'an unknown PID' : `PID ${holderPid}`;
+  return {
+    exitCode: 1,
+    message:
+      `${OWNER_SPLIT_BRAIN_PREFIX} DB writer lock is held by ${holder}, but no owner answers `
+      + `headless.owner-ping at ${socketPath}. A live process holds the database without serving IPC; `
+      + `relaunching cannot succeed until it exits. Stop ${holder} (e.g. close a stray Invoker GUI), then retry.`,
+  };
+}


### PR DESCRIPTION
## Summary

On Aug 4 the Slack bot answered everything with "Invoker is down" for 15+ minutes. A GUI instance held the DB writer lock while never serving the IPC socket.

Every owner the bot spawned died on the held lock with a generic fatal error. Supervisors could not tell "an owner already runs" from "recovery is impossible".

This PR gives the spawned owner-serve process that distinction. When it loses the writer lock to a live PID, it now pings the owner over its own socket first.

If a healthy owner answers, the spawn logs it and exits 0.

If no owner answers, it does not exit generically: the `[owner-split-brain]` error names the lock-holder PID.

## Review Claim

An owner-serve process that loses the DB writer lock to a live PID resolves its exit through one read-only ping over the message bus: exit 0 when an owner answers, or a diagnosable lock-holder-deadlock error naming the holder PID when nobody does.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The lock is never removed or stolen; dead/recycled-PID reclaim in db-writer-lock.ts is untouched; the probe is a read-only ping over a client-only bus with a 2s timeout, and it runs only on the owner-serve failure path.

## Slice Rationale

This is the decision point every relaunch funnels through, and later stack entries build on its tri-state exit: the sentinel PR enforces the invariant this diagnoses, and the supervisor PR consumes the distinction. It ships first so each successor stays one boundary.

## Non-goals

No socket re-serving (next PR), no supervisor/messaging changes (PR 3), no transport unlink changes (PR 4), and no change to how a healthy owner-serve boots.

## Architecture

### Before

```mermaid
graph TD
    S["spawned owner-serve"] -->|"writer lock held by live PID"| X["generic fatal exit 1 — no diagnosis"]
```

### After

```mermaid
graph TD
    S["spawned owner-serve"] -->|"lock held by live PID: ping owner over socket"| P{"owner answers?"}
    P -->|"yes"| OK["exit 0 — owner already running"]
    P -->|"no"| SB["exit 1 — owner-split-brain error naming holder PID"]
```

## Visual Proof

No window/UI behavior changes (the main.ts edit is the owner-serve failure path); the observable surface is terminal output. Captures show the incident repro (writer lock held by a live, IPC-silent PID in an isolated `INVOKER_DB_DIR`) run against the real binary on origin/master and on this branch.

![origin/master build: generic writer-lock fatal with no diagnosis](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260804-37db96/master-build.png)

![this branch: distinct owner-split-brain error naming the live unreachable holder PID](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260804-37db96/branch-build.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test` (owner-split-brain.test.ts: 11 tests; suite-wide only the 2 failures pre-existing on origin/master)
- [x] Incident repro against an isolated `INVOKER_DB_DIR`: hold `invoker.db.lock` with a live dummy PID and run owner-serve — origin/master prints the generic writer-lock fatal; this branch prints `[owner-split-brain]` naming the holder PID

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 848020c6e`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)