### PR TITLE
[Invoker-cli standalone skill install](2c) Ship skills/ next to the vendored npm-cli binary

### DIFF
--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -219,6 +219,9 @@ async function headlessInstallSkills(
   mode: BundledSkillsInstallMode | undefined,
   deps: Pick<HeadlessDeps, 'installBundledSkills'>,
 ): Promise<void> {
+  process.stderr.write(
+    'Deprecated: `invoker-ui --install-skills` will be removed in a future release. Run `invoker-cli setup` instead.\n',
+  );
   if (!deps.installBundledSkills) {
     throw new Error('Bundled AI helper installation is not available in this runtime.');
   }

--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -65,6 +65,7 @@ function readySetupDeps(overrides: SetupDeps = {}): SetupDeps {
     // Real skill install does real commandExists probing + filesystem work —
     // stub it by default so unrelated tests stay fast and deterministic.
     resolveSkillsRepoRoot: () => '/fake-repo-root',
+    resolveStandaloneSkillsRoot: () => null,
     bundledSkillsInstall: () => NOOP_BUNDLED_SKILLS_STATUS,
     ...overrides,
   };
@@ -246,7 +247,40 @@ describe('runSetup', () => {
     }
   });
 
-  it('skips skill installation gracefully when not running from an Invoker checkout', async () => {
+  it('falls back to skills bundled next to the running binary when not in a checkout', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'invoker-setup-skills-standalone-'));
+    const saved = { HOME: process.env.HOME };
+    const lines: string[] = [];
+    const fakeStatus = {
+      available: true,
+      promptRecommended: false,
+      managedPrefix: 'invoker-',
+      bundledSkillNames: ['plan-to-invoker'],
+      targets: [{ id: 'claude', name: 'Claude', path: '/x', available: true, installed: true, upToDate: true, installedSkillNames: [] }],
+      commandTargets: [],
+      mcpTargets: [{ id: 'claude', name: 'Claude', path: '/x/.claude.json', available: true, installed: true, upToDate: true, serverName: 'invoker' }],
+    };
+    try {
+      process.env.HOME = home;
+
+      const code = await runSetup([], {
+        print: (line) => lines.push(line),
+        prompt: async () => 'n',
+      }, readySetupDeps({
+        resolveSkillsRepoRoot: () => { throw new Error('Could not resolve repo root'); },
+        resolveStandaloneSkillsRoot: () => '/fake/vendor',
+        bundledSkillsInstall: () => fakeStatus,
+      }));
+
+      expect(code).toBe(0);
+      expect(lines.join('\n')).toContain('Skills: installed 1 bundled skill(s) for Claude.');
+    } finally {
+      restoreEnv('HOME', saved.HOME);
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('skips skill installation gracefully when not running from an Invoker checkout and no bundled skills are found', async () => {
     const home = mkdtempSync(join(tmpdir(), 'invoker-setup-skills-none-'));
     const saved = { HOME: process.env.HOME };
     const lines: string[] = [];
@@ -258,10 +292,11 @@ describe('runSetup', () => {
         prompt: async () => 'n',
       }, readySetupDeps({
         resolveSkillsRepoRoot: () => { throw new Error('Could not resolve repo root'); },
+        resolveStandaloneSkillsRoot: () => null,
       }));
 
       expect(code).toBe(0);
-      expect(lines.join('\n')).toContain('Skills: skipped (not running from an Invoker checkout).');
+      expect(lines.join('\n')).toContain('Skills: skipped (not running from an Invoker checkout, and no bundled skills next to this binary).');
     } finally {
       restoreEnv('HOME', saved.HOME);
       rmSync(home, { recursive: true, force: true });

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { createInterface } from 'node:readline/promises';
@@ -422,6 +422,7 @@ export interface SetupDeps {
   remoteDoctorChecks?: typeof runRemoteDoctorChecks;
   bundledSkillsInstall?: typeof installBundledSkills;
   resolveSkillsRepoRoot?: typeof resolveRepoRoot;
+  resolveStandaloneSkillsRoot?: typeof resolveStandaloneSkillsRoot;
 }
 
 // ── Slack manifest ───────────────────────────────────────────
@@ -1107,20 +1108,39 @@ async function runWorkerTogglesInteractive(io: SetupIO, assumeYes: boolean): Pro
 }
 
 /**
- * Only works when `setup` runs from inside an Invoker checkout (dev, or a repo
- * clone) — the standalone distribution has nowhere to source `skills/` from.
- * Fails soft: a truly standalone install (or a build without a source checkout)
- * just skips this with a note instead of breaking the rest of `setup`.
+ * Prefers an Invoker checkout (dev, or a repo clone) reachable from the
+ * current directory. The standalone release binary and the npm-cli install
+ * both ship a `skills/` directory next to the running executable
+ * (scripts/archive-cli-binary.sh, packages/npm-cli/scripts/install.js), so
+ * this falls back to that location when `setup` isn't run from a checkout.
+ * Fails soft: if neither is found, this skips with a note instead of
+ * breaking the rest of `setup`.
  */
+function resolveStandaloneSkillsRoot(): string | null {
+  let execPath: string;
+  try {
+    execPath = realpathSync(process.execPath);
+  } catch {
+    execPath = process.execPath;
+  }
+  const candidate = dirname(execPath);
+  return existsSync(join(candidate, 'skills')) ? candidate : null;
+}
+
 function installSetupBundledSkills(io: SetupIO, options: SetupDeps): void {
   const resolveSkillsRepoRoot = options.resolveSkillsRepoRoot ?? resolveRepoRoot;
+  const resolveStandaloneRoot = options.resolveStandaloneSkillsRoot ?? resolveStandaloneSkillsRoot;
   const install = options.bundledSkillsInstall ?? installBundledSkills;
   let repoRoot: string;
   try {
     repoRoot = resolveSkillsRepoRoot(process.cwd());
   } catch {
-    io.print('Skills: skipped (not running from an Invoker checkout).');
-    return;
+    const standaloneRoot = resolveStandaloneRoot();
+    if (!standaloneRoot) {
+      io.print('Skills: skipped (not running from an Invoker checkout, and no bundled skills next to this binary).');
+      return;
+    }
+    repoRoot = standaloneRoot;
   }
 
   try {

--- a/packages/npm-cli/scripts/install.js
+++ b/packages/npm-cli/scripts/install.js
@@ -23,6 +23,7 @@ const vendor = join(root, 'vendor');
 const archivePath = join(vendor, asset);
 const sumsPath = join(vendor, 'SHA256SUMS');
 const binaryPath = join(vendor, 'invoker-cli');
+const skillsPath = join(vendor, 'skills');
 
 if (!['darwin', 'linux'].includes(process.platform) || !['x64', 'arm64'].includes(process.arch)) {
   throw new Error(`Unsupported Invoker CLI platform: ${process.platform}-${process.arch}`);
@@ -52,6 +53,7 @@ function expectedHash(sums, name) {
 
 await mkdir(vendor, { recursive: true });
 await rm(binaryPath, { force: true });
+await rm(skillsPath, { force: true, recursive: true });
 await download(`${baseUrl}/SHA256SUMS`, sumsPath);
 await download(`${baseUrl}/${asset}`, archivePath);
 
@@ -66,9 +68,15 @@ if (actual !== expected) {
 }
 
 execFileSync('tar', ['-xzf', archivePath, '-C', vendor], { stdio: 'inherit' });
-const extracted = join(vendor, asset.replace(/\.tar\.gz$/, ''), 'invoker-cli');
+const extractedDir = join(vendor, asset.replace(/\.tar\.gz$/, ''));
+const extracted = join(extractedDir, 'invoker-cli');
 if (!existsSync(extracted)) {
   throw new Error(`Downloaded archive did not contain ${extracted}`);
 }
 execFileSync('cp', [extracted, binaryPath]);
 await chmod(binaryPath, 0o755);
+
+const extractedSkills = join(extractedDir, 'skills');
+if (existsSync(extractedSkills)) {
+  execFileSync('cp', ['-r', extractedSkills, skillsPath]);
+}

--- a/scripts/archive-cli-binary.sh
+++ b/scripts/archive-cli-binary.sh
@@ -19,6 +19,7 @@ mkdir -p "$STAGE/$NAME"
 cp "$BINARY" "$STAGE/$NAME/invoker-cli"
 chmod +x "$STAGE/$NAME/invoker-cli"
 cp "$ROOT/packages/cli/README.md" "$STAGE/$NAME/README.md"
+cp -r "$ROOT/skills" "$STAGE/$NAME/skills"
 
 (cd "$STAGE" && tar -czf "$RELEASE_DIR/$NAME.tar.gz" "$NAME")
 rm -rf "$STAGE"


### PR DESCRIPTION
## Summary

The release tarball now bundles `skills/` alongside the standalone binary (earlier slice).

`packages/npm-cli`'s postinstall unpacks that tarball but only ever flattened the binary itself out to `vendor/`, not anything else in it.

It now flattens the unpacked `skills/` directory next to the vendored binary too, the same way it already handles the binary.

A global `npm install -g @neko-catpital-labs/invoker-cli` ends up with the same sibling layout the standalone-skills fallback expects.

## Review Claim

Approve flattening `skills/` next to the vendored binary in `packages/npm-cli`'s postinstall.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Mirrors the existing binary copy exactly — same unpack-then-flatten shape, same `vendor/` target directory. Guarded by `existsSync(extractedSkills)`, so installing an older release tarball without a bundled `skills/` directory still succeeds; it simply omits the copy instead of failing.

## Slice Rationale

Scoped to one top-level package area per this repo's diff-atomicity rule: this slice is `packages/npm-cli` only, completing the standalone-install path started by the `packages/cli` fallback and the release-tarball packaging slices.

## Non-goals

- No change to the tarball extraction or checksum verification steps already in place for the binary.
- No change to `packages/cli` or `packages/app` (previous two slices).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node -c packages/npm-cli/scripts/install.js` — script still parses.
- [x] Manual read-through: `extractedSkills` is derived from the same `extractedDir` the binary copy already uses, and the new `cp -r` call only runs when `existsSync(extractedSkills)` is true, matching the guard style of the rest of the script.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — a global `invoker-cli` install goes back to not having local skill files.
- Data migration? No

</details>
