### PR TITLE
Add a mechanical gate requiring proof of manual inspection in PR bodies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 - Every step in a plan MUST be testable. Each implementation step must have a corresponding verification with a concrete, executable command that produces a clear pass/fail exit code (e.g. `pnpm test`, `git diff --name-only`). Do not use AI prompts for test tasks — use commands only.
 - Bug fix plans MUST follow a three-phase approach before any implementation:
   1. **Reproduce** -- Find or write a concrete reproduction case (a failing test or a command that demonstrates the bug). Report back the exact repro steps and observed vs. expected behavior. Do not proceed until the bug is reliably reproducible.
-  2. **Debug and report** -- Investigate and report: (a) the root cause — why the code is in the buggy state, and (b) the test gap — how the bug escaped existing tests (missing coverage, wrong assumptions, untested edge case, etc.).
+  2. **Debug and report** -- Investigate and report: (a) the root cause — why the code is in the buggy state, and (b) the test gap — how the bug escaped existing tests (missing coverage, wrong assumptions, untested edge case, etc.). For a UI or runtime behavior bug, instrument or trace the actual failing behavior first (logging, a MutationObserver, a debugger, a targeted repro) before proposing a fix hypothesis. Do not propose a root cause by pattern-matching to a bug that looks similar; a hypothesis that was not directly observed is a guess and must be stated as one until it is.
   3. **Plan the fix** -- Only after completing steps 1 and 2, create the implementation plan. The plan must include a verification step that re-runs the reproduction case to confirm the fix.
 
 ## Landing PR Stacks

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs",
-    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && bash scripts/test-land-stack-skill.sh && bash scripts/test-visual-proof-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-resolve-pr-body-targets.mjs && node scripts/test-pr-diff-atomicity.mjs && node scripts/test-check-added-comments.mjs && node scripts/test-ci-workflow-merge-queue-policy.mjs && node scripts/test-ci-duration-invariant.mjs && node scripts/test-review-unit-classification.mjs && node scripts/test-create-pr-stack-workflow.mjs && bash scripts/workspace-test.sh && bash scripts/test-daily-release-workflow.sh && bash scripts/test-daily-e2e-do-submit.sh",
-    "test:high-resource": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && bash scripts/test-land-stack-skill.sh && bash scripts/test-visual-proof-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-resolve-pr-body-targets.mjs && node scripts/test-create-pr-stack-workflow.mjs && INVOKER_VITEST_HIGH_RESOURCE=1 bash scripts/workspace-test.sh",
+    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && bash scripts/test-land-stack-skill.sh && bash scripts/test-visual-proof-skill.sh && bash scripts/test-prove-it-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-resolve-pr-body-targets.mjs && node scripts/test-pr-diff-atomicity.mjs && node scripts/test-check-added-comments.mjs && node scripts/test-ci-workflow-merge-queue-policy.mjs && node scripts/test-ci-duration-invariant.mjs && node scripts/test-review-unit-classification.mjs && node scripts/test-create-pr-stack-workflow.mjs && bash scripts/workspace-test.sh && bash scripts/test-daily-release-workflow.sh && bash scripts/test-daily-e2e-do-submit.sh",
+    "test:high-resource": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && bash scripts/test-land-stack-skill.sh && bash scripts/test-visual-proof-skill.sh && bash scripts/test-prove-it-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-resolve-pr-body-targets.mjs && node scripts/test-create-pr-stack-workflow.mjs && INVOKER_VITEST_HIGH_RESOURCE=1 bash scripts/workspace-test.sh",
     "test:low-resource": "pnpm run test",
     "test:low-resource:packages": "bash scripts/workspace-test.sh",
     "test:guarded": "bash scripts/run-with-resource-guard.sh bash scripts/workspace-test.sh",
