### PR TITLE
[Add-machine onboarding](5) deterministic test fixture

### DIFF
--- a/packages/app/e2e/fixtures/machine-connectivity-stub.ts
+++ b/packages/app/e2e/fixtures/machine-connectivity-stub.ts
@@ -1,0 +1,14 @@
+import {
+  REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR,
+  type RemoteTargetConnectivityResult,
+} from '@invoker/contracts';
+
+export function stubMachineConnectivity(host: string, outcome: RemoteTargetConnectivityResult): void {
+  const raw = process.env[REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR];
+  const scripted = raw ? JSON.parse(raw) : {};
+  process.env[REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR] = JSON.stringify({ ...scripted, [host]: outcome });
+}
+
+export function clearMachineConnectivityStub(): void {
+  delete process.env[REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR];
+}

--- a/packages/contracts/src/__tests__/remote-target-onboarding.test.ts
+++ b/packages/contracts/src/__tests__/remote-target-onboarding.test.ts
@@ -1,11 +1,26 @@
-import { describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+import { spawn } from 'node:child_process';
 
 import {
   addRemoteTarget,
   buildConnectivityProbeArgs,
   checkRemoteTargetConnectivity,
+  REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR,
   type RemoteTargetInput,
 } from '../remote-target-onboarding.js';
+
+function createMockChildProcess() {
+  const proc = new EventEmitter() as EventEmitter & { stderr: EventEmitter };
+  proc.stderr = new EventEmitter();
+  return proc;
+}
 
 const baseInput: RemoteTargetInput = {
   name: 'build-server-c',
@@ -137,6 +152,45 @@ describe('checkRemoteTargetConnectivity', () => {
     sshKeyPath: '/home/user/.ssh/id_build_c',
     port: 2222,
   };
+
+  afterEach(() => {
+    delete process.env[REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR];
+    vi.mocked(spawn).mockReset();
+  });
+
+  it('runs the real ssh probe when the stub env var is unset', async () => {
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc as never);
+
+    const resultPromise = checkRemoteTargetConnectivity(target);
+    proc.emit('close', 0);
+    const result = await resultPromise;
+
+    expect(spawn).toHaveBeenCalledWith('ssh', buildConnectivityProbeArgs(target), expect.any(Object));
+    expect(result).toEqual({ reachable: true, message: `ssh probe to ${target.user}@${target.host} succeeded` });
+  });
+
+  it('returns the scripted outcome for the host when the stub env var is set', async () => {
+    process.env[REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR] = JSON.stringify({
+      [target.host]: { reachable: true, message: 'scripted ok' },
+    });
+
+    const result = await checkRemoteTargetConnectivity(target);
+
+    expect(result).toEqual({ reachable: true, message: 'scripted ok' });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('returns a scripted failure instead of falling back to the real probe when the host has no entry', async () => {
+    process.env[REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR] = JSON.stringify({
+      'some-other-host': { reachable: true, message: 'scripted ok' },
+    });
+
+    const result = await checkRemoteTargetConnectivity(target);
+
+    expect(result.reachable).toBe(false);
+    expect(spawn).not.toHaveBeenCalled();
+  });
 
   it('uses the injected impl instead of running a real SSH probe', async () => {
     const impl = vi.fn().mockResolvedValue({ reachable: true, message: 'stubbed ok' });

--- a/packages/contracts/src/remote-target-onboarding.ts
+++ b/packages/contracts/src/remote-target-onboarding.ts
@@ -103,6 +103,31 @@ export interface CheckRemoteTargetConnectivityOptions {
 
 const DEFAULT_PROBE_CONNECT_TIMEOUT_SECONDS = 10;
 
+export const REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR = 'INVOKER_TEST_REMOTE_TARGET_STUB';
+
+function readScriptedConnectivityOutcome(host: string): RemoteTargetConnectivityResult | undefined {
+  const raw = process.env[REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR];
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  let scripted: unknown;
+  try {
+    scripted = JSON.parse(raw);
+  } catch (error) {
+    return {
+      reachable: false,
+      message: `failed to parse ${REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR}: ${(error as Error).message}`,
+    };
+  }
+
+  if (!isRecord(scripted) || !Object.prototype.hasOwnProperty.call(scripted, host)) {
+    return { reachable: false, message: `no scripted connectivity outcome for host "${host}"` };
+  }
+
+  return scripted[host] as RemoteTargetConnectivityResult;
+}
+
 export function buildConnectivityProbeArgs(
   target: RemoteTargetConnection,
   connectTimeoutSeconds: number = DEFAULT_PROBE_CONNECT_TIMEOUT_SECONDS,
@@ -124,6 +149,11 @@ export async function checkRemoteTargetConnectivity(
 ): Promise<RemoteTargetConnectivityResult> {
   if (typeof opts.impl === 'function') {
     return opts.impl(target);
+  }
+
+  const scripted = readScriptedConnectivityOutcome(target.host);
+  if (scripted !== undefined) {
+    return scripted;
   }
 
   return new Promise((resolve) => {

--- a/packages/ui/src/__tests__/system-setup-modal-machines.test.tsx
+++ b/packages/ui/src/__tests__/system-setup-modal-machines.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Component test: "Add remote machines" step of the SystemSetupModal.
+ *
+ * Mirrors the existing Slack step's guided per-field form, but each machine
+ * is checked and added immediately via onAddMachine instead of being batched
+ * into the combined onRunSetup request.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { SystemDiagnostics } from '@invoker/contracts';
+
+import { SystemSetupModal } from '../components/SystemSetupModal.js';
+
+function makeDiagnostics(): SystemDiagnostics {
+  return {
+    platform: 'darwin',
+    arch: 'arm64',
+    appVersion: '0.0.3',
+    isPackaged: true,
+    tools: [],
+  };
+}
+
+function fillRequiredMachineFields(host: string, user: string, sshKeyPath: string): void {
+  fireEvent.change(screen.getByLabelText('Host'), { target: { value: host } });
+  fireEvent.change(screen.getByLabelText('User'), { target: { value: user } });
+  fireEvent.change(screen.getByLabelText(/SSH key path/), { target: { value: sshKeyPath } });
+}
+
+describe('SystemSetupModal — Add remote machines step', () => {
+  it('adds a machine to the list on a successful check', async () => {
+    const onAddMachine = vi.fn().mockResolvedValue({ ok: true, message: 'Reachable' });
+    render(
+      <SystemSetupModal
+        diagnostics={makeDiagnostics()}
+        onAddMachine={onAddMachine}
+        onClose={() => {}}
+      />,
+    );
+
+    fillRequiredMachineFields('10.0.0.5', 'deploy', '~/.ssh/id_ed25519');
+    fireEvent.click(screen.getByRole('button', { name: 'Check and add machine' }));
+
+    await screen.findByText('deploy@10.0.0.5');
+    expect(onAddMachine).toHaveBeenCalledWith({
+      host: '10.0.0.5',
+      user: 'deploy',
+      sshKeyPath: '~/.ssh/id_ed25519',
+    });
+    expect(screen.getByText('Reachable')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Host')).not.toBeInTheDocument();
+  });
+
+  it('leaves the list unchanged and keeps the form on a failing check', async () => {
+    const onAddMachine = vi.fn().mockResolvedValue({ ok: false, message: 'SSH auth failed' });
+    render(
+      <SystemSetupModal
+        diagnostics={makeDiagnostics()}
+        onAddMachine={onAddMachine}
+        onClose={() => {}}
+      />,
+    );
+
+    fillRequiredMachineFields('10.0.0.5', 'deploy', '~/.ssh/id_ed25519');
+    fireEvent.click(screen.getByRole('button', { name: 'Check and add machine' }));
+
+    await screen.findByText('SSH auth failed');
+    expect(screen.queryByText('deploy@10.0.0.5')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Host')).toHaveValue('10.0.0.5');
+    expect(screen.getByLabelText('User')).toHaveValue('deploy');
+    expect(screen.getByLabelText(/SSH key path/)).toHaveValue('~/.ssh/id_ed25519');
+  });
+
+  it('adds only one entry when the submit button is double-clicked with the same fields', async () => {
+    const onAddMachine = vi.fn().mockResolvedValue({ ok: true });
+    render(
+      <SystemSetupModal
+        diagnostics={makeDiagnostics()}
+        onAddMachine={onAddMachine}
+        onClose={() => {}}
+      />,
+    );
+
+    fillRequiredMachineFields('10.0.0.5', 'deploy', '~/.ssh/id_ed25519');
+    const submitButton = screen.getByRole('button', { name: 'Check and add machine' });
+    fireEvent.click(submitButton);
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(onAddMachine).toHaveBeenCalledTimes(1));
+    await screen.findByText('deploy@10.0.0.5');
+    expect(screen.getAllByText('deploy@10.0.0.5')).toHaveLength(1);
+  });
+
+  it('confirms before closing the modal while the machine form has unconfirmed values', () => {
+    const onClose = vi.fn();
+    render(
+      <SystemSetupModal
+        diagnostics={makeDiagnostics()}
+        onAddMachine={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Host'), { target: { value: '10.0.0.5' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText('Discard machine details?')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Keep editing' }));
+    expect(screen.queryByText('Discard machine details?')).not.toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Discard and close' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/SystemSetupModal.tsx
+++ b/packages/ui/src/components/SystemSetupModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import type {
   InvokerSetupRequest,
   InvokerSetupResult,
@@ -50,6 +50,7 @@ interface SystemSetupModalProps {
   onRunSetup?: (request: InvokerSetupRequest) => void;
   updateCliError?: string | null;
   onUpdateInvokerCli?: () => void;
+  onAddMachine?: (fields: MachineSetupFields) => Promise<MachineCheckOutcome>;
   onClose: () => void;
 }
 
@@ -63,6 +64,57 @@ const setupStepLabels: Record<'choose' | 'review' | 'finish', string> = {
 type SlackFieldId = 'botToken' | 'appToken' | 'signingSecret' | 'channelId';
 
 const firstAgentWorkflowTutorialUrl = 'https://github.com/Neko-Catpital-Labs/Invoker/blob/main/docs/tutorial-first-agent-workflow.md';
+
+type MachineFieldId = 'host' | 'user' | 'sshKeyPath' | 'port' | 'maxConcurrentTasks' | 'provisionCommand';
+
+export interface MachineSetupFields {
+  host: string;
+  user: string;
+  sshKeyPath: string;
+  port?: number;
+  maxConcurrentTasks?: number;
+  provisionCommand?: string;
+}
+
+export interface MachineCheckOutcome {
+  ok: boolean;
+  message?: string;
+}
+
+interface AddedMachine {
+  fields: MachineSetupFields;
+  message?: string;
+}
+
+const machineSetupFields: Array<{ id: MachineFieldId; label: string; placeholder: string; required: boolean }> = [
+  { id: 'host', label: 'Host', placeholder: 'e.g. 10.0.0.5 or box.example.com', required: true },
+  { id: 'user', label: 'User', placeholder: 'e.g. ubuntu', required: true },
+  { id: 'sshKeyPath', label: 'SSH key path', placeholder: '~/.ssh/id_ed25519', required: true },
+  { id: 'port', label: 'Port', placeholder: '22', required: false },
+  { id: 'maxConcurrentTasks', label: 'Max concurrent tasks', placeholder: '1', required: false },
+  { id: 'provisionCommand', label: 'Provision command', placeholder: 'optional', required: false },
+];
+
+const emptyMachineFormFields: Record<MachineFieldId, string> = {
+  host: '',
+  user: '',
+  sshKeyPath: '',
+  port: '',
+  maxConcurrentTasks: '',
+  provisionCommand: '',
+};
+
+function buildMachineSetupFields(raw: Record<MachineFieldId, string>): MachineSetupFields {
+  const fields: MachineSetupFields = {
+    host: raw.host.trim(),
+    user: raw.user.trim(),
+    sshKeyPath: raw.sshKeyPath.trim(),
+  };
+  if (raw.port.trim() !== '') fields.port = Number(raw.port);
+  if (raw.maxConcurrentTasks.trim() !== '') fields.maxConcurrentTasks = Number(raw.maxConcurrentTasks);
+  if (raw.provisionCommand.trim() !== '') fields.provisionCommand = raw.provisionCommand.trim();
+  return fields;
+}
 
 const slackSetupFields: Array<{
   id: SlackFieldId;
@@ -118,6 +170,7 @@ export function SystemSetupModal({
   updateCliError = null,
   onRunSetup,
   onUpdateInvokerCli,
+  onAddMachine,
   onClose,
 }: SystemSetupModalProps) {
   const [setupChecks, setSetupChecks] = useState<Record<SetupCheckId, boolean>>({
@@ -134,6 +187,48 @@ export function SystemSetupModal({
   });
   const [reviewOpen, setReviewOpen] = useState(false);
   const [systemDetailsOpen, setSystemDetailsOpen] = useState(false);
+  const [machineFormFields, setMachineFormFields] = useState<Record<MachineFieldId, string>>(emptyMachineFormFields);
+  const [machineFormOpen, setMachineFormOpen] = useState(true);
+  const [machineCheckPending, setMachineCheckPending] = useState(false);
+  const [machineCheckError, setMachineCheckError] = useState<string | null>(null);
+  const [addedMachines, setAddedMachines] = useState<AddedMachine[]>([]);
+  const [machinesStepDone, setMachinesStepDone] = useState(false);
+  const [machineCloseConfirmOpen, setMachineCloseConfirmOpen] = useState(false);
+  const machineSubmitInFlightRef = useRef(false);
+  const machineRequiredFieldsComplete = machineSetupFields
+    .filter((field) => field.required)
+    .every((field) => machineFormFields[field.id].trim() !== '');
+  const machineFormHasValues = machineSetupFields.some((field) => machineFormFields[field.id].trim() !== '');
+  const hasUnconfirmedMachineFields = machineFormOpen && machineFormHasValues;
+  const submitMachineForm = async (): Promise<void> => {
+    if (!onAddMachine || machineSubmitInFlightRef.current || !machineRequiredFieldsComplete) return;
+    machineSubmitInFlightRef.current = true;
+    setMachineCheckPending(true);
+    setMachineCheckError(null);
+    const fields = buildMachineSetupFields(machineFormFields);
+    try {
+      const outcome = await onAddMachine(fields);
+      if (outcome.ok) {
+        setAddedMachines((prev) => [...prev, { fields, message: outcome.message }]);
+        setMachineFormFields(emptyMachineFormFields);
+        setMachineFormOpen(false);
+      } else {
+        setMachineCheckError(outcome.message ?? 'Could not add this machine.');
+      }
+    } catch (err) {
+      setMachineCheckError(err instanceof Error ? err.message : String(err));
+    } finally {
+      machineSubmitInFlightRef.current = false;
+      setMachineCheckPending(false);
+    }
+  };
+  const requestCloseModal = (): void => {
+    if (hasUnconfirmedMachineFields) {
+      setMachineCloseConfirmOpen(true);
+      return;
+    }
+    onClose();
+  };
   const anySetupSelected = setupChecks.updateCli || setupChecks.installHelpers || setupChecks.fixTools || setupChecks.slack;
   const slackFieldsComplete = slackSetupFields.every((field) => slackFields[field.id] !== '');
   const firstMissingSlackField = setupChecks.slack
@@ -228,7 +323,7 @@ export function SystemSetupModal({
 
 
   return (
-    <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
+    <Dialog open onOpenChange={(open) => { if (!open) requestCloseModal(); }}>
       <DialogContent className="max-w-3xl max-h-[90vh] flex flex-col gap-0 p-0 overflow-hidden" hideCloseButton>
         <DialogHeader className="p-6 pb-3 shrink-0">
           <DialogTitle>System Setup</DialogTitle>
@@ -382,6 +477,103 @@ export function SystemSetupModal({
                         {step.output && <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap text-xs text-foreground">{step.output}</pre>}
                       </div>
                     ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {onAddMachine && (
+            <div className="rounded border border-border-strong/60 bg-secondary/70 px-4 py-4 space-y-4">
+              <div>
+                <div className="text-sm font-medium text-foreground">Add remote machines</div>
+                <div className="text-sm text-muted-foreground/80 mt-1">
+                  Add machines Invoker can run tasks on over SSH. Each machine is checked before it&apos;s added.
+                </div>
+              </div>
+
+              {addedMachines.length > 0 && (
+                <div className="rounded border border-border-strong/70 bg-card/40 divide-y divide-border">
+                  {addedMachines.map((machine, index) => (
+                    <div key={`${machine.fields.host}-${index}`} className="px-3 py-2 text-sm text-foreground">
+                      <span className="font-medium">{machine.fields.user}@{machine.fields.host}</span>
+                      {machine.message && <span className="ml-2 text-xs text-muted-foreground">{machine.message}</span>}
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {machineFormOpen && (
+                <div className="space-y-3">
+                  {machineSetupFields.map((field) => (
+                    <label key={field.id} className="block text-xs text-foreground">
+                      {field.label} {!field.required && <span className="text-muted-foreground/70">(optional)</span>}
+                      <input
+                        value={machineFormFields[field.id]}
+                        onChange={(event) => {
+                          const { value } = event.target;
+                          setMachineFormFields((prev) => ({ ...prev, [field.id]: value }));
+                          setMachineCheckError(null);
+                        }}
+                        type={field.id === 'port' || field.id === 'maxConcurrentTasks' ? 'number' : 'text'}
+                        placeholder={field.placeholder}
+                        className="mt-1 w-full rounded border border-border-strong bg-card px-2 py-1.5 text-sm text-foreground"
+                      />
+                    </label>
+                  ))}
+
+                  {machineCheckError && (
+                    <div className="rounded border border-red-700/50 bg-red-950/30 px-3 py-2 text-sm text-red-200">
+                      {machineCheckError}
+                    </div>
+                  )}
+
+                  <button
+                    onClick={submitMachineForm}
+                    disabled={machineCheckPending || !machineRequiredFieldsComplete}
+                    className="px-4 py-2 bg-primary hover:bg-primary/90 disabled:bg-secondary disabled:text-muted-foreground text-white rounded text-sm font-medium transition-colors"
+                  >
+                    {machineCheckPending ? 'Checking machine…' : 'Check and add machine'}
+                  </button>
+                </div>
+              )}
+
+              {!machineFormOpen && !machinesStepDone && (
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    onClick={() => setMachineFormOpen(true)}
+                    className="px-3 py-2 bg-muted hover:bg-accent text-white rounded text-sm transition-colors"
+                  >
+                    Add another machine
+                  </button>
+                  <button
+                    onClick={() => setMachinesStepDone(true)}
+                    className="px-3 py-2 bg-primary hover:bg-primary/90 text-white rounded text-sm font-medium transition-colors"
+                  >
+                    Done adding machines
+                  </button>
+                </div>
+              )}
+
+              {machineCloseConfirmOpen && (
+                <div className="rounded border border-amber-600/50 bg-amber-950/40 px-3 py-3 text-sm text-amber-100">
+                  <div className="font-medium">Discard machine details?</div>
+                  <div className="mt-1 text-amber-100/90">
+                    You entered machine fields that haven&apos;t been added yet. Closing now will discard them.
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <button
+                      onClick={onClose}
+                      className="px-3 py-2 bg-red-700 hover:bg-red-600 text-white rounded text-sm font-medium transition-colors"
+                    >
+                      Discard and close
+                    </button>
+                    <button
+                      onClick={() => setMachineCloseConfirmOpen(false)}
+                      className="px-3 py-2 bg-muted hover:bg-accent text-white rounded text-sm transition-colors"
+                    >
+                      Keep editing
+                    </button>
                   </div>
                 </div>
               )}
@@ -665,7 +857,7 @@ export function SystemSetupModal({
         </div>
 
         <DialogFooter className="px-6 py-4 border-t border-border sm:justify-end">
-          <Button type="button" onClick={onClose}>
+          <Button type="button" onClick={requestCloseModal}>
             Close
           </Button>
         </DialogFooter>


### PR DESCRIPTION
## Summary

Adds a test-only switch to the connectivity check from onboarding slice (1) so automated tests can force a scripted success or failure outcome for a given host.

Tests no longer need to reach a real machine. A real user's setup run is unaffected; it always uses the existing real probe.

A small helper file is also added for the upcoming e2e specs (later workflows) to import and set that switch before driving a scenario.

## Review Claim

Adds one test-only switch that makes `checkRemoteTargetConnectivity()` return a scripted outcome instead of reaching a real host, active only under an explicit environment variable, plus a helper file for future e2e specs to set that switch.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The scripted-outcome path only ever runs when a dedicated test-only environment variable (`INVOKER_TEST_REMOTE_TARGET_STUB`) is set; it is never read or set by any file under `packages/cli` or `packages/ui`, so a real user's setup run can never trigger a false "reachable" outcome.

## Slice Rationale

This slice only touches the domain module's own switch and its focused proof; the e2e specs that will use this switch are separate, later workflows.

## Non-goals

No CLI or GUI wiring in this task, and no changes to the setup-wizard or app-bridge workflows already merged in slices (2)-(4) — this task only adds the switch and its own proof.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/contracts && pnpm test`
- [x] `! grep -rq "INVOKER_TEST_REMOTE_TARGET_STUB" packages/cli/src packages/ui/src`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
