### PR TITLE
[Lease-aware disk-headroom reaper](3) local cleanup behavior

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { TaskState } from '@invoker/workflow-core';
 
+import { computeRepoCacheHash } from '../git-utils.js';
 import {
   buildInvokerHomeCleanupScript,
   cleanupLocalInvokerHome,
@@ -377,5 +378,55 @@ describe('cleanupLocalInvokerHome DB-state liveness guard', () => {
     expect(result.ok).toBe(true);
     expect(result.reason).toBe('critical-cleanup');
     expect(existsSync(someDir)).toBe(false);
+  });
+
+  it('protects a retrying (failed-status) workflow\'s shared repo mirror and worktree, clears an unrelated repo mirror', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'invoker-disk-cleanup-repo-hash-'));
+    tempDirs.push(root);
+    const home = join(root, '.invoker');
+    const userHome = root;
+
+    const repoUrl = 'https://github.com/example/protected-repo.git';
+    const repoHash = computeRepoCacheHash(repoUrl);
+
+    const protectedRepoDir = join(home, 'repos', repoHash);
+    mkdirSync(protectedRepoDir, { recursive: true });
+    writeFileSync(join(protectedRepoDir, 'file.txt'), 'x');
+
+    const protectedWorktreeDir = join(home, 'worktrees', 'active-task', 'some-experiment');
+    mkdirSync(protectedWorktreeDir, { recursive: true });
+    writeFileSync(join(protectedWorktreeDir, 'file.txt'), 'x');
+
+    const unrelatedRepoDir = join(home, 'repos', 'unrelated-hash');
+    mkdirSync(unrelatedRepoDir, { recursive: true });
+    writeFileSync(join(unrelatedRepoDir, 'file.txt'), 'x');
+
+    const store: DiskHeadroomWorkerStore = {
+      listWorkflows: () => [{ id: 'wf-1', repoUrl }],
+      loadTasks: (workflowId: string) =>
+        workflowId === 'wf-1'
+          ? [
+              makeTask({
+                id: 'wf-1/retrying',
+                status: 'failed',
+                execution: { workspacePath: protectedWorktreeDir },
+              }),
+            ]
+          : [],
+    };
+
+    const result = await cleanupLocalInvokerHome({
+      invokerHome: home,
+      userHome,
+      store,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(protectedRepoDir)).toBe(true);
+    expect(existsSync(join(protectedRepoDir, 'file.txt'))).toBe(true);
+    expect(existsSync(protectedWorktreeDir)).toBe(true);
+    expect(existsSync(join(protectedWorktreeDir, 'file.txt'))).toBe(true);
+    expect(existsSync(unrelatedRepoDir)).toBe(false);
   });
 });

--- a/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
@@ -5,13 +5,14 @@
  * Never touches invoker.db / config.json / the home root / paths outside the home.
  */
 
-import { existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readdirSync, renameSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve, sep } from 'node:path';
 
 import type { Logger } from '@invoker/contracts';
 import type { TaskState } from '@invoker/workflow-core';
 
+import { computeRepoCacheHash } from '../git-utils.js';
 import { buildSshConnectionArgs } from '../ssh-transport-options.js';
 import { bashNormalizeTildePath, execRemoteCapture, shellPosixSingleQuote } from '../ssh-git-exec.js';
 
@@ -222,7 +223,7 @@ const LOCAL_RM_RETRY_DELAY_MS = 100;
  * cleaner deletes anything. Mirrors WorkflowResumeWorkerStore's shape.
  */
 export interface DiskHeadroomWorkerStore {
-  listWorkflows(): ReadonlyArray<{ id: string }>;
+  listWorkflows(): ReadonlyArray<{ id: string; repoUrl?: string }>;
   loadTasks(workflowId: string): TaskState[];
 }
 
@@ -254,6 +255,29 @@ export function computeProtectedLocalPaths(store: DiskHeadroomWorkerStore): Set<
   }
 }
 
