### PR TITLE
Fix cron uninstall aborting on sole-entry crontab

### DIFF
--- a/scripts/uninstall-e2e-regression-watch-cron.sh
+++ b/scripts/uninstall-e2e-regression-watch-cron.sh
@@ -7,7 +7,8 @@ TMP_CRON="$(mktemp -t invoker-cron-remove.XXXXXX)"
 trap 'rm -f "$TMP_CRON"' EXIT
 
 if crontab -l >/dev/null 2>&1; then
-  crontab -l | grep -Fv "$MARKER" > "$TMP_CRON"
+  # grep -v exits 1 when nothing remains (sole-entry crontab); only exit >1 is a real error.
+  crontab -l | { grep -Fv "$MARKER" || [ $? -eq 1 ]; } > "$TMP_CRON"
   crontab "$TMP_CRON"
   echo "Removed cron entry (if present): $MARKER"
 else


### PR DESCRIPTION
## Summary

The cron uninstall script silently failed when the watcher entry was the only crontab line. This happened live on DO1 during the 2026-08-07 thrash incident response.

`grep -Fv "$MARKER"` exits 1 when it emits no lines. Under `set -euo pipefail`, that killed the script before `crontab "$TMP_CRON"` ran, so the entry survived.

The fix treats grep exit 1 (nothing left after filtering) as success: `{ grep -Fv "$MARKER" || [ $? -eq 1 ]; }`.

Real grep errors (exit 2) still make the compound exit non-zero, so `set -e` aborts before installing a corrupt crontab.

A bare `|| true` was rejected because it would mask genuine grep failures.

## Review Claim

Uninstalling the e2e regression watcher now works when the marker entry is the only crontab line, without masking real grep errors.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The only changed line is the crontab filter pipeline; a real grep failure (exit 2) still aborts the script before `crontab "$TMP_CRON"` installs anything, so a broken filter can never replace the live crontab.

## Slice Rationale

Single-line operator-tooling fix hit live during the DO1 incident. Kept as its own PR so the reviewer approves exactly one exit-code-handling change; bundling it with other incident-response fixes would mix unrelated review units.

## Non-goals

- No change to the install script or the watcher itself.
- No repro/proof harness files added; the manual shim-based test plan below covers verification.
- No change to the no-crontab ("nothing to remove") path.

## Test Plan

<details>
<summary>Test Plan</summary>

All runs used a PATH-shimmed fake `crontab` storing state in a temp file (never the live crontab).

- [x] Sole-entry crontab (marker line only): `PATH="$SHIMDIR:$PATH" bash scripts/uninstall-e2e-regression-watch-cron.sh` → exit 0, prints `Removed cron entry (if present): # invoker-e2e-regression-watch`, resulting crontab empty. (Previously: exit 1, no output, entry survived.)
- [x] Marker + two unrelated lines: same command → exit 0, both unrelated lines preserved verbatim.
- [x] No crontab (fake `crontab -l` exits 1): same command → exit 0, prints `No crontab found for current user; nothing to remove.`
- [x] grep hard failure: with a shimmed `grep` exiting 2 → script exits 1, nothing printed, crontab untouched (`[ $? -eq 1 ]` is false for exit 2, so the compound fails and `set -e` aborts before `crontab "$TMP_CRON"`).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes — reverting only reintroduces the sole-entry uninstall failure.
- Revert command: `git revert d08a88a1e9a446b39be217a5faf111a24d746249`
- Post-revert steps: None
- Data migration? No

</details>
