### PR TITLE
Skip agent repair for a structurally stale-based failing check

### DIFF
--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -745,6 +745,11 @@ def plan_mergify_queue_repairs(
             continue
         if facts.upper_stack_needs_acceptance and facts.bottom and pr.number == facts.bottom.number:
             continue
+        if facts.stale_base_by_pr.get(pr.number) and pr.latest_mergify and pr.latest_mergify.failing_checks:
+            return plan_rebase_onto_base(
+                pr, facts.trunk, ledger, max_repair_attempts,
+                "structural stale base is blocking its failing check(s), not a code problem",
+            )
         actions = mergify_failed_check_actions(
             pr, ledger, max_repair_attempts, now, facts.suppressed_failed_checks_by_pr.get(pr.number, ()),
         )
@@ -776,6 +781,11 @@ def plan_direct_repairs(
                     continue
                 return Action("repair_conflict", pr.number, key, blocker.detail)
             if blocker.kind == "failed_check":
+                if facts.stale_base_by_pr.get(pr.number):
+                    return plan_rebase_onto_base(
+                        pr, facts.trunk, ledger, max_repair_attempts,
+                        "structural stale base is blocking its failing check(s), not a code problem",
+                    )
                 count, crashed_on_infra = repair_attempt_count_excluding_infra_crash(
                     ledger, pr.number, pr.head_ref_oid, "repair-check", blocker.key,
                     repair_check_plan_name(pr.number, blocker.key, pr.head_ref_oid),

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -462,6 +462,28 @@ class PlanStackActions(PlannerTestCase):
         actions = self._plan(pr(latest_mergify=event(failing=("build",))))
         self.assertEqual(actions[0].kind, "repair_check")
 
+    def test_failed_check_with_stale_base_skips_agent_repair(self):
+        # PR #7727 incident: no coding-agent repair can fix a git-history
+        # problem. Once the base is known to be structurally stale, the
+        # direct-repair ladder must route to rebase_onto_base, never
+        # repair_check, and must not spend a repair-check ledger attempt.
+        ledger = self._ledger()
+        snapshot = pr(number=42, checks={"build": check("failure")})
+        actions = self._plan(snapshot, ledger=ledger, stale_base_by_pr={42: True})
+        self.assertEqual((actions[0].kind, actions[0].pr_number, actions[0].key), ("rebase_onto_base", 42, "master"))
+        self.assertEqual(ledger.count("repair-check", 42, HEAD, "build"), 0)
+
+    def test_failed_check_with_stale_base_skips_agent_repair_via_mergify_dequeue(self):
+        ledger = self._ledger()
+        snapshot = pr(number=43, latest_mergify=event(failing=("build",)))
+        actions = self._plan(snapshot, ledger=ledger, stale_base_by_pr={43: True})
+        self.assertEqual((actions[0].kind, actions[0].pr_number, actions[0].key), ("rebase_onto_base", 43, "master"))
+        self.assertEqual(ledger.count("repair-check", 43, HEAD, "build"), 0)
+
+    def test_failed_check_with_clean_base_still_repairs_via_agent(self):
+        actions = self._plan(pr(checks={"build": check("failure")}), stale_base_by_pr={1: False})
+        self.assertEqual(actions[0].kind, "repair_check")
+
 
     def test_clean_bottom_missing_label_nudges_human(self):
         actions = self._plan(pr())  # green, no admin-bypass label


### PR DESCRIPTION
## Summary

Any failing required check unconditionally became a coding-agent repair attempt, even when the branch's own history was the real problem -- the same shape the previous stack's `rebase_onto_base` was built to fix. PR #7727 spent all three of its repair attempts this way before giving up.

Both places that turn a failing check into a repair attempt now check that same signal first and route to a rebase instead. A normal failing check still repairs via the agent exactly as before.

## Review Claim

Approve that a failing check caused by a git-history problem gets rebased instead of spending a coding-agent attempt, on both the queue-dequeue path and the direct-repair path, while an ordinary failing check is unaffected.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Gated entirely behind the previous stack's `stale_base_by_pr` signal, which is empty for every PR unless a bottom PR's content was already found to need a rebase. Every check failure on a PR without that signal repairs via the coding agent exactly as it did before this change.

## Slice Rationale

This is the actual decision-making change; the next slice adds its own real-git proof separately, following this repo's convention of keeping proof out of policy PRs.

## Non-goals

Does not add a new signal -- reuses the previous stack's `plan_rebase_onto_base` helper and `stale_base_by_pr` field as-is.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts/test_mergify_admin_requeue_plan.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
