### PR TITLE
[Add-machine onboarding](8) docs

### DIFF
--- a/docs/remote-ssh-targets.md
+++ b/docs/remote-ssh-targets.md
@@ -8,7 +8,34 @@ The SSH executor (`runnerKind: ssh`) runs task commands on remote hosts over SSH
 
 Each remote target is defined in the Invoker config with a host, user, and path to an SSH private key. Tasks reference targets by ID.
 
-## Configuration
+## Guided Setup: the Machines Wizard
+
+The easiest way to add a remote target is the setup wizard, rather than hand-editing config JSON:
+
+```bash
+invoker-cli setup machines
+```
+
+It asks for, in order: machine name, host, user, SSH key path, SSH port (default `22`), max
+concurrent tasks (default `1`), and an optional provision command. Before saving anything, it
+runs a real SSH connectivity probe (`ssh ... 'exit 0'` with `BatchMode=yes` and a 10s connect
+timeout) against the machine and reports "Connectivity check passed" or "Connectivity check
+failed" — a machine is only written to `~/.invoker/config.json` if that probe succeeds. It also
+rejects a name or host that duplicates an existing target. After each machine, it asks whether
+to add another, so you can add several in one run.
+
+For scripting, `invoker-cli setup machines --json` reads a JSON array of machine objects from
+stdin and writes a JSON array of per-machine results (including the connectivity outcome) to
+stdout, instead of prompting interactively.
+
+The desktop app has a matching step: the System Setup panel's "Add remote machines" section asks
+for the same fields and performs the same reachability check (via the same CLI) before adding
+the machine to your list, with its button reading "Checking machine…" while the probe runs.
+
+If you'd rather manage `~/.invoker/config.json` yourself, see **Manual Configuration (Fallback)**
+below.
+
+## Manual Configuration (Fallback)
 
 Add remote targets to `~/.invoker/config.json`.
 

--- a/packages/app/e2e/fixtures/machine-connectivity-stub.ts
+++ b/packages/app/e2e/fixtures/machine-connectivity-stub.ts
@@ -1,0 +1,14 @@
+import {
+  REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR,
+  type RemoteTargetConnectivityResult,
+} from '@invoker/contracts';
+
+export function stubMachineConnectivity(host: string, outcome: RemoteTargetConnectivityResult): void {
+  const raw = process.env[REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR];
+  const scripted = raw ? JSON.parse(raw) : {};
+  process.env[REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR] = JSON.stringify({ ...scripted, [host]: outcome });
+}
+
+export function clearMachineConnectivityStub(): void {
+  delete process.env[REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR];
+}

--- a/packages/app/e2e/fixtures/slack-fetch-stub-preload.cjs
+++ b/packages/app/e2e/fixtures/slack-fetch-stub-preload.cjs
@@ -1,0 +1,38 @@
+'use strict';
+
+/**
+ * Node `--require` preload: monkeypatches the global `fetch` so the CLI's
+ * `validateSlackCredentials()` (packages/cli/src/onboarding.ts), which calls
+ * the real global `fetch` against slack.com, resolves deterministically
+ * instead of hitting the network. Only active when
+ * INVOKER_TEST_SLACK_FETCH_STUB is set (e2e-only, never referenced by
+ * product code).
+ */
+
+const raw = process.env.INVOKER_TEST_SLACK_FETCH_STUB;
+
+if (raw) {
+  const stub = JSON.parse(raw);
+  const realFetch = globalThis.fetch;
+
+  const jsonResponse = (body) => ({
+    json: async () => body,
+    headers: {
+      get: (name) => (name.toLowerCase() === 'x-oauth-scopes' ? (body.scopes ?? null) : null),
+    },
+  });
+
+  globalThis.fetch = async (url, init) => {
+    const href = String(url);
+    if (href.startsWith('https://slack.com/api/auth.test')) {
+      return jsonResponse(stub.authTest ?? { ok: false, error: 'invalid_auth' });
+    }
+    if (href.startsWith('https://slack.com/api/apps.connections.open')) {
+      return jsonResponse(stub.connectionsOpen ?? { ok: false, error: 'invalid_auth' });
+    }
+    if (href.startsWith('https://slack.com/api/conversations.info')) {
+      return jsonResponse(stub.conversationsInfo ?? { ok: false, error: 'invalid_auth' });
+    }
+    return realFetch(url, init);
+  };
+}

