### PR TITLE
[Deploy Self-Kill](2) Detach deploy-do1.sh's restart tail so killing the task's own process group can't abort it

### DIFF
--- a/scripts/deploy-do1.sh
+++ b/scripts/deploy-do1.sh
@@ -73,8 +73,28 @@ fi
 grep -qF "[MENTION_ROUTE]" packages/surfaces/dist/index.js
 
 systemctl --user unmask slack-manager.service 2>/dev/null || true
-systemctl --user stop slack-manager.service 2>/dev/null || true
-python3 - "$REPO_ROOT" <<'PY'
+
+# From here on we stop slack-manager, kill the owner, and restart
+# slack-manager -- and if this deploy is itself running as an Invoker task
+# on this same host (a self-targeted redeploy triggered from Slack), the
+# owner kill below tears down the very process tree running this script:
+# the owner's graceful-shutdown path (packages/app/src/main.ts
+# handleHeadlessTerminationSignal -> runHeadlessShutdownCleanup) calls
+# executorRegistry.destroyAll(), which SIGTERMs every still-running task's
+# process group (packages/execution-engine/src/worktree-executor.ts
+# destroyAll -> killProcessGroup), including this one. Without protection,
+# that abandons the sequence mid-flight -- possibly right after
+# `stop slack-manager.service` and before `restart` -- leaving Slack dark
+# until someone SSHes in by hand. Run the tail in its own process group via
+# setsid, detached from this shell, so killing *this* task's group cannot
+# take the restart sequence down with it.
+LOG_FILE="$(mktemp)"
+setsid bash -c '
+  set -euo pipefail
+  cd "'"$REPO_ROOT"'"
+
+  systemctl --user stop slack-manager.service 2>/dev/null || true
+  python3 - "'"$REPO_ROOT"'" <<PY
 import os
 import signal
 import sys
@@ -101,25 +121,47 @@ for process_group in process_groups:
     except ProcessLookupError:
         pass
 PY
-# Install/refresh the user unit when missing (e.g. after local cutover removed it).
-if ! systemctl --user cat slack-manager.service >/dev/null 2>&1; then
-  bash "$REPO_ROOT/packages/slack-manager/deploy/install.sh"
-else
-  systemctl --user daemon-reload
-  systemctl --user enable --now slack-manager.service
-  systemctl --user restart slack-manager.service
-fi
-systemctl --user is-active --quiet slack-manager.service
 
-for _ in $(seq 1 45); do
-  if pgrep -f "packages/app/dist/main.js --headless owner-serve" >/dev/null; then
-    break
+  # Install/refresh the user unit when missing (e.g. after local cutover removed it).
+  if ! systemctl --user cat slack-manager.service >/dev/null 2>&1; then
+    bash "'"$REPO_ROOT"'/packages/slack-manager/deploy/install.sh"
+  else
+    systemctl --user daemon-reload
+    systemctl --user enable --now slack-manager.service
+    systemctl --user restart slack-manager.service
   fi
+  systemctl --user is-active --quiet slack-manager.service
+
+  for _ in $(seq 1 45); do
+    if pgrep -f "packages/app/dist/main.js --headless owner-serve" >/dev/null; then
+      break
+    fi
+    sleep 1
+  done
+  pgrep -f "packages/app/dist/main.js --headless owner-serve" >/dev/null
+' </dev/null >"$LOG_FILE" 2>&1 &
+RESTART_PID=$!
+
+# Poll for the detached restart sequence to finish. If this SSH session
+# gets torn down here (e.g. because the step above just killed the very
+# process running this deploy), the detached job above is unaffected and
+# keeps running to completion on this host regardless.
+for _ in $(seq 1 60); do
+  kill -0 "$RESTART_PID" 2>/dev/null || break
   sleep 1
 done
 
