### PR TITLE
[Opt-in owner workers](3) e2e-autofix dedup

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -94,7 +94,6 @@ import {
   createWorkerRegistry,
   GitHubMergeGateProvider,
   PR_STATUS_WORKER_KIND,
-  E2E_AUTOFIX_WORKER_KIND,
   registerBuiltinAgents,
   registerBuiltinWorkers,
   parseSpawnRepairWorkflowMutationArgs,
@@ -1936,9 +1935,7 @@ function startHeadlessMode(): void {
               await createStandaloneTaskExecutor().checkMergeGateStatuses();
             },
           ),
-          autoStartKinds: invokerConfig.e2eAutoFixEnabled
-            ? [...autoStartedOwnerWorkerKindsForConfig(invokerConfig), E2E_AUTOFIX_WORKER_KIND]
-            : autoStartedOwnerWorkerKindsForConfig(invokerConfig),
+          autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
           persistence,
           autoFixRetries: resolveAutoFixRetries(invokerConfig),
           canControl: () => !readOnlyMode,
@@ -3075,9 +3072,7 @@ startMainProcessBootstrap({
             await requireTaskExecutor().checkMergeGateStatuses();
           },
         ),
-        autoStartKinds: invokerConfig.e2eAutoFixEnabled
-          ? [...autoStartedOwnerWorkerKindsForConfig(invokerConfig), E2E_AUTOFIX_WORKER_KIND]
-          : autoStartedOwnerWorkerKindsForConfig(invokerConfig),
+        autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
         persistence,
         autoFixRetries: resolveAutoFixRetries(invokerConfig),
         canControl: () => ownerMode,

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -60,6 +60,7 @@ type AutoStartedOwnerWorkerKindConfig = {
   autoApproveAIFixes?: boolean;
   infraRepair?: { enabled?: boolean };
   autofix?: { enabled?: boolean };
+  e2eAutoFixEnabled?: boolean;
   reaper?: { enabled?: boolean };
   workflowResume?: { enabled?: boolean };
   requeueEnabled?: boolean;
@@ -118,7 +119,7 @@ export function autoStartedOwnerWorkerKinds(
 export function autoStartedOwnerWorkerKindsForConfig(
   config?: AutoStartedOwnerWorkerKindConfig,
 ): readonly string[] {
-  return autoStartedOwnerWorkerKinds({
+  const workerKinds = autoStartedOwnerWorkerKinds({
     prMaintenanceEnabled: Boolean(config?.prMaintenance?.enabled),
     diskHeadroomCleanupEnabled: Boolean(config?.diskHeadroom?.cleanupEnabled),
     autoApproveAIFixes: Boolean(config?.autoApproveAIFixes),
@@ -128,6 +129,9 @@ export function autoStartedOwnerWorkerKindsForConfig(
     workflowResumeEnabled: Boolean(config?.workflowResume?.enabled),
     requeueEnabled: Boolean(config?.requeueEnabled),
   });
+  return config?.e2eAutoFixEnabled
+    ? [...workerKinds, E2E_AUTOFIX_WORKER_KIND]
+    : workerKinds;
 }
 
 export interface WorkerRuntimeController {


### PR DESCRIPTION
## Summary

Centralize the e2e-autofix auto-start check in the shared owner-worker helper.

Both main-process startup paths now route through that helper, removing drift risk while preserving the existing flag behavior.

## Review Claim

Approve routing both main-process startup paths through `autoStartedOwnerWorkerKindsForConfig`, which includes e2e-autofix only when `e2eAutoFixEnabled` is true.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

E2E-autofix auto-start behavior stays identical: the field remains `e2eAutoFixEnabled`, its default remains `false`, and the worker kind is present if and only if the field is true.

## Slice Rationale

This slice handles only the e2e-autofix flag after the broader owner-worker gating change, keeping this small control-flow change independently reviewable.

## Non-goals

- No change to the `e2eAutoFixEnabled` config field or its default.
- No change to `e2eAutoFixIntervalMs`.
- No test or documentation changes.
- No changes to other worker gates.

## Architecture

### Before

```mermaid
graph TD
    H["Headless startup"] --> HG["Inline e2eAutoFixEnabled check"]
    D["Desktop startup"] --> DG["Inline e2eAutoFixEnabled check"]
    HG --> HL["Helper list plus optional e2e-autofix kind"]
    DG --> DL["Helper list plus optional e2e-autofix kind"]
```

### After

```mermaid
graph TD
    H["Headless startup"] --> S["autoStartedOwnerWorkerKindsForConfig"]
    D["Desktop startup"] --> S
    S --> G["e2eAutoFixEnabled check"]
    G --> L["Complete owner-worker auto-start list"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test`

```text
 Test Files  192 passed (192)
      Tests  1905 passed | 3 skipped (1908)
   Start at  18:18:10
   Duration  111.84s (transform 2.58s, setup 0ms, collect 21.65s, tests 158.58s, environment 340ms, prepare 8.70s)
```

- [x] `cd packages/app && pnpm test -- src/__tests__/worker-control.test.ts -t 'auto-starts e2e-autofix only when its kind is in autoStartKinds'`

```text
 ✓ src/__tests__/worker-control.test.ts (17 tests | 16 skipped) 4ms

 Test Files  1 passed (1)
      Tests  1 passed | 16 skipped (17)
   Start at  18:18:01
   Duration  1.22s (transform 641ms, setup 0ms, collect 921ms, tests 4ms, environment 0ms, prepare 64ms)
```

- [x] `node -e 'const fs=require("node:fs"); const source=fs.readFileSync("packages/app/src/main.ts", "utf8"); const found=/e2eAutoFixEnabled|E2E_AUTOFIX_WORKER_KIND/.test(source); console.log(`main.ts inline e2e-autofix gate: ${found ? "present" : "absent"}`); process.exit(found ? 1 : 0);'`

```text
main.ts inline e2e-autofix gate: absent
```

</details>

## Visual Proof

![Focused e2e-autofix worker-control test proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260810-f8fbb6/e2e-autofix-worker-control-proof.png)

The focused worker-control check exercises the e2e-autofix lifecycle using the shared auto-start list.

Manually inspected: The image shows the "E2E autofix worker-control proof" title, the focused Vitest command, `src/__tests__/worker-control.test.ts`, and a green summary with one test file passed and one test passed.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert e9a331c780fe8cc080801ed2a1116250b6f49ea2`
- Post-revert steps: Rerun `cd packages/app && pnpm test`.
- Data migration? No.

</details>
