### PR TITLE
[CI regression: f6d9528-e2e-proof-shard-3](3) Carry no-track through the run activation surface

### DIFF
--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -54,7 +54,7 @@ export async function tryDelegateRun(
   const traceId = createTraceId('headless.run');
   return tryDelegate(
     'headless.run',
-    { planPath: resolvePath(planPath), traceId },
+    { planPath: resolvePath(planPath), noTrack, traceId },
     messageBus,
     {
       waitForApproval,

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -134,6 +134,7 @@ import {
 
 export interface HeadlessRunMutationPayload {
   planPath: string;
+  noTrack?: boolean;
   traceId?: string;
 }
 
@@ -305,7 +306,7 @@ export interface GuiMutationTaskActions {
   ) => Promise<TaskState[]>;
   executeHeadlessRun: (
     payload: HeadlessRunMutationPayload,
-  ) => Promise<{ workflowId: string; tasks: TaskState[]; workflowIds: string[]; workflowCount: number; planName: string }>;
+  ) => Promise<{ workflowId: string; tasks?: TaskState[]; workflowIds: string[]; workflowCount: number; planName: string; ok?: true; accepted?: true }>;
   executeHeadlessResume: (payload: HeadlessResumeMutationPayload) => Promise<{ workflowId: string; tasks: TaskState[] }>;
   executeHeadlessExec: (payload: HeadlessExecMutationPayload) => Promise<unknown>;
   executeSpawnRepairWorkflowMutation: (payload: unknown) => Promise<unknown>;
@@ -671,7 +672,7 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
 
   async function executeHeadlessRun(
     payload: HeadlessRunMutationPayload,
-  ): Promise<{ workflowId: string; tasks: TaskState[]; workflowIds: string[]; workflowCount: number; planName: string }> {
+  ): Promise<{ workflowId: string; tasks?: TaskState[]; workflowIds: string[]; workflowCount: number; planName: string; ok?: true; accepted?: true }> {
     const { applyConfiguredPlanDefaults, parsePlanSubmissionBundleFile } = await import('../plan-parser.js');
     const submission = await parsePlanSubmissionBundleFile(payload.planPath);
     taskHandles.clear();
@@ -710,6 +711,20 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
     const workflowId = workflowIds[workflowIds.length - 1];
     if (!workflowId) {
       throw new Error('Loaded plan did not create a workflow.');
+    }
+    if (payload.noTrack) {
+      logger.info(
+        `accepted no-track run across ${workflowIds.length} workflow(s), primary "${workflowId}"`,
+        { module: 'ipc-delegate' },
+      );
+      return {
+        ok: true,
+        accepted: true,
+        workflowId,
+        workflowIds,
+        workflowCount: workflowIds.length,
+        planName: submission.name,
+      };
     }
     const started = orchestrator.startExecution();
     logger.info(


### PR DESCRIPTION
## Summary

Explicit no-track run requests need to reach the owner process without being coerced into a tracked submission along the way.

This slice extends the headless delegation payload and the GUI mutation handler's activation shape to carry a `noTrack` flag end to end.

When `noTrack` is set, the GUI mutation handler now returns an acknowledgment instead of starting execution and waiting on the started tasks.

Tracked requests are unaffected: they still start execution and return the full set of started tasks as before.

## Review Claim

Delegated run requests preserve no-track through the headless and GUI mutation activation surfaces.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Tracked runs retain their existing task-start and response behavior; only explicit no-track requests take the acknowledgment path.

## Slice Rationale

This slice defines the activation shape before the main-process owner dispatch consumes it.

## Non-goals

No owner endpoint selection, shell bootstrap, benchmark setup, or proof-runner policy changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test -- headless-delegation.test.ts gui-mutation-translation.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b530dbab2`
- Post-revert steps: None
- Data migration? No

</details>
