### PR TITLE
[Bugfix: admin-requeue planner treats a stale Mergify queue event as permanently active](1) Refresh stale queue events

### DIFF
--- a/scripts/mergify_admin_requeue_gh_executor.py
+++ b/scripts/mergify_admin_requeue_gh_executor.py
@@ -76,6 +76,10 @@ class AdminBypassGhExecutor:
         self.gh.comment(self.repo, pr.number, "@mergifyio queue")
         self.ledger.record("requeue", pr.number, pr.head_ref_oid, key, now)
 
+    def refresh_stale_queue(self, pr: PrSnapshot, key: str, now: int) -> None:
+        self.gh.comment(self.repo, pr.number, "@mergifyio refresh")
+        self.ledger.record("refresh-stale-queue", pr.number, pr.head_ref_oid, key, now)
+
     def restore_admin_bypass_label(self, pr: PrSnapshot, now: int) -> None:
         if self.ledger.count(RESTORE_ADMIN_BYPASS_LABEL_LEDGER_KIND, pr.number, pr.head_ref_oid, "admin-bypass") == 0:
             self.gh.edit_label(self.repo, pr.number, add="admin-bypass")
@@ -141,6 +145,7 @@ class AdminBypassGhExecutor:
         self.logger.trace("admin-bypass-action-execute", action=self.logger.action_payload(action))
         if action.kind in {
             "requeue",
+            "refresh_stale_queue",
             "restore_admin_bypass_label",
             "retarget_base",
             "comment_admin_bypass_nudge",
@@ -151,6 +156,9 @@ class AdminBypassGhExecutor:
             return False
         if action.kind == "requeue":
             self.requeue(pr, action.key, now)
+            return True
+        if action.kind == "refresh_stale_queue":
+            self.refresh_stale_queue(pr, action.key, now)
             return True
         if action.kind == "restore_admin_bypass_label":
             self.restore_admin_bypass_label(pr, now)

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Collection, Literal, Mapping
 
 try:
@@ -59,6 +60,9 @@ QUEUE_ONLY_REQUIRED_CHECKS = frozenset({
     "required-fast / Submit Workflow Chain",
 })
 ACTIVE_QUEUE_STATES = frozenset({"queued", "merging"})
+STALE_QUEUE_EVENT_TTL_SECONDS = 5400
+REFRESH_STALE_QUEUE_LEDGER_KIND = "refresh-stale-queue"
+STALE_QUEUE_EVENT_REFRESH_KEY = "admin-bypass-current-head"
 
 HUMAN_BLOCKER_KINDS = frozenset({"draft", "human_review_thread", "missing_check", "closed", "human_decision"})
 TERMINAL_BLOCKER_KINDS = frozenset({"merged"})
@@ -104,7 +108,48 @@ def is_queue_only_required_check(name: str) -> bool:
     return name in QUEUE_ONLY_REQUIRED_CHECKS
 
 
-def has_active_queue_event(pr: PrSnapshot) -> bool:
+def queue_event_queued_epoch(event: MergifyQueueEvent) -> int | None:
+    if not event.queued_at:
+        return None
+    try:
+        queued_at = datetime.fromisoformat(event.queued_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if queued_at.tzinfo is None:
+        queued_at = queued_at.replace(tzinfo=timezone.utc)
+    return int(queued_at.timestamp())
+
+
+def queue_event_is_stale(event: MergifyQueueEvent, now: int) -> bool:
+    queued_epoch = queue_event_queued_epoch(event)
+    if queued_epoch is None:
+        return False
+    return now - queued_epoch >= STALE_QUEUE_EVENT_TTL_SECONDS
+
+
+def has_stale_matching_head_queue_event(pr: PrSnapshot, now: int) -> bool:
+    latest = pr.latest_mergify
+    return bool(
+        latest
+        and latest.queue_rule_name == "admin-bypass"
+        and latest.state in ACTIVE_QUEUE_STATES
+        and latest.head_sha == pr.head_ref_oid
+        and queue_event_is_stale(latest, now)
+    )
+
+
+def stale_matching_head_queue_event_detail(pr: PrSnapshot) -> str:
+    latest = pr.latest_mergify
+    if not latest:
+        return "stale Mergify queue event on current head"
+    queued_at = latest.queued_at or "unknown time"
+    return (
+        f"stale Mergify queue event stayed {latest.state} on admin-bypass "
+        f"for current head since {queued_at}; force re-evaluation with @mergifyio refresh"
+    )
+
+
+def has_active_queue_event(pr: PrSnapshot, now: int) -> bool:
     latest = pr.latest_mergify
     if not latest:
         return False
@@ -118,7 +163,7 @@ def has_active_queue_event(pr: PrSnapshot) -> bool:
     if latest.queue_rule_name != "admin-bypass" or latest.state not in ACTIVE_QUEUE_STATES:
         return False
     if latest.head_sha == pr.head_ref_oid:
-        return True
+        return not queue_event_is_stale(latest, now)
     if not latest.head_sha:
         return True
     return "queued" in pr.labels
@@ -666,7 +711,7 @@ def summarize_stack(facts: StackFacts) -> dict[str, object]:
     }
 
 
-def wait_reason_for_facts(facts: StackFacts) -> str:
+def wait_reason_for_facts(facts: StackFacts, now: int) -> str:
     if facts.upper_stack_needs_acceptance:
         return "upper-stack-needs-acceptance"
     for pr in facts.stack.prs:
@@ -679,7 +724,7 @@ def wait_reason_for_facts(facts: StackFacts) -> str:
             return "terminal-merged"
         if HUMAN_BLOCKER_KINDS & blocker_kinds:
             return "blocked-needs-human"
-    if facts.bottom and has_active_queue_event(facts.bottom):
+    if facts.bottom and has_active_queue_event(facts.bottom, now):
         return "bottom-already-queued"
     return "no-action"
 
@@ -909,7 +954,7 @@ def plan_rebase_onto_base(pr: PrSnapshot, trunk: str, ledger: Ledger, max_attemp
     return Action("rebase_onto_base", pr.number, trunk, f"rebase #{pr.number} onto `{trunk}`: {reason}")
 
 
-def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts: int) -> Action | None:
+def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts: int, now: int) -> Action | None:
     if _bottom_has_pending_or_human_blocker(facts):
         return None
     if any(blocker.kind == "merge_hold" for blocker in facts.all_blockers):
