### PR TITLE
[Disk reclaim step 3: asar-safe sweep plus unreapable-bytes visibility](2) Guard asar walking and report unreapable bytes

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
@@ -267,6 +267,8 @@ describe('cleanupLocalInvokerHome', () => {
 
     expect(result.ok).toBe(true);
     expect(result.reason).toBe('critical-cleanup');
+    expect(result.protectedSkipCount).toBe(0);
+    expect(result.protectedSkipBytes).toBe(0);
     for (const name of DISK_RECLAIMABLE_DIRS) {
       expect(existsSync(join(home, name))).toBe(true);
       expect(readdirSync(join(home, name))).toEqual([]);
@@ -306,6 +308,8 @@ describe('cleanupLocalInvokerHome', () => {
 
     expect(result.ok).toBe(true);
     expect(result.reason).toBe('protected-path-in-use');
+    expect(result.protectedSkipCount).toBe(1);
+    expect(result.protectedSkipBytes).toBeGreaterThan(0);
     expect(existsSync(activeDir)).toBe(true);
     expect(existsSync(join(activeDir, 'file.txt'))).toBe(true);
     expect(readdirSync(join(home, 'worktrees'))).toEqual(['active-task']);
@@ -333,6 +337,8 @@ describe('cleanupLocalInvokerHome', () => {
     });
     expect(result.ok).toBe(false);
     expect(result.reason).toBe('path-guard');
+    expect(result.protectedSkipCount).toBe(0);
+    expect(result.protectedSkipBytes).toBe(0);
   });
 });
 
@@ -401,6 +407,8 @@ describe('cleanupLocalInvokerHome DB-state liveness guard', () => {
 
     expect(result.ok).toBe(true);
     expect(result.reason).toBe('protected-path-in-use');
+    expect(result.protectedSkipCount).toBe(1);
+    expect(result.protectedSkipBytes).toBeGreaterThan(0);
     expect(existsSync(activeDir)).toBe(true);
     expect(existsSync(join(activeDir, 'file.txt'))).toBe(true);
     expect(existsSync(staleDir)).toBe(false);
@@ -477,6 +485,8 @@ describe('cleanupLocalInvokerHome DB-state liveness guard', () => {
 
     expect(result.ok).toBe(true);
     expect(result.reason).toBe('critical-cleanup');
+    expect(result.protectedSkipCount).toBe(0);
+    expect(result.protectedSkipBytes).toBe(0);
     expect(existsSync(someDir)).toBe(false);
   });
 
@@ -528,6 +538,34 @@ describe('cleanupLocalInvokerHome DB-state liveness guard', () => {
     expect(existsSync(protectedWorktreeDir)).toBe(true);
     expect(existsSync(join(protectedWorktreeDir, 'file.txt'))).toBe(true);
     expect(existsSync(unrelatedRepoDir)).toBe(false);
+  });
+
+  it('restores process.noAsar when the local pass returns cleanup errors', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'invoker-disk-cleanup-noasar-error-'));
+    tempDirs.push(root);
+    const home = join(root, '.invoker');
+    const userHome = root;
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(home, 'worktrees'), 'not-a-directory');
+
+    const processWithNoAsar = process as NodeJS.Process & { noAsar?: boolean };
+    const hadNoAsar = Object.prototype.hasOwnProperty.call(processWithNoAsar, 'noAsar');
+    const previousNoAsar = processWithNoAsar.noAsar;
+    processWithNoAsar.noAsar = false;
+
+    try {
+      const result = await cleanupLocalInvokerHome({ invokerHome: home, userHome });
+
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe('cleanup-error');
+      expect(processWithNoAsar.noAsar).toBe(false);
+    } finally {
+      if (hadNoAsar) {
+        processWithNoAsar.noAsar = previousNoAsar;
+      } else {
+        delete processWithNoAsar.noAsar;
+      }
+    }
   });
 });
 

