### PR TITLE
[Reaper owner responsiveness](2) Yield during stale worktree cleanup

### DIFF
--- a/packages/execution-engine/src/__tests__/reaper-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/reaper-reclaim.test.ts
@@ -1,7 +1,4 @@
 import {
-  execFileSync,
-} from 'node:child_process';
-import {
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -26,23 +23,14 @@ import {
   reapLocalStaleWorktrees,
   reapStaleAutomationCheckouts,
   reapStaleWorktrees,
+  STALE_WORKTREE_GIT_TIMEOUT_MS,
   STALE_WORKTREE_MIN_AGE_HOURS,
   trimOversizedLogs,
 } from '../workers/reaper-reclaim.js';
 
-vi.mock('node:child_process', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:child_process')>();
-  return {
-    ...actual,
-    execFileSync: vi.fn(),
-  };
-});
-
 const tempDirs: string[] = [];
-const mockedExecFileSync = vi.mocked(execFileSync);
 
 afterEach(() => {
-  mockedExecFileSync.mockReset();
   vi.unstubAllEnvs();
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
@@ -138,19 +126,20 @@ describe('reapDeletingOrphans', () => {
 });
 
 describe('reapStaleWorktrees', () => {
-  it('leaves worktree entries younger than forty-eight hours untouched', () => {
+  it('leaves worktree entries younger than forty-eight hours untouched', async () => {
     const { root, home } = makeHome();
     mkdirSync(join(home, 'repos', 'repoabc123456'), { recursive: true });
     mkdirSync(join(home, 'worktrees', 'repoabc123456', 'fresh-branch'), { recursive: true });
+    const runLocalGit = vi.fn(async () => {});
 
-    const removed = reapLocalStaleWorktrees({ invokerHome: home, userHome: root });
+    const removed = await reapLocalStaleWorktrees({ invokerHome: home, userHome: root, runLocalGit });
 
     expect(removed).toEqual([]);
     expect(existsSync(join(home, 'worktrees', 'repoabc123456', 'fresh-branch'))).toBe(true);
-    expect(mockedExecFileSync).not.toHaveBeenCalled();
+    expect(runLocalGit).not.toHaveBeenCalled();
   });
 
-  it('removes stale entries with git worktree remove and prunes once per repo group', () => {
+  it('removes stale entries with git worktree remove and prunes once per repo group', async () => {
     const { root, home } = makeHome();
     const repoHash = 'repoabc123456';
     const oldA = join(home, 'worktrees', repoHash, 'old-a');
@@ -160,18 +149,20 @@ describe('reapStaleWorktrees', () => {
     mkdirSync(oldB, { recursive: true });
     backdate(oldA, (STALE_WORKTREE_MIN_AGE_HOURS + 1) * 60 * 60 * 1000);
     backdate(oldB, (STALE_WORKTREE_MIN_AGE_HOURS + 2) * 60 * 60 * 1000);
-    mockedExecFileSync.mockImplementation((_cmd, args) => {
-      const argv = args as string[];
+    const runLocalGit = vi.fn(async (argv: string[]) => {
       if (argv[3] === 'remove') rmSync(argv[5]!, { recursive: true, force: true });
-      return Buffer.from('');
     });
 
-    const removed = reapLocalStaleWorktrees({ invokerHome: home, userHome: root });
+    const removed = await reapLocalStaleWorktrees({
+      invokerHome: home,
+      userHome: root,
+      runLocalGit,
+    });
 
     expect(removed.sort()).toEqual([oldA, oldB].sort());
     expect(existsSync(oldA)).toBe(false);
     expect(existsSync(oldB)).toBe(false);
-    const calls = mockedExecFileSync.mock.calls.map((call) => call[1] as string[]);
+    const calls = runLocalGit.mock.calls.map((call) => call[0]);
     expect(calls.filter((args) => args[3] === 'remove')).toHaveLength(2);
     expect(calls.filter((args) => args[3] === 'prune')).toHaveLength(1);
     expect(calls.find((args) => args[3] === 'prune')).toEqual([
@@ -180,26 +171,30 @@ describe('reapStaleWorktrees', () => {
       'worktree',
       'prune',
     ]);
+    expect(runLocalGit.mock.calls.every((call) => call[1] === STALE_WORKTREE_GIT_TIMEOUT_MS))
+      .toBe(true);
   });
 
-  it('falls back to rm -rf when git worktree remove fails', () => {
+  it('falls back to rm -rf when git worktree remove fails', async () => {
     const { root, home } = makeHome();
     const repoHash = 'repoabc123456';
     const old = join(home, 'worktrees', repoHash, 'old-fallback');
     mkdirSync(join(home, 'repos', repoHash), { recursive: true });
     mkdirSync(old, { recursive: true });
     backdate(old, (STALE_WORKTREE_MIN_AGE_HOURS + 1) * 60 * 60 * 1000);
-    mockedExecFileSync.mockImplementation((_cmd, args) => {
-      const argv = args as string[];
+    const runLocalGit = vi.fn(async (argv: string[]) => {
       if (argv[3] === 'remove') throw new Error('worktree metadata missing');
-      return Buffer.from('');
     });
 
-    const removed = reapLocalStaleWorktrees({ invokerHome: home, userHome: root });
+    const removed = await reapLocalStaleWorktrees({
+      invokerHome: home,
+      userHome: root,
+      runLocalGit,
+    });
 
     expect(removed).toEqual([old]);
     expect(existsSync(old)).toBe(false);
-    const calls = mockedExecFileSync.mock.calls.map((call) => call[1] as string[]);
+    const calls = runLocalGit.mock.calls.map((call) => call[0]);
     expect(calls.filter((args) => args[3] === 'remove')).toHaveLength(1);
     expect(calls.filter((args) => args[3] === 'prune')).toHaveLength(1);
   });

--- a/packages/execution-engine/src/__tests__/reaper-worktree-responsiveness.test.ts
+++ b/packages/execution-engine/src/__tests__/reaper-worktree-responsiveness.test.ts
@@ -47,7 +47,7 @@ function createStaleWorktree(): { home: string; root: string; worktreePath: stri
 }
 
 describe('stale-worktree reaper responsiveness (real git)', { timeout: 30_000 }, () => {
-  it.fails('allows owner-loop callbacks to run while Git removes a stale worktree', async () => {
+  it('allows owner-loop callbacks to run while Git removes a stale worktree', async () => {
     const { home, root, worktreePath } = createStaleWorktree();
     let reapCompleted = false;
     let callbackSawReapComplete: boolean | undefined;

--- a/packages/execution-engine/src/workers/reaper-reclaim.ts
+++ b/packages/execution-engine/src/workers/reaper-reclaim.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import {
   closeSync,
   existsSync,
@@ -9,6 +9,7 @@ import {
   statSync,
   writeFileSync,
 } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -36,6 +37,7 @@ export const AUTOMATION_CHECKOUT_DIRS = [
 export const AUTOMATION_CHECKOUT_MIN_AGE_HOURS = 48;
 
 export const STALE_WORKTREE_MIN_AGE_HOURS = 48;
+export const STALE_WORKTREE_GIT_TIMEOUT_MS = 5 * 60 * 1000;
 
 export const LOG_TRIM_MAX_BYTES = 100 * 1024 * 1024;
 export const LOG_TRIM_KEEP_BYTES = 20 * 1024 * 1024;
@@ -231,12 +233,28 @@ export async function reapDeletingOrphans(opts: {
   return results;
 }
 
-export function reapLocalStaleWorktrees(opts: {
+type RunLocalGit = (args: string[], timeoutMs: number) => Promise<void>;
+
+function defaultRunLocalGit(args: string[], timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile('git', args, { timeout: timeoutMs, windowsHide: true }, (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export async function reapLocalStaleWorktrees(opts: {
   invokerHome: string;
   logger?: Logger;
   userHome?: string;
   nowMs?: number;
-}): string[] {
+  runLocalGit?: RunLocalGit;
+  gitTimeoutMs?: number;
+}): Promise<string[]> {
   const userHome = opts.userHome ?? homedir();
   const home = expandTildeHome(opts.invokerHome, userHome);
   if (!isSafeInvokerHome(home, userHome)) return [];
@@ -246,6 +264,8 @@ export function reapLocalStaleWorktrees(opts: {
 
   const nowMs = opts.nowMs ?? Date.now();
   const minAgeMs = STALE_WORKTREE_MIN_AGE_HOURS * 60 * 60 * 1000;
+  const runLocalGit = opts.runLocalGit ?? defaultRunLocalGit;
+  const gitTimeoutMs = opts.gitTimeoutMs ?? STALE_WORKTREE_GIT_TIMEOUT_MS;
   const staleByRepoHash = new Map<string, string[]>();
 
   let repoHashes: string[];
@@ -282,15 +302,16 @@ export function reapLocalStaleWorktrees(opts: {
     const repoPath = join(home, 'repos', repoHash);
     for (const path of paths) {
       try {
-        execFileSync('git', ['-C', repoPath, 'worktree', 'remove', '--force', path], {
-          stdio: 'ignore',
-        });
+        await runLocalGit(
+          ['-C', repoPath, 'worktree', 'remove', '--force', path],
+          gitTimeoutMs,
+        );
       } catch (err) {
         opts.logger?.warn?.(`[reaper] git worktree remove failed for ${path}: ${errorDetail(err)}`, {
           module: 'reaper',
         });
         try {
-          rmSync(path, { recursive: true, force: true });
+          await rm(path, { recursive: true, force: true });
         } catch (rmErr) {
           opts.logger?.warn?.(`[reaper] failed to remove stale worktree ${path}: ${errorDetail(rmErr)}`, {
             module: 'reaper',
@@ -303,7 +324,7 @@ export function reapLocalStaleWorktrees(opts: {
     }
 
     try {
-      execFileSync('git', ['-C', repoPath, 'worktree', 'prune'], { stdio: 'ignore' });
+      await runLocalGit(['-C', repoPath, 'worktree', 'prune'], gitTimeoutMs);
     } catch (err) {
       opts.logger?.warn?.(`[reaper] git worktree prune failed for ${repoPath}: ${errorDetail(err)}`, {
         module: 'reaper',
@@ -427,6 +448,8 @@ export async function reapStaleWorktrees(opts: {
   userHome?: string;
   nowMs?: number;
   runRemoteScript?: (target: RemoteDiskTarget, script: string) => Promise<string>;
+  runLocalGit?: RunLocalGit;
+  gitTimeoutMs?: number;
 }): Promise<DiskCleanupResult[]> {
   const targetKey = `local ${opts.invokerHome}`;
   const userHome = opts.userHome ?? homedir();
@@ -444,7 +467,7 @@ export async function reapStaleWorktrees(opts: {
         targetKey,
         ok: true,
         reason: 'reap-worktrees',
-        detail: `removed ${reapLocalStaleWorktrees(opts).length}`,
+        detail: `removed ${(await reapLocalStaleWorktrees(opts)).length}`,
         protectedSkipCount: 0,
         protectedSkipBytes: 0,
       };


### PR DESCRIPTION
## Summary

Local old-worktree retirement now runs Git and fallback filesystem work asynchronously so the owner process remains responsive.

Each Git operation has a five-minute timeout, while retirement order and repository prune grouping remain unchanged.

## Review Claim

The reaper can reclaim old local worktrees without monopolizing the owner event loop.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The existing safe-home check, 48-hour age gate, sequential retirement order, fallback filesystem operation, and one-prune-per-repository behavior remain unchanged. Remote maintenance, worker activation, and persistence behavior are not changed.

## Slice Rationale

This slice follows the regression proof and changes only the execution boundary needed to satisfy it.

## Non-goals

No change to old-path selection, remote scripts, worker cadence, task admission, or database state.

## Architecture

### Before

```mermaid
graph TD
    A["reaper worker"] --> B["execFileSync git worktree remove"]
    B --> C["owner event loop blocked"]
```

### After

```mermaid
graph TD
    A["reaper worker"] --> B["async execFile with timeout"]
    B --> C["owner event loop can service callbacks"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm test -- reaper-worktree-responsiveness.test.ts reaper-reclaim.test.ts` — 16 passed
- [x] `pnpm --filter @invoker/execution-engine test` — 122 files passed, 1582 tests passed, 1 skipped
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, after the proof slice is also reverted
- Revert command: `git revert 407e21fa5`
- Post-revert steps: Re-run the responsiveness regression; it should return to the documented failure.
- Data migration? No

</details>
