### PR TITLE
[Scope the workflow-completion touch sweep to affected workflows only](1) Scope the completion touch sweep to affected workflows

### DIFF
--- a/packages/workflow-core/src/__tests__/workflow-touch-scope.test.ts
+++ b/packages/workflow-core/src/__tests__/workflow-touch-scope.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from 'vitest';
+import { Orchestrator, type OrchestratorMessageBus, type OrchestratorPersistence } from '../orchestrator.js';
+import { computeWorkflowRollup } from '../task-types.js';
+import type {
+  Attempt,
+  ExternalDependency,
+  ExternalDependencyChange,
+  TaskState,
+  TaskStateChanges,
+} from '../task-types.js';
+import type { WorkResponse } from '@invoker/contracts';
+
+type WorkflowRecord = {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+  repoUrl?: string;
+  baseBranch?: string;
+  featureBranch?: string;
+  mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
+  externalDependencies?: ExternalDependency[];
+  externalDependencyChanges?: ExternalDependencyChange[];
+  generation?: number;
+};
+
+class RecordingPersistence implements OrchestratorPersistence {
+  workflows = new Map<string, WorkflowRecord>();
+  tasks = new Map<string, { workflowId: string; task: TaskState }>();
+  attempts = new Map<string, Attempt[]>();
+  updateWorkflowHistory: Array<{
+    workflowId: string;
+    changes: {
+      updatedAt?: string;
+      baseBranch?: string;
+      generation?: number;
+      mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
+      externalDependencies?: ExternalDependency[];
+      externalDependencyChanges?: ExternalDependencyChange[];
+    };
+  }> = [];
+
+  saveWorkflow(workflow: WorkflowRecord): void {
+    const now = new Date().toISOString();
+    this.workflows.set(workflow.id, {
+      ...workflow,
+      repoUrl: workflow.repoUrl ?? 'memory://test-repo',
+      createdAt: workflow.createdAt ?? now,
+      updatedAt: workflow.updatedAt ?? now,
+      generation: workflow.generation ?? 0,
+    });
+  }
+
+  updateWorkflow(
+    workflowId: string,
+    changes: {
+      updatedAt?: string;
+      baseBranch?: string;
+      generation?: number;
+      mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
+      externalDependencies?: ExternalDependency[];
+      externalDependencyChanges?: ExternalDependencyChange[];
+    },
+  ): void {
+    this.updateWorkflowHistory.push({ workflowId, changes: { ...changes } });
+    const wf = this.workflows.get(workflowId);
+    if (!wf) return;
+    if (changes.updatedAt !== undefined) wf.updatedAt = changes.updatedAt;
+    if (changes.baseBranch !== undefined) wf.baseBranch = changes.baseBranch;
+    if (changes.generation !== undefined) wf.generation = changes.generation;
+    if (changes.mergeMode !== undefined) wf.mergeMode = changes.mergeMode;
+    if ('externalDependencies' in changes) wf.externalDependencies = changes.externalDependencies;
+    if ('externalDependencyChanges' in changes) wf.externalDependencyChanges = changes.externalDependencyChanges;
+  }
+
+  saveTask(workflowId: string, task: TaskState): void {
+    this.tasks.set(task.id, { workflowId, task });
+  }
+
+  updateTask(taskId: string, changes: TaskStateChanges): void {
+    const entry = this.tasks.get(taskId);
+    if (!entry) return;
+    entry.task = {
+      ...entry.task,
+      ...(changes.status !== undefined ? { status: changes.status } : {}),
+      ...(changes.dependencies !== undefined ? { dependencies: changes.dependencies } : {}),
+      config: { ...entry.task.config, ...changes.config },
+      execution: { ...entry.task.execution, ...changes.execution },
+      taskStateVersion: (entry.task.taskStateVersion ?? 1) + 1,
+    } as TaskState;
+  }
+
+  listWorkflows(): Array<WorkflowRecord & { status: string }> {
+    return Array.from(this.workflows.values()).map((workflow) => ({
+      ...workflow,
+      status: computeWorkflowRollup(this.loadTasks(workflow.id)).status,
+    }));
+  }
+
+  loadWorkflow(workflowId: string): (WorkflowRecord & { status: string }) | undefined {
+    return this.listWorkflows().find((workflow) => workflow.id === workflowId);
+  }
+
+  loadTasks(workflowId: string): TaskState[] {
+    return Array.from(this.tasks.values())
+      .filter((entry) => entry.workflowId === workflowId)
+      .map((entry) => entry.task);
+  }
+
+  logEvent(): void {}
+
+  saveAttempt(attempt: Attempt): void {
+    const list = this.attempts.get(attempt.nodeId) ?? [];
+    list.push(attempt);
+    this.attempts.set(attempt.nodeId, list);
+  }
+
+  loadAttempts(nodeId: string): Attempt[] {
+    return this.attempts.get(nodeId) ?? [];
+  }
+
+  loadAttempt(attemptId: string): Attempt | undefined {
+    for (const list of this.attempts.values()) {
+      const found = list.find((attempt) => attempt.id === attemptId);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  updateAttempt(attemptId: string, changes: Partial<Attempt>): void {
+    for (const list of this.attempts.values()) {
+      const index = list.findIndex((attempt) => attempt.id === attemptId);
+      if (index !== -1) {
+        list[index] = { ...list[index], ...changes };
+        return;
+      }
+    }
+  }
+}
+
+class InMemoryBus implements OrchestratorMessageBus {
+  publish<T>(_channel: string, _message: T): void {}
+}
+
+function makeOrchestrator(persistence: RecordingPersistence): Orchestrator {
+  return new Orchestrator({
+    persistence,
+    messageBus: new InMemoryBus(),
+    maxConcurrency: 8,
+  });
+}
+
+function makeResponse(overrides: Partial<WorkResponse>): WorkResponse {
+  return {
+    requestId: 'req-1',
+    actionId: 'task-1',
+    executionGeneration: 0,
+    status: 'completed',
+    outputs: { exitCode: 0 },
+    ...overrides,
+  };
+}
+
+function findTask(orchestrator: Orchestrator, localId: string): TaskState {
+  return orchestrator.getAllTasks().find((task) => task.id.endsWith(`/${localId}`))!;
+}
+
+describe('workflow updatedAt touch scope', () => {
+  it('does not touch an unrelated active bystander workflow when one task completes', () => {
+    const persistence = new RecordingPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+
+    orchestrator.loadPlan({
+      name: 'driver',
+      tasks: [{ id: 'driver-task', description: 'driver task' }],
+    });
+    orchestrator.loadPlan({
+      name: 'bystander',
+      tasks: [
+        { id: 'bystander-root', description: 'unrelated running task' },
+        { id: 'bystander-leaf', description: 'unrelated blocked task', dependencies: ['bystander-root'] },
+      ],
+    });
+
+    const driverTaskId = findTask(orchestrator, 'driver-task').id;
+    const bystanderWorkflowId = findTask(orchestrator, 'bystander-root').config.workflowId!;
+
+    orchestrator.startExecution();
+    persistence.updateWorkflowHistory = [];
+
+    orchestrator.handleWorkerResponse(makeResponse({ actionId: driverTaskId, status: 'completed' }));
+
+    expect(persistence.updateWorkflowHistory.some((call) => call.workflowId === bystanderWorkflowId)).toBe(false);
+  });
+
+  it('still wakes a downstream workflow gated on the upstream merge gate', () => {
+    const persistence = new RecordingPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+
+    orchestrator.loadPlan({
+      name: 'upstream',
+      tasks: [{ id: 'upstream-task', description: 'upstream task' }],
+    });
+    const upstreamTaskId = findTask(orchestrator, 'upstream-task').id;
+    const upstreamWorkflowId = upstreamTaskId.split('/')[0]!;
+    const upstreamMergeId = `__merge__${upstreamWorkflowId}`;
+
+    orchestrator.loadPlan({
+      name: 'downstream',
+      tasks: [
+        {
+          id: 'downstream-leaf',
+          description: 'leaf waits for upstream merge gate',
+          externalDependencies: [{ workflowId: upstreamWorkflowId, gatePolicy: 'completed' }],
+        },
+      ],
+    });
+    const downstreamTaskId = findTask(orchestrator, 'downstream-leaf').id;
+
+    const initiallyStarted = orchestrator.startExecution();
+    expect(initiallyStarted.map((task) => task.id)).toContain(upstreamTaskId);
+    expect(initiallyStarted.map((task) => task.id)).not.toContain(downstreamTaskId);
+    expect(orchestrator.getTask(downstreamTaskId)!.status).toBe('pending');
+
+    const afterUpstreamTask = orchestrator.handleWorkerResponse(
+      makeResponse({ actionId: upstreamTaskId, status: 'completed' }),
+    );
+    expect(afterUpstreamTask.map((task) => task.id)).toContain(upstreamMergeId);
+    expect(afterUpstreamTask.map((task) => task.id)).not.toContain(downstreamTaskId);
+    expect(orchestrator.getTask(downstreamTaskId)!.status).toBe('pending');
+
+    const afterMergeGate = orchestrator.handleWorkerResponse(
+      makeResponse({ actionId: upstreamMergeId, status: 'completed' }),
+    );
+    expect(afterMergeGate.map((task) => task.id)).toContain(downstreamTaskId);
+    expect(orchestrator.getTask(downstreamTaskId)!.status).toBe('running');
+  });
+});

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1766,7 +1766,7 @@ export class Orchestrator {
 
     if (task.config.isMergeNode) {
       this.autoStartExternallyUnblockedReadyTasks();
-      this.checkWorkflowCompletion();
+      this.checkWorkflowCompletion(task.config.workflowId);
     }
   }
 
@@ -1953,7 +1953,7 @@ export class Orchestrator {
     started.push(...this.autoStartUnblockedTasks());
     started.push(...this.autoStartExternallyUnblockedReadyTasks());
     mergeTrace('APPROVE_STARTED', { taskId: task.id, startedIds: started.map(t => t.id), startedStatuses: started.map(t => t.status) });
-    this.checkWorkflowCompletion();
+    this.checkWorkflowCompletion(task.config.workflowId);
     return started;
   }
 
@@ -2004,7 +2004,7 @@ export class Orchestrator {
     this.persistence.logEvent?.(taskId, 'task.failed', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
-    this.checkWorkflowCompletion();
+    this.checkWorkflowCompletion(task.config.workflowId);
   }
 
   selectExperiment(taskId: string, experimentId: string): TaskState[] {
@@ -2077,7 +2077,7 @@ export class Orchestrator {
       readyTaskIds,
     });
     const started = this.autoStartReadyTasks(readyTaskIds);
-    this.checkWorkflowCompletion();
+    this.checkWorkflowCompletion(task.config.workflowId);
     return started;
   }
 
@@ -2165,7 +2165,7 @@ export class Orchestrator {
       readyTaskIds,
     });
     const started = this.autoStartReadyTasks(readyTaskIds);
-    this.checkWorkflowCompletion();
+    this.checkWorkflowCompletion(task.config.workflowId);
     return started;
   }
 
