### PR TITLE
[Disk reclaim step 2: start paced cleanup at warn instead of waiting for critical](2) Start warn-paced cleanup

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-headroom-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-worker.test.ts
@@ -96,7 +96,7 @@ describe('disk-headroom worker', () => {
     });
   });
 
-  it('cleans critical targets and skips warn-only targets', async () => {
+  it('cleans critical targets and skips single warn-only targets', async () => {
     const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
     registerDiskHeadroomWorker(registry);
 
@@ -152,11 +152,86 @@ describe('disk-headroom worker', () => {
       invokerHome: '/tmp/invoker-home',
       targetKey: localLabel,
     });
+    expect(cleanupLocal.mock.calls[0]?.[0]).not.toHaveProperty('mode');
     expect(cleanupRemote).toHaveBeenCalledTimes(1);
     expect(cleanupRemote.mock.calls[0]?.[0]).toMatchObject({
       target: remoteTargets[0],
     });
     expect(upsertWorkerAction).toHaveBeenCalled();
+  });
+
+  it('runs local warn-paced stale-only cleanup after consecutive warn ticks with an independent cooldown', async () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerDiskHeadroomWorker(registry);
+
+    const localLabel = 'local /tmp/invoker-home';
+    const evaluations = [
+      warnEval(localLabel),
+      warnEval(localLabel),
+      warnEval(localLabel),
+      criticalEval(localLabel),
+    ];
+    let tick = 0;
+    const runCheck = vi.fn(async () => [evaluations[tick++] ?? evaluations[evaluations.length - 1]!]);
+    const cleanupLocal = vi.fn(async ({ targetKey, mode }: { targetKey: string; mode?: string }) => ({
+      targetKey,
+      ok: true,
+      reason: mode === 'stale-only' ? 'warn-paced' : 'critical-cleanup',
+    }));
+    const upsertWorkerAction = vi.fn((row: unknown) => row);
+    const logger = makeLogger();
+
+    const definition = registry.get(DISK_HEADROOM_WORKER_KIND)!;
+    const runtime = definition.factory({
+      store: { upsertWorkerAction } as any,
+      submitter: { submit: vi.fn() } as any,
+      logger,
+      diskHeadroom: {
+        localPath: '/tmp/invoker-home',
+        remoteTargets: [],
+        thresholds: { warnPercent: 85, criticalPercent: 95 },
+        intervalMs: 0,
+        tickOnStart: false,
+        cleanupCooldownMs: 60_000,
+        runCheck,
+        cleanupLocal,
+      },
+    });
+
+    await runtime.tick('manual');
+    expect(cleanupLocal).not.toHaveBeenCalled();
+
+    await runtime.tick('manual');
+    expect(cleanupLocal).toHaveBeenCalledTimes(1);
+    expect(cleanupLocal.mock.calls[0]?.[0]).toMatchObject({
+      invokerHome: '/tmp/invoker-home',
+      targetKey: localLabel,
+      mode: 'stale-only',
+    });
+
+    await runtime.tick('manual');
+    expect(cleanupLocal).toHaveBeenCalledTimes(1);
+
+    await runtime.tick('manual');
+    expect(cleanupLocal).toHaveBeenCalledTimes(2);
+    expect(cleanupLocal.mock.calls[1]?.[0]).toMatchObject({
+      invokerHome: '/tmp/invoker-home',
+      targetKey: localLabel,
+    });
+    expect(cleanupLocal.mock.calls[1]?.[0]).not.toHaveProperty('mode');
+    expect(upsertWorkerAction).toHaveBeenCalledWith(expect.objectContaining({
+      externalKey: `cleanup:${localLabel}:warn-paced`,
+      payload: { reason: 'warn-paced' },
+      status: 'completed',
+    }));
+    expect(logger.info).toHaveBeenCalledWith(
+      `[disk-headroom-cleanup] warn-paced begin ${localLabel}`,
+      expect.objectContaining({ targetKey: localLabel }),
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      `[disk-headroom-cleanup] warn-paced done ${localLabel}`,
+      expect.objectContaining({ targetKey: localLabel }),
+    );
   });
 
   it('respects cleanup cooldown on a second critical tick', async () => {

--- a/packages/execution-engine/src/__tests__/disk-reclaim-warn-threshold.repro.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-reclaim-warn-threshold.repro.test.ts
@@ -102,12 +102,15 @@ describe('disk reclaim warn-threshold repro', () => {
     });
   });
 
-  it.fails('documents the gap: repeated 94% warn pressure should trigger paced reclaim', async () => {
+  it('reclaims after repeated 94% warn pressure with paced reclaim', async () => {
     const { cleanupLocal, runtime } = makeRuntime([94, 94]);
 
     await runtime.tick('manual');
     await runtime.tick('manual');
 
     expect(cleanupLocal).toHaveBeenCalledTimes(1);
+    expect(cleanupLocal.mock.calls[0]?.[0]).toMatchObject({
+      mode: 'stale-only',
+    });
   });
 });

--- a/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
@@ -7,7 +7,7 @@
 
 import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { existsSync, mkdirSync, readdirSync, renameSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, readdirSync, renameSync } from 'node:fs';
 import { rm as rmAsync } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve, sep } from 'node:path';
