### PR TITLE
[Fix headless read-only delegated query never exiting under Electron](1) Add flush-then-exit stdout helper

### DIFF
--- a/packages/app/src/__tests__/headless-stdout-flush.test.ts
+++ b/packages/app/src/__tests__/headless-stdout-flush.test.ts
@@ -2,6 +2,8 @@ import { execFileSync } from 'node:child_process';
 
 import { describe, expect, it } from 'vitest';
 
+import { writeStdoutFlushAndExit } from '../headless-stdout-flush.js';
+
 const buildPayload = (): string => JSON.stringify(Array.from({ length: 3000 }, (_, i) => ({
   id: `wf-${i}`,
   description: `synthetic workflow row ${i} padded-padded-padded-padded-padded-padded-padded-padded`,
@@ -26,6 +28,39 @@ describe('headless stdout flush', () => {
       const output = execFileSync(process.execPath, ['-e', script], { encoding: 'utf8' });
       expect(output.length).toBe(payload.length);
       expect(() => JSON.parse(output)).not.toThrow();
+    }
+  });
+
+  it('invokes the injected exit fn only after the flush resolves', async () => {
+    const originalWrite = process.stdout.write;
+    const originalExitCode = process.exitCode;
+    let capturedCallback: (() => void) | undefined;
+    const exitCalls: number[] = [];
+
+    process.exitCode = undefined;
+    process.stdout.write = ((_: string, callback?: () => void) => {
+      capturedCallback = callback;
+      return false;
+    }) as typeof process.stdout.write;
+
+    try {
+      const pending = writeStdoutFlushAndExit('payload', (code) => {
+        exitCalls.push(code);
+      });
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(exitCalls).toEqual([]);
+      expect(capturedCallback).toBeDefined();
+
+      capturedCallback?.();
+      await pending;
+
+      expect(exitCalls).toEqual([0]);
+    } finally {
+      process.stdout.write = originalWrite;
+      process.exitCode = originalExitCode;
     }
   });
 });

--- a/packages/app/src/headless-stdout-flush.ts
+++ b/packages/app/src/headless-stdout-flush.ts
@@ -4,3 +4,14 @@ export async function writeStdoutAndFlush(text: string): Promise<void> {
     process.stdout.write(text, () => resolve());
   });
 }
+
+export async function writeStdoutFlushAndExit(
+  text: string,
+  exit: (code: number) => void = (code) => process.exit(code),
+): Promise<void> {
+  await writeStdoutAndFlush(text);
+  // Electron's main process never exits on event-loop drain, so after the
+  // stdout flush resolves the client must force exit like main.ts's delegated
+  // mutation path.
+  exit(process.exitCode ?? 0);
+}

--- a/packages/app/src/headless-stdout-flush.ts
+++ b/packages/app/src/headless-stdout-flush.ts
@@ -7,7 +7,7 @@ export async function writeStdoutAndFlush(text: string): Promise<void> {
 
 export async function writeStdoutFlushAndExit(
   text: string,
-  exit: (code: number) => void = (code) => process.exit(code),
+  exit: (code: number | string) => void = (code) => process.exit(code),
 ): Promise<void> {
   await writeStdoutAndFlush(text);
   // Electron's main process never exits on event-loop drain, so after the


### PR DESCRIPTION
## Summary

PR #7439 made the headless delegated query client flush stdout and set `process.exitCode` before returning. Under plain Node the event loop then drains and the process exits.

Electron's main process never terminates on event-loop drain, so a headless client that only sets `process.exitCode` keeps running until an outer timeout kills it.

This slice adds `writeStdoutFlushAndExit` beside `writeStdoutAndFlush`: it awaits the flush, then calls an injectable exit fn with `process.exitCode ?? 0`.

A unit test pins the ordering: the exit fn must not run while the stdout write callback is pending, and runs exactly once with 0 after the flush resolves.

The main-process call site is re-pointed in the next slice.

## Review Claim

The new `writeStdoutFlushAndExit` helper invokes its exit fn strictly after the stdout flush resolves, and the existing `writeStdoutAndFlush` behavior is untouched.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the flush helper module and its unit test change. `writeStdoutAndFlush` itself is untouched and the new export has no callers yet, so shipped behavior cannot change until the next slice wires in the call site. The default exit fn is `process.exit`, sequenced after the same `await` on the write callback that #7439 introduced, so no stdout byte can be lost that was not already lost before.

## Slice Rationale

The helper and its unit test land separate from the main-process call site, so each PR stays in one review unit — the same shape as the #7438/#7439 stack.

## Non-goals

- No change to `packages/app/src/main.ts`; the delegated read-only call site is re-pointed in the next slice.
- No change to `writeStdoutAndFlush` or to the #7430/#7439 stdout truncation regression tests.
- No `scripts/repro/` live-path guard here; that lands in a separate follow-up workflow gated on this stack's merge.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- headless-stdout-flush headless-stdio-flush`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 998ae8fae393021198685c8416213947f94066e0`
- Post-revert steps: None
- Data migration? No

</details>
