### PR TITLE
[Logger Error Serialization](1) Bugfix: file logger silently drops Error message/stack when serializing log records

### DIFF
--- a/packages/app/src/__tests__/logger-error-serialization.test.ts
+++ b/packages/app/src/__tests__/logger-error-serialization.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { FileAndDbLogger } from '../logger.js';
+
+let tempDir: string | undefined;
+
+afterEach(() => {
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+function makeLogPath(): string {
+  tempDir = mkdtempSync(join(tmpdir(), 'invoker-logger-error-'));
+  return join(tempDir, 'nested', 'invoker.log');
+}
+
+function readRecord(filePath: string): Record<string, unknown> {
+  const line = readFileSync(filePath, 'utf8').trimEnd();
+  return JSON.parse(line) as Record<string, unknown>;
+}
+
+describe('FileAndDbLogger error serialization', () => {
+  it('serializes Error instances in file-backed log fields', () => {
+    const filePath = makeLogPath();
+    const logger = new FileAndDbLogger({}, { filePath });
+
+    logger.error('msg', { err: new Error('boom') });
+
+    const record = readRecord(filePath) as {
+      err: { message?: unknown; stack?: unknown };
+    };
+    expect(record.err.message).toBe('boom');
+    expect(typeof record.err.stack).toBe('string');
+    expect(record.err.stack).not.toBe('');
+  });
+
+  it('preserves plain object error shapes unchanged', () => {
+    const filePath = makeLogPath();
+    const logger = new FileAndDbLogger({}, { filePath });
+    const err = { code: 'ERR_SQLITE_ERROR', errcode: 787 };
+
+    logger.error('msg', { err });
+
+    const record = readRecord(filePath);
+    expect(record.err).toEqual(err);
+  });
+});

--- a/packages/app/src/logger.ts
+++ b/packages/app/src/logger.ts
@@ -15,6 +15,18 @@ const LOG_PATH = path.join(homedir(), '.invoker', 'invoker.log');
 
 type Level = 'debug' | 'info' | 'warn' | 'error';
 
+function errorAwareReplacer(_key: string, value: unknown): unknown {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+      ...value,
+    };
+  }
+  return value;
+}
+
 export interface FileAndDbLoggerOptions {
   /** SQLiteAdapter instance for activity_log writes. Omit to skip DB writes. */
   persistence?: SQLiteAdapter;
@@ -85,7 +97,10 @@ export class FileAndDbLogger implements Logger {
         mkdirSync(path.dirname(this.filePath), { recursive: true });
         this.dirEnsured = true;
       }
-      appendFileSync(this.filePath, JSON.stringify(record) + '\n');
+      appendFileSync(
+        this.filePath,
+        JSON.stringify(record, errorAwareReplacer) + '\n',
+      );
     } catch {
       /* Logging must never crash the app. */
     }


### PR DESCRIPTION
## Summary

The file-backed logger now preserves useful Error details when it serializes log records.

Plain Error values were becoming `err:{}` because `message` and `stack` are non-enumerable.

The logger now expands Error instances into plain JSON with `name`, `message`, `stack`, and any enumerable custom fields.

The regression test writes through a real `FileAndDbLogger` temp file and parses the emitted JSON line.

## Review Claim

`FileAndDbLogger.writeFile` should serialize Error fields with their `name`, `message`, and `stack` instead of silently reducing them to `{}`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This only changes the JSON line emitted for existing file-backed log records. It does not change logger control flow, DB activity-log writes, or callers.

## Slice Rationale

This slice contains the logger serialization fix and its deterministic regression test. The scheduler backoff fix from the same investigation is separate because it touches another runtime path.

## Non-goals

This does not change `writeDb`.

This does not change any logger caller.

This does not add a Logger interface method.

This does not modify scheduler backoff behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `cd packages/app && pnpm test -- src/__tests__/logger-error-serialization.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-file-logger-pr-body.md`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-file-logger-pr-body.md --changed-files-file /tmp/pr7505-files.txt --diff-file /tmp/pr7505-diff.patch`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/invoker-file-logger-pr-body.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c47178d33141054b454a573f3b8be003e64e0575`
- Post-revert steps: None
- Data migration? No

</details>

