### PR TITLE
Resolve real PR before deciding PR Body enforcement in the merge queue

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -31,22 +31,73 @@ jobs:
           ref: ${{ github.event.pull_request.base.ref }}
           persist-credentials: false
 
-      - name: Decide selective rollout
-        id: rollout
+      - name: Resolve PR Body targets
+        # On an ordinary PR run this just resolves back to the PR itself.
+        # On a Mergify merge-queue run (author mergify[bot], head ref
+        # mergify/merge-queue/...) the event's own PR is a synthetic
+        # wrapper Mergify opens to batch-test real PRs; this fetches the
+        # real underlying PR(s) it names so the rollout decision and the
+        # validation below run against them, not against mergify[bot]'s
+        # identity or the wrapper's boilerplate body. See
+        # scripts/test-resolve-pr-body-targets.mjs.
+        id: targets
         env:
-          PR_BODY_AUTHOR: ${{ github.event.pull_request.user.login }}
-        run: node scripts/pr-body-rollout.mjs
+          PR_BODY_ENFORCE_ALL: ${{ env.PR_BODY_ENFORCE_ALL }}
+          PR_BODY_ENFORCED_AUTHORS: ${{ env.PR_BODY_ENFORCED_AUTHORS }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('node:fs');
+            const { resolveTargetPrNumbers, shouldEnforcePrBodyForTargets } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/resolve-pr-body-targets.mjs`);
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+
+            const numbers = resolveTargetPrNumbers({
+              author: pr.user.login,
+              headRef: pr.head.ref,
+              prNumber: pr.number,
+              body: pr.body,
+            });
+
+            if (numbers.length === 0) {
+              core.setFailed(`PR Body: could not resolve an underlying PR to validate for head ref "${pr.head.ref}" (reported author ${pr.user.login}). Failing closed instead of skipping validation.`);
+              return;
+            }
+
+            const targets = [];
+            for (const number of numbers) {
+              const { data: target } = await github.rest.pulls.get({ owner, repo, pull_number: number });
+              targets.push({
+                number,
+                author: target.user.login,
+                body: target.body || '',
+                baseRef: target.base.ref,
+                headSha: target.head.sha,
+              });
+            }
+
+            const enabled = shouldEnforcePrBodyForTargets({
+              targets,
+              enforceAll: process.env.PR_BODY_ENFORCE_ALL,
+              enforcedAuthors: process.env.PR_BODY_ENFORCED_AUTHORS,
+            });
+
+            fs.writeFileSync('pr-body-targets.json', JSON.stringify(targets));
+            core.setOutput('enabled', String(enabled));
+            core.setOutput('authors', targets.map((target) => target.author).join(', '));
 
       - name: Skip unenforced author
-        if: steps.rollout.outputs.enabled != 'true'
-        run: echo "PR body validation is not enforced for ${{ github.event.pull_request.user.login }} yet."
+        if: steps.targets.outputs.enabled != 'true'
+        env:
+          TARGET_AUTHORS: ${{ steps.targets.outputs.authors }}
+        run: echo "PR body validation is not enforced for ${TARGET_AUTHORS} yet."
 
       - name: Install pnpm
-        if: steps.rollout.outputs.enabled == 'true'
+        if: steps.targets.outputs.enabled == 'true'
         uses: pnpm/action-setup@v4
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        if: steps.rollout.outputs.enabled == 'true'
+        if: steps.targets.outputs.enabled == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -56,37 +107,9 @@ jobs:
             .node-version
 
       - name: Install validator dependencies
-        if: steps.rollout.outputs.enabled == 'true'
+        if: steps.targets.outputs.enabled == 'true'
         run: pnpm install --no-frozen-lockfile --ignore-scripts
 
-      - name: Fetch live PR body
-        if: steps.rollout.outputs.enabled == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('node:fs');
-            const { owner, repo } = context.repo;
-            const pull_number = context.payload.pull_request.number;
-            const { data: pull } = await github.rest.pulls.get({ owner, repo, pull_number });
-            fs.writeFileSync('pr-body.md', pull.body || '', 'utf8');
-
-      - name: Fetch PR diff metadata
-        if: steps.rollout.outputs.enabled == 'true'
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-          git fetch --no-tags --depth=1 origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head"
-          fetched_head_sha="$(git rev-parse "refs/remotes/pull/${PR_NUMBER}/head^{commit}")"
-          if [ "$fetched_head_sha" != "$HEAD_SHA" ]; then
-            echo "Fetched PR head ${fetched_head_sha} did not match event head ${HEAD_SHA}." >&2
-            exit 1
-          fi
-          bash scripts/fetch-pr-diff-metadata.sh
-
-      - name: Validate PR body
-        if: steps.rollout.outputs.enabled == 'true'
-        run: node scripts/validate-pr-body.mjs --body-file pr-body.md --changed-files-file changed-files.txt --diff-file pr.diff
+      - name: Validate each target PR body
+        if: steps.targets.outputs.enabled == 'true'
+        run: node scripts/validate-pr-body-targets.mjs --targets-file pr-body-targets.json

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs",
-    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && bash scripts/test-land-stack-skill.sh && bash scripts/test-visual-proof-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-pr-diff-atomicity.mjs && node scripts/test-check-added-comments.mjs && node scripts/test-ci-workflow-merge-queue-policy.mjs && node scripts/test-ci-duration-invariant.mjs && node scripts/test-review-unit-classification.mjs && node scripts/test-create-pr-stack-workflow.mjs && bash scripts/workspace-test.sh && bash scripts/test-daily-release-workflow.sh && bash scripts/test-daily-e2e-do-submit.sh",
-    "test:high-resource": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && bash scripts/test-land-stack-skill.sh && bash scripts/test-visual-proof-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-create-pr-stack-workflow.mjs && INVOKER_VITEST_HIGH_RESOURCE=1 bash scripts/workspace-test.sh",
+    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && bash scripts/test-land-stack-skill.sh && bash scripts/test-visual-proof-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-resolve-pr-body-targets.mjs && node scripts/test-pr-diff-atomicity.mjs && node scripts/test-check-added-comments.mjs && node scripts/test-ci-workflow-merge-queue-policy.mjs && node scripts/test-ci-duration-invariant.mjs && node scripts/test-review-unit-classification.mjs && node scripts/test-create-pr-stack-workflow.mjs && bash scripts/workspace-test.sh && bash scripts/test-daily-release-workflow.sh && bash scripts/test-daily-e2e-do-submit.sh",
+    "test:high-resource": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && bash scripts/test-land-stack-skill.sh && bash scripts/test-visual-proof-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-resolve-pr-body-targets.mjs && node scripts/test-create-pr-stack-workflow.mjs && INVOKER_VITEST_HIGH_RESOURCE=1 bash scripts/workspace-test.sh",
     "test:low-resource": "pnpm run test",
     "test:low-resource:packages": "bash scripts/workspace-test.sh",
     "test:guarded": "bash scripts/run-with-resource-guard.sh bash scripts/workspace-test.sh",
@@ -15,6 +15,7 @@
     "test:land-stack-skill": "bash scripts/test-land-stack-skill.sh",
     "test:visual-proof-skill": "bash scripts/test-visual-proof-skill.sh",
     "test:pr-body-rollout": "node scripts/test-pr-body-rollout.mjs",
+    "test:resolve-pr-body-targets": "node scripts/test-resolve-pr-body-targets.mjs",
     "test:create-pr-e2e": "node scripts/test-create-pr-stack-workflow.mjs",
     "test:pr-diff-atomicity": "node scripts/test-pr-diff-atomicity.mjs",
     "verify-empty-canonical-sweeps": "bash scripts/verify-empty-canonical-sweeps.sh",

--- a/scripts/resolve-pr-body-targets.mjs
+++ b/scripts/resolve-pr-body-targets.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Resolves which PR(s) scripts/pr-body-rollout.mjs and validate-pr-body.mjs
+// should actually evaluate.
+//
+// Mergify's merge queue re-runs pull_request_target workflows against a
+// synthetic PR it opens itself (head ref mergify/merge-queue/<id>, author
+// mergify[bot]). scripts/pr-body-rollout.mjs's selective-rollout gate keys
+// off the reported author, so on that synthetic PR it always resolves to
+// "not enforced" -- author mergify[bot] is never in PR_BODY_ENFORCED_AUTHORS
+// -- even when the real PR underneath is by an enforced author and has a
+// body that would fail validation. Confirmed live: PR Body validation
+// failed on Neko-Catpital-Labs/Invoker#7534's own branch (missing required
+// sections) but reported success on the synthetic queue PR (#7541, author
+// mergify[bot]), and Mergify merged #7534 on that green check.
+//
+// Mergify embeds the real PR number(s) it is testing in a fenced yaml block
+// in the synthetic PR's body, e.g. (from the real #7541 body):
+//
+//   ```yaml
+//   ---
+//   checking_base_sha: 8bfbe06f9ec6634bd7af985b1f7ab5b16aa863a4
+//   previous_check_retries: []
+//   previous_failed_batches: []
+//   pull_requests:
+//     - number: 7534
+//       scopes: []
+//   scopes: []
+//   ...
+//   ```
+//
+// resolveTargetPrNumbers extracts those numbers so the workflow can fetch
+// and validate the real PR(s) instead of the synthetic wrapper.
+
+import { shouldEnforcePrBody } from './pr-body-rollout.mjs';
+
+const MERGE_QUEUE_HEAD_PREFIX = 'mergify/merge-queue/';
+const MERGE_QUEUE_BOT_LOGINS = new Set(['mergify[bot]', 'mergify']);
+const YAML_FENCE_PATTERN = /```ya?ml\r?\n([\s\S]*?)```/i;
+// Mergify's own generated block: a flat "pull_requests:" list of
+// "- number: <int>" entries. This is intentionally a narrow, dependency-free
+// scan of that fixed shape, not a general yaml parser -- the queue PR body
+// is otherwise untrusted, human-readable prose.
+const PULL_REQUESTS_LIST_PATTERN = /^pull_requests:[ \t]*\r?\n((?:^[ \t]+\S.*\r?\n?)+)/m;
+const NUMBER_ENTRY_PATTERN = /^[ \t]+-\s*number:\s*(\d+)\s*\r?$/gm;
+
+// The reported author is the actual authenticated GitHub actor who opened
+// the PR -- a regular contributor cannot make GitHub report it as
+// mergify[bot]. The head ref, in contrast, is whatever branch name the PR's
+// own author chose, so it is NOT trustworthy on its own: a PR author could
+// name their branch "mergify/merge-queue/anything" and, if headRef alone
+// were sufficient here, get resolveTargetPrNumbers() to parse THEIR OWN
+// PR body for a forged pull_requests: block pointing at a different,
+// already-compliant PR -- validating that PR's content instead of their
+// own and getting a green check without ever satisfying it. Requiring the
+// trusted bot author closes that: headRef is corroborating evidence, never
+// sufficient by itself.
+export function isMergeQueueRun({ author, headRef } = {}) {
+  const normalizedAuthor = String(author ?? '').trim().toLowerCase();
+  if (!MERGE_QUEUE_BOT_LOGINS.has(normalizedAuthor)) return false;
+  const normalizedHeadRef = String(headRef ?? '').trim();
+  return normalizedHeadRef.startsWith(MERGE_QUEUE_HEAD_PREFIX);
+}
+
+export function parseQueuedPrNumbers(body) {
+  const fenceMatch = String(body ?? '').match(YAML_FENCE_PATTERN);
+  if (!fenceMatch) return [];
+
+  const listMatch = fenceMatch[1].match(PULL_REQUESTS_LIST_PATTERN);
+  if (!listMatch) return [];
+
+  const numbers = [];
+  let match;
+  NUMBER_ENTRY_PATTERN.lastIndex = 0;
+  while ((match = NUMBER_ENTRY_PATTERN.exec(listMatch[1])) !== null) {
+    const number = Number(match[1]);
+    if (Number.isInteger(number) && number > 0 && !numbers.includes(number)) {
+      numbers.push(number);
+    }
+  }
+  return numbers;
+}
+
+// Fails closed: on a run that looks like a merge-queue run but whose body
+// doesn't parse to any underlying PR number, this returns [] rather than
+// falling back to the synthetic PR's own number. Callers must treat an
+// empty result as "resolution failed" and hard-fail instead of silently
+// validating (or skipping validation of) the wrong PR.
+export function resolveTargetPrNumbers({ author, headRef, prNumber, body } = {}) {
+  if (!isMergeQueueRun({ author, headRef })) {
+    const number = Number(prNumber);
+    return Number.isInteger(number) && number > 0 ? [number] : [];
+  }
+  return parseQueuedPrNumbers(body);
+}
+
+// A batch can bundle more than one PR (queue_rules.batch_size in
+// .mergify.yml). Enforce if ANY resolved target's real author is enforced,
+// so one enforced-author PR can't ride through validation-free behind a
+// batchmate that isn't.
+export function shouldEnforcePrBodyForTargets({ targets, enforceAll, enforcedAuthors }) {
+  return targets.some(({ author }) => shouldEnforcePrBody({ author, enforceAll, enforcedAuthors }));
+}

--- a/scripts/test-resolve-pr-body-targets.mjs
+++ b/scripts/test-resolve-pr-body-targets.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+import { strict as assert } from 'node:assert';
+import {
+  isMergeQueueRun,
+  parseQueuedPrNumbers,
+  resolveTargetPrNumbers,
+  shouldEnforcePrBodyForTargets,
+} from './resolve-pr-body-targets.mjs';
+
+// Real body of https://github.com/Neko-Catpital-Labs/Invoker/pull/7541,
+// the synthetic queue PR Mergify opened while testing #7534 -- captured
+// live during the incident this resolver fixes.
+const REAL_QUEUE_PR_BODY = `**🎉 This pull request has been checked successfully and will be merged soon. 🎉**
+
+Branch **master** (8bfbe06) and [#7534](/Neko-Catpital-Labs/Invoker/pull/7534) are queued together for merge.
+
+This pull request has been created by Mergify to check the mergeability of [#7534](/Neko-Catpital-Labs/Invoker/pull/7534).
+You don't need to do anything. Mergify will close this pull request automatically when it is complete.
+
+\`\`\`yaml
+---
+checking_base_sha: 8bfbe06f9ec6634bd7af985b1f7ab5b16aa863a4
+previous_check_retries: []
+previous_failed_batches: []
+pull_requests:
+  - number: 7534
+    scopes: []
+scopes: []
+...
+
+\`\`\`
+`;
+
+// --- isMergeQueueRun -------------------------------------------------------
+
+assert.equal(isMergeQueueRun({ author: 'mergify[bot]', headRef: 'mergify/merge-queue/abc123' }), true);
+assert.equal(isMergeQueueRun({ author: 'mergify[bot]', headRef: 'some-branch' }), false);
+// A regular PR author fully controls their own branch name and PR body.
+// Trusting headRef alone would let them name a branch
+// "mergify/merge-queue/anything" and forge a pull_requests: block in their
+// OWN PR body pointing at a different, already-compliant PR -- getting a
+// green check by validating that PR's content instead of their own. The
+// bot author can't be spoofed by a regular contributor, so it's required.
+assert.equal(isMergeQueueRun({ author: 'EdbertChan', headRef: 'mergify/merge-queue/abc123' }), false);
+assert.equal(isMergeQueueRun({ author: 'EdbertChan', headRef: 'stack/foo/bar' }), false);
+assert.equal(isMergeQueueRun({}), false);
+
+// --- parseQueuedPrNumbers ---------------------------------------------------
+
+assert.deepEqual(parseQueuedPrNumbers(REAL_QUEUE_PR_BODY), [7534]);
+assert.deepEqual(parseQueuedPrNumbers('no yaml block here'), []);
+assert.deepEqual(parseQueuedPrNumbers(''), []);
+assert.deepEqual(parseQueuedPrNumbers(undefined), []);
+
+const batchedBody = `\`\`\`yaml
+---
+checking_base_sha: abc123
+pull_requests:
+  - number: 100
+    scopes: []
+  - number: 101
+    scopes: []
+scopes: []
+...
+\`\`\``;
+assert.deepEqual(parseQueuedPrNumbers(batchedBody), [100, 101]);
+
+const malformedBody = `\`\`\`yaml
+---
+pull_requests: not-a-list
+...
+\`\`\``;
+assert.deepEqual(parseQueuedPrNumbers(malformedBody), []);
+
+// GitHub normalizes PR bodies to CRLF line endings.
+const crlfBody = [
+  '```yaml',
+  '---',
+  'checking_base_sha: abc123',
+  'pull_requests:',
+  '  - number: 7534',
+  '    scopes: []',
+  'scopes: []',
+  '...',
+  '```',
+].join('\r\n');
+assert.deepEqual(parseQueuedPrNumbers(crlfBody), [7534]);
+
+// --- resolveTargetPrNumbers -------------------------------------------------
+
+// Ordinary PR run: resolves to itself, ignoring body content entirely.
+assert.deepEqual(
+  resolveTargetPrNumbers({ author: 'EdbertChan', headRef: 'stack/foo/bar', prNumber: 7534, body: 'anything' }),
+  [7534],
+);
+
+// Merge-queue run: resolves through to the real underlying PR(s), not the
+// synthetic wrapper's own number (7541).
+assert.deepEqual(
+  resolveTargetPrNumbers({
+    author: 'mergify[bot]',
+    headRef: 'mergify/merge-queue/0aaddf1196',
+    prNumber: 7541,
+    body: REAL_QUEUE_PR_BODY,
+  }),
+  [7534],
+);
+
+// Fails closed: a merge-queue run whose body doesn't parse resolves to []
+// (the caller must hard-fail), never falls back to the synthetic PR number.
+assert.deepEqual(
+  resolveTargetPrNumbers({ author: 'mergify[bot]', headRef: 'mergify/merge-queue/xyz', prNumber: 7541, body: 'no yaml block' }),
+  [],
+);
+
+// --- shouldEnforcePrBodyForTargets ------------------------------------------
+
+assert.equal(
+  shouldEnforcePrBodyForTargets({
+    targets: [{ author: 'EdbertChan' }],
+    enforceAll: 'false',
+    enforcedAuthors: 'EdbertChan',
+  }),
+  true,
+);
+
+assert.equal(
+  shouldEnforcePrBodyForTargets({
+    targets: [{ author: 'mergify[bot]' }],
+    enforceAll: 'false',
+    enforcedAuthors: 'EdbertChan',
+  }),
+  false,
+);
+
+// This is the core regression this module exists to fix: the reported
+// wrapper author (mergify[bot]) must never be what enforcement is decided
+// on -- it must be decided on the real underlying PR's author. Author
+// matching is also case-insensitive (matches shouldEnforcePrBody's own
+// normalization), so a differently-cased enforcedAuthors config still works.
+assert.equal(
+  shouldEnforcePrBodyForTargets({
+    targets: [{ author: 'EdbertChan' }], // resolved from #7534, not mergify[bot]
+    enforceAll: 'false',
+    enforcedAuthors: 'edbertchan',
+  }),
+  true,
+  'enforcement must follow the resolved underlying author, not the queue wrapper author',
+);
+
+// Batch: enforce if ANY resolved target's author is enforced, so an
+// enforced-author PR can't ride through unvalidated behind a batchmate.
+assert.equal(
+  shouldEnforcePrBodyForTargets({
+    targets: [{ author: 'octocat' }, { author: 'EdbertChan' }],
+    enforceAll: 'false',
+    enforcedAuthors: 'EdbertChan',
+  }),
+  true,
+);
+
+assert.equal(
+  shouldEnforcePrBodyForTargets({
+    targets: [{ author: 'octocat' }, { author: 'someone-else' }],
+    enforceAll: 'false',
+    enforcedAuthors: 'EdbertChan',
+  }),
+  false,
+);
+
+console.log('OK: PR body target resolution checks passed');

--- a/scripts/validate-pr-body-targets.mjs
+++ b/scripts/validate-pr-body-targets.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// CI entry point for the "Validate each target PR body" step in
+// .github/workflows/pr-body.yml. Reads the targets written by the
+// "Resolve PR Body targets" step (one per real PR being validated -- the
+// PR itself on an ordinary run, or every PR in a Mergify merge-queue batch,
+// see scripts/resolve-pr-body-targets.mjs) and runs the same
+// validate-pr-body.mjs check against each one's real body and real diff.
+// Fails if any target fails, so one bad body in a batch can't ride through
+// behind good batchmates.
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+
+function parseArgs(argv) {
+  let targetsFile = '';
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--targets-file') {
+      targetsFile = argv[++i] || '';
+    }
+  }
+  if (!targetsFile) {
+    console.error('Usage: node scripts/validate-pr-body-targets.mjs --targets-file <file>');
+    process.exit(1);
+  }
+  return { targetsFile };
+}
+
+function runOrThrow(command, args, options = {}) {
+  const result = spawnSync(command, args, { encoding: 'utf8', ...options });
+  if (result.status !== 0) {
+    const detail = [result.error?.message, result.stdout, result.stderr].filter(Boolean).join('\n');
+    throw new Error(`${command} ${args.join(' ')} failed:\n${detail}`);
+  }
+  return result;
+}
+
+async function main() {
+  const { targetsFile } = parseArgs(process.argv.slice(2));
+  const targets = JSON.parse(readFileSync(targetsFile, 'utf8'));
+
+  const failures = [];
+
+  for (const target of targets) {
+    console.log(`\n=== PR #${target.number} (author: ${target.author}) ===`);
+
+    try {
+      runOrThrow('git', [
+        'fetch', '--no-tags', '--depth=1', 'origin',
+        `+refs/pull/${target.number}/head:refs/remotes/pull/${target.number}/head`,
+      ], { stdio: 'inherit' });
+      const fetchedHeadSha = runOrThrow('git', ['rev-parse', `refs/remotes/pull/${target.number}/head^{commit}`]).stdout.trim();
+      if (fetchedHeadSha !== target.headSha) {
+        failures.push(`PR #${target.number}: fetched head ${fetchedHeadSha} did not match resolved head ${target.headSha}.`);
+        continue;
+      }
+
+      runOrThrow('bash', ['scripts/fetch-pr-diff-metadata.sh'], {
+        env: { ...process.env, BASE_REF: target.baseRef, HEAD_SHA: target.headSha },
+      });
+    } catch (error) {
+      failures.push(`PR #${target.number}: ${error.message}`);
+      continue;
+    }
+
+    writeFileSync('pr-body-target-current.md', target.body, 'utf8');
+
+    const result = spawnSync('node', [
+      'scripts/validate-pr-body.mjs',
+      '--body-file', 'pr-body-target-current.md',
+      '--changed-files-file', 'changed-files.txt',
+      '--diff-file', 'pr.diff',
+    ], { encoding: 'utf8' });
+
+    process.stdout.write(result.stdout ?? '');
+    process.stderr.write(result.stderr ?? '');
+
+    if (result.status !== 0) {
+      failures.push(`PR #${target.number}: PR body validation failed (see output above).`);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error(`\nPR Body validation failed for ${failures.length} of ${targets.length} target(s):`);
+    for (const failure of failures) {
+      console.error(`- ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`\nPR Body validation passed for all ${targets.length} target(s).`);
+}
+
+await main();


### PR DESCRIPTION
## Summary
pr-body.yml decided enforcement from the reported PR author. Mergify re-runs it against a synthetic queue PR authored by mergify[bot], never an enforced author, so it silently reported success without reading the real PR's body.

Confirmed live: #7534 failed PR Body on its own branch. It merged anyway, because the mergify[bot]-authored copy reported `enabled:false` and Mergify only looks at that copy's checkmark.

## Review Claim
The PR Body check now resolves the real PR(s) behind a merge-queue run and enforces/validates against those, instead of deciding from the queue wrapper's own mergify[bot] identity and boilerplate body.

## Review Lane
policy

## Review Unit
tooling-policy

## Safety Invariant
If a merge-queue run's body can't be parsed back to an underlying PR number, the workflow hard-fails (`core.setFailed`) instead of silently skipping validation -- failing closed, not open.

## Slice Rationale
Isolated to the PR Body workflow and its supporting scripts; no product code changes. Fixes the exact gap #7534/#7535 exposed, verified against their real captured payloads.

## Non-goals
Does not change what the PR body schema itself requires, and does not touch any other required check.

## Test Plan
<details>
<summary>Test Plan</summary>

`node scripts/test-resolve-pr-body-targets.mjs` -- unit tests for the resolver against the real body of https://github.com/Neko-Catpital-Labs/Invoker/pull/7541, including the regression assertion that enforcement must follow the resolved underlying author (EdbertChan, from #7534), not the queue wrapper author (mergify[bot]).

`node scripts/test-pr-body-rollout.mjs` and `node scripts/test-pr-body-validator.mjs` -- confirm no regression in the untouched rollout/validator logic.

Also hand-simulated the actual `.github/workflows/pr-body.yml` "Resolve PR Body targets" step (extracted its script, ran it with mocked `context`/`core`/`github`) against an ordinary PR, the real #7541 queue-run shape, and a queue run resolving to a non-enforced author -- all three resolved and enforced correctly.

</details>

## Revert Plan
<details>
<summary>Revert Plan</summary>

Revert this commit. PR Body reverts to deciding enforcement from the event's own reported author, reopening the merge-queue bypass; no state or schema changes involved.

</details>

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pull request body validation now correctly handles merge-queue submissions and validates all underlying pull requests.
  * Validation decisions are based on the resolved pull request targets rather than only the queue wrapper.
  * Malformed or unavailable queue details now fail safely instead of allowing incomplete validation.
  * Results aggregate failures across all targets and report success only when every target passes.

* **Tests**
  * Added coverage for queued, batched, ordinary, and invalid pull request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->