### PR TITLE
Add repro proving deleteAllWorkflows() leaves the queue-status UI cache stale

### DIFF
--- a/packages/workflow-core/src/__tests__/queue-status-ui-poll-fast-path.test.ts
+++ b/packages/workflow-core/src/__tests__/queue-status-ui-poll-fast-path.test.ts
@@ -35,4 +35,34 @@ describe('getQueueStatus UI poll fast path', () => {
     expect(second).toBe(first);
     expect(loadAttempt).not.toHaveBeenCalled();
   });
+
+  it('deleteAllWorkflows invalidates a warmed UI-poll cache', () => {
+    const orchestrator = new Orchestrator({
+      persistence: new InMemoryPersistence(),
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 2,
+    });
+
+    orchestrator.loadPlan({
+      name: 'ui-poll-delete-all',
+      baseBranch: 'master',
+      featureBranch: 'feature/ui-poll-delete-all',
+      tasks: [
+        { id: 'a', description: 'A' },
+        { id: 'b', description: 'B', dependencies: ['a'] },
+      ],
+    });
+    orchestrator.startExecution();
+
+    const beforeDelete = orchestrator.getQueueStatus({ refresh: false });
+    expect(beforeDelete.runningCount).toBeGreaterThan(0);
+
+    orchestrator.deleteAllWorkflows();
+
+    const afterDelete = orchestrator.getQueueStatus({ refresh: false });
+    expect(afterDelete).not.toBe(beforeDelete);
+    expect(afterDelete.running).toEqual([]);
+    expect(afterDelete.queued).toEqual([]);
+    expect(afterDelete.runningCount).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

CodeRabbit left a Minor inline finding on merged PR #7413: `deleteAllWorkflows()` clears in-memory workflow/task state but never invalidates `queueStatusUiCache`. A UI poll that warmed the cache before deletion keeps getting the pre-wipe queue snapshot from `getQueueStatus({ refresh: false })` until the cache's 2500ms TTL expires.

Verdict: valid. Evidence on current master (`a700d6ae7476e3611226d86d17e2138daa99eb33`):
- `orchestrator.ts:694` defines `queueStatusUiCache`; `:698` sets its TTL to 2500ms.
- `orchestrator.ts:3293` returns the cached value for `getQueueStatus({ refresh: false })` when younger than the TTL checked at `:3295`.
- `orchestrator.ts:3430` warms that cache on UI-poll calls; `:3432` clears it only on the refreshed path.
- `orchestrator.ts:3009`-`:3022` (`deleteAllWorkflows()`) wipes persisted workflows, clears the scheduler and in-memory state, but never assigns `this.queueStatusUiCache = null`.

This PR adds a regression test in `queue-status-ui-poll-fast-path.test.ts` that warms the cache, calls `deleteAllWorkflows()`, and checks the next `refresh: false` poll is recomputed and empty. It fails today because the cache is never cleared. The fix lands in the next PR of this stack (#7656).

## Review Claim

`deleteAllWorkflows()` leaves a warmed `queueStatusUiCache` serving the pre-wipe queue snapshot — the finding CodeRabbit raised on PR #7413 — proven by a failing regression test rather than prose.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Adds one test case to an existing spec file; touches no product code, so runtime behavior cannot change.

## Slice Rationale

This PR only proves the finding with a failing regression test; the one-line cache-clear fix lands in its own slice (#7656) so the proof diff stays test-only.

## Non-goals

- No changes to `Orchestrator` or any other product code.
- No new `docs/audits/` file — the verdict and evidence live in this PR description.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-core && pnpm test -- queue-status-ui-poll-fast-path.test.ts` — new test fails (`AssertionError: expected ... not to be ...`), proving the finding is still valid on current master.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit sha>`
- Post-revert steps: None
- Data migration? No

</details>
