### PR TITLE
[Logger Error Serialization](1) Bugfix: file logger silently drops Error message/stack when serializing log records

### DIFF
--- a/packages/app/src/__tests__/logger-error-serialization.test.ts
+++ b/packages/app/src/__tests__/logger-error-serialization.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { FileAndDbLogger } from '../logger.js';
+
+let tempDir: string | undefined;
+
+afterEach(() => {
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+function makeLogPath(): string {
+  tempDir = mkdtempSync(join(tmpdir(), 'invoker-logger-error-'));
+  return join(tempDir, 'nested', 'invoker.log');
+}
+
+function readRecord(filePath: string): Record<string, unknown> {
+  const line = readFileSync(filePath, 'utf8').trimEnd();
+  return JSON.parse(line) as Record<string, unknown>;
+}
+
+describe('FileAndDbLogger error serialization', () => {
+  it('serializes Error instances in file-backed log fields', () => {
+    const filePath = makeLogPath();
+    const logger = new FileAndDbLogger({}, { filePath });
+
+    logger.error('msg', { err: new Error('boom') });
+
+    const record = readRecord(filePath) as {
+      err: { message?: unknown; stack?: unknown };
+    };
+    expect(record.err.message).toBe('boom');
+    expect(typeof record.err.stack).toBe('string');
+    expect(record.err.stack).not.toBe('');
+  });
+
+  it('preserves plain object error shapes unchanged', () => {
+    const filePath = makeLogPath();
+    const logger = new FileAndDbLogger({}, { filePath });
+    const err = { code: 'ERR_SQLITE_ERROR', errcode: 787 };
+
+    logger.error('msg', { err });
+
+    const record = readRecord(filePath);
+    expect(record.err).toEqual(err);
+  });
+});

--- a/packages/app/src/logger.ts
+++ b/packages/app/src/logger.ts
@@ -15,6 +15,18 @@ const LOG_PATH = path.join(homedir(), '.invoker', 'invoker.log');
 
 type Level = 'debug' | 'info' | 'warn' | 'error';
 
+function errorAwareReplacer(_key: string, value: unknown): unknown {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+      ...value,
+    };
+  }
+  return value;
+}
+
 export interface FileAndDbLoggerOptions {
   /** SQLiteAdapter instance for activity_log writes. Omit to skip DB writes. */
   persistence?: SQLiteAdapter;
@@ -85,7 +97,10 @@ export class FileAndDbLogger implements Logger {
         mkdirSync(path.dirname(this.filePath), { recursive: true });
         this.dirEnsured = true;
       }
-      appendFileSync(this.filePath, JSON.stringify(record) + '\n');
+      appendFileSync(
+        this.filePath,
+        JSON.stringify(record, errorAwareReplacer) + '\n',
+      );
     } catch {
       /* Logging must never crash the app. */
     }


### PR DESCRIPTION
## Summary

The file-backed logger now preserves real `Error` details in JSON log lines.

Before this change, `logger.error(msg, { err })` wrote `err:{}` because `Error.message` and `Error.stack` are non-enumerable.

The file writer now uses an error-aware `JSON.stringify` replacer so logged `Error` values keep `name`, `message`, and `stack`.

Plain object error shapes still serialize unchanged.

## Review Claim

`FileAndDbLogger.writeFile` should expand `Error` instances during JSON serialization so file-backed log records retain the error name, message, stack, and any enumerable subclass fields.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This only changes the JSON written to the log file for already-supplied fields.

It does not change logger call sites, control flow, DB activity-log writes, or whether logging failures are swallowed.

## Slice Rationale

This slice keeps the logger serialization defect and its deterministic regression test together.

The scheduler backoff fix from the same investigation touches a different package and remains independently reviewable.

## Non-goals

Do not change `writeDb`.

Do not change callers of `logger.error`, `logger.warn`, `logger.info`, or `logger.debug`.

Do not add a new `Logger` interface method.

Do not change execution-engine logging or scheduler behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- src/__tests__/logger-error-serialization.test.ts`
- [ ] `cd packages/app && pnpm test` (fails in existing unrelated repro `src/__tests__/repro-orphan-application-quit-mislabel.test.ts`; it now sees `reason: OWNER_RESTART_REASON` in `main.ts`)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 460317f1b`
- Post-revert steps: Re-run `cd packages/app && pnpm test -- src/__tests__/logger-error-serialization.test.ts` to confirm the regression test fails without the fix.
- Data migration? No

</details>
