### PR TITLE
[CI regression: a4a7770-playwright-9-of-9](1) Fix CI job playwright / 9-of-9 shard inventory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -662,6 +662,10 @@ jobs:
               e2e/ui-delta-timeline.spec.ts
               e2e/planning-terminal-live-model.proof.spec.ts
               e2e/workers-surface.spec.ts
+          - name: launch-dispatch-stuck-lease
+            files: >-
+              e2e/launch-dispatch-stuck-lease-cap.spec.ts
+              e2e/launch-dispatch-stuck-lease-storm.spec.ts
           - name: terminal-garbling
             files: >-
               e2e/planning-surface-navigation-garble-repro.spec.ts


### PR DESCRIPTION
## Summary

CI job `playwright / 9-of-9` first went red on default-branch push commit a4a77700abe7fdd4f5743b92b3e2795de7d4277c and stayed red through f4fab24b3dacec694a26c27b436ad02bdbdfcf40.

Every playwright shard job runs a `Verify Playwright shard inventory` step. It fails when any spec in `packages/app/e2e` is missing from the shard matrix in `ci.yml`.

That push batch landed `e2e/launch-dispatch-stuck-lease-cap.spec.ts` and `e2e/launch-dispatch-stuck-lease-storm.spec.ts` with no shard assignment, so the inventory guard failed the playwright jobs, including 9-of-9.

This PR assigns both specs to a new `launch-dispatch-stuck-lease` matrix entry. Every existing shard keeps its exact spec roster.

## Review Claim

The only change is one new playwright matrix entry in `.github/workflows/ci.yml` that assigns the two previously unassigned stuck-lease specs to exactly one shard.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

No existing shard's spec list changes and no product or test source files change, so every CI job behaves exactly as before except the repaired shard-inventory guard.

## Slice Rationale

This slice carries only the CI regression's root-cause fix; the deterministic local proof run for the repaired job is recorded separately in the next stack slice.

## Non-goals

- No refactor or unrelated cleanup.
- No test weakening and no changes to what any existing shard executes.
- No edits to product, e2e, or fixture source files.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-9-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/gui-owner-auto-bootstrap.spec.ts e2e/start-ready-daemon-owner.spec.ts e2e/ui-delta-timeline.spec.ts e2e/planning-terminal-live-model.proof.spec.ts e2e/workers-surface.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` (exit code 0)
- [ ] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs` (runs inside every playwright shard job in CI)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, but the playwright shard-inventory guard goes red again until the stuck-lease specs are re-assigned.
- Revert command: `git revert <squash-sha-of-this-pr>`
- Post-revert steps: None
- Data migration? No

</details>
