### PR TITLE
[CI regression: 8365ed9-playwright-terminal-garbling](1) Assign missing repro to terminal-garbling shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,6 +637,7 @@ jobs:
               e2e/orphan-relaunch.spec.ts
               e2e/gap-recovery-bench.spec.ts
               e2e/planning-chat-send-long-deadline.spec.ts
+              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
               e2e/system-setup-visual-proof.spec.ts
               e2e/startup-nonempty-responsiveness.spec.ts
           - name: 6-of-9


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / terminal-garbling -->

CI job `playwright / terminal-garbling` first failed on default-branch push commit 8365ed93997c669fc85eb85b4d56353378310e03 in run 31574441095.

It was most recently still red at e73ee552a6e174a85fc6107186bb802b32ec4b6e in run 31629955741.

The inventory step reported `Missing from shards: e2e/planning-chat-restore-conversational-mode-repro.spec.ts`.

This assigns that existing repro to the terminal-garbling Playwright shard.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31574441095/job/94043888939

## Review Claim

Assign `e2e/planning-chat-restore-conversational-mode-repro.spec.ts` to the terminal-garbling shard so CI accounts for the missing repro.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

The regression is one missing shard-membership entry, so the workflow roster change and its deterministic inventory check form one reviewable policy slice.

## Non-goals

- No product behavior changes.
- No test implementation or assertion changes.
- No changes to other shard rosters.
- No refactor, unrelated cleanup, test weakening, or snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs` — `[repro-ci-playwright-shard-inventory] OK: 64 CI-owned spec files each assigned to exactly one shard; 2 manual-only spec accounted for.`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-terminal-garbling' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/planning-terminal-live-model.proof.spec.ts e2e/planning-surface-navigation-garble-repro.spec.ts e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts e2e/planning-terminal-expand-collapse-garble-repro.spec.ts e2e/task-terminal-drawer-minimize-garble-repro.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — UI, surfaces, and app builds completed; Playwright did not start because `xvfb-run` is unavailable locally. The command exited 254 with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "xvfb-run" not found`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-sha-of-this-pr>`
- Post-revert steps: Re-run `node scripts/repro/repro-ci-playwright-shard-inventory.mjs`; the missing-assignment failure will return unless the spec is assigned elsewhere.
- Data migration? No

</details>
