### PR TITLE
[Bugfix: stuck-lease task never fails after retry-budget exhaustion](2) Expose failTask in Electron dispatcher

### DIFF
--- a/packages/app/src/__tests__/launch-dispatch-retry-budget-exhausted-repro.test.ts
+++ b/packages/app/src/__tests__/launch-dispatch-retry-budget-exhausted-repro.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import {
+  LAUNCH_STUCK_ABANDON_MS,
+  MAX_STUCK_LEASE_RETRIES,
+  type Logger,
+} from '@invoker/contracts';
+import {
+  createAttempt,
+  Orchestrator,
+  type OrchestratorPersistence,
+} from '@invoker/workflow-core';
+import { InMemoryBus } from '@invoker/test-kit';
+import { LaunchDispatcher } from '../launch-dispatcher.js';
+
+describe('launch-dispatcher retry-budget exhaustion', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function makeLogger(): Logger {
+    return {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      child(): Logger {
+        return this;
+      },
+    };
+  }
+
+  function setDispatchLeasedAndStale(rowId: number, startedAtMs: number): void {
+    const startedIso = new Date(startedAtMs).toISOString();
+    const staleIso = new Date(startedAtMs + LAUNCH_STUCK_ABANDON_MS + 1_000).toISOString();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (adapter as any).db.run(
+      `UPDATE task_launch_dispatch
+         SET state = 'leased',
+             dispatch_owner = 'owner-test',
+             enqueued_at = ?,
+             fenced_until = ?
+       WHERE id = ?`,
+      [startedIso, staleIso, rowId],
+    );
+  }
+
+  it('fails a launching task once stuck-lease abandon count exceeds the retry budget', () => {
+    const orchestrator = new Orchestrator({
+      persistence: adapter as OrchestratorPersistence,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 1,
+    });
+    orchestrator.loadPlan({
+      name: 'wf-budget-exhausted',
+      tasks: [{ id: 'fix-ci', description: 'fix-ci', command: 'sleep 999' }],
+    });
+
+    const workflowId = adapter.listWorkflows()[0]?.id;
+    if (!workflowId) throw new Error('Expected workflow to be persisted');
+    const taskId = `${workflowId}/fix-ci`;
+    const targetAbandons = MAX_STUCK_LEASE_RETRIES + 3;
+    const startedAtMs = Date.parse('2026-08-02T05:48:00.000Z');
+
+    for (let i = 0; i < targetAbandons - 1; i += 1) {
+      const attempt = createAttempt(taskId, { status: 'superseded' });
+      adapter.saveAttempt(attempt);
+      const row = adapter.enqueueLaunchDispatch({
+        taskId,
+        attemptId: attempt.id,
+        workflowId,
+        generation: i,
+      });
+      expect(
+        adapter.markLaunchDispatchAbandoned(row.id, 'prior stuck launch', undefined, 'stuck-lease'),
+      ).toBe(true);
+    }
+
+    const currentAttempt = createAttempt(taskId, {
+      status: 'running',
+      startedAt: new Date(startedAtMs),
+      lastHeartbeatAt: new Date(startedAtMs),
+    });
+    adapter.saveAttempt(currentAttempt);
+    adapter.updateTask(taskId, {
+      status: 'running',
+      execution: {
+        selectedAttemptId: currentAttempt.id,
+        generation: targetAbandons,
+        startedAt: new Date(startedAtMs),
+        lastHeartbeatAt: new Date(startedAtMs),
+        phase: 'launching',
+        launchStartedAt: new Date(startedAtMs),
+      },
+    });
+    const currentRow = adapter.enqueueLaunchDispatch({
+      taskId,
+      attemptId: currentAttempt.id,
+      workflowId,
+      generation: targetAbandons,
+    });
+    setDispatchLeasedAndStale(currentRow.id, startedAtMs);
+
+    const dispatcher = new LaunchDispatcher({
+      persistence: adapter,
+      orchestrator: {
+        prepareTaskForNewAttempt: (id, reason) => orchestrator.prepareTaskForNewAttempt(id, reason),
+        failTask: (id, reason) => orchestrator.failTask(id, reason),
+      },
+      ownerId: 'owner-test',
+      logger: makeLogger(),
+    });
+
+    const nowIso = new Date(startedAtMs + LAUNCH_STUCK_ABANDON_MS + 60_000).toISOString();
+    expect(dispatcher.abandonStuckLeases(nowIso)).toBe(1);
+    expect(adapter.countAbandonedLaunchDispatchesForTask(taskId)).toBe(targetAbandons);
+
+    const task = adapter.loadTask(taskId);
+    expect(task?.status).toBe('failed');
+    expect(task?.execution.error).toContain('Launch dispatch abandoned');
+  });
+});

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -53,6 +53,7 @@ export type LaunchDispatcherPersistence = Pick<
  */
 export interface LaunchDispatcherOrchestrator {
   prepareTaskForNewAttempt(taskId: string, reason: string): unknown;
+  failTask?(taskId: string, reason: string): unknown;
   syncFromDb?(workflowId: string): void;
   getTask?(taskId: string): TaskState | undefined;
   getTaskLaunchReadiness?(taskId: string): TaskLaunchReadiness;
@@ -588,6 +589,7 @@ export class LaunchDispatcher {
         maxStuckLeaseRetries: MAX_STUCK_LEASE_RETRIES,
         module: 'launch-dispatcher',
       });
