### PR TITLE
[Merge queue capacity](1) Reproduce closed-wrapper run leak

### DIFF
--- a/scripts/repro/repro-merge-queue-close-capacity.sh
+++ b/scripts/repro/repro-merge-queue-close-capacity.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+check_cleanup_contract() {
+  node --input-type=module <<'NODE'
+import { existsSync, readFileSync } from 'node:fs';
+
+const path = '.github/workflows/merge-queue-close-cleanup.yml';
+if (!existsSync(path)) {
+  throw new Error('capacity leak reproduced: closed merge-queue wrappers have no cleanup workflow');
+}
+
+const source = readFileSync(path, 'utf8');
+for (const expected of [
+  'types: [closed]',
+  'group: CI-merge-queue-${{ github.head_ref }}',
+  'group: PR Body-merge-queue-${{ github.head_ref }}',
+  'cancel-in-progress: true',
+]) {
+  if (!source.includes(expected)) {
+    throw new Error(`capacity cleanup is missing contract: ${expected}`);
+  }
+}
+NODE
+}
+
+if [[ "${1:-}" == "--expect-unfixed" ]]; then
+  set +e
+  output="$(check_cleanup_contract 2>&1)"
+  status=$?
+  set -e
+  if [[ $status -eq 0 ]]; then
+    echo "expected the unfixed capacity contract to fail" >&2
+    exit 1
+  fi
+  grep -Fq 'capacity leak reproduced' <<<"$output" || {
+    printf '%s\n' "$output" >&2
+    exit 1
+  }
+  echo "[repro] capacity leak reproduced: closed wrapper runs retain their concurrency groups"
+  exit 0
+fi
+
+check_cleanup_contract
+echo "[repro] closed merge-queue wrappers cancel stale CI and PR Body capacity"


### PR DESCRIPTION
## Summary

Closed Mergify wrapper PRs can leave CI and PR Body runs consuming runner capacity.

This slice adds a deterministic repro for runs retained after wrapper closure.

## Review Claim

Approve the deterministic closed-wrapper capacity-leak repro.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The repro only reads workflow files and changes no Actions, PR, runner, or production state.

## Slice Rationale

The evidence lands before the policy fix so the retained-run behavior is independently reviewable.

## Non-goals

- No workflow behavior changes.
- No workflow or runner mutation.
- No product runtime changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-merge-queue-close-capacity.sh --expect-unfixed`
- [x] `bash scripts/repro/repro-merge-queue-close-capacity.sh` exits 1 with `capacity leak reproduced`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert dfc994322`
- Post-revert steps: None
- Data migration? No

</details>
