### PR TITLE
[CI repair thrash prevention](5) Publication integrity: PR diff must match session output

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2322,7 +2322,7 @@ describe('TaskRunner', () => {
         status: 'running',
         dependencies: ['t1'],
         config: { isMergeNode: true, workflowId: 'wf-pub' },
-        execution: { pendingFixError: undefined },
+        execution: { pendingFixError: undefined, fixedIntegrationSha: 'deadbeef' },
       });
 
       const allTasks = [mergeTask, completedTask];
@@ -2372,7 +2372,18 @@ describe('TaskRunner', () => {
       (executor as any).execGitIn = async (args: string[], dir: string) => {
         gitCalls.push({ args: [...args], dir });
         if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'deadbeef';
-        if (args[0] === 'rev-parse' && args[1] === '--verify') return '';
+        if (args[0] === 'rev-parse' && args[1] === '--verify') {
+          if (args[2] === 'deadbeef^{commit}') return 'deadbeef';
+          return '';
+        }
+        if (
+          args[0] === 'merge-base'
+          && args[1] === '--is-ancestor'
+          && args[2] === 'deadbeef'
+          && args[3] === 'plan/ext-review'
+        ) {
+          return '';
+        }
         if (args[0] === 'merge-base' && args[1] === '--is-ancestor') throw new Error('not ancestor');
         return '';
       };
@@ -2877,16 +2888,22 @@ describe('TaskRunner', () => {
       gateWorkspacePath?: string | null;
       taskBranches?: TaskState[];
       repoUrl?: string;
+      fixedIntegrationSha?: string;
     }) {
       const mergeTaskId = '__merge__wf-pub';
       const workflowId = 'wf-pub';
+      const publishesReview = opts.mergeMode === 'external_review' || opts.onFinish === 'pull_request';
+      const fixedIntegrationSha = opts.fixedIntegrationSha ?? (publishesReview ? 'abc123deadbeef' : undefined);
 
       const mergeTask = makeTask({
         id: mergeTaskId,
         status: 'running',
         dependencies: (opts.taskBranches ?? []).map((t) => t.id),
         config: { isMergeNode: true, workflowId },
-        execution: { pendingFixError: undefined },
+        execution: {
+          pendingFixError: undefined,
+          ...(fixedIntegrationSha ? { fixedIntegrationSha } : {}),
+        },
       });
 
       const allTasks = [mergeTask, ...(opts.taskBranches ?? [])];
@@ -2937,7 +2954,20 @@ describe('TaskRunner', () => {
       (executor as any).execGitIn = async (args: string[], dir: string) => {
         gitCalls.push({ args: [...args], dir });
         if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'abc123deadbeef';
-        if (args[0] === 'rev-parse' && args[1] === '--verify') return '';
+        if (args[0] === 'rev-parse' && args[1] === '--verify') {
+          if (fixedIntegrationSha && args[2] === `${fixedIntegrationSha}^{commit}`) return fixedIntegrationSha;
+          return '';
+        }
+        if (
+          fixedIntegrationSha
+          &&
+          args[0] === 'merge-base'
+          && args[1] === '--is-ancestor'
+          && args[2] === fixedIntegrationSha
+          && args[3] === opts.featureBranch
+        ) {
+          return '';
+        }
         // merge-base --is-ancestor exits non-zero when branch is NOT an ancestor of HEAD
         if (args[0] === 'merge-base' && args[1] === '--is-ancestor') throw new Error('not ancestor');
         return '';

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -277,6 +277,33 @@ async function pushFeatureBranchWithRefLockRetry(
   await assertBranchRetrievableOnOrigin(host, dir, featureBranch);
 }
 
+async function assertBranchContainsRecordedFix(
+  host: MergeRunnerHost,
+  dir: string,
+  branch: string,
+  recordedCommit: string,
+): Promise<void> {
+  const resolvedCommit = (await execGitInMergeSafe(
+    host,
+    ['rev-parse', '--verify', `${recordedCommit}^{commit}`],
+    dir,
+  )).trim();
+  try {
+    await execGitInMergeSafe(host, ['merge-base', '--is-ancestor', resolvedCommit, branch], dir);
+  } catch {
+    const branchHead = (await execGitInMergeSafe(host, ['rev-parse', '--verify', `${branch}^{commit}`], dir)
+      .catch(() => '')).trim();
+    throw new Error(
+      [
+        'repair-publication-unowned-diff: refusing to publish a repair PR whose head does not contain the recorded fix-session commit.',
+        `Recorded commit: ${resolvedCommit}`,
+        `Published branch: ${branch}`,
+        `Published head: ${branchHead || '(unresolved)'}`,
+      ].join('\n'),
+    );
+  }
+}
+
 export async function assertBranchRetrievableOnOrigin(
   host: MergeRunnerHost,
   dir: string,
@@ -373,6 +400,7 @@ export interface MergeRunnerHost {
     cwd: string;
     expectedGeneration: number;
     reviewGate?: ReviewGateState;
+    recordedFixCommit?: string;
   }): Promise<{ artifacts: ReviewGateArtifact[]; sessionId: string; agentName: string }>;
   authorPrBodyWithSkill?(args: {
     workflowId?: string;
@@ -441,6 +469,7 @@ async function publishReviewArtifactsForMerge(host: MergeRunnerHost, args: {
   expectedGeneration: number;
   repoUrl?: string;
   reviewGate?: ReviewGateState;
+  recordedFixCommit?: string;
 }): Promise<{
   reviewUrl?: string;
   reviewId?: string;
@@ -464,6 +493,7 @@ async function publishReviewArtifactsForMerge(host: MergeRunnerHost, args: {
       cwd: args.cwd,
       expectedGeneration: args.expectedGeneration,
       reviewGate: args.reviewGate,
+      recordedFixCommit: args.recordedFixCommit,
     });
     logTaskProgress(host, args.mergeNodeTaskId, 'info', 'Review stack published', {
       agentName: published.agentName,
@@ -1295,6 +1325,7 @@ export async function publishAfterFixImpl(
   const baseBranch = workflow?.baseBranch ?? host.defaultBranch ?? await host.detectDefaultBranch();
   const featureBranch = workflow?.featureBranch;
   const visualProof = workflow?.visualProof ?? false;
+  const shouldPublishReview = mergeMode === 'external_review' || onFinish === 'pull_request';
 
   const summary = workflowId ? await host.buildMergeSummary(workflowId) : undefined;
   const gateWorkspacePath = safeGetWorkspacePath(host.persistence, task.id) ?? undefined;
@@ -1340,6 +1371,11 @@ export async function publishAfterFixImpl(
       await startReviewReadyDependents(host);
       return;
     }
+    if (shouldPublishReview && !fixedIntegrationSha) {
+      throw new Error(
+        'repair-publication-missing-session-commit: post-fix repair PR publication requires the fix session recorded commit hash.',
+      );
+    }
 
     // Consolidate task branches in the gate clone, starting from the gate
     // clone's current HEAD (which has Claude's fixes).
@@ -1378,6 +1414,11 @@ export async function publishAfterFixImpl(
           gateWorkspacePath,
           error,
         });
+        if (shouldPublishReview) {
+          throw new Error(
+            `repair-publication-missing-session-commit: recorded fix session commit ${fixedIntegrationSha} is not present in the repair workspace.`,
+          );
+        }
         console.warn(
           `[merge] Post-fix: failed to use fixedIntegrationSha=${fixedIntegrationSha} ` +
           `for ${task.id}; falling back to current gate HEAD. Error: ${error}`,
@@ -1492,12 +1533,14 @@ export async function publishAfterFixImpl(
     }
 
     // Push feature branch directly to origin (GitHub) from the gate clone
+    if (shouldPublishReview) {
+      await assertBranchContainsRecordedFix(host, consolidateDir, featureBranch, fixedIntegrationSha!);
+    }
     logTaskProgress(host, task.id, 'info', 'Pushing feature branch', {
       featureBranch,
     });
     await pushFeatureBranchWithRefLockRetry(host, consolidateDir, featureBranch);
 
-    const shouldPublishReview = mergeMode === 'external_review' || onFinish === 'pull_request';
     const reviewBase = shouldPublishReview || visualProof
       ? await resolveReviewBaseRef(host, consolidateDir, baseBranch)
       : { branchName: normalizeBranchForGithubCli(baseBranch), gitRef: baseBranch };
@@ -1523,6 +1566,7 @@ export async function publishAfterFixImpl(
         expectedGeneration: task.execution.generation ?? 0,
         repoUrl: workflow?.repoUrl,
         reviewGate: task.execution.reviewGate,
+        recordedFixCommit: fixedIntegrationSha,
       });
 
       setMergeGateReviewReady(host, task.id, {

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -731,6 +731,7 @@ export function spawnAgentPrAuthorViaRegistry(
   cwd: string,
   agent: ExecutionAgent,
   driver?: SessionDriver,
+  extraEnv: NodeJS.ProcessEnv = {},
 ): Promise<{ body: string; stdout: string; sessionId: string }> {
   const promptTransport = materializeLocalAgentPrompt(prompt, 'invoker-pr-author-prompt-');
   const spec = agent.buildCommand(promptTransport.effectivePrompt);
@@ -741,7 +742,7 @@ export function spawnAgentPrAuthorViaRegistry(
     const child = spawn(cmd, spec.args, {
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: cleanElectronEnv(),
+      env: { ...cleanElectronEnv(), ...extraEnv },
       detached: process.platform !== 'win32',
     });
 

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1547,6 +1547,7 @@ export class TaskRunner {
     cwd: string;
     expectedGeneration: number;
     reviewGate?: ReviewGateState;
+    recordedFixCommit?: string;
   }): Promise<{ artifacts: ReviewGateArtifact[]; sessionId: string; agentName: string }> {
     if (!this.executionAgentRegistry) {
       throw new Error('make-pr skill is required to publish Invoker review stacks');
@@ -1611,7 +1612,14 @@ export class TaskRunner {
           `[pr-authoring] review-stack publish starting agent=${agent.name} `
             + `workflow=${args.workflowId ?? 'unknown'} skill=invoker-make-pr cwd=${args.cwd}`,
         );
-        const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver);
+        const repairPublicationEnv = args.recordedFixCommit
+          ? {
+            INVOKER_REPAIR_PUBLICATION: '1',
+            INVOKER_REPAIR_TASK_CHAIN_ID: args.workflowId ?? args.mergeNodeTaskId ?? '',
+            INVOKER_REPAIR_SESSION_COMMIT: args.recordedFixCommit,
+          }
+          : {};
+        const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver, repairPublicationEnv);
         logProgress('info', `${agent.name} make-pr agent finished; validating output`, {
           agentName: agent.name,
           sessionId: result.sessionId,

--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -35,7 +35,7 @@
  *   and required ## Visual Proof for UI changes.
  */
 
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, mkdirSync, writeFileSync, renameSync } from 'node:fs';
 import { basename, extname, join } from 'node:path';
 import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
@@ -205,6 +205,12 @@ function parseArgs() {
 }
 
 const TRUNK_BRANCHES = new Set(['main', 'master', 'develop']);
+const REPAIR_PUBLICATION_MARKERS = join(homedir(), '.invoker', 'repair-publication-lineages.json');
+const REPAIR_PUBLICATION_ENV_KEYS = [
+  'INVOKER_REPAIR_PUBLICATION',
+  'INVOKER_REPAIR_TASK_CHAIN_ID',
+  'INVOKER_REPAIR_SESSION_COMMIT',
+];
 const STACK_PR_TITLE_PATTERN = /^\[[^\[\]\r\n]{3,80}\]\([1-9]\d*[a-z]?\)(?:\[REFACTOR: [^\[\]\r\n]{2,80}\])?(?:\s+\S.*)?$/;
 const REFACTOR_TAG_PATTERN = /\[REFACTOR: [^\[\]\r\n]{2,80}\]/;
 
@@ -463,6 +469,106 @@ function gitExitStatus(args) {
     if (typeof error.status === 'number') return error.status;
     throw error;
   }
+}
+
+function repairPublicationContext() {
+  const hasContext = REPAIR_PUBLICATION_ENV_KEYS.some((key) => process.env[key]?.trim());
+  if (!hasContext) return undefined;
+  return {
+    chainId: process.env.INVOKER_REPAIR_TASK_CHAIN_ID?.trim() || '',
+    sessionCommit: process.env.INVOKER_REPAIR_SESSION_COMMIT?.trim() || '',
+  };
+}
+
+function publicationLineageForBranch(branch) {
+  if (branch.startsWith('stack/')) return 'stack';
+  if (branch.startsWith('plan/')) return 'plan';
+  if (branch.startsWith('pr/')) return 'pr';
+  return branch.split('/')[0] || branch;
+}
+
+function loadRepairPublicationMarkers() {
+  try {
+    return JSON.parse(readFileSync(REPAIR_PUBLICATION_MARKERS, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+function persistRepairPublicationMarkers(markers) {
+  mkdirSync(join(homedir(), '.invoker'), { recursive: true });
+  const tmp = `${REPAIR_PUBLICATION_MARKERS}.${process.pid}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(markers, null, 2)}\n`);
+  renameSync(tmp, REPAIR_PUBLICATION_MARKERS);
+}
+
+function assertRepairPublicationIntegrity(currentBranch) {
+  const context = repairPublicationContext();
+  if (!context) return undefined;
+
+  if (!context.chainId) {
+    throw new Error('repair-publication-missing-task-chain: repair PR publication requires INVOKER_REPAIR_TASK_CHAIN_ID.');
+  }
+  if (!context.sessionCommit) {
+    throw new Error('repair-publication-missing-session-commit: repair PR publication requires the fix session recorded commit hash.');
+  }
+  const recordedCommit = gitTextOrEmpty(['rev-parse', '--verify', `${context.sessionCommit}^{commit}`]);
+  if (!recordedCommit) {
+    throw new Error(
+      `repair-publication-missing-session-commit: recorded fix session commit ${context.sessionCommit} is not present in this repository.`,
+    );
+  }
+  if (gitExitStatus(['merge-base', '--is-ancestor', recordedCommit, 'HEAD']) !== 0) {
+    throw new Error(
+      [
+        'repair-publication-unowned-diff: refusing to publish a repair PR whose head does not contain the recorded fix-session commit.',
+        `Recorded commit: ${recordedCommit}`,
+        `Current branch: ${currentBranch}`,
+        `Current head: ${resolveRev('HEAD')}`,
+      ].join('\n'),
+    );
+  }
+
+  const lineage = publicationLineageForBranch(currentBranch);
+  const markers = loadRepairPublicationMarkers();
+  const existing = markers[context.chainId];
+  if (existing && existing.lineage && existing.lineage !== lineage) {
+    throw new Error(
+      [
+        'repair-publication-duplicate-lineage: refusing a second published branch lineage for this repair task chain.',
+        `Task chain: ${context.chainId}`,
+        `Existing lineage: ${existing.lineage}`,
+        `Requested lineage: ${lineage}`,
+        `Existing branch: ${existing.branch ?? '(unknown)'}`,
+        `Requested branch: ${currentBranch}`,
+      ].join('\n'),
+    );
+  }
+
+  return {
+    chainId: context.chainId,
+    lineage,
+    branch: currentBranch,
+    recordedCommit,
+  };
+}
+
+function recordRepairPublicationLineage(publication) {
+  if (!publication) return;
+  const markers = loadRepairPublicationMarkers();
+  const existing = markers[publication.chainId];
+  if (existing && existing.lineage && existing.lineage !== publication.lineage) {
+    throw new Error(
+      `repair-publication-duplicate-lineage: marker changed during publication for ${publication.chainId} (${existing.lineage} != ${publication.lineage}).`,
+    );
+  }
+  markers[publication.chainId] = {
+    lineage: publication.lineage,
+    branch: publication.branch,
+    recordedCommit: publication.recordedCommit,
+    publishedAt: new Date().toISOString(),
+  };
+  persistRepairPublicationMarkers(markers);
 }
 
 export function isUiImpactingPath(filePath) {
@@ -943,6 +1049,7 @@ async function main() {
   const args = parseArgs();
 
   const currentBranch = getCurrentBranch();
+  const repairPublication = assertRepairPublicationIntegrity(currentBranch);
   const mergifyState = getMergifyBranchState(currentBranch);
   assertNotPlanBaseForMergifyStack(args.base, currentBranch, mergifyState);
   assertCleanPrBase(args.base);
@@ -1008,6 +1115,7 @@ async function main() {
   const pr = updatePrNumber
     ? await updatePr(nwo, updatePrNumber, args.title, body, args.dryRun)
     : await createPr(nwo, args.title, args.base, body, args.dryRun);
+  recordRepairPublicationLineage(repairPublication);
   if (isStackedPrContext(args.base, mergifyState)) {
     syncStackCommentsForPr(nwo, pr.number, { dryRun: args.dryRun });
   }

--- a/scripts/repro/repro-publication-empty-session-diff.sh
+++ b/scripts/repro/repro-publication-empty-session-diff.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CREATE_PR="$ROOT/scripts/create-pr.mjs"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-publication-integrity.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  if [ -n "${2:-}" ]; then
+    echo "----- detail -----" >&2
+    printf '%s\n' "$2" >&2
+  fi
+  exit 1
+}
+
+export HOME="$TMP/home"
+mkdir -p "$HOME" "$TMP/bin"
+export PATH="$TMP/bin:$PATH"
+
+cat > "$TMP/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "repo" ] && [ "${2:-}" = "view" ]; then
+  printf '%s' 'owner/repo'
+  exit 0
+fi
+
+if [ "${1:-}" = "api" ]; then
+  route="${2:-}"
+  case "$route" in
+    repos/owner/repo/pulls)
+      if [ "${3:-}" = "--method" ] && [ "${4:-}" = "POST" ]; then
+        cat >/dev/null
+        printf '{"html_url":"https://example.test/pull/123","number":123}'
+        exit 0
+      fi
+      ;;
+    repos/owner/repo/pulls\?*)
+      printf '[]'
+      exit 0
+      ;;
+    repos/owner/repo/issues/*/comments\?*)
+      printf '[]'
+      exit 0
+      ;;
+    repos/owner/repo/issues/*/comments)
+      cat >/dev/null
+      printf '{"id":123}'
+      exit 0
+      ;;
+  esac
+fi
+
+printf 'unexpected gh invocation: %s\n' "$*" >&2
+exit 2
+EOF
+chmod +x "$TMP/bin/gh"
+
+VALID_BODY="$TMP/pr-body.md"
+cat > "$VALID_BODY" <<'EOF'
+## Summary
+
+This branch publishes a repair.
+
+## Review Claim
+
+Keep repair publication tied to the fixing session.
+
+## Review Lane
+
+- policy
+
+## Review Unit
+
+- tooling-policy
+
+## Safety Invariant
+
+Only publication integrity behavior changes.
+
+## Slice Rationale
+
+One repair-publication guard.
+
+## Non-goals
+
+- Do not change runtime behavior.
+
+## Test Plan
+
+<details>
+<summary>Test Plan</summary>
+
+- [ ] `bash scripts/repro/repro-publication-empty-session-diff.sh`
+
+</details>
+
+## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
+
+- Safe to revert? Yes
+- Revert command: `git revert <sha>`
+- Post-revert steps: None
+- Data migration? No
+
+</details>
+EOF
+
+ORIGIN="$TMP/origin.git"
+WORK="$TMP/work"
+
+git init --bare -b master "$ORIGIN" >/dev/null
+git clone "$ORIGIN" "$WORK" >/dev/null
+git -C "$WORK" config user.email repro@example.test
+git -C "$WORK" config user.name 'Repro Bot'
+printf 'seed\n' > "$WORK/README.md"
+git -C "$WORK" add README.md
+git -C "$WORK" commit -m 'seed' >/dev/null
+git -C "$WORK" push origin master >/dev/null
+
+publish() {
+  local branch="$1"
+  local chain="$2"
+  local commit="$3"
+  local title="${4:-test title}"
+  (
+    cd "$WORK"
+    git switch "$branch" >/dev/null
+    env \
+      INVOKER_REPAIR_PUBLICATION=1 \
+      INVOKER_REPAIR_TASK_CHAIN_ID="$chain" \
+      INVOKER_REPAIR_SESSION_COMMIT="$commit" \
+      node "$CREATE_PR" --title "$title" --base master --body-file "$VALID_BODY"
+  ) 2>&1
+}
+
+make_session_commit() {
+  local branch="$1"
+  local file="$2"
+  git -C "$WORK" switch -C "$branch" origin/master >/dev/null
+  printf 'fix session for %s\n' "$branch" > "$WORK/$file"
+  git -C "$WORK" add "$file"
+  git -C "$WORK" commit -m "fix session $branch" >/dev/null
+  git -C "$WORK" rev-parse HEAD
+}
+
+make_publication_branch() {
+  local branch="$1"
+  local start="$2"
+  local file="$3"
+  git -C "$WORK" switch -C "$branch" "$start" >/dev/null
+  printf 'published change for %s\n' "$branch" > "$WORK/$file"
+  git -C "$WORK" add "$file"
+  git -C "$WORK" commit -m "publish $branch" >/dev/null
+}
+
+# (a) Backtest PR 8784 shape: the repair publication has a nonempty diff, but
+# there is no recorded fix-session commit to prove the fixing agent authored it.
+make_publication_branch "plan/pr-8784-quality-typescript-types" "origin/master" "pr8784-publication-authored.txt"
+if out="$(publish "plan/pr-8784-quality-typescript-types" "wf-20260812-pr-8784" "" || true)"; then
+  if ! grep -q 'repair-publication-missing-session-commit' <<<"$out"; then
+    fail 'case (a) should name missing session commit' "$out"
+  fi
+else
+  fail 'case (a) command wrapper failed unexpectedly'
+fi
+echo "PASS: case (a) PR 8784 missing session commit is refused"
+
+# (b) The task recorded a commit, but the branch being published does not contain it.
+RECORDED_B="$(make_session_commit session/case-b case-b-owned.txt)"
+make_publication_branch "plan/case-b-unowned-head" "origin/master" "case-b-publication-authored.txt"
+if out="$(publish "plan/case-b-unowned-head" "wf-case-b" "$RECORDED_B" || true)"; then
+  if ! grep -q 'repair-publication-unowned-diff' <<<"$out"; then
+    fail 'case (b) should name unowned diff' "$out"
+  fi
+else
+  fail 'case (b) command wrapper failed unexpectedly'
+fi
+echo "PASS: case (b) published head missing recorded commit is refused"
+
+# (c) The published head contains the recorded fixing-session commit.
+RECORDED_C="$(make_session_commit session/case-c case-c-owned.txt)"
+make_publication_branch "plan/case-c-owned-head" "$RECORDED_C" "case-c-followup.txt"
+if ! out="$(publish "plan/case-c-owned-head" "wf-case-c" "$RECORDED_C")"; then
+  fail 'case (c) should publish when head contains recorded commit' "$out"
+fi
+if ! grep -q 'https://example.test/pull/123' <<<"$out"; then
+  fail 'case (c) should print created PR URL' "$out"
+fi
+echo "PASS: case (c) recorded commit ancestor is allowed"
+
+# (d) Backtest duplicate 8791/8805 shape: one task chain first publishes through
+# the plan lineage, then tries to publish the same chain through a stack lineage.
+RECORDED_D="$(make_session_commit session/case-d case-d-owned.txt)"
+make_publication_branch "plan/pr-8791-quality-typescript-types" "$RECORDED_D" "case-d-plan.txt"
+if ! out="$(publish "plan/pr-8791-quality-typescript-types" "wf-20260812-8791-8805" "$RECORDED_D")"; then
+  fail 'case (d) first lineage should publish' "$out"
+fi
+make_publication_branch "stack/repro/pr/quality-typescript-types" "$RECORDED_D" "case-d-stack.txt"
+if out="$(publish "stack/repro/pr/quality-typescript-types" "wf-20260812-8791-8805" "$RECORDED_D" "[Quality Types](1) repair types" || true)"; then
+  if ! grep -q 'repair-publication-duplicate-lineage' <<<"$out"; then
+    fail 'case (d) should name duplicate lineage' "$out"
+  fi
+else
+  fail 'case (d) command wrapper failed unexpectedly'
+fi
+echo "PASS: case (d) 8791/8805 second branch lineage is refused"


### PR DESCRIPTION
## Summary

Repair PR publication now ties every generated PR head to the commit recorded by its fix session.

It halts when the session has no recorded commit, when ancestry does not line up, or when a task chain uses a second branch lineage.

The repro covers the PR 8784 empty-session shape and the 8791/8805 dual-lineage shape.

## Review Claim

Repair PR publication now requires the PR head to include the fix session's recorded commit, and each task chain uses one branch lineage.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The new path only halts publication with a named reason; it never rewrites, amends, or force-pushes branches, and matching session lineages publish as before.

## Slice Rationale

This is one publication rule between a fix session's recorded output and the PR diff reviewers see. Watcher filing and formula evidence are covered by earlier stack slices.

## Non-goals

- No changes to Mergify queue policy.
- No retroactive closing of existing repeated PRs.
- No watcher or formula changes.
- No changes to non-repair publication flows.

## Architecture

### Before

```mermaid
graph TD
    A["Fix session records commit_hash"]
    B["Publication prepares repair PR head"]
    C["PR opens from supplied head"]
    A --> B --> C
```

### After

```mermaid
graph TD
    A["Fix session records commit_hash"]
    B["Publication prepares repair PR head"]
    C["Publication confirms commit_hash ancestry"]
    D["Publication records one lineage per task chain"]
    E["PR opens for the matching lineage"]
    A --> B --> C --> D --> E
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-publication-empty-session-diff.sh`
- [x] `node scripts/test-create-pr-stack-workflow.mjs`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-body-publication-integrity-dep.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ea33bd66006416dbbd49bb1e118b6aa739c3bb2a`
- Post-revert steps: Re-run `node scripts/test-create-pr-stack-workflow.mjs`.
- Data migration? No

</details>

Depends-On: #8953


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safeguards for publishing reviews after repair sessions.
  * Publications now verify that the recorded repair commit exists and belongs to the feature branch history.
  * Prevented duplicate task-chain publications across different branch lineages.
  * Added reliable tracking of successful publication lineage.
* **Tests**
  * Added coverage for valid, missing, unavailable, and non-ancestral repair commits.
  * Added a reproduction script covering repair-publication integrity scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->