### PR TITLE
[Add headless CLI command to force a merge-gate PR-status recheck](1) Add delegated headless PR-status check

### DIFF
--- a/packages/app/src/__tests__/headless-command-classification.test.ts
+++ b/packages/app/src/__tests__/headless-command-classification.test.ts
@@ -53,6 +53,7 @@ describe('headless-command-classification', () => {
 
     expect(isHeadlessMutatingCommand(['run'])).toBe(true);
     expect(isHeadlessMutatingCommand(['migrate-compat'])).toBe(true);
+    expect(isHeadlessMutatingCommand(['check-pr-status'])).toBe(true);
     expect(isHeadlessMutatingCommand(['cancel-workflow'])).toBe(true);
     expect(isHeadlessMutatingCommand(['set', 'prompt'])).toBe(true);
     expect(isHeadlessMutatingCommand(['set', 'agent'])).toBe(true);

--- a/packages/app/src/__tests__/headless.test.ts
+++ b/packages/app/src/__tests__/headless.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { headlessCheckPrStatus, runHeadless, type HeadlessDeps } from '../headless.js';
+
+function makeTask(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    status: 'review_ready',
+    description: id,
+    dependencies: [],
+    createdAt: new Date('2026-08-07T00:00:00Z'),
+    config: { workflowId: 'wf-1', isMergeNode: true },
+    execution: {},
+    ...overrides,
+  };
+}
+
+function makeDeps(tasks = [makeTask('merge-1')]) {
+  const checkPrApprovalNow = vi.fn(async () => {});
+  const deps = {
+    orchestrator: {
+      getAllTasks: vi.fn(() => tasks),
+      getTask: vi.fn((taskId: string) => tasks.find((task) => task.id === taskId)),
+    },
+    commandService: {
+      runSerializedForWorkflow: vi.fn(async (_workflowId: string | undefined, fn: () => Promise<void>) => {
+        await fn();
+        return { ok: true as const, data: undefined };
+      }),
+      runSerializedForTask: vi.fn(async (_taskId: string, fn: () => Promise<void>) => {
+        await fn();
+        return { ok: true as const, data: undefined };
+      }),
+    },
+    ownerTaskRunnerProvider: vi.fn(() => ({ checkPrApprovalNow })),
+  } as unknown as HeadlessDeps;
+  return { deps, checkPrApprovalNow };
+}
+
+describe('headless check-pr-status', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('checks every review-ready or awaiting merge gate through the live owner TaskRunner', async () => {
+    const { deps, checkPrApprovalNow } = makeDeps([
+      makeTask('merge-review-ready'),
+      makeTask('merge-awaiting', { status: 'awaiting_approval' }),
+      makeTask('merge-completed', { status: 'completed' }),
+      makeTask('regular-review-ready', { config: { workflowId: 'wf-1', isMergeNode: false } }),
+    ]);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHeadless(['check-pr-status'], deps);
+
+    expect(deps.ownerTaskRunnerProvider).toHaveBeenCalledTimes(1);
+    expect(deps.commandService.runSerializedForWorkflow).toHaveBeenCalledWith(undefined, expect.any(Function));
+    expect(checkPrApprovalNow).toHaveBeenCalledTimes(2);
+    expect(checkPrApprovalNow).toHaveBeenNthCalledWith(1, 'merge-review-ready');
+    expect(checkPrApprovalNow).toHaveBeenNthCalledWith(2, 'merge-awaiting');
+    const output = stdout.mock.calls.map(([chunk]) => String(chunk)).join('');
+    expect(output).toContain('Checked PR status for task: merge-review-ready');
+    expect(output).toContain('Checked PR status for task: merge-awaiting');
+    expect(output).not.toContain('merge-completed');
+    expect(output).not.toContain('regular-review-ready');
+  });
+
+  it('checks only the requested taskId', async () => {
+    const { deps, checkPrApprovalNow } = makeDeps([
+      makeTask('merge-1'),
+      makeTask('merge-2', { status: 'awaiting_approval' }),
+    ]);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await headlessCheckPrStatus('merge-2', deps);
+
+    expect(deps.commandService.runSerializedForTask).toHaveBeenCalledWith('merge-2', expect.any(Function));
+    expect(deps.commandService.runSerializedForWorkflow).not.toHaveBeenCalled();
+    expect(checkPrApprovalNow).toHaveBeenCalledTimes(1);
+    expect(checkPrApprovalNow).toHaveBeenCalledWith('merge-2');
+    expect(stdout.mock.calls.map(([chunk]) => String(chunk)).join('')).toBe(
+      'Checked PR status for task: merge-2\n',
+    );
+  });
+
+  it('documents check-pr-status in help output', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHeadless(['--help'], {} as HeadlessDeps);
+
+    expect(stdout.mock.calls.map(([chunk]) => String(chunk)).join('')).toContain(
+      'check-pr-status [taskId]',
+    );
+  });
+});

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -45,6 +45,7 @@ export const HEADLESS_COMMANDS = [
   { name: 'rebase-retry', kind: 'write' },
   { name: 'rebase-recreate', kind: 'write' },
   { name: 'repair-review-gate-ci', kind: 'write' },
+  { name: 'check-pr-status', kind: 'write' },
   { name: 'fix', kind: 'write' },
   { name: 'resolve-conflict', kind: 'write' },
   { name: 'approve', kind: 'write' },

--- a/packages/app/src/headless-usage.ts
+++ b/packages/app/src/headless-usage.ts
@@ -44,6 +44,7 @@ ${BOLD}Execute:${RESET}
   rebase-retry <workflowId|mergeTaskId|taskId>        Refresh pool base, then retry incomplete work
   rebase-recreate <workflowId|mergeTaskId|taskId>     Refresh pool base, then recreate workflow
   repair-review-gate-ci <prNumber|prUrl>              Queue CI repair for one mapped review-gate PR
+  check-pr-status [taskId]                            Force an immediate merge-gate PR-status recheck
   fix <taskId> [claude|codex]                         Fix a failed task (default: claude)
 
 ${BOLD}Respond:${RESET}

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -337,6 +337,9 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
     case 'repair-review-gate-ci':
       await headlessRepairReviewGateCi(args[1], deps);
       break;
+    case 'check-pr-status':
+      await headlessCheckPrStatus(args[1], deps);
+      break;
     case 'fix':
       await headlessFix(args, deps);
       break;
@@ -440,6 +443,47 @@ export function resolveHeadlessInfraRepairConfig(
       ]),
     ),
   };
