### PR TITLE
[Guard: PR body validator cannot check a guarded-behavior sentinel comment](1) against the PR's own Safety Invariant/Non-goals claims - Add registry check

### DIFF
--- a/scripts/lint-pr-diff-atomicity.mjs
+++ b/scripts/lint-pr-diff-atomicity.mjs
@@ -39,6 +39,10 @@ const POLICY = {
     severity: 'warning',
     message: 'A skipped test (.skip) was added; confirm the skip is intentional.',
   },
+  'test-assertion-weakened': {
+    severity: 'fatal',
+    message: 'A test assertion was flipped (negation or expected value changed) in the same diff as a non-test file change; confirm the test still catches the original bug instead of matching a regression.',
+  },
   'unrelated-areas': {
     severity: 'warning',
     message: 'The diff spans multiple unrelated top-level areas; confirm this is one atomic change.',
@@ -133,8 +137,17 @@ function finalizeFile(file) {
     lines[lineNumber - 1] = text;
   }
   file.newContent = lines.join('\n');
+
+  const oldMax = file.oldLineMap.size > 0 ? Math.max(...file.oldLineMap.keys()) : 0;
+  const oldLines = new Array(oldMax).fill('');
+  for (const [lineNumber, text] of file.oldLineMap) {
+    oldLines[lineNumber - 1] = text;
+  }
+  file.oldContent = oldLines.join('\n');
+
   file.category = classifyPath(file.path);
   delete file.newLineMap;
+  delete file.oldLineMap;
   return file;
 }
 
