### PR TITLE
[Release v0.0.12](1) Roll Unreleased into 0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Invoker will be documented in this file.
 
 ## Unreleased
 
+## 0.0.12
+
+- Fix an owner-startup incident: the scheduler reloaded every active workflow's tasks from the database once per ready task on every scheduling pass instead of once per pass, so a large ready-task backlog could make the owner process's boot effectively never finish (confirmed live: the same query firing thousands of times with zero deceleration). A cold boot against a real 900-task/300-workflow database dropped from 12.4s to well under a second. Covered by a repro test and a real cold-boot-against-a-large-persisted-DB test (#8502, #8504, INV-279).
+- Add `Orchestrator.attachWorkflow`, the dynamic mirror of `detachWorkflow`, plus its headless CLI surface, so a workflow left with a lasting Detached badge after a recreate can be relinked without a full workflow recreate (#8494-8496).
+
 ## 0.0.11
 
 - Add scratch execution mode: a `scratch: true` plan runs its tasks in a plain temp directory with no git repo involved at all, for benchmark/direct-output plans that never touch a real checkout (#8243-8249, #8256, #8257).


### PR DESCRIPTION
## Summary

This is the changelog half of the v0.0.12 release cut.

It renames `## Unreleased` to `## 0.0.12` in `CHANGELOG.md` and adds a fresh empty `## Unreleased` above it.

The new `## 0.0.12` section summarizes what merged since v0.0.11: the scheduler startup fix and the attach-workflow feature.

## Review Claim

Approve the CHANGELOG heading rename and the two new bullet points summarizing what's landing in this release.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Only `CHANGELOG.md` changes. No product code, no version strings -- those are the paired PR (#8516).

## Slice Rationale

Split from the version-string bump so each PR fits one review lane: this one is pure prose (docs), the paired PR is pure mechanical version strings (no lane accepts both docs and product-file changes in one PR under this repo's review-scope rules).

## Non-goals

Does not bump any version string. Does not touch anything outside `CHANGELOG.md`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Visual diff review -- two new lines added under a renamed heading, nothing else changed.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>
