### PR TITLE
Bugfix: an SSH pool-member lease leaks when the task-start persistence write throws mid-dispatch

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-lease-capacity-battery.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-lease-capacity-battery.test.ts
@@ -192,6 +192,56 @@ describe('SSH lease capacity battery', () => {
     expect(liveLeases(adapter)[0]?.resourceKey).toBe('ssh:invoker@shared.example.com:22');
   });
 
+  it('releases a pending SSH pool lease when task-start persistence fails', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    const first = makeTask('wf-persist-fails/first', 'pnpm-ssh');
+    const second = makeTask('wf-persist-fails/second', 'pnpm-ssh');
+    const taskMap = new Map([first, second].map((task) => [task.id, task]));
+    const sshExecutor = makeSshExecutor();
+    const persistence = bindLeasePersistence(adapter);
+    const persistFailure = new Error('task-start persist failed');
+    persistence.updateTask.mockImplementationOnce(() => {
+      throw persistFailure;
+    });
+    const handleWorkerResponse = vi.fn(() => []);
+    const runner = makePoolRunner({
+      pools: 'dual-shared',
+      sshExecutor,
+      persistence,
+      orchestrator: {
+        getTask: (id: string) => taskMap.get(id) ?? null,
+        getAllTasks: () => [...taskMap.values()],
+        deferTask: vi.fn(),
+        markTaskRunningAfterLaunch: () => true,
+        handleWorkerResponse,
+      },
+    });
+
+    await runner.executeTask(first);
+
+    expect(sshExecutor.start).toHaveBeenCalledTimes(1);
+    expect(handleWorkerResponse).toHaveBeenCalledWith(expect.objectContaining({
+      actionId: first.id,
+      attemptId: first.execution.selectedAttemptId,
+      status: 'failed',
+    }));
+    expect(liveLeases(adapter)).toHaveLength(0);
+
+    const secondRun = runner.executeTask(second);
+    await vi.waitFor(() => expect(sshExecutor.start).toHaveBeenCalledTimes(2));
+    sshExecutor.completeByTaskId.get(second.id)?.({
+      requestId: `done-${second.id}`,
+      actionId: second.id,
+      attemptId: second.execution.selectedAttemptId,
+      status: 'completed',
+      outputs: { exitCode: 0 },
+    });
+    await secondRun;
+
+    expect(liveLeases(adapter)).toHaveLength(0);
+  });
+
   it('fills expectedCap after recreate/preempt-style churn with ready work remaining', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);

--- a/packages/execution-engine/src/task-runner-dispatch.ts
+++ b/packages/execution-engine/src/task-runner-dispatch.ts
@@ -327,7 +327,13 @@ export async function dispatchExecutor(
         containerId: handle.containerId ?? undefined,
       },
     };
-    host.persistence.updateTask(task.id, changes);
+    try {
+      host.persistence.updateTask(task.id, changes);
+    } catch (err) {
+      host.releasePoolSelectionLease(host.pendingPoolSelections.get(task.id));
+      host.pendingPoolSelections.delete(task.id);
+      throw err;
+    }
     // Mirror branch + workspacePath onto the attempt row so reconciliation
     // and post-mortem flows can recover provenance from the attempt without
     // joining back to the task. Pairs with the early `onBranchResolved`


### PR DESCRIPTION
## Summary

Fix an SSH pool-member lease leak when task-start persistence throws during dispatch.

The lease is now released before the error reaches the existing task failure path.

The regression test uses a real SQLite lease adapter and a one-time throwing `updateTask`.

## Review Claim

Approve releasing and clearing the pending SSH pool selection when `host.persistence.updateTask(task.id, changes)` throws between lease acquisition and active execution registration.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the exception path after start-metadata persistence changes. The accepted launch success path still persists metadata, deletes the pending selection, and registers the active execution in the same order.

## Slice Rationale

This is one behavior slice because the code change and regression test cover the same acquire-to-register window.

The separate verification task produced no tree diff, so the published review unit is the reviewable code and test change.

## Non-goals

- No executor selection changes.
- No pool capacity policy changes.
- No lease expiry or sweeper changes.
- No changes to the adjacent launch-rejected or missing-workspace guards.

## Architecture

### Before

```mermaid
graph TD
    A["pending SSH pool lease acquired"] --> B["updateTask persists start metadata"]
    B --> C["pendingPoolSelections.delete(task.id)"]
    C --> D["activeExecutions.set(...)"]
    B -->|"throws"| E["executeTask marks task failed"]
    E --> F["pending lease remains live"]
```

### After

```mermaid
graph TD
    A["pending SSH pool lease acquired"] --> B["updateTask persists start metadata"]
    B --> C["pendingPoolSelections.delete(task.id)"]
    C --> D["activeExecutions.set(...)"]
    B -->|"throws"| E["releasePoolSelectionLease(...)"]
    E --> F["pendingPoolSelections.delete(task.id)"]
    F --> G["executeTask marks task failed"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-ssh-lease-capacity-battery.sh`

```text
gate: SSH lease capacity battery

 RUN  v3.2.4 /Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786422990006-8-aiVxCA/packages/execution-engine

 ✓ src/__tests__/ssh-lease-capacity-battery.test.ts (6 tests) 340ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  21:42:20
   Duration  1.31s (transform 506ms, setup 0ms, collect 721ms, tests 340ms, environment 0ms, prepare 52ms)

PASS: SSH lease capacity battery

EXIT_CODE:0
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 84428dd85`
- Post-revert steps: Re-run `bash scripts/repro/repro-ssh-lease-capacity-battery.sh`.
- Data migration? No.

</details>
