### PR TITLE
[Pink theme](3) terminal panels

### DIFF
--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -213,7 +213,7 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActi
         cursorBlink: true,
         convertEol: false,
         scrollback: 5000,
-        theme: { background: '#0b0f1a', foreground: '#e5e7eb' },
+        theme: { background: '#7a0a49', foreground: '#e5e7eb' },
       });
       fit = new FitAddon();
       term.loadAddon(fit);
@@ -433,7 +433,7 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActi
   }, [session?.outputSnapshot, session?.sessionId, terminalActive]);
 
   return (
-    <div className="relative min-h-0 flex-1 overflow-hidden bg-black">
+    <div className="relative min-h-0 flex-1 overflow-hidden bg-[#7a0a49]">
       {!session && (
         <div
           data-testid="invoker-terminal-tmux-placeholder"

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -210,7 +210,7 @@ function TerminalSessionPane({ session, isActive, drawerState, hasHeader }: Term
         cursorBlink: true,
         convertEol: false,
         scrollback: 5000,
-        theme: { background: '#0b0f1a', foreground: '#e5e7eb' },
+        theme: { background: '#7a0a49', foreground: '#e5e7eb' },
       });
       fit = new FitAddon();
       term.loadAddon(fit);
@@ -447,7 +447,7 @@ export function TerminalDrawer({
       </div>
       <div
           data-testid="terminal-drawer-body"
-          className={isMaximized ? 'relative min-h-0 flex-1 overflow-hidden bg-black' : 'relative shrink-0 overflow-hidden bg-black'}
+          className={isMaximized ? 'relative min-h-0 flex-1 overflow-hidden bg-[#7a0a49]' : 'relative shrink-0 overflow-hidden bg-[#7a0a49]'}
           style={{
             ...(isMaximized ? {} : { height: DRAWER_BODY_HEIGHT_PX }),
             display: showBody ? undefined : 'none',


### PR DESCRIPTION
## Summary

Replaces the remaining hardcoded terminal panel background values with Barbie pink in the two terminal-rendering components.

Both components wrap the same xterm.js terminal widget. The wrapper class and xterm base background now match the theme stack.

Command output colors stay unchanged. The xterm foreground and ANSI palette keep the existing readable values.

## Review Claim

The terminal wrapper `bg-black` class and xterm base `background` hex in both terminal components now use Barbie pink, while foreground and ANSI colors are unchanged.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the terminal base background changes. The foreground and ANSI color palette used for command output are left alone, so terminal text remains readable.

## Slice Rationale

The two files wrap the same xterm widget with the same wrapper class and theme option. Reviewing them together keeps the terminal panel change separate from the App.tsx shell.

## Non-goals

No xterm ANSI color changes, no terminal behavior changes, no sizing or scrollback changes, and no edits outside `InvokerTerminal.tsx` and `TerminalDrawer.tsx`.

## Visual Proof

![Terminal planning surface on the pink theme](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260804-ab3910/terminal-planned-conversation-after-submit.png)

The planning terminal surface renders on the pink theme after the terminal-panel color substitution.

`bash scripts/ui-visual-proof.sh capture-after` built the UI and app and captured after-state screenshots. I interrupted the run after it produced current screenshots because the old neutral baselines caused expected screenshot mismatches.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/ui test`
- [x] `grep -E "bg-black|#0b0f1a" packages/ui/src/components/InvokerTerminal.tsx packages/ui/src/components/TerminalDrawer.tsx` exits 1
- [x] `bash scripts/ui-visual-proof.sh capture-after` built the UI/app and captured after-state screenshots before being interrupted after expected visual baseline mismatches.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert bcf3eb162`
- Post-revert steps: None
- Data migration? No

</details>
