### PR TITLE
[Invoker-cli standalone skill install](3) Document invoker-cli setup as the one-command install

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Spread work across SSH targets and remote machines you already manage — same a
 
 Invoker background work is owned by the built-in worker registry. `autofix` is the default failed-task recovery worker; it reconciles persisted state and submits normal `fix-with-agent` intents instead of running recovery from task-state producers.
 
-Run workers on the Invoker owner host. Operators can start and stop them from the desktop Workers tab, inspect them with `./run.sh --headless worker status --output text|json|jsonl`, or trigger one explicit scan with `./run.sh --headless worker <kind>`. Each kind takes its own single-instance lock, so a second scan of the same worker is refused without blocking other worker kinds.
+Run workers on the Invoker owner host. Operators can start and stop them from the desktop Workers tab, inspect them with `invoker-ui --headless worker status --output text|json|jsonl`, or trigger one explicit scan with `invoker-ui --headless worker <kind>`. Each kind takes its own single-instance lock, so a second scan of the same worker is refused without blocking other worker kinds.
 
 PR maintenance uses the same owner-host worker path. Enable `prMaintenance` to launch `pr-admin-bypass-land`, keep `pr-orphan-repair` available from the same built-in registry, and do not install separate cron jobs or external worker launchers for the supported setup.
 
@@ -110,15 +110,12 @@ PR maintenance uses the same owner-host worker path. Enable `prMaintenance` to l
 npm install -g @neko-catpital-labs/invoker-ui
 npm install -g @neko-catpital-labs/invoker-cli
 npm install -g @neko-catpital-labs/invoker-slack
+invoker-cli setup
 ```
 
 Or grab desktop builds and standalone binaries from [GitHub Releases](https://github.com/Neko-Catpital-Labs/Invoker/releases/latest). Full install, config, and source checkout steps: [Getting started](docs/getting-started.md).
 
-Packaged installs bundle the first-party Invoker AI helpers inside the app. Install helpers from System Setup or:
-
-```bash
-invoker-ui --install-skills
-```
+`invoker-cli setup` installs the first-party Invoker AI helper skills, registers the Invoker MCP server with Codex, Claude, Cursor, and OMP, and walks through the rest of onboarding (Slack integration, GitHub auth, a smoke-test plan run).
 
 Then, in Codex, Claude, Cursor, or OMP, run:
 
@@ -140,7 +137,7 @@ The command plans first, writes `plans/invoker-handoff.md`, converts it to `plan
 
 More: [local macOS release build](docs/local-macos-release-build.md), [remote SSH targets](docs/remote-ssh-targets.md), [Docker executor](docs/docker-executor.md), [web surface](docs/web-surface.md), [UI/backend drift tracing](docs/ui-backend-drift-tracing.md), [product story](docs/invoker-medium-article.md).
 
-If you need to turn a product or implementation plan into an Invoker workflow, install helpers from System Setup or `invoker-ui --install-skills`, then run `/invoker-plan-to-invoker "help me plan <change>"` in Codex, Claude, Cursor, or OMP. The command plans first, writes `plans/invoker-handoff.md`, converts it to `plans/invoker-handoff.yaml`, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
+If you need to turn a product or implementation plan into an Invoker workflow, run `invoker-cli setup` (or System Setup in the desktop app) to install helpers, then run `/invoker-plan-to-invoker "help me plan <change>"` in Codex, Claude, Cursor, or OMP. The command plans first, writes `plans/invoker-handoff.md`, converts it to `plans/invoker-handoff.yaml`, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
 ## License
 
 [Functional Source License, Version 1.1, ALv2 Future License](LICENSE) (SPDX: **FSL-1.1-ALv2**). Permitted use, competing use, and the future Apache License 2.0 grant are defined in the license file.

--- a/docs/architecture/recovery-lifecycle-workers.md
+++ b/docs/architecture/recovery-lifecycle-workers.md
@@ -21,7 +21,7 @@ These properties define the registered model:
 
 - **Built-in default auto-fix.** The built-in auto-fix worker is registered as kind `autofix`; its underlying runtime reports recovery ownership as `recovery` and submits normal `fix-with-agent` recovery intents.
 - **Scan on start.** Starting the auto-fix worker runs a full scan immediately (`tickOnStart`), so tasks that are already failed are reconciled when the worker comes up, not one poll interval later.