@@ -2393,7 +2393,7 @@ export class Orchestrator {
 
     // Re-evaluate and auto-start anything newly unblocked by this policy change.
     const started = this.autoStartExternallyUnblockedReadyTasks();
-    this.checkWorkflowCompletion();
+    this.checkWorkflowCompletion(workflowId);
     return started;
   }
 
@@ -3521,8 +3521,23 @@ export class Orchestrator {
     checkExperimentCompletionImpl(this as unknown as TransitionHost, taskId);
   }
 
-  private checkWorkflowCompletion(): void {
-    checkWorkflowCompletionImpl(this as unknown as TransitionHost);
+  private getWorkflowIdsToTouchAfterWorkflowTransition(workflowId: string): string[] {
+    const touched = new Set<string>();
+    if (this.activeWorkflowIds.has(workflowId)) {
+      touched.add(workflowId);
+    }
+    for (const workflow of this.persistence.listWorkflows()) {
+      if (!this.activeWorkflowIds.has(workflow.id)) continue;
+      if (workflow.id === workflowId) continue;
+      if ((workflow.externalDependencies ?? []).some((dep) => dep.workflowId === workflowId)) {
+        touched.add(workflow.id);
+      }
+    }
+    return [...touched];
+  }
+
+  private checkWorkflowCompletion(transitionedWorkflowId?: string): void {
+    checkWorkflowCompletionImpl(this as unknown as TransitionHost, transitionedWorkflowId);
   }
 
   private autoStartReadyTasks(taskIds: string[], priority: number = 0, opts?: LaunchReadinessOptions): TaskState[] {

--- a/packages/workflow-core/src/orchestrator/cancellation.ts
+++ b/packages/workflow-core/src/orchestrator/cancellation.ts
@@ -94,7 +94,7 @@ export interface CancellationHost {
   ): string;
   clearQueuedSchedulerEntries(taskId: string, attemptId?: string): void;
   invalidateLaunchArtifactsForTasks(taskIds: readonly string[], reason: string, now?: Date): void;
-  checkWorkflowCompletion(): void;
+  checkWorkflowCompletion(transitionedWorkflowId?: string): void;
   drainScheduler(): TaskState[];
 }
 
@@ -297,7 +297,7 @@ export function cancelTaskImpl(
     cancelled.push(id);
   }
 
-  host.checkWorkflowCompletion();
+  host.checkWorkflowCompletion(task.config.workflowId);
   return { cancelled, runningCancelled, toCancelIds };
 }
 
