### PR TITLE
[Opt-in owner workers](1) config schema

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -183,6 +183,39 @@ export interface InvokerConfig {
    */
   autoFixCi?: boolean;
   /**
+   * Owner-side infra-repair worker config.
+   * Default: false.
+   */
+  infraRepair?: {
+    enabled?: boolean;
+  };
+  /**
+   * Owner-side autofix worker config.
+   * Default: false.
+   */
+  autofix?: {
+    enabled?: boolean;
+  };
+  /**
+   * Owner-side reaper worker config.
+   * Default: false.
+   */
+  reaper?: {
+    enabled?: boolean;
+  };
+  /**
+   * Owner-side workflow-resume worker config.
+   * Default: false.
+   */
+  workflowResume?: {
+    enabled?: boolean;
+  };
+  /**
+   * Enables stalled-task requeue behavior.
+   * Default: false.
+   */
+  requeueEnabled?: boolean;
+  /**
    * Read-only diagnostics tuning for the Action Graph view.
    * Default stall threshold: 60000ms. Env fallback:
    * INVOKER_ACTION_STALL_THRESHOLD_MS.


### PR DESCRIPTION
## Summary

Add dormant config fields for optional owner workers.

Operators need one explicit on/off place for these workers.

This slice only extends `packages/app/src/config.ts`. Startup code does not consume the new values yet.

## Review Claim

Adds five optional config fields for owner-worker opt-in control in `packages/app/src/config.ts`.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

The change is additive and dormant. Existing config keys stay untouched, and no runtime code consumes the new keys in this slice.

## Slice Rationale

The config surface lands before the worker startup logic that will consume it in the next slice.

A single aggregate setting was rejected because the existing config uses per-feature nested objects and booleans.

## Non-goals

No changes to worker startup, main process launch, CLI commands, docs, or tests.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 40a208ae1`
- Post-revert steps: Rerun `cd packages/app && pnpm test` if reverted outside CI.
- Data migration? No

</details>
