### PR TITLE
Add a real-git end-to-end proof for rebase-onto-base

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -12,7 +12,7 @@ try:
     from .mergify_admin_requeue_loader import AdminBypassStackLoader
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Action, Ledger, PrSnapshot, load_mergify_rules
-    from .mergify_admin_requeue_plan import plan_stack_execution
+    from .mergify_admin_requeue_plan import current_bottom_pr, plan_stack_execution
     from .mergify_admin_requeue_repairer import AdminBypassRepairer
     from .mergify_admin_requeue_snapshot import GhClient
     from .mergify_admin_requeue_workflow_fastpath import (
@@ -26,7 +26,7 @@ except ImportError:
     from mergify_admin_requeue_loader import AdminBypassStackLoader
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Action, Ledger, PrSnapshot, load_mergify_rules
-    from mergify_admin_requeue_plan import plan_stack_execution
+    from mergify_admin_requeue_plan import current_bottom_pr, plan_stack_execution
     from mergify_admin_requeue_repairer import AdminBypassRepairer
     from mergify_admin_requeue_snapshot import GhClient
     from mergify_admin_requeue_workflow_fastpath import (
@@ -59,12 +59,40 @@ def print_action(action: Action, pr: PrSnapshot | None, dry_run: bool, as_json: 
     elif action.kind == "retarget_base":
         from_base = pr.base_ref_name if pr else ""
         print(f"{prefix}retarget-base PR #{action.pr_number} from={from_base} to={action.key}")
+    elif action.kind == "rebase_onto_base":
+        print(f"{prefix}rebase-onto-base PR #{action.pr_number} onto={action.key}")
     elif action.kind == "remove_merge_hold":
         print(f"{prefix}remove-merge-hold PR #{action.pr_number}")
     elif action.kind == "resolve_bot_threads":
         print(f"{prefix}resolve-bot-threads PR #{action.pr_number} thread={action.key}")
     elif action.kind == "repair_conflict":
         print(f"{prefix}repair-conflict PR #{action.pr_number} {action.detail}")
+
+
+def compute_stale_base_by_pr(stacks: Sequence, trunk: str, repo: str, gh: GhClient, logger: AdminBypassLogger) -> dict[int, bool]:
+    # Only checked for each stack's current bottom PR (base already == trunk,
+    # otherwise there is nothing to rebase onto yet) -- this bounds the cost
+    # to one `gh api compare` call per ready-to-land stack per tick, not one
+    # per candidate PR scanned. Uses GitHub's compare API instead of a local
+    # git checkout so a normal scan never touches the filesystem or shells
+    # out to real git -- `rebase_onto_base` (the executor action, dispatched
+    # only when this signal is true) is the one place that actually clones.
+    stale_base_by_pr: dict[int, bool] = {}
+    for stack in stacks:
+        bottom = current_bottom_pr(stack, trunk)
+        if bottom is None or "admin-bypass" not in bottom.labels:
+            continue
+        try:
+            status = gh.compare_status(repo, trunk, bottom.head_ref_oid)
+            stale_base_by_pr[bottom.number] = status not in {"ahead", "identical"}
+        except Exception as exc:
+            logger.trace(
+                "admin-bypass-stale-base-check-failed",
+                repo=repo,
+                pr_number=bottom.number,
+                error=str(exc),
+            )
+    return stale_base_by_pr
 
 
 def run_cycle(args: argparse.Namespace) -> bool:
@@ -112,6 +140,7 @@ def run_cycle(args: argparse.Namespace) -> bool:
     repair_dispatch_succeeded = 0
     repair_dispatch_last_error: str | None = None
     open_pr_numbers = set(pr_by_number)
+    stale_base_by_pr = compute_stale_base_by_pr(stacks, trunk, args.repo, gh, logger)
     for stack in stacks:
         plan = plan_stack_execution(
             stack,
@@ -123,6 +152,7 @@ def run_cycle(args: argparse.Namespace) -> bool:
             args.max_requeue_attempts,
             args.max_repair_attempts,
             trunk,
+            stale_base_by_pr,
         )
         queue_only_noop_check = plan.queue_only_noop_check
         logger.stack("admin-bypass-stack", plan.summary)
@@ -215,6 +245,30 @@ def run_cycle(args: argparse.Namespace) -> bool:
                     continue
                 if progressed:
                     repair_dispatch_attempted += 1
+                    repair_dispatch_succeeded += 1
+                    any_progress = True
+                else:
+                    should_poll = True
+                continue
+            elif action.kind == "rebase_onto_base":
+                try:
+                    progressed = executor.rebase_onto_base(pr, action.key, now)
+                except Exception as exc:
+                    repair_dispatch_attempted += 1
+                    repair_dispatch_failed += 1
+                    repair_dispatch_last_error = str(exc)
+                    logger.trace(
+                        "admin-bypass-repair-attempt-failed",
+                        repo=args.repo,
+                        pr_number=action.pr_number,
+                        action_kind=action.kind,
+                        key=action.key,
+                        error=str(exc),
+                    )
+                    should_poll = True
+                    continue
+                repair_dispatch_attempted += 1
+                if progressed:
                     repair_dispatch_succeeded += 1
                     any_progress = True
                 else:

--- a/scripts/mergify_admin_requeue_gh_executor.py
+++ b/scripts/mergify_admin_requeue_gh_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import tempfile
@@ -8,11 +9,13 @@ from pathlib import Path
 try:
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Action, GH_ACTIONS_JOB_RE, Ledger, PrSnapshot
-    from .mergify_admin_requeue_snapshot import GhClient
+    from .mergify_admin_requeue_repair_body import rebase_onto_base as run_rebase_onto_base
+    from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
 except ImportError:
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Action, GH_ACTIONS_JOB_RE, Ledger, PrSnapshot
-    from mergify_admin_requeue_snapshot import GhClient
+    from mergify_admin_requeue_repair_body import rebase_onto_base as run_rebase_onto_base
+    from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
 
 
 ADMIN_BYPASS_NUDGE_LEDGER_KIND = "comment-admin-bypass-nudge"
@@ -81,6 +84,17 @@ class AdminBypassGhExecutor:
     def retarget_base(self, pr: PrSnapshot, new_base: str, now: int) -> None:
         self.gh.retarget_base(self.repo, pr.number, new_base)
         self.ledger.record("retarget-base", pr.number, pr.head_ref_oid, f"{pr.base_ref_name}->{new_base}", now)
+
+    def rebase_onto_base(self, pr: PrSnapshot, new_base: str, now: int) -> bool:
+        work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
+        work_root.parent.mkdir(parents=True, exist_ok=True)
+        checkout_pr_head(self.repo, pr, work_root)
+        new_head = run_rebase_onto_base(work_root, new_base, pr.head_ref_name, pr.head_ref_oid)
+        if new_head is None:
+            self.ledger.record("rebase-onto-base-conflict", pr.number, pr.head_ref_oid, new_base, now)
+            return False
+        self.ledger.record("rebase-onto-base", pr.number, pr.head_ref_oid, new_base, now, meta={"newHead": new_head})
+        return True
 
     def comment_admin_bypass_nudge(self, pr: PrSnapshot, key: str, now: int) -> None:
         if self.ledger.count(ADMIN_BYPASS_NUDGE_LEDGER_KIND, pr.number, pr.head_ref_oid, key) == 0:

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -95,6 +95,7 @@ class StackFacts:
     suppressed_failed_checks_by_pr: Mapping[int, tuple[str, ...]]
     blockers_by_pr: Mapping[int, tuple[Blocker, ...]]
     all_blockers: tuple[Blocker, ...]
+    stale_base_by_pr: Mapping[int, bool]
 
 
 def is_queue_only_required_check(name: str) -> bool:
@@ -567,6 +568,7 @@ def build_stack_facts(
     open_pr_numbers: Collection[int],
     open_pr_numbers_by_head: Mapping[str, Collection[int]],
     trunk: str,
+    stale_base_by_pr: Mapping[int, bool] | None = None,
 ) -> StackFacts:
     required = frozenset(required_checks)
     bottom_topology = classify_bottom_topology(stack, trunk, open_pr_numbers_by_head)
@@ -622,6 +624,7 @@ def build_stack_facts(
             for pr in stack.prs
             for blocker in blockers_by_pr[pr.number]
         ),
+        stale_base_by_pr=dict(stale_base_by_pr or {}),
     )
     _assert_stack_facts_invariants(facts)
     return facts
@@ -885,6 +888,17 @@ def plan_merge_hold_cleanup(facts: StackFacts, ledger: Ledger) -> Action | None:
     return None
 
 
+def plan_rebase_onto_base(pr: PrSnapshot, trunk: str, ledger: Ledger, max_attempts: int, reason: str) -> Action:
+    rebase_attempts = ledger.count("rebase-onto-base-conflict", pr.number, pr.head_ref_oid, trunk)
+    if rebase_attempts >= max_attempts:
+        return cap_action(
+            pr,
+            Blocker("rebase-onto-base", "rebase_conflict", pr.number, "rebase onto base"),
+            f"rebase onto `{trunk}` keeps hitting a real conflict; a human needs to rebase PR #{pr.number} manually",
+        )
+    return Action("rebase_onto_base", pr.number, trunk, f"rebase #{pr.number} onto `{trunk}`: {reason}")
+
+
 def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts: int) -> Action | None:
     if _bottom_has_pending_or_human_blocker(facts):
         return None
@@ -929,6 +943,8 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
         return None
     if has_active_queue_event(bottom):
         return None
+    if bottom.base_ref_name == facts.trunk and facts.stale_base_by_pr.get(bottom.number):
+        return plan_rebase_onto_base(bottom, facts.trunk, ledger, max_requeue_attempts, "base pointer moved but content was never rebased")
     requeue_reason = "eligible-when-ready"
     requeue_key = "ready"
     if latest and latest.state == "dequeued":
@@ -1028,8 +1044,9 @@ def plan_stack_execution(
     max_requeue_attempts: int = 2,
     max_repair_attempts: int = 3,
     trunk: str = TRUNK,
+    stale_base_by_pr: Mapping[int, bool] | None = None,
 ) -> StackExecutionPlan:
-    facts = build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head, trunk)
+    facts = build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head, trunk, stale_base_by_pr=stale_base_by_pr)
     summary = summarize_stack(facts)
     if facts.prereq_status and facts.prereq_status.is_open:
         return StackExecutionPlan(

--- a/scripts/mergify_admin_requeue_repair_body.py
+++ b/scripts/mergify_admin_requeue_repair_body.py
@@ -59,6 +59,29 @@ def is_ancestor(cwd: Path, ancestor: str, descendant: str) -> bool:
     return completed.returncode == 0
 
 
+def needs_rebase_onto_base(cwd: Path, base_ref: str, head_sha: str) -> bool:
+    git_output(cwd, "fetch", "origin", base_ref)
+    return not is_ancestor(cwd, f"origin/{base_ref}", head_sha)
+
+
+def rebase_onto_base(cwd: Path, base_ref: str, branch: str, expected_head: str) -> str | None:
+    git_output(cwd, "fetch", "origin", base_ref)
+    hard_reset_work_root(cwd, expected_head)
+    completed = subprocess.run(
+        ["git", "rebase", f"origin/{base_ref}"],
+        cwd=str(cwd),
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if completed.returncode != 0:
+        subprocess.run(["git", "rebase", "--abort"], cwd=str(cwd), check=False, text=True, capture_output=True)
+        return None
+    new_head = git_output(cwd, "rev-parse", "HEAD").strip()
+    safe_push(branch=branch, expected_head=expected_head, cwd=cwd)
+    return new_head
+
+
 def normalize_repair_commit(cwd: Path, start_head: str, end_head: str, check_name: str) -> str:
     if is_ancestor(cwd, start_head, end_head):
         return end_head

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -176,6 +176,15 @@ class GhClient:
             capture_output=True,
         )
 
+    def compare_status(self, repo: str, base: str, head: str) -> str:
+        completed = subprocess.run(
+            ["gh", "api", f"repos/{repo}/compare/{base}...{head}"],
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        return str(json.loads(completed.stdout).get("status") or "")
+
     def resolve_review_thread(self, thread_id: str) -> None:
         query = "mutation($threadId:ID!) { resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } } }"
         subprocess.run(["gh", "api", "graphql", "-f", f"threadId={thread_id}", "-f", f"query={query}"], check=True, text=True, capture_output=True)

--- a/scripts/repro/fixtures/fake-gh/bin/gh
+++ b/scripts/repro/fixtures/fake-gh/bin/gh
@@ -220,6 +220,12 @@ def main() -> None:
         if comments_match and flag_value("--method") in (None, "GET"):
             print(json.dumps(state.get("issue_comments", {}).get(comments_match.group(1), [])))
             return
+        compare_match = re.fullmatch(r"repos/[^/]+/[^/]+/compare/(.+)\.\.\.(.+)", path)
+        if compare_match and flag_value("--method") in (None, "GET"):
+            base_ref, head_sha = compare_match.group(1), compare_match.group(2)
+            status = state.get("compare_status", {}).get(f"{base_ref}...{head_sha}", "identical")
+            print(json.dumps({"status": status}))
+            return
         pulls_match = re.fullmatch(r"repos/[^/]+/[^/]+/pulls", path)
         if pulls_match and flag_value("--method") == "POST":
             payload = json.loads(STDIN or "{}")

--- a/scripts/repro/repro-babysit-rebase-onto-base.sh
+++ b/scripts/repro/repro-babysit-rebase-onto-base.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-babysit-rebase-onto-base.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    echo "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+WORK_PARENT="$HOME/.invoker/mergify-admin-requeue-work"
+mkdir -p "$WORK_PARENT" "$TMP/state"
+export FAKE_GH_STATE_DIR="$TMP/state"
+export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+
+FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
+import sys
+from pathlib import Path
+sys.path.insert(0, 'scripts')
+from mergify_admin_requeue_model import load_mergify_rules
+_trunk, _labels, required = load_mergify_rules(Path('.mergify.yml'))
+print('\n'.join(sorted(required)))
+PY
+)"
+export FAKE_GH_REQUIRED_CHECKS
+
+STATE_PATH="$FAKE_GH_STATE_DIR/state.json"
+LEDGER_PATH="$TMP/ledger.jsonl"
+CALLS_PATH="$FAKE_GH_STATE_DIR/calls.log"
+export STATE_PATH LEDGER_PATH CALLS_PATH
+
+REMOTE="$TMP/origin.git"
+SEED="$TMP/seed"
+WORK_ROOT="$WORK_PARENT/6201"
+
+# PR #7727 incident, reproduced with real git: the branch's base pointer
+# already points at master (a prior retarget), but the branch still carries
+# a pre-squash duplicate of a commit that landed in master under a different
+# SHA -- master is not an ancestor of the branch's real content.
+git clone . "$SEED" >/dev/null
+(
+  cd "$SEED"
+  git config user.email repro@example.test
+  git config user.name 'Repro Bot'
+  git checkout -B master >/dev/null
+  git init --bare "$REMOTE" >/dev/null
+  git remote add publish "$REMOTE"
+  git push publish master >/dev/null
+  git switch -c feature master >/dev/null
+  printf 'feature\n' > feature-6201.txt
+  git add feature-6201.txt
+  git commit -m 'feature work' >/dev/null
+  git switch master >/dev/null
+  git merge --squash feature >/dev/null
+  git commit -m 'squash-merged feature' >/dev/null
+  git push publish master >/dev/null
+  git switch -c stack/rebase-onto-base feature >/dev/null
+  printf 'only new\n' > only-new-6201.txt
+  git add only-new-6201.txt
+  git commit -m 'genuinely new work' >/dev/null
+  git push publish stack/rebase-onto-base >/dev/null
+)
+git --git-dir="$REMOTE" symbolic-ref HEAD refs/heads/master
+STALE_HEAD="$(git -C "$SEED" rev-parse stack/rebase-onto-base)"
+MASTER_HEAD="$(git -C "$SEED" rev-parse master)"
+export STALE_HEAD MASTER_HEAD
+
+git clone "$REMOTE" "$WORK_ROOT" >/dev/null
+( cd "$WORK_ROOT" && git config user.email repro@example.test && git config user.name 'Repro Bot' )
+
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+state = {
+    "prs": [
+        {
+            "number": 6201,
+            "title": "Stale base content never rebased",
+            "body": "## Summary\n\nStale base rebase repro.\n",
+            "url": "https://github.com/fake/repo/pull/6201",
+            "state": "OPEN",
+            "isDraft": False,
+            "baseRefName": "master",
+            "headRefName": "stack/rebase-onto-base",
+            "headRefOid": os.environ["STALE_HEAD"],
+            "mergeStateStatus": "CLEAN",
+            "mergeable": "MERGEABLE",
+            "labels": ["admin-bypass"],
+            "reviewThreads": [],
+            "checks": {"*": "SUCCESS"},
+        },
+    ],
+    "issue_comments": {"6201": []},
+    "job_logs": {},
+    "compare_status": {
+        f"master...{os.environ['STALE_HEAD']}": "diverged",
+    },
+}
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+: > "$LEDGER_PATH"
+
+run_worker() {
+  python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6201 "$@" 2>&1
+}
+
+if ! out1="$(run_worker)"; then
+  fail 'tick 1: worker failed' "$out1"
+fi
+printf '%s\n' "$out1"
+
+echo "$out1" | grep -q 'rebase-onto-base PR #6201 onto=master' || fail 'tick 1 did not plan a rebase-onto-base action' "$out1"
+! echo "$out1" | grep -q 'requeue PR #6201' || fail 'tick 1 requeued a PR whose content was never rebased' "$out1"
+! echo "$out1" | grep -q 'repair-check PR #6201' || fail 'tick 1 spent an agent-repair attempt instead of rebasing' "$out1"
+
+NEW_REMOTE_HEAD="$(git --git-dir="$REMOTE" rev-parse stack/rebase-onto-base)"
+export NEW_REMOTE_HEAD
+if [ "$NEW_REMOTE_HEAD" = "$STALE_HEAD" ]; then
+  fail 'tick 1 did not push a real rebase to the remote branch'
+fi
+git --git-dir="$REMOTE" merge-base --is-ancestor "$MASTER_HEAD" "$NEW_REMOTE_HEAD" \
+  || fail 'rebased remote head is still not a descendant of master'
+
+python3 - <<'PY' || fail 'expected a rebase-onto-base ledger row, not repair-check' "$(cat "$LEDGER_PATH")"
+import json
+import os
+from pathlib import Path
+
+rows = [
+    json.loads(line)
+    for line in Path(os.environ["LEDGER_PATH"]).read_text(encoding="utf-8").splitlines()
+    if line.strip()
+]
+matches = [
+    row for row in rows
+    if row.get("kind") == "rebase-onto-base"
+    and row.get("key") == "master"
+    and int(row.get("pr", 0)) == 6201
+]
+if len(matches) != 1:
+    raise SystemExit(f"expected 1 rebase-onto-base row, saw {len(matches)}")
+if any(row.get("kind") == "repair-check" and int(row.get("pr", 0)) == 6201 for row in rows):
+    raise SystemExit("repair-check must not be attempted for a structural stale-base failure")
+PY
+
+# Tick 2: simulate the loader now observing the rebased head (a real cycle
+# would see this via a fresh `gh pr view`). Ancestry is clean now, so the
+# planner must fall through to a normal requeue instead of rebasing again.
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+state = json.loads(Path(os.environ["STATE_PATH"]).read_text(encoding="utf-8"))
+state["prs"][0]["headRefOid"] = os.environ["NEW_REMOTE_HEAD"]
+state["compare_status"][f"master...{os.environ['NEW_REMOTE_HEAD']}"] = "ahead"
+Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding="utf-8")
+PY
+
+if ! out2="$(run_worker --dry-run)"; then
+  fail 'tick 2: worker failed' "$out2"
+fi
+printf '%s\n' "$out2"
+
+echo "$out2" | grep -q 'DRY-RUN requeue PR #6201' || fail 'tick 2 did not requeue the now-clean PR' "$out2"
+! echo "$out2" | grep -q 'rebase-onto-base PR #6201' || fail 'tick 2 planned another rebase despite clean ancestry' "$out2"
+
+echo '[repro] passed'

