### PR TITLE
[CI regression: f84c1ed-required-fast-mergify-admin-requeue](1) Repair review-gate command hook

### DIFF
--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 import json
 import os
 import shlex
+import subprocess
 import tempfile
 from pathlib import Path
 
 try:
+    from .mergify_admin_requeue_headless_shell import DEFAULT_TIMEOUT_SECONDS
     from .mergify_admin_requeue_headless_shell import run_headless as _run_headless
 except ImportError:
+    from mergify_admin_requeue_headless_shell import DEFAULT_TIMEOUT_SECONDS
     from mergify_admin_requeue_headless_shell import run_headless as _run_headless
 
 
@@ -19,7 +22,21 @@ def resolve_workflow_for_pr(pr_number: int) -> str | None:
     # exception rather than silently falling back to ad-hoc repair.
     review_gate_cmd = os.environ.get("INVOKER_PR_CRON_REVIEW_GATE_CMD")
     if review_gate_cmd:
-        completed = _run_headless('"$2" "$3"', review_gate_cmd, str(pr_number))
+        try:
+            completed = subprocess.run(
+                [review_gate_cmd, str(pr_number)],
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            completed = subprocess.CompletedProcess(
+                [review_gate_cmd, str(pr_number)],
+                returncode=124,
+                stdout="",
+                stderr=f"timed out after {DEFAULT_TIMEOUT_SECONDS}s",
+            )
     else:
         completed = _run_headless('headless_query query review-gate "$2" --output json', str(pr_number))
     if completed.returncode != 0:

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -1139,16 +1139,11 @@ class WorkflowFastpathTests(unittest.TestCase):
     def test_resolve_workflow_for_pr_honors_review_gate_test_seam(self):
         completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="{}\n", stderr="")
         with mock.patch.dict(os.environ, {"INVOKER_PR_CRON_REVIEW_GATE_CMD": "/tmp/review-gate"}):
-            with mock.patch.object(headless_shell.subprocess, "run", return_value=completed) as run:
+            with mock.patch.object(fastpath.subprocess, "run", return_value=completed) as run:
                 result = fastpath.resolve_workflow_for_pr(6579)
         self.assertIsNone(result)
-        args = run.call_args.args[0]
-        self.assertEqual(args[0], "bash")
-        self.assertEqual(args[1], "-c")
-        self.assertIn('"$2" "$3"', args[2])
-        self.assertIn("headless-lib.sh", " ".join(str(part) for part in args))
-        self.assertIn("/tmp/review-gate", args)
-        self.assertIn("6579", args)
+        self.assertEqual(run.call_args.args[0], ["/tmp/review-gate", "6579"])
+        self.assertEqual(run.call_args.kwargs["timeout"], headless_shell.DEFAULT_TIMEOUT_SECONDS)
 
     def test_resolve_workflow_for_pr_raises_on_lookup_failure(self):
         completed = subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="boom")


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=f84c1edddd8a844b88c7b89f60731700db0651a4; job=required-fast / Mergify Admin Requeue -->

CI job `required-fast / Mergify Admin Requeue` first failed on default-branch commit f84c1edddd8a844b88c7b89f60731700db0651a4 in run 31289002425.

It was most recently still red at 4da49fe68c12f5cd76cdb8fa5dc294c24fae3ae7 in run 31299064557.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31289002425/job/93183826094

The review-gate test command now runs directly with the PR number and the normal headless timeout.

That keeps the required-fast proof harness aligned with the injected command behavior it tests.

## Review Claim

Approve the admin requeue review-gate command hook repair and its focused regression assertion.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change is limited to the admin requeue fastpath command hook and its unit coverage.

## Slice Rationale

One tooling-policy slice repairs the failing required-fast admin requeue command path without bundling unrelated queue behavior.

## Non-goals

- No product runtime behavior changes.
- No visible application behavior changes.
- No unrelated admin requeue cleanup.
- No test weakening or snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ci-regression-f84c1ed-required-fast-mergify-admin-requeue-pr1.md`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ci-regression-f84c1ed-required-fast-mergify-admin-requeue-pr1.md --changed-files-file /tmp/ci-regression-f84c1ed-required-fast-mergify-admin-requeue-pr1-files.txt --diff-file /tmp/ci-regression-f84c1ed-required-fast-mergify-admin-requeue-pr1.diff`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/12-mergify-admin-requeue.sh` passed in workflow task `wf-1786279575105-27/verify-ci-f84c1ed-required-fast-mergify-admin-requeue`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert dc2696f05`
- Post-revert steps: Re-run `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/12-mergify-admin-requeue.sh`.
- Data migration? No

</details>
