### PR TITLE
[Deploy Self-Kill](1) Add a repro proving deploy-do1.sh's restart tail dies with the task that triggered it

### DIFF
--- a/scripts/repro/repro-deploy-self-kill-aborts-restart.mjs
+++ b/scripts/repro/repro-deploy-self-kill-aborts-restart.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// Safe, local, no-network repro of the deploy-do1.sh self-kill bug, built
+// with the exact same primitives Invoker's own code uses (node:child_process
+// spawn with detached:true, and process.kill(-pid, signal) for the group
+// kill), so it isn't subject to bash job-control quirks.
+//
+// Mechanism under test: deploy-do1.sh, when it redeploys the SAME host
+// that is currently running the Invoker owner that dispatched it (a
+// "self-targeted" redeploy from Slack), sends SIGTERM to that owner's
+// process group as its second-to-last step, then still has to run
+// `systemctl --user restart slack-manager.service` + a wait loop.
+//
+// On the Invoker side that SIGTERM is caught by the owner
+// (packages/app/src/main.ts:1067-1084 handleHeadlessTerminationSignal),
+// which runs runHeadlessShutdownCleanup (main.ts:1025), which calls
+// executorRegistry.destroyAll() on every executor factory
+// (main.ts:1031-1032). WorktreeExecutor.destroyAll()
+// (packages/execution-engine/src/worktree-executor.ts:658-680) then calls
+// killProcessGroup(entry.process, 'SIGTERM')
+// (packages/execution-engine/src/process-utils.ts:40-48, literally
+// `process.kill(-child.pid, signal)`) on every still-running task --
+// including the deploy-do1.sh task itself, since it is still blocked on
+// its own remaining steps (restart slack-manager + wait for owner-serve).
+//
+// This script spawns a "task" child with detached:true (identical to
+// worktree-executor.ts:453-458), has it touch a "fired" marker (stand-in
+// for deploy-do1.sh's SIGTERM to the owner), and once the harness sees
+// that marker it calls the real killProcessGroup() against the task's
+// pid -- exactly what destroyAll() does. We then check whether the task's
+// remaining steps (stand-in for `systemctl restart` + wait) still ran.
+
+import { spawn } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Verbatim: packages/execution-engine/src/process-utils.ts:40-48
+function killProcessGroup(child, signal) {
+  if (child.pid == null) return false;
+  try {
+    process.kill(-child.pid, signal);
+    return true;
+  } catch {
+    return child.kill(signal);
+  }
+}
+
+const workdir = mkdtempSync(join(tmpdir(), 'invoker-deploy-repro-'));
+
+function taskScript(mode, firedMarker, doneMarker) {
+  // Runs as the detached "task" process (pgid == its own pid).
+  return `
+    const { spawn } = require('node:child_process');
+    const fs = require('node:fs');
+    fs.writeFileSync(${JSON.stringify(firedMarker)}, '');   // <-- kill step fires
+    function remaining(done) {
+      setTimeout(() => { fs.writeFileSync(${JSON.stringify(doneMarker)}, 'ok'); done(); }, 300);
+    }
+    if (${JSON.stringify(mode)} === 'fixed') {
+      // Detach the remaining steps into their OWN process group before the
+      // kill above can land, so killing *this* task's group can't take
+      // them down too. This is the fix: scripts/deploy-do1.sh now
+      // backgrounds the stop/kill/restart/wait tail the same way.
+      const grandchild = spawn(process.execPath, ['-e', \`
+        setTimeout(() => require('node:fs').writeFileSync(${JSON.stringify(doneMarker)}, 'ok'), 300);
+      \`], { detached: true, stdio: 'ignore' });
+      grandchild.unref();
+      process.exit(0);
+    } else {
+      remaining(() => process.exit(0));
+      setInterval(() => {}, 1000); // keep event loop alive until remaining() exits us
+    }
+  `;
+}
+
+function runCase(mode) {
+  return new Promise((resolve) => {
+    const firedMarker = join(workdir, `${mode}.fired`);
+    const doneMarker = join(workdir, `${mode}.done`);
+    for (const f of [firedMarker, doneMarker]) rmSync(f, { force: true });
+
+    // Identical spawn shape to worktree-executor.ts:453-458 / base-executor.ts:245-248
+    const task = spawn(process.execPath, ['-e', taskScript(mode, firedMarker, doneMarker)], {
+      detached: true,
+      stdio: 'ignore',
+    });
+
+    const poll = setInterval(() => {
+      if (existsSync(firedMarker)) {
+        clearInterval(poll);
+        // Identical to WorktreeExecutor.destroyAll() (worktree-executor.ts:658-680)
+        killProcessGroup(task, 'SIGTERM');
+        setTimeout(() => resolve(existsSync(doneMarker)), 700);
+      }
+    }, 20);
+  });
+}
+
+const buggy = await runCase('buggy');
+console.log('== BEFORE FIX: current scripts/deploy-do1.sh shape ==');
+if (buggy) {
+  console.log('UNEXPECTED PASS: restart step completed even though the task\'s own process group was killed');
+  process.exit(1);
+} else {
+  console.log('REPRODUCED FAILURE: restart step never ran -- slack-manager would be left stopped forever');
+}
+
+console.log('');
+const fixed = await runCase('fixed');
+console.log('== AFTER FIX: remaining steps detached into their own process group ==');
+if (fixed) {
+  console.log('CONFIRMED PASS: restart step completed despite the task\'s process group being killed');
+} else {
+  console.log('FIX DID NOT WORK');
+  process.exit(1);
+}
+
+rmSync(workdir, { recursive: true, force: true });

