### PR TITLE
[Add checked-in repro script for the external-dependency deadlock fix](1) Add checked-in repro script

### DIFF
--- a/scripts/repro/repro-external-dependency-deadlock.sh
+++ b/scripts/repro/repro-external-dependency-deadlock.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Repro: the 2026-08-05/06 production incident left 45 real workflows pending
+# for 2+ days with free execution capacity after their shared upstream workflow
+# was invalidated and then abandoned. PR #7704 added the original failing proof:
+# https://github.com/Neko-Catpital-Labs/Invoker/pull/7704
+#
+# PR #8058 fixes the guarded invariant by detaching direct downstream external
+# dependency gates when an abandoned upstream workflow is cancelled, while
+# invalidation paths that can still rerun the upstream keep downstream gated:
+# https://github.com/Neko-Catpital-Labs/Invoker/pull/8058
+#
+# Exit-code contract: exits 0 only when the post-#8058 invariant holds; exits
+# non-zero on the pre-#8058 deadlock behavior.
+#
+# Usage: bash scripts/repro/repro-external-dependency-deadlock.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+REPRO_SPEC="packages/workflow-core/src/__tests__/repro-permanent-external-dependency-deadlock.test.ts"
+
+cd "$REPO_ROOT"
+
+if ! grep -q "detaches downstream from an invalidated upstream when that upstream is cancelled and abandoned" "$REPRO_SPEC" \
+  || ! grep -q "keeps a genuinely-still-invalid upstream gate blocking its downstream" "$REPRO_SPEC"; then
+  echo "[repro] FAIL: fixed post-#8058 proof assertions are missing; pre-#8058 tests can false-green by expecting the deadlock."
+  exit 1
+fi
+
+echo "[repro] running external dependency deadlock proof ..."
+if ! pnpm --filter @invoker/workflow-core exec vitest run \
+  src/__tests__/repro-permanent-external-dependency-deadlock.test.ts \
+  src/__tests__/cross-workflow-cascade.test.ts \
+  src/__tests__/cross-workflow-cascade-command-service-e2e.test.ts; then
+  echo "[repro] FAIL: external dependency deadlock invariant did not hold."
+  exit 1
+fi
+
+echo "[repro] fixed: abandoned upstream cancellation releases direct downstream external-dependency gates."


### PR DESCRIPTION
## Summary

Add a checked-in repro script for the external-dependency deadlock fixed by PR #8058.

The script runs the focused workflow-core repro and cascade tests that guard abandoned-upstream detachment.

This gives the incident a standalone script entry point outside the full vitest harness.

## Review Claim

Approve this checked-in proof script for the #8058 external-dependency deadlock invariant.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice adds one executable repro script only. It does not change workflow behavior, persistence, scheduling, or invalidation code.

## Slice Rationale

PR #8058 fixes the behavior. This follow-up keeps the production incident guard runnable through the repo's checked-in repro-script convention.

## Non-goals

- No product behavior changes.
- No changes to the workflow-core tests themselves.
- No `scripts/test-suites/**` wrapper in this proof PR.
- No operational repair for workflows affected by the 2026-08-05/06 incident.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `bash scripts/repro/repro-external-dependency-deadlock.sh`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-body-external-dependency-deadlock-repro-stack.md`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/pr-body-external-dependency-deadlock-repro-stack.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
