### PR TITLE
[Planning submit timeout](1) Keep owner response alive

### DIFF
--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -489,6 +489,31 @@ describe('IpcBus', () => {
     expect(winner).toBe(stillPending);
   });
 
+  it('REGRESSION: a slow invoker:planning-chat-submit delegated over headless.gui-mutation does not report failure while the owner is still submitting', async () => {
+    const sock = tempSocketPath();
+
+    const server = new IpcBus(sock, { requestDeadlineMs: 50 });
+    buses.push(server);
+    await server.ready();
+
+    server.onRequest('headless.gui-mutation', () => new Promise(() => {}));
+
+    const client = new IpcBus(sock, { requestDeadlineMs: 50 });
+    buses.push(client);
+    await client.ready();
+    await sleep(20);
+
+    const pending = client.request('headless.gui-mutation', {
+      channel: 'invoker:planning-chat-submit',
+      args: [{ sessionId: 'session-1' }],
+    });
+
+    const stillPending = Symbol('still-pending');
+    const winner = await Promise.race([pending, sleep(300).then(() => stillPending)]);
+
+    expect(winner).toBe(stillPending);
+  });
+
   it('REGRESSION: a slow invoker:start-ready delegated over headless.gui-mutation is killed by the default deadline instead of getting the long-deadline protection headless.exec gets', async () => {
     const sock = tempSocketPath();
 

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -269,6 +269,7 @@ export const DEFAULT_SOCKET_PATH = resolveDefaultSocketPath();
 const LONG_REQUEST_DEADLINE_CHANNELS = new Set([
   'invoker:plan-from-goal',
   'invoker:planning-chat-send',
+  'invoker:planning-chat-submit',
   'invoker:start-ready',
   // start-ready --recreate-all and other bulk mutations run inline on the owner.
   'headless.exec',


### PR DESCRIPTION
## Summary

The owner could finish handling a planning draft after the viewer's 30-second IPC deadline, leaving users with a false failure message for successful work.

This change routes the planning approval request through the existing long-operation deadline already used by planning chat send and other owner operations.

## Review Claim

The planning approval route remains pending beyond the default IPC deadline instead of reporting failure while the owner is still handling it.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the `invoker:planning-chat-submit` route receives the existing two-hour long-operation deadline; all other channels and planning semantics remain unchanged.

## Slice Rationale

The allowlist entry and its directly coupled regression test form one locally reviewable transport behavior change.

## Non-goals

- No global timeout increase.
- No retry or cancellation changes.
- No planning-session, workflow, UI, or draft-state changes.

## Architecture

### Before

```mermaid
graph LR
    A["Planning UI submits draft"] --> B["headless.gui-mutation"]
    B --> C["Owner continues submission"]
    B --> D["Viewer times out after 30 seconds"]
```

### After

```mermaid
graph LR
    A["Planning UI submits draft"] --> B["headless.gui-mutation"]
    B --> C["Owner completes submission"]
    C --> D["Viewer receives owner result"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/transport test`
- [x] `pnpm --filter @invoker/transport build`
- [x] `git diff --check`

Failing-before proof from the same regression test:

```text
FAIL src/__tests__/ipc-bus.test.ts > IpcBus > REGRESSION: a slow invoker:planning-chat-submit delegated over headless.gui-mutation does not report failure while the owner is still submitting
TransportError: Request on channel "headless.gui-mutation" timed out after 50ms
baseline_exit=1
```

Passing-after proof:

```text
Test Files  3 passed (3)
Tests  63 passed (63)
transport_test_exit=0 transport_build_exit=0 diff_check_exit=0
```

</details>

## Visual Proof

Not applicable. The failure is a 30-second transport race; the deterministic regression test exercises the literal timeout behavior without changing rendered UI.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert fe1f10a5b`
- Post-revert steps: Rebuild and restart Invoker; planning submission returns to the 30-second IPC deadline.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Planning chat submissions now have additional time to complete when processed through the GUI, preventing slow requests from timing out prematurely.

* **Tests**
  * Added regression coverage for delayed planning chat submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->