### PR TITLE
[Repair PR #9062](1) PR Body libatomic prerequisite

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -106,6 +106,38 @@ jobs:
         if: steps.targets.outputs.enabled == 'true'
         uses: pnpm/action-setup@v4
 
+      - name: Install Node.js runtime dependency
+        if: steps.targets.outputs.enabled == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ldconfig -p 2>/dev/null | grep -q 'libatomic\.so\.1'; then
+            exit 0
+          fi
+
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "::error::libatomic.so.1 is required for Node.js ${NODE_VERSION}, but apt-get is not available to install libatomic1."
+            exit 1
+          fi
+
+          apt_get=(apt-get)
+          if [[ "${EUID}" -ne 0 ]]; then
+            if ! sudo -n true 2>/dev/null; then
+              if ldconfig -p 2>/dev/null | grep -q 'libatomic\.so\.1'; then
+                exit 0
+              fi
+
+              echo "::error::libatomic.so.1 is required for Node.js ${NODE_VERSION}, but installing libatomic1 requires passwordless sudo on this runner."
+              exit 1
+            fi
+
+            apt_get=(sudo apt-get)
+          fi
+
+          "${apt_get[@]}" update
+          "${apt_get[@]}" install -y --no-install-recommends libatomic1
+
       - name: Use Node.js ${{ env.NODE_VERSION }}
         if: steps.targets.outputs.enabled == 'true'
         uses: actions/setup-node@v4

--- a/scripts/test-pr-body-rollout.mjs
+++ b/scripts/test-pr-body-rollout.mjs
@@ -35,6 +35,43 @@ assert.deepEqual(evaluateRollout({ author: 'EdbertChan', enforceAll: 'false', en
 });
 
 const prBodyWorkflow = readFileSync(new URL('../.github/workflows/pr-body.yml', import.meta.url), 'utf8');
+const installPnpmIndex = prBodyWorkflow.indexOf('uses: pnpm/action-setup@v4');
+const installLibatomicIndex = prBodyWorkflow.indexOf('- name: Install Node.js runtime dependency');
+const setupNodeIndex = prBodyWorkflow.indexOf('uses: actions/setup-node@v4');
+
+assert.notEqual(installPnpmIndex, -1, 'PR Body must install pnpm before Node setup');
+assert.notEqual(installLibatomicIndex, -1, 'PR Body must install Node 26 libatomic runtime dependency');
+assert.notEqual(setupNodeIndex, -1, 'PR Body must configure Node after pre-Node prerequisites');
+assert.ok(
+  installPnpmIndex < installLibatomicIndex && installLibatomicIndex < setupNodeIndex,
+  'PR Body must install libatomic1 after pnpm setup and before actions/setup-node can probe the pnpm cache',
+);
+
+const libatomicStep = prBodyWorkflow.slice(installLibatomicIndex, setupNodeIndex);
+assert.match(
+  libatomicStep,
+  /command -v apt-get/,
+  'PR Body must install libatomic1 through apt when apt is available',
+);
+assert.match(
+  libatomicStep,
+  /sudo -n true/,
+  'PR Body must probe for passwordless sudo noninteractively before using sudo',
+);
+assert.match(
+  libatomicStep,
+  /apt_get=\(sudo apt-get\)/,
+  'PR Body must only use sudo for apt after the noninteractive sudo probe',
+);
+assert.ok(
+  libatomicStep.indexOf('sudo -n true') < libatomicStep.indexOf('apt_get=(sudo apt-get)'),
+  'PR Body must not construct the sudo apt command before the noninteractive sudo probe succeeds',
+);
+assert.match(
+  libatomicStep,
+  /if ! sudo -n true[\s\S]*if ldconfig -p[\s\S]*grep -q 'libatomic\\\.so\\\.1'; then\s+exit 0[\s\S]*requires passwordless sudo/,
+  'PR Body must still pass without sudo when libatomic.so.1 is already present, and otherwise fail clearly',
+);
 assert.match(
   prBodyWorkflow,
   /NODE_VERSION:\s*'24'/,


### PR DESCRIPTION
## Summary

Add the trusted-base setup prerequisite that PR #9062 cannot add for itself.

The PR Body workflow now installs `libatomic1` before `actions/setup-node@v4` runs the pnpm cache probe under Node 26.

This lets future PR Body runs reach validation instead of failing during setup on runners missing `libatomic.so.1`.

## Review Claim

The PR Body workflow provisions Node 26's `libatomic.so.1` runtime dependency before `actions/setup-node@v4` can execute its pnpm cache probe.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the PR Body workflow's pre-Node setup path and its static regression assertion change; PR body validation semantics stay identical.

## Slice Rationale

This must be a separate base PR because `pull_request_target` runs PR Body from `master`, not from PR #9062's head branch.

## Non-goals

Do not edit the UI Vitest job in this slice.

Do not change PR Body validation rules.

Do not alter rollout authors or merge-queue behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-rollout.mjs`
- [x] `git diff --check origin/master...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run `node scripts/test-pr-body-rollout.mjs`.
- Data migration? No

</details>
