### PR TITLE
[CI regression: 631a0d0-quality-typescript-types](1) Reclaim the type-check runner workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,10 +108,14 @@ jobs:
 
   typescript-types:
     name: quality / TypeScript Types
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: Runner_2_4_core
     timeout-minutes: 5
 
     steps:
+      - name: Reclaim workspace
+        run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" "$HOME/.invoker" "$HOME/.claude" 2>/dev/null || true
+        shell: bash
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=quality / TypeScript Types -->

## Summary

The CI-watch report associates this slice with default-branch commit `631a0d08c7072e9544813fc1b93fb616586ce441` and run 31620499765.

This slice runs the job on `Runner_2_4_core` and reclaims its workspace before checkout.

The changed runner and reclaim step are at `.github/workflows/ci.yml:111` and `.github/workflows/ci.yml:116`.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94225435567

## Review Claim

Approve dedicated capacity and pre-checkout workspace reclaim for the affected quality job.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged; the type-check job keeps the same name, setup sequence, check command, and timeout.

## Slice Rationale

One CI-policy slice contains the only file change. The verification task produced no separate diff, so it is represented in the test plan.

## Non-goals

- No product behavior changes.
- No type-check command, assertion, or timeout weakening.
- No runner changes for other CI jobs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`

  ```text
  > invoker@0.0.12 check:types /Users/edbertchan/.invoker/merge-clones/gate-__merge__wf-1786601935961-72-FR32F3
  > tsc -p tsconfig.typecheck.json

  EXIT_CODE=0
  ```

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged commit SHA>`
- Post-revert steps: Re-run `quality / TypeScript Types` and verify runner capacity and workspace ownership.
- Data migration? No

</details>
