### PR TITLE
[CI regression: a4a7770-playwright-3-of-9](1) Assign the stuck-lease specs to a dedicated playwright shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -668,6 +668,10 @@ jobs:
               e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts
               e2e/planning-terminal-expand-collapse-garble-repro.spec.ts
               e2e/task-terminal-drawer-minimize-garble-repro.spec.ts
+          - name: launch-dispatch-stuck-lease
+            files: >-
+              e2e/launch-dispatch-stuck-lease-storm.spec.ts
+              e2e/launch-dispatch-stuck-lease-cap.spec.ts
 
     name: playwright / ${{ matrix.name }}
 


### PR DESCRIPTION
## Summary
<!-- invoker-ci-regression-watch: first-bad-sha=a4a77700abe7fdd4f5743b92b3e2795de7d4277c; job=playwright / 3-of-9 -->

CI job `playwright / 3-of-9` first went red on default-branch push commit a4a77700abe7fdd4f5743b92b3e2795de7d4277c and was still red at f4fab24b3dacec694a26c27b436ad02bdbdfcf40.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30895657329/job/91965992711

That push merged `e2e/launch-dispatch-stuck-lease-storm.spec.ts` and `e2e/launch-dispatch-stuck-lease-cap.spec.ts` without assigning them to any playwright shard.

Every playwright shard job runs the shard inventory guard first, and the guard fails whenever a CI-owned spec is missing from the matrix.

This slice pins both stuck-lease specs to a new `launch-dispatch-stuck-lease` matrix entry, so every CI-owned spec is assigned to exactly one shard again.

## Review Claim

The `.github/workflows/ci.yml` playwright matrix gains one dedicated shard for the two stuck-lease specs, which turns the shard inventory guard and `playwright / 3-of-9` green again.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only `.github/workflows/ci.yml` changes, and only by adding one matrix entry. Existing shards keep their exact spec sets, and no product code or spec content is touched.

## Slice Rationale

The regression watch filed one repair slice and one proof slice. The proof slice reran the shard's acceptance check and left no diff, so the repair publishes as this single PR.

## Non-goals

- No edits to product code or to the two stuck-lease specs themselves.
- No re-slicing of the existing `1-of-9` through `9-of-9` shard assignments.
- No weakening of the shard inventory guard or of any playwright spec.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs` (fails before this change: both stuck-lease specs unassigned; exits 0 after)
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-3-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/task-death-logs.spec.ts e2e/restart-failed-task.spec.ts e2e/ui-graph-drag-performance.spec.ts e2e/pending-review-gate-target-repo.proof.spec.ts e2e/workflow-status-composition.spec.ts e2e/queue-running-vs-queued.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` (run by the workflow's verify task; exit 0)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-sha-of-this-pr>`
- Post-revert steps: None, but the shard inventory guard turns every playwright shard red again until the two stuck-lease specs are reassigned.
- Data migration? No

</details>
