### PR TITLE
[CI regression: 8365ed9-required-fast-mergify-admin-requeue](1) Disable auto-gc in disposable rebase repro

### DIFF
--- a/scripts/repro/repro-babysit-rebase-onto-base.sh
+++ b/scripts/repro/repro-babysit-rebase-onto-base.sh
@@ -49,6 +49,9 @@ WORK_ROOT="$WORK_PARENT/6201"
 git clone . "$SEED" >/dev/null
 (
   cd "$SEED"
+  # This repository is disposable and removed by the EXIT trap. Keep Git from
+  # racing that cleanup with a background auto-gc process.
+  git config gc.auto 0
   git config user.email repro@example.test
   git config user.name 'Repro Bot'
   git checkout -B master >/dev/null


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=required-fast / Mergify Admin Requeue -->

CI job `required-fast / Mergify Admin Requeue` first failed at `8365ed93997c669fc85eb85b4d56353378310e03` in run 31574441095.

The repro passed, then Git auto-packing raced the EXIT cleanup and left `.git/objects/pack` non-empty.

The disposable seed clone now disables automatic Git garbage collection before the repro creates branches and pushes commits.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31574441095/job/94043888911

## Review Claim

Approve disabling Git auto-GC inside the disposable rebase repro seed clone so its EXIT cleanup cannot race a background pack writer.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The new repository-local setting applies only to the temporary seed clone that the repro's EXIT trap removes. Product repositories and runtime behavior are outside this slice.

## Slice Rationale

The only reviewable change and its deterministic CI command stay together. The completed verification task produced no file change, so it is recorded here instead of published as an empty slice.

## Non-goals

- No admin-requeue decision or queue behavior changes.
- No global or user Git configuration changes.
- No production repository garbage-collection changes.
- No unrelated test cleanup or refactor.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `gh run view 31574441095 --job 94043888911 --log` — the failing log printed `Auto packing the repository in background for optimum performance.`, then `rm: cannot remove '.../seed/.git/objects/pack': Directory not empty`, and exited 1.
- [x] `pnpm install --frozen-lockfile` — `Done in 32s using pnpm v10.31.0`.
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/12-mergify-admin-requeue.sh` — UI printed `✓ built in 36.98s`; surfaces and app printed `CJS ⚡️ Build success`; the required runner printed `OK` and `[repro] passed`; exit 0.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: Rerun `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/12-mergify-admin-requeue.sh`.
- Data migration? No

</details>
