### PR TITLE
[Switch planning-chat harness and model per turn](1) Point visual-proof capture at the E2E spec

### DIFF
--- a/scripts/ui-visual-proof.sh
+++ b/scripts/ui-visual-proof.sh
@@ -48,7 +48,7 @@ set -euo pipefail
 #     ├── task-panel.png
 #     └── walkthrough.webm
 
-SPEC="visual-proof.spec.ts"
+SPEC="e2e/visual-proof.spec.ts"
 OUTPUT_DIR="packages/app/e2e/visual-proof"
 RESULTS_DIR="packages/app/e2e/test-results"
 SUBCOMMAND=""


### PR DESCRIPTION
## Summary

The visual-proof script now points Playwright at the E2E spec path it resolves from the app package.

This restores the repository command surface needed by the planning-chat proof slices.

## Review Claim

The visual-proof capture script invokes the repository's actual Playwright E2E spec path.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice changes only the capture script's default spec path; product code and test expectations remain unchanged.

## Slice Rationale

The command-path correction is isolated from proof and product changes so its tooling policy is independently reviewable.

## Non-goals

This slice does not change planning chat, Playwright assertions, capture destinations, or publication behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash -n scripts/ui-visual-proof.sh`
- [x] `cd packages/app && CAPTURE_MODE=after npx playwright test e2e/visual-proof.spec.ts --grep 'planning chat composer'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1f8f53ac0385a119fe4a1c441bd1b31c24d26d09`
- Post-revert steps: None
- Data migration? No

</details>
