### PR TITLE
[Scratch execution mode](2) Accept scratch: true plans in workflow-core plan parsing and routing

### DIFF
--- a/packages/workflow-core/src/__tests__/plan-parser.test.ts
+++ b/packages/workflow-core/src/__tests__/plan-parser.test.ts
@@ -122,4 +122,74 @@ tasks:
     expect(plan.mergeMode).toBe('no_op');
     expect(plan.onFinish).toBe('none');
   });
+
+  it('rejects plans without repoUrl and without scratch: true', () => {
+    const yaml = `
+name: No Repo No Scratch Plan
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/repoUrl.*scratch: true/);
+  });
+
+  it('parses a scratch: true plan with no repoUrl, defaulting onFinish/mergeMode', () => {
+    const yaml = `
+name: Scratch Plan
+scratch: true
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+`;
+    const plan = parsePlan(yaml);
+    expect(plan.scratch).toBe(true);
+    expect(plan.repoUrl).toBeUndefined();
+    expect(plan.onFinish).toBe('none');
+    expect(plan.mergeMode).toBe('no_op');
+  });
+
+  it('rejects a plan that sets both scratch: true and repoUrl', () => {
+    const yaml = `
+name: Conflicting Plan
+scratch: true
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/cannot set both "scratch: true" and "repoUrl"/);
+  });
+
+  it('rejects a scratch plan with a mergeMode other than no_op', () => {
+    const yaml = `
+name: Bad Merge Mode Scratch Plan
+scratch: true
+mergeMode: manual
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/mergeMode: "no_op"/);
+  });
+
+  it('rejects a scratch plan task that sets dockerImage', () => {
+    const yaml = `
+name: Bad Scratch Docker Plan
+scratch: true
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+    dockerImage: some/image:latest
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/dockerImage.*poolId/);
+  });
 });

--- a/packages/workflow-core/src/executor-routing.ts
+++ b/packages/workflow-core/src/executor-routing.ts
@@ -224,7 +224,8 @@ export type ExecutorRoutingReason =
   | { type: 'dockerImage' }
   | { type: 'poolId'; poolId: string }
   | { type: 'routingRule'; poolId: string; pattern?: string; regex?: string }
