### PR TITLE
[Planning review parity](12) Wire GUI doctor and proof reply

### DIFF
--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1204,6 +1204,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     return Boolean(mainWindow && !mainWindow.isDestroyed());
   };
   const ownerMode = getOwnerMode();
+  const planDoctorScriptPath = join(repoRoot, 'skills', 'plan-to-invoker', 'scripts', 'skill-doctor.sh');
   const workerRuntimeController = getWorkerRuntimeController();
   const workflowIdForTaskArg = actions.workflowIdForTaskArg;
   const workflowIdForTargetArg = actions.workflowIdForTargetArg;
@@ -1311,6 +1312,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   await restorePlanningChatSessions(persistence.listInAppPlanningSessions(), {
     config: invokerConfig,
     workingDir: repoRoot,
+    planDoctorScriptPath,
     sessions: planningChatSessions,
     planningCommandBuilder,
     executionAgentRegistry: agentRegistry,
@@ -1329,6 +1331,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   let testPlanningChatResponse:
     | { planYaml: string; planName: string; reply?: string; delayMs?: number }
     | { throwError: string }
+    | { replyOnly: string }
     | null = null;
 
 
@@ -1340,6 +1343,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     return planFromGoalInApp(args[0] as InAppPlanRequest, {
       config: invokerConfig,
       workingDir: repoRoot,
+      planDoctorScriptPath,
       loadGeneratedPlan: loadGeneratedPlanPreview,
       planningCommandBuilder,
       conversationRepo: planningConversationRepo,
@@ -1349,6 +1353,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     return createPlanningChatSession(request as InAppPlanningCreateSessionRequest | undefined, {
       config: invokerConfig,
       workingDir: repoRoot,
+      planDoctorScriptPath,
       sessions: planningChatSessions,
       planningCommandBuilder,
       executionAgentRegistry: agentRegistry,
@@ -1370,6 +1375,9 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
         if ('throwError' in planningChatResponseOverride) {
           throw new Error(planningChatResponseOverride.throwError);
         }
+        if ('replyOnly' in planningChatResponseOverride) {
+          return planningChatResponseOverride.replyOnly;
+        }
         if (planningChatResponseOverride.delayMs) {
           await new Promise((resolve) => setTimeout(resolve, planningChatResponseOverride.delayMs));
         }
@@ -1379,6 +1387,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     return sendPlanningChatMessage(request as InAppPlanningChatRequest, {
       config: invokerConfig,
       workingDir: repoRoot,
+      planDoctorScriptPath,
       sessions: planningChatSessions,
       planningCommandBuilder,
       executionAgentRegistry: agentRegistry,
@@ -1425,6 +1434,8 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       sessions: planningChatSessions,
       planningSessionStore: ownerMode ? persistence : undefined,
       repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
+      workingDir: repoRoot,
+      planDoctorScriptPath,
     });
   });
   registerGuiMutationHandler('invoker:load-plan', async (planTextArg: unknown) => {


### PR DESCRIPTION
## Summary

Activates the full plan-doctor path for GUI mutation entry points.

The same entry point gains a test-only direct-reply override used by the visual regression above it.

## Review Claim

Every GUI planning entry point supplies the repository doctor path, including restored sessions.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Normal runtime requests still use the real planner; the direct reply override remains behind the existing test API.

## Slice Rationale

The GUI entry-point wiring is isolated from the shared doctor implementation and from its visual evidence.

## Non-goals

- Do not change planner routing behavior.
- Do not change doctor policy.
- Do not add production-facing controls.

## Architecture

### Before

```mermaid
flowchart LR
    A["GUI planning entry"] --> B["Planner options"]
```

### After

```mermaid
flowchart LR
    A["GUI planning entry"] --> B["Repository doctor path"]
    A --> C["Test-only reply override"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- --run src/__tests__/in-app-planner.test.ts -t 'planFromGoal|legacy auto-fix'`
- [x] `pnpm --filter @invoker/app test -- --run src/__tests__/planning-chat-e2e-acceptance.test.ts`
- [x] `pnpm --filter @invoker/app build`

</details>

## Visual Proof

![Doctor rejection remains in discussion with no review action](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-1a9cef/plan-doctor-rejection-no-review.png)

Manually inspected: the planning transcript shows the doctor diagnostic and no review action after the test-only reply is injected.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert fada4a661`
- Post-revert steps: GUI mutation entry points no longer provide the doctor path.
- Data migration? No

</details>

Depends-On: #8538
