### PR TITLE
[Bugfix: an orphaned execution slot must be reclaimed across tasks](2) Export reclaimOrphanedExecutionSlots and add a direct-call test

### DIFF
--- a/packages/execution-engine/src/__tests__/pool-capacity-superseded-execution-leak.test.ts
+++ b/packages/execution-engine/src/__tests__/pool-capacity-superseded-execution-leak.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
+import { reclaimOrphanedExecutionSlots } from '../task-runner-pool.js';
 import type { TaskState } from '@invoker/workflow-core';
 
 /**
@@ -122,6 +123,40 @@ describe('pool capacity: superseded execution slot leak', () => {
     expect(() => runner.selectExecutor(makeTask('wf-2/task-b', 'wf-2/task-b-attempt'))).not.toThrow();
     expect((runner as unknown as { activeExecutions: Map<string, unknown> }).activeExecutions.has('wf-1/task-a-old')).toBe(false);
     expect(runner.pendingPoolSelections.get('wf-2/task-b')?.member.id).toBe('remote-a');
+    expect(kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("reclaims another task's orphaned non-live attempt so a waiter can fill the member (direct call)", () => {
+    const taskA = makeTask('wf-1/task-a', 'wf-1/task-a-live');
+    const kill = vi.fn().mockResolvedValue(undefined);
+    const executor = { kill } as never;
+    const activeExecutions = new Map<string, unknown>();
+    activeExecutions.set('wf-1/task-a-live', {
+      handle: { attemptId: 'wf-1/task-a-live' },
+      executor,
+      taskId: 'wf-1/task-a',
+      poolMemberKey: 'ssh:remote-a',
+    });
+    activeExecutions.set('wf-1/task-a-old', {
+      handle: { attemptId: 'wf-1/task-a-old' },
+      executor,
+      taskId: 'wf-1/task-a',
+      poolMemberKey: 'ssh:remote-a',
+    });
+    const host = {
+      orchestrator: {
+        getTask: (id: string) => (id === taskA.id ? taskA : null),
+        getAllTasks: () => [taskA],
+      },
+      activeExecutions,
+      persistence: { releaseExecutionResourceLease: vi.fn() },
+      logger: { warn: vi.fn() },
+    } as never;
+
+    reclaimOrphanedExecutionSlots(host);
+
+    expect(activeExecutions.has('wf-1/task-a-live')).toBe(true);
+    expect(activeExecutions.has('wf-1/task-a-old')).toBe(false);
     expect(kill).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -548,7 +548,7 @@ function reclaimSupersededExecutionSlots(host: TaskRunnerPoolHost, task: TaskSta
  * *other* tasks waiting on a wedged member; this pass does, using orchestrator
  * truth so genuinely live executions are never dropped.
  */
-function reclaimOrphanedExecutionSlots(host: TaskRunnerPoolHost & MergeRunnerHost): void {
+export function reclaimOrphanedExecutionSlots(host: TaskRunnerPoolHost & MergeRunnerHost): void {
   const getTask = host.orchestrator?.getTask?.bind(host.orchestrator);
   if (!getTask) return;
   const allTasks = host.orchestrator.getAllTasks?.() ?? [];


### PR DESCRIPTION
## Summary

`reclaimOrphanedExecutionSlots` runs on every task's turn to select an executor. It reclaims a slot left behind by a different task's kill hook.

That reclaim means one task's orphan can never wedge another task's capacity.

That already happens today. It was only reachable indirectly, by driving a full `TaskRunner` selection.

This change exports the function and adds one focused test that builds a minimal host fixture and calls it directly, as a second, cheaper oracle for the same invariant.

## Review Claim

The change adds the `export` keyword to `reclaimOrphanedExecutionSlots` in `packages/execution-engine/src/task-runner-pool.ts`, with no change to its body or its call site in `selectExecutor`, and adds one new direct-call test; no defect is being fixed.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The function's inputs, outputs, and internal logic are byte-identical before and after; only its visibility changes. The existing `TaskRunner`-level tests in `pool-capacity-superseded-execution-leak.test.ts` are untouched.

## Slice Rationale

One symbol, one PR, sequenced after the `releaseAndKillOrphanedExecution` export it depends on: widen this function's visibility and add the direct-call test it enables.

## Non-goals

- No refactor beyond the export.
- No change to `releaseAndKillOrphanedExecution` (exported in the prior slice).
- No new fields, no unrelated cleanup, no change to any existing test.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- -t "reclaims another task's orphaned non-live attempt so a waiter can fill the member"` (Test Files 1 passed | 119 skipped (120); Tests 2 passed | 1568 skipped (1570), including the new direct-call test; exit 0)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
