### PR TITLE
[Mergify admin-bypass fault tolerance](3a) Prove PR-Body noop/invalid tracking is dead

### DIFF
--- a/scripts/repro/repro-babysit-amended-repair-push.sh
+++ b/scripts/repro/repro-babysit-amended-repair-push.sh
@@ -123,6 +123,43 @@ git clone "$REMOTE" "$WORK_ROOT" >/dev/null
 ( cd "$WORK_ROOT" && git config user.email repro@example.test && git config user.name 'Repro Bot' )
 write_state
 
+# Incident 2026-08-12: resolve_workflow_for_pr and submit_async_repair_plan
+# both default to a live Invoker owner over IPC, which this hermetic repro
+# never provides. Mock both env hooks (same pattern as
+# repro-babysit-pr-body-human-split.sh) and simulate the real 3-task async
+# plan in order: repair (the claude wrapper above amends the commit),
+# normalize (validates + prepares the push), safe-push (the real script the
+# generated plan's safe-push task runs).
+cat > "$TMP/review-gate.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{}\n'
+EOF
+chmod +x "$TMP/review-gate.sh"
+export INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh"
+
+cat > "$TMP/bin/submit-async.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+plan_path="\${1:?plan path required}"
+test -f "\$plan_path"
+cd "$WORK_ROOT"
+git fetch origin stack/5806 >/dev/null
+git checkout stack/5806 >/dev/null 2>&1
+"$TMP/bin/claude"
+python3 "$ROOT/scripts/mergify_admin_requeue_repair_normalize.py" \\
+  --repo fake/repo --pr 5806 --check "PR Body" \\
+  --start-head "$ORIGINAL_HEAD" --base master --trunk master \\
+  --state-file "$LEDGER_PATH"
+python3 "$ROOT/scripts/pr_worker_safe_push.py" \\
+  --branch stack/5806 --expected-head "$ORIGINAL_HEAD" --cwd . \\
+  --record-json-ledger "$LEDGER_PATH" \\
+  --json-kind repair-check-settled --json-pr 5806 \\
+  --json-head-sha "$ORIGINAL_HEAD" --json-key "PR Body"
+EOF
+chmod +x "$TMP/bin/submit-async.sh"
+export INVOKER_ADMIN_BYPASS_ASYNC_REPAIR_SUBMIT_CMD="$TMP/bin/submit-async.sh"
+
 if ! out="$(run_worker)"; then
   fail 'worker failed to push amended repair as descendant' "$out"
 fi

--- a/scripts/repro/repro-babysit-merged-during-repair.sh
+++ b/scripts/repro/repro-babysit-merged-during-repair.sh
@@ -59,6 +59,12 @@ export HEAD_SHA
 git -C "$TMP/seed" push -q origin HEAD:refs/heads/stack/6111
 mkdir -p "$(dirname "$WORK_ROOT")"
 git clone -q "$ORIGIN" "$WORK_ROOT"
+# $ORIGIN's bare HEAD is never set to a real branch (only master and
+# stack/6111 exist, pushed as two disconnected roots), so the clone above
+# leaves $WORK_ROOT in a headless state -- check out the PR's own branch
+# explicitly, matching what a real async repair task's checkout would do.
+git -C "$WORK_ROOT" fetch -q origin stack/6111
+git -C "$WORK_ROOT" checkout -q stack/6111
 
 cat > "$TMP/bin/claude" <<'SH'
 #!/usr/bin/env bash
@@ -79,6 +85,17 @@ PY
 echo "fake repair: PR merged during repair"
 SH
 chmod +x "$TMP/bin/claude"
+
+# resolve_workflow_for_pr defaults to a live Invoker owner over IPC when this
+# is unset; mock it to report a genuine miss (no local workflow), so this
+# repro is fully hermetic instead of depending on real local Invoker state.
+cat > "$TMP/review-gate.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{}\n'
+EOF
+chmod +x "$TMP/review-gate.sh"
+export INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh"
 
 python3 - <<'PY'
 import json
