### PR TITLE
CodeRabbit audit: PR #7243 — validate findings against master and fix what holds

### DIFF
--- a/docs/audits/coderabbit/pr-7243.md
+++ b/docs/audits/coderabbit/pr-7243.md
@@ -1,0 +1,30 @@
+# CodeRabbit Audit: PR #7243
+
+Source: `gh api repos/Neko-Catpital-Labs/Invoker/pulls/7243/comments --paginate`
+
+Current master checked: `origin/master` at `a700d6ae7476e3611226d86d17e2138daa99eb33` after fetching on 2026-08-06.
+
+## Finding 1: Scope lease sweeping to the owning runner instance
+
+Quoted finding:
+
+> When two writable `TaskRunner` instances share the same data store, runner B sees runner A's expired-but-active lease as a foreign orphan.
+
+Severity: Major
+
+Verdict: invalid
+
+Evidence:
+
+- The flagged release branch still exists at `packages/app/src/launch-dispatcher.ts:205` through `packages/app/src/launch-dispatcher.ts:212`: the dispatcher renews same-runner live leases and releases expired rows that are not live for the current runner. On its own, that code would be dangerous only if a supported runtime can have another active writable runner with a live expired lease in the same store.
+- Current architecture rejects the multi-writer premise. `docs/persistence-architecture-single-writer.md:9` defines exactly one writable owner, and `docs/persistence-architecture-single-writer.md:23` through `docs/persistence-architecture-single-writer.md:27` restrict non-owner processes to read-only access or IPC mutation delegation.
+- The production opener enforces that boundary. `packages/app/src/main.ts:761` through `packages/app/src/main.ts:763` acquires the DB writer lock before writable initialization, and `packages/app/src/db-writer-lock.ts:168` through `packages/app/src/db-writer-lock.ts:180` makes the lock default-on unless the explicit unsafe test/dev bypass is set. If another live process already holds it, `packages/app/src/db-writer-lock.ts:230` through `packages/app/src/db-writer-lock.ts:235` throws instead of allowing a second writer.
+- Headless mutation commands do not silently become a second writer while an owner is present. `packages/app/src/main.ts:948` through `packages/app/src/main.ts:970` delegates mutating commands first, and `packages/app/src/main.ts:981` through `packages/app/src/main.ts:990` exits with an error when no delegation target is available outside standalone mode, warning that standalone mode opens a writable database and should only be used when no other process is accessing it.
+- In owner-serve headless mode, helper commands reuse the owner runner instead of creating a foreign active runner. `packages/app/src/headless-standalone-launch-dispatcher.ts:31` installs `ownerTaskRunnerProvider` for the standalone owner runner, and `packages/app/src/headless-shared.ts:153` through `packages/app/src/headless-shared.ts:162` returns that owner runner from `createHeadlessExecutor`.
+- The GUI same-process runner replacement path does not preserve active foreign leases. `packages/app/src/workflow-actions.ts:400` through `packages/app/src/workflow-actions.ts:414` kills active executions before delete-all purges state, `packages/execution-engine/src/task-runner.ts:400` through `packages/execution-engine/src/task-runner.ts:413` deletes the active entry and releases its lease during that kill, and only then does the clear handler rebuild the runner at `packages/app/src/ipc/gui-mutation-handlers.ts:1534`.
+
+The concrete CodeRabbit scenario is therefore not present on current master. The code still releases non-current expired rows, but current production evidence does not support two active writable `TaskRunner` owners sharing the same datastore in the way required for runner B to free runner A's live lease.
+
+## Fixes applied
+
+Fixes applied: none - all findings invalid


### PR DESCRIPTION
## Summary

CodeRabbit left one Major inline finding on merged PR #7243. It claimed a second writable TaskRunner could sweep another runner's live-but-expired lease.

This change re-verifies that finding against current master instead of trusting it blindly. The verdict is invalid, with file-and-line evidence cited in the report.

The single-writer architecture, the DB writer lock, and headless mutation delegation together rule out the two-active-writers premise the finding depends on.

Because no finding held, no product code changes. The committed report records the verdict and the explicit outcome `Fixes applied: none - all findings invalid`.

## Review Claim

Each inline CodeRabbit finding on PR #7243 has an evidence-backed valid/invalid verdict against current master, and every valid finding is fixed; since all findings are invalid, the diff is the audit report only.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The diff adds one new file under `docs/audits/coderabbit/`; no product code, config, or scripts are touched, so runtime behavior cannot change.

## Slice Rationale

Validate and fix form one review claim — the resolution of PR #7243's findings. Splitting them would separate a verdict from the change it justifies. Per-PR audit workflows keep review scope small; one bulk PR for all 11 audited PRs was rejected.

## Non-goals

- No product code changes: the only finding is judged invalid.
- No re-litigating CodeRabbit style opinions that are not concrete findings.
- No changes to the lease-sweeping code the finding pointed at.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `test -f docs/audits/coderabbit/pr-7243.md`
- [x] `grep -E '^Verdict: (valid|invalid)$' docs/audits/coderabbit/pr-7243.md`
- [x] `grep -F 'Fixes applied' docs/audits/coderabbit/pr-7243.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an audit record for a lease-sweeping review finding.
  * Documented evidence that production safely manages writable and GUI runners, delegates mutations appropriately, reuses the owner runner, and cleans up leases during replacement.
  * Recorded the finding as invalid; no product behavior changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->