### PR TITLE
[Guard: diff-atomicity linter cannot detect a same-PR test assertion](1) getting weakened alongside a product-code change

### DIFF
--- a/scripts/lint-pr-diff-atomicity.mjs
+++ b/scripts/lint-pr-diff-atomicity.mjs
@@ -39,6 +39,10 @@ const POLICY = {
     severity: 'warning',
     message: 'A skipped test (.skip) was added; confirm the skip is intentional.',
   },
+  'test-assertion-weakened': {
+    severity: 'fatal',
+    message: 'A test assertion was flipped (negation or expected value changed) in the same diff as a non-test file change; confirm the test still catches the original bug instead of matching a regression.',
+  },
   'unrelated-areas': {
     severity: 'warning',
     message: 'The diff spans multiple unrelated top-level areas; confirm this is one atomic change.',
@@ -133,8 +137,17 @@ function finalizeFile(file) {
     lines[lineNumber - 1] = text;
   }
   file.newContent = lines.join('\n');
+
+  const oldMax = file.oldLineMap.size > 0 ? Math.max(...file.oldLineMap.keys()) : 0;
+  const oldLines = new Array(oldMax).fill('');
+  for (const [lineNumber, text] of file.oldLineMap) {
+    oldLines[lineNumber - 1] = text;
+  }
+  file.oldContent = oldLines.join('\n');
+
   file.category = classifyPath(file.path);
   delete file.newLineMap;
+  delete file.oldLineMap;
   return file;
 }
 
