### PR TITLE
[Bugfix: PR-maintenance cron children must not inherit standalone mode](1) Export buildPrMaintenanceEnv and add a direct unit test

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
@@ -18,6 +18,7 @@ import {
   PR_DUPLICATE_CLOSE_WORKER_KIND,
   PR_MAINTENANCE_WORKER_STAGGER_STEP_MS,
   PR_ORPHAN_REPAIR_WORKER_KIND,
+  buildPrMaintenanceEnv,
   createPrAdminBypassLandWorker,
   createPrDuplicateCloseWorker,
   createPrOrphanRepairWorker,
@@ -178,6 +179,25 @@ describe('PR maintenance workers', () => {
       `[worker:${PR_ADMIN_BYPASS_LAND_WORKER_KIND}] diagnostic line`,
       expect.objectContaining({ stream: 'stderr' }),
     );
+  });
+
+  it('forces admin-bypass queue children into existing-owner submitter mode', () => {
+    const repoRoot = makeRepoRoot();
+    const originalStandalone = process.env.INVOKER_HEADLESS_STANDALONE;
+    process.env.INVOKER_HEADLESS_STANDALONE = '1';
+    try {
+      const env = buildPrMaintenanceEnv(repoRoot, undefined);
+
+      expect(env.INVOKER_HEADLESS_STANDALONE).toBeUndefined();
+      expect(env.INVOKER_HEADLESS_REQUIRE_EXISTING_OWNER).toBe('1');
+      expect(env.INVOKER_REPO_ROOT).toBe(repoRoot);
+    } finally {
+      if (originalStandalone === undefined) {
+        delete process.env.INVOKER_HEADLESS_STANDALONE;
+      } else {
+        process.env.INVOKER_HEADLESS_STANDALONE = originalStandalone;
+      }
+    }
   });
 
   it('spawns the orphan-repair shell entrypoint', async () => {

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -524,7 +524,7 @@ function resolvePrMaintenanceRepoRoot(repoRoot: string | undefined): string {
   return repoRoot ? resolve(repoRoot) : resolveRepoRoot(process.cwd());
 }
 
-function buildPrMaintenanceEnv(repoRoot: string, overrides: EnvOverrides | undefined): NodeJS.ProcessEnv {
+export function buildPrMaintenanceEnv(repoRoot: string, overrides: EnvOverrides | undefined): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env };
   for (const [key, value] of Object.entries(overrides ?? {})) {
     if (value === undefined) {


### PR DESCRIPTION
## Summary

PR-maintenance cron children already never inherit standalone/owner-launch mode from their parent process. That guard was already correct and already covered by a test.

The guard lived in a module-private function, so it could only be checked indirectly by asserting on a spawned child's environment.

This PR exports the existing `buildPrMaintenanceEnv` function with no change to its body, and adds a direct unit test for it.

A future edit to this function can now be caught by a fast, direct unit test instead of only a slower spawn-assertion test.

## Review Claim

`buildPrMaintenanceEnv` (`packages/execution-engine/src/workers/pr-maintenance-workers.ts:429-441`) changes from module-private to exported, with its body untouched: it still clears `INVOKER_HEADLESS_STANDALONE` and unconditionally forces `INVOKER_HEADLESS_REQUIRE_EXISTING_OWNER='1'`. The call site at line 227 is unchanged.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Every value `buildPrMaintenanceEnv` returns for a given `(repoRoot, options.env)` pair is identical before and after this change; only its visibility (module-private to exported) changes.

## Slice Rationale

One slice: export the existing function and keep its body byte-identical, plus add a direct test. No new fields, no new env-var handling, and no change to any spawn call site other than the pre-existing one at line 227.

## Non-goals

No refactor beyond the export. No new fields. No change to which env vars are deleted or forced. No unrelated cleanup. No doc edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- -t "forces admin-bypass queue children into existing-owner submitter mode"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
