### PR TITLE
[CodeRabbit audit: PR #7247 — validate findings against master and fix what holds](2) Record the fix outcome: all findings invalid

### DIFF
--- a/docs/audits/coderabbit/pr-7247.md
+++ b/docs/audits/coderabbit/pr-7247.md
@@ -22,3 +22,7 @@ Evidence:
 - `packages/app/src/__tests__/launch-dispatcher.test.ts:1274` covers this specific scenario: a stale holder from an abandoned attempt of the same task, where the task now has a different live attempt, must not be healed. `packages/app/src/__tests__/launch-dispatcher.test.ts:1298` verifies that only the genuinely live lease remains after polling.
 
 The contract shape at `packages/app/src/launch-dispatcher.ts:38` does not expose a separate `attemptId` field, but the current implementation already uses an exact, attempt-bearing holder id plus `metadata.runnerInstanceId` for the expiration decision. CodeRabbit's concrete failure mode is therefore not present on current master.
+
+## Fixes applied
+
+Fixes applied: none - all findings invalid


### PR DESCRIPTION
## Summary

This finishes the CodeRabbit audit of PR #7247 started in #7562.

There was only one finding to review, and it was already recorded as invalid.

This slice appends the closing "Fixes applied: none" line to the audit file, so the report reads as complete rather than left open-ended.

## Review Claim

Approve closing out the audit report for PR #7247: one finding reviewed, none needed a code change.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This PR only appends a closing line to `docs/audits/coderabbit/pr-7247.md`. It does not touch product code.

## Slice Rationale

Kept as its own slice on top of #7562 so the verdict-recording work and the "audit closed" bookkeeping are each a single, small, reviewable diff.

## Non-goals

Does not add new findings or revisit the verdict recorded in #7562.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `git diff --name-only` shows only `docs/audits/coderabbit/pr-7247.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an audit note indicating that no fixes were required because all reported findings were determined to be invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->