### PR TITLE
[Planning review parity](5) Scroll long review drafts

### DIFF
--- a/packages/app/e2e/planning-review-scroll.spec.ts
+++ b/packages/app/e2e/planning-review-scroll.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect, captureScreenshot } from './fixtures/electron-app.js';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+test('a long Review draft panel scrolls with the mouse wheel', async ({ page }) => {
+  const planYaml = await fs.readFile(
+    path.resolve(__dirname, '..', 'src', '__tests__', 'fixtures', 'planning-review-ad665bff.yaml'),
+    'utf8',
+  );
+  await page.evaluate(async ({ yaml }) => {
+    await window.invoker.setTestPlanningChatResponse({
+      planYaml: yaml,
+      planName: 'Reaper workers for finished e2e and admin-bypass tasks',
+      reply: 'I wrote the 3-slice plan to the draft file.',
+    });
+  }, { yaml: planYaml });
+
+  await page.getByTestId('sidebar-home').click();
+  await page.getByRole('button', { name: 'Options' }).click();
+  await page.getByTestId('invoker-terminal-input').fill('github.com/Neko-Catpital-Labs/Invoker/');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByRole('heading', { name: 'Review draft' })).toBeVisible();
+
+  const reviewBody = page.getByTestId('planning-context-panel').locator(':scope > div').nth(1);
+  await expect(reviewBody).toBeVisible();
+  const before = await reviewBody.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+    scrollTop: element.scrollTop,
+    overflowY: window.getComputedStyle(element).overflowY,
+  }));
+  console.log(`[planning-review-scroll] before=${JSON.stringify(before)}`);
+  await captureScreenshot(page, 'planning-review-scroll-before');
+  if (process.env.CAPTURE_VIDEO) await page.waitForTimeout(800);
+
+  await reviewBody.hover();
+  await page.mouse.wheel(0, 700);
+  await page.waitForTimeout(process.env.CAPTURE_VIDEO ? 800 : 100);
+
+  const after = await reviewBody.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+    scrollTop: element.scrollTop,
+    overflowY: window.getComputedStyle(element).overflowY,
+  }));
+  console.log(`[planning-review-scroll] after=${JSON.stringify(after)}`);
+  expect(after.scrollTop).toBeGreaterThan(before.scrollTop);
+  await captureScreenshot(page, 'planning-review-scroll-after');
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4604,9 +4604,9 @@ export function App() {
     return (
       <aside
         data-testid="planning-context-panel"
-        className={`${planningContextCollapsed ? 'w-16' : 'w-72'} shrink-0 border-l border-border bg-card/60 transition-all duration-150`}
+        className={`${planningContextCollapsed ? 'w-16' : 'w-72'} flex h-full min-h-0 shrink-0 flex-col border-l border-border bg-card/60 transition-all duration-150`}
       >
-        <div className="flex items-center justify-between gap-2 border-b border-border px-3 py-2.5">
+        <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border px-3 py-2.5">
           {!planningContextCollapsed && (
             <h2 className="text-sm font-semibold text-foreground">{reviewingDraft ? 'Review draft' : 'Current plan'}</h2>
           )}
@@ -4622,7 +4622,7 @@ export function App() {
         </div>
         {!planningContextCollapsed && (
           reviewingDraft ? (
-            <div className="space-y-4 p-4 text-sm">
+            <div className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain p-4 text-sm">
               <p data-testid="planning-draft-locked-note" className="text-xs text-muted-foreground">
                 This draft is locked — critique in chat, or ask Invoker to re-draft, to change it.
               </p>
@@ -4683,7 +4683,7 @@ export function App() {
               </button>
             </div>
           ) : (
-            <div className="space-y-4 p-4 text-sm">
+            <div className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain p-4 text-sm">
               <div>
                 <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Goal</div>
                 <p className="mt-1 text-foreground">


### PR DESCRIPTION
## Summary

Long Review draft panels now keep their header fixed while the draft body owns vertical scrolling.

Mouse-wheel input can reach the workflow controls beneath large task summaries and YAML.

## Review Claim

Approve the bounded, scrollable in-app review surface for long planning drafts.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This changes layout ownership only. Draft contents, approval behavior, and the `dag-surface-background-click-noop` guarded behavior remain unchanged.

## Slice Rationale

Scrolling is one user-visible interaction and is isolated from the earlier typed-approval change.

## Non-goals

- No planning lifecycle changes.
- No Slack changes.
- No draft-content or approval-policy changes.
- The `dag-surface-background-click-noop` guarded behavior remains unchanged.

## Architecture

### Before

```mermaid
graph TD
    A["Review draft body grows with content"] --> B["Outer planning row clips overflow"]
    B --> C["Lower controls remain unreachable"]
```

### After

```mermaid
graph TD
    A["Bounded review panel"] --> B["Fixed header"]
    A --> C["Vertically scrollable draft body"]
    C --> D["Workflow controls remain reachable"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`
- [ ] `CAPTURE_MODE=after CAPTURE_VIDEO=1 INVOKER_PLAYWRIGHT_WORKERS=1 pnpm --filter @invoker/app test:e2e -- e2e/planning-review-scroll.spec.ts`
- [ ] `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx`
- [ ] `pnpm run check:all`

</details>

## Visual Proof

[Animated walkthrough: wheel-scroll reveals the workflow controls beneath the long draft](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260811-7a20f5/900e09de5e53ddf45a1c4883e92d41f8.webm)

Manually inspected: I opened this exact post-rebase recording and saw the panel start at Step 1, scroll through Steps 2 and 3, then reveal Create workflow, Cancel, and Open graph while the Review draft header stayed fixed.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 439225d4302429382e67adcc540b6a239faca523`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #8510
