### PR TITLE
[Launch-dispatch enqueued_at timestamp format bug](2) Compare enqueued_at via julianday

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1571,9 +1571,7 @@ describe('SQLiteAdapter', () => {
         expect(raw).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
       });
 
-      // TODO(#julianday-fix): flip to `it` once listAbandonableLaunchDispatchLeases
-      // compares enqueued_at via julianday() instead of a raw string.
-      it.fails('does not abandon a lease enqueued a minute ago just because the ISO cutoff falls on the same calendar day', () => {
+      it('does not abandon a lease enqueued a minute ago just because the ISO cutoff falls on the same calendar day', () => {
         setupWorkflowAndTask();
         const row = adapter.enqueueLaunchDispatch({
           taskId: 'wf-launch/t1',

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3895,7 +3895,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
            AND acknowledged_at IS NULL
            AND (
              attempts_count >= ?
-             OR (? IS NOT NULL AND enqueued_at <= ?)
+             OR (? IS NOT NULL AND julianday(enqueued_at) <= julianday(?))
            )
          ORDER BY id ASC`,
       [now, options.maxAttempts, ageCutoff, ageCutoff],


### PR DESCRIPTION
## Summary

`listAbandonableLaunchDispatchLeases` compared `enqueued_at` against an
age cutoff as raw strings, even though the two sides come from different
timestamp formats.

This slice wraps both sides in `julianday()`, so SQLite parses each side
into a real point in time before comparing. Verified directly against the
`node:sqlite` engine this codebase runs on.

The previous slice's `it.fails` proof now flips to a normal assertion,
since the comparison is correct.

## Review Claim

Approve wrapping the `enqueued_at` comparison in `julianday()` so a fresh
lease is never misread as stale just because its calendar date matches
the cutoff's.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

The change is one `WHERE`-clause comparison inside a single query. It
does not touch how `enqueued_at` is written, and no other comparison in
the codebase uses this column. Full `data-store` suite (466 tests) and
the targeted `app`-package launch-dispatch and retry-storm suites (109
tests) pass unchanged.

## Slice Rationale

Kept separate from the proof slice so the bug demonstration and the
behavior fix review independently, per this repo's proof-before-fix
ordering.

## Non-goals

Does not change `fenced_until` comparisons, which already use a single
consistent format on both sides. Does not add a broader timestamp-format
guard elsewhere in the codebase.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm test`
- [x] `cd packages/app && npx vitest run src/__tests__/launch-dispatcher.test.ts src/__tests__/dispatch-capacity-invariants.test.ts src/__tests__/launch-dispatch-stuck-lease-retry-storm-repro.test.ts src/__tests__/headless-delegation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, mechanically. Reverting restores the timestamp-format bug this stack proves in the prior slice.
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
