### PR TITLE
Run required-fast-extra on the Mergify merge-queue ref, not around it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,7 @@ jobs:
         run: ${{ matrix.command }}
 
   required-fast-extra:
-    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
+    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
     runs-on:
       labels: ${{ matrix.runner_label }}


### PR DESCRIPTION
PR #7651 promoted required-fast-extra's five checks (Branch Carry
Forward, Merge Gate Concurrency Repro, Start Running MECE Repros,
Launch Dispatch Queue Repro, PR Babysit Harness) to required in
.mergify.yml's shared merge_conditions. But the job's own `if`
excludes mergify/merge-queue/* refs, and its `needs: build-artifacts`
dependency only runs on push/schedule/manual/merge-queue events -
never on an ordinary PR ref. The two conditions are mutually
exclusive with every context a not-yet-merged PR can be in: build-
artifacts skips on the PR's own branch, and required-fast-extra skips
on Mergify's speculative merge-queue branch. The check-success
conditions can only ever be satisfied by a commit already on master,
after the PR that needed them has already merged - a deadlock that
blocks every admin-bypass and default-queue PR permanently in
'checks running', confirmed via #7738 stuck 45+ minutes with every
other required check green.

Flip the guard to match required-fast and build-artifacts: run on
Mergify's merge-queue ref (in parallel with required-fast, per the
original comment's intent), not around it.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>