### PR TITLE
[Workflow Status Query Classifier](1) Pin down parseWorkflowStatusQuery's false-positive with a repro

### DIFF
--- a/packages/surfaces/src/__tests__/workflow-status-false-positive-repro.test.ts
+++ b/packages/surfaces/src/__tests__/workflow-status-false-positive-repro.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { parseWorkflowStatusQuery } from '../slack/slack-surface.js';
+
+describe('parseWorkflowStatusQuery false positive repro', () => {
+  // Real message that triggered this in Slack: a /loop babysit-loop instruction.
+  // Marked as an expected failure until the follow-up fix lands — this pins
+  // down the current (wrong) behavior instead of leaving it undocumented.
+  it.fails('does not treat a long babysit/loop instruction as a status query', () => {
+    const babysitLoopMessage = `/loop keep babysitting the DO1 admin-bypass repair worker. For each task and workflow that fails, please prove root
+cause with a repro scirpt, how it happened, why we missed it, and fix the root issue and how we can avoid this kind of
+issue again. Make a pr natively through /pr-skill and not thorugh invoker.
+Context: PR #7652 (github.com/Neko-Catpital-Labs/Invoker/pull/7652) has all individually-required checks green.
+It's in Mergify's admin-bypass queue, state "checking"/"Preparing checks", ETA has slipped from 00:17 to 00:27 UTC across
+the last two checks (still healthy progress, GH Actions still catching up post-outage, not stuck -- checks_timeout is
+60min per .mergify.yml so there's buffer).`;
+
+    expect(parseWorkflowStatusQuery(babysitLoopMessage)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a regression test for `parseWorkflowStatusQuery`, the Slack message parser that decides whether a message is asking for a workflow status report.

The test uses the real message that triggered the bug: a long, multi-line babysit-loop instruction. It mentions "workflow" and "progress" in ordinary prose, enough to misclassify the whole message as a status request.

The test is marked `it.fails` for now, documenting today's wrong behavior without breaking CI.

A follow-up PR flips it to a normal passing test once the parser is fixed.

## Review Claim

Approve adding a regression test that pins down `parseWorkflowStatusQuery`'s false-positive on long, multi-line messages, currently marked as an expected failure.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This PR only adds a new test file; it makes zero production code changes, so it cannot alter runtime behavior for any Slack conversation before or after merge.

## Slice Rationale

The repro lands before the fix so the bug is demonstrated and reviewable on its own, before the behavior change in the next PR is judged.

## Non-goals

Does not change `parseWorkflowStatusQuery` or any other parser. Does not touch the two sibling parsers checked during triage.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test -- workflow-status-false-positive-repro`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
