### PR TITLE
[Fix headless delete bugs Step 2 - stop false FK crash on racing deletes](1) Document the racing-delete FOREIGN KEY crash mechanism at the Orchestrator layer

### DIFF
--- a/packages/data-store/src/__tests__/delete-workflow-race-fk-crash.test.ts
+++ b/packages/data-store/src/__tests__/delete-workflow-race-fk-crash.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Documents the raw mechanism behind the delete-workflow race fixed in
+ * `preemptWorkflowExecution` (packages/app/src/headless-shared.ts): a second
+ * owner racing a `delete <workflowId>` against a first owner's in-flight
+ * delete of the same workflow can hit a raw FOREIGN KEY constraint error at
+ * the Orchestrator layer.
+ *
+ * `headlessDeleteWorkflow` (packages/app/src/headless-approve-delete.ts)
+ * starts by calling `preemptWorkflowExecution`, which delegates to
+ * `CommandService.cancelWorkflow` -> `Orchestrator.cancelWorkflow` ->
+ * `cancelWorkflowImpl`. That function reads the workflow's tasks from the DB
+ * (`refreshWorkflowFromDb`), then loops over them writing a `task.cancelled`
+ * event per task (`persistence.logEvent`). If another owner process deletes
+ * the workflow (and its tasks) between that read and the event write, the
+ * `events.task_id -> tasks(id)` foreign key rejects the insert with a raw
+ * "FOREIGN KEY constraint failed" error that is not an `OrchestratorError`,
+ * so `CommandService.executeCommand` cannot map it to `WORKFLOW_NOT_FOUND`.
+ *
+ * `Orchestrator.cancelWorkflow` still throws this raw error by design — the
+ * fix lives one layer up, in `preemptWorkflowExecution`, which now checks
+ * for exactly this shape (FK message + workflow confirmed missing) and
+ * treats it as an already-satisfied cancel instead of propagating it. See
+ * `packages/app/src/__tests__/headless-preempt-workflow-race.test.ts` for
+ * the regression test on that guard.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Orchestrator } from '@invoker/workflow-core';
+import type { OrchestratorMessageBus } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+class NoopBus implements OrchestratorMessageBus {
+  publish(): void {}
+  subscribe(): () => void {
+    return () => undefined;
+  }
+}
+
+describe('racing delete of the same workflow across two owners', () => {
+  let adapter: SQLiteAdapter | undefined;
+  let cleanupDir: string | undefined;
+
+  afterEach(() => {
+    adapter?.close();
+    adapter = undefined;
+    if (cleanupDir) {
+      rmSync(cleanupDir, { recursive: true, force: true });
+      cleanupDir = undefined;
+    }
+  });
+
+  it('cancelWorkflow (the first step of headlessDeleteWorkflow) throws a raw FK error when the workflow is deleted mid-flight', async () => {
+    cleanupDir = mkdtempSync(join(tmpdir(), 'invoker-delete-race-fk-'));
+    adapter = await SQLiteAdapter.create(join(cleanupDir, 'invoker.db'), { ownerCapability: true });
+
+    const orchestrator = new Orchestrator({
+      persistence: adapter,
+      messageBus: new NoopBus(),
+      maxConcurrency: 8,
+      resolveRepoDefaultBranch: () => 'main',
+    });
+
+    orchestrator.loadPlan({
+      name: 'race-target',
+      baseBranch: 'master',
+      repoUrl: 'memory://test-repo',
+      featureBranch: 'feature/race-target',
+      tasks: [{ id: 'leaf', description: 'target leaf' }],
+    });
+    const workflowId = orchestrator.getAllTasks()
+      .find((t) => !t.config.isMergeNode)!.config.workflowId!;
+
+    // logEvent is the exact call cancelWorkflowImpl makes per task after it
+    // has already read the (soon to be stale) task list. Simulate the other
+    // owner's delete completing in the gap between that read and this write
+    // by deleting the workflow for real, on the same underlying DB, the
+    // first time cancelWorkflowImpl tries to log a cancellation event.
+    const realLogEvent = adapter.logEvent.bind(adapter);
+    const logEventSpy = vi.spyOn(adapter, 'logEvent');
+    logEventSpy.mockImplementationOnce((...args) => {
+      adapter!.deleteWorkflow(workflowId);
+      return realLogEvent(...args);
+    });
+
+    let caught: unknown;
+    try {
+      orchestrator.cancelWorkflow(workflowId);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).toContain('FOREIGN KEY constraint failed');
+  });
+});


### PR DESCRIPTION
## Summary

A racing `delete <workflowId>` can crash with a raw database error.

The crash starts one layer below the app: `Orchestrator.cancelWorkflow` writes a `task.cancelled` event per task after reading the workflow's tasks from the DB.

If a second owner deletes the same workflow in that gap, the event write hits a foreign key that no longer has a parent task row.

That raw `FOREIGN KEY constraint failed` error is not an `OrchestratorError`, so nothing upstream can recognize it as "already deleted."

This PR adds a test that pins down exactly that mechanism at the Orchestrator layer, before the next slice adds a guard one layer up.

## Review Claim

Approve a new test documenting that `cancelWorkflowImpl` still throws a raw `FOREIGN KEY constraint failed` error when a workflow is deleted mid-cancel by a racing owner.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice adds a test file only; it does not touch product code or change any runtime behavior, so it is safe to review and merge independently of the fix.

## Slice Rationale

The next slice fixes the crash one layer up, in `preemptWorkflowExecution`. Landing this repro first lets the reviewer see the exact failure mode before judging whether the fix's guard condition is correct.

## Non-goals

This PR does not change `cancelWorkflowImpl` or add any guard against the FOREIGN KEY error. The raw error stays intentional at the Orchestrator layer; the guard lands in the next PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/data-store && pnpm test -- delete-workflow-race-fk-crash`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
