### PR TITLE
[Pink theme](4) remaining components

### DIFF
--- a/packages/ui/src/components/CommandPalette.tsx
+++ b/packages/ui/src/components/CommandPalette.tsx
@@ -231,7 +231,7 @@ export function CommandPalette({
       data-testid="command-palette"
       data-state={open ? 'open' : 'closed'}
       className={[
-        'fixed inset-0 z-50 flex items-start justify-center bg-black/70 px-4 pt-[18vh]',
+        'fixed inset-0 z-50 flex items-start justify-center bg-[#e0218a]/70 px-4 pt-[18vh]',
         open ? '' : 'hidden',
       ].join(' ')}
       onMouseDown={(event) => {

--- a/packages/ui/src/components/HistoryView.tsx
+++ b/packages/ui/src/components/HistoryView.tsx
@@ -311,7 +311,7 @@ function HistoryRow({
 }) {
   const rowClass = selected
     ? 'bg-indigo-900/60 border-indigo-600'
-    : 'bg-gray-800 border-gray-800 hover:border-gray-600';
+    : 'bg-[#ff69b4]/40 border-[#ff69b4]/40 hover:border-gray-600';
   return (
     <li
       className={`border rounded-md ${rowClass} transition-colors`}
@@ -406,14 +406,14 @@ function FilterBar({
     filter.dateTo !== '';
 
   return (
-    <div className="border-b border-gray-800 p-3 space-y-3 bg-gray-900/40">
+    <div className="border-b border-[#ff69b4]/40 p-3 space-y-3 bg-[#9c0f5c]/40">
       <div className="flex items-center gap-2">
         <input
           type="search"
           value={filter.search}
           onChange={(e) => onChange({ ...filter, search: e.target.value })}
           placeholder="Search description, workflow, event, error…"
-          className="flex-1 bg-gray-900 border border-gray-700 rounded px-2 py-1 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"
+          className="flex-1 bg-[#9c0f5c] border border-gray-700 rounded px-2 py-1 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"
           aria-label="Search history"
         />
         <span className="text-xs text-gray-500 shrink-0">
@@ -479,7 +479,7 @@ function FilterBar({
             type="date"
             value={filter.dateFrom}
             onChange={(e) => onChange({ ...filter, dateFrom: e.target.value })}
-            className="bg-gray-900 border border-gray-700 rounded px-1.5 py-0.5 text-xs text-gray-100"
+            className="bg-[#9c0f5c] border border-gray-700 rounded px-1.5 py-0.5 text-xs text-gray-100"
             aria-label="From date"
           />
         </label>
@@ -489,7 +489,7 @@ function FilterBar({
             type="date"
             value={filter.dateTo}
             onChange={(e) => onChange({ ...filter, dateTo: e.target.value })}
-            className="bg-gray-900 border border-gray-700 rounded px-1.5 py-0.5 text-xs text-gray-100"
+            className="bg-[#9c0f5c] border border-gray-700 rounded px-1.5 py-0.5 text-xs text-gray-100"
             aria-label="To date"
           />
         </label>

--- a/packages/ui/src/components/TimelineView.tsx
+++ b/packages/ui/src/components/TimelineView.tsx
@@ -165,7 +165,7 @@ function TaskTimelinePane({
                 }
               }}
               className={`w-full rounded text-left transition-all ${
-                isSelected ? 'ring-2 ring-indigo-400 ring-offset-1 ring-offset-gray-900' : ''
+                isSelected ? 'ring-2 ring-indigo-400 ring-offset-1 ring-offset-[#9c0f5c]' : ''
               }`}
               style={{ background: 'transparent' }}
             >
@@ -214,7 +214,7 @@ export function TimelineView({
 
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="timeline-view">
-      <div className="border-b border-gray-800 bg-gray-900/40 px-4 py-3">
+      <div className="border-b border-[#ff69b4]/40 bg-[#9c0f5c]/40 px-4 py-3">
         <div className="inline-flex overflow-hidden rounded-sm border border-border" role="group" aria-label="Timeline mode">
           <button
             type="button"

--- a/packages/ui/src/components/WorkerActionTimelinePane.tsx
+++ b/packages/ui/src/components/WorkerActionTimelinePane.tsx
@@ -170,7 +170,7 @@ export function WorkerActionTimelinePane({
 
   return (
     <div className="flex h-full min-h-0 flex-col" data-testid="worker-timeline-view">
-      <div className="space-y-3 border-b border-gray-800 bg-gray-900/40 p-3">
+      <div className="space-y-3 border-b border-[#ff69b4]/40 bg-[#9c0f5c]/40 p-3">
         <div className="flex flex-wrap items-center gap-2">
           {workflows.size > 1 ? (
             <select
@@ -193,7 +193,7 @@ export function WorkerActionTimelinePane({
             value={taskFilter}
             onChange={(event) => setTaskFilter(event.target.value)}
             placeholder="Search tasks"
-            className="flex-1 bg-gray-900 border border-gray-700 rounded px-2 py-1 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"
+            className="flex-1 bg-[#9c0f5c] border border-gray-700 rounded px-2 py-1 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"
             aria-label="Search tasks"
           />
           <span className="shrink-0 text-xs text-gray-500">{timelineRows.length} / {totalRowCount}</span>
@@ -268,7 +268,7 @@ export function WorkerActionTimelinePane({
                   <li
                     key={`${row.action.id}-${row.eventKind}`}
                     data-testid={`worker-timeline-row-${row.action.id}-${row.eventKind}`}
-                    className={`border rounded-md ${selected ? 'bg-indigo-900/60 border-indigo-600' : 'bg-gray-800 border-gray-800 hover:border-gray-600'} transition-colors ${interactive ? '' : 'opacity-90'}`}
+                    className={`border rounded-md ${selected ? 'bg-indigo-900/60 border-indigo-600' : 'bg-[#ff69b4]/40 border-[#ff69b4]/40 hover:border-gray-600'} transition-colors ${interactive ? '' : 'opacity-90'}`}
                   >
                     <button
                       type="button"

--- a/packages/ui/src/components/WorkerDetailControl.tsx
+++ b/packages/ui/src/components/WorkerDetailControl.tsx
@@ -44,7 +44,7 @@ export function WorkerDetailControl({
       data-action={showStart ? 'start' : 'stop'}
       title={disabledReason}
       disabled={disabled}
-      className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-200 disabled:cursor-not-allowed disabled:opacity-50 hover:bg-gray-800"
+      className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-200 disabled:cursor-not-allowed disabled:opacity-50 hover:bg-[#ff69b4]/40"
       onClick={() => {
         if (disabled) return;
         setOptimistic(showStart ? 'running' : 'stopped');

--- a/packages/ui/src/components/primitives/Dialog.tsx
+++ b/packages/ui/src/components/primitives/Dialog.tsx
@@ -20,7 +20,7 @@ export const DialogOverlay = forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-[#e0218a]/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary

Replaces the final hardcoded black and dark gray Tailwind color classes across six smaller UI activation surfaces with Barbie pink equivalents.

Each file only had a handful of matching sites. Keeping them together gives reviewers one mechanical component-surface claim.

This completes the hardcoded black and dark gray theme activation change under `packages/ui/src`.

## Review Claim

Every remaining `bg-black`, `border-black`, `text-black/*`, `gray-800`, `gray-900*`, `gray-950*`, `zinc-800*`, `zinc-900*`, `neutral-800*`, and `neutral-900*` class in the six named UI components now has a Barbie pink replacement with opacity suffixes preserved.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only Tailwind color utility class values are swapped. No `className` is added, removed, or reordered beyond the color token itself, and the shared Dialog primitive keeps the same props and focus behavior.

## Slice Rationale

These six activation-surface files have 13 total matching sites. Bundling them as one component-surface claim is more reviewable than six near-empty PRs, while keeping the App.tsx and terminal-panel changes separate.

## Non-goals

No edits outside the six listed component files, no JSX structural changes, no Dialog API changes, and no changes to mid-gray `gray-400` or `gray-500` text colors.

## Visual Proof

![History and task timeline on pink component surfaces](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260804-64d954/history-view-task-state-timeline.png)

The history view, timeline panel, search controls, filters, and right-side worker decision panes render on the pink component surfaces after the remaining color-class sweep.

![Worker timeline rows on pink component surfaces](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260804-64d954/timeline-worker-events.png)

The worker timeline rows and surrounding component panels render with the remaining dark utility classes replaced by pink equivalents.

`bash scripts/ui-visual-proof.sh capture-after` built the UI and app and captured current screenshots. The run collected 89 screenshots; expected screenshot mismatches remain because the stored baselines still reflect the old neutral theme.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `cd packages/ui && pnpm test`
- [x] `cd packages/ui && pnpm build`
- [x] `grep -rE "bg-black|border-black|text-black/|gray-(8|9)00|zinc-(8|9)00|neutral-(8|9)00" packages/ui/src/components/CommandPalette.tsx packages/ui/src/components/HistoryView.tsx packages/ui/src/components/primitives/Dialog.tsx packages/ui/src/components/TimelineView.tsx packages/ui/src/components/WorkerActionTimelinePane.tsx packages/ui/src/components/WorkerDetailControl.tsx` exits 1
- [x] `bash scripts/ui-visual-proof.sh capture-after` built the UI/app and captured current screenshots; Playwright reported expected pixel mismatches against old neutral baselines while still collecting proof images.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a8bf56c25`
- Post-revert steps: None
- Data migration? No

</details>
