### PR TITLE
[Disk reclaim step 1: local sweep must not block the owner event loop](2) Run local deletes out of process

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
@@ -226,6 +226,53 @@ describe('cleanupLocalInvokerHome', () => {
     expect(existsSync(join(userHome, '.cache', 'electron', 'keep.bin'))).toBe(true);
   });
 
+  it('leaves protected reclaimable paths untouched', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'invoker-disk-cleanup-protected-'));
+    tempDirs.push(root);
+    const home = join(root, '.invoker');
+    const userHome = root;
+    const activeDir = join(home, 'worktrees', 'active-task');
+    mkdirSync(activeDir, { recursive: true });
+    writeFileSync(join(activeDir, 'file.txt'), 'x');
+
+    const store = makeStore([
+      {
+        id: 'wf-1',
+        tasks: [
+          makeTask({ id: 'wf-1/active', status: 'running', execution: { workspacePath: activeDir } }),
+        ],
+      },
+    ]);
+
+    const result = await cleanupLocalInvokerHome({
+      invokerHome: home,
+      userHome,
+      store,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe('protected-path-in-use');
+    expect(existsSync(activeDir)).toBe(true);
+    expect(existsSync(join(activeDir, 'file.txt'))).toBe(true);
+    expect(readdirSync(join(home, 'worktrees'))).toEqual(['active-task']);
+  });
+
+  it('clears pre-existing deleting orphans from the invoker home', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'invoker-disk-cleanup-orphan-'));
+    tempDirs.push(root);
+    const home = join(root, '.invoker');
+    const userHome = root;
+    const orphan = join(home, 'foo.deleting.abc');
+    mkdirSync(orphan, { recursive: true });
+    writeFileSync(join(orphan, 'file.txt'), 'x');
+
+    const result = await cleanupLocalInvokerHome({ invokerHome: home, userHome });
+
+    expect(result.ok).toBe(true);
+    expect(existsSync(orphan)).toBe(false);
+  });
+
   it('refuses to clean the user home itself', async () => {
     const result = await cleanupLocalInvokerHome({
       invokerHome: '/Users/me',

--- a/packages/execution-engine/src/__tests__/disk-reclaim-event-loop-block.repro.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-reclaim-event-loop-block.repro.test.ts
@@ -51,7 +51,7 @@ describe('cleanupLocalInvokerHome event-loop blocking repro', () => {
     expect(readdirSync(join(home, 'worktrees'))).toEqual([]);
   });
 
-  it.fails('keeps watchdog-sized event-loop lag below 250ms while sweeping local worktrees', async () => {
+  it('keeps watchdog-sized event-loop lag below 250ms while sweeping local worktrees', async () => {
     const home = buildInvokerHomeWithLargeWorktree();
     let lastTick = process.hrtime.bigint();
     let maxLagMs = 0;

--- a/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
@@ -5,9 +5,13 @@
  * Never touches invoker.db / config.json / the home root / paths outside the home.
  */
 
-import { existsSync, mkdirSync, readdirSync, renameSync, rmSync } from 'node:fs';
+import { execFile } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, readdirSync, renameSync } from 'node:fs';
+import { rm as rmAsync } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve, sep } from 'node:path';
+import { promisify } from 'node:util';
 
 import type { Logger } from '@invoker/contracts';
 import type { TaskState } from '@invoker/workflow-core';
@@ -216,6 +220,7 @@ exit 0
 
 const LOCAL_RM_MAX_RETRIES = 5;
 const LOCAL_RM_RETRY_DELAY_MS = 100;
+const execFileAsync = promisify(execFile);
 
 /**
  * Read-only accessor for Invoker's own workflow/task state, used to derive
@@ -292,28 +297,43 @@ function pathIsProtected(candidate: string, protectedPaths: ReadonlySet<string>)
 /**
  * Renames `path` aside before erasing the renamed copy, mirroring
  * remove_path() in buildInvokerHomeCleanupScript above. A partial failure
- * mid-erase then leaves a `.deleting.<pid>` orphan (swept up by
+ * mid-erase then leaves a `.deleting.<random>` orphan (swept up by
  * sweepLocalDeletingOrphans next pass) instead of a half-gone directory
- * still sitting under the name other code looks up.
+ * still sitting under the name other code looks up. Erases out of process
+ * (`rm -rf` via execFile) so a large tree does not block the event loop;
+ * falls back to the async fs.rm if the rename or the subprocess fails.
  */
 async function eraseLocalPath(path: string, errors: string[]): Promise<void> {
-  const staged = `${path}.deleting.${process.pid}`;
-  let target = path;
-  try {
-    renameSync(path, staged);
-    target = staged;
-  } catch {
-    // Rename failed (e.g. cross-device); erase the original path directly below.
-  }
-  try {
-    rmSync(target, {
+  const removeWithNode = async (deletePath: string) => {
+    await rmAsync(deletePath, {
       recursive: true,
       force: true,
       maxRetries: LOCAL_RM_MAX_RETRIES,
       retryDelay: LOCAL_RM_RETRY_DELAY_MS,
     });
-  } catch (err) {
-    errors.push(`${target}: ${err instanceof Error ? err.message : String(err)}`);
+  };
+
+  let deletePath = `${path}.deleting.${randomUUID().slice(0, 8)}`;
+  try {
+    renameSync(path, deletePath);
+  } catch {
+    deletePath = path;
+    try {
+      await removeWithNode(deletePath);
+    } catch (fallbackErr) {
+      errors.push(`${path}: ${fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)}`);
+    }
+    return;
+  }
+
+  try {
+    await execFileAsync('rm', ['-rf', deletePath]);
+  } catch {
+    try {
+      await removeWithNode(deletePath);
+    } catch (fallbackErr) {
+      errors.push(`${path}: ${fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)}`);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Local reclaim now renames each selected child and awaits an external `rm -rf`.

That keeps the owner event loop responsive enough to service watchdog IPC during large sweeps.

The result shape, allowlist, and protected-path behavior stay the same.

## Review Claim

Approve changing only the local reclaim removal primitive to rename-plus-awaited child `rm`, with existing guardrails and result reporting preserved.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The sweep still operates on the same vetted children under the same top-level directories. Rename targets stay beside the original child as `.deleting.<nonce>` orphans.

## Slice Rationale

This slice carries the outage fix as one claim. Trigger thresholds, remote behavior, and failure accounting stay out of scope.

## Non-goals

- No remote reclaim changes.
- No threshold or trigger changes.
- No asar or ENOTDIR accounting changes.

## Architecture

### Before

```mermaid
graph TD
    A["cleanupLocalInvokerHome"] --> B["sweep reclaimable child"]
    B --> C["rmSync recursive remove in owner process"]
    C --> D["event loop waits until remove returns"]
```

### After

```mermaid
graph TD
    A["cleanupLocalInvokerHome"] --> B["sweep reclaimable child"]
    B --> C["rename child to .deleting.<nonce>"]
    C --> D["await external rm -rf"]
    D --> E["event loop can service IPC while child removes files"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/disk-reclaim-event-loop-block.repro.test.ts`
- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/disk-headroom-reclaim.test.ts`
- [x] `bash scripts/repro/repro-disk-reclaim-event-loop-block.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4f7fb32d491b582d200ba4a64f79862606e37180`
- Post-revert steps: None
- Data migration? No

</details>
