### PR TITLE
[Deploy self-kill via own kill-script](1a) Prove the kill-script matches its own ancestor

### DIFF
--- a/scripts/repro/repro-deploy-do1-kill-script-self-match.sh
+++ b/scripts/repro/repro-deploy-do1-kill-script-self-match.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Repro: deploy-do1.sh's python "find and kill the old owner process" step
+# matches and SIGTERMs its OWN ancestor process, aborting the restart
+# sequence before it ever reaches `systemctl restart slack-manager.service`.
+#
+# Root cause:
+#   The kill script (scripts/deploy-do1.sh, inside the `setsid bash -c '...'`
+#   restart block) finds kill targets by checking, for every /proc/<pid>:
+#     - realpath(cwd) == repo_root
+#     - the search substring appears in cmdline
+#   The `setsid bash -c '...'` wrapper that RUNS this whole restart sequence
+#   also `cd`s into repo_root, and its own cmdline is the literal script
+#   source text -- which necessarily contains the same search substring,
+#   since that substring is the pgrep/python match pattern written inline in
+#   the script itself. So the kill script matches its own ancestor and kills
+#   its own process group mid-sequence (observed live: RESTART_STATUS=143,
+#   i.e. SIGTERM, with no "restart"/"is-active" log lines ever emitted).
+#
+# Separately, the search substring itself ("packages/app/dist/main.js") is
+# stale: the real deployed owner process is invoked via invoker-ui's AppImage
+# (`invoker-ui ... --headless owner-serve` / `.../Invoker.AppImage ...
+# --headless owner-serve`), which never contains that path. So even without
+# the self-kill, the script could never find a real target to kill either.
+#
+# This script proves both problems against the CURRENT (buggy) matching
+# logic, and confirms the fix: excluding the caller's own process group from
+# the kill candidates, plus matching the real "--headless owner-serve"
+# invocation shape.
+set -euo pipefail
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-deploy-self-match.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+REPO_ROOT="$TMP/repo_root"
+mkdir -p "$REPO_ROOT"
+
+fail() { echo "[repro] FAIL: $1"; exit 1; }
+
+# The exact matcher from deploy-do1.sh today (unfixed): cwd==repo_root and
+# the stale "packages/app/dist/main.js" substring, no self-exclusion.
+BUGGY_MATCHER='
+import os, signal, sys
+repo_root = os.path.realpath(sys.argv[1])
+process_groups = set()
+for name in os.listdir("/proc"):
+    if not name.isdigit():
+        continue
+    pid = int(name)
+    try:
+        if os.path.realpath(f"/proc/{pid}/cwd") != repo_root:
+            continue
+        with open(f"/proc/{pid}/cmdline", "rb") as proc:
+            command = proc.read().replace(b"\0", b" ").decode(errors="replace")
+    except (FileNotFoundError, PermissionError, ProcessLookupError):
+        continue
+    if "packages/app/dist/main.js" in command:
+        process_groups.add(os.getpgid(pid))
+print(",".join(str(g) for g in process_groups))
+for pg in process_groups:
+    try:
+        os.killpg(pg, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+'
+
+# Fixed matcher: matches the real owner invocation shape and explicitly
+# excludes the caller's own process group.
+FIXED_MATCHER='
+import os, signal, sys
+repo_root = os.path.realpath(sys.argv[1])
+own_pgid = os.getpgid(os.getpid())
+process_groups = set()
+for name in os.listdir("/proc"):
+    if not name.isdigit():
+        continue
+    pid = int(name)
+    try:
+        if os.path.realpath(f"/proc/{pid}/cwd") != repo_root:
+            continue
+        with open(f"/proc/{pid}/cmdline", "rb") as proc:
+            command = proc.read().replace(b"\0", b" ").decode(errors="replace")
+    except (FileNotFoundError, PermissionError, ProcessLookupError):
+        continue
+    if "--headless owner-serve" not in command:
+        continue
+    pgid = os.getpgid(pid)
+    if pgid == own_pgid:
+        continue
+    process_groups.add(pgid)
+print(",".join(str(g) for g in process_groups))
+for pg in process_groups:
+    try:
+        os.killpg(pg, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+'
+
+run_case() {
+  local matcher="$1" case_name="$2"
+  local status_file="$TMP/${case_name}.status"
+  local owner_pid_file="$TMP/${case_name}.owner_pid"
+
+  # A fake "old owner" process: separate process group, matches the real
+  # invocation shape ("--headless owner-serve"), lives under repo_root.
+  # `setsid` gives it its own pgid, same as the real owner process (started
+  # independently by slack-manager, not by this restart sequence).
+  ( cd "$REPO_ROOT" && OWNER_PID_FILE="$owner_pid_file" exec setsid python3 -c '
+import os, time
+with open(os.environ["OWNER_PID_FILE"], "w") as f:
+    f.write(str(os.getpid()))
+time.sleep(30)
+' --headless owner-serve >/dev/null 2>&1 & )
+  sleep 0.3
+  local owner_pid
+  owner_pid="$(cat "$owner_pid_file" 2>/dev/null || echo "")"
+  [ -n "$owner_pid" ] || fail "fake old-owner process never started for case $case_name"
+
+  # The restart sequence itself: mirrors deploy-do1.sh's
+  # `setsid bash -c '<script embedding the matcher as literal source>'`.
+  # We embed $matcher literally so its own cmdline contains the same
+  # substrings the matcher searches for -- exactly deploy-do1.sh's shape.
+  setsid bash -c "
+    set -euo pipefail
+    cd '$REPO_ROOT'
+    python3 - '$REPO_ROOT' <<'PY'
+$matcher
+PY
+    echo survived > '$status_file'
+  " >/dev/null 2>&1
+  local seq_status=$?
+
+  sleep 0.5
+  local owner_alive="dead"
+  kill -0 "$owner_pid" 2>/dev/null && owner_alive="alive"
+  kill -9 "$owner_pid" 2>/dev/null || true
+
+  if [ -f "$status_file" ]; then
+    echo "sequence_survived seq_status=$seq_status old_owner=$owner_alive"
+  else
+    echo "sequence_self_killed seq_status=$seq_status old_owner=$owner_alive"
+  fi
+}
+
+echo "[repro] === BUGGY matcher (current deploy-do1.sh logic) ==="
+BUGGY_RESULT="$(run_case "$BUGGY_MATCHER" buggy)"
+echo "[repro] $BUGGY_RESULT"
+echo "$BUGGY_RESULT" | grep -q "sequence_self_killed" \
+  || fail "expected the buggy matcher to self-kill its own restart sequence, but it survived"
+echo "[repro] confirmed: buggy matcher kills its own ancestor, restart sequence never reaches 'systemctl restart'"
+echo "[repro] (and separately: old_owner stayed alive -- the stale pattern never matched a real target either)"
+echo
+
+echo "[repro] === FIXED matcher (excludes own pgid, matches real invocation) ==="
+FIXED_RESULT="$(run_case "$FIXED_MATCHER" fixed)"
+echo "[repro] $FIXED_RESULT"
+echo "$FIXED_RESULT" | grep -q "sequence_survived" \
+  || fail "expected the fixed matcher to let its own restart sequence survive, but it was killed"
+echo "$FIXED_RESULT" | grep -q "old_owner=dead" \
+  || fail "expected the fixed matcher to actually kill the real old-owner target"
+echo "[repro] confirmed: fixed matcher leaves its own ancestor alone AND still kills the real old owner"
+echo
+
+echo "[repro] PASS: reproduced the self-kill on the buggy matcher and confirmed the fix"


### PR DESCRIPTION
## Summary

`scripts/deploy-do1.sh` finds the old Invoker owner process to restart by walking `/proc` for processes whose working directory is the repo and whose argv text contains a match string.

The restart sequence itself runs as `setsid bash -c "<its own script text>"`. Its own working directory is also the repo, and its own argv text is that same script — containing the same match string.

The kill step matches its own ancestor and sends it SIGTERM, killing the whole restart sequence before it can restart the service.

This repro proves that mechanism in isolation, plus a second problem: the match string never matches the real owner process either, so a real old owner is never found even without the self-kill.

## Review Claim

The repro correctly demonstrates the self-kill mechanism (a buggy matcher kills its own ancestor process) and correctly demonstrates that a fixed matcher (excluding the caller's own process group) avoids it while still finding a real target.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The repro is fully self-contained: it spawns its own throwaway processes under a temp directory and only ever signals processes it created itself. It does not touch any real Invoker process, and requires no live infrastructure. Safe to run locally or in CI.

## Slice Rationale

Proof lands before the fix (next slice) so the bug is demonstrated before the behavior change is reviewed, per this repo's review-compression ordering rule. The repro embeds the buggy and fixed matcher logic as inline, self-contained snippets rather than reading `scripts/deploy-do1.sh` itself, so it does not depend on that file's state and stays meaningful before and after the fix lands.

## Non-goals

Does not modify `scripts/deploy-do1.sh` itself — that's the next slice. Does not repro the *other*, already-fixed self-kill scenario in `repro-deploy-self-kill-aborts-restart.sh` (the owner's own shutdown cascade killing the deploy task) — that's a different mechanism, already guarded.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash -n scripts/repro/repro-deploy-do1-kill-script-self-match.sh` (requires Linux `/proc`; run on a Linux host or in CI, not macOS)
- [ ] `bash scripts/repro/repro-deploy-do1-kill-script-self-match.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d0e97df4c6`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a standalone reproduction script for deployment restart process-matching issues.
  * Demonstrates the failure scenario where the restart sequence targets the wrong process.
  * Verifies the corrected behavior: the restart sequence avoids terminating itself and successfully stops the intended previous service.
  * Includes automated assertions that clearly report whether the reproduction passes or fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->