### PR TITLE
[CI regression: e21a965-playwright-terminal-garbling](2) Keep visual proof spec out of shard inventory

### DIFF
--- a/scripts/repro/repro-ci-playwright-shard-inventory.mjs
+++ b/scripts/repro/repro-ci-playwright-shard-inventory.mjs
@@ -28,6 +28,9 @@ const workflowPath = resolve(repoRoot, process.argv[2] ?? '.github/workflows/ci.
 const e2eDir = resolve(repoRoot, process.argv[3] ?? 'packages/app/e2e');
 
 const MANUAL_ONLY_SPECS = new Set([
+  // This visual-proof spec is captured through scripts/ui-visual-proof.sh
+  // with CAPTURE_MODE set; it is not stable as a normal CI shard test.
+  'onboarding-cli-visual-proof.spec.ts',
   // This spec intentionally drives the real `claude` binary and depends on
   // live auth/UI state, so it stays opt-in instead of becoming a CI shard.
   'planning-terminal-chat-tmux-toggle-real-claude-repro.spec.ts',


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=e21a96567a3fff62cf9c71befc3f0a7db15ab9c5; job=playwright / terminal-garbling -->

CI job `playwright / terminal-garbling` was most recently still red at 1e207cafb2cf3b3f24d8d1eea0f02931ac4cf601 in run 31132240528.

This slice marks `onboarding-cli-visual-proof.spec.ts` as manual-only for the shard inventory repro.

The spec depends on visual-proof capture mode, so it should not be required by normal CI shard inventory checks.

## Review Claim

Approve excluding `onboarding-cli-visual-proof.spec.ts` from the normal CI shard inventory repro because it is captured through the visual-proof script.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The diff changes only `scripts/repro/repro-ci-playwright-shard-inventory.mjs`. It does not alter CI workflow execution or product behavior.

## Slice Rationale

This is one repro inventory correction. It is stacked after the CI roster update so policy and proof changes stay reviewable separately.

## Non-goals

- No product code changes.
- No CI workflow changes in this slice.
- No changes to any Playwright spec body or assertion.
- No test weakening, skipping, or snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-terminal-garbling' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/planning-terminal-live-model.proof.spec.ts e2e/planning-surface-navigation-garble-repro.spec.ts e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts e2e/planning-terminal-expand-collapse-garble-repro.spec.ts e2e/task-terminal-drawer-minimize-garble-repro.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
