### PR TITLE
[CI regression: 8365ed9-playwright-3-of-9](1) Restore Playwright shard coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,6 +643,7 @@ jobs:
               e2e/embedded-terminal-spawn-failure.spec.ts
               e2e/embedded-terminal-restart-persistence.spec.ts
               e2e/planning-terminal-restart-persistence.spec.ts
+              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
               e2e/planning-terminal-open-daemon-owner-repro.spec.ts
               e2e/planning-terminal-tmux-blank-repro.spec.ts
               e2e/planning-tmux-blank-repro.spec.ts


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / 3-of-9 -->

This adjusts the Playwright shard manifest for the planning chat persistence spec added by 8365ed93997c669fc85eb85b4d56353378310e03.

The change is CI metadata only.

CI regression: 8365ed9-playwright-3-of-9 — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1786526391614-81/fix-ci-8365ed9-playwright-3-of-9 | CI shard manifest update. | completed |
| wf-1786526391614-81/verify-ci-8365ed9-playwright-3-of-9 | CI shard proof. | completed |

</details>

<details>
<summary>File changes per task</summary>

### wf-1786526391614-81/fix-ci-8365ed9-playwright-3-of-9

- `.github/workflows/ci.yml`: add `e2e/planning-chat-restore-conversational-mode-repro.spec.ts` to the Playwright shard manifest.

### wf-1786526391614-81/verify-ci-8365ed9-playwright-3-of-9

- No product files changed; the task recorded CI proof.

</details>

## Review Claim

The CI workflow should name the planning chat persistence spec in the Playwright shard manifest.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the CI workflow file list changes; product code, test expectations, and runtime behavior stay unchanged.

## Slice Rationale

This slice is limited to one CI shard metadata entry.

## Non-goals

No product behavior changes, no test weakening, no snapshot churn, and no Playwright harness changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-3-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/task-death-logs.spec.ts e2e/restart-failed-task.spec.ts e2e/ui-graph-drag-performance.spec.ts e2e/pending-review-gate-target-repo.proof.spec.ts e2e/workflow-status-composition.spec.ts e2e/queue-running-vs-queued.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/invoker-pr-bodies-ci-regression-8365ed9-playwright-3-of-9-1.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0982fcd51`
- Post-revert steps: Re-run the Playwright shard command if the CI regression needs to be rechecked.
- Data migration? No

</details>
