### PR TITLE
[CI repair thrash prevention](2) Retired-job hygiene: never file unverifiable repairs

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -41,7 +41,7 @@ export const TERMINAL_WORKFLOW_STATUSES = new Set(['completed', 'failed', 'close
 export const BROKEN_JOB_CONCLUSIONS = new Set(['failure', 'timed_out', 'action_required']);
 export const IGNORED_JOB_CONCLUSIONS = new Set(['cancelled', 'skipped', 'neutral']);
 export const MARKER_PREFIX = 'invoker-ci-regression-watch: first-bad-sha=';
-export const STATE_SCHEMA_VERSION = 3;
+export const STATE_SCHEMA_VERSION = 4;
 export const DEFAULT_MAX_ATTEMPTS = 3;
 export const MAX_ATTEMPTS = parseNonNegativeInteger(
   process.env.INVOKER_CI_WATCH_MAX_ATTEMPTS,
@@ -116,6 +116,7 @@ function normalizeActiveFailure(failure, fallbackJobName) {
       ? failure.lastFiledAt
       : null,
     needsHuman: Boolean(failure.needsHuman),
+    retired: Boolean(failure.retired),
   };
 }
 
@@ -294,6 +295,18 @@ export function markFailureNeedsHuman(state, failure) {
   return normalized;
 }
 
+export function markFailureRetired(state, failure, retired = true) {
+  const normalized = normalizeStateForMutation(state);
+  const jobName = failure.jobName;
+  const existing = normalized.activeFailures[jobName];
+  if (!existing) return normalized;
+  normalized.activeFailures[jobName] = {
+    ...existing,
+    retired: Boolean(retired),
+  };
+  return normalized;
+}
+
 export function recordFailureFiled(state, failure, filedAt = new Date()) {
   const normalized = normalizeStateForMutation(state);
   const jobName = failure.jobName;
@@ -304,6 +317,7 @@ export function recordFailureFiled(state, failure, filedAt = new Date()) {
     attempts: Number(existing.attempts ?? 0) + 1,
     lastFiledAt: filedAt.toISOString(),
     needsHuman: false,
+    retired: false,
   };
   return normalized;
 }
@@ -442,6 +456,11 @@ export function buildCiJobDefinitions(workflow = parseYaml(readFileSync(WORKFLOW
   return definitions;
 }
 
+export function jobNameIsMapped(jobName, jobDefinitions) {
+  const definition = jobDefinitions?.get(jobName);
+  return Boolean(definition?.verifyCommand?.trim());
+}
+
 export function fallbackVerifyCommand(jobName) {
   return `bash -lc ${shellSingleQuote(`echo "No local verify command is mapped for CI job: ${jobName}" >&2; exit 1`)}`;
 }
@@ -561,7 +580,11 @@ export function liveQueryHasNonTerminalWork(failureOrSha, jobName, queryFn = hea
 
 export function fileBugfixPlan(failure, opts = {}) {
   const repoUrl = opts.repoUrl ?? getRepoUrl();
-  const vars = buildPlanVars(failure, repoUrl, opts.jobDefinitions);
+  const jobDefinitions = opts.jobDefinitions ?? buildCiJobDefinitions();
+  if (!jobNameIsMapped(failure.jobName, jobDefinitions)) {
+    throw new Error(`Cannot file CI regression repair plan for unmapped CI job: ${failure.jobName}`);
+  }
+  const vars = buildPlanVars(failure, repoUrl, jobDefinitions);
   const outDir = join(opts.outRoot ?? join(REPO_ROOT, 'plans', 'rendered'), vars.job_slug);
   const varArgs = Object.entries(vars).flatMap(([k, v]) => ['--var', `${k}=${v}`]);
   const run = opts.runCommand ?? runCommand;
@@ -577,10 +600,12 @@ export function processFailureFilingSweep(state, {
   now = new Date(),
   maxAttempts = MAX_ATTEMPTS,
   capPerSweep = CAP_PER_SWEEP,
+  jobDefinitions = null,
   liveQuery = liveQueryHasNonTerminalWork,
   fileFailure = () => {},
   save = () => {},
   onNeedsHuman = () => {},
+  onRetired = () => {},
 } = {}) {
   const filedAt = now instanceof Date ? now : new Date(now);
   const nowMs = filedAt.getTime();
@@ -591,9 +616,17 @@ export function processFailureFilingSweep(state, {
     groupsDeferredByCap: 0,
     groupsNeedingHuman: 0,
     groupsInBackoff: 0,
+    groupsRetired: 0,
   };
 
   for (const failure of failures) {
+    if (jobDefinitions && !jobNameIsMapped(failure.jobName, jobDefinitions)) {
+      counts.groupsRetired += 1;
+      markFailureRetired(state, failure, true);
+      save(state);
+      onRetired(failure);
+      continue;
+    }
     const attemptGate = shouldFileFailure(failure, { nowMs, maxAttempts });
     if (attemptGate.action === 'needs-human') {
       counts.groupsNeedingHuman += 1;
@@ -671,10 +704,14 @@ export async function main() {
   const failures = getActionableFailures(state);
   const filingCounts = processFailureFilingSweep(state, {
     failures,
+    jobDefinitions,
     fileFailure: (failure) => fileBugfixPlan(failure, { repoUrl, jobDefinitions, dryRun }),
     save: saveState,
     onNeedsHuman: (failure, attemptGate) => {
       console.error(`ci-regression-watch: failure key "${buildMarker(failure.firstBadSha, failure.jobName)}" reached attempt cap (${attemptGate.attempts}); needs human review`);
+    },
+    onRetired: (failure) => {
+      console.error(`ci-regression-watch: failure key "${buildMarker(failure.firstBadSha, failure.jobName)}" has no mapped local verify command; marking retired and skipping filing`);
     },
   });
 

--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -1,7 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  buildCiJobDefinitions,
   buildMarker,
+  fileBugfixPlan,
+  jobNameIsMapped,
   loadEmptyState,
   liveQueryHasNonTerminalWork,
   normalizeState,
@@ -172,11 +175,12 @@ describe('attempt ledger filing gate', () => {
       },
     });
 
-    assert.equal(migrated.schemaVersion, 3);
+    assert.equal(migrated.schemaVersion, 4);
     assert.equal(migrated.lastProcessedRunId, 123);
     assert.equal(migrated.activeFailures.build.attempts, 0);
     assert.equal(migrated.activeFailures.build.lastFiledAt, null);
     assert.equal(migrated.activeFailures.build.needsHuman, false);
+    assert.equal(migrated.activeFailures.build.retired, false);
   });
 
   it('backtests the 2026-08-12 terminal-workflow loop to at most three filings', () => {
@@ -207,5 +211,116 @@ describe('attempt ledger filing gate', () => {
     assert.equal(state.activeFailures[key].attempts, 3);
     assert.equal(state.activeFailures[key].needsHuman, true);
     assert.ok(humanSweeps > 0);
+  });
+});
+
+describe('retired CI job filing gate', () => {
+  it('skips an unmapped job, marks it retired, counts it, and never files', () => {
+    const key = 'playwright / launch-dispatch-stuck-lease';
+    const state = stateWithFailure(makeFailure({ jobName: key }));
+    const jobDefinitions = new Map([
+      ['playwright / 9-of-9', { verifyCommand: 'bash scripts/test-suites/optional/40-playwright-app.sh' }],
+    ]);
+    let filed = 0;
+    let liveQueryCalled = false;
+    const retired = [];
+
+    const counts = processFailureFilingSweep(state, {
+      jobDefinitions,
+      liveQuery: () => {
+        liveQueryCalled = true;
+        return false;
+      },
+      fileFailure: () => {
+        filed += 1;
+      },
+      onRetired: (failure) => {
+        retired.push(failure.jobName);
+      },
+    });
+
+    assert.equal(jobNameIsMapped(key, jobDefinitions), false);
+    assert.equal(filed, 0);
+    assert.equal(liveQueryCalled, false, 'retired gate should skip before live workflow dedup');
+    assert.deepEqual(retired, [key]);
+    assert.equal(counts.groupsRetired, 1);
+    assert.equal(counts.groupsFiled, 0);
+    assert.equal(state.activeFailures[key].retired, true);
+    assert.equal(state.activeFailures[key].attempts, 0);
+  });
+
+  it('treats a live job without a verify command as unmapped', () => {
+    const jobDefinitions = new Map([
+      ['required-fast / Missing Command', { verifyCommand: '' }],
+    ]);
+
+    assert.equal(jobNameIsMapped('required-fast / Missing Command', jobDefinitions), false);
+  });
+
+  it('fileBugfixPlan throws before rendering for an unmapped job', () => {
+    const failure = makeFailure({ jobName: 'playwright / launch-dispatch-stuck-lease' });
+    const calls = [];
+
+    assert.throws(
+      () => fileBugfixPlan(failure, {
+        repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
+        jobDefinitions: new Map(),
+        runCommand: (cmd, args) => calls.push([cmd, args]),
+      }),
+      /unmapped CI job/,
+    );
+    assert.deepEqual(calls, []);
+  });
+
+  it('mapped live job files exactly as before', () => {
+    const key = 'required-fast / Vitest Workspace';
+    const state = stateWithFailure(makeFailure({ jobName: key }));
+    const jobDefinitions = new Map([
+      [key, { verifyCommand: 'bash scripts/test-suites/required/10-vitest-workspace.sh' }],
+    ]);
+    const filed = [];
+    const now = new Date('2026-08-12T01:00:00Z');
+
+    const counts = processFailureFilingSweep(state, {
+      now,
+      jobDefinitions,
+      liveQuery: () => false,
+      fileFailure: (failure) => {
+        filed.push(failure.jobName);
+      },
+    });
+
+    assert.deepEqual(filed, [key]);
+    assert.equal(counts.groupsRetired, 0);
+    assert.equal(counts.groupsFiled, 1);
+    assert.equal(state.activeFailures[key].attempts, 1);
+    assert.equal(state.activeFailures[key].lastFiledAt, now.toISOString());
+    assert.equal(state.activeFailures[key].retired, false);
+  });
+
+  it('backtests the real 2026-08-12 retired playwright key against current ci.yml', () => {
+    const key = 'playwright / launch-dispatch-stuck-lease';
+    const state = stateWithFailure(makeFailure({
+      jobName: key,
+      attempts: 64,
+      lastFiledAt: '2026-08-12T23:45:00.000Z',
+    }));
+    const jobDefinitions = buildCiJobDefinitions();
+    let filed = 0;
+
+    const counts = processFailureFilingSweep(state, {
+      now: new Date('2026-08-13T00:00:00Z'),
+      jobDefinitions,
+      liveQuery: () => false,
+      fileFailure: () => {
+        filed += 1;
+      },
+    });
+
+    assert.equal(jobNameIsMapped(key, jobDefinitions), false);
+    assert.equal(filed, 0);
+    assert.equal(counts.groupsRetired, 1);
+    assert.equal(counts.groupsFiled, 0);
+    assert.equal(state.activeFailures[key].retired, true);
   });
 });


### PR DESCRIPTION
## Summary

The Playwright lease job was retired from ci.yml on 2026-08-06, but the watcher could keep repairing that stale failure key.

This change makes job retirement observable before filing. Missing job names are marked retired, counted in sweeps, and excluded from repair filing.

It also refuses fallback verify mappings before plan rendering, so unverifiable repairs cannot be filed for unmapped jobs.

## Review Claim

The watcher never files a repair plan whose verify_command is the fallback sentinel, and active failures whose jobName is absent from ci.yml are marked retired, logged, and excluded from filing.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only filing eligibility changes. Failures for jobs that still exist in ci.yml with a mapped verify_command are filed exactly as before, and no activeFailure entry is deleted.

## Slice Rationale

This slice covers one failure-key lifecycle: a CI job disappeared, so the watcher must preserve history while stopping its repair loop. Attempt accounting landed in step 1, and cross-job correlation remains separate.

## Non-goals

- No successor-job mapping heuristics.
- No deletion of activeFailures state entries.
- No changes to attempt-cap or backoff logic from step 1.
- No formula or publication changes.

## Architecture

### Before

The sweep treated stale activeFailures as actionable unless another filing gate stopped them.

Jobs without a verify mapping fell through to a fallback command that exited 1 by construction.

### After

The sweep checks current ci.yml job definitions before dedupe and backoff gates, then marks absent job names retired and skips filing.

fileBugfixPlan refuses unmapped verify commands before rendering a repair plan.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --test scripts/e2e-regression-watch.test.mjs`
- [x] `node scripts/repro/repro-e2e-regression-watch.mjs`
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-body-retired-job-hygiene.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e129010253e453162a84ea9e048db1214e8c1ba2`
- Post-revert steps: Watcher may resume filing repair plans for retired or unmapped CI job names.
- Data migration? No

</details>
