### PR TITLE
[CI regression: 631a0d0-fleet-631a0d0-4-jobs](1) Use GitHub-hosted Dependency Cruise capacity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,7 @@ jobs:
           if-no-files-found: error
 
   quality-required:
-    runs-on:
-      labels: ${{ matrix.runner_label }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       fail-fast: false
@@ -76,7 +75,6 @@ jobs:
         include:
           - name: Dependency Cruise
             command: pnpm run check:deps
-            runner_label: Runner_2_4_core
 
     name: quality / ${{ matrix.name }}
 

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -43,15 +43,15 @@ for (const jobName of FULL_CI_JOBS) {
 assert(jobs['quality-required'], 'Missing quality-required job');
 assert(!jobs['quality-required'].if, 'quality-required must run on ordinary PRs');
 assert(
-  jobs['quality-required']['runs-on']?.labels === '${{ matrix.runner_label }}',
-  'quality-required must route each matrix entry through the self-hosted runner label selector',
+  jobs['quality-required']['runs-on'] === 'ubuntu-latest',
+  'quality-required must use GitHub-hosted capacity so runner setup reaches the check command',
 );
 const qualityRequiredEntries = jobs['quality-required'].strategy?.matrix?.include ?? [];
 const dependencyCruiseEntry = qualityRequiredEntries.find((entry) => entry.name === 'Dependency Cruise');
 assert(dependencyCruiseEntry, 'quality-required matrix must include Dependency Cruise');
 assert(
-  dependencyCruiseEntry.runner_label === 'Runner_2_4_core',
-  'Dependency Cruise must run on the self-hosted core runner so runner setup reaches the check command',
+  !('runner_label' in dependencyCruiseEntry),
+  'Dependency Cruise must not pin to the disk-constrained self-hosted core runner',
 );
 
 assert(jobs['quality-extra'], 'Missing quality-extra job');


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=fleet -->

Fleet-correlated CI event: 4 jobs first failed on default-branch push commit 631a0d08c7072e9544813fc1b93fb616586ce441.

Member jobs:
- quality / Dependency Cruise: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94225435692
- quality / TS check: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94225435567
- required-fast / Guardrails: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217679
- ssh / shard-30: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217681

The required Dependency Cruise job now uses GitHub-hosted capacity instead of the disk-constrained self-hosted core runner.

The merge-queue policy check now asserts that exact capacity choice.

Workflow summary: both planned tasks completed and the local proof task passed.

## Review Claim

The CI workflow policy should put the required Dependency Cruise job on GitHub-hosted capacity and assert that choice in the merge-queue guard.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only CI workflow capacity selection and its policy check change; product code and other job definitions are untouched.

## Slice Rationale

This is one tooling-policy slice because the workflow entry and policy assertion must stay aligned.

The verification-only task produced no file diff, so publishing it separately would create an empty PR.

## Non-goals

No product behavior changes.

No test weakening or snapshot churn.

No broader CI runner reshuffle beyond the required Dependency Cruise job.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:deps`
- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert abfa104fd7954a995939c8279459f8d8351e863f`
- Post-revert steps: Re-run `node scripts/test-ci-workflow-merge-queue-policy.mjs`.
- Data migration? No

</details>
