### PR TITLE
Add rebase-onto-base git primitives, with real-git tests

### DIFF
--- a/scripts/mergify_admin_requeue_repair_body.py
+++ b/scripts/mergify_admin_requeue_repair_body.py
@@ -59,6 +59,29 @@ def is_ancestor(cwd: Path, ancestor: str, descendant: str) -> bool:
     return completed.returncode == 0
 
 
+def needs_rebase_onto_base(cwd: Path, base_ref: str, head_sha: str) -> bool:
+    git_output(cwd, "fetch", "origin", base_ref)
+    return not is_ancestor(cwd, f"origin/{base_ref}", head_sha)
+
+
+def rebase_onto_base(cwd: Path, base_ref: str, branch: str, expected_head: str) -> str | None:
+    git_output(cwd, "fetch", "origin", base_ref)
+    hard_reset_work_root(cwd, expected_head)
+    completed = subprocess.run(
+        ["git", "rebase", f"origin/{base_ref}"],
+        cwd=str(cwd),
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if completed.returncode != 0:
+        subprocess.run(["git", "rebase", "--abort"], cwd=str(cwd), check=False, text=True, capture_output=True)
+        return None
+    new_head = git_output(cwd, "rev-parse", "HEAD").strip()
+    safe_push(branch=branch, expected_head=expected_head, cwd=cwd)
+    return new_head
+
+
 def normalize_repair_commit(cwd: Path, start_head: str, end_head: str, check_name: str) -> str:
     if is_ancestor(cwd, start_head, end_head):
         return end_head

--- a/scripts/test_mergify_admin_requeue_repair_body.py
+++ b/scripts/test_mergify_admin_requeue_repair_body.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import mergify_admin_requeue_repair_body as repair_body
+from scripts import pr_worker_safe_push as safe_push
+
+REAL_GIT = shutil.which("git") or "git"
+
+
+def git(cwd: Path, *args: str) -> str:
+    completed = subprocess.run(
+        [REAL_GIT, *args],
+        cwd=str(cwd),
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return completed.stdout.strip()
+
+
+class RebaseOntoBaseTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.remote = self.root / "remote.git"
+        self.repo = self.root / "repo"
+        git(self.root, "init", "--bare", str(self.remote))
+        git(self.root, "clone", str(self.remote), str(self.repo))
+        git(self.repo, "config", "user.email", "worker@example.invalid")
+        git(self.repo, "config", "user.name", "Worker Test")
+        git(self.repo, "checkout", "-B", "master")
+        self._write("shared.txt", "shared\n")
+        git(self.repo, "add", "shared.txt")
+        git(self.repo, "commit", "-m", "shared base")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/master")
+
+    def _write(self, name: str, content: str) -> None:
+        (self.repo / name).write_text(content, encoding="utf-8")
+
+    def _commit(self, message: str, filename: str = "shared.txt", content: str = "change\n") -> str:
+        target = self.repo / filename
+        existing = target.read_text(encoding="utf-8") if target.exists() else ""
+        target.write_text(existing + content, encoding="utf-8")
+        git(self.repo, "add", filename)
+        git(self.repo, "commit", "-m", message)
+        return git(self.repo, "rev-parse", "HEAD")
+
+    def test_clean_ancestry_does_not_need_rebase(self) -> None:
+        git(self.repo, "checkout", "-B", "stack/clean", "master")
+        head = self._commit("clean addition", "clean.txt", "clean\n")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/stack/clean")
+
+        self.assertFalse(repair_body.needs_rebase_onto_base(self.repo, "master", head))
+
+    def test_duplicate_pre_squash_commit_needs_rebase(self) -> None:
+        # Mirrors PR #7727's real shape: a branch carries a commit whose content
+        # was already squash-merged into master under a different SHA, so the
+        # branch's own history never became an ancestor of master's tip.
+        git(self.repo, "checkout", "-B", "feature", "master")
+        self._commit("feature work", "feature.txt", "feature\n")
+        git(self.repo, "checkout", "master")
+        git(self.repo, "merge", "--squash", "feature")
+        git(self.repo, "commit", "-m", "squash-merged feature")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/master")
+
+        git(self.repo, "checkout", "-B", "stack/stale", "feature")
+        head = git(self.repo, "rev-parse", "HEAD")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/stack/stale")
+
+        self.assertTrue(repair_body.needs_rebase_onto_base(self.repo, "master", head))
+
+    def test_rebase_onto_base_pushes_clean_rebase(self) -> None:
+        git(self.repo, "checkout", "-B", "feature", "master")
+        self._commit("feature work", "feature.txt", "feature\n")
+        git(self.repo, "checkout", "master")
+        git(self.repo, "merge", "--squash", "feature")
+        git(self.repo, "commit", "-m", "squash-merged feature")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/master")
+
+        git(self.repo, "checkout", "-B", "stack/stale", "feature")
+        self._write("only-new.txt", "only new\n")
+        git(self.repo, "add", "only-new.txt")
+        git(self.repo, "commit", "-m", "genuinely new work")
+        stale_head = git(self.repo, "rev-parse", "HEAD")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/stack/stale")
+
+        new_head = repair_body.rebase_onto_base(self.repo, "master", "stack/stale", stale_head)
+
+        self.assertIsNotNone(new_head)
+        self.assertNotEqual(new_head, stale_head)
+        remote_head = safe_push.remote_branch_sha("stack/stale", remote="origin", cwd=self.repo)
+        self.assertEqual(remote_head, new_head)
+        self.assertFalse(repair_body.needs_rebase_onto_base(self.repo, "master", new_head))
+        # Only the genuinely-new file survives the rebase; the duplicate
+        # pre-squash content is gone because it's already reachable via master.
+        self.assertTrue((self.repo / "only-new.txt").exists())
+
+    def test_real_conflict_aborts_without_pushing(self) -> None:
+        git(self.repo, "checkout", "-B", "stack/conflict", "master")
+        self._commit("conflicting change on branch", "shared.txt", "branch change\n")
+        conflict_head = git(self.repo, "rev-parse", "HEAD")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/stack/conflict")
+
+        git(self.repo, "checkout", "master")
+        self._commit("conflicting change on master", "shared.txt", "master change\n")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/master")
+
+        git(self.repo, "checkout", "stack/conflict")
+        result = repair_body.rebase_onto_base(self.repo, "master", "stack/conflict", conflict_head)
+
+        self.assertIsNone(result)
+        remote_head = safe_push.remote_branch_sha("stack/conflict", remote="origin", cwd=self.repo)
+        self.assertEqual(remote_head, conflict_head)
+        # Working tree must be left clean, not mid-rebase.
+        status = git(self.repo, "status", "--porcelain")
+        self.assertEqual(status, "")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds two small git helpers for the Mergify admin-bypass bot: one checks whether a branch's content is an ancestor-clean rebase of its base, the other performs that rebase and safely force-pushes it.

Neither is called from anywhere yet. This slice is the tested foundation; the next slice wires them into the bot's planning and dispatch.

## Review Claim

Approve `needs_rebase_onto_base` and `rebase_onto_base` as correct, tested git operations, independent of when or how the bot decides to call them.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Both functions are new and have zero callers in this slice, so nothing existing can change behavior. `rebase_onto_base` only ever pushes via the codebase's one existing `safe_push()` force-with-lease primitive, and aborts cleanly (no push) on a real conflict.

## Slice Rationale

Foundation before behavior: these are pure git primitives, testable in isolation against a real scratch git repo, with no dependency on the bot's planning layer. Landing them separately keeps the next slice's diff focused on the actual decision-making change.

## Non-goals

Does not change any bot behavior. Does not add a new bot action kind (that's the next slice).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts/test_mergify_admin_requeue_repair_body.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>