### PR TITLE
[CodeRabbit audit: PR #7053](1) Validate findings against master and fix what holds

### DIFF
--- a/docs/audits/coderabbit/pr-7053.md
+++ b/docs/audits/coderabbit/pr-7053.md
@@ -1,67 +1,45 @@
-# CodeRabbit Audit for PR #7053
+# CodeRabbit Audit: PR #7053
 
-Source: `gh api repos/Neko-Catpital-Labs/Invoker/pulls/7053/comments --paginate`
+Verified against current `master` at `a700d6ae7476e3611226d86d17e2138daa99eb33`.
 
-Baseline: current `origin/master` after fetching on 2026-08-05.
-
-## Finding 1: Restore mocks in remote finalize retry/timeout tests
+## Finding 1: Restore mocks in retry/timeout test cleanup
 
 Quoted finding:
 
-> Restore mocks in `afterEach` for this retry/timeout block. `vi.clearAllMocks()` clears call history, but it does not undo the `vi.spyOn(console, 'info').mockImplementation(() => {})` calls added in these tests.
+> Restore mocks in `afterEach` for this retry/timeout block.
 
 Severity: Minor
 
-Verdict: valid
+Verdict: invalid
 
-Evidence:
+Evidence: The retry/timeout test block now restores global spies in its cleanup. `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1735` starts the `afterEach`, the environment and timers are restored at `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1736` through `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1738`, and `vi.restoreAllMocks()` is present at `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1739`. The flagged leak of `console.info` spies no longer exists on `master`.
 
-The finding still applies on current `origin/master`. In `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1724`, the block `beforeEach` calls `vi.clearAllMocks()`, but the block `afterEach` at `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1735` only restores `INVOKER_REMOTE_FINALIZE_TIMEOUT_MS` and calls `vi.useRealTimers()` at line 1738. There is no `vi.restoreAllMocks()` or per-spy `mockRestore()` in this describe block.
-
-The same block creates console spies at `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1758`, `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1776`, `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1793`, and `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1833`. `packages/execution-engine/vitest.config.ts:4` merges `vitest.shared.ts`, and neither that package config nor `vitest.shared.ts:7` enables `restoreMocks`, so the mocked console methods are not automatically restored by configuration.
-
-## Finding 2: SIGKILL escalation is dead code
+## Finding 2: Preserve SIGKILL escalation after remote timeout
 
 Quoted finding:
 
-> Fix: the `SIGKILL` escalation is dead code. `killTimer` is cleared as a side effect of `finish()`, and `finish()` runs synchronously right after `killTimer` is created inside the timeout handler.
+> Fix: the `SIGKILL` escalation is dead code.
 
 Severity: Critical
 
 Verdict: invalid
 
-Evidence:
+Evidence: The timeout flow now tracks process closure separately from promise settlement. `closed` is declared at `packages/execution-engine/src/ssh-executor.ts:411`, set in the child `close` handler at `packages/execution-engine/src/ssh-executor.ts:431`, and the escalation callback checks `!closed` before sending `SIGKILL` at `packages/execution-engine/src/ssh-executor.ts:454` through `packages/execution-engine/src/ssh-executor.ts:456`. The `finish` helper no longer clears `killTimer`; it only clears `timeoutTimer` at `packages/execution-engine/src/ssh-executor.ts:415` through `packages/execution-engine/src/ssh-executor.ts:419`, while `killTimer` is cleared after the child closes at `packages/execution-engine/src/ssh-executor.ts:430` through `packages/execution-engine/src/ssh-executor.ts:432`. A regression test asserts the hung child receives both `SIGTERM` and `SIGKILL` at `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1742` through `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1755`.
 
-The specific dead-code condition described by CodeRabbit has been fixed on current `origin/master`. In `packages/execution-engine/src/ssh-executor.ts:410`, `settled` is tracked separately from `closed` at line 411. The `finish` helper at `packages/execution-engine/src/ssh-executor.ts:414` sets `settled` and clears `timeoutTimer`, but it no longer clears `killTimer`. The child `close` handler sets `closed = true` and clears `killTimer` at `packages/execution-engine/src/ssh-executor.ts:429`.
-
-The timeout path now creates `killTimer` at `packages/execution-engine/src/ssh-executor.ts:451`, and the timer callback checks `if (!closed)` before sending `SIGKILL` at line 452. Because the guard is based on process closure rather than promise settlement, settling the timeout error at `packages/execution-engine/src/ssh-executor.ts:455` no longer prevents escalation. The regression test at `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1741` advances fake timers and asserts `SIGKILL` at line 1754.
-
-## Finding 3: Remote finalize retries are not idempotent and may overlap
+## Finding 3: Make remote finalize retries idempotent and non-overlapping
 
 Quoted finding:
 
-> Make the remote finalize retry idempotent and wait for the previous SSH session to close. `buildRecordAndPushScript` always stages, commits, and pushes HEAD, so a retry after a local timeout can re-run a commit/push even if the remote operation already completed.
+> Make the remote finalize retry idempotent and wait for the previous SSH session to close.
 
 Severity: Major
 
-Verdict: valid
+Verdict: invalid
 
-Evidence:
+Evidence: `remoteGitRecordAndPush` now passes a stable idempotency key, `executionId`, into `buildRecordAndPushScript` at `packages/execution-engine/src/ssh-executor.ts:1019` through `packages/execution-engine/src/ssh-executor.ts:1028`. The generated script stores an idempotency marker and returns the recorded commit hash instead of recommitting when the marker is present at `packages/execution-engine/src/ssh-git-exec.ts:377` through `packages/execution-engine/src/ssh-git-exec.ts:391`; it also recognizes the idempotency footer on `HEAD` and reuses that commit at `packages/execution-engine/src/ssh-git-exec.ts:417` through `packages/execution-engine/src/ssh-git-exec.ts:419`. The commit messages include the footer before commit creation at `packages/execution-engine/src/ssh-git-exec.ts:424` through `packages/execution-engine/src/ssh-git-exec.ts:431`, and the successful hash is written to the marker after push at `packages/execution-engine/src/ssh-git-exec.ts:402` through `packages/execution-engine/src/ssh-git-exec.ts:415`.
 
-The idempotency concern still applies on current `origin/master`. `buildRecordAndPushScript` stages all changes with `git add -A` at `packages/execution-engine/src/ssh-git-exec.ts:375`, creates either an empty commit at line 382 or a changes commit at line 385, then pushes the resulting `HEAD` at `packages/execution-engine/src/ssh-git-exec.ts:397` or line 399. The script does not use a lock, marker, stable idempotency token, or completed-result check before creating the commit.
-
-The overlap concern also still applies. `execRemoteCapture` starts a timeout at `packages/execution-engine/src/ssh-executor.ts:445`, sends `SIGTERM` at line 450, schedules `SIGKILL` for later at lines 451-453, and then immediately settles the promise with a timeout rejection at lines 455-460. `remoteGitRecordAndPush` catches that timeout and continues its retry loop at `packages/execution-engine/src/ssh-executor.ts:1031` without waiting for the previous SSH child to close. Therefore the next `execRemoteCapture` call at `packages/execution-engine/src/ssh-executor.ts:1033` can begin while the previous remote command is still alive until the delayed `SIGKILL` fires or the remote process exits on its own.
+Evidence for non-overlap is also present in `execRemoteCapture`: on timeout it records `timeoutError` and sends `SIGTERM`/eventual `SIGKILL` at `packages/execution-engine/src/ssh-executor.ts:448` through `packages/execution-engine/src/ssh-executor.ts:462`, but it does not reject until the child `close` handler runs at `packages/execution-engine/src/ssh-executor.ts:430` through `packages/execution-engine/src/ssh-executor.ts:446`. The retry test documents and asserts that each attempt closes before the next attempt starts at `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1810` through `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1825`.
 
 ## Fixes applied
 
-Finding 1 fixed: the remote finalize retry/timeout test block now restores spies in `afterEach` with `vi.restoreAllMocks()` at `packages/execution-engine/src/__tests__/ssh-executor.test.ts:1739`, so console spies created by the tests no longer leak after the block.
-
-Finding 3 fixed: `remoteGitRecordAndPush` now passes the stable `executionId` into `buildRecordAndPushScript` at `packages/execution-engine/src/ssh-executor.ts:1027`. The generated script stores and reuses a per-execution successful commit marker at `packages/execution-engine/src/ssh-git-exec.ts:377` through `packages/execution-engine/src/ssh-git-exec.ts:391`, adds an `Invoker-Finalize-Id` footer before committing at `packages/execution-engine/src/ssh-git-exec.ts:424` through `packages/execution-engine/src/ssh-git-exec.ts:431`, and reuses an existing finalize commit for the same execution before creating another commit at `packages/execution-engine/src/ssh-git-exec.ts:417` through `packages/execution-engine/src/ssh-git-exec.ts:419`.
-
-Finding 3 overlap fixed: `execRemoteCapture` now records the timeout error at `packages/execution-engine/src/ssh-executor.ts:458` through `packages/execution-engine/src/ssh-executor.ts:461`, but the promise is rejected only from the child `close` handler at `packages/execution-engine/src/ssh-executor.ts:430` through `packages/execution-engine/src/ssh-executor.ts:441`. The retry loop therefore cannot start the next finalize attempt until the previous SSH child has closed.
-
-Test evidence:
-
-- `cd packages/execution-engine && pnpm test -- src/__tests__/ssh-executor.test.ts -t "SshExecutor remote finalize retry/timeout"`: passed, 5 tests.
-- `cd packages/execution-engine && pnpm test -- src/__tests__/ssh-git-exec.test.ts`: passed, 54 tests, including `buildRecordAndPushScript > reuses the recorded commit when retried with the same idempotency key`.
-- `cd packages/execution-engine && pnpm test`: attempted. The run failed before this report update with the new idempotency test parsing issue since fixed above, and an unrelated pre-existing `src/__tests__/worker-registry.test.ts` expectation that omits the registered `reaper` worker. Re-running `cd packages/execution-engine && pnpm test -- src/__tests__/worker-registry.test.ts` still fails with only that unrelated `reaper` expectation; no product code for that unrelated worker-registry issue was changed.
+Fixes applied: none - all findings invalid


### PR DESCRIPTION
## Summary

Re-verifies every inline CodeRabbit finding from merged PR #7053 against current master and records an evidence-backed verdict for each one.

All three findings are now invalid. The fixes CodeRabbit asked for already landed on master, so this audit changes no product code.

The committed report cites the exact master file and line evidence for each verdict, so the review shows why nothing needed fixing.

Standalone workflow waiver: validate and fix form one review claim (the resolution of PR #7053's findings); splitting them would separate the verdict from its justifying change without adding clarity.

## Review Claim

Each CodeRabbit finding on PR #7053 has an evidence-backed valid/invalid verdict against current master, and every valid finding is fixed; since all findings are invalid, no product code changes.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice only rewrites one audit report document under `docs/audits/`. It touches no product code, so it cannot alter runtime behavior.

## Slice Rationale

The verdicts and the fix outcome for PR #7053 belong in one slice so the review shows the resolution of each finding next to its evidence. Per-PR audits keep review scope small and independent of the other audited PRs.

## Non-goals

- No product code changes; all findings were judged invalid against master.
- No re-litigating CodeRabbit style opinions that are not concrete inline findings.
- No audits of other PRs; this slice covers PR #7053 only.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `test -f docs/audits/coderabbit/pr-7053.md && grep -Eq '^Verdict: (valid|invalid)$' docs/audits/coderabbit/pr-7053.md`
- [x] `grep -q 'Fixes applied' docs/audits/coderabbit/pr-7053.md`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-7053-audit-body.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
