### PR TITLE
Workflow delete+resubmit UI drift (4a) queue-status refresh contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1229,7 +1229,7 @@ export const IpcChannels = {
 
   // Queue & Configuration
   'invoker:get-queue-status': {} as {
-    request: [];
+    request: [options?: { refresh?: boolean }];
     response: QueueStatus;
   },
   'invoker:get-worker-status': {} as {


### PR DESCRIPTION
## Summary

Widens the `invoker:get-queue-status` IPC channel's request tuple to
accept an optional `{ refresh?: boolean }` argument.

Today every caller is hardcoded to `refresh: false` (a 5s-cached read).
A caller cannot ask for a fresh read after a mutation it just made.

This PR only changes the type. No handler or renderer yet passes the
new option — that lands in the next PR of this stack.

## Review Claim

The `invoker:get-queue-status` request tuple now accepts an optional
`{ refresh?: boolean }` argument, and every existing zero-argument
caller still type-checks unchanged.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The new argument is optional and read by nothing yet in this diff, so
no runtime behavior changes; this is a pure type widening that keeps
`request: []` call sites valid.

## Slice Rationale

Foundation before behavior: the contract change is isolated from its
consumers so it reviews as one small, obviously-safe type change ahead
of the larger IPC/renderer diff that depends on it.

## Non-goals

No IPC handler, web dispatch, or renderer change. No new runtime
behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/contracts test`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
