### PR TITLE
[Worker desired-state provenance](1) Log persisted control changes

### DIFF
--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -140,15 +140,18 @@ function controller(
   register(PR_DUPLICATE_CLOSE_WORKER_KIND, 'Closes duplicate or already-landed pull requests.');
   register(PR_AUTO_LABEL_WORKER_KIND, 'Auto-labels refactor/bugfix/repro/test-only PRs with admin-bypass.');
   register(WORKFLOW_RESUME_WORKER_KIND, 'Resumes incomplete workflows.');
+  register(REAPER_WORKER_KIND, 'Reaps stale Invoker-managed artifacts.');
   register(E2E_AUTOFIX_WORKER_KIND, 'Runs the extended e2e battery on a schedule.');
   register('external-preview', 'External preview worker.');
 
+  const runtimeDeps = deps();
   return {
     runtimes,
+    logger: runtimeDeps.logger,
     persistence: store,
     controller: createWorkerRuntimeController({
       registry,
-      deps: deps(),
+      deps: runtimeDeps,
       autoStartKinds,
       persistence: store as never,
       canControl: () => true,
@@ -301,6 +304,47 @@ describe('createWorkerRuntimeController', () => {
       desiredEnabled: false,
       autoStarts: false,
     });
+  });
+
+  it('logs persisted worker controls and configured auto-start suppression with their source', async () => {
+    const setup = controller([REAPER_WORKER_KIND], { [REAPER_WORKER_KIND]: false });
+
+    setup.controller.startAutoStartedWorkers();
+    setup.controller.start(REAPER_WORKER_KIND, { source: 'gui-ipc' });
+    await setup.controller.stop(REAPER_WORKER_KIND);
+
+    expect(setup.logger.warn).toHaveBeenCalledWith(
+      '[worker-control] configured auto-start suppressed by persisted desired state',
+      expect.objectContaining({
+        module: 'worker-control',
+        workerKind: REAPER_WORKER_KIND,
+        configuredAutoStart: true,
+        persistedDesiredEnabled: false,
+        persistedUpdatedAt: '2026-01-01T00:00:00.000Z',
+      }),
+    );
+    expect(setup.logger.info).toHaveBeenNthCalledWith(
+      1,
+      '[worker-control] persisted desired state change',
+      expect.objectContaining({
+        module: 'worker-control',
+        workerKind: REAPER_WORKER_KIND,
+        source: 'gui-ipc',
+        previousDesiredEnabled: false,
+        desiredEnabled: true,
+      }),
+    );
+    expect(setup.logger.info).toHaveBeenNthCalledWith(
+      2,
+      '[worker-control] persisted desired state change',
+      expect.objectContaining({
+        module: 'worker-control',
+        workerKind: REAPER_WORKER_KIND,
+        source: 'controller-api',
+        previousDesiredEnabled: true,
+        desiredEnabled: false,
+      }),
+    );
   });
 
   it('auto-starts e2e-autofix only when its kind is in autoStartKinds', () => {

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -138,8 +138,8 @@ export function autoStartedOwnerWorkerKindsForConfig(
 
 export interface WorkerRuntimeController {
   startAutoStartedWorkers(): void;
-  start(kind: string, options?: { persistDesiredState?: boolean }): WorkerStatusEntry;
-  stop(kind: string): Promise<WorkerStatusEntry>;
+  start(kind: string, options?: { persistDesiredState?: boolean; source?: string }): WorkerStatusEntry;
+  stop(kind: string, options?: { source?: string }): Promise<WorkerStatusEntry>;
   stopAll(): Promise<void>;
   snapshot(): WorkerStatusSnapshot;
 }
@@ -300,6 +300,20 @@ export function createWorkerRuntimeController(options: {
     return saved?.desiredEnabled ?? options.autoStartKinds.includes(kind);
   };
 
+  const persistDesiredState = (kind: string, desiredEnabled: boolean, source: string): void => {
+    if (!options.persistence.setWorkerDesiredState) return;
+    const previous = options.persistence.getWorkerDesiredState?.(kind);
+    const saved = options.persistence.setWorkerDesiredState(kind, desiredEnabled);
+    options.deps.logger.info('[worker-control] persisted desired state change', {
+      module: 'worker-control',
+      workerKind: kind,
+      source,
+      previousDesiredEnabled: previous?.desiredEnabled,
+      desiredEnabled,
+      persistedUpdatedAt: saved?.updatedAt,
+    });
+  };
+
   const rowForKind = (kind: string): WorkerStatusEntry => {
     const definition = options.registry.get(kind);
     if (!definition) {
@@ -338,15 +352,31 @@ export function createWorkerRuntimeController(options: {
   return {
     startAutoStartedWorkers(): void {
       for (const definition of options.registry.list()) {
+        const saved = options.persistence.getWorkerDesiredState?.(definition.kind);
+        if (
+          saved?.desiredEnabled === false
+          && options.autoStartKinds.includes(definition.kind)
+        ) {
+          options.deps.logger.warn(
+            '[worker-control] configured auto-start suppressed by persisted desired state',
+            {
+              module: 'worker-control',
+              workerKind: definition.kind,
+              configuredAutoStart: true,
+              persistedDesiredEnabled: false,
+              persistedUpdatedAt: saved.updatedAt,
+            },
+          );
+        }
         if (!desiredEnabledForKind(definition.kind)) continue;
         this.start(definition.kind, { persistDesiredState: false });
       }
     },
 
-    start(kind: string, optionsArg?: { persistDesiredState?: boolean }): WorkerStatusEntry {
+    start(kind: string, optionsArg?: { persistDesiredState?: boolean; source?: string }): WorkerStatusEntry {
       const definition = requireDefinition(kind);
       if (optionsArg?.persistDesiredState !== false) {
-        options.persistence.setWorkerDesiredState?.(kind, true);
+        persistDesiredState(kind, true, optionsArg?.source ?? 'controller-api');
       }
 
       const existing = handles.get(kind);
@@ -367,9 +397,9 @@ export function createWorkerRuntimeController(options: {
       stoppedAtByKind.delete(kind);
       return rowForKind(kind);
     },
-    async stop(kind: string): Promise<WorkerStatusEntry> {
+    async stop(kind: string, optionsArg?: { source?: string }): Promise<WorkerStatusEntry> {
       requireDefinition(kind);
-      options.persistence.setWorkerDesiredState?.(kind, false);
+      persistDesiredState(kind, false, optionsArg?.source ?? 'controller-api');
       const handle = handles.get(kind);
       if (!handle) {
         return rowForKind(kind);


### PR DESCRIPTION
## Summary

Persisted worker choices currently identify neither their caller nor the configured startup they replace.

Explicit controls now log their supplied source and old/new desire. Owner boot records when saved state replaces configured auto-start.

## Review Claim

Approve structured provenance logs for persisted worker controls and configured startup replacements.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Worker start/stop semantics and persisted values remain unchanged; only structured provenance records are added.

## Slice Rationale

The controller owns desired-state precedence and emits both transition and startup-selection records at that boundary.

## Non-goals

- No worker is enabled or disabled automatically.
- No desired-state precedence change.
- No database schema or retention change.

## Architecture

### Before

```mermaid
flowchart LR
    A["Explicit worker control"] --> B["Persist desired state without provenance"]
    C["Owner boot"] --> D["Saved state silently replaces configured startup"]
```

### After

```mermaid
flowchart LR
    A["Explicit worker control"] --> B["Persist unchanged state and log source plus transition"]
    C["Owner boot"] --> D["Saved choice remains authoritative and emits a diagnostic"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test --run src/__tests__/worker-control.test.ts`
- [x] `pnpm check:types`
- [x] `pnpm --filter @invoker/app build`
- [x] `git diff --check`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c7394ac84`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source tracking for worker start and stop actions.
  * Added logging of desired-state changes, including previous and current states.
  * Added warnings when automatic startup is suppressed by a persisted disabled state.
  * Added contextual details to worker control logs, including the worker and action source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->