@@ -143,6 +156,7 @@ export function parseUnifiedDiff(diffText, source = 'diff') {
   const lines = (diffText || '').split('\n');
   let current = null;
   let counter = 0;
+  let oldCounter = 0;
 
   const start = (header) => {
     const finalized = finalizeFile(current);
@@ -157,12 +171,16 @@ export function parseUnifiedDiff(diffText, source = 'diff') {
       path: '',
       changeType: 'modify',
       addedLineNumbers: new Set(),
+      removedLineNumbers: new Set(),
       removedCount: 0,
       newLineMap: new Map(),
+      oldLineMap: new Map(),
       newContent: '',
+      oldContent: '',
       category: 'other',
     };
     counter = 0;
+    oldCounter = 0;
   };
 
   for (const line of lines) {
@@ -202,11 +220,12 @@ export function parseUnifiedDiff(diffText, source = 'diff') {
       continue;
     }
     if (line.startsWith('@@')) {
-      const match = /@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
-      counter = match ? Number.parseInt(match[1], 10) : 0;
+      const match = /@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+      oldCounter = match ? Number.parseInt(match[1], 10) : 0;
+      counter = match ? Number.parseInt(match[2], 10) : 0;
       continue;
     }
-    if (counter < 1) {
+    if (counter < 1 && oldCounter < 1) {
       continue;
     }
     if (line.startsWith('+') && !line.startsWith('+++')) {
@@ -216,12 +235,17 @@ export function parseUnifiedDiff(diffText, source = 'diff') {
       continue;
     }
     if (line.startsWith('-') && !line.startsWith('---')) {
+      current.oldLineMap.set(oldCounter, line.slice(1));
+      current.removedLineNumbers.add(oldCounter);
       current.removedCount += 1;
+      oldCounter += 1;
       continue;
     }
     if (line.startsWith(' ')) {
       current.newLineMap.set(counter, line.slice(1));
+      current.oldLineMap.set(oldCounter, line.slice(1));
       counter += 1;
+      oldCounter += 1;
     }
   }
 
@@ -269,6 +293,80 @@ function collectAstFindings(file) {
   };
 
   walk(sourceFile);
+  return findings;
+}
+
+function analyzeAssertionCall(ts, node) {
+  if (!ts.isCallExpression(node) || !ts.isPropertyAccessExpression(node.expression) || !ts.isIdentifier(node.expression.name)) {
+    return null;
+  }
+  const matcherName = node.expression.name.text;
+  const matcherArgs = node.arguments.map((arg) => arg.getText()).join(', ');
+
+  let cursor = node.expression.expression;
+  let negated = false;
+  while (ts.isPropertyAccessExpression(cursor) && ts.isIdentifier(cursor.name)) {
+    if (cursor.name.text === 'not') {
+      negated = true;
+    }
+    cursor = cursor.expression;
+  }
+  if (!ts.isCallExpression(cursor) || !ts.isIdentifier(cursor.expression) || cursor.expression.text !== 'expect') {
+    return null;
+  }
+  const target = cursor.arguments.map((arg) => arg.getText()).join(', ').trim();
+  return { target, matcherName, matcherArgs, negated };
+}
+
+function collectAssertionCalls(file, content, lineNumbers) {
+  if (!CODE_EXTENSIONS.has(path.extname(file.path)) || lineNumbers.size === 0) {
+    return [];
+  }
+  const ts = getTypeScript();
+  const sourceFile = ts.createSourceFile(file.path, content, ts.ScriptTarget.Latest, true, scriptKindFor(ts, file.path));
+  const assertions = [];
+
+  const walk = (node) => {
+    const assertion = analyzeAssertionCall(ts, node);
+    if (assertion) {
+      const lineNumber = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+      if (lineNumbers.has(lineNumber)) {
+        assertions.push({ ...assertion, line: lineNumber });
+      }
+    }
+    ts.forEachChild(node, walk);
+  };
+
+  walk(sourceFile);
+  return assertions;
+}
+
+function collectTestAssertionWeakenedFindings(files) {
+  const hasNonTestFile = files.some((file) => file.category !== 'test' && file.path && file.path !== '/dev/null');
+  if (!hasNonTestFile) {
+    return [];
+  }
+
+  const findings = [];
+  for (const file of files) {
+    if (file.category !== 'test') {
+      continue;
+    }
+    const removedAssertions = collectAssertionCalls(file, file.oldContent, file.removedLineNumbers);
+    if (removedAssertions.length === 0) {
+      continue;
+    }
+    const addedAssertions = collectAssertionCalls(file, file.newContent, file.addedLineNumbers);
+    for (const added of addedAssertions) {
+      const flipped = removedAssertions.some((removed) =>
+        removed.target === added.target
+        && removed.matcherName === added.matcherName
+        && (removed.negated !== added.negated || removed.matcherArgs !== added.matcherArgs));
+      if (flipped) {
+        findings.push(makeFinding('test-assertion-weakened', file.path, added.line, file.source));
+      }
+    }
+  }
   return findings;
 }
 
@@ -366,6 +464,8 @@ export function collectDiffAtomicityFindings(options = {}) {
   for (const file of files) {
     findings.push(...collectAstFindings(file));
   }
+
+  findings.push(...collectTestAssertionWeakenedFindings(files));
 
   const areas = new Set();
   for (const file of files) {

--- a/scripts/test-pr-diff-atomicity.mjs
+++ b/scripts/test-pr-diff-atomicity.mjs
@@ -192,6 +192,74 @@ function kinds(findings) {
   assert.match(formatDiffAtomicityFindings(spreadFindings)[0], /packages\/app/);
 }
 
+// Case 7: a same-PR test-assertion flip alongside a product-code change is fatal.
+{
+  const text = diff([
+    'diff --git a/packages/ui/src/App.tsx b/packages/ui/src/App.tsx',
+    '--- a/packages/ui/src/App.tsx',
+    '+++ b/packages/ui/src/App.tsx',
+    '@@ -1,3 +1,3 @@',
+    ' export function App() {',
+    '-  return null;',
+    '+  return <Banner />;',
+    ' }',
+    'diff --git a/packages/ui/src/App.test.tsx b/packages/ui/src/App.test.tsx',
+    '--- a/packages/ui/src/App.test.tsx',
+    '+++ b/packages/ui/src/App.test.tsx',
+    '@@ -1,3 +1,3 @@',
+    " it('hides banner', () => {",
+    "-  expect(screen.queryByText('Banner')).not.toBeInTheDocument();",
+    "+  expect(screen.queryByText('Banner')).toBeInTheDocument();",
+    ' });',
+  ]);
+  const findings = collectDiffAtomicityFindings({ diffText: text });
+  assert.deepEqual(kinds(findings), ['test-assertion-weakened']);
+  assert.equal(findings[0].severity, 'fatal');
+  assert.equal(findings[0].path, 'packages/ui/src/App.test.tsx');
+  assert.equal(findings[0].line, 2);
+}
+
+// Case 8: the same flipped assertion with only test-file changes does not
+// fire — the policy targets a same-PR product-code + test-flip pairing, not
+// a bare test edit.
+{
+  const text = diff([
+    'diff --git a/packages/ui/src/App.test.tsx b/packages/ui/src/App.test.tsx',
+    '--- a/packages/ui/src/App.test.tsx',
+    '+++ b/packages/ui/src/App.test.tsx',
+    '@@ -1,3 +1,3 @@',
+    " it('hides banner', () => {",
+    "-  expect(screen.queryByText('Banner')).not.toBeInTheDocument();",
+    "+  expect(screen.queryByText('Banner')).toBeInTheDocument();",
+    ' });',
+  ]);
+  assert.deepEqual(collectDiffAtomicityFindings({ diffText: text }), []);
+}
+
+// Case 9: a product-code change alongside a test file change with no
+// assertion flip does not fire.
+{
+  const text = diff([
+    'diff --git a/packages/ui/src/App.tsx b/packages/ui/src/App.tsx',
+    '--- a/packages/ui/src/App.tsx',
+    '+++ b/packages/ui/src/App.tsx',
+    '@@ -1,3 +1,3 @@',
+    ' export function App() {',
+    '-  return null;',
+    '+  return <Banner />;',
+    ' }',
+    'diff --git a/packages/ui/src/App.test.tsx b/packages/ui/src/App.test.tsx',
+    '--- a/packages/ui/src/App.test.tsx',
+    '+++ b/packages/ui/src/App.test.tsx',
+    '@@ -1,3 +1,4 @@',
+    " it('shows banner', () => {",
+    "+  render(<Banner />);",
+    "   expect(screen.getByText('Banner')).toBeInTheDocument();",
+    ' });',
+  ]);
+  assert.deepEqual(collectDiffAtomicityFindings({ diffText: text }), []);
+}
+
 // Temp git case: the git entry path flags a real added debugger and exits 1,
 // and a clean follow-up change passes with the success message on stdout.
 {


### PR DESCRIPTION
## Summary

PR #5067 rewrote `handleDagSurfaceClick` back to a previously-removed, buggy form, and in the same PR flipped its own regression test's assertion to match the reintroduced bug. CI stayed green.

`scripts/lint-pr-diff-atomicity.mjs` already flags focused and skipped tests in a diff. It had no detector for a test assertion getting flipped alongside a product-code change.

This adds a `test-assertion-weakened` policy. It flags a diff that removes an `expect(...)` call and adds back a negation-flipped or literal-flipped one on the same target.

The finding only fires when the same diff also touches a non-test file, as a fatal finding.

## Review Claim

Approve one new POLICY entry and its AST-based detector in `scripts/lint-pr-diff-atomicity.mjs`, proven by three new fixture cases in `scripts/test-pr-diff-atomicity.mjs`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only adds one new POLICY key and its detector. No existing POLICY entry's severity, message, or trigger condition changes, so diffs that don't match the new flip-plus-product-touch pattern keep today's exit code and finding set.

## Slice Rationale

One policy slice: the new detector and its fixture-backed proof, nothing else. No refactor of existing detectors, no CLI surface change.

## Non-goals

Does not refactor existing POLICY entries. Does not add new CLI flags. Does not change how findings are reported to the PR body workflow. Does not touch product code outside `scripts/`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run test:pr-diff-atomicity`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
