### PR TITLE
[Switch planning-chat harness and model per turn](3) Split planning-chat harness and model controls

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
-import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, PlanningConfirmationMode, ReviewGateQueryResponse, RuntimeStatus, StartReadyFreshBaseScope, StartReadyRequest, StartReadyResult, TerminalOutputEvent, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
+import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, PlanningConfirmationMode, PlanningPresetOption, ReviewGateQueryResponse, RuntimeStatus, StartReadyFreshBaseScope, StartReadyRequest, StartReadyResult, TerminalOutputEvent, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus, WorkerActionSummary, WorkerLogEntry, WorkerStatusEntry } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
 import { reportUiNavigation } from './lib/report-ui-navigation.js';
@@ -1104,7 +1104,7 @@ export function App() {
   const nextPlanningSessionLocalIdRef = useRef(2);
   const nextTerminalLineIdRef = useRef(1);
   const [planningStreamBySessionId, setPlanningStreamBySessionId] = useState<Record<string, PlanningStreamState>>({});
-  const [planningPresetOptions, setPlanningPresetOptions] = useState<Array<{ key: string; label: string; isDefault?: boolean; defaultConfirmationMode?: PlanningConfirmationMode }>>([]);
+  const [planningPresetOptions, setPlanningPresetOptions] = useState<PlanningPresetOption[]>([]);
   const [selectedPlanningPresetKey, setSelectedPlanningPresetKey] = useState('');
   const [selectedPlanningConfirmationMode, setSelectedPlanningConfirmationMode] = useState<PlanningConfirmationMode>('require');
   const [keptPlanningDraftSessionIds, setKeptPlanningDraftSessionIds] = useState<Set<string>>(new Set());
@@ -1262,17 +1262,19 @@ export function App() {
           ? options.map((option) => ({
               key: option.key,
               label: option.label,
+              tool: option.tool,
+              model: option.model,
               isDefault: option.isDefault,
               defaultConfirmationMode: option.defaultConfirmationMode,
             }))
-          : [{ key: 'codex', label: 'Codex', isDefault: true, defaultConfirmationMode: 'require' as const }];
+          : [{ key: 'codex', label: 'Codex', tool: 'codex', isDefault: true, defaultConfirmationMode: 'require' as const }];
         setPlanningPresetOptions(resolved);
         setSelectedPlanningPresetKey(resolved.find((option) => option.isDefault)?.key ?? resolved[0]?.key ?? 'codex');
         setSelectedPlanningConfirmationMode(resolved.find((option) => option.isDefault)?.defaultConfirmationMode ?? resolved[0]?.defaultConfirmationMode ?? 'require');
       })
       .catch((err) => {
         console.error('Failed to load planning presets', err);
-        setPlanningPresetOptions([{ key: 'codex', label: 'Codex', isDefault: true, defaultConfirmationMode: 'require' }]);
+        setPlanningPresetOptions([{ key: 'codex', label: 'Codex', tool: 'codex', isDefault: true, defaultConfirmationMode: 'require' }]);
         setSelectedPlanningPresetKey('codex');
         setSelectedPlanningConfirmationMode('require');
       });

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -121,7 +121,7 @@ const getViewportMock = (ReactFlowModule as unknown as { __getViewportMock: Mock
 
 // Dynamic imports are required so modules see the hoisted @xyflow/react mock.
 const { App } = await import('../App.js');
-const { InvokerTerminal } = await import('../components/InvokerTerminal.js');
+const { InvokerTerminal, buildPlanningHarnessChoices } = await import('../components/InvokerTerminal.js');
 
 const COMPONENT_INPUT_HANDLER_BUDGET_MS = 16;
 
@@ -310,16 +310,104 @@ describe('Invoker terminal (component)', () => {
       busy: false,
       value: '',
       selectedPresetKey: 'codex',
-      presetOptions: [{ key: 'codex', label: 'Codex' }],
+      presetOptions: [{ key: 'codex', label: 'Codex', tool: 'codex' }],
+      selectedConfirmationMode: 'require' as const,
       draftPlanAvailable: false,
       onValueChange: vi.fn(),
       onSubmit: vi.fn(),
       onSubmitDraft: vi.fn(),
       onPresetChange: vi.fn(),
+      onConfirmationModeChange: vi.fn(),
       onExpand: vi.fn(),
       ...overrides,
     };
   }
+
+  it('groups flat configured planning presets into harness and model choices', () => {
+    expect(buildPlanningHarnessChoices([
+      { key: 'codex', label: 'Codex', tool: 'codex' },
+      { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude' },
+      { key: 'omp+codex', label: 'Codex via OMP', tool: 'omp', model: 'codex' },
+      { key: 'omp', label: 'OMP', tool: 'omp' },
+    ])).toEqual([
+      {
+        tool: 'codex',
+        label: 'Codex',
+        directPreset: { key: 'codex', label: 'Codex', tool: 'codex' },
+        modelPresets: [],
+      },
+      {
+        tool: 'omp',
+        label: 'OMP',
+        directPreset: { key: 'omp', label: 'OMP', tool: 'omp' },
+        modelPresets: [
+          { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude' },
+          { key: 'omp+codex', label: 'Codex via OMP', tool: 'omp', model: 'codex' },
+        ],
+      },
+    ]);
+  });
+
+  it('renders separate harness and model selectors while emitting configured preset keys', () => {
+    const onPresetChange = vi.fn();
+    render(<InvokerTerminal
+      {...terminalProps({
+        selectedPresetKey: 'omp+claude',
+        presetOptions: [
+          { key: 'codex', label: 'Codex', tool: 'codex' },
+          { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude' },
+          { key: 'omp+codex', label: 'Codex via OMP', tool: 'omp', model: 'codex' },
+          { key: 'omp', label: 'OMP', tool: 'omp' },
+        ],
+        onPresetChange,
+      })}
+    />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Options' }));
+
+    expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('omp');
+    const modelSelect = screen.getByTestId('invoker-terminal-model');
+    expect(modelSelect).toHaveValue('omp+claude');
+    expect(within(modelSelect).getByRole('option', { name: 'Default' })).toHaveValue('omp');
+    expect(within(modelSelect).getByRole('option', { name: 'Claude' })).toHaveValue('omp+claude');
+    expect(within(modelSelect).getByRole('option', { name: 'Codex' })).toHaveValue('omp+codex');
+
+    fireEvent.change(modelSelect, { target: { value: 'omp+codex' } });
+    expect(onPresetChange).toHaveBeenLastCalledWith('omp+codex');
+  });
+
+  it('hides the model selector for direct harness presets without configured models', () => {
+    render(<InvokerTerminal {...terminalProps()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Options' }));
+
+    expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+    expect(screen.queryByTestId('invoker-terminal-model')).not.toBeInTheDocument();
+  });
+
+  it('preserves a still-valid model when switching harnesses', () => {
+    const onPresetChange = vi.fn();
+    render(<InvokerTerminal
+      {...terminalProps({
+        selectedPresetKey: 'omp+claude',
+        presetOptions: [
+          { key: 'omp+claude', label: 'Claude via OMP', tool: 'omp', model: 'claude' },
+          { key: 'omp+codex', label: 'Codex via OMP', tool: 'omp', model: 'codex' },
+          { key: 'cursor+claude', label: 'Claude via Cursor', tool: 'cursor', model: 'claude' },
+          { key: 'cursor+codex', label: 'Codex via Cursor', tool: 'cursor', model: 'codex' },
+          { key: 'codex', label: 'Codex', tool: 'codex' },
+        ],
+        onPresetChange,
+      })}
+    />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Options' }));
+    fireEvent.change(screen.getByTestId('invoker-terminal-harness'), { target: { value: 'cursor' } });
+    expect(onPresetChange).toHaveBeenLastCalledWith('cursor+claude');
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-harness'), { target: { value: 'codex' } });
+    expect(onPresetChange).toHaveBeenLastCalledWith('codex');
+  });
 
   it('shows the submitted-plan bar running state while the workflow is still running', () => {
     render(<InvokerTerminal
@@ -984,12 +1072,14 @@ describe('Invoker terminal (component)', () => {
       busy: false,
       value: '',
       selectedPresetKey: 'codex',
-      presetOptions: [{ key: 'codex', label: 'Codex' }],
+      presetOptions: [{ key: 'codex', label: 'Codex', tool: 'codex' }],
+      selectedConfirmationMode: 'require' as const,
       draftPlanAvailable: false,
       onValueChange: vi.fn(),
       onSubmit: vi.fn(),
       onSubmitDraft: vi.fn(),
       onPresetChange: vi.fn(),
+      onConfirmationModeChange: vi.fn(),
       onExpand: vi.fn(),
     };
     const { rerender } = render(<InvokerTerminal {...props} />);
@@ -1067,12 +1157,14 @@ describe('Invoker terminal (component)', () => {
           busy={false}
           value={value}
           selectedPresetKey="codex"
-          presetOptions={[{ key: 'codex', label: 'Codex' }]}
+          presetOptions={[{ key: 'codex', label: 'Codex', tool: 'codex' }]}
+          selectedConfirmationMode="require"
           draftPlanAvailable={false}
           onValueChange={setValue}
           onSubmit={vi.fn()}
           onSubmitDraft={vi.fn()}
           onPresetChange={vi.fn()}
+          onConfirmationModeChange={vi.fn()}
           onExpand={vi.fn()}
         />
       );
@@ -1479,7 +1571,9 @@ describe('Invoker terminal (component)', () => {
     render(<App />);
     await openPlanningTerminal();
 
-    fireEvent.change(screen.getByTestId('invoker-terminal-harness'), { target: { value: 'omp+claude' } });
+    fireEvent.change(screen.getByTestId('invoker-terminal-harness'), { target: { value: 'omp' } });
+    await waitFor(() => expect(screen.getByTestId('invoker-terminal-model')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('invoker-terminal-model'), { target: { value: 'omp+claude' } });
     submitPlanningText('draft a plan');
 
     await waitFor(() => {

--- a/packages/ui/src/__tests__/planning-terminal-preset-switch-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-preset-switch-repro.test.tsx
@@ -124,6 +124,10 @@ describe('planning terminal preset ownership repro', () => {
     await openPlanningTerminal();
 
     fireEvent.change(screen.getByTestId('invoker-terminal-harness'), {
+      target: { value: 'omp' },
+    });
+    await waitFor(() => expect(screen.getByTestId('invoker-terminal-model')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('invoker-terminal-model'), {
       target: { value: 'omp+claude' },
     });
     fireEvent.click(screen.getByRole('tab', { name: 'Tmux' }));
@@ -135,6 +139,51 @@ describe('planning terminal preset ownership repro', () => {
         confirmationMode: 'require',
       });
       expect(mock.api.planningTerminalOpen).toHaveBeenCalledWith('tmux-created-with-claude');
+    });
+  });
+
+  it('sends a changed model preset on an existing chat without replacing the conversation', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'existing-chat',
+          title: 'Existing chat',
+          status: 'still_discussing',
+          presetKey: 'codex',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          updatedAt: '2026-07-26T00:00:00.000Z',
+        }),
+      ],
+    }));
+    mock.api.planningChatSend = vi.fn(async (request: any) => ({
+      ok: true,
+      sessionId: request.sessionId,
+      reply: 'Reply from the selected model.',
+      draftPlanAvailable: false,
+    })) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-harness'), {
+      target: { value: 'omp' },
+    });
+    await waitFor(() => expect(screen.getByTestId('invoker-terminal-model')).toBeInTheDocument());
+    fireEvent.change(screen.getByTestId('invoker-terminal-model'), {
+      target: { value: 'omp+claude' },
+    });
+    submitPlanningText('continue with a different model');
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        sessionId: 'existing-chat',
+        message: 'continue with a different model',
+        presetKey: 'omp+claude',
+        confirmationMode: 'require',
+      });
     });
   });
 });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -20,9 +20,66 @@ export interface InvokerTerminalPlanningStream {
   status: 'streaming' | 'failed';
 }
 
-interface PlanningPresetOptionView {
+export interface PlanningPresetOptionView {
   key: string;
   label: string;
+  tool: string;
+  model?: string;
+}
+
+export interface PlanningHarnessChoice {
+  tool: string;
+  label: string;
+  directPreset?: PlanningPresetOptionView;
+  modelPresets: PlanningPresetOptionView[];
+}
+
+function titleCaseIdentifier(value: string): string {
+  return value
+    .split(/[-_\s/]+/)
+    .filter(Boolean)
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(' ');
+}
+
+function formatPlanningHarnessLabel(tool: string, options: PlanningPresetOptionView[]): string {
+  const directPreset = options.find((option) => option.tool === tool && !option.model);
+  return directPreset?.label ?? titleCaseIdentifier(tool);
+}
+
+function formatPlanningModelLabel(model: string): string {
+  return titleCaseIdentifier(model);
+}
+
+export function buildPlanningHarnessChoices(options: PlanningPresetOptionView[]): PlanningHarnessChoice[] {
+  const byTool = new Map<string, PlanningPresetOptionView[]>();
+  for (const option of options) {
+    const existing = byTool.get(option.tool) ?? [];
+    existing.push(option);
+    byTool.set(option.tool, existing);
+  }
+
+  return Array.from(byTool.entries()).map(([tool, toolOptions]) => ({
+    tool,
+    label: formatPlanningHarnessLabel(tool, toolOptions),
+    directPreset: toolOptions.find((option) => !option.model),
+    modelPresets: toolOptions.filter((option) => Boolean(option.model)),
+  }));
+}
+
+function findPresetOption(options: PlanningPresetOptionView[], presetKey: string): PlanningPresetOptionView | undefined {
+  return options.find((option) => option.key === presetKey);
+}
+
+function resolvePresetForHarness(
+  harness: PlanningHarnessChoice,
+  preferredModel: string | undefined,
+): PlanningPresetOptionView | undefined {
+  if (preferredModel) {
+    const matchingModel = harness.modelPresets.find((option) => option.model === preferredModel);
+    if (matchingModel) return matchingModel;
+  }
+  return harness.directPreset ?? harness.modelPresets[0];
 }
 
 const TRANSCRIPT_BOTTOM_TOLERANCE_PX = 32;
@@ -613,6 +670,33 @@ export function InvokerTerminal({
   const composerDisabledCursorClass = busy || readOnly ? 'disabled:cursor-not-allowed' : '';
   const sendButtonDisabled = busy || readOnly || !value.trim();
   const sendButtonDisabledCursorClass = 'disabled:cursor-not-allowed';
+  const harnessChoices = useMemo(() => buildPlanningHarnessChoices(presetOptions), [presetOptions]);
+  const selectedPreset = useMemo(
+    () => findPresetOption(presetOptions, selectedPresetKey) ?? presetOptions[0],
+    [presetOptions, selectedPresetKey],
+  );
+  const selectedHarness = useMemo(
+    () => harnessChoices.find((choice) => choice.tool === selectedPreset?.tool) ?? harnessChoices[0],
+    [harnessChoices, selectedPreset?.tool],
+  );
+  const selectedHarnessValue = selectedHarness?.tool ?? '';
+  const modelSelectOptions = selectedHarness
+    ? [
+        ...(selectedHarness.directPreset ? [selectedHarness.directPreset] : []),
+        ...selectedHarness.modelPresets,
+      ]
+    : [];
+  const showModelSelect = Boolean(selectedHarness && selectedHarness.modelPresets.length > 0);
+  const selectedModelPresetKey = selectedPreset && modelSelectOptions.some((option) => option.key === selectedPreset.key)
+    ? selectedPreset.key
+    : modelSelectOptions[0]?.key ?? '';
+
+  const handleHarnessChange = useCallback((event: ChangeEvent<HTMLSelectElement>): void => {
+    const nextHarness = harnessChoices.find((choice) => choice.tool === event.target.value);
+    if (!nextHarness) return;
+    const nextPreset = resolvePresetForHarness(nextHarness, selectedPreset?.model);
+    if (nextPreset) onPresetChange(nextPreset.key);
+  }, [harnessChoices, onPresetChange, selectedPreset?.model]);
 
   const handleValueChange = (event: ChangeEvent<HTMLTextAreaElement>): void => {
     const startedAt = nowMs();
@@ -911,19 +995,37 @@ export function InvokerTerminal({
                   {showComposerOptions && (
                     <div className="ml-3 flex flex-wrap items-center gap-3">
                       <label className="text-xs text-muted-foreground">
-                        Agent
+                        Harness
                         <select
                           data-testid="invoker-terminal-harness"
-                          value={selectedPresetKey}
-                          onChange={(event) => onPresetChange(event.target.value)}
+                          value={selectedHarnessValue}
+                          onChange={handleHarnessChange}
                           disabled={readOnly}
                           className="ml-2 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none hover:border-border-strong focus:border-ring"
                         >
-                          {presetOptions.map((option) => (
-                            <option key={option.key} value={option.key}>{option.label}</option>
+                          {harnessChoices.map((option) => (
+                            <option key={option.tool} value={option.tool}>{option.label}</option>
                           ))}
                         </select>
                       </label>
+                      {showModelSelect && (
+                        <label className="text-xs text-muted-foreground">
+                          Model
+                          <select
+                            data-testid="invoker-terminal-model"
+                            value={selectedModelPresetKey}
+                            onChange={(event) => onPresetChange(event.target.value)}
+                            disabled={readOnly}
+                            className="ml-2 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none hover:border-border-strong focus:border-ring"
+                          >
+                            {modelSelectOptions.map((option) => (
+                              <option key={option.key} value={option.key}>
+                                {option.model ? formatPlanningModelLabel(option.model) : 'Default'}
+                              </option>
+                            ))}
+                          </select>
+                        </label>
+                      )}
                       <label className="text-xs text-muted-foreground">
                         Review
                         <select


### PR DESCRIPTION
## Summary

Planning chat now presents harness and supported-model choices as separate controls.

Each valid selection still maps to an existing configured preset key sent with the next message.

## Review Claim

Planning chat presents separate harness and supported-model selectors, and the chosen valid pair is sent with the next message.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Every selectable pair maps to an existing configured planning-chat preset; direct harnesses without model choices remain usable, and task-execution agent configuration is untouched.

## Slice Rationale

This activates one user-facing surface on top of the independently reviewable before-state fixture.

## Non-goals

This slice does not change task-execution agents, preset configuration shape, unrelated composer controls, or guarded behavior `dag-surface-background-click-noop`.

## Architecture

### Before

```mermaid
graph TD
    A["Configured preset list"] --> B["One combined Agent selector"]
    B --> C["Preset key sent with the next message"]
```

### After

```mermaid
graph TD
    A["Configured preset list"] --> B["Harness choices"]
    A --> C["Supported models for the selected harness"]
    B --> D["Existing configured preset key"]
    C --> D
    D --> E["Preset key sent with the next message"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx src/__tests__/planning-terminal-preset-switch-repro.test.tsx`
- [x] `pnpm check:types`

</details>

## Visual Proof

Animated comparison: the composer changes from one combined Agent selector to distinct Harness and Model selectors.

[Planning chat picker before/after animation](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-5b70bc/planning-chat-picker-before-after.webm)

Before: one combined Agent selector set to Cursor + Claude.

![Planning chat picker before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-5b70bc/planning-chat-picker-before.png)

After: separate Harness and Model selectors set to OMP and Claude.

![Planning chat picker after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-5b70bc/planning-chat-picker-after.png)

Manually inspected: the before image and first animation state show one Agent selector set to Cursor + Claude; the after image and second state show distinct Harness and Model selectors set to OMP and Claude.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 440196ccbc4f0b807fcc2c0f43bcddb4e9dadc84`
- Post-revert steps: None
- Data migration? No

</details>
