### PR TITLE
[Standalone invoker-watcher (3) SEA build and deploy artifacts](2) Add systemd deploy artifacts

### DIFF
--- a/packages/watcher/deploy/install.sh
+++ b/packages/watcher/deploy/install.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Install the Invoker watcher as an independently-supervised daemon.
+#
+# Prefers a packaged `invoker-watcher` on PATH (npm SEA binary). Falls back to
+# building and running packages/watcher/dist/index.js from a monorepo checkout
+# when the binary is not installed.
+#
+# Uses systemd --user when available (Restart=always + linger survives reboots),
+# else falls back to an @reboot cron keepalive loop.
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || true)"
+NODE_BIN="$(command -v node)"
+SERVICE_SRC="${REPO_ROOT:+$REPO_ROOT/packages/watcher/deploy/watcher.service}"
+WATCHER_BIN="$(command -v invoker-watcher || true)"
+
+if [ -z "$NODE_BIN" ]; then echo "node not found on PATH" >&2; exit 1; fi
+
+if [ -z "$WATCHER_BIN" ]; then
+  if [ -z "$REPO_ROOT" ] || [ ! -f "$REPO_ROOT/packages/watcher/package.json" ]; then
+    echo "invoker-watcher not on PATH and no monorepo checkout found." >&2
+    echo "Install with: npm i -g @neko-catpital-labs/invoker-watcher" >&2
+    exit 1
+  fi
+  echo "Building @invoker/watcher (dev fallback)..."
+  ( cd "$REPO_ROOT" && pnpm --filter @invoker/watcher build )
+  EXEC_START="$NODE_BIN $REPO_ROOT/packages/watcher/dist/index.js"
+  WORK_DIR="$REPO_ROOT"
+else
+  echo "Using packaged invoker-watcher at $WATCHER_BIN"
+  EXEC_START="$WATCHER_BIN"
+  WORK_DIR="${REPO_ROOT:-$HOME}"
+fi
+
+if command -v systemctl >/dev/null 2>&1; then
+  UNIT_DIR="$HOME/.config/systemd/user"
+  UNIT_NAME="invoker-watcher.service"
+  mkdir -p "$UNIT_DIR"
+  if [ -n "$SERVICE_SRC" ] && [ -f "$SERVICE_SRC" ]; then
+    sed -e "s#__REPO_ROOT__#$WORK_DIR#g" \
+        -e "s#__NODE__#$NODE_BIN#g" \
+        -e "s#ExecStart=.*#ExecStart=$EXEC_START#g" \
+      "$SERVICE_SRC" > "$UNIT_DIR/$UNIT_NAME"
+  else
+    cat > "$UNIT_DIR/$UNIT_NAME" <<EOF
+[Unit]
+Description=Invoker watcher
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=$WORK_DIR
+ExecStart=$EXEC_START
+Restart=always
+RestartSec=5
+TimeoutStopSec=20
+
+[Install]
+WantedBy=default.target
+EOF
+  fi
+  systemctl --user daemon-reload
+  systemctl --user enable --now "$UNIT_NAME"
+  loginctl enable-linger "$USER" || true
+  echo "Installed. Logs: journalctl --user -u invoker-watcher -f"
+else
+  echo "systemd not available - installing @reboot cron keepalive fallback."
+  if [ -z "$REPO_ROOT" ]; then
+    echo "Cron keepalive needs a monorepo checkout; install systemd or clone the repo." >&2
+    exit 1
+  fi
+  LINE="@reboot cd $REPO_ROOT && while true; do $EXEC_START >> $HOME/.invoker/watcher.keepalive.log 2>&1; sleep 5; done"
+  ( crontab -l 2>/dev/null | grep -v 'watcher.keepalive.log' || true; echo "$LINE" ) | crontab -
+  echo "Installed cron keepalive. Starting now..."
+  ( cd "$REPO_ROOT" && while true; do $EXEC_START >> "$HOME/.invoker/watcher.keepalive.log" 2>&1; sleep 5; done ) &
+  echo "Logs: $HOME/.invoker/watcher.keepalive.log"
+fi

--- a/packages/watcher/deploy/install.sh
+++ b/packages/watcher/deploy/install.sh
@@ -9,12 +9,120 @@
 # else falls back to an @reboot cron keepalive loop.
 set -euo pipefail
 
