### PR TITLE
[CI regression: 631a0d0-ssh-shard-31](1) Fix SSH worker provisioning

### DIFF
--- a/scripts/e2e-ssh/lib/ssh-common.sh
+++ b/scripts/e2e-ssh/lib/ssh-common.sh
@@ -152,7 +152,7 @@ invoker_e2e_ssh_provision_command() {
 }
 
 invoker_e2e_ssh_config_provision_command() {
-  printf 'INVOKER_SKIP_SHELL_HOOKS=1 %s\n' "$(invoker_e2e_ssh_provision_command)"
+  printf 'INVOKER_SKIP_AGENT_TOOLS=1 INVOKER_SKIP_SHELL_HOOKS=1 INVOKER_REPO_INSTALL_IGNORE_SCRIPTS=1 %s\n' "$(invoker_e2e_ssh_provision_command)"
 }
 
 # --------------------------------------------------------------------------- #

--- a/scripts/provision-ssh-worker.sh
+++ b/scripts/provision-ssh-worker.sh
@@ -10,6 +10,7 @@ DRY_RUN=0
 SKIP_SYSTEM_PACKAGES="${INVOKER_SKIP_SYSTEM_PACKAGES:-0}"
 SKIP_AGENT_TOOLS="${INVOKER_SKIP_AGENT_TOOLS:-0}"
 SKIP_SHELL_HOOKS="${INVOKER_SKIP_SHELL_HOOKS:-0}"
+REPO_INSTALL_IGNORE_SCRIPTS="${INVOKER_REPO_INSTALL_IGNORE_SCRIPTS:-0}"
 INVOKER_HOME="${INVOKER_HOME:-$HOME/.invoker}"
 INVOKER_ENV_FILE="${INVOKER_ENV_FILE:-$INVOKER_HOME/env.sh}"
 INVOKER_NODE_MAJOR="${INVOKER_NODE_MAJOR:-26}"
@@ -49,6 +50,8 @@ Environment overrides:
   INVOKER_SKIP_SYSTEM_PACKAGES Skip apt/brew package installation when set to 1.
   INVOKER_SKIP_AGENT_TOOLS     Skip codex/claude npm global installs when set to 1.
   INVOKER_SKIP_SHELL_HOOKS     Skip login shell hook writes when set to 1.
+  INVOKER_REPO_INSTALL_IGNORE_SCRIPTS
+                                Run repo pnpm install with --ignore-scripts when set to 1.
   INVOKER_PROVISION_TRACE_FILE Optional file that receives one line per provision run.
 EOF
 }
@@ -457,7 +460,20 @@ repo_stamp_value() {
   script_hash="$(sha256_file "$REPO_DIR/scripts/provision-ssh-worker.sh")"
   node_version="$(node --version)"
   pnpm_version="$(pnpm --version)"
-  printf 'node=%s\npnpm=%s\nlock=%s\nscript=%s\n' "$node_version" "$pnpm_version" "$lock_hash" "$script_hash"
+  printf 'node=%s\npnpm=%s\nlock=%s\nscript=%s\nignore_scripts=%s\n' \
+    "$node_version" \
+    "$pnpm_version" \
+    "$lock_hash" \
+    "$script_hash" \
+    "$REPO_INSTALL_IGNORE_SCRIPTS"
+}
+
+repo_install() {
+  local args=(install --frozen-lockfile)
+  if [[ "$REPO_INSTALL_IGNORE_SCRIPTS" == "1" ]]; then
+    args+=(--ignore-scripts)
+  fi
+  (cd "$REPO_DIR" && pnpm "${args[@]}")
 }
 
 verify_repo_binaries() {
@@ -470,7 +486,9 @@ verify_repo_binaries() {
   fi
   if [[ -d "$REPO_DIR/packages/app" ]]; then
     pnpm --dir "$REPO_DIR/packages/app" exec vitest --version >/dev/null
-    [[ -x "$REPO_DIR/packages/app/node_modules/.bin/electron" ]] || die "Electron binary missing after provisioning: packages/app/node_modules/.bin/electron"
+    if [[ "$REPO_INSTALL_IGNORE_SCRIPTS" != "1" ]]; then
+      [[ -x "$REPO_DIR/packages/app/node_modules/.bin/electron" ]] || die "Electron binary missing after provisioning: packages/app/node_modules/.bin/electron"
+    fi
   fi
 }
 
@@ -489,11 +507,11 @@ ensure_repo_install() {
   fi
   if [[ ! -d "$REPO_DIR/node_modules" || "$current_stamp" != "$desired_stamp" ]]; then
     log "Installing repo dependencies in $REPO_DIR"
-    (cd "$REPO_DIR" && pnpm install --frozen-lockfile)
+    repo_install
   fi
   verify_repo_binaries || {
     log "Repo verification failed; reinstalling dependencies."
-    (cd "$REPO_DIR" && pnpm install --frozen-lockfile)
+    repo_install
     verify_repo_binaries
   }
   mkdir -p "$(dirname "$stamp_path")"


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=ssh / shard-31 -->

CI job `ssh / shard-31` first failed on default-branch push commit 631a0d08c7072e9544813fc1b93fb616586ce441 in run 31620499765.

The SSH worker config now uses a lightweight provisioning mode for agent tools, shell hooks, and repo install scripts in this e2e path.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217551

## Review Claim

This slice makes SSH e2e worker provisioning use the lightweight dependency path needed by shard 31.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The lightweight install behavior is opt-in through `INVOKER_REPO_INSTALL_IGNORE_SCRIPTS`, and the default provisioning path still runs install scripts and checks Electron.

## Slice Rationale

This is one CI tooling policy slice: the SSH e2e provisioning config and the worker installer flag change together.

## Non-goals

No product behavior changes.

No test weakening, unrelated cleanup, or snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash 'scripts/test-suites/optional/31-e2e-ssh-merge.sh'` (workflow verification task exited 0 in commit e03fbda59ecb3253d6808ec3c6096263fe1c0f6b)
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/ci-regression-631a0d0-ssh-shard-31-pr.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 19c609d913b62f52539112f2b242256f6f8a1b20`
- Post-revert steps: Re-run `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash 'scripts/test-suites/optional/31-e2e-ssh-merge.sh'`
- Data migration? No

</details>
