### PR TITLE
[Scratch execution mode](1) Add scratch runnerKind to workflow-graph task config types

### DIFF
--- a/packages/workflow-graph/src/runner-kind.ts
+++ b/packages/workflow-graph/src/runner-kind.ts
@@ -1,8 +1,8 @@
 /** All executor types accepted at runtime (includes internal 'merge'). */
-export type RunnerKind = 'worktree' | 'docker' | 'ssh' | 'merge';
+export type RunnerKind = 'worktree' | 'docker' | 'ssh' | 'scratch' | 'merge';
 
 export const SUPPORTED_EXECUTOR_TYPES = new Set<RunnerKind>([
-  'worktree', 'docker', 'ssh',
+  'worktree', 'docker', 'ssh', 'scratch',
   'merge',  // internal: merge-node only
 ]);
 

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -90,7 +90,13 @@ export interface MergeTaskConfig extends BaseTaskConfig {
   readonly dockerImage?: never;
 }
 
-export type TaskConfig = WorktreeTaskConfig | DockerTaskConfig | SshTaskConfig | MergeTaskConfig;
+/** No-repo config: task runs in a plain temp directory, no git involved. */
+export interface ScratchTaskConfig extends BaseTaskConfig {
+  readonly runnerKind: 'scratch';
+  readonly dockerImage?: never;
+}
+
+export type TaskConfig = WorktreeTaskConfig | DockerTaskConfig | SshTaskConfig | MergeTaskConfig | ScratchTaskConfig;
 
 export type ExternalGatePolicy = 'completed' | 'review_ready' | 'ci_failed';
 


### PR DESCRIPTION
## Summary

This adds a new task kind: "scratch," meaning no git repo at all.

Today every plan needs a real repo, even for a task that never touches git,
like running a benchmark tool.

This PR only adds the label for that new kind. Nothing uses it yet — that
comes later in this stack.

## Review Claim

Add a `ScratchTaskConfig` variant to `TaskConfig` and `'scratch'` to the
`RunnerKind` union / `SUPPORTED_EXECUTOR_TYPES` set in `@invoker/workflow-graph`.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Purely additive types. `TaskConfig` becomes a wider union and `RunnerKind`
gains one more literal value; nothing in the codebase constructs a task with
`runnerKind: 'scratch'` yet, so no existing task, executor, or routing
decision can be affected. `@invoker/workflow-graph`'s full test suite (113
tests) passes unchanged.

## Slice Rationale

Foundation before behavior: every later part of this stack (the plan
checker, the new executor, task dispatch) needs this type to exist first so
it type-checks. Kept separate so each later diff stays focused on one
behavior instead of also introducing the type.

## Non-goals

Does not add any parser validation for a `scratch` plan field (next slice).
Does not add an executor that can run a `scratch` task (later slice). Does
not wire `'scratch'` into task dispatch routing (later slice).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/workflow-graph && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — later stack slices depend on this one, so revert
  the whole stack top-down if reverting.
- Data migration? No

</details>