### PR TITLE
[CI regression: 8365ed9-playwright-6-of-9](1) Externalize Slack bug scan from app bundle

### DIFF
--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     '@invoker/execution-engine',
     '@invoker/planning-core',
     '@invoker/shell',
+    '@invoker/slack-bug-scan',
     'yaml',
   ],
   clean: true,


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / 6-of-9 -->

CI job `playwright / 6-of-9` first failed on default-branch push commit 8365ed93997c669fc85eb85b4d56353378310e03 in run 31574441095.

It was most recently still red at e73ee552a6e174a85fc6107186bb802b32ec4b6e in run 31629955741.

The app build lists `@invoker/slack-bug-scan` with the workspace packages that tsup leaves external.

This preserves the package boundary used by other Invoker workspace dependencies during the Playwright app build.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31574441095/job/94043888915

## Review Claim

Approve keeping `@invoker/slack-bug-scan` outside the app bundle.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

This slice contains one app-bundling boundary change. The generated restart baselines remain isolated in the next slice.

## Non-goals

- No Slack bug-scan behavior or application call-site changes.
- No Playwright shard assignment changes.
- No unrelated dependency changes.
- No test weakening.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-6-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/embedded-terminal-spawn-failure.spec.ts e2e/embedded-terminal-restart-persistence.spec.ts e2e/planning-terminal-restart-persistence.spec.ts e2e/planning-terminal-open-daemon-owner-repro.spec.ts e2e/planning-terminal-tmux-blank-repro.spec.ts e2e/planning-tmux-blank-repro.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`
- The publication-clone attempt completed all three builds, then stopped before Playwright because `xvfb-run` is unavailable on this host.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <PR merge commit>`
- Post-revert steps: Rebuild `@invoker/app`, then rerun `playwright / 6-of-9`.
- Data migration? No

</details>
