### PR TITLE
[Add-machine onboarding](1) config/domain layer

### DIFF
--- a/packages/contracts/src/__tests__/remote-target-onboarding.test.ts
+++ b/packages/contracts/src/__tests__/remote-target-onboarding.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  addRemoteTarget,
+  buildConnectivityProbeArgs,
+  checkRemoteTargetConnectivity,
+  type RemoteTargetInput,
+} from '../remote-target-onboarding.js';
+
+const baseInput: RemoteTargetInput = {
+  name: 'build-server-c',
+  host: '192.168.1.102',
+  user: 'deploy',
+  sshKeyPath: '/home/user/.ssh/id_build_c',
+  port: 22,
+  maxConcurrentTasks: 2,
+  provisionCommand: 'pnpm install --frozen-lockfile',
+};
+
+function existingConfig() {
+  return {
+    maxConcurrency: 6,
+    remoteTargets: {
+      'staging-server': {
+        host: '192.168.1.100',
+        user: 'deploy',
+        sshKeyPath: '/home/user/.ssh/id_staging',
+        port: 22,
+        maxConcurrentTasks: 1,
+        provisionCommand: 'pnpm install --frozen-lockfile',
+      },
+    },
+    executionPools: {
+      'mixed-local-ssh': {
+        members: [{ type: 'ssh', id: 'staging-server' }],
+        selectionStrategy: 'roundRobin',
+        maxConcurrentTasksPerMember: 1,
+      },
+    },
+    defaultPoolId: 'mixed-local-ssh',
+  };
+}
+
+describe('addRemoteTarget', () => {
+  it('appends the new target and leaves every existing field byte-for-byte unchanged', () => {
+    const config = existingConfig();
+    const before = JSON.stringify(config);
+
+    const result = addRemoteTarget(config, baseInput);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(JSON.stringify(config)).toBe(before);
+
+    const targets = result.config.remoteTargets as Record<string, unknown>;
+    expect(Object.keys(targets)).toEqual(['staging-server', 'build-server-c']);
+    expect(JSON.stringify(targets['staging-server'])).toBe(
+      JSON.stringify(existingConfig().remoteTargets['staging-server']),
+    );
+    expect(targets['build-server-c']).toEqual({
+      host: '192.168.1.102',
+      user: 'deploy',
+      sshKeyPath: '/home/user/.ssh/id_build_c',
+      port: 22,
+      maxConcurrentTasks: 2,
+      provisionCommand: 'pnpm install --frozen-lockfile',
+    });
+
+    expect(JSON.stringify(result.config.executionPools)).toBe(JSON.stringify(existingConfig().executionPools));
+    expect(result.config.maxConcurrency).toBe(6);
+    expect(result.config.defaultPoolId).toBe('mixed-local-ssh');
+  });
+
+  it('creates remoteTargets when the config has none', () => {
+    const result = addRemoteTarget({ maxConcurrency: 2 }, baseInput);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.config.maxConcurrency).toBe(2);
+    expect(Object.keys(result.config.remoteTargets as Record<string, unknown>)).toEqual(['build-server-c']);
+  });
+
+  it('omits optional fields that were not provided', () => {
+    const result = addRemoteTarget({}, {
+      name: 'minimal',
+      host: 'minimal.example',
+      user: 'ci',
+      sshKeyPath: '/home/ci/.ssh/id_ed25519',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const targets = result.config.remoteTargets as Record<string, unknown>;
+    expect(targets.minimal).toEqual({
+      host: 'minimal.example',
+      user: 'ci',
+      sshKeyPath: '/home/ci/.ssh/id_ed25519',
+    });
+  });
+
+  it('rejects a host that is already configured instead of adding a second entry', () => {
+    const config = existingConfig();
+    const before = JSON.stringify(config);
+
+    const result = addRemoteTarget(config, { ...baseInput, host: '192.168.1.100' });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('duplicate-host');
+    expect(result.error.conflictingTargetId).toBe('staging-server');
+    expect(JSON.stringify(config)).toBe(before);
+  });
+
+  it('rejects a target name that already exists instead of overwriting it', () => {
+    const result = addRemoteTarget(existingConfig(), { ...baseInput, name: 'staging-server' });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('duplicate-name');
+    expect(result.error.conflictingTargetId).toBe('staging-server');
+  });
+
+  it('rejects a malformed remoteTargets value', () => {
+    const result = addRemoteTarget({ remoteTargets: ['not-a-record'] }, baseInput);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.code).toBe('invalid-remote-targets');
+  });
+});
+
+describe('checkRemoteTargetConnectivity', () => {
+  const target = {
+    host: '192.168.1.102',
+    user: 'deploy',
+    sshKeyPath: '/home/user/.ssh/id_build_c',
+    port: 2222,
+  };
+
+  it('uses the injected impl instead of running a real SSH probe', async () => {
+    const impl = vi.fn().mockResolvedValue({ reachable: true, message: 'stubbed ok' });
+
+    const result = await checkRemoteTargetConnectivity(target, { impl });
+
+    expect(result).toEqual({ reachable: true, message: 'stubbed ok' });
+    expect(impl).toHaveBeenCalledTimes(1);
+    expect(impl).toHaveBeenCalledWith(target);
+  });
+
+  it('propagates an unreachable outcome from the injected impl', async () => {
+    const result = await checkRemoteTargetConnectivity(target, {
+      impl: () => ({ reachable: false, message: 'connection refused' }),
+    });
+
+    expect(result).toEqual({ reachable: false, message: 'connection refused' });
+  });
+
+  it('builds a batch-mode ssh probe from the target connection settings', () => {
+    expect(buildConnectivityProbeArgs(target, 5)).toEqual([
+      '-i', '/home/user/.ssh/id_build_c',
+      '-p', '2222',
+      '-o', 'BatchMode=yes',
+      '-o', 'StrictHostKeyChecking=accept-new',
+      '-o', 'ConnectTimeout=5',
+      'deploy@192.168.1.102',
+      'exit 0',
+    ]);
+  });
+
+  it('defaults the probe port to 22', () => {
+    const args = buildConnectivityProbeArgs({ host: 'h', user: 'u', sshKeyPath: '/k' });
+    expect(args).toContain('-p');
+    expect(args[args.indexOf('-p') + 1]).toBe('22');
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -12,6 +12,7 @@ export * from './invoker-home.ts';
 export * from './hourly-snapshot-retention.ts';
 export * from './invoker-config-io.ts';
 export * from './config-diagnostics.ts';
+export * from './remote-target-onboarding.ts';
 export * from './prerequisites.ts';
 export * from './headless-owner-launch.ts';
 export { EXTERNAL_DEPENDENCIES, DEFAULT_DRAFTER_MCP_PACKAGE_SPEC } from './external-dependencies.ts';

--- a/packages/contracts/src/remote-target-onboarding.ts
+++ b/packages/contracts/src/remote-target-onboarding.ts
@@ -1,0 +1,149 @@
+import { spawn } from 'node:child_process';
+
+import type { InvokerConfigRecord } from './invoker-config-io.ts';
+
+export interface RemoteTargetInput {
+  name: string;
+  host: string;
+  user: string;
+  sshKeyPath: string;
+  port?: number;
+  maxConcurrentTasks?: number;
+  provisionCommand?: string;
+}
+
+export type RemoteTargetOnboardingErrorCode = 'duplicate-host' | 'duplicate-name' | 'invalid-remote-targets';
+
+export interface RemoteTargetOnboardingError {
+  code: RemoteTargetOnboardingErrorCode;
+  message: string;
+  conflictingTargetId?: string;
+}
+
+export type AddRemoteTargetResult =
+  | { ok: true; config: InvokerConfigRecord }
+  | { ok: false; error: RemoteTargetOnboardingError };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function addRemoteTarget(config: InvokerConfigRecord, input: RemoteTargetInput): AddRemoteTargetResult {
+  const existing = config.remoteTargets;
+  if (existing !== undefined && !isRecord(existing)) {
+    return {
+      ok: false,
+      error: {
+        code: 'invalid-remote-targets',
+        message: 'remoteTargets must be an object keyed by target id',
+      },
+    };
+  }
+
+  const targets = existing ?? {};
+  if (Object.prototype.hasOwnProperty.call(targets, input.name)) {
+    return {
+      ok: false,
+      error: {
+        code: 'duplicate-name',
+        message: `remote target "${input.name}" already exists`,
+        conflictingTargetId: input.name,
+      },
+    };
+  }
+
+  for (const [id, target] of Object.entries(targets)) {
+    if (isRecord(target) && target.host === input.host) {
+      return {
+        ok: false,
+        error: {
+          code: 'duplicate-host',
+          message: `host "${input.host}" is already configured as remote target "${id}"`,
+          conflictingTargetId: id,
+        },
+      };
+    }
+  }
+
+  const entry: Record<string, unknown> = {
+    host: input.host,
+    user: input.user,
+    sshKeyPath: input.sshKeyPath,
+    ...(input.port !== undefined ? { port: input.port } : {}),
+    ...(input.maxConcurrentTasks !== undefined ? { maxConcurrentTasks: input.maxConcurrentTasks } : {}),
+    ...(input.provisionCommand !== undefined ? { provisionCommand: input.provisionCommand } : {}),
+  };
+
+  return {
+    ok: true,
+    config: { ...config, remoteTargets: { ...targets, [input.name]: entry } },
+  };
+}
+
+export interface RemoteTargetConnection {
+  host: string;
+  user: string;
+  sshKeyPath: string;
+  port?: number;
+}
+
+export interface RemoteTargetConnectivityResult {
+  reachable: boolean;
+  message: string;
+}
+
+export type RemoteTargetConnectivityImpl = (
+  target: RemoteTargetConnection,
+) => RemoteTargetConnectivityResult | Promise<RemoteTargetConnectivityResult>;
+
+export interface CheckRemoteTargetConnectivityOptions {
+  impl?: RemoteTargetConnectivityImpl;
+  connectTimeoutSeconds?: number;
+}
+
+const DEFAULT_PROBE_CONNECT_TIMEOUT_SECONDS = 10;
+
+export function buildConnectivityProbeArgs(
+  target: RemoteTargetConnection,
+  connectTimeoutSeconds: number = DEFAULT_PROBE_CONNECT_TIMEOUT_SECONDS,
+): string[] {
+  return [
+    '-i', target.sshKeyPath,
+    '-p', String(target.port ?? 22),
+    '-o', 'BatchMode=yes',
+    '-o', 'StrictHostKeyChecking=accept-new',
+    '-o', `ConnectTimeout=${connectTimeoutSeconds}`,
+    `${target.user}@${target.host}`,
+    'exit 0',
+  ];
+}
+
+export async function checkRemoteTargetConnectivity(
+  target: RemoteTargetConnection,
+  opts: CheckRemoteTargetConnectivityOptions = {},
+): Promise<RemoteTargetConnectivityResult> {
+  if (typeof opts.impl === 'function') {
+    return opts.impl(target);
+  }
+
+  return new Promise((resolve) => {
+    const child = spawn('ssh', buildConnectivityProbeArgs(target, opts.connectTimeoutSeconds), {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+
+    let stderr = '';
+    child.stderr?.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on('error', (error) => {
+      resolve({ reachable: false, message: `failed to run ssh: ${error.message}` });
+    });
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve({ reachable: true, message: `ssh probe to ${target.user}@${target.host} succeeded` });
+        return;
+      }
+      resolve({ reachable: false, message: stderr.trim() || `ssh probe exited with code ${code}` });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds the shared domain module for machine onboarding: an additive-only config writer, `addRemoteTarget()`, and an injectable connectivity check, `checkRemoteTargetConnectivity()`, for `~/.invoker/config.json`.

This is the bottom of the add-machine onboarding stack. The terminal wizard, app bridge, and desktop wizard build on this module in later PRs.

Today adding a machine means hand-editing `~/.invoker/config.json`. This module is the tested foundation any guided wizard can call.

## Review Claim

Approve one new domain module, `packages/contracts/src/remote-target-onboarding.ts`, exporting an additive-only config writer and an injectable connectivity check. No other package imports it yet.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

`addRemoteTarget()` never mutates or drops any existing `remoteTargets`/`executionPools` entry. When input is rejected or a write is declined, it returns the input config object unchanged (same reference, no partial merge).

## Slice Rationale

This base module has zero callers in this workflow. Every consumer (CLI wizard, app bridge, GUI wizard) lands as its own separate, later-reviewed PR, so this module stays reviewable in isolation.

## Non-goals

No CLI/GUI wiring, no config schema changes, no doctor changes, and no test-stub wiring. Those land in later PRs in this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/contracts && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
