### PR TITLE
[Headless worker start/stop wiring](2b) Wire start/stop to the live worker runtime controller

### DIFF
--- a/packages/app/src/__tests__/headless-worker.test.ts
+++ b/packages/app/src/__tests__/headless-worker.test.ts
@@ -106,30 +106,70 @@ describe('headless worker registry', () => {
 });
 
 describe('headless worker start/stop', () => {
-  // Incident 2026-08-13: `--headless worker stop <kind>` is documented (see
-  // docs/remote-ssh-targets.md) and has a full delegation implementation in
+  // Incident 2026-08-13: `--headless worker stop <kind>` was documented (see
+  // docs/remote-ssh-targets.md) and had a full delegation implementation in
   // headless-client.ts, but nothing in the actual runtime dispatch
-  // (runHeadless -> headlessWorker) calls it -- "start"/"stop" fall through
-  // to the single-kind manual-tick branch, which rejects them as unknown
-  // worker kinds. `invoker-ui --headless worker stop e2e-autofix` fails with
-  // `Unknown worker kind: "stop"` against a live owner, even though a live
-  // WorkerRuntimeController (now reachable via getWorkerRuntimeController)
-  // is available and able to do it. The next slice makes these pass.
-  it('currently rejects "stop" as an unknown worker kind, even with a live controller available', async () => {
-    const stop = vi.fn();
-    await expect(runHeadless(['worker', 'stop', E2E_AUTOFIX_WORKER_KIND], {
-      invokerConfig: {},
-      getWorkerRuntimeController: () => ({ start: vi.fn(), stop } as never),
-    } as never)).rejects.toThrow(/Unknown worker kind: "stop"/);
-    expect(stop).not.toHaveBeenCalled();
+  // (runHeadless -> headlessWorker) ever called it -- "start"/"stop" fell
+  // through to the single-kind manual-tick branch, which rejected them as
+  // unknown worker kinds. `invoker-ui --headless worker stop e2e-autofix`
+  // failed with `Unknown worker kind: "stop"` against a live owner.
+  it('stops a live worker via the owner worker runtime controller', async () => {
+    let stdout = '';
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdout += String(chunk);
+      return true;
+    });
+
+    const stop = vi.fn().mockResolvedValue({ desiredEnabled: false });
+    const start = vi.fn();
+
+    try {
+      await runHeadless(['worker', 'stop', E2E_AUTOFIX_WORKER_KIND], {
+        invokerConfig: {},
+        getWorkerRuntimeController: () => ({ start, stop } as never),
+      } as never);
+    } finally {
+      write.mockRestore();
+    }
+
+    expect(stop).toHaveBeenCalledWith(E2E_AUTOFIX_WORKER_KIND);
+    expect(start).not.toHaveBeenCalled();
+    expect(stdout).toContain(`${E2E_AUTOFIX_WORKER_KIND}: stopped`);
   });
 
-  it('currently rejects "start" as an unknown worker kind, even with a live controller available', async () => {
-    const start = vi.fn();
-    await expect(runHeadless(['worker', 'start', E2E_AUTOFIX_WORKER_KIND], {
+  it('starts a live worker via the owner worker runtime controller', async () => {
+    let stdout = '';
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdout += String(chunk);
+      return true;
+    });
+
+    const start = vi.fn().mockReturnValue({ desiredEnabled: true });
+
+    try {
+      await runHeadless(['worker', 'start', E2E_AUTOFIX_WORKER_KIND], {
+        invokerConfig: {},
+        getWorkerRuntimeController: () => ({ start, stop: vi.fn() } as never),
+      } as never);
+    } finally {
+      write.mockRestore();
+    }
+
+    expect(start).toHaveBeenCalledWith(E2E_AUTOFIX_WORKER_KIND);
+    expect(stdout).toContain(`${E2E_AUTOFIX_WORKER_KIND}: started`);
+  });
+
+  it('rejects an unknown worker kind instead of silently no-opping', async () => {
+    await expect(runHeadless(['worker', 'stop', 'not-a-real-kind'], {
       invokerConfig: {},
-      getWorkerRuntimeController: () => ({ start, stop: vi.fn() } as never),
-    } as never)).rejects.toThrow(/Unknown worker kind: "start"/);
-    expect(start).not.toHaveBeenCalled();
+      getWorkerRuntimeController: () => ({ start: vi.fn(), stop: vi.fn() } as never),
+    } as never)).rejects.toThrow(/Unknown worker kind: "not-a-real-kind"/);
+  });
+
+  it('fails clearly when run outside a live owner process, instead of a confusing "unknown worker kind"', async () => {
+    await expect(runHeadless(['worker', 'stop', E2E_AUTOFIX_WORKER_KIND], {
+      invokerConfig: {},
+      getWorkerRuntimeController: () => null,
+    } as never)).rejects.toThrow(/no live owner worker runtime/);
   });
 });

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -514,10 +514,33 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
     return;
   }
 
+  if (subCommand === 'start' || subCommand === 'stop') {
+    const kind = args[1];
+    if (!kind) {
+      throw new Error(`Missing worker kind. Usage: --headless worker ${subCommand} <kind>`);
+    }
+    if (!registry.get(kind)) {
+      const knownKinds = registry.list().map((worker) => worker.kind).join(', ');
+      throw new Error(`Unknown worker kind: "${kind}". Use: ${knownKinds}`);
+    }
+    const controller = deps.getWorkerRuntimeController?.();
+    if (!controller) {
+      throw new Error(
+        `Cannot ${subCommand} worker "${kind}": no live owner worker runtime in this process. `
+        + `Run this against a live "owner-serve" process, or use `
+        + `"invoker-cli worker toggles --${subCommand === 'start' ? 'enable' : 'disable'} <id>" `
+        + 'to change the persisted config default instead.',
+      );
+    }
+    const entry = subCommand === 'start' ? controller.start(kind) : await controller.stop(kind);
+    process.stdout.write(`${kind}: ${subCommand === 'start' ? 'started' : 'stopped'} (desiredEnabled=${entry.desiredEnabled})\n`);
+    return;
+  }
+
   const definition = registry.get(subCommand);
   if (!definition) {
     const knownKinds = registry.list().map((worker) => worker.kind).join(', ');
-    throw new Error(`Unknown worker kind: "${subCommand}". Use: ${knownKinds}, list, status`);
+    throw new Error(`Unknown worker kind: "${subCommand}". Use: ${knownKinds}, list, status, start, stop`);
   }
 
   let lock;


### PR DESCRIPTION
headlessWorker now handles "start"/"stop" as real sub-commands: it
resolves the target kind against the worker registry, then calls
start()/stop() on the owner's live WorkerRuntimeController (reached via
the getWorkerRuntimeController accessor added in the prior slice), the
same controller the GUI's invoker:start-worker/invoker:stop-worker IPC
handlers already use. Running outside a live owner process now fails
with a clear message pointing at "invoker-cli worker toggles" instead of
a confusing "unknown worker kind".

The two tests from the prior slice are flipped to assert the fixed
behavior; two more cover the unknown-kind and no-live-owner cases.

Live verification still needed on DO1's next deploy: this closes the gap
found while trying to run `invoker-ui --headless worker stop e2e-autofix`
against a live owner, which previously failed outright.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Depends-On: #8993