### PR TITLE
[CI regression: e73ee55-optional-worktree-provisioning](1) Install libatomic1 for Worktree Provisioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1024,6 +1024,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Node.js runtime dependency
+        if: matrix.name == 'Worktree Provisioning'
+        run: sudo apt-get update && sudo apt-get install -y libatomic1
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=e73ee552a6e174a85fc6107186bb802b32ec4b6e; job=optional / Worktree Provisioning -->

Install `libatomic1` before the Worktree Provisioning CI matrix job sets up pnpm.

The package installation is conditional, so every other optional matrix job keeps its existing setup.

## Review Claim

Approve the Worktree Provisioning-only CI step that installs the Node.js runtime dependency before pnpm setup.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected Worktree Provisioning defect.

## Slice Rationale

The runtime dependency and its matrix guard form one CI policy slice. The completed verification task produced no file change, so it remains evidence instead of an empty PR.

## Non-goals

- No product behavior changes.
- No changes to other optional CI matrix jobs.
- No refactor, unrelated cleanup, test weakening, or snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/optional/60-worktree-provisioning.sh` — printed `Worktree provisioning: ALL CHECKS PASSED` and exited 0.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting restores the previous Worktree Provisioning runner setup.
- Revert command: `git revert 01cecb98a4cc1896bc9d664ff07ec3e67abfbc61`
- Post-revert steps: Re-run the Worktree Provisioning verification command.
- Data migration? No

</details>
