### PR TITLE
[Bugfix: requeue worker's stall budget resets across a process restart](1) Durable stall budget

### DIFF
--- a/packages/execution-engine/src/__tests__/requeue-retry-cap-restart.repro.test.ts
+++ b/packages/execution-engine/src/__tests__/requeue-retry-cap-restart.repro.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type {
+  WorkerActionRecord,
+  WorkerActionWrite,
+  WorkflowMutationIntent,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+import { createRequeueAttemptLedger } from '../requeue-attempt-ledger.js';
+import { requeueRetryCapExternalKey } from '../requeue-retry-cap.js';
+import {
+  createRequeueRecoveryTick,
+  parseRequeueEscalateMutationArgs,
+  REQUEUE_COMMAND_CHANNEL,
+  REQUEUE_ESCALATE_CHANNEL,
+} from '../workers/requeue-worker.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+const POLL_CTX = {
+  identity: { kind: 'requeue', instanceId: 'r1' },
+  reason: 'poll' as const,
+  tickNumber: 1,
+  signal: new AbortController().signal,
+};
+
+const NOW = '2026-01-01T00:00:00.000Z';
+
+function toRecord(write: WorkerActionWrite, existing?: WorkerActionRecord): WorkerActionRecord {
+  return {
+    ...write,
+    id: existing?.id ?? write.id,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: existing?.createdAt ?? NOW,
+    updatedAt: write.updatedAt ?? NOW,
+  };
+}
+
+function makeTask(): TaskState {
+  return {
+    id: 'wf-1/gate',
+    description: 'stalled merge gate',
+    status: 'failed',
+    dependencies: [],
+    createdAt: new Date(NOW),
+    config: { workflowId: 'wf-1', isMergeNode: true },
+    execution: {
+      error: 'Execution stalled: ... (attempt lease expired).',
+      failureClass: 'liveness_stall',
+      generation: 2,
+      selectedAttemptId: 'attempt-1',
+    },
+    taskStateVersion: 3,
+  };
+}
+
+function makeHarness(task: TaskState) {
+  const tasks = new Map<string, TaskState>([[task.id, task]]);
+  const intents: WorkflowMutationIntent[] = [];
+  const actions = new Map<string, WorkerActionRecord>();
+  const submit = vi.fn(
+    (workflowId: string, priority: WorkflowMutationPriority, channel: string, args: unknown[]) => {
+      const id = intents.length + 1;
+      intents.push({
+        id,
+        workflowId,
+        priority,
+        channel,
+        args,
+        status: 'queued',
+        createdAt: NOW,
+      });
+      return id;
+    },
+  );
+  const store = {
+    listWorkflows: () => [{ id: 'wf-1' }],
+    loadTasks: (workflowId: string) => (workflowId === 'wf-1' ? Array.from(tasks.values()) : []),
+    loadTask: (taskId: string) => tasks.get(taskId),
+    listWorkflowMutationIntents: () => intents,
+    getWorkerAction: vi.fn((workerKind: string, externalKey: string) => actions.get(`${workerKind}:${externalKey}`)),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+      const key = `${write.workerKind}:${write.externalKey}`;
+      const saved = toRecord(write, actions.get(key));
+      actions.set(key, saved);
+      return saved;
+    }),
+    logEvent: vi.fn(),
+  };
+  const makeTick = () => createRequeueRecoveryTick({
+    store,
+    submitter: { submit },
+    logger,
+    ledger: createRequeueAttemptLedger(),
+    stallRequeueRetries: 1,
+    stallRequeueBackoffMs: 0,
+    now: () => 0,
+  });
+  return { actions, makeTick, store, submit };
+}
+
+describe('requeue retry cap restart regression', () => {
+  it('keeps the exhausted stall-requeue budget durable across a worker restart', async () => {
+    const h = makeHarness(makeTask());
+    const firstProcessTick = h.makeTick();
+
+    await firstProcessTick(POLL_CTX);
+    expect(h.submit.mock.calls.map((call) => call[2])).toEqual([REQUEUE_COMMAND_CHANNEL]);
+    expect(h.store.getWorkerAction('requeue', requeueRetryCapExternalKey('wf-1/gate'))?.attemptCount).toBe(1);
+
+    await firstProcessTick(POLL_CTX);
+    expect(h.submit.mock.calls.map((call) => call[2])).toEqual([
+      REQUEUE_COMMAND_CHANNEL,
+      REQUEUE_ESCALATE_CHANNEL,
+    ]);
+    const escalation = parseRequeueEscalateMutationArgs(h.submit.mock.calls[1][3]);
+    expect(escalation.taskId).toBe('wf-1/gate');
+    expect(escalation.prompt).toContain('requeued 1 time(s)');
+
+    const callsBeforeRestart = h.submit.mock.calls.length;
+    const restartedProcessTick = h.makeTick();
+
+    await restartedProcessTick(POLL_CTX);
+
+    const channelsAfterRestart = h.submit.mock.calls.slice(callsBeforeRestart).map((call) => call[2]);
+    expect(channelsAfterRestart).not.toContain(REQUEUE_COMMAND_CHANNEL);
+    expect(h.submit.mock.calls.filter((call) => call[2] === REQUEUE_COMMAND_CHANNEL)).toHaveLength(1);
+  });
+});

