### PR TITLE
[Unknown State Invariant](4) Abandon a dispatch when launch readiness can't be verified

### DIFF
--- a/packages/app/src/__tests__/launch-claim-orphan-regression.test.ts
+++ b/packages/app/src/__tests__/launch-claim-orphan-regression.test.ts
@@ -130,6 +130,7 @@ describe('launch-claim orphan regression (2026-05-22 storm)', () => {
           prepareTaskForNewAttempt: (taskId, reason) =>
             orchestrator.prepareTaskForNewAttempt(taskId, reason),
           getTask: (taskId) => orchestrator.getTask(taskId),
+          getTaskLaunchReadiness: (taskId) => orchestrator.getTaskLaunchReadiness(taskId),
         },
         taskRunnerProvider: () => fakeTaskRunner,
         ownerId: 'cb5-test-owner',

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -655,6 +655,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask,
+          getTaskLaunchReadiness: (id: string) => ({ ready: true, task: getTask(id) }),
         },
         taskRunnerProvider: () => ({ executeTask }),
       });
@@ -710,6 +711,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask,
+          getTaskLaunchReadiness: (id: string) => ({ ready: true, task: getTask(id) }),
         },
         taskRunnerProvider: () => ({ executeTask }),
         maxLeasesPerPoll: 2,
@@ -771,6 +773,7 @@ describe('LaunchDispatcher', () => {
             cold.prepareTaskForNewAttempt(taskId, reason),
           syncFromDb: (workflowId) => cold.syncFromDb(workflowId),
           getTask: (taskId) => cold.getTask(taskId),
+          getTaskLaunchReadiness: (taskId) => cold.getTaskLaunchReadiness(taskId),
         },
         taskRunnerProvider: () => ({ executeTask }),
       });
@@ -839,6 +842,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask: () => task as any,
+          getTaskLaunchReadiness: () => ({ ready: true, task: task as any }),
           startExecution,
         },
         taskRunnerProvider: () => ({ executeTask }),
@@ -877,6 +881,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask: () => task as any,
+          getTaskLaunchReadiness: () => ({ ready: true, task: task as any }),
           startExecution,
         },
         taskRunnerProvider: () => ({ executeTask }),
@@ -926,6 +931,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask: vi.fn().mockReturnValue(currentTask as any),
+          getTaskLaunchReadiness: () => ({ ready: true, task: currentTask as any }),
         },
         taskRunnerProvider: () => ({ executeTask }),
       });
@@ -967,6 +973,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask: vi.fn().mockReturnValue(currentTask as any),
+          getTaskLaunchReadiness: () => ({ ready: true, task: currentTask as any }),
         },
         taskRunnerProvider: () => ({ executeTask }),
       });
@@ -1017,6 +1024,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask: vi.fn().mockReturnValue(currentTask as any),
+          getTaskLaunchReadiness: () => ({ ready: true, task: currentTask as any }),
         },
         taskRunnerProvider: () => ({ executeTask }),
       });
@@ -1067,6 +1075,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask: vi.fn().mockReturnValue(currentTask as any),
+          getTaskLaunchReadiness: () => ({ ready: true, task: currentTask as any }),
         },
         taskRunnerProvider: () => ({ executeTask }),
       });
@@ -1139,6 +1148,43 @@ describe('LaunchDispatcher', () => {
       });
     });
 
+    it('abandons the dispatch when the orchestrator cannot verify launch readiness', () => {
+      const task = seedWorkflowAndTask('wf-a/t-unverifiable', 'wf-a', {
+        selectedAttemptId: 'attempt-unverifiable',
+        generation: 0,
+      });
+      const enq = adapter.enqueueLaunchDispatch({
+        taskId: task.id,
+        attemptId: 'attempt-unverifiable',
+        workflowId: 'wf-a',
+        generation: 0,
+      });
+      const executeTask = vi.fn();
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask: vi.fn().mockReturnValue(task as any),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+      });
+
+      dispatcher.poll();
+
+      expect(executeTask).not.toHaveBeenCalled();
+      const after = adapter.loadLaunchDispatchById(enq.id);
+      expect(after?.state).toBe('abandoned');
+      expect(after?.lastError).toMatch(/readiness could not be verified/);
+      const events = adapter.getEvents(task.id);
+      const invalidated = events.find((event) => event.eventType === 'task.launch_dispatch_invalidated');
+      expect(invalidated).toBeDefined();
+      expect(JSON.parse(invalidated!.payload!)).toMatchObject({
+        dispatchId: enq.id,
+        reason: 'readiness_unverifiable',
+      });
+    });
+
     it('abandons the dispatch when the orchestrator has no matching task', () => {
       seedWorkflowAndTask('wf-a/t-missing', 'wf-a', {
         selectedAttemptId: 'attempt-missing',
@@ -1201,6 +1247,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask: vi.fn().mockReturnValue(task as any),
+          getTaskLaunchReadiness: () => ({ ready: true, task: task as any }),
         },
         taskRunnerProvider: () => ({ executeTask }),
       });

--- a/packages/app/src/__tests__/launch-pool-deferral-outbox-repro.test.ts
+++ b/packages/app/src/__tests__/launch-pool-deferral-outbox-repro.test.ts
@@ -88,6 +88,7 @@ async function runPoolDeferralScenario(options: { completeDeferredDispatch: bool
     orchestrator: {
       prepareTaskForNewAttempt: (id, reason) => orchestrator.prepareTaskForNewAttempt(id, reason),
       getTask: (id) => orchestrator.getTask(id),
+      getTaskLaunchReadiness: (id) => orchestrator.getTaskLaunchReadiness(id),
     },
     taskRunnerProvider: () => ({
       async executeTask(task, opts) {

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -340,6 +340,14 @@ export class LaunchDispatcher {
         );
         continue;
       }
+      if (this.orchestrator && typeof this.orchestrator.getTaskLaunchReadiness !== 'function') {
+        this.abandonInvalidDispatch(
+          leased,
+          `Task ${leased.taskId} launch readiness could not be verified: orchestrator does not implement getTaskLaunchReadiness`,
+          'readiness_unverifiable',
+        );
+        continue;
+      }
       const readiness = this.orchestrator?.getTaskLaunchReadiness?.(leased.taskId);
       if (readiness) {
         if (!readiness.ready) {


### PR DESCRIPTION
## Summary

Before launching a leased task, the dispatcher asks the orchestrator to confirm it's still safe to launch.

If the orchestrator didn't implement that confirmation method, the whole check used to be silently bypassed, and the task launched anyway on an unverified read.

Now that gap is treated the same as every other "can't trust this dispatch row" case: the dispatch is abandoned and the task is picked up again through the normal readiness path.

## Review Claim

Approve abandoning a dispatch when the orchestrator can't confirm current launch readiness, instead of launching on faith.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

When the dispatcher can't confirm current launch-readiness for a leased row, it abandons the dispatch through the same "can't trust this row" path used everywhere else in this function, rather than launching an already-resolved, possibly-stale task on faith.

## Slice Rationale

Fourth of five independent fixes for the same invariant. Only reachable through an orchestrator stub that omits this method today — every production wiring implements it — so this closes a latent gap rather than a live incident.

## Non-goals

This does not change the `this.orchestrator === undefined` mode, which is a distinct, intentional "no orchestrator wired" configuration used by reaper/topup-only paths. Other packages in this stack (disk-headroom, lock-holder detection, dependency resolution, terminal UI) are unaffected.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7548