### PR TITLE
[Unknown State Invariant](2) Distinguish an unreadable lock file from no lock holder

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-headroom-monitor.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-monitor.test.ts
@@ -74,23 +74,28 @@ describe('runDiskHeadroomCheck — local disk', () => {
     expect((deps.logger as any).debug).toHaveBeenCalled();
   });
 
-  it('logs and swallows a df failure without throwing', async () => {
+  it('surfaces a df failure as an unknown-level evaluation instead of dropping it', async () => {
     const deps = baseDeps({
       runLocalDf: async () => {
         throw new Error('df down');
       },
     });
 
-    await expect(runDiskHeadroomCheck(deps)).resolves.toEqual([]);
+    const results = await runDiskHeadroomCheck(deps);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ label: 'local /tmp', level: 'unknown', error: 'df down' });
+    expect((results[0] as any).usage).toBeUndefined();
     expect((deps.logger as any).error).toHaveBeenCalled();
   });
 
-  it('logs unparseable df output', async () => {
+  it('surfaces unparseable df output as an unknown-level evaluation instead of dropping it', async () => {
     const deps = baseDeps({
       runLocalDf: async () => 'garbage',
     });
 
-    await expect(runDiskHeadroomCheck(deps)).resolves.toEqual([]);
+    const results = await runDiskHeadroomCheck(deps);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ label: 'local /tmp', level: 'unknown' });
     expect((deps.logger as any).error).toHaveBeenCalled();
   });
 
@@ -126,7 +131,7 @@ describe('runDiskHeadroomCheck — remote targets', () => {
     expect((deps.logger as any).warn).toHaveBeenCalled();
   });
 
