### PR TITLE
[CI regression: a4a7770-playwright-5-of-9](1) Serialize the planning restore repro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -673,6 +673,7 @@ jobs:
           - name: terminal-garbling
             files: >-
               e2e/planning-terminal-live-model.proof.spec.ts
+              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
               e2e/planning-surface-navigation-garble-repro.spec.ts
               e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts
               e2e/planning-terminal-expand-collapse-garble-repro.spec.ts


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a4a77700abe7fdd4f5743b92b3e2795de7d4277c; job=playwright / 5-of-9 -->

CI job `playwright / 5-of-9` first failed on default-branch push commit a4a77700abe7fdd4f5743b92b3e2795de7d4277c in run 30895657329.

It was most recently still red at f6d952885ed5178391f91d5d8f807129371b5814 in run 31553995287.

This slice assigns the planning chat restore repro to the serialized terminal-garbling Playwright group.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30895657329/job/91965992654

## Review Claim

Assign `planning-chat-restore-conversational-mode-repro.spec.ts` to the terminal-garbling matrix entry so the inventory includes it in the serialized terminal-test group.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected shard inventory entry.

## Slice Rationale

CI matrix membership is isolated from shared fixture cleanup and benchmark event sequencing so this policy change can be reviewed independently.

## Non-goals

- No product behavior changes.
- No repro assertion changes.
- No Playwright worker-count changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3ca034213`
- Post-revert steps: Rerun the shard inventory command above.
- Data migration? No

</details>
