### PR TITLE
[Owner Split-Brain Recovery](2) Lock-holding owner self-heals its IPC socket

### DIFF
--- a/packages/app/src/__tests__/owner-socket-sentinel.test.ts
+++ b/packages/app/src/__tests__/owner-socket-sentinel.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, rmSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { IpcBus } from '@invoker/transport';
+import { createOwnerSocketSentinel } from '../owner-socket-sentinel.js';
+
+function noopLog(): void {}
+
+describe('createOwnerSocketSentinel', () => {
+  it('does not re-serve while the probe succeeds', async () => {
+    let reserves = 0;
+    const sentinel = createOwnerSocketSentinel({
+      probe: () => Promise.resolve(true),
+      reserve: () => { reserves++; },
+      log: noopLog,
+    });
+    await sentinel.tick();
+    await sentinel.tick();
+    expect(reserves).toBe(0);
+  });
+
+  it('re-serves only after consecutive probe failures', async () => {
+    let reserves = 0;
+    let ok = false;
+    const sentinel = createOwnerSocketSentinel({
+      probe: () => Promise.resolve(ok),
+      reserve: () => { reserves++; },
+      log: noopLog,
+      failuresBeforeReserve: 2,
+    });
+    await sentinel.tick();
+    expect(reserves).toBe(0);
+    await sentinel.tick();
+    expect(reserves).toBe(1);
+    ok = true;
+    await sentinel.tick();
+    ok = false;
+    await sentinel.tick();
+    expect(reserves).toBe(1);
+    await sentinel.tick();
+    expect(reserves).toBe(2);
+  });
+
+  it('treats a throwing probe as a failure', async () => {
+    let reserves = 0;
+    const sentinel = createOwnerSocketSentinel({
+      probe: () => Promise.reject(new Error('boom')),
+      reserve: () => { reserves++; },
+      log: noopLog,
+      failuresBeforeReserve: 1,
+    });
+    await sentinel.tick();
+    expect(reserves).toBe(1);
+  });
+
+  it('logs recovery after the socket becomes reachable again', async () => {
+    const lines: string[] = [];
+    let ok = false;
+    const sentinel = createOwnerSocketSentinel({
+      probe: () => Promise.resolve(ok),
+      reserve: () => {},
+      log: (_level, message) => { lines.push(message); },
+      failuresBeforeReserve: 1,
+    });
+    await sentinel.tick();
+    ok = true;
+    await sentinel.tick();
+    expect(lines.some((line) => line.includes('reachable again'))).toBe(true);
+  });
+});
+
+describe('IpcBus.serveAsOwner socket reclaim', () => {
+  let dir: string;
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('re-binds the socket path after the socket file is deleted under a live server', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'sentinel-sock-'));
+    const socketPath = join(dir, 'ipc.sock');
+    const owner = new IpcBus(socketPath, { allowServe: true });
+    await owner.ready();
+    expect(owner.isServing()).toBe(true);
+    owner.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'me' }));
+
+    unlinkSync(socketPath);
+    const strandedClient = new IpcBus(socketPath, { allowServe: false, requestDeadlineMs: 300 });
+    await strandedClient.ready();
+    await expect(strandedClient.request('headless.owner-ping', {})).rejects.toThrow();
+    strandedClient.disconnect();
+
+    owner.serveAsOwner();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const client = new IpcBus(socketPath, { allowServe: false, requestDeadlineMs: 1_000 });
+    await client.ready();
+    await expect(client.request('headless.owner-ping', {})).resolves.toEqual({ ok: true, ownerId: 'me' });
+    client.disconnect();
+    owner.disconnect();
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -196,6 +196,7 @@ import { resolveBundledCliPath } from './cli-helper.js';
 import { buildAppMenuTemplate } from './app-menu.js';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
 import { isWriterLockHeldError, resolveOwnerServeLockFailure } from './owner-split-brain.js';
+import { createOwnerSocketSentinel, type OwnerSocketSentinel } from './owner-socket-sentinel.js';
 import { CoalescedWorkflowMetadataPublisher } from './workflow-metadata-invalidation.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
@@ -497,7 +498,23 @@ const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promi
 let activeMutationContext: WorkflowMutationContext | undefined;
 let hourlyBackupInterval: ReturnType<typeof setInterval> | null = null;
 let writerLock: DbWriterLockResult | null = null;
