### PR TITLE
[CI regression: a4a7770-playwright-5-of-9](2) Clean standalone owners after Electron tests

### DIFF
--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -19,6 +19,7 @@ import { pathToFileURL } from 'node:url';
 import { stringify as yamlStringify } from 'yaml';
 import { registerTrackedBrowserUserDataDir } from './browser-process-registry.js';
 import { killOwnedProcessGroup } from './process-group.js';
+import { cleanupStandaloneOwnersForTestDir } from './headless-client.js';
 
 export type ElectronFixtures = {
   electronApp: ElectronApplication;
@@ -268,8 +269,12 @@ exit 64
         PATH: pathEnv,
       },
     });
-    await use(app);
-    await closeElectronApp(app);
+    try {
+      await use(app);
+    } finally {
+      await closeElectronApp(app);
+      await cleanupStandaloneOwnersForTestDir(testDir);
+    }
   },
 
   page: async ({ electronApp, guiOwnerMode }, use) => {


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a4a77700abe7fdd4f5743b92b3e2795de7d4277c; job=playwright / 5-of-9 -->

CI job `playwright / 5-of-9` first failed on default-branch push commit a4a77700abe7fdd4f5743b92b3e2795de7d4277c in run 30895657329.

It was most recently still red at f6d952885ed5178391f91d5d8f807129371b5814 in run 31553995287.

This slice cleans standalone owner processes whenever an Electron test fixture closes.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30895657329/job/91965992654

## Review Claim

Run test-directory-scoped standalone-owner cleanup in the Electron fixture's `finally` path after closing the app.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Other CI jobs and product behavior stay unchanged; cleanup targets only standalone owners carrying the current test directory's database or socket marker.

## Slice Rationale

Shared fixture lifecycle cleanup is separated from CI matrix policy and the gap benchmark's synthetic event inputs.

## Non-goals

- No product runtime changes.
- No test expectation changes.
- No CI matrix changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build`
- [ ] `env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-5-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/autofix-worker-ui.spec.ts e2e/orphan-relaunch.spec.ts e2e/gap-recovery-bench.spec.ts e2e/planning-chat-send-long-deadline.spec.ts e2e/system-setup-visual-proof.spec.ts e2e/startup-nonempty-responsiveness.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — local attempt stopped before Playwright because `xvfb-run` is unavailable.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 13295e70f`
- Post-revert steps: Rerun the Playwright command above.
- Data migration? No

</details>
