### PR TITLE
[Bugfix: checkMergeGateStatuses stale PR-status discard logging](1) Bugfix: checkMergeGateStatuses silently discards a resolved PR-status update with zero logging when the stale-write guard rejects it

### DIFF
--- a/packages/execution-engine/src/__tests__/repro-review-gate-logic-guards.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-review-gate-logic-guards.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 import { isInvokerRepoUrl, parseMakePrStackPublishResult } from '../pr-authoring.js';
 import { TaskRunner, type TaskRunnerConfig } from '../task-runner.js';
@@ -152,6 +152,62 @@ describe('repro #1865: reviewPollStillMatches blocks writes after the task left 
       execution: { selectedAttemptId: 'att1', generation: 0, reviewGate: undefined, reviewId: 'pr#1' },
     };
     expect(p.reviewPollStillMatches(before, reviewReady, 'pr#1')).toBe(true);
+  });
+
+  it('logs the stale poll discard reason without persisting the resolved PR status', async () => {
+    const task = {
+      id: '__merge__wf-1',
+      description: 'merge gate',
+      status: 'review_ready',
+      dependencies: [],
+      createdAt: new Date(),
+      config: { isMergeNode: true, workflowId: 'wf-1' },
+      execution: {
+        selectedAttemptId: 'att1',
+        generation: 0,
+        reviewGate: {
+          activeGeneration: 0,
+          completion: { required: 'all', status: 'approved' },
+          artifacts: [{ id: 'pr#1', providerId: 'pr#1', required: true, status: 'open', generation: 0 }],
+        },
+      },
+    } as unknown as TaskState;
+    const failed = { ...task, status: 'failed' } as TaskState;
+    const tasks = new Map<string, TaskState>([[task.id, task]]);
+
+    const warn = vi.fn();
+    const updateTask = vi.fn();
+    const orchestrator = {
+      getTask: (id: string) => tasks.get(id),
+    };
+    const persistence = { updateTask };
+    const mergeGateProvider = {
+      checkApproval: async () => {
+        tasks.set(task.id, failed);
+        return { lifecycle: 'open', rejected: false, statusText: 'Open' };
+      },
+    };
+
+    const logger = {
+      debug: () => {},
+      info: () => {},
+      warn,
+      error: () => {},
+      child: () => logger,
+    };
+    const runner = makeRunner({
+      orchestrator: orchestrator as unknown as TaskRunnerConfig['orchestrator'],
+      persistence: persistence as unknown as TaskRunnerConfig['persistence'],
+      mergeGateProvider: mergeGateProvider as unknown as TaskRunnerConfig['mergeGateProvider'],
+      logger: logger as unknown as TaskRunnerConfig['logger'],
+    });
+
+    await runner.checkPrApprovalNow(task.id);
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(`task=${task.id}`));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('providerId=pr#1'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('mismatchedFields=status'));
+    expect(updateTask).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/execution-engine/src/task-runner-review-gate.ts
+++ b/packages/execution-engine/src/task-runner-review-gate.ts
@@ -169,6 +169,31 @@ export function reviewPollStillMatches(
   );
 }
 
+function describeReviewPollMismatch(
+  before: TaskState,
+  current: TaskState | undefined,
+  providerId: string,
+): string[] {
+  if (!current) return ['current undefined'];
+
+  const fields: string[] = [];
+  if (current.status !== before.status) fields.push('status');
+  if (current.execution.selectedAttemptId !== before.execution.selectedAttemptId) {
+    fields.push('selectedAttemptId');
+  }
+  if ((current.execution.generation ?? 0) !== (before.execution.generation ?? 0)) {
+    fields.push('generation');
+  }
+  if (
+    current.execution.reviewGate?.activeGeneration
+    !== before.execution.reviewGate?.activeGeneration
+  ) {
+    fields.push('reviewGate.activeGeneration');
+  }
+  if (fields.length === 0) fields.push(`providerId ${providerId} no longer current`);
+  return fields;
+}
+
 export function updateReviewGateArtifact(
   gate: ReviewGateState,
   providerId: string,
@@ -245,6 +270,10 @@ export async function pollMergeGateTask(
 
     const current = host.orchestrator.getTask(task.id);
     if (!reviewPollStillMatches(task, current, providerId)) {
+      const mismatchedFields = describeReviewPollMismatch(task, current, providerId).join(',');
+      host.logger.warn(
+        `[merge-gate] Discarding stale PR status update for task=${task.id} providerId=${providerId}; mismatchedFields=${mismatchedFields}`,
+      );
       continue;
     }
 


### PR DESCRIPTION
## Summary

Fix `checkMergeGateStatuses` so a resolved PR-status update is no longer dropped with zero signal when the freshness comparison blocks it.

The freshness comparison still prevents old poll snapshots from writing. The blocked route now logs which task, provider, and field diverged.

This addresses the Digital Ocean 1 incident where workflow `wf-1786062626103-2` stayed open after PR #7713 was dequeued and then manually closed.

The deterministic proof is `cd packages/execution-engine && pnpm test -- repro-review-gate-logic-guards`.

## Review Claim

`pollMergeGateTask` still drops outdated poll results, but that route is now observable with a warning that names the task, provider, and diverged field.

## Review Lane

- behavior

## Review Unit

- routing

## Safety Invariant

All other behavior in `packages/execution-engine/src/task-runner-review-gate.ts` stays identical; only the defect path changes.

## Slice Rationale

One behavior slice contains the discard-site logging and the directly affected regression test.

The separate verify task produced no product diff, so it is represented in the test plan instead of as an empty PR slice.

## Non-goals

- Do not change `reviewPollStillMatches` return values.
- Do not change `checkMergeGateStatuses` task filtering.
- Do not change any persistence writes.
- Do not reconcile the specific frozen PR #7713 task.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- repro-review-gate-logic-guards`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
