### PR TITLE
[Bugfix: Relayed responses must route to original source keyed by request id](1)[REFACTOR: Extract Method] Extract relay-forwarding decision into a named guard function

### DIFF
--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -11,6 +11,7 @@ import {
   MALFORMED_FRAME_RATE_LIMIT_MS,
   resolveDefaultSocketPath,
   isServeRecoveryEligible,
+  shouldForwardRelayedErrorResponse,
   type MalformedFrameEvent,
 } from '../ipc-bus.js';
 import { TransportError, TransportErrorCode } from '../transport-error.js';
@@ -389,6 +390,23 @@ describe('IpcBus', () => {
 
     const result = await requester.request<number, number>('delayed-double', 5);
     expect(result).toBe(10);
+  });
+
+  describe('shouldForwardRelayedErrorResponse', () => {
+    it('does not forward a NO_HANDLER response while other peers are still awaited', () => {
+      expect(shouldForwardRelayedErrorResponse(true, 2)).toBe(false);
+      expect(shouldForwardRelayedErrorResponse(true, 1)).toBe(false);
+    });
+
+    it('forwards once the last peer has responded with NO_HANDLER', () => {
+      expect(shouldForwardRelayedErrorResponse(true, 0)).toBe(true);
+    });
+
+    it('forwards a non-NO_HANDLER error immediately, regardless of peers still awaited', () => {
+      expect(shouldForwardRelayedErrorResponse(false, 2)).toBe(true);
+      expect(shouldForwardRelayedErrorResponse(false, 1)).toBe(true);
+      expect(shouldForwardRelayedErrorResponse(false, 0)).toBe(true);
+    });
   });
 
   // ---------------------------------------------------------------

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -229,6 +229,22 @@ export const SUBSCRIBER_ERROR_RATE_LIMIT_MS = 1_000;
 // Default socket path
 // ---------------------------------------------------------------------------
 
+/**
+ * Decides whether a relayed error response should be forwarded to the
+ * original requester (and its relay bookkeeping cleared), given that the
+ * responding peer has already been removed from the awaiting set.
+ *
+ * Forward once the error isn't NO_HANDLER (some other, more specific error
+ * should reach the requester immediately) or once no peers remain awaited
+ * (NO_HANDLER from everyone means the request truly has no handler).
+ */
+export function shouldForwardRelayedErrorResponse(
+  isNoHandlerError: boolean,
+  remainingAwaitingCount: number,
+): boolean {
+  return !isNoHandlerError || remainingAwaitingCount === 0;
+}
+
 export function resolveDefaultSocketPath(): string {
   return resolveInvokerIpcSocketPath();
 }
@@ -651,7 +667,7 @@ export class IpcBus implements MessageBus {
 
     relay.awaiting.delete(source);
     const noHandlerError = env.code === TransportErrorCode.NO_HANDLER;
-    if (!noHandlerError || relay.awaiting.size === 0) {
+    if (shouldForwardRelayedErrorResponse(noHandlerError, relay.awaiting.size)) {
       this.relayedRequests.delete(env.reqId);
       this.sendToSocket(relay.source, env);
     }


### PR DESCRIPTION
## Summary

Relayed IPC responses already reached the original requester correctly, keyed by request id, even when several peers were queried.

This change does not touch that behavior. It pulls the existing forward/no-forward decision out of `handleRelayedResponse` into a small, named, exported function.

The new function is directly unit-tested. Before this, the decision could only be exercised through a full multi-socket relay integration test.

## Review Claim

`shouldForwardRelayedErrorResponse(isNoHandlerError, remainingAwaitingCount)` in `packages/transport/src/ipc-bus.ts` is byte-identical in behavior to the inline condition it replaces at the same call site inside `handleRelayedResponse`, and is now covered by a direct unit test in `packages/transport/src/__tests__/ipc-bus.test.ts`.

## Review Lane

refactor

## Review Unit

ownership-refactor

## Safety Invariant

For every `(relay.awaiting` state, responding peer, NO_HANDLER vs. success`)` combination, `handleRelayedResponse` forwards to `relay.source` and clears the `relayedRequests` entry under exactly the same conditions before and after this extraction. `relay.awaiting.delete(source)`, the `relayedRequests.get` lookup, and the `sendToSocket` call are unchanged; only the inline condition was replaced with a call to the new function.

## Slice Rationale

One slice: extract the existing forward/no-forward decision into a named, exported function at its current call site. No new checks, no change to `handleResponse`'s `pendingRequests` handling, and no change to the `relayedRequests` map structure.

## Non-goals

No behavior change. No change to `handleResponse`'s `pendingRequests`-first check. No change to relay bookkeeping (`relayedRequests`, `relay.awaiting`). No unrelated cleanup or doc edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/transport && pnpm test -- -t "ignores no-handler responses from other peers when one peer can satisfy the request"`
- [ ] `cd packages/transport && pnpm test -- -t "shouldForwardRelayedErrorResponse"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
