### PR TITLE
[CI regression: 631a0d0-required-fast-submit-workflow-chain](1) Assign Github_Runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
     runs-on:
-      labels: Runner_2_4_core
+      labels: ${{ matrix.runner_label }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -323,10 +323,13 @@ jobs:
               bash scripts/test-suites/required/15-owner-boundary-policy.sh
               bash scripts/test-suites/required/50-verify-executor-routing.sh
               bash scripts/test-suites/required/51-verify-scratch-execution.sh
+            runner_label: Runner_2_4_core
           - name: Vitest Workspace
             command: bash scripts/test-suites/required/10-vitest-workspace.sh
+            runner_label: Runner_2_4_core
           - name: Submit Workflow Chain
             command: bash scripts/test-suites/required/15-submit-workflow-chain.sh
+            runner_label: Github_Runner
     name: required-fast / ${{ matrix.name }}
 
     steps:


### PR DESCRIPTION
<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=required-fast / Submit Workflow Chain -->

## Summary

The affected required-fast CI job first failed on default-branch commit `631a0d08c7072e9544813fc1b93fb616586ce441` in run 31620499765.

This change assigns that matrix entry to `Github_Runner`. The other required-fast entries remain on `Runner_2_4_core`.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217860

## Review Claim

Set `matrix.runner_label` to `Github_Runner` for the affected required-fast entry while retaining `Runner_2_4_core` for the other entries.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Every required-fast matrix entry declares its runner explicitly; only `Submit Workflow Chain` selects `Github_Runner`.

## Slice Rationale

This is one CI runner-policy slice limited to the failing job's execution environment.

## Non-goals

- No product behavior changes.
- No test weakening or snapshot updates.
- No runner changes for the other required-fast matrix entries.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/15-submit-workflow-chain.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes. Reverting restores the previous shared runner label for all required-fast matrix entries.
- Revert command: `git revert 087ae4fde`
- Post-revert steps: Re-run the exact Test Plan command.
- Data migration? No.

</details>
