### PR TITLE
[Babysit Requeue Budget](1) Treat a pending Mergify queue request as in-flight

### DIFF
--- a/scripts/mergify_admin_requeue_model.py
+++ b/scripts/mergify_admin_requeue_model.py
@@ -332,9 +332,13 @@ def payload_state(payload: Mapping[str, object], body: str) -> str:
             return "dequeued"
         if "queue" in value:
             return "queued"
+        if value == "waiting":
+            return "waiting"
     low = body.lower()
     if "left the queue" in low or "dequeued" in low:
         return "dequeued"
+    if "waiting for queue conditions" in low:
+        return "waiting"
     if "queued" in low or "entered the queue" in low:
         return "queued"
     return "unknown"

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -105,7 +105,16 @@ def is_queue_only_required_check(name: str) -> bool:
 
 def has_active_queue_event(pr: PrSnapshot) -> bool:
     latest = pr.latest_mergify
-    if not latest or latest.queue_rule_name != "admin-bypass" or latest.state not in ACTIVE_QUEUE_STATES:
+    if not latest:
+        return False
+    # A pending `queue` command reports state "waiting" with a null queue
+    # rule while Mergify evaluates its conditions; requeueing on top of it is
+    # a duplicate Mergify ignores but the retry-cap ledger still counts.
+    if latest.state == "waiting":
+        if latest.head_sha and latest.head_sha != pr.head_ref_oid:
+            return "queued" in pr.labels
+        return True
+    if latest.queue_rule_name != "admin-bypass" or latest.state not in ACTIVE_QUEUE_STATES:
         return False
     if latest.head_sha == pr.head_ref_oid:
         return True

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -241,7 +241,7 @@ def parse_mergify_queue_event(comment: Mapping[str, object]) -> MergifyQueueEven
         comment_id=str(comment.get("id") or comment.get("databaseId") or ""),
         state=payload_state(payload, body),
         queue_rule_name=payload_rule(payload, body),
-        queued_at=str(comment.get("updated_at") or comment.get("created_at") or ""),
+        queued_at=str(comment.get("created_at") or comment.get("updated_at") or ""),
         head_sha=head_sha,
         waiting_for=section_items(body, "Waiting for"),
         failing_checks=failing_checks or reason_failed_checks(body),

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -489,6 +489,17 @@ class PlanStackActions(PlannerTestCase):
         self.assertEqual(plan.actions, ())
         self.assertEqual(plan.wait_reason, "bottom-already-queued")
 
+    def test_pending_queue_command_suppresses_requeue(self):
+        # Incident 2026-08-04 (PR #7420): a `queue` command still evaluating
+        # its conditions reports state "waiting" with no queue rule. Firing
+        # another requeue is a duplicate Mergify ignores, but it still burns
+        # retry-cap budget, so the planner must wait instead.
+        snapshot = pr(
+            labels=frozenset({"admin-bypass"}),
+            latest_mergify=event(state="waiting", head="", queue_rule_name=""),
+        )
+        self.assertEqual(self._plan(snapshot), ())
+
     def test_stale_active_queue_event_without_queued_label_requeues_current_head(self):
         snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="queued", head="b" * 40))
         actions = self._plan(snapshot)

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -55,6 +55,40 @@ on draft #4242
 }
 
 
+# A real Mergify "waiting" status comment, posted after an `@mergifyio queue`
+# command while its queue conditions are still being evaluated. Note the
+# payload carries `"state": "waiting"` with a null queue_rule_name.
+MERGIFY_WAITING_COMMENT = {
+    "user": {"login": "mergify[bot]"},
+    "id": "c-9002",
+    "created_at": "2026-07-07T05:10:00Z",
+    "updated_at": "2026-07-07T05:10:00Z",
+    "html_url": "https://github.com/o/r/pull/4242#issuecomment-9002",
+    "body": """\
+<!---
+DO NOT EDIT
+-*- Mergify Payload -*-
+{"version": 1, "state": "waiting", "queue_rule_name": null, "queued_at": null}
+-*- Mergify Payload End -*-
+-->
+
+# Merge Queue Status
+
+- \U0001f7e0 **Waiting for queue conditions**
+- ⏳ Enter queue
+- ⏳ Run checks
+- ⏳ Merge
+
+<details>
+<summary><strong>Waiting for</strong></summary>
+
+- [ ] `-conflict` [\U0001f4cc queue requirement]
+
+</details>
+""",
+}
+
+
 class ParseMergifyQueueEvent(unittest.TestCase):
     def test_ignores_comments_not_from_mergify(self):
         # Only Mergify's own comments describe the queue; a human/bot comment
