### PR TITLE
[CI regression: 8365ed9-playwright-8-of-9](1) Assign the missing Playwright spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -751,6 +751,7 @@ jobs:
             files: >-
               e2e/focus-switch-hitch-responsiveness.spec.ts
               e2e/planning-chat-hitch-responsiveness.spec.ts
+              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
               e2e/command-palette-open.spec.ts
               e2e/task-new-attempt-reset.spec.ts
               e2e/persistence-recovery.spec.ts


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / 8-of-9 -->

Assign the planning-chat conversational-mode restore regression spec to `playwright / 8-of-9`.

The first-bad CI run rejected the spec as missing from every shard. This entry restores complete shard inventory.

## Review Claim

Approve assigning `e2e/planning-chat-restore-conversational-mode-repro.spec.ts` to Playwright shard `8-of-9`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the shard's file list changes. Product code and the regression spec remain unchanged.

The existing inventory guard still requires each CI-owned spec to have exactly one shard owner.

## Slice Rationale

This single-line CI ownership repair is one locally reviewable policy change and does not bundle shard rebalancing or test edits.

## Non-goals

No production behavior change.

No change to the regression spec.

No rebalancing of unrelated Playwright shards and no weakening of the shard inventory guard.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs`
  - `[repro-ci-playwright-shard-inventory] OK: 64 CI-owned spec files each assigned to exactly one shard; 2 manual-only spec accounted for.`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-8-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/focus-switch-hitch-responsiveness.spec.ts e2e/planning-chat-hitch-responsiveness.spec.ts e2e/planning-chat-restore-conversational-mode-repro.spec.ts e2e/command-palette-open.spec.ts e2e/task-new-attempt-reset.spec.ts e2e/persistence-recovery.spec.ts e2e/start-ready-production-click.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`
  - The three builds passed locally, then the Playwright wrapper stopped before running tests because `xvfb-run` is unavailable (`playwright_exit=254`).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-sha>`
- Post-revert steps: Rerun the Playwright shard inventory guard.
- Data migration? No

</details>
