### PR TITLE
[Auto-label PRs](3) Document the pr-auto-label auto-start gate

### DIFF
--- a/docs/architecture/recovery-lifecycle-workers.md
+++ b/docs/architecture/recovery-lifecycle-workers.md
@@ -87,8 +87,9 @@ field, and those fields all default to off:
 
 - `disk-headroom` auto-starts when `diskHeadroom.cleanupEnabled` is true.
 - `autoapprove` auto-starts when `autoApproveAIFixes` is true.
-- `pr-admin-bypass-land`, `pr-orphan-repair`, and `pr-duplicate-close`
-  auto-start when the shared `prMaintenance.enabled` field is true.
+- `pr-admin-bypass-land`, `pr-orphan-repair`, `pr-duplicate-close`, and
+  `pr-auto-label` auto-start when the shared `prMaintenance.enabled` field
+  is true.
 - `e2e-autofix` auto-starts when `e2eAutoFixEnabled` is true.
 - `infra-repair` auto-starts when `infraRepair.enabled` is true.
 - `autofix` auto-starts when `autofix.enabled` is true.


### PR DESCRIPTION
## Summary

Updates the recovery/lifecycle worker architecture reference to list the fourth PR-maintenance worker from the previous slice, `pr-auto-label`, alongside the other three under the shared `prMaintenance.enabled` gate.

## Review Claim

Approve that the reference text now matches the auto-start behavior landed in the previous slice.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Text-only edit to one reference file. Nothing here can change runtime behavior.

## Slice Rationale

Kept as its own PR because this repo's own review-unit checks classify every `.md` file as its own unit, distinct from the source changes in the two prior slices.

## Non-goals

Does not change any source file. Does not add new reference content beyond the one line this repo's own automation already needed updated.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] Manual: read the updated bullet list against `PR_MAINTENANCE_AUTO_STARTED_WORKER_KINDS` in `packages/app/src/worker-control.ts` for agreement.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The pull request maintenance workflow now automatically starts the labeling worker when pull request maintenance is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->