### PR TITLE
Bugfix: Extract activity_log prune-throttle check into named guard

### DIFF
--- a/packages/data-store/src/__tests__/activity-log-retention.test.ts
+++ b/packages/data-store/src/__tests__/activity-log-retention.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { SQLiteAdapter } from '../sqlite-adapter.js';
+import { SQLiteAdapter, shouldPruneActivityLog } from '../sqlite-adapter.js';
 
 const PRUNE_INTERVAL = 1_000; // matches ACTIVITY_LOG_PRUNE_INTERVAL in sqlite-adapter.ts
 
@@ -55,6 +55,13 @@ describe('activity_log retention', () => {
     const newest = adapter.getActivityLogs(0, writes).map((r) => r.message);
     expect(newest).toContain(`entry-${writes - 1}`);
     expect(newest).not.toContain('entry-0');
+  });
+
+  it('shouldPruneActivityLog throttles on the writes-since-prune/interval threshold', () => {
+    expect(shouldPruneActivityLog(0, PRUNE_INTERVAL)).toBe(false);
+    expect(shouldPruneActivityLog(PRUNE_INTERVAL - 1, PRUNE_INTERVAL)).toBe(false);
+    expect(shouldPruneActivityLog(PRUNE_INTERVAL, PRUNE_INTERVAL)).toBe(true);
+    expect(shouldPruneActivityLog(PRUNE_INTERVAL + 1, PRUNE_INTERVAL)).toBe(true);
   });
 
   it('treats maxRows <= 0 as retention disabled (reproduces the unbounded growth)', async () => {

--- a/packages/data-store/src/__tests__/exclusive-locking.test.ts
+++ b/packages/data-store/src/__tests__/exclusive-locking.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, existsSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SQLiteAdapter, hasLiveWritableOwner } from '../sqlite-adapter.js';
@@ -85,11 +85,43 @@ describe('SQLiteAdapter exclusiveLocking', () => {
       owner.saveWorkflow(wf);
       expect(existsSync(`${dbPath}-wal`)).toBe(true);
       expect(existsSync(`${dbPath}-shm`)).toBe(false);
+      // The read-only rejection below is driven by hasLiveWritableOwner; pin its
+      // verdict here so the two cannot silently diverge in this sidecar shape.
+      expect(hasLiveWritableOwner(dbPath)).toBe(true);
       await expect(
         SQLiteAdapter.create(dbPath, { readOnly: true }),
       ).rejects.toThrow(/exclusive locking.*read-only viewers/i);
     } finally {
       owner.close();
+    }
+  });
+
+  it('allows a read-only open when a stale owner marker survives in the exclusive-locking sidecar shape', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true, exclusiveLocking: true });
+    owner.saveWorkflow(wf);
+    expect(existsSync(`${dbPath}-wal`)).toBe(true);
+    expect(existsSync(`${dbPath}-shm`)).toBe(false);
+
+    // Snapshot the live -wal bytes before the owner cleanly shuts down (which
+    // would checkpoint it away), then restore them after close to recreate the
+    // filesystem state a crashed owner would leave behind: -wal present with no
+    // -shm, and a stale marker naming a PID that is no longer alive.
+    const walSnapshot = readFileSync(`${dbPath}-wal`);
+    owner.close();
+    writeFileSync(`${dbPath}-wal`, walSnapshot);
+    // PID 2^22 is above every configured pid_max, so it can never be alive.
+    writeFileSync(`${dbPath}.owner`, '4194304', 'utf-8');
+
+    // Both the exported guard and the read-only open it gates must agree that
+    // no live writable owner remains in this sidecar shape.
+    expect(hasLiveWritableOwner(dbPath)).toBe(false);
+    const survivor = await SQLiteAdapter.create(dbPath, { readOnly: true });
+    try {
+      expect(survivor.listWorkflows().map((w) => w.id)).toEqual(['wf-1']);
+    } finally {
+      survivor.close();
     }
   });
 

