### PR TITLE
[Unknown State Invariant](1) Surface failed disk-headroom checks as an explicit unknown state

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-headroom-monitor.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-monitor.test.ts
@@ -74,23 +74,28 @@ describe('runDiskHeadroomCheck — local disk', () => {
     expect((deps.logger as any).debug).toHaveBeenCalled();
   });
 
-  it('logs and swallows a df failure without throwing', async () => {
+  it('surfaces a df failure as an unknown-level evaluation instead of dropping it', async () => {
     const deps = baseDeps({
       runLocalDf: async () => {
         throw new Error('df down');
       },
     });
 
-    await expect(runDiskHeadroomCheck(deps)).resolves.toEqual([]);
+    const results = await runDiskHeadroomCheck(deps);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ label: 'local /tmp', level: 'unknown', error: 'df down' });
+    expect((results[0] as any).usage).toBeUndefined();
     expect((deps.logger as any).error).toHaveBeenCalled();
   });
 
-  it('logs unparseable df output', async () => {
+  it('surfaces unparseable df output as an unknown-level evaluation instead of dropping it', async () => {
     const deps = baseDeps({
       runLocalDf: async () => 'garbage',
     });
 
-    await expect(runDiskHeadroomCheck(deps)).resolves.toEqual([]);
+    const results = await runDiskHeadroomCheck(deps);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ label: 'local /tmp', level: 'unknown' });
     expect((deps.logger as any).error).toHaveBeenCalled();
   });
 
@@ -126,7 +131,7 @@ describe('runDiskHeadroomCheck — remote targets', () => {
     expect((deps.logger as any).warn).toHaveBeenCalled();
   });
 
