### PR TITLE
[CI regression: a5d6b3e-playwright-launch-dispatch-stuck-lease](1) Remove duplicate launch-dispatch-stuck-lease shards from the Playwright CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -597,8 +597,6 @@ jobs:
               e2e/edit-task-command.spec.ts
               e2e/headless-thundering-herd.spec.ts
               e2e/launching-stall-watchdog.spec.ts
-              e2e/launch-dispatch-stuck-lease-storm.spec.ts
-              e2e/launch-dispatch-stuck-lease-cap.spec.ts
               e2e/embedded-terminal-pty.spec.ts
               e2e/keyboard-navigation.spec.ts
           - name: launch-dispatch-stuck-lease
@@ -633,8 +631,6 @@ jobs:
             files: >-
               e2e/autofix-worker-ui.spec.ts
               e2e/orphan-relaunch.spec.ts
-              e2e/launch-dispatch-stuck-lease-storm.spec.ts
-              e2e/launch-dispatch-stuck-lease-cap.spec.ts
               e2e/gap-recovery-bench.spec.ts
               e2e/planning-chat-send-long-deadline.spec.ts
               e2e/system-setup-visual-proof.spec.ts
@@ -668,13 +664,7 @@ jobs:
               e2e/gui-owner-auto-bootstrap.spec.ts
               e2e/start-ready-daemon-owner.spec.ts
               e2e/ui-delta-timeline.spec.ts
-              e2e/launch-dispatch-stuck-lease-cap.spec.ts
-              e2e/launch-dispatch-stuck-lease-storm.spec.ts
               e2e/workers-surface.spec.ts
-          - name: launch-dispatch-stuck-lease
-            files: >-
-              e2e/launch-dispatch-stuck-lease-cap.spec.ts
-              e2e/launch-dispatch-stuck-lease-storm.spec.ts
           - name: terminal-garbling
             files: >-
               e2e/planning-terminal-live-model.proof.spec.ts
@@ -682,10 +672,6 @@ jobs:
               e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts
               e2e/planning-terminal-expand-collapse-garble-repro.spec.ts
               e2e/task-terminal-drawer-minimize-garble-repro.spec.ts
-          - name: launch-dispatch-stuck-lease
-            files: >-
-              e2e/launch-dispatch-stuck-lease-storm.spec.ts
-              e2e/launch-dispatch-stuck-lease-cap.spec.ts
 
     name: playwright / ${{ matrix.name }}
 


### PR DESCRIPTION
## Summary

This keeps the launch-dispatch stuck-lease specs in one named Playwright shard.

The numbered shards keep their regular coverage without carrying that same focused shard workload.

## Review Claim

Approve the CI matrix inventory so the stuck-lease specs appear only in the dedicated Playwright shard.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change is limited to the Playwright workflow matrix and does not touch product code, spec code, or runner scripts.

## Slice Rationale

This is isolated to the Playwright matrix because the product code and spec files already have the intended coverage.

## Non-goals

- No product behavior change.
- No Playwright spec logic change.
- No runner script change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs`
- [ ] `node scripts/validate-pr-body-local.mjs --body-file <(gh pr view 7560 --repo Neko-Catpital-Labs/Invoker --json body --jq .body) --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4a64a9c1d04851d52cd9eb501348bab0393e3239`
- Post-revert steps: None
- Data migration? No

</details>
