### PR TITLE
[CI regression: 2363032-required-fast-vitest-workspace](2) refresh launch proof

### DIFF
--- a/packages/app/src/__tests__/orchestrator-cold-boot-large-db.test.ts
+++ b/packages/app/src/__tests__/orchestrator-cold-boot-large-db.test.ts
@@ -19,11 +19,13 @@ import type { TaskState } from '@invoker/workflow-core';
  * persistence layer production uses, not an in-memory mock) and written to
  * a real on-disk file. Boot is measured through the same two calls
  * main.ts's real startup path makes: Orchestrator.syncAllFromDb() (the
- * "orchestrator.restore.full-snapshot" phase) followed by
- * Orchestrator.startExecution() (the first LaunchDispatcher poll tick).
+ * "orchestrator.restore.full-snapshot" phase) followed by a bounded
+ * Orchestrator.startExecution() call (matching LaunchDispatcher's first
+ * poll tick).
  */
 
 const WORKFLOW_COUNT = 300;
+const FIRST_LAUNCH_BATCH_LIMIT = 32;
 
 describe('orchestrator cold boot against a large persisted DB', () => {
   let dbDir: string | undefined;
@@ -34,7 +36,7 @@ describe('orchestrator cold boot against a large persisted DB', () => {
   });
 
   it(
-    'completes syncAllFromDb() + startExecution() within a bounded time for a ~900-task / 300-workflow DB',
+    'completes syncAllFromDb() + a bounded first startExecution() within a bounded time for a ~900-task / 300-workflow DB',
     async () => {
       dbDir = mkdtempSync(path.join(tmpdir(), 'invoker-cold-boot-'));
       const dbPath = path.join(dbDir, 'invoker.db');
@@ -102,10 +104,11 @@ describe('orchestrator cold boot against a large persisted DB', () => {
 
         const bootStart = performance.now();
         orchestrator.syncAllFromDb();
-        const started = orchestrator.startExecution();
+        const started = orchestrator.startExecution({ limit: FIRST_LAUNCH_BATCH_LIMIT });
         const bootMs = performance.now() - bootStart;
 
-        expect(started.length).toBe(activeWorkflowCount);
+        expect(started.length).toBe(FIRST_LAUNCH_BATCH_LIMIT);
+        expect(orchestrator.getExecutableReadyTasks()).toHaveLength(activeWorkflowCount - FIRST_LAUNCH_BATCH_LIMIT);
         // Before the refreshFromDb() N+1 fix (see scheduler-domain.ts),
         // getTaskLaunchReadinessImpl() reloaded every active workflow's
         // tasks from the DB once per ready task, so this scaled with the

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -6202,11 +6202,9 @@ describe('Orchestrator', () => {
       // ready task inside planPendingLaunchQueue()'s map and once more per
       // dequeued job inside drainSchedulerImpl()'s while loop, on top of
       // the single refresh startExecution() already does at its own top.
-      // That made refreshFromDb() calls scale with the number of ready
-      // tasks in a single startExecution() call rather than staying
-      // constant. It must now stay at a small, fixed count regardless of
-      // how many tasks are ready.
-      expect(refreshCount).toBeLessThanOrEqual(5);
+      // The queued launch pass now reuses the queue-planning snapshot for
+      // draining, so refreshFromDb() stays both constant and minimal.
+      expect(refreshCount).toBeLessThanOrEqual(3);
     });
   });
 


### PR DESCRIPTION
## Summary

The Vitest Workspace regression proof now matches the repaired launch behavior.

The cold-boot test asserts a bounded first dispatch batch and leaves the remaining ready backlog queued for later launch ticks.

The orchestrator scaling test now asserts the reduced refresh count from reusing the queue-planning snapshot during launch draining.

## Review Claim

The regression proof now checks the bounded launch-dispatch behavior that repairs `required-fast / Vitest Workspace`.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The command is identical before and after the fix. This slice changes only regression expectations for the launch behavior repaired by the previous slice.

## Slice Rationale

One proof slice for the repaired CI job. Keeping the assertions separate makes the product change reviewable before the verification expectations.

## Non-goals

- No product behavior changes.
- No unrelated test coverage.
- No snapshot churn.
- No CI command changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/10-vitest-workspace.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert cca65c277`
- Post-revert steps: None
- Data migration? No

</details>
