### PR TITLE
[CI repair thrash prevention](3a) Fleet-event correlation: one incident, one ticket

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -47,6 +47,10 @@ export const MAX_ATTEMPTS = parseNonNegativeInteger(
   process.env.INVOKER_CI_WATCH_MAX_ATTEMPTS,
   DEFAULT_MAX_ATTEMPTS,
 );
+export const FLEET_EVENT_THRESHOLD = parsePositiveInteger(
+  process.env.INVOKER_CI_WATCH_FLEET_THRESHOLD,
+  3,
+);
 export const ATTEMPT_BACKOFF_BASE_MS = 30 * 60 * 1000;
 
 const STATE_DIR = process.env.INVOKER_CI_WATCH_STATE_DIR
@@ -81,6 +85,11 @@ export function slugify(value, maxLength = 72) {
 function parseNonNegativeInteger(value, fallback) {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : fallback;
+}
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
 }
 
 export function buildMarker(sha, jobName) {
@@ -262,6 +271,23 @@ export function getActionableFailures(state) {
     });
 }
 
+function isFleetEventFailure(failure) {
+  return Boolean(failure?.isFleetEvent) || failure?.markerJobName === 'fleet';
+}
+
+export function groupFailuresBySha(failures) {
+  const groups = new Map();
+  for (const failure of failures ?? []) {
+    if (isFleetEventFailure(failure)) continue;
+    const sha = typeof failure?.firstBadSha === 'string' ? failure.firstBadSha.trim() : '';
+    if (!sha) continue;
+    const group = groups.get(sha) ?? [];
+    group.push(failure);
+    groups.set(sha, group);
+  }
+  return groups;
+}
+
 export function shouldFileFailure(failure, {
   nowMs = Date.now(),
   maxAttempts = MAX_ATTEMPTS,
@@ -320,6 +346,188 @@ export function recordFailureFiled(state, failure, filedAt = new Date()) {
     retired: false,
   };
   return normalized;
+}
+
+function getVerifyCommandForFailure(failure, jobDefinitions) {
+  if (typeof failure?.verifyCommand === 'string' && failure.verifyCommand.trim()) {
+    return failure.verifyCommand.trim();
+  }
+  const definition = jobDefinitions?.get(failure?.jobName);
+  return definition?.verifyCommand?.trim() ?? '';
+}
+
+function failureIsMapped(failure, jobDefinitions) {
+  return Boolean(getVerifyCommandForFailure(failure, jobDefinitions));
+}
+
+function buildFleetJobName(sha, count) {
+  return `fleet / ${shortSha(sha)} (${count} jobs)`;
+}
+
+function buildFleetFailureDescription(sha, members) {
+  const memberLines = members.map((member) => {
+    const url = typeof member.firstJobUrl === 'string' && member.firstJobUrl
+      ? member.firstJobUrl
+      : '(no first job URL recorded)';
+    return `- ${member.jobName}: ${url}`;
+  });
+  return [
+    `Fleet-correlated CI event: ${members.length} jobs first failed on default-branch push commit ${sha}.`,
+    'Member jobs:',
+    ...memberLines,
+  ].join('\n');
+}
+
+function pickFleetVerifyCommand(members, jobDefinitions) {
+  return members
+    .map((member) => ({
+      jobName: member.jobName,
+      verifyCommand: getVerifyCommandForFailure(member, jobDefinitions),
+    }))
+    .filter((entry) => entry.verifyCommand)
+    .sort((a, b) => {
+      const lengthDelta = a.verifyCommand.length - b.verifyCommand.length;
+      if (lengthDelta !== 0) return lengthDelta;
+      return a.jobName.localeCompare(b.jobName);
+    })
+    .at(0)?.verifyCommand ?? '';
+}
+
+function synthesizeFleetFailure(state, sha, members, jobDefinitions) {
+  const verifyCommand = pickFleetVerifyCommand(members, jobDefinitions);
+  if (!verifyCommand) return null;
+
+  const existing = Object.values(state.activeFailures ?? {})
+    .find((failure) => isFleetEventFailure(failure) && failure.firstBadSha === sha);
+  const sortedMembers = [...members].sort((a, b) => a.jobName.localeCompare(b.jobName));
+  const firstMember = [...members].sort((a, b) => {
+    const runDelta = Number(a.firstBadRunId ?? 0) - Number(b.firstBadRunId ?? 0);
+    if (runDelta !== 0) return runDelta;
+    return a.jobName.localeCompare(b.jobName);
+  }).at(0);
+  const lastMember = [...members].sort((a, b) => {
+    const runDelta = Number(b.lastBadRunId ?? b.firstBadRunId ?? 0) - Number(a.lastBadRunId ?? a.firstBadRunId ?? 0);
+    if (runDelta !== 0) return runDelta;
+    return a.jobName.localeCompare(b.jobName);
+  }).at(0);
+  const jobName = buildFleetJobName(sha, members.length);
+  return {
+    ...(existing ?? {}),
+    jobName,
+    markerJobName: 'fleet',
+    isFleetEvent: true,
+    firstBadSha: sha,
+    firstBadRunId: firstMember?.firstBadRunId ?? '',
+    firstBadRunCreatedAt: firstMember?.firstBadRunCreatedAt ?? '',
+    firstJobDatabaseId: firstMember?.firstJobDatabaseId ?? '',
+    firstJobUrl: firstMember?.firstJobUrl ?? '',
+    lastBadSha: lastMember?.lastBadSha ?? sha,
+    lastBadRunId: lastMember?.lastBadRunId ?? firstMember?.firstBadRunId ?? '',
+    lastJobDatabaseId: lastMember?.lastJobDatabaseId ?? firstMember?.firstJobDatabaseId ?? '',
+    lastJobUrl: lastMember?.lastJobUrl ?? firstMember?.firstJobUrl ?? '',
+    lastObservedAt: lastMember?.lastObservedAt ?? firstMember?.lastObservedAt ?? '',
+    occurrences: members.reduce((sum, member) => sum + Number(member.occurrences ?? 1), 0),
+    attempts: Number(existing?.attempts ?? 0),
+    lastFiledAt: existing?.lastFiledAt ?? null,
+    needsHuman: Boolean(existing?.needsHuman),
+    retired: Boolean(existing?.retired),
+    verifyCommand,
+    description: buildFleetFailureDescription(sha, sortedMembers),
+    memberJobNames: sortedMembers.map((member) => member.jobName),
+  };
+}
+
+function prepareFleetCorrelatedFailures(state, failures, {
+  threshold = FLEET_EVENT_THRESHOLD,
+  jobDefinitions = null,
+} = {}) {
+  const normalized = normalizeStateForMutation(state);
+  const groups = groupFailuresBySha(failures);
+  const correlated = new Set();
+  const fleetFailures = [];
+  const retiredFleetMembers = [];
+  let stateChanged = false;
+  const existingFleetBySha = new Map(
+    Object.values(normalized.activeFailures)
+      .filter((failure) => isFleetEventFailure(failure) && typeof failure.firstBadSha === 'string')
+      .map((failure) => [failure.firstBadSha, failure]),
+  );
+
+  for (const [sha, members] of groups) {
+    if (members.length < threshold && !existingFleetBySha.has(sha)) continue;
+    const fleetFailure = synthesizeFleetFailure(normalized, sha, members, jobDefinitions);
+    if (!fleetFailure) {
+      for (const member of members) {
+        const existing = normalized.activeFailures[member.jobName];
+        if (!existing) continue;
+        normalized.activeFailures[member.jobName] = {
+          ...existing,
+          memberOfFleetEvent: sha,
+          retired: true,
+        };
+        retiredFleetMembers.push(normalized.activeFailures[member.jobName]);
+        correlated.add(member.jobName);
+        stateChanged = true;
+      }
+      continue;
+    }
+
+    const existingFleet = Object.values(normalized.activeFailures)
+      .find((failure) => isFleetEventFailure(failure) && failure.firstBadSha === sha);
+    if (existingFleet?.jobName && existingFleet.jobName !== fleetFailure.jobName) {
+      delete normalized.activeFailures[existingFleet.jobName];
+    }
+    normalized.activeFailures[fleetFailure.jobName] = fleetFailure;
+    fleetFailures.push(fleetFailure);
+    stateChanged = true;
+
+    for (const member of members) {
+      const existing = normalized.activeFailures[member.jobName];
+      if (!existing) continue;
+      normalized.activeFailures[member.jobName] = {
+        ...existing,
+        memberOfFleetEvent: sha,
+      };
+      correlated.add(member.jobName);
+      stateChanged = true;
+    }
+  }
+
+  for (const [sha, existingFleet] of existingFleetBySha) {
+    if (!groups.has(sha) && existingFleet?.jobName && normalized.activeFailures[existingFleet.jobName]) {
+      delete normalized.activeFailures[existingFleet.jobName];
+      stateChanged = true;
+    }
+  }
+
+  const prepared = [
+    ...fleetFailures,
+    ...failures.filter((failure) => {
+      if (isFleetEventFailure(failure)) return false;
+      return !correlated.has(failure.jobName);
+    }),
+  ].sort((a, b) => {
+    const runDelta = Number(a.firstBadRunId ?? 0) - Number(b.firstBadRunId ?? 0);
+    if (runDelta !== 0) return runDelta;
+    return a.jobName.localeCompare(b.jobName);
+  });
+
+  for (const failure of failures) {
+    if (correlated.has(failure.jobName)) continue;
+    const existing = normalized.activeFailures[failure.jobName];
+    if (existing?.memberOfFleetEvent) {
+      const { memberOfFleetEvent, ...withoutFleetMembership } = existing;
+      normalized.activeFailures[failure.jobName] = withoutFleetMembership;
+      stateChanged = true;
+    }
+  }
+
+  return {
+    failures: prepared,
+    groupsCorrelated: fleetFailures.length,
+    retiredFleetMembers,
+    stateChanged,
+  };
 }
 
 function shellSingleQuote(value) {
@@ -466,10 +674,19 @@ export function fallbackVerifyCommand(jobName) {
 }
 
 export function buildPlanVars(failure, repoUrl, jobDefinitions = buildCiJobDefinitions()) {
-  const definition = jobDefinitions.get(failure.jobName);
   const short = shortSha(failure.firstBadSha);
   const jobSlug = `${short}-${slugify(failure.jobName)}`;
-  const verifyCommand = definition?.verifyCommand?.trim() || fallbackVerifyCommand(failure.jobName);
+  const verifyCommand = getVerifyCommandForFailure(failure, jobDefinitions) || fallbackVerifyCommand(failure.jobName);
+  const markerJobName = failure.markerJobName ?? failure.jobName;
+  const failureDescription = typeof failure.description === 'string' && failure.description.trim()
+    ? failure.description.trim()
+    : [
+      `CI job \`${failure.jobName}\` first failed on default-branch push commit ${failure.firstBadSha}`,
+      `in run ${failure.firstBadRunId ?? ''}. It was most recently still red at ${failure.lastBadSha ?? failure.firstBadSha}`,
+      `in run ${failure.lastBadRunId ?? failure.firstBadRunId ?? ''}.`,
+      '',
+      `First bad job: ${failure.firstJobUrl ?? ''}`,
+    ].join('\n');
   return {
     repo_url: repoUrl,
     base_branch: 'master',
@@ -483,7 +700,8 @@ export function buildPlanVars(failure, repoUrl, jobDefinitions = buildCiJobDefin
     last_bad_sha: failure.lastBadSha ?? failure.firstBadSha,
     last_bad_run_id: String(failure.lastBadRunId ?? failure.firstBadRunId ?? ''),
     verify_command: verifyCommand,
-    marker: buildMarkerComment(failure.firstBadSha, failure.jobName),
+    marker: buildMarkerComment(failure.firstBadSha, markerJobName),
+    failure_description: failureDescription.split(/\r?\n/).join('\n  '),
   };
 }
 
@@ -545,7 +763,9 @@ function headlessQueryWorkflowsJson() {
 
 export function liveQueryHasNonTerminalWork(failureOrSha, jobName, queryFn = headlessQueryWorkflowsJson) {
   const sha = typeof failureOrSha === 'object' ? failureOrSha.firstBadSha : failureOrSha;
-  const job = typeof failureOrSha === 'object' ? failureOrSha.jobName : jobName;
+  const job = typeof failureOrSha === 'object'
+    ? (failureOrSha.markerJobName ?? failureOrSha.jobName)
+    : jobName;
   const marker = buildMarker(sha, job);
   let workflows;
   try {
@@ -581,7 +801,7 @@ export function liveQueryHasNonTerminalWork(failureOrSha, jobName, queryFn = hea
 export function fileBugfixPlan(failure, opts = {}) {
   const repoUrl = opts.repoUrl ?? getRepoUrl();
   const jobDefinitions = opts.jobDefinitions ?? buildCiJobDefinitions();
-  if (!jobNameIsMapped(failure.jobName, jobDefinitions)) {
+  if (!failureIsMapped(failure, jobDefinitions)) {
     throw new Error(`Cannot file CI regression repair plan for unmapped CI job: ${failure.jobName}`);
   }
   const vars = buildPlanVars(failure, repoUrl, jobDefinitions);
@@ -606,9 +826,16 @@ export function processFailureFilingSweep(state, {
   save = () => {},
   onNeedsHuman = () => {},
   onRetired = () => {},
+  fleetEventThreshold = FLEET_EVENT_THRESHOLD,
 } = {}) {
   const filedAt = now instanceof Date ? now : new Date(now);
   const nowMs = filedAt.getTime();
+  const prepared = prepareFleetCorrelatedFailures(state, failures, {
+    threshold: fleetEventThreshold,
+    jobDefinitions,
+  });
+  if (prepared.stateChanged) save(state);
+  for (const retired of prepared.retiredFleetMembers) onRetired(retired);
   const counts = {
     groupsFound: failures.length,
     groupsFiled: 0,
@@ -616,11 +843,12 @@ export function processFailureFilingSweep(state, {
     groupsDeferredByCap: 0,
     groupsNeedingHuman: 0,
     groupsInBackoff: 0,
-    groupsRetired: 0,
+    groupsRetired: prepared.retiredFleetMembers.length,
+    groupsCorrelated: prepared.groupsCorrelated,
   };
 
-  for (const failure of failures) {
-    if (jobDefinitions && !jobNameIsMapped(failure.jobName, jobDefinitions)) {
+  for (const failure of prepared.failures) {
+    if (jobDefinitions && !failureIsMapped(failure, jobDefinitions)) {
       counts.groupsRetired += 1;
       markFailureRetired(state, failure, true);
       save(state);

--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -4,6 +4,7 @@ import {
   buildCiJobDefinitions,
   buildMarker,
   fileBugfixPlan,
+  groupFailuresBySha,
   jobNameIsMapped,
   loadEmptyState,
   liveQueryHasNonTerminalWork,
@@ -36,6 +37,19 @@ function stateWithFailure(failure = makeFailure()) {
   const state = loadEmptyState();
   state.activeFailures[failure.jobName] = failure;
   return state;
+}
+
+function stateWithFailures(failures) {
+  const state = loadEmptyState();
+  for (const failure of failures) state.activeFailures[failure.jobName] = failure;
+  return state;
+}
+
+function jobDefinitionsFor(jobNames) {
+  return new Map(jobNames.map((jobName, index) => [
+    jobName,
+    { verifyCommand: `bash scripts/verify-${index + 1}.sh` },
+  ]));
 }
 
 describe('liveQueryHasNonTerminalWork', () => {
@@ -88,6 +102,223 @@ describe('liveQueryHasNonTerminalWork', () => {
       const result = liveQueryHasNonTerminalWork({ firstBadSha: 'abc1234', jobName: 'build' }, undefined, queryFn);
       assert.equal(result, true);
     });
+  });
+});
+
+describe('fleet SHA correlation', () => {
+  it('groups active failures by first bad SHA', () => {
+    const sha = 'abc123def456abc123def456abc123def456ab1';
+    const failures = [
+      makeFailure({ jobName: 'required-fast / Vitest Workspace', firstBadSha: sha }),
+      makeFailure({ jobName: 'quality / Dependency Cruise', firstBadSha: sha }),
+      makeFailure({ jobName: 'docker / comprehensive', firstBadSha: 'def456def456def456def456def456def456def4' }),
+    ];
+
+    const groups = groupFailuresBySha(failures);
+    assert.equal(groups.get(sha).length, 2);
+    assert.equal(groups.get('def456def456def456def456def456def456def4').length, 1);
+  });
+
+  it('files one consolidated plan for three same-SHA failures and names every member', () => {
+    const sha = 'abc123def456abc123def456abc123def456ab1';
+    const jobs = [
+      'required-fast / Vitest Workspace',
+      'quality / Dependency Cruise',
+      'docker / comprehensive',
+    ];
+    const state = stateWithFailures(jobs.map((jobName, index) => makeFailure({
+      jobName,
+      firstBadSha: sha,
+      firstBadRunId: 100 + index,
+      firstJobDatabaseId: 200 + index,
+      firstJobUrl: `https://example.test/job/${200 + index}`,
+    })));
+    const filed = [];
+    const liveMarkers = [];
+
+    const counts = processFailureFilingSweep(state, {
+      jobDefinitions: jobDefinitionsFor(jobs),
+      liveQuery: (failure) => {
+        liveMarkers.push(buildMarker(failure.firstBadSha, failure.markerJobName ?? failure.jobName));
+        return false;
+      },
+      fileFailure: (failure) => filed.push(failure),
+    });
+
+    assert.equal(filed.length, 1);
+    assert.equal(filed[0].jobName, 'fleet / abc123d (3 jobs)');
+    assert.equal(filed[0].markerJobName, 'fleet');
+    assert.ok(filed[0].verifyCommand.startsWith('bash scripts/verify-'));
+    assert.equal(filed[0].description.includes('No local verify command is mapped'), false);
+    for (const jobName of jobs) {
+      assert.match(filed[0].description, new RegExp(jobName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+      assert.equal(state.activeFailures[jobName].memberOfFleetEvent, sha);
+    }
+    assert.deepEqual(liveMarkers, [buildMarker(sha, 'fleet')]);
+    assert.equal(counts.groupsCorrelated, 1);
+    assert.equal(counts.groupsFiled, 1);
+    assert.equal(state.activeFailures['fleet / abc123d (3 jobs)'].attempts, 1);
+  });
+
+  it('keeps two same-SHA failures on the per-job path', () => {
+    const sha = 'abc123def456abc123def456abc123def456ab1';
+    const jobs = [
+      'required-fast / Vitest Workspace',
+      'quality / Dependency Cruise',
+    ];
+    const state = stateWithFailures(jobs.map((jobName) => makeFailure({ jobName, firstBadSha: sha })));
+    const filed = [];
+
+    const counts = processFailureFilingSweep(state, {
+      jobDefinitions: jobDefinitionsFor(jobs),
+      liveQuery: () => false,
+      fileFailure: (failure) => filed.push(failure.jobName),
+    });
+
+    assert.deepEqual(filed.sort(), [...jobs].sort());
+    assert.equal(counts.groupsCorrelated, 0);
+    assert.equal(counts.groupsFiled, 2);
+    assert.equal(state.activeFailures[jobs[0]].memberOfFleetEvent, undefined);
+  });
+
+  it('applies marker dedup and attempt cap to the fleet key', () => {
+    const sha = 'abc123def456abc123def456abc123def456ab1';
+    const jobs = [
+      'required-fast / Vitest Workspace',
+      'quality / Dependency Cruise',
+      'docker / comprehensive',
+    ];
+    const state = stateWithFailures(jobs.map((jobName) => makeFailure({ jobName, firstBadSha: sha })));
+    const jobDefinitions = jobDefinitionsFor(jobs);
+    let filed = 0;
+
+    const dedupCounts = processFailureFilingSweep(state, {
+      jobDefinitions,
+      liveQuery: (failure) => buildMarker(failure.firstBadSha, failure.markerJobName ?? failure.jobName) === buildMarker(sha, 'fleet'),
+      fileFailure: () => {
+        filed += 1;
+      },
+    });
+
+    assert.equal(filed, 0);
+    assert.equal(dedupCounts.groupsSkippedAlreadyAddressed, 1);
+    assert.equal(state.activeFailures[jobs[0]].memberOfFleetEvent, sha);
+
+    const filedCounts = processFailureFilingSweep(state, {
+      now: new Date('2026-08-12T01:00:00Z'),
+      maxAttempts: 1,
+      jobDefinitions,
+      liveQuery: () => false,
+      fileFailure: () => {
+        filed += 1;
+      },
+    });
+    assert.equal(filedCounts.groupsFiled, 1);
+    assert.equal(state.activeFailures['fleet / abc123d (3 jobs)'].attempts, 1);
+
+    let liveQueryCalled = false;
+    const cappedCounts = processFailureFilingSweep(state, {
+      now: new Date('2026-08-12T03:00:00Z'),
+      maxAttempts: 1,
+      jobDefinitions,
+      liveQuery: () => {
+        liveQueryCalled = true;
+        return false;
+      },
+      fileFailure: () => {
+        filed += 1;
+      },
+    });
+
+    assert.equal(liveQueryCalled, false, 'attempt cap should skip before live workflow dedup');
+    assert.equal(cappedCounts.groupsNeedingHuman, 1);
+    assert.equal(filed, 1);
+    assert.equal(state.activeFailures['fleet / abc123d (3 jobs)'].needsHuman, true);
+  });
+
+  it('keeps remaining members under an existing fleet key after the active count drops below threshold', () => {
+    const sha = 'abc123def456abc123def456abc123def456ab1';
+    const jobs = [
+      'required-fast / Vitest Workspace',
+      'quality / Dependency Cruise',
+      'docker / comprehensive',
+    ];
+    const state = stateWithFailures(jobs.map((jobName) => makeFailure({ jobName, firstBadSha: sha })));
+    const jobDefinitions = jobDefinitionsFor(jobs);
+
+    processFailureFilingSweep(state, {
+      now: new Date('2026-08-12T01:00:00Z'),
+      jobDefinitions,
+      liveQuery: () => false,
+      fileFailure: () => {},
+    });
+    delete state.activeFailures['docker / comprehensive'];
+
+    const filed = [];
+    const liveMarkers = [];
+    const counts = processFailureFilingSweep(state, {
+      now: new Date('2026-08-12T02:00:00Z'),
+      jobDefinitions,
+      liveQuery: (failure) => {
+        liveMarkers.push(buildMarker(failure.firstBadSha, failure.markerJobName ?? failure.jobName));
+        return true;
+      },
+      fileFailure: (failure) => filed.push(failure.jobName),
+    });
+
+    assert.deepEqual(filed, []);
+    assert.deepEqual(liveMarkers, [buildMarker(sha, 'fleet')]);
+    assert.equal(counts.groupsCorrelated, 1);
+    assert.equal(state.activeFailures['required-fast / Vitest Workspace'].memberOfFleetEvent, sha);
+    assert.equal(state.activeFailures['quality / Dependency Cruise'].memberOfFleetEvent, sha);
+  });
+
+  it('backtests the 631a0d0 fleet wave to one consolidated filing instead of eleven', () => {
+    const sha = '631a0d08c7072e9544813fc1b93fb616586ce441';
+    const jobs = [
+      'build-artifacts',
+      'quality / Dependency Cruise',
+      'quality / TypeScript Types',
+      'quality / Required Package Builds',
+      'required-fast / Vitest Workspace',
+      'required-fast / Guardrails',
+      'required-fast / PR Babysit Harness',
+      'ssh / shard-30',
+      'ssh / shard-31',
+      'docker / comprehensive',
+      'e2e-proof / shard 0',
+    ];
+    const failures = jobs.map((jobName, index) => makeFailure({
+      jobName,
+      firstBadSha: sha,
+      firstBadRunId: 6310,
+      firstJobDatabaseId: 63100 + index,
+      firstJobUrl: `https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/6310/job/${63100 + index}`,
+    }));
+    const jobDefinitions = buildCiJobDefinitions();
+    const historicalState = stateWithFailures(failures);
+    const correlatedState = stateWithFailures(failures.map((failure) => ({ ...failure })));
+    const historicalFilings = [];
+    const fleetFilings = [];
+
+    processFailureFilingSweep(historicalState, {
+      fleetEventThreshold: 99,
+      jobDefinitions,
+      liveQuery: () => false,
+      fileFailure: (failure) => historicalFilings.push(failure.jobName),
+    });
+    const counts = processFailureFilingSweep(correlatedState, {
+      jobDefinitions,
+      liveQuery: () => false,
+      fileFailure: (failure) => fleetFilings.push(failure),
+    });
+
+    assert.equal(historicalFilings.length, 11);
+    assert.equal(fleetFilings.length, 1);
+    assert.equal(fleetFilings[0].jobName, 'fleet / 631a0d0 (11 jobs)');
+    for (const jobName of jobs) assert.match(fleetFilings[0].description, new RegExp(jobName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.equal(counts.groupsCorrelated, 1);
+    assert.equal(counts.groupsFiled, 1);
   });
 });
 


### PR DESCRIPTION
## Summary

The watcher now recognizes mass CI failures that first break at the same commit.

When a same-SHA wave reaches the fleet threshold, it files one incident plan that names every affected job instead of one repair plan per job.

Below the threshold, existing per-job filing remains unchanged.

## Review Claim

When FLEET_EVENT_THRESHOLD or more actionable failures share one firstBadSha, the watcher files exactly one consolidated incident plan naming every affected job; below the threshold, per-job filing is unchanged.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Correlation only reduces filings for the same SHA wave. It never expands the incident beyond the affected jobs and leaves per-job filing below the threshold unchanged.

## Slice Rationale

This slice covers one filing-time policy change: cross-job grouping by firstBadSha. Attempt restraint and retired-job hygiene are already below it in the stack.

## Non-goals

- No log-signature classification.
- No runner-host remediation scripts.
- No changes to how single-job failures are diagnosed.
- No formula changes.

## Architecture

### Before

The filing loop evaluated each actionable failure independently.

If eleven jobs first failed at the same SHA, the watcher could file eleven separate repair plans.

### After

The filing loop pre-groups actionable failures by firstBadSha.

Groups at or above the fleet threshold render one consolidated descriptor with a wave-scoped marker and attempt key, while smaller groups keep the per-job path.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --test scripts/e2e-regression-watch.test.mjs`
- [x] `node scripts/repro/repro-e2e-regression-watch.mjs`
- [x] `node scripts/validate-pr-body.mjs --body-file .tmp/pr-body-fleet-correlation.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d3f38d8d9f04108eca15f61efcab3bf1f1774e9e`
- Post-revert steps: Same-SHA CI waves may again file one repair plan per failed job.
- Data migration? No

</details>

Depends-On: #8950
