### PR TITLE
[Renderer memory recovery](4) Bound automatic renderer recreation

### DIFF
--- a/packages/app/e2e/renderer-memory-pressure-recovery.spec.ts
+++ b/packages/app/e2e/renderer-memory-pressure-recovery.spec.ts
@@ -1,8 +1,19 @@
-import { expect, test, waitForInvokerBridge } from './fixtures/electron-app.js';
+import {
+  captureScreenshot,
+  expect,
+  loadPlan,
+  test,
+  TEST_PLAN,
+  waitForInvokerBridge,
+} from './fixtures/electron-app.js';
 
-test('critical memory pressure keeps the UI responsive and renderer loss shows a diagnostic', async ({ electronApp }) => {
-  const page = await electronApp.firstWindow();
-  await waitForInvokerBridge(page);
+test('critical memory pressure preserves state, then repeated renderer loss stops on a diagnostic', async ({ electronApp, page }) => {
+  await loadPlan(page, TEST_PLAN);
+  const selectedTask = page.locator('.react-flow__node[data-testid$="task-beta"]').first();
+  await selectedTask.click();
+  await expect(selectedTask.locator('[data-selected="true"]')).toBeVisible();
+  await expect(page.getByTestId('workflow-inspector-shell')).toContainText('Second test task depending on alpha');
+  await captureScreenshot(page, 'renderer-recovery-selected-before');
 
   const rendererPidBeforePressure = await electronApp.evaluate(({ BrowserWindow }) => {
     const window = BrowserWindow.getAllWindows()[0];
@@ -19,6 +30,24 @@ test('critical memory pressure keeps the UI responsive and renderer loss shows a
     return window?.webContents.getOSProcessId();
   })).toBe(rendererPidBeforePressure);
 
+  const replacementPagePromise = electronApp.waitForEvent('window');
+  await electronApp.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    if (!window) throw new Error('no BrowserWindow found');
+    window.webContents.forcefullyCrashRenderer();
+  });
+  const recoveredPage = await replacementPagePromise;
+
+  await expect.poll(async () => electronApp.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0];
+    return window?.webContents.getOSProcessId();
+  })).not.toBe(rendererPidBeforePressure);
+  await waitForInvokerBridge(recoveredPage);
+  const restoredTask = recoveredPage.locator('.react-flow__node[data-testid$="task-beta"]').first();
+  await expect(restoredTask.locator('[data-selected="true"]')).toBeVisible();
+  await expect(recoveredPage.getByTestId('workflow-inspector-shell')).toContainText('Second test task depending on alpha');
+  await captureScreenshot(recoveredPage, 'renderer-recovery-selected-after');
+
   await electronApp.evaluate(({ BrowserWindow }) => {
     const window = BrowserWindow.getAllWindows()[0];
     if (!window) throw new Error('no BrowserWindow found');
@@ -29,10 +58,6 @@ test('critical memory pressure keeps the UI responsive and renderer loss shows a
     const window = BrowserWindow.getAllWindows()[0];
     return window?.webContents.getURL();
   })).toContain('data:text/html');
-  await expect.poll(async () => electronApp.evaluate(({ BrowserWindow }) => {
-    const window = BrowserWindow.getAllWindows()[0];
-    return window?.webContents.getOSProcessId();
-  })).not.toBe(rendererPidBeforePressure);
 
   const recoveryPage = electronApp.windows()[0];
   if (!recoveryPage) throw new Error('recovery page was not created');
@@ -40,4 +65,5 @@ test('critical memory pressure keeps the UI responsive and renderer loss shows a
   await expect(recoveryPage.getByRole('heading', { name: 'Invoker' })).toBeVisible();
   await expect(recoveryPage.getByText('The UI failed to load.')).toBeVisible();
   await expect.poll(async () => recoveryPage.evaluate(() => document.body.innerText.trim())).not.toBe('');
+  await captureScreenshot(recoveryPage, 'renderer-recovery-crash-loop-diagnostic');
 });

--- a/packages/app/src/__tests__/window-lifecycle.test.ts
+++ b/packages/app/src/__tests__/window-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createMainWindow,
   registerMainWindowActivateHandler,
