### PR TITLE
[Repair PR #9066 PR Body Node 26 runtime prerequisite](1) Install libatomic1 before PR Body Node setup

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -96,6 +96,12 @@ jobs:
           TARGET_AUTHORS: ${{ steps.targets.outputs.authors }}
         run: echo "PR body validation is not enforced for ${TARGET_AUTHORS} yet."
 
+      - name: Install Node.js runtime prerequisites
+        if: steps.targets.outputs.enabled == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libatomic1
+
       - name: Install pnpm
         if: steps.targets.outputs.enabled == 'true'
         uses: pnpm/action-setup@v4

--- a/scripts/test-pr-body-rollout.mjs
+++ b/scripts/test-pr-body-rollout.mjs
@@ -46,6 +46,37 @@ assert.doesNotMatch(
   'PR Body must not fail before validation on a stale trusted-base lockfile',
 );
 
+const prBodyWorkflowSteps = prBodyWorkflow.match(/^      - name: .*(?:\n(?!      - name: ).*)*/gm) || [];
+const findWorkflowStepIndex = (predicate) => prBodyWorkflowSteps.findIndex((step) => predicate(step));
+const enabledOnlyCondition = "steps.targets.outputs.enabled == 'true'";
+const resolveTargetsStepIndex = findWorkflowStepIndex((step) => step.includes('name: Resolve PR Body targets'));
+const setupNodeStepIndex = findWorkflowStepIndex((step) => step.includes('uses: actions/setup-node@v4'));
+const libatomicStepIndex = findWorkflowStepIndex((step) => step.includes('name: Install Node.js runtime prerequisites'));
+
+assert.notEqual(resolveTargetsStepIndex, -1, 'PR Body must resolve rollout targets before runtime setup');
+assert.notEqual(setupNodeStepIndex, -1, 'PR Body must select a Node.js runtime with actions/setup-node');
+assert.notEqual(libatomicStepIndex, -1, 'PR Body must install libatomic1 before selecting Node.js 26');
+assert.ok(
+  libatomicStepIndex > resolveTargetsStepIndex,
+  'PR Body must install Node.js runtime prerequisites after resolving rollout targets',
+);
+assert.ok(
+  libatomicStepIndex < setupNodeStepIndex,
+  'PR Body must install libatomic1 before actions/setup-node selects Node.js 26',
+);
+
+const libatomicStep = prBodyWorkflowSteps[libatomicStepIndex];
+assert.match(
+  libatomicStep,
+  new RegExp(`^        if: ${enabledOnlyCondition.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'm'),
+  'PR Body libatomic prerequisite install must use the same enabled-only gate as Node setup',
+);
+assert.match(
+  libatomicStep,
+  /^        run: \|\n          sudo apt-get update\n          sudo apt-get install -y libatomic1$/m,
+  'PR Body libatomic prerequisite install must update apt and install libatomic1',
+);
+
 const outputDir = mkdtempSync(join(tmpdir(), 'pr-body-rollout-'));
 const outputFile = join(outputDir, 'github-output');
 try {


### PR DESCRIPTION
## Summary

Repair PR #9066 by fixing the trusted-base PR Body workflow that GitHub runs for `pull_request_target` events.

The workflow now installs `libatomic1` before selecting Node 26 on the self-hosted `Github_Runner`.

This is required outside #9066 because `pull_request_target` loads workflow YAML from `master`, not from the pull request branch.

## Review Claim

The PR Body workflow installs the Node 26 `libatomic1` runtime prerequisite before `actions/setup-node`, and a rollout test guards that ordering.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the PR Body runner setup path changes; the existing PR Body validation logic and commands stay identical after Node can start.

## Slice Rationale

This prerequisite must land separately from #9066 because #9066 cannot repair its own trusted-base `pull_request_target` workflow run.

## Non-goals

- No product code changes.
- No unrelated CI job changes.
- No repair commit on PR #9066.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-rollout.mjs`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/pr-body-9066-node26.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 36d3c3a43`
- Post-revert steps: Re-run `node scripts/test-pr-body-rollout.mjs` to confirm the guard fails without the prerequisite.
- Data migration? No

</details>
