### PR TITLE
Fix create-pr.mjs treating an open helper-base PR as stale

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -692,7 +692,9 @@ function assertOpenHelperBasePr(nwo, baseBranch, dryRun) {
   }
 
   const [pr] = prs;
-  if (pr.state === 'OPEN') return;
+  // gh api (REST) reports state as lowercase "open"/"closed", unlike gh pr
+  // view's GraphQL-backed "OPEN"/"CLOSED" — normalize before comparing.
+  if (String(pr.state || '').toUpperCase() === 'OPEN') return;
 
   const helperState = pr.merged_at ? 'merged helper PR' : 'closed helper PR';
   throw new Error(

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -478,6 +478,53 @@ function testDuplicateHelperBasePrsRejectPublication() {
   }
 }
 
+function testOpenHelperBaseWithRestApiLowercaseStateAllowsPublication() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    gitQuiet(work, 'branch', 'pr/previous', 'origin/master');
+    gitQuiet(work, 'push', 'origin', 'pr/previous');
+    createTrackedBranch(work, 'feature/on-open-helper', 'origin/pr/previous');
+    commitFile(work, 'feature.txt', 'feature\n', 'feature change');
+
+    // GitHub's REST API (gh api repos/.../pulls) reports state as lowercase
+    // "open"/"closed", unlike gh pr view's GraphQL-backed "OPEN"/"CLOSED".
+    // A genuinely open, single helper-base PR must not be treated as stale.
+    const result = runCreatePr(work, harness, ['--title', '[Test Stack](2) add feature', '--base', 'pr/previous', '--body-file', 'pr-body.md'], {
+      GH_API_PULLS_JSON: JSON.stringify([
+        {
+          number: 86,
+          state: 'open',
+          merged_at: null,
+          html_url: 'https://example.com/pull/86',
+          head: { ref: 'pr/previous', repo: { full_name: 'owner/repo' } },
+        },
+      ]),
+      GH_POST_RESPONSE: JSON.stringify({ number: 90, html_url: 'https://example.com/pull/90' }),
+      GH_API_OPEN_PULLS_JSON: JSON.stringify([
+        {
+          number: 90,
+          title: '[Test Stack](2) add feature',
+          html_url: 'https://example.com/pull/90',
+          base: { ref: 'pr/previous' },
+          head: { ref: 'feature/on-open-helper' },
+        },
+      ]),
+    });
+
+    assert(
+      result.status === 0,
+      `single open helper-base PR (lowercase REST state) should allow publication\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    assert(
+      !result.stderr.includes('belongs to a stale helper PR'),
+      `open helper-base PR must not be reported as stale\nstderr:\n${result.stderr}`,
+    );
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
 
 function testNoFileChangesBlockPrCreation() {
   const harness = createHarness();
@@ -1420,6 +1467,7 @@ const tests = [
   testStaleBaseDetection,
   testStaleMergedHelperBaseRejectsPublication,
   testDuplicateHelperBasePrsRejectPublication,
+  testOpenHelperBaseWithRestApiLowercaseStateAllowsPublication,
   testNoFileChangesBlockPrCreation,
   testEmptyCommitAloneBlocksPrCreation,
   testEmptyCommitMixedWithRealChangeBlocksPrCreation,


### PR DESCRIPTION
## Summary

Publishing a PR whose base is a plain `pr/...` branch checks that branch's own PR is still open before allowing publication.

That check compared the PR's state to the literal string `OPEN`. The real data source returns lowercase `open`, so every genuinely open helper base was treated as if its branch no longer had a live PR, and publication was refused.

Hit this live today: two open PRs (#8134, #8135) both got refused as helper-base leftovers, even though `gh pr view` showed them as open.

## Review Claim

`assertOpenHelperBasePr()` in `scripts/create-pr.mjs` now normalizes the PR state before comparing it, so a genuinely open helper-base PR no longer blocks publication.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change is a single comparison, normalizing case before checking equality. A closed or merged PR still fails the same way it always did — `"closed"` and `"merged"`-adjacent values never equal `"OPEN"` regardless of case, so only the previously-broken "genuinely open" path changes behavior.

## Slice Rationale

Standalone, unrelated to the prove-it evidence-rule stack it surfaced while publishing — this fixes a pre-existing script defect with its own independent Review Claim.

## Non-goals

- Does not change the closed/merged helper-base rejection paths.
- Does not change the duplicate-PR rejection path.
- Does not touch any other `gh api` state comparison in this file (a targeted audit found this to be the only one).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-create-pr-stack-workflow.mjs` — before this change, the new `testOpenHelperBaseWithRestApiLowercaseStateAllowsPublication` case failed with `Error: Refusing to create/update PR: base branch "pr/previous" belongs to a stale helper PR. Found closed helper PR #86`. After this change, it passes, and all other cases (stale, duplicate, merged) still pass unchanged.
- [x] `node scripts/test-create-pr-visual-proof.mjs` — passes, unaffected.
- [x] `node scripts/test-pr-diff-atomicity.mjs` — passes, unaffected.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request state handling so open statuses are recognized regardless of capitalization.
  * Prevented valid open pull requests from being incorrectly rejected during publication.

* **Tests**
  * Added regression coverage for lowercase open-status responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->