### PR TITLE
[Planning review parity](4) Activate typed submit in planner

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -12,6 +12,7 @@
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
 import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, PlanningConfirmationMode, PlanningPresetOption, ReviewGateQueryResponse, RuntimeStatus, StartReadyFreshBaseScope, StartReadyRequest, StartReadyResult, TerminalOutputEvent, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
+import { resolvePlanningSubmitAction } from '@invoker/contracts/planning-surface';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus, WorkerActionSummary, WorkerLogEntry, WorkerStatusEntry } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
 import { reportUiNavigation } from './lib/report-ui-navigation.js';
@@ -3069,10 +3070,12 @@ export function App() {
       return;
     }
 
-    if (/^submit(\s+to\s+invoker)?[.!?]*$/i.test(input)) {
-      if (activePlanningSession.draftPlanAvailable || activePlanningSession.status === 'draft_ready') {
-        await handlePlanningSubmitDraft();
-      }
+    const planningSubmitAction = resolvePlanningSubmitAction(
+      input,
+      activePlanningSession.draftPlanAvailable || activePlanningSession.status === 'draft_ready',
+    );
+    if (planningSubmitAction === 'submit_ready') {
+      await handlePlanningSubmitDraft();
       return;
     }
 
@@ -3140,9 +3143,6 @@ export function App() {
         if (result.draftPlanAvailable) {
           setReviewDraftSessionId(result.sessionId);
           setPlanningContextCollapsed(false);
-          if ((result.confirmationMode ?? 'require') === 'auto_submit') {
-            void handlePlanningSubmitDraft(result.sessionId);
-          }
         }
       } else {
         updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: false }));

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1581,7 +1581,7 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
-  it('does not submit or send typed submit before a draft is ready', async () => {
+  it('sends typed submit as a draft request before a draft is ready', async () => {
     mock.api.planningChatList = vi.fn(async () => ({
       ok: true,
       sessions: [
@@ -1619,9 +1619,24 @@ describe('Invoker terminal (component)', () => {
 
     submitPlanningText('submit');
 
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        sessionId: 'session-1',
+        message: 'submit',
+        presetKey: 'codex',
+        confirmationMode: 'require',
+      });
+    });
     expect(mock.api.planningChatSubmit).not.toHaveBeenCalled();
-    expect(mock.api.planningChatSend).not.toHaveBeenCalled();
     expect(mock.api.startReady).not.toHaveBeenCalled();
+  });
+
+  it('does not offer auto-submit in conversational planning', async () => {
+    render(<App />);
+    await openPlanningTerminal();
+
+    expect(screen.queryByRole('option', { name: 'Auto-submit' })).not.toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Ask first' })).toBeInTheDocument();
   });
 
   it('shows the bound repo and short commit sha in the planning context sidebar', async () => {

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -1036,7 +1036,6 @@ export function InvokerTerminal({
                           className="ml-2 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none hover:border-border-strong focus:border-ring"
                         >
                           <option value="require">Ask first</option>
-                          <option value="auto_submit">Auto-submit</option>
                         </select>
                       </label>
                     </div>


### PR DESCRIPTION
## Summary

Activates the shared approval action in the in-app composer while keeping conversational review explicitly user-controlled.

Before readiness, the same phrase remains an ordinary planning message. After readiness, it advances the staged draft.

## Review Claim

Approve the in-app activation surface for exact typed approval while keeping review explicitly user-controlled.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Typing `submit` before a draft is ready only sends a planning message. A ready draft is submitted only by the bound in-app requester; draft creation never auto-submits.

## Slice Rationale

This final activation-surface slice changes one user interaction after its lower-level prerequisites are already reviewable.

## Non-goals

- No Slack interaction changes.
- No new planning lifecycle states.
- No automatic approval option.
- The `dag-surface-background-click-noop` guarded behavior remains unchanged.

## Architecture

### Before

```mermaid
graph TD
    A["Composer text"] --> B["Local regular-expression branch"]
    C["Draft response"] --> D["Optional automatic execution"]
```

### After

```mermaid
graph TD
    A["Composer text plus readiness"] --> B["Shared approval action resolver"]
    B --> C["In-app approval handler"]
    D["Draft response"] --> E["Review remains user-controlled"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx`
- [ ] `pnpm run check:all`
- [ ] `CAPTURE_MODE=after CAPTURE_VIDEO=1 INVOKER_PLAYWRIGHT_WORKERS=1 pnpm --filter @invoker/app test:e2e -- --grep "planning review incident ad665bff"`

</details>

## Visual Proof

[Animated walkthrough: exact typed approval advances the recovered draft](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260811-25fe05/87ea272b480b9dac22f925d200f7be47.webm)

Manually inspected: I opened frames from this recording and saw the ready three-workflow review panel, `submit` typed into the composer, then the `Submitted` state with the system confirmation and `Started 1 task` toast.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 6138eede821503cfb290c65fbb39478415fcb1e3`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #8509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Typing “submit” before a draft exists now starts a normal planning conversation instead of triggering draft submission.
  - Planning actions no longer begin work automatically without an available draft.

- **Updates**
  - Planning conversations now offer only “Ask first” confirmation; the “Auto-submit” option has been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->