### PR TITLE
[EMBARGO: Worktree lease generalization](3) feat: add DB-backed lease capacity to RepoPool worktree slots

### DIFF
--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -245,6 +245,14 @@ export type WorkflowMutationPriority = 'high' | 'normal';
 export type WorkflowMutationIntentStatus = 'queued' | 'running' | 'completed' | 'failed';
 export const WORKFLOW_MUTATION_LEASE_MS = 30_000;
 export const EXECUTION_RESOURCE_LEASE_MS = 20 * 60 * 1000;
+/**
+ * TTL for worktree-slot leases (`resource_type: 'worktree'`). Shorter than
+ * `EXECUTION_RESOURCE_LEASE_MS` (SSH) because worktree acquisition churns much
+ * faster; sized as a safe multiple of the default executor heartbeat interval
+ * (`DEFAULT_HEARTBEAT_INTERVAL_MS` in base-executor.ts, 30s) so a live task's
+ * lease never expires between renewals.
+ */
+export const WORKTREE_LEASE_TTL_MS = 3 * 60 * 1000;
 
 export interface ExecutionResourceLease {
   resourceKey: string;

--- a/packages/execution-engine/src/__tests__/repo-pool.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-pool.test.ts
@@ -409,6 +409,98 @@ describe('RepoPool', () => {
     await limitedPool.destroyAll();
   });
 
+  describe('lease persistence (DB-backed worktree slots)', () => {
+    /** Minimal in-memory stand-in for the execution_resource_leases table. */
+    function makeFakeLeasePersistence() {
+      const rows = new Map<string, { resourceKey: string; holderId: string }>();
+      return {
+        rows,
+        claimExecutionResourceLease: vi.fn((options: {
+          resourceKey: string;
+          resourceType: string;
+          holderId: string;
+          maxHolders?: number;
+        }) => {
+          const key = `${options.resourceKey}::${options.holderId}`;
+          if (rows.has(key)) return true;
+          const maxHolders = Math.max(1, options.maxHolders ?? 1);
+          const otherHolders = [...rows.values()].filter((r) => r.resourceKey === options.resourceKey).length;
+          if (otherHolders >= maxHolders) return false;
+          rows.set(key, { resourceKey: options.resourceKey, holderId: options.holderId });
+          return true;
+        }),
+        releaseExecutionResourceLease: vi.fn((resourceKey: string, holderId: string) => {
+          rows.delete(`${resourceKey}::${holderId}`);
+        }),
+      };
+    }
+
+    it('claims a lease on acquire and releases it on softRelease', async () => {
+      const leasePersistence = makeFakeLeasePersistence();
+      const limitedPool = new RepoPool({ cacheDir: tmpDir, maxWorktrees: 1, leasePersistence });
+      const wt = await limitedPool.acquireWorktree(localRepoUrl, 'branch-lease-1', undefined, undefined, {
+        leaseHolderId: 'attempt-1',
+      });
+
+      expect(leasePersistence.claimExecutionResourceLease).toHaveBeenCalledWith(
+        expect.objectContaining({ resourceType: 'worktree', holderId: 'attempt-1', maxHolders: 1 }),
+      );
+      expect(wt.leaseHolderId).toBe('attempt-1');
+      expect(leasePersistence.rows.size).toBe(1);
+
+      wt.softRelease();
+      expect(leasePersistence.releaseExecutionResourceLease).toHaveBeenCalledWith(wt.leaseResourceKey, 'attempt-1');
+      expect(leasePersistence.rows.size).toBe(0);
+      await limitedPool.destroyAll();
+    });
+
+    it('claims a lease on acquire and releases it on full release', async () => {
+      const leasePersistence = makeFakeLeasePersistence();
+      const limitedPool = new RepoPool({ cacheDir: tmpDir, maxWorktrees: 1, leasePersistence });
+      const wt = await limitedPool.acquireWorktree(localRepoUrl, 'branch-lease-2', undefined, undefined, {
+        leaseHolderId: 'attempt-2',
+      });
+      expect(leasePersistence.rows.size).toBe(1);
+
+      await wt.release();
+      expect(leasePersistence.rows.size).toBe(0);
+    });
+
+    it('throws ResourceLimitError when the DB lease is exhausted, without mutating the in-memory Set beyond it', async () => {
+      const leasePersistence = makeFakeLeasePersistence();
+      // Pre-fill the DB lease for this repo as already held by a different holder,
+      // simulating a slot reserved by another process instance.
+      const limitedPool = new RepoPool({ cacheDir: tmpDir, maxWorktrees: 5, leasePersistence });
+      leasePersistence.rows.set('bootstrap-key::other-holder', { resourceKey: 'bootstrap-key', holderId: 'other-holder' });
+      // Use the pool's own repo-key computation via a real acquire first, then
+      // saturate the DB lease at maxHolders=5 with distinct external holders.
+      const wt1 = await limitedPool.acquireWorktree(localRepoUrl, 'branch-lease-3a', undefined, undefined, {
+        leaseHolderId: 'attempt-3a',
+      });
+      const repoKey = wt1.leaseResourceKey!;
+      for (let i = 0; i < 4; i += 1) {
+        leasePersistence.rows.set(`${repoKey}::external-${i}`, { resourceKey: repoKey, holderId: `external-${i}` });
+      }
+      // In-memory Set only has 1 active worktree (well under maxWorktrees=5),
+      // but the DB lease is now saturated (1 real + 4 external = 5).
+      await expect(
+        limitedPool.acquireWorktree(localRepoUrl, 'branch-lease-3b', undefined, undefined, {
+          leaseHolderId: 'attempt-3b',
+        }),
+      ).rejects.toThrow(ResourceLimitError);
+      await limitedPool.destroyAll();
+    });
+
+    it('degrades to in-memory-only capacity when no leaseHolderId is supplied, even with persistence configured', async () => {
+      const leasePersistence = makeFakeLeasePersistence();
+      const limitedPool = new RepoPool({ cacheDir: tmpDir, maxWorktrees: 2, leasePersistence });
+      const wt = await limitedPool.acquireWorktree(localRepoUrl, 'branch-lease-4');
+      expect(leasePersistence.claimExecutionResourceLease).not.toHaveBeenCalled();
+      expect(wt.leaseResourceKey).toBeUndefined();
+      await limitedPool.destroyAll();
+    });
+  });
+
   it('reconcileActiveWorktrees clears stale slot reservations', async () => {
     const limitedPool = new RepoPool({ cacheDir: tmpDir, maxWorktrees: 1 });
     const wt1 = await limitedPool.acquireWorktree(localRepoUrl, 'branch-stale');

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -1157,6 +1157,46 @@ describe('WorktreeExecutor', () => {
 
       await expect(executor.start(request)).rejects.toThrow();
     });
+
+    it('BUG: leaks the acquired worktree slot when the upstream merge fails for a non-conflict reason', async () => {
+      setupSpawnMock();
+      const pool = mockPool(executor);
+
+      vi.mocked((BaseExecutor.prototype as any).runBash).mockImplementation(
+        async (script: string) => {
+          if (script.includes('PRESERVED=')) {
+            return 'PRESERVED=0\nBASE_SHA=abc123\n';
+          }
+          if (script.includes('Invoker: merge')) {
+            const err = new Error('bash exited with code 30: missing ref');
+            (err as any).exitCode = 30;
+            (err as any).stderr = 'MISSING_REF=experiment/nonexistent-branch';
+            throw err;
+          }
+          return '';
+        },
+      );
+
+      const request = makeRequest({
+        inputs: {
+          command: 'echo hello',
+          upstreamBranches: ['experiment/dep-parent', 'experiment/nonexistent-branch'],
+          upstreamBase: {
+            branch: 'experiment/dep-parent',
+            commitHash: '5555555555555555555555555555555555555555',
+          },
+        },
+      });
+
+      await expect(executor.start(request)).rejects.toThrow();
+
+      // start() throws here before any WorktreeEntry is registered, so the
+      // acquired worktree slot is never freed — it leaks for the life of the
+      // process. This documents the CURRENT (buggy) behavior; the next PR in
+      // this stack fixes it and flips this assertion.
+      const acquired = await pool.acquireWorktree.mock.results[0]!.value;
+      expect(acquired.softRelease).not.toHaveBeenCalled();
+    });
   });
 
   describe('agent registry validation', () => {

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -1158,7 +1158,7 @@ describe('WorktreeExecutor', () => {
       await expect(executor.start(request)).rejects.toThrow();
     });
 
-    it('BUG: leaks the acquired worktree slot when the upstream merge fails for a non-conflict reason', async () => {
+    it('releases the acquired worktree slot when the upstream merge fails for a non-conflict reason', async () => {
       setupSpawnMock();
       const pool = mockPool(executor);
 
@@ -1190,12 +1190,12 @@ describe('WorktreeExecutor', () => {
 
       await expect(executor.start(request)).rejects.toThrow();
 
-      // start() throws here before any WorktreeEntry is registered, so the
-      // acquired worktree slot is never freed — it leaks for the life of the
-      // process. This documents the CURRENT (buggy) behavior; the next PR in
-      // this stack fixes it and flips this assertion.
+      // Regression test: start() throws here before any WorktreeEntry is
+      // registered, so the only way the acquired worktree slot gets freed is
+      // the try/catch around mergeRequestUpstreamBranches releasing it
+      // directly. Without that fix, this slot leaks for the life of the process.
       const acquired = await pool.acquireWorktree.mock.results[0]!.value;
-      expect(acquired.softRelease).not.toHaveBeenCalled();
+      expect(acquired.softRelease).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -20,12 +20,38 @@ import { remoteFetchForPool } from './remote-fetch-policy.js';
 import { isWorkspaceCleanupEnabled } from './workspace-cleanup-policy.js';
 import { computeRepoCacheHash, computeRepoCacheKey, sanitizeBranchForPath } from './git-utils.js';
 import { cleanGitRepositoryEnv } from './process-utils.js';
+import { WORKTREE_LEASE_TTL_MS } from '@invoker/data-store';
+
+/**
+ * Minimal lease surface RepoPool needs, matching `SQLiteAdapter`'s
+ * `execution_resource_leases` methods. Kept structural (not imported as
+ * `SQLiteAdapter`) so RepoPool stays constructible without persistence, as
+ * every existing `repo-pool.test.ts` case already does.
+ */
+export interface RepoPoolLeasePersistence {
+  claimExecutionResourceLease(options: {
+    resourceKey: string;
+    resourceType: string;
+    holderId: string;
+    maxHolders?: number;
+    leaseMs?: number;
+    metadata?: unknown;
+  }): boolean;
+  releaseExecutionResourceLease(resourceKey: string, holderId: string): void;
+}
 
 export interface RepoPoolConfig {
   cacheDir: string;
   maxWorktrees?: number;
   /** When set, worktrees are created here instead of inside the clone. */
   worktreeBaseDir?: string;
+  /**
+   * Optional DB-backed lease authority for worktree slots, mirroring the SSH
+   * pool-member lease in `execution_resource_leases`. Additive: the in-memory
+   * `activeWorktrees` Set stays the primary capacity gate for callers that
+   * don't pass this (e.g. unit tests constructing RepoPool directly).
+   */
+  leasePersistence?: RepoPoolLeasePersistence;
 }
 
 export interface RepoPoolTiming {
@@ -40,6 +66,9 @@ export interface AcquiredWorktree {
   release: () => Promise<void>;
   /** Free the pool slot without removing the worktree from disk. */
   softRelease: () => void;
+  /** Set only when a DB-backed worktree lease was actually claimed. */
+  leaseResourceKey?: string;
+  leaseHolderId?: string;
 }
 
 export interface AcquireWorktreeOptions {
@@ -48,6 +77,13 @@ export interface AcquireWorktreeOptions {
     branch: string;
     workspacePath: string;
   };
+  /**
+   * Identity for the DB-backed worktree lease (e.g. the task attempt id).
+   * Required for this acquisition to claim a lease even when
+   * `RepoPoolConfig.leasePersistence` is configured — without it, capacity
+   * is enforced by the in-memory Set only, same as today.
+   */
+  leaseHolderId?: string;
 }
 
 interface RebaseRefreshBatch {
@@ -81,6 +117,7 @@ export class RepoPool {
   private readonly cacheDir: string;
   private readonly maxWorktrees: number;
   private readonly worktreeBaseDir?: string;
+  private readonly leasePersistence?: RepoPoolLeasePersistence;
   private activeWorktrees = new Map<string, Set<string>>();
   private cloneLocks = new Map<string, Promise<string>>();
   /** Chain of operations per repo to serialize git operations. */
@@ -91,6 +128,7 @@ export class RepoPool {
     this.cacheDir = config.cacheDir;
     this.maxWorktrees = config.maxWorktrees ?? 5;
     this.worktreeBaseDir = config.worktreeBaseDir;
+    this.leasePersistence = config.leasePersistence;
   }
 
   private cloneDir(repoUrl: string): string {
@@ -766,6 +804,37 @@ export class RepoPool {
     if (active.size >= this.maxWorktrees) {
       throw new ResourceLimitError(`Worktree limit reached for ${repoUrl}: ${active.size}/${this.maxWorktrees}`);
     }
+
+    // DB-backed lease: additive to the in-memory Set above, never a way to
+    // grant more capacity than it already allows. Skipped (not a hard
+    // failure) when persistence or a holder id isn't supplied, so every
+    // existing no-persistence caller (all current repo-pool.test.ts cases)
+    // behaves exactly as before.
+    let leaseHolderId: string | undefined = opts?.leaseHolderId;
+    if (this.leasePersistence && leaseHolderId) {
+      let claimed = true;
+      try {
+        claimed = this.leasePersistence.claimExecutionResourceLease({
+          resourceKey: repoKey,
+          resourceType: 'worktree',
+          holderId: leaseHolderId,
+          maxHolders: this.maxWorktrees,
+          leaseMs: WORKTREE_LEASE_TTL_MS,
+          metadata: { repoUrl, branch },
+        });
+      } catch (err) {
+        console.warn(`[RepoPool] claimExecutionResourceLease failed for ${repoKey} holder=${leaseHolderId}: ${err}`);
+        leaseHolderId = undefined;
+      }
+      if (leaseHolderId && !claimed) {
+        throw new ResourceLimitError(
+          `Worktree limit reached for ${repoUrl}: lease capacity exhausted (max ${this.maxWorktrees})`,
+        );
+      }
+    } else {
+      leaseHolderId = undefined;
+    }
+
     const sanitized = sanitizeBranchForPath(branch);
     const urlHash = computeRepoCacheHash(repoUrl);
     const worktreePath = this.worktreeBaseDir
@@ -994,6 +1063,15 @@ export class RepoPool {
       activeCount: active.size,
     });
 
+    const releaseLeaseBestEffort = () => {
+      if (!leaseHolderId) return;
+      try {
+        this.leasePersistence?.releaseExecutionResourceLease(repoKey, leaseHolderId);
+      } catch (err) {
+        console.warn(`[RepoPool] releaseExecutionResourceLease failed for ${repoKey} holder=${leaseHolderId}: ${err}`);
+      }
+    };
+
     const release = async () => {
       try {
         await this.execGit(['worktree', 'remove', '--force', effectivePath], clonePath);
@@ -1001,12 +1079,24 @@ export class RepoPool {
         try { await this.execGit(['worktree', 'prune'], clonePath); } catch { /* best-effort */ }
       }
       active.delete(effectivePath);
+      releaseLeaseBestEffort();
     };
 
-    const softRelease = () => { active.delete(effectivePath); };
+    const softRelease = () => {
+      active.delete(effectivePath);
+      releaseLeaseBestEffort();
+    };
 
     bench('RepoPool.doAcquireWorktree.returning', { effectivePath });
-    return { clonePath, worktreePath: effectivePath, branch, release, softRelease };
+    return {
+      clonePath,
+      worktreePath: effectivePath,
+      branch,
+      release,
+      softRelease,
+      leaseResourceKey: leaseHolderId ? repoKey : undefined,
+      leaseHolderId,
+    };
   }
 
   /** Get the deterministic clone directory path for a given repo URL. */

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -357,6 +357,18 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         bench('WorktreeExecutor.mergeRequestUpstreamBranches.failed', {
           error: err instanceof Error ? err.message : String(err),
         });
+        // No WorktreeEntry exists yet for this failure (registration happens
+        // further below) — release the acquired slot directly so it doesn't
+        // leak for the life of this process. Soft release only: keep the
+        // workspace on disk, matching the post-registration
+        // provisioning-failure path's "keep for debugging" behavior below.
+        try {
+          acquired.softRelease();
+        } catch (releaseErr) {
+          console.warn(
+            `[WorktreeExecutor] softRelease failed after upstream-merge error for ${acquired.worktreePath}: ${releaseErr}`,
+          );
+        }
         throw err;
       }
     }


### PR DESCRIPTION
## Summary

RepoPool.activeWorktrees, which tracks worktree-slot capacity, is a bare in-memory Set with no persistence and no crash-safety.

SSH pool-member capacity already avoids this problem: it uses a DB-backed lease in execution_resource_leases, with a TTL, heartbeat renewal, and startup/poll sweeps.

This PR reuses that same table and its lease primitives for worktree slots, since resourceKey/resourceType/maxHolders are already generic, not SSH-specific.

An optional leasePersistence hook on RepoPoolConfig claims a lease alongside the existing in-memory Set, when a caller supplies both persistence and a leaseHolderId.

The DB lease never grants more capacity than the Set already allows, and releases on both release() and softRelease().

Nothing calls this yet with a real holder id. The next PR wires the actual executor flow through it.

## Review Claim

Add DB-backed lease capacity to RepoPool worktree slots, additive to the existing in-memory Set, with zero behavior change for any caller that doesn't opt in.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Every existing repo-pool.test.ts case constructs RepoPool with no persistence and is provably unaffected (all 42 pre-existing tests still pass unmodified); the new lease claim is skipped entirely (not a hard failure) when persistence or a leaseHolderId is absent, so it can only ever add a capacity check, never remove one.

## Slice Rationale

Split from the executor wiring in the next PR because this PR is purely additive capability on RepoPool in isolation (its own tests construct RepoPool directly and pass leaseHolderId manually) — the next PR is a separate claim about wiring a real caller through it and reusing the existing SSH renewal/release path.

## Non-goals

Does not wire any real executor through leaseHolderId. Does not touch the separate ExecutionPoolMember-type 'worktree' pool-member concept (used only when task.config.poolId selects among configured worktreeTargets) — that is a different capacity dimension (tasks-per-target vs. worktrees-per-repo) and out of scope for this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test -- repo-pool` — 42/42 tests pass, including 4 new lease-persistence tests (claim+release via softRelease, claim+release via full release, ResourceLimitError on exhausted lease, degrade-to-in-memory-only when no leaseHolderId)
- [ ] `cd packages/data-store && pnpm build` — clean build, confirms the new WORKTREE_LEASE_TTL_MS export
- [ ] `cd packages/execution-engine && pnpm build` — clean build, confirms RepoPool's new types compile against @invoker/data-store

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No — no schema change, reuses the existing execution_resource_leases table

</details>