--- a/packages/execution-engine/src/requeue-retry-cap.ts
+++ b/packages/execution-engine/src/requeue-retry-cap.ts
@@ -1,0 +1,49 @@
+import { normalizeAutoFixRetryBudget } from './auto-fix-gating.js';
+import { recordWorkerDecisionRow, type WorkerDecisionStore } from './worker-decision-ledger.js';
+
+export const REQUEUE_RETRY_CAP_ACTION_TYPE = 'stall-requeue-cap';
+
+const REQUEUE_RETRY_CAP_WORKER_KIND = 'requeue';
+
+export function requeueRetryCapExternalKey(taskId: string): string {
+  return `stall-requeue-cap:${taskId}`;
+}
+
+export interface RequeueRetryCapDecision {
+  readonly allowed: boolean;
+  readonly consumed: number;
+  readonly budget: number;
+}
+
+export function checkRequeueRetryCap(
+  store: WorkerDecisionStore,
+  taskId: string,
+  rawBudget: unknown,
+): RequeueRetryCapDecision {
+  const budget = normalizeAutoFixRetryBudget(rawBudget);
+  const consumed = store.getWorkerAction?.(
+    REQUEUE_RETRY_CAP_WORKER_KIND,
+    requeueRetryCapExternalKey(taskId),
+  )?.attemptCount ?? 0;
+  const allowed = budget === Number.POSITIVE_INFINITY || (budget > 0 && consumed < budget);
+  return { allowed, consumed, budget };
+}
+
+export function recordRequeueRetryConsumed(
+  store: WorkerDecisionStore,
+  taskId: string,
+  fields: { workflowId?: string; summary?: string } = {},
+): void {
+  recordWorkerDecisionRow(store, {
+    workerKind: REQUEUE_RETRY_CAP_WORKER_KIND,
+    actionType: REQUEUE_RETRY_CAP_ACTION_TYPE,
+    externalKey: requeueRetryCapExternalKey(taskId),
+    subjectType: 'task',
+    subjectId: taskId,
+    ...(fields.workflowId !== undefined ? { workflowId: fields.workflowId } : {}),
+    taskId,
+    status: 'queued',
+    summary: fields.summary ?? 'Durable per-task requeue retry counter',
+    incrementAttempt: true,
+  });
+}

--- a/packages/execution-engine/src/workers/requeue-worker.ts
+++ b/packages/execution-engine/src/workers/requeue-worker.ts
@@ -11,6 +11,10 @@ import {
   requeueLedgerKeyFromTask,
   type RequeueAttemptLedger,
 } from '../requeue-attempt-ledger.js';
+import {
+  checkRequeueRetryCap,
+  recordRequeueRetryConsumed,
+} from '../requeue-retry-cap.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import type { WorkerRegistry } from '../worker-registry.js';
@@ -151,6 +155,36 @@ export function createRequeueRecoveryTick(options: RequeueWorkerPolicyOptions): 
       handled.add(candidate.taskId);
 
       const key = requeueLedgerKeyFromTask(latest);
