### PR TITLE
[Slack Channel Bleed Fix](1) Stop trusting an empty stored channelId as a session match

### DIFF
--- a/packages/surfaces/src/__tests__/thread-session-manager.test.ts
+++ b/packages/surfaces/src/__tests__/thread-session-manager.test.ts
@@ -4,6 +4,9 @@ import * as child_process from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { SQLiteAdapter, ConversationRepository } from '@invoker/data-store';
+
+const silentLogger = { info: () => {}, warn: () => {}, error: () => {} };
 
 // ── Mock child_process.spawn ────────────────────────────────
 
@@ -186,13 +189,15 @@ describe('SessionManager', () => {
     expect(mockRepo.loadConversation).toHaveBeenCalledWith('1234.5678');
   });
 
-  it('recovers session from database when channelId is empty (backward compat)', async () => {
+  it('never trusts an empty stored channelId as a match — starts a fresh session instead of inheriting the orphaned row\'s history', async () => {
     manager.start();
     mockRepo.loadConversation.mockReturnValueOnce({
       threadTs: '1234.5678',
       channelId: '',
       userId: 'U001',
-      messages: [],
+      messages: [
+        { role: 'user', content: 'message from some other, unrelated conversation' },
+      ],
       extractedPlan: null,
       planSubmitted: false,
       createdAt: new Date().toISOString(),
@@ -202,6 +207,18 @@ describe('SessionManager', () => {
     const id = new SessionIdentifier('C123', '1234.5678');
     const handle = await manager.getOrCreateSession(id, 'U001');
     expect(handle).not.toBeNull();
+    // A fresh, empty session — never the orphaned row's history.
+    expect(handle!.history).toEqual([]);
+    // The creation path re-persists this thread with a real, non-empty channelId.
+    expect(mockRepo.saveConversation).toHaveBeenCalledWith(
+      '1234.5678',
+      [],
+      null,
+      false,
+      'C123',
+      'U001',
+      'agent',
+    );
   });
 
   it('persists channelId and userId when creating a new session', async () => {
@@ -373,6 +390,101 @@ describe('SessionManager', () => {
 
     // Sending a message after dispose should throw
     await expect(handle!.sendMessage('test')).rejects.toThrow('disposed');
+  });
+});
+
+// Repro: does the channelId='' "backward compat" bypass (thread-session-manager.ts:355)
+// let an unrelated channel inherit another conversation's full message history?
+//
+// production-realistic writer of channelId='': PlanConversation.saveState()
+// (plan-conversation.ts:994-1002) always calls conversationRepo.saveConversation()
+// with channelId=undefined. SlackSurface.getSession()'s no-sessionManager fallback
+// (slack-surface.ts:3001-3027) constructs PlanConversation directly, with no
+// upfront channel-bearing save — so saveState() is that thread's *first* DB write,
+// leaving channelId='' on the row. This test reproduces that write shape with the
+// real (unmocked) ConversationRepository + SQLiteAdapter, then proves a totally
+// different channel asking for the same thread_ts is handed the first channel's
+// full conversation instead of a fresh session.
+describe('SessionManager channel isolation with real persistence', () => {
+  let adapter: SQLiteAdapter;
+  let repo: ConversationRepository;
+  let manager: SessionManager;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    repo = new ConversationRepository(adapter, silentLogger);
+    manager = new SessionManager({
+      cursorCommand: 'cursor',
+      workingDir: '/fake',
+      conversationRepo: repo,
+      evictionIntervalMs: 60_000,
+    });
+  });
+
+  afterEach(() => {
+    manager.stop();
+    adapter.close();
+  });
+
+  it('does not hand an unrelated channel another conversation\'s history when the row was first written with channelId=""', async () => {
+    const SHARED_THREAD_TS = '1785890000.000001';
+
+    // Step 1: reproduce PlanConversation.saveState()'s exact call shape — the
+    // real production signature when it is the first writer for a thread
+    // (channelId and userId both omitted, i.e. undefined).
+    repo.saveConversation(
+      SHARED_THREAD_TS,
+      [
+        { role: 'user', content: 'Add real enforcement for silent catch blocks — no ESLint here, so it has to be a custom check:no-silent-catch script.' },
+        { role: 'assistant', content: 'Enumeration shows 57 silent .catch() handlers and an unreliable 697 try/catch count. Pick granularity: 1 workflow per violation or per file?' },
+      ],
+      null,
+      false,
+      // channelId, userId, mode all omitted — matches plan-conversation.ts:994-1002
+    );
+
+    const persistedAsWritten = repo.loadConversation(SHARED_THREAD_TS);
+    expect(persistedAsWritten?.channelId).toBe('');
+
+    // Step 2: a completely unrelated channel — a different Slack conversation
+    // about closing empty PRs — happens to ask for the exact same thread_ts
+    // (this is what SlackSurface.recoverActiveConversations() does on restart:
+    // `entry.channelId || this.channelId`, slack-surface.ts:3079-3082, silently
+    // substitutes the bot's default channel whenever the stored channelId is '').
+    manager.start();
+    const unrelatedChannelId = new SessionIdentifier('C-CLOSE-EMPTY-PRS', SHARED_THREAD_TS);
+    const handle = await manager.getOrCreateSession(unrelatedChannelId, 'U-CHIEF-CAT-OFFICER');
+
+    expect(handle).not.toBeNull();
+    // FIXED BEHAVIOR: an empty stored channelId is never trusted as a match, so
+    // the "close empty PRs" channel gets a fresh, empty session — never the
+    // unrelated silent-catch/lint-policy conversation's history.
+    expect(handle!.history).toEqual([]);
+  });
+
+  it('does NOT bleed when the row was first written with a real channelId (control case)', async () => {
+    const SHARED_THREAD_TS = '1785890000.000002';
+
+    // Same shape as above, but simulating the normal getOrCreateSession path,
+    // which always supplies a real channelId on first write.
+    repo.saveConversation(
+      SHARED_THREAD_TS,
+      [{ role: 'user', content: 'unrelated content that belongs to channel C-ORIGINAL' }],
+      null,
+      false,
+      'C-ORIGINAL',
+      'U-SOMEONE',
+      'agent',
+    );
+
+    manager.start();
+    const otherChannelId = new SessionIdentifier('C-DIFFERENT', SHARED_THREAD_TS);
+    const handle = await manager.getOrCreateSession(otherChannelId, 'U-OTHER');
+
+    expect(handle).not.toBeNull();
+    // A real, non-empty stored channelId that doesn't match is NOT trusted —
+    // a brand-new, empty session is created instead. No bleed.
+    expect(handle!.history).toEqual([]);
   });
 });
 

--- a/packages/surfaces/src/slack/thread-session-manager.ts
+++ b/packages/surfaces/src/slack/thread-session-manager.ts
@@ -346,13 +346,13 @@ export class SessionManager {
 
     if (!loaded) {
       this.log('session-manager', 'info', `No persisted conversation for ${id.threadTs}`);
-    } else if (loaded.channelId !== id.channelId && loaded.channelId !== '') {
-      this.log('session-manager', 'warn', `Channel mismatch for ${id.threadTs}: expected=${id.channelId}, found=${loaded.channelId}`);
+    } else if (loaded.channelId !== id.channelId) {
+      this.log('session-manager', 'warn', `Channel mismatch for ${id.threadTs}: expected=${id.channelId}, found=${loaded.channelId || '(empty)'}`);
     }
 
     let handle: SessionHandle;
 
-    if (loaded && (loaded.channelId === id.channelId || loaded.channelId === '')) {
+    if (loaded && loaded.channelId === id.channelId) {
       // Recover existing session
       this.log('session-manager', 'info', `Recovering session ${key} from database`);
 
@@ -517,7 +517,7 @@ export class SessionManager {
     const existing = this.sessions.get(id.toString());
     if (existing) return existing;
     const persisted = this.conversationRepo.loadConversation(id.threadTs);
-    if (!persisted || persisted.planSubmitted || (persisted.channelId && persisted.channelId !== id.channelId)) {
+    if (!persisted || persisted.planSubmitted || persisted.channelId !== id.channelId) {
       return null;
     }
     return this.getOrCreateSession(id, userId, opts);


### PR DESCRIPTION
## Summary

A Slack conversation lookup treated a blank stored channel id as "belongs to whoever asks." Any channel querying the same thread timestamp inherited that conversation's entire prior message history.

This was proven with a real, unmocked SessionManager + persistence layer test: an unrelated channel querying a poisoned thread id got back another conversation's full history.

The lookup now only recovers a conversation when the stored channel id exactly equals the requesting channel id. A blank channel id is always a mismatch, never a match.

## Review Claim

Approve that `SessionManager.getOrCreateSession()` and `SessionManager.getSession()` no longer treat an empty stored channel id as a match, closing the cross-channel history leak even for rows that are already in this state.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

A stored conversation row is only ever recovered into an active session when its persisted channel id exactly equals the requesting channel id. An empty or missing channel id is always treated as a mismatch, so no channel can inherit another channel's conversation history through this lookup.

## Slice Rationale

This is the safety-critical gate by itself, landed before the follow-up slice that stops the blank channel id from ever being written. Landing the gate first closes the hole immediately, including for any row already in this state, independent of whether the write-side fix has shipped yet.

## Non-goals

Does not change how or when a conversation row's channel id gets written — that is the next slice. Does not change eviction, TTL, or plan-submission behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation session recovery by requiring an exact channel match.
  * Prevented orphaned or mismatched conversation history from being reused.
  * Ensured fresh sessions are created and saved with the requested channel information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->