### PR TITLE
[Planning UI running indicators](3) planning chat workflow-running banner

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1843,6 +1843,14 @@ export function App() {
     [tasks, workflows, attentionTaskIdsWithFailures],
   );
   const runningEntries = useMemo(() => getRunningTaskEntries(tasks, workflows, queueStatus), [tasks, workflows, queueStatus]);
+  const runningWorkflowCount = useMemo(() => {
+    const workflowIds = new Set<string>();
+    for (const { task } of runningEntries) {
+      const workflowId = task.config.workflowId;
+      if (workflowId) workflowIds.add(workflowId);
+    }
+    return workflowIds.size;
+  }, [runningEntries]);
   const commandPaletteWorkflowEntries = useMemo(
     () => workflowEntries.slice(0, COMMAND_PALETTE_MAX_ROWS),
     [workflowEntries],
@@ -4986,6 +4994,7 @@ export function App() {
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <LeftStatusColumn
           workflowCount={workflowEntries.length}
+          runningWorkflowCount={runningWorkflowCount}
           attentionCount={attentionEntries.length}
           workerStatus={workerStatus}
           planningSessionCount={planningSessions.length}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -613,9 +613,11 @@ function isTextInputElement(target: EventTarget | null): target is HTMLInputElem
 function PlanningSessionStatusIcon({
   busy,
   status,
+  workflowRunning,
 }: {
   busy: boolean;
   status: InAppPlanningSessionStatus;
+  workflowRunning: boolean;
 }): JSX.Element {
   if (busy) {
     return (
@@ -630,6 +632,14 @@ function PlanningSessionStatusIcon({
       <span
         className="mt-1.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-foreground"
         aria-label="Needs attention"
+      />
+    );
+  }
+  if (status === 'submitted' && workflowRunning) {
+    return (
+      <span
+        className="mt-1.5 inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-primary"
+        aria-label="Workflow running"
       />
     );
   }
@@ -4466,6 +4476,9 @@ export function App() {
         {planningSessions.map((session) => {
           const selected = session.id === activePlanningSession.id;
           const preview = previewPlanningMessage(session);
+          const workflowRunning = session.submittedWorkflowId
+            ? workflows.get(session.submittedWorkflowId)?.status === 'running'
+            : false;
           return (
             <div
               key={session.id}
@@ -4477,7 +4490,11 @@ export function App() {
                 onClick={() => setActivePlanningSessionId(session.id)}
                 className={`flex w-full min-w-0 flex-1 items-start gap-2 border-l-2 px-3 py-2 text-left transition-colors ${selected ? 'border-l-foreground bg-accent/40 text-accent-foreground' : 'border-l-transparent text-foreground hover:bg-accent/20'}`}
               >
-                <PlanningSessionStatusIcon busy={session.busy} status={session.status} />
+                <PlanningSessionStatusIcon
+                  busy={session.busy}
+                  status={session.status}
+                  workflowRunning={workflowRunning}
+                />
                 <div className="min-w-0 flex-1">
                   <div className="flex items-start justify-between gap-2">
                     <div className="line-clamp-2 min-w-0 flex-1 break-words text-sm font-medium leading-5" title={session.title}>

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1154,6 +1154,9 @@ export function App() {
     () => (typeof window !== 'undefined' ? window.__INVOKER_BOOTSTRAP__?.runtimeStatus ?? null : null),
   );
   const activePlanningReadOnly = activePlanningSessionSubmitted || runtimeStatus?.readOnly === true;
+  const activePlanningWorkflowRunning = activePlanningSession.submittedWorkflowId
+    ? workflows.get(activePlanningSession.submittedWorkflowId)?.status === 'running'
+    : false;
   const [systemDiagnostics, setSystemDiagnostics] = useState<SystemDiagnostics | null>(null);
   const [showSystemSetup, setShowSystemSetup] = useState(false);
   const [showSystemBanner, setShowSystemBanner] = useState(false);
@@ -4792,6 +4795,7 @@ export function App() {
             terminalSession={activePlanningTerminalSession}
             terminalBusy={activePlanningTerminalBusy}
             terminalError={activePlanningTerminalError}
+            workflowRunning={activePlanningWorkflowRunning}
             submittedPlanName={activePlanningSession.submittedPlanName}
             onValueChange={setPlanningInput}
             onSubmit={() => void handlePlanningSubmit()}

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -167,7 +167,7 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-planning')).toHaveTextContent('Plan graph');
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
-    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();
   });
@@ -242,7 +242,7 @@ describe('App launch (component)', () => {
     const toggle = screen.getByTestId('sidebar-collapse-toggle');
 
     expect(sidebar.className).toContain('w-16');
-    expect(screen.getByTestId('sidebar-running')).toBeInTheDocument();
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
 
     for (const surface of ['workflows', 'attention', 'workers', 'planning', 'home']) {
       fireEvent.click(screen.getByTestId(`sidebar-${surface}`));

--- a/packages/ui/src/__tests__/command-palette.test.tsx
+++ b/packages/ui/src/__tests__/command-palette.test.tsx
@@ -98,6 +98,14 @@ function Harness({
     () => workflowProgressSurfaces.getRunningTaskEntries(tasks, workflows, null),
     [tasks, workflows],
   );
+  const runningWorkflowCount = useMemo(() => {
+    const workflowIds = new Set<string>();
+    for (const { task } of runningEntries) {
+      const workflowId = task.config.workflowId;
+      if (workflowId) workflowIds.add(workflowId);
+    }
+    return workflowIds.size;
+  }, [runningEntries]);
 
   return (
     <div>
@@ -107,6 +115,7 @@ function Harness({
       <span data-testid="parent-render-count">{renderCount}</span>
       <LeftStatusColumn
         workflowCount={workflowEntries.length}
+        runningWorkflowCount={runningWorkflowCount}
         attentionCount={attentionEntries.length}
         workerStatus={null}
         selectedSurface="home"
@@ -114,6 +123,7 @@ function Harness({
         onSelectSurface={() => {}}
         onToggleCollapsed={() => {}}
         planningSessionCount={0}
+        planningAttentionCount={0}
         onOpenSettings={() => {}}
         theme="dark"
         onToggleTheme={() => {}}
@@ -163,6 +173,25 @@ describe('CommandPalette', () => {
     expect(screen.getByText(/Go home/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Needs Attention/i).length).toBeGreaterThan(0);
     expect(screen.getAllByText(/Workflows/i).length).toBeGreaterThan(0);
+  });
+
+  it('drives the sidebar running workflow indicator from running task entries', () => {
+    const { workflows, tasks } = buildFixtures();
+    const { rerender } = render(<Harness workflows={workflows} tasks={tasks} />);
+
+    expect(screen.getByTestId('sidebar-workflows')).toHaveAttribute('data-tone', 'running');
+    expect(screen.getByTestId('sidebar-running')).toBeVisible();
+    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('1 workflow running');
+
+    const idleTasks = new Map(tasks);
+    idleTasks.set('t-2', {
+      ...tasks.get('t-2')!,
+      status: 'completed',
+    });
+    rerender(<Harness workflows={workflows} tasks={idleTasks} />);
+
+    expect(screen.getByTestId('sidebar-workflows')).toHaveAttribute('data-tone', 'neutral');
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
   });
 
   it('lists workflows and calls onSelectWorkflow on click', async () => {

--- a/packages/ui/src/__tests__/home-visual-snapshots.test.tsx
+++ b/packages/ui/src/__tests__/home-visual-snapshots.test.tsx
@@ -40,7 +40,7 @@ describe('Visual proof snapshots', () => {
     expect(screen.getByTestId('sidebar-planning')).toHaveAccessibleName('Plan graph');
     expect(screen.getByTestId('sidebar-workflows')).toHaveAccessibleName('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveAccessibleName('Needs Attention');
-    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
+    expect(screen.queryByTestId('sidebar-running')).not.toBeInTheDocument();
     expect(screen.getByText('Describe a change, investigate a bug, or ask Invoker to draft a full plan. Review the graph before starting work.')).toBeInTheDocument();
     expect(screen.getByTestId('rail-settings')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1747,6 +1747,48 @@ describe('Invoker terminal (component)', () => {
     expect(screen.getAllByText(/submitted/i).length).toBeGreaterThan(0);
   });
 
+  it('shows a running workflow dot only for submitted planning sessions whose workflow is still running', async () => {
+    const workflows: WorkflowMeta[] = [
+      { id: 'wf-running', name: 'Running workflow', status: 'running' },
+      { id: 'wf-completed', name: 'Completed workflow', status: 'completed' },
+    ];
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'submitted-running-chat',
+          title: 'Submitted running chat',
+          status: 'submitted',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          submittedWorkflowId: 'wf-running',
+          submittedPlanName: 'Running workflow plan',
+        }),
+        makePlanningSessionSummary({
+          id: 'submitted-completed-chat',
+          title: 'Submitted completed chat',
+          status: 'submitted',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          submittedWorkflowId: 'wf-completed',
+          submittedPlanName: 'Completed workflow plan',
+        }),
+      ],
+    })) as any;
+    mock.setTasks([], workflows);
+
+    render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+
+    const runningRow = getPlanningSessionRowByText('Submitted running chat');
+    const completedRow = getPlanningSessionRowByText('Submitted completed chat');
+
+    expect(within(runningRow).getByLabelText('Workflow running')).toHaveClass('bg-primary');
+    expect(within(completedRow).queryByLabelText('Workflow running')).not.toBeInTheDocument();
+  });
+
   it('opens the graph from a submitted planning chat by restoring the saved viewport instead of fitting', async () => {
     const savedViewport = { x: -444, y: 156, zoom: 0.71 };
     const workflows: WorkflowMeta[] = [{ id: 'wf-submitted', name: 'Submitted workflow', status: 'running' }];

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -321,6 +321,39 @@ describe('Invoker terminal (component)', () => {
     };
   }
 
+  it('shows the submitted-plan bar running state while the workflow is still running', () => {
+    render(<InvokerTerminal
+      {...terminalProps({
+        readOnly: true,
+        submittedPlanName: 'Submitted Plan',
+        workflowRunning: true,
+        onOpenGraph: vi.fn(),
+      })}
+    />);
+
+    const bar = screen.getByTestId('invoker-terminal-submitted-bar');
+    expect(within(bar).getByText(/Workflow running\.\.\./)).toBeInTheDocument();
+    expect(bar).toHaveTextContent('"Submitted Plan"');
+    expect(bar).not.toHaveTextContent('Plan ready');
+    expect(within(bar).getByTestId('invoker-terminal-open-graph')).toBeInTheDocument();
+  });
+
+  it('keeps the submitted-plan bar Plan ready content when the workflow is not running', () => {
+    render(<InvokerTerminal
+      {...terminalProps({
+        readOnly: true,
+        submittedPlanName: 'Submitted Plan',
+        workflowRunning: false,
+        onOpenGraph: vi.fn(),
+      })}
+    />);
+
+    const bar = screen.getByTestId('invoker-terminal-submitted-bar');
+    expect(bar).toHaveTextContent('Plan ready · "Submitted Plan" · review the graph, then Start ready work');
+    expect(bar).not.toHaveTextContent('Workflow running');
+    expect(within(bar).getByTestId('invoker-terminal-open-graph')).toBeInTheDocument();
+  });
+
   function makePlanningTerminalSession(
     overrides: Partial<TerminalSessionDescriptor> = {},
   ): TerminalSessionDescriptor {

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -70,6 +70,7 @@ interface InvokerTerminalProps {
   terminalBusy?: boolean;
   terminalError?: string | null;
   terminalActive?: boolean;
+  workflowRunning?: boolean;
   onValueChange: (value: string) => void;
   onSubmit: () => void;
   onPresetChange: (presetKey: string) => void;
@@ -486,6 +487,7 @@ export function InvokerTerminal({
   terminalBusy = false,
   terminalError = null,
   terminalActive = true,
+  workflowRunning = false,
   onValueChange,
   onSubmit,
   onPresetChange,
@@ -853,9 +855,21 @@ export function InvokerTerminal({
               className="sticky bottom-0 z-10 border-t border-border bg-card/80 px-4 py-3.5 text-sm text-foreground backdrop-blur-sm"
             >
               <div className="flex flex-wrap items-center justify-between gap-3">
-                <span className="text-xs text-muted-foreground">
-                  Plan ready · &quot;{submittedPlanName}&quot; · review the graph, then Start ready work
-                </span>
+                {workflowRunning ? (
+                  <span className="inline-flex min-w-0 items-center gap-2 text-xs text-foreground">
+                    <span
+                      className="inline-block h-3 w-3 shrink-0 animate-spin rounded-full border border-primary/30 border-t-primary"
+                      aria-hidden="true"
+                    />
+                    <span className="min-w-0 truncate">
+                      Workflow running... · &quot;{submittedPlanName}&quot; · open the graph to monitor progress
+                    </span>
+                  </span>
+                ) : (
+                  <span className="text-xs text-muted-foreground">
+                    Plan ready · &quot;{submittedPlanName}&quot; · review the graph, then Start ready work
+                  </span>
+                )}
                 <button
                   type="button"
                   data-testid="invoker-terminal-open-graph"

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -18,6 +18,7 @@ import type { ThemeMode } from '../lib/theme.js';
 
 interface LeftStatusColumnProps {
   workflowCount: number;
+  runningWorkflowCount: number;
   attentionCount: number;
   workerStatus: WorkerStatusSnapshot | null;
   selectedSurface: SidebarSurface;
@@ -64,6 +65,7 @@ function countClass(tone: SourceItem['tone']): string {
 
 export function LeftStatusColumn({
   workflowCount,
+  runningWorkflowCount,
   attentionCount,
   workerStatus,
   selectedSurface,
@@ -83,7 +85,7 @@ export function LeftStatusColumn({
   const sources: SourceItem[] = [
     { key: 'attention', label: 'Needs Attention', count: attentionCount, tone: 'attention', icon: <AttentionIcon className={ICON_CLASS} /> },
     { key: 'workers', label: 'Workers', count: registeredWorkers, tone: activeWorkerActions > 0 ? 'running' : 'neutral', icon: <WorkerIcon className={ICON_CLASS} /> },
-    { key: 'workflows', label: 'Workflows', count: workflowCount, tone: 'neutral', icon: <WorkflowsIcon className={ICON_CLASS} /> },
+    { key: 'workflows', label: 'Workflows', count: workflowCount, tone: runningWorkflowCount > 0 ? 'running' : 'neutral', icon: <WorkflowsIcon className={ICON_CLASS} /> },
   ];
 
   return (
@@ -181,6 +183,7 @@ export function LeftStatusColumn({
               type="button"
               aria-label={source.label}
               data-testid={`sidebar-${source.key}`}
+              data-tone={source.tone}
               data-sidebar-nav-item
               aria-current={selected ? 'page' : undefined}
               onClick={() => onSelectSurface(source.key)}
@@ -212,7 +215,16 @@ export function LeftStatusColumn({
           );
         })}
       </nav>
-      <span data-testid="sidebar-running" hidden aria-hidden="true">Running</span>
+      {runningWorkflowCount > 0 && (
+        <div
+          data-testid="sidebar-running"
+          role="status"
+          aria-live="polite"
+          className={collapsed ? 'sr-only' : 'mt-3 px-2.5 text-[11px] text-muted-foreground'}
+        >
+          {runningWorkflowCount} workflow{runningWorkflowCount === 1 ? '' : 's'} running
+        </div>
+      )}
 
       {!collapsed && (
         <div className="mt-6 flex-1 overflow-y-auto scrollbar-sleek px-2.5 text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary

Planning chat now shows a running state in the existing handoff bar while the associated workflow is active.

App.tsx derives the state from the in-scope workflow map and passes it into InvokerTerminal, with no new polling.

The component coverage exercises both the running and ready variants so the bar cannot regress to silence.

## Review Claim

The planning chat exposes an active-workflow state in its existing handoff bar while keeping the ready-state bar intact.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

No workflow execution, plan handoff, or drafting-spinner behavior changes. This slice only reads already-loaded workflow state and changes the existing chat surface rendering.

## Slice Rationale

This is one UI surface in the running-indicators stack: the planning chat banner itself, after the previous indicator slice it builds on.

## Non-goals

No new IPC channel, polling source, workflow status transition, plan handoff behavior, or redesign of the surrounding chat composer.

## Architecture

### Before

```mermaid
graph TD
    A["active planning session"] --> B["InvokerTerminal submittedPlanName prop"]
    C["workflows map from useTasks()"] --> D["other running indicators only"]
    B --> E["planning chat handoff bar"]
```

### After

```mermaid
graph TD
    A["active planning session"] --> B["submittedWorkflowId lookup"]
    C["workflows map from useTasks()"] --> B
    B --> D["InvokerTerminal workflowRunning prop"]
    D --> E["planning chat handoff bar running state"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- src/__tests__/invoker-terminal.test.tsx`

```text
✓ src/__tests__/invoker-terminal.test.tsx (62 tests) 11566ms
Test Files  1 passed (1)
Tests  62 passed (62)
```

</details>

## Visual Proof

![Planning chat workflow-running banner](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260811-82b44d/planning-chat-workflow-running-banner.png)

Manually inspected: I opened `/tmp/planning-chat-workflow-running-banner.png` and saw the planning chat handoff bar display a spinner, `Workflow running...`, the `"Submitted Plan"` name, and the `Open graph` button.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c128848f264c2f4b1d9408f55b4dfb13d8af960d`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Submitted plans now display a “Workflow running…” status with a spinner while execution is active.
  * Completed or inactive plans continue to show “Plan ready” and provide the option to open the graph.

* **Tests**
  * Added coverage for running and non-running workflow status displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->