### PR TITLE
[Slack Channel Repository Routing](1) Declare admin and channel config

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -247,6 +247,10 @@ export interface InvokerConfig {
   slackRepos?: Record<string, string>;
   /** Repo URL used for Slack planning when the message carries no `[repo:]` tag. */
   defaultRepoUrl?: string;
+  /** Slack user IDs allowed to run Slack administrative actions. */
+  slackAdminUserIds?: string[];
+  /** Stable Slack channel ID → default repository URL for channel-scoped planning. */
+  slackChannelRepos?: Record<string, string>;
   /** Maximum number of tasks that can run concurrently. Default: 6. */
   maxConcurrency?: number;
   /** Browser executable for opening external URLs (e.g. "firefox"). Default: Chrome. */


### PR DESCRIPTION
## Summary

Add optional `slackAdminUserIds` and `slackChannelRepos` fields to `InvokerConfig`.

Existing configuration files remain valid because the new field is optional.

## Review Claim

`InvokerConfig` accepts optional Slack administrator IDs and channel-to-repository mappings while existing configuration shapes remain accepted.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

The field is optional, so existing configurations, defaults, and runtime behavior remain unchanged.

## Slice Rationale

The field addition precedes the behavior that reads these mappings.

Keeping this field separate gives reviewers one configuration acceptance claim.

## Non-goals

- Do not parse runtime configuration.
- Do not create Slack channels.
- Do not alter conversations or plans.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`
- [x] `git diff --check origin/master...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged config-contract commit>`
- Post-revert steps: None
- Data migration? No

</details>