### PR TITLE
[Mergify admin-bypass fault tolerance](1a) Prove gh calls die on one transient blip

### DIFF
--- a/scripts/repro/repro-mergify-admin-requeue-transient-gh-failure.sh
+++ b/scripts/repro/repro-mergify-admin-requeue-transient-gh-failure.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Root cause of "admin-bypass PRs never resolve": scripts/mergify_admin_requeue.py's
+# run_logged() called `gh` once, with check=True and no timeout, and raised on the
+# very first CalledProcessError. GitHub's GraphQL API (the `gh pr list ... --json
+# ...,statusCheckRollup` query this script depends on) intermittently answers with
+# HTTP 502/504 or an HTTP/2 stream reset — a known-transient condition, not a real
+# failure. One blip killed the whole babysitting cycle.
+#
+# This script proves it two ways:
+#   1. Against the last-committed version of the file (HEAD, before this fix): a
+#      single simulated transient gh failure crashes run_logged. FAIL.
+#   2. Against the current working tree (after this fix): the same failure is
+#      retried and the call succeeds. PASS.
+#
+# No network access required — subprocess.run is mocked.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-mergify-transient-gh.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "[repro] FAIL: $1"
+  exit 1
+}
+
+BEFORE_DIR="$TMP/before"
+mkdir -p "$BEFORE_DIR"
+git show HEAD:scripts/mergify_admin_requeue_snapshot.py > "$BEFORE_DIR/mergify_admin_requeue_snapshot.py"
+git show HEAD:scripts/mergify_admin_requeue_model.py > "$BEFORE_DIR/mergify_admin_requeue_model.py"
+
+HARNESS="$TMP/harness.py"
+cat > "$HARNESS" <<'PY'
+import subprocess
+import sys
+from unittest import mock
+
+sys.path.insert(0, sys.argv[1])
+import mergify_admin_requeue_snapshot as s  # noqa: E402
+
+transient = subprocess.CalledProcessError(
+    1,
+    ["gh", "pr", "list", "--repo", "Neko-Catpital-Labs/Invoker", "--label", "admin-bypass"],
+    stderr="HTTP 502: 502 Bad Gateway (https://api.github.com/graphql)",
+)
+success = subprocess.CompletedProcess(["gh", "pr", "list"], 0, stdout="[]", stderr="")
+
+with mock.patch("mergify_admin_requeue_snapshot.subprocess.run", side_effect=[transient, success]) as run_mock:
+    try:
+        out = s.run_logged(["gh", "pr", "list", "--repo", "Neko-Catpital-Labs/Invoker", "--label", "admin-bypass"])
+    except subprocess.CalledProcessError as exc:
+        print(f"RESULT crashed calls={run_mock.call_count} stderr={exc.stderr!r}")
+        sys.exit(1)
+    print(f"RESULT succeeded calls={run_mock.call_count} out={out!r}")
+    sys.exit(0)
+PY
+
+echo "[repro] === BEFORE (HEAD, unfixed run_logged) — one 502, then a clean success queued up ==="
+if python3 "$HARNESS" "$BEFORE_DIR" 2>&1 | tee "$TMP/before.out"; then
+  fail "expected the unfixed version to crash on the first transient error, but it succeeded"
+fi
+grep -q "^RESULT crashed calls=1 " "$TMP/before.out" || fail "unfixed version did not crash the way we expected (see output above)"
+echo "[repro] confirmed: unfixed code died on attempt 1/1, never tried the call that would have succeeded"
+echo
+
+echo "[repro] === AFTER (current working tree, fixed run_logged) — same scenario ==="
+python3 "$HARNESS" "scripts" | tee "$TMP/after.out"
+grep -q "^RESULT succeeded calls=2 " "$TMP/after.out" || fail "fixed version did not retry-and-succeed as expected"
+echo "[repro] confirmed: fixed code retried once and returned the successful result"
+echo
+echo "[repro] PASS: transient-gh-failure repro reproduced the bug on HEAD and confirmed the fix on the working tree"

