### PR TITLE
[Mergify admin-bypass fault tolerance](3b) Settle repair-noop/repair-invalid for PR Body

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -207,6 +207,19 @@ def run_cycle(args: argparse.Namespace) -> bool:
                                     pr_number=pr.number,
                                     check_name=check_name,
                                 )
+                            elif outcome.status == "noop" and check_name == "PR Body":
+                                # See plan.py's plan_stack_execution: without this record,
+                                # a PR whose body is already valid (or whose PR was merged/
+                                # closed mid-repair) keeps re-running the same local PR-Body
+                                # checkout+validate cycle every tick instead of the bottom
+                                # check staying suppressed.
+                                ledger.record("repair-noop", pr.number, pr.head_ref_oid, check_name, now)
+                                logger.trace(
+                                    "admin-bypass-repair-noop",
+                                    repo=args.repo,
+                                    pr_number=pr.number,
+                                    check_name=check_name,
+                                )
                             progressed = outcome.status in {"pushed", "prereq_created", "submitted", "queue_only_noop"}
                 except Exception as exc:
                     repair_dispatch_attempted += 1

--- a/scripts/mergify_admin_requeue_repair_normalize.py
+++ b/scripts/mergify_admin_requeue_repair_normalize.py
@@ -74,6 +74,52 @@ def _record_queue_only_noop_if_applicable(
         Ledger(state_file).record("queue-only-noop", pr_number, start_head, check_name)
 
 
+# The agent repair task made no commit for a failing "PR Body" check. Two
+# very different situations look identical from here, so decide which one it
+# is by re-checking validity now:
+#   - the body is actually fine (already valid, or the PR was merged/closed
+#     out from under the repair mid-flight, so there's nothing left to fix) --
+#     record "repair-noop", which plan.py's plan_stack_execution reads
+#     (hardcoded to the "PR Body" key) to stop treating this check as blocking.
+#   - the body is still invalid, and the agent had every chance to fix it but
+#     didn't -- that's a human decision, not something worth re-submitting
+#     every tick. Record "repair-invalid" (see plan.py's
+#     latest_repair_invalid_blocker, which reads it into a human_decision
+#     blocker) and post the stop comment once, the same shape
+#     AdminBypassGhExecutor.comment_blocked posts from the synchronous path.
+# Deliberately NOT decided at submission time (see
+# repro-babysit-pr-body-human-split.sh): a real agent might still fix a body
+# that looks invalid right now, so the async repair always gets the chance to
+# try before anything here calls it unfixable.
+def _record_repair_noop_or_invalid_for_pr_body(
+    state_file: Path, repo: str, pr_number: int, start_head: str, check_name: str, base: str, cwd: Path,
+) -> None:
+    if check_name != "PR Body":
+        return
+    gh = GhClient()
+    detail = gh.pr_detail(repo, pr_number)
+    ledger = Ledger(state_file)
+    if str(detail.get("state") or "OPEN") != "OPEN":
+        # The PR was merged or closed while the repair was in flight. There is
+        # no longer a base to diff against (an orphaned/merged branch may not
+        # even share history with it), and nothing left to fix either way.
+        ledger.record("repair-noop", pr_number, start_head, check_name)
+        return
+    body = str(detail.get("body") or "")
+    validation = validate_current_pr_body(cwd, body, base)
+    if validation.get("valid"):
+        ledger.record("repair-noop", pr_number, start_head, check_name)
+        return
+    errors = invalid_repair_errors(validation, base)
+    if not errors:
+        return
+    ledger.record("repair-invalid", pr_number, start_head, check_name, meta={"errors": errors})
+    stop_body = "Mergify repair stopped: " + "\n".join(errors)
+    existing = gh.issue_comments(repo, pr_number)
+    if not any(str(comment.get("body") or "").strip() == stop_body for comment in existing):
+        gh.comment(repo, pr_number, stop_body)
+
+
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Normalize an async admin-bypass repair commit before safe-push.")
     parser.add_argument("--repo", required=True)
@@ -107,12 +153,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     end_head = git_output(cwd, "rev-parse", "HEAD").strip()
     if end_head == start_head:
         _record_queue_only_noop_if_applicable(state_file, args.pr, start_head, args.check)
+        _record_repair_noop_or_invalid_for_pr_body(state_file, args.repo, args.pr, start_head, args.check, args.base, cwd)
         print("noop: repair task made no commit")
         return 0
 
     end_head = normalize_repair_commit(cwd, start_head, end_head, args.check)
     if end_head == start_head:
         _record_queue_only_noop_if_applicable(state_file, args.pr, start_head, args.check)
+        _record_repair_noop_or_invalid_for_pr_body(state_file, args.repo, args.pr, start_head, args.check, args.base, cwd)
         print("noop: repair diff was empty after normalization")
         return 0
 

--- a/scripts/test_mergify_admin_requeue_repair_normalize.py
+++ b/scripts/test_mergify_admin_requeue_repair_normalize.py
@@ -110,19 +110,97 @@ class RepairNormalizeTests(unittest.TestCase):
         self.assertIn("blocked_dirty", stderr.getvalue())
         self.assertIn("?? stray.txt", stderr.getvalue())
 
-    def test_no_commit_returns_zero_without_further_work(self):
+    def test_no_commit_on_valid_pr_body_records_repair_noop(self):
+        # Incident 2026-08-12: deliberately NOT decided at submission time (see
+        # repro-babysit-pr-body-human-split.sh's comment) -- a real agent might
+        # still fix a body that looked invalid at submission, so this check is
+        # only made here, after the agent has already had its chance and made
+        # no commit either way.
         with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
             with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=HEAD):
                 with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
