### PR TITLE
[CI regression: 8365ed9-playwright-2-of-9](1) Remove repeated Slack worker external

### DIFF
--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -22,7 +22,6 @@ export default defineConfig({
     '@invoker/planning-core',
     '@invoker/slack-bug-scan',
     '@invoker/shell',
-    '@invoker/slack-bug-scan',
     'yaml',
   ],
   clean: true,


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / 2-of-9 -->

CI job `playwright / 2-of-9` first failed on default-branch push commit 8365ed93997c669fc85eb85b4d56353378310e03 in run 31574441095.

It was most recently still red at e73ee552a6e174a85fc6107186bb802b32ec4b6e in run 31629955741.

The app tsup configuration contains the same Slack worker package twice in its external array.

This slice deletes the second identical entry while preserving the package boundary.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31574441095/job/94043888934

## Review Claim

Approve deleting the second identical Slack worker package entry from the app tsup external array.

## Review Lane

cleanup

## Review Unit

cleanup

## Safety Invariant

The external package set stays unchanged, so other CI jobs and product behavior remain unchanged.

## Slice Rationale

One cleanup slice isolates the repeated configuration entry from the shard assignment work already landed on master.

## Non-goals

- No CI workflow or Playwright spec changes.
- No Slack worker behavior or application call-site changes.
- No dependency upgrades, refactors, or test weakening.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [x] `node scripts/repro/repro-ci-playwright-shard-inventory.mjs` — `[repro-ci-playwright-shard-inventory] OK: 68 CI-owned spec files each assigned to exactly one shard; 2 manual-only spec accounted for.`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-2-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/claude-planning-preset-visual-proof.spec.ts e2e/planning-presets-load-failure.spec.ts e2e/action-graph-visual-proof.spec.ts e2e/invalid-merge-workspace-visual.spec.ts e2e/invalid-task-workspace-visual.spec.ts e2e/persistence-lifecycle.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`
- The full command completed all three builds, then stopped before Playwright because `xvfb-run` is unavailable on this host (exit 254).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <PR merge commit>`
- Post-revert steps: Rebuild `@invoker/app` before rerunning the Playwright shard.
- Data migration? No

</details>
