### PR TITLE
[CodeRabbit audit: PR #7277 — validate findings against master and fix what holds](1) Record verdicts: both findings invalid on master

### DIFF
--- a/docs/audits/coderabbit/pr-7277.md
+++ b/docs/audits/coderabbit/pr-7277.md
@@ -1,0 +1,47 @@
+# CodeRabbit Audit: PR #7277
+
+Source: `gh api repos/Neko-Catpital-Labs/Invoker/pulls/7277/comments --paginate`
+
+Current master checked: `a700d6ae7476e3611226d86d17e2138daa99eb33`
+
+## Finding 1: Prune scoped remote-tracking refs before matching them
+
+Quoted finding:
+
+> Prune scoped remote-tracking refs before matching them.
+>
+> `git fetch` does not guarantee removal of refs deleted from `origin`. A stale `origin/stack/...` ref can retain a matching SHA. The command can then accept a local commit as published when the remote stack branch no longer exists.
+
+Severity: Major
+
+Verdict: invalid
+
+Evidence:
+
+The finding does not apply to current `origin/master` because the referenced stack-ref matching implementation no longer exists. The current `scripts/create-pr.mjs:748` through `scripts/create-pr.mjs:768` only decides whether a branch is managed. The publication check at `scripts/create-pr.mjs:774` through `scripts/create-pr.mjs:799` uses the configured upstream or `origin/${branch}`, then checks `` revList(`${publishedRef}..HEAD`) ``. There is no current `fetchStackHeadsPrefix` call path at the reviewed location, and there is no current scoped `refs/heads/stack/*` fetch whose pruning behavior could leave stale `origin/stack/...` refs in the publication match.
+
+The current stack workflow tests around the related unpublished-commit case are `scripts/test-create-pr-stack-workflow.mjs:870` through `scripts/test-create-pr-stack-workflow.mjs:889`; they exercise a pushed current branch followed by an unpublished local commit, not stale scoped stack remote-tracking refs.
+
+## Finding 2: Make the Change-Id fallback valid through the publication check
+
+Quoted finding:
+
+> Make the Change-Id fallback valid through the publication check.
+>
+> A Change-Id match is only selected after `headSha` does not match. The later `` revList(`${publishedRef}..HEAD`) `` check uses commit ancestry. It lists a non-identical local HEAD and rejects it. Therefore, the Change-Id fallback cannot accept the SHA-mismatch case that it was added to support.
+
+Severity: Major
+
+Verdict: invalid
+
+Evidence:
+
+The finding does not apply to current `origin/master` because the referenced Change-Id fallback was removed. In current `scripts/create-pr.mjs`, Change-Id is only used by `branchHasChangeId` at `scripts/create-pr.mjs:738` through `scripts/create-pr.mjs:745` to classify whether a branch is managed. The current publication check at `scripts/create-pr.mjs:774` through `scripts/create-pr.mjs:799` does not compare the local HEAD to remote stack tips by Change-Id and does not return a match type.
+
+The `` revList(`${publishedRef}..HEAD`) `` ancestry check still exists at `scripts/create-pr.mjs:790`, but there is no current `findMergifyPublishedRef`, `refCommitHasChangeId`, or Change-Id-selected `publishedRef` feeding that check. The related test span called out by the finding has also moved past the PR-only code: current `scripts/test-create-pr-stack-workflow.mjs:891` through `scripts/test-create-pr-stack-workflow.mjs:912` covers missing current-branch PR lookup, not a same-Change-Id/different-SHA publication success case.
+
+## Fixes applied
+
+Fixes applied: none - all findings invalid.
+
+Verification: no package test suite was run because the audit contains no `Verdict: valid` findings and this branch changes no product code.


### PR DESCRIPTION
## Summary

CodeRabbit left two inline findings on merged PR #7277. Both target the stack publication checks in `scripts/create-pr.mjs`.

This PR re-verifies each finding against current master and commits the verdicts as an audit report at `docs/audits/coderabbit/pr-7277.md`.

Both findings are invalid on master. The flagged stack-ref matching and Change-Id fallback code paths no longer exist, so there is nothing left to fix.

Because no finding held, the report records `Fixes applied: none - all findings invalid` and this PR changes no product code.

## Review Claim

Each CodeRabbit finding on PR #7277 has an evidence-backed valid/invalid verdict against current master, and the recorded fix outcome matches those verdicts.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice only adds one audit report document under `docs/audits/`. It touches no product code, tests, or configuration, so it cannot alter product behavior.

## Slice Rationale

The verdict and the fix outcome form one review claim: the resolution of PR #7277's findings. Splitting them would separate a verdict from the change it justifies without adding review clarity.

## Non-goals

- No product code changes; both findings are invalid on master, so no fix is warranted.
- No re-litigating CodeRabbit style opinions that are not concrete findings.
- No auditing of other PRs; each audited PR gets its own workflow and report.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `test -f docs/audits/coderabbit/pr-7277.md`
- [x] `grep -cE '^Verdict: (valid|invalid)$' docs/audits/coderabbit/pr-7277.md`
- [x] `grep -n 'Fixes applied' docs/audits/coderabbit/pr-7277.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/pr-7277-audit.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
