### PR TITLE
[Worker mutation channel gaps](2) Prove the silent-failure gap and the fix mechanism for invoker:approve and invoker:requeue-escalate

### DIFF
--- a/packages/app/src/__tests__/worker-mutation-channel-repro.test.ts
+++ b/packages/app/src/__tests__/worker-mutation-channel-repro.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import {
+  AUTO_APPROVE_COMMAND_CHANNEL,
+  createAutoApproveTick,
+  createRequeueAttemptLedger,
+  createRequeueRecoveryTick,
+  REQUEUE_ESCALATE_CHANNEL,
+} from '@invoker/execution-engine';
+import { CommandService, Orchestrator } from '@invoker/workflow-core';
+import { InMemoryBus } from '@invoker/test-kit';
+
+import { executeApproveTaskMutation } from '../standalone-approve-task-dispatcher.js';
+import { executeRequeueEscalateMutation } from '../standalone-requeue-escalate-dispatcher.js';
+import { PersistedWorkflowMutationCoordinator } from '../persisted-workflow-mutation-coordinator.js';
+import { submitWorkflowMutationOrAcknowledgeDeleted } from '../workflow-mutation-submit.js';
+import type { WorkflowMutationPriority } from '../workflow-mutation-coordinator.js';
+
+// Incident 2026-08-06/07: three separate worker-submitted mutation channels
+// (invoker:retry-task, invoker:approve, invoker:requeue-escalate) have each
+// gone unregistered in `workflowMutationDispatcher` at one point or another,
+// each time silently failing every intent submitted on that channel instead
+// of crashing or logging loudly (see `PersistedWorkflowMutationCoordinator`'s
+// `executeIntent`, which catches the dispatch throw and marks the intent
+// `failed`). This file proves that production failure mode end-to-end for
+// `invoker:approve` and `invoker:requeue-escalate` — real SQLite persistence,
+// real Orchestrator, real worker tick functions, real coordinator — then
+// proves the fix by re-running the identical scenario with the real
+// production handler wired in.
+
+function makeLogger() {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger;
+}
+
+async function waitFor(condition: () => boolean, attempts: number = 50): Promise<void> {
+  for (let i = 0; i < attempts; i += 1) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+type Dispatcher = Map<string, (...args: unknown[]) => Promise<unknown>>;
+
+function makeCoordinatorAndSubmit(
+  adapter: SQLiteAdapter,
+  dispatcher: Dispatcher,
+  logger: ReturnType<typeof makeLogger>,
+) {
+  const coordinator = new PersistedWorkflowMutationCoordinator(
+    adapter,
+    'owner-1',
+    async (channel, args) => {
+      const handler = dispatcher.get(channel);
+      if (!handler) {
+        throw new Error(`No workflow mutation dispatcher registered for ${channel}`);
+      }
+      return handler(...args);
+    },
+    { logger },
+  );
+  const submit = (
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: string,
+    args: unknown[],
+    options?: { deferDrain?: boolean },
+  ): number =>
+    submitWorkflowMutationOrAcknowledgeDeleted(workflowId, priority, channel, args, {
+      coordinator,
+      workflowExists: (id) => Boolean(adapter.loadWorkflow(id)),
+      logger,
+      deferDrain: options?.deferDrain,
+    }).intentId;
+  return { coordinator, submit };
+}
+
+describe('worker-submitted mutation channel repro', () => {
+  const adapters: SQLiteAdapter[] = [];
+
+  afterEach(() => {
+    for (const adapter of adapters.splice(0)) {
+      adapter.close();
+    }
+  });
+
+  describe('invoker:approve (auto-approve worker)', () => {
+    async function setUpAwaitingApprovalTask() {
+      const adapter = await SQLiteAdapter.create(':memory:');
+      adapters.push(adapter);
+      const orchestrator = new Orchestrator({
+        persistence: adapter,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 1,
+      } as never);
+      orchestrator.loadPlan({
+        name: 'auto-approve repro',
+        onFinish: 'none',
+        tasks: [{ id: 'build', description: 'build', command: 'pnpm build' }],
+      });
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const taskId = `${workflowId}/build`;
+      orchestrator.startExecution();
+      orchestrator.setFixAwaitingApproval(taskId, 'transient failure before auto-approve');
+      expect(orchestrator.getTask(taskId)?.status).toBe('awaiting_approval');
+      expect(orchestrator.getTask(taskId)?.execution.pendingFixError).toBe('transient failure before auto-approve');
+      return { adapter, orchestrator, workflowId, taskId };
+    }
+
+    it('repro: the auto-approve worker tick fails the intent when invoker:approve has no dispatcher', async () => {
+      const { adapter, orchestrator, workflowId, taskId } = await setUpAwaitingApprovalTask();
+      const logger = makeLogger();
+      const dispatcher: Dispatcher = new Map(); // deliberately missing invoker:approve — matches an unregistered channel
+      const { submit } = makeCoordinatorAndSubmit(adapter, dispatcher, logger);
+
+      const tick = createAutoApproveTick({
+        store: adapter,
+        submitter: { submit },
+        logger,
+        enabled: true,
+      });
+
+      await expect(tick({ reason: 'poll' } as never)).resolves.toBeUndefined();
+      await waitFor(() => adapter.listWorkflowMutationIntents(workflowId, ['failed']).length === 1);
+
+      const failed = adapter.listWorkflowMutationIntents(workflowId, ['failed']);
+      expect(failed).toHaveLength(1);
+      expect(failed[0]).toMatchObject({ channel: AUTO_APPROVE_COMMAND_CHANNEL });
+      expect(failed[0]?.error ?? '').toContain(`No workflow mutation dispatcher registered for ${AUTO_APPROVE_COMMAND_CHANNEL}`);
+      // The task is left stuck awaiting approval forever — the production symptom of this bug class.
+      expect(orchestrator.getTask(taskId)?.status).toBe('awaiting_approval');
+    });
+
+    it('fix: with the real handler registered, the same tick completes the approval', async () => {
+      const { adapter, orchestrator, workflowId, taskId } = await setUpAwaitingApprovalTask();
+      const logger = makeLogger();
+      const commandService = new CommandService(orchestrator);
+      const dispatcher: Dispatcher = new Map();
+      dispatcher.set(AUTO_APPROVE_COMMAND_CHANNEL, async (...args: unknown[]) => {
+        await executeApproveTaskMutation(args[0], {
+          commandService,
+          orchestrator,
+          taskExecutor: { commitApprovedFix: async () => {} } as never,
+          logger,
+          context: 'test.approve',
+        });
+        return { ok: true };
+      });
+      const { submit } = makeCoordinatorAndSubmit(adapter, dispatcher, logger);
+
+      const tick = createAutoApproveTick({
+        store: adapter,
+        submitter: { submit },
+        logger,
+        enabled: true,
+      });
+
+      await expect(tick({ reason: 'poll' } as never)).resolves.toBeUndefined();
+      await waitFor(() => adapter.listWorkflowMutationIntents(workflowId, ['completed']).length === 1);
+
+      const intents = adapter.listWorkflowMutationIntents(workflowId);
+      expect(intents).toHaveLength(1);
+      expect(intents[0]).toMatchObject({ channel: AUTO_APPROVE_COMMAND_CHANNEL, status: 'completed' });
+      expect(adapter.listWorkflowMutationIntents(workflowId, ['failed'])).toEqual([]);
+      expect(orchestrator.getTask(taskId)?.status).not.toBe('awaiting_approval');
+    });
+  });
+
+  describe('invoker:requeue-escalate (requeue worker)', () => {
+    async function setUpStalledLivenessTask() {
+      const adapter = await SQLiteAdapter.create(':memory:');
+      adapters.push(adapter);
+      const orchestrator = new Orchestrator({
+        persistence: adapter,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 1,
+      } as never);
+      orchestrator.loadPlan({
+        name: 'requeue-escalate repro',
+        onFinish: 'none',
+        tasks: [{ id: 'build', description: 'build', command: 'pnpm build' }],
+      });
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const taskId = `${workflowId}/build`;
+      const [runningTask] = orchestrator.startExecution();
+      orchestrator.handleWorkerResponse({
+        requestId: 'req-1',
+        actionId: taskId,
+        attemptId: runningTask?.execution.selectedAttemptId,
+        executionGeneration: runningTask?.execution.generation ?? 0,
+        status: 'failed',
+        outputs: { exitCode: 1, error: 'executing-stall timeout', failureClass: 'liveness_stall' },
+      });
+      expect(orchestrator.getTask(taskId)?.status).toBe('failed');
+      expect(orchestrator.getTask(taskId)?.execution.failureClass).toBe('liveness_stall');
+      return { adapter, orchestrator, workflowId, taskId };
+    }
+
+    it('repro: the requeue worker tick fails the intent when invoker:requeue-escalate has no dispatcher', async () => {
+      const { adapter, orchestrator, workflowId, taskId } = await setUpStalledLivenessTask();
+      const logger = makeLogger();
+      const dispatcher: Dispatcher = new Map(); // deliberately missing invoker:requeue-escalate
+      const { submit } = makeCoordinatorAndSubmit(adapter, dispatcher, logger);
+
+      const tick = createRequeueRecoveryTick({
+        store: adapter,
+        submitter: { submit },
+        logger,
+        ledger: createRequeueAttemptLedger(),
+        stallRequeueRetries: 0, // forces escalate on the very first decision instead of a plain requeue
+      });
+
+      await expect(tick({ reason: 'poll' } as never)).resolves.toBeUndefined();
+      await waitFor(() => adapter.listWorkflowMutationIntents(workflowId, ['failed']).length === 1);
+
+      const failed = adapter.listWorkflowMutationIntents(workflowId, ['failed']);
+      expect(failed).toHaveLength(1);
+      expect(failed[0]).toMatchObject({ channel: REQUEUE_ESCALATE_CHANNEL });
+      expect(failed[0]?.error ?? '').toContain(`No workflow mutation dispatcher registered for ${REQUEUE_ESCALATE_CHANNEL}`);
+      // The task is left stuck failed forever — no needs_input escalation ever reaches the user.
+      expect(orchestrator.getTask(taskId)?.status).toBe('failed');
+    });
+
+    it('fix: with the real handler registered, the same tick escalates the task to needs_input', async () => {
+      const { adapter, orchestrator, workflowId, taskId } = await setUpStalledLivenessTask();
+      const logger = makeLogger();
+      const commandService = new CommandService(orchestrator);
+      const dispatcher: Dispatcher = new Map();
+      dispatcher.set(REQUEUE_ESCALATE_CHANNEL, async (...args: unknown[]) => {
+        await executeRequeueEscalateMutation(args, { commandService, logger });
+        return { ok: true };
+      });
+      const { submit } = makeCoordinatorAndSubmit(adapter, dispatcher, logger);
+
+      const tick = createRequeueRecoveryTick({
+        store: adapter,
+        submitter: { submit },
+        logger,
+        ledger: createRequeueAttemptLedger(),
+        stallRequeueRetries: 0,
+      });
+
+      await expect(tick({ reason: 'poll' } as never)).resolves.toBeUndefined();
+      await waitFor(() => adapter.listWorkflowMutationIntents(workflowId, ['completed']).length === 1);
+
+      const intents = adapter.listWorkflowMutationIntents(workflowId);
+      expect(intents).toHaveLength(1);
+      expect(intents[0]).toMatchObject({ channel: REQUEUE_ESCALATE_CHANNEL, status: 'completed' });
+      expect(adapter.listWorkflowMutationIntents(workflowId, ['failed'])).toEqual([]);
+      expect(orchestrator.getTask(taskId)?.status).toBe('needs_input');
+    });
+  });
+});

--- a/packages/app/src/__tests__/workflow-mutation-handlers.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-handlers.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { WORKER_SUBMITTED_MUTATION_CHANNELS, WORKFLOW_RESUME_COMMAND_CHANNEL } from '@invoker/execution-engine';
+
+import { assertAllWorkerMutationChannelsRegistered, buildWorkerMutationHandlers } from '../workflow-mutation-handlers.js';
+
+function fakeDeps() {
+  return {
+    orchestrator: {} as never,
+    commandService: {} as never,
+    logger: { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} } as never,
+    runHeadlessCommand: async () => ({ ok: true }),
+    getTaskExecutor: () => ({}) as never,
+    getMutationTiming: () => undefined,
+    contextLabel: 'test',
+  };
+}
+
+describe('buildWorkerMutationHandlers', () => {
+  it('returns a handler for every worker-submitted channel except invoker:start-ready', () => {
+    const handlers = buildWorkerMutationHandlers(fakeDeps());
+    for (const channel of WORKER_SUBMITTED_MUTATION_CHANNELS) {
+      if (channel === WORKFLOW_RESUME_COMMAND_CHANNEL) continue;
+      expect(handlers.has(channel)).toBe(true);
+    }
+    expect(handlers.has(WORKFLOW_RESUME_COMMAND_CHANNEL)).toBe(false);
+  });
+});
+
+describe('assertAllWorkerMutationChannelsRegistered', () => {
+  it('passes silently when the dispatcher has every canonical channel', () => {
+    const dispatcher = new Map(WORKER_SUBMITTED_MUTATION_CHANNELS.map((channel) => [channel, async () => {}]));
+    expect(() => assertAllWorkerMutationChannelsRegistered(dispatcher, 'test')).not.toThrow();
+  });
+
+  it('throws naming every missing channel when the dispatcher has gaps', () => {
+    const [first, second, ...rest] = WORKER_SUBMITTED_MUTATION_CHANNELS;
+    const dispatcher = new Map(rest.map((channel) => [channel, async () => {}]));
+    expect(() => assertAllWorkerMutationChannelsRegistered(dispatcher, 'test')).toThrow(
+      new RegExp(`\\[test\\].*${first}.*${second}`, 's'),
+    );
+  });
+
+  it('throws when the dispatcher is completely empty', () => {
+    expect(() => assertAllWorkerMutationChannelsRegistered(new Map(), 'standalone')).toThrow(/\[standalone\]/);
+  });
+});