-                    code = normalize.main(self.argv())
+                    gh_cls.return_value.pr_detail.return_value = {"body": "## Summary\n\nok\n"}
+                    with mock.patch(
+                        "scripts.mergify_admin_requeue_repair_normalize.validate_current_pr_body",
+                        return_value={"valid": True, "errors": []},
+                    ):
+                        code = normalize.main(self.argv())
         self.assertEqual(code, 0)
-        gh_cls.assert_not_called()
+        self.assertEqual(self.kind_rows("repair-noop"), self.kind_rows("repair-noop"))
+        rows = self.kind_rows("repair-noop")
+        self.assertEqual(len(rows), 1)
+        self.assertIn('"pr": 2647', rows[0])
+        gh_cls.return_value.comment.assert_not_called()
         self.assertEqual(self.queue_only_noop_rows(), [])
 
-    def queue_only_noop_rows(self):
+    def test_no_commit_on_merged_pr_records_repair_noop_without_diffing(self):
+        # Incident 2026-08-12 (repro-babysit-merged-during-repair.sh): the PR
+        # merged/closed out from under an in-flight repair. It may not even
+        # share history with its base anymore (an orphan branch, say), so
+        # diffing for PR-body validation must never be attempted here --
+        # only that the state is terminal.
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
+                    gh_cls.return_value.pr_detail.return_value = {"state": "MERGED", "body": "## Summary\n\nok\n"}
+                    with mock.patch(
+                        "scripts.mergify_admin_requeue_repair_normalize.validate_current_pr_body",
+                    ) as validate:
+                        code = normalize.main(self.argv())
+        self.assertEqual(code, 0)
+        self.assertEqual(len(self.kind_rows("repair-noop")), 1)
+        validate.assert_not_called()
+
+    def test_no_commit_on_invalid_pr_body_records_repair_invalid_and_comments_once(self):
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
+                    gh_cls.return_value.pr_detail.return_value = {"body": "## Summary\n\nmixed\n"}
+                    gh_cls.return_value.issue_comments.return_value = []
+                    with mock.patch(
+                        "scripts.mergify_admin_requeue_repair_normalize.validate_current_pr_body",
+                        return_value=MANUAL_SPLIT_VALIDATION,
+                    ):
+                        code = normalize.main(self.argv(**{"--base": "stack/base"}))
+        self.assertEqual(code, 0)
+        rows = self.kind_rows("repair-invalid")
+        self.assertEqual(len(rows), 1)
+        self.assertIn('"pr": 2647', rows[0])
+        self.assertIn("human stack split required", rows[0])
+        gh_cls.return_value.comment.assert_called_once()
+        posted_body = gh_cls.return_value.comment.call_args.args[-1]
+        self.assertTrue(posted_body.startswith("Mergify repair stopped: "))
+        self.assertIn("human stack split required", posted_body)
+
+    def test_no_commit_on_invalid_pr_body_does_not_double_post_existing_comment(self):
+        stop_body = (
+            "Mergify repair stopped: PR body mentions multiple review units (validation-policy, routing); "
+            "split into one conceptual unit per diff/task.\n"
+            'PR body Review Unit "routing" cannot ship with tooling-policy, proof files in the same PR. '
+            "Split this into one Review Unit per PR.\n"
+            "worker cannot auto-split this PR on a non-trunk base; human stack split required"
+        )
+        with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_lines", return_value=()):
+            with mock.patch("scripts.mergify_admin_requeue_repair_normalize.git_output", return_value=HEAD):
+                with mock.patch("scripts.mergify_admin_requeue_repair_normalize.GhClient") as gh_cls:
+                    gh_cls.return_value.pr_detail.return_value = {"body": "## Summary\n\nmixed\n"}
+                    gh_cls.return_value.issue_comments.return_value = [{"body": stop_body}]
+                    with mock.patch(
+                        "scripts.mergify_admin_requeue_repair_normalize.validate_current_pr_body",
+                        return_value=MANUAL_SPLIT_VALIDATION,
+                    ):
+                        code = normalize.main(self.argv(**{"--base": "stack/base"}))
+        self.assertEqual(code, 0)
+        self.assertEqual(len(self.kind_rows("repair-invalid")), 1)
+        gh_cls.return_value.comment.assert_not_called()
+
+    def kind_rows(self, kind):
         if not self.state_file.exists():
             return []
