### PR TITLE
[CI regression: 8365ed9-playwright-3-of-9](1) Route planning-chat restore repro into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -677,6 +677,7 @@ jobs:
               e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts
               e2e/planning-terminal-expand-collapse-garble-repro.spec.ts
               e2e/task-terminal-drawer-minimize-garble-repro.spec.ts
+              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
 
     name: playwright / ${{ matrix.name }}
 


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / 3-of-9 -->

CI job `playwright / 3-of-9` first failed on default-branch commit 8365ed93997c669fc85eb85b4d56353378310e03 in run 31574441095.

This slice includes the planning-chat conversational-mode restart repro in the terminal-garbling Playwright shard. It changes CI policy only.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31574441095/job/94043888953

---
CI regression: 8365ed9-playwright-3-of-9 — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1786531322718-18/fix-ci-8365ed9-playwright-3-of-9 | Include the planning-chat restore repro in a Playwright CI shard. | completed |
| wf-1786531322718-18/verify-ci-8365ed9-playwright-3-of-9 | Execute the local Playwright shard check. | completed |

</details>

<details>
<summary>File changes per task</summary>

### wf-1786531322718-18/fix-ci-8365ed9-playwright-3-of-9

- `.github/workflows/ci.yml`: add `e2e/planning-chat-restore-conversational-mode-repro.spec.ts` to the terminal-garbling Playwright shard.

### wf-1786531322718-18/verify-ci-8365ed9-playwright-3-of-9

- No product files changed; this task records verification only.

</details>

## Review Claim

Include the planning-chat conversational-mode restart repro in the terminal-garbling Playwright shard.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only one Playwright shard file list changes; product code, test expectations, and runtime behavior stay unchanged.

## Slice Rationale

This slice contains one CI policy entry and no product or test-harness edits.

## Non-goals

No product behavior changes, test weakening, snapshot churn, Playwright harness changes, or unrelated shard rebalancing.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-3-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/task-death-logs.spec.ts e2e/restart-failed-task.spec.ts e2e/ui-graph-drag-performance.spec.ts e2e/pending-review-gate-target-repo.proof.spec.ts e2e/workflow-status-composition.spec.ts e2e/queue-running-vs-queued.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — publisher rerun blocked after the builds because this macOS workspace has no `xvfb-run`.
- [x] `node scripts/validate-pr-body-local.mjs --body-file pr-body-ci-regression-8365ed9-playwright-3-of-9.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f0ee902d2`
- Post-revert steps: Re-run the Playwright shard command if the CI regression needs to be rechecked.
- Data migration? No

</details>
