### PR TITLE
[CI regression: f6d9528-e2e-proof-shard-3](1) Isolate the submission benchmark from owner auto-run

### DIFF
--- a/scripts/bench-workflow-submission-storm.sh
+++ b/scripts/bench-workflow-submission-storm.sh
@@ -164,7 +164,7 @@ plan_path.write_text(contents.replace(
 PY
 
 cat > "$CONFIG_PATH" <<'EOF'
-{"autoFixRetries":0,"maxConcurrency":4}
+{"autoFixRetries":0,"maxConcurrency":4,"disableAutoRunOnStartup":true}
 EOF
 
 COMMON_ENV=(


### PR DESCRIPTION
## Summary

The workflow-submission-storm benchmark measures how fast the owner accepts explicit no-track submissions.

Startup auto-run was contaminating that measurement window with unrelated auto-started work.

This slice disables startup auto-run in the benchmark's own config, so the benchmark only measures the submissions it explicitly sends.

## Review Claim

The submission-storm benchmark disables startup auto-run so it measures explicit no-track submissions only.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the benchmark-local config changes; product defaults and runtime behavior remain unchanged.

## Slice Rationale

This benchmark configuration is independent from the runtime repair and can be reviewed first.

## Non-goals

No product behavior, benchmark thresholds, or task definitions change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash -n scripts/bench-workflow-submission-storm.sh`
- [ ] `grep -n disableAutoRunOnStartup scripts/bench-workflow-submission-storm.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7518c83c1`
- Post-revert steps: None
- Data migration? No

</details>
