### PR TITLE
[Entity research patterns](2) Route research plans to entity-research-patterns.md

### DIFF
--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -239,7 +239,8 @@ When those hardening workflows target Invoker itself, the branch/PR publication 
 
 - File/function-heavy plans: see playbook `playbooks/verify-then-build.md`
 - Schema and required fields: `references/schema.md`
-- Task decomposition and dependency patterns: `references/task-patterns.md`
+- Task decomposition and dependency patterns (code-change plans): `references/task-patterns.md`
+- Structured entity research plans (any plan whose deliverable is a fact about a real-world entity — a stock's filing quirk, a legal case's status, a product spec — not a code change): `references/entity-research-patterns.md`. Do not use `task-patterns.md`'s handoff/task-split conventions for these; use this file instead.
 - Review compression: `../review-compression/SKILL.md`
 - End-to-end examples: `references/examples.md`
 - Efficacy / soft scoring: `references/efficacy-rubric.md`

--- a/skills/plan-to-invoker/fixtures/positive/10-entity-research-write-commit-verify.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/10-entity-research-write-commit-verify.yaml
@@ -1,0 +1,98 @@
+# Positive fixture: Entity research write-and-commit-in-one-task, with independent verify
+# Source: entity-research-patterns.md Rule 1/2 — formulas/entity-research/
+# Pattern: gate-check -> research-write-and-commit -> independent HEAD re-check (no separate downstream commit task)
+
+name: "Entity research: CPB"
+description: |
+  Research CPB (S&P 500 index-removal candidate (stock ticker)) for the most recent 10-K inventory accounting method (FIFO vs LIFO) and any other choice that understates book value and
+  commit the resulting record. The write task commits its own output in the
+  same task — no separate downstream commit task exists in this shape.
+
+  REPLACE_ME: 1-3 sentences on why this entity/batch matters and what the
+  record will be used for.
+onFinish: pull_request
+mergeMode: external_review
+baseBranch: master
+repoUrl: git@github.com:EdbertChan/hidden.git
+
+tasks:
+  - id: gate-check-cpb
+    description: |
+      Deterministic eligibility check before spending research effort on CPB.
+      Review claim: CPB either passes or fails eligibility with a machine-checkable command; no research happens if it fails. REPLACE_ME with the real gate condition.
+      Review lane: docs
+      Safety invariant: This task never writes or modifies the record itself; only a pass/fail signal.
+      Slice rationale: One deterministic gate slice, separate from the research/write slice that follows it.
+      Architectural effect: None; produces no product code, only a gating signal for its own workflow.
+      Goal: Fail fast, before research, if CPB does not qualify.
+      Motivation: Cheap gating avoids wasted research effort on ineligible entities. REPLACE_ME if this batch has a real eligibility list.
+      Alternative considerations: Skipping the gate and letting research fail was rejected — it wastes the expensive step instead of the cheap one.
+      Implementation details: Run `true`; exit non-zero if CPB is ineligible. REPLACE_ME with the concrete check.
+      Non-goals: No research, no record write, no commit of the record file here.
+      Layer: docs
+      Feature state: active
+      Acceptance criteria:
+      - `true` exits 0.
+    command: "true"
+    dependencies: []
+
+  - id: research-write-cpb
+    description: |
+      Research the most recent 10-K inventory accounting method (FIFO vs LIFO) and any other choice that understates book value for CPB and write AND commit
+      the record in this same task. Do not defer the commit to a later task
+      — there must be no task after this one that touches data/stocks/CPB.json.
+      Review claim: data/stocks/CPB.json matches the fixed record envelope and every claim traces to a committed source excerpt. REPLACE_ME with the precise research claim.
+      Review lane: docs
+      Safety invariant: Every claims[] entry has a non-empty source_excerpt and source_url backed by a file under sources/CPB/; no claim is asserted without a primary-source citation.
+      Slice rationale: One research slice: write the record and commit it, nothing else.
+      Architectural effect: None; adds one data file and its source citations, no code.
+      Goal: Produce a committed, schema-valid, source-cited record for CPB.
+      Motivation: the most recent 10-K inventory accounting method (FIFO vs LIFO) and any other choice that understates book value REPLACE_ME with why this fact matters for CPB.
+      Alternative considerations: A separate downstream commit task was rejected — that split is the exact shape that silently dropped ticker CPB's record in wf-1786134278894-20 (task-runner-prepare.ts's dependency guard only checks .branch, not .commit).
+      Implementation details: Research the most recent 10-K inventory accounting method (FIFO vs LIFO) and any other choice that understates book value; write data/stocks/CPB.json matching the schema below; commit both data/stocks/CPB.json and sources/CPB/*.md yourself, in this task.
+      Non-goals: No aggregation across entities, no schema changes beyond method (enum: fifo|lifo|weighted_average|other), understatement_flag (bool), no edits outside data/stocks/CPB.json and sources/CPB/.
+      Layer: docs
+      Feature state: active
+      Files:
+      - data/stocks/CPB.json
+      - sources/CPB/*.md
+      Change types:
+      - data/stocks/CPB.json: create
+      - sources/CPB/*.md: create
+      Acceptance criteria:
+      - data/stocks/CPB.json exists, is valid JSON, and has at minimum entity_id (string), as_of (ISO date), and claims[] where each entry has value, source_excerpt, and source_url.
+      - method (enum: fifo|lifo|weighted_average|other), understatement_flag (bool) are present and correctly typed.
+      - The commit for this task includes data/stocks/CPB.json — verify with `git show --stat HEAD | grep data/stocks/CPB.json`.
+    prompt: |
+      Goal: Research the most recent 10-K inventory accounting method (FIFO vs LIFO) and any other choice that understates book value for CPB and commit a schema-valid, source-cited record.
+      Review lane: docs
+      Motivation: the most recent 10-K inventory accounting method (FIFO vs LIFO) and any other choice that understates book value REPLACE_ME with why this fact matters for CPB.
+      Alternative considerations: Do not defer the commit to a later task; there is none in this shape.
+      Implementation details: Write data/stocks/CPB.json with entity_id, as_of, claims[] (each with value, source_excerpt, source_url), plus method (enum: fifo|lifo|weighted_average|other), understatement_flag (bool). Save verbatim source excerpts under sources/CPB/. Commit data/stocks/CPB.json and sources/CPB/*.md yourself as part of this task — there is no later task that will commit this for you.
+      Non-goals: No aggregation, no schema invention beyond method (enum: fifo|lifo|weighted_average|other), understatement_flag (bool).
+      Assume no prior context. You are given only this task.
+      Acceptance criteria:
+      - data/stocks/CPB.json exists, is valid JSON, matches the schema above.
+      - `git show --stat HEAD | grep data/stocks/CPB.json` succeeds (this is the pass condition).
+    dependencies: [gate-check-cpb]
+
+  - id: verify-record-cpb
+    description: |
+      Read-only re-check that the committed record actually exists on HEAD
+      and parses, independent of what research-write-cpb claimed.
+      Review claim: `git show HEAD:data/stocks/CPB.json` succeeds and is valid JSON, checked independently of the write task's self-report.
+      Review lane: proof
+      Safety invariant: This task makes no writes; it only reads HEAD.
+      Slice rationale: One proof slice: independent verification only.
+      Architectural effect: None; adds no product behavior.
+      Goal: Catch the case where research-write-cpb reported success but data/stocks/CPB.json is absent from HEAD.
+      Motivation: This is the check that would have caught wf-1786134278894-20's CPB failure — self-reported success is not proof the file landed.
+      Alternative considerations: Trusting the write task's own acceptance criteria was rejected as non-independent.
+      Implementation details: Read data/stocks/CPB.json from HEAD and parse it; fail non-zero if missing or malformed.
+      Non-goals: No product edits, no aggregation; verification only.
+      Layer: docs
+      Feature state: active
+      Acceptance criteria:
+      - `git show HEAD:data/stocks/CPB.json | python3 -m json.tool` exits 0.
+    command: "git show HEAD:data/stocks/CPB.json | python3 -m json.tool"
+    dependencies: [research-write-cpb]

--- a/skills/plan-to-invoker/fixtures/positive/11-entity-research-aggregate-fan-in.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/11-entity-research-aggregate-fan-in.yaml
@@ -1,0 +1,54 @@
+# Positive fixture: Post-merge aggregate table, fan-in on multiple upstream entity-research workflows
+# Source: entity-research-patterns.md Rule 3 — formulas/entity-research-aggregate/
+# Pattern: externalDependencies fan-in on N upstream __merge__ tasks, reads only the shared base branch
+
+name: "Aggregate the stock quirk-check table"
+description: |
+  Regenerate SUMMARY.md from every already-merged record
+  matching data/stocks/*.json on main. Never reads an in-flight
+  entity-research branch. Gated on every upstream entity-research
+  workflow's __merge__ task via externalDependencies below — duplicate the
+  externalDependencies block once per additional upstream workflow before
+  submit; 2 entries are shown as the minimal example.
+
+  REPLACE_ME: list which entity workflows this batch actually gates on.
+onFinish: pull_request
+mergeMode: external_review
+baseBranch: main
+repoUrl: git@github.com:EdbertChan/hidden.git
+externalDependencies:
+  - workflowId: "wf-1786134278894-01"
+    taskId: "__merge__"
+    requiredStatus: completed
+    gatePolicy: review_ready
+  - workflowId: "wf-1786134278894-02"
+    taskId: "__merge__"
+    requiredStatus: completed
+    gatePolicy: review_ready
+
+tasks:
+  - id: build-stock-quirk-check-table
+    description: |
+      Read every data/stocks/*.json file on main (post-merge, never
+      an in-flight entity branch) and regenerate SUMMARY.md.
+      Review claim: SUMMARY.md's row count matches the count of files matching data/stocks/*.json exactly, or the task fails.
+      Review lane: docs
+      Safety invariant: Reads only main; never reads or merges any upstream entity-research feature branch directly.
+      Slice rationale: One deterministic transform slice: read staged records, write the mart table, nothing else.
+      Architectural effect: None; adds no product code, only a generated table.
+      Goal: Produce a single reviewable table across all landed records, with a loud failure on any gap.
+      Motivation: Building the table per-entity or pre-merge makes correctness depend on N branch-chaining operations all succeeding at once, with no single point that checks "did every one of these actually land" — the exact blind spot that made wf-1786134278894-20's CPB drop invisible.
+      Alternative considerations: Assembling the table inside a per-entity workflow, or before merge, was rejected for the reason above.
+      Implementation details: Run `python3 scripts/build-summary-table.py`, which globs data/stocks/*.json and rewrites SUMMARY.md.
+      Non-goals: No new records, no edits to any file matching data/stocks/*.json; read-only transform except for SUMMARY.md.
+      Layer: docs
+      Feature state: active
+      Files:
+      - SUMMARY.md
+      Change types:
+      - SUMMARY.md: modify
+      Acceptance criteria:
+      - SUMMARY.md has one row per file matching data/stocks/*.json present on main.
+      - Row count matches file count exactly; the task fails loudly rather than silently skipping a missing or malformed record.
+    command: "python3 scripts/build-summary-table.py"
+    dependencies: []

--- a/skills/plan-to-invoker/formulas/entity-research-aggregate/entity-research-aggregate.workflow.yaml
+++ b/skills/plan-to-invoker/formulas/entity-research-aggregate/entity-research-aggregate.workflow.yaml
@@ -1,0 +1,50 @@
+name: "Aggregate {{aggregate_summary}}"
+description: |
+  Regenerate {{aggregate_output_path}} from every already-merged record
+  matching {{record_glob}} on {{base_branch}}. Never reads an in-flight
+  entity-research branch. Gated on every upstream entity-research
+  workflow's __merge__ task via externalDependencies below — duplicate the
+  externalDependencies block once per additional upstream workflow before
+  submit; 2 entries are shown as the minimal example.
+
+  REPLACE_ME: list which entity workflows this batch actually gates on.
+onFinish: pull_request
+mergeMode: external_review
+baseBranch: {{base_branch}}
+repoUrl: {{repo_url}}
+externalDependencies:
+  - workflowId: "{{upstream_workflow_id_a}}"
+    taskId: "__merge__"
+    requiredStatus: completed
+    gatePolicy: review_ready
+  - workflowId: "{{upstream_workflow_id_b}}"
+    taskId: "__merge__"
+    requiredStatus: completed
+    gatePolicy: review_ready
+
+tasks:
+  - id: build-{{aggregate_slug}}-table
+    description: |
+      Read every {{record_glob}} file on {{base_branch}} (post-merge, never
+      an in-flight entity branch) and regenerate {{aggregate_output_path}}.
+      Review claim: {{aggregate_output_path}}'s row count matches the count of files matching {{record_glob}} exactly, or the task fails.
+      Review lane: docs
+      Safety invariant: Reads only {{base_branch}}; never reads or merges any upstream entity-research feature branch directly.
+      Slice rationale: One deterministic transform slice: read staged records, write the mart table, nothing else.
+      Architectural effect: None; adds no product code, only a generated table.
+      Goal: Produce a single reviewable table across all landed records, with a loud failure on any gap.
+      Motivation: Building the table per-entity or pre-merge makes correctness depend on N branch-chaining operations all succeeding at once, with no single point that checks "did every one of these actually land" — the exact blind spot that made wf-1786134278894-20's CPB drop invisible.
+      Alternative considerations: Assembling the table inside a per-entity workflow, or before merge, was rejected for the reason above.
+      Implementation details: Run `{{aggregate_build_command}}`, which globs {{record_glob}} and rewrites {{aggregate_output_path}}.
+      Non-goals: No new records, no edits to any file matching {{record_glob}}; read-only transform except for {{aggregate_output_path}}.
+      Layer: docs
+      Feature state: active
+      Files:
+      - {{aggregate_output_path}}
+      Change types:
+      - {{aggregate_output_path}}: modify
+      Acceptance criteria:
+      - {{aggregate_output_path}} has one row per file matching {{record_glob}} present on {{base_branch}}.
+      - Row count matches file count exactly; the task fails loudly rather than silently skipping a missing or malformed record.
+    command: "{{aggregate_build_command}}"
+    dependencies: []

--- a/skills/plan-to-invoker/formulas/entity-research-aggregate/formula.yaml
+++ b/skills/plan-to-invoker/formulas/entity-research-aggregate/formula.yaml
@@ -1,0 +1,55 @@
+formula: entity-research-aggregate
+version: 1
+description: >
+  Build the aggregate table across many already-merged entity-research
+  records as its own small, independently reviewable PR — never inside a
+  per-entity workflow. Gated on every upstream entity-research workflow's
+  __merge__ task via plan-level externalDependencies (gatePolicy:
+  review_ready), reading only the shared base branch, never any in-flight
+  branch. Ships with 2 example externalDependencies entries; duplicate the
+  block once per upstream entity workflow before submit.
+vars:
+  repo_url:
+    required: true
+    example: "git@github.com:EdbertChan/hidden.git"
+    description: "Git remote for the repo where the aggregate table is committed."
+  base_branch:
+    required: true
+    example: "main"
+    description: >
+      Base branch to pull records from (the shared trunk, never an upstream
+      feature branch). Must not be the literal string "master" — validate-plan.mjs's
+      stacked_basebranch_default check hard-fails any plan with concrete
+      externalDependencies whose baseBranch resolves to "master". See
+      references/entity-research-patterns.md's "known limitation" note. This
+      is not a stylistic choice.
+  aggregate_slug:
+    required: true
+    example: "stock-quirk-check"
+    description: "Kebab-case identifier used in task ids and the plan name."
+  aggregate_summary:
+    required: true
+    example: "the stock quirk-check table"
+    description: "One-line description of what's being aggregated."
+  record_glob:
+    required: true
+    example: "data/stocks/*.json"
+    description: "Glob of already-merged per-entity records to read (on base_branch only)."
+  aggregate_output_path:
+    required: true
+    example: "SUMMARY.md"
+    description: "Single output file the aggregate table is written to."
+  aggregate_build_command:
+    required: true
+    example: "python3 scripts/build-summary-table.py"
+    description: "Deterministic command that globs record_glob and regenerates aggregate_output_path; must fail loudly on a row-count mismatch."
+  upstream_workflow_id_a:
+    required: true
+    example: "wf-1786134278894-01"
+    description: "First upstream entity-research workflow id to gate on (__merge__ task)."
+  upstream_workflow_id_b:
+    required: true
+    example: "wf-1786134278894-02"
+    description: "Second upstream entity-research workflow id to gate on (__merge__ task); duplicate this var/block per additional upstream workflow."
+workflows:
+  - entity-research-aggregate.workflow.yaml

--- a/skills/plan-to-invoker/formulas/entity-research/entity-research.workflow.yaml
+++ b/skills/plan-to-invoker/formulas/entity-research/entity-research.workflow.yaml
@@ -1,0 +1,94 @@
+name: "Entity research: {{entity_id}}"
+description: |
+  Research {{entity_id}} ({{entity_kind}}) for {{research_question}} and
+  commit the resulting record. The write task commits its own output in the
+  same task — no separate downstream commit task exists in this shape.
+
+  REPLACE_ME: 1-3 sentences on why this entity/batch matters and what the
+  record will be used for.
+onFinish: pull_request
+mergeMode: external_review
+baseBranch: {{base_branch}}
+repoUrl: {{repo_url}}
+
+tasks:
+  - id: gate-check-{{entity_slug}}
+    description: |
+      Deterministic eligibility check before spending research effort on {{entity_id}}.
+      Review claim: {{entity_id}} either passes or fails eligibility with a machine-checkable command; no research happens if it fails. REPLACE_ME with the real gate condition.
+      Review lane: docs
+      Safety invariant: This task never writes or modifies the record itself; only a pass/fail signal.
+      Slice rationale: One deterministic gate slice, separate from the research/write slice that follows it.
+      Architectural effect: None; produces no product code, only a gating signal for its own workflow.
+      Goal: Fail fast, before research, if {{entity_id}} does not qualify.
+      Motivation: Cheap gating avoids wasted research effort on ineligible entities. REPLACE_ME if this batch has a real eligibility list.
+      Alternative considerations: Skipping the gate and letting research fail was rejected — it wastes the expensive step instead of the cheap one.
+      Implementation details: Run `{{gate_check_command}}`; exit non-zero if {{entity_id}} is ineligible. REPLACE_ME with the concrete check.
+      Non-goals: No research, no record write, no commit of the record file here.
+      Layer: docs
+      Feature state: active
+      Acceptance criteria:
+      - `{{gate_check_command}}` exits 0.
+    command: "{{gate_check_command}}"
+    dependencies: []
+
+  - id: research-write-{{entity_slug}}
+    description: |
+      Research {{research_question}} for {{entity_id}} and write AND commit
+      the record in this same task. Do not defer the commit to a later task
+      — there must be no task after this one that touches {{record_path}}.
+      Review claim: {{record_path}} matches the fixed record envelope and every claim traces to a committed source excerpt. REPLACE_ME with the precise research claim.
+      Review lane: docs
+      Safety invariant: Every claims[] entry has a non-empty source_excerpt and source_url backed by a file under {{source_dir}}/; no claim is asserted without a primary-source citation.
+      Slice rationale: One research slice: write the record and commit it, nothing else.
+      Architectural effect: None; adds one data file and its source citations, no code.
+      Goal: Produce a committed, schema-valid, source-cited record for {{entity_id}}.
+      Motivation: {{research_question}} REPLACE_ME with why this fact matters for {{entity_id}}.
+      Alternative considerations: A separate downstream commit task was rejected — that split is the exact shape that silently dropped ticker CPB's record in wf-1786134278894-20 (task-runner-prepare.ts's dependency guard only checks .branch, not .commit).
+      Implementation details: Research {{research_question}}; write {{record_path}} matching the schema below; commit both {{record_path}} and {{source_dir}}/*.md yourself, in this task.
+      Non-goals: No aggregation across entities, no schema changes beyond {{record_schema_fields}}, no edits outside {{record_path}} and {{source_dir}}/.
+      Layer: docs
+      Feature state: active
+      Files:
+      - {{record_path}}
+      - {{source_dir}}/*.md
+      Change types:
+      - {{record_path}}: create
+      - {{source_dir}}/*.md: create
+      Acceptance criteria:
+      - {{record_path}} exists, is valid JSON, and has at minimum entity_id (string), as_of (ISO date), and claims[] where each entry has value, source_excerpt, and source_url.
+      - {{record_schema_fields}} are present and correctly typed.
+      - The commit for this task includes {{record_path}} — verify with `git show --stat HEAD | grep {{record_path}}`.
+    prompt: |
+      Goal: Research {{research_question}} for {{entity_id}} and commit a schema-valid, source-cited record.
+      Review lane: docs
+      Motivation: {{research_question}} REPLACE_ME with why this fact matters for {{entity_id}}.
+      Alternative considerations: Do not defer the commit to a later task; there is none in this shape.
+      Implementation details: Write {{record_path}} with entity_id, as_of, claims[] (each with value, source_excerpt, source_url), plus {{record_schema_fields}}. Save verbatim source excerpts under {{source_dir}}/. Commit {{record_path}} and {{source_dir}}/*.md yourself as part of this task — there is no later task that will commit this for you.
+      Non-goals: No aggregation, no schema invention beyond {{record_schema_fields}}.
+      Assume no prior context. You are given only this task.
+      Acceptance criteria:
+      - {{record_path}} exists, is valid JSON, matches the schema above.
+      - `git show --stat HEAD | grep {{record_path}}` succeeds (this is the pass condition).
+    dependencies: [gate-check-{{entity_slug}}]
+
+  - id: verify-record-{{entity_slug}}
+    description: |
+      Read-only re-check that the committed record actually exists on HEAD
+      and parses, independent of what research-write-{{entity_slug}} claimed.
+      Review claim: `git show HEAD:{{record_path}}` succeeds and is valid JSON, checked independently of the write task's self-report.
+      Review lane: proof
+      Safety invariant: This task makes no writes; it only reads HEAD.
+      Slice rationale: One proof slice: independent verification only.
+      Architectural effect: None; adds no product behavior.
+      Goal: Catch the case where research-write-{{entity_slug}} reported success but {{record_path}} is absent from HEAD.
+      Motivation: This is the check that would have caught wf-1786134278894-20's CPB failure — self-reported success is not proof the file landed.
+      Alternative considerations: Trusting the write task's own acceptance criteria was rejected as non-independent.
+      Implementation details: Read {{record_path}} from HEAD and parse it; fail non-zero if missing or malformed.
+      Non-goals: No product edits, no aggregation; verification only.
+      Layer: docs
+      Feature state: active
+      Acceptance criteria:
+      - `git show HEAD:{{record_path}} | python3 -m json.tool` exits 0.
+    command: "git show HEAD:{{record_path}} | python3 -m json.tool"
+    dependencies: [research-write-{{entity_slug}}]

--- a/skills/plan-to-invoker/formulas/entity-research/formula.yaml
+++ b/skills/plan-to-invoker/formulas/entity-research/formula.yaml
@@ -1,0 +1,55 @@
+formula: entity-research
+version: 1
+description: >
+  Research one real-world entity and commit a structured record about it, as
+  one write-and-commit task plus an independent post-commit verification task
+  (and an optional upstream gate-check). The recipe locks the workflow shape
+  so the record can never be produced in one task and silently dropped by a
+  separate downstream commit task — the exact failure mode observed in
+  wf-1786134278894-20 (ticker CPB). The author fills the {{var}} slots and
+  specializes the REPLACE_ME research question/schema before submit.
+vars:
+  repo_url:
+    required: true
+    example: "git@github.com:EdbertChan/hidden.git"
+    description: "Git remote for the repo where the record is committed."
+  base_branch:
+    required: false
+    default: "master"
+    example: "main"
+    description: "Base branch for this entity's workflow."
+  entity_id:
+    required: true
+    example: "CPB"
+    description: "Short identifier used in file paths and prose (e.g. a ticker, a case number, a SKU) — display form, may be uppercase."
+  entity_slug:
+    required: true
+    example: "cpb"
+    description: "Lowercase kebab-case form of entity_id, used only in task ids and dependency references (lint-task-atomicity.sh requires kebab-case task ids)."
+  entity_kind:
+    required: true
+    example: "S&P 500 index-removal candidate (stock ticker)"
+    description: "One phrase naming what kind of real-world thing this is, for prose context."
+  research_question:
+    required: true
+    example: "the most recent 10-K inventory accounting method (FIFO vs LIFO) and any other choice that understates book value"
+    description: "The exact fact(s) to research and record for this entity."
+  record_path:
+    required: true
+    example: "data/stocks/CPB.json"
+    description: "Single JSON record file this entity's research produces (one file, one entity)."
+  source_dir:
+    required: true
+    example: "sources/CPB"
+    description: "Directory for verbatim primary-source excerpts backing the record's claims."
+  record_schema_fields:
+    required: true
+    example: "method (enum: fifo|lifo|weighted_average|other), understatement_flag (bool)"
+    description: "Domain-specific fields to add on top of the formula's fixed envelope (entity_id, as_of, claims[])."
+  gate_check_command:
+    required: false
+    default: "true"
+    example: "test -f data/index-removals.json"
+    description: "Optional deterministic eligibility check run before research starts; defaults to a no-op. Must be self-contained (no unchecked-in script)."
+workflows:
+  - entity-research.workflow.yaml

--- a/skills/plan-to-invoker/references/entity-research-patterns.md
+++ b/skills/plan-to-invoker/references/entity-research-patterns.md
@@ -1,0 +1,85 @@
+# Structured Entity Research Plan Patterns
+
+Separate from `task-patterns.md` on purpose. That file governs plans whose deliverable is a **code change**: safety invariant = don't break other code, review lane = correctness of logic. This file governs plans whose deliverable is a **claim about the world** — a fact about a real-world entity, backed by a citation. The first, concrete case this pattern was built from is a stock screen (a 10-K accounting-quirk check, one workflow per ticker), but the pattern generalizes to any entity: a legal case's docket status, a product's spec sheet, a vulnerability's disclosure record, a location's zoning history. Safety invariant there = don't fabricate or misattribute a claim; review lane = is the citation trustworthy and does the record match the source. Different failure modes, different rules. Do not fold this into `task-patterns.md`.
+
+Trigger: the plan's tasks research and record facts about entities — companies, filings, cases, products, or similar — rather than editing product code.
+
+**Scale honesty**: as of this writing, this shape has only been run at scale in one pilot (a stock-screening batch, 41 workflows in one repo). This doc generalizes the pattern preemptively, on the strength of that one pilot's real incident, not because the shape has already recurred across many domains. Use it with that in mind — it's a solid starting point, not a battle-tested-across-domains standard yet.
+
+## Origin of this file: what actually broke
+
+Workflow `wf-1786134278894-20` (ticker CPB, one of 34 identical per-ticker "index-removal and 10-K quirk check" workflows) used a 3-task chain: `gate-check-cpb` (deterministic, writes `.gate/CPB.json`) → `research-quirks-cpb` (AI prompt task, writes `data/stocks/CPB.json` + source excerpt, commits it) → `commit-findings-cpb` (deterministic, supposed to finalize the commit). `research-quirks-cpb` did its job correctly and committed the file. But `commit-findings-cpb` silently rebased onto an *earlier* commit than its own declared dependency — it landed on `gate-check-cpb`'s commit, not `research-quirks-cpb`'s — so from its worktree's point of view there was nothing to commit, and the PR that resulted (#24) merged clean with `data/stocks/CPB.json` missing entirely. No error, no failed check. 33 of the other 34 tickers happened not to hit the race. That's the dangerous part: it's a silent, intermittent, single-digit-percent corruption of an audit trail, not a loud failure.
+
+Root cause (grounded in code, `packages/execution-engine/src/task-runner-prepare.ts:25-36` vs `task-runner.ts:1863-1884` vs `worktree-executor.ts:189-190`): the branch-continuation guard only checks that a completed dependency has a `branch`, not a `commit`; if `commit` isn't populated yet, base resolution silently falls back to the workflow's base branch instead of the dependency's actual output. This is an orchestrator-level gap worth fixing on its own, but the rules below make research plans structurally immune to it regardless of whether/when that gap gets closed.
+
+Note this wasn't even a new pattern to invent — `task-patterns.md` § *Experiment artifact handoff templates* already says an `experiment-write-*` task must "require commit of the artifact in this task." The 3-task split violated a convention this repo already had.
+
+This generalizes beyond stocks; the CPB incident is the reason every rule below exists, not a finance-specific concern.
+
+## Rule 1 (hard): the task that writes a record commits that record, in the same task
+
+Never split "write the data" and "commit the data" into two tasks connected only by a task dependency, when the write is a single small artifact (one JSON record + a source excerpt or two). One task, one worktree, one commit. This closes the CPB failure mode structurally: there is no second task that could rebase onto the wrong ancestor, because there's nothing left for a second task to do.
+
+A separate upstream **gate-check** task (deterministic membership/eligibility lookup, no research) is still fine and often good — it's cheap and keeps expensive research from running on entities that don't qualify. What must not exist is a separate *downstream* commit task after the research/write task.
+
+**Don't hand-write this shape.** Render it:
+
+```bash
+bash skills/plan-to-invoker/scripts/render-formula.mjs entity-research \
+  --var entity_id=<ID> --var entity_kind="<kind>" \
+  --var research_question="<question>" --var record_path=<path> \
+  --var source_dir=<dir> --var record_schema_fields="<fields>" \
+  --var repo_url=<repo> --out plans/rendered
+```
+
+then specialize the `REPLACE_ME` prose in the rendered file. See `formulas/entity-research/entity-research.workflow.yaml` for the exact task shape and required headings (`gate-check-<id>` → `research-write-<id>` → `verify-record-<id>`). Do not hand-copy YAML from this doc into a plan — an earlier draft of this file did exactly that, and its inline examples were missing the review-compression headings (`Review claim:`, `Safety invariant:`, `Slice rationale:`, `Architectural effect:`, `Goal:`, `Motivation:`, `Alternative considerations:`, `Implementation details:`, `Non-goals:`) that `lint-task-atomicity.sh` hard-requires for any task in an `onFinish != none` plan — a doc-only example can silently drift out of `skill-doctor` compliance; a formula can't, because it's exercised by `formula-doctor.sh`.
+
+## Rule 2 (hard): every research task ships a schema, and a re-check task proves it landed
+
+A prompt task saying "write JSON matching this shape" is not a merge gate — it's an instruction the agent can silently fail to follow, exactly like CPB did (its own PR body explicitly said "does not add data/stocks/CPB.json" as a listed non-goal, and the workflow still reached `review_ready`). Two things must both be true:
+
+1. The plan/formula defines the exact JSON contract once, not ad hoc per entity — same field names, types, and enum values for every entity in the batch, so a downstream aggregator can read all of them with one schema. The `entity-research` formula bakes a fixed envelope directly into the template rather than leaving it to prose: every record has `entity_id`, `as_of`, and `claims[]` (each with `value`, `source_excerpt`, `source_url`), plus a `record_schema_fields` var for domain-specific fields on top.
+2. A **separate task**, after the write task, re-reads the committed artifact from `HEAD` (not from the agent's self-report) and fails loudly if it's missing or malformed. This mirrors `verify-index-removals-file` from the original index-removal workflow — that pattern already existed for the shared gate file, it just wasn't applied per-entity. The formula's `verify-record-<id>` task is this check.
+
+## Rule 3 (hard): build the table after merge, never before
+
+Don't have any per-entity workflow, or a later task in its own PR, try to assemble the aggregate table. That's the exact situation that made CPB's silent failure invisible until someone went looking file-by-file: 34 parallel branches, no single point where "did every one of these actually land" gets checked. Assembling a table across N in-flight PRs means the table's correctness depends on N branch-chaining operations all going right at once.
+
+Instead, run one more workflow, gated on every per-entity workflow's `__merge__` task via `externalDependencies` (`gatePolicy: review_ready`, same pattern the stack-first authoring rule in `SKILL.md` already uses for sequential PRs — this is a fan-in version, one final workflow depending on N upstream merges instead of 1). Its only task pulls the shared base branch — never any of the per-entity branches — globs the landed records, and regenerates the table as its own small, independently reviewable PR.
+
+Render this shape too, rather than hand-writing it:
+
+```bash
+bash skills/plan-to-invoker/scripts/render-formula.mjs entity-research-aggregate \
+  --var aggregate_slug=<slug> --var aggregate_summary="<summary>" \
+  --var record_glob="<glob>" --var aggregate_output_path=<path> \
+  --var aggregate_build_command="<cmd>" --var base_branch=<branch> \
+  --var repo_url=<repo> --var upstream_workflow_id_a=<wf-id> \
+  --var upstream_workflow_id_b=<wf-id> --out plans/rendered
+```
+
+then duplicate the `externalDependencies` block once per additional upstream workflow before submit. See `formulas/entity-research-aggregate/entity-research-aggregate.workflow.yaml`.
+
+Because the aggregator only ever reads the shared base branch, a branch-chaining bug in one of the upstream workflows can no longer corrupt the table by omission without a visible symptom — "row count matches file count" turns a silent gap into a task failure.
+
+**Known limitation: `base_branch` must not be the literal string `master`.** `validate-plan.mjs`'s `stacked_basebranch_default` check (`skills/plan-to-invoker/scripts/validate-plan.mjs:636-645`) hard-fails any plan with concrete `externalDependencies` whose `baseBranch` resolves to `"master"` — it exists to catch a different mistake (a stacked workflow that forgot to point at its upstream feature branch), but it doesn't distinguish that case from this aggregator's correct behavior (gate-only fan-in reading the shared trunk, never a feature branch). For a target repo whose trunk really is named `master` — which includes Invoker itself — the aggregator formula as it validates today needs a real trunk-name alias or a follow-up fix to `validate-plan.mjs` to accept this case; that fix is out of scope here (that script currently has an unrelated in-flight change) and is a named follow-up, not something to work around silently.
+
+This is the standard data-engineering answer to "how do I get a trustworthy summary out of many independently-produced records," not something bespoke to Invoker:
+
+- **Landing / staging / mart, or "bronze / silver / gold"** (the model dbt and most modern data warehouses use): raw primary-source capture (verbatim excerpt files under a per-entity source directory) is append-only and never edited after being committed — it's a citation of what a source said when it was read. One normalized record per entity is the staging layer — each per-entity workflow produces exactly one, and commits it itself (Rule 1). The aggregate table is the mart — built by a separate, deterministic transform step that reads only the staging layer, never the raw capture directly and never in-flight branches.
+- **dbt-style tests as a merge gate, not a suggestion**: dbt's `not_null`/`exists`/`unique` tests run against staging models before anything downstream trusts them. Rule 2's re-check task is that pattern applied to a git-committed JSON record instead of a database table.
+- **Point-in-time correctness / avoiding look-ahead bias**: quant research desks distinguish "when the underlying event happened" from "when it was known" (a fundamentals restatement, a 10-K filing date) precisely because using data before it was actually knowable silently corrupts backtests. The same discipline applies to any entity-research domain — keep an explicit as-of field on every record, and never let an aggregator silently overwrite a prior snapshot in place. Either date-stamp snapshots (`SUMMARY-2026-08-10.md`) or keep a change log, so the table's history stays reproducible the same way a point-in-time database would be.
+- **Screening the graveyard, not just survivors**: researching what got *removed* from a population (an index, a registry, a catalog), not just what's in it today, is a textbook survivorship-bias control — most naive screens only look at current members and silently exclude everything that failed, was delisted, or was retired. Worth calling this out explicitly as the right instinct to keep, not just an implementation detail.
+
+## Anti-patterns
+
+- **Write/commit split**: a research task writes a record; a separate deterministic task is relied on to commit it. (This is exactly what silently dropped CPB.)
+- **Self-reported acceptance criteria with no independent re-check**: "the agent said it wrote the file" is not the same claim as "the file is present on `HEAD`."
+- **Table-building inside a per-entity workflow or PR**: makes the aggregate's correctness depend on every one of N branches resolving correctly at once, with no single place that would catch a gap.
+- **Overwriting a prior snapshot in place**: destroys point-in-time reproducibility — you can no longer answer "what did we know as of last Tuesday."
+- **A numeric or verdict claim with no `source_url` + verbatim excerpt file**: every claim must trace back to a primary source, the same way every already-landed record in this batch does.
+- **Uniform schema skipped "to save time" on one entity**: an aggregator that has to special-case one entity's shape is a sign the write task didn't follow the contract — fix the write task, don't special-case the reader.
+
+## Known gap: this is undetectable by tooling today
+
+The write/commit-split anti-pattern (Rule 1) is schema-valid and passes `lint-task-atomicity.sh` cleanly — that's *why* CPB's real workflow passed every existing check and still silently dropped data. This doc and the formulas above are the mitigation for now; a generic lint rule that flags a write-then-separate-commit-task shape (mirroring the narrow `experiment-*`/`cleanup-experiment-artifacts-*` triad check that already exists in `lint-task-atomicity.sh` for that one naming convention, generalized to arbitrary task ids) would close the gap at the validator level instead of relying on plan authors to follow this doc. That's a deliberate follow-up, not an oversight — it touches the shared validator every Invoker plan runs through, so it needs its own careful design and negative-fixture coverage rather than riding along with this change.


### PR DESCRIPTION
## Summary

The plan-to-invoker index now sends an author working on a structured entity research plan to entity-research-patterns.md, added in (1), instead of leaving them with only the code-change reference.

Before this line, nothing in the index pointed a research-plan author anywhere; they had to already know the file existed.

## Review Claim

Approve one line in `SKILL.md`'s reference index that connects a structured entity research plan to the new entity-research-patterns.md content from (1).

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change is one line in `SKILL.md`'s existing reference index, adding an entry and a short qualifier on the neighboring line. No other line in the file changes, and no behavior outside this skill's own instruction text is affected.

## Slice Rationale

Ships after (1) so the entry it adds points at content that already exists at review time. Kept separate from (1) because it touches a different reviewable surface (the skill's own index) than the new content itself.

## Non-goals

Does not change any other entry in the reference index. Does not touch any check or automated gate.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-plan-to-invoker-skill.sh` — exit 0, full contract suite green (confirms this one-line change doesn't break any existing string-contract assertion against `SKILL.md`)
- [x] Manual read of the updated section confirming the new entry text matches the exact target filename from (1) with no typo.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert dea1039`
- Post-revert steps: None
- Data migration? No

</details>
