### PR TITLE
Bugfix: infra-repair worker recreates a task forever on a persistent missing-worktree failure

### DIFF
--- a/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
@@ -73,7 +73,10 @@ function toRecord(write: WorkerActionWrite): WorkerActionRecord {
   };
 }
 
-function makeHarness(tasksInput: TaskState[] = [makeTask()]) {
+function makeHarness(
+  tasksInput: TaskState[] = [makeTask()],
+  options: { defaultAutoFixRetries?: number } = {},
+) {
   const tasks = new Map(tasksInput.map((task) => [task.id, task]));
   const actions = new Map<string, WorkerActionRecord>();
   const submissions: Array<{ workflowId: string; priority: WorkflowMutationPriority; channel: string; args: unknown[] }> = [];
@@ -127,6 +130,7 @@ function makeHarness(tasksInput: TaskState[] = [makeTask()]) {
       },
     },
     repairCooldownMs: 30 * 60 * 1000,
+    defaultAutoFixRetries: options.defaultAutoFixRetries ?? Number.POSITIVE_INFINITY,
     runRemoteProvisionRepairFn,
     runRepoMirrorRepairFn,
     resolveRemoteBranchOwnerPathFn,
@@ -367,6 +371,31 @@ describe('infra-repair worker', () => {
     expect(h.submit).toHaveBeenCalledTimes(1);
     expect(h.submissions[0]?.channel).toBe(INFRA_REPAIR_RECREATE_TASK_CHANNEL);
     expect(parseInfraRepairRecreateTaskMutationArgs(h.submissions[0]?.args ?? [])).toEqual({ taskId: 'wf-1/task-1' });
+  });
+
+  it('stops recreating a task once the shared auto-fix retry budget is exhausted, instead of looping forever', async () => {
+    const h = makeHarness([
+      makeTask({
+        execution: {
+          error: 'cd ~/.invoker/worktrees/repo/task-1: No such file or directory',
+        },
+      }),
+    ], { defaultAutoFixRetries: 2 });
+    h.resolveRemoteBranchOwnerPathFn.mockResolvedValue(undefined);
+
+    for (let round = 0; round < 5; round += 1) {
+      await h.tick({ ...POLL_CTX, tickNumber: round + 1 });
+      h.tasks.set('wf-1/task-1', makeTask({
+        execution: {
+          error: 'cd ~/.invoker/worktrees/repo/task-1: No such file or directory',
+          generation: 2 + round + 1,
+        },
+        taskStateVersion: 7 + round + 1,
+      }));
+    }
+
+    const recreateSubmissions = h.submissions.filter((s) => s.channel === INFRA_REPAIR_RECREATE_TASK_CHANNEL);
+    expect(recreateSubmissions).toHaveLength(2);
   });
 
   it('recreates invalid branch-reference and no-saved-workspace failures', async () => {

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -10,7 +10,8 @@ import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport'
 import { FailureClassifier } from '@invoker/workflow-core';
 import type { SshInfraFailureClass, TaskState, TaskStateChanges } from '@invoker/workflow-core';
 
-import { isLivenessFailureTask } from '../auto-fix-gating.js';
+import { isLivenessFailureTask, normalizeAutoFixRetryBudget } from '../auto-fix-gating.js';
+import { checkAutoFixRetryCap, recordAutoFixRetryConsumed } from '../auto-fix-retry-cap.js';
 import type { ConflictResolverHost } from '../conflict-resolver.js';
 import {
   resolveRemoteBranchOwnerPath,
@@ -122,6 +123,7 @@ export interface InfraRepairWorkerPolicyOptions {
   ownerInvokerHome: string;
   remoteTargets: Record<string, InfraRepairRemoteTargetConfig>;
   repairCooldownMs?: number;
+  defaultAutoFixRetries?: number;
   now?: () => number;
   drainWakeupHints?: () => RecoveryWorkerWakeupHint[];
   resolveRemoteBranchOwnerPathFn?: typeof resolveRemoteBranchOwnerPath;
@@ -523,6 +525,10 @@ async function runTargetRepairWithCooldown(
   }
 }
 
+function infraRepairRetryBudget(options: Pick<InfraRepairWorkerPolicyOptions, 'defaultAutoFixRetries'>): number {
+  return normalizeAutoFixRetryBudget(options.defaultAutoFixRetries ?? 0);
+}
+
 async function submitFollowUpMutation(
   options: InfraRepairWorkerPolicyOptions,
   candidate: Pick<InfraRepairScanCandidate, 'taskId' | 'workflowId' | 'generation' | 'taskStateVersion'>,
@@ -532,11 +538,21 @@ async function submitFollowUpMutation(
   payload: Record<string, unknown>,
   summary: string,
 ): Promise<void> {
+  const retryCap = checkAutoFixRetryCap(options.store, candidate.taskId, infraRepairRetryBudget(options));
+  if (!retryCap.allowed) {
+    recordTaskDecision(options, candidate, reason, 'skipped',
+      `Skipped infra repair: task ${candidate.taskId} already used its shared auto-fix retry budget (${retryCap.consumed}/${retryCap.budget === Number.POSITIVE_INFINITY ? 'unlimited' : retryCap.budget}) across recreates -- an operator needs to look at this task directly`,
+      { ...payload, consumedRetries: retryCap.consumed },
+      'worker-retry-budget-exhausted');
+    return;
+  }
+
   const intentId = options.submitter.submit(candidate.workflowId, 'normal', channel, args);
   recordTaskDecision(options, candidate, reason, 'completed', summary, {
     channel,
     ...payload,
   }, channel, intentId);
+  recordAutoFixRetryConsumed(options.store, candidate.taskId, { workflowId: candidate.workflowId });
 }
 
 async function handleRemoteProvisionRecovery(
@@ -901,6 +917,7 @@ export function registerInfraRepairWorker(
             ownerInvokerHome: deps.infraRepair.ownerInvokerHome,
             remoteTargets: deps.infraRepair.remoteTargets,
             repairCooldownMs: deps.infraRepair.repairCooldownMs,
+            defaultAutoFixRetries: deps.autoFix?.defaultAutoFixRetries,
           }
           : undefined,
       }),


### PR DESCRIPTION
## Summary

The infra-repair worker recreates a failed SSH task when its remote worktree is missing.

If the underlying problem is persistent, it recreated the same task forever, once per tick, with no limit.

This happened in production on `remote_digital_ocean_1`: one task was recreated dozens of times over 14 hours.

The cause is a dedup key that includes the task's generation and version. Both change every recreate, so the guard never caught a repeat.

This repo already has a shared, generation-independent attempt counter built for this exact failure shape. The infra-repair worker was never wired into it.

This change wires it in, so infra-repair now stops after a configured number of attempts (default 3) and leaves a note for an operator instead of looping.

## Review Claim

`submitFollowUpMutation` in `infra-repair-worker.ts` now checks a shared per-task attempt counter before queuing a follow-up task mutation, and advances that counter afterward, so repeated recovery attempts across task recreates are durably bounded instead of unbounded.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The attempt counter only gates the four existing recovery paths' follow-up queuing point; it does not change failure classification, target selection, or the OAuth-session-expired alert path (which already never acts automatically). When the counter is exhausted, the worker records a decision explaining why instead of silently dropping the failure, so it stays visible via `query worker-decisions`.

## Slice Rationale

This is the minimal fix for one confirmed production incident (an unbounded recreate loop on `remote_digital_ocean_1`). It reuses an existing, already-tested counter (`checkAutoFixRetryCap` / `recordAutoFixRetryConsumed`) rather than inventing a new mechanism.

## Non-goals

Does not change the separate cooldown mechanism used by the env-repair/mirror-repair remote-script paths (`runTargetRepairWithCooldown`), which already works correctly. Does not add a new config knob -- it reuses `deps.autoFix.defaultAutoFixRetries`, the same source the autofix worker already reads from.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- infra-repair-worker.test.ts`
- [x] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b34cf68`
- Post-revert steps: None
- Data migration? No

</details>
