### PR TITLE
[CI regression: a5d6b3e-playwright-launch-dispatch-stuck-lease](1) Map the legacy stuck-lease verification job

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -65,6 +65,19 @@ const BUILD_APP_COMMAND = [
   'pnpm --filter @invoker/app build',
 ].join(' && ');
 
+const LEGACY_PLAYWRIGHT_JOB_ALIASES = new Map([
+  [
+    'playwright / launch-dispatch-stuck-lease',
+    {
+      name: 'launch-dispatch-stuck-lease',
+      files: [
+        'e2e/launch-dispatch-stuck-lease-cap.spec.ts',
+        'e2e/launch-dispatch-stuck-lease-storm.spec.ts',
+      ].join(' '),
+    },
+  ],
+]);
+
 // ---------------------------------------------------------------------------
 // Pure logic
 // ---------------------------------------------------------------------------
@@ -658,6 +671,18 @@ export function buildCiJobDefinitions(workflow = parseYaml(readFileSync(WORKFLOW
         jobName,
         matrix,
         verifyCommand: commandForJob(jobId, job, matrix),
+      });
+    }
+  }
+  const playwrightJob = workflow.jobs?.playwright;
+  if (playwrightJob) {
+    for (const [jobName, matrix] of LEGACY_PLAYWRIGHT_JOB_ALIASES) {
+      if (definitions.has(jobName)) continue;
+      definitions.set(jobName, {
+        jobId: 'playwright',
+        jobName,
+        matrix,
+        verifyCommand: commandForJob('playwright', playwrightJob, matrix),
       });
     }
   }


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a5d6b3e626ace9e963e924c0de9410dc0302de9e; job=playwright / launch-dispatch-stuck-lease -->

The regression watcher maps the retired stuck-lease job name to its dedicated label and two current Playwright specs.

Current workflow definitions still take precedence over the legacy alias.

The job first failed in run 30983254556 and remained red through run 31060913416.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30983254556/job/92238737773

## Review Claim

Approve the watcher policy that resolves the retired stuck-lease job name to its current local verification command.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect; current workflow definitions take precedence over the legacy alias.

## Slice Rationale

This policy slice defines the legacy mapping before the following proof slice exercises it.

## Non-goals

- No workflow matrix changes.
- No Playwright spec changes.
- No product or executor behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --input-type=module -e "import { buildCiJobDefinitions } from './scripts/e2e-regression-watch.mjs'; const job=buildCiJobDefinitions().get('playwright / launch-dispatch-stuck-lease'); console.log(job?.verifyCommand ?? 'MISSING'); process.exit(job ? 0 : 1)"`
  - Result: exit 0; the command contains `ci-playwright-launch-dispatch-stuck-lease` and both stuck-lease spec paths.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 6e19d7a36a89df091bc9fc77939363c29c85c450`
- Post-revert steps: Restore a replacement local verification mapping before retrying this CI regression.
- Data migration? No.

</details>
