### PR TITLE
[Onboarding wizard hardening](1) Add diskHeadroom.cleanupEnabled config field

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -306,6 +306,24 @@ describe('loadConfig', () => {
     expect(config.prMaintenance).toEqual(prMaintenance);
   });
 
+  it('defaults diskHeadroom to undefined when absent', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ defaultBranch: 'main' }),
+    );
+    const config = loadConfig();
+    expect(config.diskHeadroom).toBeUndefined();
+  });
+
+  it('reads diskHeadroom.cleanupEnabled from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ diskHeadroom: { cleanupEnabled: false } }),
+    );
+    const config = loadConfig();
+    expect(config.diskHeadroom).toEqual({ cleanupEnabled: false });
+  });
+
   it('reads imageStorage from user config', () => {
     const imageStorage = {
       provider: 'r2',

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -385,6 +385,14 @@ export interface InvokerConfig {
    * PR-maintenance workers from this block.
    */
   prMaintenance?: PrMaintenanceConfig;
+  /**
+   * Owner-side disk-headroom worker config. `cleanupEnabled` takes precedence
+   * over the legacy `INVOKER_DISK_CLEANUP_ENABLED` env var when set; the worker
+   * falls back to the env var only when this is left unset. Default: enabled.
+   */
+  diskHeadroom?: {
+    cleanupEnabled?: boolean;
+  };
 }
 export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarnessPresets']> = {
   'cursor+claude': { tool: 'cursor', model: 'claude' },


### PR DESCRIPTION
## Summary

The disk-headroom worker's file-reclaim behavior was controlled by a bare `INVOKER_DISK_CLEANUP_ENABLED` environment variable, disconnected from every other worker's on/off setting in `config.json`.

Adds `diskHeadroom.cleanupEnabled` to `InvokerConfig` as a real config field. It isn't read anywhere yet — that wiring lands in the next slice.

## Review Claim

Approve adding this one optional config field and its parsing test, with no behavior change yet.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

The field is optional and unused by any code path in this slice, so no existing behavior can change. Config files that omit it parse exactly as before.

## Slice Rationale

This is the foundation slice: the field must exist before the next slice can thread it into the owner's worker dependencies. Keeping it apart from that wiring change keeps each one easier to review.

## Non-goals

Does not read or act on the new field. Does not remove the existing `INVOKER_DISK_CLEANUP_ENABLED` env var fallback.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/config.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No — an already-written `diskHeadroom.cleanupEnabled` value in a user's config.json is simply ignored again after revert.

</details>