### PR TITLE
General alert channel (1) mergify ledger detail

### DIFF
--- a/scripts/mergify_admin_requeue_gh_executor.py
+++ b/scripts/mergify_admin_requeue_gh_executor.py
@@ -127,7 +127,7 @@ class AdminBypassGhExecutor:
             body = f"Mergify repair stopped: {detail}"
             if not self.has_blocked_comment(pr, body):
                 self.gh.comment(self.repo, pr.number, body)
-            self.ledger.record("comment-blocked", pr.number, pr.head_ref_oid, key, now)
+            self.ledger.record("comment-blocked", pr.number, pr.head_ref_oid, key, now, meta={"detail": detail})
             return
         if (
             key == "no-current-bottom"
@@ -135,7 +135,14 @@ class AdminBypassGhExecutor:
             and not self.has_blocked_comment(pr.number, detail)
         ):
             self.gh.comment(self.repo, pr.number, f"Mergify repair stopped: {detail}")
-            self.ledger.record("comment-blocked", pr.number, pr.head_ref_oid, "no-current-bottom:exact", now)
+            self.ledger.record(
+                "comment-blocked",
+                pr.number,
+                pr.head_ref_oid,
+                "no-current-bottom:exact",
+                now,
+                meta={"detail": detail},
+            )
 
     def execute(self, action: Action, pr: PrSnapshot, now: int) -> bool:
         self.logger.trace("admin-bypass-action-execute", action=self.logger.action_payload(action))


### PR DESCRIPTION
## Summary

Persists the blocked-queue detail text in the Mergify repair ledger.

The executor already records `comment-blocked` rows when repair stops. Those rows now carry `meta.detail`, so later alert-channel slices have operator-readable text.

This is the scripts-only foundation for the general alert channel stack.

## Review Claim

The `comment-blocked` ledger row now carries the blocker detail text as `meta.detail`; no other ledger row kind or matching behavior changes.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

`Ledger.record` already accepts optional `meta` at `scripts/mergify_admin_requeue_model.py:188`. Passing it only on the two `comment_blocked()` record calls adds data to newly written rows.

Existing ledger matching stays keyed by kind, PR, head SHA, and key; `count()`, `latest()`, and `has_different_head()` do not read `meta`.

## Slice Rationale

This is the missing persistence field the rest of the alert-channel stack needs.

Keeping it scripts-only separates the Mergify repair policy change from the later `packages/` product-code slices.

## Non-goals

No change to when a PR gets commented on.

No change to the GitHub comment text.

No change to any other ledger row kind.

No Node-side alert-channel consumption in this slice.

## Architecture

### Before

```mermaid
graph TD
    A["comment_blocked(detail)"] --> B["GitHub comment contains detail"]
    A --> C["ledger row has kind/pr/headSha/key/epoch only"]
```

### After

```mermaid
graph TD
    A["comment_blocked(detail)"] --> B["GitHub comment contains detail"]
    A --> C["ledger row has kind/pr/headSha/key/epoch plus meta.detail"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue_model scripts.test_mergify_admin_requeue`

```text
Ran 92 tests in 0.673s

OK
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <commit>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked comment events now retain the specific blocking details in their recorded history.
  * Existing duplicate prevention and exact-detail comment behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->