### PR TITLE
[CodeRabbit audit: PR #7247 — validate findings against master and fix what holds](1) Audit verdicts for CodeRabbit findings on PR #7247

### DIFF
--- a/docs/audits/coderabbit/pr-7247.md
+++ b/docs/audits/coderabbit/pr-7247.md
@@ -1,0 +1,24 @@
+# CodeRabbit Audit: PR #7247
+
+Current master checked: `59997318ac0799f8016c0b7d8fe0baabdd6356f0`
+
+## Finding 1: Stable execution key in lease contract
+
+> Define a stable execution key in the lease contract.
+>
+> `releaseExpiredExecutionResourceLeases` only exposes `resourceKey`, `holderId`, and optional `taskId`; there is no field for the execution instance or attempt it belongs to. A retry can start a new `execution.generation` / `selectedAttemptId` while leaving stale rows behind, so the expiration logic cannot distinguish a live execution's lease from a completed/abandoned one. Add and store a stable attempt-or-execution key to `metadata` or the contract, or otherwise document why `taskId`/`holderId` is sufficient.
+
+Severity: Minor
+
+Verdict: invalid
+
+Evidence:
+
+- `packages/execution-engine/src/task-runner-pool.ts:348` defines the lease holder id as `${host.runnerInstanceId}:${process.pid}:${taskId}:${attemptId}`, so the holder already carries the attempt id in addition to the task id and runner identity.
+- `packages/execution-engine/src/task-runner-pool.ts:363` passes that holder id into `claimExecutionResourceLease`, and `packages/execution-engine/src/task-runner-pool.ts:372` persists `metadata.runnerInstanceId`.
+- `packages/execution-engine/src/task-runner-dispatch.ts:367` stores active executions keyed by `attemptId`, and `packages/execution-engine/src/task-runner-dispatch.ts:373` stores the selected lease holder id on that active execution entry.
+- `packages/execution-engine/src/task-runner.ts:384` documents that liveness is scoped by lease holder rather than task id alone so stale abandoned-attempt leases are not treated as live after a retry. `packages/execution-engine/src/task-runner.ts:390` implements that by returning true only when an active execution entry has the exact same `leaseHolderId`.
+- `packages/app/src/launch-dispatcher.ts:205` first requires the expired row's `metadata.runnerInstanceId` to match the current runner, and `packages/app/src/launch-dispatcher.ts:206` then calls `hasActiveExecutionForLeaseHolder(row.holderId)`. Because the holder id includes the attempt id and the active lookup compares the exact holder, a new retry with a new `selectedAttemptId` does not make the stale prior-attempt lease look live.
+- `packages/app/src/__tests__/launch-dispatcher.test.ts:1274` covers this specific scenario: a stale holder from an abandoned attempt of the same task, where the task now has a different live attempt, must not be healed. `packages/app/src/__tests__/launch-dispatcher.test.ts:1298` verifies that only the genuinely live lease remains after polling.
+
+The contract shape at `packages/app/src/launch-dispatcher.ts:38` does not expose a separate `attemptId` field, but the current implementation already uses an exact, attempt-bearing holder id plus `metadata.runnerInstanceId` for the expiration decision. CodeRabbit's concrete failure mode is therefore not present on current master.


### PR DESCRIPTION
## Summary

CodeRabbit reviewed PR #7247 and raised one finding about the shape of `releaseExpiredExecutionResourceLeases`.

This PR records the audit verdict for that finding: invalid.

The lease holder id already embeds the attempt id, so a second launch attempt's leftover lease cannot be mistaken for the new attempt's live lease.

The evidence trail through `task-runner-pool.ts`, `task-runner-dispatch.ts`, `task-runner.ts`, and `launch-dispatcher.ts` is recorded in the audit file, along with the existing regression test that covers this exact scenario.

## Review Claim

Approve the invalid verdict for CodeRabbit's stable-execution-key finding on PR #7247, backed by the cited evidence.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This PR only adds a markdown audit report under `docs/audits/coderabbit/`. It does not touch any product code, so there is no runtime behavior to review beyond confirming the cited evidence is accurate.

## Slice Rationale

Audit verdicts are recorded as their own docs-only slice, separate from any code changes, so the evidence trail for a CodeRabbit finding stays reviewable on its own.

## Non-goals

Does not change `task-runner-pool.ts`, `task-runner-dispatch.ts`, `task-runner.ts`, or `launch-dispatcher.ts`. Does not re-litigate other CodeRabbit findings on PR #7247 — those are tracked in the sibling PR in this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `git diff --name-only` shows only `docs/audits/coderabbit/pr-7247.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
