### PR TITLE
[Onboarding wizard hardening](3) Wire diskHeadroom.cleanupEnabled into owner boot

### DIFF
--- a/packages/app/src/__tests__/workspace-import-resolution.test.ts
+++ b/packages/app/src/__tests__/workspace-import-resolution.test.ts
@@ -32,6 +32,12 @@ function collectInvokerImports(sourceCode: string): string[] {
   return [...imports].sort();
 }
 
+/** package.json declares the package (`@invoker/cli`), never a subpath export (`@invoker/cli/bundled-skills`). */
+function packageNameOf(specifier: string): string {
+  const parts = specifier.split('/');
+  return parts.slice(0, 2).join('/');
+}
+
 describe('workspace import resolution', () => {
   const invokerImports = collectInvokerImports(mainSource);
   const declaredDependencies = new Set([
@@ -45,7 +51,8 @@ describe('workspace import resolution', () => {
 
   it('declares every @invoker/* import in package.json', () => {
     for (const specifier of invokerImports) {
-      expect(declaredDependencies.has(specifier), `Missing dependency declaration for ${specifier}`).toBe(true);
+      const packageName = packageNameOf(specifier);
+      expect(declaredDependencies.has(packageName), `Missing dependency declaration for ${packageName} (imported as ${specifier})`).toBe(true);
     }
   });
 

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -114,7 +114,7 @@ import type { WorkerRuntimeController } from '../worker-control.js';
 import { buildTaskGraphSnapshot } from '../web/task-graph-snapshot.js';
 import { collectSystemDiagnostics } from '../system-diagnostics.js';
 import { resolveConfigFileState } from '../config.js';
-import { installBundledSkills, resolveBundledSkillsStatus } from '../bundled-skills.js';
+import { installBundledSkills, resolveBundledSkillsStatus } from '@invoker/cli/bundled-skills';
 import { resolveCliInstallerStatus, updateInvokerCli, type CliInstallerContext } from '../cli-installer.js';
 import { runInvokerCliSetup } from '../invoker-cli-setup.js';
 import { resolveBundledCliPath } from '../cli-helper.js';

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -181,7 +181,7 @@ import { createTaskTerminalAdapter } from './task-terminal-adapter.js';
 import { EmbeddedTerminalManager } from './embedded-terminal-manager.js';
 import { createEmbeddedTerminalBackend } from './embedded-terminal-backend.js';
 import { collectSystemDiagnostics } from './system-diagnostics.js';
-import { installBundledSkills, resolveBundledSkillsStatus } from './bundled-skills.js';
+import { installBundledSkills, resolveBundledSkillsStatus } from '@invoker/cli/bundled-skills';
 import {
   maybeAutoInstallCli,
   updateInvokerCli,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -365,6 +365,7 @@ function buildRegisteredOwnerWorkerDeps(
     diskHeadroom: {
       localPath: resolveInvokerHomeRoot(),
       remoteTargets,
+      cleanupEnabled: invokerConfig.diskHeadroom?.cleanupEnabled,
     },
     infraRepair: {
       ownerRepoRoot: repoRoot,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,20 @@
   "version": "0.0.9",
   "description": "Standalone Invoker command-line runner",
   "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "require": "./src/index.ts"
+    },
+    "./bundled-skills": {
+      "types": "./src/bundled-skills.ts",
+      "import": "./src/bundled-skills.ts",
+      "require": "./src/bundled-skills.ts"
+    }
+  },
   "bin": {
     "invoker-cli": "dist/index.js"
   },

--- a/packages/cli/src/__tests__/bundled-skills.test.ts
+++ b/packages/cli/src/__tests__/bundled-skills.test.ts
@@ -7,6 +7,10 @@ import { installBundledSkills, resolveBundledSkillsStatus } from '../bundled-ski
 
 const tempRoots: string[] = [];
 
+/** Deterministic stand-ins for `commandExists` — never probe the real machine in tests. */
+const allHarnessesInstalled = () => true;
+const onlyOmpInstalled = (command: string) => command === 'omp';
+
 function makeTempRoot(prefix: string): string {
   const root = mkdtempSync(join(tmpdir(), prefix));
   tempRoots.push(root);
@@ -52,14 +56,15 @@ describe('bundled-skills', () => {
         repoRoot,
         resourcesPath: resourcesRoot,
         invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
       });
 
       expect(status.commandTargets).toHaveLength(4);
       expect(status.commandTargets.every((target) => !target.installed)).toBe(true);
       expect(status.commandTargets.every((target) => !target.upToDate)).toBe(true);
-      expect(status.mcpTargets).toHaveLength(1);
-      expect(status.mcpTargets[0]?.installed).toBe(false);
-      expect(status.mcpTargets[0]?.upToDate).toBe(false);
+      expect(status.mcpTargets).toHaveLength(4);
+      expect(status.mcpTargets.every((target) => !target.installed)).toBe(true);
+      expect(status.mcpTargets.every((target) => !target.upToDate)).toBe(true);
 
       expect(status.available).toBe(true);
       expect(status.promptRecommended).toBe(true);
@@ -76,6 +81,39 @@ describe('bundled-skills', () => {
         process.env.HOME = originalHome;
       }
 
+    }
+  });
+
+  it('does not mark an MCP target available when its harness is not installed', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const fakeHome = makeTempRoot('invoker-bundled-fakehome-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+
+      const status = resolveBundledSkillsStatus({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+        isInstalled: onlyOmpInstalled,
+      });
+
+      const byId = Object.fromEntries(status.mcpTargets.map((target) => [target.id, target]));
+      expect(byId.omp?.available).toBe(true);
+      expect(byId.claude?.available).toBe(false);
+      expect(byId.codex?.available).toBe(false);
+      expect(byId.cursor?.available).toBe(false);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
     }
   });
 
@@ -97,6 +135,7 @@ describe('bundled-skills', () => {
         repoRoot,
         resourcesPath: resourcesRoot,
         invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
       });
 
       const expectedTargets = [
@@ -129,13 +168,25 @@ describe('bundled-skills', () => {
         expect(readFileSync(installedLoopCommand, 'utf-8')).toBe('Read and follow skill://loop-generator/SKILL.md\n');
       }
 
-      const mcpConfig = JSON.parse(readFileSync(join(codexHome, '.omp', 'agent', 'mcp.json'), 'utf-8'));
-      expect(mcpConfig.$schema).toBe('https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json');
-      expect(mcpConfig.mcpServers.invoker).toEqual({ type: 'stdio', command: 'invoker-cli', args: ['mcp'] });
+      const ompMcpConfig = JSON.parse(readFileSync(join(codexHome, '.omp', 'agent', 'mcp.json'), 'utf-8'));
+      expect(ompMcpConfig.$schema).toBe('https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json');
+      expect(ompMcpConfig.mcpServers.invoker).toEqual({ type: 'stdio', command: 'invoker-cli', args: ['mcp'] });
+
+      const claudeMcpConfig = JSON.parse(readFileSync(join(codexHome, '.claude.json'), 'utf-8'));
+      expect(claudeMcpConfig.$schema).toBeUndefined();
+      expect(claudeMcpConfig.mcpServers.invoker).toEqual({ type: 'stdio', command: 'invoker-cli', args: ['mcp'] });
+
+      const cursorMcpConfig = JSON.parse(readFileSync(join(codexHome, '.cursor', 'mcp.json'), 'utf-8'));
+      expect(cursorMcpConfig.mcpServers.invoker).toEqual({ type: 'stdio', command: 'invoker-cli', args: ['mcp'] });
+
+      const codexToml = readFileSync(join(codexHome, '.codex', 'config.toml'), 'utf-8');
+      expect(codexToml).toContain('[mcp_servers.invoker]');
+      expect(codexToml).toContain('command = "invoker-cli"');
+      expect(codexToml).toContain('args = ["mcp"]');
 
       expect(installed.targets).toHaveLength(4);
       expect(installed.commandTargets).toHaveLength(4);
-      expect(installed.mcpTargets).toHaveLength(1);
+      expect(installed.mcpTargets).toHaveLength(4);
       expect(installed.targets.every((target) => target.installed)).toBe(true);
       expect(installed.targets.every((target) => target.upToDate)).toBe(true);
       expect(installed.commandTargets.every((target) => target.installed)).toBe(true);
@@ -149,11 +200,74 @@ describe('bundled-skills', () => {
         repoRoot,
         resourcesPath: resourcesRoot,
         invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
       });
       expect(status.targets.every((target) => target.upToDate)).toBe(true);
       expect(status.commandTargets.every((target) => target.upToDate)).toBe(true);
       expect(status.mcpTargets.every((target) => target.upToDate)).toBe(true);
       expect(status.promptRecommended).toBe(false);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('re-running install is idempotent for the Codex TOML MCP entry', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const codexHome = makeTempRoot('invoker-codex-idempotent-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = codexHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+
+      const deps = { isPackaged: true, repoRoot, resourcesPath: resourcesRoot, invokerHomeRoot, isInstalled: allHarnessesInstalled };
+      installBundledSkills(deps);
+      installBundledSkills(deps);
+
+      const configPath = join(codexHome, '.codex', 'config.toml');
+      const toml = readFileSync(configPath, 'utf-8');
+      expect(toml.split('[mcp_servers.invoker]')).toHaveLength(2); // exactly one occurrence
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('appends to an existing Codex config.toml without disturbing its other content', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const codexHome = makeTempRoot('invoker-codex-existing-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = codexHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      const configPath = join(codexHome, '.codex', 'config.toml');
+      mkdirSync(join(codexHome, '.codex'), { recursive: true });
+      const preExisting = 'model = "gpt-5.5"\n\n[mcp_servers.other-tool]\ncommand = "other"\nargs = []\n';
+      writeFileSync(configPath, preExisting);
+
+      installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      });
+
+      const toml = readFileSync(configPath, 'utf-8');
+      expect(toml).toContain(preExisting.trim());
+      expect(toml).toContain('[mcp_servers.invoker]');
     } finally {
       if (originalHome === undefined) {
         delete process.env.HOME;
@@ -180,6 +294,7 @@ describe('bundled-skills', () => {
         repoRoot,
         resourcesPath: resourcesRoot,
         invokerHomeRoot,
+        isInstalled: onlyOmpInstalled,
       });
 
       // omp's bundledSkillRoot is ~/.omp/agent/skills; resolveSkillPathViaAgent
@@ -222,10 +337,48 @@ describe('bundled-skills', () => {
         repoRoot,
         resourcesPath: resourcesRoot,
         invokerHomeRoot,
+        isInstalled: onlyOmpInstalled,
       });
 
       const config = JSON.parse(readFileSync(mcpPath, 'utf-8'));
       expect(config.mcpServers.filesystem).toEqual({ command: 'npx', args: ['server'] });
+      expect(config.mcpServers.invoker).toEqual({ type: 'stdio', command: 'invoker-cli', args: ['mcp'] });
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('preserves unrelated keys in an existing Claude Code config while adding Invoker', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const fakeHome = makeTempRoot('invoker-claude-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      const claudeConfigPath = join(fakeHome, '.claude.json');
+      writeFileSync(claudeConfigPath, JSON.stringify({
+        numStartups: 42,
+        mcpServers: { 'personal-stack-planner': { type: 'stdio', command: 'bash', args: ['-lc', 'run'] } },
+      }, null, 2));
+
+      installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+        isInstalled: (command) => command === 'claude',
+      });
+
+      const config = JSON.parse(readFileSync(claudeConfigPath, 'utf-8'));
+      expect(config.numStartups).toBe(42);
+      expect(config.mcpServers['personal-stack-planner']).toEqual({ type: 'stdio', command: 'bash', args: ['-lc', 'run'] });
       expect(config.mcpServers.invoker).toEqual({ type: 'stdio', command: 'invoker-cli', args: ['mcp'] });
     } finally {
       if (originalHome === undefined) {
@@ -256,7 +409,8 @@ describe('bundled-skills', () => {
         repoRoot,
         resourcesPath: resourcesRoot,
         invokerHomeRoot,
-      })).toThrow(`Invalid OMP MCP config at ${mcpPath}: expected a JSON object`);
+        isInstalled: onlyOmpInstalled,
+      })).toThrow(`Invalid MCP config at ${mcpPath}: expected a JSON object`);
       expect(readFileSync(mcpPath, 'utf-8')).toBe('[]');
     } finally {
       if (originalHome === undefined) {
@@ -287,7 +441,8 @@ describe('bundled-skills', () => {
         repoRoot,
         resourcesPath: resourcesRoot,
         invokerHomeRoot,
-      })).toThrow(`Invalid OMP MCP config at ${mcpPath}: expected a JSON object`);
+        isInstalled: onlyOmpInstalled,
+      })).toThrow(`Invalid MCP config at ${mcpPath}: expected a JSON object`);
       expect(readFileSync(mcpPath, 'utf-8')).toBe('{"mcpServers":');
     } finally {
       if (originalHome === undefined) {
@@ -313,6 +468,7 @@ describe('bundled-skills', () => {
         repoRoot,
         resourcesPath: resourcesRoot,
         invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
       });
 
       writeFileSync(join(resourcesRoot, 'skills', 'plan-to-invoker', 'SKILL.md'), '# plan-to-invoker\n\nUpdated bundled content.\n');
@@ -322,6 +478,7 @@ describe('bundled-skills', () => {
         repoRoot,
         resourcesPath: resourcesRoot,
         invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
       });
 
       expect(status.targets.every((target) => target.installed)).toBe(true);
@@ -357,6 +514,7 @@ describe('bundled-skills', () => {
         repoRoot,
         resourcesPath: resourcesRoot,
         invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
       })).toThrow(/missing YAML frontmatter/);
 
       // Nothing corrupt reached the agent skill store.

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -138,6 +138,53 @@ describe('invoker-cli', () => {
     output.restore();
   });
 
+  it('lists every worker toggle at its default state when config is empty', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-worker-toggles-'));
+    const saved = process.env.INVOKER_REPO_CONFIG_PATH;
+    process.env.INVOKER_REPO_CONFIG_PATH = join(dir, 'config.json');
+    const output = captureProcessOutput();
+    try {
+      const code = await main(['worker', 'toggles']);
+
+      expect(code).toBe(0);
+      expect(output.stdout).toContain('PR maintenance: off (default)');
+      expect(output.stdout).toContain('Disk-headroom cleanup: off (default)');
+    } finally {
+      output.restore();
+      if (saved === undefined) delete process.env.INVOKER_REPO_CONFIG_PATH;
+      else process.env.INVOKER_REPO_CONFIG_PATH = saved;
+    }
+  });
+
+  it('enables one worker toggle without touching the others', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-worker-toggles-'));
+    const configPath = join(dir, 'config.json');
+    const saved = process.env.INVOKER_REPO_CONFIG_PATH;
+    process.env.INVOKER_REPO_CONFIG_PATH = configPath;
+    const output = captureProcessOutput();
+    try {
+      const code = await main(['worker', 'toggles', '--enable', 'e2e-autofix']);
+
+      expect(code).toBe(0);
+      expect(output.stdout).toContain('E2E auto-fix: on');
+      expect(JSON.parse(readFileSync(configPath, 'utf8'))).toEqual({ e2eAutoFixEnabled: true });
+    } finally {
+      output.restore();
+      if (saved === undefined) delete process.env.INVOKER_REPO_CONFIG_PATH;
+      else process.env.INVOKER_REPO_CONFIG_PATH = saved;
+    }
+  });
+
+  it('rejects an unknown worker toggle id', async () => {
+    const output = captureProcessOutput();
+
+    const code = await main(['worker', 'toggles', '--enable', 'not-a-real-toggle']);
+
+    expect(code).toBe(1);
+    expect(output.stderr).toContain('Unknown worker toggle id');
+    output.restore();
+  });
+
   it('mcp command starts the MCP server runner', async () => {
     const runMcpServer = vi.fn(async () => {});
 

--- a/packages/cli/src/__tests__/onboarding-invariants.test.ts
+++ b/packages/cli/src/__tests__/onboarding-invariants.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertNoConfigWriteOnAllDeclined,
+  assertNoSecretPrinted,
+  assertOptionalToolPromptedBeforeInstall,
+  assertRemoteTargetOnlyPersistedAfterAllChecksPass,
+  assertWorkerToggleHasSingleConfigSource,
+} from '../onboarding-invariants.js';
+
+describe('assertOptionalToolPromptedBeforeInstall', () => {
+  it('passes when nothing was installed for the tool', () => {
+    expect(() => assertOptionalToolPromptedBeforeInstall(['Invoker setup', "You're ready."], 'Drafter')).not.toThrow();
+  });
+
+  it('passes when an optional prompt naming the tool precedes the install', () => {
+    const lines = [
+      'Drafter is an optional tool that suggests task ordering for plans.',
+      'Enable Drafter now? [y/N] y',
+      'Installed Drafter into ~/.invoker/mcp.json.',
+    ];
+    expect(() => assertOptionalToolPromptedBeforeInstall(lines, 'Drafter')).not.toThrow();
+  });
+
+  it('rejects an install with no prior optional-naming prompt — the exact Drafter-MCP regression', () => {
+    const lines = [
+      'Invoker setup',
+      'Experimental planner MCP installed into ~/.invoker/mcp.json.',
+    ];
+    expect(() => assertOptionalToolPromptedBeforeInstall(lines, 'Experimental planner MCP')).toThrow(/without an earlier prompt/);
+  });
+
+  it('rejects when the prompt exists but never uses the word "optional"', () => {
+    const lines = [
+      'Enable Drafter now? [y/N] y',
+      'Installed Drafter into ~/.invoker/mcp.json.',
+    ];
+    expect(() => assertOptionalToolPromptedBeforeInstall(lines, 'Drafter')).toThrow(/without an earlier prompt/);
+  });
+});
+
+describe('assertNoConfigWriteOnAllDeclined', () => {
+  it('passes when nothing was written', () => {
+    expect(() => assertNoConfigWriteOnAllDeclined([], true)).not.toThrow();
+  });
+
+  it('is a no-op when the user did not decline everything', () => {
+    expect(() => assertNoConfigWriteOnAllDeclined(['/tmp/x/.invoker/config.json'], false)).not.toThrow();
+  });
+
+  it('rejects a config.json write on an all-declined run', () => {
+    expect(() => assertNoConfigWriteOnAllDeclined(['/tmp/x/.invoker/config.json'], true)).toThrow(/must not write any file/);
+  });
+
+  it('rejects an mcp.json or .env write on an all-declined run', () => {
+    expect(() => assertNoConfigWriteOnAllDeclined(['/tmp/x/.invoker/mcp.json'], true)).toThrow(/must not write any file/);
+    expect(() => assertNoConfigWriteOnAllDeclined(['/tmp/x/.invoker/.env'], true)).toThrow(/must not write any file/);
+  });
+});
+
+describe('assertRemoteTargetOnlyPersistedAfterAllChecksPass', () => {
+  it('passes when all checks are ok and the target was written', () => {
+    expect(() => assertRemoteTargetOnlyPersistedAfterAllChecksPass(
+      [{ id: 'git', status: 'ok' }, { id: 'push-auth', status: 'ok' }],
+      true,
+    )).not.toThrow();
+  });
+
+  it('passes when a check failed but the target was correctly not written', () => {
+    expect(() => assertRemoteTargetOnlyPersistedAfterAllChecksPass(
+      [{ id: 'push-auth', status: 'error' }],
+      false,
+    )).not.toThrow();
+  });
+
+  it('rejects a written target with a failing required check', () => {
+    expect(() => assertRemoteTargetOnlyPersistedAfterAllChecksPass(
+      [{ id: 'push-auth', status: 'error' }],
+      true,
+    )).toThrow(/persisted to config despite failing checks/);
+  });
+
+  it('treats warn-status checks as non-blocking', () => {
+    expect(() => assertRemoteTargetOnlyPersistedAfterAllChecksPass(
+      [{ id: 'disk-space', status: 'warn' }],
+      true,
+    )).not.toThrow();
+  });
+});
+
+describe('assertNoSecretPrinted', () => {
+  it('passes when no secret appears in the output', () => {
+    expect(() => assertNoSecretPrinted(['Machine name: build-a'], ['sk-live-abcdef123456'])).not.toThrow();
+  });
+
+  it('ignores trivially short values to avoid false positives on empty fields', () => {
+    expect(() => assertNoSecretPrinted(['SSH port: 22'], ['22'])).not.toThrow();
+  });
+
+  it('rejects a line that echoes a real secret value', () => {
+    const secret = 'xoxb-1234567890-abcdefg';
+    expect(() => assertNoSecretPrinted([`Bot token: ${secret}`], [secret])).toThrow(/secret value was printed/);
+  });
+});
+
+describe('assertWorkerToggleHasSingleConfigSource', () => {
+  it('passes for a real dotted InvokerConfig path', () => {
+    expect(() => assertWorkerToggleHasSingleConfigSource({ id: 'pr-maintenance', configPath: 'prMaintenance.enabled' })).not.toThrow();
+  });
+
+  it('passes for a real top-level InvokerConfig field', () => {
+    expect(() => assertWorkerToggleHasSingleConfigSource({ id: 'e2e-autofix', configPath: 'e2eAutoFixEnabled' })).not.toThrow();
+  });
+
+  it('rejects a bare env var name — the exact disk-headroom-cleanup regression', () => {
+    expect(() => assertWorkerToggleHasSingleConfigSource({
+      id: 'disk-headroom-cleanup',
+      configPath: 'INVOKER_DISK_CLEANUP_ENABLED',
+    })).toThrow(/bare env var name/);
+  });
+
+  it('rejects a malformed configPath', () => {
+    expect(() => assertWorkerToggleHasSingleConfigSource({ id: 'bad', configPath: 'foo..bar' })).toThrow(/malformed configPath/);
+  });
+});

--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -6,6 +6,13 @@ import { join } from 'node:path';
 import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, EXTERNAL_DEPENDENCIES } from '@invoker/contracts';
 
 import {
+  assertNoConfigWriteOnAllDeclined,
+  assertNoSecretPrinted,
+  assertOptionalToolPromptedBeforeInstall,
+  assertRemoteTargetOnlyPersistedAfterAllChecksPass,
+} from '../onboarding-invariants.js';
+
+import {
   checkGithubAuth,
   defaultExperimentalPlannerMcpPath,
   ensureExperimentalPlannerMcp,
@@ -40,11 +47,25 @@ function errorCheck(id: string, name: string, detail: string, remediation?: stri
 }
 
 /** Keep setup oneshot tests offline and independent of the host PATH / gh login. */
+const NOOP_BUNDLED_SKILLS_STATUS = {
+  available: false,
+  promptRecommended: false,
+  managedPrefix: 'invoker-',
+  bundledSkillNames: [],
+  targets: [],
+  commandTargets: [],
+  mcpTargets: [],
+};
+
 function readySetupDeps(overrides: SetupDeps = {}): SetupDeps {
   return {
     isInstalled: () => true,
     githubAuthCheck: async () => okCheck('github-auth', 'GitHub auth', 'gh is authenticated'),
     smokePlanValidation: async () => okCheck('smoke-plan', 'smoke: plan validation', 'Parsed 1 task(s)'),
+    // Real skill install does real commandExists probing + filesystem work —
+    // stub it by default so unrelated tests stay fast and deterministic.
+    resolveSkillsRepoRoot: () => '/fake-repo-root',
+    bundledSkillsInstall: () => NOOP_BUNDLED_SKILLS_STATUS,
     ...overrides,
   };
 }
@@ -154,7 +175,7 @@ describe('buildDoctorChecks', () => {
   });
 });
 describe('runSetup', () => {
-  it('installs the public planner MCP by default without enabling planner behavior', async () => {
+  it('does not install the Drafter planner MCP by default', async () => {
     const home = mkdtempSync(join(tmpdir(), 'invoker-setup-home-'));
     const saved = {
       HOME: process.env.HOME,
@@ -174,19 +195,101 @@ describe('runSetup', () => {
       const invokerConfigPath = join(home, '.invoker', 'config.json');
       const output = lines.join('\n');
       expect(output).toContain('Invoker setup');
-      expect(output).toContain(`Experimental planner MCP installed into ${mcpPath}`);
-      expect(output).toContain('experimentalPlanner flag: off');
+      expect(output).not.toContain('planner');
       expect(output).toContain("You're ready.");
-      expect(JSON.parse(readFileSync(mcpPath, 'utf8')).mcpServers['experimental-planner']).toEqual({
-        type: 'stdio',
-        command: 'uvx',
-        args: ['--from', DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, EXTERNAL_DEPENDENCIES.drafterMcp.commandName],
-      });
+      expect(existsSync(mcpPath)).toBe(false);
       expect(existsSync(invokerConfigPath)).toBe(false);
       expect(code).toBe(0);
+
+      expect(() => assertOptionalToolPromptedBeforeInstall(lines, 'Drafter')).not.toThrow();
+      const writtenPaths = [mcpPath, invokerConfigPath].filter((path) => existsSync(path));
+      expect(() => assertNoConfigWriteOnAllDeclined(writtenPaths, true)).not.toThrow();
     } finally {
       restoreEnv('HOME', saved.HOME);
       restoreEnv('INVOKER_MCP_CONFIG_PATH', saved.target);
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('installs bundled skills as part of setup and reports the result', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'invoker-setup-skills-'));
+    const saved = { HOME: process.env.HOME };
+    const lines: string[] = [];
+    const fakeStatus = {
+      available: true,
+      promptRecommended: false,
+      managedPrefix: 'invoker-',
+      bundledSkillNames: ['plan-to-invoker', 'make-pr'],
+      targets: [{ id: 'claude', name: 'Claude', path: '/x', available: true, installed: true, upToDate: true, installedSkillNames: [] }],
+      commandTargets: [],
+      mcpTargets: [{ id: 'claude', name: 'Claude', path: '/x/.claude.json', available: true, installed: true, upToDate: true, serverName: 'invoker' }],
+    };
+    try {
+      process.env.HOME = home;
+
+      const code = await runSetup([], {
+        print: (line) => lines.push(line),
+        prompt: async () => 'n',
+      }, readySetupDeps({
+        resolveSkillsRepoRoot: () => '/fake/repo',
+        bundledSkillsInstall: () => fakeStatus,
+      }));
+
+      expect(code).toBe(0);
+      const output = lines.join('\n');
+      expect(output).toContain('Skills: installed 2 bundled skill(s) for Claude.');
+      expect(output).toContain('Skills MCP: registered invoker-cli mcp for Claude.');
+    } finally {
+      restoreEnv('HOME', saved.HOME);
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('skips skill installation gracefully when not running from an Invoker checkout', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'invoker-setup-skills-none-'));
+    const saved = { HOME: process.env.HOME };
+    const lines: string[] = [];
+    try {
+      process.env.HOME = home;
+
+      const code = await runSetup([], {
+        print: (line) => lines.push(line),
+        prompt: async () => 'n',
+      }, readySetupDeps({
+        resolveSkillsRepoRoot: () => { throw new Error('Could not resolve repo root'); },
+      }));
+
+      expect(code).toBe(0);
+      expect(lines.join('\n')).toContain('Skills: skipped (not running from an Invoker checkout).');
+    } finally {
+      restoreEnv('HOME', saved.HOME);
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('writes only the worker toggle the user says yes to, leaving the rest unset', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'invoker-setup-toggles-'));
+    const saved = { HOME: process.env.HOME };
+    const lines: string[] = [];
+    try {
+      process.env.HOME = home;
+
+      // Prompt order: Slack, machines, then the 4 worker toggles in
+      // ONBOARDING_WORKER_TOGGLES order (PR maintenance, e2e auto-fix,
+      // auto-approve, disk-headroom cleanup).
+      const answers = ['n', 'n', 'n', 'y', 'n', 'n'];
+      const code = await runSetup([], {
+        print: (line) => lines.push(line),
+        prompt: async () => answers.shift() ?? 'n',
+      }, readySetupDeps());
+
+      expect(code).toBe(0);
+      const configPath = join(home, '.invoker', 'config.json');
+      const config = JSON.parse(readFileSync(configPath, 'utf8'));
+      expect(config).toEqual({ e2eAutoFixEnabled: true });
+      expect(lines.join('\n')).toContain('Worker toggles');
+    } finally {
+      restoreEnv('HOME', saved.HOME);
       rmSync(home, { recursive: true, force: true });
     }
   });
@@ -212,9 +315,10 @@ describe('runSetup', () => {
       process.env.SLACK_SIGNING_SECRET = 'secret-env';
       process.env.SLACK_CHANNEL_ID = 'C123';
       const prompts: string[] = [];
+      const lines: string[] = [];
 
       const code = await runSetup(['slack', '--from-env'], {
-        print: () => {},
+        print: (line) => lines.push(line),
         prompt: async (question) => {
           prompts.push(question);
           return '';
@@ -223,6 +327,7 @@ describe('runSetup', () => {
 
       expect(code).toBe(0);
       expect(prompts).toEqual([]);
+      expect(() => assertNoSecretPrinted(lines, ['xoxb-env', 'xapp-env', 'secret-env'])).not.toThrow();
     } finally {
       fetchSpy.mockRestore();
       restoreEnv('HOME', saved.HOME);
@@ -253,12 +358,23 @@ describe('runSetup', () => {
     };
   }
 
+  function passingDoctorChecks(): PrerequisiteCheck[] {
+    return [
+      { id: 'git', name: 'Git (remote)', status: 'ok', detail: 'git found on remote box' },
+      { id: 'node', name: 'Node (remote)', status: 'ok', detail: 'node found on remote box' },
+      { id: 'pnpm', name: 'pnpm (remote)', status: 'ok', detail: 'pnpm found on remote box' },
+      { id: 'disk-space', name: 'Disk space (remote)', status: 'ok', detail: '10240 MiB free on the remote box' },
+      { id: 'push-auth', name: 'GitHub push credentials (remote)', status: 'ok', detail: 'reachable' },
+    ];
+  }
+
   function machineSetupDeps(overrides: SetupDeps = {}): SetupDeps {
     return readySetupDeps({
       remoteTargetConnectivity: async (target) => ({
         reachable: true,
         message: `ssh probe to ${target.user}@${target.host} succeeded`,
       }),
+      remoteDoctorChecks: async () => passingDoctorChecks(),
       ...overrides,
     });
   }
@@ -271,6 +387,7 @@ describe('runSetup', () => {
       'build-a.example.test',
       'deploy',
       '/home/deploy/.ssh/id_ed25519',
+      'https://github.com/example/build-a.git',
       '2222',
       '3',
       'pnpm install --frozen-lockfile',
@@ -298,6 +415,8 @@ describe('runSetup', () => {
           provisionCommand: 'pnpm install --frozen-lockfile',
         },
       });
+
+      expect(() => assertRemoteTargetOnlyPersistedAfterAllChecksPass(passingDoctorChecks(), true)).not.toThrow();
     } finally {
       env.restore();
     }
@@ -312,6 +431,7 @@ describe('runSetup', () => {
       'build-a.example.test',
       'deploy',
       '/home/deploy/.ssh/id_ed25519',
+      'https://github.com/example/build-a.git',
       '22',
       '1',
       '',
@@ -339,6 +459,7 @@ describe('runSetup', () => {
       'build-a.example.test',
       'deploy',
       '/home/deploy/.ssh/id_a',
+      'https://github.com/example/build-a.git',
       '22',
       '2',
       '',
@@ -348,6 +469,7 @@ describe('runSetup', () => {
       'build-b.example.test',
       'deploy',
       '/home/deploy/.ssh/id_b',
+      'https://github.com/example/build-b.git',
       '2223',
       '4',
       'bash scripts/provision.sh',
@@ -392,6 +514,7 @@ describe('runSetup', () => {
         host: 'build-a.example.test',
         user: 'deploy',
         sshKeyPath: '/home/deploy/.ssh/id_a',
+        repoUrl: 'https://github.com/example/build-a.git',
         port: 22,
         maxConcurrentTasks: 2,
       },
@@ -400,6 +523,7 @@ describe('runSetup', () => {
         host: 'build-b.example.test',
         user: 'ci',
         sshKeyPath: '/home/ci/.ssh/id_b',
+        repoUrl: 'https://github.com/example/build-b.git',
         port: 2222,
         maxConcurrentTasks: 1,
         provisionCommand: 'pnpm install --frozen-lockfile',
@@ -422,6 +546,89 @@ describe('runSetup', () => {
         ['build-b', true],
       ]);
       expect(Object.keys(JSON.parse(readFileSync(env.configPath, 'utf8')).remoteTargets)).toEqual(['build-a', 'build-b']);
+    } finally {
+      env.restore();
+    }
+  });
+
+  it('never writes a machine whose remote doctor checks fail, even though connectivity passed', async () => {
+    const env = setupMachineTestEnv();
+    const originalConfig = { maxConcurrency: 4 };
+    writeFileSync(env.configPath, JSON.stringify(originalConfig));
+    const answers = [
+      'build-a',
+      'build-a.example.test',
+      'deploy',
+      '/home/deploy/.ssh/id_ed25519',
+      'https://github.com/example/build-a.git',
+      '22',
+      '1',
+      '',
+      'n', // "Try this machine again?" — no
+    ];
+    const lines: string[] = [];
+    const doctorChecks = [
+      { id: 'git', name: 'Git (remote)', status: 'ok' as const, detail: 'git found on remote box' },
+      {
+        id: 'push-auth',
+        name: 'GitHub push credentials (remote)',
+        status: 'error' as const,
+        detail: 'Remote box could not reach https://github.com/example/build-a.git with its own git credentials',
+      },
+    ];
+    try {
+      const code = await runSetup(['machines'], {
+        print: (line) => lines.push(line),
+        prompt: async () => answers.shift() ?? '',
+      }, machineSetupDeps({
+        remoteDoctorChecks: async () => doctorChecks,
+      }));
+
+      const finalConfig = JSON.parse(readFileSync(env.configPath, 'utf8'));
+      expect(code).toBe(0);
+      expect(finalConfig).toEqual(originalConfig);
+      expect(lines.join('\n')).toContain('Remote readiness check failed');
+      expect(lines.join('\n')).not.toContain('Keep this machine?');
+
+      const wasWritten = Boolean(finalConfig.remoteTargets?.['build-a']);
+      expect(() => assertRemoteTargetOnlyPersistedAfterAllChecksPass(doctorChecks, wasWritten)).not.toThrow();
+    } finally {
+      env.restore();
+    }
+  });
+
+  it('surfaces a doctor-check failure as an error result under --json without writing the machine', async () => {
+    const env = setupMachineTestEnv();
+    const input = [{
+      name: 'build-a',
+      host: 'build-a.example.test',
+      user: 'deploy',
+      sshKeyPath: '/home/deploy/.ssh/id_a',
+      repoUrl: 'https://github.com/example/build-a.git',
+    }];
+    const lines: string[] = [];
+    try {
+      const code = await runSetup(['machines', '--json'], {
+        print: (line) => lines.push(line),
+        prompt: async () => { throw new Error('should not prompt in json mode'); },
+        readStdin: async () => JSON.stringify(input),
+        interactive: false,
+      }, machineSetupDeps({
+        remoteDoctorChecks: async () => [
+          {
+            id: 'disk-space',
+            name: 'Disk space (remote)',
+            status: 'error',
+            detail: 'out of disk space',
+          },
+        ],
+      }));
+
+      expect(code).toBe(1);
+      const results = JSON.parse(lines[0]);
+      expect(results[0].written).toBe(false);
+      expect(results[0].error.code).toBe('doctor-check-failed');
+      expect(existsSync(env.configPath)).toBe(false);
     } finally {
       env.restore();
     }
@@ -673,7 +880,7 @@ describe('runSetup in a non-interactive shell', () => {
 
   it('fails loudly instead of silently answering no to every prompt', async () => {
     const { lines, io } = collectingIO();
-    const code = await runSetup([], io);
+    const code = await runSetup([], io, readySetupDeps());
 
     expect(code).toBe(1);
     expect(lines.join('\n')).toContain('stdin is not a TTY');
@@ -681,14 +888,14 @@ describe('runSetup in a non-interactive shell', () => {
 
   it('names the non-interactive escape hatches in the failure message', async () => {
     const { lines, io } = collectingIO();
-    await runSetup([], io);
+    await runSetup([], io, readySetupDeps());
 
     const output = lines.join('\n');
     expect(output).toContain('--yes');
     expect(output).toContain('--from-env');
   });
 
-  it('accepts the planner prompt under --yes without reading stdin', async () => {
+  it('does not prompt about the planner under --yes', async () => {
     const { lines, io } = collectingIO({
       prompt: async () => { throw new Error('should not prompt under --yes'); },
     });
@@ -696,8 +903,20 @@ describe('runSetup in a non-interactive shell', () => {
     const code = await runSetup(['--yes'], io, readySetupDeps());
 
     expect(code).toBe(0);
-    expect(lines.join('\n')).toContain('Enable the experimental planner now?');
+    expect(lines.join('\n')).not.toContain('planner');
     expect(lines.join('\n')).toContain("You're ready.");
+  });
+
+  it('leaves every worker toggle unset under --yes without prompting', async () => {
+    const { lines, io } = collectingIO({
+      prompt: async () => { throw new Error('should not prompt under --yes'); },
+    });
+
+    const code = await runSetup(['--yes'], io, readySetupDeps());
+
+    expect(code).toBe(0);
+    expect(lines.join('\n')).toContain('Worker toggles');
+    expect(lines.join('\n')).toContain('PR maintenance: off');
   });
 
   it('skips Slack under --yes rather than starting a flow it cannot finish', async () => {
@@ -712,14 +931,14 @@ describe('runSetup in a non-interactive shell', () => {
     expect(output).toContain("You're ready.");
   });
 
-  it('writes only inside the configured Invoker home', async () => {
+  it('writes nothing under --yes since planner, Slack, and machines all stay opt-in', async () => {
     const { io } = collectingIO({
       prompt: async () => { throw new Error('should not prompt under --yes'); },
     });
 
     await runSetup(['--yes'], io, readySetupDeps());
 
-    expect(existsSync(join(home, 'mcp.json'))).toBe(true);
+    expect(existsSync(join(home, 'mcp.json'))).toBe(false);
   });
 });
 

--- a/packages/cli/src/__tests__/remote-doctor.test.ts
+++ b/packages/cli/src/__tests__/remote-doctor.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import { runRemoteDoctorChecks } from '../remote-doctor.js';
+
+const TARGET = { host: '203.0.113.5', user: 'invoker', sshKeyPath: '/tmp/key' };
+const REPO_URL = 'https://github.com/example/repo.git';
+
+function stubCapture(stdout: string) {
+  return async () => stdout;
+}
+
+function failingCapture(message: string) {
+  return async () => {
+    throw new Error(message);
+  };
+}
+
+describe('runRemoteDoctorChecks', () => {
+  it('reports ok for every check when the remote box is fully ready', async () => {
+    const stdout = [
+      'check:git:ok',
+      'check:node:ok',
+      'check:pnpm:ok',
+      'disk_kb:5242880',
+      'check:push-auth:ok',
+    ].join('\n');
+
+    const checks = await runRemoteDoctorChecks({
+      target: TARGET,
+      repoUrl: REPO_URL,
+      execRemoteCaptureImpl: stubCapture(stdout),
+    });
+
+    expect(checks.every((check) => check.status === 'ok')).toBe(true);
+    expect(checks.map((check) => check.id)).toEqual(['git', 'node', 'pnpm', 'disk-space', 'push-auth']);
+  });
+
+  it('marks a missing tool as an error, not a warning', async () => {
+    const stdout = [
+      'check:git:missing',
+      'check:node:ok',
+      'check:pnpm:ok',
+      'disk_kb:5242880',
+      'check:push-auth:ok',
+    ].join('\n');
+
+    const checks = await runRemoteDoctorChecks({
+      target: TARGET,
+      repoUrl: REPO_URL,
+      execRemoteCaptureImpl: stubCapture(stdout),
+    });
+
+    const git = checks.find((check) => check.id === 'git');
+    expect(git?.status).toBe('error');
+  });
+
+  it('warns, but does not error, on low disk space', async () => {
+    const stdout = [
+      'check:git:ok',
+      'check:node:ok',
+      'check:pnpm:ok',
+      'disk_kb:1024', // 1 MiB, well under the 1 GiB threshold
+      'check:push-auth:ok',
+    ].join('\n');
+
+    const checks = await runRemoteDoctorChecks({
+      target: TARGET,
+      repoUrl: REPO_URL,
+      execRemoteCaptureImpl: stubCapture(stdout),
+    });
+
+    const disk = checks.find((check) => check.id === 'disk-space');
+    expect(disk?.status).toBe('warn');
+  });
+
+  it('errors when the remote box cannot reach the repo with its own git credentials', async () => {
+    const stdout = [
+      'check:git:ok',
+      'check:node:ok',
+      'check:pnpm:ok',
+      'disk_kb:5242880',
+      'check:push-auth:missing',
+    ].join('\n');
+
+    const checks = await runRemoteDoctorChecks({
+      target: TARGET,
+      repoUrl: REPO_URL,
+      execRemoteCaptureImpl: stubCapture(stdout),
+    });
+
+    const pushAuth = checks.find((check) => check.id === 'push-auth');
+    expect(pushAuth?.status).toBe('error');
+    expect(pushAuth?.detail).toContain(REPO_URL);
+  });
+
+  it('reports every check as an error when the SSH round trip itself fails', async () => {
+    const checks = await runRemoteDoctorChecks({
+      target: TARGET,
+      repoUrl: REPO_URL,
+      execRemoteCaptureImpl: failingCapture('ssh: connection refused'),
+    });
+
+    expect(checks.every((check) => check.status === 'error' || check.status === 'warn')).toBe(true);
+    expect(checks.find((check) => check.id === 'git')?.status).toBe('error');
+    expect(checks.some((check) => check.detail.includes('connection refused'))).toBe(true);
+  });
+
+  it('embeds the repo URL safely even if it contains shell metacharacters', async () => {
+    const maliciousUrl = "https://example.com/'; rm -rf /;'.git";
+    const stdout = 'check:git:ok\ncheck:node:ok\ncheck:pnpm:ok\ndisk_kb:5242880\ncheck:push-auth:ok';
+
+    // The assertion here is just that this resolves without throwing while
+    // constructing the script — real quoting correctness is exercised by
+    // shellPosixSingleQuote's own tests in execution-engine.
+    const checks = await runRemoteDoctorChecks({
+      target: TARGET,
+      repoUrl: maliciousUrl,
+      execRemoteCaptureImpl: stubCapture(stdout),
+    });
+
+    expect(checks.find((check) => check.id === 'push-auth')?.status).toBe('ok');
+  });
+});

--- a/packages/cli/src/__tests__/worker-toggles.test.ts
+++ b/packages/cli/src/__tests__/worker-toggles.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { assertWorkerToggleHasSingleConfigSource } from '../onboarding-invariants.js';
+import {
+  applyWorkerToggle,
+  findWorkerToggle,
+  ONBOARDING_WORKER_TOGGLES,
+  readWorkerToggleValue,
+} from '../worker-toggles.js';
+
+describe('ONBOARDING_WORKER_TOGGLES', () => {
+  it('has a unique id and a real InvokerConfig-backed path for every toggle', () => {
+    const ids = ONBOARDING_WORKER_TOGGLES.map((spec) => spec.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const spec of ONBOARDING_WORKER_TOGGLES) {
+      // Guards the exact disk-headroom-cleanup regression found this session:
+      // a toggle backed by a bare env var instead of a real config field.
+      expect(() => assertWorkerToggleHasSingleConfigSource(spec)).not.toThrow();
+    }
+  });
+});
+
+describe('applyWorkerToggle / readWorkerToggleValue', () => {
+  it('sets and reads a top-level boolean field', () => {
+    const spec = findWorkerToggle('e2e-autofix')!;
+    const config = applyWorkerToggle({}, spec, true);
+    expect(config).toEqual({ e2eAutoFixEnabled: true });
+    expect(readWorkerToggleValue(config, spec)).toBe(true);
+  });
+
+  it('sets and reads a nested boolean field, preserving sibling keys', () => {
+    const spec = findWorkerToggle('pr-maintenance')!;
+    const config = applyWorkerToggle({ prMaintenance: { repoRoot: '/srv/invoker' } }, spec, true);
+    expect(config).toEqual({ prMaintenance: { repoRoot: '/srv/invoker', enabled: true } });
+    expect(readWorkerToggleValue(config, spec)).toBe(true);
+  });
+
+  it('creates the nested object when it does not exist yet', () => {
+    const spec = findWorkerToggle('disk-headroom-cleanup')!;
+    const config = applyWorkerToggle({}, spec, false);
+    expect(config).toEqual({ diskHeadroom: { cleanupEnabled: false } });
+  });
+
+  it('returns undefined for an unset toggle, not a false default', () => {
+    const spec = findWorkerToggle('auto-approve')!;
+    expect(readWorkerToggleValue({}, spec)).toBeUndefined();
+  });
+
+  it('does not mutate the input config object', () => {
+    const spec = findWorkerToggle('e2e-autofix')!;
+    const original = { defaultBranch: 'main' };
+    const updated = applyWorkerToggle(original, spec, true);
+    expect(original).toEqual({ defaultBranch: 'main' });
+    expect(updated).not.toBe(original);
+  });
+});

--- a/packages/cli/src/bundled-skills.ts
+++ b/packages/cli/src/bundled-skills.ts
@@ -3,6 +3,7 @@ import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
 
+import { resolveInvokerHomeRoot, type IsInstalled } from '@invoker/contracts';
 import type {
   HarnessConfigState,
   HarnessMcpConfigState,
@@ -11,12 +12,13 @@ import type {
   BundledSkillTargetStatus,
 } from '@invoker/contracts';
 
-import { resolveInvokerHomeRoot } from './delete-all-snapshot.js';
+import { commandExists } from './onboarding.js';
 
 const MANAGED_PREFIX = 'invoker-';
 const MANIFEST_FILE = 'bundled-skills.json';
 const OMP_MCP_SCHEMA_URL = 'https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json';
 const INVOKER_MCP_SERVER = { type: 'stdio', command: 'invoker-cli', args: ['mcp'] } as const;
+const INVOKER_MCP_SERVER_NAME = 'invoker';
 
 interface BundledSkillsManifest {
   bundledHash: string;
@@ -33,14 +35,23 @@ interface BundledSkillsContext {
   repoRoot: string;
   resourcesPath?: string;
   invokerHomeRoot?: string;
+  /** Injectable for tests; defaults to real `command -v` probing. */
+  isInstalled?: IsInstalled;
 }
 
 type JsonRecord = Record<string, unknown>;
 type BundledSkillStaleReason = NonNullable<BundledSkillTargetStatus['staleReason']>;
+type McpConfigFormat = 'json' | 'toml';
+
+/** Only set inside a packaged Electron app (packages/app); undefined for the standalone CLI. */
+function electronResourcesPath(): string | undefined {
+  return (process as unknown as { resourcesPath?: string }).resourcesPath;
+}
 
 function resolveBundledSkillsSourceRoot(context: BundledSkillsContext): string | null {
   if (context.isPackaged) {
-    const resourceRoot = context.resourcesPath ?? process.resourcesPath;
+    const resourceRoot = context.resourcesPath ?? electronResourcesPath();
+    if (!resourceRoot) return null;
     const packagedSkills = path.join(resourceRoot, 'skills');
     return existsSync(packagedSkills) ? packagedSkills : null;
   }
@@ -195,18 +206,63 @@ function resolveManagedCommandTargets(): HarnessConfigState[] {
   ];
 }
 
-function resolveManagedMcpTargets(): HarnessMcpConfigState[] {
-  return [
+interface McpTargetCandidate extends HarnessMcpConfigState {
+  format: McpConfigFormat;
+  /** Command probed via `isInstalled` to decide `available`. */
+  probeCommand: string;
+}
+
+/**
+ * MCP registration is per-harness config, not a shared file like skills/commands
+ * are, so — unlike resolveManagedTargets above — this only registers a harness
+ * that's actually installed, checked via `isInstalled` (defaults to real
+ * `command -v` probing). Each harness stores MCP servers differently:
+ * Claude Code and Cursor use their own JSON config, Codex uses TOML.
+ */
+function resolveManagedMcpTargets(isInstalled: IsInstalled = commandExists): McpTargetCandidate[] {
+  const candidates: Array<Omit<McpTargetCandidate, 'available'>> = [
+    {
+      id: 'claude',
+      name: 'Claude',
+      path: path.join(homedir(), '.claude.json'),
+      installed: false,
+      upToDate: false,
+      serverName: INVOKER_MCP_SERVER_NAME,
+      format: 'json',
+      probeCommand: 'claude',
+    },
+    {
+      id: 'codex',
+      name: 'Codex',
+      path: path.join(homedir(), '.codex', 'config.toml'),
+      installed: false,
+      upToDate: false,
+      serverName: INVOKER_MCP_SERVER_NAME,
+      format: 'toml',
+      probeCommand: 'codex',
+    },
+    {
+      id: 'cursor',
+      name: 'Cursor',
+      path: path.join(homedir(), '.cursor', 'mcp.json'),
+      installed: false,
+      upToDate: false,
+      serverName: INVOKER_MCP_SERVER_NAME,
+      format: 'json',
+      probeCommand: 'cursor',
+    },
     {
       id: 'omp',
       name: 'OMP',
       path: path.join(homedir(), '.omp', 'agent', 'mcp.json'),
-      available: true,
       installed: false,
       upToDate: false,
-      serverName: 'invoker',
+      serverName: INVOKER_MCP_SERVER_NAME,
+      format: 'json',
+      probeCommand: 'omp',
     },
   ];
+  return candidates.map((candidate) => ({ ...candidate, available: isInstalled(candidate.probeCommand) }));
 }
 
 function resolveManifestPath(invokerHomeRoot: string): string {
@@ -382,44 +438,64 @@ function isInvokerMcpServer(value: unknown): boolean {
     && value.args[0] === 'mcp';
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Crude but safe: a text scan for the TOML table header, never a full parse. */
+function isTomlInvokerServerRegistered(content: string, serverName: string): boolean {
+  const headerRe = new RegExp(`^\\[mcp_servers\\.${escapeRegExp(serverName)}\\]\\s*$`, 'm');
+  return headerRe.test(content);
+}
+
+function isMcpTargetInstalled(target: McpTargetCandidate): boolean {
+  if (!existsSync(target.path)) return false;
+  if (target.format === 'toml') {
+    return isTomlInvokerServerRegistered(readFileSync(target.path, 'utf-8'), target.serverName);
+  }
+  const config = readJsonRecordIfPresent(target.path);
+  const servers = isJsonRecord(config?.mcpServers) ? config.mcpServers : undefined;
+  return isInvokerMcpServer(servers?.[target.serverName]);
+}
+
 function buildMcpConfigState(
-  target: HarnessMcpConfigState,
+  target: McpTargetCandidate,
   bundledHash: string,
   manifest: BundledSkillsManifest | null,
 ): HarnessMcpConfigState {
-  const config = readJsonRecordIfPresent(target.path);
-  const servers = isJsonRecord(config?.mcpServers) ? config.mcpServers : undefined;
-  const installed = isInvokerMcpServer(servers?.[target.serverName]);
+  const installed = target.available && isMcpTargetInstalled(target);
   const manifestTarget = manifest?.mcpTargets?.[target.id];
   const upToDate = installed
     && manifest?.bundledHash === bundledHash
     && manifestTarget?.path === target.path
     && manifestTarget.serverName === target.serverName;
 
-  return {
-    ...target,
-    installed,
-    upToDate,
-  };
+  const { format: _format, probeCommand: _probeCommand, ...state } = target;
+  return { ...state, installed, upToDate };
 }
 
-function readMutableMcpConfig(filePath: string): { config: JsonRecord; created: boolean } {
-  if (!existsSync(filePath)) {
-    return { config: { $schema: OMP_MCP_SCHEMA_URL }, created: true };
-  }
+function readMutableJsonMcpConfig(filePath: string, defaultConfig: JsonRecord): JsonRecord {
+  if (!existsSync(filePath)) return { ...defaultConfig };
 
   try {
     const parsed = JSON.parse(readFileSync(filePath, 'utf-8')) as unknown;
-    if (isJsonRecord(parsed)) return { config: parsed, created: false };
+    if (isJsonRecord(parsed)) return parsed;
   } catch {
     // Throw the same public error for invalid JSON and non-object JSON.
   }
 
-  throw new Error(`Invalid OMP MCP config at ${filePath}: expected a JSON object`);
+  throw new Error(`Invalid MCP config at ${filePath}: expected a JSON object`);
 }
 
-function installOmpMcpTarget(target: HarnessMcpConfigState): void {
-  const { config } = readMutableMcpConfig(target.path);
+/**
+ * Generic JSON writer for harnesses whose MCP config is `{ mcpServers: { ... } }`
+ * (OMP, Cursor, Claude Code). `defaultConfig` seeds a fresh file (OMP wants a
+ * `$schema` pointer; others don't) — every other key in an existing file is
+ * preserved untouched, since Claude Code's `~/.claude.json` in particular
+ * carries many unrelated top-level keys this must never disturb.
+ */
+function installJsonMcpTarget(target: McpTargetCandidate, defaultConfig: JsonRecord): void {
+  const config = readMutableJsonMcpConfig(target.path, defaultConfig);
   const existingServers = isJsonRecord(config.mcpServers) ? config.mcpServers : {};
   config.mcpServers = {
     ...existingServers,
@@ -429,8 +505,41 @@ function installOmpMcpTarget(target: HarnessMcpConfigState): void {
   writeFileSync(target.path, `${JSON.stringify(config, null, 2)}\n`);
 }
 
+/**
+ * Codex stores MCP servers in `~/.codex/config.toml`, a single hand-maintained
+ * file that can grow very large (project trust entries, other MCP servers).
+ * Rather than parse+rewrite the whole TOML document (real corruption risk on
+ * a file this sensitive), this only ever text-scans for an existing
+ * `[mcp_servers.invoker]` table and, if absent, appends a new one — a pure
+ * additive text operation that can't touch anything else in the file.
+ */
+function installTomlMcpTarget(target: McpTargetCandidate): void {
+  mkdirSync(path.dirname(target.path), { recursive: true });
+  const existing = existsSync(target.path) ? readFileSync(target.path, 'utf-8') : '';
+  if (isTomlInvokerServerRegistered(existing, target.serverName)) return;
+
+  const block = [
+    `[mcp_servers.${target.serverName}]`,
+    'command = "invoker-cli"',
+    'args = ["mcp"]',
+    '',
+  ].join('\n');
+  const separator = existing.length > 0 && !existing.endsWith('\n') ? '\n\n' : existing.length > 0 ? '\n' : '';
+  writeFileSync(target.path, existing + separator + block);
+}
+
+function installMcpTarget(target: McpTargetCandidate): void {
+  if (target.format === 'toml') {
+    installTomlMcpTarget(target);
+    return;
+  }
+  const defaultConfig: JsonRecord = target.id === 'omp' ? { $schema: OMP_MCP_SCHEMA_URL } : {};
+  installJsonMcpTarget(target, defaultConfig);
+}
+
 export function resolveBundledSkillsStatus(context: BundledSkillsContext): BundledSkillsStatus {
   const invokerHomeRoot = context.invokerHomeRoot ?? resolveInvokerHomeRoot();
+  const isInstalled = context.isInstalled ?? commandExists;
   const sourceRoot = resolveBundledSkillsSourceRoot(context);
   if (!sourceRoot) {
     return {
@@ -440,7 +549,7 @@ export function resolveBundledSkillsStatus(context: BundledSkillsContext): Bundl
       bundledSkillNames: [],
       targets: resolveManagedTargets(),
       commandTargets: resolveManagedCommandTargets(),
-      mcpTargets: resolveManagedMcpTargets(),
+      mcpTargets: resolveManagedMcpTargets(isInstalled),
     };
   }
 
@@ -455,7 +564,7 @@ export function resolveBundledSkillsStatus(context: BundledSkillsContext): Bundl
   const commandTargets = resolveManagedCommandTargets().map((target) =>
     buildCommandConfigState(target, commandFiles, bundledHash, manifest),
   );
-  const mcpTargets = resolveManagedMcpTargets().map((target) =>
+  const mcpTargets = resolveManagedMcpTargets(isInstalled).map((target) =>
     buildMcpConfigState(target, bundledHash, manifest),
   );
 
@@ -482,6 +591,7 @@ export function installBundledSkills(
   mode: BundledSkillsInstallMode = 'install',
 ): BundledSkillsStatus {
   const invokerHomeRoot = context.invokerHomeRoot ?? resolveInvokerHomeRoot();
+  const isInstalled = context.isInstalled ?? commandExists;
   const sourceRoot = resolveBundledSkillsSourceRoot(context);
   if (!sourceRoot) {
     throw new Error('Bundled skills are not available in this app build.');
@@ -495,7 +605,7 @@ export function installBundledSkills(
   const installedNames = prefixedSkillNames(bundledSkillNames);
   const targets = resolveManagedTargets();
   const commandTargets = resolveManagedCommandTargets();
-  const mcpTargets = resolveManagedMcpTargets();
+  const mcpTargets = resolveManagedMcpTargets(isInstalled);
   const manifestTargets: BundledSkillsManifest['targets'] = {};
   const manifestCommandTargets: NonNullable<BundledSkillsManifest['commandTargets']> = {};
   const manifestMcpTargets: NonNullable<BundledSkillsManifest['mcpTargets']> = {};
@@ -528,7 +638,8 @@ export function installBundledSkills(
   }
 
   for (const target of mcpTargets) {
-    installOmpMcpTarget(target);
+    if (!target.available) continue;
+    installMcpTarget(target);
     manifestMcpTargets[target.id] = {
       path: target.path,
       serverName: target.serverName,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,9 +5,11 @@ import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import {
   DEFAULT_DRAFTER_MCP_PACKAGE_SPEC,
+  readInvokerConfigFile,
   resolveHeadlessOwnerLaunchSpec,
   resolveInvokerHomeRoot,
   resolveRepoRoot,
+  updateInvokerConfigFile,
   type HeadlessOwnerLaunchSpec,
   type Logger,
 } from '@invoker/contracts';
@@ -48,7 +50,13 @@ import {
   type LiveOwnerInfo,
 } from './live-owner-bus.js';
 import { runMcpServer } from './mcp-server.js';
-import { runDoctor, runSetup } from './onboarding.js';
+import { defaultConfigPath, runDoctor, runSetup } from './onboarding.js';
+import {
+  applyWorkerToggle,
+  findWorkerToggle,
+  ONBOARDING_WORKER_TOGGLES,
+  readWorkerToggleValue,
+} from './worker-toggles.js';
 
 const VERSION = '0.0.9';
 
@@ -176,6 +184,7 @@ function usage(): string {
     '  invoker-cli setup [planner|slack] [--check|--from-env] [--yes] [--json]',
     '  invoker-cli mcp',
     '  invoker-cli worker [autofix|list]',
+    '  invoker-cli worker toggles [--enable <id>|--disable <id> ...]',
     '  invoker-cli --help',
     '  invoker-cli --version',
     '',
@@ -192,6 +201,7 @@ function usage(): string {
     '  setup [planner|slack]  Run the setup wizard, or directly configure planner MCP or Slack.',
     '  mcp             Start the Invoker MCP stdio server.',
     '  worker [kind|list]  Run a registry-selected worker or list available worker kinds.',
+    '  worker toggles      Show or set the on/off state of optional owner workers (PR maintenance, e2e auto-fix, auto-approve, disk-headroom cleanup).',
     '',
     'Options:',
     '  --planner-url <url>   Planner service URL for `setup planner`.',
@@ -947,6 +957,49 @@ function printWorkerKinds<TDeps>(registry: WorkerRegistry<TDeps>): void {
   }
 }
 
+/**
+ * `invoker-cli worker toggles [--enable <id>|--disable <id> ...]`
+ * With no flags, prints each toggle's current state. Each flag applies
+ * immediately, writing to ~/.invoker/config.json (or INVOKER_REPO_CONFIG_PATH).
+ */
+function runWorkerTogglesCommand(args: string[]): number {
+  const changes: Array<{ spec: ReturnType<typeof findWorkerToggle>; enabled: boolean }> = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const flag = args[i];
+    if (flag !== '--enable' && flag !== '--disable') {
+      throw new Error(`Unknown option for worker toggles: "${flag}". Usage: invoker-cli worker toggles [--enable <id>|--disable <id> ...]`);
+    }
+    const id = args[++i];
+    const spec = id ? findWorkerToggle(id) : undefined;
+    if (!spec) {
+      const knownIds = ONBOARDING_WORKER_TOGGLES.map((toggle) => toggle.id).join(', ');
+      throw new Error(`Unknown worker toggle id: "${id ?? ''}". Known ids: ${knownIds}`);
+    }
+    changes.push({ spec, enabled: flag === '--enable' });
+  }
+
+  if (changes.length > 0) {
+    const configPath = defaultConfigPath();
+    updateInvokerConfigFile(configPath, (config) => {
+      for (const { spec, enabled } of changes) {
+        Object.assign(config, applyWorkerToggle(config, spec!, enabled));
+      }
+    });
+    for (const { spec, enabled } of changes) {
+      process.stdout.write(`${spec!.label}: ${enabled ? 'on' : 'off'}\n`);
+    }
+    return 0;
+  }
+
+  const config = readInvokerConfigFile(defaultConfigPath());
+  process.stdout.write('Worker toggles\n');
+  for (const spec of ONBOARDING_WORKER_TOGGLES) {
+    const value = readWorkerToggleValue(config, spec);
+    process.stdout.write(`  ${spec.label}: ${value === undefined ? 'off (default)' : (value ? 'on' : 'off')} — ${spec.description}\n`);
+  }
+  return 0;
+}
+
 function isExternalWorkerRuntime(worker: WorkerRuntime): worker is ExternalWorkerRuntime {
   return 'finished' in worker && worker.finished instanceof Promise;
 }
@@ -1070,6 +1123,9 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     }
     if (argv[0] === 'worker') {
       const subcommand = argv[1] ?? 'list';
+      if (subcommand === 'toggles') {
+        return runWorkerTogglesCommand(argv.slice(2));
+      }
       const registry = registerExternalWorkers(
         registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
         readWorkerConfig(resolveInvokerHomeRoot()).externalWorkers,

--- a/packages/cli/src/onboarding-invariants.ts
+++ b/packages/cli/src/onboarding-invariants.ts
@@ -1,0 +1,90 @@
+/**
+ * Executable guardrails for the CLI onboarding wizard, encoding lessons from
+ * past regressions as assertions instead of tribal knowledge — so a future
+ * AI-assisted rewrite of onboarding.ts can't silently reintroduce them. Each
+ * function throws on violation; wire calls into onboarding.test.ts alongside
+ * the flow it guards, following the pattern in
+ * packages/workflow-core/src/state-invariants.ts.
+ */
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Guards the Drafter-MCP regression: an optional external tool must never be
+ * installed/written without a prior prompt that names it and calls it optional.
+ * Scans `printedLines` in order; if nothing about `toolName` looks like an
+ * install, there is nothing to guard (pass trivially).
+ */
+export function assertOptionalToolPromptedBeforeInstall(printedLines: readonly string[], toolName: string): void {
+  const nameRe = new RegExp(escapeRegExp(toolName), 'i');
+  const installIndex = printedLines.findIndex((line) => nameRe.test(line) && /\b(install(ed)?|wrote|enabled)\b/i.test(line));
+  if (installIndex === -1) return;
+
+  const promptedBefore = printedLines
+    .slice(0, installIndex)
+    .some((line) => nameRe.test(line) && /\boptional\b/i.test(line));
+  if (!promptedBefore) {
+    throw new Error(`"${toolName}" was installed/written without an earlier prompt naming it as optional`);
+  }
+}
+
+const GUARDED_CONFIG_FILENAMES = ['config.json', 'mcp.json', '.env'];
+
+/**
+ * Guards against a "declined everything" wizard run writing anything.
+ * `writtenFilePaths` should be every file path the wizard actually wrote
+ * during the run (e.g. from existsSync checks or a write log).
+ */
+export function assertNoConfigWriteOnAllDeclined(writtenFilePaths: readonly string[], allDeclined: boolean): void {
+  if (!allDeclined) return;
+  const offending = writtenFilePaths.filter((path) => GUARDED_CONFIG_FILENAMES.some((name) => path.endsWith(name)));
+  if (offending.length > 0) {
+    throw new Error(`declining every setup prompt must not write any file, but wrote: ${offending.join(', ')}`);
+  }
+}
+
+/**
+ * Guards the remote-doctor gate added alongside this module: a machine must
+ * never be persisted to config while any required readiness check failed.
+ */
+export function assertRemoteTargetOnlyPersistedAfterAllChecksPass(
+  doctorChecks: readonly { id?: string; status: string }[],
+  written: boolean,
+): void {
+  const failed = doctorChecks.filter((check) => check.status === 'error');
+  if (written && failed.length > 0) {
+    throw new Error(`remote target was persisted to config despite failing checks: ${failed.map((check) => check.id ?? '?').join(', ')}`);
+  }
+}
+
+/**
+ * Guards against a secret (SSH key path contents, token, password) ending up
+ * in printed wizard output. Ignores trivially short values (<6 chars) so
+ * empty/placeholder fields don't produce false positives.
+ */
+export function assertNoSecretPrinted(printedLines: readonly string[], secretValues: readonly string[]): void {
+  for (const secret of secretValues) {
+    if (secret.trim().length < 6) continue;
+    const leaked = printedLines.find((line) => line.includes(secret));
+    if (leaked) {
+      throw new Error(`a secret value was printed to stdout: "${leaked.slice(0, 40)}${leaked.length > 40 ? '…' : ''}"`);
+    }
+  }
+}
+
+/**
+ * Guards the disk-headroom-cleanup regression: a worker toggle's configPath
+ * must look like a real dotted InvokerConfig field, never a bare env var
+ * name. This is what would have caught `INVOKER_DISK_CLEANUP_ENABLED` being
+ * used as a toggle's source of truth instead of a config field.
+ */
+export function assertWorkerToggleHasSingleConfigSource(spec: { id: string; configPath: string }): void {
+  if (/^[A-Z][A-Z0-9_]*$/.test(spec.configPath)) {
+    throw new Error(`worker toggle "${spec.id}" is backed by what looks like a bare env var name ("${spec.configPath}") instead of an InvokerConfig field`);
+  }
+  if (!/^[a-zA-Z][a-zA-Z0-9]*(\.[a-zA-Z][a-zA-Z0-9]*)?$/.test(spec.configPath)) {
+    throw new Error(`worker toggle "${spec.id}" has a malformed configPath "${spec.configPath}"`);
+  }
+}

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -13,6 +13,7 @@ import {
   EXTERNAL_DEPENDENCIES,
   formatReport,
   readInvokerConfigFile,
+  resolveRepoRoot,
   type RemoteTargetConnectivityImpl,
   type RemoteTargetInput,
   type IsInstalled,
@@ -23,6 +24,9 @@ import {
 } from '@invoker/contracts';
 import { parsePlanFile } from '@invoker/workflow-core';
 import { formatCaughtException, logCaughtException } from './logging.js';
+import { installBundledSkills } from './bundled-skills.js';
+import { runRemoteDoctorChecks } from './remote-doctor.js';
+import { applyWorkerToggle, ONBOARDING_WORKER_TOGGLES, readWorkerToggleValue } from './worker-toggles.js';
 
 // ── Paths ────────────────────────────────────────────────────
 
@@ -418,6 +422,9 @@ export interface SetupDeps {
   githubAuthCheck?: (runner: CommandRunner) => PrerequisiteCheck | Promise<PrerequisiteCheck>;
   smokePlanValidation?: () => Promise<PrerequisiteCheck>;
   remoteTargetConnectivity?: RemoteTargetConnectivityImpl;
+  remoteDoctorChecks?: typeof runRemoteDoctorChecks;
+  bundledSkillsInstall?: typeof installBundledSkills;
+  resolveSkillsRepoRoot?: typeof resolveRepoRoot;
 }
 
 // ── Slack manifest ───────────────────────────────────────────
@@ -791,6 +798,7 @@ interface MachineSetupSuccessResult {
   reachable: boolean;
   written: boolean;
   message: string;
+  doctorChecks?: PrerequisiteCheck[];
 }
 
 interface MachineSetupErrorResult {
@@ -803,6 +811,7 @@ interface MachineSetupErrorResult {
     message: string;
     conflictingTargetId?: string;
   };
+  doctorChecks?: PrerequisiteCheck[];
 }
 
 type MachineSetupResult = MachineSetupSuccessResult | MachineSetupErrorResult;
@@ -816,6 +825,18 @@ function parseOptionalPositiveInteger(value: string, fieldName: string, max?: nu
     throw new Error(`${fieldName} must be ${max === undefined ? 'a positive integer' : `between 1 and ${max}`}`);
   }
   return parsed;
+}
+
+/**
+ * Repo URL used only to run the remote doctor's push-credential check
+ * (`git ls-remote` on the box) — deliberately not part of `RemoteTargetInput`,
+ * so it never gets written into `remoteTargets` config.
+ */
+function extractRepoUrl(value: unknown): string {
+  if (!isJsonRecord(value)) throw new Error('machine must be an object');
+  const raw = value.repoUrl;
+  if (typeof raw !== 'string' || raw.trim() === '') throw new Error('repoUrl is required');
+  return raw.trim();
 }
 
 function normalizeRemoteTargetInput(value: unknown): RemoteTargetInput {
@@ -855,11 +876,17 @@ function normalizeRemoteTargetInput(value: unknown): RemoteTargetInput {
   return input;
 }
 
-async function askRemoteTargetInput(io: SetupIO): Promise<RemoteTargetInput> {
+interface RemoteTargetDraft {
+  input: RemoteTargetInput;
+  repoUrl: string;
+}
+
+async function askRemoteTargetInput(io: SetupIO): Promise<RemoteTargetDraft> {
   const name = await askLine(io, 'Machine name: ');
   const host = await askLine(io, 'Host: ');
   const user = await askLine(io, 'User: ');
   const sshKeyPath = await askLine(io, 'SSH key path: ');
+  const repoUrl = await askLine(io, 'Repo URL (used to verify this box can push code back): ');
   const port = parseOptionalPositiveInteger(await askLine(io, 'SSH port [22]: '), 'port', 65535);
   const maxConcurrentTasks = parseOptionalPositiveInteger(
     await askLine(io, 'Max concurrent tasks [1]: '),
@@ -867,7 +894,7 @@ async function askRemoteTargetInput(io: SetupIO): Promise<RemoteTargetInput> {
   );
   const provisionCommand = (await askLine(io, 'Provision command (optional): ')).trim();
 
-  return normalizeRemoteTargetInput({
+  const input = normalizeRemoteTargetInput({
     name,
     host,
     user,
@@ -876,22 +903,24 @@ async function askRemoteTargetInput(io: SetupIO): Promise<RemoteTargetInput> {
     ...(maxConcurrentTasks !== undefined ? { maxConcurrentTasks } : {}),
     ...(provisionCommand !== '' ? { provisionCommand } : {}),
   });
+
+  return { input, repoUrl: extractRepoUrl({ repoUrl }) };
 }
 
 async function checkAndMaybeWriteRemoteTarget(
   input: RemoteTargetInput,
+  repoUrl: string,
   write: boolean,
   options: SetupDeps,
 ): Promise<MachineSetupResult> {
-  const connectivity = await checkRemoteTargetConnectivity(
-    {
-      host: input.host,
-      user: input.user,
-      sshKeyPath: input.sshKeyPath,
-      port: input.port,
-    },
-    { impl: options.remoteTargetConnectivity },
-  );
+  const target = {
+    host: input.host,
+    user: input.user,
+    sshKeyPath: input.sshKeyPath,
+    port: input.port,
+  };
+
+  const connectivity = await checkRemoteTargetConnectivity(target, { impl: options.remoteTargetConnectivity });
 
   if (!connectivity.reachable) {
     return {
@@ -903,16 +932,33 @@ async function checkAndMaybeWriteRemoteTarget(
     };
   }
 
+  const runDoctorChecks = options.remoteDoctorChecks ?? runRemoteDoctorChecks;
+  const doctorChecks = await runDoctorChecks({ target, repoUrl });
+  const failedCheck = doctorChecks.find((check) => check.status === 'error');
+
+  if (failedCheck) {
+    const message = `Remote readiness check failed: ${failedCheck.name} — ${failedCheck.detail}`;
+    return {
+      name: input.name,
+      reachable: true,
+      written: false,
+      message,
+      error: { code: 'doctor-check-failed', message },
+      doctorChecks,
+    };
+  }
+
   if (!write) {
     return {
       name: input.name,
       reachable: true,
       written: false,
       message: connectivity.message,
+      doctorChecks,
     };
   }
 
-  return writeRemoteTarget(input);
+  return { ...writeRemoteTarget(input), doctorChecks };
 }
 
 function writeRemoteTarget(input: RemoteTargetInput): MachineSetupResult {
@@ -947,19 +993,29 @@ async function runMachinesSetupInteractive(io: SetupIO, options: SetupDeps): Pro
   while (addAnother) {
     let repeatThisMachine = true;
     while (repeatThisMachine) {
-      let input: RemoteTargetInput;
+      let draft: RemoteTargetDraft;
       try {
-        input = await askRemoteTargetInput(io);
+        draft = await askRemoteTargetInput(io);
       } catch (error) {
         io.print(`Invalid machine input: ${formatCaughtException(error)}`);
         repeatThisMachine = await promptYes(io, 'Try this machine again? [y/N] ');
         continue;
       }
 
-      const checked = await checkAndMaybeWriteRemoteTarget(input, false, options);
+      const checked = await checkAndMaybeWriteRemoteTarget(draft.input, draft.repoUrl, false, options);
       io.print(formatMachineConnectivity(checked));
 
       if (!checked.reachable) {
+        repeatThisMachine = await promptYes(io, 'Try this machine again? [y/N] ');
+        continue;
+      }
+
+      if (checked.doctorChecks) {
+        io.print('');
+        io.print(formatReport(buildReport(checked.doctorChecks)));
+      }
+
+      if ('error' in checked && checked.error.code === 'doctor-check-failed') {
         repeatThisMachine = await promptYes(io, 'Try this machine again? [y/N] ');
         continue;
       }
@@ -971,7 +1027,7 @@ async function runMachinesSetupInteractive(io: SetupIO, options: SetupDeps): Pro
         continue;
       }
 
-      const written = writeRemoteTarget(input);
+      const written = writeRemoteTarget(draft.input);
       if (written.written) {
         io.print(written.message);
       } else {
@@ -1009,8 +1065,10 @@ async function runMachinesSetupJson(io: SetupIO, options: SetupDeps): Promise<nu
   const results: MachineSetupResult[] = [];
   for (const item of parsed) {
     let input: RemoteTargetInput;
+    let repoUrl: string;
     try {
       input = normalizeRemoteTargetInput(item);
+      repoUrl = extractRepoUrl(item);
     } catch (error) {
       results.push({
         written: false,
@@ -1019,23 +1077,69 @@ async function runMachinesSetupJson(io: SetupIO, options: SetupDeps): Promise<nu
       });
       continue;
     }
-    results.push(await checkAndMaybeWriteRemoteTarget(input, true, options));
+    results.push(await checkAndMaybeWriteRemoteTarget(input, repoUrl, true, options));
   }
 
   io.print(JSON.stringify(results));
   return results.every((result) => result.written) ? 0 : 1;
 }
 
-function plannerMcpCheck(state: ExperimentalPlannerSetupState): PrerequisiteCheck {
-  return {
-    id: 'planner-mcp',
-    name: 'Experimental planner MCP',
-    status: state.installed ? 'ok' : 'error',
-    detail: state.installed
-      ? `Installed into ${state.targetPath} (experimentalPlanner ${state.experimentalPlanner ? 'on' : 'off'})`
-      : `Missing at ${state.targetPath}`,
-    remediation: state.installed ? undefined : 'Re-run `invoker-cli setup` or `invoker-cli setup planner`',
-  };
+/**
+ * Every toggle defaults to "leave unset" (matches ONBOARDING_WORKER_TOGGLES' own
+ * documented off-by-default worker behavior) so mashing Enter through this step,
+ * or running it under --yes, reproduces today's default config exactly.
+ */
+async function runWorkerTogglesInteractive(io: SetupIO, assumeYes: boolean): Promise<void> {
+  const configPath = defaultConfigPath();
+  let config = readInvokerConfigFile(configPath);
+  let changed = false;
+  const summary: string[] = [];
+
+  for (const spec of ONBOARDING_WORKER_TOGGLES) {
+    io.print(`\n${spec.label}: ${spec.description}`);
+    const enable = assumeYes ? false : await promptYes(io, `Enable ${spec.label}? [y/N] `);
+    const current = readWorkerToggleValue(config, spec) ?? false;
+    if (enable !== current) {
+      config = applyWorkerToggle(config, spec, enable);
+      changed = true;
+    }
+    summary.push(`${spec.label}: ${enable ? 'on' : 'off'}`);
+  }
+
+  if (changed) {
+    writeInvokerConfigFile(configPath, config);
+  }
+
+  io.print('');
+  io.print(`Worker toggles — ${summary.join(', ')}`);
+}
+
+/**
+ * Only works when `setup` runs from inside an Invoker checkout (dev, or a repo
+ * clone) — the standalone distribution has nowhere to source `skills/` from.
+ * Fails soft: a truly standalone install (or a build without a source checkout)
+ * just skips this with a note instead of breaking the rest of `setup`.
+ */
+function installSetupBundledSkills(io: SetupIO, options: SetupDeps): void {
+  const resolveSkillsRepoRoot = options.resolveSkillsRepoRoot ?? resolveRepoRoot;
+  const install = options.bundledSkillsInstall ?? installBundledSkills;
+  let repoRoot: string;
+  try {
+    repoRoot = resolveSkillsRepoRoot(process.cwd());
+  } catch {
+    io.print('Skills: skipped (not running from an Invoker checkout).');
+    return;
+  }
+
+  try {
+    const status = install({ isPackaged: false, repoRoot });
+    const installedTargets = status.targets.filter((target) => target.installed).map((target) => target.name);
+    const installedMcp = status.mcpTargets.filter((target) => target.installed).map((target) => target.name);
+    io.print(`Skills: installed ${status.bundledSkillNames.length} bundled skill(s) for ${installedTargets.join(', ') || 'no targets'}.`);
+    io.print(`Skills MCP: registered invoker-cli mcp for ${installedMcp.join(', ') || 'no detected harnesses'}.`);
+  } catch (error) {
+    io.print(`Skills: install skipped — ${formatCaughtException(error)}`);
+  }
 }
 
 async function collectGithubAndSmokeChecks(options: SetupDeps): Promise<PrerequisiteCheck[]> {
@@ -1095,20 +1199,8 @@ export async function runSetup(
     io.print(formatReport(buildReport(doctorChecks)));
     io.print('');
 
-    const plannerState = ensureExperimentalPlannerMcp({
-      targetPath: parsed.targetPath,
-      plannerPackage: parsed.plannerPackage ?? process.env.INVOKER_PLANNER_PACKAGE,
-    });
-    io.print(`Experimental planner MCP installed into ${plannerState.targetPath}.`);
-    io.print(`experimentalPlanner flag: ${plannerState.experimentalPlanner ? 'on' : 'off'}`);
+    installSetupBundledSkills(io, options);
     io.print('');
-    checks.push(plannerMcpCheck(plannerState));
-
-    if (!wantSlack && !wantMachines && !fromEnv && await promptYes(io, 'Enable the experimental planner now? [y/N] ', parsed.assumeYes)) {
-      await maybeInstallPlanner(parsed, io);
-      io.print('');
-      checks.push(plannerMcpCheck(readExperimentalPlannerSetup({ targetPath: parsed.targetPath })));
-    }
 
     let doSlack = wantSlack || fromEnv;
     if (!wantSlack && !wantMachines && !fromEnv) {
@@ -1169,6 +1261,10 @@ export async function runSetup(
     }
     if (doMachines) {
       await runMachinesSetupInteractive(io, options);
+    }
+
+    if (!wantSlack && !wantMachines && !fromEnv) {
+      await runWorkerTogglesInteractive(io, parsed.assumeYes);
     }
 
     const extras = await collectGithubAndSmokeChecks(options);

--- a/packages/cli/src/remote-doctor.ts
+++ b/packages/cli/src/remote-doctor.ts
@@ -1,0 +1,149 @@
+import {
+  buildSshConnectionArgs,
+  execRemoteCapture,
+  shellPosixSingleQuote,
+  type SshTargetConnection,
+} from '@invoker/execution-engine';
+import type { PrerequisiteCheck } from '@invoker/contracts';
+
+const REQUIRED_REMOTE_TOOLS = [
+  { id: 'git', name: 'Git (remote)', command: 'git' },
+  { id: 'node', name: 'Node (remote)', command: 'node' },
+  { id: 'pnpm', name: 'pnpm (remote)', command: 'pnpm' },
+] as const;
+
+const DISK_WARN_THRESHOLD_KB = 1 * 1024 * 1024; // 1 GiB, df -Pk reports 1024-byte blocks
+
+export type ExecRemoteCaptureImpl = typeof execRemoteCapture;
+
+export interface RunRemoteDoctorChecksOptions {
+  target: SshTargetConnection;
+  repoUrl: string;
+  execRemoteCaptureImpl?: ExecRemoteCaptureImpl;
+}
+
+function buildDoctorScript(repoUrl: string): string {
+  const toolChecks = REQUIRED_REMOTE_TOOLS
+    .map((tool) => `if command -v ${tool.command} >/dev/null 2>&1; then echo "check:${tool.id}:ok"; else echo "check:${tool.id}:missing"; fi`)
+    .join('\n');
+
+  return [
+    'set -u',
+    toolChecks,
+    'disk_kb=$(df -Pk "$HOME" 2>/dev/null | awk \'NR==2{print $4}\')',
+    'echo "disk_kb:${disk_kb:-unknown}"',
+    `if git ls-remote ${shellPosixSingleQuote(repoUrl)} >/dev/null 2>&1; then echo "check:push-auth:ok"; else echo "check:push-auth:missing"; fi`,
+    'exit 0',
+  ].join('\n');
+}
+
+function parseDoctorOutput(stdout: string): RunRemoteDoctorChecksResults {
+  const lines = stdout.split('\n');
+  const checkStatus = new Map<string, 'ok' | 'missing'>();
+  let diskKb: number | undefined;
+
+  for (const line of lines) {
+    const checkMatch = line.match(/^check:([a-z-]+):(ok|missing)$/);
+    if (checkMatch) {
+      checkStatus.set(checkMatch[1], checkMatch[2] as 'ok' | 'missing');
+      continue;
+    }
+    const diskMatch = line.match(/^disk_kb:(\d+|unknown)$/);
+    if (diskMatch && diskMatch[1] !== 'unknown') {
+      diskKb = Number.parseInt(diskMatch[1], 10);
+    }
+  }
+
+  return { checkStatus, diskKb };
+}
+
+interface RunRemoteDoctorChecksResults {
+  checkStatus: Map<string, 'ok' | 'missing'>;
+  diskKb: number | undefined;
+}
+
+function toolCheckResult(id: string, name: string, status: 'ok' | 'missing' | undefined): PrerequisiteCheck {
+  if (status === 'ok') {
+    return { id, name, status: 'ok', detail: `${name} found on remote box` };
+  }
+  return {
+    id,
+    name,
+    status: 'error',
+    detail: status === 'missing' ? `${name} not found on remote box` : `${name} check did not report a result`,
+    remediation: 'Install the missing tool on the remote box, then re-run `invoker-cli setup machines`.',
+  };
+}
+
+function diskCheckResult(diskKb: number | undefined): PrerequisiteCheck {
+  if (diskKb === undefined) {
+    return {
+      id: 'disk-space',
+      name: 'Disk space (remote)',
+      status: 'warn',
+      detail: 'Could not determine free disk space on the remote box',
+    };
+  }
+  if (diskKb < DISK_WARN_THRESHOLD_KB) {
+    return {
+      id: 'disk-space',
+      name: 'Disk space (remote)',
+      status: 'warn',
+      detail: `Only ${Math.round(diskKb / 1024)} MiB free on the remote box (below the ${Math.round(DISK_WARN_THRESHOLD_KB / 1024)} MiB warning threshold)`,
+      remediation: 'Free up disk space on the remote box before routing heavy tasks to it.',
+    };
+  }
+  return {
+    id: 'disk-space',
+    name: 'Disk space (remote)',
+    status: 'ok',
+    detail: `${Math.round(diskKb / 1024)} MiB free on the remote box`,
+  };
+}
+
+function pushAuthCheckResult(repoUrl: string, status: 'ok' | 'missing' | undefined): PrerequisiteCheck {
+  if (status === 'ok') {
+    return { id: 'push-auth', name: 'GitHub push credentials (remote)', status: 'ok', detail: `Remote box can reach ${repoUrl}` };
+  }
+  return {
+    id: 'push-auth',
+    name: 'GitHub push credentials (remote)',
+    status: 'error',
+    detail: `Remote box could not reach ${repoUrl} with its own git credentials`,
+    remediation: 'Give the remote box its own way to authenticate to GitHub (deploy key, ssh-agent forwarding, or an HTTPS credential helper), then re-run `invoker-cli setup machines`.',
+  };
+}
+
+/**
+ * Runs a bundle of readiness probes on a remote SSH target in a single round trip:
+ * required tools present, free disk space, and whether the box's own git credentials
+ * can reach the task's repo. `repoUrl`'s `sshKeyPath` never enters this remote script —
+ * git push authenticates independently on the remote box, so this is the only way to
+ * catch a missing push credential before a real task fails at the finish line.
+ */
+export async function runRemoteDoctorChecks(options: RunRemoteDoctorChecksOptions): Promise<PrerequisiteCheck[]> {
+  const sshArgs = buildSshConnectionArgs(options.target, { batchMode: true });
+  const script = buildDoctorScript(options.repoUrl);
+  const runCapture = options.execRemoteCaptureImpl ?? execRemoteCapture;
+
+  let stdout: string;
+  try {
+    stdout = await runCapture({ sshArgs, script, phase: 'remote-doctor' });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const detail = `Could not run readiness checks on the remote box: ${message}`;
+    return [
+      ...REQUIRED_REMOTE_TOOLS.map((tool) => ({ id: tool.id, name: tool.name, status: 'error' as const, detail })),
+      { id: 'disk-space', name: 'Disk space (remote)', status: 'warn' as const, detail },
+      { id: 'push-auth', name: 'GitHub push credentials (remote)', status: 'error' as const, detail },
+    ];
+  }
+
+  const { checkStatus, diskKb } = parseDoctorOutput(stdout);
+
+  return [
+    ...REQUIRED_REMOTE_TOOLS.map((tool) => toolCheckResult(tool.id, tool.name, checkStatus.get(tool.id))),
+    diskCheckResult(diskKb),
+    pushAuthCheckResult(options.repoUrl, checkStatus.get('push-auth')),
+  ];
+}

--- a/packages/cli/src/worker-toggles.ts
+++ b/packages/cli/src/worker-toggles.ts
@@ -1,0 +1,88 @@
+import type { InvokerConfigRecord } from '@invoker/contracts';
+
+/**
+ * Dotted config paths for the workers this wizard exposes as on/off toggles.
+ * Every path is backed by a real `InvokerConfig` field read at owner boot —
+ * never a bare env var — see onboarding-invariants.ts's
+ * assertWorkerToggleHasSingleConfigSource for the guard against that drifting.
+ */
+export type WorkerToggleConfigPath =
+  | 'prMaintenance.enabled'
+  | 'e2eAutoFixEnabled'
+  | 'autoApproveAIFixes'
+  | 'diskHeadroom.cleanupEnabled';
+
+export interface WorkerToggleSpec {
+  id: string;
+  label: string;
+  description: string;
+  configPath: WorkerToggleConfigPath;
+}
+
+export const ONBOARDING_WORKER_TOGGLES: readonly WorkerToggleSpec[] = [
+  {
+    id: 'pr-maintenance',
+    label: 'PR maintenance',
+    description: 'Babysits open PRs: re-queues stuck merges, closes duplicates, repairs orphaned stack fragments.',
+    configPath: 'prMaintenance.enabled',
+  },
+  {
+    id: 'e2e-autofix',
+    label: 'E2E auto-fix',
+    description: 'Runs the extended test battery on a schedule and opens a fix PR when it finds a failing suite.',
+    configPath: 'e2eAutoFixEnabled',
+  },
+  {
+    id: 'auto-approve',
+    label: 'Auto-approve AI fixes',
+    description: 'Skips the manual "Approve Fix" step for fix-with-agent and resolve-conflict flows. The worker itself always runs; this only controls whether it acts automatically.',
+    configPath: 'autoApproveAIFixes',
+  },
+  {
+    id: 'disk-headroom-cleanup',
+    label: 'Disk-headroom cleanup',
+    description: 'Automatically reclaims disk space when a machine gets critically full. The monitoring worker always runs; this only controls whether it is allowed to delete anything.',
+    configPath: 'diskHeadroom.cleanupEnabled',
+  },
+] as const;
+
+function splitConfigPath(path: WorkerToggleConfigPath): [string, string | undefined] {
+  const [head, tail] = path.split('.', 2);
+  return [head, tail];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+/** Reads a toggle's current value from config; `undefined` means "unset" (worker uses its own default). */
+export function readWorkerToggleValue(config: InvokerConfigRecord, spec: WorkerToggleSpec): boolean | undefined {
+  const [head, tail] = splitConfigPath(spec.configPath);
+  if (!tail) {
+    const value = config[head];
+    return typeof value === 'boolean' ? value : undefined;
+  }
+  const nested = asRecord(config[head]);
+  const value = nested?.[tail];
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+/** Pure setter — returns a new config record with the toggle applied, does not write to disk. */
+export function applyWorkerToggle(
+  config: InvokerConfigRecord,
+  spec: WorkerToggleSpec,
+  enabled: boolean,
+): InvokerConfigRecord {
+  const [head, tail] = splitConfigPath(spec.configPath);
+  if (!tail) {
+    return { ...config, [head]: enabled };
+  }
+  const nested = asRecord(config[head]) ?? {};
+  return { ...config, [head]: { ...nested, [tail]: enabled } };
+}
+
+export function findWorkerToggle(id: string): WorkerToggleSpec | undefined {
+  return ONBOARDING_WORKER_TOGGLES.find((spec) => spec.id === id);
+}


### PR DESCRIPTION
Threads the new config field added in slice 1 into the owner's disk-headroom
worker dependencies, so setting it in config.json actually takes effect
(execution-engine's resolveDiskCleanupEnabled already prefers this over the
env var when present — this is the missing wiring, not new logic).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Depends-On: #8110