### PR TITLE
[CI regression: 8365ed9-playwright-8-of-9](1) Optimize planning transcript appends

### DIFF
--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -658,6 +658,7 @@ type InAppPlanningMessagePersistState = {
   count: number;
   maxMessageId: number;
   signature?: string;
+  messagesRef?: InAppPlanningChatLine[];
 };
 
 function parseTerminalArgsJson(value: unknown): string[] {
@@ -777,6 +778,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
   private dirty = false;
   private readonly inAppPlanningMessagePersistStates = new Map<string, InAppPlanningMessagePersistState>();
   private readonly inAppPlanningMessagePersistSignatures = new Map<string, string>();
+  private readonly inAppPlanningMessagePersistRefs = new Map<string, InAppPlanningChatLine[]>();
   private outputTailLimit: number;
   private outputTailCache = new Map<string, OutputChunk[]>();
   private outputDir: string;
@@ -1582,6 +1584,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       this.db.run('DELETE FROM in_app_planning_sessions WHERE session_id = ?', [sessionId]);
       this.inAppPlanningMessagePersistStates.delete(sessionId);
       this.inAppPlanningMessagePersistSignatures.delete(sessionId);
+      this.inAppPlanningMessagePersistRefs.delete(sessionId);
     });
   }
 
@@ -3014,6 +3017,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     if (state.signature !== undefined) {
       this.inAppPlanningMessagePersistSignatures.set(sessionId, state.signature);
     }
+    this.inAppPlanningMessagePersistRefs.set(sessionId, messages);
   }
 
   private persistInAppPlanningMessages(
@@ -3030,11 +3034,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     for (const message of messages.slice(persistedState.count)) {
       this.insertInAppPlanningMessage(sessionId, message, fallbackCreatedAt);
     }
-    const state = this.stateForInAppPlanningMessages(messages);
+    const state = this.stateForAppendedInAppPlanningMessages(messages, persistedState);
     this.inAppPlanningMessagePersistStates.set(sessionId, state);
     if (state.signature !== undefined) {
       this.inAppPlanningMessagePersistSignatures.set(sessionId, state.signature);
     }
+    this.inAppPlanningMessagePersistRefs.set(sessionId, messages);
   }
 
   private getInAppPlanningMessagePersistState(sessionId: string): InAppPlanningMessagePersistState {
@@ -3051,6 +3056,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       count: Number(row?.message_count ?? 0),
       maxMessageId: Number(row?.max_message_id ?? 0),
       signature: this.inAppPlanningMessagePersistSignatures.get(sessionId),
+      messagesRef: this.inAppPlanningMessagePersistRefs.get(sessionId),
     };
     this.inAppPlanningMessagePersistStates.set(sessionId, state);
     return state;
@@ -3062,8 +3068,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
   ): boolean {
     if (persistedState.count > messages.length) return false;
 
-    let previousMessageId = 0;
-    for (const message of messages) {
+    let previousMessageId = persistedState.count > 0 ? persistedState.maxMessageId : 0;
+    const firstUnseenIndex = persistedState.count > 0 ? persistedState.count : 0;
+    for (let index = firstUnseenIndex; index < messages.length; index += 1) {
+      const message = messages[index];
       if (!Number.isSafeInteger(message.id) || message.id <= previousMessageId) {
         return false;
       }
@@ -3073,6 +3081,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
     if (persistedState.count === 0) return true;
     if (messages[persistedState.count - 1]?.id !== persistedState.maxMessageId) {
       return false;
+    }
+    if (persistedState.messagesRef === messages) {
+      return true;
     }
     if (persistedState.signature === undefined) {
       return messages.length > persistedState.count;
@@ -3085,12 +3096,36 @@ export class SQLiteAdapter implements PersistenceAdapter {
       count: messages.length,
       maxMessageId: messages.reduce((maxMessageId, message) => Math.max(maxMessageId, message.id), 0),
       signature: this.signatureForInAppPlanningMessages(messages),
+      messagesRef: messages,
     };
   }
 
-  private signatureForInAppPlanningMessages(messages: InAppPlanningChatLine[], count = messages.length): string {
+  private stateForAppendedInAppPlanningMessages(
+    messages: InAppPlanningChatLine[],
+    persistedState: InAppPlanningMessagePersistState,
+  ): InAppPlanningMessagePersistState {
+    const lastMessage = messages[messages.length - 1];
+    return {
+      count: messages.length,
+      maxMessageId: lastMessage ? lastMessage.id : persistedState.maxMessageId,
+      signature: persistedState.signature === undefined
+        ? undefined
+        : persistedState.signature + this.signatureForInAppPlanningMessages(
+          messages,
+          messages.length,
+          persistedState.count,
+        ),
+      messagesRef: messages,
+    };
+  }
+
+  private signatureForInAppPlanningMessages(
+    messages: InAppPlanningChatLine[],
+    count = messages.length,
+    startIndex = 0,
+  ): string {
     let signature = '';
-    for (let index = 0; index < count; index += 1) {
+    for (let index = startIndex; index < count; index += 1) {
       const message = messages[index];
       if (!message) break;
       signature += `${message.id}\x1f${message.role}\x1f${message.tone ?? ''}\x1f${message.createdAt ?? ''}\x1f${message.text.length}\x1f${message.text}\x1e`;
@@ -3187,6 +3222,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         });
       }
       this.inAppPlanningMessagePersistSignatures.set(id, this.signatureForInAppPlanningMessages(messages));
+      this.inAppPlanningMessagePersistRefs.set(id, messages);
 
       return {
         id,


### PR DESCRIPTION
## Summary

Invoker's planning chat backend re-signed the whole in-app transcript every time a new message was appended during an active session.

That repeated work grew with conversation length, adding cost to the planning-chat send path.

This change lets the backend reuse its prior append state when it is handed the exact same in-memory message array it just appended to.

## Review Claim

The planning-message persistence layer in `packages/data-store` avoids recomputing a full transcript checksum on repeat appends to the same message array, without changing what gets written to storage.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

The persisted message rows and their order are identical to the prior implementation; only the in-memory bookkeeping that decides whether a re-signature is needed changed. Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

This is the lowest layer of the fix, reviewed on its own before the caller-side (`in-app-planner`) and IPC-layer changes above it that depend on this behavior.

## Non-goals

No schema change. No change to persisted message content or ordering. No change to the in-app-planner or IPC layers landed in later slices of this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/data-store test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