--- a/packages/data-store/src/__tests__/exclusive-locking.test.ts
+++ b/packages/data-store/src/__tests__/exclusive-locking.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, existsSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { SQLiteAdapter, hasLiveWritableOwner } from '../sqlite-adapter.js';
+import { DatabaseSync } from 'node:sqlite';
+import { SQLiteAdapter, hasLiveWritableOwner, applyExclusiveLockingBeforeWal } from '../sqlite-adapter.js';
 import type { Workflow } from '../adapter.js';
 
 /**
@@ -41,6 +42,26 @@ describe('SQLiteAdapter exclusiveLocking', () => {
       expect(existsSync(`${dbPath}-wal`)).toBe(true); // still WAL, just heap wal-index
     } finally {
       adapter.close();
+    }
+  });
+
+  it('applyExclusiveLockingBeforeWal sets EXCLUSIVE locking_mode when true, leaves default when false', () => {
+    const dir = makeDir();
+
+    const exclusiveDb = new DatabaseSync(join(dir, 'exclusive.db'));
+    try {
+      applyExclusiveLockingBeforeWal(exclusiveDb, true);
+      expect((exclusiveDb.prepare('PRAGMA locking_mode').get() as { locking_mode?: string }).locking_mode).toBe('exclusive');
+    } finally {
+      exclusiveDb.close();
+    }
+
+    const normalDb = new DatabaseSync(join(dir, 'normal.db'));
+    try {
+      applyExclusiveLockingBeforeWal(normalDb, false);
+      expect((normalDb.prepare('PRAGMA locking_mode').get() as { locking_mode?: string }).locking_mode).toBe('normal');
+    } finally {
+      normalDb.close();
     }
   });
 

--- a/packages/data-store/src/__tests__/sqlite-adapter-corruption-recovery.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter-corruption-recovery.test.ts
@@ -10,7 +10,7 @@ import {
 } from 'node:fs';
 import { basename, join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { SQLiteAdapter, isDatabaseCorruptionError } from '../sqlite-adapter.js';
+import { SQLiteAdapter, isDatabaseCorruptionError, findLatestCleanHourlySnapshot } from '../sqlite-adapter.js';
 
 /**
  * SQLiteAdapter.create() recovers a corrupt database by renaming it (and its
@@ -192,6 +192,36 @@ describe('SQLiteAdapter.create auto-restore from hourly snapshot', () => {
     } finally {
       adapter.close();
     }
+  });
+
+  it('findLatestCleanHourlySnapshot picks the newest clean snapshot from a fixture directory, skipping corrupt ones', async () => {
+    const dir = makeDir();
+    const backupDir = join(dir, 'db-backups');
+    mkdirSync(backupDir);
+    const dbBasename = 'invoker.db';
+
+    await seedSnapshot(join(backupDir, `${dbBasename}.hourly-auto-20260708-090000-000Z`), ['wf-clean-older']);
+    writeFileSync(
+      join(backupDir, `${dbBasename}.hourly-auto-20260708-100000-000Z`),
+      Buffer.from('xx not a sqlite header xx '.repeat(50)),
+    );
+
+    const result = await findLatestCleanHourlySnapshot(backupDir, dbBasename);
+    expect(result).toBe(join(backupDir, `${dbBasename}.hourly-auto-20260708-090000-000Z`));
+  });
+
+  it('findLatestCleanHourlySnapshot returns null when no snapshot in the fixture directory is clean', async () => {
+    const dir = makeDir();
+    const backupDir = join(dir, 'db-backups');
+    mkdirSync(backupDir);
+    const dbBasename = 'invoker.db';
+    writeFileSync(
+      join(backupDir, `${dbBasename}.hourly-auto-20260708-090000-000Z`),
+      Buffer.from('xx not a sqlite header xx '.repeat(50)),
+    );
+
+    const result = await findLatestCleanHourlySnapshot(backupDir, dbBasename);
+    expect(result).toBeNull();
   });
 
   it('falls back to an empty DB when db-backups has no clean snapshot', async () => {

--- a/packages/data-store/src/__tests__/sqlite-adapter-corruption-recovery.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter-corruption-recovery.test.ts
@@ -10,7 +10,12 @@ import {
 } from 'node:fs';
 import { basename, join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { SQLiteAdapter, isDatabaseCorruptionError, findLatestCleanHourlySnapshot } from '../sqlite-adapter.js';
+import {
+  SQLiteAdapter,
+  isDatabaseCorruptionError,
+  isCorruptionRecoveryEligible,
+  findLatestCleanHourlySnapshot,
+} from '../sqlite-adapter.js';
 
 /**
  * SQLiteAdapter.create() recovers a corrupt database by renaming it (and its
@@ -119,6 +124,51 @@ describe('SQLiteAdapter.create recovery', () => {
 
     expect(readdirSync(dir).some((name) => name.includes('.corrupt-'))).toBe(false);
     expect(existsSync(join(dbPath, 'sentinel'))).toBe(true);
+  });
+});
+
+describe('isCorruptionRecoveryEligible', () => {
+  const corruptionErr = { errcode: 11 }; // SQLITE_CORRUPT
+  const operationalErr = { errcode: 14 }; // SQLITE_CANTOPEN, not corruption
+
+  it('is eligible when the target is a file, writable, existing, and the error is corruption', () => {
+    expect(isCorruptionRecoveryEligible(corruptionErr, {
+      isFile: true,
+      readOnly: false,
+      dbPathExists: true,
+    })).toBe(true);
+  });
+
+  it('is NOT eligible for a non-file (e.g. in-memory/ephemeral) database', () => {
+    expect(isCorruptionRecoveryEligible(corruptionErr, {
+      isFile: false,
+      readOnly: false,
+      dbPathExists: true,
+    })).toBe(false);
+  });
+
+  it('is NOT eligible when opened read-only', () => {
+    expect(isCorruptionRecoveryEligible(corruptionErr, {
+      isFile: true,
+      readOnly: true,
+      dbPathExists: true,
+    })).toBe(false);
+  });
+
+  it('is NOT eligible when the db file does not exist yet', () => {
+    expect(isCorruptionRecoveryEligible(corruptionErr, {
+      isFile: true,
+      readOnly: false,
+      dbPathExists: false,
+    })).toBe(false);
+  });
+
+  it('is NOT eligible when the error is not classified as corruption', () => {
+    expect(isCorruptionRecoveryEligible(operationalErr, {
+      isFile: true,
+      readOnly: false,
+      dbPathExists: true,
+    })).toBe(false);
   });
 });
 

--- a/packages/data-store/src/__tests__/wal-snapshot-isolation.test.ts
+++ b/packages/data-store/src/__tests__/wal-snapshot-isolation.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { Workflow } from '../adapter.js';
+
+/**
+ * Commit b2e54f4b7 removed the blanket "read-only open fails whenever WAL
+ * sidecars exist" check, relying instead on SQLite's own WAL snapshot
+ * isolation: an already-open reader stays pinned to the snapshot it took,
+ * even while a live writer commits further changes to the same file. These
+ * tests hold that guarantee to a concrete repro rather than trusting it by
+ * assertion.
+ */
+
+const dirs: string[] = [];
+function makeDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'wal-snapshot-'));
+  dirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function makeWorkflow(id: string): Workflow {
+  return {
+    id,
+    name: id,
+    status: 'running',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+describe('WAL snapshot isolation for an already-open reader', () => {
+  it('does not observe a write made after its snapshot', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+
+    const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      owner.saveWorkflow(makeWorkflow('wf-1'));
+
+      // Same WAL PRAGMA Invoker's own connections use (configureConnection in
+      // sqlite-adapter.ts); busy_timeout matters here since the reader shares
+      // the file with a live writable owner.
+      const reader = new DatabaseSync(dbPath, { readOnly: true });
+      try {
+        reader.exec('PRAGMA busy_timeout = 5000');
+
+        // A deferred BEGIN does not itself take the WAL snapshot; the first
+        // read does. Run one now so the snapshot is pinned before the
+        // owner's second write commits.
+        reader.exec('BEGIN');
+        const beforeRows = reader.prepare('SELECT id FROM workflows ORDER BY id').all() as Array<{ id: string }>;
+        expect(beforeRows.map((r) => r.id)).toEqual(['wf-1']);
+
+        owner.saveWorkflow(makeWorkflow('wf-2'));
+
+        // The reader's still-open transaction must stay pinned to its
+        // original snapshot even though the file on disk now has two rows.
+        const duringRows = reader.prepare('SELECT id FROM workflows ORDER BY id').all() as Array<{ id: string }>;
+        expect(duringRows.map((r) => r.id)).toEqual(['wf-1']);
+
+        reader.exec('COMMIT');
+
+        // A fresh snapshot (post-commit) sees both rows.
+        const afterRows = reader.prepare('SELECT id FROM workflows ORDER BY id').all() as Array<{ id: string }>;
+        expect(afterRows.map((r) => r.id)).toEqual(['wf-1', 'wf-2']);
+      } finally {
+        reader.close();
+      }
+    } finally {
+      owner.close();
+    }
+  });
+});

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -305,6 +305,16 @@ export function isDatabaseCorruptionError(err: unknown): boolean {
   return message.includes('malformed') || message.includes('not a database');
 }
 
