### PR TITLE
[Scratch execution mode](8) Add a real e2e test for scratch execution

### DIFF
--- a/plans/verify-scratch-execution-headless.yaml
+++ b/plans/verify-scratch-execution-headless.yaml
@@ -1,0 +1,16 @@
+# Run: bash scripts/verify-scratch-execution.sh
+#
+# Asserts scratch mode end to end: a plan with no repoUrl at all, running
+# through the real headless submit path, completes with runnerKind=scratch
+# and a workspace_path that is a plain temp directory, never the repo
+# checkout.
+name: "Verify scratch execution (headless Invoker)"
+scratch: true
+onFinish: none
+mergeMode: no_op
+
+tasks:
+  - id: verify-scratch-command
+    description: "Command task proves it ran with no git repo present"
+    command: test ! -e .git && pwd
+    dependencies: []

--- a/scripts/verify-scratch-execution.sh
+++ b/scripts/verify-scratch-execution.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# End-to-end validation: a scratch: true plan runs through the real headless
+# submit path with no git repo involved at all.
+#
+# Submits plans/verify-scratch-execution-headless.yaml (no repoUrl field)
+# using a temp INVOKER_DB_DIR so the user's DB is never touched, then asserts
+# the task completed with runnerKind=scratch and a workspace_path that sits
+# outside this repo checkout (a plain OS temp directory).
+#
+# Usage (from repo root): bash scripts/verify-scratch-execution.sh
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [[ ! -f packages/app/dist/main.js ]]; then
+  echo "==> packages/app/dist/main.js missing — building..." >&2
+  pnpm --filter @invoker/core build >&2
+  pnpm --filter @invoker/persistence build >&2
+  pnpm --filter @invoker/execution-engine build >&2
+  pnpm --filter @invoker/surfaces build >&2
+  pnpm --filter @invoker/ui build >&2
+  pnpm --filter @invoker/app build >&2
+fi
+
+TMPDB="$(mktemp -d)"
+trap 'rm -rf "$TMPDB"' EXIT
+
+export INVOKER_DB_DIR="$TMPDB"
+export INVOKER_HEADLESS_STANDALONE=1
+
+echo "==> Using temp DB: $TMPDB"
+PLAN="$ROOT/plans/verify-scratch-execution-headless.yaml"
+echo "==> submit-plan (headless run) $PLAN"
+./submit-plan.sh "$PLAN"
+
+DB="$TMPDB/invoker.db"
+if [[ -f "$DB" ]] && command -v sqlite3 >/dev/null 2>&1; then
+  STATUS=$(sqlite3 "$DB" "SELECT status FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
+  RUNNER_KIND=$(sqlite3 "$DB" "SELECT runner_kind FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
+  WORKSPACE_PATH=$(sqlite3 "$DB" "SELECT workspace_path FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
+
+  if [[ "$STATUS" != "completed" ]]; then
+    echo "FAIL: expected scratch task to complete, got status='$STATUS'" >&2
+    exit 1
+  fi
+  if [[ "$RUNNER_KIND" != "scratch" ]]; then
+    echo "FAIL: expected persisted task runner_kind=scratch, got '$RUNNER_KIND'" >&2
+    exit 1
+  fi
+  if [[ -z "$WORKSPACE_PATH" ]]; then
+    echo "FAIL: expected a workspace_path for the scratch task, got empty" >&2
+    exit 1
+  fi
+  case "$WORKSPACE_PATH" in
+    "$ROOT"|"$ROOT"/*)
+      echo "FAIL: scratch task workspace_path is inside the repo checkout ($WORKSPACE_PATH); scratch mode must never use the repo" >&2
+      exit 1
+      ;;
+  esac
+  # A bare `run` (not `owner-serve`) never calls executor destroyAll() for
+  # ANY executor type -- worktrees are not reclaimed after it either, per
+  # verify-executor-routing.sh. So the scratch temp dir persisting here is
+  # expected, not a leak; only owner-serve's shutdown path reclaims it.
+  echo "PASS: scratch task completed with runner_kind=$RUNNER_KIND workspace_path=$WORKSPACE_PATH (outside repo)"
+else
+  echo "FAIL: expected a queryable sqlite DB at $DB" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

This proves scratch mode actually works, not just in unit tests.

It runs a real plan through the real app, the same way a user would,
and checks the task really finished.

Nothing turns this check on yet — that's the next PR.

## Review Claim

Add a new plan-checking script for a `scratch: true` plan, modeled directly
on the existing pool-routing check.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only adds a new fixture plan and a new checking script; no product code
path changes. It uses a temp database directory so it never touches a real
user database, matching the existing script's own safety comment.

This script is not decorative: while writing it, it caught a real bug — a
configured default pool silently overrode scratch routing to `ssh`, so a
scratch task assigned to a member requiring a real repo failed. That fix
already landed earlier in this stack (slices 2 and 4), verified by this
same script going from failing to passing before this PR was written.

## Slice Rationale

Kept as its own top slice rather than folded into slice 3 (the executor) or
slice 4 (the wiring), since "does the whole real system behave correctly
end to end" is a distinct claim from "is each piece correct alone," and it
needed every earlier slice to exist first to even run.

## Non-goals

Does not add a Playwright/Electron-UI test — scratch mode has no screen to
prove, and this path already exercises the real production code with far
less overhead. Does not turn this check on anywhere yet (next PR). Does not
change the existing pool-routing script it's modeled on.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/verify-scratch-execution.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added headless verification for executing command tasks in scratch mode without a Git repository.
  * Added end-to-end validation confirming scratch tasks complete successfully and use temporary workspaces outside the repository.
  * Added isolated database setup and automatic package preparation when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->