### PR TITLE
[Fix workflow-resume recovery audit event: key events.task_id by a real task id](1) Key recovery.worker.submit by the ready task id

### DIFF
--- a/packages/execution-engine/src/__tests__/workflow-resume-fk-regression.test.ts
+++ b/packages/execution-engine/src/__tests__/workflow-resume-fk-regression.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { SQLiteAdapter, type Workflow, type WorkflowMutationPriority } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+import {
+  createWorkflowResumeCooldownLedger,
+  createWorkflowResumeTick,
+  WORKFLOW_RESUME_COMMAND_CHANNEL,
+} from '../workers/workflow-resume-worker.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+const POLL_CTX = {
+  identity: { kind: 'workflow-resume', instanceId: 'w1' },
+  reason: 'poll' as const,
+  tickNumber: 1,
+  signal: new AbortController().signal,
+};
+
+function makeWorkflow(id: string): Workflow {
+  return {
+    id,
+    name: id,
+    status: 'running',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+  };
+}
+
+function makeTask(workflowId: string, taskId: string): TaskState {
+  return {
+    id: taskId,
+    description: taskId,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date('2026-07-01T00:00:00.000Z'),
+    config: { workflowId },
+    execution: {},
+    taskStateVersion: 1,
+  };
+}
+
+describe('workflow resume FK regression', () => {
+  let adapter: SQLiteAdapter | undefined;
+
+  afterEach(() => {
+    adapter?.close();
+    adapter = undefined;
+  });
+
+  it('persists recovery.worker.submit keyed by a real task id', async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    adapter.saveWorkflow(makeWorkflow('wf-1'));
+    adapter.saveTask('wf-1', makeTask('wf-1', 'wf-1/t1'));
+    adapter.saveWorkflow(makeWorkflow('wf-2'));
+    adapter.saveTask('wf-2', makeTask('wf-2', 'wf-2/t1'));
+
+    const submit = vi.fn((
+      workflowId: string,
+      priority: WorkflowMutationPriority,
+      channel: string,
+      args: unknown[],
+    ) => {
+      expect(priority).toBe('normal');
+      expect(channel).toBe(WORKFLOW_RESUME_COMMAND_CHANNEL);
+      expect(args).toEqual([{}]);
+      return workflowId === 'wf-1' ? 1 : 2;
+    });
+    const tick = createWorkflowResumeTick({
+      store: adapter,
+      submitter: { submit },
+      logger,
+      ledger: createWorkflowResumeCooldownLedger(),
+      now: () => 0,
+    });
+
+    await expect(tick(POLL_CTX)).resolves.toBeUndefined();
+
+    expect(submit.mock.calls.map(([workflowId]) => workflowId)).toEqual(['wf-1', 'wf-2']);
+    expect(adapter.getEvents('wf-1/t1').map((event) => event.eventType)).toEqual([
+      'recovery.worker.submit',
+    ]);
+    expect(adapter.getEvents('wf-2/t1').map((event) => event.eventType)).toEqual([
+      'recovery.worker.submit',
+    ]);
+    expect(adapter.getEvents('wf-1')).toEqual([]);
+    expect(adapter.getEvents('wf-2')).toEqual([]);
+  });
+});

--- a/packages/execution-engine/src/__tests__/workflow-resume-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/workflow-resume-worker.test.ts
@@ -314,7 +314,7 @@ describe('workflow resume worker tick', () => {
     expect(h.submit).toHaveBeenCalledTimes(1);
   });
 
