### PR TITLE
[Attach workflow](2a) command-service routing

### DIFF
--- a/packages/workflow-core/src/__tests__/attach-workflow.test.ts
+++ b/packages/workflow-core/src/__tests__/attach-workflow.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { Orchestrator } from '../orchestrator.js';
+import {
+  InMemoryPersistence,
+  makeOrchestrator,
+  setupChain,
+} from './helpers/cross-workflow-cascade-helpers.js';
+
+function loadLoneWorkflow(
+  orchestrator: Orchestrator,
+  name: string,
+  repoUrl: string,
+): string {
+  const before = new Set(orchestrator.getAllTasks().map((t) => t.config.workflowId));
+  orchestrator.loadPlan({
+    name,
+    repoUrl,
+    baseBranch: 'master',
+    featureBranch: `feature/${name}`,
+    tasks: [{ id: 't', description: 't' }],
+  });
+  return orchestrator.getAllTasks().find(
+    (t) => !t.config.isMergeNode && !before.has(t.config.workflowId),
+  )!.config.workflowId!;
+}
+
+describe('Orchestrator.attachWorkflow', () => {
+  it('re-attaches a previously-detached pair and clears the Detached provenance', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const ctx = setupChain(orchestrator);
+
+    orchestrator.detachWorkflow(ctx.downstreamWfId, ctx.upstreamWfId);
+    expect(persistence.loadWorkflow(ctx.downstreamWfId)!.externalDependencies).toBeUndefined();
+    expect(persistence.loadWorkflow(ctx.downstreamWfId)!.detachedExternalDependencies).toEqual([
+      expect.objectContaining({ workflowId: ctx.upstreamWfId }),
+    ]);
+
+    orchestrator.attachWorkflow(ctx.downstreamWfId, ctx.upstreamWfId);
+
+    expect(persistence.loadWorkflow(ctx.downstreamWfId)!.externalDependencies).toEqual([
+      { workflowId: ctx.upstreamWfId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
+    ]);
+    expect(
+      persistence.loadWorkflow(ctx.downstreamWfId)!.detachedExternalDependencies,
+      'Detached provenance for this upstream must be cleared once re-attached',
+    ).toBeUndefined();
+  });
+
+  it('attaches two workflows that were never previously linked', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const aId = loadLoneWorkflow(orchestrator, 'lone-a', 'memory://test-repo');
+    const bId = loadLoneWorkflow(orchestrator, 'lone-b', 'memory://test-repo');
+
+    expect(persistence.loadWorkflow(bId)!.externalDependencies).toBeUndefined();
+    orchestrator.attachWorkflow(bId, aId);
+    expect(persistence.loadWorkflow(bId)!.externalDependencies).toEqual([
+      { workflowId: aId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
+    ]);
+  });
+
+  it('rejects self-attach', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const ctx = setupChain(orchestrator);
+    expect(() => orchestrator.attachWorkflow(ctx.upstreamWfId, ctx.upstreamWfId)).toThrow(/itself/);
+  });
+
+  it('rejects a cycle (attaching the upstream back onto its own downstream)', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const ctx = setupChain(orchestrator);
+    expect(() => orchestrator.attachWorkflow(ctx.upstreamWfId, ctx.downstreamWfId)).toThrow(/cycle/);
+  });
+
+  it('rejects cross-repo attach unless forced', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const aId = loadLoneWorkflow(orchestrator, 'repo-a', 'memory://repo-a');
+    const bId = loadLoneWorkflow(orchestrator, 'repo-b', 'memory://repo-b');
+
+    expect(() => orchestrator.attachWorkflow(bId, aId)).toThrow(/different repos/);
+    expect(() => orchestrator.attachWorkflow(bId, aId, { force: true })).not.toThrow();
+  });
+
+  it('rejects attaching a new dependency onto an already-completed downstream unless forced', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const aId = loadLoneWorkflow(orchestrator, 'lone-a2', 'memory://test-repo');
+    const bId = loadLoneWorkflow(orchestrator, 'lone-b2', 'memory://test-repo');
+    const bTaskId = orchestrator.getAllTasks().find(
+      (t) => t.config.workflowId === bId && !t.config.isMergeNode,
+    )!.id;
+    const bMergeId = `__merge__${bId}`;
+
+    orchestrator.startExecution();
+    orchestrator.handleWorkerResponse({
+      requestId: 'r1', actionId: bTaskId, executionGeneration: 0,
+      status: 'completed', outputs: { exitCode: 0 },
+    });
+    orchestrator.handleWorkerResponse({
+      requestId: 'r2', actionId: bMergeId, executionGeneration: 0,
+      status: 'completed', outputs: { exitCode: 0 },
+    });
+
+    expect(() => orchestrator.attachWorkflow(bId, aId)).toThrow(/already completed/);
+    expect(() => orchestrator.attachWorkflow(bId, aId, { force: true })).not.toThrow();
+  });
+
+  it('is forward-only: does not touch a downstream task that already ran ahead', () => {
+    const persistence = new InMemoryPersistence();
+    const orchestrator = makeOrchestrator(persistence);
+    const aId = loadLoneWorkflow(orchestrator, 'lone-a3', 'memory://test-repo');
+    const bId = loadLoneWorkflow(orchestrator, 'lone-b3', 'memory://test-repo');
+    const bTaskId = orchestrator.getAllTasks().find(
+      (t) => t.config.workflowId === bId && !t.config.isMergeNode,
+    )!.id;
+
+    orchestrator.startExecution();
+    orchestrator.handleWorkerResponse({
+      requestId: 'r1', actionId: bTaskId, executionGeneration: 0,
+      status: 'completed', outputs: { exitCode: 0 },
+    });
+    expect(orchestrator.getTask(bTaskId)!.status).toBe('completed');
+
+    orchestrator.attachWorkflow(bId, aId, { force: true });
+
+    expect(
+      orchestrator.getTask(bTaskId)!.status,
+      'attach must not reset a task that already ran ahead',
+    ).toBe('completed');
+  });
+});

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -8,6 +8,7 @@
 import type { CommandEnvelope, CommandResult } from '@invoker/contracts';
 import { OrchestratorError } from './orchestrator.js';
 import type { Orchestrator, ExternalGatePolicyUpdate, TaskReplacementDef } from './orchestrator.js';
