### PR TITLE
[Slack cross-thread contamination: incident audit and regression proof](2) Same-channel interleaving regression test

### DIFF
--- a/docs/audits/slack-cross-thread-contamination.md
+++ b/docs/audits/slack-cross-thread-contamination.md
@@ -1,0 +1,73 @@
+# Slack Cross-Thread Contamination Audit
+
+Date reviewed: 2026-08-06
+
+Scope: observed production Slack manager cross-thread incidents from 2026-08-05 UTC, judged against PR #7514 / commit `713eb285f` (`[Slack Channel Bleed Fix](1) Stop trusting an empty stored channelId as a session match`).
+
+## Predicate Under Review
+
+`SessionManager.getOrCreateSession()` and `SessionManager.getSession()` build a `SessionIdentifier(channelId, threadTs)` and then call `conversationRepo.loadConversation(id.threadTs)`. `ConversationRepository.loadConversation()` delegates to `SQLiteAdapter.loadConversation(threadTs)`, which selects the row with `WHERE thread_ts = ?`.
+
+Before PR #7514:
+
+- `getOrCreateSession()` recovered a persisted row when `loaded.channelId === id.channelId || loaded.channelId === ''`.
+- `getSession()` accepted a persisted row unless `persisted.channelId && persisted.channelId !== id.channelId`.
+
+After PR #7514:
+
+- `getOrCreateSession()` recovers only when `loaded.channelId === id.channelId`.
+- `getSession()` accepts only when `persisted.channelId === id.channelId`.
+
+That fixes a real empty-`channelId` recovery hole for a row returned for the requested `threadTs`. It does not make either lookup capable of distinguishing a wrong upstream `threadTs`, and it does not explain selection of a distinct same-channel thread row because the persistence lookup is already by exact `thread_ts`.
+
+## Incident 1: `1785890604.484199`
+
+Observed behavior: the CodeRabbit-audit planning thread's turns 7 and 8 replied about a different thread's Slack-bot-icon scope and denied the CodeRabbit-audit thread's earlier YAML draft.
+
+Incident verdict: unexplained
+
+Code-path reasoning: for this incident to be explained by PR #7514's bug, the relevant lookup would have to be `SessionManager.getOrCreateSession(new SessionIdentifier(channel, '1785890604.484199'), ...)` or `SessionManager.getSession(new SessionIdentifier(channel, '1785890604.484199'), ...)` loading a persisted row whose `thread_ts` is `1785890604.484199` and whose `channelId` is blank. Before the fix, either lookup could recover that same-`threadTs` blank-channel row; after the fix, the exact-match predicate rejects it. That path does not explain why a distinct same-channel Slack-bot-icon thread's conversation would be returned for `1785890604.484199`, because the repository lookup is `loadConversation('1785890604.484199')`, not a scan by channel or any cross-thread selector.
+
+## Incident 2: `1785890283.654509`
+
+Observed behavior: the repo-context-default planning thread's final turns drafted silent-catch YAML belonging to other threads.
+
+Incident verdict: unexplained
+
+Code-path reasoning: the #7514 path could only recover persisted state for `thread_ts = '1785890283.654509'`. Before the fix, a blank `channelId` on that exact row would have been treated as a match by both `getOrCreateSession()` and `getSession()`; after the fix, blank no longer equals the requested channel and is excluded. The observed symptom names silent-catch YAML from other same-channel threads with different thread timestamps. The fixed predicate cannot make `loadConversation('1785890283.654509')` return those other thread rows, so this incident is not explained by the empty-`channelId` session match alone.
+
+## Incident 3: `1785904741.484399`
+
+Observed behavior: the close-empty-PRs thread's turn 2 interpreted the user's four answers as silent-catch enforcement scope.
+
+Incident verdict: unexplained
+
+Code-path reasoning: this is the closest match to the synthetic regression theme because the reported source content is silent-catch scope and the victim content is close-empty-PRs answers. Even so, the production facts supplied here say the involved conversations were in the same channel and persisted under stable per-thread session directories. In `thread-session-manager.ts`, the relevant lookup for the victim thread is still `conversationRepo.loadConversation('1785904741.484399')`. Before PR #7514, a blank `channelId` on that exact victim row could be recovered; after PR #7514, it is rejected. The predicate change does not provide a route for the silent-catch thread's distinct persisted row to be selected for `1785904741.484399`.
+
+## Incident 4: `1785883369.730089`
+
+Observed behavior: the land-stack thread's late turn answered with silent-catch docs scope.
+
+Incident verdict: unexplained
+
+Code-path reasoning: the only session-manager lookups that PR #7514 changed are same-requested-thread recovery lookups. For `1785883369.730089`, a pre-fix blank-channel row at `thread_ts = '1785883369.730089'` could be treated as belonging to the requested channel, and the post-fix exact predicate now excludes it. That would explain stale or wrong content already stored on the land-stack thread row, but not a lookup returning a different same-channel silent-catch docs thread row. The distinct-thread part remains outside the fixed empty-`channelId` match.
+
+## Incident 5: `1785888856.764159`
+
+Observed behavior: the decomposition-experiment thread's late turn folded its 5-trials answer into silent-catch docs scope.
+
+Incident verdict: unexplained
+
+Code-path reasoning: for this incident, `getSession()` or `getOrCreateSession()` would query `loadConversation('1785888856.764159')`. Before the fix, those methods could accept a returned row with `channelId = ''`; after the fix, they require exact channel equality and exclude that blank row. Because the observed contamination is from a different same-channel silent-catch docs thread, PR #7514 does not identify a lookup that could return the other thread's conversation for this victim thread timestamp.
+
+## Residual Mechanism Summary
+
+All five incidents are unexplained by PR #7514's empty-`channelId` session-match bug as stated. The fixed predicate now excludes blank-channel persisted rows for the requested thread timestamp, but the observed incidents all require either distinct same-channel thread content to have been selected, or wrong content to have already been written under the victim thread timestamp before the audited lookup ran.
+
+A residual contamination mechanism therefore remains unless production evidence shows that each victim thread's own persisted row already contained the foreign content under its own `thread_ts`. The recommended next investigation is to correlate production logs and database snapshots for these exact thread IDs:
+
+- `MENTION_RECEIVED`, `PASSIVE_THREAD_CONTEXT`, `getSession`, `getOrCreateSession`, `loadConversation`, and `RESPONSE_PROVENANCE` log lines, verifying the `event_ts`, `thread_ts`, `channel`, and `source_event_ts` used for each affected turn.
+- `conversations` and message rows for the five victim thread timestamps and the suspected Slack-bot-icon / silent-catch source timestamps, checking whether foreign messages were already stored under victim `thread_ts` values.
+- persisted planning launch context and harness session IDs keyed by each `threadTs`, checking for a reused or overwritten `harnessSessionId` that could attach one Slack thread to another model/agent conversation despite stable per-thread working directories.
+
+If those checks show correct Slack `thread_ts` routing and clean victim conversation rows before the contaminated turns, the next likely area is the harness/session-resume layer rather than `SessionManager`'s channel predicate.

