### PR TITLE
[CI regression: f6d9528-e2e-proof-shard-3](4) Honor no-track in writable owner routing

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1220,6 +1220,10 @@ function startHeadlessMode(): void {
         if (!workflowId) {
           throw new Error(`Failed to resolve workflow id for delegated plan: ${payload.planPath}`);
         }
+        if (payload.noTrack) {
+          logger.info(`standalone accepted no-track run for workflow "${workflowId}"`, { module: 'ipc-delegate' });
+          return { ok: true, accepted: true, workflowId };
+        }
         const started = orchestrator.startExecution();
         logger.info(`standalone started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
         const tasks = orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflowId);
@@ -1814,7 +1818,7 @@ function startHeadlessMode(): void {
 
         const executeStandaloneHeadlessRun = async (
           payload: HeadlessRunMutationPayload,
-        ): Promise<{ workflowId: string; tasks: TaskState[]; workflowIds: string[]; workflowCount: number; planName: string }> => {
+        ): Promise<{ workflowId: string; tasks?: TaskState[]; workflowIds: string[]; workflowCount: number; planName: string; ok?: true; accepted?: true }> => {
           const { applyConfiguredPlanDefaults, parsePlanSubmissionBundleFile } = await import('./plan-parser.js');
           const submission = await parsePlanSubmissionBundleFile(payload.planPath);
           const existingWorkflowIds = new Set(orchestrator.getWorkflowIds());
@@ -1850,6 +1854,20 @@ function startHeadlessMode(): void {
           if (!workflowId) {
             throw new Error('Loaded plan did not create a workflow.');
           }
+          if (payload.noTrack) {
+            logger.info(
+              `accepted no-track run across ${workflowIds.length} workflow(s), primary "${workflowId}"`,
+              { module: 'ipc-delegate' },
+            );
+            return {
+              ok: true,
+              accepted: true,
+              workflowId,
+              workflowIds,
+              workflowCount: workflowIds.length,
+              planName: submission.name,
+            };
+          }
           const started = orchestrator.startExecution();
           logger.info(
             `started ${started.length} task(s) across ${workflowIds.length} workflow(s), primary "${workflowId}"`,
@@ -1872,14 +1890,15 @@ function startHeadlessMode(): void {
 
         messageBus.onRequest('headless.run', async (req: unknown) => {
           noteStandaloneOwnerActivity();
-          const { planPath, traceId } = req as { planPath: string; traceId?: string };
+          const { planPath, noTrack, traceId } = req as { planPath: string; noTrack?: boolean; traceId?: string };
           logger.info(
-            `headless.run received trace=${traceId ?? '<none>'} planPath="${planPath}" ownerId=${workflowMutationOwnerId} mode=standalone`,
+            `headless.run received trace=${traceId ?? '<none>'} planPath="${planPath}" noTrack=${noTrack ? 'true' : 'false'} ownerId=${workflowMutationOwnerId} mode=standalone`,
             { module: 'ipc-delegate' },
           );
-          const result = await executeStandaloneHeadlessRun({ planPath });
+          const result = await executeStandaloneHeadlessRun({ planPath, noTrack });
+          const taskCount = Array.isArray(result.tasks) ? result.tasks.length : 0;
           logger.info(
-            `headless.run accepted trace=${traceId ?? '<none>'} workflow="${result.workflowId}" tasks=${result.tasks.length} mode=standalone`,
+            `headless.run accepted trace=${traceId ?? '<none>'} workflow="${result.workflowId}" tasks=${taskCount} mode=standalone`,
             { module: 'ipc-delegate' },
           );
           return result;
@@ -3029,14 +3048,15 @@ startMainProcessBootstrap({
           resetUiPerfStats,
         }));
       messageBus.onRequest('headless.run', async (req: unknown) => {
-        const { planPath, traceId } = req as { planPath: string; traceId?: string };
+        const { planPath, noTrack, traceId } = req as { planPath: string; noTrack?: boolean; traceId?: string };
         logger.info(
-          `headless.run received trace=${traceId ?? '<none>'} planPath="${planPath}" ownerId=${workflowMutationOwnerId} mode=gui`,
+          `headless.run received trace=${traceId ?? '<none>'} planPath="${planPath}" noTrack=${noTrack ? 'true' : 'false'} ownerId=${workflowMutationOwnerId} mode=gui`,
           { module: 'ipc-delegate' },
         );
-        const result = await mutationActions.executeHeadlessRun({ planPath });
+        const result = await mutationActions.executeHeadlessRun({ planPath, noTrack });
+        const taskCount = Array.isArray(result.tasks) ? result.tasks.length : 0;
         logger.info(
-          `headless.run accepted trace=${traceId ?? '<none>'} workflow="${result.workflowId}" tasks=${result.tasks.length} mode=gui`,
+          `headless.run accepted trace=${traceId ?? '<none>'} workflow="${result.workflowId}" tasks=${taskCount} mode=gui`,
           { module: 'ipc-delegate' },
         );
         return result;


### PR DESCRIPTION
## Summary

The previous slice taught the run payload to carry `noTrack` end to end, but the writable owners still ignored it.

Both the GUI-mode and standalone-mode writable-owner handlers in the main process now branch on `noTrack` before starting execution.

An explicit no-track submission gets a lightweight acknowledgment and never starts or tracks its tasks.

Tracked submissions keep starting execution and returning their started tasks exactly as before.

## Review Claim

GUI and standalone writable owners acknowledge explicit no-track run submissions without starting or tracking their tasks.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Tracked run requests still start execution and return task lists; only explicit no-track requests return early.

## Slice Rationale

Owner routing consumes the activation contract from the preceding slice while staying separate from shell and proof policy.

## Non-goals

No plan parsing, owner discovery, task execution logic, or UI layout changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test -- owner-delegation.test.ts headless-no-track-microtask.test.ts acknowledge-no-track-start-ready.test.ts`

</details>

## Visual Proof

![No-track owner submission stays pending](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260812-a82464/no-track-owner-pending.png)

Manually inspected: I opened `packages/app/e2e/visual-proof/after/no-track-owner-pending.png` and saw the "No-track owner submission" workflow (`wf-test-1`) with its task graph showing the submitted task with STATUS `pending`, the queue counters reading `Executing (0/6)` and `Queued (1)`, and no worker started — confirming the writable owner accepted the no-track submission without starting or tracking its task.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 935f87ca3`
- Post-revert steps: None
- Data migration? No

</details>
