### PR TITLE
[General alert channel (5) Slack + headless query](1) Add alert history query

### DIFF
--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -19,7 +19,7 @@ import {
   type WorkerStatusSnapshot,
 } from '@invoker/contracts';
 import { AUTO_FIX_WORKER_KIND, createWorkerRegistry, registerBuiltinWorkers, type AgentRegistry, type WorkerRuntimeDependencies } from '@invoker/execution-engine';
-import type { CostAttributionAttempt } from '@invoker/data-store';
+import type { CostAttributionAttempt, WorkerActionRecord } from '@invoker/data-store';
 import type { CostGroupDimension } from './cost-rollup.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
@@ -53,7 +53,7 @@ import {
  * per request, so concurrent delegated queries never cross output.
  */
 const queryOutputSink = new AsyncLocalStorage<(chunk: string) => void>();
-const QUERY_SUBCOMMANDS = 'workflows, workflow, tasks, task, task-output, container-id, queue, review-gate, action-graph, audit, session, workers, worker-actions, worker-decisions, cost, cost-events, costs, ui-perf, stats, execution-leases, mutation-locks';
+const QUERY_SUBCOMMANDS = 'workflows, workflow, tasks, task, task-output, container-id, queue, review-gate, action-graph, audit, session, workers, worker-actions, worker-decisions, alert-history, cost, cost-events, costs, ui-perf, stats, execution-leases, mutation-locks';
 const QUERY_SUBCOMMAND_USAGE = QUERY_SUBCOMMANDS.replaceAll(', ', '|');
 
 function writeOut(chunk: string): void {
@@ -71,6 +71,30 @@ export type HeadlessQueryDeps = Pick<
   HeadlessDeps,
   'orchestrator' | 'persistence' | 'executionAgentRegistry' | 'invokerConfig' | 'getUiPerfStats' | 'resetUiPerfStats'
 >;
+
+function hasStringProp(value: unknown, key: string): boolean {
+  return Boolean(value && typeof value === 'object' && typeof (value as Record<string, unknown>)[key] === 'string');
+}
+
+function isAlertWorkerAction(action: WorkerActionRecord): boolean {
+  const searchable = [
+    action.actionType,
+    action.subjectType,
+    action.subjectId,
+    action.externalKey,
+  ].join(' ').toLowerCase();
+  if (searchable.includes('alert')) return true;
+  const payload = action.payload;
+  return hasStringProp(payload, 'alertKey')
+    || hasStringProp(payload, 'alertSource')
+    || (hasStringProp(payload, 'severity') && (hasStringProp(payload, 'subject') || hasStringProp(payload, 'message')));
+}
+
+export function listAlertHistoryRows(
+  persistence: Pick<HeadlessQueryDeps['persistence'], 'listWorkerActions'>,
+): WorkerActionRecord[] {
+  return persistence.listWorkerActions().filter(isAlertWorkerAction);
+}
 
 export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Promise<void> {
   const subCommand = args[0];
@@ -339,6 +363,16 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
         case 'json': writeOut(formatAsJson(response.actions) + '\n'); break;
         case 'jsonl': writeOut(formatAsJsonl(response.actions) + '\n'); break;
         default: writeOut(formatWorkerDecisions(response.actions) + '\n'); break;
+      }
+      break;
+    }
+    case 'alert-history': {
+      const alerts = listAlertHistoryRows(deps.persistence);
+      switch (flags.output) {
+        case 'label': writeOut(formatAsLabel(alerts) + '\n'); break;
+        case 'json': writeOut(formatAsJson(alerts.map(serializeWorkerAction)) + '\n'); break;
+        case 'jsonl': writeOut(formatAsJsonl(alerts.map(serializeWorkerAction)) + '\n'); break;
+        default: writeOut(formatWorkerActions(alerts) + '\n'); break;
       }
       break;
     }


### PR DESCRIPTION
## Summary

Depends on the mergify-bridge workflow's merge.

Adds `query alert-history` beside the existing worker queries.

The command filters existing worker-action rows for alert markers and renders the neighboring label, JSON, JSONL, and default formats.

Nothing in this slice writes a row.

## Review Claim

Approve the standalone `alert-history` query and its alert-row filter.

No inference: `packages/app/src/headless-query-list.ts:75` and `packages/app/src/headless-query-list.ts:369` show the filter and command branch.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The command is a new switch case; existing command cases retain their current branches and output paths.

The filter reads existing worker-action rows and returns a filtered array; it performs no mutation.

No inference: `packages/app/src/headless-query-list.ts:93` shows the read-only filter and `packages/app/src/headless-query-list.ts:369` shows the isolated switch branch.

## Slice Rationale

This slice owns the standalone command surface. Owner-process routing and Slack delivery have separate review claims and repo-enforced review units.

## Non-goals

- No owner IPC route.
- No Slack rendering or delivery.
- No new producer or persistence table.
- No change to existing command output.

## Architecture

### Before

```mermaid
graph TD
    A["Worker-action rows"] --> B["Existing worker query commands"]
```

### After

```mermaid
graph TD
    A["Worker-action rows"] --> B["Filter rows carrying alert markers"]
    B --> C["query alert-history output"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `cd packages/app && pnpm test` — 198 test files passed; 1,952 tests passed and 3 skipped.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>