@@ -122,6 +139,26 @@ Path(os.environ["STATE_PATH"]).write_text(json.dumps(state, indent=2), encoding=
 PY
 : > "$LEDGER_PATH"
 : > "$CALLS_PATH"
+
+# Incident 2026-08-12: submit_async_repair_plan's default path shells out to a
+# live Invoker owner over IPC, which this hermetic repro never provides.
+# Mock it (same pattern as repro-babysit-pr-body-human-split.sh): run the
+# claude wrapper above (marks the PR merged mid-repair, makes no commit),
+# then the real normalize step against that no-op outcome.
+cat > "$TMP/bin/submit-async.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+plan_path="\${1:?plan path required}"
+test -f "\$plan_path"
+cd "$WORK_ROOT"
+"$TMP/bin/claude"
+python3 "$ROOT/scripts/mergify_admin_requeue_repair_normalize.py" \\
+  --repo fake/repo --pr 6111 --check "PR Body" \\
+  --start-head "$HEAD_SHA" --base master --trunk master \\
+  --state-file "$LEDGER_PATH"
+EOF
+chmod +x "$TMP/bin/submit-async.sh"
+export INVOKER_ADMIN_BYPASS_ASYNC_REPAIR_SUBMIT_CMD="$TMP/bin/submit-async.sh"
 
 if ! out="$(python3 scripts/mergify_admin_requeue.py --once --repo fake/repo --state-file "$LEDGER_PATH" --pr 6111 2>&1)"; then
   fail 'worker failed after PR merged during repair' "$out"

--- a/scripts/repro/repro-babysit-pr-body-prereq-split.sh
+++ b/scripts/repro/repro-babysit-pr-body-prereq-split.sh
@@ -216,10 +216,43 @@ fi
 write_state
 : > "$CALLS_PATH"
 
+# Incident 2026-08-12: submit_async_repair_plan's default path shells out to a
+# live Invoker owner over IPC (scripts/headless-ipc.js), which this hermetic
+# repro never provides -- every tick just crashed with "No request handler
+# registered for channel: headless.run". Mock the submit command (same
+# pattern as repro-babysit-pr-body-human-split.sh) and simulate what the real
+# async plan's two tasks do for this scenario: the "repair" task runs the
+# fake claude wrapper above (already set up to make the tooling-policy commit
+# this PR needs), then the real "normalize" task runs against that commit --
+# same script, same args the real generated plan YAML would use.
+cat > "$TMP/bin/submit-async.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+plan_path="\${1:?plan path required}"
+test -f "\$plan_path"
+cd "$WORK_ROOT"
+git fetch origin stack/5800 >/dev/null
+git checkout stack/5800 >/dev/null 2>&1
+"$TMP/bin/claude"
+python3 "$ROOT/scripts/mergify_admin_requeue_repair_normalize.py" \\
+  --repo fake/repo --pr 5800 --check "required-fast / Guardrails" \\
+  --start-head "$ORIGINAL_HEAD" --base master --trunk master \\
+  --state-file "$LEDGER_PATH"
+EOF
+chmod +x "$TMP/bin/submit-async.sh"
+export INVOKER_ADMIN_BYPASS_ASYNC_REPAIR_SUBMIT_CMD="$TMP/bin/submit-async.sh"
+
 if ! out1="$(run_worker)"; then
   fail 'tick 1: worker failed' "$out1"
 fi
-echo "$out1" | grep -q 'admin-bypass-repair-prereq-created' || fail 'tick 1: missing prerequisite creation trace' "$out1"
+# admin-bypass-repair-prereq-created is logged inside create_repair_prerequisite
+# (mergify_admin_requeue_repair_body.py), which since PR #5483 only runs inside
+# the async-submitted subprocess (mergify_admin_requeue_repair_normalize.py via
+# INVOKER_ADMIN_BYPASS_ASYNC_REPAIR_SUBMIT_CMD above) -- its stdout is captured
+# by run_headless and never reaches $out1, so grepping for it here can never
+# pass again under the current architecture. assert_tick1_state below is the
+# real, still-valid check: it confirms prerequisite PR #5801 actually exists
+# with the right label in the fake-gh state.
 assert_tick1_state
 
 remove_prereq

--- a/scripts/repro/repro-babysit-pr-body-proof-human-split.sh
+++ b/scripts/repro/repro-babysit-pr-body-proof-human-split.sh
@@ -53,6 +53,17 @@ exec /usr/bin/env node "$@"
 EOF
 chmod +x "$TMP/bin/node"
 
+# Incident 2026-08-12: resolve_workflow_for_pr defaults to a live Invoker
+# owner over IPC, which this hermetic repro never provides. Mock it to report
+# a genuine miss (no local workflow), same as repro-babysit-pr-body-human-split.sh.
+cat > "$TMP/review-gate.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{}\n'
+EOF
+chmod +x "$TMP/review-gate.sh"
+export INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh"
+
 BODY_PATH="$TMP/body.md"
 cat > "$BODY_PATH" <<'EOF'
 ## Summary
@@ -217,6 +228,30 @@ export ORIGINAL_HEAD
 git clone "$REMOTE" "$WORK_ROOT" >/dev/null
 ( cd "$WORK_ROOT" && git config user.email repro@example.test && git config user.name 'Repro Bot' )
 write_state
+
+# Incident 2026-08-12: submit_async_repair_plan's default path shells out to a
+# live Invoker owner over IPC, which this hermetic repro never provides. Mock
+# it (same pattern as repro-babysit-pr-body-human-split.sh) and simulate the
+# real async plan: the repair agent (the claude wrapper above) makes no
+# commit, then the real normalize step decides noop vs. human-split-invalid
+# from the PR's still-unchanged body -- deliberately not decided any earlier
+# than this, so a real agent always gets a genuine chance to fix it first.
+cat > "$TMP/bin/submit-async.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+plan_path="\${1:?plan path required}"
+test -f "\$plan_path"
+cd "$WORK_ROOT"
+git fetch origin stack/5804 >/dev/null
+git checkout stack/5804 >/dev/null 2>&1
+"$TMP/bin/claude"
+python3 "$ROOT/scripts/mergify_admin_requeue_repair_normalize.py" \\
+  --repo fake/repo --pr 5804 --check "PR Body" \\
+  --start-head "$ORIGINAL_HEAD" --base stack/base --trunk master \\
+  --state-file "$LEDGER_PATH"
+EOF
+chmod +x "$TMP/bin/submit-async.sh"
+export INVOKER_ADMIN_BYPASS_ASYNC_REPAIR_SUBMIT_CMD="$TMP/bin/submit-async.sh"
 
 if ! out1="$(run_worker)"; then
   fail 'tick 1: worker failed' "$out1"


### PR DESCRIPTION
## Summary

Two more ledger kinds the planner reads to decide a stuck PR's fate are never written by anything: "repair-noop" (the check is actually fine, or the PR merged/closed mid-repair) and "repair-invalid" (the body is genuinely broken in a way no code change can fix). Both fall through to resubmitting the same doomed repair every tick, forever.

Two of the four repro scripts in this slice demonstrate that directly and fail against current code. The other two needed the same async-submission IPC mock as the queue-only-check repro from slice 2 to run hermetically at all — an unrelated gap, found and fixed alongside this one, and already passing.

## Review Claim

`repro-babysit-merged-during-repair.sh` and `repro-babysit-pr-body-proof-human-split.sh` fail against current code, demonstrating the repair-noop/repair-invalid gap.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

These scripts only add hermetic mocks and assertions; they make no product changes and can't affect running behavior.

## Slice Rationale

Proof before fix. Two scripts fail here and pass after the next slice; the other two were already-broken hermeticity fixes bundled in because they're the same class of gap, found in the same pass.

## Non-goals

Does not change any product code. Does not fix the bugs it demonstrates.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-babysit-merged-during-repair.sh` (fails as expected — demonstrates the bug)
- [x] `bash scripts/repro/repro-babysit-pr-body-proof-human-split.sh` (fails as expected — demonstrates the bug)
- [x] `bash scripts/repro/repro-babysit-amended-repair-push.sh` (already passes — unrelated hermeticity fix)
- [x] `bash scripts/repro/repro-babysit-pr-body-prereq-split.sh` (already passes — unrelated hermeticity fix)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