--- a/scripts/test-suites/required/12-mergify-admin-requeue.sh
+++ b/scripts/test-suites/required/12-mergify-admin-requeue.sh
@@ -4,6 +4,8 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
 python3 -m unittest scripts/test_pr_worker_safe_push.py
 python3 -m unittest scripts/test_mergify_admin_requeue.py
+python3 -m unittest scripts/test_mergify_admin_requeue_plan.py
+python3 -m unittest scripts/test_mergify_admin_requeue_repair_body.py
 bash scripts/repro/repro-mergify-admin-requeue.sh
 bash scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh
 bash scripts/repro/repro-mergify-rejected-pr.sh

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -75,9 +75,9 @@ class PlannerTestCase(unittest.TestCase):
         self.addCleanup(lambda: shutil.rmtree(d, ignore_errors=True))
         return m.Ledger(Path(d) / "ledger.jsonl")
 
-    def _facts(self, stack, required_checks=REQUIRED, ledger=None, open_pr_numbers=(), open_pr_numbers_by_head=None, trunk="master"):
+    def _facts(self, stack, required_checks=REQUIRED, ledger=None, open_pr_numbers=(), open_pr_numbers_by_head=None, trunk="master", stale_base_by_pr=None):
         ledger = ledger or self._ledger()
-        return p.build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head or {}, trunk), ledger
+        return p.build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head or {}, trunk, stale_base_by_pr=stale_base_by_pr or {}), ledger
 
 
 class ClassifyPr(unittest.TestCase):
