### PR TITLE
[CI repair thrash prevention](3) Add watcher failure-description formula input

### DIFF
--- a/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
+++ b/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
@@ -2,11 +2,7 @@ name: "CI regression: {{job_slug}}"
 description: |
   {{marker}}
 
-  CI job `{{job_name}}` first failed on default-branch push commit {{sha}}
-  in run {{run_id}}. It was most recently still red at {{last_bad_sha}}
-  in run {{last_bad_run_id}}.
-
-  First bad job: {{job_url}}
+  {{failure_description}}
 onFinish: pull_request
 mergeMode: external_review
 baseBranch: {{base_branch}}

--- a/skills/plan-to-invoker/formulas/ci-regression-watch/formula.yaml
+++ b/skills/plan-to-invoker/formulas/ci-regression-watch/formula.yaml
@@ -58,5 +58,9 @@ vars:
     required: true
     example: "<!-- invoker-ci-regression-watch: first-bad-sha=abc123def456abc123def456abc123def456ab1; job=playwright / 1-of-9 -->"
     description: "Exact dedup marker embedded in the workflow description."
+  failure_description:
+    required: true
+    example: "CI job `playwright / 1-of-9` first failed on default-branch push commit abc123def456abc123def456abc123def456ab1"
+    description: "Indented workflow description body for the failing CI job or fleet event."
 workflows:
   - ci-regression-watch.workflow.yaml


### PR DESCRIPTION
## Summary

The CI regression formula now accepts the watcher-provided failure description.

That lets ordinary job filings and consolidated fleet filings render the exact incident context without relying on undeclared template variables.

## Review Claim

The ci-regression-watch formula declares and forwards the watcher failure description so the rendered repair plan can include single-job and fleet-event context.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Formula rendering only gains an explicit input that the watcher already supplies; no CI watcher control flow or filing policy changes in this slice.

## Slice Rationale

This is the foundation for fleet-event filing. The formula must accept the richer incident description before the watcher can safely render consolidated plans.

## Non-goals

- No watcher grouping logic.
- No attempt-ledger changes.
- No retired-job behavior changes.
- No PR publication policy changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-e2e-regression-watch.mjs`
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-body-fleet-formula.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? No
- Revert command: `git revert 87337c853b1ea0db674ae30d3e12397e90c0e995`
- Post-revert steps: Also revert dependent fleet-correlation watcher and repro slices, or plan rendering will reject the watcher-provided failure_description variable.
- Data migration? No

</details>
