### PR TITLE
[Invoker-cli standalone skill install](2b) Deprecate invoker-ui --install-skills

### DIFF
--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -219,6 +219,9 @@ async function headlessInstallSkills(
   mode: BundledSkillsInstallMode | undefined,
   deps: Pick<HeadlessDeps, 'installBundledSkills'>,
 ): Promise<void> {
+  process.stderr.write(
+    'Deprecated: `invoker-ui --install-skills` will be removed in a future release. Run `invoker-cli setup` instead.\n',
+  );
   if (!deps.installBundledSkills) {
     throw new Error('Bundled AI helper installation is not available in this runtime.');
   }

--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -65,6 +65,7 @@ function readySetupDeps(overrides: SetupDeps = {}): SetupDeps {
     // Real skill install does real commandExists probing + filesystem work —
     // stub it by default so unrelated tests stay fast and deterministic.
     resolveSkillsRepoRoot: () => '/fake-repo-root',
+    resolveStandaloneSkillsRoot: () => null,
     bundledSkillsInstall: () => NOOP_BUNDLED_SKILLS_STATUS,
     ...overrides,
   };
@@ -246,7 +247,40 @@ describe('runSetup', () => {
     }
   });
 
-  it('skips skill installation gracefully when not running from an Invoker checkout', async () => {
+  it('falls back to skills bundled next to the running binary when not in a checkout', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'invoker-setup-skills-standalone-'));
+    const saved = { HOME: process.env.HOME };
+    const lines: string[] = [];
+    const fakeStatus = {
+      available: true,
+      promptRecommended: false,
+      managedPrefix: 'invoker-',
+      bundledSkillNames: ['plan-to-invoker'],
+      targets: [{ id: 'claude', name: 'Claude', path: '/x', available: true, installed: true, upToDate: true, installedSkillNames: [] }],
+      commandTargets: [],
+      mcpTargets: [{ id: 'claude', name: 'Claude', path: '/x/.claude.json', available: true, installed: true, upToDate: true, serverName: 'invoker' }],
+    };
+    try {
+      process.env.HOME = home;
+
+      const code = await runSetup([], {
+        print: (line) => lines.push(line),
+        prompt: async () => 'n',
+      }, readySetupDeps({
+        resolveSkillsRepoRoot: () => { throw new Error('Could not resolve repo root'); },
+        resolveStandaloneSkillsRoot: () => '/fake/vendor',
+        bundledSkillsInstall: () => fakeStatus,
+      }));
+
+      expect(code).toBe(0);
+      expect(lines.join('\n')).toContain('Skills: installed 1 bundled skill(s) for Claude.');
+    } finally {
+      restoreEnv('HOME', saved.HOME);
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('skips skill installation gracefully when not running from an Invoker checkout and no bundled skills are found', async () => {
     const home = mkdtempSync(join(tmpdir(), 'invoker-setup-skills-none-'));
     const saved = { HOME: process.env.HOME };
     const lines: string[] = [];
@@ -258,10 +292,11 @@ describe('runSetup', () => {
         prompt: async () => 'n',
       }, readySetupDeps({
         resolveSkillsRepoRoot: () => { throw new Error('Could not resolve repo root'); },
+        resolveStandaloneSkillsRoot: () => null,
       }));
 
       expect(code).toBe(0);
-      expect(lines.join('\n')).toContain('Skills: skipped (not running from an Invoker checkout).');
+      expect(lines.join('\n')).toContain('Skills: skipped (not running from an Invoker checkout, and no bundled skills next to this binary).');
     } finally {
       restoreEnv('HOME', saved.HOME);
       rmSync(home, { recursive: true, force: true });

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { createInterface } from 'node:readline/promises';
@@ -422,6 +422,7 @@ export interface SetupDeps {
   remoteDoctorChecks?: typeof runRemoteDoctorChecks;
   bundledSkillsInstall?: typeof installBundledSkills;
   resolveSkillsRepoRoot?: typeof resolveRepoRoot;
+  resolveStandaloneSkillsRoot?: typeof resolveStandaloneSkillsRoot;
 }
 
 // ── Slack manifest ───────────────────────────────────────────
@@ -1107,20 +1108,39 @@ async function runWorkerTogglesInteractive(io: SetupIO, assumeYes: boolean): Pro
 }
 
 /**
- * Only works when `setup` runs from inside an Invoker checkout (dev, or a repo
- * clone) — the standalone distribution has nowhere to source `skills/` from.
- * Fails soft: a truly standalone install (or a build without a source checkout)
- * just skips this with a note instead of breaking the rest of `setup`.
+ * Prefers an Invoker checkout (dev, or a repo clone) reachable from the
+ * current directory. The standalone release binary and the npm-cli install
+ * both ship a `skills/` directory next to the running executable
+ * (scripts/archive-cli-binary.sh, packages/npm-cli/scripts/install.js), so
+ * this falls back to that location when `setup` isn't run from a checkout.
+ * Fails soft: if neither is found, this skips with a note instead of
+ * breaking the rest of `setup`.
  */
+function resolveStandaloneSkillsRoot(): string | null {
+  let execPath: string;
+  try {
+    execPath = realpathSync(process.execPath);
+  } catch {
+    execPath = process.execPath;
+  }
+  const candidate = dirname(execPath);
+  return existsSync(join(candidate, 'skills')) ? candidate : null;
+}
+
 function installSetupBundledSkills(io: SetupIO, options: SetupDeps): void {
   const resolveSkillsRepoRoot = options.resolveSkillsRepoRoot ?? resolveRepoRoot;
+  const resolveStandaloneRoot = options.resolveStandaloneSkillsRoot ?? resolveStandaloneSkillsRoot;
   const install = options.bundledSkillsInstall ?? installBundledSkills;
   let repoRoot: string;
   try {
     repoRoot = resolveSkillsRepoRoot(process.cwd());
   } catch {
-    io.print('Skills: skipped (not running from an Invoker checkout).');
-    return;
+    const standaloneRoot = resolveStandaloneRoot();
+    if (!standaloneRoot) {
+      io.print('Skills: skipped (not running from an Invoker checkout, and no bundled skills next to this binary).');
+      return;
+    }
+    repoRoot = standaloneRoot;
   }
 
   try {

--- a/scripts/archive-cli-binary.sh
+++ b/scripts/archive-cli-binary.sh
@@ -19,6 +19,7 @@ mkdir -p "$STAGE/$NAME"
 cp "$BINARY" "$STAGE/$NAME/invoker-cli"
 chmod +x "$STAGE/$NAME/invoker-cli"
 cp "$ROOT/packages/cli/README.md" "$STAGE/$NAME/README.md"
+cp -r "$ROOT/skills" "$STAGE/$NAME/skills"
 
 (cd "$STAGE" && tar -czf "$RELEASE_DIR/$NAME.tar.gz" "$NAME")
 rm -rf "$STAGE"


### PR DESCRIPTION
## Summary

The standalone-skills fallback (previous slice) makes `invoker-cli setup` a complete replacement for the app's `--install-skills` headless command.

`invoker-ui --install-skills` now prints a one-line deprecation notice to stderr pointing at `invoker-cli setup`, without changing its own behavior.

## Review Claim

Approve the stderr-only deprecation notice on the app's headless `install-skills` command.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The notice writes to `process.stderr` only, never `process.stdout`. `headless-install-skills.test.ts` only mocks and asserts `process.stdout.write`, and all 3 of its tests still pass unmodified — proof the notice does not alter the command's observable stdout contract, exit behavior, or the underlying install it performs.

## Slice Rationale

Split by top-level package area per this repo's diff-atomicity rule: this slice is `packages/app` only, following the `packages/cli` fallback it points users away from. Kept separate from that slice and from the `packages/npm-cli` packaging follow-through (next) for the same reason.

## Non-goals

- Does not remove or disable `invoker-ui --install-skills` — it keeps working, just with a deprecation notice.
- No change to `packages/cli` (previous slice) or `packages/npm-cli` (next slice).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && npx vitest run src/__tests__/headless-install-skills.test.ts` — 3/3 pass; deprecation notice observed on stderr in the test output, stdout assertions unaffected.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — the deprecation notice disappears.
- Data migration? No

</details>