@@ -369,7 +369,7 @@ export function cancelWorkflowImpl(
     cancelled.push(id);
   }
 
-  host.checkWorkflowCompletion();
+  host.checkWorkflowCompletion(workflowId);
   return { cancelled, runningCancelled, toCancelIds };
 }
 

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -59,6 +59,7 @@ export interface TransitionHost {
   buildUpdateDelta(before: TaskState, after: TaskState, changes: TaskStateChanges): TaskDelta;
   ensureCurrentPendingAttempt(task: TaskState): string;
   touchWorkflow(workflowId: string): void;
+  getWorkflowIdsToTouchAfterWorkflowTransition(workflowId: string): string[];
   setTaskApprovalStatus(
     taskId: string,
     status: 'awaiting_approval' | 'review_ready',
@@ -180,7 +181,7 @@ export function handleCompletedImpl(
     started.push(...host.autoStartReadyTasks(deferredTaskIds));
   }
 
-  checkWorkflowCompletionImpl(host);
+  checkWorkflowCompletionImpl(host, task?.config.workflowId);
   return started;
 }
 
@@ -267,7 +268,7 @@ export function finalizeFailedTaskImpl(
     started.push(...host.autoStartReadyTasks(deferredTaskIds));
   }
 
-  checkWorkflowCompletionImpl(host);
+  checkWorkflowCompletionImpl(host, existing.config.workflowId);
   return started;
 }
 
