### PR TITLE
[Owner Watchdog Deadlocks](6) Bound PR-maintenance tick duration so a hung child can't wedge the owner

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Logger } from '@invoker/contracts';
 import type { WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store';
 
+import { SIGKILL_TIMEOUT_MS } from '../process-utils.js';
 import {
   DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS,
   PR_ADMIN_BYPASS_LAND_WORKER_KIND,
@@ -71,6 +72,35 @@ function makeSpawnHarness(options: {
       child.emit('close', options.exitCode ?? 0, null);
     });
 
+    return child;
+  });
+
+  return { calls, spawnProcess: spawnProcess as unknown as typeof spawn };
+}
+
+function makeHungSpawnHarness(options: {
+  cooperativeKill?: boolean;
+} = {}): { calls: SpawnCall[]; spawnProcess: typeof spawn } {
+  const calls: SpawnCall[] = [];
+  const spawnProcess = vi.fn((command: string, args: string[], spawnOptions: SpawnOptions) => {
+    calls.push({ command, args, options: spawnOptions });
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const child = Object.assign(new EventEmitter(), {
+      stdout,
+      stderr,
+      stdin: null,
+      killed: false,
+      pid: 12345,
+      // Never emits 'close' or 'error' on its own — simulates a wedged
+      // child (e.g. blocked on a dead owner's IPC handshake).
+      kill: vi.fn(() => {
+        if (options.cooperativeKill) {
+          queueMicrotask(() => child.emit('close', null, 'SIGTERM'));
+        }
+        return true;
+      }),
+    }) as unknown as ChildProcess;
     return child;
   });
 
@@ -356,5 +386,107 @@ describe('PR maintenance workers', () => {
     await vi.advanceTimersByTimeAsync(1);
     expect(spawnHarness.calls).toHaveLength(1);
     await worker.stop();
+  });
+
+  it('reproduces the pre-fix hang: a hung child with the tick timeout disabled wedges the scheduler forever', async () => {
+    vi.useFakeTimers();
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeHungSpawnHarness();
+    const worker = createPrAdminBypassLandWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => ({ held: false }),
+      installSignalHandlers: false,
+      tickTimeoutMs: 0,
+      intervalMs: 60_000,
+    });
+
+    worker.start();
+    await vi.advanceTimersByTimeAsync(60_000 * 5);
+
+    expect(spawnHarness.calls).toHaveLength(1);
+    await worker.stop({ settleTimeoutMs: 0 });
+  });
+
+  it('kills a hung child after the tick timeout and lets the next scheduled tick proceed', async () => {
+    vi.useFakeTimers();
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeHungSpawnHarness();
+    const worker = createPrAdminBypassLandWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => ({ held: false }),
+      installSignalHandlers: false,
+      tickTimeoutMs: 1_000,
+      intervalMs: 10_000,
+    });
+
+    worker.start();
+    await vi.advanceTimersByTimeAsync(10_000 + 999);
+    expect(spawnHarness.calls).toHaveLength(1);
+    expect(logger.error).not.toHaveBeenCalledWith(
+      expect.stringContaining('killing spawned child'),
+      expect.anything(),
+    );
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('killing spawned child'),
+      expect.anything(),
+    );
+
+    await vi.advanceTimersByTimeAsync(SIGKILL_TIMEOUT_MS + 1_000);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('force-abandoning'),
+      expect.anything(),
+    );
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(spawnHarness.calls).toHaveLength(2);
+
+    await worker.stop({ settleTimeoutMs: 0 });
+  });
+
+  it('fails the tick as tick-timeout (not force-abandoned) when the child cooperates with SIGTERM/SIGKILL, and pins detached:true on the spawn call', async () => {
+    vi.useFakeTimers();
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeHungSpawnHarness({ cooperativeKill: true });
+    const store = {
+      getWorkerAction: vi.fn(() => undefined),
+      upsertWorkerAction: vi.fn((write: WorkerActionWrite) => write as WorkerActionRecord),
+    };
+    const worker = createPrAdminBypassLandWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => ({ held: false }),
+      installSignalHandlers: false,
+      tickTimeoutMs: 1_000,
+      intervalMs: 10_000,
+      store,
+    });
+
+    worker.start();
+    await vi.advanceTimersByTimeAsync(10_000 + 1_000);
+
+    const failedCall = store.upsertWorkerAction.mock.calls
+      .map((call) => call[0] as WorkerActionWrite)
+      .find((write) => write.status === 'failed');
+    expect(failedCall?.payload).toMatchObject({ reason: 'tick-timeout' });
+    expect(logger.error).not.toHaveBeenCalledWith(
+      expect.stringContaining('force-abandoning'),
+      expect.anything(),
+    );
+    expect(spawnHarness.calls[0]?.options.detached).toBe(process.platform !== 'win32');
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(spawnHarness.calls).toHaveLength(2);
+
+    await worker.stop({ settleTimeoutMs: 0 });
   });
 });

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -7,6 +7,7 @@ import { resolveRepoRoot, type Logger } from '@invoker/contracts';
 import type { WorkerActionStatus } from '@invoker/data-store';
 
 import { recordWorkerDecisionRow, type WorkerDecisionStore } from '../worker-decision-ledger.js';
