### PR TITLE
[Owner Split-Brain Recovery](4) Never unlink a possibly-live IPC socket before binding

### DIFF
--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { join, dirname } from 'node:path';
-import { existsSync, mkdtempSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -522,6 +522,60 @@ describe('IpcBus', () => {
     busA.subscribe('ch', (msg: string) => received.push(msg));
     busA.publish('ch', 'ok');
     expect(received).toEqual(['ok']);
+  });
+
+  it('never unlinks a live server socket when connect fails with an unexpected error', async () => {
+    const sock = tempSocketPath();
+
+    const server = createBus(sock);
+    await server.ready();
+    server.onRequest<string, string>('echo', (value) => `owner:${value}`);
+
+    chmodSync(sock, 0o000);
+    const blocked = createBus(sock);
+    await blocked.ready();
+    await sleep(100);
+
+    expect(existsSync(sock)).toBe(true);
+    expect(server.isServing()).toBe(true);
+
+    chmodSync(sock, 0o777);
+    await waitFor(() => !blocked.isServing(), 2000);
+    await sleep(200);
+
+    expect(server.isServing()).toBe(true);
+    expect(blocked.isServing()).toBe(false);
+    const result = await blocked.request<string, string>('echo', 'ok');
+    expect(result).toBe('owner:ok');
+  });
+
+  it('still reclaims a stale socket file left behind by a crashed server', async () => {
+    const sock = tempSocketPath();
+
+    const crashed = spawn(process.execPath, [
+      '-e',
+      "const s = require('node:net').createServer(() => {}); s.listen(process.argv[1], () => process.stdout.write('ready'));",
+      sock,
+    ]);
+    await new Promise<void>((resolve) => {
+      crashed.stdout.on('data', (chunk: Buffer) => {
+        if (chunk.toString().includes('ready')) resolve();
+      });
+    });
+    crashed.kill('SIGKILL');
+    await new Promise<void>((resolve) => crashed.on('exit', () => resolve()));
+    expect(existsSync(sock)).toBe(true);
+
+    const owner = createBus(sock);
+    await owner.ready();
+    await waitFor(() => owner.isServing(), 2000);
+    owner.onRequest<string, string>('echo', (value) => `owner:${value}`);
+
+    const client = new IpcBus(sock, { allowServe: false });
+    buses.push(client);
+    await client.ready();
+    const result = await client.request<string, string>('echo', 'ok');
+    expect(result).toBe('owner:ok');
   });
 
   it('surviving client reclaims the socket after the original server disappears', async () => {

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -331,33 +331,35 @@ export class IpcBus implements MessageBus {
     });
 
     sock.on('error', (err: NodeJS.ErrnoException) => {
-      if (err.code === 'ECONNREFUSED' || err.code === 'ENOENT') {
-        if (!this.allowServe) {
-          this.resolveReady();
-          return;
-        }
-        // No server yet — try to become the server.
-        this.tryServe();
+      if (!this.allowServe) {
+        this.resolveReady();
+        return;
+      }
+      if (err.code === 'ECONNREFUSED') {
+        // Safety invariant: only a refused connect proves the socket file is
+        // dead, so this is the sole path allowed to reclaim (unlink) it.
+        this.tryServe(true);
+      } else if (err.code === 'ENOENT') {
+        this.tryServe(false);
       } else {
-        if (!this.allowServe) {
-          this.resolveReady();
-          return;
-        }
-        // Unexpected error — still try to serve.
-        this.tryServe();
+        // Safety invariant: on any other error the server may be alive —
+        // never unlink its socket; retry connecting instead.
+        this.resolveReady();
+        this.scheduleRecovery();
       }
     });
   }
 
-  private tryServe(): void {
+  private tryServe(reclaimStale: boolean): void {
     // Ensure directory exists.
     mkdirSync(dirname(this.socketPath), { recursive: true });
 
-    // Clean stale socket file before binding.
-    try {
-      unlinkSync(this.socketPath);
-    } catch {
-      // File may not exist — fine.
+    if (reclaimStale) {
+      try {
+        unlinkSync(this.socketPath);
+      } catch {
+        // File may not exist — fine.
+      }
     }
 
     const srv = createServer((client) => {
@@ -387,14 +389,14 @@ export class IpcBus implements MessageBus {
 
     sock.on('error', () => {
       if (this.allowServe) {
-        this.scheduleServeRecovery();
+        this.scheduleRecovery();
       }
       // Nothing else we can do synchronously — resolve ready so callers don't hang forever.
       this.resolveReady();
     });
   }
 
-  private scheduleServeRecovery(): void {
+  private scheduleRecovery(): void {
     if (this.disconnected || !this.allowServe || this.server || this.peers.size > 0 || this.serveRetryScheduled) {
       return;
     }
@@ -404,7 +406,7 @@ export class IpcBus implements MessageBus {
       if (this.disconnected || !this.allowServe || this.server || this.peers.size > 0) {
         return;
       }
-      this.tryServe();
+      this.tryConnect();
     }, 25).unref?.();
   }
 
@@ -425,12 +427,12 @@ export class IpcBus implements MessageBus {
     sock.on('data', (chunk: Buffer) => decoder.push(chunk));
     sock.on('close', () => {
       this.peers.delete(sock);
-      this.scheduleServeRecovery();
+      this.scheduleRecovery();
     });
     sock.on('error', () => {
       sock.destroy();
       this.peers.delete(sock);
-      this.scheduleServeRecovery();
+      this.scheduleRecovery();
     });
   }
 
@@ -718,7 +720,7 @@ export class IpcBus implements MessageBus {
       this.server.close();
       this.server = null;
     }
-    this.tryServe();
+    this.tryServe(true);
   }
 
   disconnect(): void {


### PR DESCRIPTION
## Summary

During the Aug 4 outage, every doomed relaunch could unlink the live owner's socket file on its way down: `tryServe` unlinked the path unconditionally before binding.

Now the socket file is only unlinked when a preceding connect attempt was refused — proof nothing accepts on it — or when the authoritative writer-lock holder re-binds via `serveAsOwner()`.

Unexpected connect errors (EACCES, EAGAIN) no longer serve-steal; the bus resolves ready and keeps reconnecting. Peer-loss takeover goes through reconnect-first, so it can never unlink a live server's socket either.

## Review Claim

Unlinking the IPC socket file is gated on proof of death (a refused connect) or writer-lock authority, in one place, without changing single-server election on a healthy boot.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The two legitimate serve paths behave exactly as before — serve fresh when no socket file exists, reclaim after a refused connect — so server election is unchanged; only the paths that could unlink a live socket are closed.

## Slice Rationale

This closes the transport-side entry into the lock-holder deadlock independently of the app-layer stack entries: even a process about to die on the writer lock can no longer take the live owner's socket down with it.

## Non-goals

No wire-format or channel changes, no change to `serveAsOwner()` semantics (introduced in the sentinel PR), no app-layer changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/transport && pnpm test` (50 passed, including: live server survives another bus's EACCES connect attempt; socket file left behind by a SIGKILLed server is still reclaimed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e4bf293e2`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)