### PR TITLE
[Stop the async repair normalize task from blocking on its own bytecode cache](1) Make the normalize dirty-gate immune to its own bytecode cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ local-builds/
 
 # Local pipeline secrets/config
 config/nightly-usage.env
+__pycache__/

--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -200,7 +200,7 @@ def build_repair_check_plan(
     yaml_text += _repair_task_yaml(description=f"Repair PR #{pr.number} (failed check {check_name})", prompt=prompt)
     normalize_command = (
         "set -euo pipefail\n"
-        "python3 scripts/mergify_admin_requeue_repair_normalize.py \\\n"
+        "python3 -B scripts/mergify_admin_requeue_repair_normalize.py \\\n"
         f"  --repo {_shlex(repo)} --pr {pr.number} --check {_shlex(check_name)} \\\n"
         f"  --start-head {_shlex(start_head)} --base {_shlex(pr.base_ref_name)} --trunk master\n"
     )

--- a/scripts/mergify_admin_requeue_repair_normalize.py
+++ b/scripts/mergify_admin_requeue_repair_normalize.py
@@ -5,6 +5,9 @@ import sys
 from pathlib import Path
 from typing import Sequence
 
+# The normalize process must not dirty the checkout it is about to dirty-check.
+sys.dont_write_bytecode = True
+
 try:
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Ledger
@@ -78,9 +81,10 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     _record_settle_marker(state_file, args.pr, start_head, args.check)
 
-    if git_lines(cwd, "status", "--porcelain"):
+    dirty = git_lines(cwd, "status", "--porcelain")
+    if dirty:
         hard_reset_work_root(cwd, start_head)
-        print("blocked_dirty: repair left the working tree dirty", file=sys.stderr)
+        print("blocked_dirty: repair left the working tree dirty: " + "; ".join(dirty), file=sys.stderr)
         return 1
 
     end_head = git_output(cwd, "rev-parse", "HEAD").strip()

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -98,8 +98,8 @@ class AsyncRepairPlanTests(unittest.TestCase):
     def test_repair_check_plan_runs_normalize_with_bytecode_disabled(self):
         plan = async_repair.build_repair_check_plan(
             pr(), "PR Body", repo="owner/repo", details_url="https://example.invalid/job",
-            log_path="/tmp/pr-body.log", queue_only=False, queue_pr_number=0, latest=None,
-            start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
+            log_path="/does/not/exist/pr-body.log", queue_only=False, queue_pr_number=0, latest=None,
+            start_head=HEAD, state_file=Path("ledger.jsonl"),
         )
         self.assertIn("python3 -B scripts/mergify_admin_requeue_repair_normalize.py", plan.yaml_text)
 

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -95,6 +95,14 @@ class AsyncRepairPlanTests(unittest.TestCase):
         # PR titles with quotes/colons must not corrupt the YAML document.
         self.assertIn('Fix \\"quoted\\" title: with colons', plan.yaml_text)
 
+    def test_repair_check_plan_runs_normalize_with_bytecode_disabled(self):
+        plan = async_repair.build_repair_check_plan(
+            pr(), "PR Body", repo="owner/repo", details_url="https://example.invalid/job",
+            log_path="/tmp/pr-body.log", queue_only=False, queue_pr_number=0, latest=None,
+            start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
+        )
+        self.assertIn("python3 -B scripts/mergify_admin_requeue_repair_normalize.py", plan.yaml_text)
+
     def test_repair_check_plan_inlines_job_log_content_not_local_path(self):
         # log_path is a tempfile on the orchestrator's own machine; the plan
         # is dispatched to a separate headless worker that does not share

--- a/scripts/test_mergify_admin_requeue_repair_normalize.py
+++ b/scripts/test_mergify_admin_requeue_repair_normalize.py
@@ -10,6 +10,7 @@ Run:  python3 scripts/test_mergify_admin_requeue_repair_normalize.py
 
 from __future__ import annotations
 
+import io
 import os
 import sys
 import tempfile
@@ -82,6 +83,9 @@ class RepairNormalizeTests(unittest.TestCase):
             return []
         return [line for line in self.state_file.read_text(encoding="utf-8").splitlines() if '"repair-check-settled"' in line]
 
+    def test_import_disables_bytecode_writes(self):
+        self.assertIs(normalize.sys.dont_write_bytecode, True)
+
     def test_records_settle_marker_first_regardless_of_outcome(self):
         with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=("M file.py",)):
             with mock.patch("scripts.mergify_admin_requeue_repair_normalize.hard_reset_work_root"):