+      this.orchestrator?.failTask?.(row.taskId, message);
       return;
     }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2847,6 +2847,7 @@ startMainProcessBootstrap({
         orchestrator: {
           prepareTaskForNewAttempt: (taskId, reason) =>
             orchestrator.prepareTaskForNewAttempt(taskId, reason),
+          failTask: (taskId, reason) => orchestrator.failTask(taskId, reason),
           syncFromDb: (workflowId) => orchestrator.syncFromDb(workflowId),
           getTask: (taskId) => orchestrator.getTask(taskId),
           getTaskLaunchReadiness: (taskId) => orchestrator.getTaskLaunchReadiness(taskId),

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2019,6 +2019,29 @@ export class Orchestrator {
     this.checkWorkflowCompletion(task.config.workflowId);
   }
 
+  failTask(taskId: string, reason?: string): void {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task || task.status === 'completed' || task.status === 'failed' || task.status === 'closed' || task.status === 'stale') return;
+
+    const error = reason ?? 'Failed';
+    const changes: TaskStateChanges = {
+      status: 'failed',
+      execution: { error, completedAt: new Date(), fixSessionEntryStatus: undefined },
+    };
+    const updated = this.writeAndSync(taskId, changes);
+    this.updateSelectedAttempt(taskId, {
+      status: 'failed',
+      error,
+      completedAt: changes.execution?.completedAt,
+    });
+    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changes);
+    this.persistence.logEvent?.(taskId, 'task.failed', changes);
+    this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+
+    this.checkWorkflowCompletion(task.config.workflowId);
+  }
+
   selectExperiment(taskId: string, experimentId: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);


### PR DESCRIPTION
## Summary

The Electron main process adapter now passes `failTask` into `LaunchDispatcher`.

The desktop runtime can reach the terminal failure path added below it.

## Review Claim

The Electron `LaunchDispatcher` adapter routes exhausted stuck leases to `Orchestrator.failTask`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The adapter only forwards to the existing orchestrator method; no Electron behavior changes when the exhausted path is not reached.

## Slice Rationale

This routing slice keeps the Electron adapter update separate from core state logic and headless entry points.

## Non-goals

- No change to dispatcher state logic.
- No change to orchestrator task failure semantics.
- No change to headless or standalone dispatcher construction.

## Architecture

### Before

```mermaid
graph TD
    A["Electron main creates LaunchDispatcher"] --> B["adapter exposes prepareTaskForNewAttempt"]
    B --> C["dispatcher cannot call failTask"]
```

### After

```mermaid
graph TD
    A["Electron main creates LaunchDispatcher"] --> B["adapter exposes prepareTaskForNewAttempt and failTask"]
    B --> C["dispatcher can call Orchestrator.failTask"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- launch-dispatch-retry-budget-exhausted-repro.test.ts`
  Observed: `✓ src/__tests__/launch-dispatch-retry-budget-exhausted-repro.test.ts (1 test) 27ms` and `Test Files  1 passed (1)`.
- [x] `cd packages/app && pnpm test -- launch-dispatch-stuck-lease-retry-storm-repro.test.ts`
  Observed: `✓ src/__tests__/launch-dispatch-stuck-lease-retry-storm-repro.test.ts (1 test) 22ms` and `Test Files  1 passed (1)`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <this PR commit>`
- Post-revert steps: Rerun the two launch-dispatch tests listed above.
- Data migration? No.

</details>
