### PR TITLE
[Bugfix: Extract dependency-branch-metadata guard into named function](1)[REFACTOR: Extract Method] Combine duplicated branch-metadata checks into one function

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TaskRunner, collectManagedWorkflowBranchesFromDb } from '../task-runner.js';
+import { assertCompletedDependencyHasBranch } from '../task-runner-prepare.js';
 import { collectDirectNonMergeTaskIds } from '../merge-runner.js';
 import { SshExecutor } from '../ssh-executor.js';
 import { WorktreeExecutor } from '../worktree-executor.js';
@@ -1916,6 +1917,42 @@ describe('TaskRunner', () => {
           }),
         }),
       );
+    });
+
+    it('assertCompletedDependencyHasBranch throws when a completed dep has no branch', () => {
+      const dep = makeTask({
+        id: 'dep-a',
+        status: 'completed',
+        config: { runnerKind: 'worktree' },
+      });
+
+      expect(() =>
+        assertCompletedDependencyHasBranch('child-task', 'dependency "dep-a"', dep),
+      ).toThrow('completed without branch metadata');
+    });
+
+    it('assertCompletedDependencyHasBranch does not throw when the dep has a branch', () => {
+      const dep = makeTask({
+        id: 'dep-a',
+        status: 'completed',
+        config: { runnerKind: 'worktree' },
+        execution: { branch: 'experiment/dep-a' },
+      });
+
+      expect(() =>
+        assertCompletedDependencyHasBranch('child-task', 'dependency "dep-a"', dep),
+      ).not.toThrow();
+    });
+
+    it('assertCompletedDependencyHasBranch does not throw when the dep is undefined or not completed', () => {
+      expect(() =>
+        assertCompletedDependencyHasBranch('child-task', 'dependency "dep-a"', undefined),
+      ).not.toThrow();
+
+      const pendingDep = makeTask({ id: 'dep-a', status: 'pending', config: { runnerKind: 'worktree' } });
+      expect(() =>
+        assertCompletedDependencyHasBranch('child-task', 'dependency "dep-a"', pendingDep),
+      ).not.toThrow();
     });
 
     it('fails task when a completed external dependency has no branch metadata', async () => {

--- a/packages/execution-engine/src/task-runner-prepare.ts
+++ b/packages/execution-engine/src/task-runner-prepare.ts
@@ -17,6 +17,24 @@ import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
 import { formatLifecycleTag, extractAttemptSuffix } from './branch-utils.js';
 import type { TaskRunnerPhaseHost } from './task-runner-phase-host.js';
 
+/**
+ * Guard: a completed dependency (local or external) must have branch
+ * metadata. Without it the downstream worktree would run against the bare
+ * base branch, silently dropping all upstream implementation changes.
+ */
+export function assertCompletedDependencyHasBranch(
+  taskId: string,
+  depLabel: string,
+  dep: TaskState | undefined,
+): void {
+  if (dep && dep.status === 'completed' && !dep.execution.branch) {
+    throw new Error(
+      `Task "${taskId}": ${depLabel} completed without branch metadata` +
+      ` — upstream changes would be silently dropped. The plan may need to be restarted.`,
+    );
+  }
+}
+
 export async function buildWorkRequest(
   host: TaskRunnerPhaseHost,
   args: {
@@ -56,21 +74,15 @@ export async function buildWorkRequest(
   if (!task.config.isMergeNode) {
     for (const depId of task.dependencies) {
       const dep = host.orchestrator.getTask(depId);
-      if (dep && dep.status === 'completed' && !dep.execution.branch) {
-        throw new Error(
-          `Task "${task.id}": dependency "${depId}" completed without branch metadata` +
-          ` — upstream changes would be silently dropped. The plan may need to be restarted.`,
-        );
-      }
+      assertCompletedDependencyHasBranch(task.id, `dependency "${depId}"`, dep);
     }
     for (const depRef of task.config.externalDependencies ?? []) {
       const dep = host.resolveExternalDependencyTask(depRef.workflowId, depRef.taskId);
-      if (dep && dep.status === 'completed' && !dep.execution.branch) {
-        throw new Error(
-          `Task "${task.id}": external dependency "${depRef.workflowId}/${depRef.taskId}" completed without branch metadata` +
-          ` — upstream changes would be silently dropped. The plan may need to be restarted.`,
-        );
-      }
+      assertCompletedDependencyHasBranch(
+        task.id,
+        `external dependency "${depRef.workflowId}/${depRef.taskId}"`,
+        dep,
+      );
     }
   }
   bench('dependencyBranchGuard.end');


### PR DESCRIPTION
## Summary

When a completed task dependency has no branch, the downstream worktree would silently run against bare base instead of the dependency's changes.

Two near-identical inline checks already guarded against this, one for local dependencies and one for external dependencies, each throwing the same error shape.

This PR combines both inline checks into one named, exported function, `assertCompletedDependencyHasBranch`, and adds direct unit tests for it.

## Review Claim

Approve that `assertCompletedDependencyHasBranch` throws in exactly the same cases, with exactly the same message text, as the two inline blocks it replaces, and that no other behavior in `buildWorkRequest` changed.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

For every `(taskId, depLabel, dep)` input, the extracted function throws in exactly the same cases and with exactly the same message text as the two inline blocks it replaces; no other behavior in `buildWorkRequest` changes.

## Slice Rationale

One slice: combine the two repeated inline checks into a single named function and add a direct test for it. Nothing else changes.

## Non-goals

No behavior change. This does not touch the `onBranchResolved` early-write path in `task-runner-prepare.ts`, does not change `transitions.ts`, adds no new fields, and includes no doc edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- -t "fails task when a completed worktree dep has no branch"`
- [x] `cd packages/execution-engine && pnpm test -- -t "assertCompletedDependencyHasBranch"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
