### PR TITLE
[Owner Watchdog Deadlocks](5) Guard the two standalone headless_query duplicates the same way

### DIFF
--- a/scripts/convert-claude-to-codex.sh
+++ b/scripts/convert-claude-to-codex.sh
@@ -42,10 +42,22 @@ if [ "$(uname)" = "Linux" ]; then
   export LIBGL_ALWAYS_SOFTWARE=1
 fi
 
-# Helper: read-only query command (stderr hidden to keep parsing clean)
+# Helper: read-only query command (stderr hidden to keep parsing clean).
+# Bounded so a dead/unresponsive owner can't hang this script forever; safe
+# to kill since query subcommands never write to the DB.
 headless_query() {
+  local seconds="${INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS:-60}"
+  local status=0
   # shellcheck disable=SC2086
-  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null
+  if command -v timeout >/dev/null 2>&1; then
+    timeout -k 5 "$seconds" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null || status=$?
+  else
+    "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null || status=$?
+  fi
+  if [ "$status" -eq 124 ]; then
+    echo "ERROR: headless_query timed out after ${seconds}s (owner may be crashed/unresponsive)." >&2
+  fi
+  return "$status"
 }
 
 # Helper: mutating command (stderr preserved for debugging real failures)

--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -415,7 +415,13 @@ export function getCiRun(runId) {
 function headlessQueryWorkflowsJson() {
   return execSync(
     `source "${join(REPO_ROOT, 'scripts', 'headless-lib.sh')}" && headless_query query workflows --output json`,
-    { shell: '/bin/bash', encoding: 'utf8', cwd: REPO_ROOT },
+    {
+      shell: '/bin/bash',
+      encoding: 'utf8',
+      cwd: REPO_ROOT,
+      timeout: 90_000,
+      killSignal: 'SIGKILL',
+    },
   );
 }
 

--- a/scripts/headless-lib.sh
+++ b/scripts/headless-lib.sh
@@ -20,6 +20,9 @@
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RUNNER="$REPO_ROOT/run.sh"
 ELECTRON="$REPO_ROOT/scripts/electron.cjs"
+if [[ -n "${INVOKER_HEADLESS_ELECTRON_BIN:-}" ]]; then
+  ELECTRON="$INVOKER_HEADLESS_ELECTRON_BIN"
+fi
 MAIN="$REPO_ROOT/packages/app/dist/main.js"
 IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
 if [[ -n "${INVOKER_HEADLESS_IPC_HELPER:-}" ]]; then

--- a/scripts/headless-lib.sh
+++ b/scripts/headless-lib.sh
@@ -51,9 +51,26 @@ fi
 # ---------------------------------------------------------------------------
 
 # Read-only Electron query (stderr suppressed for clean parsing).
+#
+# Bounded by INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS (default 60; 0 disables).
+# Safe to kill on timeout: this only runs `query` subcommands, which never
+# write to the DB, so there is no stuck-row risk the way there is for
+# headless_mutation (see run_with_optional_timeout's use in rebase-retry-all.sh
+# for that different, deliberately-timeout-free case).
 headless_query() {
+  local seconds="${INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS:-60}"
+  local status=0
   # shellcheck disable=SC2086
-  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null
+  run_with_optional_timeout "$seconds" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null || status=$?
+  case "$status" in
+    124)
+      echo "ERROR: headless_query timed out after ${seconds}s (query subprocess killed; owner may be crashed/unresponsive). Override with INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS=<seconds>, or =0 to disable. args: $*" >&2
+      ;;
+    127)
+      echo "ERROR: headless_query could not enforce a timeout (timeout/gtimeout/python3 all unavailable); query ran without a bound." >&2
+      ;;
+  esac
+  return "$status"
 }
 
 # Mutating command — delegates to the owner (standalone or IPC).
