### PR TITLE
[Logger Error Serialization](1) Bugfix: file logger silently drops Error message/stack when serializing log records

### DIFF
--- a/packages/app/src/__tests__/logger-error-serialization.test.ts
+++ b/packages/app/src/__tests__/logger-error-serialization.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { FileAndDbLogger } from '../logger.js';
+
+let tempDir: string | undefined;
+
+afterEach(() => {
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+function makeLogPath(): string {
+  tempDir = mkdtempSync(join(tmpdir(), 'invoker-logger-error-'));
+  return join(tempDir, 'nested', 'invoker.log');
+}
+
+function readRecord(filePath: string): Record<string, unknown> {
+  const line = readFileSync(filePath, 'utf8').trimEnd();
+  return JSON.parse(line) as Record<string, unknown>;
+}
+
+describe('FileAndDbLogger error serialization', () => {
+  it('serializes Error instances in file-backed log fields', () => {
+    const filePath = makeLogPath();
+    const logger = new FileAndDbLogger({}, { filePath });
+
+    logger.error('msg', { err: new Error('boom') });
+
+    const record = readRecord(filePath) as {
+      err: { message?: unknown; stack?: unknown };
+    };
+    expect(record.err.message).toBe('boom');
+    expect(typeof record.err.stack).toBe('string');
+    expect(record.err.stack).not.toBe('');
+  });
+
+  it('preserves plain object error shapes unchanged', () => {
+    const filePath = makeLogPath();
+    const logger = new FileAndDbLogger({}, { filePath });
+    const err = { code: 'ERR_SQLITE_ERROR', errcode: 787 };
+
+    logger.error('msg', { err });
+
+    const record = readRecord(filePath);
+    expect(record.err).toEqual(err);
+  });
+});

--- a/packages/app/src/logger.ts
+++ b/packages/app/src/logger.ts
@@ -18,10 +18,10 @@ type Level = 'debug' | 'info' | 'warn' | 'error';
 function errorAwareReplacer(_key: string, value: unknown): unknown {
   if (value instanceof Error) {
     return {
+      ...value,
       name: value.name,
       message: value.message,
       stack: value.stack,
-      ...value,
     };
   }
   return value;

--- a/packages/app/src/logger.ts
+++ b/packages/app/src/logger.ts
@@ -15,6 +15,18 @@ const LOG_PATH = path.join(homedir(), '.invoker', 'invoker.log');
 
 type Level = 'debug' | 'info' | 'warn' | 'error';
 
+function errorAwareReplacer(_key: string, value: unknown): unknown {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+      ...value,
+    };
+  }
+  return value;
+}
+
 export interface FileAndDbLoggerOptions {
   /** SQLiteAdapter instance for activity_log writes. Omit to skip DB writes. */
   persistence?: SQLiteAdapter;
@@ -85,7 +97,10 @@ export class FileAndDbLogger implements Logger {
         mkdirSync(path.dirname(this.filePath), { recursive: true });
         this.dirEnsured = true;
       }
-      appendFileSync(this.filePath, JSON.stringify(record) + '\n');
+      appendFileSync(
+        this.filePath,
+        JSON.stringify(record, errorAwareReplacer) + '\n',
+      );
     } catch {
       /* Logging must never crash the app. */
     }

--- a/packages/app/src/logger.ts
+++ b/packages/app/src/logger.ts
@@ -17,12 +17,8 @@ type Level = 'debug' | 'info' | 'warn' | 'error';
 
 function errorAwareReplacer(_key: string, value: unknown): unknown {
   if (value instanceof Error) {
-    return {
-      ...value,
-      name: value.name,
-      message: value.message,
-      stack: value.stack,
-    };
+    const { name, message, stack, ...rest } = value;
+    return { ...rest, name, message, stack };
   }
   return value;
 }


### PR DESCRIPTION
## Summary

File-backed logs now preserve `Error` details when callers include an error object in structured log fields.

Previously, `JSON.stringify` collapsed plain `Error` instances to `{}` because `message` and `stack` are non-enumerable own properties.

The logger now uses an error-aware replacer at the file serialization boundary.

The regression test covers both real `Error` instances and plain SQLite-style error shapes.

## Review Claim

`FileAndDbLogger.writeFile` should serialize `Error` values with `name`, `message`, and `stack` while preserving enumerable custom error fields.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This only changes JSON written to the file log for already-supplied field values. It does not change logger control flow, DB activity logging, or callers.

## Slice Rationale

This slice is limited to the logger's Error-serialization defect and its deterministic regression coverage.

The separate scheduler backoff investigation touches a different runtime file and stays independently reviewable.

## Non-goals

This does not change `writeDb`.

This does not change any `logger.error`, `logger.warn`, or other logger call site.

This does not add a new `Logger` interface method.

This does not touch execution-engine scheduler backoff behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- src/__tests__/logger-error-serialization.test.ts`
- [x] `cd packages/app && pnpm test` (fails on current `master` at `src/__tests__/repro-orphan-application-quit-mislabel.test.ts`; unrelated to this logger diff)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
