### PR TITLE
[CI regression: 631a0d0-quality-required-package-builds](1) Run Required Package Builds on GitHub-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,36 @@ jobs:
       - name: Run UI vitest
         run: pnpm --filter @invoker/ui test
 
+  quality-required-builds:
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    name: quality / Required Package Builds
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .node-version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run required package builds
+        run: pnpm run check:required-builds
+
   quality-extra:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     runs-on:
@@ -157,9 +187,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Required Package Builds
-            command: pnpm run check:required-builds
-            runner_label: Runner_2_4_core
           - name: Large File Guardrail
             command: pnpm run check:large-files
             runner_label: Runner_1

--- a/scripts/test-ci-duration-invariant.mjs
+++ b/scripts/test-ci-duration-invariant.mjs
@@ -6,6 +6,7 @@ const MAX_PR_FACING_TIMEOUT_MINUTES = 5;
 
 const BUDGETED_JOBS = new Set([
   'quality-required',
+  'quality-required-builds',
   'ui-vitest',
   'quality-extra',
 ]);


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=quality / Required Package Builds -->

CI job `quality / Required Package Builds` first failed on default-branch push commit `631a0d08c7072e9544813fc1b93fb616586ce441` in run 31620499765.

Its self-hosted runner stopped during action setup with `No space left on device`.

This slice gives the check a dedicated `ubuntu-latest` job while preserving its command and five-minute timeout.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94225435596

## Review Claim

Approve moving Required Package Builds from the shared self-hosted quality matrix to a dedicated GitHub-hosted job without changing the command it executes.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The job still runs `pnpm run check:required-builds` with a five-minute timeout; remaining quality checks and product behavior stay unchanged.

## Slice Rationale

The verification task produced no file changes, so the review stack contains one non-empty CI-policy slice.

## Non-goals

- No changes to the required-builds script or packages.
- No changes to remaining quality-check commands or runners.
- No product-behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:required-builds`
- [x] `node --input-type=module -e "import { readFileSync } from 'node:fs'; import YAML from 'yaml'; const jobs=YAML.parse(readFileSync('.github/workflows/ci.yml','utf8')).jobs; const job=jobs['quality-required-builds']; if (!job) throw new Error('missing quality-required-builds'); if (job['runs-on'] !== 'ubuntu-latest') throw new Error('wrong runner'); if (job['timeout-minutes'] !== 5) throw new Error('wrong timeout'); const commands=job.steps.map((step)=>step.run).filter(Boolean); if (!commands.includes('pnpm run check:required-builds')) throw new Error('missing command'); const matrix=jobs['quality-extra'].strategy.matrix.include; if (matrix.some((entry)=>entry.name === 'Required Package Builds')) throw new Error('duplicate matrix entry'); console.log('required-builds CI isolation OK')"` — printed `required-builds CI isolation OK` and exited 0.
- [x] `gh run view 31620499765 --repo Neko-Catpital-Labs/Invoker --job 94225435596 --log | tail -n 120` — the failing runner log ends with `No space left on device` while downloading actions.
- [ ] `node scripts/test-ci-duration-invariant.mjs` — currently reaches the unrelated master failure `playwright shard 9-of-9 has 8 specs; keep <= 6 per shard`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: Monitor `quality / Required Package Builds` for self-hosted runner disk exhaustion.
- Data migration? No.

</details>
