### PR TITLE
[Jailbreak admin-bypass land (2) force-merge core](1) Add guarded force-merge core

### DIFF
--- a/scripts/jailbreak-admin-bypass-land.mjs
+++ b/scripts/jailbreak-admin-bypass-land.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { appendFileSync, realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { analyzeStack, analyzeCompleteOpenStack, queueTargets } from './land-stack.mjs';
+
+const TRUNK = 'master';
+const ADMIN_BYPASS_LABEL = 'admin-bypass';
+const JAILBREAK_MERGED_LABEL = 'jailbreak-merged';
+
+export function planJailbreakActions({ prs, hasLocalCommit }) {
+  if (!Array.isArray(prs)) return [];
+
+  const candidates = prs.filter(hasAdminBypassLabel);
+  const chains = masterRootedChains(candidates);
+  const planned = [];
+  const plannedNumbers = new Set();
+
+  for (const chain of chains) {
+    const structure = analyzeStack({ prs: chain, hasLocalCommit, trunk: TRUNK });
+    const completeness = analyzeCompleteOpenStack({
+      selectedPrs: chain,
+      allOpenPrs: candidates,
+      trunk: TRUNK,
+    });
+    if (!structure.ok || !completeness.ok) continue;
+
+    for (const pr of queueTargets(chain)) {
+      if (isConflict(pr) || plannedNumbers.has(pr.number)) continue;
+      planned.push(pr);
+      plannedNumbers.add(pr.number);
+    }
+  }
+
+  return planned;
+}
+
+function masterRootedChains(prs) {
+  const index = new Map(prs.map((pr, i) => [pr.number, i]));
+  const childrenByBase = new Map();
+  for (const pr of prs) {
+    const children = childrenByBase.get(pr.baseRefName) ?? [];
+    children.push(pr);
+    childrenByBase.set(pr.baseRefName, children);
+  }
+  for (const children of childrenByBase.values()) {
+    children.sort((a, b) => (index.get(a.number) ?? 0) - (index.get(b.number) ?? 0));
+  }
+
+  const bottoms = prs
+    .filter((pr) => pr.baseRefName === TRUNK)
+    .sort((a, b) => (index.get(a.number) ?? 0) - (index.get(b.number) ?? 0));
+  const chains = [];
+  const included = new Set();
+
+  for (const bottom of bottoms) {
+    if (included.has(bottom.number)) continue;
+    const chain = [bottom];
+    const seen = new Set([bottom.number]);
+    let top = bottom;
+
+    while (true) {
+      const children = (childrenByBase.get(top.headRefName) ?? []).filter((pr) => pr.number !== top.number);
+      if (children.length !== 1) break;
+      const child = children[0];
+      if (seen.has(child.number)) break;
+      chain.push(child);
+      seen.add(child.number);
+      top = child;
+    }
+
+    chains.push(chain);
+    for (const pr of chain) included.add(pr.number);
+  }
+
+  return chains;
+}
+
+function hasAdminBypassLabel(pr) {
+  if (!Object.hasOwn(pr ?? {}, 'labels')) return true;
+  const labels = pr.labels;
+  if (labels instanceof Set) return labels.has(ADMIN_BYPASS_LABEL);
+  if (Array.isArray(labels)) {
+    return labels.some((label) => label === ADMIN_BYPASS_LABEL || label?.name === ADMIN_BYPASS_LABEL);
+  }
+  if (Array.isArray(labels?.nodes)) {
+    return labels.nodes.some((label) => label === ADMIN_BYPASS_LABEL || label?.name === ADMIN_BYPASS_LABEL);
+  }
+  return false;
+}
+
+function isConflict(pr) {
+  return pr.mergeStateStatus === 'DIRTY' || pr.mergeable === 'CONFLICTING';
+}
+
+function gh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' });
+}
+
+function localCommitChecker() {
+  return (sha) => {
+    try {
+      execFileSync('git', ['cat-file', '-e', `${sha}^{commit}`], { stdio: 'ignore' });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+}
+
+function fetchAdminBypassMasterPrs() {
+  const out = gh(['pr', 'list', '--search', 'is:open label:admin-bypass base:master', '--json',
+    'number,headRefOid,headRefName,baseRefName,state,mergeStateStatus,mergeable']);
+  return JSON.parse(out);
+}
+
+function fetchFreshPr(prNumber) {
+  const out = gh(['pr', 'view', String(prNumber), '--json', 'headRefOid,mergeStateStatus,mergeable,state']);
+  return JSON.parse(out);
+}
+
+function addJailbreakMergedLabel(prNumber) {
+  gh(['api', '--silent', '--method', 'POST', `repos/{owner}/{repo}/issues/${prNumber}/labels`, '-f', `labels[]=${JAILBREAK_MERGED_LABEL}`]);
+}
+
+function appendLedger(pr) {
+  const path = `${process.env.TMPDIR || '/tmp'}/invoker-jailbreak-ledger.jsonl`;
+  appendFileSync(path, `${JSON.stringify({
+    pr: pr.number,
+    sha: pr.headRefOid,
+    mergedAt: new Date().toISOString(),
+    checksSkipped: true,
+    reviewSkipped: true,
+  })}\n`);
+}
+
+function runConcurrencyGate() {
+  return spawnSync('node', ['scripts/gh-actions-concurrency-exhausted.mjs'], { stdio: 'inherit' });
+}
+
+function main() {
+  const gate = runConcurrencyGate();
+  if (gate.status !== 0) {
+    console.log('not exhausted, nothing to do');
+    return;
+  }
+
+  let prs;
+  try {
+    prs = fetchAdminBypassMasterPrs();
+  } catch (e) {
+    console.error(`error: failed to list admin-bypass PRs: ${e.message}`);
+    process.exit(2);
+  }
+
+  const planned = planJailbreakActions({ prs, hasLocalCommit: localCommitChecker() });
+  if (planned.length === 0) {
+    console.log('no jailbreak merge candidates');
+    return;
+  }
+
+  for (const pr of planned) {
+    let freshPr;
+    try {
+      freshPr = { ...pr, ...fetchFreshPr(pr.number), number: pr.number };
+    } catch (e) {
+      console.error(`PR #${pr.number}: skip; failed to refresh PR state: ${e.message}`);
+      continue;
+    }
+
+    const recheck = analyzeStack({ prs: [freshPr], hasLocalCommit: localCommitChecker(), trunk: TRUNK });
+    if (!recheck.ok || isConflict(freshPr)) {
+      console.log(`PR #${pr.number}: skip; fresh recheck failed`);
+      continue;
+    }
+
+    if (process.env.INVOKER_JAILBREAK_LIVE !== '1') {
+      console.log(`PR #${pr.number}: dry-run would merge head ${freshPr.headRefOid}`);
+      continue;
+    }
+
+    try {
+      gh(['pr', 'merge', String(pr.number), '--squash', '--admin', '--match-head-commit', freshPr.headRefOid]);
+      addJailbreakMergedLabel(pr.number);
+      appendLedger(freshPr);
+      console.log(`PR #${pr.number}: merged head ${freshPr.headRefOid}`);
+    } catch (e) {
+      console.error(`PR #${pr.number}: merge failed: ${e.message}`);
+    }
+  }
+}
+
+const invokedDirectly = (() => {
+  try {
+    return process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) main();

--- a/scripts/test-jailbreak-admin-bypass-land.mjs
+++ b/scripts/test-jailbreak-admin-bypass-land.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { planJailbreakActions } from './jailbreak-admin-bypass-land.mjs';
+
+const SHA_1 = '1111111111111111111111111111111111111111';
+const SHA_2 = '2222222222222222222222222222222222222222';
+const SHA_3 = '3333333333333333333333333333333333333333';
+
+const hasLocalCommit = (sha) => new Set([SHA_1, SHA_2, SHA_3]).has(sha);
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log(`ok - ${name}`);
+}
+
+function pr(overrides) {
+  return {
+    number: 1,
+    headRefOid: SHA_1,
+    headRefName: 'stack/bottom',
+    baseRefName: 'master',
+    state: 'OPEN',
+    mergeStateStatus: 'CLEAN',
+    mergeable: 'MERGEABLE',
+    labels: ['admin-bypass'],
+    ...overrides,
+  };
+}
+
+const stack = [
+  pr({ number: 10, headRefOid: SHA_1, headRefName: 'stack/bottom', baseRefName: 'master' }),
+  pr({ number: 11, headRefOid: SHA_2, headRefName: 'stack/middle', baseRefName: 'stack/bottom' }),
+  pr({ number: 12, headRefOid: SHA_3, headRefName: 'stack/top', baseRefName: 'stack/middle' }),
+];
+
+test('valid bottom-up stack returns every PR in merge order', () => {
+  const planned = planJailbreakActions({ prs: [stack[2], stack[0], stack[1]], hasLocalCommit });
+  assert.deepEqual(planned.map((item) => item.number), [10, 11, 12]);
+});
+
+test('DIRTY PR is excluded while the rest of a valid stack returns', () => {
+  const planned = planJailbreakActions({
+    prs: [stack[0], { ...stack[1], mergeStateStatus: 'DIRTY' }, stack[2]],
+    hasLocalCommit,
+  });
+  assert.deepEqual(planned.map((item) => item.number), [10, 12]);
+});
+
+test('CONFLICTING PR is excluded while the rest of a valid stack returns', () => {
+  const planned = planJailbreakActions({
+    prs: [stack[0], { ...stack[1], mergeable: 'CONFLICTING' }, stack[2]],
+    hasLocalCommit,
+  });
+  assert.deepEqual(planned.map((item) => item.number), [10, 12]);
+});
+
+test('stack that fails land-stack ancestry checks is excluded', () => {
+  const planned = planJailbreakActions({
+    prs: [pr({ number: 20, headRefName: 'stack/wrong-base', baseRefName: 'some-other-branch' })],
+    hasLocalCommit,
+  });
+  assert.deepEqual(planned, []);
+});
+
+console.log(`\n${passed} tests passed`);


### PR DESCRIPTION
## Summary

Adds a standalone tool that force-squash-merges eligible admin-bypass PRs after the existing Actions-congestion detector reports sustained exhaustion.

It orders connected PRs bottom-up, omits conflicted entries, and refreshes each candidate before invoking GitHub's SHA-pinned admin merge.

Real merges require `INVOKER_JAILBREAK_LIVE=1`. The default mode only reports intended actions.

Successful merges receive a `jailbreak-merged` label and an audit record. Existing workers and schedules remain unchanged.

## Review Claim

Approve a dry-run-by-default admin-bypass landing tool with conflict filtering, fresh head-state checks, and GitHub-enforced head-SHA pinning.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Without `INVOKER_JAILBREAK_LIVE=1`, `scripts/jailbreak-admin-bypass-land.mjs:178-180` logs the intended merge and continues before merge, label, or ledger mutations.

Live merges pass the freshly fetched head SHA to `--match-head-commit` at `scripts/jailbreak-admin-bypass-land.mjs:183-186`, so GitHub rejects a moved head.

## Slice Rationale

The detector already exists on `master`, while scheduler registration belongs in the next slice. This slice keeps the landing tool with its directly affected offline proof.

## Non-goals

- Does not register or schedule the tool.
- Does not change the existing conflict-repair worker.
- Does not modify Mergify configuration or queue state.
- Does not calibrate the existing congestion detector.

## Architecture

### Before

```mermaid
graph TD
    A["Actions-congestion detector"] --> B["No force-merge consumer"]
```

### After

```mermaid
graph TD
    A["Actions-congestion detector exits 0"] --> B["Planner orders eligible admin-bypass PRs"]
    B --> C["Refresh candidate state and head SHA"]
    C --> D["Dry-run log or live SHA-pinned admin merge"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-jailbreak-admin-bypass-land.mjs`
- [x] `node --check scripts/jailbreak-admin-bypass-land.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-PR-sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tooling to safely plan and optionally execute eligible administrative pull request squash merges.
  - Validates merge order, stack completeness, conflicts, and current pull request state before acting.
  - Supports dry-run previews, concurrency checks, commit verification, merge labeling, and audit records.
  - Skips unsuitable pull requests and reports refresh or service failures without stopping unrelated actions.

- **Tests**
  - Added coverage for valid merge ordering, conflicts, dirty changes, and invalid ancestry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->