### PR TITLE
[CI repair thrash prevention](4) Repro-gated repair formula: fail-before, pass-after

### DIFF
--- a/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
+++ b/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
@@ -22,6 +22,10 @@ tasks:
       Motivation: This job first failed on default-branch commit {{sha}} and stayed red through {{last_bad_sha}}.
       Alternative considerations: Re-running or weakening the test was rejected; fix the underlying defect.
       Implementation details: Reproduce at {{sha}}, then implement on current master.
+      Repro protocol:
+      - Before editing, check out {{sha}} in a detached temporary worktree and run `{{verify_command}}` or the narrowest probe derived from failing CI job `{{job_name}}`; record the failing exit code in the task summary.
+      - If the failure cannot reproduce locally because it is infra-class, write a `Repro waiver:` block in the task summary quoting the CI job log evidence, including the URL and exact relevant lines; an unproven fix without this waiver is a task failure.
+      - After the fix, run the same probe on the final branch and record the passing exit code in the task summary.
       Non-goals: No refactor, no unrelated cleanup, no test weakening, no snapshot churn unless it is the reviewed expected output.
       Layer: e2e_regression
       Feature state: active
@@ -46,18 +50,23 @@ tasks:
       `.github/workflows/ci.yml`, the relevant `scripts/` suite entrypoint, and
       the first failing GitHub job logs:
       `gh run view {{run_id}} --repo Neko-Catpital-Labs/Invoker --job {{job_database_id}} --log`.
-      Inspect the introducing commit with `git show {{sha}}`. Reproduce against
-      the historical commit without doing final work there: use a detached
-      temporary worktree or clone at {{sha}}, then run `{{verify_command}}`.
-      Return to the current task branch based on master and implement the fix
-      there. If historical reproduction is blocked by external runner setup,
-      use the GitHub job logs as the historical evidence and still prove the
-      final fix locally.
+      Inspect the introducing commit with `git show {{sha}}`.
+      Acceptance criteria: `{{verify_command}}` exits 0 on the final branch
+      after the change.
       Non-goals: Do not weaken, skip, or delete assertions; do not make broad
       refactors; do not manually edit GitHub CI state; do not target a PR at
       the historical SHA.
-      Acceptance criteria: `{{verify_command}}` must exit code 0 on the final
-      branch after the change.
+      Repro protocol:
+      1. Before editing, check out {{sha}} in a detached temporary worktree and
+         run `{{verify_command}}` or the narrowest probe derived from failing CI
+         job `{{job_name}}`; record the failing exit code in the task summary.
+      2. If the failure cannot reproduce locally because it is infra-class,
+         write a `Repro waiver:` block in the task summary quoting the CI job
+         log evidence, including the URL and exact relevant lines; an unproven
+         fix without this waiver is a task failure.
+      3. Return to the current task branch based on master, implement the fix
+         there, then run the same probe and record the passing exit code in the
+         task summary.
     dependencies: []
 
   - id: verify-ci-{{job_slug}}

--- a/skills/plan-to-invoker/formulas/ci-regression-watch/formula.yaml
+++ b/skills/plan-to-invoker/formulas/ci-regression-watch/formula.yaml
@@ -16,19 +16,19 @@ vars:
     description: "Current target branch for the repair PR."
   sha:
     required: true
-    example: "abc123def456abc123def456abc123def456ab1"
+    example: "e73ee55abc123def456abc123def456abc123def"
     description: "Default-branch commit where this CI job first failed."
   short_sha:
     required: true
-    example: "abc123d"
+    example: "e73ee55"
     description: "Short SHA used in ids."
   job_name:
     required: true
-    example: "playwright / 1-of-9"
+    example: "UI Vitest"
     description: "Exact GitHub Actions job name."
   job_slug:
     required: true
-    example: "abc123d-playwright-1-of-9"
+    example: "e73ee55-ui-vitest"
     description: "Kebab-case plan/task id suffix."
   run_id:
     required: true
@@ -52,15 +52,15 @@ vars:
     description: "Most recent run id where the job was still broken."
   verify_command:
     required: true
