### PR TITLE
[General alert channel (3) publish helper](1) Add surface alert publisher

### DIFF
--- a/packages/app/src/surface-event-relay.ts
+++ b/packages/app/src/surface-event-relay.ts
@@ -28,6 +28,19 @@ export interface SurfaceEventRelayDeps {
   logWarn: (message: string) => void;
 }
 
+export interface SurfaceAlertFields {
+  readonly severity: string;
+  readonly source: string;
+  readonly subject: string;
+  readonly message: string;
+  readonly alertKey: string;
+}
+
+export interface SurfaceAlertEvent {
+  readonly type: 'alert';
+  readonly alert: SurfaceAlertFields;
+}
+
 const PROGRESS_DEBOUNCE_MS = 2500;
 const TERMINAL_DERIVED_STATUSES = new Set(['completed', 'failed', 'closed']);
 
@@ -59,6 +72,44 @@ function reviewStateLabel(substate: ReturnType<typeof buildReviewGateQueryRespon
     default:
       return undefined;
   }
+}
+
+export function publishSurfaceAlert(messageBus: MessageBus, alert: SurfaceAlertFields): void;
+export function publishSurfaceAlert(
+  messageBus: MessageBus,
+  severity: string,
+  source: string,
+  subject: string,
+  message: string,
+  alertKey: string,
+): void;
+export function publishSurfaceAlert(
+  messageBus: MessageBus,
+  alertOrSeverity: SurfaceAlertFields | string,
+  source?: string,
+  subject?: string,
+  message?: string,
+  alertKey?: string,
+): void {
+  const alert = typeof alertOrSeverity === 'string'
+    ? {
+        severity: alertOrSeverity,
+        source: source ?? '',
+        subject: subject ?? '',
+        message: message ?? '',
+        alertKey: alertKey ?? '',
+      }
+    : {
+        severity: alertOrSeverity.severity,
+        source: alertOrSeverity.source,
+        subject: alertOrSeverity.subject,
+        message: alertOrSeverity.message,
+        alertKey: alertOrSeverity.alertKey,
+      };
+  messageBus.publish<SurfaceAlertEvent>(Channels.SURFACE_EVENT, {
+    type: 'alert',
+    alert,
+  });
 }
 
 export function startSurfaceEventRelay(deps: SurfaceEventRelayDeps): () => void {


### PR DESCRIPTION
## Summary

Depends on the prior alert-event workflow's merge.

This adds `publishSurfaceAlert` beside the existing surface-event relay.

The helper publishes one alert event on `Channels.SURFACE_EVENT`, with the alert values nested under `alert`.

No product caller is wired yet. The existing workflow-progress relay keeps its debounced task-delta path.

## Review Claim

A new exported helper routes one alert event through the existing surface-event bus, while the workflow-progress relay remains on its current debounced path.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The helper is standalone and shares no state, timer, or subscription with `startSurfaceEventRelay`.

It calls `messageBus.publish(Channels.SURFACE_EVENT, ...)` once per invocation, so it cannot change when workflow-progress cards are emitted.

## Slice Rationale

This is the smallest callable transport slice for the existing alert payload.

The worker that decides when to send an alert belongs in a separate workflow with its own review claim.

## Non-goals

- No caller is added for the helper.
- No Slack rendering changes.
- No query command changes.
- No change to `emitWorkflowProgress` or its debounce behavior.

## Architecture

### Before

```mermaid
graph TD
    Shape["Alert event shape exists"] --> Missing["No owner-process alert send helper"]
    Progress["emitWorkflowProgress"] --> Bus["messageBus.publish(Channels.SURFACE_EVENT, workflow_progress)"]
```

### After

```mermaid
graph TD
    Caller["Future owner-process caller"] --> Helper["publishSurfaceAlert(...)"]
    Helper --> Bus["messageBus.publish(Channels.SURFACE_EVENT, alert)"]
    Progress["emitWorkflowProgress debounced path"] --> Bus
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `cd packages/app && pnpm test`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/general-alert-channel-publish-helper-pr.md --base master`
- [x] `node scripts/safe-stack-push.mjs --skip-rebase`
- [x] `node scripts/safe-stack-push.mjs --skip-rebase --execute`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>
