### PR TITLE
[CI regression: 631a0d0-required-fast-guardrails](1) Externalize Slack bug scan

### DIFF
--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     '@invoker/execution-engine',
     '@invoker/planning-core',
     '@invoker/shell',
+    '@invoker/slack-bug-scan',
     'yaml',
   ],
   clean: true,


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=required-fast / Guardrails -->

CI job `required-fast / Guardrails` first failed on default-branch push commit 631a0d08c7072e9544813fc1b93fb616586ce441 in run 31620499765.

`@invoker/app` now treats `@invoker/slack-bug-scan` as an external workspace dependency during bundling.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217679

## Review Claim

The app bundle keeps Slack bug scanning at the existing workspace-package boundary.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

This is the smallest product slice: one bundler boundary change, separate from the guard policy that exercises it.

## Non-goals

- No Slack bug-scan behavior changes.
- No app entry-point changes.
- No unrelated dependency changes.
- No test or guard weakening.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 96ad2fb9faf3b4c1744bf8ec1abb5a7b186fc575`
- Post-revert steps: Rerun `pnpm --filter @invoker/app build`.
- Data migration? No.

</details>
