### PR TITLE
[Bugfix: land-stack.mjs re-queues PRs already active in Mergify's merge queue](1) Skip active Mergify queue PRs

### DIFF
--- a/scripts/land-stack.mjs
+++ b/scripts/land-stack.mjs
@@ -38,6 +38,7 @@ import { fileURLToPath } from 'node:url';
 
 export const TRUNK_DEFAULT = 'master';
 export const STACK_PREFIX_DEFAULT = 'stack/';
+const ACTIVE_MERGIFY_QUEUE_STATUSES = new Set(['queued', 'waiting_for_merge']);
 
 export function analyzeStack({ prs, hasLocalCommit, trunk = TRUNK_DEFAULT, stackPrefix = STACK_PREFIX_DEFAULT }) {
   const checks = [];
@@ -136,7 +137,7 @@ export function analyzeCompleteOpenStack({ selectedPrs, allOpenPrs, trunk = TRUN
 }
 
 export function queueTargets(prs) {
-  return prs.filter((pr) => pr.state === 'OPEN');
+  return prs.filter((pr) => pr.state === 'OPEN' && !ACTIVE_MERGIFY_QUEUE_STATUSES.has(normalizeMergifyQueueStatus(pr.mergifyQueueStatus)));
 }
 
 export function short(sha) {
@@ -157,6 +158,69 @@ function listOpenPrs() {
   const out = gh(['pr', 'list', '--state', 'open', '--limit', '200', '--json',
     'number,headRefOid,headRefName,baseRefName,state']);
   return JSON.parse(out);
+}
+
+function normalizeMergifyQueueStatus(status) {
+  return String(status || 'none').trim().toLowerCase();
+}
+
+function extractFirstJsonObject(text) {
+  const start = text.indexOf('{');
+  if (start === -1) return null;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        try {
+          const payload = JSON.parse(text.slice(start, i + 1));
+          return payload && typeof payload === 'object' && !Array.isArray(payload) ? payload : null;
+        } catch {
+          return null;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function parseMergifyQueueStatus(comment) {
+  let author = '';
+  if (comment?.user && typeof comment.user === 'object') author = String(comment.user.login || '');
+  else if (comment?.author && typeof comment.author === 'object') author = String(comment.author.login || '');
+  else author = String(comment?.user || comment?.author || '');
+  if (author !== 'mergify[bot]' && author !== 'mergify') return null;
+  const body = String(comment?.body || '');
+  const marker = '-*- Mergify Payload -*-';
+  const markerIndex = body.indexOf(marker);
+  if (markerIndex === -1) return null;
+  const payload = extractFirstJsonObject(body.slice(markerIndex));
+  return normalizeMergifyQueueStatus(payload?.state || payload?.queue_state || payload?.event || payload?.action);
+}
+
+function fetchMergifyQueueStatus(prNumber) {
+  const out = gh(['pr', 'view', String(prNumber), '--json', 'comments']);
+  const comments = JSON.parse(out).comments;
+  if (!Array.isArray(comments)) return 'none';
+  const statuses = comments
+    .map((comment) => ({
+      status: parseMergifyQueueStatus(comment),
+      updatedAt: String(comment?.updated_at || comment?.updatedAt || comment?.created_at || comment?.createdAt || ''),
+    }))
+    .filter((event) => event.status);
+  statuses.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  return statuses[0]?.status || 'none';
 }
 
 function addAdminBypassLabel(prNumber) {
@@ -284,7 +348,20 @@ function main() {
     return;
   }
 
+  try {
+    prData = prData.map((pr) => ({ ...pr, mergifyQueueStatus: fetchMergifyQueueStatus(pr.number) }));
+  } catch (e) {
+    console.error(`\nerror: failed to read Mergify queue status via gh: ${e.message}`);
+    process.exit(2);
+  }
+
   const targets = queueTargets(prData);
+  for (const pr of prData) {
+    const status = normalizeMergifyQueueStatus(pr.mergifyQueueStatus);
+    if (pr.state === 'OPEN' && ACTIVE_MERGIFY_QUEUE_STATUSES.has(status)) {
+      console.warn(`warning: PR #${pr.number} already has Mergify queue status '${status}'; not re-queueing it.`);
+    }
+  }
   if (targets.length === 0) {
     console.error('\nerror: no open PRs to queue.');
     process.exit(1);


### PR DESCRIPTION
## Summary

Teach `land-stack.mjs` to read each PR's live Mergify queue status before admin-bypass labeling.

Already queued or waiting PRs now stay out of the relabel path, and operators see a warning instead.

That keeps repeated land runs from resetting Mergify's batch order.

## Review Claim

`land-stack.mjs --execute` reads each PR's live Mergify queue status and leaves out PRs already marked `queued` or `waiting_for_merge` before it adds `admin-bypass`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only PRs with live Mergify queue status `queued` or `waiting_for_merge` leave the admin-bypass path. Open PRs without those queue statuses still flow to the existing label mutation.

## Slice Rationale

This slice keeps the queue-status read, queue-target filter, and warning in one review unit because they implement one tooling-policy guard against re-triggering Mergify queue entries.

## Non-goals

No stack-shape check changes.

No change to which PRs pass the existing open, local-SHA, stack-branch, base-linkage, or complete-stack checks.

No changes outside `scripts/land-stack.mjs`.

## Architecture

### Before

```mermaid
graph TD
    A["Verified open PR stack"] --> B["queueTargets() keeps every OPEN PR"]
    B --> C["--execute calls addAdminBypassLabel()"]
```

### After

```mermaid
graph TD
    A["Verified open PR stack"] --> B["fetchMergifyQueueStatus() reads live Mergify comment payloads"]
    B --> C["queueTargets() leaves out queued and waiting_for_merge PRs"]
    C --> D["Only non-active queue PRs receive admin-bypass"]
    B --> E["Active queue PRs emit a warning"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Repro/verify command:

```bash
node -e 'import(`./scripts/land-stack.mjs`).then(({queueTargets})=>((r)=>r.includes(3)&&!r.includes(1)&&!r.includes(2)?console.log(`PASS`,r):(console.error(`FAIL`,r),process.exit(1)))(queueTargets([{number:1,state:`OPEN`,mergifyQueueStatus:`queued`},{number:2,state:`OPEN`,mergifyQueueStatus:`waiting_for_merge`},{number:3,state:`OPEN`,mergifyQueueStatus:`none`}]).map(p=>p.number)))'
```

Output:

```text
PASS [ 3 ]
EXIT:0
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 085193cb0dc84f1b9abc8880ddd30e2cd6c2ed79`
- Post-revert steps: Re-run the repro/verify command above.
- Data migration? No.

</details>
