### PR TITLE
[Workflow delete+resubmit UI drift](2a) refresh-snapshot: optional stream-sequence compat shim + main/web callers

### DIFF
--- a/packages/app/src/__tests__/gui-refresh-task-graph.test.ts
+++ b/packages/app/src/__tests__/gui-refresh-task-graph.test.ts
@@ -216,6 +216,7 @@ describe('registerGuiMutationIpcHandlers refresh-task-graph', () => {
       'refresh-task-graph',
       [makeTask('wf-1/task-1')],
       [{ id: 'wf-1', name: 'Workflow 1', status: 'running' }],
+      undefined,
       true,
     );
     expect(recordStartupDuration).toHaveBeenCalledWith('refresh-task-graph.return', expect.any(Number), {
@@ -243,6 +244,7 @@ describe('registerGuiMutationIpcHandlers refresh-task-graph', () => {
       'refresh-task-graph-delegated',
       [localTask],
       [localWorkflow],
+      undefined,
       true,
     );
   });

--- a/packages/app/src/__tests__/refresh-task-graph.test.ts
+++ b/packages/app/src/__tests__/refresh-task-graph.test.ts
@@ -42,12 +42,35 @@ describe('publishForcedRefreshTaskGraphSnapshot', () => {
     publishForcedRefreshTaskGraphSnapshot(publisher, 'refresh-task-graph', {
       tasks: [task],
       workflows: [workflow],
+      streamSequence: 5,
     });
 
     expect(publisher.publishSnapshot).toHaveBeenCalledWith(
       'refresh-task-graph',
       [task],
       [workflow],
+      5,
+      true,
+    );
+  });
+
+  it('passes through an omitted streamSequence so the publisher falls back to its own counter', () => {
+    const publisher = {
+      publishSnapshot: vi.fn(),
+    };
+    const task = makeTask('wf-1/task-1');
+    const workflow = { id: 'wf-1', name: 'Workflow 1', status: 'running' };
+
+    publishForcedRefreshTaskGraphSnapshot(publisher, 'refresh-task-graph', {
+      tasks: [task],
+      workflows: [workflow],
+    });
+
+    expect(publisher.publishSnapshot).toHaveBeenCalledWith(
+      'refresh-task-graph',
+      [task],
+      [workflow],
+      undefined,
       true,
     );
   });
@@ -136,5 +159,32 @@ describe('resolveRefreshTaskGraphSnapshot fallback', () => {
       message: expect.stringContaining('owner home mismatch: owner=/tmp/invoker-remote local=/tmp/invoker-local'),
       meta: { module: 'ipc' },
     });
+  });
+
+  it('captures streamSequence via getStreamSequence at the same synchronous read as tasks/workflows', async () => {
+    const localTask = makeTask('wf-4/task-1');
+    const localWorkflow = { id: 'wf-4', name: 'Local', status: 'running' };
+    const { logger } = makeLogger();
+
+    const result = await resolveRefreshTaskGraphSnapshot({
+      ownerMode: true,
+      messageBus: { async request() { throw new Error('unused in owner mode'); } } as never,
+      resolveInvokerHomeRoot: () => '/tmp/invoker-owner',
+      logger: logger as never,
+      orchestrator: {
+        syncAllFromDb() {},
+        getAllTasks() {
+          return [localTask];
+        },
+      } as never,
+      persistence: {
+        listWorkflows() {
+          return [localWorkflow];
+        },
+      } as never,
+      getStreamSequence: () => 42,
+    });
+
+    expect(result).toEqual({ tasks: [localTask], workflows: [localWorkflow], streamSequence: 42 });
   });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2621,8 +2621,14 @@ startMainProcessBootstrap({
               orchestrator,
               persistence,
               logger,
+              getStreamSequence: getTaskDeltaStreamSequence,
             });
-            taskGraphEventPublisher.publishSnapshot('refresh-task-graph', snapshot.tasks, snapshot.workflows);
+            taskGraphEventPublisher.publishSnapshot(
+              'refresh-task-graph',
+              snapshot.tasks,
+              snapshot.workflows,
+              snapshot.streamSequence,
+            );
           },
           deleteWorkflow: (workflowId) => requireGuiMutationTaskActions().performDeleteWorkflow(workflowId),
           detachWorkflow: (workflowId, upstreamWorkflowId) =>

