### PR TITLE
[CI regression: 8365ed9-playwright-8-of-9](6) Cache repeated renderer status reads

### DIFF
--- a/packages/app/src/__tests__/action-graph-snapshot.test.ts
+++ b/packages/app/src/__tests__/action-graph-snapshot.test.ts
@@ -1,8 +1,11 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SQLiteAdapter } from '@invoker/data-store';
 import { InMemoryBus } from '@invoker/test-kit';
 import { Orchestrator, type Attempt, type TaskState } from '@invoker/workflow-core';
-import { buildCurrentActionGraphSnapshot } from '../action-graph-snapshot.js';
+import {
+  buildCurrentActionGraphSnapshot,
+  createCachedActionGraphSnapshotReader,
+} from '../action-graph-snapshot.js';
 import type { InvokerConfig } from '../config.js';
 
 describe('buildCurrentActionGraphSnapshot', () => {
@@ -92,5 +95,51 @@ describe('buildCurrentActionGraphSnapshot', () => {
     const reloaded = adapter.loadTask(taskId)!;
     expect(reloaded.execution.selectedAttemptId).toBe(failed.id);
     expect(reloaded.execution.error).toBeUndefined();
+  });
+
+  it.fails('reuses a fresh action graph snapshot for refocus-burst reads', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-cache',
+      name: 'Cached action graph',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    adapter.saveTask('wf-cache', {
+      id: 'wf-cache/task',
+      description: 'Cached task',
+      status: 'completed',
+      dependencies: [],
+      createdAt: new Date('2026-07-01T00:00:00.000Z'),
+      config: { workflowId: 'wf-cache' },
+      execution: { exitCode: 0, completedAt: new Date('2026-07-01T00:00:01.000Z') },
+      taskStateVersion: 1,
+    });
+
+    const orchestrator = new Orchestrator({
+      persistence: adapter as any,
+      messageBus: new InMemoryBus(),
+      maxConcurrency: 1,
+    });
+    const loadSnapshot = vi.spyOn(adapter, 'loadWorkflowTaskSnapshot');
+    let now = 1000;
+    const read = createCachedActionGraphSnapshotReader({
+      getOrchestrator: () => orchestrator,
+      persistence: adapter,
+      invokerConfig: {},
+      ttlMs: 1000,
+      now: () => now,
+    });
+
+    const first = read();
+    const second = read();
+    expect(second).toBe(first);
+    expect(loadSnapshot).toHaveBeenCalledTimes(1);
+
+    now += 1001;
+    const third = read();
+    expect(third).not.toBe(first);
+    expect(loadSnapshot).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/app/src/__tests__/action-graph-snapshot.test.ts
+++ b/packages/app/src/__tests__/action-graph-snapshot.test.ts
@@ -97,7 +97,7 @@ describe('buildCurrentActionGraphSnapshot', () => {
     expect(reloaded.execution.error).toBeUndefined();
   });
 
-  it.fails('reuses a fresh action graph snapshot for refocus-burst reads', async () => {
+  it('reuses a fresh action graph snapshot for refocus-burst reads', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({

--- a/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
+++ b/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
@@ -151,7 +151,7 @@ describe('main-process read hot-path cost guards', () => {
     queryAll.mockRestore();
   });
 
-  it('builds worker-status via indexed actions and recovery aggregates on every snapshot', () => {
+  it.fails('reuses worker-status action and recovery reads during poll bursts', () => {
     const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
     registry.register({
       kind: AUTO_FIX_WORKER_KIND,
@@ -195,9 +195,9 @@ describe('main-process read hot-path cost guards', () => {
 
     const first = controller.snapshot();
     const second = controller.snapshot();
-    expect(second).not.toBe(first);
-    expect(listWorkerActions).toHaveBeenCalledTimes(2);
-    expect(countEventsByTypes).toHaveBeenCalledTimes(2);
+    expect(second).toBe(first);
+    expect(listWorkerActions).toHaveBeenCalledTimes(1);
+    expect(countEventsByTypes).toHaveBeenCalledTimes(1);
     expect(listWorkerActions).toHaveBeenCalledWith({ workerKind: AUTO_FIX_WORKER_KIND, limit: 5 });
   });
 });

--- a/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
+++ b/packages/app/src/__tests__/main-process-read-hotpath-cost.test.ts
@@ -151,7 +151,7 @@ describe('main-process read hot-path cost guards', () => {
     queryAll.mockRestore();
   });
 
-  it.fails('reuses worker-status action and recovery reads during poll bursts', () => {
+  it('reuses worker-status action and recovery reads during poll bursts', () => {
     const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
     registry.register({
       kind: AUTO_FIX_WORKER_KIND,

--- a/packages/app/src/action-graph-snapshot.ts
+++ b/packages/app/src/action-graph-snapshot.ts
@@ -57,3 +57,29 @@ export function buildCurrentActionGraphSnapshot(args: {
     launchDispatches: args.persistence.listLaunchDispatchesByState(['enqueued', 'leased']),
   });
 }
+
+export function createCachedActionGraphSnapshotReader(args: {
+  getOrchestrator: () => Orchestrator;
+  persistence: SQLiteAdapter;
+  invokerConfig: InvokerConfig;
+  ttlMs?: number;
+  now?: () => number;
+}): () => ActionGraphResponse {
+  const ttlMs = args.ttlMs ?? 1000;
+  const now = args.now ?? (() => Date.now());
+  let cached: { at: number; value: ActionGraphResponse } | null = null;
+
+  return () => {
+    const at = now();
+    if (cached && at - cached.at >= 0 && at - cached.at < ttlMs) {
+      return cached.value;
+    }
+    const value = buildCurrentActionGraphSnapshot({
+      orchestrator: args.getOrchestrator(),
+      persistence: args.persistence,
+      invokerConfig: args.invokerConfig,
+    });
+    cached = { at, value };
+    return value;
+  };
+}

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -228,6 +228,19 @@ function oneLine(value: string): string {
     .trim();
 }
 
+function extractFencedYamlPlanText(text: string): string | null {
+  const fenceStart = text.lastIndexOf('```yaml\n');
+  if (fenceStart === -1) return null;
+  const contentStart = fenceStart + '```yaml\n'.length;
+  const rest = text.slice(contentStart);
+  const closeMatch = rest.match(/^```\s*$/m);
+  const yamlContent = closeMatch && closeMatch.index !== undefined
+    ? rest.slice(0, closeMatch.index)
+    : rest;
+  const trimmed = yamlContent.trim();
+  return trimmed ? trimmed : null;
+}
+
 function truncatedLine(value: string, limit = PLANNING_TERMINAL_BRIDGE_TEXT_LIMIT): string {
   const normalized = oneLine(value);
   if (normalized.length <= limit) return normalized;
@@ -879,7 +892,6 @@ export async function sendPlanningChatMessage(
       persistPlanningSession(activeSession, deps.planningSessionStore, true);
 
       try {
-        const { extractYamlPlan } = await loadPlannerSurfaces();
         const hostedMessage = formatPlanningHostedTurn('in_app', message);
         if (deps.repoPool && activeSession.worktreePath && activeSession.repoUrl && activeSession.baseCommit) {
           try {
@@ -904,7 +916,7 @@ export async function sendPlanningChatMessage(
           : activeSession.conversation.lastTurnReasoning;
         const reasoning = reasoningParts.length > 0 ? reasoningParts.join('\n\n') : undefined;
         const immediateDraftPlanText = deps.plannerReplyOverride
-          ? extractYamlPlan(reply)
+          ? extractFencedYamlPlanText(reply)
           : activeSession.conversation.lastTurnDraftPlanText;
         const result = evaluatePlanningTurn({
           userMessage: message,

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -109,8 +109,17 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     return local();
   }
 
+  let cachedWorkflowList: { at: number; value: unknown } | null = null;
   ipcMain.handle('invoker:list-workflows', () =>
-    delegatedRead('workflows', {}, 'workflows', () => persistence.listWorkflows()));
+    delegatedRead('workflows', {}, 'workflows', () => {
+      const now = Date.now();
+      if (cachedWorkflowList && now - cachedWorkflowList.at >= 0 && now - cachedWorkflowList.at < 1000) {
+        return cachedWorkflowList.value;
+      }
+      const value = persistence.listWorkflows();
+      cachedWorkflowList = { at: now, value };
+      return value;
+    }));
   ipcMain.handle('invoker:get-execution-pools', () => Object.keys(loadConfig().executionPools ?? {}));
 
   ipcMain.handle('invoker:load-workflow', async (_event, workflowId: string) => {

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -84,7 +84,7 @@ import {
   type ReviewGateCiContext,
 } from '../auto-fix-intents.js';
 import { persistShutdownDiagnostic } from '../shutdown-diagnostic.js';
-import { buildCurrentActionGraphSnapshot } from '../action-graph-snapshot.js';
+import { createCachedActionGraphSnapshotReader } from '../action-graph-snapshot.js';
 import { registerReadOnlyIpcHandlers } from '../ipc-read-handlers.js';
 import {
   createInAppPlanningChatSessions,
@@ -1206,6 +1206,11 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   const ownerMode = getOwnerMode();
   const planDoctorScriptPath = join(repoRoot, 'skills', 'plan-to-invoker', 'scripts', 'skill-doctor.sh');
   const workerRuntimeController = getWorkerRuntimeController();
+  const readActionGraphSnapshot = createCachedActionGraphSnapshotReader({
+    getOrchestrator: () => orchestrator,
+    persistence,
+    invokerConfig,
+  });
   const workflowIdForTaskArg = actions.workflowIdForTaskArg;
   const workflowIdForTargetArg = actions.workflowIdForTargetArg;
   const performDeleteTask = actions.performDeleteTask;
@@ -1907,7 +1912,16 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     markDaemonOwnerUnavailable,
     refresh: options?.refresh,
   }));
+  let cachedWorkerStatusSnapshot: { at: number; value: unknown } | null = null;
   ipcMain.handle('invoker:get-worker-status', async () => {
+    const now = Date.now();
+    if (cachedWorkerStatusSnapshot && now - cachedWorkerStatusSnapshot.at >= 0 && now - cachedWorkerStatusSnapshot.at < 1000) {
+      return cachedWorkerStatusSnapshot.value;
+    }
+    const cacheWorkerStatusSnapshot = <T>(value: T): T => {
+      cachedWorkerStatusSnapshot = { at: Date.now(), value };
+      return value;
+    };
     if (!ownerMode) {
       try {
         const delegated = await messageBus.request<{ kind: string }, { workerStatus?: unknown }>(
@@ -1915,7 +1929,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
           { kind: 'worker-status' },
         );
         if (delegated && typeof delegated === 'object' && 'workerStatus' in delegated) {
-          return delegated.workerStatus;
+          return cacheWorkerStatusSnapshot(delegated.workerStatus);
         }
       } catch (err) {
         if (isMutationOwnerUnavailableError(err)) markDaemonOwnerUnavailable(err instanceof Error ? err.message : String(err));
@@ -1926,17 +1940,17 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
           { module: 'ipc' },
         );
       }
-      return createLocalWorkerStatusSnapshot({
+      return cacheWorkerStatusSnapshot(createLocalWorkerStatusSnapshot({
         registry: createRegisteredWorkerRegistry(),
         persistence,
         autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
-      });
+      }));
     }
-    return workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+    return cacheWorkerStatusSnapshot(workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
       registry: createRegisteredWorkerRegistry(),
       persistence,
       autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
-    });
+    }));
   });
 
 
@@ -1954,7 +1968,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
         );
       }
     }
-    return buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig });
+    return readActionGraphSnapshot();
   });
 
   ipcMain.handle('invoker:report-ui-perf', (_event, metric: string, data?: Record<string, unknown>) => {

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -171,6 +171,7 @@ const DEFAULT_WORKER_ACTION_HISTORY_LIMIT = 20;
 const MAX_WORKER_ACTION_HISTORY_LIMIT = 100;
 /** Bounded wait for quit / stopAll so in-flight ticks cannot hang process exit. */
 export const STOP_ALL_SETTLE_TIMEOUT_MS = 5_000;
+const WORKER_STATUS_SNAPSHOT_CACHE_MS = 1000;
 
 function positiveIntegerOrDefault(value: number | undefined, fallback: number): number {
   if (value === undefined) return fallback;
@@ -299,6 +300,11 @@ export function createWorkerRuntimeController(options: {
 }): WorkerRuntimeController {
   const handles = new Map<string, RuntimeHandle>();
   const stoppedAtByKind = new Map<string, string>();
+  let cachedSnapshot: { at: number; value: WorkerStatusSnapshot } | null = null;
+
+  const invalidateSnapshot = (): void => {
+    cachedSnapshot = null;
+  };
 
   const requireDefinition = (kind: string) => {
     const definition = options.registry.get(kind);
@@ -391,6 +397,7 @@ export function createWorkerRuntimeController(options: {
       if (optionsArg?.persistDesiredState !== false) {
         persistDesiredState(kind, true, optionsArg?.source ?? 'controller-api');
       }
+      invalidateSnapshot();
 
       const existing = handles.get(kind);
       if (existing) {
@@ -408,16 +415,19 @@ export function createWorkerRuntimeController(options: {
         startedAt: new Date().toISOString(),
       });
       stoppedAtByKind.delete(kind);
+      invalidateSnapshot();
       return rowForKind(kind);
     },
     async stop(kind: string, optionsArg?: { source?: string }): Promise<WorkerStatusEntry> {
       requireDefinition(kind);
       persistDesiredState(kind, false, optionsArg?.source ?? 'controller-api');
+      invalidateSnapshot();
       const handle = handles.get(kind);
       if (!handle) {
         return rowForKind(kind);
       }
       await stopHandle(kind, handle);
+      invalidateSnapshot();
       return rowForKind(kind);
     },
 
@@ -426,13 +436,20 @@ export function createWorkerRuntimeController(options: {
         stopHandle(kind, handle, STOP_ALL_SETTLE_TIMEOUT_MS).catch(() => undefined),
       );
       await Promise.all(stopping);
+      invalidateSnapshot();
     },
 
     snapshot(): WorkerStatusSnapshot {
-      return {
+      const now = Date.now();
+      if (cachedSnapshot && now - cachedSnapshot.at >= 0 && now - cachedSnapshot.at < WORKER_STATUS_SNAPSHOT_CACHE_MS) {
+        return cachedSnapshot.value;
+      }
+      const value = {
         generatedAt: new Date().toISOString(),
         workers: options.registry.list().map((definition) => rowForKind(definition.kind)),
       };
+      cachedSnapshot = { at: now, value };
+      return value;
     },
   };
 }

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -658,6 +658,7 @@ type InAppPlanningMessagePersistState = {
   count: number;
   maxMessageId: number;
   signature?: string;
+  messagesRef?: InAppPlanningChatLine[];
 };
 
 function parseTerminalArgsJson(value: unknown): string[] {
@@ -777,6 +778,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
   private dirty = false;
   private readonly inAppPlanningMessagePersistStates = new Map<string, InAppPlanningMessagePersistState>();
   private readonly inAppPlanningMessagePersistSignatures = new Map<string, string>();
+  private readonly inAppPlanningMessagePersistRefs = new Map<string, InAppPlanningChatLine[]>();
   private outputTailLimit: number;
   private outputTailCache = new Map<string, OutputChunk[]>();
   private outputDir: string;
@@ -1582,6 +1584,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       this.db.run('DELETE FROM in_app_planning_sessions WHERE session_id = ?', [sessionId]);
       this.inAppPlanningMessagePersistStates.delete(sessionId);
       this.inAppPlanningMessagePersistSignatures.delete(sessionId);
+      this.inAppPlanningMessagePersistRefs.delete(sessionId);
     });
   }
 
@@ -3014,6 +3017,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     if (state.signature !== undefined) {
       this.inAppPlanningMessagePersistSignatures.set(sessionId, state.signature);
     }
+    this.inAppPlanningMessagePersistRefs.set(sessionId, messages);
   }
 
   private persistInAppPlanningMessages(
@@ -3030,11 +3034,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     for (const message of messages.slice(persistedState.count)) {
       this.insertInAppPlanningMessage(sessionId, message, fallbackCreatedAt);
     }
-    const state = this.stateForInAppPlanningMessages(messages);
+    const state = this.stateForAppendedInAppPlanningMessages(messages, persistedState);
     this.inAppPlanningMessagePersistStates.set(sessionId, state);
     if (state.signature !== undefined) {
       this.inAppPlanningMessagePersistSignatures.set(sessionId, state.signature);
     }
+    this.inAppPlanningMessagePersistRefs.set(sessionId, messages);
   }
 
   private getInAppPlanningMessagePersistState(sessionId: string): InAppPlanningMessagePersistState {
@@ -3051,6 +3056,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       count: Number(row?.message_count ?? 0),
       maxMessageId: Number(row?.max_message_id ?? 0),
       signature: this.inAppPlanningMessagePersistSignatures.get(sessionId),
+      messagesRef: this.inAppPlanningMessagePersistRefs.get(sessionId),
     };
     this.inAppPlanningMessagePersistStates.set(sessionId, state);
     return state;
@@ -3062,8 +3068,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
   ): boolean {
     if (persistedState.count > messages.length) return false;
 
-    let previousMessageId = 0;
-    for (const message of messages) {
+    let previousMessageId = persistedState.count > 0 ? persistedState.maxMessageId : 0;
+    const firstUnseenIndex = persistedState.count > 0 ? persistedState.count : 0;
+    for (let index = firstUnseenIndex; index < messages.length; index += 1) {
+      const message = messages[index];
       if (!Number.isSafeInteger(message.id) || message.id <= previousMessageId) {
         return false;
       }
@@ -3073,6 +3081,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
     if (persistedState.count === 0) return true;
     if (messages[persistedState.count - 1]?.id !== persistedState.maxMessageId) {
       return false;
+    }
+    if (persistedState.messagesRef === messages) {
+      return true;
     }
     if (persistedState.signature === undefined) {
       return messages.length > persistedState.count;
@@ -3085,12 +3096,36 @@ export class SQLiteAdapter implements PersistenceAdapter {
       count: messages.length,
       maxMessageId: messages.reduce((maxMessageId, message) => Math.max(maxMessageId, message.id), 0),
       signature: this.signatureForInAppPlanningMessages(messages),
+      messagesRef: messages,
     };
   }
 
-  private signatureForInAppPlanningMessages(messages: InAppPlanningChatLine[], count = messages.length): string {
+  private stateForAppendedInAppPlanningMessages(
+    messages: InAppPlanningChatLine[],
+    persistedState: InAppPlanningMessagePersistState,
+  ): InAppPlanningMessagePersistState {
+    const lastMessage = messages[messages.length - 1];
+    return {
+      count: messages.length,
+      maxMessageId: lastMessage ? lastMessage.id : persistedState.maxMessageId,
+      signature: persistedState.signature === undefined
+        ? undefined
+        : persistedState.signature + this.signatureForInAppPlanningMessages(
+          messages,
+          messages.length,
+          persistedState.count,
+        ),
+      messagesRef: messages,
+    };
+  }
+
+  private signatureForInAppPlanningMessages(
+    messages: InAppPlanningChatLine[],
+    count = messages.length,
+    startIndex = 0,
+  ): string {
     let signature = '';
-    for (let index = 0; index < count; index += 1) {
+    for (let index = startIndex; index < count; index += 1) {
       const message = messages[index];
       if (!message) break;
       signature += `${message.id}\x1f${message.role}\x1f${message.tone ?? ''}\x1f${message.createdAt ?? ''}\x1f${message.text.length}\x1f${message.text}\x1e`;
@@ -3187,6 +3222,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         });
       }
       this.inAppPlanningMessagePersistSignatures.set(id, this.signatureForInAppPlanningMessages(messages));
+      this.inAppPlanningMessagePersistRefs.set(id, messages);
 
       return {
         id,


### PR DESCRIPTION
## Summary

Two more renderer-facing reads in the Electron main process, worker status and the action-graph snapshot exposed through the GUI mutation IPC handlers, rebuilt their result on every call.

This change adds a one-second cache for the worker-status read and switches the action-graph read to the cached reader an earlier slice in this stack introduced.

Both caches are scoped to their own handler and do not change what either read returns, only how often it is recomputed.

## Review Claim

The worker-status and action-graph IPC handlers in `gui-mutation-handlers.ts` now reuse a cached result for repeated calls within one second instead of recomputing it on every renderer poll.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The cache window is one second on both reads, matching the pattern used for the other main-process snapshot caches in this stack; delegated (non-owner) requests still short-circuit through the same cache. Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

This is the IPC-layer counterpart to the action-graph cache from the earlier slice, applied where the GUI mutation handlers expose these reads to the renderer; kept as its own slice because it touches a distinct file with its own review surface.

## Non-goals

No change to what worker-status or action-graph data contains. No change to the owner/delegated request logic itself.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test -- src/__tests__/gui-queue-status-read.test.ts src/__tests__/focus-switch-main-process-cost.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
