### PR TITLE
[External Dependency Deadlock](1) Add a repro proving cascade invalidation leaves a permanent stale-dependency gate

### DIFF
--- a/packages/workflow-core/src/__tests__/helpers/cross-workflow-cascade-helpers.ts
+++ b/packages/workflow-core/src/__tests__/helpers/cross-workflow-cascade-helpers.ts
@@ -6,18 +6,24 @@ import {
 } from '../../orchestrator.js';
 import { computeWorkflowRollup, type TaskState, type TaskStateChanges, type Attempt } from '../../task-types.js';
 import type { WorkResponse } from '@invoker/contracts';
+import type { ExternalDependency, ExternalDependencyChange, DetachedExternalDependency } from '@invoker/workflow-graph';
+
+interface InMemoryWorkflowRecord {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  repoUrl?: string;
+  baseBranch?: string;
+  featureBranch?: string;
+  mergeMode?: 'manual' | 'automatic' | 'external_review';
+  externalDependencies?: ExternalDependency[];
+  externalDependencyChanges?: ExternalDependencyChange[];
+  detachedExternalDependencies?: DetachedExternalDependency[];
+}
 
 export class InMemoryPersistence implements OrchestratorPersistence {
-  workflows = new Map<string, {
-    id: string;
-    name: string;
-    createdAt: string;
-    updatedAt: string;
-    repoUrl?: string;
-    baseBranch?: string;
-    featureBranch?: string;
-    mergeMode?: 'manual' | 'automatic' | 'external_review';
-  }>();
+  workflows = new Map<string, InMemoryWorkflowRecord>();
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
   private attempts = new Map<string, Attempt[]>();
   events: Array<{ taskId: string; eventType: string; payload?: unknown }> = [];
@@ -29,6 +35,7 @@ export class InMemoryPersistence implements OrchestratorPersistence {
     baseBranch?: string;
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    externalDependencies?: ExternalDependency[];
   }): void {
     const now = new Date().toISOString();
     this.workflows.set(workflow.id, {
@@ -39,12 +46,15 @@ export class InMemoryPersistence implements OrchestratorPersistence {
       updatedAt: (workflow as { updatedAt?: string }).updatedAt ?? now,
     });
   }
-  updateWorkflow(): void {}
-  loadWorkflow(workflowId: string): { repoUrl?: string; baseBranch?: string; featureBranch?: string } | undefined {
-    const wf = this.workflows.get(workflowId);
-    return wf
-      ? { repoUrl: wf.repoUrl, baseBranch: wf.baseBranch, featureBranch: wf.featureBranch }
-      : undefined;
+  // Mirrors the real SQLite adapter's updateWorkflow: merges only the
+  // provided keys, same shape as OrchestratorPersistence['updateWorkflow'].
+  updateWorkflow(workflowId: string, changes: Partial<InMemoryWorkflowRecord>): void {
+    const existing = this.workflows.get(workflowId);
+    if (!existing) return;
+    this.workflows.set(workflowId, { ...existing, ...changes });
+  }
+  loadWorkflow(workflowId: string): InMemoryWorkflowRecord | undefined {
+    return this.workflows.get(workflowId);
   }
   saveTask(workflowId: string, task: TaskState): void {
     this.tasks.set(task.id, { workflowId, task });

--- a/packages/workflow-core/src/__tests__/repro-permanent-external-dependency-deadlock.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-permanent-external-dependency-deadlock.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { Orchestrator } from '../orchestrator.js';
+import {
+  applyInvalidation,
+  type InvalidationDeps,
+} from '../invalidation-policy.js';
+import {
+  InMemoryPersistence,
+  makeOrchestrator,
+  makeResponse,
+  setupChain,
+} from './helpers/cross-workflow-cascade-helpers.js';
+
+function buildOrchestratorDeps(orchestrator: Orchestrator): InvalidationDeps {
+  return {
+    cancelInFlight: async (scope, id) => {
+      if (scope === 'none') return;
+      try {
+        if (scope === 'task') {
+          orchestrator.cancelTask(id);
+          return;
+        }
+        orchestrator.cancelWorkflow(id);
+      } catch (e) {
+        const code = (e as { code?: string })?.code;
+        if (code === 'TASK_ALREADY_TERMINAL' || code === 'WORKFLOW_ALREADY_TERMINAL') return;
+        throw e;
+      }
+    },
+    retryTask: (taskId) => orchestrator.retryTask(taskId),
+    recreateTask: (taskId) => orchestrator.recreateTask(taskId),
+    retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),
+    recreateWorkflow: (workflowId) => orchestrator.recreateWorkflow(workflowId),
+    recreateWorkflowFromFreshBase: (workflowId) =>
+      orchestrator.recreateWorkflowFromFreshBase(workflowId, {
+        refreshBase: async () => ({ commit: 'fresh-sha' }),
+      }),
+    workflowFork: (workflowId) => {
+      const result = orchestrator.forkWorkflow(workflowId);
+      return result.started;
+    },
+    cascadeDownstream: (scope, id) => {
+      const workflowId = scope === 'workflow' ? id : orchestrator.getTask(id)?.config.workflowId;
+      if (!workflowId) return [];
+      return orchestrator.cascadeInvalidationToDownstream(workflowId);
+    },
+  };
+}
+
+// Incident 2026-08-06: 45 real Invoker workflows sat `pending` for 2+ days
+// with free execution capacity because their upstream prerequisite
+// (wf-1785491638881-15) was invalidated and never re-completed. start-ready
+// ran repeatedly in that window and correctly dispatched unrelated work, but
+// silently skipped all 45 forever via getExecutableReadyTasks's
+// externalDependencies gate. The only thing that ever unblocked them was an
+// unrelated manual `detachWorkflow` call two days later.
+describe('REPRO: an invalidated-and-abandoned upstream permanently deadlocks its downstream', () => {
+  it('cascadeInvalidationToDownstream resets downstream to pending but never clears its externalDependencies gate, so a downstream task with free capacity and no other blockers never becomes ready again once its upstream stops progressing', async () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const deps = buildOrchestratorDeps(orchestrator);
+    const ctx = setupChain(orchestrator);
+
+    // Upstream is invalidated (mirrors recreateTask/retryTask/recreateWorkflow
+    // in production — any of MUTATION_POLICIES' invalidating actions cascade
+    // the same way). Downstream root correctly resets to pending.
+    await applyInvalidation('workflow', 'recreateWorkflow', ctx.upstreamWfId, deps);
+    expect(orchestrator.getTask(ctx.upstreamMergeId)!.status).toBe('pending');
+    expect(orchestrator.getTask(ctx.downstreamRootId)!.status).toBe('pending');
+
+    // The upstream workflow is now abandoned for good — exactly what
+    // happened to wf-1785491638881-15 (superseded by other work, never
+    // going to be retried to completion again). Nothing else in the
+    // orchestrator ever revisits downstream's stale dependency pointer.
+    orchestrator.cancelWorkflow(ctx.upstreamWfId);
+
+    // BUG: downstream root sits `pending` with zero task-level blockers and
+    // free scheduler capacity (maxConcurrency: 8, nothing else running in
+    // this orchestrator instance) — yet it can never be selected, forever,
+    // because getExecutableReadyTasks -> getExternalDependencyBlocker only
+    // clears once the upstream's status equals the required 'completed',
+    // which a cancelled workflow will never reach again. This loop
+    // reproduces the exact "start-ready dispatches everything else, skips
+    // this one, forever" symptom observed in production logs.
+    for (let i = 0; i < 5; i += 1) {
+      const ready = orchestrator.getExecutableReadyTasks().map((t) => t.id);
+      expect(ready, `poll ${i}: downstream root must still be blocked`).not.toContain(ctx.downstreamRootId);
+    }
+    expect(orchestrator.getTask(ctx.downstreamRootId)!.status).toBe('pending');
+
+    // Proves the mechanism: nothing in cascadeInvalidationToDownstream ever
+    // clears the workflow-level externalDependencies pointer, so it's the
+    // one thing standing between "pending forever" and "ready". The real
+    // fix (detachWorkflow) does exactly this clear, plus a default-branch
+    // git lookup this in-memory test has no remote for — asserted directly
+    // here to isolate the actual blocking mechanism from that unrelated I/O.
+    persistence.updateWorkflow(ctx.downstreamWfId, { externalDependencies: undefined });
+    expect(orchestrator.getExecutableReadyTasks().map((t) => t.id))
+      .toContain(ctx.downstreamRootId);
+  });
+});


### PR DESCRIPTION
## Summary

45 real workflows sat idle for 2+ days with free execution capacity, because their one shared upstream prerequisite stopped moving.

The cause: resetting a downstream task after its upstream is invalidated leaves one pointer untouched. That pointer never gets rechecked or cleared on its own.

Once the upstream stops progressing for good, the downstream is stuck forever — no error, no visible reason, just silently skipped on every cycle.

This PR adds the proof: a test that drives exactly that sequence and confirms the downstream task never becomes selectable again, across five separate polls.

## Review Claim

Approve one new test, `repro-permanent-external-dependency-deadlock.test.ts`, plus a fix to the shared in-memory test double it depends on — `loadWorkflow` silently dropped the one field this bug lives on, and `updateWorkflow` was a no-op, so this class of defect could never have been caught by this suite before now.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change plus a test-double fix; no product code changes. The double now mirrors the real persistence adapter's shape for `loadWorkflow`/`updateWorkflow` — closer to production, not further from it. All 39 pre-existing tests across the 4 files that share this double still pass unchanged.

## Slice Rationale

The defect is demonstrated here, on its own, before any fix lands — the same repro flips from red to green once the real fix ships in the next slice.

## Non-goals

- No product code changes; the actual fix (clearing the stale pointer, or a bulk recovery command) is a separate follow-up slice.
- Does not touch the 43 real Invoker workflows currently affected by this in production — that's an operational cleanup, tracked separately from this code-level proof.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-core && pnpm test -- src/__tests__/repro-permanent-external-dependency-deadlock.test.ts`
- [x] `cd packages/workflow-core && pnpm test` (41 files, 869 passed, 3 skipped, 0 failed)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
