### PR TITLE
[CI regression: a4a7770-playwright-7-of-9](1) Assign the launch-dispatch stuck-lease specs to the playwright 7-of-9 shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,6 +641,8 @@ jobs:
               e2e/planning-tmux-blank-repro.spec.ts
           - name: 7-of-9
             files: >-
+              e2e/launch-dispatch-stuck-lease-cap.spec.ts
+              e2e/launch-dispatch-stuck-lease-storm.spec.ts
               e2e/worker-tab-scroll.spec.ts
               e2e/workflow-delete-latency.spec.ts
               e2e/main-process-hitch-responsiveness.spec.ts


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a4a77700abe7fdd4f5743b92b3e2795de7d4277c; job=playwright / 7-of-9 -->

CI job `playwright / 7-of-9` first failed on default-branch commit a4a77700abe7fdd4f5743b92b3e2795de7d4277c in run 30895657329. It stayed red through f4fab24b3dacec694a26c27b436ad02bdbdfcf40 in run 30947825449.

That commit landed two new specs, `packages/app/e2e/launch-dispatch-stuck-lease-cap.spec.ts` and `launch-dispatch-stuck-lease-storm.spec.ts`, without assigning them to any Playwright shard.

Every `playwright / N-of-9` job runs the `Verify Playwright shard inventory` guard. It fails whenever a deterministic spec is missing from the shard matrix.

This change assigns both stuck-lease specs to the `7-of-9` shard in `.github/workflows/ci.yml`, restoring a complete one-shard-per-spec inventory.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30895657329/job/91965992660

## Review Claim

Approve assigning `e2e/launch-dispatch-stuck-lease-cap.spec.ts` and `e2e/launch-dispatch-stuck-lease-storm.spec.ts` to the `7-of-9` Playwright shard so the shard-inventory guard passes again.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect. The diff touches only the `7-of-9` `files:` list in `.github/workflows/ci.yml`; no product code, test code, or other shard changes.

## Slice Rationale

One slice for the failing CI job's root cause: the unassigned-spec inventory drift introduced at a4a77700abe7fdd4f5743b92b3e2795de7d4277c. The local proof run is a separate proof slice stacked on top.

## Non-goals

- No refactor and no unrelated cleanup.
- No test weakening and no snapshot churn.
- No changes to the specs themselves or to other shards.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs` exits 0 with this change (and fails on master without it).
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-7-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/worker-tab-scroll.spec.ts e2e/workflow-delete-latency.spec.ts e2e/main-process-hitch-responsiveness.spec.ts e2e/dag-click-hitch-responsiveness.spec.ts e2e/terminal-upsert-hitch-responsiveness.spec.ts e2e/attention-click-hitch-responsiveness.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` exits 0 (ran in the workflow's verify task).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None, but the `playwright / N-of-9` shard-inventory guard will fail again until the specs are reassigned.
- Data migration? No

</details>
