### PR TITLE
[CI regression: 631a0d0-quality-typescript-types](1) Route type checks to GitHub-hosted capacity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,6 @@ jobs:
           - name: Dependency Cruise
             command: pnpm run check:deps
             runner_label: ubuntu-latest
-          - name: TypeScript Types
-            command: pnpm run check:types
-            runner_label: Github_Runner
 
     name: quality / ${{ matrix.name }}
 
@@ -108,6 +105,35 @@ jobs:
 
       - name: Run quality check
         run: ${{ matrix.command }}
+
+  typescript-types:
+    name: quality / TypeScript Types
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .node-version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run TypeScript type check
+        run: pnpm run check:types
 
   # UI component suite (@invoker/ui vitest, ~2-3m). Runs on every PR for early
   # feedback AND on merge-queue refs, where `.mergify.yml` requires it — this is


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=quality / TypeScript Types -->

CI job `quality / TypeScript Types` failed during runner setup because the assigned self-hosted runner had no disk space.

This slice gives that job dedicated GitHub-hosted capacity while preserving its visible identity and execution steps.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94225435567

## Review Claim

Assign `quality / TypeScript Types` to `ubuntu-latest` outside the self-hosted quality matrix.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged; the type-check job keeps the same name, setup sequence, and check command.

## Slice Rationale

One CI-policy slice isolates the capacity-sensitive type check without changing the remaining quality matrix.

## Non-goals

- No product behavior changes.
- No type-check command, assertion, or timeout weakening.
- No runner changes for other CI jobs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types` — exited 0.
- [x] `node scripts/validate-pr-body-local.mjs --body-file .git/pr-body-ci-regression-631a0d0.md --base master` — passed.
- [ ] GitHub Actions runs `quality / TypeScript Types` on `ubuntu-latest`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; this restores the type check to the shared self-hosted quality matrix.
- Revert command: `git revert <merged commit SHA>`
- Post-revert steps: Re-run `quality / TypeScript Types` and verify self-hosted runner capacity.
- Data migration? No

</details>
