### PR TITLE
Bugfix: file logger silently drops Error message/stack when serializing log records

### DIFF
--- a/packages/app/src/__tests__/logger-error-serialization.test.ts
+++ b/packages/app/src/__tests__/logger-error-serialization.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { FileAndDbLogger } from '../logger.js';
+
+let tempDir: string | undefined;
+
+afterEach(() => {
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+function makeLogPath(): string {
+  tempDir = mkdtempSync(join(tmpdir(), 'invoker-logger-error-'));
+  return join(tempDir, 'nested', 'invoker.log');
+}
+
+function readRecord(filePath: string): Record<string, unknown> {
+  const line = readFileSync(filePath, 'utf8').trimEnd();
+  return JSON.parse(line) as Record<string, unknown>;
+}
+
+describe('FileAndDbLogger error serialization', () => {
+  it('serializes Error instances in file-backed log fields', () => {
+    const filePath = makeLogPath();
+    const logger = new FileAndDbLogger({}, { filePath });
+
+    logger.error('msg', { err: new Error('boom') });
+
+    const record = readRecord(filePath) as {
+      err: { message?: unknown; stack?: unknown };
+    };
+    expect(record.err.message).toBe('boom');
+    expect(typeof record.err.stack).toBe('string');
+    expect(record.err.stack).not.toBe('');
+  });
+
+  it('preserves plain object error shapes unchanged', () => {
+    const filePath = makeLogPath();
+    const logger = new FileAndDbLogger({}, { filePath });
+    const err = { code: 'ERR_SQLITE_ERROR', errcode: 787 };
+
+    logger.error('msg', { err });
+
+    const record = readRecord(filePath);
+    expect(record.err).toEqual(err);
+  });
+});

--- a/packages/app/src/logger.ts
+++ b/packages/app/src/logger.ts
@@ -18,10 +18,10 @@ type Level = 'debug' | 'info' | 'warn' | 'error';
 function errorAwareReplacer(_key: string, value: unknown): unknown {
   if (value instanceof Error) {
     return {
+      ...value,
       name: value.name,
       message: value.message,
       stack: value.stack,
-      ...value,
     };
   }
   return value;

--- a/packages/app/src/logger.ts
+++ b/packages/app/src/logger.ts
@@ -15,6 +15,18 @@ const LOG_PATH = path.join(homedir(), '.invoker', 'invoker.log');
 
 type Level = 'debug' | 'info' | 'warn' | 'error';
 
+function errorAwareReplacer(_key: string, value: unknown): unknown {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+      ...value,
+    };
+  }
+  return value;
+}
+
 export interface FileAndDbLoggerOptions {
   /** SQLiteAdapter instance for activity_log writes. Omit to skip DB writes. */
   persistence?: SQLiteAdapter;
@@ -85,7 +97,10 @@ export class FileAndDbLogger implements Logger {
         mkdirSync(path.dirname(this.filePath), { recursive: true });
         this.dirEnsured = true;
       }
-      appendFileSync(this.filePath, JSON.stringify(record) + '\n');
+      appendFileSync(
+        this.filePath,
+        JSON.stringify(record, errorAwareReplacer) + '\n',
+      );
     } catch {
       /* Logging must never crash the app. */
     }


### PR DESCRIPTION
## Summary

The file logger now preserves Error details when a log field contains an Error instance.

Before this change, file-backed JSON logs emitted `err:{}` for plain Error values.

That hid the recovery worker failure details during an incident with 49,493 repeated failed ticks since 2026-07-11.

The serializer now expands Error values into `name`, `message`, and `stack`, while preserving enumerable subclass fields.

This leaves plain object error shapes unchanged.

## Review Claim

`FileAndDbLogger.writeFile` now serializes Error instances without dropping their non-enumerable `message` and `stack` properties.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This only changes the JSON written to the log file for pre-existing Error-valued fields. It does not change logger control flow, callers, or activity-log DB writes.

## Slice Rationale

This slice contains the logger serialization fix and its directly affected regression test. The separate worker-runtime backoff fix from the same investigation remains independent.

## Non-goals

This does not change `writeDb`.

This does not change any logger caller.

This does not add a new Logger interface method.

This does not touch execution-engine logger implementations or worker scheduler behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `cd packages/app && pnpm test -- src/__tests__/logger-error-serialization.test.ts`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/invoker-file-logger-pr-body.md --base master`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-file-logger-pr-body.md`
- [ ] `cd packages/app && pnpm test` fails on existing repro `src/__tests__/repro-orphan-application-quit-mislabel.test.ts`; the focused logger test passes.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 31b4567d2`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file log output for errors by preserving their name, message, stack trace, and additional properties.
  * Ensured existing plain error-shaped objects continue to be recorded without changes.

* **Tests**
  * Added coverage verifying error details are correctly written to JSON logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->