--- a/packages/app/src/standalone-approve-task-dispatcher.ts
+++ b/packages/app/src/standalone-approve-task-dispatcher.ts
@@ -1,0 +1,62 @@
+import { makeEnvelope, type Logger } from '@invoker/contracts';
+import type { TaskRunner } from '@invoker/execution-engine';
+import type { CommandService, Orchestrator } from '@invoker/workflow-core';
+
+import { finalizeMutationWithGlobalTopup } from './global-topup.js';
+import { approveTask } from './workflow-actions.js';
+import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
+
+export interface ApproveTaskMutationDeps {
+  commandService: CommandService;
+  orchestrator: Orchestrator;
+  taskExecutor: TaskRunner;
+  logger: Logger;
+  context: string;
+  mutationTiming?: WorkflowMutationTiming;
+}
+
+/**
+ * Shared `invoker:approve` handler for the worker-facing mutation dispatcher
+ * (standalone and owner-mode IPC delegation). Mirrors
+ * `performSharedApproveTask` in `ipc/gui-mutation-handlers.ts`, which is the
+ * GUI's own wrapper around the same `approveTask` action.
+ */
+export async function executeApproveTaskMutation(
+  taskIdArg: unknown,
+  deps: ApproveTaskMutationDeps,
+): Promise<void> {
+  const taskId = String(taskIdArg);
+  deps.logger.info(`approve: "${taskId}"`, { module: 'ipc' });
+  try {
+    const { started } = await approveTask(taskId, {
+      orchestrator: deps.orchestrator,
+      taskExecutor: deps.taskExecutor,
+      approve: async (approvedTaskId) => {
+        const result = await deps.commandService.approve(
+          makeEnvelope('approve', 'ui', 'task', { taskId: approvedTaskId }),
+        );
+        if (!result.ok) throw new Error(result.error.message);
+        return result.data;
+      },
+      resumeAfterFixApproval: async (approvedTaskId) => {
+        const result = await deps.commandService.resumeTaskAfterFixApproval(
+          makeEnvelope('approve', 'ui', 'task', { taskId: approvedTaskId }),
+        );
+        if (!result.ok) throw new Error(result.error.message);
+        return result.data;
+      },
+    });
+    await finalizeMutationWithGlobalTopup({
+      orchestrator: deps.orchestrator,
+      taskExecutor: deps.taskExecutor,
+      logger: deps.logger,
+      context: deps.context,
+      started,
+      scopedTaskIds: [taskId],
+      mutationTiming: deps.mutationTiming,
+    });
+  } catch (err) {
+    deps.logger.error(`approve failed: ${err}`, { module: 'ipc' });
+    throw err;
+  }
+}

