### PR TITLE
[Headless worker start/stop wiring](2) Wire start/stop to the live worker runtime controller

### DIFF
--- a/packages/app/src/__tests__/headless-worker.test.ts
+++ b/packages/app/src/__tests__/headless-worker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { INFRA_REPAIR_WORKER_KIND } from '@invoker/execution-engine';
+import { E2E_AUTOFIX_WORKER_KIND, INFRA_REPAIR_WORKER_KIND } from '@invoker/execution-engine';
 import {
   resolveHeadlessDiskHeadroomConfig,
   resolveHeadlessInfraRepairConfig,
@@ -102,5 +102,74 @@ describe('headless worker registry', () => {
         },
       },
     });
+  });
+});
+
+describe('headless worker start/stop', () => {
+  // Incident 2026-08-13: `--headless worker stop <kind>` was documented (see
+  // docs/remote-ssh-targets.md) and had a full delegation implementation in
+  // headless-client.ts, but nothing in the actual runtime dispatch
+  // (runHeadless -> headlessWorker) ever called it -- "start"/"stop" fell
+  // through to the single-kind manual-tick branch, which rejected them as
+  // unknown worker kinds. `invoker-ui --headless worker stop e2e-autofix`
+  // failed with `Unknown worker kind: "stop"` against a live owner.
+  it('stops a live worker via the owner worker runtime controller', async () => {
+    let stdout = '';
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdout += String(chunk);
+      return true;
+    });
+
+    const stop = vi.fn().mockResolvedValue({ desiredEnabled: false });
+    const start = vi.fn();
+
+    try {
+      await runHeadless(['worker', 'stop', E2E_AUTOFIX_WORKER_KIND], {
+        invokerConfig: {},
+        getWorkerRuntimeController: () => ({ start, stop } as never),
+      } as never);
+    } finally {
+      write.mockRestore();
+    }
+
+    expect(stop).toHaveBeenCalledWith(E2E_AUTOFIX_WORKER_KIND);
+    expect(start).not.toHaveBeenCalled();
+    expect(stdout).toContain(`${E2E_AUTOFIX_WORKER_KIND}: stopped`);
+  });
+
+  it('starts a live worker via the owner worker runtime controller', async () => {
+    let stdout = '';
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdout += String(chunk);
+      return true;
+    });
+
+    const start = vi.fn().mockReturnValue({ desiredEnabled: true });
+
+    try {
+      await runHeadless(['worker', 'start', E2E_AUTOFIX_WORKER_KIND], {
+        invokerConfig: {},
+        getWorkerRuntimeController: () => ({ start, stop: vi.fn() } as never),
+      } as never);
+    } finally {
+      write.mockRestore();
+    }
+
+    expect(start).toHaveBeenCalledWith(E2E_AUTOFIX_WORKER_KIND);
+    expect(stdout).toContain(`${E2E_AUTOFIX_WORKER_KIND}: started`);
+  });
+
+  it('rejects an unknown worker kind instead of silently no-opping', async () => {
+    await expect(runHeadless(['worker', 'stop', 'not-a-real-kind'], {
+      invokerConfig: {},
+      getWorkerRuntimeController: () => ({ start: vi.fn(), stop: vi.fn() } as never),
+    } as never)).rejects.toThrow(/Unknown worker kind: "not-a-real-kind"/);
+  });
+
+  it('fails clearly when run outside a live owner process, instead of a confusing "unknown worker kind"', async () => {
+    await expect(runHeadless(['worker', 'stop', E2E_AUTOFIX_WORKER_KIND], {
+      invokerConfig: {},
+      getWorkerRuntimeController: () => null,
+    } as never)).rejects.toThrow(/no live owner worker runtime/);
   });
 });

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -36,6 +36,7 @@ import type { WorkflowCancelResult } from './workflow-preemption.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import type { RuntimeServices } from '@invoker/runtime-service';
 import type { ReviewGateCiRepairCommandResult } from './review-gate-ci-repair-command.js';
