### PR TITLE
[CodeRabbit audit: PR #7224 — validate findings against master and fix what holds](1) Audit verdict report: finding invalid on master

### DIFF
--- a/docs/audits/coderabbit/pr-7224.md
+++ b/docs/audits/coderabbit/pr-7224.md
@@ -1,0 +1,29 @@
+# CodeRabbit Audit: PR #7224
+
+Source: `gh api repos/Neko-Catpital-Labs/Invoker/pulls/7224/comments --paginate`
+
+Current master checked: `a700d6ae7476e3611226d86d17e2138daa99eb33`
+
+## Finding 1: Signal shutdown can run cleanup twice
+
+Quoted finding:
+
+> Guard the normal quit cleanup when the signal handler already owns shutdown.
+>
+> For `owner-serve`, `runHeadless(cliArgs, headlessDeps)` blocks while `headlessOwnerServe` polls, so a SIGTERM/SIGINT can start signal cleanup asynchronously. The `finally` block then enters `runHeadlessShutdownCleanup` regardless, so it can call `persistence.requeueRunningWorkflowMutationIntents()`, `persistence.close()`, `writerLock.release()`, and `messageBus.disconnect()` a second time. Guard the final cleanup and `process.exit(exitCode)` so only the first shutdown path runs cleanup.
+
+Severity: Major
+
+Verdict: invalid
+
+Evidence:
+
+The finding was addressed before current `origin/master`. The signal handler still claims shutdown ownership by returning early if `headlessSignalShutdownInProgress` is already set and setting it before starting signal cleanup at `packages/app/src/main.ts:1067` through `packages/app/src/main.ts:1071`.
+
+The normal `finally` path is now guarded. `packages/app/src/main.ts:2037` checks `if (!headlessSignalShutdownInProgress)`, then line 2038 sets `headlessSignalShutdownInProgress = true`, line 2039 runs `runHeadlessShutdownCleanup('Application quit')`, and line 2040 exits with the normal exit code. If the signal handler already started cleanup, this block is skipped, so the duplicate calls described by CodeRabbit no longer occur.
+
+The behavior is also covered by a focused regression assertion in `packages/app/src/__tests__/headless-termination-signal-handling.test.ts:57`, which verifies that normal-quit cleanup and exit are skipped when a signal handler already owns shutdown. The concrete flagged problem is therefore fixed on current master.
+
+## Fixes applied
+
+Fixes applied: none - all findings invalid.


### PR DESCRIPTION
## Summary

Re-verify the inline CodeRabbit review finding on merged PR #7224 against current master and record the verdict with evidence.

The one concrete finding warned that `owner-serve` shutdown cleanup could run twice when a SIGTERM/SIGINT arrives during a normal quit.

Current master already guards both shutdown paths behind `headlessSignalShutdownInProgress` and has regression coverage, so the finding is recorded as invalid.

No product code changes ship here. The committed report states `Fixes applied: none - all findings invalid`.

## Review Claim

Approve the committed audit report `docs/audits/coderabbit/pr-7224.md`, which judges CodeRabbit's PR #7224 finding invalid against current master with file:line evidence and records that no fixes were needed.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice adds one new markdown report under `docs/audits/` and touches no product code, tests, or tooling, so it cannot alter runtime behavior.

## Slice Rationale

Validate and fix form one review claim: the resolution of PR #7224's CodeRabbit findings. Every finding was judged invalid, so the entire resolution is this single docs slice; separating the verdict from its empty fix outcome would double the review surface without adding clarity.

## Non-goals

- No product code changes; the audited shutdown-cleanup concern is already fixed on master.
- No re-litigation of CodeRabbit style opinions that are not concrete inline findings.
- No audits of other PRs; each audited PR gets its own workflow and stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `test -f docs/audits/coderabbit/pr-7224.md`
- [ ] `grep -E "^Verdict: (valid|invalid)$" docs/audits/coderabbit/pr-7224.md`
- [ ] `grep -F "Fixes applied" docs/audits/coderabbit/pr-7224.md`
- [ ] `git diff --name-only origin/master...HEAD` lists only `docs/audits/coderabbit/pr-7224.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge or squash sha>`
- Post-revert steps: None
- Data migration? No

</details>
