### PR TITLE
Reap stale CLI test temp directories

### DIFF
--- a/packages/execution-engine/src/__tests__/reaper-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/reaper-reclaim.test.ts
@@ -20,6 +20,7 @@ import {
   DELETING_ORPHAN_MIN_AGE_MINUTES,
   enforceHourlySnapshotRetention,
   reapDeletingOrphans,
+  reapStaleInvokerCliTempDirs,
   reapLocalStaleWorktrees,
   reapStaleAutomationCheckouts,
   reapStaleWorktrees,
@@ -264,6 +265,37 @@ describe('reapStaleAutomationCheckouts', () => {
   it('returns nothing when the locations are absent', () => {
     const { root, home } = makeHome();
     expect(reapStaleAutomationCheckouts({ invokerHome: home, userHome: root })).toEqual([]);
+  });
+});
+
+describe('reapStaleInvokerCliTempDirs', () => {
+  it('removes stale CLI test directories while preserving fresh and unrelated temp entries', async () => {
+    const { root } = makeHome();
+    const tempRoot = join(root, 'tmp');
+    const stale = join(tempRoot, 'invoker-cli-prompt-stale');
+    const fresh = join(tempRoot, 'invoker-cli-prompt-fresh');
+    const unrelated = join(tempRoot, 'other-tool-stale');
+    mkdirSync(stale, { recursive: true });
+    mkdirSync(fresh, { recursive: true });
+    mkdirSync(unrelated, { recursive: true });
+    backdate(stale, 49 * 60 * 60 * 1000);
+    backdate(unrelated, 49 * 60 * 60 * 1000);
+
+    const removed = await reapStaleInvokerCliTempDirs({ tempRoot, userHome: join(root, 'user') });
+
+    expect(removed).toEqual([stale]);
+    expect(existsSync(stale)).toBe(false);
+    expect(existsSync(fresh)).toBe(true);
+    expect(existsSync(unrelated)).toBe(true);
+  });
+
+  it('refuses unsafe temp roots', async () => {
+    const { root } = makeHome();
+    const userHome = join(root, 'user');
+    mkdirSync(userHome, { recursive: true });
+
+    await expect(reapStaleInvokerCliTempDirs({ tempRoot: '/', userHome })).resolves.toEqual([]);
+    await expect(reapStaleInvokerCliTempDirs({ tempRoot: userHome, userHome })).resolves.toEqual([]);
   });
 });
 

--- a/packages/execution-engine/src/__tests__/reaper-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/reaper-worker.test.ts
@@ -52,7 +52,7 @@ describe('reaper worker', () => {
     expect(runtime.identity.kind).toBe(REAPER_WORKER_KIND);
   });
 
-  it('calls each of the five checks once per tick and writes one record-keeping entry', async () => {
+  it('calls each cleanup once per tick and writes one record-keeping entry', async () => {
     const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
     registerReaperWorker(registry);
     expect(registry.get(REAPER_WORKER_KIND)).toBeTruthy();
@@ -66,6 +66,7 @@ describe('reaper worker', () => {
       { ...okResult('local /tmp/invoker-home'), reason: 'reap-worktrees', detail: 'removed 2' },
       { ...okResult('ssh:remote-1 ~/.invoker'), reason: 'reap-worktrees', detail: 'removed 3' },
     ]);
+    const reapTempDirs = vi.fn(async () => ['/tmp/invoker-cli-prompt-old']);
     const enforceRetention = vi.fn(() => 2);
     const trimLogs = vi.fn(() => ['/tmp/invoker-home/invoker.log']);
     const upsertWorkerAction = vi.fn((row: any) => row);
@@ -80,6 +81,7 @@ describe('reaper worker', () => {
       reapOrphans,
       reapCheckouts,
       reapWorktrees,
+      reapTempDirs,
       enforceRetention,
       trimLogs,
     });
@@ -93,6 +95,7 @@ describe('reaper worker', () => {
     });
     expect(reapCheckouts).toHaveBeenCalledTimes(1);
     expect(reapCheckouts.mock.calls[0]?.[0]).toMatchObject({ invokerHome: '/tmp/invoker-home' });
+    expect(reapTempDirs).toHaveBeenCalledTimes(1);
     expect(enforceRetention).toHaveBeenCalledTimes(1);
     expect(enforceRetention.mock.calls[0]?.[0]).toBe('/tmp/invoker-home');
     expect(trimLogs).toHaveBeenCalledTimes(1);
@@ -114,10 +117,12 @@ describe('reaper worker', () => {
       attemptCount: 1,
     });
     expect(upsertWorkerAction.mock.calls[0]?.[0].summary).toContain('checkouts removed 1');
+    expect(upsertWorkerAction.mock.calls[0]?.[0].summary).toContain('CLI temp dirs removed 1');
     expect(upsertWorkerAction.mock.calls[0]?.[0].summary).toContain('snapshots pruned 2');
     expect(upsertWorkerAction.mock.calls[0]?.[0].summary).toContain('logs trimmed 1');
     expect(upsertWorkerAction.mock.calls[0]?.[0].summary).toContain('worktrees removed 5');
     expect(upsertWorkerAction.mock.calls[0]?.[0].payload).toMatchObject({
+      tempDirsRemoved: ['/tmp/invoker-cli-prompt-old'],
       worktreesRemoved: 5,
       worktreeResults: [
         { targetKey: 'local /tmp/invoker-home', reason: 'reap-worktrees', detail: 'removed 2' },
@@ -146,6 +151,7 @@ describe('reaper worker', () => {
       reapOrphans: vi.fn(async () => [okResult('local /tmp/invoker-home'), failedResult]),
       reapCheckouts: vi.fn(() => []),
       reapWorktrees: vi.fn(async () => []),
+      reapTempDirs: vi.fn(async () => []),
       enforceRetention: vi.fn(() => 0),
       trimLogs: vi.fn(() => []),
     });

--- a/packages/execution-engine/src/workers/reaper-reclaim.ts
+++ b/packages/execution-engine/src/workers/reaper-reclaim.ts
@@ -2,6 +2,7 @@ import { execFile } from 'node:child_process';
 import {
   closeSync,
   existsSync,
+  lstatSync,
   openSync,
   readdirSync,
   readSync,
@@ -10,8 +11,8 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { rm } from 'node:fs/promises';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { homedir, tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 
 import { hourlySnapshotRetention, pruneHourlySnapshots, type Logger } from '@invoker/contracts';
 
@@ -38,6 +39,7 @@ export const AUTOMATION_CHECKOUT_MIN_AGE_HOURS = 48;
 
 export const STALE_WORKTREE_MIN_AGE_HOURS = 48;
 export const STALE_WORKTREE_GIT_TIMEOUT_MS = 5 * 60 * 1000;
+export const STALE_INVOKER_CLI_TEMP_MIN_AGE_HOURS = 48;
 
 export const LOG_TRIM_MAX_BYTES = 100 * 1024 * 1024;
 export const LOG_TRIM_KEEP_BYTES = 20 * 1024 * 1024;
@@ -523,6 +525,61 @@ export function reapStaleAutomationCheckouts(opts: {
     }
   }
   return removed;
+}
+
+export async function reapStaleInvokerCliTempDirs(opts: {
+  tempRoot?: string;
+  userHome?: string;
+  nowMs?: number;
+  minAgeHours?: number;
+  logger?: Logger;
+} = {}): Promise<string[]> {
+  const rawTempRoot = opts.tempRoot ?? tmpdir();
+  if (!rawTempRoot.trim()) return [];
+  const tempRoot = resolve(rawTempRoot);
+  const userHome = resolve(opts.userHome ?? homedir());
+  if (tempRoot === '/' || tempRoot === userHome) return [];
+
+  let entries: string[];
+  try {
+    entries = readdirSync(tempRoot);
+  } catch {
+    return [];
+  }
+
+  const nowMs = opts.nowMs ?? Date.now();
+  const minAgeMs = (opts.minAgeHours ?? STALE_INVOKER_CLI_TEMP_MIN_AGE_HOURS) * 60 * 60 * 1000;
+  const candidates = entries.flatMap((name) => {
+    if (!name.startsWith('invoker-cli-')) return [];
+    const path = join(tempRoot, name);
+    try {
+      const stat = lstatSync(path);
+      if (!stat.isDirectory() || stat.isSymbolicLink() || nowMs - stat.mtimeMs < minAgeMs) return [];
+      return [{ path, mtimeMs: stat.mtimeMs }];
+    } catch {
+      return [];
+    }
+  }).sort((a, b) => a.mtimeMs - b.mtimeMs);
+
+  const removed: string[] = [];
+  let cursor = 0;
+  const worker = async () => {
+    while (cursor < candidates.length) {
+      const candidate = candidates[cursor++];
+      if (!candidate) return;
+      try {
+        await rm(candidate.path, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+        removed.push(candidate.path);
+        opts.logger?.info?.(`[reaper] removed stale CLI temp directory ${candidate.path}`, { module: 'reaper' });
+      } catch (err) {
+        opts.logger?.warn?.(`[reaper] failed to remove stale CLI temp directory ${candidate.path}: ${errorDetail(err)}`, {
+          module: 'reaper',
+        });
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(4, candidates.length) }, worker));
+  return removed.sort();
 }
 
 export function enforceHourlySnapshotRetention(

--- a/packages/execution-engine/src/workers/reaper-worker.ts
+++ b/packages/execution-engine/src/workers/reaper-worker.ts
@@ -10,6 +10,7 @@ import type { RemoteDiskTarget } from './disk-headroom-monitor.js';
 import {
   enforceHourlySnapshotRetention,
   reapDeletingOrphans,
+  reapStaleInvokerCliTempDirs,
   reapStaleAutomationCheckouts,
   reapStaleWorktrees,
   trimOversizedLogs,
@@ -40,6 +41,8 @@ export interface ReaperWorkerOptions {
   reapCheckouts?: typeof reapStaleAutomationCheckouts;
   /** Test seam: override stale task-worktree reap. */
   reapWorktrees?: typeof reapStaleWorktrees;
+  /** Test seam: override stale CLI temp-directory reap. */
+  reapTempDirs?: typeof reapStaleInvokerCliTempDirs;
   /** Test seam: override snapshot-retention enforcement. */
   enforceRetention?: typeof enforceHourlySnapshotRetention;
   /** Test seam: override oversized-log trimming. */
@@ -52,6 +55,7 @@ export function createReaperWorker(options: ReaperWorkerOptions): WorkerRuntime 
   const reapOrphans = options.reapOrphans ?? reapDeletingOrphans;
   const reapCheckouts = options.reapCheckouts ?? reapStaleAutomationCheckouts;
   const reapWorktrees = options.reapWorktrees ?? reapStaleWorktrees;
+  const reapTempDirs = options.reapTempDirs ?? reapStaleInvokerCliTempDirs;
   const enforceRetention = options.enforceRetention ?? enforceHourlySnapshotRetention;
   const trimLogs = options.trimLogs ?? trimOversizedLogs;
 
@@ -76,6 +80,8 @@ export function createReaperWorker(options: ReaperWorkerOptions): WorkerRuntime 
         invokerHome: options.invokerHome,
         logger: options.logger,
       });
+      const tempDirsRemoved = await reapTempDirs({ logger: options.logger });
+      if (ctx.signal?.aborted) return;
       const snapshotsPruned = enforceRetention(options.invokerHome);
       const logsTrimmed = trimLogs({
         invokerHome: options.invokerHome,
@@ -95,7 +101,8 @@ export function createReaperWorker(options: ReaperWorkerOptions): WorkerRuntime 
       const failed = [...orphanResults, ...worktreeResults].filter((result) => !result.ok);
       const summary =
         `Reaper pass: orphan targets ${orphanResults.length - orphanFailed.length}/${orphanResults.length} ok, `
-        + `checkouts removed ${checkoutsRemoved.length}, snapshots pruned ${snapshotsPruned}, `
+        + `checkouts removed ${checkoutsRemoved.length}, CLI temp dirs removed ${tempDirsRemoved.length}, `
+        + `snapshots pruned ${snapshotsPruned}, `
         + `logs trimmed ${logsTrimmed.length}, worktrees removed ${worktreesRemoved}`;
 
       if (options.store) {
@@ -111,6 +118,7 @@ export function createReaperWorker(options: ReaperWorkerOptions): WorkerRuntime 
           payload: {
             orphanResults,
             checkoutsRemoved,
+            tempDirsRemoved,
             snapshotsPruned,
             logsTrimmed,
             worktreeResults,
@@ -130,7 +138,7 @@ export function registerReaperWorker(
 ): WorkerRegistry<WorkerRuntimeDependencies> {
   registry.register({
     kind: REAPER_WORKER_KIND,
-    note: 'Reaps orphaned .deleting dirs, stale automation checkouts, stale task worktrees, excess hourly snapshots, and oversized logs on an interval.',
+    note: 'Reaps orphaned .deleting dirs, stale automation checkouts, stale CLI temp dirs, stale task worktrees, excess hourly snapshots, and oversized logs on an interval.',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
       createReaperWorker({
         logger: deps.logger,


### PR DESCRIPTION
## Summary

Completed fixture runs can still leave temp directories after a process crash or forced termination.

The reaper now reclaims direct `invoker-cli-*` directories from the OS temp directory after 48 hours.

## Review Claim

Approve crash-leftover reclamation for old Invoker fixture directories.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Reclamation is limited to direct `invoker-cli-*` directories older than 48 hours; `/`, the user home, files, symlinks, and newer or unrelated entries are preserved.

## Slice Rationale

This fallback follows producer reclamation so it handles only abnormal exits that producer-side teardown cannot reach.

## Non-goals

- No blanket `/tmp` deletion.
- No cleanup of arbitrary application or user directories.
- No changes to worker scheduling or desired-state persistence.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test --run src/__tests__/reaper-reclaim.test.ts src/__tests__/reaper-worker.test.ts`
- [x] `pnpm check:types`
- [x] `git diff --check`

</details>

Depends-On: #8607

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c53a7ae6d`
- Post-revert steps: None
- Data migration? No

</details>
