### PR TITLE
[Headless set-merge-branch](1) domain layer

### DIFF
--- a/packages/app/src/__tests__/headless-set-merge-branch.test.ts
+++ b/packages/app/src/__tests__/headless-set-merge-branch.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { LocalBus } from '@invoker/transport';
+import type { CommandService } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import { headlessSetMergeBranch } from '../headless-run-resume.js';
+import type { HeadlessDeps } from '../headless-shared.js';
+
+describe('headless set merge-branch', () => {
+  let mockDeps: HeadlessDeps;
+
+  beforeEach(() => {
+    const noopLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(() => noopLogger),
+    };
+    mockDeps = {
+      logger: noopLogger as any,
+      orchestrator: {
+        startExecution: vi.fn(() => []),
+        syncFromDb: vi.fn(),
+      } as any,
+      persistence: {
+        readOnly: false,
+        loadWorkflow: vi.fn(() => ({
+          id: 'wf-1',
+          name: 'test-workflow',
+          generation: 0,
+          status: 'running' as const,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        })),
+        loadTasks: vi.fn(() => [
+          {
+            id: 'wf-1/task-1',
+            status: 'pending',
+            config: { workflowId: 'wf-1' },
+            execution: {},
+          } as any,
+          {
+            id: 'wf-1/merge',
+            status: 'failed',
+            config: { workflowId: 'wf-1', isMergeNode: true },
+            execution: {},
+          } as any,
+        ]),
+        updateWorkflow: vi.fn(),
+      } as unknown as SQLiteAdapter,
+      commandService: {
+        retryTask: vi.fn(async () => ({ ok: true as const, data: [] })),
+      } as unknown as CommandService,
+      executorRegistry: {} as any,
+      messageBus: new LocalBus() as any,
+      repoRoot: '/fake/repo',
+      invokerConfig: {} as any,
+      initServices: vi.fn(async () => {}),
+      noTrack: true,
+      ownerTaskRunnerProvider: () => ({ executeTasks: vi.fn(async () => {}) } as any),
+    } as HeadlessDeps;
+  });
+
+  it('updates the workflow base branch and retries the merge task', async () => {
+    await headlessSetMergeBranch('wf-1', 'fix/some-branch', mockDeps);
+
+    expect(mockDeps.persistence.updateWorkflow).toHaveBeenCalledWith(
+      'wf-1',
+      { baseBranch: 'fix/some-branch' },
+    );
+    expect(mockDeps.commandService.retryTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandId: 'set-merge-branch',
+        source: 'headless',
+        scope: 'task',
+        payload: { taskId: 'wf-1/merge' },
+      }),
+    );
+  });
+});

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -15,7 +15,7 @@ import {
   type StartReadyRequest,
   type StartReadyResult,
 } from '@invoker/contracts';
-import type { TaskState } from '@invoker/workflow-core';
+import { normalizeWorkflowBaseBranch, type TaskState } from '@invoker/workflow-core';
 import {
   remoteFetchForPool,
   registerBuiltinAgents,
@@ -627,6 +627,35 @@ export async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Pro
       printTaskOutput: true,
       setExitCodeOnFailure: false,
     });
+  });
+}
+
+export async function headlessSetMergeBranch(
+  workflowId: string,
+  baseBranchArg: string,
+  deps: HeadlessDeps,
+): Promise<void> {
+  deps.persistence.updateWorkflow(workflowId, {
+    baseBranch: normalizeWorkflowBaseBranch(baseBranchArg),
+  });
+
+  const tasks = deps.persistence.loadTasks(workflowId);
+  const mergeTask = tasks.find((task) => task.config.isMergeNode);
+  if (!mergeTask) return;
+
+  const envelope = makeEnvelope('set-merge-branch', 'headless', 'task', { taskId: mergeTask.id });
+  const result = await deps.commandService.retryTask(envelope);
+  if (!result.ok) throw new Error(result.error.message);
+
+  const taskExecutor = createHeadlessExecutor(deps);
+  await dispatchStartedTasksWithGlobalTopup({
+    orchestrator: deps.orchestrator,
+    taskExecutor,
+    logger: deps.logger,
+    context: 'headless.set-merge-branch',
+    started: result.data,
+    scopedTaskIds: [mergeTask.id],
+    mutationTiming: deps.mutationTiming,
   });
 }
 


### PR DESCRIPTION
## Summary

This adds a headless-callable domain helper for `invoker:set-merge-branch`.

The helper updates a workflow's `baseBranch`, finds its merge task, and relaunches that task through the existing command service path.

The function is exported from `headless-run-resume.ts` but no CLI route calls it in this slice.

The direct unit test covers the update and retry envelope without depending on the Electron GUI.

## Review Claim

Adds an exported `headlessSetMergeBranch` function to `packages/app/src/headless-run-resume.ts` that updates a workflow's `baseBranch` and relaunches its merge task, with no CLI wiring in this slice.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The GUI's `invoker:set-merge-branch` IPC handler keeps its existing body untouched.

This slice only adds a headless helper next to the existing `rebaseRetry` and `rebaseRecreate` helpers, and no transport path invokes it yet.

## Slice Rationale

This is the domain layer for a two-workflow stack.

The mutation function lands first so the transport slice can wire a tested helper instead of mixing behavior and CLI exposure.

## Non-goals

- No change to `packages/app/src/ipc/gui-mutation-handlers.ts`.
- No change to `packages/app/src/web/web-invoker-dispatch.ts`.
- No change to `packages/app/src/headless-command-registry.ts`, `packages/app/src/headless.ts`, or `packages/app/src/headless-usage.ts`.
- No attempt to repair any live workflow state.

## Architecture

### Before

```mermaid
graph TD
    GUI["Electron IPC handler: invoker:set-merge-branch"] --> Persist["persistence.updateWorkflow(baseBranch)"]
    GUI --> Retry["commandService.retryTask(merge task)"]
    Headless["Headless runtime"] --> Missing["No callable set-merge-branch helper"]
```

### After

```mermaid
graph TD
    GUI["Electron IPC handler remains unchanged"] --> Persist["persistence.updateWorkflow(baseBranch)"]
    Helper["headlessSetMergeBranch()"] --> Persist
    Helper --> Retry["commandService.retryTask(merge task)"]
    CLI["Headless CLI"] --> Unwired["No command wiring in this slice"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- headless-set-merge-branch`

```text
✓ src/__tests__/headless-set-merge-branch.test.ts (1 test) 4ms
Test Files  1 passed (1)
Tests  1 passed (1)
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f75b349d2`
- Post-revert steps: None
- Data migration? No

</details>
