### PR TITLE
[Reduce planning-chat terminal startup latency](1) Reuse lockfile-keyed dependencies

### DIFF
--- a/packages/app/src/__tests__/planning-chat-dependency-cache.test.ts
+++ b/packages/app/src/__tests__/planning-chat-dependency-cache.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const childProcessMocks = vi.hoisted(() => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    execFile: childProcessMocks.execFile,
+  };
+});
+
+import { preparePlanningWorktreeDependencies } from '../planning-chat-dependency-cache.js';
+
+function createWorktree(root: string, name: string, options: { lockfile?: string; packageManager?: string } = {}): string {
+  const path = join(root, name);
+  mkdirSync(path, { recursive: true });
+  writeFileSync(join(path, 'pnpm-lock.yaml'), options.lockfile ?? 'lockfileVersion: 9.0\n', 'utf8');
+  writeFileSync(join(path, 'package.json'), JSON.stringify({
+    name,
+    packageManager: options.packageManager ?? 'pnpm@10.31.0',
+  }), 'utf8');
+  return path;
+}
+
+function installCalls(): unknown[][] {
+  return childProcessMocks.execFile.mock.calls.filter((call) => {
+    const args = call[1] as string[] | undefined;
+    return args?.[0] === 'install';
+  });
+}
+
+function mockSuccessfulPnpmInstall(delayMs = 0): void {
+  childProcessMocks.execFile.mockImplementation((_file, args, options, callback) => {
+    if (args[0] === '--version') {
+      callback?.(null, '10.31.0\n', '');
+      return {} as never;
+    }
+    setTimeout(() => {
+      const cwd = options.cwd as string;
+      mkdirSync(join(cwd, 'node_modules', '.pnpm'), { recursive: true });
+      writeFileSync(join(cwd, 'node_modules', '.modules.yaml'), 'layoutVersion: 5\n', 'utf8');
+      writeFileSync(join(cwd, 'node_modules', 'installed-from.txt'), cwd, 'utf8');
+      callback?.(null, '', '');
+    }, delayMs);
+    return {} as never;
+  });
+}
+
+describe('planning-chat dependency cache', () => {
+  let root: string;
+  let cacheRoot: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'planning-deps-cache-test-'));
+    cacheRoot = join(root, 'cache');
+    childProcessMocks.execFile.mockReset();
+    mockSuccessfulPnpmInstall();
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('installs on a cold miss, then restores an identical lockfile without sharing a writable node_modules tree', async () => {
+    const first = createWorktree(root, 'first');
+    const cold = await preparePlanningWorktreeDependencies(first, { cacheRoot });
+
+    expect(cold.status).toBe('miss-installed');
+    expect(installCalls()).toHaveLength(1);
+    expect(existsSync(join(first, 'node_modules', '.modules.yaml'))).toBe(true);
+
+    const second = createWorktree(root, 'second');
+    const warm = await preparePlanningWorktreeDependencies(second, { cacheRoot });
+
+    expect(warm.status).toBe('hit');
+    expect(warm.cacheKey).toBe(cold.cacheKey);
+    expect(installCalls()).toHaveLength(1);
+    expect(readFileSync(join(second, 'node_modules', '.modules.yaml'), 'utf8')).toContain('layoutVersion');
+    expect(lstatSync(join(second, 'node_modules')).isSymbolicLink()).toBe(false);
+
+    writeFileSync(join(second, 'node_modules', 'private.txt'), 'second-only', 'utf8');
+    expect(existsSync(join(first, 'node_modules', 'private.txt'))).toBe(false);
+  });
+
+  it('misses when compatibility inputs change', async () => {
+    await preparePlanningWorktreeDependencies(createWorktree(root, 'base'), { cacheRoot });
+
+    const changedLockfile = createWorktree(root, 'changed-lockfile', {
+      lockfile: 'lockfileVersion: 9.0\npackages:\n  left-pad@1.3.0: {}\n',
+    });
+    const changedPackageManager = createWorktree(root, 'changed-package-manager', {
+      packageManager: 'pnpm@10.32.0',
+    });
+
+    expect((await preparePlanningWorktreeDependencies(changedLockfile, { cacheRoot })).status).toBe('miss-installed');
+    expect((await preparePlanningWorktreeDependencies(changedPackageManager, { cacheRoot })).status).toBe('miss-installed');
+    expect(installCalls()).toHaveLength(3);
+  });
+
+  it('converges concurrent creators on one published snapshot', async () => {
+    mockSuccessfulPnpmInstall(20);
+    const first = createWorktree(root, 'concurrent-a');
+    const second = createWorktree(root, 'concurrent-b');
+
+    const [a, b] = await Promise.all([
+      preparePlanningWorktreeDependencies(first, { cacheRoot }),
+      preparePlanningWorktreeDependencies(second, { cacheRoot }),
+    ]);
+
+    expect([a.status, b.status].sort()).toEqual(['hit', 'miss-installed']);
+    expect(a.cacheKey).toBe(b.cacheKey);
+    expect(installCalls()).toHaveLength(1);
+    expect(existsSync(join(first, 'node_modules', '.modules.yaml'))).toBe(true);
+    expect(existsSync(join(second, 'node_modules', '.modules.yaml'))).toBe(true);
+  });
+
+  it('treats corrupt cache entries as misses and republishes them', async () => {
+    const first = createWorktree(root, 'corrupt-source');
+    const cold = await preparePlanningWorktreeDependencies(first, { cacheRoot });
+    expect(cold.cacheKey).toBeTruthy();
+
+    const entry = join(cacheRoot, 'entries', cold.cacheKey!);
+    writeFileSync(join(entry, 'manifest.json'), '{"schemaVersion":1,"key":"wrong"}\n', 'utf8');
+
+    const second = createWorktree(root, 'corrupt-consumer');
+    const result = await preparePlanningWorktreeDependencies(second, { cacheRoot });
+
+    expect(result.status).toBe('miss-installed');
+    expect(installCalls()).toHaveLength(2);
+    expect(readFileSync(join(entry, 'manifest.json'), 'utf8')).toContain(cold.cacheKey!);
+  });
+
+  it('leaves the cache incomplete and reports the existing soft-failure install path when install fails', async () => {
+    childProcessMocks.execFile.mockImplementation((_file, args, _options, callback) => {
+      if (args[0] === '--version') {
+        callback?.(null, '10.31.0\n', '');
+        return {} as never;
+      }
+      callback?.(new Error('install failed'), '', 'broken');
+      return {} as never;
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const worktree = createWorktree(root, 'failed-install');
+
+    const result = await preparePlanningWorktreeDependencies(worktree, { cacheRoot });
+
+    expect(result.status).toBe('miss-install-failed');
+    expect(installCalls()).toHaveLength(1);
+    expect(existsSync(join(cacheRoot, 'entries', result.cacheKey ?? '', 'manifest.json'))).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('pnpm install --frozen-lockfile --ignore-scripts failed'));
+    warn.mockRestore();
+  });
+});