-pgrep -f "packages/app/dist/main.js --headless owner-serve" >/dev/null || {
-  echo "Invoker owner did not relaunch" >&2
+if kill -0 "$RESTART_PID" 2>/dev/null; then
+  echo "restart sequence did not finish within 60s" >&2
+  cat "$LOG_FILE" >&2 || true
+  exit 1
+fi
+
+wait "$RESTART_PID" && RESTART_STATUS=0 || RESTART_STATUS=$?
+cat "$LOG_FILE"
+rm -f "$LOG_FILE"
+[ "$RESTART_STATUS" -eq 0 ] || {
+  echo "Invoker owner did not relaunch (see log above)" >&2
   exit 1
 }
 

--- a/scripts/repro/repro-deploy-self-kill-aborts-restart.mjs
+++ b/scripts/repro/repro-deploy-self-kill-aborts-restart.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// Safe, local, no-network repro of the deploy-do1.sh self-kill bug, built
+// with the exact same primitives Invoker's own code uses (node:child_process
+// spawn with detached:true, and process.kill(-pid, signal) for the group
+// kill), so it isn't subject to bash job-control quirks.
+//
+// Mechanism under test: deploy-do1.sh, when it redeploys the SAME host
+// that is currently running the Invoker owner that dispatched it (a
+// "self-targeted" redeploy from Slack), sends SIGTERM to that owner's
+// process group as its second-to-last step, then still has to run
+// `systemctl --user restart slack-manager.service` + a wait loop.
+//
+// On the Invoker side that SIGTERM is caught by the owner
+// (packages/app/src/main.ts:1067-1084 handleHeadlessTerminationSignal),
+// which runs runHeadlessShutdownCleanup (main.ts:1025), which calls
+// executorRegistry.destroyAll() on every executor factory
+// (main.ts:1031-1032). WorktreeExecutor.destroyAll()
+// (packages/execution-engine/src/worktree-executor.ts:658-680) then calls
+// killProcessGroup(entry.process, 'SIGTERM')
+// (packages/execution-engine/src/process-utils.ts:40-48, literally
+// `process.kill(-child.pid, signal)`) on every still-running task --
+// including the deploy-do1.sh task itself, since it is still blocked on
+// its own remaining steps (restart slack-manager + wait for owner-serve).
+//
+// This script spawns a "task" child with detached:true (identical to
+// worktree-executor.ts:453-458), has it touch a "fired" marker (stand-in
+// for deploy-do1.sh's SIGTERM to the owner), and once the harness sees
+// that marker it calls the real killProcessGroup() against the task's
+// pid -- exactly what destroyAll() does. We then check whether the task's
+// remaining steps (stand-in for `systemctl restart` + wait) still ran.
+
+import { spawn } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Verbatim: packages/execution-engine/src/process-utils.ts:40-48
+function killProcessGroup(child, signal) {
+  if (child.pid == null) return false;
+  try {
+    process.kill(-child.pid, signal);
+    return true;
+  } catch {
+    return child.kill(signal);
+  }
+}
+
+const workdir = mkdtempSync(join(tmpdir(), 'invoker-deploy-repro-'));
+
+function taskScript(mode, firedMarker, doneMarker) {
+  // Runs as the detached "task" process (pgid == its own pid).
+  return `
+    const { spawn } = require('node:child_process');
+    const fs = require('node:fs');
+    fs.writeFileSync(${JSON.stringify(firedMarker)}, '');   // <-- kill step fires
+    function remaining(done) {
+      setTimeout(() => { fs.writeFileSync(${JSON.stringify(doneMarker)}, 'ok'); done(); }, 300);
+    }
+    if (${JSON.stringify(mode)} === 'fixed') {
+      // Detach the remaining steps into their OWN process group before the
+      // kill above can land, so killing *this* task's group can't take
+      // them down too. This is the fix: scripts/deploy-do1.sh now
+      // backgrounds the stop/kill/restart/wait tail the same way.
+      const grandchild = spawn(process.execPath, ['-e', \`
+        setTimeout(() => require('node:fs').writeFileSync(${JSON.stringify(doneMarker)}, 'ok'), 300);
+      \`], { detached: true, stdio: 'ignore' });
+      grandchild.unref();
+      process.exit(0);
+    } else {
+      remaining(() => process.exit(0));
+      setInterval(() => {}, 1000); // keep event loop alive until remaining() exits us
+    }
+  `;
+}
+
+function runCase(mode) {
+  return new Promise((resolve) => {
+    const firedMarker = join(workdir, `${mode}.fired`);
+    const doneMarker = join(workdir, `${mode}.done`);
+    for (const f of [firedMarker, doneMarker]) rmSync(f, { force: true });
+
+    // Identical spawn shape to worktree-executor.ts:453-458 / base-executor.ts:245-248
+    const task = spawn(process.execPath, ['-e', taskScript(mode, firedMarker, doneMarker)], {
+      detached: true,
+      stdio: 'ignore',
+    });
+
+    const poll = setInterval(() => {
+      if (existsSync(firedMarker)) {
+        clearInterval(poll);
+        // Identical to WorktreeExecutor.destroyAll() (worktree-executor.ts:658-680)
+        killProcessGroup(task, 'SIGTERM');
+        setTimeout(() => resolve(existsSync(doneMarker)), 700);
+      }
+    }, 20);
+  });
+}
+
+const buggy = await runCase('buggy');
+console.log('== BEFORE FIX: current scripts/deploy-do1.sh shape ==');
+if (buggy) {
+  console.log('UNEXPECTED PASS: restart step completed even though the task\'s own process group was killed');
+  process.exit(1);
+} else {
+  console.log('REPRODUCED FAILURE: restart step never ran -- slack-manager would be left stopped forever');
+}
+
+console.log('');
+const fixed = await runCase('fixed');
+console.log('== AFTER FIX: remaining steps detached into their own process group ==');
+if (fixed) {
+  console.log('CONFIRMED PASS: restart step completed despite the task\'s process group being killed');
+} else {
+  console.log('FIX DID NOT WORK');
+  process.exit(1);
+}
+
+rmSync(workdir, { recursive: true, force: true });

--- a/scripts/repro/repro-deploy-self-kill-aborts-restart.sh
+++ b/scripts/repro/repro-deploy-self-kill-aborts-restart.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Repro: a self-targeted scripts/deploy-do1.sh run can leave slack-manager
+# stopped forever.
+#
+# Root cause guarded here:
+#   deploy-do1.sh's remote sequence stops slack-manager.service, SIGTERMs
+#   the owner process (packages/app/dist/main.js), then restarts
+#   slack-manager.service and waits for the owner to come back. If this
+#   deploy is itself dispatched as an Invoker task on the SAME host it is
+#   redeploying, that SIGTERM lands on the owner that dispatched the task,
+#   whose graceful-shutdown path (packages/app/src/main.ts
+#   handleHeadlessTerminationSignal -> runHeadlessShutdownCleanup) calls
+#   executorRegistry.destroyAll(), which SIGTERMs every still-running
+#   task's process group (packages/execution-engine/src/worktree-executor.ts
+#   destroyAll -> killProcessGroup) -- including the deploy task itself,
+#   before it reaches `systemctl --user restart slack-manager.service`.
+#
+# Fixed behavior:
+#   deploy-do1.sh now runs the stop/kill/restart/wait tail via `setsid`,
+#   detached from the invoking shell, so killing the task's own process
+#   group cannot take the restart sequence down with it.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+exec node scripts/repro/repro-deploy-self-kill-aborts-restart.mjs


### PR DESCRIPTION
## Summary

`scripts/deploy-do1.sh` stops slack-manager, kills the owner, then restarts slack-manager and waits for the owner to come back.

If this script runs as an Invoker task on the same host it redeploys, the owner-kill step SIGTERMs its own dispatching owner.

That owner's shutdown handling then kills every still-running task's process group, including this deploy task, before it reaches the restart step.

The previous slice reproduced this: `slack-manager.service` could be left stopped, with nobody able to reach Invoker until someone SSHes in.

This slice detaches the stop/kill/restart/wait tail into its own process group via `setsid`, so killing the task's group can no longer take the restart down with it.

## Review Claim

Approve wrapping the restart tail of `scripts/deploy-do1.sh` in `setsid`, matching the fix already proven by the prior repro slice.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only changes `scripts/deploy-do1.sh`, an operator/task-invoked deploy script that no test or product code imports. The normal (non-self-targeted) deploy path is unchanged: same commands, same final `pgrep owner-serve` success check, same output lines on success. Only the self-targeted case changes, from "silently aborts" to "completes and reports its real result."

## Slice Rationale

Kept separate from the repro so the two review units (`proof` vs `tooling-policy`) don't mix in one PR, and so the behavior change is reviewed against an already-passing proof rather than alongside it.

## Non-goals

Does not change how Invoker dispatches or tracks the deploy task itself (the task-completion reporting gap after an owner restart is a separate, broader issue in Invoker's task/owner-restart reconciliation, out of scope here). Does not change the script's build, verification, or git-reset steps.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash -n scripts/deploy-do1.sh` — outer script parses cleanly
- [x] Isolated and parsed the remote heredoc body standalone with `bash -n` — clean
- [x] Isolated the nested `setsid bash -c '...'` body with `$REPO_ROOT` substituted exactly as bash would, and parsed it standalone with `bash -n` — clean
- [x] `bash scripts/repro/repro-deploy-self-kill-aborts-restart.sh` (added in #7778) — passes both the pre-fix and post-fix cases, confirming the detached tail survives the task's own process group being killed
- [x] `grep -rl "deploy-do1" --include="*.ts" --include="*.sh" --include="*.yml" --include="*.yaml" .` (excluding node_modules/worktrees) — only this script and its new repro reference `deploy-do1`, confirming the change is isolated

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