@@ -14,6 +14,7 @@
     "test:make-pr-skill": "bash scripts/test-make-pr-skill.sh",
     "test:land-stack-skill": "bash scripts/test-land-stack-skill.sh",
     "test:visual-proof-skill": "bash scripts/test-visual-proof-skill.sh",
+    "test:prove-it-skill": "bash scripts/test-prove-it-skill.sh",
     "test:pr-body-rollout": "node scripts/test-pr-body-rollout.mjs",
     "test:resolve-pr-body-targets": "node scripts/test-resolve-pr-body-targets.mjs",
     "test:create-pr-e2e": "node scripts/test-create-pr-stack-workflow.mjs",

--- a/scripts/pr-body-template.md
+++ b/scripts/pr-body-template.md
@@ -64,6 +64,8 @@ graph TD
 
 Required when the diff changes UI-impacting files. Include before/after screenshots or a video link.
 
+Manually inspected: state exactly what you saw when you opened the image or video yourself, not just that it was captured.
+
 ## Revert Plan
 
 <details>

--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -282,6 +282,7 @@ export function classifyReviewUnitsForPath(filePath) {
     || path === 'skills/plan-to-invoker/SKILL.md'
     || path === 'skills/land-stack/SKILL.md'
     || path === 'skills/visual-proof/SKILL.md'
+    || path === 'skills/prove-it/SKILL.md'
   ) return ['tooling-policy'];
   if (path.startsWith('docs/') || path.startsWith('skills/') || path.endsWith('.md')) return ['docs'];
   if (path.startsWith('.github/')) return ['tooling-policy'];

--- a/scripts/test-invoker-ops-skill.sh
+++ b/scripts/test-invoker-ops-skill.sh
@@ -38,4 +38,8 @@ must_contain "$README" "invoker-ops" "README must mention the operator skill"
 
 bash "$RETRY_SCRIPT" --self-test
 
+must_contain "$SKILL_MD" "Never report a workflow/task count, CI status, merge status" "skill must forbid reporting stale status from memory"
+must_contain "$SKILL_MD" "Run the query command again in the same turn" "skill must require a fresh query before reporting state"
+must_contain "$SKILL_MD" "skills/prove-it/SKILL.md" "skill must reference the shared prove-it evidence rule"
+
 echo "OK: invoker-ops skill contract checks passed"

--- a/scripts/test-land-stack-skill.sh
+++ b/scripts/test-land-stack-skill.sh
@@ -52,4 +52,11 @@ must_appear_before "before any write" \
   "node scripts/land-stack.mjs <bottom-pr> ... --execute" \
   "land-stack must require the guard before its landing command"
 
+must_contain "re-run the exact \`gh pr view\`/queue query in that same turn" \
+  "land-stack must require a fresh status query before reporting PR state"
+must_contain "\"Merging\" is not \"merged\"" \
+  "land-stack must distinguish an in-progress merge from a completed one"
+must_contain "skills/prove-it/SKILL.md" \
+  "land-stack must reference the shared prove-it evidence rule"
+
 echo "OK: land-stack skill contract checks passed"

--- a/scripts/test-make-pr-skill.sh
+++ b/scripts/test-make-pr-skill.sh
@@ -161,4 +161,16 @@ must_contain "$SKILL_MD" "After any branch update, rebase, force-push, or stacke
 must_contain "$SKILL_MD" "ensure the PR title still matches the current slice after any branch update or force-push" "make-pr skill validation checklist must include the PR-title staleness check"
 must_contain "$SKILL_MD" 'ensure the `## Summary` section still describes the current diff, not the earlier version' "make-pr skill validation checklist must include the Summary staleness check"
 
