### PR TITLE
[Hardening: SSH lease claimed at pool-member selection time](1) Add a direct-call regression test for claim-at-select

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-lease-capacity-authority.proof.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-lease-capacity-authority.proof.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
-import { sshHostLeaseLoad, type TaskRunnerPoolHost } from '../task-runner-pool.js';
+import { acquirePoolSelectionLease, sshHostLeaseLoad, type PoolSelection, type TaskRunnerPoolHost } from '../task-runner-pool.js';
 import type { TaskState } from '@invoker/workflow-core';
 import { SQLiteAdapter } from '@invoker/data-store';
 
@@ -136,6 +136,57 @@ describe('SSH lease capacity authority (proof)', () => {
     const member = { type: 'ssh', id: 'remote-shared', maxConcurrentTasks: 1 } as const;
 
     expect(sshHostLeaseLoad(host, member)).toBe(3);
+  });
+
+  // Direct-call proof: acquirePoolSelectionLease claims the host lease at select
+  // time, so a future refactor that moves the claim later fails this unit test
+  // even if the higher-level selectExecutor integration test still passes.
+  it('acquirePoolSelectionLease claims on first call and rejects a conflicting second call', () => {
+    const claims = new Map<string, string>();
+    const persistence = {
+      claimExecutionResourceLease: vi.fn(
+        (params: { resourceKey: string; holderId: string }) => {
+          const existingHolder = claims.get(params.resourceKey);
+          if (existingHolder && existingHolder !== params.holderId) return false;
+          claims.set(params.resourceKey, params.holderId);
+          return true;
+        },
+      ),
+      logEvent: vi.fn(),
+    };
+    const host = {
+      persistence,
+      runnerInstanceId: 'runner-1',
+      getRemoteTargets: () => ({
+        'remote-shared': sharedHost,
+      }),
+      getExecutionPools: () => ({
+        'pnpm-ssh': {
+          selectionStrategy: 'leastLoaded',
+          maxConcurrentTasksPerMember: 1,
+          members: [{ id: 'remote-shared', type: 'ssh', maxConcurrentTasks: 1 }],
+        },
+      }),
+    } as unknown as TaskRunnerPoolHost;
+
+    const member = { type: 'ssh', id: 'remote-shared', maxConcurrentTasks: 1 } as const;
+    const makeSelection = (): PoolSelection => ({
+      poolId: 'pnpm-ssh',
+      member,
+      memberKey: 'ssh:remote-shared',
+      selectionStrategy: 'leastLoaded',
+    });
+
+    const firstTask = makeTask('wf-1/task-a', 'pnpm-ssh');
+    const firstSelection = makeSelection();
+    expect(acquirePoolSelectionLease(host, firstTask, 'wf-1/task-a-attempt', firstSelection)).toBe(true);
+    expect(firstSelection.leaseResourceKey).toBeDefined();
+    expect(firstSelection.leaseHolderId).toBeDefined();
+
+    const secondTask = makeTask('wf-2/task-b', 'pnpm-ssh');
+    const secondSelection = makeSelection();
+    expect(acquirePoolSelectionLease(host, secondTask, 'wf-2/task-b-attempt', secondSelection)).toBe(false);
+    expect(secondSelection.leaseResourceKey).toBeUndefined();
   });
 
   // Host-keyed claim-at-select prevents two pools from double-booking one droplet.


### PR DESCRIPTION
## Summary

An SSH host lease must be claimed at pool-member selection time, before the executor starts, so two same-tick selections can never both win the same host.

That invariant already holds today. `acquirePoolSelectionLease` claims the host lease synchronously inside `reservePoolMemberSelection`, called from `selectExecutor`, before any start or dispatch path runs.

This slice does not change that guard or its call site. It adds a test that calls `acquirePoolSelectionLease` directly.

A future refactor that quietly moves the claim later now fails a unit test, even if the higher-level integration test still passes.

## Review Claim

`acquirePoolSelectionLease` in `packages/execution-engine/src/task-runner-pool.ts` already claims the SSH host lease synchronously during selection, before any start/dispatch path runs. This slice confirms the call site stays byte-identical and adds a direct-call regression test for the guard.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The selection call site (`reservePoolMemberSelection` -> `acquirePoolSelectionLease`) and its byte-for-byte behavior are unchanged; only test coverage is added.

## Slice Rationale

One slice: add a direct-call regression test for the existing exported guard. No product behavior changes, so there is nothing to split from.

## Non-goals

No refactor, no new fields, no behavior change, no unrelated cleanup, no doc edits. `packages/execution-engine/src/task-runner-pool.ts` is not touched.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- -t "blocks a second pool from selecting a host already reserved by another pool"`
- [x] `cd packages/execution-engine && pnpm test -- -t "acquirePoolSelectionLease claims on first call and rejects a conflicting second call"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