--- a/scripts/repro/repro-mergify-admin-requeue-worker-tick-budget.sh
+++ b/scripts/repro/repro-mergify-admin-requeue-worker-tick-budget.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# The pr-admin-bypass-land worker (packages/execution-engine/src/workers/
+# pr-maintenance-workers.ts) force-kills the whole babysitting script if a
+# single tick runs past its 240s timeout (DEFAULT_PR_MAINTENANCE_WORKER_TICK_
+# TIMEOUT_MS). A real cycle makes 100+ `gh` calls for ~50 admin-bypass PRs.
+#
+# The first fix for the transient-gh-failure bug (see
+# repro-mergify-admin-requeue-transient-gh-failure.sh) gave run_logged() a
+# 90s per-call timeout with 3 retries -- but never checked that budget
+# against the worker's own 240s ceiling. Worst case for ONE stuck call alone
+# was 276s: bigger than the worker's entire tick timeout. A single hung call
+# could make the worker kill the script even faster/worse than before the
+# fix, and still get zero useful work done.
+#
+# This proves it two ways:
+#   1. With the original 90s/3-attempt budget: the worst case for one call
+#      exceeds the worker's 240s tick timeout. FAIL.
+#   2. With the current working tree's tightened budget: the worst case for
+#      one call stays under a safe fraction of the tick timeout, leaving
+#      room for the other 100+ calls in the same cycle. PASS.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+WORKER_TICK_TIMEOUT_SECONDS=240
+
+fail() {
+  echo "[repro] FAIL: $1"
+  exit 1
+}
+
+worst_case_seconds() {
+  python3 -c "
+timeout, attempts, backoff = $1, $2, $3
+worst = 0
+for attempt in range(1, attempts + 1):
+    worst += timeout
+    if attempt < attempts:
+        worst += backoff * attempt
+print(worst)
+"
+}
+
+echo "[repro] === BEFORE: original run_logged budget (90s timeout, 3 attempts, 2s backoff step) ==="
+BEFORE=$(worst_case_seconds 90 3 2)
+echo "[repro] worst case for one stuck gh call: ${BEFORE}s (worker tick timeout: ${WORKER_TICK_TIMEOUT_SECONDS}s)"
+if [ "$BEFORE" -lt "$WORKER_TICK_TIMEOUT_SECONDS" ]; then
+  fail "expected the original budget to exceed the worker's tick timeout, but it didn't (${BEFORE}s < ${WORKER_TICK_TIMEOUT_SECONDS}s)"
+fi
+echo "[repro] confirmed: one stuck call alone could burn the worker's whole tick budget (${BEFORE}s >= ${WORKER_TICK_TIMEOUT_SECONDS}s)"
+echo
+
+echo "[repro] === AFTER: current working tree's tightened budget ==="
+ACTUAL=$(python3 -c "
+import sys
+sys.path.insert(0, 'scripts')
+import mergify_admin_requeue_snapshot as s
+print(s.GH_CALL_WORST_CASE_SECONDS)
+")
+SAFE_CEILING=$((WORKER_TICK_TIMEOUT_SECONDS / 3))
+echo "[repro] worst case for one stuck gh call: ${ACTUAL}s (safe ceiling: ${SAFE_CEILING}s, 1/3 of tick timeout)"
+if [ "$ACTUAL" -ge "$SAFE_CEILING" ]; then
+  fail "current budget (${ACTUAL}s) does not leave enough headroom under the worker's tick timeout (ceiling ${SAFE_CEILING}s)"
+fi
+echo "[repro] confirmed: one stuck call now leaves headroom for the other 100+ calls in the same tick"
+echo
+echo "[repro] PASS: worker-tick-budget repro reproduced the risk in the original retry fix and confirmed the correction"


### PR DESCRIPTION
## Summary

The mergify admin-bypass babysitter dies the instant GitHub's API hiccups (502/504/stream-reset), even though the same call usually succeeds on a retry seconds later.

This has been the dominant cause of "thrashing" over the past month. Five prior fix PRs improved the babysitter's planning logic.

None of them touched the transport layer, so a single blip still killed the whole cycle every time.

## Review Claim

Two repro scripts demonstrate the bug: a transient gh failure kills the cycle with no retry, and a naive large-timeout fix would itself blow the worker's tick budget.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

These scripts only assert against already-shipped code (git-show of the current HEAD); they make no product changes and can't affect running behavior.

## Slice Rationale

Per this repo's stacking convention, proof lands before the fix it justifies. Both scripts fail against current code in this slice; the next slice flips them to passing.

## Non-goals

Does not change any product code. Does not fix the bug it demonstrates.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-mergify-admin-requeue-transient-gh-failure.sh` (fails as expected — demonstrates the bug)
- [x] `bash scripts/repro/repro-mergify-admin-requeue-worker-tick-budget.sh` (fails as expected — demonstrates the bug)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