+import type { ExternalGatePolicy } from '@invoker/workflow-graph';
 import {
   applyInvalidation,
   buildOrchestratorOnlyInvalidationDeps,
@@ -451,6 +452,30 @@ export class CommandService {
       () => this.orchestrator.detachWorkflow(
         envelope.payload.workflowId,
         envelope.payload.upstreamWorkflowId,
+      ),
+      undefined,
+    );
+  }
+
+  async attachWorkflow(
+    envelope: CommandEnvelope<{
+      workflowId: string;
+      upstreamWorkflowId: string;
+      taskId?: string;
+      gatePolicy?: ExternalGatePolicy;
+      force?: boolean;
+    }>,
+  ): Promise<CommandResult<void>> {
+    return this.executeCommand<void>(
+      'ATTACH_WORKFLOW_FAILED',
+      () => this.orchestrator.attachWorkflow(
+        envelope.payload.workflowId,
+        envelope.payload.upstreamWorkflowId,
+        {
+          taskId: envelope.payload.taskId,
+          gatePolicy: envelope.payload.gatePolicy,
+          force: envelope.payload.force,
+        },
       ),
       undefined,
     );

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -21,7 +21,7 @@ import type { ParsedResponse } from './response-handler.js';
 import { TaskScheduler } from './scheduler.js';
 import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, TaskExecution, Attempt, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency, ExternalGatePolicy, TaskStatus, TaskHeartbeatSource } from '@invoker/workflow-graph';
 import type { RunnerKind } from '@invoker/workflow-graph';
