### PR TITLE
[Bugfix: SSH pool load must be counted from durable, unexpired lease rows](1) Export sshHostLeaseLoad and add a direct-call test

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-lease-capacity-authority.proof.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-lease-capacity-authority.proof.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
+import { sshHostLeaseLoad, type TaskRunnerPoolHost } from '../task-runner-pool.js';
 import type { TaskState } from '@invoker/workflow-core';
 import { SQLiteAdapter } from '@invoker/data-store';
 
@@ -116,6 +117,25 @@ describe('SSH lease capacity authority (proof)', () => {
 
     expect((runner as any).persistence.listExecutionResourceLeases()).toEqual([]);
     expect(() => runner.selectExecutor(makeTask('wf-2/task-b', 'pnpm-ssh'))).not.toThrow();
+  });
+
+  // Direct-call proof: sshHostLeaseLoad reads the durable lease count, not activeExecutions.
+  it('sshHostLeaseLoad returns the durable lease count rather than in-memory activeExecutions size', () => {
+    const host = {
+      persistence: {
+        countExecutionResourceLeases: () => 3,
+      },
+      getRemoteTargets: () => ({
+        'remote-shared': sharedHost,
+      }),
+      activeExecutions: new Map([
+        ['some-other-attempt', { poolId: 'pnpm-ssh', poolMemberKey: 'ssh:remote-shared' }],
+      ]),
+    } as unknown as TaskRunnerPoolHost;
+
+    const member = { type: 'ssh', id: 'remote-shared', maxConcurrentTasks: 1 } as const;
+
+    expect(sshHostLeaseLoad(host, member)).toBe(3);
   });
 
   // Host-keyed claim-at-select prevents two pools from double-booking one droplet.

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -133,7 +133,7 @@ function memoryPoolMemberLoad(host: TaskRunnerPoolHost, poolId: string, memberKe
   return load;
 }
 
-function sshHostLeaseLoad(host: TaskRunnerPoolHost, member: Extract<ExecutionPoolMember, { type: 'ssh' }>): number | undefined {
+export function sshHostLeaseLoad(host: TaskRunnerPoolHost, member: Extract<ExecutionPoolMember, { type: 'ssh' }>): number | undefined {
   const target = host.getRemoteTargets()[member.id];
   if (!target) return undefined;
   const resourceKey = sshResourceKey(target);


### PR DESCRIPTION
## Summary

SSH pool members must count their load from durable, unexpired lease rows, keyed by host.

They must never count from an in-memory map that can outlive the real lease.

That already happens today: `sshHostLeaseLoad` reads `countExecutionResourceLeases`, filtered by unexpired `leaseExpiresAt`, and only falls back to the in-memory map when a host has no lease API at all.

It was only reachable indirectly, by driving a full `TaskRunner` selection.

This change exports the function and adds one focused test that builds a minimal host fixture and calls it directly, as a second, cheaper oracle for the same invariant.

## Review Claim

The change adds the `export` keyword to `sshHostLeaseLoad` in `packages/execution-engine/src/task-runner-pool.ts`, with no change to its body or its call site in `poolMemberLoad`, and adds one new direct-call test; no defect is being fixed.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The function's inputs, outputs, and internal logic are byte-identical before and after; only its visibility changes. The existing `TaskRunner`-level tests in `ssh-lease-capacity-authority.proof.test.ts` are untouched.

## Slice Rationale

One symbol, one PR: widen `sshHostLeaseLoad`'s visibility and add the direct-call test it enables, nothing else.

## Non-goals

- No refactor beyond the export.
- No change to `poolMemberLoad` or `memoryPoolMemberLoad`.
- No new fields, no unrelated cleanup, no change to any existing test.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- -t "does not wedge SSH capacity on a lease-less activeExecutions ghost"` (Test Files 1 passed | 119 skipped (120); Tests 1 passed | 1570 skipped (1571); exit 0)
- [x] `cd packages/execution-engine && pnpm test -- -t "sshHostLeaseLoad returns the durable lease count"` (Test Files 1 passed | 119 skipped (120); Tests 1 passed | 1570 skipped (1571), the new direct-call test; exit 0)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
