### PR TITLE
[Scratch execution mode](9) Wire the scratch execution e2e test into required CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,7 @@ jobs:
               bash scripts/test-suites/required/10-dag-background-click-noop-guard.sh
               bash scripts/test-suites/required/15-owner-boundary-policy.sh
               bash scripts/test-suites/required/50-verify-executor-routing.sh
+              bash scripts/test-suites/required/51-verify-scratch-execution.sh
           - name: Vitest Workspace
             command: bash scripts/test-suites/required/10-vitest-workspace.sh
           - name: Submit Workflow Chain

--- a/scripts/test-suites/required/51-verify-scratch-execution.sh
+++ b/scripts/test-suites/required/51-verify-scratch-execution.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Headless submit-plan e2e for scratch: true (no-repo) execution.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+exec bash "$ROOT/scripts/verify-scratch-execution.sh"

--- a/scripts/verify-scratch-execution.sh
+++ b/scripts/verify-scratch-execution.sh
@@ -34,35 +34,41 @@ echo "==> submit-plan (headless run) $PLAN"
 ./submit-plan.sh "$PLAN"
 
 DB="$TMPDB/invoker.db"
-if [[ -f "$DB" ]] && command -v sqlite3 >/dev/null 2>&1; then
-  STATUS=$(sqlite3 "$DB" "SELECT status FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
-  RUNNER_KIND=$(sqlite3 "$DB" "SELECT runner_kind FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
-  WORKSPACE_PATH=$(sqlite3 "$DB" "SELECT workspace_path FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
-
-  if [[ "$STATUS" != "completed" ]]; then
-    echo "FAIL: expected scratch task to complete, got status='$STATUS'" >&2
-    exit 1
-  fi
-  if [[ "$RUNNER_KIND" != "scratch" ]]; then
-    echo "FAIL: expected persisted task runner_kind=scratch, got '$RUNNER_KIND'" >&2
-    exit 1
-  fi
-  if [[ -z "$WORKSPACE_PATH" ]]; then
-    echo "FAIL: expected a workspace_path for the scratch task, got empty" >&2
-    exit 1
-  fi
-  case "$WORKSPACE_PATH" in
-    "$ROOT"|"$ROOT"/*)
-      echo "FAIL: scratch task workspace_path is inside the repo checkout ($WORKSPACE_PATH); scratch mode must never use the repo" >&2
-      exit 1
-      ;;
-  esac
-  # A bare `run` (not `owner-serve`) never calls executor destroyAll() for
-  # ANY executor type -- worktrees are not reclaimed after it either, per
-  # verify-executor-routing.sh. So the scratch temp dir persisting here is
-  # expected, not a leak; only owner-serve's shutdown path reclaims it.
-  echo "PASS: scratch task completed with runner_kind=$RUNNER_KIND workspace_path=$WORKSPACE_PATH (outside repo)"
-else
-  echo "FAIL: expected a queryable sqlite DB at $DB" >&2
+if [[ ! -f "$DB" ]]; then
+  echo "FAIL: expected invoker.db at $DB, but it does not exist" >&2
+  echo "==> Contents of $TMPDB:" >&2
+  ls -la "$TMPDB" >&2 || true
   exit 1
 fi
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "FAIL: sqlite3 CLI is not installed on this machine" >&2
+  exit 1
+fi
+
+STATUS=$(sqlite3 "$DB" "SELECT status FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
+RUNNER_KIND=$(sqlite3 "$DB" "SELECT runner_kind FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
+WORKSPACE_PATH=$(sqlite3 "$DB" "SELECT workspace_path FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
+
+if [[ "$STATUS" != "completed" ]]; then
+  echo "FAIL: expected scratch task to complete, got status='$STATUS'" >&2
+  exit 1
+fi
+if [[ "$RUNNER_KIND" != "scratch" ]]; then
+  echo "FAIL: expected persisted task runner_kind=scratch, got '$RUNNER_KIND'" >&2
+  exit 1
+fi
+if [[ -z "$WORKSPACE_PATH" ]]; then
+  echo "FAIL: expected a workspace_path for the scratch task, got empty" >&2
+  exit 1
+fi
+case "$WORKSPACE_PATH" in
+  "$ROOT"|"$ROOT"/*)
+    echo "FAIL: scratch task workspace_path is inside the repo checkout ($WORKSPACE_PATH); scratch mode must never use the repo" >&2
+    exit 1
+    ;;
+esac
+# A bare `run` (not `owner-serve`) never calls executor destroyAll() for
+# ANY executor type -- worktrees are not reclaimed after it either, per
+# verify-executor-routing.sh. So the scratch temp dir persisting here is
+# expected, not a leak; only owner-serve's shutdown path reclaims it.
+echo "PASS: scratch task completed with runner_kind=$RUNNER_KIND workspace_path=$WORKSPACE_PATH (outside repo)"


### PR DESCRIPTION
## Summary

This turns on the new check from the previous PR, so it runs on every
future change instead of only by hand.

It's added right next to the check it's modeled on, in the same required
group that already exists.

## Review Claim

Add the previous PR's checking script as a required step, right after the
existing pool-routing step it's modeled on.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

One new file (a thin wrapper matching the existing wrapper's own shape) and
one new line inserted into an existing required group. Nothing existing is
removed, replaced, or reordered, so every check that already runs still
runs exactly as before.

## Slice Rationale

Kept apart from the previous PR (the checking script itself) since "does
this script check the right thing" and "does it actually run automatically"
are two separate claims a reviewer can approve independently.

## Non-goals

Does not change any other required step. Does not touch the optional or
extended groups.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/test-suites/required/51-verify-scratch-execution.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
