### PR TITLE
[Mergify admin-bypass fault tolerance](4) Auto-discover the required CI suite

### DIFF
--- a/scripts/test-suites/required/12-mergify-admin-requeue.sh
+++ b/scripts/test-suites/required/12-mergify-admin-requeue.sh
@@ -2,16 +2,41 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
+
+# Incident 2026-08-12: this suite used to hand-list specific test files and
+# repro scripts. New test files and repro scripts kept getting written and
+# merged (some PRs even self-reported running them in their own checklist)
+# without ever being added to this list, so they were never enforced again
+# after the PR that added them landed -- one of those repros went on to sit
+# broken on master for weeks with nobody noticing. Discover both sets instead
+# of hand-listing them, so a new repro or test file is automatically part of
+# this required gate the moment it's added.
+#
+# Excluded on purpose: repro-mergify-stack-dogfood.sh needs live GitHub
+# credentials and pushes real disposable branches/PRs to a real repo -- not
+# safe or hermetic for an automated CI runner. It stays a manual/local check.
+DOGFOOD_EXCLUSIONS=(
+  "scripts/repro/repro-mergify-stack-dogfood.sh"
+)
+
+is_excluded() {
+  local candidate="$1"
+  for excluded in "${DOGFOOD_EXCLUSIONS[@]}"; do
+    if [ "$candidate" = "$excluded" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 python3 -m unittest scripts/test_pr_worker_safe_push.py
-python3 -m unittest scripts/test_mergify_admin_requeue.py
-python3 -m unittest scripts/test_mergify_admin_requeue_plan.py
-python3 -m unittest scripts/test_mergify_admin_requeue_repair_body.py
-bash scripts/repro/repro-mergify-admin-requeue.sh
-bash scripts/repro/repro-mergify-admin-requeue-stack-expansion.sh
-bash scripts/repro/repro-mergify-rejected-pr.sh
-bash scripts/repro/repro-mergify-closed-pr-guard.sh
-bash scripts/repro/repro-babysit-pr-body-human-split.sh
-bash scripts/repro/repro-babysit-no-current-bottom-comment.sh
-bash scripts/repro/repro-babysit-retarget-stale-bottom-base.sh
-bash scripts/repro/repro-babysit-rebase-onto-base.sh
-bash scripts/repro/repro-babysit-stale-base-skips-agent-repair.sh
+
+for test_file in scripts/test_mergify_admin_requeue*.py; do
+  python3 -m unittest "$test_file"
+done
+
+for repro in scripts/repro/repro-*.sh; do
+  is_excluded "$repro" && continue
+  grep -q "mergify_admin_requeue" "$repro" || continue
+  bash "$repro"
+done


### PR DESCRIPTION
## Summary

The required CI suite for this feature hand-listed 4 test files and 8 repro scripts. The feature now has 10 test files and 33 relevant repro scripts. Most were never added to this list, so they ran once at review time and then rotted unenforced.

One of those unenforced repros (`repro-babysit-queue-only-check.sh`) sat broken on master for weeks this way, caught only by chance during an unrelated investigation into why admin-bypass PRs kept getting stuck.

## Review Claim

The required suite now discovers its test files and repro scripts by content instead of a hand-maintained list, so a new one is automatically enforced the moment it's added.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The explicit exclusion list only removes the one repro needing live GitHub credentials that mutates a real repo (`repro-mergify-stack-dogfood.sh`). Every other repro/test file discovered by content-match still runs — nothing silently drops out of the required gate.

## Slice Rationale

Landing last in this stack because it depends on every repro script from slices 1-3 already being fixed and green; wiring auto-discovery in earlier would have made the required suite red mid-stack.

## Non-goals

Does not change any product code or test behavior. Does not add new tests or repro scripts.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-suites/required/12-mergify-admin-requeue.sh` (full run: 10 test-module runs + all discovered repro scripts, all green)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
