### PR TITLE
[Bugfix: harden duplicate task id guard in plan parser](1)[REFACTOR: Extract Method] assertNoDuplicateTaskIds guard

### DIFF
--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { parsePlan, parsePlanFile, parsePlanSubmissionBundle, parsePlanSubmissionBundleFile, PlanParseError, detectDefaultBranch, applyPlanDefinitionDefaults, applyConfiguredPlanDefaults } from '../plan-parser.js';
+import { parsePlan, parsePlanFile, parsePlanSubmissionBundle, parsePlanSubmissionBundleFile, PlanParseError, detectDefaultBranch, applyPlanDefinitionDefaults, applyConfiguredPlanDefaults, assertNoDuplicateTaskIds } from '../plan-parser.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { mkdtempSync, writeFileSync } from 'node:fs';
@@ -622,6 +622,15 @@ tasks:
 `;
     expect(() => parsePlan(yaml)).toThrow(PlanParseError);
     expect(() => parsePlan(yaml)).toThrow('Duplicate task id "build"');
+  });
+
+  it('assertNoDuplicateTaskIds throws for a duplicate task id', () => {
+    expect(() => assertNoDuplicateTaskIds([{ id: 'build' }, { id: 'build' }])).toThrow(PlanParseError);
+    expect(() => assertNoDuplicateTaskIds([{ id: 'build' }, { id: 'build' }])).toThrow('Duplicate task id "build"');
+  });
+
+  it('assertNoDuplicateTaskIds does not throw for unique task ids', () => {
+    expect(() => assertNoDuplicateTaskIds([{ id: 'build' }, { id: 'test' }])).not.toThrow();
   });
 
   it('rejects non-object task entries with a parse error', () => {

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -295,6 +295,16 @@ function assertNoLegacyRoutingKeys(ownerLabel: string, value: object): void {
   }
 }
 
+export function assertNoDuplicateTaskIds(tasks: { id: string }[]): void {
+  const seenTaskIds = new Set<string>();
+  for (const task of tasks) {
+    if (seenTaskIds.has(task.id)) {
+      throw new PlanParseError(`Duplicate task id "${task.id}". Task ids must be unique within a plan.`);
+    }
+    seenTaskIds.add(task.id);
+  }
+}
+
 /**
  * Parse a YAML string into a validated PlanDefinition.
  * Throws PlanParseError if validation fails.
@@ -370,7 +380,6 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
 
   const topLevelExternalDependencies = parseExternalDependencies(ownerLabel, raw.externalDependencies);
 
-  const seenTaskIds = new Set<string>();
   const tasks = raw.tasks.map((task, index) => {
     if (!task || typeof task !== 'object' || Array.isArray(task)) {
       throw new PlanParseError(`Task at index ${index} must be an object with an "id" field`);
@@ -378,10 +387,7 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
     if (!task.id || typeof task.id !== 'string') {
       throw new PlanParseError(`Task at index ${index} must have an "id" field`);
     }
-    if (seenTaskIds.has(task.id)) {
-      throw new PlanParseError(`Duplicate task id "${task.id}". Task ids must be unique within a plan.`);
-    }
-    seenTaskIds.add(task.id);
+    assertNoDuplicateTaskIds(raw.tasks.slice(0, index + 1) as { id: string }[]);
 
     if (!task.description || typeof task.description !== 'string') {
       throw new PlanParseError(`Task "${task.id}" must have a "description" field`);

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -380,14 +380,15 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
 
   const topLevelExternalDependencies = parseExternalDependencies(ownerLabel, raw.externalDependencies);
 
-  const tasks = raw.tasks.map((task, index) => {
+  const rawTasks = raw.tasks;
+  const tasks = rawTasks.map((task, index) => {
     if (!task || typeof task !== 'object' || Array.isArray(task)) {
       throw new PlanParseError(`Task at index ${index} must be an object with an "id" field`);
     }
     if (!task.id || typeof task.id !== 'string') {
       throw new PlanParseError(`Task at index ${index} must have an "id" field`);
     }
-    assertNoDuplicateTaskIds(raw.tasks.slice(0, index + 1) as { id: string }[]);
+    assertNoDuplicateTaskIds(rawTasks.slice(0, index + 1) as { id: string }[]);
 
     if (!task.description || typeof task.description !== 'string') {
       throw new PlanParseError(`Task "${task.id}" must have a "description" field`);


### PR DESCRIPTION
## Summary

Plan parsing already stops a plan whose tasks repeat the same id, raising an error before any graph edges are built.

That check used to live inline inside the full parse loop, so it could only be exercised by running the entire parser.

This change gives that check its own name and makes it callable on its own, from the same place in the parser.

Behavior is unchanged: same error message, same timing, same call site.

## Review Claim

`packages/app/src/plan-parser.ts:378-384` already throws `PlanParseError` when a task id repeats via a `seenTaskIds` Set; this PR only relocates that inline check into an exported `assertNoDuplicateTaskIds(tasks)` function called from the same call site, with identical throw conditions, message, and timing.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

Parsing a plan with a repeated task id still throws `PlanParseError` with the same message, at the same point in parsing, for every input that throws today; parsing a plan with all-unique task ids is unaffected byte-for-byte.

## Slice Rationale

One slice: give the existing inline repeated-task-id check its own name and wire the one call site, nothing else. Sharing this guard across `packages/app/src/plan-parser.ts` and `packages/workflow-core/src/plan-parser.ts` belongs in its own change with its own review surface and stays out of scope here.

## Non-goals

No behavior change. No change to `packages/workflow-core/src/plan-parser.ts`, no change to the error message text, no change to when this check runs relative to other checks, no new fields on `PlanParseError`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- -t 'rejects plan with duplicate task ids'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
