### PR TITLE
[CodeRabbit audit: PR #7167 — validate findings against master and fix what holds](1) Record verdict: the single finding is invalid on master

### DIFF
--- a/docs/audits/coderabbit/pr-7167.md
+++ b/docs/audits/coderabbit/pr-7167.md
@@ -1,0 +1,33 @@
+# CodeRabbit Audit for PR #7167
+
+Source: `gh api repos/Neko-Catpital-Labs/Invoker/pulls/7167/comments --paginate`
+
+Baseline: current `origin/master` after fetching on 2026-08-06.
+
+Current master checked: `a700d6ae7476e3611226d86d17e2138daa99eb33`
+
+## Finding 1: Synchronize workflow validator with manual spec allowlist
+
+Quoted finding:
+
+> Synchronize the workflow validator with this allowlist.
+>
+> `ciDiscovered` excludes `e2e/planning-terminal-chat-tmux-toggle-real-claude-repro.spec.ts`, but `.github/workflows/ci.yml` Lines [692-725] still discovers every `*.spec.ts` file and checks the full set against the shard matrix. That validator will report the manual spec as missing and exit with status 1. Update that check to apply the same `manualSpecs` exclusion, or invoke this script from the workflow, before merging the stack.
+
+Severity: Major
+
+Verdict: invalid
+
+Evidence:
+
+The finding no longer applies on current `origin/master`. The workflow's "Verify Playwright shard inventory" step invokes the shared validator script directly at `.github/workflows/ci.yml:716` and `.github/workflows/ci.yml:717`, so the workflow no longer has a separate inline discovery/check path that can drift from the script allowlist.
+
+The invoked script defines the manual-only allowlist at `scripts/repro/repro-ci-playwright-shard-inventory.mjs:31`, including `planning-terminal-chat-tmux-toggle-real-claude-repro.spec.ts` at `scripts/repro/repro-ci-playwright-shard-inventory.mjs:34`. It discovers all spec files at `scripts/repro/repro-ci-playwright-shard-inventory.mjs:50`, then filters out entries in `MANUAL_ONLY_SPECS` before converting them to CI shard paths at `scripts/repro/repro-ci-playwright-shard-inventory.mjs:54` through `scripts/repro/repro-ci-playwright-shard-inventory.mjs:57`.
+
+The comparison against shard matrix entries uses that filtered `discovered` set: `missing` is computed from filtered discovered specs at `scripts/repro/repro-ci-playwright-shard-inventory.mjs:64`, and `extra` is computed against the same filtered set at `scripts/repro/repro-ci-playwright-shard-inventory.mjs:65`. The script separately checks that manual-only allowlist entries still exist at `scripts/repro/repro-ci-playwright-shard-inventory.mjs:61` through `scripts/repro/repro-ci-playwright-shard-inventory.mjs:63`, preserving coverage without requiring the manual real-Claude spec to appear in CI shards.
+
+Because current master invokes this script from CI and the script excludes the manual-only spec before shard comparison, CodeRabbit's concrete failure mode is fixed since the PR review comment.
+
+## Fixes applied
+
+Fixes applied: none - all findings invalid


### PR DESCRIPTION
## Summary

PR #7167 merged with one concrete CodeRabbit inline finding left unresolved. This audit re-checks that finding against current master instead of trusting it blindly.

The finding warned that the CI Playwright shard-inventory check would flag a manual-only spec as missing and fail. Current master already runs the shared validator script, which excludes that spec.

The committed report quotes the finding, records the verdict as invalid with file:line evidence, and states that no fixes are needed because no finding held.

## Review Claim

The audit report for PR #7167 records an evidence-backed invalid verdict for its single concrete CodeRabbit finding, so no code change is justified.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice only adds one markdown report under `docs/audits/coderabbit/`. It changes no executable file, so it cannot alter any runtime or CI behavior.

## Slice Rationale

Standalone workflow waiver: the verdict and the fix outcome form one review claim — the resolution of PR #7167's findings. Splitting them would separate a verdict from the change it justifies. Because every finding was judged invalid, the fix outcome is a recorded "none" rather than a code change.

## Non-goals

- No product code changes; the audit found nothing valid to fix.
- No re-litigating CodeRabbit style opinions that are not concrete findings.
- No auditing of other PRs; each audited PR gets its own workflow and stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `test -f docs/audits/coderabbit/pr-7167.md`
- [x] `grep -cE '^Verdict: (valid|invalid)$' docs/audits/coderabbit/pr-7167.md`
- [x] `grep -n 'Fixes applied' docs/audits/coderabbit/pr-7167.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>` of the squash-merge commit for this PR
- Post-revert steps: None
- Data migration? No

</details>
