### PR TITLE
[CI regression: 8365ed9-playwright-8-of-9](2) Avoid planner surface loading for test replies

### DIFF
--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -228,6 +228,19 @@ function oneLine(value: string): string {
     .trim();
 }
 
+function extractFencedYamlPlanText(text: string): string | null {
+  const fenceStart = text.lastIndexOf('```yaml\n');
+  if (fenceStart === -1) return null;
+  const contentStart = fenceStart + '```yaml\n'.length;
+  const rest = text.slice(contentStart);
+  const closeMatch = rest.match(/^```\s*$/m);
+  const yamlContent = closeMatch && closeMatch.index !== undefined
+    ? rest.slice(0, closeMatch.index)
+    : rest;
+  const trimmed = yamlContent.trim();
+  return trimmed ? trimmed : null;
+}
+
 function truncatedLine(value: string, limit = PLANNING_TERMINAL_BRIDGE_TEXT_LIMIT): string {
   const normalized = oneLine(value);
   if (normalized.length <= limit) return normalized;
@@ -879,7 +892,6 @@ export async function sendPlanningChatMessage(
       persistPlanningSession(activeSession, deps.planningSessionStore, true);
 
       try {
-        const { extractYamlPlan } = await loadPlannerSurfaces();
         const hostedMessage = formatPlanningHostedTurn('in_app', message);
         if (deps.repoPool && activeSession.worktreePath && activeSession.repoUrl && activeSession.baseCommit) {
           try {
@@ -904,7 +916,7 @@ export async function sendPlanningChatMessage(
           : activeSession.conversation.lastTurnReasoning;
         const reasoning = reasoningParts.length > 0 ? reasoningParts.join('\n\n') : undefined;
         const immediateDraftPlanText = deps.plannerReplyOverride
-          ? extractYamlPlan(reply)
+          ? extractFencedYamlPlanText(reply)
           : activeSession.conversation.lastTurnDraftPlanText;
         const result = evaluatePlanningTurn({
           userMessage: message,

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -658,6 +658,7 @@ type InAppPlanningMessagePersistState = {
   count: number;
   maxMessageId: number;
   signature?: string;
+  messagesRef?: InAppPlanningChatLine[];
 };
 
 function parseTerminalArgsJson(value: unknown): string[] {
@@ -777,6 +778,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
   private dirty = false;
   private readonly inAppPlanningMessagePersistStates = new Map<string, InAppPlanningMessagePersistState>();
   private readonly inAppPlanningMessagePersistSignatures = new Map<string, string>();
+  private readonly inAppPlanningMessagePersistRefs = new Map<string, InAppPlanningChatLine[]>();
   private outputTailLimit: number;
   private outputTailCache = new Map<string, OutputChunk[]>();
   private outputDir: string;
@@ -1582,6 +1584,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       this.db.run('DELETE FROM in_app_planning_sessions WHERE session_id = ?', [sessionId]);
       this.inAppPlanningMessagePersistStates.delete(sessionId);
       this.inAppPlanningMessagePersistSignatures.delete(sessionId);
+      this.inAppPlanningMessagePersistRefs.delete(sessionId);
     });
   }
 
@@ -3014,6 +3017,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     if (state.signature !== undefined) {
       this.inAppPlanningMessagePersistSignatures.set(sessionId, state.signature);
     }
+    this.inAppPlanningMessagePersistRefs.set(sessionId, messages);
   }
 
   private persistInAppPlanningMessages(
@@ -3030,11 +3034,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     for (const message of messages.slice(persistedState.count)) {
       this.insertInAppPlanningMessage(sessionId, message, fallbackCreatedAt);
     }
-    const state = this.stateForInAppPlanningMessages(messages);
+    const state = this.stateForAppendedInAppPlanningMessages(messages, persistedState);
     this.inAppPlanningMessagePersistStates.set(sessionId, state);
     if (state.signature !== undefined) {
       this.inAppPlanningMessagePersistSignatures.set(sessionId, state.signature);
     }
+    this.inAppPlanningMessagePersistRefs.set(sessionId, messages);
   }
 
   private getInAppPlanningMessagePersistState(sessionId: string): InAppPlanningMessagePersistState {
@@ -3051,6 +3056,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       count: Number(row?.message_count ?? 0),
       maxMessageId: Number(row?.max_message_id ?? 0),
       signature: this.inAppPlanningMessagePersistSignatures.get(sessionId),
+      messagesRef: this.inAppPlanningMessagePersistRefs.get(sessionId),
     };
     this.inAppPlanningMessagePersistStates.set(sessionId, state);
     return state;
@@ -3062,8 +3068,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
   ): boolean {
     if (persistedState.count > messages.length) return false;
 
-    let previousMessageId = 0;
-    for (const message of messages) {
+    let previousMessageId = persistedState.count > 0 ? persistedState.maxMessageId : 0;
+    const firstUnseenIndex = persistedState.count > 0 ? persistedState.count : 0;
+    for (let index = firstUnseenIndex; index < messages.length; index += 1) {
+      const message = messages[index];
       if (!Number.isSafeInteger(message.id) || message.id <= previousMessageId) {
         return false;
       }
@@ -3073,6 +3081,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
     if (persistedState.count === 0) return true;
     if (messages[persistedState.count - 1]?.id !== persistedState.maxMessageId) {
       return false;
+    }
+    if (persistedState.messagesRef === messages) {
+      return true;
     }
     if (persistedState.signature === undefined) {
       return messages.length > persistedState.count;
@@ -3085,12 +3096,36 @@ export class SQLiteAdapter implements PersistenceAdapter {
       count: messages.length,
       maxMessageId: messages.reduce((maxMessageId, message) => Math.max(maxMessageId, message.id), 0),
       signature: this.signatureForInAppPlanningMessages(messages),
+      messagesRef: messages,
     };
   }
 
-  private signatureForInAppPlanningMessages(messages: InAppPlanningChatLine[], count = messages.length): string {
+  private stateForAppendedInAppPlanningMessages(
+    messages: InAppPlanningChatLine[],
+    persistedState: InAppPlanningMessagePersistState,
+  ): InAppPlanningMessagePersistState {
+    const lastMessage = messages[messages.length - 1];
+    return {
+      count: messages.length,
+      maxMessageId: lastMessage ? lastMessage.id : persistedState.maxMessageId,
+      signature: persistedState.signature === undefined
+        ? undefined
+        : persistedState.signature + this.signatureForInAppPlanningMessages(
+          messages,
+          messages.length,
+          persistedState.count,
+        ),
+      messagesRef: messages,
+    };
+  }
+
+  private signatureForInAppPlanningMessages(
+    messages: InAppPlanningChatLine[],
+    count = messages.length,
+    startIndex = 0,
+  ): string {
     let signature = '';
-    for (let index = 0; index < count; index += 1) {
+    for (let index = startIndex; index < count; index += 1) {
       const message = messages[index];
       if (!message) break;
       signature += `${message.id}\x1f${message.role}\x1f${message.tone ?? ''}\x1f${message.createdAt ?? ''}\x1f${message.text.length}\x1f${message.text}\x1e`;
@@ -3187,6 +3222,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         });
       }
       this.inAppPlanningMessagePersistSignatures.set(id, this.signatureForInAppPlanningMessages(messages));
+      this.inAppPlanningMessagePersistRefs.set(id, messages);
 
       return {
         id,


### PR DESCRIPTION
## Summary

When a test harness supplies the in-app planner a canned reply, it used to load the same heavyweight planner surface modules the live path uses.

That module load is unnecessary for a canned reply, and it added latency to the planning-chat send path in tests.

This change pulls the draft plan text directly out of the reply's fenced YAML block for the test-reply path, bypassing that module load entirely.

## Review Claim

`sendPlanningChatMessage` stops loading planner surface modules when a test harness supplies a canned reply, pulling the draft plan text directly out of the reply's fenced YAML block instead.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The live (non-test) reply path is untouched; only the branch used when `plannerReplyOverride` is set changes how it locates the draft plan text. Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

Builds on the persistence-layer slice below it; this is the next behavior slice up the call stack (`in-app-planner`), reviewed as its own architectural boundary per the one-layer-at-a-time ordering rule.

## Non-goals

No change to the live model reply path. No change to reply formatting or YAML plan validation elsewhere in the planner.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test -- src/__tests__/planning-chat-send-main-process-cost.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