+let ownerSocketSentinel: OwnerSocketSentinel | null = null;
 const workflowMutationOwnerId = `owner-${process.pid}-${Date.now()}`;
+
+function startOwnerSocketSentinelForBus(bus: MessageBus | undefined): void {
+  ownerSocketSentinel?.stop();
+  ownerSocketSentinel = null;
+  if (!(bus instanceof IpcBus)) return;
+  ownerSocketSentinel = createOwnerSocketSentinel({
+    reserve: () => bus.serveAsOwner(),
+    expectedOwnerId: workflowMutationOwnerId,
+    log: (level, message) => {
+      if (level === 'warn') logger.warn(message, { module: 'owner-socket-sentinel' });
+      else logger.info(message, { module: 'owner-socket-sentinel' });
+    },
+  });
+  ownerSocketSentinel.start();
+}
 const appProcessStartedAt = Date.now();
 
 let logger: Logger = new FileAndDbLogger({ module: 'main' });
@@ -1007,6 +1024,7 @@ function startHeadlessMode(): void {
     let headlessWebBridge: WebBridge | null = null;
 
     const runHeadlessShutdownCleanup = async (forcedStopReason: string): Promise<void> => {
+      ownerSocketSentinel?.stop();
       await headlessWebBridge?.close();
       standaloneLaunchDispatcherController?.stop();
       lifecycleEventBridge?.stop();
@@ -1990,6 +2008,7 @@ function startHeadlessMode(): void {
             },
             apiServerDeps,
           );
+          startOwnerSocketSentinelForBus(messageBus);
         }
 
         void recoverWorkflowMutationsOnStartup({
@@ -3025,6 +3044,7 @@ startMainProcessBootstrap({
       });
       logger.info(`owner-ipc-ready ownerId=${workflowMutationOwnerId}`, { module: 'ipc-delegate' });
       recordStartupMark('owner-ipc-ready');
+      startOwnerSocketSentinelForBus(messageBus);
     }
 
     if (ownerMode) {
@@ -3402,6 +3422,7 @@ startMainProcessBootstrap({
         }
         guiInstanceLock?.release();
         guiInstanceLock = null;
+        ownerSocketSentinel?.stop();
         if (writerLock) writerLock.release();
         if (messageBus) messageBus.disconnect();
       } finally {

--- a/packages/app/src/owner-socket-sentinel.ts
+++ b/packages/app/src/owner-socket-sentinel.ts
@@ -1,0 +1,95 @@
+/**
+ * Owner socket sentinel — enforces "the DB writer-lock holder serves the IPC
+ * socket". A lock-holding owner periodically pings its own socket path with a
+ * fresh client connection; after consecutive failures (socket file deleted,
+ * lost serve takeover, or a foreign process answering with a different
+ * ownerId) it authoritatively re-serves the socket. Without this, an owner can
+ * hold the database while being unreachable — the split-brain that strands
+ * every relaunch attempt.
+ */
+
+import { probeLockHolderOwner } from './owner-split-brain.js';
+
+const DEFAULT_INTERVAL_MS = 15_000;
+const DEFAULT_FAILURES_BEFORE_RESERVE = 2;
+const DEFAULT_PROBE_TIMEOUT_MS = 2_000;
+
+export interface OwnerSocketSentinel {
+  start(): void;
+  stop(): void;
+  /** Run one probe/re-serve cycle. Exposed for tests. */
+  tick(): Promise<void>;
+}
+
+export interface OwnerSocketSentinelDeps {
+  reserve: () => void;
+  log: (level: string, message: string) => void;
+  expectedOwnerId?: string;
+  probe?: () => Promise<boolean>;
+  intervalMs?: number;
+  failuresBeforeReserve?: number;
+  probeTimeoutMs?: number;
+}
+
+export function createOwnerSocketSentinel(deps: OwnerSocketSentinelDeps): OwnerSocketSentinel {
+  const intervalMs = deps.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const failuresBeforeReserve = deps.failuresBeforeReserve ?? DEFAULT_FAILURES_BEFORE_RESERVE;
+  const probeTimeoutMs = deps.probeTimeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS;
+  const probe = deps.probe ?? (async () => {
+    const result = await probeLockHolderOwner({ timeoutMs: probeTimeoutMs });
+    if (result.kind !== 'owner-alive') return false;
+    return deps.expectedOwnerId === undefined || result.ownerId === deps.expectedOwnerId;
+  });
+
+  let consecutiveFailures = 0;
+  let busy = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  const tick = async (): Promise<void> => {
+    if (busy) return;
+    busy = true;
+    try {
+      let reachable = false;
+      try {
+        reachable = await probe();
+      } catch {
+        reachable = false;
+      }
+      if (reachable) {
+        if (consecutiveFailures >= failuresBeforeReserve) {
+          deps.log('info', '[owner-socket-sentinel] owner socket is reachable again');
+        }
+        consecutiveFailures = 0;
+        return;
+      }
+      consecutiveFailures++;
+      if (consecutiveFailures < failuresBeforeReserve) {
+        deps.log(
+          'warn',
+          `[owner-socket-sentinel] owner socket probe failed (${consecutiveFailures}/${failuresBeforeReserve})`,
+        );
+        return;
+      }
+      deps.log(
+        'warn',
+        `[owner-socket-sentinel] owner socket unreachable ${consecutiveFailures} consecutive times — re-serving as writer-lock holder`,
+      );
+      deps.reserve();
+    } finally {
+      busy = false;
+    }
+  };
+
+  return {
+    tick,
+    start() {
+      if (timer) return;
+      timer = setInterval(() => void tick(), intervalMs);
+      timer.unref?.();
+    },
+    stop() {
+      clearInterval(timer);
+      timer = undefined;
+    },
+  };
+}

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -697,6 +697,30 @@ export class IpcBus implements MessageBus {
     return this.readyPromise;
   }
 
+  /** True when this bus currently owns the listening socket. */
+  isServing(): boolean {
+    return this.server !== null;
+  }
+
+  /**
+   * Authoritatively (re)bind the socket. Only for a process that holds the DB
+   * writer lock: it drops any client peers, closes a stale server, and serves
+   * fresh — reclaiming a socket path that was deleted or taken while this
+   * process remained the rightful owner.
+   */
+  serveAsOwner(): void {
+    if (this.disconnected || !this.allowServe) return;
+    for (const peer of this.peers) {
+      peer.destroy();
+    }
+    this.peers.clear();
+    if (this.server) {
+      this.server.close();
+      this.server = null;
+    }
+    this.tryServe();
+  }
+
   disconnect(): void {
     this.disconnected = true;
     this.subscribers.clear();


### PR DESCRIPTION
## Summary

The Aug 4 outage happened because a process can hold the DB writer lock while its IPC socket is gone. Nothing notices, so the owner stays unreachable forever.

This PR makes lock-holding owners notice. A sentinel pings the owner's own socket path every 15s through a fresh client connection.

After two consecutive failed pings — vanished socket file, lost takeover, or a foreign ownerId answering — the owner re-serves the socket via the new `IpcBus.serveAsOwner()`.

Both long-lived owner shapes run it: the GUI owner and owner-serve. The sentinel stops on shutdown alongside the writer lock release.

## Review Claim

Any process holding the DB writer lock continuously proves its own socket answers as itself on the message bus, and authoritatively re-binds the socket within ~30s when it does not.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The probe is a read-only ping; re-binding happens only inside a process that currently holds the DB writer lock and never touches the DB; `IpcBus.serveAsOwner()` is inert on client-only buses; nothing outside the lock holder is signalled or terminated.

## Slice Rationale

This enforces the invariant the previous stack entry diagnoses — the DB holder must be reachable — so the deadlock heals instead of stranding relaunches. `serveAsOwner` ships here because the sentinel is its only caller.

## Non-goals

No change to spawn-failure handling (previous PR), no supervisor messaging (next PR), no change to when the socket file may be unlinked during startup election (PR 4).

## Visual Proof

No window/UI behavior changes (the main.ts edits wire the sentinel into owner startup/shutdown); the observable surface is socket behavior. Capture shows the real Unix-socket test on this branch: the socket file is unlinked under a live server, a client is stranded, `serveAsOwner()` re-binds, and a fresh client's ping answers again.

![this branch: sentinel unit tests and real socket-reclaim integration test passing](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260804-37db96/sentinel-tests.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test` (owner-socket-sentinel.test.ts: 4 sentinel unit tests + 1 real-socket serveAsOwner integration test)
- [x] `cd packages/transport && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 29c177176`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)