### PR TITLE
[CI regression: 8365ed9-playwright-4-of-9](1) Run restored planning-chat regression in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -677,6 +677,7 @@ jobs:
               e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts
               e2e/planning-terminal-expand-collapse-garble-repro.spec.ts
               e2e/task-terminal-drawer-minimize-garble-repro.spec.ts
+              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
 
     name: playwright / ${{ matrix.name }}
 


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / 4-of-9 -->

CI job `playwright / 4-of-9` first failed on default-branch push commit 8365ed93997c669fc85eb85b4d56353378310e03 in run 31574441095.

The workflow now includes `e2e/planning-chat-restore-conversational-mode-repro.spec.ts` in the terminal-garbling Playwright shard that owns related terminal and planning-chat regressions.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31574441095/job/94043889051

## Review Claim

The CI workflow should run the restored conversational-mode regression spec with the terminal-garbling Playwright shard.

## Review Lane

- policy

## Review Unit

- tooling-policy

## Safety Invariant

Only the CI Playwright shard file list changes; product code and test assertions stay unchanged.

## Slice Rationale

This slice only repairs the workflow coverage gap for the observed CI regression.

## Non-goals

- Do not change product behavior.
- Do not weaken or rewrite the regression test.
- Do not rebalance unrelated Playwright shards.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-4-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/startup-window-liveness.spec.ts e2e/workflow-lifecycle.spec.ts e2e/base-branch-normalization.proof.spec.ts e2e/edit-task-prompt.spec.ts e2e/fix-with-claude.spec.ts e2e/fix-with-agent-transition.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`
  - Invoker verify task `wf-1786526397569-82/verify-ci-8365ed9-playwright-4-of-9` recorded `Exit code: 0`; not re-run during PR metadata repair.
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/pr-body-ci-regression-8365ed9-playwright-4-of-9.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run the Playwright shard that exposed the regression.
- Data migration? No

</details>
