### PR TITLE
Classify skills/prove-it/SKILL.md as tooling-policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 - Every step in a plan MUST be testable. Each implementation step must have a corresponding verification with a concrete, executable command that produces a clear pass/fail exit code (e.g. `pnpm test`, `git diff --name-only`). Do not use AI prompts for test tasks — use commands only.
 - Bug fix plans MUST follow a three-phase approach before any implementation:
   1. **Reproduce** -- Find or write a concrete reproduction case (a failing test or a command that demonstrates the bug). Report back the exact repro steps and observed vs. expected behavior. Do not proceed until the bug is reliably reproducible.
-  2. **Debug and report** -- Investigate and report: (a) the root cause — why the code is in the buggy state, and (b) the test gap — how the bug escaped existing tests (missing coverage, wrong assumptions, untested edge case, etc.).
+  2. **Debug and report** -- Investigate and report: (a) the root cause — why the code is in the buggy state, and (b) the test gap — how the bug escaped existing tests (missing coverage, wrong assumptions, untested edge case, etc.). For a UI or runtime behavior bug, instrument or trace the actual failing behavior first (logging, a MutationObserver, a debugger, a targeted repro) before proposing a fix hypothesis. Do not propose a root cause by pattern-matching to a bug that looks similar; a hypothesis that was not directly observed is a guess and must be stated as one until it is.
   3. **Plan the fix** -- Only after completing steps 1 and 2, create the implementation plan. The plan must include a verification step that re-runs the reproduction case to confirm the fix.
 
 ## Landing PR Stacks

--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -282,6 +282,7 @@ export function classifyReviewUnitsForPath(filePath) {
     || path === 'skills/plan-to-invoker/SKILL.md'
     || path === 'skills/land-stack/SKILL.md'
     || path === 'skills/visual-proof/SKILL.md'
+    || path === 'skills/prove-it/SKILL.md'
   ) return ['tooling-policy'];
   if (path.startsWith('docs/') || path.startsWith('skills/') || path.endsWith('.md')) return ['docs'];
   if (path.startsWith('.github/')) return ['tooling-policy'];

--- a/scripts/test-review-unit-classification.mjs
+++ b/scripts/test-review-unit-classification.mjs
@@ -39,6 +39,7 @@ const stillToolingPolicy = [
   'skills/plan-to-invoker/SKILL.md',
   'skills/land-stack/SKILL.md',
   'skills/visual-proof/SKILL.md',
+  'skills/prove-it/SKILL.md',
 ];
 for (const path of stillToolingPolicy) {
   assert.deepEqual(

--- a/skills/invoker-ops/SKILL.md
+++ b/skills/invoker-ops/SKILL.md
@@ -94,3 +94,7 @@ After submitting, verify with query commands, not database reads.
 Do not invent SQL as the fallback.
 
 Report the missing command surface and add/fix the command if the user asked for a durable production-safe path.
+
+## State claims must be fresh
+
+Never report a workflow/task count, CI status, merge status, or "it's running"/"it's fixed"/"autofix kicked in" from memory of an earlier check in this conversation. Run the query command again in the same turn and report what it actually returns now. State drifts between when you last checked and when you answer — a count from five minutes ago is not current state. See `skills/prove-it/SKILL.md`.

--- a/skills/review-compression/SKILL.md
+++ b/skills/review-compression/SKILL.md
@@ -66,6 +66,12 @@ require user confirmation.
   decomposition) deletes the old path in the SAME slice as the move — see
   Rehome / Relocation Refactors.
 
+## Proof Must Match the Claim
+
+A `proof` slice (repro, regression test, benchmark) exists to demonstrate one specific claim. Before writing it, name the exact property the bug report or Review Claim describes, then check the assertion tests that literal property — not a nearby signal that is easier to check but proves a different thing. "The panel stayed visible" is not evidence for "the camera did not move"; "the request returned 200" is not evidence for "the record was written correctly." A proxy assertion can pass while the real behavior described in the claim is still broken, which lets a broken fix ship as proven.
+
+When authoring or reviewing a `proof` slice, ask: if I only read this assertion's name and expect, would I know it tests the same thing the Review Claim states? If not, rewrite the assertion against the literal property, even if that property is harder to check. See `skills/prove-it/SKILL.md` for the same rule applied to PR bodies and live system claims, not just tests.
+
 ## Boundary Rules
 
 Split across architectural boundaries unless the downstream edit is required to


### PR DESCRIPTION
## Summary

The next slice adds a new skill file that several other skills will point to.

Its Review Unit classification lands here first, one slice early, so the next slice's own PR body checks against a base that already knows the new path.

## Review Claim

Add `skills/prove-it` to the hardcoded set of tooling-policy paths in `classifyReviewUnitsForPath`, matching its siblings `make-pr`, `plan-to-invoker`, `land-stack`, and `visual-proof`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

A one-line addition to an existing conditional's list of literal path strings. The new path does not exist yet, so this changes classification for a file nobody has created, with no effect on any current PR.

## Slice Rationale

Kept apart from the file it classifies: a PR body is checked against its base branch's own copy of the classifier, so adding the rule and the file in the same slice would have the file's own PR checked by a classifier that does not yet know it — landing the rule one slice early avoids that.

## Non-goals

- Does not create `skills/prove-it/SKILL.md` — that is the next slice.
- Does not change any other path's classification.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-review-unit-classification.mjs` — passes with the new path added to the tooling-policy fixture list.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
