### PR TITLE
[CI regression: 2363032-required-fast-vitest-workspace](1) narrow launch writes

### DIFF
--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -355,7 +355,13 @@ export interface PersistenceAdapter {
 
   // Tasks
   saveTask(workflowId: string, task: TaskState): void;
-  updateTask(taskId: string, changes: TaskStateChanges): void;
+  updateTask(taskId: string, changes: TaskStateChanges, opts?: { skipWorkflowStatusSync?: boolean }): void;
+  updateTaskFromKnownState?(
+    taskId: string,
+    beforeTask: TaskState,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): void;
   loadTasks(workflowId: string): TaskState[];
   loadWorkflowTaskSnapshot?(options?: WorkflowReadOptions): WorkflowTaskSnapshot;
   /** Authoritative single-task read by ID, suitable for recovery workflows. */

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -821,7 +821,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         : null);
     this.corruptionRecovery = corruptionRecovery;
     this.taskAttemptRepo = new SqliteTaskAttemptRepository(this.executor, {
-      updateTask: (taskId, changes) => this.updateTask(taskId, changes),
+      updateTask: (taskId, changes, opts) => this.updateTask(taskId, changes, opts),
       updateAttempt: (attemptId, changes) => this.updateAttempt(attemptId, changes),
     });
     this.workflowRepo = new SqliteWorkflowRepository(
@@ -1231,8 +1231,21 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.taskAttemptRepo.saveTask(workflowId, task);
   }
 
