### PR TITLE
[Bugfix: stuck-lease task never fails after retry-budget exhaustion](2) Wire desktop dispatcher

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2847,6 +2847,7 @@ startMainProcessBootstrap({
         orchestrator: {
           prepareTaskForNewAttempt: (taskId, reason) =>
             orchestrator.prepareTaskForNewAttempt(taskId, reason),
+          failTask: (taskId, reason) => orchestrator.failTask(taskId, reason),
           syncFromDb: (workflowId) => orchestrator.syncFromDb(workflowId),
           getTask: (taskId) => orchestrator.getTask(taskId),
           getTaskLaunchReadiness: (taskId) => orchestrator.getTaskLaunchReadiness(taskId),


### PR DESCRIPTION
## Summary

The desktop launch dispatcher now receives the task-failure hook from the orchestrator.

This lets the core exhausted-abandon path take effect in the Electron owner process.

## Review Claim

The desktop LaunchDispatcher construction includes `failTask`, so exhausted abandons can use the core task-failure path in the owner process.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The adapter forwards to an existing orchestrator method only; it does not change launch selection, leasing, or queue polling.

## Slice Rationale

The desktop process has its own adapter object, so this pass-through is reviewed separately from the core behavior.

## Non-goals

No change to the core failure semantics from the previous slice.

No change to headless entrypoints; those are wired in the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- launch-dispatch-retry-budget-exhausted-repro.test.ts`

```text
 ✓ src/__tests__/launch-dispatch-retry-budget-exhausted-repro.test.ts (1 test) 28ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

- [x] `cd packages/app && pnpm test -- launch-dispatch-stuck-lease-retry-storm-repro.test.ts`

```text
 ✓ src/__tests__/launch-dispatch-stuck-lease-retry-storm-repro.test.ts (1 test) 24ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

</details>

## Visual Proof

![terminal proof for the desktop dispatcher adapter](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260811-27d20c/launch-dispatch-after.svg.png)

Manually inspected: I opened `.tmp/pr-proof/launch-dispatch-after.svg.png` and saw a terminal-style proof image showing the exhausted repro command, `1 passed (1)`, and the `task.status` failed assertion.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; the core hook remains available but the desktop owner process stops passing it through.
- Revert command: `git revert 8a9971ef7`
- Post-revert steps: Rerun the two package/app commands from the test plan.
- Data migration? No.

</details>
