### PR TITLE
[Disk reclaim step 2: start paced cleanup at warn instead of waiting for critical](1) Add warn-threshold repro

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-reclaim-warn-threshold.repro.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-reclaim-warn-threshold.repro.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createWorkerRegistry } from '../worker-registry.js';
+import type { WorkerRuntime } from '../worker-runtime.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+
+import {
+  DISK_HEADROOM_WORKER_KIND,
+  registerDiskHeadroomWorker,
+} from '../workers/disk-headroom-worker.js';
+import {
+  runDiskHeadroomCheck,
+  type DiskHeadroomMonitorDeps,
+} from '../workers/disk-headroom-monitor.js';
+
+function makeLogger() {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
+
+  logger.child.mockImplementation(() => logger as any);
+  return logger as any;
+}
+
+/** `df -P -k` output for a filesystem at `pct`% used. */
+function dfAt(pct: number): string {
+  return `Filesystem 1024-blocks Used Available Capacity Mounted on
+/dev/vda1 100 ${pct} ${100 - pct} ${pct}% /`;
+}
+
+function makeRuntime(usedPercents: number[]): {
+  cleanupLocal: ReturnType<typeof vi.fn>;
+  runtime: WorkerRuntime;
+} {
+  const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+  registerDiskHeadroomWorker(registry);
+
+  let dfCall = 0;
+  const runLocalDf = vi.fn(async () => {
+    const fallback = usedPercents[usedPercents.length - 1] ?? 0;
+    const pct = usedPercents[dfCall] ?? fallback;
+    dfCall += 1;
+    return dfAt(pct);
+  });
+  const runCheck = vi.fn(async (deps: DiskHeadroomMonitorDeps) => (
+    runDiskHeadroomCheck({ ...deps, runLocalDf })
+  ));
+  const cleanupLocal = vi.fn(async ({ targetKey }: { targetKey: string }) => ({
+    targetKey,
+    ok: true,
+    reason: 'critical-cleanup' as const,
+  }));
+
+  const definition = registry.get(DISK_HEADROOM_WORKER_KIND)!;
+  const runtime = definition.factory({
+    store: {} as any,
+    submitter: { submit: vi.fn() } as any,
+    logger: makeLogger(),
+    diskHeadroom: {
+      localPath: '/tmp/invoker-home',
+      remoteTargets: [],
+      thresholds: { warnPercent: 85, criticalPercent: 95 },
+      intervalMs: 0,
+      tickOnStart: false,
+      cleanupCooldownMs: 0,
+      runCheck,
+      cleanupLocal,
+    },
+  });
+
+  return { cleanupLocal, runtime };
+}
+
+describe('disk reclaim warn-threshold repro', () => {
+  it('does not reclaim at 94% warn pressure, then reclaims at 95% critical pressure', async () => {
+    const { cleanupLocal, runtime } = makeRuntime([94, 95]);
+
+    await runtime.tick('manual');
+    expect(cleanupLocal).not.toHaveBeenCalled();
+
+    await runtime.tick('manual');
+    expect(cleanupLocal).toHaveBeenCalledTimes(1);
+    expect(cleanupLocal.mock.calls[0]?.[0]).toMatchObject({
+      invokerHome: '/tmp/invoker-home',
+      targetKey: 'local /tmp/invoker-home',
+    });
+  });
+
+  it.fails('documents the gap: repeated 94% warn pressure should trigger paced reclaim', async () => {
+    const { cleanupLocal, runtime } = makeRuntime([94, 94]);
+
+    await runtime.tick('manual');
+    await runtime.tick('manual');
+
+    expect(cleanupLocal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/execution-engine/src/__tests__/disk-reclaim-warn-threshold.repro.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-reclaim-warn-threshold.repro.test.ts
@@ -34,6 +34,7 @@ function dfAt(pct: number): string {
 
 function makeRuntime(usedPercents: number[]): {
   cleanupLocal: ReturnType<typeof vi.fn>;
+  logger: ReturnType<typeof makeLogger>;
   runtime: WorkerRuntime;
 } {
   const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
@@ -56,10 +57,11 @@ function makeRuntime(usedPercents: number[]): {
   }));
 
   const definition = registry.get(DISK_HEADROOM_WORKER_KIND)!;
+  const logger = makeLogger();
   const runtime = definition.factory({
     store: {} as any,
     submitter: { submit: vi.fn() } as any,
-    logger: makeLogger(),
+    logger,
     diskHeadroom: {
       localPath: '/tmp/invoker-home',
       remoteTargets: [],
@@ -72,15 +74,25 @@ function makeRuntime(usedPercents: number[]): {
     },
   });
 
-  return { cleanupLocal, runtime };
+  return { cleanupLocal, logger, runtime };
 }
 
 describe('disk reclaim warn-threshold repro', () => {
   it('does not reclaim at 94% warn pressure, then reclaims at 95% critical pressure', async () => {
-    const { cleanupLocal, runtime } = makeRuntime([94, 95]);
+    const { cleanupLocal, logger, runtime } = makeRuntime([94, 95]);
 
     await runtime.tick('manual');
     expect(cleanupLocal).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      '[disk-headroom] warn: local /tmp/invoker-home (94% used)',
+      expect.objectContaining({
+        module: 'disk-headroom',
+        label: 'local /tmp/invoker-home',
+        usedPercent: 94,
+        warnPercent: 85,
+        criticalPercent: 95,
+      }),
+    );
 
     await runtime.tick('manual');
     expect(cleanupLocal).toHaveBeenCalledTimes(1);

--- a/scripts/repro/repro-disk-reclaim-warn-threshold.sh
+++ b/scripts/repro/repro-disk-reclaim-warn-threshold.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Repro: warn-level local disk pressure (85-94%) records a warning but does not
+# run disk reclaim. Critical pressure (>=95%) still invokes reclaim immediately.
+#
+# Usage: bash scripts/repro/repro-disk-reclaim-warn-threshold.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SPEC="src/__tests__/disk-reclaim-warn-threshold.repro.test.ts"
+
+cd "$REPO_ROOT/packages/execution-engine"
+
+echo "[repro] running disk reclaim warn-threshold proof ..."
+if ! pnpm exec vitest run "$SPEC"; then
+  echo "[repro] FAIL: disk reclaim warn-threshold repro did not match the expected behavior."
+  exit 1
+fi
+
+if grep -q "it.fails" "$SPEC"; then
+  echo "[repro] reproduced: warn-level disk pressure triggers no reclaim (fix pending in this stack)"
+else
+  echo "[repro] fixed: warn-level disk pressure now triggers paced reclaim"
+fi


### PR DESCRIPTION
## Summary

This adds an executable repro for the disk-headroom worker's current warn-threshold behavior.

The spec shows that 94% local disk usage logs pressure but does not reclaim space.

It also confirms that the existing critical path still runs at 95%.

## Review Claim

Approve one expected-failing repro spec plus its wrapper for the current critical-only trigger behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This is test-only. The spec uses injected worker seams and writes no real disk state.

## Slice Rationale

The trigger gap is pinned as executable evidence before the behavior change lands in the next slice.

## Non-goals

No production code changes.

No pacing-policy assertions beyond the current warn-does-not-reclaim and critical-does-reclaim behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/disk-reclaim-warn-threshold.repro.test.ts`
- [x] `bash scripts/repro/repro-disk-reclaim-warn-threshold.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-commit>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for disk headroom reclaim behavior at warning and critical usage thresholds.
  * Verifies that critical disk usage triggers cleanup while lower usage does not.
  * Documents expected paced cleanup behavior under repeated warning-level pressure.

* **Chores**
  * Added a script to reproduce and report the disk-reclaim threshold behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->