### PR TITLE
[Planning UI running indicators](2) chat-list dot for running submitted plans

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -613,9 +613,11 @@ function isTextInputElement(target: EventTarget | null): target is HTMLInputElem
 function PlanningSessionStatusIcon({
   busy,
   status,
+  workflowRunning,
 }: {
   busy: boolean;
   status: InAppPlanningSessionStatus;
+  workflowRunning: boolean;
 }): JSX.Element {
   if (busy) {
     return (
@@ -630,6 +632,14 @@ function PlanningSessionStatusIcon({
       <span
         className="mt-1.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-foreground"
         aria-label="Needs attention"
+      />
+    );
+  }
+  if (status === 'submitted' && workflowRunning) {
+    return (
+      <span
+        className="mt-1.5 inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-primary"
+        aria-label="Workflow running"
       />
     );
   }
@@ -4466,6 +4476,9 @@ export function App() {
         {planningSessions.map((session) => {
           const selected = session.id === activePlanningSession.id;
           const preview = previewPlanningMessage(session);
+          const workflowRunning = session.submittedWorkflowId
+            ? workflows.get(session.submittedWorkflowId)?.status === 'running'
+            : false;
           return (
             <div
               key={session.id}
@@ -4477,7 +4490,11 @@ export function App() {
                 onClick={() => setActivePlanningSessionId(session.id)}
                 className={`flex w-full min-w-0 flex-1 items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
               >
-                <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
+                <PlanningSessionStatusIcon
+                  busy={session.busy}
+                  status={session.status}
+                  workflowRunning={workflowRunning}
+                />
                 <div className="min-w-0 flex-1">
                   <div className="flex items-start justify-between gap-2">
                     <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1747,6 +1747,48 @@ describe('Invoker terminal (component)', () => {
     expect(screen.getAllByText(/submitted/i).length).toBeGreaterThan(0);
   });
 
+  it('shows a running workflow dot only for submitted planning sessions whose workflow is still running', async () => {
+    const workflows: WorkflowMeta[] = [
+      { id: 'wf-running', name: 'Running workflow', status: 'running' },
+      { id: 'wf-completed', name: 'Completed workflow', status: 'completed' },
+    ];
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'submitted-running-chat',
+          title: 'Submitted running chat',
+          status: 'submitted',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          submittedWorkflowId: 'wf-running',
+          submittedPlanName: 'Running workflow plan',
+        }),
+        makePlanningSessionSummary({
+          id: 'submitted-completed-chat',
+          title: 'Submitted completed chat',
+          status: 'submitted',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          submittedWorkflowId: 'wf-completed',
+          submittedPlanName: 'Completed workflow plan',
+        }),
+      ],
+    })) as any;
+    mock.setTasks([], workflows);
+
+    render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+
+    const runningRow = getPlanningSessionRowByText('Submitted running chat');
+    const completedRow = getPlanningSessionRowByText('Submitted completed chat');
+
+    expect(within(runningRow).getByLabelText('Workflow running')).toHaveClass('bg-primary');
+    expect(within(completedRow).queryByLabelText('Workflow running')).not.toBeInTheDocument();
+  });
+
   it('opens the graph from a submitted planning chat by restoring the saved viewport instead of fitting', async () => {
     const savedViewport = { x: -444, y: 156, zoom: 0.71 };
     const workflows: WorkflowMeta[] = [{ id: 'wf-submitted', name: 'Submitted workflow', status: 'running' }];


### PR DESCRIPTION
## Summary

The planning rail keeps a visible running dot after a plan is handed off to its workflow.

The dot uses the session's workflow id and the workflow map already in App.tsx.

The focused terminal test covers a running workflow beside a finished workflow in the rail.

## Review Claim

The planning rail row distinguishes a handed-off plan whose workflow is still running from one whose workflow has finished.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This is a read-only rendering change. It does not change planning session status transitions, workflow execution, polling, or IPC.

## Slice Rationale

This slice is limited to the rail status icon and its focused component coverage, after the sidebar running badge slice.

## Non-goals

- No new IPC channel.
- No change to planningNeedsAttention behavior.
- No change to planning session status transitions.
- No change to workflow execution or queue behavior.
- No redesign of the planning session list beyond this icon state.

## Architecture

### Before

```mermaid
graph TD
    A["Planning session row"] --> B["busy or attention status"]
    B --> C["Status icon"]
```

### After

```mermaid
graph TD
    A["Planning session row"] --> B["busy or attention status"]
    A --> C["session workflow id plus workflow map"]
    B --> D["Status icon"]
    C --> D
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- src/__tests__/invoker-terminal.test.tsx`
  - `✓ src/__tests__/invoker-terminal.test.tsx (60 tests) 11197ms`
  - `Tests 60 passed (60)`

</details>

## Visual Proof

![Planning chat row with running workflow dot](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260811-f058c0/planning-chat-running-dot-proof.png)

Manually inspected: I opened the screenshot and saw the selected "Submitted running chat" row with a small dot at the left edge, while the "Submitted completed chat" row below has no dot.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <PR merge commit>`
- Post-revert steps: None
- Data migration? No

</details>
