### PR TITLE
Bugfix: e2e-autofix-worker leaking INVOKER_HEADLESS_STANDALONE into its spawned child

### DIFF
--- a/packages/execution-engine/src/__tests__/e2e-autofix-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/e2e-autofix-worker.test.ts
@@ -127,6 +127,54 @@ describe('e2e auto-fix worker', () => {
     );
   });
 
+  it('does not leak standalone headless mode into the spawned watcher env', async () => {
+    const repoRoot = makeRepoRoot();
+    const harness = makeSpawnHarness();
+    const originalStandalone = process.env.INVOKER_HEADLESS_STANDALONE;
+    const originalUnrelated = process.env.E2E_AUTOFIX_WORKER_TEST_UNRELATED;
+    const originalOverride = process.env.E2E_AUTOFIX_WORKER_TEST_OVERRIDE;
+
+    try {
+      process.env.INVOKER_HEADLESS_STANDALONE = '1';
+      process.env.E2E_AUTOFIX_WORKER_TEST_UNRELATED = 'owner-value';
+      process.env.E2E_AUTOFIX_WORKER_TEST_OVERRIDE = 'owner-value';
+
+      const tick = createE2eAutoFixTick({
+        logger: makeLogger(),
+        repoRoot,
+        env: {
+          E2E_AUTOFIX_WORKER_TEST_OVERRIDE: 'override-value',
+        },
+        spawnProcess: harness.spawnProcess,
+      });
+
+      await tick(makeCtx());
+
+      expect(harness.calls).toHaveLength(1);
+      expect(harness.calls[0].options.env).not.toHaveProperty('INVOKER_HEADLESS_STANDALONE');
+      expect(harness.calls[0].options.env).toEqual(expect.objectContaining({
+        E2E_AUTOFIX_WORKER_TEST_UNRELATED: 'owner-value',
+        E2E_AUTOFIX_WORKER_TEST_OVERRIDE: 'override-value',
+      }));
+    } finally {
+      if (originalStandalone === undefined) {
+        delete process.env.INVOKER_HEADLESS_STANDALONE;
+      } else {
+        process.env.INVOKER_HEADLESS_STANDALONE = originalStandalone;
+      }
+      if (originalUnrelated === undefined) {
+        delete process.env.E2E_AUTOFIX_WORKER_TEST_UNRELATED;
+      } else {
+        process.env.E2E_AUTOFIX_WORKER_TEST_UNRELATED = originalUnrelated;
+      }
+      if (originalOverride === undefined) {
+        delete process.env.E2E_AUTOFIX_WORKER_TEST_OVERRIDE;
+      } else {
+        process.env.E2E_AUTOFIX_WORKER_TEST_OVERRIDE = originalOverride;
+      }
+    }
+  });
+
   it('resolves when the script exits with code 0', async () => {
     const repoRoot = makeRepoRoot();
     const tick = createE2eAutoFixTick({

--- a/packages/execution-engine/src/workers/e2e-autofix-worker.ts
+++ b/packages/execution-engine/src/workers/e2e-autofix-worker.ts
@@ -97,9 +97,11 @@ async function runE2eAutoFixEntrypoint(options: E2eAutoFixTickOptions): Promise<
 
   let child: ChildProcess;
   try {
+    const childEnv = { ...process.env, ...options.env };
+    delete childEnv.INVOKER_HEADLESS_STANDALONE;
     child = spawnProcess(shell, [scriptPath], {
       cwd: repoRoot,
-      env: { ...process.env, ...options.env },
+      env: childEnv,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
   } catch (err) {


### PR DESCRIPTION
## Summary

The e2e-autofix worker no longer forwards the owner's standalone launch flag to its spawned plan-submission child.

That child now delegates to the running owner instead of trying to bootstrap services beside it.

The regression test covers the exact env merge path and keeps caller-provided env precedence intact.

## Review Claim

Approve the routing fix that omits the inherited standalone flag from the spawned e2e-autofix child environment after the final env merge.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the env object passed to `spawnProcess` inside `runE2eAutoFixEntrypoint` changes.

The script path, args, cwd, stdio wiring, and `E2eAutoFixWorkerConfig.env` precedence are unchanged.

The removal happens after merging `options.env`, matching the existing pr-maintenance worker pattern that strips `INVOKER_HEADLESS_STANDALONE` from its final child env.

## Slice Rationale

This is one routing slice for the e2e-autofix child process env construction path and its focused regression test.

The other call sites already strip this flag, so this slice does not add a shared helper or touch unrelated launch paths.

## Non-goals

- No changes to the script being spawned.
- No changes to child process args, cwd, or stdio.
- No changes to `packages/execution-engine/src/process-utils.ts`.
- No changes to `packages/execution-engine/src/workers/pr-maintenance-workers.ts`.
- No new `INVOKER_HEADLESS_REQUIRE_EXISTING_OWNER` behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- e2e-autofix-worker`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert f698aa684`
- Post-revert steps: Re-run `cd packages/execution-engine && pnpm test -- e2e-autofix-worker`.
- Data migration? No.

</details>
