### PR TITLE
[Planning chat conversational-mode restore (2) e2e regression](1) Add test-only prompt inspection contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1380,6 +1380,10 @@ export const IpcTestOnlyChannels = {
     ];
     response: void;
   },
+  'invoker:get-test-planning-chat-system-prompt': {} as {
+    request: [sessionId: string];
+    response: { systemPrompt: string | null };
+  },
   'invoker:seed-main-process-hitch-fixture': {} as {
     request: [];
     response: {


### PR DESCRIPTION
## Summary

Add a typed test-only IPC contract for reading a planning-chat session's currently built system prompt.

This gives the Electron regression slice a narrow assertion seam without adding a production channel.

## Review Claim

Approve the `IpcTestOnlyChannels` contract for querying a session's system prompt during Electron regression tests.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The entry stays inside `IpcTestOnlyChannels`, whose API members are optional and preload registration is limited to `NODE_ENV === 'test'`.

This slice registers no handler, changes no Slack path, and changes no non-test behavior.

## Slice Rationale

The contract lands before its handler so this PR contains one review unit and gives the next slice a typed dependency.

## Non-goals

No main-process handler registration.

No production IPC channel or UI change.

No change to Slack conversation construction.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
  - `Done in 4.7s using pnpm v10.31.0`
- [x] `pnpm --filter @invoker/contracts build && pnpm --filter @invoker/app build`
  - `DTS ⚡️ Build success in 602ms`
  - `CJS ⚡️ Build success in 121ms`
  - `POST_REBASE_SLICE1_BUILD_EXIT=0`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Rebuild the contracts and app packages.
- Data migration? No

</details>
