### PR TITLE
[CodeRabbit audit: PR #7224 — validate findings against master and fix what holds](1) Audit verdict report: single finding invalid on master, no fixes

### DIFF
--- a/docs/audits/coderabbit/pr-7224.md
+++ b/docs/audits/coderabbit/pr-7224.md
@@ -1,0 +1,25 @@
+# CodeRabbit Audit for PR #7224
+
+Source: `gh api repos/Neko-Catpital-Labs/Invoker/pulls/7224/comments --paginate`
+
+Baseline: current `origin/master` after fetching on 2026-08-06.
+
+## Finding 1: Guard normal quit cleanup after signal shutdown starts
+
+Quoted finding:
+
+> Guard the normal quit cleanup when the signal handler already owns shutdown. For `owner-serve`, `runHeadless(cliArgs, headlessDeps)` blocks while `headlessOwnerServe` polls, so a SIGTERM/SIGINT can start signal cleanup asynchronously. The `finally` block then enters `runHeadlessShutdownCleanup` regardless, so it can call `persistence.requeueRunningWorkflowMutationIntents()`, `persistence.close()`, `writerLock.release()`, and `messageBus.disconnect()` a second time. Guard the final cleanup and `process.exit(exitCode)` so only the first shutdown path runs cleanup.
+
+Severity: Major
+
+Verdict: invalid
+
+Evidence:
+
+The finding was concrete, but the flagged problem no longer exists on current `origin/master`. In `packages/app/src/main.ts:1065`, `headlessSignalShutdownInProgress` is initialized before the signal handlers are registered. The SIGTERM/SIGINT handler returns immediately when the flag is already set at `packages/app/src/main.ts:1068`, and the first signal path sets it to `true` at `packages/app/src/main.ts:1069` before calling `runHeadlessShutdownCleanup(...)` at `packages/app/src/main.ts:1071`.
+
+The normal `finally` path now respects the same ownership flag. `packages/app/src/main.ts:2036` enters `finally`, `packages/app/src/main.ts:2037` checks `if (!headlessSignalShutdownInProgress)`, and only that branch sets the flag, runs `runHeadlessShutdownCleanup('Application quit')`, and calls `process.exit(exitCode)` at `packages/app/src/main.ts:2038` through `packages/app/src/main.ts:2040`. If signal cleanup already started, the normal cleanup and normal exit path are skipped, so the duplicate teardown described by CodeRabbit is fixed on master.
+
+## Fixes applied
+
+Fixes applied: none - all findings invalid.


### PR DESCRIPTION
## Summary

Re-verify the inline CodeRabbit review finding on merged PR #7224 against current master and record the verdict with evidence.

The one concrete finding warned that `owner-serve` shutdown teardown could run twice when a SIGTERM/SIGINT arrives during a normal quit.

Current master already guards both shutdown paths behind the `headlessSignalShutdownInProgress` guard flag, so the finding is recorded as invalid with file:line evidence.

No product code changes ship here. The committed report states `Fixes applied: none - all findings invalid`.

## Review Claim

Approve the committed audit report `docs/audits/coderabbit/pr-7224.md`, which judges CodeRabbit's PR #7224 finding invalid against current master with file:line evidence and records that no fixes were needed.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This slice adds one new markdown report under `docs/audits/` and touches no product code, tests, or tooling, so it cannot alter runtime behavior.

## Slice Rationale

Validate and fix form one review claim: the resolution of PR #7224's CodeRabbit findings. The single finding was judged invalid, so the entire resolution is this one docs slice; separating the verdict from its empty fix outcome would double the review surface without adding clarity.

## Non-goals

- No product code changes; the audited shutdown-teardown concern is already fixed on master.
- No re-litigation of CodeRabbit style opinions that are not concrete inline findings.
- No audits of other PRs; each audited PR gets its own workflow and stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `test -f docs/audits/coderabbit/pr-7224.md`
- [ ] `grep -E "^Verdict: (valid|invalid)$" docs/audits/coderabbit/pr-7224.md`
- [ ] `grep -F "Fixes applied" docs/audits/coderabbit/pr-7224.md`
- [ ] `git diff --name-only origin/master...HEAD` lists only `docs/audits/coderabbit/pr-7224.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge or squash sha>`
- Post-revert steps: None
- Data migration? No

</details>
