### PR TITLE
[Jailbreak admin-bypass land (3) worker registration](2) Register manual-only worker

### DIFF
--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -10,6 +10,7 @@ import {
   E2E_AUTOFIX_WORKER_KIND,
   createWorkerRegistry,
   INFRA_REPAIR_WORKER_KIND,
+  PR_JAILBREAK_LAND_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
   REAPER_WORKER_KIND,
   REQUEUE_WORKER_KIND,
@@ -98,6 +99,33 @@ function deps(): WorkerRuntimeDependencies {
 }
 
 type AutoStartConfig = Parameters<typeof autoStartedOwnerWorkerKindsForConfig>[0];
+type AutoStartOptions = Parameters<typeof autoStartedOwnerWorkerKinds>[0];
+
+const AUTO_STARTED_OWNER_WORKER_KIND_CONFIG_CASES = [
+  {},
+  { diskHeadroom: { cleanupEnabled: true } },
+  { diskHeadroom: { cleanupEnabled: false } },
+  { autoApproveAIFixes: true },
+  { autoApproveAIFixes: false },
+  { infraRepair: { enabled: true } },
+  { infraRepair: { enabled: false } },
+  { autofix: { enabled: true } },
+  { autofix: { enabled: false } },
+  { reaper: { enabled: true } },
+  { reaper: { enabled: false } },
+  { workflowResume: { enabled: true } },
+  { workflowResume: { enabled: false } },
+  { requeueEnabled: true },
+  { requeueEnabled: false },
+  { e2eAutoFixEnabled: true },
+  { e2eAutoFixEnabled: false },
+  { prMaintenance: { enabled: true } },
+] satisfies AutoStartConfig[];
+
+const AUTO_STARTED_OWNER_WORKER_KIND_OPTION_CASES = [
+  { prMaintenanceEnabled: true },
+  { prMaintenanceEnabled: false },
+] satisfies AutoStartOptions[];
 
 function expectConfigGate(
   workerKind: string,
@@ -138,6 +166,7 @@ function controller(
   register(PR_ADMIN_BYPASS_LAND_WORKER_KIND, 'Lands eligible PRs via admin bypass.');
   register(PR_ORPHAN_REPAIR_WORKER_KIND, 'Repairs unmapped broken pull requests.');
   register(PR_DUPLICATE_CLOSE_WORKER_KIND, 'Closes duplicate or already-landed pull requests.');
+  register(PR_JAILBREAK_LAND_WORKER_KIND, 'Force-merges eligible jailbreak PRs via admin bypass.');
   register(PR_AUTO_LABEL_WORKER_KIND, 'Auto-labels refactor/bugfix/repro/test-only PRs with admin-bypass.');
   register(WORKFLOW_RESUME_WORKER_KIND, 'Resumes incomplete workflows.');
   register(REAPER_WORKER_KIND, 'Reaps stale Invoker-managed artifacts.');
@@ -236,6 +265,15 @@ describe('autoStartedOwnerWorkerKindsForConfig', () => {
       PR_DUPLICATE_CLOSE_WORKER_KIND,
       PR_AUTO_LABEL_WORKER_KIND,
     ]);
+  });
+
+  it('never auto-starts jailbreak-land for the existing flag cases', () => {
+    for (const config of AUTO_STARTED_OWNER_WORKER_KIND_CONFIG_CASES) {
+      expect(autoStartedOwnerWorkerKindsForConfig(config)).not.toContain(PR_JAILBREAK_LAND_WORKER_KIND);
+    }
+    for (const options of AUTO_STARTED_OWNER_WORKER_KIND_OPTION_CASES) {
+      expect(autoStartedOwnerWorkerKinds(options)).not.toContain(PR_JAILBREAK_LAND_WORKER_KIND);
+    }
   });
 });
 

