### PR TITLE
[Bugfix: Extract prepared-statement free pattern into named helper](1) Extract runWithFreedStatement from queryOne and queryAll

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, statSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { SQLiteAdapter, isLaunchDispatchCandidateStale } from '../sqlite-adapter.js';
+import { SQLiteAdapter, isLaunchDispatchCandidateStale, runWithFreedStatement } from '../sqlite-adapter.js';
 import type { Workflow, Conversation, WorkerActionWrite, TerminalSessionRecord, InAppPlanningSessionRecord } from '../adapter.js';
 import { createAttempt, assertWorkflowConsistent, assertWorkflowPatchConsistent } from '@invoker/workflow-core';
 import type { Attempt, TaskState, TaskStateChanges } from '@invoker/workflow-core';
@@ -6077,6 +6077,29 @@ describe('SQLiteAdapter', () => {
       } finally {
         handle.restore();
       }
+    });
+
+    it('runWithFreedStatement frees the statement and returns the callback result', () => {
+      const stmt = { free: vi.fn() };
+      const db = { prepare: vi.fn(() => stmt) };
+      const result = runWithFreedStatement(db, 'SELECT 1', (s) => {
+        expect(s).toBe(stmt);
+        return 'ok';
+      });
+      expect(result).toBe('ok');
+      expect(db.prepare).toHaveBeenCalledWith('SELECT 1');
+      expect(stmt.free).toHaveBeenCalledTimes(1);
+    });
+
+    it('runWithFreedStatement frees the statement when the callback throws', () => {
+      const stmt = { free: vi.fn() };
+      const db = { prepare: vi.fn(() => stmt) };
+      expect(() =>
+        runWithFreedStatement(db, 'SELECT 1', () => {
+          throw new Error('boom');
+        }),
+      ).toThrow('boom');
+      expect(stmt.free).toHaveBeenCalledTimes(1);
     });
 
     it('frees the prepared statement when stmt.get throws with params inside queryOne', () => {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -490,6 +490,20 @@ class NativeDatabaseCompat {
   }
 }
 
+/** Prepares `sql` against `db`, runs `run` against the statement, and always frees it. */
+export function runWithFreedStatement<S extends { free(): void }, T>(
+  db: { prepare(sql: string): S },
+  sql: string,
+  run: (stmt: S) => T,
+): T {
+  const stmt = db.prepare(sql);
+  try {
+    return run(stmt);
+  } finally {
+    stmt.free();
+  }
+}
+
 export interface WorkflowMutationIntent {
   id: number;
   workflowId: string;
@@ -957,27 +971,21 @@ export class SQLiteAdapter implements PersistenceAdapter {
   /** Run a single-row SELECT, returning the row as an object or undefined. */
   private queryOne(sql: string, params: unknown[] = []): Record<string, unknown> | undefined {
     const startedAt = performance.now();
-    const stmt = this.db.prepare(sql);
-    try {
+    return runWithFreedStatement(this.db, sql, (stmt) => {
       const row = stmt.get(...(paramsToArgs(params) as any[])) as Record<string, unknown> | undefined;
       this.noteSlowQuery(startedAt, sql, row === undefined ? 0 : 1);
       return row;
-    } finally {
-      stmt.free();
-    }
+    });
   }
 
   /** Run a multi-row SELECT, returning an array of row objects. */
   private queryAll(sql: string, params: unknown[] = []): Record<string, unknown>[] {
     const startedAt = performance.now();
-    const stmt = this.db.prepare(sql);
-    try {
+    return runWithFreedStatement(this.db, sql, (stmt) => {
       const rows = stmt.all(...(paramsToArgs(params) as any[])) as Record<string, unknown>[];
       this.noteSlowQuery(startedAt, sql, rows.length);
       return rows;
-    } finally {
-      stmt.free();
-    }
+    });
   }
 
   private ensureWritable(): void {


### PR DESCRIPTION
## Summary

Every SQL read prepares a statement, runs it, then frees it — even if the run throws. That behavior already worked correctly in both read methods.

This change only takes the existing prepare-run-free shape and gives it its own name, `runWithFreedStatement`. Nothing about what runs, or when, changes.

The new function is exported so the finally-free guarantee can be checked directly, without duplicating the same try/finally in two places.

## Review Claim

Approve that the shared prepare/try/finally-free pattern in `queryOne` and `queryAll` was extracted into a named, exported helper with byte-identical behavior, and gained a direct unit test.

## Review Lane

behavior

## Review Unit

ownership-refactor

## Safety Invariant

`queryOne` and `queryAll` still call `stmt.get`/`stmt.all` with the same arguments, still call `noteSlowQuery` with the same arguments, and `stmt.free()` still runs in a finally block on every path including throw; only the duplicated wrapper moves into one named function.

## Slice Rationale

This is one slice: pull the existing inline prepare/try/finally-free shape into a named function and add a direct test for it. Nothing else changes here.

## Non-goals

No refactor of `noteSlowQuery`, no new configuration fields, no change to `appendOutputChunk` or the `output_spool` write path, no doc edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm test -- -t "frees the prepared statement when stmt.get throws inside queryOne"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8972867`
- Post-revert steps: None
- Data migration? No

</details>
