### PR TITLE
[Scratch execution mode](4) Wire ScratchExecutor into task dispatch and terminal resume

### DIFF
--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -11,6 +11,7 @@ import {
   DockerExecutor,
   getEffectivePath,
   WorktreeExecutor,
+  ScratchExecutor,
   SshExecutor,
   type Executor,
   type ExecutorHandle,
@@ -251,15 +252,21 @@ export function resolveTaskTerminalSpec(
       });
       executorRegistry.register('worktree', worktree);
       executor = worktree;
+    } else if (repairedMeta.runnerKind === 'scratch') {
+      const scratch = new ScratchExecutor({
+        agentRegistry: opts.executionAgentRegistry,
+      });
+      executorRegistry.register('scratch', scratch);
+      executor = scratch;
     } else {
       executor = executorRegistry.getDefault();
     }
   }
 
-  // Managed-workspace executors (worktree, ssh, docker) MUST have a resolved workspacePath.
+  // Managed-workspace executors (worktree, ssh, docker, scratch) MUST have a resolved workspacePath.
   // Refuse fallback to repoRoot host cwd to prevent silent data loss when workspace metadata is missing.
-  const managedRunnerKinds = ['worktree', 'ssh', 'docker'];
-  const hostWorkspaceRunnerKinds = ['worktree'];
+  const managedRunnerKinds = ['worktree', 'ssh', 'docker', 'scratch'];
+  const hostWorkspaceRunnerKinds = ['worktree', 'scratch'];
   const isManagedExecutor = managedRunnerKinds.includes(repairedMeta.runnerKind);
   if (isManagedExecutor && !repairedMeta.workspacePath) {
     const errorMsg = [

--- a/packages/execution-engine/src/__tests__/scratch-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/scratch-executor.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import type { ExecutorHandle } from '../executor.js';
+import type { WorkRequest, WorkResponse } from '@invoker/contracts';
+import { ScratchExecutor } from '../scratch-executor.js';
+
+let reqCounter = 0;
+function makeRequest(overrides: Partial<WorkRequest> = {}): WorkRequest {
+  const { inputs: inputOverrides, ...restOverrides } = overrides;
+  reqCounter += 1;
+  return {
+    requestId: `req-${reqCounter}`,
+    actionId: `action-${reqCounter}`,
+    actionType: 'command',
+    inputs: { command: 'true', ...inputOverrides },
+    callbackUrl: 'http://localhost:3000/callback',
+    timestamps: { createdAt: new Date().toISOString() },
+    ...restOverrides,
+  };
+}
+
+function waitForComplete(executor: ScratchExecutor, handle: ExecutorHandle): Promise<WorkResponse> {
+  return new Promise((resolve) => {
+    executor.onComplete(handle, (res) => resolve(res));
+  });
+}
+
+describe('ScratchExecutor', () => {
+  it('runs a command task in an isolated temp dir with no .git present', async () => {
+    const executor = new ScratchExecutor();
+    const request = makeRequest({ inputs: { command: '[ ! -e .git ]' } });
+    const handle = await executor.start(request);
+    const response = await waitForComplete(executor, handle);
+
+    expect(response.status).toBe('completed');
+    expect(handle.workspacePath).toBeTruthy();
+    expect(existsSync(handle.workspacePath!)).toBe(true);
+
+    await executor.destroyAll();
+  });
+
+  it('does not require repoUrl on the request', async () => {
+    const executor = new ScratchExecutor();
+    const request = makeRequest();
+    expect(request.inputs.repoUrl).toBeUndefined();
+    const response = await waitForComplete(executor, await executor.start(request));
+    expect(response.status).toBe('completed');
+    await executor.destroyAll();
+  });
+
+  it('gives concurrently started tasks distinct temp dirs', async () => {
+    const executor = new ScratchExecutor();
+    const requests = Array.from({ length: 6 }, () => makeRequest({ inputs: { command: 'true' } }));
+    const handles = await Promise.all(requests.map((r) => executor.start(r)));
+    await Promise.all(handles.map((h) => waitForComplete(executor, h)));
+
+    const paths = handles.map((h) => h.workspacePath);
+    expect(paths.every((p) => !!p)).toBe(true);
+    expect(new Set(paths).size).toBe(paths.length);
+
+    await executor.destroyAll();
+  });
+
+  it('reports a non-zero exit code as a failed task', async () => {
+    const executor = new ScratchExecutor();
+    const request = makeRequest({ inputs: { command: 'exit 3' } });
+    const handle = await executor.start(request);
+    const response = await waitForComplete(executor, handle);
+
+    expect(response.status).toBe('failed');
+    expect(response.outputs.exitCode).toBe(3);
+
+    await executor.destroyAll();
+  });
+
+  it('destroyAll removes temp dirs from disk', async () => {
+    const executor = new ScratchExecutor();
+    const request = makeRequest({ inputs: { command: 'true' } });
+    const handle = await executor.start(request);
+    await waitForComplete(executor, handle);
+    const workspacePath = handle.workspacePath!;
+
+    expect(existsSync(workspacePath)).toBe(true);
+    await executor.destroyAll();
+    expect(existsSync(workspacePath)).toBe(false);
+  });
+});

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -14,6 +14,7 @@ export * from './process-utils.js';
 export * from './agent-prompt-transport.js';
 export * from './docker-executor.js';
 export * from './worktree-executor.js';
+export * from './scratch-executor.js';
 export * from './merge-gate-executor.js';
 export * from './ssh-executor.js';
 export {

--- a/packages/execution-engine/src/scratch-executor.ts
+++ b/packages/execution-engine/src/scratch-executor.ts
@@ -1,0 +1,231 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { WorkRequest, WorkResponse } from '@invoker/contracts';
+import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
+import { BaseExecutor, type BaseEntry } from './base-executor.js';
+import { killProcessGroup, cleanElectronEnv, resolveExecutableOnCurrentPath, SIGKILL_TIMEOUT_MS } from './process-utils.js';
+import { DEFAULT_EXECUTION_AGENT } from './agent.js';
+import { traceExecution } from './exec-trace.js';
+
+export interface ScratchExecutorConfig {
+  /** Command to invoke the Claude CLI. Defaults to 'claude'. */
+  claudeCommand?: string;
+  /** Agent registry for pluggable AI agents. When set, overrides claudeCommand. */
+  agentRegistry?: import('./agent-registry.js').AgentRegistry;
+  /** Heartbeat interval in milliseconds. Default: 30000. */
+  heartbeatIntervalMs?: number;
+  /** Maximum task duration in milliseconds. Default: 4 hours. */
+  maxDurationMs?: number;
+}
+
+interface ScratchEntry extends BaseEntry {
+  process: ChildProcess | null;
+  tmpDir: string;
+  agentSessionId?: string;
+  agentName?: string;
+  rawStdout?: string;
+}
+
+function getDisplayOnlyBridgeSpec(
+  source: { displayOnlyBridgeText?: string },
+): Pick<TerminalSpec, 'displayOnlyBridgeText'> {
+  return source.displayOnlyBridgeText === undefined
+    ? {}
+    : { displayOnlyBridgeText: source.displayOnlyBridgeText };
+}
+
+/**
+ * Executor for plans declaring `scratch: true`: runs each task in a plain OS
+ * temp directory with no git clone/worktree/branch involved. Reuses
+ * BaseExecutor's spawn/heartbeat/handleProcessExit machinery — omitting
+ * `branch` from handleProcessExit's opts means it performs zero git operations.
+ */
+export class ScratchExecutor extends BaseExecutor<ScratchEntry> {
+  readonly type = 'scratch';
+
+  private readonly claudeCommand: string;
+  private readonly agentRegistry?: import('./agent-registry.js').AgentRegistry;
+  /**
+   * Every temp dir this executor has ever created, independent of `entries`
+   * (which drops completed tasks shortly after completion). destroyAll()
+   * uses this so completed tasks' temp dirs are still reclaimed on shutdown.
+   */
+  private readonly allTmpDirs = new Set<string>();
+
+  constructor(config: ScratchExecutorConfig = {}) {
+    super(config.heartbeatIntervalMs, config.maxDurationMs);
+    this.claudeCommand = config.claudeCommand ?? 'claude';
+    this.agentRegistry = config.agentRegistry;
+  }
+
+  async start(request: WorkRequest): Promise<ExecutorHandle> {
+    const handle = this.createHandle(request);
+    const executionId = handle.executionId;
+    const tmpDir = mkdtempSync(join(tmpdir(), 'invoker-scratch-'));
+    this.allTmpDirs.add(tmpDir);
+    traceExecution(`[ScratchExecutor] start task=${request.actionId} tmpDir=${tmpDir}`);
+
+    const entry: ScratchEntry = {
+      process: null,
+      request,
+      tmpDir,
+      outputListeners: new Set(),
+      outputBuffer: [],
+      outputBufferBytes: 0,
+      evictedChunkCount: 0,
+      completeListeners: new Set(),
+      heartbeatListeners: new Set(),
+      completed: false,
+    };
+    this.registerEntry(handle, entry);
+    handle.workspacePath = tmpDir;
+
+    const { cmd, args, agentSessionId } = this.buildCommandAndArgs(request, {
+      claudeCommand: this.claudeCommand,
+      agentRegistry: this.agentRegistry,
+    });
+
+    const usesAgent = request.actionType === 'ai_task';
+    const executionAgent = request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
+    const stdinMode = usesAgent && this.agentRegistry
+      ? this.agentRegistry.getOrThrow(executionAgent).stdinMode
+      : (usesAgent ? 'ignore' : 'pipe');
+    const spawnCmd = request.actionType === 'ai_task' ? (resolveExecutableOnCurrentPath(cmd) ?? cmd) : cmd;
+
+    const child = spawn(spawnCmd, args, {
+      stdio: [stdinMode, 'pipe', 'pipe'],
+      cwd: tmpDir,
+      detached: true,
+      env: cleanElectronEnv(),
+    });
+
+    child.on('error', (err) => {
+      traceExecution(`[ScratchExecutor] child process spawn error: ${err.message}`);
+      const response: WorkResponse = {
+        requestId: request.requestId,
+        actionId: request.actionId,
+        executionGeneration: request.executionGeneration,
+        status: 'failed',
+        outputs: {
+          exitCode: 1,
+          error: `Failed to spawn command: ${err.message}`,
+          agentName: request.actionType === 'ai_task' ? executionAgent : undefined,
+        },
+      };
+      this.emitComplete(executionId, response);
+    });
+
+    entry.process = child;
+    if (agentSessionId) {
+      entry.agentSessionId = agentSessionId;
+      handle.agentSessionId = agentSessionId;
+    }
+
+    const driver = usesAgent ? this.agentRegistry?.getSessionDriver(executionAgent) : undefined;
+    child.stdout?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      if (driver) {
+        entry.rawStdout = (entry.rawStdout ?? '') + text;
+      } else {
+        this.emitOutput(executionId, text);
+      }
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      this.emitOutput(executionId, chunk.toString());
+    });
+
+    child.on('close', async (code, signal) => {
+      const exitCode = code ?? (signal ? 1 : 0);
+      entry.finalizingAfterClose = true;
+      try {
+        if (driver && entry.rawStdout) {
+          const realId = driver.extractSessionId?.(entry.rawStdout);
+          if (realId) entry.agentSessionId = realId;
+          const readable = driver.processOutput(entry.agentSessionId ?? '', entry.rawStdout);
+          if (readable) this.emitOutput(executionId, readable);
+        }
+        await this.handleProcessExit(executionId, request, tmpDir, exitCode, {
+          signal,
+          agentSessionId: entry.agentSessionId,
+          agentName: request.actionType === 'ai_task' ? executionAgent : undefined,
+        });
+      } finally {
+        entry.finalizingAfterClose = false;
+      }
+    });
+
+    this.startHeartbeat(executionId, child);
+    return handle;
+  }
+
+  sendInput(handle: ExecutorHandle, input: string): void {
+    const entry = this.getEntry(handle);
+    this.writeProcessInput(entry, input);
+  }
+
+  getTerminalSpec(handle: ExecutorHandle): TerminalSpec | null {
+    const entry = this.getEntry(handle);
+    if (!entry) return null;
+    const displayBridge = getDisplayOnlyBridgeSpec(handle);
+    if (entry.agentSessionId) {
+      const agentName = entry.request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
+      const resume = this.agentRegistry
+        ? this.agentRegistry.getOrThrow(agentName).buildResumeArgs(entry.agentSessionId)
+        : { cmd: 'claude', args: ['--resume', entry.agentSessionId, '--dangerously-skip-permissions'] };
+      return { command: resume.cmd, args: resume.args, cwd: entry.tmpDir, ...displayBridge };
+    }
+    return { cwd: entry.tmpDir, ...displayBridge };
+  }
+
+  getRestoredTerminalSpec(meta: PersistedTaskMeta): TerminalSpec {
+    if (meta.workspacePath && !existsSync(meta.workspacePath)) {
+      throw new Error(
+        `Scratch workspace ${meta.workspacePath} no longer exists for task ${meta.taskId}. ` +
+        'It was a temp directory and has since been cleaned up.',
+      );
+    }
+    const displayBridge = getDisplayOnlyBridgeSpec(meta);
+    if (meta.agentSessionId) {
+      const resume = this.agentRegistry
+        ? this.agentRegistry.getOrThrow(meta.executionAgent ?? DEFAULT_EXECUTION_AGENT).buildResumeArgs(meta.agentSessionId)
+        : { cmd: 'claude', args: ['--resume', meta.agentSessionId, '--dangerously-skip-permissions'] };
+      return { command: resume.cmd, args: resume.args, cwd: meta.workspacePath, ...displayBridge };
+    }
+    return { cwd: meta.workspacePath, ...displayBridge };
+  }
+
+  async destroyAll(): Promise<void> {
+    const allEntries = Array.from(this.entries.entries());
+    const closePromises: Promise<void>[] = [];
+
+    for (const [, entry] of allEntries) {
+      if (!entry.completed && entry.process) {
+        closePromises.push(
+          new Promise<void>((resolve) => {
+            entry.process!.on('close', () => resolve());
+            killProcessGroup(entry.process!, 'SIGTERM');
+            setTimeout(() => {
+              if (!entry.completed && entry.process) {
+                killProcessGroup(entry.process, 'SIGKILL');
+              }
+            }, SIGKILL_TIMEOUT_MS);
+          }),
+        );
+      }
+    }
+
+    await Promise.all(closePromises);
+    this.entries.clear();
+
+    for (const tmpDir of this.allTmpDirs) {
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+      } catch (err) {
+        traceExecution(`[ScratchExecutor] failed to clean up tmpDir=${tmpDir}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    this.allTmpDirs.clear();
+  }
+}

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -19,6 +19,7 @@ import { ResourceLimitError } from './repo-pool.js';
 import { traceExecution } from './exec-trace.js';
 import { DockerExecutor } from './docker-executor.js';
 import { WorktreeExecutor } from './worktree-executor.js';
+import { ScratchExecutor } from './scratch-executor.js';
 import { MergeGateExecutor } from './merge-gate-executor.js';
 import { SshExecutor } from './ssh-executor.js';
 import type { MergeRunnerHost } from './merge-runner.js';
@@ -616,6 +617,24 @@ export function selectExecutor(
   clearPendingPoolSelection(host, task.id);
   reclaimSupersededExecutionSlots(host, task);
   reclaimOrphanedExecutionSlots(host);
+
+  // Scratch tasks never resolve a pool: no repo to clone means no pool
+  // member (ssh/worktree) can ever run them. A poolId attached to a scratch
+  // task by any other path (config default pool, routing rule, replacement
+  // task inheriting a parent's poolId) must never override this.
+  if (effectiveType === 'scratch') {
+    const registered = host.executorRegistry.get('scratch');
+    if (registered) {
+      traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=scratch → scratch (cached)`);
+      return { executor: registered, resolvedExecution, selectedPoolMemberId: undefined };
+    }
+    const scratch = new ScratchExecutor({
+      agentRegistry: host.executionAgentRegistry,
+    });
+    host.executorRegistry.register('scratch', scratch);
+    traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=scratch → scratch (lazy registered)`);
+    return { executor: scratch, resolvedExecution, selectedPoolMemberId: undefined };
+  }
 
   if (task.config.poolId && explicitPoolMemberId) {
     const pool = host.getExecutionPools()[task.config.poolId];

--- a/packages/workflow-core/src/__tests__/plan-parser.test.ts
+++ b/packages/workflow-core/src/__tests__/plan-parser.test.ts
@@ -122,4 +122,74 @@ tasks:
     expect(plan.mergeMode).toBe('no_op');
     expect(plan.onFinish).toBe('none');
   });
+
+  it('rejects plans without repoUrl and without scratch: true', () => {
+    const yaml = `
+name: No Repo No Scratch Plan
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/repoUrl.*scratch: true/);
+  });
+
+  it('parses a scratch: true plan with no repoUrl, defaulting onFinish/mergeMode', () => {
+    const yaml = `
+name: Scratch Plan
+scratch: true
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+`;
+    const plan = parsePlan(yaml);
+    expect(plan.scratch).toBe(true);
+    expect(plan.repoUrl).toBeUndefined();
+    expect(plan.onFinish).toBe('none');
+    expect(plan.mergeMode).toBe('no_op');
+  });
+
+  it('rejects a plan that sets both scratch: true and repoUrl', () => {
+    const yaml = `
+name: Conflicting Plan
+scratch: true
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/cannot set both "scratch: true" and "repoUrl"/);
+  });
+
+  it('rejects a scratch plan with a mergeMode other than no_op', () => {
+    const yaml = `
+name: Bad Merge Mode Scratch Plan
+scratch: true
+mergeMode: manual
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/mergeMode: "no_op"/);
+  });
+
+  it('rejects a scratch plan task that sets dockerImage', () => {
+    const yaml = `
+name: Bad Scratch Docker Plan
+scratch: true
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+    dockerImage: some/image:latest
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/dockerImage.*poolId/);
+  });
 });

--- a/packages/workflow-core/src/executor-routing.ts
+++ b/packages/workflow-core/src/executor-routing.ts
@@ -224,7 +224,8 @@ export type ExecutorRoutingReason =
   | { type: 'dockerImage' }
   | { type: 'poolId'; poolId: string }
   | { type: 'routingRule'; poolId: string; pattern?: string; regex?: string }
-  | { type: 'defaultWorktree' };
+  | { type: 'defaultWorktree' }
+  | { type: 'scratch' };
 
 export function buildExecutorRoutedPayload(
   runnerKind: RunnerKind,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -401,6 +401,8 @@ export interface PlanDefinition {
   mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
   reviewProvider?: string;
   repoUrl?: string;
+  /** No-repo mode: every task runs in a plain temp directory, no git involved. Mutually exclusive with repoUrl. */
+  scratch?: boolean;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
     workflowId: string;
@@ -1356,14 +1358,18 @@ export class Orchestrator {
     const validatedTasks: TaskState[] = [];
     const resolvedRoutingByTaskId = new Map<string, ExecutorRoutingReason>();
     for (const taskDef of plan.tasks) {
-      const resolvedRouting = resolveExecutorRouting(
-        taskDef.id,
-        taskDef.command,
-        taskDef.poolId,
-        this.defaultPoolId,
-        this.executorRoutingRules,
-        this.availablePoolIds,
-      );
+      // Scratch plans never resolve a pool: no clone, no config-level default
+      // pool, no routing rule can ever hijack a scratch task's runnerKind.
+      const resolvedRouting: ReturnType<typeof resolveExecutorRouting> = plan.scratch
+        ? { poolId: undefined, reason: { type: 'scratch' } }
+        : resolveExecutorRouting(
+            taskDef.id,
+            taskDef.command,
+            taskDef.poolId,
+            this.defaultPoolId,
+            this.executorRoutingRules,
+            this.availablePoolIds,
+          );
       const effectivePoolId = resolvedRouting.poolId;
 
       const scopedId = localToScoped.get(taskDef.id)!;
@@ -1391,7 +1397,9 @@ export class Orchestrator {
         poolId: effectivePoolId,
       } as const;
       let taskConfig: TaskConfig;
-      if (taskDef.dockerImage) {
+      if (plan.scratch) {
+        taskConfig = { ...baseConfig, runnerKind: 'scratch' as const };
+      } else if (taskDef.dockerImage) {
         taskConfig = { ...baseConfig, runnerKind: 'docker' as const, dockerImage: taskDef.dockerImage };
       } else if (effectivePoolId) {
         taskConfig = { ...baseConfig, runnerKind: 'ssh' as const };
@@ -2660,6 +2668,9 @@ export class Orchestrator {
             ...rtBase, runnerKind: 'ssh',
             poolMemberId: task.config.runnerKind === 'ssh' ? (task.config as { poolMemberId?: string }).poolMemberId : undefined,
           } as unknown) as TaskConfig;
+          break;
+        case 'scratch':
+          rtConfig = { ...rtBase, runnerKind: 'scratch' as const };
           break;
         default:
           rtConfig = { ...rtBase, runnerKind: 'worktree' as const };

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -48,6 +48,7 @@ export interface RawPlan {
   mergeMode?: string;
   reviewProvider?: string;
   repoUrl?: string;
+  scratch?: boolean;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
     workflowId?: string;
@@ -167,21 +168,35 @@ export function parsePlan(yamlContent: string): PlanDefinition {
   }
   assertNoLegacyRoutingKeys('Plan', raw as object);
 
+  if (raw.scratch !== undefined && typeof raw.scratch !== 'boolean') {
+    throw new PlanParseError('Plan "scratch" must be a boolean when provided.');
+  }
+  const scratch = raw.scratch === true;
+
   const validOnFinishValues = ['none', 'merge', 'pull_request'] as const;
   if (raw.onFinish !== undefined && !validOnFinishValues.includes(raw.onFinish as any)) {
     throw new PlanParseError(`"onFinish" must be one of: ${validOnFinishValues.join(', ')}. Got: "${raw.onFinish}"`);
   }
-  const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? 'pull_request';
+  if (scratch && raw.onFinish !== undefined && raw.onFinish !== 'none') {
+    throw new PlanParseError('Plan with "scratch: true" must use onFinish: "none" (or omit it) — there is no branch/PR to finish.');
+  }
+  const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? (scratch ? 'none' : 'pull_request');
 
   const validMergeModes = ['manual', 'automatic', 'external_review', 'no_op'] as const;
   if (raw.mergeMode !== undefined && !validMergeModes.includes(raw.mergeMode as any)) {
     throw new PlanParseError(`"mergeMode" must be one of: ${validMergeModes.join(', ')}. Got: "${raw.mergeMode}"`);
   }
-  const mergeMode = raw.mergeMode as (typeof validMergeModes)[number] | undefined;
+  if (scratch && raw.mergeMode !== undefined && raw.mergeMode !== 'no_op') {
+    throw new PlanParseError('Plan with "scratch: true" must use mergeMode: "no_op" (or omit it) — there is no repo/branch to merge.');
+  }
+  const mergeMode = (raw.mergeMode as (typeof validMergeModes)[number] | undefined) ?? (scratch ? 'no_op' : undefined);
   const reviewProvider = raw.reviewProvider ?? (raw.mergeMode === 'external_review' ? 'github' : undefined);
 
-  if (!raw.repoUrl || typeof raw.repoUrl !== 'string') {
-    throw new PlanParseError('Plan must have a "repoUrl" field (e.g. repoUrl: git@github.com:user/repo.git).');
+  if (scratch && raw.repoUrl !== undefined) {
+    throw new PlanParseError('Plan cannot set both "scratch: true" and "repoUrl" — scratch plans run with no git repo.');
+  }
+  if (!scratch && (!raw.repoUrl || typeof raw.repoUrl !== 'string')) {
+    throw new PlanParseError('Plan must have either a "repoUrl" field (e.g. repoUrl: git@github.com:user/repo.git) or "scratch: true" (no-repo mode).');
   }
   if (raw.intermediateRepoUrl !== undefined) {
     if (typeof raw.intermediateRepoUrl !== 'string' || raw.intermediateRepoUrl.trim() === '') {
@@ -213,6 +228,9 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     }
     if (task.command && /\bnpx vitest run\b/.test(task.command)) {
       throw new PlanParseError(`Task "${task.id}" uses 'npx vitest run' which may not resolve correctly. Use 'pnpm test' instead.`);
+    }
+    if (scratch && (task.dockerImage || task.poolId)) {
+      throw new PlanParseError(`Task "${task.id}" sets "dockerImage"/"poolId" but the plan has "scratch: true" — scratch tasks always run in a plain temp directory.`);
     }
 
     if (task.externalDependencies !== undefined) {
@@ -258,6 +276,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     mergeMode,
     reviewProvider,
     repoUrl: raw.repoUrl,
+    scratch: scratch || undefined,
     intermediateRepoUrl: raw.intermediateRepoUrl,
     externalDependencies: topLevelExternalDependencies,
     tasks,

--- a/packages/workflow-graph/src/runner-kind.ts
+++ b/packages/workflow-graph/src/runner-kind.ts
@@ -1,8 +1,8 @@
 /** All executor types accepted at runtime (includes internal 'merge'). */
-export type RunnerKind = 'worktree' | 'docker' | 'ssh' | 'merge';
+export type RunnerKind = 'worktree' | 'docker' | 'ssh' | 'scratch' | 'merge';
 
 export const SUPPORTED_EXECUTOR_TYPES = new Set<RunnerKind>([
-  'worktree', 'docker', 'ssh',
+  'worktree', 'docker', 'ssh', 'scratch',
   'merge',  // internal: merge-node only
 ]);
 

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -90,7 +90,13 @@ export interface MergeTaskConfig extends BaseTaskConfig {
   readonly dockerImage?: never;
 }
 
-export type TaskConfig = WorktreeTaskConfig | DockerTaskConfig | SshTaskConfig | MergeTaskConfig;
+/** No-repo config: task runs in a plain temp directory, no git involved. */
+export interface ScratchTaskConfig extends BaseTaskConfig {
+  readonly runnerKind: 'scratch';
+  readonly dockerImage?: never;
+}
+
+export type TaskConfig = WorktreeTaskConfig | DockerTaskConfig | SshTaskConfig | MergeTaskConfig | ScratchTaskConfig;
 
 export type ExternalGatePolicy = 'completed' | 'review_ready' | 'ci_failed';
 


### PR DESCRIPTION
## Summary

This turns on the new "no git" task kind for real.

Before this PR, a `scratch: true` plan had nowhere to actually run, and
reopening its terminal later would just crash.

Now both work, the same way they already do for every other task kind.

## Review Claim

Add a `'scratch'` branch to `selectExecutor()`'s dispatch and to
`open-terminal-for-task`'s executor resolution and managed-workspace checks.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Both changes add a new `if (effectiveType === 'scratch')` /
`else if (repairedMeta.runnerKind === 'scratch')` branch alongside the
existing branches, without reordering, removing, or modifying any of them.
Every task whose `runnerKind` is not `'scratch'` — 100% of tasks that could
exist before this stack, since nothing could previously produce that value —
takes the exact identical code path as before this diff.

## Slice Rationale

Kept apart from the executor itself (previous slice): "does the new class
work in isolation" is a different review claim from "is it safely reachable
from live dispatch." Bundling `packages/execution-engine/task-runner-pool.ts`
with `packages/app/src/open-terminal-for-task.ts` here (2 packages, not 3+)
keeps one conceptual claim — send scratch tasks to the new executor
everywhere that decision is made — in one diff, per the repo's
diff-atomicity threshold.

## Non-goals

Does not change the second, separate plan-parser implementation in
`packages/app` that governs whether a plan can even declare `scratch: true`
via the Electron GUI / headless submit path (next slice).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test`
- [ ] `cd packages/app && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — later stack slices depend on this one, so revert
  the whole stack top-down if reverting.
- Data migration? No

</details>

Depends-On: #8245