### PR TITLE
[CI regression: 631a0d0-required-fast-guardrails](1) Remove sqlite3 CLI dependency

### DIFF
--- a/scripts/verify-scratch-execution.sh
+++ b/scripts/verify-scratch-execution.sh
@@ -40,35 +40,46 @@ if [[ ! -f "$DB" ]]; then
   ls -la "$TMPDB" >&2 || true
   exit 1
 fi
-if ! command -v sqlite3 >/dev/null 2>&1; then
-  echo "FAIL: sqlite3 CLI is not installed on this machine" >&2
-  exit 1
-fi
+node --input-type=module - "$DB" "$ROOT" <<'EOF'
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 
-STATUS=$(sqlite3 "$DB" "SELECT status FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
-RUNNER_KIND=$(sqlite3 "$DB" "SELECT runner_kind FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
-WORKSPACE_PATH=$(sqlite3 "$DB" "SELECT workspace_path FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
+const [, , dbPath, repoRoot] = process.argv;
+const db = new DatabaseSync(dbPath, { readOnly: true });
+const row = db
+  .prepare("SELECT status, runner_kind AS runnerKind, workspace_path AS workspacePath FROM tasks WHERE id LIKE '%/verify-scratch-command' LIMIT 1;")
+  .get();
+db.close();
 
-if [[ "$STATUS" != "completed" ]]; then
-  echo "FAIL: expected scratch task to complete, got status='$STATUS'" >&2
-  exit 1
-fi
-if [[ "$RUNNER_KIND" != "scratch" ]]; then
-  echo "FAIL: expected persisted task runner_kind=scratch, got '$RUNNER_KIND'" >&2
-  exit 1
-fi
-if [[ -z "$WORKSPACE_PATH" ]]; then
-  echo "FAIL: expected a workspace_path for the scratch task, got empty" >&2
-  exit 1
-fi
-case "$WORKSPACE_PATH" in
-  "$ROOT"|"$ROOT"/*)
-    echo "FAIL: scratch task workspace_path is inside the repo checkout ($WORKSPACE_PATH); scratch mode must never use the repo" >&2
-    exit 1
-    ;;
-esac
+if (!row) {
+  console.error('FAIL: expected persisted scratch task row, got none');
+  process.exit(1);
+}
+if (row.status !== 'completed') {
+  console.error(`FAIL: expected scratch task to complete, got status='${row.status ?? ''}'`);
+  process.exit(1);
+}
+if (row.runnerKind !== 'scratch') {
+  console.error(`FAIL: expected persisted task runner_kind=scratch, got '${row.runnerKind ?? ''}'`);
+  process.exit(1);
+}
+if (!row.workspacePath) {
+  console.error('FAIL: expected a workspace_path for the scratch task, got empty');
+  process.exit(1);
+}
+
+const normalizedRepoRoot = path.resolve(repoRoot);
+const normalizedWorkspacePath = path.resolve(String(row.workspacePath));
+if (
+  normalizedWorkspacePath === normalizedRepoRoot ||
+  normalizedWorkspacePath.startsWith(`${normalizedRepoRoot}${path.sep}`)
+) {
+  console.error(`FAIL: scratch task workspace_path is inside the repo checkout (${row.workspacePath}); scratch mode must never use the repo`);
+  process.exit(1);
+}
+EOF
 # A bare `run` (not `owner-serve`) never calls executor destroyAll() for
 # ANY executor type -- worktrees are not reclaimed after it either, per
 # verify-executor-routing.sh. So the scratch temp dir persisting here is
 # expected, not a leak; only owner-serve's shutdown path reclaims it.
-echo "PASS: scratch task completed with runner_kind=$RUNNER_KIND workspace_path=$WORKSPACE_PATH (outside repo)"
+echo "PASS: scratch task completed with runner_kind=scratch workspace_path outside repo"


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=required-fast / Guardrails -->

CI job `required-fast / Guardrails` first failed on default-branch push commit 631a0d08c7072e9544813fc1b93fb616586ce441 in run 31620499765.

This slice replaces `sqlite3` CLI reads in the scratch execution guardrail with Node's built-in SQLite API.

The persisted status, runner-kind, and workspace-containment assertions remain in place.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217679

## Review Claim

Approve replacing the scratch guardrail's `sqlite3` CLI queries with one read-only `node:sqlite` query while preserving its persisted-state assertions.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The guardrail queries the same task row and still checks completion, scratch routing, a non-empty workspace path, and containment outside the repository. Product runtime code is unchanged.

## Slice Rationale

One policy slice keeps the CI-environment dependency removal and its equivalent guardrail assertions together.

## Non-goals

- No product runtime behavior changes.
- No assertion weakening.
- No changes to other guardrails.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/verify-scratch-execution.sh` — `PASS: scratch task completed with runner_kind=scratch workspace_path outside repo`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/05-delete-all-prod-db-guard.sh && bash scripts/test-suites/required/06-large-file-guardrail.sh && bash scripts/test-suites/required/07-invalid-config-json.sh && bash scripts/test-suites/required/08-build-artifact-surfaces-guard.sh && bash scripts/test-suites/required/10-dag-background-click-noop-guard.sh && bash scripts/test-suites/required/15-owner-boundary-policy.sh && bash scripts/test-suites/required/50-verify-executor-routing.sh` — builds and guardrails through owner-boundary passed locally; the final routing guard ended with `FAIL: expected routed task to complete, got status='failed'`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert c67e1110a283f05cfd9c607c58333eb02f43e9c3`
- Post-revert steps: Re-run `bash scripts/verify-scratch-execution.sh` in an environment that provides the `sqlite3` CLI.
- Data migration? No.

</details>
