### PR TITLE
[Mergify admin-bypass fault tolerance](3) Settle repair-noop/repair-invalid for PR Body

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -207,6 +207,19 @@ def run_cycle(args: argparse.Namespace) -> bool:
                                     pr_number=pr.number,
                                     check_name=check_name,
                                 )
+                            elif outcome.status == "noop" and check_name == "PR Body":
+                                # See plan.py's plan_stack_execution: without this record,
+                                # a PR whose body is already valid (or whose PR was merged/
+                                # closed mid-repair) keeps re-running the same local PR-Body
+                                # checkout+validate cycle every tick instead of the bottom
+                                # check staying suppressed.
+                                ledger.record("repair-noop", pr.number, pr.head_ref_oid, check_name, now)
+                                logger.trace(
+                                    "admin-bypass-repair-noop",
+                                    repo=args.repo,
+                                    pr_number=pr.number,
+                                    check_name=check_name,
+                                )
                             progressed = outcome.status in {"pushed", "prereq_created", "submitted", "queue_only_noop"}
                 except Exception as exc:
                     repair_dispatch_attempted += 1

--- a/scripts/mergify_admin_requeue_repair_normalize.py
+++ b/scripts/mergify_admin_requeue_repair_normalize.py
@@ -74,6 +74,52 @@ def _record_queue_only_noop_if_applicable(
         Ledger(state_file).record("queue-only-noop", pr_number, start_head, check_name)
 
 
+# The agent repair task made no commit for a failing "PR Body" check. Two
+# very different situations look identical from here, so decide which one it
+# is by re-checking validity now:
+#   - the body is actually fine (already valid, or the PR was merged/closed
+#     out from under the repair mid-flight, so there's nothing left to fix) --
+#     record "repair-noop", which plan.py's plan_stack_execution reads
+#     (hardcoded to the "PR Body" key) to stop treating this check as blocking.
+#   - the body is still invalid, and the agent had every chance to fix it but
+#     didn't -- that's a human decision, not something worth re-submitting
+#     every tick. Record "repair-invalid" (see plan.py's
+#     latest_repair_invalid_blocker, which reads it into a human_decision
+#     blocker) and post the stop comment once, the same shape
+#     AdminBypassGhExecutor.comment_blocked posts from the synchronous path.
+# Deliberately NOT decided at submission time (see
+# repro-babysit-pr-body-human-split.sh): a real agent might still fix a body
+# that looks invalid right now, so the async repair always gets the chance to
+# try before anything here calls it unfixable.
+def _record_repair_noop_or_invalid_for_pr_body(
+    state_file: Path, repo: str, pr_number: int, start_head: str, check_name: str, base: str, cwd: Path,
+) -> None:
+    if check_name != "PR Body":
+        return
+    gh = GhClient()
+    detail = gh.pr_detail(repo, pr_number)
+    ledger = Ledger(state_file)
+    if str(detail.get("state") or "OPEN") != "OPEN":
+        # The PR was merged or closed while the repair was in flight. There is
+        # no longer a base to diff against (an orphaned/merged branch may not
+        # even share history with it), and nothing left to fix either way.
+        ledger.record("repair-noop", pr_number, start_head, check_name)
+        return
+    body = str(detail.get("body") or "")
+    validation = validate_current_pr_body(cwd, body, base)
+    if validation.get("valid"):
+        ledger.record("repair-noop", pr_number, start_head, check_name)
+        return
+    errors = invalid_repair_errors(validation, base)
+    if not errors:
+        return
+    ledger.record("repair-invalid", pr_number, start_head, check_name, meta={"errors": errors})
+    stop_body = "Mergify repair stopped: " + "\n".join(errors)
+    existing = gh.issue_comments(repo, pr_number)
+    if not any(str(comment.get("body") or "").strip() == stop_body for comment in existing):
+        gh.comment(repo, pr_number, stop_body)
+
+
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Normalize an async admin-bypass repair commit before safe-push.")
     parser.add_argument("--repo", required=True)
@@ -107,12 +153,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     end_head = git_output(cwd, "rev-parse", "HEAD").strip()
     if end_head == start_head:
         _record_queue_only_noop_if_applicable(state_file, args.pr, start_head, args.check)
+        _record_repair_noop_or_invalid_for_pr_body(state_file, args.repo, args.pr, start_head, args.check, args.base, cwd)
         print("noop: repair task made no commit")
         return 0
 
     end_head = normalize_repair_commit(cwd, start_head, end_head, args.check)
     if end_head == start_head:
         _record_queue_only_noop_if_applicable(state_file, args.pr, start_head, args.check)
+        _record_repair_noop_or_invalid_for_pr_body(state_file, args.repo, args.pr, start_head, args.check, args.base, cwd)
         print("noop: repair diff was empty after normalization")
         return 0
 

--- a/scripts/repro/repro-babysit-amended-repair-push.sh
+++ b/scripts/repro/repro-babysit-amended-repair-push.sh
@@ -123,6 +123,43 @@ git clone "$REMOTE" "$WORK_ROOT" >/dev/null
 ( cd "$WORK_ROOT" && git config user.email repro@example.test && git config user.name 'Repro Bot' )
 write_state
 
+# Incident 2026-08-12: resolve_workflow_for_pr and submit_async_repair_plan
+# both default to a live Invoker owner over IPC, which this hermetic repro
+# never provides. Mock both env hooks (same pattern as
+# repro-babysit-pr-body-human-split.sh) and simulate the real 3-task async
+# plan in order: repair (the claude wrapper above amends the commit),
+# normalize (validates + prepares the push), safe-push (the real script the
+# generated plan's safe-push task runs).
+cat > "$TMP/review-gate.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{}\n'
+EOF
+chmod +x "$TMP/review-gate.sh"
+export INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh"
+
+cat > "$TMP/bin/submit-async.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+plan_path="\${1:?plan path required}"
+test -f "\$plan_path"
+cd "$WORK_ROOT"
+git fetch origin stack/5806 >/dev/null
+git checkout stack/5806 >/dev/null 2>&1
+"$TMP/bin/claude"
+python3 "$ROOT/scripts/mergify_admin_requeue_repair_normalize.py" \\
+  --repo fake/repo --pr 5806 --check "PR Body" \\
+  --start-head "$ORIGINAL_HEAD" --base master --trunk master \\
+  --state-file "$LEDGER_PATH"
+python3 "$ROOT/scripts/pr_worker_safe_push.py" \\
+  --branch stack/5806 --expected-head "$ORIGINAL_HEAD" --cwd . \\
+  --record-json-ledger "$LEDGER_PATH" \\
+  --json-kind repair-check-settled --json-pr 5806 \\
+  --json-head-sha "$ORIGINAL_HEAD" --json-key "PR Body"
+EOF
+chmod +x "$TMP/bin/submit-async.sh"
+export INVOKER_ADMIN_BYPASS_ASYNC_REPAIR_SUBMIT_CMD="$TMP/bin/submit-async.sh"
+
 if ! out="$(run_worker)"; then
   fail 'worker failed to push amended repair as descendant' "$out"
 fi

--- a/scripts/repro/repro-babysit-merged-during-repair.sh
+++ b/scripts/repro/repro-babysit-merged-during-repair.sh
@@ -59,6 +59,12 @@ export HEAD_SHA
 git -C "$TMP/seed" push -q origin HEAD:refs/heads/stack/6111
 mkdir -p "$(dirname "$WORK_ROOT")"
 git clone -q "$ORIGIN" "$WORK_ROOT"
+# $ORIGIN's bare HEAD is never set to a real branch (only master and
+# stack/6111 exist, pushed as two disconnected roots), so the clone above
+# leaves $WORK_ROOT in a headless state -- check out the PR's own branch
+# explicitly, matching what a real async repair task's checkout would do.
+git -C "$WORK_ROOT" fetch -q origin stack/6111
+git -C "$WORK_ROOT" checkout -q stack/6111
 
 cat > "$TMP/bin/claude" <<'SH'
 #!/usr/bin/env bash
@@ -79,6 +85,17 @@ PY
 echo "fake repair: PR merged during repair"
 SH
 chmod +x "$TMP/bin/claude"
+
+# resolve_workflow_for_pr defaults to a live Invoker owner over IPC when this
+# is unset; mock it to report a genuine miss (no local workflow), so this
+# repro is fully hermetic instead of depending on real local Invoker state.
+cat > "$TMP/review-gate.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{}\n'
+EOF
+chmod +x "$TMP/review-gate.sh"
+export INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh"
 
 python3 - <<'PY'
 import json
@@ -122,6 +139,26 @@ Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding=
 PY
 : > "$LEDGER_PATH"
 : > "$CALLS_PATH"
+
+# Incident 2026-08-12: submit_async_repair_plan's default path shells out to a
+# live Invoker owner over IPC, which this hermetic repro never provides.
+# Mock it (same pattern as repro-babysit-pr-body-human-split.sh): run the
+# claude wrapper above (marks the PR merged mid-repair, makes no commit),
+# then the real normalize step against that no-op outcome.
+cat > "$TMP/bin/submit-async.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+plan_path="\${1:?plan path required}"
+test -f "\$plan_path"
+cd "$WORK_ROOT"
+"$TMP/bin/claude"
+python3 "$ROOT/scripts/mergify_admin_requeue_repair_normalize.py" \\
+  --repo fake/repo --pr 6111 --check "PR Body" \\
+  --start-head "$HEAD_SHA" --base master --trunk master \\
+  --state-file "$LEDGER_PATH"
+EOF
+chmod +x "$TMP/bin/submit-async.sh"
+export INVOKER_ADMIN_BYPASS_ASYNC_REPAIR_SUBMIT_CMD="$TMP/bin/submit-async.sh"
 
 if ! out="$(python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6111 2>&1)"; then
   fail 'worker failed after PR merged during repair' "$out"

--- a/scripts/repro/repro-babysit-pr-body-prereq-split.sh
+++ b/scripts/repro/repro-babysit-pr-body-prereq-split.sh
@@ -216,10 +216,43 @@ fi
 write_state
 : > "$CALLS_PATH"
 
+# Incident 2026-08-12: submit_async_repair_plan's default path shells out to a
+# live Invoker owner over IPC (scripts/headless-ipc.js), which this hermetic
+# repro never provides -- every tick just crashed with "No request handler
+# registered for channel: headless.run". Mock the submit command (same
+# pattern as repro-babysit-pr-body-human-split.sh) and simulate what the real
+# async plan's two tasks do for this scenario: the "repair" task runs the
+# fake claude wrapper above (already set up to make the tooling-policy commit
+# this PR needs), then the real "normalize" task runs against that commit --
+# same script, same args the real generated plan YAML would use.
+cat > "$TMP/bin/submit-async.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+plan_path="\${1:?plan path required}"
+test -f "\$plan_path"
+cd "$WORK_ROOT"
+git fetch origin stack/5800 >/dev/null
+git checkout stack/5800 >/dev/null 2>&1
+"$TMP/bin/claude"
+python3 "$ROOT/scripts/mergify_admin_requeue_repair_normalize.py" \\
+  --repo fake/repo --pr 5800 --check "required-fast / Guardrails" \\
+  --start-head "$ORIGINAL_HEAD" --base master --trunk master \\
+  --state-file "$LEDGER_PATH"
+EOF
+chmod +x "$TMP/bin/submit-async.sh"
+export INVOKER_ADMIN_BYPASS_ASYNC_REPAIR_SUBMIT_CMD="$TMP/bin/submit-async.sh"
+
 if ! out1="$(run_worker)"; then
   fail 'tick 1: worker failed' "$out1"
 fi
-echo "$out1" | grep -q 'admin-bypass-repair-prereq-created' || fail 'tick 1: missing prerequisite creation trace' "$out1"
+# admin-bypass-repair-prereq-created is logged inside create_repair_prerequisite
+# (mergify_admin_requeue_repair_body.py), which since PR #5483 only runs inside
+# the async-submitted subprocess (mergify_admin_requeue_repair_normalize.py via
+# INVOKER_ADMIN_BYPASS_ASYNC_REPAIR_SUBMIT_CMD above) -- its stdout is captured
+# by run_headless and never reaches $out1, so grepping for it here can never
+# pass again under the current architecture. assert_tick1_state below is the
+# real, still-valid check: it confirms prerequisite PR #5801 actually exists
+# with the right label in the fake-gh state.
 assert_tick1_state
 
 remove_prereq

--- a/scripts/repro/repro-babysit-pr-body-proof-human-split.sh
+++ b/scripts/repro/repro-babysit-pr-body-proof-human-split.sh
@@ -53,6 +53,17 @@ exec /usr/bin/env node "$@"
 EOF
 chmod +x "$TMP/bin/node"
 
+# Incident 2026-08-12: resolve_workflow_for_pr defaults to a live Invoker
+# owner over IPC, which this hermetic repro never provides. Mock it to report
+# a genuine miss (no local workflow), same as repro-babysit-pr-body-human-split.sh.
+cat > "$TMP/review-gate.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{}\n'
+EOF
+chmod +x "$TMP/review-gate.sh"
+export INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh"
+
 BODY_PATH="$TMP/body.md"
 cat > "$BODY_PATH" <<'EOF'
 ## Summary
@@ -217,6 +228,30 @@ export ORIGINAL_HEAD
 git clone "$REMOTE" "$WORK_ROOT" >/dev/null
 ( cd "$WORK_ROOT" && git config user.email repro@example.test && git config user.name 'Repro Bot' )
 write_state
+
+# Incident 2026-08-12: submit_async_repair_plan's default path shells out to a
+# live Invoker owner over IPC, which this hermetic repro never provides. Mock
+# it (same pattern as repro-babysit-pr-body-human-split.sh) and simulate the
+# real async plan: the repair agent (the claude wrapper above) makes no
+# commit, then the real normalize step decides noop vs. human-split-invalid
+# from the PR's still-unchanged body -- deliberately not decided any earlier
+# than this, so a real agent always gets a genuine chance to fix it first.
+cat > "$TMP/bin/submit-async.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+plan_path="\${1:?plan path required}"
+test -f "\$plan_path"
+cd "$WORK_ROOT"
+git fetch origin stack/5804 >/dev/null
+git checkout stack/5804 >/dev/null 2>&1
+"$TMP/bin/claude"
+python3 "$ROOT/scripts/mergify_admin_requeue_repair_normalize.py" \\
+  --repo fake/repo --pr 5804 --check "PR Body" \\
+  --start-head "$ORIGINAL_HEAD" --base stack/base --trunk master \\
+  --state-file "$LEDGER_PATH"
+EOF
+chmod +x "$TMP/bin/submit-async.sh"
+export INVOKER_ADMIN_BYPASS_ASYNC_REPAIR_SUBMIT_CMD="$TMP/bin/submit-async.sh"
 
 if ! out1="$(run_worker)"; then
   fail 'tick 1: worker failed' "$out1"

--- a/scripts/test_mergify_admin_requeue_repair_normalize.py
+++ b/scripts/test_mergify_admin_requeue_repair_normalize.py
@@ -110,19 +110,97 @@ class RepairNormalizeTests(unittest.TestCase):
         self.assertIn("blocked_dirty", stderr.getvalue())
         self.assertIn("?? stray.txt", stderr.getvalue())
 
-    def test_no_commit_returns_zero_without_further_work(self):
+    def test_no_commit_on_valid_pr_body_records_repair_noop(self):
+        # Incident 2026-08-12: deliberately NOT decided at submission time (see
+        # repro-babysit-pr-body-human-split.sh's comment) -- a real agent might
+        # still fix a body that looked invalid at submission, so this check is
+        # only made here, after the agent has already had its chance and made
+        # no commit either way.
         with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
             with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=HEAD):
                 with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
