### PR TITLE
[CI regression: required-fast Mergify Admin Requeue](1) Load repro required-check fixtures from .mergify.yml

### DIFF
--- a/scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh
+++ b/scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh
@@ -13,17 +13,15 @@ cat > "$TMP/bin/gh" <<'PY'
 #!/usr/bin/env python3
 import json
 import sys
+from pathlib import Path
+
+sys.path.insert(0, "scripts")
+from mergify_admin_requeue_model import load_mergify_rules
 
 HEAD = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-REQUIRED = [
-    "build-artifacts",
-    "quality / Dependency Cruise",
-    "PR Body",
-    "quality / TypeScript Types",
-    "required-fast / Guardrails",
-    "required-fast / Submit Workflow Chain",
-    "UI Vitest",
-]
+# Loaded from .mergify.yml, not hardcoded: a hardcoded copy silently drifts
+# out of sync whenever the real required-check set changes.
+_, _, REQUIRED = load_mergify_rules(Path(".mergify.yml"))
 REPO = "Neko-Catpital-Labs/Invoker"
 
 

--- a/scripts/repro/repro-mergify-admin-requeue.sh
+++ b/scripts/repro/repro-mergify-admin-requeue.sh
@@ -12,17 +12,17 @@ cat > "$TMP/bin/gh" <<'PY'
 #!/usr/bin/env python3
 import json
 import sys
+from pathlib import Path
+
+sys.path.insert(0, "scripts")
+from mergify_admin_requeue_model import load_mergify_rules
 
 HEAD = "c2532d229dbed2fd57419698c48d973001c78e9e"
