### PR TITLE
[CI regression: 8365ed9-playwright-4-of-9](1) Assign planning-chat repro to shard 4-of-9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -631,6 +631,7 @@ jobs:
               e2e/edit-task-prompt.spec.ts
               e2e/fix-with-claude.spec.ts
               e2e/fix-with-agent-transition.spec.ts
+              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
           - name: 5-of-9
             files: >-
               e2e/autofix-worker-ui.spec.ts


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / 4-of-9 -->

Playwright shard inventory validation rejected the planning-chat restart repro because no CI shard owned the new spec.

This assigns that spec to `playwright / 4-of-9`, alongside the related planning and workflow lifecycle coverage.

The failure first appeared in run 31574441095 and remained present through run 31629955741.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31574441095/job/94043889051

## Review Claim

Approve assigning `e2e/planning-chat-restore-conversational-mode-repro.spec.ts` to the `playwright / 4-of-9` CI shard.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged; this only adds the previously unassigned spec to one existing Playwright shard.

## Slice Rationale

This is one CI ownership correction in `.github/workflows/ci.yml:634`; it contains no product edits or test changes.

## Non-goals

- No product behavior changes.
- No test weakening or snapshot updates.
- No shard renaming or broader CI rebalancing.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs <(git show origin/master:.github/workflows/ci.yml) packages/app/e2e` — fails with `Missing from shards: e2e/planning-chat-restore-conversational-mode-repro.spec.ts`.
- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs .github/workflows/ci.yml packages/app/e2e` — passes with `OK: 64 CI-owned spec files each assigned to exactly one shard; 2 manual-only spec accounted for.`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes. Reverting restores the prior shard inventory and its known validation failure.
- Revert command: `git revert b75869990`
- Post-revert steps: Reassign the spec to another Playwright shard before merging the revert.
- Data migration? No.

</details>
