### PR TITLE
Stabilize launch-dispatcher lag test with paired median samples

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher-topup-event-loop-lag.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher-topup-event-loop-lag.test.ts
@@ -20,6 +20,7 @@ import { Orchestrator, type PlanDefinition } from '@invoker/workflow-core';
  */
 
 const BURST_TASK_COUNT = 150;
+const PAIRED_SAMPLE_COUNT = 3;
 
 function singleTaskWorkflow(name: string): PlanDefinition {
   return {
@@ -50,6 +51,11 @@ async function measureMaxSyncGapMs(fn: () => void, probeMs = 4): Promise<number>
     clearInterval(timer);
   }
   return maxGapMs;
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
 }
 
 describe('launch-dispatcher topUpReadyLaunches event-loop lag', () => {
@@ -108,25 +114,52 @@ describe('launch-dispatcher topUpReadyLaunches event-loop lag', () => {
   it(
     'stays meaningfully faster: capped startExecution({ limit: 32 }) over the same 150-task ready burst',
     async () => {
-      const uncappedOrchestrator = await buildBurstOrchestrator();
-      const uncappedMaxGapMs = await measureMaxSyncGapMs(() => {
-        const started = uncappedOrchestrator.startExecution();
-        expect(started.length).toBe(BURST_TASK_COUNT);
-      });
+      const uncappedSamples: number[] = [];
+      const cappedSamples: number[] = [];
 
-      const cappedOrchestrator = await buildBurstOrchestrator();
-      const cappedMaxGapMs = await measureMaxSyncGapMs(() => {
-        // 32 matches LaunchDispatcher's default maxLeasesPerPoll
-        // (packages/app/src/launch-dispatcher.ts:106) — this is the exact
-        // call topUpReadyLaunches() now makes.
-        const started = cappedOrchestrator.startExecution({ limit: 32 });
-        expect(started.length).toBe(32);
-      });
+      async function measureUncappedSample(): Promise<void> {
+        const orchestrator = await buildBurstOrchestrator();
+        uncappedSamples.push(
+          await measureMaxSyncGapMs(() => {
+            const started = orchestrator.startExecution();
+            expect(started.length).toBe(BURST_TASK_COUNT);
+          }),
+        );
+      }
+
+      async function measureCappedSample(): Promise<void> {
+        const orchestrator = await buildBurstOrchestrator();
+        cappedSamples.push(
+          await measureMaxSyncGapMs(() => {
+            // 32 matches LaunchDispatcher's default maxLeasesPerPoll
+            // (packages/app/src/launch-dispatcher.ts:106) — this is the exact
+            // call topUpReadyLaunches() now makes.
+            const started = orchestrator.startExecution({ limit: 32 });
+            expect(started.length).toBe(32);
+          }),
+        );
+      }
+
+      for (let sample = 0; sample < PAIRED_SAMPLE_COUNT; sample += 1) {
+        if (sample % 2 === 0) {
+          await measureUncappedSample();
+          await measureCappedSample();
+        } else {
+          await measureCappedSample();
+          await measureUncappedSample();
+        }
+      }
+
+      const uncappedMedianGapMs = median(uncappedSamples);
+      const cappedMedianGapMs = median(cappedSamples);
+
       expect(
-        cappedMaxGapMs,
-        `cappedMaxGapMs=${cappedMaxGapMs}, uncappedMaxGapMs=${uncappedMaxGapMs} (${BURST_TASK_COUNT}-task burst)`,
-      ).toBeLessThan(uncappedMaxGapMs);
+        cappedMedianGapMs,
+        `cappedMedianGapMs=${cappedMedianGapMs}, uncappedMedianGapMs=${uncappedMedianGapMs}, cappedSamples=${cappedSamples.join(
+          ',',
+        )}, uncappedSamples=${uncappedSamples.join(',')} (${BURST_TASK_COUNT}-task burst)`,
+      ).toBeLessThan(uncappedMedianGapMs);
     },
-    30_000,
+    60_000,
   );
 });


### PR DESCRIPTION
## Summary

Fixes the finding proven in the previous PR of this stack (#7653): `launch-dispatcher-topup-event-loop-lag.test.ts` compared a single uncapped sample against a single capped sample in a fixed order.

The comparison now takes three paired samples (`PAIRED_SAMPLE_COUNT = 3`), alternates uncapped-first/capped-first order on each pair, keeps the existing per-run burst-size assertions, and compares `cappedMedianGapMs` against `uncappedMedianGapMs` instead of one fixed-order sample pair.

## Review Claim

The capped-versus-uncapped lag comparison now uses order-alternated paired samples and a median aggregate, fixing the finding proven valid by PR #7653's repro.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the existing spec file changes; no product code is touched, so runtime behavior cannot change.

## Slice Rationale

The repro in #7653 proves exactly this finding; keeping the fix in its own slice on top keeps that diff spec-only and this one focused on the fix.

## Non-goals

- No changes to `LaunchDispatcher` or `Orchestrator` product code.
- No new `docs/audits/` file — the verdict, evidence, and fix record live in these two PR descriptions instead.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-coderabbit-pr7488-event-loop-lag-single-sample.sh` — now exits 0 (PASS).
- [x] `cd packages/app && pnpm test -- launch-dispatcher-topup-event-loop-lag.test.ts` — 2 tests passed.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7653
