### PR TITLE
CI regression: 2363032-required-fast-vitest-workspace (1)

### DIFF
--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1055,6 +1055,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   private runTransaction<T>(work: () => T): T {
     this.ensureWritable();
+    if (this.writeTransactionDepth > 0) {
+      return work();
+    }
     this.db.run(this.writeTransactionDepth === 0 ? 'BEGIN IMMEDIATE' : `SAVEPOINT invoker_nested_${this.writeTransactionDepth}`);
     this.writeTransactionDepth += 1;
     try {
@@ -1230,6 +1233,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   updateTask(taskId: string, changes: TaskStateChanges): void {
     this.taskAttemptRepo.updateTask(taskId, changes);
+  }
+
+  updateTaskLaunchState(taskId: string, changes: TaskStateChanges): void {
+    this.taskAttemptRepo.updateTaskLaunchState(taskId, changes);
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -3721,43 +3728,41 @@ export class SQLiteAdapter implements PersistenceAdapter {
     workflowId: string;
     priority?: TaskLaunchDispatchPriority;
     generation: number;
+    suppressEvent?: boolean;
   }): TaskLaunchDispatch {
     const priority: TaskLaunchDispatchPriority = input.priority ?? 'normal';
     return this.runTransaction(() => {
-      const existing = this.queryOne(
-        `SELECT * FROM task_launch_dispatch
-           WHERE attempt_id = ?
-             AND state IN ('enqueued', 'leased')
-           LIMIT 1`,
-        [input.attemptId],
-      );
-      if (existing) {
-        return this.rowToTaskLaunchDispatch(existing);
-      }
-      this.execRun(
-        `INSERT INTO task_launch_dispatch (
+      const inserted = this.queryOne(
+        `INSERT OR IGNORE INTO task_launch_dispatch (
           task_id, attempt_id, workflow_id, state, priority, generation
-        ) VALUES (?, ?, ?, 'enqueued', ?, ?)`,
+        ) VALUES (?, ?, ?, 'enqueued', ?, ?)
+        RETURNING *`,
         [input.taskId, input.attemptId, input.workflowId, priority, input.generation],
       );
-      const inserted = this.queryOne(
-        `SELECT * FROM task_launch_dispatch
-           WHERE attempt_id = ?
-             AND state IN ('enqueued', 'leased')
-           LIMIT 1`,
-        [input.attemptId],
-      );
       if (!inserted) {
+        const existing = this.queryOne(
+          `SELECT * FROM task_launch_dispatch
+             WHERE attempt_id = ?
+               AND state IN ('enqueued', 'leased')
+             LIMIT 1`,
+          [input.attemptId],
+        );
+        if (existing) {
+          return this.rowToTaskLaunchDispatch(existing);
+        }
         throw new Error('Failed to read back inserted task_launch_dispatch row');
       }
+      this.dirty = true;
       const dispatch = this.rowToTaskLaunchDispatch(inserted);
-      this.logEvent(input.taskId, 'task.launch_dispatch_enqueued', {
-        dispatchId: dispatch.id,
-        attemptId: input.attemptId,
-        workflowId: input.workflowId,
-        generation: input.generation,
-        priority,
-      });
+      if (!input.suppressEvent) {
+        this.logEvent(input.taskId, 'task.launch_dispatch_enqueued', {
+          dispatchId: dispatch.id,
+          attemptId: input.attemptId,
+          workflowId: input.workflowId,
+          generation: input.generation,
+          priority,
+        });
+      }
       return dispatch;
     });
   }

--- a/packages/data-store/src/sqlite-task-attempt-repository.ts
+++ b/packages/data-store/src/sqlite-task-attempt-repository.ts
@@ -18,7 +18,7 @@ import {
 import { mapRowToTask, mapRowToAttempt } from './sqlite-row-mappers.js';
 import type { SqliteExecutor } from './sqlite-executor.js';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
-import { appendJournalEntry } from './sync-journal.js';
+import { appendJournalEntry, appendJournalEntryWithoutReadback } from './sync-journal.js';
 
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
@@ -558,11 +558,90 @@ export class SqliteTaskAttemptRepository {
       if (!statusChanged || !workflowId) return;
       const afterWorkflow = this.loadWorkflowJournalPayload(workflowId);
       if (!afterWorkflow || beforeWorkflow?.status === afterWorkflow.status) return;
-      appendJournalEntry(this.exec, {
+      appendJournalEntryWithoutReadback(this.exec, {
         entityType: 'workflow',
         entityId: workflowId,
         op: 'upsert',
         payload: afterWorkflow.payload,
+      });
+    });
+  }
+
+  updateTaskLaunchState(taskId: string, changes: TaskStateChanges): void {
+    const unsupportedTopLevel = Object.keys(changes).filter((key) => key !== 'status' && key !== 'execution');
+    if (unsupportedTopLevel.length > 0) {
+      throw new Error(`updateTaskLaunchState received unsupported task fields: ${unsupportedTopLevel.join(', ')}`);
+    }
+
+    const execution = changes.execution as Record<string, unknown> | undefined;
+    const supportedExecutionFields = new Set([
+      'selectedAttemptId',
+      'generation',
+      'startedAt',
+      'lastHeartbeatAt',
+      'phase',
+      'launchStartedAt',
+      'launchCompletedAt',
+    ]);
+    const unsupportedExecution = execution
+      ? Object.keys(execution).filter((key) => !supportedExecutionFields.has(key))
+      : [];
+    if (unsupportedExecution.length > 0) {
+      throw new Error(`updateTaskLaunchState received unsupported execution fields: ${unsupportedExecution.join(', ')}`);
+    }
+
+    const setClauses: string[] = [];
+    const values: unknown[] = [];
+
+    if (changes.status !== undefined) {
+      setClauses.push('status = ?');
+      values.push(changes.status);
+    }
+    if (execution) {
+      const execMap: Record<string, string> = {
+        selectedAttemptId: 'selected_attempt_id',
+        generation: 'execution_generation',
+        phase: 'launch_phase',
+      };
+      const execDateMap: Record<string, string> = {
+        startedAt: 'started_at',
+        lastHeartbeatAt: 'last_heartbeat_at',
+        launchStartedAt: 'launch_started_at',
+        launchCompletedAt: 'launch_completed_at',
+      };
+      for (const [key, col] of Object.entries(execMap)) {
+        if (key in execution) {
+          setClauses.push(`${col} = ?`);
+          values.push(execution[key] ?? null);
+        }
+      }
+      for (const [key, col] of Object.entries(execDateMap)) {
+        if (key in execution) {
+          const value = execution[key];
+          setClauses.push(`${col} = ?`);
+          values.push(value instanceof Date ? value.toISOString() : value ?? null);
+        }
+      }
+    }
+
+    if (setClauses.length === 0) return;
+    setClauses.push('task_state_version = task_state_version + 1');
+    values.push(taskId);
+
+    this.exec.runTransaction(() => {
+      const taskPayload = this.exec.queryOne(
+        `UPDATE tasks SET ${setClauses.join(', ')} WHERE id = ? RETURNING *`,
+        values,
+      );
+      if (!taskPayload) {
+        throw new Error(`Failed to load task ${taskId} after launch-state update for sync journal`);
+      }
+      this.exec.markDirty();
+      appendJournalEntry(this.exec, {
+        entityType: 'task',
+        entityId: taskId,
+        op: 'upsert',
+        payload: taskPayload,
       });
     });
   }

--- a/packages/data-store/src/sqlite-task-repository.ts
+++ b/packages/data-store/src/sqlite-task-repository.ts
@@ -50,6 +50,10 @@ export class SqliteTaskRepository implements TaskRepository {
     this.adapter.updateTask(taskId, changes);
   }
 
+  updateTaskLaunchState(taskId: string, changes: TaskStateChanges): void {
+    this.adapter.updateTaskLaunchState(taskId, changes);
+  }
+
   deleteTask(taskId: string): void {
     this.adapter.deleteTask(taskId);
   }

--- a/packages/data-store/src/sync-journal.ts
+++ b/packages/data-store/src/sync-journal.ts
@@ -87,13 +87,7 @@ export function appendJournalEntry(
   db: SqliteExecutor,
   entry: SyncJournalEntryInput,
 ): SyncJournalEntry {
-  const entityType = entry.entityType ?? entry.entity_type;
-  const entityId = entry.entityId ?? entry.entity_id;
-  if (!entityType) throw new Error('sync journal entry requires entityType');
-  if (!entityId) throw new Error('sync journal entry requires entityId');
-  const createdAt = entry.createdAt ?? entry.created_at ?? new Date().toISOString();
-  const origin = entry.origin ?? LOCAL_SYNC_ORIGIN;
-  const payload = JSON.stringify(entry.payload ?? null);
+  const { entityType, entityId, createdAt, origin, payload } = normalizeJournalEntryInput(entry);
 
   db.execRun(
     `INSERT INTO sync_journal (entity_type, entity_id, op, payload, origin, created_at)
@@ -113,6 +107,35 @@ export function appendJournalEntry(
     throw new Error(`Failed to load sync journal entry ${seq} after insert`);
   }
   return mapJournalRow(row);
+}
+
+export function appendJournalEntryWithoutReadback(
+  db: SqliteExecutor,
+  entry: SyncJournalEntryInput,
+): void {
+  const { entityType, entityId, createdAt, origin, payload } = normalizeJournalEntryInput(entry);
+  db.execRun(
+    `INSERT INTO sync_journal (entity_type, entity_id, op, payload, origin, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [entityType, entityId, entry.op, payload, origin, createdAt],
+  );
+}
+
+function normalizeJournalEntryInput(entry: SyncJournalEntryInput): {
+  entityType: SyncEntityType;
+  entityId: string;
+  createdAt: string;
+  origin: string;
+  payload: string;
+} {
+  const entityType = entry.entityType ?? entry.entity_type;
+  const entityId = entry.entityId ?? entry.entity_id;
+  if (!entityType) throw new Error('sync journal entry requires entityType');
+  if (!entityId) throw new Error('sync journal entry requires entityId');
+  const createdAt = entry.createdAt ?? entry.created_at ?? new Date().toISOString();
+  const origin = entry.origin ?? LOCAL_SYNC_ORIGIN;
+  const payload = JSON.stringify(entry.payload ?? null);
+  return { entityType, entityId, createdAt, origin, payload };
 }
 
 export function readJournalSince(

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -2413,7 +2413,6 @@ describe('Orchestrator', () => {
       const firstStarted = parkOrchestrator.startExecution();
       expect(firstStarted).toHaveLength(1);
       const taskId = firstStarted[0].id;
-      const dispatchedAt = Date.now();
 
       parkOrchestrator.deferTask(taskId, {
         reason: 'resource-limit',
@@ -2422,8 +2421,9 @@ describe('Orchestrator', () => {
         phase: 'launching',
       });
 
-      expect(parkOrchestrator.isLaunchParked(taskId, dispatchedAt)).toBe(true);
-      expect(parkOrchestrator.isLaunchParked(taskId, dispatchedAt + 60_001)).toBe(false);
+      const deferredAt = Date.now();
+      expect(parkOrchestrator.isLaunchParked(taskId, deferredAt)).toBe(true);
+      expect(parkOrchestrator.isLaunchParked(taskId, deferredAt + 60_001)).toBe(false);
     });
 
     it.skip('keeps a parked resource-limit task queued between scheduler polls', () => {

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -248,10 +248,16 @@ class InMemoryPersistence implements OrchestratorPersistence {
 
 class CountingPersistence extends InMemoryPersistence {
   loadTasksCalls: string[] = [];
+  transactionCalls = 0;
 
   override loadTasks(workflowId: string): TaskState[] {
     this.loadTasksCalls.push(workflowId);
     return super.loadTasks(workflowId);
+  }
+
+  runInTransaction<T>(work: () => T): T {
+    this.transactionCalls += 1;
+    return work();
   }
 }
 
@@ -6190,6 +6196,7 @@ describe('Orchestrator', () => {
       }
 
       expect(started.length).toBe(workflowCount);
+      expect(persistence.transactionCalls).toBe(1);
       // Before the fix, getTaskLaunchReadinessImpl() called refreshFromDb()
       // -- reloading every active workflow's tasks from the DB -- once per
       // ready task inside planPendingLaunchQueue()'s map and once more per

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -258,7 +258,7 @@ export interface ExecutionResourceLeaseReleaseRow {
 export type TaskLaunchReadiness =
   | { ready: true; task: TaskState }
   | { ready: false; reason: string; task?: TaskState };
-export type LaunchReadinessOptions = { bypassLocalDependencyReadiness?: boolean };
+export type LaunchReadinessOptions = { bypassLocalDependencyReadiness?: boolean; activePersistedAttempts?: number };
 export type StartExecutionOptions = { limit?: number };
 
 export interface OrchestratorPersistence {
@@ -282,6 +282,7 @@ export interface OrchestratorPersistence {
   updateWorkflow?(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op'; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[]; detachedExternalDependencies?: DetachedExternalDependency[] }): void;
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
+  updateTaskLaunchState?(taskId: string, changes: TaskStateChanges): void;
   logEvent?(taskId: string, eventType: string, payload?: unknown): void;
   listWorkflows(): Array<{
     id: string;
@@ -369,6 +370,7 @@ export interface OrchestratorPersistence {
     workflowId: string;
     priority?: 'high' | 'normal' | 'low';
     generation: number;
+    suppressEvent?: boolean;
   }): {
     id: number;
     state?: 'enqueued' | 'leased' | 'completed' | 'abandoned';
@@ -600,6 +602,14 @@ export function taskRepositoryFromPersistence(p: OrchestratorPersistence): TaskR
     deleteAllWorkflows: () => p.deleteAllWorkflows?.(),
     saveTask: (wfId, t) => p.saveTask(wfId, t),
     updateTask: (id, c) => p.updateTask(id, c),
+    updateTaskLaunchState: (id, c) => {
+      const maybeLaunchUpdater = partial as Partial<{ updateTaskLaunchState(taskId: string, changes: TaskStateChanges): void }>;
+      if (typeof maybeLaunchUpdater.updateTaskLaunchState === 'function') {
+        maybeLaunchUpdater.updateTaskLaunchState(id, c);
+        return;
+      }
+      p.updateTask(id, c);
+    },
     deleteTask: (id) => {
       if (!p.deleteTask) throw new Error('Persistence adapter does not support deleteTask');
       p.deleteTask(id);
@@ -807,14 +817,18 @@ export class Orchestrator {
   private writeAndSync(
     taskId: string,
     changes: TaskStateChanges,
-    opts?: { skipWorkflowStatusSync?: boolean },
+    opts?: { skipWorkflowStatusSync?: boolean; launchStateUpdate?: boolean },
   ): TaskState {
     const existing = this.stateGetTask(taskId);
     if (!existing) {
       throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `writeAndSync: task ${taskId} not found in graph`);
     }
     const id = existing.id;
-    this.taskRepository.updateTask(id, changes);
+    if (opts?.launchStateUpdate && this.taskRepository.updateTaskLaunchState) {
+      this.taskRepository.updateTaskLaunchState(id, changes);
+    } else {
+      this.taskRepository.updateTask(id, changes);
+    }
     this.queueStatusUiCache = null;
     const updated: TaskState = {
       ...existing,
@@ -1535,7 +1549,9 @@ export class Orchestrator {
       readyTaskIds = readyTaskIds.slice(0, opts.limit);
     }
 
-    return this.autoStartReadyTasks(readyTaskIds);
+    return this.taskRepository.runInTransaction(() => this.autoStartReadyTasks(readyTaskIds, 0, {
+      activePersistedAttempts: activeAttempts,
+    }));
   }
 
   /**

--- a/packages/workflow-core/src/orchestrator/scheduler-domain.ts
+++ b/packages/workflow-core/src/orchestrator/scheduler-domain.ts
@@ -55,7 +55,7 @@ export interface SchedulerDomainHost {
   writeAndSync(
     taskId: string,
     changes: TaskStateChanges,
-    opts?: { skipWorkflowStatusSync?: boolean },
+    opts?: { skipWorkflowStatusSync?: boolean; launchStateUpdate?: boolean },
   ): TaskState;
   buildUpdateDelta(before: TaskState, after: TaskState, changes: TaskStateChanges): TaskDelta;
   replaceSelectedAttempt(
@@ -125,7 +125,11 @@ function hasPendingLaunchRuntimeState(task: TaskState): boolean {
   );
 }
 
-function planPendingLaunchQueue(host: SchedulerDomainHost, candidateJobs: TaskJob[]): TaskJob[] {
+function planPendingLaunchQueue(
+  host: SchedulerDomainHost,
+  candidateJobs: TaskJob[],
+  opts?: LaunchReadinessOptions,
+): TaskJob[] {
   // Refresh once for the whole batch, not once per candidate job below --
   // readiness for every job in this pass is evaluated against the same
   // in-memory snapshot, so a per-job refresh only re-reads data this
@@ -137,7 +141,7 @@ function planPendingLaunchQueue(host: SchedulerDomainHost, candidateJobs: TaskJo
     if (!task || (task.status !== 'pending' && (task.status as string) !== 'queued')) continue;
     if (host.getExternalDependencyBlocker(task) !== undefined) continue;
     const knownAttemptId = sourceJob.attemptId ?? task.execution.selectedAttemptId;
-    if (hasActiveLaunchAttempt(host, task, knownAttemptId)) continue;
+    if (opts?.activePersistedAttempts !== 0 && hasActiveLaunchAttempt(host, task, knownAttemptId)) continue;
     const existing = mergedJobs.get(task.id);
     mergedJobs.set(task.id, {
       taskId: task.id,
@@ -198,9 +202,13 @@ export function getPendingLaunchQueueSnapshotImpl(
   return planPendingLaunchQueue(host, candidateJobs);
 }
 
-function rebuildPendingLaunchQueue(host: SchedulerDomainHost, candidateJobs: TaskJob[]): void {
+function rebuildPendingLaunchQueue(
+  host: SchedulerDomainHost,
+  candidateJobs: TaskJob[],
+  opts?: LaunchReadinessOptions,
+): void {
   const orderedJobs: TaskJob[] = [];
-  for (const job of planPendingLaunchQueue(host, candidateJobs)) {
+  for (const job of planPendingLaunchQueue(host, candidateJobs, opts)) {
     const task = host.stateGetTask(job.taskId);
     if (!task) continue;
     const attemptId = host.ensureCurrentPendingAttempt(task);
@@ -256,8 +264,8 @@ export function autoStartReadyTasksImpl(
     });
   }
 
-  rebuildPendingLaunchQueue(host, candidateJobs);
-  return drainSchedulerImpl(host);
+  rebuildPendingLaunchQueue(host, candidateJobs, opts);
+  return drainSchedulerImpl(host, opts);
 }
 
 export function enqueueIfNotScheduledImpl(
@@ -382,7 +390,7 @@ export function getLocalDependencyBlockerImpl(host: SchedulerDomainHost, task: T
   return undefined;
 }
 
-export function drainSchedulerImpl(host: SchedulerDomainHost): TaskState[] {
+export function drainSchedulerImpl(host: SchedulerDomainHost, opts?: LaunchReadinessOptions): TaskState[] {
   // Refresh once for the whole drain pass, not once per dequeued job below
   // (see planPendingLaunchQueue for the same reasoning).
   host.refreshFromDb();
@@ -416,13 +424,18 @@ export function drainSchedulerImpl(host: SchedulerDomainHost): TaskState[] {
     const now = new Date();
     let launchTask = task;
     let attemptId = job.attemptId;
-    let currentAttempt = host.loadAttemptById(attemptId);
-    if (!isReusableLaunchAttempt(host, launchTask, currentAttempt)) {
+    const canClaimWithoutAttemptLoad = opts?.activePersistedAttempts === 0
+      && typeof host.taskRepository.claimAttemptForLaunch === 'function'
+      && launchTask.status === 'pending'
+      && !hasPendingLaunchRuntimeState(launchTask)
+      && Boolean(attemptId);
+    let currentAttempt = canClaimWithoutAttemptLoad ? undefined : host.loadAttemptById(attemptId);
+    if (!canClaimWithoutAttemptLoad && !isReusableLaunchAttempt(host, launchTask, currentAttempt)) {
       attemptId = host.ensureCurrentPendingAttempt(task);
       launchTask = host.stateGetTask(job.taskId) ?? task;
       currentAttempt = host.loadAttemptById(attemptId);
     }
-    if (!isReusableLaunchAttempt(host, launchTask, currentAttempt)) {
+    if (!canClaimWithoutAttemptLoad && !isReusableLaunchAttempt(host, launchTask, currentAttempt)) {
       host.logger.info('[orchestrator] drainScheduler: skipping non-runnable attempt', {
         taskId: job.taskId,
         attemptId,
@@ -441,7 +454,10 @@ export function drainSchedulerImpl(host: SchedulerDomainHost): TaskState[] {
     const launchAttemptId = attemptId;
     const selectedTask = host.stateGetTask(job.taskId) ?? task;
     if (selectedTask.execution.selectedAttemptId !== launchAttemptId) {
-      host.writeAndSync(job.taskId, { execution: { selectedAttemptId: launchAttemptId } });
+      host.writeAndSync(job.taskId, { execution: { selectedAttemptId: launchAttemptId } }, {
+        skipWorkflowStatusSync: true,
+        launchStateUpdate: true,
+      });
     }
     let claimSucceeded = false;
     const claimPatch = host.deferRunningUntilLaunch
@@ -496,7 +512,10 @@ export function drainSchedulerImpl(host: SchedulerDomainHost): TaskState[] {
             launchCompletedAt: undefined,
           },
         };
-    const updated = host.writeAndSync(job.taskId, changes);
+    const updated = host.writeAndSync(job.taskId, changes, {
+      skipWorkflowStatusSync: true,
+      launchStateUpdate: true,
+    });
     host.persistence.logEvent?.(
       job.taskId,
       host.deferRunningUntilLaunch ? 'task.launch_claimed' : 'task.running',
@@ -512,6 +531,7 @@ export function drainSchedulerImpl(host: SchedulerDomainHost): TaskState[] {
           attemptId: launchAttemptId,
           workflowId: task.config.workflowId,
           generation: host.getExecutionGeneration(task),
+          suppressEvent: true,
         });
         host.persistence.logEvent?.(job.taskId, 'task.dispatch_enqueued', {
           ...changes,

--- a/packages/workflow-core/src/task-repository.ts
+++ b/packages/workflow-core/src/task-repository.ts
@@ -121,6 +121,12 @@ export interface TaskRepository {
   /** Apply a partial update to an existing task. */
   updateTask(taskId: string, changes: TaskStateChanges): void;
 
+  /**
+   * Apply the narrow launch-state update written by drainScheduler after an
+   * attempt has already been claimed.
+   */
+  updateTaskLaunchState?(taskId: string, changes: TaskStateChanges): void;
+
   /** Delete one task and its task-owned rows. */
   deleteTask(taskId: string): void;
 


### PR DESCRIPTION
## Summary

The Vitest Workspace CI job started failing at commit 2363032b. The auto-start path loaded and rewrote full task rows per launch, causing SQLite contention under concurrency.

The fix wraps auto-start in one write transaction, bypasses attempt loads when none exist, and uses narrow launch-state updates instead of full rewrites.

A new `appendJournalEntryWithoutReadback` avoids redundant readback SELECTs after journal inserts. Reentrant write-transaction support prevents deadlocks when the transaction is already held.

## Review Claim

The change reduces SQLite contention in the scheduler launch path enough to fix the Vitest Workspace CI timeout, with no behavior change to task execution semantics.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect. The new transaction boundary and narrow-write path produce identical task state transitions; only the write granularity and locking scope change.

## Slice Rationale

One behavior slice: all nine files serve the same root cause (scheduler launch contention). Separating the transaction wrapper from the narrow-write path would leave the fix incomplete.

## Non-goals

- No unrelated restructuring beyond what the fix requires.
- No unrelated cleanup.
- No test weakening or snapshot churn.
- No new module boundaries.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/10-vitest-workspace.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c56d62e5e`
- Post-revert steps: None
- Data migration? No

</details>
