### PR TITLE
[CI regression: a4a7770-playwright-8-of-9](1) Mark onboarding visual proof as manual-only

### DIFF
--- a/scripts/repro/repro-ci-playwright-shard-inventory.mjs
+++ b/scripts/repro/repro-ci-playwright-shard-inventory.mjs
@@ -28,6 +28,9 @@ const workflowPath = resolve(repoRoot, process.argv[2] ?? '.github/workflows/ci.
 const e2eDir = resolve(repoRoot, process.argv[3] ?? 'packages/app/e2e');
 
 const MANUAL_ONLY_SPECS = new Set([
+  // Capture-only visual proof driven by scripts/ui-visual-proof.sh with
+  // CAPTURE_MODE; normal CI shards should not run the full onboarding capture.
+  'onboarding-cli-visual-proof.spec.ts',
   // This spec intentionally drives the real `claude` binary and depends on
   // live auth/UI state, so it stays opt-in instead of becoming a CI shard.
   'planning-terminal-chat-tmux-toggle-real-claude-repro.spec.ts',


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a4a77700abe7fdd4f5743b92b3e2795de7d4277c; job=playwright / 8-of-9 -->

The CI shard inventory repro now treats the onboarding visual proof spec as manual-only.

That spec is capture-only and runs through `scripts/ui-visual-proof.sh` with `CAPTURE_MODE`, not the normal Playwright CI shards.

This keeps the inventory guard focused on deterministic shard-owned specs while still checking that manual-only allowlist entries exist.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30895657329/job/91965992697

## Review Claim

Approve exempting the onboarding visual proof spec from the local shard-inventory repro.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the repro inventory allowlist changes. No workflow shard, product behavior, or Playwright spec changes in this slice.

## Slice Rationale

This separates the manual-only proof exception from the CI matrix slice so each change remains reviewable on its own.

## Non-goals

- No CI workflow changes.
- No product behavior changes.
- No test weakening for deterministic CI-owned specs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-8-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/focus-switch-hitch-responsiveness.spec.ts e2e/planning-chat-hitch-responsiveness.spec.ts e2e/command-palette-open.spec.ts e2e/task-new-attempt-reset.spec.ts e2e/persistence-recovery.spec.ts e2e/start-ready-production-click.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` exited 0 in the workflow verify task.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None, but the shard-inventory repro will again require `onboarding-cli-visual-proof.spec.ts` to have CI shard ownership.
- Data migration? No

</details>
