### PR TITLE
[Owner-first standalone mutations](3) Document owner-first standalone fallback

### DIFF
--- a/docs/persistence-architecture-single-writer.md
+++ b/docs/persistence-architecture-single-writer.md
@@ -20,11 +20,11 @@ The owner boundary covers writes. Normal WAL mode allows the writable owner and 
 
 ### Acceptance Rules
 
-1. **Owner process**: GUI process (main.ts) or standalone headless process (when `INVOKER_HEADLESS_STANDALONE=1`).
+1. **Owner process**: GUI process (main.ts) or standalone headless owner process. A standalone-enabled mutation may become a local writable owner only after it cannot reach a compatible owner and there is no live writable-owner marker.
 2. **GUI viewer** opens the shared database read-only when it exists. `openMainProcessDatabase({ detachedViewer: true })` falls back to process-local placeholder persistence only before `invoker.db` has been created.
 3. **Non-owner processes**: headless CLI invocations (when GUI is running).
 4. **Non-owner processes CANNOT initialize writable persistence**. Attempting to do so throws or delegates.
-5. **All non-owner mutations MUST traverse RPC** (`headless.run`, `headless.resume`, `headless.exec` channels via IpcBus).
+5. **All non-owner mutations MUST traverse RPC** (`headless.run`, `headless.resume`, `headless.exec` channels via IpcBus). `owner-serve` is the local owner bootstrap command and is exempt from delegation so it cannot delegate to itself.
 
 Implementation note: the missing-file placeholder is SQLite ephemeral storage via `SQLiteAdapter.createEphemeral()`. The raw SQLite `:memory:` sentinel is private to the data-store adapter so viewer startup code cannot accidentally create `invoker.db`.
 
@@ -57,27 +57,27 @@ This table lists every mutating command path and how the owner-boundary contract
 | `invoker:replace-task` | main.ts:1257 | N/A (owner) | `orchestrator.replaceTask()` → persistence | |
 | `invoker:delete-workflow` | main.ts:867 | N/A (owner) | `orchestrator.deleteWorkflow()` → persistence | |
 | `invoker:delete-all-workflows` | main.ts:856 | N/A (owner) | `orchestrator.deleteAllWorkflows()` → persistence | |