--- a/packages/app/e2e/fixtures/slack-fetch-stub.ts
+++ b/packages/app/e2e/fixtures/slack-fetch-stub.ts
@@ -1,0 +1,34 @@
+import * as path from 'node:path';
+
+export const SLACK_FETCH_STUB_ENV_VAR = 'INVOKER_TEST_SLACK_FETCH_STUB';
+
+export const SLACK_FETCH_STUB_PRELOAD_PATH = path.resolve(__dirname, 'slack-fetch-stub-preload.cjs');
+
+/** Mirrors REQUIRED_BOT_SCOPES in packages/cli/src/onboarding.ts (not importable: the CLI package has no library entry point). */
+const REQUIRED_BOT_SCOPES = [
+  'app_mentions:read',
+  'chat:write',
+  'files:write',
+  'pins:write',
+  'channels:history',
+  'channels:read',
+  'groups:write',
+  'groups:history',
+  'users:read',
+];
+
+export function slackFetchStubSuccessJson(): string {
+  return JSON.stringify({
+    authTest: { ok: true, user: 'invoker-bot', team: 'Invoker E2E', scopes: REQUIRED_BOT_SCOPES.join(',') },
+    connectionsOpen: { ok: true },
+    conversationsInfo: { ok: true, channel: { name: 'lobby' } },
+  });
+}
+
+export function slackFetchStubBadTokenJson(): string {
+  return JSON.stringify({
+    authTest: { ok: false, error: 'invalid_auth' },
+    connectionsOpen: { ok: false, error: 'invalid_auth' },
+    conversationsInfo: { ok: false, error: 'invalid_auth' },
+  });
+}

