### PR TITLE
[CI regression: 631a0d0-ssh-shard-30](1) Forward Electron cache to SSH tasks

### DIFF
--- a/scripts/e2e-ssh/lib/ssh-common.sh
+++ b/scripts/e2e-ssh/lib/ssh-common.sh
@@ -103,19 +103,19 @@ invoker_e2e_ssh_prune_login_path_file() {
   local env_path="$1"
   [ -f "$env_path" ] || return 0
   awk '
-    /# invoker-e2e-ssh-pnpm-path / {
+    /# invoker-e2e-ssh-runtime-env / {
       prefix = $0
-      sub(/[[:space:]]*# invoker-e2e-ssh-pnpm-path .*/, "", prefix)
+      sub(/[[:space:]]*# invoker-e2e-ssh-runtime-env .*/, "", prefix)
       if (prefix != "") print prefix
-      skip_path = 1
+      skip_exports = 2
       next
     }
-    skip_path && /^export PATH=/ {
-      skip_path = 0
+    skip_exports > 0 && /^export (PATH|electron_config_cache)=/ {
+      skip_exports--
       next
     }
     {
-      skip_path = 0
+      skip_exports = 0
       print
     }
   ' "$env_path" > "${env_path}.tmp" || true
@@ -153,6 +153,17 @@ invoker_e2e_ssh_provision_command() {
 
 invoker_e2e_ssh_config_provision_command() {
   printf 'INVOKER_SKIP_SHELL_HOOKS=1 %s\n' "$(invoker_e2e_ssh_provision_command)"
+}
+
+invoker_e2e_electron_cache_dir() {
+  if [ -n "${electron_config_cache:-}" ]; then
+    printf '%s\n' "$electron_config_cache"
+    return 0
+  fi
+  case "$(uname -s)" in
+    Darwin) printf '%s\n' "$HOME/Library/Caches/electron" ;;
+    *) printf '%s\n' "${XDG_CACHE_HOME:-$HOME/.cache}/electron" ;;
+  esac
 }
 
 # --------------------------------------------------------------------------- #
@@ -219,7 +230,7 @@ invoker_e2e_ssh_init() {
 # SshExecutor uses a non-login shell and sources remoteInvokerHome/env.sh.
 # --------------------------------------------------------------------------- #
 invoker_e2e_ssh_install_login_path() {
-  local pnpm_bin node_bin pnpm_dir node_dir
+  local pnpm_bin node_bin pnpm_dir node_dir electron_cache_dir
   pnpm_bin="$(command -v pnpm || true)"
   node_bin="$(command -v node || true)"
   if [ -z "$pnpm_bin" ] || [ -z "$node_bin" ]; then
@@ -228,15 +239,17 @@ invoker_e2e_ssh_install_login_path() {
   fi
   pnpm_dir="$(cd "$(dirname "$pnpm_bin")" && pwd)"
   node_dir="$(cd "$(dirname "$node_bin")" && pwd)"
+  electron_cache_dir="$(invoker_e2e_electron_cache_dir)"
 
   mkdir -p "$_INVOKER_E2E_SSH_REMOTE_HOME"
   touch "$_INVOKER_E2E_SSH_REMOTE_HOME/env.sh"
   chmod 600 "$_INVOKER_E2E_SSH_REMOTE_HOME/env.sh"
   invoker_e2e_ssh_prune_login_path_file "$_INVOKER_E2E_SSH_REMOTE_HOME/env.sh"
-  if ! grep -Fq "# invoker-e2e-ssh-pnpm-path ${_INVOKER_E2E_SSH_TAG}" "$_INVOKER_E2E_SSH_REMOTE_HOME/env.sh" 2>/dev/null; then
+  if ! grep -Fq "# invoker-e2e-ssh-runtime-env ${_INVOKER_E2E_SSH_TAG}" "$_INVOKER_E2E_SSH_REMOTE_HOME/env.sh" 2>/dev/null; then
     {
-      printf '%s\n' "# invoker-e2e-ssh-pnpm-path ${_INVOKER_E2E_SSH_TAG}"
+      printf '%s\n' "# invoker-e2e-ssh-runtime-env ${_INVOKER_E2E_SSH_TAG}"
       printf 'export PATH="%s:%s:$PATH"\n' "$node_dir" "$pnpm_dir"
+      printf 'export electron_config_cache="%s"\n' "$electron_cache_dir"
     } >> "$_INVOKER_E2E_SSH_REMOTE_HOME/env.sh"
   fi
 

--- a/scripts/test-e2e-ssh-runtime-env.sh
+++ b/scripts/test-e2e-ssh-runtime-env.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-e2e-ssh-runtime-env.XXXXXX")"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+# shellcheck disable=SC1091
+source "$ROOT/scripts/e2e-ssh/lib/ssh-common.sh"
+
+_INVOKER_E2E_SSH_REMOTE_HOME="$TEST_TMPDIR/remote-home"
+_INVOKER_E2E_SSH_TAG="runtime-env-test"
+mkdir -p "$_INVOKER_E2E_SSH_REMOTE_HOME"
+
+invoker_e2e_ssh_run() {
+  bash -c "$1"
+}
+
+expected_cache="$TEST_TMPDIR/electron-cache"
+electron_config_cache="$expected_cache" invoker_e2e_ssh_install_login_path
+
+env_file="$_INVOKER_E2E_SSH_REMOTE_HOME/env.sh"
+grep -F "# invoker-e2e-ssh-runtime-env ${_INVOKER_E2E_SSH_TAG}" "$env_file" >/dev/null
+grep -F "export electron_config_cache=\"$expected_cache\"" "$env_file" >/dev/null
+
+unset electron_config_cache
+case "$(uname -s)" in
+  Darwin) expected_default_cache="$HOME/Library/Caches/electron" ;;
+  *) expected_default_cache="${XDG_CACHE_HOME:-$HOME/.cache}/electron" ;;
+esac
+test "$(invoker_e2e_electron_cache_dir)" = "$expected_default_cache"
+
+invoker_e2e_ssh_prune_login_path_file "$env_file"
+if grep -Fq "invoker-e2e-ssh-runtime-env" "$env_file" || grep -Fq 'export electron_config_cache=' "$env_file"; then
+  echo "FAIL: SSH runtime environment cleanup left tagged exports behind" >&2
+  exit 1
+fi
+
+echo "PASS: SSH runtime environment forwards and cleans the Electron cache"

--- a/scripts/test-suites/optional/30-e2e-ssh.sh
+++ b/scripts/test-suites/optional/30-e2e-ssh.sh
@@ -3,4 +3,5 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
+bash "$ROOT/scripts/test-e2e-ssh-runtime-env.sh"
 exec bash "$ROOT/scripts/e2e-ssh/run-all.sh" 'case-3.[123]-*.sh'


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=ssh / shard-30 -->

CI job `ssh / shard-30` first failed on default-branch push commit `631a0d08c7072e9544813fc1b93fb616586ce441` in run 31620499765.

The failing job log shows Electron postinstall failing during the managed SSH worktree's dependency installation.

This change forwards the host Electron cache path into managed SSH task shells and exercises that runtime-environment contract before shard 30.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217681

## Review Claim

Approve the SSH E2E harness forwarding the host Electron cache location into managed remote task shells, with focused coverage in shard 30.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

The SSH helper, focused contract test, and shard hook form one tooling-policy slice around the same remote-runtime environment contract.

## Non-goals

- No product runtime behavior changes.
- No SSH executor refactor.
- No unrelated CI cleanup or test weakening.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash 'scripts/test-suites/optional/30-e2e-ssh.sh'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f02209435`
- Post-revert steps: None
- Data migration? No

</details>
