### PR TITLE
[CI regression: e73ee55-required-fast-merge-gate-concurrency-repro](1) Install libatomic1 before Node setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,7 +507,6 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Install system libraries for Node
-        if: matrix.name == 'Launch Dispatch Queue Repro'
         run: sudo apt-get update -qq && sudo apt-get install -y libatomic1
 
       - name: Use Node.js ${{ env.NODE_VERSION }}


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=e73ee552a6e174a85fc6107186bb802b32ec4b6e; job=required-fast / Merge Gate Concurrency Repro -->

CI job `required-fast / Merge Gate Concurrency Repro` failed before its repro started because Node could not load `libatomic.so.1`.

The system-library step ran only for `Launch Dispatch Queue Repro`.

This change runs that existing install step for every `required-fast-extra` matrix entry before Node setup.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31629955741/job/94262949340

## Review Claim

Install `libatomic1` for every `required-fast-extra` matrix entry before Node setup.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Job selection, matrix commands, and product code stay unchanged. Every existing `required-fast-extra` entry receives the same prerequisite package before Node setup.

## Slice Rationale

One CI-policy slice removes the single restrictive guard. The verification task produced no file diff, so its proof belongs in this PR's Test Plan.

## Non-goals

- No product behavior changes.
- No CI job, matrix entry, or test-command changes.
- No test weakening or unrelated workflow cleanup.

## Architecture

### Before

`Install system libraries for Node` ran only when the matrix name was `Launch Dispatch Queue Repro`.

### After

The existing install step runs for every `required-fast-extra` matrix entry before Node setup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting restores the job-specific install guard and may restore the missing-library setup failure.
- Revert command: `git revert 6e69b103154ed8bc67b5197bf649adde6f36b0cd`
- Post-revert steps: Re-run the required-fast matrix job.
- Data migration? No.

</details>
