### PR TITLE
[CI regression: 631a0d0-ssh-shard-30](1) Repair SSH worker bootstrap

### DIFF
--- a/scripts/electron.cjs
+++ b/scripts/electron.cjs
@@ -119,6 +119,10 @@ async function repairElectronWithSystemUnzip(electronPackageDir) {
 }
 
 async function installElectronOrExit() {
+  if (process.env.INVOKER_SKIP_ELECTRON_INSTALL === '1') {
+    return null;
+  }
+
   const electronPackageDir = resolveElectronPackageDir();
   if (!electronPackageDir) {
     console.error('Electron package is not installed. Run pnpm install with network access.');

--- a/scripts/provision-ssh-worker.sh
+++ b/scripts/provision-ssh-worker.sh
@@ -489,7 +489,12 @@ install_repo_dependencies() {
 
   local attempt delay_seconds
   for ((attempt = 1; attempt <= INVOKER_PNPM_INSTALL_ATTEMPTS; attempt += 1)); do
-    if (cd "$REPO_DIR" && pnpm install --frozen-lockfile); then
+    if (
+      cd "$REPO_DIR"
+      INVOKER_SKIP_ELECTRON_INSTALL=1 ELECTRON_SKIP_BINARY_DOWNLOAD=1 pnpm install --frozen-lockfile \
+        && node scripts/electron.cjs --install-only \
+        && node scripts/fix-node-pty-spawn-helper.mjs
+    ); then
       return 0
     fi
     if [[ "$attempt" -eq "$INVOKER_PNPM_INSTALL_ATTEMPTS" ]]; then

--- a/scripts/test-provision-ssh-worker-retry.sh
+++ b/scripts/test-provision-ssh-worker-retry.sh
@@ -17,6 +17,8 @@ mkdir -p \
   "$TMP_ROOT/home"
 
 cp "$ROOT/scripts/provision-ssh-worker.sh" "$REPO_DIR/scripts/provision-ssh-worker.sh"
+printf 'process.exit(0);\n' > "$REPO_DIR/scripts/electron.cjs"
+printf 'process.exit(0);\n' > "$REPO_DIR/scripts/fix-node-pty-spawn-helper.mjs"
 printf '{"private":true}\n' > "$REPO_DIR/package.json"
 printf 'lockfileVersion: 9.0\n' > "$REPO_DIR/pnpm-lock.yaml"
 


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=ssh / shard-30 -->

The SSH worker bootstrap now skips Electron's binary download during the offline dependency install.

It installs the Electron binary explicitly afterward, then reapplies the node-pty helper fix before verifying repo binaries.

This keeps shard 30 from failing while preserving the full verification path for the provisioned worker.

## Review Claim

Approve the SSH worker dependency bootstrap policy change that separates offline package installation from Electron binary repair.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the SSH worker provisioning script and its Electron install helper are touched; product runtime behavior and other CI jobs stay unchanged except for the repaired bootstrap.

## Slice Rationale

This slice contains the CI bootstrap correction because the verification commit was proof-only and made no reviewable file changes.

## Non-goals

No product behavior changes.

No test weakening.

No unrelated cleanup or snapshot churn.

No changes to non-SSH CI jobs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `INVOKER_SKIP_ELECTRON_INSTALL=1 ELECTRON_SKIP_BINARY_DOWNLOAD=1 pnpm install --frozen-lockfile`
- [x] `node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash 'scripts/test-suites/optional/30-e2e-ssh.sh'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b0f9106689367cff6ebdf3b89d2602e19380b48f`
- Post-revert steps: rerun `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash 'scripts/test-suites/optional/30-e2e-ssh.sh'`
- Data migration? No

</details>
