### PR TITLE
[Invite Slack repository-channel requester and prove repo-targeted submissions](1) Invite requester and prove routing

### DIFF
--- a/packages/surfaces/src/__tests__/slack-planning-session-happy-path.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-planning-session-happy-path.e2e.test.ts
@@ -72,7 +72,10 @@ vi.mock('../slack/plan-conversation.js', async (importOriginal) => ({
       lastTurnReasoning: [] as string[],
       init: vi.fn().mockResolvedValue(undefined),
       getDraftedPlan: () => instance.lastTurnDraftPlanText,
-      runPlanConversion: vi.fn().mockResolvedValue(''),
+      runPlanConversion: vi.fn().mockImplementation(async () => {
+        instance.lastTurnDraftPlanText = nextDraftPlanText;
+        return nextReply;
+      }),
       sendMessage: vi.fn().mockImplementation(async () => {
         instance.lastTurnDraftPlanText = nextDraftPlanText;
         return nextReply;
@@ -136,6 +139,13 @@ function actionHandler(surface: SlackSurface, actionId: string): Function {
   const app = surface.getApp() as any;
   const handler = app._actionHandlers.find((h: MockHandler) => h.pattern === actionId)?.handler;
   if (!handler) throw new Error(`${actionId} action handler not registered`);
+  return handler;
+}
+
+function messageHandler(surface: SlackSurface): Function {
+  const app = surface.getApp() as any;
+  const handler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'message')?.handler;
+  if (!handler) throw new Error('message handler not registered');
   return handler;
 }
 
@@ -215,10 +225,12 @@ describe('slack planning session happy path', () => {
       channelRepoBindings: repos,
     });
     const approve = actionHandler(surface, 'plan_draft_approve');
+    const message = messageHandler(surface);
 
     for (const [channelId, repoUrl] of Object.entries(repos)) {
-      nextReply = 'Draft ready.';
-      nextDraftPlanText = `name: "Channel pinned"
+      nextReply = 'Let me scope that first.';
+      nextDraftPlanText = null;
+      const draftPlanText = `name: "Channel pinned"
 repoUrl: "https://github.com/wrong/root"
 workflows:
   - name: Child workflow
@@ -232,8 +244,17 @@ workflows:
       const threadTs = `${channelId}-thread`;
 
       await mentionHandler(surface)({
-        event: { text: '<@UBOT> draft a channel-pinned plan', ts: threadTs, user: 'U1', channel: channelId },
+        event: { text: '<@UBOT> discuss channel-pinned work', ts: threadTs, user: 'U1', channel: channelId },
         say: vi.fn().mockResolvedValue({ ts: `${threadTs}-card` }),
+      });
+      expect(slackPlanDraftRepo.getReady(channelId, threadTs)).toBeUndefined();
+      expect(onCommand).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'start_plan', repoUrl }));
+
+      nextReply = 'Draft ready.';
+      nextDraftPlanText = draftPlanText;
+      await message({
+        event: { text: '/plan', ts: `${threadTs}-plan`, thread_ts: threadTs, user: 'U1', channel: channelId },
+        say: vi.fn().mockResolvedValue({ ts: `${threadTs}-review` }),
       });
 
       const draft = slackPlanDraftRepo.getReady(channelId, threadTs);
@@ -257,5 +278,10 @@ workflows:
         planText: draft!.planText,
       }));
     }
