### PR TITLE
[CI regression: a4a7770-playwright-5-of-9](1) Give the stuck-lease specs their own Playwright shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,6 +599,10 @@ jobs:
               e2e/launching-stall-watchdog.spec.ts
               e2e/embedded-terminal-pty.spec.ts
               e2e/keyboard-navigation.spec.ts
+          - name: launch-dispatch-stuck-lease
+            files: >-
+              e2e/launch-dispatch-stuck-lease-storm.spec.ts
+              e2e/launch-dispatch-stuck-lease-cap.spec.ts
           - name: 2-of-9
             files: >-
               e2e/claude-planning-preset-visual-proof.spec.ts


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a4a77700abe7fdd4f5743b92b3e2795de7d4277c; job=playwright / 5-of-9 -->

CI job `playwright / 5-of-9` first went red on default-branch commit a4a77700abe7fdd4f5743b92b3e2795de7d4277c in run 30895657329, and was still red at f4fab24b3dacec694a26c27b436ad02bdbdfcf40 in run 30947825449.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30895657329/job/91965992654

Every Playwright shard job starts with an inventory guard: it goes red when any e2e spec belongs to no shard.

Commit a4a7770 introduced two stuck-lease specs without a shard, so every shard job failed, including `5-of-9`.

This change adds a dedicated `launch-dispatch-stuck-lease` matrix entry that carries both specs, so the inventory guard passes again everywhere.

## Review Claim

`playwright / 5-of-9` goes green because the two stuck-lease specs now belong to their own shard matrix entry in `.github/workflows/ci.yml`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the Playwright shard matrix gains one entry. Every existing shard keeps its exact spec assignment, so all other CI jobs run exactly as before.

## Slice Rationale

The regression has one root cause in one workflow file, so one slice carries the whole repair together with its recorded proof runs.

## Non-goals

- No product code changes.
- No edits to any spec file, no test weakening, and no snapshot churn.
- No changes to other CI jobs or to the spec sets of existing shards.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs` — exits 1 on current master (both stuck-lease specs unassigned) and exits 0 with this change.
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-5-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/autofix-worker-ui.spec.ts e2e/orphan-relaunch.spec.ts e2e/gap-recovery-bench.spec.ts e2e/planning-chat-send-long-deadline.spec.ts e2e/system-setup-visual-proof.spec.ts e2e/startup-nonempty-responsiveness.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — exited 0 in workflow task wf-1785882124230-7/verify-ci-a4a7770-playwright-5-of-9.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <squash-merge sha of PR #7473>`
- Post-revert steps: None, but the shard inventory guard goes red again until both stuck-lease specs get a shard.
- Data migration? No

</details>
