### PR TITLE
[Autofix Worker Stdout Truncation](3) Await flushOutputStream before exiting the headless query CLI

### DIFF
--- a/packages/app/src/__tests__/fixtures/large-json-payload.mjs
+++ b/packages/app/src/__tests__/fixtures/large-json-payload.mjs
@@ -1,0 +1,10 @@
+// Shared by write-then-exit-buggy.mjs and write-then-flush-then-exit-fixed.ts:
+// a JSON payload comfortably over the ~64KB OS pipe buffer, so a truncated
+// write is unambiguous.
+export function buildLargePayload() {
+  return JSON.stringify(Array.from({ length: 3000 }, (_, i) => ({
+    id: `wf-${i}`,
+    description: `synthetic workflow row ${i} padded-padded-padded-padded-padded`,
+    status: 'completed',
+  })));
+}

--- a/packages/app/src/__tests__/fixtures/write-then-exit-buggy.mjs
+++ b/packages/app/src/__tests__/fixtures/write-then-exit-buggy.mjs
@@ -1,0 +1,9 @@
+// The historical bug at packages/app/src/main.ts (pre-fix): write to a piped
+// stdout, then exit immediately without waiting for the write to flush.
+// Used as the "before" half of the regression test in ../headless-stdio-flush.test.ts.
+import { buildLargePayload } from './large-json-payload.mjs';
+
+const payload = buildLargePayload();
+process.stderr.write(JSON.stringify({ expectedLength: payload.length }));
+process.stdout.write(payload);
+process.exit(0);

--- a/packages/app/src/__tests__/fixtures/write-then-flush-then-exit-fixed.mts
+++ b/packages/app/src/__tests__/fixtures/write-then-flush-then-exit-fixed.mts
@@ -1,0 +1,16 @@
+// Uses the real, shared flushOutputStream helper that both
+// packages/app/src/main.ts and packages/app/src/headless-client.ts rely on to
+// avoid truncating a piped stdout write before process.exit().
+// Used as the "after" half of the regression test in ../headless-stdio-flush.test.ts.
+import { flushOutputStream } from '../../headless-stdio.ts';
+import { buildLargePayload } from './large-json-payload.mjs';
+
+async function main(): Promise<void> {
+  const payload = buildLargePayload();
+  process.stderr.write(JSON.stringify({ expectedLength: payload.length }));
+  process.stdout.write(payload);
+  await flushOutputStream(process.stdout);
+  process.exit(0);
+}
+
+main();

--- a/packages/app/src/__tests__/headless-stdio-flush.test.ts
+++ b/packages/app/src/__tests__/headless-stdio-flush.test.ts
@@ -1,0 +1,38 @@
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { buildLargePayload } from './fixtures/large-json-payload.mjs';
+
+// Regression test for the bug that silently truncated `--headless query
+// workflows --output json`: process.stdout.write() to a pipe is asynchronous
+// in Node, and process.exit() does not wait for it to flush, so payloads over
+// the ~64KB OS pipe buffer get cut off when a parent process captures this
+// process's stdout (e.g. via execFileSync, exactly as both fixtures below are
+// invoked). This must spawn a real child process and read its stdout through
+// a real OS pipe — an in-process call or a mocked stream cannot reproduce the
+// race, which is exactly why no earlier test caught the original bug.
+const buggyFixturePath = fileURLToPath(new URL('./fixtures/write-then-exit-buggy.mjs', import.meta.url));
+const fixedFixturePath = fileURLToPath(new URL('./fixtures/write-then-flush-then-exit-fixed.mts', import.meta.url));
+const expectedPayload = buildLargePayload();
+
+describe('flushOutputStream regression (main.ts / headless-client.ts write-then-exit)', () => {
+  it('the historical write-then-exit pattern truncates a large piped payload', () => {
+    const result = execFileSync(process.execPath, [buggyFixturePath], {
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    expect(result.length).toBeLessThan(expectedPayload.length);
+    expect(() => JSON.parse(result)).toThrow(/Unterminated string|Unexpected end of JSON input/);
+  });
+
+  it('flushOutputStream (the real, shared helper) prevents truncation of the same payload', () => {
+    const result = execFileSync(process.execPath, [fixedFixturePath], {
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    expect(result.length).toBe(expectedPayload.length);
+    expect(JSON.parse(result)).toEqual(JSON.parse(expectedPayload));
+  });
+});

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -30,6 +30,7 @@ import {
 } from './headless-owner-bootstrap.js';
 import { loadConfig, type InvokerConfig } from './config.js';
 import { BOLD, RESET } from './headless-shared.js';
+import { flushOutputStream } from './headless-stdio.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 import {
   discoverOwner,
@@ -78,12 +79,6 @@ async function runElectronHeadless(args: string[]): Promise<number> {
       }
       resolveExit(code ?? 0);
     });
-  });
-}
-
-async function flushOutputStream(stream: NodeJS.WriteStream): Promise<void> {
-  await new Promise<void>((resolve) => {
-    stream.write('', () => resolve());
   });
 }
 

