### PR TITLE
[Bugfix: stuck-lease task never fails after retry-budget exhaustion](2) Wire headless dispatchers

### DIFF
--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -228,6 +228,7 @@ function startTrackedHeadlessLaunchDispatcher(
     orchestrator: {
       prepareTaskForNewAttempt: (taskId, reason) =>
         deps.orchestrator.prepareTaskForNewAttempt(taskId, reason),
+      failTask: (taskId, reason) => deps.orchestrator.failTask(taskId, reason),
       syncFromDb: (workflowId) => deps.orchestrator.syncFromDb(workflowId),
       getTask: (taskId) => deps.orchestrator.getTask(taskId),
       getTaskLaunchReadiness: (taskId) => deps.orchestrator.getTaskLaunchReadiness(taskId),

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -123,6 +123,7 @@ async function dispatchHeadlessRunnableTasks(
     orchestrator: {
       prepareTaskForNewAttempt: (taskId, reason) =>
         deps.orchestrator.prepareTaskForNewAttempt(taskId, reason),
+      failTask: (taskId, reason) => deps.orchestrator.failTask(taskId, reason),
       syncFromDb: (workflowId) => deps.orchestrator.syncFromDb(workflowId),
       getTask: (taskId) => deps.orchestrator.getTask(taskId),
       getTaskLaunchReadiness: (taskId) => deps.orchestrator.getTaskLaunchReadiness(taskId),


### PR DESCRIPTION
## Summary

The headless launch dispatcher adapters now expose the orchestrator failure method.

Both changed adapter files pass failTask through to the shared orchestrator surface: packages/app/src/headless.ts:126 and packages/app/src/headless-run-resume.ts:231.

## Review Claim

Approve the headless activation-surface wiring that exposes orchestrator.failTask to both launch dispatcher construction sites.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The adapters only forward an existing orchestrator method; they do not change scheduling, leasing, or task state logic.

## Slice Rationale

This slice is only the headless adapter activation surface. It follows the previous slice because the failure method already exists there.

## Non-goals

This does not change the launch dispatcher budget logic.

This does not change Orchestrator.failTask behavior.

This does not change GUI startup wiring.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- launch-dispatch-retry-budget-exhausted-repro.test.ts`
  Evidence: `✓ src/__tests__/launch-dispatch-retry-budget-exhausted-repro.test.ts (1 test) 29ms`; `Test Files  1 passed (1)`.
- [x] `cd packages/app && pnpm test -- launch-dispatch-stuck-lease-retry-storm-repro.test.ts`
  Evidence: `✓ src/__tests__/launch-dispatch-stuck-lease-retry-storm-repro.test.ts (1 test) 22ms`; `Test Files  1 passed (1)`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-commit>`
- Post-revert steps: None
- Data migration? No

</details>
