### PR TITLE
[CI regression: a5d6b3e-playwright-launch-dispatch-stuck-lease](2) Map legacy stuck-lease verification

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -54,6 +54,19 @@ const BUILD_APP_COMMAND = [
   'pnpm --filter @invoker/surfaces build',
   'pnpm --filter @invoker/app build',
 ].join(' && ');
+const LEGACY_PLAYWRIGHT_JOB_ALIASES = [
+  {
+    jobId: 'playwright',
+    jobName: 'playwright / launch-dispatch-stuck-lease',
+    matrix: {
+      name: 'launch-dispatch-stuck-lease',
+      files: [
+        'e2e/launch-dispatch-stuck-lease-cap.spec.ts',
+        'e2e/launch-dispatch-stuck-lease-storm.spec.ts',
+      ].join(' '),
+    },
+  },
+];
 
 // ---------------------------------------------------------------------------
 // Pure logic
@@ -340,18 +353,32 @@ export function buildCiJobDefinitions(workflow = parseYaml(readFileSync(WORKFLOW
       });
     }
   }
+  for (const alias of LEGACY_PLAYWRIGHT_JOB_ALIASES) {
+    if (definitions.has(alias.jobName)) continue;
+    const job = workflow.jobs?.[alias.jobId];
+    if (!job) continue;
+    definitions.set(alias.jobName, {
+      jobId: alias.jobId,
+      jobName: alias.jobName,
+      matrix: alias.matrix,
+      verifyCommand: commandForJob(alias.jobId, job, alias.matrix),
+    });
+  }
   return definitions;
 }
 
+export function resolveVerifyCommand(jobName, jobDefinitions = buildCiJobDefinitions()) {
+  return jobDefinitions.get(jobName)?.verifyCommand?.trim() ?? '';
+}
+
 export function fallbackVerifyCommand(jobName) {
-  return `bash -lc ${shellSingleQuote(`echo "No local verify command is mapped for CI job: ${jobName}" >&2; exit 1`)}`;
+  return `node scripts/e2e-regression-watch.mjs --exec-verify-command ${shellSingleQuote(jobName)}`;
 }
 
 export function buildPlanVars(failure, repoUrl, jobDefinitions = buildCiJobDefinitions()) {
-  const definition = jobDefinitions.get(failure.jobName);
   const short = shortSha(failure.firstBadSha);
   const jobSlug = `${short}-${slugify(failure.jobName)}`;
-  const verifyCommand = definition?.verifyCommand?.trim() || fallbackVerifyCommand(failure.jobName);
+  const verifyCommand = resolveVerifyCommand(failure.jobName, jobDefinitions) || fallbackVerifyCommand(failure.jobName);
   return {
     repo_url: repoUrl,
     base_branch: 'master',
@@ -551,10 +578,42 @@ export async function main() {
   });
 }
 
+function runVerifyCommandCli(jobName) {
+  const verifyCommand = resolveVerifyCommand(jobName);
+  if (!verifyCommand) {
+    console.error(`No local verify command is mapped for CI job: ${jobName}`);
+    process.exitCode = 1;
+    return;
+  }
+  execSync(verifyCommand, {
+    cwd: REPO_ROOT,
+    env: process.env,
+    shell: '/bin/bash',
+    stdio: 'inherit',
+  });
+}
+
+function printVerifyCommandCli(jobName) {
+  const verifyCommand = resolveVerifyCommand(jobName);
+  if (!verifyCommand) {
+    console.error(`No local verify command is mapped for CI job: ${jobName}`);
+    process.exitCode = 1;
+    return;
+  }
+  process.stdout.write(`${verifyCommand}\n`);
+}
+
 const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
 if (isMain) {
-  main().catch((err) => {
-    console.error('ci-regression-watch: fatal error', err);
-    process.exitCode = 1;
-  });
+  const [command, ...args] = process.argv.slice(2);
+  if (command === '--exec-verify-command') {
+    runVerifyCommandCli(args.join(' '));
+  } else if (command === '--print-verify-command') {
+    printVerifyCommandCli(args.join(' '));
+  } else {
+    main().catch((err) => {
+      console.error('ci-regression-watch: fatal error', err);
+      process.exitCode = 1;
+    });
+  }
 }


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a5d6b3e626ace9e963e924c0de9410dc0302de9e; job=playwright / launch-dispatch-stuck-lease -->

The regression watcher maps the retired stuck-lease job name to its two current Playwright specs.

Unknown jobs defer verification lookup until execution instead of persisting an irreversible failure command.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30983254556/job/92238737773

## Review Claim

Approve late-bound verification resolution for legacy CI-watch job names.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged; current workflow definitions take precedence over the legacy alias.

## Slice Rationale

This policy slice defines the lookup boundary without mixing in repro proof or executor runtime compatibility.

## Non-goals

- No executor behavior changes.
- No workflow matrix changes.
- No product-test changes.

## Architecture

### Before

```mermaid
graph TD
    A["Unknown CI job"] --> B["Persist permanent failure command"]
```

### After

```mermaid
graph TD
    A["Unknown CI job"] --> B["Persist deferred watcher lookup"]
    B --> C["Resolve current job mapping at execution time"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/e2e-regression-watch.mjs --print-verify-command 'playwright / launch-dispatch-stuck-lease'`
  - Result: `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-launch-dispatch-stuck-lease' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/launch-dispatch-stuck-lease-cap.spec.ts e2e/launch-dispatch-stuck-lease-storm.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert eed0158d153eed3ce842d4fce7a722c95b73a9c5`
- Post-revert steps: Restore a replacement local verification mapping before re-enabling the watcher.
- Data migration? No.

</details>
