### PR TITLE
Architecture boundary hygiene (1) full dependency-cruiser package coverage

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -123,11 +123,11 @@ module.exports = {
         'Layer 0 packages (contracts, workflow-graph, transport, runtime-domain, runtime-service, shell, ui) should not depend on other workspace packages.',
       severity: 'error',
       from: {
-        path: '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+        path: '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|npm-cli|npm-slack|npm-ui|svc-api|web-app)/',
       },
       to: {
         path: '^packages/',
-        pathNot: '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+        pathNot: '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|npm-cli|npm-slack|npm-ui|svc-api|web-app)/',
       },
     },
     {
@@ -142,7 +142,7 @@ module.exports = {
         path: '^packages/',
         pathNot: [
           '^packages/(workflow-core|protocol|runtime-adapters|graph)/',
-          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|npm-cli|npm-slack|npm-ui|svc-api|web-app)/',
         ],
       },
     },
@@ -159,7 +159,7 @@ module.exports = {
         pathNot: [
           '^packages/(data-store|persistence|core)/',
           '^packages/(workflow-core|protocol|runtime-adapters|graph)/',
-          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|npm-cli|npm-slack|npm-ui|svc-api|web-app)/',
         ],
       },
     },
@@ -177,7 +177,7 @@ module.exports = {
           '^packages/(execution-engine|surfaces|planning-core)/',
           '^packages/(data-store|persistence|core)/',
           '^packages/(workflow-core|protocol|runtime-adapters|graph)/',
-          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui)/',
+          '^packages/(contracts|workflow-graph|transport|runtime-domain|runtime-service|shell|ui|npm-cli|npm-slack|npm-ui|svc-api|web-app)/',
         ],
       },
     },
@@ -187,12 +187,12 @@ module.exports = {
         'Layer 4 packages (test-kit, app) can only depend on Layers 0, 1, 2, and 3.',
       severity: 'error',
       from: {
-        path: '^packages/(test-kit|app)/',
+        path: '^packages/(test-kit|app|cli|slack-manager)/',
       },
       to: {
         path: '^packages/',
         pathNot: [
-          '^packages/(test-kit|app)/',
+          '^packages/(test-kit|app|cli|slack-manager)/',
           '^packages/(execution-engine|surfaces|planning-core)/',
           '^packages/(data-store|persistence|core)/',
           '^packages/(workflow-core|protocol|runtime-adapters|graph)/',


### PR DESCRIPTION
## Summary

A layered dependency-cruiser check already runs in CI.

Seven packages were not named in the package-layer regexes, so their outbound imports were not checked by those rules.

This adds those packages to existing layer groups only. It changes no package code, rule severity, or CI wiring.

## Review Claim

Every package under `packages/` is now covered by an existing dependency-cruiser package-boundary `from` rule.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only package names are appended to existing regex groups and matching comments. No rule names, severities, existing layer entries, CI commands, or package source files change.

## Slice Rationale

One policy slice closes the coverage gap in the existing CI-enforced boundary check. The unchanged `pnpm run check:deps` command proves the updated policy accepts the current package graph.

## Non-goals

No new dependency-cruiser rules.

No package source or `package.json` changes.

No severity, CI workflow, or check command changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run check:deps`

```text
> invoker@0.0.10 check:deps /Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786417061478-8-2N8Awk
> depcruise packages --config .dependency-cruiser.js

x 77 dependency violations (0 errors, 77 warnings). 658 modules, 2706 dependencies cruised.
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e49927dffa8761ddc5da6c7a2ed53697c80d045f`
- Post-revert steps: Run `pnpm run check:deps`
- Data migration? No

</details>