--- a/packages/app/src/headless-stdio.ts
+++ b/packages/app/src/headless-stdio.ts
@@ -1,0 +1,11 @@
+/**
+ * A pending `process.stdout`/`process.stderr` write to a pipe is asynchronous
+ * in Node; `process.exit()` does not wait for it to drain. Await this before
+ * exiting after writing output that a parent process captures (e.g. via
+ * `execSync`), or large payloads silently truncate at the OS pipe buffer size.
+ */
+export async function flushOutputStream(stream: NodeJS.WriteStream): Promise<void> {
+  await new Promise<void>((resolve) => {
+    stream.write('', () => resolve());
+  });
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -167,6 +167,7 @@ import {
 } from './headless.js';
 import { printHeadlessUsage } from './headless-usage.js';
 import { buildHeadlessApiServerDeps } from './headless-shared.js';
+import { flushOutputStream } from './headless-stdio.js';
 import { parseReviewGatePrNumber, repairReviewGateCiByPr } from './review-gate-ci-repair-command.js';
 import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
 import {
@@ -986,6 +987,7 @@ function startHeadlessMode(): void {
         delegationBus.disconnect();
         if (delegated && typeof delegated.output === 'string') {
           process.stdout.write(delegated.output);
+          await flushOutputStream(process.stdout);
           process.exit(0);
           return;
         }


### PR DESCRIPTION
## Summary

One CLI command wrote its answer to stdout and exited on the same line, with no wait in between.

Under load, exiting that fast can cut the answer off before the operating system finishes handing it to whatever is reading it.

That silently broke the tool that watches CI and files repair work: every attempt to read its own status crashed on cut-off output, so it never filed anything.

This change adds the one missing wait, using the shared helper from the first slice in this stack.

## Review Claim

Approve inserting one awaited call before `process.exit(0)` in the read-only query branch of `startHeadlessMode`, so a large answer finishes writing before the process exits.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`process.exit()` itself is unchanged and still runs right after; only a wait for the pending write is added before it, so callers that depend on this process actually terminating are unaffected. The prior slice's test proves the added wait is what prevents the cutoff. The existing suite for this dispatch branch, plus a full package test run, both pass unchanged.

## Slice Rationale

The previous two slices establish the shared fix and prove it works in isolation. This slice is the one line that actually applies it to the branch that was broken, kept minimal so a reviewer can see exactly what changed in the real code path.

## Non-goals

This does not change routing logic, add new commands, or touch any other exit path in this file. Other `process.exit()` call sites in the same file were reviewed and write only small, fixed-size text, so they are out of scope here.

## Visual Proof

This slice has no GUI/window changes — `main.ts` only trips the path-based visual-proof requirement because it is the Electron main entrypoint. The behavior itself is CLI-only, so the proof here is a terminal transcript rather than an app screenshot. There is no single UI element transitioning state here: the two panels are two independent, real command transcripts shown side by side for comparison, not frames of one animation.

Left panel: real `invoker.log` output showing a worker tick crashing on truncated JSON, unpatched. Right panel: the same command run against the live, already-running owner process with the fix applied, returning complete JSON, followed by the autofix sweep finally filing its 11 known repairs.

![Left: a worker tick crashing on truncated JSON, unpatched. Right: the same command returning complete JSON with the fix applied, and the autofix sweep filing its 11 known repairs.](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260804-1d9bf1/autofix-stdout-truncation-terminal-comparison.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- src/__tests__/headless-stdio-flush.test.ts`
- [ ] `cd packages/app && pnpm test`
- [ ] `bash -c 'source scripts/headless-lib.sh && headless_query query workflows --output json' | node -e "JSON.parse(require('fs').readFileSync(0,'utf8')); console.log('OK')"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