--- a/packages/execution-engine/src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-entrypoint-bootstrap.test.ts
@@ -15,6 +15,7 @@ const PR_MAINTENANCE_ENTRYPOINTS = [
   { kind: 'pr-admin-bypass-land', scriptRelativePath: 'scripts/cron-pr-admin-bypass-land.sh' },
   { kind: 'pr-orphan-repair', scriptRelativePath: 'scripts/cron-pr-orphan-repair.sh' },
   { kind: 'pr-duplicate-close', scriptRelativePath: 'scripts/cron-pr-duplicate-close.sh' },
+  { kind: 'pr-jailbreak-land', scriptRelativePath: 'scripts/cron-pr-jailbreak-land.sh' },
 ] as const;
 
 describe('PR maintenance entrypoints bootstrap', () => {

--- a/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
@@ -12,11 +12,14 @@ import type { Logger } from '@invoker/contracts';
 import type { WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store';
 
 import { SIGKILL_TIMEOUT_MS } from '../process-utils.js';
+import { createWorkerRegistry } from '../worker-registry.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import {
   DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS,
   PR_ADMIN_BYPASS_LAND_WORKER_KIND,
   PR_AUTO_LABEL_WORKER_KIND,
   PR_DUPLICATE_CLOSE_WORKER_KIND,
+  PR_JAILBREAK_LAND_WORKER_KIND,
   PR_MAINTENANCE_WORKER_STAGGER_STEP_MS,
   PR_ORPHAN_REPAIR_WORKER_KIND,
   buildPrMaintenanceEnv,
@@ -24,6 +27,7 @@ import {
   createPrAutoLabelWorker,
   createPrDuplicateCloseWorker,
   createPrOrphanRepairWorker,
+  registerPrMaintenanceWorkers,
   type PrMaintenanceLockProbeOptions,
 } from '../workers/pr-maintenance-workers.js';
 
@@ -261,6 +265,35 @@ describe('PR maintenance workers', () => {
     expect(spawnHarness.calls[0]).toEqual(expect.objectContaining({
       command: 'bash',
       args: [resolve(repoRoot, 'scripts/cron-pr-auto-label.sh')],
+      options: expect.objectContaining({ cwd: repoRoot }),
+    }));
+  });
+
+  it('registers the jailbreak-land worker with its shell entrypoint', async () => {
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness();
+    const registry = registerPrMaintenanceWorkers(createWorkerRegistry<WorkerRuntimeDependencies>());
+    const definition = registry.get(PR_JAILBREAK_LAND_WORKER_KIND);
+
+    expect(definition?.kind).toBe(PR_JAILBREAK_LAND_WORKER_KIND);
+
+    const worker = definition!.factory({
+      logger,
+      store: {} as WorkerRuntimeDependencies['store'],
+      submitter: { submit: vi.fn(() => 0) } as WorkerRuntimeDependencies['submitter'],
+      prMaintenance: {
+        repoRoot,
+        spawnProcess: spawnHarness.spawnProcess,
+        lockProbe: () => ({ held: false }),
+      },
+    } as WorkerRuntimeDependencies);
+
+    await worker.tick();
+
+    expect(spawnHarness.calls[0]).toEqual(expect.objectContaining({
+      command: 'bash',
+      args: [resolve(repoRoot, 'scripts/cron-pr-jailbreak-land.sh')],
       options: expect.objectContaining({ cwd: repoRoot }),
     }));
   });

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -15,6 +15,7 @@ import {
   PR_ADMIN_BYPASS_LAND_WORKER_KIND,
   PR_AUTO_LABEL_WORKER_KIND,
   PR_DUPLICATE_CLOSE_WORKER_KIND,
+  PR_JAILBREAK_LAND_WORKER_KIND,
   PR_ORPHAN_REPAIR_WORKER_KIND,
 } from '../workers/pr-maintenance-workers.js';
 import { PR_STATUS_WORKER_KIND } from '../workers/pr-status-worker.js';
@@ -82,6 +83,7 @@ describe('worker registry', () => {
       PR_ADMIN_BYPASS_LAND_WORKER_KIND,
       PR_ORPHAN_REPAIR_WORKER_KIND,
       PR_DUPLICATE_CLOSE_WORKER_KIND,
+      PR_JAILBREAK_LAND_WORKER_KIND,
       PR_AUTO_LABEL_WORKER_KIND,
       E2E_AUTOFIX_WORKER_KIND,
       SLACK_BUG_SCAN_WORKER_KIND,
@@ -96,6 +98,8 @@ describe('worker registry', () => {
     expect(registry.get(AUTO_APPROVE_WORKER_KIND)).toBeDefined();
     expect(registry.get(PR_ADMIN_BYPASS_LAND_WORKER_KIND)).toBeDefined();
     expect(registry.get(PR_ORPHAN_REPAIR_WORKER_KIND)).toBeDefined();
+    expect(registry.get(PR_DUPLICATE_CLOSE_WORKER_KIND)).toBeDefined();
+    expect(registry.get(PR_JAILBREAK_LAND_WORKER_KIND)).toBeDefined();
     expect(registry.get(PR_AUTO_LABEL_WORKER_KIND)).toBeDefined();
     expect(registry.get(E2E_AUTOFIX_WORKER_KIND)).toBeDefined();
     expect(registry.get(SLACK_BUG_SCAN_WORKER_KIND)).toBeDefined();
@@ -128,6 +132,8 @@ describe('worker registry', () => {
       .toBe(PR_ORPHAN_REPAIR_WORKER_KIND);
     expect(registry.get(PR_DUPLICATE_CLOSE_WORKER_KIND)?.factory(deps()).identity.kind)
       .toBe(PR_DUPLICATE_CLOSE_WORKER_KIND);
+    expect(registry.get(PR_JAILBREAK_LAND_WORKER_KIND)?.factory(deps()).identity.kind)
+      .toBe(PR_JAILBREAK_LAND_WORKER_KIND);
     expect(registry.get(PR_AUTO_LABEL_WORKER_KIND)?.factory(deps()).identity.kind)
       .toBe(PR_AUTO_LABEL_WORKER_KIND);
   });

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -17,6 +17,7 @@ import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../wor
 export const PR_ADMIN_BYPASS_LAND_WORKER_KIND = 'pr-admin-bypass-land';
 export const PR_ORPHAN_REPAIR_WORKER_KIND = 'pr-orphan-repair';
 export const PR_DUPLICATE_CLOSE_WORKER_KIND = 'pr-duplicate-close';
+export const PR_JAILBREAK_LAND_WORKER_KIND = 'pr-jailbreak-land';
 export const PR_AUTO_LABEL_WORKER_KIND = 'pr-auto-label';
 export const DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS = 5 * 60_000;
 const DEFAULT_MERGIFY_ADMIN_REQUEUE_LEDGER_RELATIVE_PATH = '.invoker/mergify-admin-requeue-state.jsonl';
@@ -42,6 +43,7 @@ export type PrMaintenanceWorkerKind =
   | typeof PR_ADMIN_BYPASS_LAND_WORKER_KIND
   | typeof PR_ORPHAN_REPAIR_WORKER_KIND
   | typeof PR_DUPLICATE_CLOSE_WORKER_KIND
+  | typeof PR_JAILBREAK_LAND_WORKER_KIND
   | typeof PR_AUTO_LABEL_WORKER_KIND;
 
 type EnvOverrides = Record<string, string | undefined>;
@@ -66,6 +68,11 @@ const PR_DUPLICATE_CLOSE_ENTRYPOINT: PrMaintenanceEntrypoint = {
   kind: PR_DUPLICATE_CLOSE_WORKER_KIND,
   scriptRelativePath: 'scripts/cron-pr-duplicate-close.sh',
   note: 'Closes open PRs already landed on master or duplicating another open PR, via one Invoker close task per PR.',
+};
+const PR_JAILBREAK_LAND_ENTRYPOINT: PrMaintenanceEntrypoint = {
+  kind: PR_JAILBREAK_LAND_WORKER_KIND,
+  scriptRelativePath: 'scripts/cron-pr-jailbreak-land.sh',
+  note: 'Force-merges eligible jailbreak PRs via the admin-bypass land script under manual worker scheduling.',
 };
 const PR_AUTO_LABEL_ENTRYPOINT: PrMaintenanceEntrypoint = {
   kind: PR_AUTO_LABEL_WORKER_KIND,
@@ -139,6 +146,7 @@ export function registerPrMaintenanceWorkers(
   registerPrAdminBypassLandWorker(registry);
   registerPrOrphanRepairWorker(registry);
   registerPrDuplicateCloseWorker(registry);
+  registerPrJailbreakLandWorker(registry);
   registerPrAutoLabelWorker(registry);
   return registry;
 }
@@ -194,6 +202,23 @@ export function registerPrDuplicateCloseWorker(
   return registry;
 }
 
+export function registerPrJailbreakLandWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: PR_JAILBREAK_LAND_WORKER_KIND,
+    note: PR_JAILBREAK_LAND_ENTRYPOINT.note,
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createPrJailbreakLandWorker({
+        logger: deps.logger,
+        ...deps.prMaintenance,
+        store: deps.store,
+        startDelayMs: 3 * PR_MAINTENANCE_WORKER_STAGGER_STEP_MS,
+      }),
+  });
+  return registry;
+}
+
 export function registerPrAutoLabelWorker(
   registry: WorkerRegistry<WorkerRuntimeDependencies>,
 ): WorkerRegistry<WorkerRuntimeDependencies> {
@@ -221,6 +246,10 @@ export function createPrOrphanRepairWorker(options: PrMaintenanceWorkerOptions):
 
 export function createPrDuplicateCloseWorker(options: PrMaintenanceWorkerOptions): WorkerRuntime {
   return createPrMaintenanceWorker(PR_DUPLICATE_CLOSE_ENTRYPOINT, options);
+}
+
+export function createPrJailbreakLandWorker(options: PrMaintenanceWorkerOptions): WorkerRuntime {
+  return createPrMaintenanceWorker(PR_JAILBREAK_LAND_ENTRYPOINT, options);
 }
 
 export function createPrAutoLabelWorker(options: PrMaintenanceWorkerOptions): WorkerRuntime {

--- a/scripts/cron-pr-jailbreak-land.sh
+++ b/scripts/cron-pr-jailbreak-land.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck source=scripts/cron-pr-lib.sh
+source "$(dirname "$0")/cron-pr-lib.sh"
+
+cron_lock
+
+(
+  cd "$REPO_ROOT"
+  node scripts/jailbreak-admin-bypass-land.mjs
+)


### PR DESCRIPTION
## Summary

Registers `pr-jailbreak-land` with the existing PR-maintenance worker family and assigns it a distinct stagger slot.

The registry can construct the worker, while every existing auto-start configuration continues to omit it.

A human must start the worker explicitly. Real merges still require the script's separate `INVOKER_JAILBREAK_LIVE=1` gate.

## Review Claim

Approve registry wiring for `pr-jailbreak-land` with a regression test proving every existing auto-start configuration omits it.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Registration is added only to the existing registry aggregate at `packages/execution-engine/src/workers/pr-maintenance-workers.ts:143-150`.

The worker receives its own stagger at `packages/execution-engine/src/workers/pr-maintenance-workers.ts:205-217`.

The auto-start regression checks every existing flag case at `packages/app/src/__tests__/worker-control.test.ts:270-276`; production auto-start arrays are unchanged.

## Slice Rationale

This slice contains the runtime registry route and its directly affected tests. The tooling-policy wrapper is the preceding stack slice.

## Non-goals

- Does not change the force-merge script's behavior or live-mode gate.
- Does not add the worker to any auto-start array.
- Does not change existing workers' intervals or behavior.
- Does not add a separate registration call site.

## Architecture

### Before

```mermaid
graph LR
    A["Worker registry"] -.-> B["No jailbreak worker kind"]
```

### After

```mermaid
graph LR
    A["Worker registry"] --> B["pr-jailbreak-land runtime"]
    B --> C["Locked cron wrapper"]
    C --> D["Guarded force-merge script"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `(cd packages/execution-engine && INVOKER_MERGIFY_ADMIN_REQUEUE_STATE_FILE=/tmp/invoker-pr-jailbreak-empty-ledger.jsonl pnpm vitest run src/__tests__/pr-maintenance-workers.test.ts src/__tests__/worker-registry.test.ts)`
  - Output: `Test Files  2 passed (2)`
  - Output: `Tests  23 passed (23)`
- [x] `(cd packages/app && pnpm vitest run src/__tests__/worker-control.test.ts)`
  - Output: `Test Files  1 passed (1)`
  - Output: `Tests  29 passed (29)`
- [ ] `(cd packages/execution-engine && pnpm test)`
  - Output: `Test Files  1 failed | 122 passed (123)`
  - The live default Mergify ledger added 162 decision rows to an existing environment-dependent assertion; the isolated run above pins an empty ledger.
- [ ] `(cd packages/app && pnpm test)`
  - Output: `Test Files  3 failed | 198 passed (201)`
  - Six base-branch failures remain outside this slice: five planning-chat prompt assertions and one missing built workspace dependency.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-PR-sha>`
- Post-revert steps: None; the preceding wrapper becomes inert again.
- Data migration? No

</details>
