### PR TITLE
Add repoProvisionCommands to InvokerConfig schema

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -302,6 +302,14 @@ export interface InvokerConfig {
     maxConcurrentTasks?: number;
   }>;
   /**
+   * Per-repo override for local worktree targets' `provisionCommand`, keyed
+   * by `repoUrl` (any `git@`/`https://`/`.git` form — normalized before
+   * matching). A workflow whose `repoUrl` has an entry here uses that
+   * command instead of its worktree target's default, including `''` to run
+   * no install step at all for a repo that isn't a Node project.
+   */
+  repoProvisionCommands?: Record<string, string>;
+  /**
    * Named execution pools used by routing rules.
    * Pools provide shared queue + drain semantics with per-member capacity limits.
    */


### PR DESCRIPTION
## Summary

The previous slice added `repoProvisionCommands` support to `WorktreeExecutor` directly.

There was no way yet for an operator to set it from `~/.invoker/config.json`.

This slice adds the field to `InvokerConfig`: a map from `repoUrl` to the install step that repo actually needs.

An operator can now add an entry for a specific repo without touching any pool-wide setting.

## Review Claim

`InvokerConfig` gains a `repoProvisionCommands` field, documented the same way its neighboring `worktreeTargets` field already is.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Adds one optional field to an existing interface. Nothing reads it yet, so no runtime behavior changes in this slice.

## Slice Rationale

Kept separate from the capability it configures (a different reviewed unit) and from the piece that actually reads it into a running process (the next slice).

## Non-goals

Does not wire this field into any provider yet — the next slice does that. Does not change `worktreeTargets` or any other existing field.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1105aeb9b`
- Post-revert steps: None
- Data migration? No

</details>
