### PR TITLE
[CI regression: 8365ed9-playwright-3-of-9](1) Restore shard inventory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -635,6 +635,7 @@ jobs:
               e2e/autofix-worker-ui.spec.ts
               e2e/orphan-relaunch.spec.ts
               e2e/gap-recovery-bench.spec.ts
+              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
               e2e/planning-chat-send-long-deadline.spec.ts
               e2e/system-setup-visual-proof.spec.ts
               e2e/startup-nonempty-responsiveness.spec.ts


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / 3-of-9 -->

The `playwright / 3-of-9` job failed because the shard inventory guard found a new CI-owned spec missing from every shard.

Assign the planning-chat restore regression spec to `5-of-9`, restoring complete inventory coverage without changing the spec or application behavior.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31574441095/job/94043888953

## Review Claim

Approve adding `e2e/planning-chat-restore-conversational-mode-repro.spec.ts` to the Playwright shard manifest so every CI-owned spec is assigned exactly once.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only CI shard membership changes. The test and product code remain unchanged, and the restored spec is assigned to exactly one shard.

## Slice Rationale

The one-line manifest correction and its inventory proof form one indivisible CI-policy review unit.

## Non-goals

- No application behavior change.
- No test implementation change.
- No weakening of the shard inventory guard.
- No reassignment of existing shard entries.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `gh run view 31574441095 --job 94043888953 --log`
  - `[repro-ci-playwright-shard-inventory] Playwright shard inventory drift detected.`
  - `Missing from shards: e2e/planning-chat-restore-conversational-mode-repro.spec.ts`
  - `Process completed with exit code 1.`
- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs`
  - On `origin/master`: `Missing from shards: e2e/planning-chat-restore-conversational-mode-repro.spec.ts`
  - On this branch: `[repro-ci-playwright-shard-inventory] OK: 62 CI-owned spec files each assigned to exactly one shard; 2 manual-only spec accounted for.`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-3-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/task-death-logs.spec.ts e2e/restart-failed-task.spec.ts e2e/ui-graph-drag-performance.spec.ts e2e/pending-review-gate-target-repo.proof.spec.ts e2e/workflow-status-composition.spec.ts e2e/queue-running-vs-queued.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`
  - Local macOS run built `@invoker/ui`, `@invoker/surfaces`, and `@invoker/app`, then stopped before Playwright because `xvfb-run` is unavailable: `PLAYWRIGHT_3_OF_9_EXIT=254`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, but reverting restores the known shard inventory failure.
- Revert command: `git revert <merged-sha>`
- Post-revert steps: Rerun `node scripts/repro/repro-ci-playwright-shard-inventory.mjs` and reassign the spec before merging other CI changes.
- Data migration? No

</details>