--- a/packages/app/e2e/onboarding-cli-visual-proof.spec.ts
+++ b/packages/app/e2e/onboarding-cli-visual-proof.spec.ts
@@ -1,0 +1,206 @@
+/**
+ * E2E: CLI onboarding visual proof.
+ *
+ * Drives the app's embedded terminal (the Planning "Tmux" pane, backed by
+ * node-pty -- see InvokerTerminal.tsx / TerminalDrawer.tsx) to run the real
+ * `invoker-cli setup` wizard (packages/cli/src/onboarding.ts) and captures a
+ * named screenshot at each onboarding scenario. Remote-machine connectivity
+ * is forced deterministically via INVOKER_TEST_REMOTE_TARGET_STUB (see
+ * packages/contracts/src/remote-target-onboarding.ts); Slack credential
+ * validation is forced deterministically via a `--require` fetch stub (see
+ * fixtures/slack-fetch-stub-preload.cjs) so nothing here needs a real remote
+ * host, real Slack app, or network access.
+ *
+ * Only runs when CAPTURE_MODE is set (see fixtures/electron-app.ts
+ * captureScreenshot) -- driven by scripts/ui-visual-proof.sh capture-after.
+ */
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { resolveRepoRoot, REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR } from '@invoker/contracts';
+import type { Page } from '@playwright/test';
+import { test, expect, captureScreenshot } from './fixtures/electron-app.js';
+import {
+  SLACK_FETCH_STUB_ENV_VAR,
+  SLACK_FETCH_STUB_PRELOAD_PATH,
+  slackFetchStubBadTokenJson,
+  slackFetchStubSuccessJson,
+} from './fixtures/slack-fetch-stub.js';
+
+const repoRoot = resolveRepoRoot(__dirname);
+const cliEntry = path.join(repoRoot, 'packages', 'cli', 'dist', 'index.js');
+
+test.beforeAll(() => {
+  if (!fs.existsSync(cliEntry)) {
+    execFileSync('pnpm', ['--filter', '@invoker/cli', 'run', 'build'], { cwd: repoRoot, stdio: 'inherit' });
+  }
+});
+
+async function openHome(page: Page): Promise<void> {
+  await page.getByTestId('sidebar-home').click();
+  await expect(page.getByTestId('invoker-terminal-input')).toBeVisible({ timeout: 10000 });
+}
+
+async function readOutputSnapshot(page: Page, sessionId: string): Promise<string> {
+  return page.evaluate(async (targetSessionId) => {
+    const sessions = await window.invoker.planningTerminalList();
+    return sessions.find((session) => session.sessionId === targetSessionId)?.outputSnapshot ?? '';
+  }, sessionId);
+}
+
+async function openPlanningTmux(page: Page): Promise<string> {
+  await page.getByTestId('invoker-terminal-mode-toggle').getByRole('tab', { name: 'Tmux' }).click();
+  const pane = page.getByTestId('invoker-terminal-tmux-pane');
+  await expect(pane).toBeVisible({ timeout: 10000 });
+  const sessionId = await pane.getAttribute('data-session-id');
+  expect(sessionId).toBeTruthy();
+  await expect
+    .poll(async () => readOutputSnapshot(page, sessionId ?? ''), { timeout: 10000 })
+    .toContain('Invoker planning tmux bridge');
+  return sessionId ?? '';
+}
+
+async function writeToTmux(page: Page, sessionId: string, data: string): Promise<void> {
+  const result = await page.evaluate(async ({ targetSessionId, payload }) => {
+    return window.invoker.planningTerminalWrite(targetSessionId, payload);
+  }, { targetSessionId: sessionId, payload: data });
+  expect(result).toMatchObject({ ok: true });
+}
+
+async function waitForTerminalText(page: Page, sessionId: string, substring: string, timeoutMs = 30000): Promise<void> {
+  await expect.poll(async () => readOutputSnapshot(page, sessionId), { timeout: timeoutMs }).toContain(substring);
+}
+
+async function waitForTerminalMatch(page: Page, sessionId: string, pattern: RegExp, timeoutMs = 30000): Promise<void> {
+  await expect.poll(async () => readOutputSnapshot(page, sessionId), { timeout: timeoutMs }).toMatch(pattern);
+}
+
+interface MachineAnswers {
+  name: string;
+  host: string;
+  user: string;
+  sshKeyPath: string;
+}
+
+/** The 7 sequential prompts of askRemoteTargetInput(); port/max/provision left blank (defaults). */
+function machineAnswers(input: MachineAnswers): string {
+  return `${[input.name, input.host, input.user, input.sshKeyPath, '', '', ''].join('\n')}\n`;
+}
+
+test.describe('CLI onboarding visual proof', () => {
+  test('captures every named onboarding-cli scenario', async ({ page }) => {
+    test.setTimeout(240_000);
+
+    await openHome(page);
+    const sessionId = await openPlanningTmux(page);
+
+    // ── Machines: happy path (empty -> checking -> success -> loop -> final state) ──
+    const happyPathStub = JSON.stringify({
+      'alpha.e2e.test': { reachable: true, message: 'ssh probe to deploy@alpha.e2e.test succeeded' },
+      'beta.e2e.test': { reachable: true, message: 'ssh probe to deploy@beta.e2e.test succeeded' },
+    });
+    await writeToTmux(
+      page,
+      sessionId,
+      `${REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR}='${happyPathStub}' node ${cliEntry} setup machines\n`,
+    );
+    await waitForTerminalText(page, sessionId, 'Machine name:');
+    await captureScreenshot(page, 'cli-machine-empty');
+
+    await writeToTmux(page, sessionId, machineAnswers({
+      name: 'alpha-machine',
+      host: 'alpha.e2e.test',
+      user: 'deploy',
+      sshKeyPath: '/home/deploy/.ssh/id_alpha',
+    }));
+    await page.waitForTimeout(150);
+    await captureScreenshot(page, 'cli-machine-checking');
+
+    await waitForTerminalText(page, sessionId, 'Connectivity check passed: ssh probe to deploy@alpha.e2e.test succeeded');
+    await captureScreenshot(page, 'cli-machine-success');
+
+    // Keep alpha-machine, add another, then fill in beta-machine and keep it too.
+    await writeToTmux(
+      page,
+      sessionId,
+      `y\ny\n${machineAnswers({
+        name: 'beta-machine',
+        host: 'beta.e2e.test',
+        user: 'deploy',
+        sshKeyPath: '/home/deploy/.ssh/id_beta',
+      })}y\n`,
+    );
+    await waitForTerminalText(page, sessionId, 'Wrote machine "beta-machine"');
+    await captureScreenshot(page, 'cli-machine-loop-second-added');
+
+    await writeToTmux(page, sessionId, 'n\n');
+    await waitForTerminalMatch(page, sessionId, /You're ready\.|Fix this first:/);
+    await captureScreenshot(page, 'cli-machine-final-state');
+
+    // ── Machines: connectivity failure ──
+    const failureStub = JSON.stringify({
+      'down.e2e.test': { reachable: false, message: 'ssh: connect to host down.e2e.test port 22: Connection refused' },
+    });
+    await writeToTmux(
+      page,
+      sessionId,
+      `${REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR}='${failureStub}' node ${cliEntry} setup machines\n${machineAnswers({
+        name: 'down-machine',
+        host: 'down.e2e.test',
+        user: 'deploy',
+        sshKeyPath: '/home/deploy/.ssh/id_down',
+      })}`,
+    );
+    await waitForTerminalText(page, sessionId, 'Connectivity check failed: ssh: connect to host down.e2e.test port 22: Connection refused');
+    await captureScreenshot(page, 'cli-machine-failure');
+    await writeToTmux(page, sessionId, 'n\nn\n');
+
+    // ── Machines: duplicate host ──
+    const duplicateHostStub = JSON.stringify({
+      'dup.e2e.test': { reachable: true, message: 'ssh probe to deploy@dup.e2e.test succeeded' },
+    });
+    await writeToTmux(
+      page,
+      sessionId,
+      `${REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR}='${duplicateHostStub}' node ${cliEntry} setup machines\n`
+      + machineAnswers({ name: 'dup-a', host: 'dup.e2e.test', user: 'deploy', sshKeyPath: '/home/deploy/.ssh/id_dup_a' })
+      + 'y\ny\n'
+      + machineAnswers({ name: 'dup-b', host: 'dup.e2e.test', user: 'deploy', sshKeyPath: '/home/deploy/.ssh/id_dup_b' })
+      + 'y\n',
+    );
+    await waitForTerminalText(page, sessionId, 'Nothing written: host "dup.e2e.test" is already configured as remote target "dup-a"');
+    await captureScreenshot(page, 'cli-machine-duplicate-host');
+    await writeToTmux(page, sessionId, 'n\n');
+
+    // ── Slack: decline, then review + finish (bare `setup`, no subcommand) ──
+    await writeToTmux(page, sessionId, `node ${cliEntry} setup\nn\nn\nn\n`);
+    await waitForTerminalText(page, sessionId, 'Set up remote machines now?');
+    await captureScreenshot(page, 'cli-slack-decline');
+    await waitForTerminalText(page, sessionId, 'smoke: plan validation');
+    await captureScreenshot(page, 'cli-review');
+    await waitForTerminalMatch(page, sessionId, /You're ready\.|Fix this first:/);
+    await captureScreenshot(page, 'cli-finish');
+
+    // ── Slack: bad token (offline fetch stub) ──
+    await writeToTmux(
+      page,
+      sessionId,
+      `NODE_OPTIONS="--require ${SLACK_FETCH_STUB_PRELOAD_PATH}" ${SLACK_FETCH_STUB_ENV_VAR}='${slackFetchStubBadTokenJson()}' `
+      + `node ${cliEntry} setup slack\nxoxb-bad-token\nxapp-bad-token\nbad-signing-secret\nC0BADTOKEN\n`,
+    );
+    await waitForTerminalText(page, sessionId, 'auth.test failed: invalid_auth');
+    await captureScreenshot(page, 'cli-slack-bad-token');
+    await writeToTmux(page, sessionId, 'n\n');
+
+    // ── Slack: success (offline fetch stub) ──
+    await writeToTmux(
+      page,
+      sessionId,
+      `NODE_OPTIONS="--require ${SLACK_FETCH_STUB_PRELOAD_PATH}" ${SLACK_FETCH_STUB_ENV_VAR}='${slackFetchStubSuccessJson()}' `
+      + `node ${cliEntry} setup slack\nxoxb-success-token\nxapp-success-token\nsuccess-signing-secret\nC0SUCCESS\n`,
+    );
+    await waitForTerminalText(page, sessionId, 'Authenticated as invoker-bot in Invoker E2E');
+    await captureScreenshot(page, 'cli-slack-success');
+  });
+});

--- a/packages/contracts/src/__tests__/remote-target-onboarding.test.ts
+++ b/packages/contracts/src/__tests__/remote-target-onboarding.test.ts
@@ -1,11 +1,26 @@
-import { describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+import { spawn } from 'node:child_process';
 
 import {
   addRemoteTarget,
   buildConnectivityProbeArgs,
   checkRemoteTargetConnectivity,
+  REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR,
   type RemoteTargetInput,
 } from '../remote-target-onboarding.js';
+
+function createMockChildProcess() {
+  const proc = new EventEmitter() as EventEmitter & { stderr: EventEmitter };
+  proc.stderr = new EventEmitter();
+  return proc;
+}
 
 const baseInput: RemoteTargetInput = {
   name: 'build-server-c',
@@ -137,6 +152,45 @@ describe('checkRemoteTargetConnectivity', () => {
     sshKeyPath: '/home/user/.ssh/id_build_c',
     port: 2222,
   };
+
+  afterEach(() => {
+    delete process.env[REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR];
+    vi.mocked(spawn).mockReset();
+  });
+
+  it('runs the real ssh probe when the stub env var is unset', async () => {
+    const proc = createMockChildProcess();
+    vi.mocked(spawn).mockReturnValue(proc as never);
+
+    const resultPromise = checkRemoteTargetConnectivity(target);
+    proc.emit('close', 0);
+    const result = await resultPromise;
+
+    expect(spawn).toHaveBeenCalledWith('ssh', buildConnectivityProbeArgs(target), expect.any(Object));
+    expect(result).toEqual({ reachable: true, message: `ssh probe to ${target.user}@${target.host} succeeded` });
+  });
+
+  it('returns the scripted outcome for the host when the stub env var is set', async () => {
+    process.env[REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR] = JSON.stringify({
+      [target.host]: { reachable: true, message: 'scripted ok' },
+    });
+
+    const result = await checkRemoteTargetConnectivity(target);
+
+    expect(result).toEqual({ reachable: true, message: 'scripted ok' });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('returns a scripted failure instead of falling back to the real probe when the host has no entry', async () => {
+    process.env[REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR] = JSON.stringify({
+      'some-other-host': { reachable: true, message: 'scripted ok' },
+    });
+
+    const result = await checkRemoteTargetConnectivity(target);
+
+    expect(result.reachable).toBe(false);
+    expect(spawn).not.toHaveBeenCalled();
+  });
 
   it('uses the injected impl instead of running a real SSH probe', async () => {
     const impl = vi.fn().mockResolvedValue({ reachable: true, message: 'stubbed ok' });

--- a/packages/contracts/src/remote-target-onboarding.ts
+++ b/packages/contracts/src/remote-target-onboarding.ts
@@ -103,6 +103,31 @@ export interface CheckRemoteTargetConnectivityOptions {
 
 const DEFAULT_PROBE_CONNECT_TIMEOUT_SECONDS = 10;
 
+export const REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR = 'INVOKER_TEST_REMOTE_TARGET_STUB';
+
+function readScriptedConnectivityOutcome(host: string): RemoteTargetConnectivityResult | undefined {
+  const raw = process.env[REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR];
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  let scripted: unknown;
+  try {
+    scripted = JSON.parse(raw);
+  } catch (error) {
+    return {
+      reachable: false,
+      message: `failed to parse ${REMOTE_TARGET_CONNECTIVITY_STUB_ENV_VAR}: ${(error as Error).message}`,
+    };
+  }
+
+  if (!isRecord(scripted) || !Object.prototype.hasOwnProperty.call(scripted, host)) {
+    return { reachable: false, message: `no scripted connectivity outcome for host "${host}"` };
+  }
+
+  return scripted[host] as RemoteTargetConnectivityResult;
+}
+
 export function buildConnectivityProbeArgs(
   target: RemoteTargetConnection,
   connectTimeoutSeconds: number = DEFAULT_PROBE_CONNECT_TIMEOUT_SECONDS,
@@ -124,6 +149,11 @@ export async function checkRemoteTargetConnectivity(
 ): Promise<RemoteTargetConnectivityResult> {
   if (typeof opts.impl === 'function') {
     return opts.impl(target);
+  }
+
+  const scripted = readScriptedConnectivityOutcome(target.host);
+  if (scripted !== undefined) {
+    return scripted;
   }
 
   return new Promise((resolve) => {

--- a/packages/ui/src/__tests__/system-setup-modal-machines.test.tsx
+++ b/packages/ui/src/__tests__/system-setup-modal-machines.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Component test: "Add remote machines" step of the SystemSetupModal.
+ *
+ * Mirrors the existing Slack step's guided per-field form, but each machine
+ * is checked and added immediately via onAddMachine instead of being batched
+ * into the combined onRunSetup request.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { SystemDiagnostics } from '@invoker/contracts';
+
+import { SystemSetupModal } from '../components/SystemSetupModal.js';
+
+function makeDiagnostics(): SystemDiagnostics {
+  return {
+    platform: 'darwin',
+    arch: 'arm64',
+    appVersion: '0.0.3',
+    isPackaged: true,
+    tools: [],
+  };
+}
+
+function fillRequiredMachineFields(host: string, user: string, sshKeyPath: string): void {
+  fireEvent.change(screen.getByLabelText('Host'), { target: { value: host } });
+  fireEvent.change(screen.getByLabelText('User'), { target: { value: user } });
+  fireEvent.change(screen.getByLabelText(/SSH key path/), { target: { value: sshKeyPath } });
+}
+
+describe('SystemSetupModal — Add remote machines step', () => {
+  it('adds a machine to the list on a successful check', async () => {
+    const onAddMachine = vi.fn().mockResolvedValue({ ok: true, message: 'Reachable' });
+    render(
+      <SystemSetupModal
+        diagnostics={makeDiagnostics()}
+        onAddMachine={onAddMachine}
+        onClose={() => {}}
+      />,
+    );
+
+    fillRequiredMachineFields('10.0.0.5', 'deploy', '~/.ssh/id_ed25519');
+    fireEvent.click(screen.getByRole('button', { name: 'Check and add machine' }));
+
+    await screen.findByText('deploy@10.0.0.5');
+    expect(onAddMachine).toHaveBeenCalledWith({
+      host: '10.0.0.5',
+      user: 'deploy',
+      sshKeyPath: '~/.ssh/id_ed25519',
+    });
+    expect(screen.getByText('Reachable')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Host')).not.toBeInTheDocument();
+  });
+
+  it('leaves the list unchanged and keeps the form on a failing check', async () => {
+    const onAddMachine = vi.fn().mockResolvedValue({ ok: false, message: 'SSH auth failed' });
+    render(
+      <SystemSetupModal
+        diagnostics={makeDiagnostics()}
+        onAddMachine={onAddMachine}
+        onClose={() => {}}
+      />,
+    );
+
+    fillRequiredMachineFields('10.0.0.5', 'deploy', '~/.ssh/id_ed25519');
+    fireEvent.click(screen.getByRole('button', { name: 'Check and add machine' }));
+
+    await screen.findByText('SSH auth failed');
+    expect(screen.queryByText('deploy@10.0.0.5')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Host')).toHaveValue('10.0.0.5');
+    expect(screen.getByLabelText('User')).toHaveValue('deploy');
+    expect(screen.getByLabelText(/SSH key path/)).toHaveValue('~/.ssh/id_ed25519');
+  });
+
+  it('adds only one entry when the submit button is double-clicked with the same fields', async () => {
+    const onAddMachine = vi.fn().mockResolvedValue({ ok: true });
+    render(
+      <SystemSetupModal
+        diagnostics={makeDiagnostics()}
+        onAddMachine={onAddMachine}
+        onClose={() => {}}
+      />,
+    );
+
+    fillRequiredMachineFields('10.0.0.5', 'deploy', '~/.ssh/id_ed25519');
+    const submitButton = screen.getByRole('button', { name: 'Check and add machine' });
+    fireEvent.click(submitButton);
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(onAddMachine).toHaveBeenCalledTimes(1));
+    await screen.findByText('deploy@10.0.0.5');
+    expect(screen.getAllByText('deploy@10.0.0.5')).toHaveLength(1);
+  });
+
+  it('confirms before closing the modal while the machine form has unconfirmed values', () => {
+    const onClose = vi.fn();
+    render(
+      <SystemSetupModal
+        diagnostics={makeDiagnostics()}
+        onAddMachine={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Host'), { target: { value: '10.0.0.5' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText('Discard machine details?')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Keep editing' }));
+    expect(screen.queryByText('Discard machine details?')).not.toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Discard and close' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/SystemSetupModal.tsx
+++ b/packages/ui/src/components/SystemSetupModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import type {
   InvokerSetupRequest,
   InvokerSetupResult,
@@ -50,6 +50,7 @@ interface SystemSetupModalProps {
   onRunSetup?: (request: InvokerSetupRequest) => void;
   updateCliError?: string | null;
   onUpdateInvokerCli?: () => void;
+  onAddMachine?: (fields: MachineSetupFields) => Promise<MachineCheckOutcome>;
   onClose: () => void;
 }
 
@@ -63,6 +64,57 @@ const setupStepLabels: Record<'choose' | 'review' | 'finish', string> = {
 type SlackFieldId = 'botToken' | 'appToken' | 'signingSecret' | 'channelId';
 
 const firstAgentWorkflowTutorialUrl = 'https://github.com/Neko-Catpital-Labs/Invoker/blob/main/docs/tutorial-first-agent-workflow.md';
+
+type MachineFieldId = 'host' | 'user' | 'sshKeyPath' | 'port' | 'maxConcurrentTasks' | 'provisionCommand';
+
+export interface MachineSetupFields {
+  host: string;
+  user: string;
+  sshKeyPath: string;
+  port?: number;
+  maxConcurrentTasks?: number;
+  provisionCommand?: string;
+}
+
+export interface MachineCheckOutcome {
+  ok: boolean;
+  message?: string;
+}
+
+interface AddedMachine {
+  fields: MachineSetupFields;
+  message?: string;
+}
+
+const machineSetupFields: Array<{ id: MachineFieldId; label: string; placeholder: string; required: boolean }> = [
+  { id: 'host', label: 'Host', placeholder: 'e.g. 10.0.0.5 or box.example.com', required: true },
+  { id: 'user', label: 'User', placeholder: 'e.g. ubuntu', required: true },
+  { id: 'sshKeyPath', label: 'SSH key path', placeholder: '~/.ssh/id_ed25519', required: true },
+  { id: 'port', label: 'Port', placeholder: '22', required: false },
+  { id: 'maxConcurrentTasks', label: 'Max concurrent tasks', placeholder: '1', required: false },
+  { id: 'provisionCommand', label: 'Provision command', placeholder: 'optional', required: false },
+];
+
+const emptyMachineFormFields: Record<MachineFieldId, string> = {
+  host: '',
+  user: '',
+  sshKeyPath: '',
+  port: '',
+  maxConcurrentTasks: '',
+  provisionCommand: '',
+};
+
+function buildMachineSetupFields(raw: Record<MachineFieldId, string>): MachineSetupFields {
+  const fields: MachineSetupFields = {
+    host: raw.host.trim(),
+    user: raw.user.trim(),
+    sshKeyPath: raw.sshKeyPath.trim(),
+  };
+  if (raw.port.trim() !== '') fields.port = Number(raw.port);
+  if (raw.maxConcurrentTasks.trim() !== '') fields.maxConcurrentTasks = Number(raw.maxConcurrentTasks);
+  if (raw.provisionCommand.trim() !== '') fields.provisionCommand = raw.provisionCommand.trim();
+  return fields;
+}
 
 const slackSetupFields: Array<{
   id: SlackFieldId;
@@ -118,6 +170,7 @@ export function SystemSetupModal({
   updateCliError = null,
   onRunSetup,
   onUpdateInvokerCli,
+  onAddMachine,
   onClose,
 }: SystemSetupModalProps) {
   const [setupChecks, setSetupChecks] = useState<Record<SetupCheckId, boolean>>({
@@ -134,6 +187,48 @@ export function SystemSetupModal({
   });
   const [reviewOpen, setReviewOpen] = useState(false);
   const [systemDetailsOpen, setSystemDetailsOpen] = useState(false);
+  const [machineFormFields, setMachineFormFields] = useState<Record<MachineFieldId, string>>(emptyMachineFormFields);
+  const [machineFormOpen, setMachineFormOpen] = useState(true);
+  const [machineCheckPending, setMachineCheckPending] = useState(false);
+  const [machineCheckError, setMachineCheckError] = useState<string | null>(null);
+  const [addedMachines, setAddedMachines] = useState<AddedMachine[]>([]);
+  const [machinesStepDone, setMachinesStepDone] = useState(false);
+  const [machineCloseConfirmOpen, setMachineCloseConfirmOpen] = useState(false);
+  const machineSubmitInFlightRef = useRef(false);
+  const machineRequiredFieldsComplete = machineSetupFields
+    .filter((field) => field.required)
+    .every((field) => machineFormFields[field.id].trim() !== '');
+  const machineFormHasValues = machineSetupFields.some((field) => machineFormFields[field.id].trim() !== '');
+  const hasUnconfirmedMachineFields = machineFormOpen && machineFormHasValues;
+  const submitMachineForm = async (): Promise<void> => {
+    if (!onAddMachine || machineSubmitInFlightRef.current || !machineRequiredFieldsComplete) return;
+    machineSubmitInFlightRef.current = true;
+    setMachineCheckPending(true);
+    setMachineCheckError(null);
+    const fields = buildMachineSetupFields(machineFormFields);
+    try {
+      const outcome = await onAddMachine(fields);
+      if (outcome.ok) {
+        setAddedMachines((prev) => [...prev, { fields, message: outcome.message }]);
+        setMachineFormFields(emptyMachineFormFields);
+        setMachineFormOpen(false);
+      } else {
+        setMachineCheckError(outcome.message ?? 'Could not add this machine.');
+      }
+    } catch (err) {
+      setMachineCheckError(err instanceof Error ? err.message : String(err));
+    } finally {
+      machineSubmitInFlightRef.current = false;
+      setMachineCheckPending(false);
+    }
+  };
+  const requestCloseModal = (): void => {
+    if (hasUnconfirmedMachineFields) {
+      setMachineCloseConfirmOpen(true);
+      return;
+    }
+    onClose();
+  };
   const anySetupSelected = setupChecks.updateCli || setupChecks.installHelpers || setupChecks.fixTools || setupChecks.slack;
   const slackFieldsComplete = slackSetupFields.every((field) => slackFields[field.id] !== '');
   const firstMissingSlackField = setupChecks.slack
@@ -228,7 +323,7 @@ export function SystemSetupModal({
 
 
   return (
-    <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
+    <Dialog open onOpenChange={(open) => { if (!open) requestCloseModal(); }}>
       <DialogContent className="max-w-3xl max-h-[90vh] flex flex-col gap-0 p-0 overflow-hidden" hideCloseButton>
         <DialogHeader className="p-6 pb-3 shrink-0">
           <DialogTitle>System Setup</DialogTitle>
@@ -382,6 +477,103 @@ export function SystemSetupModal({
                         {step.output && <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap text-xs text-foreground">{step.output}</pre>}
                       </div>
                     ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {onAddMachine && (
+            <div className="rounded border border-border-strong/60 bg-secondary/70 px-4 py-4 space-y-4">
+              <div>
+                <div className="text-sm font-medium text-foreground">Add remote machines</div>
+                <div className="text-sm text-muted-foreground/80 mt-1">
+                  Add machines Invoker can run tasks on over SSH. Each machine is checked before it&apos;s added.
+                </div>
+              </div>
+
+              {addedMachines.length > 0 && (
+                <div className="rounded border border-border-strong/70 bg-card/40 divide-y divide-border">
+                  {addedMachines.map((machine, index) => (
+                    <div key={`${machine.fields.host}-${index}`} className="px-3 py-2 text-sm text-foreground">
+                      <span className="font-medium">{machine.fields.user}@{machine.fields.host}</span>
+                      {machine.message && <span className="ml-2 text-xs text-muted-foreground">{machine.message}</span>}
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {machineFormOpen && (
+                <div className="space-y-3">
+                  {machineSetupFields.map((field) => (
+                    <label key={field.id} className="block text-xs text-foreground">
+                      {field.label} {!field.required && <span className="text-muted-foreground/70">(optional)</span>}
+                      <input
+                        value={machineFormFields[field.id]}
+                        onChange={(event) => {
+                          const { value } = event.target;
+                          setMachineFormFields((prev) => ({ ...prev, [field.id]: value }));
+                          setMachineCheckError(null);
+                        }}
+                        type={field.id === 'port' || field.id === 'maxConcurrentTasks' ? 'number' : 'text'}
+                        placeholder={field.placeholder}
+                        className="mt-1 w-full rounded border border-border-strong bg-card px-2 py-1.5 text-sm text-foreground"
+                      />
+                    </label>
+                  ))}
+
+                  {machineCheckError && (
+                    <div className="rounded border border-red-700/50 bg-red-950/30 px-3 py-2 text-sm text-red-200">
+                      {machineCheckError}
+                    </div>
+                  )}
+
+                  <button
+                    onClick={submitMachineForm}
+                    disabled={machineCheckPending || !machineRequiredFieldsComplete}
+                    className="px-4 py-2 bg-primary hover:bg-primary/90 disabled:bg-secondary disabled:text-muted-foreground text-white rounded text-sm font-medium transition-colors"
+                  >
+                    {machineCheckPending ? 'Checking machine…' : 'Check and add machine'}
+                  </button>
+                </div>
+              )}
+
+              {!machineFormOpen && !machinesStepDone && (
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    onClick={() => setMachineFormOpen(true)}
+                    className="px-3 py-2 bg-muted hover:bg-accent text-white rounded text-sm transition-colors"
+                  >
+                    Add another machine
+                  </button>
+                  <button
+                    onClick={() => setMachinesStepDone(true)}
+                    className="px-3 py-2 bg-primary hover:bg-primary/90 text-white rounded text-sm font-medium transition-colors"
+                  >
+                    Done adding machines
+                  </button>
+                </div>
+              )}
+
+              {machineCloseConfirmOpen && (
+                <div className="rounded border border-amber-600/50 bg-amber-950/40 px-3 py-3 text-sm text-amber-100">
+                  <div className="font-medium">Discard machine details?</div>
+                  <div className="mt-1 text-amber-100/90">
+                    You entered machine fields that haven&apos;t been added yet. Closing now will discard them.
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <button
+                      onClick={onClose}
+                      className="px-3 py-2 bg-red-700 hover:bg-red-600 text-white rounded text-sm font-medium transition-colors"
+                    >
+                      Discard and close
+                    </button>
+                    <button
+                      onClick={() => setMachineCloseConfirmOpen(false)}
+                      className="px-3 py-2 bg-muted hover:bg-accent text-white rounded text-sm transition-colors"
+                    >
+                      Keep editing
+                    </button>
                   </div>
                 </div>
               )}
@@ -665,7 +857,7 @@ export function SystemSetupModal({
         </div>
 
         <DialogFooter className="px-6 py-4 border-t border-border sm:justify-end">
-          <Button type="button" onClick={onClose}>
+          <Button type="button" onClick={requestCloseModal}>
             Close
           </Button>
         </DialogFooter>

--- a/skills/invoker-setup/SKILL.md
+++ b/skills/invoker-setup/SKILL.md
@@ -42,6 +42,12 @@ invoker-cli doctor --fix
 Ask plainly: "Do you want to set up the Slack integration now?" If no, stop — report that they are
 good to go for CLI and UI workflows and that `invoker-cli setup slack` can add Slack later.
 
+## 2b. Ask about remote machines
+
+Ask plainly: "Do you want to add any remote SSH machines now?" If no, skip to the next step — a
+user with no remote machines is still "good to go" for local CLI and UI workflows, and
+`invoker-cli setup machines` can add machines later.
+
 ## 3. Guided Slack setup (only if they said yes)
 
 Run the wizard, which writes a ready-to-paste app manifest to `~/.invoker/slack-app-manifest.json`
@@ -68,6 +74,23 @@ If you are doing it on the user's behalf (you cannot click api.slack.com), drive
 Adding scopes after install does **not** update the existing token. The user MUST click
 **Reinstall to Workspace** or the bot keeps the old (insufficient) scopes. If the scope check fails,
 tell them to add the scope **and reinstall**.
+
+## 3b. Guided machines setup (only if they said yes)
+
+Run the wizard:
+
+```bash
+invoker-cli setup machines
+```
+
+It prompts for each machine's name, host, user, SSH key path, port (default `22`), max concurrent
+tasks (default `1`), and an optional provision command, then probes SSH connectivity before
+saving — only a machine that answers the probe is written to `~/.invoker/config.json`. It asks
+after each one whether to add another. The desktop System Setup panel's "Add remote machines"
+section offers the same fields and the same reachability check for users who prefer the GUI.
+
+If a probe fails, report the connectivity error and let the user retry or skip that machine —
+never write an unreachable machine to config.
 
 ## 4. Validate credentials
 


### PR DESCRIPTION
## Summary

Updates docs/remote-ssh-targets.md and skills/invoker-setup/SKILL.md to describe the machines wizard now that earlier stack workflows have landed.

The docs now lead with guided setup and keep manual config edits as the fallback path.

## Review Claim

Updates the setup docs and the setup skill guide so they describe the new machines wizard as the primary way to add a machine, keeping the existing hand-edit path documented as a fallback.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

The hand-edit instructions stay in the doc as a fallback section; nothing describes a flow that does not exist, because every workflow this doc now describes already landed earlier in this stack.

## Slice Rationale

This slice only touches docs; every behavior it describes already landed in earlier workflows of this stack.

## Non-goals

No code changes in this task. This task only touches the two named doc files.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `grep -q "setup machines" docs/remote-ssh-targets.md && grep -qi "machine" skills/invoker-setup/SKILL.md && grep -qi "fallback" docs/remote-ssh-targets.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/add-machine-onboarding-8-docs-pr.md --base stack/EdbertChan/pr/add-machine-onboarding-6-cli-visual-proof/add-machine-onboarding-6-cli-visual-proof--ed01adcb`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
