### PR TITLE
[CI regression: 631a0d0-quality-dependency-cruise](1) Select core runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,8 @@ jobs:
           if-no-files-found: error
 
   quality-required:
-    runs-on: ${{ matrix.runner_label }}
+    runs-on:
+      labels: ${{ matrix.runner_label }}
     timeout-minutes: 5
     strategy:
       fail-fast: false
@@ -75,7 +76,7 @@ jobs:
         include:
           - name: Dependency Cruise
             command: pnpm run check:deps
-            runner_label: ubuntu-latest
+            runner_label: Runner_2_4_core
 
     name: quality / ${{ matrix.name }}
 

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -43,15 +43,15 @@ for (const jobName of FULL_CI_JOBS) {
 assert(jobs['quality-required'], 'Missing quality-required job');
 assert(!jobs['quality-required'].if, 'quality-required must run on ordinary PRs');
 assert(
-  jobs['quality-required']['runs-on'] === '${{ matrix.runner_label }}',
-  'quality-required must use each matrix entry as the full runner selector',
+  jobs['quality-required']['runs-on']?.labels === '${{ matrix.runner_label }}',
+  'quality-required must route each matrix entry through the self-hosted runner label selector',
 );
 const qualityRequiredEntries = jobs['quality-required'].strategy?.matrix?.include ?? [];
 const dependencyCruiseEntry = qualityRequiredEntries.find((entry) => entry.name === 'Dependency Cruise');
 assert(dependencyCruiseEntry, 'quality-required matrix must include Dependency Cruise');
 assert(
-  dependencyCruiseEntry.runner_label === 'ubuntu-latest',
-  'Dependency Cruise must run on a GitHub-hosted runner to avoid self-hosted setup disk pressure',
+  dependencyCruiseEntry.runner_label === 'Runner_2_4_core',
+  'Dependency Cruise must run on the self-hosted core runner so runner setup reaches the check command',
 );
 
 assert(jobs['quality-extra'], 'Missing quality-extra job');


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=quality / Dependency Cruise -->

Run `quality / Dependency Cruise` on the self-hosted core runner via the workflow label selector.

Align the merge-queue workflow policy test with that runner contract.

The job first failed in [run 31620499765](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94225435692).

## Review Claim

Approve selecting `Runner_2_4_core` for Dependency Cruise and enforcing that choice in the existing workflow policy test.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected Dependency Cruise runner selection.

## Slice Rationale

The workflow selector and its directly affected policy assertion form one reviewable CI policy change.

The verification task changed no files, so its empty slice is folded into this policy slice.

## Non-goals

- No product behavior changes.
- No dependency-rule changes.
- No unrelated CI job changes.
- No test weakening or snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:deps`
- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <PR merge commit>`
- Post-revert steps: Re-run the two Test Plan commands.
- Data migration? No

</details>
