### PR TITLE
[Slack Plan Review Upload](1) Read the nested files.uploadV2 response so the review card reaches ready

### DIFF
--- a/packages/surfaces/src/__tests__/slack-approve-button-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-approve-button-repros.e2e.test.ts
@@ -55,7 +55,7 @@ const sharedSlack = vi.hoisted(() => ({
       update: vi.fn().mockResolvedValue({}),
       delete: vi.fn().mockResolvedValue({}),
     },
-    files: { uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F-proof' }] }) },
+    files: { uploadV2: vi.fn().mockResolvedValue({ ok: true, files: [{ ok: true, files: [{ id: 'F-proof' }] }] }) },
     reactions: { add: vi.fn().mockResolvedValue({}), remove: vi.fn().mockResolvedValue({}) },
     conversations: { replies: vi.fn().mockResolvedValue({ messages: [] }) },
   },

--- a/packages/surfaces/src/__tests__/slack-confirm-expiry-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-confirm-expiry-repros.e2e.test.ts
@@ -57,7 +57,7 @@ const sharedSlack = vi.hoisted(() => ({
       update: vi.fn().mockResolvedValue({}),
       delete: vi.fn().mockResolvedValue({}),
     },
-    files: { uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F-proof' }] }) },
+    files: { uploadV2: vi.fn().mockResolvedValue({ ok: true, files: [{ ok: true, files: [{ id: 'F-proof' }] }] }) },
     reactions: { add: vi.fn().mockResolvedValue({}), remove: vi.fn().mockResolvedValue({}) },
     conversations: { replies: vi.fn().mockResolvedValue({ messages: [] }) },
   },

--- a/packages/surfaces/src/__tests__/slack-conversational-draft-staging.test.ts
+++ b/packages/surfaces/src/__tests__/slack-conversational-draft-staging.test.ts
@@ -33,7 +33,7 @@ vi.mock('@slack/bolt', () => {
         test: vi.fn().mockResolvedValue({ user_id: 'UBOT' }),
       },
       files: {
-        uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F1' }] }),
+        uploadV2: vi.fn().mockResolvedValue({ ok: true, files: [{ ok: true, files: [{ id: 'F1' }] }] }),
       },
       reactions: {
         add: vi.fn().mockResolvedValue({}),

--- a/packages/surfaces/src/__tests__/slack-plan-draft-approve.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-draft-approve.test.ts
@@ -19,7 +19,7 @@ vi.mock('@slack/bolt', () => {
     client = {
       auth: { test: vi.fn().mockResolvedValue({ user_id: 'U_BOT' }) },
       chat: { postMessage: vi.fn().mockResolvedValue({ ts: '1.1' }), update: vi.fn().mockResolvedValue({}) },
-      files: { uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F1' }] }) },
+      files: { uploadV2: vi.fn().mockResolvedValue({ ok: true, files: [{ ok: true, files: [{ id: 'F1' }] }] }) },
     };
   }
   return { App: MockApp };

--- a/packages/surfaces/src/__tests__/slack-plan-intent-auto-detect-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-intent-auto-detect-repros.e2e.test.ts
@@ -28,7 +28,7 @@ const sharedSlack = vi.hoisted(() => ({
       update: vi.fn().mockResolvedValue({}),
       delete: vi.fn().mockResolvedValue({}),
     },
-    files: { uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F_PLAN' }] }) },
+    files: { uploadV2: vi.fn().mockResolvedValue({ ok: true, files: [{ ok: true, files: [{ id: 'F_PLAN' }] }] }) },
     reactions: { add: vi.fn().mockResolvedValue({}), remove: vi.fn().mockResolvedValue({}) },
     conversations: { replies: vi.fn().mockResolvedValue({ messages: [] }) },
   },

--- a/packages/surfaces/src/__tests__/slack-plan-intent-confirm-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-intent-confirm-repros.e2e.test.ts
@@ -18,7 +18,7 @@ const sharedSlack = vi.hoisted(() => ({
       update: vi.fn().mockResolvedValue({}),
       delete: vi.fn().mockResolvedValue({}),
     },
-    files: { uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F_PLAN' }] }) },
+    files: { uploadV2: vi.fn().mockResolvedValue({ ok: true, files: [{ ok: true, files: [{ id: 'F_PLAN' }] }] }) },
     reactions: { add: vi.fn().mockResolvedValue({}), remove: vi.fn().mockResolvedValue({}) },
     conversations: { replies: vi.fn().mockResolvedValue({ messages: [] }) },
   },

--- a/packages/surfaces/src/__tests__/slack-plan-intent-monkey.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-intent-monkey.e2e.test.ts
@@ -28,7 +28,7 @@ const sharedSlack = vi.hoisted(() => ({
       update: vi.fn().mockResolvedValue({}),
       delete: vi.fn().mockResolvedValue({}),
     },
-    files: { uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F_PLAN' }] }) },
+    files: { uploadV2: vi.fn().mockResolvedValue({ ok: true, files: [{ ok: true, files: [{ id: 'F_PLAN' }] }] }) },
     reactions: { add: vi.fn().mockResolvedValue({}), remove: vi.fn().mockResolvedValue({}) },
     conversations: { replies: vi.fn().mockResolvedValue({ messages: [] }) },
   },

--- a/packages/surfaces/src/__tests__/slack-plan-intent-real-thread-repro.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-intent-real-thread-repro.e2e.test.ts
@@ -31,7 +31,7 @@ const sharedSlack = vi.hoisted(() => ({
       update: vi.fn().mockResolvedValue({}),
       delete: vi.fn().mockResolvedValue({}),
     },
-    files: { uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F_PLAN' }] }) },
+    files: { uploadV2: vi.fn().mockResolvedValue({ ok: true, files: [{ ok: true, files: [{ id: 'F_PLAN' }] }] }) },
     reactions: { add: vi.fn().mockResolvedValue({}), remove: vi.fn().mockResolvedValue({}) },
     conversations: { replies: vi.fn().mockResolvedValue({ messages: [] }) },
   },

--- a/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-submission-repros.e2e.test.ts
@@ -31,7 +31,7 @@ const sharedSlack = vi.hoisted(() => ({
     },
     reactions: { add: vi.fn().mockResolvedValue({}), remove: vi.fn().mockResolvedValue({}) },
     conversations: { replies: vi.fn().mockResolvedValue({ messages: [] }) },
-    files: { uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F1' }] }) },
+    files: { uploadV2: vi.fn().mockResolvedValue({ ok: true, files: [{ ok: true, files: [{ id: 'F1' }] }] }) },
   },
 }));
 

--- a/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
@@ -97,7 +97,7 @@ vi.mock('@slack/bolt', () => {
         }),
       },
       files: {
-        uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F1' }] }),
+        uploadV2: vi.fn().mockResolvedValue({ ok: true, files: [{ ok: true, files: [{ id: 'F1' }] }] }),
       },
     };
   }

--- a/packages/surfaces/src/__tests__/slack-surface.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface.test.ts
@@ -42,7 +42,7 @@ vi.mock('@slack/bolt', () => {
         remove: vi.fn().mockResolvedValue({}),
       },
       files: {
-        uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F_TEST' }] }),
+        uploadV2: vi.fn().mockResolvedValue({ ok: true, files: [{ ok: true, files: [{ id: 'F_TEST' }] }] }),
       },
     };
   }

--- a/packages/surfaces/src/__tests__/slack-terminal-parity.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-terminal-parity.e2e.test.ts
@@ -40,7 +40,7 @@ vi.mock('@slack/bolt', () => {
         test: vi.fn().mockResolvedValue({ user_id: 'UBOT' }),
       },
       files: {
-        uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F1' }] }),
+        uploadV2: vi.fn().mockResolvedValue({ ok: true, files: [{ ok: true, files: [{ id: 'F1' }] }] }),
       },
       reactions: {
         add: vi.fn().mockResolvedValue({}),

--- a/packages/surfaces/src/__tests__/slack-thread-isolation.test.ts
+++ b/packages/surfaces/src/__tests__/slack-thread-isolation.test.ts
@@ -35,7 +35,7 @@ vi.mock('@slack/bolt', () => {
         test: vi.fn().mockResolvedValue({ user_id: 'U_BOT' }),
       },
       files: {
-        uploadV2: vi.fn().mockResolvedValue({ files: [{ id: 'F1' }] }),
+        uploadV2: vi.fn().mockResolvedValue({ ok: true, files: [{ ok: true, files: [{ id: 'F1' }] }] }),
       },
     };
   }

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -1585,8 +1585,8 @@ export class SlackSurface implements Surface {
           filename: `${draft.draftId}.yaml`,
           title: `${summary.name}.yaml`,
         }],
-      }) as unknown as { files?: Array<{ id?: string }> };
-      const fileId = upload.files?.[0]?.id;
+      }) as unknown as { files?: Array<{ files?: Array<{ id?: string }> }> };
+      const fileId = upload.files?.[0]?.files?.[0]?.id;
       if (!fileId) throw new Error('Slack did not return an uploaded YAML file id.');
       this.slackPlanDraftRepo.bindAttachment(draft, fileId);
       this.slackPlanDraftRepo.markReady(draft);


### PR DESCRIPTION
## Summary

Slack plan drafting worked, but the review card always failed with "Slack did not return an uploaded YAML file id", so Approve never appeared and nothing could be submitted.

The bot reads the uploaded file id from the `files.uploadV2` result.

The Slack SDK answers with one nested result per upload job, so the id sits one level deeper than the code expected.

Every test mocked the flat shape instead of the real one, which is how the bug passed the suite.

The mocks now match the SDK. The e2e proofs for the ready card and the full session land in the next slice, #7509.

## Review Claim

Reading the uploaded file id from the nested `files.uploadV2` result restores the Slack plan review card, so drafted plans can be approved and submitted again.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

The only production change is one line inside `postSlackPlanDraft`; every other changed file is test-only. `cd packages/surfaces && pnpm test` exercises the changed behavior directly.

## Slice Rationale

The fix and the mock-shape sync are inseparable: with either half alone the surfaces suite goes red, so they land together and the e2e proofs stack on top in #7509.

## Non-goals

- No change to the artifact upload call, which never reads a file id.
- No change to planning-core or the in-app planner; their suites pass unchanged.
- No change to draft staging behavior beyond the id read.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test`
- [x] `cd packages/planning-core && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d4c9d88eb`
- Post-revert steps: None
- Data migration? No

</details>
