### PR TITLE
[Workflow delete+resubmit UI drift](4c) register e2e repro specs in CI shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,6 +670,8 @@ jobs:
               e2e/start-ready-daemon-owner.spec.ts
               e2e/ui-delta-timeline.spec.ts
               e2e/workers-surface.spec.ts
+              e2e/rebase-recreate-ui-drift-repro.spec.ts
+              e2e/rebase-recreate-ui-never-recovers.spec.ts
           - name: terminal-garbling
             files: >-
               e2e/planning-terminal-live-model.proof.spec.ts

--- a/packages/app/e2e/rebase-recreate-ui-drift-repro.spec.ts
+++ b/packages/app/e2e/rebase-recreate-ui-drift-repro.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Repro: does the rendered UI (the actual DOM the user looks at) ever show a
+ * stale status while the backend (invoker query / sqlite) has already moved
+ * on, right after a rebase-recreate on a failed workflow?
+ */
+import { DatabaseSync } from 'node:sqlite';
+import * as path from 'node:path';
+import {
+  test,
+  expect,
+  E2E_REPO_URL,
+  loadPlan,
+  startPlan,
+  waitForTaskStatus,
+} from './fixtures/electron-app.js';
+
+test.use({
+  repoConfig: {
+    autoFixRetries: 0,
+    maxConcurrency: 1,
+  },
+});
+
+const FAILING_PLAN = {
+  name: 'Rebase Recreate UI Drift Repro',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    { id: 'a', description: 'Fails on purpose so we can rebase-recreate it', command: 'exit 1', dependencies: [] },
+  ],
+};
+
+test.describe('rebase-recreate UI drift repro', () => {
+  test('UI chip, invoker query, and raw sqlite must agree right after rebase-recreate', async ({ page, testDir }) => {
+    await loadPlan(page, FAILING_PLAN);
+    await startPlan(page);
+    await waitForTaskStatus(page, 'a', 'failed');
+
+    const workflowId = await page.evaluate(async () => {
+      const workflows = await window.invoker.listWorkflows();
+      return workflows[workflows.length - 1]!.id as string;
+    });
+
+    // Queue chips live on Plan graph bottom chrome (not Planning home) —
+    // see e2e/queue-running-vs-queued.spec.ts. loadPlan already leaves us here.
+    const chipBefore = await page.getByTestId('queue-chip-running').textContent();
+    console.log(`[before] UI chip: ${chipBefore}`);
+
+    // rebase-recreate = "refresh pool base, then recreate workflow"
+    // (packages/app/src/headless-usage.ts:45). The facade awaits the whole
+    // thing (packages/app/src/workflow-mutation-facade.ts:340-345) before
+    // this promise resolves.
+    const { mutationResult, tasks: tasksRightAfterRecreate } = await page.evaluate(async (wfId) => {
+      const mutationResult = await window.invoker.rebaseRecreate(wfId);
+      const result = await window.invoker.getTasks();
+      return { mutationResult, tasks: Array.isArray(result) ? result : result.tasks };
+    }, workflowId);
+    console.log(`[mutation] rebaseRecreate result: ${JSON.stringify(mutationResult)}`);
+
+    const taskAAfter = tasksRightAfterRecreate.find((t: { id: string }) => t.id.endsWith('/a'));
+
+    // Read the real sqlite file directly — a second, independent connection,
+    // completely bypassing the Electron process, the orchestrator, and every
+    // in-memory cache.
+    const dbPath = path.join(testDir, 'invoker.db');
+    const db = new DatabaseSync(dbPath, { readOnly: true });
+    const row = db.prepare('SELECT id, status FROM tasks WHERE id = ?').get(taskAAfter.id) as
+      | { id: string; status: string }
+      | undefined;
+    db.close();
+
+    // The rendered DOM, read immediately (no artificial wait) after the
+    // above resolved — this is literally what the user's screen shows.
+    const chipAfter = await page.getByTestId('queue-chip-running').textContent();
+
+    console.log(`[after] sqlite row status: ${row?.status}`);
+    console.log(`[after] invoker query (getTasks) status: ${taskAAfter.status}`);
+    console.log(`[after] UI chip DOM text: ${chipAfter}`);
+
+    expect(row?.status).toBe(taskAAfter.status);
+
+    // "accepted:true" only means the mutation intent was queued
+    // (packages/app/src/persisted-workflow-mutation-coordinator.ts), not that
+    // it has landed. Poll all three sources every 50ms for 5s and log every
+    // tick, so any transient disagreement between what sqlite has, what
+    // invoker query reports, and what's actually painted on screen shows up
+    // in the log instead of being masked by a single end-state check.
+    const startedAt = Date.now();
+    const deadline = startedAt + 8000;
+    let tick = 0;
+    let sawDisagreement = false;
+    let backendFlippedAtMs: number | null = null;
+    let chipCaughtUpAtMs: number | null = null;
+
+    while (Date.now() < deadline) {
+      tick += 1;
+      const elapsed = Date.now() - startedAt;
+
+      const polled = await page.evaluate(async () => {
+        const result = await window.invoker.getTasks();
+        return Array.isArray(result) ? result : result.tasks;
+      });
+      const polledTaskA = polled.find((t: { id: string }) => t.id.endsWith('/a'));
+
+      const db2 = new DatabaseSync(dbPath, { readOnly: true });
+      const polledRow = db2.prepare('SELECT status FROM tasks WHERE id = ?').get(polledTaskA.id) as
+        | { status: string }
+        | undefined;
+      db2.close();
+
+      const polledChip = await page.getByTestId('queue-chip-running').textContent();
+
+      if (polledTaskA.status === 'running' && backendFlippedAtMs === null) backendFlippedAtMs = elapsed;
+      const chipShowsRunning = polledChip === 'Executing (1/1)';
+      if (chipShowsRunning && chipCaughtUpAtMs === null) chipCaughtUpAtMs = elapsed;
+
+      const agree = polledRow?.status === polledTaskA.status
+        && (polledTaskA.status === 'running' ? chipShowsRunning : polledChip === 'Executing (0/1)');
+      if (!agree) sawDisagreement = true;
+
+      console.log(
+        `[poll ${tick} t=${elapsed}ms] sqlite=${polledRow?.status} invoker-query=${polledTaskA.status} ui-chip=${polledChip} agree=${agree}`,
+      );
+
+      if (chipCaughtUpAtMs !== null) break;
+      await page.waitForTimeout(50);
+    }
+
+    console.log(`[summary] backend (sqlite+query) showed running at t=${backendFlippedAtMs}ms`);
+    console.log(`[summary] UI chip caught up at t=${chipCaughtUpAtMs}ms`);
+    console.log(`[summary] drift window = ${chipCaughtUpAtMs !== null && backendFlippedAtMs !== null ? chipCaughtUpAtMs - backendFlippedAtMs : 'unknown'}ms`);
+
+    expect(sawDisagreement).toBe(false);
+  });
+});

