### PR TITLE
[Owner-Serve Crash Visibility](2) Log fatal headless startup errors synchronously before exit

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher-bad-poolmember-crash-repro.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher-bad-poolmember-crash-repro.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator } from '@invoker/workflow-core';
+import { TaskRunner } from '@invoker/execution-engine';
+import { LaunchDispatcher } from '../launch-dispatcher.js';
+
+/**
+ * Repro for a live DO1 incident: a task's config pinned poolMemberId
+ * "local-worktree" against a pool member of that id, but worktreeTargets
+ * had no matching entry (the config didn't ship one). selectExecutor()
+ * throws for that task by design -- the question this test answers is
+ * whether that throw stays scoped to the one task/dispatch, or whether it
+ * escapes as an unhandled rejection and takes the whole owner process down.
+ */
+describe('LaunchDispatcher + real TaskRunner: bad poolMemberId does not crash the process', () => {
+  const adapters: SQLiteAdapter[] = [];
+
+  afterEach(() => {
+    for (const adapter of adapters.splice(0)) {
+      adapter.close();
+    }
+  });
+
+  it('fails only the offending dispatch instead of throwing out of poll()', async () => {
+    const persistence = await SQLiteAdapter.create(':memory:');
+    adapters.push(persistence);
+
+    const orchestrator = new Orchestrator({
+      persistence: persistence as any,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 4,
+    });
+
+    orchestrator.loadPlan({
+      name: 'wf-a',
+      tasks: [
+        {
+          id: 'verify-routing-command',
+          description: 'verify-routing-command',
+          command: 'echo hi',
+          poolId: 'mixed-local-ssh',
+          poolMemberId: 'local-worktree',
+        },
+      ],
+    } as any);
+
+    // Mirrors DO1's live config.json: a pool member named "local-worktree"
+    // but an empty worktreeTargets map -- nothing backs that member id.
+    const taskRunner = new TaskRunner({
+      orchestrator: orchestrator as any,
+      persistence: persistence as any,
+      executorRegistry: {
+        get: () => null,
+        getAll: () => [],
+        register: vi.fn(),
+      } as any,
+      cwd: '/tmp',
+      worktreeTargetsProvider: () => ({}),
+      executionPoolsProvider: () => ({
+        'mixed-local-ssh': {
+          selectionStrategy: 'leastLoaded',
+          maxConcurrentTasksPerMember: 1,
+          members: [{ id: 'local-worktree', type: 'worktree' as const, maxConcurrentTasks: 2 }],
+        },
+      }),
+    });
+
+    const dispatcher = new LaunchDispatcher({
+      persistence,
+      ownerId: 'repro-owner',
+      orchestrator: {
+        prepareTaskForNewAttempt: (taskId, reason) => orchestrator.prepareTaskForNewAttempt(taskId, reason),
+        getTask: (taskId) => orchestrator.getTask(taskId),
+        getTaskLaunchReadiness: (taskId) => orchestrator.getTaskLaunchReadiness(taskId),
+        getExecutableReadyTasks: () => orchestrator.getExecutableReadyTasks(),
+        startExecution: (opts) => orchestrator.startExecution(opts),
+      },
+      taskRunnerProvider: () => taskRunner,
+    });
+
+    let unhandled: unknown;
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandled = reason;
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      // poll() itself must stay synchronous-safe regardless of what the
+      // fire-and-forget executeTask() promise later does.
+      expect(() => dispatcher.poll()).not.toThrow();
+
+      // Let the fire-and-forget executeTask() promise chain settle.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+
+    expect(unhandled).toBeUndefined();
+
+    const task = orchestrator.getTask('wf-a/verify-routing-command');
+    // The task must land in a normal failed/retryable state, not disappear
+    // or leave the orchestrator/owner process in an inconsistent spot.
+    expect(task?.status).not.toBe('running');
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -543,6 +543,9 @@ const invokerConfig: InvokerConfig = (() => {
     return loadConfig();
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
+    // logger.error is a synchronous appendFileSync; process.stderr.write on a
+    // piped stderr is not guaranteed to flush before the exit() below.
+    logger.error(`[startup] config load failed fatally: ${message}`, { module: 'startup' });
     process.stderr.write(`${message}\n`);
     process.exit(1);
   }
@@ -1996,6 +1999,13 @@ function startHeadlessMode(): void {
         );
         exitCode = resolution.exitCode;
       } else {
+        // Same flush-race concern as the loadConfig() catch above: a fatal
+        // owner-serve startup error must survive process.exit() below even
+        // when stderr is a pipe, or it vanishes with no trace anywhere.
+        logger.error(
+          `[headless] ${command ?? 'unknown command'} failed fatally: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+          { module: 'headless', command: command ?? 'unknown' },
+        );
         process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
         exitCode = 1;
       }


### PR DESCRIPTION
## Summary

An owner-serve process on a remote host crashed with zero trace anywhere -- no stack, no stderr output, no invoker.log entry.

Both fatal-error paths in `main.ts` only wrote to `process.stderr` before calling `process.exit()`. That write is not guaranteed to flush before the process dies when stderr is a pipe.

Owner-serve's stderr is always a pipe: it runs under a supervisor, not an interactive terminal.

This routes both paths through the logger first. `FileAndDbLogger.error()` does a synchronous `appendFileSync`, so the error survives the exit regardless of stderr's flush timing.

This does not change how often the crash happens. It guarantees the next occurrence leaves a real stack trace instead of silence, which is what made the original incident undiagnosable.

## Review Claim

Approve that both fatal-error exit paths in `main.ts` (config load failure, and the top-level `runHeadless()` catch) now log through the synchronous file logger before `process.exit()`, instead of relying on a `process.stderr` write that can be lost.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Purely additive logging on two already-fatal exit paths. Neither path returns or continues after logging -- both still call `process.exit()` immediately after, same as before. No change to what triggers the exit, only to what's recorded before it happens.

## Slice Rationale

This is a separate PR from (1) because they are different review claims: (1) proves one specific dispatch path is already safe, (2) changes runtime behavior on unrelated fatal-error paths. Ordered after (1) so the reviewer has the safety context first.

## Non-goals

Does not fix or explain the original crash's root cause -- it was never reproduced reliably enough to pin a specific mechanism, even under repeated local stress testing with the same broken config that triggered it live. Does not change retry behavior, exit codes, or add new recovery logic.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm run check:types` (repo root: `pnpm run check:types`)
- [ ] `cd packages/app && pnpm run build`
- [ ] `cd packages/app && pnpm test -- src/__tests__/launch-dispatcher-bad-poolmember-crash-repro.test.ts src/__tests__/launch-dispatcher.test.ts`

</details>

## Visual Proof

This diff has no UI-facing behavior; `main.ts` is flagged by path, not by anything user-visible changing. The proof is a real terminal run of the two exact functions this diff touches (`loadConfig`, `FileAndDbLogger`), captured in a single static frame.

![Terminal output: loadConfig() throwing, labeled old vs. new catch-block behavior, then invoker.log going from absent to containing the logged fatal error](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260810-08886a/logger-fix-proof.png)

Manually inspected: I opened this image myself. It shows a real `vitest` run against the actual `loadConfig`/`FileAndDbLogger` source, not a mock. The old catch-block path leaves `invoker.log exists: false`; the new one (what this PR ships) leaves `invoker.log exists: true` with the real JSON log line printed, matching exactly what the patched catch block writes.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
