### PR TITLE
[CI regression: e21a965-playwright-terminal-garbling](1) Add stuck-lease specs to the playwright 9-of-9 shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -665,6 +665,8 @@ jobs:
               e2e/start-ready-daemon-owner.spec.ts
               e2e/ui-delta-timeline.spec.ts
               e2e/planning-terminal-live-model.proof.spec.ts
+              e2e/launch-dispatch-stuck-lease-cap.spec.ts
+              e2e/launch-dispatch-stuck-lease-storm.spec.ts
               e2e/workers-surface.spec.ts
           - name: terminal-garbling
             files: >-


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=e21a96567a3fff62cf9c71befc3f0a7db15ab9c5; job=playwright / terminal-garbling -->

CI job `playwright / terminal-garbling` first failed on default-branch push commit e21a965 in run 30771302330. It stayed red at 406c00e in run 30957855805.

This slice edits `.github/workflows/ci.yml` so the two stuck-lease specs run in the `9-of-9` playwright shard roster.

The change touches CI shard wiring only. No product code, no test bodies, and no test expectations move.

## Review Claim

Approve adding `e2e/launch-dispatch-stuck-lease-cap.spec.ts` and `e2e/launch-dispatch-stuck-lease-storm.spec.ts` to the `9-of-9` playwright shard roster in `.github/workflows/ci.yml`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The diff changes only the CI workflow shard roster. Other CI jobs, product behavior, and every test's assertions are untouched, so it is safe to review in isolation.

## Slice Rationale

This is one CI-configuration edit to `.github/workflows/ci.yml`. It carries no product edits and no proof files, so it stays a single tooling-policy slice.

## Non-goals

- No product code changes.
- No changes to any test body or assertion.
- No changes to other playwright shards or CI jobs.
- No test weakening, skipping, or snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-terminal-garbling' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/planning-surface-navigation-garble-repro.spec.ts e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts e2e/planning-terminal-expand-collapse-garble-repro.spec.ts e2e/task-terminal-drawer-minimize-garble-repro.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

> Recreated from #7487, which was auto-closed when a botched automated conflict repair briefly force-pushed its head branch to master's content. Original head restored (eeae45b9a); conflict with master is still present and needs a proper rebase.