### PR TITLE
[Worker mutation channel gaps](3) Wire both dispatcher registration blocks to the shared builder, fixing invoker:approve and invoker:requeue-escalate

### DIFF
--- a/packages/app/src/__tests__/no-requeue-outside-worker.test.ts
+++ b/packages/app/src/__tests__/no-requeue-outside-worker.test.ts
@@ -16,7 +16,14 @@ const TRIGGER_SIGNALS: ReadonlyArray<{ name: string; pattern: RegExp }> = [
 
 const ALLOWLIST: ReadonlySet<string> = new Set([
   'packages/execution-engine/src/workers/requeue-worker.ts',
-  'packages/app/src/main.ts',
+  // The channel constants are re-listed here as the single source of truth
+  // every mode's dispatcher registration is checked against — see
+  // `WORKER_SUBMITTED_MUTATION_CHANNELS` in `worker-mutation-channels.ts`.
+  'packages/execution-engine/src/worker-mutation-channels.ts',
+  // `main.ts` no longer references these channels directly: both the
+  // standalone and owner-mode registration blocks now call the shared
+  // `buildWorkerMutationHandlers()`, which owns the actual `.set(...)` calls.
+  'packages/app/src/workflow-mutation-handlers.ts',
 ]);
 
 function findRepoRoot(): string {

--- a/packages/app/src/__tests__/owner-worker-mutation-dispatcher-completeness.test.ts
+++ b/packages/app/src/__tests__/owner-worker-mutation-dispatcher-completeness.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import * as path from 'node:path';
 
-import { AUTO_FIX_BARE_RETRY_CHANNEL, AUTO_FIX_COMMAND_CHANNEL } from '@invoker/execution-engine';
+import { WORKER_SUBMITTED_MUTATION_CHANNELS, WORKFLOW_RESUME_COMMAND_CHANNEL } from '@invoker/execution-engine';
+
+import { buildWorkerMutationHandlers } from '../workflow-mutation-handlers.js';
 
 const MAIN = path.resolve(__dirname, '..', 'main.ts');
 
@@ -15,47 +17,106 @@ const MAIN = path.resolve(__dirname, '..', 'main.ts');
 // invoker:retry-task" and no failed task was ever auto-fixed. A prior PR
 // (#6808) claimed to add this registration plus a regression test, but
 // merged as a no-op (identical tree to its parent commit).
-describe('standalone owner worker mutation dispatcher completeness', () => {
-  it('registers a dispatcher for every channel the auto-fix recovery worker submits through', () => {
-    const source = readFileSync(MAIN, 'utf8');
-
-    const guardIdx = source.indexOf('if (standaloneMode && messageBus) {');
-    expect(guardIdx, 'standalone owner mutation-routing guard not found').toBeGreaterThan(-1);
-    const openBraceIdx = source.indexOf('{', guardIdx);
-    let closeBraceIdx = -1;
-    let depth = 0;
-    for (let idx = openBraceIdx; idx < source.length; idx += 1) {
-      if (source[idx] === '{') depth += 1;
-      else if (source[idx] === '}') {
-        depth -= 1;
-        if (depth === 0) {
-          closeBraceIdx = idx;
-          break;
-        }
+//
+// That same gap later recurred for the owner-mode IPC-delegation block
+// (only `AUTO_FIX_BARE_RETRY_CHANNEL` was ever proven there), and a
+// mutation-channel audit found it recurring again for two entirely
+// different workers (`invoker:approve`, `invoker:requeue-escalate`) that
+// were never registered in either block. The root cause both times was the
+// same: hand-written per-channel `.set(...)` calls with nothing forcing the
+// standalone block, the owner-mode IPC-delegation block, and GUI mode to
+// list the same channels.
+//
+// This test now covers every channel in `WORKER_SUBMITTED_MUTATION_CHANNELS`
+// (the single canonical list — see `worker-mutation-channels.ts`) across both
+// registration surfaces that actually dispatch worker-submitted mutations
+// (standalone, owner-mode IPC delegation), instead of two hardcoded channels
+// in one block, so a future channel added to the list without being wired
+// everywhere fails here immediately.
+//
+// `gui-mutation-handlers.ts` is deliberately NOT checked here. It registers
+// direct user-button IPC actions (Approve, Retry, Fix with Agent), a
+// different code path that happens to share 3 of the 8 channel names because
+// those actions are dual-purpose. It has no entry for background-only
+// channels (requeue, requeue-escalate, infra-repair-*, start-ready) because
+// there is no button for them, and that's correct: a GUI process acting as
+// owner dispatches worker-submitted mutations through the same `if
+// (ownerMode)` block checked below (see the `mode: 'gui'` label on its
+// `headless.owner-ping` handler in main.ts) — there is no separate
+// GUI-specific registration surface for these channels to audit.
+function balancedBlockAfter(source: string, marker: string): string {
+  const markerIdx = source.indexOf(marker);
+  expect(markerIdx, `${marker} not found`).toBeGreaterThan(-1);
+  const openBraceIdx = source.indexOf('{', markerIdx);
+  let closeBraceIdx = -1;
+  let depth = 0;
+  for (let idx = openBraceIdx; idx < source.length; idx += 1) {
+    if (source[idx] === '{') depth += 1;
+    else if (source[idx] === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        closeBraceIdx = idx;
+        break;
       }
     }
-    expect(closeBraceIdx, 'standalone owner mutation-routing guard closing brace not found').toBeGreaterThan(-1);
-    const registrationBlock = source.slice(openBraceIdx, closeBraceIdx);
+  }
+  expect(closeBraceIdx, `${marker} closing brace not found`).toBeGreaterThan(-1);
+  return source.slice(openBraceIdx, closeBraceIdx);
+}
 
-    // A handler is registered either by the channel's literal string or by
-    // importing and passing its exported constant identifier — both forms
-    // resolve to the same runtime channel name.
-    const isRegistered = (channel: string, constantName: string): boolean =>
-      registrationBlock.includes(`workflowMutationDispatcher.set('${channel}'`)
-      || registrationBlock.includes(`workflowMutationDispatcher.set(${constantName}`);
+describe('worker mutation channel completeness', () => {
+  it('buildWorkerMutationHandlers() returns a handler for every worker-submitted channel except invoker:start-ready', () => {
+    const handlers = buildWorkerMutationHandlers({
+      orchestrator: {} as never,
+      commandService: {} as never,
+      logger: { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} } as never,
+      runHeadlessCommand: async () => ({ ok: true }),
+      getTaskExecutor: () => ({}) as never,
+      getMutationTiming: () => undefined,
+      contextLabel: 'test',
+    });
 
-    expect(
-      isRegistered(AUTO_FIX_BARE_RETRY_CHANNEL, 'AUTO_FIX_BARE_RETRY_CHANNEL'),
-      `standalone owner startup must register a workflowMutationDispatcher handler for '${AUTO_FIX_BARE_RETRY_CHANNEL}' `
-        + '(the auto-fix recovery worker submits its free bare retry through this channel directly, '
-        + 'bypassing any IPC/GUI translation layer)',
-    ).toBe(true);
-
-    expect(
-      isRegistered(AUTO_FIX_COMMAND_CHANNEL, 'AUTO_FIX_COMMAND_CHANNEL'),
-      `standalone owner startup must register a workflowMutationDispatcher handler for '${AUTO_FIX_COMMAND_CHANNEL}' `
-        + '(the auto-fix recovery worker submits its AI fix attempts through this channel directly, '
-        + 'bypassing any IPC/GUI translation layer)',
-    ).toBe(true);
+    for (const channel of WORKER_SUBMITTED_MUTATION_CHANNELS) {
+      if (channel === WORKFLOW_RESUME_COMMAND_CHANNEL) continue; // intentionally hand-registered in both blocks, see workflow-mutation-handlers.ts
+      expect(
+        handlers.has(channel),
+        `buildWorkerMutationHandlers() must return a handler for '${channel}' — add it in workflow-mutation-handlers.ts`,
+      ).toBe(true);
+    }
   });
+
+  it('both main.ts registration blocks call the shared builder and the boot-time completeness assertion', () => {
+    const source = readFileSync(MAIN, 'utf8');
+
+    const standaloneBlock = balancedBlockAfter(source, 'if (standaloneMode && messageBus) {');
+    expect(standaloneBlock, 'standalone block must call buildWorkerMutationHandlers').toContain('buildWorkerMutationHandlers(');
+    expect(standaloneBlock, 'standalone block must call assertAllWorkerMutationChannelsRegistered').toContain('assertAllWorkerMutationChannelsRegistered(');
+
+    const ipcMarkerIdx = source.indexOf('// ── IPC Delegation Handlers');
+    expect(ipcMarkerIdx, 'IPC delegation handler marker not found').toBeGreaterThan(-1);
+    const ownerBlock = balancedBlockAfter(source.slice(ipcMarkerIdx), 'if (ownerMode) {');
+    expect(ownerBlock, 'owner-mode IPC delegation block must call buildWorkerMutationHandlers').toContain('buildWorkerMutationHandlers(');
+    expect(ownerBlock, 'owner-mode IPC delegation block must call assertAllWorkerMutationChannelsRegistered').toContain('assertAllWorkerMutationChannelsRegistered(');
+  });
+
+  it.each(WORKER_SUBMITTED_MUTATION_CHANNELS)(
+    "registers a dispatcher for worker-submitted channel '%s' in both main.ts blocks",
+    (channel) => {
+      // invoker:start-ready is intentionally hand-registered per block (see
+      // workflow-mutation-handlers.ts) rather than routed through the shared
+      // builder, so it still needs its own literal check here.
+      if (channel !== WORKFLOW_RESUME_COMMAND_CHANNEL) return;
+
+      const source = readFileSync(MAIN, 'utf8');
+      const standaloneBlock = balancedBlockAfter(source, 'if (standaloneMode && messageBus) {');
+      const ipcMarkerIdx = source.indexOf('// ── IPC Delegation Handlers');
+      const ownerBlock = balancedBlockAfter(source.slice(ipcMarkerIdx), 'if (ownerMode) {');
+
+      const isRegistered = (block: string): boolean =>
+        block.includes(`workflowMutationDispatcher.set('${channel}'`) || block.includes(`workflowMutationDispatcher.set(${channel}`);
+
+      expect(isRegistered(standaloneBlock), `standalone block must register '${channel}'`).toBe(true);
+      expect(isRegistered(ownerBlock), `owner-mode IPC delegation block must register '${channel}'`).toBe(true);
+    },
+  );
 });

--- a/packages/app/src/__tests__/worker-mutation-channel-repro.test.ts
+++ b/packages/app/src/__tests__/worker-mutation-channel-repro.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import {
+  AUTO_APPROVE_COMMAND_CHANNEL,
+  createAutoApproveTick,
+  createRequeueAttemptLedger,
+  createRequeueRecoveryTick,
+  REQUEUE_ESCALATE_CHANNEL,
+} from '@invoker/execution-engine';
+import { CommandService, Orchestrator } from '@invoker/workflow-core';
+import { InMemoryBus } from '@invoker/test-kit';
+
+import { executeApproveTaskMutation } from '../standalone-approve-task-dispatcher.js';
+import { executeRequeueEscalateMutation } from '../standalone-requeue-escalate-dispatcher.js';
+import { PersistedWorkflowMutationCoordinator } from '../persisted-workflow-mutation-coordinator.js';
+import { submitWorkflowMutationOrAcknowledgeDeleted } from '../workflow-mutation-submit.js';
+import type { WorkflowMutationPriority } from '../workflow-mutation-coordinator.js';
+
+// Incident 2026-08-06/07: three separate worker-submitted mutation channels
+// (invoker:retry-task, invoker:approve, invoker:requeue-escalate) have each
+// gone unregistered in `workflowMutationDispatcher` at one point or another,
+// each time silently failing every intent submitted on that channel instead
+// of crashing or logging loudly (see `PersistedWorkflowMutationCoordinator`'s
+// `executeIntent`, which catches the dispatch throw and marks the intent
+// `failed`). This file proves that production failure mode end-to-end for
+// `invoker:approve` and `invoker:requeue-escalate` — real SQLite persistence,
+// real Orchestrator, real worker tick functions, real coordinator — then
+// proves the fix by re-running the identical scenario with the real
+// production handler wired in.
+
+function makeLogger() {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger;
+}
+
+async function waitFor(condition: () => boolean, attempts: number = 50): Promise<void> {
+  for (let i = 0; i < attempts; i += 1) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+type Dispatcher = Map<string, (...args: unknown[]) => Promise<unknown>>;
+
+function makeCoordinatorAndSubmit(
+  adapter: SQLiteAdapter,
+  dispatcher: Dispatcher,
+  logger: ReturnType<typeof makeLogger>,
+) {
+  const coordinator = new PersistedWorkflowMutationCoordinator(
+    adapter,
+    'owner-1',
+    async (channel, args) => {
+      const handler = dispatcher.get(channel);
+      if (!handler) {
+        throw new Error(`No workflow mutation dispatcher registered for ${channel}`);
+      }
+      return handler(...args);
+    },
+    { logger },
+  );
+  const submit = (
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: string,
+    args: unknown[],
+    options?: { deferDrain?: boolean },
+  ): number =>
+    submitWorkflowMutationOrAcknowledgeDeleted(workflowId, priority, channel, args, {
+      coordinator,
+      workflowExists: (id) => Boolean(adapter.loadWorkflow(id)),
+      logger,
+      deferDrain: options?.deferDrain,
+    }).intentId;
+  return { coordinator, submit };
+}
+
+describe('worker-submitted mutation channel repro', () => {
+  const adapters: SQLiteAdapter[] = [];
+
+  afterEach(() => {
+    for (const adapter of adapters.splice(0)) {
+      adapter.close();
+    }
+  });
+
+  describe('invoker:approve (auto-approve worker)', () => {
+    async function setUpAwaitingApprovalTask() {
+      const adapter = await SQLiteAdapter.create(':memory:');
+      adapters.push(adapter);
+      const orchestrator = new Orchestrator({
+        persistence: adapter,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 1,
+      } as never);
+      orchestrator.loadPlan({
+        name: 'auto-approve repro',
+        onFinish: 'none',
+        tasks: [{ id: 'build', description: 'build', command: 'pnpm build' }],
+      });
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const taskId = `${workflowId}/build`;
+      orchestrator.startExecution();
+      orchestrator.setFixAwaitingApproval(taskId, 'transient failure before auto-approve');
+      expect(orchestrator.getTask(taskId)?.status).toBe('awaiting_approval');
+      expect(orchestrator.getTask(taskId)?.execution.pendingFixError).toBe('transient failure before auto-approve');
+      return { adapter, orchestrator, workflowId, taskId };
+    }
+
+    it('repro: the auto-approve worker tick fails the intent when invoker:approve has no dispatcher', async () => {
+      const { adapter, orchestrator, workflowId, taskId } = await setUpAwaitingApprovalTask();
+      const logger = makeLogger();
+      const dispatcher: Dispatcher = new Map(); // deliberately missing invoker:approve — matches an unregistered channel
+      const { submit } = makeCoordinatorAndSubmit(adapter, dispatcher, logger);
+
+      const tick = createAutoApproveTick({
+        store: adapter,
+        submitter: { submit },
+        logger,
+        enabled: true,
+      });
+
+      await expect(tick({ reason: 'poll' } as never)).resolves.toBeUndefined();
+      await waitFor(() => adapter.listWorkflowMutationIntents(workflowId, ['failed']).length === 1);
+
+      const failed = adapter.listWorkflowMutationIntents(workflowId, ['failed']);
+      expect(failed).toHaveLength(1);
+      expect(failed[0]).toMatchObject({ channel: AUTO_APPROVE_COMMAND_CHANNEL });
+      expect(failed[0]?.error ?? '').toContain(`No workflow mutation dispatcher registered for ${AUTO_APPROVE_COMMAND_CHANNEL}`);
+      // The task is left stuck awaiting approval forever — the production symptom of this bug class.
+      expect(orchestrator.getTask(taskId)?.status).toBe('awaiting_approval');
+    });
+
+    it('fix: with the real handler registered, the same tick completes the approval', async () => {
+      const { adapter, orchestrator, workflowId, taskId } = await setUpAwaitingApprovalTask();
+      const logger = makeLogger();
+      const commandService = new CommandService(orchestrator);
+      const dispatcher: Dispatcher = new Map();
+      dispatcher.set(AUTO_APPROVE_COMMAND_CHANNEL, async (...args: unknown[]) => {
+        await executeApproveTaskMutation(args[0], {
+          commandService,
+          orchestrator,
+          taskExecutor: { commitApprovedFix: async () => {} } as never,
+          logger,
+          context: 'test.approve',
+        });
+        return { ok: true };
+      });
+      const { submit } = makeCoordinatorAndSubmit(adapter, dispatcher, logger);
+
+      const tick = createAutoApproveTick({
+        store: adapter,
+        submitter: { submit },
+        logger,
+        enabled: true,
+      });
+
+      await expect(tick({ reason: 'poll' } as never)).resolves.toBeUndefined();
+      await waitFor(() => adapter.listWorkflowMutationIntents(workflowId, ['completed']).length === 1);
+
+      const intents = adapter.listWorkflowMutationIntents(workflowId);
+      expect(intents).toHaveLength(1);
+      expect(intents[0]).toMatchObject({ channel: AUTO_APPROVE_COMMAND_CHANNEL, status: 'completed' });
+      expect(adapter.listWorkflowMutationIntents(workflowId, ['failed'])).toEqual([]);
+      expect(orchestrator.getTask(taskId)?.status).not.toBe('awaiting_approval');
+    });
+  });
+
+  describe('invoker:requeue-escalate (requeue worker)', () => {
+    async function setUpStalledLivenessTask() {
+      const adapter = await SQLiteAdapter.create(':memory:');
+      adapters.push(adapter);
+      const orchestrator = new Orchestrator({
+        persistence: adapter,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 1,
+      } as never);
+      orchestrator.loadPlan({
+        name: 'requeue-escalate repro',
+        onFinish: 'none',
+        tasks: [{ id: 'build', description: 'build', command: 'pnpm build' }],
+      });
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const taskId = `${workflowId}/build`;
+      const [runningTask] = orchestrator.startExecution();
+      orchestrator.handleWorkerResponse({
+        requestId: 'req-1',
+        actionId: taskId,
+        attemptId: runningTask?.execution.selectedAttemptId,
+        executionGeneration: runningTask?.execution.generation ?? 0,
+        status: 'failed',
+        outputs: { exitCode: 1, error: 'executing-stall timeout', failureClass: 'liveness_stall' },
+      });
+      expect(orchestrator.getTask(taskId)?.status).toBe('failed');
+      expect(orchestrator.getTask(taskId)?.execution.failureClass).toBe('liveness_stall');
+      return { adapter, orchestrator, workflowId, taskId };
+    }
+
+    it('repro: the requeue worker tick fails the intent when invoker:requeue-escalate has no dispatcher', async () => {
+      const { adapter, orchestrator, workflowId, taskId } = await setUpStalledLivenessTask();
+      const logger = makeLogger();
+      const dispatcher: Dispatcher = new Map(); // deliberately missing invoker:requeue-escalate
+      const { submit } = makeCoordinatorAndSubmit(adapter, dispatcher, logger);
+
+      const tick = createRequeueRecoveryTick({
+        store: adapter,
+        submitter: { submit },
+        logger,
+        ledger: createRequeueAttemptLedger(),
+        stallRequeueRetries: 0, // forces escalate on the very first decision instead of a plain requeue
+      });
+
+      await expect(tick({ reason: 'poll' } as never)).resolves.toBeUndefined();
+      await waitFor(() => adapter.listWorkflowMutationIntents(workflowId, ['failed']).length === 1);
+
+      const failed = adapter.listWorkflowMutationIntents(workflowId, ['failed']);
+      expect(failed).toHaveLength(1);
+      expect(failed[0]).toMatchObject({ channel: REQUEUE_ESCALATE_CHANNEL });
+      expect(failed[0]?.error ?? '').toContain(`No workflow mutation dispatcher registered for ${REQUEUE_ESCALATE_CHANNEL}`);
+      // The task is left stuck failed forever — no needs_input escalation ever reaches the user.
+      expect(orchestrator.getTask(taskId)?.status).toBe('failed');
+    });
+
+    it('fix: with the real handler registered, the same tick escalates the task to needs_input', async () => {
+      const { adapter, orchestrator, workflowId, taskId } = await setUpStalledLivenessTask();
+      const logger = makeLogger();
+      const commandService = new CommandService(orchestrator);
+      const dispatcher: Dispatcher = new Map();
+      dispatcher.set(REQUEUE_ESCALATE_CHANNEL, async (...args: unknown[]) => {
+        await executeRequeueEscalateMutation(args, { commandService, logger });
+        return { ok: true };
+      });
+      const { submit } = makeCoordinatorAndSubmit(adapter, dispatcher, logger);
+
+      const tick = createRequeueRecoveryTick({
+        store: adapter,
+        submitter: { submit },
+        logger,
+        ledger: createRequeueAttemptLedger(),
+        stallRequeueRetries: 0,
+      });
+
+      await expect(tick({ reason: 'poll' } as never)).resolves.toBeUndefined();
+      await waitFor(() => adapter.listWorkflowMutationIntents(workflowId, ['completed']).length === 1);
+
+      const intents = adapter.listWorkflowMutationIntents(workflowId);
+      expect(intents).toHaveLength(1);
+      expect(intents[0]).toMatchObject({ channel: REQUEUE_ESCALATE_CHANNEL, status: 'completed' });
+      expect(adapter.listWorkflowMutationIntents(workflowId, ['failed'])).toEqual([]);
+      expect(orchestrator.getTask(taskId)?.status).toBe('needs_input');
+    });
+  });
+});

--- a/packages/app/src/__tests__/workflow-mutation-handlers.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-handlers.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { WORKER_SUBMITTED_MUTATION_CHANNELS, WORKFLOW_RESUME_COMMAND_CHANNEL } from '@invoker/execution-engine';
+
+import { assertAllWorkerMutationChannelsRegistered, buildWorkerMutationHandlers } from '../workflow-mutation-handlers.js';
+
+function fakeDeps() {
+  return {
+    orchestrator: {} as never,
+    commandService: {} as never,
+    logger: { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} } as never,
+    runHeadlessCommand: async () => ({ ok: true }),
+    getTaskExecutor: () => ({}) as never,
+    getMutationTiming: () => undefined,
+    contextLabel: 'test',
+  };
+}
+
+describe('buildWorkerMutationHandlers', () => {
+  it('returns a handler for every worker-submitted channel except invoker:start-ready', () => {
+    const handlers = buildWorkerMutationHandlers(fakeDeps());
+    for (const channel of WORKER_SUBMITTED_MUTATION_CHANNELS) {
+      if (channel === WORKFLOW_RESUME_COMMAND_CHANNEL) continue;
+      expect(handlers.has(channel)).toBe(true);
+    }
+    expect(handlers.has(WORKFLOW_RESUME_COMMAND_CHANNEL)).toBe(false);
+  });
+});
+
+describe('assertAllWorkerMutationChannelsRegistered', () => {
+  it('passes silently when the dispatcher has every canonical channel', () => {
+    const dispatcher = new Map(WORKER_SUBMITTED_MUTATION_CHANNELS.map((channel) => [channel, async () => {}]));
+    expect(() => assertAllWorkerMutationChannelsRegistered(dispatcher, 'test')).not.toThrow();
+  });
+
+  it('throws naming every missing channel when the dispatcher has gaps', () => {
+    const [first, second, ...rest] = WORKER_SUBMITTED_MUTATION_CHANNELS;
+    const dispatcher = new Map(rest.map((channel) => [channel, async () => {}]));
+    expect(() => assertAllWorkerMutationChannelsRegistered(dispatcher, 'test')).toThrow(
+      new RegExp(`\\[test\\].*${first}.*${second}`, 's'),
+    );
+  });
+
+  it('throws when the dispatcher is completely empty', () => {
+    expect(() => assertAllWorkerMutationChannelsRegistered(new Map(), 'standalone')).toThrow(/\[standalone\]/);
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -89,10 +89,7 @@ import {
   ExecutorRegistry,
   TaskRunner,
   WorktreeExecutor,
-  INFRA_REPAIR_RECREATE_TASK_CHANNEL,
-  INFRA_REPAIR_RETRY_TASK_CHANNEL,
   initializeShellEnvironment,
-  AUTO_FIX_BARE_RETRY_CHANNEL,
   createAutoFixAttemptLedger,
   createWorkerRegistry,
   GitHubMergeGateProvider,
@@ -101,10 +98,6 @@ import {
   registerBuiltinAgents,
   registerBuiltinWorkers,
   parseSpawnRepairWorkflowMutationArgs,
-  parseInfraRepairRecreateTaskMutationArgs,
-  parseInfraRepairRetryTaskMutationArgs,
-  parseRequeueMutationArgs,
-  parseRequeueEscalateMutationArgs,
   parseReviewGateCiRepairWorkflowMutationArgs,
   parseReviewGateStackCiRepairWorkflowMutationArgs,
   fetchOpenStackPrs,
@@ -154,6 +147,7 @@ import { backupPlan } from './plan-backup.js';
 import { loadPlanSubmissionBundle } from './plan-submission-loader.js';
 import { startApiServer, type ApiServer } from './api-server.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
+import { assertAllWorkerMutationChannelsRegistered, buildWorkerMutationHandlers } from './workflow-mutation-handlers.js';
 import {
   runHeadless,
   isDelegated,
@@ -217,10 +211,6 @@ import type { WebBridgeTerminalEvents } from './web/web-bridge-server.js';
 import { preserveCrashedInFlightTasks } from './crash-preserved-tasks.js';
 
 
-import {
-  buildHeadlessFixArgs,
-  parseFixWithAgentMutationArgs,
-} from './auto-fix-intents.js';
 import { spawnReviewGateCiRepairWorkflow } from './review-gate-ci-repair-workflow.js';
 import { spawnReviewGateStackCiRepairWorkflow } from './review-gate-stack-repair-workflow.js';
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
@@ -1645,20 +1635,6 @@ function startHeadlessMode(): void {
             }),
           );
         }
-        if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
-          workflowMutationDispatcher.set('invoker:fix-with-agent', async (...fixArgs: unknown[]) => {
-            const { taskId, agentName, context } = parseFixWithAgentMutationArgs(fixArgs);
-            const args = buildHeadlessFixArgs(taskId, agentName, context);
-            await runHeadless(args, {
-              ...headlessDeps,
-              waitForApproval: false,
-              noTrack: true,
-              signal: activeMutationContext?.signal,
-              mutationTiming: activeMutationContext?.mutationTiming,
-            });
-            return { ok: true };
-          });
-        }
         if (!workflowMutationDispatcher.has('invoker:spawn-review-gate-ci-repair')) {
           workflowMutationDispatcher.set('invoker:spawn-review-gate-ci-repair', async (...repairArgs: unknown[]) => {
             const args = parseReviewGateCiRepairWorkflowMutationArgs(repairArgs);
@@ -1716,10 +1692,9 @@ function startHeadlessMode(): void {
             return result;
           });
         }
-        if (!workflowMutationDispatcher.has(INFRA_REPAIR_RETRY_TASK_CHANNEL)) {
-          workflowMutationDispatcher.set(INFRA_REPAIR_RETRY_TASK_CHANNEL, async (...retryArgs: unknown[]) => {
-            const { taskId } = parseInfraRepairRetryTaskMutationArgs(retryArgs);
-            await runHeadless(['retry-task', taskId], {
+        {
+          const standaloneRunHeadlessCommand = async (args: string[]): Promise<unknown> => {
+            await runHeadless(args, {
               ...headlessDeps,
               waitForApproval: false,
               noTrack: true,
@@ -1727,46 +1702,22 @@ function startHeadlessMode(): void {
               mutationTiming: activeMutationContext?.mutationTiming,
             });
             return { ok: true };
+          };
+          const standaloneWorkerHandlers = buildWorkerMutationHandlers({
+            orchestrator,
+            commandService,
+            logger,
+            runHeadlessCommand: standaloneRunHeadlessCommand,
+            getTaskExecutor: createStandaloneTaskExecutor,
+            getMutationTiming: () => activeMutationContext?.mutationTiming,
+            contextLabel: 'standalone',
           });
-        }
-        if (!workflowMutationDispatcher.has(INFRA_REPAIR_RECREATE_TASK_CHANNEL)) {
-          workflowMutationDispatcher.set(INFRA_REPAIR_RECREATE_TASK_CHANNEL, async (...recreateArgs: unknown[]) => {
-            const { taskId } = parseInfraRepairRecreateTaskMutationArgs(recreateArgs);
-            await runHeadless(['recreate-task', taskId], {
-              ...headlessDeps,
-              waitForApproval: false,
-              noTrack: true,
-              signal: activeMutationContext?.signal,
-              mutationTiming: activeMutationContext?.mutationTiming,
-            });
-            return { ok: true };
-          });
-        }
-        if (!workflowMutationDispatcher.has('invoker:requeue')) {
-          workflowMutationDispatcher.set('invoker:requeue', async (...requeueArgs: unknown[]) => {
-            const { taskId } = parseRequeueMutationArgs(requeueArgs);
-            await runHeadless(['retry-task', taskId], {
-              ...headlessDeps,
-              waitForApproval: false,
-              noTrack: true,
-              signal: activeMutationContext?.signal,
-              mutationTiming: activeMutationContext?.mutationTiming,
-            });
-            return { ok: true };
-          });
-        }
-        if (!workflowMutationDispatcher.has(AUTO_FIX_BARE_RETRY_CHANNEL)) {
-          workflowMutationDispatcher.set(AUTO_FIX_BARE_RETRY_CHANNEL, async (...retryArgs: unknown[]) => {
-            const taskId = String(retryArgs[0]);
-            await runHeadless(['retry-task', taskId], {
-              ...headlessDeps,
-              waitForApproval: false,
-              noTrack: true,
-              signal: activeMutationContext?.signal,
-              mutationTiming: activeMutationContext?.mutationTiming,
-            });
-            return { ok: true };
-          });
+          for (const [channel, handler] of standaloneWorkerHandlers) {
+            if (!workflowMutationDispatcher.has(channel)) {
+              workflowMutationDispatcher.set(channel, handler);
+            }
+          }
+          assertAllWorkerMutationChannelsRegistered(workflowMutationDispatcher, 'standalone');
         }
         if (!workflowMutationCoordinator) {
           workflowMutationCoordinator = new PersistedWorkflowMutationCoordinator(
@@ -2931,6 +2882,21 @@ startMainProcessBootstrap({
       workflowMutationDispatcher.set('surface:approve-task', async (taskIdArg: unknown) => {
         await mutationActions.performSharedApproveTask(String(taskIdArg), 'surface');
       });
+      {
+        const ownerWorkerHandlers = buildWorkerMutationHandlers({
+          orchestrator,
+          commandService,
+          logger,
+          runHeadlessCommand: (args) => mutationActions.executeHeadlessExec({ args, waitForApproval: false, noTrack: true }),
+          getTaskExecutor: requireTaskExecutor,
+          getMutationTiming: () => activeMutationContext?.mutationTiming,
+          contextLabel: 'owner',
+        });
+        for (const [channel, handler] of ownerWorkerHandlers) {
+          workflowMutationDispatcher.set(channel, handler);
+        }
+        assertAllWorkerMutationChannelsRegistered(workflowMutationDispatcher, 'owner');
+      }
       messageBus.onRequest('headless.owner-ping', async () => ({
         ok: true,
         ownerId: workflowMutationOwnerId,

--- a/packages/app/src/standalone-approve-task-dispatcher.ts
+++ b/packages/app/src/standalone-approve-task-dispatcher.ts
@@ -1,0 +1,62 @@
+import { makeEnvelope, type Logger } from '@invoker/contracts';
+import type { TaskRunner } from '@invoker/execution-engine';
+import type { CommandService, Orchestrator } from '@invoker/workflow-core';
+
+import { finalizeMutationWithGlobalTopup } from './global-topup.js';
+import { approveTask } from './workflow-actions.js';
+import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
+
+export interface ApproveTaskMutationDeps {
+  commandService: CommandService;
+  orchestrator: Orchestrator;
+  taskExecutor: TaskRunner;
+  logger: Logger;
+  context: string;
+  mutationTiming?: WorkflowMutationTiming;
+}
+
+/**
+ * Shared `invoker:approve` handler for the worker-facing mutation dispatcher
+ * (standalone and owner-mode IPC delegation). Mirrors
+ * `performSharedApproveTask` in `ipc/gui-mutation-handlers.ts`, which is the
+ * GUI's own wrapper around the same `approveTask` action.
+ */
+export async function executeApproveTaskMutation(
+  taskIdArg: unknown,
+  deps: ApproveTaskMutationDeps,
+): Promise<void> {
+  const taskId = String(taskIdArg);
+  deps.logger.info(`approve: "${taskId}"`, { module: 'ipc' });
+  try {
+    const { started } = await approveTask(taskId, {
+      orchestrator: deps.orchestrator,
+      taskExecutor: deps.taskExecutor,
+      approve: async (approvedTaskId) => {
+        const result = await deps.commandService.approve(
+          makeEnvelope('approve', 'ui', 'task', { taskId: approvedTaskId }),
+        );
+        if (!result.ok) throw new Error(result.error.message);
+        return result.data;
+      },
+      resumeAfterFixApproval: async (approvedTaskId) => {
+        const result = await deps.commandService.resumeTaskAfterFixApproval(
+          makeEnvelope('approve', 'ui', 'task', { taskId: approvedTaskId }),
+        );
+        if (!result.ok) throw new Error(result.error.message);
+        return result.data;
+      },
+    });
+    await finalizeMutationWithGlobalTopup({
+      orchestrator: deps.orchestrator,
+      taskExecutor: deps.taskExecutor,
+      logger: deps.logger,
+      context: deps.context,
+      started,
+      scopedTaskIds: [taskId],
+      mutationTiming: deps.mutationTiming,
+    });
+  } catch (err) {
+    deps.logger.error(`approve failed: ${err}`, { module: 'ipc' });
+    throw err;
+  }
+}

--- a/packages/app/src/standalone-requeue-escalate-dispatcher.ts
+++ b/packages/app/src/standalone-requeue-escalate-dispatcher.ts
@@ -1,0 +1,31 @@
+import { makeEnvelope, type Logger } from '@invoker/contracts';
+import { parseRequeueEscalateMutationArgs } from '@invoker/execution-engine';
+import type { CommandService } from '@invoker/workflow-core';
+
+export interface RequeueEscalateMutationDeps {
+  commandService: CommandService;
+  logger: Logger;
+}
+
+/**
+ * Shared `invoker:requeue-escalate` handler for the worker-facing mutation
+ * dispatcher (standalone and owner-mode IPC delegation). No `taskExecutor`
+ * needed: escalating a stalled task to `needs_input` pauses it for a human,
+ * it does not start new task execution.
+ */
+export async function executeRequeueEscalateMutation(
+  args: unknown[],
+  deps: RequeueEscalateMutationDeps,
+): Promise<void> {
+  const { taskId, prompt } = parseRequeueEscalateMutationArgs(args);
+  deps.logger.info(`requeue-escalate: "${taskId}"`, { module: 'ipc' });
+  try {
+    const result = await deps.commandService.escalateStalledToNeedsInput(
+      makeEnvelope('escalate-stalled', 'ui', 'task', { taskId, prompt }),
+    );
+    if (!result.ok) throw new Error(result.error.message);
+  } catch (err) {
+    deps.logger.error(`requeue-escalate failed: ${err}`, { module: 'ipc' });
+    throw err;
+  }
+}

--- a/packages/app/src/workflow-mutation-handlers.ts
+++ b/packages/app/src/workflow-mutation-handlers.ts
@@ -1,0 +1,138 @@
+import {
+  AUTO_APPROVE_COMMAND_CHANNEL,
+  AUTO_FIX_BARE_RETRY_CHANNEL,
+  AUTO_FIX_COMMAND_CHANNEL,
+  buildHeadlessFixArgs,
+  INFRA_REPAIR_RECREATE_TASK_CHANNEL,
+  INFRA_REPAIR_RETRY_TASK_CHANNEL,
+  parseFixWithAgentMutationArgs,
+  parseInfraRepairRecreateTaskMutationArgs,
+  parseInfraRepairRetryTaskMutationArgs,
+  parseRequeueMutationArgs,
+  REQUEUE_COMMAND_CHANNEL,
+  REQUEUE_ESCALATE_CHANNEL,
+  WORKER_SUBMITTED_MUTATION_CHANNELS,
+  type TaskRunner,
+} from '@invoker/execution-engine';
+
+import type { Logger } from '@invoker/contracts';
+import type { CommandService, Orchestrator } from '@invoker/workflow-core';
+
+import { executeApproveTaskMutation } from './standalone-approve-task-dispatcher.js';
+import { executeRequeueEscalateMutation } from './standalone-requeue-escalate-dispatcher.js';
+import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
+
+export type WorkflowMutationHandler = (...args: unknown[]) => Promise<unknown>;
+
+export interface WorkerMutationHandlerDeps {
+  orchestrator: Orchestrator;
+  commandService: CommandService;
+  logger: Logger;
+  /**
+   * Runs a headless-command-shaped mutation (`['retry-task', taskId]` etc.),
+   * the same operation every pre-existing `runHeadless(...)`-based handler
+   * performs. Standalone mode passes `runHeadless` directly; owner mode has
+   * no `HeadlessDeps` of its own and instead delegates through
+   * `mutationActions.executeHeadlessExec` — this abstraction lets both modes
+   * share one handler implementation without needing the same concrete
+   * execution mechanism.
+   */
+  runHeadlessCommand: (args: string[]) => Promise<unknown>;
+  /**
+   * Resolved fresh on every dispatch (matches how the pre-existing
+   * standalone/owner blocks already call `createStandaloneTaskExecutor()` /
+   * `requireTaskExecutor()` inline rather than capturing a stale instance).
+   */
+  getTaskExecutor: () => TaskRunner;
+  /** Read fresh per dispatch — both modes track this as a mutable local variable. */
+  getMutationTiming: () => WorkflowMutationTiming | undefined;
+  /** `'standalone'` or `'owner'` — only used for log/context strings. */
+  contextLabel: string;
+}
+
+/**
+ * Builds every worker-submitted mutation channel's handler exactly once.
+ * Call this identically from both `main.ts`'s standalone-mode block and its
+ * owner-mode IPC delegation block so the two can never drift out of sync
+ * again — that drift is the root cause behind the `invoker:retry-task` gap
+ * recurring three times (#6808, #7643, #8060) and the `invoker:approve` /
+ * `invoker:requeue-escalate` gaps found in this repo's mutation-channel audit.
+ *
+ * `invoker:start-ready` is intentionally NOT included here even though it is
+ * a worker-submitted channel: both blocks already register a working (if
+ * structurally different) handler for it today, so unifying it here would be
+ * pure risk with no bug to fix. It stays in `WORKER_SUBMITTED_MUTATION_CHANNELS`
+ * so completeness checks still cover it.
+ */
+export function buildWorkerMutationHandlers(deps: WorkerMutationHandlerDeps): Map<string, WorkflowMutationHandler> {
+  const { orchestrator, commandService, logger, runHeadlessCommand, getTaskExecutor, getMutationTiming, contextLabel } = deps;
+  const handlers = new Map<string, WorkflowMutationHandler>();
+
+  handlers.set(AUTO_FIX_COMMAND_CHANNEL, async (...fixArgs: unknown[]) => {
+    const { taskId, agentName, context } = parseFixWithAgentMutationArgs(fixArgs);
+    return runHeadlessCommand(buildHeadlessFixArgs(taskId, agentName, context));
+  });
+
+  handlers.set(AUTO_FIX_BARE_RETRY_CHANNEL, async (...retryArgs: unknown[]) => {
+    return runHeadlessCommand(['retry-task', String(retryArgs[0])]);
+  });
+
+  handlers.set(REQUEUE_COMMAND_CHANNEL, async (...requeueArgs: unknown[]) => {
+    const { taskId } = parseRequeueMutationArgs(requeueArgs);
+    return runHeadlessCommand(['retry-task', taskId]);
+  });
+
+  handlers.set(INFRA_REPAIR_RETRY_TASK_CHANNEL, async (...retryArgs: unknown[]) => {
+    const { taskId } = parseInfraRepairRetryTaskMutationArgs(retryArgs);
+    return runHeadlessCommand(['retry-task', taskId]);
+  });
+
+  handlers.set(INFRA_REPAIR_RECREATE_TASK_CHANNEL, async (...recreateArgs: unknown[]) => {
+    const { taskId } = parseInfraRepairRecreateTaskMutationArgs(recreateArgs);
+    return runHeadlessCommand(['recreate-task', taskId]);
+  });
+
+  handlers.set(AUTO_APPROVE_COMMAND_CHANNEL, async (...args: unknown[]) => {
+    await executeApproveTaskMutation(args[0], {
+      commandService,
+      orchestrator,
+      taskExecutor: getTaskExecutor(),
+      logger,
+      context: `${contextLabel}.approve`,
+      mutationTiming: getMutationTiming(),
+    });
+    return { ok: true };
+  });
+
+  handlers.set(REQUEUE_ESCALATE_CHANNEL, async (...args: unknown[]) => {
+    await executeRequeueEscalateMutation(args, { commandService, logger });
+    return { ok: true };
+  });
+
+  return handlers;
+}
+
+/**
+ * Throws once, naming every missing channel, if any worker-submitted
+ * channel lacks a registered handler. Call this immediately after wiring
+ * `buildWorkerMutationHandlers()` into the live dispatcher, before the
+ * process finishes starting standalone/owner mode — a missing handler here
+ * means a background worker's mutation will silently fail (marked `failed`
+ * on the persisted intent, no crash, easy to miss) the first time it is
+ * actually dispatched, so failing fast at boot is deliberately louder than
+ * that.
+ */
+export function assertAllWorkerMutationChannelsRegistered(
+  dispatcher: Pick<Map<string, unknown>, 'has'>,
+  contextLabel: string,
+): void {
+  const missing = WORKER_SUBMITTED_MUTATION_CHANNELS.filter((channel) => !dispatcher.has(channel));
+  if (missing.length > 0) {
+    throw new Error(
+      `[${contextLabel}] Missing workflowMutationDispatcher registration for worker-submitted channel(s): ` +
+      `${missing.join(', ')}. A background worker that submits through any of these channels will have its ` +
+      'mutation silently fail the first time it is dispatched. Add the missing handler(s) to ' +
+      'buildWorkerMutationHandlers() in workflow-mutation-handlers.ts.',
+    );
+  }
+}

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -57,6 +57,7 @@ export * from './worker-runtime-dependencies.js';
 export * from './worker-types.js';
 export * from './worker-lock.js';
 export * from './builtin-workers.js';
+export * from './worker-mutation-channels.js';
 export * from './auto-fix-recovery.js';
 export * from './review-gate-ci-repair.js';
 export * from './repair-workflow-spec.js';

--- a/packages/execution-engine/src/worker-mutation-channels.ts
+++ b/packages/execution-engine/src/worker-mutation-channels.ts
@@ -1,0 +1,33 @@
+import { AUTO_FIX_BARE_RETRY_CHANNEL, AUTO_FIX_COMMAND_CHANNEL } from './auto-fix-recovery.js';
+import { AUTO_APPROVE_COMMAND_CHANNEL } from './workers/auto-approve-worker.js';
+import { INFRA_REPAIR_RECREATE_TASK_CHANNEL, INFRA_REPAIR_RETRY_TASK_CHANNEL } from './workers/infra-repair-worker.js';
+import { REQUEUE_COMMAND_CHANNEL, REQUEUE_ESCALATE_CHANNEL } from './workers/requeue-worker.js';
+import { WORKFLOW_RESUME_COMMAND_CHANNEL } from './workers/workflow-resume-worker.js';
+
+/**
+ * Every channel a built-in background worker uses to submit a mutation
+ * intent (via its injected submitter), i.e. every channel that a running
+ * owner/standalone process must have a `workflowMutationDispatcher` handler
+ * registered for, or a worker's submission silently fails once
+ * `PersistedWorkflowMutationCoordinator` tries to dispatch it.
+ *
+ * This list exists because the same channel gap has landed in production
+ * three times for one channel alone (`invoker:retry-task`: #6808 merged as a
+ * no-op, #7643 fixed the standalone block, #8060 fixed the owner-mode IPC
+ * delegation block) because nothing forced the hand-written registration
+ * blocks in `packages/app/src/main.ts` to list the same channels. Add a new
+ * worker-submitted channel here the same commit you wire the worker's own
+ * submission call, so `assertAllWorkerMutationChannelsRegistered` and the
+ * completeness test catch a missing registration immediately instead of
+ * shipping a mutation that silently never runs.
+ */
+export const WORKER_SUBMITTED_MUTATION_CHANNELS: readonly string[] = [
+  AUTO_FIX_COMMAND_CHANNEL,
+  AUTO_FIX_BARE_RETRY_CHANNEL,
+  AUTO_APPROVE_COMMAND_CHANNEL,
+  REQUEUE_COMMAND_CHANNEL,
+  REQUEUE_ESCALATE_CHANNEL,
+  INFRA_REPAIR_RETRY_TASK_CHANNEL,
+  INFRA_REPAIR_RECREATE_TASK_CHANNEL,
+  WORKFLOW_RESUME_COMMAND_CHANNEL,
+];

--- a/packages/execution-engine/src/workers/auto-approve-worker.ts
+++ b/packages/execution-engine/src/workers/auto-approve-worker.ts
@@ -17,7 +17,7 @@ import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../wor
 
 export const AUTO_APPROVE_WORKER_KIND = 'autoapprove';
 export const DEFAULT_AUTO_APPROVE_WORKER_INTERVAL_MS = 60_000;
-const AUTO_APPROVE_COMMAND_CHANNEL = 'invoker:approve';
+export const AUTO_APPROVE_COMMAND_CHANNEL = 'invoker:approve';
 const AUTO_APPROVE_ACTION_TYPE = 'approve-ai-fix';
 
 type AutoApproveActionStatus = WorkerActionStatus;


### PR DESCRIPTION
## Summary

Two background actions, approving a fix and moving a stuck task into a state that asks a person for input, have never actually worked. The real running process never had anything wired up to answer their channel.

This hooks both channels into the real process, in both places a process can start (standalone and owner mode).

It uses the shared builder added earlier in this stack instead of two more hand-copied entries. It also adds a hard check at process boot.

If any of these channels is ever left unanswered again, the process refuses to start instead of quietly shipping a broken worker.

## Review Claim

Approve wiring the two missing channels into the real process in both startup modes, plus the boot-time check that catches this class of gap going forward.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The only two channels newly answered here were previously answered nowhere at all, so wiring them in can only turn an existing silent failure into working behavior — there is no existing working path on either channel to break. The channel already being fixed by a separate open PR keeps its own path untouched, and the already-working channel for waking a ready workflow keeps its own separate registration, unchanged, in both modes.

## Slice Rationale

Third of three slices. The first slice added the new code; the second slice proved it works; this slice is the actual fix, hooking that proven code into the real process, plus the coverage that checks the real process is wired correctly in every mode.

## Non-goals

Does not touch GUI-mode registration: it answers a direct button press, a different code path with no gap to fix (confirmed by reading it directly — it already only registers channels that have a matching button). Does not touch the already-working channel for waking a ready workflow. Does not touch the channel already being fixed by a separate open PR.

## Visual Proof

This diff only touches two headless dispatcher-registration blocks in `main.ts` (standalone and owner-mode startup) — no window, menu, or renderer code. The repo's tooling flags any `main.ts` touch as UI-impacting regardless of content, so this section proves there is no visual difference rather than showing a new behavior.

Captured with `bash scripts/ui-visual-proof.sh capture-before` on this PR's base branch and `capture-after` on this PR's branch, covering the full existing visual-proof suite (94–99 states). Two representative states below; the only pixel difference across the whole suite is the live task-event timestamp text, which is expected between two separate capture runs, not a regression.

**Task panel** — before:

![task panel before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260809-449ddb/task-panel-before.png)

**Task panel** — after:

![task panel after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260809-449ddb/task-panel-after.png)

**Workflow graph** — before:

![workflow graph before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260809-449ddb/dag-loaded-before.png)

**Workflow graph** — after:

![workflow graph after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260809-449ddb/dag-loaded-after.png)

Full side-by-side comparison video across the whole suite: [side-by-side comparison video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260809-449ddb/comparison.webm)

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- src/__tests__/owner-worker-mutation-dispatcher-completeness.test.ts`
- [ ] `cd packages/app && pnpm test -- src/__tests__/no-requeue-outside-worker.test.ts`
- [ ] `pnpm --filter @invoker/app test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
