### PR TITLE
Bugfix: map provisionCommand to repoUrl instead of guessing per pool

### DIFF
--- a/packages/execution-engine/src/__tests__/repo-provision-commands-e2e.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-provision-commands-e2e.test.ts
@@ -1,0 +1,144 @@
+/**
+ * End-to-end test: repoProvisionCommands against a real git repo.
+ *
+ * Proves the repoUrl -> provision command mapping works against a real
+ * `file://` repo checkout (real git clone/worktree, no mocked
+ * child_process), not just the mocked-spawn unit tests in
+ * worktree-executor.test.ts.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execSync } from 'node:child_process';
+import type { WorkRequest, WorkResponse } from '@invoker/contracts';
+import { WorktreeExecutor } from '../worktree-executor.js';
+
+function git(cwd: string, args: string): string {
+  return execSync(`git ${args}`, { cwd, stdio: ['ignore', 'pipe', 'pipe'] }).toString().trim();
+}
+
+async function runToCompletion(
+  executor: WorktreeExecutor,
+  request: WorkRequest,
+): Promise<WorkResponse> {
+  const handle = await executor.start(request);
+  return new Promise((resolve) => {
+    executor.onComplete(handle, (response) => resolve(response));
+  });
+}
+
+describe('repoProvisionCommands (real git, no mocked spawn)', { timeout: 30_000 }, () => {
+  let root: string;
+
+  afterEach(() => {
+    if (root) rmSync(root, { recursive: true, force: true });
+  });
+
+  it('runs the repo-specific command against a real non-Node repo instead of the pool default', async () => {
+    root = mkdtempSync(join(tmpdir(), 'repo-provision-e2e-'));
+
+    // A repo with no package.json, mirroring a non-Node target repoUrl
+    // (e.g. a data-only repo) — the pool default `pnpm install
+    // --frozen-lockfile` would fail against this checkout every time.
+    const bare = join(root, 'bare.git');
+    execSync(`git init --bare -b master ${bare}`);
+    const seed = join(root, 'seed');
+    execSync(`git clone ${bare} ${seed}`);
+    git(seed, 'config user.email "test@test.com"');
+    git(seed, 'config user.name "Test"');
+    writeFileSync(join(seed, 'README.md'), 'not a node project\n');
+    git(seed, 'add -A');
+    git(seed, 'commit -m "seed"');
+    git(seed, 'push origin master');
+
+    const repoUrl = `file://${bare}`;
+    const markerRelPath = 'provision-ran.txt';
+
+    const executor = new WorktreeExecutor({
+      cacheDir: join(root, 'cache'),
+      worktreeBaseDir: join(root, 'worktrees'),
+      // Pool default: would fail immediately (ERR_PNPM_NO_PKG_MANIFEST) if
+      // it were the command that actually ran for this repoUrl.
+      provisionCommand: 'pnpm install --frozen-lockfile',
+      repoProvisionCommands: {
+        [repoUrl]: `echo real-provisioning-ran > ${markerRelPath}`,
+      },
+    });
+
+    const request: WorkRequest = {
+      requestId: 'req-e2e-1',
+      actionId: 'e2e-repo-provision-command',
+      actionType: 'command',
+      inputs: {
+        command: `test -f ${markerRelPath}`,
+        repoUrl,
+        baseBranch: 'master',
+      },
+      callbackUrl: 'http://localhost:0/callback',
+      timestamps: { createdAt: new Date().toISOString() },
+    };
+
+    const response = await runToCompletion(executor, request);
+
+    // The task command (`test -f provision-ran.txt`) only exits 0 if the
+    // repo-specific override actually ran and wrote the marker file --
+    // the pool default (`pnpm install --frozen-lockfile`) would have
+    // failed outright against this non-Node repo before the task command
+    // ever got a chance to run.
+    expect(response.status).toBe('completed');
+    expect(response.outputs.exitCode).toBe(0);
+
+    const commitHash = response.outputs.commitHash;
+    if (!commitHash) throw new Error('expected a commitHash on the completed response');
+    const markerContent = execSync(`git --git-dir="${bare}" show ${commitHash}:${markerRelPath}`).toString().trim();
+    expect(markerContent).toBe('real-provisioning-ran');
+
+    await executor.destroyAll();
+  });
+
+  it('still fails with the pool default when the repo has no repoProvisionCommands entry', async () => {
+    root = mkdtempSync(join(tmpdir(), 'repo-provision-e2e-noop-'));
+
+    const bare = join(root, 'bare.git');
+    execSync(`git init --bare -b master ${bare}`);
+    const seed = join(root, 'seed');
+    execSync(`git clone ${bare} ${seed}`);
+    git(seed, 'config user.email "test@test.com"');
+    git(seed, 'config user.name "Test"');
+    writeFileSync(join(seed, 'README.md'), 'not a node project\n');
+    git(seed, 'add -A');
+    git(seed, 'commit -m "seed"');
+    git(seed, 'push origin master');
+
+    const repoUrl = `file://${bare}`;
+
+    const executor = new WorktreeExecutor({
+      cacheDir: join(root, 'cache'),
+      worktreeBaseDir: join(root, 'worktrees'),
+      // Deterministically-failing stand-in for a pool default that doesn't
+      // apply to this repo (real production case: `pnpm install
+      // --frozen-lockfile` against a repo with no package.json).
+      provisionCommand: 'test -f this-file-does-not-exist',
+      // No repoProvisionCommands entry for repoUrl -- unmapped repos keep
+      // today's behavior on purpose, by design (see the previous slice).
+    });
+
+    const request: WorkRequest = {
+      requestId: 'req-e2e-2',
+      actionId: 'e2e-repo-provision-command-unmapped',
+      actionType: 'command',
+      inputs: {
+        command: 'echo should-never-run',
+        repoUrl,
+        baseBranch: 'master',
+      },
+      callbackUrl: 'http://localhost:0/callback',
+      timestamps: { createdAt: new Date().toISOString() },
+    };
+
+    await expect(executor.start(request)).rejects.toThrow(/Worktree provisioning failed/);
+
+    await executor.destroyAll();
+  });
+});

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -426,6 +426,69 @@ describe('WorktreeExecutor', () => {
 
     await expect(startPromise).rejects.toThrow('ERR_PNPM_NO_PKG_MANIFEST');
   });
+  it('uses the repo-specific provision command instead of the pool default when repoUrl has an override', async () => {
+    const { taskProcess } = setupSpawnMock();
+    const baseImpl = mockedSpawn.getMockImplementation();
+    const provisionProcess = createMockProcess();
+    mockedSpawn.mockImplementation((cmd: string, args?: readonly string[], options?: { signal?: AbortSignal }) => {
+      if (cmd === '/bin/bash' && (args as string[] | undefined)?.[1] === 'echo repo-specific-install') {
+        return provisionProcess;
+      }
+      return baseImpl!(cmd, args, options);
+    });
+
+    const provisionedExecutor = new WorktreeExecutor({
+      cacheDir: '/fake/cache',
+      worktreeBaseDir: '/fake/worktrees',
+      provisionCommand: 'pnpm install --frozen-lockfile',
+      repoProvisionCommands: {
+        // Deliberately not byte-identical to the request's repoUrl
+        // (https:// form vs. the request's git@ form, trailing .git) to
+        // prove lookup normalization, not just an exact string match.
+        'https://github.com/test/repo.git': 'echo repo-specific-install',
+      },
+    });
+    mockPool(provisionedExecutor);
+
+    const startPromise = provisionedExecutor.start(makeRequest());
+    await vi.waitFor(() => {
+      expect(mockedSpawn.mock.calls.find(
+        ([cmd, args]) => cmd === '/bin/bash' && (args as string[] | undefined)?.[1] === 'echo repo-specific-install',
+      )).toBeDefined();
+    });
+
+    expect(mockedSpawn.mock.calls.find(
+      ([cmd, args]) => cmd === '/bin/bash' && (args as string[] | undefined)?.[1] === 'pnpm install --frozen-lockfile',
+    )).toBeUndefined();
+
+    provisionProcess.emit('close', 0, null);
+    await startPromise;
+
+    taskProcess.emit('close', 0, null);
+  });
+  it('skips provisioning when repoProvisionCommands maps the repo to an empty command', async () => {
+    const { taskProcess } = setupSpawnMock();
+
+    const provisionedExecutor = new WorktreeExecutor({
+      cacheDir: '/fake/cache',
+      worktreeBaseDir: '/fake/worktrees',
+      provisionCommand: 'pnpm install --frozen-lockfile',
+      repoProvisionCommands: {
+        'git@github.com:test/repo.git': '',
+      },
+    });
+    mockPool(provisionedExecutor);
+
+    await provisionedExecutor.start(makeRequest());
+
+    expect(mockedSpawn.mock.calls.find(
+      ([cmd, args]) => cmd === '/bin/bash' && (args as string[] | undefined)?.[1] === 'pnpm install --frozen-lockfile',
+    )).toBeUndefined();
+    const taskCall = mockedSpawn.mock.calls.find(([cmd]) => cmd !== 'git');
+    expect(taskCall).toBeDefined();
+
+    taskProcess.emit('close', 0, null);
+  });
   it('times out hung provision commands and terminates their process group', async () => {
     vi.useFakeTimers();
     const previousTimeout = process.env.INVOKER_EXECUTOR_START_TIMEOUT_MS;

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -22,7 +22,7 @@ vi.mock('node:fs', async (importOriginal) => {
 import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync } from 'node:fs';
 import { WorktreeExecutor, computeContentHash } from '../worktree-executor.js';
-import { BaseExecutor, isHeartbeatAliveDuringFinalize } from '../base-executor.js';
+import { BaseExecutor, isHeartbeatAliveDuringFinalize, normalizeRepoUrlForProvisionLookup } from '../base-executor.js';
 import { registerBuiltinAgents } from '../agents/index.js';
 import { SIGKILL_TIMEOUT_MS } from '../process-utils.js';
 
@@ -199,6 +199,17 @@ describe('computeContentHash (re-exported by worktree-executor)', () => {
     const a = computeContentHash('t1', 'cmd', undefined, [], 'HEAD1');
     const b = computeContentHash('t1', 'cmd', undefined, [], 'HEAD1');
     expect(a).toBe(b);
+  });
+});
+
+describe('normalizeRepoUrlForProvisionLookup', () => {
+  it.each([
+    'git@github.com:test/repo.git',
+    'https://github.com/test/repo.git',
+    'https://github.com/test/repo.git/',
+    'ssh://git@github.com/test/repo.git',
+  ])('canonicalizes %s', (repoUrl) => {
+    expect(normalizeRepoUrlForProvisionLookup(repoUrl)).toBe('github.com/test/repo');
   });
 });
 
@@ -451,6 +462,46 @@ describe('WorktreeExecutor', () => {
     mockPool(provisionedExecutor);
 
     const startPromise = provisionedExecutor.start(makeRequest());
+    await vi.waitFor(() => {
+      expect(mockedSpawn.mock.calls.find(
+        ([cmd, args]) => cmd === '/bin/bash' && (args as string[] | undefined)?.[1] === 'echo repo-specific-install',
+      )).toBeDefined();
+    });
+
+    expect(mockedSpawn.mock.calls.find(
+      ([cmd, args]) => cmd === '/bin/bash' && (args as string[] | undefined)?.[1] === 'pnpm install --frozen-lockfile',
+    )).toBeUndefined();
+
+    provisionProcess.emit('close', 0, null);
+    await startPromise;
+
+    taskProcess.emit('close', 0, null);
+  });
+  it.each([
+    ['https repoUrl with trailing slash after .git', 'https://github.com/test/repo.git/'],
+    ['ssh URI repoUrl with git user', 'ssh://git@github.com/test/repo.git'],
+  ])('uses the repo-specific provision command for %s', async (_name, repoUrl) => {
+    const { taskProcess } = setupSpawnMock();
+    const baseImpl = mockedSpawn.getMockImplementation();
+    const provisionProcess = createMockProcess();
+    mockedSpawn.mockImplementation((cmd: string, args?: readonly string[], options?: { signal?: AbortSignal }) => {
+      if (cmd === '/bin/bash' && (args as string[] | undefined)?.[1] === 'echo repo-specific-install') {
+        return provisionProcess;
+      }
+      return baseImpl!(cmd, args, options);
+    });
+
+    const provisionedExecutor = new WorktreeExecutor({
+      cacheDir: '/fake/cache',
+      worktreeBaseDir: '/fake/worktrees',
+      provisionCommand: 'pnpm install --frozen-lockfile',
+      repoProvisionCommands: {
+        'git@github.com:test/repo.git': 'echo repo-specific-install',
+      },
+    });
+    mockPool(provisionedExecutor);
+
+    const startPromise = provisionedExecutor.start(makeRequest({ inputs: { repoUrl } }));
     await vi.waitFor(() => {
       expect(mockedSpawn.mock.calls.find(
         ([cmd, args]) => cmd === '/bin/bash' && (args as string[] | undefined)?.[1] === 'echo repo-specific-install',

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -29,12 +29,24 @@ const PROVISION_OUTPUT_TAIL_CHAR_LIMIT = 32_000;
  * the same config entry.
  */
 export function normalizeRepoUrlForProvisionLookup(repoUrl: string): string {
-  const trimmed = repoUrl.trim().toLowerCase();
-  const sshMatch = /^git@([^:]+):(.+)$/.exec(trimmed);
-  const withoutScheme = sshMatch
-    ? `${sshMatch[1]}/${sshMatch[2]}`
-    : trimmed.replace(/^[a-z][a-z0-9+.-]*:\/\//, '');
-  return withoutScheme.replace(/\.git$/, '').replace(/\/+$/, '');
+  let normalized = repoUrl.trim().toLowerCase();
+  const schemeSeparatorIndex = normalized.indexOf('://');
+  if (schemeSeparatorIndex >= 0) {
+    normalized = normalized.slice(schemeSeparatorIndex + '://'.length);
+  }
+  if (normalized.startsWith('git@')) {
+    const withoutGitUser = normalized.slice('git@'.length);
+    const scpPathSeparatorIndex = withoutGitUser.indexOf(':');
+    normalized = scpPathSeparatorIndex >= 0
+      ? `${withoutGitUser.slice(0, scpPathSeparatorIndex)}/${withoutGitUser.slice(scpPathSeparatorIndex + 1)}`
+      : withoutGitUser;
+  }
+  let endIndex = normalized.length;
+  while (endIndex > 0 && normalized[endIndex - 1] === '/') {
+    endIndex -= 1;
+  }
+  normalized = normalized.slice(0, endIndex);
+  return normalized.endsWith('.git') ? normalized.slice(0, -4) : normalized;
 }
 
 export interface BaseEntry {

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -22,6 +22,21 @@ const DEFAULT_GIT_NETWORK_TIMEOUT_MS = 15 * 60 * 1000;
 const PROVISION_OUTPUT_TAIL_LINE_LIMIT = 50;
 const PROVISION_OUTPUT_TAIL_CHAR_LIMIT = 32_000;
 
+/**
+ * Canonicalizes a repoUrl for `repoProvisionCommands` lookups so
+ * `git@github.com:org/repo.git`, `https://github.com/org/repo.git`, and
+ * `https://github.com/org/repo` (any trailing slash, any case) all resolve to
+ * the same config entry.
+ */
+export function normalizeRepoUrlForProvisionLookup(repoUrl: string): string {
+  const trimmed = repoUrl.trim().toLowerCase();
+  const sshMatch = /^git@([^:]+):(.+)$/.exec(trimmed);
+  const withoutScheme = sshMatch
+    ? `${sshMatch[1]}/${sshMatch[2]}`
+    : trimmed.replace(/^[a-z][a-z0-9+.-]*:\/\//, '');
+  return withoutScheme.replace(/\.git$/, '').replace(/\/+$/, '');
+}
+
 export interface BaseEntry {
   request: WorkRequest;
   outputListeners: Set<(data: string) => void>;
@@ -125,6 +140,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
   protected maxBufferChunks: number;
   protected maxBufferBytes: number;
   protected provisionCommand = '';
+  private repoProvisionCommands: Record<string, string> = {};
   private readonly localProvisioningTimeoutsMs = new Map<string, number>();
 
   constructor(
@@ -141,6 +157,32 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
   protected setProvisionCommand(command: string | undefined, fallback: string): void {
     const trimmed = command?.trim();
     this.provisionCommand = trimmed ? trimmed : fallback;
+  }
+
+  /**
+   * `repoUrl` keys are normalized with {@link normalizeRepoUrlForProvisionLookup}
+   * so config authors don't need to match the exact string form a workflow's
+   * `repoUrl` happens to use.
+   */
+  protected setRepoProvisionCommands(commands: Record<string, string> | undefined): void {
+    this.repoProvisionCommands = {};
+    for (const [repoUrl, command] of Object.entries(commands ?? {})) {
+      this.repoProvisionCommands[normalizeRepoUrlForProvisionLookup(repoUrl)] = command;
+    }
+  }
+
+  /**
+   * A pool's `provisionCommand` (e.g. `pnpm install --frozen-lockfile`) is
+   * tuned for the repo the pool was set up for, not for whatever `repoUrl` a
+   * given task happens to check out. `repoProvisionCommands` lets config map
+   * a specific repo to its own command (including an explicit empty string
+   * for repos that need no install step at all), taking priority over the
+   * pool's default when the task's `repoUrl` has an entry.
+   */
+  protected resolveProvisionCommand(repoUrl: string | undefined): string {
+    if (!repoUrl) return this.provisionCommand;
+    const override = this.repoProvisionCommands[normalizeRepoUrlForProvisionLookup(repoUrl)];
+    return override !== undefined ? override : this.provisionCommand;
   }
 
   protected setLocalProvisioningTimeout(executionId: string, timeoutMs: number): void {

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -105,6 +105,7 @@ export type TaskRunnerPoolHost = Pick<
   | 'runnerInstanceId'
   | 'getRemoteTargets'
   | 'getWorktreeTargets'
+  | 'getRepoProvisionCommands'
   | 'getExecutionPools'
   | 'resolveExecutionAgent'
   | 'resolveExecutionModel'
@@ -697,9 +698,11 @@ export function selectExecutor(
           `entry exists in worktreeTargets config. Available: [${Object.keys(worktreeTargets).join(', ')}]`,
         );
       }
+      const repoProvisionCommands = host.getRepoProvisionCommands();
       const configFingerprint = JSON.stringify({
         ...(selectedWorktreeTarget ?? {}),
         provisionCommand: selectedWorktreeTarget?.provisionCommand?.trim() || '',
+        repoProvisionCommands,
         worktreeBaseDir: resolve(invokerHome, 'worktrees'),
         cacheDir: resolve(invokerHome, 'repos'),
       });
@@ -715,6 +718,7 @@ export function selectExecutor(
         maxWorktrees: host.maxWorktreesPerRepo,
         agentRegistry: host.executionAgentRegistry,
         provisionCommand: selectedWorktreeTarget?.provisionCommand,
+        repoProvisionCommands,
       });
       host.executorRegistry.register('worktree', worktree);
       host.worktreeExecutorCache.set(configFingerprint, worktree);

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -199,6 +199,7 @@ export interface TaskRunnerConfig {
     provisionCommand?: string;
     maxConcurrentTasks?: number;
   }>;
+  repoProvisionCommandsProvider?: () => Record<string, string>;
   executionPoolsProvider?: () => Record<string, {
     members: Array<
       | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
@@ -268,6 +269,7 @@ export class TaskRunner {
 
   /** @internal */ getRemoteTargets: () => Record<string, RemoteTargetDisplay>;
   /** @internal */ getWorktreeTargets: () => Record<string, WorktreeTargetDisplay>;
+  /** @internal */ getRepoProvisionCommands: () => Record<string, string>;
   /** @internal */ getExecutionPools: () => Record<string, ExecutionPoolConfig>;
   private getExecutionDefaults: () => { executionAgent?: string; executionModel?: string };
   /** @internal */ dockerConfig: { imageName?: string; secretsFile?: string };
@@ -373,6 +375,7 @@ export class TaskRunner {
     this.reviewGateMergeConflictPublisher = config.reviewGateMergeConflictPublisher;
     this.getRemoteTargets = config.remoteTargetsProvider ?? (() => ({}));
     this.getWorktreeTargets = config.worktreeTargetsProvider ?? (() => ({}));
+    this.getRepoProvisionCommands = config.repoProvisionCommandsProvider ?? (() => ({}));
     this.getExecutionPools = config.executionPoolsProvider ?? (() => ({}));
     this.getExecutionDefaults = config.executionDefaultsProvider ?? (() => ({}));
     this.dockerConfig = config.dockerConfig ?? {};

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -40,6 +40,13 @@ export interface WorktreeExecutorConfig {
   agentRegistry?: import('./agent-registry.js').AgentRegistry;
   /** Optional dependency/bootstrap command run before the task command in local worktrees. */
   provisionCommand?: string;
+  /**
+   * Per-repo override for `provisionCommand`, keyed by `repoUrl` (normalized —
+   * see `normalizeRepoUrlForProvisionLookup`). A workflow whose `repoUrl` has
+   * an entry here uses that command (including `''` to run no install step)
+   * instead of the pool's default `provisionCommand`.
+   */
+  repoProvisionCommands?: Record<string, string>;
   /** Heartbeat interval in milliseconds. Default: 30000. */
   heartbeatIntervalMs?: number;
   /** Maximum task duration in milliseconds. Default: 4 hours. */
@@ -82,6 +89,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     this.claudeCommand = config.claudeCommand ?? 'claude';
     this.agentRegistry = config.agentRegistry;
     this.setProvisionCommand(config.provisionCommand, DEFAULT_WORKTREE_PROVISION_COMMAND);
+    this.setRepoProvisionCommands(config.repoProvisionCommands);
     this.worktreeBaseDir =
       config.worktreeBaseDir ?? resolve(homedir(), '.invoker', 'worktrees');
     this.pool = new RepoPool({
@@ -407,6 +415,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     const provisioning = this.provisionWorktree(
       acquired.worktreePath,
       executionId,
+      this.resolveProvisionCommand(repoUrl),
     );
     entry.process = provisioning.child;
     try {
@@ -710,10 +719,11 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
 
   private provisionWorktree(
     dir: string,
-    executionId?: string,
+    executionId: string | undefined,
+    command: string,
   ): { child: ChildProcess | null; completion: Promise<void> } {
     return this.spawnLocalProvisioningProcess({
-      command: this.provisionCommand,
+      command,
       cwd: dir,
       executionId,
       traceLabel: 'WorktreeExecutor.provisionWorktree',


### PR DESCRIPTION
## Summary

A pool's install step, usually `pnpm install --frozen-lockfile`, is set once per pool.

It runs for every `repoUrl` a task in that pool happens to check out, whether or not the step is right for that particular repo.

`WorktreeExecutor` now accepts `repoProvisionCommands`, a map from `repoUrl` to the step that actually applies to it.

Matching is normalized, so `git@github.com:org/name.git` and `https://github.com/org/name` both hit the same entry.

A `repoUrl` with an entry uses it instead of the pool's default, including an empty entry to run no install step at all.

A `repoUrl` with no entry keeps today's behavior exactly as it is: same pool default, same failure if that default doesn't fit.

An end-to-end test proves both directions against a real git repo — no mocked `child_process`.

A mapped repo runs its own step and the task completes; the same repo with no entry still fails through the pool default.

## Review Claim

`WorktreeExecutor` resolves its install step per task from a new `repoProvisionCommands` map keyed by `repoUrl`, falling back to the pool default only when the task's repo has no entry.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

With no `repoProvisionCommands` entries configured (today's state for every pool), every task resolves to the exact same pool default it does today. Behavior only changes for a `repoUrl` an operator explicitly adds an entry for.

## Slice Rationale

This is the capability on its own: a caller can already pass `repoProvisionCommands` directly to `WorktreeExecutor`. Reading it from `~/.invoker/config.json` is the next two slices, kept separate because they touch a different reviewed unit (the field definition, then app wiring).

## Non-goals

Does not add any config source for `repoProvisionCommands` yet — the next two slices do that. Does not touch `SshExecutor`, which has its own repo-agnostic bootstrap script.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- repo-provision-commands-e2e.test.ts` (real git, no mocked spawn — proves both the mapped and unmapped case against an actual repo)
- [x] `cd packages/execution-engine && pnpm test -- -t "uses the repo-specific provision command instead of the pool default when repoUrl has an override"`
- [x] `cd packages/execution-engine && pnpm test -- -t "skips provisioning when repoProvisionCommands maps the repo to an empty command"`
- [x] `cd packages/execution-engine && pnpm test -- worktree-executor.test.ts`
- [x] `cd packages/execution-engine && pnpm test` (full package suite)
- [x] `pnpm --filter @invoker/execution-engine build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3024b81fa`
- Post-revert steps: None
- Data migration? No

</details>
