### PR TITLE
[Planning review parity](8) Document obsolete auto-fix fields

### DIFF
--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -137,6 +137,9 @@ done
 
 # SKILL.md — focused runtime verification + Invoker headless as complementary lane
 must_contain "$SKILL_MD" "## Intended flow (do not skip steps)" "SKILL must document the full flow"
+must_contain "$SKILL_MD" 'Never emit `autoFix` or `autoFixRetries`' "SKILL must forbid obsolete auto-fix YAML fields"
+must_contain "$SKILL_MD" 'configured only with `autoFixRetries` in `~/.invoker/config.json`' "SKILL must direct auto-fix retries to user configuration"
+must_contain "$SKILL_MD" 'must be corrected and re-run through `skill-doctor.sh`; do not present or submit it' "SKILL must require doctor success before review"
 must_contain "$SKILL_MD" "Runtime verification (Phase 1b)" "SKILL must require runtime behavioral verification"
 must_contain "$SKILL_MD" "Invoker headless" "SKILL must mention Invoker headless as a verification lane"
 must_contain "$SKILL_MD" "cheapest deterministic command" "SKILL must prefer focused behavioral proof"

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -71,6 +71,8 @@ Use this mode when invoked by the installed command or MCP prompt.
 
 ## Intended flow (do not skip steps)
 
+**Current auto-fix schema:** Never emit `autoFix` or `autoFixRetries` at the plan, workflow, or task level. Those YAML fields are obsolete. Auto-fix retries are configured only with `autoFixRetries` in `~/.invoker/config.json`. A draft containing either YAML field must be corrected and re-run through `skill-doctor.sh`; do not present or submit it.
+
 1. Discuss scope/risk with the user; before authoring YAML, propose each
    `Safety invariant:` and ask the user to confirm or correct it. If the work
    has no repo URL, do not silently pick or invent one — force an explicit


### PR DESCRIPTION
## Summary

The plan-to-invoker policy explicitly forbids obsolete `autoFix` and `autoFixRetries` YAML fields.

Focused checks keep the field prohibition, config-file direction, and doctor-before-review rule present in the skill.

## Review Claim

Planning guidance prevents the obsolete fields before a YAML candidate is handed to a host.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only skill instruction text and its focused checks change. Runtime behavior is untouched.

## Slice Rationale

The checker behavior lands first; this independent policy slice then teaches planners how to satisfy it.

## Non-goals

- Change doctor behavior.
- Change either planning host.
- Rewrite an existing draft automatically.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-plan-to-invoker-skill.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7c32e3e86`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #8532
