### PR TITLE
[Web Bridge Bind Race](1) Survive a lost web-port bind race instead of dying on an uncaught EADDRINUSE

### DIFF
--- a/packages/app/src/__tests__/web-bridge-port-conflict.test.ts
+++ b/packages/app/src/__tests__/web-bridge-port-conflict.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import http from 'node:http';
+import { tmpdir } from 'node:os';
+import { startWebBridge, type WebBridge } from '../web/web-bridge-server.js';
+
+// Regression fence for the production crashes
+//   uncaughtException: Error: listen EADDRINUSE: address already in use 0.0.0.0:4200
+// (invoker.log 2026-07-30 02:05/04:46, 2026-08-03 19:33/23:18/23:19): the web
+// bridge had no server 'error' listener, so losing the bind race killed the
+// whole booting process. Also fences the refuted storm hypothesis: request
+// bursts never harmed the listener.
+
+const TOKEN = 'repro-token';
+
+function stubDeps() {
+  return {
+    dispatch: (async () => ({})) as never,
+    messageBus: {
+      subscribe: () => () => {},
+      publish: () => {},
+    } as never,
+    persistence: { getActivityLogs: () => [], listWorkflows: () => [] } as never,
+    uiDistDir: tmpdir(),
+    token: TOKEN,
+    host: '127.0.0.1',
+  };
+}
+
+function fire(port: number, path: string, opts: { headers?: Record<string, string>; abortAfterMs?: number } = {}): Promise<number | 'aborted' | 'error'> {
+  return new Promise((resolve) => {
+    const req = http.request({ host: '127.0.0.1', port, path, method: 'GET', headers: opts.headers }, (res) => {
+      res.resume();
+      res.on('end', () => resolve(res.statusCode ?? 0));
+      res.on('error', () => resolve('error'));
+      if (opts.abortAfterMs !== undefined) {
+        setTimeout(() => { req.destroy(); resolve('aborted'); }, opts.abortAfterMs);
+      }
+    });
+    req.on('error', () => resolve(opts.abortAfterMs !== undefined ? 'aborted' : 'error'));
+    req.end();
+  });
+}
+
+describe('web bridge port conflict', () => {
+  it('survives a 600-request connection storm', async () => {
+    const bridge: WebBridge = startWebBridge({ ...stubDeps(), port: 0 });
+    const port = await bridge.whenReady;
+    try {
+      const storm: Promise<unknown>[] = [];
+      for (let i = 0; i < 200; i++) storm.push(fire(port, '/invoke', { headers: { 'x-invoker-token': 'wrong' } }));
+      for (let i = 0; i < 200; i++) storm.push(fire(port, `/events?token=${TOKEN}`, { abortAfterMs: 25 }));
+      for (let i = 0; i < 200; i++) storm.push(fire(port, '/', {}));
+      await Promise.all(storm);
+
+      const after = await fire(port, '/', {});
+      expect(typeof after).toBe('number');
+    } finally {
+      await bridge.close();
+    }
+  }, 30_000);
+
+  it('losing the bind race settles whenReady with EADDRINUSE instead of escalating to a process-level uncaughtException', async () => {
+    const first: WebBridge = startWebBridge({ ...stubDeps(), port: 0 });
+    const port = await first.whenReady;
+
+    const priorListeners = process.listeners('uncaughtException');
+    process.removeAllListeners('uncaughtException');
+    let escalated: Error | null = null;
+    const trap = (err: Error) => { escalated = err; };
+    process.on('uncaughtException', trap);
+    let second: WebBridge | null = null;
+    try {
+      second = startWebBridge({ ...stubDeps(), port });
+
+      const outcome = await Promise.race([
+        second.whenReady.then(
+          () => ({ kind: 'resolved' as const }),
+          (err: NodeJS.ErrnoException) => ({ kind: 'settled-with-failure' as const, code: err.code }),
+        ),
+        new Promise<{ kind: 'dangling' }>((r) => setTimeout(() => r({ kind: 'dangling' }), 5_000)),
+      ]);
+
+      expect(outcome).toEqual({ kind: 'settled-with-failure', code: 'EADDRINUSE' });
+      expect(escalated, 'a lost bind race must never reach the process-level uncaughtException handler').toBeNull();
+
+      const stillServing = await fire(port, '/', {});
+      expect(typeof stillServing, 'the winning listener must be unaffected').toBe('number');
+
+      await expect(second.close()).resolves.toBeUndefined();
+      second = null;
+    } finally {
+      process.removeListener('uncaughtException', trap);
+      for (const l of priorListeners) process.on('uncaughtException', l);
+      await first.close();
+      await second?.close().catch(() => {});
+    }
+  }, 20_000);
+});

