### PR TITLE
[CI regression: a4a7770-playwright-8-of-9](2) Assign stuck-lease specs to shard 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -663,6 +663,8 @@ jobs:
               e2e/start-ready-production-click.spec.ts
           - name: 9-of-9
             files: >-
+              e2e/launch-dispatch-stuck-lease-cap.spec.ts
+              e2e/launch-dispatch-stuck-lease-storm.spec.ts
               e2e/gui-owner-auto-bootstrap.spec.ts
               e2e/start-ready-daemon-owner.spec.ts
               e2e/ui-delta-timeline.spec.ts

--- a/scripts/repro/repro-ci-playwright-shard-inventory.mjs
+++ b/scripts/repro/repro-ci-playwright-shard-inventory.mjs
@@ -28,6 +28,9 @@ const workflowPath = resolve(repoRoot, process.argv[2] ?? '.github/workflows/ci.
 const e2eDir = resolve(repoRoot, process.argv[3] ?? 'packages/app/e2e');
 
 const MANUAL_ONLY_SPECS = new Set([
+  // Capture-only visual proof driven by scripts/ui-visual-proof.sh with
+  // CAPTURE_MODE; normal CI shards should not run the full onboarding capture.
+  'onboarding-cli-visual-proof.spec.ts',
   // This spec intentionally drives the real `claude` binary and depends on
   // live auth/UI state, so it stays opt-in instead of becoming a CI shard.
   'planning-terminal-chat-tmux-toggle-real-claude-repro.spec.ts',


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a4a77700abe7fdd4f5743b92b3e2795de7d4277c; job=playwright / 8-of-9 -->

CI job `playwright / 8-of-9` first failed on default-branch commit a4a77700abe7fdd4f5743b92b3e2795de7d4277c in run 30895657329.

It was most recently still red at 1e207cafb2cf3b3f24d8d1eea0f02931ac4cf601 in run 31132240528.

This assigns the two stuck-lease Playwright specs to shard `9-of-9`, restoring shard ownership for those deterministic CI specs.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30895657329/job/91965992697

## Review Claim

Approve assigning the stuck-lease Playwright specs to shard `9-of-9` so the shard inventory is complete.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the Playwright shard matrix changes. Other CI jobs and product behavior stay unchanged except for the corrected shard ownership.

## Slice Rationale

One policy slice owns the CI matrix repair after the manual-only repro exception is established in the lower proof slice.

## Non-goals

- No refactor or unrelated cleanup.
- No test weakening.
- No snapshot churn.
- No changes to the specs themselves.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-8-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/focus-switch-hitch-responsiveness.spec.ts e2e/planning-chat-hitch-responsiveness.spec.ts e2e/command-palette-open.spec.ts e2e/task-new-attempt-reset.spec.ts e2e/persistence-recovery.spec.ts e2e/start-ready-production-click.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` exited 0 in the workflow verify task.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None, but the shard-inventory guard can report the stuck-lease specs as unassigned again.
- Data migration? No

</details>
