### PR TITLE
[Owner Watchdog Deadlocks](1) Add a test seam for overriding headless_query's Electron binary

### DIFF
--- a/scripts/headless-lib.sh
+++ b/scripts/headless-lib.sh
@@ -20,6 +20,9 @@
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RUNNER="$REPO_ROOT/run.sh"
 ELECTRON="$REPO_ROOT/scripts/electron.cjs"
+if [[ -n "${INVOKER_HEADLESS_ELECTRON_BIN:-}" ]]; then
+  ELECTRON="$INVOKER_HEADLESS_ELECTRON_BIN"
+fi
 MAIN="$REPO_ROOT/packages/app/dist/main.js"
 IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
 if [[ -n "${INVOKER_HEADLESS_IPC_HELPER:-}" ]]; then


### PR DESCRIPTION
## Summary

The DigitalOcean Invoker owner crashed tonight, and the cron-scheduled CI-failure watcher that queries it hung for 14+ hours instead of noticing and backing off.

The root cause traces to a shared helper with zero timeout anywhere in its call chain. This slice adds a small override hook so the next slice can prove that in a repro, before touching the real behavior.

## Review Claim

Approve a no-op-when-unset override for which Electron binary `headless_query` execs, mirroring an existing override convention already in this file.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The override only takes effect when the env var is explicitly set. Every real caller leaves it unset, so this change has zero effect on any production code path today.

## Slice Rationale

First of six independent slices fixing a real production incident. This one only adds a test hook; the next slice uses it to prove the bug before any behavior changes.

## Non-goals

This does not change any runtime behavior. The actual timeout fix is a later slice in this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash -n scripts/headless-lib.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