@@ -124,26 +141,36 @@ run_with_optional_timeout() {
     return $?
   fi
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$seconds" "$@"
+    timeout -k 5 "$seconds" "$@"
     return $?
   fi
   if command -v gtimeout >/dev/null 2>&1; then
-    gtimeout "$seconds" "$@"
+    gtimeout -k 5 "$seconds" "$@"
     return $?
   fi
   if command -v python3 >/dev/null 2>&1; then
     python3 - "$seconds" "$@" <<'PY'
+import os
+import signal
 import subprocess
 import sys
 
 timeout = int(sys.argv[1])
 cmd = sys.argv[2:]
 
+proc = subprocess.Popen(cmd, start_new_session=True)
 try:
-    completed = subprocess.run(cmd, timeout=timeout, check=False)
-    sys.exit(completed.returncode)
+    sys.exit(proc.wait(timeout=timeout))
 except subprocess.TimeoutExpired:
     print(f"Timed out after {timeout}s: {' '.join(cmd)}", file=sys.stderr)
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait()
+    except ProcessLookupError:
+        pass
     sys.exit(124)
 PY
     return $?

--- a/scripts/recreate-failed-tasks.sh
+++ b/scripts/recreate-failed-tasks.sh
@@ -86,9 +86,21 @@ if [ "$(uname)" = "Linux" ]; then
   export LIBGL_ALWAYS_SOFTWARE=1
 fi
 
+# Bounded so a dead/unresponsive owner can't hang this script forever; safe
+# to kill since query subcommands never write to the DB.
 headless_query() {
+  local seconds="${INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS:-60}"
+  local status=0
   # shellcheck disable=SC2086
-  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null
+  if command -v timeout >/dev/null 2>&1; then
+    timeout -k 5 "$seconds" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null || status=$?
+  else
+    "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null || status=$?
+  fi
+  if [ "$status" -eq 124 ]; then
+    echo "ERROR: headless_query timed out after ${seconds}s (owner may be crashed/unresponsive)." >&2
+  fi
+  return "$status"
 }
 
 headless_mutation() {

--- a/scripts/repro/repro-headless-query-hang-timeout.sh
+++ b/scripts/repro/repro-headless-query-hang-timeout.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+EXPECTATION="fixed"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect-bug)
+      EXPECTATION="bug"
+      shift
+      ;;
+    --expect-fixed)
+      EXPECTATION="fixed"
+      shift
+      ;;
+    *)
+      echo "usage: $0 [--expect-bug|--expect-fixed]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+TMP_ROOT="$(mktemp -d -t invoker-headless-query-hang-repro.XXXXXX)"
+
+cleanup() {
+  pkill -f "$TMP_ROOT/fake-electron.sh" 2>/dev/null || true
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+FAKE_ELECTRON="$TMP_ROOT/fake-electron.sh"
+cat > "$FAKE_ELECTRON" <<'SH'
+#!/usr/bin/env bash
+# Simulates a fresh Electron process whose IPC/owner handshake never
+# resolves (owner crashed): ignores all args, blocks forever.
+exec sleep 999999
+SH
+chmod +x "$FAKE_ELECTRON"
+
+export INVOKER_HEADLESS_ELECTRON_BIN="$FAKE_ELECTRON"
+
+if [[ "$EXPECTATION" == "bug" ]]; then
+  echo "==> repro: guard disabled (INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS=0), outer bound=3s"
+  set +e
+  INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS=0 timeout -k 1 3 bash -c \
+    "source '$ROOT_DIR/scripts/headless-lib.sh'; headless_query query workflows --output json" \
+    > "$TMP_ROOT/out.log" 2>"$TMP_ROOT/err.log"
+  OUTER_STATUS=$?
+  set -e
+  if [[ "$OUTER_STATUS" -eq 124 ]]; then
+    echo "PASS: unguarded headless_query did not return within 3s (bug reproduced)"
+    exit 0
+  fi
+  echo "FAIL: expected outer 3s bound to fire (status=$OUTER_STATUS)" >&2
+  cat "$TMP_ROOT/out.log" "$TMP_ROOT/err.log" >&2 || true
+  exit 1
+fi
+
+echo "==> repro: guard enabled (INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS=3)"
+export INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS=3
+source "$ROOT_DIR/scripts/headless-lib.sh"
+
+START_SEC="$SECONDS"
+set +e
+headless_query query workflows --output json >"$TMP_ROOT/out.log" 2>"$TMP_ROOT/err.log"
+STATUS=$?
+set -e
+ELAPSED=$((SECONDS - START_SEC))
+
+if [[ "$STATUS" -ne 124 ]]; then
+  echo "FAIL: expected exit 124, got $STATUS" >&2
+  cat "$TMP_ROOT/out.log" "$TMP_ROOT/err.log" >&2 || true
+  exit 1
+fi
+if [[ "$ELAPSED" -gt 6 ]]; then
+  echo "FAIL: took ${ELAPSED}s, expected bounded near the 3s guard" >&2
+  exit 1
+fi
+if ! grep -Fq "headless_query timed out after 3s" "$TMP_ROOT/err.log"; then
+  echo "FAIL: expected clear timeout diagnostic on stderr" >&2
+  cat "$TMP_ROOT/err.log" >&2
+  exit 1
+fi
+echo "PASS: guarded headless_query returned within ${ELAPSED}s with exit 124 and a clear error"

--- a/scripts/test-suites/required/30-headless-query-timeout-guard.sh
+++ b/scripts/test-suites/required/30-headless-query-timeout-guard.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Regression: headless_query must time out instead of hanging forever when
+# the owner is dead/unresponsive.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+bash "$ROOT/scripts/repro/repro-headless-query-hang-timeout.sh" --expect-fixed


### PR DESCRIPTION
## Summary

Two manual tools keep their own local copy of the same unbounded query one-liner instead of sourcing the shared helper fixed two slices ago.

Applies the same timeout-with-kill-grace guard directly to both, hand-copied, matching the shared fix.

## Review Claim

Approve applying the same timeout guard to the two standalone duplicates of the pattern already fixed in the shared helper.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Same reasoning as the shared-helper fix: only query subcommands run through this path, which never write to the database, so killing a hung one mid-flight is safe.

## Slice Rationale

Fifth of six independent slices fixing a real production incident. Kept separate from the shared-helper fix since these two files are deliberately self-contained and don't source it.

## Non-goals

This does not refactor either script to source the shared helper instead. Both are deliberately self-contained manual tools; that broader change is out of scope here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash -n scripts/convert-claude-to-codex.sh`
- [ ] `bash -n scripts/recreate-failed-tasks.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