@@ -80,6 +114,30 @@ class ParseMergifyQueueEvent(unittest.TestCase):
         self.assertEqual(event.failing_checks, ("build (ubuntu-latest)",))
         self.assertEqual(event.comment_id, "c-9001")
         self.assertEqual(event.queued_at, "2026-07-07T05:00:00Z")
+
+    def test_parses_waiting_command_comment_into_event(self):
+        # Incident 2026-08-04 (PR #7420): a pending `queue` command reports
+        # `state: "waiting"` with no queue rule; it must not parse as
+        # "unknown" or the planner cannot tell a command is in flight.
+        event = s.parse_mergify_queue_event(MERGIFY_WAITING_COMMENT)
+        assert event is not None
+        self.assertEqual(event.state, "waiting")
+        self.assertEqual(event.queue_rule_name, "")
+        self.assertEqual(event.head_sha, "")
+
+    def test_edited_stale_dequeue_comment_does_not_outrank_newer_waiting_comment(self):
+        # Incident 2026-08-04 (PR #7420): Mergify edited the old "dequeued"
+        # status comment one second after posting the new "waiting" comment,
+        # so ordering by updated_at resurfaced the stale dequeue event and the
+        # planner kept requeueing into the retry cap. Creation order is the
+        # command order; in-place edits must not promote an old event.
+        stale_dequeue = dict(MERGIFY_DEQUEUE_COMMENT)
+        stale_dequeue["created_at"] = "2026-07-07T05:00:00Z"
+        stale_dequeue["updated_at"] = "2026-07-07T05:10:01Z"
+        detail = {"number": 4242, "headRefOid": HEAD, "state": "OPEN"}
+        snap = s.snapshot_from_detail(detail, [stale_dequeue, MERGIFY_WAITING_COMMENT], required_checks=[])
+        assert snap.latest_mergify is not None
+        self.assertEqual(snap.latest_mergify.state, "waiting")
 
 
 class GhCommandFailures(unittest.TestCase):


### PR DESCRIPTION
## Summary

On 2026-08-04, PR #7420 exhausted its requeue budget without ever re-entering the merge queue. Both attempts were spent while an earlier `@mergifyio queue` request was still pending.

Mergify reports a pending request as payload state `waiting`. The babysit snapshot layer had no mapping for it, so the planner could not tell a request was in flight.

Worse, Mergify edited the older `dequeued` status comment one second after posting the `waiting` one. Ordering events by comment update time resurfaced the stale `dequeued` event.

Each babysit tick then fired another requeue, which Mergify ignored as a duplicate while the retry-cap ledger still counted it. The cap tripped with zero real queue runs.

This change parses `waiting` as its own event state, orders queue events by comment creation time, and makes the planner wait while a queue request is pending.

## Review Claim

A pending `@mergifyio queue` request (Mergify payload state `waiting`) must count as an active queue event, so the babysit planner waits instead of spending retry budget on duplicates.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the babysit tooling in `scripts/mergify_admin_requeue_*.py` changes; no product package is touched. When no `waiting` event exists and no status comment was edited after creation, planner decisions are identical to before.

## Slice Rationale

One incident, one fix: all three edits are needed together for the planner to notice a pending queue request and stand down. Landing them separately would leave the retry cap still reachable.

## Non-goals

- No change to retry-cap accounting itself (`max_requeue_attempts` stays 2).
- No change to how `dequeued` or `queued` events are parsed.
- No change to product packages or to the durable per-task auto-fix cap.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 scripts/test_mergify_admin_requeue_snapshot.py`
- [ ] `python3 scripts/test_mergify_admin_requeue_plan.py`
- [ ] `python3 scripts/test_mergify_admin_requeue.py`
- [ ] `python3 scripts/test_mergify_admin_requeue_model.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
