### PR TITLE
[Planning review parity](9) Gate drafts on full doctor

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -138,7 +138,7 @@ describe('extractYamlPlan', () => {
     expect(plan.onFinish).toBeUndefined();
   });
 
-  it('preserves explicit supported fields and strips legacy auto-fix fields from planner YAML', () => {
+  it('preserves legacy auto-fix fields so the doctor can reject instead of silently sanitizing them', () => {
     const text = `\`\`\`yaml
 name: "Full"
 onFinish: merge
@@ -162,14 +162,14 @@ tasks:
     expect(plan.baseBranch).toBe('develop');
     expect(plan.featureBranch).toBe('feature/test');
     expect(plan.mergeMode).toBe('automatic');
-    expect(plan.autoFixRetries).toBeUndefined();
+    expect(plan.autoFixRetries).toBe(3);
     expect(plan.tasks[0].pivot).toBe(true);
-    expect(plan.tasks[0].autoFix).toBeUndefined();
-    expect(plan.tasks[0].autoFixRetries).toBeUndefined();
+    expect(plan.tasks[0].autoFix).toBe(true);
+    expect(plan.tasks[0].autoFixRetries).toBe(2);
     expect(plan.tasks[0].requiresManualApproval).toBe(true);
   });
 
-  it('accepts stacked workflow YAML and strips legacy fields recursively', () => {
+  it('preserves stacked legacy fields for recursive doctor diagnostics', () => {
     const text = `\`\`\`yaml
 name: "Workers Surface"
 repoUrl: git@github.com:test/repo.git
@@ -203,9 +203,9 @@ workflows:
       'Workers Surface Contracts',
       'Workers Surface UI',
     ]);
-    expect(plan.autoFixRetries).toBeUndefined();
-    expect(plan.workflows[0].autoFixRetries).toBeUndefined();
-    expect(plan.workflows[0].tasks[0].autoFix).toBeUndefined();
+    expect(plan.autoFixRetries).toBe(3);
+    expect(plan.workflows[0].autoFixRetries).toBe(2);
+    expect(plan.workflows[0].tasks[0].autoFix).toBe(true);
   });
 
   it('preserves discovered repo commands without rewriting them', () => {
@@ -902,6 +902,8 @@ describe('PlanConversation prompt construction', () => {
     expect(prompt).toContain('plan-to-invoker');
     expect(prompt).toContain('skills/plan-to-invoker/SKILL.md');
     expect(prompt).toContain('Harness handoff mode');
+    expect(prompt).toContain('Never include `autoFix` or `autoFixRetries`');
+    expect(prompt).toContain('will not present the draft until every check passes');
     expect(prompt).not.toContain('tasks:\n  - id: task-1');
     expect(prompt).not.toContain('name: "Plan Name"');
   });

--- a/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-draft-file-activation.test.ts
@@ -169,8 +169,14 @@ describe('plan draft file - activation side', () => {
     expect(parsedDraft.name).toBe('Draft Activation');
   });
 
-  it.fails('does not expose the 76829fbb sidecar incident before the draft passes validation', async () => {
-    const conversation = new PlanConversation({ workingDir, threadTs: '76829fbb-432f-4115-b401-72d08c1645a4', plannerRetryLimit: 0 });
+  it('does not expose the 76829fbb sidecar incident before the draft passes the full doctor', async () => {
+    const conversation = new PlanConversation({
+      workingDir,
+      threadTs: '76829fbb-432f-4115-b401-72d08c1645a4',
+      plannerRetryLimit: 0,
+      planDoctorRepairLimit: 0,
+      planDoctorScriptPath: join(testDir, '../../../../skills/plan-to-invoker/scripts/skill-doctor.sh'),
+    });
     const path = conversation.planDraftFilePath();
     if (!path) throw new Error('expected a plan draft path');
     const incidentPlan = readFileSync(join(testDir, 'planning-review-76829fbb.yaml'), 'utf8');
@@ -179,8 +185,95 @@ describe('plan draft file - activation side', () => {
       'Drafted the plan.',
       () => writeFileSync(path, incidentPlan, 'utf8'),
     ));
-    await conversation.sendMessage('Draft the approved plan');
+    const reply = await conversation.sendMessage('Draft the approved plan');
 
+    expect(reply).toContain('Draft not shown: the plan doctor rejected it.');
+    expect(reply).toContain('uses "autoFix", which is no longer supported');
+    expect(existsSync(path)).toBe(false);
+    expect(conversation.lastTurnDraftPlanText).toBeNull();
+    expect(conversation.getDraftedPlan()).toBeNull();
+  });
+
+  it('exposes the exact candidate when the full doctor passes', async () => {
+    const conversation = new PlanConversation({
+      workingDir,
+      threadTs: 'doctor-pass',
+      plannerRetryLimit: 0,
+      planDoctorScriptPath: join(testDir, '../../../../skills/plan-to-invoker/scripts/skill-doctor.sh'),
+    });
+    const path = conversation.planDraftFilePath();
+    if (!path) throw new Error('expected a plan draft path');
+    const validPlan = readFileSync(
+      join(testDir, '../../../../skills/plan-to-invoker/fixtures/positive/08-bash-wrapped-pipefail.yaml'),
+      'utf8',
+    ).trim();
+
+    mockSpawn.mockReturnValueOnce(fakePlannerChild(
+      'Drafted the plan.',
+      () => writeFileSync(path, validPlan, 'utf8'),
+    ));
+    const reply = await conversation.sendMessage('Draft the approved plan');
+
+    expect(reply).toBe('Drafted the plan.');
+    expect(conversation.lastTurnDraftPlanText).toBe(validPlan);
+    expect(conversation.getDraftedPlan()).toBe(validPlan);
+  });
+
+  it('repairs a rejected candidate and exposes only the replacement that passes', async () => {
+    const doctor = vi.fn()
+      .mockResolvedValueOnce({ ok: false, diagnostics: ['validate-plan: task uses unsupported autoFix'] })
+      .mockResolvedValueOnce({ ok: true, diagnostics: [] });
+    const conversation = new PlanConversation({
+      workingDir,
+      threadTs: 'doctor-repair',
+      plannerRetryLimit: 0,
+      planDoctorRepairLimit: 2,
+      draftDoctor: doctor,
+    });
+    const path = conversation.planDraftFilePath();
+    if (!path) throw new Error('expected a plan draft path');
+    const incidentPlan = readFileSync(join(testDir, 'planning-review-76829fbb.yaml'), 'utf8');
+
+    mockSpawn
+      .mockReturnValueOnce(fakePlannerChild('Drafted the first plan.', () => writeFileSync(path, incidentPlan, 'utf8')))
+      .mockReturnValueOnce(fakePlannerChild('Drafted the corrected plan.', () => writeFileSync(path, VALID_PLAN_YAML, 'utf8')));
+
+    const reply = await conversation.sendMessage('Draft the approved plan');
+
+    expect(reply).toBe('Drafted the corrected plan.');
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(doctor).toHaveBeenCalledTimes(2);
+    expect(doctor).toHaveBeenNthCalledWith(1, incidentPlan.trim());
+    expect(doctor).toHaveBeenNthCalledWith(2, VALID_PLAN_YAML.trim());
+    expect(String(mockSpawn.mock.calls[1]?.[1])).toContain('validate-plan: task uses unsupported autoFix');
+    expect(conversation.lastTurnDraftPlanText).toBe(VALID_PLAN_YAML.trim());
+    expect(conversation.getDraftedPlan()).toBe(VALID_PLAN_YAML.trim());
+  });
+
+  it('fails closed after the bounded repair budget is exhausted', async () => {
+    const doctor = vi.fn().mockResolvedValue({ ok: false, diagnostics: ['validate-plan: still invalid'] });
+    const conversation = new PlanConversation({
+      workingDir,
+      threadTs: 'doctor-exhausted',
+      plannerRetryLimit: 0,
+      planDoctorRepairLimit: 2,
+      draftDoctor: doctor,
+    });
+    const path = conversation.planDraftFilePath();
+    if (!path) throw new Error('expected a plan draft path');
+
+    mockSpawn
+      .mockReturnValueOnce(fakePlannerChild('Candidate one.', () => writeFileSync(path, VALID_PLAN_YAML, 'utf8')))
+      .mockReturnValueOnce(fakePlannerChild('Candidate two.', () => writeFileSync(path, VALID_PLAN_YAML, 'utf8')))
+      .mockReturnValueOnce(fakePlannerChild('Candidate three.', () => writeFileSync(path, VALID_PLAN_YAML, 'utf8')));
+
+    const reply = await conversation.sendMessage('Draft the approved plan');
+
+    expect(reply).toContain('Draft not shown: the plan doctor rejected it.');
+    expect(reply).toContain('Nothing was submitted.');
+    expect(mockSpawn).toHaveBeenCalledTimes(3);
+    expect(doctor).toHaveBeenCalledTimes(3);
+    expect(existsSync(path)).toBe(false);
     expect(conversation.lastTurnDraftPlanText).toBeNull();
     expect(conversation.getDraftedPlan()).toBeNull();
   });

--- a/packages/surfaces/src/slack/index.ts
+++ b/packages/surfaces/src/slack/index.ts
@@ -2,6 +2,7 @@ export * from './slack-commands.js';
 export * from './slack-formatter.js';
 export * from './slack-surface.js';
 export * from './plan-conversation.js';
+export * from './planning-draft-doctor.js';
 export * from './thread-session-manager.js';
 export * from './harness-session-driver-select.js';
 export * from './workflow-assistant.js';

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -26,6 +26,8 @@ import {
   type PlanningHostSurface,
 } from '@invoker/planning-core';
 import type { LogFn } from '../surface.js';
+import { createPlanningDraftDoctor } from './planning-draft-doctor.js';
+import type { PlanningDraftDoctor, PlanningDraftDoctorResult } from './planning-draft-doctor.js';
 import {
   buildTrackedChangesRevertedNotice,
   buildUnverifiedNotice,
@@ -72,6 +74,7 @@ const EMPTY_PLANNER_STDERR_TAIL_LIMIT = 500;
 
 export const DEFAULT_PLANNER_RETRY_LIMIT = 2;
 export const DEFAULT_PLANNER_RETRY_BASE_DELAY_MS = 500;
+export const DEFAULT_PLAN_DOCTOR_REPAIR_LIMIT = 2;
 
 // Shared with slack-surface.ts so both planner spawn paths surface the same
 // actionable error when the CLI exits 0 but writes nothing to stdout. The
@@ -169,6 +172,12 @@ export interface PlanConversationConfig {
    * attempt 2, 1000ms before attempt 3, and so on).
    */
   plannerRetryBaseDelayMs?: number;
+  /** Full skill-doctor script used to gate the exact draft before review. */
+  planDoctorScriptPath?: string;
+  /** Test/host injection for the full draft doctor. Takes precedence over planDoctorScriptPath. */
+  draftDoctor?: PlanningDraftDoctor;
+  /** Maximum planner repair turns after doctor rejection. Default: 2 (3 candidates total). */
+  planDoctorRepairLimit?: number;
 }
 
 // ── Confirmation Detection ──────────────────────────────────
@@ -383,7 +392,7 @@ function buildConversationalPlanSystemPrompt(
   });
   const draftingInstructions = draftingAuthorized
     ? `
-The user has explicitly approved drafting. Produce the full Invoker YAML task plan now, using the plan shape from \`skills/plan-to-invoker/SKILL.md\` if you need the exact schema. ${handoffInstructions}`
+The user has explicitly approved drafting. Produce the full Invoker YAML task plan now, using the plan shape from \`skills/plan-to-invoker/SKILL.md\` if you need the exact schema. Never include \`autoFix\` or \`autoFixRetries\` anywhere in plan YAML; retries are configured only in \`~/.invoker/config.json\`. The planning host will run the full plan doctor and will not present the draft until every check passes. ${handoffInstructions}`
     : `
 Drafting is not authorized yet. Do NOT output a \`\`\`yaml code block, do NOT write a draft plan file, and do NOT tell the user the plan can be executed.
 
@@ -491,6 +500,8 @@ export class PlanConversation {
   private onRawPlannerOutput?: RawPlannerOutputHandler;
   private plannerRetryLimit: number;
   private plannerRetryBaseDelayMs: number;
+  private draftDoctor?: PlanningDraftDoctor;
+  private planDoctorRepairLimit: number;
   // Serializes turns on this conversation. Without this, two concurrent
   // sendMessage calls (e.g. two Slack events for the same thread arriving
   // close together) can interleave their per-turn side-channel files
@@ -532,6 +543,9 @@ export class PlanConversation {
     this.onRawPlannerOutput = config.onRawPlannerOutput;
     this.plannerRetryLimit = Math.max(0, config.plannerRetryLimit ?? DEFAULT_PLANNER_RETRY_LIMIT);
     this.plannerRetryBaseDelayMs = Math.max(0, config.plannerRetryBaseDelayMs ?? DEFAULT_PLANNER_RETRY_BASE_DELAY_MS);
+    this.draftDoctor = config.draftDoctor
+      ?? (config.planDoctorScriptPath ? createPlanningDraftDoctor(config.planDoctorScriptPath) : undefined);
+    this.planDoctorRepairLimit = Math.max(0, config.planDoctorRepairLimit ?? DEFAULT_PLAN_DOCTOR_REPAIR_LIMIT);
     this.log = config.log ?? ((src, lvl, msg) => {
       (lvl === 'error' ? console.error : console.log)(`[${src}] ${msg}`);
     });
@@ -642,17 +656,24 @@ export class PlanConversation {
     }
     const fileDraft = this.readPlanDraftFile();
     const inlineDraft = extractYamlPlan(message);
-    const nextDraft = fileDraft && summarizePlanText(fileDraft)
+    let nextDraft = fileDraft && summarizePlanText(fileDraft)
       ? fileDraft
       : inlineDraft;
+    let finalFormatted = formatted;
+    if (nextDraft && this.draftDoctor) {
+      const gated = await this.gateDraftForReview(nextDraft, message, formatted, turn);
+      nextDraft = gated.planText;
+      message = gated.message;
+      finalFormatted = gated.formatted;
+    }
     this._lastTurnDraftPlanText = nextDraft;
     if (nextDraft) this.lastKnownGoodPlanText = nextDraft;
     this._lastTurnPlanIntentSignal = this.mode === 'agent' ? this.readPlanIntentSignalFile() : null;
     if (!nextDraft) {
       message = removeStandaloneSubmitInstruction(message);
     }
-    this._lastTurnReasoning = formatted.reasoning;
-    this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: responseLen=${response.length}, messageLen=${message.length}, reasoningParts=${formatted.reasoning.length}, responsePreview="${message.slice(0, 500).replace(/\n/g, '\\n')}"`);
+    this._lastTurnReasoning = finalFormatted.reasoning;
+    this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: responseLen=${response.length}, messageLen=${message.length}, reasoningParts=${finalFormatted.reasoning.length}, responsePreview="${message.slice(0, 500).replace(/\n/g, '\\n')}"`);
 
     this.messages.push({ role: 'assistant', content: message });
     this.saveState();
@@ -660,6 +681,87 @@ export class PlanConversation {
 
     this.log('plan-conversation', 'info', `[PERF] sendMessage: init=${tInit - t0}ms, buildPrompt=${tPrompt - tInit}ms, cursor=${tCursor - tPrompt}ms, saveState=${tSave - tCursor}ms, total=${tSave - t0}ms`);
     return message;
+  }
+
+  private async gateDraftForReview(
+    initialPlanText: string,
+    initialMessage: string,
+    initialFormatted: ReturnType<typeof formatCodexPlannerStdout>,
+    turn: number,
+  ): Promise<{ planText: string | null; message: string; formatted: ReturnType<typeof formatCodexPlannerStdout> }> {
+    let planText = initialPlanText;
+    let message = initialMessage;
+    let formatted = initialFormatted;
+    let lastResult: PlanningDraftDoctorResult = { ok: false, diagnostics: ['skill-doctor did not run'] };
+
+    for (let candidateNumber = 1; candidateNumber <= this.planDoctorRepairLimit + 1; candidateNumber += 1) {
+      try {
+        lastResult = await this.draftDoctor!(planText);
+      } catch (error) {
+        lastResult = {
+          ok: false,
+          infrastructureError: true,
+          diagnostics: [`skill-doctor could not run: ${error instanceof Error ? error.message : String(error)}`],
+        };
+      }
+      if (lastResult.ok) {
+        this.log('plan-conversation', 'info', `[PLAN_DOCTOR] Candidate ${candidateNumber} passed (turn=${turn})`);
+        return { planText, message, formatted };
+      }
+
+      this.log(
+        'plan-conversation',
+        'warn',
+        `[PLAN_DOCTOR] Candidate ${candidateNumber} rejected (turn=${turn}, infrastructure=${lastResult.infrastructureError === true}): ${lastResult.diagnostics.join(' | ')}`,
+      );
+      this.resetPlanDraftFile();
+      if (lastResult.infrastructureError || candidateNumber > this.planDoctorRepairLimit) break;
+
+      const repairPrompt = this.buildDoctorRepairPrompt(planText, lastResult.diagnostics, candidateNumber);
+      const repairResponse = await this.spawnPlanner(repairPrompt, turn);
+      formatted = formatCodexPlannerStdout(repairResponse);
+      message = formatted.message;
+      const fileDraft = this.readPlanDraftFile();
+      const inlineDraft = extractYamlPlan(message);
+      const repairedDraft = fileDraft && summarizePlanText(fileDraft) ? fileDraft : inlineDraft;
+      if (!repairedDraft) {
+        lastResult = { ok: false, diagnostics: ['Planner repair turn did not produce a complete YAML candidate.'] };
+        break;
+      }
+      planText = repairedDraft;
+    }
+
+    this.resetPlanDraftFile();
+    const heading = lastResult.infrastructureError
+      ? 'Draft not shown: plan validation is unavailable.'
+      : 'Draft not shown: the plan doctor rejected it.';
+    const diagnostics = lastResult.diagnostics.slice(0, 8).map((line) => `- ${line}`).join('\n');
+    return {
+      planText: null,
+      message: `${heading}\n\nNothing was submitted.\n\n${diagnostics}`,
+      formatted,
+    };
+  }
+
+  private buildDoctorRepairPrompt(planText: string, diagnostics: string[], repairNumber: number): string {
+    const path = this.planDraftFilePath();
+    const destination = path
+      ? `Write the complete corrected YAML to \`${path}\` and reply with only a one-or-two-sentence summary.`
+      : 'Return the complete corrected YAML in a ```yaml fenced block.';
+    return [
+      `The host rejected candidate ${repairNumber}; it cannot be shown or submitted.`,
+      'Repair the YAML itself. Do not remove requirements merely to silence the doctor.',
+      'Correct every doctor diagnostic below; the host will run the full doctor again against the replacement.',
+      destination,
+      '',
+      'Doctor diagnostics:',
+      ...diagnostics.slice(0, 40).map((line) => `- ${line}`),
+      '',
+      'Rejected candidate:',
+      '```yaml',
+      planText.trim(),
+      '```',
+    ].join('\n');
   }
 
   async runPlanConversion(): Promise<string> {
@@ -714,12 +816,12 @@ export class PlanConversation {
 
   /** Returns the last complete YAML plan drafted in this conversation, or null. */
   getDraftedPlan(): string | null {
-    // Gate the file draft the same way sendMessage does: a truncated or
-    // incomplete draft file (parses but cannot be summarized) must not shadow
-    // a valid inline plan — that would post a draft with no Approve button.
+    // Only sendMessage may promote a candidate after its configured doctor
+    // passes. Re-reading the sidecar here would bypass that review gate.
+    if (this.draftDoctor) return this._lastTurnDraftPlanText ?? this.lastKnownGoodPlanText;
     const fileDraft = this.readPlanDraftFile();
     if (fileDraft && summarizePlanText(fileDraft)) return fileDraft;
-    return this.extractLastPlanFromMessages() ?? this.lastKnownGoodPlanText;
+    return this._lastTurnDraftPlanText ?? this.extractLastPlanFromMessages() ?? this.lastKnownGoodPlanText;
   }
 
   // The planner writes the full YAML plan here so its chat reply can stay a
@@ -1096,20 +1198,6 @@ function validateExtractedPlanTasks(tasks: unknown, ownerLabel: string): boolean
   return true;
 }
 
-function stripPlannerOnlyFields(plan: Record<string, any>): void {
-  delete plan.autoFix;
-  delete plan.autoFixRetries;
-  for (const task of Array.isArray(plan.tasks) ? plan.tasks : []) {
-    if (!isExtractedPlanRecord(task)) continue;
-    delete task.autoFix;
-    delete task.autoFixRetries;
-  }
-  for (const workflow of Array.isArray(plan.workflows) ? plan.workflows : []) {
-    if (!isExtractedPlanRecord(workflow)) continue;
-    stripPlannerOnlyFields(workflow);
-  }
-}
-
 // ── YAML Extraction ─────────────────────────────────────────
 
 /**
@@ -1166,7 +1254,6 @@ export function extractYamlPlan(text: string): string | null {
       return null;
     }
 
-    stripPlannerOnlyFields(plan);
     return stringifyYaml(plan);
   } catch (err) {
     console.warn(`extractYamlPlan: YAML parse error: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/surfaces/src/slack/planning-draft-doctor.ts
+++ b/packages/surfaces/src/slack/planning-draft-doctor.ts
@@ -1,0 +1,119 @@
+import { execFile } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export interface PlanningDraftDoctorResult {
+  ok: boolean;
+  diagnostics: string[];
+  infrastructureError?: boolean;
+}
+
+export type PlanningDraftDoctor = (planText: string) => Promise<PlanningDraftDoctorResult>;
+
+interface SkillDoctorCheck {
+  stepId?: unknown;
+  status?: unknown;
+  message?: unknown;
+  output?: unknown;
+}
+
+interface SkillDoctorReport {
+  allPassed?: unknown;
+  firstFailedStep?: unknown;
+  checks?: unknown;
+}
+
+const DEFAULT_DOCTOR_TIMEOUT_MS = 120_000;
+const DEFAULT_DOCTOR_MAX_BUFFER_BYTES = 4 * 1024 * 1024;
+
+function runSkillDoctor(
+  scriptPath: string,
+  planPath: string,
+  timeoutMs: number,
+): Promise<{ stdout: string; stderr: string; exitCode: number | null; error?: Error }> {
+  return new Promise((resolve) => {
+    execFile(
+      'bash',
+      [scriptPath, planPath],
+      { timeout: timeoutMs, maxBuffer: DEFAULT_DOCTOR_MAX_BUFFER_BYTES },
+      (error, stdout, stderr) => {
+        const processError = error instanceof Error ? error : undefined;
+        const exitCode = typeof (error as NodeJS.ErrnoException & { code?: unknown } | null)?.code === 'number'
+          ? (error as NodeJS.ErrnoException & { code: number }).code
+          : error ? null : 0;
+        resolve({ stdout, stderr, exitCode, error: processError });
+      },
+    );
+  });
+}
+
+function diagnosticLines(report: SkillDoctorReport, stderr: string): string[] {
+  const checks = Array.isArray(report.checks) ? report.checks as SkillDoctorCheck[] : [];
+  const failed = checks.filter((check) => check.status === 'failed');
+  const diagnostics = failed.flatMap((check) => {
+    const step = typeof check.stepId === 'string' ? check.stepId : 'doctor';
+    const message = typeof check.message === 'string' ? check.message.trim() : '';
+    const output = typeof check.output === 'string' ? check.output.trim() : '';
+    if (!output) return [`${step}: ${message || 'failed'}`];
+    try {
+      const parsed = JSON.parse(output) as unknown;
+      if (Array.isArray(parsed)) {
+        const structured = parsed.flatMap((entry) => {
+          if (typeof entry !== 'object' || entry === null) return [];
+          const candidate = entry as { message?: unknown };
+          return typeof candidate.message === 'string' ? [candidate.message] : [];
+        });
+        if (structured.length > 0) return [`${step}: ${message || 'failed'}`, ...structured];
+      }
+    } catch {
+      // Non-JSON linter output is already human-readable.
+    }
+    return [`${step}: ${message || 'failed'}`, ...output.split(/\r?\n/).slice(0, 40)];
+  });
+  if (diagnostics.length > 0) return diagnostics;
+  const stderrLines = stderr.trim().split(/\r?\n/).filter(Boolean);
+  return stderrLines.length > 0 ? stderrLines.slice(-8) : ['skill-doctor rejected the candidate without diagnostics'];
+}
+
+/** Run the canonical full plan-to-invoker doctor against the exact candidate text. */
+export function createPlanningDraftDoctor(
+  scriptPath: string,
+  options: { timeoutMs?: number } = {},
+): PlanningDraftDoctor {
+  return async (planText) => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'invoker-planning-doctor-'));
+    const planPath = join(tempDir, 'candidate.yaml');
+    try {
+      writeFileSync(planPath, planText, 'utf8');
+      const result = await runSkillDoctor(scriptPath, planPath, options.timeoutMs ?? DEFAULT_DOCTOR_TIMEOUT_MS);
+      let report: SkillDoctorReport;
+      try {
+        report = JSON.parse(result.stdout) as SkillDoctorReport;
+      } catch {
+        return {
+          ok: false,
+          infrastructureError: true,
+          diagnostics: [
+            `skill-doctor did not return JSON (exit ${result.exitCode ?? 'unknown'})`,
+            ...result.stderr.trim().split(/\r?\n/).filter(Boolean).slice(-8),
+          ],
+        };
+      }
+
+      if (result.exitCode === 0 && report.allPassed === true) {
+        return { ok: true, diagnostics: [] };
+      }
+      if (report.allPassed === false) {
+        return { ok: false, diagnostics: diagnosticLines(report, result.stderr) };
+      }
+      return {
+        ok: false,
+        infrastructureError: true,
+        diagnostics: [result.error?.message ?? `skill-doctor exited ${result.exitCode ?? 'without an exit code'}`],
+      };
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  };
+}

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -104,6 +104,8 @@ export interface SlackSurfaceConfig {
   plannerRetryBaseDelayMs?: number;
   /** Opt in to scoping-first conversational planning before YAML drafting. Default: false. */
   conversationalPlanning?: boolean;
+  /** Canonical full skill-doctor script used before exposing review drafts. */
+  planDoctorScriptPath?: string;
 
   // ── Slack-native workflow extensions ──────────────────────
   /** Lobby channel where `@Invoker` starts planning. Defaults to channelId. */
@@ -594,6 +596,7 @@ export class SlackSurface implements Surface {
   private plannerRetryLimit: number;
   private plannerRetryBaseDelayMs: number;
   private conversationalPlanning: boolean;
+  private planDoctorScriptPath?: string;
   /** Minimum spacing between thread message posts to avoid Slack burst limits. */
   private readonly messagePacingMs = 1_100;
   /** Session lifecycle metrics */
@@ -656,6 +659,7 @@ export class SlackSurface implements Surface {
     this.plannerRetryLimit = Math.max(0, config.plannerRetryLimit ?? DEFAULT_PLANNER_RETRY_LIMIT);
     this.plannerRetryBaseDelayMs = Math.max(0, config.plannerRetryBaseDelayMs ?? DEFAULT_PLANNER_RETRY_BASE_DELAY_MS);
     this.conversationalPlanning = config.conversationalPlanning ?? false;
+    this.planDoctorScriptPath = config.planDoctorScriptPath;
     this.lobbyChannelId = config.lobbyChannelId ?? config.channelId;
     this.planningCommandBuilder = config.planningCommandBuilder;
     this.prepareRepoCheckout = config.prepareRepoCheckout;
@@ -691,6 +695,7 @@ export class SlackSurface implements Surface {
         plannerRetryLimit: this.plannerRetryLimit,
         plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
         conversationalPlanning: this.conversationalPlanning,
+        planDoctorScriptPath: this.planDoctorScriptPath,
         onHarnessSessionId: (id, sessionId) => this.persistHarnessSessionId(id.threadTs, sessionId),
       });
     }
@@ -3290,6 +3295,7 @@ ${text}`;
         plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
         conversationalPlanning: this.conversationalPlanning,
         planningSurface: 'slack',
+        planDoctorScriptPath: this.planDoctorScriptPath,
         harnessSessionDriver: opts?.harnessSessionDriver,
         harnessSessionId: opts?.harnessSessionId,
         onHarnessSessionId: (sessionId) => this.persistHarnessSessionId(threadTs, sessionId),
@@ -3390,6 +3396,7 @@ ${text}`;
             plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
             conversationalPlanning: this.conversationalPlanning,
             planningSurface: 'slack',
+            planDoctorScriptPath: this.planDoctorScriptPath,
             ...this.harnessDriverSessionOpts(harness, context ?? {}),
             onHarnessSessionId: (sessionId) => this.persistHarnessSessionId(entry.threadTs, sessionId),
           });

