### PR TITLE
[Standalone invoker-watcher (3) SEA build and deploy artifacts](1) Add SEA build tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dist:desktop:mac:x64": "bash scripts/package-desktop.sh --mac --x64",
     "dist:cli": "node scripts/build-cli-standalone.mjs && bash scripts/archive-cli-binary.sh",
     "dist:slack": "node scripts/build-slack-standalone.mjs && bash scripts/archive-slack-binary.sh",
+    "dist:watcher": "node scripts/build-watcher-standalone.mjs && bash scripts/archive-watcher-binary.sh",
     "build:tsc": "tsc -b tsconfig.build.json",
     "build:tsc:clean": "tsc -b tsconfig.build.json --clean",
     "clean": "pnpm -r clean",

--- a/scripts/archive-watcher-binary.sh
+++ b/scripts/archive-watcher-binary.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="$(node -p "require('$ROOT/packages/watcher/package.json').version")"
+PLATFORM="${INVOKER_TARGET_PLATFORM:-$(node -p "process.platform")}"
+ARCH="${INVOKER_TARGET_ARCH:-$(node -p "process.arch")}"
+RELEASE_DIR="${INVOKER_RELEASE_DIR:-$ROOT/release}"
+BINARY="$RELEASE_DIR/invoker-watcher-$VERSION-$PLATFORM-$ARCH"
+
+if [ ! -x "$BINARY" ]; then
+  echo "Standalone Watcher binary not found: $BINARY" >&2
+  exit 66
+fi
+
+STAGE="$(mktemp -d "${TMPDIR:-/tmp}/invoker-watcher-archive.XXXXXX")"
+NAME="invoker-watcher-$VERSION-$PLATFORM-$ARCH"
+mkdir -p "$STAGE/$NAME"
+cp "$BINARY" "$STAGE/$NAME/invoker-watcher"
+chmod +x "$STAGE/$NAME/invoker-watcher"
+
+(cd "$STAGE" && tar -czf "$RELEASE_DIR/$NAME.tar.gz" "$NAME")
+rm -rf "$STAGE"
+echo "$RELEASE_DIR/$NAME.tar.gz"

