### PR TITLE
[PR Body CA fallback Step 2: Use cached base when valid](1)

### DIFF
--- a/scripts/fetch-pr-diff-metadata.sh
+++ b/scripts/fetch-pr-diff-metadata.sh
@@ -25,9 +25,26 @@ set -euo pipefail
 BASE_SHA="${BASE_SHA:-}"
 DEPTH="${FETCH_PR_DIFF_BASE_DEPTH:-1000}"
 
-git fetch --no-tags --depth="$DEPTH" origin "$BASE_REF"
+base_fetch_stderr="$(mktemp "${TMPDIR:-/tmp}/fetch-pr-diff-base-fetch.XXXXXX")"
+trap 'rm -f "$base_fetch_stderr"' EXIT
 
-merge_base="$(git merge-base "origin/$BASE_REF" "$HEAD_SHA" 2>/dev/null || true)"
+merge_base=""
+if git fetch --no-tags --depth="$DEPTH" origin "$BASE_REF" 2>"$base_fetch_stderr"; then
+  if [ -s "$base_fetch_stderr" ]; then
+    cat "$base_fetch_stderr" >&2
+  fi
+else
+  merge_base="$(git merge-base "origin/$BASE_REF" "$HEAD_SHA" 2>/dev/null || true)"
+  if [ -z "$merge_base" ]; then
+    cat "$base_fetch_stderr" >&2
+    exit 1
+  fi
+  echo "Warning: failed to refresh origin/$BASE_REF, but cached origin/$BASE_REF has a merge-base with $HEAD_SHA; using cached base ref for diff metadata." >&2
+fi
+
+if [ -z "$merge_base" ]; then
+  merge_base="$(git merge-base "origin/$BASE_REF" "$HEAD_SHA" 2>/dev/null || true)"
+fi
 if [ -z "$merge_base" ]; then
   # Shallow depth didn't reach a common ancestor -- deepen once and retry.
   git fetch --no-tags --deepen="$DEPTH" origin "$BASE_REF"

--- a/scripts/repro/repro-pr-body-base-fetch-cached-fallback.sh
+++ b/scripts/repro/repro-pr-body-base-fetch-cached-fallback.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Repro: pr-body.yml fetches the PR head before scripts/fetch-pr-diff-metadata.sh
+# refreshes the base branch. If that later base refresh fails on a self-hosted
+# runner, diff metadata generation currently exits before using the already
+# cached origin/<base> ref, even when that cached ref is enough to compute the
+# correct merge-base. Confirmed live on
+# https://github.com/Neko-Catpital-Labs/Invoker/pull/8508.
+#
+# This builds a small local repo, creates a shallow CI-style checkout with
+# origin/master cached, fetches the PR head into refs/remotes/pull/999/head,
+# then points origin at an unreachable HTTPS URL before running the actual
+# metadata helper. The current implementation fails at the base refresh. After
+# the fallback fix, this same script should pass and prove the cached base ref
+# produces the expected changed-files.txt.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-pr-body-base-fetch-cached-fallback.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+git init -q --bare "$TMP/origin.git"
+git -C "$TMP/origin.git" symbolic-ref HEAD refs/heads/master
+
+WORK="$TMP/work"
+git clone -q "$TMP/origin.git" "$WORK"
+cd "$WORK"
+git config user.email test@example.com
+git config user.name Test
+
+echo base > README.md
+git add README.md
+git commit -q -m "base: initial"
+
+echo "base-only change" > base-only.txt
+git add base-only.txt
+git commit -q -m "base: add base-only file"
+BASE_SHA="$(git rev-parse HEAD)"
+git push -q origin HEAD:refs/heads/master
+
+git checkout -q -b pr-branch
+echo "pr change" > pr-file.txt
+git add pr-file.txt
+git commit -q -m "pr: add pr-file"
+git push -q origin HEAD:refs/heads/pr-branch
+
+CI="$TMP/ci-checkout"
+git clone -q --depth=2 "file://$TMP/origin.git" "$CI"
+cd "$CI"
+git fetch -q --depth=2 origin "+refs/heads/pr-branch:refs/remotes/pull/999/head"
+HEAD_SHA="$(git rev-parse refs/remotes/pull/999/head)"
+CACHED_MERGE_BASE="$(git merge-base origin/master "$HEAD_SHA")"
+if [ "$CACHED_MERGE_BASE" != "$BASE_SHA" ]; then
+  echo "[repro] FAILED: cached origin/master cannot compute the expected merge-base" >&2
+  echo "[repro] expected: $BASE_SHA" >&2
+  echo "[repro] actual:   $CACHED_MERGE_BASE" >&2
+  exit 1
+fi
+
+# Simulate the PR head fetch having succeeded, followed by a network failure
+# before the base refresh. The cached origin/master ref is still sufficient:
+# merge-base(origin/master, HEAD_SHA) is BASE_SHA.
+git remote set-url origin https://127.0.0.1:1/unreachable/repo.git
+
+export BASE_REF=master
+export BASE_SHA
+export HEAD_SHA
+bash "$ROOT/scripts/fetch-pr-diff-metadata.sh"
+
+echo "[repro] changed-files.txt:"
+sed 's/^/  /' changed-files.txt
+
+if grep -qx "base-only.txt" changed-files.txt; then
+  echo "[repro] FAILED: base-only.txt (already on cached origin/master) leaked into the diff" >&2
+  exit 1
+fi
+if ! grep -qx "pr-file.txt" changed-files.txt; then
+  echo "[repro] FAILED: pr-file.txt (the PR's real change) is missing from the diff" >&2
+  exit 1
+fi
+echo "[repro] passed: cached origin/master was enough to compute the correct PR diff"

