### PR TITLE
[Add repro guarding the normalize pycache blocked_dirty fix](1) Add scripts/repro normalize pycache blocked_dirty regression guard

### DIFF
--- a/scripts/repro/repro-normalize-blocked-dirty-pycache.sh
+++ b/scripts/repro/repro-normalize-blocked-dirty-pycache.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-normalize-blocked-dirty-pycache.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+WORK="$TMP/work"
+mkdir -p "$WORK/scripts"
+cp scripts/*.py "$WORK/scripts/"
+
+git -C "$WORK" init -q
+git -C "$WORK" add scripts
+git -C "$WORK" -c user.name=repro -c user.email=repro@example.invalid commit -q -m "fixture"
+
+START_HEAD="$(git -C "$WORK" rev-parse HEAD)"
+STATE_FILE="$TMP/ledger.jsonl"
+
+run_normalize() {
+  (
+    cd "$WORK"
+    env -u PYTHONDONTWRITEBYTECODE -u PYTHONPYCACHEPREFIX python3 \
+      scripts/mergify_admin_requeue_repair_normalize.py \
+      --repo Neko-Catpital-Labs/Invoker \
+      --pr 7560 \
+      --check "PR Body" \
+      --start-head "$START_HEAD" \
+      --base master \
+      --trunk master \
+      --state-file "$STATE_FILE"
+  )
+}
+
+clean_stdout="$TMP/clean.stdout"
+clean_stderr="$TMP/clean.stderr"
+if ! run_normalize >"$clean_stdout" 2>"$clean_stderr"; then
+  printf '[repro] clean noop normalize unexpectedly failed\n' >&2
+  printf '%s\n' '--- stdout ---' >&2
+  cat "$clean_stdout" >&2
+  printf '%s\n' '--- stderr ---' >&2
+  cat "$clean_stderr" >&2
+  exit 1
+fi
+
+if ! grep -qx "noop: repair task made no commit" "$clean_stdout"; then
+  printf '[repro] clean noop normalize did not report noop\n' >&2
+  printf '%s\n' '--- stdout ---' >&2
+  cat "$clean_stdout" >&2
+  exit 1
+fi
+
+dirty_after_clean="$(git -C "$WORK" status --porcelain)"
+if [[ -n "$dirty_after_clean" ]]; then
+  printf '[repro] clean noop normalize dirtied the worktree\n' >&2
+  printf '%s\n' "$dirty_after_clean" >&2
+  exit 1
+fi
+
+touch "$WORK/dirty-sentinel.txt"
+dirty_stdout="$TMP/dirty.stdout"
+dirty_stderr="$TMP/dirty.stderr"
+if run_normalize >"$dirty_stdout" 2>"$dirty_stderr"; then
+  printf '[repro] dirty normalize unexpectedly succeeded\n' >&2
+  exit 1
+fi
+
+if ! grep -q "blocked_dirty" "$dirty_stderr"; then
+  printf '[repro] dirty normalize did not report blocked_dirty\n' >&2
+  printf '%s\n' '--- stderr ---' >&2
+  cat "$dirty_stderr" >&2
+  exit 1
+fi
+
+if ! grep -q "?? dirty-sentinel.txt" "$dirty_stderr"; then
+  printf '[repro] blocked_dirty did not name the dirty path\n' >&2
+  printf '%s\n' '--- stderr ---' >&2
+  cat "$dirty_stderr" >&2
+  exit 1
+fi
+
+echo "[repro] passed: clean noop normalizes to noop; blocked_dirty names the dirty path"


### PR DESCRIPTION
## Summary

Adds a checked-in regression guard proving the normalize self-dirtying fix from the slice below this one.

The guard rebuilds the incident shape: it commits the worker's own Python modules into a hermetic throwaway git repo and runs the real normalize entrypoint there with plain `python3`.

It asserts a clean noop repair normalizes to `noop` with a still-clean tree, so the script's own bytecode can never trip the dirty-gate again.

It also asserts a genuinely dirty tree still fails `blocked_dirty` and that the failure names the offending path.

It deliberately omits the repo `.gitignore` and the `-B` flag: the guard must prove the script-level `sys.dont_write_bytecode` defense, the only layer protecting pre-fix PR branches.

## Review Claim

`bash scripts/repro/repro-normalize-blocked-dirty-pycache.sh` exits 0 only when the normalize entrypoint, run with plain python3 in a hermetic freshly committed checkout of the worker's own modules (no .gitignore), yields 'noop: repair task made no commit' with a still-clean tree, and a genuinely dirty tree fails with blocked_dirty naming the dirty path.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Adds one executable shell script under scripts/repro/ and touches nothing else; the script itself writes only inside a mktemp directory, performs no network access, and never modifies the invoking repo's working tree, git state, or ~/.invoker.

## Slice Rationale

One proof slice: the checked-in regression guard only, matching this repo's convention for admin-requeue fixes (see scripts/repro/repro-mergify-admin-requeue.sh for an equivalent guard). Kept apart from the fix because scripts/repro/ files carry the proof classification and cannot land in the same PR as the tooling change.

## Non-goals

- No change to any scripts/mergify_admin_requeue_*.py file.
- No unittest changes and no test-suite wiring under scripts/test-suites/.
- No exercise of the safe-push or prerequisite-split paths.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-normalize-blocked-dirty-pycache.sh` exits 0 and prints the passed line
- [x] `test -x scripts/repro/repro-normalize-blocked-dirty-pycache.sh`
- [x] `git status --porcelain` stays empty after the run

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a reproduction check for normalization behavior in clean and dirty worktrees.
  * Verifies clean worktrees complete without changes.
  * Confirms dirty worktrees are blocked and identify the untracked file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->