### PR TITLE
[Planning Gate Parity](7) Prove the Slack bot and planning terminal now give the same experience end-to-end

### DIFF
--- a/packages/surfaces/src/__tests__/conversational-plan-submission-repro.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/conversational-plan-submission-repro.e2e.test.ts
@@ -11,26 +11,28 @@ const PINK_CONFIRMATION_ASK =
   + "and I'll convert it to the YAML workflow stack and submit.";
 
 describe('conversational planning submission ownership (repro for the pink-theme terminal incident)', () => {
-  it('the drafting-authorized conversational prompt orders the model to run review/submission itself', () => {
+  it('the drafting-authorized conversational prompt forbids self-submission and hands approval to the surface', () => {
     const prompt = buildPlanSystemPrompt('master', 'https://github.com/acme/repo.git', {
       conversationalPlanning: true,
       draftingAuthorized: true,
       planFilePath: PLAN_FILE_PATH,
     });
 
-    expect(prompt).toContain("proceed through the skill's review/submission steps");
-    expect(prompt).not.toContain('may submit the plan after approval');
-    expect(prompt).not.toMatch(/do not (?:call|run|submit).*invoker/i);
+    expect(prompt).not.toContain("proceed through the skill's review/submission steps");
+    expect(prompt).toContain('Only the hosting surface (the Slack orchestrator or the in-app planner) may submit the plan');
+    expect(prompt).toContain('Never run `invoker-cli`, `invoker_submit_plan`, `scripts/headless-ipc.js`');
+    expect(prompt).toContain("overrides the plan-to-invoker skill's Harness handoff mode");
   });
 
-  it('the conversational prompt never advertises the plan-draft file, so file-draft detection cannot stage approval', () => {
+  it('the conversational prompt advertises the plan-draft file so file-draft detection stages approval', () => {
     const prompt = buildPlanSystemPrompt('master', 'https://github.com/acme/repo.git', {
       conversationalPlanning: true,
       draftingAuthorized: true,
       planFilePath: PLAN_FILE_PATH,
     });
 
-    expect(prompt).not.toContain(PLAN_FILE_PATH);
+    expect(prompt).toContain(PLAN_FILE_PATH);
+    expect(prompt).toContain('write the COMPLETE YAML');
   });
 
   it('the direct Slack plan prompt already has both protections the conversational prompt lacks', () => {

--- a/packages/surfaces/src/__tests__/slack-conversational-draft-staging.test.ts
+++ b/packages/surfaces/src/__tests__/slack-conversational-draft-staging.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SlackSurface } from '../slack/slack-surface.js';
+import { SQLiteAdapter, ConversationRepository, SlackPlanDraftRepository, SlackSessionRepository, WorkflowChannelRepository } from '@invoker/data-store';
+
+interface MockHandler {
+  pattern: string | RegExp;
+  handler: Function;
+}
+
+vi.mock('@slack/bolt', () => {
+  class MockApp {
+    _commandHandlers: MockHandler[] = [];
+    _actionHandlers: MockHandler[] = [];
+    _eventHandlers: MockHandler[] = [];
+    command = vi.fn((name: string, handler: Function) => {
+      this._commandHandlers.push({ pattern: name, handler });
+    });
+    action = vi.fn((pattern: string | RegExp, handler: Function) => {
+      this._actionHandlers.push({ pattern, handler });
+    });
+    event = vi.fn((name: string, handler: Function) => {
+      this._eventHandlers.push({ pattern: name, handler });
+    });
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    client = {
+      chat: {
+        postMessage: vi.fn().mockResolvedValue({ ts: '1234567890.123456' }),
+        update: vi.fn().mockResolvedValue({}),
+        delete: vi.fn().mockResolvedValue({}),
+      },
+      auth: {
+        test: vi.fn().mockResolvedValue({ user_id: 'UBOT' }),
+      },
+      files: {
+        uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F1' }] }),
+      },
+      reactions: {
+        add: vi.fn().mockResolvedValue({}),
+        remove: vi.fn().mockResolvedValue({}),
+      },
+    };
+  }
+  return { App: MockApp };
+});
+
+const conversationInstances = new Map<string, any>();
+let nextDraftPlanText: string | null = null;
+let nextReply = 'Here are some scoping questions.';
+
+vi.mock('../slack/plan-conversation.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../slack/plan-conversation.js')>()),
+  PlanConversation: vi.fn((config: any) => {
+    const instance = {
+      _config: config,
+      workingDir: config?.workingDir,
+      submittedPlanText: null as string | null,
+      planSubmitted: false,
+      conversationMode: config?.mode ?? 'plan',
+      lastTurnDraftPlanText: null as string | null,
+      lastTurnPlanIntentSignal: null,
+      lastTurnReasoning: [] as string[],
+      init: vi.fn().mockResolvedValue(undefined),
+      getDraftedPlan: () => instance.lastTurnDraftPlanText,
+      runPlanConversion: vi.fn().mockResolvedValue(''),
+      sendMessage: vi.fn().mockImplementation(async () => {
+        instance.lastTurnDraftPlanText = nextDraftPlanText;
+        return nextReply;
+      }),
+      reset: vi.fn(),
+      history: [],
+    };
+    if (config?.threadTs) conversationInstances.set(config.threadTs, instance);
+    return instance;
+  }),
+}));
+
+const VALID_PLAN_YAML = `name: "Pink Theme Retheme"
+repoUrl: "https://github.com/example/repo.git"
+onFinish: pull_request
+mergeMode: external_review
+baseBranch: master
+tasks:
+  - id: retheme-tokens
+    description: "Swap theme tokens to pink"
+    prompt: "Edit index.css"
+    dependencies: []
+  - id: verify-tokens
+    description: "Verify"
+    command: "pnpm test"
+    dependencies: [retheme-tokens]
+`;
+
+async function buildSurface(conversationalPlanning: boolean) {
+  const adapter = await SQLiteAdapter.create(':memory:');
+  const surface = new SlackSurface({
+    botToken: 'xoxb-test',
+    appToken: 'xapp-test',
+    signingSecret: 'test-secret',
+    channelId: 'C-test',
+    cursorCommand: 'cursor',
+    workingDir: '/repo',
+    defaultRepoUrl: 'https://github.com/example/repo.git',
+    conversationalPlanning,
+    conversationRepo: new ConversationRepository(adapter),
+    slackSessionRepo: new SlackSessionRepository(adapter),
+    slackPlanDraftRepo: new SlackPlanDraftRepository(adapter),
+    workflowChannelRepo: new WorkflowChannelRepository(adapter),
+  });
+  await surface.start(async () => {});
+  return surface;
+}
+
+function mentionHandler(surface: SlackSurface): Function {
+  const app = surface.getApp() as any;
+  const handler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')?.handler;
+  if (!handler) throw new Error('app_mention handler not registered');
+  return handler;
+}
+
+describe('conversational-planning drafts stage the Slack review card automatically', () => {
+  beforeEach(() => {
+    conversationInstances.clear();
+    nextDraftPlanText = null;
+    nextReply = 'Here are some scoping questions.';
+  });
+
+  it('a conversational turn that produces a draft posts the review card and uploads the YAML', async () => {
+    const surface = await buildSurface(true);
+    const say = vi.fn().mockResolvedValue({ ts: 'reply-ts' });
+    nextReply = 'Draft ready — pink retheme in 2 steps.';
+    nextDraftPlanText = VALID_PLAN_YAML;
+
+    await mentionHandler(surface)({
+      event: { text: '<@UBOT> lets change the theme of the app from black to pink', ts: 'thread-pink', user: 'U1' },
+      say,
+    });
+
+    const cardCall = say.mock.calls.find(([msg]) => typeof msg?.text === 'string' && msg.text.includes('Pink Theme Retheme'));
+    expect(cardCall).toBeDefined();
+    const app = surface.getApp() as any;
+    expect(app.client.files.uploadV2).toHaveBeenCalledTimes(1);
+  });
+
+  it('a scoping turn with no draft stages nothing', async () => {
+    const surface = await buildSurface(true);
+    const say = vi.fn().mockResolvedValue({ ts: 'reply-ts' });
+
+    await mentionHandler(surface)({
+      event: { text: '<@UBOT> lets change the theme of the app from black to pink', ts: 'thread-scope', user: 'U1' },
+      say,
+    });
+
+    const app = surface.getApp() as any;
+    expect(app.client.chat.update).toHaveBeenCalledWith(expect.objectContaining({ text: 'Here are some scoping questions.' }));
+    expect(app.client.files.uploadV2).not.toHaveBeenCalled();
+  });
+
+  it('without conversationalPlanning a draft-producing turn does not auto-stage', async () => {
+    const surface = await buildSurface(false);
+    const say = vi.fn().mockResolvedValue({ ts: 'reply-ts' });
+    nextDraftPlanText = VALID_PLAN_YAML;
+
+    await mentionHandler(surface)({
+      event: { text: '<@UBOT> lets change the theme of the app from black to pink', ts: 'thread-legacy', user: 'U1' },
+      say,
+    });
+
+    const app = surface.getApp() as any;
+    expect(app.client.files.uploadV2).not.toHaveBeenCalled();
+  });
+});

--- a/packages/surfaces/src/__tests__/slack-terminal-parity.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-terminal-parity.e2e.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SlackSurface } from '../slack/slack-surface.js';
+import { PlanConversation } from '../slack/plan-conversation.js';
+import { SQLiteAdapter, ConversationRepository, SlackPlanDraftRepository, SlackSessionRepository, WorkflowChannelRepository } from '@invoker/data-store';
+import * as child_process from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+
+interface MockHandler {
+  pattern: string | RegExp;
+  handler: Function;
+}
+
+vi.mock('@slack/bolt', () => {
+  class MockApp {
+    _commandHandlers: MockHandler[] = [];
+    _actionHandlers: MockHandler[] = [];
+    _eventHandlers: MockHandler[] = [];
+    command = vi.fn((name: string, handler: Function) => {
+      this._commandHandlers.push({ pattern: name, handler });
+    });
+    action = vi.fn((pattern: string | RegExp, handler: Function) => {
+      this._actionHandlers.push({ pattern, handler });
+    });
+    event = vi.fn((name: string, handler: Function) => {
+      this._eventHandlers.push({ pattern: name, handler });
+    });
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    client = {
+      chat: {
+        postMessage: vi.fn().mockResolvedValue({ ts: '1234567890.123456' }),
+        update: vi.fn().mockResolvedValue({}),
+        delete: vi.fn().mockResolvedValue({}),
+      },
+      auth: {
+        test: vi.fn().mockResolvedValue({ user_id: 'UBOT' }),
+      },
+      files: {
+        uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F1' }] }),
+      },
+      reactions: {
+        add: vi.fn().mockResolvedValue({}),
+        remove: vi.fn().mockResolvedValue({}),
+      },
+    };
+  }
+  return { App: MockApp };
+});
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof child_process>();
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  };
+});
+
+const mockSpawn = vi.mocked(child_process.spawn);
+
+const capturedPrompts: string[] = [];
+
+function plannerTurn(stdout: string, sideEffect?: () => void): void {
+  mockSpawn.mockImplementationOnce((_cmd: any, args: any) => {
+    const stringArgs = (args as string[]).filter((a) => typeof a === 'string');
+    capturedPrompts.push(stringArgs.reduce((longest, arg) => (arg.length > longest.length ? arg : longest), ''));
+    const proc = new EventEmitter() as any;
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = vi.fn();
+    setTimeout(() => {
+      sideEffect?.();
+      proc.stdout.emit('data', Buffer.from(stdout));
+      proc.emit('close', 0);
+    }, 0);
+    return proc;
+  });
+}
+
+function initSandboxRepo(prefix: string): string {
+  const workingDir = mkdtempSync(join(tmpdir(), prefix));
+  execFileSync('git', ['init'], { cwd: workingDir });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: workingDir });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: workingDir });
+  writeFileSync(join(workingDir, 'index.css'), ':root { --background: 10 10 10; }\n');
+  execFileSync('git', ['add', '.'], { cwd: workingDir });
+  execFileSync('git', ['commit', '-m', 'initial'], { cwd: workingDir });
+  return workingDir;
+}
+
+function trackedChanges(workingDir: string): string[] {
+  return execFileSync('git', ['status', '--porcelain'], { cwd: workingDir, encoding: 'utf8' })
+    .split('\n')
+    .filter((line) => line.trim().length > 0 && !line.startsWith('??'));
+}
+
+const PINK_REQUEST = 'lets change the theme of the app from black to pink';
+const SCOPING_REPLY = 'The colors live in packages/ui/src/index.css as CSS variables. Do you want me to draft the YAML plan?';
+const DRAFT_REPLY = 'Draft ready — pink retheme in 2 steps.';
+
+const VALID_PLAN_YAML = `name: "Pink Theme Retheme"
+repoUrl: "https://github.com/example/repo.git"
+onFinish: pull_request
+mergeMode: external_review
+baseBranch: master
+tasks:
+  - id: retheme-tokens
+    description: "Swap theme tokens to pink"
+    prompt: "Edit index.css"
+    dependencies: []
+  - id: verify-tokens
+    description: "Verify"
+    command: "cd packages/ui && pnpm test"
+    dependencies: [retheme-tokens]
+`;
+
+function writeDraftFile(workingDir: string, threadTs: string): void {
+  const path = join(workingDir, '.invoker', 'plan-drafts', `${threadTs}.yaml`);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, VALID_PLAN_YAML);
+}
+
+function normalizePrompt(prompt: string, workingDir: string): string {
+  return prompt.split(workingDir).join('<worktree>');
+}
+
+describe('Slack and planning-terminal parity for the same request (real surface, real conversation engine)', () => {
+  let slackDir: string;
+  let terminalDir: string;
+
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    capturedPrompts.length = 0;
+    slackDir = initSandboxRepo('invoker-parity-slack-');
+    terminalDir = initSandboxRepo('invoker-parity-terminal-');
+  });
+
+  afterEach(() => {
+    rmSync(slackDir, { recursive: true, force: true });
+    rmSync(terminalDir, { recursive: true, force: true });
+  });
+
+  it('the pink request gets the identical scoping-then-gated-draft experience on both surfaces', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    const surface = new SlackSurface({
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      signingSecret: 'test-secret',
+      channelId: 'C-test',
+      cursorCommand: 'cursor',
+      workingDir: slackDir,
+      defaultRepoUrl: 'https://github.com/example/repo.git',
+      conversationalPlanning: true,
+      conversationRepo: new ConversationRepository(adapter),
+      slackSessionRepo: new SlackSessionRepository(adapter),
+      slackPlanDraftRepo: new SlackPlanDraftRepository(adapter),
+      workflowChannelRepo: new WorkflowChannelRepository(adapter),
+    });
+    await surface.start(async () => {});
+    const app = surface.getApp() as any;
+    const mentionHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')!.handler;
+    const say = vi.fn().mockResolvedValue({ ts: 'reply-ts' });
+
+    const terminal = new PlanConversation({
+      cursorCommand: 'cursor',
+      mode: 'plan',
+      conversationalPlanning: true,
+      workingDir: terminalDir,
+      threadTs: 'thread-pink',
+    });
+
+    plannerTurn(SCOPING_REPLY);
+    await mentionHandler({ event: { text: `<@UBOT> ${PINK_REQUEST}`, ts: 'thread-pink', user: 'U1' }, say });
+
+    plannerTurn(SCOPING_REPLY);
+    const terminalScopingReply = await terminal.sendMessage(PINK_REQUEST);
+
+    expect(capturedPrompts).toHaveLength(2);
+    const slackScopingPrompt = normalizePrompt(capturedPrompts[0], slackDir);
+    const terminalScopingPrompt = normalizePrompt(capturedPrompts[1], terminalDir);
+    expect(slackScopingPrompt).toBe(terminalScopingPrompt);
+    expect(slackScopingPrompt).toContain('conversational planning mode');
+    expect(slackScopingPrompt).toContain('Drafting is not authorized yet');
+    expect(slackScopingPrompt).not.toContain('edit code');
+    expect(terminalScopingReply).toBe(SCOPING_REPLY);
+    expect(app.client.files.uploadV2).not.toHaveBeenCalled();
+    expect(trackedChanges(slackDir)).toEqual([]);
+    expect(trackedChanges(terminalDir)).toEqual([]);
+
+    plannerTurn(DRAFT_REPLY, () => writeDraftFile(slackDir, 'thread-pink'));
+    await mentionHandler({
+      event: { text: '<@UBOT> yes', ts: 'msg-2', thread_ts: 'thread-pink', user: 'U1', channel: 'C-test' },
+      say,
+    });
+
+    plannerTurn(DRAFT_REPLY, () => writeDraftFile(terminalDir, 'thread-pink'));
+    await terminal.sendMessage('yes');
+
+    expect(capturedPrompts).toHaveLength(4);
+    const slackDraftPrompt = normalizePrompt(capturedPrompts[2], slackDir);
+    const terminalDraftPrompt = normalizePrompt(capturedPrompts[3], terminalDir);
+    expect(slackDraftPrompt).toBe(terminalDraftPrompt);
+    expect(slackDraftPrompt).toContain('Only the hosting surface (the Slack orchestrator or the in-app planner) may submit the plan');
+    expect(slackDraftPrompt).toContain(join('<worktree>', '.invoker', 'plan-drafts', 'thread-pink.yaml'));
+
+    const cardCall = say.mock.calls.find(([msg]) => typeof msg?.text === 'string' && msg.text.includes('Pink Theme Retheme'));
+    expect(cardCall).toBeDefined();
+    expect(app.client.files.uploadV2).toHaveBeenCalledTimes(1);
+
+    expect(terminal.lastTurnDraftPlanText).toBe(VALID_PLAN_YAML.trim());
+    expect(terminal.planSubmitted).toBe(false);
+
+    expect(mockSpawn.mock.calls.map((call) => call[0])).toEqual(['cursor', 'cursor', 'cursor', 'cursor']);
+    expect(trackedChanges(slackDir)).toEqual([]);
+    expect(trackedChanges(terminalDir)).toEqual([]);
+  });
+});

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -350,9 +350,15 @@ function buildConversationalPlanSystemPrompt(
   options: BuildPlanSystemPromptOptions,
 ): string {
   const draftingAuthorized = options.draftingAuthorized ?? false;
+  const handoffInstructions = buildPlanningHandoffInstructions({
+    planFilePath: options.planFilePath,
+    reviewInstruction: 'After the YAML exists, the hosting surface reads that exact YAML, renders the ordered steps in its review flow, and owns the approval step.',
+    shortReplyInstruction: 'Then reply in chat with only a one-or-two-sentence summary. Never paste the YAML into chat.',
+    submissionInstruction: 'Only the hosting surface (the Slack orchestrator or the in-app planner) may submit the plan after your draft is approved in its review flow. Never run `invoker-cli`, `invoker_submit_plan`, `scripts/headless-ipc.js`, or any other submission command yourself. This rule overrides the plan-to-invoker skill\'s Harness handoff mode in this session.',
+  });
   const draftingInstructions = draftingAuthorized
     ? `
-The user has explicitly approved drafting. Follow the plan-to-invoker skill's Harness handoff mode now: first produce a Markdown planning artifact, then convert the approved Markdown plan into a full Invoker YAML task plan, and proceed through the skill's review/submission steps (\`skill-doctor.sh\` when inside an Invoker source checkout, the MCP review/submit flow as the canonical path otherwise). Read \`skills/plan-to-invoker/SKILL.md\` for the exact steps if you need them.`
+The user has explicitly approved drafting. Produce the full Invoker YAML task plan now, using the plan shape from \`skills/plan-to-invoker/SKILL.md\` if you need the exact schema. ${handoffInstructions}`
     : `
 Drafting is not authorized yet. Do NOT output a \`\`\`yaml code block, do NOT write a draft plan file, and do NOT tell the user the plan can be executed.
 

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -1173,18 +1173,37 @@ export class SlackSurface implements Surface {
       return;
     }
     const plannerOutput = await conversation.runPlanConversion();
+    await this.stageDraftReviewFromPlannerOutput(plannerOutput, conversation, channel, threadTs, userId, say, { silentWhenNotReady: false });
+  }
+
+  private async stageDraftReviewFromPlannerOutput(
+    plannerOutput: string,
+    conversation: ConversationLike,
+    channel: string,
+    threadTs: string,
+    userId: string,
+    say: SayFn,
+    opts: { silentWhenNotReady: boolean },
+  ): Promise<void> {
+    if (!this.slackPlanDraftRepo) return;
     const review = preparePlanningReview({
       plannerOutput,
       extractDraftPlanText: () => conversation.lastTurnDraftPlanText,
       confirmationMode: this.loadPlanningContext(threadTs)?.confirmationMode ?? this.defaultPlanningConfirmationMode,
     });
     if ('kind' in review) {
-      await this.sayWithRateLimitRetry(say, { text: review.reply, thread_ts: threadTs });
+      if (!opts.silentWhenNotReady) {
+        await this.sayWithRateLimitRetry(say, { text: review.reply, thread_ts: threadTs });
+      }
       return;
     }
     const draftReview = review;
     const context = this.loadPlanningContext(threadTs);
     if (!context?.repoUrl || !context.workingDir) {
+      if (opts.silentWhenNotReady) {
+        this.log('slack', 'warn', `[DRAFT_STAGE] Skipped staging draft for thread ${threadTs}: no pinned repository context.`);
+        return;
+      }
       await this.sayWithRateLimitRetry(say, {
         text: 'This thread has no pinned repository context. Start a new thread with the repository selected.',
         thread_ts: threadTs,
@@ -2726,6 +2745,15 @@ ${text}`;
           }, say);
         } catch (err) {
           this.log('slack', 'error', `[PLAN_INTENT_CONFIRM] failed to stage from auto-detect thread_ts=${threadTs}: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+        }
+      }
+
+      if (this.conversationalPlanning && conversation.conversationMode === 'plan' && conversation.lastTurnDraftPlanText) {
+        try {
+          await this.stageDraftReviewFromPlannerOutput(reply, conversation, channel, threadTs,
+            planIntentContext?.userId ?? 'unknown', say, { silentWhenNotReady: true });
+        } catch (err) {
+          this.log('slack', 'error', `[DRAFT_STAGE] failed to stage conversational draft thread_ts=${threadTs}: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
         }
       }
 


### PR DESCRIPTION
## Summary

This is the regression net for the whole stack, and the direct answer to "show me the Slack and planning-terminal experiences are the same."

A single e2e test drives the real `SlackSurface` `app_mention` handler and a terminal-configured `PlanConversation` with the literal pink-theme request, against two sandbox git repositories, with a scripted planner.

It asserts sameness at every step: identical prompts, scoping first, drafting only after explicit approval, an approval affordance on each side, clean worktrees, no spawned submission process.

## Review Claim

Both surfaces give the same experience for the same request: byte-identical prompts (modulo worktree path), gated drafting, staged approval, no tracked-file edits, no model-initiated submission.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only slice; no product code changes.

## Slice Rationale

The stack's terminal proof: any future drift between the two surfaces breaks this test.

## Non-goals

- No live-model runs (planner is scripted; a live eval can be added separately behind an env gate).
- No behavior change.

## Test Plan

<details><summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test` (544 tests pass, including the new parity e2e)

</details>

## Revert Plan

<details><summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
