### PR TITLE
[CI regression: e73ee55-optional-visual-proof-validate](1) Reclaim optional job workspace before checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -923,6 +923,9 @@ jobs:
     name: optional / ${{ matrix.name }}
 
     steps:
+      - name: Reclaim workspace
+        run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" "$HOME/.invoker" "$HOME/.claude" 2>/dev/null || true
+        shell: bash
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=e73ee552a6e174a85fc6107186bb802b32ec4b6e; job=optional / Visual Proof Validate -->

The optional CI matrix reclaims runner-owned workspace directories before checkout.

That prevents leftover runner-owned files from blocking setup while leaving the existing job script unchanged.

The failure was recorded in run 31629955741 at commit e73ee552a6e174a85fc6107186bb802b32ec4b6e.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31629955741/job/94262949321

## Review Claim

The optional CI matrix should reclaim runner-owned workspace directories before checkout so the existing job script can run.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged because the ownership repair is scoped to the optional matrix setup step and only changes runner filesystem permissions.

## Slice Rationale

One tooling-policy slice keeps the optional runner permissions repair and its deterministic proof in one locally reviewable change.

## Non-goals

- No product runtime behavior changes.
- No test weakening or snapshot churn.
- No changes to the optional visual-proof validation command.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/optional/70-ui-visual-proof-validate.sh`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-body-ci-regression-e73ee55.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ce60c38a31542ae733fef9285c01917450915093`
- Post-revert steps: Rerun `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/optional/70-ui-visual-proof-validate.sh` if the optional job regresses again.
- Data migration? No

</details>

## Workflow Summary

CI regression: e73ee55-optional-visual-proof-validate — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1786595690958-41/fix-ci-e73ee55-optional-visual-proof-validate | Reclaim runner-owned optional-job workspace directories before checkout without changing the job command. | completed |
| wf-1786595690958-41/verify-ci-e73ee55-optional-visual-proof-validate | Run the exact local verification command for `optional / Visual Proof Validate`. | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1786595690958-41/fix-ci-e73ee55-optional-visual-proof-validate

`.github/workflows/ci.yml` now reclaims `$GITHUB_WORKSPACE`, `$HOME/.invoker`, and `$HOME/.claude` before optional matrix checkout.

### wf-1786595690958-41/verify-ci-e73ee55-optional-visual-proof-validate

No file changes. The verification task ran the required command.

</details>