-| **Headless Commands** (delegate when GUI present, standalone otherwise) |
-| `run` | headless.ts:565 | **Yes** (line 356) | `tryDelegateRun()` → IPC `headless.run` (owner handles) OR standalone opens writable via `initServices({ readOnly: false })` | Delegation timeout = 5s |
-| `resume` | headless.ts:620 | **Yes** (line 361) | `tryDelegateResume()` → IPC `headless.resume` OR standalone writable | |
-| `retry-task` | headless.ts:273 | **Yes** (line 365) | `tryDelegateExec()` → IPC `headless.exec` OR standalone writable | Task-scoped retry uses the default 5s delegation timeout |
-| `recreate` | headless.ts:769 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `recreate-task` | headless.ts:788 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `rebase-retry` / `rebase-recreate` | headless.ts:296 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | Workflow-scoped fresh-base commands delegate with a 60s timeout; task-scoped fresh-base commands stay at 5s |
-| `approve` | headless.ts:666 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `reject` | headless.ts:681 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `input` | headless.ts:688 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `select` | headless.ts:695 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `fix` | headless.ts:722 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `resolve-conflict` | headless.ts:742 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `cancel` | headless.ts:967 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `cancel-workflow` | headless.ts:978 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `delete` | headless.ts:1005 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `delete-all` | headless.ts:434 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `set command` | headless.ts:829 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `set executor` | headless.ts:841 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `set agent` | headless.ts:853 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `set merge-mode` | headless.ts:1011 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | Allowed modes: `manual | automatic | external_review` |
+| **Headless Commands** (owner-first, including when `INVOKER_HEADLESS_STANDALONE=1`; `owner-serve` remains local) |
+| `run` | headless.ts:565 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateRun()` → IPC `headless.run` when a compatible owner is reachable; otherwise local writable fallback only when no live writable-owner marker exists | Delegation timeout = 5s |
+| `resume` | headless.ts:620 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateResume()` → IPC `headless.resume` when a compatible owner is reachable; otherwise marker-gated local writable fallback | |
+| `retry-task` | headless.ts:273 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` → IPC `headless.exec` when a compatible owner is reachable; otherwise marker-gated local writable fallback | Task-scoped retry uses the default 5s delegation timeout |
+| `recreate` | headless.ts:769 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | |
+| `recreate-task` | headless.ts:788 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | |
+| `rebase-retry` / `rebase-recreate` | headless.ts:296 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | Workflow-scoped fresh-base commands delegate with a 60s timeout; task-scoped fresh-base commands stay at 5s |
+| `approve` | headless.ts:666 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | |
+| `reject` | headless.ts:681 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | |
+| `input` | headless.ts:688 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | |
+| `select` | headless.ts:695 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | |
+| `fix` | headless.ts:722 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | |
+| `resolve-conflict` | headless.ts:742 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | |
+| `cancel` | headless.ts:967 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | |
+| `cancel-workflow` | headless.ts:978 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | |
+| `delete` | headless.ts:1005 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | |
+| `delete-all` | headless.ts:434 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | |
+| `set command` | headless.ts:829 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | |
+| `set executor` | headless.ts:841 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | |
+| `set agent` | headless.ts:853 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | |
+| `set merge-mode` | headless.ts:1011 | **Yes** (`headless-client.ts:827-839`, `main.ts:996-1020`) | `tryDelegateExec()` when a compatible owner is reachable; otherwise marker-gated local writable fallback | Allowed modes: `manual | automatic | external_review` |
 | **Headless Read-Only Commands** | | | | delegate to the owner when present; open `readOnly` only when none |
 | `query workflows` | headless.ts:193 | **Yes** (cli-query) | Owner answers over IPC, else opens `readOnly: true` | Safe: no writes |
 | `query tasks` | headless.ts:206 | **Yes** (cli-query) | Owner answers over IPC, else opens `readOnly: true` | Safe: no writes |
@@ -105,24 +105,25 @@ This table lists every mutating command path and how the owner-boundary contract
 
 | Component | File | Line(s) | Enforcement Mechanism |
 |-----------|------|---------|----------------------|
-| **GUI main process** | packages/app/src/main.ts | 605-613 | `initServices()` opens writable DB (no `readOnly` flag) |
-| **Headless delegation** | packages/app/src/main.ts, packages/app/src/headless-delegation.ts | 346-381, 68-145 | `tryDelegateRun()`, `tryDelegateResume()`, `tryDelegateExec()` send IPC request to owner; `run`, `resume`, and default `exec` delegation use 5s timeout, while workflow-scoped `rebase-retry` / `rebase-recreate` use 60s before standalone fallback |
-| **Headless standalone** | packages/app/src/main.ts | 386 | `initServices({ readOnly: isHeadlessReadOnlyCommand(cliArgs) })` — read-only for query commands, writable for standalone mutating commands (when `INVOKER_HEADLESS_STANDALONE=1` or no GUI) |
+| **GUI main process** | packages/app/src/main.ts | 743-760 | `initServices()` opens writable DB (no `readOnly` flag) |
+| **Headless delegation** | packages/app/src/headless-client.ts, packages/app/src/main.ts, packages/app/src/headless-delegation.ts | 160-188 / 704-765 / 827-839; 925-971 / 996-1020; 68-145 | `tryDelegateRun()`, `tryDelegateResume()`, `tryDelegateExec()` send IPC requests to a compatible owner before writable fallback. Standalone-enabled mutations use the same owner-first rule and fail closed if a live writable-owner marker exists but no compatible owner can be reached. |
+| **Headless standalone** | packages/app/src/headless-client.ts, packages/app/src/main.ts | 827-839; 981-982 / 996-1020 / 1150-1155 | `INVOKER_HEADLESS_STANDALONE=1` permits local writable execution only after existing-owner delegation fails and `hasLiveWritableOwnerMarker()` is false; `owner-serve` stays local and opens the writable owner. |
 | **SQLiteAdapter read-only gate** | packages/persistence/src/sqlite-adapter.ts | 113-117 | `ensureWritable()` throws if `readOnly: true` and a write is attempted |
-| **Delegation handlers (owner)** | packages/app/src/main.ts | 618-674 | `headless.run`, `headless.resume`, `headless.exec` IPC handlers receive delegated commands, execute via owner's writable orchestrator/persistence |
+| **Delegation handlers (owner)** | packages/app/src/main.ts | 1873-1978 | `headless.run`, `headless.resume`, `headless.exec` IPC handlers receive delegated commands, execute via owner's writable orchestrator/persistence |
 
 ### Critical Guarantees
 
-1. **GUI always owns DB**: When GUI is running, `initServices()` (main.ts:605) opens writable persistence. All IPC handlers mutate via this owner instance.
-2. **Headless delegates by default**: When GUI is present, headless commands try delegation first. `run`, `resume`, and most `headless.exec` commands use a 5s timeout; workflow-scoped `rebase-retry` and `rebase-recreate` use 60s. Only if delegation fails (no GUI or timeout) does headless open its own writable DB.
-3. **Read-only commands never write**: `query` subcommands delegate reads to the owner when one is present; otherwise they open `readOnly: true` persistence (main.ts:386).
-4. **Standalone escape hatch**: `INVOKER_HEADLESS_STANDALONE=1` skips delegation, allowing headless to own the DB (main.ts:348-349).
-5. **Delegation timeout prevents deadlock**: IPC delegation is bounded so headless does not hang if GUI is unresponsive. The default is 5s, with a 60s allowance for workflow-scoped `rebase-retry` and `rebase-recreate` command shapes in `headless.exec`.
+1. **GUI always owns DB**: When GUI is running, `initServices()` (main.ts:743) opens writable persistence. All IPC handlers mutate via this owner instance.
+2. **Headless delegates by default**: When GUI or a standalone owner is present, headless mutations try delegation first. `run`, `resume`, and most `headless.exec` commands use a 5s timeout; workflow-scoped `rebase-retry` and `rebase-recreate` use 60s.
+3. **Read-only commands never write**: `query` subcommands delegate reads to the owner when one is present; otherwise they open `readOnly: true` persistence.
+4. **Standalone is owner-first, not a bypass**: `INVOKER_HEADLESS_STANDALONE=1` first routes mutating commands to a compatible reachable owner. Local writable fallback is allowed only when no compatible owner responds and `hasLiveWritableOwnerMarker()` is false. If a live writable-owner marker exists but IPC cannot reach a compatible owner, the command exits non-zero and refuses writable fallback.
+5. **`owner-serve` cannot delegate to itself**: `owner-serve` remains local owner startup. Delegation guards exclude it in both `headless-client.ts` and `main.ts`.
+6. **Delegation timeout prevents deadlock**: IPC delegation is bounded so headless does not hang if the owner is unresponsive. The default is 5s, with a 60s allowance for workflow-scoped `rebase-retry` and `rebase-recreate` command shapes in `headless.exec`.
 
 ### Test Coverage
 
 - **Concurrent write safety**: Run GUI + headless concurrently (`pnpm test packages/app` includes `concurrent-writes.test.ts` if present).
-- **Delegation flow**: Verify `tryDelegateRun()` succeeds when GUI is running, falls back to standalone when GUI is not running.
+- **Delegation flow**: Verify `tryDelegateRun()`, `tryDelegateResume()`, and `tryDelegateExec()` route standalone-enabled mutations to a reachable compatible owner, allow local fallback only without a live owner marker, fail closed when a live marker is present but IPC is unavailable, and leave `owner-serve` local.
 - **Read-only enforcement**: Attempt write on `readOnly: true` adapter, expect throw.
 - **Historical failure-mode repro**: `bash scripts/repro/repro-sqljs-last-writer-wins.sh` demonstrates last-writer-wins when two writable adapters bypass the owner boundary.
 

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -254,6 +254,120 @@ describe('headless-client', () => {
     expect(runElectronHeadless).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      label: 'delete',
+      argv: ['delete', 'wf-1', '--no-track'],
+      channel: 'headless.exec',
+      expectedPayload: { args: ['delete', 'wf-1'], noTrack: true, waitForApproval: false },
+    },
+    {
+      label: 'run',
+      argv: ['run', '/tmp/plan.yaml', '--no-track'],
+      channel: 'headless.run',
+      expectedPayload: { planPath: expect.stringContaining('plan.yaml') },
+    },
+    {
+      label: 'resume',
+      argv: ['resume', 'wf-42', '--no-track'],
+      channel: 'headless.resume',
+      expectedPayload: { workflowId: 'wf-42' },
+    },
+    {
+      label: 'generic mutation',
+      argv: ['recreate', 'wf-1', '--no-track'],
+      channel: 'headless.exec',
+      expectedPayload: { args: ['recreate', 'wf-1'], noTrack: true, waitForApproval: false },
+    },
+  ])('delegates standalone-enabled $label to a compatible owner before local Electron fallback', async ({ argv, channel, expectedPayload }) => {
+    process.env.INVOKER_HEADLESS_STANDALONE = '1';
+    const bus = new LocalBus();
+    const ownerHandler = vi.fn(async () => ({ ok: true }));
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-standalone-first', mode: 'gui' }));
+    bus.onRequest(channel, ownerHandler);
+
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const runElectronHeadless = vi.fn(async () => 23);
+
+    const exitCode = await runHeadlessClientCommand(argv, {
+      messageBus: bus,
+      ensureStandaloneOwner,
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(ownerHandler).toHaveBeenCalledTimes(1);
+    expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining(expectedPayload));
+    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    expect(runElectronHeadless).not.toHaveBeenCalled();
+  });
+
+  it('preserves direct standalone mutation execution when no owner and no live marker exist', async () => {
+    process.env.INVOKER_HEADLESS_STANDALONE = '1';
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const runElectronHeadless = vi.fn(async () => 23);
+    const argv = ['delete', 'wf-1'];
+
+    const exitCode = await runHeadlessClientCommand(argv, {
+      messageBus: new LocalBus(),
+      ensureStandaloneOwner,
+      refreshMessageBus: vi.fn(async () => new LocalBus()),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(23);
+    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    expect(runElectronHeadless).toHaveBeenCalledWith(argv);
+  });
+
+  it('refuses standalone writable fallback when a live owner marker exists but IPC is unavailable', async () => {
+    process.env.INVOKER_HEADLESS_STANDALONE = '1';
+    const dbPath = join(dbDir, 'invoker.db');
+    writeFileSync(dbPath, '');
+    writeFileSync(`${dbPath}-wal`, '');
+    writeFileSync(`${dbPath}.owner`, String(process.pid), 'utf-8');
+
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const runElectronHeadless = vi.fn(async () => 23);
+    try {
+      const exitCode = await runHeadlessClientCommand(['delete', 'wf-1'], {
+        messageBus: new LocalBus(),
+        ensureStandaloneOwner,
+        refreshMessageBus: vi.fn(async () => new LocalBus()),
+        runElectronHeadless,
+      });
+
+      const output = stderr.mock.calls.map(([chunk]) => String(chunk)).join('');
+      expect(exitCode).toBe(1);
+      expect(output).toContain('live writable owner marker');
+      expect(output).toContain('could not reach a compatible owner');
+      expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+      expect(runElectronHeadless).not.toHaveBeenCalled();
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
+  it('keeps owner-serve local even when standalone delegation is enabled', async () => {
+    process.env.INVOKER_HEADLESS_STANDALONE = '1';
+    const bus = new LocalBus();
+    const ownerHandler = vi.fn(async () => ({ ok: true }));
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-self', mode: 'gui' }));
+    bus.onRequest('headless.exec', ownerHandler);
+    const runElectronHeadless = vi.fn(async () => 23);
+
+    const exitCode = await runHeadlessClientCommand(['owner-serve'], {
+      messageBus: bus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(23);
+    expect(ownerHandler).not.toHaveBeenCalled();
+    expect(runElectronHeadless).toHaveBeenCalledWith(['owner-serve']);
+  });
+
   it('delegates mutating commands to a standalone-capable owner endpoint', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -6,6 +6,7 @@ import {
   tryDelegateRun,
   tryDelegateResume,
 } from '../headless.js';
+import { runHeadlessClientCommand } from '../headless-client.js';
 import { LocalBus } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
 import type { HeadlessTargetLookup } from '../headless-command-classification.js';
@@ -116,6 +117,58 @@ describe('headless→owner delegation', () => {
   });
 
   describe('successful delegation when owner is present', () => {
+    it.each([
+      {
+        label: 'delete',
+        argv: ['delete', 'wf-1', '--no-track'],
+        channel: 'headless.exec',
+        expectedPayload: { args: ['delete', 'wf-1'], noTrack: true, waitForApproval: false },
+      },
+      {
+        label: 'run',
+        argv: ['run', '/path/to/plan.yaml', '--no-track'],
+        channel: 'headless.run',
+        expectedPayload: { planPath: expect.stringContaining('plan.yaml') },
+      },
+      {
+        label: 'resume',
+        argv: ['resume', 'wf-1', '--no-track'],
+        channel: 'headless.resume',
+        expectedPayload: { workflowId: 'wf-1' },
+      },
+      {
+        label: 'generic mutation',
+        argv: ['approve', 'wf-1/task-1', '--no-track'],
+        channel: 'headless.exec',
+        expectedPayload: { args: ['approve', 'wf-1/task-1'], noTrack: true, waitForApproval: false },
+      },
+    ])('routes standalone-enabled $label to a compatible owner before local fallback', async ({ argv, channel, expectedPayload }) => {
+      const savedStandalone = process.env.INVOKER_HEADLESS_STANDALONE;
+      process.env.INVOKER_HEADLESS_STANDALONE = '1';
+      try {
+        const ownerHandler = vi.fn(async () => ({ ok: true }));
+        messageBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-standalone-route', mode: 'standalone' }));
+        messageBus.onRequest(channel, ownerHandler);
+        const ensureStandaloneOwner = vi.fn(async () => {});
+        const runElectronHeadless = vi.fn(async () => 23);
+
+        const exitCode = await runHeadlessClientCommand(argv, {
+          messageBus,
+          ensureStandaloneOwner,
+          runElectronHeadless,
+        });
+
+        expect(exitCode).toBe(0);
+        expect(ownerHandler).toHaveBeenCalledTimes(1);
+        expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining(expectedPayload));
+        expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+        expect(runElectronHeadless).not.toHaveBeenCalled();
+      } finally {
+        if (savedStandalone === undefined) delete process.env.INVOKER_HEADLESS_STANDALONE;
+        else process.env.INVOKER_HEADLESS_STANDALONE = savedStandalone;
+      }
+    });
+
     it('delegates mutation command to owner via RPC', async () => {
       // Simulate owner process registering a handler
       const ownerHandler = vi.fn(async (_req: { args: string[] }) => {

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -89,6 +89,8 @@ const READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS = 20_000;
 const OPTIONAL_READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS = 2_000;
 const READ_ONLY_QUERY_REQUEST_TIMEOUT_MS = 15_000;
 const GENERIC_READ_OWNER_PING_TIMEOUT_MS = 10_000;
+const EXISTING_MUTATION_OWNER_DISCOVERY_TIMEOUT_MS = 3_000;
+const EXISTING_MUTATION_OWNER_REFRESH_DISCOVERY_TIMEOUT_MS = 1_000;
 const POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS = 3;
 const DEFAULT_STANDALONE_OWNER_BOOTSTRAP_TIMEOUT_MS = 60_000;
 const REQUIRE_EXISTING_OWNER_ENV = 'INVOKER_HEADLESS_REQUIRE_EXISTING_OWNER';
@@ -592,6 +594,14 @@ function shouldUseSharedMutationOwner(args: string[], standaloneMode: boolean, i
   return isHeadlessMutatingCommand(args) && !standaloneMode && !internalOwnerServe;
 }
 
+function liveWritableOwnerDbPath(): string {
+  return resolve(resolveInvokerHomeRoot(), 'invoker.db');
+}
+
+function hasLiveWritableOwnerMarker(): boolean {
+  return hasLiveWritableOwner(liveWritableOwnerDbPath());
+}
+
 /**
  * Resolve a writable owner endpoint using the resolver, then delegate.
  *
@@ -691,6 +701,69 @@ async function resolveOwnerAndDelegate(
   return null; // Could not resolve
 }
 
+async function resolveExistingOwnerAndDelegate(
+  args: string[],
+  deps: HeadlessClientDeps,
+  waitForApproval?: boolean,
+  noTrack?: boolean,
+): Promise<number | null> {
+  delegationClientLog(`resolveExistingOwnerAndDelegate begin command=${args[0] ?? '<missing>'} noTrack=${noTrack ? 'true' : 'false'}`);
+  const resolver = createOwnerResolver(
+    {
+      messageBus: deps.messageBus,
+      refreshMessageBus: deps.refreshMessageBus,
+      ensureStandaloneOwner: async () => {},
+    },
+    {
+      discoveryTimeoutMs: EXISTING_MUTATION_OWNER_DISCOVERY_TIMEOUT_MS,
+      refreshDiscoveryTimeoutMs: EXISTING_MUTATION_OWNER_REFRESH_DISCOVERY_TIMEOUT_MS,
+      maxBootstrapAttempts: 0,
+    },
+  );
+
+  const discovered = await resolver.discover();
+  const resolved = discovered.resolved ? discovered : await resolver.refreshAndDiscover();
+  if (!resolved.resolved) {
+    delegationClientLog('resolveExistingOwnerAndDelegate no compatible existing owner');
+    return null;
+  }
+
+  let outcome: DelegationOutcome;
+  try {
+    outcome = await delegateMutation(
+      args,
+      resolved.bus,
+      waitForApproval,
+      noTrack,
+      noTrack ? POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS : DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
+    );
+  } catch (err) {
+    if (isAcceptedStaleOwnerNoTrackTaskMutationError(args, noTrack, err)) {
+      delegationClientLog(
+        `accepted stale-owner no-track task mutation command=${args[0]} workflow=${explicitTaskTargetWorkflowId(args)}`,
+      );
+      process.stdout.write('Delegated to owner\n');
+      process.stdout.write('--no-track enabled: delegated submission accepted; exiting without tracking.\n');
+      const exitCode = process.exitCode;
+      return typeof exitCode === 'number' ? exitCode : 0;
+    }
+    throw err;
+  }
+
+  if (outcome.kind === 'delegated') {
+    const exitCode = process.exitCode;
+    return typeof exitCode === 'number' ? exitCode : 0;
+  }
+
+  const detail = outcome.kind === 'protocol-error'
+    ? `: ${outcome.message}`
+    : ` (${outcome.kind})`;
+  process.stderr.write(
+    `${RED}Error:${RESET} Compatible owner "${resolved.owner.ownerId}" responded to discovery but did not accept mutation command "${args[0] ?? ''}"${detail}.\n`,
+  );
+  return 1;
+}
+
 export async function runHeadlessClientCommand(
   argv: string[],
   deps: HeadlessClientDeps,
@@ -749,6 +822,21 @@ export async function runHeadlessClientCommand(
       return 0;
     }
     return runLocalWorkersQuery(args, invokerConfig);
+  }
+
+  if (standaloneMode && isHeadlessMutatingCommand(args) && !internalOwnerServe) {
+    const delegatedToExistingOwner = await resolveExistingOwnerAndDelegate(args, deps, waitForApproval, noTrack);
+    if (delegatedToExistingOwner !== null) {
+      return delegatedToExistingOwner;
+    }
+    if (hasLiveWritableOwnerMarker()) {
+      process.stderr.write(
+        `${RED}Error:${RESET} Standalone mutation command "${args[0] ?? ''}" found a live writable owner marker but could not reach a compatible owner over IPC.\n` +
+        'Refusing writable standalone fallback while another owner may have the database open.\n',
+      );
+      return 1;
+    }
+    return deps.runElectronHeadless(argv);
   }
 
   if (!shouldUseSharedMutationOwner(args, standaloneMode, internalOwnerServe)) {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -73,7 +73,7 @@ import type {
   StartReadyRequest,
   StartReadyResult,
 } from '@invoker/contracts';
-import { ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
+import { ConversationRepository, SqliteTaskRepository, hasLiveWritableOwner } from '@invoker/data-store';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
 import {
@@ -915,6 +915,60 @@ const RESET = '\x1b[0m';
 const BOLD = '\x1b[1m';
 const RED = '\x1b[31m';
 const YELLOW = '\x1b[33m';
+const EXISTING_HEADLESS_MUTATION_OWNER_DISCOVERY_TIMEOUT_MS = 3_000;
+const EXISTING_HEADLESS_MUTATION_OWNER_REFRESH_TIMEOUT_MS = 1_000;
+
+function hasLiveWritableOwnerMarker(): boolean {
+  return hasLiveWritableOwner(path.join(resolveInvokerHomeRoot(), 'invoker.db'));
+}
+
+async function tryDelegateHeadlessMutationToBus(
+  args: string[],
+  bus: MessageBus,
+  command: string | undefined,
+): Promise<boolean> {
+  if (command === 'run') {
+    const planPath = args[1];
+    if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
+    return isDelegated(await tryDelegateRun(planPath, bus, waitForApproval, noTrack));
+  }
+  if (command === 'resume') {
+    const workflowId = args[1];
+    if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
+    return isDelegated(await tryDelegateResume(workflowId, bus, waitForApproval, noTrack));
+  }
+  const timeoutMs = noTrack ? undefined : await resolveDelegationTimeoutMs(args);
+  return isDelegated(await tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs));
+}
+
+async function tryDelegateHeadlessMutationToExistingOwner(
+  args: string[],
+  command: string | undefined,
+): Promise<'delegated' | 'no-compatible-owner' | 'failed'> {
+  let delegationBus = new IpcBus(undefined, { allowServe: false });
+  try {
+    await delegationBus.ready();
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const timeoutMs = attempt === 0
+        ? EXISTING_HEADLESS_MUTATION_OWNER_DISCOVERY_TIMEOUT_MS
+        : EXISTING_HEADLESS_MUTATION_OWNER_REFRESH_TIMEOUT_MS;
+      const owner = await discoverOwner(delegationBus, timeoutMs);
+      if (isStandaloneCapable(owner)) {
+        return await tryDelegateHeadlessMutationToBus(args, delegationBus, command)
+          ? 'delegated'
+          : 'failed';
+      }
+      if (attempt === 0) {
+        delegationBus.disconnect();
+        delegationBus = new IpcBus(undefined, { allowServe: false });
+        await delegationBus.ready();
+      }
+    }
+    return 'no-compatible-owner';
+  } finally {
+    delegationBus.disconnect();
+  }
+}
 
 function startHeadlessMode(): void {
   const runHeadlessMain = async (): Promise<void> => {
@@ -940,40 +994,54 @@ function startHeadlessMode(): void {
     }
 
     // Try delegation for mutating commands first (owner mode).
-    // In standalone mode we skip delegation and run locally.
-    if (mutatingMode && !standaloneMode) {
-      // Delegating headless commands must never become the IPC server.
-      // Otherwise a transient submitter can steal the transport socket away
-      // from the actual shared mutation owner.
-      const delegationBus = new IpcBus(undefined, { allowServe: false });
-      try {
-        await delegationBus.ready();
-
-        let delegated = false;
-        if (command === 'run') {
-          const planPath = cliArgs[1];
-          if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
-          delegated = isDelegated(await tryDelegateRun(planPath, delegationBus, waitForApproval, noTrack));
-        } else if (command === 'resume') {
-          const workflowId = cliArgs[1];
-          if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
-          delegated = isDelegated(await tryDelegateResume(workflowId, delegationBus, waitForApproval, noTrack));
-        } else {
-          const timeoutMs = noTrack ? undefined : await resolveDelegationTimeoutMs(cliArgs);
-          delegated = isDelegated(await tryDelegateExec(cliArgs, delegationBus, waitForApproval, noTrack, timeoutMs));
-        }
-
-        if (delegated) {
-          // Successfully delegated to owner
-          delegationBus.disconnect();
-          await flushStdoutAndStderr();
-          process.exit(process.exitCode ?? 0);
+    if (mutatingMode && command !== 'owner-serve') {
+      if (standaloneMode) {
+        try {
+          const delegationResult = await tryDelegateHeadlessMutationToExistingOwner(cliArgs, command);
+          if (delegationResult === 'delegated') {
+            await flushStdoutAndStderr();
+            process.exit(process.exitCode ?? 0);
+            return; // Guard: process.exit() may not halt in Electron async context
+          }
+          if (delegationResult === 'failed') {
+            process.stderr.write(
+              `${RED}Error:${RESET} Compatible owner responded to discovery but did not accept mutation command "${command ?? ''}".\n`,
+            );
+            process.exit(1);
+            return; // Guard: process.exit() may not halt in Electron async context
+          }
+          if (hasLiveWritableOwnerMarker()) {
+            process.stderr.write(
+              `${RED}Error:${RESET} Standalone mutation command "${command ?? ''}" found a live writable owner marker but could not reach a compatible owner over IPC.\n` +
+              'Refusing writable standalone fallback while another owner may have the database open.\n',
+            );
+            process.exit(1);
+            return; // Guard: process.exit() may not halt in Electron async context
+          }
+        } catch (err) {
+          process.stderr.write(`${RED}Delegation error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
+          process.exit(1);
           return; // Guard: process.exit() may not halt in Electron async context
         }
