### PR TITLE
Bugfix: merge gate approves only once PR state is MERGED

### DIFF
--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { GitHubMergeGateProvider } from '../github-merge-gate-provider.js';
+import { GitHubMergeGateProvider, resolveMergeGatePrLifecycle } from '../github-merge-gate-provider.js';
 
 vi.mock('node:child_process');
 
@@ -575,6 +575,12 @@ describe('GitHubMergeGateProvider', () => {
       expect(result.lifecycle).toBe('open');
       expect(result.rejected).toBe(false);
       expect(result.statusText).toBe('Approved, awaiting merge');
+    });
+
+    it('resolveMergeGatePrLifecycle maps PR states to lifecycle values', () => {
+      expect(resolveMergeGatePrLifecycle('MERGED')).toBe('merged');
+      expect(resolveMergeGatePrLifecycle('CLOSED')).toBe('closed');
+      expect(resolveMergeGatePrLifecycle('OPEN')).toBe('open');
     });
 
     it('treats a closed non-merged PR as terminal with statusText "Closed"', async () => {

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -19,6 +19,10 @@ type ExistingPullRequest = { url: string; number: number };
 const DEFAULT_GITHUB_CLI_TIMEOUT_MS = 60_000;
 const GITHUB_CLI_TIMEOUT_ENV = 'INVOKER_GITHUB_CLI_TIMEOUT_MS';
 
+export function resolveMergeGatePrLifecycle(state: string): MergeGatePrLifecycle {
+  return state === 'MERGED' ? 'merged' : state === 'CLOSED' ? 'closed' : 'open';
+}
+
 function getGitHubCliTimeoutMs(): number {
   const raw = process.env[GITHUB_CLI_TIMEOUT_ENV]?.trim();
   if (!raw) return DEFAULT_GITHUB_CLI_TIMEOUT_MS;
@@ -168,8 +172,7 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       statusCheckRollup?: unknown[];
     };
 
-    const lifecycle: MergeGatePrLifecycle =
-      data.state === 'MERGED' ? 'merged' : data.state === 'CLOSED' ? 'closed' : 'open';
+    const lifecycle: MergeGatePrLifecycle = resolveMergeGatePrLifecycle(data.state);
     const rejected = data.reviewDecision === 'CHANGES_REQUESTED';
 
     let statusText: string;


### PR DESCRIPTION
## Summary

Invoker's merge gate only counts a pull request as approved once GitHub reports its real state as MERGED. A review-approved but still-open PR must keep waiting, never look done.

That check already lived inline inside `checkApproval`. This change pulls it into a small, named, exported function called from the same place.

The check itself does not change. It still only reports a PR as merged when GitHub's state is MERGED, matching the earlier fixes in commits 48b09a701 and 3510f698c.

## Review Claim

The reviewer is approving that the MERGED-vs-open check becomes a standalone, named function called from its one existing call site, returning the exact same value for every input state.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

All other behavior in `packages/execution-engine/src/github-merge-gate-provider.ts` stays identical; the guard function returns the exact same lifecycle value as the inline ternary it replaces for every input state string.

## Slice Rationale

This is scoped to naming the existing check on its own, so it can be tested directly instead of only through a full `gh pr view` mock and the rest of `checkApproval`.

## Non-goals

No behavior change. This does not change `checkApproval`'s control flow, the `statusText` derivation, or the downstream `mapReviewGateArtifactStatus` consumer. No new fields, no unrelated cleanup, no doc edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- -t "treats an open approved PR as non-terminal with statusText \"Approved, awaiting merge\""`
- [x] `cd packages/execution-engine && pnpm test -- -t "resolveMergeGatePrLifecycle maps PR states to lifecycle values"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7b51727a0`
- Post-revert steps: None
- Data migration? No

</details>