-REQUIRED = [
-    "build-artifacts",
-    "quality / Dependency Cruise",
-    "PR Body",
-    "quality / TypeScript Types",
-    "required-fast / Guardrails",
+# Loaded from .mergify.yml, not hardcoded: a hardcoded copy silently drifts
+# out of sync whenever the real required-check set changes.
+_, _, _REQUIRED_FROM_MERGIFY_YML = load_mergify_rules(Path(".mergify.yml"))
+REQUIRED = sorted(_REQUIRED_FROM_MERGIFY_YML | {
     "required-fast / Vitest Workspace",
-    "required-fast / Submit Workflow Chain",
-    "UI Vitest",
     "e2e-proof / aggregate",
     "playwright / 1-of-6",
     "playwright / 2-of-6",
@@ -34,7 +34,7 @@ REQUIRED = [
     "ssh / shard-31",
     "optional / Worktree Provisioning",
     "optional / Visual Proof Validate",
-]
+})
 
 
 def contexts(number):

--- a/scripts/repro/repro-mergify-closed-pr-guard.sh
+++ b/scripts/repro/repro-mergify-closed-pr-guard.sh
@@ -12,16 +12,17 @@ cat > "$TMP/bin/gh" <<'PY'
 #!/usr/bin/env python3
 import json
 import sys
+from pathlib import Path
+
+sys.path.insert(0, "scripts")
+from mergify_admin_requeue_model import load_mergify_rules
 
 HEAD = "1111111111111111111111111111111111111111"
-REQUIRED = [
-    "build-artifacts",
-    "quality / Dependency Cruise",
-    "PR Body",
-    "quality / TypeScript Types",
-    "required-fast / Guardrails",
+# Loaded from .mergify.yml, not hardcoded: a hardcoded copy silently drifts
+# out of sync whenever the real required-check set changes.
+_, _, _REQUIRED_FROM_MERGIFY_YML = load_mergify_rules(Path(".mergify.yml"))
+REQUIRED = sorted(_REQUIRED_FROM_MERGIFY_YML | {
     "required-fast / Vitest Workspace",
-    "required-fast / Submit Workflow Chain",
     "e2e-proof / aggregate",
     "playwright / 1-of-6",
     "playwright / 2-of-6",
@@ -33,7 +34,7 @@ REQUIRED = [
     "ssh / shard-31",
     "optional / Worktree Provisioning",
     "optional / Visual Proof Validate",
-]
+})
 
 
 def pr():

--- a/scripts/repro/repro-mergify-rejected-pr.sh
+++ b/scripts/repro/repro-mergify-rejected-pr.sh
@@ -12,16 +12,17 @@ cat > "$TMP/bin/gh" <<'PY'
 #!/usr/bin/env python3
 import json
 import sys
+from pathlib import Path
+
+sys.path.insert(0, "scripts")
+from mergify_admin_requeue_model import load_mergify_rules
 
 HEAD = "79035e5e42f8eda9f22a68697c241eb459555081"
-REQUIRED = [
-    "build-artifacts",
-    "quality / Dependency Cruise",
-    "PR Body",
-    "quality / TypeScript Types",
-    "required-fast / Guardrails",
+# Loaded from .mergify.yml, not hardcoded: a hardcoded copy silently drifts
+# out of sync whenever the real required-check set changes.
+_, _, _REQUIRED_FROM_MERGIFY_YML = load_mergify_rules(Path(".mergify.yml"))
+REQUIRED = sorted(_REQUIRED_FROM_MERGIFY_YML | {
     "required-fast / Vitest Workspace",
-    "required-fast / Submit Workflow Chain",
     "e2e-proof / aggregate",
     "playwright / 1-of-6",
     "playwright / 2-of-6",
@@ -32,7 +33,7 @@ REQUIRED = [
     "ssh / shard-30",
     "ssh / shard-31",
     "optional / Worktree Provisioning",
-]
+})
 
 
 def pr():


### PR DESCRIPTION
## Summary

`required-fast / Mergify Admin Requeue` has failed on every merge-queue batch since PR #7651 merged. That PR added 4 new required checks to `.mergify.yml`.

Four repro scripts under `scripts/repro/` build a fake `gh` binary to exercise the admin-bypass worker. Each one hand-wrote its own second copy of the required-check names.

Once `.mergify.yml` grew names the second copies didn't know about, PRs that should look fully green in the fixtures instead showed spurious "missing check" blockers. That broke each script's output assertions.

The fix makes each fixture pull its required-check names straight from `.mergify.yml`. It uses the same parser the production worker relies on, so no fixture falls behind again.

A teammate's working theory pinned this on PR #7750 and a `claude` subprocess failure it logs as an ERROR event. That is ruled out below.

## Review Claim

Reviewer confirms these 4 repro fixtures now read their required-check names from `.mergify.yml` instead of a hand-written second copy, so the two can never fall out of step again.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Each fixture's fake `gh` binary now calls `load_mergify_rules(Path(".mergify.yml"))` — the identical function `scripts/mergify_admin_requeue_exec.py` uses at runtime to decide real blockers. Only fixture files change; no production worker behavior is touched.

## Slice Rationale

One mechanical cause (a hand-written second copy of the required-check names) affects all 4 fixtures the same way. Separate PRs would just be four copies of the same one-line diff with nothing distinct to review in each.

## Non-goals

Does not change `.mergify.yml`, the admin-bypass worker's dispatch/retry/ledger behavior, or the `claude` CLI subprocess error handling (already degrades gracefully — see root-cause note below).

## Root cause (for the reviewer)

Confirmed via `git show` on PR #7651 (`[Promote Fast Required Checks]`, merged 2026-08-06T23:45:48Z): it touched only `.mergify.yml`, adding `required-fast / Branch Carry Forward`, `Merge Gate Concurrency Repro`, `Launch Dispatch Queue Repro`, and `Start Running MECE Repros` to the required set. It did not touch any repro fixture.

`scripts/repro/repro-mergify-admin-requeue.sh` and `repro-mergify-admin-requeue-stack-expansion.sh` hardcode a `REQUIRED` check list to build a mocked `statusCheckRollup`. Neither included the 4 new names, so their fixture PRs now show `missing_check` blockers that didn't exist before, breaking each script's `case "$out" in ... esac` assertions (`[repro] missing requeue line`, `[repro] expected stack expansion to nudge ...`) and exiting 1 under `set -euo pipefail`.

Confirmed via the GitHub Actions API: 44+ consecutive `required-fast / Mergify Admin Requeue` job runs on `mergify/merge-queue/*` branches failed (100%) from shortly after PR #7651 merged through the present — a standing merge-queue outage for any batch that exercises this required-fast leg, not limited to one PR's batch.

**Ruled out:** PR #7750 only adds a `logger.error()` print statement (`scripts/mergify_admin_requeue_logger.py`) — no control flow or exit-code change; `run_cycle` still returns a plain bool and `run_once` still returns 0 unless a `RuntimeError` is raised. The `claude` CLI subprocess failures visible in the CI log come from an existing (pre-#7750) unit test in `test_mergify_admin_requeue.py` that deliberately exercises the repair-check dispatch-failure path; all 67 tests in that suite pass (`OK`) — the failure is already caught and logged, never propagated. That log line sits right before the real failure in interleaved stderr output, which is why it looked causal.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-mergify-admin-requeue.sh` — was exit 1 (`[repro] missing requeue line`), now exit 0 (`[repro] passed`)
- [x] `bash scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh` — was exit 1, now exit 0 (`[repro] passed`)
- [x] `bash scripts/repro/repro-mergify-rejected-pr.sh` — exit 0 (unaffected scenario, still passes with the dynamic list)
- [x] `bash scripts/repro/repro-mergify-closed-pr-guard.sh` — exit 0 (unaffected scenario, still passes with the dynamic list)
- [x] `python3 -m unittest scripts/test_mergify_admin_requeue.py` — 67 tests, OK, unaffected by this change
- [x] `bash scripts/test-suites/required/12-mergify-admin-requeue.sh` — the exact CI command; no longer fails at the `repro-mergify-admin-requeue.sh` step

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4478ced70`
- Post-revert steps: None
- Data migration? No

</details>
