### PR TITLE
[Workflow delete+resubmit UI drift](2) refresh-snapshot stream-sequence atomicity

### DIFF
--- a/packages/app/src/__tests__/gui-refresh-task-graph.test.ts
+++ b/packages/app/src/__tests__/gui-refresh-task-graph.test.ts
@@ -216,6 +216,7 @@ describe('registerGuiMutationIpcHandlers refresh-task-graph', () => {
       'refresh-task-graph',
       [makeTask('wf-1/task-1')],
       [{ id: 'wf-1', name: 'Workflow 1', status: 'running' }],
+      17,
       true,
     );
     expect(recordStartupDuration).toHaveBeenCalledWith('refresh-task-graph.return', expect.any(Number), {
@@ -243,6 +244,7 @@ describe('registerGuiMutationIpcHandlers refresh-task-graph', () => {
       'refresh-task-graph-delegated',
       [localTask],
       [localWorkflow],
+      17,
       true,
     );
   });

--- a/packages/app/src/__tests__/refresh-task-graph.test.ts
+++ b/packages/app/src/__tests__/refresh-task-graph.test.ts
@@ -42,12 +42,14 @@ describe('publishForcedRefreshTaskGraphSnapshot', () => {
     publishForcedRefreshTaskGraphSnapshot(publisher, 'refresh-task-graph', {
       tasks: [task],
       workflows: [workflow],
+      streamSequence: 5,
     });
 
     expect(publisher.publishSnapshot).toHaveBeenCalledWith(
       'refresh-task-graph',
       [task],
       [workflow],
+      5,
       true,
     );
   });
@@ -84,9 +86,10 @@ describe('resolveRefreshTaskGraphSnapshot fallback', () => {
           return [localWorkflow];
         },
       } as never,
+      getStreamSequence: () => 9,
     });
 
