### PR TITLE
[Planning chat conversational-mode restore (2) e2e regression](2) Prove prompt mode survives app restart

### DIFF
--- a/packages/app/e2e/planning-chat-restore-conversational-mode-repro.spec.ts
+++ b/packages/app/e2e/planning-chat-restore-conversational-mode-repro.spec.ts
@@ -70,6 +70,10 @@ async function closeApp(app: ElectronApplication): Promise<void> {
   const child = app.process();
   let childExited = child.exitCode !== null || child.signalCode !== null;
   const childExitPromise = new Promise<void>((resolve) => {
+    if (childExited) {
+      resolve();
+      return;
+    }
     const markChildExited = () => {
       childExited = true;
       resolve();
@@ -79,13 +83,16 @@ async function closeApp(app: ElectronApplication): Promise<void> {
   });
   const closePromise = app.close().catch(() => undefined);
   const timedOut = await Promise.race([
-    closePromise.then(() => false),
+    Promise.all([closePromise, childExitPromise]).then(() => false),
     delay(5_000).then(() => true),
   ]);
   if (timedOut && !childExited) {
     child.kill('SIGTERM');
-    await Promise.race([closePromise, childExitPromise, delay(2_000)]);
-    if (!childExited) child.kill('SIGKILL');
+    await Promise.race([childExitPromise, delay(2_000)]);
+    if (!childExited) {
+      child.kill('SIGKILL');
+      await Promise.race([childExitPromise, delay(2_000)]);
+    }
   }
 }
 

--- a/packages/app/e2e/planning-chat-restore-conversational-mode-repro.spec.ts
+++ b/packages/app/e2e/planning-chat-restore-conversational-mode-repro.spec.ts
@@ -1,0 +1,156 @@
+import { test as base, _electron as electron, expect, type ElectronApplication, type Page } from '@playwright/test';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { stringify as yamlStringify } from 'yaml';
+import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
+
+const MAIN_JS = path.resolve(__dirname, '..', 'dist', 'main.js');
+
+const PLANNING_RESTART_PLAN = {
+  name: 'Planning Chat Conversational Restore',
+  onFinish: 'none' as const,
+  tasks: [
+    {
+      id: 'update-readme',
+      description: 'Update README',
+      command: 'echo readme',
+      dependencies: [],
+    },
+  ],
+};
+
+function launchArgs(): string[] {
+  return [
+    ...(process.platform === 'linux'
+      ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-gpu-compositing', '--disable-gpu-sandbox', '--disable-software-rasterizer']
+      : []),
+    MAIN_JS,
+  ];
+}
+
+async function waitForInvoker(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10000 });
+}
+
+async function launchApp(paths: { dbDir: string; userDataDir: string; ipcSocketPath: string; configPath: string }): Promise<{ app: ElectronApplication; page: Page }> {
+  registerTrackedBrowserUserDataDir(paths.userDataDir);
+  const app = await electron.launch({
+    args: [
+      ...launchArgs().slice(0, -1),
+      `--user-data-dir=${paths.userDataDir}`,
+      MAIN_JS,
+    ],
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+          INVOKER_TEST_WORKFLOW_IDS: '1',
+      INVOKER_USER_DATA_DIR: paths.userDataDir,
+      INVOKER_DISABLE_SLACK: '1',
+      TZ: 'UTC',
+      INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
+      INVOKER_DB_DIR: paths.dbDir,
+      INVOKER_IPC_SOCKET: paths.ipcSocketPath,
+      INVOKER_ALLOW_DELETE_ALL: '1',
+      INVOKER_E2E_ENABLE_COMPOSITOR: '1',
+      INVOKER_EMBEDDED_TERMINAL_BACKEND: 'bash',
+      INVOKER_REPO_CONFIG_PATH: paths.configPath,
+      INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS:
+        process.env.INVOKER_E2E_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '10000',
+    },
+  });
+  const page = await app.firstWindow();
+  await waitForInvoker(page);
+  return { app, page };
+}
+
+async function closeApp(app: ElectronApplication): Promise<void> {
+  const child = app.process();
+  let childExited = child.exitCode !== null || child.signalCode !== null;
+  const childExitPromise = new Promise<void>((resolve) => {
+    const markChildExited = () => {
+      childExited = true;
+      resolve();
+    };
+    child.once('exit', markChildExited);
+    child.once('close', markChildExited);
+  });
+  const closePromise = app.close().catch(() => undefined);
+  const timedOut = await Promise.race([
+    closePromise.then(() => false),
+    delay(5_000).then(() => true),
+  ]);
+  if (timedOut && !childExited) {
+    child.kill('SIGTERM');
+    await Promise.race([closePromise, childExitPromise, delay(2_000)]);
+    if (!childExited) child.kill('SIGKILL');
+  }
+}
+
+async function openPlanningTerminal(page: Page): Promise<void> {
+  await page.getByTestId('sidebar-home').click();
+  await expect(page.getByTestId('invoker-terminal-input')).toBeVisible({ timeout: 10000 });
+}
+
+async function submitPlanningText(page: Page, text: string): Promise<void> {
+  await page.getByTestId('invoker-terminal-input').fill(text);
+  await page.getByTestId('invoker-terminal-input').press('Enter');
+}
+
+base.describe('Planning chat conversational mode restore', () => {
+  base('restores a UI-created planning chat with the conversational planning system prompt', async () => {
+    const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-planning-chat-conversational-restore-'));
+    const configPath = path.join(testDir, 'e2e-config.json');
+    const userDataDir = path.join(testDir, 'electron-user-data');
+    const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+    const planYaml = yamlStringify(PLANNING_RESTART_PLAN);
+    writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0, disableAutoRunOnStartup: true }), 'utf8');
+
+    let app: ElectronApplication | undefined;
+    let page: Page | undefined;
+    try {
+      ({ app, page } = await launchApp({ dbDir: testDir, userDataDir, ipcSocketPath, configPath }));
+      await page.evaluate(async () => {
+        await window.invoker.clear();
+        await window.invoker.deleteAllWorkflows();
+      });
+      await page.evaluate(async ({ yaml }) => {
+        await window.invoker.setTestPlanningChatResponse({
+          planYaml: yaml,
+          planName: 'Planning Chat Conversational Restore',
+          reply: 'I drafted the conversational restore plan.',
+        });
+      }, { yaml: planYaml });
+
+      await openPlanningTerminal(page);
+      await submitPlanningText(page, 'Draft a YAML plan to add a README');
+      await expect(page.getByTestId('invoker-terminal-ready-bar')).toContainText('Draft ready', { timeout: 10000 });
+      const savedSessionId = await page.evaluate(async () => {
+        const list = await window.invoker.planningChatList();
+        return list.sessions[0]?.id;
+      });
+      expect(savedSessionId).toBeTruthy();
+
+      await closeApp(app);
+      app = undefined;
+      page = undefined;
+      await delay(1500);
+
+      ({ app, page } = await launchApp({ dbDir: testDir, userDataDir, ipcSocketPath, configPath }));
+      const prompt = await page.evaluate(async (sessionId) => {
+        if (!window.invoker.getTestPlanningChatSystemPrompt) {
+          throw new Error('getTestPlanningChatSystemPrompt is not exposed (NODE_ENV=test required)');
+        }
+        return window.invoker.getTestPlanningChatSystemPrompt(sessionId);
+      }, savedSessionId);
+
+      expect(prompt.systemPrompt).toContain('conversational planning mode');
+      expect(prompt.systemPrompt).not.toContain('Slack orchestrator');
+    } finally {
+      if (app) await closeApp(app).catch(() => undefined);
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1437,6 +1437,10 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
           | null;
       },
     );
