### PR TITLE
[Attach workflow](1) orchestrator primitive

### DIFF
--- a/packages/workflow-core/src/__tests__/attach-workflow.test.ts
+++ b/packages/workflow-core/src/__tests__/attach-workflow.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { Orchestrator } from '../orchestrator.js';
+import {
+  InMemoryPersistence,
+  makeOrchestrator,
+  setupChain,
+} from './helpers/cross-workflow-cascade-helpers.js';
+
+function loadLoneWorkflow(
+  orchestrator: Orchestrator,
+  name: string,
+  repoUrl: string,
+): string {
+  const before = new Set(orchestrator.getAllTasks().map((t) => t.config.workflowId));
+  orchestrator.loadPlan({
+    name,
+    repoUrl,
+    baseBranch: 'master',
+    featureBranch: `feature/${name}`,
+    tasks: [{ id: 't', description: 't' }],
+  });
+  return orchestrator.getAllTasks().find(
+    (t) => !t.config.isMergeNode && !before.has(t.config.workflowId),
+  )!.config.workflowId!;
+}
+
+describe('Orchestrator.attachWorkflow', () => {
+  it('re-attaches a previously-detached pair and clears the Detached provenance', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const ctx = setupChain(orchestrator);
+
+    orchestrator.detachWorkflow(ctx.downstreamWfId, ctx.upstreamWfId);
+    expect(persistence.loadWorkflow(ctx.downstreamWfId)!.externalDependencies).toBeUndefined();
+    expect(persistence.loadWorkflow(ctx.downstreamWfId)!.detachedExternalDependencies).toEqual([
+      expect.objectContaining({ workflowId: ctx.upstreamWfId }),
+    ]);
+
+    orchestrator.attachWorkflow(ctx.downstreamWfId, ctx.upstreamWfId);
+
+    expect(persistence.loadWorkflow(ctx.downstreamWfId)!.externalDependencies).toEqual([
+      { workflowId: ctx.upstreamWfId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
+    ]);
+    expect(
+      persistence.loadWorkflow(ctx.downstreamWfId)!.detachedExternalDependencies,
+      'Detached provenance for this upstream must be cleared once re-attached',
+    ).toBeUndefined();
+  });
+
+  it('attaches two workflows that were never previously linked', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const aId = loadLoneWorkflow(orchestrator, 'lone-a', 'memory://test-repo');
+    const bId = loadLoneWorkflow(orchestrator, 'lone-b', 'memory://test-repo');
+
+    expect(persistence.loadWorkflow(bId)!.externalDependencies).toBeUndefined();
+    orchestrator.attachWorkflow(bId, aId);
+    expect(persistence.loadWorkflow(bId)!.externalDependencies).toEqual([
+      { workflowId: aId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
+    ]);
+  });
+
+  it('rejects self-attach', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const ctx = setupChain(orchestrator);
+    expect(() => orchestrator.attachWorkflow(ctx.upstreamWfId, ctx.upstreamWfId)).toThrow(/itself/);
+  });
+
+  it('rejects a cycle (attaching the upstream back onto its own downstream)', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const ctx = setupChain(orchestrator);
+    expect(() => orchestrator.attachWorkflow(ctx.upstreamWfId, ctx.downstreamWfId)).toThrow(/cycle/);
+  });
+
+  it('rejects cross-repo attach unless forced', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const aId = loadLoneWorkflow(orchestrator, 'repo-a', 'memory://repo-a');
+    const bId = loadLoneWorkflow(orchestrator, 'repo-b', 'memory://repo-b');
+
+    expect(() => orchestrator.attachWorkflow(bId, aId)).toThrow(/different repos/);
+    expect(() => orchestrator.attachWorkflow(bId, aId, { force: true })).not.toThrow();
+  });
+
+  it('rejects attaching a new dependency onto an already-completed downstream unless forced', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const aId = loadLoneWorkflow(orchestrator, 'lone-a2', 'memory://test-repo');
+    const bId = loadLoneWorkflow(orchestrator, 'lone-b2', 'memory://test-repo');
+    const bTaskId = orchestrator.getAllTasks().find(
+      (t) => t.config.workflowId === bId && !t.config.isMergeNode,
+    )!.id;
+    const bMergeId = `__merge__${bId}`;
+
+    orchestrator.startExecution();
+    orchestrator.handleWorkerResponse({
+      requestId: 'r1', actionId: bTaskId, executionGeneration: 0,
+      status: 'completed', outputs: { exitCode: 0 },
+    });
+    orchestrator.handleWorkerResponse({
+      requestId: 'r2', actionId: bMergeId, executionGeneration: 0,
+      status: 'completed', outputs: { exitCode: 0 },
+    });
+
+    expect(() => orchestrator.attachWorkflow(bId, aId)).toThrow(/already completed/);
+    expect(() => orchestrator.attachWorkflow(bId, aId, { force: true })).not.toThrow();
+  });
+
+  it('is forward-only: does not touch a downstream task that already ran ahead', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const aId = loadLoneWorkflow(orchestrator, 'lone-a3', 'memory://test-repo');
+    const bId = loadLoneWorkflow(orchestrator, 'lone-b3', 'memory://test-repo');
+    const bTaskId = orchestrator.getAllTasks().find(
+      (t) => t.config.workflowId === bId && !t.config.isMergeNode,
+    )!.id;
+
+    orchestrator.startExecution();
+    orchestrator.handleWorkerResponse({
+      requestId: 'r1', actionId: bTaskId, executionGeneration: 0,
+      status: 'completed', outputs: { exitCode: 0 },
+    });
+    expect(orchestrator.getTask(bTaskId)!.status).toBe('completed');
+
+    orchestrator.attachWorkflow(bId, aId, { force: true });
+
+    expect(
+      orchestrator.getTask(bTaskId)!.status,
+      'attach must not reset a task that already ran ahead',
+    ).toBe('completed');
+  });
+});

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -21,7 +21,7 @@ import type { ParsedResponse } from './response-handler.js';
 import { TaskScheduler } from './scheduler.js';
 import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, TaskExecution, Attempt, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency, ExternalGatePolicy, TaskStatus, TaskHeartbeatSource } from '@invoker/workflow-graph';
 import type { RunnerKind } from '@invoker/workflow-graph';
