### PR TITLE
[DAG Background Click Guard](2) Add required source guard for handleDagSurfaceClick

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,7 @@ jobs:
               bash scripts/test-suites/required/06-large-file-guardrail.sh
               bash scripts/test-suites/required/07-invalid-config-json.sh
               bash scripts/test-suites/required/08-build-artifact-surfaces-guard.sh
+              bash scripts/test-suites/required/10-dag-background-click-noop-guard.sh
               bash scripts/test-suites/required/15-owner-boundary-policy.sh
               bash scripts/test-suites/required/50-verify-executor-routing.sh
           - name: Vitest Workspace

--- a/scripts/test-suites/required/10-dag-background-click-noop-guard.sh
+++ b/scripts/test-suites/required/10-dag-background-click-noop-guard.sh
@@ -14,38 +14,72 @@ cd "$ROOT"
 node - <<'EOF'
 const fs = require('fs');
 const path = require('path');
+const ts = require('typescript');
 
 const filePath = path.join('packages', 'ui', 'src', 'App.tsx');
 const src = fs.readFileSync(filePath, 'utf8');
+const sourceFile = ts.createSourceFile(filePath, src, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
 
-const startMarker = 'const handleDagSurfaceClick = useCallback(';
-const startIdx = src.indexOf(startMarker);
-if (startIdx === -1) {
-  console.error(`FAIL: could not find "${startMarker}" in ${filePath}`);
+function findHandleDagSurfaceClick(node) {
+  if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.name.text === 'handleDagSurfaceClick') {
+    return node.initializer;
+  }
+
+  return ts.forEachChild(node, findHandleDagSurfaceClick);
+}
+
+function unwrapExpression(node) {
+  let current = node;
+  while (ts.isParenthesizedExpression(current) || ts.isAsExpression(current) || ts.isTypeAssertionExpression(current)) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function expressionMatches(node, expectedKind) {
+  return unwrapExpression(node).kind === expectedKind;
+}
+
+function calleeName(node) {
+  const expression = unwrapExpression(node.expression);
+  return ts.isIdentifier(expression) ? expression.text : null;
+}
+
+const handleDagSurfaceClick = findHandleDagSurfaceClick(sourceFile);
+if (!handleDagSurfaceClick) {
+  console.error(`FAIL: could not find "handleDagSurfaceClick" in ${filePath}`);
   process.exit(1);
 }
 
-let depth = 0;
-let end = -1;
-for (let i = startIdx + startMarker.length - 1; i < src.length; i += 1) {
-  const ch = src[i];
-  if (ch === '(') depth += 1;
-  else if (ch === ')') {
-    depth -= 1;
-    if (depth === 0) {
-      end = i;
-      break;
+if (!ts.isCallExpression(handleDagSurfaceClick) || calleeName(handleDagSurfaceClick) !== 'useCallback') {
+  console.error('FAIL: handleDagSurfaceClick is not initialized with useCallback(...)');
+  process.exit(1);
+}
+
+const forbidden = new Map([
+  ['setSelectedTaskId', ts.SyntaxKind.NullKeyword],
+  ['setSelectedWorkflowId', ts.SyntaxKind.NullKeyword],
+  ['setWorkflowSelectionDismissed', ts.SyntaxKind.TrueKeyword],
+]);
+const found = [];
+
+function inspect(node) {
+  if (ts.isCallExpression(node)) {
+    const name = calleeName(node);
+    const expectedArgumentKind = forbidden.get(name);
+    if (
+      expectedArgumentKind !== undefined &&
+      node.arguments.length > 0 &&
+      expressionMatches(node.arguments[0], expectedArgumentKind)
+    ) {
+      found.push(node.getText(sourceFile));
     }
   }
-}
-if (end === -1) {
-  console.error('FAIL: could not find the end of the handleDagSurfaceClick useCallback(...) call');
-  process.exit(1);
+
+  ts.forEachChild(node, inspect);
 }
 
-const body = src.slice(startIdx, end + 1);
-const forbidden = ['setSelectedTaskId(null)', 'setSelectedWorkflowId(null)', 'setWorkflowSelectionDismissed(true)'];
-const found = forbidden.filter((call) => body.includes(call));
+inspect(handleDagSurfaceClick.arguments[0] ?? handleDagSurfaceClick);
 
 if (found.length > 0) {
   console.error('FAIL: handleDagSurfaceClick must be a no-op on background click (closing an open context menu excluded).');

--- a/scripts/test-suites/required/10-dag-background-click-noop-guard.sh
+++ b/scripts/test-suites/required/10-dag-background-click-noop-guard.sh
@@ -30,7 +30,12 @@ function findHandleDagSurfaceClick(node) {
 
 function unwrapExpression(node) {
   let current = node;
-  while (ts.isParenthesizedExpression(current) || ts.isAsExpression(current) || ts.isTypeAssertionExpression(current)) {
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isTypeAssertionExpression(current) ||
+    ts.isNonNullExpression(current)
+  ) {
     current = current.expression;
   }
   return current;

--- a/scripts/test-suites/required/10-dag-background-click-noop-guard.sh
+++ b/scripts/test-suites/required/10-dag-background-click-noop-guard.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Guardrail: clicking the workflow graph's empty background must stay a no-op
+# for task/workflow selection. This behavior shipped (#4982), was silently
+# reverted by an unrelated PR that also flipped the one e2e assertion covering
+# it so CI stayed green through the regression (#5067), and was re-fixed
+# (#7222/#7223). This checks the literal handler source, independent of any
+# e2e test, so a reintroduced clear-on-click call fails loudly and immediately
+# instead of depending on a Playwright assertion nobody notices got flipped.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+node - <<'EOF'
+const fs = require('fs');
+const path = require('path');
+
+const filePath = path.join('packages', 'ui', 'src', 'App.tsx');
+const src = fs.readFileSync(filePath, 'utf8');
+
+const startMarker = 'const handleDagSurfaceClick = useCallback(';
+const startIdx = src.indexOf(startMarker);
+if (startIdx === -1) {
+  console.error(`FAIL: could not find "${startMarker}" in ${filePath}`);
+  process.exit(1);
+}
+
+let depth = 0;
+let end = -1;
+for (let i = startIdx + startMarker.length - 1; i < src.length; i += 1) {
+  const ch = src[i];
+  if (ch === '(') depth += 1;
+  else if (ch === ')') {
+    depth -= 1;
+    if (depth === 0) {
+      end = i;
+      break;
+    }
+  }
+}
+if (end === -1) {
+  console.error('FAIL: could not find the end of the handleDagSurfaceClick useCallback(...) call');
+  process.exit(1);
+}
+
+const body = src.slice(startIdx, end + 1);
+const forbidden = ['setSelectedTaskId(null)', 'setSelectedWorkflowId(null)', 'setWorkflowSelectionDismissed(true)'];
+const found = forbidden.filter((call) => body.includes(call));
+
+if (found.length > 0) {
+  console.error('FAIL: handleDagSurfaceClick must be a no-op on background click (closing an open context menu excluded).');
+  console.error(`Found forbidden call(s): ${found.join(', ')}`);
+  console.error('This exact regression shipped before (#5067, silently reverting #4982) and was re-fixed by #7222.');
+  console.error('If background click should clear selection again, that is an explicit product decision: update this guard deliberately, do not delete it.');
+  process.exit(1);
+}
+
+console.log('PASS: handleDagSurfaceClick has no forbidden selection-clearing calls');
+EOF


### PR DESCRIPTION
## Summary

The click-to-clear-selection regression on the workflow graph's background has shipped twice: fixed by #4982, silently reverted by an unrelated PR two days later, and not caught for two weeks because that PR also flipped the one test covering it.

A behavioral test living in a 3,000-line spec file is exactly the kind of thing an unrelated refactor can quietly flip without a reviewer noticing. This adds a second, structural layer that doesn't depend on any Playwright assertion staying correct.

The new guard reads the literal source of `handleDagSurfaceClick` in `App.tsx` and fails if it ever calls `setSelectedTaskId(null)`, `setSelectedWorkflowId(null)`, or `setWorkflowSelectionDismissed(true)` again. It's wired into `required-fast / Guardrails`, which Mergify already blocks merges on.

## Review Claim

`scripts/test-suites/required/10-dag-background-click-noop-guard.sh` fails the build if `handleDagSurfaceClick` reintroduces the forbidden selection-clearing calls; it's added as one more command in the existing `required-fast / Guardrails` matrix entry in `ci.yml`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only adds a new script and one line to the existing `Guardrails` matrix `command:` block in `ci.yml`. No other `required-fast` entries, jobs, or product code change. No new Mergify required-check name is introduced.

## Slice Rationale

Stacked on top of the new e2e test slice so the proof and the policy check land as separate reviewable units.

## Non-goals

- No product code changes.
- No changes to any other guard script or CI job.
- Does not touch `.mergify.yml`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-suites/required/10-dag-background-click-noop-guard.sh` — exits 0 on this branch.
- [x] Same command against the pre-fix commit (a700d6ae7) during investigation — exited 1 with `FAIL: handleDagSurfaceClick must be a no-op on background click ... Found forbidden call(s): setSelectedTaskId(null), setSelectedWorkflowId(null), setWorkflowSelectionDismissed(true)`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated validation to ensure background clicks in the DAG do not unintentionally clear task or workflow selections.
  * Included this check in the required fast verification suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->