-- **Manual one-shot scan.** `./run.sh --headless worker autofix` drives the same registered auto-fix worker for an explicit operator scan.
+- **Manual one-shot scan.** `invoker-cli worker autofix` drives the same registered auto-fix worker for an explicit operator scan.
 - **External extension point.** `externalWorkers` config entries add more registry kinds without changing producer code; each entry supplies a supervised process launch boundary.
 
 A **sweep-and-assert guard** pattern fails the build if a recovery channel is triggered from any code path outside its registered worker engine and sanctioned command/dispatcher routes. This locks the single-owner invariant in against future drift, so a new direct auto-fix or requeue call cannot reintroduce a second recovery path.
@@ -113,7 +113,7 @@ Registered workers may subscribe to the same lifecycle event stream. Contention 
 
 ## Auto-Fix Worker
 
-Automatic fix attempts are owned by the built-in auto-fix worker registered as kind `autofix` in `@invoker/execution-engine`. The worker's underlying runtime identity remains `recovery` for existing recovery audit events. It subscribes to lifecycle wakeups, scans persisted state, keys consumed attempts in worker runtime memory by task lineage, and decides whether an auto-fix command should be submitted. `./run.sh --headless worker autofix` is only a manual one-shot scan through the same registered definition.
+Automatic fix attempts are owned by the built-in auto-fix worker registered as kind `autofix` in `@invoker/execution-engine`. The worker's underlying runtime identity remains `recovery` for existing recovery audit events. It subscribes to lifecycle wakeups, scans persisted state, keys consumed attempts in worker runtime memory by task lineage, and decides whether an auto-fix command should be submitted. `invoker-cli worker autofix` is only a manual one-shot scan through the same registered definition.
 
 Lifetime and concurrency are constrained so the registered worker stays single for each explicit start path:
 
@@ -175,8 +175,8 @@ place.
 Operators can inspect recovery ownership and recent decisions with:
 
 ```bash
-./run.sh --headless worker status --output text
-./run.sh --headless worker status --output json
+invoker-ui --headless worker status --output text
+invoker-ui --headless worker status --output json
 ```
 
 The status view is audit-backed and read-only. It reports the recovery worker id, owner, last wakeup, last scan, last submitted recovery command, and the latest skip reason. Status reporting must not change recovery eligibility or command submission ordering.
@@ -206,8 +206,8 @@ with `attemptCount` and timestamps carrying the history.
 Query decisions read-only:
 
 ```bash
-./run.sh --headless query worker-decisions --workflow <id> --output json
-./run.sh --headless query worker-decisions --decision skip --reason budget
+invoker-ui --headless query worker-decisions --workflow <id> --output json
+invoker-ui --headless query worker-decisions --decision skip --reason budget
 ```
 
 The desktop Workers tab surfaces the same feed: selecting a worker shows a

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,8 +33,11 @@ Install with npm:
 npm install -g @neko-catpital-labs/invoker-cli
 invoker-cli --version
 invoker-cli doctor
+invoker-cli setup
 invoker-cli run plans/fixtures/hello-world.yaml --standalone
 ```
+
+`invoker-cli setup` installs the first-party Invoker AI helper skills, registers the Invoker MCP server with Codex, Claude, Cursor, and OMP, and walks through the rest of onboarding (Slack integration, GitHub auth, a smoke-test plan run) — one command for the full standalone install.
 
 Or download the platform binary from GitHub Releases:
 
@@ -96,11 +99,7 @@ Tagged releases are configured to publish:
 - desktop `.dmg`, `.zip`, `.deb`, and `.AppImage`
 - `SHA256SUMS` covering release assets
 
-Packaged installs bundle the first-party Invoker AI helpers inside the app. Install helpers from System Setup or:
-
-```bash
-invoker-ui --install-skills
-```
+Packaged installs bundle the first-party Invoker AI helpers inside the app. Install helpers by running `invoker-cli setup` (or System Setup in the desktop app).
 
 Then, in Codex, Claude, Cursor, or OMP, run:
 
@@ -138,7 +137,7 @@ Invoker reads user config from `~/.invoker/config.json`.
 If you want a repo-specific config file, point the app at it explicitly:
 
 ```bash
