### PR TITLE
[CI regression: f6d9528-e2e-proof-shard-3](5) Create the proof runner temp root before state writes

### DIFF
--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -18,6 +18,9 @@ SHARD_INDEX="${INVOKER_TEST_ALL_SHARD_INDEX:-}"
 SHARD_TOTAL="${INVOKER_TEST_ALL_SHARD_TOTAL:-1}"
 AGGREGATE="${INVOKER_TEST_ALL_AGGREGATE:-0}"
 SHARDED=0
+TMP_ROOT="${TMPDIR:-/tmp}"
+
+mkdir -p "$TMP_ROOT"
 
 if [ "$PROOF" = "1" ]; then
   FORCE_RERUN=1
@@ -153,7 +156,7 @@ load_state() {
 
 persist_state() {
   local tmp
-  tmp="$(mktemp "${TMPDIR:-/tmp}/invoker-test-state.XXXXXX")"
+  tmp="$(mktemp "$TMP_ROOT/invoker-test-state.XXXXXX")"
   : > "$tmp"
   for key in "${!STATE_MAP[@]}"; do
     IFS='|' read -r mode suite <<<"$key"
@@ -215,7 +218,7 @@ suite_preflight() {
 cleanup_proof_tmp() {
   [ "$PROOF" = "1" ] || return 0
   [ "$JOBS" -eq 1 ] || return 0
-  local tmp_root="${TMPDIR:-/tmp}"
+  local tmp_root="$TMP_ROOT"
   [ -d "$tmp_root" ] || return 0
   local state_real=""
   if [ -n "${STATE_FILE:-}" ] && [ -e "$STATE_FILE" ]; then


### PR DESCRIPTION
## Summary

The all-tests runner's proof mode persists state and cleans up under a configured temp root.

That temp root was never created before the first write, so a fresh `TMPDIR` (as CI shard 3 configures) could make the write fail.

This slice resolves the temp root once at startup, creates it, and reuses that same path for both state persistence and cleanup.

Existing temp roots and the default `/tmp` path keep their current state-file and cleanup behavior.

## Review Claim

The all-tests runner creates its configured temp root before proof state persistence and cleanup use it.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Existing temp roots and the default /tmp path keep the same state-file and cleanup behavior.

## Slice Rationale

This proof-runner filesystem policy is independent from the runtime and benchmark slices.

## Non-goals

No suite selection, sharding, proof force-rerun, or test command changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash -n scripts/run-all-tests.sh`
- [ ] `env INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_SHARD_INDEX='3' INVOKER_TEST_ALL_SHARD_TOTAL=4 INVOKER_TEST_ALL_STATE_FILE=/tmp/invoker-ci-watch-proof-state.tsv TMPDIR=/tmp/invoker-tmp bash scripts/run-all-tests.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0cbc5c17f`
- Post-revert steps: None
- Data migration? No

</details>
