### PR TITLE
[CodeRabbit audit: PR #5942 — validate findings against master and fix what holds](1) Record per-finding verdicts

### DIFF
--- a/docs/audits/coderabbit/pr-5942.md
+++ b/docs/audits/coderabbit/pr-5942.md
@@ -1,0 +1,49 @@
+# CodeRabbit Audit: PR #5942
+
+Source: `gh api repos/Neko-Catpital-Labs/Invoker/pulls/5942/comments --paginate`
+
+Current master checked: `a700d6ae7476e3611226d86d17e2138daa99eb33`
+
+## Finding 1: Search the full repository scope
+
+Quoted finding:
+
+> Search the full repository scope.
+>
+> Line 13 excludes root files and `scripts/`. A reintroduced deprecated string in either location makes this checker report `PASS`.
+>
+> Scan the repository root. Exclude this checker explicitly because it contains the required search patterns.
+
+Severity: Major
+
+Verdict: invalid
+
+Evidence:
+
+The finding has been fixed on current `origin/master`. The checker no longer limits searches to `packages`, `docs`, and `invoker-ctl`; `scripts/verify-empty-canonical-sweeps.sh:13` sets `paths=(.)`, which includes the repository root and `scripts/`.
+
+The self-match concern is also handled. `scripts/verify-empty-canonical-sweeps.sh:18` explicitly excludes `scripts/verify-empty-canonical-sweeps.sh` from the ripgrep glob list, so the checker can search the full repository without matching its own search expressions.
+
+## Finding 2: Do not convert `rg` errors into empty results
+
+Quoted finding:
+
+> Do not convert `rg` errors into empty results.
+>
+> Line 22 suppresses all non-zero `rg` statuses. `rg` uses status 2 for errors such as an unreadable or missing search path. The checker then treats the failed scan as no matches and can report `PASS`.
+>
+> Accept status 1 only. Fail for every other non-zero status.
+
+Severity: Major
+
+Verdict: invalid
+
+Evidence:
+
+The finding has been fixed on current `origin/master`. `scripts/verify-empty-canonical-sweeps.sh:24` initializes a `status` variable, and `scripts/verify-empty-canonical-sweeps.sh:26` captures ripgrep's exit status instead of appending `|| true`.
+
+The checker now fails on real ripgrep errors. `scripts/verify-empty-canonical-sweeps.sh:27` checks `if (( status > 1 ))`, and `scripts/verify-empty-canonical-sweeps.sh:28` calls `fail "rg failed with exit status ${status}"`. That preserves status 1 as an empty result while preventing status 2 or other scan failures from being interpreted as a passing empty search.
+
+## Fixes applied
+
+Fixes applied: none - all findings invalid


### PR DESCRIPTION
## Summary

Re-verifies both inline CodeRabbit findings from merged PR #5942 against current master.

Both findings describe problems master has since fixed. Each verdict cites current file and line evidence in the flagged checker script.

Because every finding is invalid, no product code changes. The committed report records the verdicts and the explicit no-fixes outcome.

## Review Claim

Each inline CodeRabbit finding on PR #5942 has an evidence-backed valid/invalid verdict against current master, and the recorded fix outcome matches those verdicts (none needed), in `docs/audits/coderabbit/pr-5942.md`.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice adds one audit report document under `docs/audits/`; it cannot alter product behavior.

## Slice Rationale

Validate and fix form one review claim — the resolution of PR #5942's findings. Splitting them would separate a verdict from the change it justifies without adding review clarity.

## Non-goals

- No product code changes; both findings are invalid on current master.
- No re-litigating CodeRabbit style opinions that are not concrete findings.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `test -f docs/audits/coderabbit/pr-5942.md`
- [x] `grep -E "^Verdict: (valid|invalid)$" docs/audits/coderabbit/pr-5942.md`
- [x] `grep -n "Fixes applied" docs/audits/coderabbit/pr-5942.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