-INVOKER_REPO_CONFIG_PATH=$PWD/.invoker.local.json ./run.sh
+INVOKER_REPO_CONFIG_PATH=$PWD/.invoker.local.json invoker-ui
 ```
 
 The config loader does not automatically read `<repo>/.invoker.json`.
@@ -215,15 +214,15 @@ For a guided first run, use [the first agent workflow tutorial](tutorial-first-a
 For day-to-day use, start the desktop app:
 
 ```bash
-./run.sh
+invoker-ui
 ```
 
 Or run a plan through the headless surface:
 
 ```bash
-./run.sh --headless --help
-./run.sh --headless query workflows
-./run.sh --headless run /path/to/plan.yaml
+invoker-ui --headless --help
+invoker-ui --headless query workflows
+invoker-ui --headless run /path/to/plan.yaml
 ```
 
 For app development with hot reload:
@@ -274,15 +273,15 @@ tasks:
     dependencies: [api, ui]
 ```
 
-If you need to turn a product or implementation plan into an Invoker workflow, install helpers from System Setup or `invoker-ui --install-skills`, then run `/invoker-plan-to-invoker "help me plan <change>"` in Codex, Claude, Cursor, or OMP. The command plans first, writes `plans/invoker-handoff.md`, converts it to `plans/invoker-handoff.yaml`, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
+If you need to turn a product or implementation plan into an Invoker workflow, run `invoker-cli setup` (or System Setup in the desktop app) to install helpers, then run `/invoker-plan-to-invoker "help me plan <change>"` in Codex, Claude, Cursor, or OMP. The command plans first, writes `plans/invoker-handoff.md`, converts it to `plans/invoker-handoff.yaml`, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
 
 If you need to operate existing workflows or tasks, use the `invoker-ops` skill.
 
-Use `--output text|label|json|jsonl` on headless `query` commands. Use `./run.sh --headless retry-tasks --status pending|failed --parallel 8` for bulk safe retries. Inspect recovery ownership and decisions with `./run.sh --headless worker status --output text|json|jsonl`. Only **one** process should **write** the workflow database at a time; see [persistence-architecture-single-writer.md](persistence-architecture-single-writer.md).
+Use `--output text|label|json|jsonl` on headless `query` commands. Use `invoker-ui --headless retry-tasks --status pending|failed --parallel 8` for bulk safe retries. Inspect recovery ownership and decisions with `invoker-ui --headless worker status --output text|json|jsonl`. Only **one** process should **write** the workflow database at a time; see [persistence-architecture-single-writer.md](persistence-architecture-single-writer.md).
 
 ### Auto-fix worker (single shared engine)
 
-Auto-fix recovery runs through **one** shared worker engine in `@invoker/execution-engine`. Starting that worker — the Workers-tab off→on toggle — now runs a full scan immediately, submitting a fix-with-agent intent for every task that is already failed, so turning it on reconciles the current backlog at once. After that startup scan, failure lifecycle events wake it and its periodic scan covers missed wakeups. The manual dev door `./run.sh --headless worker autofix` runs the same engine for an explicit one-shot scan. `autoFixRetries` is enforced from a worker-local in-memory ledger before the worker submits another fix intent. A sweep-and-assert guard test fails the build if auto-fix is ever triggered outside this shared worker engine. See [architecture/recovery-lifecycle-workers.md](architecture/recovery-lifecycle-workers.md).
+Auto-fix recovery runs through **one** shared worker engine in `@invoker/execution-engine`. Starting that worker — the Workers-tab off→on toggle — now runs a full scan immediately, submitting a fix-with-agent intent for every task that is already failed, so turning it on reconciles the current backlog at once. After that startup scan, failure lifecycle events wake it and its periodic scan covers missed wakeups. The manual dev door `invoker-cli worker autofix` runs the same engine for an explicit one-shot scan. `autoFixRetries` is enforced from a worker-local in-memory ledger before the worker submits another fix intent. A sweep-and-assert guard test fails the build if auto-fix is ever triggered outside this shared worker engine. See [architecture/recovery-lifecycle-workers.md](architecture/recovery-lifecycle-workers.md).
 
 ## Architecture (at a glance)
 
