### PR TITLE
[Unknown State Invariant](7) Add an e2e proof for the unconfirmed-terminal-status fix

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -21,11 +21,14 @@ import {
   openPlanGraph,
   E2E_REPO_URL,
 } from './fixtures/electron-app.js';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import * as fs from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import * as path from 'node:path';
 import { stringify as yamlStringify } from 'yaml';
-import type { Locator, Page } from '@playwright/test';
-import { SQLiteAdapter, type WorkerActionWrite } from '@invoker/data-store';
+import { _electron as electron, type Locator, type Page } from '@playwright/test';
+import { SQLiteAdapter, type WorkerActionWrite, type InAppPlanningSessionRecord } from '@invoker/data-store';
+import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
 /** Plan for queue-semantics visual proof: enough tasks to fill Action Queue and Backlog. */
 const QUEUE_SEMANTICS_PLAN = {
   name: 'Queue Semantics Visual Proof',
@@ -2948,5 +2951,88 @@ test.describe('Visual proof capture', () => {
     await expect(dialog.getByText('Start and recreate failed, pending, and running')).toBeVisible();
     await expect(dialog.getByText('Running workflows')).toBeVisible();
     await captureScreenshot(page, 'start-ready-recreate-failed-pending-and-running-dialog');
+  });
+});
+
+test.describe('Unknown terminal status visual proof', () => {
+  test('hydrated session with unconfirmed terminal status shows the reattach placeholder, then reattaches for real', async () => {
+    const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-unknown-terminal-status-'));
+    const userDataDir = path.join(testDir, 'electron-user-data');
+    const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+    const configPath = path.join(testDir, 'e2e-config.json');
+    await fs.mkdir(userDataDir, { recursive: true });
+    writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0 }), 'utf8');
+    registerTrackedBrowserUserDataDir(userDataDir);
+
+    const record: InAppPlanningSessionRecord = {
+      id: 'plan-unknown-terminal-status',
+      title: 'Unknown terminal status session',
+      presetKey: 'codex',
+      status: 'still_discussing',
+      confirmationMode: 'require',
+      messages: [
+        { id: 1, role: 'user', text: 'Keep going on this plan.', createdAt: '2026-07-28T00:00:00.000Z' },
+        { id: 2, role: 'assistant', text: 'Picking back up where we left off.', createdAt: '2026-07-28T00:00:05.000Z' },
+      ],
+      terminalMode: 'tmux',
+      terminalSessionId: 'term-unknown-status-fixture',
+      terminalOutputSnapshot: 'stale snapshot captured before the last restart',
+      pendingResponse: false,
+      createdAt: '2026-07-28T00:00:00.000Z',
+      updatedAt: '2026-07-28T00:00:05.000Z',
+    };
+    const seedAdapter = await SQLiteAdapter.create(path.join(testDir, 'invoker.db'), { ownerCapability: true });
+    try {
+      seedAdapter.upsertInAppPlanningSession(record);
+    } finally {
+      seedAdapter.close();
+    }
+
+    const app = await electron.launch({
+      args: [
+        ...(process.platform === 'linux'
+          ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-gpu-compositing', '--disable-gpu-sandbox', '--disable-software-rasterizer']
+          : []),
+        `--user-data-dir=${userDataDir}`,
+        path.resolve(__dirname, '..', 'dist', 'main.js'),
+      ],
+      env: {
+        ...process.env,
+        NODE_ENV: 'test',
+        INVOKER_TEST_WORKFLOW_IDS: '1',
+        INVOKER_DISABLE_SLACK: '1',
+        TZ: 'UTC',
+        INVOKER_GUI_OWNER_MODE: 'gui',
+        INVOKER_DB_DIR: testDir,
+        INVOKER_IPC_SOCKET: ipcSocketPath,
+        INVOKER_ALLOW_DELETE_ALL: '1',
+        INVOKER_E2E_ENABLE_COMPOSITOR: '1',
+        INVOKER_REPO_CONFIG_PATH: configPath,
+        INVOKER_E2E_SKIP_PLANNING_TERMINAL_RESTORE: '1',
+      },
+    });
+
+    try {
+      const page = await app.firstWindow();
+      await page.waitForLoadState('domcontentloaded');
+      await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 15000 });
+
+      await page.getByTestId('sidebar-home').click();
+
+      await expect(page.getByTestId('invoker-terminal-tmux-placeholder')).toBeVisible({ timeout: 10000 });
+      await expect(page.getByTestId('invoker-terminal-tmux-pane')).toHaveCount(0);
+      await captureScreenshot(page, 'unknown-terminal-status-placeholder');
+
+      await page.locator('[data-testid="invoker-terminal-mode-toggle"]').getByRole('tab', { name: 'Tmux' }).click();
+
+      await expect(page.getByTestId('invoker-terminal-tmux-pane')).toBeVisible({ timeout: 15000 });
+      const reattachedSessionId = await page.getByTestId('invoker-terminal-tmux-pane').getAttribute('data-session-id');
+      expect(reattachedSessionId).toBeTruthy();
+      expect(reattachedSessionId).not.toBe('term-unknown-status-fixture');
+      await captureScreenshot(page, 'unknown-terminal-status-reattached');
+    } finally {
+      await app.close().catch(() => undefined);
+      rmSync(testDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -1687,6 +1687,26 @@ describe('planning chat worktree provisioning', () => {
     expect(hydrated.baseCommit).toBe('fake-head-sha');
   });
 
+  it('preserves a terminalSessionId-present/terminalStatus-absent divergence verbatim across hydration', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    const created = await createPlanningChatSession({}, {
+      config: { defaultRepoUrl: 'https://example.com/repo.git', defaultBranch: 'main' },
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    if (!created.ok) throw new Error(created.error);
+
+    const ambiguousSummary = {
+      ...created.session,
+      terminalSessionId: 'term-ambiguous',
+      terminalStatus: undefined,
+    };
+    const hydrated = hydrateRemotePlanningTerminalSession(ambiguousSummary);
+    expect(hydrated.terminalSessionId).toBe('term-ambiguous');
+    expect(hydrated.terminalStatus).toBeUndefined();
+  });
+
   it('falls back to deps.workingDir exactly as before when no repoPool is supplied', async () => {
     const workingDir = mkdtempSync(join(tmpdir(), 'in-app-no-repo-pool-'));
     try {

--- a/packages/app/src/__tests__/launch-claim-orphan-regression.test.ts
+++ b/packages/app/src/__tests__/launch-claim-orphan-regression.test.ts
@@ -130,6 +130,7 @@ describe('launch-claim orphan regression (2026-05-22 storm)', () => {
           prepareTaskForNewAttempt: (taskId, reason) =>
             orchestrator.prepareTaskForNewAttempt(taskId, reason),
           getTask: (taskId) => orchestrator.getTask(taskId),
+          getTaskLaunchReadiness: (taskId) => orchestrator.getTaskLaunchReadiness(taskId),
         },
         taskRunnerProvider: () => fakeTaskRunner,
         ownerId: 'cb5-test-owner',

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -655,6 +655,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask,
+          getTaskLaunchReadiness: (id: string) => ({ ready: true, task: getTask(id) }),
         },
         taskRunnerProvider: () => ({ executeTask }),
       });
@@ -710,6 +711,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask,
+          getTaskLaunchReadiness: (id: string) => ({ ready: true, task: getTask(id) }),
         },
         taskRunnerProvider: () => ({ executeTask }),
         maxLeasesPerPoll: 2,
@@ -771,6 +773,7 @@ describe('LaunchDispatcher', () => {
             cold.prepareTaskForNewAttempt(taskId, reason),
           syncFromDb: (workflowId) => cold.syncFromDb(workflowId),
           getTask: (taskId) => cold.getTask(taskId),
+          getTaskLaunchReadiness: (taskId) => cold.getTaskLaunchReadiness(taskId),
         },
         taskRunnerProvider: () => ({ executeTask }),
       });
@@ -839,6 +842,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask: () => task as any,
+          getTaskLaunchReadiness: () => ({ ready: true, task: task as any }),
           startExecution,
         },
         taskRunnerProvider: () => ({ executeTask }),
@@ -877,6 +881,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask: () => task as any,
+          getTaskLaunchReadiness: () => ({ ready: true, task: task as any }),
           startExecution,
         },
         taskRunnerProvider: () => ({ executeTask }),
