### PR TITLE
Wire repoProvisionCommands from config into TaskRunner

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -302,6 +302,14 @@ export interface InvokerConfig {
     maxConcurrentTasks?: number;
   }>;
   /**
+   * Per-repo override for local worktree targets' `provisionCommand`, keyed
+   * by `repoUrl` (any `git@`/`https://`/`.git` form — normalized before
+   * matching). A workflow whose `repoUrl` has an entry here uses that
+   * command instead of its worktree target's default, including `''` to run
+   * no install step at all for a repo that isn't a Node project.
+   */
+  repoProvisionCommands?: Record<string, string>;
+  /**
    * Named execution pools used by routing rules.
    * Pools provide shared queue + drain semantics with per-member capacity limits.
    */

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -173,6 +173,7 @@ export function createHeadlessExecutor(
     },
     remoteTargetsProvider: () => loadConfig().remoteTargets ?? {},
     worktreeTargetsProvider: () => loadConfig().worktreeTargets ?? {},
+    repoProvisionCommandsProvider: () => loadConfig().repoProvisionCommands ?? {},
     executionPoolsProvider: () => deps.invokerConfig.executionPools ?? {},
     reviewGateCiFailurePublisher: {
       publish: (trigger) => {


### PR DESCRIPTION
## Summary

The previous slice added the `repoProvisionCommands` field to `InvokerConfig`, but nothing read it yet.

This slice adds `repoProvisionCommandsProvider` to the runtime service composition.

It reads `InvokerConfig.repoProvisionCommands` the same way the existing `worktreeTargetsProvider` reads `worktreeTargets`.

An operator's entry in `~/.invoker/config.json` now reaches the running worktree pool.

## Review Claim

The runtime service composition now supplies `repoProvisionCommandsProvider`, so `TaskRunner` can resolve a live `repoProvisionCommands` map instead of always getting the default empty one.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

With an empty (or absent) `repoProvisionCommands` in an operator's config, this provider returns `{}`, the exact default `TaskRunner` already falls back to. Behavior only changes once an operator adds an entry.

## Slice Rationale

The last slice in this stack's capability chain: config field, executor support, and this provider each land as their own reviewed unit.

## Non-goals

Does not add any default entries to anyone's `~/.invoker/config.json` — that is a separate, config-only action for whoever wants to use this for a specific repo.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 02720d5c6`
- Post-revert steps: None
- Data migration? No

</details>
