### PR TITLE
[Planning review parity](13) Capture doctor rejection review state

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -903,6 +903,38 @@ test.describe('Visual proof capture', () => {
     });
   });
 
+  test('plan doctor rejection stays out of the review UI', async ({ page }) => {
+    const rejectedReply = [
+      'Draft not shown: the plan doctor rejected it.',
+      '',
+      'Nothing was submitted.',
+      '',
+      '- Task "define-terminal-workflow-cleanup-policy" uses "autoFix", which is no longer supported in plan YAML.',
+    ].join('\n');
+    await page.evaluate(async (replyOnly) => {
+      await window.invoker.setTestPlanningChatResponse({ replyOnly } as never);
+    }, rejectedReply);
+
+    await page.getByTestId('sidebar-home').click();
+    await page.getByRole('button', { name: 'Options' }).click();
+    await expect(page.getByRole('heading', { name: 'Planning chat' })).toBeVisible();
+    await page.getByTestId('invoker-terminal-input').fill('Draft the approved plan');
+    await page.getByRole('button', { name: 'Send' }).click();
+
+    const transcript = page.getByTestId('invoker-terminal-transcript');
+    await expect(transcript).toContainText('Draft not shown: the plan doctor rejected it.');
+    await expect(transcript).toContainText('Nothing was submitted.');
+    await expect(transcript).toContainText('uses "autoFix", which is no longer supported');
+    await expect(page.getByRole('button', { name: 'Review draft' })).toHaveCount(0);
+    await expect(page.getByTestId('invoker-terminal-ready-bar')).toHaveCount(0);
+
+    await captureScreenshot(page, 'plan-doctor-rejection-no-review');
+
+    await page.evaluate(async () => {
+      await window.invoker.setTestPlanningChatResponse(null);
+    });
+  });
+
   test('planning context sidebar shows repo bind status', async ({ page }) => {
     await page.getByTestId('sidebar-home').click();
     await page.getByRole('button', { name: 'Options' }).click();


### PR DESCRIPTION
## Summary

Adds the visual regression for the original obsolete-`autoFix` incident.

The scenario records the visible diagnostic and the absence of review actions after the doctor refuses the candidate.

## Review Claim

The original incident now has durable visual proof at the review boundary.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes only browser evidence. It does not alter planning, review, doctor, or submission behavior.

## Slice Rationale

The visual scenario lands after the shared route and its GUI proof hook, so the behavior and evidence remain independently reviewable.

## Non-goals

- Change runtime behavior.
- Change review controls.
- Add another doctor rule.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `CAPTURE_MODE=after pnpm --dir packages/app exec playwright test visual-proof.spec.ts -g 'plan doctor rejection stays out of the review UI'`

</details>

## Visual Proof

![Doctor rejection remains in discussion with no review action](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-1f9eaf/plan-doctor-rejection-no-review.png)

Manually inspected: the planning transcript shows “Draft not shown,” “Nothing was submitted,” and the obsolete `autoFix` diagnostic. Status remains “Still discussing”; no ready banner or “Review draft” button is visible.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert fae3da9ac`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #8535