-    example: "bash scripts/test-suites/required/10-vitest-workspace.sh"
+    example: "pnpm --filter @invoker/ui test"
     description: "Local command that should fail before and pass after the fix."
   marker:
     required: true
-    example: "<!-- invoker-ci-regression-watch: first-bad-sha=abc123def456abc123def456abc123def456ab1; job=playwright / 1-of-9 -->"
+    example: "<!-- invoker-ci-regression-watch: first-bad-sha=e73ee55abc123def456abc123def456abc123def; job=UI Vitest -->"
     description: "Exact dedup marker embedded in the workflow description."
   failure_description:
     required: true
-    example: "CI job `playwright / 1-of-9` first failed on default-branch push commit abc123def456abc123def456abc123def456ab1"
+    example: "CI job `UI Vitest` first failed on default-branch push commit e73ee55abc123def456abc123def456abc123def"
     description: "Indented workflow description body for the failing CI job or fleet event."
 workflows:
   - ci-regression-watch.workflow.yaml

--- a/skills/plan-to-invoker/scripts/render-formula.mjs
+++ b/skills/plan-to-invoker/scripts/render-formula.mjs
@@ -110,6 +110,10 @@ for (const [name, spec] of Object.entries(varSpecs)) {
 }
 if (missing.length) die(`missing required --var: ${missing.join(', ')} (or pass --example)`);
 
+if (typeof values.verify_command === 'string' && values.verify_command.includes('No local verify command is mapped')) {
+  die('verify_command rejected: contains watcher sentinel "No local verify command is mapped"');
+}
+
 function substitute(text, file) {
   const unresolved = new Set();
   const out = text.replace(/\{\{\s*([A-Za-z0-9_.]+)\s*\}\}/g, (m, key) => {


### PR DESCRIPTION
## Summary

The ci-regression-watch formula text now tells repair tasks to prove the target probe failed before the fix and passed after it.

When a failure cannot reproduce locally, the rendered plan requires an explicit repro waiver with CI evidence instead.

Formula rendering now stops on the watcher sentinel verify text so locally unverifiable jobs cannot become normal repair tasks.

## Review Claim

Every ci-regression-watch repair plan now carries fail-before/pass-after evidence instructions or an explicit repro waiver path, and formula rendering stops on the watcher sentinel verify text.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Only the rendered repair-plan evidence text tightens; the formula shape, task ids, marker comment, and merge behavior are unchanged, so existing consumers keep working.

## Slice Rationale

This is one documentation-shaped formula unit: the evidence contract of rendered CI repair plans. Watcher filing behavior lives in the earlier stack slices, and publication integrity remains separate.

## Non-goals

- No global skill-doctor policy change.
- No changes to other formulas.
- No watcher code changes.
- No PR publication changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash skills/plan-to-invoker/scripts/formula-doctor.sh ci-regression-watch`
- [x] `node skills/plan-to-invoker/scripts/render-formula.mjs ci-regression-watch --example --var 'verify_command=echo No local verify command is mapped for playwright / launch-dispatch-stuck-lease; exit 1' --out "$TMP_SENTINEL"` failed with `verify_command rejected: contains watcher sentinel "No local verify command is mapped"`
- [x] `node skills/plan-to-invoker/scripts/render-formula.mjs ci-regression-watch --example --out "$TMP_OK" --print`, then `grep -F 'Repro protocol' "$PLAN"` and `grep -F 'Repro waiver:' "$PLAN"`
- [x] `node scripts/validate-pr-body-local.mjs --body-file .tmp/pr-body-repro-gated-formula.md --base stack/EdbertChan/pr/ci-repair-thrash-prevention-3-fleet-event-correlation-v2/ci-repair-thrash-prevention-3b-add-fleet-event--645e02ee`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9bb4dc62d2dd498d1d7f6c99eb13e2659317081d`
- Post-revert steps: Re-run `bash skills/plan-to-invoker/scripts/formula-doctor.sh ci-regression-watch`.
- Data migration? No

</details>

Depends-On: #8952
