### PR TITLE
[Renderer memory recovery](1) Reproduce renderer-loss fallback failure

### DIFF
--- a/packages/app/e2e/renderer-memory-pressure-recovery.spec.ts
+++ b/packages/app/e2e/renderer-memory-pressure-recovery.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test, waitForInvokerBridge } from './fixtures/electron-app.js';
+
+test('critical memory pressure keeps the UI responsive and renderer loss shows a diagnostic', async ({ electronApp }) => {
+  test.fail(true, 'renderer-loss fallback is truncated by its unescaped data URL');
+  const page = await electronApp.firstWindow();
+  await waitForInvokerBridge(page);
+
+  const rendererPidBeforePressure = await electronApp.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    if (!window) throw new Error('no BrowserWindow found');
+    return window.webContents.getOSProcessId();
+  });
+
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('Memory.simulatePressureNotification', { level: 'critical' });
+
+  await expect.poll(async () => page.evaluate(() => typeof window.invoker)).toBe('object');
+  await expect.poll(async () => electronApp.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    return window?.webContents.getOSProcessId();
+  })).toBe(rendererPidBeforePressure);
+
+  await electronApp.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    if (!window) throw new Error('no BrowserWindow found');
+    window.webContents.forcefullyCrashRenderer();
+  });
+
+  await expect.poll(async () => electronApp.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    return window?.webContents.getURL();
+  })).toContain('data:text/html');
+  await expect.poll(async () => electronApp.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    return window?.webContents.getOSProcessId();
+  })).not.toBe(rendererPidBeforePressure);
+
+  const recoveryPage = electronApp.windows()[0];
+  if (!recoveryPage) throw new Error('recovery page was not created');
+  await recoveryPage.waitForLoadState('domcontentloaded');
+  await expect(recoveryPage.getByRole('heading', { name: 'Invoker' })).toBeVisible();
+  await expect(recoveryPage.getByText('The UI failed to load.')).toBeVisible();
+  await expect.poll(async () => recoveryPage.evaluate(() => document.body.innerText.trim())).not.toBe('');
+});


### PR DESCRIPTION
## Summary

Add deterministic Electron coverage for critical memory pressure and renderer termination.

The expected failure records the blank recovery document before product behavior changes.

## Review Claim

The regression proof exercises the literal white-window failure through a real Electron renderer.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice changes no production code; its expected failure records current behavior while keeping the branch green.

## Slice Rationale

Evidence lands before the behavior change so reviewers can see the failure independently.

## Non-goals

- Change renderer recovery behavior.
- Change UI state persistence.
- Allocate enough host memory to trigger a real operating-system OOM.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/renderer-memory-pressure-recovery.spec.ts --workers=1`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e5b3e2e7e`
- Post-revert steps: None
- Data migration? No

</details>
