### PR TITLE
[Workflow delete+resubmit UI drift](2b) refresh-snapshot: wire IPC refresh-task-graph to the atomic stream sequence

### DIFF
--- a/packages/app/src/__tests__/gui-refresh-task-graph.test.ts
+++ b/packages/app/src/__tests__/gui-refresh-task-graph.test.ts
@@ -216,7 +216,7 @@ describe('registerGuiMutationIpcHandlers refresh-task-graph', () => {
       'refresh-task-graph',
       [makeTask('wf-1/task-1')],
       [{ id: 'wf-1', name: 'Workflow 1', status: 'running' }],
-      undefined,
+      17,
       true,
     );
     expect(recordStartupDuration).toHaveBeenCalledWith('refresh-task-graph.return', expect.any(Number), {
@@ -244,7 +244,7 @@ describe('registerGuiMutationIpcHandlers refresh-task-graph', () => {
       'refresh-task-graph-delegated',
       [localTask],
       [localWorkflow],
-      undefined,
+      17,
       true,
     );
   });

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1552,6 +1552,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       orchestrator,
       persistence,
       logger,
+      getStreamSequence: getTaskDeltaStreamSequence,
     });
 
     publishForcedRefreshTaskGraphSnapshot(
@@ -1562,7 +1563,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     recordStartupDuration('refresh-task-graph.return', startedAtMs, {
       taskCount: snapshot.tasks.length,
       workflowCount: snapshot.workflows.length,
-      streamSequence: getTaskDeltaStreamSequence(),
+      streamSequence: snapshot.streamSequence,
     });
   });
   registerReadOnlyIpcHandlers({


### PR DESCRIPTION
## Summary

The desktop IPC `refresh-task-graph` handler still has the stream-sequence race the previous slice fixed for the web-dispatch and web-surface paths. It reads tasks/workflows, publishes them, then separately re-reads the live counter for a log line.

This slice wires the same fix into that IPC handler. It passes `getStreamSequence` in and publishes/logs the snapshot's own `streamSequence`, captured at the same synchronous read as the tasks and workflows.

The change is two lines in `gui-mutation-handlers.ts`, made possible by the optional, fallback-safe parameter the previous slice added.

## Review Claim

Wire `packages/app/src/ipc/gui-mutation-handlers.ts`'s `invoker:refresh-task-graph` handler to pass `getStreamSequence` in and read `snapshot.streamSequence` back out, closing the same teardown-and-resubmit UI drift race for the desktop IPC path.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The `streamSequence` field and parameter were already optional and fallback-safe as of the prior slice; this diff only changes what one IPC handler passes in and reads back. The two updated assertions in `gui-refresh-task-graph.test.ts` (expecting `17` instead of `undefined`) plus the unchanged `recordStartupDuration` expectation confirm the new value flows through correctly and nothing else in the handler changed.

## Slice Rationale

`gui-mutation-handlers.ts` falls under a different CI review-unit bucket than the prior slice's files; the review-unit-per-PR CI gate blocks mixing them in one PR. This is the smallest possible diff that finishes wiring the atomic value into the one remaining caller.

## Non-goals

Does not touch `refresh-task-graph.ts`, `task-graph-event-publisher.ts`, `main.ts`, or `start-web-surface.ts`. Does not tighten `streamSequence` back to a required field — that is the next, final cleanup slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- refresh-task-graph`
- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
