### PR TITLE
[Fix headless delete bugs Step 2 - stop false FK crash on racing deletes](2) Make headless delete idempotent against a racing duplicate delete

### DIFF
--- a/packages/app/src/__tests__/headless-preempt-workflow-race.test.ts
+++ b/packages/app/src/__tests__/headless-preempt-workflow-race.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression test for the delete-workflow race described in
+ * packages/data-store/src/__tests__/delete-workflow-race-fk-crash.test.ts:
+ * a second owner's `preemptWorkflowExecution` (the first step of
+ * `headlessDeleteWorkflow`) must not surface a raw FOREIGN KEY error when
+ * the workflow was deleted by another owner between its DB read and its
+ * per-task `task.cancelled` event write.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { preemptWorkflowExecution } from '../headless-shared.js';
+import type { HeadlessDeps } from '../headless.js';
+import type { CommandService } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+
+const noopLogger = {
+  debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  child: vi.fn(function () { return noopLogger; }),
+};
+
+function makeDeps(overrides: {
+  cancelWorkflowError: { code: string; message: string };
+  workflowExists: boolean;
+}): HeadlessDeps {
+  return {
+    logger: noopLogger as any,
+    orchestrator: {} as any,
+    persistence: {
+      loadWorkflow: vi.fn(() => (overrides.workflowExists ? { id: 'wf-1' } : undefined)),
+    } as unknown as SQLiteAdapter,
+    commandService: {
+      cancelWorkflow: vi.fn(async () => ({ ok: false, error: overrides.cancelWorkflowError })),
+    } as unknown as CommandService,
+    executorRegistry: {} as any,
+    messageBus: {} as any,
+    repoRoot: '/fake/repo',
+    invokerConfig: {} as any,
+    initServices: vi.fn(async () => {}),
+  };
+}
+
+describe('preemptWorkflowExecution race with a concurrent delete', () => {
+  it('returns a clean empty result instead of throwing when the workflow is already gone', async () => {
+    const deps = makeDeps({
+      cancelWorkflowError: { code: 'CANCEL_WORKFLOW_FAILED', message: 'FOREIGN KEY constraint failed' },
+      workflowExists: false,
+    });
+
+    const result = await preemptWorkflowExecution('wf-1', deps);
+
+    expect(result).toEqual({ cancelled: [], runningCancelled: [] });
+  });
+
+  it('still throws a FOREIGN KEY error for a workflow that genuinely still exists', async () => {
+    const deps = makeDeps({
+      cancelWorkflowError: { code: 'CANCEL_WORKFLOW_FAILED', message: 'FOREIGN KEY constraint failed' },
+      workflowExists: true,
+    });
+
+    await expect(preemptWorkflowExecution('wf-1', deps)).rejects.toThrow('FOREIGN KEY constraint failed');
+  });
+
+  it('still throws unrelated errors for a missing workflow', async () => {
+    const deps = makeDeps({
+      cancelWorkflowError: { code: 'CANCEL_WORKFLOW_FAILED', message: 'disk I/O error' },
+      workflowExists: false,
+    });
+
+    await expect(preemptWorkflowExecution('wf-1', deps)).rejects.toThrow('disk I/O error');
+  });
+});

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -426,6 +426,17 @@ const preemptSkipCodes: ReadonlySet<string> = new Set([
   OrchestratorErrorCode.WORKFLOW_NOT_FOUND,
 ]);
 