+    registerGuiMutationHandler('invoker:get-test-planning-chat-system-prompt', async (sessionIdArg: unknown) => {
+      const session = planningChatSessions.get(String(sessionIdArg));
+      return { systemPrompt: session ? session.conversation.buildCursorPrompt() : null };
+    });
     registerGuiMutationHandler('invoker:seed-main-process-hitch-fixture', async () => {
       const seeded = seedMainProcessHitchFixture(persistence);
       orchestrator.syncAllFromDb();


### PR DESCRIPTION
## Summary

Add a test-gated main-process handler that returns the real planning-chat system prompt for a requested session.

The Electron regression creates a chat through the UI, restarts the app with the same persistence directories, and checks the restored session's prompt wording.

## Review Claim

Approve that a real Electron restart uses the restored session's actual `buildCursorPrompt()` output to guard conversational planning mode.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The new handler is registered only inside the existing `if (process.env.NODE_ENV === 'test')` block beside the other test-only handlers.

No existing IPC channel, Slack path, or non-test behavior changes.

## Slice Rationale

The handler and direct e2e test stay together because the test is its only consumer and both support one restart-regression claim.

## Non-goals

No production API or UI change.

No change to Slack conversation construction.

No rewrite of the existing planning-terminal restart-persistence spec.

## Architecture

### Before

```mermaid
graph LR
    T["Electron regression"] --> M["plannerReplyOverride"]
    M --> D["deterministic draft"]
```

### After

```mermaid
graph LR
    T["Electron regression"] --> M["plannerReplyOverride"]
    M --> D["deterministic draft"]
    T --> I["test-only prompt IPC"]
    I --> S["restored planningChatSessions entry"]
    S --> P["PlanConversation.buildCursorPrompt()"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
  - `Done in 4.7s using pnpm v10.31.0`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && pnpm --filter @invoker/app test:e2e -- e2e/planning-chat-restore-conversational-mode-repro.spec.ts --workers=1`
  - `✓ built in 8.48s`
  - `CJS ⚡️ Build success in 134ms`
  - `1 passed (8.1s)`
  - `POST_REBASE_ACCEPTANCE_EXIT=0`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Rebuild the app and rerun the focused e2e spec.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured planning chats restore in conversational mode after restarting the app.
  - Prevented restored planning chats from incorrectly using the Slack orchestrator prompt.

- **Tests**
  - Added end-to-end coverage for creating, saving, restarting, and restoring planning chats.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->