### PR TITLE
[Add diu ELI5 brevity skill](1) Add diu ELI5 brevity skill

### DIFF
--- a/skills/diu/SKILL.md
+++ b/skills/diu/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: diu
+description: >
+  Default communication-brevity rule: before finishing any response, check
+  whether it would run over roughly 150 words or lean on unexplained jargon. If
+  so, and the user has not explicitly asked for full technical detail in the
+  same turn, replace it with an ELI5 answer under 40 words instead. Also
+  triggers immediately on a literal ELI5 request in the user's message (eli5,
+  ELI5, Eli5, "ELI 5" with a space, or an explicit word cap like "< 40 words"),
+  even with no other context. Fires most often on debugging "why" questions,
+  architecture explanations, and PR summaries.
+---
+
+# diu
+
+## Why this exists
+
+Calibrated from ~24 real "eli5" requests mined from Claude Code and Codex CLI
+session history: the user asks for "eli5" constantly, almost always
+proactively in the same message as the question rather than as a follow-up
+complaint after a bad answer, most often on root-cause "why is this broken"
+debugging questions, architecture explanations, and PR summaries.
+
+## The rule
+
+1. Before sending a response, estimate its length and jargon density.
+2. If it would exceed 150 words, or uses terms the user hasn't already used and
+   hasn't asked to have explained at that depth, stop and rewrite it as ELI5:
+   under 40 words, plain everyday language, lead with the outcome, no
+   unexplained acronyms or jargon.
+3. Do not apply the ELI5 cap when the user's message explicitly asks for
+   technical detail, full depth, or a specific longer format (a PR summary, a
+   written plan, a list of files) in that same turn — brevity does not override
+   an explicit request for depth.
+4. Treat a literal ELI5 request as an immediate override regardless of the
+   150-word/jargon check: match case-insensitively on "eli5", "eli 5" (optional
+   space before the digit), and "explain like i'm 5" / "explain like i am 5".
+   An explicit word cap in the same message (e.g. "< 40 words", "< 50 words")
+   sets the ceiling instead of the 40-word default when given.
+5. A bare trigger with no other words (e.g. "eli5", "eli5 <link>") still means:
+   answer the open question from context, in ELI5 register, under 40 words. Do
+   not ask what "it" refers to if the prior turn makes it clear.
+
+## What this looks like
+
+- Root-cause/debugging "why" questions: state the one-line cause and fix in
+  plain words, skip the investigation narrative.
+- Architecture/design explanations: one sentence on the mechanic, stop unless
+  asked how or why.
+- PR summaries: outcome in one sentence, cause in one sentence, fix in one
+  sentence.


### PR DESCRIPTION
## Summary

Adds a self-contained `diu` skill under `skills/diu/`.

The skill tells Claude Code, Codex, and Cursor to compress long or jargon-heavy answers into short ELI5 responses unless the user asks for detail.

Its provenance (~24 mined real "eli5" requests from Claude and Codex sessions) is folded into the skill's own "Why this exists" section, not a separate file.

No existing skill or bundling script changes.

## Review Claim

A new self-contained `diu` skill in `skills/diu/` defines the ELI5 brevity rule, with its calibration provenance folded directly into the skill file.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Only one new file, `skills/diu/SKILL.md`, is added. Existing skills and `scripts/setup-agent-skills.sh` are untouched, so current skill bundling behavior remains unchanged.

## Slice Rationale

This is one docs slice: a single self-contained skill file with no separate reference file, since the corpus file added no functional value and was only used at authoring time.

## Non-goals

- Do not change `scripts/setup-agent-skills.sh`.
- Do not modify any existing skill.
- Do not add scripts, fixtures, or runtime behavior for `diu`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `test -f skills/diu/SKILL.md && grep -qx "name: diu" skills/diu/SKILL.md && grep -q "^description:" skills/diu/SKILL.md && echo "frontmatter check passed"`

```text
frontmatter check passed
```

- [x] `test ! -f skills/diu/references/eli5-trigger-corpus.md && echo "corpus file removed as expected"`

```text
corpus file removed as expected
```

- [x] `git diff --name-only origin/master...HEAD | awk '($0 !~ /^skills\/diu\//) { bad=1; print } END { exit bad }' && echo "scope check passed"`

```text
scope check passed
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
