### PR TITLE
[Lease-aware disk-headroom reaper](5) remote cleanup behavior

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -6,9 +7,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { TaskState } from '@invoker/workflow-core';
 
 import { computeRepoCacheHash } from '../git-utils.js';
+import type { RemoteDiskTarget } from '../workers/disk-headroom-monitor.js';
 import {
   buildInvokerHomeCleanupScript,
   cleanupLocalInvokerHome,
+  cleanupRemoteInvokerHome,
   computeProtectedLocalPaths,
   DISK_RECLAIMABLE_DIRS,
   DiskCleanupCooldownTracker,
@@ -93,6 +96,56 @@ describe('disk-headroom cleanup guards', () => {
     expect(script).not.toContain('$HOME/.cache/electron');
     expect(script).not.toContain('$HOME/.local/share/pnpm');
     expect(script).not.toContain('$HOME/.pnpm-store');
+  });
+
+  it('passes over a preserved path and no longer clears $INVOKER_HOME/repos as one whole unit', () => {
+    const preservedScript = buildInvokerHomeCleanupScript('~/.invoker', ['repos/abc123']);
+    expect(preservedScript).not.toContain('remove_path "$INVOKER_HOME/repos"');
+    expect(preservedScript).toContain("PRESERVE=('repos/abc123')");
+    expect(preservedScript).toContain('sweep_children_preserving "$INVOKER_HOME/repos" "repos"');
+    expect(preservedScript).toContain('sweep_children_preserving "$INVOKER_HOME/worktrees" "worktrees"');
+    expect(preservedScript).toContain('sweep_children_preserving "$INVOKER_HOME/merge-clones" "merge-clones"');
+    expect(preservedScript).toContain('sweep_children_preserving "$INVOKER_HOME/merge-launches" "merge-launches"');
+    // runtime and pr-cron-work stay whole-unit removals.
+    expect(preservedScript).toContain('remove_path "$INVOKER_HOME/runtime"');
+    expect(preservedScript).toContain('remove_path "$INVOKER_HOME/pr-cron-work"');
+    expect(preservedScript).toContain('#6632');
+  });
+
+  it('builds an empty PRESERVE array when no paths are given', () => {
+    const script = buildInvokerHomeCleanupScript('~/.invoker');
+    expect(script).toContain('PRESERVE=()');
+  });
+
+  it('actually preserves a listed child and clears its unrelated sibling when run for real', () => {
+    const root = mkdtempSync(join(tmpdir(), 'invoker-remote-cleanup-real-'));
+    tempDirs.push(root);
+    const invokerHome = join(root, 'home');
+    const isolatedTmp = join(root, 'scratch-tmp');
+    mkdirSync(isolatedTmp, { recursive: true });
+
+    const preservedHash = 'preserved-hash';
+    const otherHash = 'other-hash';
+    const preservedDir = join(invokerHome, 'repos', preservedHash);
+    const otherDir = join(invokerHome, 'repos', otherHash);
+    mkdirSync(preservedDir, { recursive: true });
+    writeFileSync(join(preservedDir, 'file.txt'), 'keep-me');
+    mkdirSync(otherDir, { recursive: true });
+    writeFileSync(join(otherDir, 'file.txt'), 'clear-me');
+
+    const script = buildInvokerHomeCleanupScript(invokerHome, [`repos/${preservedHash}`]);
+    const scriptPath = join(root, 'cleanup.sh');
+    writeFileSync(scriptPath, script);
+
+    const result = spawnSync('bash', [scriptPath], {
+      encoding: 'utf8',
+      env: { ...process.env, TMPDIR: isolatedTmp },
+    });
+
+    expect(result.status).toBe(0);
+    expect(existsSync(join(preservedDir, 'file.txt'))).toBe(true);
+    expect(existsSync(otherDir)).toBe(false);
+    expect(existsSync(join(invokerHome, 'repos'))).toBe(true);
   });
 
   it('reclaims the pr-cron-work scratch dir', () => {
@@ -475,5 +528,98 @@ describe('cleanupLocalInvokerHome DB-state liveness guard', () => {
     expect(existsSync(protectedWorktreeDir)).toBe(true);
     expect(existsSync(join(protectedWorktreeDir, 'file.txt'))).toBe(true);
     expect(existsSync(unrelatedRepoDir)).toBe(false);
+  });
+});
+
+describe('cleanupRemoteInvokerHome', () => {
+  function makeTarget(overrides: Partial<RemoteDiskTarget> = {}): RemoteDiskTarget {
+    return {
+      name: 'remote-1',
+      connection: { host: 'h', user: 'u', sshKeyPath: '/k' },
+      remotePath: '~/.invoker',
+      ...overrides,
+    };
+  }
+
+  it('never calls its execution callback when the accessor it is given throws', async () => {
+    const target = makeTarget();
+    const throwingStore: DiskHeadroomWorkerStore = {
+      listWorkflows: () => {
+        throw new Error('db unavailable');
+      },
+      loadTasks: () => [],
+    };
+    const runRemoteScript = vi.fn(async () => 'ok');
+
+    const result = await cleanupRemoteInvokerHome({
+      target,
+      store: throwingStore,
+      runRemoteScript,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+    });
+
+    expect(runRemoteScript).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('cleanup-error');
+  });
+
+  it('narrows preservation to this target\'s own poolMemberId and embeds it in the generated script', async () => {
+    const target = makeTarget({ name: 'remote-1', remotePath: '/home/remote/.invoker' });
+    const otherTarget = makeTarget({ name: 'remote-2', remotePath: '/home/remote/.invoker' });
+
+    const store: DiskHeadroomWorkerStore = {
+      listWorkflows: () => [{ id: 'wf-1' }],
+      loadTasks: (workflowId: string) =>
+        workflowId === 'wf-1'
+          ? [
+              makeTask({
+                id: 'wf-1/on-target',
+                status: 'running',
+                config: { workflowId: 'wf-1', command: 'x', poolMemberId: 'remote-1' },
+                execution: { workspacePath: '/home/remote/.invoker/worktrees/hash1/branch' },
+              }),
+              makeTask({
+                id: 'wf-1/on-other-target',
+                status: 'running',
+                config: { workflowId: 'wf-1', command: 'x', poolMemberId: 'remote-2' },
+                execution: { workspacePath: '/home/remote/.invoker/worktrees/hash2/branch' },
+              }),
+            ]
+          : [],
+    };
+
+    const capturedScripts: string[] = [];
+    const runRemoteScript = vi.fn(async (_t: RemoteDiskTarget, script: string) => {
+      capturedScripts.push(script);
+      return 'ok';
+    });
+
+    const result = await cleanupRemoteInvokerHome({ target, store, runRemoteScript });
+    expect(result.ok).toBe(true);
+    expect(capturedScripts[0]).toContain('worktrees/hash1/branch');
+    expect(capturedScripts[0]).not.toContain('worktrees/hash2/branch');
+
+    const otherResult = await cleanupRemoteInvokerHome({
+      target: otherTarget,
+      store,
+      runRemoteScript,
+    });
+    expect(otherResult.ok).toBe(true);
+    expect(capturedScripts[1]).toContain('worktrees/hash2/branch');
+    expect(capturedScripts[1]).not.toContain('worktrees/hash1/branch');
+  });
+
+  it('clears everything (empty PRESERVE) when no store is provided', async () => {
+    const target = makeTarget();
+    let capturedScript = '';
+    const runRemoteScript = vi.fn(async (_t: RemoteDiskTarget, script: string) => {
+      capturedScript = script;
+      return 'ok';
+    });
+
+    const result = await cleanupRemoteInvokerHome({ target, runRemoteScript });
+
+    expect(result.ok).toBe(true);
+    expect(capturedScript).toContain('PRESERVE=()');
   });
 });

--- a/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
@@ -123,17 +123,32 @@ export function isDeletingOrphanName(name: string): boolean {
   return name.includes('.deleting.');
 }
 
+/** Reclaimable dirs swept one child at a time so `preservePaths` can protect a single in-use child without protecting its siblings. */
+const REMOTE_CHILD_SWEPT_DIRS = ['repos', 'worktrees', 'merge-clones', 'merge-launches'] as const;
+
 /**
  * Remote bash that frees Invoker-managed disk under `$INVOKER_HOME`.
  * Kills only provision grinders (pnpm install / electron unzip), not every
  * process whose argv mentions the home (that can kill the SSH session).
  * Deletes synchronously so SSH timeout cannot leave fire-and-forget orphans.
+ *
+ * `preservePaths` are paths relative to `$INVOKER_HOME` (e.g. `repos/<hash>`,
+ * `worktrees/<hash>/<branch>`) for in-flight work on this target's own pool.
+ * Each direct child of a REMOTE_CHILD_SWEPT_DIRS entry is checked against
+ * this set before deletion; a match is passed over instead of removed.
  */
-export function buildInvokerHomeCleanupScript(invokerHome: string): string {
+export function buildInvokerHomeCleanupScript(
+  invokerHome: string,
+  preservePaths: readonly string[] = [],
+): string {
   const homeQ = shellPosixSingleQuote(invokerHome);
-  const removeCalls = DISK_RECLAIMABLE_DIRS
-    .map((name) => `remove_path "$INVOKER_HOME/${name}"`)
+  const preserveArrayLiteral = preservePaths.map((p) => shellPosixSingleQuote(p)).join(' ');
+  const childSweptRemoveCalls = REMOTE_CHILD_SWEPT_DIRS
+    .map((name) => `sweep_children_preserving "$INVOKER_HOME/${name}" "${name}"`)
     .join('\n');
+  const wholeDirRemoveCalls = `remove_path "$INVOKER_HOME/runtime"
+# pr-cron-work: PR #6632 retired its only producer, so there is nothing to preserve here.
+remove_path "$INVOKER_HOME/pr-cron-work"`;
   const mkdirArgs = DISK_RECLAIMABLE_DIRS
     .map((name) => `"$INVOKER_HOME/${name}"`)
     .join(' ');
@@ -168,7 +183,35 @@ remove_path() {
     rm -rf "$path" 2>/dev/null || true
   fi
 }
-${removeCalls}
+# In-flight work on this target's own pool — checked before a child is removed below.
+PRESERVE=(${preserveArrayLiteral})
+is_preserved() {
+  local rel="$1"
+  local p
+  for p in "\${PRESERVE[@]}"; do
+    case "$p" in
+      "$rel") return 0 ;;
+      "$rel"/*) return 0 ;;
+    esac
+  done
+  return 1
+}
+sweep_children_preserving() {
+  local dir="$1"
+  local prefix="$2"
+  [ -d "$dir" ] || return 0
+  find "$dir" -mindepth 1 -maxdepth 1 -print0 2>/dev/null | while IFS= read -r -d '' child; do
+    local base
+    base=$(basename "$child")
+    if is_preserved "$prefix/$base"; then
+      echo "[disk-headroom-cleanup] preserve $child (in-use)"
+      continue
+    fi
+    remove_path "$child"
+  done
+}
+${childSweptRemoveCalls}
+${wholeDirRemoveCalls}
 rm -rf "$INVOKER_HOME"/*.deleting.* >/dev/null 2>&1
 mkdir -p ${mkdirArgs}
 chmod 700 ${mkdirArgs}
@@ -528,9 +571,63 @@ export async function cleanupLocalInvokerHome(opts: {
   return { targetKey, ok: true, reason: 'critical-cleanup' };
 }
 
+/**
+ * Eagerly reads `store` down to the tasks belonging to `poolMemberId` (the
+ * same key task dispatch joins on — see selectedRemoteTargetId in
+ * task-runner-pool.ts). Fetches happen here, outside of
+ * computeProtectedLocalPaths/computeProtectedRepoHashes's own fail-safe
+ * try/catch, so a real accessor error propagates to the caller instead of
+ * being swallowed into an empty (i.e. "protect nothing") result — remote
+ * cleanup must fail closed, not fail open onto an unprotected wipe.
+ */
+function narrowStoreToPoolMemberOrThrow(
+  store: DiskHeadroomWorkerStore,
+  poolMemberId: string,
+): DiskHeadroomWorkerStore {
+  const workflows = store.listWorkflows();
+  const tasksByWorkflowId = new Map<string, TaskState[]>();
+  for (const workflow of workflows) {
+    const tasks = store.loadTasks(workflow.id).filter(
+      (task) => (task.config as { poolMemberId?: string }).poolMemberId === poolMemberId,
+    );
+    tasksByWorkflowId.set(workflow.id, tasks);
+  }
+  return {
+    listWorkflows: () => workflows,
+    loadTasks: (workflowId) => tasksByWorkflowId.get(workflowId) ?? [],
+  };
+}
+
+/**
+ * This target's short preservation set, as paths relative to
+ * `target.remotePath`: `repos/<hash>` for protected repo mirrors and
+ * `worktrees/<hash>/<branch>` (etc.) for protected task workspaces. Throws
+ * if `store` throws — callers must fail closed on that, not fall back to an
+ * unprotected remote wipe.
+ */
+function computeRemotePreservationPaths(
+  store: DiskHeadroomWorkerStore,
+  target: RemoteDiskTarget,
+): string[] {
+  const narrowed = narrowStoreToPoolMemberOrThrow(store, target.name);
+  const preserved = new Set<string>();
+  for (const hash of computeProtectedRepoHashes(narrowed)) {
+    preserved.add(`repos/${hash}`);
+  }
+  const resolvedHome = resolve(target.remotePath);
+  const homePrefix = `${resolvedHome}${sep}`;
+  for (const path of computeProtectedLocalPaths(narrowed)) {
+    if (!path.startsWith(homePrefix)) continue;
+    const relative = path.slice(homePrefix.length);
+    if (relative) preserved.add(relative);
+  }
+  return [...preserved];
+}
+
 export async function cleanupRemoteInvokerHome(opts: {
   target: RemoteDiskTarget;
   logger?: Logger;
+  store?: DiskHeadroomWorkerStore;
   runRemoteScript?: (target: RemoteDiskTarget, script: string) => Promise<string>;
 }): Promise<DiskCleanupResult> {
   const targetKey = `ssh:${opts.target.name} ${opts.target.remotePath}`;
@@ -543,7 +640,21 @@ export async function cleanupRemoteInvokerHome(opts: {
     };
   }
 
-  const script = buildInvokerHomeCleanupScript(opts.target.remotePath);
+  let preservePaths: string[] = [];
+  if (opts.store) {
+    try {
+      preservePaths = computeRemotePreservationPaths(opts.store, opts.target);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      opts.logger?.error?.(
+        `[disk-headroom-cleanup] remote preservation lookup failed ${targetKey}: ${detail}`,
+        { module: 'disk-headroom', targetKey },
+      );
+      return { targetKey, ok: false, reason: 'cleanup-error', detail };
+    }
+  }
+
+  const script = buildInvokerHomeCleanupScript(opts.target.remotePath, preservePaths);
   const run = opts.runRemoteScript ?? defaultRunRemoteCleanup;
   try {
     opts.logger?.info?.(`[disk-headroom-cleanup] remote begin ${targetKey}`, {

--- a/packages/execution-engine/src/workers/disk-headroom-worker.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-worker.ts
@@ -213,6 +213,7 @@ export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): Wo
             result = await cleanupRemote({
               target,
               logger: options.logger,
+              store: options.workflowStore,
             });
           }
         } else {


### PR DESCRIPTION
## Summary

Extends the local preservation fix to the remote SSH reaper. The local reaper already routes reclaim decisions through active task state.

The remote reaper only runs as plain shell on each remote host, with no way to call back to the owner's task state directly.

So the owner now routes, per target, the paths that target's in-flight tasks still need into the shell text it already builds before sending it over SSH.

If the owner cannot produce that data for a target, this reaper withholds that target's run entirely for this pass.

Sending a script with nothing routed in would be exactly the failure this change exists to close.

## Review Claim

A remote target's reclaim pass never erases a path its own in-flight tasks still need, and if the owner cannot produce that target's preservation data, this reaper sends nothing to that target for this pass.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A target whose preservation set cannot be produced gets no cleanup run at all for this pass — never a run built without that list. Every path that would have been cleared before, and that no in-flight task on that target needs, must still be cleared.

## Slice Rationale

One behavior change — what a remote cleanup pass leaves in place. This is the remote counterpart to the local behavior change already landed for the local reaper. The two are separate slices because one is TypeScript-plus-fixture and the other is generated shell text plus a live shell run.

## Non-goals

- No change to the local reaper (already landed).
- No live network round-trip from a remote host back to the owner at cleanup time.
- No change to `pr-cron-work` beyond a one-line comment noting it has no current producer.
- No change to how task dispatch itself picks a `poolMemberId`, only how this reaper reads that same field.

## Architecture

### Before

```mermaid
flowchart LR
  A["critical disk pressure on a remote target"] --> B["buildInvokerHomeCleanupScript"]
  B -->|"sent over SSH"| C["remote host: clear repos/worktrees/merge-clones/merge-launches as whole directories"]
```

### After

```mermaid
flowchart LR
  A["owner: task/workflow accessor, filtered to one target's tasks"] --> B["short list of paths that target still needs"]
  B -->|"written into the generated shell text"| C["buildInvokerHomeCleanupScript"]
  C -->|"sent over SSH"| D["remote host: leave listed paths alone, clear the rest"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/disk-headroom-reclaim.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert d178ca79c58a975487bbe030cf6a8e9808aa0d00`
- Post-revert steps: Re-run `pnpm --filter @invoker/execution-engine test -- src/__tests__/disk-headroom-reclaim.test.ts`.
- Data migration? No.

</details>
