### PR TITLE
[CI regression: a5d6b3e-playwright-launch-dispatch-stuck-lease](1) Stabilize stuck-lease Playwright launch

### DIFF
--- a/packages/app/e2e/launch-dispatch-stuck-lease-cap.spec.ts
+++ b/packages/app/e2e/launch-dispatch-stuck-lease-cap.spec.ts
@@ -34,8 +34,9 @@ function launchArgs(): string[] {
 }
 
 async function waitForInvoker(page: Page): Promise<void> {
+  await page.waitForURL((url) => url.href !== 'about:blank', { timeout: 30_000 });
   await page.waitForLoadState('domcontentloaded');
-  await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10000 });
+  await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 30_000 });
 }
 
 function findTask(tasks: Array<{ id: string; status: string }>, taskId: string) {
@@ -73,6 +74,7 @@ base.describe('Launch-dispatch stuck-lease retry cap', () => {
           INVOKER_REPO_CONFIG_PATH: configPath,
           INVOKER_STARTUP_POLL_DELAY_MS: '0',
           INVOKER_USER_DATA_DIR: electronUserDataDir,
+          INVOKER_E2E_ENABLE_COMPOSITOR: '1',
           INVOKER_LAUNCH_DISPATCH_LEASE_MS: String(LEASE_MS),
           INVOKER_EXECUTOR_START_TIMEOUT_MS: String(HANG_MS * 2),
           INVOKER_E2E_HANG_LAUNCH_STARTUP_MS: String(HANG_MS),

--- a/packages/app/e2e/launch-dispatch-stuck-lease-storm.spec.ts
+++ b/packages/app/e2e/launch-dispatch-stuck-lease-storm.spec.ts
@@ -39,8 +39,9 @@ function launchArgs(): string[] {
 }
 
 async function waitForInvoker(page: Page): Promise<void> {
+  await page.waitForURL((url) => url.href !== 'about:blank', { timeout: 30_000 });
   await page.waitForLoadState('domcontentloaded');
-  await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10000 });
+  await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 30_000 });
 }
 
 function findTask(tasks: Array<{ id: string; status: string }>, taskId: string) {
@@ -67,6 +68,7 @@ async function launchApp(testDir: string, extraEnv: Record<string, string>): Pro
       INVOKER_REPO_CONFIG_PATH: configPath,
       INVOKER_STARTUP_POLL_DELAY_MS: '0',
       INVOKER_USER_DATA_DIR: electronUserDataDir,
+      INVOKER_E2E_ENABLE_COMPOSITOR: '1',
       ...extraEnv,
     },
   });


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a5d6b3e626ace9e963e924c0de9410dc0302de9e; job=playwright / launch-dispatch-stuck-lease -->

The stuck-lease Playwright specs wait for a real Electron URL and enable the compositor used by CI.

The watched job first failed in run 30983254556 and remained red through run 31060913416.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30983254556/job/92238737773

## Review Claim

Approve the test-harness launch stabilization for the two stuck-lease Playwright specs.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

No product behavior changes; only the two stuck-lease Playwright specs alter their launch setup and readiness wait.

## Slice Rationale

This proof slice isolates Playwright startup reliability from watcher policy and executor routing.

## Non-goals

- No product code changes.
- No broad Playwright timeout change.
- No snapshot or visual-proof churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-launch-dispatch-stuck-lease' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/launch-dispatch-stuck-lease-cap.spec.ts e2e/launch-dispatch-stuck-lease-storm.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`
  - Darwin result: `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "xvfb-run" not found`; tests did not start.
- [x] `env CI=true INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-launch-dispatch-stuck-lease-native-darwin' INVOKER_PLAYWRIGHT_WORKERS=1 pnpm --filter @invoker/app test:e2e -- e2e/launch-dispatch-stuck-lease-cap.spec.ts e2e/launch-dispatch-stuck-lease-storm.spec.ts --reporter=line`
  - Result: `2 passed (44.3s)`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert af8f5c21aa8622486a3bdc809a78f0578207dba7`
- Post-revert steps: Rerun the stuck-lease Playwright job.
- Data migration? No.

</details>
