### PR TITLE
[CI regression: a4a7770-playwright-8-of-9](1) Stabilize task reset runtime mode

### DIFF
--- a/packages/app/e2e/task-new-attempt-reset.spec.ts
+++ b/packages/app/e2e/task-new-attempt-reset.spec.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { SQLiteAdapter } from '@invoker/data-store';
 import { stringify as yamlStringify } from 'yaml';
-import { E2E_REPO_URL } from './fixtures/electron-app.js';
+import { E2E_REPO_URL, waitForRuntimeMode } from './fixtures/electron-app.js';
 import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
 
 const MAIN_JS = path.resolve(__dirname, '..', 'dist', 'main.js');
@@ -78,7 +78,7 @@ async function launchApp(testDir: string, configPath: string): Promise<{ app: El
       NODE_ENV: 'test',
           INVOKER_TEST_WORKFLOW_IDS: '1',
       TZ: 'UTC',
-      INVOKER_GUI_OWNER_MODE: 'standalone',
+      INVOKER_GUI_OWNER_MODE: 'gui',
       INVOKER_DB_DIR: testDir,
       INVOKER_IPC_SOCKET: ipcSocketPath,
       INVOKER_ALLOW_DELETE_ALL: '1',
@@ -93,6 +93,7 @@ async function launchApp(testDir: string, configPath: string): Promise<{ app: El
   });
   const page = await app.firstWindow();
   await waitForInvoker(page);
+  await waitForRuntimeMode(page, 'local-owner', 30_000);
   return { app, page };
 }
 


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a4a77700abe7fdd4f5743b92b3e2795de7d4277c; job=playwright / 8-of-9 -->

CI job `playwright / 8-of-9` first failed on default-branch push commit a4a77700abe7fdd4f5743b92b3e2795de7d4277c in run 30895657329.

It was most recently still red at f84c1edddd8a844b88c7b89f60731700db0651a4 in run 31289002425.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30895657329/job/91965992697

This updates the task-new-attempt-reset Playwright launch harness to use GUI owner mode and wait for local-owner runtime readiness.

The job-specific verification command passed after the change.

## Review Claim

The task-new-attempt-reset Playwright coverage now waits for the runtime mode it needs before exercising the new-attempt reset flow.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected Playwright harness readiness defect.

## Slice Rationale

One behavior slice repairs the failing CI job's root cause and keeps the deterministic proof in the test plan.

## Non-goals

No product runtime behavior changes, no unrelated cleanup, no test weakening, and no snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-8-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/focus-switch-hitch-responsiveness.spec.ts e2e/planning-chat-hitch-responsiveness.spec.ts e2e/command-palette-open.spec.ts e2e/task-new-attempt-reset.spec.ts e2e/persistence-recovery.spec.ts e2e/start-ready-production-click.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 37cfe6ffba689b384fcfe043008d850bb901a486`
- Post-revert steps: None
- Data migration? No

</details>
