### PR TITLE
[CI regression: 631a0d0-required-fast-guardrails](2) Harden executor-routing guard

### DIFF
--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     '@invoker/execution-engine',
     '@invoker/planning-core',
     '@invoker/shell',
+    '@invoker/slack-bug-scan',
     'yaml',
   ],
   clean: true,

--- a/plans/verify-executor-routing.invoker.json
+++ b/plans/verify-executor-routing.invoker.json
@@ -1,6 +1,9 @@
 {
   "allowGraphMutation": true,
   "defaultBranch": "master",
+  "worktreeTargets": {
+    "local-worktree": {}
+  },
   "executorRoutingRules": [
     {
       "pattern": "verify-routing-ok",

--- a/scripts/verify-executor-routing.sh
+++ b/scripts/verify-executor-routing.sh
@@ -53,23 +53,38 @@ dest.write_text(nl.join(out) + (nl if text.endswith('\n') else ''), encoding='ut
 echo "==> submit-plan (headless run) $PLAN_SRC (repoUrl -> file:// checkout)"
 ./submit-plan.sh "$PLAN_TMP"
 
-# Assert the routed task completed through the configured worktree pool member if sqlite3 is available.
 DB="$TMPDB/invoker.db"
-if [[ -f "$DB" ]] && command -v sqlite3 >/dev/null 2>&1; then
-  STATUS=$(sqlite3 "$DB" "SELECT status FROM tasks WHERE id LIKE '%/verify-routing-command' LIMIT 1;")
-  RUNNER_KIND=$(sqlite3 "$DB" "SELECT runner_kind FROM tasks WHERE id LIKE '%/verify-routing-command' LIMIT 1;")
-  POOL_ID=$(sqlite3 "$DB" "SELECT pool_id FROM tasks WHERE id LIKE '%/verify-routing-command' LIMIT 1;")
-  if [[ "$STATUS" != "completed" ]]; then
-    echo "FAIL: expected routed task to complete, got status='$STATUS'" >&2
-    exit 1
-  fi
-  if [[ "$POOL_ID" != "dummy-target" ]]; then
-    echo "FAIL: expected routed task pool_id=dummy-target, got '$POOL_ID'" >&2
-    exit 1
-  fi
-  if [[ "$RUNNER_KIND" != "worktree" ]]; then
-    echo "FAIL: expected persisted pool-routed task runner_kind=worktree, got '$RUNNER_KIND'" >&2
-    exit 1
-  fi
-  echo "PASS: routed task completed with pool_id=$POOL_ID runner_kind=$RUNNER_KIND"
+if [[ ! -f "$DB" ]]; then
+  echo "FAIL: expected invoker.db at $DB, but it does not exist" >&2
+  echo "==> Contents of $TMPDB:" >&2
+  ls -la "$TMPDB" >&2 || true
+  exit 1
 fi
+node --input-type=module - "$DB" <<'EOF'
+import { DatabaseSync } from 'node:sqlite';
+
+const [, , dbPath] = process.argv;
+const db = new DatabaseSync(dbPath, { readOnly: true });
+const row = db
+  .prepare("SELECT status, runner_kind AS runnerKind, pool_id AS poolId FROM tasks WHERE id LIKE '%/verify-routing-command' LIMIT 1;")
+  .get();
+db.close();
+
+if (!row) {
+  console.error('FAIL: expected persisted routed task row, got none');
+  process.exit(1);
+}
+if (row.status !== 'completed') {
+  console.error(`FAIL: expected routed task to complete, got status='${row.status ?? ''}'`);
+  process.exit(1);
+}
+if (row.poolId !== 'dummy-target') {
+  console.error(`FAIL: expected routed task pool_id=dummy-target, got '${row.poolId ?? ''}'`);
+  process.exit(1);
+}
+if (row.runnerKind !== 'worktree') {
+  console.error(`FAIL: expected persisted pool-routed task runner_kind=worktree, got '${row.runnerKind ?? ''}'`);
+  process.exit(1);
+}
+EOF
+echo "PASS: routed task completed with pool_id=dummy-target runner_kind=worktree"


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=required-fast / Guardrails -->

CI job `required-fast / Guardrails` first failed on default-branch push commit 631a0d08c7072e9544813fc1b93fb616586ce441 in run 31620499765.

The executor-routing guard declares its local worktree target and always inspects persisted results through Node's built-in SQLite support.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217679

## Review Claim

The required-fast Guardrails policy always checks the persisted executor-routing result without depending on a host `sqlite3` binary.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

This policy slice keeps the routing fixture and its persisted-result assertion together, after the app bundling prerequisite.

## Non-goals

- No product feature changes.
- No unrelated cleanup.
- No weakened routing assertions.
- No changes to other CI jobs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/05-delete-all-prod-db-guard.sh && bash scripts/test-suites/required/06-large-file-guardrail.sh && bash scripts/test-suites/required/07-invalid-config-json.sh && bash scripts/test-suites/required/08-build-artifact-surfaces-guard.sh && bash scripts/test-suites/required/10-dag-background-click-noop-guard.sh && bash scripts/test-suites/required/15-owner-boundary-policy.sh && bash scripts/test-suites/required/50-verify-executor-routing.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 69687f3a89d6f169a91f584ad8bf61ede031ec26`
- Post-revert steps: Rerun `required-fast / Guardrails`.
- Data migration? No.

</details>