@@ -276,6 +277,7 @@ export function handleReviewReadyImpl(
   taskId: string,
   parsed: Extract<ParsedResponse, { type: 'review_ready' }>,
 ): TaskState[] {
+  const task = host.stateGetTask(taskId);
   const changes: TaskStateChanges = {
     config: { summary: parsed.summary },
     execution: {
@@ -292,7 +294,7 @@ export function handleReviewReadyImpl(
 
   const started = host.autoStartUnblockedTasks();
   started.push(...host.autoStartExternallyUnblockedReadyTasks());
-  checkWorkflowCompletionImpl(host);
+  checkWorkflowCompletionImpl(host, task?.config.workflowId);
   return started;
 }
 
@@ -452,8 +454,9 @@ export function checkExperimentCompletionImpl(host: TransitionHost, taskId: stri
   }
 }
 
-export function checkWorkflowCompletionImpl(host: TransitionHost): void {
-  for (const wfId of host.activeWorkflowIds) {
+export function checkWorkflowCompletionImpl(host: TransitionHost, transitionedWorkflowId?: string): void {
+  if (!transitionedWorkflowId) return;
+  for (const wfId of host.getWorkflowIdsToTouchAfterWorkflowTransition(transitionedWorkflowId)) {
     host.touchWorkflow(wfId);
   }
 }


### PR DESCRIPTION
## Summary

One task finishing used to stamp `updated_at` on every active workflow row — 93 rows in one second in the incident DB — making old failures look brand new.

Workflow status is a read-time rollup, never stored, so `updated_at` is the only freshness signal. The sweep in `checkWorkflowCompletionImpl` turned each completion into a phantom mass-failure event.

This change scopes that sweep to workflows actually affected by the transition: the owning workflow, plus workflows whose `externalDependencies` reference it. Bystander rows stay untouched.

Cross-workflow wakeup is preserved: a downstream workflow gated on an upstream merge gate still wakes exactly as before. A regression test in packages/workflow-core proves both properties.

## Review Claim

After one task's terminal transition, only the owning workflow and workflows whose `externalDependencies` reference it get a fresh `updated_at`; an unaffected bystander row is not rewritten, and dependent-workflow wakeup still fires.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only `checkWorkflowCompletionImpl`'s touch scope plus the minimal `TransitionHost`/orchestrator plumbing it needs changes. A task's own status write still touches its owning workflow via `writeAndSync`, and the new regression test locks in both the bystander and wakeup properties.

## Slice Rationale

One behavior slice: the sweep-scope fix at its source in packages/workflow-core plus its directly affected regression test. The checked-in scripts/repro/ guard is a different review claim (proof lane) and lands as the next stacked workflow in this chain.

## Non-goals

- No change to packages/data-store: `updateWorkflow` keeps stamping `updated_at` for real updates.
- No change to the read-time rollup in packages/workflow-graph.
- No fix for the separate workflow-resume worker FK-violation amplifier (different bug, its own chain).
- No checked-in scripts/repro/ file in this slice (next workflow in the chain).
- No schema migration and no stored workflow status column.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core test -- workflow-touch-scope`
- [x] `pnpm --filter @invoker/workflow-core test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0ecb116981d7378eaaeb22a3cb2c3789c1bc78f7`
- Post-revert steps: None
- Data migration? No

</details>