### PR TITLE
Clear queue-status UI cache on workflow delete-all

### DIFF
--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -3016,6 +3016,7 @@ export class Orchestrator {
     // 4. Clear memory
     this.activeWorkflowIds.clear();
     this.stateMachine.clear();
+    this.queueStatusUiCache = null;
 
     // 5. Publish removal deltas (skipped when publishRemovalDeltas is false)
     for (const task of allTasks) {


### PR DESCRIPTION
## Summary

Fixes the finding proven in the previous PR of this stack (#7655): `deleteAllWorkflows()` now invalidates `queueStatusUiCache` after clearing in-memory workflow/task state, so an immediately subsequent UI poll can't reuse the pre-wipe queue snapshot.

## Review Claim

`deleteAllWorkflows()` clears `queueStatusUiCache`, fixing the finding proven valid by PR #7655's regression test.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Adds one `this.queueStatusUiCache = null` assignment inside `deleteAllWorkflows()`, after in-memory state is already cleared; no other code path changes, so a UI poll on any other command still hits its normal cache/refresh behavior.

## Slice Rationale

The repro in #7655 proves exactly this finding; keeping the fix in its own slice on top keeps that diff test-only and this one focused on the one-line fix.

## Non-goals

- No changes to the cache's TTL, warm path, or any other invalidation site.
- No new `docs/audits/` file — the verdict, evidence, and fix record live in these two PR descriptions instead.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-core && pnpm test -- queue-status-ui-poll-fast-path.test.ts` — 2 tests passed.
- [x] `cd packages/workflow-core && pnpm test` — 39 test files, 867 tests passed, 3 skipped.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7655

