### PR TITLE
[Bugfix: externalDependencies: undefined must clear stored deps](1)[REFACTOR: Extract Method] Extract isExternalDependenciesKeyPresent guard

### DIFF
--- a/packages/data-store/src/__tests__/delete-workflow-dependent-cleanup.test.ts
+++ b/packages/data-store/src/__tests__/delete-workflow-dependent-cleanup.test.ts
@@ -17,6 +17,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { Orchestrator } from '@invoker/workflow-core';
 import type { OrchestratorMessageBus } from '@invoker/workflow-core';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
+import { isExternalDependenciesKeyPresent } from '../sqlite-workflow-repository.js';
 
 class NoopBus implements OrchestratorMessageBus {
   publish(): void {}
@@ -95,6 +96,9 @@ describe('delete/detach upstream workflow clears dependent externalDependencies'
     // With no dangling gate the dependent's root task must dispatch.
     const started = orchestrator.startExecution();
     expect(started.map((t) => t.id)).toContain(downstreamRootId);
+
+    expect(isExternalDependenciesKeyPresent({ externalDependencies: undefined })).toBe(true);
+    expect(isExternalDependenciesKeyPresent({})).toBe(false);
   });
 
   it('detachWorkflow with a single dependency clears it and unblocks the dependent', async () => {

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -56,6 +56,10 @@ export type WorkflowMetadataChanges = Partial<
   >
 >;
 
+export function isExternalDependenciesKeyPresent(changes: Partial<WorkflowMetadataChanges>): boolean {
+  return 'externalDependencies' in changes;
+}
+
 /** Row shape for the columns loaded by the workflow rollup query. */
 interface WorkflowRollupTaskRow {
   id: string;
@@ -148,7 +152,7 @@ export class SqliteWorkflowRepository {
     // detachWorkflowInternal clears a dependent's last dependency by passing
     // `externalDependencies: undefined` — a skip-if-undefined check here left
     // dangling dependencies behind after upstream workflow deletion.
-    if ('externalDependencies' in changes) {
+    if (isExternalDependenciesKeyPresent(changes)) {
       setClauses.push('external_dependencies = ?');
       values.push(changes.externalDependencies ? JSON.stringify(changes.externalDependencies) : null);
     }


### PR DESCRIPTION
## Summary

A workflow update with `externalDependencies: undefined` must clear the stored dependency value. Only an omitted key should mean "leave unchanged."

That presence-vs-value distinction already holds in `updateWorkflow`, guarded by an inline `'externalDependencies' in changes` check.

This change pulls that check into a small, named, exported function, `isExternalDependenciesKeyPresent`, called from the same place.

The check itself does not change. It returns the exact same boolean for every input, including an explicit `undefined` value, matching the fix already landed in commit 5a7160381.

## Review Claim

Extract Method: the reviewer is approving that the inline `'externalDependencies' in changes` presence check becomes a standalone, named, exported function, `isExternalDependenciesKeyPresent`, called from the same `if` site with byte-identical behavior.

## Review Lane

refactor

## Review Unit

ownership-refactor

## Safety Invariant

All other behavior in `packages/data-store/src/sqlite-workflow-repository.ts` stays identical; the guard function returns the exact same boolean as the inline `in` check it replaces for every input, including an explicit `undefined` value.

## Slice Rationale

This is scoped to naming the existing presence check on its own, so it can be asserted against directly instead of only through the full `updateWorkflow` method and a live SQLite adapter.

## Non-goals

No behavior change. This does not change `updateWorkflow`'s control flow or the surrounding column-mapping logic, add new fields, touch `externalDependencyChanges` or `detachedExternalDependencies` handling, or change the task-level duplicate in `sqlite-task-attempt-repository.ts`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm test -- -t "deleteWorkflow(upstream) clears the single dangling dependency and unblocks the dependent"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 29d1c1a6e`
- Post-revert steps: None
- Data migration? No

</details>
