### PR TITLE
[Autofix Worker Stdout Truncation](1)[REFACTOR: Move Method] Extract flushOutputStream into a shared headless-stdio module

### DIFF
--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -30,6 +30,7 @@ import {
 } from './headless-owner-bootstrap.js';
 import { loadConfig, type InvokerConfig } from './config.js';
 import { BOLD, RESET } from './headless-shared.js';
+import { flushOutputStream } from './headless-stdio.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 import {
   discoverOwner,
@@ -78,12 +79,6 @@ async function runElectronHeadless(args: string[]): Promise<number> {
       }
       resolveExit(code ?? 0);
     });
-  });
-}
-
-async function flushOutputStream(stream: NodeJS.WriteStream): Promise<void> {
-  await new Promise<void>((resolve) => {
-    stream.write('', () => resolve());
   });
 }
 

--- a/packages/app/src/headless-stdio.ts
+++ b/packages/app/src/headless-stdio.ts
@@ -1,0 +1,11 @@
+/**
+ * A pending `process.stdout`/`process.stderr` write to a pipe is asynchronous
+ * in Node; `process.exit()` does not wait for it to drain. Await this before
+ * exiting after writing output that a parent process captures (e.g. via
+ * `execSync`), or large payloads silently truncate at the OS pipe buffer size.
+ */
+export async function flushOutputStream(stream: NodeJS.WriteStream): Promise<void> {
+  await new Promise<void>((resolve) => {
+    stream.write('', () => resolve());
+  });
+}


### PR DESCRIPTION
## Summary

The headless CLI has a small helper that waits for a stdout write to finish before the process exits.

It only lived inside one file. This slice relocates it into its own module so a second file can call the same, already-working code instead of writing its own copy.

Nothing about behavior changes here. The one caller that used it before still calls it the same way.

## Review Claim

Approve a Move Method: relocating the existing `flushOutputStream` helper into its own file and updating its one caller's import, with no logic change.

## Review Lane

refactor

## Review Unit

activation-surface

## Safety Invariant

The relocated helper is byte-for-byte the same logic that has been live in `packages/app/src/headless-client.ts` since 2026-04-27 (commit `5b7233b8a`). Its existing caller is untouched aside from the import path, and the full `headless-client.test.ts` suite (39 tests) still passes unchanged against it.

## Slice Rationale

A later slice in this stack needs a second file to call this exact helper. Landing the relocation on its own, ahead of that, keeps the later slice to a one-line change instead of bundling this plumbing with a behavior fix.

## Non-goals

No behavior change. This slice does not touch any call site's control flow, add a new caller, or change what gets written to stdout.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- src/__tests__/headless-client.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert dd74078c7` for the newest slice first, or `git revert <this-commit-sha>` in isolation once no later slice depends on the new file
- Post-revert steps: None
- Data migration? No

</details>
