### PR TITLE
[CI regression: d19a0f4-playwright-1-of-9](2) Reap leaked standalone owners and assert the minimized drawer is hidden

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,8 +643,6 @@ jobs:
               e2e/planning-tmux-blank-repro.spec.ts
           - name: 7-of-9
             files: >-
-              e2e/launch-dispatch-stuck-lease-cap.spec.ts
-              e2e/launch-dispatch-stuck-lease-storm.spec.ts
               e2e/worker-tab-scroll.spec.ts
               e2e/workflow-delete-latency.spec.ts
               e2e/main-process-hitch-responsiveness.spec.ts

--- a/packages/app/e2e/fixtures/headless-client.ts
+++ b/packages/app/e2e/fixtures/headless-client.ts
@@ -86,6 +86,8 @@ export async function cleanupStandaloneOwnersForTestDir(testDir: string): Promis
     }
   }
 
+  if (pids.size === 0) return;
+
   await delay(1000);
 
   for (const pid of pids) {

--- a/packages/app/e2e/fixtures/headless-client.ts
+++ b/packages/app/e2e/fixtures/headless-client.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process';
 import * as path from 'node:path';
-import { writeFile } from 'node:fs/promises';
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { setTimeout as delay } from 'node:timers/promises';
 import { promisify } from 'node:util';
 import { resolveRepoRoot } from '@invoker/contracts';
 
@@ -22,6 +23,8 @@ export function headlessTestEnv(testDir: string): NodeJS.ProcessEnv {
     INVOKER_DB_DIR: testDir,
     INVOKER_IPC_SOCKET: ipcSocketPath,
     INVOKER_REPO_CONFIG_PATH: configPath,
+    INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS:
+      process.env.INVOKER_E2E_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '5000',
   };
 }
 
@@ -33,6 +36,66 @@ export async function runHeadlessClient(testDir: string, args: string[]): Promis
     env: headlessTestEnv(testDir),
     maxBuffer: 10 * 1024 * 1024,
   });
+}
+
+export async function cleanupStandaloneOwnersForTestDir(testDir: string): Promise<void> {
+  if (process.platform !== 'linux') return;
+
+  const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+  const pids = new Set<number>();
+  let procEntries: string[];
+  try {
+    procEntries = await readdir('/proc');
+  } catch {
+    return;
+  }
+
+  for (const entry of procEntries) {
+    if (!/^\d+$/.test(entry)) continue;
+
+    const pid = Number(entry);
+    let cmdline: string;
+    let environ: string;
+    try {
+      cmdline = (await readFile(`/proc/${pid}/cmdline`, 'utf8')).replace(/\0/g, ' ');
+      if (
+        !cmdline.includes('packages/app/dist/main.js') ||
+        !cmdline.includes('--headless') ||
+        !cmdline.includes('owner-serve')
+      ) {
+        continue;
+      }
+      environ = await readFile(`/proc/${pid}/environ`, 'utf8');
+    } catch {
+      continue;
+    }
+
+    if (
+      environ.includes(`INVOKER_DB_DIR=${testDir}\0`) ||
+      environ.includes(`INVOKER_IPC_SOCKET=${ipcSocketPath}\0`)
+    ) {
+      pids.add(pid);
+    }
+  }
+
+  for (const pid of pids) {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      // Process already exited.
+    }
+  }
+
+  await delay(1000);
+
+  for (const pid of pids) {
+    try {
+      process.kill(pid, 0);
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      // Process already exited.
+    }
+  }
 }
 
 export function parseWorkflowId(stdout: string): string {

--- a/packages/app/e2e/fixtures/headless-client.ts
+++ b/packages/app/e2e/fixtures/headless-client.ts
@@ -8,6 +8,12 @@ import { resolveRepoRoot } from '@invoker/contracts';
 const execFileAsync = promisify(execFile);
 const repoRoot = resolveRepoRoot(__dirname);
 
+type StandaloneOwnerProcess = {
+  pid: number;
+  cmdline: string;
+  envMarker: string;
+};
+
 export async function ensureHeadlessTestConfig(testDir: string): Promise<void> {
   await writeFile(path.join(testDir, 'e2e-config.json'), JSON.stringify({ autoFixRetries: 0 }), 'utf8');
 }
@@ -38,11 +44,41 @@ export async function runHeadlessClient(testDir: string, args: string[]): Promis
   });
 }
 
