### PR TITLE
[Add-machine onboarding](3) app bridge

### DIFF
--- a/packages/app/src/__tests__/invoker-cli-setup.test.ts
+++ b/packages/app/src/__tests__/invoker-cli-setup.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { runInvokerCliSetup } from '../invoker-cli-setup.js';
+import { runInvokerCliSetup, runMachinesSetup } from '../invoker-cli-setup.js';
 
 const tempRoots: string[] = [];
 
@@ -79,5 +79,84 @@ if (args === 'setup slack --from-env') process.stdout.write('slack still ran');
     expect(result.steps.map((step) => step.id)).toEqual(['tools', 'slack']);
     expect(result.steps[0]).toMatchObject({ ok: false });
     expect(result.steps[1]).toMatchObject({ ok: true });
+  });
+});
+
+describe('runMachinesSetup', () => {
+  it('writes the machine field set to stdin and returns one result per machine', async () => {
+    const cliPath = makeCli(`
+const args = process.argv.slice(2).join(' ');
+if (args !== 'setup machines --json') process.exit(9);
+let input = '';
+process.stdin.on('data', (chunk) => { input += chunk; });
+process.stdin.on('end', () => {
+  const machines = JSON.parse(input);
+  const results = machines.map((m) => ({ name: m.name, reachable: true, written: true, message: 'Wrote machine "' + m.name + '"' }));
+  process.stdout.write(JSON.stringify(results));
+});
+`);
+
+    const results = await runMachinesSetup([
+      { name: 'box1', host: 'example.com', user: 'deploy', sshKeyPath: '/home/deploy/.ssh/id_ed25519' },
+      { name: 'box2', host: 'example2.com', user: 'deploy', sshKeyPath: '/home/deploy/.ssh/id_ed25519' },
+    ], { cliPath });
+
+    expect(results).toEqual([
+      { name: 'box1', reachable: true, written: true, message: 'Wrote machine "box1"' },
+      { name: 'box2', reachable: true, written: true, message: 'Wrote machine "box2"' },
+    ]);
+  });
+
+  it('returns an error result for every machine when the child process fails', async () => {
+    const cliPath = makeCli(`
+process.stdin.on('data', () => {});
+process.stdin.on('end', () => {
+  process.stderr.write('boom');
+  process.exit(3);
+});
+`);
+
+    const results = await runMachinesSetup([
+      { name: 'box1', host: 'example.com', user: 'deploy', sshKeyPath: '/home/deploy/.ssh/id_ed25519' },
+      { name: 'box2', host: 'example2.com', user: 'deploy', sshKeyPath: '/home/deploy/.ssh/id_ed25519' },
+    ], { cliPath });
+
+    expect(results).toHaveLength(2);
+    for (const result of results) {
+      expect(result.written).toBe(false);
+      expect(result.error?.code).toBeTruthy();
+    }
+  });
+
+  it('never writes machine field values to console output', async () => {
+    const secretKeyPath = '/home/deploy/.ssh/super-secret-token-abc123';
+    const cliPath = makeCli(`
+let input = '';
+process.stdin.on('data', (chunk) => { input += chunk; });
+process.stdin.on('end', () => {
+  const machines = JSON.parse(input);
+  const results = machines.map((m) => ({ name: m.name, reachable: true, written: true, message: 'ok' }));
+  process.stdout.write(JSON.stringify(results));
+});
+`);
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    try {
+      await runMachinesSetup([
+        { name: 'box1', host: 'example.com', user: 'deploy', sshKeyPath: secretKeyPath },
+      ], { cliPath });
+
+      const captured = [...logSpy.mock.calls, ...errorSpy.mock.calls, ...warnSpy.mock.calls]
+        .flat()
+        .map((value) => String(value))
+        .join(' ');
+      expect(captured).not.toContain(secretKeyPath);
+    } finally {
+      logSpy.mockRestore();
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/app/src/__tests__/invoker-cli-setup.test.ts
+++ b/packages/app/src/__tests__/invoker-cli-setup.test.ts
@@ -128,6 +128,33 @@ process.stdin.on('end', () => {
     }
   });
 
+  it.each([
+    ['empty array', '[]'],
+    ['malformed result', '[{}]'],
+  ])('returns an error result for every machine when the child process returns %s', async (_label, output) => {
+    const cliPath = makeCli(`
+process.stdin.on('data', () => {});
+process.stdin.on('end', () => {
+  process.stdout.write(${JSON.stringify(output)});
+});
+`);
+
+    const results = await runMachinesSetup([
+      { name: 'box1', host: 'example.com', user: 'deploy', sshKeyPath: '/home/deploy/.ssh/id_ed25519' },
+    ], { cliPath });
+
+    expect(results).toEqual([
+      {
+        written: false,
+        message: 'invoker-cli returned invalid machine setup output',
+        error: {
+          code: 'invoker-cli-failed',
+          message: 'invoker-cli returned invalid machine setup output',
+        },
+      },
+    ]);
+  });
+
   it('never writes machine field values to console output', async () => {
     const secretKeyPath = '/home/deploy/.ssh/super-secret-token-abc123';
     const cliPath = makeCli(`

--- a/packages/app/src/cli-helper.ts
+++ b/packages/app/src/cli-helper.ts
@@ -42,6 +42,6 @@ export function spawnBundledCli(
   return spawn(runtime, cliArgs, {
     cwd: options.cwd,
     env: { ...process.env, ...options.env },
-    stdio: ['ignore', 'pipe', 'pipe'],
+    stdio: ['pipe', 'pipe', 'pipe'],
   });
 }

--- a/packages/app/src/invoker-cli-setup.ts
+++ b/packages/app/src/invoker-cli-setup.ts
@@ -102,6 +102,24 @@ function machinesErrorResult(machines: RemoteTargetInput[], message: string): Ma
   }));
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isMachineSetupError(value: unknown): value is MachineSetupResult['error'] {
+  if (!isRecord(value)) return false;
+  if (typeof value.code !== 'string' || typeof value.message !== 'string') return false;
+  return value.conflictingTargetId === undefined || typeof value.conflictingTargetId === 'string';
+}
+
+function isMachineSetupResult(value: unknown): value is MachineSetupResult {
+  if (!isRecord(value)) return false;
+  if (typeof value.written !== 'boolean' || typeof value.message !== 'string') return false;
+  if (value.name !== undefined && typeof value.name !== 'string') return false;
+  if (value.reachable !== undefined && typeof value.reachable !== 'boolean') return false;
+  return value.error === undefined || isMachineSetupError(value.error);
+}
+
 export async function runMachinesSetup(
   machines: RemoteTargetInput[],
   deps: Pick<InvokerCliSetupDeps, 'cliPath'>,
@@ -121,6 +139,10 @@ export async function runMachinesSetup(
 
   if (!Array.isArray(parsed)) {
     return machinesErrorResult(machines, 'invoker-cli returned unexpected output');
+  }
+
+  if (parsed.length !== machines.length || !parsed.every(isMachineSetupResult)) {
+    return machinesErrorResult(machines, 'invoker-cli returned invalid machine setup output');
   }
 
   return parsed as MachineSetupResult[];

--- a/packages/app/src/invoker-cli-setup.ts
+++ b/packages/app/src/invoker-cli-setup.ts
@@ -5,6 +5,7 @@ import type {
   InvokerSetupRequest,
   InvokerSetupResult,
   InvokerSetupStepResult,
+  RemoteTargetInput,
 } from '@invoker/contracts';
 
 import { spawnBundledCli } from './cli-helper.js';
@@ -24,13 +25,25 @@ interface CliCommandResult {
   error?: string;
 }
 
+export interface MachineSetupResult {
+  name?: string;
+  reachable?: boolean;
+  written: boolean;
+  message: string;
+  error?: {
+    code: string;
+    message: string;
+    conflictingTargetId?: string;
+  };
+}
+
 function appendOutput(current: string, chunk: Buffer | string): string {
   const next = current + chunk.toString();
   if (Buffer.byteLength(next, 'utf8') <= MAX_SETUP_OUTPUT_BYTES) return next;
   return `${next.slice(0, MAX_SETUP_OUTPUT_BYTES)}\n[output truncated]`;
 }
 
-function runCli(cliPath: string, args: string[], env?: NodeJS.ProcessEnv): Promise<CliCommandResult> {
+function runCli(cliPath: string, args: string[], env?: NodeJS.ProcessEnv, stdinInput?: string): Promise<CliCommandResult> {
   const { promise, resolve } = Promise.withResolvers<CliCommandResult>();
   let stdout = '';
   let stderr = '';
@@ -57,6 +70,10 @@ function runCli(cliPath: string, args: string[], env?: NodeJS.ProcessEnv): Promi
       const output = [stdout, stderr].filter(Boolean).join('\n');
       settle({ ok: exitCode === 0, exitCode, output, error: exitCode === 0 ? undefined : `invoker-cli exited with ${exitCode}` });
     });
+    if (stdinInput !== undefined) {
+      child.stdin?.write(stdinInput);
+    }
+    child.stdin?.end();
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     settle({ ok: false, exitCode: null, output: '', error: message });
@@ -75,6 +92,38 @@ function summarizeHelpers(status: BundledSkillsStatus): string {
   const targets = [...status.targets, ...status.commandTargets, ...status.mcpTargets];
   const installed = targets.filter((target) => target.installed && target.upToDate).length;
   return `Installed ${status.bundledSkillNames.length} bundled helper set(s) across ${installed}/${targets.length} available target(s).`;
+}
+
+function machinesErrorResult(machines: RemoteTargetInput[], message: string): MachineSetupResult[] {
+  return machines.map(() => ({
+    written: false,
+    message,
+    error: { code: 'invoker-cli-failed', message },
+  }));
+}
+
+export async function runMachinesSetup(
+  machines: RemoteTargetInput[],
+  deps: Pick<InvokerCliSetupDeps, 'cliPath'>,
+): Promise<MachineSetupResult[]> {
+  const result = await runCli(deps.cliPath, ['setup', 'machines', '--json'], undefined, JSON.stringify(machines));
+
+  if (!result.ok) {
+    return machinesErrorResult(machines, result.error ?? 'invoker-cli exited with an error');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(result.output);
+  } catch {
+    return machinesErrorResult(machines, 'invoker-cli returned unparsable output');
+  }
+
+  if (!Array.isArray(parsed)) {
+    return machinesErrorResult(machines, 'invoker-cli returned unexpected output');
+  }
+
+  return parsed as MachineSetupResult[];
 }
 
 export async function runInvokerCliSetup(request: InvokerSetupRequest, deps: InvokerCliSetupDeps): Promise<InvokerSetupResult> {


### PR DESCRIPTION
## Summary

The desktop app already has a helper that shells out to the setup tool's Slack step. This adds a matching helper for the machines setup step from workflow (2).

`runMachinesSetup()` spawns the setup tool's non-interactive machines mode as a child process and returns its structured per-machine result.

No renderer code calls this helper yet. That wiring is a separate, later workflow that builds the actual GUI wizard step.

## Review Claim

Approve one new app-layer helper, `runMachinesSetup()`, that runs the setup tool's machines step as a child process and hands back a structured result, mirroring the existing Slack helper's shape.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Every field passed to the child process travels through its environment or standard input only; none of it is ever written to the app's own event log or printed to the renderer console.

## Slice Rationale

This slice only touches the app-side helper. The renderer-facing wizard step that will call it is a separate, later workflow built on top of this one.

## Non-goals

- No renderer or `packages/ui` changes in this task.
- No changes to the setup tool's entry point itself beyond what workflow (2) already added.

## Architecture

### Before

`packages/app/src/invoker-cli-setup.ts` could shell out to the Slack setup step only.

### After

`packages/app/src/invoker-cli-setup.ts` also shells out to the non-interactive machines setup step, using the same child-process shape as the Slack helper, and returns a typed per-machine result.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added machine setup support using structured JSON input and per-machine results.
  * Added clear status and error reporting for setup outcomes, command failures, invalid responses, and unreachable machines.
  * Prevented sensitive machine field values from appearing in console output.

* **Bug Fixes**
  * Improved CLI communication by correctly passing input data to bundled processes.
  * Added handling for empty, malformed, or unexpected CLI output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->