### PR TITLE
[Planning review parity](7) Align doctor with submission schema

### DIFF
--- a/skills/plan-to-invoker/scripts/test-fixtures.sh
+++ b/skills/plan-to-invoker/scripts/test-fixtures.sh
@@ -293,6 +293,45 @@ test_runner_kind_is_unsupported() {
   return 0
 }
 
+test_legacy_autofix_fields_are_unsupported() {
+  local temp_plan
+  temp_plan=$(mktemp)
+  trap "rm -f $temp_plan" RETURN
+  cat > "$temp_plan" <<'EOF'
+name: "Legacy auto-fix fields"
+onFinish: none
+repoUrl: git@github.com:example-org/acme-repo.git
+autoFixRetries: 2
+tasks:
+  - id: legacy-task
+    description: "Exercise obsolete task metadata"
+    command: "echo ok"
+    dependencies: []
+    autoFix: true
+EOF
+
+  local output
+  set +e
+  output=$(bash "$VALIDATE_SCRIPT" "$temp_plan" 2>&1)
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "Expected legacy auto-fix fields to fail validation" >&2
+    return 1
+  fi
+  if ! echo "$output" | jq -e '[.[] | select(.errorType == "unsupported_field" and .field == "autoFixRetries")] | length == 1' &>/dev/null; then
+    echo "Expected plan-level autoFixRetries diagnostic" >&2
+    echo "Output: $output" >&2
+    return 1
+  fi
+  if ! echo "$output" | jq -e '[.[] | select(.errorType == "unsupported_field" and .field == "autoFix" and .taskId == "legacy-task")] | length == 1' &>/dev/null; then
+    echo "Expected task-level autoFix diagnostic" >&2
+    echo "Output: $output" >&2
+    return 1
+  fi
+}
+
 test_lint_allows_focused_verification_without_test_all() {
   local temp_plan
   temp_plan=$(mktemp)
@@ -1408,6 +1447,7 @@ run_test "Edge: invalid_dependency_reference" test_edge_invalid_dependency
 run_test "Edge: unrendered_template_placeholder" test_unrendered_template_placeholder
 run_test "Edge: stacked_basebranch_default" test_stacked_basebranch_master
 run_test "Edge: unsupported runnerKind field" test_runner_kind_is_unsupported
+run_test "Edge: unsupported legacy auto-fix fields" test_legacy_autofix_fields_are_unsupported
 run_test "Lint: allow focused verification without test:all" test_lint_allows_focused_verification_without_test_all
 run_test "Lint: reject multi-prompt standalone without waiver" test_lint_rejects_multi_prompt_standalone_without_waiver
 run_test "Lint: allow stack workflows with focused verification" test_lint_allows_nonterminal_stack_workflow_without_test_all

--- a/skills/plan-to-invoker/scripts/validate-plan.mjs
+++ b/skills/plan-to-invoker/scripts/validate-plan.mjs
@@ -584,6 +584,17 @@ function validatePlan(yamlContent, repoRoot) {
     });
   }
 
+  for (const field of ['autoFix', 'autoFixRetries']) {
+    if (Object.prototype.hasOwnProperty.call(raw, field)) {
+      errors.push({
+        errorType: 'unsupported_field',
+        field,
+        message: `Plan-level "${field}" is no longer supported. Configure "~/.invoker/config.json" with "autoFixRetries" instead.`,
+        value: raw[field],
+      });
+    }
+  }
+
   // Validate description required when onFinish is pull_request or merge
   const onFinish = raw.onFinish ?? 'pull_request';
   if ((onFinish === 'pull_request' || onFinish === 'merge') &&
@@ -729,6 +740,18 @@ function validatePlan(yamlContent, repoRoot) {
     }
 
     // Validate obsolete executor routing fields.
+    for (const field of ['autoFix', 'autoFixRetries']) {
+      if (Object.prototype.hasOwnProperty.call(task, field)) {
+        errors.push({
+          errorType: 'unsupported_field',
+          field,
+          taskId,
+          message: `Task "${taskId}" uses "${field}", which is no longer supported in plan YAML. Configure "~/.invoker/config.json" with "autoFixRetries" instead.`,
+          value: task[field],
+        });
+      }
+    }
+
     if (task.runnerKind !== undefined) {
       errors.push({
         errorType: 'unsupported_field',


### PR DESCRIPTION
## Summary

The plan-to-invoker checker now reports obsolete `autoFix` and `autoFixRetries` YAML fields.

Fixture coverage records the rule at plan, workflow, and task levels.

## Review Claim

The checker reports both obsolete fields everywhere they can appear.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

The checker adds errors only for fields already refused later. Supported YAML retains its prior results.

## Slice Rationale

This checker slice lands before host behavior, giving later work one diagnostic source.

## Non-goals

- Automatically rewrite rejected plans.
- Change review presentation.
- Change global `~/.invoker/config.json` semantics.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash skills/plan-to-invoker/scripts/test-fixtures.sh`
- [x] `pnpm --filter @invoker/surfaces test -- --run src/__tests__/plan-conversation.test.ts -t "forbids unsupported auto-fix fields"`
- [x] `bash skills/plan-to-invoker/scripts/skill-doctor.sh packages/surfaces/src/__tests__/planning-review-76829fbb.yaml` (expected exit 1 at `validate-plan`)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4e778a8f6`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #8531