+# Visual proof claims must be backed by actually looking at the media, not just
+# capturing it. Locks the prove-it hard gate wiring.
+must_contain "$SKILL_MD" "actually open that exact media yourself" "make-pr skill must require actually opening visual proof media before claiming it"
+must_contain "$SKILL_MD" "Do not trust an automated DOM/test assertion as a substitute for looking" "make-pr skill must reject automated assertions as a substitute for looking at proof"
+must_contain "$SKILL_MD" 'rejects a Visual Proof section that has media but no `Manually inspected:` line' "make-pr skill must document the Manually inspected validator gate"
+must_contain "$SKILL_MD" "skills/prove-it/SKILL.md" "make-pr skill must reference the shared prove-it evidence rule"
+must_contain "$SKILL_MD" "Manually inspected: state exactly what you saw when you opened the image or video yourself" "make-pr skill schema must include the Manually inspected template line"
+
+# Proof-lane assertions must test the exact claim, not an easier proxy signal.
+must_contain "$REVIEW_COMPRESSION_MD" "## Proof Must Match the Claim" "review-compression must keep the proof-must-match-the-claim section heading"
+must_contain "$REVIEW_COMPRESSION_MD" "A proxy assertion can pass while the real behavior described in the claim is still broken" "review-compression must explain why a proxy assertion is unsafe"
+
 echo "OK: make-pr skill contract checks passed"

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -329,6 +329,8 @@ const restartAnimatedProofErrors = await validatePrBody(`${validMinimal}
 Animated restart proof showing the drafted chat, app relaunch, and restored chat.
 
 ![Restart walkthrough](proof-restart.gif)
+
+Manually inspected: watched proof-restart.gif frame by frame and confirmed the drafted chat survives the relaunch.
 `, { requiresVisualProof: true });
 assert(
   restartAnimatedProofErrors.length === 0,
@@ -768,10 +770,12 @@ const validVisualProof = `${validMinimal}
 Restored chat with the draft-ready bar visible.
 
 ![restored chat](restored-chat.png)
+
+Manually inspected: opened restored-chat.png and confirmed the draft-ready bar renders above the input box.
 `;
 assert(
   (await validatePrBody(validVisualProof, { requiresVisualProof: true })).length === 0,
-  'single-state screenshot proof should satisfy UI proof requirement',
+  'single-state screenshot proof with a Manually inspected line should satisfy UI proof requirement',
 );
 
 const warningOnlyVisualProofErrors = await validatePrBody(`${validMinimal}
@@ -783,6 +787,34 @@ const warningOnlyVisualProofErrors = await validatePrBody(`${validMinimal}
 assert(
   warningOnlyVisualProofErrors.some((error) => error.includes('UI-impacting changes require a ## Visual Proof section')),
   'warning-only visual proof should not satisfy UI proof requirement',
+);
+
+const missingManualInspectionErrors = await validatePrBody(`${validMinimal}
+
+## Visual Proof
+
+Restored chat with the draft-ready bar visible.
+
+![restored chat](restored-chat.png)
+`, { requiresVisualProof: true });
+assert(
+  missingManualInspectionErrors.some((error) => error.includes('"Manually inspected:" line')),
+  'screenshot proof without a Manually inspected line should fail validation',
+);
+
+const manualInspectionCaseInsensitiveBody = `${validMinimal}
+
+## Visual Proof
+
+Restored chat with the draft-ready bar visible.
+
+![restored chat](restored-chat.png)
+
+**MANUALLY INSPECTED:** opened restored-chat.png and confirmed the draft-ready bar renders above the input box.
+`;
+assert(
+  (await validatePrBody(manualInspectionCaseInsensitiveBody, { requiresVisualProof: true })).length === 0,
+  'Manually inspected line should match case-insensitively and inside bold markdown',
 );
 
 const prAuthoringPolicyErrors = await validatePrBody(validMinimal.replace('- behavior', '- policy').replace('- routing', '- tooling-policy'), {
@@ -1304,6 +1336,8 @@ const preloadRegressionBody = `${validMinimal}
 The preload script is unaffected.
 
 ![screenshot](proof.png)
+
+Manually inspected: opened proof.png and confirmed the preload-adjacent UI is unchanged.
 `;
 const preloadRegressionErrors = await validatePrBody(preloadRegressionBody, { requiresVisualProof: true });
 assert(

--- a/scripts/test-prove-it-skill.sh
+++ b/scripts/test-prove-it-skill.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Contract tests for the prove-it skill.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL_MD="$REPO_ROOT/skills/prove-it/SKILL.md"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+must_contain() {
+  local needle="$1"
+  local hint="$2"
+  grep -qF -- "$needle" "$SKILL_MD" || fail "$hint — missing: $needle"
+}
+
+[[ -f "$SKILL_MD" ]] || fail "expected $SKILL_MD"
+
+must_contain "do not assert something is fixed, working, passing, merged, or running" \
+  "prove-it skill must state the core no-unverified-claim rule in its description"
+must_contain "actually opened the exact screenshot or video yourself" \
+  "prove-it skill must require actually opening visual proof media before claiming it"
+must_contain "An automated DOM assertion, a test passing, or a file existing at the expected path is not a substitute for looking" \
+  "prove-it skill must reject automated signals as a substitute for looking"
+must_contain "run the exact query command fresh in this turn and cite its real output" \
+  "prove-it skill must require a fresh query for live-system claims"
+must_contain "Never restate a count or status from earlier in the conversation as if it were still current" \
+  "prove-it skill must forbid restating stale status as current"
+must_contain "A hypothesis that has not been directly observed is a guess" \
+  "prove-it skill must require root-cause claims to be directly observed, not guessed"
+must_contain "write \`UNVERIFIED:\` immediately before the claim" \
+  "prove-it skill must require the UNVERIFIED prefix when evidence is missing"
+must_contain "rejects a \`## Visual Proof\` section that has" \
+  "prove-it skill must document the mechanical validate-pr-body.mjs gate"
+
+echo "OK: prove-it skill contract checks passed"

--- a/scripts/test-review-unit-classification.mjs
+++ b/scripts/test-review-unit-classification.mjs
@@ -39,6 +39,7 @@ const stillToolingPolicy = [
   'skills/plan-to-invoker/SKILL.md',
   'skills/land-stack/SKILL.md',
   'skills/visual-proof/SKILL.md',
+  'skills/prove-it/SKILL.md',
 ];
 for (const path of stillToolingPolicy) {
   assert.deepEqual(

--- a/scripts/test-visual-proof-skill.sh
+++ b/scripts/test-visual-proof-skill.sh
@@ -31,4 +31,14 @@ must_contain "Capture whatever partial signal actually IS visible" \
 must_contain "substitute an image that doesn't actually demonstrate the claim" \
   "visual-proof skill must forbid substituting an unrelated image for an uncapturable claim"
 
+# A captured file is not proof anyone looked at it. Locks the prove-it hard gate wiring.
+must_contain "A captured screenshot or video file is not proof that anyone looked at it" \
+  "visual-proof skill must state that capture alone is not proof"
+must_contain "open the exact file yourself" \
+  "visual-proof skill must require opening the exact captured media before claiming it"
+must_contain "rejects a Visual Proof section that has media but no \`Manually inspected:\` line" \
+  "visual-proof skill must document the Manually inspected validator gate"
+must_contain "skills/prove-it/SKILL.md" \
+  "visual-proof skill must reference the shared prove-it evidence rule"
+
 echo "OK: visual-proof skill contract checks passed"

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -173,6 +173,13 @@ function hasAnimatedVisualProofMedia(body) {
     || /\bhttps?:\/\/\S+\.(?:gif|webm|mp4)\b/i.test(visualProof);
 }
 
+function hasManualInspectionNote(body) {
+  const visualProof = getVisualProofBody(body);
+  if (!visualProof) return false;
+
+  return /\bmanually inspected\s*:/i.test(visualProof);
+}
+
 export function visualProofNeedsAnimation(body) {
   const visualProof = getVisualProofBody(body);
   if (!visualProof) return false;
@@ -470,6 +477,10 @@ export async function validatePrBody(body, options = {}) {
   } else if (options.requiresVisualProof && visualProofNeedsAnimation(trimmed) && !hasAnimatedVisualProofMedia(trimmed)) {
     errors.push(
       'Restart or multi-state visual proof must include animated media such as a gif, webm, mp4, or walkthrough/video link.',
+    );
+  } else if (options.requiresVisualProof && !hasManualInspectionNote(trimmed)) {
+    errors.push(
+      'UI-impacting changes require a "Manually inspected:" line in ## Visual Proof stating exactly what you personally saw when you opened the screenshot or video yourself — a captured file is not proof that anyone looked at it. See skills/prove-it/SKILL.md.',
     );
   }
 

--- a/skills/invoker-ops/SKILL.md
+++ b/skills/invoker-ops/SKILL.md
@@ -94,3 +94,7 @@ After submitting, verify with query commands, not database reads.
 Do not invent SQL as the fallback.
 
 Report the missing command surface and add/fix the command if the user asked for a durable production-safe path.
+
+## State claims must be fresh
+
+Never report a workflow/task count, CI status, merge status, or "it's running"/"it's fixed"/"autofix kicked in" from memory of an earlier check in this conversation. Run the query command again in the same turn and report what it actually returns now. State drifts between when you last checked and when you answer — a count from five minutes ago is not current state. See `skills/prove-it/SKILL.md`.

--- a/skills/land-stack/SKILL.md
+++ b/skills/land-stack/SKILL.md
@@ -78,6 +78,10 @@ before any write (label, thread-resolve, queue, merge).
   to defer those findings; record the deferral on the PR.
 - Do not act on a PR whose head SHA is not in your local clone.
 
+## Prove state before reporting it
+
+Before telling the user a PR is merged, queued, blocked, or failing CI, re-run the exact `gh pr view`/queue query in that same turn — do not repeat a status you checked earlier in the conversation. "Merging" is not "merged"; a queued PR can still fail the re-run suite. See `skills/prove-it/SKILL.md`.
+
 ## Why this exists
 
 A raw workflow-branch PR (#505) shared a branch name with the intended stack

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -126,6 +126,8 @@ graph TD
 
 Required when the diff changes UI-impacting files. Include before/after screenshots or a video link.
 
+Manually inspected: state exactly what you saw when you opened the image or video yourself, not just that it was captured.
+
 ## Revert Plan
 
 <details>
@@ -150,6 +152,8 @@ Test Plan and Revert Plan are the opposite: keep their `## Test Plan` / `## Reve
 CI validates the declared Review Lane and Review Unit against the actual changed files. Keep `behavior`, `refactor`, and `cleanup` slices separate from docs, policy, and proof files. Keep `proof` separate from product, docs, and policy files. Keep `policy` separate from product and proof files. Keep `docs` separate from product, policy, proof, and product-test files. The exact classification and review-unit boundaries live in `scripts/validate-pr-body.mjs` and `scripts/review-unit-rules.mjs`; split the PR when the local validator reports a mismatch.
 
 When an existing PR changes after its body or proof was written, rerun this skill from the current diff before updating the PR. If the new diff touches UI-impacting files, rerun `skills/visual-proof/SKILL.md` and replace old screenshot or video links with fresh proof for the current code. Do not reuse earlier proof media after UI behavior changes.
+Before writing any "Fixed"/"resolves"/"no longer happens" claim backed by a screenshot or video, actually open that exact media yourself — Read the image, or extract and Read video frames — in the same turn you write the claim. Do not trust an automated DOM/test assertion as a substitute for looking; a test passing proves the test's assertion, not that you looked at what the media shows. State precisely what you saw on a `Manually inspected:` line inside `## Visual Proof`. `scripts/validate-pr-body.mjs` rejects a Visual Proof section that has media but no `Manually inspected:` line. See `skills/prove-it/SKILL.md` for the full rule, including the same standard applied to live-system status claims.
+
 Visual proof must show the changed behavior itself, not just the changed screen area. Before creating or updating the PR, open every screenshot or video and verify the user-visible target is present and identifiable. For conditional or event-driven UI, drive the exact condition that triggers the new state and capture that state. A generic task panel, unchanged sidebar, unrelated graph, or stale screenshot is not proof, even when the right file changed.
 
 If the changed behavior spans multiple states or a state transition — for example restart persistence, before/after workflow transitions, progress animations, opening then dismissing overlays, or any proof labeled “before” and “after” — use animated proof. A gif, mp4, webm, or walkthrough video is required; static screenshots alone are not enough.

--- a/skills/prove-it/SKILL.md
+++ b/skills/prove-it/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: prove-it
+description: >
+  Shared evidence rule for every claim about code, UI, or live Invoker state:
+  do not assert something is fixed, working, passing, merged, or running
+  unless you personally observed it this turn and can show what you saw.
+---
+
+# prove-it
+
+Referenced by `make-pr`, `visual-proof`, `land-stack`, and `invoker-ops`. One rule, kept in one place, so it cannot drift out of sync across skills.
+
+## Why this exists
+
+Claiming something is fixed, working, or merged without actually checking it live is a recurring failure mode in this project: a "fixed" PR claim that turned out to still show the bug in its own proof video, visual proof screenshots reused from a stale build, and status reports ("it's merged," "N tasks are running," "autofix kicked in") repeated from memory instead of a fresh query. In every case a cheaper, easier-to-check signal stood in for the thing that was actually asked about, and nobody looked at the real evidence before stating the claim as settled.
+
+## The rule
+
+Before writing any claim of the form "this is fixed," "this now works," "this shows X," "this is merged," "N tasks are running," or similar — in a PR body, a chat reply, or a status report — you must have, in the SAME turn:
+
+1. **For a visual/UI claim:** actually opened the exact screenshot or video yourself (`Read` the image, or extract and `Read` video frames) and can state precisely what you saw. An automated DOM assertion, a test passing, or a file existing at the expected path is not a substitute for looking. Never trust a proxy signal ("the panel is visible") as evidence for a different claim ("the camera did not move") — check the literal thing that was reported broken.
+2. **For a live-system claim** (CI status, merge status, task/workflow counts, "it's running," "it's fixed," "autofix kicked in"): run the exact query command fresh in this turn and cite its real output. Never restate a count or status from earlier in the conversation as if it were still current — state drifts while you work.
+3. **For a "root cause" claim:** you instrumented or traced the actual failing behavior (logging, a MutationObserver, a debugger, a repro script) rather than pattern-matching to a bug that looked similar. A hypothesis that has not been directly observed is a guess, and must be stated as one.
+
+If you have not done one of the above, either do it now or write `UNVERIFIED:` immediately before the claim — never state it as settled fact.
+
+## Where this is enforced mechanically
+
+- `scripts/validate-pr-body.mjs` rejects a `## Visual Proof` section that has media but no `Manually inspected:` line describing what was actually seen.
+- Everything else on this page is a discipline, not a mechanical gate. Treat the gate as the floor, not the ceiling — the rest still applies even where nothing will stop you from skipping it.

--- a/skills/review-compression/SKILL.md
+++ b/skills/review-compression/SKILL.md
@@ -66,6 +66,12 @@ require user confirmation.
   decomposition) deletes the old path in the SAME slice as the move — see
   Rehome / Relocation Refactors.
 
+## Proof Must Match the Claim
+
+A `proof` slice (repro, regression test, benchmark) exists to demonstrate one specific claim. Before writing it, name the exact property the bug report or Review Claim describes, then check the assertion tests that literal property — not a nearby signal that is easier to check but proves a different thing. "The panel stayed visible" is not evidence for "the camera did not move"; "the request returned 200" is not evidence for "the record was written correctly." A proxy assertion can pass while the real behavior described in the claim is still broken, which lets a broken fix ship as proven.
+
+When authoring or reviewing a `proof` slice, ask: if I only read this assertion's name and expect, would I know it tests the same thing the Review Claim states? If not, rewrite the assertion against the literal property, even if that property is harder to check. See `skills/prove-it/SKILL.md` for the same rule applied to PR bodies and live system claims, not just tests.
+
 ## Boundary Rules
 
 Split across architectural boundaries unless the downstream edit is required to

--- a/skills/visual-proof/SKILL.md
+++ b/skills/visual-proof/SKILL.md
@@ -34,6 +34,10 @@ animation's motion in a single still frame, a race that only exists for millisec
    concrete non-visual proof instead (a DOM/class assertion, a grep check, a test name) — never
    substitute an image that doesn't actually demonstrate the claim.
 
+## Actually look before you claim
+
+A captured screenshot or video file is not proof that anyone looked at it. Before writing any claim about what the media shows — "fixed," "no longer happens," "stays in place" — open the exact file yourself: `Read` the image, or extract frames from a video (`ffmpeg -vf fps=4 ...`) and `Read` those. State precisely what you saw on a `Manually inspected:` line inside `## Visual Proof`. `scripts/validate-pr-body.mjs` rejects a Visual Proof section that has media but no `Manually inspected:` line. See `skills/prove-it/SKILL.md`.
+
 ## Subcommands
 
 The script `scripts/ui-visual-proof.sh` provides four explicit subcommands:


### PR DESCRIPTION
## Summary

A captured screenshot or video was never proof that anyone opened it and looked.

CI now checks for that directly: a `## Visual Proof` section with media but no `Manually inspected:` line describing what was actually seen now fails the check.

This adds one shared page, `skills/prove-it`, stating the rule once. `make-pr`, `visual-proof`, and `land-stack` each get a short pointer to it plus the one instruction specific to that skill — a fresh status query for `land-stack`, actually opening media for the other two.

## Review Claim

The PR-body checker now requires a `Manually inspected:` line in `## Visual Proof` whenever visual proof media is present; `skills/prove-it` is the one shared statement of the rule, referenced from three other skills.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The new check only fires when `requiresVisualProof` is already true and only adds a third `else if` branch after the two existing checks, so a body that already fails for missing media or missing animation still reports that error first — nothing about the existing two checks changes. Every skill instruction added here has a matching `must_contain` assertion in its own contract test script, so removing the instruction text fails CI.

## Slice Rationale

Kept apart from the two prior slices: the prose-only rules classify under a different Review Unit than this one, and CI does not allow mixing two Review Units in one PR. Stacked on the classification-only slice so this slice's own PR body is checked against a base that already recognizes the new file's path. This slice's tests also reference exact strings added in the first slice, so it lands third.

## Non-goals

- Does not change the existing missing-media or missing-animation checks — only adds a third condition after both pass.
- Does not touch `packages/**` product code.
- Does not add the rule to every skill in the repo — scoped to the four skills where this exact failure pattern was observed (`make-pr`, `visual-proof`, `land-stack`, `invoker-ops`).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-validator.mjs` — passes, including new cases for a missing `Manually inspected:` line (fails), a present one (passes), and a bold-markdown/case-insensitive variant (passes).
- [x] `bash scripts/test-make-pr-skill.sh` — passes.
- [x] `bash scripts/test-visual-proof-skill.sh` — passes.
- [x] `bash scripts/test-land-stack-skill.sh` — passes.
- [x] `bash scripts/test-invoker-ops-skill.sh` — passes.
- [x] `bash scripts/test-prove-it-skill.sh` — passes.
- [x] `node scripts/test-review-unit-classification.mjs` — passes with `skills/prove-it/SKILL.md` added to the tooling-policy fixture list.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