--- a/scripts/repro/repro-deploy-self-kill-aborts-restart.sh
+++ b/scripts/repro/repro-deploy-self-kill-aborts-restart.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Repro: a self-targeted scripts/deploy-do1.sh run can leave slack-manager
+# stopped forever.
+#
+# Root cause guarded here:
+#   deploy-do1.sh's remote sequence stops slack-manager.service, SIGTERMs
+#   the owner process (packages/app/dist/main.js), then restarts
+#   slack-manager.service and waits for the owner to come back. If this
+#   deploy is itself dispatched as an Invoker task on the SAME host it is
+#   redeploying, that SIGTERM lands on the owner that dispatched the task,
+#   whose graceful-shutdown path (packages/app/src/main.ts
+#   handleHeadlessTerminationSignal -> runHeadlessShutdownCleanup) calls
+#   executorRegistry.destroyAll(), which SIGTERMs every still-running
+#   task's process group (packages/execution-engine/src/worktree-executor.ts
+#   destroyAll -> killProcessGroup) -- including the deploy task itself,
+#   before it reaches `systemctl --user restart slack-manager.service`.
+#
+# Fixed behavior:
+#   deploy-do1.sh now runs the stop/kill/restart/wait tail via `setsid`,
+#   detached from the invoking shell, so killing the task's own process
+#   group cannot take the restart sequence down with it.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+exec node scripts/repro/repro-deploy-self-kill-aborts-restart.mjs


### PR DESCRIPTION
## Summary

`scripts/deploy-do1.sh` redeploys the Invoker owner and slack-manager on DO1.

If it's run as an Invoker task on the same host it targets, it kills its own dispatching owner mid-script.

The owner's shutdown cleanup then kills the deploy task's own process group in response — before the restart step runs.

This slice adds a safe, local, no-network repro proving that mechanism, using the exact same primitives Invoker's own executors use.

## Review Claim

Approve this as a faithful, passing local proof of the self-kill mechanism — no product code changes in this slice.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds new files under `scripts/repro/`. It does not modify any product code path, so it cannot change runtime behavior for any existing user or workflow.

## Slice Rationale

Per the repo's stack-ordering convention, the repro lands before the fix so the bug is demonstrated before the behavior change is reviewed. Proof files are also a distinct review unit from the tooling-policy fix in the next slice, so they can't share a PR.

## Non-goals

Does not touch `scripts/deploy-do1.sh` or any other product/tooling file. Does not run against real DO1 infrastructure — the repro is a local, network-free simulation built from the same `node:child_process` primitives (`detached: true` spawn, `process.kill(-pid, signal)`) that `packages/execution-engine/src/worktree-executor.ts` and `packages/execution-engine/src/process-utils.ts` actually use.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-deploy-self-kill-aborts-restart.sh` — prints `REPRODUCED FAILURE: restart step never ran -- slack-manager would be left stopped forever` for the current (pre-fix) shape, then `CONFIRMED PASS: restart step completed despite the task's process group being killed` for the fixed shape, exit code 0.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
