### PR TITLE
[CI regression: f84c1ed-required-fast-mergify-admin-requeue](1) Repair admin requeue stack metadata

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -6,7 +6,11 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ startsWith(github.head_ref, 'mergify/merge-queue/') && format('merge-queue-{0}', github.head_ref) || format('pr-{0}', github.event.pull_request.number) }}
-  cancel-in-progress: true
+  # Mergify treats cancelled required checks as failed checks. Merge-queue
+  # wrapper PRs can emit several pull_request_target events for the same head,
+  # so let those runs finish instead of cancelling an earlier PR Body check
+  # that Mergify may already be watching.
+  cancel-in-progress: ${{ !startsWith(github.head_ref, 'mergify/merge-queue/') }}
 
 permissions:
   contents: read

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -1047,10 +1047,11 @@ def plan_stack_execution(
             prereq_status=facts.prereq_status,
             queue_only_noop_check=facts.queue_only_noop_check,
         )
+    wait_reason = "repair-in-flight" if has_active_repair_for_current_blocker(facts, ledger, now_epoch) else wait_reason_for_facts(facts)
     return StackExecutionPlan(
         summary=summary,
         actions=(),
-        wait_reason=wait_reason_for_facts(facts),
+        wait_reason=wait_reason,
         prereq_status=facts.prereq_status,
         queue_only_noop_check=facts.queue_only_noop_check,
     )

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -5,9 +5,11 @@ import YAML from 'yaml';
 const FULL_CI_GATE = "${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}";
 const NON_PR_GATE = "${{ github.event_name != 'pull_request' }}";
 const ORDINARY_PR_GATE = "${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}";
+const PR_BODY_MERGE_QUEUE_CANCEL_GATE = "${{ !startsWith(github.head_ref, 'mergify/merge-queue/') }}";
 const FULL_CI_JOBS = new Set(['build-artifacts', 'e2e-proof', 'e2e-proof-aggregate', 'required-fast', 'playwright', 'ssh', 'optional-other']);
 
 const workflow = YAML.parse(readFileSync('.github/workflows/ci.yml', 'utf8'));
+const prBodyWorkflow = YAML.parse(readFileSync('.github/workflows/pr-body.yml', 'utf8'));
 const mergify = YAML.parse(readFileSync('.mergify.yml', 'utf8'));
 const jobs = workflow.jobs ?? {};
 
@@ -44,6 +46,16 @@ assert(jobs['quality-extra'].if === ORDINARY_PR_GATE, 'quality-extra must run on
 
 assert(jobs.docker, 'Missing docker job');
 assert(jobs.docker.if === NON_PR_GATE, 'docker must not run on pull_request events');
+
+assert(prBodyWorkflow.concurrency, 'PR Body workflow must declare concurrency');
+assert(
+  String(prBodyWorkflow.concurrency.group ?? '').includes("startsWith(github.head_ref, 'mergify/merge-queue/')"),
+  'PR Body workflow must isolate merge-queue heads in its concurrency group',
+);
+assert(
+  prBodyWorkflow.concurrency['cancel-in-progress'] === PR_BODY_MERGE_QUEUE_CANCEL_GATE,
+  'PR Body workflow must not cancel in-progress merge-queue runs',
+);
 
 const mergeConditions = (mergify.queue_rules ?? []).flatMap((rule) => rule.merge_conditions ?? []);
 const requiredChecks = new Set(

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -703,6 +703,8 @@ class PlanStackActions(PlannerTestCase):
         ledger.record("repair-check", 5885, HEAD, "build", epoch=NOW - 100)
         actions = p.plan_stack_actions(stack, REQUIRED, ledger, now_epoch=NOW, open_pr_numbers_by_head={})
         self.assertEqual(actions, ())
+        execution = p.plan_stack_execution(stack, REQUIRED, ledger, NOW, (), {}, trunk="master")
+        self.assertEqual(execution.wait_reason, "repair-in-flight")
 
     def test_requeue_is_capped_after_repeated_attempts(self):
         ledger = self._ledger()


### PR DESCRIPTION
## Summary

The admin requeue planner reports an active repair wait state before taking another blocker action.

PR Body validation no longer cancels in-progress merge-queue runs, so Mergify does not treat a superseded required check as failed while the replacement run is still pending.

## Review Claim

Approve the Mergify admin requeue and PR Body merge-queue policy fix.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change is limited to admin requeue scripts, PR Body workflow policy, and direct policy coverage for the repaired queue path.

## Slice Rationale

One tooling-policy slice repairs the required merge-queue path that could act while a repair was already active or fail due to cancelled PR Body runs.

## Non-goals

- No product runtime behavior changes.
- No UI behavior changes.
- No weakening of CI or PR body validation.
- No checked-in repro script changes in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [x] `node scripts/test-resolve-pr-body-targets.mjs`
- [x] `bash scripts/test-suites/required/12-mergify-admin-requeue.sh` (passes on the requested `plan/...` repair branch; #8105 alone still needs the stacked #8106 proof slice for the repro harness)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2951084f4 d67e3840e`
- Post-revert steps: Re-run the PR Body workflow policy test and admin-requeue suite.
- Data migration? No

</details>