+      const retryCap = checkRequeueRetryCap(options.store, latest.id, budget);
+      if (!retryCap.allowed) {
+        if (options.ledger.hasEscalated(key)) continue;
+        const prompt = buildStallEscalationPrompt(retryCap.consumed, retryCap.budget);
+        const intentId = options.submitter.submit(
+          workflowId,
+          'normal',
+          REQUEUE_ESCALATE_CHANNEL,
+          buildRequeueEscalateMutationArgs(latest.id, prompt),
+        );
+        options.ledger.markEscalated(key);
+        options.store.logEvent?.(latest.id, 'recovery.worker.submit', {
+          worker: REQUEUE_WORKER_KIND,
+          phase: 'requeue-escalate',
+          workflowId,
+          intentId,
+          channel: REQUEUE_ESCALATE_CHANNEL,
+          attempts: retryCap.consumed,
+          budget: retryCap.budget,
+        });
+        options.logger.info(`[worker:${REQUEUE_WORKER_KIND}] escalated stalled task to needs_input`, {
+          module: 'requeue-worker',
+          taskId: latest.id,
+          workflowId,
+          attempts: retryCap.consumed,
+          budget: retryCap.budget,
+        });
+        continue;
+      }
+
       const decision = options.ledger.decide(key, budget, backoffMs, nowMs);
 
       if (decision.kind === 'backoff') {
@@ -200,6 +234,9 @@ export function createRequeueRecoveryTick(options: RequeueWorkerPolicyOptions): 
         REQUEUE_COMMAND_CHANNEL,
         buildRequeueMutationArgs(latest.id),
       );
+      recordRequeueRetryConsumed(options.store, latest.id, {
+        workflowId,
+      });
       options.store.logEvent?.(latest.id, 'recovery.worker.submit', {
         worker: REQUEUE_WORKER_KIND,
         phase: 'requeue',


### PR DESCRIPTION
## Summary

The requeue worker now records stalled-task attempt consumption in the durable worker action ledger.

The new counter is scoped to worker kind `requeue`, with task-specific durable keys.

The recovery tick reads that durable cap before another automatic requeue, and records consumption immediately after requeue handoff.

## Review Claim

A task that has exhausted its configured stall-requeue budget will not get another automatic requeue after the requeue worker process restarts.

Evidence: `packages/execution-engine/src/workers/requeue-worker.ts:157` through `packages/execution-engine/src/workers/requeue-worker.ts:186` checks the durable cap and escalates when it is exhausted. `packages/execution-engine/src/workers/requeue-worker.ts:231` through `packages/execution-engine/src/workers/requeue-worker.ts:239` records a consumed durable attempt only after requeue handoff.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The durable counter is stored under worker kind `requeue`, so it cannot collide with the existing auto-fix counter namespace.

The existing in-memory ledger still controls same-process backoff and same-process escalation behavior.

## Slice Rationale

This slice closes one restart gap in the requeue worker's stall budget without changing other workers.

The regression test is included with the behavior because it directly exercises the new durable branch in the tick.

## Non-goals

No auto-fix worker change.

No new database table.

No merge of the auto-fix and requeue retry-cap helpers.

No change to any other worker.

No documentation edit.

## Architecture

### Before

```mermaid
graph TD
    A["requeue worker process"] --> B["in-memory requeue ledger"]
    B --> C["submit requeue or escalate"]
    D["process restart"] --> E["fresh empty ledger"]
```

### After

```mermaid
graph TD
    A["requeue worker process"] --> B["durable requeue retry cap"]
    B --> C["in-memory requeue ledger"]
    C --> D["submit requeue or escalate"]
    E["process restart"] --> B
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/requeue-retry-cap-restart.repro.test.ts src/__tests__/requeue-worker.test.ts src/__tests__/requeue-attempt-ledger.test.ts`

```text
> @invoker/execution-engine@0.0.4 test /Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786418626472-9-XRhmkU/packages/execution-engine
> node scripts/run-vitest.mjs -- src/__tests__/requeue-retry-cap-restart.repro.test.ts src/__tests__/requeue-worker.test.ts src/__tests__/requeue-attempt-ledger.test.ts


 RUN  v3.2.4 /Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786418626472-9-XRhmkU/packages/execution-engine

 ✓ src/__tests__/requeue-worker.test.ts (7 tests) 5ms
 ✓ src/__tests__/requeue-retry-cap-restart.repro.test.ts (1 test) 4ms
 ✓ src/__tests__/requeue-attempt-ledger.test.ts (5 tests) 2ms

 Test Files  3 passed (3)
      Tests  13 passed (13)
   Start at  21:40:17
   Duration  1.26s (transform 291ms, setup 0ms, collect 551ms, tests 12ms, environment 0ms, prepare 153ms)
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert d8863fae2`
- Post-revert steps: rerun `cd packages/execution-engine && pnpm test -- src/__tests__/requeue-worker.test.ts src/__tests__/requeue-attempt-ledger.test.ts`
- Data migration? No.

</details>