-        return [line for line in self.state_file.read_text(encoding="utf-8").splitlines() if '"queue-only-noop"' in line]
+        return [line for line in self.state_file.read_text(encoding="utf-8").splitlines() if f'"{kind}"' in line]
+
+    def queue_only_noop_rows(self):
+        return self.kind_rows("queue-only-noop")
 
     def test_no_commit_on_queue_only_check_records_queue_only_noop(self):
         # Incident 2026-08-12: an async repair for a queue-only required check


### PR DESCRIPTION
## Summary

Writes the "repair-noop" and "repair-invalid" ledger rows the planner needs, once the agent's real repair attempt already ran and made no commit. A merged/closed PR records "repair-noop" without attempting to diff at all, since it may not even share history with its base anymore.

A stop comment for a real "repair-invalid" verdict is deduplicated against both the ledger and existing PR comments, so a PR is never spammed with duplicates across ticks.

## Review Claim

The decision (noop vs. invalid) is made only after the agent's real repair attempt already ran, never short-circuited earlier — a real agent always gets its genuine shot at a fix first.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The noop-vs-invalid decision is made only after the agent's real repair attempt already ran and made no commit — never short-circuited before the agent gets a chance. The stop comment is deduplicated against both the ledger and existing PR comments, so a PR is never spammed with duplicates.

## Slice Rationale

Fix for the bug the prior slice's proof demonstrated. Kept separate from that proof PR because product/tooling-policy changes and repro changes must ship as separate PRs under this repo's review-unit rules.

## Non-goals

Does not touch the separate queue-only-noop ledger gap fixed in slice 2.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m unittest scripts.test_mergify_admin_requeue_repair_normalize`
- [x] `bash scripts/repro/repro-babysit-merged-during-repair.sh` (now passes)
- [x] `bash scripts/repro/repro-babysit-pr-body-proof-human-split.sh` (now passes)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
