### PR TITLE
[CI regression: 631a0d0-required-fast-submit-workflow-chain](1) Move workflow-chain shard to Github_Runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
     runs-on:
-      labels: Runner_2_4_core
+      labels: ${{ matrix.runner_label }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -323,10 +323,13 @@ jobs:
               bash scripts/test-suites/required/15-owner-boundary-policy.sh
               bash scripts/test-suites/required/50-verify-executor-routing.sh
               bash scripts/test-suites/required/51-verify-scratch-execution.sh
+            runner_label: Runner_2_4_core
           - name: Vitest Workspace
             command: bash scripts/test-suites/required/10-vitest-workspace.sh
+            runner_label: Runner_2_4_core
           - name: Submit Workflow Chain
             command: bash scripts/test-suites/required/15-submit-workflow-chain.sh
+            runner_label: Github_Runner
     name: required-fast / ${{ matrix.name }}
 
     steps:


### PR DESCRIPTION
## Summary

CI job `required-fast` matrix entry for the workflow-chain shard was failing on default-branch commit 631a0d08c7072e9544813fc1b93fb616586ce441 in run 31620499765.

This assigns only that matrix entry back to the GitHub runner class while leaving the other required-fast jobs on `Runner_2_4_core`.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217860

## Review Claim

The required-fast CI policy now assigns only the workflow-chain shard to `Github_Runner`, which restores the failing job without weakening or broadening required CI.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected runner selection for the workflow-chain shard.

## Slice Rationale

This is one CI policy slice: the runner assignment that caused the regression and the recorded deterministic verification for the repaired job.

## Non-goals

- No product behavior changes.
- No test weakening.
- No unrelated workflow cleanup.
- No changes to the required-fast commands themselves.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/15-submit-workflow-chain.sh` (recorded by workflow verification commit b87b64674 with exit code 0)
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/ci-regression-631a0d0-required-fast-submit-workflow-chain-pr.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert b6365aca2`
- Post-revert steps: rerun the required-fast `Submit Workflow Chain` job to confirm whether the original runner capacity failure returns.
- Data migration? No.

</details>