+}
+
+function getLiveOwnerTaskRunnerForPrStatus(
+  deps: Pick<HeadlessDeps, 'ownerTaskRunnerProvider'>,
+): Pick<TaskRunner, 'checkPrApprovalNow'> {
+  const taskRunner = deps.ownerTaskRunnerProvider?.() ?? null;
+  if (!taskRunner) {
+    throw new Error('check-pr-status requires a live owner TaskRunner.');
+  }
+  return taskRunner;
+}
+
+function isCheckPrStatusCandidate(task: TaskState): boolean {
+  return Boolean(task.config.isMergeNode) && (task.status === 'review_ready' || task.status === 'awaiting_approval');
+}
+
+export async function headlessCheckPrStatus(
+  taskId: string | undefined,
+  deps: Pick<HeadlessDeps, 'commandService' | 'orchestrator' | 'ownerTaskRunnerProvider'>,
+): Promise<void> {
+  const taskRunner = getLiveOwnerTaskRunnerForPrStatus(deps);
+
+  if (taskId) {
+    const task = deps.orchestrator.getTask(taskId);
+    if (!task) throw new Error(`Task not found: ${taskId}`);
+    const result = await deps.commandService.runSerializedForTask(task.id, async () => {
+      await taskRunner.checkPrApprovalNow(task.id);
+    });
+    if (!result.ok) throw new Error(result.error.message);
+    process.stdout.write(`Checked PR status for task: ${task.id}\n`);
+    return;
+  }
+
+  const tasks = deps.orchestrator.getAllTasks().filter(isCheckPrStatusCandidate);
+  const result = await deps.commandService.runSerializedForWorkflow(undefined, async () => {
+    await Promise.all(tasks.map((task) => taskRunner.checkPrApprovalNow(task.id)));
+  });
+  if (!result.ok) throw new Error(result.error.message);
+  for (const task of tasks) {
+    process.stdout.write(`Checked PR status for task: ${task.id}\n`);
+  }
 }
 
 async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void> {

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -209,7 +209,7 @@ export function acknowledgeNoTrackHeadlessExec(
   const command = Array.isArray(payload.args) ? payload.args[0] : undefined;
   // Global commands are not workflow-scoped. Fall through to inline execution
   // instead of requiring a mutation-intent workflow id.
-  if (command === 'start-ready') {
+  if (command === 'start-ready' || command === 'check-pr-status') {
     context.logger.info(
       `headless.exec start-ready noTrack fallthrough ${headlessExecLogFields(payload, mode, Boolean(workflowMutationCoordinator), { workflow: '"<global>"', priority })}`,
       { module: 'ipc-delegate' },
@@ -774,6 +774,9 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
         return;
       },
       executionAgentRegistry: registerBuiltinAgents(),
+      ownerTaskRunnerProvider: headlessCommand === 'check-pr-status'
+        ? () => requireTaskExecutor()
+        : undefined,
     });
     const { workflowId } = classifyHeadlessExecMutation(payload);
     logger.info(`executeHeadlessExec end args="${payload.args.join(' ')}" workflow="${workflowId ?? 'unknown'}"`, {
@@ -880,6 +883,8 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
       case 'fix':
       case 'resolve-conflict':
         return { workflowId: workflowIdForTaskArg(arg0), priority: 'normal' };
+      case 'check-pr-status':
+        return { workflowId: arg0 === undefined ? undefined : workflowIdForTaskArg(arg0), priority: 'normal' };
       default:
         return { priority: 'normal' };
     }


### PR DESCRIPTION
## Summary

Add a headless `check-pr-status` command for merge-gate PR status checks.

The command delegates to the live owner process, so operators can force an immediate check without restarting the owner.

This avoids racing the periodic PR-status worker's exclusive lock.

The new path supports one task id or all pending merge-gate tasks.

## Review Claim

`--headless check-pr-status [taskId]` reaches the same live in-memory TaskRunner path as the GUI check action instead of creating a second standalone worker.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The periodic PR-status worker, merge-gate polling logic, and existing headless commands keep their current behavior; this slice only adds one delegated command surface.

## Slice Rationale

This slice contains the new command, command registration and usage text, the shared GUI mutation helper adjustment it reuses, and directly affected tests.

The proof-only workflow task produced no file diff, so its verification result is folded into this PR's test plan instead of publishing an empty stack slice.

## Non-goals

No change to the PR-status worker polling cadence or lock semantics.

No change to `checkMergeGateStatuses`, `pollMergeGateTask`, or stale-write guard behavior.

No GUI changes and no new persisted fields.

## Architecture

### Before

```mermaid
graph TD
    A["--headless worker pr-status"] --> B["standalone TaskRunner"]
    B --> C["worker-pr-status.lock"]
    D["GUI check PR status action"] --> E["live owner TaskRunner"]
```

### After

```mermaid
graph TD
    A["--headless worker pr-status"] --> B["standalone TaskRunner"]
    B --> C["worker-pr-status.lock"]
    D["GUI check PR status action"] --> E["live owner TaskRunner"]
    F["--headless check-pr-status [taskId]"] --> E
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `cd packages/app && pnpm test -- headless`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/add-headless-cli-command-pr.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>