-import { createTaskState, createAttempt, hasFailedDependencyPath, isCrashPreservedExecution, isLivenessFailureClass } from '@invoker/workflow-graph';
+import { createTaskState, createAttempt, hasFailedDependencyPath, isCrashPreservedExecution, isLivenessFailureClass, computeWorkflowRollup } from '@invoker/workflow-graph';
 import type { WorkflowDerivedStatus } from '@invoker/workflow-graph';
 import type { Logger, WorkResponse } from '@invoker/contracts';
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
@@ -3033,6 +3033,120 @@ export class Orchestrator {
   detachWorkflow(workflowId: string, upstreamWorkflowId: string): void {
     this.syncAllFromDb();
     this.detachWorkflowInternal(workflowId, upstreamWorkflowId);
+  }
+
+  /**
+   * Attach a workflow to an upstream workflow's merge gate, dynamically,
+   * regardless of whether the two were ever previously linked (including
+   * re-attaching a pair that a prior `detachWorkflow` severed). This is a
+   * forward-only, non-invalidating mutation: it never resets or cancels any
+   * existing task, so it has no retroactive effect on a downstream task
+   * that already ran past the point the gate would have held it — it only
+   * gates tasks that are still pending/queued when the new dependency is
+   * added, via the normal `getExternalDependencyBlocker` scheduling check.
+   *
+   * Hard-blocked (never overridable, would corrupt the dependency graph):
+   * attaching a workflow to itself, or attaching in a direction that would
+   * create a dependency cycle (the proposed upstream already transitively
+   * depends on the proposed downstream).
+   *
+   * Blocked unless `opts.force` is set: attaching across two different
+   * `repoUrl`s, or attaching onto a downstream workflow whose rollup status
+   * is already `completed` or `closed` (a new gate could never hold a
+   * workflow that is already done).
+   */
+  attachWorkflow(
+    workflowId: string,
+    upstreamWorkflowId: string,
+    opts?: { taskId?: string; gatePolicy?: ExternalGatePolicy; force?: boolean },
+  ): void {
+    this.refreshFromDb();
+
+    if (workflowId === upstreamWorkflowId) {
+      throw new Error(`Cannot attach workflow ${workflowId} to itself`);
+    }
+
+    const targetTasks = this.stateMachine.getAllTasks().filter(
+      (task) => task.config.workflowId === workflowId,
+    );
+    if (targetTasks.length === 0) {
+      throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
+    }
+    const upstreamTasks = this.stateMachine.getAllTasks().filter(
+      (task) => task.config.workflowId === upstreamWorkflowId,
+    );
+    if (upstreamTasks.length === 0) {
+      throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${upstreamWorkflowId} not found`);
+    }
+
+    if (this.collectDownstreamWorkflowIds(workflowId).includes(upstreamWorkflowId)) {
+      throw new Error(
+        `Cannot attach workflow ${workflowId} to ${upstreamWorkflowId}: ${upstreamWorkflowId} already transitively depends on ${workflowId}, so this would create a dependency cycle`,
+      );
+    }
+
+    const targetWorkflow = this.persistence.loadWorkflow?.(workflowId)
+      ?? this.persistence.listWorkflows().find((candidate) => candidate.id === workflowId);
+    const upstreamWorkflow = this.persistence.loadWorkflow?.(upstreamWorkflowId)
+      ?? this.persistence.listWorkflows().find((candidate) => candidate.id === upstreamWorkflowId);
+
+    if (!opts?.force && targetWorkflow?.repoUrl && upstreamWorkflow?.repoUrl
+      && targetWorkflow.repoUrl !== upstreamWorkflow.repoUrl) {
+      throw new Error(
+        `Cannot attach workflow ${workflowId} (repo ${targetWorkflow.repoUrl}) to ${upstreamWorkflowId} `
+        + `(repo ${upstreamWorkflow.repoUrl}): different repos. Pass { force: true } to override.`,
+      );
+    }
+
+    const targetStatus = computeWorkflowRollup(targetTasks).status;
+    if (!opts?.force && (targetStatus === 'completed' || targetStatus === 'closed')) {
+      throw new Error(
+        `Cannot attach workflow ${workflowId}: it is already ${targetStatus}, so a new dependency would `
+        + `never gate anything. Pass { force: true } to override.`,
+      );
+    }
+
+    const deps = targetWorkflow?.externalDependencies ?? [];
+    if (deps.some((dep) => dep.workflowId === upstreamWorkflowId)) {
+      throw new Error(`Workflow ${workflowId} already depends on upstream workflow ${upstreamWorkflowId}`);
+    }
+
+    const newDep: ExternalDependency = {
+      workflowId: upstreamWorkflowId,
+      taskId: opts?.taskId?.trim() || '__merge__',
+      requiredStatus: 'completed',
+      gatePolicy: opts?.gatePolicy ?? 'completed',
+    };
+    const nextDeps: ExternalDependency[] = [...deps, newDep];
+
+    const now = workflowTimestamp().toISOString();
+    const existingChanges = targetWorkflow?.externalDependencyChanges ?? [];
+    const dependencyChanges: ExternalDependencyChange[] = [...existingChanges, { after: newDep, changedAt: now }];
+
+    const existingProvenance = targetWorkflow?.detachedExternalDependencies ?? [];
+    const nextProvenance = existingProvenance.filter((dep) => dep.workflowId !== upstreamWorkflowId);
+
+    this.taskRepository.updateWorkflow(workflowId, {
+      externalDependencies: nextDeps,
+      externalDependencyChanges: dependencyChanges,
+      detachedExternalDependencies: nextProvenance.length > 0 ? nextProvenance : undefined,
+    });
+
+    const eventTask = this.getMergeNode(workflowId) ?? targetTasks[0];
+    this.persistence.logEvent?.(eventTask.id, 'workflow.external_dependency_changed', {
+      workflowId,
+      upstreamWorkflowId,
+      action: 'added',
+      changes: dependencyChanges.slice(existingChanges.length),
+    });
+    this.persistence.logEvent?.(eventTask.id, 'task.external_dependency_changed', {
+      workflowId,
+      upstreamWorkflowId,
+      action: 'added',
+    });
+
+    this.autoStartExternallyUnblockedReadyTasks();
+    this.checkWorkflowCompletion(workflowId);
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds `CommandService.attachWorkflow` for the attach primitive introduced by slice (1).

The method forwards workflow, upstream, task, gate-policy, and force inputs through the existing serialized result boundary.

## Review Claim

Approve `CommandService.attachWorkflow` as the routing layer for the existing orchestrator attach primitive.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`CommandService.detachWorkflow` and every existing method are unchanged; this slice only adds a new method and error code.

## Slice Rationale

Routing is isolated from the headless activation surface because the repository validator assigns these files to separate review units.

## Non-goals

- No headless command, dispatch case, registry entry, or usage text.
- No IPC channel, GUI context-menu action, or picker UI.
- No change to the orchestrator attach primitive introduced by slice (1).

## Architecture

### Before

```mermaid
graph LR
    A["Orchestrator.attachWorkflow"]
```

### After

```mermaid
graph LR
    A["CommandService.attachWorkflow"] --> B["Orchestrator.attachWorkflow"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `(cd packages/workflow-core && pnpm test)` — `Test Files 43 passed (43)`; `Tests 889 passed | 3 skipped (892)`; `EXIT_CODE=0`.
- [x] The three skips are pre-existing `it.skip` cases in `orchestrator-gates-and-workflow-admin.test.ts`: `surfaces deferred tasks as queued instead of pending`, `keeps a parked resource-limit task queued between scheduler polls`, and `re-dispatches a queued resource-limit task when a slot frees`. No inline skip reason is recorded.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes. This removes only the new command-service route.
- Revert command: `git revert 3f64e87f5`
- Post-revert steps: Revert the dependent headless slice first if it has landed.
- Data migration? No.

</details>
