### PR TITLE
[Invariant hardening: lease stays alive through publishAfterFix](1) Prove publishAfterFix renews the attempt heartbeat lease while running

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -3323,6 +3323,80 @@ describe('TaskRunner', () => {
         }),
       }));
     });
+
+    it('renews selected attempt heartbeat while publishAfterFix is still running', async () => {
+      vi.useFakeTimers();
+      try {
+        const mergeTask = makeTask({
+          id: '__merge__wf-pub',
+          status: 'running',
+          config: { isMergeNode: true, workflowId: 'wf-pub' },
+          execution: {
+            selectedAttemptId: 'pub-attempt-1',
+            generation: 3,
+          },
+        });
+        const setTaskReviewReady = vi.fn();
+        const autoStartExternallyUnblockedReadyTasksMock = vi.fn(() => []);
+        const orchestrator = {
+          getTask: (id: string) => (id === mergeTask.id ? mergeTask : undefined),
+          getAllTasks: () => [mergeTask],
+          setTaskReviewReady,
+          autoStartExternallyUnblockedReadyTasks: autoStartExternallyUnblockedReadyTasksMock,
+        };
+        const updateAttempt = vi.fn();
+        const onHeartbeat = vi.fn();
+        const executor = new TaskRunner({
+          orchestrator: orchestrator as any,
+          persistence: {
+            loadWorkflow: () => ({
+              id: 'wf-pub',
+              onFinish: 'none',
+              mergeMode: 'manual',
+              baseBranch: 'master',
+              featureBranch: undefined,
+              name: 'Workflow',
+            }),
+            updateAttempt,
+            updateTask: vi.fn(),
+          } as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          cwd: '/tmp',
+          callbacks: { onHeartbeat },
+        });
+
+        (executor as any).buildMergeSummary = () => new Promise<string>((resolve) => {
+          setTimeout(() => resolve('summary'), 60_000);
+        });
+
+        const pending = executor.publishAfterFix(mergeTask);
+        await vi.advanceTimersByTimeAsync(30_000);
+
+        expect(updateAttempt).toHaveBeenCalledWith(
+          'pub-attempt-1',
+          expect.objectContaining({
+            lastHeartbeatAt: expect.any(Date),
+            leaseExpiresAt: expect.any(Date),
+          }),
+        );
+        expect(onHeartbeat).toHaveBeenCalled();
+        expect(setTaskReviewReady).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(30_000);
+        await pending;
+
+        expect(setTaskReviewReady).toHaveBeenCalledWith(
+          '__merge__wf-pub',
+          expect.objectContaining({
+            execution: expect.objectContaining({ workspacePath: undefined }),
+          }),
+          expect.objectContaining({ selectedAttemptId: 'pub-attempt-1', generation: 3 }),
+        );
+        expect(autoStartExternallyUnblockedReadyTasksMock).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe('SSH Executor Caching', () => {


### PR DESCRIPTION
## Summary

publishAfterFix already keeps a task's lease alive by renewing its heartbeat while the post-fix publish step runs, exactly like executeMergeNode does.

That guard had no direct test. A regression that dropped it would ship silently.

This PR adds a fake-timer regression test that proves the heartbeat keeps renewing while publishAfterFix is still in flight.

No product code changes. Test-only.

## Review Claim

publishAfterFix already wraps its work in withAttemptHeartbeat exactly like executeMergeNode does; this slice adds a "publishAfterFix heartbeat lease" test mirroring the existing "executeMergeNode heartbeat lease" test, with no product code change.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

publishAfterFix keeps calling withAttemptHeartbeat around publishAfterFixImpl exactly as today; behavior is unchanged.

## Slice Rationale

One proof slice: add the missing heartbeat-lease regression coverage for publishAfterFix specifically, nothing else.

## Non-goals

No refactor of task-runner.ts, no new exported helper, no unrelated cleanup, no doc edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- -t "renews selected attempt heartbeat while publishAfterFix is still running"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
