### PR TITLE
[Planning review parity](2) Define shared review lifecycle

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -14,6 +14,11 @@
       "types": "./src/ipc-channels.ts",
       "import": "./src/ipc-channels.ts",
       "require": "./src/ipc-channels.ts"
+    },
+    "./planning-surface": {
+      "types": "./src/planning-surface.ts",
+      "import": "./src/planning-surface.ts",
+      "require": "./src/planning-surface.ts"
     }
   },
   "scripts": {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -15,4 +15,5 @@ export * from './config-diagnostics.ts';
 export * from './remote-target-onboarding.ts';
 export * from './prerequisites.ts';
 export * from './headless-owner-launch.ts';
+export * from './planning-surface.ts';
 export { EXTERNAL_DEPENDENCIES, DEFAULT_DRAFTER_MCP_PACKAGE_SPEC } from './external-dependencies.ts';

--- a/packages/contracts/src/planning-surface.ts
+++ b/packages/contracts/src/planning-surface.ts
@@ -1,0 +1,47 @@
+export type PlanningHostSurface = 'in_app' | 'slack';
+
+export type PlanningSubmitAction = 'prepare_review' | 'submit_ready';
+
+function normalizedPlanningCommand(text: string): string {
+  return text.trim().toLowerCase().replace(/[.!?]+$/g, '').replace(/\s+/g, ' ');
+}
+
+export function isExactPlanningSubmitCommand(text: string): boolean {
+  return [
+    'submit',
+    'submit it',
+    'submit to invoker',
+  ].includes(normalizedPlanningCommand(text));
+}
+
+export function resolvePlanningSubmitAction(
+  text: string,
+  hasReadyDraft: boolean,
+): PlanningSubmitAction | null {
+  if (!isExactPlanningSubmitCommand(text)) return null;
+  return hasReadyDraft ? 'submit_ready' : 'prepare_review';
+}
+
+export function planningHostContext(surface: PlanningHostSurface): string {
+  if (surface === 'in_app') {
+    return [
+      'Current planning host: Invoker in-app planner.',
+      '- Never direct the user to Slack or claim that a Slack review card exists.',
+      '- When you write valid YAML, the in-app host stages that exact draft in its review panel.',
+      '- Writing YAML does not submit or execute it; the user must approve the staged draft.',
+    ].join('\n');
+  }
+
+  return [
+    'Current planning host: Invoker Slack planner.',
+    '- When you write valid YAML, the Slack host stages that exact draft in an Approve/Cancel review card.',
+    '- Writing YAML does not submit or execute it; the user must approve the staged draft.',
+  ].join('\n');
+}
+
+export function formatPlanningHostedTurn(
+  surface: PlanningHostSurface,
+  userMessage: string,
+): string {
+  return `${planningHostContext(surface)}\n\nUser message:\n${userMessage}`;
+}

--- a/packages/planning-core/package.json
+++ b/packages/planning-core/package.json
@@ -17,6 +17,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@invoker/contracts": "workspace:*",
     "yaml": "^2.7.0"
   },
   "devDependencies": {

--- a/packages/planning-core/src/__tests__/lifecycle.test.ts
+++ b/packages/planning-core/src/__tests__/lifecycle.test.ts
@@ -7,6 +7,10 @@ import {
 describe('Planning Terminal lifecycle contract', () => {
   it('authorizes only explicit draft intent or confirmation of an assistant draft question', () => {
     expect(hasExplicitDraftIntent('proceed')).toBe(true);
+    expect(hasExplicitDraftIntent('submit')).toBe(true);
+    expect(hasExplicitDraftIntent('submit it!')).toBe(true);
+    expect(hasExplicitDraftIntent('submit to invoker')).toBe(true);
+    expect(hasExplicitDraftIntent("don't submit to Slack; submit to Invoker")).toBe(false);
     expect(isDraftingAuthorized('yes', [
       { role: 'assistant', content: 'Would you like me to draft the YAML plan?' },
     ])).toBe(true);

--- a/packages/planning-core/src/__tests__/planning-review-incident-corpus.test.ts
+++ b/packages/planning-core/src/__tests__/planning-review-incident-corpus.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { isDraftingAuthorized } from '../lifecycle.js';
+import { evaluatePlanningTurn } from '../planning-turn.js';
+
+const validPlan = [
+  'name: Incident corpus plan',
+  'tasks:',
+  '  - id: implement',
+  '    description: Exercise the real conversation wording',
+].join('\n');
+
+const affectedTurns = [
+  ['ad665bff', 'github.com/Neko-Catpital-Labs/Invoker/'],
+  ['01bd9064', 'github.com/Neko-Catpital-Labs/Invoker, yes'],
+  ['95535743', 'submit to inovker'],
+  ['b35866a8', 'dont submi to slack. submit to invoker'],
+  ['33cde460', 'first one'],
+  ['6f3203c7', 'Yes please. do both of those and also make sure you ship the repro script'],
+  ['8cae6f0f', 'Yes thats the one'],
+] as const;
+
+describe('planning review incident corpus from 2026-08-11', () => {
+  it.each(affectedTurns)('%s stages valid YAML despite unmatched current-turn phrasing', (_session, userMessage) => {
+    const messagesBeforeTurn = [{
+      role: 'assistant' as const,
+      content: 'The scope is resolved. Send the repository or choose the preferred option.',
+    }];
+
+    expect(isDraftingAuthorized(userMessage, messagesBeforeTurn)).toBe(false);
+    expect(evaluatePlanningTurn({
+      userMessage,
+      messagesBeforeTurn,
+      assistantReply: 'Plan written.',
+      immediateDraftPlanText: validPlan,
+    })).toMatchObject({
+      kind: 'draft_ready',
+      planText: validPlan,
+      draftingAuthorized: false,
+    });
+  });
+});

--- a/packages/planning-core/src/__tests__/planning-surface.test.ts
+++ b/packages/planning-core/src/__tests__/planning-surface.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatPlanningHostedTurn,
+  resolvePlanningSubmitAction,
+} from '../planning-surface.js';
+
+describe('planning surface parity contract', () => {
+  it('resolves exact submit commands from shared draft state', () => {
+    for (const command of ['submit', 'Submit it!', 'submit to invoker.']) {
+      expect(resolvePlanningSubmitAction(command, false)).toBe('prepare_review');
+      expect(resolvePlanningSubmitAction(command, true)).toBe('submit_ready');
+    }
+  });
+
+  it('does not execute submit-like prose', () => {
+    expect(resolvePlanningSubmitAction("don't submit to Slack; submit to Invoker", true)).toBeNull();
+    expect(resolvePlanningSubmitAction('can you submit this?', true)).toBeNull();
+    expect(resolvePlanningSubmitAction('submit to inovker', true)).toBeNull();
+  });
+
+  it('restates the current host on every hosted turn', () => {
+    expect(formatPlanningHostedTurn('in_app', 'continue')).toContain('Current planning host: Invoker in-app planner.');
+    expect(formatPlanningHostedTurn('in_app', 'continue')).toContain('Never direct the user to Slack');
+    expect(formatPlanningHostedTurn('slack', 'continue')).toContain('Current planning host: Invoker Slack planner.');
+  });
+});

--- a/packages/planning-core/src/__tests__/planning-turn.test.ts
+++ b/packages/planning-core/src/__tests__/planning-turn.test.ts
@@ -9,15 +9,30 @@ const planText = [
 ].join('\n');
 
 describe('evaluatePlanningTurn', () => {
-  it('returns an ordinary message when drafting is not authorized', () => {
+  it('stages a valid current-turn draft even when prompt drafting was not authorized', () => {
     expect(evaluatePlanningTurn({
       userMessage: 'What would this involve?',
       messagesBeforeTurn: [],
       assistantReply: 'Here is the scope.',
       immediateDraftPlanText: planText,
+    })).toMatchObject({
+      kind: 'draft_ready',
+      text: 'Here is the scope.',
+      planText,
+      draftingAuthorized: false,
+    });
+  });
+
+  it('does not replace a locked draft without explicit redraft authorization', () => {
+    expect(evaluatePlanningTurn({
+      userMessage: 'Can we skip the extra dependency?',
+      messagesBeforeTurn: [],
+      assistantReply: 'Here is an incidental YAML restatement.',
+      immediateDraftPlanText: planText,
+      hasExistingDraft: true,
     })).toEqual({
       kind: 'message',
-      text: 'Here is the scope.',
+      text: 'Here is an incidental YAML restatement.',
       status: 'still_discussing',
       draftingAuthorized: false,
     });

--- a/packages/planning-core/src/index.ts
+++ b/packages/planning-core/src/index.ts
@@ -5,3 +5,4 @@ export * from './planning-turn.js';
 export * from './planning-review.js';
 export * from './planning-handoff-prompt.js';
 export * from './planning-actions.js';
+export * from './planning-surface.js';

--- a/packages/planning-core/src/lifecycle.ts
+++ b/packages/planning-core/src/lifecycle.ts
@@ -1,3 +1,5 @@
+import { isExactPlanningSubmitCommand } from './planning-surface.js';
+
 export type PlanningRole = 'user' | 'assistant' | 'system';
 
 export interface PlanningMessage {
@@ -10,6 +12,7 @@ function normalized(text: string): string {
 }
 
 export function hasExplicitDraftIntent(message: string): boolean {
+  if (isExactPlanningSubmitCommand(message)) return true;
   const value = message.trim().toLowerCase().replace(/\s+/g, ' ');
   return [
     /^draft$/,

--- a/packages/planning-core/src/planning-actions.ts
+++ b/packages/planning-core/src/planning-actions.ts
@@ -47,6 +47,7 @@ export async function appendPlanningTurn({
     assistantReply: reply,
     immediateDraftPlanText,
     requireDraftAuthorization,
+    hasExistingDraft: Boolean(state.draftPlanText),
   });
 
   const nextMessages: PlanningMessage[] = [
@@ -59,7 +60,7 @@ export async function appendPlanningTurn({
     return {
       reply,
       state: { ...state, messages: nextMessages, draftPlanText: turn.planText, status: 'draft_ready' },
-      draftingAuthorized: true,
+      draftingAuthorized: turn.draftingAuthorized,
       draftPlanText: turn.planText,
       summary: turn.summary,
     };
@@ -71,4 +72,3 @@ export async function appendPlanningTurn({
     draftingAuthorized: turn.draftingAuthorized,
   };
 }
-

--- a/packages/planning-core/src/planning-surface.ts
+++ b/packages/planning-core/src/planning-surface.ts
@@ -1,0 +1,8 @@
+export {
+  formatPlanningHostedTurn,
+  isExactPlanningSubmitCommand,
+  planningHostContext,
+  resolvePlanningSubmitAction,
+  type PlanningHostSurface,
+  type PlanningSubmitAction,
+} from '@invoker/contracts/planning-surface';

--- a/packages/planning-core/src/planning-turn.ts
+++ b/packages/planning-core/src/planning-turn.ts
@@ -19,7 +19,7 @@ export type SharedPlanningTurn =
       text: string;
       planText: string;
       summary: PlanSummary;
-      draftingAuthorized: true;
+      draftingAuthorized: boolean;
     };
 
 export interface EvaluatePlanningTurnInput {
@@ -28,6 +28,7 @@ export interface EvaluatePlanningTurnInput {
   assistantReply: string;
   immediateDraftPlanText: string | null | undefined;
   requireDraftAuthorization?: boolean;
+  hasExistingDraft?: boolean;
 }
 
 export function evaluatePlanningTurn({
@@ -36,19 +37,20 @@ export function evaluatePlanningTurn({
   assistantReply,
   immediateDraftPlanText,
   requireDraftAuthorization = true,
+  hasExistingDraft = false,
 }: EvaluatePlanningTurnInput): SharedPlanningTurn {
   const draftingAuthorized = !requireDraftAuthorization
     || isDraftingAuthorized(userMessage, messagesBeforeTurn);
   const planText = immediateDraftPlanText?.trim() || null;
   const summary = planText ? summarizePlanText(planText) : null;
 
-  if (draftingAuthorized && planText && summary) {
+  if (planText && summary && (!hasExistingDraft || draftingAuthorized)) {
     return {
       kind: 'draft_ready',
       text: assistantReply,
       planText,
       summary,
-      draftingAuthorized: true,
+      draftingAuthorized,
     };
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,6 +311,9 @@ importers:
 
   packages/planning-core:
     dependencies:
+      '@invoker/contracts':
+        specifier: workspace:*
+        version: link:../contracts
       yaml:
         specifier: ^2.7.0
         version: 2.8.2


### PR DESCRIPTION
## Summary

Defines one shared planning-review contract for host identity, lifecycle state, and exact approval phrases.

The shared rules keep a written YAML draft inert until an authorized host action advances it.

## Review Claim

Approve the shared interfaces and lifecycle rules as the single contract both planning hosts consume.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Writing or persisting YAML can only produce `ready` state. Execution still requires an authorized action from the bound planning host and requester.

## Slice Rationale

This contract slice precedes host-specific behavior so both surfaces depend on one review model instead of duplicating policy.

## Non-goals

- No Slack card rendering.
- No in-app panel rendering.
- No renderer event handling.

## Architecture

### Before

```mermaid
graph TD
    A["Sidecar YAML"] --> B["Host-specific interpretation"]
```

### After

```mermaid
graph TD
    A["Sidecar YAML"] --> B["Shared planning-review contract"]
    B --> C["Ready lifecycle state"]
    C --> D["Authorized host action"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/planning-core test -- src/__tests__/lifecycle.test.ts src/__tests__/planning-review-incident-corpus.test.ts src/__tests__/planning-surface.test.ts src/__tests__/planning-turn.test.ts`
- [ ] `pnpm run check:all`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, before dependent slices
- Revert command: `git revert 85997241779376687e6d9daf1627126e0cb91563`
- Post-revert steps: Revert dependent slices first
- Data migration? No

</details>