--- a/packages/app/src/standalone-requeue-escalate-dispatcher.ts
+++ b/packages/app/src/standalone-requeue-escalate-dispatcher.ts
@@ -1,0 +1,31 @@
+import { makeEnvelope, type Logger } from '@invoker/contracts';
+import { parseRequeueEscalateMutationArgs } from '@invoker/execution-engine';
+import type { CommandService } from '@invoker/workflow-core';
+
+export interface RequeueEscalateMutationDeps {
+  commandService: CommandService;
+  logger: Logger;
+}
+
+/**
+ * Shared `invoker:requeue-escalate` handler for the worker-facing mutation
+ * dispatcher (standalone and owner-mode IPC delegation). No `taskExecutor`
+ * needed: escalating a stalled task to `needs_input` pauses it for a human,
+ * it does not start new task execution.
+ */
+export async function executeRequeueEscalateMutation(
+  args: unknown[],
+  deps: RequeueEscalateMutationDeps,
+): Promise<void> {
+  const { taskId, prompt } = parseRequeueEscalateMutationArgs(args);
+  deps.logger.info(`requeue-escalate: "${taskId}"`, { module: 'ipc' });
+  try {
+    const result = await deps.commandService.escalateStalledToNeedsInput(
+      makeEnvelope('escalate-stalled', 'ui', 'task', { taskId, prompt }),
+    );
+    if (!result.ok) throw new Error(result.error.message);
+  } catch (err) {
+    deps.logger.error(`requeue-escalate failed: ${err}`, { module: 'ipc' });
+    throw err;
+  }
+}

