### PR TITLE
[CI regression: 631a0d0-quality-typescript-types](1) Route TypeScript Types to GitHub-hosted capacity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,7 @@ jobs:
 
   typescript-types:
     name: quality / TypeScript Types
-    runs-on:
-      labels: Runner_2_4_core
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -57,6 +57,12 @@ assert(
 assert(jobs['quality-extra'], 'Missing quality-extra job');
 assert(jobs['quality-extra'].if === ORDINARY_PR_GATE, 'quality-extra must run on ordinary PRs and skip merge queue refs');
 
+assert(jobs['typescript-types'], 'Missing typescript-types job');
+assert(
+  jobs['typescript-types']['runs-on'] === 'ubuntu-latest',
+  'TypeScript Types must use GitHub-hosted capacity so self-hosted workspace pressure cannot fail before tsc runs',
+);
+
 assert(jobs['required-package-builds'], 'Missing required-package-builds job');
 assert(
   jobs['required-package-builds'].if === ORDINARY_PR_GATE,


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=quality / TypeScript Types -->

CI job `quality / TypeScript Types` first failed on default-branch push `631a0d08c7072e9544813fc1b93fb616586ce441` in run `31620499765`.

It was most recently still red at `e73ee552a6e174a85fc6107186bb802b32ec4b6e` in run `31629955741`.

This slice assigns the job to GitHub-hosted capacity instead of the shared core runner.

The matching CI policy assertion requires `ubuntu-latest` for this job.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94225435567

## Review Claim

Approve assigning TypeScript Types to GitHub-hosted capacity and guarding that CI policy.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged; only the TypeScript Types runner selection and its matching policy assertion change.

## Slice Rationale

The runner selection and its policy assertion form one reviewable CI policy slice.

The empty verification task is not published as a separate review slice.

## Non-goals

- No application runtime behavior changes.
- No changes to other CI jobs.
- No relaxation of the type-check command or compiler settings.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ea3a5f5517c4d5d8e54e2372a0031bd15ee33cbc`
- Post-revert steps: Re-run the CI policy test and TypeScript type check.
- Data migration? No

</details>
