### PR TITLE
[Planning review parity](10) Wire Slack doctor path

### DIFF
--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -146,6 +146,7 @@ async function main(): Promise<void> {
     prepareRepoCheckout: createPrepareRepoCheckout(path.join(managerHome, 'planning-clones')),
     defaultBranch: process.env.INVOKER_DEFAULT_BRANCH ?? 'master',
     conversationalPlanning: process.env.INVOKER_SLACK_CONVERSATIONAL_PLANNING !== '0',
+    planDoctorScriptPath: path.join(repoRoot, 'skills', 'plan-to-invoker', 'scripts', 'skill-doctor.sh'),
     repoUrl,
     defaultRepoUrl: repoUrl,
     repoAliases: runtimeConfig.repoAliases,


### PR DESCRIPTION
## Summary

Routes Slack-manager startup through the shared plan doctor by supplying the repository doctor path.

## Review Claim

Slack startup enables the same pre-review doctor route used by the shared planning surface.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The manager supplies one additional planner option; all other Slack startup behavior remains unchanged.

## Slice Rationale

This one-line host wiring stays separate from the shared surfaces implementation and app wiring.

## Non-goals

- Change shared doctor behavior.
- Change Slack approval controls.
- Add another planning entry point.

## Architecture

### Before

```mermaid
flowchart LR
    A["Slack manager"] --> B["Planning surface"]
```

### After

```mermaid
flowchart LR
    A["Slack manager"] --> B["Repository doctor path"]
    B --> C["Planning surface"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/slack-manager test`
- [x] `pnpm --filter @invoker/slack-manager build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1ca7bb40e`
- Post-revert steps: Slack startup no longer supplies the doctor path.
- Data migration? No

</details>

Depends-On: #8533
