### PR TITLE
[CI regression: e21a965-playwright-terminal-garbling](1) Flag manual-only specs assigned to shards

### DIFF
--- a/scripts/repro/repro-ci-playwright-shard-inventory.mjs
+++ b/scripts/repro/repro-ci-playwright-shard-inventory.mjs
@@ -60,16 +60,21 @@ function main() {
 
   const listedSet = new Set(listed);
   const discoveredSet = new Set(discovered);
+  const manualListed = [...MANUAL_ONLY_SPECS]
+    .map((file) => `e2e/${file}`)
+    .filter((file) => listedSet.has(file));
+  const manualListedSet = new Set(manualListed);
   const manualMissing = [...MANUAL_ONLY_SPECS]
     .filter((file) => !allDiscoveredSet.has(file))
     .map((file) => `e2e/${file}`);
   const missing = discovered.filter((file) => !listedSet.has(file));
-  const extra = listed.filter((file) => !discoveredSet.has(file));
+  const extra = listed.filter((file) => !discoveredSet.has(file) && !manualListedSet.has(file));
   const duplicates = [...new Set(listed.filter((file, index) => listed.indexOf(file) !== index))];
 
-  if (manualMissing.length || missing.length || extra.length || duplicates.length) {
+  if (manualMissing.length || manualListed.length || missing.length || extra.length || duplicates.length) {
     console.error('[repro-ci-playwright-shard-inventory] Playwright shard inventory drift detected.');
     if (manualMissing.length) console.error(`  Manual spec allowlist entries do not exist: ${manualMissing.join(', ')}`);
+    if (manualListed.length) console.error(`  Manual-only specs assigned to shards: ${manualListed.join(', ')}`);
     if (missing.length) console.error(`  Missing from shards: ${missing.join(', ')}`);
     if (extra.length) console.error(`  Extra in shards: ${extra.join(', ')}`);
     if (duplicates.length) console.error(`  Duplicate shard entries: ${duplicates.join(', ')}`);


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=e21a96567a3fff62cf9c71befc3f0a7db15ab9c5; job=playwright / terminal-garbling -->

The shard inventory repro now treats manual-only Playwright specs as a separate drift class.

This keeps manual-only specs out of the generic extra-file bucket and reports when they are assigned to CI shards.

CI job `playwright / terminal-garbling` first failed on default-branch push commit e21a96567a3fff62cf9c71befc3f0a7db15ab9c5 in run 30771302330.

It was most recently still red at f84c1edddd8a844b88c7b89f60731700db0651a4 in run 31289002425.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30771302330/job/91560715660

## Review Claim

The repro inventory check now fails with the precise manual-only shard assignment that caused this CI regression.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the CI repro inventory script changes, so product behavior and shipped runtime paths stay unchanged.

## Slice Rationale

This slice isolates the regression detection repair from the verification-only slice that records the passing CI command.

## Non-goals

This does not change Playwright tests, shard definitions, product code, or CI job selection.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-terminal-garbling' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/planning-terminal-live-model.proof.spec.ts e2e/planning-surface-navigation-garble-repro.spec.ts e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts e2e/planning-terminal-expand-collapse-garble-repro.spec.ts e2e/task-terminal-drawer-minimize-garble-repro.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ci-regression-e21a965-pr1.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7407f43a25fd87d086db456ea957c5a1f167e9f5`
- Post-revert steps: Re-run the terminal-garbling Playwright shard command.
- Data migration? No

</details>