+
+    expect(onCommand.mock.calls.map(([command]) => (command as any).repoUrl)).toEqual([
+      'https://github.com/Neko-Catpital-Labs/Invoker',
+      'https://github.com/EdbertChan/notarepo',
+    ]);
   });
 });

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -1158,6 +1158,8 @@ describe('lobby verb routing', () => {
 
       expect(client.conversations.create).toHaveBeenNthCalledWith(1, { name: 'invoker-repo', is_private: false });
       expect(client.conversations.create).toHaveBeenNthCalledWith(2, { name: 'rips-clone-mobile-repo', is_private: false });
+      expect(client.conversations.invite).toHaveBeenNthCalledWith(1, { channel: 'C_INVOKER_REPO', users: 'U_ADMIN' });
+      expect(client.conversations.invite).toHaveBeenNthCalledWith(2, { channel: 'C_RIPS_REPO', users: 'U_ADMIN' });
       expect(setupSay.mock.calls.map((call) => call[0].text).join('\n')).not.toContain('multiple repository URLs');
       expect(workflowChannelRepo.getByChannelId('C_INVOKER_REPO')?.repoUrl).toBe('https://github.com/Neko-Catpital-Labs/Invoker');
       expect(workflowChannelRepo.getByChannelId('C_RIPS_REPO')?.repoUrl).toBe('https://github.com/EdbertChan/notarepo');
@@ -1205,6 +1207,7 @@ describe('lobby verb routing', () => {
       });
 
       expect(client.conversations.create).not.toHaveBeenCalled();
+      expect(client.conversations.invite).not.toHaveBeenCalled();
       expect(workflowChannelRepo.list()).toHaveLength(0);
       expect(planConversationConfigs).toHaveLength(0);
       expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Permission denied') }));
@@ -1234,7 +1237,75 @@ describe('lobby verb routing', () => {
       });
 
       expect(client.conversations.list).toHaveBeenCalledWith({ types: 'public_channel', limit: 1000 });
+      expect(client.conversations.invite).toHaveBeenCalledWith({ channel: 'C_EXISTING', users: 'U_ADMIN' });
       expect(workflowChannelRepo.getByChannelId('C_EXISTING')?.repoUrl).toBe('https://github.com/Neko-Catpital-Labs/Invoker');
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
+  });
+
+  it('treats public channel requester invite idempotency errors as successful setup', async () => {
+    const { adapter, workflowChannelRepo, surface } = await persistentLobbySurface({ adminUserIds: ['U_ADMIN'] });
+    const client = (surface.getApp() as any).client;
+    client.conversations.create
+      .mockResolvedValueOnce({ channel: { id: 'C_ALREADY' } })
+      .mockResolvedValueOnce({ channel: { id: 'C_SELF' } });
+    client.conversations.invite
+      .mockRejectedValueOnce({ data: { error: 'already_in_channel' } })
+      .mockRejectedValueOnce({ data: { error: 'cant_invite_self' } });
+
+    try {
+      await surface.start(async () => {});
+      const say = vi.fn().mockResolvedValue({ ts: 'ok' });
+      await mentionHandler(surface)({
+        event: {
+          text: '<@BOT> setup #invoker-repo https://github.com/Neko-Catpital-Labs/Invoker #rips-clone-mobile-repo https://github.com/EdbertChan/notarepo',
+          ts: 'setup-idempotent',
+          user: 'U_ADMIN',
+          channel: 'CLOBBY',
+        },
+        say,
+      });
+
+      expect(client.conversations.invite).toHaveBeenNthCalledWith(1, { channel: 'C_ALREADY', users: 'U_ADMIN' });
+      expect(client.conversations.invite).toHaveBeenNthCalledWith(2, { channel: 'C_SELF', users: 'U_ADMIN' });
+      expect(workflowChannelRepo.getByChannelId('C_ALREADY')?.repoUrl).toBe('https://github.com/Neko-Catpital-Labs/Invoker');
+      expect(workflowChannelRepo.getByChannelId('C_SELF')?.repoUrl).toBe('https://github.com/EdbertChan/notarepo');
+      const text = say.mock.calls.map((call) => call[0].text).join('\n');
+      expect(text).toContain('Configured 2 channel repository defaults');
+      expect(text).not.toContain('could not invite');
+    } finally {
+      await surface.stop();
+      adapter.close();
+    }
+  });
+
+  it('keeps a public channel binding but reports partial success when requester invite fails', async () => {
+    const { adapter, workflowChannelRepo, surface } = await persistentLobbySurface({ adminUserIds: ['U_ADMIN'] });
+    const client = (surface.getApp() as any).client;
+    client.conversations.create.mockResolvedValueOnce({ channel: { id: 'C_BOUND' } });
+    client.conversations.invite.mockRejectedValueOnce({ data: { error: 'missing_scope' } });
+
+    try {
+      await surface.start(async () => {});
+      const say = vi.fn().mockResolvedValue({ ts: 'partial' });
+      await mentionHandler(surface)({
+        event: {
+          text: '<@BOT> map #invoker-repo to https://github.com/Neko-Catpital-Labs/Invoker',
+          ts: 'setup-invite-failed',
+          user: 'U_ADMIN',
+          channel: 'CLOBBY',
+        },
+        say,
+      });
+
+      expect(client.conversations.invite).toHaveBeenCalledWith({ channel: 'C_BOUND', users: 'U_ADMIN' });
+      expect(workflowChannelRepo.getByChannelId('C_BOUND')?.repoUrl).toBe('https://github.com/Neko-Catpital-Labs/Invoker');
+      const text = say.mock.calls.map((call) => call[0].text).join('\n');
+      expect(text).toContain('Configured 1 channel repository default');
+      expect(text).toContain('could not invite you to <#C_BOUND> (missing_scope)');
+      expect(text).toContain('Ask a workspace admin to invite you');
     } finally {
       await surface.stop();
       adapter.close();

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -2251,6 +2251,7 @@ ${text}`;
 
     const bound: string[] = [];
     const failed: string[] = [];
+    const inviteFailed: string[] = [];
     for (const pair of pairs) {
       const channelId = await this.resolveOrCreatePublicChannel(pair.channelName);
       if (!channelId) {
@@ -2269,13 +2270,35 @@ ${text}`;
         createdAt: new Date().toISOString(),
       });
       bound.push(`<#${channelId}> -> \`${repoDisplayName(repoUrl)}\``);
+      const inviteError = await this.inviteRequesterToChannel(channelId, userId);
+      if (inviteError) {
+        inviteFailed.push(`<#${channelId}> (${inviteError})`);
+      }
     }
 
     const lines = [
       ...(bound.length ? [`Configured ${bound.length} channel repository default${bound.length === 1 ? '' : 's'}:`, ...bound.map((item) => `- ${item}`)] : []),
+      ...(inviteFailed.length ? [
+        `The repository default is bound, but I could not invite you to ${inviteFailed.join(', ')}. Ask a workspace admin to invite you, or check that the bot has permission to invite users to public channels and was reinstalled after permission changes.`,
+      ] : []),
       ...(failed.length ? [`Failed to configure: ${failed.join(', ')}.`] : []),
     ];
     await say({ text: lines.join('\n') || 'No channel repository defaults were configured.', thread_ts: event.ts });