@@ -329,10 +329,10 @@ class BuildStackFacts(PlannerTestCase):
 class PlanStackActions(PlannerTestCase):
     """Named planning passes over prebuilt facts still honor the same ladder."""
 
-    def _plan(self, stack_or_snapshot, ledger=None, required_checks=REQUIRED, open_pr_numbers=(), open_pr_numbers_by_head=None):
+    def _plan(self, stack_or_snapshot, ledger=None, required_checks=REQUIRED, open_pr_numbers=(), open_pr_numbers_by_head=None, stale_base_by_pr=None):
         ledger = ledger or self._ledger()
         stack = stack_or_snapshot if isinstance(stack_or_snapshot, m.StackGroup) else m.StackGroup("s", (stack_or_snapshot,))
-        facts = p.build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head or {}, "master")
+        facts = p.build_stack_facts(stack, required_checks, ledger, open_pr_numbers, open_pr_numbers_by_head or {}, "master", stale_base_by_pr=stale_base_by_pr or {})
         return p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3, now=NOW)
 
     def test_pending_check_means_wait_do_nothing(self):
@@ -462,6 +462,7 @@ class PlanStackActions(PlannerTestCase):
         actions = self._plan(pr(latest_mergify=event(failing=("build",))))
         self.assertEqual(actions[0].kind, "repair_check")
 
