### PR TITLE
[CI regression: 8365ed9-playwright-7-of-9](1) Restore shard inventory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -650,6 +650,7 @@ jobs:
             files: >-
               e2e/worker-tab-scroll.spec.ts
               e2e/workflow-delete-latency.spec.ts
+              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
               e2e/main-process-hitch-responsiveness.spec.ts
               e2e/dag-click-hitch-responsiveness.spec.ts
               e2e/terminal-upsert-hitch-responsiveness.spec.ts


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / 7-of-9 -->

CI job `playwright / 7-of-9` first failed on 8365ed93997c669fc85eb85b4d56353378310e03 because the shard inventory omitted a newly added E2E spec.

Shard 7 now includes `planning-chat-restore-conversational-mode-repro.spec.ts`, and the inventory check accounts for every CI-owned Playwright spec.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31574441095/job/94043888956

## Review Claim

Assign the missing conversational-mode restart regression spec to Playwright shard 7 so the CI shard inventory is complete.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only shard membership changes; other CI jobs and product behavior remain unchanged.

## Slice Rationale

This policy slice isolates the shard inventory correction from the DAG timing-test proof update above it.

## Non-goals

- No product behavior changes.
- No Playwright test logic changes.
- No shard-count or inventory-policy changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 222167bd76a07ed564064d2dea7f809defc20fa5`
- Post-revert steps: Rerun the shard inventory check and reassign the omitted spec before merging another CI change.
- Data migration? No

</details>

