### PR TITLE
[CI regression: 631a0d0-ssh-shard-30](1) Propagate writable Electron cache to SSH jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -922,6 +922,8 @@ jobs:
     runs-on: [self-hosted, Linux, X64, Runner_Heavy_Ubuntu, Runner_Heavy_Docker]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
+    env:
+      electron_config_cache: /tmp/invoker-electron-cache
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/scripts/e2e-ssh/lib/ssh-common.sh
+++ b/scripts/e2e-ssh/lib/ssh-common.sh
@@ -219,7 +219,7 @@ invoker_e2e_ssh_init() {
 # SshExecutor uses a non-login shell and sources remoteInvokerHome/env.sh.
 # --------------------------------------------------------------------------- #
 invoker_e2e_ssh_install_login_path() {
-  local pnpm_bin node_bin pnpm_dir node_dir
+  local pnpm_bin node_bin pnpm_dir node_dir electron_cache
   pnpm_bin="$(command -v pnpm || true)"
   node_bin="$(command -v node || true)"
   if [ -z "$pnpm_bin" ] || [ -z "$node_bin" ]; then
@@ -238,6 +238,16 @@ invoker_e2e_ssh_install_login_path() {
       printf '%s\n' "# invoker-e2e-ssh-pnpm-path ${_INVOKER_E2E_SSH_TAG}"
       printf 'export PATH="%s:%s:$PATH"\n' "$node_dir" "$pnpm_dir"
     } >> "$_INVOKER_E2E_SSH_REMOTE_HOME/env.sh"
+  fi
+  electron_cache="${electron_config_cache:-}"
+  if [ -n "$electron_cache" ]; then
+    mkdir -p "$electron_cache"
+    if ! grep -Fq "# invoker-e2e-ssh-electron-cache ${_INVOKER_E2E_SSH_TAG}" "$_INVOKER_E2E_SSH_REMOTE_HOME/env.sh" 2>/dev/null; then
+      {
+        printf '%s\n' "# invoker-e2e-ssh-electron-cache ${_INVOKER_E2E_SSH_TAG}"
+        printf 'export electron_config_cache=%q\n' "$electron_cache"
+      } >> "$_INVOKER_E2E_SSH_REMOTE_HOME/env.sh"
+    fi
   fi
 
   # Verify via non-login bash — matches the executor sourcing remoteInvokerHome/env.sh explicitly.


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=ssh / shard-30 -->

CI job `ssh / shard-30` first failed on default-branch commit `631a0d08c7072e9544813fc1b93fb616586ce441`.

The job now gives Electron a writable cache under `/tmp` and exports that setting into the remote SSH executor environment.

This keeps Electron config writes out of the repository checkout while preserving the remaining SSH test flow.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217681

## Review Claim

Approve the SSH CI policy that assigns Electron a writable cache and propagates it to remote executor shells.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

The workflow setting and SSH environment export form one policy slice because either change alone leaves the remote Electron process without the intended cache.

## Non-goals

- No product behavior changes.
- No unrelated CI job changes.
- No test weakening or snapshot updates.
- No refactor or cleanup outside the SSH test environment.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash 'scripts/test-suites/optional/30-e2e-ssh.sh'` — the three builds passed, then the SSH suite reported `e2e-ssh: 0 passed, 3 failed (3 total)` and `TASK_EXIT_CODE=1` because `packages/slack-bug-scan/src/contract.js` was missing.
- Earlier evidence: the Invoker verification task recorded `Exit code: 0` before publication and before the branch was rebased onto current `master`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 054b72b96de6c54e19791d29d2f16e832dbf2fe7`
- Post-revert steps: Rerun the SSH shard command from the Test Plan.
- Data migration? No.

</details>
