### PR TITLE
[CodeRabbit audit: PR #7247 — validate findings against master and fix what holds](1) Refresh audit verdict against current master

### DIFF
--- a/docs/audits/coderabbit/pr-7247.md
+++ b/docs/audits/coderabbit/pr-7247.md
@@ -1,6 +1,6 @@
 # CodeRabbit Audit: PR #7247
 
-Current master checked: `59997318ac0799f8016c0b7d8fe0baabdd6356f0`
+Current master checked: `a700d6ae7476e3611226d86d17e2138daa99eb33`
 
 ## Finding 1: Stable execution key in lease contract
 
@@ -19,7 +19,7 @@ Evidence:
 - `packages/execution-engine/src/task-runner-dispatch.ts:367` stores active executions keyed by `attemptId`, and `packages/execution-engine/src/task-runner-dispatch.ts:373` stores the selected lease holder id on that active execution entry.
 - `packages/execution-engine/src/task-runner.ts:384` documents that liveness is scoped by lease holder rather than task id alone so stale abandoned-attempt leases are not treated as live after a retry. `packages/execution-engine/src/task-runner.ts:390` implements that by returning true only when an active execution entry has the exact same `leaseHolderId`.
 - `packages/app/src/launch-dispatcher.ts:205` first requires the expired row's `metadata.runnerInstanceId` to match the current runner, and `packages/app/src/launch-dispatcher.ts:206` then calls `hasActiveExecutionForLeaseHolder(row.holderId)`. Because the holder id includes the attempt id and the active lookup compares the exact holder, a new retry with a new `selectedAttemptId` does not make the stale prior-attempt lease look live.
-- `packages/app/src/__tests__/launch-dispatcher.test.ts:1274` covers this specific scenario: a stale holder from an abandoned attempt of the same task, where the task now has a different live attempt, must not be healed. `packages/app/src/__tests__/launch-dispatcher.test.ts:1298` verifies that only the genuinely live lease remains after polling.
+- `packages/app/src/__tests__/launch-dispatcher.test.ts:1321` covers this specific scenario: a stale holder from an abandoned attempt of the same task, where the task now has a different live attempt, must not be healed. `packages/app/src/__tests__/launch-dispatcher.test.ts:1345` verifies that only the genuinely live lease remains after polling.
 
 The contract shape at `packages/app/src/launch-dispatcher.ts:38` does not expose a separate `attemptId` field, but the current implementation already uses an exact, attempt-bearing holder id plus `metadata.runnerInstanceId` for the expiration decision. CodeRabbit's concrete failure mode is therefore not present on current master.
 


### PR DESCRIPTION
## Summary

CodeRabbit left one Minor inline finding on merged PR #7247. It asked for a stable execution key on lease rows so expiration can tell live leases from abandoned ones.

An earlier audit already judged that finding invalid: the lease holder id embeds the attempt id, and expiration compares exact holder ids plus `metadata.runnerInstanceId`.

This change re-verifies that verdict against current master `a700d6ae747`. The verdict still holds, so no product code changes.

The diff refreshes the committed report only: the checked-master SHA and the line numbers of the launch-dispatcher test, which sit lower in the file than at the last audit.

The outcome stays `Fixes applied: none - all findings invalid`.

## Review Claim

Each inline CodeRabbit finding on PR #7247 has an evidence-backed valid/invalid verdict against current master `a700d6ae747`; the single finding remains invalid, so the diff is an audit-report refresh only.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

The diff edits two lines of one file under `docs/audits/coderabbit/`; no product code, config, or scripts are touched, so runtime behavior cannot change.

## Slice Rationale

Validate and fix form one review claim — the resolution of PR #7247's findings. Splitting them would separate a verdict from the change it justifies. Per-PR audit workflows keep review scope small; one bulk PR for all 11 audited PRs was rejected.

## Non-goals

- No product code changes: the only finding remains invalid.
- No re-litigating CodeRabbit style opinions that are not concrete findings.
- No changes to the lease-expiration code the finding pointed at.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `test -f docs/audits/coderabbit/pr-7247.md`
- [x] `grep -E '^Verdict: (valid|invalid)$' docs/audits/coderabbit/pr-7247.md`
- [x] `grep -F 'Fixes applied' docs/audits/coderabbit/pr-7247.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
