### PR TITLE
[Hardening: WorkResponse.outputs array rejection gets a named guard](1)[REFACTOR: Extract Method] isValidWorkResponseOutputs guard

### DIFF
--- a/packages/contracts/src/__tests__/validation.test.ts
+++ b/packages/contracts/src/__tests__/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateWorkRequest, validateWorkResponse } from '../validation.js';
+import { validateWorkRequest, validateWorkResponse, isValidWorkResponseOutputs } from '../validation.js';
 import { createWorkRequest } from '../types.js';
 import type { WorkResponse } from '../types.js';
 
@@ -39,6 +39,25 @@ describe('validateWorkRequest', () => {
     const result = validateWorkRequest({ requestId: 'r', actionId: 'a', executionGeneration: 0, actionType: 'invalid', inputs: {}, callbackUrl: 'http://x' });
     expect(result.valid).toBe(false);
     expect(result.error).toContain('actionType');
+  });
+});
+
+describe('isValidWorkResponseOutputs', () => {
+  it('accepts a plain object', () => {
+    expect(isValidWorkResponseOutputs({})).toBe(true);
+    expect(isValidWorkResponseOutputs({ exitCode: 0 })).toBe(true);
+  });
+
+  it('rejects null, undefined, and non-object values', () => {
+    expect(isValidWorkResponseOutputs(null)).toBe(false);
+    expect(isValidWorkResponseOutputs(undefined)).toBe(false);
+    expect(isValidWorkResponseOutputs('not-an-object')).toBe(false);
+    expect(isValidWorkResponseOutputs(42)).toBe(false);
+  });
+
+  it('rejects arrays', () => {
+    expect(isValidWorkResponseOutputs([])).toBe(false);
+    expect(isValidWorkResponseOutputs([1, 2, 3])).toBe(false);
   });
 });
 

--- a/packages/contracts/src/validation.ts
+++ b/packages/contracts/src/validation.ts
@@ -206,6 +206,10 @@ function validateReviewGate(reviewGate: unknown): ValidationResult {
   return { valid: true };
 }
 
+export function isValidWorkResponseOutputs(value: unknown): boolean {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
 export function validateWorkResponse(res: unknown): ValidationResult {
   if (!res || typeof res !== 'object' || Array.isArray(res)) {
     return { valid: false, error: 'WorkResponse must be an object' };
@@ -234,7 +238,7 @@ export function validateWorkResponse(res: unknown): ValidationResult {
     return { valid: false, error: `status must be one of: ${validStatuses.join(', ')}` };
   }
 
-  if (!r.outputs || typeof r.outputs !== 'object' || Array.isArray(r.outputs)) {
+  if (!isValidWorkResponseOutputs(r.outputs)) {
     return { valid: false, error: 'outputs is required and must be an object' };
   }
 


### PR DESCRIPTION
## Summary

Today `validateWorkResponse` inline-checks that `outputs` is a non-array object, guarding against a silent-corruption bug from commit ba2ab851a.

That inline check now lives in its own small, named, exported function: `isValidWorkResponseOutputs`.

`validateWorkResponse` calls the new function from the exact same place, with the exact same error text and result. No caller-visible behavior changes.

This is a hardening/testability slice, not a bugfix. The array-rejection invariant is already correct and already covered by a regression test.

This slice only makes the specific condition directly testable on its own.

## Review Claim

The inline `!r.outputs || typeof r.outputs !== 'object' || Array.isArray(r.outputs)` condition inside `validateWorkResponse` becomes a standalone, named, exported boolean function called from the same place with the same result.

## Review Lane

refactor

## Review Unit

contract

## Safety Invariant

`validateWorkResponse` still returns the same error for every input; behavior is unchanged before and after this slice, for every existing caller and every existing test. No behavior change.

## Slice Rationale

One slice: give the existing inline condition its own name and export it, plus a direct unit test, nothing else. The three sibling copies of this check in `protocol`, `core`, and `workflow-core` are out of scope for this slice.

## Non-goals

This slice makes no behavior change: no new call sites, no change to `validateWorkResponse`'s own signature or error text, no unrelated cleanup, no documentation edits, and no change to the three sibling duplicate checks in `protocol`, `core`, or `workflow-core`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/contracts && pnpm test -- -t 'rejects array outputs (silent-corruption guard)'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
