### PR TITLE
[Headless CLI bundling gap](2) Dedupe noExternal and guard packages/app's build against the same gap recurring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,6 +400,7 @@ jobs:
               bash scripts/test-suites/required/06-large-file-guardrail.sh
               bash scripts/test-suites/required/07-invalid-config-json.sh
               bash scripts/test-suites/required/08-build-artifact-surfaces-guard.sh
+              bash scripts/test-suites/required/09-headless-cli-boots-smoke.sh
               bash scripts/test-suites/required/10-dag-background-click-noop-guard.sh
               bash scripts/test-suites/required/15-owner-boundary-policy.sh
               bash scripts/test-suites/required/50-verify-executor-routing.sh

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -58,7 +58,7 @@
     }
   },
   "scripts": {
-    "build": "node scripts/verify-workspace-imports.cjs && tsup",
+    "build": "node scripts/verify-workspace-imports.cjs && node scripts/verify-noexternal-completeness.cjs && tsup",
     "dist": "electron-builder --publish never",
     "dist:linux": "electron-builder --linux AppImage deb --publish never",
     "dist:mac": "electron-builder --mac dmg --publish never",

--- a/packages/app/scripts/verify-noexternal-completeness.cjs
+++ b/packages/app/scripts/verify-noexternal-completeness.cjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+//
+// Guardrail: every @invoker/* runtime dependency of packages/app whose
+// package.json main/exports points at raw, unbuilt TypeScript source must
+// either be bundled via tsup.config.ts's noExternal (exactly once), or be
+// explicitly listed in KNOWN_SAFE_EXTERNAL below with a reason.
+//
+// Regression (2026-08-13): @invoker/slack-bug-scan has main: "src/index.ts"
+// (never compiled to a dist). Left external, at runtime Node's ESM loader
+// tries to resolve that raw .ts file's own relative imports directly and
+// crashes packages/app/dist/main.js on load -- silently, since Electron's
+// headless entrypoint never exits after the crash, it just hangs until an
+// external caller's timeout kills it. See scripts/test-suites/required/
+// 09-headless-cli-boots-smoke.sh for the functional repro of that crash.
+//
+// This package was independently added to and removed from noExternal
+// across three separate automated CI-regression fixes (#8986, #8989, #9002)
+// before anyone noticed, because none of them checked for an existing entry
+// or a build-time invariant -- the array ended up with a duplicate. This
+// check exists so the next such fix has one place to check first, instead
+// of another blind text edit.
+
+const { readFileSync, existsSync } = require('node:fs');
+const { join } = require('node:path');
+
+const packageRoot = join(__dirname, '..');
+
+// Packages intentionally left external with a documented reason. Adding an
+// entry here is a deliberate decision, not a silent gap -- keep it short and
+// specific.
+const KNOWN_SAFE_EXTERNAL = {
+  '@invoker/cli': 'never imported into the bundle; spawned as a separate subprocess via packages/app/src/cli-helper.ts, pointing at its own independently-built dist',
+  '@invoker/surfaces': 'has a real compiled dist (main: dist/index.js); packaged separately into app-build-dist.tgz, see scripts/test-suites/required/08-build-artifact-surfaces-guard.sh',
+};
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf-8'));
+}
+
+const appPackageJson = readJson(join(packageRoot, 'package.json'));
+const dependencies = Object.keys(appPackageJson.dependencies ?? {}).filter((name) => name.startsWith('@invoker/'));
+
+const tsupConfigSource = readFileSync(join(packageRoot, 'tsup.config.ts'), 'utf-8');
+const noExternalMatch = tsupConfigSource.match(/noExternal:\s*\[([\s\S]*?)\]/);
+if (!noExternalMatch) {
+  console.error('FAIL: could not find a noExternal: [...] array in packages/app/tsup.config.ts');
+  process.exit(1);
+}
+const noExternalEntries = [...noExternalMatch[1].matchAll(/['"]([^'"]+)['"]/g)].map((m) => m[1]);
+const noExternal = new Set(noExternalEntries);
+
+const failures = [];
+
+const entryCounts = new Map();
+for (const entry of noExternalEntries) {
+  entryCounts.set(entry, (entryCounts.get(entry) ?? 0) + 1);
+}
+for (const [entry, count] of entryCounts) {
+  if (count > 1) {
+    failures.push(
+      `${entry}: listed ${count} times in packages/app/tsup.config.ts's noExternal array. Harmless to `
+      + `tsup itself, but a duplicate entry is a sign two separate fixes both added it without checking `
+      + `for an existing one -- remove the repeat.`,
+    );
+  }
+}
+
+for (const name of dependencies) {
+  const pkgJsonPath = join(packageRoot, 'node_modules', name, 'package.json');
+  if (!existsSync(pkgJsonPath)) {
+    failures.push(`${name}: no packages/app/node_modules/${name}/package.json (run pnpm install?)`);
+    continue;
+  }
+
+  const depPackageJson = readJson(pkgJsonPath);
+  const mainEntry = depPackageJson.main ?? '';
+  const isRawTypeScript = /\.tsx?$/.test(mainEntry) && !mainEntry.startsWith('dist/');
+
+  if (!isRawTypeScript) {
+    continue; // has a real compiled entry point; safe to leave external either way
+  }
+
+  if (noExternal.has(name)) {
+    continue; // bundled; safe
+  }
+
+  if (name in KNOWN_SAFE_EXTERNAL) {
+    continue; // deliberate, documented exception
+  }
+
+  failures.push(
+    `${name}: main is unbuilt TypeScript source ("${mainEntry}") but the package is neither in `
+    + `packages/app/tsup.config.ts's noExternal nor in KNOWN_SAFE_EXTERNAL in this script. Left as-is, `
+    + `it will crash packages/app/dist/main.js at runtime the moment any code path touches it -- add it `
+    + `to noExternal (bundle it), or to KNOWN_SAFE_EXTERNAL with a reason if it's genuinely never `
+    + `imported into the bundle (e.g. spawned as a subprocess like @invoker/cli).`,
+  );
+}
+
+if (failures.length > 0) {
+  console.error('FAIL: packages/app has @invoker/* dependencies unsafe to leave external:\n');
+  for (const failure of failures) {
+    console.error(`  - ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(`PASS: all ${dependencies.length} @invoker/* dependencies of packages/app are either bundled, compiled, or a documented exception`);

--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -20,7 +20,6 @@ export default defineConfig({
     '@invoker/transport',
     '@invoker/execution-engine',
     '@invoker/planning-core',
-    '@invoker/slack-bug-scan',
     '@invoker/shell',
     '@invoker/slack-bug-scan',
     'yaml',

--- a/scripts/test-suites/required/09-headless-cli-boots-smoke.sh
+++ b/scripts/test-suites/required/09-headless-cli-boots-smoke.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Guardrail: packages/app/dist/main.js must actually boot and answer a
+# headless query, not just build without a tsc/tsup error.
+#
+# Regression (2026-08-13): @invoker/slack-bug-scan was left out of
+# packages/app/tsup.config.ts's noExternal list. Its package.json points
+# main/exports straight at raw src/index.ts (never compiled to dist), so
+# leaving it external meant Node tried to resolve that TypeScript file's own
+# relative imports (e.g. "./contract.js") against the filesystem at runtime
+# and failed with ERR_MODULE_NOT_FOUND the moment any code path touched the
+# slack-bug-scan worker. The crash happened during Electron's app "ready"
+# load phase as an uncaught main-process exception, so the process never
+# exited -- every `scripts/headless-lib.sh` caller (every cron worker,
+# including e2e-autofix's ci-regression-watch sweep) hung until its own
+# external timeout killed it, and every check it was mid-way through was
+# silently treated as "assume non-terminal work exists, skip filing". A
+# production droplet ran for an unknown period filing zero CI-regression
+# repair PRs with no visible error anywhere in that path.
+#
+# This is a functional check, not a config-text grep: it actually runs the
+# built CLI end to end, so it also covers any other workspace dependency
+# left external by mistake in the future, not just this one package.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+MAIN="$ROOT/packages/app/dist/main.js"
+if [[ ! -f "$MAIN" ]]; then
+  echo "FAIL: $MAIN does not exist -- build @invoker/app before running this check" >&2
+  exit 1
+fi
+
+ELECTRON="$ROOT/scripts/electron.cjs"
+SANDBOX_FLAG=""
+if [ "$(uname)" = "Linux" ]; then
+  SANDBOX_BIN="$ROOT/node_modules/.pnpm/electron@*/node_modules/electron/dist/chrome-sandbox"
+  # shellcheck disable=SC2086
+  if ! stat -c '%U:%a' $SANDBOX_BIN 2>/dev/null | grep -q '^root:4755$'; then
+    SANDBOX_FLAG="--no-sandbox"
+  fi
+  export LIBGL_ALWAYS_SOFTWARE=1
+fi
+
+OUT="$(mktemp)"
+ERR="$(mktemp)"
+trap 'rm -f "$OUT" "$ERR"' EXIT
+
+STATUS=0
+# shellcheck disable=SC2086
+timeout 30 "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless query workflows --output json >"$OUT" 2>"$ERR" || STATUS=$?
+
+if [[ "$STATUS" -eq 124 ]]; then
+  echo "FAIL: headless CLI hung for 30s and was killed. This is the exact symptom of a" >&2
+  echo "workspace dependency left external in packages/app/tsup.config.ts's noExternal" >&2
+  echo "whose package.json main/exports points at unbuilt raw .ts source -- Node's ESM" >&2
+  echo "loader crashes the Electron main process during load, and the crashed process" >&2
+  echo "never exits on its own." >&2
+  echo "-- stderr --" >&2
+  cat "$ERR" >&2
+  exit 1
+fi
+
+if [[ "$STATUS" -ne 0 ]]; then
+  echo "FAIL: headless CLI exited $STATUS" >&2
+  echo "-- stderr --" >&2
+  cat "$ERR" >&2
+  exit 1
+fi
+
+if ! python3 -c "import json,sys; json.load(open('$OUT'))" 2>/dev/null; then
+  echo "FAIL: headless CLI exited 0 but did not print valid JSON" >&2
+  echo "-- stdout --" >&2
+  cat "$OUT" >&2
+  echo "-- stderr --" >&2
+  cat "$ERR" >&2
+  exit 1
+fi
+
+echo "PASS: packages/app/dist/main.js boots and answers a headless query"


### PR DESCRIPTION
## Summary

One workspace package's name appeared twice in the bundler's noExternal entries.

Three separate automated fixes had independently added and taken out that same entry.

None of them checked for an existing entry first, so the array ended up with a repeat.

The repeat is harmless to the bundler itself, just a sign of an unenforced invariant.

This PR collapses the repeat into one entry and adds a build-time check enforcing that invariant going forward.

The check fails the build if a bundled-source dependency is left out, or appears more than once.

Two dependencies are already known-safe to leave out and are recorded as explicit, reasoned exceptions.

## Review Claim

Approve collapsing the repeated entry into one and adding a build-time guard so the next omission or repeat fails the build instead of shipping silently.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The array edit removes an inert duplicate string with no effect on what gets bundled; the new guard only runs at build time and cannot change what a successful build produces.

## Slice Rationale

The repeated entry and its guard are one claim: the guard is what makes the repeat provably a one-time fix rather than a recurring pattern.

## Non-goals

Does not change which packages are bundled versus left out; every currently-bundled dependency stays bundled.

Does not change `@invoker/cli`'s subprocess-spawn design or `@invoker/surfaces`'s separate packaging; both are recorded as deliberate, already-correct exceptions.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `node packages/app/scripts/verify-noexternal-completeness.cjs`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/workspace-import-resolution.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
