### PR TITLE
[Disk reclaim step 1: local sweep must not block the owner event loop](1) Add executable blocking repro

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-reclaim-event-loop-block.repro.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-reclaim-event-loop-block.repro.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { cleanupLocalInvokerHome } from '../workers/disk-headroom-reclaim.js';
+
+const tempDirs: string[] = [];
+const FILE_CONTENT = 'x'.repeat(256);
+const DIR_COUNT = 100;
+const FILES_PER_DIR = 200;
+const WATCHDOG_PERIOD_MS = 25;
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function buildInvokerHomeWithLargeWorktree(): string {
+  const root = mkdtempSync(join(tmpdir(), 'invoker-disk-reclaim-event-loop-'));
+  tempDirs.push(root);
+  const home = join(root, '.invoker');
+  const worktree = join(home, 'worktrees', 'wt-1');
+
+  for (let dirIndex = 0; dirIndex < DIR_COUNT; dirIndex += 1) {
+    const dir = join(worktree, `dir-${dirIndex}`);
+    mkdirSync(dir, { recursive: true });
+    for (let fileIndex = 0; fileIndex < FILES_PER_DIR; fileIndex += 1) {
+      writeFileSync(join(dir, `file-${fileIndex}.txt`), FILE_CONTENT);
+    }
+  }
+
+  return home;
+}
+
+async function cleanupLargeWorktree(home: string) {
+  return cleanupLocalInvokerHome({
+    invokerHome: home,
+    userHome: join(home, '..'),
+  });
+}
+
+describe('cleanupLocalInvokerHome event-loop blocking repro', () => {
+  it('clears a large local worktree tree successfully', async () => {
+    const home = buildInvokerHomeWithLargeWorktree();
+
+    const result = await cleanupLargeWorktree(home);
+
+    expect(result.ok).toBe(true);
+    expect(readdirSync(join(home, 'worktrees'))).toEqual([]);
+  });
+
+  it.fails('keeps watchdog-sized event-loop lag below 250ms while sweeping local worktrees', async () => {
+    const home = buildInvokerHomeWithLargeWorktree();
+    let lastTick = process.hrtime.bigint();
+    let maxLagMs = 0;
+
+    const interval = setInterval(() => {
+      const now = process.hrtime.bigint();
+      const elapsedMs = Number(now - lastTick) / 1_000_000;
+      maxLagMs = Math.max(maxLagMs, elapsedMs - WATCHDOG_PERIOD_MS);
+      lastTick = now;
+    }, WATCHDOG_PERIOD_MS);
+
+    await cleanupLargeWorktree(home);
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    clearInterval(interval);
+
+    expect(maxLagMs).toBeLessThan(250);
+  });
+});

--- a/packages/execution-engine/src/__tests__/disk-reclaim-event-loop-block.repro.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-reclaim-event-loop-block.repro.test.ts
@@ -63,9 +63,12 @@ describe('cleanupLocalInvokerHome event-loop blocking repro', () => {
       lastTick = now;
     }, WATCHDOG_PERIOD_MS);
 
-    await cleanupLargeWorktree(home);
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
-    clearInterval(interval);
+    try {
+      await cleanupLargeWorktree(home);
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    } finally {
+      clearInterval(interval);
+    }
 
     expect(maxLagMs).toBeLessThan(250);
   });

--- a/scripts/repro/repro-disk-reclaim-event-loop-block.sh
+++ b/scripts/repro/repro-disk-reclaim-event-loop-block.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SPEC="src/__tests__/disk-reclaim-event-loop-block.repro.test.ts"
+
+cd "$REPO_ROOT/packages/execution-engine"
+
+if ! pnpm exec vitest run "$SPEC"; then
+  echo "[repro] FAIL: local disk sweep event-loop blocking repro failed to run"
+  exit 1
+fi
+
+if grep -q "it.fails" "$SPEC"; then
+  echo "[repro] reproduced: local disk sweep blocks the owner event loop (fix pending in this stack)"
+else
+  echo "[repro] fixed: local disk sweep no longer blocks the owner event loop"
+fi


### PR DESCRIPTION
## Summary

Adds an executable repro for the disk reclaim stall that preceded the 2026-08-07 owner restart.

The spec builds a large local worktree, samples event-loop lag, and documents the current blocking remove with `it.fails`.

The wrapper runs the spec and reports whether the bug is still reproduced or fixed.

## Review Claim

Approve one expected-failing repro spec plus its bash wrapper; production disk reclaim code is untouched.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This is test-only. The spec writes only under a fresh `mkdtemp` directory and asserts existing public cleanup behavior.

## Slice Rationale

Evidence lands before the production change, so the next slice carries its own local proof.

## Non-goals

- No production code changes.
- No remote reclaim coverage.
- No asar or ENOTDIR coverage.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/disk-reclaim-event-loop-block.repro.test.ts`
- [x] `bash scripts/repro/repro-disk-reclaim-event-loop-block.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 07e16d905577b6a45f42471187d21c2495177065`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for cleaning up large temporary worktrees.
  * Added monitoring to detect excessive event-loop delays during cleanup.
  * Added automatic cleanup of temporary test directories.

* **Chores**
  * Added a script to run the disk-reclamation regression test and report its status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->