### PR TITLE
[CI regression: 631a0d0-quality-large-file-guardrail](1) Isolate the large-file guardrail job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,9 +160,6 @@ jobs:
           - name: Required Package Builds
             command: pnpm run check:required-builds
             runner_label: Runner_2_4_core
-          - name: Large File Guardrail
-            command: pnpm run check:large-files
-            runner_label: Runner_1
           - name: Release Version Sync
             command: pnpm run check:versions
             runner_label: Runner_2_4_core
@@ -192,6 +189,33 @@ jobs:
 
       - name: Run quality check
         run: ${{ matrix.command }}
+
+  quality-large-file-guardrail:
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    name: quality / Large File Guardrail
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .node-version
+
+      - name: Run large file guardrail
+        run: pnpm run check:large-files
 
   e2e-proof:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=quality / Large File Guardrail -->

The large-file guardrail now runs in a dedicated GitHub-hosted job without installing repository dependencies.

The failed job exhausted its self-hosted runner before executing any workflow steps. Other quality checks remain in the existing matrix.

## Review Claim

Run `quality / Large File Guardrail` independently on GitHub-hosted infrastructure so self-hosted runner disk exhaustion cannot prevent the source-size check from starting.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

This slice only changes the execution policy for one quality check: it removes that check from the shared matrix and recreates it as a dedicated job.

## Non-goals

- No guardrail threshold or source-classification changes.
- No product behavior changes.
- No changes to other quality commands.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:large-files`
- [x] `git diff --check origin/master...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: Re-run `pnpm run check:large-files`.
- Data migration? No

</details>