+async function readStandaloneOwnerProcess(pid: number, testDir: string, ipcSocketPath: string): Promise<StandaloneOwnerProcess | null> {
+  let cmdline: string;
+  let environ: string;
+  try {
+    cmdline = (await readFile(`/proc/${pid}/cmdline`, 'utf8')).replace(/\0/g, ' ');
+    if (
+      !cmdline.includes('packages/app/dist/main.js') ||
+      !cmdline.includes('--headless') ||
+      !cmdline.includes('owner-serve')
+    ) {
+      return null;
+    }
+    environ = await readFile(`/proc/${pid}/environ`, 'utf8');
+  } catch {
+    return null;
+  }
+
+  const dbMarker = `INVOKER_DB_DIR=${testDir}\0`;
+  if (environ.includes(dbMarker)) {
+    return { pid, cmdline, envMarker: dbMarker };
+  }
+
+  const ipcMarker = `INVOKER_IPC_SOCKET=${ipcSocketPath}\0`;
+  if (environ.includes(ipcMarker)) {
+    return { pid, cmdline, envMarker: ipcMarker };
+  }
+
+  return null;
+}
+
 export async function cleanupStandaloneOwnersForTestDir(testDir: string): Promise<void> {
   if (process.platform !== 'linux') return;
 
   const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
-  const pids = new Set<number>();
+  const owners = new Map<number, StandaloneOwnerProcess>();
   let procEntries: string[];
   try {
     procEntries = await readdir('/proc');
@@ -54,31 +90,11 @@ export async function cleanupStandaloneOwnersForTestDir(testDir: string): Promis
     if (!/^\d+$/.test(entry)) continue;
 
     const pid = Number(entry);
-    let cmdline: string;
-    let environ: string;
-    try {
-      cmdline = (await readFile(`/proc/${pid}/cmdline`, 'utf8')).replace(/\0/g, ' ');
-      if (
-        !cmdline.includes('packages/app/dist/main.js') ||
-        !cmdline.includes('--headless') ||
-        !cmdline.includes('owner-serve')
-      ) {
-        continue;
-      }
-      environ = await readFile(`/proc/${pid}/environ`, 'utf8');
-    } catch {
-      continue;
-    }
-
-    if (
-      environ.includes(`INVOKER_DB_DIR=${testDir}\0`) ||
-      environ.includes(`INVOKER_IPC_SOCKET=${ipcSocketPath}\0`)
-    ) {
-      pids.add(pid);
-    }
+    const owner = await readStandaloneOwnerProcess(pid, testDir, ipcSocketPath);
+    if (owner) owners.set(pid, owner);
   }
 
-  for (const pid of pids) {
+  for (const pid of owners.keys()) {
     try {
       process.kill(pid, 'SIGTERM');
     } catch {
@@ -86,11 +102,16 @@ export async function cleanupStandaloneOwnersForTestDir(testDir: string): Promis
     }
   }
 
-  if (pids.size === 0) return;
+  if (owners.size === 0) return;
 
   await delay(1000);
 
-  for (const pid of pids) {
+  for (const [pid, owner] of owners) {
+    const currentOwner = await readStandaloneOwnerProcess(pid, testDir, ipcSocketPath);
+    if (!currentOwner || currentOwner.cmdline !== owner.cmdline || currentOwner.envMarker !== owner.envMarker) {
+      continue;
+    }
+
     try {
       process.kill(pid, 0);
       process.kill(pid, 'SIGKILL');

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -6,6 +6,7 @@ import { stringify as yamlStringify } from 'yaml';
 
 import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
 import {
+  closeElectronApp,
   E2E_REPO_URL,
   expect,
   loadPlan,
@@ -19,6 +20,7 @@ import {
   uiPerfPayloadsSince,
 } from './fixtures/ui-perf.js';
 import {
+  cleanupStandaloneOwnersForTestDir,
   ensureHeadlessTestConfig,
   expectDelegated,
   headlessTestEnv,
@@ -94,6 +96,10 @@ async function settleHeadlessHerdWorkflows(page: Page): Promise<void> {
 }
 
 test.describe('Headless thundering herd', () => {
+  test.afterEach(async ({ testDir }) => {
+    await cleanupStandaloneOwnersForTestDir(testDir);
+  });
+
   test('burst headless restarts do not spawn headless electron herds or freeze the UI', async ({ page, testDir }) => {
     await loadPlan(page, HEADLESS_HERD_UI_PLAN);
     await startPlan(page);
@@ -251,7 +257,7 @@ test.describe('Headless thundering herd', () => {
       expect(Array.isArray(queueStatus.running)).toBe(true);
       expect(Array.isArray(queueStatus.queued)).toBe(true);
     } finally {
-      await ownerApp.close().catch(() => undefined);
+      await closeElectronApp(ownerApp);
     }
   });
 });

--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -1662,7 +1662,7 @@ test.describe('Visual proof capture', () => {
 
     // Drawer starts minimized.
     await expect(page.getByRole('button', { name: 'Partial terminal drawer' })).toBeVisible();
-    await expect(page.getByTestId('terminal-drawer-body')).toHaveCount(0);
+    await expect(page.getByTestId('terminal-drawer-body')).toBeHidden();
 
     const taskCard = page.locator('[title$="task-alpha"]').first();
     await expect(taskCard).toBeVisible({ timeout: 10000 });

--- a/packages/app/src/__tests__/headless-client-fixture-cleanup.test.ts
+++ b/packages/app/src/__tests__/headless-client-fixture-cleanup.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('node:fs/promises', () => ({
   readdir: vi.fn(async () => []),
@@ -15,6 +15,16 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { cleanupStandaloneOwnersForTestDir } from '../../e2e/fixtures/headless-client.js';
 
 describe('cleanupStandaloneOwnersForTestDir', () => {
+  const linuxIt = process.platform === 'linux' ? it : it.skip;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('skips the grace delay when no standalone owners match the test dir', async () => {
     await cleanupStandaloneOwnersForTestDir('/tmp/invoker-no-owner-test-dir');
 
@@ -23,5 +33,42 @@ describe('cleanupStandaloneOwnersForTestDir', () => {
     }
     expect(readFile).not.toHaveBeenCalled();
     expect(delay).not.toHaveBeenCalled();
+  });
+
+  linuxIt('revalidates the same standalone owner identity before SIGKILL escalation', async () => {
+    const testDir = '/tmp/invoker-owner-test-dir';
+    const ipcSocketPath = `${testDir}/ipc-transport.sock`;
+    const cmdline = 'node packages/app/dist/main.js --headless owner-serve';
+    vi.mocked(readdir).mockResolvedValue(['123']);
+    vi.mocked(readFile)
+      .mockResolvedValueOnce(cmdline)
+      .mockResolvedValueOnce(`INVOKER_DB_DIR=${testDir}\0INVOKER_IPC_SOCKET=${ipcSocketPath}\0`)
+      .mockResolvedValueOnce(cmdline)
+      .mockResolvedValueOnce(`INVOKER_DB_DIR=${testDir}\0INVOKER_IPC_SOCKET=${ipcSocketPath}\0`);
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    await cleanupStandaloneOwnersForTestDir(testDir);
+
+    expect(kill).toHaveBeenCalledWith(123, 'SIGTERM');
+    expect(kill).toHaveBeenCalledWith(123, 0);
+    expect(kill).toHaveBeenCalledWith(123, 'SIGKILL');
+  });
+
+  linuxIt('does not SIGKILL when a PID no longer matches the captured owner identity', async () => {
+    const testDir = '/tmp/invoker-reused-pid-test-dir';
+    const cmdline = 'node packages/app/dist/main.js --headless owner-serve';
+    vi.mocked(readdir).mockResolvedValue(['123']);
+    vi.mocked(readFile)
+      .mockResolvedValueOnce(cmdline)
+      .mockResolvedValueOnce(`INVOKER_DB_DIR=${testDir}\0`)
+      .mockResolvedValueOnce('node unrelated.js');
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    await cleanupStandaloneOwnersForTestDir(testDir);
+
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(kill).toHaveBeenCalledWith(123, 'SIGTERM');
+    expect(kill).not.toHaveBeenCalledWith(123, 0);
+    expect(kill).not.toHaveBeenCalledWith(123, 'SIGKILL');
   });
 });

--- a/packages/app/src/__tests__/headless-client-fixture-cleanup.test.ts
+++ b/packages/app/src/__tests__/headless-client-fixture-cleanup.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs/promises', () => ({
+  readdir: vi.fn(async () => []),
+  readFile: vi.fn(),
+  writeFile: vi.fn(async () => undefined),
+}));
+
+vi.mock('node:timers/promises', () => ({
+  setTimeout: vi.fn(async () => undefined),
+}));
+
+import { readdir, readFile } from 'node:fs/promises';
+import { setTimeout as delay } from 'node:timers/promises';
+import { cleanupStandaloneOwnersForTestDir } from '../../e2e/fixtures/headless-client.js';
+
+describe('cleanupStandaloneOwnersForTestDir', () => {
+  it('skips the grace delay when no standalone owners match the test dir', async () => {
+    await cleanupStandaloneOwnersForTestDir('/tmp/invoker-no-owner-test-dir');
+
+    if (process.platform === 'linux') {
+      expect(readdir).toHaveBeenCalledWith('/proc');
+    }
+    expect(readFile).not.toHaveBeenCalled();
+    expect(delay).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/test-suites/optional/40-playwright-app.sh
+++ b/scripts/test-suites/optional/40-playwright-app.sh
@@ -37,6 +37,10 @@ elif [ -n "${INVOKER_PLAYWRIGHT_SHARD_INDEX:-}" ] && [ -n "${INVOKER_PLAYWRIGHT_
 fi
 RUN_LABEL="$(sanitize_label "$RUN_LABEL")"
 
+if [ -z "${CI:-}" ] && [[ "$RUN_LABEL" == ci-playwright-* ]]; then
+  export CI=true
+fi
+
 ARTIFACT_ROOT="$(git rev-parse --path-format=absolute --git-path "playwright-artifacts/$RUN_LABEL")"
 mkdir -p "$ARTIFACT_ROOT"
 


### PR DESCRIPTION
## Summary

CI job `playwright / 1-of-9` runs the headless thundering-herd, visual-proof, and four other `packages/app` e2e specs.

The herd spec left standalone `owner-serve` Electron processes alive after each test. The leftover owners kept the shard flaky for the specs that ran after them.

The headless fixture now caps the standalone owner idle timeout at five seconds and, after each herd test, reaps leftover `owner-serve` processes tied to that test's private directory.

The herd spec also shuts its extra Electron app down through the shared `closeElectronApp` helper, matching the teardown used elsewhere in the suite.

The visual-proof spec expected the minimized terminal drawer body to be absent from the DOM. The app keeps it mounted and hidden, so the spec now asserts it is hidden.

The CI-side roster and runner corrections ride in the slice below this one.

## Review Claim

Approve reaping leaked standalone `owner-serve` processes in the headless e2e fixtures and asserting the minimized terminal drawer body is hidden, so the `playwright / 1-of-9` specs pass deterministically.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only e2e fixture and spec files under `packages/app/e2e/` change; no product source, no CI workflow, and no runner script changes. The afterEach reaper signals only `owner-serve` processes whose environment names that test's own temporary directory, and it is a no-op off Linux.

## Slice Rationale

This slice carries the spec and fixture repairs for the failing shard on their own, apart from the CI roster and runner slice below it, so a reviewer can judge the e2e behavior change without tooling noise.

## Non-goals

- No product source changes and no CI workflow changes.
- No test weakening: the herd and drawer specs still exercise the same user-visible behavior.
- No changes to shard rosters or the suite runner; those are the slice below.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-1-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/visual-proof.spec.ts e2e/edit-task-command.spec.ts e2e/headless-thundering-herd.spec.ts e2e/launching-stall-watchdog.spec.ts e2e/embedded-terminal-pty.spec.ts e2e/keyboard-navigation.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` exits 0 at the top of this stack (ran in the workflow's verify task).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None, but the `playwright / 1-of-9` shard goes flaky again from leaked standalone owners and the drawer assertion fails.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of standalone processes during headless test runs, reducing leftover processes after tests complete.
  * Improved Electron app shutdown handling in end-to-end tests.
  * Updated terminal visual validation to correctly verify that minimized drawer content is hidden while preserving expansion and tab behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->