### PR TITLE
[Promote Fast Required Checks](1) Promote 4 fast core state-machine checks to required

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,6 +24,14 @@ queue_rules:
     # worker-registry + SSH executor drift). "UI Vitest" runs only @invoker/ui
     # and IS required: it holds the UI component guards, so a UI regression
     # cannot merge even when the diff still type-checks.
+    # required-fast / Merge Gate Concurrency Repro, Launch Dispatch Queue
+    # Repro, Start Running MECE Repros, and Branch Carry Forward guard core
+    # task/workflow state-machine and dispatch behavior, run in parallel with
+    # the checks above (~1 min each), and have been green for 5+ consecutive
+    # master runs — promoted to required at effectively no queue-wait cost.
+    # required-fast / Reset Rulebook Repro was deliberately left non-required:
+    # same core-behavior class, but 6-13 min per run would materially slow
+    # every merge.
     merge_conditions: &required_checks
       - check-success = build-artifacts
       - check-success = quality / Dependency Cruise
@@ -31,6 +39,10 @@ queue_rules:
       - check-success = quality / TypeScript Types
       - check-success = required-fast / Guardrails
       - check-success = required-fast / Submit Workflow Chain
+      - check-success = required-fast / Merge Gate Concurrency Repro
+      - check-success = required-fast / Launch Dispatch Queue Repro
+      - check-success = required-fast / Start Running MECE Repros
+      - check-success = required-fast / Branch Carry Forward
       - check-success = UI Vitest
       - "#review-threads-unresolved = 0"
 


### PR DESCRIPTION
## Summary

Four core checks already ran on every PR and master push, but a red result never blocked anything from landing.

They cover task/workflow dispatch and state-machine behavior, take about a minute each, and have been green for 5 consecutive master runs.

This adds them to Mergify's required list. A fifth check in the same class runs 6-13 minutes per run, so it stays out for now.

## Review Claim

Approve adding four green, ~1-minute checks to Mergify's `merge_conditions`, so a regression in core dispatch/state-machine behavior blocks the queue instead of merging silently.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Pure config: four `check-success` lines added to an existing list. No script changed. All four checks already run today with no schedule or trigger change — this only changes whether their result blocks a merge. Confirmed locally: all four pass (see Test Plan), and `.mergify.yml` validates against Mergify's schema.

## Slice Rationale

One conceptual change — narrowing the required-check gap for core behavior — landed as a single config diff.

## Non-goals

- Does not add the slower fifth check in this class (6-13 min); that's a separate cost/benefit call.
- Does not change anything about the checks that stay non-required (Vitest Workspace, e2e-proof, Playwright) — those remain red-on-master and out of scope here.
- Does not modify any check's own logic or script content.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `mergify config validate` — configuration file is valid
- [x] `python3 -c "import yaml; yaml.safe_load(open('.mergify.yml'))"` — parses, required-check list confirmed
- [x] `bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh` — exit 0
- [x] `bash scripts/test-suites/required/25-launch-dispatch-queue-handoff-repro.sh` — exit 0
- [x] `bash scripts/test-suites/required/18-start-running-mece-repros.sh` — exit 0
- [x] `bash scripts/test-suites/required/16-branch-carry-forward.sh` — exit 0
- [x] All four checks green across the last 5 completed master CI runs (checked via `gh run view --json jobs`)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the four checks to non-blocking.
- Data migration? No

</details>
