### PR TITLE
[Bugfix: Extract owner-capability write gate into named guard](1)[REFACTOR: Extract Function] Move the check into assertOwnerCapabilityForWritableOpen

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, statSync, existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { SQLiteAdapter, isLaunchDispatchCandidateStale, runWithFreedStatement } from '../sqlite-adapter.js';
+import { SQLiteAdapter, isLaunchDispatchCandidateStale, runWithFreedStatement, assertOwnerCapabilityForWritableOpen } from '../sqlite-adapter.js';
 import type { Workflow, Conversation, WorkerActionWrite, TerminalSessionRecord, InAppPlanningSessionRecord } from '../adapter.js';
 import { createAttempt, assertWorkflowConsistent, assertWorkflowPatchConsistent } from '@invoker/workflow-core';
 import type { Attempt, TaskState, TaskStateChanges } from '@invoker/workflow-core';
@@ -6192,6 +6192,29 @@ describe('SQLiteAdapter', () => {
       } finally {
         handle.restore();
       }
+    });
+  });
+
+  describe('assertOwnerCapabilityForWritableOpen', () => {
+    it('throws when a writable open of a file-backed database lacks ownerCapability', () => {
+      expect(() => assertOwnerCapabilityForWritableOpen(true, true, undefined)).toThrow(
+        'Writable persistence initialization requires owner capability.',
+      );
+      expect(() => assertOwnerCapabilityForWritableOpen(true, true, false)).toThrow(
+        'Writable persistence initialization requires owner capability.',
+      );
+    });
+
+    it('does not throw when ownerCapability is granted for a writable file-backed open', () => {
+      expect(() => assertOwnerCapabilityForWritableOpen(true, true, true)).not.toThrow();
+    });
+
+    it('does not throw for a read-only request regardless of ownerCapability', () => {
+      expect(() => assertOwnerCapabilityForWritableOpen(true, false, undefined)).not.toThrow();
+    });
+
+    it('does not throw for a non-file-backed (ephemeral) database regardless of ownerCapability', () => {
+      expect(() => assertOwnerCapabilityForWritableOpen(false, true, undefined)).not.toThrow();
     });
   });
 });

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -342,6 +342,25 @@ export function isCorruptionRecoveryEligible(
 }
 
 /**
+ * Enforces owner-only writable initialization for file-backed databases:
+ * a writable open of a file-backed database must carry ownerCapability, or
+ * it throws so non-owner processes are forced to delegate mutations via IPC.
+ */
+export function assertOwnerCapabilityForWritableOpen(
+  isFile: boolean,
+  requestWritable: boolean,
+  ownerCapability: boolean | undefined,
+): void {
+  if (isFile && requestWritable && !ownerCapability) {
+    throw new Error(
+      'Writable persistence initialization requires owner capability. ' +
+      'Non-owner processes must delegate mutations via IPC (headless.run, headless.resume, headless.exec) ' +
+      'or open the database in read-only mode.',
+    );
+  }
+}
+
+/**
  * Metadata attached to an adapter that opened via the corruption-recovery
  * branch of {@link SQLiteAdapter.create}. `restoredFromSnapshot` is the source
  * of the recovered data when auto-restore succeeded, or `null` when no clean
@@ -873,13 +892,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     }
 
     // Enforce owner-only writable initialization for file-backed databases
-    if (isFile && requestWritable && !options?.ownerCapability) {
-      throw new Error(
-        'Writable persistence initialization requires owner capability. ' +
-        'Non-owner processes must delegate mutations via IPC (headless.run, headless.resume, headless.exec) ' +
-        'or open the database in read-only mode.',
-      );
-    }
+    assertOwnerCapabilityForWritableOpen(isFile, requestWritable, options?.ownerCapability);
 
     if (isFile) {
       mkdirSync(dirname(dbPath), { recursive: true });


### PR DESCRIPTION
## Summary

Only the owning process may open a database file for writing. Every other process gets a read-only connection or a temporary placeholder. That rule already existed and is unchanged.

This change only moves the existing check into its own named function, `assertOwnerCapabilityForWritableOpen`, inside `packages/data-store/src/sqlite-adapter.ts`. It runs at the same point, on the same condition, with the same error message.

Putting it in a named function makes it possible to test the rule on its own, without building a real database first.

## Review Claim

Approve moving the existing owner-capability check out of `SQLiteAdapter.create()` and into a named, exported function (`assertOwnerCapabilityForWritableOpen`), called from the same place with the exact same behavior, plus new tests that call the function directly.

## Review Lane

refactor

## Review Unit

ownership-refactor

## Safety Invariant

`SQLiteAdapter.create()` still throws the exact same error message, under the exact same condition (`isFile && requestWritable && !ownerCapability`), at the exact same point in the function. Only the condition now lives inside a named function instead of an inline `if` block.

## Slice Rationale

One slice: move the check into a named function and add tests that exercise it directly. Nothing else changes.

## Non-goals

No behavior change: the calling code in `packages/app/src/viewer-db-boundary.ts` is untouched, and the nearby exclusiveLocking and owner-pid checks next to this one are untouched. Only the inline check becomes a named function; the condition, error message, and throw point stay the same as before.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/data-store && pnpm test -- -t "assertOwnerCapabilityForWritableOpen"`
- [ ] `cd packages/app && pnpm test -- -t "rejects detached viewer writes when the real database exists"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
