### PR TITLE
[Headless worker start/stop wiring](1) Add owner worker runtime accessor

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1234,6 +1234,7 @@ function startHeadlessMode(): void {
         }),
         runtimeServices,
         appRootDir: __dirname,
+        getWorkerRuntimeController: () => workerRuntimeController,
       } as HeadlessDeps;
 
       const createStandaloneTaskExecutor = (): TaskRunner => {


### PR DESCRIPTION
## Summary

Adds an accessor for the owner's live worker runtime to the one real `headlessDeps` construction site, closing over the same variable the existing `getWorkerStatus`/`getWorkers` accessors already close over.

Nothing reads this new accessor yet. The next slice uses it to reach a running worker from an operator request.

## Review Claim

The new accessor correctly closes over the owner's worker runtime and returns it once constructed, with no other change to how `headlessDeps` behaves today.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

No behavior change. This slice adds one field that nothing reads; the rest of `headlessDeps` and every existing caller is untouched.

## Slice Rationale

Foundation precedes the fix that consumes it, per this repo's ordering rule. This one line lives in `main.ts` (routing), while the consumer lives in `headless.ts`/`headless-shared.ts` (a different review unit), so they land as separate slices rather than one mixed-unit PR.

## Non-goals

Does not add any new "start"/"stop" handling — that's the next slice. Does not touch any other `headlessDeps` field. Behavior unchanged.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 61cfe3940e`
- Post-revert steps: None
- Data migration? No

</details>
