### PR TITLE
[Workflow Submission Storm](2) Retry a pure-client IPC bus's connection instead of giving up forever

### DIFF
--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -328,6 +328,44 @@ describe('IpcBus', () => {
     expect(result).toBe('owner:ok');
   });
 
+  // Regression: a headless CLI constructs its bus with allowServe: false at
+  // process startup, often before any owner process exists yet (socket file
+  // ENOENT). ensureStandaloneOwnerViaBootstrap (packages/app/src/headless-
+  // client.ts) then spawns an owner and polls discoverOwner() on that SAME
+  // bus for up to 60s waiting for it to come up. Before this fix, a pure
+  // client bus that failed its very first connect attempt gave up
+  // permanently — it never retried — so every poll iteration failed
+  // immediately (no peers), and only a fresh bus (via refreshMessageBus())
+  // could ever succeed. That wasted the full 60s timeout on every cold
+  // owner bootstrap, even though the owner was ready in well under a
+  // second. This proves a client-only bus now keeps retrying in the
+  // background and connects once a server appears, without recreating it.
+  it('a client-only bus created before any server exists still connects once one appears later', async () => {
+    const sock = tempSocketPath();
+
+    // No server exists yet at this socket path — this connect attempt must
+    // fail (ENOENT). With the bug, this bus would be permanently unable to
+    // reach any server for the rest of its lifetime.
+    const earlyClient = new IpcBus(sock, { allowServe: false });
+    buses.push(earlyClient);
+    await earlyClient.ready();
+
+    // The server only comes up afterward — simulating the owner process
+    // still booting when the CLI's bus made its first connection attempt.
+    const owner = createBus(sock);
+    await owner.ready();
+    owner.onRequest<string, string>('echo', (value) => `owner:${value}`);
+
+    // Give the background reconnect (25ms interval) a chance to land a peer
+    // before asserting — request() checks live peers synchronously and does
+    // not itself wait for a reconnect in flight.
+    await sleep(150);
+
+    // No new bus is constructed here — the SAME earlyClient must recover.
+    const result = await earlyClient.request<string, string>('echo', 'still-works');
+    expect(result).toBe('owner:still-works');
+  });
+
   it('ignores no-handler responses from other peers when one peer can satisfy the request', async () => {
     const sock = tempSocketPath();
 

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -332,7 +332,15 @@ export class IpcBus implements MessageBus {
 
     sock.on('error', (err: NodeJS.ErrnoException) => {
       if (!this.allowServe) {
+        // A pure client (allowServe: false, e.g. a headless CLI) must never
+        // become the server, but the server it's waiting for may simply not
+        // exist yet (ENOENT while an owner is still booting) or be mid
+        // restart (ECONNREFUSED) — keep retrying in the background so a
+        // caller polling via request()/discoverOwner() eventually succeeds
+        // once a server appears, instead of this bus being permanently
+        // unable to connect for its entire lifetime.
         this.resolveReady();
+        this.scheduleRecovery();
         return;
       }
       if (err.code === 'ECONNREFUSED') {
@@ -396,14 +404,17 @@ export class IpcBus implements MessageBus {
     });
   }
 
+  // Reconnection is valid for both server-capable and pure-client buses —
+  // only *becoming* the server (tryServe) is exclusively gated on
+  // allowServe, and that gate lives in tryConnect()'s error handler above.
   private scheduleRecovery(): void {
-    if (this.disconnected || !this.allowServe || this.server || this.peers.size > 0 || this.serveRetryScheduled) {
+    if (this.disconnected || this.server || this.peers.size > 0 || this.serveRetryScheduled) {
       return;
     }
     this.serveRetryScheduled = true;
     setTimeout(() => {
       this.serveRetryScheduled = false;
-      if (this.disconnected || !this.allowServe || this.server || this.peers.size > 0) {
+      if (this.disconnected || this.server || this.peers.size > 0) {
         return;
       }
       this.tryConnect();


### PR DESCRIPTION
## Summary

The previous slice's benchmark showed the first workflow submission after a cold start taking over sixty seconds, with every later one around 350 milliseconds.

The connection a client process uses to find the shared owner gives up permanently the moment its first attempt fails, even when that failure just means the owner hasn't finished starting yet.

It then wastes the full sixty-second bootstrap window before a separate, later fallback path finally builds a fresh connection that works immediately.

## Review Claim

Approve letting a client-only IPC connection keep retrying after a failed first attempt, instead of giving up for its entire lifetime, so a caller waiting for an owner process to finish starting isn't stuck behind an unrelated sixty-second timeout.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

A client-only connection object may keep retrying to reach a server, but it may never become the server itself — that separate check already exists and is untouched by this change. Reconnection attempts only start a plain socket connect, never a listen/bind.

## Slice Rationale

Stacked on the benchmark slice so the sixty-second cost is demonstrated before this change addresses it.

## Non-goals

Does not change owner discovery, bootstrap spawning, or delegation timeout values. Does not address per-submission cost beyond the cold-start case — every later submission was already comfortably under budget before this change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/transport && pnpm test`
- [ ] `bash scripts/bench-workflow-submission-storm.sh --count 50`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7525