### PR TITLE
[Mergify admin-bypass fault tolerance](1) Retry transient gh API failures

### DIFF
--- a/scripts/mergify_admin_requeue_gh_executor.py
+++ b/scripts/mergify_admin_requeue_gh_executor.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import re
-import subprocess
 import tempfile
 from pathlib import Path
 
@@ -10,12 +9,12 @@ try:
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Action, GH_ACTIONS_JOB_RE, Ledger, PrSnapshot
     from .mergify_admin_requeue_repair_body import rebase_onto_base as run_rebase_onto_base
-    from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
+    from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head, run_logged
 except ImportError:
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Action, GH_ACTIONS_JOB_RE, Ledger, PrSnapshot
     from mergify_admin_requeue_repair_body import rebase_onto_base as run_rebase_onto_base
-    from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head
+    from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head, run_logged
 
 
 ADMIN_BYPASS_NUDGE_LEDGER_KIND = "comment-admin-bypass-nudge"
@@ -63,12 +62,7 @@ class AdminBypassGhExecutor:
             return ""
         tmp = Path(tempfile.mkdtemp(prefix=f"mergify-admin-requeue-{pr_number}-"))
         path = tmp / (re.sub(r"[^A-Za-z0-9_.-]+", "-", check_name).strip("-") + ".log")
-        out = subprocess.run(
-            ["gh", "run", "view", "--repo", repo, "--job", match.group(1), "--log"],
-            check=True,
-            text=True,
-            capture_output=True,
-        ).stdout
+        out = run_logged(["gh", "run", "view", "--repo", repo, "--job", match.group(1), "--log"])
         path.write_text(out, encoding="utf-8")
         return str(path)
 

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -5,8 +5,35 @@ from pathlib import Path
 import re
 import subprocess
 import sys
+import time
 from typing import Mapping, Sequence
 from urllib.parse import quote
