### PR TITLE
[CI regression: e73ee55-required-fast-launch-dispatch-queue-repro](1) Install libatomic for launch dispatch queue repro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,6 +424,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
+      - name: Install system libraries for Node
+        if: matrix.name == 'Launch Dispatch Queue Repro'
+        run: sudo apt-get update -qq && sudo apt-get install -y libatomic1
+
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=e73ee552a6e174a85fc6107186bb802b32ec4b6e; job=required-fast / Launch Dispatch Queue Repro -->

Install `libatomic1` before Node setup for the `Launch Dispatch Queue Repro` matrix entry.

The added condition keeps this runner dependency out of every other `required-fast` matrix entry.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31629955741/job/94262949380

## Review Claim

Approve the CI policy that installs `libatomic1` only for the `Launch Dispatch Queue Repro` matrix entry before Node setup.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged; the new setup step is gated by `matrix.name == 'Launch Dispatch Queue Repro'`.

## Slice Rationale

The workflow produced one non-empty CI-policy change. Its verification task produced no files, so this PR keeps the single reviewable slice.

## Non-goals

- No product-code changes.
- No changes to other CI matrix entries.
- No test weakening or snapshot updates.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/25-launch-dispatch-queue-handoff-repro.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes. Reverting restores the previous runner setup for this matrix entry.
- Revert command: `git revert b8b3281d5f7e1dbfcca4ef6eb9b283ad9e1e99ce`
- Post-revert steps: Re-run `required-fast / Launch Dispatch Queue Repro`.
- Data migration? No.

</details>
