### PR TITLE
[Admin-bypass worker: escalate a fully failed dispatch tick to an ERROR event](1) Emit degraded dispatch event

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -107,6 +107,10 @@ def run_cycle(args: argparse.Namespace) -> bool:
     )
     should_poll = False
     any_progress = False
+    repair_dispatch_attempted = 0
+    repair_dispatch_failed = 0
+    repair_dispatch_succeeded = 0
+    repair_dispatch_last_error: str | None = None
     open_pr_numbers = set(pr_by_number)
     for stack in stacks:
         plan = plan_stack_execution(
@@ -162,6 +166,9 @@ def run_cycle(args: argparse.Namespace) -> bool:
                             outcome = repairer.repair_check(pr, check_name, now)
                             progressed = outcome.status in {"pushed", "prereq_created", "submitted"}
                 except Exception as exc:
+                    repair_dispatch_attempted += 1
+                    repair_dispatch_failed += 1
+                    repair_dispatch_last_error = str(exc)
                     logger.trace(
                         "admin-bypass-repair-attempt-failed",
                         repo=args.repo,
@@ -173,6 +180,8 @@ def run_cycle(args: argparse.Namespace) -> bool:
                     should_poll = True
                     continue
                 if progressed:
+                    repair_dispatch_attempted += 1
+                    repair_dispatch_succeeded += 1
                     any_progress = True
                 else:
                     should_poll = True
@@ -191,6 +200,9 @@ def run_cycle(args: argparse.Namespace) -> bool:
                         outcome = repairer.repair_conflict(pr, action.detail, now)
                         progressed = outcome.status in {"pushed", "prereq_created", "submitted"}
                 except Exception as exc:
+                    repair_dispatch_attempted += 1
+                    repair_dispatch_failed += 1
+                    repair_dispatch_last_error = str(exc)
                     logger.trace(
                         "admin-bypass-repair-attempt-failed",
                         repo=args.repo,
@@ -202,6 +214,8 @@ def run_cycle(args: argparse.Namespace) -> bool:
                     should_poll = True
                     continue
                 if progressed:
+                    repair_dispatch_attempted += 1
+                    repair_dispatch_succeeded += 1
                     any_progress = True
                 else:
                     should_poll = True
@@ -234,6 +248,14 @@ def run_cycle(args: argparse.Namespace) -> bool:
                         )
                 if action.kind not in {"comment_blocked", "comment_admin_bypass_nudge"}:
                     any_progress = True
+    if repair_dispatch_attempted >= 1 and repair_dispatch_succeeded == 0:
+        logger.error(
+            "admin-bypass-dispatch-degraded",
+            repo=args.repo,
+            attempted=repair_dispatch_attempted,
+            failed=repair_dispatch_failed,
+            last_error=repair_dispatch_last_error,
+        )
     if not stacks:
         logger.trace("admin-bypass-scan-empty")
     return any_progress or should_poll

--- a/scripts/mergify_admin_requeue_logger.py
+++ b/scripts/mergify_admin_requeue_logger.py
@@ -15,6 +15,10 @@ class AdminBypassLogger:
         payload = {"event": event, **fields}
         print(f"TRACE {json.dumps(payload, sort_keys=True)}", file=sys.stderr)
 
+    def error(self, event: str, **fields: object) -> None:
+        payload = {"event": event, **fields}
+        print(f"ERROR {json.dumps(payload, sort_keys=True)}", file=sys.stderr)
+
     def action_payload(self, action: Action) -> dict[str, object]:
         return {
             "kind": action.kind,

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -1,4 +1,5 @@
 import io
+import json
 import os
 import subprocess
 import sys
@@ -133,6 +134,17 @@ class MergifyAdminRequeueTests(unittest.TestCase):
         executor = AdminBypassGhExecutor(gh, ledger, logger, repo)
         return AdminBypassRepairer(gh, executor, logger, ledger, repo)
 
+    def log_rows(self, text):
+        rows = []
+        for line in text.splitlines():
+            if " " not in line:
+                continue
+            level, payload = line.split(" ", 1)
+            row = json.loads(payload)
+            row["_level"] = level
+            rows.append(row)
+        return rows
+
     def test_loads_admin_bypass_rule_from_mergify_yml(self):
         trunk, labels, required = load_mergify_rules(Path(".mergify.yml"))
         self.assertEqual(trunk, "master")
@@ -143,6 +155,10 @@ class MergifyAdminRequeueTests(unittest.TestCase):
             "PR Body",
             "quality / TypeScript Types",
             "required-fast / Guardrails",
+            "required-fast / Merge Gate Concurrency Repro",
+            "required-fast / Launch Dispatch Queue Repro",
+            "required-fast / Start Running MECE Repros",
+            "required-fast / Branch Carry Forward",
             "required-fast / Submit Workflow Chain",
             "UI Vitest",
         }))
@@ -578,6 +594,73 @@ Failing checks
         self.assertIn('"kind": "repair_check"', log)
         self.assertIn('"failed_check"', log)
         self.assertIn('"pr_number": 2606', log)
