### PR TITLE
[CI regression: 8365ed9-required-fast-mergify-admin-requeue](1) Stabilize admin requeue repro cleanup

### DIFF
--- a/scripts/repro/repro-babysit-rebase-onto-base.sh
+++ b/scripts/repro/repro-babysit-rebase-onto-base.sh
@@ -49,6 +49,9 @@ WORK_ROOT="$WORK_PARENT/6201"
 git clone . "$SEED" >/dev/null
 (
   cd "$SEED"
+  # This repository is disposable and removed by the EXIT trap. Keep Git from
+  # racing that cleanup with a background auto-gc process.
+  git config gc.auto 0
   git config user.email repro@example.test
   git config user.name 'Repro Bot'
   git checkout -B master >/dev/null


### PR DESCRIPTION
## Summary
<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=required-fast / Mergify Admin Requeue -->

The disposable rebase repro now disables Git auto-gc before creating its seed repository commits.

That keeps cleanup from racing a background maintenance process while the required-fast admin requeue proof runs.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31574441095/job/94043888911

## Review Claim

Disable Git auto-gc in the disposable rebase repro seed so the required-fast admin requeue proof runs deterministically.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the disposable repro repository setup changes; product code and the admin requeue worker behavior stay untouched.

## Slice Rationale

This slice is limited to the failing repro harness condition that made the required CI proof flaky.

## Non-goals

No product behavior changes, no CI weakening, no unrelated cleanup, and no changes to the admin requeue planner.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Workflow verification task reported: `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/12-mergify-admin-requeue.sh`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/ci-regression-8365ed9-pr-body-1.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2d4543b36`
- Post-revert steps: Rerun `bash scripts/test-suites/required/12-mergify-admin-requeue.sh` if the CI regression reappears.
- Data migration? No

</details>
