### PR TITLE
Fix abandoned external dependency deadlock

### DIFF
--- a/packages/workflow-core/src/__tests__/cross-workflow-cascade-command-service-e2e.test.ts
+++ b/packages/workflow-core/src/__tests__/cross-workflow-cascade-command-service-e2e.test.ts
@@ -21,7 +21,7 @@ function buildOrchestratorDeps(orchestrator: Orchestrator): InvalidationDeps {
           orchestrator.cancelTask(id);
           return;
         }
-        orchestrator.cancelWorkflow(id);
+        orchestrator.cancelWorkflow(id, { detachDependents: false });
       } catch (e) {
         const code = (e as { code?: string })?.code;
         if (code === 'TASK_ALREADY_TERMINAL' || code === 'WORKFLOW_ALREADY_TERMINAL') return;

--- a/packages/workflow-core/src/__tests__/cross-workflow-cascade.test.ts
+++ b/packages/workflow-core/src/__tests__/cross-workflow-cascade.test.ts
@@ -21,7 +21,7 @@ function buildOrchestratorDeps(orchestrator: Orchestrator): InvalidationDeps {
           orchestrator.cancelTask(id);
           return;
         }
-        orchestrator.cancelWorkflow(id);
+        orchestrator.cancelWorkflow(id, { detachDependents: false });
       } catch (e) {
         // Already-terminal targets have nothing to cancel; the rest
         // of the pipeline still runs.

--- a/packages/workflow-core/src/__tests__/helpers/cross-workflow-cascade-helpers.ts
+++ b/packages/workflow-core/src/__tests__/helpers/cross-workflow-cascade-helpers.ts
@@ -131,6 +131,7 @@ export function makeOrchestrator(persistence: OrchestratorPersistence): Orchestr
     persistence,
     messageBus: new InMemoryBus(),
     maxConcurrency: 8,
+    resolveRepoDefaultBranch: () => 'master',
   });
 }
 

--- a/packages/workflow-core/src/__tests__/repro-permanent-external-dependency-deadlock.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-permanent-external-dependency-deadlock.test.ts
@@ -20,7 +20,7 @@ function buildOrchestratorDeps(orchestrator: Orchestrator): InvalidationDeps {
           orchestrator.cancelTask(id);
           return;
         }
