### PR TITLE
[CI regression: a5d6b3e-playwright-launch-dispatch-stuck-lease](1) Prove legacy and retired job classification

### DIFF
--- a/scripts/repro/repro-e2e-regression-watch.mjs
+++ b/scripts/repro/repro-e2e-regression-watch.mjs
@@ -410,10 +410,14 @@ function testFleetCorrelationScenario() {
 }
 
 function testRetiredJobScenario() {
-  const retiredKey = 'playwright / launch-dispatch-stuck-lease';
+  const retiredKey = 'playwright / retired-example';
   const defs = buildCiJobDefinitions();
   if (jobNameIsMapped(retiredKey, defs)) {
     fail(`${retiredKey} should be absent from current ci.yml`);
+  }
+  const legacyStuckLeaseKey = 'playwright / launch-dispatch-stuck-lease';
+  if (!jobNameIsMapped(legacyStuckLeaseKey, defs)) {
+    fail(`${legacyStuckLeaseKey} should stay mapped to its focused local verifier`);
   }
 
   const state = stateWithFailure(fakeFailure({


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a5d6b3e626ace9e963e924c0de9410dc0302de9e; job=playwright / launch-dispatch-stuck-lease -->

The regression-watch repro distinguishes an unmapped retired job from the legacy stuck-lease job, which still has a focused local verifier.

The watched job first failed in run 30983254556 and was still red in run 31060913416.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30983254556/job/92238737773

## Review Claim

Approve deterministic proof that retired jobs remain distinguishable from the mapped legacy stuck-lease job.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Product behavior stays unchanged; this slice only strengthens assertions in the existing regression-watch repro.

## Slice Rationale

This proof slice precedes the policy-test update so each PR contains one review unit.

## Non-goals

- No watcher policy changes.
- No workflow matrix changes.
- No Playwright or product behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/repro/repro-e2e-regression-watch.mjs`
  - Result: `[repro-e2e-regression-watch] all checks passed`; exit 0.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert d7eeac94e35a45c391026760fbe493a85f915fc1`
- Post-revert steps: None.
- Data migration? No.

</details>