@@ -95,6 +99,16 @@ class RepairNormalizeTests(unittest.TestCase):
                 code = normalize.main(self.argv())
         self.assertEqual(code, 1)
         reset.assert_called_once_with(Path.cwd(), HEAD)
+
+    def test_dirty_working_tree_error_names_dirty_paths(self):
+        stderr = io.StringIO()
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=["?? stray.txt"]):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.hard_reset_work_root"):
+                with mock.patch("sys.stderr", stderr):
+                    code = normalize.main(self.argv())
+        self.assertEqual(code, 1)
+        self.assertIn("blocked_dirty", stderr.getvalue())
+        self.assertIn("?? stray.txt", stderr.getvalue())
 
     def test_no_commit_returns_zero_without_further_work(self):
         with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):


### PR DESCRIPTION
## Summary

Every admin-bypass-repair-check workflow was failing at its normalize step with `blocked_dirty: repair left the working tree dirty`, even when the repair agent had correctly committed nothing.

The script's own imports made CPython write `scripts/__pycache__/` into the fresh task checkout. That directory was not gitignored, so the dirty check tripped on the script's own bytecode.

This PR stops the normalize process from writing bytecode at all. The script sets `sys.dont_write_bytecode` before importing its siblings, and the generated plan command becomes `python3 -B`.

The `-B` flag matters on its own: the command text renders from the cron host's master checkout, while the executed script comes from the PR branch under repair.

That means `-B` immediately fixes repair runs against branches cut before this change.

`.gitignore` also gains `__pycache__/`, so any Python the repair agent itself runs cannot dirty a task checkout either. A genuine `blocked_dirty` failure now names the offending `git status --porcelain` entries.

## Review Claim

The normalize dirty-gate can no longer be tripped by CPython bytecode written by the normalize process itself (the script sets `sys.dont_write_bytecode`, the generated invocation adds `-B`, and `__pycache__/` is gitignored), and a genuine blocked_dirty failure now names the offending `git status --porcelain` entries instead of an unactionable one-liner.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Three narrow edits with no control-flow change on the success path: one interpreter flag set before imports in `scripts/mergify_admin_requeue_repair_normalize.py` plus an enriched stderr string in its existing dirty branch, one literal `-B` added to the generated command string in `scripts/mergify_admin_requeue_async_repair.py`, and one ignore rule appended to `.gitignore`. No schema, API, planner-gate, or repairer change; the two touched test files gain cases only. Nothing currently tracked in the repo matches `__pycache__/` (`git ls-files | grep __pycache__` is empty), so the new ignore rule cannot untrack or hide existing content.

## Slice Rationale

One policy slice: the single self-dirtying defect and its diagnostic gap in the shared normalize pipeline, plus directly-affected unittests (this repo's review-compression rule keeps directly-affected tests with the change). The workflow's proof step was a deterministic inline verification that made no file changes, so it publishes no PR slice; the checked-in `scripts/repro/` regression guard lands as its own stacked proof slice because `scripts/repro/` files carry the proof classification and cannot land in this tooling-policy PR.

## Non-goals

- No change to the repairer, planner gates, exec loop, headless shell timeout, safe-push task, or any TS package.
- No `scripts/repro/` file in this slice — the checked-in regression guard lands as the stacked proof slice.
- No retroactive retry of the failed PR #7560 workflows (the babysit worker resubmits on its own once the fix lands).
- No filtering or special-casing of pycache paths inside the dirty check itself.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m py_compile scripts/mergify_admin_requeue_repair_normalize.py scripts/mergify_admin_requeue_async_repair.py`
- [x] `python3 scripts/test_mergify_admin_requeue_repair_normalize.py`
- [x] `python3 scripts/test_mergify_admin_requeue_async_repair.py`
- [x] `grep -q 'python3 -B scripts/mergify_admin_requeue_repair_normalize.py' scripts/mergify_admin_requeue_async_repair.py`
- [x] `grep -qx '__pycache__/' .gitignore && git check-ignore scripts/__pycache__/x.pyc`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <squash-merge sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repair normalization now avoids generating Python bytecode cache files.
  * Dirty working-tree errors now identify the specific files blocking the operation.

* **Chores**
  * Python bytecode cache directories are now excluded from version control.

* **Tests**
  * Added coverage for bytecode suppression and detailed dirty-tree error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->