### PR TITLE
[CI regression: 1e207ca-required-fast-reset-rulebook-repro](1) Scope reset rulebook repro to one workflow

### DIFF
--- a/scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh
+++ b/scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh
@@ -131,7 +131,7 @@ fi
 
 echo "==> case 2.16: recreate-all --follow and observe first 5s"
 RECREATE_START_EPOCH="$(date +%s)"
-bash scripts/recreate-all.sh --follow >/tmp/e2e-2.16-recreate.log 2>&1 &
+bash scripts/recreate-all.sh --workflow "$WF_ID" --follow >/tmp/e2e-2.16-recreate.log 2>&1 &
 RECREATE_PID=$!
 recreate_snapshot_has_reset_state=0
 for i in 0 1 2 3 4 5; do

--- a/scripts/recreate-all.sh
+++ b/scripts/recreate-all.sh
@@ -5,6 +5,7 @@
 #
 # Usage:
 #   bash scripts/recreate-all.sh                       # all workflows
+#   bash scripts/recreate-all.sh --workflow wf-123-1   # one workflow
 #   bash scripts/recreate-all.sh --status running      # only running workflows
 #   bash scripts/recreate-all.sh --status failed       # only failed workflows
 #   bash scripts/recreate-all.sh --dry-run             # show what would run
@@ -21,6 +22,7 @@ source "$(dirname "$0")/headless-lib.sh"
 
 DRY_RUN=false
 STATUS_FILTER=""
+WORKFLOW_FILTER=""
 PARALLELISM=""
 FOLLOW=false
 DEFAULT_PARALLELISM=4
@@ -29,11 +31,17 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run) DRY_RUN=true; shift ;;
     --follow) FOLLOW=true; shift ;;
+    --workflow) WORKFLOW_FILTER="$2"; shift 2 ;;
     --status) STATUS_FILTER="$2"; shift 2 ;;
     --parallel) PARALLELISM="$2"; shift 2 ;;
     *) echo "Unknown arg: $1"; exit 1 ;;
   esac
 done
+
+if [[ -n "$WORKFLOW_FILTER" ]] && ! [[ "$WORKFLOW_FILTER" =~ ^wf-[0-9]+-[0-9]+$ ]]; then
+  echo "Invalid --workflow value: $WORKFLOW_FILTER" >&2
+  exit 1
+fi
 
 if [[ -n "$PARALLELISM" ]] && ! [[ "$PARALLELISM" =~ ^[1-9][0-9]*$ ]]; then
   echo "Invalid --parallel value: $PARALLELISM (expected integer >= 1)" >&2
@@ -49,7 +57,11 @@ if [[ -n "$STATUS_FILTER" ]]; then
   QUERY_ARGS+=(--status "$STATUS_FILTER")
 fi
 
-WORKFLOWS=$(headless_workflow_ids "${QUERY_ARGS[@]}")
+if [[ -n "$WORKFLOW_FILTER" ]]; then
+  WORKFLOWS="$WORKFLOW_FILTER"
+else
+  WORKFLOWS=$(headless_workflow_ids "${QUERY_ARGS[@]}")
+fi
 
 if [[ -z "$WORKFLOWS" ]]; then
   echo "No workflows found."


### PR DESCRIPTION
## Summary

Teach `scripts/recreate-all.sh` to accept one explicit workflow id when a repro needs a scoped relaunch.

Use that scoped relaunch in case 2.16 so the five-second reset-window observation is not polluted by unrelated workflow state.

## Review Claim

Approve the targeted `recreate-all --workflow` path and its use by the retry-vs-recreate dry-run case.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The default `recreate-all` behavior still enumerates every matching workflow when `--workflow` is omitted.

The changed dry-run case passes the workflow id it created, so the repro remains local to one workflow.

## Slice Rationale

This slice keeps the helper option and the only repro consumer together because the repro is the reason the helper needs a scoped mode.

## Non-goals

This does not change Invoker workflow execution semantics.

This does not change retry, recreate, or reset rulebook behavior outside the shell helper and dry-run repro wiring.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-8063-body-fixed.md --changed-files-file /tmp/pr-8063-files.txt --diff-file /tmp/pr-8063.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f30bdfd06d27fde6dac130f447be767e0abad337`
- Post-revert steps: None
- Data migration? No

</details>