### PR TITLE
[Attach workflow](3b) Add GUI action and searchable picker

### DIFF
--- a/packages/app/e2e/attach-workflow.spec.ts
+++ b/packages/app/e2e/attach-workflow.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect, waitForStableUI, E2E_REPO_URL } from './fixtures/electron-app.js';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import { stringify as yamlStringify } from 'yaml';
+
+function yamlPlan(plan: Record<string, unknown>): string {
+  return yamlStringify(plan);
+}
+
+const OUT_DIR = path.resolve(__dirname, '..', 'e2e-scratch', 'attach-workflow');
+
+test('attach removes the Detached badge from a workflow node', async ({ page }) => {
+  await fs.mkdir(OUT_DIR, { recursive: true });
+
+  const upstreamIdsBefore = await page.evaluate(async () => {
+    const workflows = await window.invoker.listWorkflows();
+    return workflows.map((w: { id: string }) => w.id);
+  });
+  await page.evaluate((p) => window.invoker.loadPlan(p), yamlPlan({
+    name: 'e2e-attach-upstream',
+    repoUrl: E2E_REPO_URL,
+    onFinish: 'none',
+    tasks: [{ id: 'up', description: 'upstream', command: 'echo up' }],
+  }));
+  const upstreamId: string = await page.waitForFunction(
+    (knownIds) => window.invoker.listWorkflows().then((workflows: { id: string }[]) => {
+      const created = workflows.find((w) => !knownIds.includes(w.id));
+      return created?.id ?? null;
+    }),
+    upstreamIdsBefore,
+    { timeout: 10000 },
+  ).then((handle) => handle.jsonValue());
+  expect(upstreamId).toBeTruthy();
+
+  const downstreamIdsBefore = await page.evaluate(async () => {
+    const workflows = await window.invoker.listWorkflows();
+    return workflows.map((w: { id: string }) => w.id);
+  });
+  await page.evaluate((p) => window.invoker.loadPlan(p), yamlPlan({
+    name: 'e2e-attach-downstream',
+    repoUrl: E2E_REPO_URL,
+    onFinish: 'none',
+    externalDependencies: [{ workflowId: upstreamId, gatePolicy: 'completed' }],
+    tasks: [{ id: 'down', description: 'downstream', command: 'echo down' }],
+  }));
+  const downstreamId: string = await page.waitForFunction(
+    (knownIds) => window.invoker.listWorkflows().then((workflows: { id: string }[]) => {
+      const created = workflows.find((w) => !knownIds.includes(w.id));
+      return created?.id ?? null;
+    }),
+    downstreamIdsBefore,
+    { timeout: 10000 },
+  ).then((handle) => handle.jsonValue());
+  expect(downstreamId).toBeTruthy();
+
+  await page.getByTestId('sidebar-planning').click();
+  await page.getByRole('button', { name: 'Refresh' }).click();
+
+  await page.evaluate((id) => window.invoker.detachWorkflow(id[0], id[1]), [downstreamId, upstreamId]);
+  await page.waitForFunction(
+    (id) => window.invoker.listWorkflows().then((workflows: any[]) =>
+      (workflows.find((w) => w.id === id)?.detachedExternalDependencies?.length ?? 0) > 0),
+    downstreamId,
+    { timeout: 10000 },
+  );
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await waitForStableUI(page);
+
+  const nodeLocator = page.getByTestId(`workflow-node-${downstreamId}`);
+  await nodeLocator.waitFor({ state: 'visible', timeout: 10000 });
+  const badgeBefore = page.getByTestId(`workflow-node-${downstreamId}-detached-lineage`);
+  await expect(badgeBefore).toBeVisible();
+  await nodeLocator.screenshot({ path: path.join(OUT_DIR, 'before-detached-badge.png') });
+
+  page.once('dialog', (dialog) => void dialog.accept());
+  await nodeLocator.dispatchEvent('contextmenu', { bubbles: true, cancelable: true, button: 2, buttons: 2 });
+  await page.getByRole('menuitem', { name: 'More' }).click();
+  await page.getByRole('menuitem', { name: 'Attach to...' }).click();
+  const picker = page.getByTestId('attach-workflow-picker');
+  await expect(picker).toHaveAttribute('data-state', 'open');
+  await picker.locator('input').fill(upstreamId);
+  await picker.getByText('e2e-attach-upstream').click();
+
+  await page.waitForFunction(
+    (id) => window.invoker.listWorkflows().then((workflows: any[]) =>
+      (workflows.find((w) => w.id === id)?.detachedExternalDependencies?.length ?? 0) === 0),
+    downstreamId,
+    { timeout: 10000 },
+  );
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await waitForStableUI(page);
+
+  const badgeAfter = page.getByTestId(`workflow-node-${downstreamId}-detached-lineage`);
+  await expect(badgeAfter).toHaveCount(0);
+  await nodeLocator.screenshot({ path: path.join(OUT_DIR, 'after-no-detached-badge.png') });
+});

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -287,6 +287,11 @@ export interface GuiMutationTaskActions {
   logAutoFixDebug: (taskId: string, phase: string, details?: Record<string, unknown>) => void;
   performDeleteWorkflow: (workflowId: string) => Promise<void>;
   performDetachWorkflow: (workflowId: string, upstreamWorkflowId: string) => Promise<void>;
+  performAttachWorkflow: (
+    workflowId: string,
+    upstreamWorkflowId: string,
+    opts?: { taskId?: string; gatePolicy?: string; force?: boolean },
+  ) => Promise<void>;
   performCancelTask: (taskId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
   performDeleteTask: (taskId: string) => Promise<void>;
   performCancelWorkflow: (workflowId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
@@ -635,6 +640,25 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
     requestWorkflowMetadataPublish('detach-workflow');
   }
 
+  async function performAttachWorkflow(
+    workflowId: string,
+    upstreamWorkflowId: string,
+    opts?: { taskId?: string; gatePolicy?: string; force?: boolean },
+  ): Promise<void> {
+    logger.info(`performAttachWorkflow begin workflow="${workflowId}" upstream="${upstreamWorkflowId}"`, { module: 'kill' });
+    const envelope = makeEnvelope('attach-workflow', 'ui', 'workflow', {
+      workflowId,
+      upstreamWorkflowId,
+      taskId: opts?.taskId,
+      gatePolicy: opts?.gatePolicy as 'completed' | 'review_ready' | 'ci_failed' | undefined,
+      force: opts?.force,
+    });
+    const result = await commandService.attachWorkflow(envelope);
+    if (!result.ok) throw new Error(result.error.message);
+    logger.info(`performAttachWorkflow end workflow="${workflowId}" upstream="${upstreamWorkflowId}"`, { module: 'kill' });
+    requestWorkflowMetadataPublish('attach-workflow');
+  }
+
   /** Orchestrator error codes that preemption treats as benign (cancel is best-effort). */
   const preemptSkipCodes: ReadonlySet<string> = new Set([
     OrchestratorErrorCode.TASK_NOT_FOUND,
@@ -976,6 +1000,17 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
         return { channel: 'headless.exec', request: { args: ['delete', String(arg0)], noTrack: true } };
       case 'invoker:detach-workflow':
         return { channel: 'headless.exec', request: { args: ['detach-workflow', String(arg0), String(arg1)], noTrack: true } };
+      case 'invoker:attach-workflow': {
+        const opts = arg2 as { taskId?: string; gatePolicy?: string; force?: boolean } | undefined;
+        const flags: string[] = [];
+        if (opts?.gatePolicy) flags.push('--gate-policy', opts.gatePolicy);
+        if (opts?.taskId) flags.push('--task-id', opts.taskId);
+        if (opts?.force) flags.push('--force');
+        return {
+          channel: 'headless.exec',
+          request: { args: ['attach-workflow', String(arg0), String(arg1), ...flags], noTrack: true },
+        };
+      }
       case 'invoker:provide-input':
         return { channel: 'headless.exec', request: { args: ['input', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:approve':
@@ -1091,6 +1126,7 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
     logAutoFixDebug,
     performDeleteWorkflow,
     performDetachWorkflow,
+    performAttachWorkflow,
     performCancelTask,
     performDeleteTask,
     performCancelWorkflow,
@@ -1178,6 +1214,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   const preemptWorkflowExecution = actions.preemptWorkflowExecution;
   const performDeleteWorkflow = actions.performDeleteWorkflow;
   const performDetachWorkflow = actions.performDetachWorkflow;
+  const performAttachWorkflow = actions.performAttachWorkflow;
   const performSharedApproveTask = actions.performSharedApproveTask;
   const executeFixWithAgentMutation = actions.executeFixWithAgentMutation;
   const executeSpawnRepairWorkflowMutation = actions.executeSpawnRepairWorkflowMutation;
@@ -1652,6 +1689,27 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
         await performDetachWorkflow(workflowId, upstreamWorkflowId);
       } catch (err) {
         logger.error(`detach-workflow failed: ${err}`, { module: 'ipc' });
+        throw err;
+      }
+    },
+  );
+
+  registerWorkflowScopedGuiMutationHandler(
+    'invoker:attach-workflow',
+    (workflowIdArg: unknown) => String(workflowIdArg),
+    'high',
+    async (workflowIdArg: unknown, upstreamWorkflowIdArg: unknown, optsArg: unknown) => {
+      const workflowId = String(workflowIdArg);
+      const upstreamWorkflowId = String(upstreamWorkflowIdArg);
+      const opts = optsArg as { taskId?: string; gatePolicy?: string; force?: boolean } | undefined;
+      logger.info(
+        `attach-workflow: workflow="${workflowId}" upstream="${upstreamWorkflowId}"`,
+        { module: 'ipc' },
+      );
+      try {
+        await performAttachWorkflow(workflowId, upstreamWorkflowId, opts);
+      } catch (err) {
+        logger.error(`attach-workflow failed: ${err}`, { module: 'ipc' });
         throw err;
       }
     },

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -52,6 +52,7 @@ import { Trash2 } from 'lucide-react';
 import { Button } from './components/primitives/index.js';
 import { ChevronDownIcon, PlayIcon } from './components/icons/index.js';
 import { CommandPalette, COMMAND_PALETTE_MAX_ROWS } from './components/CommandPalette.js';
+import { AttachWorkflowPicker } from './components/AttachWorkflowPicker.js';
 import {
   getAttentionTaskEntries,
   getRunningTaskEntries,
@@ -706,6 +707,7 @@ interface WorkflowContextMenuProps {
   onCancelWorkflow: (workflowId: string) => void;
   onDeleteWorkflow: (workflowId: string) => void;
   onDetachWorkflow: (workflowId: string) => void;
+  onAttachWorkflow: (workflowId: string) => void;
   onCopyWorkflowId: (workflowId: string) => void;
   /** True when this workflow has exactly one upstream dependency that can be detached from the UI. */
   canDetach: boolean;
@@ -744,6 +746,7 @@ function WorkflowContextMenu({
   onCancelWorkflow,
   onDeleteWorkflow,
   onDetachWorkflow,
+  onAttachWorkflow,
   onCopyWorkflowId,
   canDetach,
   onClose,
@@ -836,6 +839,7 @@ function WorkflowContextMenu({
           ...(canDetach
             ? [{ id: 'detach-workflow', label: 'Detach Upstream Workflow', className: dangerButtonClass, action: () => runAction(onDetachWorkflow) }]
             : []),
+          { id: 'attach-workflow', label: 'Attach to...', className: buttonClass, action: () => runAction(onAttachWorkflow) },
           { id: 'delete-workflow', label: 'Delete Workflow', className: dangerButtonClass, action: () => runAction(onDeleteWorkflow) },
         ]),
   ];
@@ -1175,6 +1179,7 @@ export function App() {
   const [terminalSessions, setTerminalSessions] = useState<TerminalSessionDescriptor[]>([]);
   const [activeTerminalSessionId, setActiveTerminalSessionId] = useState<string | null>(null);
   const [workflowContextMenu, setWorkflowContextMenu] = useState<WorkflowContextMenuState | null>(null);
+  const [attachPickerWorkflowId, setAttachPickerWorkflowId] = useState<string | null>(null);
   const [graphActionsMenuOpen, setGraphActionsMenuOpen] = useState(false);
   const [startReadyMenuOpen, setStartReadyMenuOpen] = useState(false);
   const [startReadyBusy, setStartReadyBusy] = useState(false);
@@ -2634,6 +2639,35 @@ export function App() {
       notifyMutationError('Detach Workflow failed:', err);
     }
   }, [workflows, refreshTaskGraph]);
+
+  const handleAttachWorkflow = useCallback((workflowId: string) => {
+    setWorkflowContextMenu(null);
+    setAttachPickerWorkflowId(workflowId);
+  }, []);
+
+  const handleAttachWorkflowSelect = useCallback(async (upstreamWorkflowId: string) => {
+    const workflowId = attachPickerWorkflowId;
+    setAttachPickerWorkflowId(null);
+    if (!workflowId) return;
+    const workflow = workflows.get(workflowId);
+    const downstreamName = workflow?.name ?? workflowId;
+    const upstreamName = workflows.get(upstreamWorkflowId)?.name ?? upstreamWorkflowId;
+    const confirmed = window.confirm(
+      `Attach "${downstreamName}" to upstream "${upstreamName}"?\n\n` +
+      `This adds a dependency so "${downstreamName}" waits on "${upstreamName}"'s merge. ` +
+      `Tasks that already ran ahead of this gate are left untouched.`,
+    );
+    if (!confirmed) return;
+    try {
+      await window.invoker?.attachWorkflow(workflowId, upstreamWorkflowId);
+      setDetachNotice(
+        `Attached "${downstreamName}" to upstream "${upstreamName}". The dependency was added.`,
+      );
+      refreshTaskGraph();
+    } catch (err) {
+      notifyMutationError('Attach Workflow failed:', err);
+    }
+  }, [workflows, refreshTaskGraph, attachPickerWorkflowId]);
 
   useEffect(() => {
     if (!detachNotice) return;
@@ -4962,6 +4996,17 @@ export function App() {
         }}
         planningSessionCount={planningSessions.length}
       />
+      <AttachWorkflowPicker
+        open={attachPickerWorkflowId !== null}
+        downstreamName={
+          attachPickerWorkflowId ? (workflows.get(attachPickerWorkflowId)?.name ?? attachPickerWorkflowId) : ''
+        }
+        entries={Array.from(workflows.values())
+          .filter((candidate) => candidate.id !== attachPickerWorkflowId)
+          .map((candidate) => ({ id: candidate.id, name: candidate.name }))}
+        onSelect={(upstreamWorkflowId) => void handleAttachWorkflowSelect(upstreamWorkflowId)}
+        onClose={() => setAttachPickerWorkflowId(null)}
+      />
 
       {showSystemBanner && (
         <div className="px-4 py-3 border-b border-amber-700 bg-amber-950/50 flex items-center justify-between gap-4">
@@ -5346,6 +5391,7 @@ export function App() {
           onCancelWorkflow={(workflowId) => void handleCancelWorkflow(workflowId)}
           onDeleteWorkflow={(workflowId) => void handleDeleteWorkflow(workflowId)}
           onDetachWorkflow={(workflowId) => void handleDetachWorkflow(workflowId)}
+          onAttachWorkflow={(workflowId) => void handleAttachWorkflow(workflowId)}
           canDetach={(workflows.get(workflowContextMenu.workflowId)?.externalDependencies?.length ?? 0) === 1}
           onCopyWorkflowId={handleCopyWorkflowId}
           onClose={closeContextMenu}

--- a/packages/ui/src/components/AttachWorkflowPicker.tsx
+++ b/packages/ui/src/components/AttachWorkflowPicker.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef, type JSX } from 'react';
+import { GitBranch } from 'lucide-react';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from './primitives/index.js';
+
+export interface AttachWorkflowPickerEntry {
+  id: string;
+  name: string;
+}
+
+export interface AttachWorkflowPickerProps {
+  open: boolean;
+  downstreamName: string;
+  entries: AttachWorkflowPickerEntry[];
+  onSelect: (upstreamWorkflowId: string) => void;
+  onClose: () => void;
+}
+
+export function AttachWorkflowPicker({
+  open,
+  downstreamName,
+  entries,
+  onSelect,
+  onClose,
+}: AttachWorkflowPickerProps): JSX.Element {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const frame = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [open, onClose]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal={open}
+      aria-label={`Attach ${downstreamName} to...`}
+      aria-hidden={!open}
+      data-testid="attach-workflow-picker"
+      data-state={open ? 'open' : 'closed'}
+      className={[
+        'fixed inset-0 z-50 flex items-start justify-center bg-black/70 px-4 pt-[18vh]',
+        open ? '' : 'hidden',
+      ].join(' ')}
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div className="w-full max-w-xl overflow-hidden rounded-lg border border-border-strong bg-card text-card-foreground shadow-lg">
+        <Command loop shouldFilter>
+          <CommandInput
+            ref={inputRef}
+            placeholder={`Attach "${downstreamName}" to which upstream workflow?`}
+          />
+          <CommandList>
+            <CommandEmpty>No matching workflows.</CommandEmpty>
+            <CommandGroup heading="Workflows">
+              {entries.map((entry) => (
+                <CommandItem
+                  key={entry.id}
+                  value={`${entry.id} ${entry.name}`}
+                  onSelect={() => onSelect(entry.id)}
+                >
+                  <GitBranch strokeWidth={1.75} />
+                  <span className="truncate">{entry.name}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds an IPC handler that sends workflow attachment requests to `CommandService.attachWorkflow`.

Adds a searchable picker to the workflow context menu so desktop users can choose an upstream workflow without entering an ID.

Adds Playwright coverage for the detached-badge transition through the real Electron UI.

## Review Claim

A user can attach one workflow to another from the workflow node context menu through a searchable upstream-workflow picker.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The existing "Detach Upstream Workflow" action, handler, and `invoker:detach-workflow` path are unchanged; this slice adds parallel attach-only paths.

## Slice Rationale

The GUI handler, context-menu action, picker, and end-to-end proof stay together because none is independently usable or demonstrable without the others.

## Non-goals

- No changes to workflow attachment semantics in `CommandService`.
- No changes to the existing detach action or IPC path.
- No new headless verb or CLI surface.
- The guarded `dag-surface-background-click-noop` behavior remains unchanged.

## Architecture

### Before

```mermaid
graph LR
    A["Workflow context menu"] --> B["Detach only"]
    C["CommandService.attachWorkflow"] --> D["Existing callers"]
```

### After

```mermaid
graph LR
    A["Workflow context menu"] --> B["Attach to..."]
    B --> C["Searchable workflow picker"]
    C --> D["invoker:attach-workflow"]
    D --> E["CommandService.attachWorkflow"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `(cd packages/workflow-core && pnpm test)`
- [x] `(cd packages/app && pnpm test)`
- [x] `(cd packages/ui && pnpm test)`
- [x] `(cd packages/app && CAPTURE_VIDEO=1 INVOKER_PLAYWRIGHT_WORKERS=1 pnpm exec playwright test e2e/attach-workflow.spec.ts)`

</details>

## Visual Proof

![Animated click-through: the detached workflow opens the searchable upstream picker, then returns without the detached badge](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260811-f4fb14/attach-workflow-click-through.gif)

![Before attachment: the downstream workflow node shows the amber Detached badge](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260811-f4fb14/before-detached-badge.png)

![After attachment: the same downstream workflow node no longer shows the Detached badge](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260811-f4fb14/after-no-detached-badge.png)

Manually inspected: the animation shows the amber `DETACHED` badge, the searchable picker containing `e2e-attach-upstream`, and the final graph with the badge absent and an attachment success toast. The two screenshots show the same downstream node immediately before and after that transition.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a39ed0c64f298fe2a4c9fc3769ca30999ea456e9`
- Post-revert steps: Rebuild the desktop app.
- Data migration? No

</details>