+import { terminateChildProcessGroup, SIGKILL_TIMEOUT_MS } from '../process-utils.js';
 
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import type { WorkerRegistry } from '../worker-registry.js';
@@ -22,6 +23,17 @@ export const DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS = 5 * 60_000;
  * the same intervalMs boundary and race for it every cycle.
  */
 export const PR_MAINTENANCE_WORKER_STAGGER_STEP_MS = DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS / 3;
+/**
+ * Wall-clock cap on a single tick's spawned child before it is killed and the
+ * tick fails. Default four minutes: comfortably under the five-minute poll
+ * interval (with margin for the SIGTERM->SIGKILL escalation below) so a hung
+ * child never survives into -- or steals -- the next scheduled tick.
+ * worker-runtime.ts's scheduler coalesces ticks (a tick that never settles
+ * blocks every future tick of that worker kind forever), so this bound is
+ * what keeps a wedged child from permanently killing the worker. `0` disables
+ * it. Override via INVOKER_PR_MAINTENANCE_TICK_TIMEOUT_MS.
+ */
+export const DEFAULT_PR_MAINTENANCE_WORKER_TICK_TIMEOUT_MS = 4 * 60_000;
 
 export type PrMaintenanceWorkerKind =
   | typeof PR_ADMIN_BYPASS_LAND_WORKER_KIND
