### PR TITLE
[CI regression: 8365ed9-playwright-2-of-9](1) Add planning-chat spec to shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -614,6 +614,7 @@ jobs:
               e2e/invalid-merge-workspace-visual.spec.ts
               e2e/invalid-task-workspace-visual.spec.ts
               e2e/persistence-lifecycle.spec.ts
+              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
           - name: 3-of-9
             files: >-
               e2e/task-death-logs.spec.ts


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / 2-of-9 -->

CI job `playwright / 2-of-9` first failed on default-branch commit 8365ed93997c669fc85eb85b4d56353378310e03 in run 31574441095.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31574441095/job/94043888934

This CI policy change adds the restored planning-chat restart regression spec to shard `playwright / 2-of-9`.

## Review Claim

The CI policy for `playwright / 2-of-9` now includes the restored planning-chat restart regression spec.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only `.github/workflows/ci.yml` changes, and the shard keeps its existing command, runner setup, and neighboring spec list.

## Slice Rationale

This slice contains only the CI shard membership fix so reviewers can verify the missing spec is restored without unrelated artifact churn.

## Non-goals

This does not weaken, skip, or delete tests.

This does not change product behavior, Playwright runner scripts, or other CI shard definitions.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-2-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/claude-planning-preset-visual-proof.spec.ts e2e/planning-presets-load-failure.spec.ts e2e/action-graph-visual-proof.spec.ts e2e/invalid-merge-workspace-visual.spec.ts e2e/invalid-task-workspace-visual.spec.ts e2e/persistence-lifecycle.spec.ts e2e/planning-chat-restore-conversational-mode-repro.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 30152f9`
- Post-revert steps: None
- Data migration? No

</details>
