### PR TITLE
[Jailbreak admin-bypass land (3) worker registration](1) Add cron wrapper

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts
@@ -15,6 +15,7 @@ const PR_MAINTENANCE_ENTRYPOINTS = [
   { kind: 'pr-admin-bypass-land', scriptRelativePath: 'scripts/cron-pr-admin-bypass-land.sh' },
   { kind: 'pr-orphan-repair', scriptRelativePath: 'scripts/cron-pr-orphan-repair.sh' },
   { kind: 'pr-duplicate-close', scriptRelativePath: 'scripts/cron-pr-duplicate-close.sh' },
+  { kind: 'pr-jailbreak-land', scriptRelativePath: 'scripts/cron-pr-jailbreak-land.sh' },
 ] as const;
 
 describe('PR maintenance entrypoints bootstrap', () => {

--- a/scripts/cron-pr-jailbreak-land.sh
+++ b/scripts/cron-pr-jailbreak-land.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=scripts/cron-pr-lib.sh
+source "$(dirname "$0")/cron-pr-lib.sh"
+
+cron_lock
+
+(
+  cd "$REPO_ROOT"
+  node scripts/jailbreak-admin-bypass-land.mjs
+)


### PR DESCRIPTION
## Summary

Adds a cron wrapper for the guarded jailbreak landing tool already on `master`.

The wrapper shares the existing PR-maintenance lock before invoking the force-merge script.

Nothing registers or schedules the wrapper in this slice.

## Review Claim

Approve the locked cron wrapper as the tooling boundary for invoking the existing jailbreak landing script.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The wrapper acquires the shared lock before invocation at `scripts/cron-pr-jailbreak-land.sh:7-11`.

This slice has no registry change, so the new wrapper has no runtime caller when it lands alone.

## Slice Rationale

These files form one validator-enforced tooling unit. Worker registration follows in a separate stack slice.

## Non-goals

- Does not register or schedule a worker.
- Does not change the force-merge script.
- Does not change any auto-start configuration.
- Does not modify Mergify configuration.

## Architecture

### Before

```mermaid
graph LR
    A["Existing guarded force-merge script"]
```

### After

```mermaid
graph LR
    A["Cron wrapper"] --> B["Shared PR-maintenance lock"]
    B --> C["Existing guarded force-merge script"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash -n scripts/cron-pr-jailbreak-land.sh`
  - Output: `bash -n scripts/cron-pr-jailbreak-land.sh: exit 0`
- [x] `(cd packages/execution-engine && pnpm vitest run src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts)`
  - Output: `Test Files  1 passed (1)`
  - Output: `Tests  7 passed (7)`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-PR-sha>`
- Post-revert steps: None
- Data migration? No

</details>
