### PR TITLE
[Scratch execution mode](5) Accept scratch: true in the app-side plan parser

### DIFF
--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -129,7 +129,79 @@ tasks:
     command: echo "Hello"
 `;
     expect(() => parsePlan(yaml)).toThrow(PlanParseError);
-    expect(() => parsePlan(yaml)).toThrow('must have a "repoUrl" field');
+    expect(() => parsePlan(yaml)).toThrow('must have either a "repoUrl" field');
+  });
+
+  it('parses a scratch: true plan with no repoUrl, defaulting onFinish/mergeMode', () => {
+    const yaml = `
+name: Scratch Plan
+scratch: true
+tasks:
+  - id: greet
+    description: Say hello
+    command: echo "Hello"
+`;
+    const plan = parsePlan(yaml);
+    expect(plan.scratch).toBe(true);
+    expect(plan.repoUrl).toBeUndefined();
+    expect(plan.onFinish).toBe('none');
+    expect(plan.mergeMode).toBe('no_op');
+  });
+
+  it('rejects a plan that sets both scratch: true and repoUrl', () => {
+    const yaml = `
+name: Conflicting Plan
+scratch: true
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: greet
+    description: Say hello
+    command: echo "Hello"
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow('cannot set both "scratch: true" and "repoUrl"');
+  });
+
+  it('rejects a scratch plan with a mergeMode other than no_op', () => {
+    const yaml = `
+name: Bad Merge Mode Scratch Plan
+scratch: true
+mergeMode: manual
+tasks:
+  - id: greet
+    description: Say hello
+    command: echo "Hello"
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow('mergeMode: "no_op"');
+  });
+
+  it('rejects a scratch plan task that sets poolId', () => {
+    const yaml = `
+name: Bad Scratch Pool Plan
+scratch: true
+tasks:
+  - id: greet
+    description: Say hello
+    command: echo "Hello"
+    poolId: some-pool
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/dockerImage.*poolId/);
+  });
+
+  it('does not require repoUrl to be cloneable when scratch: true is set', async () => {
+    const planPath = join(tmpdir(), `invoker-scratch-plan-${process.pid}.yaml`);
+    writeFileSync(planPath, `
+name: Scratch File Plan
+scratch: true
+tasks:
+  - id: greet
+    description: Say hello
+    command: echo "Hello"
+`);
+    const plan = await parsePlanFile(planPath);
+    expect(plan.scratch).toBe(true);
   });
 
   it('rejects blank intermediateRepoUrl', () => {

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -11,6 +11,7 @@ import {
   DockerExecutor,
   getEffectivePath,
   WorktreeExecutor,
+  ScratchExecutor,
   SshExecutor,
   type Executor,
   type ExecutorHandle,
@@ -251,15 +252,21 @@ export function resolveTaskTerminalSpec(
       });
       executorRegistry.register('worktree', worktree);
       executor = worktree;
+    } else if (repairedMeta.runnerKind === 'scratch') {
+      const scratch = new ScratchExecutor({
+        agentRegistry: opts.executionAgentRegistry,
+      });
+      executorRegistry.register('scratch', scratch);
+      executor = scratch;
     } else {
       executor = executorRegistry.getDefault();
     }
   }
 
-  // Managed-workspace executors (worktree, ssh, docker) MUST have a resolved workspacePath.
+  // Managed-workspace executors (worktree, ssh, docker, scratch) MUST have a resolved workspacePath.
   // Refuse fallback to repoRoot host cwd to prevent silent data loss when workspace metadata is missing.