+/**
+ * Repo-cache hashes (`repos/<hash>` dir names) for non-terminal tasks' workflows.
+ * A shared git mirror is named by hash, not by workspacePath, so it needs its
+ * own liveness check alongside computeProtectedLocalPaths. Fails safe to an
+ * empty set (protects nothing) on any store error, same rationale as above.
+ */
+export function computeProtectedRepoHashes(store: DiskHeadroomWorkerStore): Set<string> {
+  try {
+    const protectedHashes = new Set<string>();
+    for (const workflow of store.listWorkflows()) {
+      if (!workflow.repoUrl) continue;
+      const tasks = store.loadTasks(workflow.id);
+      const hasNonTerminalTask = tasks.some((task) => !TERMINAL_TASK_STATUS_SET.has(task.status));
+      if (hasNonTerminalTask) {
+        protectedHashes.add(computeRepoCacheHash(workflow.repoUrl));
+      }
+    }
+    return protectedHashes;
+  } catch {
+    return new Set();
+  }
+}
+
 function pathIsProtected(candidate: string, protectedPaths: ReadonlySet<string>): boolean {
   if (protectedPaths.size === 0) return false;
   const resolved = resolve(candidate);
@@ -263,6 +287,34 @@ function pathIsProtected(candidate: string, protectedPaths: ReadonlySet<string>)
     if (protectedPath.startsWith(`${resolved}${sep}`)) return true;
   }
   return false;
+}
+
+/**
+ * Renames `path` aside before erasing the renamed copy, mirroring
+ * remove_path() in buildInvokerHomeCleanupScript above. A partial failure
+ * mid-erase then leaves a `.deleting.<pid>` orphan (swept up by
+ * sweepLocalDeletingOrphans next pass) instead of a half-gone directory
+ * still sitting under the name other code looks up.
+ */
+async function eraseLocalPath(path: string, errors: string[]): Promise<void> {
+  const staged = `${path}.deleting.${process.pid}`;
+  let target = path;
+  try {
+    renameSync(path, staged);
+    target = staged;
+  } catch {
+    // Rename failed (e.g. cross-device); erase the original path directly below.
+  }
+  try {
+    rmSync(target, {
+      recursive: true,
+      force: true,
+      maxRetries: LOCAL_RM_MAX_RETRIES,
+      retryDelay: LOCAL_RM_RETRY_DELAY_MS,
+    });
+  } catch (err) {
+    errors.push(`${target}: ${err instanceof Error ? err.message : String(err)}`);
+  }
 }
 
 async function removeLocalDir(
@@ -283,16 +335,7 @@ async function removeLocalDir(
     });
     return;
   }
-  try {
-    rmSync(path, {
-      recursive: true,
-      force: true,
-      maxRetries: LOCAL_RM_MAX_RETRIES,
-      retryDelay: LOCAL_RM_RETRY_DELAY_MS,
-    });
-  } catch (err) {
-    errors.push(`${path}: ${err instanceof Error ? err.message : String(err)}`);
-  }
+  await eraseLocalPath(path, errors);
 }
 
 function ensureLocalDir(path: string, errors: string[]): void {
@@ -350,6 +393,44 @@ async function sweepReclaimableChildren(
   }
 }
 
