### PR TITLE
[CI regression: 8365ed9-playwright-6-of-9](1) Restore shard coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,6 +643,7 @@ jobs:
               e2e/embedded-terminal-spawn-failure.spec.ts
               e2e/embedded-terminal-restart-persistence.spec.ts
               e2e/planning-terminal-restart-persistence.spec.ts
+              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
               e2e/planning-terminal-open-daemon-owner-repro.spec.ts
               e2e/planning-terminal-tmux-blank-repro.spec.ts
               e2e/planning-tmux-blank-repro.spec.ts


### PR DESCRIPTION
## Summary

CI job `playwright / 6-of-9` omitted the conversational-mode restore repro from its shard list.

This adds `e2e/planning-chat-restore-conversational-mode-repro.spec.ts` beside the related restart specs in that shard.

## Review Claim

CI shard `playwright / 6-of-9` should include `e2e/planning-chat-restore-conversational-mode-repro.spec.ts`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the shard file list changes; product code, test expectations, and the other shard entries stay unchanged.

## Slice Rationale

One workflow-policy slice restores the missing shard membership before the proof assets are reviewed.

## Non-goals

No product behavior changes.

No test weakening.

No shard reshuffle beyond adding the omitted spec to `playwright / 6-of-9`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-6-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/embedded-terminal-spawn-failure.spec.ts e2e/embedded-terminal-restart-persistence.spec.ts e2e/planning-terminal-restart-persistence.spec.ts e2e/planning-terminal-open-daemon-owner-repro.spec.ts e2e/planning-terminal-tmux-blank-repro.spec.ts e2e/planning-tmux-blank-repro.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`
- [ ] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-bodies/ci-regression-8365ed9-playwright-6-of-9-1.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8ff33c1aa`
- Post-revert steps: Re-run the affected Playwright shard if the regression investigation resumes.
- Data migration? No

</details>
