### PR TITLE
[Headless owner launch on Linux](1) Give the packaged invoker-ui the Linux Electron flags

### DIFF
--- a/packages/contracts/src/__tests__/headless-owner-launch.test.ts
+++ b/packages/contracts/src/__tests__/headless-owner-launch.test.ts
@@ -39,10 +39,23 @@ describe('resolveHeadlessOwnerLaunchSpec', () => {
     });
   });
 
-  it('uses the packaged invoker-ui wrapper when present', () => {
+  it('gives the packaged invoker-ui wrapper the same Linux stability flags as the repo path', () => {
     expect(resolveHeadlessOwnerLaunchSpec({
       repoRoot: '/repo',
       platform: 'linux',
+      env: {},
+      which: (command) => (command === 'invoker-ui' ? '/usr/local/bin/invoker-ui' : undefined),
+      existsSync: () => false,
+    })).toEqual({
+      command: '/usr/local/bin/invoker-ui',
+      args: [...LINUX_HEADLESS_ELECTRON_FLAGS, '--headless', 'owner-serve'],
+    });
+  });
+
+  it('keeps the packaged invoker-ui wrapper free of Linux-only switches on macOS', () => {
+    expect(resolveHeadlessOwnerLaunchSpec({
+      repoRoot: '/repo',
+      platform: 'darwin',
       env: {},
       which: (command) => (command === 'invoker-ui' ? '/usr/local/bin/invoker-ui' : undefined),
       existsSync: () => false,

--- a/packages/contracts/src/headless-owner-launch.ts
+++ b/packages/contracts/src/headless-owner-launch.ts
@@ -88,7 +88,14 @@ export function resolveHeadlessOwnerLaunchSpec(
 
   const invokerUi = which('invoker-ui');
   if (invokerUi) {
-    return { command: invokerUi, args: ['--headless', 'owner-serve'] };
+    return {
+      command: invokerUi,
+      args: [
+        ...(platform === 'linux' ? LINUX_HEADLESS_ELECTRON_FLAGS : []),
+        '--headless',
+        'owner-serve',
+      ],
+    };
   }
 
   const electronCjs = join(options.repoRoot, 'scripts', 'electron.cjs');


### PR DESCRIPTION
## Summary

Invoker on DO1 now runs from the published npm binaries rather than a monorepo checkout.

Started that way, the owner process aborted immediately on Linux with a fatal Chromium sandbox error.

The shared launch contract already knew about this. It applies a set of Linux Electron flags, including `--no-sandbox`, but only on the monorepo checkout branch.

The packaged `invoker-ui` branch returned bare arguments with no flags at all.

So the AppImage aborts on any host whose Chromium setuid sandbox is not configured, which is the default on Ubuntu 24.04 and newer.

This applies the same flag constant to both branches of the contract.

## Review Claim

The shared launch contract gives the packaged `invoker-ui` the same Linux Electron flags it already gives the monorepo checkout.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The flags are gated on `platform === 'linux'`, so macOS and the explicit `INVOKER_GUI_COMMAND` override keep their existing arguments byte-for-byte. A new test pins the macOS case to prove that.

The flags come from the same `LINUX_HEADLESS_ELECTRON_FLAGS` constant the monorepo branch has always used, not a new list.

## Slice Rationale

Kept separate from the PATH work in the next commit, which belongs to a different review unit and touches the Slack manager rather than this shared type.

## Non-goals

Does not change owner behavior after startup, the monorepo launch path, the `INVOKER_GUI_COMMAND` override path, or any non-Linux platform.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/contracts && pnpm test`
- [ ] `cd packages/slack-manager && pnpm test`

</details>

Reproduced on DO1 against the real npm binary. `invoker-ui --version` exits 1 with `FATAL:setuid_sandbox_host.cc(163) The SUID sandbox helper binary was found, but is not configured correctly`. Adding `--no-sandbox` clears that abort.

The host reports `kernel.apparmor_restrict_unprivileged_userns = 1`, the Ubuntu default, which is what leaves the AppImage's bundled `chrome-sandbox` unusable.

After the change the resolver returns the flagged arguments on this host, and those arguments run the owner through to `standalone owner ready`.

The existing test asserted the old flagless arguments on Linux, so it encoded the bug and is updated here.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert fa4fffc39`
- Post-revert steps: None
- Data migration? No

</details>
