### PR TITLE
Workflow delete+resubmit UI drift (3) renderer per-task version guard

### DIFF
--- a/packages/ui/src/__tests__/rebase-recreate-task-graph-drift-repro.test.tsx
+++ b/packages/ui/src/__tests__/rebase-recreate-task-graph-drift-repro.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Repro: after rebase+recreate, the UI can show a task as pending forever while
+ * backend truth has already moved the task to running (Executing stays 0/N when
+ * chips are derived from the task map).
+ *
+ * Mechanism under test (mutation-accept refresh race):
+ *   1. Recreate resets the task → pending delta applies (matches user: "I see pending").
+ *   2. Launch publishes running/executing delta.
+ *   3. trackAcceptedMutation fires non-forced refreshTaskGraph; the snapshot is
+ *      still mid-reset pending but stamped with the current (advanced) stream
+ *      sequence — exactly what publishSnapshot + syncAllFromDb can emit.
+ *   4. useTasks replaces the task map with that pending snapshot and advances
+ *      the watermark, so the running delta is lost / clobbered.
+ *
+ * Correct behavior (assertions below): UI must show running after the race.
+ * On current HEAD this test is expected to FAIL, proving the drift.
+ *
+ * Self-contained for git bisect: does not import getLiveQueueCounts (newer API).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useTasks } from '../hooks/useTasks.js';
+import { makeUITask } from './helpers/mock-invoker.js';
+import type { WorkflowMeta } from '../types.js';
+
+vi.setConfig({ testTimeout: 20_000 });
+
+const TASK_ID = 'wf-rebase-recreate/a';
+const WORKFLOW_ID = 'wf-rebase-recreate';
+
+function flushPipeline(ms = 130): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setTimeout(resolve, ms);
+  return promise;
+}
+
+function countActiveExecuting(tasks: Map<string, { status: string; execution?: { crashPreservedAt?: unknown } }>): number {
+  let count = 0;
+  for (const task of tasks.values()) {
+    if (task.execution?.crashPreservedAt) continue;
+    if (task.status === 'running' || task.status === 'fixing_with_ai') count += 1;
+  }
+  return count;
+}
+
+function makeFailedTask() {
+  return makeUITask({
+    id: TASK_ID,
+    workflowId: WORKFLOW_ID, description: 'Fails then rebase-recreates',
+    status: 'failed',
+    execution: { phase: 'idle', exitCode: 1 },
+    taskStateVersion: 1,
+  });
+}
+
+function makePendingTask(version: number) {
+  return makeUITask({
+    id: TASK_ID,
+    workflowId: WORKFLOW_ID, description: 'Fails then rebase-recreates',
+    status: 'pending',
+    execution: { phase: 'idle' },
+    taskStateVersion: version,
+  });
+}
+
+function makeRunningTask(version: number) {
+  return makeUITask({
+    id: TASK_ID,
+    workflowId: WORKFLOW_ID, description: 'Fails then rebase-recreates',
+    status: 'running',
+    execution: { phase: 'executing', selectedAttemptId: 'attempt-1' },
+    taskStateVersion: version,
+  });
+}
+
+const workflow: WorkflowMeta = {
+  id: WORKFLOW_ID,
+  name: 'Rebase Recreate Drift',
+  status: 'running',
+};
+
+describe('rebase-recreate UI task-graph drift', () => {
+  let taskGraphEventHandler: ((event: unknown) => void) | undefined;
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    taskGraphEventHandler = undefined;
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [],
+      workflows: [],
+      streamSequence: 0,
+    };
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks: vi.fn().mockResolvedValue({ tasks: [], workflows: [], streamSequence: 0 }),
+      listWorkflows: vi.fn().mockResolvedValue([]),
+      reportUiPerf: vi.fn().mockResolvedValue(undefined),
+      refreshTaskGraph: vi.fn().mockResolvedValue(undefined),
+      onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
+        taskGraphEventHandler = cb;
+        return () => {};
+      }),
+      onWorkflowsChanged: vi.fn(() => () => {}),
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as unknown as { invoker?: unknown }).invoker;
+    delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
+  });
+
+  it('keeps running after recreate when a stale pending refresh snapshot races the stream', async () => {
+    const { result } = renderHook(() => useTasks());
+
+    // Seed: failed task (pre-recreate).
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'snapshot',
+        tasks: [makeFailedTask()],
+        workflows: [workflow],
+        reason: 'live',
+        streamSequence: 1,
+      });
+      await flushPipeline();
+    });
+    expect(result.current.tasks.get(TASK_ID)?.status).toBe('failed');
+
+    // 1. Recreate reset → pending (user sees this).
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'delta',
+        delta: {
+          type: 'updated',
+          taskId: TASK_ID,
+          changes: { status: 'pending', execution: { phase: 'idle' } },
+          taskStateVersion: 2,
+          previousTaskStateVersion: 1,
+          streamSequence: 2,
+        },
+        workflowRollups: [],
+      });
+      await flushPipeline();
+    });
+    expect(result.current.tasks.get(TASK_ID)?.status).toBe('pending');
+
+    // 2. Backend progresses to running (orchestrator/query truth).
+    const backendTruth = makeRunningTask(3);
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'delta',
+        delta: {
+          type: 'updated',
+          taskId: TASK_ID,
+          changes: {
+            status: 'running',
+            execution: { phase: 'executing', selectedAttemptId: 'attempt-1' },
+          },
+          taskStateVersion: 3,
+          previousTaskStateVersion: 2,
+          streamSequence: 3,
+        },
+        workflowRollups: [],
+      });
+      await flushPipeline();
+    });
+    expect(result.current.tasks.get(TASK_ID)?.status).toBe('running');
+    expect(countActiveExecuting(result.current.tasks)).toBe(1);
+
+    // 3. Non-forced mutation-accept refresh: mid-launch pending snapshot stamped
+    // with the current advanced stream sequence (publishSnapshot behavior).
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'snapshot',
+        tasks: [makePendingTask(2)],
+        workflows: [{ ...workflow, status: 'pending' }],
+        reason: 'refresh-task-graph',
+        streamSequence: 3,
+        // forced intentionally omitted — desktop IPC does not pass forced today
+      });
+      await flushPipeline();
+    });
+
+    const uiStatus = result.current.tasks.get(TASK_ID)?.status;
+    const uiExecuting = countActiveExecuting(result.current.tasks);
+
+    // Backend already running; UI must not stay stuck on pending / Executing 0.
+    expect(backendTruth.status).toBe('running');
+    expect(uiStatus).toBe('running');
+    expect(uiExecuting).toBe(1);
+  });
+});

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -350,8 +350,20 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
         const t0 = performance.now();
 
         if (firstEvent?.type === 'snapshot') {
+          const previousTasks = nextTasks;
           nextTasks = new Map<string, TaskState>();
-          for (const task of firstEvent.tasks) nextTasks.set(task.id, task);
+          for (const task of firstEvent.tasks) {
+            const existingTask = previousTasks.get(task.id);
+            // A snapshot can race a delta in flight and arrive with data
+            // captured before that delta landed; never let it regress a
+            // task backward from state the renderer has already applied.
+            nextTasks.set(
+              task.id,
+              existingTask && existingTask.taskStateVersion > task.taskStateVersion
+                ? existingTask
+                : task,
+            );
+          }
           nextWorkflows = replaceWorkflowMapPreservingTaskBackedEntries(
             nextWorkflows,
             firstEvent.workflows,

--- a/packages/ui/src/lib/delta.ts
+++ b/packages/ui/src/lib/delta.ts
@@ -27,6 +27,7 @@ export function applyDeltaInPlace(
           ...topLevel,
           config: { ...existing.config, ...cfgChanges },
           execution: { ...existing.execution, ...execChanges },
+          taskStateVersion: delta.taskStateVersion,
         });
       } else {
         console.warn(


### PR DESCRIPTION
## Summary

An outdated 'snapshot' event from the backend can still overwrite a task's correct, newer status in the UI, even with the backend fix from the previous PR in this stack.

`useTasks`'s snapshot handling wholesale-replaces the local task map with no per-task ordering check, so an older snapshot can regress a task backward with no later correction.

This fix makes the snapshot merge per-task version-aware: it keeps the locally-newer task whenever its `taskStateVersion` is strictly greater than the incoming snapshot's copy.

That guard needs an accurate `taskStateVersion` after each delta, so this PR also fixes `applyDeltaInPlace`, which merged delta changes but never copied `taskStateVersion` onto the result.

Both changes ship together: the guard is not correct without the delta fix, and one test proves the whole fix across both files in a single sequence.

## Review Claim

A 'snapshot' task-graph event can no longer regress an individual task's rendered status backward when the renderer has already applied a newer delta for that same task.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The per-task guard only changes which of two already-known task objects (the local one or the snapshot's copy) is kept for a given task id when both are present; it never changes whether a task is added or removed by a snapshot, and it never applies to tasks the snapshot doesn't mention. Tasks with no prior local entry (first bootstrap, or a task the renderer has never seen) are always accepted from the snapshot unchanged, so first-load and cold-start behavior is unaffected.

## Slice Rationale

One behavior slice: the renderer's defense-in-depth guard against an outdated snapshot regressing task state. It is kept separate from the backend atomicity fix it complements (a prior PR in this stack) because the two fixes address the same defect at different layers and are each independently reviewable, but `delta.ts` and `useTasks.ts` change together in this single PR because the guard depends on the delta-merge fix and both are proven by one repro sequence.

## Non-goals

No change to the global `streamSequence` watermark gate in `useTasks.ts`. No change to the delta gap-detection/resync logic in `useTasks.ts`. No change to any backend file. No change to workflow-level rollup handling.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- rebase-recreate-task-graph-drift-repro`
- [x] `cd packages/ui && pnpm test -- delta.test`
- [x] `pnpm --filter @invoker/ui test` (full `@invoker/ui` suite, same command as the required "UI Vitest" CI check — 91 files / 842 tests passed)

</details>

## Visual Proof

The defect's trigger is a sub-100ms wire-level race between a delta and an outdated snapshot arriving for the same task. Reproducing that exact interleaving through the live app requires injecting raw `snapshot`/`delta` task-graph stream events out of order; today's e2e fixtures only inject task state through the legitimate backend mutation path (`injectTaskStates`), which cannot construct an out-of-order pair. Building that event-injection harness is explicitly out of scope for this PR — it is the Playwright e2e work planned for step 4 of this stack.

Concrete non-visual proof instead: `packages/ui/src/__tests__/rebase-recreate-task-graph-drift-repro.test.tsx` renders the real `useTasks` hook and drives it through the exact delta/delta/snapshot sequence that causes the drift, asserting the rendered `uiStatus` stays `'running'` instead of regressing to `'pending'`. This fails on the pre-fix code and passes after the fix — see `## Test Plan`.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2fc199334e011d7630243df8567edde459e6cf97`
- Post-revert steps: None
- Data migration? No

</details>
