### PR TITLE
[Strengthen prove-it investigation evidence](1) Require executable investigation evidence

### DIFF
--- a/scripts/test-prove-it-skill.sh
+++ b/scripts/test-prove-it-skill.sh
@@ -20,6 +20,10 @@ must_contain() {
 
 must_contain "do not assert something is fixed, working, passing, merged, or running" \
   "prove-it skill must state the core no-unverified-claim rule in its description"
+must_contain "investigating, diagnosing, debugging, proving, or explaining what happened or why for any problem or situation" \
+  "prove-it skill metadata must load for broad problem and situation investigations"
+must_contain "investigate, diagnose, debug, prove, explain what happened, explain why something happened" \
+  "prove-it skill must name the generalized investigation trigger phrases"
 must_contain "actually opened the exact screenshot or video yourself" \
   "prove-it skill must require actually opening visual proof media before claiming it"
 must_contain "An automated DOM assertion, a test passing, or a file existing at the expected path is not a substitute for looking" \
@@ -28,10 +32,38 @@ must_contain "run the exact query command fresh in this turn and cite its real o
   "prove-it skill must require a fresh query for live-system claims"
 must_contain "Never restate a count or status from earlier in the conversation as if it were still current" \
   "prove-it skill must forbid restating stale status as current"
+must_contain "first restate the literal reported behavior and resolve the current target being investigated" \
+  "prove-it skill must require restating the literal behavior and current target before causal explanation"
+must_contain "author and execute a task-specific repro that visibly fails against that current target before explaining why" \
+  "prove-it skill must require an executable failing repro before explaining why"
+must_contain "isolate the suspected cause with a controlled comparison in the actual failing path" \
+  "prove-it skill must require controlled cause isolation"
 must_contain "A hypothesis that has not been directly observed is a guess" \
   "prove-it skill must require root-cause claims to be directly observed, not guessed"
+must_contain "rerun the same repro that failed before the fix and show the real passing output" \
+  "prove-it skill must require the same repro to pass after a fix"
+must_contain "All unproven causal hypotheses must be prefixed with \`UNVERIFIED:\`" \
+  "prove-it skill must label unproven causal hypotheses"
 must_contain "write \`UNVERIFIED:\` immediately before the claim" \
   "prove-it skill must require the UNVERIFIED prefix when evidence is missing"
+must_contain "Proxy proof:" \
+  "prove-it skill must include a generalized proxy-proof example"
+must_contain "Stale state:" \
+  "prove-it skill must include a generalized stale-state example"
+must_contain "Wrong target:" \
+  "prove-it skill must include a generalized wrong-target example"
+must_contain "Broken repro:" \
+  "prove-it skill must include a generalized broken-repro example"
+must_contain "Premature theory:" \
+  "prove-it skill must include a generalized premature-theory example"
+must_contain "Scope drift:" \
+  "prove-it skill must include a generalized scope-drift example"
+must_contain "Assertion mismatch:" \
+  "prove-it skill must include a generalized assertion-mismatch example"
+must_contain "Visual mismatch:" \
+  "prove-it skill must include a generalized visual-mismatch example"
+must_contain "Live-state mismatch:" \
+  "prove-it skill must include a generalized live-state-mismatch example"
 must_contain "rejects a \`## Visual Proof\` section that has" \
   "prove-it skill must document the mechanical validate-pr-body.mjs gate"
 

--- a/skills/prove-it/SKILL.md
+++ b/skills/prove-it/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: prove-it
 description: >
-  Shared evidence rule for every claim about code, UI, or live Invoker state:
+  Shared evidence rule for investigating, diagnosing, debugging, proving, or explaining what happened or why for any problem or situation:
   do not assert something is fixed, working, passing, merged, or running
-  unless you personally observed it this turn and can show what you saw.
+  unless you personally observed it this turn and can show what you saw; do not
+  assert it was caused by X until a repro and controlled isolation prove that
+  cause.
 ---
 
 # prove-it
@@ -12,17 +14,43 @@ Referenced by `make-pr`, `visual-proof`, `land-stack`, and `invoker-ops`. One ru
 
 ## Why this exists
 
-Claiming something is fixed, working, or merged without actually checking it live is a recurring failure mode in this project: a "fixed" PR claim that turned out to still show the bug in its own proof video, visual proof screenshots reused from a stale build, and status reports ("it's merged," "N tasks are running," "autofix kicked in") repeated from memory instead of a fresh query. In every case a cheaper, easier-to-check signal stood in for the thing that was actually asked about, and nobody looked at the real evidence before stating the claim as settled.
+Claiming something is fixed, working, merged, or understood without actually checking it live is a recurring failure mode in this project: a "fixed" PR claim that turned out to still show the bug in its own proof video, visual proof screenshots reused from a stale build, status reports ("it's merged," "N tasks are running," "autofix kicked in") repeated from memory instead of a fresh query, and correction replies that explained a cause before reproducing the literal failure. In every case a cheaper, easier-to-check signal stood in for the thing that was actually asked about, and nobody looked at the real evidence before stating the claim as settled.
 
 ## The rule
 
-Before writing any claim of the form "this is fixed," "this now works," "this shows X," "this is merged," "N tasks are running," or similar — in a PR body, a chat reply, or a status report — you must have, in the SAME turn:
+This skill applies at the start of any investigation into a problem or situation, including requests to investigate, diagnose, debug, prove, explain what happened, explain why something happened, or determine why a behavior occurred. Begin read-only unless the user requested changes.
+
+Before writing any claim of the form "this is fixed," "this now works," "this shows X," "this is merged," "N tasks are running," "the cause is X," or similar — in a PR body, a chat reply, or a status report — you must have, in the SAME turn:
 
 1. **For a visual/UI claim:** actually opened the exact screenshot or video yourself (`Read` the image, or extract and `Read` video frames) and can state precisely what you saw. An automated DOM assertion, a test passing, or a file existing at the expected path is not a substitute for looking. Never trust a proxy signal ("the panel is visible") as evidence for a different claim ("the camera did not move") — check the literal thing that was reported broken.
 2. **For a live-system claim** (CI status, merge status, task/workflow counts, "it's running," "it's fixed," "autofix kicked in"): run the exact query command fresh in this turn and cite its real output. Never restate a count or status from earlier in the conversation as if it were still current — state drifts while you work.
-3. **For a "root cause" claim:** you instrumented or traced the actual failing behavior (logging, a MutationObserver, a debugger, a repro script) rather than pattern-matching to a bug that looked similar. A hypothesis that has not been directly observed is a guess, and must be stated as one.
+3. **For a problem or situation investigation:** first restate the literal reported behavior and resolve the current target being investigated. Then author and execute a task-specific repro that visibly fails against that current target before explaining why. The repro must exercise the reported behavior itself, not a proxy such as "a related test passed," "the file exists," "the panel rendered," or "the logs looked similar."
+4. **For a "root cause" claim:** isolate the suspected cause with a controlled comparison in the actual failing path (for example logging, a MutationObserver, a debugger, a repro script, a one-variable change, or another task-specific control) rather than pattern-matching to a bug that looked similar. A hypothesis that has not been directly observed is a guess, and must be stated as one.
+5. **For a fix/resolution claim:** rerun the same repro that failed before the fix and show the real passing output. A different test, a broader suite, or a screenshot of a nearby state can supplement the repro but cannot replace it.
 
-If you have not done one of the above, either do it now or write `UNVERIFIED:` immediately before the claim — never state it as settled fact.
+If you have not done one of the above, either do it now or write `UNVERIFIED:` immediately before the claim — never state it as settled fact. All unproven causal hypotheses must be prefixed with `UNVERIFIED:`.
+
+## Investigation sequence
+
+When asked what happened, why it happened, or to investigate/diagnose/debug a problem:
+
+1. Restate the literal reported behavior and the current target.
+2. Build and run an executable repro against that target; show the real failing output.
+3. Isolate the proposed cause with a controlled comparison; show the real output.
+4. Only then explain the cause. If isolation is missing, prefix the explanation with `UNVERIFIED:`.
+5. If you changed anything, rerun the same repro and show the real passing output before claiming resolution.
+
+## Examples this rule is meant to stop
+
+- Proxy proof: do not cite "a test passed" when the reported failure was visual or behavioral and was never exercised.
+- Stale state: do not report an old merge, CI, task, or workflow status without a fresh live query.
+- Wrong target: do not reproduce against a sample, another branch, another PR, or another deployment unless you label the result as not the current target.
+- Broken repro: do not explain a failure from a repro that did not execute, did not fail, or failed for setup reasons.
+- Premature theory: do not name a cause before an executable failing repro and controlled isolation support it.
+- Scope drift: do not mutate systems, broaden product behavior, or start fixing during a read-only investigation unless the user requested changes.
+- Assertion mismatch: do not claim the proof shows one thing when the output only demonstrates a weaker or different fact.
+- Visual mismatch: do not rely on DOM, file, or path checks instead of opening the exact screenshot or video and stating what you saw.
+- Live-state mismatch: do not use remembered counts or statuses as current evidence for running, merged, queued, or failed work.
 
 ## Where this is enforced mechanically
 


### PR DESCRIPTION
## Summary

The shared prove-it skill now activates when an agent investigates, diagnoses, debugs, or explains a problem or situation.

Causal explanations now require an executable reproduction of the literal failure and a controlled comparison that isolates the proposed cause.

Focused contract checks cover nine generalized regression classes without storing private transcript contents.

## Review Claim

The shared prove-it policy applies at the start of problem or situation investigations and prevents causal explanations until a current-target executable repro proves the literal failure and isolates the proposed cause.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Existing visual-inspection and fresh-live-query requirements remain mandatory, and investigation remains read-only unless changes were requested. A causal explanation or root-cause claim requires an executable repro that fails against the literal reported behavior on the current target and isolates the proposed cause; after a fix, the same repro must pass. If reproduction is impossible, the agent may report raw observations but must label every causal hypothesis `UNVERIFIED:`.

## Slice Rationale

The skill instructions and their directly coupled rule assertions form one policy change. Separating them would leave either unenforced wording or checks without the policy they protect.

## Non-goals

- No product-code or UI changes.
- No live-system mutations or bundled transcript archive.
- No manual edits to installed skill copies.
- No change to PR-body mechanical validation.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-prove-it-skill.sh` — `OK: prove-it skill contract checks passed`
- [x] `python3 /Users/edbertchan/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/prove-it` — `Skill is valid!`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert bcb89ba966d237b262257175e5f8ee721c3bca60`
- Post-revert steps: Re-run the focused contract and skill-structure validation.
- Data migration? No

</details>
