### PR TITLE
[Bugfix: Harden destroyAll single-terminal-response guard with deletion assertion](1) Add destroyAll entry-deletion assertion

### DIFF
--- a/packages/execution-engine/src/__tests__/merge-gate-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/merge-gate-executor.test.ts
@@ -177,6 +177,7 @@ describe('MergeGateExecutor', () => {
         error: 'Merge gate execution was stopped before completion',
       },
     });
+    expect((executor as any).entries.has(handle.executionId)).toBe(false);
 
     blockedSummary.resolve('summary after destroy');
     await new Promise<void>((resolve) => setImmediate(resolve));


### PR DESCRIPTION
## Summary

`destroyAll()` already emits exactly one terminal response for an in-flight merge action before deleting that action's entry.

This PR adds a direct assertion proving the entry is actually removed from the internal map afterward.

The existing test only checked that no second response arrives later. It never confirmed the internal entry itself was deleted.

No product code changes in this slice.

## Review Claim

Approve adding a direct assertion that `destroyAll()` removes the in-flight entry from its internal map after emitting the terminal response, closing a gap in existing coverage.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

`packages/execution-engine/src/merge-gate-executor.ts` is unchanged; only `packages/execution-engine/src/__tests__/merge-gate-executor.test.ts` gains one assertion line in an existing test.

## Slice Rationale

One slice: extend the existing direct test on the named `destroyAll` guard with a deletion check, nothing else.

## Non-goals

No refactor of `destroyAll`, no new fields, no changes to `run()`'s late-result guard, and no doc edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- -t "emits a terminal failure when destroyed while a merge action is in flight"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
