### PR TITLE
[Workflow Status Query Classifier](2) Anchor parseWorkflowStatusQuery to short, single-line text

### DIFF
--- a/packages/surfaces/src/__tests__/workflow-status-false-positive-repro.test.ts
+++ b/packages/surfaces/src/__tests__/workflow-status-false-positive-repro.test.ts
@@ -3,9 +3,7 @@ import { parseWorkflowStatusQuery } from '../slack/slack-surface.js';
 
 describe('parseWorkflowStatusQuery false positive repro', () => {
   // Real message that triggered this in Slack: a /loop babysit-loop instruction.
-  // Marked as an expected failure until the follow-up fix lands — this pins
-  // down the current (wrong) behavior instead of leaving it undocumented.
-  it.fails('does not treat a long babysit/loop instruction as a status query', () => {
+  it('does not treat a long babysit/loop instruction as a status query', () => {
     const babysitLoopMessage = `/loop keep babysitting the DO1 admin-bypass repair worker. For each task and workflow that fails, please prove root
 cause with a repro scirpt, how it happened, why we missed it, and fix the root issue and how we can avoid this kind of
 issue again. Make a pr natively through /pr-skill and not thorugh invoker.

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -392,6 +392,11 @@ function repositoryIdentity(repoUrl: string): string {
 
 export function parseWorkflowStatusQuery(text: string): { intent: 'command'; operation: 'status'; target: { all: true } } | null {
   const trimmed = text.trim();
+  // A quick status ask is a single short line. Longer or multi-line text is an
+  // instruction that happens to mention "workflow" and a progress-ish word in
+  // passing, not a request for a status report — fall through to conversation.
+  if (/\n/.test(trimmed)) return null;
+  if (trimmed.split(/\s+/).length > 12) return null;
   if (!/\bworkflows?\b/i.test(trimmed)) return null;
   if (!/\b(status|how many|count|running|active|in progress|progress)\b/i.test(trimmed)) return null;
   return { intent: 'command', operation: 'status', target: { all: true } };


### PR DESCRIPTION
## Summary

`parseWorkflowStatusQuery` decided whether a Slack message should route to a status reply by checking for a couple of words anywhere in the message body, with no anchor to where those words appeared.

A long, multi-line instruction that merely mentioned "workflow" and a word like "progress" in passing got routed to the status reply instead of conversation, and the rest of the message was thrown away.

This narrows the check to short, single-line text only. Longer text now falls through to conversation, matching how the other two message parsers in this file already handle prose.

## Review Claim

Approve narrowing `parseWorkflowStatusQuery`'s routing check so only short, single-line text can trigger the status-report shortcut.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This PR only narrows `parseWorkflowStatusQuery`'s match condition by adding two early-return guards; it can only cause previously-matched text to now fall through to conversation, never the reverse, so it cannot introduce a new false-positive class, only remove the proven one. Existing short single-line status queries stay covered by tests.

## Slice Rationale

This is the minimal fix isolated to the one parser proven broken by the repro in the prior PR. The two other message parsers in this file were checked against the same real-world input and already route free-form prose to conversation correctly, so they are out of scope here.

## Non-goals

Does not touch the two sibling parsers. Does not add any new classification capability, only tightens an existing one.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test -- workflow-status-false-positive-repro`
- [x] `cd packages/surfaces && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes — revert both PRs in this stack together. Reverting only this one restores the original matcher and the earlier repro test would fail again.
- Revert command: `git revert <sha-of-this-pr> <sha-of-prior-pr>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message handling so long or multiline instructions are no longer incorrectly interpreted as workflow status queries.
  * Long `/loop` babysitting instructions now continue through normal conversation handling as expected.
* **Tests**
  * Added coverage confirming these instructions are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->