### PR TITLE
[Reaper owner responsiveness](1) Reproduce local worktree cleanup starvation

### DIFF
--- a/packages/execution-engine/src/__tests__/reaper-worktree-responsiveness.test.ts
+++ b/packages/execution-engine/src/__tests__/reaper-worktree-responsiveness.test.ts
@@ -1,0 +1,80 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, utimesSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  reapStaleWorktrees,
+  STALE_WORKTREE_MIN_AGE_HOURS,
+} from '../workers/reaper-reclaim.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createStaleWorktree(): { home: string; root: string; worktreePath: string } {
+  const root = mkdtempSync(join(tmpdir(), 'invoker-reaper-responsiveness-'));
+  tempDirs.push(root);
+
+  const home = join(root, '.invoker');
+  const repoHash = 'repoabc123456';
+  const repoPath = join(home, 'repos', repoHash);
+  const worktreePath = join(home, 'worktrees', repoHash, 'old-worktree');
+  mkdirSync(join(home, 'worktrees', repoHash), { recursive: true });
+
+  execFileSync('git', ['init', '--quiet', repoPath]);
+  execFileSync('git', ['-C', repoPath, 'commit', '--quiet', '--allow-empty', '-m', 'seed'], {
+    env: {
+      ...process.env,
+      GIT_AUTHOR_EMAIL: 'repro@example.invalid',
+      GIT_AUTHOR_NAME: 'Reaper Repro',
+      GIT_COMMITTER_EMAIL: 'repro@example.invalid',
+      GIT_COMMITTER_NAME: 'Reaper Repro',
+    },
+  });
+  execFileSync('git', ['-C', repoPath, 'worktree', 'add', '--quiet', '--detach', worktreePath]);
+
+  const staleSeconds =
+    (Date.now() - (STALE_WORKTREE_MIN_AGE_HOURS + 1) * 60 * 60 * 1000) / 1000;
+  utimesSync(worktreePath, staleSeconds, staleSeconds);
+
+  return { home, root, worktreePath };
+}
+
+describe('stale-worktree reaper responsiveness (real git)', { timeout: 30_000 }, () => {
+  it.fails('allows owner-loop callbacks to run while Git removes a stale worktree', async () => {
+    const { home, root, worktreePath } = createStaleWorktree();
+    let reapCompleted = false;
+    let callbackSawReapComplete: boolean | undefined;
+
+    const ownerLoopCallback = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        callbackSawReapComplete = reapCompleted;
+        resolve();
+      }, 0);
+    });
+    const reaping = reapStaleWorktrees({
+      invokerHome: home,
+      userHome: root,
+      remoteTargets: [],
+    }).then((results) => {
+      reapCompleted = true;
+      return results;
+    });
+
+    const [, results] = await Promise.all([ownerLoopCallback, reaping]);
+
+    expect(callbackSawReapComplete).toBe(false);
+    expect(results[0]).toMatchObject({
+      ok: true,
+      reason: 'reap-worktrees',
+      detail: 'removed 1',
+    });
+    expect(existsSync(worktreePath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This slice adds a real-Git regression reproducing owner-loop starvation during old worktree retirement.

The test uses only a disposable repository under the operating system temporary directory.

## Review Claim

The regression test proves that synchronous local worktree retirement blocks owner-loop callbacks.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The test creates and discards only its own temporary Git repository. It never addresses a real Invoker home or production worktree.

## Slice Rationale

This proof lands before the behavior change so reviewers can see the failure that motivates the fix.

## Non-goals

No production runtime behavior, retention policy, age threshold, or worker scheduling changes are included.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm test -- reaper-worktree-responsiveness.test.ts`

The unfixed implementation failed with `expected true to be false`; the proof remains pending with `it.fails` until the next slice.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4405544d5`
- Post-revert steps: None
- Data migration? No

</details>
