### PR TITLE
[e2e-autofix stdout truncation](2) Add flushStdoutAndStderr(): wait for stdout/stderr to drain before exit

### DIFF
--- a/packages/app/src/__tests__/headless-stdout-flush.test.ts
+++ b/packages/app/src/__tests__/headless-stdout-flush.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'node:child_process';
 
 import { describe, expect, it } from 'vitest';
 
-import { writeStdoutFlushAndExit } from '../headless-stdout-flush.js';
+import { flushStdoutAndStderr, writeStdoutFlushAndExit } from '../headless-stdout-flush.js';
 
 const buildPayload = (): string => JSON.stringify(Array.from({ length: 3000 }, (_, i) => ({
   id: `wf-${i}`,
@@ -19,6 +19,19 @@ const payload = JSON.stringify(Array.from({ length: 3000 }, (_, i) => ({
 process.stdout.write(payload, () => { process.exitCode = 0; });
 `;
 
+// Mirrors writeOut()'s raw process.stdout.write() in headless-query-list.ts
+// followed immediately by process.exit() in main.ts's standalone exit path
+// -- the pattern that shipped, before this file's flushStdoutAndStderr fix.
+const buggyScript = `
+const payload = JSON.stringify(Array.from({ length: 3000 }, (_, i) => ({
+  id: 'wf-' + i,
+  description: 'synthetic workflow row ' + i + ' padded-padded-padded-padded-padded-padded-padded-padded',
+  status: 'completed',
+})));
+process.stdout.write(payload);
+process.exit(0);
+`;
+
 describe('headless stdout flush', () => {
   it('preserves large JSON stdout when the child waits for the write callback', () => {
     const payload = buildPayload();
@@ -28,6 +41,54 @@ describe('headless stdout flush', () => {
       const output = execFileSync(process.execPath, ['-e', script], { encoding: 'utf8' });
       expect(output.length).toBe(payload.length);
       expect(() => JSON.parse(output)).not.toThrow();
+    }
+  });
+
+  it('reproduces the live incident: raw write + immediate exit truncates large piped stdout', () => {
+    const payload = buildPayload();
+    expect(payload.length).toBeGreaterThanOrEqual(250 * 1024);
+
+    const output = execFileSync(process.execPath, ['-e', buggyScript], { encoding: 'utf8' });
+    // Truncates at the OS pipe buffer boundary -- deterministic, not flaky.
+    expect(output.length).toBeLessThan(payload.length);
+    expect(() => JSON.parse(output)).toThrow();
+  });
+
+  it('flushStdoutAndStderr resolves only after both streams drain', async () => {
+    const originalStdoutWrite = process.stdout.write;
+    const originalStderrWrite = process.stderr.write;
+    let stdoutCallback: (() => void) | undefined;
+    let stderrCallback: (() => void) | undefined;
+
+    process.stdout.write = ((_: string, callback?: () => void) => {
+      stdoutCallback = callback;
+      return false;
+    }) as typeof process.stdout.write;
+    process.stderr.write = ((_: string, callback?: () => void) => {
+      stderrCallback = callback;
+      return false;
+    }) as typeof process.stderr.write;
+
+    try {
+      let resolved = false;
+      const pending = flushStdoutAndStderr().then(() => { resolved = true; });
+
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+      expect(stdoutCallback).toBeDefined();
+      expect(stderrCallback).toBeDefined();
+
+      stdoutCallback?.();
+      await Promise.resolve();
+      expect(resolved).toBe(false); // stderr hasn't drained yet
+
+      stderrCallback?.();
+      await pending;
+      expect(resolved).toBe(true);
+    } finally {
+      process.stdout.write = originalStdoutWrite;
+      process.stderr.write = originalStderrWrite;
     }
   });
 

--- a/packages/app/src/headless-stdout-flush.ts
+++ b/packages/app/src/headless-stdout-flush.ts
@@ -5,6 +5,21 @@ export async function writeStdoutAndFlush(text: string): Promise<void> {
   });
 }
 
+/**
+ * Wait for any writes already queued on stdout/stderr to actually drain
+ * before the caller exits. Node's streams preserve write order, so an
+ * empty-string write's callback only fires after every write queued ahead
+ * of it has flushed -- this is a barrier, not a new write. Any output piped
+ * into another process truncates silently at the OS pipe buffer size if
+ * process.exit() runs before earlier writes finish flushing.
+ */
+export async function flushStdoutAndStderr(): Promise<void> {
+  await Promise.all([
+    new Promise<void>((resolve) => process.stdout.write('', () => resolve())),
+    new Promise<void>((resolve) => process.stderr.write('', () => resolve())),
+  ]);
+}
+
 export async function writeStdoutFlushAndExit(
   text: string,
   exit: (code: number | string) => void = (code) => process.exit(code),

--- a/scripts/repro/repro-headless-query-stdout-truncation.mjs
+++ b/scripts/repro/repro-headless-query-stdout-truncation.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Repro for a live incident: `headless_query query workflows --output json`
+ * (used by scripts/e2e-regression-watch.mjs's liveQueryHasNonTerminalWork)
+ * returned truncated JSON on a large workflow set, crashing every sweep with
+ * "Unterminated string in JSON at position N" and silently disabling
+ * automatic e2e-fix PR creation.
+ *
+ * Root cause: main.ts's standalone headless command exit path wrote query
+ * output via a single raw `process.stdout.write()` (headless-query-list.ts's
+ * writeOut()), then called `process.exit()` without waiting for that write
+ * to drain. When the caller captures stdout via a pipe (execSync, exactly
+ * how e2e-regression-watch.mjs invokes it) and the payload is large, Node
+ * buffers the write and drains it asynchronously -- if the process exits
+ * first, the pipe closes mid-write and the reader gets a truncated string,
+ * cut off wherever the buffer happened to be. The delegated-query path
+ * already avoided this (writeStdoutFlushAndExit awaits the write callback);
+ * the standalone/fallback path -- taken whenever there's no live owner to
+ * delegate to -- did not.
+ *
+ * Fix: packages/app/src/headless-stdout-flush.ts's flushStdoutAndStderr(),
+ * wired into main.ts's shared standalone exit `finally` block. This repro
+ * demonstrates the underlying mechanism directly (no Electron/DB needed):
+ * a large JSON payload, written the old way (write + immediate exit) vs.
+ * the fixed way (write, wait for the callback, then exit), captured via
+ * execSync exactly like the real caller does.
+ *
+ * Exit 0 = the buggy pattern truncates (as expected) AND the fixed pattern
+ *          does not -- i.e. the fix in headless-stdout-flush.ts genuinely
+ *          prevents this class of truncation.
+ * Exit 1 = either pattern behaved unexpectedly (repro itself is broken, or
+ *          the fix regressed).
+ */
+import { execFileSync } from 'node:child_process';
+
+const ROWS = Number(process.env.REPRO_ROWS ?? '30000');
+
+function buildPayload() {
+  const rows = [];
+  for (let i = 0; i < ROWS; i += 1) {
+    rows.push({
+      id: `wf-repro-${i}`,
+      name: `repro-workflow-${i}-with-a-reasonably-long-descriptive-name-for-realism`,
+      status: 'completed',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+  }
+  return JSON.stringify(rows) + '\n';
+}
+
+const buggyScript = `
+const rows = [];
+for (let i = 0; i < ${ROWS}; i += 1) {
+  rows.push({
+    id: 'wf-repro-' + i,
+    name: 'repro-workflow-' + i + '-with-a-reasonably-long-descriptive-name-for-realism',
+    status: 'completed',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  });
+}
+const json = JSON.stringify(rows) + '\\n';
+process.stdout.write(json);
+process.exit(0);
+`;
+
+const fixedScript = `
+const rows = [];
+for (let i = 0; i < ${ROWS}; i += 1) {
+  rows.push({
+    id: 'wf-repro-' + i,
+    name: 'repro-workflow-' + i + '-with-a-reasonably-long-descriptive-name-for-realism',
+    status: 'completed',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  });
+}
+const json = JSON.stringify(rows) + '\\n';
+process.stdout.write(json, () => {
+  process.exit(0);
+});
+`;
+
+function run(label, script, expectTruncation) {
+  const expected = buildPayload();
+  const out = execFileSync(process.execPath, ['-e', script], {
+    encoding: 'utf8',
+    maxBuffer: 200 * 1024 * 1024,
+  });
+
+  let parseError;
+  try {
+    JSON.parse(out);
+  } catch (err) {
+    parseError = err;
+  }
+
+  const truncated = out.length !== expected.length || Boolean(parseError);
+  console.log(`[${label}] expected bytes=${expected.length} captured bytes=${out.length} truncated=${truncated}${parseError ? ` (${parseError.message})` : ''}`);
+
+  if (truncated !== expectTruncation) {
+    console.error(`[${label}] UNEXPECTED: expected truncated=${expectTruncation}, got truncated=${truncated}`);
+    return false;
+  }
+  return true;
+}
+
+let ok = true;
+ok = run('buggy (write + immediate exit)', buggyScript, true) && ok;
+ok = run('fixed (write, wait for callback, then exit)', fixedScript, false) && ok;
+
+if (!ok) {
+  console.error('\nrepro-headless-query-stdout-truncation: FAILED');
+  process.exit(1);
+}
+console.log('\nrepro-headless-query-stdout-truncation: PASSED (bug mechanism confirmed, fix confirmed to prevent it)');


### PR DESCRIPTION
## Summary

An empty-string write queued behind existing ones on both stdout and stderr. Node preserves write order, so its callback only fires once every write ahead of it has finished -- a barrier, not a new write.

Any output piped into another process, the case for every invocation whose result a script captures, truncates silently at the OS pipe buffer size if the process exits before earlier writes finish flushing.

This adds the primitive only. Nothing calls it yet -- the next PR wires it into the exit paths that need it.

## Review Claim

Approve the new `flushStdoutAndStderr()` function on its own: it waits for both streams to actually finish writing before resolving.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

New export, not called from anywhere yet in this PR. Zero behavior change on its own -- the following PR is what actually changes an exit path.

## Slice Rationale

A separate PR from the exit-path change so each PR has one file matching one required review unit -- this file's path always classifies on its own, apart from `main.ts`. Lands after (1) so the reviewer already has the mechanism confirmed.

## Non-goals

Does not call this function from anywhere. Does not change any exit behavior by itself.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm run check:types`
- [ ] `cd packages/app && pnpm test -- src/__tests__/headless-stdout-flush.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
