### PR TITLE
Repro: worktree provisioning fails a task for a repo with no package.json

### DIFF
--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -383,6 +383,49 @@ describe('WorktreeExecutor', () => {
 
     taskProcess.emit('close', 0, null);
   });
+  it('BUG: fails the whole task when the provision command fails only because the repo has no package.json', async () => {
+    // Repro for a production incident: a pool's provisionCommand (e.g. this
+    // repo's own local-mac/local-fallback `pnpm install --frozen-lockfile`)
+    // is configured per pool, not per repoUrl. When a workflow targets a
+    // repoUrl that isn't a Node/pnpm project, pnpm reports
+    // ERR_PNPM_NO_PKG_MANIFEST and today that hard-fails the task even
+    // though there was never anything for this command to install here.
+    // This test currently documents that buggy behavior (task.start()
+    // rejects); a follow-up slice flips this assertion once the executor
+    // treats a missing package.json as "this command doesn't apply" instead
+    // of a fatal provisioning error.
+    setupSpawnMock();
+    const baseImpl = mockedSpawn.getMockImplementation();
+    const provisionProcess = createMockProcess();
+    mockedSpawn.mockImplementation((cmd: string, args?: readonly string[], options?: { signal?: AbortSignal }) => {
+      if (cmd === '/bin/bash' && (args as string[] | undefined)?.[1] === 'pnpm install --frozen-lockfile') {
+        return provisionProcess;
+      }
+      return baseImpl!(cmd, args, options);
+    });
+
+    const provisionedExecutor = new WorktreeExecutor({
+      cacheDir: '/fake/cache',
+      worktreeBaseDir: '/fake/worktrees',
+      provisionCommand: 'pnpm install --frozen-lockfile',
+    });
+    mockPool(provisionedExecutor);
+
+    const startPromise = provisionedExecutor.start(makeRequest());
+    await vi.waitFor(() => {
+      expect(mockedSpawn.mock.calls.find(
+        ([cmd, args]) => cmd === '/bin/bash' && (args as string[] | undefined)?.[1] === 'pnpm install --frozen-lockfile',
+      )).toBeDefined();
+    });
+
+    (provisionProcess.stdout as EventEmitter).emit(
+      'data',
+      'ERR_PNPM_NO_PKG_MANIFEST  No package.json found in /fake/worktrees/checkout\n',
+    );
+    provisionProcess.emit('close', 1, null);
+
+    await expect(startPromise).rejects.toThrow('ERR_PNPM_NO_PKG_MANIFEST');
+  });
   it('times out hung provision commands and terminates their process group', async () => {
     vi.useFakeTimers();
     const previousTimeout = process.env.INVOKER_EXECUTOR_START_TIMEOUT_MS;


### PR DESCRIPTION
## Summary

A local task's worktree provisioning fails when the target repo has no `package.json`.

The task's pool has an install step configured for it, usually `pnpm install --frozen-lockfile`. That step is set per pool, not per repo.

A workflow can target any `repoUrl`. When that repo isn't a Node project, pnpm reports `ERR_PNPM_NO_PKG_MANIFEST` and the whole task fails to start.

This happened in production. One task targeting a non-Node repo was recreated 48 times over a week. Every attempt failed the same way.

This slice adds a test that pins today's behavior: the task never starts. It stays green as committed.

## Review Claim

`WorktreeExecutor.start()` fails when the checked-out repo has no `package.json`, even though there was nothing for the install step to do.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds a test. It makes no product change and cannot alter runtime behavior.

## Slice Rationale

Proof lands before the fix so a reviewer sees the bug demonstrated before approving the change that addresses it.

## Non-goals

Does not change `spawnLocalProvisioningProcess` or any other executor behavior. The next slice in this stack does that.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- -t "BUG: fails the whole task when the provision command fails only because the repo has no package.json"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f00e3ce26`
- Post-revert steps: None
- Data migration? No

</details>