+
+GH_COMMAND_TIMEOUT_SECONDS = 20
+GH_RETRY_MAX_ATTEMPTS = 3
+GH_RETRY_BACKOFF_SECONDS = 2
+# Worst case for one call: GH_COMMAND_TIMEOUT_SECONDS * GH_RETRY_MAX_ATTEMPTS, plus
+# backoff between attempts. A run makes 100+ of these calls for ~50 admin-bypass
+# PRs, so this must stay a small fraction of the pr-admin-bypass-land worker's
+# tick timeout (packages/execution-engine/src/workers/pr-maintenance-workers.ts,
+# DEFAULT_PR_MAINTENANCE_WORKER_TICK_TIMEOUT_MS, currently 240s) or one stuck
+# call can alone blow the whole tick's budget. Keep comfortably under 240s.
+GH_CALL_WORST_CASE_SECONDS = GH_COMMAND_TIMEOUT_SECONDS * GH_RETRY_MAX_ATTEMPTS + GH_RETRY_BACKOFF_SECONDS * (
+    GH_RETRY_MAX_ATTEMPTS * (GH_RETRY_MAX_ATTEMPTS - 1) // 2
+)
+
+TRANSIENT_GH_ERROR_MARKERS = (
+    "http 500",
+    "http 502",
+    "http 503",
+    "http 504",
+    "bad gateway",
+    "gateway timeout",
+    "stream error",
+    "connection reset",
+    "eof occurred in violation of protocol",
+    "temporary failure in name resolution",
+)
 
 PR_LIST_FIELDS = (
     "number,title,url,headRefName,headRefOid,baseRefName,state,isDraft,"
@@ -133,14 +160,8 @@ class GhClient:
 
     def create_pr(self, repo: str, title: str, body: str, head: str, base: str) -> dict:
         payload = json.dumps({"title": title, "body": body, "head": head, "base": base})
-        completed = subprocess.run(
-            ["gh", "api", f"repos/{repo}/pulls", "--method", "POST", "--input", "-"],
-            check=True,
-            text=True,
-            input=payload,
-            capture_output=True,
-        )
-        value = json.loads(completed.stdout) if completed.stdout.strip() else None
+        out = run_logged(["gh", "api", f"repos/{repo}/pulls", "--method", "POST", "--input", "-"], input=payload)
+        value = json.loads(out) if out.strip() else None
         if not isinstance(value, dict):
             raise RuntimeError("empty PR create response")
         return value
@@ -150,71 +171,90 @@ class GhClient:
         return value if isinstance(value, list) else []
 
     def comment(self, repo: str, number: int, body: str) -> None:
-        subprocess.run(["gh", "pr", "comment", str(number), "--repo", repo, "--body", body], check=True, text=True, capture_output=True)
+        run_logged(["gh", "pr", "comment", str(number), "--repo", repo, "--body", body])
 
     def edit_label(self, repo: str, number: int, add: str | None = None, remove: str | None = None) -> None:
         if add:
-            subprocess.run(
-                ["gh", "api", "--method", "POST", f"repos/{repo}/issues/{number}/labels", "-f", f"labels[]={add}"],
-                check=True,
-                text=True,
-                capture_output=True,
-            )
+            run_logged(["gh", "api", "--method", "POST", f"repos/{repo}/issues/{number}/labels", "-f", f"labels[]={add}"])
         if remove:
-            subprocess.run(
-                ["gh", "api", "--method", "DELETE", f"repos/{repo}/issues/{number}/labels/{quote(remove, safe='')}"],
-                check=True,
-                text=True,
-                capture_output=True,
-            )
+            run_logged(["gh", "api", "--method", "DELETE", f"repos/{repo}/issues/{number}/labels/{quote(remove, safe='')}"])
 
     def retarget_base(self, repo: str, number: int, base: str) -> None:
-        subprocess.run(
-            ["gh", "api", "--method", "PATCH", f"repos/{repo}/pulls/{number}", "-f", f"base={base}"],
-            check=True,
-            text=True,
-            capture_output=True,
-        )
+        run_logged(["gh", "api", "--method", "PATCH", f"repos/{repo}/pulls/{number}", "-f", f"base={base}"])
 
     def compare_status(self, repo: str, base: str, head: str) -> str:
-        completed = subprocess.run(
-            ["gh", "api", f"repos/{repo}/compare/{base}...{head}"],
-            check=True,
-            text=True,
-            capture_output=True,
-        )
-        return str(json.loads(completed.stdout).get("status") or "")
+        out = run_logged(["gh", "api", f"repos/{repo}/compare/{base}...{head}"])
+        return str(json.loads(out).get("status") or "")
 
     def resolve_review_thread(self, thread_id: str) -> None:
         query = "mutation($threadId:ID!) { resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } } }"
-        subprocess.run(["gh", "api", "graphql", "-f", f"threadId={thread_id}", "-f", f"query={query}"], check=True, text=True, capture_output=True)
+        run_logged(["gh", "api", "graphql", "-f", f"threadId={thread_id}", "-f", f"query={query}"])
 
 
-def run_logged(args: Sequence[str], *, cwd: Path | str | None = None, capture: bool = True) -> str:
-    try:
-        completed = subprocess.run(
-            list(args),
-            cwd=str(cwd) if cwd is not None else None,
-            check=True,
-            text=True,
-            capture_output=capture,
-        )
-    except subprocess.CalledProcessError as exc:
-        print(f"ERROR: command failed: {' '.join(str(part) for part in args)}", file=sys.stderr)
-        if exc.stdout:
-            print(exc.stdout, file=sys.stderr, end="" if exc.stdout.endswith("\n") else "\n")
-        if exc.stderr:
-            print(exc.stderr, file=sys.stderr, end="" if exc.stderr.endswith("\n") else "\n")
-        if is_github_rate_limit_error(exc):
-            raise RuntimeError("GitHub API rate limit exceeded while loading PR snapshots") from exc
-        raise
-    return completed.stdout or ""
+def run_logged(
+    args: Sequence[str],
+    *,
+    cwd: Path | str | None = None,
+    capture: bool = True,
+    input: str | None = None,
+) -> str:
+    last_exc: subprocess.CalledProcessError | subprocess.TimeoutExpired | None = None
+    for attempt in range(1, GH_RETRY_MAX_ATTEMPTS + 1):
+        try:
+            completed = subprocess.run(
+                list(args),
+                cwd=str(cwd) if cwd is not None else None,
+                check=True,
+                text=True,
+                capture_output=capture,
+                input=input,
+                timeout=GH_COMMAND_TIMEOUT_SECONDS,
+            )
+            return completed.stdout or ""
+        except subprocess.TimeoutExpired as exc:
+            last_exc = exc
+            print(
+                f"WARN: command timed out after {GH_COMMAND_TIMEOUT_SECONDS}s "
+                f"(attempt {attempt}/{GH_RETRY_MAX_ATTEMPTS}): {' '.join(str(part) for part in args)}",
+                file=sys.stderr,
+            )
+            if attempt < GH_RETRY_MAX_ATTEMPTS:
+                time.sleep(GH_RETRY_BACKOFF_SECONDS * attempt)
+                continue
+            raise RuntimeError(
+                f"command timed out after {GH_RETRY_MAX_ATTEMPTS} attempts: {' '.join(str(part) for part in args)}"
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            last_exc = exc
+            if attempt < GH_RETRY_MAX_ATTEMPTS and is_transient_gh_error(exc):
+                print(
+                    f"WARN: transient command failure (attempt {attempt}/{GH_RETRY_MAX_ATTEMPTS}), retrying: "
+                    f"{' '.join(str(part) for part in args)}",
+                    file=sys.stderr,
+                )
+                time.sleep(GH_RETRY_BACKOFF_SECONDS * attempt)
+                continue
+            print(f"ERROR: command failed: {' '.join(str(part) for part in args)}", file=sys.stderr)
+            if exc.stdout:
+                print(exc.stdout, file=sys.stderr, end="" if exc.stdout.endswith("\n") else "\n")
+            if exc.stderr:
+                print(exc.stderr, file=sys.stderr, end="" if exc.stderr.endswith("\n") else "\n")
+            if is_github_rate_limit_error(exc):
+                raise RuntimeError("GitHub API rate limit exceeded while loading PR snapshots") from exc
+            raise
+    assert last_exc is not None
+    raise last_exc
 
 
 def is_github_rate_limit_error(exc: subprocess.CalledProcessError) -> bool:
     text = "\n".join(str(part or "") for part in (exc.stdout, exc.stderr))
     lowered = text.lower()
     return "rate_limit" in text or "rate limit" in lowered
+
+
+def is_transient_gh_error(exc: subprocess.CalledProcessError) -> bool:
+    text = "\n".join(str(part or "") for part in (exc.stdout, exc.stderr)).lower()
+    return any(marker in text for marker in TRANSIENT_GH_ERROR_MARKERS)
 
 
 def checkout_pr_head(repo: str, pr: PrSnapshot, work_root: Path) -> None:

--- a/scripts/repro/repro-mergify-admin-requeue-transient-gh-failure.sh
+++ b/scripts/repro/repro-mergify-admin-requeue-transient-gh-failure.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Root cause of "admin-bypass PRs never resolve": scripts/mergify_admin_requeue.py's
+# run_logged() called `gh` once, with check=True and no timeout, and raised on the
+# very first CalledProcessError. GitHub's GraphQL API (the `gh pr list ... --json
+# ...,statusCheckRollup` query this script depends on) intermittently answers with
+# HTTP 502/504 or an HTTP/2 stream reset — a known-transient condition, not a real
+# failure. One blip killed the whole babysitting cycle.
+#
+# This script proves it two ways:
+#   1. Against the last-committed version of the file (HEAD, before this fix): a
+#      single simulated transient gh failure crashes run_logged. FAIL.
+#   2. Against the current working tree (after this fix): the same failure is
+#      retried and the call succeeds. PASS.
+#
+# No network access required — subprocess.run is mocked.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-mergify-transient-gh.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1"
+  exit 1
+}
+
+BEFORE_DIR="$TMP/before"
+mkdir -p "$BEFORE_DIR"
+git show HEAD:scripts/mergify_admin_requeue_snapshot.py > "$BEFORE_DIR/mergify_admin_requeue_snapshot.py"
+git show HEAD:scripts/mergify_admin_requeue_model.py > "$BEFORE_DIR/mergify_admin_requeue_model.py"
+
+HARNESS="$TMP/harness.py"
+cat > "$HARNESS" <<'PY'
+import subprocess
+import sys
+from unittest import mock
+
+sys.path.insert(0, sys.argv[1])
+import mergify_admin_requeue_snapshot as s  # noqa: E402
+
+transient = subprocess.CalledProcessError(
+    1,
+    ["gh", "pr", "list", "--repo", "Neko-Catpital-Labs/Invoker", "--label", "admin-bypass"],
+    stderr="HTTP 502: 502 Bad Gateway (https://api.github.com/graphql)",
+)
+success = subprocess.CompletedProcess(["gh", "pr", "list"], 0, stdout="[]", stderr="")
+
+with mock.patch("mergify_admin_requeue_snapshot.subprocess.run", side_effect=[transient, success]) as run_mock:
+    try:
+        out = s.run_logged(["gh", "pr", "list", "--repo", "Neko-Catpital-Labs/Invoker", "--label", "admin-bypass"])
+    except subprocess.CalledProcessError as exc:
+        print(f"RESULT crashed calls={run_mock.call_count} stderr={exc.stderr!r}")
+        sys.exit(1)
+    print(f"RESULT succeeded calls={run_mock.call_count} out={out!r}")
+    sys.exit(0)
+PY
+
+echo "[repro] === BEFORE (HEAD, unfixed run_logged) — one 502, then a clean success queued up ==="
+if python3 "$HARNESS" "$BEFORE_DIR" 2>&1 | tee "$TMP/before.out"; then
+  fail "expected the unfixed version to crash on the first transient error, but it succeeded"
+fi
+grep -q "^RESULT crashed calls=1 " "$TMP/before.out" || fail "unfixed version did not crash the way we expected (see output above)"
+echo "[repro] confirmed: unfixed code died on attempt 1/1, never tried the call that would have succeeded"
+echo
+
+echo "[repro] === AFTER (current working tree, fixed run_logged) — same scenario ==="
+python3 "$HARNESS" "scripts" | tee "$TMP/after.out"
+grep -q "^RESULT succeeded calls=2 " "$TMP/after.out" || fail "fixed version did not retry-and-succeed as expected"
+echo "[repro] confirmed: fixed code retried once and returned the successful result"
+echo
+echo "[repro] PASS: transient-gh-failure repro reproduced the bug on HEAD and confirmed the fix on the working tree"

--- a/scripts/repro/repro-mergify-admin-requeue-worker-tick-budget.sh
+++ b/scripts/repro/repro-mergify-admin-requeue-worker-tick-budget.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The pr-admin-bypass-land worker (packages/execution-engine/src/workers/
+# pr-maintenance-workers.ts) force-kills the whole babysitting script if a
+# single tick runs past its 240s timeout (DEFAULT_PR_MAINTENANCE_WORKER_TICK_
+# TIMEOUT_MS). A real cycle makes 100+ `gh` calls for ~50 admin-bypass PRs.
+#
+# The first fix for the transient-gh-failure bug (see
+# repro-mergify-admin-requeue-transient-gh-failure.sh) gave run_logged() a
+# 90s per-call timeout with 3 retries -- but never checked that budget
+# against the worker's own 240s ceiling. Worst case for ONE stuck call alone
+# was 276s: bigger than the worker's entire tick timeout. A single hung call
+# could make the worker kill the script even faster/worse than before the
+# fix, and still get zero useful work done.
+#
+# This proves it two ways:
+#   1. With the original 90s/3-attempt budget: the worst case for one call
+#      exceeds the worker's 240s tick timeout. FAIL.
+#   2. With the current working tree's tightened budget: the worst case for
+#      one call stays under a safe fraction of the tick timeout, leaving
+#      room for the other 100+ calls in the same cycle. PASS.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+WORKER_TICK_TIMEOUT_SECONDS=240
+
+fail() {
+  echo "[repro] FAIL: $1"
+  exit 1
+}
+
+worst_case_seconds() {
+  python3 -c "
+timeout, attempts, backoff = $1, $2, $3
+worst = 0
+for attempt in range(1, attempts + 1):
+    worst += timeout
+    if attempt < attempts:
+        worst += backoff * attempt
+print(worst)
+"
+}
+
+echo "[repro] === BEFORE: original run_logged budget (90s timeout, 3 attempts, 2s backoff step) ==="
+BEFORE=$(worst_case_seconds 90 3 2)
+echo "[repro] worst case for one stuck gh call: ${BEFORE}s (worker tick timeout: ${WORKER_TICK_TIMEOUT_SECONDS}s)"
+if [ "$BEFORE" -lt "$WORKER_TICK_TIMEOUT_SECONDS" ]; then
+  fail "expected the original budget to exceed the worker's tick timeout, but it didn't (${BEFORE}s < ${WORKER_TICK_TIMEOUT_SECONDS}s)"
+fi
+echo "[repro] confirmed: one stuck call alone could burn the worker's whole tick budget (${BEFORE}s >= ${WORKER_TICK_TIMEOUT_SECONDS}s)"
+echo
+
+echo "[repro] === AFTER: current working tree's tightened budget ==="
+ACTUAL=$(python3 -c "
+import sys
+sys.path.insert(0, 'scripts')
+import mergify_admin_requeue_snapshot as s
+print(s.GH_CALL_WORST_CASE_SECONDS)
+")
+SAFE_CEILING=$((WORKER_TICK_TIMEOUT_SECONDS / 3))
+echo "[repro] worst case for one stuck gh call: ${ACTUAL}s (safe ceiling: ${SAFE_CEILING}s, 1/3 of tick timeout)"
+if [ "$ACTUAL" -ge "$SAFE_CEILING" ]; then
+  fail "current budget (${ACTUAL}s) does not leave enough headroom under the worker's tick timeout (ceiling ${SAFE_CEILING}s)"
+fi
+echo "[repro] confirmed: one stuck call now leaves headroom for the other 100+ calls in the same tick"
+echo
+echo "[repro] PASS: worker-tick-budget repro reproduced the risk in the original retry fix and confirmed the correction"

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -12,6 +12,7 @@ Run:  python3 scripts/test_mergify_admin_requeue_snapshot.py
 
 from __future__ import annotations
 
+import ast
 import sys
 import subprocess
 import unittest
@@ -150,6 +151,58 @@ class GhCommandFailures(unittest.TestCase):
         with mock.patch("mergify_admin_requeue_snapshot.subprocess.run", side_effect=error):
             with self.assertRaisesRegex(RuntimeError, "GitHub API rate limit exceeded"):
                 s.run_logged(["gh", "api", "graphql"])
+
+
+class GhCommandTransientRetry(unittest.TestCase):
+    # Incident 2026-08-12: gh's GraphQL calls intermittently fail with 502/504
+    # gateway errors and stream resets; run_logged previously raised on the
+    # first failure, killing the whole babysitting cycle for a blip that
+    # would have succeeded on the very next attempt.
+    def test_retries_transient_gateway_error_then_succeeds(self):
+        transient = subprocess.CalledProcessError(
+            1, ["gh", "pr", "list"], stderr="HTTP 502: 502 Bad Gateway (https://api.github.com/graphql)",
+        )
+        success = subprocess.CompletedProcess(["gh", "pr", "list"], 0, stdout="[]", stderr="")
+        with mock.patch("mergify_admin_requeue_snapshot.subprocess.run", side_effect=[transient, success]) as run_mock:
+            with mock.patch("mergify_admin_requeue_snapshot.time.sleep"):
+                out = s.run_logged(["gh", "pr", "list"])
+        self.assertEqual(out, "[]")
+        self.assertEqual(run_mock.call_count, 2)
+
+    def test_retries_stream_reset_then_succeeds(self):
+        transient = subprocess.CalledProcessError(
+            1, ["gh", "pr", "list"], stderr="stream error: stream ID 1; CANCEL; received from peer",
+        )
+        success = subprocess.CompletedProcess(["gh", "pr", "list"], 0, stdout="[]", stderr="")
+        with mock.patch("mergify_admin_requeue_snapshot.subprocess.run", side_effect=[transient, success]):
+            with mock.patch("mergify_admin_requeue_snapshot.time.sleep"):
+                out = s.run_logged(["gh", "pr", "list"])
+        self.assertEqual(out, "[]")
+
+    def test_exhausts_retries_and_raises_last_error(self):
+        transient = subprocess.CalledProcessError(
+            1, ["gh", "pr", "list"], stderr="HTTP 504: gateway timeout",
+        )
+        with mock.patch("mergify_admin_requeue_snapshot.subprocess.run", side_effect=transient) as run_mock:
+            with mock.patch("mergify_admin_requeue_snapshot.time.sleep"):
+                with self.assertRaises(subprocess.CalledProcessError):
+                    s.run_logged(["gh", "pr", "list"])
+        self.assertEqual(run_mock.call_count, 3)
+
+    def test_non_transient_error_does_not_retry(self):
+        hard_error = subprocess.CalledProcessError(1, ["gh", "pr", "list"], stderr="HTTP 404: Not Found")
+        with mock.patch("mergify_admin_requeue_snapshot.subprocess.run", side_effect=hard_error) as run_mock:
+            with self.assertRaises(subprocess.CalledProcessError):
+                s.run_logged(["gh", "pr", "list"])
+        self.assertEqual(run_mock.call_count, 1)
+
+    def test_hang_times_out_and_is_retried(self):
+        timeout_exc = subprocess.TimeoutExpired(["gh", "pr", "list"], 90)
+        success = subprocess.CompletedProcess(["gh", "pr", "list"], 0, stdout="[]", stderr="")
+        with mock.patch("mergify_admin_requeue_snapshot.subprocess.run", side_effect=[timeout_exc, success]):
+            with mock.patch("mergify_admin_requeue_snapshot.time.sleep"):
+                out = s.run_logged(["gh", "pr", "list"])
+        self.assertEqual(out, "[]")
 
 
 class ParseStackMetadata(unittest.TestCase):
@@ -368,7 +421,7 @@ class GhClientLabelEdit(unittest.TestCase):
 
     def test_add_label_uses_rest_issue_labels_endpoint(self):
         client = s.GhClient()
-        with mock.patch("mergify_admin_requeue_snapshot.subprocess.run") as run:
+        with mock.patch("mergify_admin_requeue_snapshot.run_logged") as run:
             client.edit_label("Neko-Catpital-Labs/Invoker", 4157, add="admin-bypass")
 
         run.assert_called_once_with(
@@ -380,15 +433,12 @@ class GhClientLabelEdit(unittest.TestCase):
                 "repos/Neko-Catpital-Labs/Invoker/issues/4157/labels",
                 "-f",
                 "labels[]=admin-bypass",
-            ],
-            check=True,
-            text=True,
-            capture_output=True,
+            ]
         )
 
     def test_remove_label_uses_rest_issue_labels_endpoint(self):
         client = s.GhClient()
-        with mock.patch("mergify_admin_requeue_snapshot.subprocess.run") as run:
+        with mock.patch("mergify_admin_requeue_snapshot.run_logged") as run:
             client.edit_label("Neko-Catpital-Labs/Invoker", 4157, remove="merge-hold")
 
         run.assert_called_once_with(
@@ -398,11 +448,77 @@ class GhClientLabelEdit(unittest.TestCase):
                 "--method",
                 "DELETE",
                 "repos/Neko-Catpital-Labs/Invoker/issues/4157/labels/merge-hold",
-            ],
-            check=True,
-            text=True,
-            capture_output=True,
+            ]
         )
