### PR TITLE
[CodeRabbit audit: PR #5942 — validate findings against master and fix what holds](1) Audit findings with verdicts

### DIFF
--- a/docs/audits/coderabbit/pr-5942.md
+++ b/docs/audits/coderabbit/pr-5942.md
@@ -1,0 +1,55 @@
+# CodeRabbit Audit: PR #5942
+
+Repository: `Neko-Catpital-Labs/Invoker`
+Review source: `gh api repos/Neko-Catpital-Labs/Invoker/pulls/5942/comments --paginate`
+Master checked: `origin/master` at `a700d6ae7476e3611226d86d17e2138daa99eb33`
+
+Only concrete inline findings from `coderabbitai[bot]` are included. Auto-summaries,
+walkthroughs, and review-limit notices were excluded.
+
+## Finding 1: Repository Search Scope
+
+Quoted finding:
+
+> Search the full repository scope.
+>
+> Line 13 excludes root files and `scripts/`. A reintroduced deprecated string in
+> either location makes this checker report `PASS`.
+>
+> Scan the repository root. Exclude this checker explicitly because it contains the
+> required search patterns.
+
+Severity: Major
+
+Verdict: invalid
+
+Evidence:
+
+Current master no longer limits the checker to `packages`, `docs`, and
+`invoker-ctl`. In `scripts/verify-empty-canonical-sweeps.sh`, line 13 sets
+`paths=(.)`, which includes repository-root files and `scripts/`, and line 18
+explicitly excludes only `scripts/verify-empty-canonical-sweeps.sh` so the
+checker's own search patterns do not self-match.
+
+## Finding 2: Ripgrep Error Handling
+
+Quoted finding:
+
+> Do not convert `rg` errors into empty results.
+>
+> Line 22 suppresses all non-zero `rg` statuses. `rg` uses status 2 for errors
+> such as an unreadable or missing search path. The checker then treats the failed
+> scan as no matches and can report `PASS`.
+>
+> Accept status 1 only. Fail for every other non-zero status.
+
+Severity: Major
+
+Verdict: invalid
+
+Evidence:
+
+Current master no longer uses `|| true` to suppress all `rg` failures. In
+`scripts/verify-empty-canonical-sweeps.sh`, lines 24-29 capture the `rg` exit
+status, allow status 1 as an empty result, and call `fail "rg failed with exit
+status ${status}"` for statuses greater than 1.


### PR DESCRIPTION
## Summary

Re-checks both inline CodeRabbit findings from merged PR #5942 against current master.

Both findings flag issues that master has since resolved. The report cites the current master lines as evidence.

The committed audit report records each finding, its verdict, and file:line evidence so the review shows why no code change is needed.

## Review Claim

Each inline CodeRabbit finding on PR #5942 has an evidence-backed valid/invalid verdict against current master, recorded in `docs/audits/coderabbit/pr-5942.md`.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice adds one new audit report document; it cannot alter product behavior.

## Slice Rationale

The verdicts must exist before any fix so invalid findings never produce code churn; the fix outcome lands in the next slice.

## Non-goals

- No product code changes.
- No re-litigating CodeRabbit style opinions that are not concrete findings.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `test -f docs/audits/coderabbit/pr-5942.md`
- [x] `grep -E "^Verdict: (valid|invalid)$" docs/audits/coderabbit/pr-5942.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
