### PR TITLE
[Bugfix: harden cascading FK delete ordering guard](1)[REFACTOR: Extract Method] name FK-safe task cleanup order

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -3037,7 +3037,27 @@ describe('SQLiteAdapter', () => {
         generation: 1,
       });
 
+      const runSpy = vi.spyOn((adapter as any).db, 'run');
+
       expect(() => adapter.deleteAllTasks('wf-1')).not.toThrow();
+
+      const deletedTables = runSpy.mock.calls
+        .map(([sql]) => /DELETE FROM (\w+)/.exec(sql as string)?.[1])
+        .filter((table): table is string => table !== undefined);
+
+      expect(deletedTables).toEqual([
+        'workflow_mutation_leases',
+        'workflow_mutation_intents',
+        'task_launch_dispatch',
+        'worker_actions',
+        'execution_resource_leases',
+        'events',
+        'task_output',
+        'attempts',
+        'output_spool',
+        'terminal_sessions',
+        'tasks',
+      ]);
 
       expect(adapter.loadWorkflow('wf-1')).toBeDefined();
       expect(adapter.loadTasks('wf-1')).toEqual([]);

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1548,47 +1548,52 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.removeOutputFiles([taskId]);
   }
 
+  // FK-safety invariant: must run before DELETE FROM tasks, in this order.
+  private deleteDurableTaskCoordinatorRowsBeforeTasks(workflowId: string): void {
+    this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
+    this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
+    this.db.run('DELETE FROM task_launch_dispatch WHERE workflow_id = ?', [workflowId]);
+    this.db.run(`
+      DELETE FROM worker_actions WHERE workflow_id = ? OR task_id IN (
+        SELECT id FROM tasks WHERE workflow_id = ?
+      )
+    `, [workflowId, workflowId]);
+    this.db.run(`
+      DELETE FROM execution_resource_leases WHERE task_id IN (
+        SELECT id FROM tasks WHERE workflow_id = ?
+      )
+    `, [workflowId]);
+    this.db.run(`
+      DELETE FROM events WHERE task_id IN (
+        SELECT id FROM tasks WHERE workflow_id = ?
+      )
+    `, [workflowId]);
+    this.db.run(`
+      DELETE FROM task_output WHERE task_id IN (
+        SELECT id FROM tasks WHERE workflow_id = ?
+      )
+    `, [workflowId]);
+    this.db.run(`
+      DELETE FROM attempts WHERE node_id IN (
+        SELECT id FROM tasks WHERE workflow_id = ?
+      )
+    `, [workflowId]);
+    this.db.run(`
+      DELETE FROM output_spool WHERE task_id IN (
+        SELECT id FROM tasks WHERE workflow_id = ?
+      )
+    `, [workflowId]);
+    this.db.run(`
+      DELETE FROM terminal_sessions WHERE task_id IN (
+        SELECT id FROM tasks WHERE workflow_id = ?
+      )
+    `, [workflowId]);
+  }
+
   deleteAllTasks(workflowId: string): void {
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
     this.runTransaction(() => {
-      this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
-      this.db.run('DELETE FROM task_launch_dispatch WHERE workflow_id = ?', [workflowId]);
-      this.db.run(`
-        DELETE FROM worker_actions WHERE workflow_id = ? OR task_id IN (
-          SELECT id FROM tasks WHERE workflow_id = ?
-        )
-      `, [workflowId, workflowId]);
-      this.db.run(`
-        DELETE FROM execution_resource_leases WHERE task_id IN (
-          SELECT id FROM tasks WHERE workflow_id = ?
-        )
-      `, [workflowId]);
-      this.db.run(`
-        DELETE FROM events WHERE task_id IN (
-          SELECT id FROM tasks WHERE workflow_id = ?
-        )
-      `, [workflowId]);
-      this.db.run(`
-        DELETE FROM task_output WHERE task_id IN (
-          SELECT id FROM tasks WHERE workflow_id = ?
-        )
-      `, [workflowId]);
-      this.db.run(`
-        DELETE FROM attempts WHERE node_id IN (
-          SELECT id FROM tasks WHERE workflow_id = ?
-        )
-      `, [workflowId]);
-      this.db.run(`
-        DELETE FROM output_spool WHERE task_id IN (
-          SELECT id FROM tasks WHERE workflow_id = ?
-        )
-      `, [workflowId]);
-      this.db.run(`
-        DELETE FROM terminal_sessions WHERE task_id IN (
-          SELECT id FROM tasks WHERE workflow_id = ?
-        )
-      `, [workflowId]);
+      this.deleteDurableTaskCoordinatorRowsBeforeTasks(workflowId);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
     });
     this.removeOutputFiles(taskIds);


### PR DESCRIPTION
## Summary

This names the existing FK-safe coordinator-table order inside `deleteAllTasks`.

The task-row statement still runs only after the durable coordinator table statements in the same transaction.

The regression test now fails as soon as that ordering drifts, before it reaches the final task-row assertion.

## Review Claim

Approve this Extract Method refactor: `deleteAllTasks` now uses a named helper for the existing durable coordinator table statement order, with no behavior change.

## Review Lane

refactor

## Review Unit

ownership-refactor

## Safety Invariant

The helper runs the same statements, with the same bind values, in the same transaction, before the final task-row removal.

## Slice Rationale

This slice only names the current ordering and tightens the nearby regression test around that order.

The proof command remains in the test plan instead of becoming a separate empty PR slice.

## Non-goals

No behavior change.

No schema changes.

No new caller.

No change to transaction boundaries.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm test -- -t 'removes durable workflow coordinator rows before deleting tasks'`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .pr-body-cascading-fk.md --base plan/bugfix-harden-duplicate-task-id-guard-in-plan-parser`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run `cd packages/data-store && pnpm test -- -t 'removes durable workflow coordinator rows before deleting tasks'`
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of bulk task deletion by preserving the correct cleanup sequence across related task data.

* **Tests**
  * Added verification that all associated records are deleted in the expected order during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->