### PR TITLE
[Standalone invoker-watcher (2) npm-publishable wrapper](1) npm-publishable wrapper

### DIFF
--- a/packages/npm-watcher/bin/invoker-watcher.js
+++ b/packages/npm-watcher/bin/invoker-watcher.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const binary = join(root, 'vendor', 'invoker-watcher');
+
+if (!existsSync(binary)) {
+  console.error(`invoker-watcher binary is missing at ${binary}. Reinstall @neko-catpital-labs/invoker-watcher.`);
+  process.exit(1);
+}
+
+const result = spawnSync(binary, process.argv.slice(2), { stdio: 'inherit' });
+process.exit(result.status ?? 1);

--- a/packages/npm-watcher/package.json
+++ b/packages/npm-watcher/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@neko-catpital-labs/invoker-watcher",
+  "version": "0.0.11",
+  "description": "Invoker standalone owner-restart watcher installer",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Neko-Catpital-Labs/Invoker.git",
+    "directory": "packages/npm-watcher"
+  },
+  "bin": {
+    "invoker-watcher": "bin/invoker-watcher.js"
+  },
+  "files": [
+    "bin/**/*",
+    "scripts/**/*",
+    "vendor/.gitkeep",
+    "package.json"
+  ],
+  "scripts": {
+    "postinstall": "node scripts/install.js",
+    "test": "node bin/invoker-watcher.js --version || true"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/npm-watcher/scripts/install.js
+++ b/packages/npm-watcher/scripts/install.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { createWriteStream, existsSync } from 'node:fs';
+import { chmod, mkdir, readFile, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const pkg = require(join(root, 'package.json'));
+
+if (existsSync(join(root, '..', '..', 'pnpm-workspace.yaml'))) {
+  process.exit(0);
+}
+
+const repo = process.env.INVOKER_RELEASE_REPOSITORY ?? 'Neko-Catpital-Labs/Invoker';
+const baseUrl = process.env.INVOKER_RELEASE_BASE_URL ?? `https://github.com/${repo}/releases/download/v${pkg.version}`;
+const asset = `invoker-watcher-${pkg.version}-${process.platform}-${process.arch}.tar.gz`;
+const vendor = join(root, 'vendor');
+const archivePath = join(vendor, asset);
+const sumsPath = join(vendor, 'SHA256SUMS');
+const binaryPath = join(vendor, 'invoker-watcher');
+
+if (!['darwin', 'linux'].includes(process.platform) || !['x64', 'arm64'].includes(process.arch)) {
+  throw new Error(`Unsupported Invoker Watcher platform: ${process.platform}-${process.arch}`);
+}
+
+async function download(url, destination) {
+  const response = await fetch(url);
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download ${url}: ${response.status} ${response.statusText}`);
+  }
+  await pipeline(response.body, createWriteStream(destination));
+}
+
+async function sha256(path) {
+  const hash = createHash('sha256');
+  hash.update(await readFile(path));
+  return hash.digest('hex');
+}
+
+function expectedHash(sums, name) {
+  for (const line of sums.split(/\r?\n/)) {
+    const match = line.match(/^([a-f0-9]{64})\s+\*?(.+)$/i);
+    if (match && match[2].trim() === name) return match[1].toLowerCase();
+  }
+  return undefined;
+}
+
+await mkdir(vendor, { recursive: true });
+await rm(binaryPath, { force: true });
+await download(`${baseUrl}/SHA256SUMS`, sumsPath);
+await download(`${baseUrl}/${asset}`, archivePath);
+
+const sums = await readFile(sumsPath, 'utf8');
+const expected = expectedHash(sums, asset);
+if (!expected) {
+  throw new Error(`SHA256SUMS does not contain ${asset}`);
+}
+const actual = await sha256(archivePath);
+if (actual !== expected) {
+  throw new Error(`Checksum mismatch for ${asset}: expected ${expected}, got ${actual}`);
+}
+
+execFileSync('tar', ['-xzf', archivePath, '-C', vendor], { stdio: 'inherit' });
+const extracted = join(vendor, asset.replace(/\.tar\.gz$/, ''), 'invoker-watcher');
+if (!existsSync(extracted)) {
+  throw new Error(`Downloaded archive did not contain ${extracted}`);
+}
+execFileSync('cp', [extracted, binaryPath]);
+await chmod(binaryPath, 0o755);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,8 @@ importers:
         specifier: workspace:*
         version: link:../npm-cli
 
+  packages/npm-watcher: {}
+
   packages/persistence:
     dependencies:
       '@invoker/data-store':


### PR DESCRIPTION
## Summary

Add `@neko-catpital-labs/invoker-watcher`, a publishable npm wrapper for the standalone watcher core package.

The package follows the existing npm Slack wrapper: a thin command shim runs a downloaded per-platform binary from `vendor/`.

Postinstall downloads the matching release asset, verifies its SHA-256 checksum, and unpacks the watcher binary.

Inside this monorepo, postinstall exits before any network request because the release binary does not exist yet.

## Review Claim

`@neko-catpital-labs/invoker-watcher` provides the npm installation surface for the standalone watcher through the repository's existing verified SEA-binary wrapper pattern.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Postinstall exits successfully without a network request whenever `pnpm-workspace.yaml` is present two directories above the package, matching the existing npm Slack wrapper guard.

Outside the monorepo, the installer verifies the downloaded archive against `SHA256SUMS` before unpacking or installing the watcher binary.

## Slice Rationale

This slice contains one publishable wrapper: its package manifest, command shim, verified installer, vendor placeholder, and lockfile registration.

The core watcher landed in the preceding stack slice. SEA build artifacts, deployment files, CI wiring, and reference documentation remain separate review units.

## Non-goals

No changes to the watcher core logic.

No SEA build script or release workflow.

No systemd unit or deployment installer.

No changes to `packages/npm-slack`, `packages/npm-cli`, or `packages/npm-ui`.

No reference documentation.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/npm-watcher && pnpm test`

```text
> @neko-catpital-labs/invoker-watcher@0.0.11 test /Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786429276457-2-H9H2PL/packages/npm-watcher
> node bin/invoker-watcher.js --version || true

invoker-watcher binary is missing at /Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786429276457-2-H9H2PL/packages/npm-watcher/vendor/invoker-watcher. Reinstall @neko-catpital-labs/invoker-watcher.
PNPM_TEST_EXIT=0
```

- [x] `node -e "JSON.parse(require('fs').readFileSync('packages/npm-watcher/package.json','utf8'))"`

```text
PACKAGE_JSON_PARSE_EXIT=0
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-sha>`
- Post-revert steps: None
- Data migration? No

</details>
