### PR TITLE
[Jailbreak admin-bypass land](1) Actions concurrency detection

### DIFF
--- a/scripts/gh-actions-concurrency-exhausted.mjs
+++ b/scripts/gh-actions-concurrency-exhausted.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, realpathSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_STATE = { consecutiveExhausted: 0 };
+
+export function isActionsConcurrencyExhausted({
+  listQueuedRunCount,
+  debounceStatePath,
+  threshold,
+  requiredConsecutivePolls,
+  readState,
+  writeState,
+}) {
+  const queuedRunCount = listQueuedRunCount();
+
+  if (queuedRunCount >= threshold) {
+    const state = readState(debounceStatePath) ?? DEFAULT_STATE;
+    const nextState = {
+      consecutiveExhausted: (state.consecutiveExhausted ?? 0) + 1,
+    };
+    writeState(debounceStatePath, nextState);
+    return nextState.consecutiveExhausted >= requiredConsecutivePolls;
+  }
+
+  writeState(debounceStatePath, DEFAULT_STATE);
+  return false;
+}
+
+function parseIntegerEnv(name, fallback) {
+  const value = Number.parseInt(process.env[name] ?? '', 10);
+  return Number.isNaN(value) ? fallback : value;
+}
+
+function repoFromRemoteUrl(remoteUrl) {
+  const trimmed = remoteUrl.trim();
+  const match = trimmed.match(/[:/]([^/:]+\/[^/]+?)(?:\.git)?$/);
+  if (!match) {
+    throw new Error(`could not parse owner/repo from origin remote URL: ${trimmed}`);
+  }
+  return match[1];
+}
+
+function getRepo() {
+  if (process.env.INVOKER_JAILBREAK_REPO) {
+    return process.env.INVOKER_JAILBREAK_REPO;
+  }
+  const remoteUrl = execFileSync('git', ['remote', 'get-url', 'origin'], { encoding: 'utf8' });
+  return repoFromRemoteUrl(remoteUrl);
+}
+
+function readJsonState(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (e) {
+    if (e.code === 'ENOENT') {
+      return DEFAULT_STATE;
+    }
+    throw e;
+  }
+}
+
+function writeJsonState(path, state) {
+  writeFileSync(path, `${JSON.stringify(state)}\n`);
+}
+
+function main() {
+  const repo = getRepo();
+  const debounceStatePath =
+    process.env.INVOKER_JAILBREAK_DEBOUNCE_STATE_PATH ??
+    `${process.env.TMPDIR || '/tmp'}/invoker-jailbreak-debounce.json`;
+
+  // Unverified placeholder defaults pending real observed data; these are not calibrated thresholds.
+  const threshold = parseIntegerEnv('INVOKER_JAILBREAK_QUEUED_THRESHOLD', 40);
+  const requiredConsecutivePolls = parseIntegerEnv('INVOKER_JAILBREAK_CONSECUTIVE_POLLS', 3);
+
+  let ghApiError;
+  const listQueuedRunCount = () => {
+    try {
+      const output = execFileSync(
+        'gh',
+        ['api', `repos/${repo}/actions/runs?status=queued&per_page=1`, '--jq', '.total_count'],
+        { encoding: 'utf8' },
+      );
+      return Number.parseInt(output.trim(), 10);
+    } catch (e) {
+      ghApiError = e;
+      throw e;
+    }
+  };
+
+  let exhausted;
+  try {
+    exhausted = isActionsConcurrencyExhausted({
+      listQueuedRunCount,
+      debounceStatePath,
+      threshold,
+      requiredConsecutivePolls,
+      readState: readJsonState,
+      writeState: writeJsonState,
+    });
+  } catch (e) {
+    if (!ghApiError) {
+      throw e;
+    }
+    console.error(`error: failed to read queued GitHub Actions runs via gh: ${ghApiError.message}`);
+    process.exit(2);
+  }
+
+  process.exit(exhausted ? 0 : 1);
+}
+
+const invokedDirectly = (() => {
+  try {
+    return process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) main();

--- a/scripts/test-gh-actions-concurrency-exhausted.mjs
+++ b/scripts/test-gh-actions-concurrency-exhausted.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { isActionsConcurrencyExhausted } from './gh-actions-concurrency-exhausted.mjs';
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log(`ok - ${name}`);
+}
+
+function createHarness(counts, initialState = undefined) {
+  const path = 'fake-state.json';
+  const states = new Map();
+  const writes = [];
+  if (initialState) {
+    states.set(path, initialState);
+  }
+
+  return {
+    path,
+    writes,
+    call(options = {}) {
+      return isActionsConcurrencyExhausted({
+        listQueuedRunCount: () => counts.shift(),
+        debounceStatePath: path,
+        threshold: 10,
+        requiredConsecutivePolls: 3,
+        readState: (statePath) => states.get(statePath) ?? { consecutiveExhausted: 0 },
+        writeState: (statePath, state) => {
+          writes.push({ statePath, state });
+          states.set(statePath, state);
+        },
+        ...options,
+      });
+    },
+    readState() {
+      return states.get(path) ?? { consecutiveExhausted: 0 };
+    },
+  };
+}
+
+test('count below threshold never trips consecutiveExhausted above 0', () => {
+  const harness = createHarness([0, 9, 4], { consecutiveExhausted: 2 });
+
+  assert.equal(harness.call(), false);
+  assert.equal(harness.call(), false);
+  assert.equal(harness.call(), false);
+
+  assert.deepEqual(harness.readState(), { consecutiveExhausted: 0 });
+  assert.deepEqual(harness.writes.map((write) => write.state), [
+    { consecutiveExhausted: 0 },
+    { consecutiveExhausted: 0 },
+    { consecutiveExhausted: 0 },
+  ]);
+});
+
+test('threshold streak returns true only on requiredConsecutivePolls call', () => {
+  const harness = createHarness([10, 11, 12]);
+
+  assert.equal(harness.call(), false);
+  assert.equal(harness.call(), false);
+  assert.equal(harness.call(), true);
+
+  assert.deepEqual(harness.writes.map((write) => write.state), [
+    { consecutiveExhausted: 1 },
+    { consecutiveExhausted: 2 },
+    { consecutiveExhausted: 3 },
+  ]);
+});
+
+test('below-threshold poll resets an in-progress streak back to 0', () => {
+  const harness = createHarness([15, 15, 8, 15]);
+
+  assert.equal(harness.call(), false);
+  assert.equal(harness.call(), false);
+  assert.equal(harness.call(), false);
+  assert.equal(harness.call(), false);
+
+  assert.deepEqual(harness.writes.map((write) => write.state), [
+    { consecutiveExhausted: 1 },
+    { consecutiveExhausted: 2 },
+    { consecutiveExhausted: 0 },
+    { consecutiveExhausted: 1 },
+  ]);
+});
+
+test('state access is fully routed through injected fakes', () => {
+  const calls = [];
+
+  const result = isActionsConcurrencyExhausted({
+    listQueuedRunCount: () => {
+      calls.push(['listQueuedRunCount']);
+      return 40;
+    },
+    debounceStatePath: 'injected-state.json',
+    threshold: 40,
+    requiredConsecutivePolls: 2,
+    readState: (statePath) => {
+      calls.push(['readState', statePath]);
+      return { consecutiveExhausted: 1 };
+    },
+    writeState: (statePath, state) => {
+      calls.push(['writeState', statePath, state]);
+    },
+  });
+
+  assert.equal(result, true);
+  assert.deepEqual(calls, [
+    ['listQueuedRunCount'],
+    ['readState', 'injected-state.json'],
+    ['writeState', 'injected-state.json', { consecutiveExhausted: 2 }],
+  ]);
+});
+
+console.log(`passed ${passed} tests`);


### PR DESCRIPTION
## Summary

Adds a standalone GitHub Actions queue detector with threshold and debounce state.

The exported logic accepts injected queue and state functions, while the CLI reads queued workflow runs and stores a small debounce file.

This bottom stack slice supplies a congestion signal for later break-glass workers. It does not register a worker or receive merge authority.

## Review Claim

Approve one standalone Actions queue detector with injected threshold/debounce logic and a CLI wrapper.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice cannot merge, label, or mutate PRs or branches: its only `gh` call reads the Actions Runs endpoint (`scripts/gh-actions-concurrency-exhausted.mjs:82`).

Its only write targets the configured debounce-state path, which defaults under `$TMPDIR` (`scripts/gh-actions-concurrency-exhausted.mjs:65`).

## Slice Rationale

The detector and its directly affected test share one local claim. Registration and force-merge behavior remain separate later slices.

## Non-goals

- Does not wire the detector into a worker, cron, or scheduler.
- Does not implement admin-bypass labels or merge behavior.
- Does not claim the placeholder threshold and debounce defaults are calibrated.
- Does not modify Mergify configuration.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-gh-actions-concurrency-exhausted.mjs` — `passed 4 tests`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d6932c67854a2fe06dac724b8baadaa87fb014b1`
- Post-revert steps: None
- Data migration? No

</details>
