### PR TITLE
[General alert channel (2) alert event shape](1) Add SurfaceEvent alert member

### DIFF
--- a/packages/surfaces/src/slack/slack-formatter.ts
+++ b/packages/surfaces/src/slack/slack-formatter.ts
@@ -292,5 +292,7 @@ export function formatSurfaceEvent(event: SurfaceEvent): SlackMessage | null {
       return null;
     case 'error':
       return formatError(event.message);
+    case 'alert':
+      return null;
   }
 }

--- a/packages/surfaces/src/surface.ts
+++ b/packages/surfaces/src/surface.ts
@@ -96,6 +96,14 @@ export type SurfaceEvent =
   | { type: 'workflow_status'; status: WorkflowStatus; workflowId?: string }
   | { type: 'workflow_progress'; progress: WorkflowProgress }
   | {
+      type: 'alert';
+      severity: 'info' | 'warning' | 'critical';
+      source: string;
+      subject: string;
+      message: string;
+      alertKey: string;
+    }
+  | {
       type: 'workflow_created';
       workflowId: string;
       requestedBy?: string;
@@ -106,6 +114,17 @@ export type SurfaceEvent =
       planFile?: string;
     }
   | { type: 'error'; message: string };
+
+type SurfaceEventTypecheck<T extends SurfaceEvent> = T;
+
+type SurfaceAlertEventTypecheck = SurfaceEventTypecheck<{
+  type: 'alert';
+  severity: 'info';
+  source: string;
+  subject: string;
+  message: string;
+  alertKey: string;
+}>;
 
 // ── Logging ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Depends on the ledger-detail workflow's merge.

This adds one general alert member to the shared SurfaceEvent contract.

The alert carries severity, source, subject, message, and alertKey.

No publisher or subscriber is added here. The one existing exhaustive switch over this union (Slack's event router) needed a matching no-op case added so it keeps compiling -- see Safety Invariant.

## Review Claim

SurfaceEvent gains one new alert member with severity, source, subject, message, and alertKey; every existing member remains unchanged.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This is a pure addition to a discriminated union.

Existing SurfaceEvent members keep the same fields and the same handling.

Adding a union member makes every exhaustive switch over it a compile error until each one adds a matching case, so this PR also adds one `case 'alert': return null;` branch to the Slack event router -- the same no-op pattern that router already uses for `workflow_created`. This returns null, not a rendered message, so it renders nothing and adds no new behavior; it only keeps the file compiling.

## Slice Rationale

The alert shape is the shared contract that later publisher and consumer workflows need.

Landing the shape first keeps this slice to the contract file plus the one compile-compatibility case a TypeScript exhaustive switch requires; no other file changes.

## Non-goals

- No publisher is added.
- No Slack rendering is added -- the added switch case returns null.
- No query command is added.
- No existing SurfaceEvent member changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test`
- [x] `pnpm --filter @invoker/surfaces build`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>
