### PR TITLE
[CI regression: 631a0d0-required-fast-branch-carry-forward](1) Reclaim workspace before required-fast checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,6 +416,9 @@ jobs:
     name: required-fast / ${{ matrix.name }}
 
     steps:
+      - name: Reclaim workspace
+        run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" "$HOME/.invoker" "$HOME/.claude" 2>/dev/null || true
+        shell: bash
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=required-fast / Branch Carry Forward -->

CI job `required-fast / Branch Carry Forward` first failed on default-branch commit 631a0d08c7072e9544813fc1b93fb616586ce441 in run 31620499765.

The workflow now reclaims ownership of the runner workspace and Invoker state directories before required-fast checkout.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217691

## Review Claim

Approve reclaiming required-fast runner workspace ownership before checkout.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The pre-checkout step changes only filesystem ownership. It leaves the required-fast matrix, checkout inputs, test commands, and product code unchanged.

## Slice Rationale

One CI-policy slice contains the ownership preflight and its Branch Carry Forward verification.

The command-only verification task produced no file changes, so its result belongs here instead of in an empty PR.

## Non-goals

- No product behavior changes.
- No CI test weakening or skipped assertions.
- No changes to required-fast job selection or test commands.

## Architecture

### Before

```mermaid
graph LR
    A["Checkout"] --> B["Run required-fast suite"]
```

### After

```mermaid
graph LR
    A["Reclaim runner workspace ownership"] --> B["Checkout"]
    B --> C["Run required-fast suite"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/16-branch-carry-forward.sh`

Observed result: exit 0.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 178f661f6ca112b0517525965f93b9b473968acc`
- Post-revert steps: None
- Data migration? No

</details>
