### PR TITLE
[Fix headless read-only delegated query never exiting under Electron](2) Force exit after delegated read-only query flush

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -168,7 +168,7 @@ import {
 } from './headless.js';
 import { printHeadlessUsage } from './headless-usage.js';
 import { buildHeadlessApiServerDeps } from './headless-shared.js';
-import { writeStdoutAndFlush } from './headless-stdout-flush.js';
+import { writeStdoutFlushAndExit } from './headless-stdout-flush.js';
 import { parseReviewGatePrNumber, repairReviewGateCiByPr } from './review-gate-ci-repair-command.js';
 import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
 import {
@@ -1005,9 +1005,9 @@ function startHeadlessMode(): void {
         const delegated = await tryDelegateQuery(delegationBus, { kind: 'cli-query', args: cliArgs }, 5_000);
         delegationBus.disconnect();
         if (delegated && typeof delegated.output === 'string') {
-          await writeStdoutAndFlush(delegated.output);
           process.exitCode = 0;
-          return;
+          await writeStdoutFlushAndExit(delegated.output);
+          return; // Guard: process.exit() may not halt in Electron async context
         }
       } catch (err) {
         delegationBus.disconnect();


### PR DESCRIPTION
## Summary

When the app main process answers a delegated read-only query, it flushed the owner's output, set `process.exitCode = 0`, and returned, relying on event-loop drain to terminate.

Electron never terminates on drain. The client hung with its complete JSON already on stdout until an outer 60s timeout killed it with exit 124.

Live repro: exit 124 at 60.0s wall with a complete, valid 101995-byte payload on stdout, while the owner answered the delegated query in 22ms.

That hang failed every 15-minute e2e-autofix worker tick and every `scripts/cron-e2e-regression-watch.sh` sweep.

This slice re-points the branch at `writeStdoutFlushAndExit`, forcing exit after the flush resolves, mirroring the delegated mutation path directly above it.

## Review Claim

The delegated read-only output branch in `packages/app/src/main.ts` now awaits the stdout flush and then forces process termination, instead of returning with only `process.exitCode` set.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the delegated read-only stdout branch changes. The exit call is sequenced after the same `await` on the write callback that #7439 introduced, so no stdout byte can be lost that was not already lost before; mutation delegation, owner serving, the local read-only fallback, and the error handling branches are untouched.

## Slice Rationale

The `main.ts` call-site change lands separate from the helper slice below it, so each PR stays in one review unit — the same shape as the #7438/#7439 stack.

## Non-goals

- No change to the delegated mutation path (`main.ts:972-976`), the no-owner local fallback, owner-serve, or `headless-client.ts`'s own flush-then-exitCode handlers.
- No change to `scripts/headless-lib.sh`'s 60s timeout guard or to `packages/app/src/headless-stdio.ts`.
- No `scripts/repro/` live-path guard here; that lands in a separate follow-up workflow gated on this stack's merge.

## Architecture

### Before

```mermaid
graph TD
    A["Owner answers delegated read-only query"] --> B["Client flushes stdout"]
    B --> C["Client sets process.exitCode = 0 and returns"]
    C --> D["Electron main process keeps running"]
    D --> E["Outer 60s timeout kills client with exit 124"]
```

### After

```mermaid
graph TD
    A["Owner answers delegated read-only query"] --> B["Client sets process.exitCode = 0"]
    B --> C["writeStdoutFlushAndExit awaits the stdout flush"]
    C --> D["Client forces exit with process.exitCode ?? 0"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- headless-stdout-flush headless-stdio-flush`

</details>

## Visual Proof

![Terminal proof of the focused flush regression run: 4 tests pass, including "invokes the injected exit fn only after the flush resolves"](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260807-068ede/headless-readonly-exit-flush-tests.svg)

The affected surface is captured stdout of a terminal client, so the relevant user-visible proof is the focused vitest run passing: both #7430/#7439 truncation regression tests stay green and the new exit-ordering unit passes.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert be7784072`
- Post-revert steps: None
- Data migration? No

</details>