### PR TITLE
(2) Flush stdout/stderr before process.exit() in standalone headless exit paths

### DIFF
--- a/packages/app/src/__tests__/headless-stdout-flush.test.ts
+++ b/packages/app/src/__tests__/headless-stdout-flush.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process';
 
 import { describe, expect, it } from 'vitest';
 
-import { writeStdoutFlushAndExit } from '../headless-stdout-flush.js';
+import { flushStdoutAndStderr, writeStdoutFlushAndExit } from '../headless-stdout-flush.js';
 
 const buildPayload = (): string => JSON.stringify(Array.from({ length: 3000 }, (_, i) => ({
   id: `wf-${i}`,
@@ -19,6 +19,19 @@ const payload = JSON.stringify(Array.from({ length: 3000 }, (_, i) => ({
 process.stdout.write(payload, () => { process.exitCode = 0; });
 `;
 
+// Mirrors writeOut()'s raw process.stdout.write() in headless-query-list.ts
+// followed immediately by process.exit() in main.ts's standalone exit path
+// -- the pattern that shipped, before this file's flushStdoutAndStderr fix.
+const buggyScript = `
+const payload = JSON.stringify(Array.from({ length: 3000 }, (_, i) => ({
+  id: 'wf-' + i,
+  description: 'synthetic workflow row ' + i + ' padded-padded-padded-padded-padded-padded-padded-padded',
+  status: 'completed',
+})));
+process.stdout.write(payload);
+process.exit(0);
+`;
+
 describe('headless stdout flush', () => {
   it('preserves large JSON stdout when the child waits for the write callback', () => {
     const payload = buildPayload();
@@ -28,6 +41,54 @@ describe('headless stdout flush', () => {
       const output = execFileSync(process.execPath, ['-e', script], { encoding: 'utf8' });
       expect(output.length).toBe(payload.length);
       expect(() => JSON.parse(output)).not.toThrow();
+    }
+  });
+
+  it('reproduces the live incident: raw write + immediate exit truncates large piped stdout', () => {
+    const payload = buildPayload();
+    expect(payload.length).toBeGreaterThanOrEqual(250 * 1024);
+
+    const output = execFileSync(process.execPath, ['-e', buggyScript], { encoding: 'utf8' });
+    // Truncates at the OS pipe buffer boundary -- deterministic, not flaky.
+    expect(output.length).toBeLessThan(payload.length);
+    expect(() => JSON.parse(output)).toThrow();
+  });
+
+  it('flushStdoutAndStderr resolves only after both streams drain', async () => {
+    const originalStdoutWrite = process.stdout.write;
+    const originalStderrWrite = process.stderr.write;
+    let stdoutCallback: (() => void) | undefined;
+    let stderrCallback: (() => void) | undefined;
+
+    process.stdout.write = ((_: string, callback?: () => void) => {
+      stdoutCallback = callback;
+      return false;
+    }) as typeof process.stdout.write;
+    process.stderr.write = ((_: string, callback?: () => void) => {
+      stderrCallback = callback;
+      return false;
+    }) as typeof process.stderr.write;
+
+    try {
+      let resolved = false;
+      const pending = flushStdoutAndStderr().then(() => { resolved = true; });
+
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+      expect(stdoutCallback).toBeDefined();
+      expect(stderrCallback).toBeDefined();
+
+      stdoutCallback?.();
+      await Promise.resolve();
+      expect(resolved).toBe(false); // stderr hasn't drained yet
+
+      stderrCallback?.();
+      await pending;
+      expect(resolved).toBe(true);
+    } finally {
+      process.stdout.write = originalStdoutWrite;
+      process.stderr.write = originalStderrWrite;
     }
   });
 

--- a/packages/app/src/headless-stdout-flush.ts
+++ b/packages/app/src/headless-stdout-flush.ts
@@ -5,6 +5,21 @@ export async function writeStdoutAndFlush(text: string): Promise<void> {
   });
 }
 
+/**
+ * Wait for any writes already queued on stdout/stderr to actually drain
+ * before the caller exits. Node's streams preserve write order, so an
+ * empty-string write's callback only fires after every write queued ahead
+ * of it has flushed -- this is a barrier, not a new write. Any output piped
+ * into another process truncates silently at the OS pipe buffer size if
+ * process.exit() runs before earlier writes finish flushing.
+ */
+export async function flushStdoutAndStderr(): Promise<void> {
+  await Promise.all([
+    new Promise<void>((resolve) => process.stdout.write('', () => resolve())),
+    new Promise<void>((resolve) => process.stderr.write('', () => resolve())),
+  ]);
+}
+
 export async function writeStdoutFlushAndExit(
   text: string,
   exit: (code: number | string) => void = (code) => process.exit(code),

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -162,7 +162,7 @@ import {
 } from './headless.js';
 import { printHeadlessUsage } from './headless-usage.js';
 import { buildHeadlessApiServerDeps } from './headless-shared.js';
-import { writeStdoutFlushAndExit } from './headless-stdout-flush.js';
+import { writeStdoutFlushAndExit, flushStdoutAndStderr } from './headless-stdout-flush.js';
 import { parseReviewGatePrNumber, repairReviewGateCiByPr } from './review-gate-ci-repair-command.js';
 import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
 import {
@@ -967,6 +967,7 @@ function startHeadlessMode(): void {
         if (delegated) {
           // Successfully delegated to owner
           delegationBus.disconnect();
+          await flushStdoutAndStderr();
           process.exit(process.exitCode ?? 0);
           return; // Guard: process.exit() may not halt in Electron async context
         }
@@ -2013,6 +2014,13 @@ function startHeadlessMode(): void {
       if (!headlessSignalShutdownInProgress) {
         headlessSignalShutdownInProgress = true;
         await runHeadlessShutdownCleanup('Application quit');
+        // The standalone-mode fallback (no owner answered delegation)
+        // writes its result via writeOut() -> raw process.stdout.write(),
+        // unlike the delegated path which already flushes through
+        // writeStdoutFlushAndExit(). A large payload on a piped stdout
+        // truncates silently at the OS pipe buffer size if process.exit()
+        // runs before that write finishes draining.
+        await flushStdoutAndStderr();
         process.exit(exitCode);
       }
     }


### PR DESCRIPTION
Both fatal-error paths already had a synchronous-logging fix; this is the
other half. main.ts's standalone command exit path (query/set/run when no
owner answered delegation) writes its result via a single raw
process.stdout.write() (headless-query-list.ts's writeOut()), then reaches
the shared finally block's process.exit() with no wait for that write to
drain. That's fine for small output; for a large workflow list on a piped
stdout (the case for every headless command a script captures) it truncates
silently at the OS pipe buffer size.

flushStdoutAndStderr() waits for both streams to drain -- an empty-string
write behind the queue, not a new write, so its callback only fires once
everything ahead of it has flushed. Wired into both exit points found to
share this shape: the standalone exit finally block, and the mutating-
command delegated-success exit (lower risk in practice since it streams
small chunks rather than one large blob, fixed for consistency).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Depends-On: #8266