### PR TITLE
[General alert channel (5) Slack + headless query](3) Post guarded alerts to the Slack lobby

### DIFF
--- a/packages/surfaces/src/slack/slack-formatter.ts
+++ b/packages/surfaces/src/slack/slack-formatter.ts
@@ -259,6 +259,31 @@ export function formatError(message: string): SlackMessage {
   };
 }
 
+export function formatAlert(event: Extract<SurfaceEvent, { type: 'alert' }>): SlackMessage {
+  const severityEmoji: Record<typeof event.severity, string> = {
+    info: ':information_source:',
+    warning: ':warning:',
+    critical: ':rotating_light:',
+  };
+  const severityLabel = event.severity.toUpperCase();
+  const lines = [
+    `${severityEmoji[event.severity]} *${severityLabel} alert*: ${event.subject}`,
+    `*Source:* ${event.source}`,
+    event.message,
+    `_${event.alertKey}_`,
+  ];
+
+  return {
+    text: clampMrkdwnText(`${severityLabel} alert: ${event.subject} - ${event.message}`),
+    blocks: [
+      {
+        type: 'section',
+        text: { type: 'mrkdwn', text: clampMrkdwnText(lines.join('\n')) },
+      },
+    ],
+  };
+}
+
 // ── Top-Level Event Router ──────────────────────────────────
 
 export function formatSurfaceEvent(event: SurfaceEvent): SlackMessage | null {
@@ -293,6 +318,6 @@ export function formatSurfaceEvent(event: SurfaceEvent): SlackMessage | null {
     case 'error':
       return formatError(event.message);
     case 'alert':
-      return null;
+      return formatAlert(event);
   }
 }

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -186,12 +186,31 @@ export type LocalRequest =
   | { kind: 'agent'; text: string }
   | { kind: 'change'; text: string };
 
+type AlertSurfaceEvent = Extract<SurfaceEvent, { type: 'alert' }>;
+
+function normalizeAlertSurfaceEvent(event: AlertSurfaceEvent): AlertSurfaceEvent {
+  const nested = (event as unknown as { alert?: Partial<AlertSurfaceEvent> }).alert;
+  if (!nested) return event;
+  const severity = nested.severity === 'info' || nested.severity === 'critical'
+    ? nested.severity
+    : 'warning';
+  return {
+    type: 'alert',
+    severity,
+    source: nested.source ?? '',
+    subject: nested.subject ?? '',
+    message: nested.message ?? '',
+    alertKey: nested.alertKey ?? '',
+  };
+}
+
 /**
  * Upper bound on stdout/stderr retained per stream while a local command runs.
  * Bounds process memory against noisy commands; only the tail is kept because
  * `formatLocalCommandResult` shows the last chars anyway.
  */
 const MAX_LOCAL_CAPTURE_CHARS = 65_536;
+const DEFAULT_ALERT_POST_COOLDOWN_MS = 30 * 60 * 1_000;
 
 // Internal marker for the "success with empty stdout" case so the runOneShotPlanner
 // retry wrapper can distinguish transient silent-success from user-actionable
@@ -557,6 +576,8 @@ export class SlackSurface implements Surface {
   private onRestartInvoker?: () => Promise<void>;
   private instanceId: string;
   private harnessSessionDriverFactory?: (preset: HarnessPreset) => HarnessSessionDriver | undefined;
+  /** Guard key -> last lobby alert post timestamp, held in-process like watchdog cooldowns. */
+  private alertLastPostAt = new Map<string, number>();
 
   constructor(config: SlackSurfaceConfig) {
     this.app = new App({
@@ -662,6 +683,21 @@ export class SlackSurface implements Surface {
   async handleEvent(event: SurfaceEvent): Promise<void> {
     if (event.type === 'workflow_created') {
       await this.createWorkflowChannel(event);
+      return;
+    }
+
+    if (event.type === 'alert') {
+      const alert = normalizeAlertSurfaceEvent(event);
+      const lastPostAt = this.alertLastPostAt.get(alert.alertKey);
+      const now = Date.now();
+      if (lastPostAt !== undefined && now - lastPostAt < DEFAULT_ALERT_POST_COOLDOWN_MS) {
+        this.log('slack', 'info', `[ALERT] Suppressed cooldown duplicate (alertKey=${alert.alertKey})`);
+        return;
+      }
+      const message = formatSurfaceEvent(alert);
+      if (!message) return;
+      const ts = await this.postMessage(message, this.lobbyChannelId);
+      if (ts) this.alertLastPostAt.set(alert.alertKey, now);
       return;
     }
 


### PR DESCRIPTION
## Summary

Depends on the mergify-bridge workflow's merge.

Alert events now render as severity-aware Slack messages and post to the operator lobby.

A per-alert-key timestamp ignores repeat posts inside a 30-minute cooldown. The timestamp advances only after Slack accepts the post.

## Review Claim

Approve lobby delivery for alert events with a per-key repeat guard in `packages/surfaces/src/slack/slack-surface.ts:689` and alert formatting in `packages/surfaces/src/slack/slack-formatter.ts:262`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The new alert branch returns before the existing workflow-progress and generic paths at `packages/surfaces/src/slack/slack-surface.ts:689`, leaving every other event kind on its prior path.

Cooldown state is keyed by `alertKey`, checked before posting, and recorded only after a successful post at `packages/surfaces/src/slack/slack-surface.ts:691` and `packages/surfaces/src/slack/slack-surface.ts:699`.

## Slice Rationale

This slice activates one contact surface: Slack delivery. Headless commands and owner routing remain separate review claims.

## Non-goals

- No new alert producer.
- No change to the mergify bridge.
- No persistence for cooldown timestamps.
- No change to other Slack event rendering.
- No headless query changes.

## Architecture

### Before

```mermaid
graph TD
    A["Alert surface event"] --> B["No Slack message"]
```

### After

```mermaid
graph TD
    A["Alert surface event"] --> B["Per-alert-key cooldown check"]
    B --> C["Severity-aware Slack message"]
    C --> D["Operator lobby"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test` — 50 test files passed; 555 tests passed.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

</details>