@@ -345,7 +344,7 @@ Layer rules: [ARCHITECTURE.md](../ARCHITECTURE.md). Agent/repo conventions: [CLA
 ## Troubleshooting
 
 - **DB conflicts** — Do not run two writers on the same DB; headless CLI mutations use a standalone owner, while GUI-started workflows stay owned by the desktop app process.
-- **`pnpm` or `git` not found from the desktop app** — On macOS this is often a Finder/GUI `PATH` issue. Launch Invoker from a terminal with `./run.sh`, or make the required binaries available to GUI-launched apps.
+- **`pnpm` or `git` not found from the desktop app** — On macOS this is often a Finder/GUI `PATH` issue. Launch Invoker from a terminal with `invoker-ui`, or make the required binaries available to GUI-launched apps.
 - **Missing bundled agent skills** — `bash scripts/setup-agent-skills.sh`
 - **Install failures** — Use Node 26 as per `engines`
 - **Obsidian (README / Mermaid)** — In **Source** mode the diagram stays plain text. Open **Reading view** (book icon in the header, or the *Toggle reading view* command). **Live Preview** usually renders Mermaid as well; if you see an empty box or a parse error, update Obsidian, try the default theme, and disable CSS snippets (some themes hide Mermaid).

--- a/docs/remote-ssh-targets.md
+++ b/docs/remote-ssh-targets.md
@@ -83,9 +83,9 @@ Remote SSH targets execute workflow tasks only. Long-lived operator automation b
 For the supported PR-maintenance setup, enable `prMaintenance` in `~/.invoker/config.json` on the owner host and run the surviving built-in worker kinds from the Workers tab or headless CLI:
 
 ```bash
-./run.sh --headless worker status --output text
-./run.sh --headless worker pr-admin-bypass-land
-./run.sh --headless worker pr-orphan-repair
+invoker-ui --headless worker status --output text
+invoker-ui --headless worker pr-admin-bypass-land
+invoker-ui --headless worker pr-orphan-repair
 ```
 
 Do not install separate cron jobs on SSH targets for these maintenance paths. The workers share the owner process, owner database, and per-kind worker locks; SSH targets stay disposable execution capacity.
@@ -178,7 +178,7 @@ SSH member capacity is decided by durable host-keyed leases in `execution_resour
 - **Claim-at-select:** the runner acquires the lease while selecting a pool member, before start. Dispatch renews an already-held lease instead of claiming again.
 - **In-memory maps:** `activeExecutions` / `pendingPoolSelections` still drive kill, heartbeat, and start plumbing, but they do **not** contribute to SSH `poolMemberLoad`. Worktree pool members still use in-memory load.
 - **Reclaim:** orphan-executor reclaim remains useful cleanup; it is not the source of truth for “is this host full?”.
-- **Inspect:** with the GUI/owner up, `./run.sh --headless query execution-leases [--output json|text|label]` lists live holders (`resourceKey`, `poolId`, `poolMemberId`, `taskId`, `holderId`, expiry).
+- **Inspect:** with the GUI/owner up, `invoker-ui --headless query execution-leases [--output json|text|label]` lists live holders (`resourceKey`, `poolId`, `poolMemberId`, `taskId`, `holderId`, expiry).
 - **Regression gate:** `bash scripts/repro/repro-ssh-lease-capacity-battery.sh --gate` (orphan ghosts, cross-pool exclusivity, churn refill, lease/occupancy parity).
 
 ## Member Health & Circuit Breaker

--- a/docs/slack-native-workflows.md
+++ b/docs/slack-native-workflows.md
@@ -92,7 +92,7 @@ documented. The standalone manager reads that config first, then falls back to
 `INVOKER_SLACK_DEFAULT_PRESET` only when the config leaves the preset unset.
 To configure by hand, put these credential values in `~/.invoker/.env`
 (canonical, loaded on startup before the Slack check) or `<repoRoot>/.env`
-(fallback), then run `invoker-slack` (or `./run.sh` for the desktop app only):
+(fallback), then run `invoker-slack` (or `invoker-ui` for the desktop app only):
 
 ```
 SLACK_BOT_TOKEN=xoxb-...

--- a/docs/tutorial-first-agent-workflow.md
+++ b/docs/tutorial-first-agent-workflow.md
@@ -29,7 +29,7 @@ bash scripts/setup-agent-skills.sh
 pnpm run build
 ```
 
-For your own changes, install helpers from System Setup or `invoker-ui --install-skills`, then run `/invoker-plan-to-invoker "help me plan <change>"` in Codex, Claude, Cursor, or OMP. The command plans first, writes `plans/invoker-handoff.md`, converts it to `plans/invoker-handoff.yaml`, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
+For your own changes, run `invoker-cli setup` (or System Setup in the desktop app) to install helpers, then run `/invoker-plan-to-invoker "help me plan <change>"` in Codex, Claude, Cursor, or OMP. The command plans first, writes `plans/invoker-handoff.md`, converts it to `plans/invoker-handoff.yaml`, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
 
 Make sure at least one supported agent CLI is installed and authenticated:
 
@@ -69,7 +69,7 @@ You should see a failing `node --test` run. That failure is the work the agent w
 Start the desktop app from the Invoker repo root:
 
 ```bash
-./run.sh
+invoker-ui
 ```
 
 In the left rail, click `Open`.
@@ -125,7 +125,7 @@ If the agent task fails because the agent CLI is missing or unauthenticated, ins
 
 If `verify` fails, select the failed task and read the inspector error. You can right-click the workflow and choose `Retry Workflow`, or right-click an individual failed task and choose a task action such as retry or open terminal.
 
-If the desktop app cannot find `npm`, `node`, `git`, `codex`, or `claude`, quit it and restart with `./run.sh` from your terminal.
+If the desktop app cannot find `npm`, `node`, `git`, `codex`, or `claude`, quit it and restart with `invoker-ui` from your terminal.
 
 ## Use the same pattern on your own repo
 

--- a/docs/web-surface.md
+++ b/docs/web-surface.md
@@ -23,7 +23,7 @@ Env always wins over config. Two more optional knobs:
 Localhost (desktop app already running):
 
 ```
-INVOKER_WEB_TOKEN=secret ./run.sh
+INVOKER_WEB_TOKEN=secret invoker-ui
 # open http://127.0.0.1:4200/?token=secret
 ```
 
@@ -31,7 +31,7 @@ Remote / headless host (e.g. the DO box):
 
 ```
 INVOKER_WEB_TOKEN=secret INVOKER_WEB_HOST=0.0.0.0 INVOKER_WEB_PORT=4200 \
-  INVOKER_HEADLESS_STANDALONE=1 ./run.sh --headless run plan.yaml
+  INVOKER_HEADLESS_STANDALONE=1 invoker-ui --headless run plan.yaml
 # from your laptop: open http://<do-ip>:4200/?token=secret
 ```
 

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -219,6 +219,9 @@ async function headlessInstallSkills(
   mode: BundledSkillsInstallMode | undefined,
   deps: Pick<HeadlessDeps, 'installBundledSkills'>,
 ): Promise<void> {
+  process.stderr.write(
+    'Deprecated: `invoker-ui --install-skills` will be removed in a future release. Run `invoker-cli setup` instead.\n',
+  );
   if (!deps.installBundledSkills) {
     throw new Error('Bundled AI helper installation is not available in this runtime.');
   }

--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -65,6 +65,7 @@ function readySetupDeps(overrides: SetupDeps = {}): SetupDeps {
     // Real skill install does real commandExists probing + filesystem work —
     // stub it by default so unrelated tests stay fast and deterministic.
     resolveSkillsRepoRoot: () => '/fake-repo-root',
+    resolveStandaloneSkillsRoot: () => null,
     bundledSkillsInstall: () => NOOP_BUNDLED_SKILLS_STATUS,
     ...overrides,
   };
@@ -246,7 +247,40 @@ describe('runSetup', () => {
     }
   });
 
-  it('skips skill installation gracefully when not running from an Invoker checkout', async () => {
+  it('falls back to skills bundled next to the running binary when not in a checkout', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'invoker-setup-skills-standalone-'));
+    const saved = { HOME: process.env.HOME };
+    const lines: string[] = [];
+    const fakeStatus = {
+      available: true,
+      promptRecommended: false,
+      managedPrefix: 'invoker-',
+      bundledSkillNames: ['plan-to-invoker'],
+      targets: [{ id: 'claude', name: 'Claude', path: '/x', available: true, installed: true, upToDate: true, installedSkillNames: [] }],
+      commandTargets: [],
+      mcpTargets: [{ id: 'claude', name: 'Claude', path: '/x/.claude.json', available: true, installed: true, upToDate: true, serverName: 'invoker' }],
+    };
+    try {
+      process.env.HOME = home;
+
+      const code = await runSetup([], {
+        print: (line) => lines.push(line),
+        prompt: async () => 'n',
+      }, readySetupDeps({
+        resolveSkillsRepoRoot: () => { throw new Error('Could not resolve repo root'); },
+        resolveStandaloneSkillsRoot: () => '/fake/vendor',
+        bundledSkillsInstall: () => fakeStatus,
+      }));
+
+      expect(code).toBe(0);
+      expect(lines.join('\n')).toContain('Skills: installed 1 bundled skill(s) for Claude.');
+    } finally {
+      restoreEnv('HOME', saved.HOME);
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('skips skill installation gracefully when not running from an Invoker checkout and no bundled skills are found', async () => {
     const home = mkdtempSync(join(tmpdir(), 'invoker-setup-skills-none-'));
     const saved = { HOME: process.env.HOME };
     const lines: string[] = [];
@@ -258,10 +292,11 @@ describe('runSetup', () => {
         prompt: async () => 'n',
       }, readySetupDeps({
         resolveSkillsRepoRoot: () => { throw new Error('Could not resolve repo root'); },
+        resolveStandaloneSkillsRoot: () => null,
       }));
 
       expect(code).toBe(0);
-      expect(lines.join('\n')).toContain('Skills: skipped (not running from an Invoker checkout).');
+      expect(lines.join('\n')).toContain('Skills: skipped (not running from an Invoker checkout, and no bundled skills next to this binary).');
     } finally {
       restoreEnv('HOME', saved.HOME);
       rmSync(home, { recursive: true, force: true });

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { createInterface } from 'node:readline/promises';
@@ -422,6 +422,7 @@ export interface SetupDeps {
   remoteDoctorChecks?: typeof runRemoteDoctorChecks;
   bundledSkillsInstall?: typeof installBundledSkills;
   resolveSkillsRepoRoot?: typeof resolveRepoRoot;
+  resolveStandaloneSkillsRoot?: typeof resolveStandaloneSkillsRoot;
 }
 
 // ── Slack manifest ───────────────────────────────────────────
@@ -1107,20 +1108,39 @@ async function runWorkerTogglesInteractive(io: SetupIO, assumeYes: boolean): Pro
 }
 
 /**
- * Only works when `setup` runs from inside an Invoker checkout (dev, or a repo
- * clone) — the standalone distribution has nowhere to source `skills/` from.
- * Fails soft: a truly standalone install (or a build without a source checkout)
- * just skips this with a note instead of breaking the rest of `setup`.
+ * Prefers an Invoker checkout (dev, or a repo clone) reachable from the
+ * current directory. The standalone release binary and the npm-cli install
+ * both ship a `skills/` directory next to the running executable
+ * (scripts/archive-cli-binary.sh, packages/npm-cli/scripts/install.js), so
+ * this falls back to that location when `setup` isn't run from a checkout.
+ * Fails soft: if neither is found, this skips with a note instead of
+ * breaking the rest of `setup`.
  */
+function resolveStandaloneSkillsRoot(): string | null {
+  let execPath: string;
+  try {
+    execPath = realpathSync(process.execPath);
+  } catch {
+    execPath = process.execPath;
+  }
+  const candidate = dirname(execPath);
+  return existsSync(join(candidate, 'skills')) ? candidate : null;
+}
+
 function installSetupBundledSkills(io: SetupIO, options: SetupDeps): void {
   const resolveSkillsRepoRoot = options.resolveSkillsRepoRoot ?? resolveRepoRoot;
+  const resolveStandaloneRoot = options.resolveStandaloneSkillsRoot ?? resolveStandaloneSkillsRoot;
   const install = options.bundledSkillsInstall ?? installBundledSkills;
   let repoRoot: string;
   try {
     repoRoot = resolveSkillsRepoRoot(process.cwd());
   } catch {
-    io.print('Skills: skipped (not running from an Invoker checkout).');
-    return;
+    const standaloneRoot = resolveStandaloneRoot();
+    if (!standaloneRoot) {
+      io.print('Skills: skipped (not running from an Invoker checkout, and no bundled skills next to this binary).');
+      return;
+    }
+    repoRoot = standaloneRoot;
   }
 
   try {

--- a/packages/npm-cli/scripts/install.js
+++ b/packages/npm-cli/scripts/install.js
@@ -23,6 +23,7 @@ const vendor = join(root, 'vendor');
 const archivePath = join(vendor, asset);
 const sumsPath = join(vendor, 'SHA256SUMS');
 const binaryPath = join(vendor, 'invoker-cli');
+const skillsPath = join(vendor, 'skills');
 
 if (!['darwin', 'linux'].includes(process.platform) || !['x64', 'arm64'].includes(process.arch)) {
   throw new Error(`Unsupported Invoker CLI platform: ${process.platform}-${process.arch}`);
@@ -52,6 +53,7 @@ function expectedHash(sums, name) {
 
 await mkdir(vendor, { recursive: true });
 await rm(binaryPath, { force: true });
+await rm(skillsPath, { force: true, recursive: true });
 await download(`${baseUrl}/SHA256SUMS`, sumsPath);
 await download(`${baseUrl}/${asset}`, archivePath);
 
@@ -66,9 +68,15 @@ if (actual !== expected) {
 }
 
 execFileSync('tar', ['-xzf', archivePath, '-C', vendor], { stdio: 'inherit' });
-const extracted = join(vendor, asset.replace(/\.tar\.gz$/, ''), 'invoker-cli');
+const extractedDir = join(vendor, asset.replace(/\.tar\.gz$/, ''));
+const extracted = join(extractedDir, 'invoker-cli');
 if (!existsSync(extracted)) {
   throw new Error(`Downloaded archive did not contain ${extracted}`);
 }
 execFileSync('cp', [extracted, binaryPath]);
 await chmod(binaryPath, 0o755);
+
+const extractedSkills = join(extractedDir, 'skills');
+if (existsSync(extractedSkills)) {
+  execFileSync('cp', ['-r', extractedSkills, skillsPath]);
+}

--- a/scripts/archive-cli-binary.sh
+++ b/scripts/archive-cli-binary.sh
@@ -19,6 +19,7 @@ mkdir -p "$STAGE/$NAME"
 cp "$BINARY" "$STAGE/$NAME/invoker-cli"
 chmod +x "$STAGE/$NAME/invoker-cli"
 cp "$ROOT/packages/cli/README.md" "$STAGE/$NAME/README.md"
+cp -r "$ROOT/skills" "$STAGE/$NAME/skills"
 
 (cd "$STAGE" && tar -czf "$RELEASE_DIR/$NAME.tar.gz" "$NAME")
 rm -rf "$STAGE"

--- a/skills/invoker-ops/SKILL.md
+++ b/skills/invoker-ops/SKILL.md
@@ -29,17 +29,17 @@ Use Invoker commands first. Direct database reads are only allowed when the user
 ### List workflows
 
 ```bash
-./run.sh --headless query workflows --output text
-./run.sh --headless query workflows --status failed --output json
+invoker-ui --headless query workflows --output text
+invoker-ui --headless query workflows --status failed --output json
 ```
 
 ### List tasks
 
 ```bash
-./run.sh --headless query tasks --workflow <workflowId> --output text
-./run.sh --headless query tasks --workflow <workflowId> --status pending --output json
-./run.sh --headless query tasks --workflow <workflowId> --status failed --output json
-./run.sh --headless query tasks --workflow <workflowId> --status running --output json
+invoker-ui --headless query tasks --workflow <workflowId> --output text
+invoker-ui --headless query tasks --workflow <workflowId> --status pending --output json
+invoker-ui --headless query tasks --workflow <workflowId> --status failed --output json
+invoker-ui --headless query tasks --workflow <workflowId> --status running --output json
 ```
 
 If the request says "all workflows", first list workflows, then query each workflow through `query tasks --workflow <workflowId>`.
@@ -47,31 +47,31 @@ If the request says "all workflows", first list workflows, then query each workf
 ### Retry failed tasks
 
 ```bash
-./run.sh --headless retry-tasks --status failed --parallel 8
+invoker-ui --headless retry-tasks --status failed --parallel 8
 ```
 
 ### Retry pending tasks
 
 ```bash
-./run.sh --headless retry-tasks --status pending --parallel 8
+invoker-ui --headless retry-tasks --status pending --parallel 8
 ```
 
 ### Dry-run a bulk retry
 
 ```bash
-./run.sh --headless retry-tasks --status pending --parallel 8 --dry-run
+invoker-ui --headless retry-tasks --status pending --parallel 8 --dry-run
 ```
 
 ### Retry one task
 
 ```bash
-./run.sh --headless retry-task <taskId> --no-track
+invoker-ui --headless retry-task <taskId> --no-track
 ```
 
 ### Retry one workflow
 
 ```bash
-./run.sh --headless retry <workflowId> --no-track
+invoker-ui --headless retry <workflowId> --no-track
 ```
 
 ## Acknowledgement boundary
@@ -85,7 +85,7 @@ After submitting, verify with query commands, not database reads.
 ## Workflow for "retry/restart all failed or pending tasks"
 
 1. Run a dry-run if the request is broad or destructive-looking.
-2. Run `./run.sh --headless retry-tasks --status <status> --parallel 8`.
+2. Run `invoker-ui --headless retry-tasks --status <status> --parallel 8`.
 3. Report accepted and failed submission counts from command output.
 4. Verify remaining tasks with `query tasks` commands when the user asks for current state.
 

--- a/skills/plan-to-invoker/playbooks/verify-then-build.md
+++ b/skills/plan-to-invoker/playbooks/verify-then-build.md
@@ -81,7 +81,7 @@ For policy-matrix inputs, `skill-doctor` now fails if the coverage map or stack 
 #### Phase 1b-invoker — Headless Invoker (`submit-plan.sh`)
 
 - **Actually execute** `./submit-plan.sh plans/verify-<slug>.yaml` after `pnpm --filter @invoker/app build` if `packages/app/dist/main.js` is missing.
-- Optionally wrap with `./run.sh --headless delete-all` first to avoid duplicate task IDs.
+- Optionally wrap with `invoker-ui --headless delete-all` first to avoid duplicate task IDs.
 - **Record** exit code and relevant log lines (e.g. `tee /tmp/invoker-verify.txt`).
 - **Authoring** a verify YAML or running **`validate-plan.sh` only** does **not** satisfy Phase 1b-invoker — those do not run the orchestrator or write SQLite.
 
@@ -112,7 +112,7 @@ Must exit 0. This validates schema + dependency wiring + deterministic **atomici
 #### Agent must run Invoker (Phase 1b-invoker)
 
 ```bash
-./run.sh --headless delete-all   # optional: avoid PlanConflictError on duplicate task IDs
+invoker-ui --headless delete-all   # optional: avoid PlanConflictError on duplicate task IDs
 ./submit-plan.sh plans/verify-<slug>.yaml 2>&1 | tee /tmp/invoker-verify.txt
 ```
 
@@ -134,7 +134,7 @@ bash skills/plan-to-invoker/scripts/parse-results.sh < /tmp/invoker-verify.txt
 #### Clean up before implementation
 
 ```bash
-./run.sh --headless delete-all
+invoker-ui --headless delete-all
 ```
 
 Remove verification workflows before submitting the **implementation** plan if you need a clean graph.


### PR DESCRIPTION
README, getting-started, and the tutorial pointed users at
'invoker-ui --install-skills' (a headless subcommand of the Electron
app binary) to install AI helper skills, separately from the
invoker-cli setup wizard that already runs doctor checks, planner MCP,
Slack, and GitHub auth. invoker-cli setup already installs skills too
(prior work) — the docs just never said so. They now point at
invoker-cli setup as the single install-and-onboard command, with
System Setup in the desktop app as the GUI alternative.

Separately, every ./run.sh reference in product- and operator-facing
docs and in the bundled skills (which get installed into other repos,
where ./run.sh does not exist) now uses the actual published binary:
invoker-ui --headless <command> for the app-only headless commands
invoker-cli does not implement (query, worker <kind>, retry-tasks,
retry-task, retry, delete-all), invoker-cli worker autofix for the one
worker kind invoker-cli genuinely supports natively, and invoker-ui for
bare GUI launches. CLAUDE.md, CHANGELOG.md, and a few internal
investigation/incident docs were left untouched — ./run.sh is correct
there, since that audience is always working from a repo checkout.

Depends-On: #8202