-                    code = normalize.main(self.argv())
+                    gh_cls.return_value.pr_detail.return_value = {"body": "## Summary\n\nok\n"}
+                    with mock.patch(
+                        "scripts.mergify_admin_requeue_repair_normalize.validate_current_pr_body",
+                        return_value={"valid": True, "errors": []},
+                    ):
+                        code = normalize.main(self.argv())
         self.assertEqual(code, 0)
-        gh_cls.assert_not_called()
+        self.assertEqual(self.kind_rows("repair-noop"), self.kind_rows("repair-noop"))
+        rows = self.kind_rows("repair-noop")
+        self.assertEqual(len(rows), 1)
+        self.assertIn('"pr": 2647', rows[0])
+        gh_cls.return_value.comment.assert_not_called()
         self.assertEqual(self.queue_only_noop_rows(), [])
 
-    def queue_only_noop_rows(self):
+    def test_no_commit_on_merged_pr_records_repair_noop_without_diffing(self):
+        # Incident 2026-08-12 (repro-babysit-merged-during-repair.sh): the PR
+        # merged/closed out from under an in-flight repair. It may not even
+        # share history with its base anymore (an orphan branch, say), so
+        # diffing for PR-body validation must never be attempted here --
+        # only that the state is terminal.
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
+                    gh_cls.return_value.pr_detail.return_value = {"state": "MERGED", "body": "## Summary\n\nok\n"}
+                    with mock.patch(
+                        "scripts.mergify_admin_requeue_repair_normalize.validate_current_pr_body",
+                    ) as validate:
+                        code = normalize.main(self.argv())
+        self.assertEqual(code, 0)
+        self.assertEqual(len(self.kind_rows("repair-noop")), 1)
+        validate.assert_not_called()
+
+    def test_no_commit_on_invalid_pr_body_records_repair_invalid_and_comments_once(self):
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
+                    gh_cls.return_value.pr_detail.return_value = {"body": "## Summary\n\nmixed\n"}
+                    gh_cls.return_value.issue_comments.return_value = []
+                    with mock.patch(
+                        "scripts.mergify_admin_requeue_repair_normalize.validate_current_pr_body",
+                        return_value=MANUAL_SPLIT_VALIDATION,
+                    ):
+                        code = normalize.main(self.argv(**{"--base": "stack/base"}))
+        self.assertEqual(code, 0)
+        rows = self.kind_rows("repair-invalid")
+        self.assertEqual(len(rows), 1)
+        self.assertIn('"pr": 2647', rows[0])
+        self.assertIn("human stack split required", rows[0])
+        gh_cls.return_value.comment.assert_called_once()
+        posted_body = gh_cls.return_value.comment.call_args.args[-1]
+        self.assertTrue(posted_body.startswith("Mergify repair stopped: "))
+        self.assertIn("human stack split required", posted_body)
+
+    def test_no_commit_on_invalid_pr_body_does_not_double_post_existing_comment(self):
+        stop_body = (
+            "Mergify repair stopped: PR body mentions multiple review units (validation-policy, routing); "
+            "split into one conceptual unit per diff/task.\n"
+            'PR body Review Unit "routing" cannot ship with tooling-policy, proof files in the same PR. '
+            "Split this into one Review Unit per PR.\n"
+            "worker cannot auto-split this PR on a non-trunk base; human stack split required"
+        )
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
+                    gh_cls.return_value.pr_detail.return_value = {"body": "## Summary\n\nmixed\n"}
+                    gh_cls.return_value.issue_comments.return_value = [{"body": stop_body}]
+                    with mock.patch(
+                        "scripts.mergify_admin_requeue_repair_normalize.validate_current_pr_body",
+                        return_value=MANUAL_SPLIT_VALIDATION,
+                    ):
+                        code = normalize.main(self.argv(**{"--base": "stack/base"}))
+        self.assertEqual(code, 0)
+        self.assertEqual(len(self.kind_rows("repair-invalid")), 1)
+        gh_cls.return_value.comment.assert_not_called()
+
+    def kind_rows(self, kind):
         if not self.state_file.exists():
             return []
-        return [line for line in self.state_file.read_text(encoding="utf-8").splitlines() if '"queue-only-noop"' in line]
+        return [line for line in self.state_file.read_text(encoding="utf-8").splitlines() if f'"{kind}"' in line]
+
+    def queue_only_noop_rows(self):
+        return self.kind_rows("queue-only-noop")
 
     def test_no_commit_on_queue_only_check_records_queue_only_noop(self):
         # Incident 2026-08-12: an async repair for a queue-only required check


### PR DESCRIPTION
Two more ledger kinds the planner reads to decide a PR's fate were never
written by anything: "repair-noop" (this PR-Body check is actually fine, or
the PR got merged/closed out from under an in-flight repair) and
"repair-invalid" (the body is genuinely broken in a way no code change can
fix, e.g. a non-trunk-base manual split). Both silently fell through to
resubmitting the same doomed repair every single tick forever.

The decision is made only after the agent's real repair attempt already ran
and made no commit -- never short-circuited earlier, so a real agent always
gets its genuine shot at a fix first. A merged/closed PR skips diffing
entirely (an orphaned branch may not even share history with its base). The
stop comment posted for a real "repair-invalid" verdict is deduplicated
against both the ledger and existing PR comments.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Depends-On: #8743