### PR TITLE
[CI regression: d19a0f4-playwright-1-of-9](1) Drop duplicated launch-dispatch-stuck-lease shard entries so each spec has one owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,10 +601,6 @@ jobs:
               e2e/launch-dispatch-stuck-lease-cap.spec.ts
               e2e/embedded-terminal-pty.spec.ts
               e2e/keyboard-navigation.spec.ts
-          - name: launch-dispatch-stuck-lease
-            files: >-
-              e2e/launch-dispatch-stuck-lease-storm.spec.ts
-              e2e/launch-dispatch-stuck-lease-cap.spec.ts
           - name: 2-of-9
             files: >-
               e2e/claude-planning-preset-visual-proof.spec.ts
@@ -633,8 +629,6 @@ jobs:
             files: >-
               e2e/autofix-worker-ui.spec.ts
               e2e/orphan-relaunch.spec.ts
-              e2e/launch-dispatch-stuck-lease-storm.spec.ts
-              e2e/launch-dispatch-stuck-lease-cap.spec.ts
               e2e/gap-recovery-bench.spec.ts
               e2e/planning-chat-send-long-deadline.spec.ts
               e2e/system-setup-visual-proof.spec.ts
@@ -668,13 +662,7 @@ jobs:
               e2e/gui-owner-auto-bootstrap.spec.ts
               e2e/start-ready-daemon-owner.spec.ts
               e2e/ui-delta-timeline.spec.ts
-              e2e/launch-dispatch-stuck-lease-cap.spec.ts
-              e2e/launch-dispatch-stuck-lease-storm.spec.ts
               e2e/workers-surface.spec.ts
-          - name: launch-dispatch-stuck-lease
-            files: >-
-              e2e/launch-dispatch-stuck-lease-cap.spec.ts
-              e2e/launch-dispatch-stuck-lease-storm.spec.ts
           - name: terminal-garbling
             files: >-
               e2e/planning-terminal-live-model.proof.spec.ts
@@ -682,10 +670,6 @@ jobs:
               e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts
               e2e/planning-terminal-expand-collapse-garble-repro.spec.ts
               e2e/task-terminal-drawer-minimize-garble-repro.spec.ts
-          - name: launch-dispatch-stuck-lease
-            files: >-
-              e2e/launch-dispatch-stuck-lease-storm.spec.ts
-              e2e/launch-dispatch-stuck-lease-cap.spec.ts
 
     name: playwright / ${{ matrix.name }}
 


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=d19a0f4af741226c3edb9509e2768529bf97fef9; job=playwright / 1-of-9 -->

CI job `playwright / 1-of-9` first went red on default-branch commit d19a0f4af741226c3edb9509e2768529bf97fef9 and stayed red through a700d6ae7476e3611226d86d17e2138daa99eb33.

The Playwright shard matrix carried three extra `launch-dispatch-stuck-lease` entries whose specs already belong to the regular numbered shards.

The shard-inventory guard fails every Playwright shard job when any spec has more than one shard owner, so those duplicated entries kept the matrix red.

This slice drops the three duplicated entries. Every spec keeps exactly one shard owner and the guard passes again.

## Review Claim

Dropping the three duplicated `launch-dispatch-stuck-lease` matrix entries restores a single shard owner for every CI-run Playwright spec, and changes nothing else in CI.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only `.github/workflows/ci.yml` changes, and only by dropping the three duplicated matrix entries; every spec they named still runs in its original numbered shard, so no coverage is lost.

## Slice Rationale

The failing job's root cause is confined to the shard matrix, so the whole repair is one tooling-policy slice; the guard's incident note is a proof-unit file and follows as its own slice.

## Non-goals

- No spec file changes and no change to which specs CI covers.
- No change to `scripts/repro/repro-ci-playwright-shard-inventory.mjs`; its incident note is generalized in the next slice.
- No job re-runs and no weakening of the shard-inventory guard.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs` exits 0 on this branch (61 CI-owned specs, one shard owner each) and exits 1 on master.
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-1-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/visual-proof.spec.ts e2e/edit-task-command.spec.ts e2e/headless-thundering-herd.spec.ts e2e/launching-stall-watchdog.spec.ts e2e/launch-dispatch-stuck-lease-storm.spec.ts e2e/launch-dispatch-stuck-lease-cap.spec.ts e2e/embedded-terminal-pty.spec.ts e2e/keyboard-navigation.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` exited 0 in the workflow's verification task on this exact tree (commit fa3019194, same tree as this stack's head).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, but reverting restores the duplicated shard entries and turns the Playwright shard jobs red again.
- Revert command: `git revert <merge-sha-of-this-pr>`
- Post-revert steps: None
- Data migration? No

</details>
