### PR TITLE
[CI regression: 631a0d0-docker-comprehensive](1) Route docker comprehensive to heavy runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -958,8 +958,7 @@ jobs:
   docker:
     if: ${{ github.event_name != 'pull_request' }}
     needs: build-artifacts
-    runs-on:
-      labels: Runner_2_4_core
+    runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu, Runner_Heavy_Docker]
     timeout-minutes: 60
     name: docker / comprehensive
 


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=docker / comprehensive -->

CI job `docker / comprehensive` first failed on default-branch push commit 631a0d08c7072e9544813fc1b93fb616586ce441 in run 31620499765.

The workflow now routes that Docker-heavy job to the self-hosted heavy Docker runner labels instead of the undersized 2-core runner label.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217748

## Review Claim

Approve changing only the `docker / comprehensive` runner selection to the heavy Docker runner class.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change is limited to one GitHub Actions runner selector; job steps, dependencies, timeout, and product code stay unchanged.

## Slice Rationale

This is the smallest reviewable CI-policy slice for the regression: it changes where the existing job runs without changing what the job executes.

## Non-goals

No product behavior changes, test weakening, workflow-step rewrites, unrelated CI cleanup, or snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] Not rerun during PR publication: `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/build-agent-base-image.sh && docker build -t invoker-agent:latest scripts/fixtures/hello-world-agent && bash scripts/test-suites/dangerous/10-docker-comprehensive.sh`
- [x] Invoker verification commit `cece2e7e6c1a1d34884d7f8f69a97e8739c69873` records exit code 0 for the local verification task.
- [x] `node scripts/validate-pr-body.mjs --body "$(gh pr view 8827 --json body --jq .body)"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 7e673f99c0dc298707ca6795a86f8f07ca9eb04f`
- Post-revert steps: Re-run the `docker / comprehensive` CI job.
- Data migration? No.

</details>
