### PR TITLE
[Lease-aware disk-headroom reaper](4a)[REFACTOR: Replace Magic Number with Symbolic Constant] remote store wiring honors main remote home

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -345,7 +345,7 @@ function buildRegisteredOwnerWorkerDeps(
       sshKeyPath: target.sshKeyPath,
       port: target.port,
     },
-    remotePath: '~/.invoker',
+    remotePath: target.remoteInvokerHome ?? '~/.invoker',
   }));
 
   return {


### PR DESCRIPTION
## Summary

Updates the `RemoteDiskTarget` builder in `packages/app/src/main.ts` so the configured remote home flows into `remotePath`.

Targets without `remoteInvokerHome` still use `~/.invoker`. That keeps the default remote target path unchanged.

This makes the remote store path available before later path comparisons depend on it.

## Review Claim

Replace Magic Number with Config Field: `RemoteDiskTarget.remotePath` construction in `packages/app/src/main.ts` honors `remoteInvokerHome` per target and preserves the `~/.invoker` default otherwise.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

For every remote target that does not set `remoteInvokerHome`, the resulting path is identical to the previous hardcoded `~/.invoker` value.

## Slice Rationale

This slice keeps the Electron entry-point wiring reviewable on its own before the second construction site and its test are reviewed.

## Non-goals

Behavior unchanged for remote targets that do not set `remoteInvokerHome`.

No remote reaping behavior change on any host.

No changes to the headless worker construction site in this slice.

No new deletion, preservation, or lease filtering behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `bash scripts/ui-visual-proof.sh capture-after` (captured fresh media for the main-process touchpoint; the script reported existing screenshot baseline drift while still writing after-capture artifacts)

</details>

## Visual Proof

The remote-home wiring has no visible UI state of its own. This fresh after-capture shows the app shell still launches after the `main.ts` construction-site change.

![App shell after remote-home wiring](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260807-51dd35/invoker-pr-7815-visual-proof.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3b906bb0c`
- Post-revert steps: None
- Data migration? No

</details>
