### PR TITLE
[Repair Outcome Reconciliation](4) Stall watchdog: a worker that stops ticking says so at error level

### DIFF
--- a/packages/execution-engine/src/__tests__/worker-runtime-stall-watchdog.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-runtime-stall-watchdog.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWorkerRuntime } from '../worker-runtime.js';
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn(), child: vi.fn() };
+
+// Regression fence for 2026-08-05: pr-admin-bypass-land stopped ticking at
+// 07:02:45Z and nothing said so for over an hour. A hung or dead tick loop
+// must announce itself: the watchdog logs an error once no tick activity has
+// happened for 2x the poll interval.
+
+describe('createWorkerRuntime stall watchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('logs an error when a hung tick blocks the loop for 2x the interval', async () => {
+    const hangForever = () => new Promise<void>(() => {});
+    const runtime = createWorkerRuntime({
+      kind: 'test-stall',
+      logger,
+      onTick: hangForever,
+      intervalMs: 100,
+      tickOnStart: true,
+      installSignalHandlers: false,
+    });
+
+    runtime.start();
+    await vi.advanceTimersByTimeAsync(150);
+    expect(logger.error).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('looks stalled'),
+      expect.anything(),
+    );
+    expect(logger.error).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+
+    await runtime.stop({ settleTimeoutMs: 0 });
+  });
+
+  it('healthy ticking never trips the watchdog', async () => {
+    const runtime = createWorkerRuntime({
+      kind: 'test-healthy',
+      logger,
+      onTick: vi.fn().mockResolvedValue(undefined),
+      intervalMs: 100,
+      tickOnStart: true,
+      installSignalHandlers: false,
+    });
+
+    runtime.start();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(logger.error).not.toHaveBeenCalled();
+
+    await runtime.stop();
+  });
+
+  it('recovers after a stall: a completed tick re-arms the single-shot log for the next stall', async () => {
+    let release: (() => void) | null = null;
+    let mode: 'hang-releasable' | 'fast' | 'hang-forever' = 'hang-releasable';
+    const runtime = createWorkerRuntime({
+      kind: 'test-stall-recover',
+      logger,
+      onTick: () => {
+        if (mode === 'fast') return Promise.resolve();
+        if (mode === 'hang-forever') return new Promise<void>(() => {});
+        return new Promise<void>((r) => { release = r; });
+      },
+      intervalMs: 100,
+      tickOnStart: true,
+      installSignalHandlers: false,
+    });
+
+    runtime.start();
+    await vi.advanceTimersByTimeAsync(350);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+
+    mode = 'fast';
+    release?.();
+    await vi.advanceTimersByTimeAsync(300);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+
+    mode = 'hang-forever';
+    await vi.advanceTimersByTimeAsync(400);
+    expect(logger.error).toHaveBeenCalledTimes(2);
+
+    await runtime.stop({ settleTimeoutMs: 0 });
+  });
+});

--- a/packages/execution-engine/src/worker-runtime.ts
+++ b/packages/execution-engine/src/worker-runtime.ts
@@ -145,6 +145,9 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
   let inFlight: Promise<void> | null = null;
   let pendingReason: WorkerTickReason | null = null;
   let tickNumber = 0;
+  let lastTickActivityAt = Date.now();
+  let watchdogTimer: NodeJS.Timeout | null = null;
+  let stallLogged = false;
   const signalHandlers = new Map<NodeJS.Signals, () => void>();
   let abortController = new AbortController();
 
@@ -156,6 +159,7 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
       tickNumber,
       signal: abortController.signal,
     };
+    lastTickActivityAt = Date.now();
     try {
       await options.onTick(ctx);
       return true;
@@ -166,6 +170,9 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
       }
       options.logger.error(`[worker:${identity.kind}] tick failed`, { ...logFields, reason, err });
       return false;
+    } finally {
+      lastTickActivityAt = Date.now();
+      stallLogged = false;
     }
   };
 
@@ -228,6 +235,10 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
     if (interval) {
       clearInterval(interval);
       interval = null;
+    }
+    if (watchdogTimer) {
+      clearInterval(watchdogTimer);
+      watchdogTimer = null;
     }
     if (startDelayTimer) {
       clearTimeout(startDelayTimer);
@@ -298,6 +309,19 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
       if (intervalMs > 0) {
         interval = setInterval(() => wake('poll'), intervalMs);
         interval.unref?.();
+        lastTickActivityAt = Date.now();
+        stallLogged = false;
+        watchdogTimer = setInterval(() => {
+          const idleMs = Date.now() - lastTickActivityAt;
+          if (idleMs > intervalMs * 2 && !stallLogged) {
+            stallLogged = true;
+            options.logger.error(
+              `[worker:${identity.kind}] no tick activity for ${idleMs}ms (interval ${intervalMs}ms) — worker looks stalled`,
+              { ...logFields, tickNumber },
+            );
+          }
+        }, intervalMs);
+        watchdogTimer.unref?.();
       }
       if (tickOnStart) wake('startup');
     };


### PR DESCRIPTION
## Summary

When pr-admin-bypass-land stopped ticking at 07:02:45 on 2026-08-05, nothing said so for over an hour.

A hung tick is worse than a dead one: the coalescing scheduler waits on it forever, so polling silently stops with no log at any level.

The runtime now tracks tick activity. When polling is enabled and no tick has started or finished for twice the poll interval, it logs one error naming the idle time.

A completed tick re-arms the watchdog, so each distinct stall logs exactly once.

## Review Claim

A worker whose tick loop stops making progress announces it at error level within two poll intervals, and a recovered worker re-arms the alarm for the next stall.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The watchdog is observation-only — an unref'd timer that logs; it never restarts, aborts, or reschedules ticks, so tick semantics are byte-for-byte unchanged.

## Slice Rationale

Final leg of the outage stack: #7534 unstrands repairs, #7535 revives signal-stopped workers, #7539 closes the likely signal source, and this makes any future silent stall visible.

## Non-goals

- No automatic recovery from stalls (observation only).
- No changes to tick scheduling or coalescing.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/worker-runtime-stall-watchdog.test.ts src/__tests__/worker-runtime-survived-signal-restart.test.ts src/__tests__/worker-runtime-start-delay.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 921ba2a`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added monitoring to detect when worker processing becomes unresponsive.
  - Logs an error when a worker remains stalled beyond the expected polling interval.
  - Resumes stall detection after completed work and safely stops monitoring during shutdown.

- **Tests**
  - Added coverage for stalled workers, healthy processing, and recovery followed by a later stall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->