### PR TITLE
[Mergify admin-bypass fault tolerance](2b) Restore admin-bypass label after a queue-only noop

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -194,7 +194,20 @@ def run_cycle(args: argparse.Namespace) -> bool:
                             progressed = True
                         else:
                             outcome = repairer.repair_check(pr, check_name, now)
-                            progressed = outcome.status in {"pushed", "prereq_created", "submitted"}
+                            if outcome.status == "queue_only_noop":
+                                # See plan.py's latest_queue_only_noop_check: without this
+                                # record, a queue-only check with an empty job log settles
+                                # here and then goes nowhere -- plan_bottom_progress can
+                                # never see it, so the admin-bypass label never comes back
+                                # and the PR is stuck outside the queue for good.
+                                ledger.record("queue-only-noop", pr.number, pr.head_ref_oid, check_name, now)
+                                logger.trace(
+                                    "admin-bypass-queue-only-noop",
+                                    repo=args.repo,
+                                    pr_number=pr.number,
+                                    check_name=check_name,
+                                )
+                            progressed = outcome.status in {"pushed", "prereq_created", "submitted", "queue_only_noop"}
                 except Exception as exc:
                     repair_dispatch_attempted += 1
                     repair_dispatch_failed += 1

--- a/scripts/mergify_admin_requeue_repair_normalize.py
+++ b/scripts/mergify_admin_requeue_repair_normalize.py
@@ -11,6 +11,7 @@ sys.dont_write_bytecode = True
 try:
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Ledger
+    from .mergify_admin_requeue_plan import is_queue_only_required_check
     from .mergify_admin_requeue_repair_body import (
         create_repair_prerequisite,
         git_lines,
@@ -25,6 +26,7 @@ try:
 except ImportError:
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Ledger
+    from mergify_admin_requeue_plan import is_queue_only_required_check
     from mergify_admin_requeue_repair_body import (
         create_repair_prerequisite,
         git_lines,
@@ -55,6 +57,21 @@ PREREQ_SENTINEL = Path(".invoker-repair-prereq-created")
 # this write, and that's exactly the case the in-flight TTL exists to bound.
 def _record_settle_marker(state_file: Path, pr_number: int, start_head: str, check_name: str) -> None:
     Ledger(state_file).record("repair-check-settled", pr_number, start_head, check_name)
+
+
+# A queue-only required check (see is_queue_only_required_check) never runs on
+# an ordinary PR head, only on the merge-queue draft -- so an agent repair
+# attempt against it settling with no commit isn't "nothing needed fixing", it
+# means the check's failure can't be repaired locally at all. plan.py's
+# plan_bottom_progress reads for this exact ("queue-only-noop", pr, headSha,
+# check) row to know it can restore the admin-bypass label and let Mergify's
+# queue retry the check for real, instead of leaving the PR permanently
+# unlabeled with no path back into the queue.
+def _record_queue_only_noop_if_applicable(
+    state_file: Path, pr_number: int, start_head: str, check_name: str,
+) -> None:
+    if is_queue_only_required_check(check_name):
+        Ledger(state_file).record("queue-only-noop", pr_number, start_head, check_name)
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
@@ -89,11 +106,13 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     end_head = git_output(cwd, "rev-parse", "HEAD").strip()
     if end_head == start_head:
+        _record_queue_only_noop_if_applicable(state_file, args.pr, start_head, args.check)
         print("noop: repair task made no commit")
         return 0
 
     end_head = normalize_repair_commit(cwd, start_head, end_head, args.check)
     if end_head == start_head:
+        _record_queue_only_noop_if_applicable(state_file, args.pr, start_head, args.check)
         print("noop: repair diff was empty after normalization")
         return 0
 

--- a/scripts/test_mergify_admin_requeue.py
+++ b/scripts/test_mergify_admin_requeue.py
@@ -865,6 +865,56 @@ Failing checks
         refreshed = Ledger(ledger.path)
         self.assertEqual(refreshed.count("queue-only-requeue", 5811, HEAD, "required-fast / Guardrails"), 1)
 
+    def test_run_cycle_records_queue_only_noop_from_empty_job_log_repair(self):
+        # Incident 2026-08-12: plan_bottom_progress's restore_admin_bypass_label
+        # only fires once a "queue-only-noop" ledger row exists (see
+        # test_run_cycle_restores_label_then_requeues_after_queue_only_noop,
+        # which pre-seeds one). Nothing ever wrote that row: repair_check's
+        # own "queue_only_noop" outcome was silently dropped by run_cycle's
+        # dispatch loop, so a real queue-only check with an empty job log
+        # settled and then went nowhere -- the PR stayed unlabeled forever.
+        # This proves run_cycle itself now writes the row, with no pre-seed.
+        class FakeGh:
+            def __init__(self):
+                self.comments = []
+                self.label_edits = []
+
+            def comment(self, repo, pr_number, body):
+                self.comments.append((repo, pr_number, body))
+
+            def edit_label(self, repo, pr_number, *, add=None, remove=None):
+                self.label_edits.append((repo, pr_number, add, remove))
+
+        ledger = self.ledger()
+        latest = MergifyQueueEvent(
+            "m5811",
+            "dequeued",
+            "admin-bypass",
+            "2026-07-03T06:13:00Z",
+            HEAD,
+            (),
+            ("required-fast / Guardrails",),
+            "https://github.com/Neko-Catpital-Labs/Invoker/pull/5811#issuecomment-1",
+            5854,
+            (("required-fast / Guardrails", ("https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/1/job/2",)),),
+        )
+        fake_gh = FakeGh()
+        stack = StackGroup("orig", (pr(5811, labels={"dequeued"}, checks={}, latest=latest),))
+        empty_log = tempfile.NamedTemporaryFile(delete=False)
+        self.addCleanup(lambda: os.unlink(empty_log.name))
+        stderr = io.StringIO()
+        stdout = io.StringIO()
+        with mock.patch.object(exec_impl, "load_mergify_rules", return_value=("master", frozenset({"admin-bypass"}), {"required-fast / Guardrails"})):
+            with mock.patch.object(exec_impl, "GhClient", return_value=fake_gh):
+                with mock.patch.object(exec_impl, "resolve_workflow_for_pr", return_value=None):
+                    with mock.patch.object(AdminBypassGhExecutor, "download_job_log", return_value=empty_log.name):
+                        with mock.patch.object(AdminBypassStackLoader, "load", return_value=LoadedStacks(stacks=(stack,), open_pr_numbers_by_head={})):
+                            with redirect_stdout(stdout), redirect_stderr(stderr):
+                                should_poll = exec_impl.run_cycle(requeue.parse_args(["--once", "--repo", "owner/repo", "--state-file", str(ledger.path)]))
+        self.assertTrue(should_poll)
+        refreshed = Ledger(ledger.path)
+        self.assertEqual(refreshed.count("queue-only-noop", 5811, HEAD, "required-fast / Guardrails"), 1)
+
     def test_run_cycle_stops_suppressing_after_prereq_requeue(self):
         ledger = self.ledger()
         args = requeue.parse_args(["--once", "--dry-run", "--repo", "owner/repo", "--state-file", str(ledger.path)])

--- a/scripts/test_mergify_admin_requeue_repair_normalize.py
+++ b/scripts/test_mergify_admin_requeue_repair_normalize.py
@@ -117,6 +117,40 @@ class RepairNormalizeTests(unittest.TestCase):
                     code = normalize.main(self.argv())
         self.assertEqual(code, 0)
         gh_cls.assert_not_called()
+        self.assertEqual(self.queue_only_noop_rows(), [])
+
+    def queue_only_noop_rows(self):
+        if not self.state_file.exists():
+            return []
+        return [line for line in self.state_file.read_text(encoding="utf-8").splitlines() if '"queue-only-noop"' in line]
+
+    def test_no_commit_on_queue_only_check_records_queue_only_noop(self):
+        # Incident 2026-08-12: an async repair for a queue-only required check
+        # (e.g. "required-fast / Guardrails", which only runs on the merge-queue
+        # draft, never the PR head) settling with no commit is the *expected*
+        # outcome, not "nothing needed fixing" -- there's no code to fix. Without
+        # this row, plan.py's latest_queue_only_noop_check never sees it and
+        # restore_admin_bypass_label can never fire; the PR is stuck outside the
+        # queue for good. See test_mergify_admin_requeue.py's
+        # test_run_cycle_records_queue_only_noop_from_empty_job_log_repair for
+        # the synchronous twin of this same gap.
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=HEAD):
+                code = normalize.main(self.argv(**{"--check": "required-fast / Guardrails"}))
+        self.assertEqual(code, 0)
+        rows = self.queue_only_noop_rows()
+        self.assertEqual(len(rows), 1)
+        self.assertIn('"pr": 2647', rows[0])
+        self.assertIn(f'"headSha": "{HEAD}"', rows[0])
+        self.assertIn('"key": "required-fast / Guardrails"', rows[0])
+
+    def test_no_commit_after_normalization_on_queue_only_check_also_records(self):
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=NEW_HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.normalize_repair_commit", return_value=HEAD):
+                    code = normalize.main(self.argv(**{"--check": "required-fast / Vitest Workspace"}))
+        self.assertEqual(code, 0)
+        self.assertEqual(len(self.queue_only_noop_rows()), 1)
 
     def test_valid_body_ready_for_push_returns_zero(self):
         with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):


### PR DESCRIPTION
## Summary

The ledger row that tells the babysitter's planner "this queue-only check settled as a no-op, restore the label" was never written by anything, on either the synchronous or async repair path. The planner's read side has worked all along; nothing ever populated it.

This went unnoticed because tests covered each side in isolation — given the row already exists, does the right thing happen; does the repair outcome status come back correctly — never the wiring between them.

## Review Claim

Both the synchronous (empty job log) and async repair paths now write the "queue-only-noop" ledger row, so the admin-bypass label reliably comes back.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The label-restore path only fires when Mergify's own queue event confirms `state=dequeued` with a matching head SHA, and the suppressed check is still in `latest.failing_checks` — a stale/superseded queue event can't trigger it.

## Slice Rationale

Fix for the bug the prior slice's proof demonstrated. Kept as its own PR (not bundled with the proof) because this repo's review-unit rules require product/tooling-policy changes and repro/proof changes to ship as separate PRs.

## Non-goals

Does not touch the separate repair-noop/repair-invalid ledger gap fixed in slice 3.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue`
- [x] `python3 -m unittest scripts.test_mergify_admin_requeue_repair_normalize`
- [x] `bash scripts/repro/repro-babysit-queue-only-check.sh` (now passes)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
