### PR TITLE
[Switch planning-chat harness and model per turn](4) Update the picker visual proof for the active controls

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -976,7 +976,7 @@ test.describe('Visual proof capture', () => {
     await expect(rows).toHaveCount(2);
   });
 
-  test('planning chat composer — combined Agent picker before picker split', async ({ page }) => {
+  test('planning chat composer — split harness and model picker', async ({ page }) => {
     await page.getByTestId('sidebar-home').click();
     await expect(page.getByRole('heading', { name: 'Planning chat' })).toBeVisible();
 
@@ -990,6 +990,10 @@ test.describe('Visual proof capture', () => {
     await expect(harnessSelect).toBeVisible({ timeout: 10000 });
     await expect(harnessSelect.locator('option')).not.toHaveCount(0);
     await expect.poll(async () => harnessSelect.inputValue()).not.toBe('');
+    await harnessSelect.selectOption('omp');
+    const modelSelect = page.getByTestId('invoker-terminal-model');
+    await expect(modelSelect).toBeVisible({ timeout: 10000 });
+    await expect(modelSelect.locator('option')).not.toHaveCount(0);
     await expect(page.getByTestId('invoker-terminal-confirmation-mode')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Send' })).toBeVisible();
 


### PR DESCRIPTION
## Summary

The planning-chat visual fixture now drives the active Harness and Model selectors.

It captures the same composer surface after the UI activation slice.

## Review Claim

The visual-proof suite captures planning chat with distinct Harness and supported-model controls in the active UI.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes only E2E proof assertions and capture setup; production planning-chat behavior remains unchanged.

## Slice Rationale

The after-state proof follows UI activation so artifact generation cannot be mistaken for product behavior.

## Non-goals

This slice does not change product code, preset mapping, or task-execution configuration.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && CAPTURE_MODE=after npx playwright test e2e/visual-proof.spec.ts --grep 'planning chat composer'`

</details>

## Visual Proof

Animated comparison: the composer changes from one combined Agent selector to distinct Harness and Model selectors.

[Planning chat picker before/after animation](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-1353be/planning-chat-picker-before-after.webm)

Before: one combined Agent selector set to Cursor + Claude.

![Planning chat picker before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-1353be/planning-chat-picker-before.png)

After: separate Harness and Model selectors set to OMP and Claude.

![Planning chat picker after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-1353be/planning-chat-picker-after.png)

Manually inspected: the before image and first animation state show one Agent selector set to Cursor + Claude; the after image and second state show distinct Harness and Model selectors set to OMP and Claude.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8c94c16e05b4d14eabda64fe6037612d88ca254d`
- Post-revert steps: None
- Data migration? No

</details>


