### PR TITLE
[CI regression: 631a0d0-quality-typescript-types](1) Run TypeScript Types on GitHub-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,6 @@ jobs:
           - name: Dependency Cruise
             command: pnpm run check:deps
             runner_label: Runner_2_4_core
-          - name: TypeScript Types
-            command: pnpm run check:types
-            runner_label: Github_Runner
 
     name: quality / ${{ matrix.name }}
 
@@ -109,6 +106,35 @@ jobs:
 
       - name: Run quality check
         run: ${{ matrix.command }}
+
+  typescript-types:
+    name: quality / TypeScript Types
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .node-version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run TypeScript type check
+        run: pnpm run check:types
 
   # UI component suite (@invoker/ui vitest, ~2-3m). Runs on every PR for early
   # feedback AND on merge-queue refs, where `.mergify.yml` requires it — this is


### PR DESCRIPTION
<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=quality / TypeScript Types -->

## Summary

The failing quality check ran out of disk space on its self-hosted runner at `631a0d08c7072e9544813fc1b93fb616586ce441`.

This slice gives that check a dedicated `ubuntu-latest` job instead of a `Github_Runner` matrix entry.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94225435567

## Review Claim

Approve moving the failing quality check to a dedicated GitHub-hosted job while leaving its behavior and other quality checks unchanged.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The job still runs `pnpm run check:types`; other CI jobs and product behavior stay unchanged.

## Slice Rationale

The verification task produced no file changes, so the review stack contains one non-empty CI-policy slice.

## Non-goals

- No type-checking rule changes.
- No changes to other CI jobs.
- No product-behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: Monitor `quality / TypeScript Types` for self-hosted runner disk exhaustion.
- Data migration? No

</details>
