### PR TITLE
[EMBARGO: Worktree lease generalization](1) proof: repro worktree-slot leak on non-conflict upstream-merge failure

### DIFF
--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -1157,6 +1157,46 @@ describe('WorktreeExecutor', () => {
 
       await expect(executor.start(request)).rejects.toThrow();
     });
+
+    it('BUG: leaks the acquired worktree slot when the upstream merge fails for a non-conflict reason', async () => {
+      setupSpawnMock();
+      const pool = mockPool(executor);
+
+      vi.mocked((BaseExecutor.prototype as any).runBash).mockImplementation(
+        async (script: string) => {
+          if (script.includes('PRESERVED=')) {
+            return 'PRESERVED=0\nBASE_SHA=abc123\n';
+          }
+          if (script.includes('Invoker: merge')) {
+            const err = new Error('bash exited with code 30: missing ref');
+            (err as any).exitCode = 30;
+            (err as any).stderr = 'MISSING_REF=experiment/nonexistent-branch';
+            throw err;
+          }
+          return '';
+        },
+      );
+
+      const request = makeRequest({
+        inputs: {
+          command: 'echo hello',
+          upstreamBranches: ['experiment/dep-parent', 'experiment/nonexistent-branch'],
+          upstreamBase: {
+            branch: 'experiment/dep-parent',
+            commitHash: '5555555555555555555555555555555555555555',
+          },
+        },
+      });
+
+      await expect(executor.start(request)).rejects.toThrow();
+
+      // start() throws here before any WorktreeEntry is registered, so the
+      // acquired worktree slot is never freed — it leaks for the life of the
+      // process. This documents the CURRENT (buggy) behavior; the next PR in
+      // this stack fixes it and flips this assertion.
+      const acquired = await pool.acquireWorktree.mock.results[0]!.value;
+      expect(acquired.softRelease).not.toHaveBeenCalled();
+    });
   });
 
   describe('agent registry validation', () => {


### PR DESCRIPTION
## Summary

WorktreeExecutor.start() acquires a worktree slot before merging upstream dependency branches.

When that merge fails for any reason other than a merge conflict, the error is rethrown before a WorktreeEntry is ever registered.

No WorktreeEntry means the slot's softRelease is never wired up, so it leaks for the life of the process.

This PR adds a regression test that documents the leak as it exists today, with no production code change.

## Review Claim

Add a test proving WorktreeExecutor leaks an acquired worktree slot when the upstream merge fails for a non-conflict reason.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change against a mocked RepoPool; no production code path is touched, so this cannot affect running behavior.

## Slice Rationale

Repro/proof lands before its fix per this repo's review-compression ordering rules, so the bug is demonstrated before the next PR's fix is approved.

## Non-goals

Does not fix the leak. Does not touch any other acquireWorktree call site or the merge-conflict path, which already registers an entry and releases correctly.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test -- worktree-executor` — confirms the new test passes against unmodified code, proving the leak exists (81/81 tests pass)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
