### PR TITLE
[Planning Gate Parity](5) The hosting surface, not the model, owns plan submission

### DIFF
--- a/packages/surfaces/src/__tests__/conversational-plan-submission-repro.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/conversational-plan-submission-repro.e2e.test.ts
@@ -11,26 +11,28 @@ const PINK_CONFIRMATION_ASK =
   + "and I'll convert it to the YAML workflow stack and submit.";
 
 describe('conversational planning submission ownership (repro for the pink-theme terminal incident)', () => {
-  it('the drafting-authorized conversational prompt orders the model to run review/submission itself', () => {
+  it('the drafting-authorized conversational prompt forbids self-submission and hands approval to the surface', () => {
     const prompt = buildPlanSystemPrompt('master', 'https://github.com/acme/repo.git', {
       conversationalPlanning: true,
       draftingAuthorized: true,
       planFilePath: PLAN_FILE_PATH,
     });
 
-    expect(prompt).toContain("proceed through the skill's review/submission steps");
-    expect(prompt).not.toContain('may submit the plan after approval');
-    expect(prompt).not.toMatch(/do not (?:call|run|submit).*invoker/i);
+    expect(prompt).not.toContain("proceed through the skill's review/submission steps");
+    expect(prompt).toContain('Only the hosting surface (the Slack orchestrator or the in-app planner) may submit the plan');
+    expect(prompt).toContain('Never run `invoker-cli`, `invoker_submit_plan`, `scripts/headless-ipc.js`');
+    expect(prompt).toContain("overrides the plan-to-invoker skill's Harness handoff mode");
   });
 
-  it('the conversational prompt never advertises the plan-draft file, so file-draft detection cannot stage approval', () => {
+  it('the conversational prompt advertises the plan-draft file so file-draft detection stages approval', () => {
     const prompt = buildPlanSystemPrompt('master', 'https://github.com/acme/repo.git', {
       conversationalPlanning: true,
       draftingAuthorized: true,
       planFilePath: PLAN_FILE_PATH,
     });
 
-    expect(prompt).not.toContain(PLAN_FILE_PATH);
+    expect(prompt).toContain(PLAN_FILE_PATH);
+    expect(prompt).toContain('write the COMPLETE YAML');
   });
 
   it('the direct Slack plan prompt already has both protections the conversational prompt lacks', () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -350,9 +350,15 @@ function buildConversationalPlanSystemPrompt(
   options: BuildPlanSystemPromptOptions,
 ): string {
   const draftingAuthorized = options.draftingAuthorized ?? false;
+  const handoffInstructions = buildPlanningHandoffInstructions({
+    planFilePath: options.planFilePath,
+    reviewInstruction: 'After the YAML exists, the hosting surface reads that exact YAML, renders the ordered steps in its review flow, and owns the approval step.',
+    shortReplyInstruction: 'Then reply in chat with only a one-or-two-sentence summary. Never paste the YAML into chat.',
+    submissionInstruction: 'Only the hosting surface (the Slack orchestrator or the in-app planner) may submit the plan after your draft is approved in its review flow. Never run `invoker-cli`, `invoker_submit_plan`, `scripts/headless-ipc.js`, or any other submission command yourself. This rule overrides the plan-to-invoker skill\'s Harness handoff mode in this session.',
+  });
   const draftingInstructions = draftingAuthorized
     ? `
-The user has explicitly approved drafting. Follow the plan-to-invoker skill's Harness handoff mode now: first produce a Markdown planning artifact, then convert the approved Markdown plan into a full Invoker YAML task plan, and proceed through the skill's review/submission steps (\`skill-doctor.sh\` when inside an Invoker source checkout, the MCP review/submit flow as the canonical path otherwise). Read \`skills/plan-to-invoker/SKILL.md\` for the exact steps if you need them.`
+The user has explicitly approved drafting. Produce the full Invoker YAML task plan now, using the plan shape from \`skills/plan-to-invoker/SKILL.md\` if you need the exact schema. ${handoffInstructions}`
     : `
 Drafting is not authorized yet. Do NOT output a \`\`\`yaml code block, do NOT write a draft plan file, and do NOT tell the user the plan can be executed.
 


### PR DESCRIPTION
## Summary

The conversational planning prompt's drafting-authorized branch previously delegated review and submission to the model via the plan-to-invoker skill's Harness handoff mode.

Now it uses the same handoff instructions the Slack direct-plan prompt already used. The model saves the complete YAML into the session's plan-draft file and replies with a short summary.

Submission is explicitly forbidden to the model: only the hosting surface may submit after its review flow approves. This overrides the skill's Harness handoff mode.

Because the draft lands in the advertised file, each surface's existing draft detection can stage its approval affordance: the terminal's Draft-ready bar, and the Slack review card.

## Review Claim

The drafting-authorized conversational prompt forbids model self-submission and advertises the plan-draft file, so surface draft detection stages approval.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

Only the conversational drafting-authorized prompt branch changes; the pre-authorization scoping branch, the Slack direct-plan prompt, and all draft-detection and submission code paths are untouched.

## Slice Rationale

One claim — submission ownership — kept separate from session-mode selection and approval-card staging.

## Non-goals

- No hardening of `invoker_submit_plan` against non-`draft_ready` sessions (different boundary; follow-up).
- No changes to draft detection or the approval flows themselves.

## Test Plan

<details><summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test` (slice-4 repro flipped: override present, plan-draft path advertised)
- [x] `cd packages/app && pnpm test` (two pre-existing perf/env failures reproduce identically on clean master on this machine)

</details>

## Revert Plan

<details><summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