--- a/scripts/build-watcher-standalone.mjs
+++ b/scripts/build-watcher-standalone.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto';
+import { createWriteStream, existsSync } from 'node:fs';
+import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const pkg = require(join(root, 'packages/watcher/package.json'));
+const nodeVersion = process.env.INVOKER_STANDALONE_NODE_VERSION ?? process.version.replace(/^v/, '');
+const platform = process.env.INVOKER_TARGET_PLATFORM ?? process.platform;
+const arch = process.env.INVOKER_TARGET_ARCH ?? process.arch;
+const outDir = resolve(process.env.INVOKER_WATCHER_STANDALONE_DIR ?? join(root, 'release'));
+const binaryName = `invoker-watcher-${pkg.version}-${platform}-${arch}${platform === 'win32' ? '.exe' : ''}`;
+const outPath = join(outDir, binaryName);
+
+if (!['darwin', 'linux'].includes(platform)) {
+  throw new Error(`Unsupported standalone Watcher platform: ${platform}`);
+}
+if (!['x64', 'arm64'].includes(arch)) {
+  throw new Error(`Unsupported standalone Watcher architecture: ${arch}`);
+}
+
+function run(command, args, options = {}) {
+  execFileSync(command, args, {
+    cwd: root,
+    stdio: 'inherit',
+    ...options,
+  });
+}
+
+async function download(url, destination) {
+  const response = await fetch(url);
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download ${url}: ${response.status} ${response.statusText}`);
+  }
+  await pipeline(response.body, createWriteStream(destination));
+}
+
+async function ensureTargetNode(stage) {
+  if (process.env.INVOKER_USE_HOST_NODE_FOR_SEA === '1' && platform === process.platform && arch === process.arch) {
+    return process.execPath;
+  }
+
+  const ext = platform === 'darwin' ? 'tar.gz' : 'tar.xz';
+  const archiveBase = `node-v${nodeVersion}-${platform}-${arch}`;
+  const archiveName = `${archiveBase}.${ext}`;
+  const archivePath = join(stage, archiveName);
+  const url = `https://nodejs.org/dist/v${nodeVersion}/${archiveName}`;
+  await download(url, archivePath);
+  run('tar', ['-xf', archivePath, '-C', stage]);
+  return join(stage, archiveBase, 'bin', 'node');
+}
+
+async function sha256(path) {
+  const hash = createHash('sha256');
+  hash.update(await readFile(path));
+  return hash.digest('hex');
+}
+
+await mkdir(outDir, { recursive: true });
+const stage = await mkdtemp(join(tmpdir(), 'invoker-watcher-sea-'));
+
+try {
+  const bundlePath = join(stage, 'index.js');
+  const blobPath = join(stage, 'sea-prep.blob');
+  const seaConfigPath = join(stage, 'sea-config.json');
+  const standaloneEntryPath = join(stage, 'index.ts');
+  const targetNode = await ensureTargetNode(stage);
+  const watcherEntryImportPath = join(root, 'packages/watcher/src/index.ts').replaceAll('\\', '/');
+
+  await writeFile(standaloneEntryPath, [
+    `import ${JSON.stringify(watcherEntryImportPath)};`,
+    '',
+  ].join('\n'));
+
+  // Bundle workspace packages into the SEA blob. Keep only true native / node
+  // builtins external (same set as the CLI SEA builder).
+  run('pnpm', [
+    'exec',
+    'tsup',
+    standaloneEntryPath,
+    '--format',
+    'cjs',
+    '--platform',
+    'node',
+    '--target',
+    'node26',
+    '--no-dts',
+    '--no-splitting',
+    '--no-config',
+    '--out-dir',
+    stage,
+    '--external',
+    'node:sqlite',
+    '--external',
+    'dockerode',
+    '--external',
+    'ssh2',
+    '--external',
+    'cpu-features',
+    '--external',
+    'node-pty',
+  ]);
+
+  if (!existsSync(bundlePath)) {
+    throw new Error(`Standalone Watcher bundle missing at ${bundlePath}`);
+  }
+
+  await writeFile(seaConfigPath, JSON.stringify({
+    main: bundlePath,
+    output: blobPath,
+    disableExperimentalSEAWarning: true,
+    useCodeCache: false,
+    useSnapshot: false,
+  }, null, 2));
+
+  run(process.execPath, ['--experimental-sea-config', seaConfigPath]);
+  await copyFile(targetNode, outPath);
+  await chmod(outPath, 0o755);
+
+  if (platform === 'darwin') {
+    try {
+      run('codesign', ['--remove-signature', outPath]);
+    } catch {
+      // Downloaded Node binaries are not always signed in local/dev builds.
+    }
+  }
+
+  const postjectArgs = [
+    outPath,
+    'NODE_SEA_BLOB',
+    blobPath,
+    '--sentinel-fuse',
+    'NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2',
+  ];
+  if (platform === 'darwin') {
+    postjectArgs.push('--macho-segment-name', 'NODE_SEA');
+  }
+  run('pnpm', ['exec', 'postject', ...postjectArgs]);
+
+  if (platform === 'darwin') {
+    try {
+      run('codesign', ['--sign', '-', outPath]);
+    } catch {
+      // Ad-hoc signing is best-effort for local builds. Release runners have codesign.
+    }
+  }
+
+  console.log(`${outPath}`);
+  console.log(`${await sha256(outPath)}  ${basename(outPath)}`);
+} finally {
+  if (process.env.INVOKER_KEEP_STANDALONE_STAGE !== '1') {
+    await rm(stage, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Summary

Add watcher-specific SEA build and archive scripts following the existing Slack release pattern.

Expose them through a root `dist:watcher` command without changing the existing distribution commands.

## Review Claim

Add the repository tooling that bundles `@invoker/watcher` into a platform SEA binary and archives it for release.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice adds two watcher-specific scripts and one root command. Its changed-file check shows no edits to the existing CLI, UI, or Slack builders.

## Slice Rationale

The build and archive scripts form one release-tooling path. Deployment remains in the next slice because it changes a product installation surface.

## Non-goals

No CI workflow or npm publication changes.

No systemd deployment files.

No edits to the existing CLI, UI, or Slack build and archive scripts.

No release build or deployment is executed by this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --check scripts/build-watcher-standalone.mjs`

```text
node_check_exit=0
```

- [x] `bash -n scripts/archive-watcher-binary.sh`

```text
archive_bash_n_exit=0
```

- [x] `node -e "const script=require('./package.json').scripts['dist:watcher']; if(script!=='node scripts/build-watcher-standalone.mjs && bash scripts/archive-watcher-binary.sh') process.exit(1); console.log(script)"`

```text
node scripts/build-watcher-standalone.mjs && bash scripts/archive-watcher-binary.sh
package_script_check_exit=0
```

- [x] `git diff --name-only origin/master...HEAD`

```text
package.json
scripts/archive-watcher-binary.sh
scripts/build-watcher-standalone.mjs
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Remove any release automation reference to `dist:watcher` if added separately.
- Data migration? No

</details>