--- a/packages/app/src/__tests__/planning-chat-worktree.test.ts
+++ b/packages/app/src/__tests__/planning-chat-worktree.test.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 const childProcessMocks = vi.hoisted(() => ({
-  execFile: vi.fn((_file, _args, _options, callback) => {
+  execFile: vi.fn((_file, args, options, callback) => {
+    if (args?.[0] === '--version') {
+      callback?.(null, '10.31.0\n', '');
+      return {} as never;
+    }
+    if (args?.[0] === 'install' && options?.cwd && existsSync(options.cwd)) {
+      mkdirSync(join(options.cwd, 'node_modules', '.pnpm'), { recursive: true });
+      writeFileSync(join(options.cwd, 'node_modules', '.modules.yaml'), 'layoutVersion: 5\n', 'utf8');
+    }
     callback?.(null, '', '');
     return {} as never;
   }),
@@ -49,6 +57,24 @@ function createFakePool(overrides: Partial<Record<keyof PlanningRepoPool, unknow
     } as unknown as PlanningRepoPool,
     spies: { ensureCloneThroughRepoQueue, resolveBaseCommit, acquireWorktree, externalWorktreePath, release, softRelease },
   };
+}
+
+function installCalls(): unknown[][] {
+  return childProcessMocks.execFile.mock.calls.filter((call) => {
+    const args = call[1] as string[] | undefined;
+    return args?.[0] === 'install';
+  });
+}
+
+function createDependencyWorktree(root: string, name: string): string {
+  const path = join(root, name);
+  mkdirSync(path, { recursive: true });
+  writeFileSync(join(path, 'pnpm-lock.yaml'), 'lockfileVersion: 9.0\n', 'utf8');
+  writeFileSync(join(path, 'package.json'), JSON.stringify({
+    name,
+    packageManager: 'pnpm@10.31.0',
+  }), 'utf8');
+  return path;
 }
 
 describe('resolvePlanningWorktreeBranch', () => {
@@ -112,6 +138,48 @@ describe('provisionPlanningWorktree', () => {
       expect.any(Function),
     );
     expect(spies.softRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses a validated dependency snapshot for a second planning worktree with the same lockfile inputs', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'planning-worktree-deps-'));
+    try {
+      const firstWorktree = createDependencyWorktree(tmpDir, 'first');
+      const secondWorktree = createDependencyWorktree(tmpDir, 'second');
+      const cacheRoot = join(tmpDir, 'dependency-cache');
+      const { pool, spies } = createFakePool();
+      spies.acquireWorktree
+        .mockResolvedValueOnce({
+          clonePath: '/clone/path',
+          worktreePath: firstWorktree,
+          branch: 'invoker/planning/session-1',
+          release: spies.release,
+          softRelease: spies.softRelease,
+        })
+        .mockResolvedValueOnce({
+          clonePath: '/clone/path',
+          worktreePath: secondWorktree,
+          branch: 'invoker/planning/session-2',
+          release: spies.release,
+          softRelease: spies.softRelease,
+        });
+
+      await provisionPlanningWorktree(pool, {
+        repoUrl: 'https://example.com/repo.git',
+        baseBranch: 'main',
+        sessionId: 'session-1',
+      }, { cacheRoot });
+      await provisionPlanningWorktree(pool, {
+        repoUrl: 'https://example.com/repo.git',
+        baseBranch: 'main',
+        sessionId: 'session-2',
+      }, { cacheRoot });
+
+      expect(installCalls()).toHaveLength(1);
+      expect(readFileSync(join(secondWorktree, 'node_modules', '.modules.yaml'), 'utf8')).toContain('layoutVersion');
+      expect(spies.softRelease).toHaveBeenCalledTimes(2);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/app/src/planning-chat-dependency-cache.ts
+++ b/packages/app/src/planning-chat-dependency-cache.ts
@@ -1,0 +1,363 @@
+import { execFile } from 'node:child_process';
+import {
+  constants as fsConstants,
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
+import { promisify } from 'node:util';
+import { resolveInvokerHomeRoot } from '@invoker/contracts';
+
+const execFileAsync = promisify(execFile);
+
+export const PLANNING_WORKTREE_INSTALL_ARGS = ['install', '--frozen-lockfile', '--ignore-scripts'] as const;
+export const PLANNING_WORKTREE_INSTALL_TIMEOUT_MS = 120_000;
+
+const CACHE_SCHEMA_VERSION = 1;
+const PNPM_VERSION_TIMEOUT_MS = 10_000;
+const LOCK_RETRY_MS = 25;
+const LOCK_TIMEOUT_MS = PLANNING_WORKTREE_INSTALL_TIMEOUT_MS + 30_000;
+const STALE_TMP_ENTRY_MS = 24 * 60 * 60 * 1000;
+const MAX_TMP_ENTRY_CLEANUPS = 20;
+
+interface PlanningDependencyCompatibilityKey {
+  schemaVersion: number;
+  lockfileSha256: string;
+  packageManager: string;
+  pnpmVersion: string;
+  nodeAbi: string;
+  nodeMajor: string;
+  platform: string;
+  arch: string;
+  installArgs: readonly string[];
+}
+
+interface PlanningDependencyManifest {
+  schemaVersion: number;
+  key: string;
+  compatibility: PlanningDependencyCompatibilityKey;
+  createdAt: string;
+}
+
+export interface PlanningDependencyPreparationOptions {
+  cacheRoot?: string;
+}
+
+export interface PlanningDependencyPreparationResult {
+  status: 'hit' | 'miss-installed' | 'miss-install-failed' | 'skipped';
+  cacheKey?: string;
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function cacheRootForPlanningDependencies(options?: PlanningDependencyPreparationOptions): string {
+  return options?.cacheRoot
+    ?? process.env.INVOKER_PLANNING_NODE_MODULES_CACHE_DIR
+    ?? join(resolveInvokerHomeRoot(), 'planning-node-modules-cache');
+}
+
+async function readPnpmVersion(): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('pnpm', ['--version'], {
+      timeout: PNPM_VERSION_TIMEOUT_MS,
+    });
+    return stdout.trim() || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function readPackageManager(worktreePath: string): string {
+  const packageJsonPath = join(worktreePath, 'package.json');
+  if (!existsSync(packageJsonPath)) return 'unknown';
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { packageManager?: unknown };
+    return typeof parsed.packageManager === 'string' && parsed.packageManager.trim()
+      ? parsed.packageManager.trim()
+      : 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+async function buildCompatibilityKey(worktreePath: string): Promise<PlanningDependencyCompatibilityKey | undefined> {
+  const lockfilePath = join(worktreePath, 'pnpm-lock.yaml');
+  if (!existsSync(lockfilePath)) return undefined;
+  const lockfile = readFileSync(lockfilePath);
+  const nodeMajor = process.versions.node.split('.')[0] ?? 'unknown';
+  return {
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    lockfileSha256: sha256(lockfile),
+    packageManager: readPackageManager(worktreePath),
+    pnpmVersion: await readPnpmVersion(),
+    nodeAbi: process.versions.modules ?? 'unknown',
+    nodeMajor,
+    platform: process.platform,
+    arch: process.arch,
+    installArgs: PLANNING_WORKTREE_INSTALL_ARGS,
+  };
+}
+
+function cacheKeyFor(compatibility: PlanningDependencyCompatibilityKey): string {
+  return sha256(stableJson(compatibility));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function entryPath(cacheRoot: string, key: string): string {
+  return join(cacheRoot, 'entries', key);
+}
+
+function lockPath(cacheRoot: string, key: string): string {
+  return join(cacheRoot, 'locks', `${key}.lock`);
+}
+
+function nodeModulesPath(path: string): string {
+  return join(path, 'node_modules');
+}
+
+function readManifest(path: string): PlanningDependencyManifest | undefined {
+  try {
+    return JSON.parse(readFileSync(join(path, 'manifest.json'), 'utf8')) as PlanningDependencyManifest;
+  } catch {
+    return undefined;
+  }
+}
+
+function manifestMatches(
+  manifest: PlanningDependencyManifest | undefined,
+  key: string,
+  compatibility: PlanningDependencyCompatibilityKey,
+): boolean {
+  const cached = manifest?.compatibility;
+  return !!manifest
+    && manifest.schemaVersion === CACHE_SCHEMA_VERSION
+    && manifest.key === key
+    && cached?.schemaVersion === compatibility.schemaVersion
+    && cached.lockfileSha256 === compatibility.lockfileSha256
+    && cached.packageManager === compatibility.packageManager
+    && cached.pnpmVersion === compatibility.pnpmVersion
+    && cached.nodeAbi === compatibility.nodeAbi
+    && cached.nodeMajor === compatibility.nodeMajor
+    && cached.platform === compatibility.platform
+    && cached.arch === compatibility.arch
+    && Array.isArray(cached.installArgs)
+    && cached.installArgs.length === compatibility.installArgs.length
+    && cached.installArgs.every((arg, index) => arg === compatibility.installArgs[index]);
+}
+
+function validEntry(path: string, key: string, compatibility: PlanningDependencyCompatibilityKey): boolean {
+  return existsSync(nodeModulesPath(path))
+    && manifestMatches(readManifest(path), key, compatibility);
+}
+
+async function acquireCacheLock(cacheRoot: string, key: string): Promise<() => void> {
+  const path = lockPath(cacheRoot, key);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const startedAt = Date.now();
+  while (true) {
+    try {
+      mkdirSync(path, { mode: 0o700 });
+      writeFileSync(join(path, 'owner.json'), JSON.stringify({
+        pid: process.pid,
+        acquiredAt: new Date().toISOString(),
+      }), 'utf8');
+      return () => {
+        rmSync(path, { recursive: true, force: true });
+      };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      if (Date.now() - startedAt > LOCK_TIMEOUT_MS) {
+        throw new Error(`Timed out waiting for planning dependency cache lock ${path}`);
+      }
+      await sleep(LOCK_RETRY_MS);
+    }
+  }
+}
+
+function copyTreeCloneFirst(source: string, target: string): void {
+  const stat = lstatSync(source);
+  if (stat.isSymbolicLink()) {
+    symlinkSync(readlinkSync(source), target);
+    return;
+  }
+  if (stat.isDirectory()) {
+    mkdirSync(target, { recursive: true, mode: stat.mode });
+    for (const entry of readdirSync(source)) {
+      copyTreeCloneFirst(join(source, entry), join(target, entry));
+    }
+    return;
+  }
+  copyFileSync(source, target, fsConstants.COPYFILE_FICLONE);
+}
+
+function materializeNodeModules(sourceNodeModules: string, targetWorktreePath: string): void {
+  const target = nodeModulesPath(targetWorktreePath);
+  const tmp = join(targetWorktreePath, `.node_modules.tmp-${process.pid}-${randomUUID()}`);
+  rmSync(tmp, { recursive: true, force: true });
+  rmSync(target, { recursive: true, force: true });
+  try {
+    copyTreeCloneFirst(sourceNodeModules, tmp);
+    if (!existsSync(tmp)) {
+      throw new Error(`Copied node_modules tree missing at ${tmp}`);
+    }
+    renameSync(tmp, target);
+    if (!existsSync(target)) {
+      throw new Error(`Materialized node_modules tree missing at ${target}`);
+    }
+  } catch (error) {
+    rmSync(tmp, { recursive: true, force: true });
+    rmSync(target, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function publishSnapshot(
+  worktreePath: string,
+  cacheRoot: string,
+  key: string,
+  compatibility: PlanningDependencyCompatibilityKey,
+): void {
+  const sourceNodeModules = nodeModulesPath(worktreePath);
+  if (!existsSync(sourceNodeModules)) return;
+
+  const entriesRoot = join(cacheRoot, 'entries');
+  mkdirSync(entriesRoot, { recursive: true, mode: 0o700 });
+  const finalPath = entryPath(cacheRoot, key);
+  if (validEntry(finalPath, key, compatibility)) return;
+  rmSync(finalPath, { recursive: true, force: true });
+
+  const tmpPath = join(entriesRoot, `${key}.tmp-${process.pid}-${randomUUID()}`);
+  rmSync(tmpPath, { recursive: true, force: true });
+  try {
+    mkdirSync(tmpPath, { recursive: true, mode: 0o700 });
+    copyTreeCloneFirst(sourceNodeModules, nodeModulesPath(tmpPath));
+    const manifest: PlanningDependencyManifest = {
+      schemaVersion: CACHE_SCHEMA_VERSION,
+      key,
+      compatibility,
+      createdAt: new Date().toISOString(),
+    };
+    writeFileSync(join(tmpPath, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+    renameSync(tmpPath, finalPath);
+  } catch (error) {
+    rmSync(tmpPath, { recursive: true, force: true });
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+  }
+}
+
+function cleanupStaleTemporaryEntries(cacheRoot: string): void {
+  const entriesRoot = join(cacheRoot, 'entries');
+  if (!existsSync(entriesRoot)) return;
+  let removed = 0;
+  const now = Date.now();
+  for (const name of readdirSync(entriesRoot)) {
+    if (removed >= MAX_TMP_ENTRY_CLEANUPS || !name.includes('.tmp-')) break;
+    const path = join(entriesRoot, name);
+    try {
+      const stat = lstatSync(path);
+      if (now - stat.mtimeMs < STALE_TMP_ENTRY_MS) continue;
+      rmSync(path, { recursive: true, force: true });
+      removed += 1;
+    } catch {
+      /* best-effort cache hygiene only */
+    }
+  }
+}
+
+async function runBestEffortInstall(worktreePath: string): Promise<boolean> {
+  try {
+    await execFileAsync('pnpm', [...PLANNING_WORKTREE_INSTALL_ARGS], {
+      cwd: worktreePath,
+      timeout: PLANNING_WORKTREE_INSTALL_TIMEOUT_MS,
+    });
+    return true;
+  } catch (error) {
+    console.warn(
+      `[planning-chat-worktree] pnpm install --frozen-lockfile --ignore-scripts failed in ${worktreePath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return false;
+  }
+}
+
+async function tryMaterializeHit(
+  worktreePath: string,
+  cacheRoot: string,
+  key: string,
+  compatibility: PlanningDependencyCompatibilityKey,
+): Promise<boolean> {
+  const path = entryPath(cacheRoot, key);
+  if (!validEntry(path, key, compatibility)) return false;
+  materializeNodeModules(nodeModulesPath(path), worktreePath);
+  return true;
+}
+
+export async function preparePlanningWorktreeDependencies(
+  worktreePath: string,
+  options?: PlanningDependencyPreparationOptions,
+): Promise<PlanningDependencyPreparationResult> {
+  const compatibility = await buildCompatibilityKey(worktreePath);
+  if (!compatibility) {
+    const installed = await runBestEffortInstall(worktreePath);
+    return { status: installed ? 'miss-installed' : 'miss-install-failed' };
+  }
+
+  const key = cacheKeyFor(compatibility);
+  const cacheRoot = cacheRootForPlanningDependencies(options);
+  try {
+    mkdirSync(cacheRoot, { recursive: true, mode: 0o700 });
+    cleanupStaleTemporaryEntries(cacheRoot);
+    if (await tryMaterializeHit(worktreePath, cacheRoot, key, compatibility)) {
+      return { status: 'hit', cacheKey: key };
+    }
+
+    const release = await acquireCacheLock(cacheRoot, key);
+    try {
+      if (await tryMaterializeHit(worktreePath, cacheRoot, key, compatibility)) {
+        return { status: 'hit', cacheKey: key };
+      }
+      const installed = await runBestEffortInstall(worktreePath);
+      if (!installed) return { status: 'miss-install-failed', cacheKey: key };
+      try {
+        publishSnapshot(worktreePath, cacheRoot, key, compatibility);
+      } catch (error) {
+        console.warn(
+          `[planning-chat-worktree] dependency cache publish failed in ${worktreePath}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+      return { status: 'miss-installed', cacheKey: key };
+    } finally {
+      release();
+    }
+  } catch (error) {
+    console.warn(
+      `[planning-chat-worktree] dependency cache failed in ${worktreePath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    const installed = await runBestEffortInstall(worktreePath);
+    return { status: installed ? 'miss-installed' : 'miss-install-failed', cacheKey: key };
+  }
+}

--- a/packages/app/src/planning-chat-worktree.ts
+++ b/packages/app/src/planning-chat-worktree.ts
@@ -1,12 +1,10 @@
 import { existsSync, writeFileSync } from 'node:fs';
-import { execFile } from 'node:child_process';
 import { join } from 'node:path';
-import { promisify } from 'node:util';
 import type { AcquiredWorktree, RepoPool } from '@invoker/execution-engine';
-
-const execFileAsync = promisify(execFile);
-
-const PLANNING_WORKTREE_INSTALL_TIMEOUT_MS = 120_000;
+import {
+  preparePlanningWorktreeDependencies,
+  type PlanningDependencyPreparationOptions,
+} from './planning-chat-dependency-cache.js';
 
 export type PlanningRepoPool = Pick<
   RepoPool,
@@ -34,21 +32,6 @@ export interface PlanningWorktreeState {
   baseCommit: string;
   sessionId: string;
   worktreePath?: string;
-}
-
-async function runBestEffortInstall(worktreePath: string): Promise<void> {
-  try {
-    await execFileAsync('pnpm', ['install', '--frozen-lockfile', '--ignore-scripts'], {
-      cwd: worktreePath,
-      timeout: PLANNING_WORKTREE_INSTALL_TIMEOUT_MS,
-    });
-  } catch (error) {
-    console.warn(
-      `[planning-chat-worktree] pnpm install --frozen-lockfile --ignore-scripts failed in ${worktreePath}: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-  }
 }
 
 export function planningMcpConfigPath(worktreePath: string): string {
@@ -82,9 +65,10 @@ async function acquireProvisionAndSoftRelease(
   branch: string,
   baseCommit: string,
   sessionId: string,
+  dependencyOptions?: PlanningDependencyPreparationOptions,
 ): Promise<AcquiredWorktree> {
   const acquired = await pool.acquireWorktree(repoUrl, branch, baseCommit, sessionId);
-  await runBestEffortInstall(acquired.worktreePath);
+  await preparePlanningWorktreeDependencies(acquired.worktreePath, dependencyOptions);
   writePlanningMcpConfig(acquired.worktreePath, sessionId);
   acquired.softRelease();
   return acquired;
@@ -93,18 +77,20 @@ async function acquireProvisionAndSoftRelease(
 export async function provisionPlanningWorktree(
   pool: PlanningRepoPool,
   binding: PlanningWorktreeBinding,
+  dependencyOptions?: PlanningDependencyPreparationOptions,
 ): Promise<ProvisionedPlanningWorktree> {
   const { repoUrl, baseBranch, sessionId } = binding;
   await pool.ensureCloneThroughRepoQueue(repoUrl);
   const baseCommit = await pool.resolveBaseCommit(repoUrl, baseBranch);
   const branch = resolvePlanningWorktreeBranch(sessionId);
-  const acquired = await acquireProvisionAndSoftRelease(pool, repoUrl, branch, baseCommit, sessionId);
+  const acquired = await acquireProvisionAndSoftRelease(pool, repoUrl, branch, baseCommit, sessionId, dependencyOptions);
   return { worktreePath: acquired.worktreePath, baseCommit, branch };
 }
 
 export async function ensurePlanningWorktreeReady(
   pool: PlanningRepoPool,
   state: PlanningWorktreeState,
+  dependencyOptions?: PlanningDependencyPreparationOptions,
 ): Promise<{ worktreePath: string; recreated: boolean }> {
   const branch = resolvePlanningWorktreeBranch(state.sessionId);
   const expectedPath = pool.externalWorktreePath(state.repoUrl, branch);
@@ -112,7 +98,7 @@ export async function ensurePlanningWorktreeReady(
     return { worktreePath: expectedPath, recreated: false };
   }
   await pool.ensureCloneThroughRepoQueue(state.repoUrl);
-  const acquired = await acquireProvisionAndSoftRelease(pool, state.repoUrl, branch, state.baseCommit, state.sessionId);
+  const acquired = await acquireProvisionAndSoftRelease(pool, state.repoUrl, branch, state.baseCommit, state.sessionId, dependencyOptions);
   return { worktreePath: acquired.worktreePath, recreated: true };
 }
 


### PR DESCRIPTION
## Summary

Planning-chat worktrees now restore dependencies from an immutable cache when their lockfile, package manager, Node ABI, platform, architecture, and install mode match.

Each worktree receives a private `node_modules` copy. Missing, incompatible, corrupt, or failed cache entries fall back to the existing frozen install.

## Review Claim

Planning-chat worktrees safely reuse lockfile-keyed dependency snapshots without sharing a mutable `node_modules` directory or weakening install failure handling.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A cache hit never shares a mutable `node_modules` directory between live worktrees, never bypasses exact-key validation, and any miss, corruption, incompatibility, or materialization failure safely falls back to the existing pnpm install behavior.

## Slice Rationale

Dependency reuse has distinct local artifact and concurrency risks, so this slice excludes fetch scoping and startup proof work.

## Non-goals

- Do not change dependency versions or `pnpm-lock.yaml`.
- Do not change lifecycle-script policy or the global pnpm store.
- Do not affect non-planning worktrees.
- Do not share writable `node_modules` directories across sessions.

## Architecture

### Before

```mermaid
graph TD
    A["Planning worktree acquired"] --> B["Run frozen pnpm install"]
    B --> C["Write planning MCP config"]
```

### After

```mermaid
graph TD
    A["Planning worktree acquired"] --> B["Derive compatibility cache key"]
    B --> C{"Valid immutable snapshot exists?"}
    C -->|"Yes"| D["Privately materialize node_modules"]
    C -->|"No"| E["Run frozen pnpm install"]
    E --> F["Atomically publish validated snapshot"]
    D --> G["Write planning MCP config"]
    F --> G
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/planning-chat-dependency-cache.test.ts src/__tests__/planning-chat-worktree.test.ts` — `Test Files  2 passed (2)`; `Tests  11 passed (11)`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/reduce-planning-chat-terminal-startup-latency-1.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e3696f837`
- Post-revert steps: None; existing cache entries become unused local files.
- Data migration? No

</details>
