### PR TITLE
[Attach workflow](3a) Add attach-workflow IPC contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -13,6 +13,7 @@ import type {
   TaskState,
   TaskDelta,
   TaskStateChanges,
+  ExternalGatePolicy,
   WorkflowDerivedStatus,
   WorkflowRollup,
 } from '@invoker/workflow-graph';
@@ -1046,7 +1047,7 @@ export const IpcChannels = {
     response: WorkflowMutationAcceptedResult;
   },
   'invoker:attach-workflow': {} as {
-    request: [workflowId: string, upstreamWorkflowId: string, opts?: { taskId?: string; gatePolicy?: string; force?: boolean }];
+    request: [workflowId: string, upstreamWorkflowId: string, opts?: { taskId?: string; gatePolicy?: ExternalGatePolicy; force?: boolean }];
     response: WorkflowMutationAcceptedResult;
   },
   'invoker:load-workflow': {} as {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -1045,6 +1045,10 @@ export const IpcChannels = {
     request: [workflowId: string, upstreamWorkflowId: string];
     response: WorkflowMutationAcceptedResult;
   },
+  'invoker:attach-workflow': {} as {
+    request: [workflowId: string, upstreamWorkflowId: string, opts?: { taskId?: string; gatePolicy?: string; force?: boolean }];
+    response: WorkflowMutationAcceptedResult;
+  },
   'invoker:load-workflow': {} as {
     request: [workflowId: string];
     response: { workflow: unknown; tasks: unknown[] };


### PR DESCRIPTION
## Summary

Adds the typed `invoker:attach-workflow` IPC request for a downstream workflow, its upstream workflow, and optional gate settings.

Uses the existing workflow-mutation response shape so desktop callers share the same accepted-mutation semantics as detach.

## Review Claim

The shared IPC contract defines one typed, additive request for attaching a downstream workflow to an upstream workflow.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The channel registry change is additive, and the existing `invoker:detach-workflow` request and response types remain unchanged.

## Slice Rationale

This foundation slice isolates the public IPC shape so the dependent GUI slice can use a stable typed boundary.

## Non-goals

- No IPC handler registration.
- No workflow context-menu changes.
- No changes to `CommandService.attachWorkflow` semantics.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `(cd packages/contracts && pnpm test)`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, before the dependent GUI slice lands.
- Revert command: `git revert 4edcda6108ed00c48d25d45f5dae435260039d14`
- Post-revert steps: None.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for attaching a workflow to an upstream workflow.
  - Attachment requests can optionally specify a task, gate policy, or force option.
  - Requests now return an acceptance result for tracking the workflow update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->