### PR TITLE
[Fix planning-chat resync loop](3) proof: useTasks has no cap on resync retries

### DIFF
--- a/packages/app/src/__tests__/owner-read-query-stream-sequence.test.ts
+++ b/packages/app/src/__tests__/owner-read-query-stream-sequence.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { answerOwnerReadQuery, buildOwnerReadQueryHandlers } from '../owner-read-query.js';
+import { createTaskDeltaStreamSequence } from '../task-delta-stream-sequence.js';
+
+// Documents a real, permanent, and INTENTIONAL characteristic surfaced
+// while root-causing a live infinite-resync-loop incident: the headless
+// standalone owner has no renderer/window of its own, so it has no local
+// task-delta-stream counter to report (main.ts, `getStreamSequence: () => 0`
+// on the standalone `headless.query` handler) — that counter is a
+// per-GUI-process delivery count (task-delta-stream-sequence.ts), which
+// doesn't exist for a window-less process. `task-graph-refresh` and plain
+// `tasks` reads both route through the same `getTasksSnapshot()` handler
+// (owner-read-query.ts:243-251), so this 0 is what standalone always
+// answers.
+//
+// Today, resolveRefreshTaskGraphSnapshot (refresh-task-graph.ts) blindly
+// trusts this value for delegated reads, handing callers a number from a
+// different process's counter that could never satisfy their own
+// gap-detection watermark (see refresh-task-graph.test.ts, "uses the
+// caller's own local streamSequence..." — currently `it.fails`, fixed in
+// the next slice of this stack). Once that lands, this 0 answer becomes
+// provably inert instead of silently wrong. This test guards the stub's
+// own behavior either way.
+describe('owner-read-query: standalone getStreamSequence stub stays inert', () => {
+  it('task-graph-refresh answers streamSequence 0 even after real deltas have been stamped past 0', () => {
+    // The real, single, shared counter every live delta gets stamped with —
+    // exactly what main.ts:2234 creates and main.ts:2235 exposes as
+    // getTaskDeltaStreamSequence for the (unused-by-standalone) real path.
+    const taskDeltaStream = createTaskDeltaStreamSequence();
+    for (let i = 0; i < 7285; i += 1) {
+      taskDeltaStream.stamp({ type: 'updated', taskId: 't1', changes: {} } as never);
+    }
+    expect(taskDeltaStream.current()).toBe(7285); // matches the live "actual" seen in ~/.invoker/invoker.log
+
+    // This mirrors main.ts:1826-1832's ACTUAL standalone wiring verbatim —
+    // including the hardcoded `getStreamSequence: () => 0` — deliberately
+    // NOT wired to `taskDeltaStream` above, exactly as shipped today.
+    const handlers = buildOwnerReadQueryHandlers({
+      ownerModeLabel: 'standalone',
+      getUiPerfStats: () => ({}),
+      resetUiPerfStats: () => {},
+      getStreamSequence: () => 0,
+      getWorkerStatus: () => ({ generatedAt: 'now', workers: [] }),
+      getWorkers: () => ({ generatedAt: 'now', workers: [] }),
+      resolveInvokerHomeRoot: () => '/home',
+      orchestrator: {
+        getQueueStatus: () => ({}),
+        getWorkflowStatus: () => ({}),
+        getAllTasks: () => [{ id: 't1' }],
+        getMergeNode: () => undefined,
+        syncAllFromDb: vi.fn(),
+        syncFromDb: vi.fn(),
+      } as never,
+      persistence: { listWorkflows: () => [] } as never,
+      getActionGraphSnapshot: () => ({}),
+      getPlanningChatSession: () => ({}),
+    });
+
+    const refreshReply = answerOwnerReadQuery({ kind: 'task-graph-refresh' }, handlers) as { streamSequence: number };
+
+    // The standalone owner's raw answer is still 0 here, even with 7285 real
+    // deltas stamped elsewhere — expected, since this process has no
+    // renderer-local counter of its own. resolveRefreshTaskGraphSnapshot no
+    // longer trusts this value for delegated reads (see
+    // refresh-task-graph.test.ts), so this is now provably harmless.
+    expect(refreshReply.streamSequence).toBe(0);
+    expect(refreshReply.streamSequence).toBeLessThan(taskDeltaStream.current());
+  });
+});

--- a/packages/app/src/__tests__/owner-read-query-stream-sequence.test.ts
+++ b/packages/app/src/__tests__/owner-read-query-stream-sequence.test.ts
@@ -13,14 +13,13 @@ import { createTaskDeltaStreamSequence } from '../task-delta-stream-sequence.js'
 // (owner-read-query.ts:243-251), so this 0 is what standalone always
 // answers.
 //
