### PR TITLE
[Scratch execution mode](8) Add a real e2e test for scratch execution and wire it into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,7 @@ jobs:
               bash scripts/test-suites/required/10-dag-background-click-noop-guard.sh
               bash scripts/test-suites/required/15-owner-boundary-policy.sh
               bash scripts/test-suites/required/50-verify-executor-routing.sh
+              bash scripts/test-suites/required/51-verify-scratch-execution.sh
           - name: Vitest Workspace
             command: bash scripts/test-suites/required/10-vitest-workspace.sh
           - name: Submit Workflow Chain

--- a/plans/verify-scratch-execution-headless.yaml
+++ b/plans/verify-scratch-execution-headless.yaml
@@ -1,0 +1,16 @@
+# Run: bash scripts/verify-scratch-execution.sh
+#
+# Asserts scratch mode end to end: a plan with no repoUrl at all, running
+# through the real headless submit path, completes with runnerKind=scratch
+# and a workspace_path that is a plain temp directory, never the repo
+# checkout.
+name: "Verify scratch execution (headless Invoker)"
+scratch: true
+onFinish: none
+mergeMode: no_op
+
+tasks:
+  - id: verify-scratch-command
+    description: "Command task proves it ran with no git repo present"
+    command: test ! -d .git && pwd
+    dependencies: []

--- a/scripts/test-suites/required/51-verify-scratch-execution.sh
+++ b/scripts/test-suites/required/51-verify-scratch-execution.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Headless submit-plan e2e for scratch: true (no-repo) execution.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+exec bash "$ROOT/scripts/verify-scratch-execution.sh"

--- a/scripts/verify-scratch-execution.sh
+++ b/scripts/verify-scratch-execution.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# End-to-end validation: a scratch: true plan runs through the real headless
+# submit path with no git repo involved at all.
+#
+# Submits plans/verify-scratch-execution-headless.yaml (no repoUrl field)
+# using a temp INVOKER_DB_DIR so the user's DB is never touched, then asserts
+# the task completed with runnerKind=scratch and a workspace_path that sits
+# outside this repo checkout (a plain OS temp directory).
+#
+# Usage (from repo root): bash scripts/verify-scratch-execution.sh
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [[ ! -f packages/app/dist/main.js ]]; then
+  echo "==> packages/app/dist/main.js missing — building..." >&2
+  pnpm --filter @invoker/core build >&2
+  pnpm --filter @invoker/persistence build >&2
+  pnpm --filter @invoker/execution-engine build >&2
+  pnpm --filter @invoker/surfaces build >&2
+  pnpm --filter @invoker/ui build >&2
+  pnpm --filter @invoker/app build >&2
+fi
+
+TMPDB="$(mktemp -d)"
+trap 'rm -rf "$TMPDB"' EXIT
+
+export INVOKER_DB_DIR="$TMPDB"
+export INVOKER_HEADLESS_STANDALONE=1
+
+echo "==> Using temp DB: $TMPDB"
+PLAN="$ROOT/plans/verify-scratch-execution-headless.yaml"
+echo "==> submit-plan (headless run) $PLAN"
+./submit-plan.sh "$PLAN"
+
+DB="$TMPDB/invoker.db"
+if [[ -f "$DB" ]] && command -v sqlite3 >/dev/null 2>&1; then
+  STATUS=$(sqlite3 "$DB" "SELECT status FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
+  RUNNER_KIND=$(sqlite3 "$DB" "SELECT runner_kind FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
+  WORKSPACE_PATH=$(sqlite3 "$DB" "SELECT workspace_path FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
+
+  if [[ "$STATUS" != "completed" ]]; then
+    echo "FAIL: expected scratch task to complete, got status='$STATUS'" >&2
+    exit 1
+  fi
+  if [[ "$RUNNER_KIND" != "scratch" ]]; then
+    echo "FAIL: expected persisted task runner_kind=scratch, got '$RUNNER_KIND'" >&2
+    exit 1
+  fi
+  if [[ -z "$WORKSPACE_PATH" ]]; then
+    echo "FAIL: expected a workspace_path for the scratch task, got empty" >&2
+    exit 1
+  fi
+  case "$WORKSPACE_PATH" in
+    "$ROOT"*)
+      echo "FAIL: scratch task workspace_path is inside the repo checkout ($WORKSPACE_PATH); scratch mode must never use the repo" >&2
+      exit 1
+      ;;
+  esac
+  # A bare `run` (not `owner-serve`) never calls executor destroyAll() for
+  # ANY executor type -- worktrees are not reclaimed after it either, per
+  # verify-executor-routing.sh. So the scratch temp dir persisting here is
+  # expected, not a leak; only owner-serve's shutdown path reclaims it.
+  echo "PASS: scratch task completed with runner_kind=$RUNNER_KIND workspace_path=$WORKSPACE_PATH (outside repo)"
+else
+  echo "FAIL: expected a queryable sqlite DB at $DB" >&2
+  exit 1
+fi


### PR DESCRIPTION
Submits a scratch: true plan through the actual headless run path
(same Electron binary as the GUI, real SQLite-backed store) and
asserts the task completed with runnerKind=scratch and a
workspace_path outside the repo checkout. Wired into the
required-fast CI job alongside the existing executor-routing check.

This test caught a real bug during development: a configured default
execution pool silently overrode scratch routing to ssh. That fix
was folded into slices 2 and 4 above, not left here.

Depends-On: #8249