### PR TITLE
[Invoker-Ops Skill Test](1) Fix stale ./run.sh wording assertion

### DIFF
--- a/scripts/test-invoker-ops-skill.sh
+++ b/scripts/test-invoker-ops-skill.sh
@@ -26,8 +26,8 @@ must_contain() {
 [[ -x "$RETRY_SCRIPT" ]] || fail "expected executable $RETRY_SCRIPT"
 
 must_contain "$SKILL_MD" "Do not query or mutate the SQLite database directly" "skill must forbid normal direct DB operations"
-must_contain "$SKILL_MD" "./run.sh --headless retry-tasks --status failed --parallel 8" "skill must document failed retry command"
-must_contain "$SKILL_MD" "./run.sh --headless retry-tasks --status pending --parallel 8" "skill must document pending retry command"
+must_contain "$SKILL_MD" "invoker-ui --headless retry-tasks --status failed --parallel 8" "skill must document failed retry command"
+must_contain "$SKILL_MD" "invoker-ui --headless retry-tasks --status pending --parallel 8" "skill must document pending retry command"
 must_contain "$SKILL_MD" "Bulk retry commands must use \`--no-track\`" "skill must document acknowledgement boundary"
 must_contain "$SKILL_MD" "Do not invent SQL as the fallback" "skill must reject SQL fallback"
 


### PR DESCRIPTION
## Summary

`scripts/test-invoker-ops-skill.sh` looked for one wording of a task-recovery instruction inside `skills/invoker-ops/SKILL.md`.

An earlier docs pass in v0.0.11 (#8275, #8276, #8280) changed that instruction's wording, so this has failed on plain `origin/master` ever since.

That failure silently blocked a required quality job for every PR going through the admin-bypass merge queue.

## Review Claim

Approve updating the two mismatched assertions in `scripts/test-invoker-ops-skill.sh` so they match the instruction text the skill doc actually contains today, not a retired one.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Pure test-expectation fix. The two changed lines only change what string this file looks for inside `SKILL.md`; nothing about the skill doc, the underlying recovery helper, or `run.sh` changes. Confirmed the doc already contains the wording this PR now looks for, unchanged by this PR.

## Slice Rationale

A standalone one-line-class fix found while landing an unrelated PR through the merge queue -- it was failing there too, for everyone, not just that other PR. Landing it on its own keeps that PR's diff scoped to its own claim.

## Non-goals

Does not touch `skills/invoker-ops/SKILL.md` itself, the underlying recovery helper script, or `run.sh`. Does not address any other wording drift that might exist elsewhere in the docs/skills surface -- this fixes the one broken assertion found while landing other work today.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-invoker-ops-skill.sh` -- fails on unpatched master with `FAIL: skill must document failed retry command`, passes after this change (`OK: invoker-ops skill contract checks passed`).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>