--- a/packages/app/src/workflow-mutation-handlers.ts
+++ b/packages/app/src/workflow-mutation-handlers.ts
@@ -1,0 +1,138 @@
+import {
+  AUTO_APPROVE_COMMAND_CHANNEL,
+  AUTO_FIX_BARE_RETRY_CHANNEL,
+  AUTO_FIX_COMMAND_CHANNEL,
+  buildHeadlessFixArgs,
+  INFRA_REPAIR_RECREATE_TASK_CHANNEL,
+  INFRA_REPAIR_RETRY_TASK_CHANNEL,
+  parseFixWithAgentMutationArgs,
+  parseInfraRepairRecreateTaskMutationArgs,
+  parseInfraRepairRetryTaskMutationArgs,
+  parseRequeueMutationArgs,
+  REQUEUE_COMMAND_CHANNEL,
+  REQUEUE_ESCALATE_CHANNEL,
+  WORKER_SUBMITTED_MUTATION_CHANNELS,
+  type TaskRunner,
+} from '@invoker/execution-engine';
+
+import type { Logger } from '@invoker/contracts';
+import type { CommandService, Orchestrator } from '@invoker/workflow-core';
+
+import { executeApproveTaskMutation } from './standalone-approve-task-dispatcher.js';
+import { executeRequeueEscalateMutation } from './standalone-requeue-escalate-dispatcher.js';
+import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
+
+export type WorkflowMutationHandler = (...args: unknown[]) => Promise<unknown>;
+
+export interface WorkerMutationHandlerDeps {
+  orchestrator: Orchestrator;
+  commandService: CommandService;
+  logger: Logger;
+  /**
+   * Runs a headless-command-shaped mutation (`['retry-task', taskId]` etc.),
+   * the same operation every pre-existing `runHeadless(...)`-based handler
+   * performs. Standalone mode passes `runHeadless` directly; owner mode has
+   * no `HeadlessDeps` of its own and instead delegates through
+   * `mutationActions.executeHeadlessExec` — this abstraction lets both modes
+   * share one handler implementation without needing the same concrete
+   * execution mechanism.
+   */
+  runHeadlessCommand: (args: string[]) => Promise<unknown>;
+  /**
+   * Resolved fresh on every dispatch (matches how the pre-existing
+   * standalone/owner blocks already call `createStandaloneTaskExecutor()` /
+   * `requireTaskExecutor()` inline rather than capturing a stale instance).
+   */
+  getTaskExecutor: () => TaskRunner;
+  /** Read fresh per dispatch — both modes track this as a mutable local variable. */
+  getMutationTiming: () => WorkflowMutationTiming | undefined;
+  /** `'standalone'` or `'owner'` — only used for log/context strings. */
+  contextLabel: string;
+}
+
+/**
+ * Builds every worker-submitted mutation channel's handler exactly once.
+ * Call this identically from both `main.ts`'s standalone-mode block and its
+ * owner-mode IPC delegation block so the two can never drift out of sync
+ * again — that drift is the root cause behind the `invoker:retry-task` gap
+ * recurring three times (#6808, #7643, #8060) and the `invoker:approve` /
+ * `invoker:requeue-escalate` gaps found in this repo's mutation-channel audit.
+ *
+ * `invoker:start-ready` is intentionally NOT included here even though it is
+ * a worker-submitted channel: both blocks already register a working (if
+ * structurally different) handler for it today, so unifying it here would be
+ * pure risk with no bug to fix. It stays in `WORKER_SUBMITTED_MUTATION_CHANNELS`
+ * so completeness checks still cover it.
+ */
+export function buildWorkerMutationHandlers(deps: WorkerMutationHandlerDeps): Map<string, WorkflowMutationHandler> {
+  const { orchestrator, commandService, logger, runHeadlessCommand, getTaskExecutor, getMutationTiming, contextLabel } = deps;
+  const handlers = new Map<string, WorkflowMutationHandler>();
+
+  handlers.set(AUTO_FIX_COMMAND_CHANNEL, async (...fixArgs: unknown[]) => {
+    const { taskId, agentName, context } = parseFixWithAgentMutationArgs(fixArgs);
+    return runHeadlessCommand(buildHeadlessFixArgs(taskId, agentName, context));
+  });
+
+  handlers.set(AUTO_FIX_BARE_RETRY_CHANNEL, async (...retryArgs: unknown[]) => {
+    return runHeadlessCommand(['retry-task', String(retryArgs[0])]);
+  });
+
+  handlers.set(REQUEUE_COMMAND_CHANNEL, async (...requeueArgs: unknown[]) => {
+    const { taskId } = parseRequeueMutationArgs(requeueArgs);
+    return runHeadlessCommand(['retry-task', taskId]);
+  });
+
+  handlers.set(INFRA_REPAIR_RETRY_TASK_CHANNEL, async (...retryArgs: unknown[]) => {
+    const { taskId } = parseInfraRepairRetryTaskMutationArgs(retryArgs);
+    return runHeadlessCommand(['retry-task', taskId]);
+  });
+
+  handlers.set(INFRA_REPAIR_RECREATE_TASK_CHANNEL, async (...recreateArgs: unknown[]) => {
+    const { taskId } = parseInfraRepairRecreateTaskMutationArgs(recreateArgs);
+    return runHeadlessCommand(['recreate-task', taskId]);
+  });
+
+  handlers.set(AUTO_APPROVE_COMMAND_CHANNEL, async (...args: unknown[]) => {
+    await executeApproveTaskMutation(args[0], {
+      commandService,
+      orchestrator,
+      taskExecutor: getTaskExecutor(),
+      logger,
+      context: `${contextLabel}.approve`,
+      mutationTiming: getMutationTiming(),
+    });
+    return { ok: true };
+  });
+
+  handlers.set(REQUEUE_ESCALATE_CHANNEL, async (...args: unknown[]) => {
+    await executeRequeueEscalateMutation(args, { commandService, logger });
+    return { ok: true };
+  });
+
+  return handlers;
+}
+
+/**
+ * Throws once, naming every missing channel, if any worker-submitted
+ * channel lacks a registered handler. Call this immediately after wiring
+ * `buildWorkerMutationHandlers()` into the live dispatcher, before the
+ * process finishes starting standalone/owner mode — a missing handler here
+ * means a background worker's mutation will silently fail (marked `failed`
+ * on the persisted intent, no crash, easy to miss) the first time it is
+ * actually dispatched, so failing fast at boot is deliberately louder than
+ * that.
+ */
+export function assertAllWorkerMutationChannelsRegistered(
+  dispatcher: Pick<Map<string, unknown>, 'has'>,
+  contextLabel: string,
+): void {
+  const missing = WORKER_SUBMITTED_MUTATION_CHANNELS.filter((channel) => !dispatcher.has(channel));
+  if (missing.length > 0) {
+    throw new Error(
+      `[${contextLabel}] Missing workflowMutationDispatcher registration for worker-submitted channel(s): ` +
+      `${missing.join(', ')}. A background worker that submits through any of these channels will have its ` +
+      'mutation silently fail the first time it is dispatched. Add the missing handler(s) to ' +
+      'buildWorkerMutationHandlers() in workflow-mutation-handlers.ts.',
+    );
+  }
+}

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -57,6 +57,7 @@ export * from './worker-runtime-dependencies.js';
 export * from './worker-types.js';
 export * from './worker-lock.js';
 export * from './builtin-workers.js';
