### PR TITLE
Bugfix: headlessDeleteWorkflow throws on a benign FK race after the delete already succeeded

### DIFF
--- a/packages/app/src/__tests__/headless-delete-workflow-race.test.ts
+++ b/packages/app/src/__tests__/headless-delete-workflow-race.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Regression test for the delete-workflow race described in
+ * packages/data-store/src/__tests__/delete-workflow-race-fk-crash.test.ts.
+ *
+ * headlessDeleteWorkflow makes two calls that can race a concurrent delete:
+ *  1. preemptWorkflowExecution (cancel) — already guarded, see
+ *     headless-preempt-workflow-race.test.ts.
+ *  2. commandService.deleteWorkflow — NOT guarded: any raw FOREIGN KEY
+ *     constraint failure from a racing owner's concurrent write is thrown
+ *     verbatim even though the workflow row was already deleted.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { headlessDeleteWorkflow } from '../headless-approve-delete.js';
+import type { HeadlessDeps } from '../headless.js';
+import type { CommandService } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { TaskRunner } from '@invoker/execution-engine';
+
+const noopLogger = {
+  debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  child: vi.fn(function () { return noopLogger; }),
+};
+
+const stubTaskRunner = {
+  closeWorkflowReview: vi.fn(async () => {}),
+} as unknown as TaskRunner;
+
+function makeDeps(overrides: {
+  deleteWorkflowError: { code: string; message: string };
+  workflowExists: boolean;
+}): HeadlessDeps {
+  return {
+    logger: noopLogger as any,
+    orchestrator: {} as any,
+    persistence: {
+      loadWorkflow: vi.fn(() => (overrides.workflowExists ? { id: 'wf-1' } : undefined)),
+    } as unknown as SQLiteAdapter,
+    commandService: {
+      deleteWorkflow: vi.fn(async () => ({ ok: false, error: overrides.deleteWorkflowError })),
+    } as unknown as CommandService,
+    executorRegistry: {} as any,
+    messageBus: {} as any,
+    repoRoot: '/fake/repo',
+    invokerConfig: {} as any,
+    initServices: vi.fn(async () => {}),
+    ownerTaskRunnerProvider: () => stubTaskRunner,
+    preemptWorkflowExecution: vi.fn(async () => ({ cancelled: [], runningCancelled: [] })),
+  };
+}
+
+describe('headlessDeleteWorkflow race with a concurrent delete', () => {
+  it('resolves cleanly instead of throwing when the workflow is already gone', async () => {
+    const deps = makeDeps({
+      deleteWorkflowError: { code: 'DELETE_WORKFLOW_FAILED', message: 'FOREIGN KEY constraint failed' },
+      workflowExists: false,
+    });
+
+    await expect(headlessDeleteWorkflow('wf-1', deps)).resolves.toBeUndefined();
+  });
+
+  it('still throws a FOREIGN KEY error for a workflow that genuinely still exists', async () => {
+    const deps = makeDeps({
+      deleteWorkflowError: { code: 'DELETE_WORKFLOW_FAILED', message: 'FOREIGN KEY constraint failed' },
+      workflowExists: true,
+    });
+
+    await expect(headlessDeleteWorkflow('wf-1', deps)).rejects.toThrow('FOREIGN KEY constraint failed');
+  });
+
+  it('still throws unrelated errors for a missing workflow', async () => {
+    const deps = makeDeps({
+      deleteWorkflowError: { code: 'DELETE_WORKFLOW_FAILED', message: 'disk I/O error' },
+      workflowExists: false,
+    });
+
+    await expect(headlessDeleteWorkflow('wf-1', deps)).rejects.toThrow('disk I/O error');
+  });
+});

--- a/packages/app/src/headless-approve-delete.ts
+++ b/packages/app/src/headless-approve-delete.ts
@@ -23,6 +23,7 @@ import {
   trackHeadlessWorkflow,
   withRestoredTaskUnlessDeleteAllWon,
   preemptWorkflowExecution,
+  isRaceLostForeignKeyConstraintFailure,
 } from './headless-shared.js';
 
 function buildHeadlessApproveAction(
@@ -315,7 +316,9 @@ export async function headlessDeleteWorkflow(workflowId: string, deps: HeadlessD
   // Serialized via CommandService: DB delete + memory clear + scheduler cleanup + removal deltas
   const envelope = makeEnvelope('delete-workflow', 'headless', 'workflow', { workflowId });
   const result = await deps.commandService.deleteWorkflow(envelope);
-  if (!result.ok) throw new Error(result.error.message);
+  if (!result.ok && !isRaceLostForeignKeyConstraintFailure(result.error.message, workflowId, deps)) {
+    throw new Error(result.error.message);
+  }
   process.stdout.write(`Deleted workflow: ${workflowId}\n`);
 }
 

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -428,13 +428,15 @@ const preemptSkipCodes: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * A racing owner can delete the workflow's tasks between cancelWorkflowImpl's
- * DB read and its per-task `task.cancelled` event write, tripping the
- * `events.task_id -> tasks(id)` foreign key. That raw error isn't an
- * OrchestratorError, so it can't carry a `WORKFLOW_NOT_FOUND` code through
- * CommandService — check the message text and confirm against persistence.
+ * A racing owner can delete the workflow's tasks between another write's DB
+ * read and its own follow-up write (e.g. cancelWorkflowImpl's per-task
+ * `task.cancelled` event insert), tripping a `-> tasks(id)`/`-> workflows(id)`
+ * foreign key. That raw error isn't an OrchestratorError, so it can't carry a
+ * `WORKFLOW_NOT_FOUND` code through CommandService — check the message text
+ * and confirm against persistence. Used by both preemptWorkflowExecution
+ * (cancel) and headlessDeleteWorkflow (delete) call sites.
  */
-function isRaceLostForeignKeyConstraintFailure(message: string, workflowId: string, deps: HeadlessDeps): boolean {
+export function isRaceLostForeignKeyConstraintFailure(message: string, workflowId: string, deps: HeadlessDeps): boolean {
   return message.includes('FOREIGN KEY constraint failed') && !deps.persistence.loadWorkflow?.(workflowId);
 }
 


### PR DESCRIPTION
## Summary

A racing owner process can trip a foreign key error on an unrelated concurrent write while a workflow is being taken down.

The headless cancel path already tolerates this outcome when the workflow is confirmed gone.

The headless path for the other command lacked the same guard. It could report a foreign key failure and exit 1 even though the underlying row was already gone.

## Review Claim

Approve that the second headless command now reuses the same already-tested race check the first command uses, instead of throwing on a benign race outcome.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only widens an existing, already-tested check (previously private to the cancel path) to a second call site with the same race shape. Any other error still throws unchanged.

## Slice Rationale

Small, self-contained fix: one guard reused at one additional call site, with its own regression test in the same commit.

## Non-goals

Does not change the check's logic. Does not change behavior for any error that isn't this specific race.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- src/__tests__/headless-delete-workflow-race.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
