### PR TITLE
CodeRabbit audit: PR #7413 — validate findings against master and fix what holds (2/2): clear queue-status UI cache on workflow delete-all

### DIFF
--- a/docs/audits/coderabbit/pr-7413.md
+++ b/docs/audits/coderabbit/pr-7413.md
@@ -27,4 +27,6 @@ Because current master can return the pre-delete cached queue status after `dele
 
 ## Fixes applied
 
-Fixes applied: none - audit verdict only.
+- Finding 1 fixed by clearing `queueStatusUiCache` inside `deleteAllWorkflows()` after workflow/task memory is cleared, so an immediately subsequent UI poll cannot reuse the pre-delete queue snapshot.
+- Regression coverage added in `packages/workflow-core/src/__tests__/queue-status-ui-poll-fast-path.test.ts`: `deleteAllWorkflows invalidates a warmed UI-poll cache` warms `getQueueStatus({ refresh: false })`, deletes all workflows, and verifies the next UI-poll result is recomputed and empty.
+- Test evidence: `cd packages/workflow-core && pnpm test` passed with 39 test files and 867 tests passing.

--- a/packages/workflow-core/src/__tests__/queue-status-ui-poll-fast-path.test.ts
+++ b/packages/workflow-core/src/__tests__/queue-status-ui-poll-fast-path.test.ts
@@ -35,4 +35,34 @@ describe('getQueueStatus UI poll fast path', () => {
     expect(second).toBe(first);
     expect(loadAttempt).not.toHaveBeenCalled();
   });
+
+  it('deleteAllWorkflows invalidates a warmed UI-poll cache', () => {
+    const orchestrator = new Orchestrator({
+      persistence: new InMemoryPersistence(),
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 2,
+    });
+
+    orchestrator.loadPlan({
+      name: 'ui-poll-delete-all',
+      baseBranch: 'master',
+      featureBranch: 'feature/ui-poll-delete-all',
+      tasks: [
+        { id: 'a', description: 'A' },
+        { id: 'b', description: 'B', dependencies: ['a'] },
+      ],
+    });
+    orchestrator.startExecution();
+
+    const beforeDelete = orchestrator.getQueueStatus({ refresh: false });
+    expect(beforeDelete.runningCount).toBeGreaterThan(0);
+
+    orchestrator.deleteAllWorkflows();
+
+    const afterDelete = orchestrator.getQueueStatus({ refresh: false });
+    expect(afterDelete).not.toBe(beforeDelete);
+    expect(afterDelete.running).toEqual([]);
+    expect(afterDelete.queued).toEqual([]);
+    expect(afterDelete.runningCount).toBe(0);
+  });
 });

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -3014,6 +3014,7 @@ export class Orchestrator {
     // 4. Clear memory
     this.activeWorkflowIds.clear();
     this.stateMachine.clear();
+    this.queueStatusUiCache = null;
 
     // 5. Publish removal deltas (skipped when publishRemovalDeltas is false)
     for (const task of allTasks) {


### PR DESCRIPTION
## Summary

`deleteAllWorkflows()` cleared persisted tasks and in-memory state but left `queueStatusUiCache` warm. A UI poll with `refresh: false` could keep serving the pre-wipe queue for up to 2.5 seconds.

The method now nulls `queueStatusUiCache` after workflow and task memory are cleared, so the next UI poll recomputes an empty queue.

A regression test warms the cache, wipes all workflows, and asserts the next UI-poll result is recomputed and empty. The audit report records the outcome in a Fixes applied section.

## Review Claim

The finding judged still-present in the PR #7413 audit is resolved: `deleteAllWorkflows()` now invalidates the queue-status UI cache so a UI poll cannot serve the pre-wipe queue snapshot.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The only product change is one assignment that nulls a cache field inside `deleteAllWorkflows()`; the cache is rebuilt on the next queue-status read, so the worst case is one extra recomputation.

## Slice Rationale

The fix ships directly on top of the verdict PR that justifies it, so the reviewer sees exactly why this one-line change exists.

## Non-goals

- No refactors beyond the flagged site.
- No changes for findings not judged still-present.
- No broader queue-status cache redesign.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-core && pnpm test queue-status-ui-poll-fast-path` (includes the new regression case `deleteAllWorkflows invalidates a warmed UI-poll cache`)
- [x] `cd packages/workflow-core && pnpm test` (full suite: 39 test files, 867 tests passed during the workflow run)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge sha of this PR>`
- Post-revert steps: None; the pre-fix behavior returns (a UI poll may serve a pre-wipe queue snapshot for up to 2.5 seconds).
- Data migration? No

</details>