--- a/scripts/test-suites/required/11-pr-authoring-guardrails.sh
+++ b/scripts/test-suites/required/11-pr-authoring-guardrails.sh
@@ -6,3 +6,4 @@ node scripts/test-pr-diff-atomicity.mjs
 node scripts/test-pr-body-validator.mjs
 node scripts/test-create-pr-visual-proof.mjs
 bash scripts/repro/repro-pr-body-stale-base-sha.sh
+bash scripts/repro/repro-pr-body-base-fetch-cached-fallback.sh

--- a/scripts/validate-pr-body-targets.mjs
+++ b/scripts/validate-pr-body-targets.mjs
@@ -37,6 +37,7 @@ function runOrThrow(command, args, options = {}) {
 async function main() {
   const { targetsFile } = parseArgs(process.argv.slice(2));
   const targets = JSON.parse(readFileSync(targetsFile, 'utf8'));
+  const fetchDepth = process.env.FETCH_PR_DIFF_BASE_DEPTH || '1000';
 
   const failures = [];
 
@@ -45,7 +46,7 @@ async function main() {
 
     try {
       runOrThrow('git', [
-        'fetch', '--no-tags', '--depth=1', 'origin',
+        'fetch', '--no-tags', `--depth=${fetchDepth}`, 'origin',
         `+refs/pull/${target.number}/head:refs/remotes/pull/${target.number}/head`,
       ], { stdio: 'inherit' });
       const fetchedHeadSha = runOrThrow('git', ['rev-parse', `refs/remotes/pull/${target.number}/head^{commit}`]).stdout.trim();


### PR DESCRIPTION
## Summary

Fix the trusted-base PR Body diff metadata path after the proof-only repro lands.

The validator now refreshes the base ref first, then falls back to cached trusted refs only when they still merge-base with the fetched PR head.

This keeps PR Body validation resilient to the observed self-hosted runner CA failure without accepting missing or unrelated base refs.

## Review Claim

The PR Body validator computes diff metadata from cached base refs when the base refresh fails but a valid merge-base with the fetched PR head already exists.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The fallback is used only after a failed base refresh and only when `git merge-base origin/<base> <head>` succeeds; otherwise the original failure still fails closed.

## Slice Rationale

One tooling-policy slice updates the trusted validator path and wires the already-landed repro into required guardrails, without adding new proof files.

## Non-goals

No PR body schema changes, no enforcement rollout changes, no workflow trigger changes, and no edits to PR #8508's planning contract files.

## Architecture

### Before

```mermaid
graph TD
    A["PR Body target resolver fetches the PR head at depth 1"]
    B["diff metadata script refreshes origin/<base>"]
    C["base refresh failure exits before markdown validation"]
    A --> B --> C
```

### After

```mermaid
graph TD
    A["PR Body target resolver fetches the PR head at base diff depth"]
    B["diff metadata script refreshes origin/<base>"]
    C["refresh succeeds"]
    D["refresh fails"]
    E["cached origin/<base> has merge-base with fetched head"]
    F["write changed-files.txt and pr.diff"]
    G["exit with original fetch failure"]
    A --> B
    B --> C --> F
    B --> D --> E
    E --> F
    D --> G
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-pr-body-base-fetch-cached-fallback.sh`
- [x] `node scripts/test-resolve-pr-body-targets.mjs`
- [x] `node scripts/test-pr-body-validator.mjs`
- [x] `node scripts/test-pr-diff-atomicity.mjs`
- [x] `bash scripts/test-suites/required/11-pr-authoring-guardrails.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 15b34b888`
- Post-revert steps: Re-run `bash scripts/test-suites/required/11-pr-authoring-guardrails.sh`
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pull request change detection when the base branch cannot be refreshed.
  - Cached base information is now used when valid, preventing failures in restricted or unavailable network environments.
  - Base and pull request files are more reliably identified in generated change lists.

- **Improvements**
  - Pull request diff fetch depth is now configurable, with a default depth of 1,000 for more complete comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->