-  | { type: 'defaultWorktree' };
+  | { type: 'defaultWorktree' }
+  | { type: 'scratch' };
 
 export function buildExecutorRoutedPayload(
   runnerKind: RunnerKind,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -401,6 +401,8 @@ export interface PlanDefinition {
   mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
   reviewProvider?: string;
   repoUrl?: string;
+  /** No-repo mode: every task runs in a plain temp directory, no git involved. Mutually exclusive with repoUrl. */
+  scratch?: boolean;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
     workflowId: string;
@@ -1356,14 +1358,18 @@ export class Orchestrator {
     const validatedTasks: TaskState[] = [];
     const resolvedRoutingByTaskId = new Map<string, ExecutorRoutingReason>();
     for (const taskDef of plan.tasks) {
-      const resolvedRouting = resolveExecutorRouting(
-        taskDef.id,
-        taskDef.command,
-        taskDef.poolId,
-        this.defaultPoolId,
-        this.executorRoutingRules,
-        this.availablePoolIds,
-      );
+      // Scratch plans never resolve a pool: no clone, no config-level default
+      // pool, no routing rule can ever hijack a scratch task's runnerKind.
+      const resolvedRouting: ReturnType<typeof resolveExecutorRouting> = plan.scratch
+        ? { poolId: undefined, reason: { type: 'scratch' } }
+        : resolveExecutorRouting(
+            taskDef.id,
+            taskDef.command,
+            taskDef.poolId,
+            this.defaultPoolId,
+            this.executorRoutingRules,
+            this.availablePoolIds,
+          );
       const effectivePoolId = resolvedRouting.poolId;
 
       const scopedId = localToScoped.get(taskDef.id)!;
@@ -1391,7 +1397,9 @@ export class Orchestrator {
         poolId: effectivePoolId,
       } as const;
       let taskConfig: TaskConfig;
-      if (taskDef.dockerImage) {
+      if (plan.scratch) {
+        taskConfig = { ...baseConfig, runnerKind: 'scratch' as const };
+      } else if (taskDef.dockerImage) {
         taskConfig = { ...baseConfig, runnerKind: 'docker' as const, dockerImage: taskDef.dockerImage };
       } else if (effectivePoolId) {
         taskConfig = { ...baseConfig, runnerKind: 'ssh' as const };
@@ -2660,6 +2668,9 @@ export class Orchestrator {
             ...rtBase, runnerKind: 'ssh',
             poolMemberId: task.config.runnerKind === 'ssh' ? (task.config as { poolMemberId?: string }).poolMemberId : undefined,
           } as unknown) as TaskConfig;
+          break;
+        case 'scratch':
+          rtConfig = { ...rtBase, runnerKind: 'scratch' as const };
           break;
         default:
           rtConfig = { ...rtBase, runnerKind: 'worktree' as const };

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -48,6 +48,7 @@ export interface RawPlan {
   mergeMode?: string;
   reviewProvider?: string;
   repoUrl?: string;
+  scratch?: boolean;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
     workflowId?: string;
@@ -167,21 +168,35 @@ export function parsePlan(yamlContent: string): PlanDefinition {
   }
   assertNoLegacyRoutingKeys('Plan', raw as object);
 
+  if (raw.scratch !== undefined && typeof raw.scratch !== 'boolean') {
+    throw new PlanParseError('Plan "scratch" must be a boolean when provided.');
+  }
+  const scratch = raw.scratch === true;
+
   const validOnFinishValues = ['none', 'merge', 'pull_request'] as const;
   if (raw.onFinish !== undefined && !validOnFinishValues.includes(raw.onFinish as any)) {
     throw new PlanParseError(`"onFinish" must be one of: ${validOnFinishValues.join(', ')}. Got: "${raw.onFinish}"`);
   }
-  const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? 'pull_request';
+  if (scratch && raw.onFinish !== undefined && raw.onFinish !== 'none') {
+    throw new PlanParseError('Plan with "scratch: true" must use onFinish: "none" (or omit it) — there is no branch/PR to finish.');
+  }
+  const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? (scratch ? 'none' : 'pull_request');
 
   const validMergeModes = ['manual', 'automatic', 'external_review', 'no_op'] as const;
   if (raw.mergeMode !== undefined && !validMergeModes.includes(raw.mergeMode as any)) {
     throw new PlanParseError(`"mergeMode" must be one of: ${validMergeModes.join(', ')}. Got: "${raw.mergeMode}"`);
   }
-  const mergeMode = raw.mergeMode as (typeof validMergeModes)[number] | undefined;
+  if (scratch && raw.mergeMode !== undefined && raw.mergeMode !== 'no_op') {
+    throw new PlanParseError('Plan with "scratch: true" must use mergeMode: "no_op" (or omit it) — there is no repo/branch to merge.');
+  }
+  const mergeMode = (raw.mergeMode as (typeof validMergeModes)[number] | undefined) ?? (scratch ? 'no_op' : undefined);
   const reviewProvider = raw.reviewProvider ?? (raw.mergeMode === 'external_review' ? 'github' : undefined);
 
-  if (!raw.repoUrl || typeof raw.repoUrl !== 'string') {
-    throw new PlanParseError('Plan must have a "repoUrl" field (e.g. repoUrl: git@github.com:user/repo.git).');
+  if (scratch && raw.repoUrl !== undefined) {
+    throw new PlanParseError('Plan cannot set both "scratch: true" and "repoUrl" — scratch plans run with no git repo.');
+  }
+  if (!scratch && (!raw.repoUrl || typeof raw.repoUrl !== 'string')) {
+    throw new PlanParseError('Plan must have either a "repoUrl" field (e.g. repoUrl: git@github.com:user/repo.git) or "scratch: true" (no-repo mode).');
   }
   if (raw.intermediateRepoUrl !== undefined) {
     if (typeof raw.intermediateRepoUrl !== 'string' || raw.intermediateRepoUrl.trim() === '') {
@@ -213,6 +228,9 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     }
     if (task.command && /\bnpx vitest run\b/.test(task.command)) {
       throw new PlanParseError(`Task "${task.id}" uses 'npx vitest run' which may not resolve correctly. Use 'pnpm test' instead.`);
+    }
+    if (scratch && (task.dockerImage || task.poolId)) {
+      throw new PlanParseError(`Task "${task.id}" sets "dockerImage"/"poolId" but the plan has "scratch: true" — scratch tasks always run in a plain temp directory.`);
     }
 
     if (task.externalDependencies !== undefined) {
@@ -258,6 +276,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     mergeMode,
     reviewProvider,
     repoUrl: raw.repoUrl,
+    scratch: scratch || undefined,
     intermediateRepoUrl: raw.intermediateRepoUrl,
     externalDependencies: topLevelExternalDependencies,
     tasks,

--- a/packages/workflow-graph/src/runner-kind.ts
+++ b/packages/workflow-graph/src/runner-kind.ts
@@ -1,8 +1,8 @@
 /** All executor types accepted at runtime (includes internal 'merge'). */
-export type RunnerKind = 'worktree' | 'docker' | 'ssh' | 'merge';
+export type RunnerKind = 'worktree' | 'docker' | 'ssh' | 'scratch' | 'merge';
 
 export const SUPPORTED_EXECUTOR_TYPES = new Set<RunnerKind>([
-  'worktree', 'docker', 'ssh',
+  'worktree', 'docker', 'ssh', 'scratch',
   'merge',  // internal: merge-node only
 ]);
 

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -90,7 +90,13 @@ export interface MergeTaskConfig extends BaseTaskConfig {
   readonly dockerImage?: never;
 }
 
-export type TaskConfig = WorktreeTaskConfig | DockerTaskConfig | SshTaskConfig | MergeTaskConfig;
+/** No-repo config: task runs in a plain temp directory, no git involved. */
+export interface ScratchTaskConfig extends BaseTaskConfig {
+  readonly runnerKind: 'scratch';
+  readonly dockerImage?: never;
+}
+
+export type TaskConfig = WorktreeTaskConfig | DockerTaskConfig | SshTaskConfig | MergeTaskConfig | ScratchTaskConfig;
 
 export type ExternalGatePolicy = 'completed' | 'review_ready' | 'ci_failed';
 


### PR DESCRIPTION
## Summary

A plan can now say `scratch: true` instead of giving a git repo.

Today, even a plan that never touches git has to fake a repo, because
Invoker refuses to load it otherwise.

Leaving both out still fails to load, same as before. You have to choose
one on purpose.

## Review Claim

Accept `scratch: true` as a plan-level alternative to `repoUrl` in
`workflow-core`'s plan parser and task-config routing.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`scratch: true` is strictly opt-in — a plan must explicitly set it. Setting
both `scratch: true` and `repoUrl` is a parse error, and a task in a scratch
plan that also sets `dockerImage`/`poolId` is a parse error. A new regression
test pins that a plan with neither `repoUrl` nor `scratch: true` still throws
exactly as before. Every existing plan YAML in the repo and in production
sets `repoUrl`, so this diff cannot change their parse result.

## Slice Rationale

This is the parsing and task-routing half of scratch mode, kept apart from
the executor that will actually run a scratch task (different package,
different architectural boundary — turning plan YAML into task config vs.
spawning a process). No `ScratchExecutor` exists yet at this point in the
stack, so a `scratch: true` plan given to Invoker would still fail at
dispatch time until a later part lands; that is expected for a bottom-up
stack.

## Non-goals

Does not add the executor that runs a scratch task (next slice). Does not
wire `'scratch'` into task dispatch routing (later slice). Does not touch
the second, separate plan-parser implementation in `packages/app` (later
slice, per the app package's own release cadence).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/workflow-core && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — later stack slices depend on this one, so revert
  the whole stack top-down if reverting.
- Data migration? No

</details>

Depends-On: #8243