### PR TITLE
Require fresh evidence for status claims and matching assertions for proof

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 - Every step in a plan MUST be testable. Each implementation step must have a corresponding verification with a concrete, executable command that produces a clear pass/fail exit code (e.g. `pnpm test`, `git diff --name-only`). Do not use AI prompts for test tasks — use commands only.
 - Bug fix plans MUST follow a three-phase approach before any implementation:
   1. **Reproduce** -- Find or write a concrete reproduction case (a failing test or a command that demonstrates the bug). Report back the exact repro steps and observed vs. expected behavior. Do not proceed until the bug is reliably reproducible.
-  2. **Debug and report** -- Investigate and report: (a) the root cause — why the code is in the buggy state, and (b) the test gap — how the bug escaped existing tests (missing coverage, wrong assumptions, untested edge case, etc.).
+  2. **Debug and report** -- Investigate and report: (a) the root cause — why the code is in the buggy state, and (b) the test gap — how the bug escaped existing tests (missing coverage, wrong assumptions, untested edge case, etc.). For a UI or runtime behavior bug, instrument or trace the actual failing behavior first (logging, a MutationObserver, a debugger, a targeted repro) before proposing a fix hypothesis. Do not propose a root cause by pattern-matching to a bug that looks similar; a hypothesis that was not directly observed is a guess and must be stated as one until it is.
   3. **Plan the fix** -- Only after completing steps 1 and 2, create the implementation plan. The plan must include a verification step that re-runs the reproduction case to confirm the fix.
 
 ## Landing PR Stacks

--- a/skills/invoker-ops/SKILL.md
+++ b/skills/invoker-ops/SKILL.md
@@ -94,3 +94,7 @@ After submitting, verify with query commands, not database reads.
 Do not invent SQL as the fallback.
 
 Report the missing command surface and add/fix the command if the user asked for a durable production-safe path.
+
+## State claims must be fresh
+
+Never report a workflow/task count, CI status, merge status, or "it's running"/"it's fixed"/"autofix kicked in" from memory of an earlier check in this conversation. Run the query command again in the same turn and report what it actually returns now. State drifts between when you last checked and when you answer — a count from five minutes ago is not current state. See `skills/prove-it/SKILL.md`.

--- a/skills/review-compression/SKILL.md
+++ b/skills/review-compression/SKILL.md
@@ -66,6 +66,12 @@ require user confirmation.
   decomposition) deletes the old path in the SAME slice as the move — see
   Rehome / Relocation Refactors.
 
+## Proof Must Match the Claim
+
+A `proof` slice (repro, regression test, benchmark) exists to demonstrate one specific claim. Before writing it, name the exact property the bug report or Review Claim describes, then check the assertion tests that literal property — not a nearby signal that is easier to check but proves a different thing. "The panel stayed visible" is not evidence for "the camera did not move"; "the request returned 200" is not evidence for "the record was written correctly." A proxy assertion can pass while the real behavior described in the claim is still broken, which lets a broken fix ship as proven.
+
+When authoring or reviewing a `proof` slice, ask: if I only read this assertion's name and expect, would I know it tests the same thing the Review Claim states? If not, rewrite the assertion against the literal property, even if that property is harder to check. See `skills/prove-it/SKILL.md` for the same rule applied to PR bodies and live system claims, not just tests.
+
 ## Boundary Rules
 
 Split across architectural boundaries unless the downstream edit is required to


### PR DESCRIPTION
## Summary

We kept claiming a fix, a merge, or a live count was true without actually checking it.

One example: a "fixed" PR claim whose own proof video still showed the bug, because nobody watched it before writing the claim.

This adds three prose rules for that pattern. Proof-lane tests must assert the exact property a bug names, not an easier stand-in signal.

Operator status reports must come from a fresh query in the same turn, not memory of an earlier check.

UI and runtime bug fixes must be instrumented and observed before a root cause is proposed, not guessed by resemblance to a past bug.

## Review Claim

Add three evidence-focused prose rules — to `skills/review-compression/SKILL.md`, `skills/invoker-ops/SKILL.md`, and `CLAUDE.md` — no code changes.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Pure prose additions to three markdown files. No script, validator, or command behavior changes; nothing here can break an existing check.

## Slice Rationale

Kept apart from the mechanical enforcement gate in the next stacked slice: these three files classify under one Review Unit while the gate, its skill wiring, and its tests classify under another, and CI does not allow two Review Units in one PR. The next slice's tests reference the exact strings added here, so this slice must land first.

## Non-goals

- No validator or script changes — the mechanical `Manually inspected:` gate is the next slice.
- No `skills/prove-it/SKILL.md` yet — referenced here by name but created in the next slice, where its own Review Unit lives.
- `CLAUDE.md` is not a `skills/**/SKILL.md` file, so no dedicated contract test is required for it here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-plan-to-invoker-skill.sh` — passes; the CLAUDE.md edit does not touch any string that script locks.
- [x] `grep -n "Proof Must Match the Claim" skills/review-compression/SKILL.md` and `grep -n "State claims must be fresh" skills/invoker-ops/SKILL.md` — both present on disk.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
