### PR TITLE
CI regression: a4a7770-playwright-2-of-9 (1/2) Assign the stuck-lease specs to a Playwright shard roster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,6 +627,8 @@ jobs:
             files: >-
               e2e/autofix-worker-ui.spec.ts
               e2e/orphan-relaunch.spec.ts
+              e2e/launch-dispatch-stuck-lease-storm.spec.ts
+              e2e/launch-dispatch-stuck-lease-cap.spec.ts
               e2e/gap-recovery-bench.spec.ts
               e2e/planning-chat-send-long-deadline.spec.ts
               e2e/system-setup-visual-proof.spec.ts


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a4a77700abe7fdd4f5743b92b3e2795de7d4277c; job=playwright / 2-of-9 -->

CI job `playwright / 2-of-9` went red on master starting at a4a77700abe7fdd4f5743b92b3e2795de7d4277c and stayed red through f4fab24b3dacec694a26c27b436ad02bdbdfcf40.

The specs `launch-dispatch-stuck-lease-storm` and `launch-dispatch-stuck-lease-cap` exist on disk but are absent from every Playwright shard roster in `ci.yml`.

The shard inventory guard requires each spec to belong to exactly one shard, so every shard job, including `playwright / 2-of-9`, fails before running any tests.

This change assigns both stuck-lease specs to one shard roster, which makes the inventory guard and the `playwright / 2-of-9` job green again.

## Review Claim

One shard roster in `.github/workflows/ci.yml` now carries the two stuck-lease specs; nothing else changes.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only one shard roster inside `.github/workflows/ci.yml` gains two entries; every other CI job and all product code stay untouched.

## Slice Rationale

This slice carries the CI roster repair on its own, so the reviewer can check the two-line roster change against the shard inventory guard with nothing else in the diff.

## Non-goals

- No product code changes.
- No spec content changes and no test weakening.
- No re-balancing of the other shard rosters.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-2-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/claude-planning-preset-visual-proof.spec.ts e2e/planning-presets-load-failure.spec.ts e2e/action-graph-visual-proof.spec.ts e2e/invalid-merge-workspace-visual.spec.ts e2e/invalid-task-workspace-visual.spec.ts e2e/persistence-lifecycle.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, but reverting re-opens the `playwright / 2-of-9` shard inventory failure on master.
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None
- Data migration? No

</details>
