### PR TITLE
[Owner Watchdog Deadlocks](4) Add an independent execSync timeout backstop to the CI watcher

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -415,7 +415,13 @@ export function getCiRun(runId) {
 function headlessQueryWorkflowsJson() {
   return execSync(
     `source "${join(REPO_ROOT, 'scripts', 'headless-lib.sh')}" && headless_query query workflows --output json`,
-    { shell: '/bin/bash', encoding: 'utf8', cwd: REPO_ROOT },
+    {
+      shell: '/bin/bash',
+      encoding: 'utf8',
+      cwd: REPO_ROOT,
+      timeout: 90_000,
+      killSignal: 'SIGKILL',
+    },
   );
 }
 

--- a/scripts/headless-lib.sh
+++ b/scripts/headless-lib.sh
@@ -20,6 +20,9 @@
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RUNNER="$REPO_ROOT/run.sh"
 ELECTRON="$REPO_ROOT/scripts/electron.cjs"
+if [[ -n "${INVOKER_HEADLESS_ELECTRON_BIN:-}" ]]; then
+  ELECTRON="$INVOKER_HEADLESS_ELECTRON_BIN"
+fi
 MAIN="$REPO_ROOT/packages/app/dist/main.js"
 IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
 if [[ -n "${INVOKER_HEADLESS_IPC_HELPER:-}" ]]; then

--- a/scripts/headless-lib.sh
+++ b/scripts/headless-lib.sh
@@ -51,9 +51,26 @@ fi
 # ---------------------------------------------------------------------------
 
 # Read-only Electron query (stderr suppressed for clean parsing).
+#
+# Bounded by INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS (default 60; 0 disables).
+# Safe to kill on timeout: this only runs `query` subcommands, which never
+# write to the DB, so there is no stuck-row risk the way there is for
+# headless_mutation (see run_with_optional_timeout's use in rebase-retry-all.sh
+# for that different, deliberately-timeout-free case).
 headless_query() {
+  local seconds="${INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS:-60}"
+  local status=0
   # shellcheck disable=SC2086
-  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null
+  run_with_optional_timeout "$seconds" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null || status=$?
+  case "$status" in
+    124)
+      echo "ERROR: headless_query timed out after ${seconds}s (query subprocess killed; owner may be crashed/unresponsive). Override with INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS=<seconds>, or =0 to disable. args: $*" >&2
+      ;;
+    127)
+      echo "ERROR: headless_query could not enforce a timeout (timeout/gtimeout/python3 all unavailable); query ran without a bound." >&2
+      ;;
+  esac
+  return "$status"
 }
 
 # Mutating command — delegates to the owner (standalone or IPC).
