### PR TITLE
[Slack Channel Repository Routing](2) Provision and route bound channels

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -247,6 +247,10 @@ export interface InvokerConfig {
   slackRepos?: Record<string, string>;
   /** Repo URL used for Slack planning when the message carries no `[repo:]` tag. */
   defaultRepoUrl?: string;
+  /** Slack user IDs allowed to run Slack administrative actions. */
+  slackAdminUserIds?: string[];
+  /** Stable Slack channel ID → default repository URL for channel-scoped planning. */
+  slackChannelRepos?: Record<string, string>;
   /** Maximum number of tasks that can run concurrently. Default: 6. */
   maxConcurrency?: number;
   /** Browser executable for opening external URLs (e.g. "firefox"). Default: Chrome. */

--- a/packages/slack-manager/src/__tests__/runtime-config.test.ts
+++ b/packages/slack-manager/src/__tests__/runtime-config.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 
 import { describe, expect, it } from 'vitest';
 
-import { readDefaultSlackHarnessPreset, readSlackRuntimeConfig, resolveDefaultHarnessPreset } from '../runtime-config.js';
+import { readDefaultSlackHarnessPreset, readSlackRuntimeConfig, resolveDefaultHarnessPreset, resolveSlackAdminUserIds } from '../runtime-config.js';
 
 describe('runtime-config', () => {
   it('reads defaultSlackHarnessPreset from ~/.invoker/config.json shape', () => {
@@ -28,11 +28,22 @@ describe('runtime-config', () => {
         notarepo: 'https://github.com/EdbertChan/notarepo.git',
         invalid: 42,
       },
+      slackAdminUserIds: ['U_ADMIN', '', 42],
+      slackChannelRepos: {
+        C_INVOKER: 'https://github.com/Neko-Catpital-Labs/Invoker',
+        C_RIPS: 'https://github.com/EdbertChan/notarepo',
+        invalid: '',
+      },
     }));
 
     expect(readSlackRuntimeConfig(configPath)).toEqual({
       defaultRepoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
       repoAliases: { notarepo: 'https://github.com/EdbertChan/notarepo.git' },
+      adminUserIds: ['U_ADMIN'],
+      channelRepoBindings: {
+        C_INVOKER: 'https://github.com/Neko-Catpital-Labs/Invoker',
+        C_RIPS: 'https://github.com/EdbertChan/notarepo',
+      },
     });
   });
 
@@ -44,5 +55,9 @@ describe('runtime-config', () => {
   // INVOKER_SLACK_DEFAULT_PRESET in ~/.invoker/.slack-owner.env.
   it('prefers ~/.invoker/config.json over a stale owner env preset', () => {
     expect(resolveDefaultHarnessPreset('omp+codex', 'codex')).toBe('codex');
+  });
+
+  it('unions Slack admin user IDs from config and owner env', () => {
+    expect(resolveSlackAdminUserIds('U_ENV, U_ADMIN,', ['U_ADMIN', 'U_CFG'])).toEqual(['U_ADMIN', 'U_CFG', 'U_ENV']);
   });
 });

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -19,7 +19,7 @@ import { ConversationRepository, SlackPlanDraftRepository, SlackSessionRepositor
 
 import { IpcInvokerClient } from './invoker-client.js';
 import { createInvokerLauncher } from './invoker-launcher.js';
-import { readSlackRuntimeConfig, resolveDefaultHarnessPreset } from './runtime-config.js';
+import { readSlackRuntimeConfig, resolveDefaultHarnessPreset, resolveSlackAdminUserIds } from './runtime-config.js';
 import { createRunWorkflowOp } from './workflow-ops.js';
 import { createCommandHandler } from './command-handler.js';
 import { startEventSubscription } from './event-subscription.js';
@@ -113,6 +113,7 @@ async function main(): Promise<void> {
   const runtimeConfig = readSlackRuntimeConfig();
   const repoUrl = process.env.INVOKER_REPO_URL ?? runtimeConfig.defaultRepoUrl ?? detectRepoUrl(repoRoot, log);
   const defaultHarnessPreset = resolveDefaultHarnessPreset(process.env.INVOKER_SLACK_DEFAULT_PRESET, runtimeConfig.defaultHarnessPreset);
+  const adminUserIds = resolveSlackAdminUserIds(process.env.INVOKER_SLACK_ADMIN_USER_IDS, runtimeConfig.adminUserIds);
 
   const launcher = createInvokerLauncher({
     repoRoot,
@@ -148,6 +149,8 @@ async function main(): Promise<void> {
     repoUrl,
     defaultRepoUrl: repoUrl,
     repoAliases: runtimeConfig.repoAliases,
+    channelRepoBindings: runtimeConfig.channelRepoBindings,
+    adminUserIds,
     runWorkflowOp,
     gatherWorkflowContext,
     onRestartInvoker: async () => {

--- a/packages/slack-manager/src/runtime-config.ts
+++ b/packages/slack-manager/src/runtime-config.ts
@@ -14,10 +14,12 @@ export interface SlackRuntimeConfig {
   defaultHarnessPreset?: string;
   defaultRepoUrl?: string;
   repoAliases: Record<string, string>;
+  adminUserIds?: string[];
+  channelRepoBindings?: Record<string, string>;
 }
 
 export function readSlackRuntimeConfig(configPath = resolveInvokerConfigPath()): SlackRuntimeConfig {
-  const empty: SlackRuntimeConfig = { repoAliases: {} };
+  const empty: SlackRuntimeConfig = { repoAliases: {}, adminUserIds: [], channelRepoBindings: {} };
   if (!existsSync(configPath)) return empty;
   try {
     const raw = JSON.parse(readFileSync(configPath, 'utf8'));
@@ -26,7 +28,14 @@ export function readSlackRuntimeConfig(configPath = resolveInvokerConfigPath()):
       defaultSlackHarnessPreset?: unknown;
       defaultRepoUrl?: unknown;
       slackRepos?: unknown;
+      slackAdminUserIds?: unknown;
+      slackChannelRepos?: unknown;
     };
+    const readStringRecord = (value: unknown): Record<string, string> => Object.fromEntries(
+      Object.entries(value && typeof value === 'object' && !Array.isArray(value) ? value : {}).filter(
+        (entry): entry is [string, string] => typeof entry[0] === 'string' && typeof entry[1] === 'string' && entry[1].trim().length > 0,
+      ),
+    );
     const repoAliases = Object.fromEntries(
       Object.entries(
         config.slackRepos && typeof config.slackRepos === 'object' && !Array.isArray(config.slackRepos)
@@ -44,6 +53,10 @@ export function readSlackRuntimeConfig(configPath = resolveInvokerConfigPath()):
         ? config.defaultRepoUrl.trim()
         : undefined,
       repoAliases,
+      adminUserIds: Array.isArray(config.slackAdminUserIds)
+        ? config.slackAdminUserIds.filter((value): value is string => typeof value === 'string' && value.trim().length > 0).map((value) => value.trim())
+        : [],
+      channelRepoBindings: readStringRecord(config.slackChannelRepos),
     };
   } catch {
     return empty;
@@ -54,4 +67,12 @@ export function resolveDefaultHarnessPreset(envPreset: string | undefined, confi
   if (configPreset?.trim()) return configPreset.trim();
   if (envPreset?.trim()) return envPreset.trim();
   return undefined;
+}
+
+export function resolveSlackAdminUserIds(envUserIds: string | undefined, configUserIds: string[] | undefined): string[] {
+  const values = [
+    ...(configUserIds ?? []),
+    ...(envUserIds?.split(',') ?? []),
+  ].map((value) => value.trim()).filter(Boolean);
+  return [...new Set(values)];
 }

--- a/packages/surfaces/src/__tests__/slack-planning-session-happy-path.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-planning-session-happy-path.e2e.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 import { SlackSurface } from '../slack/slack-surface.js';
 import { SQLiteAdapter, ConversationRepository, SlackPlanDraftRepository, SlackSessionRepository, WorkflowChannelRepository } from '@invoker/data-store';
 
@@ -99,7 +100,10 @@ tasks:
     dependencies: [audit-findings]
 `;
 
-async function buildSurface(onCommand: (command: unknown) => Promise<unknown>) {
+async function buildSurface(
+  onCommand: (command: unknown) => Promise<unknown>,
+  extra: Partial<ConstructorParameters<typeof SlackSurface>[0]> = {},
+) {
   const adapter = await SQLiteAdapter.create(':memory:');
   const slackPlanDraftRepo = new SlackPlanDraftRepository(adapter);
   const surface = new SlackSurface({
@@ -115,6 +119,7 @@ async function buildSurface(onCommand: (command: unknown) => Promise<unknown>) {
     slackSessionRepo: new SlackSessionRepository(adapter),
     slackPlanDraftRepo,
     workflowChannelRepo: new WorkflowChannelRepository(adapter),
+    ...extra,
   });
   await surface.start(onCommand as never);
   return { surface, slackPlanDraftRepo };
@@ -175,7 +180,10 @@ describe('slack planning session happy path', () => {
       planText: draft!.planText,
       repoUrl: 'https://github.com/example/repo.git',
     }));
-    expect(draft?.planText).toContain('name: "CodeRabbit Audit"');
+    expect(parseYaml(draft!.planText)).toMatchObject({
+      name: 'CodeRabbit Audit',
+      repoUrl: 'https://github.com/example/repo.git',
+    });
 
     const submitted = slackPlanDraftRepo.get(draft!.draftId, draft!.version);
     expect(submitted?.status).toBe('submitted');
@@ -194,5 +202,60 @@ describe('slack planning session happy path', () => {
 
     expect(slackPlanDraftRepo.getReady('C-test', 'thread-scoping')).toBeUndefined();
     expect(onCommand).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'start_plan' }));
+  });
+
+  it('channel defaults normalize staged YAML and approved start_plan repoUrl for the reported channels', async () => {
+    const repos = {
+      C_INVOKER_REPO: 'https://github.com/Neko-Catpital-Labs/Invoker',
+      C_RIPS_REPO: 'https://github.com/EdbertChan/notarepo',
+    };
+    const onCommand = vi.fn(async () => ({ workflowIds: ['wf-channel'] }));
+    const { surface, slackPlanDraftRepo } = await buildSurface(onCommand, {
+      defaultRepoUrl: 'https://github.com/example/default',
+      channelRepoBindings: repos,
+    });
+    const approve = actionHandler(surface, 'plan_draft_approve');
+
+    for (const [channelId, repoUrl] of Object.entries(repos)) {
+      nextReply = 'Draft ready.';
+      nextDraftPlanText = `name: "Channel pinned"
+repoUrl: "https://github.com/wrong/root"
+workflows:
+  - name: Child workflow
+    repoUrl: "https://github.com/wrong/child"
+    tasks:
+      - id: proof
+        description: "Prove channel pinning"
+        command: "pnpm test"
+        dependencies: []
+`;
+      const threadTs = `${channelId}-thread`;
+
+      await mentionHandler(surface)({
+        event: { text: '<@UBOT> draft a channel-pinned plan', ts: threadTs, user: 'U1', channel: channelId },
+        say: vi.fn().mockResolvedValue({ ts: `${threadTs}-card` }),
+      });
+
+      const draft = slackPlanDraftRepo.getReady(channelId, threadTs);
+      expect(draft?.repoUrl).toBe(repoUrl);
+      expect(draft?.planText.match(new RegExp(`repoUrl: ${repoUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'g'))).toHaveLength(2);
+      expect(parseYaml(draft!.planText)).toMatchObject({
+        repoUrl,
+        workflows: [{ repoUrl }],
+      });
+
+      await approve({
+        action: { type: 'button', value: `${draft!.draftId}:${draft!.version}` },
+        body: { channel: { id: draft!.channelId }, message: { thread_ts: draft!.threadTs }, user: { id: 'U1' } },
+        ack: vi.fn().mockResolvedValue(undefined),
+        respond: vi.fn().mockResolvedValue(undefined),
+      });
+
+      expect(onCommand).toHaveBeenLastCalledWith(expect.objectContaining({
+        type: 'start_plan',
+        repoUrl,
+        planText: draft!.planText,
+      }));
+    }
   });
 });

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -676,8 +676,9 @@ describe('lobby verb routing', () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     const conversationRepo = new ConversationRepository(adapter, { info: silentLog, warn: silentLog, error: silentLog });
     const slackSessionRepo = new SlackSessionRepository(adapter);
-    const surface = lobbySurface(true, { conversationRepo, slackSessionRepo, ...extra });
-    return { adapter, conversationRepo, slackSessionRepo, surface };
+    const workflowChannelRepo = new WorkflowChannelRepository(adapter);
+    const surface = lobbySurface(true, { conversationRepo, slackSessionRepo, workflowChannelRepo, ...extra });
+    return { adapter, conversationRepo, slackSessionRepo, workflowChannelRepo, surface };
   }
 
   it('returns only the final Codex message from one-shot Slack replies', async () => {
@@ -1130,6 +1131,244 @@ describe('lobby verb routing', () => {
     });
     expect(multipleSay).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('multiple repository URLs') }));
     expect(planConversationConfigs).toHaveLength(0);
+  });
+
+  it('provisions the reported public repo channels and routes each channel by resolved ID', async () => {
+    const { adapter, slackSessionRepo, workflowChannelRepo, surface } = await persistentLobbySurface({
+      adminUserIds: ['U_ADMIN'],
+      defaultRepoUrl: 'https://github.com/example/default',
+    });
+    const client = (surface.getApp() as any).client;
+    client.conversations.create
+      .mockResolvedValueOnce({ channel: { id: 'C_INVOKER_REPO' } })
+      .mockResolvedValueOnce({ channel: { id: 'C_RIPS_REPO' } });
+
+    try {
+      await surface.start(async (cmd) => { received.push(cmd); });
+      const setupSay = vi.fn().mockResolvedValue({ ts: 'setup-reply' });
+      await mentionHandler(surface)({
+        event: {
+          text: '<@BOT> set up #invoker-repo https://github.com/Neko-Catpital-Labs/Invoker and #rips-clone-mobile-repo https://github.com/EdbertChan/notarepo',
+          ts: 'setup-thread',
+          user: 'U_ADMIN',
+          channel: 'CLOBBY',
+        },
+        say: setupSay,
+      });
+
+      expect(client.conversations.create).toHaveBeenNthCalledWith(1, { name: 'invoker-repo', is_private: false });
+      expect(client.conversations.create).toHaveBeenNthCalledWith(2, { name: 'rips-clone-mobile-repo', is_private: false });
+      expect(setupSay.mock.calls.map((call) => call[0].text).join('\n')).not.toContain('multiple repository URLs');
+      expect(workflowChannelRepo.getByChannelId('C_INVOKER_REPO')?.repoUrl).toBe('https://github.com/Neko-Catpital-Labs/Invoker');
+      expect(workflowChannelRepo.getByChannelId('C_RIPS_REPO')?.repoUrl).toBe('https://github.com/EdbertChan/notarepo');
+      expect(planConversationConfigs).toHaveLength(0);
+
+      await mentionHandler(surface)({
+        event: { text: '<@BOT> plan: harden routing', ts: 'invoker-thread', user: 'U1', channel: 'C_INVOKER_REPO' },
+        say: vi.fn().mockResolvedValue({ ts: 'invoker-reply' }),
+      });
+      await mentionHandler(surface)({
+        event: { text: '<@BOT> plan: harden routing', ts: 'rips-thread', user: 'U1', channel: 'C_RIPS_REPO' },
+        say: vi.fn().mockResolvedValue({ ts: 'rips-reply' }),
+      });
+
+      expect(planConversationConfigs.at(-2)).toEqual(expect.objectContaining({
+        channelId: 'C_INVOKER_REPO',
+        repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker',
+      }));
+      expect(planConversationConfigs.at(-1)).toEqual(expect.objectContaining({
+        channelId: 'C_RIPS_REPO',
+        repoUrl: 'https://github.com/EdbertChan/notarepo',
+      }));
+      expect(slackSessionRepo.getLaunchContext('invoker-thread')?.repoUrl).toBe('https://github.com/Neko-Catpital-Labs/Invoker');
+      expect(slackSessionRepo.getLaunchContext('rips-thread')?.repoUrl).toBe('https://github.com/EdbertChan/notarepo');
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
+  });
+
+  it('denies channel repository setup from a non-admin before Slack channel creation', async () => {
+    const { adapter, workflowChannelRepo, surface } = await persistentLobbySurface({ adminUserIds: ['U_ADMIN'] });
+    const client = (surface.getApp() as any).client;
+    try {
+      await surface.start(async () => {});
+      const say = vi.fn().mockResolvedValue({ ts: 'denied' });
+      await mentionHandler(surface)({
+        event: {
+          text: '<@BOT> set up #invoker-repo https://github.com/Neko-Catpital-Labs/Invoker and #rips-clone-mobile-repo https://github.com/EdbertChan/notarepo',
+          ts: 'setup-denied',
+          user: 'U_INTRUDER',
+          channel: 'CLOBBY',
+        },
+        say,
+      });
+
+      expect(client.conversations.create).not.toHaveBeenCalled();
+      expect(workflowChannelRepo.list()).toHaveLength(0);
+      expect(planConversationConfigs).toHaveLength(0);
+      expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Permission denied') }));
+      expect(say.mock.calls.map((call) => call[0].text).join('\n')).not.toContain('multiple repository URLs');
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
+  });
+
+  it('reuses an existing public channel ID on channel setup name_taken', async () => {
+    const { adapter, workflowChannelRepo, surface } = await persistentLobbySurface({ adminUserIds: ['U_ADMIN'] });
+    const client = (surface.getApp() as any).client;
+    client.conversations.create.mockRejectedValueOnce({ data: { error: 'name_taken' } });
+    client.conversations.list.mockResolvedValueOnce({ channels: [{ id: 'C_EXISTING', name: 'invoker-repo', is_private: false }] });
+
+    try {
+      await surface.start(async () => {});
+      await mentionHandler(surface)({
+        event: {
+          text: '<@BOT> map #invoker-repo to https://github.com/Neko-Catpital-Labs/Invoker',
+          ts: 'setup-name-taken',
+          user: 'U_ADMIN',
+          channel: 'CLOBBY',
+        },
+        say: vi.fn().mockResolvedValue({ ts: 'ok' }),
+      });
+
+      expect(client.conversations.list).toHaveBeenCalledWith({ types: 'public_channel', limit: 1000 });
+      expect(workflowChannelRepo.getByChannelId('C_EXISTING')?.repoUrl).toBe('https://github.com/Neko-Catpital-Labs/Invoker');
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
+  });
+
+  it('keeps successful channel bindings when a later setup pair fails', async () => {
+    const { adapter, workflowChannelRepo, surface } = await persistentLobbySurface({ adminUserIds: ['U_ADMIN'] });
+    const client = (surface.getApp() as any).client;
+    client.conversations.create
+      .mockResolvedValueOnce({ channel: { id: 'C_OK' } })
+      .mockRejectedValueOnce({ data: { error: 'missing_scope' } });
+
+    try {
+      await surface.start(async () => {});
+      const say = vi.fn().mockResolvedValue({ ts: 'partial' });
+      await mentionHandler(surface)({
+        event: {
+          text: '<@BOT> setup #invoker-repo https://github.com/Neko-Catpital-Labs/Invoker #rips-clone-mobile-repo https://github.com/EdbertChan/notarepo',
+          ts: 'setup-partial',
+          user: 'U_ADMIN',
+          channel: 'CLOBBY',
+        },
+        say,
+      });
+
+      expect(workflowChannelRepo.getByChannelId('C_OK')?.repoUrl).toBe('https://github.com/Neko-Catpital-Labs/Invoker');
+      expect(workflowChannelRepo.list()).toHaveLength(1);
+      expect(say.mock.calls.map((call) => call[0].text).join('\n')).toContain('Failed to configure: #rips-clone-mobile-repo');
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
+  });
+
+  it('falls back to defaultRepoUrl in an unmapped channel', async () => {
+    const surface = lobbySurface(true, { defaultRepoUrl: 'https://github.com/example/default' });
+    await surface.start(async () => {});
+
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> plan: add fallback behavior', ts: 'fallback-thread', user: 'U1', channel: 'C_UNMAPPED' },
+      say: vi.fn().mockResolvedValue({ ts: 'fallback' }),
+    });
+
+    expect(planConversationConfigs.at(-1)).toEqual(expect.objectContaining({
+      channelId: 'C_UNMAPPED',
+      repoUrl: 'https://github.com/example/default',
+    }));
+  });
+
+  it('lets an explicit repo selector win over a channel default with a visible notice', async () => {
+    const { adapter, surface } = await persistentLobbySurface({
+      defaultRepoUrl: 'https://github.com/example/default',
+      channelRepoBindings: { C_INVOKER: 'https://github.com/Neko-Catpital-Labs/Invoker' },
+      repoAliases: { mobile: 'https://github.com/EdbertChan/notarepo' },
+    });
+    try {
+      await surface.start(async () => {});
+      const say = vi.fn().mockResolvedValue({ ts: 'notice' });
+      await mentionHandler(surface)({
+        event: { text: '<@BOT> [repo:mobile] plan: add mobile behavior', ts: 'override-thread', user: 'U1', channel: 'C_INVOKER' },
+        say,
+      });
+
+      expect(planConversationConfigs.at(-1)).toEqual(expect.objectContaining({
+        channelId: 'C_INVOKER',
+        repoUrl: 'https://github.com/EdbertChan/notarepo',
+      }));
+      expect(say.mock.calls.map((call) => call[0].text).join('\n')).toContain('instead of this channel\'s default');
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
+  });
+
+  it('keeps an existing thread pinned when the channel default changes', async () => {
+    const { adapter, slackSessionRepo, surface } = await persistentLobbySurface({
+      defaultRepoUrl: 'https://github.com/example/default',
+      channelRepoBindings: { C_INVOKER: 'https://github.com/Neko-Catpital-Labs/Invoker' },
+    });
+    try {
+      await surface.start(async () => {});
+      await mentionHandler(surface)({
+        event: { text: '<@BOT> plan: start here', ts: 'pinned-thread', user: 'U1', channel: 'C_INVOKER' },
+        say: vi.fn().mockResolvedValue({ ts: 'start' }),
+      });
+
+      (surface as any).channelRepoBindings.C_INVOKER = 'https://github.com/EdbertChan/notarepo';
+
+      await mentionHandler(surface)({
+        event: { text: '<@BOT> continue planning', ts: 'pinned-thread-reply', thread_ts: 'pinned-thread', user: 'U1', channel: 'C_INVOKER' },
+        say: vi.fn().mockResolvedValue({ ts: 'continue' }),
+      });
+
+      expect(slackSessionRepo.getLaunchContext('pinned-thread')?.repoUrl).toBe('https://github.com/Neko-Catpital-Labs/Invoker');
+      expect(planConversationConfigs[0].repoUrl).toBe('https://github.com/Neko-Catpital-Labs/Invoker');
+      expect(planConversationConfigs).toHaveLength(1);
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
+  });
+
+  it('routes by resolved channel ID after the setup channel is renamed', async () => {
+    const { adapter, surface } = await persistentLobbySurface({ adminUserIds: ['U_ADMIN'] });
+    const client = (surface.getApp() as any).client;
+    client.conversations.create.mockRejectedValueOnce({ data: { error: 'name_taken' } });
+    client.conversations.list.mockResolvedValueOnce({ channels: [{ id: 'C_STABLE', name: 'old-invoker-repo', is_private: false }] });
+
+    try {
+      await surface.start(async () => {});
+      await mentionHandler(surface)({
+        event: {
+          text: '<@BOT> bind #old-invoker-repo to https://github.com/Neko-Catpital-Labs/Invoker',
+          ts: 'setup-rename',
+          user: 'U_ADMIN',
+          channel: 'CLOBBY',
+        },
+        say: vi.fn().mockResolvedValue({ ts: 'setup' }),
+      });
+
+      await mentionHandler(surface)({
+        event: { text: '<@BOT> plan: after rename', ts: 'renamed-thread', user: 'U1', channel: 'C_STABLE' },
+        say: vi.fn().mockResolvedValue({ ts: 'renamed' }),
+      });
+
+      expect(planConversationConfigs.at(-1)).toEqual(expect.objectContaining({
+        channelId: 'C_STABLE',
+        repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker',
+      }));
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
   });
 
   it('lets a [repo:] tag win over a repo URL in the same first plan message', async () => {

--- a/packages/surfaces/src/__tests__/slack-surface.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface.test.ts
@@ -642,7 +642,11 @@ describe('SlackSurface', () => {
         respond: vi.fn().mockResolvedValue(undefined),
       });
       expect(receivedCommands).toEqual([
-        expect.objectContaining({ type: 'start_plan', planText }),
+        expect.objectContaining({
+          type: 'start_plan',
+          repoUrl: 'https://github.com/example/repo.git',
+          planText: expect.stringContaining('repoUrl: https://github.com/example/repo.git'),
+        }),
       ]);
     });
 

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -119,6 +119,8 @@ export interface SlackSurfaceConfig {
   repoAliases?: Record<string, string>;
   /** Repo URL used when the message carries no `[repo:]` tag. */
   defaultRepoUrl?: string;
+  /** Channel ID → repo URL defaults. Channel IDs are stable across renames; channel names are not accepted here. */
+  channelRepoBindings?: Record<string, string>;
   /** Default Slack plan review mode. Default: 'require'. */
   defaultPlanningConfirmationMode?: PlanningConfirmationMode;
   /** Persisted workflow↔channel mapping for routing + channel creation. */
@@ -219,6 +221,9 @@ const MESSAGE_REPO_TOKEN_RE = /<((?:https?|ssh):\/\/[^|>\s]+|git@[\w.-]+:[^|>\s]
 const TRAILING_URL_PUNCTUATION = new Set(['.', ',', ';', ':', '!']);
 const GITHUB_REPO_ROOT_PATH_RE = /^\/[^/]+\/[^/]+(?:\.git)?\/?$/;
 const INVALID_LITERAL_REPO_URL_GUIDANCE = 'Use a GitHub repo URL or a clone URL ending in .git.';
+const CHANNEL_REPO_BINDING_WORKFLOW_PREFIX = '__slack_channel_repo__:';
+const CHANNEL_REPO_SETUP_INTENT_RE = /\b(?:set\s*up|setup|configure|map|bind)\b/i;
+const CHANNEL_REPO_PAIR_RE = /#([A-Za-z0-9][A-Za-z0-9_-]{0,79})\s*(?:(?:=>|->|=|:|\bto\b|\bfor\b|\brepo(?:sitory)?\b)\s*)?(<((?:https?|ssh):\/\/[^|>\s]+|git@[\w.-]+:[^|>\s]+)(?:\|[^>]+)?>|\b(?:https?:\/\/[^\s<>()\[\]{}"'|]+|ssh:\/\/[^\s<>()\[\]{}"'|]+|git@[\w.-]+:[^\s<>()\[\]{}"'|]+))/gi;
 
 /** A leading bracket tag is a likely preset attempt when it names a known tool or uses the tool+model form. */
 function looksLikePreset(normalized: string): boolean {
@@ -388,6 +393,45 @@ function repositoryIdentity(repoUrl: string): string {
   return `${host}/${path}`;
 }
 
+function channelRepoBindingWorkflowId(channelId: string): string {
+  return `${CHANNEL_REPO_BINDING_WORKFLOW_PREFIX}${channelId}`;
+}
+
+function isChannelRepoBinding(mapping: WorkflowChannel | undefined | null): boolean {
+  return !!mapping?.workflowId?.startsWith(CHANNEL_REPO_BINDING_WORKFLOW_PREFIX);
+}
+
+function normalizePublicChannelName(name: string): string {
+  return name.trim().replace(/^#/, '').toLowerCase().replace(/[^a-z0-9_-]/g, '-').replace(/^-+|-+$/g, '').slice(0, 80);
+}
+
+interface ChannelRepoSetupPair {
+  channelName: string;
+  repoUrl: string;
+}
+
+function parseChannelRepoSetupRequest(text: string): ChannelRepoSetupPair[] | null {
+  if (!CHANNEL_REPO_SETUP_INTENT_RE.test(text)) return null;
+  const repositoryUrls = extractRepositoryUrls(text);
+  if (repositoryUrls.length === 0) return null;
+
+  const pairs: ChannelRepoSetupPair[] = [];
+  const seenChannels = new Set<string>();
+  for (const match of text.matchAll(CHANNEL_REPO_PAIR_RE)) {
+    const channelName = normalizePublicChannelName(match[1]);
+    let rawRepo = (match[3] ?? match[2]).trim();
+    while (rawRepo && TRAILING_URL_PUNCTUATION.has(rawRepo.at(-1)!)) {
+      rawRepo = rawRepo.slice(0, -1);
+    }
+    const repoUrl = normalizeSupportedRepoCandidate(rawRepo);
+    if (!channelName || !repoUrl || seenChannels.has(channelName)) return null;
+    seenChannels.add(channelName);
+    pairs.push({ channelName, repoUrl });
+  }
+
+  return pairs.length === repositoryUrls.length ? pairs : null;
+}
+
 // ── Lobby intent routing ─────────────────────────────────────
 
 export function parseWorkflowStatusQuery(text: string): { intent: 'command'; operation: 'status'; target: { all: true } } | null {
@@ -551,6 +595,7 @@ export class SlackSurface implements Surface {
   private defaultHarnessPreset: string;
   private repoAliases: Record<string, string>;
   private defaultRepoUrl?: string;
+  private channelRepoBindings: Record<string, string>;
   private workflowChannelRepo?: WorkflowChannelRepository;
   private gatherWorkflowContext?: (workflowId: string) => Promise<WorkflowContext>;
   private runWorkflowOp?: (op: WorkflowOp, onProgress?: (p: WorkflowOpProgress) => void) => Promise<WorkflowOpResult>;
@@ -592,6 +637,7 @@ export class SlackSurface implements Surface {
     this.defaultHarnessPreset = config.defaultHarnessPreset ?? DEFAULT_HARNESS_PRESET;
     this.repoAliases = config.repoAliases ?? {};
     this.defaultRepoUrl = config.defaultRepoUrl ?? config.repoUrl;
+    this.channelRepoBindings = config.channelRepoBindings ?? {};
     this.defaultPlanningConfirmationMode = config.defaultPlanningConfirmationMode ?? 'require';
     this.workflowChannelRepo = config.workflowChannelRepo;
     this.gatherWorkflowContext = config.gatherWorkflowContext;
@@ -966,7 +1012,7 @@ export class SlackSurface implements Surface {
     channel: string,
     mapping?: WorkflowChannel,
   ): Promise<void> {
-    if (mapping) {
+    if (mapping && !isChannelRepoBinding(mapping)) {
       this.log('slack', 'info', `[MENTION_ROUTE] instance=${this.instanceId} event_ts=${event.ts} route=workflow workflow=${mapping.workflowId}`);
       await this.handleWorkflowAssistantMention(mapping, event, say);
       return;
@@ -1009,6 +1055,12 @@ export class SlackSurface implements Surface {
       return;
     }
 
+    const channelRepoSetup = parseChannelRepoSetupRequest(parsed.text);
+    if (channelRepoSetup) {
+      await this.handleChannelRepoSetup(channelRepoSetup, event, channel, say);
+      return;
+    }
+
     const preset = this.resolveHarnessPreset(parsed.presetKey);
     const explicitRepoResolution = parsed.repo ? this.resolveRepoUrl(parsed.repo) : {};
     if (explicitRepoResolution.error) {
@@ -1031,10 +1083,19 @@ export class SlackSurface implements Surface {
       ? this.findMentionedRepoAlias(parsed.text)
       : undefined;
     const mentionedRepoResolution = mentionedRepoAlias ? this.resolveRepoUrl(mentionedRepoAlias) : {};
+    const channelDefaultRepoUrl = this.resolveChannelDefaultRepoUrl(channel);
     const routeRepoUrl = explicitRepoResolution.url
       ?? detectedRepoResolution.url
       ?? mentionedRepoResolution.url
+      ?? channelDefaultRepoUrl
       ?? this.resolveRepoUrl().url;
+
+    if ((parsed.repo || repositoryUrls.length === 1) && channelDefaultRepoUrl && routeRepoUrl && !sameRepoUrl(channelDefaultRepoUrl, routeRepoUrl)) {
+      await say({
+        text: `Using explicitly selected repository \`${repoDisplayName(routeRepoUrl)}\` instead of this channel's default \`${repoDisplayName(channelDefaultRepoUrl)}\`.`,
+        thread_ts: event.ts,
+      });
+    }
 
     if (/^\/plan\s+.+/i.test(parsed.text)) {
       const context: PlanningContext = {
@@ -1215,11 +1276,13 @@ export class SlackSurface implements Surface {
       });
       return;
     }
+    const normalizedPlanText = this.normalizeDraftedPlanRepoUrl(draftReview.planText, context.repoUrl);
+    const normalizedSummary = summarizePlanText(normalizedPlanText) ?? draftReview.summary;
     const draft = this.slackPlanDraftRepo.create({
       channelId: channel,
       threadTs,
-      planText: draftReview.planText,
-      summaryJson: JSON.stringify(draftReview.summary),
+      planText: normalizedPlanText,
+      summaryJson: JSON.stringify(normalizedSummary),
       repoUrl: context.repoUrl,
       harnessPreset: context.presetKey,
       workingDir: context.workingDir,
@@ -1227,7 +1290,7 @@ export class SlackSurface implements Surface {
       confirmationMode: draftReview.confirmationMode,
     });
     try {
-      await this.postSlackPlanDraft(draft, draftReview.summary, say);
+      await this.postSlackPlanDraft(draft, normalizedSummary, say);
     } catch (error) {
       // The draft row already exists at this point and postSlackPlanDraft has
       // already surfaced the failure by updating the Slack message in place,
@@ -1251,14 +1314,15 @@ export class SlackSurface implements Surface {
     if (!this.slackPlanDraftRepo) {
       throw new Error('Slack plan reviews are not configured in this deployment.');
     }
-    const summary = summarizePlanText(input.planText);
+    const planText = this.normalizeDraftedPlanRepoUrl(input.planText, input.repoUrl);
+    const summary = summarizePlanText(planText);
     if (!summary) {
       throw new Error('The supplied plan YAML could not be summarized for Slack review.');
     }
     const draft = this.slackPlanDraftRepo.create({
       channelId: input.channelId,
       threadTs: input.threadTs,
-      planText: input.planText,
+      planText,
       summaryJson: JSON.stringify(summary),
       repoUrl: input.repoUrl,
       harnessPreset: input.harnessPreset,
@@ -1444,9 +1508,10 @@ export class SlackSurface implements Surface {
     }
     await this.replacePlanDraftMessage(draft, 'Starting plan execution…', []);
     try {
+      const planText = this.normalizeDraftedPlanRepoUrl(draft.planText, draft.repoUrl);
       const result = await this.onCommand?.({
         type: 'start_plan',
-        planText: draft.planText,
+        planText,
         repoUrl: draft.repoUrl,
         harnessPreset: draft.harnessPreset,
         requestedBy: draft.requestedBy,
@@ -2157,6 +2222,83 @@ ${text}`;
     );
   }
 
+  private resolveChannelDefaultRepoUrl(channelId: string | undefined): string | undefined {
+    if (!channelId) return undefined;
+    const configured = this.channelRepoBindings[channelId];
+    if (configured) return this.normalizeRepositoryUrl(configured);
+    const mapping = this.workflowChannelRepo?.getByChannelId(channelId);
+    if (isChannelRepoBinding(mapping) && mapping?.repoUrl) {
+      return this.normalizeRepositoryUrl(mapping.repoUrl);
+    }
+    return undefined;
+  }
+
+  private async handleChannelRepoSetup(
+    pairs: ChannelRepoSetupPair[],
+    event: SlackMentionEvent,
+    channel: string,
+    say: SayFn,
+  ): Promise<void> {
+    const userId = event.user;
+    if (!userId || !this.adminUserIds.has(userId)) {
+      await say({ text: 'Permission denied. Slack channel repository setup requires admin access.', thread_ts: event.ts });
+      return;
+    }
+    if (!this.workflowChannelRepo) {
+      await say({ text: 'Slack channel repository setup is not available because channel persistence is not configured.', thread_ts: event.ts });
+      return;
+    }
+
+    const bound: string[] = [];
+    const failed: string[] = [];
+    for (const pair of pairs) {
+      const channelId = await this.resolveOrCreatePublicChannel(pair.channelName);
+      if (!channelId) {
+        failed.push(`#${pair.channelName}`);
+        continue;
+      }
+      const repoUrl = this.normalizeRepositoryUrl(pair.repoUrl);
+      this.workflowChannelRepo.save({
+        workflowId: channelRepoBindingWorkflowId(channelId),
+        channelId,
+        requestedBy: userId,
+        lobbyChannelId: channel,
+        lobbyThreadTs: event.ts,
+        harnessPreset: this.defaultHarnessPreset,
+        repoUrl,
+        createdAt: new Date().toISOString(),
+      });
+      bound.push(`<#${channelId}> -> \`${repoDisplayName(repoUrl)}\``);
+    }
+
+    const lines = [
+      ...(bound.length ? [`Configured ${bound.length} channel repository default${bound.length === 1 ? '' : 's'}:`, ...bound.map((item) => `- ${item}`)] : []),
+      ...(failed.length ? [`Failed to configure: ${failed.join(', ')}.`] : []),
+    ];
+    await say({ text: lines.join('\n') || 'No channel repository defaults were configured.', thread_ts: event.ts });
+  }
+
+  private async resolveOrCreatePublicChannel(name: string): Promise<string | undefined> {
+    const client = this.app.client;
+    try {
+      const created = await client.conversations.create({ name, is_private: false });
+      return created.channel?.id;
+    } catch (err) {
+      const code = this.slackErrorCode(err);
+      if (code !== 'name_taken') {
+        this.log('slack', 'error', `Failed to create public channel ${name}: ${err}`);
+        return undefined;
+      }
+      try {
+        const list = await client.conversations.list({ types: 'public_channel', limit: 1000 });
+        return (list.channels ?? []).find((candidate) => candidate.name === name && !candidate.is_private)?.id;
+      } catch (listErr) {
+        this.log('slack', 'error', `Failed to list public channels after name_taken for ${name}: ${listErr}`);
+        return undefined;
+      }
+    }
+  }
+
   private resolveRepoUrl(repo?: string): { url?: string; error?: string } {
     if (!repo) return { url: this.defaultRepoUrl && this.normalizeRepositoryUrl(this.defaultRepoUrl) };
     const aliasKey = Object.keys(this.repoAliases).find((key) => key.toLowerCase() === repo.toLowerCase());
@@ -2189,6 +2331,20 @@ ${text}`;
     if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return planText;
 
     const plan = raw as Record<string, unknown>;
+    if (plan.scratch === true) return planText;
+    if (contextRepoUrl) {
+      plan.repoUrl = contextRepoUrl;
+      if (Array.isArray(plan.workflows)) {
+        for (const workflow of plan.workflows) {
+          if (workflow && typeof workflow === 'object' && !Array.isArray(workflow)) {
+            const child = workflow as Record<string, unknown>;
+            if (child.scratch !== true) child.repoUrl = contextRepoUrl;
+          }
+        }
+      }
+      return stringifyYaml(plan);
+    }
+
     if (typeof plan.repoUrl !== 'string') return planText;
     const repoUrl = plan.repoUrl.trim();
     const aliasKey = Object.keys(this.repoAliases).find((key) => key.toLowerCase() === repoUrl.toLowerCase());
@@ -2563,7 +2719,8 @@ ${text}`;
       if (this.botUserId && (msg.text ?? '').includes(`<@${this.botUserId}>`)) return;
 
       const channel = (msg.channel as string | undefined) ?? this.channelId;
-      if (msg.channel && this.workflowChannelRepo?.getByChannelId(msg.channel)) return;
+      const mapping = msg.channel ? this.workflowChannelRepo?.getByChannelId(msg.channel) : null;
+      if (mapping && !isChannelRepoBinding(mapping)) return;
 
       const text = (msg.text ?? '').replace(/<@[A-Z0-9]+>/g, '').trim();
       if (!text) return;


### PR DESCRIPTION
## Summary

Authorized Slack setup requests can create or reuse public repository channels and bind each immutable channel ID to its repository.

New conversations inherit the channel repository. Drafted YAML and approved plan submissions are normalized to the same pinned target.

Explicit repository selectors still override channel defaults with a visible notice.

## Review Claim

Authorized channel setup safely carries each resolved channel repository through conversation creation, draft staging, and approved plan submission.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Ordinary planning messages selecting multiple repositories remain rejected before session creation. Only deterministic, authorized channel-repository setup may provision or bind multiple repositories.

Existing single-repository selection, explicit selector precedence, pinned-thread isolation, and unmapped-channel fallback remain intact.

## Slice Rationale

Channel creation, ID binding, conversation routing, and approved-plan normalization form one contact-surface behavior.

Splitting them would allow setup without guaranteeing that later conversations and submissions use the configured repository.

## Non-goals

- Do not relax ambiguity handling for ordinary multi-repository requests.
- Do not allow non-admin users to mutate channel mappings.
- Do not change repository defaults for unmapped Slack channels.
- Do not change Slack client rendering or workspace-wide default-channel membership.

## Architecture

### Before

```mermaid
graph TD
    A["Slack mention containing multiple repository URLs"] --> B["Generic repository ambiguity guard"]
    B --> C["Request rejected before channel configuration"]
```

### After

```mermaid
graph TD
    A["Authorized deterministic channel setup request"] --> B["Create or reuse public Slack channels"]
    B --> C["Persist channel ID to repository mappings"]
    C --> D["Pin new conversations to the channel repository"]
    D --> E["Normalize drafted YAML and approved start_plan"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm exec vitest run src/__tests__/slack-planning-session-happy-path.e2e.test.ts src/__tests__/slack-surface.test.ts src/__tests__/slack-surface-workflows.test.ts`
- [x] `cd packages/slack-manager && pnpm exec vitest run src/__tests__/runtime-config.test.ts`
- [x] `git diff --check origin/master...HEAD`

</details>

## Visual Proof

Static Slack screenshots cannot prove the repository URL passed through conversation state and approved `start_plan` submission.

The focused E2E test `channel defaults normalize staged YAML and approved start_plan repoUrl for the reported channels` verifies that routing transition for both channels.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged routing commit>`
- Post-revert steps: Rebuild and redeploy the Slack manager; remove `slackChannelRepos` from runtime configuration if no longer needed.
- Data migration? No

</details>

Depends-On: #8599