### PR TITLE
[CodeRabbit audit: PR #7053 — validate findings against master and fix what holds](2) Make remote finalize retry idempotent and restore test spies

### DIFF
--- a/docs/audits/coderabbit/pr-7053.md
+++ b/docs/audits/coderabbit/pr-7053.md
@@ -1,0 +1,53 @@
+# CodeRabbit Audit for PR #7053
+
+Source: `gh api repos/Neko-Catpital-Labs/Invoker/pulls/7053/comments --paginate`
+
+Baseline: current `origin/master` after fetching on 2026-08-05.
+
+## Finding 1: Restore mocks in remote finalize retry/timeout tests
+
+Quoted finding:
+
+> Restore mocks in `afterEach` for this retry/timeout block. `vi.clearAllMocks()` clears call history, but it does not undo the `vi.spyOn(console, 'info').mockImplementation(() => {})` calls added in these tests.
+
+Severity: Minor
+
+Verdict: valid
+
+Evidence:
+
+The finding still applies on current `origin/master`. In `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1724`, the block `beforeEach` calls `vi.clearAllMocks()`, but the block `afterEach` at `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1735` only restores `INVOKER_REMOTE_FINALIZE_TIMEOUT_MS` and calls `vi.useRealTimers()` at line 1738. There is no `vi.restoreAllMocks()` or per-spy `mockRestore()` in this describe block.
+
+The same block creates console spies at `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1758`, `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1776`, `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1793`, and `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1833`. `packages/execution-engine/vitest.config.ts:4` merges `vitest.shared.ts`, and neither that package config nor `vitest.shared.ts:7` enables `restoreMocks`, so the mocked console methods are not automatically restored by configuration.
+
+## Finding 2: SIGKILL escalation is dead code
+
+Quoted finding:
+
+> Fix: the `SIGKILL` escalation is dead code. `killTimer` is cleared as a side effect of `finish()`, and `finish()` runs synchronously right after `killTimer` is created inside the timeout handler.
+
+Severity: Critical
+
+Verdict: invalid
+
+Evidence:
+
+The specific dead-code condition described by CodeRabbit has been fixed on current `origin/master`. In `packages/execution-engine/src/ssh-executor.ts:410`, `settled` is tracked separately from `closed` at line 411. The `finish` helper at `packages/execution-engine/src/ssh-executor.ts:414` sets `settled` and clears `timeoutTimer`, but it no longer clears `killTimer`. The child `close` handler sets `closed = true` and clears `killTimer` at `packages/execution-engine/src/ssh-executor.ts:429`.
+
+The timeout path now creates `killTimer` at `packages/execution-engine/src/ssh-executor.ts:451`, and the timer callback checks `if (!closed)` before sending `SIGKILL` at line 452. Because the guard is based on process closure rather than promise settlement, settling the timeout error at `packages/execution-engine/src/ssh-executor.ts:455` no longer prevents escalation. The regression test at `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1741` advances fake timers and asserts `SIGKILL` at line 1754.
+
+## Finding 3: Remote finalize retries are not idempotent and may overlap
+
+Quoted finding:
+
+> Make the remote finalize retry idempotent and wait for the previous SSH session to close. `buildRecordAndPushScript` always stages, commits, and pushes HEAD, so a retry after a local timeout can re-run a commit/push even if the remote operation already completed.
+
+Severity: Major
+
+Verdict: valid
+
+Evidence:
+
+The idempotency concern still applies on current `origin/master`. `buildRecordAndPushScript` stages all changes with `git add -A` at `packages/execution-engine/src/ssh-git-exec.ts:375`, creates either an empty commit at line 382 or a changes commit at line 385, then pushes the resulting `HEAD` at `packages/execution-engine/src/ssh-git-exec.ts:397` or line 399. The script does not use a lock, marker, stable idempotency token, or completed-result check before creating the commit.
+
+The overlap concern also still applies. `execRemoteCapture` starts a timeout at `packages/execution-engine/src/ssh-executor.ts:445`, sends `SIGTERM` at line 450, schedules `SIGKILL` for later at lines 451-453, and then immediately settles the promise with a timeout rejection at lines 455-460. `remoteGitRecordAndPush` catches that timeout and continues its retry loop at `packages/execution-engine/src/ssh-executor.ts:1031` without waiting for the previous SSH child to close. Therefore the next `execRemoteCapture` call at `packages/execution-engine/src/ssh-executor.ts:1033` can begin while the previous remote command is still alive until the delayed `SIGKILL` fires or the remote process exits on its own.

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -1736,6 +1736,7 @@ describe('SshExecutor remote finalize retry/timeout', () => {
     if (previousTimeoutEnv === undefined) delete process.env.INVOKER_REMOTE_FINALIZE_TIMEOUT_MS;
     else process.env.INVOKER_REMOTE_FINALIZE_TIMEOUT_MS = previousTimeoutEnv;
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('execRemoteCapture escalates a timed-out hung child from SIGTERM to SIGKILL', async () => {
@@ -1744,7 +1745,6 @@ describe('SshExecutor remote finalize retry/timeout', () => {
     const assertion = expect(pending).rejects.toMatchObject({ timedOut: true });
 
     await vi.advanceTimersByTimeAsync(20);
-    await assertion;
 
     const sshProcess = spawnedProcesses[spawnedProcesses.length - 1];
     expect(sshProcess.kill).toHaveBeenCalledWith('SIGTERM');
@@ -1752,6 +1752,8 @@ describe('SshExecutor remote finalize retry/timeout', () => {
     await vi.advanceTimersByTimeAsync(SIGKILL_TIMEOUT_MS);
 
     expect(sshProcess.kill).toHaveBeenCalledWith('SIGKILL');
+    sshProcess.emit('close', null, 'SIGKILL');
+    await assertion;
   });
 
   it('logs any remote command failure (non-zero exit), not just the finalize step', async () => {
@@ -1805,10 +1807,23 @@ describe('SshExecutor remote finalize retry/timeout', () => {
       0,
     );
 
-    // 3 sequential attempts, each bounded by the 20ms finalize timeout.
+    // 3 sequential attempts, each bounded by the 20ms finalize timeout and
+    // followed by process close before the next attempt starts.
     await vi.advanceTimersByTimeAsync(20);
+    expect(spawnedProcesses.length).toBe(1);
+    await vi.advanceTimersByTimeAsync(SIGKILL_TIMEOUT_MS);
+    spawnedProcesses[0]!.emit('close', null, 'SIGKILL');
+
     await vi.advanceTimersByTimeAsync(20);
+    expect(spawnedProcesses.length).toBe(2);
+    await vi.advanceTimersByTimeAsync(SIGKILL_TIMEOUT_MS);
+    spawnedProcesses[1]!.emit('close', null, 'SIGKILL');
+
     await vi.advanceTimersByTimeAsync(20);
+    expect(spawnedProcesses.length).toBe(3);
+    await vi.advanceTimersByTimeAsync(SIGKILL_TIMEOUT_MS);
+    spawnedProcesses[2]!.emit('close', null, 'SIGKILL');
+
     const result = await resultPromise;
 
     expect(result.error).toContain('timed out after 20ms');

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -454,6 +454,7 @@ describe('buildRecordAndPushScript', () => {
       commitMessageEmpty: 'invoker: task-123\n\nExit code: 0',
       gitUserName: 'Invoker Bot',
       gitUserEmail: 'invoker@local',
+      idempotencyKey: 'exec-1',
     });
 
     expect(script).toContain('set -euo pipefail');
@@ -469,6 +470,8 @@ describe('buildRecordAndPushScript', () => {
     expect(script).toContain('HASH=$(git rev-parse HEAD)');
     expect(script).toContain('REMOTE_EXPECTED=$(git ls-remote "$PUSH_REMOTE" "refs/heads/$BR"');
     expect(script).toContain('git push --force-with-lease="refs/heads/$BR:$REMOTE_EXPECTED" "$PUSH_REMOTE" "$HASH:refs/heads/$BR"');
+    expect(script).toContain('IDEMPOTENCY_KEY=$(printf');
+    expect(script).toContain('MARKER="$STATE_DIR/$SAFE_IDEMPOTENCY_KEY.hash"');
     expect(script).toContain('printf "%s" "$HASH"');
   });
 
@@ -548,6 +551,70 @@ describe('buildRecordAndPushScript', () => {
     expect(authorName).toBe('Remote CI Bot');
     expect(authorEmail).toBe('remote-ci@example.com');
     expect(pushedHead).toBe(localHead);
+  });
+
+  it('reuses the recorded commit when retried with the same idempotency key', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ssh-record-push-idempotent-'));
+    try {
+      const source = join(root, 'source');
+      const bare = join(root, 'remote.git');
+      const clone = join(root, 'clone');
+      const branch = 'experiment/test-branch';
+
+      mkdirSync(source, { recursive: true });
+      execSync('git init -b master', { cwd: source, stdio: 'ignore' });
+      writeFileSync(join(source, 'README.md'), 'seed\n');
+      execSync('git add README.md', { cwd: source, stdio: 'ignore' });
+      execSync('git -c user.name="Seed User" -c user.email="seed@example.com" commit -m "seed"', {
+        cwd: source,
+        stdio: 'ignore',
+      });
+      execSync(`git clone --bare ${JSON.stringify(source)} ${JSON.stringify(bare)}`, { stdio: 'ignore' });
+      execSync(`git clone ${JSON.stringify(bare)} ${JSON.stringify(clone)}`, { stdio: 'ignore' });
+      execSync(`git checkout -b ${branch}`, { cwd: clone, stdio: 'ignore' });
+      writeFileSync(join(clone, 'result.txt'), 'ok\n');
+
+      const script = buildRecordAndPushScript({
+        worktreePath: clone,
+        branch,
+        commitMessageChanges: 'invoker: record remote result',
+        commitMessageEmpty: 'invoker: record remote empty result',
+        gitUserName: 'Remote CI Bot',
+        gitUserEmail: 'remote-ci@example.com',
+        idempotencyKey: 'exec-1',
+      });
+
+      const firstOutput = execFileSync('bash', ['-lc', script], {
+        env: {
+          ...process.env,
+          HOME: mkdtempSync(join(tmpdir(), 'ssh-record-push-home-')),
+        },
+      }).toString().trim();
+      const firstHash = firstOutput.split(/\s+/).pop();
+
+      const markerDir = execSync('git rev-parse --git-path invoker-record-and-push', { cwd: clone }).toString().trim();
+      rmSync(markerDir, { recursive: true, force: true });
+
+      const secondOutput = execFileSync('bash', ['-lc', script], {
+        env: {
+          ...process.env,
+          HOME: mkdtempSync(join(tmpdir(), 'ssh-record-push-home-')),
+        },
+      }).toString().trim();
+      const secondHash = secondOutput.split(/\s+/).pop();
+      const commitCount = execSync('git rev-list --count HEAD', { cwd: clone }).toString().trim();
+      const commitMessage = execSync('git log -1 --format=%B', { cwd: clone }).toString();
+      const pushedHead = execSync(`git --git-dir=${JSON.stringify(bare)} rev-parse refs/heads/${branch}`)
+        .toString()
+        .trim();
+
+      expect(secondHash).toBe(firstHash);
+      expect(commitCount).toBe('2');
+      expect(commitMessage).toContain('Invoker-Finalize-Id: exec-1');
+      expect(pushedHead).toBe(firstHash);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('pushes the recorded HEAD when the checkout branch differs from the target branch', () => {

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -411,6 +411,7 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
       let closed = false;
       let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
       let killTimer: ReturnType<typeof setTimeout> | undefined;
+      let timeoutError: (Error & { timedOut?: boolean }) | undefined;
       const finish = (fn: () => void): void => {
         if (settled) return;
         settled = true;
@@ -435,7 +436,9 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
             stdoutBytes: out.length,
             stderrBytes: err.length,
           });
-          if (code === 0) resolve(out);
+          if (timeoutError) {
+            reject(timeoutError);
+          } else if (code === 0) resolve(out);
           else {
             logRemoteCommandFailure(this.host, this.user, phase, `exited with code ${code ?? 'null'}`, err, out);
             reject(createSshRemoteScriptError(code, out, err, phase));
@@ -452,13 +455,10 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
             if (!closed) killProcessGroup(child, 'SIGKILL');
           }, SIGKILL_TIMEOUT_MS);
           killTimer.unref?.();
-          finish(() => {
-            const timeoutError = createSshRemoteScriptError(null, out, err, phase) as Error & { timedOut?: boolean };
-            const prefix = `SSH remote command timed out after ${opts.timeoutMs}ms${phase ? ` (phase=${phase})` : ''}`;
-            timeoutError.message = `${prefix}\n${timeoutError.message}`;
-            timeoutError.timedOut = true;
-            reject(timeoutError);
-          });
+          timeoutError = createSshRemoteScriptError(null, out, err, phase) as Error & { timedOut?: boolean };
+          const prefix = `SSH remote command timed out after ${opts.timeoutMs}ms${phase ? ` (phase=${phase})` : ''}`;
+          timeoutError.message = `${prefix}\n${timeoutError.message}`;
+          timeoutError.timedOut = true;
         }, opts.timeoutMs);
         timeoutTimer.unref?.();
       }
@@ -1024,6 +1024,7 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
       gitUserName,
       gitUserEmail,
       pushRemoteUrl: request.inputs.branchRepoUrl?.trim() || undefined,
+      idempotencyKey: executionId,
     });
 
     const timeoutMs = remoteFinalizeTimeoutMs();

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -349,6 +349,7 @@ export interface GitRecordAndPushOpts {
   gitUserName: string;
   gitUserEmail: string;
   pushRemoteUrl?: string;
+  idempotencyKey?: string;
 }
 
 /**
@@ -366,25 +367,31 @@ export function buildRecordAndPushScript(opts: GitRecordAndPushOpts): string {
   const userNameB = base64Encode(opts.gitUserName);
   const userEmailB = base64Encode(opts.gitUserEmail);
   const pushRemoteUrlB = base64Encode(opts.pushRemoteUrl ?? '');
+  const idempotencyKeyB = base64Encode(opts.idempotencyKey ?? '');
 
   return `set -euo pipefail
 ${buildPortableBase64DecodeFunction()}
 WT=$(printf '%s' ${shellPosixSingleQuote(wtB)} | invoker_base64_decode)
 ${bashNormalizeTildePath()}
 cd "$WT"
-git add -A
-M=$(mktemp)
-trap 'rm -f "$M"' EXIT
+IDEMPOTENCY_KEY=$(printf '%s' ${shellPosixSingleQuote(idempotencyKeyB)} | invoker_base64_decode)
+MARKER=''
+IDEMPOTENCY_FOOTER=''
+if [ -n "$IDEMPOTENCY_KEY" ]; then
+  IDEMPOTENCY_FOOTER="Invoker-Finalize-Id: $IDEMPOTENCY_KEY"
+  SAFE_IDEMPOTENCY_KEY=$(printf '%s' "$IDEMPOTENCY_KEY" | tr -c 'A-Za-z0-9_.-' '_')
+  STATE_DIR=$(git rev-parse --git-path invoker-record-and-push)
+  MARKER="$STATE_DIR/$SAFE_IDEMPOTENCY_KEY.hash"
+  if [ -s "$MARKER" ]; then
+    RECORDED_HASH=$(cat "$MARKER")
+    if git rev-parse --verify --quiet "$RECORDED_HASH^{commit}" >/dev/null; then
+      printf "%s" "$RECORDED_HASH"
+      exit 0
+    fi
+  fi
+fi
 GIT_NAME=$(printf '%s' ${shellPosixSingleQuote(userNameB)} | invoker_base64_decode)
 GIT_EMAIL=$(printf '%s' ${shellPosixSingleQuote(userEmailB)} | invoker_base64_decode)
-if git diff --cached --quiet; then
-  printf '%s' ${shellPosixSingleQuote(emB)} | invoker_base64_decode > "$M"
-  GIT_AUTHOR_NAME="$GIT_NAME" GIT_AUTHOR_EMAIL="$GIT_EMAIL" GIT_COMMITTER_NAME="$GIT_NAME" GIT_COMMITTER_EMAIL="$GIT_EMAIL" git commit --allow-empty -F "$M"
-else
-  printf '%s' ${shellPosixSingleQuote(chB)} | invoker_base64_decode > "$M"
-  GIT_AUTHOR_NAME="$GIT_NAME" GIT_AUTHOR_EMAIL="$GIT_EMAIL" GIT_COMMITTER_NAME="$GIT_NAME" GIT_COMMITTER_EMAIL="$GIT_EMAIL" git commit -F "$M"
-fi
-HASH=$(git rev-parse HEAD)
 BR=$(printf '%s' ${shellPosixSingleQuote(brB)} | invoker_base64_decode)
 PUSH_URL=$(printf '%s' ${shellPosixSingleQuote(pushRemoteUrlB)} | invoker_base64_decode)
 if [ -n "$PUSH_URL" ]; then
@@ -392,13 +399,38 @@ if [ -n "$PUSH_URL" ]; then
 else
   PUSH_REMOTE=origin
 fi
-REMOTE_EXPECTED=$(git ls-remote "$PUSH_REMOTE" "refs/heads/$BR" | awk 'NR == 1 { print $1 }')
-if [ -n "$REMOTE_EXPECTED" ]; then
-  git push --force-with-lease="refs/heads/$BR:$REMOTE_EXPECTED" "$PUSH_REMOTE" "$HASH:refs/heads/$BR"
-else
-  git push "$PUSH_REMOTE" "$HASH:refs/heads/$BR"
+push_recorded_head() {
+  HASH=$(git rev-parse HEAD)
+  REMOTE_EXPECTED=$(git ls-remote "$PUSH_REMOTE" "refs/heads/$BR" | awk 'NR == 1 { print $1 }')
+  if [ -n "$REMOTE_EXPECTED" ]; then
+    git push --force-with-lease="refs/heads/$BR:$REMOTE_EXPECTED" "$PUSH_REMOTE" "$HASH:refs/heads/$BR"
+  else
+    git push "$PUSH_REMOTE" "$HASH:refs/heads/$BR"
+  fi
+  if [ -n "$MARKER" ]; then
+    mkdir -p "$(dirname "$MARKER")"
+    printf "%s" "$HASH" > "$MARKER.tmp"
+    mv "$MARKER.tmp" "$MARKER"
+  fi
+  printf "%s" "$HASH"
+}
+if [ -n "$IDEMPOTENCY_FOOTER" ] && git log -1 --format=%B | grep -Fqx "$IDEMPOTENCY_FOOTER"; then
+  push_recorded_head
+  exit 0
 fi
-printf "%s" "$HASH"
+git add -A
+M=$(mktemp)
+trap 'rm -f "$M"' EXIT
+if git diff --cached --quiet; then
+  printf '%s' ${shellPosixSingleQuote(emB)} | invoker_base64_decode > "$M"
+  if [ -n "$IDEMPOTENCY_FOOTER" ]; then printf '\\n%s\\n' "$IDEMPOTENCY_FOOTER" >> "$M"; fi
+  GIT_AUTHOR_NAME="$GIT_NAME" GIT_AUTHOR_EMAIL="$GIT_EMAIL" GIT_COMMITTER_NAME="$GIT_NAME" GIT_COMMITTER_EMAIL="$GIT_EMAIL" git commit --allow-empty -F "$M"
+else
+  printf '%s' ${shellPosixSingleQuote(chB)} | invoker_base64_decode > "$M"
+  if [ -n "$IDEMPOTENCY_FOOTER" ]; then printf '\\n%s\\n' "$IDEMPOTENCY_FOOTER" >> "$M"; fi
+  GIT_AUTHOR_NAME="$GIT_NAME" GIT_AUTHOR_EMAIL="$GIT_EMAIL" GIT_COMMITTER_NAME="$GIT_NAME" GIT_COMMITTER_EMAIL="$GIT_EMAIL" git commit -F "$M"
+fi
+push_recorded_head
 `;
 }
 


### PR DESCRIPTION
## Summary

The slice 1 audit confirmed two CodeRabbit findings from PR #7053 still hold on master. This slice fixes both in the remote finalize path.

The finalize timeout test block now restores console spies with `vi.restoreAllMocks()` in `afterEach`, so spies made inside the block no longer leak into later tests.

`remoteGitRecordAndPush` now passes the stable execution id into `buildRecordAndPushScript`. The generated script records a per-execution commit marker and reuses that finalize commit when the same execution runs again.

`execRemoteCapture` now settles timeout failures only from the child close handler, so a repeated finalize attempt cannot begin while the previous SSH session is still alive.

## Review Claim

Repeated remote finalize attempts are idempotent (one finalize commit per execution id, reused on later attempts) and cannot overlap a still-open SSH session, and the finalize timeout tests restore their console spies.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the sites named by the two "Verdict: valid" findings change: the finalize script builder, the timeout settlement path, and the test block that leaked spies. The code behind the finding judged invalid is untouched and no new components are introduced.

## Slice Rationale

These fixes exist because the slice 1 audit judged findings 1 and 3 valid. Keeping them in their own behavior slice ties each code change to its recorded verdict; the audit report update lands in slice 3.

## Non-goals

- No refactors beyond the finding sites.
- No changes for finding 2, which the audit judged invalid because master already fixed it.
- No audit-report edits; the fix record lands in slice 3.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/ssh-git-exec.test.ts` (54 passed, including the new idempotency-key reuse test)
- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/ssh-executor.test.ts -t "SshExecutor remote finalize retry/timeout"` (5 passed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert` this PR's merge commit (or the GitHub Revert button)
- Post-revert steps: None; reverting restores the previous non-idempotent finalize behavior only
- Data migration? No

</details>
