### PR TITLE
[Release v0.0.12](2) Bump release version strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Invoker will be documented in this file.
 
 ## Unreleased
 
+## 0.0.12
+
+- Fix an owner-startup incident: the scheduler reloaded every active workflow's tasks from the database once per ready task on every scheduling pass instead of once per pass, so a large ready-task backlog could make the owner process's boot effectively never finish (confirmed live: the same query firing thousands of times with zero deceleration). A cold boot against a real 900-task/300-workflow database dropped from 12.4s to well under a second. Covered by a repro test and a real cold-boot-against-a-large-persisted-DB test (#8502, #8504, INV-279).
+- Add `Orchestrator.attachWorkflow`, the dynamic mirror of `detachWorkflow`, plus its headless CLI surface, so a workflow left with a lasting Detached badge after a recreate can be relinked without a full workflow recreate (#8494-8496).
+
 ## 0.0.11
 
 - Add scratch execution mode: a `scratch: true` plan runs its tasks in a plain temp directory with no git repo involved at all, for benchmark/direct-output plans that never touch a real checkout (#8243-8249, #8256, #8257).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "invoker",
   "private": true,
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -2,7 +2,7 @@
   "name": "@invoker/app",
   "productName": "Invoker",
   "desktopName": "invoker.desktop",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Invoker desktop app",
   "homepage": "https://github.com/Neko-Catpital-Labs/Invoker",
   "author": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/cli",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Standalone Invoker command-line runner",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -58,7 +58,7 @@ import {
   readWorkerToggleValue,
 } from './worker-toggles.js';
 
-const VERSION = '0.0.11';
+const VERSION = '0.0.12';
 
 type CliOptions = {
   dbDir?: string;

--- a/packages/npm-cli/package.json
+++ b/packages/npm-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-cli",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Invoker standalone CLI installer",
   "type": "module",
   "repository": {

--- a/packages/npm-slack/package.json
+++ b/packages/npm-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-slack",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Invoker standalone Slack manager installer",
   "type": "module",
   "repository": {

--- a/packages/npm-ui/package.json
+++ b/packages/npm-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-ui",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Invoker desktop UI launcher",
   "type": "module",
   "repository": {

--- a/packages/slack-manager/package.json
+++ b/packages/slack-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/slack-manager",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -28,7 +28,7 @@ import { createWatchdog } from './watchdog.js';
 import { errMessage } from './util.js';
 import { acquireSlackConsumerLock } from './slack-consumer-lock.js';
 import { loadSlackOwnerEnv, runComplaintScoutDraftCommand } from './complaint-scout-bridge.js';
-const VERSION = '0.0.11';
+const VERSION = '0.0.12';
 let runDaemon = true;
 
 if (process.argv.includes('--version') || process.argv.includes('-V')) {


### PR DESCRIPTION
## Summary

This is the version-bump half of the v0.0.12 release cut.

It updates the release version field in the root and every publishable `package.json` (app, cli, slack-manager, npm-cli, npm-ui, npm-slack), plus the two hardcoded `VERSION` constants in the CLI and Slack manager sources, from `0.0.11` to `0.0.12`.

Produced mechanically by `node scripts/bump-version.mjs 0.0.12`.

## Review Claim

Approve the literal `0.0.11` -> `0.0.12` string change across the nine listed files, with no other edits.

## Review Lane

refactor

## Review Unit

activation-surface

## Safety Invariant

Every changed line is a version string literal. No logic, no control flow, no new dependencies. `node scripts/check-version-sync.mjs` confirms all nine sources agree after this change.

## Slice Rationale

A separate PR from the CHANGELOG update (#8515) so each PR fits one review lane -- this one is pure mechanical file changes, the paired PR is pure prose.

## Non-goals

Does not change `CHANGELOG.md`. Behavior unchanged: every touched line is a literal version string, reachable at runtime only through a `--version` report or similar.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/check-version-sync.mjs` -- `ok all release versions are 0.0.12`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>