@@ -124,26 +141,36 @@ run_with_optional_timeout() {
     return $?
   fi
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$seconds" "$@"
+    timeout -k 5 "$seconds" "$@"
     return $?
   fi
   if command -v gtimeout >/dev/null 2>&1; then
-    gtimeout "$seconds" "$@"
+    gtimeout -k 5 "$seconds" "$@"
     return $?
   fi
   if command -v python3 >/dev/null 2>&1; then
     python3 - "$seconds" "$@" <<'PY'
+import os
+import signal
 import subprocess
 import sys
 
 timeout = int(sys.argv[1])
 cmd = sys.argv[2:]
 
+proc = subprocess.Popen(cmd, start_new_session=True)
 try:
-    completed = subprocess.run(cmd, timeout=timeout, check=False)
-    sys.exit(completed.returncode)
+    sys.exit(proc.wait(timeout=timeout))
 except subprocess.TimeoutExpired:
     print(f"Timed out after {timeout}s: {' '.join(cmd)}", file=sys.stderr)
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait()
+    except ProcessLookupError:
+        pass
     sys.exit(124)
 PY
     return $?

--- a/scripts/repro/repro-headless-query-hang-timeout.sh
+++ b/scripts/repro/repro-headless-query-hang-timeout.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+EXPECTATION="fixed"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect-bug)
+      EXPECTATION="bug"
+      shift
+      ;;
+    --expect-fixed)
+      EXPECTATION="fixed"
+      shift
+      ;;
+    *)
+      echo "usage: $0 [--expect-bug|--expect-fixed]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+TMP_ROOT="$(mktemp -d -t invoker-headless-query-hang-repro.XXXXXX)"
+
+cleanup() {
+  pkill -f "$TMP_ROOT/fake-electron.sh" 2>/dev/null || true
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+FAKE_ELECTRON="$TMP_ROOT/fake-electron.sh"
+cat > "$FAKE_ELECTRON" <<'SH'
+#!/usr/bin/env bash
+# Simulates a fresh Electron process whose IPC/owner handshake never
+# resolves (owner crashed): ignores all args, blocks forever.
+exec sleep 999999
+SH
+chmod +x "$FAKE_ELECTRON"
+
+export INVOKER_HEADLESS_ELECTRON_BIN="$FAKE_ELECTRON"
+
+if [[ "$EXPECTATION" == "bug" ]]; then
+  echo "==> repro: guard disabled (INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS=0), outer bound=3s"
+  set +e
+  INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS=0 timeout -k 1 3 bash -c \
+    "source '$ROOT_DIR/scripts/headless-lib.sh'; headless_query query workflows --output json" \
+    > "$TMP_ROOT/out.log" 2>"$TMP_ROOT/err.log"
+  OUTER_STATUS=$?
+  set -e
+  if [[ "$OUTER_STATUS" -eq 124 ]]; then
+    echo "PASS: unguarded headless_query did not return within 3s (bug reproduced)"
+    exit 0
+  fi
+  echo "FAIL: expected outer 3s bound to fire (status=$OUTER_STATUS)" >&2
+  cat "$TMP_ROOT/out.log" "$TMP_ROOT/err.log" >&2 || true
+  exit 1
+fi
+
+echo "==> repro: guard enabled (INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS=3)"
+export INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS=3
+source "$ROOT_DIR/scripts/headless-lib.sh"
+
+START_SEC="$SECONDS"
+set +e
+headless_query query workflows --output json >"$TMP_ROOT/out.log" 2>"$TMP_ROOT/err.log"
+STATUS=$?
+set -e
+ELAPSED=$((SECONDS - START_SEC))
+
+if [[ "$STATUS" -ne 124 ]]; then
+  echo "FAIL: expected exit 124, got $STATUS" >&2
+  cat "$TMP_ROOT/out.log" "$TMP_ROOT/err.log" >&2 || true
+  exit 1
+fi
+if [[ "$ELAPSED" -gt 6 ]]; then
+  echo "FAIL: took ${ELAPSED}s, expected bounded near the 3s guard" >&2
+  exit 1
+fi
+if ! grep -Fq "headless_query timed out after 3s" "$TMP_ROOT/err.log"; then
+  echo "FAIL: expected clear timeout diagnostic on stderr" >&2
+  cat "$TMP_ROOT/err.log" >&2
+  exit 1
+fi
+echo "PASS: guarded headless_query returned within ${ELAPSED}s with exit 124 and a clear error"

--- a/scripts/test-suites/required/30-headless-query-timeout-guard.sh
+++ b/scripts/test-suites/required/30-headless-query-timeout-guard.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Regression: headless_query must time out instead of hanging forever when
+# the owner is dead/unresponsive.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+bash "$ROOT/scripts/repro/repro-headless-query-hang-timeout.sh" --expect-fixed


### PR DESCRIPTION
## Summary

Adds a second, independent, generously-margined bound around the CI-failure watcher's own query call: 90 seconds, well above the shared helper's own 60-second default from the previous slice.

This only matters as a last resort — if the shell-layer timeout mechanism itself is unavailable on a given machine, the watcher process can still never block past roughly 90 seconds.

## Review Claim

Approve an independent backstop timeout on the watcher's own call site, on top of (not instead of) the shared helper's fix in the previous slice.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This only adds a bound that is well above the layer beneath it, so under normal conditions the inner, more precise timeout always fires first. It changes nothing about what gets queried, only guarantees the watcher process itself has a hard ceiling.

## Slice Rationale

Fourth of six independent slices fixing a real production incident. Separable from the previous slice on purpose, so it can be reviewed or skipped independently.

## Non-goals

This does not replace the previous slice's fix. It is a defense-in-depth layer, not the primary mechanism.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node --check scripts/e2e-regression-watch.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
