### PR TITLE
[CI regression: f8533de-playwright-1-of-9](1) Restore prompt-mode sidecar approval

### DIFF
--- a/packages/app/src/__tests__/planning-chat-e2e-acceptance.test.ts
+++ b/packages/app/src/__tests__/planning-chat-e2e-acceptance.test.ts
@@ -271,7 +271,7 @@ describe('planning chat incident ad665bff: valid sidecar after repository answer
     vi.restoreAllMocks();
   });
 
-  it.fails('persists the exact recovered reaper draft and makes it review-ready', async () => {
+  it('persists the exact recovered reaper draft and makes it review-ready', async () => {
     const workingDir = mkdtempSync(join(tmpdir(), 'planning-chat-ad665bff-'));
     const adapter = await SQLiteAdapter.create(':memory:');
     const sessions = createInAppPlanningChatSessions();

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -906,13 +906,15 @@ export async function sendPlanningChatMessage(
           ? []
           : activeSession.conversation.lastTurnReasoning;
         const reasoning = reasoningParts.length > 0 ? reasoningParts.join('\n\n') : undefined;
+        const immediateDraftPlanText = deps.plannerReplyOverride
+          ? extractYamlPlan(reply)
+          : activeSession.conversation.lastTurnDraftPlanText;
         const result = evaluatePlanningTurn({
           userMessage: message,
           messagesBeforeTurn,
           assistantReply: reply,
-          immediateDraftPlanText: deps.plannerReplyOverride
-            ? extractYamlPlan(reply)
-            : activeSession.conversation.lastTurnDraftPlanText,
+          immediateDraftPlanText,
+          requireDraftAuthorization: hasDraftPlan(activeSession) || !immediateDraftPlanText,
         });
         if (result.kind === 'message') {
           activeSession.status = hasDraftPlan(activeSession)


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=f8533de99d21ae3fcb2167b708feaf4440992287; job=playwright / 1-of-9 -->

Planning chat now evaluates a fresh YAML sidecar immediately when an override returns a draft.

That lets the recovered reaper draft persist as review-ready instead of requiring another authorization turn.

CI job `playwright / 1-of-9` first failed on default-branch push commit f8533de99d21ae3fcb2167b708feaf4440992287 in run 31455346185.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31455346185/job/93684954990

## Review Claim

The planning chat turn evaluator should treat an immediate draft plan as authorization-ready when one exists.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the existing planning chat turn-evaluation inputs change; sessions without an immediate draft still require draft authorization.

## Slice Rationale

This slice contains the source behavior fix and its directly affected acceptance test. Visual proof expectation refresh stays in the next slice.

## Non-goals

- No snapshot refresh.
- No unrelated planner or session cleanup.
- No test weakening.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-1-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/visual-proof.spec.ts e2e/edit-task-command.spec.ts e2e/headless-thundering-herd.spec.ts e2e/launching-stall-watchdog.spec.ts e2e/embedded-terminal-pty.spec.ts e2e/keyboard-navigation.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`
- [ ] `node scripts/validate-pr-body-local.mjs --body-file /tmp/ci-regression-f8533de-pr1.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d14fac385`
- Post-revert steps: Re-run the Playwright shard verification command above.
- Data migration? No

</details>
