### PR TITLE
[CI regression: 8365ed9-playwright-7-of-9](1) Externalize Slack bug scan from app bundle

### DIFF
--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     '@invoker/transport',
     '@invoker/execution-engine',
     '@invoker/planning-core',
+    '@invoker/slack-bug-scan',
     '@invoker/shell',
     'yaml',
   ],


### PR DESCRIPTION
## Summary

The app build lists `@invoker/slack-bug-scan` with the workspace packages that tsup leaves external (`packages/app/tsup.config.ts:23`).

This aligns that package boundary with the other Invoker workspace dependencies during the Playwright job's app build.

## Review Claim

Approve keeping `@invoker/slack-bug-scan` outside the app bundle.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

The app packaging boundary is isolated from the separate Playwright shard-assignment policy change.

## Non-goals

- No changes to Slack scan behavior, package source, or application call sites.
- No Playwright shard changes in this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app build`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-7-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/worker-tab-scroll.spec.ts e2e/workflow-delete-latency.spec.ts e2e/main-process-hitch-responsiveness.spec.ts e2e/dag-click-hitch-responsiveness.spec.ts e2e/terminal-upsert-hitch-responsiveness.spec.ts e2e/attention-click-hitch-responsiveness.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert e3aaa21dc`
- Post-revert steps: Rebuild `@invoker/app` before rerunning the Playwright shard.
- Data migration? No

</details>
