### PR TITLE
[Renderer memory recovery](2) Encode renderer-loss fallback document

### DIFF
--- a/packages/app/e2e/renderer-memory-pressure-recovery.spec.ts
+++ b/packages/app/e2e/renderer-memory-pressure-recovery.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test, waitForInvokerBridge } from './fixtures/electron-app.js';
 
 test('critical memory pressure keeps the UI responsive and renderer loss shows a diagnostic', async ({ electronApp }) => {
-  test.fail(true, 'renderer-loss fallback is truncated by its unescaped data URL');
   const page = await electronApp.firstWindow();
   await waitForInvokerBridge(page);
 

--- a/packages/app/src/__tests__/window-lifecycle.test.ts
+++ b/packages/app/src/__tests__/window-lifecycle.test.ts
@@ -111,7 +111,9 @@ describe('window-lifecycle', () => {
 
     electronMock.webContentsHandlers.get('did-fail-load')?.({}, -6, 'ERR_FILE_NOT_FOUND', 'file:///missing/index.html');
 
-    expect(electronMock.fakeWindow.loadURL).toHaveBeenCalledWith(expect.stringContaining('The UI failed to load'));
+    const fallbackUrl = electronMock.fakeWindow.loadURL.mock.calls[0]?.[0];
+    expect(fallbackUrl).toMatch(/^data:text\/html;charset=utf-8,/);
+    expect(decodeURIComponent(fallbackUrl)).toContain('The UI failed to load');
     expect(logger.error).toHaveBeenCalledWith(
       'main window did-fail-load: code=-6 desc=ERR_FILE_NOT_FOUND url=file:///missing/index.html',
       { module: 'window' },
@@ -134,7 +136,9 @@ describe('window-lifecycle', () => {
 
     electronMock.webContentsHandlers.get('render-process-gone')?.({}, { reason: 'crashed', exitCode: 9 });
 
-    expect(electronMock.fakeWindow.loadURL).toHaveBeenCalledWith(expect.stringContaining('The UI failed to load'));
+    const fallbackUrl = electronMock.fakeWindow.loadURL.mock.calls[0]?.[0];
+    expect(fallbackUrl).toMatch(/^data:text\/html;charset=utf-8,/);
+    expect(decodeURIComponent(fallbackUrl)).toContain('The UI failed to load');
   });
 
   it('maps and focuses e2e compositor windows', () => {

--- a/packages/app/src/window/window-lifecycle.ts
+++ b/packages/app/src/window/window-lifecycle.ts
@@ -47,7 +47,8 @@ export function registerMainWindowActivateHandler(deps: MainWindowActivateDeps):
   });
 }
 
-const FALLBACK_WINDOW_HTML = 'data:text/html,<html><body style="background:#1a1a2e;color:#eee;font-family:system-ui;padding:2rem"><h1>Invoker</h1><p>The UI failed to load. Restart Invoker. If this keeps happening, reinstall Invoker or rebuild the UI from a source checkout.</p></body></html>';
+const FALLBACK_WINDOW_DOCUMENT = '<html><body style="background:#1a1a2e;color:#eee;font-family:system-ui;padding:2rem"><h1>Invoker</h1><p>The UI failed to load. Restart Invoker. If this keeps happening, reinstall Invoker or rebuild the UI from a source checkout.</p></body></html>';
+const FALLBACK_WINDOW_HTML = `data:text/html;charset=utf-8,${encodeURIComponent(FALLBACK_WINDOW_DOCUMENT)}`;
 
 export function createMainWindow(deps: MainWindowLifecycleDeps): BrowserWindow {
   deps.recordStartupMark('createWindow.begin');


### PR DESCRIPTION
## Summary

Encode the inline recovery document so URL fragment characters cannot truncate its HTML.

Renderer loss now displays the intended diagnostic instead of blank white content.

## Review Claim

The renderer-loss fallback document is transported intact as an encoded data URL.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only failed-load and renderer-loss presentation changes; normal window startup remains unchanged.

## Slice Rationale

This isolates the existing fallback defect from automatic recovery policy and UI state restoration.

## Non-goals

- Recreate the BrowserWindow automatically.
- Persist renderer UI selection.
- Change normal startup or task execution.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- --run src/__tests__/window-lifecycle.test.ts`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/renderer-memory-pressure-recovery.spec.ts --workers=1`

</details>

## Visual Proof

[Walkthrough: blank fallback before encoding, readable diagnostic after encoding](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-a2229a/renderer-fallback-before-after.webm)

Before: renderer loss leaves blank white content.

![Blank renderer-loss fallback](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-a2229a/renderer-fallback-before.png)

After: the encoded fallback displays the Invoker diagnostic.

![Visible renderer-loss diagnostic](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-a2229a/renderer-fallback-after.png)

Manually inspected: I opened both exact captures and frames 1 and 4 of the walkthrough. The first state is completely white; the second has a navy background, Invoker heading, and readable recovery guidance.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 047762470`
- Post-revert steps: None
- Data migration? No

</details>
