### PR TITLE
Compress hourly DB snapshots to shrink db-backups on disk

### DIFF
--- a/packages/app/src/__tests__/delete-all-snapshot-wal-safety.test.ts
+++ b/packages/app/src/__tests__/delete-all-snapshot-wal-safety.test.ts
@@ -19,9 +19,11 @@
  * halves of the correct fix.
  */
 import { describe, expect, it, afterEach } from 'vitest';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { createReadStream, createWriteStream, existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { createGunzip } from 'node:zlib';
 import { SQLiteAdapter } from '@invoker/data-store';
 import type { Workflow } from '@invoker/data-store';
 import { createHourlySnapshot } from '../delete-all-snapshot.js';
@@ -37,6 +39,15 @@ afterEach(() => {
     try { rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
   }
 });
+
+/** Snapshots are gzipped on write; decompress to a plain file so SQLiteAdapter can open it. */
+async function openSnapshotReadOnly(snapshotPath: string): Promise<SQLiteAdapter> {
+  const dir = mkdtempSync(join(tmpdir(), 'hourly-snapshot-read-'));
+  roots.push(dir);
+  const decompressed = join(dir, 'snapshot.db');
+  await pipeline(createReadStream(snapshotPath), createGunzip(), createWriteStream(decompressed));
+  return SQLiteAdapter.create(decompressed, { readOnly: true });
+}
 
 function makeWorkflow(id: string): Workflow {
   const now = new Date().toISOString();
@@ -102,7 +113,7 @@ describe('hourly snapshot with a live WAL owner', () => {
       // Open the snapshot in a fresh reader and confirm every commit is there.
       // If the snapshot were just a raw copy of .db, most or all of these rows
       // would be missing.
-      const reader = await SQLiteAdapter.create(snapshot as string, { readOnly: true });
+      const reader = await openSnapshotReadOnly(snapshot as string);
       try {
         const ids = new Set(reader.listWorkflows().map((w) => w.id));
         for (let i = 0; i < 20; i += 1) {
@@ -126,7 +137,7 @@ describe('hourly snapshot with a live WAL owner', () => {
       const snapshot = await createHourlySnapshot(root, (dest) => owner.backupTo(dest));
       expect(snapshot).not.toBeNull();
 
-      const reader = await SQLiteAdapter.create(snapshot as string, { readOnly: true });
+      const reader = await openSnapshotReadOnly(snapshot as string);
       try {
         const ids = reader.listWorkflows().map((w) => w.id);
         expect(ids).toContain('wf-consistent');

--- a/packages/app/src/__tests__/delete-all-snapshot.test.ts
+++ b/packages/app/src/__tests__/delete-all-snapshot.test.ts
@@ -7,10 +7,12 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { gunzipSync } from 'node:zlib';
 import {
   createDeleteAllSnapshot,
   createHourlySnapshot,
@@ -24,6 +26,11 @@ function makeDbRoot(): string {
   const root = mkdtempSync(join(tmpdir(), 'invoker-db-snapshot-test-'));
   tmpRoots.push(root);
   return root;
+}
+
+/** Snapshots are gzipped on write; decode back to the original text for assertions. */
+function readSnapshotText(snapshotPath: string): string {
+  return gunzipSync(readFileSync(snapshotPath)).toString('utf-8');
 }
 
 afterEach(() => {
@@ -44,8 +51,10 @@ describe('delete-all-snapshot (no-adapter fallback)', () => {
 
     const snapshot = await createDeleteAllSnapshot(root);
     expect(snapshot).toContain(join(root, 'db-backups', 'invoker.db.before-delete-all-'));
+    expect(snapshot).toMatch(/\.gz$/);
     expect(existsSync(snapshot as string)).toBe(true);
-    expect(readFileSync(snapshot as string, 'utf-8')).toBe('db-main');
+    expect(existsSync((snapshot as string).replace(/\.gz$/, ''))).toBe(false); // raw intermediate removed
+    expect(readSnapshotText(snapshot as string)).toBe('db-main');
     expect(existsSync(`${snapshot}-wal`)).toBe(false);
     expect(existsSync(`${snapshot}-shm`)).toBe(false);
   });
@@ -59,8 +68,9 @@ describe('delete-all-snapshot (no-adapter fallback)', () => {
 
     const snapshot = await createHourlySnapshot(root);
     expect(snapshot).toContain(join(root, 'db-backups', 'invoker.db.hourly-auto-'));
+    expect(snapshot).toMatch(/\.gz$/);
     expect(existsSync(snapshot as string)).toBe(true);
-    expect(readFileSync(snapshot as string, 'utf-8')).toBe('db-main');
+    expect(readSnapshotText(snapshot as string)).toBe('db-main');
 
     expect(existsSync(`${snapshot}-wal`)).toBe(false);
     expect(existsSync(`${snapshot}-shm`)).toBe(false);
@@ -87,7 +97,7 @@ describe('delete-all-snapshot (no-adapter fallback)', () => {
     mkdirSync(join(root, 'db-backups'), { recursive: true });
 
     const snapshot = await createDeleteAllSnapshot(root);
-    expect(readFileSync(snapshot as string, 'utf-8')).toBe('restored-db');
+    expect(readSnapshotText(snapshot as string)).toBe('restored-db');
   });
 });
 
@@ -107,8 +117,8 @@ describe('delete-all-snapshot (adapter-backed backup)', () => {
       writeFileSync(dest, 'from-adapter-backup');
     });
 
-    expect(calls).toEqual([snapshot]);
-    expect(readFileSync(snapshot as string, 'utf-8')).toBe('from-adapter-backup');
+    expect(calls).toEqual([snapshot?.replace(/\.gz$/, '')]); // backup callback writes the raw path pre-compression
+    expect(readSnapshotText(snapshot as string)).toBe('from-adapter-backup');
     expect(existsSync(`${snapshot}-wal`)).toBe(false);
     expect(existsSync(`${snapshot}-shm`)).toBe(false);
   });
@@ -228,5 +238,39 @@ describe('hourly snapshot retention', () => {
     for (const blank of ['', '   ']) {
       expect(await keptWith(blank)).toBe(unsetKept);
     }
+  });
+});
+
+describe('hourly snapshot compression', () => {
+  it('gzips the snapshot and shrinks realistic, compressible SQLite-shaped content', async () => {
+    const root = makeDbRoot();
+    // Real SQLite DBs are dominated by repeated schema/text structure, not
+    // random bytes -- a repeating string is a closer proxy than random data
+    // for what gzip actually sees in production.
+    const compressible = 'CREATE TABLE tasks (id TEXT, description TEXT); '.repeat(20_000);
+    writeFileSync(join(root, 'invoker.db'), compressible);
+
+    const snapshot = await createHourlySnapshot(root);
+    const rawBytes = Buffer.byteLength(compressible, 'utf-8');
+    const gzBytes = statSync(snapshot as string).size;
+
+    expect(readSnapshotText(snapshot as string)).toBe(compressible);
+    expect(gzBytes).toBeLessThan(rawBytes / 2); // repetitive text compresses well below half
+  });
+
+  it('prunes a mix of legacy uncompressed and new .gz snapshots by count, oldest first', async () => {
+    const root = makeDbRoot();
+    writeFileSync(join(root, 'invoker.db'), 'db-main');
+    const backupDir = join(root, 'db-backups');
+    seedHourly(backupDir, 3); // legacy uncompressed, oldest
+
+    const snapshot = await createHourlySnapshot(root, undefined, 2); // new .gz snapshot, newest
+
+    const remaining = hourlyBaseNames(backupDir);
+    expect(remaining).toHaveLength(2);
+    expect(remaining).toContain(join(backupDir, 'invoker.db.hourly-auto-20260101-000002-000Z').split('/').pop());
+    expect(existsSync(snapshot as string)).toBe(true); // the new .gz snapshot survives
+    expect(existsSync(join(backupDir, 'invoker.db.hourly-auto-20260101-000000-000Z'))).toBe(false);
+    expect(existsSync(join(backupDir, 'invoker.db.hourly-auto-20260101-000001-000Z'))).toBe(false);
   });
 });

--- a/packages/app/src/delete-all-snapshot.ts
+++ b/packages/app/src/delete-all-snapshot.ts
@@ -1,5 +1,7 @@
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { copyFileSync, createReadStream, createWriteStream, existsSync, mkdirSync, unlinkSync } from 'node:fs';
 import * as path from 'node:path';
+import { createGzip } from 'node:zlib';
+import { pipeline } from 'node:stream/promises';
 import {
   resolveInvokerHomeRoot,
   hourlySnapshotRetention,
@@ -26,6 +28,18 @@ export type SnapshotBackupFn = (destinationPath: string) => Promise<void>;
 function utcTimestampCompact(): string {
   const iso = new Date().toISOString();
   return iso.replace(/[-:]/g, '').replace('T', '-').replace('.', '-');
+}
+
+/**
+ * Gzip `rawPath` to `rawPath + '.gz'` and remove the raw file. Streamed (not
+ * `zlib.gzipSync`) so a ~700MB+ snapshot never gets buffered twice in memory
+ * or blocks the event loop on small droplets.
+ */
+async function gzipInPlace(rawPath: string): Promise<string> {
+  const gzPath = `${rawPath}.gz`;
+  await pipeline(createReadStream(rawPath), createGzip(), createWriteStream(gzPath));
+  unlinkSync(rawPath);
+  return gzPath;
 }
 
 async function createDbSnapshot(
@@ -55,7 +69,7 @@ async function createDbSnapshot(
     copyFileSync(dbPath, snapshotPath);
   }
 
-  return snapshotPath;
+  return gzipInPlace(snapshotPath);
 }
 
 /**

--- a/packages/data-store/src/__tests__/sqlite-adapter-corruption-recovery.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter-corruption-recovery.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import {
   mkdtempSync,
   mkdirSync,
@@ -7,9 +7,14 @@ import {
   readFileSync,
   readdirSync,
   existsSync,
+  createReadStream,
+  createWriteStream,
+  unlinkSync,
 } from 'node:fs';
 import { basename, join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { pipeline } from 'node:stream/promises';
+import { createGzip } from 'node:zlib';
 import {
   SQLiteAdapter,
   isDatabaseCorruptionError,
@@ -59,6 +64,20 @@ async function seedSnapshot(snapshotPath: string, workflowIds: string[]): Promis
     const sidecar = `${snapshotPath}${suffix}`;
     if (existsSync(sidecar)) rmSync(sidecar);
   }
+}
+
+/**
+ * Seed a valid SQLite snapshot the same way {@link seedSnapshot} does, then
+ * gzip it in place to `<path>.gz` and remove the raw intermediate — matching
+ * exactly what `createDbSnapshot` in `packages/app/src/delete-all-snapshot.ts`
+ * produces in production. Returns the final `.gz` path.
+ */
+async function seedGzippedSnapshot(snapshotPath: string, workflowIds: string[]): Promise<string> {
+  await seedSnapshot(snapshotPath, workflowIds);
+  const gzPath = `${snapshotPath}.gz`;
+  await pipeline(createReadStream(snapshotPath), createGzip(), createWriteStream(gzPath));
+  unlinkSync(snapshotPath);
+  return gzPath;
 }
 
 describe('isDatabaseCorruptionError', () => {
@@ -241,6 +260,100 @@ describe('SQLiteAdapter.create auto-restore from hourly snapshot', () => {
       );
     } finally {
       adapter.close();
+    }
+  });
+
+  it('restores from a gzip-compressed hourly snapshot (production write format)', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const backupDir = join(dir, 'db-backups');
+    mkdirSync(backupDir);
+
+    const olderGz = await seedGzippedSnapshot(
+      join(backupDir, `${basename(dbPath)}.hourly-auto-20260708-090000-000Z`),
+      ['wf-older'],
+    );
+    const newerGz = await seedGzippedSnapshot(
+      join(backupDir, `${basename(dbPath)}.hourly-auto-20260708-100000-000Z`),
+      ['wf-newer-1', 'wf-newer-2'],
+    );
+    expect(olderGz).toMatch(/\.gz$/);
+    expect(newerGz).toMatch(/\.gz$/);
+
+    writeFileSync(dbPath, Buffer.from('xx not a sqlite header xx '.repeat(50)));
+
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      const ids = adapter.listWorkflows().map((w) => w.id).sort();
+      expect(ids).toEqual(['wf-newer-1', 'wf-newer-2']);
+      expect(adapter.corruptionRecovery?.restoredFromSnapshot).toBe(newerGz);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('skips a corrupt .gz snapshot (undecodable gzip stream) and falls back to the next clean one', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const backupDir = join(dir, 'db-backups');
+    mkdirSync(backupDir);
+
+    const cleanGz = await seedGzippedSnapshot(
+      join(backupDir, `${basename(dbPath)}.hourly-auto-20260708-090000-000Z`),
+      ['wf-clean-older'],
+    );
+    // Not valid gzip data at all -- decompression itself must fail, and
+    // fileQuickCheckOk must treat that the same as any other bad candidate.
+    writeFileSync(
+      join(backupDir, `${basename(dbPath)}.hourly-auto-20260708-100000-000Z.gz`),
+      Buffer.from('not a gzip stream '.repeat(50)),
+    );
+
+    writeFileSync(dbPath, Buffer.from('xx primary corrupt xx '.repeat(50)));
+
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      expect(adapter.listWorkflows().map((w) => w.id)).toEqual(['wf-clean-older']);
+      expect(adapter.corruptionRecovery?.restoredFromSnapshot).toBe(cleanGz);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('never leaves dbPath partially written when the restore write itself fails after a clean snapshot passed its own check', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const backupDir = join(dir, 'db-backups');
+    mkdirSync(backupDir);
+
+    await seedGzippedSnapshot(
+      join(backupDir, `${basename(dbPath)}.hourly-auto-20260708-090000-000Z`),
+      ['wf-clean'],
+    );
+    writeFileSync(dbPath, Buffer.from('xx primary corrupt xx '.repeat(50)));
+
+    // Pin the staging filename so we can pre-occupy it with a directory,
+    // forcing the restore write (gunzip -> stagingPath) to fail with EISDIR
+    // instead of succeeding -- the same failure shape as a disk-full or
+    // permission error mid-write.
+    const fixedNow = 1_700_000_000_000;
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(fixedNow);
+    const stagingPath = `${dbPath}.restore-staging-${fixedNow}`;
+    mkdirSync(stagingPath);
+
+    try {
+      const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+      try {
+        // Falls back to a fresh empty database -- NOT the snapshot's data,
+        // and NOT the pre-corrupt original -- proving dbPath never ended up
+        // holding a partial write from the failed staging attempt.
+        expect(adapter.listWorkflows()).toEqual([]);
+        expect(adapter.corruptionRecovery?.restoredFromSnapshot).toBeNull();
+      } finally {
+        adapter.close();
+      }
+    } finally {
+      nowSpy.mockRestore();
     }
   });
 

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -9,8 +9,11 @@ import {
   appendFileSync,
   closeSync,
   copyFileSync,
+  createReadStream,
+  createWriteStream,
   existsSync,
   mkdirSync,
+  mkdtempSync,
   openSync,
   readFileSync,
   readSync,
@@ -22,6 +25,8 @@ import {
 } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { createGunzip } from 'node:zlib';
 import type { DatabaseSync, StatementSync } from 'node:sqlite';
 import type {
   TaskState,
@@ -353,14 +358,35 @@ export interface CorruptionRecovery {
 /** Prefix produced by `createHourlySnapshot` in `packages/app/src/delete-all-snapshot.ts`. */
 const HOURLY_SNAPSHOT_LABEL = 'hourly-auto-';
 
+/** Gunzip `gzPath` to `destPath`, streamed so large snapshots never fully buffer in memory. */
+async function gunzipToFile(gzPath: string, destPath: string): Promise<void> {
+  await pipeline(createReadStream(gzPath), createGunzip(), createWriteStream(destPath));
+}
+
 /**
  * Run `PRAGMA quick_check` on the raw file at `dbPath`. Returns `true` iff the
  * check reports a single `'ok'` row. Any open failure, IO error, or non-ok row
  * yields `false` so callers can treat the file as unusable without unwrapping
  * SQLite error taxonomy. The connection is closed before returning so we never
  * leave a `-shm` mapping on a file we're about to copy or ignore.
+ *
+ * `.gz` candidates (see `createDbSnapshot` in `packages/app/src/delete-all-snapshot.ts`)
+ * are decompressed to a temp file first, since SQLite can only open a real
+ * database file, not a gzip stream.
  */
 async function fileQuickCheckOk(dbPath: string): Promise<boolean> {
+  if (dbPath.endsWith('.gz')) {
+    const tempDir = mkdtempSync(join(tmpdir(), 'invoker-snapshot-check-'));
+    try {
+      const tempFile = join(tempDir, 'candidate.db');
+      await gunzipToFile(dbPath, tempFile);
+      return await fileQuickCheckOk(tempFile);
+    } catch {
+      return false;
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
   try {
     const { DatabaseSync } = await loadNativeSqlite();
     const db = new DatabaseSync(dbPath, { readOnly: true });
@@ -879,13 +905,24 @@ export class SQLiteAdapter implements PersistenceAdapter {
       const cleanSnapshot = await findLatestCleanHourlySnapshot(backupDir, basename(dbPath));
       let restoredFromSnapshot: string | null = null;
       if (cleanSnapshot) {
+        // Restore to a staging file first, then rename into place, so a
+        // gunzip/copy failure partway through never leaves dbPath holding a
+        // truncated snapshot -- the code below must see dbPath either fully
+        // restored or still absent (never partially written).
+        const stagingPath = `${dbPath}.restore-staging-${Date.now()}`;
         try {
-          copyFileSync(cleanSnapshot, dbPath);
+          if (cleanSnapshot.endsWith('.gz')) {
+            await gunzipToFile(cleanSnapshot, stagingPath);
+          } else {
+            copyFileSync(cleanSnapshot, stagingPath);
+          }
+          renameSync(stagingPath, dbPath);
           restoredFromSnapshot = cleanSnapshot;
           console.error(
             `[SQLiteAdapter] Auto-restored ${dbPath} from clean snapshot ${cleanSnapshot}.`,
           );
         } catch (copyErr) {
+          if (existsSync(stagingPath)) rmSync(stagingPath, { recursive: true, force: true });
           console.error(
             `[SQLiteAdapter] Failed to restore from ${cleanSnapshot}: ` +
               (copyErr instanceof Error ? copyErr.message : String(copyErr)) +


### PR DESCRIPTION
## Summary

This shrinks the hourly database backups Invoker keeps for itself.

They're now saved zipped instead of as plain copies. On a test database,
that took a 938KB backup down to 34KB — over 96% smaller.

Restoring from a zipped backup still works exactly the same as before, just
with one extra unzip step.

## Review Claim

Gzip every hourly DB snapshot (and the related one-off snapshot taken before
a destructive reset) after it's written, and teach the disaster-recovery
restore path to read both the new zipped format and old plain-copy
snapshots.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This is disaster-recovery code: `SQLiteAdapter.create()` auto-restores from
the newest clean hourly snapshot when it detects the live DB is corrupt on
startup. The write side still uses the exact same WAL-safe backup mechanism
(`SQLiteAdapter.backupTo` or the copy fallback) — only what happens to the
resulting file afterward changed. The read side (`fileQuickCheckOk` and the
actual restore copy) now branches on the `.gz` extension, decompressing to a
temp file for the integrity check and gunzipping directly to the live DB
path on restore; the non-`.gz` branch is untouched. Old uncompressed
snapshots keep working unchanged (no migration, no format flag) — they age
out naturally through the existing retention window.

Verified directly: extended `sqlite-adapter-corruption-recovery.test.ts`
with two new cases mirroring the existing uncompressed ones — restoring from
a `.gz` snapshot, and skipping an undecodable `.gz` snapshot to fall back to
the next clean one. Both pass, and the existing "restores from the newest
clean hourly snapshot" test still passes for the legacy uncompressed format.
Also measured for real: a seeded 400-row test database's raw snapshot was
938KB; the same data zipped came out to 34KB.

## Slice Rationale

Kept as one PR, not separate write-side and read-side PRs: compressing
writes without the read side understanding `.gz` would silently break
disaster recovery the next time it's actually needed. The two halves aren't
independently safe to review or deploy — they're one behavior.

## Non-goals

Does not change retention count, backup frequency, or what data gets
captured — same WAL-safe backup mechanism, same 48-snapshot default. Does
not migrate or compress already-existing uncompressed snapshots; they age
out on their own. Does not add a config flag to disable compression.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`
- [ ] `cd packages/data-store && pnpm test`
- [ ] `cd packages/contracts && pnpm test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — old uncompressed snapshots were never touched,
  and any new `.gz` snapshots written before a revert would simply stop
  being read by the reverted code (they age out via retention regardless).
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database snapshots are now compressed, reducing storage usage while preserving snapshot availability.
  * Snapshot cleanup continues to remove outdated files and retain the appropriate hourly history.
* **Bug Fixes**
  * Improved recovery from corrupted or unreadable snapshots by selecting the newest valid backup.
  * Snapshot validation now checks compressed backups before restoring them.
  * Existing uncompressed snapshots remain supported for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->