-    expect(result).toEqual({ tasks: [localTask], workflows: [localWorkflow] });
+    expect(result).toEqual({ tasks: [localTask], workflows: [localWorkflow], streamSequence: 9 });
     expect(calls).toEqual({ sync: 1, tasks: 1, workflows: 1 });
     expect(warnings).toEqual([
       {
@@ -109,6 +112,7 @@ describe('resolveRefreshTaskGraphSnapshot fallback', () => {
           return {
             tasks: [makeTask('wf-remote/task-1')],
             workflows: [{ id: 'wf-remote', name: 'Remote', status: 'running' }],
+            streamSequence: 1,
             invokerHomeRoot: '/tmp/invoker-remote',
           };
         },
@@ -128,9 +132,10 @@ describe('resolveRefreshTaskGraphSnapshot fallback', () => {
           return [localWorkflow];
         },
       } as never,
+      getStreamSequence: () => 9,
     });
 
-    expect(result).toEqual({ tasks: [localTask], workflows: [localWorkflow] });
+    expect(result).toEqual({ tasks: [localTask], workflows: [localWorkflow], streamSequence: 9 });
     expect(calls.sync).toBe(1);
     expect(warnings[0]).toEqual({
       message: expect.stringContaining('owner home mismatch: owner=/tmp/invoker-remote local=/tmp/invoker-local'),

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1552,6 +1552,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       orchestrator,
       persistence,
       logger,
+      getStreamSequence: getTaskDeltaStreamSequence,
     });
 
     publishForcedRefreshTaskGraphSnapshot(
@@ -1562,7 +1563,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     recordStartupDuration('refresh-task-graph.return', startedAtMs, {
       taskCount: snapshot.tasks.length,
       workflowCount: snapshot.workflows.length,
-      streamSequence: getTaskDeltaStreamSequence(),
+      streamSequence: snapshot.streamSequence,
     });
   });
   registerReadOnlyIpcHandlers({

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2287,7 +2287,6 @@ startMainProcessBootstrap({
     getMainWindow: () => mainWindow,
     isUiInteractive: () => uiInteractive,
     stampDelta: (delta) => taskDeltaStream.stamp(delta),
-    getStreamSequence: getTaskDeltaStreamSequence,
     onLargeBatch: ({ batchSize, remaining }) => {
       uiPerfStats.largeTaskDeltaBatches += 1;
       uiPerfStats.maxTaskDeltaBatchSize = Math.max(uiPerfStats.maxTaskDeltaBatchSize, batchSize);
@@ -2621,8 +2620,14 @@ startMainProcessBootstrap({
               orchestrator,
               persistence,
               logger,
+              getStreamSequence: getTaskDeltaStreamSequence,
             });
-            taskGraphEventPublisher.publishSnapshot('refresh-task-graph', snapshot.tasks, snapshot.workflows);
+            taskGraphEventPublisher.publishSnapshot(
+              'refresh-task-graph',
+              snapshot.tasks,
+              snapshot.workflows,
+              snapshot.streamSequence,
+            );
           },
           deleteWorkflow: (workflowId) => requireGuiMutationTaskActions().performDeleteWorkflow(workflowId),
           detachWorkflow: (workflowId, upstreamWorkflowId) =>

--- a/packages/app/src/refresh-task-graph.ts
+++ b/packages/app/src/refresh-task-graph.ts
@@ -6,12 +6,14 @@ import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 interface DelegatedRefreshTaskGraphSnapshot {
   tasks: TaskState[];
   workflows: WorkflowMeta[];
+  streamSequence: number;
   invokerHomeRoot?: string;
 }
 
 export interface RefreshTaskGraphSnapshot {
   tasks: TaskState[];
   workflows: WorkflowMeta[];
+  streamSequence: number;
 }
 
 export interface ResolveRefreshTaskGraphSnapshotDeps {
@@ -21,9 +23,16 @@ export interface ResolveRefreshTaskGraphSnapshotDeps {
   orchestrator: Pick<Orchestrator, 'syncAllFromDb' | 'getAllTasks'>;
   persistence: Pick<SQLiteAdapter, 'listWorkflows'>;
   logger: Logger;
+  getStreamSequence: () => number;
 }
 export interface RefreshTaskGraphSnapshotPublisher {
-  publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[], forced?: boolean): void;
+  publishSnapshot(
+    reason: string,
+    tasks: TaskState[],
+    workflows: WorkflowMeta[],
+    streamSequence: number,
+    forced?: boolean,
+  ): void;
 }
 
 
@@ -38,9 +47,14 @@ function parseDelegatedRefreshTaskGraphSnapshot(
   const snapshot = value as {
     tasks?: unknown[];
     workflows?: unknown[];
+    streamSequence?: unknown;
     invokerHomeRoot?: string;
   };
-  if (!Array.isArray(snapshot.tasks) || !Array.isArray(snapshot.workflows)) {
+  if (
+    !Array.isArray(snapshot.tasks) ||
+    !Array.isArray(snapshot.workflows) ||
+    typeof snapshot.streamSequence !== 'number'
+  ) {
     throw new Error('refresh-task-graph owner delegation returned an invalid snapshot');
   }
   if (snapshot.invokerHomeRoot && snapshot.invokerHomeRoot !== localInvokerHomeRoot) {
@@ -60,6 +74,7 @@ export async function resolveRefreshTaskGraphSnapshot(
     return {
       tasks: deps.orchestrator.getAllTasks(),
       workflows: deps.persistence.listWorkflows() as WorkflowMeta[],
+      streamSequence: deps.getStreamSequence(),
     };
   };
 
@@ -75,6 +90,7 @@ export async function resolveRefreshTaskGraphSnapshot(
     return {
       tasks: delegated.tasks,
       workflows: delegated.workflows,
+      streamSequence: delegated.streamSequence,
     };
   } catch (err) {
     deps.logger.warn(
@@ -91,5 +107,5 @@ export function publishForcedRefreshTaskGraphSnapshot(
   reason: string,
   snapshot: RefreshTaskGraphSnapshot,
 ): void {
-  publisher.publishSnapshot(reason, snapshot.tasks, snapshot.workflows, true);
+  publisher.publishSnapshot(reason, snapshot.tasks, snapshot.workflows, snapshot.streamSequence, true);
 }

--- a/packages/app/src/task-graph-event-publisher.ts
+++ b/packages/app/src/task-graph-event-publisher.ts
@@ -10,14 +10,19 @@ type SnapshotTaskStates = Extract<TaskGraphEvent, { type: 'snapshot' }>['tasks']
 
 export interface TaskGraphEventPublisher {
   publishDelta(delta: TaskDelta, workflowRollups: readonly WorkflowRollupPatch[]): void;
-  publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[], forced?: boolean): void;
+  publishSnapshot(
+    reason: string,
+    tasks: TaskState[],
+    workflows: WorkflowMeta[],
+    streamSequence: number,
+    forced?: boolean,
+  ): void;
 }
 
 export interface CreateTaskGraphEventPublisherOptions {
   getMainWindow: () => BrowserWindow | null;
   isUiInteractive: () => boolean;
   stampDelta: (delta: TaskDelta) => TaskDelta;
-  getStreamSequence: () => number;
   onLargeBatch?: (stats: { batchSize: number; remaining: number }) => void;
   onEvent?: (event: TaskGraphEvent) => void;
 }
@@ -77,13 +82,19 @@ export function createTaskGraphEventPublisher(
         workflowRollups: [...workflowRollups],
       });
     },
-    publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[], forced?: boolean): void {
+    publishSnapshot(
+      reason: string,
+      tasks: TaskState[],
+      workflows: WorkflowMeta[],
+      streamSequence: number,
+      forced?: boolean,
+    ): void {
       publishEvent({
         type: 'snapshot',
         tasks: tasks as SnapshotTaskStates,
         workflows,
         reason,
-        streamSequence: options.getStreamSequence(),
+        streamSequence,
         ...(forced ? { forced: true } : {}),
       });
     },

--- a/packages/app/src/web/start-web-surface.ts
+++ b/packages/app/src/web/start-web-surface.ts
@@ -168,7 +168,6 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
     getMainWindow: () => null,
     isUiInteractive: () => false,
     stampDelta: (delta) => streamSeq.stamp(delta),
-    getStreamSequence: () => streamSeq.current(),
     onEvent: (event) => bridge?.broadcast('invoker:task-graph-event', event),
   });
 
@@ -182,10 +181,12 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
     deps.orchestrator.syncAllFromDb();
     const tasks = deps.orchestrator.getAllTasks();
     const workflows = deps.persistence.listWorkflows();
+    const streamSequence = streamSeq.current();
     projection.replaceAll(tasks);
     publishForcedRefreshTaskGraphSnapshot(publisher, 'refresh-task-graph', {
       tasks,
       workflows,
+      streamSequence,
     });
   };
 


### PR DESCRIPTION
## Summary

Manual task-graph refresh snapshots now carry the stream sequence captured beside their task data.

That stops older refresh data from being stamped with a newer sequence after an in-flight delta lands.

Delegated owner refresh responses now keep their sequence in the returned snapshot.

The publisher now receives the sequence explicitly, so it no longer re-reads the counter later.

## Review Claim

A refresh snapshot's task data and `streamSequence` are now captured from the same synchronous read point before publishing.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Every caller of `resolveRefreshTaskGraphSnapshot` and `publishSnapshot` is updated in this slice, so the changed call shape builds end to end.

## Slice Rationale

This is one behavior slice because the snapshot shape and every caller must change together. Publishing either side alone would leave broken call sites.

## Non-goals

This does not change the renderer's snapshot watermark logic.

This does not change `owner-read-query.ts`, which already captures and returns the stream sequence.

This does not change delta publishing.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`
- [x] `cd packages/app && pnpm test -- refresh-task-graph`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3377ffe5d34cdadcff48cbc0ed9d4c7e22f92947`
- Post-revert steps: Re-run `pnpm run check:types` and `cd packages/app && pnpm test -- refresh-task-graph`
- Data migration? No

</details>
