### PR TITLE
[CI regression: 631a0d0-quality-dependency-cruise](1) Run Dependency Cruise on hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,7 @@ jobs:
           if-no-files-found: error
 
   quality-required:
-    runs-on:
-      labels: ${{ matrix.runner_label }}
+    runs-on: ${{ matrix.runner_label }}
     timeout-minutes: 5
     strategy:
       fail-fast: false
@@ -76,7 +75,7 @@ jobs:
         include:
           - name: Dependency Cruise
             command: pnpm run check:deps
-            runner_label: Runner_2_4_core
+            runner_label: ubuntu-latest
           - name: TypeScript Types
             command: pnpm run check:types
             runner_label: Github_Runner

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -39,6 +39,17 @@ for (const jobName of FULL_CI_JOBS) {
 
 assert(jobs['quality-required'], 'Missing quality-required job');
 assert(!jobs['quality-required'].if, 'quality-required must run on ordinary PRs');
+assert(
+  jobs['quality-required']['runs-on'] === '${{ matrix.runner_label }}',
+  'quality-required must use each matrix entry as the full runner selector',
+);
+const qualityRequiredEntries = jobs['quality-required'].strategy?.matrix?.include ?? [];
+const dependencyCruiseEntry = qualityRequiredEntries.find((entry) => entry.name === 'Dependency Cruise');
+assert(dependencyCruiseEntry, 'quality-required matrix must include Dependency Cruise');
+assert(
+  dependencyCruiseEntry.runner_label === 'ubuntu-latest',
+  'Dependency Cruise must run on a GitHub-hosted runner to avoid self-hosted setup disk pressure',
+);
 
 assert(jobs['quality-extra'], 'Missing quality-extra job');
 assert(jobs['quality-extra'].if === ORDINARY_PR_GATE, 'quality-extra must run on ordinary PRs and skip merge queue refs');


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=quality / Dependency Cruise -->

CI job `quality / Dependency Cruise` first failed on default-branch push commit 631a0d08c7072e9544813fc1b93fb616586ce441 in run 31620499765.

This routes Dependency Cruise to the GitHub-hosted runner and keeps the CI workflow policy check aligned with that runner selector.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94225435692

## Review Claim

The CI workflow policy now keeps Dependency Cruise on a GitHub-hosted runner, avoiding self-hosted setup disk pressure without weakening the dependency check.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the CI runner selector for Dependency Cruise changes; the command remains `pnpm run check:deps`, and the workflow policy test asserts that exact selector.

## Slice Rationale

One tooling-policy slice covers the workflow runner fix and the local policy assertion that prevents this CI regression from returning.

## Non-goals

No dependency rules are changed.

No product runtime behavior is changed.

No tests are weakened or skipped.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:deps`
- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert HEAD`
- Post-revert steps: Re-run `node scripts/test-ci-workflow-merge-queue-policy.mjs` and `pnpm run check:deps`.
- Data migration? No

</details>