@@ -926,6 +931,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask: vi.fn().mockReturnValue(currentTask as any),
+          getTaskLaunchReadiness: () => ({ ready: true, task: currentTask as any }),
         },
         taskRunnerProvider: () => ({ executeTask }),
       });
@@ -967,6 +973,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask: vi.fn().mockReturnValue(currentTask as any),
+          getTaskLaunchReadiness: () => ({ ready: true, task: currentTask as any }),
         },
         taskRunnerProvider: () => ({ executeTask }),
       });
@@ -1017,6 +1024,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask: vi.fn().mockReturnValue(currentTask as any),
+          getTaskLaunchReadiness: () => ({ ready: true, task: currentTask as any }),
         },
         taskRunnerProvider: () => ({ executeTask }),
       });
@@ -1067,6 +1075,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask: vi.fn().mockReturnValue(currentTask as any),
+          getTaskLaunchReadiness: () => ({ ready: true, task: currentTask as any }),
         },
         taskRunnerProvider: () => ({ executeTask }),
       });
@@ -1139,6 +1148,43 @@ describe('LaunchDispatcher', () => {
       });
     });
 
+    it('abandons the dispatch when the orchestrator cannot verify launch readiness', () => {
+      const task = seedWorkflowAndTask('wf-a/t-unverifiable', 'wf-a', {
+        selectedAttemptId: 'attempt-unverifiable',
+        generation: 0,
+      });
+      const enq = adapter.enqueueLaunchDispatch({
+        taskId: task.id,
+        attemptId: 'attempt-unverifiable',
+        workflowId: 'wf-a',
+        generation: 0,
+      });
+      const executeTask = vi.fn();
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask: vi.fn().mockReturnValue(task as any),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+      });
+
+      dispatcher.poll();
+
+      expect(executeTask).not.toHaveBeenCalled();
+      const after = adapter.loadLaunchDispatchById(enq.id);
+      expect(after?.state).toBe('abandoned');
+      expect(after?.lastError).toMatch(/readiness could not be verified/);
+      const events = adapter.getEvents(task.id);
+      const invalidated = events.find((event) => event.eventType === 'task.launch_dispatch_invalidated');
+      expect(invalidated).toBeDefined();
+      expect(JSON.parse(invalidated!.payload!)).toMatchObject({
+        dispatchId: enq.id,
+        reason: 'readiness_unverifiable',
+      });
+    });
+
     it('abandons the dispatch when the orchestrator has no matching task', () => {
       seedWorkflowAndTask('wf-a/t-missing', 'wf-a', {
         selectedAttemptId: 'attempt-missing',
@@ -1201,6 +1247,7 @@ describe('LaunchDispatcher', () => {
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
           getTask: vi.fn().mockReturnValue(task as any),
+          getTaskLaunchReadiness: () => ({ ready: true, task: task as any }),
         },
         taskRunnerProvider: () => ({ executeTask }),
       });

--- a/packages/app/src/__tests__/launch-pool-deferral-outbox-repro.test.ts
+++ b/packages/app/src/__tests__/launch-pool-deferral-outbox-repro.test.ts
@@ -88,6 +88,7 @@ async function runPoolDeferralScenario(options: { completeDeferredDispatch: bool
     orchestrator: {
       prepareTaskForNewAttempt: (id, reason) => orchestrator.prepareTaskForNewAttempt(id, reason),
       getTask: (id) => orchestrator.getTask(id),
+      getTaskLaunchReadiness: (id) => orchestrator.getTaskLaunchReadiness(id),
     },
     taskRunnerProvider: () => ({
       async executeTask(task, opts) {

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -340,6 +340,14 @@ export class LaunchDispatcher {
         );
         continue;
       }
+      if (this.orchestrator && typeof this.orchestrator.getTaskLaunchReadiness !== 'function') {
+        this.abandonInvalidDispatch(
+          leased,
+          `Task ${leased.taskId} launch readiness could not be verified: orchestrator does not implement getTaskLaunchReadiness`,
+          'readiness_unverifiable',
+        );
+        continue;
+      }
       const readiness = this.orchestrator?.getTaskLaunchReadiness?.(leased.taskId);
       if (readiness) {
         if (!readiness.ready) {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3239,7 +3239,7 @@ startMainProcessBootstrap({
         logger,
       });
     });
-    if (ownerMode) {
+    if (ownerMode && process.env.INVOKER_E2E_SKIP_PLANNING_TERMINAL_RESTORE !== '1') {
       planningTerminalState.restorePersistedPlanningTerminals();
     }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -339,12 +339,13 @@ function planningSessionFromSummary(
   overrides: Partial<PlanningSessionView> = {},
 ): PlanningSessionView {
   const restoredTerminalSession = summary.terminalSessionId
+    && (summary.terminalStatus === 'running' || summary.terminalStatus === 'exited')
     ? {
         sessionId: summary.terminalSessionId,
         taskId: `planning:${summary.id}`,
         kind: 'planning' as const,
         planningSessionId: summary.id,
-        status: summary.terminalStatus ?? ('running' as const),
+        status: summary.terminalStatus,
         exitCode: summary.terminalExitCode,
         cwd: undefined,
         mode: 'spawn' as const,

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -805,6 +805,40 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
+  it('does not trust an unconfirmed terminal status as live, and reattaches for real when asked', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'plan-ambiguous',
+          title: 'Ambiguous tmux session',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          terminalMode: 'tmux',
+          terminalSessionId: 'term-ambiguous',
+          terminalOutputSnapshot: 'stale snapshot from before restart',
+        }),
+      ],
+    })) as any;
+
+    render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+
+    expect(await screen.findByTestId('invoker-terminal-tmux-placeholder')).toBeInTheDocument();
+    expect(screen.queryByTestId('invoker-terminal-tmux-pane')).not.toBeInTheDocument();
+    expect(mock.api.planningTerminalOpen).not.toHaveBeenCalled();
+
+    fireEvent.click(within(screen.getByTestId('invoker-terminal-mode-toggle')).getByRole('tab', { name: 'Tmux' }));
+
+    await waitFor(() => expect(mock.api.planningTerminalOpen).toHaveBeenCalledWith('plan-ambiguous'));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-tmux-pane')).toHaveAttribute(
+        'data-session-id',
+        'mock-planning-terminal-plan-ambiguous',
+      );
+    });
+  });
+
   it('renders chat role labels and fenced YAML in a mono code panel', async () => {
     mock.api.planningChatSend = vi.fn(async () => ({
       ok: true,


### PR DESCRIPTION
## Summary

A sibling fix in this stack stops the UI from fabricating a live terminal session when a restored planning session's status can't be confirmed.

That fix was already covered by a component-level test, but nothing exercised the real end-to-end path: a genuinely persisted row, a real app boot, a real reattach click.

Adds a Playwright test that seeds the exact ambiguous row directly, using the previous slice's switch to make it observable, and captures the honest placeholder plus the real reattach as visual proof.

## Review Claim

Approve a new end-to-end test that proves the honest-placeholder behavior against a real persisted row and a real app boot, not just a component-level fixture.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This adds a test only; it does not change any production code path or file.

## Slice Rationale

Seventh slice in this stack, split from the previous one because a Playwright spec under `e2e/` is classified as a distinct review unit from the production file it depends on, and the two can't ship in the same PR without breaking the atomicity gate.

## Non-goals

This does not change the fix itself (an earlier slice) or the switch it depends on (the previous slice). It adds coverage only.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm run test:e2e e2e/visual-proof.spec.ts -g "Unknown terminal status visual proof"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
