### PR TITLE
[Switch planning-chat harness and model per turn](2) Add the planning-chat before-state fixture

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -976,6 +976,26 @@ test.describe('Visual proof capture', () => {
     await expect(rows).toHaveCount(2);
   });
 
+  test('planning chat composer — combined Agent picker before picker split', async ({ page }) => {
+    await page.getByTestId('sidebar-home').click();
+    await expect(page.getByRole('heading', { name: 'Planning chat' })).toBeVisible();
+
+    const input = page.getByTestId('invoker-terminal-input');
+    await expect(input).toBeVisible({ timeout: 10000 });
+    await input.fill('Draft a plan for the chat picker visual proof fixture');
+
+    await page.getByRole('button', { name: 'Options' }).click();
+
+    const harnessSelect = page.getByTestId('invoker-terminal-harness');
+    await expect(harnessSelect).toBeVisible({ timeout: 10000 });
+    await expect(harnessSelect.locator('option')).not.toHaveCount(0);
+    await expect.poll(async () => harnessSelect.inputValue()).not.toBe('');
+    await expect(page.getByTestId('invoker-terminal-confirmation-mode')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Send' })).toBeVisible();
+
+    await captureScreenshot(page, 'planning-chat-composer-combined-agent-picker-before');
+  });
+
   test('terminal planning captures long transcript follow surface', async ({ page }) => {
     const longTranscriptPlan = {
       ...TERMINAL_PLANNED_PLAN,

--- a/scripts/ui-visual-proof.sh
+++ b/scripts/ui-visual-proof.sh
@@ -48,7 +48,7 @@ set -euo pipefail
 #     ├── task-panel.png
 #     └── walkthrough.webm
 
-SPEC="visual-proof.spec.ts"
+SPEC="e2e/visual-proof.spec.ts"
 OUTPUT_DIR="packages/app/e2e/visual-proof"
 RESULTS_DIR="packages/app/e2e/test-results"
 SUBCOMMAND=""


### PR DESCRIPTION
## Summary

Planning chat now has a focused visual-proof case for the composer controls.

The case captures the existing combined Agent selector before product UI activation.

## Review Claim

The visual-proof suite deterministically opens planning chat in the existing single-agent-picker state and captures the exact composer surface that will change.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes only E2E proof coverage; production planning-chat behavior and styling remain unchanged.

## Slice Rationale

The old surface is established before UI activation so reviewers receive a genuine before-state artifact from the dependency-ordered stack.

## Non-goals

This slice does not implement separate controls, change production behavior, or broaden the E2E harness.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && CAPTURE_MODE=before npx playwright test e2e/visual-proof.spec.ts --grep 'planning chat composer'`

</details>

## Visual Proof

Before-state planning composer with the single combined Agent selector set to Cursor + Claude:

![Planning chat before state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-5f261b/planning-chat-picker-before.png)

Manually inspected: the Planning chat composer shows one Agent selector with Cursor + Claude and a separate Review selector set to Ask first.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a7d8407e777fbd9b4ca53c88fc688642ad9469e1`
- Post-revert steps: None
- Data migration? No

</details>
