### PR TITLE
[Reaper: reclaim stale task worktrees](1) Worker reap pass

### DIFF
--- a/packages/execution-engine/src/__tests__/reaper-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/reaper-reclaim.test.ts
@@ -1,4 +1,7 @@
 import {
+  execFileSync,
+} from 'node:child_process';
+import {
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -16,16 +19,30 @@ import type { RemoteDiskTarget } from '../workers/disk-headroom-monitor.js';
 import {
   AUTOMATION_CHECKOUT_DIRS,
   buildDeletingOrphanReapScript,
+  buildStaleWorktreeReapScript,
   DELETING_ORPHAN_MIN_AGE_MINUTES,
   enforceHourlySnapshotRetention,
   reapDeletingOrphans,
+  reapLocalStaleWorktrees,
   reapStaleAutomationCheckouts,
+  reapStaleWorktrees,
+  STALE_WORKTREE_MIN_AGE_HOURS,
   trimOversizedLogs,
 } from '../workers/reaper-reclaim.js';
 
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execFileSync: vi.fn(),
+  };
+});
+
 const tempDirs: string[] = [];
+const mockedExecFileSync = vi.mocked(execFileSync);
 
 afterEach(() => {
+  mockedExecFileSync.mockReset();
   vi.unstubAllEnvs();
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
@@ -117,6 +134,115 @@ describe('reapDeletingOrphans', () => {
     expect(script).not.toContain('$INVOKER_HOME/worktrees');
     expect(script).not.toContain('$INVOKER_HOME/repos');
     expect(script).not.toContain('TMP_CLEAN');
+  });
+});
+
+describe('reapStaleWorktrees', () => {
+  it('leaves worktree entries younger than forty-eight hours untouched', () => {
+    const { root, home } = makeHome();
+    mkdirSync(join(home, 'repos', 'repoabc123456'), { recursive: true });
+    mkdirSync(join(home, 'worktrees', 'repoabc123456', 'fresh-branch'), { recursive: true });
+
+    const removed = reapLocalStaleWorktrees({ invokerHome: home, userHome: root });
+
+    expect(removed).toEqual([]);
+    expect(existsSync(join(home, 'worktrees', 'repoabc123456', 'fresh-branch'))).toBe(true);
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it('removes stale entries with git worktree remove and prunes once per repo group', () => {
+    const { root, home } = makeHome();
+    const repoHash = 'repoabc123456';
+    const oldA = join(home, 'worktrees', repoHash, 'old-a');
+    const oldB = join(home, 'worktrees', repoHash, 'old-b');
+    mkdirSync(join(home, 'repos', repoHash), { recursive: true });
+    mkdirSync(oldA, { recursive: true });
+    mkdirSync(oldB, { recursive: true });
+    backdate(oldA, (STALE_WORKTREE_MIN_AGE_HOURS + 1) * 60 * 60 * 1000);
+    backdate(oldB, (STALE_WORKTREE_MIN_AGE_HOURS + 2) * 60 * 60 * 1000);
+    mockedExecFileSync.mockImplementation((_cmd, args) => {
+      const argv = args as string[];
+      if (argv[3] === 'remove') rmSync(argv[5]!, { recursive: true, force: true });
+      return Buffer.from('');
+    });
+
+    const removed = reapLocalStaleWorktrees({ invokerHome: home, userHome: root });
+
+    expect(removed.sort()).toEqual([oldA, oldB].sort());
+    expect(existsSync(oldA)).toBe(false);
+    expect(existsSync(oldB)).toBe(false);
+    const calls = mockedExecFileSync.mock.calls.map((call) => call[1] as string[]);
+    expect(calls.filter((args) => args[3] === 'remove')).toHaveLength(2);
+    expect(calls.filter((args) => args[3] === 'prune')).toHaveLength(1);
+    expect(calls.find((args) => args[3] === 'prune')).toEqual([
+      '-C',
+      join(home, 'repos', repoHash),
+      'worktree',
+      'prune',
+    ]);
+  });
+
+  it('falls back to rm -rf when git worktree remove fails', () => {
+    const { root, home } = makeHome();
+    const repoHash = 'repoabc123456';
+    const old = join(home, 'worktrees', repoHash, 'old-fallback');
+    mkdirSync(join(home, 'repos', repoHash), { recursive: true });
+    mkdirSync(old, { recursive: true });
+    backdate(old, (STALE_WORKTREE_MIN_AGE_HOURS + 1) * 60 * 60 * 1000);
+    mockedExecFileSync.mockImplementation((_cmd, args) => {
+      const argv = args as string[];
+      if (argv[3] === 'remove') throw new Error('worktree metadata missing');
+      return Buffer.from('');
+    });
+
+    const removed = reapLocalStaleWorktrees({ invokerHome: home, userHome: root });
+
+    expect(removed).toEqual([old]);
+    expect(existsSync(old)).toBe(false);
+    const calls = mockedExecFileSync.mock.calls.map((call) => call[1] as string[]);
+    expect(calls.filter((args) => args[3] === 'remove')).toHaveLength(1);
+    expect(calls.filter((args) => args[3] === 'prune')).toHaveLength(1);
+  });
+
+  it('builds and runs the age-gated stale-worktree reap script on remote targets', async () => {
+    const { root, home } = makeHome();
+    const target: RemoteDiskTarget = {
+      name: 'remote-1',
+      connection: { host: 'h', user: 'u', sshKeyPath: '/k' },
+      remotePath: '~/.invoker',
+    };
+    const runRemoteScript = vi.fn(async () => 'removed /home/u/.invoker/worktrees/repo/old\n');
+
+    const results = await reapStaleWorktrees({
+      invokerHome: home,
+      userHome: root,
+      remoteTargets: [target],
+      runRemoteScript,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[1]).toMatchObject({
+      ok: true,
+      targetKey: 'ssh:remote-1 ~/.invoker',
+      reason: 'reap-worktrees',
+      detail: 'removed 1',
+    });
+    expect(runRemoteScript).toHaveBeenCalledTimes(1);
+    const script = runRemoteScript.mock.calls[0]?.[1] as unknown as string;
+    expect(script).toContain('INVOKER_HOME=\'~/.invoker\'');
+    expect(script).toContain('Refusing unsafe INVOKER_HOME');
+    expect(script).toContain('find "$INVOKER_HOME/worktrees" -mindepth 2 -maxdepth 2 -type d');
+    expect(script).toContain(`-mmin +${STALE_WORKTREE_MIN_AGE_HOURS * 60}`);
+    expect(script).toContain('git -C "$repo" worktree remove --force "$path"');
+    expect(script).toContain('rm -rf "$path"');
+    expect(script).toContain('git -C "$INVOKER_HOME/repos/$repo_hash" worktree prune');
+  });
+
+  it('does not include the orphan glob in the stale-worktree remote script', () => {
+    const script = buildStaleWorktreeReapScript('~/.invoker', STALE_WORKTREE_MIN_AGE_HOURS);
+    expect(script).toContain('$INVOKER_HOME/worktrees');
+    expect(script).toContain('$INVOKER_HOME/repos/$repo_hash');
+    expect(script).not.toContain("'*.deleting.*'");
   });
 });
 

--- a/packages/execution-engine/src/__tests__/reaper-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/reaper-worker.test.ts
@@ -52,13 +52,20 @@ describe('reaper worker', () => {
     expect(runtime.identity.kind).toBe(REAPER_WORKER_KIND);
   });
 
-  it('calls each of the four checks once per tick and writes one record-keeping entry', async () => {
+  it('calls each of the five checks once per tick and writes one record-keeping entry', async () => {
     const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
     registerReaperWorker(registry);
     expect(registry.get(REAPER_WORKER_KIND)).toBeTruthy();
 
+    const remoteTargets = [
+      { name: 'remote-1', connection: { host: 'h', user: 'u', sshKeyPath: '/k' }, remotePath: '~/.invoker' },
+    ];
     const reapOrphans = vi.fn(async () => [okResult('local /tmp/invoker-home')]);
     const reapCheckouts = vi.fn(() => ['/tmp/invoker-home/mergify-admin-requeue-work/old-item']);
+    const reapWorktrees = vi.fn(async () => [
+      { ...okResult('local /tmp/invoker-home'), reason: 'reap-worktrees', detail: 'removed 2' },
+      { ...okResult('ssh:remote-1 ~/.invoker'), reason: 'reap-worktrees', detail: 'removed 3' },
+    ]);
     const enforceRetention = vi.fn(() => 2);
     const trimLogs = vi.fn(() => ['/tmp/invoker-home/invoker.log']);
     const upsertWorkerAction = vi.fn((row: any) => row);
@@ -66,12 +73,13 @@ describe('reaper worker', () => {
     const runtime = createReaperWorker({
       logger: makeLogger(),
       invokerHome: '/tmp/invoker-home',
-      remoteTargets: [],
+      remoteTargets,
       intervalMs: 0,
       tickOnStart: false,
       store: { upsertWorkerAction },
       reapOrphans,
       reapCheckouts,
+      reapWorktrees,
       enforceRetention,
       trimLogs,
     });
@@ -81,7 +89,7 @@ describe('reaper worker', () => {
     expect(reapOrphans).toHaveBeenCalledTimes(1);
     expect(reapOrphans.mock.calls[0]?.[0]).toMatchObject({
       invokerHome: '/tmp/invoker-home',
-      remoteTargets: [],
+      remoteTargets,
     });
     expect(reapCheckouts).toHaveBeenCalledTimes(1);
     expect(reapCheckouts.mock.calls[0]?.[0]).toMatchObject({ invokerHome: '/tmp/invoker-home' });
@@ -89,6 +97,11 @@ describe('reaper worker', () => {
     expect(enforceRetention.mock.calls[0]?.[0]).toBe('/tmp/invoker-home');
     expect(trimLogs).toHaveBeenCalledTimes(1);
     expect(trimLogs.mock.calls[0]?.[0]).toMatchObject({ invokerHome: '/tmp/invoker-home' });
+    expect(reapWorktrees).toHaveBeenCalledTimes(1);
+    expect(reapWorktrees.mock.calls[0]?.[0]).toMatchObject({
+      invokerHome: '/tmp/invoker-home',
+      remoteTargets,
+    });
 
     expect(upsertWorkerAction).toHaveBeenCalledTimes(1);
     expect(upsertWorkerAction.mock.calls[0]?.[0]).toMatchObject({
@@ -103,6 +116,14 @@ describe('reaper worker', () => {
     expect(upsertWorkerAction.mock.calls[0]?.[0].summary).toContain('checkouts removed 1');
     expect(upsertWorkerAction.mock.calls[0]?.[0].summary).toContain('snapshots pruned 2');
     expect(upsertWorkerAction.mock.calls[0]?.[0].summary).toContain('logs trimmed 1');
+    expect(upsertWorkerAction.mock.calls[0]?.[0].summary).toContain('worktrees removed 5');
+    expect(upsertWorkerAction.mock.calls[0]?.[0].payload).toMatchObject({
+      worktreesRemoved: 5,
+      worktreeResults: [
+        { targetKey: 'local /tmp/invoker-home', reason: 'reap-worktrees', detail: 'removed 2' },
+        { targetKey: 'ssh:remote-1 ~/.invoker', reason: 'reap-worktrees', detail: 'removed 3' },
+      ],
+    });
   });
 
   it('records a failed pass when an orphan target fails', async () => {
@@ -124,6 +145,7 @@ describe('reaper worker', () => {
       store: { upsertWorkerAction },
       reapOrphans: vi.fn(async () => [okResult('local /tmp/invoker-home'), failedResult]),
       reapCheckouts: vi.fn(() => []),
+      reapWorktrees: vi.fn(async () => []),
       enforceRetention: vi.fn(() => 0),
       trimLogs: vi.fn(() => []),
     });

--- a/packages/execution-engine/src/workers/reaper-reclaim.ts
+++ b/packages/execution-engine/src/workers/reaper-reclaim.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import {
   closeSync,
   existsSync,
@@ -34,6 +35,8 @@ export const AUTOMATION_CHECKOUT_DIRS = [
 
 export const AUTOMATION_CHECKOUT_MIN_AGE_HOURS = 48;
 
+export const STALE_WORKTREE_MIN_AGE_HOURS = 48;
+
 export const LOG_TRIM_MAX_BYTES = 100 * 1024 * 1024;
 export const LOG_TRIM_KEEP_BYTES = 20 * 1024 * 1024;
 export const REAPER_LOG_SUFFIX = '.log';
@@ -47,6 +50,14 @@ function entryAgeMs(path: string, nowMs: number): number | null {
     return nowMs - statSync(path).mtimeMs;
   } catch {
     return null;
+  }
+}
+
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
   }
 }
 
@@ -211,6 +222,237 @@ export async function reapDeletingOrphans(opts: {
   for (const target of opts.remoteTargets ?? []) {
     results.push(
       await reapRemoteDeletingOrphans({
+        target,
+        logger: opts.logger,
+        runRemoteScript: opts.runRemoteScript,
+      }),
+    );
+  }
+  return results;
+}
+
+export function reapLocalStaleWorktrees(opts: {
+  invokerHome: string;
+  logger?: Logger;
+  userHome?: string;
+  nowMs?: number;
+}): string[] {
+  const userHome = opts.userHome ?? homedir();
+  const home = expandTildeHome(opts.invokerHome, userHome);
+  if (!isSafeInvokerHome(home, userHome)) return [];
+
+  const worktreesRoot = join(home, 'worktrees');
+  if (!isDirectory(worktreesRoot)) return [];
+
+  const nowMs = opts.nowMs ?? Date.now();
+  const minAgeMs = STALE_WORKTREE_MIN_AGE_HOURS * 60 * 60 * 1000;
+  const staleByRepoHash = new Map<string, string[]>();
+
+  let repoHashes: string[];
+  try {
+    repoHashes = readdirSync(worktreesRoot);
+  } catch {
+    return [];
+  }
+
+  for (const repoHash of repoHashes) {
+    const repoWorktreeRoot = join(worktreesRoot, repoHash);
+    if (!isDirectory(repoWorktreeRoot)) continue;
+
+    let branches: string[];
+    try {
+      branches = readdirSync(repoWorktreeRoot);
+    } catch {
+      continue;
+    }
+
+    for (const branch of branches) {
+      const path = join(repoWorktreeRoot, branch);
+      if (!isDirectory(path)) continue;
+      const ageMs = entryAgeMs(path, nowMs);
+      if (ageMs === null || ageMs < minAgeMs) continue;
+      const paths = staleByRepoHash.get(repoHash) ?? [];
+      paths.push(path);
+      staleByRepoHash.set(repoHash, paths);
+    }
+  }
+
+  const removed: string[] = [];
+  for (const [repoHash, paths] of staleByRepoHash) {
+    const repoPath = join(home, 'repos', repoHash);
+    for (const path of paths) {
+      try {
+        execFileSync('git', ['-C', repoPath, 'worktree', 'remove', '--force', path], {
+          stdio: 'ignore',
+        });
+      } catch (err) {
+        opts.logger?.warn?.(`[reaper] git worktree remove failed for ${path}: ${errorDetail(err)}`, {
+          module: 'reaper',
+        });
+        try {
+          rmSync(path, { recursive: true, force: true });
+        } catch (rmErr) {
+          opts.logger?.warn?.(`[reaper] failed to remove stale worktree ${path}: ${errorDetail(rmErr)}`, {
+            module: 'reaper',
+          });
+          continue;
+        }
+      }
+      removed.push(path);
+      opts.logger?.info?.(`[reaper] removed stale worktree ${path}`, { module: 'reaper' });
+    }
+
+    try {
+      execFileSync('git', ['-C', repoPath, 'worktree', 'prune'], { stdio: 'ignore' });
+    } catch (err) {
+      opts.logger?.warn?.(`[reaper] git worktree prune failed for ${repoPath}: ${errorDetail(err)}`, {
+        module: 'reaper',
+      });
+    }
+  }
+  return removed;
+}
+
+export function buildStaleWorktreeReapScript(invokerHome: string, minAgeHours: number): string {
+  const homeQ = shellPosixSingleQuote(invokerHome);
+  const minAgeMinutes = Math.floor(minAgeHours * 60);
+  return `set +e
+INVOKER_HOME=${homeQ}
+${bashNormalizeTildePath('INVOKER_HOME')}
+case "$INVOKER_HOME" in
+  ""|"/"|"$HOME"|"~")
+    echo "Refusing unsafe INVOKER_HOME: $INVOKER_HOME" >&2
+    exit 64
+    ;;
+esac
+REPOS_SEEN=$(mktemp "\${TMPDIR:-/tmp}/invoker-stale-worktrees.XXXXXX") || exit 1
+trap 'rm -f "$REPOS_SEEN"' EXIT
+if [ -d "$INVOKER_HOME/worktrees" ]; then
+  find "$INVOKER_HOME/worktrees" -mindepth 2 -maxdepth 2 -type d -mmin +${minAgeMinutes} \\
+    -print0 2>/dev/null | while IFS= read -r -d '' path; do
+    rel=\${path#"$INVOKER_HOME/worktrees/"}
+    repo_hash=\${rel%%/*}
+    case "$repo_hash" in
+      ""|"."|".."|*/*)
+        continue
+        ;;
+    esac
+    repo="$INVOKER_HOME/repos/$repo_hash"
+    if git -C "$repo" worktree remove --force "$path" >/dev/null 2>&1 || rm -rf "$path" >/dev/null 2>&1; then
+      if [ ! -e "$path" ]; then
+        echo "removed $path"
+        printf '%s\\n' "$repo_hash" >> "$REPOS_SEEN"
+      fi
+    fi
+  done
+fi
+if [ -s "$REPOS_SEEN" ]; then
+  sort -u "$REPOS_SEEN" | while IFS= read -r repo_hash; do
+    [ -n "$repo_hash" ] || continue
+    git -C "$INVOKER_HOME/repos/$repo_hash" worktree prune >/dev/null 2>&1 || true
+  done
+fi
+exit 0
+`;
+}
+
+export async function reapRemoteStaleWorktrees(opts: {
+  target: RemoteDiskTarget;
+  logger?: Logger;
+  runRemoteScript?: (target: RemoteDiskTarget, script: string) => Promise<string>;
+}): Promise<DiskCleanupResult> {
+  const targetKey = `ssh:${opts.target.name} ${opts.target.remotePath}`;
+  if (!isSafeRemoteInvokerHomePath(opts.target.remotePath)) {
+    return {
+      targetKey,
+      ok: false,
+      reason: 'path-guard',
+      detail: opts.target.remotePath,
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
+    };
+  }
+
+  const script = buildStaleWorktreeReapScript(
+    opts.target.remotePath,
+    STALE_WORKTREE_MIN_AGE_HOURS,
+  );
+  const run = opts.runRemoteScript ?? defaultRunRemoteStaleWorktreeReap;
+  try {
+    const output = await run(opts.target, script);
+    const removed = output
+      .split('\n')
+      .filter((line) => line.trimStart().startsWith('removed ')).length;
+    return {
+      targetKey,
+      ok: true,
+      reason: 'reap-worktrees',
+      detail: `removed ${removed}`,
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
+    };
+  } catch (err) {
+    const detail = errorDetail(err);
+    opts.logger?.error?.(`[reaper] remote stale worktree reap failed ${targetKey}: ${detail}`, {
+      module: 'reaper',
+      targetKey,
+    });
+    return {
+      targetKey,
+      ok: false,
+      reason: 'cleanup-error',
+      detail,
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
+    };
+  }
+}
+
+function defaultRunRemoteStaleWorktreeReap(
+  target: RemoteDiskTarget,
+  script: string,
+): Promise<string> {
+  const sshArgs = buildSshConnectionArgs(target.connection, { batchMode: true });
+  return execRemoteCapture({
+    sshArgs,
+    script,
+    phase: `reaper-worktrees:${target.name}`,
+  });
+}
+
+export async function reapStaleWorktrees(opts: {
+  invokerHome: string;
+  remoteTargets?: RemoteDiskTarget[];
+  logger?: Logger;
+  userHome?: string;
+  nowMs?: number;
+  runRemoteScript?: (target: RemoteDiskTarget, script: string) => Promise<string>;
+}): Promise<DiskCleanupResult[]> {
+  const targetKey = `local ${opts.invokerHome}`;
+  const userHome = opts.userHome ?? homedir();
+  const home = expandTildeHome(opts.invokerHome, userHome);
+  const localResult: DiskCleanupResult = !isSafeInvokerHome(home, userHome)
+    ? {
+        targetKey,
+        ok: false,
+        reason: 'path-guard',
+        detail: home,
+        protectedSkipCount: 0,
+        protectedSkipBytes: 0,
+      }
+    : {
+        targetKey,
+        ok: true,
+        reason: 'reap-worktrees',
+        detail: `removed ${reapLocalStaleWorktrees(opts).length}`,
+        protectedSkipCount: 0,
+        protectedSkipBytes: 0,
+      };
+
+  const results: DiskCleanupResult[] = [localResult];
+  for (const target of opts.remoteTargets ?? []) {
+    results.push(
+      await reapRemoteStaleWorktrees({
         target,
         logger: opts.logger,
         runRemoteScript: opts.runRemoteScript,

--- a/packages/execution-engine/src/workers/reaper-worker.ts
+++ b/packages/execution-engine/src/workers/reaper-worker.ts
@@ -11,6 +11,7 @@ import {
   enforceHourlySnapshotRetention,
   reapDeletingOrphans,
   reapStaleAutomationCheckouts,
+  reapStaleWorktrees,
   trimOversizedLogs,
 } from './reaper-reclaim.js';
 
@@ -37,6 +38,8 @@ export interface ReaperWorkerOptions {
   reapOrphans?: typeof reapDeletingOrphans;
   /** Test seam: override the stale automation-checkout reap. */
   reapCheckouts?: typeof reapStaleAutomationCheckouts;
+  /** Test seam: override stale task-worktree reap. */
+  reapWorktrees?: typeof reapStaleWorktrees;
   /** Test seam: override snapshot-retention enforcement. */
   enforceRetention?: typeof enforceHourlySnapshotRetention;
   /** Test seam: override oversized-log trimming. */
@@ -48,6 +51,7 @@ export interface ReaperWorkerOptions {
 export function createReaperWorker(options: ReaperWorkerOptions): WorkerRuntime {
   const reapOrphans = options.reapOrphans ?? reapDeletingOrphans;
   const reapCheckouts = options.reapCheckouts ?? reapStaleAutomationCheckouts;
+  const reapWorktrees = options.reapWorktrees ?? reapStaleWorktrees;
   const enforceRetention = options.enforceRetention ?? enforceHourlySnapshotRetention;
   const trimLogs = options.trimLogs ?? trimOversizedLogs;
 
@@ -77,12 +81,22 @@ export function createReaperWorker(options: ReaperWorkerOptions): WorkerRuntime 
         invokerHome: options.invokerHome,
         logger: options.logger,
       });
+      const worktreeResults = await reapWorktrees({
+        invokerHome: options.invokerHome,
+        remoteTargets: options.remoteTargets ?? [],
+        logger: options.logger,
+      });
+      const worktreesRemoved = worktreeResults.reduce((sum, result) => {
+        const match = result.detail?.match(/^removed (\d+)$/);
+        return sum + (match ? Number.parseInt(match[1] ?? '0', 10) : 0);
+      }, 0);
 
-      const failed = orphanResults.filter((result) => !result.ok);
+      const orphanFailed = orphanResults.filter((result) => !result.ok);
+      const failed = [...orphanResults, ...worktreeResults].filter((result) => !result.ok);
       const summary =
-        `Reaper pass: orphan targets ${orphanResults.length - failed.length}/${orphanResults.length} ok, `
+        `Reaper pass: orphan targets ${orphanResults.length - orphanFailed.length}/${orphanResults.length} ok, `
         + `checkouts removed ${checkoutsRemoved.length}, snapshots pruned ${snapshotsPruned}, `
-        + `logs trimmed ${logsTrimmed.length}`;
+        + `logs trimmed ${logsTrimmed.length}, worktrees removed ${worktreesRemoved}`;
 
       if (options.store) {
         recordWorkerDecisionRow(options.store, {
@@ -99,6 +113,8 @@ export function createReaperWorker(options: ReaperWorkerOptions): WorkerRuntime 
             checkoutsRemoved,
             snapshotsPruned,
             logsTrimmed,
+            worktreeResults,
+            worktreesRemoved,
           },
           incrementAttempt: true,
         });
@@ -114,7 +130,7 @@ export function registerReaperWorker(
 ): WorkerRegistry<WorkerRuntimeDependencies> {
   registry.register({
     kind: REAPER_WORKER_KIND,
-    note: 'Reaps orphaned .deleting dirs, stale automation checkouts, excess hourly snapshots, and oversized logs on an interval.',
+    note: 'Reaps orphaned .deleting dirs, stale automation checkouts, stale task worktrees, excess hourly snapshots, and oversized logs on an interval.',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
       createReaperWorker({
         logger: deps.logger,


### PR DESCRIPTION
## Summary

The reaper worker now clears old task worktree directories left behind after completed task attempts.

This covers the local invoker home and the same SSH-managed remote targets already passed into the reaper tick.

The behavior addresses the disk-growth failure seen on digital_ocean_7, where old task worktrees accumulated indefinitely.

## Review Claim

The reaper worker now reclaims idle task worktrees on local and SSH-managed hosts during its normal tick.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only task worktree directories under `<invokerHome>/worktrees/<repoHash>/<branch>` older than `STALE_WORKTREE_MIN_AGE_HOURS` are candidates.

The age floor is 48 hours. Live task paths include attempt id and content hash, so active attempts do not share those old paths.

The worker still does not read or mutate persistence state. It only routes an additional reap pass through the existing worker tick.

## Slice Rationale

The reclaim function and worker wiring land together because neither has independent runtime value alone.

The proof-only Invoker tasks produced no source diff, so they are represented here as test evidence instead of empty PR slices.

## Non-goals

No change to `INVOKER_ENABLE_WORKSPACE_CLEANUP`.

No change to `RepoPool.maxWorktrees` admission behavior.

No DB or persistence access is added to the reaper worker.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test`

```text
 Test Files  120 passed (120)
      Tests  1573 passed | 1 skipped (1574)
```

- [x] `pnpm run check:types`

```text
> invoker@0.0.10 check:types /Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786410650866-2-I9VUFW
> tsc -p tsconfig.typecheck.json
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 7da79b387`
- Post-revert steps: None.
- Data migration? No.

</details>
