### PR TITLE
Wire reaper to the OS temp directory

### DIFF
--- a/packages/execution-engine/src/__tests__/reaper-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/reaper-worker.test.ts
@@ -96,6 +96,7 @@ describe('reaper worker', () => {
     expect(reapCheckouts).toHaveBeenCalledTimes(1);
     expect(reapCheckouts.mock.calls[0]?.[0]).toMatchObject({ invokerHome: '/tmp/invoker-home' });
     expect(reapTempDirs).toHaveBeenCalledTimes(1);
+    expect(reapTempDirs.mock.calls[0]?.[0]).toMatchObject({ tempRoot: expect.any(String) });
     expect(enforceRetention).toHaveBeenCalledTimes(1);
     expect(enforceRetention.mock.calls[0]?.[0]).toBe('/tmp/invoker-home');
     expect(trimLogs).toHaveBeenCalledTimes(1);

--- a/packages/execution-engine/src/workers/reaper-worker.ts
+++ b/packages/execution-engine/src/workers/reaper-worker.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@invoker/contracts';
+import { tmpdir } from 'node:os';
 
 import { resolveInvokerHomeRoot } from '../worker-lock.js';
 import { recordWorkerDecisionRow, type WorkerDecisionStore } from '../worker-decision-ledger.js';
@@ -80,7 +81,10 @@ export function createReaperWorker(options: ReaperWorkerOptions): WorkerRuntime 
         invokerHome: options.invokerHome,
         logger: options.logger,
       });
-      const tempDirsRemoved = await reapTempDirs({ logger: options.logger });
+      const tempDirsRemoved = await reapTempDirs({
+        tempRoot: tmpdir(),
+        logger: options.logger,
+      });
       if (ctx.signal?.aborted) return;
       const snapshotsPruned = enforceRetention(options.invokerHome);
       const logsTrimmed = trimLogs({


### PR DESCRIPTION
## Summary

The reaper reclamation function accepts an explicit temp-root boundary.

The worker now passes the host OS temp directory into that reclamation path on every pass.

## Review Claim

Approve explicit wiring of the reaper to the OS temp directory.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The worker passes `tmpdir()` without widening the reclamation predicate or changing any other reaper action.

## Slice Rationale

This adapter-only slice makes the runtime path visible and testable after the cleanup implementation is reviewed.

## Non-goals

- No new targets beyond the existing `invoker-cli-*` predicate.
- No worker enablement change.
- No broad `/tmp` reclamation.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test --run src/__tests__/reaper-worker.test.ts src/__tests__/reaper-reclaim.test.ts`
- [x] `pnpm check:types`
- [x] `git diff --check`

</details>

Depends-On: #8608

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 77b5292b9`
- Post-revert steps: None
- Data migration? No

</details>
