### PR TITLE
[e2e-autofix stdout truncation](4) Fail closed instead of crashing the sweep on a bad query response

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -429,8 +429,30 @@ export function liveQueryHasNonTerminalWork(failureOrSha, jobName, queryFn = hea
   const sha = typeof failureOrSha === 'object' ? failureOrSha.firstBadSha : failureOrSha;
   const job = typeof failureOrSha === 'object' ? failureOrSha.jobName : jobName;
   const marker = buildMarker(sha, job);
-  const workflows = JSON.parse(queryFn());
-  const items = Array.isArray(workflows) ? workflows : workflows.items ?? [];
+  let workflows;
+  try {
+    workflows = JSON.parse(queryFn());
+  } catch (err) {
+    // A bad query response (truncated output, transient CLI failure, ...)
+    // must not crash the whole sweep and must not risk filing a duplicate
+    // fix for work that may already be running -- fail closed by assuming
+    // non-terminal work exists, so this one failure is skipped this round
+    // and picked back up on the next sweep once the query is healthy again.
+    console.error(`ci-regression-watch: liveQueryHasNonTerminalWork query failed for marker "${marker}", assuming non-terminal work exists: ${err instanceof Error ? err.message : String(err)}`);
+    return true;
+  }
+  const items = Array.isArray(workflows)
+    ? workflows
+    : Array.isArray(workflows?.items)
+      ? workflows.items
+      : null;
+  if (items === null) {
+    // Valid JSON that isn't the expected shape (e.g. `null`, a bare object
+    // without an `items` array) -- fail closed the same way a parse error
+    // does, instead of throwing past this function's own try/catch.
+    console.error(`ci-regression-watch: liveQueryHasNonTerminalWork received an invalid response shape for marker "${marker}", assuming non-terminal work exists`);
+    return true;
+  }
   return items.some(
     (w) => !TERMINAL_WORKFLOW_STATUSES.has(w.status)
       && typeof w.description === 'string'

--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -1,0 +1,56 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { liveQueryHasNonTerminalWork, buildMarker } from './e2e-regression-watch.mjs';
+
+describe('liveQueryHasNonTerminalWork', () => {
+  it('detects non-terminal work from a matching marker in valid JSON', () => {
+    const queryFn = () => JSON.stringify([
+      { status: 'running', description: `filed via ${buildMarker('abc1234', 'build')}` },
+    ]);
+    assert.equal(
+      liveQueryHasNonTerminalWork({ firstBadSha: 'abc1234', jobName: 'build' }, undefined, queryFn),
+      true,
+    );
+  });
+
+  it('returns false when no live workflow matches the marker', () => {
+    const queryFn = () => JSON.stringify([
+      { status: 'completed', description: `filed via ${buildMarker('abc1234', 'build')}` },
+    ]);
+    assert.equal(
+      liveQueryHasNonTerminalWork({ firstBadSha: 'abc1234', jobName: 'build' }, undefined, queryFn),
+      false,
+    );
+  });
+
+  it('fails closed (assumes work exists) instead of throwing on truncated query output', () => {
+    // Reproduces the live incident: query workflows --output json truncated
+    // mid-string when the standalone headless exit path didn't wait for a
+    // large stdout write to flush before calling process.exit().
+    const truncated = JSON.stringify([
+      { status: 'running', description: 'a'.repeat(50_000) },
+    ]).slice(0, 30_000);
+    const queryFn = () => truncated;
+
+    assert.doesNotThrow(() => {
+      const result = liveQueryHasNonTerminalWork({ firstBadSha: 'abc1234', jobName: 'build' }, undefined, queryFn);
+      assert.equal(result, true, 'must fail closed, not crash the sweep or risk a duplicate fix PR');
+    });
+  });
+
+  it('fails closed on a query function that throws outright', () => {
+    const queryFn = () => { throw new Error('headless_query timed out after 60s'); };
+    assert.doesNotThrow(() => {
+      const result = liveQueryHasNonTerminalWork({ firstBadSha: 'abc1234', jobName: 'build' }, undefined, queryFn);
+      assert.equal(result, true);
+    });
+  });
+
+  it('fails closed on valid JSON that parses to null instead of an array or {items}', () => {
+    const queryFn = () => 'null';
+    assert.doesNotThrow(() => {
+      const result = liveQueryHasNonTerminalWork({ firstBadSha: 'abc1234', jobName: 'build' }, undefined, queryFn);
+      assert.equal(result, true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`liveQueryHasNonTerminalWork` ran `JSON.parse(queryFn())` with no error handling. A bad response threw straight out of the per-failure loop, aborting the entire sweep.

Every other actionable failure in that batch got skipped too, and nothing from that run got logged or filed.

This was hit live, repeatedly: the stdout-truncation bug fixed in (2)/(3) made every single sweep crash on the same JSON parse error, disabling automatic e2e-fix PR creation entirely.

A parse failure is now caught, logged clearly, and treated as "assume non-terminal work exists" -- the conservative default. That one failure is skipped this round and picked back up next sweep; every other failure in the batch still gets processed normally.

## Review Claim

Approve that a bad query response now fails closed for just the one affected failure check, instead of crashing the whole sweep.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The conservative default (assume work exists, skip filing) can only cause a missed/delayed fix-PR filing for one failure this round, never a duplicate filing and never data loss -- `getActionableFailures` state is unaffected, and the same failure is re-evaluated next sweep.

## Slice Rationale

Separate from (3) because it's a different file (`scripts/`, not `packages/app/src/`) and a different review unit -- the CI validator rejects mixing them in one PR. Lands last because it's the piece that turns "the truncation bug is fixed" into "and a similar future failure can't take the whole sweep down with it."

## Non-goals

Does not change what counts as an actionable failure, how fixes get filed, or the dedup marker format. Does not retry the failed query within the same sweep.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node --test scripts/e2e-regression-watch.test.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
