### PR TITLE
[Hardening: crash-preserved tasks stay excluded from capacity](1) Pin isCrashPreservedExecution boundary cases with a direct unit test

### DIFF
--- a/packages/app/src/__tests__/executing-stall.test.ts
+++ b/packages/app/src/__tests__/executing-stall.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { evaluateExecutingStall, taskNeedsExecutingStallCheck } from '../executing-stall.js';
-import type { TaskState } from '@invoker/workflow-core';
+import { isCrashPreservedExecution, type TaskState } from '@invoker/workflow-core';
 
 describe('evaluateExecutingStall', () => {
   const now = new Date('2026-05-13T08:00:00.000Z');
@@ -81,6 +81,24 @@ describe('evaluateExecutingStall', () => {
 
     expect(result.executingStalled).toBe(true);
     expect(result.staleReason).toBe('attempt lease expired');
+  });
+});
+
+describe('isCrashPreservedExecution', () => {
+  it('is false for undefined execution', () => {
+    expect(isCrashPreservedExecution(undefined)).toBe(false);
+  });
+
+  it('is false for null execution', () => {
+    expect(isCrashPreservedExecution(null)).toBe(false);
+  });
+
+  it('is false for an execution without crashPreservedAt', () => {
+    expect(isCrashPreservedExecution({ generation: 0 })).toBe(false);
+  });
+
+  it('is true for an execution with crashPreservedAt set', () => {
+    expect(isCrashPreservedExecution({ generation: 0, crashPreservedAt: new Date('2026-05-13T08:00:00.000Z') })).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

A crash-preserved task must keep its captured status and stay out of scheduler capacity accounting. That invariant already lives in one small guard function.

`isCrashPreservedExecution` in `packages/workflow-graph/src/types.ts` is already exported and already used at all three call sites the invariant covers.

This change adds a direct unit test against that guard function itself, pinning its boundary behavior (undefined, null, missing `crashPreservedAt`, present `crashPreservedAt`) independent of any one caller's test.

No production code changes. This is test-coverage hardening only.

## Review Claim

Approve adding a direct unit test for `isCrashPreservedExecution`'s four boundary cases, with no change to the guard itself or any of its call sites.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

`packages/workflow-graph/src/types.ts` is untouched. `isCrashPreservedExecution`'s behavior at every call site (the two orchestrator checks and the stall-watchdog gate) is identical before and after this PR. Only test coverage changes.

## Slice Rationale

The guard's boundary behavior was previously covered only indirectly, through `taskNeedsExecutingStallCheck`'s test. This adds one direct test file section against the guard itself so the invariant survives even if a caller's coverage regresses later.

## Non-goals

No production file changes. No new call sites. No rewrite or rename of the guard. No unrelated cleanup or documentation edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- -t 'skips crash-preserved tasks so restart inspection does not mutate them later'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
