### PR TITLE
Add repro proving PR #7488's event-loop-lag test is single-sample and order-fixed

### DIFF
--- a/scripts/repro/repro-coderabbit-pr7488-event-loop-lag-single-sample.sh
+++ b/scripts/repro/repro-coderabbit-pr7488-event-loop-lag-single-sample.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Repro: CodeRabbit finding on PR #7488 — the launch-dispatcher event-loop-lag
+# regression test must not compare a single uncapped sample against a single
+# capped sample taken in a fixed order. JIT warm-up, GC, and CI load can swing
+# either single measurement, and the fixed order can make the capped path
+# look faster just because the runtime already warmed up.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TARGET="packages/app/src/__tests__/launch-dispatcher-topup-event-loop-lag.test.ts"
+
+echo "Repro: launch-dispatcher event-loop-lag test must use paired, order-alternated samples"
+
+if [ ! -f "$TARGET" ]; then
+  echo "[repro] FAIL: missing $TARGET" >&2
+  exit 1
+fi
+
+if grep -q "PAIRED_SAMPLE_COUNT" "$TARGET" \
+  && grep -q "uncappedMedianGapMs" "$TARGET" \
+  && grep -q "cappedMedianGapMs" "$TARGET" \
+  && grep -q "sample % 2 === 0" "$TARGET"; then
+  echo "[repro] PASS: test takes multiple paired samples, alternates measurement order, and compares medians"
+  exit 0
+fi
+
+echo "[repro] FAIL: test still takes one uncapped sample then one capped sample in a fixed order" >&2
+echo "[repro] see CodeRabbit finding on PR #7488" >&2
+exit 1


### PR DESCRIPTION
## Summary

CodeRabbit left a Major inline finding on merged PR #7488: `packages/app/src/__tests__/launch-dispatcher-topup-event-loop-lag.test.ts` compared a single uncapped sample against a single capped sample in a fixed order (uncapped always measured first). JIT warm-up, GC, and CI load can swing either single measurement, and the fixed order can make the capped path look faster just because the runtime already warmed up.

Verdict: valid. Evidence on current master (`a700d6ae7476e3611226d86d17e2138daa99eb33`): `launch-dispatcher-topup-event-loop-lag.test.ts:111` builds one uncapped orchestrator and records one `uncappedMaxGapMs` sample; `:117` builds one capped orchestrator and records one `cappedMaxGapMs` sample; `:125`-`:128` compares them directly with `toBeLessThan`. No repeated sampling, no order alternation, no aggregate.

This PR adds `scripts/repro/repro-coderabbit-pr7488-event-loop-lag-single-sample.sh`, a structural check that fails today because the test still has that single-sample, fixed-order shape. The fix lands in the next PR of this stack (#7654) and makes this repro pass.

## Review Claim

The launch-dispatcher event-loop-lag test's single-sample, fixed-order comparison — the finding CodeRabbit raised on PR #7488 — is still present on current master, proven by an executable repro rather than prose.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Adds one new script under `scripts/repro/`; touches no product or test code, so runtime behavior cannot change.

## Slice Rationale

This PR only proves the finding with an executable repro; the paired-median-sample fix lands in its own slice (#7654) so this diff stays repro-only.

## Non-goals

- No changes to `launch-dispatcher-topup-event-loop-lag.test.ts` or any other test/product code.
- No new `docs/audits/` file — the verdict and evidence live in this PR description.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-coderabbit-pr7488-event-loop-lag-single-sample.sh` — exits 1 (FAIL) on current master, proving the finding is still valid.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit sha>`
- Post-revert steps: None
- Data migration? No

</details>