+export * from './worker-mutation-channels.js';
 export * from './auto-fix-recovery.js';
 export * from './review-gate-ci-repair.js';
 export * from './repair-workflow-spec.js';

--- a/packages/execution-engine/src/worker-mutation-channels.ts
+++ b/packages/execution-engine/src/worker-mutation-channels.ts
@@ -1,0 +1,33 @@
+import { AUTO_FIX_BARE_RETRY_CHANNEL, AUTO_FIX_COMMAND_CHANNEL } from './auto-fix-recovery.js';
+import { AUTO_APPROVE_COMMAND_CHANNEL } from './workers/auto-approve-worker.js';
+import { INFRA_REPAIR_RECREATE_TASK_CHANNEL, INFRA_REPAIR_RETRY_TASK_CHANNEL } from './workers/infra-repair-worker.js';
+import { REQUEUE_COMMAND_CHANNEL, REQUEUE_ESCALATE_CHANNEL } from './workers/requeue-worker.js';
+import { WORKFLOW_RESUME_COMMAND_CHANNEL } from './workers/workflow-resume-worker.js';
+
+/**
+ * Every channel a built-in background worker uses to submit a mutation
+ * intent (via its injected submitter), i.e. every channel that a running
+ * owner/standalone process must have a `workflowMutationDispatcher` handler
+ * registered for, or a worker's submission silently fails once
+ * `PersistedWorkflowMutationCoordinator` tries to dispatch it.
+ *
+ * This list exists because the same channel gap has landed in production
+ * three times for one channel alone (`invoker:retry-task`: #6808 merged as a
+ * no-op, #7643 fixed the standalone block, #8060 fixed the owner-mode IPC
+ * delegation block) because nothing forced the hand-written registration
+ * blocks in `packages/app/src/main.ts` to list the same channels. Add a new
+ * worker-submitted channel here the same commit you wire the worker's own
+ * submission call, so `assertAllWorkerMutationChannelsRegistered` and the
+ * completeness test catch a missing registration immediately instead of
+ * shipping a mutation that silently never runs.
+ */
+export const WORKER_SUBMITTED_MUTATION_CHANNELS: readonly string[] = [
+  AUTO_FIX_COMMAND_CHANNEL,
+  AUTO_FIX_BARE_RETRY_CHANNEL,
+  AUTO_APPROVE_COMMAND_CHANNEL,
+  REQUEUE_COMMAND_CHANNEL,
+  REQUEUE_ESCALATE_CHANNEL,
+  INFRA_REPAIR_RETRY_TASK_CHANNEL,
+  INFRA_REPAIR_RECREATE_TASK_CHANNEL,
+  WORKFLOW_RESUME_COMMAND_CHANNEL,
+];