+systemd_quote() {
+  case "$1" in
+    *$'\n'*|*$'\r'*)
+      echo "systemd unit values cannot contain newlines: $1" >&2
+      return 1
+      ;;
+  esac
+
+  local value="${1//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//%/%%}"
+  printf '"%s"' "$value"
+}
+
+systemd_setting_value() {
+  case "$1" in
+    *$'\n'*|*$'\r'*)
+      echo "systemd unit values cannot contain newlines: $1" >&2
+      return 1
+      ;;
+  esac
+
+  local value="${1//\\/\\\\}"
+  value="${value//%/%%}"
+  printf '%s' "$value"
+}
+
+systemd_exec_start() {
+  local output=""
+  local arg
+  for arg in "$@"; do
+    if [ -n "$output" ]; then
+      output+=" "
+    fi
+    output+="$(systemd_quote "$arg")"
+  done
+  printf '%s\n' "$output"
+}
+
+shell_quote() {
+  printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
+shell_command_line() {
+  local output=""
+  local arg
+  for arg in "$@"; do
+    if [ -n "$output" ]; then
+      output+=" "
+    fi
+    output+="$(shell_quote "$arg")"
+  done
+  printf '%s\n' "$output"
+}
+
+render_systemd_unit() {
+  local work_dir="$1"
+  shift
+
+  local escaped_work_dir
+  escaped_work_dir="$(systemd_setting_value "$work_dir")"
+  local escaped_exec_start
+  escaped_exec_start="$(systemd_exec_start "$@")"
+
+  cat <<EOF
+[Unit]
+Description=Invoker watcher
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=$escaped_work_dir
+ExecStart=$escaped_exec_start
+Restart=always
+RestartSec=5
+TimeoutStopSec=20
+
+[Install]
+WantedBy=default.target
+EOF
+}
+
+render_systemd_template() {
+  local template="$1"
+  local work_dir="$2"
+  shift 2
+
+  local escaped_work_dir
+  escaped_work_dir="$(systemd_setting_value "$work_dir")"
+  local escaped_exec_start
+  escaped_exec_start="$(systemd_exec_start "$@")"
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in
+      "WorkingDirectory=__REPO_ROOT__")
+        printf 'WorkingDirectory=%s\n' "$escaped_work_dir"
+        ;;
+      ExecStart=*)
+        printf 'ExecStart=%s\n' "$escaped_exec_start"
+        ;;
+      *)
+        printf '%s\n' "$line"
+        ;;
+    esac
+  done < "$template"
+}
+
+main() {
 REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null || true)"
-NODE_BIN="$(command -v node)"
 SERVICE_SRC="${REPO_ROOT:+$REPO_ROOT/packages/watcher/deploy/watcher.service}"
 WATCHER_BIN="$(command -v invoker-watcher || true)"
 
-if [ -z "$NODE_BIN" ]; then echo "node not found on PATH" >&2; exit 1; fi
+declare -a EXEC_START
 
 if [ -z "$WATCHER_BIN" ]; then
   if [ -z "$REPO_ROOT" ] || [ ! -f "$REPO_ROOT/packages/watcher/package.json" ]; then
@@ -22,13 +130,15 @@ if [ -z "$WATCHER_BIN" ]; then
     echo "Install with: npm i -g @neko-catpital-labs/invoker-watcher" >&2
     exit 1
   fi
+  NODE_BIN="$(command -v node || true)"
+  if [ -z "$NODE_BIN" ]; then echo "node not found on PATH" >&2; exit 1; fi
   echo "Building @invoker/watcher (dev fallback)..."
   ( cd "$REPO_ROOT" && pnpm --filter @invoker/watcher build )
-  EXEC_START="$NODE_BIN $REPO_ROOT/packages/watcher/dist/index.js"
+  EXEC_START=( "$NODE_BIN" "$REPO_ROOT/packages/watcher/dist/index.js" )
   WORK_DIR="$REPO_ROOT"
 else
   echo "Using packaged invoker-watcher at $WATCHER_BIN"
-  EXEC_START="$WATCHER_BIN"
+  EXEC_START=( "$WATCHER_BIN" )
   WORK_DIR="${REPO_ROOT:-$HOME}"
 fi
 
@@ -37,28 +147,9 @@ if command -v systemctl >/dev/null 2>&1; then
   UNIT_NAME="invoker-watcher.service"
   mkdir -p "$UNIT_DIR"
   if [ -n "$SERVICE_SRC" ] && [ -f "$SERVICE_SRC" ]; then
-    sed -e "s#__REPO_ROOT__#$WORK_DIR#g" \
-        -e "s#__NODE__#$NODE_BIN#g" \
-        -e "s#ExecStart=.*#ExecStart=$EXEC_START#g" \
-      "$SERVICE_SRC" > "$UNIT_DIR/$UNIT_NAME"
+    render_systemd_template "$SERVICE_SRC" "$WORK_DIR" "${EXEC_START[@]}" > "$UNIT_DIR/$UNIT_NAME"
   else
-    cat > "$UNIT_DIR/$UNIT_NAME" <<EOF
-[Unit]
-Description=Invoker watcher
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-Type=simple
-WorkingDirectory=$WORK_DIR
-ExecStart=$EXEC_START
-Restart=always
-RestartSec=5
-TimeoutStopSec=20
-
-[Install]
-WantedBy=default.target
-EOF
+    render_systemd_unit "$WORK_DIR" "${EXEC_START[@]}" > "$UNIT_DIR/$UNIT_NAME"
   fi
   systemctl --user daemon-reload
   systemctl --user enable --now "$UNIT_NAME"
