### PR TITLE
[CI regression: a4a7770-playwright-9-of-9](1) Configure workers-surface fixture

### DIFF
--- a/packages/app/e2e/workers-surface.spec.ts
+++ b/packages/app/e2e/workers-surface.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect, captureScreenshot } from './fixtures/electron-app.js';
 
+test.use({
+  repoConfig: {
+    autoFixRetries: 0,
+    infraRepair: { enabled: true },
+  },
+});
+
 test('workers surface shows the worker control in the details panel', async ({ page }) => {
   await page.getByTestId('sidebar-workers').click();
 


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a4a77700abe7fdd4f5743b92b3e2795de7d4277c; job=playwright / 9-of-9 -->

CI job `playwright / 9-of-9` first failed on default-branch commit a4a77700abe7fdd4f5743b92b3e2795de7d4277c in run 30895657329.

It was most recently still red at f6d952885ed5178391f91d5d8f807129371b5814 in run 31553995287.

That run expected the infra-repair worker to remain running after stopping the selected worker, but the fixture had infra repair disabled.

This test-only slice explicitly enables infra repair for the workers-surface spec while keeping automatic fix retries disabled.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30895657329/job/91965992713

Latest failing job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31553995287/job/93982887731

## Review Claim

Approve the workers-surface E2E fixture configuration that keeps infra repair running while the test stops only the selected worker.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

The regression and its deterministic fixture setup form one proof slice. The verification task changed no files, so it does not create a separate review unit.

## Non-goals

No product runtime changes, unrelated cleanup, assertion weakening, worker lifecycle redesign, or snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Failing-before evidence: `playwright / 9-of-9` run 31553995287 reported `1 failed` and `7 passed`; infra repair was expected `running` but received `stopped`.
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-9-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/launch-dispatch-stuck-lease-cap.spec.ts e2e/launch-dispatch-stuck-lease-storm.spec.ts e2e/gui-owner-auto-bootstrap.spec.ts e2e/start-ready-daemon-owner.spec.ts e2e/ui-delta-timeline.spec.ts e2e/workers-surface.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — local macOS used an `xvfb-run` compatibility shim; `8 passed (2.9m)`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes. Reverting restores the previous workers-surface fixture configuration and may restore the shard failure.
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: Re-run `playwright / 9-of-9`.
- Data migration? No.

</details>
