### PR TITLE
[CodeRabbit audit: PR #7419 — validate findings against master and fix what holds](1) Record verdict: finding invalid on master

### DIFF
--- a/docs/audits/coderabbit/pr-7419.md
+++ b/docs/audits/coderabbit/pr-7419.md
@@ -1,0 +1,29 @@
+# CodeRabbit Audit for PR #7419
+
+Checked against current `origin/master` / `FETCH_HEAD` at commit `a700d6ae7476e3611226d86d17e2138daa99eb33`.
+
+## Finding 1: source-structure assertions inside `it.fails`
+
+Comment: https://github.com/Neko-Catpital-Labs/Invoker/pull/7419#discussion_r3715299168
+
+Quoted finding:
+
+> Keep source-structure assertions outside `it.fails`.
+>
+> `it.fails` accepts any thrown assertion as an expected failure. A missing source file, a regex mismatch, or an unexpected match count will make these tests pass without proving the intended call sites exist.
+>
+> Add normal `it` cases that verify the files and expected matches. Keep only the `>= 1000` timeout assertions in `it.fails`.
+
+Severity: Minor
+
+Verdict: invalid
+
+Evidence:
+
+The flagged problem no longer exists on current `master`. In `packages/app/src/__tests__/owner-ping-race.repro.test.ts`, the two tests CodeRabbit flagged are now plain `it` cases, not `it.fails`: line 36 starts `it('discoverStandaloneOwnerForGui in main.ts does not use the 500ms outlier budget', ...)`, and line 47 starts `it('the two discoverOwner call sites in headless-client.ts do not use the 500ms outlier budget', ...)`. The structural checks therefore cannot be hidden by `it.fails` on current `master`.
+
+The current `master` code also shows the timeout fix landed: `packages/app/src/main.ts:565` calls `discoverOwner(ownerBus, 1500)`, and `packages/app/src/headless-client.ts:551` and `packages/app/src/headless-client.ts:752` call `discoverOwner(..., 1500)`. That corroborates the PR-thread reply that the later slice would remove the `it.fails` masking window.
+
+## Fixes applied
+
+Fixes applied: none - all findings invalid


### PR DESCRIPTION
## Summary

CodeRabbit left one Minor inline finding on merged PR #7419. It claimed source-structure assertions were hidden inside `it.fails`, letting broken checks pass silently.

This change re-verifies that finding against current master instead of trusting it blindly. The verdict is invalid, with file-and-line evidence cited in the report.

On current master the two flagged tests in `owner-ping-race.repro.test.ts` are plain `it` cases, so the masking window the finding described no longer exists.

Because no finding held, no product code changes. The committed report records the verdict and the explicit outcome `Fixes applied: none - all findings invalid`.

## Review Claim

Each inline CodeRabbit finding on PR #7419 has an evidence-backed valid/invalid verdict against current master, and every valid finding is fixed; since the only finding is invalid, the diff is the audit report only.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

The diff adds one new file under `docs/audits/coderabbit/`; no product code, config, or scripts are touched, so runtime behavior cannot change.

## Slice Rationale

Validate and fix form one review claim — the resolution of PR #7419's findings. Splitting them would separate a verdict from the change it justifies. Per-PR audit workflows keep review scope small; one bulk PR for all 11 audited PRs was rejected.

## Non-goals

- No product code changes: the only finding is judged invalid.
- No re-litigating CodeRabbit style opinions that are not concrete findings.
- No changes to the `owner-ping-race.repro.test.ts` tests the finding pointed at.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `test -f docs/audits/coderabbit/pr-7419.md`
- [x] `grep -E '^Verdict: (valid|invalid)$' docs/audits/coderabbit/pr-7419.md`
- [x] `grep -F 'Fixes applied' docs/audits/coderabbit/pr-7419.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
