### PR TITLE
[CI regression: a4a7770-playwright-2-of-9](1) Assign stuck-lease specs to playwright shard 1-of-9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,6 +597,8 @@ jobs:
               e2e/edit-task-command.spec.ts
               e2e/headless-thundering-herd.spec.ts
               e2e/launching-stall-watchdog.spec.ts
+              e2e/launch-dispatch-stuck-lease-storm.spec.ts
+              e2e/launch-dispatch-stuck-lease-cap.spec.ts
               e2e/embedded-terminal-pty.spec.ts
               e2e/keyboard-navigation.spec.ts
           - name: 2-of-9


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a4a77700abe7fdd4f5743b92b3e2795de7d4277c; job=playwright / 2-of-9 -->

CI job `playwright / 2-of-9` first failed on default-branch push a4a77700abe7fdd4f5743b92b3e2795de7d4277c and was still red at f4fab24b3dacec694a26c27b436ad02bdbdfcf40.

Every playwright shard job starts with the shard inventory guard, `scripts/repro/repro-ci-playwright-shard-inventory.mjs`. It fails the job when any CI-owned e2e spec has no shard assignment.

That push introduced `e2e/launch-dispatch-stuck-lease-storm.spec.ts` and `e2e/launch-dispatch-stuck-lease-cap.spec.ts` without a shard assignment, so the guard turned every shard red, including `2-of-9`.

This PR assigns both specs to shard `1-of-9` in the CI workflow matrix, so the inventory guard passes again.

## Review Claim

Every CI-owned playwright e2e spec is assigned to exactly one shard again, so the shard inventory guard exits 0 on every shard job.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the shard `1-of-9` files entry in `.github/workflows/ci.yml` gains two lines; no other shard entry, workflow step, product file, or spec changes.

## Slice Rationale

This slice carries only the CI workflow repair; the shard `2-of-9` snapshot refresh that completes the stack ships in the next slice.

## Non-goals

- No product code or spec content changes.
- No re-balancing of other shard assignments and no test weakening.
- No change to the `2-of-9` file set; its snapshot refresh lands in the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs` — exits 0 on this branch (61 CI-owned specs each assigned to exactly one shard).
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-2-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/claude-planning-preset-visual-proof.spec.ts e2e/planning-presets-load-failure.spec.ts e2e/action-graph-visual-proof.spec.ts e2e/invalid-merge-workspace-visual.spec.ts e2e/invalid-task-workspace-visual.spec.ts e2e/persistence-lifecycle.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — exits 0 at the stack head.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>` (the landed commit of this PR)
- Post-revert steps: None; the shard inventory guard fails again until the two specs get a shard assignment.
- Data migration? No

</details>
