### PR TITLE
[CI regression: 8365ed9-playwright-terminal-garbling](1) Reconcile Playwright shard inventory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -702,7 +702,7 @@ jobs:
               e2e/invalid-merge-workspace-visual.spec.ts
               e2e/invalid-task-workspace-visual.spec.ts
               e2e/persistence-lifecycle.spec.ts
-              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
+              e2e/renderer-state-restoration.spec.ts
           - name: 3-of-9
             files: >-
               e2e/task-death-logs.spec.ts
@@ -711,6 +711,7 @@ jobs:
               e2e/pending-review-gate-target-repo.proof.spec.ts
               e2e/workflow-status-composition.spec.ts
               e2e/queue-running-vs-queued.spec.ts
+              e2e/attach-workflow.spec.ts
           - name: 4-of-9
             files: >-
               e2e/startup-window-liveness.spec.ts
@@ -719,14 +720,14 @@ jobs:
               e2e/edit-task-prompt.spec.ts
               e2e/fix-with-claude.spec.ts
               e2e/fix-with-agent-transition.spec.ts
-              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
+              e2e/renderer-memory-pressure-recovery.spec.ts
           - name: 5-of-9
             files: >-
               e2e/autofix-worker-ui.spec.ts
               e2e/orphan-relaunch.spec.ts
               e2e/gap-recovery-bench.spec.ts
               e2e/planning-chat-send-long-deadline.spec.ts
-              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
+              e2e/planning-review-scroll.spec.ts
               e2e/system-setup-visual-proof.spec.ts
               e2e/startup-nonempty-responsiveness.spec.ts
           - name: 6-of-9
@@ -734,7 +735,6 @@ jobs:
               e2e/embedded-terminal-spawn-failure.spec.ts
               e2e/embedded-terminal-restart-persistence.spec.ts
               e2e/planning-terminal-restart-persistence.spec.ts
-              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
               e2e/planning-terminal-open-daemon-owner-repro.spec.ts
               e2e/planning-terminal-tmux-blank-repro.spec.ts
               e2e/planning-tmux-blank-repro.spec.ts
@@ -742,7 +742,6 @@ jobs:
             files: >-
               e2e/worker-tab-scroll.spec.ts
               e2e/workflow-delete-latency.spec.ts
-              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
               e2e/main-process-hitch-responsiveness.spec.ts
               e2e/dag-click-hitch-responsiveness.spec.ts
               e2e/terminal-upsert-hitch-responsiveness.spec.ts
@@ -768,7 +767,6 @@ jobs:
           - name: terminal-garbling
             files: >-
               e2e/planning-terminal-live-model.proof.spec.ts
-              e2e/planning-chat-restore-conversational-mode-repro.spec.ts
               e2e/planning-surface-navigation-garble-repro.spec.ts
               e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts
               e2e/planning-terminal-expand-collapse-garble-repro.spec.ts


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / terminal-garbling -->

CI job `playwright / terminal-garbling` first failed on default-branch push commit 8365ed93997c669fc85eb85b4d56353378310e03 in run 31574441095.

It was most recently still red at e73ee552a6e174a85fc6107186bb802b32ec4b6e in run 31629955741.

The Playwright inventory assigned one repro to multiple shards while omitting four CI-owned specs.

This restores one owner per spec and leaves terminal-garbling with only its dedicated regression set.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31574441095/job/94043888939

## Review Claim

Reconcile the Playwright shard roster so every CI-owned spec has exactly one owner and terminal-garbling runs only its dedicated regressions.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Product behavior and test implementations stay unchanged; the workflow-only edit restores exactly one shard owner for every CI-owned Playwright spec.

## Slice Rationale

Duplicate removal and missing assignments form one roster-consistency policy change enforced by the existing inventory repro.

## Non-goals

- No product behavior changes.
- No test implementation or assertion changes.
- No Playwright timeout, worker, or reporter changes.
- No refactor, unrelated cleanup, test weakening, or snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs` — `[repro-ci-playwright-shard-inventory] OK: 68 CI-owned spec files each assigned to exactly one shard; 2 manual-only spec accounted for.`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-terminal-garbling' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/planning-terminal-live-model.proof.spec.ts e2e/planning-surface-navigation-garble-repro.spec.ts e2e/planning-terminal-chat-tmux-toggle-garble-repro.spec.ts e2e/planning-terminal-expand-collapse-garble-repro.spec.ts e2e/task-terminal-drawer-minimize-garble-repro.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — all three builds passed; Playwright did not start locally because `xvfb-run` is unavailable. The command exited 254 with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "xvfb-run" not found`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-sha-of-this-pr>`
- Post-revert steps: Re-run `node scripts/repro/repro-ci-playwright-shard-inventory.mjs`; duplicate and missing shard assignments will return unless the roster changes elsewhere.
- Data migration? No

</details>