+  }
+
+  private async inviteRequesterToChannel(channelId: string, userId: string): Promise<string | undefined> {
+    try {
+      await this.app.client.conversations.invite({ channel: channelId, users: userId });
+      return undefined;
+    } catch (err) {
+      const code = this.slackErrorCode(err);
+      if (code === 'already_in_channel' || code === 'cant_invite_self') {
+        return undefined;
+      }
+      const error = code ?? (err instanceof Error ? err.message : String(err));
+      this.log('slack', 'warn', `Failed to invite ${userId} to public repo channel ${channelId}: ${err}`);
+      return error;
+    }
   }
 
   private async resolveOrCreatePublicChannel(name: string): Promise<string | undefined> {


### PR DESCRIPTION
## Summary

Authorized Slack repository-channel setup now invites the requesting human to each new or reused public channel.

Repository bindings survive non-idempotent invitation failures, while the requester receives visible remediation instead of a false discoverability claim.

Focused Slack coverage follows both configured channel IDs through conversation, draft approval, and repository-targeted `start_plan` submission.

## Review Claim

Authorized public repository-channel setup invites only the requester and preserves each channel ID's repository target through approved plan submission.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Invite only the authenticated `event.user` after the existing admin authorization check. Configured admin IDs authorize setup but are not a bulk invitation list.

Do not invite unrelated users, weaken authorization, or alter ordinary channel membership.

## Slice Rationale

Requester membership and the directly affected Slack routing coverage form one user-visible setup claim.

The runner-only verification task produced no file changes, so it remains evidence for this slice rather than an empty predecessor PR.

## Non-goals

- No live Slack workspace mutation or deployment change.
- No bulk administrator invitations or private-channel conversion.
- No channel-name-based routing or ordinary workflow membership changes.
- No unrelated Slack refactor or workflow execution change.

## Architecture

### Before

```mermaid
graph TD
    A["Authorized repository-channel setup"] --> B["Create or reuse public channel"]
    B --> C["Persist channel ID repository binding"]
    C --> D["Requester may still lack channel membership"]
```

### After

```mermaid
graph TD
    A["Authorized repository-channel setup"] --> B["Create or reuse public channel"]
    B --> C["Persist channel ID repository binding"]
    C --> D["Invite authenticated requester only"]
    D --> E{"Invitation result"}
    E -->|"Success or idempotent error"| F["Report configured channel"]
    E -->|"Other Slack error"| G["Keep binding and report remediation"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --dir packages/surfaces exec vitest run src/__tests__/slack-surface-workflows.test.ts -t 'provisions the reported public repo channels and routes each channel by resolved ID' --reporter=verbose` — `Test Files  1 passed (1)` and `Tests  1 passed | 91 skipped (92)`.
- [x] `pnpm --dir packages/surfaces exec vitest run src/__tests__/slack-surface-workflows.test.ts src/__tests__/slack-planning-session-happy-path.e2e.test.ts --reporter=verbose` — `Test Files  2 passed (2)` and `Tests  95 passed (95)`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged requester-invitation commit>`
- Post-revert steps: Rebuild and redeploy the Slack surface, then rerun the focused Slack tests.
- Data migration? No; persisted channel bindings remain compatible.

</details>