--- a/packages/app/src/web/web-bridge-server.ts
+++ b/packages/app/src/web/web-bridge-server.ts
@@ -356,7 +356,24 @@ export function startWebBridge(deps: WebBridgeDeps): WebBridge {
   }, SSE_PING_INTERVAL_MS);
   pingTimer.unref?.();
 
-  const { promise: whenReady, resolve: resolveReady } = Promise.withResolvers<number>();
+  const { promise: whenReady, resolve: resolveReady, reject: rejectReady } = Promise.withResolvers<number>();
+  // Production callers fire-and-forget the bridge; a settled failure must not
+  // become an unhandledRejection while still being observable via whenReady.
+  whenReady.catch(() => {});
+  server.on('error', (err: NodeJS.ErrnoException) => {
+    if (server.listening) {
+      logger?.error(`Web surface server error: ${err.stack ?? err.message}`, { module: 'web-bridge' });
+      return;
+    }
+    clearInterval(activityTimer);
+    clearInterval(workflowsTimer);
+    clearInterval(pingTimer);
+    logger?.error(
+      `Web surface failed to bind http://${host}:${port} (${err.code ?? err.message}) — continuing without the web surface`,
+      { module: 'web-bridge' },
+    );
+    rejectReady(err);
+  });
   server.listen(port, host, () => {
     const address = server.address();
     const boundPort = typeof address === 'object' && address ? address.port : port;


### PR DESCRIPTION
## Summary

Any process that lost the race for the fixed webPort died mid-startup on an uncaught EADDRINUSE. Five such crashes are on record in invoker.log.

The web bridge started listening with no error handler, and whenReady had no failure path, so a lost bind race escalated to a fatal process-level exception.

Losers of the race were transient headless boots and standalone-owner bootstraps that mis-detected "no owner" while the real owner was busy.

Now the server handles the error: one loud log line, bridge timers torn down, and whenReady settles with the failure. Fire-and-forget callers stay safe via a pre-attached handler.

Errors after a successful bind are logged and the listener keeps serving.

A regression test proves the loser survives, the winner keeps serving, and a 600-request storm never harms the listener — the storm hypothesis was tested and refuted.

## Review Claim

A lost webPort bind race is now loud and survivable: whenReady settles with EADDRINUSE, the process never sees an uncaught exception, and the winning listener keeps serving.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The successful-bind path is untouched — same log line, same whenReady resolution. Only the previously fatal failure path changes, and the regression test pins both paths.

## Slice Rationale

The shared scripts/repro proof ships as the stacked next slice (#7529) because this repo's review-unit rule keeps repro scripts out of behavior PRs.

## Non-goals

- No change to which processes attempt to bind the webPort (role/binding policy is a follow-up).
- No change to owner discovery or ping timeouts.
- No change to the api-server listener on 4100.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- src/__tests__/web-bridge-port-conflict.test.ts src/__tests__/web-bridge-server.test.ts src/__tests__/start-web-surface.test.ts src/__tests__/standalone-owner-web-surface.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert fc37178f8`
- Post-revert steps: None
- Data migration? No

</details>
