### PR TITLE
[Headless CLI bundling gap](1) Add CI-blocking functional smoke test for the headless CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,6 +400,7 @@ jobs:
               bash scripts/test-suites/required/06-large-file-guardrail.sh
               bash scripts/test-suites/required/07-invalid-config-json.sh
               bash scripts/test-suites/required/08-build-artifact-surfaces-guard.sh
+              bash scripts/test-suites/required/09-headless-cli-boots-smoke.sh
               bash scripts/test-suites/required/10-dag-background-click-noop-guard.sh
               bash scripts/test-suites/required/15-owner-boundary-policy.sh
               bash scripts/test-suites/required/50-verify-executor-routing.sh

--- a/scripts/test-suites/required/09-headless-cli-boots-smoke.sh
+++ b/scripts/test-suites/required/09-headless-cli-boots-smoke.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Guardrail: packages/app/dist/main.js must actually boot and answer a
+# headless query, not just build without a tsc/tsup error.
+#
+# Regression (2026-08-13): @invoker/slack-bug-scan was left out of
+# packages/app/tsup.config.ts's noExternal list. Its package.json points
+# main/exports straight at raw src/index.ts (never compiled to dist), so
+# leaving it external meant Node tried to resolve that TypeScript file's own
+# relative imports (e.g. "./contract.js") against the filesystem at runtime
+# and failed with ERR_MODULE_NOT_FOUND the moment any code path touched the
+# slack-bug-scan worker. The crash happened during Electron's app "ready"
+# load phase as an uncaught main-process exception, so the process never
+# exited -- every `scripts/headless-lib.sh` caller (every cron worker,
+# including e2e-autofix's ci-regression-watch sweep) hung until its own
+# external timeout killed it, and every check it was mid-way through was
+# silently treated as "assume non-terminal work exists, skip filing". A
+# production droplet ran for an unknown period filing zero CI-regression
+# repair PRs with no visible error anywhere in that path.
+#
+# This is a functional check, not a config-text grep: it actually runs the
+# built CLI end to end, so it also covers any other workspace dependency
+# left external by mistake in the future, not just this one package.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+MAIN="$ROOT/packages/app/dist/main.js"
+if [[ ! -f "$MAIN" ]]; then
+  echo "FAIL: $MAIN does not exist -- build @invoker/app before running this check" >&2
+  exit 1
+fi
+
+ELECTRON="$ROOT/scripts/electron.cjs"
+SANDBOX_FLAG=""
+if [ "$(uname)" = "Linux" ]; then
+  SANDBOX_BIN="$ROOT/node_modules/.pnpm/electron@*/node_modules/electron/dist/chrome-sandbox"
+  # shellcheck disable=SC2086
+  if ! stat -c '%U:%a' $SANDBOX_BIN 2>/dev/null | grep -q '^root:4755$'; then
+    SANDBOX_FLAG="--no-sandbox"
+  fi
+  export LIBGL_ALWAYS_SOFTWARE=1
+fi
+
+OUT="$(mktemp)"
+ERR="$(mktemp)"
+trap 'rm -f "$OUT" "$ERR"' EXIT
+
+STATUS=0
+# shellcheck disable=SC2086
+timeout 30 "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless query workflows --output json >"$OUT" 2>"$ERR" || STATUS=$?
+
+if [[ "$STATUS" -eq 124 ]]; then
+  echo "FAIL: headless CLI hung for 30s and was killed. This is the exact symptom of a" >&2
+  echo "workspace dependency left external in packages/app/tsup.config.ts's noExternal" >&2
+  echo "whose package.json main/exports points at unbuilt raw .ts source -- Node's ESM" >&2
+  echo "loader crashes the Electron main process during load, and the crashed process" >&2
+  echo "never exits on its own." >&2
+  echo "-- stderr --" >&2
+  cat "$ERR" >&2
+  exit 1
+fi
+
+if [[ "$STATUS" -ne 0 ]]; then
+  echo "FAIL: headless CLI exited $STATUS" >&2
+  echo "-- stderr --" >&2
+  cat "$ERR" >&2
+  exit 1
+fi
+
+if ! python3 -c "import json,sys; json.load(open('$OUT'))" 2>/dev/null; then
+  echo "FAIL: headless CLI exited 0 but did not print valid JSON" >&2
+  echo "-- stdout --" >&2
+  cat "$OUT" >&2
+  echo "-- stderr --" >&2
+  cat "$ERR" >&2
+  exit 1
+fi
+
+echo "PASS: packages/app/dist/main.js boots and answers a headless query"


### PR DESCRIPTION
## Summary

The headless CLI can crash on load without any visible error anywhere near the caller.

One workspace dependency's package.json pointed straight at raw, uncompiled source.

Left unbundled, Node tried to resolve that source file's own relative import at runtime and failed.

The crash happened during Electron's load phase as an uncaught exception, so the process never exited.

Every cron worker script that calls the headless CLI hung until its own timeout killed it.

In production this silently blocked a worker from filing any of its expected pull requests.

This PR adds a functional check that boots the real built CLI and asserts it doesn't crash.

The affected package is already fixed on master; this check exists as standing protection.

## Review Claim

Approve adding a functional boot check for the built headless CLI to required CI, as standing protection against this exact failure mode recurring with a different dependency.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The added check only reads and executes the already-built artifact; it does not modify any build step, config, or product code, so it cannot change what ships.

## Slice Rationale

This is pure new verification tooling with no product-code change; it stands on its own regardless of any specific fix.

## Non-goals

Does not change any build configuration or product code.

Does not attempt to enumerate or fix every dependency that could exhibit this failure mode; that is a separate, already-passing concern.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `bash scripts/test-suites/required/09-headless-cli-boots-smoke.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
