### PR TITLE
[CI regression: a4a7770-playwright-5-of-9](1) Bundle Slack bug scan into Electron output

### DIFF
--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     '@invoker/execution-engine',
     '@invoker/planning-core',
     '@invoker/shell',
+    '@invoker/slack-bug-scan',
     'yaml',
   ],
   clean: true,


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a4a77700abe7fdd4f5743b92b3e2795de7d4277c; job=playwright / 5-of-9 -->

CI job `playwright / 5-of-9` first failed at a4a77700abe7fdd4f5743b92b3e2795de7d4277c and remained red through e73ee552a6e174a85fc6107186bb802b32ec4b6e.

[First bad job](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30895657329/job/91965992654)

The Electron app now bundles its Slack bug reporting workspace package instead of treating it as an external runtime dependency.

## Review Claim

Approve adding the Slack bug reporting module to the Electron app's bundled workspace packages so packaged startup paths can import it.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected module-resolution defect.

## Slice Rationale

This activation-surface slice contains only the bundler boundary change required by the failing Playwright shard.

## Non-goals

- No refactor or unrelated cleanup.
- No test weakening or snapshot churn.
- No changes to Slack bug scan behavior or its public API.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-5-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/autofix-worker-ui.spec.ts e2e/orphan-relaunch.spec.ts e2e/gap-recovery-bench.spec.ts e2e/planning-chat-send-long-deadline.spec.ts e2e/system-setup-visual-proof.spec.ts e2e/startup-nonempty-responsiveness.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — blocked locally because this macOS host lacks `xvfb-run`; exit 254 occurred before Playwright started.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert dca28d9df47d31cc5a416af994ece32b60b53152`
- Post-revert steps: None
- Data migration? No

</details>
