### PR TITLE
Fix admin-bypass repair retry cap: record before submit, not after

### DIFF
--- a/scripts/mergify_admin_requeue_repairer.py
+++ b/scripts/mergify_admin_requeue_repairer.py
@@ -193,8 +193,13 @@ class AdminBypassRepairer:
             head_sha=start_head,
             plan_name=plan.plan_name,
         )
-        async_repair.submit_async_repair_plan(plan)
+        # Record before submitting: once submitted, the workflow is real and
+        # running whether or not this process survives another instruction.
+        # Recording first means a broken ledger write (e.g. disk full) raises
+        # here and skips the submission entirely, instead of leaving a real,
+        # running repair permanently invisible to the retry-cap count.
         self.ledger.record("repair-check", pr.number, start_head, check_name, now)
+        async_repair.submit_async_repair_plan(plan)
         return self.blocked_outcome("submitted", check_name, start_head, start_head)
 
     def repair_conflict(self, pr: PrSnapshot, reason: str, now: int | None = None) -> RepairOutcome:
@@ -213,8 +218,10 @@ class AdminBypassRepairer:
             head_sha=start_head,
             plan_name=plan.plan_name,
         )
-        async_repair.submit_async_repair_plan(plan)
+        # See repair_check: record before submitting so a broken ledger write
+        # blocks the submission instead of orphaning a real, running repair.
         self.ledger.record("conflict-repair", pr.number, start_head, f"conflict:{pr.number}", now)
+        async_repair.submit_async_repair_plan(plan)
         return self.blocked_outcome("submitted", check_name, start_head, start_head)
 
     def repair_bot_thread(self, pr: PrSnapshot, thread_id: str, now: int | None = None) -> RepairOutcome:
@@ -230,6 +237,8 @@ class AdminBypassRepairer:
             head_sha=start_head,
             plan_name=plan.plan_name,
         )
-        async_repair.submit_async_repair_plan(plan)
+        # See repair_check: record before submitting so a broken ledger write
+        # blocks the submission instead of orphaning a real, running repair.
         self.ledger.record("repair-bot-thread", pr.number, start_head, thread_id, now)
+        async_repair.submit_async_repair_plan(plan)
         return self.blocked_outcome("submitted", thread_id, start_head, start_head)

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -394,7 +394,12 @@ Failing checks
         self.assertEqual(result.end_head, HEAD)
         self.assertEqual(ledger.count("conflict-repair", item.number, item.head_ref_oid, f"conflict:{item.number}"), 1)
 
-    def test_repair_conflict_does_not_record_ledger_when_submission_fails(self):
+    def test_repair_conflict_records_ledger_before_submitting_so_a_failed_submission_is_still_counted(self):
+        # The ledger row is written before submission (not after) so a broken
+        # ledger write can never leave a real, running repair uncounted. The
+        # cost is the mirror case here: if submission itself fails, the
+        # attempt is still counted -- an acceptable trade since submission
+        # failures are rare and non-silent, unlike a lost ledger write.
         item = pr(2661, merge_state="DIRTY", latest=mergify())
         ledger = self.ledger()
         repairer = self.repairer(object(), ledger)
@@ -404,9 +409,9 @@ Failing checks
         ):
             with self.assertRaises(RuntimeError):
                 repairer.repair_conflict(item, "GitHub reports merge conflict", 1)
-        self.assertEqual(ledger.count("conflict-repair", item.number, item.head_ref_oid, f"conflict:{item.number}"), 0)
+        self.assertEqual(ledger.count("conflict-repair", item.number, item.head_ref_oid, f"conflict:{item.number}"), 1)
 
-    def test_repair_check_ledger_row_not_written_when_submission_fails(self):
+    def test_repair_check_records_ledger_before_submitting_so_a_failed_submission_is_still_counted(self):
         item = pr(2662, latest=mergify())
         ledger = self.ledger()
         repairer = self.repairer(object(), ledger)
@@ -417,7 +422,7 @@ Failing checks
             ):
                 with self.assertRaises(RuntimeError):
                     repairer.repair_check(item, "PR Body", 1)
-        self.assertEqual(ledger.count("repair-check", item.number, item.head_ref_oid, "PR Body"), 0)
+        self.assertEqual(ledger.count("repair-check", item.number, item.head_ref_oid, "PR Body"), 1)
 
     def test_candidate_stack_includes_unlabeled_upper_prs(self):
         def raw(number, base, head, labels):