+export function isCorruptionRecoveryEligible(
+  err: unknown,
+  context: { isFile: boolean; readOnly: boolean; dbPathExists: boolean },
+): boolean {
+  return context.isFile
+    && !context.readOnly
+    && context.dbPathExists
+    && isDatabaseCorruptionError(err);
+}
+
 /**
  * Metadata attached to an adapter that opened via the corruption-recovery
  * branch of {@link SQLiteAdapter.create}. `restoredFromSnapshot` is the source
@@ -821,7 +831,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
       if (isFile && requestWritable && options?.ownerCapability) writeOwnerMarker(dbPath);
       return new SQLiteAdapter(db, isFile ? dbPath : null, options);
     } catch (err) {
-      if (!isFile || options?.readOnly === true || !existsSync(dbPath) || !isDatabaseCorruptionError(err)) {
+      if (!isCorruptionRecoveryEligible(err, {
+        isFile,
+        readOnly: options?.readOnly === true,
+        dbPathExists: existsSync(dbPath),
+      })) {
         throw err;
       }
       const detectedAt = new Date().toISOString();

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -351,7 +351,7 @@ async function fileQuickCheckOk(dbPath: string): Promise<boolean> {
  * ISO-derived timestamp (`YYYYMMDD-HHMMSS-mmmZ`), so lexicographic descending
  * order is chronologically newest-first.
  */