-  updateTask(taskId: string, changes: TaskStateChanges): void {
-    this.taskAttemptRepo.updateTask(taskId, changes);
+  updateTask(
+    taskId: string,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): void {
+    this.taskAttemptRepo.updateTask(taskId, changes, opts);
+  }
+
+  updateTaskFromKnownState(
+    taskId: string,
+    beforeTask: TaskState,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): void {
+    this.taskAttemptRepo.updateTaskFromKnownState(taskId, beforeTask, changes, opts);
   }
 
   updateTaskLaunchState(taskId: string, changes: TaskStateChanges): void {

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -56,7 +56,11 @@ export function assertSaveTaskPersistsSelectedAttemptId(
  * updateAttempt on the adapter instance).
  */
 export interface TaskAttemptMutators {
-  updateTask(taskId: string, changes: TaskStateChanges): void;
+  updateTask(
+    taskId: string,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): void;
   updateAttempt(
     attemptId: string,
     changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>,
@@ -344,9 +348,34 @@ export class SqliteTaskAttemptRepository {
     });
   }
 
-  updateTask(taskId: string, changes: TaskStateChanges): void {
+  updateTask(
+    taskId: string,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): void {
     const beforeTask = this.loadTask(taskId);
     if (!beforeTask) return;
+    this.updateTaskWithBefore(beforeTask, changes, opts);
+  }
+
+  updateTaskFromKnownState(
+    taskId: string,
+    beforeTask: TaskState,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): void {
+    if (beforeTask.id !== taskId) {
+      throw new Error(`updateTaskFromKnownState: task id mismatch (${beforeTask.id} !== ${taskId})`);
+    }
+    this.updateTaskWithBefore(beforeTask, changes, opts);
+  }
+
+  private updateTaskWithBefore(
+    beforeTask: TaskState,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): void {
+    const taskId = beforeTask.id;
 
     const setClauses: string[] = [];
     const values: unknown[] = [];
@@ -535,7 +564,10 @@ export class SqliteTaskAttemptRepository {
       const cols = setClauses.map((c) => c.split(/\s*=\s*/)[0]!.trim()).join(', ');
       console.log(`[persist-sql] taskId=${taskId} columns=[${cols}]`);
     }
-    const statusChanged = changes.status !== undefined && changes.status !== beforeTask.status;
+    const statusChanged =
+      !opts?.skipWorkflowStatusSync
+      && changes.status !== undefined
+      && changes.status !== beforeTask.status;
     const workflowId = beforeTask.config.workflowId;
     const beforeWorkflow = statusChanged && workflowId
       ? this.loadWorkflowJournalPayload(workflowId)

--- a/packages/data-store/src/sqlite-task-repository.ts
+++ b/packages/data-store/src/sqlite-task-repository.ts
@@ -46,8 +46,25 @@ export class SqliteTaskRepository implements TaskRepository {
     this.adapter.saveTask(workflowId, task);
   }
 
-  updateTask(taskId: string, changes: TaskStateChanges): void {
-    this.adapter.updateTask(taskId, changes);
+  updateTask(
+    taskId: string,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): void {
+    this.adapter.updateTask(taskId, changes, opts);
+  }
+
+  updateTaskFromKnownState(
+    taskId: string,
+    beforeTask: TaskState,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): void {
+    if (this.adapter.updateTaskFromKnownState) {
+      this.adapter.updateTaskFromKnownState(taskId, beforeTask, changes, opts);
+      return;
+    }
+    this.adapter.updateTask(taskId, changes, opts);
   }
 
   updateTaskLaunchState(taskId: string, changes: TaskStateChanges): void {

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -97,16 +97,18 @@ export function appendJournalEntry(
 
   const inserted = db.queryOne('SELECT last_insert_rowid() AS seq') as { seq?: number } | undefined;
   const seq = Number(inserted?.seq);
-  const row = db.queryOne(
-    `SELECT seq, entity_type, entity_id, op, payload, origin, created_at
-       FROM sync_journal
-      WHERE seq = ?`,
-    [seq],
-  );
-  if (!row) {
-    throw new Error(`Failed to load sync journal entry ${seq} after insert`);
+  if (!Number.isFinite(seq) || seq <= 0) {
+    throw new Error('Failed to read sync journal row id after insert');
   }
-  return mapJournalRow(row);
+  return {
+    seq,
+    entityType,
+    entityId,
+    op: entry.op,
+    payload: entry.payload ?? null,
+    origin,
+    createdAt,
+  };
 }
 
 export function appendJournalEntryWithoutReadback(

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -281,8 +281,14 @@ export interface OrchestratorPersistence {
   }): void;
   updateWorkflow?(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op'; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[]; detachedExternalDependencies?: DetachedExternalDependency[] }): void;
   saveTask(workflowId: string, task: TaskState): void;
-  updateTask(taskId: string, changes: TaskStateChanges): void;
+  updateTask(taskId: string, changes: TaskStateChanges, opts?: { skipWorkflowStatusSync?: boolean }): void;
   updateTaskLaunchState?(taskId: string, changes: TaskStateChanges): void;
+  updateTaskFromKnownState?(
+    taskId: string,
+    beforeTask: TaskState,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): void;
   logEvent?(taskId: string, eventType: string, payload?: unknown): void;
   listWorkflows(): Array<{
     id: string;
@@ -601,7 +607,7 @@ export function taskRepositoryFromPersistence(p: OrchestratorPersistence): TaskR
     deleteWorkflow: (id) => p.deleteWorkflow?.(id),
     deleteAllWorkflows: () => p.deleteAllWorkflows?.(),
     saveTask: (wfId, t) => p.saveTask(wfId, t),
-    updateTask: (id, c) => p.updateTask(id, c),
+    updateTask: (id, c, opts) => p.updateTask(id, c, opts),
     updateTaskLaunchState: (id, c) => {
       const maybeLaunchUpdater = partial as Partial<{ updateTaskLaunchState(taskId: string, changes: TaskStateChanges): void }>;
       if (typeof maybeLaunchUpdater.updateTaskLaunchState === 'function') {
@@ -609,6 +615,14 @@ export function taskRepositoryFromPersistence(p: OrchestratorPersistence): TaskR
         return;
       }
       p.updateTask(id, c);
+    },
+    updateTaskFromKnownState: (id, before, c, opts) => {
+      const knownStateUpdater = (partial as Partial<OrchestratorPersistence>).updateTaskFromKnownState;
+      if (typeof knownStateUpdater === 'function') {
+        knownStateUpdater.call(p, id, before, c, opts);
+        return;
+      }
+      p.updateTask(id, c, opts);
     },
     deleteTask: (id) => {
       if (!p.deleteTask) throw new Error('Persistence adapter does not support deleteTask');
@@ -826,8 +840,10 @@ export class Orchestrator {
     const id = existing.id;
     if (opts?.launchStateUpdate && this.taskRepository.updateTaskLaunchState) {
       this.taskRepository.updateTaskLaunchState(id, changes);
+    } else if (this.taskRepository.updateTaskFromKnownState) {
+      this.taskRepository.updateTaskFromKnownState(id, existing, changes, opts);
     } else {
-      this.taskRepository.updateTask(id, changes);
+      this.taskRepository.updateTask(id, changes, opts);
     }
     this.queueStatusUiCache = null;
     const updated: TaskState = {
@@ -1115,6 +1131,12 @@ export class Orchestrator {
   private countActivePersistedAttempts(now: number = Date.now()): number {
     let count = 0;
     for (const task of this.stateMachine.getAllTasks()) {
+      if (
+        (task.status === 'pending' || (task.status as string) === 'queued')
+        && !this.hasPendingLaunchRuntimeState(task)
+      ) {
+        continue;
+      }
       if (this.isTaskExecutionActive(task, this.getSelectedAttempt(task), now)) {
         count += 1;
       }
@@ -1157,6 +1179,12 @@ export class Orchestrator {
   getPersistedActiveTaskIds(now: number = Date.now()): Set<string> {
     const active = new Set<string>();
     for (const task of this.stateMachine.getAllTasks()) {
+      if (
+        (task.status === 'pending' || (task.status as string) === 'queued')
+        && !this.hasPendingLaunchRuntimeState(task)
+      ) {
+        continue;
+      }
       if (this.isTaskExecutionActive(task, this.getSelectedAttempt(task), now)) {
         active.add(task.id);
       }
@@ -1164,7 +1192,10 @@ export class Orchestrator {
     return active;
   }
 
-  private ensureCurrentPendingAttempt(task: TaskState): string {
+  private ensureCurrentPendingAttempt(
+    task: TaskState,
+    writeOpts?: { skipWorkflowStatusSync?: boolean; deferTaskSelectionWriteWhenClean?: boolean },
+  ): string {
     const selected = this.getSelectedAttempt(task);
     if (selected && this.isReusablePendingLaunchAttempt(task, selected)) {
       return selected.id;
@@ -1176,7 +1207,19 @@ export class Orchestrator {
     const current = attempts[attempts.length - 1];
     if (current && this.isReusablePendingLaunchAttempt(task, current)) {
       if (task.execution.selectedAttemptId !== current.id) {
-        this.writeAndSync(task.id, { execution: { selectedAttemptId: current.id } });
+        if (
+          writeOpts?.deferTaskSelectionWriteWhenClean
+          && task.status === 'pending'
+          && !this.hasPendingLaunchRuntimeState(task)
+        ) {
+          this.stateMachine.restoreTask({
+            ...task,
+            execution: { ...task.execution, selectedAttemptId: current.id },
+          });
+          this.queueStatusUiCache = null;
+          return current.id;
+        }
+        this.writeAndSync(task.id, { execution: { selectedAttemptId: current.id } }, writeOpts);
       }
       return current.id;
     }
@@ -1193,12 +1236,25 @@ export class Orchestrator {
       this.taskRepository.updateAttempt(current.id, { status: 'superseded' });
     }
     this.taskRepository.saveAttempt(freshAttempt);
+    if (
+      writeOpts?.deferTaskSelectionWriteWhenClean
+      && task.status === 'pending'
+      && !this.hasPendingLaunchRuntimeState(task)
+    ) {
+      this.stateMachine.restoreTask({
+        ...task,
+        execution: { ...task.execution, selectedAttemptId: freshAttempt.id },
+      });
+      this.queueStatusUiCache = null;
+      return freshAttempt.id;
+    }
     this.writeResetAndSync(
       task,
       'newAttempt',
       buildTaskResetChanges('newAttempt', {
         execution: { selectedAttemptId: freshAttempt.id },
       }),
+      writeOpts,
     );
     return freshAttempt.id;
   }
@@ -1523,7 +1579,12 @@ export class Orchestrator {
     this.pruneLaunchDeferrals();
 
     const activeAttempts = this.countActivePersistedAttempts();
-    const readyTasks = this.getExecutableReadyTasks();
+    const hasPerCallLimit = typeof opts?.limit === 'number' && opts.limit >= 0;
+    const readyTasks = hasPerCallLimit
+      ? this.getExecutableReadyTasks({ alreadyRefreshed: true })
+      : this.stateMachine
+        .getReadyTasks()
+        .filter((task) => this.getExternalDependencyBlocker(task) === undefined);
     this.logger.info('[orchestrator] startExecution', {
       ready: readyTasks.length,
       active: activeAttempts,
@@ -1545,7 +1606,7 @@ export class Orchestrator {
       })
       .map((task) => task.id);
 
-    if (typeof opts?.limit === 'number' && opts.limit >= 0) {
+    if (hasPerCallLimit) {
       readyTaskIds = readyTaskIds.slice(0, opts.limit);
     }
 
@@ -3264,7 +3325,7 @@ export class Orchestrator {
     return this.stateMachine.getReadyTasks();
   }
 
-  getExecutableReadyTasks(): TaskState[] {
+  getExecutableReadyTasks(opts?: { alreadyRefreshed?: boolean }): TaskState[] {
     const readyTasks = this.stateMachine
       .getReadyTasks()
       .filter((task) => this.getExternalDependencyBlocker(task) === undefined);
@@ -3276,6 +3337,7 @@ export class Orchestrator {
         attemptId: task.execution.selectedAttemptId,
         priority: this.loadAttemptById(task.execution.selectedAttemptId)?.queuePriority ?? 0,
       })),
+      opts,
     )
       .map((job) => readyTasksById.get(job.taskId))
       .filter((task): task is TaskState => task !== undefined);
@@ -3418,9 +3480,15 @@ export class Orchestrator {
       phase?: string;
     },
   ): void {
+    const taskBeforeDefer = reason?.reason === 'resource-limit'
+      ? this.stateGetTask(taskId)
+      : undefined;
+    const launchAnchor = taskBeforeDefer?.execution.launchStartedAt
+      ?? taskBeforeDefer?.execution.startedAt
+      ?? taskBeforeDefer?.execution.lastHeartbeatAt;
     deferTaskImpl(this as unknown as CancellationHost, taskId, reason);
     if (reason?.reason === 'resource-limit') {
-      this.recordLaunchDeferral(taskId);
+      this.recordLaunchDeferral(taskId, launchAnchor);
     }
   }
 
@@ -3429,11 +3497,15 @@ export class Orchestrator {
    * execution pool had no member capacity. Attempts drive an exponential
    * schedule so a persistently starved task backs off toward the cap.
    */
-  private recordLaunchDeferral(taskId: string): void {
+  private recordLaunchDeferral(taskId: string, anchor?: Date): void {
     const attempts = (this.launchDeferrals.get(taskId)?.attempts ?? 0) + 1;
     const backoff = this.computeLaunchBackoffMs(attempts);
+    const anchorMs = anchor?.getTime();
+    const startAt = anchorMs !== undefined && Number.isFinite(anchorMs)
+      ? anchorMs
+      : Date.now();
     // lastHeartbeatAt=0 forces a heartbeat on the first parked poll.
-    this.launchDeferrals.set(taskId, { until: Date.now() + backoff, attempts, lastHeartbeatAt: 0 });
+    this.launchDeferrals.set(taskId, { until: startAt + backoff, attempts, lastHeartbeatAt: 0 });
   }
 
   private computeLaunchBackoffMs(attempts: number): number {

--- a/packages/workflow-core/src/orchestrator/scheduler-domain.ts
+++ b/packages/workflow-core/src/orchestrator/scheduler-domain.ts
@@ -128,13 +128,15 @@ function hasPendingLaunchRuntimeState(task: TaskState): boolean {
 function planPendingLaunchQueue(
   host: SchedulerDomainHost,
   candidateJobs: TaskJob[],
-  opts?: LaunchReadinessOptions,
+  opts?: LaunchReadinessOptions & { alreadyRefreshed?: boolean },
 ): TaskJob[] {
   // Refresh once for the whole batch, not once per candidate job below --
   // readiness for every job in this pass is evaluated against the same
   // in-memory snapshot, so a per-job refresh only re-reads data this
   // function already has.
-  host.refreshFromDb();
+  if (!opts?.alreadyRefreshed) {
+    host.refreshFromDb();
+  }
   const mergedJobs = new Map<string, TaskJob>();
   for (const sourceJob of [...host.scheduler.getQueuedJobs(), ...candidateJobs]) {
     const task = host.stateGetTask(sourceJob.taskId);
@@ -198,8 +200,9 @@ function planPendingLaunchQueue(
 export function getPendingLaunchQueueSnapshotImpl(
   host: SchedulerDomainHost,
   candidateJobs: TaskJob[],
+  opts?: { alreadyRefreshed?: boolean },
 ): TaskJob[] {
-  return planPendingLaunchQueue(host, candidateJobs);
+  return planPendingLaunchQueue(host, candidateJobs, opts);
 }
 
 function rebuildPendingLaunchQueue(

--- a/packages/workflow-core/src/task-repository.ts
+++ b/packages/workflow-core/src/task-repository.ts
@@ -119,7 +119,23 @@ export interface TaskRepository {
   saveTask(workflowId: string, task: TaskState): void;
 
   /** Apply a partial update to an existing task. */
-  updateTask(taskId: string, changes: TaskStateChanges): void;
+  updateTask(
+    taskId: string,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): void;
+
+  /**
+   * Same logical write as updateTask, but lets adapters avoid re-reading the
+   * pre-update task when the orchestrator already has the authoritative
+   * in-memory state for this mutation.
+   */
+  updateTaskFromKnownState?(
+    taskId: string,
+    beforeTask: TaskState,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): void;
 
   /**
    * Apply the narrow launch-state update written by drainScheduler after an


### PR DESCRIPTION
## Summary

CI job `required-fast / Vitest Workspace` first failed on default-branch commit 2363032b499063ce4fc9fea27ddb4ad57a14f78d.

Ready-task launch processing was doing broad task reads and rewrites during scheduler dispatch, which amplified SQLite contention in the workspace workload.

This change routes launch updates through narrower repository operations, keeps auto-start work inside one write transaction, and avoids unnecessary journal and attempt readbacks.

## Review Claim

The scheduler launch path now reduces SQLite contention enough to repair the Vitest Workspace CI regression, without changing task execution semantics.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect. The updated launch route preserves task state transitions while narrowing transaction scope and write granularity.

## Slice Rationale

One behavior slice: the workflow-core scheduler changes and data-store repository updates are one launch-routing fix. Publishing either half alone would leave the CI regression only partially repaired.

## Non-goals

- No unrelated restructuring.
- No unrelated cleanup.
- No test weakening or snapshot churn.
- No new module boundaries.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/10-vitest-workspace.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 37705b0e3`
- Post-revert steps: None
- Data migration? No

</details>
