### PR TITLE
[CI regression: a5d6b3e-playwright-launch-dispatch-stuck-lease](4) Route stale sentinels through the current watcher

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -4,7 +4,7 @@ import type { ChildProcess } from 'node:child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { SshExecutor } from '../ssh-executor.js';
+import { SshExecutor, resolveLegacyCiWatchVerifySentinel } from '../ssh-executor.js';
 import type { WorkRequest } from '@invoker/contracts';
 import type { PersistedTaskMeta } from '../executor.js';
 import { createSshRemoteScriptError } from '../ssh-git-exec.js';
@@ -171,6 +171,22 @@ describe('SshExecutor pre-flight validation', () => {
       expect.any(Object),
       expect.objectContaining({ base: '0123456789abcdef0123456789abcdef01234567' }),
     );
+  });
+});
+
+describe('resolveLegacyCiWatchVerifySentinel', () => {
+  it('defers stale CI-watch missing-command sentinels to the current watcher mapping', () => {
+    const staleCommand = 'bash -lc \'echo "No local verify command is mapped for CI job: playwright / launch-dispatch-stuck-lease" >&2; exit 1\'';
+
+    expect(resolveLegacyCiWatchVerifySentinel(staleCommand)).toBe(
+      "node scripts/e2e-regression-watch.mjs --exec-verify-command 'playwright / launch-dispatch-stuck-lease'",
+    );
+  });
+
+  it('leaves ordinary commands unchanged', () => {
+    const command = 'bash scripts/test-suites/required/10-vitest-workspace.sh';
+
+    expect(resolveLegacyCiWatchVerifySentinel(command)).toBe(command);
   });
 });
 

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -56,6 +56,18 @@ function tailFor(text: string): string {
     : trimmed;
 }
 
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function resolveLegacyCiWatchVerifySentinel(payload: string): string {
+  const match = payload.match(
+    /^bash -lc 'echo "No local verify command is mapped for CI job: ([^"]+)" >&2; exit 1'$/,
+  );
+  if (!match) return payload;
+  return `node scripts/e2e-regression-watch.mjs --exec-verify-command ${shellSingleQuote(match[1])}`;
+}
+
 // Every remote-contact primitive (bootstrap, worktree list/cleanup, record-and-push,
 // etc.) funnels through execRemoteCapture, so logging failures here -- unconditionally,
 // unlike the bench() calls above which are opt-in -- covers all of them without each
@@ -225,9 +237,10 @@ exit "$PAYLOAD_EXIT"
 
 
   private buildPayloadScript(payload: string): string {
+    const executablePayload = resolveLegacyCiWatchVerifySentinel(payload);
     return `#!/usr/bin/env bash
 set -e
-${payload}
+${executablePayload}
 `;
   }
 


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a5d6b3e626ace9e963e924c0de9410dc0302de9e; job=playwright / launch-dispatch-stuck-lease -->

SSH execution routes persisted CI-watch sentinel payloads through the watcher's current verification lookup.

Ordinary payloads remain unchanged.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30983254556/job/92238737773

## Review Claim

Approve routing from legacy CI-watch sentinels to the current watcher lookup.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the stale-sentinel compatibility path; ordinary commands pass through unchanged.

## Slice Rationale

This final routing slice depends on the watcher lookup and stays separate from tooling policy and repro proof.

## Non-goals

- No generic payload rewriting.
- No watcher mapping changes.
- No Playwright harness changes.

## Architecture

### Before

```mermaid
graph TD
    A["Persisted missing-command sentinel"] --> B["SSH payload fails permanently"]
```

### After

```mermaid
graph TD
    A["Persisted missing-command sentinel"] --> B["SSH executor recognizes sentinel"]
    B --> C["Current watcher resolves verification command"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/ssh-executor.test.ts`
  - Result: `Test Files 1 passed (1); Tests 46 passed | 1 skipped (47)`
- [x] `node scripts/repro/repro-e2e-regression-watch.mjs`
  - Result: `[repro-e2e-regression-watch] all checks passed`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 16780f209bb12e73f5a01e25451137f4146ad4e1`
- Post-revert steps: Existing stale sentinels must be replaced manually before retry.
- Data migration? No.

</details>
