### PR TITLE
[CI regression: 631a0d0-required-fast-guardrails](1) Make guardrail verification self-contained

### DIFF
--- a/plans/verify-executor-routing.invoker.json
+++ b/plans/verify-executor-routing.invoker.json
@@ -7,6 +7,9 @@
       "poolId": "dummy-target"
     }
   ],
+  "worktreeTargets": {
+    "local-worktree": {}
+  },
   "executionPools": {
     "dummy-target": {
       "members": [

--- a/scripts/verify-executor-routing.sh
+++ b/scripts/verify-executor-routing.sh
@@ -53,23 +53,45 @@ dest.write_text(nl.join(out) + (nl if text.endswith('\n') else ''), encoding='ut
 echo "==> submit-plan (headless run) $PLAN_SRC (repoUrl -> file:// checkout)"
 ./submit-plan.sh "$PLAN_TMP"
 
-# Assert the routed task completed through the configured worktree pool member if sqlite3 is available.
+# Assert the routed task completed through the configured worktree pool member.
 DB="$TMPDB/invoker.db"
-if [[ -f "$DB" ]] && command -v sqlite3 >/dev/null 2>&1; then
-  STATUS=$(sqlite3 "$DB" "SELECT status FROM tasks WHERE id LIKE '%/verify-routing-command' LIMIT 1;")
-  RUNNER_KIND=$(sqlite3 "$DB" "SELECT runner_kind FROM tasks WHERE id LIKE '%/verify-routing-command' LIMIT 1;")
-  POOL_ID=$(sqlite3 "$DB" "SELECT pool_id FROM tasks WHERE id LIKE '%/verify-routing-command' LIMIT 1;")
-  if [[ "$STATUS" != "completed" ]]; then
-    echo "FAIL: expected routed task to complete, got status='$STATUS'" >&2
-    exit 1
-  fi
-  if [[ "$POOL_ID" != "dummy-target" ]]; then
-    echo "FAIL: expected routed task pool_id=dummy-target, got '$POOL_ID'" >&2
-    exit 1
-  fi
-  if [[ "$RUNNER_KIND" != "worktree" ]]; then
-    echo "FAIL: expected persisted pool-routed task runner_kind=worktree, got '$RUNNER_KIND'" >&2
-    exit 1
-  fi
-  echo "PASS: routed task completed with pool_id=$POOL_ID runner_kind=$RUNNER_KIND"
+if [[ ! -f "$DB" ]]; then
+  echo "FAIL: expected invoker.db at $DB, but it does not exist" >&2
+  exit 1
 fi
+
+TASK_STATE="$(node - "$DB" <<'EOF'
+const { DatabaseSync } = require('node:sqlite');
+
+const db = new DatabaseSync(process.argv[2], { readOnly: true });
+const row = db.prepare(`
+  SELECT status, runner_kind, pool_id
+  FROM tasks
+  WHERE id LIKE '%/verify-routing-command'
+  LIMIT 1
+`).get();
+db.close();
+
+if (!row) {
+  console.error('FAIL: routed task row was not persisted');
+  process.exit(1);
+}
+
+process.stdout.write([row.status, row.runner_kind ?? '', row.pool_id ?? ''].join('\t'));
+EOF
+)"
+IFS=$'\t' read -r STATUS RUNNER_KIND POOL_ID <<<"$TASK_STATE"
+
+if [[ "$STATUS" != "completed" ]]; then
+  echo "FAIL: expected routed task to complete, got status='$STATUS'" >&2
+  exit 1
+fi
+if [[ "$POOL_ID" != "dummy-target" ]]; then
+  echo "FAIL: expected routed task pool_id=dummy-target, got '$POOL_ID'" >&2
+  exit 1
+fi
+if [[ "$RUNNER_KIND" != "worktree" ]]; then
+  echo "FAIL: expected persisted pool-routed task runner_kind=worktree, got '$RUNNER_KIND'" >&2
+  exit 1
+fi
+echo "PASS: routed task completed with pool_id=$POOL_ID runner_kind=$RUNNER_KIND"

--- a/scripts/verify-scratch-execution.sh
+++ b/scripts/verify-scratch-execution.sh
@@ -40,14 +40,27 @@ if [[ ! -f "$DB" ]]; then
   ls -la "$TMPDB" >&2 || true
   exit 1
 fi
-if ! command -v sqlite3 >/dev/null 2>&1; then
-  echo "FAIL: sqlite3 CLI is not installed on this machine" >&2
-  exit 1
-fi
+TASK_STATE="$(node - "$DB" <<'EOF'
+const { DatabaseSync } = require('node:sqlite');
 
-STATUS=$(sqlite3 "$DB" "SELECT status FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
-RUNNER_KIND=$(sqlite3 "$DB" "SELECT runner_kind FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
-WORKSPACE_PATH=$(sqlite3 "$DB" "SELECT workspace_path FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
+const db = new DatabaseSync(process.argv[2], { readOnly: true });
+const row = db.prepare(`
+  SELECT status, runner_kind, workspace_path
+  FROM tasks
+  WHERE id LIKE '%/verify-scratch-command'
+  LIMIT 1
+`).get();
+db.close();
+
+if (!row) {
+  console.error('FAIL: scratch task row was not persisted');
+  process.exit(1);
+}
+
+process.stdout.write([row.status, row.runner_kind ?? '', row.workspace_path ?? ''].join('\t'));
+EOF
+)"
+IFS=$'\t' read -r STATUS RUNNER_KIND WORKSPACE_PATH <<<"$TASK_STATE"
 
 if [[ "$STATUS" != "completed" ]]; then
   echo "FAIL: expected scratch task to complete, got status='$STATUS'" >&2


### PR DESCRIPTION
## Summary

Makes `required-fast / Guardrails` independent of an external `sqlite3` binary and registers the named local worktree used by its routing fixture.

The checks still inspect persisted task status, runner kind, pool ID, and scratch workspace location through Node's built-in SQLite API.

## Review Claim

Approve making the Guardrails verification scripts self-contained while preserving their existing routing and scratch-execution assertions.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior remain unchanged; only the Guardrails verification harness and its fixture are modified.

## Slice Rationale

The fixture and script edits form one CI-policy slice because together they make the existing Guardrails checks portable and deterministic.

## Non-goals

- No product runtime behavior changes.
- No CI assertion weakening.
- No unrelated refactor or cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/05-delete-all-prod-db-guard.sh && bash scripts/test-suites/required/06-large-file-guardrail.sh && bash scripts/test-suites/required/07-invalid-config-json.sh && bash scripts/test-suites/required/08-build-artifact-surfaces-guard.sh && bash scripts/test-suites/required/10-dag-background-click-noop-guard.sh && bash scripts/test-suites/required/15-owner-boundary-policy.sh && bash scripts/test-suites/required/50-verify-executor-routing.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 74a7d53784530c8960cd2b1138b03f954c59da21`
- Post-revert steps: Re-run `required-fast / Guardrails`.
- Data migration? No.

</details>