-import { createTaskState, createAttempt, hasFailedDependencyPath, isCrashPreservedExecution, isLivenessFailureClass } from '@invoker/workflow-graph';
+import { createTaskState, createAttempt, hasFailedDependencyPath, isCrashPreservedExecution, isLivenessFailureClass, computeWorkflowRollup } from '@invoker/workflow-graph';
 import type { WorkflowDerivedStatus } from '@invoker/workflow-graph';
 import type { Logger, WorkResponse } from '@invoker/contracts';
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
@@ -3033,6 +3033,120 @@ export class Orchestrator {
   detachWorkflow(workflowId: string, upstreamWorkflowId: string): void {
     this.syncAllFromDb();
     this.detachWorkflowInternal(workflowId, upstreamWorkflowId);
+  }
+
+  /**
+   * Attach a workflow to an upstream workflow's merge gate, dynamically,
+   * regardless of whether the two were ever previously linked (including
+   * re-attaching a pair that a prior `detachWorkflow` severed). This is a
+   * forward-only, non-invalidating mutation: it never resets or cancels any
+   * existing task, so it has no retroactive effect on a downstream task
+   * that already ran past the point the gate would have held it — it only
+   * gates tasks that are still pending/queued when the new dependency is
+   * added, via the normal `getExternalDependencyBlocker` scheduling check.
+   *
+   * Hard-blocked (never overridable, would corrupt the dependency graph):
+   * attaching a workflow to itself, or attaching in a direction that would
+   * create a dependency cycle (the proposed upstream already transitively
+   * depends on the proposed downstream).
+   *
+   * Blocked unless `opts.force` is set: attaching across two different
+   * `repoUrl`s, or attaching onto a downstream workflow whose rollup status
+   * is already `completed` or `closed` (a new gate could never hold a
+   * workflow that is already done).
+   */
+  attachWorkflow(
+    workflowId: string,
+    upstreamWorkflowId: string,
+    opts?: { taskId?: string; gatePolicy?: ExternalGatePolicy; force?: boolean },
+  ): void {
+    this.refreshFromDb();
+
+    if (workflowId === upstreamWorkflowId) {
+      throw new Error(`Cannot attach workflow ${workflowId} to itself`);
+    }
+
+    const targetTasks = this.stateMachine.getAllTasks().filter(
+      (task) => task.config.workflowId === workflowId,
+    );
+    if (targetTasks.length === 0) {
+      throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
+    }
+    const upstreamTasks = this.stateMachine.getAllTasks().filter(
+      (task) => task.config.workflowId === upstreamWorkflowId,
+    );
+    if (upstreamTasks.length === 0) {
+      throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${upstreamWorkflowId} not found`);
+    }
+
+    if (this.collectDownstreamWorkflowIds(workflowId).includes(upstreamWorkflowId)) {
+      throw new Error(
+        `Cannot attach workflow ${workflowId} to ${upstreamWorkflowId}: ${upstreamWorkflowId} already transitively depends on ${workflowId}, so this would create a dependency cycle`,
+      );
+    }
+
+    const targetWorkflow = this.persistence.loadWorkflow?.(workflowId)
+      ?? this.persistence.listWorkflows().find((candidate) => candidate.id === workflowId);
+    const upstreamWorkflow = this.persistence.loadWorkflow?.(upstreamWorkflowId)
+      ?? this.persistence.listWorkflows().find((candidate) => candidate.id === upstreamWorkflowId);
+
+    if (!opts?.force && targetWorkflow?.repoUrl && upstreamWorkflow?.repoUrl
+      && targetWorkflow.repoUrl !== upstreamWorkflow.repoUrl) {
+      throw new Error(
+        `Cannot attach workflow ${workflowId} (repo ${targetWorkflow.repoUrl}) to ${upstreamWorkflowId} `
+        + `(repo ${upstreamWorkflow.repoUrl}): different repos. Pass { force: true } to override.`,
+      );
+    }
+
+    const targetStatus = computeWorkflowRollup(targetTasks).status;
+    if (!opts?.force && (targetStatus === 'completed' || targetStatus === 'closed')) {
+      throw new Error(
+        `Cannot attach workflow ${workflowId}: it is already ${targetStatus}, so a new dependency would `
+        + `never gate anything. Pass { force: true } to override.`,
+      );
+    }
+
+    const deps = targetWorkflow?.externalDependencies ?? [];
+    if (deps.some((dep) => dep.workflowId === upstreamWorkflowId)) {
+      throw new Error(`Workflow ${workflowId} already depends on upstream workflow ${upstreamWorkflowId}`);
+    }
+
+    const newDep: ExternalDependency = {
+      workflowId: upstreamWorkflowId,
+      taskId: opts?.taskId?.trim() || '__merge__',
+      requiredStatus: 'completed',
+      gatePolicy: opts?.gatePolicy ?? 'completed',
+    };
+    const nextDeps: ExternalDependency[] = [...deps, newDep];
+
+    const now = workflowTimestamp().toISOString();
+    const existingChanges = targetWorkflow?.externalDependencyChanges ?? [];
+    const dependencyChanges: ExternalDependencyChange[] = [...existingChanges, { after: newDep, changedAt: now }];
+
+    const existingProvenance = targetWorkflow?.detachedExternalDependencies ?? [];
+    const nextProvenance = existingProvenance.filter((dep) => dep.workflowId !== upstreamWorkflowId);
+
+    this.taskRepository.updateWorkflow(workflowId, {
+      externalDependencies: nextDeps,
+      externalDependencyChanges: dependencyChanges,
+      detachedExternalDependencies: nextProvenance.length > 0 ? nextProvenance : undefined,
+    });
+
+    const eventTask = this.getMergeNode(workflowId) ?? targetTasks[0];
+    this.persistence.logEvent?.(eventTask.id, 'workflow.external_dependency_changed', {
+      workflowId,
+      upstreamWorkflowId,
+      action: 'added',
+      changes: dependencyChanges.slice(existingChanges.length),
+    });
+    this.persistence.logEvent?.(eventTask.id, 'task.external_dependency_changed', {
+      workflowId,
+      upstreamWorkflowId,
+      action: 'added',
+    });
+
+    this.autoStartExternallyUnblockedReadyTasks();
+    this.checkWorkflowCompletion(workflowId);
   }
 
   /**


### PR DESCRIPTION
## Summary

During the 2026-08-11 incident, recreating “General alert channel (2)” left downstream workflow “(3)” displaying a lasting amber Detached badge without a supported relink path.

This first planned slice adds `Orchestrator.attachWorkflow`, the dynamic mirror of `detachWorkflow`, in `packages/workflow-core` with focused unit coverage.

Attach routes a new upstream merge-gate dependency through existing persistence and scheduling paths. It never resets or cancels work that already ran.

Self-attach and dependency cycles remain forbidden. Cross-repository and completed-or-closed downstream attachment require an explicit force option.

Reattaching a previously detached pair replaces that upstream’s Detached provenance with the active dependency record.

Later slices cover outward integrations.

## Review Claim

Approve `Orchestrator.attachWorkflow` as a forward-only routing primitive that links or relinks a downstream workflow to an upstream merge gate without invalidating completed work.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`Orchestrator.detachWorkflow`, `detachWorkflowInternal`, and existing recreate, retry, and cascade methods are unchanged. The additive method calls no invalidation or reset path.

## Slice Rationale

This slice contains one domain behavior: the dependency-graph primitive and its directly affected tests.

## Non-goals

- No command-service, headless CLI, IPC, or UI surface.
- No change to detach behavior.
- No retroactive reset, cancellation, or rerun of downstream tasks.
- No automatic cross-repository attachment.

## Architecture

### Before

Before this slice, severed dependencies had no supported orchestration mutation for relinking; restoring one required a raw persistence edit outside scheduling safeguards.

### After

After this slice, the orchestrator checks graph and workflow constraints, persists the dependency and provenance update, then reuses existing scheduling and completion checks.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --dir packages/workflow-core test`
  - `✓ src/__tests__/attach-workflow.test.ts (7 tests) 25ms`
  - `Test Files  43 passed (43)`
  - `Tests  889 passed | 3 skipped (892)`
- The three baseline skips are explicit `it.skip` cases with no reason recorded in source:
  - `Orchestrator deferTask surfaces deferred tasks as queued instead of pending`
  - `Orchestrator deferTask keeps a parked resource-limit task queued between scheduler polls`
  - `Orchestrator deferTask re-dispatches a queued resource-limit task when a slot frees`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes. This slice introduces no migration or external surface.
- Revert command: `git revert 2f8b9f9e4`
- Post-revert steps: None.
- Data migration? No.

</details>
