### PR TITLE
CodeRabbit audit: PR #7488 — validate findings against master and fix what holds (1/3): audit verdict report

### DIFF
--- a/docs/audits/coderabbit/pr-7488.md
+++ b/docs/audits/coderabbit/pr-7488.md
@@ -1,0 +1,21 @@
+# CodeRabbit Audit: PR #7488
+
+Baseline: `origin/master` at `a700d6ae7476e3611226d86d17e2138daa99eb33`
+
+Source: `gh api repos/Neko-Catpital-Labs/Invoker/pulls/7488/comments --paginate`, filtered to inline comments by `coderabbitai[bot]`. Auto-summaries, walkthroughs, and review-limit notices were ignored.
+
+## Finding 1: Single-sample performance assertion is unstable
+
+Quoted finding:
+
+> Use repeated, paired measurements for the performance assertion.
+>
+> The test takes one uncapped sample and one capped sample in a fixed order. JIT warm-up, garbage collection, timer jitter, and CI load can change either result. The uncapped-first order can also make the capped path appear faster because the runtime is already warmed.
+>
+> Run several paired samples, alternate the measurement order, and compare a robust aggregate such as the median. Keep the burst-size assertions.
+
+Severity: Major
+
+Verdict: valid
+
+Evidence: On current `origin/master`, `packages/app/src/__tests__/launch-dispatcher-topup-event-loop-lag.test.ts:111` builds a single uncapped orchestrator, `:112` records one `uncappedMaxGapMs` sample, `:117` builds a single capped orchestrator, and `:118` records one `cappedMaxGapMs` sample. The measurement order is fixed because the uncapped sample always runs before the capped sample. The assertion at `:125` through `:128` compares the single capped sample directly with the single uncapped sample using `toBeLessThan(uncappedMaxGapMs)`. There is no repeated sampling, alternating order, or median/aggregate comparison in this test on master.


### PR DESCRIPTION
## Summary

Re-checks every inline CodeRabbit finding from merged PR #7488 against current master. Each concrete finding gets an explicit verdict backed by file:line evidence.

The one concrete finding — the launch-dispatcher event-loop-lag comparison takes a single sample pair in a fixed order — is judged still present on master.

The verdict artifact is committed at `docs/audits/coderabbit/pr-7488.md` so the fix in the next PR of this stack carries its justification.

## Review Claim

Each inline CodeRabbit finding on PR #7488 has an evidence-backed verdict against current master, recorded in the committed audit report.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice only adds one audit report file under `docs/audits/`; it cannot alter product behavior.

## Slice Rationale

The verdict must exist before any fix so findings judged wrong never produce code churn.

## Non-goals

- No product code changes in this slice.
- No fix for the confirmed finding here; that lands in the next PR of this stack.
- No re-litigating CodeRabbit style opinions that are not concrete findings.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `test -f docs/audits/coderabbit/pr-7488.md`
- [x] `grep -E 'Verdict: (valid|invalid)' docs/audits/coderabbit/pr-7488.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit sha>`
- Post-revert steps: None
- Data migration? No

</details>
