### PR TITLE
[Repair Outcome Reconciliation](3) Group-kill only a verified group leader in e2e teardown

### DIFF
--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -18,6 +18,7 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { pathToFileURL } from 'node:url';
 import { stringify as yamlStringify } from 'yaml';
 import { registerTrackedBrowserUserDataDir } from './browser-process-registry.js';
+import { killOwnedProcessGroup } from './process-group.js';
 
 export type ElectronFixtures = {
   electronApp: ElectronApplication;
@@ -106,10 +107,9 @@ export async function closeElectronApp(app: ElectronApplication): Promise<void> 
   if (!childExited) {
     child.kill('SIGTERM');
     if (child.pid && process.platform !== 'win32') {
-      try {
-        process.kill(-child.pid, 'SIGTERM');
-      } catch {
-        // Process group may already be gone.
+      const groupKill = killOwnedProcessGroup(child.pid, 'SIGTERM');
+      if (groupKill !== 'group-killed') {
+        console.warn(`[electron-app fixture] group kill for pid ${child.pid} not sent (${groupKill}); killed the child alone`);
       }
     }
     await Promise.race([closePromise, childExitPromise, delay(2_000)]);

--- a/packages/app/e2e/fixtures/process-group.ts
+++ b/packages/app/e2e/fixtures/process-group.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Process-group helpers for fixture teardown. A group kill aimed at
+ * `-child.pid` only reaches the child's own tree when the child leads its own
+ * process group (pgid === pid). When it does not — the child was not spawned
+ * detached, or its pid matches an unrelated group's id — the same call
+ * signals whichever process group happens to carry that id. On 2026-08-05 a
+ * SIGTERM the production owner survived (worker + web-bridge teardown, owner
+ * pgid 1164189, a long-freed pid) showed why an unverified group kill behind
+ * a silent catch is not acceptable teardown behavior.
+ */
+export function readProcessGroupId(pid: number): number | null {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+    const afterComm = stat.slice(stat.lastIndexOf(')') + 2);
+    const fields = afterComm.split(' ');
+    const pgid = Number.parseInt(fields[2] ?? '', 10);
+    return Number.isFinite(pgid) ? pgid : null;
+  } catch {
+    // /proc unavailable (non-linux) — fall through to ps.
+  }
+  try {
+    const out = execFileSync('ps', ['-o', 'pgid=', '-p', String(pid)], { encoding: 'utf8' });
+    const pgid = Number.parseInt(out.trim(), 10);
+    return Number.isFinite(pgid) ? pgid : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * SIGTERM the child's process group only when the child verifiably leads it.
+ * Returns what happened so callers can log it; never throws.
+ */
+export function killOwnedProcessGroup(pid: number, signal: NodeJS.Signals = 'SIGTERM'): 'group-killed' | 'skipped-not-leader' | 'skipped-unknown-pgid' | 'kill-failed' {
+  const pgid = readProcessGroupId(pid);
+  if (pgid === null) return 'skipped-unknown-pgid';
+  if (pgid !== pid) return 'skipped-not-leader';
+  try {
+    process.kill(-pid, signal);
+    return 'group-killed';
+  } catch {
+    return 'kill-failed';
+  }
+}

--- a/packages/app/src/__tests__/process-group-guard.test.ts
+++ b/packages/app/src/__tests__/process-group-guard.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { readProcessGroupId, killOwnedProcessGroup } from '../../e2e/fixtures/process-group.js';
+
+// Regression fence for 2026-08-05T07:02:45Z: fixture teardown ran
+// `process.kill(-child.pid, 'SIGTERM')` behind a bare silent catch without
+// verifying the child leads the group with that id. A group id is just a pid;
+// when the child is not its own group leader (or the pid matches a foreign
+// group after pid reuse) the identical call SIGTERMs an unrelated process
+// tree — the production owner survived exactly such a signal, losing all its
+// workers and its web bridge. The guard only group-kills a verified leader.
+
+const children: ChildProcess[] = [];
+
+function spawnSleeper(opts: { detached: boolean }): Promise<ChildProcess> {
+  const child = spawn('sleep', ['30'], { detached: opts.detached, stdio: 'ignore' });
+  children.push(child);
+  return new Promise((resolve, reject) => {
+    child.once('spawn', () => resolve(child));
+    child.once('error', reject);
+  });
+}
+
+afterEach(() => {
+  for (const child of children.splice(0)) {
+    try {
+      if (child.pid) {
+        try { process.kill(-child.pid, 'SIGKILL'); } catch { /* not a leader */ }
+        child.kill('SIGKILL');
+      }
+    } catch { /* already gone */ }
+  }
+});
+
+describe('process group teardown guard', () => {
+  it('reads the real pgid: detached child leads its own group, non-detached child does not', async () => {
+    const leader = await spawnSleeper({ detached: true });
+    const follower = await spawnSleeper({ detached: false });
+    expect(readProcessGroupId(leader.pid!)).toBe(leader.pid);
+    expect(readProcessGroupId(follower.pid!)).toBe(process.platform === 'linux' ? readProcessGroupId(process.pid) : readProcessGroupId(follower.pid!));
+    expect(readProcessGroupId(follower.pid!)).not.toBe(follower.pid);
+  });
+
+  it('group-kills a verified leader and its group', async () => {
+    const leader = await spawnSleeper({ detached: true });
+    const exited = new Promise<NodeJS.Signals | number | null>((resolve) => {
+      leader.once('exit', (code, signal) => resolve(signal ?? code));
+    });
+    expect(killOwnedProcessGroup(leader.pid!, 'SIGTERM')).toBe('group-killed');
+    expect(await exited).toBe('SIGTERM');
+  });
+
+  it('REPRO: the pre-fix unguarded shape signals a foreign process group; the guard refuses', async () => {
+    // The victim stands in for the production owner: a detached process
+    // leading a group whose id has nothing to do with the fixture's child.
+    const victim = await spawnSleeper({ detached: true });
+    const nonLeader = await spawnSleeper({ detached: false });
+
+    // Pre-fix shape: kill the group with id == some pid we did not verify.
+    // Aimed at the victim's group id, it reaches the victim even though the
+    // victim is not the child being torn down.
+    const victimExited = new Promise<NodeJS.Signals | number | null>((resolve) => {
+      victim.once('exit', (code, signal) => resolve(signal ?? code));
+    });
+    try {
+      process.kill(-victim.pid!, 'SIGTERM');
+    } catch {
+      // the silent catch from the pre-fix fixture
+    }
+    expect(await victimExited).toBe('SIGTERM');
+
+    // Fixed shape: the guard refuses to group-kill a pid that does not lead
+    // its own group, so a foreign group can never be struck via a non-leader
+    // child pid.
+    expect(killOwnedProcessGroup(nonLeader.pid!, 'SIGTERM')).toBe('skipped-not-leader');
+    expect(nonLeader.exitCode).toBeNull();
+  });
+});

--- a/packages/execution-engine/src/__tests__/worker-runtime-survived-signal-restart.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-runtime-survived-signal-restart.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWorkerRuntime } from '../worker-runtime.js';
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn(), child: vi.fn() };
+
+// Regression fence for 2026-08-05T07:02:45Z: the owner process received a
+// SIGTERM it survived; every worker's process.once handler stopped its
+// runtime permanently, leaving a half-dead owner (running workflows, no
+// PR-maintenance workers, no scanning) for over an hour with only an info
+// log. With restartAfterSurvivedSignalMs set, a signal the process outlives
+// restarts the worker and logs an error.
+
+const TEST_SIGNAL = 'SIGUSR2' as const;
+
+describe('createWorkerRuntime restartAfterSurvivedSignalMs', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    process.removeAllListeners(TEST_SIGNAL);
+  });
+
+  it('restarts the worker when the process survives a shutdown signal', async () => {
+    const onTick = vi.fn();
+    const runtime = createWorkerRuntime({
+      kind: 'test-survivor',
+      logger,
+      onTick,
+      intervalMs: 0,
+      tickOnStart: false,
+      shutdownSignals: [TEST_SIGNAL],
+      installSignalHandlers: true,
+      restartAfterSurvivedSignalMs: 50,
+    });
+
+    runtime.start();
+    expect(runtime.isRunning()).toBe(true);
+
+    process.emit(TEST_SIGNAL, TEST_SIGNAL);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(runtime.isRunning()).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(60);
+    expect(runtime.isRunning()).toBe(true);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('process survived SIGUSR2'),
+      expect.anything(),
+    );
+
+    await runtime.tick();
+    expect(onTick).toHaveBeenCalledTimes(1);
+
+    await runtime.stop();
+  });
+
+  it('a second survived signal after restart restarts again', async () => {
+    const runtime = createWorkerRuntime({
+      kind: 'test-survivor-twice',
+      logger,
+      onTick: vi.fn(),
+      intervalMs: 0,
+      tickOnStart: false,
+      shutdownSignals: [TEST_SIGNAL],
+      installSignalHandlers: true,
+      restartAfterSurvivedSignalMs: 50,
+    });
+
+    runtime.start();
+    process.emit(TEST_SIGNAL, TEST_SIGNAL);
+    await vi.advanceTimersByTimeAsync(60);
+    expect(runtime.isRunning()).toBe(true);
+
+    process.emit(TEST_SIGNAL, TEST_SIGNAL);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(runtime.isRunning()).toBe(false);
+    await vi.advanceTimersByTimeAsync(60);
+    expect(runtime.isRunning()).toBe(true);
+
+    await runtime.stop();
+  });
+
+  it('default behavior is unchanged: signal stop is final', async () => {
+    const runtime = createWorkerRuntime({
+      kind: 'test-final-stop',
+      logger,
+      onTick: vi.fn(),
+      intervalMs: 0,
+      tickOnStart: false,
+      shutdownSignals: [TEST_SIGNAL],
+      installSignalHandlers: true,
+    });
+
+    runtime.start();
+    process.emit(TEST_SIGNAL, TEST_SIGNAL);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(runtime.isRunning()).toBe(false);
+  });
+});

