### PR TITLE
[Planning Gate Parity](6) Auto-stage the Slack review card when a conversational turn drafts a plan

### DIFF
--- a/packages/surfaces/src/__tests__/conversational-plan-submission-repro.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/conversational-plan-submission-repro.e2e.test.ts
@@ -11,26 +11,28 @@ const PINK_CONFIRMATION_ASK =
   + "and I'll convert it to the YAML workflow stack and submit.";
 
 describe('conversational planning submission ownership (repro for the pink-theme terminal incident)', () => {
-  it('the drafting-authorized conversational prompt orders the model to run review/submission itself', () => {
+  it('the drafting-authorized conversational prompt forbids self-submission and hands approval to the surface', () => {
     const prompt = buildPlanSystemPrompt('master', 'https://github.com/acme/repo.git', {
       conversationalPlanning: true,
       draftingAuthorized: true,
       planFilePath: PLAN_FILE_PATH,
     });
 
-    expect(prompt).toContain("proceed through the skill's review/submission steps");
-    expect(prompt).not.toContain('may submit the plan after approval');
-    expect(prompt).not.toMatch(/do not (?:call|run|submit).*invoker/i);
+    expect(prompt).not.toContain("proceed through the skill's review/submission steps");
+    expect(prompt).toContain('Only the hosting surface (the Slack orchestrator or the in-app planner) may submit the plan');
+    expect(prompt).toContain('Never run `invoker-cli`, `invoker_submit_plan`, `scripts/headless-ipc.js`');
+    expect(prompt).toContain("overrides the plan-to-invoker skill's Harness handoff mode");
   });
 
-  it('the conversational prompt never advertises the plan-draft file, so file-draft detection cannot stage approval', () => {
+  it('the conversational prompt advertises the plan-draft file so file-draft detection stages approval', () => {
     const prompt = buildPlanSystemPrompt('master', 'https://github.com/acme/repo.git', {
       conversationalPlanning: true,
       draftingAuthorized: true,
       planFilePath: PLAN_FILE_PATH,
     });
 
-    expect(prompt).not.toContain(PLAN_FILE_PATH);
+    expect(prompt).toContain(PLAN_FILE_PATH);
+    expect(prompt).toContain('write the COMPLETE YAML');
   });
 
   it('the direct Slack plan prompt already has both protections the conversational prompt lacks', () => {

--- a/packages/surfaces/src/__tests__/slack-conversational-draft-staging.test.ts
+++ b/packages/surfaces/src/__tests__/slack-conversational-draft-staging.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SlackSurface } from '../slack/slack-surface.js';
+import { SQLiteAdapter, ConversationRepository, SlackPlanDraftRepository, SlackSessionRepository, WorkflowChannelRepository } from '@invoker/data-store';
+
+interface MockHandler {
+  pattern: string | RegExp;
+  handler: Function;
+}
+
+vi.mock('@slack/bolt', () => {
+  class MockApp {
+    _commandHandlers: MockHandler[] = [];
+    _actionHandlers: MockHandler[] = [];
+    _eventHandlers: MockHandler[] = [];
+    command = vi.fn((name: string, handler: Function) => {
+      this._commandHandlers.push({ pattern: name, handler });
+    });
+    action = vi.fn((pattern: string | RegExp, handler: Function) => {
+      this._actionHandlers.push({ pattern, handler });
+    });
+    event = vi.fn((name: string, handler: Function) => {
+      this._eventHandlers.push({ pattern: name, handler });
+    });
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    client = {
+      chat: {
+        postMessage: vi.fn().mockResolvedValue({ ts: '1234567890.123456' }),
+        update: vi.fn().mockResolvedValue({}),
+        delete: vi.fn().mockResolvedValue({}),
+      },
+      auth: {
+        test: vi.fn().mockResolvedValue({ user_id: 'UBOT' }),
+      },
+      files: {
+        uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F1' }] }),
+      },
+      reactions: {
+        add: vi.fn().mockResolvedValue({}),
+        remove: vi.fn().mockResolvedValue({}),
+      },
+    };
+  }
+  return { App: MockApp };
+});
+
+const conversationInstances = new Map<string, any>();
+let nextDraftPlanText: string | null = null;
+let nextReply = 'Here are some scoping questions.';
+
+vi.mock('../slack/plan-conversation.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../slack/plan-conversation.js')>()),
+  PlanConversation: vi.fn((config: any) => {
+    const instance = {
+      _config: config,
+      workingDir: config?.workingDir,
+      submittedPlanText: null as string | null,
+      planSubmitted: false,
+      conversationMode: config?.mode ?? 'plan',
+      lastTurnDraftPlanText: null as string | null,
+      lastTurnPlanIntentSignal: null,
+      lastTurnReasoning: [] as string[],
+      init: vi.fn().mockResolvedValue(undefined),
+      getDraftedPlan: () => instance.lastTurnDraftPlanText,
+      runPlanConversion: vi.fn().mockResolvedValue(''),
+      sendMessage: vi.fn().mockImplementation(async () => {
+        instance.lastTurnDraftPlanText = nextDraftPlanText;
+        return nextReply;
+      }),
+      reset: vi.fn(),
+      history: [],
+    };
+    if (config?.threadTs) conversationInstances.set(config.threadTs, instance);
+    return instance;
+  }),
+}));
+
+const VALID_PLAN_YAML = `name: "Pink Theme Retheme"
+repoUrl: "https://github.com/example/repo.git"
+onFinish: pull_request
+mergeMode: external_review
+baseBranch: master
+tasks:
+  - id: retheme-tokens
+    description: "Swap theme tokens to pink"
+    prompt: "Edit index.css"
+    dependencies: []
+  - id: verify-tokens
+    description: "Verify"
+    command: "pnpm test"
+    dependencies: [retheme-tokens]
+`;
+
+async function buildSurface(conversationalPlanning: boolean) {
+  const adapter = await SQLiteAdapter.create(':memory:');
+  const surface = new SlackSurface({
+    botToken: 'xoxb-test',
+    appToken: 'xapp-test',
+    signingSecret: 'test-secret',
+    channelId: 'C-test',
+    cursorCommand: 'cursor',
+    workingDir: '/repo',
+    defaultRepoUrl: 'https://github.com/example/repo.git',
+    conversationalPlanning,
+    conversationRepo: new ConversationRepository(adapter),
+    slackSessionRepo: new SlackSessionRepository(adapter),
+    slackPlanDraftRepo: new SlackPlanDraftRepository(adapter),
+    workflowChannelRepo: new WorkflowChannelRepository(adapter),
+  });
+  await surface.start(async () => {});
+  return surface;
+}
+
+function mentionHandler(surface: SlackSurface): Function {
+  const app = surface.getApp() as any;
+  const handler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')?.handler;
+  if (!handler) throw new Error('app_mention handler not registered');
+  return handler;
+}
+
+describe('conversational-planning drafts stage the Slack review card automatically', () => {
+  beforeEach(() => {
+    conversationInstances.clear();
+    nextDraftPlanText = null;
+    nextReply = 'Here are some scoping questions.';
+  });
+
+  it('a conversational turn that produces a draft posts the review card and uploads the YAML', async () => {
+    const surface = await buildSurface(true);
+    const say = vi.fn().mockResolvedValue({ ts: 'reply-ts' });
+    nextReply = 'Draft ready — pink retheme in 2 steps.';
+    nextDraftPlanText = VALID_PLAN_YAML;
+
+    await mentionHandler(surface)({
+      event: { text: '<@UBOT> lets change the theme of the app from black to pink', ts: 'thread-pink', user: 'U1' },
+      say,
+    });
+
+    const cardCall = say.mock.calls.find(([msg]) => typeof msg?.text === 'string' && msg.text.includes('Pink Theme Retheme'));
+    expect(cardCall).toBeDefined();
+    const app = surface.getApp() as any;
+    expect(app.client.files.uploadV2).toHaveBeenCalledTimes(1);
+  });
+
+  it('a scoping turn with no draft stages nothing', async () => {
+    const surface = await buildSurface(true);
+    const say = vi.fn().mockResolvedValue({ ts: 'reply-ts' });
+
+    await mentionHandler(surface)({
+      event: { text: '<@UBOT> lets change the theme of the app from black to pink', ts: 'thread-scope', user: 'U1' },
+      say,
+    });
+
+    const app = surface.getApp() as any;
+    expect(app.client.chat.update).toHaveBeenCalledWith(expect.objectContaining({ text: 'Here are some scoping questions.' }));
+    expect(app.client.files.uploadV2).not.toHaveBeenCalled();
+  });
+
+  it('without conversationalPlanning a draft-producing turn does not auto-stage', async () => {
+    const surface = await buildSurface(false);
+    const say = vi.fn().mockResolvedValue({ ts: 'reply-ts' });
+    nextDraftPlanText = VALID_PLAN_YAML;
+
+    await mentionHandler(surface)({
+      event: { text: '<@UBOT> lets change the theme of the app from black to pink', ts: 'thread-legacy', user: 'U1' },
+      say,
+    });
+
+    const app = surface.getApp() as any;
+    expect(app.client.files.uploadV2).not.toHaveBeenCalled();
+  });
+});

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -350,9 +350,15 @@ function buildConversationalPlanSystemPrompt(
   options: BuildPlanSystemPromptOptions,
 ): string {
   const draftingAuthorized = options.draftingAuthorized ?? false;
+  const handoffInstructions = buildPlanningHandoffInstructions({
+    planFilePath: options.planFilePath,
+    reviewInstruction: 'After the YAML exists, the hosting surface reads that exact YAML, renders the ordered steps in its review flow, and owns the approval step.',
+    shortReplyInstruction: 'Then reply in chat with only a one-or-two-sentence summary. Never paste the YAML into chat.',
+    submissionInstruction: 'Only the hosting surface (the Slack orchestrator or the in-app planner) may submit the plan after your draft is approved in its review flow. Never run `invoker-cli`, `invoker_submit_plan`, `scripts/headless-ipc.js`, or any other submission command yourself. This rule overrides the plan-to-invoker skill\'s Harness handoff mode in this session.',
+  });
   const draftingInstructions = draftingAuthorized
     ? `
-The user has explicitly approved drafting. Follow the plan-to-invoker skill's Harness handoff mode now: first produce a Markdown planning artifact, then convert the approved Markdown plan into a full Invoker YAML task plan, and proceed through the skill's review/submission steps (\`skill-doctor.sh\` when inside an Invoker source checkout, the MCP review/submit flow as the canonical path otherwise). Read \`skills/plan-to-invoker/SKILL.md\` for the exact steps if you need them.`
+The user has explicitly approved drafting. Produce the full Invoker YAML task plan now, using the plan shape from \`skills/plan-to-invoker/SKILL.md\` if you need the exact schema. ${handoffInstructions}`
     : `
 Drafting is not authorized yet. Do NOT output a \`\`\`yaml code block, do NOT write a draft plan file, and do NOT tell the user the plan can be executed.
 

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -1173,18 +1173,37 @@ export class SlackSurface implements Surface {
       return;
     }
     const plannerOutput = await conversation.runPlanConversion();
+    await this.stageDraftReviewFromPlannerOutput(plannerOutput, conversation, channel, threadTs, userId, say, { silentWhenNotReady: false });
+  }
+
+  private async stageDraftReviewFromPlannerOutput(
+    plannerOutput: string,
+    conversation: ConversationLike,
+    channel: string,
+    threadTs: string,
+    userId: string,
+    say: SayFn,
+    opts: { silentWhenNotReady: boolean },
+  ): Promise<void> {
+    if (!this.slackPlanDraftRepo) return;
     const review = preparePlanningReview({
       plannerOutput,
       extractDraftPlanText: () => conversation.lastTurnDraftPlanText,
       confirmationMode: this.loadPlanningContext(threadTs)?.confirmationMode ?? this.defaultPlanningConfirmationMode,
     });
     if ('kind' in review) {
-      await this.sayWithRateLimitRetry(say, { text: review.reply, thread_ts: threadTs });
+      if (!opts.silentWhenNotReady) {
+        await this.sayWithRateLimitRetry(say, { text: review.reply, thread_ts: threadTs });
+      }
       return;
     }
     const draftReview = review;
     const context = this.loadPlanningContext(threadTs);
     if (!context?.repoUrl || !context.workingDir) {
+      if (opts.silentWhenNotReady) {
+        this.log('slack', 'warn', `[DRAFT_STAGE] Skipped staging draft for thread ${threadTs}: no pinned repository context.`);
+        return;
+      }
       await this.sayWithRateLimitRetry(say, {
         text: 'This thread has no pinned repository context. Start a new thread with the repository selected.',
         thread_ts: threadTs,
@@ -2726,6 +2745,15 @@ ${text}`;
           }, say);
         } catch (err) {
           this.log('slack', 'error', `[PLAN_INTENT_CONFIRM] failed to stage from auto-detect thread_ts=${threadTs}: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+        }
+      }
+
+      if (this.conversationalPlanning && conversation.conversationMode === 'plan' && conversation.lastTurnDraftPlanText) {
+        try {
+          await this.stageDraftReviewFromPlannerOutput(reply, conversation, channel, threadTs,
+            planIntentContext?.userId ?? 'unknown', say, { silentWhenNotReady: true });
+        } catch (err) {
+          this.log('slack', 'error', `[DRAFT_STAGE] failed to stage conversational draft thread_ts=${threadTs}: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
         }
       }
 


### PR DESCRIPTION
## Summary

The planning terminal shows its Draft-ready bar automatically the moment a draft exists. Slack previously showed its review card only for the explicit `/plan` flow or a manual thread verb.

Now, when `conversationalPlanning` is enabled and a plan-mode turn produces a draft, the surface stages the same Approve/Cancel review card automatically.

Scoping turns stage nothing. Deployments without the flag are unchanged. Staging failures are logged and never break the conversational reply.

## Review Claim

A conversational plan-mode turn that produces a draft stages the Slack review card automatically; scoping turns and non-conversational deployments stage nothing.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The explicit `/plan` flow's behavior and user-facing messages are unchanged; the shared helper was lifted verbatim. Staging is gated on the flag, plan mode, and a detected draft.

## Non-goals

- No changes to the Approve/Cancel button handlers.
- No changes to the auto-confirmation mode semantics.
- No terminal-side changes.

## Slice Rationale

Earlier slices make Slack produce gated drafts; this slice gives those drafts the approval affordance, completing surface parity.

## Test Plan

<details><summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test` (543 tests; three new tests cover card staged, scoping turn passive, flag-off passive)

</details>

## Revert Plan

<details><summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None (the manual thread verb still stages the card)
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversational planning turns can now automatically stage available plan drafts for review.
  * Draft reviews include a review card and uploaded YAML plan details.
  * Planning turns that refine scope update the conversation without staging a draft.

* **Bug Fixes**
  * Incomplete review states no longer produce unnecessary replies.
  * Legacy non-conversational planning behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->