-  it('logs and swallows a remote df failure', async () => {
+  it('surfaces a remote df failure as unknown instead of dropping the target', async () => {
     const deps = baseDeps({
       remoteTargets: [{ name: 'a', connection: CONN, remotePath: '~/.invoker' }],
       runLocalDf: async () => dfAt(10),
@@ -136,7 +141,9 @@ describe('runDiskHeadroomCheck — remote targets', () => {
     });
 
     const results = await runDiskHeadroomCheck(deps);
-    expect(results).toHaveLength(1);
+    expect(results).toHaveLength(2);
+    const remote = results.find((r) => r.label.startsWith('ssh:'));
+    expect(remote).toMatchObject({ level: 'unknown', error: 'remote down' });
     expect((deps.logger as any).error).toHaveBeenCalled();
   });
 });

--- a/packages/execution-engine/src/__tests__/disk-headroom-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-worker.test.ts
@@ -47,6 +47,10 @@ function warnEval(label: string): DiskHeadroomEvaluation {
   };
 }
 
+function unknownEval(label: string, error = 'df failed'): DiskHeadroomEvaluation {
+  return { label, level: 'unknown', thresholds: { warnPercent: 85, criticalPercent: 95 }, error };
+}
+
 describe('disk-headroom worker', () => {
   it('registers and runs a disk check on tick', async () => {
     const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
@@ -212,5 +216,110 @@ describe('disk-headroom worker', () => {
 
     await runtime.tick('manual');
     expect(cleanupLocal).not.toHaveBeenCalled();
+  });
+
+  it('does not alert on a single unknown check for a target', async () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerDiskHeadroomWorker(registry);
+
+    const localLabel = 'local /tmp/invoker-home';
+    const logger = makeLogger();
+    const writeActivityLog = vi.fn();
+    const upsertWorkerAction = vi.fn((row: unknown) => row);
+    const definition = registry.get(DISK_HEADROOM_WORKER_KIND)!;
+    const runtime = definition.factory({
+      store: { upsertWorkerAction } as any,
+      submitter: { submit: vi.fn() } as any,
+      logger,
+      diskHeadroom: {
+        localPath: '/tmp/invoker-home',
+        remoteTargets: [],
+        intervalMs: 0,
+        tickOnStart: false,
+        cleanupEnabled: false,
+        runCheck: async () => [unknownEval(localLabel)],
+        writeActivityLog,
+      },
+    });
+
+    await runtime.tick('manual');
+
+    expect(upsertWorkerAction).not.toHaveBeenCalled();
+    expect(writeActivityLog).not.toHaveBeenCalled();
+  });
+
+  it('alerts once a target has repeated unknown checks in a row', async () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerDiskHeadroomWorker(registry);
+
+    const localLabel = 'local /tmp/invoker-home';
+    const logger = makeLogger();
+    const writeActivityLog = vi.fn();
+    const upsertWorkerAction = vi.fn((row: unknown) => row);
+    const definition = registry.get(DISK_HEADROOM_WORKER_KIND)!;
+    const runtime = definition.factory({
+      store: { upsertWorkerAction } as any,
+      submitter: { submit: vi.fn() } as any,
+      logger,
+      diskHeadroom: {
+        localPath: '/tmp/invoker-home',
+        remoteTargets: [],
+        intervalMs: 0,
+        tickOnStart: false,
+        cleanupEnabled: false,
+        runCheck: async () => [unknownEval(localLabel, 'ssh timeout')],
+        writeActivityLog,
+      },
+    });
+
+    await runtime.tick('manual');
+    expect(upsertWorkerAction).not.toHaveBeenCalled();
+
+    await runtime.tick('manual');
+    expect(upsertWorkerAction).toHaveBeenCalledTimes(1);
+    expect(upsertWorkerAction.mock.calls[0]?.[0]).toMatchObject({
+      workerKind: DISK_HEADROOM_WORKER_KIND,
+      actionType: 'disk-check-unknown',
+      subjectId: localLabel,
+      status: 'skipped',
+      payload: { reason: 'ssh timeout' },
+    });
+    expect(writeActivityLog).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalled();
+
+    await runtime.tick('manual');
+    expect(upsertWorkerAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the unknown streak once a check for that target succeeds again', async () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerDiskHeadroomWorker(registry);
+
+    const localLabel = 'local /tmp/invoker-home';
+    const upsertWorkerAction = vi.fn((row: unknown) => row);
+    let tick = 0;
+    const definition = registry.get(DISK_HEADROOM_WORKER_KIND)!;
+    const runtime = definition.factory({
+      store: { upsertWorkerAction } as any,
+      submitter: { submit: vi.fn() } as any,
+      logger: makeLogger(),
+      diskHeadroom: {
+        localPath: '/tmp/invoker-home',
+        remoteTargets: [],
+        intervalMs: 0,
+        tickOnStart: false,
+        cleanupEnabled: false,
+        runCheck: async () => {
+          tick += 1;
+          return [tick === 2 ? warnEval(localLabel) : unknownEval(localLabel)];
+        },
+      },
+    });
+
+    await runtime.tick('manual');
+    await runtime.tick('manual');
+    await runtime.tick('manual');
+
+    expect(upsertWorkerAction).not.toHaveBeenCalled();
   });
 });

--- a/packages/execution-engine/src/workers/disk-headroom-monitor.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-monitor.ts
@@ -97,6 +97,15 @@ function auditLog(
 }
 
 function emit(deps: DiskHeadroomMonitorDeps, result: DiskHeadroomEvaluation): void {
+  if (result.level === 'unknown') {
+    deps.logger.warn(`[disk-headroom] unknown: ${result.label} (${result.error ?? 'check failed'})`, {
+      module: MODULE,
+      label: result.label,
+      error: result.error,
+    });
+    return;
+  }
+
   const fields = {
     module: MODULE,
     label: result.label,
@@ -127,20 +136,25 @@ async function checkOne(
   deps: DiskHeadroomMonitorDeps,
   label: string,
   runDf: () => Promise<string>,
-): Promise<DiskHeadroomEvaluation | null> {
+): Promise<DiskHeadroomEvaluation> {
   let stdout = '';
   try {
     stdout = await runDf();
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     deps.logger.error(`[disk-headroom] df failed for ${label}: ${reason}`, { module: MODULE, label });
-    return null;
+    const result: DiskHeadroomEvaluation = { label, level: 'unknown', thresholds: deps.thresholds, error: reason };
+    emit(deps, result);
+    return result;
   }
 
   const usage = parseDfOutput(stdout);
   if (!usage) {
-    deps.logger.error(`[disk-headroom] unparseable df output for ${label}`, { module: MODULE, label });
-    return null;
+    const reason = 'unparseable df output';
+    deps.logger.error(`[disk-headroom] ${reason} for ${label}`, { module: MODULE, label });
+    const result: DiskHeadroomEvaluation = { label, level: 'unknown', thresholds: deps.thresholds, error: reason };
+    emit(deps, result);
+    return result;
   }
 
   const result = evaluateDiskHeadroom(usage, deps.thresholds, label);
@@ -150,8 +164,10 @@ async function checkOne(
 
 /**
  * Run one disk-headroom pass: the local disk, then every remote target in
- * parallel. Returns the evaluations that succeeded (parse/df failures are
- * logged and omitted). Never throws.
+ * parallel. Every target always contributes exactly one entry — a target
+ * whose check couldn't complete (df failed, unparseable output) is included
+ * with level 'unknown' rather than being silently omitted, so a target that
+ * can't be verified never goes unnoticed. Never throws.
  */
 export async function runDiskHeadroomCheck(
   deps: DiskHeadroomMonitorDeps,
@@ -159,11 +175,8 @@ export async function runDiskHeadroomCheck(
   const runLocal = deps.runLocalDf ?? defaultRunLocalDf;
   const runRemote = deps.runRemoteDf ?? defaultRunRemoteDf;
 
-  const results: DiskHeadroomEvaluation[] = [];
-
   const localLabel = `local ${deps.localPath}`;
   const local = await checkOne(deps, localLabel, () => runLocal(deps.localPath));
-  if (local) results.push(local);
 
   const remotes = await Promise.all(
     deps.remoteTargets.map(async (target) => {
@@ -171,11 +184,8 @@ export async function runDiskHeadroomCheck(
       return checkOne(deps, label, () => runRemote(target));
     }),
   );
-  for (const r of remotes) {
-    if (r) results.push(r);
-  }
 
-  return results;
+  return [local, ...remotes];
 }
 
 export interface DiskHeadroomMonitorHandle {

--- a/packages/execution-engine/src/workers/disk-headroom-worker.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-worker.ts
@@ -84,6 +84,22 @@ function isEvaluationList(value: unknown): value is DiskHeadroomEvaluation[] {
   return Array.isArray(value);
 }
 
+const UNKNOWN_ALERT_STREAK = 2;
+
+class DiskUnknownStreakTracker {
+  private readonly streaks = new Map<string, number>();
+
+  recordAndShouldAlert(targetKey: string, isUnknown: boolean): boolean {
+    if (!isUnknown) {
+      this.streaks.delete(targetKey);
+      return false;
+    }
+    const next = (this.streaks.get(targetKey) ?? 0) + 1;
+    this.streaks.set(targetKey, next);
+    return next === UNKNOWN_ALERT_STREAK;
+  }
+}
+
 function recordCleanupDecision(
   store: WorkerDecisionStore | undefined,
   result: DiskCleanupResult,
@@ -115,6 +131,7 @@ export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): Wo
   const cooldown = new DiskCleanupCooldownTracker(
     options.cleanupCooldownMs ?? resolveDiskCleanupCooldownMs(),
   );
+  const unknownStreaks = new DiskUnknownStreakTracker();
 
   return createWorkerRuntime({
     kind: DISK_HEADROOM_WORKER_KIND,
@@ -135,8 +152,32 @@ export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): Wo
         writeActivityLog: options.writeActivityLog,
       });
       if (ctx.signal?.aborted) return;
-      if (!cleanupEnabled) return;
       if (!isEvaluationList(evaluationsRaw)) return;
+
+      for (const evaluation of evaluationsRaw) {
+        const shouldAlert = unknownStreaks.recordAndShouldAlert(
+          evaluation.label,
+          evaluation.level === 'unknown',
+        );
+        if (!shouldAlert) continue;
+        const message = `[disk-headroom] ${evaluation.label} has failed its last ${UNKNOWN_ALERT_STREAK} disk checks — usage can no longer be verified`;
+        options.logger.error(message, { module: 'disk-headroom', targetKey: evaluation.label });
+        options.writeActivityLog?.('error', message);
+        if (options.store) {
+          recordWorkerDecisionRow(options.store, {
+            workerKind: DISK_HEADROOM_WORKER_KIND,
+            actionType: 'disk-check-unknown',
+            externalKey: `unknown:${evaluation.label}`,
+            subjectType: 'disk-target',
+            subjectId: evaluation.label,
+            status: 'skipped',
+            summary: message,
+            reason: evaluation.level === 'unknown' ? evaluation.error : undefined,
+          });
+        }
+      }
+
+      if (!cleanupEnabled) return;
 
       const critical = evaluationsRaw.filter((e) => e.level === 'critical');
       for (const evaluation of critical) {

--- a/packages/execution-engine/src/workers/disk-headroom.ts
+++ b/packages/execution-engine/src/workers/disk-headroom.ts
@@ -14,19 +14,28 @@ export interface DiskUsage {
   mountedOn: string;
 }
 
-export type DiskHeadroomLevel = 'ok' | 'warn' | 'critical';
+export type DiskHeadroomLevel = 'ok' | 'warn' | 'critical' | 'unknown';
 
 export interface DiskHeadroomThresholds {
   warnPercent: number;
   criticalPercent: number;
 }
 
-export interface DiskHeadroomEvaluation {
+export interface DiskHeadroomEvaluationVerified {
   label: string;
-  level: DiskHeadroomLevel;
+  level: 'ok' | 'warn' | 'critical';
   usage: DiskUsage;
   thresholds: DiskHeadroomThresholds;
 }
+
+export interface DiskHeadroomEvaluationUnknown {
+  label: string;
+  level: 'unknown';
+  thresholds: DiskHeadroomThresholds;
+  error: string;
+}
+
+export type DiskHeadroomEvaluation = DiskHeadroomEvaluationVerified | DiskHeadroomEvaluationUnknown;
 
 function parsePositiveInt(raw: string): number | null {
   if (!raw) return null;


### PR DESCRIPTION
## Summary

When a disk check on a remote host fails to run (SSH down, `df` timing out), the failure used to vanish entirely.

The host never appeared in the evaluated set, so nothing about it was ever recorded.

Now a failed check always produces exactly one entry, carrying a new `unknown` level and an error message, instead of disappearing.

A single failed check stays quiet, matching today's behavior. Only a host that keeps failing across ticks escalates to an operator-facing alert.

## Review Claim

Approve treating a failed disk-headroom check as a first-class `unknown` result instead of dropping it from the evaluated set.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A target whose disk usage can't be verified is surfaced as a distinct, escalating `unknown` state instead of silently vanishing from the monitored set. The existing `critical`-level cleanup filter is untouched, so `unknown` entries correctly never trigger destructive cleanup.

## Slice Rationale

First of five independent fixes applying the same invariant — an ambiguous read must produce an explicit unknown outcome rather than a convenient default. Each fix touches a different package and ships as its own reviewable slice.

## Non-goals

This does not change the critical-level cleanup threshold or which hosts trigger destructive cleanup. Other packages (lock-holder detection, dependency resolution, launch dispatch, terminal UI) are separate slices later in this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>