### PR TITLE
[CI regression: f8533de-playwright-1-of-9](2) Refresh visual proof expectations

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -738,6 +738,8 @@ test.describe('Visual proof capture', () => {
     await expect(page.getByTestId('sidebar-planning')).toHaveAttribute('aria-label', 'Plan graph');
     await expect(page.getByTestId('sidebar-workflows')).toHaveAttribute('aria-label', 'Workflows');
     await expect(page.getByTestId('sidebar-attention')).toHaveAttribute('aria-label', 'Needs Attention');
+    await expect(page.getByTestId('sidebar-workers')).toHaveAttribute('aria-label', 'Workers');
+    await expect(page.getByTestId('sidebar-workflows')).toHaveAttribute('data-tone', 'neutral');
     await expect(page.getByTestId('sidebar-running')).toHaveCount(0);
     await expect(page.getByTestId('rail-settings')).toBeVisible();
     await expect(page.getByTestId('sidebar-home')).toBeVisible();
@@ -1925,9 +1927,12 @@ test.describe('Visual proof capture', () => {
     await expect(page.locator('.react-flow__node[data-testid$="task-alpha"]')).toBeVisible();
     await selectWorkflowNode(page, 'wf-test-1');
     await waitForStableViewportTransform(page, page.getByTestId('workflow-graph-surface').locator('.react-flow__viewport').first());
-    const pendingChip = page.getByTestId('workflow-status-pill-pending');
-    await expect(pendingChip).toBeVisible();
-    await expect(pendingChip).toContainText('pending (1)');
+    const runningWorkflowChip = page
+      .getByTestId('workflow-status-pill-running')
+      .filter({ hasText: 'workflows running (1)' });
+    await expect(runningWorkflowChip).toBeVisible();
+    await expect(page.getByTestId('workflow-status-pill-pending').filter({ hasText: 'pending (0)' })).toBeVisible();
+    await expect(page.getByTestId('queue-chip-queued')).toContainText('Queued (0)');
     await expect(page.getByText('System Log')).toHaveCount(0);
     await captureScreenshot(page, 'status-bar-no-system-log');
     await assertPageScreenshot(page, 'status-bar-no-system-log');


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=f8533de99d21ae3fcb2167b708feaf4440992287; job=playwright / 1-of-9 -->

The visual proof spec now expects the empty-state rail and status bar counts produced by current master.

The empty-state screenshot baseline is refreshed for the corrected Playwright shard.

CI job `playwright / 1-of-9` first failed on default-branch push commit f8533de99d21ae3fcb2167b708feaf4440992287 in run 31455346185.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31455346185/job/93684954990

## Review Claim

The visual proof expectations should match the corrected `playwright / 1-of-9` shard state.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only visual proof expectations and their snapshot baseline change; product behavior is unchanged by this proof slice.

## Slice Rationale

This proof refresh is separate from the planner behavior fix so reviewers can check generated visual-proof churn independently.

## Non-goals

- No product behavior change.
- No unrelated screenshot refresh.
- No planner or session cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-1-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/visual-proof.spec.ts e2e/edit-task-command.spec.ts e2e/headless-thundering-herd.spec.ts e2e/launching-stall-watchdog.spec.ts e2e/embedded-terminal-pty.spec.ts e2e/keyboard-navigation.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`
- [ ] `node scripts/validate-pr-body-local.mjs --body-file /tmp/ci-regression-f8533de-pr2.md --base stack/EdbertChan/plan/ci-regression-f8533de-playwright-1-of-9/restore-prompt-mode-sidecar-approval--56fdcd31`

</details>

## Visual Proof

![Empty planning chat with neutral Workflows rail and no running badge](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-fddd60/empty-state.png)

Manually inspected: the screenshot shows the empty planning chat, the Workers rail item, neutral Workflows rail state, and no running badge.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 27c5d338`
- Post-revert steps: Re-run the Playwright shard verification command above.
- Data migration? No

</details>
