### PR TITLE
[CI regression: 631a0d0-required-fast-pr-authoring-guardrails](1) Switch PR authoring guardrails to GitHub runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,7 +408,7 @@ jobs:
             runner_label: Runner_2_4_core
           - name: PR Authoring Guardrails
             command: bash scripts/test-suites/required/11-pr-authoring-guardrails.sh
-            runner_label: Runner_2_4_core
+            runner_label: Github_Runner
           - name: Mergify Admin Requeue
             command: bash scripts/test-suites/required/12-mergify-admin-requeue.sh
             runner_label: Runner_2_4_core


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=required-fast / PR Authoring Guardrails -->

CI job `required-fast / PR Authoring Guardrails` first failed on default-branch push commit 631a0d08c7072e9544813fc1b93fb616586ce441 in run 31620499765.

It was most recently still red at 631a0d08c7072e9544813fc1b93fb616586ce441 in run 31620499765.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217705

This switches the PR Authoring Guardrails CI matrix row to a GitHub-hosted runner.

The guardrail job keeps the same script while avoiding unavailable self-hosted runner capacity.

---

CI regression: 631a0d0-required-fast-pr-authoring-guardrails - 2 tasks completed, 0 failed, 0 closed, 0 omitted

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1786567852573-140/fix-ci-631a0d0-required-fast-pr-authoring-guardrails | Fix CI job required-fast / PR Authoring Guardrails first observed failing at 631a0d08c7072e9544813fc1b93fb616586ce441. | completed |
| wf-1786567852573-140/verify-ci-631a0d0-required-fast-pr-authoring-guardrails | Run the local verification script for CI job required-fast / PR Authoring Guardrails. | completed (passed) |

</details>

## Review Claim

Switch only the PR Authoring Guardrails CI matrix row to a GitHub-hosted runner so the required-fast job can schedule reliably again.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged because this slice changes only the runner label for one existing required-fast matrix entry.

## Slice Rationale

This is one CI policy slice: the failing guardrail job's scheduling root cause and deterministic proof stay together.

## Non-goals

No refactor, no product behavior change, no test weakening, and no snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/11-pr-authoring-guardrails.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert: `git revert bc4b613a6`
- Post-revert steps: Rerun the PR Authoring Guardrails required-fast job or its local proof script.
- Data migration? No

</details>