-  it('logs a recovery.worker.submit event with the workflow id and intent id', async () => {
+  it('logs a recovery.worker.submit event keyed by the ready task id', async () => {
     const h = harness({
       workflows: [
         {
@@ -325,7 +325,7 @@ describe('workflow resume worker tick', () => {
     });
     await h.tick(POLL_CTX);
     expect(h.logEvent).toHaveBeenCalledWith(
-      'wf-1',
+      'wf-1/task',
       'recovery.worker.submit',
       expect.objectContaining({
         worker: 'workflow-resume',

--- a/packages/execution-engine/src/workers/workflow-resume-worker.ts
+++ b/packages/execution-engine/src/workers/workflow-resume-worker.ts
@@ -69,9 +69,9 @@ export function createWorkflowResumeCooldownLedger(): WorkflowResumeCooldownLedg
   };
 }
 
-function hasLocallyReadyPendingTask(store: WorkflowResumeWorkerStore, workflowId: string): boolean {
+function findLocallyReadyPendingTaskId(store: WorkflowResumeWorkerStore, workflowId: string): string | null {
   const tasks = store.loadTasks(workflowId);
-  if (tasks.length === 0) return false;
+  if (tasks.length === 0) return null;
   const tasksById = new Map(tasks.map((task) => [task.id, task]));
   for (const task of tasks) {
     if (task.status !== 'pending') continue;
@@ -80,9 +80,9 @@ function hasLocallyReadyPendingTask(store: WorkflowResumeWorkerStore, workflowId
       const dependency = tasksById.get(dependencyId);
       return dependency !== undefined && dependency.status === 'completed';
     });
-    if (localDependenciesSatisfied) return true;
+    if (localDependenciesSatisfied) return task.id;
   }
-  return false;
+  return null;
 }
 
 function collectWakeupWorkflowIds(hints: RecoveryWorkerWakeupHint[]): string[] {
@@ -94,11 +94,14 @@ function collectWakeupWorkflowIds(hints: RecoveryWorkerWakeupHint[]): string[] {
   return Array.from(seen);
 }
 
-function listAllWorkflowsWithReadyPendingTasks(store: WorkflowResumeWorkerStore): string[] {
-  const targets: string[] = [];
+function listAllWorkflowsWithReadyPendingTasks(
+  store: WorkflowResumeWorkerStore,
+): Array<{ workflowId: string; readyTaskId: string }> {
+  const targets: Array<{ workflowId: string; readyTaskId: string }> = [];
   for (const workflow of store.listWorkflows()) {
-    if (hasLocallyReadyPendingTask(store, workflow.id)) {
-      targets.push(workflow.id);
+    const readyTaskId = findLocallyReadyPendingTaskId(store, workflow.id);
+    if (readyTaskId !== null) {
+      targets.push({ workflowId: workflow.id, readyTaskId });
     }
   }
   return targets;
@@ -112,12 +115,19 @@ export function createWorkflowResumeTick(options: WorkflowResumeWorkerPolicyOpti
     const wakeups = options.drainWakeupHints?.() ?? [];
     const wakeupWorkflowIds = collectWakeupWorkflowIds(wakeups);
 
-    const candidateIds = wakeupWorkflowIds.length > 0 && ctx.reason === 'wake'
-      ? wakeupWorkflowIds.filter((id) => hasLocallyReadyPendingTask(options.store, id))
+    const candidates = wakeupWorkflowIds.length > 0 && ctx.reason === 'wake'
+      ? wakeupWorkflowIds
+        .map((id) => ({
+          workflowId: id,
+          readyTaskId: findLocallyReadyPendingTaskId(options.store, id),
+        }))
+        .filter((candidate): candidate is { workflowId: string; readyTaskId: string } =>
+          candidate.readyTaskId !== null)
       : listAllWorkflowsWithReadyPendingTasks(options.store);
 
     const submitted = new Set<string>();
-    for (const workflowId of candidateIds) {
+    for (const candidate of candidates) {
+      const { workflowId } = candidate;
       if (submitted.has(workflowId)) continue;
       if (!options.ledger.shouldSubmit(workflowId, nowMs)) {
         options.logger.debug?.(`[worker:${WORKFLOW_RESUME_WORKER_KIND}] cooldown-skip`, {
@@ -136,7 +146,7 @@ export function createWorkflowResumeTick(options: WorkflowResumeWorkerPolicyOpti
         [{}],
       );
       options.ledger.markSubmitted(workflowId, nowMs + cooldownMs);
-      options.store.logEvent?.(workflowId, 'recovery.worker.submit', {
+      options.store.logEvent?.(candidate.readyTaskId, 'recovery.worker.submit', {
         worker: WORKFLOW_RESUME_WORKER_KIND,
         phase: 'start-ready',
         workflowId,


### PR DESCRIPTION
## Summary

The workflow-resume worker crashed on every tick that resumed a workflow. Its audit write put a workflow id into `events.task_id`, and the events table requires a real task id.

The crash aborted the candidate loop after the first workflow, so every later candidate in the same tick starved until a future tick.

The audit row is now keyed by the locally-ready pending task that made the workflow a candidate. The workflow id stays in the event payload, unchanged.

A regression test drives the real SQLite adapter through a real tick with two candidate workflows and asserts both resume and both audit rows persist.

## Review Claim

Keying the workflow-resume worker's audit row by the candidate's locally-ready pending task id, in place of the workflow id, satisfies the `events.task_id` foreign key, ends the per-tick crash, and stops later candidates from starving.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only workflow-resume-worker.ts's candidate-walk return shape and the logEvent first argument change, plus that file's colocated tests in packages/execution-engine. The submit call and its arguments, the cooldown ledger, the candidacy rule (a workflow is a candidate iff it has a pending task whose local dependencies are all completed), the 'recovery.worker.submit' event name, and the payload fields (which already include workflowId) are semantically unchanged, so a reviewer can verify the whole change inside one worker file and its tests.

## Slice Rationale

One behavior slice: the single foreign-key defect at its source plus the directly affected colocated tests. The source workflow's other task was a run-only vitest gate with zero file changes, so the publishable stack is this one PR.

## Non-goals

- No change to SQLiteAdapter.logEvent, the events table DDL, or the sqlite foreign-key declarations.
- No change to the submitter path (workflow_mutation_intents, already FK-safe since #7285).
- No change to worker registration, poll/wake cadence, cooldown ledger semantics, or packages/app wiring.
- No checked-in scripts/repro/ file in this slice.
- No fix for the distinct workflow_mutation_intents.workflow_id FK bug already fixed by a9a619799 (#7285).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- -t 'persists recovery.worker.submit keyed by a real task id'`
- [x] `pnpm --filter @invoker/execution-engine test -- -t 'workflow resume worker tick'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 742977593f53e260a626384b894ee60673f323fb`
- Post-revert steps: None
- Data migration? No

</details>
