### PR TITLE
[Hardening: waiting-task liveness follows only its own dependency chain](1) Pin sibling-isolation case for hasFailedDependencyPath

### DIFF
--- a/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
+++ b/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
@@ -147,4 +147,12 @@ describe('hasFailedDependencyPath', () => {
   it('is false when there are no dependencies', () => {
     expect(hasFailedDependencyPath(task('solo', 'blocked'), mapOf())).toBe(false);
   });
+
+  it('is false for a target with a satisfied chain even when an unrelated sibling has a failed dependency', () => {
+    const siblingRoot = task('sibling-root', 'failed');
+    const sibling = task('sibling', 'blocked', ['sibling-root']);
+    const root = task('root', 'completed');
+    const target = task('target', 'blocked', ['root']);
+    expect(hasFailedDependencyPath(target, mapOf(siblingRoot, sibling, root, target))).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

A waiting task's liveness must be judged from its own dependency chain, never inferred from an unrelated sibling task.

`hasFailedDependencyPath` in `packages/workflow-graph/src/workflow-rollup.ts` is already exported and already recurses only through the one task's own `dependencies`.

Existing direct-call tests cover a task's own failed, transitive, and satisfied dependency chains. None of them place an unrelated sibling with its own failed dependency in the same task map.

This change adds that one case: a sibling with a failed root sits beside the target's own satisfied chain, and the guard still returns false for the target.

No production code changes. This is test-coverage hardening only.

## Review Claim

Approve adding one direct-call test case to `hasFailedDependencyPath`'s existing test suite, proving an unrelated sibling's failed dependency does not leak into the target task's liveness check.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

`packages/workflow-graph/src/workflow-rollup.ts` is untouched. `hasFailedDependencyPath`'s behavior at its one call site inside `computeWorkflowStatusFromTaskGraph` is identical before and after this PR. Only test coverage changes.

## Slice Rationale

The per-task isolation half of the invariant (a sibling's own failure never widens beyond `task.dependencies`) was not pinned by any existing case. This adds one direct test against the guard itself so a future edit that accidentally widens the lookup would be caught.

## Non-goals

No production file changes. No new call sites. No rewrite or rename of the guard. No unrelated cleanup or documentation edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-graph && pnpm test -- -t 'is false when every dependency is satisfied (external-gate shape)'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>