### PR TITLE
[Owner-first standalone mutations](2) Guard Electron fallback behind owner discovery

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -254,6 +254,120 @@ describe('headless-client', () => {
     expect(runElectronHeadless).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      label: 'delete',
+      argv: ['delete', 'wf-1', '--no-track'],
+      channel: 'headless.exec',
+      expectedPayload: { args: ['delete', 'wf-1'], noTrack: true, waitForApproval: false },
+    },
+    {
+      label: 'run',
+      argv: ['run', '/tmp/plan.yaml', '--no-track'],
+      channel: 'headless.run',
+      expectedPayload: { planPath: expect.stringContaining('plan.yaml') },
+    },
+    {
+      label: 'resume',
+      argv: ['resume', 'wf-42', '--no-track'],
+      channel: 'headless.resume',
+      expectedPayload: { workflowId: 'wf-42' },
+    },
+    {
+      label: 'generic mutation',
+      argv: ['recreate', 'wf-1', '--no-track'],
+      channel: 'headless.exec',
+      expectedPayload: { args: ['recreate', 'wf-1'], noTrack: true, waitForApproval: false },
+    },
+  ])('delegates standalone-enabled $label to a compatible owner before local Electron fallback', async ({ argv, channel, expectedPayload }) => {
+    process.env.INVOKER_HEADLESS_STANDALONE = '1';
+    const bus = new LocalBus();
+    const ownerHandler = vi.fn(async () => ({ ok: true }));
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-standalone-first', mode: 'gui' }));
+    bus.onRequest(channel, ownerHandler);
+
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const runElectronHeadless = vi.fn(async () => 23);
+
+    const exitCode = await runHeadlessClientCommand(argv, {
+      messageBus: bus,
+      ensureStandaloneOwner,
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(ownerHandler).toHaveBeenCalledTimes(1);
+    expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining(expectedPayload));
+    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    expect(runElectronHeadless).not.toHaveBeenCalled();
+  });
+
+  it('preserves direct standalone mutation execution when no owner and no live marker exist', async () => {
+    process.env.INVOKER_HEADLESS_STANDALONE = '1';
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const runElectronHeadless = vi.fn(async () => 23);
+    const argv = ['delete', 'wf-1'];
+
+    const exitCode = await runHeadlessClientCommand(argv, {
+      messageBus: new LocalBus(),
+      ensureStandaloneOwner,
+      refreshMessageBus: vi.fn(async () => new LocalBus()),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(23);
+    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    expect(runElectronHeadless).toHaveBeenCalledWith(argv);
+  });
+
+  it('refuses standalone writable fallback when a live owner marker exists but IPC is unavailable', async () => {
+    process.env.INVOKER_HEADLESS_STANDALONE = '1';
+    const dbPath = join(dbDir, 'invoker.db');
+    writeFileSync(dbPath, '');
+    writeFileSync(`${dbPath}-wal`, '');
+    writeFileSync(`${dbPath}.owner`, String(process.pid), 'utf-8');
+
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const runElectronHeadless = vi.fn(async () => 23);
+    try {
+      const exitCode = await runHeadlessClientCommand(['delete', 'wf-1'], {
+        messageBus: new LocalBus(),
+        ensureStandaloneOwner,
+        refreshMessageBus: vi.fn(async () => new LocalBus()),
+        runElectronHeadless,
+      });
+
+      const output = stderr.mock.calls.map(([chunk]) => String(chunk)).join('');
+      expect(exitCode).toBe(1);
+      expect(output).toContain('live writable owner marker');
+      expect(output).toContain('could not reach a compatible owner');
+      expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+      expect(runElectronHeadless).not.toHaveBeenCalled();
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
+  it('keeps owner-serve local even when standalone delegation is enabled', async () => {
+    process.env.INVOKER_HEADLESS_STANDALONE = '1';
+    const bus = new LocalBus();
+    const ownerHandler = vi.fn(async () => ({ ok: true }));
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-self', mode: 'gui' }));
+    bus.onRequest('headless.exec', ownerHandler);
+    const runElectronHeadless = vi.fn(async () => 23);
+
+    const exitCode = await runHeadlessClientCommand(['owner-serve'], {
+      messageBus: bus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(23);
+    expect(ownerHandler).not.toHaveBeenCalled();
+    expect(runElectronHeadless).toHaveBeenCalledWith(['owner-serve']);
+  });
+
   it('delegates mutating commands to a standalone-capable owner endpoint', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -6,6 +6,7 @@ import {
   tryDelegateRun,
   tryDelegateResume,
 } from '../headless.js';
+import { runHeadlessClientCommand } from '../headless-client.js';
 import { LocalBus } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
 import type { HeadlessTargetLookup } from '../headless-command-classification.js';
@@ -116,6 +117,58 @@ describe('headless→owner delegation', () => {
   });
 
   describe('successful delegation when owner is present', () => {
+    it.each([
+      {
+        label: 'delete',
+        argv: ['delete', 'wf-1', '--no-track'],
+        channel: 'headless.exec',
+        expectedPayload: { args: ['delete', 'wf-1'], noTrack: true, waitForApproval: false },
+      },
+      {
+        label: 'run',
+        argv: ['run', '/path/to/plan.yaml', '--no-track'],
+        channel: 'headless.run',
+        expectedPayload: { planPath: expect.stringContaining('plan.yaml') },
+      },
+      {
+        label: 'resume',
+        argv: ['resume', 'wf-1', '--no-track'],
+        channel: 'headless.resume',
+        expectedPayload: { workflowId: 'wf-1' },
+      },
+      {
+        label: 'generic mutation',
+        argv: ['approve', 'wf-1/task-1', '--no-track'],
+        channel: 'headless.exec',
+        expectedPayload: { args: ['approve', 'wf-1/task-1'], noTrack: true, waitForApproval: false },
+      },
+    ])('routes standalone-enabled $label to a compatible owner before local fallback', async ({ argv, channel, expectedPayload }) => {
+      const savedStandalone = process.env.INVOKER_HEADLESS_STANDALONE;
+      process.env.INVOKER_HEADLESS_STANDALONE = '1';
+      try {
+        const ownerHandler = vi.fn(async () => ({ ok: true }));
+        messageBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-standalone-route', mode: 'standalone' }));
+        messageBus.onRequest(channel, ownerHandler);
+        const ensureStandaloneOwner = vi.fn(async () => {});
+        const runElectronHeadless = vi.fn(async () => 23);
+
+        const exitCode = await runHeadlessClientCommand(argv, {
+          messageBus,
+          ensureStandaloneOwner,
+          runElectronHeadless,
+        });
+
+        expect(exitCode).toBe(0);
+        expect(ownerHandler).toHaveBeenCalledTimes(1);
+        expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining(expectedPayload));
+        expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+        expect(runElectronHeadless).not.toHaveBeenCalled();
+      } finally {
+        if (savedStandalone === undefined) delete process.env.INVOKER_HEADLESS_STANDALONE;
+        else process.env.INVOKER_HEADLESS_STANDALONE = savedStandalone;
+      }
+    });
+
     it('delegates mutation command to owner via RPC', async () => {
       // Simulate owner process registering a handler
       const ownerHandler = vi.fn(async (_req: { args: string[] }) => {

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -89,6 +89,8 @@ const READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS = 20_000;
 const OPTIONAL_READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS = 2_000;
 const READ_ONLY_QUERY_REQUEST_TIMEOUT_MS = 15_000;
 const GENERIC_READ_OWNER_PING_TIMEOUT_MS = 10_000;
+const EXISTING_MUTATION_OWNER_DISCOVERY_TIMEOUT_MS = 3_000;
+const EXISTING_MUTATION_OWNER_REFRESH_DISCOVERY_TIMEOUT_MS = 1_000;
 const POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS = 3;
 const DEFAULT_STANDALONE_OWNER_BOOTSTRAP_TIMEOUT_MS = 60_000;
 const REQUIRE_EXISTING_OWNER_ENV = 'INVOKER_HEADLESS_REQUIRE_EXISTING_OWNER';
@@ -592,6 +594,14 @@ function shouldUseSharedMutationOwner(args: string[], standaloneMode: boolean, i
   return isHeadlessMutatingCommand(args) && !standaloneMode && !internalOwnerServe;
 }
 
+function liveWritableOwnerDbPath(): string {
+  return resolve(resolveInvokerHomeRoot(), 'invoker.db');
+}
+
+function hasLiveWritableOwnerMarker(): boolean {
+  return hasLiveWritableOwner(liveWritableOwnerDbPath());
+}
+
 /**
  * Resolve a writable owner endpoint using the resolver, then delegate.
  *
@@ -691,6 +701,69 @@ async function resolveOwnerAndDelegate(
   return null; // Could not resolve
 }
 
+async function resolveExistingOwnerAndDelegate(
+  args: string[],
+  deps: HeadlessClientDeps,
+  waitForApproval?: boolean,
+  noTrack?: boolean,
+): Promise<number | null> {
+  delegationClientLog(`resolveExistingOwnerAndDelegate begin command=${args[0] ?? '<missing>'} noTrack=${noTrack ? 'true' : 'false'}`);
+  const resolver = createOwnerResolver(
+    {
+      messageBus: deps.messageBus,
+      refreshMessageBus: deps.refreshMessageBus,
+      ensureStandaloneOwner: async () => {},
+    },
+    {
+      discoveryTimeoutMs: EXISTING_MUTATION_OWNER_DISCOVERY_TIMEOUT_MS,
+      refreshDiscoveryTimeoutMs: EXISTING_MUTATION_OWNER_REFRESH_DISCOVERY_TIMEOUT_MS,
+      maxBootstrapAttempts: 0,
+    },
+  );
+
+  const discovered = await resolver.discover();
+  const resolved = discovered.resolved ? discovered : await resolver.refreshAndDiscover();
+  if (!resolved.resolved) {
+    delegationClientLog('resolveExistingOwnerAndDelegate no compatible existing owner');
+    return null;
+  }
+
+  let outcome: DelegationOutcome;
+  try {
+    outcome = await delegateMutation(
+      args,
+      resolved.bus,
+      waitForApproval,
+      noTrack,
+      noTrack ? POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS : DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
+    );
+  } catch (err) {
+    if (isAcceptedStaleOwnerNoTrackTaskMutationError(args, noTrack, err)) {
+      delegationClientLog(
+        `accepted stale-owner no-track task mutation command=${args[0]} workflow=${explicitTaskTargetWorkflowId(args)}`,
+      );
+      process.stdout.write('Delegated to owner\n');
+      process.stdout.write('--no-track enabled: delegated submission accepted; exiting without tracking.\n');
+      const exitCode = process.exitCode;
+      return typeof exitCode === 'number' ? exitCode : 0;
+    }
+    throw err;
+  }
+
+  if (outcome.kind === 'delegated') {
+    const exitCode = process.exitCode;
+    return typeof exitCode === 'number' ? exitCode : 0;
+  }
+
+  const detail = outcome.kind === 'protocol-error'
+    ? `: ${outcome.message}`
+    : ` (${outcome.kind})`;
+  process.stderr.write(
+    `${RED}Error:${RESET} Compatible owner "${resolved.owner.ownerId}" responded to discovery but did not accept mutation command "${args[0] ?? ''}"${detail}.\n`,
+  );
+  return 1;
+}
+
 export async function runHeadlessClientCommand(
   argv: string[],
   deps: HeadlessClientDeps,
@@ -749,6 +822,21 @@ export async function runHeadlessClientCommand(
       return 0;
     }
     return runLocalWorkersQuery(args, invokerConfig);
+  }
+
+  if (standaloneMode && isHeadlessMutatingCommand(args) && !internalOwnerServe) {
+    const delegatedToExistingOwner = await resolveExistingOwnerAndDelegate(args, deps, waitForApproval, noTrack);
+    if (delegatedToExistingOwner !== null) {
+      return delegatedToExistingOwner;
+    }
+    if (hasLiveWritableOwnerMarker()) {
+      process.stderr.write(
+        `${RED}Error:${RESET} Standalone mutation command "${args[0] ?? ''}" found a live writable owner marker but could not reach a compatible owner over IPC.\n` +
+        'Refusing writable standalone fallback while another owner may have the database open.\n',
+      );
+      return 1;
+    }
+    return deps.runElectronHeadless(argv);
   }
 
   if (!shouldUseSharedMutationOwner(args, standaloneMode, internalOwnerServe)) {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -73,7 +73,7 @@ import type {
   StartReadyRequest,
   StartReadyResult,
 } from '@invoker/contracts';
-import { ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
+import { ConversationRepository, SqliteTaskRepository, hasLiveWritableOwner } from '@invoker/data-store';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
 import {
@@ -915,6 +915,60 @@ const RESET = '\x1b[0m';
 const BOLD = '\x1b[1m';
 const RED = '\x1b[31m';
 const YELLOW = '\x1b[33m';
+const EXISTING_HEADLESS_MUTATION_OWNER_DISCOVERY_TIMEOUT_MS = 3_000;
+const EXISTING_HEADLESS_MUTATION_OWNER_REFRESH_TIMEOUT_MS = 1_000;
+
+function hasLiveWritableOwnerMarker(): boolean {
+  return hasLiveWritableOwner(path.join(resolveInvokerHomeRoot(), 'invoker.db'));
+}
+
+async function tryDelegateHeadlessMutationToBus(
+  args: string[],
+  bus: MessageBus,
+  command: string | undefined,
+): Promise<boolean> {
+  if (command === 'run') {
+    const planPath = args[1];
+    if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
+    return isDelegated(await tryDelegateRun(planPath, bus, waitForApproval, noTrack));
+  }
+  if (command === 'resume') {
+    const workflowId = args[1];
+    if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
+    return isDelegated(await tryDelegateResume(workflowId, bus, waitForApproval, noTrack));
+  }
+  const timeoutMs = noTrack ? undefined : await resolveDelegationTimeoutMs(args);
+  return isDelegated(await tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs));
+}
+
+async function tryDelegateHeadlessMutationToExistingOwner(
+  args: string[],
+  command: string | undefined,
+): Promise<'delegated' | 'no-compatible-owner' | 'failed'> {
+  let delegationBus = new IpcBus(undefined, { allowServe: false });
+  try {
+    await delegationBus.ready();
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const timeoutMs = attempt === 0
+        ? EXISTING_HEADLESS_MUTATION_OWNER_DISCOVERY_TIMEOUT_MS
+        : EXISTING_HEADLESS_MUTATION_OWNER_REFRESH_TIMEOUT_MS;
+      const owner = await discoverOwner(delegationBus, timeoutMs);
+      if (isStandaloneCapable(owner)) {
+        return await tryDelegateHeadlessMutationToBus(args, delegationBus, command)
+          ? 'delegated'
+          : 'failed';
+      }
+      if (attempt === 0) {
+        delegationBus.disconnect();
+        delegationBus = new IpcBus(undefined, { allowServe: false });
+        await delegationBus.ready();
+      }
+    }
+    return 'no-compatible-owner';
+  } finally {
+    delegationBus.disconnect();
+  }
+}
 
 function startHeadlessMode(): void {
   const runHeadlessMain = async (): Promise<void> => {
@@ -940,40 +994,54 @@ function startHeadlessMode(): void {
     }
 
     // Try delegation for mutating commands first (owner mode).
-    // In standalone mode we skip delegation and run locally.
-    if (mutatingMode && !standaloneMode) {
-      // Delegating headless commands must never become the IPC server.
-      // Otherwise a transient submitter can steal the transport socket away
-      // from the actual shared mutation owner.
-      const delegationBus = new IpcBus(undefined, { allowServe: false });
-      try {
-        await delegationBus.ready();
-
-        let delegated = false;
-        if (command === 'run') {
-          const planPath = cliArgs[1];
-          if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
-          delegated = isDelegated(await tryDelegateRun(planPath, delegationBus, waitForApproval, noTrack));
-        } else if (command === 'resume') {
-          const workflowId = cliArgs[1];
-          if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
-          delegated = isDelegated(await tryDelegateResume(workflowId, delegationBus, waitForApproval, noTrack));
-        } else {
-          const timeoutMs = noTrack ? undefined : await resolveDelegationTimeoutMs(cliArgs);
-          delegated = isDelegated(await tryDelegateExec(cliArgs, delegationBus, waitForApproval, noTrack, timeoutMs));
-        }
-
-        if (delegated) {
-          // Successfully delegated to owner
-          delegationBus.disconnect();
-          await flushStdoutAndStderr();
-          process.exit(process.exitCode ?? 0);
+    if (mutatingMode && command !== 'owner-serve') {
+      if (standaloneMode) {
+        try {
+          const delegationResult = await tryDelegateHeadlessMutationToExistingOwner(cliArgs, command);
+          if (delegationResult === 'delegated') {
+            await flushStdoutAndStderr();
+            process.exit(process.exitCode ?? 0);
+            return; // Guard: process.exit() may not halt in Electron async context
+          }
+          if (delegationResult === 'failed') {
+            process.stderr.write(
+              `${RED}Error:${RESET} Compatible owner responded to discovery but did not accept mutation command "${command ?? ''}".\n`,
+            );
+            process.exit(1);
+            return; // Guard: process.exit() may not halt in Electron async context
+          }
+          if (hasLiveWritableOwnerMarker()) {
+            process.stderr.write(
+              `${RED}Error:${RESET} Standalone mutation command "${command ?? ''}" found a live writable owner marker but could not reach a compatible owner over IPC.\n` +
+              'Refusing writable standalone fallback while another owner may have the database open.\n',
+            );
+            process.exit(1);
+            return; // Guard: process.exit() may not halt in Electron async context
+          }
+        } catch (err) {
+          process.stderr.write(`${RED}Delegation error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
+          process.exit(1);
           return; // Guard: process.exit() may not halt in Electron async context
         }
+      } else {
+        // Delegating headless commands must never become the IPC server.
+        // Otherwise a transient submitter can steal the transport socket away
+        // from the actual shared mutation owner.
+        const delegationBus = new IpcBus(undefined, { allowServe: false });
+        try {
+          await delegationBus.ready();
 
-        // Delegation failed: no owner handler available.
-        delegationBus.disconnect();
-        if (!standaloneMode) {
+          const delegated = await tryDelegateHeadlessMutationToBus(cliArgs, delegationBus, command);
+          if (delegated) {
+            // Successfully delegated to owner
+            delegationBus.disconnect();
+            await flushStdoutAndStderr();
+            process.exit(process.exitCode ?? 0);
+            return; // Guard: process.exit() may not halt in Electron async context
+          }
+
+          // Delegation failed: no owner handler available.
+          delegationBus.disconnect();
           process.stderr.write(
             `${RED}Error:${RESET} Mutation command "${command}" requires a running owner process.\n` +
             `\n${BOLD}Options:${RESET}\n` +
@@ -983,12 +1051,12 @@ function startHeadlessMode(): void {
           );
           process.exit(1);
           return; // Guard: process.exit() may not halt in Electron async context
+        } catch (err) {
+          process.stderr.write(`${RED}Delegation error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
+          delegationBus.disconnect();
+          process.exit(1);
+          return; // Guard: process.exit() may not halt in Electron async context
         }
-      } catch (err) {
-        process.stderr.write(`${RED}Delegation error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
-        delegationBus.disconnect();
-        process.exit(1);
-        return; // Guard: process.exit() may not halt in Electron async context
       }
     }
 


### PR DESCRIPTION
## Summary

The Electron mutation entry point now routes standalone-enabled writes to a compatible running owner before considering local execution.

Local writable fallback remains available only without a live writable-owner marker.

An unreachable live owner produces a clear non-zero error instead of a competing database open.

## Review Claim

The Electron mutation entry point routes standalone-enabled writes through existing-owner discovery before local fallback (`packages/app/src/main.ts:997`).

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A process may open the database only after no compatible owner responds and `hasLiveWritableOwnerMarker()` is false (`packages/app/src/main.ts:1013`).

## Slice Rationale

This slice mirrors the owner-first decision at the Electron process boundary without mixing it into the client activation surface.

## Non-goals

- No client entry-point changes.
- No owner protocol redesign or command-specific allowlist.
- No database restoration or user-data deletion.

## Architecture

### Before

```mermaid
graph TD
    A["Standalone-enabled Electron mutation"] --> B["Open writable database locally"]
```

### After

```mermaid
graph TD
    A["Standalone-enabled Electron mutation"] --> B{"Compatible owner responds?"}
    B -->|"Yes"| C["Delegate mutation"]
    B -->|"No"| D{"Live writable-owner marker?"}
    D -->|"Yes"| E["Exit non-zero"]
    D -->|"No"| F["Continue local writable startup"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test --run src/__tests__/headless-client.test.ts src/__tests__/owner-delegation.test.ts` — the runner printed `✓` for the owner-first mutation and fail-closed cases after this slice.
- [x] `pnpm --filter @invoker/app build` — `CJS ⚡️ Build success in 125ms`.
- [x] `bash scripts/check-owner-boundary.sh` — `[owner-boundary] policy checks passed`.

</details>

## Visual Proof

![Focused owner-first regression output](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-a4aaeb/owner-first-regression.png)

Manually inspected: the image shows green checks for owner-first delete, run, resume, and generic mutations, isolated fallback, live-marker refusal, and the `owner-serve` exemption.

The changed process boundary has no graphical state; the captured focused regression output is its visible proof surface.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged PR commit>`
- Post-revert steps: Re-run the focused app tests and owner-boundary check.
- Data migration? No

</details>
