### PR TITLE
[CI regression: e73ee55-required-fast-merge-gate-concurrency-repro](1) Move merge gate repro to larger runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,7 +396,7 @@ jobs:
             runner_label: Runner_2_4_core
           - name: Merge Gate Concurrency Repro
             command: bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh
-            runner_label: Runner_1
+            runner_label: Runner_2_4_core
           - name: Start Running MECE Repros
             command: bash scripts/test-suites/required/18-start-running-mece-repros.sh
             runner_label: Runner_2_4_core


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=e73ee552a6e174a85fc6107186bb802b32ec4b6e; job=required-fast / Merge Gate Concurrency Repro -->

The CI regression report identifies `required-fast / Merge Gate Concurrency Repro` at commit e73ee552a6e174a85fc6107186bb802b32ec4b6e in run 31629955741.

This PR changes only that job's runner label from `Runner_1` to `Runner_2_4_core` at `.github/workflows/ci.yml:399`.

The job continues to invoke the same repro script at `.github/workflows/ci.yml:398`.

First reported job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31629955741/job/94262949340

## Review Claim

Approve the isolated runner-label change for the required-fast Merge Gate Concurrency Repro job, with no product behavior change.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only this job's GitHub Actions runner label changes; its command remains `bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh` at `.github/workflows/ci.yml:398`.

## Slice Rationale

One CI policy slice isolates the runner allocation change from product code and unrelated workflow cleanup.

## Non-goals

No product code changes.

No test weakening.

No refactor or unrelated CI cleanup.

No script changes for the repro job.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh`
- Runner output: `required-vitest: src/__tests__/task-runner-fix-publish-and-ssh.test.ts -t 'starts an independent merge gate while another merge gate is still preparing review' passed 1 active test(s) with 0 failure(s)`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7a9f781d4`
- Post-revert steps: Rerun `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh`.
- Data migration? No

</details>
