### PR TITLE
[CI regression: e73ee55-ui-vitest](1) Repair UI Vitest CI runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Run quality check
         run: ${{ matrix.command }}
 
-  # UI component suite (@invoker/ui vitest, ~2-3m). Runs on every PR for early
+  # UI component suite (@invoker/ui vitest). Runs on every PR for early
   # feedback AND on merge-queue refs, where `.mergify.yml` requires it — this is
   # the gate that blocks behavioral UI regressions (e.g. the sidebar navigation
   # guard) that still type-check. Scoped to @invoker/ui on purpose: the full
@@ -119,7 +119,7 @@ jobs:
     name: UI Vitest
     runs-on:
       labels: Runner_Vitest
-    timeout-minutes: 5
+    timeout-minutes: 15
 
     steps:
       - name: Reclaim workspace
@@ -132,6 +132,11 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+
+      - name: Install Node runtime dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libatomic1
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=e73ee552a6e174a85fc6107186bb802b32ec4b6e; job=UI Vitest -->

CI job `UI Vitest` first failed on default-branch push commit e73ee552a6e174a85fc6107186bb802b32ec4b6e in run 31629955741.

The job now installs the missing Node runtime library before setup-node and has a CI timeout sized for the component suite.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31629955741/job/94257840486

## Review Claim

The UI Vitest CI policy now provisions the runtime dependency and timeout required for the existing test command to complete.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the `UI Vitest` workflow job changes; product code, test assertions, and other CI jobs stay unchanged.

## Slice Rationale

This is one CI-policy slice for the failed `UI Vitest` job because the runtime package install and timeout both affect the same job execution path.

## Non-goals

No product behavior changes.

No test weakening, assertion rewrites, or snapshot churn.

No changes to other CI jobs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test`
- [x] `node scripts/validate-pr-body-local.mjs --body-file pr-body-e73ee55-ui-vitest.md --base master`
- [x] `node scripts/validate-pr-body.mjs --body-file pr-body-e73ee55-ui-vitest.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <this PR commit>`
- Post-revert steps: Re-run `pnpm --filter @invoker/ui test` before re-queueing any replacement CI-policy fix.
- Data migration? No

</details>