+
     def test_clean_bottom_missing_label_nudges_human(self):
         actions = self._plan(pr())  # green, no admin-bypass label
         self.assertEqual((actions[0].kind, actions[0].key), ("comment_admin_bypass_nudge", "admin-bypass"))
@@ -508,6 +509,29 @@ class PlanStackActions(PlannerTestCase):
     def test_clean_bottom_queues_without_prior_dequeue(self):
         snapshot = pr(labels=frozenset({"admin-bypass"}))
         actions = self._plan(snapshot)
+        self.assertEqual((actions[0].kind, actions[0].detail), ("requeue", "eligible-when-ready"))
+
+    def test_stale_base_content_rebases_before_requeue(self):
+        # PR #7727 incident: retarget_base already moved the base pointer to
+        # `master`, but the branch content was never rebased. Once the loader
+        # reports the base as `master` again (bottom_topology is now
+        # "current_bottom", not "stale_unowned_base"), the planner must not
+        # requeue a PR whose content still isn't an ancestor of master.
+        snapshot = pr(number=5885, labels=frozenset({"admin-bypass"}))
+        actions = self._plan(snapshot, stale_base_by_pr={5885: True})
+        self.assertEqual(
+            (actions[0].kind, actions[0].pr_number, actions[0].key),
+            ("rebase_onto_base", 5885, "master"),
+        )
+
+    def test_clean_ancestry_bottom_still_requeues_normally(self):
+        snapshot = pr(number=5885, labels=frozenset({"admin-bypass"}))
+        actions = self._plan(snapshot, stale_base_by_pr={5885: False})
+        self.assertEqual((actions[0].kind, actions[0].detail), ("requeue", "eligible-when-ready"))
+
+    def test_stale_base_signal_for_other_pr_does_not_affect_this_bottom(self):
+        snapshot = pr(number=5885, labels=frozenset({"admin-bypass"}))
+        actions = self._plan(snapshot, stale_base_by_pr={9999: True})
         self.assertEqual((actions[0].kind, actions[0].detail), ("requeue", "eligible-when-ready"))
 
     def test_upper_human_decision_does_not_block_clean_bottom_requeue(self):

