### PR TITLE
[CI regression: e73ee55-optional-worktree-provisioning](1) Install libatomic for optional worktree CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -931,6 +931,17 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
+      - name: Install Node runtime system dependencies
+        run: |
+          if command -v apt-get >/dev/null 2>&1; then
+            SUDO=""
+            if command -v sudo >/dev/null 2>&1; then
+              SUDO="sudo"
+            fi
+            $SUDO apt-get update
+            $SUDO apt-get install -y libatomic1
+          fi
+
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=e73ee552a6e174a85fc6107186bb802b32ec4b6e; job=optional / Worktree Provisioning -->

CI job `optional / Worktree Provisioning` first failed on default-branch push commit e73ee552a6e174a85fc6107186bb802b32ec4b6e in run 31629955741.

The failure was still red at e73ee552a6e174a85fc6107186bb802b32ec4b6e in run 31629955741.

This change installs the missing `libatomic1` runtime dependency before the optional worktree provisioning job sets up Node.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31629955741/job/94262949307

## Review Claim

The optional worktree provisioning CI job now provisions the Node runtime system dependency it needs on Linux runners.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The new dependency install is scoped to the optional worktree provisioning job and is guarded behind `apt-get`, so other CI jobs and product behavior stay unchanged.

## Slice Rationale

This is one CI workflow policy slice: the failing job's runner setup gains the missing runtime package without changing application code or test expectations.

## Non-goals

No product code changes, no test weakening, no unrelated workflow cleanup, and no changes to required CI jobs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/optional/60-worktree-provisioning.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3027d0985`
- Post-revert steps: Re-run `bash scripts/test-suites/optional/60-worktree-provisioning.sh` if the optional CI job is still red.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for CI environments that require the `libatomic1` system package.
  * Added safeguards to skip package installation when the system package manager is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->