### PR TITLE
[CI regression: 8365ed9-playwright-3-of-9](1) Add planning-chat restore CI shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -773,6 +773,9 @@ jobs:
               e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts
               e2e/planning-terminal-expand-collapse-garble-repro.spec.ts
               e2e/task-terminal-drawer-minimize-garble-repro.spec.ts
+          - name: planning-chat-restore
+            files: >-
+              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
 
     name: playwright / ${{ matrix.name }}
 


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / 3-of-9 -->

CI job `playwright / 3-of-9` first failed on default-branch push commit 8365ed93997c669fc85eb85b4d56353378310e03 in run 31574441095.

It was most recently still red at e73ee552a6e174a85fc6107186bb802b32ec4b6e in run 31629955741.

This adds the omitted planning-chat restore regression spec to the Playwright matrix as a dedicated CI shard.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31574441095/job/94043888953

## Review Claim

Add the planning-chat restore regression spec to the Playwright CI matrix as one dedicated shard.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Existing CI matrix entries and product behavior stay unchanged; only the omitted regression spec gains CI coverage.

## Slice Rationale

The matrix addition is one atomic CI-policy change and does not require a separate proof-only diff.

## Non-goals

No Playwright assertions, product code, existing shard membership, or test-runner behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-3-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/task-death-logs.spec.ts e2e/restart-failed-task.spec.ts e2e/ui-graph-drag-performance.spec.ts e2e/pending-review-gate-target-repo.proof.spec.ts e2e/workflow-status-composition.spec.ts e2e/queue-running-vs-queued.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f4a5b906e6191db3399ac78b36535f53d4e57969`
- Post-revert steps: None
- Data migration? No

</details>