@@ -70,9 +161,15 @@ else
     echo "Cron keepalive needs a monorepo checkout; install systemd or clone the repo." >&2
     exit 1
   fi
-  LINE="@reboot cd $REPO_ROOT && while true; do $EXEC_START >> $HOME/.invoker/watcher.keepalive.log 2>&1; sleep 5; done"
+  LOG_FILE="$HOME/.invoker/watcher.keepalive.log"
+  LINE="@reboot cd $(shell_quote "$REPO_ROOT") && while true; do $(shell_command_line "${EXEC_START[@]}") >> $(shell_quote "$LOG_FILE") 2>&1; sleep 5; done"
   ( crontab -l 2>/dev/null | grep -v 'watcher.keepalive.log' || true; echo "$LINE" ) | crontab -
   echo "Installed cron keepalive. Starting now..."
-  ( cd "$REPO_ROOT" && while true; do $EXEC_START >> "$HOME/.invoker/watcher.keepalive.log" 2>&1; sleep 5; done ) &
-  echo "Logs: $HOME/.invoker/watcher.keepalive.log"
+  ( cd "$REPO_ROOT" && while true; do "${EXEC_START[@]}" >> "$LOG_FILE" 2>&1; sleep 5; done ) &
+  echo "Logs: $LOG_FILE"
+fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
 fi

--- a/packages/watcher/deploy/watcher.service
+++ b/packages/watcher/deploy/watcher.service
@@ -1,0 +1,26 @@
+# systemd user unit for the Invoker watcher.
+#
+# Install via packages/watcher/deploy/install.sh, which substitutes
+# __REPO_ROOT__ / __NODE__ and copies this to ~/.config/systemd/user/.
+#
+# The watcher is supervised INDEPENDENTLY of Invoker: Restart=always brings it
+# back if it crashes, and `loginctl enable-linger` keeps it running across
+# reboots and while the user is logged out.
+
+[Unit]
+Description=Invoker watcher
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=__REPO_ROOT__
+# install.sh rewrites ExecStart to `invoker-watcher` when the npm binary is on
+# PATH; the monorepo node entry below is the dev fallback.
+ExecStart=__NODE__ packages/watcher/dist/index.js
+Restart=always
+RestartSec=5
+TimeoutStopSec=20
+
+[Install]
+WantedBy=default.target

--- a/packages/watcher/deploy/watcher.service
+++ b/packages/watcher/deploy/watcher.service
@@ -1,7 +1,7 @@
 # systemd user unit for the Invoker watcher.
 #
-# Install via packages/watcher/deploy/install.sh, which substitutes
-# __REPO_ROOT__ / __NODE__ and copies this to ~/.config/systemd/user/.
+# Install via packages/watcher/deploy/install.sh, which renders escaped local
+# paths and copies the resulting unit to ~/.config/systemd/user/.
 #
 # The watcher is supervised INDEPENDENTLY of Invoker: Restart=always brings it
 # back if it crashes, and `loginctl enable-linger` keeps it running across


### PR DESCRIPTION
## Summary

Add a user-scoped systemd installer and service template for `invoker-watcher`.

The installer prefers the packaged binary and falls back to a monorepo build when that binary is unavailable.

## Review Claim

Add the user-scoped deployment surface that runs `invoker-watcher` as an independently supervised process.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The systemd path writes only `~/.config/systemd/user/invoker-watcher.service` and invokes `systemctl --user`; it never uses `sudo`, system-level units, or credentials.

On hosts without systemd, the fallback is also user-scoped: it writes a user crontab entry and logs under `~/.invoker`.

## Slice Rationale

Deployment follows the SEA tooling so reviewers can assess host installation and supervision separately from artifact construction.

## Non-goals

No CI workflow or npm publication changes.

No changes to watcher runtime logic.

No Slack credentials or environment files.

No deployment to a host as part of this PR.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash -n packages/watcher/deploy/install.sh`

```text
install_bash_n_exit=0
```

- [x] `if rg -n 'sudo systemctl|EnvironmentFile|\.slack-owner\.env' packages/watcher/deploy/install.sh packages/watcher/deploy/watcher.service; then exit 1; else printf 'forbidden_deploy_tokens_absent=true\n'; fi`

```text
forbidden_deploy_tokens_absent=true
```

- [x] `rg -n 'systemctl --user|UNIT_DIR="\$HOME/\.config/systemd/user"|UNIT_NAME="invoker-watcher\.service"' packages/watcher/deploy/install.sh`

```text
36:  UNIT_DIR="$HOME/.config/systemd/user"
37:  UNIT_NAME="invoker-watcher.service"
63:  systemctl --user daemon-reload
64:  systemctl --user enable --now "$UNIT_NAME"
user_unit_scope_check_exit=0
```

- [x] `git diff --name-only HEAD^...HEAD`

```text
packages/watcher/deploy/install.sh
packages/watcher/deploy/watcher.service
```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: On deployed hosts, disable the user unit or remove the fallback crontab entry, then remove the generated service file.
- Data migration? No

</details>