-        orchestrator.cancelWorkflow(id);
+        orchestrator.cancelWorkflow(id, { detachDependents: false });
       } catch (e) {
         const code = (e as { code?: string })?.code;
         if (code === 'TASK_ALREADY_TERMINAL' || code === 'WORKFLOW_ALREADY_TERMINAL') return;
@@ -55,7 +55,7 @@ function buildOrchestratorDeps(orchestrator: Orchestrator): InvalidationDeps {
 // externalDependencies gate. The only thing that ever unblocked them was an
 // unrelated manual `detachWorkflow` call two days later.
 describe('REPRO: an invalidated-and-abandoned upstream permanently deadlocks its downstream', () => {
-  it('cascadeInvalidationToDownstream resets downstream to pending but never clears its externalDependencies gate, so a downstream task with free capacity and no other blockers never becomes ready again once its upstream stops progressing', async () => {
+  it('detaches downstream from an invalidated upstream when that upstream is cancelled and abandoned', async () => {
     const persistence = new InMemoryPersistence();
     const orchestrator = makeOrchestrator(persistence);
     const deps = buildOrchestratorDeps(orchestrator);
@@ -68,34 +68,44 @@ describe('REPRO: an invalidated-and-abandoned upstream permanently deadlocks its
     expect(orchestrator.getTask(ctx.upstreamMergeId)!.status).toBe('pending');
     expect(orchestrator.getTask(ctx.downstreamRootId)!.status).toBe('pending');
 
-    // The upstream workflow is now abandoned for good — exactly what
-    // happened to wf-1785491638881-15 (superseded by other work, never
-    // going to be retried to completion again). Nothing else in the
-    // orchestrator ever revisits downstream's stale dependency pointer.
-    orchestrator.cancelWorkflow(ctx.upstreamWfId);
-
-    // BUG: downstream root sits `pending` with zero task-level blockers and
-    // free scheduler capacity (maxConcurrency: 8, nothing else running in
-    // this orchestrator instance) — yet it can never be selected, forever,
-    // because getExecutableReadyTasks -> getExternalDependencyBlocker only
-    // clears once the upstream's status equals the required 'completed',
-    // which a cancelled workflow will never reach again. This loop
-    // reproduces the exact "start-ready dispatches everything else, skips
-    // this one, forever" symptom observed in production logs.
     for (let i = 0; i < 5; i += 1) {
       const ready = orchestrator.getExecutableReadyTasks().map((t) => t.id);
-      expect(ready, `poll ${i}: downstream root must still be blocked`).not.toContain(ctx.downstreamRootId);
+      expect(ready, `poll ${i}: downstream root must still be blocked while upstream can rerun`)
+        .not.toContain(ctx.downstreamRootId);
     }
-    expect(orchestrator.getTask(ctx.downstreamRootId)!.status).toBe('pending');
 
-    // Proves the mechanism: nothing in cascadeInvalidationToDownstream ever
-    // clears the workflow-level externalDependencies pointer, so it's the
-    // one thing standing between "pending forever" and "ready". The real
-    // fix (detachWorkflow) does exactly this clear, plus a default-branch
-    // git lookup this in-memory test has no remote for — asserted directly
-    // here to isolate the actual blocking mechanism from that unrelated I/O.
-    persistence.updateWorkflow(ctx.downstreamWfId, { externalDependencies: undefined });
+    // The upstream workflow is now abandoned for good — exactly what
+    // happened to wf-1785491638881-15 (superseded by other work, never
+    // going to be retried to completion again).
+    orchestrator.cancelWorkflow(ctx.upstreamWfId);
+
+    expect(persistence.loadWorkflow(ctx.downstreamWfId)!.externalDependencies).toBeUndefined();
     expect(orchestrator.getExecutableReadyTasks().map((t) => t.id))
       .toContain(ctx.downstreamRootId);
+  });
+
+  it('keeps a genuinely-still-invalid upstream gate blocking its downstream', async () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const deps = buildOrchestratorDeps(orchestrator);
+    const ctx = setupChain(orchestrator);
+
+    await applyInvalidation('workflow', 'recreateWorkflow', ctx.upstreamWfId, deps);
+    expect(orchestrator.getTask(ctx.upstreamMergeId)!.status).toBe('pending');
+    expect(orchestrator.getTask(ctx.downstreamRootId)!.status).toBe('pending');
+
+    for (let i = 0; i < 5; i += 1) {
+      const ready = orchestrator.getExecutableReadyTasks().map((t) => t.id);
+      expect(ready, `poll ${i}: downstream root must still be blocked by invalid upstream`)
+        .not.toContain(ctx.downstreamRootId);
+    }
+    expect(persistence.loadWorkflow(ctx.downstreamWfId)!.externalDependencies).toEqual([
+      {
+        workflowId: ctx.upstreamWfId,
+        taskId: '__merge__',
+        requiredStatus: 'completed',
+        gatePolicy: 'completed',
+      },
+    ]);
   });
 });

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -446,10 +446,10 @@ export async function applyInvalidation(
 // `Orchestrator` class (which imports `applyInvalidation` from here).
 export interface InvalidationDepsOrchestrator {
   cancelTask(taskId: string): { runningCancelled: string[] };
-  cancelWorkflow(workflowId: string): { runningCancelled: string[] };
+  cancelWorkflow(workflowId: string, opts?: { detachDependents?: boolean }): { runningCancelled: string[] };
   /** Deferred-invalidation variant of cancelTask: skips releasing resource leases/abandoning dispatch rows so the caller can kill the real process first. */
   cancelTaskAwaitingKill?(taskId: string): { runningCancelled: string[]; toCancelIds: string[] };
-  cancelWorkflowAwaitingKill?(workflowId: string): { runningCancelled: string[]; toCancelIds: string[] };
+  cancelWorkflowAwaitingKill?(workflowId: string, opts?: { detachDependents?: boolean }): { runningCancelled: string[]; toCancelIds: string[] };
   /** Performs the deferred invalidation skipped above, once every running task has been killed. */
   finalizeCancelInvalidation?(toCancelIds: readonly string[], reason: string): void;
   retryTask(taskId: string): TaskState[];
@@ -586,7 +586,7 @@ export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlig
       try {
         result = scope === 'task'
           ? deps.orchestrator.cancelTaskAwaitingKill!(id)
-          : deps.orchestrator.cancelWorkflowAwaitingKill!(id);
+          : deps.orchestrator.cancelWorkflowAwaitingKill!(id, { detachDependents: false });
       } catch (e) {
         const code = (e as { code?: string })?.code;
         if (code && TERMINAL_CANCEL_ERROR_CODES.has(code)) return;
@@ -606,7 +606,7 @@ export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlig
     try {
       result = scope === 'task'
         ? deps.orchestrator.cancelTask(id)
-        : deps.orchestrator.cancelWorkflow(id);
+        : deps.orchestrator.cancelWorkflow(id, { detachDependents: false });
     } catch (e) {
       const code = (e as { code?: string })?.code;
       if (code && TERMINAL_CANCEL_ERROR_CODES.has(code)) return;

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2418,7 +2418,7 @@ export class Orchestrator {
       throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `forkWorkflow: workflow ${workflowId} not found (no tasks)`);
     }
 
-    this.cancelWorkflow(workflowId);
+    this.cancelWorkflow(workflowId, { detachDependents: false });
 
     this.refreshWorkflowFromDb(workflowId);
     const settledSourceTasks = this.stateMachine
@@ -3175,8 +3175,37 @@ export class Orchestrator {
    * Cancel all active tasks in a workflow.
    * Terminal tasks (completed/stale) are preserved as-is.
    */
-  cancelWorkflow(workflowId: string): { cancelled: string[]; runningCancelled: string[] } {
-    return cancelWorkflowImpl(this as unknown as CancellationHost, workflowId);
+  cancelWorkflow(
+    workflowId: string,
+    opts: { detachDependents?: boolean } = {},
+  ): { cancelled: string[]; runningCancelled: string[] } {
+    const detachDependents = opts.detachDependents ?? true;
+    if (!detachDependents) {
+      return cancelWorkflowImpl(this as unknown as CancellationHost, workflowId);
+    }
+
+    this.syncAllFromDb();
+    const directDependents = this.collectDirectDependentWorkflowIds(workflowId);
+    const workflowMetadata = this.persistence.listWorkflows();
+    const directDependentBaseBranches = new Map<string, string>();
+    for (const dependentWorkflowId of directDependents) {
+      const dependentWorkflow = this.persistence.loadWorkflow?.(dependentWorkflowId)
+        ?? workflowMetadata.find((candidate) => candidate.id === dependentWorkflowId);
+      directDependentBaseBranches.set(
+        dependentWorkflowId,
+        this.resolveDetachDefaultBranch(dependentWorkflowId, dependentWorkflow),
+      );
+    }
+
+    const result = cancelWorkflowImpl(this as unknown as CancellationHost, workflowId);
+    for (const dependentWorkflowId of directDependents) {
+      this.detachWorkflowInternal(
+        dependentWorkflowId,
+        workflowId,
+        directDependentBaseBranches.get(dependentWorkflowId)!,
+      );
+    }
+    return result;
   }
 
   /**
@@ -3193,7 +3222,9 @@ export class Orchestrator {
   /** Deferred-invalidation counterpart to `cancelWorkflow` -- see `cancelTaskAwaitingKill`. */
   cancelWorkflowAwaitingKill(
     workflowId: string,
+    opts: { detachDependents?: boolean } = {},
   ): { cancelled: string[]; runningCancelled: string[]; toCancelIds: string[] } {
+    void opts;
     return cancelWorkflowImpl(this as unknown as CancellationHost, workflowId, { deferInvalidation: true });
   }
 


### PR DESCRIPTION
## Summary

Standalone workflow cancellation now detaches direct downstream workflows from that abandoned upstream.

Invalidation still keeps downstream workflows gated while the upstream is pending and expected to rerun.

The repro now proves both halves: abandonment unblocks, and a still-invalid upstream still blocks.

## Review Claim

Approve that workflow cancellation removes stale downstream external-dependency gates without weakening invalidation-time dependency readiness.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The scheduler external-dependency gate remains unchanged and still runs for every ready-task launch check.

Only standalone workflow cancellation detaches dependents. Invalidation cancel-first paths and fork cancellation explicitly opt out.

## Slice Rationale

This slice fixes the deadlock at the workflow dependency lifecycle boundary where abandonment is decided.

It avoids changing scheduler readiness semantics, which would broaden the blast radius for cross-workflow execution ordering.

## Non-goals

This does not change gate-policy satisfaction rules.

This does not change cascade invalidation reset semantics.

This does not change task-level local dependency readiness.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --dir packages/workflow-core exec vitest run src/__tests__/repro-permanent-external-dependency-deadlock.test.ts src/__tests__/cross-workflow-cascade.test.ts src/__tests__/cross-workflow-cascade-command-service-e2e.test.ts src/__tests__/invalidation-policy.test.ts src/__tests__/cancel-task.test.ts`
- [x] `pnpm run check:types`
- [x] `pnpm --dir packages/workflow-core exec vitest run`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 96b4b0999`
- Post-revert steps: None
- Data migration? No

</details>
