### PR TITLE
[EMBARGO: Worktree lease generalization](4) feat: renew/release worktree leases via the existing SSH lease path

### DIFF
--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -245,6 +245,14 @@ export type WorkflowMutationPriority = 'high' | 'normal';
 export type WorkflowMutationIntentStatus = 'queued' | 'running' | 'completed' | 'failed';
 export const WORKFLOW_MUTATION_LEASE_MS = 30_000;
 export const EXECUTION_RESOURCE_LEASE_MS = 20 * 60 * 1000;
+/**
+ * TTL for worktree-slot leases (`resource_type: 'worktree'`). Shorter than
+ * `EXECUTION_RESOURCE_LEASE_MS` (SSH) because worktree acquisition churns much
+ * faster; sized as a safe multiple of the default executor heartbeat interval
+ * (`DEFAULT_HEARTBEAT_INTERVAL_MS` in base-executor.ts, 30s) so a live task's
+ * lease never expires between renewals.
+ */
+export const WORKTREE_LEASE_TTL_MS = 3 * 60 * 1000;
 
 export interface ExecutionResourceLease {
   resourceKey: string;

--- a/packages/execution-engine/src/__tests__/repo-pool.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-pool.test.ts
@@ -409,6 +409,98 @@ describe('RepoPool', () => {
     await limitedPool.destroyAll();
   });
 
+  describe('lease persistence (DB-backed worktree slots)', () => {
+    /** Minimal in-memory stand-in for the execution_resource_leases table. */
+    function makeFakeLeasePersistence() {
+      const rows = new Map<string, { resourceKey: string; holderId: string }>();
+      return {
+        rows,
+        claimExecutionResourceLease: vi.fn((options: {
+          resourceKey: string;
+          resourceType: string;
+          holderId: string;
+          maxHolders?: number;
+        }) => {
+          const key = `${options.resourceKey}::${options.holderId}`;
+          if (rows.has(key)) return true;
+          const maxHolders = Math.max(1, options.maxHolders ?? 1);
+          const otherHolders = [...rows.values()].filter((r) => r.resourceKey === options.resourceKey).length;
+          if (otherHolders >= maxHolders) return false;
+          rows.set(key, { resourceKey: options.resourceKey, holderId: options.holderId });
+          return true;
+        }),
+        releaseExecutionResourceLease: vi.fn((resourceKey: string, holderId: string) => {
+          rows.delete(`${resourceKey}::${holderId}`);
+        }),
+      };
+    }
+
+    it('claims a lease on acquire and releases it on softRelease', async () => {
+      const leasePersistence = makeFakeLeasePersistence();
+      const limitedPool = new RepoPool({ cacheDir: tmpDir, maxWorktrees: 1, leasePersistence });
+      const wt = await limitedPool.acquireWorktree(localRepoUrl, 'branch-lease-1', undefined, undefined, {
+        leaseHolderId: 'attempt-1',
+      });
+
+      expect(leasePersistence.claimExecutionResourceLease).toHaveBeenCalledWith(
+        expect.objectContaining({ resourceType: 'worktree', holderId: 'attempt-1', maxHolders: 1 }),
+      );
+      expect(wt.leaseHolderId).toBe('attempt-1');
+      expect(leasePersistence.rows.size).toBe(1);
+
+      wt.softRelease();
+      expect(leasePersistence.releaseExecutionResourceLease).toHaveBeenCalledWith(wt.leaseResourceKey, 'attempt-1');
+      expect(leasePersistence.rows.size).toBe(0);
+      await limitedPool.destroyAll();
+    });
+
+    it('claims a lease on acquire and releases it on full release', async () => {
+      const leasePersistence = makeFakeLeasePersistence();
+      const limitedPool = new RepoPool({ cacheDir: tmpDir, maxWorktrees: 1, leasePersistence });
+      const wt = await limitedPool.acquireWorktree(localRepoUrl, 'branch-lease-2', undefined, undefined, {
+        leaseHolderId: 'attempt-2',
+      });
+      expect(leasePersistence.rows.size).toBe(1);
+
+      await wt.release();
+      expect(leasePersistence.rows.size).toBe(0);
+    });
+
+    it('throws ResourceLimitError when the DB lease is exhausted, without mutating the in-memory Set beyond it', async () => {
+      const leasePersistence = makeFakeLeasePersistence();
+      // Pre-fill the DB lease for this repo as already held by a different holder,
+      // simulating a slot reserved by another process instance.
+      const limitedPool = new RepoPool({ cacheDir: tmpDir, maxWorktrees: 5, leasePersistence });
+      leasePersistence.rows.set('bootstrap-key::other-holder', { resourceKey: 'bootstrap-key', holderId: 'other-holder' });
+      // Use the pool's own repo-key computation via a real acquire first, then
+      // saturate the DB lease at maxHolders=5 with distinct external holders.
+      const wt1 = await limitedPool.acquireWorktree(localRepoUrl, 'branch-lease-3a', undefined, undefined, {
+        leaseHolderId: 'attempt-3a',
+      });
+      const repoKey = wt1.leaseResourceKey!;
+      for (let i = 0; i < 4; i += 1) {
+        leasePersistence.rows.set(`${repoKey}::external-${i}`, { resourceKey: repoKey, holderId: `external-${i}` });
+      }
+      // In-memory Set only has 1 active worktree (well under maxWorktrees=5),
+      // but the DB lease is now saturated (1 real + 4 external = 5).
+      await expect(
+        limitedPool.acquireWorktree(localRepoUrl, 'branch-lease-3b', undefined, undefined, {
+          leaseHolderId: 'attempt-3b',
+        }),
+      ).rejects.toThrow(ResourceLimitError);
+      await limitedPool.destroyAll();
+    });
+
+    it('degrades to in-memory-only capacity when no leaseHolderId is supplied, even with persistence configured', async () => {
+      const leasePersistence = makeFakeLeasePersistence();
+      const limitedPool = new RepoPool({ cacheDir: tmpDir, maxWorktrees: 2, leasePersistence });
+      const wt = await limitedPool.acquireWorktree(localRepoUrl, 'branch-lease-4');
+      expect(leasePersistence.claimExecutionResourceLease).not.toHaveBeenCalled();
+      expect(wt.leaseResourceKey).toBeUndefined();
+      await limitedPool.destroyAll();
+    });
+  });
+
   it('reconcileActiveWorktrees clears stale slot reservations', async () => {
     const limitedPool = new RepoPool({ cacheDir: tmpDir, maxWorktrees: 1 });
     const wt1 = await limitedPool.acquireWorktree(localRepoUrl, 'branch-stale');

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -1157,6 +1157,46 @@ describe('WorktreeExecutor', () => {
 
       await expect(executor.start(request)).rejects.toThrow();
     });
+
+    it('BUG: leaks the acquired worktree slot when the upstream merge fails for a non-conflict reason', async () => {
+      setupSpawnMock();
+      const pool = mockPool(executor);
+
+      vi.mocked((BaseExecutor.prototype as any).runBash).mockImplementation(
+        async (script: string) => {
+          if (script.includes('PRESERVED=')) {
+            return 'PRESERVED=0\nBASE_SHA=abc123\n';
+          }
+          if (script.includes('Invoker: merge')) {
+            const err = new Error('bash exited with code 30: missing ref');
+            (err as any).exitCode = 30;
+            (err as any).stderr = 'MISSING_REF=experiment/nonexistent-branch';
+            throw err;
+          }
+          return '';
+        },
+      );
+
+      const request = makeRequest({
+        inputs: {
+          command: 'echo hello',
+          upstreamBranches: ['experiment/dep-parent', 'experiment/nonexistent-branch'],
+          upstreamBase: {
+            branch: 'experiment/dep-parent',
+            commitHash: '5555555555555555555555555555555555555555',
+          },
+        },
+      });
+
+      await expect(executor.start(request)).rejects.toThrow();
+
+      // start() throws here before any WorktreeEntry is registered, so the
+      // acquired worktree slot is never freed — it leaks for the life of the
+      // process. This documents the CURRENT (buggy) behavior; the next PR in
+      // this stack fixes it and flips this assertion.
+      const acquired = await pool.acquireWorktree.mock.results[0]!.value;
+      expect(acquired.softRelease).not.toHaveBeenCalled();
+    });
   });
 
   describe('agent registry validation', () => {

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -906,7 +906,7 @@ describe('WorktreeExecutor', () => {
         expect.any(String),
         expect.any(String),
         'action-1',
-        { forceFresh: true },
+        { forceFresh: true, leaseHolderId: 'action-1' },
       );
 
       taskProcess.emit('close', 0, null);

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -1158,7 +1158,7 @@ describe('WorktreeExecutor', () => {
       await expect(executor.start(request)).rejects.toThrow();
     });
 
-    it('BUG: leaks the acquired worktree slot when the upstream merge fails for a non-conflict reason', async () => {
+    it('releases the acquired worktree slot when the upstream merge fails for a non-conflict reason', async () => {
       setupSpawnMock();
       const pool = mockPool(executor);
 
@@ -1190,12 +1190,12 @@ describe('WorktreeExecutor', () => {
 
       await expect(executor.start(request)).rejects.toThrow();
 
-      // start() throws here before any WorktreeEntry is registered, so the
-      // acquired worktree slot is never freed — it leaks for the life of the
-      // process. This documents the CURRENT (buggy) behavior; the next PR in
-      // this stack fixes it and flips this assertion.
+      // Regression test: start() throws here before any WorktreeEntry is
+      // registered, so the only way the acquired worktree slot gets freed is
+      // the try/catch around mergeRequestUpstreamBranches releasing it
+      // directly. Without that fix, this slot leaks for the life of the process.
       const acquired = await pool.acquireWorktree.mock.results[0]!.value;
-      expect(acquired.softRelease).not.toHaveBeenCalled();
+      expect(acquired.softRelease).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/execution-engine/src/executor.ts
+++ b/packages/execution-engine/src/executor.ts
@@ -11,6 +11,14 @@ export interface ExecutorHandle {
   containerId?: string;
   workspacePath?: string;
   branch?: string;
+  /**
+   * Set when this executor claimed a DB-backed resource lease during
+   * start() (e.g. a worktree slot) that dispatch should renew on heartbeat
+   * and release on completion via the generic `activeExecution.leaseResourceKey`/
+   * `leaseHolderId` path already used for SSH pool-member leases.
+   */
+  leaseResourceKey?: string;
+  leaseHolderId?: string;
 }
 
 export interface TerminalSpec {

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -20,12 +20,38 @@ import { remoteFetchForPool } from './remote-fetch-policy.js';
 import { isWorkspaceCleanupEnabled } from './workspace-cleanup-policy.js';
 import { computeRepoCacheHash, computeRepoCacheKey, sanitizeBranchForPath } from './git-utils.js';
 import { cleanGitRepositoryEnv } from './process-utils.js';
+import { WORKTREE_LEASE_TTL_MS } from '@invoker/data-store';
+
+/**
+ * Minimal lease surface RepoPool needs, matching `SQLiteAdapter`'s
+ * `execution_resource_leases` methods. Kept structural (not imported as
+ * `SQLiteAdapter`) so RepoPool stays constructible without persistence, as
+ * every existing `repo-pool.test.ts` case already does.
+ */
+export interface RepoPoolLeasePersistence {
+  claimExecutionResourceLease(options: {
+    resourceKey: string;
+    resourceType: string;
+    holderId: string;
+    maxHolders?: number;
+    leaseMs?: number;
+    metadata?: unknown;
+  }): boolean;
+  releaseExecutionResourceLease(resourceKey: string, holderId: string): void;
+}
 
 export interface RepoPoolConfig {
   cacheDir: string;
   maxWorktrees?: number;
   /** When set, worktrees are created here instead of inside the clone. */
   worktreeBaseDir?: string;
+  /**
+   * Optional DB-backed lease authority for worktree slots, mirroring the SSH
+   * pool-member lease in `execution_resource_leases`. Additive: the in-memory
+   * `activeWorktrees` Set stays the primary capacity gate for callers that
+   * don't pass this (e.g. unit tests constructing RepoPool directly).
+   */
+  leasePersistence?: RepoPoolLeasePersistence;
 }
 
 export interface RepoPoolTiming {
@@ -40,6 +66,9 @@ export interface AcquiredWorktree {
   release: () => Promise<void>;
   /** Free the pool slot without removing the worktree from disk. */
   softRelease: () => void;
+  /** Set only when a DB-backed worktree lease was actually claimed. */
+  leaseResourceKey?: string;
+  leaseHolderId?: string;
 }
 
 export interface AcquireWorktreeOptions {
@@ -48,6 +77,13 @@ export interface AcquireWorktreeOptions {
     branch: string;
     workspacePath: string;
   };
+  /**
+   * Identity for the DB-backed worktree lease (e.g. the task attempt id).
+   * Required for this acquisition to claim a lease even when
+   * `RepoPoolConfig.leasePersistence` is configured — without it, capacity
+   * is enforced by the in-memory Set only, same as today.
+   */
+  leaseHolderId?: string;
 }
 
 interface RebaseRefreshBatch {
@@ -81,6 +117,7 @@ export class RepoPool {
   private readonly cacheDir: string;
   private readonly maxWorktrees: number;
   private readonly worktreeBaseDir?: string;
+  private readonly leasePersistence?: RepoPoolLeasePersistence;
   private activeWorktrees = new Map<string, Set<string>>();
   private cloneLocks = new Map<string, Promise<string>>();
   /** Chain of operations per repo to serialize git operations. */
@@ -91,6 +128,7 @@ export class RepoPool {
     this.cacheDir = config.cacheDir;
     this.maxWorktrees = config.maxWorktrees ?? 5;
     this.worktreeBaseDir = config.worktreeBaseDir;
+    this.leasePersistence = config.leasePersistence;
   }
 
   private cloneDir(repoUrl: string): string {
@@ -766,6 +804,37 @@ export class RepoPool {
     if (active.size >= this.maxWorktrees) {
       throw new ResourceLimitError(`Worktree limit reached for ${repoUrl}: ${active.size}/${this.maxWorktrees}`);
     }
+
+    // DB-backed lease: additive to the in-memory Set above, never a way to
+    // grant more capacity than it already allows. Skipped (not a hard
+    // failure) when persistence or a holder id isn't supplied, so every
+    // existing no-persistence caller (all current repo-pool.test.ts cases)
+    // behaves exactly as before.
+    let leaseHolderId: string | undefined = opts?.leaseHolderId;
+    if (this.leasePersistence && leaseHolderId) {
+      let claimed = true;
+      try {
+        claimed = this.leasePersistence.claimExecutionResourceLease({
+          resourceKey: repoKey,
+          resourceType: 'worktree',
+          holderId: leaseHolderId,
+          maxHolders: this.maxWorktrees,
+          leaseMs: WORKTREE_LEASE_TTL_MS,
+          metadata: { repoUrl, branch },
+        });
+      } catch (err) {
+        console.warn(`[RepoPool] claimExecutionResourceLease failed for ${repoKey} holder=${leaseHolderId}: ${err}`);
+        leaseHolderId = undefined;
+      }
+      if (leaseHolderId && !claimed) {
+        throw new ResourceLimitError(
+          `Worktree limit reached for ${repoUrl}: lease capacity exhausted (max ${this.maxWorktrees})`,
+        );
+      }
+    } else {
+      leaseHolderId = undefined;
+    }
+
     const sanitized = sanitizeBranchForPath(branch);
     const urlHash = computeRepoCacheHash(repoUrl);
     const worktreePath = this.worktreeBaseDir
@@ -994,6 +1063,15 @@ export class RepoPool {
       activeCount: active.size,
     });
 
+    const releaseLeaseBestEffort = () => {
+      if (!leaseHolderId) return;
+      try {
+        this.leasePersistence?.releaseExecutionResourceLease(repoKey, leaseHolderId);
+      } catch (err) {
+        console.warn(`[RepoPool] releaseExecutionResourceLease failed for ${repoKey} holder=${leaseHolderId}: ${err}`);
+      }
+    };
+
     const release = async () => {
       try {
         await this.execGit(['worktree', 'remove', '--force', effectivePath], clonePath);
@@ -1001,12 +1079,24 @@ export class RepoPool {
         try { await this.execGit(['worktree', 'prune'], clonePath); } catch { /* best-effort */ }
       }
       active.delete(effectivePath);
+      releaseLeaseBestEffort();
     };
 
-    const softRelease = () => { active.delete(effectivePath); };
+    const softRelease = () => {
+      active.delete(effectivePath);
+      releaseLeaseBestEffort();
+    };
 
     bench('RepoPool.doAcquireWorktree.returning', { effectivePath });
-    return { clonePath, worktreePath: effectivePath, branch, release, softRelease };
+    return {
+      clonePath,
+      worktreePath: effectivePath,
+      branch,
+      release,
+      softRelease,
+      leaseResourceKey: leaseHolderId ? repoKey : undefined,
+      leaseHolderId,
+    };
   }
 
   /** Get the deterministic clone directory path for a given repo URL. */

--- a/packages/execution-engine/src/task-runner-dispatch.ts
+++ b/packages/execution-engine/src/task-runner-dispatch.ts
@@ -370,8 +370,12 @@ export async function dispatchExecutor(
     taskId: task.id,
     poolId: poolSelection?.poolId,
     poolMemberKey: poolSelection?.memberKey,
-    leaseResourceKey: poolSelection?.leaseResourceKey,
-    leaseHolderId: poolSelection?.leaseHolderId,
+    // Prefer the handle's own lease (claimed inside executor.start(), e.g. a
+    // worktree slot) over poolSelection's (claimed before start(), SSH-only
+    // today) — both feed the same generic heartbeat-renewal/finalize-release
+    // path below, so either executor type gets crash-safe leases for free.
+    leaseResourceKey: activeHandle.leaseResourceKey ?? poolSelection?.leaseResourceKey,
+    leaseHolderId: activeHandle.leaseHolderId ?? poolSelection?.leaseHolderId,
   });
   host.logger.info(
     `[TaskRunner] active execution registered task=${task.id} attempt=${attemptId} ` +

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -719,6 +719,7 @@ export function selectExecutor(
         agentRegistry: host.executionAgentRegistry,
         provisionCommand: selectedWorktreeTarget?.provisionCommand,
         repoProvisionCommands,
+        leasePersistence: host.persistence,
       });
       host.executorRegistry.register('worktree', worktree);
       host.worktreeExecutorCache.set(configFingerprint, worktree);

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -357,6 +357,18 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         bench('WorktreeExecutor.mergeRequestUpstreamBranches.failed', {
           error: err instanceof Error ? err.message : String(err),
         });
+        // No WorktreeEntry exists yet for this failure (registration happens
+        // further below) — release the acquired slot directly so it doesn't
+        // leak for the life of this process. Soft release only: keep the
+        // workspace on disk, matching the post-registration
+        // provisioning-failure path's "keep for debugging" behavior below.
+        try {
+          acquired.softRelease();
+        } catch (releaseErr) {
+          console.warn(
+            `[WorktreeExecutor] softRelease failed after upstream-merge error for ${acquired.worktreePath}: ${releaseErr}`,
+          );
+        }
         throw err;
       }
     }

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -5,7 +5,7 @@ import { homedir } from 'node:os';
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
 import { BaseExecutor, MergeConflictError, type BaseEntry } from './base-executor.js';
-import { RepoPool } from './repo-pool.js';
+import { RepoPool, type RepoPoolLeasePersistence } from './repo-pool.js';
 import { killProcessGroup, cleanElectronEnv, resolveExecutableOnCurrentPath, SIGKILL_TIMEOUT_MS } from './process-utils.js';
 import { DEFAULT_WORKTREE_PROVISION_COMMAND } from './default-worktree-provision-command.js';
 import { getExecutorStartTimeoutMs } from './task-runner-launch-support.js';
@@ -51,6 +51,8 @@ export interface WorktreeExecutorConfig {
   heartbeatIntervalMs?: number;
   /** Maximum task duration in milliseconds. Default: 4 hours. */
   maxDurationMs?: number;
+  /** Optional DB-backed lease authority for worktree slots (see RepoPoolConfig). */
+  leasePersistence?: RepoPoolLeasePersistence;
 }
 
 
@@ -69,6 +71,9 @@ interface WorktreeEntry extends BaseEntry {
   agentName?: string;
   rawStdout?: string;
   poolSlotReleased?: boolean;
+  /** Set only when the acquired worktree claimed a DB-backed lease. */
+  leaseResourceKey?: string;
+  leaseHolderId?: string;
 }
 
 /**
@@ -96,6 +101,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       cacheDir: config.cacheDir,
       maxWorktrees: config.maxWorktrees,
       worktreeBaseDir: this.worktreeBaseDir,
+      leasePersistence: config.leasePersistence,
     });
   }
 
@@ -233,6 +239,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         request.actionId,
         {
           forceFresh: request.inputs.freshWorkspace === true,
+          leaseHolderId: request.attemptId ?? request.actionId,
           ...(request.inputs.reusableWorktree
             ? { reusableWorktree: request.inputs.reusableWorktree }
             : {}),
@@ -259,10 +266,14 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         completed: false,
         poolRelease: acquired.release,
         poolSoftRelease: acquired.softRelease,
+        leaseResourceKey: acquired.leaseResourceKey,
+        leaseHolderId: acquired.leaseHolderId,
       };
       this.registerEntry(handle, entry);
       handle.workspacePath = acquired.worktreePath;
       handle.branch = acquired.branch;
+      handle.leaseResourceKey = acquired.leaseResourceKey;
+      handle.leaseHolderId = acquired.leaseHolderId;
       bench('WorktreeExecutor.registerEntry.reconciliation.done', {
         workspacePath: handle.workspacePath,
         branch: handle.branch,
@@ -301,6 +312,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       request.actionId,
       {
         forceFresh: request.inputs.freshWorkspace === true,
+        leaseHolderId: request.attemptId ?? request.actionId,
         ...(request.inputs.reusableWorktree
           ? { reusableWorktree: request.inputs.reusableWorktree }
           : {}),
@@ -331,10 +343,14 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
             completed: true,
             poolRelease: acquired.release,
             poolSoftRelease: acquired.softRelease,
+            leaseResourceKey: acquired.leaseResourceKey,
+            leaseHolderId: acquired.leaseHolderId,
           };
           this.registerEntry(handle, entry);
           handle.workspacePath = acquired.worktreePath;
           handle.branch = acquired.branch;
+          handle.leaseResourceKey = acquired.leaseResourceKey;
+          handle.leaseHolderId = acquired.leaseHolderId;
           const response: WorkResponse = {
             requestId: request.requestId,
             actionId: request.actionId,
@@ -384,10 +400,14 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         completed: false,
         poolRelease: acquired.release,
         poolSoftRelease: acquired.softRelease,
+        leaseResourceKey: acquired.leaseResourceKey,
+        leaseHolderId: acquired.leaseHolderId,
       };
       this.registerEntry(handle, entry);
       handle.workspacePath = acquired.worktreePath;
       handle.branch = acquired.branch;
+      handle.leaseResourceKey = acquired.leaseResourceKey;
+      handle.leaseHolderId = acquired.leaseHolderId;
       bench('WorktreeExecutor.registerEntry.noCommand.done', {
         workspacePath: handle.workspacePath,
         branch: handle.branch,
@@ -414,10 +434,14 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       completed: false,
       poolRelease: acquired.release,
       poolSoftRelease: acquired.softRelease,
+      leaseResourceKey: acquired.leaseResourceKey,
+      leaseHolderId: acquired.leaseHolderId,
     };
     this.registerEntry(handle, entry);
     handle.workspacePath = acquired.worktreePath;
     handle.branch = acquired.branch;
+    handle.leaseResourceKey = acquired.leaseResourceKey;
+    handle.leaseHolderId = acquired.leaseHolderId;
     bench('WorktreeExecutor.registerEntry.provisioning.done', {
       workspacePath: handle.workspacePath,
       branch: handle.branch,


### PR DESCRIPTION
## Summary

The previous PR added lease-claiming capability to RepoPool, but nothing calls it with a real holder id yet.

This PR wires WorktreeExecutor to pass a leaseHolderId (the task attempt id) into every acquireWorktree() call, and threads host.persistence through as RepoPoolConfig.leasePersistence.

The claimed lease's resourceKey/holderId are carried on the ExecutorHandle and preferred over poolSelection's in the dispatcher's active-execution registration.

The heartbeat-renewal handler and the finalize-time release already read those fields generically, with no check on executor type.

A worktree task's lease now renews and releases exactly like an SSH pool-member lease does today, with no new renewal or release code required.

## Review Claim

Wire the RepoPool lease claim into WorktreeExecutor and the dispatcher's existing generic lease-renewal/release path, so worktree leases renew and release exactly like SSH leases do today.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Renewal and release calls stay best-effort (the same optional-chaining pattern already used for SSH leases), so a persistence hiccup degrades to "the lease expires and gets swept later" and can never leave a task stuck or failing solely because of the lease layer.

## Slice Rationale

Kept separate from the RepoPool capability PR: that PR's claim is "RepoPool can claim a lease when asked," fully testable in isolation; this PR's claim is "a real caller asks it to, and the existing SSH renewal machinery picks it up for free" — a different, dispatcher-facing seam.

## Non-goals

Does not add a new renewal loop or a worktree-specific release path — both are intentionally reused unchanged from the existing SSH lease code. Does not change the separate ExecutionPoolMember-type 'worktree' pool-selection concept.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test -- worktree-executor ssh-pool-member-capacity ssh-lease-capacity pool-capacity-superseded` — 111/111 tests pass, confirming SSH lease behavior is unaffected
- [ ] `cd packages/execution-engine && pnpm build` — clean build

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
