### PR TITLE
[Bugfix: stuck-lease task never fails after retry-budget exhaustion](3) Wire headless dispatchers

### DIFF
--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -228,6 +228,7 @@ function startTrackedHeadlessLaunchDispatcher(
     orchestrator: {
       prepareTaskForNewAttempt: (taskId, reason) =>
         deps.orchestrator.prepareTaskForNewAttempt(taskId, reason),
+      failTask: (taskId, reason) => deps.orchestrator.failTask(taskId, reason),
       syncFromDb: (workflowId) => deps.orchestrator.syncFromDb(workflowId),
       getTask: (taskId) => deps.orchestrator.getTask(taskId),
       getTaskLaunchReadiness: (taskId) => deps.orchestrator.getTaskLaunchReadiness(taskId),

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -123,6 +123,7 @@ async function dispatchHeadlessRunnableTasks(
     orchestrator: {
       prepareTaskForNewAttempt: (taskId, reason) =>
         deps.orchestrator.prepareTaskForNewAttempt(taskId, reason),
+      failTask: (taskId, reason) => deps.orchestrator.failTask(taskId, reason),
       syncFromDb: (workflowId) => deps.orchestrator.syncFromDb(workflowId),
       getTask: (taskId) => deps.orchestrator.getTask(taskId),
       getTaskLaunchReadiness: (taskId) => deps.orchestrator.getTaskLaunchReadiness(taskId),


### PR DESCRIPTION
## Summary

Headless launch dispatchers now receive the task-failure hook from the orchestrator.

This covers both immediate headless dispatch and tracked resume dispatch.

## Review Claim

The headless LaunchDispatcher construction sites include `failTask`, so exhausted abandons can fail tasks outside the desktop owner process.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The headless adapters only forward to the orchestrator method introduced earlier in the stack; no headless command flow changes.

## Slice Rationale

Headless entrypoints are a separate activation surface from the core dispatcher behavior and the desktop owner process.

## Non-goals

No change to core launch-dispatch behavior.

No change to desktop construction-site wiring.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- launch-dispatch-retry-budget-exhausted-repro.test.ts`

```text
 ✓ src/__tests__/launch-dispatch-retry-budget-exhausted-repro.test.ts (1 test) 28ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

- [x] `cd packages/app && pnpm test -- launch-dispatch-stuck-lease-retry-storm-repro.test.ts`

```text
 ✓ src/__tests__/launch-dispatch-stuck-lease-retry-storm-repro.test.ts (1 test) 24ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; headless dispatchers stop passing the hook through, while earlier stack slices remain revertable independently.
- Revert command: `git revert a56dbe22b`
- Post-revert steps: Rerun the two package/app commands from the test plan.
- Data migration? No.

</details>
