### PR TITLE
[Headless owner launch on Linux] Start the packaged owner under a systemd supervisor

### DIFF
--- a/packages/contracts/src/__tests__/headless-owner-launch.test.ts
+++ b/packages/contracts/src/__tests__/headless-owner-launch.test.ts
@@ -39,10 +39,23 @@ describe('resolveHeadlessOwnerLaunchSpec', () => {
     });
   });
 
-  it('uses the packaged invoker-ui wrapper when present', () => {
+  it('gives the packaged invoker-ui wrapper the same Linux stability flags as the repo path', () => {
     expect(resolveHeadlessOwnerLaunchSpec({
       repoRoot: '/repo',
       platform: 'linux',
+      env: {},
+      which: (command) => (command === 'invoker-ui' ? '/usr/local/bin/invoker-ui' : undefined),
+      existsSync: () => false,
+    })).toEqual({
+      command: '/usr/local/bin/invoker-ui',
+      args: [...LINUX_HEADLESS_ELECTRON_FLAGS, '--headless', 'owner-serve'],
+    });
+  });
+
+  it('keeps the packaged invoker-ui wrapper free of Linux-only switches on macOS', () => {
+    expect(resolveHeadlessOwnerLaunchSpec({
+      repoRoot: '/repo',
+      platform: 'darwin',
       env: {},
       which: (command) => (command === 'invoker-ui' ? '/usr/local/bin/invoker-ui' : undefined),
       existsSync: () => false,

--- a/packages/contracts/src/headless-owner-launch.ts
+++ b/packages/contracts/src/headless-owner-launch.ts
@@ -88,7 +88,14 @@ export function resolveHeadlessOwnerLaunchSpec(
 
   const invokerUi = which('invoker-ui');
   if (invokerUi) {
-    return { command: invokerUi, args: ['--headless', 'owner-serve'] };
+    return {
+      command: invokerUi,
+      args: [
+        ...(platform === 'linux' ? LINUX_HEADLESS_ELECTRON_FLAGS : []),
+        '--headless',
+        'owner-serve',
+      ],
+    };
   }
 
   const electronCjs = join(options.repoRoot, 'scripts', 'electron.cjs');

--- a/packages/slack-manager/src/__tests__/invoker-launcher.test.ts
+++ b/packages/slack-manager/src/__tests__/invoker-launcher.test.ts
@@ -2,7 +2,29 @@ import { describe, it, expect } from 'vitest';
 
 import { LINUX_HEADLESS_ELECTRON_FLAGS } from '@invoker/contracts';
 
-import { resolveOwnerLaunch } from '../invoker-launcher.js';
+import { resolveOwnerLaunch, withoutMissingPathEntries } from '../invoker-launcher.js';
+
+describe('withoutMissingPathEntries', () => {
+  const exists = (path: string) => path !== '/snap/bin' && path !== '/gone';
+
+  it('drops directories that do not exist so the owner does not segfault at startup', () => {
+    expect(withoutMissingPathEntries('/usr/bin:/snap/bin', exists)).toBe('/usr/bin');
+  });
+
+  it('keeps a PATH whose entries all exist unchanged', () => {
+    expect(withoutMissingPathEntries('/usr/local/bin:/usr/bin:/bin', exists)).toBe(
+      '/usr/local/bin:/usr/bin:/bin',
+    );
+  });
+
+  it('drops empty entries rather than leaving an implicit current directory', () => {
+    expect(withoutMissingPathEntries('/usr/bin::/bin', exists)).toBe('/usr/bin:/bin');
+  });
+
+  it('passes an unset PATH through untouched', () => {
+    expect(withoutMissingPathEntries(undefined, exists)).toBeUndefined();
+  });
+});
 
 describe('resolveOwnerLaunch', () => {
   it('prefers INVOKER_GUI_COMMAND when set', () => {
@@ -30,6 +52,20 @@ describe('resolveOwnerLaunch', () => {
     expect(spec).toEqual({
       command: '/usr/local/bin/invoker-ui',
       args: ['--headless', 'owner-serve'],
+    });
+  });
+
+  it('launches invoker-ui with the Linux stability flags so a host without a configured Chromium sandbox still starts', () => {
+    const spec = resolveOwnerLaunch({
+      repoRoot: '/repo',
+      platform: 'linux',
+      env: {},
+      which: (command) => (command === 'invoker-ui' ? '/usr/local/bin/invoker-ui' : undefined),
+      existsSync: () => false,
+    });
+    expect(spec).toEqual({
+      command: '/usr/local/bin/invoker-ui',
+      args: [...LINUX_HEADLESS_ELECTRON_FLAGS, '--headless', 'owner-serve'],
     });
   });
 

--- a/packages/slack-manager/src/invoker-launcher.ts
+++ b/packages/slack-manager/src/invoker-launcher.ts
@@ -13,7 +13,8 @@
  */
 
 import { spawn, type ChildProcess } from 'node:child_process';
-import { openSync } from 'node:fs';
+import { existsSync, openSync } from 'node:fs';
+import { delimiter } from 'node:path';
 
 import {
   resolveHeadlessOwnerLaunchSpec,
@@ -27,6 +28,23 @@ const SLACK_ENV_VARS = [
   'SLACK_CHANNEL_ID',
   'SLACK_LOBBY_CHANNEL_ID',
 ] as const;
+
+/**
+ * The packaged Electron owner aborts with SIGSEGV during startup when PATH
+ * carries directories that do not exist -- systemd's default user PATH ends in
+ * /snap/bin, which is absent on hosts without snapd, so the supervised owner
+ * crashed on every launch while the same binary ran fine from a login shell.
+ */
+export function withoutMissingPathEntries(
+  pathValue: string | undefined,
+  directoryExists: (path: string) => boolean = existsSync,
+): string | undefined {
+  if (!pathValue) return pathValue;
+  return pathValue
+    .split(delimiter)
+    .filter((entry) => entry.length > 0 && directoryExists(entry))
+    .join(delimiter);
+}
 
 export interface InvokerLauncherOptions {
   repoRoot: string;
@@ -59,6 +77,7 @@ export function createInvokerLauncher(options: InvokerLauncherOptions): InvokerL
       const env: NodeJS.ProcessEnv = {
         ...process.env,
         LIBGL_ALWAYS_SOFTWARE: process.platform === 'linux' ? '1' : process.env.LIBGL_ALWAYS_SOFTWARE,
+        PATH: withoutMissingPathEntries(process.env.PATH),
       };
       for (const key of SLACK_ENV_VARS) delete env[key];
 


### PR DESCRIPTION
The npm invoker-ui path skipped the Linux Electron stability flags that the
monorepo path already applied, so the AppImage aborted on hosts without a
configured Chromium setuid sandbox. Apply the same flags to both paths.

The supervised owner also segfaulted whenever PATH carried a directory that
does not exist -- systemd's default user PATH ends in /snap/bin, absent on
hosts without snapd. Drop dead PATH entries before spawning the owner.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>