--- a/packages/execution-engine/src/worker-runtime.ts
+++ b/packages/execution-engine/src/worker-runtime.ts
@@ -70,6 +70,15 @@ export interface WorkerRuntimeOptions {
   shutdownSignals?: NodeJS.Signals[];
   /** Install process signal handlers on `start()`. Default `true`. */
   installSignalHandlers?: boolean;
+  /**
+   * When > 0 and a shutdown signal stopped this runtime but the process is
+   * still alive this many ms later, log an error and restart the runtime.
+   * A signal a long-lived owner survives must not permanently strip its
+   * workers (2026-08-05: a SIGTERM the owner outlived silently killed all
+   * PR-maintenance workers for over an hour). Default 0 (signal stop is
+   * final), preserving shutdown semantics for processes that exit.
+   */
+  restartAfterSurvivedSignalMs?: number;
 }
 
 export interface WorkerRuntime {
@@ -248,7 +257,22 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
       for (const signal of shutdownSignals) {
         const handler = (): void => {
           options.logger.info(`[worker:${identity.kind}] received ${signal}; shutting down`, logFields);
-          void stop({ settleTimeoutMs: 5_000 });
+          const stopping = stop({ settleTimeoutMs: 5_000 });
+          const restartMs = options.restartAfterSurvivedSignalMs ?? 0;
+          if (restartMs <= 0) return;
+          void stopping.then(() => {
+            const timer = setTimeout(() => {
+              options.logger.error(
+                `[worker:${identity.kind}] process survived ${signal} for ${restartMs}ms after worker stop; restarting worker`,
+                logFields,
+              );
+              stopped = false;
+              started = false;
+              abortController = new AbortController();
+              start();
+            }, restartMs);
+            timer.unref?.();
+          });
         };
         signalHandlers.set(signal, handler);
         process.once(signal, handler);

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -94,6 +94,8 @@ export interface PrMaintenanceWorkerOptions extends PrMaintenanceWorkerConfig {
   logger: Logger;
   instanceId?: string;
   installSignalHandlers?: boolean;
+  /** See WorkerRuntimeOptions.restartAfterSurvivedSignalMs. Default 30s for PR-maintenance workers. */
+  restartAfterSurvivedSignalMs?: number;
   tickOnStart?: boolean;
   onTick?: WorkerTick;
   spawnProcess?: typeof spawn;
@@ -229,6 +231,7 @@ function createPrMaintenanceWorker(
     startDelayMs: options.startDelayMs,
     tickOnStart: options.tickOnStart ?? false,
     installSignalHandlers: options.installSignalHandlers,
+    restartAfterSurvivedSignalMs: options.restartAfterSurvivedSignalMs ?? 30_000,
     onTick: options.onTick ?? createPrMaintenanceTick({
       entrypoint,
       logger: options.logger,

--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -17,6 +17,7 @@ try:
     from .mergify_admin_requeue_snapshot import GhClient
     from .mergify_admin_requeue_workflow_fastpath import (
         resolve_workflow_for_pr,
+        settle_workflow_fastpath_rows,
         submit_rebase_recreate,
         submit_repair_review_gate_ci,
     )
@@ -30,6 +31,7 @@ except ImportError:
     from mergify_admin_requeue_snapshot import GhClient
     from mergify_admin_requeue_workflow_fastpath import (
         resolve_workflow_for_pr,
+        settle_workflow_fastpath_rows,
         submit_rebase_recreate,
         submit_repair_review_gate_ci,
     )
@@ -90,6 +92,12 @@ def run_cycle(args: argparse.Namespace) -> bool:
     loaded = loader.load(args.repo, args.author, args.pr, required_checks, trunk)
     stacks = loaded.stacks
     now = int(time.time())
+    try:
+        fastpath_settled = settle_workflow_fastpath_rows(ledger, now)
+        if fastpath_settled:
+            logger.trace("admin-bypass-fastpath-settled", count=fastpath_settled)
+    except Exception as exc:
+        logger.trace("admin-bypass-fastpath-settle-failed", error=str(exc))
     pr_by_number = {pr.number: pr for stack in stacks for pr in stack.prs}
     logger.trace(
         "admin-bypass-scan-loaded",
@@ -145,7 +153,10 @@ def run_cycle(args: argparse.Namespace) -> bool:
                         workflow_id = resolve_workflow_for_pr(action.pr_number)
                         if workflow_id:
                             submit_repair_review_gate_ci(action.pr_number)
-                            ledger.record("repair-check", action.pr_number, pr.head_ref_oid, check_name, now)
+                            ledger.record(
+                                "repair-check", action.pr_number, pr.head_ref_oid, check_name, now,
+                                meta={"workflowId": workflow_id, "via": "fastpath"},
+                            )
                             progressed = True
                         else:
                             outcome = repairer.repair_check(pr, check_name, now)
@@ -171,7 +182,10 @@ def run_cycle(args: argparse.Namespace) -> bool:
                     workflow_id = resolve_workflow_for_pr(action.pr_number)
                     if workflow_id:
                         submit_rebase_recreate(workflow_id)
-                        ledger.record("conflict-repair", action.pr_number, pr.head_ref_oid, action.key, now)
+                        ledger.record(
+                            "conflict-repair", action.pr_number, pr.head_ref_oid, action.key, now,
+                            meta={"workflowId": workflow_id, "via": "fastpath"},
+                        )
                         progressed = True
                     else:
                         outcome = repairer.repair_conflict(pr, action.detail, now)

--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -48,6 +48,83 @@ def submit_rebase_recreate(workflow_id: str) -> None:
         )
 
 
+# Fast-path submissions are fire-and-forget: `--no-track` exit 0 means the
+# owner ACCEPTED the mutation, not that the repair ran. Unlike repairer.py's
+# ad-hoc repair plans (whose normalize task writes the `-settled` ledger row),
+# a rebase-recreate of an existing workflow has no task that settles the
+# ledger, so the planner could only infer the outcome by letting the 90-minute
+# repair_in_flight TTL expire. These helpers close that gap by observing the
+# workflow's actual terminal status and writing the settle row the plan
+# machinery already understands (PR #7484, 2026-08-05: an accepted-but-starved
+# recreate looked "handled" while its three predecessors had already failed).
+
+_FASTPATH_SETTLE_KINDS = ("conflict-repair", "repair-check")
+_TERMINAL_WORKFLOW_STATUSES = frozenset({"completed", "failed", "cancelled", "review_ready", "merged"})
+
+
+def _parse_last_json_object(stdout: str) -> dict | None:
+    text = stdout.strip()
+    if not text:
+        return None
+    try:
+        parsed = json.loads(text)
+        return parsed if isinstance(parsed, dict) else None
+    except json.JSONDecodeError:
+        pass
+    for line in reversed(text.splitlines()):
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+def workflow_status(workflow_id: str) -> str | None:
+    completed = _run_headless('headless_query query workflow "$2" --output json', workflow_id)
+    if completed.returncode != 0:
+        return None
+    record = _parse_last_json_object(completed.stdout)
+    if record is None:
+        return None
+    status = record.get("status")
+    return str(status) if status else None
+
+
+def settle_workflow_fastpath_rows(ledger, now: int) -> int:
+    """Write `<kind>-settled` rows for fast-path submissions whose workflow
+    reached a terminal status. Returns how many rows were settled. Rows whose
+    workflow is still pending/running (or whose status cannot be read) are
+    left alone; the existing repair_in_flight TTL stays as the backstop."""
+    settled = 0
+    for row in list(ledger.rows):
+        kind = row.get("kind")
+        if kind not in _FASTPATH_SETTLE_KINDS:
+            continue
+        meta = row.get("meta") or {}
+        workflow_id = meta.get("workflowId")
+        if not workflow_id:
+            continue
+        pr = int(row.get("pr", -1))
+        head = str(row.get("headSha") or "")
+        key = str(row.get("key") or "")
+        existing = ledger.latest(f"{kind}-settled", pr, head, key)
+        if existing is not None and int(existing.get("epoch", 0) or 0) >= int(row.get("epoch", 0) or 0):
+            continue
+        status = workflow_status(str(workflow_id))
+        if status in _TERMINAL_WORKFLOW_STATUSES:
+            ledger.record(
+                f"{kind}-settled", pr, head, key, now,
+                meta={"workflowId": str(workflow_id), "workflowStatus": status, "settledBy": "fastpath-observer"},
+            )
+            settled += 1
+    return settled
+
+
 def submit_repair_review_gate_ci(pr_number: int) -> None:
     completed = _run_headless('headless_mutation --no-track repair-review-gate-ci "$2"', str(pr_number))
     if completed.returncode != 0:

--- a/scripts/test_mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/test_mergify_admin_requeue_workflow_fastpath.py
@@ -110,3 +110,67 @@ class SubmitClosePr(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class FastpathSettleObserver(unittest.TestCase):
+    def _ledger(self, tmpdir):
+        from mergify_admin_requeue_model import Ledger
+        return Ledger(Path(tmpdir) / "state.jsonl")
+
+    def test_settles_submitted_row_when_workflow_terminal(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            ledger.record("conflict-repair", 7484, "head1", "conflict:7484", 100,
+                          meta={"workflowId": "wf-1", "via": "fastpath"})
+            with mock.patch.object(f, "workflow_status", return_value="failed"):
+                settled = f.settle_workflow_fastpath_rows(ledger, 200)
+            self.assertEqual(settled, 1)
+            row = ledger.latest("conflict-repair-settled", 7484, "head1", "conflict:7484")
+            self.assertIsNotNone(row)
+            self.assertEqual(row["meta"]["workflowStatus"], "failed")
+            self.assertEqual(row["meta"]["workflowId"], "wf-1")
+
+    def test_leaves_running_workflow_unsettled(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            ledger.record("conflict-repair", 7484, "head1", "conflict:7484", 100,
+                          meta={"workflowId": "wf-1", "via": "fastpath"})
+            with mock.patch.object(f, "workflow_status", return_value="running"):
+                self.assertEqual(f.settle_workflow_fastpath_rows(ledger, 200), 0)
+            self.assertIsNone(ledger.latest("conflict-repair-settled", 7484, "head1", "conflict:7484"))
+
+    def test_skips_rows_without_workflow_handle(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            ledger.record("conflict-repair", 7484, "head1", "conflict:7484", 100)
+            with mock.patch.object(f, "workflow_status") as status:
+                self.assertEqual(f.settle_workflow_fastpath_rows(ledger, 200), 0)
+                status.assert_not_called()
+
+    def test_does_not_resettle_already_settled_row(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            ledger.record("repair-check", 7055, "head2", "pr-body", 100,
+                          meta={"workflowId": "wf-2", "via": "fastpath"})
+            ledger.record("repair-check-settled", 7055, "head2", "pr-body", 150,
+                          meta={"workflowId": "wf-2"})
+            with mock.patch.object(f, "workflow_status") as status:
+                self.assertEqual(f.settle_workflow_fastpath_rows(ledger, 200), 0)
+                status.assert_not_called()
+
+    def test_unreadable_status_leaves_row_for_ttl_backstop(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            ledger.record("conflict-repair", 7484, "head1", "conflict:7484", 100,
+                          meta={"workflowId": "wf-1", "via": "fastpath"})
+            with mock.patch.object(f, "workflow_status", return_value=None):
+                self.assertEqual(f.settle_workflow_fastpath_rows(ledger, 200), 0)
+
+    def test_parse_last_json_object_skips_noise_lines(self):
+        stdout = '[invoker] maxConcurrency=13 exceeds pool capacity\n{"id": "wf-1", "status": "failed"}\n'
+        self.assertEqual(f._parse_last_json_object(stdout), {"id": "wf-1", "status": "failed"})


### PR DESCRIPTION
## Summary

At 07:02:45 on 2026-08-05 the production owner caught a SIGTERM no in-repo sender logged. Its workers and web bridge died; the process survived.

The one in-repo shape capable of that silently is the electron-app fixture teardown: `process.kill(-child.pid, SIGTERM)` behind a bare empty catch.

A group id is just a pid. When the torn-down child does not lead that group — or the id matches a foreign group after pid reuse — the same call SIGTERMs an unrelated tree.

Teardown now group-kills only when /proc (or ps) confirms the child leads its own group, and logs a warning naming why a group kill was skipped.

The repro test proves both halves: the pre-fix shape striking a foreign group, and the guard refusing a non-leader pid. The exact 07:02:45 sender left no trail; this closes the mechanism.

## Review Claim

E2e teardown can no longer SIGTERM a process group it does not own: group kills require a verified group leader, and every skipped kill says why.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Only test-fixture files change; the guarded path still kills the child itself and still escalates to SIGKILL, so leaked test apps are reaped exactly as before when the child leads its own group.

## Slice Rationale

Stacked with the outage's other fixes because this is the third leg of the same incident: the likely signal source, alongside stranded repairs (#7534) and worker death (#7535).

## Non-goals

- No production runtime changes.
- No attribution of the specific 07:02:45 sender; only the mechanism is closed.
- No changes to how test apps are launched.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- src/__tests__/process-group-guard.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e1b6045`
- Post-revert steps: None
- Data migration? No

</details>
