### PR TITLE
[Renderer memory recovery](3) Persist renderer recovery UI state

### DIFF
--- a/packages/app/e2e/renderer-memory-pressure-recovery.spec.ts
+++ b/packages/app/e2e/renderer-memory-pressure-recovery.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test, waitForInvokerBridge } from './fixtures/electron-app.js';
+
+test('critical memory pressure keeps the UI responsive and renderer loss shows a diagnostic', async ({ electronApp }) => {
+  test.fail(true, 'renderer-loss fallback is truncated by its unescaped data URL');
+  const page = await electronApp.firstWindow();
+  await waitForInvokerBridge(page);
+
+  const rendererPidBeforePressure = await electronApp.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    if (!window) throw new Error('no BrowserWindow found');
+    return window.webContents.getOSProcessId();
+  });
+
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('Memory.simulatePressureNotification', { level: 'critical' });
+
+  await expect.poll(async () => page.evaluate(() => typeof window.invoker)).toBe('object');
+  await expect.poll(async () => electronApp.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    return window?.webContents.getOSProcessId();
+  })).toBe(rendererPidBeforePressure);
+
+  await electronApp.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    if (!window) throw new Error('no BrowserWindow found');
+    window.webContents.forcefullyCrashRenderer();
+  });
+
+  await expect.poll(async () => electronApp.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    return window?.webContents.getURL();
+  })).toContain('data:text/html');
+  await expect.poll(async () => electronApp.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    return window?.webContents.getOSProcessId();
+  })).not.toBe(rendererPidBeforePressure);
+
+  const recoveryPage = electronApp.windows()[0];
+  if (!recoveryPage) throw new Error('recovery page was not created');
+  await recoveryPage.waitForLoadState('domcontentloaded');
+  await expect(recoveryPage.getByRole('heading', { name: 'Invoker' })).toBeVisible();
+  await expect(recoveryPage.getByText('The UI failed to load.')).toBeVisible();
+  await expect.poll(async () => recoveryPage.evaluate(() => document.body.innerText.trim())).not.toBe('');
+});

