### PR TITLE
Document the Slack app icon: manual avatar upload from the repo's Invoker logo

### DIFF
--- a/docs/slack-app-icon.md
+++ b/docs/slack-app-icon.md
@@ -1,0 +1,37 @@
+# Slack App Icon
+
+Use the existing Invoker logo asset when setting the Slack app's real avatar.
+
+The canonical source logo is:
+
+```text
+packages/app/assets/icons/source/invoker-logo.png
+```
+
+Ready-made PNG renditions are available under:
+
+```text
+packages/app/assets/icons/png/
+```
+
+Slack app icons want a square image at least 512x512 pixels. Use this rendition for the app icon upload:
+
+```text
+packages/app/assets/icons/png/512x512.png
+```
+
+## Manual Update Path
+
+1. Open `https://api.slack.com/apps`.
+2. Select the Invoker app.
+3. Go to `Settings`.
+4. Open `Basic Information`.
+5. In `Display Information`, find `App icon`.
+6. Upload `packages/app/assets/icons/png/512x512.png`.
+7. Save the change.
+
+## Automation Constraint
+
+Slack does not provide an API or app manifest field for setting the real app avatar. This means the app icon upload cannot be automated by repository code, Slack app manifests, or deployment scripts.
+
+Slack does support per-message `icon_url` overrides, but those were explicitly not chosen for Invoker. The intended result is the bot's real Slack app avatar, set manually through the Slack dashboard.


### PR DESCRIPTION
## Summary

The Slack bot still shows a placeholder icon. Planning chose the real app avatar, sourced from the Invoker logo already in this repo.

Slack has no API, manifest field, or hosted-URL path for the real app avatar. The upload is a manual action in the Slack app dashboard.

This adds `docs/slack-app-icon.md` so any workspace admin can finish that manual step without re-deriving it.

The doc names the canonical logo source, the 512x512 rendition to upload, the exact dashboard path, and the automation constraint.

## Review Claim

A workspace admin can set the bot's real avatar to the Invoker logo using only this document.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Documentation only; no product code or configuration changes, so runtime behavior cannot change.

## Slice Rationale

The only automatable remainder of this issue is the doc; the upload itself is a human dashboard action, so this ships as a single docs slice.

## Non-goals

- No code changes.
- No per-message `icon_url` overrides.
- No asset edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `rg -n "packages/app/assets/icons/source/invoker-logo.png" docs/slack-app-icon.md`
- [x] `rg -n "packages/app/assets/icons/png/512x512.png" docs/slack-app-icon.md`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/slack-icon-pr-body.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
