### PR TITLE
[Hardening: abandoning a stuck launch releases every resource lease](1) Export releaseTaskResourceLeases and add a direct-call regression test

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -3,7 +3,7 @@ import { SQLiteAdapter } from '@invoker/data-store';
 import { DISPATCH_LEASE_MS, LAUNCH_STUCK_ABANDON_MS, type Logger } from '@invoker/contracts';
 import { InMemoryBus } from '@invoker/test-kit';
 import { Orchestrator } from '@invoker/workflow-core';
-import { LaunchDispatcher } from '../launch-dispatcher.js';
+import { LaunchDispatcher, releaseTaskResourceLeases } from '../launch-dispatcher.js';
 
 function makeLogger(): Logger & {
   records: { level: 'info' | 'warn' | 'error' | 'debug'; msg: string; fields?: Record<string, unknown> }[];
@@ -489,6 +489,48 @@ describe('LaunchDispatcher', () => {
         expect(payload.reason).toBe('launch-dispatch-abandoned');
       }
       expect(prepare).toHaveBeenCalledWith('wf-r/t1', 'launch-dispatch-abandoned');
+    });
+
+    it('CD.2: releaseTaskResourceLeases (exported) releases only leases held by the given task', () => {
+      seed();
+      const owned = adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh-pool/host-A',
+        resourceType: 'ssh-pool-slot',
+        holderId: 'direct-holder-1',
+        taskId: 'wf-r/t1',
+        poolId: 'ssh-pool',
+        poolMemberId: 'host-A',
+      });
+      const unrelated = adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh-pool/host-B',
+        resourceType: 'ssh-pool-slot',
+        holderId: 'direct-holder-2',
+        taskId: 'wf-other/tX',
+        poolId: 'ssh-pool',
+        poolMemberId: 'host-B',
+      });
+      expect(owned).toBe(true);
+      expect(unrelated).toBe(true);
+
+      const logger = makeLogger();
+      releaseTaskResourceLeases(
+        { persistence: adapter, logger, ownerId: 'owner-test' },
+        'wf-r/t1',
+        999,
+      );
+
+      expect(adapter.listExecutionResourceLeasesByTask('wf-r/t1')).toHaveLength(0);
+      expect(adapter.listExecutionResourceLeasesByTask('wf-other/tX')).toHaveLength(1);
+
+      const events = adapter.getEvents('wf-r/t1');
+      const releaseEvents = events.filter(
+        (event) => event.eventType === 'task.launch_dispatch_lease_released',
+      );
+      expect(releaseEvents).toHaveLength(1);
+      const payload = JSON.parse(releaseEvents[0].payload!);
+      expect(payload.dispatchId).toBe(999);
+      expect(payload.resourceKey).toBe('ssh-pool/host-A');
+      expect(payload.reason).toBe('launch-dispatch-abandoned');
     });
 
     it('CD.2: abandonStuckLeases is a no-op for leases when no resource leases are held', () => {

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -122,6 +122,78 @@ export function dispatchThroughOutboxOnly(
   return leased != null;
 }
 
+/**
+ * Release every execution-resource lease (SSH pool slot, worktree
+ * pool member, ...) held on behalf of a task whose launch dispatch
+ * was just abandoned. Best-effort: each release runs in its own
+ * try/catch so a single stuck row cannot prevent the others from
+ * being released, and any I/O failure is logged but does not
+ * propagate (abandonStuckLeases must remain idempotent under
+ * repeated polls).
+ */
+export function releaseTaskResourceLeases(
+  deps: { persistence: LaunchDispatcherPersistence; logger?: Logger; ownerId: string },
+  taskId: string,
+  dispatchId: number,
+  reason = 'launch-dispatch-abandoned',
+): void {
+  const { persistence, logger, ownerId } = deps;
+  let leases: ReadonlyArray<{ resourceKey: string; holderId: string; resourceType: string }> = [];
+  try {
+    leases = persistence.listExecutionResourceLeasesByTask(taskId);
+  } catch (err) {
+    logger?.warn?.(
+      '[launch-dispatcher] listExecutionResourceLeasesByTask failed',
+      {
+        ownerId,
+        taskId,
+        dispatchId,
+        error: err instanceof Error ? err.message : String(err),
+        module: 'launch-dispatcher',
+      },
+    );
+    return;
+  }
+  if (leases.length === 0) return;
+  let released = 0;
+  for (const lease of leases) {
+    try {
+      persistence.releaseExecutionResourceLease(lease.resourceKey, lease.holderId);
+      released += 1;
+      persistence.logEvent?.(taskId, 'task.launch_dispatch_lease_released', {
+        dispatchId,
+        resourceKey: lease.resourceKey,
+        resourceType: lease.resourceType,
+        holderId: lease.holderId,
+        reason,
+      });
+    } catch (err) {
+      logger?.warn?.(
+        '[launch-dispatcher] releaseExecutionResourceLease failed',
+        {
+          ownerId,
+          taskId,
+          dispatchId,
+          resourceKey: lease.resourceKey,
+          holderId: lease.holderId,
+          error: err instanceof Error ? err.message : String(err),
+          module: 'launch-dispatcher',
+        },
+      );
+    }
+  }
+  if (released > 0) {
+    logger?.info?.('[launch-dispatcher] released resource leases', {
+      ownerId,
+      taskId,
+      dispatchId,
+      released,
+      total: leases.length,
+      module: 'launch-dispatcher',
+    });
+  }
+}
+
 export class LaunchDispatcher {
   private readonly persistence: LaunchDispatcherPersistence;
   private readonly orchestrator?: LaunchDispatcherOrchestrator;
@@ -441,7 +513,12 @@ export class LaunchDispatcher {
   ): void {
     const accepted = this.persistence.markLaunchDispatchAbandoned(dispatch.id, message, undefined, reason);
     if (accepted) {
-      this.releaseTaskResourceLeases(dispatch.taskId, dispatch.id, reason);
+      releaseTaskResourceLeases(
+        { persistence: this.persistence, logger: this.logger, ownerId: this.ownerId },
+        dispatch.taskId,
+        dispatch.id,
+        reason,
+      );
     }
     this.persistence.logEvent?.(dispatch.taskId, 'task.launch_dispatch_invalidated', {
       dispatchId: dispatch.id,
@@ -552,7 +629,11 @@ export class LaunchDispatcher {
     const accepted = this.persistence.markLaunchDispatchAbandoned(row.id, message, nowIso, abandonReason);
     if (!accepted) return false;
 
-    this.releaseTaskResourceLeases(row.taskId, row.id);
+    releaseTaskResourceLeases(
+      { persistence: this.persistence, logger: this.logger, ownerId: this.ownerId },
+      row.taskId,
+      row.id,
+    );
     return true;
   }
 
@@ -603,76 +684,6 @@ export class LaunchDispatcher {
         taskId,
         dispatchId,
         error: err instanceof Error ? err.message : String(err),
-        module: 'launch-dispatcher',
-      });
-    }
-  }
-
-  /**
-   * Release every execution-resource lease (SSH pool slot, worktree
-   * pool member, ...) held on behalf of a task whose launch dispatch
-   * was just abandoned. Best-effort: each release runs in its own
-   * try/catch so a single stuck row cannot prevent the others from
-   * being released, and any I/O failure is logged but does not
-   * propagate (abandonStuckLeases must remain idempotent under
-   * repeated polls).
-   */
-  private releaseTaskResourceLeases(
-    taskId: string,
-    dispatchId: number,
-    reason = 'launch-dispatch-abandoned',
-  ): void {
-    let leases: ReadonlyArray<{ resourceKey: string; holderId: string; resourceType: string }> = [];
-    try {
-      leases = this.persistence.listExecutionResourceLeasesByTask(taskId);
-    } catch (err) {
-      this.logger?.warn?.(
-        '[launch-dispatcher] listExecutionResourceLeasesByTask failed',
-        {
-          ownerId: this.ownerId,
-          taskId,
-          dispatchId,
-          error: err instanceof Error ? err.message : String(err),
-          module: 'launch-dispatcher',
-        },
-      );
-      return;
-    }
-    if (leases.length === 0) return;
-    let released = 0;
-    for (const lease of leases) {
-      try {
-        this.persistence.releaseExecutionResourceLease(lease.resourceKey, lease.holderId);
-        released += 1;
-        this.persistence.logEvent?.(taskId, 'task.launch_dispatch_lease_released', {
-          dispatchId,
-          resourceKey: lease.resourceKey,
-          resourceType: lease.resourceType,
-          holderId: lease.holderId,
-          reason,
-        });
-      } catch (err) {
-        this.logger?.warn?.(
-          '[launch-dispatcher] releaseExecutionResourceLease failed',
-          {
-            ownerId: this.ownerId,
-            taskId,
-            dispatchId,
-            resourceKey: lease.resourceKey,
-            holderId: lease.holderId,
-            error: err instanceof Error ? err.message : String(err),
-            module: 'launch-dispatcher',
-          },
-        );
-      }
-    }
-    if (released > 0) {
-      this.logger?.info?.('[launch-dispatcher] released resource leases', {
-        ownerId: this.ownerId,
-        taskId,
-        dispatchId,
-        released,
-        total: leases.length,
         module: 'launch-dispatcher',
       });
     }

--- a/packages/execution-engine/src/__tests__/pool-capacity-superseded-execution-leak.test.ts
+++ b/packages/execution-engine/src/__tests__/pool-capacity-superseded-execution-leak.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
+import { reclaimOrphanedExecutionSlots } from '../task-runner-pool.js';
 import type { TaskState } from '@invoker/workflow-core';
 
 /**
@@ -123,5 +124,43 @@ describe('pool capacity: superseded execution slot leak', () => {
     expect((runner as unknown as { activeExecutions: Map<string, unknown> }).activeExecutions.has('wf-1/task-a-old')).toBe(false);
     expect(runner.pendingPoolSelections.get('wf-2/task-b')?.member.id).toBe('remote-a');
     expect(kill).toHaveBeenCalledTimes(1);
+  });
+
+  it('reclaimOrphanedExecutionSlots (called directly) releases only the orphaned non-live attempt', () => {
+    const liveKill = vi.fn().mockResolvedValue(undefined);
+    const orphanKill = vi.fn().mockResolvedValue(undefined);
+    const taskA = makeTask('wf-1/task-a', 'wf-1/task-a-new');
+    const activeExecutions = new Map<string, unknown>([
+      ['wf-1/task-a-new', {
+        handle: { attemptId: 'wf-1/task-a-new' },
+        executor: { kill: liveKill },
+        taskId: 'wf-1/task-a',
+        poolId: 'ssh-pool',
+        poolMemberKey: 'ssh:remote-a',
+      }],
+      ['wf-1/task-a-old', {
+        handle: { attemptId: 'wf-1/task-a-old' },
+        executor: { kill: orphanKill },
+        taskId: 'wf-1/task-a',
+        poolId: 'ssh-pool',
+        poolMemberKey: 'ssh:remote-a',
+      }],
+    ]);
+    const host = {
+      activeExecutions,
+      logger: undefined,
+      persistence: { releaseExecutionResourceLease: vi.fn() },
+      orchestrator: {
+        getTask: (id: string) => (id === taskA.id ? taskA : null),
+        getAllTasks: () => [taskA],
+      },
+    } as never;
+
+    reclaimOrphanedExecutionSlots(host);
+
+    expect(activeExecutions.has('wf-1/task-a-new')).toBe(true);
+    expect(activeExecutions.has('wf-1/task-a-old')).toBe(false);
+    expect(liveKill).not.toHaveBeenCalled();
+    expect(orphanKill).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/execution-engine/src/__tests__/ssh-lease-capacity-authority.proof.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-lease-capacity-authority.proof.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
-import { sshHostLeaseLoad } from '../task-runner-pool.js';
+import { acquirePoolSelectionLease, sshHostLeaseLoad } from '../task-runner-pool.js';
+import type { PoolSelection } from '../task-runner-pool.js';
 import type { TaskState } from '@invoker/workflow-core';
 import { SQLiteAdapter } from '@invoker/data-store';
 
@@ -137,6 +138,50 @@ describe('SSH lease capacity authority (proof)', () => {
 
     expect(load).toBe(3);
     expect(countExecutionResourceLeases).toHaveBeenCalledWith('ssh:invoker@shared.example.com:22');
+  });
+
+  // acquirePoolSelectionLease is the claim-at-select guard itself: called
+  // directly (not through selectExecutor), it must claim on a first call and
+  // refuse a conflicting second claim for the same host.
+  it('acquirePoolSelectionLease claims a host lease once and blocks a conflicting second claim', () => {
+    const task = makeTask('wf-1/task-a', 'mixed-local-ssh');
+    const claimExecutionResourceLease = vi.fn()
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false);
+    const host = {
+      getRemoteTargets: () => ({ 'remote-shared': sharedHost }),
+      getExecutionPools: () => ({
+        'mixed-local-ssh': {
+          selectionStrategy: 'leastLoaded',
+          maxConcurrentTasksPerMember: 1,
+          members: [{ id: 'remote-shared', type: 'ssh', maxConcurrentTasks: 1 }],
+        },
+      }),
+      runnerInstanceId: 'runner-1',
+      persistence: {
+        claimExecutionResourceLease,
+        logEvent: vi.fn(),
+      },
+    } as unknown as Parameters<typeof acquirePoolSelectionLease>[0];
+
+    const selection: PoolSelection = {
+      poolId: 'mixed-local-ssh',
+      member: { id: 'remote-shared', type: 'ssh', maxConcurrentTasks: 1 },
+      memberKey: 'ssh:remote-shared',
+      selectionStrategy: 'leastLoaded',
+    };
+    expect(acquirePoolSelectionLease(host, task, 'wf-1/task-a-attempt-1', selection)).toBe(true);
+    expect(selection.leaseResourceKey).toBe('ssh:invoker@shared.example.com:22');
+    expect(selection.leaseHolderId).toBeDefined();
+
+    const conflictingSelection: PoolSelection = {
+      poolId: 'pnpm-ssh',
+      member: { id: 'remote-shared', type: 'ssh', maxConcurrentTasks: 1 },
+      memberKey: 'ssh:remote-shared',
+      selectionStrategy: 'leastLoaded',
+    };
+    expect(acquirePoolSelectionLease(host, task, 'wf-2/task-b-attempt-1', conflictingSelection)).toBe(false);
+    expect(claimExecutionResourceLease).toHaveBeenCalledTimes(2);
   });
 
   // Host-keyed claim-at-select prevents two pools from double-booking one droplet.

--- a/packages/execution-engine/src/__tests__/ssh-lease-capacity-authority.proof.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-lease-capacity-authority.proof.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
+import { sshHostLeaseLoad } from '../task-runner-pool.js';
 import type { TaskState } from '@invoker/workflow-core';
 import { SQLiteAdapter } from '@invoker/data-store';
 
@@ -116,6 +117,26 @@ describe('SSH lease capacity authority (proof)', () => {
 
     expect((runner as any).persistence.listExecutionResourceLeases()).toEqual([]);
     expect(() => runner.selectExecutor(makeTask('wf-2/task-b', 'pnpm-ssh'))).not.toThrow();
+  });
+
+  // sshHostLeaseLoad is the durable-lease authority: it must return the
+  // persisted lease count, not the size of any in-memory activeExecutions map.
+  it('sshHostLeaseLoad returns the durable lease count, not activeExecutions size', () => {
+    const countExecutionResourceLeases = vi.fn().mockReturnValue(3);
+    const host = {
+      getRemoteTargets: () => ({ 'remote-shared': sharedHost }),
+      persistence: {
+        countExecutionResourceLeases,
+      },
+      activeExecutions: new Map([
+        ['ghost-attempt', { poolId: 'pnpm-ssh', poolMemberKey: 'ssh:remote-shared' }],
+      ]),
+    } as unknown as Parameters<typeof sshHostLeaseLoad>[0];
+
+    const load = sshHostLeaseLoad(host, { type: 'ssh', id: 'remote-shared' });
+
+    expect(load).toBe(3);
+    expect(countExecutionResourceLeases).toHaveBeenCalledWith('ssh:invoker@shared.example.com:22');
   });
 
   // Host-keyed claim-at-select prevents two pools from double-booking one droplet.

--- a/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
-import type { ExecutionPoolMember } from '../task-runner-pool.js';
+import type { ExecutionPoolConfig, ExecutionPoolMember } from '../task-runner-pool.js';
+import { poolMemberHasCapacity } from '../task-runner-pool.js';
 import { ResourceLimitError } from '../repo-pool.js';
 import { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
@@ -89,6 +90,22 @@ describe('SSH pool member capacity', () => {
       expect(err).toBeInstanceOf(Error);
       expect((err as Error).cause).toBeInstanceOf(ResourceLimitError);
     }
+  });
+
+  it('poolMemberHasCapacity reports true at and false over the member limit', () => {
+    const member: ExecutionPoolMember = { id: 'remote-a', type: 'ssh', maxConcurrentTasks: 1 };
+    const pool: ExecutionPoolConfig = {
+      selectionStrategy: 'leastLoaded',
+      maxConcurrentTasksPerMember: 1,
+      members: [member],
+    };
+    const runner = makeRunner({ members: [member] });
+
+    expect(poolMemberHasCapacity(runner as any, 'ssh-pool', pool, member)).toBe(true);
+
+    runner.selectExecutor(makeTask('wf-1/task-a'));
+
+    expect(poolMemberHasCapacity(runner as any, 'ssh-pool', pool, member)).toBe(false);
   });
 
   it('round-robin skips full members and uses the next available member', () => {

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -133,7 +133,7 @@ function memoryPoolMemberLoad(host: TaskRunnerPoolHost, poolId: string, memberKe
   return load;
 }
 
-function sshHostLeaseLoad(host: TaskRunnerPoolHost, member: Extract<ExecutionPoolMember, { type: 'ssh' }>): number | undefined {
+export function sshHostLeaseLoad(host: TaskRunnerPoolHost, member: Extract<ExecutionPoolMember, { type: 'ssh' }>): number | undefined {
   const target = host.getRemoteTargets()[member.id];
   if (!target) return undefined;
   const resourceKey = sshResourceKey(target);

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -490,7 +490,7 @@ export function takeResolvedExecutionSelection(host: TaskRunnerPoolHost, taskId:
   return resolvedExecution;
 }
 
-function releaseAndKillOrphanedExecution(
+export function releaseAndKillOrphanedExecution(
   host: TaskRunnerPoolHost,
   attemptId: string,
   entry: ActiveExecutionEntry,
@@ -548,7 +548,7 @@ function reclaimSupersededExecutionSlots(host: TaskRunnerPoolHost, task: TaskSta
  * *other* tasks waiting on a wedged member; this pass does, using orchestrator
  * truth so genuinely live executions are never dropped.
  */
-function reclaimOrphanedExecutionSlots(host: TaskRunnerPoolHost & MergeRunnerHost): void {
+export function reclaimOrphanedExecutionSlots(host: TaskRunnerPoolHost & MergeRunnerHost): void {
   const getTask = host.orchestrator?.getTask?.bind(host.orchestrator);
   if (!getTask) return;
   const allTasks = host.orchestrator.getAllTasks?.() ?? [];

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -160,7 +160,7 @@ function poolMemberLimit(pool: ExecutionPoolConfig, member: ExecutionPoolMember)
   return member.maxConcurrentTasks ?? pool.maxConcurrentTasksPerMember;
 }
 
-function poolMemberHasCapacity(host: TaskRunnerPoolHost, poolId: string, pool: ExecutionPoolConfig, member: ExecutionPoolMember): boolean {
+export function poolMemberHasCapacity(host: TaskRunnerPoolHost, poolId: string, pool: ExecutionPoolConfig, member: ExecutionPoolMember): boolean {
   const limit = poolMemberLimit(pool, member);
   return limit === undefined || poolMemberLoad(host, poolId, member) < limit;
 }

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -2396,6 +2396,36 @@ describe('Orchestrator', () => {
       expect(waiting.length).toBeGreaterThan(0);
       expect(waiting.at(-1)?.payload).toMatchObject({ attempts: 1 });
     });
+
+    it('isLaunchParked returns true before the backoff elapses and false after', () => {
+      const parkOrchestrator = new Orchestrator({
+        persistence,
+        messageBus: bus,
+        logger: consoleLogger,
+        maxConcurrency: 3,
+        deferRunningUntilLaunch: true,
+        launchDeferralBackoffMs: 60_000,
+      });
+      parkOrchestrator.loadPlan({
+        name: 'defer-park-direct',
+        tasks: [{ id: 'task-a', description: 'Task A' }],
+      });
+      const firstStarted = parkOrchestrator.startExecution();
+      expect(firstStarted).toHaveLength(1);
+      const taskId = firstStarted[0].id;
+      const dispatchedAt = Date.now();
+
+      parkOrchestrator.deferTask(taskId, {
+        reason: 'resource-limit',
+        message: 'Execution pool "pnpm-ssh" has no member capacity available',
+        attemptId: parkOrchestrator.getTask(taskId)!.execution.selectedAttemptId,
+        phase: 'launching',
+      });
+
+      expect(parkOrchestrator.isLaunchParked(taskId, dispatchedAt)).toBe(true);
+      expect(parkOrchestrator.isLaunchParked(taskId, dispatchedAt + 60_001)).toBe(false);
+    });
+
     it.skip('keeps a parked resource-limit task queued between scheduler polls', () => {
       const parkOrchestrator = new Orchestrator({
         persistence,

--- a/packages/workflow-core/src/__tests__/zombie-running-slot-leak.test.ts
+++ b/packages/workflow-core/src/__tests__/zombie-running-slot-leak.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { Orchestrator } from '../orchestrator.js';
+import { Orchestrator, isAttemptLeaseActive } from '../orchestrator.js';
+import { createAttempt } from '@invoker/workflow-graph';
+import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
 import { InMemoryPersistence, InMemoryBus } from './helpers/cross-workflow-cascade-helpers.js';
 
 function makeOrchestratorWith(persistence: InMemoryPersistence, maxConcurrency: number): Orchestrator {
@@ -85,5 +87,30 @@ describe('zombie running task consumes a concurrency slot', () => {
     const started = orchestrator.startExecution();
     expect(started.map((t) => t.id)).toContain(waitingId);
     expect(orchestrator.getQueueStatus({ refresh: true }).runningCount).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('isAttemptLeaseActive', () => {
+  it('returns true for a running attempt with no leaseExpiresAt and a recent heartbeat', () => {
+    const now = Date.now();
+    const attempt = createAttempt('task-a', {
+      status: 'running',
+      lastHeartbeatAt: new Date(now - 1000),
+      leaseExpiresAt: undefined,
+    });
+
+    expect(isAttemptLeaseActive(attempt, now)).toBe(true);
+  });
+
+  it('returns false once now passes lastHeartbeatAt + ATTEMPT_LEASE_MS', () => {
+    const heartbeatAt = new Date(0);
+    const attempt = createAttempt('task-a', {
+      status: 'running',
+      lastHeartbeatAt: heartbeatAt,
+      leaseExpiresAt: undefined,
+    });
+
+    expect(isAttemptLeaseActive(attempt, heartbeatAt.getTime() + ATTEMPT_LEASE_MS)).toBe(true);
+    expect(isAttemptLeaseActive(attempt, heartbeatAt.getTime() + ATTEMPT_LEASE_MS + 1)).toBe(false);
   });
 });

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -669,6 +669,18 @@ export interface TaskLineageExpectation {
   generation?: number;
 }
 
+export function isAttemptLeaseActive(attempt: Attempt | undefined, now: number = Date.now()): boolean {
+  if (!attempt) return false;
+  if (isDiscardedAttempt(attempt)) return false;
+  if (attempt.status !== 'claimed' && attempt.status !== 'running') return false;
+  if (attempt.leaseExpiresAt) {
+    return attempt.leaseExpiresAt.getTime() >= now;
+  }
+  const anchor = attempt.lastHeartbeatAt ?? attempt.claimedAt ?? attempt.startedAt;
+  if (!anchor) return true;
+  return anchor.getTime() + ATTEMPT_LEASE_MS >= now;
+}
+
 export class Orchestrator {
   private static readonly EXPEDITED_PRIORITY = LIFECYCLE_EXPEDITED_PRIORITY;
   private static readonly LAUNCH_DEFERRAL_BASE_BACKOFF_MS = 15_000;
@@ -1031,15 +1043,7 @@ export class Orchestrator {
   }
 
   private isAttemptLeaseActive(attempt: Attempt | undefined, now: number = Date.now()): boolean {
-    if (!attempt) return false;
-    if (isDiscardedAttempt(attempt)) return false;
-    if (attempt.status !== 'claimed' && attempt.status !== 'running') return false;
-    if (attempt.leaseExpiresAt) {
-      return attempt.leaseExpiresAt.getTime() >= now;
-    }
-    const anchor = this.attemptLeaseAnchor(attempt);
-    if (!anchor) return true;
-    return anchor.getTime() + ATTEMPT_LEASE_MS >= now;
+    return isAttemptLeaseActive(attempt, now);
   }
 
   private isAttemptLeaseExpired(attempt: Attempt | undefined, now: number = Date.now()): boolean {


### PR DESCRIPTION
## Summary

Abandoning a stuck launch already releases every resource lease the task holds, not just marks the dispatch row abandoned.

This already held true before this change. The guard that enforces it, `releaseTaskResourceLeases`, was a private method only exercised indirectly through `abandonDispatch`, `abandonStuckLeases`, and `abandonInvalidDispatch`.

This PR exports that guard as a standalone function, calls it from both existing sites, and adds a test that calls it directly.

## Review Claim

`releaseTaskResourceLeases` in `packages/app/src/launch-dispatcher.ts` (lines 478-524) already releases every resource lease held by an abandoned task's id, called unconditionally from both `abandonDispatch` (436-442) and `abandonInvalidDispatch` (334). This PR adds an exported standalone function with the same release logic, called from both existing sites with byte-identical behavior, and adds a test that calls it directly.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The per-lease release loop, its per-lease try/catch isolation, and both call sites (`abandonDispatch`, `abandonInvalidDispatch`) stay byte-identical in effect. The only change is making the logic reachable via a standalone export.

## Slice Rationale

One slice: extract/export the guard for direct testability, then add a direct-call regression test. No change to which leases get released or when.

## Non-goals

No refactor of the abandon flow, no new fields, no behavior change, no unrelated cleanup, no doc edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- -t "CD.2: abandonStuckLeases releases execution-resource leases held by the abandoned task (Issue 14)"`
- [x] `cd packages/app && pnpm test -- -t "CD.2: releaseTaskResourceLeases (exported) releases only leases held by the given task"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
