### PR TITLE
[Merge queue capacity](2) Cancel runs when wrappers close

### DIFF
--- a/.github/workflows/merge-queue-close-cleanup.yml
+++ b/.github/workflows/merge-queue-close-cleanup.yml
@@ -1,0 +1,27 @@
+name: Merge Queue Close Cleanup
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  cancel-ci:
+    if: ${{ startsWith(github.head_ref, 'mergify/merge-queue/') }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: CI-merge-queue-${{ github.head_ref }}
+      cancel-in-progress: true
+    steps:
+      - run: echo "Closed merge-queue wrapper released its CI concurrency group."
+
+  cancel-pr-body:
+    if: ${{ startsWith(github.head_ref, 'mergify/merge-queue/') }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: PR Body-merge-queue-${{ github.head_ref }}
+      cancel-in-progress: true
+    steps:
+      - run: echo "Closed merge-queue wrapper released its PR Body concurrency group."

--- a/scripts/repro/repro-merge-queue-close-capacity.sh
+++ b/scripts/repro/repro-merge-queue-close-capacity.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+check_cleanup_contract() {
+  node --input-type=module <<'NODE'
+import { existsSync, readFileSync } from 'node:fs';
+
+const path = '.github/workflows/merge-queue-close-cleanup.yml';
+if (!existsSync(path)) {
+  throw new Error('capacity leak reproduced: closed merge-queue wrappers have no cleanup workflow');
+}
+
+const source = readFileSync(path, 'utf8');
+for (const expected of [
+  'types: [closed]',
+  'group: CI-merge-queue-${{ github.head_ref }}',
+  'group: PR Body-merge-queue-${{ github.head_ref }}',
+  'cancel-in-progress: true',
+]) {
+  if (!source.includes(expected)) {
+    throw new Error(`capacity cleanup is missing contract: ${expected}`);
+  }
+}
+NODE
+}
+
+if [[ "${1:-}" == "--expect-unfixed" ]]; then
+  set +e
+  output="$(check_cleanup_contract 2>&1)"
+  status=$?
+  set -e
+  if [[ $status -eq 0 ]]; then
+    echo "expected the unfixed capacity contract to fail" >&2
+    exit 1
+  fi
+  grep -Fq 'capacity leak reproduced' <<<"$output" || {
+    printf '%s\n' "$output" >&2
+    exit 1
+  }
+  echo "[repro] capacity leak reproduced: closed wrapper runs retain their concurrency groups"
+  exit 0
+fi
+
+check_cleanup_contract
+echo "[repro] closed merge-queue wrappers cancel stale CI and PR Body capacity"

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -1,15 +1,18 @@
 #!/usr/bin/env node
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import YAML from 'yaml';
 
 const FULL_CI_GATE = "${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}";
 const NON_PR_GATE = "${{ github.event_name != 'pull_request' }}";
 const ORDINARY_PR_GATE = "${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}";
 const PR_BODY_MERGE_QUEUE_CANCEL_GATE = "${{ !startsWith(github.head_ref, 'mergify/merge-queue/') }}";
+const MERGE_QUEUE_HEAD_GATE = "${{ startsWith(github.head_ref, 'mergify/merge-queue/') }}";
+const HEAD_REF_EXPRESSION = '${{ github.head_ref }}';
 const FULL_CI_JOBS = new Set(['build-artifacts', 'e2e-proof', 'e2e-proof-aggregate', 'required-fast', 'playwright', 'ssh', 'optional-other']);
 
 const workflow = YAML.parse(readFileSync('.github/workflows/ci.yml', 'utf8'));
 const prBodyWorkflow = YAML.parse(readFileSync('.github/workflows/pr-body.yml', 'utf8'));
+const closeCleanupPath = '.github/workflows/merge-queue-close-cleanup.yml';
 const mergify = YAML.parse(readFileSync('.mergify.yml', 'utf8'));
 const jobs = workflow.jobs ?? {};
 
@@ -56,6 +59,36 @@ assert(
   prBodyWorkflow.concurrency['cancel-in-progress'] === PR_BODY_MERGE_QUEUE_CANCEL_GATE,
   'PR Body workflow must not cancel in-progress merge-queue runs',
 );
+
+assert(
+  existsSync(closeCleanupPath),
+  'Merge-queue close cleanup workflow must cancel runs left behind by closed wrapper PRs',
+);
+const closeCleanupWorkflow = YAML.parse(readFileSync(closeCleanupPath, 'utf8'));
+assert(
+  closeCleanupWorkflow.on?.pull_request_target?.types?.length === 1
+    && closeCleanupWorkflow.on.pull_request_target.types[0] === 'closed',
+  'Merge-queue close cleanup workflow must run only when a PR closes',
+);
+
+for (const [jobName, sourceWorkflow] of [
+  ['cancel-ci', workflow],
+  ['cancel-pr-body', prBodyWorkflow],
+]) {
+  assert(
+    String(sourceWorkflow.concurrency?.group ?? '').includes("format('merge-queue-{0}', github.head_ref)"),
+    `${sourceWorkflow.name} must isolate merge-queue runs by head ref`,
+  );
+  const cleanupJob = closeCleanupWorkflow.jobs?.[jobName];
+  assert(cleanupJob, `Missing merge-queue close cleanup job ${jobName}`);
+  assert(cleanupJob.if === MERGE_QUEUE_HEAD_GATE, `${jobName} must target only Mergify merge-queue wrappers`);
+  assert(cleanupJob['runs-on'] === 'ubuntu-latest', `${jobName} must not consume the self-hosted capacity it repairs`);
+  assert(cleanupJob.concurrency?.['cancel-in-progress'] === true, `${jobName} must cancel the matching stale run`);
+  assert(
+    cleanupJob.concurrency?.group === `${sourceWorkflow.name}-merge-queue-${HEAD_REF_EXPRESSION}`,
+    `${jobName} must reuse ${sourceWorkflow.name}'s merge-queue concurrency group`,
+  );
+}
 
 const mergeConditions = (mergify.queue_rules ?? []).flatMap((rule) => rule.merge_conditions ?? []);
 const requiredChecks = new Set(


### PR DESCRIPTION
## Summary

Closed Mergify wrapper PRs now release the CI and PR Body concurrency groups they created.

The close handler runs on GitHub-hosted capacity, so a saturated self-hosted fleet cannot block cancellation.

## Review Claim

Approve close-triggered cancellation for stale merge-queue workflow runs.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only closed Mergify wrapper PRs trigger cleanup. Ordinary PRs and active queue batches keep their existing concurrency behavior.

## Slice Rationale

This slice adds the close handler and its focused assertion after the repro established the gap.

## Non-goals

- No cancellation change for active merge-queue wrappers.
- No self-hosted runner configuration change.
- No product runtime change.

## Architecture

### Before

```mermaid
flowchart LR
    A["Mergify wrapper closes"] --> B["CI and PR Body runs remain queued"]
    B --> C["Self-hosted capacity stays occupied"]
```

### After

```mermaid
flowchart LR
    A["Mergify wrapper closes"] --> B["GitHub-hosted close jobs reuse both concurrency keys"]
    B --> C["Matching stale CI and PR Body runs are cancelled"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-merge-queue-close-capacity.sh`
- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [x] `node scripts/test-resolve-pr-body-targets.mjs`
- [x] `git diff --check`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1704ea705`
- Post-revert steps: Re-run the merge-queue policy repro.
- Data migration? No

</details>
