### PR TITLE
[Headless owner launch on Linux](2) Drop non-existent PATH entries before spawning the owner

### DIFF
--- a/packages/contracts/src/__tests__/headless-owner-launch.test.ts
+++ b/packages/contracts/src/__tests__/headless-owner-launch.test.ts
@@ -39,10 +39,23 @@ describe('resolveHeadlessOwnerLaunchSpec', () => {
     });
   });
 
-  it('uses the packaged invoker-ui wrapper when present', () => {
+  it('gives the packaged invoker-ui wrapper the same Linux stability flags as the repo path', () => {
     expect(resolveHeadlessOwnerLaunchSpec({
       repoRoot: '/repo',
       platform: 'linux',
+      env: {},
+      which: (command) => (command === 'invoker-ui' ? '/usr/local/bin/invoker-ui' : undefined),
+      existsSync: () => false,
+    })).toEqual({
+      command: '/usr/local/bin/invoker-ui',
+      args: [...LINUX_HEADLESS_ELECTRON_FLAGS, '--headless', 'owner-serve'],
+    });
+  });
+
+  it('keeps the packaged invoker-ui wrapper free of Linux-only switches on macOS', () => {
+    expect(resolveHeadlessOwnerLaunchSpec({
+      repoRoot: '/repo',
+      platform: 'darwin',
       env: {},
       which: (command) => (command === 'invoker-ui' ? '/usr/local/bin/invoker-ui' : undefined),
       existsSync: () => false,

--- a/packages/contracts/src/headless-owner-launch.ts
+++ b/packages/contracts/src/headless-owner-launch.ts
@@ -88,7 +88,14 @@ export function resolveHeadlessOwnerLaunchSpec(
 
   const invokerUi = which('invoker-ui');
   if (invokerUi) {
-    return { command: invokerUi, args: ['--headless', 'owner-serve'] };
+    return {
+      command: invokerUi,
+      args: [
+        ...(platform === 'linux' ? LINUX_HEADLESS_ELECTRON_FLAGS : []),
+        '--headless',
+        'owner-serve',
+      ],
+    };
   }
 
   const electronCjs = join(options.repoRoot, 'scripts', 'electron.cjs');

--- a/packages/slack-manager/src/__tests__/invoker-launcher.test.ts
+++ b/packages/slack-manager/src/__tests__/invoker-launcher.test.ts
@@ -2,7 +2,29 @@ import { describe, it, expect } from 'vitest';
 
 import { LINUX_HEADLESS_ELECTRON_FLAGS } from '@invoker/contracts';
 
-import { resolveOwnerLaunch } from '../invoker-launcher.js';
+import { resolveOwnerLaunch, withoutMissingPathEntries } from '../invoker-launcher.js';
+
+describe('withoutMissingPathEntries', () => {
+  const exists = (path: string) => path !== '/snap/bin' && path !== '/gone';
+
+  it('drops directories that do not exist so the owner does not segfault at startup', () => {
+    expect(withoutMissingPathEntries('/usr/bin:/snap/bin', exists)).toBe('/usr/bin');
+  });
+
+  it('keeps a PATH whose entries all exist unchanged', () => {
+    expect(withoutMissingPathEntries('/usr/local/bin:/usr/bin:/bin', exists)).toBe(
+      '/usr/local/bin:/usr/bin:/bin',
+    );
+  });
+
+  it('drops empty entries rather than leaving an implicit current directory', () => {
+    expect(withoutMissingPathEntries('/usr/bin::/bin', exists)).toBe('/usr/bin:/bin');
+  });
+
+  it('passes an unset PATH through untouched', () => {
+    expect(withoutMissingPathEntries(undefined, exists)).toBeUndefined();
+  });
+});
 
 describe('resolveOwnerLaunch', () => {
   it('prefers INVOKER_GUI_COMMAND when set', () => {
@@ -30,6 +52,20 @@ describe('resolveOwnerLaunch', () => {
     expect(spec).toEqual({
       command: '/usr/local/bin/invoker-ui',
       args: ['--headless', 'owner-serve'],
+    });
+  });
+
+  it('launches invoker-ui with the Linux stability flags so a host without a configured Chromium sandbox still starts', () => {
+    const spec = resolveOwnerLaunch({
+      repoRoot: '/repo',
+      platform: 'linux',
+      env: {},
+      which: (command) => (command === 'invoker-ui' ? '/usr/local/bin/invoker-ui' : undefined),
+      existsSync: () => false,
+    });
+    expect(spec).toEqual({
+      command: '/usr/local/bin/invoker-ui',
+      args: [...LINUX_HEADLESS_ELECTRON_FLAGS, '--headless', 'owner-serve'],
     });
   });
 

--- a/packages/slack-manager/src/invoker-launcher.ts
+++ b/packages/slack-manager/src/invoker-launcher.ts
@@ -13,7 +13,8 @@
  */
 
 import { spawn, type ChildProcess } from 'node:child_process';
-import { openSync } from 'node:fs';
+import { existsSync, openSync } from 'node:fs';
+import { delimiter } from 'node:path';
 
 import {
   resolveHeadlessOwnerLaunchSpec,
@@ -27,6 +28,23 @@ const SLACK_ENV_VARS = [
   'SLACK_CHANNEL_ID',
   'SLACK_LOBBY_CHANNEL_ID',
 ] as const;
+
+/**
+ * The packaged Electron owner aborts with SIGSEGV during startup when PATH
+ * carries directories that do not exist -- systemd's default user PATH ends in
+ * /snap/bin, which is absent on hosts without snapd, so the supervised owner
+ * crashed on every launch while the same binary ran fine from a login shell.
+ */
+export function withoutMissingPathEntries(
+  pathValue: string | undefined,
+  directoryExists: (path: string) => boolean = existsSync,
+): string | undefined {
+  if (!pathValue) return pathValue;
+  return pathValue
+    .split(delimiter)
+    .filter((entry) => entry.length > 0 && directoryExists(entry))
+    .join(delimiter);
+}
 
 export interface InvokerLauncherOptions {
   repoRoot: string;
@@ -59,6 +77,7 @@ export function createInvokerLauncher(options: InvokerLauncherOptions): InvokerL
       const env: NodeJS.ProcessEnv = {
         ...process.env,
         LIBGL_ALWAYS_SOFTWARE: process.platform === 'linux' ? '1' : process.env.LIBGL_ALWAYS_SOFTWARE,
+        PATH: withoutMissingPathEntries(process.env.PATH),
       };
       for (const key of SLACK_ENV_VARS) delete env[key];
 


### PR DESCRIPTION
## Summary

With the Electron flags from the previous commit, the headless owner starts fine by hand but still died on every launch under the systemd-supervised Slack manager.

The cause is a startup segfault in the packaged Electron owner. It triggers when `PATH` carries a directory that is absent from disk.

systemd's default user `PATH` ends in `/snap/bin`. That directory is missing on hosts running snapd, including this one.

A login shell's `PATH` has no such entry, which is why the same binary ran fine by hand and crashed under the supervisor.

The npm wrapper reports the signal as a bare exit code 1 with an empty message, so the crash left nothing in the logs to go on.

This filters absent directories out of `PATH` before the manager spawns the headless owner.

## Review Claim

The Slack manager hands the headless owner a `PATH` whose directories are all present on disk.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The filter only removes entries that fail an `existsSync` check, so a `PATH` whose directories are all present is passed through unchanged. A test pins that case.

It applies solely to the environment of the spawned owner. The Slack manager's own `PATH` is untouched, and no other environment variable is altered.

## Slice Rationale

Kept separate from the Electron flag work in the previous commit, which belongs to a different review unit and changes a shared type in `packages/contracts`.

## Non-goals

Does not fix the underlying Electron crash on an absent `PATH` directory, only the environment handed to it. Does not change the watchdog's relaunch policy, the systemd unit file, or the published npm packages.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/slack-manager && pnpm test`
- [ ] `pnpm --filter @invoker/slack-manager build`

</details>

Isolated on DO1 with an interleaved A/B run of the AppImage under an otherwise identical environment. A `PATH` ending in `/snap/bin` gave `signal=SIGSEGV` on both runs, and the same `PATH` without that entry stayed alive on both. A generic `/does/not/exist` entry reproduced the segfault too, so the trigger is the absent directory rather than snap itself.

Confirmed end to end by giving the live service a `PATH` with no absent directories. The watchdog went from `Invoker did not become healthy within 90s` on every attempt to `Invoker is healthy again`, the owner now appears in the service cgroup, and `./run.sh --headless query queue` answers with `mode=standalone`.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4ed0837ef`
- Post-revert steps: None
- Data migration? No

</details>