@@ -143,6 +156,7 @@ export function parseUnifiedDiff(diffText, source = 'diff') {
   const lines = (diffText || '').split('\n');
   let current = null;
   let counter = 0;
+  let oldCounter = 0;
 
   const start = (header) => {
     const finalized = finalizeFile(current);
@@ -157,12 +171,16 @@ export function parseUnifiedDiff(diffText, source = 'diff') {
       path: '',
       changeType: 'modify',
       addedLineNumbers: new Set(),
+      removedLineNumbers: new Set(),
       removedCount: 0,
       newLineMap: new Map(),
+      oldLineMap: new Map(),
       newContent: '',
+      oldContent: '',
       category: 'other',
     };
     counter = 0;
+    oldCounter = 0;
   };
 
   for (const line of lines) {
@@ -202,11 +220,12 @@ export function parseUnifiedDiff(diffText, source = 'diff') {
       continue;
     }
     if (line.startsWith('@@')) {
-      const match = /@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
-      counter = match ? Number.parseInt(match[1], 10) : 0;
+      const match = /@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+      oldCounter = match ? Number.parseInt(match[1], 10) : 0;
+      counter = match ? Number.parseInt(match[2], 10) : 0;
       continue;
     }
-    if (counter < 1) {
+    if (counter < 1 && oldCounter < 1) {
       continue;
     }
     if (line.startsWith('+') && !line.startsWith('+++')) {
@@ -216,12 +235,17 @@ export function parseUnifiedDiff(diffText, source = 'diff') {
       continue;
     }
     if (line.startsWith('-') && !line.startsWith('---')) {
+      current.oldLineMap.set(oldCounter, line.slice(1));
+      current.removedLineNumbers.add(oldCounter);
       current.removedCount += 1;
+      oldCounter += 1;
       continue;
     }
     if (line.startsWith(' ')) {
       current.newLineMap.set(counter, line.slice(1));
+      current.oldLineMap.set(oldCounter, line.slice(1));
       counter += 1;
+      oldCounter += 1;
     }
   }
 
@@ -269,6 +293,80 @@ function collectAstFindings(file) {
   };
 
   walk(sourceFile);
+  return findings;
+}
+
+function analyzeAssertionCall(ts, node) {
+  if (!ts.isCallExpression(node) || !ts.isPropertyAccessExpression(node.expression) || !ts.isIdentifier(node.expression.name)) {
+    return null;
+  }
+  const matcherName = node.expression.name.text;
+  const matcherArgs = node.arguments.map((arg) => arg.getText()).join(', ');
+
+  let cursor = node.expression.expression;
+  let negated = false;
+  while (ts.isPropertyAccessExpression(cursor) && ts.isIdentifier(cursor.name)) {
+    if (cursor.name.text === 'not') {
+      negated = true;
+    }
+    cursor = cursor.expression;
+  }
+  if (!ts.isCallExpression(cursor) || !ts.isIdentifier(cursor.expression) || cursor.expression.text !== 'expect') {
+    return null;
+  }
+  const target = cursor.arguments.map((arg) => arg.getText()).join(', ').trim();
+  return { target, matcherName, matcherArgs, negated };
+}
+
+function collectAssertionCalls(file, content, lineNumbers) {
+  if (!CODE_EXTENSIONS.has(path.extname(file.path)) || lineNumbers.size === 0) {
+    return [];
+  }
+  const ts = getTypeScript();
+  const sourceFile = ts.createSourceFile(file.path, content, ts.ScriptTarget.Latest, true, scriptKindFor(ts, file.path));
+  const assertions = [];
+
+  const walk = (node) => {
+    const assertion = analyzeAssertionCall(ts, node);
+    if (assertion) {
+      const lineNumber = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+      if (lineNumbers.has(lineNumber)) {
+        assertions.push({ ...assertion, line: lineNumber });
+      }
+    }
+    ts.forEachChild(node, walk);
+  };
+
+  walk(sourceFile);
+  return assertions;
+}
+
+function collectTestAssertionWeakenedFindings(files) {
+  const hasNonTestFile = files.some((file) => file.category !== 'test' && file.path && file.path !== '/dev/null');
+  if (!hasNonTestFile) {
+    return [];
+  }
+
+  const findings = [];
+  for (const file of files) {
+    if (file.category !== 'test') {
+      continue;
+    }
+    const removedAssertions = collectAssertionCalls(file, file.oldContent, file.removedLineNumbers);
+    if (removedAssertions.length === 0) {
+      continue;
+    }
+    const addedAssertions = collectAssertionCalls(file, file.newContent, file.addedLineNumbers);
+    for (const added of addedAssertions) {
+      const flipped = removedAssertions.some((removed) =>
+        removed.target === added.target
+        && removed.matcherName === added.matcherName
+        && (removed.negated !== added.negated || removed.matcherArgs !== added.matcherArgs));
+      if (flipped) {
+        findings.push(makeFinding('test-assertion-weakened', file.path, added.line, file.source));
+      }
+    }
+  }
   return findings;
 }
 
@@ -366,6 +464,8 @@ export function collectDiffAtomicityFindings(options = {}) {
   for (const file of files) {
     findings.push(...collectAstFindings(file));
   }
+
+  findings.push(...collectTestAssertionWeakenedFindings(files));
 
   const areas = new Set();
   for (const file of files) {

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -1345,4 +1345,50 @@ assert(
   `a PR body whose Visual Proof section merely mentions "preload" should pass with a static screenshot: ${preloadRegressionErrors.join('; ')}`,
 );
 
+const guardedBehaviorTouchingDiff = `diff --git a/packages/ui/src/App.tsx b/packages/ui/src/App.tsx
+--- a/packages/ui/src/App.tsx
++++ b/packages/ui/src/App.tsx
+@@ -10,7 +10,7 @@
+   // guarded-behavior: dag-surface-background-click-noop — see #4982
+   const handleDagSurfaceClick = useCallback(() => {
+-    if (contextMenu || workflowContextMenu) {
++    if (contextMenu) {
+       setContextMenu(null);
+       setWorkflowContextMenu(null);
+     }
+   }, [contextMenu, workflowContextMenu]);
+`;
+
+const guardedBehaviorNonTouchingDiff = `diff --git a/packages/ui/src/Other.tsx b/packages/ui/src/Other.tsx
+--- a/packages/ui/src/Other.tsx
++++ b/packages/ui/src/Other.tsx
+@@ -1,3 +1,3 @@
+   const label = 'sidebar';
+-  const count = 1;
++  const count = 2;
+   return label;
+`;
+
+const guardedBehaviorOmittedIdErrors = await validatePrBody(validMinimal, { diffText: guardedBehaviorTouchingDiff });
+assert(
+  guardedBehaviorOmittedIdErrors.some((error) => error.includes('Guarded behavior "dag-surface-background-click-noop"') && error.includes('not mentioned in ## Safety Invariant or ## Non-goals')),
+  'a diff touching a guarded-behavior marker line should fail when the PR body omits the marker id',
+);
+
+const guardedBehaviorClaimedBody = validMinimal.replace(
+  'Only the refresh path changes.',
+  'Only the refresh path changes. dag-surface-background-click-noop stays a no-op.',
+);
+const guardedBehaviorClaimedErrors = await validatePrBody(guardedBehaviorClaimedBody, { diffText: guardedBehaviorTouchingDiff });
+assert(
+  !guardedBehaviorClaimedErrors.some((error) => error.includes('Guarded behavior "dag-surface-background-click-noop"')),
+  'a diff touching a guarded-behavior marker line should pass when the PR body names the marker id in Safety Invariant or Non-goals',
+);
+
+const guardedBehaviorNonTouchingErrors = await validatePrBody(validMinimal, { diffText: guardedBehaviorNonTouchingDiff });
+assert(
+  !guardedBehaviorNonTouchingErrors.some((error) => error.includes('Guarded behavior')),
+  'a diff that does not touch any guarded-behavior marker line should have no effect regardless of PR body content',
+);
+
 console.log('OK: PR body validator checks passed');

--- a/scripts/test-pr-diff-atomicity.mjs
+++ b/scripts/test-pr-diff-atomicity.mjs
@@ -192,6 +192,74 @@ function kinds(findings) {
   assert.match(formatDiffAtomicityFindings(spreadFindings)[0], /packages\/app/);
 }
 
+// Case 7: a same-PR test-assertion flip alongside a product-code change is fatal.
+{
+  const text = diff([
+    'diff --git a/packages/ui/src/App.tsx b/packages/ui/src/App.tsx',
+    '--- a/packages/ui/src/App.tsx',
+    '+++ b/packages/ui/src/App.tsx',
+    '@@ -1,3 +1,3 @@',
+    ' export function App() {',
+    '-  return null;',
+    '+  return <Banner />;',
+    ' }',
+    'diff --git a/packages/ui/src/App.test.tsx b/packages/ui/src/App.test.tsx',
+    '--- a/packages/ui/src/App.test.tsx',
+    '+++ b/packages/ui/src/App.test.tsx',
+    '@@ -1,3 +1,3 @@',
+    " it('hides banner', () => {",
+    "-  expect(screen.queryByText('Banner')).not.toBeInTheDocument();",
+    "+  expect(screen.queryByText('Banner')).toBeInTheDocument();",
+    ' });',
+  ]);
+  const findings = collectDiffAtomicityFindings({ diffText: text });
+  assert.deepEqual(kinds(findings), ['test-assertion-weakened']);
+  assert.equal(findings[0].severity, 'fatal');
+  assert.equal(findings[0].path, 'packages/ui/src/App.test.tsx');
+  assert.equal(findings[0].line, 2);
+}
+
+// Case 8: the same flipped assertion with only test-file changes does not
+// fire — the policy targets a same-PR product-code + test-flip pairing, not
+// a bare test edit.
+{
+  const text = diff([
+    'diff --git a/packages/ui/src/App.test.tsx b/packages/ui/src/App.test.tsx',
+    '--- a/packages/ui/src/App.test.tsx',
+    '+++ b/packages/ui/src/App.test.tsx',
+    '@@ -1,3 +1,3 @@',
+    " it('hides banner', () => {",
+    "-  expect(screen.queryByText('Banner')).not.toBeInTheDocument();",
+    "+  expect(screen.queryByText('Banner')).toBeInTheDocument();",
+    ' });',
+  ]);
+  assert.deepEqual(collectDiffAtomicityFindings({ diffText: text }), []);
+}
+
+// Case 9: a product-code change alongside a test file change with no
+// assertion flip does not fire.
+{
+  const text = diff([
+    'diff --git a/packages/ui/src/App.tsx b/packages/ui/src/App.tsx',
+    '--- a/packages/ui/src/App.tsx',
+    '+++ b/packages/ui/src/App.tsx',
+    '@@ -1,3 +1,3 @@',
+    ' export function App() {',
+    '-  return null;',
+    '+  return <Banner />;',
+    ' }',
+    'diff --git a/packages/ui/src/App.test.tsx b/packages/ui/src/App.test.tsx',
+    '--- a/packages/ui/src/App.test.tsx',
+    '+++ b/packages/ui/src/App.test.tsx',
+    '@@ -1,3 +1,4 @@',
+    " it('shows banner', () => {",
+    "+  render(<Banner />);",
+    "   expect(screen.getByText('Banner')).toBeInTheDocument();",
+    ' });',
+  ]);
+  assert.deepEqual(collectDiffAtomicityFindings({ diffText: text }), []);
+}
+
 // Temp git case: the git entry path flags a real added debugger and exits 1,
 // and a clean follow-up change passes with the success message on stdout.
 {

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { readFileSync } from 'node:fs';
-import { collectDiffAtomicityFindings, formatDiffAtomicityFindings } from './lint-pr-diff-atomicity.mjs';
+import { collectDiffAtomicityFindings, formatDiffAtomicityFindings, parseUnifiedDiff } from './lint-pr-diff-atomicity.mjs';
 import {
   formatReviewUnits,
   getLabelSection,
@@ -316,6 +316,47 @@ export function validatePrScope({ changedFiles = [], reviewLane = '', body = '' 
   return errors;
 }
 
+const GUARDED_BEHAVIOR_MARKER_PATTERN = /\/\/\s*guarded-behavior:\s*([A-Za-z0-9][\w-]*)/;
+
+export function collectGuardedBehaviorMarkers(diffText) {
+  if (!diffText) return [];
+
+  const markers = [];
+  const seen = new Set();
+  for (const file of parseUnifiedDiff(diffText)) {
+    if (!file.path || file.path === '/dev/null') continue;
+    for (const content of [file.newContent, file.oldContent]) {
+      const lines = content.split('\n');
+      for (let index = 0; index < lines.length; index += 1) {
+        const match = GUARDED_BEHAVIOR_MARKER_PATTERN.exec(lines[index]);
+        if (!match) continue;
+        const line = index + 1;
+        const key = `${file.path}:${line}:${match[1]}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        markers.push({ id: match[1], path: file.path, line });
+      }
+    }
+  }
+  return markers;
+}
+
+export function validateGuardedBehaviorMarkers({ diffText = '', body = '' } = {}) {
+  const markers = collectGuardedBehaviorMarkers(diffText);
+  if (markers.length === 0) return [];
+
+  const claimedIds = `${getSectionBody(body, '## Safety Invariant')}\n${getSectionBody(body, '## Non-goals')}`;
+  const errors = [];
+  for (const marker of markers) {
+    if (!claimedIds.includes(marker.id)) {
+      errors.push(
+        `Guarded behavior "${marker.id}" at ${marker.path}:${marker.line} is touched by this diff but not mentioned in ## Safety Invariant or ## Non-goals. Name it explicitly so reviewers know this decision is intentional.`,
+      );
+    }
+  }
+  return errors;
+}
+
 export function getPrAtomicityBlockers(options = {}) {
   const diffText = options.diffText ?? '';
   if (!diffText) return [];
@@ -504,6 +545,7 @@ export async function validatePrBody(body, options = {}) {
     for (const line of formatDiffAtomicityFindings(fatalFindings)) {
       errors.push(`Diff atomicity violation: ${line}`);
     }
+    errors.push(...validateGuardedBehaviorMarkers({ diffText: options.diffText, body: trimmed }));
   }
 
   return errors;


### PR DESCRIPTION
## Summary

Adds a generic guarded-behavior sentinel registry to `scripts/validate-pr-body.mjs`.

A `// guarded-behavior: <id>` marker can sit beside code that encodes a deliberate decision.

If a diff touches a marked line, the PR body's Safety Invariant or Non-goals section must mention that `<id>`.

This closes the gap where a PR body could claim a safety invariant that its own diff contradicted.

## Review Claim

If a diff touches a line marked `// guarded-behavior: <id>`, `scripts/validate-pr-body.mjs` fails validation unless the PR body's Safety Invariant or Non-goals section mentions `<id>`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only adds one new check function to `scripts/validate-pr-body.mjs`; no other validator rule or exit code for unrelated diffs changes. The registry is generic, keyed by whatever `<id>` appears in the marker, and not hardcoded to one case. No product file changes ship in this slice.

## Slice Rationale

One policy slice: the sentinel-registry check and its fixture-backed proof, nothing else. The real-world sentinel usage ships as its own follow-up slice so this PR stays product-file free and matches the `tooling-policy` review unit.

## Non-goals

No product-file changes, no other validator rule changes, and no retroactive scan of already-merged PRs. `dag-surface-background-click-noop` appears only as literal fixture text inside `scripts/test-pr-body-validator.mjs`; this PR does not touch `packages/ui/src/App.tsx` or change that behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-validator.mjs` -> `OK: PR body validator checks passed`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3d7de3833`
- Post-revert steps: None
- Data migration? No

</details>