-  const managedRunnerKinds = ['worktree', 'ssh', 'docker'];
-  const hostWorkspaceRunnerKinds = ['worktree'];
+  const managedRunnerKinds = ['worktree', 'ssh', 'docker', 'scratch'];
+  const hostWorkspaceRunnerKinds = ['worktree', 'scratch'];
   const isManagedExecutor = managedRunnerKinds.includes(repairedMeta.runnerKind);
   if (isManagedExecutor && !repairedMeta.workspacePath) {
     const errorMsg = [

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -100,6 +100,7 @@ export interface RawPlan {
   mergeMode?: string;
   reviewProvider?: string;
   repoUrl?: string;
+  scratch?: boolean;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
     workflowId?: string;
@@ -337,13 +338,23 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
   }
   assertNoLegacyRoutingKeys(ownerLabel, raw as object);
 
+  if (raw.scratch !== undefined && typeof raw.scratch !== 'boolean') {
+    throw new PlanParseError(`${ownerLabel} "scratch" must be a boolean when provided.`);
+  }
+  const scratch = raw.scratch === true;
+
   const validOnFinishValues = ['none', 'merge', 'pull_request'] as const;
   if (raw.onFinish !== undefined && !validOnFinishValues.includes(raw.onFinish as any)) {
     throw new PlanParseError(
       `"onFinish" must be one of: ${validOnFinishValues.join(', ')}. Got: "${raw.onFinish}"`,
     );
   }
-  const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? 'pull_request';
+  if (scratch && raw.onFinish !== undefined && raw.onFinish !== 'none') {
+    throw new PlanParseError(
+      `${ownerLabel} with "scratch: true" must use onFinish: "none" (or omit it) — there is no branch/PR to finish.`,
+    );
+  }
+  const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? (scratch ? 'none' : 'pull_request');
 
   const validMergeModes = ['manual', 'automatic', 'external_review', 'no_op'] as const;
   if (raw.mergeMode !== undefined && !validMergeModes.includes(raw.mergeMode as any)) {
@@ -351,7 +362,12 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
       `"mergeMode" must be one of: ${validMergeModes.join(', ')}. Got: "${raw.mergeMode}"`,
     );
   }
-  const rawMergeMode = raw.mergeMode as (typeof validMergeModes)[number] | undefined;
+  if (scratch && raw.mergeMode !== undefined && raw.mergeMode !== 'no_op') {
+    throw new PlanParseError(
+      `${ownerLabel} with "scratch: true" must use mergeMode: "no_op" (or omit it) — there is no repo/branch to merge.`,
+    );
+  }
+  const rawMergeMode = (raw.mergeMode as (typeof validMergeModes)[number] | undefined) ?? (scratch ? 'no_op' : undefined);
   const mergeMode = rawMergeMode !== undefined
     ? normalizeMergeModeForPersistence(rawMergeMode)
     : undefined;
@@ -364,9 +380,14 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
     raw.featureBranch = `plan/${slug}`;
   }
 
-  if (!raw.repoUrl || typeof raw.repoUrl !== 'string') {
+  if (scratch && raw.repoUrl !== undefined) {
     throw new PlanParseError(
-      `${ownerLabel} must have a "repoUrl" field (e.g. repoUrl: git@github.com:user/repo.git).`,
+      `${ownerLabel} cannot set both "scratch: true" and "repoUrl" — scratch plans run with no git repo.`,
+    );
+  }
+  if (!scratch && (!raw.repoUrl || typeof raw.repoUrl !== 'string')) {
+    throw new PlanParseError(
+      `${ownerLabel} must have either a "repoUrl" field (e.g. repoUrl: git@github.com:user/repo.git) or "scratch: true" (no-repo mode).`,
     );
   }
   if (raw.intermediateRepoUrl !== undefined) {
@@ -415,6 +436,12 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
       );
     }
 