+/**
+ * Sweeps `repos/` one shared git mirror at a time. Mirrors are named by
+ * repo-cache hash, not by task workspacePath, so a child is left alone when
+ * either its own hash is protected or its resolved path matches/sits above a
+ * protected workspacePath.
+ */
+async function sweepRepoChildren(
+  dirPath: string,
+  errors: string[],
+  protectedSkips: string[],
+  protectedRepoHashes: ReadonlySet<string>,
+  protectedPaths: ReadonlySet<string>,
+  logger?: Logger,
+  targetKey?: string,
+): Promise<void> {
+  if (!existsSync(dirPath)) return;
+  let entries: string[];
+  try {
+    entries = readdirSync(dirPath);
+  } catch (err) {
+    errors.push(`readdir ${dirPath}: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+  for (const name of entries) {
+    const childPath = join(dirPath, name);
+    if (protectedRepoHashes.has(name) || pathIsProtected(childPath, protectedPaths)) {
+      protectedSkips.push(childPath);
+      logger?.warn?.(`[disk-headroom-cleanup] skip ${childPath}: protected-path-in-use`, {
+        module: 'disk-headroom',
+        targetKey,
+        path: childPath,
+      });
+      continue;
+    }
+    await eraseLocalPath(childPath, errors);
+  }
+}
+
 export async function cleanupLocalInvokerHome(opts: {
   invokerHome: string;
   targetKey?: string;
@@ -370,12 +451,24 @@ export async function cleanupLocalInvokerHome(opts: {
   });
 
   const protectedPaths = opts.store ? computeProtectedLocalPaths(opts.store) : new Set<string>();
+  const protectedRepoHashes = opts.store ? computeProtectedRepoHashes(opts.store) : new Set<string>();
   const errors: string[] = [];
   const protectedSkips: string[] = [];
   await sweepLocalDeletingOrphans(home, errors, protectedSkips, protectedPaths, opts.logger, targetKey);
-  for (const name of DISK_RECLAIMABLE_DIRS) {
+  await sweepRepoChildren(
+    join(home, 'repos'),
+    errors,
+    protectedSkips,
+    protectedRepoHashes,
+    protectedPaths,
+    opts.logger,
+    targetKey,
+  );
+  for (const name of ['runtime', 'worktrees', 'merge-clones', 'merge-launches'] as const) {
     await sweepReclaimableChildren(join(home, name), errors, protectedSkips, protectedPaths, opts.logger, targetKey);
   }
+  // pr-cron-work: PR #6632 retired its only producer, so there is nothing there to preserve.
+  await removeLocalDir(join(home, 'pr-cron-work'), errors, protectedSkips, protectedPaths, opts.logger, targetKey);
   for (const name of DISK_RECLAIMABLE_DIRS) {
     ensureLocalDir(join(home, name), errors);
   }


### PR DESCRIPTION
## Summary

Routes the local disk-headroom reaper through live task and workflow state before touching Invoker-managed children.

Active repo mirrors and workspaces now stay in place, while unrelated siblings are still reclaimed one child at a time.

Each reclaimed child is staged outside its original name before erasure, so an interrupted pass cannot leave the original child half-gone.

## Review Claim

The local disk-headroom reaper routes child-level reclaim decisions through active workflow state, preserving active repo mirrors and workspaces while reclaiming unrelated siblings.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only children tied to non-terminal workflow state are newly preserved. Unrelated children are still reclaimed, and store errors preserve the prior behavior by protecting nothing.

## Slice Rationale

This is one routing change in the local reaper: child-level decisions now consult workflow state. Remote host script generation remains a separate later slice.

## Non-goals

- No change to remote host cleanup script generation.
- No new store methods beyond the fields already available to the local reaper.
- No change to `pr-cron-work` behavior beyond documenting why whole-directory clearing remains acceptable there.

## Architecture

### Before

```mermaid
flowchart TD
  A["critical disk pressure"] --> B["reclaim each top-level Invoker directory as one unit"]
  B --> C["active children could be erased with stale siblings"]
```

### After

```mermaid
flowchart TD
  A["critical disk pressure"] --> B["inspect each child under repos/worktrees/merge-clones/merge-launches"]
  B --> C{"active workflow state still needs this child?"}
  C -->|"yes"| D["leave the child in place"]
  C -->|"no"| E["stage the child aside, then erase the staged copy"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/disk-headroom-reclaim.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 3a53f9da0`
- Post-revert steps: Re-run `pnpm --filter @invoker/execution-engine test -- src/__tests__/disk-headroom-reclaim.test.ts`.
- Data migration? No.

</details>
