### PR TITLE
[Repair Outcome Reconciliation](1) Settle fast-path repair submissions by observing workflow outcomes

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -17,6 +17,7 @@ try:
     from .mergify_admin_requeue_snapshot import GhClient
     from .mergify_admin_requeue_workflow_fastpath import (
         resolve_workflow_for_pr,
+        settle_workflow_fastpath_rows,
         submit_rebase_recreate,
         submit_repair_review_gate_ci,
     )
@@ -30,6 +31,7 @@ except ImportError:
     from mergify_admin_requeue_snapshot import GhClient
     from mergify_admin_requeue_workflow_fastpath import (
         resolve_workflow_for_pr,
+        settle_workflow_fastpath_rows,
         submit_rebase_recreate,
         submit_repair_review_gate_ci,
     )
@@ -90,6 +92,12 @@ def run_cycle(args: argparse.Namespace) -> bool:
     loaded = loader.load(args.repo, args.author, args.pr, required_checks, trunk)
     stacks = loaded.stacks
     now = int(time.time())
+    try:
+        fastpath_settled = settle_workflow_fastpath_rows(ledger, now)
+        if fastpath_settled:
+            logger.trace("admin-bypass-fastpath-settled", count=fastpath_settled)
+    except Exception as exc:
+        logger.trace("admin-bypass-fastpath-settle-failed", error=str(exc))
     pr_by_number = {pr.number: pr for stack in stacks for pr in stack.prs}
     logger.trace(
         "admin-bypass-scan-loaded",
@@ -145,7 +153,10 @@ def run_cycle(args: argparse.Namespace) -> bool:
                         workflow_id = resolve_workflow_for_pr(action.pr_number)
                         if workflow_id:
                             submit_repair_review_gate_ci(action.pr_number)
-                            ledger.record("repair-check", action.pr_number, pr.head_ref_oid, check_name, now)
+                            ledger.record(
+                                "repair-check", action.pr_number, pr.head_ref_oid, check_name, now,
+                                meta={"workflowId": workflow_id, "via": "fastpath"},
+                            )
                             progressed = True
                         else:
                             outcome = repairer.repair_check(pr, check_name, now)
@@ -171,7 +182,10 @@ def run_cycle(args: argparse.Namespace) -> bool:
                     workflow_id = resolve_workflow_for_pr(action.pr_number)
                     if workflow_id:
                         submit_rebase_recreate(workflow_id)
-                        ledger.record("conflict-repair", action.pr_number, pr.head_ref_oid, action.key, now)
+                        ledger.record(
+                            "conflict-repair", action.pr_number, pr.head_ref_oid, action.key, now,
+                            meta={"workflowId": workflow_id, "via": "fastpath"},
+                        )
                         progressed = True
                     else:
                         outcome = repairer.repair_conflict(pr, action.detail, now)

--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -48,6 +48,83 @@ def submit_rebase_recreate(workflow_id: str) -> None:
         )
 
 
+# Fast-path submissions are fire-and-forget: `--no-track` exit 0 means the
+# owner ACCEPTED the mutation, not that the repair ran. Unlike repairer.py's
+# ad-hoc repair plans (whose normalize task writes the `-settled` ledger row),
+# a rebase-recreate of an existing workflow has no task that settles the
+# ledger, so the planner could only infer the outcome by letting the 90-minute
+# repair_in_flight TTL expire. These helpers close that gap by observing the
+# workflow's actual terminal status and writing the settle row the plan
+# machinery already understands (PR #7484, 2026-08-05: an accepted-but-starved
+# recreate looked "handled" while its three predecessors had already failed).
+
+_FASTPATH_SETTLE_KINDS = ("conflict-repair", "repair-check")
+_TERMINAL_WORKFLOW_STATUSES = frozenset({"completed", "failed", "cancelled", "review_ready", "merged"})
+
+
+def _parse_last_json_object(stdout: str) -> dict | None:
+    text = stdout.strip()
+    if not text:
+        return None
+    try:
+        parsed = json.loads(text)
+        return parsed if isinstance(parsed, dict) else None
+    except json.JSONDecodeError:
+        pass
+    for line in reversed(text.splitlines()):
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+def workflow_status(workflow_id: str) -> str | None:
+    completed = _run_headless('headless_query query workflow "$2" --output json', workflow_id)
+    if completed.returncode != 0:
+        return None
+    record = _parse_last_json_object(completed.stdout)
+    if record is None:
+        return None
+    status = record.get("status")
+    return str(status) if status else None
+
+
+def settle_workflow_fastpath_rows(ledger, now: int) -> int:
+    """Write `<kind>-settled` rows for fast-path submissions whose workflow
+    reached a terminal status. Returns how many rows were settled. Rows whose
+    workflow is still pending/running (or whose status cannot be read) are
+    left alone; the existing repair_in_flight TTL stays as the backstop."""
+    settled = 0
+    for row in list(ledger.rows):
+        kind = row.get("kind")
+        if kind not in _FASTPATH_SETTLE_KINDS:
+            continue
+        meta = row.get("meta") or {}
+        workflow_id = meta.get("workflowId")
+        if not workflow_id:
+            continue
+        pr = int(row.get("pr", -1))
+        head = str(row.get("headSha") or "")
+        key = str(row.get("key") or "")
+        existing = ledger.latest(f"{kind}-settled", pr, head, key)
+        if existing is not None and int(existing.get("epoch", 0) or 0) >= int(row.get("epoch", 0) or 0):
+            continue
+        status = workflow_status(str(workflow_id))
+        if status in _TERMINAL_WORKFLOW_STATUSES:
+            ledger.record(
+                f"{kind}-settled", pr, head, key, now,
+                meta={"workflowId": str(workflow_id), "workflowStatus": status, "settledBy": "fastpath-observer"},
+            )
+            settled += 1
+    return settled
+
+
 def submit_repair_review_gate_ci(pr_number: int) -> None:
     completed = _run_headless('headless_mutation --no-track repair-review-gate-ci "$2"', str(pr_number))
     if completed.returncode != 0:

--- a/scripts/test_mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/test_mergify_admin_requeue_workflow_fastpath.py
@@ -110,3 +110,67 @@ class SubmitClosePr(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class FastpathSettleObserver(unittest.TestCase):
+    def _ledger(self, tmpdir):
+        from mergify_admin_requeue_model import Ledger
+        return Ledger(Path(tmpdir) / "state.jsonl")
+
+    def test_settles_submitted_row_when_workflow_terminal(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            ledger.record("conflict-repair", 7484, "head1", "conflict:7484", 100,
+                          meta={"workflowId": "wf-1", "via": "fastpath"})
+            with mock.patch.object(f, "workflow_status", return_value="failed"):
+                settled = f.settle_workflow_fastpath_rows(ledger, 200)
+            self.assertEqual(settled, 1)
+            row = ledger.latest("conflict-repair-settled", 7484, "head1", "conflict:7484")
+            self.assertIsNotNone(row)
+            self.assertEqual(row["meta"]["workflowStatus"], "failed")
+            self.assertEqual(row["meta"]["workflowId"], "wf-1")
+
+    def test_leaves_running_workflow_unsettled(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            ledger.record("conflict-repair", 7484, "head1", "conflict:7484", 100,
+                          meta={"workflowId": "wf-1", "via": "fastpath"})
+            with mock.patch.object(f, "workflow_status", return_value="running"):
+                self.assertEqual(f.settle_workflow_fastpath_rows(ledger, 200), 0)
+            self.assertIsNone(ledger.latest("conflict-repair-settled", 7484, "head1", "conflict:7484"))
+
+    def test_skips_rows_without_workflow_handle(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            ledger.record("conflict-repair", 7484, "head1", "conflict:7484", 100)
+            with mock.patch.object(f, "workflow_status") as status:
+                self.assertEqual(f.settle_workflow_fastpath_rows(ledger, 200), 0)
+                status.assert_not_called()
+
+    def test_does_not_resettle_already_settled_row(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            ledger.record("repair-check", 7055, "head2", "pr-body", 100,
+                          meta={"workflowId": "wf-2", "via": "fastpath"})
+            ledger.record("repair-check-settled", 7055, "head2", "pr-body", 150,
+                          meta={"workflowId": "wf-2"})
+            with mock.patch.object(f, "workflow_status") as status:
+                self.assertEqual(f.settle_workflow_fastpath_rows(ledger, 200), 0)
+                status.assert_not_called()
+
+    def test_unreadable_status_leaves_row_for_ttl_backstop(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            ledger.record("conflict-repair", 7484, "head1", "conflict:7484", 100,
+                          meta={"workflowId": "wf-1", "via": "fastpath"})
+            with mock.patch.object(f, "workflow_status", return_value=None):
+                self.assertEqual(f.settle_workflow_fastpath_rows(ledger, 200), 0)
+
+    def test_parse_last_json_object_skips_noise_lines(self):
+        stdout = '[invoker] maxConcurrency=13 exceeds pool capacity\n{"id": "wf-1", "status": "failed"}\n'
+        self.assertEqual(f._parse_last_json_object(stdout), {"id": "wf-1", "status": "failed"})


### PR DESCRIPTION
## Summary
Fast-path repairs (rebase-recreate / repair-review-gate-ci) were fire-and-forget: `--no-track` exit 0 meant the mutation was accepted, not that it ran.

Fast-path submissions now record their workflowId, and each tick observes those workflows, writing the same `-settled` row the plan machinery already understands.

## Review Claim
Fast-path repair submissions settle by observing their own workflow outcome, instead of relying only on the 90-minute repair_in_flight TTL to infer success or failure.

## Review Lane
policy

## Review Unit
tooling-policy

## Safety Invariant
Only a terminal workflow status (success or failure) writes the `-settled` row; running workflows and unreadable statuses are left untouched for the existing TTL backstop to reclaim.

## Slice Rationale
Isolated to the mergify admin-requeue scripts that add workflow-outcome observation; no execution-engine or product package files are touched in this slice.

## Non-goals
Does not change the TTL backstop itself.

## Test Plan
<details>
<summary>Test Plan</summary>

`python3 scripts/test_mergify_admin_requeue_workflow_fastpath.py` covering settle_workflow_fastpath_rows.

</details>

## Revert Plan
<details>
<summary>Revert Plan</summary>

Revert this commit. Fast-path submissions fall back to TTL-only inference; no ledger schema change, so no data migration is needed.

</details>

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
