### PR TITLE
CodeRabbit audit: PR #7413 — validate findings against master and fix what holds (1/2): verdict report

### DIFF
--- a/docs/audits/coderabbit/pr-7413.md
+++ b/docs/audits/coderabbit/pr-7413.md
@@ -1,0 +1,30 @@
+# CodeRabbit Audit: PR #7413
+
+Current master checked: `a700d6ae7476e3611226d86d17e2138daa99eb33`
+
+Source: `gh api repos/Neko-Catpital-Labs/Invoker/pulls/7413/comments --paginate`
+
+## Finding 1: Delete-all leaves queue status UI cache stale
+
+> **Invalidate the UI cache after `deleteAllWorkflows()`.**
+>
+> Line 2978 fixes the single-workflow path, but `deleteAllWorkflows()` still removes persisted tasks and clears the graph without clearing `queueStatusUiCache`. If a UI poll warmed the cache first, `getQueueStatus({ refresh: false })` can show deleted tasks for up to 2.5 seconds. Clear the cache in `deleteAllWorkflows()`. Add a regression case that warms the cache before deletion.
+
+Severity: Minor
+
+Verdict: valid
+
+Evidence:
+
+- `packages/workflow-core/src/orchestrator.ts:694` defines `queueStatusUiCache` as the cache for UI polls, and `packages/workflow-core/src/orchestrator.ts:698` sets its TTL to 2500 ms.
+- `packages/workflow-core/src/orchestrator.ts:3293` returns the cached queue status for `getQueueStatus({ refresh: false })` when the cached value is younger than the TTL checked at `packages/workflow-core/src/orchestrator.ts:3295`.
+- `packages/workflow-core/src/orchestrator.ts:3430` warms that cache on UI-poll calls, while `packages/workflow-core/src/orchestrator.ts:3432` clears it only on the refreshed path.
+- `packages/workflow-core/src/orchestrator.ts:3009` deletes all workflows from persistence, `packages/workflow-core/src/orchestrator.ts:3012` clears the scheduler, and `packages/workflow-core/src/orchestrator.ts:3015` through `packages/workflow-core/src/orchestrator.ts:3016` clear in-memory workflow/task state, but the method ends at `packages/workflow-core/src/orchestrator.ts:3022` without assigning `this.queueStatusUiCache = null`.
+- The existing fast-path regression at `packages/workflow-core/src/__tests__/queue-status-ui-poll-fast-path.test.ts:28` through `packages/workflow-core/src/__tests__/queue-status-ui-poll-fast-path.test.ts:35` proves two consecutive `refresh: false` calls return the same cached object.
+- Existing delete-all tests at `packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts:1939` through `packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts:2071` cover memory, persistence, delta publication, and bulk mode, but none warms `getQueueStatus({ refresh: false })` before deletion and then checks the post-delete UI-poll result.
+
+Because current master can return the pre-delete cached queue status after `deleteAllWorkflows()` until the 2500 ms cache window expires, the flagged problem still exists.
+
+## Fixes applied
+
+Fixes applied: none - audit verdict only.


### PR DESCRIPTION
## Summary

Re-checks every inline CodeRabbit finding from merged PR #7413 against current master. Each concrete finding gets an explicit verdict backed by file:line evidence.

The one concrete finding — `deleteAllWorkflows()` leaves the queue-status UI cache warm — is judged still present on master.

The verdict artifact is committed at `docs/audits/coderabbit/pr-7413.md` so the follow-up change in the next PR of this stack carries its justification.

## Review Claim

Each inline CodeRabbit finding on PR #7413 has an evidence-backed verdict against current master, recorded in the committed audit report.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds one audit report file under `docs/audits/`; it cannot alter product behavior.

## Slice Rationale

The verdict must exist before any fix so findings judged wrong never produce code churn.

## Non-goals

- No product code changes in this slice.
- No re-litigating CodeRabbit style opinions that are not concrete findings.
- No fix for the confirmed finding here; that lands in the next PR of this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `test -f docs/audits/coderabbit/pr-7413.md`
- [x] `grep -E "^Verdict: (valid|invalid)$" docs/audits/coderabbit/pr-7413.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge sha of this PR>`
- Post-revert steps: None
- Data migration? No

</details>
