### PR TITLE
[CI regression: 8365ed9-playwright-2-of-9](1) Add the missing planning restore spec to shard 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -610,6 +610,7 @@ jobs:
             files: >-
               e2e/claude-planning-preset-visual-proof.spec.ts
               e2e/planning-presets-load-failure.spec.ts
+              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
               e2e/action-graph-visual-proof.spec.ts
               e2e/invalid-merge-workspace-visual.spec.ts
               e2e/invalid-task-workspace-visual.spec.ts


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / 2-of-9 -->

CI job `playwright / 2-of-9` first failed on default-branch push commit 8365ed93997c669fc85eb85b4d56353378310e03 in run 31574441095.

It was most recently still red at 8365ed93997c669fc85eb85b4d56353378310e03 in run 31574441095.

The failed inventory step printed: `Playwright shard inventory drift detected. Missing from shards: e2e/planning-chat-restore-conversational-mode-repro.spec.ts`.

This slice assigns that existing regression spec to shard 2, alongside the related planning restoration coverage.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31574441095/job/94043888934

## Review Claim

Approve adding the existing planning-chat restoration regression spec to the `playwright / 2-of-9` shard roster.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged. This slice only assigns one existing spec to the shard whose related planning restoration coverage already runs.

## Slice Rationale

The missing shard entry is the complete CI policy repair, so no test implementation, product change, or generated screenshot belongs in this slice.

## Non-goals

- No product behavior changes.
- No test implementation or assertion changes.
- No changes to other shard rosters.
- No refactor, unrelated cleanup, test weakening, or snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs` — `[repro-ci-playwright-shard-inventory] OK: 62 CI-owned spec files each assigned to exactly one shard; 2 manual-only spec accounted for.`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-2-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/claude-planning-preset-visual-proof.spec.ts e2e/planning-presets-load-failure.spec.ts e2e/action-graph-visual-proof.spec.ts e2e/invalid-merge-workspace-visual.spec.ts e2e/invalid-task-workspace-visual.spec.ts e2e/persistence-lifecycle.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — build output included `✓ built in 54.40s`, `ESM ⚡️ Build success in 513ms`, `CJS ⚡️ Build success in 931ms`, `DTS ⚡️ Build success in 8671ms`, and `CJS ⚡️ Build success in 1262ms`; the wrapper then printed `Command "xvfb-run" not found` and exited 254 before Playwright.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; no product code or data changes.
- Revert command: `git revert <merge-sha-of-this-pr>`
- Post-revert steps: Rerun the shard inventory check and expect it to report the restored missing assignment.
- Data migration? No

</details>
