### PR TITLE
[CI regression: 8365ed9-playwright-8-of-9](1) Assign missing Playwright spec to shard 8-of-9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,6 +658,7 @@ jobs:
             files: >-
               e2e/focus-switch-hitch-responsiveness.spec.ts
               e2e/planning-chat-hitch-responsiveness.spec.ts
+              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
               e2e/command-palette-open.spec.ts
               e2e/task-new-attempt-reset.spec.ts
               e2e/persistence-recovery.spec.ts


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / 8-of-9 -->

Playwright shard `8-of-9` failed its inventory check because the conversational-mode restore regression spec was not assigned to any CI shard.

The failing job reported:

```text
[repro-ci-playwright-shard-inventory] Playwright shard inventory drift detected.
  Missing from shards: e2e/planning-chat-restore-conversational-mode-repro.spec.ts
Process completed with exit code 1.
```

This assigns that existing spec to shard `8-of-9`, restoring complete, single-shard coverage for every CI-owned Playwright spec.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31574441095/job/94043888969

## Review Claim

Assign `e2e/planning-chat-restore-conversational-mode-repro.spec.ts` to Playwright shard `8-of-9` so the CI shard inventory includes every CI-owned spec exactly once.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

This is one CI-policy slice: it adds the single missing shard assignment without changing the regression spec or unrelated workflow configuration.

## Non-goals

No product behavior, test assertions, shard count, unrelated CI job, refactor, cleanup, or snapshot changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs`

  ```text
  [repro-ci-playwright-shard-inventory] OK: 62 CI-owned spec files each assigned to exactly one shard; 2 manual-only spec accounted for.
  exit_code=0
  ```

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-8-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/focus-switch-hitch-responsiveness.spec.ts e2e/planning-chat-hitch-responsiveness.spec.ts e2e/planning-chat-restore-conversational-mode-repro.spec.ts e2e/command-palette-open.spec.ts e2e/task-new-attempt-reset.spec.ts e2e/persistence-recovery.spec.ts e2e/start-ready-production-click.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

  Local macOS run built UI, surfaces, and app, then stopped because `xvfb-run` is unavailable:

  ```text
  /Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786526849568-8-W6cigo/packages/app:
   ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "xvfb-run" not found
  ```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting restores the prior incomplete Playwright shard inventory.
- Revert command: `git revert 58d7c7ad32cfe6757432db2683c5bda9b6097dcc`
- Post-revert steps: Reassign the spec to a CI shard before rerunning the Playwright matrix.
- Data migration? No.

</details>