@@ -68,6 +68,18 @@ export interface DiskCleanupResult {
   ok: boolean;
   reason: string;
   detail?: string;
+}
+
+export type LocalDiskCleanupMode = 'critical' | 'stale-only';
+
+export interface CleanupLocalInvokerHomeOptions {
+  invokerHome: string;
+  targetKey?: string;
+  logger?: Logger;
+  userHome?: string;
+  store?: DiskHeadroomWorkerStore;
+  mode?: LocalDiskCleanupMode;
+  minAgeMinutes?: number;
 }
 
 /**
@@ -494,21 +506,49 @@ async function sweepRepoChildren(
   }
 }
 
-export async function cleanupLocalInvokerHome(opts: {
-  invokerHome: string;
-  targetKey?: string;
-  logger?: Logger;
-  userHome?: string;
-  store?: DiskHeadroomWorkerStore;
-}): Promise<DiskCleanupResult> {
+async function sweepStaleReclaimableChildren(
+  dirPath: string,
+  minAgeMinutes: number,
+  errors: string[],
+  protectedSkips: string[],
+  protectedPaths: ReadonlySet<string>,
+  logger?: Logger,
+  targetKey?: string,
+): Promise<void> {
+  if (!existsSync(dirPath)) return;
+  let entries: string[];
+  try {
+    entries = readdirSync(dirPath);
+  } catch (err) {
+    errors.push(`readdir ${dirPath}: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
+
+  const cutoffMs = Date.now() - minAgeMinutes * 60 * 1000;
+  for (const name of entries) {
+    const childPath = join(dirPath, name);
+    try {
+      if (lstatSync(childPath).mtimeMs > cutoffMs) continue;
+    } catch (err) {
+      errors.push(`lstat ${childPath}: ${err instanceof Error ? err.message : String(err)}`);
+      continue;
+    }
+    await removeLocalDir(childPath, errors, protectedSkips, protectedPaths, logger, targetKey);
+  }
+}
+
+export async function cleanupLocalInvokerHome(
+  opts: CleanupLocalInvokerHomeOptions,
+): Promise<DiskCleanupResult> {
   const targetKey = opts.targetKey ?? `local ${opts.invokerHome}`;
   const userHome = opts.userHome ?? homedir();
   const home = expandTildeHome(opts.invokerHome, userHome);
+  const mode = opts.mode ?? 'critical';
   if (!isSafeInvokerHome(home, userHome)) {
     return { targetKey, ok: false, reason: 'path-guard', detail: home };
   }
 
-  opts.logger?.info?.(`[disk-headroom-cleanup] local begin home=${home}`, {
+  opts.logger?.info?.(`[disk-headroom-cleanup] local ${mode === 'stale-only' ? 'stale-only ' : ''}begin home=${home}`, {
     module: 'disk-headroom',
     targetKey,
   });
@@ -517,23 +557,41 @@ export async function cleanupLocalInvokerHome(opts: {
   const protectedRepoHashes = opts.store ? computeProtectedRepoHashes(opts.store) : new Set<string>();
   const errors: string[] = [];
   const protectedSkips: string[] = [];
-  await sweepLocalDeletingOrphans(home, errors, protectedSkips, protectedPaths, opts.logger, targetKey);
-  await sweepRepoChildren(
-    join(home, 'repos'),
-    errors,
-    protectedSkips,
-    protectedRepoHashes,
-    protectedPaths,
-    opts.logger,
-    targetKey,
-  );
-  for (const name of ['runtime', 'worktrees', 'merge-clones', 'merge-launches'] as const) {
-    await sweepReclaimableChildren(join(home, name), errors, protectedSkips, protectedPaths, opts.logger, targetKey);
-  }
-  // pr-cron-work: PR #6632 retired its only producer, so there is nothing there to preserve.
-  await removeLocalDir(join(home, 'pr-cron-work'), errors, protectedSkips, protectedPaths, opts.logger, targetKey);
-  for (const name of DISK_RECLAIMABLE_DIRS) {
-    ensureLocalDir(join(home, name), errors);
+  if (mode === 'stale-only') {
+    const minAgeMinutes = Math.max(
+      opts.minAgeMinutes ?? TMP_SCRATCH_MIN_AGE_MINUTES,
+      TMP_SCRATCH_MIN_AGE_MINUTES,
+    );
+    for (const name of DISK_RECLAIMABLE_DIRS) {
+      await sweepStaleReclaimableChildren(
+        join(home, name),
+        minAgeMinutes,
+        errors,
+        protectedSkips,
+        protectedPaths,
+        opts.logger,
+        targetKey,
+      );
+    }
+  } else {
+    await sweepLocalDeletingOrphans(home, errors, protectedSkips, protectedPaths, opts.logger, targetKey);
+    await sweepRepoChildren(
+      join(home, 'repos'),
+      errors,
+      protectedSkips,
+      protectedRepoHashes,
+      protectedPaths,
+      opts.logger,
+      targetKey,
+    );
+    for (const name of ['runtime', 'worktrees', 'merge-clones', 'merge-launches'] as const) {
+      await sweepReclaimableChildren(join(home, name), errors, protectedSkips, protectedPaths, opts.logger, targetKey);
+    }
+    // pr-cron-work: PR #6632 retired its only producer, so there is nothing there to preserve.
+    await removeLocalDir(join(home, 'pr-cron-work'), errors, protectedSkips, protectedPaths, opts.logger, targetKey);
+    for (const name of DISK_RECLAIMABLE_DIRS) {
+      ensureLocalDir(join(home, name), errors);
+    }
   }
 
   if (errors.length > 0) {
@@ -559,16 +617,16 @@ export async function cleanupLocalInvokerHome(opts: {
     return {
       targetKey,
       ok: true,
-      reason: 'protected-path-in-use',
+      reason: mode === 'stale-only' ? 'warn-paced' : 'protected-path-in-use',
       detail: protectedSkips.slice(0, 5).join('; '),
     };
   }
 
-  opts.logger?.info?.(`[disk-headroom-cleanup] local done home=${home}`, {
+  opts.logger?.info?.(`[disk-headroom-cleanup] local ${mode === 'stale-only' ? 'stale-only ' : ''}done home=${home}`, {
     module: 'disk-headroom',
     targetKey,
   });
-  return { targetKey, ok: true, reason: 'critical-cleanup' };
+  return { targetKey, ok: true, reason: mode === 'stale-only' ? 'warn-paced' : 'critical-cleanup' };
 }
 
 /**

--- a/packages/execution-engine/src/workers/disk-headroom-worker.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-worker.ts
@@ -103,12 +103,13 @@ class DiskUnknownStreakTracker {
 function recordCleanupDecision(
   store: WorkerDecisionStore | undefined,
   result: DiskCleanupResult,
+  externalKey = `cleanup:${result.targetKey}:${result.reason}`,
 ): void {
   if (!store) return;
   recordWorkerDecisionRow(store, {
     workerKind: DISK_HEADROOM_WORKER_KIND,
     actionType: 'disk-cleanup',
-    externalKey: `cleanup:${result.targetKey}:${result.reason}`,
+    externalKey,
     subjectType: 'disk-target',
     subjectId: result.targetKey,
     status: result.ok ? 'completed' : result.reason === 'cooldown' || result.reason === 'disabled'
@@ -123,6 +124,16 @@ function recordCleanupDecision(
   });
 }
 
+const WARN_PACED_STREAK = 2;
+
+function isLocalTargetKey(targetKey: string): boolean {
+  return !targetKey.startsWith('ssh:');
+}
+
+function warnPacedCooldownKey(targetKey: string): string {
+  return `cleanup:${targetKey}:warn-paced`;
+}
+
 export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): WorkerRuntime {
   const runCheck = options.runCheck ?? runDiskHeadroomCheck;
   const cleanupLocal = options.cleanupLocal ?? cleanupLocalInvokerHome;
@@ -132,6 +143,7 @@ export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): Wo
     options.cleanupCooldownMs ?? resolveDiskCleanupCooldownMs(),
   );
   const unknownStreaks = new DiskUnknownStreakTracker();
+  const warnStreaks = new Map<string, number>();
 
   return createWorkerRuntime({
     kind: DISK_HEADROOM_WORKER_KIND,
@@ -178,6 +190,66 @@ export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): Wo
       }
 
       if (!cleanupEnabled) return;
+
+      const warnPacedTargets: DiskHeadroomEvaluation[] = [];
+      for (const evaluation of evaluationsRaw) {
+        const targetKey = evaluation.label;
+        if (!isLocalTargetKey(targetKey)) continue;
+        if (evaluation.level !== 'warn') {
+          warnStreaks.delete(targetKey);
+          continue;
+        }
+        const next = (warnStreaks.get(targetKey) ?? 0) + 1;
+        warnStreaks.set(targetKey, next);
+        if (next >= WARN_PACED_STREAK) {
+          warnPacedTargets.push(evaluation);
+        }
+      }
+
+      for (const evaluation of warnPacedTargets) {
+        if (ctx.signal?.aborted) return;
+        const targetKey = evaluation.label;
+        const cooldownKey = warnPacedCooldownKey(targetKey);
+        if (!cooldown.canCleanup(cooldownKey)) {
+          const skipped: DiskCleanupResult = {
+            targetKey,
+            ok: false,
+            reason: 'cooldown',
+          };
+          options.logger.info?.(
+            `[disk-headroom-cleanup] skip ${targetKey}: warn-paced cooldown`,
+            { module: 'disk-headroom', targetKey },
+          );
+          recordCleanupDecision(options.store, skipped, cooldownKey);
+          continue;
+        }
+
+        options.logger.info?.(
+          `[disk-headroom-cleanup] warn-paced begin ${targetKey}`,
+          { module: 'disk-headroom', targetKey },
+        );
+        const result = await cleanupLocal({
+          invokerHome: options.localPath,
+          targetKey,
+          logger: options.logger,
+          store: options.workflowStore,
+          mode: 'stale-only',
+        });
+        const recordedResult: DiskCleanupResult = result.ok
+          ? { ...result, reason: 'warn-paced' }
+          : result;
+        cooldown.markCleaned(cooldownKey);
+        options.logger.info?.(
+          `[disk-headroom-cleanup] warn-paced done ${targetKey}`,
+          { module: 'disk-headroom', targetKey, result: recordedResult },
+        );
+        recordCleanupDecision(options.store, recordedResult, cooldownKey);
+        options.writeActivityLog?.(
+          recordedResult.ok ? 'warn' : 'error',
+          `[disk-headroom-cleanup] ${recordedResult.reason}: ${recordedResult.targetKey}`
+            + (recordedResult.detail ? ` (${recordedResult.detail.slice(0, 200)})` : ''),
+        );
+      }
 
       const critical = evaluationsRaw.filter((e) => e.level === 'critical');
       for (const evaluation of critical) {


### PR DESCRIPTION
## Summary

This adds a warn-paced local reclaim lane for sustained disk pressure.

Two consecutive warn readings now start an aged-child pass under a separate cooldown key.

The critical path keeps its existing decision point and cooldown behavior.

## Review Claim

Approve one additive disk-pressure lane: two consecutive warn readings route into aged-child local reclaim while critical decisions stay unchanged.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The warn lane only reaches paths the critical sweep may already reach, and it adds a stale-age floor. Existing allowlist, protected-path, cooldown, and kill-switch checks still apply.

## Slice Rationale

This isolates the warn-to-reclaim routing from the prior reclaim primitive change and from later failure-accounting work.

## Non-goals

No change to critical thresholds or the critical cooldown key.

No remote warn-paced lane.

No change to reclaimable directory allowlists or protected-path semantics.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/disk-reclaim-warn-threshold.repro.test.ts`
- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/disk-headroom-worker.test.ts`
- [x] `bash scripts/repro/repro-disk-reclaim-warn-threshold.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-commit>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7759