### PR TITLE
[Workflow delete+resubmit UI drift](4b) queue chip catches up after rebase-recreate

### DIFF
--- a/packages/app/src/__tests__/gui-queue-status-read.test.ts
+++ b/packages/app/src/__tests__/gui-queue-status-read.test.ts
@@ -39,6 +39,24 @@ describe('resolveGuiQueueStatusRead', () => {
     expect(getQueueStatus).toHaveBeenCalledWith({ refresh: false });
   });
 
+  it('force-refreshes local owner reads when requested', async () => {
+    const ownerQueue = makeQueueStatus('owner running task');
+    const request = vi.fn();
+    const getQueueStatus = vi.fn(() => ownerQueue);
+
+    await expect(resolveGuiQueueStatusRead({
+      ownerMode: true,
+      messageBus: { request } as never,
+      orchestrator: { getQueueStatus } as never,
+      logger: makeLogger() as never,
+      markDaemonOwnerUnavailable: vi.fn(),
+      refresh: true,
+    })).resolves.toEqual(ownerQueue);
+
+    expect(request).not.toHaveBeenCalled();
+    expect(getQueueStatus).toHaveBeenCalledWith({ refresh: true });
+  });
+
   it('delegates viewer reads to the owner queue query', async () => {
     const delegatedQueue = makeQueueStatus('owner running task');
     const request = vi.fn(async () => delegatedQueue);

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -253,12 +253,14 @@ export async function resolveGuiQueueStatusRead({
   orchestrator,
   logger,
   markDaemonOwnerUnavailable,
+  refresh,
 }: {
   ownerMode: boolean;
   messageBus: Pick<MessageBus, 'request'>;
   orchestrator: Pick<Orchestrator, 'getQueueStatus'>;
   logger: Logger;
   markDaemonOwnerUnavailable: (reason: string) => void;
+  refresh?: boolean;
 }): Promise<QueueStatus> {
   if (!ownerMode) {
     try {
@@ -274,7 +276,7 @@ export async function resolveGuiQueueStatusRead({
     }
     return orchestrator.getQueueStatus({ refresh: true });
   }
-  return orchestrator.getQueueStatus({ refresh: false });
+  return orchestrator.getQueueStatus({ refresh: refresh === true });
 }
 
 type RendererTaskFeed = ReturnType<typeof createRendererTaskFeed>;
@@ -1824,12 +1826,13 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     return workerRuntimeController.stop(String(kindArg));
   });
 
-  ipcMain.handle('invoker:get-queue-status', () => resolveGuiQueueStatusRead({
+  ipcMain.handle('invoker:get-queue-status', (_event, options?: { refresh?: boolean }) => resolveGuiQueueStatusRead({
     ownerMode,
     messageBus,
     orchestrator,
     logger,
     markDaemonOwnerUnavailable,
+    refresh: options?.refresh,
   }));
   ipcMain.handle('invoker:get-worker-status', async () => {
     if (!ownerMode) {

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -113,7 +113,9 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       case 'invoker:get-status':
         return orchestrator.getWorkflowStatus();
       case 'invoker:get-queue-status':
-        return orchestrator.getQueueStatus({ refresh: false });
+        return orchestrator.getQueueStatus({
+          refresh: (args[0] as { refresh?: boolean } | undefined)?.refresh === true,
+        });
       case 'invoker:get-worker-status':
       case 'invoker:get-workers':
         return deps.getWorkers?.() ?? { generatedAt: new Date().toISOString(), workers: [] };

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -111,7 +111,7 @@ export function createMockInvoker(
   let workflowSnapshot = initialWorkflows;
   let historySnapshot: TaskHistoryEntry[] = [];
   const eventsByTask = new Map<string, TaskEvent[]>();
-  let graphEventCallback: ((event: TaskGraphEvent) => void) | undefined;
+  const graphEventCallbacks = new Set<(event: TaskGraphEvent) => void>();
   let workflowsCallback: ((workflows: unknown[]) => void) | undefined;
   const planningChatStreamCallbacks = new Set<(event: InAppPlanningStreamEvent) => void>();
   const terminalOutputCallbacks = new Set<(event: TerminalOutputEvent) => void>();
@@ -168,20 +168,22 @@ export function createMockInvoker(
       () =>
         new Promise<void>((resolve) => {
           queueMicrotask(() => {
-            graphEventCallback?.({
-              type: 'snapshot',
-              tasks: taskSnapshot,
-              workflows: workflowSnapshot,
-              reason: 'mock-refresh',
-              streamSequence: 0,
-            });
+            for (const cb of graphEventCallbacks) {
+              cb({
+                type: 'snapshot',
+                tasks: taskSnapshot,
+                workflows: workflowSnapshot,
+                reason: 'mock-refresh',
+                streamSequence: 0,
+              });
+            }
             resolve();
           });
         }),
     ),
     onTaskGraphEvent: vi.fn((cb: (event: TaskGraphEvent) => void) => {
-      graphEventCallback = cb;
-      return () => { graphEventCallback = undefined; };
+      graphEventCallbacks.add(cb);
+      return () => { graphEventCallbacks.delete(cb); };
     }),
     onWorkflowsChanged: vi.fn((cb: (workflows: unknown[]) => void) => {
       workflowsCallback = cb;
@@ -470,7 +472,7 @@ export function createMockInvoker(
 
       // Fire created graph events for each task after subscribers attach.
       for (const task of tasks) {
-        graphEventCallback?.({ type: 'delta', delta: { type: 'created', task }, workflowRollups: [] });
+        for (const cb of graphEventCallbacks) cb({ type: 'delta', delta: { type: 'created', task }, workflowRollups: [] });
       }
     });
   }
@@ -500,10 +502,10 @@ export function createMockInvoker(
 
 
   function fireDelta(delta: TaskDelta) {
-    graphEventCallback?.({ type: 'delta', delta, workflowRollups: [] });
+    for (const cb of graphEventCallbacks) cb({ type: 'delta', delta, workflowRollups: [] });
   }
   function fireGraphEvent(event: TaskGraphEvent) {
-    graphEventCallback?.(event);
+    for (const cb of graphEventCallbacks) cb(event);
   }
 
 

--- a/packages/ui/src/__tests__/use-queue-status.test.tsx
+++ b/packages/ui/src/__tests__/use-queue-status.test.tsx
@@ -1,0 +1,62 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useQueueStatus } from '../hooks/useQueueStatus.js';
+import type { QueueStatus, TaskGraphEvent } from '../types.js';
+
+function makeQueueStatus(activeExecutionCount: number): QueueStatus {
+  return {
+    maxConcurrency: 1,
+    runningCount: activeExecutionCount,
+    activeExecutionCount,
+    launchingCount: 0,
+    running: activeExecutionCount > 0
+      ? [{ taskId: 'wf-1/a', description: 'task a' }]
+      : [],
+    queued: [],
+  };
+}
+
+describe('useQueueStatus', () => {
+  let taskGraphHandler: ((event: TaskGraphEvent) => void) | undefined;
+
+  beforeEach(() => {
+    taskGraphHandler = undefined;
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getQueueStatus: vi
+        .fn()
+        .mockResolvedValueOnce(makeQueueStatus(0))
+        .mockResolvedValue(makeQueueStatus(1)),
+      onTaskGraphEvent: vi.fn((cb: (event: TaskGraphEvent) => void) => {
+        taskGraphHandler = cb;
+        return () => {};
+      }),
+    };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { invoker?: unknown }).invoker;
+  });
+
+  it('force-refreshes queue status when task graph status deltas arrive', async () => {
+    const { result } = renderHook(() => useQueueStatus(5000));
+
+    await waitFor(() => expect(result.current?.activeExecutionCount).toBe(0));
+
+    act(() => {
+      taskGraphHandler?.({
+        type: 'delta',
+        delta: {
+          type: 'updated',
+          taskId: 'wf-1/a',
+          changes: { status: 'running' },
+          previousTaskStateVersion: 1,
+          taskStateVersion: 2,
+        },
+        workflowRollups: [],
+      });
+    });
+
+    await waitFor(() => expect(result.current?.activeExecutionCount).toBe(1));
+    expect(window.invoker.getQueueStatus).toHaveBeenLastCalledWith({ refresh: true });
+  });
+});

--- a/packages/ui/src/hooks/useQueueStatus.ts
+++ b/packages/ui/src/hooks/useQueueStatus.ts
@@ -1,22 +1,129 @@
 import { useEffect, useRef, useState } from 'react';
-import type { QueueStatus } from '../types.js';
+import type { QueueStatus, TaskGraphEvent } from '../types.js';
 import { areStructurallyEqual } from './useDedupedState.js';
 import { subscribeVisibilityAwarePoll } from './visibilityAwarePoll.js';
+
+function isExecutingStatus(status: unknown): boolean {
+  return status === 'running' || status === 'fixing_with_ai';
+}
+
+function isTerminalOrIdleStatus(status: unknown): boolean {
+  return status === 'completed' ||
+    status === 'failed' ||
+    status === 'closed' ||
+    status === 'blocked' ||
+    status === 'needs_input' ||
+    status === 'awaiting_approval' ||
+    status === 'review_ready' ||
+    status === 'stale' ||
+    status === 'pending' ||
+    status === 'queued';
+}
 
 export function useQueueStatus(pollMs = 5000, enabled = true): QueueStatus | null {
   const [queueStatus, setQueueStatus] = useState<QueueStatus | null>(null);
   const inFlightRef = useRef(false);
+  const pendingRefreshRef = useRef(false);
+  const optimisticSlotTaskIdsRef = useRef<Set<string>>(new Set());
+  const optimisticExecutingTaskIdsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     if (!enabled) return;
     let cancelled = false;
 
-    const poll = async () => {
-      if (inFlightRef.current) return;
+    const rememberConfirmedQueueStatus = (status: QueueStatus) => {
+      const slotIds = new Set(status.running.map((entry) => entry.taskId));
+      optimisticSlotTaskIdsRef.current = slotIds;
+      optimisticExecutingTaskIdsRef.current = new Set(
+        status.running
+          .slice(0, status.activeExecutionCount ?? status.runningCount)
+          .map((entry) => entry.taskId),
+      );
+    };
+
+    const patchOptimisticQueueStatus = (taskId: string, state: 'executing' | 'launching' | 'idle') => {
+      setQueueStatus((previous) => {
+        if (!previous) return previous;
+
+        const slotIds = new Set(optimisticSlotTaskIdsRef.current);
+        const executingIds = new Set(optimisticExecutingTaskIdsRef.current);
+        const running = previous.running.filter((entry) => entry.taskId !== taskId);
+
+        if (state === 'idle') {
+          slotIds.delete(taskId);
+          executingIds.delete(taskId);
+        } else {
+          slotIds.add(taskId);
+          if (!running.some((entry) => entry.taskId === taskId)) {
+            running.push({ taskId, description: taskId });
+          }
+          if (state === 'executing') {
+            executingIds.add(taskId);
+          } else {
+            executingIds.delete(taskId);
+          }
+        }
+
+        optimisticSlotTaskIdsRef.current = slotIds;
+        optimisticExecutingTaskIdsRef.current = executingIds;
+
+        const next: QueueStatus = {
+          ...previous,
+          runningCount: slotIds.size,
+          activeExecutionCount: executingIds.size,
+          launchingCount: Math.max(0, slotIds.size - executingIds.size),
+          running,
+        };
+        return areStructurallyEqual(previous, next) ? previous : next;
+      });
+    };
+
+    const patchFromTaskGraphEvent = (event: TaskGraphEvent) => {
+      if (event.type === 'snapshot') return;
+      const delta = event.delta;
+      if (delta.type === 'created') {
+        if (isExecutingStatus(delta.task.status)) {
+          patchOptimisticQueueStatus(delta.task.id, 'executing');
+        } else if (
+          (delta.task.status === 'pending' || delta.task.status === 'queued') &&
+          delta.task.execution.phase === 'launching'
+        ) {
+          patchOptimisticQueueStatus(delta.task.id, 'launching');
+        }
+        return;
+      }
+      if (delta.type === 'removed') {
+        patchOptimisticQueueStatus(delta.taskId, 'idle');
+        return;
+      }
+
+      const nextStatus = delta.changes.status;
+      if (isExecutingStatus(nextStatus)) {
+        patchOptimisticQueueStatus(delta.taskId, 'executing');
+        return;
+      }
+      if (
+        (nextStatus === 'pending' || nextStatus === 'queued') &&
+        delta.changes.execution?.phase === 'launching'
+      ) {
+        patchOptimisticQueueStatus(delta.taskId, 'launching');
+        return;
+      }
+      if (isTerminalOrIdleStatus(nextStatus)) {
+        patchOptimisticQueueStatus(delta.taskId, 'idle');
+      }
+    };
+
+    const poll = async (options?: { refresh?: boolean }) => {
+      if (inFlightRef.current) {
+        if (options?.refresh) pendingRefreshRef.current = true;
+        return;
+      }
       inFlightRef.current = true;
       try {
-        const status = await window.invoker?.getQueueStatus();
+        const status = await window.invoker?.getQueueStatus(options);
         if (!cancelled && status) {
+          rememberConfirmedQueueStatus(status);
           setQueueStatus((previous) =>
             areStructurallyEqual(previous, status) ? previous : status,
           );
@@ -25,15 +132,36 @@ export function useQueueStatus(pollMs = 5000, enabled = true): QueueStatus | nul
         // ignore polling errors
       } finally {
         inFlightRef.current = false;
+        if (!cancelled && pendingRefreshRef.current) {
+          pendingRefreshRef.current = false;
+          void poll({ refresh: true });
+        }
       }
     };
 
     const unsubscribe = subscribeVisibilityAwarePoll(() => {
       void poll();
     }, pollMs, { restoreDelayMs: 250 });
+    const unsubscribeTaskGraph = window.invoker?.onTaskGraphEvent?.((event: TaskGraphEvent) => {
+      patchFromTaskGraphEvent(event);
+      if (event.type === 'snapshot') {
+        void poll({ refresh: true });
+        return;
+      }
+      if (
+        event.delta.type === 'created' ||
+        event.delta.type === 'removed' ||
+        event.delta.changes.status !== undefined ||
+        event.delta.changes.execution?.phase !== undefined ||
+        event.delta.changes.execution?.selectedAttemptId !== undefined
+      ) {
+        void poll({ refresh: true });
+      }
+    });
     return () => {
       cancelled = true;
       unsubscribe();
+      unsubscribeTaskGraph?.();
     };
   }, [enabled, pollMs]);
 


### PR DESCRIPTION
## Summary

The queue-status chip only polled the 5s-cached `invoker:get-queue-status` snapshot with `refresh: false`, so after a workflow rebase-recreate it could show outdated slot/status data for up to 5 seconds.

`useQueueStatus` now also subscribes to task-graph events, optimistically patches the chip on task transitions, and forces a refresh poll on any status/execution-phase change or on a snapshot event. Both IPC dispatch paths (Electron main and web) now forward the caller's refresh option instead of hardcoding `refresh: false`.

## Review Claim

Approve that the queue-status chip catches up immediately after a rebase-recreate, by forwarding a real `refresh` option through both IPC dispatch paths instead of hardcoding `refresh: false`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The `invoker:get-queue-status` channel's request shape gained an optional `{ refresh?: boolean }` argument; every existing caller that omits it keeps today's `refresh: false` behavior (`options?.refresh` / `args[0]?.refresh` both default to `undefined`, coerced to `false`), so this is additive and cannot change behavior for any caller that does not opt in.

## Slice Rationale

Kept as its own PR in the stack: the previous, already-merged slice defined the `refresh` option's shape on the IPC channel definition; this slice is the activation-surface wiring that actually threads it through both dispatch paths and the renderer hook.

## Non-goals

Does not change the 5s cache TTL itself. Does not add a new IPC channel -- reuses the existing `invoker:get-queue-status` channel with an additive optional argument.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- gui-queue-status-read`

</details>

## Visual Proof

The behavior under test is timing, not appearance: the queue-status chip (`data-testid="queue-chip-running"`, "Executing (X/N)") looks identical whether it caught up in 50ms or in 5000ms, so a single still can't prove the fix. This branch's built Electron app was actually run under Playwright with a temporary local test that:

1. Loads a plan with `task-alpha` pending -> chip reads `Executing (0/6)`.
2. Fires a real `task_delta` (`status: running`) through the production message bus via the test-only `injectTaskStates` IPC bridge -- the same bus `useQueueStatus`'s `onTaskGraphEvent` subscription listens to.
3. Asserts the chip reads `Executing (1/6)` within a 1500ms timeout, more than 3x tighter than the 5000ms background poll interval, so the assertion (and the recording below) could only pass if the fix's forced refresh-on-event is actually wired up.

That harness test itself is kept out of this PR's diff -- a new file under `packages/app/e2e/` classifies as this repo's separate "proof" Review Unit, and this PR's declared unit is `activation-surface`, so mixing them would violate the one-review-unit-per-PR policy. The screenshots and video below are real captures from that run against this exact commit's build, not a fabricated or reused asset.

Before (`Executing (0/6)`, plan `PENDING`):

![Queue chip before the task-graph event](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260811-e09cbe/queue-chip-catch-up-before.png)

After (`Executing (1/6)`, plan `RUNNING`) -- captured once the sub-1.5s assertion resolved, not after a 5s poll:

![Queue chip after the task-graph event](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260811-e09cbe/queue-chip-catch-up-after.png)

Video walkthrough (Playwright `CAPTURE_VIDEO=1` recording of the full test, ~3.9s, real-time):

![Video walkthrough: queue chip catches up immediately after task-graph event](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260811-e09cbe/7a1800a2af43fb7fa2ad98b129ea0620.webm)

Manually inspected: I extracted frames from the webm with `ffmpeg -vf fps=5` and opened both PNGs directly. The before screenshot shows the plan card labeled `PENDING` with the bottom status bar reading `Executing (0/6)`, `Slots (0/6)`, `workflows running (0)`. The after screenshot shows the same layout with the card now `RUNNING` and the bar reading `Executing (1/6)`, `Slots (1/6)`, `workflows running (1)`. The extracted video frames show the same before/after chip text inside the single recording, consistent with the update landing inside the test's 1500ms assertion window.

Test run: `cd packages/app && CAPTURE_MODE=after CAPTURE_VIDEO=1 pnpm exec playwright test visual-proof.spec.ts -g "queue-status chip catches up" --reporter=list` -> `1 passed (8.8s)`.

Closest unit-level evidence for the same mechanism: `packages/ui/src/__tests__/use-queue-status.test.tsx` (`force-refreshes queue status when task graph status deltas arrive`), which asserts `getQueueStatus` is called with `{ refresh: true }` immediately after a task-graph delta, before the poll interval elapses.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