+
+    def test_run_cycle_logs_degraded_once_when_all_repair_dispatches_fail(self):
+        args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
+        checks = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        stacks = (
+            StackGroup("s1", (pr(7101, checks=checks, latest=mergify()),)),
+            StackGroup("s2", (pr(7102, checks=checks, latest=mergify()),)),
+        )
+        stderr = io.StringIO()
+        stdout = io.StringIO()
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=object()):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=stacks, open_pr_numbers_by_head={})):
+                    with mock.patch.object(exec_impl, "resolve_workflow_for_pr", return_value=None):
+                        with mock.patch.object(AdminBypassRepairer, "repair_check", side_effect=[TimeoutError("timed out after 30s"), RuntimeError("second failure")]):
+                            with redirect_stdout(stdout), redirect_stderr(stderr):
+                                should_poll = exec_impl.run_cycle(args)
+        self.assertTrue(should_poll)
+        log = stderr.getvalue()
+        self.assertEqual(log.count('"event": "admin-bypass-repair-attempt-failed"'), 2)
+        degraded = [row for row in self.log_rows(log) if row.get("event") == "admin-bypass-dispatch-degraded"]
+        self.assertEqual(len(degraded), 1)
+        self.assertEqual(degraded[0]["_level"], "ERROR")
+        self.assertEqual(degraded[0]["repo"], "owner/repo")
+        self.assertEqual(degraded[0]["attempted"], 2)
+        self.assertEqual(degraded[0]["failed"], 2)
+        self.assertEqual(degraded[0]["last_error"], "second failure")
+
+    def test_run_cycle_does_not_log_degraded_when_any_repair_dispatch_succeeds(self):
+        args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
+        checks = {"PR Body": check("PR Body", "failure"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        stacks = (
+            StackGroup("s1", (pr(7201, checks=checks, latest=mergify()),)),
+            StackGroup("s2", (pr(7202, checks=checks, latest=mergify()),)),
+        )
+        outcome = RepairOutcome(status="submitted", check_name="PR Body", start_head=HEAD, end_head=HEAD)
+        stderr = io.StringIO()
+        stdout = io.StringIO()
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=object()):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=stacks, open_pr_numbers_by_head={})):
+                    with mock.patch.object(exec_impl, "resolve_workflow_for_pr", return_value=None):
+                        with mock.patch.object(AdminBypassRepairer, "repair_check", side_effect=[RuntimeError("first failure"), outcome]):
+                            with redirect_stdout(stdout), redirect_stderr(stderr):
+                                should_poll = exec_impl.run_cycle(args)
+        self.assertTrue(should_poll)
+        log = stderr.getvalue()
+        self.assertEqual(log.count('"event": "admin-bypass-repair-attempt-failed"'), 1)
+        self.assertNotIn('"event": "admin-bypass-dispatch-degraded"', log)
+
+    def test_run_cycle_does_not_log_degraded_when_no_repair_actions_are_planned(self):
+        args = requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])
+        checks = {"PR Body": check("PR Body", "pending"), "quality / TypeScript Types": check("quality / TypeScript Types")}
+        stack = StackGroup("s", (pr(7301, checks=checks, latest=mergify()),))
+        stderr = io.StringIO()
+        stdout = io.StringIO()
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), REQUIRED)):
+            with mock.patch.object(exec_impl, "GhClient", return_value=object()):
+                with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
+                    with mock.patch.object(exec_impl, "resolve_workflow_for_pr") as resolve:
+                        with mock.patch.object(AdminBypassRepairer, "repair_check") as repair_check:
+                            with redirect_stdout(stdout), redirect_stderr(stderr):
+                                should_poll = exec_impl.run_cycle(args)
+        self.assertTrue(should_poll)
+        resolve.assert_not_called()
+        repair_check.assert_not_called()
+        self.assertNotIn('"event": "admin-bypass-dispatch-degraded"', stderr.getvalue())
 
     def test_run_cycle_blocks_once_for_unaccepted_upper_stack(self):
         args = requeue.parse_args(["--once", "--dry-run", "--repo", "owner/repo", "--state-file", str(self.ledger().path)])


### PR DESCRIPTION
## Summary

During the August 6-7, 2026 incident, the admin-bypass worker kept ticking while every repair dispatch timed out.

That produced hundreds of TRACE failure events but no operator-visible ERROR signal.

This change emits one structured ERROR event when a tick attempts repairs and every dispatch fails.

The event carries attempted and failed counts plus the last dispatch error.

## Review Claim

A run_cycle that attempts at least one repair dispatch and records zero successes emits exactly one admin-bypass-dispatch-degraded ERROR event with attempted count, failed count, and last_error.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This is a logging-only addition at the end of existing per-tick failure accounting. It does not change repair dispatch, planner, ledger, retry, or merge behavior.

## Slice Rationale

The slice keeps the escalation predicate, structured event shape, and directly affected unittest coverage together. Retry caps and operator alerting surfaces remain separate claims.

## Non-goals

No change to dispatch behavior, retries, retry caps, planner gates, the TypeScript worker runtime, Slack alerts, or UI alerting surfaces.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/admin-bypass-worker-pr1.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1deb8ceb`
- Post-revert steps: None
- Data migration? No

</details>
