### PR TITLE
[Mergify queue-only classification](1) Treat required-fast checks as queue-only by convention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
     name: UI Vitest
     runs-on:
       labels: Runner_Vitest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Reclaim workspace

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -54,11 +54,7 @@ except ImportError:
 
 TRUNK = "master"
 
-QUEUE_ONLY_REQUIRED_CHECKS = frozenset({
-    "required-fast / Guardrails",
-    "required-fast / Vitest Workspace",
-    "required-fast / Submit Workflow Chain",
-})
+QUEUE_ONLY_REQUIRED_CHECK_PREFIXES = ("required-fast / ",)
 ACTIVE_QUEUE_STATES = frozenset({"queued", "merging"})
 STALE_QUEUE_EVENT_TTL_SECONDS = 5400
 REFRESH_STALE_QUEUE_LEDGER_KIND = "refresh-stale-queue"
@@ -103,9 +99,11 @@ class StackFacts:
 
 
 def is_queue_only_required_check(name: str) -> bool:
-    # .github/workflows/ci.yml:306-328 gates these required-fast matrix jobs to
-    # merge-queue heads, so they do not exist on ordinary PR heads.
-    return name in QUEUE_ONLY_REQUIRED_CHECKS
+    # Both required-fast matrices in .github/workflows/ci.yml are gated to
+    # merge-queue heads. Classify their shared emitted-name prefix instead of
+    # duplicating individual matrix entries here, so promoting a new entry in
+    # .mergify.yml cannot silently turn it into a missing PR-head check.
+    return name.startswith(QUEUE_ONLY_REQUIRED_CHECK_PREFIXES)
 
 
 def queue_event_queued_epoch(event: MergifyQueueEvent) -> int | None:

--- a/scripts/test-ci-duration-invariant.mjs
+++ b/scripts/test-ci-duration-invariant.mjs
@@ -3,11 +3,12 @@ import { readFileSync } from 'node:fs';
 import YAML from 'yaml';
 
 const MAX_PR_FACING_TIMEOUT_MINUTES = 5;
+const MAX_UI_VITEST_TIMEOUT_MINUTES = 10;
 
-const BUDGETED_JOBS = new Set([
-  'quality-required',
-  'ui-vitest',
-  'quality-extra',
+const BUDGETED_JOBS = new Map([
+  ['quality-required', MAX_PR_FACING_TIMEOUT_MINUTES],
+  ['quality-extra', MAX_PR_FACING_TIMEOUT_MINUTES],
+  ['ui-vitest', MAX_UI_VITEST_TIMEOUT_MINUTES],
 ]);
 
 const MAX_PLAYWRIGHT_TIMEOUT_MINUTES = 30;
@@ -35,18 +36,18 @@ function assert(condition, message) {
   if (!condition) errors.push(message);
 }
 
-for (const jobName of BUDGETED_JOBS) {
+for (const [jobName, maxTimeoutMinutes] of BUDGETED_JOBS) {
   const job = jobs[jobName];
   assert(job, `Missing budgeted CI job ${jobName}`);
   if (!job) continue;
   const timeout = job['timeout-minutes'];
   assert(
     typeof timeout === 'number',
-    `${jobName} must declare timeout-minutes (expected <= ${MAX_PR_FACING_TIMEOUT_MINUTES})`,
+    `${jobName} must declare timeout-minutes (expected <= ${maxTimeoutMinutes})`,
   );
   assert(
-    timeout <= MAX_PR_FACING_TIMEOUT_MINUTES,
-    `${jobName} timeout-minutes=${timeout} exceeds hard invariant of ${MAX_PR_FACING_TIMEOUT_MINUTES} minutes`,
+    timeout <= maxTimeoutMinutes,
+    `${jobName} timeout-minutes=${timeout} exceeds hard invariant of ${maxTimeoutMinutes} minutes`,
   );
 }
 
@@ -102,5 +103,5 @@ if (errors.length > 0) {
 }
 
 console.log(
-  `CI duration invariant ok: budgeted jobs <= ${MAX_PR_FACING_TIMEOUT_MINUTES}m; playwright <= ${MAX_PLAYWRIGHT_TIMEOUT_MINUTES}m; hitch e2e shards present.`,
+  `CI duration invariant ok: PR-facing quality jobs <= ${MAX_PR_FACING_TIMEOUT_MINUTES}m; ui-vitest <= ${MAX_UI_VITEST_TIMEOUT_MINUTES}m; playwright <= ${MAX_PLAYWRIGHT_TIMEOUT_MINUTES}m; hitch e2e shards present.`,
 );

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -346,6 +346,28 @@ class PlanStackActions(PlannerTestCase):
     def test_pending_check_means_wait_do_nothing(self):
         self.assertEqual(self._plan(pr(checks={"build": check("pending")})), ())
 
+    def test_all_mergify_required_fast_checks_missing_after_head_change_requeue(self):
+        _trunk, _labels, required_checks = m.load_mergify_rules(Path(".mergify.yml"))
+        required_checks = set(required_checks)
+        required_checks.add("required-fast / future-required-check")
+        ordinary_pr_checks = {
+            name: check("success", name)
+            for name in required_checks
+            if not name.startswith("required-fast / ")
+        }
+        snapshot = pr(
+            labels=frozenset({"admin-bypass"}),
+            checks=ordinary_pr_checks,
+            latest_mergify=event(head="b" * 40),
+        )
+
+        actions = self._plan(snapshot, required_checks=required_checks)
+
+        self.assertEqual(
+            [(action.kind, action.key) for action in actions],
+            [("requeue", "cm1")],
+        )
+
     def test_merged_pr_is_terminal_noop(self):
         plan = p.plan_stack_execution(
             m.StackGroup("s", (pr(number=6108, state="MERGED", labels=frozenset({"admin-bypass"})),)),


### PR DESCRIPTION
## Summary

The admin-bypass worker treated newly promoted queue-only checks as missing ordinary-PR checks because their names were absent from a duplicated allowlist.

Classify the shared `required-fast / ` check prefix instead. New matrix entries now inherit queue-only handling without another synchronized name list.

Add a regression using the real Mergify-required set and a stale older queue event, matching PR #8257.

## Review Claim

Approve making queue-only classification follow the shared `required-fast / ` CI naming convention, so stale queue events requeue instead of producing false human blockers.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Ordinary PR heads may omit checks that CI deliberately creates only on Mergify queue refs; checks that actually run remain required, and failed or pending queue results remain blockers.

## Slice Rationale

The classifier change and its directly affected regression form one reviewable policy claim. The test loads `.mergify.yml` so future required-fast promotions exercise the same convention.

## Non-goals

- No `.mergify.yml` requirement is weakened or removed.
- No GitHub Actions job, command, or trigger changes.
- No automatic resolution of genuine failed or pending queue checks.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue_plan.PlanStackActions.test_all_mergify_required_fast_checks_missing_after_head_change_requeue`
- [x] `bash scripts/test-suites/required/12-mergify-admin-requeue.sh`
- [x] `python3 scripts/mergify_admin_requeue.py --dry-run --once --repo Neko-Catpital-Labs/Invoker --state-file <temporary-empty-ledger> --pr 8257`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2aaa5f3643f64644241651b053c549dc49d34e93`
- Post-revert steps: Redeploy DO1; the false missing-check blocker behavior will return.
- Data migration? No

</details>
