### PR TITLE
[CI regression: a5d6b3e-playwright-launch-dispatch-stuck-lease](2) Backtest the legacy stuck-lease filing state

### DIFF
--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -447,7 +447,7 @@ describe('attempt ledger filing gate', () => {
 
 describe('retired CI job filing gate', () => {
   it('skips an unmapped job, marks it retired, counts it, and never files', () => {
-    const key = 'playwright / launch-dispatch-stuck-lease';
+    const key = 'playwright / retired-example';
     const state = stateWithFailure(makeFailure({ jobName: key }));
     const jobDefinitions = new Map([
       ['playwright / 9-of-9', { verifyCommand: 'bash scripts/test-suites/optional/40-playwright-app.sh' }],
@@ -489,7 +489,7 @@ describe('retired CI job filing gate', () => {
   });
 
   it('fileBugfixPlan throws before rendering for an unmapped job', () => {
-    const failure = makeFailure({ jobName: 'playwright / launch-dispatch-stuck-lease' });
+    const failure = makeFailure({ jobName: 'playwright / retired-example' });
     const calls = [];
 
     assert.throws(
@@ -529,7 +529,7 @@ describe('retired CI job filing gate', () => {
     assert.equal(state.activeFailures[key].retired, false);
   });
 
-  it('backtests the real 2026-08-12 retired playwright key against current ci.yml', () => {
+  it('backtests the legacy 2026-08-12 stuck-lease playwright key against current ci.yml', () => {
     const key = 'playwright / launch-dispatch-stuck-lease';
     const state = stateWithFailure(makeFailure({
       jobName: key,
@@ -548,10 +548,12 @@ describe('retired CI job filing gate', () => {
       },
     });
 
-    assert.equal(jobNameIsMapped(key, jobDefinitions), false);
+    assert.equal(jobNameIsMapped(key, jobDefinitions), true);
     assert.equal(filed, 0);
-    assert.equal(counts.groupsRetired, 1);
+    assert.equal(counts.groupsRetired, 0);
     assert.equal(counts.groupsFiled, 0);
-    assert.equal(state.activeFailures[key].retired, true);
+    assert.equal(counts.groupsNeedingHuman, 1);
+    assert.equal(state.activeFailures[key].retired, false);
+    assert.equal(state.activeFailures[key].needsHuman, true);
   });
 });

--- a/scripts/repro/repro-e2e-regression-watch.mjs
+++ b/scripts/repro/repro-e2e-regression-watch.mjs
@@ -410,10 +410,14 @@ function testFleetCorrelationScenario() {
 }
 
 function testRetiredJobScenario() {
-  const retiredKey = 'playwright / launch-dispatch-stuck-lease';
+  const retiredKey = 'playwright / retired-example';
   const defs = buildCiJobDefinitions();
   if (jobNameIsMapped(retiredKey, defs)) {
     fail(`${retiredKey} should be absent from current ci.yml`);
+  }
+  const legacyStuckLeaseKey = 'playwright / launch-dispatch-stuck-lease';
+  if (!jobNameIsMapped(legacyStuckLeaseKey, defs)) {
+    fail(`${legacyStuckLeaseKey} should stay mapped to its focused local verifier`);
   }
 
   const state = stateWithFailure(fakeFailure({


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a5d6b3e626ace9e963e924c0de9410dc0302de9e; job=playwright / launch-dispatch-stuck-lease -->

The retired-job filing tests now use a genuinely unmapped example instead of the legacy stuck-lease job.

The historical stuck-lease case now expects the mapped job to remain active and reach human review after its filing cap.

The watched job first failed in run 30983254556 and was still red in run 31060913416.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30983254556/job/92238737773

## Review Claim

Approve the watcher policy test expectations for retired jobs and the mapped legacy stuck-lease job.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged; this slice only updates watcher-policy tests for existing job classification behavior.

## Slice Rationale

This policy-test slice follows the repro proof and stays separate from proof files.

## Non-goals

- No watcher implementation changes.
- No workflow matrix changes.
- No Playwright or product behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --test scripts/e2e-regression-watch.test.mjs`
  - Result: `tests 21`; `pass 21`; `fail 0`; exit 0.
- [x] `node scripts/repro/repro-e2e-regression-watch.mjs`
  - Result: `[repro-e2e-regression-watch] all checks passed`; exit 0.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert bd4562ab748b3a2a89440194ce7dafa5c0f6e8bf`
- Post-revert steps: None.
- Data migration? No.

</details>
