### PR TITLE
[CI regression: e73ee55-required-fast-launch-dispatch-queue-repro](1) Reclaim required-fast workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,6 +416,9 @@ jobs:
     name: required-fast / ${{ matrix.name }}
 
     steps:
+      - name: Reclaim workspace
+        run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" "$HOME/.invoker" "$HOME/.claude" 2>/dev/null || true
+        shell: bash
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=e73ee552a6e174a85fc6107186bb802b32ec4b6e; job=required-fast / Launch Dispatch Queue Repro -->

CI job `required-fast / Launch Dispatch Queue Repro` first failed on default-branch push commit e73ee552a6e174a85fc6107186bb802b32ec4b6e in run 31629955741.

The required-fast matrix now reclaims runner-owned workspace paths before checkout so this repro can start from a writable workspace.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31629955741/job/94262949380

---

CI regression: e73ee55-required-fast-launch-dispatch-queue-repro — 2 tasks completed.

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1786574113426-154/fix-ci-e73ee55-required-fast-launch-dispatch-queue-repro | Fix CI job required-fast / Launch Dispatch Queue Repro first observed failing at e73ee552a6e174a85fc6107186bb802b32ec4b6e. | completed |
| wf-1786574113426-154/verify-ci-e73ee55-required-fast-launch-dispatch-queue-repro | Run local proof for CI job required-fast / Launch Dispatch Queue Repro. | completed |

</details>

## Review Claim

Reclaiming runner-owned workspace directories before the required-fast checkout fixes the launch dispatch queue CI regression at the CI policy source.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only required-fast runner workspace permissions are adjusted before checkout; repository code and product behavior are unchanged.

## Slice Rationale

This slice is limited to the CI job setup needed for the failing required-fast launch dispatch queue repro to start reliably.

## Non-goals

No product behavior changes.

No test weakening, snapshot churn, or unrelated CI restructuring.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/25-launch-dispatch-queue-handoff-repro.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert: `git revert f51cab092`
- Post-revert steps: Re-run `required-fast / Launch Dispatch Queue Repro`.
- Data migration? No

</details>