-  it('logs and swallows a remote df failure', async () => {
+  it('surfaces a remote df failure as unknown instead of dropping the target', async () => {
     const deps = baseDeps({
       remoteTargets: [{ name: 'a', connection: CONN, remotePath: '~/.invoker' }],
       runLocalDf: async () => dfAt(10),
@@ -136,7 +141,9 @@ describe('runDiskHeadroomCheck — remote targets', () => {
     });
 
     const results = await runDiskHeadroomCheck(deps);
-    expect(results).toHaveLength(1);
+    expect(results).toHaveLength(2);
+    const remote = results.find((r) => r.label.startsWith('ssh:'));
+    expect(remote).toMatchObject({ level: 'unknown', error: 'remote down' });
     expect((deps.logger as any).error).toHaveBeenCalled();
   });
 });

--- a/packages/execution-engine/src/__tests__/disk-headroom-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-worker.test.ts
@@ -47,6 +47,10 @@ function warnEval(label: string): DiskHeadroomEvaluation {
   };
 }
 
+function unknownEval(label: string, error = 'df failed'): DiskHeadroomEvaluation {
+  return { label, level: 'unknown', thresholds: { warnPercent: 85, criticalPercent: 95 }, error };
+}
+
 describe('disk-headroom worker', () => {
   it('registers and runs a disk check on tick', async () => {
     const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
@@ -212,5 +216,110 @@ describe('disk-headroom worker', () => {
 
     await runtime.tick('manual');
     expect(cleanupLocal).not.toHaveBeenCalled();
+  });
+
+  it('does not alert on a single unknown check for a target', async () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerDiskHeadroomWorker(registry);
+
+    const localLabel = 'local /tmp/invoker-home';
+    const logger = makeLogger();
+    const writeActivityLog = vi.fn();
+    const upsertWorkerAction = vi.fn((row: unknown) => row);
+    const definition = registry.get(DISK_HEADROOM_WORKER_KIND)!;
+    const runtime = definition.factory({
+      store: { upsertWorkerAction } as any,
+      submitter: { submit: vi.fn() } as any,
+      logger,
+      diskHeadroom: {
+        localPath: '/tmp/invoker-home',
+        remoteTargets: [],
+        intervalMs: 0,
+        tickOnStart: false,
+        cleanupEnabled: false,
+        runCheck: async () => [unknownEval(localLabel)],
+        writeActivityLog,
+      },
+    });
+
+    await runtime.tick('manual');
+
+    expect(upsertWorkerAction).not.toHaveBeenCalled();
+    expect(writeActivityLog).not.toHaveBeenCalled();
+  });
+
+  it('alerts once a target has repeated unknown checks in a row', async () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerDiskHeadroomWorker(registry);
+
+    const localLabel = 'local /tmp/invoker-home';
+    const logger = makeLogger();
+    const writeActivityLog = vi.fn();
+    const upsertWorkerAction = vi.fn((row: unknown) => row);
+    const definition = registry.get(DISK_HEADROOM_WORKER_KIND)!;
+    const runtime = definition.factory({
+      store: { upsertWorkerAction } as any,
+      submitter: { submit: vi.fn() } as any,
+      logger,
+      diskHeadroom: {
+        localPath: '/tmp/invoker-home',
+        remoteTargets: [],
+        intervalMs: 0,
+        tickOnStart: false,
+        cleanupEnabled: false,
+        runCheck: async () => [unknownEval(localLabel, 'ssh timeout')],
+        writeActivityLog,
+      },
+    });
+
+    await runtime.tick('manual');
+    expect(upsertWorkerAction).not.toHaveBeenCalled();
+
+    await runtime.tick('manual');
+    expect(upsertWorkerAction).toHaveBeenCalledTimes(1);
+    expect(upsertWorkerAction.mock.calls[0]?.[0]).toMatchObject({
+      workerKind: DISK_HEADROOM_WORKER_KIND,
+      actionType: 'disk-check-unknown',
+      subjectId: localLabel,
+      status: 'skipped',
+      payload: { reason: 'ssh timeout' },
+    });
+    expect(writeActivityLog).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalled();
+
+    await runtime.tick('manual');
+    expect(upsertWorkerAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the unknown streak once a check for that target succeeds again', async () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerDiskHeadroomWorker(registry);
+
+    const localLabel = 'local /tmp/invoker-home';
+    const upsertWorkerAction = vi.fn((row: unknown) => row);
+    let tick = 0;
+    const definition = registry.get(DISK_HEADROOM_WORKER_KIND)!;
+    const runtime = definition.factory({
+      store: { upsertWorkerAction } as any,
+      submitter: { submit: vi.fn() } as any,
+      logger: makeLogger(),
+      diskHeadroom: {
+        localPath: '/tmp/invoker-home',
+        remoteTargets: [],
+        intervalMs: 0,
+        tickOnStart: false,
+        cleanupEnabled: false,
+        runCheck: async () => {
+          tick += 1;
+          return [tick === 2 ? warnEval(localLabel) : unknownEval(localLabel)];
+        },
+      },
+    });
+
+    await runtime.tick('manual');
+    await runtime.tick('manual');
+    await runtime.tick('manual');
+
+    expect(upsertWorkerAction).not.toHaveBeenCalled();
   });
 });

--- a/packages/execution-engine/src/workers/disk-headroom-monitor.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-monitor.ts
@@ -97,6 +97,15 @@ function auditLog(
 }
 
 function emit(deps: DiskHeadroomMonitorDeps, result: DiskHeadroomEvaluation): void {
+  if (result.level === 'unknown') {
+    deps.logger.warn(`[disk-headroom] unknown: ${result.label} (${result.error ?? 'check failed'})`, {
+      module: MODULE,
+      label: result.label,
+      error: result.error,
+    });
+    return;
+  }
+
   const fields = {
     module: MODULE,
     label: result.label,
@@ -127,20 +136,25 @@ async function checkOne(
   deps: DiskHeadroomMonitorDeps,
   label: string,
   runDf: () => Promise<string>,
-): Promise<DiskHeadroomEvaluation | null> {
+): Promise<DiskHeadroomEvaluation> {
   let stdout = '';
   try {
     stdout = await runDf();
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     deps.logger.error(`[disk-headroom] df failed for ${label}: ${reason}`, { module: MODULE, label });
-    return null;
+    const result: DiskHeadroomEvaluation = { label, level: 'unknown', thresholds: deps.thresholds, error: reason };
+    emit(deps, result);
+    return result;
   }
 
   const usage = parseDfOutput(stdout);
   if (!usage) {
-    deps.logger.error(`[disk-headroom] unparseable df output for ${label}`, { module: MODULE, label });
-    return null;
+    const reason = 'unparseable df output';
+    deps.logger.error(`[disk-headroom] ${reason} for ${label}`, { module: MODULE, label });
+    const result: DiskHeadroomEvaluation = { label, level: 'unknown', thresholds: deps.thresholds, error: reason };
+    emit(deps, result);
+    return result;
   }
 
   const result = evaluateDiskHeadroom(usage, deps.thresholds, label);
@@ -150,8 +164,10 @@ async function checkOne(
 
 /**
  * Run one disk-headroom pass: the local disk, then every remote target in
- * parallel. Returns the evaluations that succeeded (parse/df failures are
- * logged and omitted). Never throws.
+ * parallel. Every target always contributes exactly one entry — a target
+ * whose check couldn't complete (df failed, unparseable output) is included
+ * with level 'unknown' rather than being silently omitted, so a target that
+ * can't be verified never goes unnoticed. Never throws.
  */
 export async function runDiskHeadroomCheck(
   deps: DiskHeadroomMonitorDeps,
@@ -159,11 +175,8 @@ export async function runDiskHeadroomCheck(
   const runLocal = deps.runLocalDf ?? defaultRunLocalDf;
   const runRemote = deps.runRemoteDf ?? defaultRunRemoteDf;
 
-  const results: DiskHeadroomEvaluation[] = [];
-
   const localLabel = `local ${deps.localPath}`;
   const local = await checkOne(deps, localLabel, () => runLocal(deps.localPath));
-  if (local) results.push(local);
 
   const remotes = await Promise.all(
     deps.remoteTargets.map(async (target) => {
@@ -171,11 +184,8 @@ export async function runDiskHeadroomCheck(
       return checkOne(deps, label, () => runRemote(target));
     }),
   );
-  for (const r of remotes) {
-    if (r) results.push(r);
-  }
 
-  return results;
+  return [local, ...remotes];
 }
 
 export interface DiskHeadroomMonitorHandle {

--- a/packages/execution-engine/src/workers/disk-headroom-worker.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-worker.ts
@@ -84,6 +84,22 @@ function isEvaluationList(value: unknown): value is DiskHeadroomEvaluation[] {
   return Array.isArray(value);
 }
 
+const UNKNOWN_ALERT_STREAK = 2;
+
+class DiskUnknownStreakTracker {
+  private readonly streaks = new Map<string, number>();
+
+  recordAndShouldAlert(targetKey: string, isUnknown: boolean): boolean {
+    if (!isUnknown) {
+      this.streaks.delete(targetKey);
+      return false;
+    }
+    const next = (this.streaks.get(targetKey) ?? 0) + 1;
+    this.streaks.set(targetKey, next);
+    return next === UNKNOWN_ALERT_STREAK;
+  }
+}
+
 function recordCleanupDecision(
   store: WorkerDecisionStore | undefined,
   result: DiskCleanupResult,
@@ -115,6 +131,7 @@ export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): Wo
   const cooldown = new DiskCleanupCooldownTracker(
     options.cleanupCooldownMs ?? resolveDiskCleanupCooldownMs(),
   );
+  const unknownStreaks = new DiskUnknownStreakTracker();
 
   return createWorkerRuntime({
     kind: DISK_HEADROOM_WORKER_KIND,
@@ -135,8 +152,32 @@ export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): Wo
         writeActivityLog: options.writeActivityLog,
       });
       if (ctx.signal?.aborted) return;
-      if (!cleanupEnabled) return;
       if (!isEvaluationList(evaluationsRaw)) return;
+
+      for (const evaluation of evaluationsRaw) {
+        const shouldAlert = unknownStreaks.recordAndShouldAlert(
+          evaluation.label,
+          evaluation.level === 'unknown',
+        );
+        if (!shouldAlert) continue;
+        const message = `[disk-headroom] ${evaluation.label} has failed its last ${UNKNOWN_ALERT_STREAK} disk checks — usage can no longer be verified`;
+        options.logger.error(message, { module: 'disk-headroom', targetKey: evaluation.label });
+        options.writeActivityLog?.('error', message);
+        if (options.store) {
+          recordWorkerDecisionRow(options.store, {
+            workerKind: DISK_HEADROOM_WORKER_KIND,
+            actionType: 'disk-check-unknown',
+            externalKey: `unknown:${evaluation.label}`,
+            subjectType: 'disk-target',
+            subjectId: evaluation.label,
+            status: 'skipped',
+            summary: message,
+            reason: evaluation.level === 'unknown' ? evaluation.error : undefined,
+          });
+        }
+      }
+
+      if (!cleanupEnabled) return;
 
       const critical = evaluationsRaw.filter((e) => e.level === 'critical');
       for (const evaluation of critical) {

--- a/packages/execution-engine/src/workers/disk-headroom.ts
+++ b/packages/execution-engine/src/workers/disk-headroom.ts
@@ -14,19 +14,28 @@ export interface DiskUsage {
   mountedOn: string;
 }
 
-export type DiskHeadroomLevel = 'ok' | 'warn' | 'critical';
+export type DiskHeadroomLevel = 'ok' | 'warn' | 'critical' | 'unknown';
 
 export interface DiskHeadroomThresholds {
   warnPercent: number;
   criticalPercent: number;
 }
 
-export interface DiskHeadroomEvaluation {
+export interface DiskHeadroomEvaluationVerified {
   label: string;
-  level: DiskHeadroomLevel;
+  level: 'ok' | 'warn' | 'critical';
   usage: DiskUsage;
   thresholds: DiskHeadroomThresholds;
 }
+
+export interface DiskHeadroomEvaluationUnknown {
+  label: string;
+  level: 'unknown';
+  thresholds: DiskHeadroomThresholds;
+  error: string;
+}
+
+export type DiskHeadroomEvaluation = DiskHeadroomEvaluationVerified | DiskHeadroomEvaluationUnknown;
 
 function parsePositiveInt(raw: string): number | null {
   if (!raw) return null;

--- a/packages/slack-manager/src/__tests__/invoker-client.test.ts
+++ b/packages/slack-manager/src/__tests__/invoker-client.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { TransportError, TransportErrorCode } from '@invoker/transport';
-import { IpcInvokerClient, InvokerDownError, type ConnectableBus } from '../invoker-client.js';
+import { IpcInvokerClient, InvokerDownError, defaultReadLockHolderPid, type ConnectableBus } from '../invoker-client.js';
 
 /** A fake IpcBus whose owner-ping succeeds only while `ownerUp()` is true. */
 function makeFakeBus(ownerUp: () => boolean): ConnectableBus & { subscribe: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> } {
@@ -171,6 +174,27 @@ describe('IpcInvokerClient', () => {
     expect(await client.launch()).toEqual({ healthy: false, cause: 'unhealthy' });
   });
 
+  it('a healthy launch resets the ambiguous-read streak', async () => {
+    let ownerUp = false;
+    let spawnSucceeds = false;
+    const client = new IpcInvokerClient({
+      spawnInvoker: vi.fn(() => { if (spawnSucceeds) ownerUp = true; }),
+      log: () => {},
+      busFactory: () => makeFakeBus(() => ownerUp),
+      sleep: async () => {}, healthPollIntervalMs: 2, launchHealthTimeoutMs: 10,
+      minLaunchIntervalMs: 0,
+      httpHealthCheck: async () => false,
+      readLockHolderPid: () => ({ kind: 'error', detail: 'EACCES' }),
+    });
+
+    expect(await client.launch()).toEqual({ healthy: false, cause: 'unhealthy' });
+    spawnSucceeds = true;
+    expect(await client.launch()).toEqual({ healthy: true });
+    ownerUp = false;
+    spawnSucceeds = false;
+    expect(await client.launch()).toEqual({ healthy: false, cause: 'unhealthy' });
+  });
+
   it('force launch never signals when the lock read is ambiguous', async () => {
     const terminatePid = vi.fn();
     const client = new IpcInvokerClient({
@@ -266,5 +290,35 @@ describe('IpcInvokerClient', () => {
     expect(await client.ping()).toBe(true);          // fresh probe connects + re-subscribes
     expect(buses).toHaveLength(2);
     expect(buses[1].subscribe).toHaveBeenCalledWith('task.delta', expect.any(Function));
+  });
+});
+
+describe('defaultReadLockHolderPid', () => {
+  afterEach(() => { vi.unstubAllEnvs(); });
+
+  function withPidFile(raw: string): string {
+    const root = mkdtempSync(join(tmpdir(), 'invoker-lock-'));
+    mkdirSync(join(root, 'invoker.db.lock'), { recursive: true });
+    writeFileSync(join(root, 'invoker.db.lock', 'pid'), raw);
+    vi.stubEnv('INVOKER_DB_DIR', root);
+    return root;
+  }
+
+  it('accepts a plain positive integer token', () => {
+    const root = withPidFile('4242');
+    try {
+      expect(defaultReadLockHolderPid()).toEqual({ kind: 'found', pid: 4242 });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it.each(['4242.tmp', '-5', '0', '99007199254740993', 'abc', ''])('rejects %j as an error, not a pid', (raw) => {
+    const root = withPidFile(raw);
+    try {
+      expect(defaultReadLockHolderPid().kind).toBe('error');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/slack-manager/src/__tests__/invoker-client.test.ts
+++ b/packages/slack-manager/src/__tests__/invoker-client.test.ts
@@ -67,7 +67,7 @@ describe('IpcInvokerClient', () => {
       sleep: async (ms) => { nowMs += ms; },
       healthPollIntervalMs: 2, launchHealthTimeoutMs: 10,
       minLaunchIntervalMs: 60_000, httpHealthCheck: async () => false,
-      readLockHolderPid: () => null,
+      readLockHolderPid: () => ({ kind: 'absent' }),
     });
 
     expect(await client.launch()).toEqual({ healthy: false, cause: 'unhealthy' });
@@ -106,7 +106,7 @@ describe('IpcInvokerClient', () => {
       busFactory: () => makeFakeBus(() => false),
       sleep: async () => {}, healthPollIntervalMs: 2, launchHealthTimeoutMs: 10,
       httpHealthCheck: async () => false,
-      readLockHolderPid: () => 4242,
+      readLockHolderPid: () => ({ kind: 'found', pid: 4242 }),
       isPidAlive: () => true,
     });
 
@@ -119,11 +119,71 @@ describe('IpcInvokerClient', () => {
       busFactory: () => makeFakeBus(() => false),
       sleep: async () => {}, healthPollIntervalMs: 2, launchHealthTimeoutMs: 10,
       httpHealthCheck: async () => false,
-      readLockHolderPid: () => 4242,
+      readLockHolderPid: () => ({ kind: 'found', pid: 4242 }),
       isPidAlive: () => false,
     });
 
     expect(await client.launch()).toEqual({ healthy: false, cause: 'unhealthy' });
+  });
+
+  it('a single ambiguous lock read stays quiet (unhealthy, not lock-unknown)', async () => {
+    const client = new IpcInvokerClient({
+      spawnInvoker: vi.fn(), log: () => {},
+      busFactory: () => makeFakeBus(() => false),
+      sleep: async () => {}, healthPollIntervalMs: 2, launchHealthTimeoutMs: 10,
+      minLaunchIntervalMs: 0,
+      httpHealthCheck: async () => false,
+      readLockHolderPid: () => ({ kind: 'error', detail: 'EACCES' }),
+    });
+
+    expect(await client.launch()).toEqual({ healthy: false, cause: 'unhealthy' });
+  });
+
+  it('escalates to lock-unknown after a repeated ambiguous lock read across launches', async () => {
+    const client = new IpcInvokerClient({
+      spawnInvoker: vi.fn(), log: () => {},
+      busFactory: () => makeFakeBus(() => false),
+      sleep: async () => {}, healthPollIntervalMs: 2, launchHealthTimeoutMs: 10,
+      minLaunchIntervalMs: 0,
+      httpHealthCheck: async () => false,
+      readLockHolderPid: () => ({ kind: 'error', detail: 'EACCES' }),
+    });
+
+    expect(await client.launch()).toEqual({ healthy: false, cause: 'unhealthy' });
+    expect(await client.launch()).toEqual({ healthy: false, cause: 'lock-unknown', lockReadError: 'EACCES' });
+  });
+
+  it('resets the ambiguous-read streak once a launch succeeds or gets a definite answer', async () => {
+    let mode: 'error' | 'absent' = 'error';
+    const client = new IpcInvokerClient({
+      spawnInvoker: vi.fn(), log: () => {},
+      busFactory: () => makeFakeBus(() => false),
+      sleep: async () => {}, healthPollIntervalMs: 2, launchHealthTimeoutMs: 10,
+      minLaunchIntervalMs: 0,
+      httpHealthCheck: async () => false,
+      readLockHolderPid: () => (mode === 'error' ? { kind: 'error', detail: 'EACCES' } : { kind: 'absent' }),
+    });
+
+    expect(await client.launch()).toEqual({ healthy: false, cause: 'unhealthy' });
+    mode = 'absent';
+    expect(await client.launch()).toEqual({ healthy: false, cause: 'unhealthy' });
+    mode = 'error';
+    expect(await client.launch()).toEqual({ healthy: false, cause: 'unhealthy' });
+  });
+
+  it('force launch never signals when the lock read is ambiguous', async () => {
+    const terminatePid = vi.fn();
+    const client = new IpcInvokerClient({
+      spawnInvoker: vi.fn(), log: () => {},
+      busFactory: () => makeFakeBus(() => false),
+      sleep: async () => {}, healthPollIntervalMs: 1, launchHealthTimeoutMs: 10,
+      httpHealthCheck: async () => false,
+      readLockHolderPid: () => ({ kind: 'error', detail: 'EACCES' }),
+      terminatePid,
+    });
+
+    await client.launch({ force: true });
+    expect(terminatePid).not.toHaveBeenCalled();
   });
 
   it('withRecovery propagates the launch failure cause on the thrown InvokerDownError', async () => {
@@ -132,7 +192,7 @@ describe('IpcInvokerClient', () => {
       busFactory: () => makeFakeBus(() => false),
       sleep: async () => {}, healthPollIntervalMs: 2, launchHealthTimeoutMs: 10,
       httpHealthCheck: async () => false,
-      readLockHolderPid: () => 4242,
+      readLockHolderPid: () => ({ kind: 'found', pid: 4242 }),
       isPidAlive: () => true,
     });
 
@@ -155,7 +215,7 @@ describe('IpcInvokerClient', () => {
       busFactory: () => makeFakeBus(() => ownerUp),
       sleep: async () => {}, healthPollIntervalMs: 1, launchHealthTimeoutMs: 1_000,
       httpHealthCheck: async () => false,
-      readLockHolderPid: () => 4242,
+      readLockHolderPid: () => ({ kind: 'found', pid: 4242 }),
       isPidAlive: () => holderAlive,
       terminatePid,
     });
@@ -175,7 +235,7 @@ describe('IpcInvokerClient', () => {
       busFactory: () => makeFakeBus(() => ownerUp),
       sleep: async () => {}, healthPollIntervalMs: 1, launchHealthTimeoutMs: 1_000,
       httpHealthCheck: async () => false,
-      readLockHolderPid: () => 4242,
+      readLockHolderPid: () => ({ kind: 'found', pid: 4242 }),
       isPidAlive: () => true,
       terminatePid,
     });

--- a/packages/slack-manager/src/__tests__/watchdog.test.ts
+++ b/packages/slack-manager/src/__tests__/watchdog.test.ts
@@ -124,6 +124,29 @@ describe('createWatchdog', () => {
     expect(message).toContain('`@Invoker restart`');
   });
 
+  it('gives an honest "could not confirm" alert on lock-unknown, never claiming a specific PID is alive', async () => {
+    let nowMs = 0;
+    const launch = vi.fn(async (): Promise<LaunchResult> => (
+      { healthy: false, cause: 'lock-unknown', lockReadError: 'EACCES' }
+    ));
+    const alert = vi.fn();
+    const wd = createWatchdog({
+      client: { isHealthy: vi.fn(async () => false), launch },
+      log: () => {}, alert,
+      failuresBeforeRelaunch: 1, maxAttempts: 1, baseBackoffMs: 1_000, maxBackoffMs: 1_000,
+      now: () => nowMs,
+    });
+
+    await wd.tick();
+    expect(alert).toHaveBeenCalledTimes(1);
+    const message = (alert.mock.calls[0] as string[])[0];
+    expect(message).toContain('EACCES');
+    expect(message).toContain('could not confirm');
+    expect(message).toContain('`@Invoker restart`');
+    expect(message).not.toContain('is alive but not');
+    expect(message).not.toContain('PID undefined');
+  });
+
   it('rate-limits repeated give-up alerts while Invoker stays down', async () => {
     let nowMs = 0;
     const launch = vi.fn(async (): Promise<LaunchResult> => ({ healthy: false, cause: 'unhealthy' }));

--- a/packages/slack-manager/src/invoker-client.ts
+++ b/packages/slack-manager/src/invoker-client.ts
@@ -35,13 +35,14 @@ export interface ConnectableBus extends MessageBus {
 }
 
 /** Why a (re)launch did not produce a healthy owner. */
-export type LaunchFailureCause = 'throttled' | 'unhealthy' | 'split-brain';
+export type LaunchFailureCause = 'throttled' | 'unhealthy' | 'split-brain' | 'lock-unknown';
 
 export interface LaunchResult {
   healthy: boolean;
   cause?: LaunchFailureCause;
   /** PID holding the DB writer lock while unreachable over IPC (split-brain only). */
   holderPid?: number;
+  lockReadError?: string;
 }
 
 /** Thrown when an operation cannot reach the Invoker owner (transport-level down). */
@@ -50,6 +51,7 @@ export class InvokerDownError extends Error {
     message: string,
     readonly failureCause?: LaunchFailureCause,
     readonly holderPid?: number,
+    readonly lockReadError?: string,
   ) {
     super(message);
     this.name = 'InvokerDownError';
@@ -66,6 +68,10 @@ export function describeInvokerDown(err: InvokerDownError): string {
       return `Invoker cannot be relaunched: its database is locked by PID ${err.holderPid ?? '<unknown>'}, `
         + 'which is alive but not answering IPC (often a stray Invoker GUI). Reply `@Invoker restart` to force '
         + `recovery (this stops PID ${err.holderPid ?? '<unknown>'}), or stop that process manually.`;
+    case 'lock-unknown':
+      return 'Invoker cannot be relaunched: I could not confirm whether another process is holding the '
+        + `database lock (${err.lockReadError ?? 'unreadable lock file'}). Reply \`@Invoker restart\` to force `
+        + 'recovery, or check `~/.invoker/invoker.db.lock/pid` manually.';
     default:
       return 'Invoker is down and I could not bring it back. Reply `@Invoker restart` to retry.';
   }
@@ -127,7 +133,7 @@ export interface InvokerClientOptions {
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
   httpHealthCheck?: () => Promise<boolean>;
-  readLockHolderPid?: () => number | null;
+  readLockHolderPid?: () => LockHolderReadResult;
   isPidAlive?: (pid: number) => boolean;
   terminatePid?: (pid: number) => void;
 }
@@ -141,6 +147,7 @@ interface SubscriptionEntry {
 const QUERY_TIMEOUT_MS = 5_000;
 const OUTPUT_QUERY_TIMEOUT_MS = 10_000;
 const EXEC_TIMEOUT_MS = 60_000;
+const LOCK_READ_UNKNOWN_ALERT_STREAK = 2;
 
 function defaultSleep(ms: number): Promise<void> {
   const { promise, resolve } = Promise.withResolvers<void>();
@@ -175,14 +182,22 @@ function errMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-function defaultReadLockHolderPid(): number | null {
+export type LockHolderReadResult =
+  | { kind: 'absent' }
+  | { kind: 'found'; pid: number }
+  | { kind: 'error'; detail: string };
+
+function defaultReadLockHolderPid(): LockHolderReadResult {
+  let raw: string;
   try {
-    const raw = readFileSync(join(resolveInvokerHomeRoot(), 'invoker.db.lock', 'pid'), 'utf8').trim();
-    const pid = Number.parseInt(raw, 10);
-    return Number.isFinite(pid) ? pid : null;
-  } catch {
-    return null;
+    raw = readFileSync(join(resolveInvokerHomeRoot(), 'invoker.db.lock', 'pid'), 'utf8').trim();
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { kind: 'absent' };
+    return { kind: 'error', detail: errMessage(err) };
   }
+  const pid = Number.parseInt(raw, 10);
+  if (!Number.isFinite(pid)) return { kind: 'error', detail: `unparseable lock pid: ${JSON.stringify(raw)}` };
+  return { kind: 'found', pid };
 }
 
 function defaultIsPidAlive(pid: number): boolean {
@@ -207,7 +222,7 @@ export class IpcInvokerClient implements InvokerClient {
   private readonly now: () => number;
   private readonly sleep: (ms: number) => Promise<void>;
   private readonly httpHealthCheck: () => Promise<boolean>;
-  private readonly readLockHolderPid: () => number | null;
+  private readonly readLockHolderPid: () => LockHolderReadResult;
   private readonly isPidAlive: (pid: number) => boolean;
   private readonly terminatePid: (pid: number) => void;
 
@@ -215,6 +230,7 @@ export class IpcInvokerClient implements InvokerClient {
   private healthy = false;
   private lastLaunchAt = 0;
   private launchInFlight: Promise<LaunchResult> | null = null;
+  private lockReadUnknownStreak = 0;
   private readonly subs = new Set<SubscriptionEntry>();
   private readonly reconnectHandlers = new Set<() => void>();
 
@@ -317,6 +333,7 @@ export class IpcInvokerClient implements InvokerClient {
           `Invoker is down and could not be relaunched (${result.cause ?? 'unhealthy'})`,
           result.cause,
           result.holderPid,
+          result.lockReadError,
         );
       }
       return fn();
@@ -346,18 +363,33 @@ export class IpcInvokerClient implements InvokerClient {
       await this.forceReclaimSplitBrainHolder();
     }
     if (await this.doLaunch()) return { healthy: true };
-    const holderPid = this.detectUnreachableLockHolder();
-    if (holderPid !== null) {
-      this.log('error', `relaunch failed: DB writer lock held by live, IPC-unreachable PID ${holderPid} (split-brain)`);
-      return { healthy: false, cause: 'split-brain', holderPid };
+    const holder = this.detectUnreachableLockHolder();
+    if (holder.status === 'unreachable') {
+      this.lockReadUnknownStreak = 0;
+      this.log('error', `relaunch failed: DB writer lock held by live, IPC-unreachable PID ${holder.pid} (split-brain)`);
+      return { healthy: false, cause: 'split-brain', holderPid: holder.pid };
     }
+    if (holder.status === 'unknown') {
+      this.lockReadUnknownStreak += 1;
+      this.log('warn', `relaunch failed: could not confirm the DB writer lock holder (${holder.detail}), streak=${this.lockReadUnknownStreak}`);
+      if (this.lockReadUnknownStreak >= LOCK_READ_UNKNOWN_ALERT_STREAK) {
+        this.log('error', `relaunch failed: lock holder unconfirmable for ${this.lockReadUnknownStreak} consecutive attempts (${holder.detail})`);
+        return { healthy: false, cause: 'lock-unknown', lockReadError: holder.detail };
+      }
+      return { healthy: false, cause: 'unhealthy' };
+    }
+    this.lockReadUnknownStreak = 0;
     return { healthy: false, cause: 'unhealthy' };
   }
 
-  private detectUnreachableLockHolder(): number | null {
-    const holderPid = this.readLockHolderPid();
-    if (holderPid === null || holderPid === process.pid) return null;
-    return this.isPidAlive(holderPid) ? holderPid : null;
+  private detectUnreachableLockHolder():
+    | { status: 'none' }
+    | { status: 'unreachable'; pid: number }
+    | { status: 'unknown'; detail: string } {
+    const read = this.readLockHolderPid();
+    if (read.kind === 'error') return { status: 'unknown', detail: read.detail };
+    if (read.kind === 'absent' || read.pid === process.pid) return { status: 'none' };
+    return this.isPidAlive(read.pid) ? { status: 'unreachable', pid: read.pid } : { status: 'none' };
   }
 
   /**
@@ -367,8 +399,9 @@ export class IpcInvokerClient implements InvokerClient {
    */
   private async forceReclaimSplitBrainHolder(): Promise<void> {
     if (await this.ping()) return;
-    const holderPid = this.detectUnreachableLockHolder();
-    if (holderPid === null) return;
+    const holder = this.detectUnreachableLockHolder();
+    if (holder.status !== 'unreachable') return;
+    const holderPid = holder.pid;
     this.log('warn', `force restart: writer lock held by unreachable PID ${holderPid} — sending SIGTERM`);
     try {
       this.terminatePid(holderPid);

--- a/packages/slack-manager/src/invoker-client.ts
+++ b/packages/slack-manager/src/invoker-client.ts
@@ -187,7 +187,7 @@ export type LockHolderReadResult =
   | { kind: 'found'; pid: number }
   | { kind: 'error'; detail: string };
 
-function defaultReadLockHolderPid(): LockHolderReadResult {
+export function defaultReadLockHolderPid(): LockHolderReadResult {
   let raw: string;
   try {
     raw = readFileSync(join(resolveInvokerHomeRoot(), 'invoker.db.lock', 'pid'), 'utf8').trim();
@@ -195,8 +195,9 @@ function defaultReadLockHolderPid(): LockHolderReadResult {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { kind: 'absent' };
     return { kind: 'error', detail: errMessage(err) };
   }
+  if (!/^\d+$/.test(raw)) return { kind: 'error', detail: `unparseable lock pid: ${JSON.stringify(raw)}` };
   const pid = Number.parseInt(raw, 10);
-  if (!Number.isFinite(pid)) return { kind: 'error', detail: `unparseable lock pid: ${JSON.stringify(raw)}` };
+  if (!Number.isSafeInteger(pid) || pid <= 0) return { kind: 'error', detail: `unparseable lock pid: ${JSON.stringify(raw)}` };
   return { kind: 'found', pid };
 }
 
@@ -353,7 +354,10 @@ export class IpcInvokerClient implements InvokerClient {
 
   private async runLaunch(force: boolean): Promise<LaunchResult> {
     if (!force) {
-      if (await this.ping()) return { healthy: true };
+      if (await this.ping()) {
+        this.lockReadUnknownStreak = 0;
+        return { healthy: true };
+      }
       const sinceLast = this.now() - this.lastLaunchAt;
       if (sinceLast < this.minLaunchIntervalMs) {
         this.log('warn', `launch throttled — only ${Math.round(sinceLast / 1000)}s since last launch`);
@@ -362,7 +366,10 @@ export class IpcInvokerClient implements InvokerClient {
     } else {
       await this.forceReclaimSplitBrainHolder();
     }
-    if (await this.doLaunch()) return { healthy: true };
+    if (await this.doLaunch()) {
+      this.lockReadUnknownStreak = 0;
+      return { healthy: true };
+    }
     const holder = this.detectUnreachableLockHolder();
     if (holder.status === 'unreachable') {
       this.lockReadUnknownStreak = 0;

--- a/packages/slack-manager/src/watchdog.ts
+++ b/packages/slack-manager/src/watchdog.ts
@@ -62,12 +62,20 @@ export function createWatchdog(deps: WatchdogDeps): Watchdog {
   let busy = false;
   let timer: ReturnType<typeof setInterval> | undefined;
 
-  const splitBrainDetail = (): string =>
-    lastLaunchFailure?.cause === 'split-brain'
-      ? ` The database is locked by PID ${lastLaunchFailure.holderPid ?? '<unknown>'}, which is alive but not `
+  const splitBrainDetail = (): string => {
+    if (lastLaunchFailure?.cause === 'split-brain') {
+      return ` The database is locked by PID ${lastLaunchFailure.holderPid ?? '<unknown>'}, which is alive but not `
         + 'answering IPC (often a stray Invoker GUI) — auto-relaunch cannot succeed while it runs. '
-        + 'Replying `@Invoker restart` will stop that process and take over.'
-      : '';
+        + 'Replying `@Invoker restart` will stop that process and take over.';
+    }
+    if (lastLaunchFailure?.cause === 'lock-unknown') {
+      return ' I could not confirm whether another process is holding the database lock '
+        + `(${lastLaunchFailure.lockReadError ?? 'unreadable lock file'}) — I do not know if this is a stray `
+        + 'process or a transient read error. Replying `@Invoker restart` will force recovery, '
+        + 'or check `~/.invoker/invoker.db.lock/pid` manually.';
+    }
+    return '';
+  };
 
   const reset = (): void => {
     consecutiveFailures = 0;


### PR DESCRIPTION
## Summary

A lock file that fails to read — a permission error, or a transient read mid-write — used to be treated the same as "no one holds the lock."

That quietly turns an ambiguous read into a routine retry, right when a live process is most likely writing the file.

Now that read produces a distinct, escalating state. A single ambiguous read stays quiet like today, but a repeated streak surfaces to the operator.

## Review Claim

Approve validating an unreadable lock file as its own escalating state instead of silently downgrading it to "no holder."

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

An unreadable lock file surfaces as an explicit, escalating "can't confirm" state that still reaches the operator, instead of silently downgrading to a generic retry that could persist forever on something as mundane as a permissions error. The reclaim path still only ever signals on a confirmed-unreachable PID, never on an unknown read.

## Slice Rationale

Second of five independent fixes for the same invariant — an ambiguous read must produce an explicit unknown outcome rather than a convenient default. This one is scoped to the Slack lock-holder detection path only.

## Non-goals

This does not change `forceReclaimSplitBrainHolder`'s signal target. Other packages in this stack (disk-headroom, workflow-resume-worker, launch-dispatcher, terminal UI) are unaffected.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/slack-manager && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unreadable lock files during launches.
  * Repeated lock-read failures now report an “unknown lock” condition with diagnostic details.
  * Force-reclaim operations avoid terminating holders unless they are confirmed unreachable.
  * Watchdog alerts now include clearer recovery guidance and restart commands without reporting uncertain process IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->