+    if (scratch && (task.dockerImage || task.poolId)) {
+      throw new PlanParseError(
+        `Task "${task.id}" sets "dockerImage"/"poolId" but ${ownerLabel.toLowerCase()} has "scratch: true" — scratch tasks always run in a plain temp directory.`,
+      );
+    }
+
     if (task.externalDependencies !== undefined) {
       throw new PlanParseError(
         `Task "${task.id}" uses task-level "externalDependencies", which is no longer supported. ` +
@@ -460,6 +487,7 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
     mergeMode,
     reviewProvider,
     repoUrl: raw.repoUrl,
+    scratch: scratch || undefined,
     intermediateRepoUrl: raw.intermediateRepoUrl,
     externalDependencies: topLevelExternalDependencies,
     tasks,
@@ -489,6 +517,7 @@ function inheritStackWorkflowDefaults(stack: RawPlanBundle, workflow: RawPlan): 
   return {
     ...workflow,
     repoUrl: workflow.repoUrl ?? stack.repoUrl,
+    scratch: workflow.scratch ?? stack.scratch,
     intermediateRepoUrl: workflow.intermediateRepoUrl ?? stack.intermediateRepoUrl,
     onFinish: workflow.onFinish ?? stack.onFinish,
     baseBranch: workflow.baseBranch ?? stack.baseBranch,
@@ -559,7 +588,7 @@ export async function parsePlanFile(filePath: string): Promise<PlanDefinition> {
   const { readFile } = await import('node:fs/promises');
   const content = await readFile(filePath, 'utf-8');
   const plan = parsePlan(content);
-  assertRepoUrlCloneable(plan.repoUrl!);
+  if (!plan.scratch) assertRepoUrlCloneable(plan.repoUrl!);
   return plan;
 }
 
@@ -568,7 +597,7 @@ export async function parsePlanSubmissionBundleFile(filePath: string): Promise<P
   const content = await readFile(filePath, 'utf-8');
   const submission = parsePlanSubmissionBundle(content);
   for (const plan of submission.plans) {
-    assertRepoUrlCloneable(plan.repoUrl!);
+    if (!plan.scratch) assertRepoUrlCloneable(plan.repoUrl!);
   }
   return submission;
 }

--- a/packages/execution-engine/src/__tests__/scratch-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/scratch-executor.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import type { ExecutorHandle } from '../executor.js';
+import type { WorkRequest, WorkResponse } from '@invoker/contracts';
+import { ScratchExecutor } from '../scratch-executor.js';
+
+let reqCounter = 0;
+function makeRequest(overrides: Partial<WorkRequest> = {}): WorkRequest {
+  const { inputs: inputOverrides, ...restOverrides } = overrides;
+  reqCounter += 1;
+  return {
+    requestId: `req-${reqCounter}`,
+    actionId: `action-${reqCounter}`,
+    actionType: 'command',
+    inputs: { command: 'true', ...inputOverrides },
+    callbackUrl: 'http://localhost:3000/callback',
+    timestamps: { createdAt: new Date().toISOString() },
+    ...restOverrides,
+  };
+}
+
+function waitForComplete(executor: ScratchExecutor, handle: ExecutorHandle): Promise<WorkResponse> {
+  return new Promise((resolve) => {
+    executor.onComplete(handle, (res) => resolve(res));
+  });
+}
+
+describe('ScratchExecutor', () => {
+  it('runs a command task in an isolated temp dir with no .git present', async () => {
+    const executor = new ScratchExecutor();
+    const request = makeRequest({ inputs: { command: '[ ! -e .git ]' } });
+    const handle = await executor.start(request);
+    const response = await waitForComplete(executor, handle);
+
+    expect(response.status).toBe('completed');
+    expect(handle.workspacePath).toBeTruthy();
+    expect(existsSync(handle.workspacePath!)).toBe(true);
+
+    await executor.destroyAll();
+  });
+
+  it('does not require repoUrl on the request', async () => {
+    const executor = new ScratchExecutor();
+    const request = makeRequest();
+    expect(request.inputs.repoUrl).toBeUndefined();
+    const response = await waitForComplete(executor, await executor.start(request));
+    expect(response.status).toBe('completed');
+    await executor.destroyAll();
+  });
+
+  it('gives concurrently started tasks distinct temp dirs', async () => {
+    const executor = new ScratchExecutor();
+    const requests = Array.from({ length: 6 }, () => makeRequest({ inputs: { command: 'true' } }));
+    const handles = await Promise.all(requests.map((r) => executor.start(r)));
+    await Promise.all(handles.map((h) => waitForComplete(executor, h)));
+
+    const paths = handles.map((h) => h.workspacePath);
+    expect(paths.every((p) => !!p)).toBe(true);
+    expect(new Set(paths).size).toBe(paths.length);
+
+    await executor.destroyAll();
+  });
+
+  it('reports a non-zero exit code as a failed task', async () => {
+    const executor = new ScratchExecutor();
+    const request = makeRequest({ inputs: { command: 'exit 3' } });
+    const handle = await executor.start(request);
+    const response = await waitForComplete(executor, handle);
+
+    expect(response.status).toBe('failed');
+    expect(response.outputs.exitCode).toBe(3);
+
+    await executor.destroyAll();
+  });
+
+  it('destroyAll removes temp dirs from disk', async () => {
+    const executor = new ScratchExecutor();
+    const request = makeRequest({ inputs: { command: 'true' } });
+    const handle = await executor.start(request);
+    await waitForComplete(executor, handle);
+    const workspacePath = handle.workspacePath!;
+
+    expect(existsSync(workspacePath)).toBe(true);
+    await executor.destroyAll();
+    expect(existsSync(workspacePath)).toBe(false);
+  });
+});

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -14,6 +14,7 @@ export * from './process-utils.js';
 export * from './agent-prompt-transport.js';
 export * from './docker-executor.js';
 export * from './worktree-executor.js';
+export * from './scratch-executor.js';
 export * from './merge-gate-executor.js';
 export * from './ssh-executor.js';
 export {

--- a/packages/execution-engine/src/scratch-executor.ts
+++ b/packages/execution-engine/src/scratch-executor.ts
@@ -1,0 +1,231 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { WorkRequest, WorkResponse } from '@invoker/contracts';
+import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
+import { BaseExecutor, type BaseEntry } from './base-executor.js';
+import { killProcessGroup, cleanElectronEnv, resolveExecutableOnCurrentPath, SIGKILL_TIMEOUT_MS } from './process-utils.js';
+import { DEFAULT_EXECUTION_AGENT } from './agent.js';
+import { traceExecution } from './exec-trace.js';
+
+export interface ScratchExecutorConfig {
+  /** Command to invoke the Claude CLI. Defaults to 'claude'. */
+  claudeCommand?: string;
+  /** Agent registry for pluggable AI agents. When set, overrides claudeCommand. */
+  agentRegistry?: import('./agent-registry.js').AgentRegistry;
+  /** Heartbeat interval in milliseconds. Default: 30000. */
+  heartbeatIntervalMs?: number;
+  /** Maximum task duration in milliseconds. Default: 4 hours. */
+  maxDurationMs?: number;
+}
+
+interface ScratchEntry extends BaseEntry {
+  process: ChildProcess | null;
+  tmpDir: string;
+  agentSessionId?: string;
+  agentName?: string;
+  rawStdout?: string;
+}
+
+function getDisplayOnlyBridgeSpec(
+  source: { displayOnlyBridgeText?: string },
+): Pick<TerminalSpec, 'displayOnlyBridgeText'> {
+  return source.displayOnlyBridgeText === undefined
+    ? {}
+    : { displayOnlyBridgeText: source.displayOnlyBridgeText };
+}
+
+/**
+ * Executor for plans declaring `scratch: true`: runs each task in a plain OS
+ * temp directory with no git clone/worktree/branch involved. Reuses
+ * BaseExecutor's spawn/heartbeat/handleProcessExit machinery — omitting
+ * `branch` from handleProcessExit's opts means it performs zero git operations.
+ */
+export class ScratchExecutor extends BaseExecutor<ScratchEntry> {
+  readonly type = 'scratch';
+
+  private readonly claudeCommand: string;
+  private readonly agentRegistry?: import('./agent-registry.js').AgentRegistry;
+  /**
+   * Every temp dir this executor has ever created, independent of `entries`
+   * (which drops completed tasks shortly after completion). destroyAll()
+   * uses this so completed tasks' temp dirs are still reclaimed on shutdown.
+   */
+  private readonly allTmpDirs = new Set<string>();
+
+  constructor(config: ScratchExecutorConfig = {}) {
+    super(config.heartbeatIntervalMs, config.maxDurationMs);
+    this.claudeCommand = config.claudeCommand ?? 'claude';
+    this.agentRegistry = config.agentRegistry;
+  }
+
+  async start(request: WorkRequest): Promise<ExecutorHandle> {
+    const handle = this.createHandle(request);
+    const executionId = handle.executionId;
+    const tmpDir = mkdtempSync(join(tmpdir(), 'invoker-scratch-'));
+    this.allTmpDirs.add(tmpDir);
+    traceExecution(`[ScratchExecutor] start task=${request.actionId} tmpDir=${tmpDir}`);
+
+    const entry: ScratchEntry = {
+      process: null,
+      request,
+      tmpDir,
+      outputListeners: new Set(),
+      outputBuffer: [],
+      outputBufferBytes: 0,
+      evictedChunkCount: 0,
+      completeListeners: new Set(),
+      heartbeatListeners: new Set(),
+      completed: false,
+    };
+    this.registerEntry(handle, entry);
+    handle.workspacePath = tmpDir;
+
+    const { cmd, args, agentSessionId } = this.buildCommandAndArgs(request, {
+      claudeCommand: this.claudeCommand,
+      agentRegistry: this.agentRegistry,
+    });
+
+    const usesAgent = request.actionType === 'ai_task';
+    const executionAgent = request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
+    const stdinMode = usesAgent && this.agentRegistry
+      ? this.agentRegistry.getOrThrow(executionAgent).stdinMode
+      : (usesAgent ? 'ignore' : 'pipe');
+    const spawnCmd = request.actionType === 'ai_task' ? (resolveExecutableOnCurrentPath(cmd) ?? cmd) : cmd;
+
+    const child = spawn(spawnCmd, args, {
+      stdio: [stdinMode, 'pipe', 'pipe'],
+      cwd: tmpDir,
+      detached: true,
+      env: cleanElectronEnv(),
+    });
+
+    child.on('error', (err) => {
+      traceExecution(`[ScratchExecutor] child process spawn error: ${err.message}`);
+      const response: WorkResponse = {
+        requestId: request.requestId,
+        actionId: request.actionId,
+        executionGeneration: request.executionGeneration,
+        status: 'failed',
+        outputs: {
+          exitCode: 1,
+          error: `Failed to spawn command: ${err.message}`,
+          agentName: request.actionType === 'ai_task' ? executionAgent : undefined,
+        },
+      };
+      this.emitComplete(executionId, response);
+    });
+
+    entry.process = child;
+    if (agentSessionId) {
+      entry.agentSessionId = agentSessionId;
+      handle.agentSessionId = agentSessionId;
+    }
+
+    const driver = usesAgent ? this.agentRegistry?.getSessionDriver(executionAgent) : undefined;
+    child.stdout?.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      if (driver) {
+        entry.rawStdout = (entry.rawStdout ?? '') + text;
+      } else {
+        this.emitOutput(executionId, text);
+      }
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      this.emitOutput(executionId, chunk.toString());
+    });
+
+    child.on('close', async (code, signal) => {
+      const exitCode = code ?? (signal ? 1 : 0);
+      entry.finalizingAfterClose = true;
+      try {
+        if (driver && entry.rawStdout) {
+          const realId = driver.extractSessionId?.(entry.rawStdout);
+          if (realId) entry.agentSessionId = realId;
+          const readable = driver.processOutput(entry.agentSessionId ?? '', entry.rawStdout);
+          if (readable) this.emitOutput(executionId, readable);
+        }
+        await this.handleProcessExit(executionId, request, tmpDir, exitCode, {
+          signal,
+          agentSessionId: entry.agentSessionId,
+          agentName: request.actionType === 'ai_task' ? executionAgent : undefined,
+        });
+      } finally {
+        entry.finalizingAfterClose = false;
+      }
+    });
+
+    this.startHeartbeat(executionId, child);
+    return handle;
+  }
+
+  sendInput(handle: ExecutorHandle, input: string): void {
+    const entry = this.getEntry(handle);
+    this.writeProcessInput(entry, input);
+  }
+
+  getTerminalSpec(handle: ExecutorHandle): TerminalSpec | null {
+    const entry = this.getEntry(handle);
+    if (!entry) return null;
+    const displayBridge = getDisplayOnlyBridgeSpec(handle);
+    if (entry.agentSessionId) {
+      const agentName = entry.request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
+      const resume = this.agentRegistry
+        ? this.agentRegistry.getOrThrow(agentName).buildResumeArgs(entry.agentSessionId)
+        : { cmd: 'claude', args: ['--resume', entry.agentSessionId, '--dangerously-skip-permissions'] };
+      return { command: resume.cmd, args: resume.args, cwd: entry.tmpDir, ...displayBridge };
+    }
+    return { cwd: entry.tmpDir, ...displayBridge };
+  }
+
+  getRestoredTerminalSpec(meta: PersistedTaskMeta): TerminalSpec {
+    if (meta.workspacePath && !existsSync(meta.workspacePath)) {
+      throw new Error(
+        `Scratch workspace ${meta.workspacePath} no longer exists for task ${meta.taskId}. ` +
+        'It was a temp directory and has since been cleaned up.',
+      );
+    }
+    const displayBridge = getDisplayOnlyBridgeSpec(meta);
+    if (meta.agentSessionId) {
+      const resume = this.agentRegistry
+        ? this.agentRegistry.getOrThrow(meta.executionAgent ?? DEFAULT_EXECUTION_AGENT).buildResumeArgs(meta.agentSessionId)
+        : { cmd: 'claude', args: ['--resume', meta.agentSessionId, '--dangerously-skip-permissions'] };
+      return { command: resume.cmd, args: resume.args, cwd: meta.workspacePath, ...displayBridge };
+    }
+    return { cwd: meta.workspacePath, ...displayBridge };
+  }
+
+  async destroyAll(): Promise<void> {
+    const allEntries = Array.from(this.entries.entries());
+    const closePromises: Promise<void>[] = [];
+
+    for (const [, entry] of allEntries) {
+      if (!entry.completed && entry.process) {
+        closePromises.push(
+          new Promise<void>((resolve) => {
+            entry.process!.on('close', () => resolve());
+            killProcessGroup(entry.process!, 'SIGTERM');
+            setTimeout(() => {
+              if (!entry.completed && entry.process) {
+                killProcessGroup(entry.process, 'SIGKILL');
+              }
+            }, SIGKILL_TIMEOUT_MS);
+          }),
+        );
+      }
+    }
+
+    await Promise.all(closePromises);
+    this.entries.clear();
+
+    for (const tmpDir of this.allTmpDirs) {
+      try {
+        rmSync(tmpDir, { recursive: true, force: true });
+      } catch (err) {
+        traceExecution(`[ScratchExecutor] failed to clean up tmpDir=${tmpDir}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    this.allTmpDirs.clear();
+  }
+}

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -19,6 +19,7 @@ import { ResourceLimitError } from './repo-pool.js';
 import { traceExecution } from './exec-trace.js';
 import { DockerExecutor } from './docker-executor.js';
 import { WorktreeExecutor } from './worktree-executor.js';
+import { ScratchExecutor } from './scratch-executor.js';
 import { MergeGateExecutor } from './merge-gate-executor.js';
 import { SshExecutor } from './ssh-executor.js';
 import type { MergeRunnerHost } from './merge-runner.js';
@@ -616,6 +617,24 @@ export function selectExecutor(
   clearPendingPoolSelection(host, task.id);
   reclaimSupersededExecutionSlots(host, task);
   reclaimOrphanedExecutionSlots(host);
+
+  // Scratch tasks never resolve a pool: no repo to clone means no pool
+  // member (ssh/worktree) can ever run them. A poolId attached to a scratch
+  // task by any other path (config default pool, routing rule, replacement
+  // task inheriting a parent's poolId) must never override this.
+  if (effectiveType === 'scratch') {
+    const registered = host.executorRegistry.get('scratch');
+    if (registered) {
+      traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=scratch → scratch (cached)`);
+      return { executor: registered, resolvedExecution, selectedPoolMemberId: undefined };
+    }
+    const scratch = new ScratchExecutor({
+      agentRegistry: host.executionAgentRegistry,
+    });
+    host.executorRegistry.register('scratch', scratch);
+    traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=scratch → scratch (lazy registered)`);
+    return { executor: scratch, resolvedExecution, selectedPoolMemberId: undefined };
+  }
 
   if (task.config.poolId && explicitPoolMemberId) {
     const pool = host.getExecutionPools()[task.config.poolId];

--- a/packages/workflow-core/src/__tests__/plan-parser.test.ts
+++ b/packages/workflow-core/src/__tests__/plan-parser.test.ts
@@ -122,4 +122,74 @@ tasks:
     expect(plan.mergeMode).toBe('no_op');
     expect(plan.onFinish).toBe('none');
   });
+
+  it('rejects plans without repoUrl and without scratch: true', () => {
+    const yaml = `
+name: No Repo No Scratch Plan
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/repoUrl.*scratch: true/);
+  });
+
+  it('parses a scratch: true plan with no repoUrl, defaulting onFinish/mergeMode', () => {
+    const yaml = `
+name: Scratch Plan
+scratch: true
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+`;
+    const plan = parsePlan(yaml);
+    expect(plan.scratch).toBe(true);
+    expect(plan.repoUrl).toBeUndefined();
+    expect(plan.onFinish).toBe('none');
+    expect(plan.mergeMode).toBe('no_op');
+  });
+
+  it('rejects a plan that sets both scratch: true and repoUrl', () => {
+    const yaml = `
+name: Conflicting Plan
+scratch: true
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/cannot set both "scratch: true" and "repoUrl"/);
+  });
+
+  it('rejects a scratch plan with a mergeMode other than no_op', () => {
+    const yaml = `
+name: Bad Merge Mode Scratch Plan
+scratch: true
+mergeMode: manual
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/mergeMode: "no_op"/);
+  });
+
+  it('rejects a scratch plan task that sets dockerImage', () => {
+    const yaml = `
+name: Bad Scratch Docker Plan
+scratch: true
+tasks:
+  - id: work
+    description: Do work
+    command: echo "ok"
+    dockerImage: some/image:latest
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/dockerImage.*poolId/);
+  });
 });

--- a/packages/workflow-core/src/executor-routing.ts
+++ b/packages/workflow-core/src/executor-routing.ts
@@ -224,7 +224,8 @@ export type ExecutorRoutingReason =
   | { type: 'dockerImage' }
   | { type: 'poolId'; poolId: string }
   | { type: 'routingRule'; poolId: string; pattern?: string; regex?: string }
-  | { type: 'defaultWorktree' };
+  | { type: 'defaultWorktree' }
+  | { type: 'scratch' };
 
 export function buildExecutorRoutedPayload(
   runnerKind: RunnerKind,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -401,6 +401,8 @@ export interface PlanDefinition {
   mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op';
   reviewProvider?: string;
   repoUrl?: string;
+  /** No-repo mode: every task runs in a plain temp directory, no git involved. Mutually exclusive with repoUrl. */
+  scratch?: boolean;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
     workflowId: string;
@@ -1356,14 +1358,18 @@ export class Orchestrator {
     const validatedTasks: TaskState[] = [];
     const resolvedRoutingByTaskId = new Map<string, ExecutorRoutingReason>();
     for (const taskDef of plan.tasks) {
-      const resolvedRouting = resolveExecutorRouting(
-        taskDef.id,
-        taskDef.command,
-        taskDef.poolId,
-        this.defaultPoolId,
-        this.executorRoutingRules,
-        this.availablePoolIds,
-      );
+      // Scratch plans never resolve a pool: no clone, no config-level default
+      // pool, no routing rule can ever hijack a scratch task's runnerKind.
+      const resolvedRouting: ReturnType<typeof resolveExecutorRouting> = plan.scratch
+        ? { poolId: undefined, reason: { type: 'scratch' } }
+        : resolveExecutorRouting(
+            taskDef.id,
+            taskDef.command,
+            taskDef.poolId,
+            this.defaultPoolId,
+            this.executorRoutingRules,
+            this.availablePoolIds,
+          );
       const effectivePoolId = resolvedRouting.poolId;
 
       const scopedId = localToScoped.get(taskDef.id)!;
@@ -1391,7 +1397,9 @@ export class Orchestrator {
         poolId: effectivePoolId,
       } as const;
       let taskConfig: TaskConfig;
-      if (taskDef.dockerImage) {
+      if (plan.scratch) {
+        taskConfig = { ...baseConfig, runnerKind: 'scratch' as const };
+      } else if (taskDef.dockerImage) {
         taskConfig = { ...baseConfig, runnerKind: 'docker' as const, dockerImage: taskDef.dockerImage };
       } else if (effectivePoolId) {
         taskConfig = { ...baseConfig, runnerKind: 'ssh' as const };
@@ -2660,6 +2668,9 @@ export class Orchestrator {
             ...rtBase, runnerKind: 'ssh',
             poolMemberId: task.config.runnerKind === 'ssh' ? (task.config as { poolMemberId?: string }).poolMemberId : undefined,
           } as unknown) as TaskConfig;
+          break;
+        case 'scratch':
+          rtConfig = { ...rtBase, runnerKind: 'scratch' as const };
           break;
         default:
           rtConfig = { ...rtBase, runnerKind: 'worktree' as const };

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -48,6 +48,7 @@ export interface RawPlan {
   mergeMode?: string;
   reviewProvider?: string;
   repoUrl?: string;
+  scratch?: boolean;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
     workflowId?: string;
@@ -167,21 +168,35 @@ export function parsePlan(yamlContent: string): PlanDefinition {
   }
   assertNoLegacyRoutingKeys('Plan', raw as object);
 
+  if (raw.scratch !== undefined && typeof raw.scratch !== 'boolean') {
+    throw new PlanParseError('Plan "scratch" must be a boolean when provided.');
+  }
+  const scratch = raw.scratch === true;
+
   const validOnFinishValues = ['none', 'merge', 'pull_request'] as const;
   if (raw.onFinish !== undefined && !validOnFinishValues.includes(raw.onFinish as any)) {
     throw new PlanParseError(`"onFinish" must be one of: ${validOnFinishValues.join(', ')}. Got: "${raw.onFinish}"`);
   }
-  const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? 'pull_request';
+  if (scratch && raw.onFinish !== undefined && raw.onFinish !== 'none') {
+    throw new PlanParseError('Plan with "scratch: true" must use onFinish: "none" (or omit it) — there is no branch/PR to finish.');
+  }
+  const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? (scratch ? 'none' : 'pull_request');
 
   const validMergeModes = ['manual', 'automatic', 'external_review', 'no_op'] as const;
   if (raw.mergeMode !== undefined && !validMergeModes.includes(raw.mergeMode as any)) {
     throw new PlanParseError(`"mergeMode" must be one of: ${validMergeModes.join(', ')}. Got: "${raw.mergeMode}"`);
   }
-  const mergeMode = raw.mergeMode as (typeof validMergeModes)[number] | undefined;
+  if (scratch && raw.mergeMode !== undefined && raw.mergeMode !== 'no_op') {
+    throw new PlanParseError('Plan with "scratch: true" must use mergeMode: "no_op" (or omit it) — there is no repo/branch to merge.');
+  }
+  const mergeMode = (raw.mergeMode as (typeof validMergeModes)[number] | undefined) ?? (scratch ? 'no_op' : undefined);
   const reviewProvider = raw.reviewProvider ?? (raw.mergeMode === 'external_review' ? 'github' : undefined);
 
-  if (!raw.repoUrl || typeof raw.repoUrl !== 'string') {
-    throw new PlanParseError('Plan must have a "repoUrl" field (e.g. repoUrl: git@github.com:user/repo.git).');
+  if (scratch && raw.repoUrl !== undefined) {
+    throw new PlanParseError('Plan cannot set both "scratch: true" and "repoUrl" — scratch plans run with no git repo.');
+  }
+  if (!scratch && (!raw.repoUrl || typeof raw.repoUrl !== 'string')) {
+    throw new PlanParseError('Plan must have either a "repoUrl" field (e.g. repoUrl: git@github.com:user/repo.git) or "scratch: true" (no-repo mode).');
   }
   if (raw.intermediateRepoUrl !== undefined) {
     if (typeof raw.intermediateRepoUrl !== 'string' || raw.intermediateRepoUrl.trim() === '') {
@@ -213,6 +228,9 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     }
     if (task.command && /\bnpx vitest run\b/.test(task.command)) {
       throw new PlanParseError(`Task "${task.id}" uses 'npx vitest run' which may not resolve correctly. Use 'pnpm test' instead.`);
+    }
+    if (scratch && (task.dockerImage || task.poolId)) {
+      throw new PlanParseError(`Task "${task.id}" sets "dockerImage"/"poolId" but the plan has "scratch: true" — scratch tasks always run in a plain temp directory.`);
     }
 
     if (task.externalDependencies !== undefined) {
@@ -258,6 +276,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     mergeMode,
     reviewProvider,
     repoUrl: raw.repoUrl,
+    scratch: scratch || undefined,
     intermediateRepoUrl: raw.intermediateRepoUrl,
     externalDependencies: topLevelExternalDependencies,
     tasks,

--- a/packages/workflow-graph/src/runner-kind.ts
+++ b/packages/workflow-graph/src/runner-kind.ts
@@ -1,8 +1,8 @@
 /** All executor types accepted at runtime (includes internal 'merge'). */
-export type RunnerKind = 'worktree' | 'docker' | 'ssh' | 'merge';
+export type RunnerKind = 'worktree' | 'docker' | 'ssh' | 'scratch' | 'merge';
 
 export const SUPPORTED_EXECUTOR_TYPES = new Set<RunnerKind>([
-  'worktree', 'docker', 'ssh',
+  'worktree', 'docker', 'ssh', 'scratch',
   'merge',  // internal: merge-node only
 ]);
 

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -90,7 +90,13 @@ export interface MergeTaskConfig extends BaseTaskConfig {
   readonly dockerImage?: never;
 }
 
-export type TaskConfig = WorktreeTaskConfig | DockerTaskConfig | SshTaskConfig | MergeTaskConfig;
+/** No-repo config: task runs in a plain temp directory, no git involved. */
+export interface ScratchTaskConfig extends BaseTaskConfig {
+  readonly runnerKind: 'scratch';
+  readonly dockerImage?: never;
+}
+
+export type TaskConfig = WorktreeTaskConfig | DockerTaskConfig | SshTaskConfig | MergeTaskConfig | ScratchTaskConfig;
 
 export type ExternalGatePolicy = 'completed' | 'review_ready' | 'ci_failed';
 


### PR DESCRIPTION
## Summary

Invoker checks a plan's shape in two separate places, not one.

The first copy already learned `scratch: true` earlier in this stack. The
second copy, used by the desktop app and its non-GUI entry point, had not.

This PR teaches the second copy the same trick, so scratch plans work
everywhere.

## Review Claim

Accept `scratch: true` in `packages/app/src/plan-parser.ts`, the parser
behind the Electron GUI and `./run.sh`'s non-GUI plan flow.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Same opt-in guarantee and same conflict/default rules as the workflow-core
slice earlier in this stack, including a regression test that a plan with
neither `repoUrl` nor `scratch: true` still throws. This package's own
plan-parser test suite (76 tests, all passing) exercises every existing
non-scratch code path unchanged, plus 6 new cases for the scratch behavior.
Also guards the two `assertRepoUrlCloneable(plan.repoUrl!)` call sites on
`!plan.scratch`, since a scratch plan has no `repoUrl` to check.

## Slice Rationale

Different package (`packages/app` vs `packages/workflow-core`), same
conceptual change repeated at its mirror location — kept as its own slice
rather than bundled with the workflow-core parser slice so each package's
own test suite and review can proceed independently.

## Non-goals

Does not change the executor or dispatch routing (both already landed
earlier in this stack). Does not deduplicate the two parser
implementations — that overlap predates this stack and is out of scope here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — later stack slices depend on this one, so revert
  the whole stack top-down if reverting.
- Data migration? No

</details>

Depends-On: #8246