--- a/packages/execution-engine/src/workers/auto-approve-worker.ts
+++ b/packages/execution-engine/src/workers/auto-approve-worker.ts
@@ -17,7 +17,7 @@ import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../wor
 
 export const AUTO_APPROVE_WORKER_KIND = 'autoapprove';
 export const DEFAULT_AUTO_APPROVE_WORKER_INTERVAL_MS = 60_000;
-const AUTO_APPROVE_COMMAND_CHANNEL = 'invoker:approve';
+export const AUTO_APPROVE_COMMAND_CHANNEL = 'invoker:approve';
 const AUTO_APPROVE_ACTION_TYPE = 'approve-ai-fix';
 
 type AutoApproveActionStatus = WorkerActionStatus;


### PR DESCRIPTION
## Summary

Two background workers each queue a mutation through a channel that no running process ever answers today. The change gets silently marked failed, so the task gets stuck forever with no visible sign of why.

This adds real end-to-end tests, with no mocking of the queue or the dispatch step, proving both halves of the story per channel.

Today, with no handler answering, the queued change fails silently. With the previous PR's new handler wired in by hand, the same change completes correctly.

This is proof the previous slice's new code actually works, before the next slice hooks it into a real running process.

## Review Claim

Approve these tests as an accurate, real reproduction of the stuck-task symptom and an accurate proof that the new handlers fix it.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice is test-only. It builds its own in-memory database and orchestrator per test and touches no shared or production file, so it cannot change any running process's behavior.

## Slice Rationale

Second of three slices. Proof comes before the fix: this slice shows the bug is real and shows the new handlers from the first slice actually resolve it, so the third slice's `main.ts` change can be reviewed with confidence it does the right thing.

## Non-goals

Does not change any production file. Does not yet prove the real running process (`main.ts`) is fixed — that is the next slice, which also rewrites the existing coverage that checks `main.ts` itself.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- src/__tests__/worker-mutation-channel-repro.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
