### PR TITLE
[CI regression: 8365ed9-playwright-terminal-garbling](1) Assign missing repro to terminal-garbling shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -673,6 +673,7 @@ jobs:
           - name: terminal-garbling
             files: >-
               e2e/planning-terminal-live-model.proof.spec.ts
+              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
               e2e/planning-surface-navigation-garble-repro.spec.ts
               e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts
               e2e/planning-terminal-expand-collapse-garble-repro.spec.ts


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / terminal-garbling -->

CI job `playwright / terminal-garbling` first failed on default-branch push commit 8365ed93997c669fc85eb85b4d56353378310e03 in run 31574441095.

It was most recently still red at 8365ed93997c669fc85eb85b4d56353378310e03 in run 31574441095.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31574441095/job/94043888939

This assigns the omitted conversational-mode restore repro to the terminal-garbling shard.

Product code and test assertions stay unchanged.

## Review Claim

Assign `e2e/planning-chat-restore-conversational-mode-repro.spec.ts` to the terminal-garbling shard so CI accounts for the missing repro.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the terminal-garbling CI file list changes; product code, test expectations, and other CI shards stay unchanged.

## Slice Rationale

This is one CI policy slice because the root cause is shard membership, and the proof is the same shard inventory and terminal-garbling command.

## Non-goals

This does not change product behavior, weaken tests, refactor code, alter test assertions, or modify any non-terminal-garbling CI job.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/ci-regression-8365ed9-pr-body.md --base master`
- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs`
- [x] Invoker verification task recorded exit 0 for `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-terminal-garbling' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/planning-terminal-live-model.proof.spec.ts e2e/planning-surface-navigation-garble-repro.spec.ts e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts e2e/planning-terminal-expand-collapse-garble-repro.spec.ts e2e/task-terminal-drawer-minimize-garble-repro.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: Re-run `node scripts/repro/repro-ci-playwright-shard-inventory.mjs`; the inventory failure will return until the spec is assigned elsewhere.
- Data migration? No

</details>
