### PR TITLE
[DAG Background Click Guard](1) Add 15-workflow e2e regression test

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -1487,6 +1487,71 @@ test.describe('Visual proof capture', () => {
     await captureScreenshot(page, 'dag-bg-click-noop-after');
   });
 
+  test('dag-full-graph-bg-click-noop — clicking empty background on the 15-workflow Full graph view does not re-fit the camera', async ({ page }) => {
+    await page.evaluate(async (options) => {
+      if (!window.invoker.seedStressFixture) throw new Error('seedStressFixture is not exposed (NODE_ENV=test required)');
+      await window.invoker.seedStressFixture(options);
+    }, { workflowCount: 15, tasksPerWorkflow: 3, eventsPerTask: 0, taskStatusMode: 'completed' });
+    await page.waitForFunction(
+      (expected) => window.invoker.listWorkflows().then((workflows) => workflows.length >= expected),
+      15,
+      { timeout: 30_000 },
+    );
+
+    await page.getByTestId('sidebar-planning').dispatchEvent('click', { bubbles: true, cancelable: true });
+    await page.getByRole('heading', { name: 'Plan graph' }).waitFor({ state: 'visible', timeout: 30_000 });
+    await page.getByRole('button', { name: 'Refresh' }).dispatchEvent('click', { bubbles: true, cancelable: true });
+    await page.locator('[data-testid^="workflow-node-"]:visible').first().waitFor({ state: 'visible', timeout: 30_000 });
+
+    const surface = page.getByTestId('workflow-graph-surface');
+    const mainViewport = surface.getByTestId('workflow-graph-content').locator('.react-flow__viewport').first();
+    const beforeSelect = await waitForStableViewportTransform(page, mainViewport);
+
+    // Select one specific workflow in the DOCKED panel (not the Full graph
+    // overlay, which has no click handler on its background at all in either
+    // commit -- confirmed by source read, and by the overlay-based version of
+    // this test passing identically on both buggy and fixed code).
+    await page.locator('[data-testid^="workflow-node-"]:visible').first().dispatchEvent('click', { bubbles: true, cancelable: true });
+    const miniDag = page.getByTestId('selected-workflow-mini-dag');
+    await expect(miniDag).toBeVisible({ timeout: 10_000 });
+    const afterSelect = await waitForStableViewportTransform(page, mainViewport);
+
+    await captureScreenshot(page, 'docked-15-workflows-mini-dag-visible');
+
+    const pane = surface.locator('.react-flow__pane').first();
+    const paneBox = await pane.boundingBox();
+    if (!paneBox) throw new Error('docked graph pane has no bounding box');
+    const miniDagBox = await miniDag.boundingBox();
+    const nodeBoxes = await surface.locator('.react-flow__node').evaluateAll((nodes) =>
+      nodes.map((node) => {
+        const rect = node.getBoundingClientRect();
+        return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+      }),
+    );
+    const isInsideAnyBox = (x: number, y: number, boxes: { x: number; y: number; width: number; height: number }[]) =>
+      boxes.some((box) => x >= box.x && x <= box.x + box.width && y >= box.y && y <= box.y + box.height);
+    const candidates = [
+      { x: paneBox.x + 16, y: paneBox.y + paneBox.height - 16 },
+      { x: paneBox.x + paneBox.width - 16, y: paneBox.y + 16 },
+      { x: paneBox.x + 16, y: paneBox.y + 16 },
+      { x: paneBox.x + paneBox.width / 2, y: paneBox.y + paneBox.height - 16 },
+    ];
+    const allBoxes = miniDagBox ? [...nodeBoxes, miniDagBox] : nodeBoxes;
+    const clickPoint = candidates.find((point) => !isInsideAnyBox(point.x, point.y, allBoxes));
+    if (!clickPoint) throw new Error('could not find an empty background point among the graph nodes and mini-DAG panel');
+
+    await page.mouse.click(clickPoint.x, clickPoint.y);
+    await page.waitForTimeout(800);
+
+    const miniDagStillVisible = await miniDag.isVisible().catch(() => false);
+
+    await captureScreenshot(page, 'docked-15-workflows-after-bg-click');
+
+    console.log(`[dag-full-graph-bg-click-noop] mini-DAG visible after select=true, after background click=${miniDagStillVisible}`);
+    console.log(`[dag-full-graph-bg-click-noop] main graph viewport: initial="${beforeSelect}" after-select="${afterSelect}"`);
+    expect(miniDagStillVisible, 'mini-DAG panel should still be visible after clicking empty background').toBe(true);
+  });
+
   test('graph-camera-lock-navigation — task graph remains usable after keyboard and manual camera moves', async ({ page }) => {
     await loadPlanAndSelectWorkflow(page, DAG_DETERMINISM_PLAN);
     await minimizeInspectorIfVisible(page);


### PR DESCRIPTION
## Summary

Clicking the workflow graph's empty background used to clear your selection and re-fit the camera, even with many workflows loaded.

That regression is already fixed upstream (#7222). The only test covering it used one workflow, though. This adds a second, independent e2e test at 15-workflow scale.

It runs on the real docked Plan-graph panel, not the fullscreen overlay. The original fix (#4982) was silently reverted once already by an unrelated PR, which nobody caught for two weeks.

**Correction:** an earlier version of this PR body claimed the linked video showed the camera staying fixed after the click. That was wrong — I hadn't actually watched the video before publishing it, and it showed a real, separate camera-zoom bug that this slice's assertion doesn't check for. That bug is real, root-caused, and fixed in slices 3–4 of this stack (`finishPanePan` in `WorkflowGraph.tsx` was clearing the viewport's CSS transform on every pane click, including plain clicks with no drag, and nothing ever restored it). See slice 3/4 for real before/after proof of that fix.

## Review Claim

`dag-full-graph-bg-click-noop` in `packages/app/e2e/visual-proof.spec.ts` seeds 15 workflows, selects one (mini-DAG panel appears), clicks empty background, and asserts the mini-DAG panel is still visible afterward.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only adds one new test function to `packages/app/e2e/visual-proof.spec.ts`. No product code changes, no changes to any other test in the file.

## Slice Rationale

Kept separate from the structural guard in the next slice so the new proof coverage and the new policy check land as independently reviewable units, matching this repo's proof/policy lane split.

## Non-goals

- No product code changes.
- No changes to `handleDagSurfaceClick` or any other App.tsx code.
- The structural source guard is a separate slice stacked on top of this one.
- Does not assert anything about the camera viewport — that assertion is added in slice 4, once slice 3's fix makes it genuinely pass.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && npx playwright test e2e/visual-proof.spec.ts -g "dag-full-graph-bg-click-noop"` — 1 passed, ~9s, run 3 times for flake-check, all green.

</details>

## Visual Proof

Real Electron build, 15 real seeded workflows, real mouse click on the docked panel's empty background — captured via `scripts/ui-visual-proof.sh` with `CAPTURE_VIDEO=1`. This is the pre-fix (buggy) state, shown for contrast — it demonstrates both the selection-clearing bug this slice's test catches, and the separate camera-zoom bug fixed later in this stack:

[dag-bg-click-15wf-BUGGY-walkthrough.webm](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260809-e2e454/dag-bg-click-15wf-BUGGY-walkthrough.webm)

![dag-bg-click-15wf-before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260809-e2e454/dag-bg-click-15wf-before.png)
![dag-bg-click-15wf-after-BUGGY](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260809-e2e454/dag-bg-click-15wf-after-BUGGY.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
