### PR TITLE
[Invoker-cli standalone skill install](1) Bundle skills/ into the CLI release tarball

### DIFF
--- a/scripts/archive-cli-binary.sh
+++ b/scripts/archive-cli-binary.sh
@@ -19,6 +19,7 @@ mkdir -p "$STAGE/$NAME"
 cp "$BINARY" "$STAGE/$NAME/invoker-cli"
 chmod +x "$STAGE/$NAME/invoker-cli"
 cp "$ROOT/packages/cli/README.md" "$STAGE/$NAME/README.md"
+cp -r "$ROOT/skills" "$STAGE/$NAME/skills"
 
 (cd "$STAGE" && tar -czf "$RELEASE_DIR/$NAME.tar.gz" "$NAME")
 rm -rf "$STAGE"


### PR DESCRIPTION
## Summary

The standalone release tarball only ever shipped the binary and one short usage-instructions file.

It had nowhere to source the bundled first-party AI helper skills from once installed outside a repo checkout.

This adds a `skills/` directory alongside the binary in the release archive, so a later slice can teach the standalone binary to find it there.

## Review Claim

Approve adding one `cp -r skills/` step to `scripts/archive-cli-binary.sh`, with no other change to what gets built or archived.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only adds a single `cp -r` step to the existing archive-staging sequence in `scripts/archive-cli-binary.sh`. No other packaging step, the binary build itself, or `packages/npm-cli`'s install flow changes in this slice.

## Slice Rationale

Foundation slice: the packaging change that makes the next slice's fallback resolution actually find real skill files, stacked first so it lands and is verifiable before any code depends on it.

## Non-goals

- No change to which files ship in `vendor/.gitkeep` or the binary build itself.
- No change to `packages/npm-cli`'s install/extraction logic (next slice).
- No change to any CLI runtime behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash -n scripts/archive-cli-binary.sh` — script still parses.
- [x] Manual read-through: the added `cp -r "$ROOT/skills" "$STAGE/$NAME/skills"` line sits alongside the existing binary/usage-file copy steps, before the `tar -czf` invocation, so it is included in the produced archive the same way the other staged files are.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — the next release build simply stops including `skills/` in the tarball again.
- Data migration? No

</details>
