### PR TITLE
[Planning review parity](11) Route app drafts through doctor

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -1041,7 +1041,7 @@ tasks:
     });
   });
 
-  it('submits planner drafts after stripping legacy auto-fix fields', async () => {
+  it('does not stage or submit planner drafts rejected for legacy auto-fix fields', async () => {
     const legacyPlan = `Here is the plan.
 
 \`\`\`yaml
@@ -1065,8 +1065,11 @@ tasks:
       loadGeneratedPlan: vi.fn(),
       sessions,
       planningCommandBuilder,
+      planDoctorScriptPath: join(process.cwd(), '../../skills/plan-to-invoker/scripts/skill-doctor.sh'),
     });
     if (!sent.ok) throw new Error(sent.error);
+    expect(sent.draftPlanAvailable).toBe(false);
+    expect(sent.reply).toContain('Draft not shown: the plan doctor rejected it.');
     const loadGeneratedPlan = vi.fn().mockResolvedValue({ planName: 'Legacy AutoFix Draft', workflowId: 'wf-1' });
 
     await expect(submitPlanningChatDraft({
@@ -1074,12 +1077,8 @@ tasks:
     }, {
       sessions,
       loadGeneratedPlan,
-    })).resolves.toEqual({ ok: true, planName: 'Legacy AutoFix Draft', workflowId: 'wf-1' });
-
-    const submittedPlan = loadGeneratedPlan.mock.calls[0]?.[0] as string;
-    expect(submittedPlan).toContain('id: make-selected-lists-scroll');
-    expect(submittedPlan).not.toContain('autoFix');
-    expect(submittedPlan).not.toContain('autoFixRetries');
+    })).resolves.toEqual({ ok: false, error: NO_COMPLETE_PLAN_DRAFTED_ERROR });
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
   });
 
   it('submits stacked drafts as stacked workflows', async () => {

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -91,6 +91,8 @@ export interface InAppPlannerDeps {
   logger?: Logger;
   plannerReplyOverride?: (formattedMessage: string) => Promise<string>;
   onRawPlannerOutput?: (event: InAppPlanningStreamEvent) => void;
+  /** Canonical full skill-doctor script. Kept separate from target worktrees. */
+  planDoctorScriptPath?: string;
 }
 
 export interface InAppPlanningChatSession {
@@ -602,7 +604,7 @@ export function isDraftingAuthorizedByTurn(message: string, messagesBeforeTurn: 
 
 function planConversationConfig(
   preset: HarnessPreset,
-  deps: Pick<InAppPlannerDeps, 'config' | 'workingDir' | 'planningCommandBuilder' | 'executionAgentRegistry' | 'conversationRepo' | 'logger' | 'onRawPlannerOutput'> & { mcpConfigPath?: string },
+  deps: Pick<InAppPlannerDeps, 'config' | 'workingDir' | 'planningCommandBuilder' | 'executionAgentRegistry' | 'conversationRepo' | 'logger' | 'onRawPlannerOutput' | 'planDoctorScriptPath'> & { mcpConfigPath?: string },
   threadTs: string,
   selectHarnessSessionDriver: PlannerSurfacesModule['selectHarnessSessionDriver'],
   options: { conversationalPlanning?: boolean; draftingPreauthorized?: boolean } = {},
@@ -629,6 +631,7 @@ function planConversationConfig(
     }),
     plannerRetryLimit: deps.config.plannerRetryLimit,
     plannerRetryBaseDelayMs: deps.config.plannerRetryBaseDelayMs,
+    planDoctorScriptPath: deps.planDoctorScriptPath,
     onRawPlannerOutput: deps.onRawPlannerOutput
       ? (chunk) => deps.onRawPlannerOutput?.({ sessionId: threadTs, chunk })
       : undefined,
@@ -685,7 +688,12 @@ async function createSession(
     };
   }
   const conversationDeps = worktreeBinding
-    ? { ...deps, workingDir: worktreeBinding.worktreePath, mcpConfigPath: planningMcpConfigPath(worktreeBinding.worktreePath) }
+    ? {
+        ...deps,
+        planDoctorScriptPath: deps.planDoctorScriptPath,
+        workingDir: worktreeBinding.worktreePath,
+        mcpConfigPath: planningMcpConfigPath(worktreeBinding.worktreePath),
+      }
     : deps;
 
   const session: InAppPlanningChatSession = {
@@ -753,7 +761,7 @@ export async function planFromGoal(
     const { PlanConversation, extractYamlPlan, selectHarnessSessionDriver } = await loadPlannerSurfaces();
     const conversation = new PlanConversation(planConversationConfig(preset, deps, randomUUID(), selectHarnessSessionDriver, { conversationalPlanning: true, draftingPreauthorized: true }));
     const plannerOutput = await conversation.sendMessage(goal);
-    const planText = extractYamlPlan(plannerOutput);
+    const planText = conversation.lastTurnDraftPlanText ?? extractYamlPlan(plannerOutput);
     if (!planText) {
       return { ok: false, error: 'Planner did not return a valid YAML plan.' };
     }
@@ -1107,6 +1115,8 @@ export async function rebindPlanningChatRepo(
     sessions: InAppPlanningChatSessions;
     planningSessionStore?: InAppPlanningSessionStore;
     repoPool?: PlanningRepoPool;
+    workingDir?: string;
+    planDoctorScriptPath?: string;
   },
 ): Promise<InAppPlanningRebindRepoResponse> {
   const rawRequest = request as Partial<InAppPlanningRebindRepoRequest> | null | undefined;
@@ -1171,6 +1181,7 @@ export async function rebindPlanningChatRepo(
     const { PlanConversation, selectHarnessSessionDriver } = await loadPlannerSurfaces();
     const conversationDeps = {
       ...deps,
+      planDoctorScriptPath: deps.planDoctorScriptPath,
       workingDir: provisioned.worktreePath,
       mcpConfigPath: planningMcpConfigPath(provisioned.worktreePath),
     };
@@ -1294,7 +1305,12 @@ export async function restorePlanningChatSessions(
       }
     }
     const conversationDeps = restoredWorktreePath
-      ? { ...deps, workingDir: restoredWorktreePath, mcpConfigPath: planningMcpConfigPath(restoredWorktreePath) }
+      ? {
+          ...deps,
+          planDoctorScriptPath: deps.planDoctorScriptPath,
+          workingDir: restoredWorktreePath,
+          mcpConfigPath: planningMcpConfigPath(restoredWorktreePath),
+        }
       : deps;
 
     const conversation = new PlanConversation(planConversationConfig(preset, conversationDeps, record.id, selectHarnessSessionDriver, { conversationalPlanning: true }));

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -559,6 +559,7 @@ process.on('unhandledRejection', (reason) => {
 });
 
 const repoRoot = resolveRepoRoot(__dirname, { fallback: process.resourcesPath });
+const planDoctorScriptPath = path.join(repoRoot, 'skills', 'plan-to-invoker', 'scripts', 'skill-doctor.sh');
 
 // Load secrets from ~/.invoker/.env (canonical) then the repo .env BEFORE any startup guard
 // reads process.env. dotenv never overrides vars already set in the real environment.
@@ -1286,6 +1287,7 @@ function startHeadlessMode(): void {
       await restorePlanningChatSessions(persistence.listInAppPlanningSessions(), {
         config: invokerConfig,
         workingDir: repoRoot,
+        planDoctorScriptPath,
         sessions: planningChatSessions,
         planningCommandBuilder,
         executionAgentRegistry: agentRegistry,
@@ -1299,6 +1301,7 @@ function startHeadlessMode(): void {
       let testPlanningChatResponse:
         | { planYaml: string; planName: string; reply?: string; delayMs?: number }
         | { throwError: string }
+        | { replyOnly: string }
         | null = null;
 
       const executeStandaloneGuiMutation = async (payload: GuiMutationPayload): Promise<unknown> => {
@@ -1334,6 +1337,7 @@ function startHeadlessMode(): void {
             return planFromGoalInApp(payload.args[0] as InAppPlanRequest, {
               config: invokerConfig,
               workingDir: repoRoot,
+              planDoctorScriptPath,
               loadGeneratedPlan,
               planningCommandBuilder,
               conversationRepo: planningConversationRepo,
@@ -1343,6 +1347,7 @@ function startHeadlessMode(): void {
             return createPlanningChatSession(payload.args[0] as InAppPlanningCreateSessionRequest | undefined, {
               config: invokerConfig,
               workingDir: repoRoot,
+              planDoctorScriptPath,
               sessions: planningChatSessions,
               planningCommandBuilder,
               executionAgentRegistry: agentRegistry,
@@ -1363,6 +1368,9 @@ function startHeadlessMode(): void {
                 if ('throwError' in planningChatResponseOverride) {
                   throw new Error(planningChatResponseOverride.throwError);
                 }
+                if ('replyOnly' in planningChatResponseOverride) {
+                  return planningChatResponseOverride.replyOnly;
+                }
                 if (planningChatResponseOverride.delayMs) {
                   await new Promise((resolve) => setTimeout(resolve, planningChatResponseOverride.delayMs));
                 }
@@ -1372,6 +1380,7 @@ function startHeadlessMode(): void {
             return sendPlanningChatMessage(payload.args[0] as InAppPlanningChatRequest, {
               config: invokerConfig,
               workingDir: repoRoot,
+              planDoctorScriptPath,
               sessions: planningChatSessions,
               planningCommandBuilder,
               executionAgentRegistry: agentRegistry,
@@ -1408,6 +1417,8 @@ function startHeadlessMode(): void {
               sessions: planningChatSessions,
               planningSessionStore: readOnlyMode ? undefined : persistence,
               repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
+              workingDir: repoRoot,
+              planDoctorScriptPath,
             });
           }
           case 'invoker:planning-chat-delete': {


### PR DESCRIPTION
## Summary

Routes app planner creation and restoration through the repository doctor path in main-process entry points.

## Review Claim

App planning sessions use the shared pre-review doctor route in both fresh and restored flows.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The app supplies one additional planner option; existing session lifecycle and approval behavior remain unchanged.

## Slice Rationale

App host routing is isolated from Slack-manager wiring and the later GUI entry-point slice.

## Non-goals

- Change shared doctor behavior.
- Change review controls.
- Add test-only IPC behavior.

## Architecture

### Before

```mermaid
flowchart LR
    A["App planner entry"] --> B["Planning session"]
```

### After

```mermaid
flowchart LR
    A["App planner entry"] --> B["Repository doctor path"]
    B --> C["Planning session"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- --run src/__tests__/in-app-planner.test.ts -t 'planFromGoal|legacy auto-fix'`
- [x] `pnpm --filter @invoker/app test -- --run src/__tests__/planning-chat-e2e-acceptance.test.ts`
- [x] `pnpm --filter @invoker/app build`

</details>

## Visual Proof

![Doctor rejection remains in discussion with no review action](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-392d84/plan-doctor-rejection-no-review.png)

Manually inspected: the planning transcript shows the doctor diagnostic and no ready banner or “Review draft” button.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 34be56fd4`
- Post-revert steps: Main-process app entry points no longer supply the doctor path.
- Data migration? No

</details>

Depends-On: #8537