--- a/packages/surfaces/src/__tests__/slack-thread-interleaving-contamination.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-thread-interleaving-contamination.e2e.test.ts
@@ -1,0 +1,210 @@
+// E2E regression coverage for the 2026-08-05 Slack cross-thread contamination
+// outage shape: same channel, interleaved persisted planning threads, and a
+// legacy conversation row whose stored channelId is empty.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import * as childProcess from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ConversationRepository, SQLiteAdapter } from '@invoker/data-store';
+import type { HarnessSessionDriver } from '@invoker/execution-engine';
+import { SlackSurface } from '../slack/slack-surface.js';
+import type { SurfaceCommand } from '../surface.js';
+
+interface MockHandler {
+  pattern: string | RegExp;
+  handler: Function;
+}
+
+const sharedSlack = vi.hoisted(() => ({
+  client: {
+    auth: { test: vi.fn().mockResolvedValue({ user_id: 'UBOT' }) },
+    chat: {
+      postMessage: vi.fn().mockResolvedValue({ ts: 'posted' }),
+      update: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    },
+    reactions: { add: vi.fn().mockResolvedValue({}), remove: vi.fn().mockResolvedValue({}) },
+    files: { uploadV2: vi.fn().mockResolvedValue({ ok: true, files: [{ ok: true, files: [{ id: 'F1' }] }] }) },
+  },
+}));
+
+vi.mock('@slack/bolt', () => {
+  class MockApp {
+    _eventHandlers: MockHandler[] = [];
+    _actionHandlers: MockHandler[] = [];
+    command = vi.fn();
+    event = vi.fn((pattern: string, handler: Function) => this._eventHandlers.push({ pattern, handler }));
+    action = vi.fn((pattern: string | RegExp, handler: Function) => this._actionHandlers.push({ pattern, handler }));
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    client = sharedSlack.client;
+  }
+  return { App: MockApp };
+});
+
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:child_process')>()),
+  spawn: vi.fn(),
+}));
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+const silentLog = () => {};
+
+function processWith(stdout: string): any {
+  const process = new EventEmitter() as any;
+  process.stdout = new EventEmitter();
+  process.stderr = new EventEmitter();
+  process.kill = vi.fn();
+  queueMicrotask(() => {
+    process.stdout.emit('data', Buffer.from(stdout));
+    process.emit('close', 0);
+  });
+  return process;
+}
+
+function getMentionHandler(surface: SlackSurface): Function {
+  const found = (surface.getApp() as any)._eventHandlers.find((entry: MockHandler) => entry.pattern === 'app_mention');
+  if (!found) throw new Error('app_mention handler not registered');
+  return found.handler;
+}
+
+function recordingHarnessDriver(prompts: Array<{ kind: 'start' | 'append'; sessionId: string; prompt: string }>): HarnessSessionDriver {
+  let nextSession = 0;
+  return {
+    harness: 'recording-harness',
+    supportsSessionContinuity: false,
+    start: (prompt: string) => {
+      const sessionId = `recording-session-${++nextSession}`;
+      prompts.push({ kind: 'start', sessionId, prompt });
+      return { command: 'agent', args: ['--print', prompt], sessionId };
+    },
+    append: (_sessionId: string, prompt: string) => {
+      const sessionId = `recording-session-${++nextSession}`;
+      prompts.push({ kind: 'append', sessionId, prompt });
+      return { command: 'agent', args: ['--print', prompt], sessionId };
+    },
+  };
+}
+
+describe('E2E: Slack same-channel interleaving contamination regression', () => {
+  let adapter: SQLiteAdapter;
+  let repo: ConversationRepository;
+  let workingDir: string;
+  let surface: SlackSurface;
+  let prompts: Array<{ kind: 'start' | 'append'; sessionId: string; prompt: string }>;
+  let commands: SurfaceCommand[];
+
+  beforeEach(async () => {
+    mockSpawn.mockReset();
+    mockSpawn.mockImplementation(() => processWith('acknowledged'));
+    sharedSlack.client.auth.test.mockClear();
+    sharedSlack.client.chat.postMessage.mockClear();
+    sharedSlack.client.chat.update.mockClear();
+    sharedSlack.client.chat.delete.mockClear();
+    sharedSlack.client.files.uploadV2.mockClear();
+
+    adapter = await SQLiteAdapter.create(':memory:');
+    repo = new ConversationRepository(adapter, { info: silentLog, warn: silentLog, error: silentLog });
+    workingDir = mkdtempSync(join(tmpdir(), 'slack-thread-interleaving-'));
+    prompts = [];
+    commands = [];
+  });
+
+  afterEach(async () => {
+    await surface?.stop();
+    adapter.close();
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  async function startSurface(): Promise<void> {
+    surface = new SlackSurface({
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+      signingSecret: 'test-secret',
+      channelId: 'C-SAME-CHANNEL',
+      lobbyChannelId: 'C-SAME-CHANNEL',
+      defaultRepoUrl: 'https://github.com/example/repo.git',
+      workingDir,
+      conversationRepo: repo,
+      enableImmediateAck: false,
+      planningHeartbeatIntervalSeconds: 0,
+      log: silentLog,
+      harnessPresets: { recording: { tool: 'recording-harness' } },
+      defaultHarnessPreset: 'recording',
+      harnessSessionDriverFactory: () => recordingHarnessDriver(prompts),
+    });
+    await surface.start(async (command) => { commands.push(command); });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  async function mention(text: string, ts: string, threadTs?: string) {
+    const say = vi.fn().mockResolvedValue({ ts: `${ts}-reply` });
+    await getMentionHandler(surface)({
+      event: {
+        text: `<@UBOT> ${text}`,
+        ts,
+        thread_ts: threadTs,
+        user: 'U_PROOF',
+        channel: 'C-SAME-CHANNEL',
+      },
+      say,
+    });
+    return say;
+  }
+
+  it('keeps two same-channel persisted threads isolated across interleaved turns despite an empty-channelId legacy row', async () => {
+    repo.saveConversation(
+      'thread-A',
+      [
+        { role: 'user', content: 'LEGACY silent-catch scope from a different Slack thread' },
+        { role: 'assistant', content: 'LEGACY unrelated YAML draft denial' },
+      ],
+      null,
+      false,
+    );
+    expect(repo.loadConversation('thread-A')?.channelId).toBe('');
+
+    await startSurface();
+
+    const sayA1 = await mention('A asks about CodeRabbit audit planning', 'thread-A');
+    const sayB1 = await mention('B asks about Slack-bot-icon scope', 'thread-B');
+    const sayA2 = await mention('A follow-up: keep this on CodeRabbit only', 'thread-A-turn-2', 'thread-A');
+
+    expect(sayA1).toHaveBeenCalledWith(expect.objectContaining({ thread_ts: 'thread-A' }));
+    expect(sayB1).toHaveBeenCalledWith(expect.objectContaining({ thread_ts: 'thread-B' }));
+    expect(sayA2).toHaveBeenCalledWith(expect.objectContaining({ thread_ts: 'thread-A' }));
+
+    expect(prompts).toHaveLength(3);
+    const [aFirst, bFirst, aSecond] = prompts;
+
+    expect(aFirst.prompt).toContain('A asks about CodeRabbit audit planning');
+    expect(aFirst.prompt).not.toContain('LEGACY silent-catch scope');
+    expect(aFirst.prompt).not.toContain('LEGACY unrelated YAML draft denial');
+    expect(aFirst.prompt).not.toContain('Slack-bot-icon scope');
+
+    expect(bFirst.prompt).toContain('B asks about Slack-bot-icon scope');
+    expect(bFirst.prompt).not.toContain('CodeRabbit audit planning');
+    expect(bFirst.prompt).not.toContain('LEGACY silent-catch scope');
+
+    expect(aSecond.prompt).toContain('A asks about CodeRabbit audit planning');
+    expect(aSecond.prompt).toContain('A follow-up: keep this on CodeRabbit only');
+    expect(aSecond.prompt).toContain('acknowledged');
+    expect(aSecond.prompt).not.toContain('B asks about Slack-bot-icon scope');
+    expect(aSecond.prompt).not.toContain('LEGACY silent-catch scope');
+
+    const threadA = repo.loadConversation('thread-A');
+    const threadB = repo.loadConversation('thread-B');
+    expect(threadA).not.toBeNull();
+    expect(threadB).not.toBeNull();
+    // The legacy row itself remains an old append-only persistence artifact;
+    // the regression property here is that it is not loaded into the live
+    // PlanConversation prompt and does not pick up thread B's history.
+    expect(JSON.stringify(threadA!.messages)).toContain('A follow-up: keep this on CodeRabbit only');
+    expect(JSON.stringify(threadA!.messages)).not.toContain('Slack-bot-icon scope');
+    expect(JSON.stringify(threadB!.messages)).toContain('Slack-bot-icon scope');
+    expect(JSON.stringify(threadB!.messages)).not.toContain('CodeRabbit audit planning');
+  });
+});


### PR DESCRIPTION
## Summary

The 2026-08-05 outage shape was interleaved turns across same-channel Slack planning threads with persisted sessions.

This adds an e2e regression test that drives the SlackSurface mention handler for two threads in one channel with interleaved turns (thread A, thread B, thread A).

It also seeds a legacy conversation row whose stored channelId is an empty string, the exact shape whose recovery PR #7514's predicate now excludes.

The test asserts each thread's PlanConversation receives only its own history and that replies post back to the originating thread.

## Review Claim

The surfaces suite now fails if two same-channel Slack threads with persisted sessions can ever swap conversation history.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only a test file under `packages/surfaces/src/__tests__/` is added. No production file is edited, so runtime behavior cannot change.

## Slice Rationale

PR #7514's unit test covers the predicate alone. The production incident shape — interleaved multi-thread flow plus a legacy blank-channelId row — needs its own end-to-end fence, kept apart from the audit-report slice below it in this stack.

## Non-goals

- No production code changes.
- No fix for the residual contamination mechanism the stacked audit report names; a follow-up workflow owns any fix.
- No coverage for other package suites.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
