### PR TITLE
Fail fast with a clear error when the IPC socket path is too long

### DIFF
--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -555,6 +555,13 @@ async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void>
         );
         return;
       }
+      if (bus instanceof IpcBus) {
+        const fatal = bus.getFatalConnectError();
+        if (fatal) {
+          delegationClientLog(`bootstrap fatal connect error attempts=${attempts} elapsedMs=${Date.now() - startedAt}: ${fatal.message}`);
+          throw fatal;
+        }
+      }
       await new Promise((resolveDelay) => setTimeout(resolveDelay, 200));
     }
     delegationClientLog(`bootstrap timeout elapsedMs=${Date.now() - startedAt}`);

--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { join, dirname } from 'node:path';
-import { chmodSync, existsSync, mkdtempSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
@@ -585,6 +585,38 @@ describe('IpcBus', () => {
     expect(blocked.isServing()).toBe(false);
     const result = await blocked.request<string, string>('echo', 'ok');
     expect(result).toBe('owner:ok');
+  });
+
+  function tooLongSocketPath(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'ipc-bus-test-'));
+    const nested = join(dir, 'x'.repeat(60), 'y'.repeat(60));
+    mkdirSync(nested, { recursive: true });
+    return join(nested, 'test.sock');
+  }
+
+  it('surfaces a non-retryable getFatalConnectError() instead of retrying forever when a server cannot bind a too-long socket path', async () => {
+    const sock = tooLongSocketPath();
+    const server = createBus(sock);
+
+    await waitFor(() => server.getFatalConnectError() !== null, 2000);
+
+    const fatal = server.getFatalConnectError();
+    expect(fatal).toBeInstanceOf(TransportError);
+    expect(fatal?.code).toBe(TransportErrorCode.SOCKET_PATH_INVALID);
+    expect(fatal?.message).toContain(String(sock.length));
+    expect(fatal?.message).toContain('INVOKER_IPC_SOCKET');
+  });
+
+  it('surfaces a non-retryable getFatalConnectError() for a pure client (headless CLI) on a too-long socket path', async () => {
+    const sock = tooLongSocketPath();
+    const client = new IpcBus(sock, { allowServe: false });
+    buses.push(client);
+
+    await waitFor(() => client.getFatalConnectError() !== null, 2000);
+
+    const fatal = client.getFatalConnectError();
+    expect(fatal).toBeInstanceOf(TransportError);
+    expect(fatal?.code).toBe(TransportErrorCode.SOCKET_PATH_INVALID);
   });
 
   it('still reclaims a stale socket file left behind by a crashed server', async () => {

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -233,6 +233,17 @@ export function resolveDefaultSocketPath(): string {
   return resolveInvokerIpcSocketPath();
 }
 
+/**
+ * True for errno codes that mean a socket path can never be connected to or
+ * bound, regardless of retries (e.g. it exceeds the OS's `sun_path` length
+ * limit, ~104 bytes on macOS / ~108 on Linux). Every other connect/listen
+ * error (ECONNREFUSED, ENOENT, EACCES from a transient permission race, ...)
+ * is treated as potentially transient elsewhere in this file.
+ */
+function isPermanentSocketPathError(err: NodeJS.ErrnoException): boolean {
+  return err.code === 'EINVAL' || err.code === 'ENAMETOOLONG';
+}
+
 export const DEFAULT_SOCKET_PATH = resolveDefaultSocketPath();
 
 /** Default request deadline in milliseconds (30 s). */
@@ -291,6 +302,7 @@ export class IpcBus implements MessageBus {
   private readyPromise: Promise<void>;
   private resolveReady!: () => void;
   private disconnected = false;
+  private fatalConnectError: TransportError | null = null;
 
   // Request/reply correlation.
   private nextReqId = 0;
@@ -323,6 +335,18 @@ export class IpcBus implements MessageBus {
     this.tryConnect();
   }
 
+  /** Record a permanent socket-path failure, once, for `getFatalConnectError()`. */
+  private recordFatalConnectError(err: NodeJS.ErrnoException): void {
+    if (this.fatalConnectError) return;
+    this.fatalConnectError = new TransportError(
+      TransportErrorCode.SOCKET_PATH_INVALID,
+      `Cannot use IPC socket path "${this.socketPath}" (${this.socketPath.length} chars): `
+        + `${err.code}. Unix domain socket paths are limited to roughly 100 characters on `
+        + 'most operating systems. Set INVOKER_IPC_SOCKET to a shorter path, or shorten '
+        + 'INVOKER_DB_DIR.',
+    );
+  }
+
   private tryConnect(): void {
     const sock = createConnection({ path: this.socketPath }, () => {
       // Connected as client.
@@ -331,6 +355,14 @@ export class IpcBus implements MessageBus {
     });
 
     sock.on('error', (err: NodeJS.ErrnoException) => {
+      if (isPermanentSocketPathError(err)) {
+        // Retrying this path can never succeed, so still keep the existing
+        // resolve+retry contract (every other caller of ready()/request()
+        // depends on it), but record the cause so a caller that specifically
+        // checks getFatalConnectError() can fail fast instead of waiting out
+        // a bootstrap timeout for a condition that will never clear.
+        this.recordFatalConnectError(err);
+      }
       if (!this.allowServe) {
         // A pure client (allowServe: false, e.g. a headless CLI) must never
         // become the server, but the server it's waiting for may simply not
@@ -378,6 +410,10 @@ export class IpcBus implements MessageBus {
       if (err.code === 'EADDRINUSE') {
         // Another process won the race — fall back to client.
         this.tryConnectRetry();
+        return;
+      }
+      if (isPermanentSocketPathError(err)) {
+        this.recordFatalConnectError(err);
       }
       // Other server errors are silently ignored (no payload logging).
     });
@@ -708,6 +744,17 @@ export class IpcBus implements MessageBus {
   /** Wait until the transport is connected or serving. */
   ready(): Promise<void> {
     return this.readyPromise;
+  }
+
+  /**
+   * A permanent, non-retryable reason this bus can never connect or serve
+   * (currently: the socket path is too long for the OS), or null if none has
+   * been observed. Callers that poll on `ready()`/`request()` in a loop with
+   * their own timeout (e.g. headless CLI bootstrap) can check this to fail
+   * fast with a clear cause instead of waiting out the full timeout.
+   */
+  getFatalConnectError(): TransportError | null {
+    return this.fatalConnectError;
   }
 
   /** True when this bus currently owns the listening socket. */

--- a/packages/transport/src/transport-error.ts
+++ b/packages/transport/src/transport-error.ts
@@ -14,6 +14,10 @@ export const TransportErrorCode = {
   HANDLER_ERROR: 'HANDLER_ERROR',
   /** The request exceeded its deadline without receiving a response. */
   REQUEST_TIMEOUT: 'REQUEST_TIMEOUT',
+  /** The socket path is structurally unusable (e.g. exceeds the OS's Unix
+   *  domain socket path length limit), so connecting or serving on it can
+   *  never succeed no matter how many times it is retried. */
+  SOCKET_PATH_INVALID: 'SOCKET_PATH_INVALID',
 } as const;
 
 export type TransportErrorCode = (typeof TransportErrorCode)[keyof typeof TransportErrorCode];


### PR DESCRIPTION
## Summary

`./run.sh --headless run <plan>` hung for 60 seconds, then failed with "could not reach a standalone shared owner" — even while a real owner process was running the whole time.

The real cause: `INVOKER_DB_DIR` was long enough that the derived Unix socket path exceeded the OS's ~104-character limit. Binding or connecting to it failed with `EINVAL`.

The code treated that `EINVAL` the same as "server may just be booting," and retried silently forever, both connecting and binding. It's permanent, not transient.

This adds a narrow classifier for that one error class and records it once. The headless CLI's bootstrap loop checks it and fails fast with a clear message, instead of exhausting its 60-second timeout.

## Review Claim

`IpcBus` now records a `getFatalConnectError()` when a connect or bind attempt hits `EINVAL`/`ENAMETOOLONG` (socket path too long), and the headless CLI's bootstrap loop checks it to fail fast with the real cause instead of waiting out its timeout.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Every existing retry path (`ECONNREFUSED`, `ENOENT`, `EADDRINUSE`, and all other errors) keeps its exact prior behavior — `resolveReady()`/`scheduleRecovery()` still fire unconditionally on every path. The only new behavior is recording the fatal error alongside the existing retry, and one new early-exit check in the headless bootstrap loop. No existing caller of `bus.ready()` can observe a rejection that wasn't possible before; that promise's resolve/reject contract is unchanged.

## Slice Rationale

Single cohesive change: the transport-level classification and the one call site that needed it (headless CLI bootstrap, the only place this was actually observed hanging). Both `## Review Unit` checks pass together with no product/policy/proof file split needed.

## Non-goals

- Does not change how `main.ts`'s owner-side startup paths use `bus.ready()` — deliberately left alone given 11+ existing call sites depend on it always resolving.
- Does not auto-shorten or relocate the socket path. The fix is "fail fast with a clear message," not "silently work around it" — the user still needs to shorten `INVOKER_DB_DIR` or set `INVOKER_IPC_SOCKET`, they just find out in under a second instead of a minute.
- Does not touch the `EADDRINUSE` server-election race logic.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/transport && pnpm test` — 53 tests passed (51 pre-existing + 2 new), including two new tests proving `getFatalConnectError()` fires for both a server (`allowServe: true`) and a pure client (`allowServe: false`) on a too-long socket path.
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/headless-client.test.ts src/__tests__/headless-client-fixture-cleanup.test.ts` — 40 passed, 2 pre-existing skips, no regressions.
- [x] `pnpm run check:types` — clean, no errors.
- [x] Real end-to-end repro, before this fix (pre-fix commit, same 154-char `INVOKER_DB_DIR` that originally triggered this): hangs the full 60s, then fails with the generic error, while `ps aux` confirms a real owner process was alive the whole time.
- [x] Real end-to-end repro, after this fix, same exact command and path:
  ```
  [headless-client] bootstrap fatal connect error attempts=1 elapsedMs=3: Cannot use IPC socket path
  "/private/tmp/.../invoker-15wf-demo/db/ipc-transport.sock" (154 chars): EINVAL. Unix domain socket
  paths are limited to roughly 100 characters on most operating systems. Set INVOKER_IPC_SOCKET to a
  shorter path, or shorten INVOKER_DB_DIR.
  Error: Cannot use IPC socket path ... (154 chars): EINVAL. ...
  ```
  Total wall time: 0.52s (was 60s+).
- [x] Real end-to-end repro of the happy path (short socket path) after this fix: unaffected — workflow submitted, task ran, completed, exit 0, in ~1.2s to owner-ready as before.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
