### PR TITLE
[Hardening: abandoning a stuck launch releases every resource lease](1) Export releaseTaskResourceLeases and add a direct-call regression test

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -3,7 +3,7 @@ import { SQLiteAdapter } from '@invoker/data-store';
 import { DISPATCH_LEASE_MS, LAUNCH_STUCK_ABANDON_MS, type Logger } from '@invoker/contracts';
 import { InMemoryBus } from '@invoker/test-kit';
 import { Orchestrator } from '@invoker/workflow-core';
-import { LaunchDispatcher } from '../launch-dispatcher.js';
+import { LaunchDispatcher, releaseTaskResourceLeases } from '../launch-dispatcher.js';
 
 function makeLogger(): Logger & {
   records: { level: 'info' | 'warn' | 'error' | 'debug'; msg: string; fields?: Record<string, unknown> }[];
@@ -489,6 +489,59 @@ describe('LaunchDispatcher', () => {
         expect(payload.reason).toBe('launch-dispatch-abandoned');
       }
       expect(prepare).toHaveBeenCalledWith('wf-r/t1', 'launch-dispatch-abandoned');
+    });
+
+    it('CD.2: releaseTaskResourceLeases releases only the owned task leases when called directly', () => {
+      seed();
+      const owned1 = adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh-pool/host-A',
+        resourceType: 'ssh-pool-slot',
+        holderId: 'direct-holder-1',
+        taskId: 'wf-r/t1',
+        poolId: 'ssh-pool',
+        poolMemberId: 'host-A',
+      });
+      const owned2 = adapter.claimExecutionResourceLease({
+        resourceKey: 'worktree-pool/slot-9',
+        resourceType: 'worktree-pool-slot',
+        holderId: 'direct-holder-2',
+        taskId: 'wf-r/t1',
+        poolId: 'worktree-pool',
+        poolMemberId: 'slot-9',
+      });
+      const unrelated = adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh-pool/host-C',
+        resourceType: 'ssh-pool-slot',
+        holderId: 'direct-holder-3',
+        taskId: 'wf-other/tY',
+        poolId: 'ssh-pool',
+        poolMemberId: 'host-C',
+      });
+      expect(owned1).toBe(true);
+      expect(owned2).toBe(true);
+      expect(unrelated).toBe(true);
+
+      const logger = makeLogger();
+      releaseTaskResourceLeases(adapter, logger, 'owner-direct', 'wf-r/t1', 4242);
+
+      expect(adapter.listExecutionResourceLeasesByTask('wf-r/t1')).toHaveLength(0);
+      const stillThere = adapter.listExecutionResourceLeasesByTask('wf-other/tY');
+      expect(stillThere).toHaveLength(1);
+
+      const events = adapter.getEvents('wf-r/t1');
+      const releaseEvents = events.filter(
+        (event) => event.eventType === 'task.launch_dispatch_lease_released',
+      );
+      expect(releaseEvents).toHaveLength(2);
+      const keys = releaseEvents
+        .map((event) => JSON.parse(event.payload!).resourceKey as string)
+        .sort();
+      expect(keys).toEqual(['ssh-pool/host-A', 'worktree-pool/slot-9']);
+      for (const event of releaseEvents) {
+        const payload = JSON.parse(event.payload!);
+        expect(payload.dispatchId).toBe(4242);
+        expect(payload.reason).toBe('launch-dispatch-abandoned');
+      }
     });
 
     it('CD.2: abandonStuckLeases is a no-op for leases when no resource leases are held', () => {

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -122,6 +122,83 @@ export function dispatchThroughOutboxOnly(
   return leased != null;
 }
 
+/**
+ * Release every execution-resource lease (SSH pool slot, worktree
+ * pool member, ...) held on behalf of a task whose launch dispatch
+ * was just abandoned. Best-effort: each release runs in its own
+ * try/catch so a single stuck row cannot prevent the others from
+ * being released, and any I/O failure is logged but does not
+ * propagate (abandonStuckLeases must remain idempotent under
+ * repeated polls).
+ *
+ * Exported as a standalone function (rather than only a private
+ * class method) so it is directly testable without going through
+ * the full abandon flow.
+ */
+export function releaseTaskResourceLeases(
+  persistence: LaunchDispatcherPersistence,
+  logger: Logger | undefined,
+  ownerId: string,
+  taskId: string,
+  dispatchId: number,
+  reason = 'launch-dispatch-abandoned',
+): void {
+  let leases: ReadonlyArray<{ resourceKey: string; holderId: string; resourceType: string }> = [];
+  try {
+    leases = persistence.listExecutionResourceLeasesByTask(taskId);
+  } catch (err) {
+    logger?.warn?.(
+      '[launch-dispatcher] listExecutionResourceLeasesByTask failed',
+      {
+        ownerId,
+        taskId,
+        dispatchId,
+        error: err instanceof Error ? err.message : String(err),
+        module: 'launch-dispatcher',
+      },
+    );
+    return;
+  }
+  if (leases.length === 0) return;
+  let released = 0;
+  for (const lease of leases) {
+    try {
+      persistence.releaseExecutionResourceLease(lease.resourceKey, lease.holderId);
+      released += 1;
+      persistence.logEvent?.(taskId, 'task.launch_dispatch_lease_released', {
+        dispatchId,
+        resourceKey: lease.resourceKey,
+        resourceType: lease.resourceType,
+        holderId: lease.holderId,
+        reason,
+      });
+    } catch (err) {
+      logger?.warn?.(
+        '[launch-dispatcher] releaseExecutionResourceLease failed',
+        {
+          ownerId,
+          taskId,
+          dispatchId,
+          resourceKey: lease.resourceKey,
+          holderId: lease.holderId,
+          error: err instanceof Error ? err.message : String(err),
+          module: 'launch-dispatcher',
+        },
+      );
+    }
+  }
+  if (released > 0) {
+    logger?.info?.('[launch-dispatcher] released resource leases', {
+      ownerId,
+      taskId,
+      dispatchId,
+      released,
+      total: leases.length,
+      module: 'launch-dispatcher',
+    });
+  }
+}
+
 export class LaunchDispatcher {
   private readonly persistence: LaunchDispatcherPersistence;
   private readonly orchestrator?: LaunchDispatcherOrchestrator;
@@ -441,7 +518,7 @@ export class LaunchDispatcher {
   ): void {
     const accepted = this.persistence.markLaunchDispatchAbandoned(dispatch.id, message, undefined, reason);
     if (accepted) {
-      this.releaseTaskResourceLeases(dispatch.taskId, dispatch.id, reason);
+      releaseTaskResourceLeases(this.persistence, this.logger, this.ownerId, dispatch.taskId, dispatch.id, reason);
     }
     this.persistence.logEvent?.(dispatch.taskId, 'task.launch_dispatch_invalidated', {
       dispatchId: dispatch.id,
@@ -552,7 +629,7 @@ export class LaunchDispatcher {
     const accepted = this.persistence.markLaunchDispatchAbandoned(row.id, message, nowIso, abandonReason);
     if (!accepted) return false;
 
-    this.releaseTaskResourceLeases(row.taskId, row.id);
+    releaseTaskResourceLeases(this.persistence, this.logger, this.ownerId, row.taskId, row.id);
     return true;
   }
 
@@ -603,76 +680,6 @@ export class LaunchDispatcher {
         taskId,
         dispatchId,
         error: err instanceof Error ? err.message : String(err),
-        module: 'launch-dispatcher',
-      });
-    }
-  }
-
-  /**
-   * Release every execution-resource lease (SSH pool slot, worktree
-   * pool member, ...) held on behalf of a task whose launch dispatch
-   * was just abandoned. Best-effort: each release runs in its own
-   * try/catch so a single stuck row cannot prevent the others from
-   * being released, and any I/O failure is logged but does not
-   * propagate (abandonStuckLeases must remain idempotent under
-   * repeated polls).
-   */
-  private releaseTaskResourceLeases(
-    taskId: string,
-    dispatchId: number,
-    reason = 'launch-dispatch-abandoned',
-  ): void {
-    let leases: ReadonlyArray<{ resourceKey: string; holderId: string; resourceType: string }> = [];
-    try {
-      leases = this.persistence.listExecutionResourceLeasesByTask(taskId);
-    } catch (err) {
-      this.logger?.warn?.(
-        '[launch-dispatcher] listExecutionResourceLeasesByTask failed',
-        {
-          ownerId: this.ownerId,
-          taskId,
-          dispatchId,
-          error: err instanceof Error ? err.message : String(err),
-          module: 'launch-dispatcher',
-        },
-      );
-      return;
-    }
-    if (leases.length === 0) return;
-    let released = 0;
-    for (const lease of leases) {
-      try {
-        this.persistence.releaseExecutionResourceLease(lease.resourceKey, lease.holderId);
-        released += 1;
-        this.persistence.logEvent?.(taskId, 'task.launch_dispatch_lease_released', {
-          dispatchId,
-          resourceKey: lease.resourceKey,
-          resourceType: lease.resourceType,
-          holderId: lease.holderId,
-          reason,
-        });
-      } catch (err) {
-        this.logger?.warn?.(
-          '[launch-dispatcher] releaseExecutionResourceLease failed',
-          {
-            ownerId: this.ownerId,
-            taskId,
-            dispatchId,
-            resourceKey: lease.resourceKey,
-            holderId: lease.holderId,
-            error: err instanceof Error ? err.message : String(err),
-            module: 'launch-dispatcher',
-          },
-        );
-      }
-    }
-    if (released > 0) {
-      this.logger?.info?.('[launch-dispatcher] released resource leases', {
-        ownerId: this.ownerId,
-        taskId,
-        dispatchId,
-        released,
-        total: leases.length,
         module: 'launch-dispatcher',
       });
     }


### PR DESCRIPTION
## Summary

Abandoning a stuck launch already releases every resource lease the task holds, not just the dispatch row.

This slice does not fix a bug. It exports the existing release logic as a standalone function so it can be tested directly, not only through the full abandon flow.

Both existing call sites (`abandonDispatch`, `abandonInvalidDispatch`) now call the exported function with byte-identical behavior. A new test calls it directly.

## Review Claim

`releaseTaskResourceLeases` in `packages/app/src/launch-dispatcher.ts` already releases every resource lease held by an abandoned task, called unconditionally from both `abandonDispatch` and `abandonInvalidDispatch`. This slice promotes that logic to a standalone exported function, keeps both call sites' behavior byte-identical, and adds a test that calls the exported function directly.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The per-lease release loop, its per-lease try/catch isolation, and both call sites (`abandonDispatch`, `abandonInvalidDispatch`) stay byte-identical in effect. The only change is making the logic reachable via a standalone export.

## Slice Rationale

One slice: extract/export the guard for direct testability, then add a direct-call regression test. No change to which leases get released or when.

## Non-goals

No refactor of the abandon flow, no new fields, no behavior change, no unrelated cleanup, no doc edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- -t "CD.2: abandonStuckLeases releases execution-resource leases held by the abandoned task (Issue 14)"`
- [x] `cd packages/app && npx vitest run src/__tests__/launch-dispatcher.test.ts` (41 passed, including the CD.2 case and the new direct-call case)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