@@ -70,6 +82,8 @@ export interface PrMaintenanceWorkerConfig {
   startDelayMs?: number;
   /** Shared cron lock path. Defaults to the shell script's `INVOKER_PR_CRON_LOCK` behavior. */
   lockPath?: string;
+  /** Per-tick wall-clock cap for the spawned child. See DEFAULT_PR_MAINTENANCE_WORKER_TICK_TIMEOUT_MS. */
+  tickTimeoutMs?: number;
   /** Shell executable used to run the existing entrypoint. Defaults to `bash`. */
   shell?: string;
   store?: WorkerDecisionStore;
@@ -239,6 +253,7 @@ function createPrMaintenanceWorker(
       env: options.env,
       intervalMs: options.intervalMs,
       lockPath: options.lockPath,
+      tickTimeoutMs: options.tickTimeoutMs,
       shell: options.shell,
       spawnProcess: options.spawnProcess,
       lockProbe: options.lockProbe,
@@ -296,6 +311,7 @@ async function runPrMaintenanceEntrypoint(
       cwd: repoRoot,
       env,
       stdio: ['ignore', 'pipe', 'pipe'],
+      detached: process.platform !== 'win32',
     });
   } catch (err) {
     options.logger.error(`[worker:${options.entrypoint.kind}] spawn failed`, {
@@ -314,32 +330,67 @@ async function runPrMaintenanceEntrypoint(
   attachChildStreamLogger(options, child.stderr, 'stderr');
   recordPrMaintenanceRun(options, runExternalKey, repoRoot, 'running', `Started ${options.entrypoint.scriptRelativePath}`);
 
+  const tickTimeoutMs = resolvePrMaintenanceTickTimeoutMs(options.tickTimeoutMs);
+
   await new Promise<void>((resolvePromise, rejectPromise) => {
     let settled = false;
+    let timedOut = false;
+    let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+    let forceAbandonTimer: ReturnType<typeof setTimeout> | null = null;
+
     const settle = (fn: () => void): void => {
       if (settled) return;
       settled = true;
+      if (timeoutTimer) { clearTimeout(timeoutTimer); timeoutTimer = null; }
+      if (forceAbandonTimer) { clearTimeout(forceAbandonTimer); forceAbandonTimer = null; }
       fn();
     };
 
     const onAbort = (): void => {
-      if (!child.killed) {
-        child.kill('SIGTERM');
-      }
-      settle(() => {
-        recordPrMaintenanceRun(options, runExternalKey, repoRoot, 'failed', 'PR maintenance aborted by stop', {
-          reason: 'aborted',
-        });
-        resolvePromise();
-      });
+      void terminateChildProcessGroup(child, () => settled);
     };
 
     if (signal) {
       if (signal.aborted) {
         onAbort();
-        return;
+      } else {
+        signal.addEventListener('abort', onAbort, { once: true });
       }
-      signal.addEventListener('abort', onAbort, { once: true });
+    }
+
+    const onTickTimeout = (): void => {
+      timedOut = true;
+      options.logger.error(
+        `[worker:${options.entrypoint.kind}] tick exceeded ${tickTimeoutMs}ms; killing spawned child`,
+        { module: 'pr-maintenance-worker', worker: options.entrypoint.kind, tickTimeoutMs },
+      );
+      void terminateChildProcessGroup(child, () => settled);
+      // Belt-and-suspenders: terminateChildProcessGroup already escalates
+      // SIGTERM -> SIGKILL within SIGKILL_TIMEOUT_MS and the close handler
+      // below settles this promise once the OS confirms exit. If 'close' is
+      // somehow never delivered, force-settle anyway so worker-runtime.ts's
+      // coalescing scheduler can never be wedged by this child no matter what.
+      forceAbandonTimer = setTimeout(() => {
+        settle(() => {
+          const message = `PR maintenance worker ${options.entrypoint.kind} child did not exit within `
+            + `${SIGKILL_TIMEOUT_MS}ms of SIGKILL after a ${tickTimeoutMs}ms tick timeout; abandoning`;
+          options.logger.error(`[worker:${options.entrypoint.kind}] force-abandoning unresponsive child`, {
+            module: 'pr-maintenance-worker',
+            worker: options.entrypoint.kind,
+          });
+          recordPrMaintenanceRun(options, runExternalKey, repoRoot, 'failed', message, {
+            reason: 'tick-timeout-force-abandoned',
+            tickTimeoutMs,
+          });
+          rejectPromise(new Error(message));
+        });
+      }, SIGKILL_TIMEOUT_MS + 1_000);
+      forceAbandonTimer.unref?.();
+    };
+
+    if (tickTimeoutMs > 0) {
+      timeoutTimer = setTimeout(onTickTimeout, tickTimeoutMs);
+      timeoutTimer.unref?.();
     }
 
     child.once('error', (err) => {
@@ -367,6 +418,18 @@ async function runPrMaintenanceEntrypoint(
           code,
           signal: closeSignal,
         };
+        if (timedOut) {
+          const message = `PR maintenance worker ${options.entrypoint.kind} exceeded its ${tickTimeoutMs}ms tick timeout and was killed`;
+          options.logger.error(`[worker:${options.entrypoint.kind}] shell entrypoint killed after tick timeout`, fields);
+          recordPrMaintenanceRun(options, runExternalKey, repoRoot, 'failed', message, {
+            reason: 'tick-timeout',
+            tickTimeoutMs,
+            code,
+            signal: closeSignal,
+          });
+          rejectPromise(new Error(message));
+          return;
+        }
         if (code === 0) {
           options.logger.info(`[worker:${options.entrypoint.kind}] shell entrypoint completed`, fields);
           recordPrMaintenanceRun(options, runExternalKey, repoRoot, 'completed', 'PR maintenance run completed');
@@ -374,6 +437,9 @@ async function runPrMaintenanceEntrypoint(
           return;
         }
         if (signal?.aborted) {
+          recordPrMaintenanceRun(options, runExternalKey, repoRoot, 'failed', 'PR maintenance aborted by stop', {
+            reason: 'aborted',
+          });
           resolvePromise();
           return;
         }
@@ -482,6 +548,15 @@ function parsePositiveInteger(raw: string | undefined): number | undefined {
   if (!raw) return undefined;
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function resolvePrMaintenanceTickTimeoutMs(explicit: number | undefined): number {
+  if (explicit !== undefined) return explicit;
+  const raw = process.env.INVOKER_PR_MAINTENANCE_TICK_TIMEOUT_MS?.trim();
+  if (raw === '0') return 0;
+  if (!raw || !/^(0|[1-9]\d*)$/.test(raw)) return DEFAULT_PR_MAINTENANCE_WORKER_TICK_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : DEFAULT_PR_MAINTENANCE_WORKER_TICK_TIMEOUT_MS;
 }
 
 function readMkdirLockHolder(lockDir: string): number | undefined {

--- a/scripts/convert-claude-to-codex.sh
+++ b/scripts/convert-claude-to-codex.sh
@@ -42,10 +42,22 @@ if [ "$(uname)" = "Linux" ]; then
   export LIBGL_ALWAYS_SOFTWARE=1
 fi
 
-# Helper: read-only query command (stderr hidden to keep parsing clean)
+# Helper: read-only query command (stderr hidden to keep parsing clean).
+# Bounded so a dead/unresponsive owner can't hang this script forever; safe
+# to kill since query subcommands never write to the DB.
 headless_query() {
+  local seconds="${INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS:-60}"
+  local status=0
   # shellcheck disable=SC2086
-  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null
+  if command -v timeout >/dev/null 2>&1; then
+    timeout -k 5 "$seconds" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null || status=$?
+  else
+    "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null || status=$?
+  fi
+  if [ "$status" -eq 124 ]; then
+    echo "ERROR: headless_query timed out after ${seconds}s (owner may be crashed/unresponsive)." >&2
+  fi
+  return "$status"
 }
 
 # Helper: mutating command (stderr preserved for debugging real failures)

--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -415,7 +415,13 @@ export function getCiRun(runId) {
 function headlessQueryWorkflowsJson() {
   return execSync(
     `source "${join(REPO_ROOT, 'scripts', 'headless-lib.sh')}" && headless_query query workflows --output json`,
-    { shell: '/bin/bash', encoding: 'utf8', cwd: REPO_ROOT },
+    {
+      shell: '/bin/bash',
+      encoding: 'utf8',
+      cwd: REPO_ROOT,
+      timeout: 90_000,
+      killSignal: 'SIGKILL',
+    },
   );
 }
 

--- a/scripts/headless-lib.sh
+++ b/scripts/headless-lib.sh
@@ -20,6 +20,9 @@
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RUNNER="$REPO_ROOT/run.sh"
 ELECTRON="$REPO_ROOT/scripts/electron.cjs"
+if [[ -n "${INVOKER_HEADLESS_ELECTRON_BIN:-}" ]]; then
+  ELECTRON="$INVOKER_HEADLESS_ELECTRON_BIN"
+fi
 MAIN="$REPO_ROOT/packages/app/dist/main.js"
 IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
 if [[ -n "${INVOKER_HEADLESS_IPC_HELPER:-}" ]]; then

--- a/scripts/headless-lib.sh
+++ b/scripts/headless-lib.sh
@@ -51,9 +51,26 @@ fi
 # ---------------------------------------------------------------------------
 
 # Read-only Electron query (stderr suppressed for clean parsing).
+#
+# Bounded by INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS (default 60; 0 disables).
+# Safe to kill on timeout: this only runs `query` subcommands, which never
+# write to the DB, so there is no stuck-row risk the way there is for
+# headless_mutation (see run_with_optional_timeout's use in rebase-retry-all.sh
+# for that different, deliberately-timeout-free case).
 headless_query() {
+  local seconds="${INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS:-60}"
+  local status=0
   # shellcheck disable=SC2086
-  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null
+  run_with_optional_timeout "$seconds" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null || status=$?
+  case "$status" in
+    124)
+      echo "ERROR: headless_query timed out after ${seconds}s (query subprocess killed; owner may be crashed/unresponsive). Override with INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS=<seconds>, or =0 to disable. args: $*" >&2
+      ;;
+    127)
+      echo "ERROR: headless_query could not enforce a timeout (timeout/gtimeout/python3 all unavailable); query ran without a bound." >&2
+      ;;
+  esac
+  return "$status"
 }
 
 # Mutating command — delegates to the owner (standalone or IPC).
@@ -124,26 +141,36 @@ run_with_optional_timeout() {
     return $?
   fi
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$seconds" "$@"
+    timeout -k 5 "$seconds" "$@"
     return $?
   fi
   if command -v gtimeout >/dev/null 2>&1; then
-    gtimeout "$seconds" "$@"
+    gtimeout -k 5 "$seconds" "$@"
     return $?
   fi
   if command -v python3 >/dev/null 2>&1; then
     python3 - "$seconds" "$@" <<'PY'
+import os
+import signal
 import subprocess
 import sys
 
 timeout = int(sys.argv[1])
 cmd = sys.argv[2:]
 
+proc = subprocess.Popen(cmd, start_new_session=True)
 try:
-    completed = subprocess.run(cmd, timeout=timeout, check=False)
-    sys.exit(completed.returncode)
+    sys.exit(proc.wait(timeout=timeout))
 except subprocess.TimeoutExpired:
     print(f"Timed out after {timeout}s: {' '.join(cmd)}", file=sys.stderr)
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        os.killpg(proc.pid, signal.SIGKILL)
+        proc.wait()
+    except ProcessLookupError:
+        pass
     sys.exit(124)
 PY
     return $?

--- a/scripts/recreate-failed-tasks.sh
+++ b/scripts/recreate-failed-tasks.sh
@@ -86,9 +86,21 @@ if [ "$(uname)" = "Linux" ]; then
   export LIBGL_ALWAYS_SOFTWARE=1
 fi
 
+# Bounded so a dead/unresponsive owner can't hang this script forever; safe
+# to kill since query subcommands never write to the DB.
 headless_query() {
+  local seconds="${INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS:-60}"
+  local status=0
   # shellcheck disable=SC2086
-  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null
+  if command -v timeout >/dev/null 2>&1; then
+    timeout -k 5 "$seconds" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null || status=$?
+  else
+    "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null || status=$?
+  fi
+  if [ "$status" -eq 124 ]; then
+    echo "ERROR: headless_query timed out after ${seconds}s (owner may be crashed/unresponsive)." >&2
+  fi
+  return "$status"
 }
 
 headless_mutation() {

--- a/scripts/repro/repro-headless-query-hang-timeout.sh
+++ b/scripts/repro/repro-headless-query-hang-timeout.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+EXPECTATION="fixed"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect-bug)
+      EXPECTATION="bug"
+      shift
+      ;;
+    --expect-fixed)
+      EXPECTATION="fixed"
+      shift
+      ;;
+    *)
+      echo "usage: $0 [--expect-bug|--expect-fixed]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+TMP_ROOT="$(mktemp -d -t invoker-headless-query-hang-repro.XXXXXX)"
+
+cleanup() {
+  pkill -f "$TMP_ROOT/fake-electron.sh" 2>/dev/null || true
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+FAKE_ELECTRON="$TMP_ROOT/fake-electron.sh"
+cat > "$FAKE_ELECTRON" <<'SH'
+#!/usr/bin/env bash
+# Simulates a fresh Electron process whose IPC/owner handshake never
+# resolves (owner crashed): ignores all args, blocks forever.
+exec sleep 999999
+SH
+chmod +x "$FAKE_ELECTRON"
+
+export INVOKER_HEADLESS_ELECTRON_BIN="$FAKE_ELECTRON"
+
+if [[ "$EXPECTATION" == "bug" ]]; then
+  echo "==> repro: guard disabled (INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS=0), outer bound=3s"
+  set +e
+  INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS=0 timeout -k 1 3 bash -c \
+    "source '$ROOT_DIR/scripts/headless-lib.sh'; headless_query query workflows --output json" \
+    > "$TMP_ROOT/out.log" 2>"$TMP_ROOT/err.log"
+  OUTER_STATUS=$?
+  set -e
+  if [[ "$OUTER_STATUS" -eq 124 ]]; then
+    echo "PASS: unguarded headless_query did not return within 3s (bug reproduced)"
+    exit 0
+  fi
+  echo "FAIL: expected outer 3s bound to fire (status=$OUTER_STATUS)" >&2
+  cat "$TMP_ROOT/out.log" "$TMP_ROOT/err.log" >&2 || true
+  exit 1
+fi
+
+echo "==> repro: guard enabled (INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS=3)"
+export INVOKER_HEADLESS_QUERY_TIMEOUT_SECONDS=3
+source "$ROOT_DIR/scripts/headless-lib.sh"
+
+START_SEC="$SECONDS"
+set +e
+headless_query query workflows --output json >"$TMP_ROOT/out.log" 2>"$TMP_ROOT/err.log"
+STATUS=$?
+set -e
+ELAPSED=$((SECONDS - START_SEC))
+
+if [[ "$STATUS" -ne 124 ]]; then
+  echo "FAIL: expected exit 124, got $STATUS" >&2
+  cat "$TMP_ROOT/out.log" "$TMP_ROOT/err.log" >&2 || true
+  exit 1
+fi
+if [[ "$ELAPSED" -gt 6 ]]; then
+  echo "FAIL: took ${ELAPSED}s, expected bounded near the 3s guard" >&2
+  exit 1
+fi
+if ! grep -Fq "headless_query timed out after 3s" "$TMP_ROOT/err.log"; then
+  echo "FAIL: expected clear timeout diagnostic on stderr" >&2
+  cat "$TMP_ROOT/err.log" >&2
+  exit 1
+fi
+echo "PASS: guarded headless_query returned within ${ELAPSED}s with exit 124 and a clear error"

--- a/scripts/test-suites/required/30-headless-query-timeout-guard.sh
+++ b/scripts/test-suites/required/30-headless-query-timeout-guard.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Regression: headless_query must time out instead of hanging forever when
+# the owner is dead/unresponsive.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+bash "$ROOT/scripts/repro/repro-headless-query-hang-timeout.sh" --expect-fixed


### PR DESCRIPTION
## Summary

The owner's own PR-maintenance workers spawn shell scripts every five minutes that share a code path with the fix earlier in this stack.

The runtime's scheduler coalesces ticks. If one hangs, the pending promise never settles, so that worker kind silently stops forever, inside an otherwise-healthy owner. This is independent of the earlier incident and live today.

Adds a per-tick wall-clock cap that kills the spawned child using the same escalation utility already used everywhere else in this package, plus a fallback timer beneath even that so the tick can never stay pending no matter what.

## Review Claim

Approve a bounded wall-clock cap on each PR-maintenance tick, so a wedged child process can never permanently silence that worker's future ticks.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A single tick, regardless of what the spawned shell script does, now settles within a fixed, provable wall-clock bound. The runtime's coalescing scheduler can never stay pending forever, and that worker kind is guaranteed to attempt its next scheduled wakeup.

## Slice Rationale

Sixth and final slice of this stack, and the only one that lives outside the shell layer. Fixing the owner-internal path required holding the child process handle directly, which only the code in this file has.

## Non-goals

This does not change the runtime's generic scheduling contract. The bound lives entirely in the code that owns the spawned child, reusing an existing utility rather than introducing a new mechanism.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test -- src/__tests__/pr-maintenance-workers.test.ts`
- [ ] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
