### PR TITLE
[CodeRabbit audit: PR #5942 — validate findings against master and fix what holds](1) Validate findings and record no-fix outcome

### DIFF
--- a/docs/audits/coderabbit/pr-5942.md
+++ b/docs/audits/coderabbit/pr-5942.md
@@ -1,0 +1,49 @@
+# CodeRabbit Audit: PR #5942
+
+Source: `gh api repos/Neko-Catpital-Labs/Invoker/pulls/5942/comments --paginate`
+
+Current master checked: `a700d6ae7476e3611226d86d17e2138daa99eb33`
+
+## Finding 1: Search the full repository scope
+
+Quoted finding:
+
+> Search the full repository scope.
+>
+> Line 13 excludes root files and `scripts/`. A reintroduced deprecated string in either location makes this checker report `PASS`.
+>
+> Scan the repository root. Exclude this checker explicitly because it contains the required search patterns.
+
+Severity: Major
+
+Verdict: invalid
+
+Evidence:
+
+The scope issue described by CodeRabbit has been fixed on current `master`. `scripts/verify-empty-canonical-sweeps.sh:13` now sets `paths=(.)`, so the checker scans from the repository root instead of only `packages`, `docs`, and `invoker-ctl`. The checker also explicitly excludes itself at `scripts/verify-empty-canonical-sweeps.sh:18` with `--glob '!scripts/verify-empty-canonical-sweeps.sh'`, preventing its own search expressions from becoming false positives.
+
+Because root files and `scripts/` are now in scope while the checker file itself is excluded, the flagged failure mode is not present on current `master`.
+
+## Finding 2: Do not convert `rg` errors into empty results
+
+Quoted finding:
+
+> Do not convert `rg` errors into empty results.
+>
+> Line 22 suppresses all non-zero `rg` statuses. `rg` uses status 2 for errors such as an unreadable or missing search path. The checker then treats the failed scan as no matches and can report `PASS`.
+>
+> Accept status 1 only. Fail for every other non-zero status.
+
+Severity: Major
+
+Verdict: invalid
+
+Evidence:
+
+The error-suppression issue described by CodeRabbit has been fixed on current `master`. In `scripts/verify-empty-canonical-sweeps.sh:24`, `rg_source_hits` initializes `status=0`, and `scripts/verify-empty-canonical-sweeps.sh:26` captures the `rg` exit code when the command returns non-zero. `scripts/verify-empty-canonical-sweeps.sh:27` then checks `if (( status > 1 ))`, and `scripts/verify-empty-canonical-sweeps.sh:28` fails the script with the captured status.
+
+That means `rg` status 1 still represents no matches, while error statuses such as 2 no longer become empty successful results. The flagged failure mode is not present on current `master`.
+
+## Fixes applied
+
+Fixes applied: none - both findings are invalid on current `master`.


### PR DESCRIPTION
## Summary

Re-verifies both inline CodeRabbit findings from merged PR #5942 against current master.

Both findings describe problems master has since fixed. Each verdict cites current file and line evidence in the flagged checker script.

Because every finding is invalid, no product code changes. The committed report records the verdicts and the explicit no-fixes outcome.

## Review Claim

Each inline CodeRabbit finding on PR #5942 has an evidence-backed valid/invalid verdict against current master, and the recorded fix outcome matches those verdicts (none needed), in `docs/audits/coderabbit/pr-5942.md`.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice adds one audit report document under `docs/audits/`; it cannot alter product behavior.

## Slice Rationale

Validate and fix form one review claim — the resolution of PR #5942's findings. Splitting them would separate a verdict from the change it justifies without adding review clarity.

## Non-goals

- No product code changes; both findings are invalid on current master.
- No re-litigating CodeRabbit style opinions that are not concrete findings.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `test -f docs/audits/coderabbit/pr-5942.md`
- [x] `grep -E "^Verdict: (valid|invalid)$" docs/audits/coderabbit/pr-5942.md`
- [x] `grep -n "Fixes applied" docs/audits/coderabbit/pr-5942.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
