### PR TITLE
[CI regression: 631a0d0-ssh-shard-31](1) Retry SSH worker dependency installation

### DIFF
--- a/scripts/provision-ssh-worker.sh
+++ b/scripts/provision-ssh-worker.sh
@@ -14,6 +14,8 @@ INVOKER_HOME="${INVOKER_HOME:-$HOME/.invoker}"
 INVOKER_ENV_FILE="${INVOKER_ENV_FILE:-$INVOKER_HOME/env.sh}"
 INVOKER_NODE_MAJOR="${INVOKER_NODE_MAJOR:-26}"
 INVOKER_PNPM_VERSION="${INVOKER_PNPM_VERSION:-10.31.0}"
+INVOKER_PNPM_INSTALL_ATTEMPTS="${INVOKER_PNPM_INSTALL_ATTEMPTS:-3}"
+INVOKER_PNPM_INSTALL_RETRY_DELAY_SECONDS="${INVOKER_PNPM_INSTALL_RETRY_DELAY_SECONDS:-2}"
 INVOKER_NODE_INSTALL_DIR="${INVOKER_NODE_INSTALL_DIR:-$HOME/.local/node-v$INVOKER_NODE_MAJOR}"
 INVOKER_NPM_GLOBAL_PREFIX="${INVOKER_NPM_GLOBAL_PREFIX:-$HOME/.local/npm-global}"
 INVOKER_AGENT_TOOLS="${INVOKER_AGENT_TOOLS:-codex,claude}"
@@ -43,6 +45,9 @@ Options:
 Environment overrides:
   INVOKER_NODE_MAJOR            Node major version. Default: 26
   INVOKER_PNPM_VERSION         pnpm version. Default: 10.31.0
+  INVOKER_PNPM_INSTALL_ATTEMPTS Maximum frozen-install attempts. Default: 3
+  INVOKER_PNPM_INSTALL_RETRY_DELAY_SECONDS
+                               Base delay between install attempts. Default: 2
   INVOKER_AGENT_TOOLS          Comma-separated list. Default: codex,claude
   INVOKER_GIT_USER_NAME        Git committer name for managed worktrees.
   INVOKER_GIT_USER_EMAIL       Git committer email for managed worktrees.
@@ -474,6 +479,31 @@ verify_repo_binaries() {
   fi
 }
 
