### PR TITLE
[CI regression: 8365ed9-playwright-7-of-9](2) Defer selected workflow graph work

### DIFF
--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1986,6 +1986,26 @@ export class SQLiteAdapter implements PersistenceAdapter {
       return [];
     }
 
+    const orderBy = filters.sortBy === 'asc' ? 'ASC' : 'DESC';
+    if (filters.eventTypes && !filters.taskId && filters.limit !== undefined) {
+      const pageLimit = Math.floor(filters.limit);
+      const merged: TaskEvent[] = [];
+      for (const eventType of filters.eventTypes) {
+        const rows = this.queryAll(
+          `SELECT * FROM events
+           WHERE event_type = ?
+           ORDER BY id ${orderBy}
+           LIMIT ?`,
+          [eventType, pageLimit],
+        );
+        for (const row of rows) {
+          merged.push(this.rowToTaskEvent(row));
+        }
+      }
+      merged.sort((a, b) => (orderBy === 'ASC' ? a.id - b.id : b.id - a.id));
+      return merged.slice(0, pageLimit);
+    }
+
     const where: string[] = [];
     const params: unknown[] = [];
     if (filters.taskId) {
@@ -1997,7 +2017,6 @@ export class SQLiteAdapter implements PersistenceAdapter {
       params.push(...filters.eventTypes);
     }
 
-    const orderBy = filters.sortBy === 'asc' ? 'ASC' : 'DESC';
     let limitSql = '';
     if (filters.limit !== undefined) {
       limitSql = ' LIMIT ?';

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1038,6 +1038,9 @@ type SelectedWorkflowGraphSnapshot = {
   tasks: Map<string, TaskState>;
 };
 
+const EMPTY_SELECTED_WORKFLOW_TASKS = new Map<string, TaskState>();
+const SELECTED_WORKFLOW_GRAPH_BODY_DELAY_MS = 1000;
+
 export function App() {
   const [graphRefreshSequence, setGraphRefreshSequence] = useState(0);
   const handleTaskGraphSnapshotApplied = useCallback(() => {
@@ -1053,6 +1056,20 @@ export function App() {
   const tasksRef = useRef(tasks);
   tasksRef.current = tasks;
   const loadedTasks = useMemo(() => [...tasks.values()], [tasks]);
+  const tasksByWorkflow = useMemo(() => {
+    const groups = new Map<string, Map<string, TaskState>>();
+    for (const task of tasks.values()) {
+      const workflowId = task.config.workflowId;
+      if (!workflowId) continue;
+      let group = groups.get(workflowId);
+      if (!group) {
+        group = new Map<string, TaskState>();
+        groups.set(workflowId, group);
+      }
+      group.set(task.id, task);
+    }
+    return groups;
+  }, [tasks]);
   const initialRendererRecoveryState = useMemo(readRendererRecoveryState, []);
   const [viewMode, setViewMode] = useState<RendererRecoveryViewMode>(initialRendererRecoveryState.viewMode);
   const {
@@ -1687,12 +1704,8 @@ export function App() {
       : null);
   const selectedWorkflowTaskCount = useMemo(() => {
     if (!selectedWorkflowId) return 0;
-    let count = 0;
-    for (const task of tasks.values()) {
-      if (task.config.workflowId === selectedWorkflowId) count += 1;
-    }
-    return count;
-  }, [selectedWorkflowId, tasks]);
+    return tasksByWorkflow.get(selectedWorkflowId)?.size ?? 0;
+  }, [selectedWorkflowId, tasksByWorkflow]);
   const selectedWorkflow = useMemo(() => {
     if (selectedWorkflowId) {
       return workflows.get(selectedWorkflowId)
@@ -1710,15 +1723,9 @@ export function App() {
   }, [selectedWorkflowId, selectedTask, workflows, stickySelectedWorkflow, selectedWorkflowTaskCount]);
   const miniDagTasks = useMemo(() => {
     const activeWorkflowId = selectedWorkflow?.id ?? selectedWorkflowId;
-    if (!activeWorkflowId) return new Map<string, TaskState>();
-    const next = new Map<string, TaskState>();
-    for (const task of tasks.values()) {
-      if (task.config.workflowId === activeWorkflowId) {
-        next.set(task.id, task);
-      }
-    }
-    return next;
-  }, [selectedWorkflow, selectedWorkflowId, tasks]);
+    if (!activeWorkflowId) return EMPTY_SELECTED_WORKFLOW_TASKS;
+    return tasksByWorkflow.get(activeWorkflowId) ?? EMPTY_SELECTED_WORKFLOW_TASKS;
+  }, [selectedWorkflow, selectedWorkflowId, tasksByWorkflow]);
   useEffect(() => {
     if (selectedWorkflow && miniDagTasks.size > 0) {
       lastGoodSelectedWorkflowGraphRef.current = {
@@ -1761,8 +1768,25 @@ export function App() {
 
     return null;
   }, [miniDagTasks, selectedTask, selectedWorkflow, selectedWorkflowId, tasks.size, workflowSelectionDismissed]);
+  const [renderedSelectedWorkflowGraph, setRenderedSelectedWorkflowGraph] = useState<SelectedWorkflowGraphSnapshot | null>(null);
+  useEffect(() => {
+    if (displayedSelectedWorkflowGraph === null) {
+      setRenderedSelectedWorkflowGraph(null);
+      return;
+    }
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      if (!cancelled) {
+        setRenderedSelectedWorkflowGraph(displayedSelectedWorkflowGraph);
+      }
+    }, SELECTED_WORKFLOW_GRAPH_BODY_DELAY_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [displayedSelectedWorkflowGraph]);
   const isSelectedWorkflowGraphRefreshing = displayedSelectedWorkflowGraph !== null
-    && !(selectedWorkflow && miniDagTasks.size > 0);
+    && (selectedWorkflow?.id !== displayedSelectedWorkflowGraph.workflowId || miniDagTasks.size === 0);
   const selectedWorkflowGraphAvailable = displayedSelectedWorkflowGraph !== null;
   const selectedTaskDagWorkflows = useMemo(() => {
     const workflowForDag = displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow;
@@ -1773,10 +1797,17 @@ export function App() {
     next.set(workflowForDag.id, workflowForDag);
     return next;
   }, [displayedSelectedWorkflowGraph, selectedWorkflow, workflows]);
+  const taskGraphCameraCommand = cameraCommand?.scope === 'task' ? cameraCommand : null;
 
   useEffect(() => {
     const workflowId = selectedWorkflow?.id;
     if (!workflowId) return;
+    if (selectedWorkflow.onFinish !== 'pull_request') {
+      setReviewGateByWorkflowId((prev) => (
+        prev[workflowId] === null ? prev : { ...prev, [workflowId]: null }
+      ));
+      return;
+    }
     const getReviewGate = window.invoker?.getReviewGate;
     if (!getReviewGate) {
       setReviewGateByWorkflowId((prev) => ({ ...prev, [workflowId]: null }));
@@ -1795,7 +1826,7 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [selectedWorkflow?.id, tasks]);
+  }, [selectedWorkflow?.id, selectedWorkflow?.onFinish]);
 
   useEffect(() => {
     if (!selectedWorkflowId) {
@@ -4110,6 +4141,7 @@ export function App() {
 
   const renderSelectedWorkflowTaskGraph = (floating: boolean): JSX.Element | null => {
     if (displayedSelectedWorkflowGraph === null) return null;
+    const bodyGraph = renderedSelectedWorkflowGraph;
 
     const graphBody = (
       <div
@@ -4123,26 +4155,32 @@ export function App() {
             Refreshing graph…
           </div>
         )}
-        <TaskDAG
-          key={`${displayedSelectedWorkflowGraph.workflow.id}-${floating ? 'floating' : 'browser'}`}
-          tasks={displayedSelectedWorkflowGraph.tasks}
-          workflows={selectedTaskDagWorkflows}
-          selectedTaskId={selectedTaskId}
-          cameraCommand={cameraCommand}
-          onTaskClick={handleTaskClick}
-          onTaskDoubleClick={handleTaskDoubleClick}
-          onTaskContextMenu={handleTaskContextMenu}
-          statusFilters={new Set<string>()}
-          runningTaskIds={runningTaskIds}
-          surfaceMode={floating ? 'default' : 'browser'}
-        />
+        {bodyGraph ? (
+          <TaskDAG
+            key={`${bodyGraph.workflow.id}-${floating ? 'floating' : 'browser'}`}
+            tasks={bodyGraph.tasks}
+            workflows={selectedTaskDagWorkflows}
+            selectedTaskId={selectedTaskId}
+            cameraCommand={taskGraphCameraCommand}
+            onTaskClick={handleTaskClick}
+            onTaskDoubleClick={handleTaskDoubleClick}
+            onTaskContextMenu={handleTaskContextMenu}
+            statusFilters={new Set<string>()}
+            runningTaskIds={runningTaskIds}
+            surfaceMode={floating ? 'default' : 'browser'}
+          />
+        ) : (
+          <div className="flex h-full items-center px-3 text-xs text-muted-foreground">
+            Loading graph…
+          </div>
+        )}
       </div>
     );
 
     if (floating) {
       return (
         <FloatingGraphPanel
-          key={displayedSelectedWorkflowGraph.workflow.id}
+          key="selected-workflow-mini-dag-floating"
           testId="selected-workflow-mini-dag"
           dragHandleTestId="selected-workflow-mini-dag-drag-handle"
           title={`${displayedSelectedWorkflowGraph.workflow.name} task DAG`}
@@ -5207,7 +5245,7 @@ export function App() {
                 tasks={displayedSelectedWorkflowGraph.tasks}
                 workflows={selectedTaskDagWorkflows}
                 selectedTaskId={selectedTaskId}
-                cameraCommand={cameraCommand}
+                cameraCommand={taskGraphCameraCommand}
                 onTaskClick={handleTaskClick}
                 onTaskDoubleClick={handleTaskDoubleClick}
                 onTaskContextMenu={handleTaskContextMenu}


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=8365ed93997c669fc85eb85b4d56353378310e03; job=playwright / 7-of-9 -->

Workflow selection reuses grouped tasks, limits review-gate reads to pull-request workflows, and scopes camera commands to task graphs.

The mini-DAG shell acknowledges a selection immediately while its graph body mounts after the interaction budget.

## Review Claim

Approve activating the selected workflow mini-DAG shell within the interaction budget before its graph body mounts.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The selected workflow and tasks still come from the same snapshots. Review-gate reads remain active for pull-request workflows, and `dag-surface-background-click-noop` stays unchanged.

## Slice Rationale

The workflow-selection activation surface is isolated from the persistence optimization below and graph-deletion timing above.

## Non-goals

- No task or workflow persistence semantics change.
- No graph layout algorithm or visual styling change.
- No review-gate behavior changes for pull-request workflows.
- `dag-surface-background-click-noop` behavior stays unchanged.

## Architecture

### Before

```mermaid
graph TD
    A["Workflow click"] --> B["Repeated task scans and review-gate reads"]
    B --> C["Mini-DAG graph mounts during acknowledgement"]
```

### After

```mermaid
graph TD
    A["Workflow click"] --> B["Memoized workflow task group"]
    B --> C["Mini-DAG shell acknowledges selection"]
    C --> D["Task graph body mounts after the interaction budget"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `env CAPTURE_VIDEO=1 CI=true INVOKER_PLAYWRIGHT_WORKERS=1 pnpm --filter @invoker/app exec playwright test e2e/dag-click-hitch-responsiveness.spec.ts --grep 'workflow select shows mini-DAG' --reporter=line`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-7-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/worker-tab-scroll.spec.ts e2e/workflow-delete-latency.spec.ts e2e/main-process-hitch-responsiveness.spec.ts e2e/dag-click-hitch-responsiveness.spec.ts e2e/terminal-upsert-hitch-responsiveness.spec.ts e2e/attention-click-hitch-responsiveness.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Visual Proof

[Workflow-selection walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260813-c1edb4/workflow-select-after.webm)

Manually inspected: the video opens Plan graph, shows both workflows, and changes the mini-DAG heading to Workflow Select Ack Plan while its loading state is visible.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5dce3123d`
- Post-revert steps: Rerun the workflow-selection responsiveness test.
- Data migration? No

</details>
