### PR TITLE
[Fix: recreate/rerun preemption detaches a live downstream dependency](1) Add dependency-preserving workflow preemption

### DIFF
--- a/packages/workflow-core/src/__tests__/repro-recreate-preemption-detaches-downstream.test.ts
+++ b/packages/workflow-core/src/__tests__/repro-recreate-preemption-detaches-downstream.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { CommandService } from '../command-service.js';
+import {
+  InMemoryPersistence,
+  makeOrchestrator,
+  setupChain,
+} from './helpers/cross-workflow-cascade-helpers.js';
+
+describe('REPRO: recreate preemption detaches a live downstream dependency', () => {
+  it('CommandService.preemptWorkflow must not detach downstream externalDependencies', async () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const commandService = new CommandService(orchestrator);
+    const ctx = setupChain(orchestrator);
+
+    expect(persistence.loadWorkflow(ctx.downstreamWfId)!.externalDependencies).toEqual([
+      {
+        workflowId: ctx.upstreamWfId,
+        taskId: '__merge__',
+        requiredStatus: 'completed',
+        gatePolicy: 'completed',
+      },
+    ]);
+    expect(orchestrator.getTask(ctx.downstreamLastId)!.status).toBe('running');
+
+    persistence.updateTask(ctx.upstreamTaskId, { status: 'running' });
+    expect(
+      persistence.getTaskEntry(ctx.upstreamTaskId)!.task.status,
+      'upstream task must be active before preemption, or the cancellation this test asserts is a no-op',
+    ).toBe('running');
+
+    const preemptResult = await commandService.preemptWorkflow({
+      commandId: 'cmd-preempt-upstream',
+      source: 'headless',
+      scope: 'workflow',
+      idempotencyKey: 'idemp-preempt-1',
+      payload: { workflowId: ctx.upstreamWfId },
+    });
+    expect(preemptResult.ok).toBe(true);
+    expect(preemptResult.ok && preemptResult.data.runningCancelled).toEqual([ctx.upstreamTaskId]);
+
+    expect(
+      persistence.loadWorkflow(ctx.downstreamWfId)!.externalDependencies,
+      'downstream must remain gated on the upstream while a recreate is in flight',
+    ).toEqual([
+      {
+        workflowId: ctx.upstreamWfId,
+        taskId: '__merge__',
+        requiredStatus: 'completed',
+        gatePolicy: 'completed',
+      },
+    ]);
+  });
+
+  it('CommandService.cancelWorkflow (the real standalone abandon action) must still detach downstream', async () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const commandService = new CommandService(orchestrator);
+    const ctx = setupChain(orchestrator);
+
+    const cancelResult = await commandService.cancelWorkflow({
+      commandId: 'cmd-cancel-upstream',
+      source: 'ui',
+      scope: 'workflow',
+      idempotencyKey: 'idemp-cancel-1',
+      payload: { workflowId: ctx.upstreamWfId },
+    });
+    expect(cancelResult.ok).toBe(true);
+
+    expect(
+      persistence.loadWorkflow(ctx.downstreamWfId)!.externalDependencies,
+      'a genuinely abandoned upstream must still detach its downstream dependents',
+    ).toBeUndefined();
+  });
+});

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -434,6 +434,21 @@ export class CommandService {
     );
   }
 
+  /**
+   * Cancel a workflow's own in-flight tasks as a preamble to rerunning it (recreate, retry,
+   * rebase-recreate, rebase-retry), without detaching downstream workflows gated on it via
+   * externalDependencies. Unlike cancelWorkflow, this workflow is expected to complete again shortly.
+   */
+  async preemptWorkflow(
+    envelope: CommandEnvelope<{ workflowId: string }>,
+  ): Promise<CommandResult<CancelResult>> {
+    return this.executeCommand<CancelResult>(
+      'PREEMPT_WORKFLOW_FAILED',
+      () => this.orchestrator.cancelWorkflow(envelope.payload.workflowId, { detachDependents: false }),
+      envelope.payload.workflowId,
+    );
+  }
+
   async deleteWorkflow(
     envelope: CommandEnvelope<{ workflowId: string }>,
   ): Promise<CommandResult<void>> {


### PR DESCRIPTION
## Summary

Adds a preemption-specific workflow cancellation path in workflow-core.

Temporary rerun preemption now preserves downstream dependency links while the upstream workflow is expected to run again.

Permanent workflow cancellation still uses the existing abandon path that detaches downstream dependents.

## Review Claim

The workflow-core preemption path cancels a workflow for temporary preemption without detaching downstream externalDependencies, while permanent abandonment keeps detaching them.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`Orchestrator.cancelWorkflow` defaults and permanent-abandon behavior stay unchanged; only the new explicit preemption path passes `detachDependents: false`.

## Slice Rationale

The lower-level behavior lands in its own PR so the PR Body check sees only the routing review unit.

## Non-goals

- No app caller edits.
- No GUI or CLI exposure.
- No PR body policy change.
- No unrelated cleanup.

## Architecture

### Before

```mermaid
graph TD
    A["Temporary rerun preemption"] --> B["CommandService.cancelWorkflow"]
    B --> C["Orchestrator.cancelWorkflow default detachDependents true"]
    C --> D["Downstream externalDependencies detached"]
```

### After

```mermaid
graph TD
    A["Temporary rerun preemption"] --> B["CommandService.preemptWorkflow"]
    B --> C["Orchestrator.cancelWorkflow detachDependents false"]
    C --> D["Downstream externalDependencies preserved"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --dir packages/workflow-core test -- src/__tests__/repro-recreate-preemption-detaches-downstream.test.ts`
  Output: `Test Files  44 passed (44)`
  Output: `Tests  892 passed | 3 skipped (895)`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 59e77521a`
- Post-revert steps: Revert dependent stack slices first.
- Data migration? No

</details>