+install_repo_dependencies() {
+  if ! [[ "$INVOKER_PNPM_INSTALL_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+    die "INVOKER_PNPM_INSTALL_ATTEMPTS must be a positive integer."
+  fi
+  if ! [[ "$INVOKER_PNPM_INSTALL_RETRY_DELAY_SECONDS" =~ ^[0-9]+$ ]]; then
+    die "INVOKER_PNPM_INSTALL_RETRY_DELAY_SECONDS must be a non-negative integer."
+  fi
+
+  local attempt delay_seconds
+  for ((attempt = 1; attempt <= INVOKER_PNPM_INSTALL_ATTEMPTS; attempt += 1)); do
+    if (cd "$REPO_DIR" && pnpm install --frozen-lockfile); then
+      return 0
+    fi
+    if [[ "$attempt" -eq "$INVOKER_PNPM_INSTALL_ATTEMPTS" ]]; then
+      die "Repo dependency installation failed after $attempt attempts."
+    fi
+
+    delay_seconds=$((INVOKER_PNPM_INSTALL_RETRY_DELAY_SECONDS * attempt))
+    warn "Repo dependency installation failed on attempt $attempt/$INVOKER_PNPM_INSTALL_ATTEMPTS; retrying in ${delay_seconds}s."
+    if [[ "$delay_seconds" -gt 0 ]]; then
+      sleep "$delay_seconds"
+    fi
+  done
+}
+
 ensure_repo_install() {
   [[ -f "$REPO_DIR/package.json" ]] || die "No package.json found at $REPO_DIR"
   [[ -f "$REPO_DIR/pnpm-lock.yaml" ]] || die "No pnpm-lock.yaml found at $REPO_DIR"
@@ -489,11 +519,11 @@ ensure_repo_install() {
   fi
   if [[ ! -d "$REPO_DIR/node_modules" || "$current_stamp" != "$desired_stamp" ]]; then
     log "Installing repo dependencies in $REPO_DIR"
-    (cd "$REPO_DIR" && pnpm install --frozen-lockfile)
+    install_repo_dependencies
   fi
   verify_repo_binaries || {
     log "Repo verification failed; reinstalling dependencies."
-    (cd "$REPO_DIR" && pnpm install --frozen-lockfile)
+    install_repo_dependencies
     verify_repo_binaries
   }
   mkdir -p "$(dirname "$stamp_path")"

--- a/scripts/test-provision-ssh-worker-retry.sh
+++ b/scripts/test-provision-ssh-worker-retry.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/invoker-provision-retry.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+REPO_DIR="$TMP_ROOT/repo"
+NODE_INSTALL_DIR="$TMP_ROOT/node-install"
+FAKE_BIN="$NODE_INSTALL_DIR/bin"
+FAKE_PNPM_STATE="$TMP_ROOT/pnpm-attempts"
+mkdir -p \
+  "$REPO_DIR/scripts" \
+  "$REPO_DIR/packages/ui" \
+  "$REPO_DIR/packages/app" \
+  "$FAKE_BIN" \
+  "$TMP_ROOT/home"
+
+cp "$ROOT/scripts/provision-ssh-worker.sh" "$REPO_DIR/scripts/provision-ssh-worker.sh"
+printf '{"private":true}\n' > "$REPO_DIR/package.json"
+printf 'lockfileVersion: 9.0\n' > "$REPO_DIR/pnpm-lock.yaml"
+
+cat > "$FAKE_BIN/pnpm" <<'FAKE_PNPM'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--version" ]]; then
+  printf '%s\n' "$FAKE_PNPM_VERSION"
+  exit 0
+fi
+
+if [[ "${1:-}" == "--dir" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" != "install" ]]; then
+  printf 'unexpected fake pnpm invocation: %s\n' "$*" >&2
+  exit 2
+fi
+
+attempt=0
+if [[ -f "$FAKE_PNPM_STATE" ]]; then
+  attempt="$(cat "$FAKE_PNPM_STATE")"
+fi
+attempt=$((attempt + 1))
+printf '%s\n' "$attempt" > "$FAKE_PNPM_STATE"
+
+if [[ "$attempt" -eq 1 ]]; then
+  printf 'simulated Electron postinstall RequestError: socket hang up\n' >&2
+  exit 1
+fi
+
+mkdir -p node_modules packages/app/node_modules/.bin
+printf '#!/usr/bin/env bash\nexit 0\n' > packages/app/node_modules/.bin/electron
+chmod +x packages/app/node_modules/.bin/electron
+FAKE_PNPM
+chmod +x "$FAKE_BIN/pnpm"
+
+NODE_BIN="$(command -v node)"
+ln -s "$NODE_BIN" "$FAKE_BIN/node"
+PNPM_VERSION="$(pnpm --version)"
+
+env \
+  HOME="$TMP_ROOT/home" \
+  PATH="$FAKE_BIN:$PATH" \
+  FAKE_PNPM_STATE="$FAKE_PNPM_STATE" \
+  FAKE_PNPM_VERSION="$PNPM_VERSION" \
+  INVOKER_HOME="$TMP_ROOT/home/.invoker" \
+  INVOKER_NODE_MAJOR="$(node -p 'process.versions.node.split(".")[0]')" \
+  INVOKER_NODE_INSTALL_DIR="$NODE_INSTALL_DIR" \
+  INVOKER_PNPM_VERSION="$PNPM_VERSION" \
+  INVOKER_PNPM_INSTALL_RETRY_DELAY_SECONDS=0 \
+  INVOKER_SKIP_SYSTEM_PACKAGES=1 \
+  INVOKER_SKIP_AGENT_TOOLS=1 \
+  INVOKER_SKIP_SHELL_HOOKS=1 \
+  bash "$REPO_DIR/scripts/provision-ssh-worker.sh" ensure-repo-ready --repo-dir "$REPO_DIR"
+
+attempts="$(cat "$FAKE_PNPM_STATE")"
+if [[ "$attempts" != "2" ]]; then
+  printf 'FAIL: expected provisioning to recover on attempt 2, saw %s attempts\n' "$attempts" >&2
+  exit 1
+fi
+
+printf 'PASS: SSH worker provisioning retried pnpm install and recovered on attempt 2\n'

--- a/scripts/test-suites/optional/31-e2e-ssh-merge.sh
+++ b/scripts/test-suites/optional/31-e2e-ssh-merge.sh
@@ -3,4 +3,5 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
+bash "$ROOT/scripts/test-provision-ssh-worker-retry.sh"
 exec bash "$ROOT/scripts/e2e-ssh/run-all.sh" 'case-3.[456]-*.sh'


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=ssh / shard-31 -->

CI job `ssh / shard-31` first failed on default-branch commit `631a0d08c7072e9544813fc1b93fb616586ce441` in run 31620499765.

SSH worker provisioning now retries frozen dependency installation up to three times with bounded linear delay. Persistent failures still stop provisioning.

Shard 31 runs a deterministic harness that simulates one transient Electron postinstall socket hang-up and observes recovery on the second attempt.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217551

## Review Claim

Approve bounded retry handling for transient `pnpm install` failures during SSH worker repository provisioning.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect. Retry count and delay are bounded, and exhausted installs still fail.

## Slice Rationale

The provisioning retry, its deterministic harness, and shard-31 wiring form one tooling-policy unit that exercises the changed dependency-install path.

## Non-goals

- No product runtime behavior changes.
- No CI assertion weakening, skipped cases, or timeout increases.
- No dependency or lockfile changes.
- No UI changes or visual proof.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-provision-ssh-worker-retry.sh` — printed `PASS: SSH worker provisioning retried pnpm install and recovered on attempt 2` and exited 0.
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash 'scripts/test-suites/optional/31-e2e-ssh-merge.sh'` — printed `e2e-ssh: 3 passed, 0 failed (3 total)` and exited 0.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; this restores single-attempt dependency installation and removes the focused retry harness from shard 31.
- Revert command: `git revert 79ba7bf9dafaedfba4b2a66f12d3bcd83e790334`
- Post-revert steps: Re-run shard 31.
- Data migration? No

</details>