-// Today, resolveRefreshTaskGraphSnapshot (refresh-task-graph.ts) blindly
-// trusts this value for delegated reads, handing callers a number from a
+// resolveRefreshTaskGraphSnapshot (refresh-task-graph.ts) used to blindly
+// trust this value for delegated reads, handing callers a number from a
 // different process's counter that could never satisfy their own
-// gap-detection watermark (see refresh-task-graph.test.ts, "uses the
-// caller's own local streamSequence..." — currently `it.fails`, fixed in
-// the next slice of this stack). Once that lands, this 0 answer becomes
-// provably inert instead of silently wrong. This test guards the stub's
-// own behavior either way.
+// gap-detection watermark. That's fixed there now (see
+// refresh-task-graph.test.ts, "uses the caller's own local
+// streamSequence...") — the fix makes this 0 answer provably inert, not
+// wrong-but-unused. This test guards the stub's own behavior either way.
 describe('owner-read-query: standalone getStreamSequence stub stays inert', () => {
   it('task-graph-refresh answers streamSequence 0 even after real deltas have been stamped past 0', () => {
     // The real, single, shared counter every live delta gets stamped with —

--- a/packages/app/src/__tests__/refresh-task-graph.test.ts
+++ b/packages/app/src/__tests__/refresh-task-graph.test.ts
@@ -99,6 +99,50 @@ describe('resolveRefreshTaskGraphSnapshot fallback', () => {
     ]);
   });
 
+  it.fails('uses the caller\'s own local streamSequence on a successful delegated read, not the remote reply\'s', async () => {
+    // PROOF for a live infinite-resync-loop incident: streamSequence is a
+    // per-caller delivery count (how many deltas THIS process has locally
+    // stamped and forwarded to its own renderer). The remote owner cannot
+    // know that count -- especially a headless standalone owner, whose own
+    // "streamSequence" is a hardcoded 0 stub (main.ts, `getStreamSequence: () => 0`
+    // for the standalone `headless.query` handler) because it has no
+    // renderer of its own. Today, resolveRefreshTaskGraphSnapshot trusts the
+    // remote reply's streamSequence on a successful delegated read, handing
+    // callers a number from a different process's counter -- which could
+    // never satisfy their own gap-detection watermark, so a resync could
+    // never actually close the gap that triggered it, looping forever. This
+    // assertion is expected to fail against today's code (it.fails); the
+    // next slice in this stack fixes resolveRefreshTaskGraphSnapshot and
+    // flips this to a normal `it`.
+    const remoteTask = makeTask('wf-9/task-1');
+    const remoteWorkflow = { id: 'wf-9', name: 'Remote', status: 'running' };
+
+    const result = await resolveRefreshTaskGraphSnapshot({
+      ownerMode: false,
+      messageBus: {
+        async request() {
+          // Mirrors the real standalone owner's answer: valid data, but a
+          // streamSequence that means nothing to this caller (0, or any
+          // other process's own count -- same bug either way).
+          return {
+            tasks: [remoteTask],
+            workflows: [remoteWorkflow],
+            streamSequence: 0,
+          };
+        },
+      } as never,
+      resolveInvokerHomeRoot: () => '/tmp/invoker-caller',
+      logger: makeLogger().logger as never,
+      orchestrator: { syncAllFromDb() {}, getAllTasks() { return []; } } as never,
+      persistence: { listWorkflows() { return []; } } as never,
+      // This caller has already locally forwarded 7285 deltas to its own
+      // renderer -- that's the number a resync must report to be useful.
+      getStreamSequence: () => 7285,
+    });
+
+    expect(result).toEqual({ tasks: [remoteTask], workflows: [remoteWorkflow], streamSequence: 7285 });
+  });
+
   it('falls back to the local snapshot when the owner home does not match', async () => {
     const localTask = makeTask('wf-3/task-1');
     const localWorkflow = { id: 'wf-3', name: 'Local', status: 'running' };

--- a/packages/app/src/__tests__/refresh-task-graph.test.ts
+++ b/packages/app/src/__tests__/refresh-task-graph.test.ts
@@ -99,21 +99,20 @@ describe('resolveRefreshTaskGraphSnapshot fallback', () => {
     ]);
   });
 
-  it.fails('uses the caller\'s own local streamSequence on a successful delegated read, not the remote reply\'s', async () => {
-    // PROOF for a live infinite-resync-loop incident: streamSequence is a
-    // per-caller delivery count (how many deltas THIS process has locally
+  it('uses the caller\'s own local streamSequence on a successful delegated read, not the remote reply\'s', async () => {
+    // REGRESSION for a live infinite-resync-loop incident: streamSequence is
+    // a per-caller delivery count (how many deltas THIS process has locally
     // stamped and forwarded to its own renderer). The remote owner cannot
     // know that count -- especially a headless standalone owner, whose own
     // "streamSequence" is a hardcoded 0 stub (main.ts, `getStreamSequence: () => 0`
     // for the standalone `headless.query` handler) because it has no
-    // renderer of its own. Today, resolveRefreshTaskGraphSnapshot trusts the
+    // renderer of its own. resolveRefreshTaskGraphSnapshot used to trust the
     // remote reply's streamSequence on a successful delegated read, handing
     // callers a number from a different process's counter -- which could
     // never satisfy their own gap-detection watermark, so a resync could
-    // never actually close the gap that triggered it, looping forever. This
-    // assertion is expected to fail against today's code (it.fails); the
-    // next slice in this stack fixes resolveRefreshTaskGraphSnapshot and
-    // flips this to a normal `it`.
+    // never actually close the gap that triggered it, looping forever. Fixed
+    // by reporting the caller's own local streamSequence instead (previous
+    // slice in this stack proved this as `it.fails`).
     const remoteTask = makeTask('wf-9/task-1');
     const remoteWorkflow = { id: 'wf-9', name: 'Remote', status: 'running' };
 

--- a/packages/app/src/refresh-task-graph.ts
+++ b/packages/app/src/refresh-task-graph.ts
@@ -87,10 +87,17 @@ export async function resolveRefreshTaskGraphSnapshot(
       await deps.messageBus.request('headless.query', { kind: 'task-graph-refresh' }) as unknown,
       deps.resolveInvokerHomeRoot(),
     );
+    // streamSequence is a per-caller delivery count (how many deltas THIS
+    // process has locally stamped and forwarded to its own renderer), not a
+    // value the remote owner can know. Trusting `delegated.streamSequence`
+    // here handed the caller a number from a different process's counter
+    // (or the standalone owner's unrelated stub) — never comparable to the
+    // watermark the caller's own gap-detection tracks, so a resync could
+    // never actually close the gap that triggered it.
     return {
       tasks: delegated.tasks,
       workflows: delegated.workflows,
-      streamSequence: delegated.streamSequence,
+      streamSequence: deps.getStreamSequence(),
     };
   } catch (err) {
     deps.logger.warn(

--- a/packages/ui/src/__tests__/use-tasks-stream-gap-resync-cap.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks-stream-gap-resync-cap.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useTasks } from '../hooks/useTasks.js';
+import { makeUITask } from './helpers/mock-invoker.js';
+
+// PROOF for a live incident: "Error invoking remote method
+// 'invoker:planning-chat-send': TransportError: Request on channel
+// headless.gui-mutation timed out after 7200000ms" and a
+// ui_delta_stream_gap_detected storm observed in ~/.invoker/invoker.log
+// (2367 occurrences over 52 min, expected frozen while actual climbed past
+// 7000).
+//
+// Server root cause (already fixed in an earlier slice of this stack,
+// packages/app/src/refresh-task-graph.ts): a delegated resync used to trust
+// the remote owner's own streamSequence, which belongs to a different
+// process's counter (or the headless standalone owner's inert stub) and
+// could never satisfy the caller's own watermark.
+//
+// This slice covers the client-side half, as defense-in-depth: even if
+// some future resync reply still doesn't close the gap, useTasks must not
+// retry forever. Today it has no cap, so this assertion fails by design
+// (it.fails) -- the next slice adds the cap and flips this to a normal
+// `it`.
+describe('useTasks stream-gap resync cap', () => {
+  it.fails('stops auto-retrying after MAX_CONSECUTIVE_RESYNC_FAILURES round trips and recovers instead of looping forever', async () => {
+    const t1 = makeUITask({ id: 't1', status: 'pending' });
+
+    let handler: ((event: unknown) => void) | undefined;
+    const STUCK_SEQ = 5; // simulates a resync reply that never advances past 5
+
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [t1],
+      workflows: [],
+      streamSequence: STUCK_SEQ,
+    };
+
+    const refreshTaskGraphMock = vi.fn(async () => {
+      queueMicrotask(() => {
+        handler?.({
+          type: 'snapshot',
+          tasks: [t1],
+          workflows: [],
+          reason: 'test-resync-stuck',
+          streamSequence: STUCK_SEQ,
+        });
+      });
+    });
+
+    const reportUiPerfMock = vi.fn();
+    const onTaskGraphEventMock = vi.fn((cb: (event: unknown) => void) => {
+      handler = cb;
+      return () => { handler = undefined; };
+    });
+
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks: vi.fn(async () => ({ tasks: [t1], workflows: [], streamSequence: STUCK_SEQ })),
+      refreshTaskGraph: refreshTaskGraphMock,
+      reportUiPerf: reportUiPerfMock,
+      onTaskGraphEvent: onTaskGraphEventMock,
+      onWorkflowsChanged: vi.fn(() => () => {}),
+      checkPrStatuses: vi.fn(async () => {}),
+    };
+
+    renderHook(() => useTasks());
+    await waitFor(() => expect(onTaskGraphEventMock).toHaveBeenCalledTimes(1));
+
+    // 4 consecutive real deltas, none of which the (broken) resync ever
+    // catches up to: 3 round trips (the cap), then a 4th that must give up
+    // instead of retrying a 4th time.
+    for (const seq of [STUCK_SEQ + 2, STUCK_SEQ + 3, STUCK_SEQ + 4, STUCK_SEQ + 5]) {
+      await act(async () => {
+        handler?.({
+          type: 'delta',
+          delta: { type: 'updated', taskId: 't1', changes: { status: 'running' }, taskStateVersion: 2, previousTaskStateVersion: 1, streamSequence: seq },
+          workflowRollups: [],
+        });
+        // >100ms: the task-graph-event batch pipeline (flushMs: 100) must
+        // flush and apply the pushed snapshot before the next delta arrives.
+        await new Promise((resolve) => setTimeout(resolve, 150));
+      });
+    }
+
+    // Capped at 3 — not a 4th call for the 4th gap.
+    expect(refreshTaskGraphMock).toHaveBeenCalledTimes(3);
+
+    const exhaustedReports = reportUiPerfMock.mock.calls.filter((c) => c[0] === 'ui_delta_stream_resync_exhausted');
+    expect(exhaustedReports).toHaveLength(1);
+    expect(exhaustedReports[0][1]).toMatchObject({ attempts: 4 });
+
+    // Recovered: the 4th delta's data made it through instead of the UI
+    // staying stuck on stale data forever.
+    await waitFor(() => {
+      expect(reportUiPerfMock.mock.calls.filter((c) => c[0] === 'ui_delta_stream_gap_detected')).toHaveLength(4);
+    });
+
+    delete (window as unknown as { invoker?: unknown }).invoker;
+    delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
+  });
+});


### PR DESCRIPTION
## Summary

The previous two slices fixed the root cause: a resync now reports a streamSequence the caller can actually use.

This slice adds a defense-in-depth test for the client side. `useTasks` has no limit today on retriggering a resync when one still leaves a gap.

The test is `it.fails`, proving that gap with today's code, ahead of the fix in the next slice of this stack.

## Review Claim

Approve adding a failing-by-design test proving `useTasks` re-triggers a stream-gap resync once per incoming delta, without limit, whenever a resync round trip does not close the gap.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. `it.fails` means the assertion is expected to fail against today's code, so CI cannot go red from this slice, and no product code path executes any differently.

## Slice Rationale

Proof lands before the fix, matching this stack's earlier two slices and this repo's stack-ordering convention.

## Non-goals

Does not change `useTasks.ts` itself. The fix lands in the next slice.

## Visual Proof

This change has no rendered UI surface — it's a proof for internal retry-counting logic in a React hook, exercised via `renderHook` with no DOM output to show. Per this repo's visual-proof policy for behavior a screenshot cannot demonstrate, here is a terminal capture of the test run itself as the closest available non-visual proof, plus the test name and file to inspect directly.

![Terminal showing the it.fails proof test passing on this slice's commit](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260810-5a6456/slice3-proof-test-passing.png)

Manually inspected: the terminal shows `TEST-PROOF-SLICE-3`, then `Test Files 1 passed (90)` / `Tests 1 passed | 839 skipped (840)` for `pnpm test -- -t "resync cap"`, run on this slice's exact checked-out commit (`842e3748a`). Note vitest reports an `it.fails` test that correctly failed the same way it reports a normal passing `it` — this screenshot cannot visually distinguish the two on its own; the actual proof is `packages/ui/src/__tests__/use-tasks-stream-gap-resync-cap.test.tsx` itself, which wraps the assertion in `it.fails` in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test -- -t "resync cap"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