--- a/packages/app/e2e/rebase-recreate-ui-never-recovers.spec.ts
+++ b/packages/app/e2e/rebase-recreate-ui-never-recovers.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Literal repro of the user's report: rebase + recreate a failed workflow,
+ * then just watch the UI. No early exit, no assumptions — log every tick for
+ * a long window and report exactly what happened.
+ */
+import {
+  test,
+  E2E_REPO_URL,
+  loadPlan,
+  startPlan,
+  waitForTaskStatus,
+} from './fixtures/electron-app.js';
+
+test.use({
+  repoConfig: {
+    autoFixRetries: 0,
+    maxConcurrency: 13,
+  },
+});
+
+const FAILING_PLAN = {
+  name: 'Rebase Recreate Never Recovers Repro',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    { id: 'a', description: 'Fails on purpose', command: 'exit 1', dependencies: [] },
+  ],
+};
+
+test.describe('rebase-recreate: does the UI ever change', () => {
+  test('watch the queue chip for 60s after rebase-recreate, no early exit', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    await loadPlan(page, FAILING_PLAN);
+    await startPlan(page);
+    await waitForTaskStatus(page, 'a', 'failed');
+
+    const workflowId = await page.evaluate(async () => {
+      const workflows = await window.invoker.listWorkflows();
+      return workflows[workflows.length - 1]!.id as string;
+    });
+
+    const chipBefore = await page.getByTestId('queue-chip-running').textContent();
+    const slotsBefore = await page.getByTestId('queue-chip-slots').textContent();
+    console.log(`[before] chip=${chipBefore} slots=${slotsBefore}`);
+
+    const mutationResult = await page.evaluate(
+      (wfId) => window.invoker.rebaseRecreate(wfId),
+      workflowId,
+    );
+    console.log(`[mutation] rebaseRecreate result: ${JSON.stringify(mutationResult)}`);
+
+    const startedAt = Date.now();
+    const deadline = startedAt + 60_000;
+    let lastChip = '';
+    let lastSlots = '';
+    let lastTaskStatus = '';
+    let changedAtLeastOnce = false;
+
+    while (Date.now() < deadline) {
+      const elapsed = Date.now() - startedAt;
+      const chip = await page.getByTestId('queue-chip-running').textContent();
+      const slots = await page.getByTestId('queue-chip-slots').textContent();
+      const tasks = await page.evaluate(async () => {
+        const result = await window.invoker.getTasks();
+        return Array.isArray(result) ? result : result.tasks;
+      });
+      const taskA = tasks.find((t: { id: string }) => t.id.endsWith('/a'));
+
+      if (chip !== lastChip || slots !== lastSlots || taskA.status !== lastTaskStatus) {
+        changedAtLeastOnce = true;
+        console.log(
+          `[t=${elapsed}ms] CHANGED -> chip=${chip} slots=${slots} invoker-query-status=${taskA.status}`,
+        );
+        lastChip = chip ?? '';
+        lastSlots = slots ?? '';
+        lastTaskStatus = taskA.status;
+      }
+
+      await page.waitForTimeout(500);
+    }
+
+    console.log(`[final t=60000ms] chip=${lastChip} slots=${lastSlots} invoker-query-status=${lastTaskStatus}`);
+    console.log(`[verdict] did the UI ever change after rebase-recreate: ${changedAtLeastOnce}`);
+  });
+});


### PR DESCRIPTION
## Summary

This adds two Playwright repro specs for the rebase-recreate UI drift case.

The CI Playwright shard matrix now includes those specs in shard 9-of-9, so the shard inventory guard tracks them.

Depends-On: #8440

## Review Claim

Register the rebase-recreate UI drift repro specs in the Playwright CI shard inventory.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only adds isolated E2E specs and CI shard registration; it does not change product runtime code or workflow mutation behavior.

## Slice Rationale

This is the CI registration slice for the repro specs, kept separate from the behavior fix so reviewers can approve the new coverage surface independently.

## Non-goals

This does not fix rebase-recreate UI drift.

This does not change workflow deletion, resubmission, task status propagation, or queue chip rendering.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-8442-body.md --base master`
- [ ] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs`
- [ ] CI `playwright / 9-of-9`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