+
+class GhRetryBudgetRespectsWorkerTickTimeout(unittest.TestCase):
+    # The pr-admin-bypass-land worker (packages/execution-engine/src/workers/
+    # pr-maintenance-workers.ts) force-kills the whole script if a tick runs
+    # past its 240s timeout. A run makes 100+ gh calls for ~50 admin-bypass
+    # PRs. If run_logged's own per-call retry budget were allowed to approach
+    # that 240s ceiling, a single stuck call could alone burn the worker's
+    # entire tick budget -- worse than having no retries at all, since the
+    # old behavior at least failed fast. This keeps the two budgets honest
+    # relative to each other without needing a cross-language test harness.
+    WORKER_TICK_TIMEOUT_SECONDS = 240  # pr-maintenance-workers.ts DEFAULT_PR_MAINTENANCE_WORKER_TICK_TIMEOUT_MS
+    MAX_SAFE_FRACTION = 1 / 3  # leave headroom for the other 100+ calls in one tick
+
+    def test_worst_case_single_call_retry_budget_leaves_room_for_the_rest_of_the_tick(self):
+        budget = s.GH_CALL_WORST_CASE_SECONDS
+        ceiling = self.WORKER_TICK_TIMEOUT_SECONDS * self.MAX_SAFE_FRACTION
+        self.assertLess(
+            budget, ceiling,
+            f"one stuck gh call could burn {budget}s, more than {self.MAX_SAFE_FRACTION:.0%} of the worker's "
+            f"{self.WORKER_TICK_TIMEOUT_SECONDS}s tick timeout -- tighten GH_COMMAND_TIMEOUT_SECONDS, "
+            "GH_RETRY_MAX_ATTEMPTS, or GH_RETRY_BACKOFF_SECONDS",
+        )
+
+
+class GhCallsGoThroughRunLogged(unittest.TestCase):
+    # Incident 2026-08-12: multiple `gh` CLI call sites across this script
+    # family bypassed run_logged and had zero retry/timeout protection, so
+    # any transient GitHub API 5xx or hang crashed the whole babysitting
+    # cycle. Five prior PRs (#3224, #5127, #5721, #5483, #5866) fixed
+    # planner/babysitting *logic* but never noticed this gap. This guard
+    # keeps any future `gh` call in this file family routed through
+    # run_logged, so it inherits retry protection automatically instead of
+    # needing a human to remember.
+    def test_no_gh_subprocess_call_bypasses_run_logged(self):
+        root = Path(__file__).resolve().parent
+        offenders: list[str] = []
+        for path in sorted(root.glob("mergify_admin_requeue*.py")):
+            if path.name.startswith("test_"):
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            offenders.extend(self._raw_gh_subprocess_calls(tree, path.name))
+        self.assertEqual(
+            offenders, [],
+            "raw subprocess.run(['gh', ...]) call(s) bypassing run_logged (add via run_logged() instead): "
+            + ", ".join(offenders),
+        )
+
+    @staticmethod
+    def _raw_gh_subprocess_calls(tree: ast.AST, filename: str) -> list[str]:
+        found: list[str] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef) or node.name == "run_logged":
+                continue
+            for call in ast.walk(node):
+                if not (
+                    isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Attribute)
+                    and call.func.attr == "run"
+                    and isinstance(call.func.value, ast.Name)
+                    and call.func.value.id == "subprocess"
+                ):
+                    continue
+                if not call.args or not isinstance(call.args[0], ast.List) or not call.args[0].elts:
+                    continue
+                first = call.args[0].elts[0]
+                if isinstance(first, ast.Constant) and first.value == "gh":
+                    found.append(f"{filename}:{node.name}:{call.lineno}")
+        return found
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
The mergify admin-bypass babysitter dies the instant GitHub's API hiccups
(502/504/stream-reset), even though the exact same call usually succeeds on
a retry seconds later. This has been the dominant cause of the babysitter
"thrashing" over the past month: five prior fix PRs improved its planning
logic, but none touched the transport layer underneath, so a single blip
still killed the whole cycle every time.

run_logged() now retries transient failures up to 3 times with backoff, and
every gh call in the script family is routed through it (a guardrail test
blocks future call sites from bypassing it). The per-call timeout is tuned
so a stuck call can't alone exceed the worker's own 240s tick budget.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>