-async function findLatestCleanHourlySnapshot(
+export async function findLatestCleanHourlySnapshot(
   backupDir: string,
   dbBasename: string,
 ): Promise<string | null> {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -802,8 +802,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
       && existsSync(`${dbPath}-wal`)
       && !existsSync(`${dbPath}-shm`)
     ) {
-      const ownerPid = readLiveOwnerPid(dbPath);
-      if (ownerPid !== null) {
+      if (hasLiveWritableOwner(dbPath)) {
+        const ownerPid = readLiveOwnerPid(dbPath);
         throw new Error(
           `Cannot open SQLite database read-only while writable owner PID ${ownerPid} is using exclusive locking for ${dbPath}. ` +
           'exclusiveLocking is incompatible with delegated read-only viewers; restart the owner in normal WAL mode.',

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -142,6 +142,15 @@ export function hasLiveWritableOwner(dbPath: string): boolean {
   return sidecarsExist && readLiveOwnerPid(dbPath) !== null;
 }
 
+/**
+ * Heap wal-index (no -shm file). MUST precede `journal_mode = WAL`.
+ */
+export function applyExclusiveLockingBeforeWal(db: DatabaseSync, exclusiveLocking: boolean): void {
+  if (exclusiveLocking) {
+    db.exec('PRAGMA locking_mode = EXCLUSIVE');
+  }
+}
+
 function writeOwnerMarker(dbPath: string): void {
   try {
     writeFileSync(ownerMarkerPath(dbPath), String(process.pid), 'utf-8');
@@ -917,10 +926,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.nativeDb.exec('PRAGMA busy_timeout = 5000');
     this.nativeDb.exec('PRAGMA foreign_keys = ON');
     if (fileBacked) {
-      if (this.exclusiveLocking) {
-        // Heap wal-index (no -shm file). MUST precede `journal_mode = WAL`.
-        this.nativeDb.exec('PRAGMA locking_mode = EXCLUSIVE');
-      }
+      applyExclusiveLockingBeforeWal(this.nativeDb, this.exclusiveLocking);
       this.nativeDb.exec('PRAGMA journal_mode = WAL');
       this.nativeDb.exec('PRAGMA synchronous = FULL');
       this.nativeDb.exec('PRAGMA wal_autocheckpoint = 1000');

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -100,6 +100,10 @@ const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 const DEFAULT_ACTIVITY_LOG_MAX_ROWS = 100_000;
 const ACTIVITY_LOG_PRUNE_INTERVAL = 1_000; // prune at most once per N writes
 
+export function shouldPruneActivityLog(writesSincePrune: number, interval: number): boolean {
+  return writesSincePrune >= interval;
+}
+
 const OUTPUT_DIAGNOSTIC_TAIL_CHARS = 8_000;
 
 export interface OutputChunk {
@@ -2824,7 +2828,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       [source, level, message],
     );
     this.activityLogWritesSincePrune += 1;
-    if (this.activityLogWritesSincePrune >= ACTIVITY_LOG_PRUNE_INTERVAL) {
+    if (shouldPruneActivityLog(this.activityLogWritesSincePrune, ACTIVITY_LOG_PRUNE_INTERVAL)) {
       this.activityLogWritesSincePrune = 0;
       try {
         this.pruneActivityLog();


### PR DESCRIPTION
## Summary

The database writes an activity log entry, then counts writes since it last trimmed the table. Once that count hits a threshold, it trims. That behavior already worked correctly.

This change only takes the existing threshold check and gives it its own name, `shouldPruneActivityLog`. Nothing about what runs, or when, changes.

The new function is exported so it can be checked directly, without needing to open a real database connection.

## Review Claim

Approve that the activity_log prune-throttle check was extracted into a named, exported, pure function with byte-identical behavior, and gained a direct unit test.

## Review Lane

behavior

## Review Unit

ownership-refactor

## Safety Invariant

`writeActivityLog()` still inserts unconditionally first, still increments `activityLogWritesSincePrune` the same way, and still wraps `pruneActivityLog()` in the same try/catch; only the threshold comparison moves into a named pure function with identical inputs and output.

## Slice Rationale

This is one slice: pull the existing inline throttle condition into a named function and add a direct test for it. Nothing else changes here.

## Non-goals

No refactor of `pruneActivityLog()` itself, no new configuration fields, no change to the OFFSET-based deletion boundary, no doc edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm test -- -t "bounds the table on write without an explicit prune call"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 961b3f3`
- Post-revert steps: None
- Data migration? No

</details>
