### PR TITLE
[CI regression: 631a0d0-quality-dependency-cruise](1) Route Dependency Cruise to a GitHub-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,7 @@ jobs:
           if-no-files-found: error
 
   quality-required:
-    runs-on:
-      labels: ${{ matrix.runner_label }}
+    runs-on: ${{ matrix.runner_label }}
     timeout-minutes: 5
     strategy:
       fail-fast: false
@@ -76,7 +75,7 @@ jobs:
         include:
           - name: Dependency Cruise
             command: pnpm run check:deps
-            runner_label: Runner_2_4_core
+            runner_label: ubuntu-latest
           - name: TypeScript Types
             command: pnpm run check:types
             runner_label: Github_Runner

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -39,6 +39,17 @@ for (const jobName of FULL_CI_JOBS) {
 
 assert(jobs['quality-required'], 'Missing quality-required job');
 assert(!jobs['quality-required'].if, 'quality-required must run on ordinary PRs');
+assert(
+  jobs['quality-required']['runs-on'] === '${{ matrix.runner_label }}',
+  'quality-required must use each matrix entry as the full runner selector',
+);
+const qualityRequiredEntries = jobs['quality-required'].strategy?.matrix?.include ?? [];
+const dependencyCruiseEntry = qualityRequiredEntries.find((entry) => entry.name === 'Dependency Cruise');
+assert(dependencyCruiseEntry, 'quality-required matrix must include Dependency Cruise');
+assert(
+  dependencyCruiseEntry.runner_label === 'ubuntu-latest',
+  'Dependency Cruise must run on a GitHub-hosted runner to avoid self-hosted setup disk pressure',
+);
 
 assert(jobs['quality-extra'], 'Missing quality-extra job');
 assert(jobs['quality-extra'].if === ORDINARY_PR_GATE, 'quality-extra must run on ordinary PRs and skip merge queue refs');


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=quality / Dependency Cruise -->

CI job `quality / Dependency Cruise` first failed on default-branch push commit 631a0d08c7072e9544813fc1b93fb616586ce441 in run 31620499765.

It was most recently still red at e73ee552a6e174a85fc6107186bb802b32ec4b6e in run 31629955741.

The first failed job exhausted disk space while preparing actions on self-hosted runner `invoker-do-s-05`.

This routes Dependency Cruise to `ubuntu-latest` while preserving matrix-selected runners for the other required quality checks.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94225435692

## Review Claim

Dependency Cruise uses a GitHub-hosted runner, and the required-quality matrix continues to treat each entry as its complete runner selector.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the Dependency Cruise runner selection.

## Slice Rationale

The workflow correction and its focused policy assertion form one reviewable CI-policy slice. The verification-only task produced no file changes, so it is recorded in the test plan.

## Non-goals

- No product behavior changes.
- No dependency-rule changes or warning cleanup.
- No changes to runner selection for other CI jobs.
- No weakening of the Dependency Cruise command.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:deps`
- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting restores the previous self-hosted Dependency Cruise runner selection.
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: Re-run `node scripts/test-ci-workflow-merge-queue-policy.mjs` and `pnpm run check:deps`.
- Data migration? No.

</details>
