### PR TITLE
[Repair PR Body Node 26 startup failure](1) Use runner-compatible PR Body runtime

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -17,7 +17,7 @@ permissions:
   pull-requests: read
 
 env:
-  NODE_VERSION: '26'
+  NODE_VERSION: '24'
   PR_BODY_ENFORCE_ALL: ${{ vars.PR_BODY_ENFORCE_ALL || 'false' }}
   PR_BODY_ENFORCED_AUTHORS: ${{ vars.PR_BODY_ENFORCED_AUTHORS || 'EdbertChan' }}
 

--- a/scripts/test-pr-body-rollout.mjs
+++ b/scripts/test-pr-body-rollout.mjs
@@ -37,6 +37,16 @@ assert.deepEqual(evaluateRollout({ author: 'EdbertChan', enforceAll: 'false', en
 const prBodyWorkflow = readFileSync(new URL('../.github/workflows/pr-body.yml', import.meta.url), 'utf8');
 assert.match(
   prBodyWorkflow,
+  /NODE_VERSION:\s*'24'/,
+  'PR Body must use runner-compatible Node 24 on Github_Runner so validation does not fail loading libatomic.so.1',
+);
+assert.doesNotMatch(
+  prBodyWorkflow,
+  /NODE_VERSION:\s*'26'/,
+  'PR Body must not select Node 26 on Github_Runner because it fails before validation while loading libatomic.so.1',
+);
+assert.match(
+  prBodyWorkflow,
   /run: pnpm install --no-frozen-lockfile --ignore-scripts/,
   'PR Body must resolve trusted-base validator dependencies when its lockfile is stale',
 );


### PR DESCRIPTION
## Summary

PR Body now uses Node 24 for the trusted-base workflow bootstrap on Github_Runner.

This keeps validation on master while avoiding the Node 26 `libatomic.so.1` startup failure before the validator starts.

The rollout regression test now asserts that PR Body does not select the unsafe Node 26 runtime.

## Review Claim

PR Body uses a runner-compatible Node setup policy on Github_Runner.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

PR-body validation semantics stay unchanged; only the workflow runtime bootstrap and its invariant test change.

## Slice Rationale

This is one prerequisite CI slice because PR #9073 cannot change the pull_request_target workflow used by its required PR Body check.

## Non-goals

- No product behavior changes.
- No queue-capacity E2E proof edits.
- No Mergify rule edits.
- No repo-wide Node version change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-rollout.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, if Github_Runner can start the prior Node 26 PR Body bootstrap or the runner image gains `libatomic.so.1`.
- Revert command: `git revert 026699537166e76c56ee6d1465e2010ff26f2e37`
- Post-revert steps: Re-run `node scripts/test-pr-body-rollout.mjs` and the PR Body workflow check.
- Data migration? No

</details>
