### PR TITLE
[CodeRabbit audit: PR #7053 — validate findings against master and fix what holds](1) Record per-finding verdicts against master

### DIFF
--- a/docs/audits/coderabbit/pr-7053.md
+++ b/docs/audits/coderabbit/pr-7053.md
@@ -1,0 +1,53 @@
+# CodeRabbit Audit for PR #7053
+
+Source: `gh api repos/Neko-Catpital-Labs/Invoker/pulls/7053/comments --paginate`
+
+Baseline: current `origin/master` after fetching on 2026-08-05.
+
+## Finding 1: Restore mocks in remote finalize retry/timeout tests
+
+Quoted finding:
+
+> Restore mocks in `afterEach` for this retry/timeout block. `vi.clearAllMocks()` clears call history, but it does not undo the `vi.spyOn(console, 'info').mockImplementation(() => {})` calls added in these tests.
+
+Severity: Minor
+
+Verdict: valid
+
+Evidence:
+
+The finding still applies on current `origin/master`. In `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1724`, the block `beforeEach` calls `vi.clearAllMocks()`, but the block `afterEach` at `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1735` only restores `INVOKER_REMOTE_FINALIZE_TIMEOUT_MS` and calls `vi.useRealTimers()` at line 1738. There is no `vi.restoreAllMocks()` or per-spy `mockRestore()` in this describe block.
+
+The same block creates console spies at `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1758`, `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1776`, `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1793`, and `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1833`. `packages/execution-engine/vitest.config.ts:4` merges `vitest.shared.ts`, and neither that package config nor `vitest.shared.ts:7` enables `restoreMocks`, so the mocked console methods are not automatically restored by configuration.
+
+## Finding 2: SIGKILL escalation is dead code
+
+Quoted finding:
+
+> Fix: the `SIGKILL` escalation is dead code. `killTimer` is cleared as a side effect of `finish()`, and `finish()` runs synchronously right after `killTimer` is created inside the timeout handler.
+
+Severity: Critical
+
+Verdict: invalid
+
+Evidence:
+
+The specific dead-code condition described by CodeRabbit has been fixed on current `origin/master`. In `packages/execution-engine/src/ssh-executor.ts:410`, `settled` is tracked separately from `closed` at line 411. The `finish` helper at `packages/execution-engine/src/ssh-executor.ts:414` sets `settled` and clears `timeoutTimer`, but it no longer clears `killTimer`. The child `close` handler sets `closed = true` and clears `killTimer` at `packages/execution-engine/src/ssh-executor.ts:429`.
+
+The timeout path now creates `killTimer` at `packages/execution-engine/src/ssh-executor.ts:451`, and the timer callback checks `if (!closed)` before sending `SIGKILL` at line 452. Because the guard is based on process closure rather than promise settlement, settling the timeout error at `packages/execution-engine/src/ssh-executor.ts:455` no longer prevents escalation. The regression test at `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1741` advances fake timers and asserts `SIGKILL` at line 1754.
+
+## Finding 3: Remote finalize retries are not idempotent and may overlap
+
+Quoted finding:
+
+> Make the remote finalize retry idempotent and wait for the previous SSH session to close. `buildRecordAndPushScript` always stages, commits, and pushes HEAD, so a retry after a local timeout can re-run a commit/push even if the remote operation already completed.
+
+Severity: Major
+
+Verdict: valid
+
+Evidence:
+
+The idempotency concern still applies on current `origin/master`. `buildRecordAndPushScript` stages all changes with `git add -A` at `packages/execution-engine/src/ssh-git-exec.ts:375`, creates either an empty commit at line 382 or a changes commit at line 385, then pushes the resulting `HEAD` at `packages/execution-engine/src/ssh-git-exec.ts:397` or line 399. The script does not use a lock, marker, stable idempotency token, or completed-result check before creating the commit.
+
+The overlap concern also still applies. `execRemoteCapture` starts a timeout at `packages/execution-engine/src/ssh-executor.ts:445`, sends `SIGTERM` at line 450, schedules `SIGKILL` for later at lines 451-453, and then immediately settles the promise with a timeout rejection at lines 455-460. `remoteGitRecordAndPush` catches that timeout and continues its retry loop at `packages/execution-engine/src/ssh-executor.ts:1031` without waiting for the previous SSH child to close. Therefore the next `execRemoteCapture` call at `packages/execution-engine/src/ssh-executor.ts:1033` can begin while the previous remote command is still alive until the delayed `SIGKILL` fires or the remote process exits on its own.


### PR DESCRIPTION
## Summary

CodeRabbit left three inline findings on merged PR #7053. This slice records an evidence-backed verdict for each one, judged against current master.

Two findings still hold: the finalize timeout tests leak console spies, and repeated finalize attempts are not idempotent and can overlap a live SSH session.

One finding does not hold. The SIGKILL escalation it flagged as unreachable was already fixed on master, and a regression test covers it.

The report quotes each finding, states its verdict, and cites file and line evidence so reviewers can re-check every judgment.

## Review Claim

Each CodeRabbit inline finding on PR #7053 has an evidence-backed "Verdict: valid" or "Verdict: invalid" entry in docs/audits/coderabbit/pr-7053.md, judged against current master.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice adds one audit report document and touches nothing else, so it cannot alter product behavior.

## Slice Rationale

The verdicts must exist before any fix so findings judged invalid never produce code churn. Slice 2 then fixes only what this report marks "Verdict: valid".

## Non-goals

- No product code changes.
- No fixes in this slice; the fixes for the two valid findings land in slice 2.
- No re-litigating CodeRabbit style opinions that are not concrete findings.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `test -f docs/audits/coderabbit/pr-7053.md`
- [x] `grep -E "Verdict: (valid|invalid)" docs/audits/coderabbit/pr-7053.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert` this PR's merge commit (or the GitHub Revert button)
- Post-revert steps: None
- Data migration? No

</details>
