### PR TITLE
[CI regression: 631a0d0-required-fast-guardrails](1) Make guardrail verification self-contained

### DIFF
--- a/plans/verify-executor-routing.invoker.json
+++ b/plans/verify-executor-routing.invoker.json
@@ -7,6 +7,9 @@
       "poolId": "dummy-target"
     }
   ],
+  "worktreeTargets": {
+    "local-worktree": {}
+  },
   "executionPools": {
     "dummy-target": {
       "members": [

--- a/scripts/verify-executor-routing.sh
+++ b/scripts/verify-executor-routing.sh
@@ -53,23 +53,45 @@ dest.write_text(nl.join(out) + (nl if text.endswith('\n') else ''), encoding='ut
 echo "==> submit-plan (headless run) $PLAN_SRC (repoUrl -> file:// checkout)"
 ./submit-plan.sh "$PLAN_TMP"
 
-# Assert the routed task completed through the configured worktree pool member if sqlite3 is available.
+# Assert the routed task completed through the configured worktree pool member.
 DB="$TMPDB/invoker.db"
-if [[ -f "$DB" ]] && command -v sqlite3 >/dev/null 2>&1; then
-  STATUS=$(sqlite3 "$DB" "SELECT status FROM tasks WHERE id LIKE '%/verify-routing-command' LIMIT 1;")
-  RUNNER_KIND=$(sqlite3 "$DB" "SELECT runner_kind FROM tasks WHERE id LIKE '%/verify-routing-command' LIMIT 1;")
-  POOL_ID=$(sqlite3 "$DB" "SELECT pool_id FROM tasks WHERE id LIKE '%/verify-routing-command' LIMIT 1;")
-  if [[ "$STATUS" != "completed" ]]; then
-    echo "FAIL: expected routed task to complete, got status='$STATUS'" >&2
-    exit 1
-  fi
-  if [[ "$POOL_ID" != "dummy-target" ]]; then
-    echo "FAIL: expected routed task pool_id=dummy-target, got '$POOL_ID'" >&2
-    exit 1
-  fi
-  if [[ "$RUNNER_KIND" != "worktree" ]]; then
-    echo "FAIL: expected persisted pool-routed task runner_kind=worktree, got '$RUNNER_KIND'" >&2
-    exit 1
-  fi
-  echo "PASS: routed task completed with pool_id=$POOL_ID runner_kind=$RUNNER_KIND"
+if [[ ! -f "$DB" ]]; then
+  echo "FAIL: expected invoker.db at $DB, but it does not exist" >&2
+  echo "==> Contents of $TMPDB:" >&2
+  ls -la "$TMPDB" >&2 || true
+  exit 1
 fi
+
+node --input-type=module - "$DB" <<'EOF'
+const { DatabaseSync } = await import('node:sqlite');
+
+const db = new DatabaseSync(process.argv[2], { readOnly: true });
+try {
+  const row = db.prepare(`
+    SELECT status, runner_kind, pool_id, error
+    FROM tasks
+    WHERE id LIKE '%/verify-routing-command'
+    LIMIT 1
+  `).get();
+
+  if (!row) {
+    console.error('FAIL: could not find persisted verify-routing-command task');
+    process.exit(1);
+  }
+  if (row.status !== 'completed') {
+    console.error(`FAIL: expected routed task to complete, got status='${row.status}' error='${row.error ?? ''}'`);
+    process.exit(1);
+  }
+  if (row.pool_id !== 'dummy-target') {
+    console.error(`FAIL: expected routed task pool_id=dummy-target, got '${row.pool_id ?? ''}'`);
+    process.exit(1);
+  }
+  if (row.runner_kind !== 'worktree') {
+    console.error(`FAIL: expected persisted pool-routed task runner_kind=worktree, got '${row.runner_kind ?? ''}'`);
+    process.exit(1);
+  }
+  console.log(`PASS: routed task completed with pool_id=${row.pool_id} runner_kind=${row.runner_kind}`);
+} finally {
+  db.close();
+}
+EOF

--- a/scripts/verify-scratch-execution.sh
+++ b/scripts/verify-scratch-execution.sh
@@ -40,35 +40,52 @@ if [[ ! -f "$DB" ]]; then
   ls -la "$TMPDB" >&2 || true
   exit 1
 fi
-if ! command -v sqlite3 >/dev/null 2>&1; then
-  echo "FAIL: sqlite3 CLI is not installed on this machine" >&2
-  exit 1
-fi
 
-STATUS=$(sqlite3 "$DB" "SELECT status FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
-RUNNER_KIND=$(sqlite3 "$DB" "SELECT runner_kind FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
-WORKSPACE_PATH=$(sqlite3 "$DB" "SELECT workspace_path FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
+node --input-type=module - "$DB" "$ROOT" <<'EOF'
+const { DatabaseSync } = await import('node:sqlite');
 
-if [[ "$STATUS" != "completed" ]]; then
-  echo "FAIL: expected scratch task to complete, got status='$STATUS'" >&2
-  exit 1
-fi
-if [[ "$RUNNER_KIND" != "scratch" ]]; then
-  echo "FAIL: expected persisted task runner_kind=scratch, got '$RUNNER_KIND'" >&2
-  exit 1
-fi
-if [[ -z "$WORKSPACE_PATH" ]]; then
-  echo "FAIL: expected a workspace_path for the scratch task, got empty" >&2
-  exit 1
-fi
-case "$WORKSPACE_PATH" in
-  "$ROOT"|"$ROOT"/*)
-    echo "FAIL: scratch task workspace_path is inside the repo checkout ($WORKSPACE_PATH); scratch mode must never use the repo" >&2
-    exit 1
-    ;;
-esac
-# A bare `run` (not `owner-serve`) never calls executor destroyAll() for
-# ANY executor type -- worktrees are not reclaimed after it either, per
-# verify-executor-routing.sh. So the scratch temp dir persisting here is
-# expected, not a leak; only owner-serve's shutdown path reclaims it.
-echo "PASS: scratch task completed with runner_kind=$RUNNER_KIND workspace_path=$WORKSPACE_PATH (outside repo)"
+const db = new DatabaseSync(process.argv[2], { readOnly: true });
+const root = process.argv[3];
+try {
+  const row = db.prepare(`
+    SELECT status, runner_kind, workspace_path, error
+    FROM tasks
+    WHERE id LIKE '%/verify-scratch-command'
+    LIMIT 1
+  `).get();
+
+  if (!row) {
+    console.error('FAIL: could not find persisted verify-scratch-command task');
+    process.exit(1);
+  }
+  if (row.status !== 'completed') {
+    console.error(`FAIL: expected scratch task to complete, got status='${row.status}' error='${row.error ?? ''}'`);
+    process.exit(1);
+  }
+  if (row.runner_kind !== 'scratch') {
+    console.error(`FAIL: expected persisted task runner_kind=scratch, got '${row.runner_kind ?? ''}'`);
+    process.exit(1);
+  }
+  if (!row.workspace_path) {
+    console.error('FAIL: expected a workspace_path for the scratch task, got empty');
+    process.exit(1);
+  }
+  if (row.workspace_path === root || row.workspace_path.startsWith(`${root}/`)) {
+    console.error(
+      `FAIL: scratch task workspace_path is inside the repo checkout (${row.workspace_path}); ` +
+      'scratch mode must never use the repo',
+    );
+    process.exit(1);
+  }
+  // A bare `run` (not `owner-serve`) never calls executor destroyAll() for
+  // ANY executor type -- worktrees are not reclaimed after it either, per
+  // verify-executor-routing.sh. So the scratch temp dir persisting here is
+  // expected, not a leak; only owner-serve's shutdown path reclaims it.
+  console.log(
+    `PASS: scratch task completed with runner_kind=${row.runner_kind} ` +
+    `workspace_path=${row.workspace_path} (outside repo)`,
+  );
+} finally {
+  db.close();
+}
+EOF


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=required-fast / Guardrails -->

CI job `required-fast / Guardrails` first failed on default-branch push commit 631a0d08c7072e9544813fc1b93fb616586ce441 in run 31620499765.

The latest recorded failing run was still red at 631a0d08c7072e9544813fc1b93fb616586ce441 in run 31620499765.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217679

This updates the guardrail suite to inspect the temporary SQLite database through Node's built-in sqlite module.

The fixture also includes the local worktree target that its dummy pool member references.

---

CI regression: 631a0d0-required-fast-guardrails - both workflow tasks completed before publication.

## Review Claim

The required-fast guardrail suite no longer depends on a host `sqlite3` binary, and its fixture includes the local worktree target it needs.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only guardrail verification scripts and their fixture config change; product executor behavior and runtime routing stay unchanged.

## Slice Rationale

The CI regression is isolated to the guardrail suite, so the empty follow-up slice was folded into the repair before stack publication.

## Non-goals

No product executor changes.

No routing policy changes outside the required-fast guardrail fixture.

No test weakening or snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/05-delete-all-prod-db-guard.sh && bash scripts/test-suites/required/06-large-file-guardrail.sh && bash scripts/test-suites/required/07-invalid-config-json.sh && bash scripts/test-suites/required/08-build-artifact-surfaces-guard.sh && bash scripts/test-suites/required/10-dag-background-click-noop-guard.sh && bash scripts/test-suites/required/15-owner-boundary-policy.sh && bash scripts/test-suites/required/50-verify-executor-routing.sh` (recorded by the completed verification task commit with exit code 0 before publication)
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-body-ci-regression.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c27638da2`
- Post-revert steps: rerun `bash scripts/test-suites/required/50-verify-executor-routing.sh`
- Data migration? No

</details>
