### PR TITLE
Bugfix: file logger silently drops Error message/stack when serializing log records

### DIFF
--- a/packages/app/src/__tests__/logger-error-serialization.test.ts
+++ b/packages/app/src/__tests__/logger-error-serialization.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { FileAndDbLogger } from '../logger.js';
+
+let tempDir: string | undefined;
+
+afterEach(() => {
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+function makeLogPath(): string {
+  tempDir = mkdtempSync(join(tmpdir(), 'invoker-logger-error-'));
+  return join(tempDir, 'nested', 'invoker.log');
+}
+
+function readRecord(filePath: string): Record<string, unknown> {
+  const line = readFileSync(filePath, 'utf8').trimEnd();
+  return JSON.parse(line) as Record<string, unknown>;
+}
+
+describe('FileAndDbLogger error serialization', () => {
+  it('serializes Error instances in file-backed log fields', () => {
+    const filePath = makeLogPath();
+    const logger = new FileAndDbLogger({}, { filePath });
+
+    logger.error('msg', { err: new Error('boom') });
+
+    const record = readRecord(filePath) as {
+      err: { message?: unknown; stack?: unknown };
+    };
+    expect(record.err.message).toBe('boom');
+    expect(typeof record.err.stack).toBe('string');
+    expect(record.err.stack).not.toBe('');
+  });
+
+  it('preserves plain object error shapes unchanged', () => {
+    const filePath = makeLogPath();
+    const logger = new FileAndDbLogger({}, { filePath });
+    const err = { code: 'ERR_SQLITE_ERROR', errcode: 787 };
+
+    logger.error('msg', { err });
+
+    const record = readRecord(filePath);
+    expect(record.err).toEqual(err);
+  });
+});

--- a/packages/app/src/logger.ts
+++ b/packages/app/src/logger.ts
@@ -15,6 +15,18 @@ const LOG_PATH = path.join(homedir(), '.invoker', 'invoker.log');
 
 type Level = 'debug' | 'info' | 'warn' | 'error';
 
+function errorAwareReplacer(_key: string, value: unknown): unknown {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+      ...value,
+    };
+  }
+  return value;
+}
+
 export interface FileAndDbLoggerOptions {
   /** SQLiteAdapter instance for activity_log writes. Omit to skip DB writes. */
   persistence?: SQLiteAdapter;
@@ -85,7 +97,10 @@ export class FileAndDbLogger implements Logger {
         mkdirSync(path.dirname(this.filePath), { recursive: true });
         this.dirEnsured = true;
       }
-      appendFileSync(this.filePath, JSON.stringify(record) + '\n');
+      appendFileSync(
+        this.filePath,
+        JSON.stringify(record, errorAwareReplacer) + '\n',
+      );
     } catch {
       /* Logging must never crash the app. */
     }


### PR DESCRIPTION
## Summary

File-backed log records now preserve useful Error details instead of writing `err:{}`.

This fixes the recovery worker investigation path where repeated `tick failed` lines hid the thrown message and stack.

The serializer still preserves enumerable custom fields from SQLite-style error objects.

## Review Claim

`FileAndDbLogger.writeFile` now uses an Error-aware JSON replacer so Error fields keep `name`, `message`, `stack`, and enumerable custom properties in the log file.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This only changes the JSON written to the file-backed log for values that are already being logged. It does not change logger control flow, database activity-log writes, or caller behavior.

## Slice Rationale

One slice carries the logger serialization fix and its focused regression test. The verification-only workflow task made no file changes, so publishing it as a separate PR would create an empty stack slice.

## Non-goals

This does not change `writeDb`, any logger caller, the Logger interface, or execution-engine logging behavior.

It does not add scheduler backoff or address the separate recovery worker failure directly.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- src/__tests__/logger-error-serialization.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 38fd6c49b`
- Post-revert steps: Re-run `cd packages/app && pnpm test -- src/__tests__/logger-error-serialization.test.ts`
- Data migration? No

</details>
