### PR TITLE
[Planning UI running indicators](1) sidebar running-task badge

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1843,6 +1843,14 @@ export function App() {
     [tasks, workflows, attentionTaskIdsWithFailures],
   );
   const runningEntries = useMemo(() => getRunningTaskEntries(tasks, workflows, queueStatus), [tasks, workflows, queueStatus]);
+  const runningWorkflowCount = useMemo(() => {
+    const workflowIds = new Set<string>();
+    for (const { task } of runningEntries) {
+      const workflowId = task.config.workflowId;
+      if (workflowId) workflowIds.add(workflowId);
+    }
+    return workflowIds.size;
+  }, [runningEntries]);
   const commandPaletteWorkflowEntries = useMemo(
     () => workflowEntries.slice(0, COMMAND_PALETTE_MAX_ROWS),
     [workflowEntries],
@@ -4986,6 +4994,7 @@ export function App() {
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <LeftStatusColumn
           workflowCount={workflowEntries.length}
+          runningWorkflowCount={runningWorkflowCount}
           attentionCount={attentionEntries.length}
           workerStatus={workerStatus}
           planningSessionCount={planningSessions.length}

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -167,7 +167,7 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Plan graph');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();
   });
@@ -242,7 +242,7 @@ describe('App launch (component)', () => {
     const toggle = screen.getByTestId('sidebar-collapse-toggle');
 
     expect(sidebar.className).toContain('w-16');
-    expect(screen.getByTestId('sidebar-running')).toBeInTheDocument();
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
 
     for (const surface of ['workflows', 'attention', 'workers', 'planning', 'home']) {
       fireEvent.click(screen.getByTestId(`sidebar-${surface}`));

--- a/packages/ui/src/__tests__/command-palette.test.tsx
+++ b/packages/ui/src/__tests__/command-palette.test.tsx
@@ -98,6 +98,14 @@ function Harness({
     () => workflowProgressSurfaces.getRunningTaskEntries(tasks, workflows, null),
     [tasks, workflows],
   );
+  const runningWorkflowCount = useMemo(() => {
+    const workflowIds = new Set<string>();
+    for (const { task } of runningEntries) {
+      const workflowId = task.config.workflowId;
+      if (workflowId) workflowIds.add(workflowId);
+    }
+    return workflowIds.size;
+  }, [runningEntries]);
 
   return (
     <div>
@@ -107,6 +115,7 @@ function Harness({
       <span data-testid="parent-render-count">{renderCount}</span>
       <LeftStatusColumn
         workflowCount={workflowEntries.length}
+        runningWorkflowCount={runningWorkflowCount}
         attentionCount={attentionEntries.length}
         workerStatus={null}
         selectedSurface="home"
@@ -114,6 +123,7 @@ function Harness({
         onSelectSurface={() => {}}
         onToggleCollapsed={() => {}}
         planningSessionCount={0}
+        planningAttentionCount={0}
         onOpenSettings={() => {}}
         theme="dark"
         onToggleTheme={() => {}}
@@ -163,6 +173,25 @@ describe('CommandPalette', () => {
     expect(screen.getByText(/Go home/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Needs Attention/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Workflows/i).length).toBeGreaterThan(0);
+  });
+
+  it('drives the sidebar running workflow indicator from running task entries', () => {
+    const { workflows, tasks } = buildFixtures();
+    const { rerender } = render(<Harness workflows={workflows} tasks={tasks} />);
+
+    expect(screen.getByTestId('sidebar-workflows')).toHaveAttribute('data-tone', 'running');
+    expect(screen.getByTestId('sidebar-running')).toBeVisible();
+    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('1 workflow running');
+
+    const idleTasks = new Map(tasks);
+    idleTasks.set('t-2', {
+      ...tasks.get('t-2')!,
+      status: 'completed',
+    });
+    rerender(<Harness workflows={workflows} tasks={idleTasks} />);
+
+    expect(screen.getByTestId('sidebar-workflows')).toHaveAttribute('data-tone', 'neutral');
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
   });
 
   it('lists workflows and calls onSelectWorkflow on click', async () => {

--- a/packages/ui/src/__tests__/home-visual-snapshots.test.tsx
+++ b/packages/ui/src/__tests__/home-visual-snapshots.test.tsx
@@ -40,7 +40,7 @@ describe('Visual proof snapshots', () => {
     expect(screen.getByTestId('sidebar-planning')).toHaveAccessibleName('Plan graph');
     expect(screen.getByTestId('sidebar-workflows')).toHaveAccessibleName('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveAccessibleName('Needs Attention');
-    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
     expect(screen.getByText('Describe a change, investigate a bug, or ask Invoker to draft a full plan. Review the graph before starting work.')).toBeInTheDocument();
     expect(screen.getByTestId('rail-settings')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -18,6 +18,7 @@ import type { ThemeMode } from '../lib/theme.js';
 
 interface LeftStatusColumnProps {
   workflowCount: number;
+  runningWorkflowCount: number;
   attentionCount: number;
   workerStatus: WorkerStatusSnapshot | null;
   selectedSurface: SidebarSurface;
@@ -64,6 +65,7 @@ function countClass(tone: SourceItem['tone']): string {
 
 export function LeftStatusColumn({
   workflowCount,
+  runningWorkflowCount,
   attentionCount,
   workerStatus,
   selectedSurface,
@@ -83,7 +85,7 @@ export function LeftStatusColumn({
   const sources: SourceItem[] = [
     { key: 'attention', label: 'Needs Attention', count: attentionCount, tone: 'attention', icon: <AttentionIcon className={ICON_CLASS} /> },
     { key: 'workers', label: 'Workers', count: registeredWorkers, tone: activeWorkerActions > 0 ? 'running' : 'neutral', icon: <WorkerIcon className={ICON_CLASS} /> },
-    { key: 'workflows', label: 'Workflows', count: workflowCount, tone: 'neutral', icon: <WorkflowsIcon className={ICON_CLASS} /> },
+    { key: 'workflows', label: 'Workflows', count: workflowCount, tone: runningWorkflowCount > 0 ? 'running' : 'neutral', icon: <WorkflowsIcon className={ICON_CLASS} /> },
   ];
 
   return (
@@ -181,6 +183,7 @@ export function LeftStatusColumn({
               type="button"
               aria-label={source.label}
               data-testid={`sidebar-${source.key}`}
+              data-tone={source.tone}
               data-sidebar-nav-item
               aria-current={selected ? 'page' : undefined}
               onClick={() => onSelectSurface(source.key)}
@@ -212,7 +215,16 @@ export function LeftStatusColumn({
           );
         })}
       </nav>
-      <span data-testid="sidebar-running" hidden aria-hidden="true">Running</span>
+      {runningWorkflowCount > 0 && (
+        <div
+          data-testid="sidebar-running"
+          role="status"
+          aria-live="polite"
+          className={collapsed ? 'sr-only' : 'mt-3 px-2.5 text-[11px] text-muted-foreground'}
+        >
+          {runningWorkflowCount} workflow{runningWorkflowCount === 1 ? '' : 's'} running
+        </div>
+      )}
 
       {!collapsed && (
         <div className="mt-6 flex-1 overflow-y-auto scrollbar-sleek px-2.5 text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

The sidebar now receives the existing running workflow count from App.

When at least one workflow has running tasks, Workflows gets the running tone and the sidebar shows a status line.

The indicator disappears again when no workflow has running tasks.

## Review Claim

The sidebar running-task badge is a real rendering surface driven by existing workflow task state, not a permanently hidden stub.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice only reads `runningEntries` already computed in App and passes a derived count into the sidebar.

It adds no polling, IPC, persistence, or workflow execution behavior.

## Slice Rationale

This is one UI slice: wire the existing running-task data to the existing sidebar indicator and directly affected assertions.

## Non-goals

No new polling hook, no new IPC channel, no task execution behavior changes, no worker indicator behavior changes, and no sidebar redesign.

## Architecture

### Before

App computed `runningEntries` for the command palette, while `LeftStatusColumn` rendered a hardcoded hidden `sidebar-running` stub.

### After

App derives a distinct running workflow count from `runningEntries` and passes it to `LeftStatusColumn` for the Workflows tone and visible status line.

## Visual Proof

![Sidebar showing Workflows running tone and the visible running-workflow status line](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260811-7fbd0a/sidebar-running-workflows.png)

Manually inspected: I opened `/tmp/invoker-pr-proof/sidebar-running-workflows.png` and saw the Workflows row with count `3` plus the visible `2 workflows running` sidebar status line.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- src/__tests__/command-palette.test.tsx src/__tests__/home-visual-snapshots.test.tsx src/__tests__/app-launch.test.tsx`
  - `Test Files  3 passed (3)`
  - `Tests  28 passed (28)`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <published PR merge commit>`
- Post-revert steps: None
- Data migration? No

</details>
