### PR TITLE
[Bugfix: An allowed-to-serve bus must keep retrying when serverless](1) Extract serve-recovery eligibility guard into a named function

### DIFF
--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_REQUEST_DEADLINE_MS,
   MALFORMED_FRAME_RATE_LIMIT_MS,
   resolveDefaultSocketPath,
+  isServeRecoveryEligible,
   type MalformedFrameEvent,
 } from '../ipc-bus.js';
 import { TransportError, TransportErrorCode } from '../transport-error.js';
@@ -646,6 +647,48 @@ describe('IpcBus', () => {
     await client.ready();
     const result = await client.request<string, string>('echo', 'ok');
     expect(result).toBe('owner:ok');
+  });
+
+  describe('isServeRecoveryEligible', () => {
+    const eligibleState = {
+      disconnected: false,
+      hasServer: false,
+      hasPeers: false,
+      recoveryAlreadyScheduled: false,
+    };
+
+    it('is eligible when disconnected, server, peers, and scheduled are all false', () => {
+      expect(isServeRecoveryEligible(eligibleState)).toBe(true);
+    });
+
+    it('is ineligible once disconnected', () => {
+      expect(isServeRecoveryEligible({ ...eligibleState, disconnected: true })).toBe(false);
+    });
+
+    it('is ineligible once it already has a server', () => {
+      expect(isServeRecoveryEligible({ ...eligibleState, hasServer: true })).toBe(false);
+    });
+
+    it('is ineligible once it already has a peer', () => {
+      expect(isServeRecoveryEligible({ ...eligibleState, hasPeers: true })).toBe(false);
+    });
+
+    it('is ineligible once a recovery attempt is already scheduled', () => {
+      expect(isServeRecoveryEligible({ ...eligibleState, recoveryAlreadyScheduled: true })).toBe(
+        false,
+      );
+    });
+
+    it('is ineligible when every condition is true', () => {
+      expect(
+        isServeRecoveryEligible({
+          disconnected: true,
+          hasServer: true,
+          hasPeers: true,
+          recoveryAlreadyScheduled: true,
+        }),
+      ).toBe(false);
+    });
   });
 
   it('surviving client reclaims the socket after the original server disappears', async () => {

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -273,6 +273,24 @@ export interface IpcBusOptions {
   onSubscriberError?: SubscriberErrorObserver;
 }
 
+/** Snapshot of the state {@link isServeRecoveryEligible} needs to decide whether an
+ *  IpcBus should schedule another attempt at reconnecting/becoming the server. */
+export interface ServeRecoveryState {
+  disconnected: boolean;
+  hasServer: boolean;
+  hasPeers: boolean;
+  recoveryAlreadyScheduled: boolean;
+}
+
+/** Whether an IpcBus in the given state should schedule another recovery attempt.
+ *  Recovery is unnecessary once the bus is disconnected, already has a server, already
+ *  has a peer, or already has a recovery attempt in flight. */
+export function isServeRecoveryEligible(state: ServeRecoveryState): boolean {
+  return (
+    !state.disconnected && !state.hasServer && !state.hasPeers && !state.recoveryAlreadyScheduled
+  );
+}
+
 // ---------------------------------------------------------------------------
 // IpcBus
 // ---------------------------------------------------------------------------
@@ -444,13 +462,27 @@ export class IpcBus implements MessageBus {
   // only *becoming* the server (tryServe) is exclusively gated on
   // allowServe, and that gate lives in tryConnect()'s error handler above.
   private scheduleRecovery(): void {
-    if (this.disconnected || this.server || this.peers.size > 0 || this.serveRetryScheduled) {
+    if (
+      !isServeRecoveryEligible({
+        disconnected: this.disconnected,
+        hasServer: this.server !== null,
+        hasPeers: this.peers.size > 0,
+        recoveryAlreadyScheduled: this.serveRetryScheduled,
+      })
+    ) {
       return;
     }
     this.serveRetryScheduled = true;
     setTimeout(() => {
       this.serveRetryScheduled = false;
-      if (this.disconnected || this.server || this.peers.size > 0) {
+      if (
+        !isServeRecoveryEligible({
+          disconnected: this.disconnected,
+          hasServer: this.server !== null,
+          hasPeers: this.peers.size > 0,
+          recoveryAlreadyScheduled: false,
+        })
+      ) {
         return;
       }
       this.tryConnect();


### PR DESCRIPTION
## Summary

An IpcBus instance allowed to serve already kept retrying whenever it had no server and no peers, so it never got stuck permanently client-less.

This change does not touch that behavior. It pulls the existing serve-recovery eligibility check out of `scheduleRecovery` into a small, named, exported function.

The new function is directly unit-tested. Before this, the check could only be exercised through a full socket-disconnect integration test.

## Review Claim

`isServeRecoveryEligible(state: ServeRecoveryState)` in `packages/transport/src/ipc-bus.ts` is byte-identical in behavior to the two inline conditions it replaces at their call sites inside `scheduleRecovery`, and is now covered by a direct unit test in `packages/transport/src/__tests__/ipc-bus.test.ts`.

## Review Lane

refactor

## Review Unit

ownership-refactor

## Safety Invariant

For every combination of `disconnected`, server presence, `peers.size`, and whether a recovery attempt is already scheduled, `scheduleRecovery` schedules (or skips scheduling) a retry under exactly the same conditions before and after this extraction. The 25ms `setTimeout` scheduling and the `tryConnect()` call inside the callback are unchanged; only the two inline conditions were replaced with calls to the new function.

## Slice Rationale

One slice: extract the existing serve-recovery eligibility condition into a named, exported function, called from both of its existing call sites inside `scheduleRecovery`. No new checks, no change to the retry delay or `tryConnect()`.

## Non-goals

No behavior change. No change to the 25ms recovery-attempt delay. No change to the callers of `scheduleRecovery` (`addPeer`'s `close`/`error` handlers, `tryConnectRetry`). No unrelated cleanup or doc edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/transport && pnpm test -- -t "surviving client reclaims the socket after the original server disappears"`
- [ ] `cd packages/transport && pnpm test -- -t "isServeRecoveryEligible"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
