### PR TITLE
[CI regression: 631a0d0-quality-required-package-builds](1) Run package builds on ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,36 @@ jobs:
       - name: Run UI vitest
         run: pnpm --filter @invoker/ui test
 
+  required-package-builds:
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    name: quality / Required Package Builds
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .node-version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run required package builds
+        run: pnpm run check:required-builds
+
   quality-extra:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     runs-on:
@@ -156,9 +186,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Required Package Builds
-            command: pnpm run check:required-builds
-            runner_label: Runner_2_4_core
           - name: Release Version Sync
             command: pnpm run check:versions
             runner_label: Runner_2_4_core

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -54,6 +54,11 @@ assert(
 assert(jobs['quality-extra'], 'Missing quality-extra job');
 assert(jobs['quality-extra'].if === ORDINARY_PR_GATE, 'quality-extra must run on ordinary PRs and skip merge queue refs');
 
+assert(jobs['required-package-builds'], 'Missing required-package-builds job');
+assert(
+  jobs['required-package-builds'].if === ORDINARY_PR_GATE,
+  'required-package-builds must run on ordinary PRs and skip merge queue refs',
+);
 
 assert(jobs.docker, 'Missing docker job');
 assert(jobs.docker.if === NON_PR_GATE, 'docker must not run on pull_request events');


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=quality / Required Package Builds -->

Required Package Builds now has a dedicated CI job on ordinary pull requests and default-branch pushes.

It uses `ubuntu-latest` so the package build no longer depends on `Runner_2_4_core` capacity.

The existing CI workflow audit now covers that job's event condition.

## Review Claim

The CI workflow gives `quality / Required Package Builds` a dedicated `ubuntu-latest` job with matching workflow-audit coverage.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for `quality / Required Package Builds` runner placement.

## Slice Rationale

This is one CI policy slice because the workflow row and audit assertion define the same required build job.

## Non-goals

No product code changes.

No weakening of required checks.

No unrelated CI cleanup.

No test expectation weakening.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:required-builds`
- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/invoker-pr-bodies/ci-regression-631a0d0.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 197336b82`
- Post-revert steps: Re-run `pnpm run check:required-builds` and `node scripts/test-ci-workflow-merge-queue-policy.mjs`.
- Data migration? No

</details>
