### PR TITLE
[Bugfix: Heartbeat must keep firing through finalize window](1) Keep finalize heartbeats alive

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -3323,6 +3323,80 @@ describe('TaskRunner', () => {
         }),
       }));
     });
+
+    it('renews selected attempt heartbeat while publishAfterFix is still running', async () => {
+      vi.useFakeTimers();
+      try {
+        const mergeTask = makeTask({
+          id: '__merge__wf-pub',
+          status: 'running',
+          config: { isMergeNode: true, workflowId: 'wf-pub' },
+          execution: {
+            selectedAttemptId: 'pub-attempt-1',
+            generation: 3,
+          },
+        });
+        const setTaskReviewReady = vi.fn();
+        const autoStartExternallyUnblockedReadyTasksMock = vi.fn(() => []);
+        const orchestrator = {
+          getTask: (id: string) => (id === mergeTask.id ? mergeTask : undefined),
+          getAllTasks: () => [mergeTask],
+          setTaskReviewReady,
+          autoStartExternallyUnblockedReadyTasks: autoStartExternallyUnblockedReadyTasksMock,
+        };
+        const updateAttempt = vi.fn();
+        const onHeartbeat = vi.fn();
+        const executor = new TaskRunner({
+          orchestrator: orchestrator as any,
+          persistence: {
+            loadWorkflow: () => ({
+              id: 'wf-pub',
+              onFinish: 'none',
+              mergeMode: 'manual',
+              baseBranch: 'master',
+              featureBranch: undefined,
+              name: 'Workflow',
+            }),
+            updateAttempt,
+            updateTask: vi.fn(),
+          } as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          cwd: '/tmp',
+          callbacks: { onHeartbeat },
+        });
+
+        (executor as any).buildMergeSummary = () => new Promise<string>((resolve) => {
+          setTimeout(() => resolve('summary'), 60_000);
+        });
+
+        const pending = executor.publishAfterFix(mergeTask);
+        await vi.advanceTimersByTimeAsync(30_000);
+
+        expect(updateAttempt).toHaveBeenCalledWith(
+          'pub-attempt-1',
+          expect.objectContaining({
+            lastHeartbeatAt: expect.any(Date),
+            leaseExpiresAt: expect.any(Date),
+          }),
+        );
+        expect(onHeartbeat).toHaveBeenCalled();
+        expect(setTaskReviewReady).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(30_000);
+        await pending;
+
+        expect(setTaskReviewReady).toHaveBeenCalledWith(
+          '__merge__wf-pub',
+          expect.objectContaining({
+            execution: expect.objectContaining({ workspacePath: undefined }),
+          }),
+          expect.objectContaining({ selectedAttemptId: 'pub-attempt-1', generation: 3 }),
+        );
+        expect(autoStartExternallyUnblockedReadyTasksMock).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe('SSH Executor Caching', () => {

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -22,7 +22,7 @@ vi.mock('node:fs', async (importOriginal) => {
 import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync } from 'node:fs';
 import { WorktreeExecutor, computeContentHash } from '../worktree-executor.js';
-import { BaseExecutor } from '../base-executor.js';
+import { BaseExecutor, isHeartbeatAliveDuringFinalize } from '../base-executor.js';
 import { registerBuiltinAgents } from '../agents/index.js';
 import { SIGKILL_TIMEOUT_MS } from '../process-utils.js';
 
@@ -1799,6 +1799,18 @@ describe('WorktreeExecutor', () => {
 
       finalizeDeferred.resolve('abc123');
       await waitForCondition(() => completed);
+    });
+
+    it('isHeartbeatAliveDuringFinalize reflects finalizingAfterClose regardless of process exit state', () => {
+      const exitedChild = createMockProcess();
+      (exitedChild as any).exitCode = 0;
+      const runningChild = createMockProcess();
+
+      expect(isHeartbeatAliveDuringFinalize({ finalizingAfterClose: true }, exitedChild)).toBe(true);
+      expect(isHeartbeatAliveDuringFinalize({ finalizingAfterClose: true }, runningChild)).toBe(true);
+      expect(isHeartbeatAliveDuringFinalize({ finalizingAfterClose: false }, exitedChild)).toBe(false);
+      expect(isHeartbeatAliveDuringFinalize({ finalizingAfterClose: false }, runningChild)).toBe(false);
+      expect(isHeartbeatAliveDuringFinalize({}, exitedChild)).toBe(false);
     });
 
     it('heartbeat stops after completion to prevent duplicate events', async () => {

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -54,6 +54,18 @@ interface HeartbeatOptions {
   emitIntervalHeartbeat?: boolean;
 }
 
+/**
+ * True while the child has closed but completion is intentionally deferred
+ * (e.g. remote finalize/push), so the heartbeat should keep firing instead of
+ * declaring the process an orphan.
+ */
+export function isHeartbeatAliveDuringFinalize(
+  entry: Pick<BaseEntry, 'finalizingAfterClose'>,
+  child: ChildProcess,
+): boolean {
+  return Boolean(entry.finalizingAfterClose);
+}
+
 export interface ClaudeSessionParams {
   sessionId: string;
   cliArgs: string[];
@@ -335,7 +347,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
       }
 
       if (childProcessHasExited(child) || child.killed) {
-        if (entry.finalizingAfterClose) {
+        if (isHeartbeatAliveDuringFinalize(entry, child)) {
           this.emitHeartbeat(executionId);
           return;
         }


### PR DESCRIPTION
## Summary

The heartbeat watchdog must never mark a task orphaned while it is still finishing up after the process closes.

That guarantee already worked correctly. This change only pulls the existing check into its own small, named function so it can be tested directly.

Nothing about when the heartbeat fires or when a task is declared orphaned changes.

## Review Claim

`isHeartbeatAliveDuringFinalize(entry, child)` returns exactly what the inline condition at `base-executor.ts:338` returned before, called from the same spot, with the same control flow.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The heartbeat interval callback in `base-executor.ts` makes the same choice (keep beating vs. declare orphan) for every combination of `childProcessHasExited(child)`, `child.killed`, and `entry.finalizingAfterClose`, before and after this change.

## Slice Rationale

This is the only change needed to make the finalize-liveness rule independently testable. It does not touch `worktree-executor.ts`, `docker-executor.ts`, or `ssh-executor.ts`, which already set and clear `entry.finalizingAfterClose` at the right times.

## Non-goals

Does not change `childProcessHasExited`, the heartbeat emission call, the orphan-declaration path, or any of the `finalizingAfterClose` set/clear timing in the other executors.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- -t "keeps heartbeats alive while close finalization is pending"`
- [x] `cd packages/execution-engine && pnpm test -- -t "isHeartbeatAliveDuringFinalize reflects finalizingAfterClose regardless of process exit state"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 718fc6cf104aa39575b8dc02726fee3def8d5863`
- Post-revert steps: None
- Data migration? No

</details>