--- a/scripts/test_mergify_admin_requeue_repair_body.py
+++ b/scripts/test_mergify_admin_requeue_repair_body.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import mergify_admin_requeue_repair_body as repair_body
+from scripts import pr_worker_safe_push as safe_push
+
+REAL_GIT = shutil.which("git") or "git"
+
+
+def git(cwd: Path, *args: str) -> str:
+    completed = subprocess.run(
+        [REAL_GIT, *args],
+        cwd=str(cwd),
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return completed.stdout.strip()
+
+
+class RebaseOntoBaseTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.remote = self.root / "remote.git"
+        self.repo = self.root / "repo"
+        git(self.root, "init", "--bare", str(self.remote))
+        git(self.root, "clone", str(self.remote), str(self.repo))
+        git(self.repo, "config", "user.email", "worker@example.invalid")
+        git(self.repo, "config", "user.name", "Worker Test")
+        git(self.repo, "checkout", "-B", "master")
+        self._write("shared.txt", "shared\n")
+        git(self.repo, "add", "shared.txt")
+        git(self.repo, "commit", "-m", "shared base")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/master")
+
+    def _write(self, name: str, content: str) -> None:
+        (self.repo / name).write_text(content, encoding="utf-8")
+
+    def _commit(self, message: str, filename: str = "shared.txt", content: str = "change\n") -> str:
+        target = self.repo / filename
+        existing = target.read_text(encoding="utf-8") if target.exists() else ""
+        target.write_text(existing + content, encoding="utf-8")
+        git(self.repo, "add", filename)
+        git(self.repo, "commit", "-m", message)
+        return git(self.repo, "rev-parse", "HEAD")
+
+    def test_clean_ancestry_does_not_need_rebase(self) -> None:
+        git(self.repo, "checkout", "-B", "stack/clean", "master")
+        head = self._commit("clean addition", "clean.txt", "clean\n")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/stack/clean")
+
+        self.assertFalse(repair_body.needs_rebase_onto_base(self.repo, "master", head))
+
+    def test_duplicate_pre_squash_commit_needs_rebase(self) -> None:
+        # Mirrors PR #7727's real shape: a branch carries a commit whose content
+        # was already squash-merged into master under a different SHA, so the
+        # branch's own history never became an ancestor of master's tip.
+        git(self.repo, "checkout", "-B", "feature", "master")
+        self._commit("feature work", "feature.txt", "feature\n")
+        git(self.repo, "checkout", "master")
+        git(self.repo, "merge", "--squash", "feature")
+        git(self.repo, "commit", "-m", "squash-merged feature")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/master")
+
+        git(self.repo, "checkout", "-B", "stack/stale", "feature")
+        head = git(self.repo, "rev-parse", "HEAD")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/stack/stale")
+
+        self.assertTrue(repair_body.needs_rebase_onto_base(self.repo, "master", head))
+
+    def test_rebase_onto_base_pushes_clean_rebase(self) -> None:
+        git(self.repo, "checkout", "-B", "feature", "master")
+        self._commit("feature work", "feature.txt", "feature\n")
+        git(self.repo, "checkout", "master")
+        git(self.repo, "merge", "--squash", "feature")
+        git(self.repo, "commit", "-m", "squash-merged feature")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/master")
+
+        git(self.repo, "checkout", "-B", "stack/stale", "feature")
+        self._write("only-new.txt", "only new\n")
+        git(self.repo, "add", "only-new.txt")
+        git(self.repo, "commit", "-m", "genuinely new work")
+        stale_head = git(self.repo, "rev-parse", "HEAD")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/stack/stale")
+
+        new_head = repair_body.rebase_onto_base(self.repo, "master", "stack/stale", stale_head)
+
+        self.assertIsNotNone(new_head)
+        self.assertNotEqual(new_head, stale_head)
+        remote_head = safe_push.remote_branch_sha("stack/stale", remote="origin", cwd=self.repo)
+        self.assertEqual(remote_head, new_head)
+        self.assertFalse(repair_body.needs_rebase_onto_base(self.repo, "master", new_head))
+        # Only the genuinely-new file survives the rebase; the duplicate
+        # pre-squash content is gone because it's already reachable via master.
+        self.assertTrue((self.repo / "only-new.txt").exists())
+
+    def test_real_conflict_aborts_without_pushing(self) -> None:
+        git(self.repo, "checkout", "-B", "stack/conflict", "master")
+        self._commit("conflicting change on branch", "shared.txt", "branch change\n")
+        conflict_head = git(self.repo, "rev-parse", "HEAD")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/stack/conflict")
+
+        git(self.repo, "checkout", "master")
+        self._commit("conflicting change on master", "shared.txt", "master change\n")
+        git(self.repo, "push", "origin", "HEAD:refs/heads/master")
+
+        git(self.repo, "checkout", "stack/conflict")
+        result = repair_body.rebase_onto_base(self.repo, "master", "stack/conflict", conflict_head)
+
+        self.assertIsNone(result)
+        remote_head = safe_push.remote_branch_sha("stack/conflict", remote="origin", cwd=self.repo)
+        self.assertEqual(remote_head, conflict_head)
+        # Working tree must be left clean, not mid-rebase.
+        status = git(self.repo, "status", "--porcelain")
+        self.assertEqual(status, "")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds a real end-to-end proof for the previous slice, using a real git remote and branch shaped exactly like PR #7727: a base pointer that already points at `master`, but content that still carries a duplicate commit.

Confirms the bot pushes a real ancestor-clean rebase on the first pass, then leaves a clean PR alone on the next pass.

## Review Claim

Approve that this proof exercises real git end to end -- a real fetch, rebase, and force-with-lease push -- rather than asserting against mocks.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only: a new script under `scripts/repro/` plus one added handler in the shared fake-`gh` fixture. Cannot change any runtime behavior.

## Slice Rationale

Kept apart from the behavior slice per this repo's convention of landing proof separately from the change it verifies.

## Non-goals

Does not add new bot behavior. Does not wire this script into the required CI suite -- that's the next slice, so a required-suite failure here can't be blamed on a script that didn't exist yet at an earlier commit in this stack. Does not cover the second fix (routing a failing check away from a coding-agent attempt) -- that lands in a follow-on stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-babysit-rebase-onto-base.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
