### PR TITLE
[Autofix Retry Dispatcher Gap](1) Add a repro proving invoker:retry-task has no owner-worker dispatcher

### DIFF
--- a/packages/app/src/__tests__/owner-worker-mutation-dispatcher-completeness.test.ts
+++ b/packages/app/src/__tests__/owner-worker-mutation-dispatcher-completeness.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+const MAIN = path.resolve(__dirname, '..', 'main.ts');
+
+// Incident 2026-08-06: the recovery worker's tick calls
+// submitRegisteredOwnerWorkerMutation(...) directly (not through any IPC/GUI
+// translation layer), so every channel it submits through needs a real
+// `workflowMutationDispatcher.set(...)` entry in the standalone owner
+// startup block. The bare-retry channel never got one — every recovery
+// tick threw "No workflow mutation dispatcher registered for
+// invoker:retry-task" and no failed task was ever auto-fixed. A prior PR
+// (#6808) claimed to add this registration plus a regression test, but
+// merged as a no-op (identical tree to its parent commit).
+const AUTO_FIX_BARE_RETRY_CHANNEL = 'invoker:retry-task';
+const AUTO_FIX_COMMAND_CHANNEL = 'invoker:fix-with-agent';
+
+describe('standalone owner worker mutation dispatcher completeness', () => {
+  // REPRO: reproduces the missing invoker:retry-task dispatcher registration.
+  // Currently fails (as expected) because AUTO_FIX_BARE_RETRY_CHANNEL has no
+  // workflowMutationDispatcher.set(...) entry. The fix slice removes `.fails`.
+  it.fails('registers a dispatcher for every channel the auto-fix recovery worker submits through', () => {
+    const source = readFileSync(MAIN, 'utf8');
+
+    const guardIdx = source.indexOf('if (standaloneMode && messageBus) {');
+    expect(guardIdx, 'standalone owner mutation-routing guard not found').toBeGreaterThan(-1);
+    const openBraceIdx = source.indexOf('{', guardIdx);
+    let closeBraceIdx = -1;
+    let depth = 0;
+    for (let idx = openBraceIdx; idx < source.length; idx += 1) {
+      if (source[idx] === '{') depth += 1;
+      else if (source[idx] === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          closeBraceIdx = idx;
+          break;
+        }
+      }
+    }
+    expect(closeBraceIdx, 'standalone owner mutation-routing guard closing brace not found').toBeGreaterThan(-1);
+    const registrationBlock = source.slice(openBraceIdx, closeBraceIdx);
+
+    // A handler is registered either by the channel's literal string or by
+    // importing and passing its exported constant identifier — both forms
+    // resolve to the same runtime channel name.
+    const isRegistered = (channel: string, constantName: string): boolean =>
+      registrationBlock.includes(`workflowMutationDispatcher.set('${channel}'`)
+      || registrationBlock.includes(`workflowMutationDispatcher.set(${constantName}`);
+
+    expect(
+      isRegistered(AUTO_FIX_BARE_RETRY_CHANNEL, 'AUTO_FIX_BARE_RETRY_CHANNEL'),
+      `standalone owner startup must register a workflowMutationDispatcher handler for '${AUTO_FIX_BARE_RETRY_CHANNEL}' `
+        + '(the auto-fix recovery worker submits its free bare retry through this channel directly, '
+        + 'bypassing any IPC/GUI translation layer)',
+    ).toBe(true);
+
+    expect(
+      isRegistered(AUTO_FIX_COMMAND_CHANNEL, 'AUTO_FIX_COMMAND_CHANNEL'),
+      `standalone owner startup must register a workflowMutationDispatcher handler for '${AUTO_FIX_COMMAND_CHANNEL}' `
+        + '(the auto-fix recovery worker submits its AI fix attempts through this channel directly, '
+        + 'bypassing any IPC/GUI translation layer)',
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Auto-fix has been silently broken. Every recovery-worker cycle threw an error on its very first step, before touching any failed task.

The cause: `packages/app/src/main.ts` has no handler wired up for a channel name the worker depends on. This has been true since the feature shipped.

This PR adds the proof: a test marked `it.fails`, so it passes today against the broken code. The next PR turns it into a normal test once the handler exists.

## Review Claim

Approve one new text-based test file proving `packages/app/src/main.ts` has no handler wired up for the channel name `invoker:retry-task`, which the auto-fix recovery worker depends on.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Adds one new test file only; touches no product code. The test is marked `it.fails`, so CI stays green only while the underlying gap is real — it turns red the moment someone closes the gap without also updating this file, which is exactly the signal the next PR needs.

## Slice Rationale

The defect is demonstrated on its own here, reviewable independently of the change that closes it.

## Non-goals

- No product code changes.
- Does not close the gap (next PR).
- Does not cover the GUI-mode owner startup path, which has a related but separately-scoped gap outside what this incident proved.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- src/__tests__/owner-worker-mutation-dispatcher-completeness.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
