### PR TITLE
[CI regression: 631a0d0-quality-dependency-cruise](1) Route Dependency Cruise to GitHub-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         include:
           - name: Dependency Cruise
             command: pnpm run check:deps
-            runner_label: Runner_2_4_core
+            runner_label: Github_Runner
           - name: TypeScript Types
             command: pnpm run check:types
             runner_label: Github_Runner


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=quality / Dependency Cruise -->

`quality / Dependency Cruise` failed on default-branch commit `631a0d08c7072e9544813fc1b93fb616586ce441` after its self-hosted runner exhausted disk space.

This slice assigns only Dependency Cruise from `Runner_2_4_core` to `Github_Runner`.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94225435692

## Review Claim

Approve assigning Dependency Cruise to the GitHub-hosted runner while leaving its dependency check and other quality matrix entries unchanged.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the Dependency Cruise `runner_label` changes; its dependency check and every other quality matrix entry stay unchanged.

## Slice Rationale

The verification task produced no file changes, so the review stack contains one non-empty CI-policy slice.

## Non-goals

- No dependency-rule changes.
- No changes to other CI jobs.
- No product-behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:deps`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: Monitor `quality / Dependency Cruise` for self-hosted runner disk exhaustion.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Dependency Cruise check to run on the standard GitHub runner, improving CI workflow compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