--- a/packages/app/e2e/renderer-memory-pressure-recovery.spec.ts
+++ b/packages/app/e2e/renderer-memory-pressure-recovery.spec.ts
@@ -1,7 +1,6 @@
 import { expect, test, waitForInvokerBridge } from './fixtures/electron-app.js';
 
 test('critical memory pressure keeps the UI responsive and renderer loss shows a diagnostic', async ({ electronApp }) => {
-  test.fail(true, 'renderer-loss fallback is truncated by its unescaped data URL');
   const page = await electronApp.firstWindow();
   await waitForInvokerBridge(page);
 

--- a/packages/app/e2e/renderer-state-restoration.spec.ts
+++ b/packages/app/e2e/renderer-state-restoration.spec.ts
@@ -1,0 +1,26 @@
+import {
+  captureScreenshot,
+  expect,
+  loadPlan,
+  test,
+  TEST_PLAN,
+  waitForInvokerBridge,
+} from './fixtures/electron-app.js';
+
+test('reload restores the selected task and inspector', async ({ page }) => {
+  await loadPlan(page, TEST_PLAN);
+
+  const selectedTask = page.locator('.react-flow__node[data-testid$="task-beta"]').first();
+  await selectedTask.click();
+  await expect(selectedTask.locator('[data-selected="true"]')).toBeVisible();
+  await expect(page.getByTestId('workflow-inspector-shell')).toContainText('Second test task depending on alpha');
+  await captureScreenshot(page, 'renderer-state-before-reload');
+
+  await page.reload();
+  await waitForInvokerBridge(page);
+
+  const restoredTask = page.locator('.react-flow__node[data-testid$="task-beta"]').first();
+  await expect(restoredTask.locator('[data-selected="true"]')).toBeVisible();
+  await expect(page.getByTestId('workflow-inspector-shell')).toContainText('Second test task depending on alpha');
+  await captureScreenshot(page, 'renderer-state-after-reload');
+});

--- a/packages/app/src/__tests__/window-lifecycle.test.ts
+++ b/packages/app/src/__tests__/window-lifecycle.test.ts
@@ -111,7 +111,9 @@ describe('window-lifecycle', () => {
 
     electronMock.webContentsHandlers.get('did-fail-load')?.({}, -6, 'ERR_FILE_NOT_FOUND', 'file:///missing/index.html');
 
-    expect(electronMock.fakeWindow.loadURL).toHaveBeenCalledWith(expect.stringContaining('The UI failed to load'));
+    const fallbackUrl = electronMock.fakeWindow.loadURL.mock.calls[0]?.[0];
+    expect(fallbackUrl).toMatch(/^data:text\/html;charset=utf-8,/);
+    expect(decodeURIComponent(fallbackUrl)).toContain('The UI failed to load');
     expect(logger.error).toHaveBeenCalledWith(
       'main window did-fail-load: code=-6 desc=ERR_FILE_NOT_FOUND url=file:///missing/index.html',
       { module: 'window' },
@@ -134,7 +136,9 @@ describe('window-lifecycle', () => {
 
     electronMock.webContentsHandlers.get('render-process-gone')?.({}, { reason: 'crashed', exitCode: 9 });
 
-    expect(electronMock.fakeWindow.loadURL).toHaveBeenCalledWith(expect.stringContaining('The UI failed to load'));
+    const fallbackUrl = electronMock.fakeWindow.loadURL.mock.calls[0]?.[0];
+    expect(fallbackUrl).toMatch(/^data:text\/html;charset=utf-8,/);
+    expect(decodeURIComponent(fallbackUrl)).toContain('The UI failed to load');
   });
 
   it('maps and focuses e2e compositor windows', () => {

--- a/packages/app/src/window/window-lifecycle.ts
+++ b/packages/app/src/window/window-lifecycle.ts
@@ -47,7 +47,8 @@ export function registerMainWindowActivateHandler(deps: MainWindowActivateDeps):
   });
 }
 
-const FALLBACK_WINDOW_HTML = 'data:text/html,<html><body style="background:#1a1a2e;color:#eee;font-family:system-ui;padding:2rem"><h1>Invoker</h1><p>The UI failed to load. Restart Invoker. If this keeps happening, reinstall Invoker or rebuild the UI from a source checkout.</p></body></html>';
+const FALLBACK_WINDOW_DOCUMENT = '<html><body style="background:#1a1a2e;color:#eee;font-family:system-ui;padding:2rem"><h1>Invoker</h1><p>The UI failed to load. Restart Invoker. If this keeps happening, reinstall Invoker or rebuild the UI from a source checkout.</p></body></html>';
+const FALLBACK_WINDOW_HTML = `data:text/html;charset=utf-8,${encodeURIComponent(FALLBACK_WINDOW_DOCUMENT)}`;
 
 export function createMainWindow(deps: MainWindowLifecycleDeps): BrowserWindow {
   deps.recordStartupMark('createWindow.begin');

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -15,6 +15,11 @@ import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppP
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus, WorkerActionSummary, WorkerLogEntry, WorkerStatusEntry } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
 import { reportUiNavigation } from './lib/report-ui-navigation.js';
+import {
+  persistRendererRecoveryState,
+  readRendererRecoveryState,
+  type RendererRecoveryViewMode,
+} from './lib/renderer-recovery-state.js';
 
 import { useTasks } from './hooks/useTasks.js';
 import { useQueueStatus } from './hooks/useQueueStatus.js';
@@ -1043,7 +1048,8 @@ export function App() {
   const tasksRef = useRef(tasks);
   tasksRef.current = tasks;
   const loadedTasks = useMemo(() => [...tasks.values()], [tasks]);
-  const [viewMode, setViewMode] = useState<'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph'>('dag');
+  const initialRendererRecoveryState = useMemo(readRendererRecoveryState, []);
+  const [viewMode, setViewMode] = useState<RendererRecoveryViewMode>(initialRendererRecoveryState.viewMode);
   const {
     graph: actionGraph,
     error: actionGraphError,
@@ -1081,13 +1087,13 @@ export function App() {
   const lastGoodSelectedWorkflowGraphRef = useRef<SelectedWorkflowGraphSnapshot | null>(null);
   const suppressDagSurfaceDismissRef = useRef(false);
   const contextMenuTaskRef = useRef<TaskState | null>(null);
-  const [sidebarSurface, setSidebarSurface] = useState<SidebarSurface>('home');
+  const [sidebarSurface, setSidebarSurface] = useState<SidebarSurface>(initialRendererRecoveryState.sidebarSurface);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(initialRendererRecoveryState.selectedTaskId);
   const selectedTaskIdRef = useRef<string | null>(selectedTaskId);
   selectedTaskIdRef.current = selectedTaskId;
   const [selectedWorkerKind, setSelectedWorkerKind] = useState<string | null>(null);
-  const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
+  const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(initialRendererRecoveryState.selectedWorkflowId);
   const [reviewGateByWorkflowId, setReviewGateByWorkflowId] = useState<Record<string, ReviewGateQueryResponse | null>>({});
   const [stickySelectedWorkflow, setStickySelectedWorkflow] = useState<WorkflowMeta | null>(null);
   const [workflowSelectionDismissed, setWorkflowSelectionDismissed] = useState(false);
@@ -1167,7 +1173,7 @@ export function App() {
   const [setupPending, setSetupPending] = useState(false);
   const [setupResult, setSetupResult] = useState<InvokerSetupResult | null>(null);
   const [updateCliError, setUpdateCliError] = useState<string | null>(null);
-  const [inspectorCollapsed, setInspectorCollapsed] = useState(false);
+  const [inspectorCollapsed, setInspectorCollapsed] = useState(initialRendererRecoveryState.inspectorCollapsed);
   const [inspectorManualOpen, setInspectorManualOpen] = useState(false);
   const [viewportWidth, setViewportWidth] = useState(() => (typeof window === 'undefined' ? 1600 : window.innerWidth));
   const [advancedMetadataExpanded, setAdvancedMetadataExpanded] = useState(false);
@@ -1204,6 +1210,16 @@ export function App() {
   const planningTypingSequenceRef = useRef(0);
   const planningTypingFrameIdsRef = useRef<Set<number>>(new Set());
   const systemSetupAutoOpenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    persistRendererRecoveryState({
+      sidebarSurface,
+      viewMode,
+      selectedTaskId,
+      selectedWorkflowId,
+      inspectorCollapsed,
+    });
+  }, [inspectorCollapsed, selectedTaskId, selectedWorkflowId, sidebarSurface, viewMode]);
 
   const cancelPendingSystemSetupAutoOpen = useCallback(() => {
     if (systemSetupAutoOpenTimerRef.current !== null) {

--- a/packages/ui/src/__tests__/renderer-recovery-state.test.ts
+++ b/packages/ui/src/__tests__/renderer-recovery-state.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  persistRendererRecoveryState,
+  readRendererRecoveryState,
+  RENDERER_RECOVERY_STATE_KEY,
+} from '../lib/renderer-recovery-state.js';
+
+describe('renderer recovery state', () => {
+  it('round-trips safe navigation state', () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+
+    persistRendererRecoveryState({
+      sidebarSurface: 'workflows',
+      viewMode: 'dag',
+      selectedTaskId: 'task-beta',
+      selectedWorkflowId: 'workflow-1',
+      inspectorCollapsed: false,
+    }, storage);
+
+    expect(readRendererRecoveryState(storage)).toEqual({
+      sidebarSurface: 'workflows',
+      viewMode: 'dag',
+      selectedTaskId: 'task-beta',
+      selectedWorkflowId: 'workflow-1',
+      inspectorCollapsed: false,
+    });
+    expect(values.has(RENDERER_RECOVERY_STATE_KEY)).toBe(true);
+  });
+
+  it('falls back when persisted state is malformed or storage throws', () => {
+    expect(readRendererRecoveryState({ getItem: () => '{broken' })).toEqual({
+      sidebarSurface: 'home',
+      viewMode: 'dag',
+      selectedTaskId: null,
+      selectedWorkflowId: null,
+      inspectorCollapsed: false,
+    });
+
+    const setItem = vi.fn(() => { throw new Error('blocked'); });
+    expect(() => persistRendererRecoveryState({
+      sidebarSurface: 'home',
+      viewMode: 'dag',
+      selectedTaskId: null,
+      selectedWorkflowId: null,
+      inspectorCollapsed: false,
+    }, { setItem })).not.toThrow();
+  });
+});

--- a/packages/ui/src/lib/renderer-recovery-state.ts
+++ b/packages/ui/src/lib/renderer-recovery-state.ts
@@ -1,0 +1,65 @@
+import type { SidebarSurface } from './workflow-progress-surfaces.js';
+
+export type RendererRecoveryViewMode = 'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph';
+
+export type RendererRecoveryState = {
+  sidebarSurface: SidebarSurface;
+  viewMode: RendererRecoveryViewMode;
+  selectedTaskId: string | null;
+  selectedWorkflowId: string | null;
+  inspectorCollapsed: boolean;
+};
+
+export const RENDERER_RECOVERY_STATE_KEY = 'invoker.renderer-recovery-state.v1';
+
+const DEFAULT_RENDERER_RECOVERY_STATE: RendererRecoveryState = {
+  sidebarSurface: 'home',
+  viewMode: 'dag',
+  selectedTaskId: null,
+  selectedWorkflowId: null,
+  inspectorCollapsed: false,
+};
+
+const SIDEBAR_SURFACES = new Set<SidebarSurface>(['home', 'planning', 'workflows', 'attention', 'workers']);
+const VIEW_MODES = new Set<RendererRecoveryViewMode>(['dag', 'history', 'timeline', 'queue', 'actionGraph']);
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+export function readRendererRecoveryState(
+  storage: Pick<Storage, 'getItem'> | undefined = typeof window === 'undefined' ? undefined : window.localStorage,
+): RendererRecoveryState {
+  if (!storage) return DEFAULT_RENDERER_RECOVERY_STATE;
+  try {
+    const raw = storage.getItem(RENDERER_RECOVERY_STATE_KEY);
+    if (!raw) return DEFAULT_RENDERER_RECOVERY_STATE;
+    const parsed = JSON.parse(raw) as Partial<RendererRecoveryState>;
+    return {
+      sidebarSurface: SIDEBAR_SURFACES.has(parsed.sidebarSurface as SidebarSurface)
+        ? parsed.sidebarSurface as SidebarSurface
+        : DEFAULT_RENDERER_RECOVERY_STATE.sidebarSurface,
+      viewMode: VIEW_MODES.has(parsed.viewMode as RendererRecoveryViewMode)
+        ? parsed.viewMode as RendererRecoveryViewMode
+        : DEFAULT_RENDERER_RECOVERY_STATE.viewMode,
+      selectedTaskId: nullableString(parsed.selectedTaskId),
+      selectedWorkflowId: nullableString(parsed.selectedWorkflowId),
+      inspectorCollapsed: typeof parsed.inspectorCollapsed === 'boolean'
+        ? parsed.inspectorCollapsed
+        : DEFAULT_RENDERER_RECOVERY_STATE.inspectorCollapsed,
+    };
+  } catch {
+    return DEFAULT_RENDERER_RECOVERY_STATE;
+  }
+}
+
+export function persistRendererRecoveryState(
+  state: RendererRecoveryState,
+  storage: Pick<Storage, 'setItem'> | undefined = typeof window === 'undefined' ? undefined : window.localStorage,
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(RENDERER_RECOVERY_STATE_KEY, JSON.stringify(state));
+  } catch {
+  }
+}

--- a/packages/ui/src/test-setup.ts
+++ b/packages/ui/src/test-setup.ts
@@ -2,6 +2,7 @@
 process.env.TZ = 'UTC';
 
 import '@testing-library/jest-dom/vitest';
+import { beforeEach } from 'vitest';
 
 if (typeof globalThis.ResizeObserver === 'undefined') {
   class ResizeObserverPolyfill {
@@ -41,7 +42,16 @@ if (typeof window !== 'undefined') {
     configurable: true,
     value: createMemoryStorage(),
   });
+  Object.defineProperty(window, 'sessionStorage', {
+    configurable: true,
+    value: createMemoryStorage(),
+  });
 }
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
 
 if (typeof HTMLCanvasElement !== 'undefined') {
   const context = {


### PR DESCRIPTION
## Summary

Persist a bounded renderer navigation snapshot in origin storage.

Reloaded UI restores the selected task, workflow, surface, view, and inspector state.

## Review Claim

Safe navigation state survives renderer reload without persisting transient dialogs or draft input.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only bounded navigation fields are stored; malformed storage defaults safely, while dialogs, terminal input, and draft input remain transient.

## Slice Rationale

State restoration lands before automatic window recreation so its behavior can be reviewed independently.

## Non-goals

- Recreate a crashed BrowserWindow.
- Persist modal, terminal-input, or draft-input contents.
- Change workflow or task persistence.
- Change the guarded `dag-surface-background-click-noop` decision.

## Architecture

### Before

```mermaid
graph LR
    A["Renderer selection"] --> B["React memory only"]
    C["Page reload"] --> D["Default navigation state"]
```

### After

```mermaid
graph LR
    A["Renderer selection"] --> B["Bounded local snapshot"]
    C["Page reload"] --> B
    B --> D["Restored navigation state"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- --run src/__tests__/renderer-recovery-state.test.ts src/__tests__/theme.test.tsx src/__tests__/app-launch.test.tsx`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/renderer-state-restoration.spec.ts --workers=1`

</details>

## Visual Proof

[Walkthrough: selected task before reload, then restored selection and inspector after reload](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-5412ab/renderer-state-restoration-walkthrough.webm)

Manually inspected: I opened frames at seconds 1 and 4. Both show task beta selected with “Second test task depending on alpha” in the inspector; the labels identify before and after reload.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 895507832`
- Post-revert steps: None
- Data migration? No; the unused local-storage key is harmless.

</details>
