### PR TITLE
[Wire Orphaned Required Suites](1) Wire 5 orphaned required/ test scripts into master-push CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,6 +404,12 @@ jobs:
           - name: PR Babysit Harness
             command: bash scripts/test-suites/required/28-pr-babysit-harness.sh
             runner_label: Runner_2_4_core
+          - name: PR Authoring Guardrails
+            command: bash scripts/test-suites/required/11-pr-authoring-guardrails.sh
+            runner_label: Runner_2_4_core
+          - name: Mergify Admin Requeue
+            command: bash scripts/test-suites/required/12-mergify-admin-requeue.sh
+            runner_label: Runner_2_4_core
 
     name: required-fast / ${{ matrix.name }}
 

--- a/scripts/test-suites/proof-e2e.manifest
+++ b/scripts/test-suites/proof-e2e.manifest
@@ -13,3 +13,6 @@ required/23b-fix-intent-cancellation-stale-ssh-metadata.sh
 required/08-electron-preprovision-repro.sh
 required/23a-recreate-task-queue-authority.sh
 required/29-bench-workflow-submission-storm.sh
+required/24-start-running-mece-repros.sh
+required/27-reset-assertions-proof.sh
+required/30-headless-query-timeout-guard.sh

--- a/scripts/test-suites/required/27-reset-assertions-proof.sh
+++ b/scripts/test-suites/required/27-reset-assertions-proof.sh
@@ -4,9 +4,4 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
 
-if [[ "${INVOKER_TEST_ALL_PROOF:-0}" == "1" ]]; then
-  echo "SKIP: required-fast runs reset assertion repro separately."
-  exit 0
-fi
-
 exec bash scripts/repro/prove-reset-assertions.sh


### PR DESCRIPTION
## Summary

Five checks under `scripts/test-suites/required/` existed on disk but ran nowhere: not in CI, not in any local dev flow.

Three were pure e2e/mock-DB checks (see Test Plan for exact names). They now join the manifest their siblings already use.

The other two were only reachable from a local, manual dev loop, never from CI. They now join the neighboring job matrix that already runs their siblings.

One of the three also had an early-exit branch, on the false premise another job covered it. Nothing does, so that branch is gone.

## Review Claim

Approve wiring these five checks into the two places their siblings already live, so all five execute at HEAD of every master push, same as the checks beside them.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Every added line points at a script that already exists, is syntactically valid, and was run locally before this PR (see Test Plan). No script content changed except deleting `27`'s dead guard branch — the executable path it always took stays byte-for-byte the same.

## Slice Rationale

One conceptual change — closing a coverage gap — landed as one diff across the two config files plus the one script the gap analysis found broken.

## Non-goals

- Does not fix any test that fails once wired in. `12-mergify-admin-requeue.sh` currently fails locally on `repro-babysit-pr-body-human-split.sh` (a `resolve_workflow_for_pr` timeout) — that is a pre-existing defect this PR surfaces, not one it introduces or hides.
- Does not touch the ~230 other files under `scripts/repro/` that aren't referenced by any `required/` wrapper — that's a separate curation effort.
- Does not add `23-fix-intent-repros.sh` to the manifest: its merge-queue-aware scenarios 1-3 already run individually as `23a`/`23b`/`23c`, already in the manifest; adding the bundle too would just re-run the same proofs.
- Does not change any existing manifest entry or job matrix leg.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses
- [x] Every `proof-e2e.manifest` entry resolves to a file on disk (verified with a small script mirroring `run-all-tests.sh`'s own check)
- [x] `bash scripts/test-suites/required/24-start-running-mece-repros.sh` — exit 0
- [x] `INVOKER_TEST_ALL_PROOF=1 bash scripts/test-suites/required/27-reset-assertions-proof.sh` — exit 0, runs for real instead of self-skipping
- [x] `bash scripts/test-suites/required/30-headless-query-timeout-guard.sh` — exit 0
- [x] `bash scripts/test-suites/required/11-pr-authoring-guardrails.sh` — exit 0
- [x] `bash scripts/test-suites/required/12-mergify-admin-requeue.sh` — fails today on `repro-babysit-pr-body-human-split.sh` (pre-existing; see Non-goals)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the five checks to running nowhere.
- Data migration? No

</details>
