### PR TITLE
[Unknown State Invariant](3) Treat a missing workflow-resume dependency as unsatisfied

### DIFF
--- a/packages/execution-engine/src/__tests__/workflow-resume-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/workflow-resume-worker.test.ts
@@ -165,6 +165,25 @@ describe('workflow resume worker tick', () => {
     expect(h.submit).toHaveBeenCalledTimes(1);
   });
 
+  it('does not submit pending work whose dependency id is missing from the locally loaded task set', async () => {
+    const h = harness({
+      workflows: [
+        {
+          id: 'wf-1',
+          tasks: [
+            makeTask({
+              id: 'wf-1/b',
+              status: 'pending' as TaskState['status'],
+              dependencies: ['wf-1/ghost'],
+            }),
+          ],
+        },
+      ],
+    });
+    await h.tick(POLL_CTX);
+    expect(h.submit).not.toHaveBeenCalled();
+  });
+
   it('skips workflows whose tasks are all terminal', async () => {
     const h = harness({
       workflows: [

--- a/packages/execution-engine/src/workers/workflow-resume-worker.ts
+++ b/packages/execution-engine/src/workers/workflow-resume-worker.ts
@@ -78,7 +78,7 @@ function hasLocallyReadyPendingTask(store: WorkflowResumeWorkerStore, workflowId
     const dependencies = task.dependencies ?? [];
     const localDependenciesSatisfied = dependencies.every((dependencyId) => {
       const dependency = tasksById.get(dependencyId);
-      return dependency === undefined || dependency.status === 'completed';
+      return dependency !== undefined && dependency.status === 'completed';
     });
     if (localDependenciesSatisfied) return true;
   }


### PR DESCRIPTION
## Summary

A pending task's dependency wakeup check treated a missing dependency ID as satisfied — silently read as "done" instead of "unknown, don't proceed."

A same-workflow dependency should always be present in the loaded set; cross-workflow references live in a separate field, rejected elsewhere at parse time.

A miss here means something's wrong, not a legitimate reference to work outside the loaded set.

## Review Claim

Approve treating a workflow-resume dependency the worker can't locally confirm as unmet, not satisfied.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A dependency this worker can't locally confirm as completed never counts as satisfied. Low stakes: this only gates a non-authoritative wakeup hint — the real scheduler still independently re-verifies readiness before dispatching, so this is hardening, not a live-bug fix.

## Slice Rationale

Third of five independent fixes for the same invariant. This one only gates a non-authoritative wakeup hint — the real scheduler still independently re-verifies readiness before dispatching, so this closes a latent gap rather than fixing a live incident.

## Non-goals

This does not change the authoritative scheduler's own readiness check. Other packages in this stack (disk-headroom, lock-holder detection, launch dispatch, terminal UI) are unaffected.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented pending tasks from starting when a required dependency is missing or incomplete.
  - Improved workflow resumption reliability by ensuring tasks run only after all dependencies are confirmed complete.

- **Tests**
  - Added regression coverage for workflows with unavailable dependency records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->