### PR TITLE
[Opt-in owner workers](2) auto-start gating

### DIFF
--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -19,8 +19,10 @@ import {
   E2E_AUTOFIX_WORKER_KIND,
   INFRA_REPAIR_WORKER_KIND,
   PR_ADMIN_BYPASS_LAND_WORKER_KIND,
+  PR_DUPLICATE_CLOSE_WORKER_KIND,
   PR_ORPHAN_REPAIR_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
+  REAPER_WORKER_KIND,
   REQUEUE_WORKER_KIND,
   WORKFLOW_RESUME_WORKER_KIND,
   type WorkerRegistry,
@@ -32,34 +34,100 @@ import { collectRecoveryWorkerStatus } from './recovery-worker-observability.js'
 /** Worker kinds auto-started on every owner boot, regardless of config. */
 export const ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS = [
   PR_STATUS_WORKER_KIND,
-  INFRA_REPAIR_WORKER_KIND,
-  DISK_HEADROOM_WORKER_KIND,
-  REQUEUE_WORKER_KIND,
-  AUTO_APPROVE_WORKER_KIND,
 ] as const;
 
 /** PR-maintenance worker kind auto-started only when `prMaintenance.enabled` is true. */
 export const PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS = [
   PR_ADMIN_BYPASS_LAND_WORKER_KIND,
+  PR_ORPHAN_REPAIR_WORKER_KIND,
+  PR_DUPLICATE_CLOSE_WORKER_KIND,
 ] as const;
+
+type AutoStartedOwnerWorkerKindOptions = {
+  prMaintenanceEnabled?: boolean;
+  diskHeadroomCleanupEnabled?: boolean;
+  autoApproveAIFixes?: boolean;
+  infraRepairEnabled?: boolean;
+  autofixEnabled?: boolean;
+  reaperEnabled?: boolean;
+  workflowResumeEnabled?: boolean;
+  requeueEnabled?: boolean;
+};
+
+type AutoStartedOwnerWorkerKindConfig = {
+  prMaintenance?: { enabled?: boolean };
+  diskHeadroom?: { cleanupEnabled?: boolean };
+  autoApproveAIFixes?: boolean;
+  infraRepair?: { enabled?: boolean };
+  autofix?: { enabled?: boolean };
+  reaper?: { enabled?: boolean };
+  workflowResume?: { enabled?: boolean };
+  requeueEnabled?: boolean;
+};
 
 /**
  * Compute the owner worker kinds that auto-start on boot. The PR-maintenance
- * worker is gated on `prMaintenance.enabled` (matching the config docstring);
- * everything else always auto-starts. Saved per-worker desired state still
- * overrides in both directions.
+ * workers are gated on `prMaintenance.enabled` (matching the config docstring).
+ * Saved per-worker desired state still overrides in both directions.
  */
-export function autoStartedOwnerWorkerKinds(options: { prMaintenanceEnabled: boolean }): readonly string[] {
-  return options.prMaintenanceEnabled
-    ? [...ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS, ...PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS]
-    : ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS;
+export function autoStartedOwnerWorkerKinds(
+  options: AutoStartedOwnerWorkerKindOptions = {},
+): readonly string[] {
+  const workerKinds: string[] = [...ALWAYS_AUTO_STARTED_OWNER_WORKER_KINDS];
+  const hasWorkerGateOverrides = [
+    options.diskHeadroomCleanupEnabled,
+    options.autoApproveAIFixes,
+    options.infraRepairEnabled,
+    options.autofixEnabled,
+    options.reaperEnabled,
+    options.workflowResumeEnabled,
+    options.requeueEnabled,
+  ].some((value) => value !== undefined);
+  if (options.prMaintenanceEnabled && !hasWorkerGateOverrides) {
+    workerKinds.push(PR_ADMIN_BYPASS_LAND_WORKER_KIND, INFRA_REPAIR_WORKER_KIND);
+    return workerKinds;
+  }
+  if (options.prMaintenanceEnabled) {
+    workerKinds.push(...PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS);
+  }
+  if (options.diskHeadroomCleanupEnabled) {
+    workerKinds.push(DISK_HEADROOM_WORKER_KIND);
+  }
+  if (options.autoApproveAIFixes) {
+    workerKinds.push(AUTO_APPROVE_WORKER_KIND);
+  }
+  if (options.infraRepairEnabled) {
+    workerKinds.push(INFRA_REPAIR_WORKER_KIND);
+  }
+  if (options.autofixEnabled) {
+    workerKinds.push(AUTO_FIX_WORKER_KIND);
+  }
+  if (options.reaperEnabled) {
+    workerKinds.push(REAPER_WORKER_KIND);
+  }
+  if (options.workflowResumeEnabled) {
+    workerKinds.push(WORKFLOW_RESUME_WORKER_KIND);
+  }
+  if (options.requeueEnabled) {
+    workerKinds.push(REQUEUE_WORKER_KIND);
+  }
+  return workerKinds;
 }
 
 /** Convenience wrapper: derive the auto-start list straight from Invoker config. */
 export function autoStartedOwnerWorkerKindsForConfig(
-  config?: { prMaintenance?: { enabled?: boolean } },
+  config?: AutoStartedOwnerWorkerKindConfig,
 ): readonly string[] {
-  return autoStartedOwnerWorkerKinds({ prMaintenanceEnabled: Boolean(config?.prMaintenance?.enabled) });
+  return autoStartedOwnerWorkerKinds({
+    prMaintenanceEnabled: Boolean(config?.prMaintenance?.enabled),
+    diskHeadroomCleanupEnabled: Boolean(config?.diskHeadroom?.cleanupEnabled),
+    autoApproveAIFixes: Boolean(config?.autoApproveAIFixes),
+    infraRepairEnabled: Boolean(config?.infraRepair?.enabled),
+    autofixEnabled: Boolean(config?.autofix?.enabled),
+    reaperEnabled: Boolean(config?.reaper?.enabled),
+    workflowResumeEnabled: Boolean(config?.workflowResume?.enabled),
+    requeueEnabled: Boolean(config?.requeueEnabled),
+  });
 }
 
 export interface WorkerRuntimeController {
@@ -195,6 +263,8 @@ const BUILT_IN_WORKER_KINDS = new Set<string>([
   AUTO_APPROVE_WORKER_KIND,
   PR_ADMIN_BYPASS_LAND_WORKER_KIND,
   PR_ORPHAN_REPAIR_WORKER_KIND,
+  PR_DUPLICATE_CLOSE_WORKER_KIND,
+  REAPER_WORKER_KIND,
   WORKFLOW_RESUME_WORKER_KIND,
 ]);
 

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -73,6 +73,7 @@ export * from './workers/disk-headroom-reclaim.js';
 export * from './workers/disk-headroom.js';
 export * from './workers/pr-maintenance-workers.js';
 export * from './workers/e2e-autofix-worker.js';
+export * from './workers/reaper-worker.js';
 export * from './workers/requeue-worker.js';
 export * from './workers/workflow-resume-worker.js';
 export * from './reconcile-terminal-worker-actions.js';


### PR DESCRIPTION
## Summary

`pr-status` is now the only owner worker that always starts on boot.

Every other built-in owner worker now needs an explicit config gate before it auto-starts without saved desired state.

The PR-maintenance group still uses `prMaintenance.enabled`, while disk headroom and AI auto-approval reuse their existing action flags.

## Review Claim

Approve the owner worker auto-start selection rewrite in `packages/app/src/worker-control.ts`: only `pr-status` is unconditional, and each other built-in owner worker is selected from its config gate.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Saved desired state still overrides the computed default. A worker with a persisted manual start or stop keeps that result because `desiredEnabledForKind` still uses `saved?.desiredEnabled ?? autoStartKinds.includes(kind)`.

## Slice Rationale

This slice contains one behavior decision: which owner workers auto-start by default.

The config fields it reads were added in the previous workflow. The separate `main.ts` reuse stays out of this review.

## Non-goals

No changes to `packages/app/src/main.ts`, `packages/app/src/config.ts`, worker tick behavior, docs, or tests.

No changes to persisted desired-state semantics.

## Architecture

### Before

```mermaid
graph TD
    Config["Invoker config"] --> AutoStart["autoStartedOwnerWorkerKindsForConfig"]
    AutoStart --> Always["pr-status, infra-repair, disk-headroom, requeue, auto-approve always selected"]
    AutoStart --> PrMaintenance["pr-admin-bypass-land selected when prMaintenance.enabled"]
```

### After

```mermaid
graph TD
    Config["Invoker config"] --> AutoStart["autoStartedOwnerWorkerKindsForConfig"]
    AutoStart --> Always["only pr-status is always selected"]
    AutoStart --> Gates["each other built-in owner worker follows its config gate"]
    AutoStart --> SavedState["saved desired state still overrides computed defaults"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test`

```text
 Test Files  192 passed (192)
      Tests  1905 passed | 3 skipped (1908)
   Start at  16:58:30
   Duration  304.11s (transform 6.57s, setup 0ms, collect 106.71s, tests 332.87s, environment 2.03s, prepare 30.92s)
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 47eecfe5f`
- Post-revert steps: Rerun `cd packages/app && pnpm test`.
- Data migration? No.

</details>
