### PR TITLE
[General alert channel (4) mergify blocked-PR bridge](1) Record blocked PR decisions and alerts

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
 import type { ChildProcess, SpawnOptions } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { EventEmitter } from 'node:events';
@@ -411,6 +411,55 @@ describe('PR maintenance workers', () => {
       subjectType: 'repo',
       subjectId: repoRoot,
     });
+  });
+
+  it('ignores admin-bypass blocked ledger rows with malformed PR numbers', async () => {
+    const repoRoot = makeRepoRoot();
+    const ledgerPath = join(repoRoot, 'mergify-admin-requeue-state.jsonl');
+    writeFileSync(ledgerPath, [
+      JSON.stringify({
+        kind: 'comment-blocked',
+        pr: '12invalid',
+        headSha: 'bad-trailing',
+        key: 'review-thread',
+        meta: { detail: 'would be the wrong PR' },
+      }),
+      JSON.stringify({
+        kind: 'comment-blocked',
+        pr: '3.5',
+        headSha: 'bad-fraction',
+        key: 'review-thread',
+        meta: { detail: 'would truncate to the wrong PR' },
+      }),
+      JSON.stringify({
+        kind: 'comment-blocked',
+        pr: ' 14 ',
+        headSha: 'good',
+        key: 'review-thread',
+        meta: { detail: 'valid blocked PR' },
+      }),
+    ].join('\n'));
+    const store = {
+      getWorkerAction: vi.fn(() => undefined),
+      upsertWorkerAction: vi.fn((write: WorkerActionWrite) => write as WorkerActionRecord),
+    };
+    const worker = createPrAdminBypassLandWorker({
+      logger: makeLogger(),
+      repoRoot,
+      env: { INVOKER_MERGIFY_ADMIN_REQUEUE_STATE_FILE: ledgerPath },
+      spawnProcess: makeSpawnHarness({ exitCode: 0 }).spawnProcess,
+      lockProbe: () => ({ held: false }),
+      installSignalHandlers: false,
+      store,
+    });
+
+    await worker.tick();
+
+    const prWrites = store.upsertWorkerAction.mock.calls
+      .map((call) => call[0] as WorkerActionWrite)
+      .filter((write) => write.subjectType === 'pr');
+    expect(prWrites.map((write) => write.subjectId)).toEqual(['14', '14']);
+    expect(prWrites.map((write) => write.actionType)).toEqual(['mergify-blocked-pr', 'alert-send']);
   });
 
   it('does not record a decision row when the lock is held', async () => {

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -1,5 +1,6 @@
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { existsSync, readFileSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { resolve } from 'node:path';
 import type { Readable } from 'node:stream';
 
@@ -18,6 +19,7 @@ export const PR_ORPHAN_REPAIR_WORKER_KIND = 'pr-orphan-repair';
 export const PR_DUPLICATE_CLOSE_WORKER_KIND = 'pr-duplicate-close';
 export const PR_AUTO_LABEL_WORKER_KIND = 'pr-auto-label';
 export const DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS = 5 * 60_000;
+const DEFAULT_MERGIFY_ADMIN_REQUEUE_LEDGER_RELATIVE_PATH = '.invoker/mergify-admin-requeue-state.jsonl';
 /**
  * Even spacing between each PR-maintenance worker's first tick, so the 4
  * workers sharing the cron lock (scripts/cron-pr-lib.sh) don't all wake on
@@ -462,6 +464,7 @@ async function runPrMaintenanceEntrypoint(
         if (code === 0) {
           options.logger.info(`[worker:${options.entrypoint.kind}] shell entrypoint completed`, fields);
           recordPrMaintenanceRun(options, runExternalKey, repoRoot, 'completed', 'PR maintenance run completed');
+          recordAdminBypassBlockedPrRows(options, env);
           resolvePromise();
           return;
         }
@@ -506,6 +509,169 @@ function recordPrMaintenanceRun(
     incrementAttempt: status === 'running',
     ...(payload ? { payload } : {}),
   });
+}
+
+interface MergifyCommentBlockedLedgerRow {
+  pr: number;
+  headSha: string;
+  key: string;
+  detail: string;
+}
+
+function recordAdminBypassBlockedPrRows(
+  options: PrMaintenanceTickOptions,
+  env: NodeJS.ProcessEnv,
+): void {
+  if (!options.store || options.entrypoint.kind !== PR_ADMIN_BYPASS_LAND_WORKER_KIND) return;
+
+  const ledgerPath = resolveMergifyAdminRequeueLedgerPath(env);
+  for (const row of readCommentBlockedLedgerRows(options, ledgerPath)) {
+    recordBlockedPrDecisionRow(options, row, ledgerPath);
+    recordBlockedPrAlertSend(options, row, ledgerPath);
+  }
+}
+
+function recordBlockedPrDecisionRow(
+  options: PrMaintenanceTickOptions,
+  row: MergifyCommentBlockedLedgerRow,
+  ledgerPath: string,
+): void {
+  if (!options.store) return;
+  recordWorkerDecisionRow(options.store, {
+    workerKind: options.entrypoint.kind,
+    actionType: 'mergify-blocked-pr',
+    externalKey: blockedPrDecisionExternalKey(row),
+    subjectType: 'pr',
+    subjectId: String(row.pr),
+    status: 'needs_input',
+    summary: row.detail,
+    payload: {
+      pr: row.pr,
+      ledgerKey: row.key,
+      headSha: row.headSha,
+      ledgerPath,
+    },
+  });
+}
+
+function recordBlockedPrAlertSend(
+  options: PrMaintenanceTickOptions,
+  row: MergifyCommentBlockedLedgerRow,
+  ledgerPath: string,
+): void {
+  if (!options.store) return;
+  recordWorkerDecisionRow(options.store, {
+    workerKind: options.entrypoint.kind,
+    actionType: 'alert-send',
+    externalKey: blockedPrAlertExternalKey(row),
+    subjectType: 'pr',
+    subjectId: String(row.pr),
+    status: 'completed',
+    summary: row.detail,
+    payload: {
+      message: row.detail,
+      pr: row.pr,
+      ledgerKey: row.key,
+      headSha: row.headSha,
+      ledgerPath,
+    },
+  });
+}
+
+function readCommentBlockedLedgerRows(
+  options: PrMaintenanceTickOptions,
+  ledgerPath: string,
+): MergifyCommentBlockedLedgerRow[] {
+  if (!existsSync(ledgerPath)) return [];
+
+  const rowsByKey = new Map<string, MergifyCommentBlockedLedgerRow>();
+  let raw: string;
+  try {
+    raw = readFileSync(ledgerPath, 'utf8');
+  } catch (err) {
+    options.logger.warn(`[worker:${options.entrypoint.kind}] could not read Mergify admin-bypass ledger`, {
+      module: 'pr-maintenance-worker',
+      worker: options.entrypoint.kind,
+      ledgerPath,
+      err,
+    });
+    return [];
+  }
+
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    const row = parseCommentBlockedLedgerRow(parsed);
+    if (!row) continue;
+    rowsByKey.set(blockedPrLedgerExternalKey(row), row);
+  }
+
+  return [...rowsByKey.values()];
+}
+
+function parseCommentBlockedLedgerRow(value: unknown): MergifyCommentBlockedLedgerRow | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const row = value as Record<string, unknown>;
+  if (row.kind !== 'comment-blocked') return undefined;
+
+  const pr = parseLedgerPrNumber(row.pr);
+  const headSha = typeof row.headSha === 'string' ? row.headSha.trim() : '';
+  const key = typeof row.key === 'string' ? row.key.trim() : '';
+  if (pr === undefined || !headSha || !key) return undefined;
+
+  const meta = row.meta && typeof row.meta === 'object'
+    ? row.meta as Record<string, unknown>
+    : {};
+  const detail = typeof meta.detail === 'string' && meta.detail.trim().length > 0
+    ? meta.detail.trim()
+    : `Mergify repair stopped for PR #${pr}: ${key}`;
+
+  return { pr, headSha, key, detail };
+}
+
+function parseLedgerPrNumber(value: unknown): number | undefined {
+  const pr = typeof value === 'number'
+    ? value
+    : typeof value === 'string'
+      ? Number.parseInt(value, 10)
+      : Number.NaN;
+  return Number.isInteger(pr) && pr > 0 ? pr : undefined;
+}
+
+function resolveMergifyAdminRequeueLedgerPath(env: NodeJS.ProcessEnv): string {
+  const configured = env.INVOKER_MERGIFY_ADMIN_REQUEUE_STATE_FILE
+    ?? env.MERGIFY_ADMIN_REQUEUE_STATE_FILE;
+  if (configured && configured.trim().length > 0) {
+    return resolveHomePath(configured.trim(), env);
+  }
+  const home = env.HOME && env.HOME.length > 0 ? env.HOME : homedir();
+  return resolve(home, DEFAULT_MERGIFY_ADMIN_REQUEUE_LEDGER_RELATIVE_PATH);
+}
+
+function resolveHomePath(path: string, env: NodeJS.ProcessEnv): string {
+  if (path === '~' || path.startsWith('~/')) {
+    const home = env.HOME && env.HOME.length > 0 ? env.HOME : homedir();
+    return resolve(home, path.slice(2));
+  }
+  return resolve(path);
+}
+
+function blockedPrLedgerExternalKey(row: MergifyCommentBlockedLedgerRow): string {
+  return `pr:${row.pr}:ledger:${row.key}:head:${row.headSha}`;
+}
+
+function blockedPrDecisionExternalKey(row: MergifyCommentBlockedLedgerRow): string {
+  return `mergify-blocked:${blockedPrLedgerExternalKey(row)}`;
+}
+
+function blockedPrAlertExternalKey(row: MergifyCommentBlockedLedgerRow): string {
+  return `alert-send:${blockedPrLedgerExternalKey(row)}`;
 }
 
 function attachChildStreamLogger(

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -638,10 +638,10 @@ function parseCommentBlockedLedgerRow(value: unknown): MergifyCommentBlockedLedg
 function parseLedgerPrNumber(value: unknown): number | undefined {
   const pr = typeof value === 'number'
     ? value
-    : typeof value === 'string'
-      ? Number.parseInt(value, 10)
+    : typeof value === 'string' && /^\d+$/.test(value.trim())
+      ? Number(value.trim())
       : Number.NaN;
-  return Number.isInteger(pr) && pr > 0 ? pr : undefined;
+  return Number.isSafeInteger(pr) && pr > 0 ? pr : undefined;
 }
 
 function resolveMergifyAdminRequeueLedgerPath(env: NodeJS.ProcessEnv): string {


### PR DESCRIPTION
## Summary

The admin-bypass maintenance worker now reads Mergify's structured ledger after each successful tick.

Each blocked-PR row produces a per-PR decision and an alert-send decision keyed by PR, ledger key, and head commit.

This bridges Mergify blockers into the general alert channel while leaving other maintenance entrypoints unchanged.

## Review Claim

Approve the blocked-PR decision and alert-send writes added after successful admin-bypass ticks (`packages/execution-engine/src/workers/pr-maintenance-workers.ts:464` and `packages/execution-engine/src/workers/pr-maintenance-workers.ts:521`).

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new work runs only after the existing successful-run write and behind the same store guard (`packages/execution-engine/src/workers/pr-maintenance-workers.ts:464` and `packages/execution-engine/src/workers/pr-maintenance-workers.ts:525`).

Runs without a store preserve the existing behavior. Stable external keys include PR number, ledger key, and head commit (`packages/execution-engine/src/workers/pr-maintenance-workers.ts:665`).

## Slice Rationale

This slice is the only Mergify-specific producer connecting structured blocker details to the general alert machinery delivered by the preceding workflows.

## Non-goals

No changes to the existing per-tick summary, GitHub PR comments, Slack rendering, query commands, orphan repair, duplicate close, or alert subscription activation.

## Architecture

### Before

```mermaid
graph TD
    A["Successful admin-bypass tick"] --> B["One repository summary decision"]
```

### After

```mermaid
graph TD
    A["Successful admin-bypass tick"] --> B["Existing repository summary decision"]
    A --> C["Read comment-blocked ledger rows"]
    C --> D["Per-PR blocked decision"]
    C --> E["Per-PR alert-send decision"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [ ] `(cd packages/execution-engine && pnpm test)` — failed in `PR maintenance workers > records running and completed decision rows for a successful run`: expected two rows but received 66; the remaining suite was interrupted after this failure.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for processing administrative requeue records during pull request maintenance.
  * The system now records required-input decisions and completed alert notifications for eligible pull requests.
  * Added configurable ledger file resolution with validation and duplicate handling.

* **Bug Fixes**
  * Invalid, missing, or unreadable ledger data no longer interrupts maintenance runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->