### PR TITLE
[CI regression: 8365ed9-playwright-8-of-9](4) Reuse main-process polling snapshots

### DIFF
--- a/packages/app/src/__tests__/action-graph-snapshot.test.ts
+++ b/packages/app/src/__tests__/action-graph-snapshot.test.ts
@@ -97,7 +97,7 @@ describe('buildCurrentActionGraphSnapshot', () => {
     expect(reloaded.execution.error).toBeUndefined();
   });
 
-  it.fails('reuses a fresh action graph snapshot for refocus-burst reads', async () => {
+  it('reuses a fresh action graph snapshot for refocus-burst reads', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({

--- a/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
+++ b/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
@@ -151,7 +151,7 @@ describe('main-process read hot-path cost guards', () => {
     queryAll.mockRestore();
   });
 
-  it.fails('reuses worker-status action and recovery reads during poll bursts', () => {
+  it('reuses worker-status action and recovery reads during poll bursts', () => {
     const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
     registry.register({
       kind: AUTO_FIX_WORKER_KIND,

--- a/packages/app/src/action-graph-snapshot.ts
+++ b/packages/app/src/action-graph-snapshot.ts
@@ -57,3 +57,29 @@ export function buildCurrentActionGraphSnapshot(args: {
     launchDispatches: args.persistence.listLaunchDispatchesByState(['enqueued', 'leased']),
   });
 }
+
+export function createCachedActionGraphSnapshotReader(args: {
+  getOrchestrator: () => Orchestrator;
+  persistence: SQLiteAdapter;
+  invokerConfig: InvokerConfig;
+  ttlMs?: number;
+  now?: () => number;
+}): () => ActionGraphResponse {
+  const ttlMs = args.ttlMs ?? 1000;
+  const now = args.now ?? (() => Date.now());
+  let cached: { at: number; value: ActionGraphResponse } | null = null;
+
+  return () => {
+    const at = now();
+    if (cached && at - cached.at >= 0 && at - cached.at < ttlMs) {
+      return cached.value;
+    }
+    const value = buildCurrentActionGraphSnapshot({
+      orchestrator: args.getOrchestrator(),
+      persistence: args.persistence,
+      invokerConfig: args.invokerConfig,
+    });
+    cached = { at, value };
+    return value;
+  };
+}

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -171,6 +171,7 @@ const DEFAULT_WORKER_ACTION_HISTORY_LIMIT = 20;
 const MAX_WORKER_ACTION_HISTORY_LIMIT = 100;
 /** Bounded wait for quit / stopAll so in-flight ticks cannot hang process exit. */
 export const STOP_ALL_SETTLE_TIMEOUT_MS = 5_000;
+const WORKER_STATUS_SNAPSHOT_CACHE_MS = 1000;
 
 function positiveIntegerOrDefault(value: number | undefined, fallback: number): number {
   if (value === undefined) return fallback;
@@ -299,6 +300,11 @@ export function createWorkerRuntimeController(options: {
 }): WorkerRuntimeController {
   const handles = new Map<string, RuntimeHandle>();
   const stoppedAtByKind = new Map<string, string>();
+  let cachedSnapshot: { at: number; value: WorkerStatusSnapshot } | null = null;
+
+  const invalidateSnapshot = (): void => {
+    cachedSnapshot = null;
+  };
 
   const requireDefinition = (kind: string) => {
     const definition = options.registry.get(kind);
@@ -391,6 +397,7 @@ export function createWorkerRuntimeController(options: {
       if (optionsArg?.persistDesiredState !== false) {
         persistDesiredState(kind, true, optionsArg?.source ?? 'controller-api');
       }
+      invalidateSnapshot();
 
       const existing = handles.get(kind);
       if (existing) {
@@ -408,16 +415,19 @@ export function createWorkerRuntimeController(options: {
         startedAt: new Date().toISOString(),
       });
       stoppedAtByKind.delete(kind);
+      invalidateSnapshot();
       return rowForKind(kind);
     },
     async stop(kind: string, optionsArg?: { source?: string }): Promise<WorkerStatusEntry> {
       requireDefinition(kind);
       persistDesiredState(kind, false, optionsArg?.source ?? 'controller-api');
+      invalidateSnapshot();
       const handle = handles.get(kind);
       if (!handle) {
         return rowForKind(kind);
       }
       await stopHandle(kind, handle);
+      invalidateSnapshot();
       return rowForKind(kind);
     },
 
@@ -426,13 +436,20 @@ export function createWorkerRuntimeController(options: {
         stopHandle(kind, handle, STOP_ALL_SETTLE_TIMEOUT_MS).catch(() => undefined),
       );
       await Promise.all(stopping);
+      invalidateSnapshot();
     },
 
     snapshot(): WorkerStatusSnapshot {
-      return {
+      const now = Date.now();
+      if (cachedSnapshot && now - cachedSnapshot.at >= 0 && now - cachedSnapshot.at < WORKER_STATUS_SNAPSHOT_CACHE_MS) {
+        return cachedSnapshot.value;
+      }
+      const value = {
         generatedAt: new Date().toISOString(),
         workers: options.registry.list().map((definition) => rowForKind(definition.kind)),
       };
+      cachedSnapshot = { at: now, value };
+      return value;
     },
   };
 }


### PR DESCRIPTION
## Summary

The previous slice added two vitest cases, marked `it.fails`, asserting that the action-graph snapshot and worker-status snapshot should reuse a recent result instead of rebuilding it on every call.

This slice implements that reuse: both snapshot builders now keep a short-lived cached result and return it for calls that land within the same window.

Mutating worker actions such as start, stop, and stopAll invalidate the cache immediately so callers never see outdated state after a change.

## Review Claim

Both snapshot builders introduced in the previous proof slice now cache their result for a short window and invalidate that cache on worker start/stop, matching the behavior the `it.fails` cases from the prior slice asserted.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The cache window is short (1 second) and every worker-mutating action explicitly invalidates it, so a caller can never observe worker state older than its own most recent mutation. Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

Repro-before-fix: the previous slice proved the gap with failing assertions; this slice flips those two cases from `it.fails` to `it` by implementing the caching they describe, with no other test changes.

## Non-goals

No new test cases beyond flipping the two from `it.fails` to `it`. No change to cache windows elsewhere in the app. No change to the data-store or in-app-planner slices below this one.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test -- src/__tests__/action-graph-snapshot.test.ts src/__tests__/main-process-read-hotpath-cost.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness for repeated action graph and worker status requests through short-lived caching.
  * Worker status updates refresh promptly after workers start, stop, or complete shutdown.

* **Bug Fixes**
  * Enabled coverage for action graph snapshot reuse and expiration behavior.
  * Enabled coverage for worker status polling during rapid request bursts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->