### PR TITLE
[Planning Gate Parity](2) Revert tracked-file edits made by pre-approval agent turns

### DIFF
--- a/packages/surfaces/src/__tests__/slack-agent-edit-guard-repro.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-agent-edit-guard-repro.e2e.test.ts
@@ -52,26 +52,30 @@ describe('Slack agent-mode pre-approval edit guard (repro for the pink-theme inc
     mockSpawn.mockReset();
   });
 
-  it('a mention turn that edits a tracked file leaves the edit in the working tree with no revert and no warning', async () => {
+  it('a mention turn that edits a tracked file has the edit reverted, keeps new repro artifacts, and says so in the reply', async () => {
     const workingDir = initSandboxRepo();
     const conversation = new PlanConversation({ mode: 'agent', workingDir, threadTs: 'thread-pink' });
     try {
       plannerTurn(
         'Done. Changed: index.css retheme to pink.',
-        () => writeFileSync(join(workingDir, 'index.css'), ':root { --background: 40 14 28; }\n'),
+        () => {
+          writeFileSync(join(workingDir, 'index.css'), ':root { --background: 40 14 28; }\n');
+          writeFileSync(join(workingDir, 'repro.txt'), 'repro artifact\n');
+        },
       );
 
       const reply = await conversation.sendMessage('lets change the theme of the app from black to pink');
 
-      expect(porcelain(workingDir)).toBe('M index.css');
-      expect(readFileSync(join(workingDir, 'index.css'), 'utf8')).toContain('40 14 28');
-      expect(reply).toBe('Done. Changed: index.css retheme to pink.');
+      expect(porcelain(workingDir)).toBe('?? repro.txt');
+      expect(readFileSync(join(workingDir, 'index.css'), 'utf8')).toContain('10 10 10');
+      expect(reply).toContain('Done. Changed: index.css retheme to pink.');
+      expect(reply).toContain('tracked-file edits from this pre-approval session were reverted');
     } finally {
       rmSync(workingDir, { recursive: true, force: true });
     }
   });
 
-  it('the agent-mode system prompt authorizes tracked-file edits and never requires a plan for them', async () => {
+  it('the agent-mode system prompt no longer authorizes tracked-file edits', async () => {
     const workingDir = initSandboxRepo();
     const conversation = new PlanConversation({ mode: 'agent', workingDir, threadTs: 'thread-pink' });
     try {
@@ -79,10 +83,9 @@ describe('Slack agent-mode pre-approval edit guard (repro for the pink-theme inc
       await conversation.sendMessage('lets change the theme of the app from black to pink');
 
       const prompt = mockSpawn.mock.calls[0][1]!.filter((a): a is string => typeof a === 'string').join('\n');
-      expect(prompt).toContain('edit code, and run focused verification when useful');
-      expect(prompt).toContain('Inside your worktree you are unrestricted');
-      expect(prompt).not.toMatch(/require[sd]? an? (Invoker )?plan/i);
-      expect(prompt).not.toContain('cannot modify tracked files');
+      expect(prompt).toContain('cannot modify tracked files');
+      expect(prompt).toContain('route code changes through a plan');
+      expect(prompt).not.toContain('edit code, and run focused verification when useful');
     } finally {
       rmSync(workingDir, { recursive: true, force: true });
     }

--- a/packages/surfaces/src/slack/agent-turn-verification.ts
+++ b/packages/surfaces/src/slack/agent-turn-verification.ts
@@ -57,3 +57,7 @@ export function looksLikeCompletionClaim(replyText: string): boolean {
 export function buildUnverifiedNotice(): string {
   return 'Note: no working-tree changes or new commits were detected in this session checkout, so this completion summary could not be verified.';
 }
+
+export function buildTrackedChangesRevertedNotice(): string {
+  return 'Note: tracked-file edits from this pre-approval session were reverted. New repro artifacts were kept. To execute changes through review, ask for a plan with `/plan`.';
+}

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -20,10 +20,13 @@ import type { HarnessSessionDriver } from '@invoker/execution-engine';
 import { buildPlanningHandoffInstructions, isDraftingAuthorized, summarizePlanText } from '@invoker/planning-core';
 import type { LogFn } from '../surface.js';
 import {
+  buildTrackedChangesRevertedNotice,
   buildUnverifiedNotice,
   captureRepoState,
   looksLikeCompletionClaim,
   repoStateUnchanged,
+  restoreTrackedChanges,
+  trackedFilesChanged,
 } from './agent-turn-verification.js';
 
 // ── Types ───────────────────────────────────────────────────
@@ -204,7 +207,7 @@ function isDraftingAuthorizedForPrompt(messages: ConversationMessage[]): boolean
 // ── System Prompt ───────────────────────────────────────────
 
 export const SLACK_LOCAL_REPRO_POLICY = `Execution boundary:
-- Inside your worktree you are unrestricted. Read, grep, edit, build, and run tests freely. Reproducing a bug locally is always allowed and never needs permission.
+- Inside your worktree you are unrestricted for exploration: read, grep, build, run tests, and write new repro artifacts freely. Reproducing a bug locally is always allowed and never needs permission. Tracked-file edits are not kept in pre-approval sessions.
 - Never run anything that changes state outside your worktree: \`git push\`, \`gh pr create\`/\`edit\`/\`merge\`, \`gh\` label writes, \`mergify stack push\`, \`scripts/safe-stack-push.mjs\`, or \`scripts/land-stack.mjs --execute\`.
 - If the request needs any of those, stop and hand off: describe the change, post the plan, and ask the user to confirm. Do not perform it yourself and do not offer a manual workaround for it.`;
 
@@ -217,7 +220,8 @@ function buildAgentSystemPrompt(intentSignalFilePath?: string): string {
 
 Default behavior:
 - Treat the thread like an ordinary OMP/Codex coding session.
-- Answer questions, run local commands, inspect files, edit code, and run focused verification when useful.
+- Answer questions, run local commands, inspect files, and run focused verification when useful.
+- This pre-approval session cannot modify tracked files: any tracked-file edit is reverted after the turn. Write repro artifacts as new files instead, and route code changes through a plan.
 ${planIntentGuidance}
 - Keep Slack replies short and concrete: changed files, verification, and any remaining risk. Return only the final user-facing message; never include chain-of-thought, reasoning traces, tool output, or raw planner JSONL.
 - To share a generated file (screenshot, diagram, report), write it inside your worktree and link it by absolute path as a markdown link, e.g. \`[chart](/abs/path/in/worktree/chart.png)\`. Files linked that way are uploaded to the thread. Files written outside your worktree cannot be shared, so do not put artifacts in /tmp.
@@ -583,7 +587,10 @@ export class PlanConversation {
     const repoStateAfter = this.mode === 'agent'
       ? await captureRepoState(this.workingDir)
       : null;
-    if (looksLikeCompletionClaim(message) && repoStateUnchanged(repoStateBefore, repoStateAfter)) {
+    if (this.mode === 'agent' && trackedFilesChanged(repoStateBefore, repoStateAfter)) {
+      restoreTrackedChanges(this.workingDir);
+      message = `${message}\n\n${buildTrackedChangesRevertedNotice()}`;
+    } else if (looksLikeCompletionClaim(message) && repoStateUnchanged(repoStateBefore, repoStateAfter)) {
       message = `${message}\n\n${buildUnverifiedNotice()}`;
     }
     const fileDraft = this.readPlanDraftFile();


### PR DESCRIPTION
## Summary

Pre-approval Slack agent turns could silently modify tracked files in the session checkout. The guard that reverted such edits was dropped in #5788.

This PR reinstates enforcement. After an agent turn, tracked-file changes are reverted with `git restore`, new untracked repro artifacts are kept, and the reply gains an explicit notice.

The agent prompt now states the boundary: exploration is free, tracked-file edits are not kept, and code changes go through a plan.

## Review Claim

An agent-mode turn that modifies tracked files has those edits reverted and surfaced in the reply; untracked repro artifacts survive.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

Only mode `agent` turns are affected. Plan-mode turns, plan-draft files under gitignored `.invoker/`, and untracked artifacts are untouched.

## Slice Rationale

Hard enforcement lands before the routing change so no window exists where mentions can still edit silently.

## Non-goals

- Mention-to-session mode selection is unchanged here (next slice).
- No conversational-planning prompt changes.
- No change to the old thrown-error semantics: the reply is kept, with a notice appended.

## Test Plan

<details><summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test` (534 tests pass; the slice-1 repro now asserts revert + notice + kept artifacts)

</details>

## Revert Plan

<details><summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None (reverting restores silent-edit behavior; see repro slice)
- Data migration? No

</details>