--- a/packages/app/src/refresh-task-graph.ts
+++ b/packages/app/src/refresh-task-graph.ts
@@ -6,12 +6,14 @@ import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 interface DelegatedRefreshTaskGraphSnapshot {
   tasks: TaskState[];
   workflows: WorkflowMeta[];
+  streamSequence?: number;
   invokerHomeRoot?: string;
 }
 
 export interface RefreshTaskGraphSnapshot {
   tasks: TaskState[];
   workflows: WorkflowMeta[];
+  streamSequence?: number;
 }
 
 export interface ResolveRefreshTaskGraphSnapshotDeps {
@@ -21,9 +23,16 @@ export interface ResolveRefreshTaskGraphSnapshotDeps {
   orchestrator: Pick<Orchestrator, 'syncAllFromDb' | 'getAllTasks'>;
   persistence: Pick<SQLiteAdapter, 'listWorkflows'>;
   logger: Logger;
+  getStreamSequence?: () => number;
 }
 export interface RefreshTaskGraphSnapshotPublisher {
-  publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[], forced?: boolean): void;
+  publishSnapshot(
+    reason: string,
+    tasks: TaskState[],
+    workflows: WorkflowMeta[],
+    streamSequence?: number,
+    forced?: boolean,
+  ): void;
 }
 
 
