### PR TITLE
[Invariant hardening: auto-approve snapshot revalidation](1)[REFACTOR: Change Function Declaration] Export compareCandidateSnapshot for a direct unit test

### DIFF
--- a/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   collectValidatedAutoApproveCandidates,
+  compareCandidateSnapshot,
   createAutoApproveTick,
   isApproveIntentForTask,
   listAutoApproveScanCandidates,
@@ -194,6 +195,24 @@ describe('autoapprove worker', () => {
       expect(result).toEqual([]);
       expect(writes[0]).toMatchObject({ status: 'skipped', summary: `Skipped AI fix approval: ${reason}` });
     }
+  });
+
+  it('compareCandidateSnapshot detects each staleness reason directly', () => {
+    const cases: Array<[string, TaskState, AutoApproveCandidate]> = [
+      ['stale-workflow', task({ config: { workflowId: 'wf-2' } }), candidate()],
+      ['stale-generation', task({ execution: { generation: 2 } }), candidate()],
+      ['stale-task-state-version', task({ taskStateVersion: 5 }), candidate()],
+      ['stale-attempt', task({ execution: { selectedAttemptId: 'attempt-2' } }), candidate()],
+    ];
+
+    for (const [reason, latest, snapshot] of cases) {
+      expect(compareCandidateSnapshot(snapshot, latest)).toMatchObject({ ok: false, reason });
+    }
+
+    expect(compareCandidateSnapshot(candidate(), task())).toMatchObject({
+      ok: true,
+      ref: { taskId: 'wf-1/task-1', workflowId: 'wf-1', generation: 1, taskStateVersion: 4, attemptId: 'attempt-1' },
+    });
   });
 
   it('dedupes duplicate wakeups for the same snapshot', async () => {

--- a/packages/execution-engine/src/workers/auto-approve-worker.ts
+++ b/packages/execution-engine/src/workers/auto-approve-worker.ts
@@ -198,7 +198,7 @@ function loadLatestTask(
   return options.store.loadTasks(candidate.workflowId).find((task) => task.id === candidate.taskId);
 }
 
-function compareCandidateSnapshot(
+export function compareCandidateSnapshot(
   candidate: AutoApproveCandidate,
   latest: TaskState,
 ): AutoApproveSnapshotComparison {


### PR DESCRIPTION
## Summary

The auto-approve worker re-checks a task's workflow, generation, task-state version, and attempt id right before it approves it. That check already runs correctly today.

This change makes the check itself directly testable. It marks the existing `compareCandidateSnapshot` function as exported, with no change to its logic or its call site.

A new test then imports that function directly. It calls it with synthetic before/after snapshots, one case per staleness reason.

Today those same four cases are only provable indirectly, through the full worker tick.

## Review Claim

`compareCandidateSnapshot` in `packages/execution-engine/src/workers/auto-approve-worker.ts` keeps its exact logic, parameters, and return values; only its module visibility changes from unexported to exported, so it can be imported directly by a unit test. No catalog Fowler technique names a bare visibility change, so none is claimed here beyond "change function declaration" in the loose sense of altering how the function is referenced, not what it does.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

`compareCandidateSnapshot`'s logic, call site, and return values are unchanged; only its module visibility changes from unexported to exported.

## Slice Rationale

One slice: make the existing guard directly importable and add a unit test that calls it directly, nothing else.

## Non-goals

No behavior change. No change to the comparison logic, no new fields, no unrelated cleanup, no doc edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- -t "skips stale workflow, generation, task-state version, and attempt snapshots"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for candidate snapshot comparison, including stale snapshot scenarios and valid snapshot references.
* **Refactor**
  * Made snapshot comparison functionality available for reuse without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->