### PR TITLE
[Bugfix: Export clean-snapshot selection helper for direct unit testing](1) Export findLatestCleanHourlySnapshot and add a direct unit test

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter-corruption-recovery.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter-corruption-recovery.test.ts
@@ -10,7 +10,7 @@ import {
 } from 'node:fs';
 import { basename, join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { SQLiteAdapter, isDatabaseCorruptionError } from '../sqlite-adapter.js';
+import { SQLiteAdapter, isDatabaseCorruptionError, findLatestCleanHourlySnapshot } from '../sqlite-adapter.js';
 
 /**
  * SQLiteAdapter.create() recovers a corrupt database by renaming it (and its
@@ -192,6 +192,36 @@ describe('SQLiteAdapter.create auto-restore from hourly snapshot', () => {
     } finally {
       adapter.close();
     }
+  });
+
+  it('findLatestCleanHourlySnapshot picks the newest clean snapshot from a fixture directory, skipping corrupt ones', async () => {
+    const dir = makeDir();
+    const backupDir = join(dir, 'db-backups');
+    mkdirSync(backupDir);
+    const dbBasename = 'invoker.db';
+
+    await seedSnapshot(join(backupDir, `${dbBasename}.hourly-auto-20260708-090000-000Z`), ['wf-clean-older']);
+    writeFileSync(
+      join(backupDir, `${dbBasename}.hourly-auto-20260708-100000-000Z`),
+      Buffer.from('xx not a sqlite header xx '.repeat(50)),
+    );
+
+    const result = await findLatestCleanHourlySnapshot(backupDir, dbBasename);
+    expect(result).toBe(join(backupDir, `${dbBasename}.hourly-auto-20260708-090000-000Z`));
+  });
+
+  it('findLatestCleanHourlySnapshot returns null when no snapshot in the fixture directory is clean', async () => {
+    const dir = makeDir();
+    const backupDir = join(dir, 'db-backups');
+    mkdirSync(backupDir);
+    const dbBasename = 'invoker.db';
+    writeFileSync(
+      join(backupDir, `${dbBasename}.hourly-auto-20260708-090000-000Z`),
+      Buffer.from('xx not a sqlite header xx '.repeat(50)),
+    );
+
+    const result = await findLatestCleanHourlySnapshot(backupDir, dbBasename);
+    expect(result).toBeNull();
   });
 
   it('falls back to an empty DB when db-backups has no clean snapshot', async () => {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -351,7 +351,7 @@ async function fileQuickCheckOk(dbPath: string): Promise<boolean> {
  * ISO-derived timestamp (`YYYYMMDD-HHMMSS-mmmZ`), so lexicographic descending
  * order is chronologically newest-first.
  */
-async function findLatestCleanHourlySnapshot(
+export async function findLatestCleanHourlySnapshot(
   backupDir: string,
   dbBasename: string,
 ): Promise<string | null> {


### PR DESCRIPTION
## Summary

`findLatestCleanHourlySnapshot` in `packages/data-store/src/sqlite-adapter.ts` already picks the newest backup snapshot that passes `PRAGMA quick_check`, but it was only reachable through the full corruption-recovery flow inside `SQLiteAdapter.create`.

This change adds the `export` keyword to that existing function so it can be called directly.

It also adds a unit test that exercises the function against a fixture directory of clean and corrupt snapshot files.

No production behavior changes. The function's body, ordering, and return values stay exactly the same.

## Review Claim

Approve exporting `findLatestCleanHourlySnapshot` (visibility only, no logic change) plus a direct unit test for it.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

`findLatestCleanHourlySnapshot`'s body, control flow, and return values are byte-identical before and after this change; only its visibility (module-private to exported) changes.

## Slice Rationale

One export-plus-test slice: make the existing named function reachable for direct unit testing and add that test, nothing else changes.

## Non-goals

No change to `fileQuickCheckOk`. No change to the quarantine rename logic in `SQLiteAdapter.create`. No new fields. No doc edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm test -- -t "skips a corrupt snapshot and falls back to the next clean one"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