@@ -38,9 +47,14 @@ function parseDelegatedRefreshTaskGraphSnapshot(
   const snapshot = value as {
     tasks?: unknown[];
     workflows?: unknown[];
+    streamSequence?: unknown;
     invokerHomeRoot?: string;
   };
-  if (!Array.isArray(snapshot.tasks) || !Array.isArray(snapshot.workflows)) {
+  if (
+    !Array.isArray(snapshot.tasks) ||
+    !Array.isArray(snapshot.workflows) ||
+    (snapshot.streamSequence !== undefined && typeof snapshot.streamSequence !== 'number')
+  ) {
     throw new Error('refresh-task-graph owner delegation returned an invalid snapshot');
   }
   if (snapshot.invokerHomeRoot && snapshot.invokerHomeRoot !== localInvokerHomeRoot) {
@@ -60,6 +74,7 @@ export async function resolveRefreshTaskGraphSnapshot(
     return {
       tasks: deps.orchestrator.getAllTasks(),
       workflows: deps.persistence.listWorkflows() as WorkflowMeta[],
+      streamSequence: deps.getStreamSequence?.(),
     };
   };
 
@@ -75,6 +90,7 @@ export async function resolveRefreshTaskGraphSnapshot(
     return {
       tasks: delegated.tasks,
       workflows: delegated.workflows,
+      streamSequence: delegated.streamSequence,
     };
   } catch (err) {
     deps.logger.warn(
@@ -91,5 +107,5 @@ export function publishForcedRefreshTaskGraphSnapshot(
   reason: string,
   snapshot: RefreshTaskGraphSnapshot,
 ): void {
-  publisher.publishSnapshot(reason, snapshot.tasks, snapshot.workflows, true);
+  publisher.publishSnapshot(reason, snapshot.tasks, snapshot.workflows, snapshot.streamSequence, true);
 }

--- a/packages/app/src/task-graph-event-publisher.ts
+++ b/packages/app/src/task-graph-event-publisher.ts
@@ -10,7 +10,13 @@ type SnapshotTaskStates = Extract<TaskGraphEvent, { type: 'snapshot' }>['tasks']
 
 export interface TaskGraphEventPublisher {
   publishDelta(delta: TaskDelta, workflowRollups: readonly WorkflowRollupPatch[]): void;
-  publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[], forced?: boolean): void;
+  publishSnapshot(
+    reason: string,
+    tasks: TaskState[],
+    workflows: WorkflowMeta[],
+    streamSequence?: number,
+    forced?: boolean,
+  ): void;
 }
 
 export interface CreateTaskGraphEventPublisherOptions {
@@ -77,13 +83,19 @@ export function createTaskGraphEventPublisher(
         workflowRollups: [...workflowRollups],
       });
     },
-    publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[], forced?: boolean): void {
+    publishSnapshot(
+      reason: string,
+      tasks: TaskState[],
+      workflows: WorkflowMeta[],
+      streamSequence?: number,
+      forced?: boolean,
+    ): void {
       publishEvent({
         type: 'snapshot',
         tasks: tasks as SnapshotTaskStates,
         workflows,
         reason,
-        streamSequence: options.getStreamSequence(),
+        streamSequence: streamSequence ?? options.getStreamSequence(),
         ...(forced ? { forced: true } : {}),
       });
     },

--- a/packages/app/src/web/start-web-surface.ts
+++ b/packages/app/src/web/start-web-surface.ts
@@ -182,10 +182,12 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
     deps.orchestrator.syncAllFromDb();
     const tasks = deps.orchestrator.getAllTasks();
     const workflows = deps.persistence.listWorkflows();
+    const streamSequence = streamSeq.current();
     projection.replaceAll(tasks);
     publishForcedRefreshTaskGraphSnapshot(publisher, 'refresh-task-graph', {
       tasks,
       workflows,
+      streamSequence,
     });
   };
 


### PR DESCRIPTION
## Summary

The desktop UI can show an out-of-sync task graph after a workflow is torn down and resubmitted. `refresh-task-graph` reads tasks/workflows, then separately re-reads a live stream-sequence counter later, which can have already advanced.

That reread is the underlying bug: two reads of related state, taken at two different times, treated as one atomic snapshot.

This slice adds an optional `streamSequence` to the refresh-snapshot shape. Two routing callers now capture it at the same synchronous read as the task/workflow data.

The parameter falls back to the old counter read when omitted, so any caller not yet touched keeps compiling unchanged.

A later slice wires the remaining caller. A final slice tightens the shape once every caller supplies the value.

## Review Claim

Add an optional, fallback-safe `streamSequence` to `resolveRefreshTaskGraphSnapshot`/`publishSnapshot`, and start passing an atomically-captured value from `main.ts`'s web-dispatch refresh handler and `start-web-surface.ts`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new field is optional everywhere (`getStreamSequence?`, `streamSequence?`) and both `resolveRefreshTaskGraphSnapshot` and `publishSnapshot` fall back to the prior behavior (an unset field, or a live re-read inside the publisher) when it is omitted. `packages/app/src/ipc/gui-mutation-handlers.ts` is not touched in this slice and its existing call sites compile and run unchanged, so this diff cannot regress the IPC refresh path even though that path isn't fixed yet.

## Slice Rationale

`streamSequence` cannot be threaded through every caller as a required parameter in one PR: `packages/app/src/ipc/gui-mutation-handlers.ts` falls under a different CI review-unit bucket than `refresh-task-graph.ts`, `task-graph-event-publisher.ts`, `main.ts`, and `start-web-surface.ts` (all `routing`), and the repo's review-unit-per-PR CI gate blocks a diff that spans two buckets (this is exactly why the original single-PR version of this change, #7953, failed CI). Landing the shape as optional-with-fallback here lets the two routing callers become atomic immediately, ahead of and independent from the IPC-path slice.

## Non-goals

Does not touch `packages/app/src/ipc/gui-mutation-handlers.ts`. Does not make `streamSequence` required — that is a separate, final cleanup slice once every caller passes it.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- refresh-task-graph`
- [ ] `cd packages/app && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Visual Proof

`main.ts` is flagged UI-impacting by path convention, but this specific hunk changes when an internal counter value is captured relative to a data read — it does not add, remove, or restyle anything a screenshot can render. Before and after this change, the desktop task graph and every panel look pixel-identical in any single frame; the only observable difference is a timing race that only shows up as occasional stale data during a delete-then-resubmit sequence, which a static image cannot demonstrate honestly.

The behavior is instead proven by `packages/app/src/__tests__/refresh-task-graph.test.ts`'s `captures streamSequence via getStreamSequence at the same synchronous read as tasks/workflows` test, which asserts the snapshot's `streamSequence` reflects the value read at snapshot time rather than a later, potentially-advanced read.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