@@ -951,8 +996,23 @@ def plan_bottom_progress(facts: StackFacts, ledger: Ledger, max_requeue_attempts
         return Action("comment_admin_bypass_nudge", bottom.number, "admin-bypass", "missing admin-bypass label")
     if facts.upper_stack_needs_acceptance:
         return None
-    if has_active_queue_event(bottom):
+    if has_active_queue_event(bottom, now):
         return None
+    if has_stale_matching_head_queue_event(bottom, now):
+        detail = stale_matching_head_queue_event_detail(bottom)
+        attempts = ledger.count(
+            REFRESH_STALE_QUEUE_LEDGER_KIND,
+            bottom.number,
+            bottom.head_ref_oid,
+            STALE_QUEUE_EVENT_REFRESH_KEY,
+        )
+        if attempts >= max_requeue_attempts:
+            return cap_action(
+                bottom,
+                Blocker(STALE_QUEUE_EVENT_REFRESH_KEY, "stale_queue_event", bottom.number, detail),
+                detail,
+            )
+        return Action("refresh_stale_queue", bottom.number, STALE_QUEUE_EVENT_REFRESH_KEY, detail)
     if bottom.base_ref_name == facts.trunk and facts.stale_base_by_pr.get(bottom.number):
         return plan_rebase_onto_base(bottom, facts.trunk, ledger, max_requeue_attempts, "base pointer moved but content was never rebased")
     requeue_reason = "eligible-when-ready"
@@ -993,7 +1053,7 @@ def plan_actions_from_facts(
             return ()
         if _bottom_has_pending_or_human_blocker(facts) or _bottom_has_repairable_blocker(facts):
             return ()
-        action = plan_bottom_progress(facts, ledger, max_requeue_attempts)
+        action = plan_bottom_progress(facts, ledger, max_requeue_attempts, now)
         if action is not None:
             return (action,)
     action = plan_mergify_queue_repairs(facts, ledger, max_repair_attempts, now)
@@ -1016,7 +1076,7 @@ def plan_actions_from_facts(
     action = plan_merge_hold_cleanup(facts, ledger)
     if action is not None:
         return (action,)
-    action = plan_bottom_progress(facts, ledger, max_requeue_attempts)
+    action = plan_bottom_progress(facts, ledger, max_requeue_attempts, now)
     if action is not None:
         return (action,)
     return ()
@@ -1074,7 +1134,7 @@ def plan_stack_execution(
             prereq_status=facts.prereq_status,
             queue_only_noop_check=facts.queue_only_noop_check,
         )
-    wait_reason = "repair-in-flight" if has_active_repair_for_current_blocker(facts, ledger, now_epoch) else wait_reason_for_facts(facts)
+    wait_reason = "repair-in-flight" if has_active_repair_for_current_blocker(facts, ledger, now_epoch) else wait_reason_for_facts(facts, now_epoch)
     return StackExecutionPlan(
         summary=summary,
         actions=(),

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -33,12 +33,20 @@ def check(state, name="build"):
     return m.CheckContext(name=name, state=state, details_url="", head_sha=HEAD, completed_at="")
 
 
-def event(state="dequeued", head=HEAD, comment_id="cm1", failing=(), conditions=(), queue_rule_name="admin-bypass"):
+def event(
+    state="dequeued",
+    head=HEAD,
+    comment_id="cm1",
+    failing=(),
+    conditions=(),
+    queue_rule_name="admin-bypass",
+    queued_at="2026-07-07T05:00:00Z",
+):
     return m.MergifyQueueEvent(
         comment_id=comment_id,
         state=state,
         queue_rule_name=queue_rule_name,
-        queued_at="2026-07-07T05:00:00Z",
+        queued_at=queued_at,
         head_sha=head,
         waiting_for=(),
         failing_checks=failing,
@@ -511,6 +519,40 @@ class PlanStackActions(PlannerTestCase):
         )
         self.assertEqual(plan.actions, ())
         self.assertEqual(plan.wait_reason, "bottom-already-queued")
+
+    def test_stale_matching_head_queue_event_refreshes_then_hands_off_after_cap(self):
+        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="queued", head=HEAD))
+        ledger = self._ledger()
+
+        actions = self._plan(snapshot, ledger)
+        self.assertEqual(
+            (actions[0].kind, actions[0].key),
+            ("refresh_stale_queue", p.STALE_QUEUE_EVENT_REFRESH_KEY),
+        )
+
+        ledger.record(
+            p.REFRESH_STALE_QUEUE_LEDGER_KIND,
+            1,
+            HEAD,
+            p.STALE_QUEUE_EVENT_REFRESH_KEY,
+            epoch=NOW - 2,
+        )
+        ledger.record(
+            p.REFRESH_STALE_QUEUE_LEDGER_KIND,
+            1,
+            HEAD,
+            p.STALE_QUEUE_EVENT_REFRESH_KEY,
+            epoch=NOW - 1,
+        )
+        actions = self._plan(snapshot, ledger)
+        self.assertEqual((actions[0].kind, actions[0].key), ("comment_blocked", "capped"))
+        self.assertIn("stale Mergify queue event", actions[0].detail)
+
+        fresh = pr(
+            labels=frozenset({"admin-bypass"}),
+            latest_mergify=event(state="queued", head=HEAD, queued_at="2033-05-18T03:33:00Z"),
+        )
+        self.assertEqual(self._plan(fresh), ())
 
     def test_pending_queue_command_suppresses_requeue(self):
         # Incident 2026-08-04 (PR #7420): a `queue` command still evaluating


### PR DESCRIPTION
## Summary

The admin-requeue planner now treats stale matching-head Mergify queue events as recoverable work instead of waiting forever.

Fresh active queue events still wait as before. Stale events trigger a ledger-capped `@mergifyio refresh`, then fall back to human handoff when the cap is exhausted.

The executor now dispatches the new refresh action and records the same ledger key the planner uses for the cap.

## Review Claim

Approve the stale queue-event policy: `has_active_queue_event` stops treating matching-head `queued` or `merging` events as active after `STALE_QUEUE_EVENT_TTL_SECONDS`, `plan_bottom_progress` emits `refresh_stale_queue` until the cap is reached, and `AdminBypassGhExecutor.execute()` posts `@mergifyio refresh` for that action.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The planner never silently treats a queue event as active indefinitely. Past the bounded staleness window, it must either force re-evaluation or hand off to a human.

Fresh events remain guarded by `has_active_queue_event`: scripts/mergify_admin_requeue_plan.py:152 returns active for a matching-head event only when `queue_event_is_stale` is false, and scripts/test_mergify_admin_requeue_plan.py:551 keeps the fresh-event no-action case covered.

## Slice Rationale

This is one review claim across the planner and executor because the new action kind is not reviewable without its dispatch path.

The empty verification commit from the Invoker task was folded into this publication slice. Publishing an empty proof-only stack predecessor would violate the repo stack publication rule against empty slices.

## Non-goals

No change to ordinary requeue behavior.

No change to stale-base repair, failed-check repair, merge-hold cleanup, or dry-run text rendering in `scripts/mergify_admin_requeue_exec.py`.

No UI, docs, or schema changes.

## Architecture

### Before

```mermaid
graph TD
    A["matching-head Mergify queue event is queued or merging"] --> B["has_active_queue_event returns true"]
    B --> C["plan_bottom_progress returns no action"]
```

### After

```mermaid
graph TD
    A["matching-head Mergify queue event is queued or merging"] --> B["queue_event_is_stale checks queued_at against now"]
    B --> C["fresh event waits with no action"]
    B --> D["stale event emits refresh_stale_queue while under cap"]
    D --> E["AdminBypassGhExecutor posts @mergifyio refresh and records refresh-stale-queue"]
    B --> F["cap exhausted emits comment_blocked human handoff"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 scripts/test_mergify_admin_requeue_plan.py`

```text
Ran 70 tests in 33.639s
OK
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f47e9d782`
- Post-revert steps: Rerun `python3 scripts/test_mergify_admin_requeue_plan.py`
- Data migration? No

</details>