+import type { WorkerRuntimeController } from './worker-control.js';
 
 
 export interface HeadlessDeps {
@@ -87,6 +88,15 @@ export interface HeadlessDeps {
   ownerTaskRunnerProvider?: () => TaskRunner | null;
   /** Main process dist directory (`__dirname` of main.js); used to locate the built web UI. */
   appRootDir?: string;
+  /**
+   * Accessor for the owner's live `WorkerRuntimeController`, used by
+   * `--headless worker start/stop <kind>` to control an already-running
+   * persistent worker in this process. A getter (not the controller itself)
+   * because it is constructed after `headlessDeps`; `null` when there is no
+   * live owner worker runtime in this process (e.g. a bare CLI command that
+   * only delegated here to run one command and exit).
+   */
+  getWorkerRuntimeController?: () => WorkerRuntimeController | null;
 }
 
 export const RESET = '\x1b[0m';

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -514,10 +514,33 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
     return;
   }
 
+  if (subCommand === 'start' || subCommand === 'stop') {
+    const kind = args[1];
+    if (!kind) {
+      throw new Error(`Missing worker kind. Usage: --headless worker ${subCommand} <kind>`);
+    }
+    if (!registry.get(kind)) {
+      const knownKinds = registry.list().map((worker) => worker.kind).join(', ');
+      throw new Error(`Unknown worker kind: "${kind}". Use: ${knownKinds}`);
+    }
+    const controller = deps.getWorkerRuntimeController?.();
+    if (!controller) {
+      throw new Error(
+        `Cannot ${subCommand} worker "${kind}": no live owner worker runtime in this process. `
+        + `Run this against a live "owner-serve" process, or use `
+        + `"invoker-cli worker toggles --${subCommand === 'start' ? 'enable' : 'disable'} <id>" `
+        + 'to change the persisted config default instead.',
+      );
+    }
+    const entry = subCommand === 'start' ? controller.start(kind) : await controller.stop(kind);
+    process.stdout.write(`${kind}: ${subCommand === 'start' ? 'started' : 'stopped'} (desiredEnabled=${entry.desiredEnabled})\n`);
+    return;
+  }
+
   const definition = registry.get(subCommand);
   if (!definition) {
     const knownKinds = registry.list().map((worker) => worker.kind).join(', ');
-    throw new Error(`Unknown worker kind: "${subCommand}". Use: ${knownKinds}, list, status`);
+    throw new Error(`Unknown worker kind: "${subCommand}". Use: ${knownKinds}, list, status, start, stop`);
   }
 
   let lock;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1234,6 +1234,7 @@ function startHeadlessMode(): void {
         }),
         runtimeServices,
         appRootDir: __dirname,
+        getWorkerRuntimeController: () => workerRuntimeController,
       } as HeadlessDeps;
 
       const createStandaloneTaskExecutor = (): TaskRunner => {


### PR DESCRIPTION
## Summary

A prior investigation found that stopping a worker by name against a live owner always failed with "Unknown worker kind: stop", even though the underlying capability to stop it was fully present and reachable.

The "start"/"stop" words were being treated as if they were worker names themselves, falling into the single-name manual-tick branch instead of a dedicated path.

`headlessWorker` now handles "start" and "stop" directly: it resolves the target name against the worker registry, then calls the owner's live worker runtime — the same one the desktop app's own toggle buttons already use.

Running this outside a live owner process now fails with a clear message pointing at the config-based toggle instead, rather than the confusing "unknown" message from before.

## Review Claim

The new "start"/"stop" handling correctly resolves a real target and hands off to the owner's live worker runtime, and fails clearly (not confusingly) when no such runtime is reachable.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

An unrecognized target name is rejected with the same "Unknown worker kind" message as before, listing the known names — it never silently no-ops. A recognized target with no live runtime available fails loudly with a specific message rather than doing nothing.

## Slice Rationale

This is the behavior half of the two-part change; the accessor it depends on landed as its own foundation slice first, since it belongs to a different review unit.

## Non-goals

Does not remove the older, unused delegation path in `headless-client.ts` — a separate cleanup. Does not change what happens for any other sub-word this function already understood.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test -- headless-worker.test.ts`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4ee0c6b286`
- Post-revert steps: None
- Data migration? No

</details>
