### PR TITLE
[Lease-aware disk-headroom reaper](4b)[REFACTOR: Replace Magic Number with Symbolic Constant] remote store wiring honors headless remote home

### DIFF
--- a/packages/app/src/__tests__/headless-worker.test.ts
+++ b/packages/app/src/__tests__/headless-worker.test.ts
@@ -49,6 +49,31 @@ describe('headless worker registry', () => {
     }]);
   });
 
+  it('uses a target\'s remoteInvokerHome as the remotePath when set', () => {
+    const config = resolveHeadlessDiskHeadroomConfig({
+      remoteTargets: {
+        digitalOcean: {
+          host: '203.0.113.10',
+          user: 'invoker',
+          sshKeyPath: '/tmp/test-key',
+          port: 2222,
+          remoteInvokerHome: '~/.invoker-custom',
+        },
+      },
+    });
+
+    expect(config.remoteTargets).toEqual([{
+      name: 'digitalOcean',
+      connection: {
+        host: '203.0.113.10',
+        user: 'invoker',
+        sshKeyPath: '/tmp/test-key',
+        port: 2222,
+      },
+      remotePath: '~/.invoker-custom',
+    }]);
+  });
+
   it('maps configured SSH targets into infra-repair worker dependencies', () => {
     const config = resolveHeadlessInfraRepairConfig({
       remoteTargets: {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -414,7 +414,7 @@ export function resolveHeadlessDiskHeadroomConfig(
         sshKeyPath: target.sshKeyPath,
         port: target.port,
       },
-      remotePath: '~/.invoker',
+      remotePath: target.remoteInvokerHome ?? '~/.invoker',
     })),
   };
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -345,7 +345,7 @@ function buildRegisteredOwnerWorkerDeps(
       sshKeyPath: target.sshKeyPath,
       port: target.port,
     },
-    remotePath: '~/.invoker',
+    remotePath: target.remoteInvokerHome ?? '~/.invoker',
   }));
 
   return {


### PR DESCRIPTION
## Summary

Extends the headless worker remote disk-headroom resolver so each target's `remotePath` can come from its configured `remoteInvokerHome`.

Targets without `remoteInvokerHome` still use `~/.invoker`. That preserves today's default for existing target configs.

Adds a focused regression test proving the headless resolver keeps both the override and default cases correct.

## Review Claim

Replace Magic Number with Config Field: `resolveHeadlessDiskHeadroomConfig` honors `remoteInvokerHome` per target and preserves the `~/.invoker` default otherwise.

## Review Lane

refactor

## Review Unit

activation-surface

## Safety Invariant

For every remote target that does not set `remoteInvokerHome`, the resulting path is identical to the previous hardcoded `~/.invoker` value.

## Slice Rationale

This slice applies the same remote-home wiring to the headless activation path and keeps the proof beside the resolver that is directly unit tested.

## Non-goals

Behavior unchanged for remote targets that do not set `remoteInvokerHome`.

No remote reaping behavior change on any host.

No changes to Electron main process wiring in this slice.

No new deletion, preservation, or lease filtering behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/headless-worker.test.ts`
- [x] `pnpm --filter @invoker/app build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d4cd10ff4`
- Post-revert steps: None
- Data migration? No

</details>
