### PR TITLE
[Fix: recreate/rerun preemption detaches a live downstream dependency](2) Use preemption path before reruns

### DIFF
--- a/packages/app/src/__tests__/headless-preempt-workflow-race.test.ts
+++ b/packages/app/src/__tests__/headless-preempt-workflow-race.test.ts
@@ -28,7 +28,7 @@ function makeDeps(overrides: {
       loadWorkflow: vi.fn(() => (overrides.workflowExists ? { id: 'wf-1' } : undefined)),
     } as unknown as SQLiteAdapter,
     commandService: {
-      cancelWorkflow: vi.fn(async () => ({ ok: false, error: overrides.cancelWorkflowError })),
+      preemptWorkflow: vi.fn(async () => ({ ok: false, error: overrides.cancelWorkflowError })),
     } as unknown as CommandService,
     executorRegistry: {} as any,
     messageBus: {} as any,

--- a/packages/app/src/__tests__/repro-recreate-preemption-detaches-downstream.e2e.test.ts
+++ b/packages/app/src/__tests__/repro-recreate-preemption-detaches-downstream.e2e.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { makeEnvelope } from '@invoker/contracts';
+import { Orchestrator, CommandService } from '@invoker/workflow-core';
+import { InMemoryBus, InMemoryPersistence } from '@invoker/test-kit';
+import { preemptWorkflowExecution } from '../headless-shared.js';
+import { preemptWorkflowBeforeMutation } from '../workflow-preemption.js';
+import type { HeadlessDeps } from '../headless.js';
+
+function buildGatedDownstreamChain(orchestrator: Orchestrator) {
+  orchestrator.loadPlan({
+    name: 'upstream',
+    repoUrl: 'memory://test-repo',
+    baseBranch: 'master',
+    featureBranch: 'feature/upstream',
+    tasks: [{ id: 'verify-upstream', description: 'upstream prerequisite' }],
+  });
+  const upstreamTaskId = orchestrator.getAllTasks().find(
+    (t) => !t.config.isMergeNode && t.id.endsWith('/verify-upstream'),
+  )!.id;
+  const upstreamWfId = upstreamTaskId.split('/')[0]!;
+  const upstreamMergeId = `__merge__${upstreamWfId}`;
+
+  orchestrator.loadPlan({
+    name: 'downstream',
+    repoUrl: 'memory://test-repo',
+    baseBranch: 'feature/upstream',
+    featureBranch: 'feature/downstream',
+    tasks: [
+      {
+        id: 'root',
+        description: 'downstream root waits for upstream merge gate',
+        externalDependencies: [{ workflowId: upstreamWfId, gatePolicy: 'completed' }],
+      },
+      { id: 'mid', description: 'downstream mid depends on root', dependencies: ['root'] },
+    ],
+  });
+  const downstreamRootId = orchestrator.getAllTasks().find((t) => t.id.endsWith('/root'))!.id;
+  const downstreamWfId = downstreamRootId.split('/')[0]!;
+  const downstreamMidId = `${downstreamWfId}/mid`;
+
+  orchestrator.startExecution();
+  orchestrator.handleWorkerResponse({
+    requestId: 'req-upstream-task', actionId: upstreamTaskId, executionGeneration: 0,
+    status: 'completed', outputs: { exitCode: 0 },
+  });
+  orchestrator.handleWorkerResponse({
+    requestId: 'req-upstream-merge', actionId: upstreamMergeId, executionGeneration: 0,
+    status: 'completed', outputs: { exitCode: 0 },
+  });
+  expect(orchestrator.getTask(downstreamRootId)!.status).toBe('running');
+  orchestrator.handleWorkerResponse({
+    requestId: 'req-downstream-root', actionId: downstreamRootId, executionGeneration: 0,
+    status: 'completed', outputs: { exitCode: 0 },
+  });
+  expect(orchestrator.getTask(downstreamMidId)!.status).toBe('running');
+
+  return { upstreamWfId, downstreamWfId, downstreamRootId, downstreamMidId };
+}
+
+describe('E2E: recreate command must not detach a live downstream dependency', () => {
+  it('preempt-then-recreate on the upstream keeps the downstream gate intact and blocked', async () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = new Orchestrator({
+      persistence,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 8,
+      resolveRepoDefaultBranch: () => 'master',
+    } as never);
+    const commandService = new CommandService(orchestrator);
+    const deps = { commandService } as unknown as HeadlessDeps;
+
+    const ctx = buildGatedDownstreamChain(orchestrator);
+
+    expect(persistence.loadWorkflow(ctx.downstreamWfId)!.externalDependencies).toEqual([
+      { workflowId: ctx.upstreamWfId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
+    ]);
+
+    await preemptWorkflowBeforeMutation(ctx.upstreamWfId, {
+      preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
+      context: 'headless.recreate-workflow',
+    });
+    const recreateResult = await commandService.recreateWorkflow(
+      makeEnvelope('recreate-workflow', 'headless', 'workflow', { workflowId: ctx.upstreamWfId }),
+    );
+    expect(recreateResult.ok).toBe(true);
+
+    expect(
+      persistence.loadWorkflow(ctx.downstreamWfId)!.externalDependencies,
+      'downstream must remain gated on the upstream after a recreate command',
+    ).toEqual([
+      { workflowId: ctx.upstreamWfId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
+    ]);
+    expect(
+      orchestrator.getExecutableReadyTasks().map((t) => t.id),
+      'downstream root must not become executable while its upstream gate is unsatisfied',
+    ).not.toContain(ctx.downstreamRootId);
+    expect(orchestrator.getTask(ctx.downstreamMidId)!.status).toBe('pending');
+  });
+});

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -458,11 +458,11 @@ export async function preemptWorkflowExecution(workflowId: string, deps: Headles
   if (deps.preemptWorkflowExecution) {
     return deps.preemptWorkflowExecution(workflowId);
   }
-  if (typeof deps.commandService.cancelWorkflow !== 'function') {
+  if (typeof deps.commandService.preemptWorkflow !== 'function') {
     return { cancelled: [], runningCancelled: [] };
   }
-  const envelope = makeEnvelope('cancel-workflow', 'headless', 'workflow', { workflowId });
-  const result = await deps.commandService.cancelWorkflow(envelope);
+  const envelope = makeEnvelope('preempt-workflow', 'headless', 'workflow', { workflowId });
+  const result = await deps.commandService.preemptWorkflow(envelope);
   if (!result.ok) {
     if (preemptSkipCodes.has(result.error.code)) return { cancelled: [], runningCancelled: [] };
     if (isRaceLostForeignKeyConstraintFailure(result.error.message, workflowId, deps)) {


### PR DESCRIPTION
## Summary

The shared headless rerun preamble now calls the preemption path.

All rerun entrypoints keep live downstream dependency gates attached.

The standalone cancel action still uses the abandonment path from the prior slice.

## Review Claim

Headless rerun flows use dependency-preserving preemption before they reset an upstream workflow.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the shared pre-rerun preamble changes call targets.

Standalone cancellation still reaches `CommandService.cancelWorkflow`.

The prior slice owns the workflow-core behavior this surface now calls.

## Slice Rationale

This slice activates the new preemption path at the one shared headless rerun boundary.

Keeping activation separate from workflow-core behavior makes the caller change locally reviewable.

## Non-goals

- No change to standalone cancel behavior.
- No change to workflow retry or recreate invalidation semantics.
- No change to unrelated foreign-key handling in `headless-shared.ts`.

## Architecture

### Before

```mermaid
graph TD
    A["Headless recreate / retry / rebase"] --> B["preemptWorkflowExecution"]
    B --> C["CommandService.cancelWorkflow"]
    C --> D["Downstream dependency link detached"]
```

### After

```mermaid
graph TD
    A["Headless recreate / retry / rebase"] --> B["preemptWorkflowExecution"]
    B --> C["CommandService.preemptWorkflow"]
    C --> D["Downstream dependency link remains attached"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `(cd packages/app && pnpm test)`
  Output: `Test Files  196 passed (196)`
  Output: `Tests  1934 passed | 3 skipped (1937)`
- [x] `(cd packages/workflow-core && pnpm test)`
  Output: `Test Files  43 passed (43)`
  Output: `Tests  882 passed | 3 skipped (885)`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9099856f4`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow preemption handling to use the correct preemption action.
  * Preserved existing fallback and error-handling behavior during preemption.
  * Fixed a race condition where recreating a preempted workflow could detach downstream dependencies.
  * Ensured dependent tasks remain correctly pending after workflow recreation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->