--- a/packages/surfaces/src/slack/thread-session-manager.ts
+++ b/packages/surfaces/src/slack/thread-session-manager.ts
@@ -208,6 +208,8 @@ export interface SessionManagerConfig {
   plannerRetryBaseDelayMs?: number;
   /** Opt in to scoping-first conversational planning before YAML drafting. Default: false. */
   conversationalPlanning?: boolean;
+  /** Canonical full skill-doctor script used before exposing review drafts. */
+  planDoctorScriptPath?: string;
   /** Fired whenever a session establishes or updates its harness session id, so callers can persist it. */
   onHarnessSessionId?: (id: SessionIdentifier, sessionId: string) => void;
 }
@@ -261,6 +263,7 @@ export class SessionManager {
   private readonly plannerRetryLimit?: number;
   private readonly plannerRetryBaseDelayMs?: number;
   private readonly conversationalPlanning: boolean;
+  private readonly planDoctorScriptPath?: string;
   private readonly onHarnessSessionId?: (id: SessionIdentifier, sessionId: string) => void;
 
   constructor(config: SessionManagerConfig) {
@@ -280,6 +283,7 @@ export class SessionManager {
     this.plannerRetryLimit = config.plannerRetryLimit;
     this.plannerRetryBaseDelayMs = config.plannerRetryBaseDelayMs;
     this.conversationalPlanning = config.conversationalPlanning ?? false;
+    this.planDoctorScriptPath = config.planDoctorScriptPath;
     this.onHarnessSessionId = config.onHarnessSessionId;
   }
 
@@ -375,6 +379,7 @@ export class SessionManager {
         plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
         conversationalPlanning: this.conversationalPlanning,
         planningSurface: 'slack',
+        planDoctorScriptPath: this.planDoctorScriptPath,
         harnessSessionDriver: opts?.harnessSessionDriver,
         harnessSessionId: opts?.harnessSessionId,
         onHarnessSessionId: this.onHarnessSessionId ? (sessionId) => this.onHarnessSessionId!(id, sessionId) : undefined,
@@ -414,6 +419,7 @@ export class SessionManager {
         plannerRetryBaseDelayMs: this.plannerRetryBaseDelayMs,
         conversationalPlanning: this.conversationalPlanning,
         planningSurface: 'slack',
+        planDoctorScriptPath: this.planDoctorScriptPath,
         harnessSessionDriver: opts?.harnessSessionDriver,
         harnessSessionId: opts?.harnessSessionId,
         onHarnessSessionId: this.onHarnessSessionId ? (sessionId) => this.onHarnessSessionId!(id, sessionId) : undefined,


### PR DESCRIPTION
## Summary

Routes every YAML candidate through the full plan doctor before shared review state is published.

Doctor failures return diagnostics to the same planner for at most two additional attempts. A third failure leaves prior review state intact.

## Review Claim

The shared surfaces route admits only doctor-passing candidates to review state.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A failed candidate does not replace the last known-good draft, survive as a readable sidecar, or reach later plan processing.

## Slice Rationale

This slice owns the shared doctor adapter, bounded planner loop, state protection, and surfaces routing as one behavioral unit.

## Non-goals

- Change doctor rules.
- Change approval controls.
- Submit plans automatically.

## Architecture

### Before

```mermaid
flowchart LR
    A["Planner candidate"] --> B["Host review state"]
    B --> C["Later plan error"]
```

### After

```mermaid
flowchart LR
    A["Planner candidate"] --> B["Full plan doctor"]
    B -->|"passes"| C["Host review state"]
    B -->|"fails"| D["Same planner"]
    D --> B
    B -->|"third failure"| E["Prior state remains"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces test -- --run src/__tests__/plan-draft-file-activation.test.ts src/__tests__/plan-conversation.test.ts src/__tests__/plan-draft-file.test.ts src/__tests__/thread-session-manager.test.ts src/__tests__/slack-surface-workflows.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e40ba1949`
- Post-revert steps: A YAML candidate may again reach review before the full doctor runs.
- Data migration? No

</details>

Depends-On: #8534