--- a/packages/execution-engine/src/__tests__/disk-headroom-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-worker.test.ts
@@ -119,11 +119,15 @@ describe('disk-headroom worker', () => {
       targetKey: localLabel,
       ok: true,
       reason: 'critical-cleanup',
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
     }));
     const cleanupRemote = vi.fn(async () => ({
       targetKey: remoteLabel,
       ok: true,
       reason: 'critical-cleanup',
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
     }));
     const upsertWorkerAction = vi.fn((row: unknown) => row);
 
@@ -177,6 +181,8 @@ describe('disk-headroom worker', () => {
       targetKey,
       ok: true,
       reason: mode === 'stale-only' ? 'warn-paced' : 'critical-cleanup',
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
     }));
     const upsertWorkerAction = vi.fn((row: unknown) => row);
     const logger = makeLogger();
@@ -221,7 +227,11 @@ describe('disk-headroom worker', () => {
     expect(cleanupLocal.mock.calls[1]?.[0]).not.toHaveProperty('mode');
     expect(upsertWorkerAction).toHaveBeenCalledWith(expect.objectContaining({
       externalKey: `cleanup:${localLabel}:warn-paced`,
-      payload: { reason: 'warn-paced' },
+      payload: expect.objectContaining({
+        reason: 'warn-paced',
+        protectedSkipCount: 0,
+        protectedSkipBytes: 0,
+      }),
       status: 'completed',
     }));
     expect(logger.info).toHaveBeenCalledWith(
@@ -244,6 +254,8 @@ describe('disk-headroom worker', () => {
       targetKey: localLabel,
       ok: true,
       reason: 'critical-cleanup',
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
     }));
 
     const definition = registry.get(DISK_HEADROOM_WORKER_KIND)!;

--- a/packages/execution-engine/src/__tests__/disk-reclaim-asar-noasar.repro.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-reclaim-asar-noasar.repro.test.ts
@@ -37,7 +37,7 @@ describe('cleanupLocalInvokerHome Electron asar guard repro', () => {
     expect(getNoAsar()).toBeFalsy();
   });
 
-  it.fails('enables process.noAsar during the local disk sweep', async () => {
+  it('enables process.noAsar during the local disk sweep', async () => {
     const { home, userHome } = makeInvokerHome();
     let observedNoAsar: boolean | undefined;
     const observeBeginLine = (message: string) => {

--- a/packages/execution-engine/src/__tests__/reaper-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/reaper-worker.test.ts
@@ -25,7 +25,14 @@ function makeLogger() {
 }
 
 function okResult(targetKey: string): DiskCleanupResult {
-  return { targetKey, ok: true, reason: 'reap-orphans', detail: 'removed 1' };
+  return {
+    targetKey,
+    ok: true,
+    reason: 'reap-orphans',
+    detail: 'removed 1',
+    protectedSkipCount: 0,
+    protectedSkipBytes: 0,
+  };
 }
 
 describe('reaper worker', () => {
@@ -104,6 +111,8 @@ describe('reaper worker', () => {
       ok: false,
       reason: 'cleanup-error',
       detail: 'ssh timed out',
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
     };
     const upsertWorkerAction = vi.fn((row: any) => row);
 

--- a/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
@@ -68,6 +68,9 @@ export interface DiskCleanupResult {
   ok: boolean;
   reason: string;
   detail?: string;
+  protectedSkipCount: number;
+  protectedSkipBytes: number;
+  protectedSkipBytesTruncated?: boolean;
 }
 
 export type LocalDiskCleanupMode = 'critical' | 'stale-only';
@@ -275,7 +278,22 @@ exit 0
 
 const LOCAL_RM_MAX_RETRIES = 5;
 const LOCAL_RM_RETRY_DELAY_MS = 100;
+const PROTECTED_SKIP_BYTE_WALK_ENTRY_CAP = 10_000;
 const execFileAsync = promisify(execFile);
+
+type ProcessWithNoAsar = NodeJS.Process & { noAsar?: boolean };
+
+interface ProtectedSkipAccounting {
+  paths: string[];
+  count: number;
+  bytes: number;
+  truncated: boolean;
+}
+
+interface ApproximateTreeBytesResult {
+  bytes: number;
+  truncated: boolean;
+}
 
 /**
  * Read-only accessor for Invoker's own workflow/task state, used to derive
@@ -392,21 +410,66 @@ async function eraseLocalPath(path: string, errors: string[]): Promise<void> {
   }
 }
 
+function approximateTreeBytes(path: string, capEntries: number): ApproximateTreeBytesResult {
+  const stack = [path];
+  let visited = 0;
+  let bytes = 0;
+  let truncated = false;
+
+  while (stack.length > 0) {
+    if (visited >= capEntries) {
+      truncated = true;
+      break;
+    }
+
+    const current = stack.pop()!;
+    let stat;
+    try {
+      stat = lstatSync(current);
+    } catch {
+      truncated = true;
+      continue;
+    }
+    visited += 1;
+    bytes += stat.size;
+
+    if (!stat.isDirectory()) continue;
+    let children: string[];
+    try {
+      children = readdirSync(current);
+    } catch {
+      truncated = true;
+      continue;
+    }
+    for (const child of children) {
+      stack.push(join(current, child));
+    }
+  }
+
+  return { bytes, truncated };
+}
+
 async function removeLocalDir(
   path: string,
   errors: string[],
-  protectedSkips: string[],
+  protectedSkips: ProtectedSkipAccounting,
   protectedPaths: ReadonlySet<string>,
   logger?: Logger,
   targetKey?: string,
 ): Promise<void> {
   if (!existsSync(path)) return;
   if (pathIsProtected(path, protectedPaths)) {
-    protectedSkips.push(path);
+    const approximateBytes = approximateTreeBytes(path, PROTECTED_SKIP_BYTE_WALK_ENTRY_CAP);
+    protectedSkips.paths.push(path);
+    protectedSkips.count += 1;
+    protectedSkips.bytes += approximateBytes.bytes;
+    protectedSkips.truncated ||= approximateBytes.truncated;
     logger?.warn?.(`[disk-headroom-cleanup] skip ${path}: protected-path-in-use`, {
       module: 'disk-headroom',
       targetKey,
       path,
+      protectedSkipBytes: approximateBytes.bytes,
+      protectedSkipBytesTruncated: approximateBytes.truncated,
     });
     return;
   }
@@ -421,10 +484,35 @@ function ensureLocalDir(path: string, errors: string[]): void {
   }
 }
 
+function logLocalCleanupDone(opts: {
+  logger?: Logger;
+  mode: LocalDiskCleanupMode;
+  home: string;
+  targetKey: string;
+  ok: boolean;
+  reason: string;
+  protectedSkips: ProtectedSkipAccounting;
+}): void {
+  const stalePrefix = opts.mode === 'stale-only' ? 'stale-only ' : '';
+  const truncated = opts.protectedSkips.truncated
+    ? ' protectedSkipBytesTruncated=true'
+    : '';
+  opts.logger?.info?.(
+    `[disk-headroom-cleanup] local ${stalePrefix}done home=${opts.home} ok=${opts.ok ? 'true' : 'false'} reason=${opts.reason} protectedSkipCount=${opts.protectedSkips.count} protectedSkipBytes=${opts.protectedSkips.bytes}${truncated}`,
+    {
+      module: 'disk-headroom',
+      targetKey: opts.targetKey,
+      protectedSkipCount: opts.protectedSkips.count,
+      protectedSkipBytes: opts.protectedSkips.bytes,
+      protectedSkipBytesTruncated: opts.protectedSkips.truncated,
+    },
+  );
+}
+
 async function sweepLocalDeletingOrphans(
   home: string,
   errors: string[],
-  protectedSkips: string[],
+  protectedSkips: ProtectedSkipAccounting,
   protectedPaths: ReadonlySet<string>,
   logger?: Logger,
   targetKey?: string,
@@ -450,7 +538,7 @@ async function sweepLocalDeletingOrphans(
 async function sweepReclaimableChildren(
   dirPath: string,
   errors: string[],
-  protectedSkips: string[],
+  protectedSkips: ProtectedSkipAccounting,
   protectedPaths: ReadonlySet<string>,
   logger?: Logger,
   targetKey?: string,
@@ -477,7 +565,7 @@ async function sweepReclaimableChildren(
 async function sweepRepoChildren(
   dirPath: string,
   errors: string[],
-  protectedSkips: string[],
+  protectedSkips: ProtectedSkipAccounting,
   protectedRepoHashes: ReadonlySet<string>,
   protectedPaths: ReadonlySet<string>,
   logger?: Logger,
@@ -494,11 +582,17 @@ async function sweepRepoChildren(
   for (const name of entries) {
     const childPath = join(dirPath, name);
     if (protectedRepoHashes.has(name) || pathIsProtected(childPath, protectedPaths)) {
-      protectedSkips.push(childPath);
+      const approximateBytes = approximateTreeBytes(childPath, PROTECTED_SKIP_BYTE_WALK_ENTRY_CAP);
+      protectedSkips.paths.push(childPath);
+      protectedSkips.count += 1;
+      protectedSkips.bytes += approximateBytes.bytes;
+      protectedSkips.truncated ||= approximateBytes.truncated;
       logger?.warn?.(`[disk-headroom-cleanup] skip ${childPath}: protected-path-in-use`, {
         module: 'disk-headroom',
         targetKey,
         path: childPath,
+        protectedSkipBytes: approximateBytes.bytes,
+        protectedSkipBytesTruncated: approximateBytes.truncated,
       });
       continue;
     }
@@ -510,7 +604,7 @@ async function sweepStaleReclaimableChildren(
   dirPath: string,
   minAgeMinutes: number,
   errors: string[],
-  protectedSkips: string[],
+  protectedSkips: ProtectedSkipAccounting,
   protectedPaths: ReadonlySet<string>,
   logger?: Logger,
   targetKey?: string,
@@ -545,88 +639,150 @@ export async function cleanupLocalInvokerHome(
   const home = expandTildeHome(opts.invokerHome, userHome);
   const mode = opts.mode ?? 'critical';
   if (!isSafeInvokerHome(home, userHome)) {
-    return { targetKey, ok: false, reason: 'path-guard', detail: home };
+    return {
+      targetKey,
+      ok: false,
+      reason: 'path-guard',
+      detail: home,
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
+    };
   }
 
-  opts.logger?.info?.(`[disk-headroom-cleanup] local ${mode === 'stale-only' ? 'stale-only ' : ''}begin home=${home}`, {
-    module: 'disk-headroom',
-    targetKey,
-  });
+  const processWithNoAsar = process as ProcessWithNoAsar;
+  const hadNoAsar = Object.prototype.hasOwnProperty.call(processWithNoAsar, 'noAsar');
+  const previousNoAsar = processWithNoAsar.noAsar;
+  processWithNoAsar.noAsar = true;
 
-  const protectedPaths = opts.store ? computeProtectedLocalPaths(opts.store) : new Set<string>();
-  const protectedRepoHashes = opts.store ? computeProtectedRepoHashes(opts.store) : new Set<string>();
-  const errors: string[] = [];
-  const protectedSkips: string[] = [];
-  if (mode === 'stale-only') {
-    const minAgeMinutes = Math.max(
-      opts.minAgeMinutes ?? TMP_SCRATCH_MIN_AGE_MINUTES,
-      TMP_SCRATCH_MIN_AGE_MINUTES,
-    );
-    for (const name of DISK_RECLAIMABLE_DIRS) {
-      await sweepStaleReclaimableChildren(
-        join(home, name),
-        minAgeMinutes,
+  try {
+    opts.logger?.info?.(`[disk-headroom-cleanup] local ${mode === 'stale-only' ? 'stale-only ' : ''}begin home=${home}`, {
+      module: 'disk-headroom',
+      targetKey,
+    });
+
+    const protectedPaths = opts.store ? computeProtectedLocalPaths(opts.store) : new Set<string>();
+    const protectedRepoHashes = opts.store ? computeProtectedRepoHashes(opts.store) : new Set<string>();
+    const errors: string[] = [];
+    const protectedSkips: ProtectedSkipAccounting = {
+      paths: [],
+      count: 0,
+      bytes: 0,
+      truncated: false,
+    };
+    if (mode === 'stale-only') {
+      const minAgeMinutes = Math.max(
+        opts.minAgeMinutes ?? TMP_SCRATCH_MIN_AGE_MINUTES,
+        TMP_SCRATCH_MIN_AGE_MINUTES,
+      );
+      for (const name of DISK_RECLAIMABLE_DIRS) {
+        await sweepStaleReclaimableChildren(
+          join(home, name),
+          minAgeMinutes,
+          errors,
+          protectedSkips,
+          protectedPaths,
+          opts.logger,
+          targetKey,
+        );
+      }
+    } else {
+      await sweepLocalDeletingOrphans(home, errors, protectedSkips, protectedPaths, opts.logger, targetKey);
+      await sweepRepoChildren(
+        join(home, 'repos'),
         errors,
         protectedSkips,
+        protectedRepoHashes,
         protectedPaths,
         opts.logger,
         targetKey,
       );
+      for (const name of ['runtime', 'worktrees', 'merge-clones', 'merge-launches'] as const) {
+        await sweepReclaimableChildren(join(home, name), errors, protectedSkips, protectedPaths, opts.logger, targetKey);
+      }
+      // pr-cron-work: PR #6632 retired its only producer, so there is nothing there to preserve.
+      await removeLocalDir(join(home, 'pr-cron-work'), errors, protectedSkips, protectedPaths, opts.logger, targetKey);
+      for (const name of DISK_RECLAIMABLE_DIRS) {
+        ensureLocalDir(join(home, name), errors);
+      }
     }
-  } else {
-    await sweepLocalDeletingOrphans(home, errors, protectedSkips, protectedPaths, opts.logger, targetKey);
-    await sweepRepoChildren(
-      join(home, 'repos'),
-      errors,
-      protectedSkips,
-      protectedRepoHashes,
-      protectedPaths,
-      opts.logger,
-      targetKey,
-    );
-    for (const name of ['runtime', 'worktrees', 'merge-clones', 'merge-launches'] as const) {
-      await sweepReclaimableChildren(join(home, name), errors, protectedSkips, protectedPaths, opts.logger, targetKey);
-    }
-    // pr-cron-work: PR #6632 retired its only producer, so there is nothing there to preserve.
-    await removeLocalDir(join(home, 'pr-cron-work'), errors, protectedSkips, protectedPaths, opts.logger, targetKey);
-    for (const name of DISK_RECLAIMABLE_DIRS) {
-      ensureLocalDir(join(home, name), errors);
-    }
-  }
 
-  if (errors.length > 0) {
-    opts.logger?.warn?.(`[disk-headroom-cleanup] local partial failures`, {
-      module: 'disk-headroom',
+    const resultBase = {
       targetKey,
-      errors,
-    });
-    return {
-      targetKey,
-      ok: false,
-      reason: 'cleanup-error',
-      detail: errors.slice(0, 5).join('; '),
+      protectedSkipCount: protectedSkips.count,
+      protectedSkipBytes: protectedSkips.bytes,
+      ...(protectedSkips.truncated ? { protectedSkipBytesTruncated: true } : {}),
     };
-  }
 
-  if (protectedSkips.length > 0) {
-    opts.logger?.warn?.(`[disk-headroom-cleanup] local skipped in-use paths`, {
-      module: 'disk-headroom',
-      targetKey,
-      protectedSkips,
-    });
-    return {
+    if (errors.length > 0) {
+      opts.logger?.warn?.(`[disk-headroom-cleanup] local partial failures`, {
+        module: 'disk-headroom',
+        targetKey,
+        errors,
+      });
+      logLocalCleanupDone({
+        logger: opts.logger,
+        mode,
+        home,
+        targetKey,
+        ok: false,
+        reason: 'cleanup-error',
+        protectedSkips,
+      });
+      return {
+        ...resultBase,
+        ok: false,
+        reason: 'cleanup-error',
+        detail: errors.slice(0, 5).join('; '),
+      };
+    }
+
+    if (protectedSkips.count > 0) {
+      opts.logger?.warn?.(`[disk-headroom-cleanup] local skipped in-use paths`, {
+        module: 'disk-headroom',
+        targetKey,
+        protectedSkips: protectedSkips.paths,
+        protectedSkipCount: protectedSkips.count,
+        protectedSkipBytes: protectedSkips.bytes,
+        protectedSkipBytesTruncated: protectedSkips.truncated,
+      });
+      logLocalCleanupDone({
+        logger: opts.logger,
+        mode,
+        home,
+        targetKey,
+        ok: true,
+        reason: mode === 'stale-only' ? 'warn-paced' : 'protected-path-in-use',
+        protectedSkips,
+      });
+      return {
+        ...resultBase,
+        ok: true,
+        reason: mode === 'stale-only' ? 'warn-paced' : 'protected-path-in-use',
+        detail: protectedSkips.paths.slice(0, 5).join('; '),
+      };
+    }
+
+    logLocalCleanupDone({
+      logger: opts.logger,
+      mode,
+      home,
       targetKey,
       ok: true,
-      reason: mode === 'stale-only' ? 'warn-paced' : 'protected-path-in-use',
-      detail: protectedSkips.slice(0, 5).join('; '),
+      reason: mode === 'stale-only' ? 'warn-paced' : 'critical-cleanup',
+      protectedSkips,
+    });
+    return {
+      ...resultBase,
+      ok: true,
+      reason: mode === 'stale-only' ? 'warn-paced' : 'critical-cleanup',
     };
+  } finally {
+    if (hadNoAsar) {
+      processWithNoAsar.noAsar = previousNoAsar;
+    } else {
+      delete processWithNoAsar.noAsar;
+    }
   }
-
-  opts.logger?.info?.(`[disk-headroom-cleanup] local ${mode === 'stale-only' ? 'stale-only ' : ''}done home=${home}`, {
-    module: 'disk-headroom',
-    targetKey,
-  });
-  return { targetKey, ok: true, reason: mode === 'stale-only' ? 'warn-paced' : 'critical-cleanup' };
 }
 
 /**
@@ -695,6 +851,8 @@ export async function cleanupRemoteInvokerHome(opts: {
       ok: false,
       reason: 'path-guard',
       detail: opts.target.remotePath,
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
     };
   }
 
@@ -725,14 +883,28 @@ export async function cleanupRemoteInvokerHome(opts: {
       targetKey,
       outputTail: output.slice(-400),
     });
-    return { targetKey, ok: true, reason: 'critical-cleanup', detail: output.slice(-400) };
+    return {
+      targetKey,
+      ok: true,
+      reason: 'critical-cleanup',
+      detail: output.slice(-400),
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
+    };
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     opts.logger?.error?.(`[disk-headroom-cleanup] remote failed ${targetKey}: ${detail}`, {
       module: 'disk-headroom',
       targetKey,
     });
-    return { targetKey, ok: false, reason: 'cleanup-error', detail };
+    return {
+      targetKey,
+      ok: false,
+      reason: 'cleanup-error',
+      detail,
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
+    };
   }
 }
 

--- a/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
@@ -780,7 +780,7 @@ export async function cleanupLocalInvokerHome(
     if (hadNoAsar) {
       processWithNoAsar.noAsar = previousNoAsar;
     } else {
-      delete processWithNoAsar.noAsar;
+      Reflect.deleteProperty(processWithNoAsar, 'noAsar');
     }
   }
 }
@@ -866,7 +866,7 @@ export async function cleanupRemoteInvokerHome(opts: {
         `[disk-headroom-cleanup] remote preservation lookup failed ${targetKey}: ${detail}`,
         { module: 'disk-headroom', targetKey },
       );
-      return { targetKey, ok: false, reason: 'cleanup-error', detail };
+      return { targetKey, ok: false, reason: 'cleanup-error', detail, protectedSkipCount: 0, protectedSkipBytes: 0 };
     }
   }
 

--- a/packages/execution-engine/src/workers/disk-headroom-worker.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-worker.ts
@@ -106,6 +106,8 @@ function recordCleanupDecision(
   externalKey = `cleanup:${result.targetKey}:${result.reason}`,
 ): void {
   if (!store) return;
+  const protectedSkipCount = result.protectedSkipCount ?? 0;
+  const protectedSkipBytes = result.protectedSkipBytes ?? 0;
   recordWorkerDecisionRow(store, {
     workerKind: DISK_HEADROOM_WORKER_KIND,
     actionType: 'disk-cleanup',
@@ -119,7 +121,12 @@ function recordCleanupDecision(
       ? `Cleaned ${result.targetKey}`
       : `Cleanup ${result.reason} for ${result.targetKey}`,
     reason: result.reason,
-    payload: result.detail ? { detail: result.detail } : undefined,
+    payload: {
+      ...(result.detail ? { detail: result.detail } : {}),
+      protectedSkipCount,
+      protectedSkipBytes,
+      ...(result.protectedSkipBytesTruncated ? { protectedSkipBytesTruncated: true } : {}),
+    },
     incrementAttempt: result.ok,
   });
 }
@@ -215,6 +222,8 @@ export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): Wo
             targetKey,
             ok: false,
             reason: 'cooldown',
+            protectedSkipCount: 0,
+            protectedSkipBytes: 0,
           };
           options.logger.info?.(
             `[disk-headroom-cleanup] skip ${targetKey}: warn-paced cooldown`,
@@ -260,6 +269,8 @@ export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): Wo
             targetKey,
             ok: false,
             reason: 'cooldown',
+            protectedSkipCount: 0,
+            protectedSkipBytes: 0,
           };
           options.logger.info?.(
             `[disk-headroom-cleanup] skip ${targetKey}: cooldown`,
@@ -280,6 +291,8 @@ export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): Wo
               ok: false,
               reason: 'cleanup-error',
               detail: `remote target not found for ${targetKey}`,
+              protectedSkipCount: 0,
+              protectedSkipBytes: 0,
             };
           } else {
             result = await cleanupRemote({

--- a/packages/execution-engine/src/workers/reaper-reclaim.ts
+++ b/packages/execution-engine/src/workers/reaper-reclaim.ts
@@ -79,10 +79,24 @@ export function reapLocalDeletingOrphans(opts: {
   const userHome = opts.userHome ?? homedir();
   const home = expandTildeHome(opts.invokerHome, userHome);
   if (!isSafeInvokerHome(home, userHome)) {
-    return { targetKey, ok: false, reason: 'path-guard', detail: home };
+    return {
+      targetKey,
+      ok: false,
+      reason: 'path-guard',
+      detail: home,
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
+    };
   }
   if (!existsSync(home)) {
-    return { targetKey, ok: true, reason: 'reap-orphans', detail: 'removed 0' };
+    return {
+      targetKey,
+      ok: true,
+      reason: 'reap-orphans',
+      detail: 'removed 0',
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
+    };
   }
 
   const nowMs = opts.nowMs ?? Date.now();
@@ -111,9 +125,23 @@ export function reapLocalDeletingOrphans(opts: {
   }
 
   if (errors.length > 0) {
-    return { targetKey, ok: false, reason: 'cleanup-error', detail: errors.slice(0, 5).join('; ') };
+    return {
+      targetKey,
+      ok: false,
+      reason: 'cleanup-error',
+      detail: errors.slice(0, 5).join('; '),
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
+    };
   }
-  return { targetKey, ok: true, reason: 'reap-orphans', detail: `removed ${removed}` };
+  return {
+    targetKey,
+    ok: true,
+    reason: 'reap-orphans',
+    detail: `removed ${removed}`,
+    protectedSkipCount: 0,
+    protectedSkipBytes: 0,
+  };
 }
 
 export async function reapRemoteDeletingOrphans(opts: {
@@ -123,21 +151,42 @@ export async function reapRemoteDeletingOrphans(opts: {
 }): Promise<DiskCleanupResult> {
   const targetKey = `ssh:${opts.target.name} ${opts.target.remotePath}`;
   if (!isSafeRemoteInvokerHomePath(opts.target.remotePath)) {
-    return { targetKey, ok: false, reason: 'path-guard', detail: opts.target.remotePath };
+    return {
+      targetKey,
+      ok: false,
+      reason: 'path-guard',
+      detail: opts.target.remotePath,
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
+    };
   }
 
   const script = buildDeletingOrphanReapScript(opts.target.remotePath);
   const run = opts.runRemoteScript ?? defaultRunRemoteReap;
   try {
     const output = await run(opts.target, script);
-    return { targetKey, ok: true, reason: 'reap-orphans', detail: output.slice(-400) };
+    return {
+      targetKey,
+      ok: true,
+      reason: 'reap-orphans',
+      detail: output.slice(-400),
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
+    };
   } catch (err) {
     const detail = errorDetail(err);
     opts.logger?.error?.(`[reaper] remote orphan reap failed ${targetKey}: ${detail}`, {
       module: 'reaper',
       targetKey,
     });
-    return { targetKey, ok: false, reason: 'cleanup-error', detail };
+    return {
+      targetKey,
+      ok: false,
+      reason: 'cleanup-error',
+      detail,
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
+    };
   }
 }
 


### PR DESCRIPTION
## Summary

This scopes `process.noAsar` around the local disk-headroom pass so Electron sees real filesystem entries.

The pass restores the prior value in `finally`, including error paths.

`DiskCleanupResult` now reports protected bypass counts and approximate bytes. Other result producers return zeroes for those new fields.

The disk-headroom worker includes the totals in its decision ledger.

## Review Claim

Approve a scoped `process.noAsar` guard around the local pass plus additive accounting for protected paths that could not free bytes.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The guard changes only what the local pass can see, and it is restored in `finally`. Protected paths remain protected, and byte accounting is read-only and capped.

## Slice Rationale

This keeps walk correctness and operator visibility together while leaving the earlier removal primitive and warn trigger policy in prior stack steps.

## Non-goals

No trigger-policy changes.

No new deletion behavior.

No dashboard or UI surface.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/disk-reclaim-asar-noasar.repro.test.ts`
- [ ] Not run in this merge clone: `pnpm exec vitest` failed because `vitest` is not installed.
- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/disk-headroom-reclaim.test.ts`
- [ ] Not run in this merge clone: package dependencies are not installed.
- [ ] `bash scripts/repro/repro-disk-reclaim-asar-enotdir.sh`
- [ ] Not run in this merge clone: Electron is not installed without `pnpm install` and approved Electron build scripts.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-commit>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #7761