### PR TITLE
[CI regression: d19a0f4-playwright-1-of-9](1) Remove the duplicate stuck-lease shard entries and run labeled shards under CI semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,8 +643,6 @@ jobs:
               e2e/planning-tmux-blank-repro.spec.ts
           - name: 7-of-9
             files: >-
-              e2e/launch-dispatch-stuck-lease-cap.spec.ts
-              e2e/launch-dispatch-stuck-lease-storm.spec.ts
               e2e/worker-tab-scroll.spec.ts
               e2e/workflow-delete-latency.spec.ts
               e2e/main-process-hitch-responsiveness.spec.ts

--- a/scripts/test-suites/optional/40-playwright-app.sh
+++ b/scripts/test-suites/optional/40-playwright-app.sh
@@ -37,6 +37,10 @@ elif [ -n "${INVOKER_PLAYWRIGHT_SHARD_INDEX:-}" ] && [ -n "${INVOKER_PLAYWRIGHT_
 fi
 RUN_LABEL="$(sanitize_label "$RUN_LABEL")"
 
+if [ -z "${CI:-}" ] && [[ "$RUN_LABEL" == ci-playwright-* ]]; then
+  export CI=true
+fi
+
 ARTIFACT_ROOT="$(git rev-parse --path-format=absolute --git-path "playwright-artifacts/$RUN_LABEL")"
 mkdir -p "$ARTIFACT_ROOT"
 


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=d19a0f4af741226c3edb9509e2768529bf97fef9; job=playwright / 1-of-9 -->

CI job `playwright / 1-of-9` first failed on default-branch push commit d19a0f4af741226c3edb9509e2768529bf97fef9 in run 30680710516. It was still red at 406c00ef33b69d729ee4170b031c7ddaa8658bed in run 30957855805.

Every `playwright / N-of-9` job runs the shard-inventory guard. On current master the guard fails in every shard because the stuck-lease specs sit in both the `5-of-9` and `7-of-9` rosters.

This change drops the duplicate `7-of-9` roster entries and keeps the earlier `5-of-9` assignment, restoring one shard per spec.

It also makes `scripts/test-suites/optional/40-playwright-app.sh` export `CI=true` for local `ci-playwright-*` labeled runs, so a labeled local repro behaves like the CI job. In real CI the variable is already set.

The spec-level repairs for this shard ride in the next slice of this stack.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30680710516/job/91317782173

## Review Claim

Approve dropping the duplicate stuck-lease entries from the `7-of-9` Playwright roster and exporting `CI=true` in the shared suite runner for labeled local runs.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The diff touches only the `7-of-9` roster in `.github/workflows/ci.yml` and one guarded env export in `scripts/test-suites/optional/40-playwright-app.sh`. No product code, no spec content, and no other shard rosters change; in real CI `CI` is already set, so the export is a no-op there.

## Slice Rationale

One tooling slice for the CI-side causes: the roster duplication that keeps the shard-inventory guard red in every shard, and the runner env drift that let labeled local runs behave unlike CI. The e2e repairs for this shard are the next slice.

## Non-goals

- No spec content changes and no test weakening.
- No changes to other shard rosters or other CI jobs.
- No product code changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs` exits 0 with this change; on master it fails with `Duplicate shard entries: e2e/launch-dispatch-stuck-lease-cap.spec.ts, e2e/launch-dispatch-stuck-lease-storm.spec.ts`.
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-1-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/visual-proof.spec.ts e2e/edit-task-command.spec.ts e2e/headless-thundering-herd.spec.ts e2e/launching-stall-watchdog.spec.ts e2e/embedded-terminal-pty.spec.ts e2e/keyboard-navigation.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` exits 0 on the full stack (ran in the workflow's verify task).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None, but the shard-inventory guard will fail in every `playwright / N-of-9` shard again until the duplicate roster entries are dropped again.
- Data migration? No

</details>
