### PR TITLE
[CI regression: 631a0d0-docker-comprehensive](1) Clean up fixture-image Docker resources

### DIFF
--- a/scripts/test-docker-comprehensive.sh
+++ b/scripts/test-docker-comprehensive.sh
@@ -39,7 +39,19 @@ PLAN_FILE="$REPO_ROOT/plans/test-docker-comprehensive.yaml"
 PATCHED_PLAN_FILE=""
 FIXTURE_IMAGE_TAG="${FIXTURE_IMAGE_TAG:-invoker-docker-comprehensive:latest}"
 
+cleanup_docker_resources() {
+  local containers
+  containers="$(docker ps -aq --filter "ancestor=$FIXTURE_IMAGE_TAG" 2>/dev/null || true)"
+  if [[ -n "$containers" ]]; then
+    # Use rm -f so restored tail containers do not each wait for Docker's
+    # default stop timeout on persistent CI runners.
+    docker rm -f $containers >/dev/null 2>&1 || true
+  fi
+  docker image rm "$FIXTURE_IMAGE_TAG" >/dev/null 2>&1 || true
+}
+
 cleanup() {
+  cleanup_docker_resources
   if [[ -n "$PATCHED_PLAN_FILE" ]]; then
     rm -f "$PATCHED_PLAN_FILE" 2>/dev/null || true
   fi
@@ -407,13 +419,7 @@ fi
 
 echo ""
 echo "==> Cleaning up test containers"
-for TASK_ID in $RESTORABLE_TASKS; do
-  CID=$(task_container_id "$TASK_ID")
-  if [ -n "$CID" ] && [ "$CID" != "null" ]; then
-    docker stop "$CID" >/dev/null 2>&1 || true
-    docker rm "$CID" >/dev/null 2>&1 || true
-  fi
-done
+cleanup_docker_resources
 
 echo "==> Clearing Invoker state"
 ./run.sh --headless delete-all 2>/dev/null || true


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=docker / comprehensive -->

CI job `docker / comprehensive` first failed at commit `631a0d08c7072e9544813fc1b93fb616586ce441` in run 31620499765.

The comprehensive Docker runner now removes every container created from its fixture image during both trapped and normal teardown.

Forced removal avoids waiting on each restored container's normal stop timeout.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217748

## Review Claim

Approve fixture-image-scoped cleanup for the Docker comprehensive runner.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Cleanup targets only containers descended from `FIXTURE_IMAGE_TAG`. Other CI jobs and product behavior remain unchanged.

## Slice Rationale

This is one tooling-policy slice because trapped and normal teardown must share the same Docker resource cleanup rule.

## Non-goals

- No product runtime changes.
- No changes to Docker executor behavior.
- No test weakening or unrelated cleanup.

## Architecture

### Before

```mermaid
graph TD
    A["EXIT trap"] --> B["Remove temporary plan and database"]
    C["Normal teardown"] --> D["Stop known restorable-task containers one at a time"]
```

### After

```mermaid
graph TD
    A["EXIT trap"] --> B["Shared fixture-image cleanup"]
    C["Normal teardown"] --> B
    B --> D["Force-remove fixture containers and fixture image"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash -n scripts/test-docker-comprehensive.sh`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/build-agent-base-image.sh && docker build -t invoker-agent:latest scripts/fixtures/hello-world-agent && bash scripts/test-suites/dangerous/10-docker-comprehensive.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this PR's commit>`
- Post-revert steps: None
- Data migration? No

</details>
