### PR TITLE
[Planning Gate Parity](3) Route plain Slack mentions into conversational planning

### DIFF
--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -144,6 +144,7 @@ async function main(): Promise<void> {
     harnessSessionDriverFactory: createHarnessSessionDriverFactory(planningCommandBuilder),
     prepareRepoCheckout: createPrepareRepoCheckout(path.join(managerHome, 'planning-clones')),
     defaultBranch: process.env.INVOKER_DEFAULT_BRANCH ?? 'master',
+    conversationalPlanning: process.env.INVOKER_SLACK_CONVERSATIONAL_PLANNING !== '0',
     repoUrl,
     defaultRepoUrl: repoUrl,
     repoAliases: runtimeConfig.repoAliases,

--- a/packages/surfaces/src/__tests__/slack-agent-edit-guard-repro.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-agent-edit-guard-repro.e2e.test.ts
@@ -52,26 +52,30 @@ describe('Slack agent-mode pre-approval edit guard (repro for the pink-theme inc
     mockSpawn.mockReset();
   });
 
-  it('a mention turn that edits a tracked file leaves the edit in the working tree with no revert and no warning', async () => {
+  it('a mention turn that edits a tracked file has the edit reverted, keeps new repro artifacts, and says so in the reply', async () => {
     const workingDir = initSandboxRepo();
     const conversation = new PlanConversation({ mode: 'agent', workingDir, threadTs: 'thread-pink' });
     try {
       plannerTurn(
         'Done. Changed: index.css retheme to pink.',
-        () => writeFileSync(join(workingDir, 'index.css'), ':root { --background: 40 14 28; }\n'),
+        () => {
+          writeFileSync(join(workingDir, 'index.css'), ':root { --background: 40 14 28; }\n');
+          writeFileSync(join(workingDir, 'repro.txt'), 'repro artifact\n');
+        },
       );
 
       const reply = await conversation.sendMessage('lets change the theme of the app from black to pink');
 
-      expect(porcelain(workingDir)).toBe('M index.css');
-      expect(readFileSync(join(workingDir, 'index.css'), 'utf8')).toContain('40 14 28');
-      expect(reply).toBe('Done. Changed: index.css retheme to pink.');
+      expect(porcelain(workingDir)).toBe('?? repro.txt');
+      expect(readFileSync(join(workingDir, 'index.css'), 'utf8')).toContain('10 10 10');
+      expect(reply).toContain('Done. Changed: index.css retheme to pink.');
+      expect(reply).toContain('tracked-file edits from this pre-approval session were reverted');
     } finally {
       rmSync(workingDir, { recursive: true, force: true });
     }
   });
 
-  it('the agent-mode system prompt authorizes tracked-file edits and never requires a plan for them', async () => {
+  it('the agent-mode system prompt no longer authorizes tracked-file edits', async () => {
     const workingDir = initSandboxRepo();
     const conversation = new PlanConversation({ mode: 'agent', workingDir, threadTs: 'thread-pink' });
     try {
@@ -79,10 +83,9 @@ describe('Slack agent-mode pre-approval edit guard (repro for the pink-theme inc
       await conversation.sendMessage('lets change the theme of the app from black to pink');
 
       const prompt = mockSpawn.mock.calls[0][1]!.filter((a): a is string => typeof a === 'string').join('\n');
-      expect(prompt).toContain('edit code, and run focused verification when useful');
-      expect(prompt).toContain('Inside your worktree you are unrestricted');
-      expect(prompt).not.toMatch(/require[sd]? an? (Invoker )?plan/i);
-      expect(prompt).not.toContain('cannot modify tracked files');
+      expect(prompt).toContain('cannot modify tracked files');
+      expect(prompt).toContain('route code changes through a plan');
+      expect(prompt).not.toContain('edit code, and run focused verification when useful');
     } finally {
       rmSync(workingDir, { recursive: true, force: true });
     }

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -1032,6 +1032,27 @@ describe('lobby verb routing', () => {
     expect(runWorkflowOp).not.toHaveBeenCalled();
   });
 
+  it('routes a build request into conversational planning when conversationalPlanning is enabled', async () => {
+    const surface = lobbySurface(true, { defaultRepoUrl: 'git@github.com:default/repo.git', conversationalPlanning: true });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> lets change the theme of the app from black to pink', ts: 't1', user: 'U1' }, say });
+    expect(planConversationConfigs).toHaveLength(1);
+    expect(planConversationConfigs[0].mode).toBe('plan');
+    expect(planConversationConfigs[0].conversationalPlanning).toBe(true);
+    expect(runWorkflowOp).not.toHaveBeenCalled();
+  });
+
+  it('keeps an explicit local: request in agent mode even when conversationalPlanning is enabled', async () => {
+    const surface = lobbySurface(true, { defaultRepoUrl: 'git@github.com:default/repo.git', conversationalPlanning: true });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> local: reproduce the flaky test', ts: 't1', user: 'U1' }, say });
+    expect(planConversationConfigs).toHaveLength(1);
+    expect(planConversationConfigs[0].mode).toBe('agent');
+    expect(runWorkflowOp).not.toHaveBeenCalled();
+  });
+
   it('treats a `plan:`-prefixed message as literal agent text, not a mode switch', async () => {
     const surface = lobbySurface(true, { defaultRepoUrl: 'git@github.com:default/repo.git' });
     await surface.start(async () => {});

--- a/packages/surfaces/src/slack/agent-turn-verification.ts
+++ b/packages/surfaces/src/slack/agent-turn-verification.ts
@@ -57,3 +57,7 @@ export function looksLikeCompletionClaim(replyText: string): boolean {
 export function buildUnverifiedNotice(): string {
   return 'Note: no working-tree changes or new commits were detected in this session checkout, so this completion summary could not be verified.';
 }
+
+export function buildTrackedChangesRevertedNotice(): string {
+  return 'Note: tracked-file edits from this pre-approval session were reverted. New repro artifacts were kept. To execute changes through review, ask for a plan with `/plan`.';
+}

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -20,10 +20,13 @@ import type { HarnessSessionDriver } from '@invoker/execution-engine';
 import { buildPlanningHandoffInstructions, isDraftingAuthorized, summarizePlanText } from '@invoker/planning-core';
 import type { LogFn } from '../surface.js';
 import {
+  buildTrackedChangesRevertedNotice,
   buildUnverifiedNotice,
   captureRepoState,
   looksLikeCompletionClaim,
   repoStateUnchanged,
+  restoreTrackedChanges,
+  trackedFilesChanged,
 } from './agent-turn-verification.js';
 
 // ── Types ───────────────────────────────────────────────────
@@ -204,7 +207,7 @@ function isDraftingAuthorizedForPrompt(messages: ConversationMessage[]): boolean
 // ── System Prompt ───────────────────────────────────────────
 
 export const SLACK_LOCAL_REPRO_POLICY = `Execution boundary:
-- Inside your worktree you are unrestricted. Read, grep, edit, build, and run tests freely. Reproducing a bug locally is always allowed and never needs permission.
+- Inside your worktree you are unrestricted for exploration: read, grep, build, run tests, and write new repro artifacts freely. Reproducing a bug locally is always allowed and never needs permission. Tracked-file edits are not kept in pre-approval sessions.
 - Never run anything that changes state outside your worktree: \`git push\`, \`gh pr create\`/\`edit\`/\`merge\`, \`gh\` label writes, \`mergify stack push\`, \`scripts/safe-stack-push.mjs\`, or \`scripts/land-stack.mjs --execute\`.
 - If the request needs any of those, stop and hand off: describe the change, post the plan, and ask the user to confirm. Do not perform it yourself and do not offer a manual workaround for it.`;
 
@@ -217,7 +220,8 @@ function buildAgentSystemPrompt(intentSignalFilePath?: string): string {
 
 Default behavior:
 - Treat the thread like an ordinary OMP/Codex coding session.
-- Answer questions, run local commands, inspect files, edit code, and run focused verification when useful.
+- Answer questions, run local commands, inspect files, and run focused verification when useful.
+- This pre-approval session cannot modify tracked files: any tracked-file edit is reverted after the turn. Write repro artifacts as new files instead, and route code changes through a plan.
 ${planIntentGuidance}
 - Keep Slack replies short and concrete: changed files, verification, and any remaining risk. Return only the final user-facing message; never include chain-of-thought, reasoning traces, tool output, or raw planner JSONL.
 - To share a generated file (screenshot, diagram, report), write it inside your worktree and link it by absolute path as a markdown link, e.g. \`[chart](/abs/path/in/worktree/chart.png)\`. Files linked that way are uploaded to the thread. Files written outside your worktree cannot be shared, so do not put artifacts in /tmp.
@@ -583,7 +587,10 @@ export class PlanConversation {
     const repoStateAfter = this.mode === 'agent'
       ? await captureRepoState(this.workingDir)
       : null;
-    if (looksLikeCompletionClaim(message) && repoStateUnchanged(repoStateBefore, repoStateAfter)) {
+    if (this.mode === 'agent' && trackedFilesChanged(repoStateBefore, repoStateAfter)) {
+      restoreTrackedChanges(this.workingDir);
+      message = `${message}\n\n${buildTrackedChangesRevertedNotice()}`;
+    } else if (looksLikeCompletionClaim(message) && repoStateUnchanged(repoStateBefore, repoStateAfter)) {
       message = `${message}\n\n${buildUnverifiedNotice()}`;
     }
     const fileDraft = this.readPlanDraftFile();

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -1132,11 +1132,12 @@ export class SlackSurface implements Surface {
         }
       }
 
+      const explicitLocalAgent = localRequest?.kind === 'agent' || localRequest?.kind === 'change';
       const opts = {
         tool: contextPreset.tool,
         model: contextPreset.model,
         workingDir,
-        mode: 'agent' as ConversationMode,
+        mode: (explicitLocalAgent || !this.conversationalPlanning ? 'agent' : 'plan') as ConversationMode,
         repoUrl: context.repoUrl,
         ...this.harnessDriverSessionOpts(contextPreset, context),
       };


### PR DESCRIPTION
## Summary

The pink-theme incident happened because a plain Slack mention always booted an edit-capable agent session. The planning terminal, on the same engine, boots a scoping-first conversational planning session.

This PR routes plain mentions into that conversational planning mode when `SlackSurfaceConfig.conversationalPlanning` is enabled. Explicit `local:` and `run local:` requests keep their agent behavior.

The slack-manager daemon enables the flag by default. Setting `INVOKER_SLACK_CONVERSATIONAL_PLANNING=0` restores the previous behavior without a deploy.

## Review Claim

With `conversationalPlanning` enabled, a plain mention starts a mode `plan` conversational session; `local:`-prefixed requests and all deterministic verbs are unchanged.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

With the flag unset at the surface level nothing changes (default stays false); lobby verbs, `/plan`, workflow-channel handling, and `local:` prefixes are untouched.

## Slice Rationale

This lands after the edit-revert guard so no ordering window allows silent edits during rollout.

## Non-goals

- No prompt changes (later slice).
- No approval-card changes (later slice).
- No change to the SlackSurface constructor default.

## Test Plan

<details><summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test` (two new tests: flag on routes to plan mode; `local:` stays agent)
- [x] `cd packages/slack-manager && pnpm test` (one pre-existing environment-dependent failure in `complaint-scout-bridge.test.ts` fails identically on clean master: expected preset `codex`, machine resolves `omp`)

</details>

## Revert Plan

<details><summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`, or set `INVOKER_SLACK_CONVERSATIONAL_PLANNING=0` for a config-only rollback
- Post-revert steps: None
- Data migration? No

</details>