@@ -17,6 +17,7 @@ const electronMock = vi.hoisted(() => {
     },
     loadURL: vi.fn(() => Promise.resolve()),
     loadFile: vi.fn(() => Promise.resolve()),
+    destroy: vi.fn(),
     isDestroyed: vi.fn(() => false),
     setIcon: vi.fn(),
     on: vi.fn(),
@@ -53,6 +54,10 @@ beforeEach(() => {
   electronMock.fakeWindow.loadFile.mockResolvedValue(undefined);
   delete process.env.CAPTURE_MODE;
   delete process.env.INVOKER_VISUAL_PROOF_SHOW_UI;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 afterAll(() => {
@@ -120,8 +125,9 @@ describe('window-lifecycle', () => {
     );
   });
 
-  it('shows a diagnostic page when the renderer process dies instead of leaving a white window', () => {
+  it('recreates once after renderer loss and shows a diagnostic when the replacement also dies', () => {
     const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() };
+    vi.spyOn(Date, 'now').mockReturnValueOnce(1_000).mockReturnValueOnce(2_000);
     createMainWindow({
       appRootDir: '/tmp/app',
       invokerConfig: {},
@@ -136,9 +142,42 @@ describe('window-lifecycle', () => {
 
     electronMock.webContentsHandlers.get('render-process-gone')?.({}, { reason: 'crashed', exitCode: 9 });
 
+    expect(electronMock.fakeWindow.destroy).toHaveBeenCalledTimes(1);
+    expect(electronMock.fakeWindow.loadURL).not.toHaveBeenCalled();
+    const recreateWindow = electronMock.fakeWindow.once.mock.calls.find(([eventName]) => eventName === 'closed')?.[1];
+    expect(recreateWindow).toBeDefined();
+    recreateWindow?.();
+
+    electronMock.webContentsHandlers.get('render-process-gone')?.({}, { reason: 'crashed', exitCode: 9 });
+
     const fallbackUrl = electronMock.fakeWindow.loadURL.mock.calls[0]?.[0];
     expect(fallbackUrl).toMatch(/^data:text\/html;charset=utf-8,/);
     expect(decodeURIComponent(fallbackUrl)).toContain('The UI failed to load');
+  });
+
+  it('allows another renderer recovery after the crash-loop window expires', () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() };
+    vi.spyOn(Date, 'now').mockReturnValueOnce(1_000).mockReturnValueOnce(61_000);
+    createMainWindow({
+      appRootDir: '/tmp/app',
+      invokerConfig: {},
+      logger,
+      hideE2eWindow: false,
+      enableTestCompositor: false,
+      recordStartupMark: vi.fn(),
+      setUiInteractive: vi.fn(),
+      startDeferredStartupWork: vi.fn(),
+      setMainWindow: vi.fn(),
+    });
+
+    electronMock.webContentsHandlers.get('render-process-gone')?.({}, { reason: 'oom', exitCode: 9 });
+    const recreateWindow = electronMock.fakeWindow.once.mock.calls.find(([eventName]) => eventName === 'closed')?.[1];
+    expect(recreateWindow).toBeDefined();
+    recreateWindow?.();
+    electronMock.webContentsHandlers.get('render-process-gone')?.({}, { reason: 'oom', exitCode: 9 });
+
+    expect(electronMock.fakeWindow.destroy).toHaveBeenCalledTimes(2);
+    expect(electronMock.fakeWindow.loadURL).not.toHaveBeenCalled();
   });
 
   it('maps and focuses e2e compositor windows', () => {

--- a/packages/app/src/window/window-lifecycle.ts
+++ b/packages/app/src/window/window-lifecycle.ts
@@ -15,6 +15,11 @@ export interface MainWindowLifecycleDeps {
   setUiInteractive: (uiInteractive: boolean) => void;
   startDeferredStartupWork: () => void;
   setMainWindow: (window: BrowserWindow | null) => void;
+  rendererRecoveryState?: MainWindowRendererRecoveryState;
+}
+
+export interface MainWindowRendererRecoveryState {
+  lastRecoveryAt: number | null;
 }
 
 export interface MainWindowSecondInstanceDeps {
@@ -49,6 +54,7 @@ export function registerMainWindowActivateHandler(deps: MainWindowActivateDeps):
 
 const FALLBACK_WINDOW_DOCUMENT = '<html><body style="background:#1a1a2e;color:#eee;font-family:system-ui;padding:2rem"><h1>Invoker</h1><p>The UI failed to load. Restart Invoker. If this keeps happening, reinstall Invoker or rebuild the UI from a source checkout.</p></body></html>';
 const FALLBACK_WINDOW_HTML = `data:text/html;charset=utf-8,${encodeURIComponent(FALLBACK_WINDOW_DOCUMENT)}`;
+const RENDERER_RECOVERY_WINDOW_MS = 60_000;
 
 export function createMainWindow(deps: MainWindowLifecycleDeps): BrowserWindow {
   deps.recordStartupMark('createWindow.begin');
@@ -88,6 +94,7 @@ export function createMainWindow(deps: MainWindowLifecycleDeps): BrowserWindow {
   }
 
   let fallbackShown = false;
+  const rendererRecoveryState = deps.rendererRecoveryState ?? { lastRecoveryAt: null };
   const showFallbackWindow = (reason: string): void => {
     if (mainWindow.isDestroyed() || fallbackShown) return;
     fallbackShown = true;
@@ -125,11 +132,27 @@ export function createMainWindow(deps: MainWindowLifecycleDeps): BrowserWindow {
   });
 
   mainWindow.webContents.on('render-process-gone', (_event, details) => {
+    const reason = `render-process-gone reason=${details.reason} exitCode=${details.exitCode}`;
     deps.logger.error(
       `main window render-process-gone: reason=${details.reason} exitCode=${details.exitCode}`,
       { module: 'window' },
     );
-    showFallbackWindow(`render-process-gone reason=${details.reason} exitCode=${details.exitCode}`);
+    const now = Date.now();
+    if (rendererRecoveryState.lastRecoveryAt === null || now - rendererRecoveryState.lastRecoveryAt >= RENDERER_RECOVERY_WINDOW_MS) {
+      rendererRecoveryState.lastRecoveryAt = now;
+      deps.logger.warn(`main window renderer recovery: ${reason}`, { module: 'window' });
+      try {
+        mainWindow.once('closed', () => createMainWindow({ ...deps, rendererRecoveryState }));
+        mainWindow.destroy();
+        return;
+      } catch (err) {
+        deps.logger.error(
+          `main window renderer recovery reload failed: ${err instanceof Error ? err.message : String(err)}`,
+          { module: 'window' },
+        );
+      }
+    }
+    showFallbackWindow(reason);
   });
 
   const shouldShowWindow = process.env.NODE_ENV !== 'test' || deps.enableTestCompositor;


### PR DESCRIPTION
## Summary

Recreate the BrowserWindow once after renderer loss and stop repeated failure on the diagnostic page.

The replacement window restores its prior navigation state.

## Review Claim

The window activation surface performs one automatic recovery per 60 seconds and breaks a repeated crash loop with a diagnostic.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

At most one automatic recreation occurs per 60 seconds; a repeated loss stops on static recovery content, while durable task execution remains untouched.

## Slice Rationale

This activates recovery only after fallback transport and renderer state restoration are independently reviewable.

## Non-goals

- Restart the Electron main process.
- Restart or mutate durable task execution.
- Treat simulated Chromium pressure as proof of host-level OOM behavior.

## Architecture

### Before

```mermaid
graph LR
    A["Renderer process gone"] --> B["Static fallback"]
```

### After

```mermaid
graph TD
    A["Renderer process gone"] --> B{"Recovery in last 60 seconds?"}
    B -->|"No"| C["Destroy and recreate BrowserWindow"]
    C --> D["Restore bounded navigation state"]
    B -->|"Yes"| E["Show static diagnostic"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- --run src/__tests__/window-lifecycle.test.ts`
- [x] `pnpm check:types`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/renderer-memory-pressure-recovery.spec.ts --workers=1`

</details>

## Visual Proof

[Walkthrough: selected task, replacement BrowserWindow restoration, then crash-loop diagnostic](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-6879b5/renderer-memory-recovery-walkthrough.webm)

Manually inspected: I opened frames at seconds 1, 4, and 7. They show task beta selected, the same inspector restored in a new BrowserWindow, then the navy diagnostic after repeated renderer loss.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f1951238b`
- Post-revert steps: None
- Data migration? No

</details>
