### PR TITLE
[General alert channel (5) Slack + headless query](2) Route owner alert history reads

### DIFF
--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -19,7 +19,7 @@ import {
   type WorkerStatusSnapshot,
 } from '@invoker/contracts';
 import { AUTO_FIX_WORKER_KIND, createWorkerRegistry, registerBuiltinWorkers, type AgentRegistry, type WorkerRuntimeDependencies } from '@invoker/execution-engine';
-import type { CostAttributionAttempt } from '@invoker/data-store';
+import type { CostAttributionAttempt, WorkerActionRecord } from '@invoker/data-store';
 import type { CostGroupDimension } from './cost-rollup.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
@@ -53,7 +53,7 @@ import {
  * per request, so concurrent delegated queries never cross output.
  */
 const queryOutputSink = new AsyncLocalStorage<(chunk: string) => void>();
-const QUERY_SUBCOMMANDS = 'workflows, workflow, tasks, task, task-output, container-id, queue, review-gate, action-graph, audit, session, workers, worker-actions, worker-decisions, cost, cost-events, costs, ui-perf, stats, execution-leases, mutation-locks';
+const QUERY_SUBCOMMANDS = 'workflows, workflow, tasks, task, task-output, container-id, queue, review-gate, action-graph, audit, session, workers, worker-actions, worker-decisions, alert-history, cost, cost-events, costs, ui-perf, stats, execution-leases, mutation-locks';
 const QUERY_SUBCOMMAND_USAGE = QUERY_SUBCOMMANDS.replaceAll(', ', '|');
 
 function writeOut(chunk: string): void {
@@ -71,6 +71,30 @@ export type HeadlessQueryDeps = Pick<
   HeadlessDeps,
   'orchestrator' | 'persistence' | 'executionAgentRegistry' | 'invokerConfig' | 'getUiPerfStats' | 'resetUiPerfStats'
 >;
+
+function hasStringProp(value: unknown, key: string): boolean {
+  return Boolean(value && typeof value === 'object' && typeof (value as Record<string, unknown>)[key] === 'string');
+}
+
+function isAlertWorkerAction(action: WorkerActionRecord): boolean {
+  const searchable = [
+    action.actionType,
+    action.subjectType,
+    action.subjectId,
+    action.externalKey,
+  ].join(' ').toLowerCase();
+  if (searchable.includes('alert')) return true;
+  const payload = action.payload;
+  return hasStringProp(payload, 'alertKey')
+    || hasStringProp(payload, 'alertSource')
+    || (hasStringProp(payload, 'severity') && (hasStringProp(payload, 'subject') || hasStringProp(payload, 'message')));
+}
+
+export function listAlertHistoryRows(
+  persistence: Pick<HeadlessQueryDeps['persistence'], 'listWorkerActions'>,
+): WorkerActionRecord[] {
+  return persistence.listWorkerActions().filter(isAlertWorkerAction);
+}
 
 export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Promise<void> {
   const subCommand = args[0];
@@ -339,6 +363,16 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
         case 'json': writeOut(formatAsJson(response.actions) + '\n'); break;
         case 'jsonl': writeOut(formatAsJsonl(response.actions) + '\n'); break;
         default: writeOut(formatWorkerDecisions(response.actions) + '\n'); break;
+      }
+      break;
+    }
+    case 'alert-history': {
+      const alerts = listAlertHistoryRows(deps.persistence);
+      switch (flags.output) {
+        case 'label': writeOut(formatAsLabel(alerts) + '\n'); break;
+        case 'json': writeOut(formatAsJson(alerts.map(serializeWorkerAction)) + '\n'); break;
+        case 'jsonl': writeOut(formatAsJsonl(alerts.map(serializeWorkerAction)) + '\n'); break;
+        default: writeOut(formatWorkerActions(alerts) + '\n'); break;
       }
       break;
     }

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -1,5 +1,5 @@
 import type { Orchestrator } from '@invoker/workflow-core';
-import type { SQLiteAdapter } from '@invoker/data-store';
+import type { SQLiteAdapter, WorkerActionRecord } from '@invoker/data-store';
 import type {
   GetEventsOptions,
   WorkerActionHistoryRequest,
@@ -11,7 +11,7 @@ import type {
 import { getEventsPage } from './get-events-page.js';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
 import { isHeadlessReadOnlyCommand } from './headless-command-classification.js';
-import { runReadOnlyHeadlessQueryToString, type HeadlessQueryDeps } from './headless-query-list.js';
+import { listAlertHistoryRows, runReadOnlyHeadlessQueryToString, type HeadlessQueryDeps } from './headless-query-list.js';
 import { listWorkerActionHistory, listWorkerDecisions } from './worker-control.js';
 
 /**
@@ -39,6 +39,7 @@ export interface OwnerReadQueryHandlers {
   getQueueStatus: () => Record<string, unknown>;
   listWorkerActionHistory: (request: WorkerActionHistoryRequest) => WorkerActionHistoryResponse;
   listWorkerDecisions: (request: WorkerDecisionsRequest) => WorkerDecisionsResponse;
+  getAlertHistory?: () => WorkerActionRecord[];
   getWorkerStatus: () => WorkerStatusSnapshot;
   getWorkers: () => WorkerStatusSnapshot;
   getWorkflowStatus: (workflowId?: string) => Record<string, unknown>;
@@ -122,6 +123,9 @@ export function answerOwnerReadQuery(
       return { workerActionHistory: handlers.listWorkerActionHistory(workerActionHistoryRequest()) };
     case 'worker-decisions':
       return { workerDecisions: handlers.listWorkerDecisions(workerDecisionsRequest()) };
+    case 'alert-history':
+      if (!handlers.getAlertHistory) throw new Error('Unsupported headless query: alert-history');
+      return { alertHistory: handlers.getAlertHistory() };
     case 'workflow-status':
       return handlers.getWorkflowStatus(body.workflowId);
     case 'tasks':
@@ -239,6 +243,7 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     getWorkers: deps.getWorkers,
     listWorkerActionHistory: (request: WorkerActionHistoryRequest) => listWorkerActionHistory(persistence, request),
     listWorkerDecisions: (request: WorkerDecisionsRequest) => listWorkerDecisions(persistence, request),
+    getAlertHistory: () => listAlertHistoryRows(persistence),
     getWorkflowStatus: (workflowId?: string) => orchestrator.getWorkflowStatus(workflowId) as unknown as Record<string, unknown>,
     getTasksSnapshot: () => {
       orchestrator.syncAllFromDb();


### PR DESCRIPTION
## Summary

Depends on the preceding alert-history query slice.

Adds `alert-history` to the shared owner read dispatcher.

GUI and standalone owners return the same filtered rows through the existing read-query response path.

## Review Claim

Approve routing owner `alert-history` reads to the shared filter and returning `{ alertHistory }` in `packages/app/src/owner-read-query.ts:126`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The dispatcher adds one discriminated `alert-history` branch at `packages/app/src/owner-read-query.ts:126`; every existing read kind retains its current branch.

The optional handler rejects unsupported callers explicitly, while both owner builders wire the same read-only filter at `packages/app/src/owner-read-query.ts:234`.

## Slice Rationale

Owner routing is its own repo-assigned review unit, downstream from the query surface.

## Non-goals

- No new alert filtering rules.
- No standalone command formatting changes.
- No Slack behavior.
- No write path or persistence change.

## Architecture

### Before

```mermaid
graph TD
    A["Owner read request"] --> B["Existing read-kind branches"]
```

### After

```mermaid
graph TD
    A["Owner alert-history request"] --> B["Shared alert-row filter"]
    B --> C["alertHistory response"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `cd packages/app && pnpm test` — 198 test files passed; 1,952 tests passed and 3 skipped.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>