+      } else {
+        // Delegating headless commands must never become the IPC server.
+        // Otherwise a transient submitter can steal the transport socket away
+        // from the actual shared mutation owner.
+        const delegationBus = new IpcBus(undefined, { allowServe: false });
+        try {
+          await delegationBus.ready();
 
-        // Delegation failed: no owner handler available.
-        delegationBus.disconnect();
-        if (!standaloneMode) {
+          const delegated = await tryDelegateHeadlessMutationToBus(cliArgs, delegationBus, command);
+          if (delegated) {
+            // Successfully delegated to owner
+            delegationBus.disconnect();
+            await flushStdoutAndStderr();
+            process.exit(process.exitCode ?? 0);
+            return; // Guard: process.exit() may not halt in Electron async context
+          }
+
+          // Delegation failed: no owner handler available.
+          delegationBus.disconnect();
           process.stderr.write(
             `${RED}Error:${RESET} Mutation command "${command}" requires a running owner process.\n` +
             `\n${BOLD}Options:${RESET}\n` +
@@ -983,12 +1051,12 @@ function startHeadlessMode(): void {
           );
           process.exit(1);
           return; // Guard: process.exit() may not halt in Electron async context
+        } catch (err) {
+          process.stderr.write(`${RED}Delegation error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
+          delegationBus.disconnect();
+          process.exit(1);
+          return; // Guard: process.exit() may not halt in Electron async context
         }
-      } catch (err) {
-        process.stderr.write(`${RED}Delegation error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
-        delegationBus.disconnect();
-        process.exit(1);
-        return; // Guard: process.exit() may not halt in Electron async context
       }
     }
 


### PR DESCRIPTION
## Summary

The persistence guide now describes standalone mode as owner-first fallback instead of an unconditional delegation bypass.

It documents the marker-gated local fallback, fail-closed live-owner case, and `owner-serve` exemption.

## Review Claim

The persistence documentation states the implemented owner-first standalone fallback rule and fail-closed live-owner case (`docs/persistence-architecture-single-writer.md:119`).

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

The guide describes only behavior in the preceding implementation slices and does not broaden standalone write permission.

## Slice Rationale

Documentation follows both implementation boundaries so its operational guidance cannot get ahead of the behavior it describes.

## Non-goals

- No runtime code or tests.
- No owner protocol redesign.
- No broad architecture rewrite or unrelated documentation cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `rg -n "Standalone is owner-first|owner-serve cannot delegate|live writable-owner marker" docs/persistence-architecture-single-writer.md` — matched the owner-first guarantee at line 119 and `owner-serve` exemption at line 120.
- [x] `node scripts/validate-pr-body-local.mjs --body-file .git/invoker-pr-bodies/03-docs.md --base stack/EdbertChan/plan/owner-first-standalone-mutations/owner-first-standalone-mutations-2-guard-electron--17864916` — `PR body validation passed.`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, together with the preceding behavior slices.
- Revert command: `git revert <merged PR commit>`
- Post-revert steps: Restore the previous standalone-mode guidance only if the behavior slices are also reverted.
- Data migration? No

</details>