+/**
+ * A racing owner can delete the workflow's tasks between cancelWorkflowImpl's
+ * DB read and its per-task `task.cancelled` event write, tripping the
+ * `events.task_id -> tasks(id)` foreign key. That raw error isn't an
+ * OrchestratorError, so it can't carry a `WORKFLOW_NOT_FOUND` code through
+ * CommandService — check the message text and confirm against persistence.
+ */
+function isRaceLostForeignKeyConstraintFailure(message: string, workflowId: string, deps: HeadlessDeps): boolean {
+  return message.includes('FOREIGN KEY constraint failed') && !deps.persistence.loadWorkflow?.(workflowId);
+}
+
 export async function preemptTaskSubgraph(taskId: string, deps: HeadlessDeps): Promise<void> {
   if (deps.preemptTaskSubgraph) {
     await deps.preemptTaskSubgraph(taskId);
@@ -451,6 +462,9 @@ export async function preemptWorkflowExecution(workflowId: string, deps: Headles
   const result = await deps.commandService.cancelWorkflow(envelope);
   if (!result.ok) {
     if (preemptSkipCodes.has(result.error.code)) return { cancelled: [], runningCancelled: [] };
+    if (isRaceLostForeignKeyConstraintFailure(result.error.message, workflowId, deps)) {
+      return { cancelled: [], runningCancelled: [] };
+    }
     throw new Error(result.error.message);
   }
   return result.data;

--- a/packages/data-store/src/__tests__/delete-workflow-race-fk-crash.test.ts
+++ b/packages/data-store/src/__tests__/delete-workflow-race-fk-crash.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Documents the raw mechanism behind the delete-workflow race fixed in
+ * `preemptWorkflowExecution` (packages/app/src/headless-shared.ts): a second
+ * owner racing a `delete <workflowId>` against a first owner's in-flight
+ * delete of the same workflow can hit a raw FOREIGN KEY constraint error at
+ * the Orchestrator layer.
+ *
+ * `headlessDeleteWorkflow` (packages/app/src/headless-approve-delete.ts)
+ * starts by calling `preemptWorkflowExecution`, which delegates to
+ * `CommandService.cancelWorkflow` -> `Orchestrator.cancelWorkflow` ->
+ * `cancelWorkflowImpl`. That function reads the workflow's tasks from the DB
+ * (`refreshWorkflowFromDb`), then loops over them writing a `task.cancelled`
+ * event per task (`persistence.logEvent`). If another owner process deletes
+ * the workflow (and its tasks) between that read and the event write, the
+ * `events.task_id -> tasks(id)` foreign key rejects the insert with a raw
+ * "FOREIGN KEY constraint failed" error that is not an `OrchestratorError`,
+ * so `CommandService.executeCommand` cannot map it to `WORKFLOW_NOT_FOUND`.
+ *
+ * `Orchestrator.cancelWorkflow` still throws this raw error by design — the
+ * fix lives one layer up, in `preemptWorkflowExecution`, which now checks
+ * for exactly this shape (FK message + workflow confirmed missing) and
+ * treats it as an already-satisfied cancel instead of propagating it. See
+ * `packages/app/src/__tests__/headless-preempt-workflow-race.test.ts` for
+ * the regression test on that guard.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Orchestrator } from '@invoker/workflow-core';
+import type { OrchestratorMessageBus } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+class NoopBus implements OrchestratorMessageBus {
+  publish(): void {}
+  subscribe(): () => void {
+    return () => undefined;
+  }
+}
+
+describe('racing delete of the same workflow across two owners', () => {
+  let adapter: SQLiteAdapter | undefined;
+  let cleanupDir: string | undefined;
+
+  afterEach(() => {
+    adapter?.close();
+    adapter = undefined;
+    if (cleanupDir) {
+      rmSync(cleanupDir, { recursive: true, force: true });
+      cleanupDir = undefined;
+    }
+  });
+
+  it('cancelWorkflow (the first step of headlessDeleteWorkflow) throws a raw FK error when the workflow is deleted mid-flight', async () => {
+    cleanupDir = mkdtempSync(join(tmpdir(), 'invoker-delete-race-fk-'));
+    adapter = await SQLiteAdapter.create(join(cleanupDir, 'invoker.db'), { ownerCapability: true });
+
+    const orchestrator = new Orchestrator({
+      persistence: adapter,
+      messageBus: new NoopBus(),
+      maxConcurrency: 8,
+      resolveRepoDefaultBranch: () => 'main',
+    });
+
+    orchestrator.loadPlan({
+      name: 'race-target',
+      baseBranch: 'master',
+      repoUrl: 'memory://test-repo',
+      featureBranch: 'feature/race-target',
+      tasks: [{ id: 'leaf', description: 'target leaf' }],
+    });
+    const workflowId = orchestrator.getAllTasks()
+      .find((t) => !t.config.isMergeNode)!.config.workflowId!;
+
+    // logEvent is the exact call cancelWorkflowImpl makes per task after it
+    // has already read the (soon to be stale) task list. Simulate the other
+    // owner's delete completing in the gap between that read and this write
+    // by deleting the workflow for real, on the same underlying DB, the
+    // first time cancelWorkflowImpl tries to log a cancellation event.
+    const realLogEvent = adapter.logEvent.bind(adapter);
+    const logEventSpy = vi.spyOn(adapter, 'logEvent');
+    logEventSpy.mockImplementationOnce((...args) => {
+      adapter!.deleteWorkflow(workflowId);
+      return realLogEvent(...args);
+    });
+
+    let caught: unknown;
+    try {
+      orchestrator.cancelWorkflow(workflowId);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).toContain('FOREIGN KEY constraint failed');
+  });
+});


### PR DESCRIPTION
## Summary

A plain `<workflowId>` deletion can crash with a raw database error instead of just succeeding.

The previous PR pinned down why: a racing second owner can trip a `FOREIGN KEY constraint failed` error one layer below the app.

That raw error carries no code, so nothing upstream could tell the difference between "genuinely broken" and "already gone."

`preemptWorkflowExecution` now checks for exactly that error message and confirms the workflow is actually gone before treating it as a clean, already-satisfied result.

Any other error, or a workflow that still exists, still throws as before.

## Review Claim

Approve the guard in `preemptWorkflowExecution` that treats a confirmed-gone workflow's raw `FOREIGN KEY constraint failed` error as an already-satisfied result instead of throwing.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The guard only swallows the error when the message matches the exact FK string and a persistence read confirms the workflow row is gone; every other error path, and the case where the workflow still exists, is unchanged and still throws.

## Slice Rationale

The previous PR documented the raw error at the layer where it originates; this PR is the actual fix, one layer up, where the caller has enough context (a persistence read) to tell a race from a real failure.

## Non-goals

This PR does not change the Orchestrator-layer behavior verified in the prior PR; the raw error there stays intentional. It does not add retries or change any other error path.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- headless-preempt-workflow-race`
- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
