### PR TITLE
[CI regression: 8365ed9-playwright-4-of-9](1) Deduplicate Slack bug scan external

### DIFF
--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -22,7 +22,6 @@ export default defineConfig({
     '@invoker/planning-core',
     '@invoker/slack-bug-scan',
     '@invoker/shell',
-    '@invoker/slack-bug-scan',
     'yaml',
   ],
   clean: true,


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / 4-of-9 -->

Keep one entry for the already externalized package after related CI work introduced the same entry twice.

The remaining entry keeps the package externalized with unchanged bundling behavior.

## Review Claim

Keep exactly one external entry for the package, with Electron bundling behavior unchanged.

## Review Lane

cleanup

## Review Unit

cleanup

## Safety Invariant

Other CI jobs and product behavior stay unchanged; the one remaining entry preserves package externalization.

## Slice Rationale

This is the only surviving branch change against current `master`. Already-landed CI and build changes are not republished.

## Non-goals

- No Playwright shard assignments change.
- No runtime dependency or application behavior changes.
- No other bundler settings change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-4-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/startup-window-liveness.spec.ts e2e/workflow-lifecycle.spec.ts e2e/base-branch-normalization.proof.spec.ts e2e/edit-task-prompt.spec.ts e2e/fix-with-claude.spec.ts e2e/fix-with-agent-transition.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — local rerun reached Playwright setup, then exited 254 because `xvfb-run` is unavailable.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2f96bb9a7`
- Post-revert steps: None
- Data migration? No

</details>
