### PR TITLE
[Standalone invoker-watcher (1) core package](1) Core package

### DIFF
--- a/packages/watcher/package.json
+++ b/packages/watcher/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@invoker/watcher",
+  "version": "0.0.11",
+  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsup",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@invoker/slack-manager": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.3",
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/watcher/src/__tests__/invoker-watcher.test.ts
+++ b/packages/watcher/src/__tests__/invoker-watcher.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createInvokerWatcher } from '../invoker-watcher.js';
+
+describe('createInvokerWatcher', () => {
+  const downThresholdMs = 20 * 60_000;
+  const restartCooldownMs = 15 * 60_000;
+  let healthy: boolean;
+  let currentTime: number;
+  let isHealthy: ReturnType<typeof vi.fn<() => Promise<boolean>>>;
+  let restart: ReturnType<typeof vi.fn<() => Promise<void>>>;
+  let log: ReturnType<typeof vi.fn<(level: string, message: string) => void>>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    healthy = true;
+    currentTime = 0;
+    isHealthy = vi.fn(async () => healthy);
+    restart = vi.fn(async () => {});
+    log = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function makeWatcher() {
+    return createInvokerWatcher({
+      client: { isHealthy },
+      restart,
+      log,
+      pollIntervalMs: 1_000,
+      downThresholdMs,
+      restartCooldownMs,
+      now: () => currentTime,
+    });
+  }
+
+  async function flushPromises(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  it('does not restart before the continuous unhealthy threshold elapses', async () => {
+    const watcher = makeWatcher();
+    healthy = false;
+
+    await watcher.tick();
+    currentTime = downThresholdMs - 1;
+    await watcher.tick();
+
+    expect(restart).not.toHaveBeenCalled();
+  });
+
+  it('restarts exactly once at the continuous unhealthy threshold', async () => {
+    const watcher = makeWatcher();
+    healthy = false;
+
+    await watcher.tick();
+    currentTime = downThresholdMs;
+    await watcher.tick();
+    await watcher.tick();
+
+    expect(restart).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith('error', expect.stringContaining(`${downThresholdMs}ms`));
+  });
+
+  it('respects restart cooldown during one continuous unhealthy period', async () => {
+    const watcher = makeWatcher();
+    healthy = false;
+
+    await watcher.tick();
+    currentTime = downThresholdMs;
+    await watcher.tick();
+    currentTime = downThresholdMs + restartCooldownMs - 1;
+    await watcher.tick();
+    currentTime = downThresholdMs + restartCooldownMs;
+    await watcher.tick();
+
+    expect(restart).toHaveBeenCalledTimes(2);
+  });
+
+  it('requires a fresh threshold window after a healthy poll', async () => {
+    const watcher = makeWatcher();
+    healthy = false;
+
+    await watcher.tick();
+    currentTime = downThresholdMs;
+    await watcher.tick();
+
+    healthy = true;
+    await watcher.tick();
+
+    healthy = false;
+    currentTime += 1;
+    await watcher.tick();
+    currentTime += downThresholdMs - 1;
+    await watcher.tick();
+    expect(restart).toHaveBeenCalledTimes(1);
+
+    currentTime += 1;
+    await watcher.tick();
+    expect(restart).toHaveBeenCalledTimes(2);
+  });
+
+  it('starts immediately, keeps polling, and logs individual tick failures', async () => {
+    isHealthy
+      .mockRejectedValueOnce(new Error('ipc unavailable'))
+      .mockResolvedValue(true);
+    const watcher = makeWatcher();
+
+    watcher.start();
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(1_000);
+    watcher.stop();
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(isHealthy).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenCalledWith('error', 'watcher tick failed: ipc unavailable');
+  });
+});

--- a/packages/watcher/src/index.ts
+++ b/packages/watcher/src/index.ts
@@ -1,0 +1,64 @@
+import { execFile } from 'node:child_process';
+
+import { IpcInvokerClient } from '@invoker/slack-manager/src/invoker-client.js';
+
+import { createInvokerWatcher } from './invoker-watcher.js';
+
+function readDurationEnv(name: string): number | undefined {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return undefined;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative number of milliseconds`);
+  }
+  return value;
+}
+
+function makeLog(): (level: string, message: string) => void {
+  return (level, message) => {
+    const line = `[watcher] ${new Date().toISOString()} ${level.toUpperCase()} ${message}`;
+    if (level === 'error') console.error(line);
+    else console.log(line);
+  };
+}
+
+function restartService(service: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile('systemctl', ['--user', 'restart', service], (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  const log = makeLog();
+  const service = process.env.INVOKER_WATCHER_RESTART_SERVICE ?? 'slack-manager.service';
+  const client = new IpcInvokerClient({
+    spawnInvoker: () => {},
+    log,
+  });
+  const watcher = createInvokerWatcher({
+    client,
+    restart: () => restartService(service),
+    log,
+    pollIntervalMs: readDurationEnv('INVOKER_WATCHER_POLL_INTERVAL_MS'),
+    downThresholdMs: readDurationEnv('INVOKER_WATCHER_DOWN_THRESHOLD_MS'),
+    restartCooldownMs: readDurationEnv('INVOKER_WATCHER_RESTART_COOLDOWN_MS'),
+  });
+
+  const shutdown = (): void => {
+    watcher.stop();
+    process.exit(0);
+  };
+
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+  watcher.start();
+}
+
+void main().catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`[watcher] fatal: ${message}`);
+  process.exit(1);
+});

--- a/packages/watcher/src/invoker-watcher.ts
+++ b/packages/watcher/src/invoker-watcher.ts
@@ -1,0 +1,80 @@
+import type { InvokerClient } from '@invoker/slack-manager/src/invoker-client.js';
+
+export interface InvokerWatcherDeps {
+  client: Pick<InvokerClient, 'isHealthy'>;
+  restart: () => Promise<void>;
+  log: (level: string, message: string) => void;
+  pollIntervalMs?: number;
+  downThresholdMs?: number;
+  restartCooldownMs?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface InvokerWatcher {
+  start(): void;
+  stop(): void;
+  tick(): Promise<void>;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 60_000;
+const DEFAULT_DOWN_THRESHOLD_MS = 20 * 60_000;
+const DEFAULT_RESTART_COOLDOWN_MS = 15 * 60_000;
+
+export function createInvokerWatcher(deps: InvokerWatcherDeps): InvokerWatcher {
+  const pollIntervalMs = deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const downThresholdMs = deps.downThresholdMs ?? DEFAULT_DOWN_THRESHOLD_MS;
+  const restartCooldownMs = deps.restartCooldownMs ?? DEFAULT_RESTART_COOLDOWN_MS;
+  const now = deps.now ?? (() => Date.now());
+
+  let unhealthySince: number | null = null;
+  let lastRestartAt: number | null = null;
+  let interval: NodeJS.Timeout | null = null;
+
+  const tick = async (): Promise<void> => {
+    const healthy = await deps.client.isHealthy();
+    const observedAt = now();
+
+    if (healthy) {
+      unhealthySince = null;
+      return;
+    }
+
+    if (unhealthySince === null) {
+      unhealthySince = observedAt;
+      return;
+    }
+
+    const downDurationMs = observedAt - unhealthySince;
+    const sinceLastRestartMs = lastRestartAt === null ? Number.POSITIVE_INFINITY : observedAt - lastRestartAt;
+    if (downDurationMs < downThresholdMs || sinceLastRestartMs < restartCooldownMs) {
+      return;
+    }
+
+    deps.log('error', `invoker unhealthy for ${downDurationMs}ms; restarting slack manager service`);
+    lastRestartAt = observedAt;
+    await deps.restart();
+  };
+
+  const runTick = (): void => {
+    void tick().catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      deps.log('error', `watcher tick failed: ${message}`);
+    });
+  };
+
+  return {
+    start(): void {
+      if (interval !== null) return;
+      runTick();
+      interval = setInterval(runTick, pollIntervalMs);
+      interval.unref?.();
+    },
+    stop(): void {
+      if (interval === null) return;
+      clearInterval(interval);
+      interval = null;
+    },
+    tick,
+  };
+}

--- a/packages/watcher/tsconfig.json
+++ b/packages/watcher/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "references": [
+    { "path": "../slack-manager" }
+  ]
+}

--- a/packages/watcher/tsconfig.tsup.json
+++ b/packages/watcher/tsconfig.tsup.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/watcher/tsup.config.ts
+++ b/packages/watcher/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs'],
+  outDir: 'dist',
+  tsconfig: 'tsconfig.tsup.json',
+  clean: true,
+  noExternal: ['@invoker/slack-manager'],
+});

--- a/packages/watcher/vitest.config.ts
+++ b/packages/watcher/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import sharedConfig from '../../vitest.shared.ts';
+
+export default mergeConfig(sharedConfig, defineConfig({ test: {} }));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -656,6 +656,25 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@1.21.7)(jsdom@25.0.1)(yaml@2.8.2)
 
+  packages/watcher:
+    dependencies:
+      '@invoker/slack-manager':
+        specifier: workspace:*
+        version: link:../slack-manager
+    devDependencies:
+      '@types/node':
+        specifier: ^25.3.3
+        version: 25.3.3
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
+
   packages/web-app:
     devDependencies:
       jsdom:

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -21,6 +21,7 @@
     "packages/shell/src/**/*.ts",
     "packages/surfaces/src/**/*.ts",
     "packages/slack-manager/src/**/*.ts",
+    "packages/watcher/src/**/*.ts",
     "packages/test-kit/src/**/*.ts",
     "packages/transport/src/**/*.ts",
     "packages/workflow-core/src/**/*.ts",


### PR DESCRIPTION
## Summary

Add a private `@invoker/watcher` workspace package.

The watcher polls Invoker health through `@invoker/slack-manager` and restarts `slack-manager.service` when Invoker stays unreachable past the configured threshold.

This is the core package only. Packaging, deploy artifacts, and CI wiring stay in later stack slices.

## Review Claim

`@invoker/watcher` adds an independently testable outer supervisor that can restart the configured user service after Invoker remains unhealthy past its threshold and cooldown rules.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The only external action is `execFile('systemctl', ['--user', 'restart', service])` for the configured service name, defaulting to `slack-manager.service`.

It never kills arbitrary PIDs, writes to the database, or writes files outside its own process.

The default 20-minute down threshold leaves `slack-manager`'s own five-attempt watchdog sequence room to finish before this outer watcher acts.

The 15-minute cooldown prevents this watcher from becoming a restart-storm source.

## Slice Rationale

This slice adds the core polling, threshold, cooldown, restart logic, package scaffold, and direct tests together.

The npm wrapper, SEA build and deploy artifacts, and CI wiring are separate review units and stay out of this PR.

## Non-goals

No `packages/npm-watcher` publishable wrapper.

No SEA build script.

No `packages/watcher/deploy/*` systemd unit or install script.

No `.github/workflows/*` CI changes.

No change to `packages/slack-manager`'s own watchdog or give-up behavior.

## Architecture

### Before

```mermaid
graph TD
    A["slack-manager watchdog exhausts its bounded retry sequence"]
    B["No outer supervisor retries later"]
    A --> B
```

### After

```mermaid
graph TD
    A["slack-manager watchdog exhausts its bounded retry sequence"]
    B["@invoker/watcher polls Invoker health independently"]
    C["systemctl --user restart slack-manager.service after threshold and cooldown"]
    A --> B
    B --> C
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`

```text
Scope: all 28 workspace projects
 WARN  There are cyclic workspace dependencies: /Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786429272336-1-ksvdk7/packages/data-store, /Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786429272336-1-ksvdk7/packages/persistence
Lockfile is up to date, resolution step is skipped
Progress: resolved 1, reused 0, downloaded 0, added 0
Packages: +922
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 922, reused 914, downloaded 0, added 78
Progress: resolved 922, reused 915, downloaded 0, added 473
Progress: resolved 922, reused 915, downloaded 0, added 683
Progress: resolved 922, reused 915, downloaded 0, added 916
Progress: resolved 922, reused 915, downloaded 0, added 921
Progress: resolved 922, reused 915, downloaded 0, added 922, done
 WARN  Failed to create bin at /Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786429272336-1-ksvdk7/packages/app/node_modules/.bin/invoker-cli. ENOENT: no such file or directory, open '/Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786429272336-1-ksvdk7/packages/cli/dist/index.js'

devDependencies:
+ @mergifyio/vitest 0.3.0
+ aws4 1.13.2
+ concurrently 10.0.4
+ dependency-cruiser 17.3.10
+ electron-builder 26.8.1
+ jsdom 25.0.1
+ mermaid 11.15.0
+ postject 1.0.0-alpha.6
+ tsup 8.5.1
+ typescript 5.9.3
+ yaml 2.8.2

packages/npm-cli postinstall$ node scripts/install.js
packages/npm-slack postinstall$ node scripts/install.js
. postinstall$ node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs
packages/npm-cli postinstall: Done
packages/npm-slack postinstall: Done
. postinstall: [fix-node-pty] restored exec permission: node_modules/.pnpm/node-pty@1.1.0/node_modules/node-pty/prebuilds/darwin-x64/spawn-helper
. postinstall: [fix-node-pty] restored exec permission: node_modules/.pnpm/node-pty@1.1.0/node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper
. postinstall: Done
packages/npm-ui postinstall$ node scripts/install.js
packages/npm-ui postinstall: Done
 WARN  Failed to create bin at /Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786429272336-1-ksvdk7/packages/app/node_modules/.bin/invoker-cli. ENOENT: no such file or directory, open '/Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786429272336-1-ksvdk7/packages/app/node_modules/@invoker/cli/dist/index.js'
╭ Warning ─────────────────────────────────────────────────────────────────────╮
│                                                                              │
│   Ignored build scripts: cpu-features@0.0.10, electron-winstaller@5.4.0,     │
│   esbuild@0.25.12, esbuild@0.27.3, protobufjs@7.5.4, ssh2@1.17.0.            │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed     │
│   to run scripts.                                                            │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
Done in 6.1s using pnpm v10.31.0
```

- [x] `cd packages/watcher && pnpm test`

```text
> @invoker/watcher@0.0.11 test /Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786429272336-1-ksvdk7/packages/watcher
> vitest run


 RUN  v3.2.4 /Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786429272336-1-ksvdk7/packages/watcher

 ✓ src/__tests__/invoker-watcher.test.ts (5 tests) 9ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  23:33:26
   Duration  367ms (transform 28ms, setup 0ms, collect 29ms, tests 9ms, environment 0ms, prepare 72ms)
```

- [x] `pnpm run check:types`

```text
> invoker@0.0.11 check:types /Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786429272336-1-ksvdk7
> tsc -p tsconfig.typecheck.json

Exit code: 0
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5c0abbd9e3f56356f996e9d9f2800cfb746645ef`
- Post-revert steps: None
- Data migration? No

</details>