--- a/scripts/test_mergify_admin_requeue_repairer.py
+++ b/scripts/test_mergify_admin_requeue_repairer.py
@@ -1,0 +1,108 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.mergify_admin_requeue_gh_executor import AdminBypassGhExecutor
+from scripts.mergify_admin_requeue_logger import AdminBypassLogger
+from scripts.mergify_admin_requeue_model import Ledger, PrSnapshot
+from scripts.mergify_admin_requeue_repairer import AdminBypassRepairer
+
+HEAD = "c2532d229dbed2fd57419698c48d973001c78e9e"
+CHECK_NAME = "quality / TypeScript Types"
+
+
+def make_pr(number=2606):
+    return PrSnapshot(
+        number=number,
+        title=f"PR {number}",
+        body="",
+        url=f"https://github.com/owner/repo/pull/{number}",
+        state="OPEN",
+        is_draft=False,
+        base_ref_name="master",
+        head_ref_name=f"stack/{number}",
+        head_ref_oid=HEAD,
+        merge_state_status="CLEAN",
+        mergeable="MERGEABLE",
+        labels=frozenset({"admin-bypass"}),
+        checks={},
+        review_threads=(),
+        latest_mergify=None,
+    )
+
+
+class RepairCheckLedgerOrderingTests(unittest.TestCase):
+    """Covers AdminBypassRepairer.repair_check's submit-then-record sequence.
+
+    No test previously exercised this execution path at all -- every existing
+    mergify_admin_requeue test seeds a Ledger directly and asserts on the
+    planner's resulting decision, never on what repair_check itself does when
+    submission and ledger bookkeeping disagree. That gap is why PR #7560's
+    "PR Body" check retried 11+ times on 2026-08-06 instead of stopping at the
+    3-attempt cap: the DO1 disk filled to 0 bytes free, Ledger.record's
+    unguarded append write started raising OSError(ENOSPC), and because
+    repair_check submits the real Invoker workflow *before* recording the
+    attempt, every write failure left a real, running repair permanently
+    invisible to repair_attempt_count_excluding_infra_crash's ledger count.
+    """
+
+    def ledger(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        return Ledger(Path(tmp.name) / "ledger.jsonl")
+
+    def repairer(self, ledger):
+        gh = object()  # no pr_detail attribute -> terminal_repair_outcome is a no-op
+        logger = AdminBypassLogger()
+        executor = AdminBypassGhExecutor(gh, ledger, logger, "owner/repo")
+        return AdminBypassRepairer(gh, executor, logger, ledger, "owner/repo")
+
+    def test_a_submitted_repair_is_always_countable_by_the_retry_cap_ledger(self):
+        ledger = self.ledger()
+        pr = make_pr()
+        repairer = self.repairer(ledger)
+
+        submitted = []
+        with mock.patch(
+            "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
+            side_effect=lambda plan: submitted.append(plan),
+        ):
+            repairer.repair_check(pr, CHECK_NAME, now=1000)
+
+        self.assertEqual(len(submitted), 1, "expected exactly one real submission")
+        self.assertEqual(
+            ledger.count("repair-check", pr.number, HEAD, CHECK_NAME),
+            1,
+            "a submitted repair attempt must always be reflected in the retry-cap ledger",
+        )
+
+    def test_a_broken_ledger_write_blocks_submission_instead_of_orphaning_it(self):
+        ledger = self.ledger()
+        pr = make_pr()
+        repairer = self.repairer(ledger)
+
+        def raise_enospc(*args, **kwargs):
+            raise OSError(28, "No space left on device")
+
+        submitted = []
+        with mock.patch(
+            "scripts.mergify_admin_requeue_repairer.async_repair.submit_async_repair_plan",
+            side_effect=lambda plan: submitted.append(plan),
+        ), mock.patch.object(ledger, "record", side_effect=raise_enospc):
+            with self.assertRaises(OSError):
+                repairer.repair_check(pr, CHECK_NAME, now=1000)
+
+        self.assertEqual(
+            submitted,
+            [],
+            "must not submit a repair to Invoker when the attempt can't be recorded -- "
+            "otherwise the workflow runs but is invisible to the retry cap forever",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The admin-bypass repair pipeline hands a real Invoker workflow off, then writes a local ledger entry counting that attempt. It did those two things in the wrong order.

Tonight DO1's disk filled to 0 bytes free. The ledger write failed right after a repair workflow had already gone out. That workflow became invisible to the 3-attempt cap, so PR #7560's "PR Body" check kept getting relaunched every cycle instead of stopping — 11+ times and counting.

This swaps the order: record the attempt first, hand off the workflow second. A broken ledger write now blocks the handoff instead of silently orphaning it.

## Review Claim

Approve reordering `ledger.record()` before `submit_async_repair_plan()` at all three `AdminBypassRepairer` call sites, plus the new/updated tests proving the old order is unsafe.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Pure Python, a two-line reorder repeated at three call sites plus test-only changes — no schema, API, or config changes. The full `mergify_admin_requeue` test suite (166 tests) passes. Worst case of the new ordering is a handoff that fails right after a successful record — that just overcounts one cap slot, which is safe; the old ordering's failure mode was an unbounded loop, which is not.

## Slice Rationale

The ordering fix and its test coverage are inseparable — landing one without the other either ships an unverified behavior change or adds tests for a bug that's already fixed. Kept as a single slice.

## Non-goals

Does not address why DO1's disk filled up (root-caused and fixed separately: 44 stale hourly DB backups, ~25GB reclaimed, the existing Disk Hygiene Reaper worker now runs unblocked). Does not add alerting/observability for ledger write failures beyond making them fail closed.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue scripts.test_mergify_admin_requeue_repairer` — 166 tests, all pass
- [x] `python3 -m unittest scripts.test_mergify_admin_requeue_repairer` in isolation, run against pre-fix code first — one of two tests fails (`test_a_broken_ledger_write_blocks_submission_instead_of_orphaning_it`), proving the bug; passes after the fix

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3c346068d`
- Post-revert steps: None
- Data migration? No

</details>
