### PR TITLE
[CI regression: d19a0f4-playwright-1-of-9](1) Hide draft-ready bar during review

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4591,12 +4591,12 @@ export function App() {
 
   const planningReadyCount = planningSessions.filter((session) => session.status === 'draft_ready').length;
   const submittedPlanningSessionCount = planningSessions.filter((session) => session.status === 'submitted').length;
+  const activeDraftReviewOpen = reviewDraftSessionId === activePlanningSession.id && Boolean(draftPlanSummary);
   const connectedAgentLabels = (systemDiagnostics?.tools ?? [])
     .filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed)
     .map((tool) => tool.name.replace(/\s+CLI$/i, ''));
 
   const renderPlanningContextPanel = (): JSX.Element => {
-    const reviewingDraft = reviewDraftSessionId === activePlanningSession.id && Boolean(draftPlanSummary);
     const draftTaskGroups = draftPlanSummary?.taskGroups ?? (
       draftPlanSummary ? [{ workflow: null, tasks: draftPlanSummary.steps }] : []
     );
@@ -4608,7 +4608,7 @@ export function App() {
       >
         <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border px-3 py-2.5">
           {!planningContextCollapsed && (
-            <h2 className="text-sm font-semibold text-foreground">{reviewingDraft ? 'Review draft' : 'Current plan'}</h2>
+            <h2 className="text-sm font-semibold text-foreground">{activeDraftReviewOpen ? 'Review draft' : 'Current plan'}</h2>
           )}
           <button
             type="button"
@@ -4621,7 +4621,7 @@ export function App() {
           </button>
         </div>
         {!planningContextCollapsed && (
-          reviewingDraft ? (
+          activeDraftReviewOpen ? (
             <div className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain p-4 text-sm">
               <p data-testid="planning-draft-locked-note" className="text-xs text-muted-foreground">
                 This draft is locked — critique in chat, or ask Invoker to re-draft, to change it.
@@ -4840,6 +4840,7 @@ export function App() {
             presetOptions={planningPresetOptions}
             selectedConfirmationMode={selectedPlanningConfirmationMode}
             draftPlanAvailable={draftPlanAvailable}
+            draftReviewOpen={activeDraftReviewOpen}
             draftPlanSummary={draftPlanSummary}
             planningStream={activePlanningStream}
             readOnly={activePlanningReadOnly}

--- a/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
@@ -55,9 +55,9 @@ describe('CodeRabbit PR #3050 — draft state cleared after submit', () => {
     fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'draft the full plan' } });
     fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
 
-    await screen.findByTestId('invoker-terminal-ready-bar');
-    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
-    fireEvent.click(await screen.findByTestId('planning-create-workflow'));
+    await screen.findByTestId('planning-create-workflow');
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('planning-create-workflow'));
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });

--- a/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
@@ -49,9 +49,9 @@ describe('CodeRabbit PR #3050 — submitted planning stays read-only after start
 
     fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'draft the full plan' } });
     fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
-    await screen.findByTestId('invoker-terminal-ready-bar');
-    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
-    fireEvent.click(await screen.findByTestId('planning-create-workflow'));
+    await screen.findByTestId('planning-create-workflow');
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('planning-create-workflow'));
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1721,9 +1721,8 @@ describe('Invoker terminal (component)', () => {
 
     submitPlanningText('draft the full plan');
 
-    await waitFor(() => {
-      expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('Draft ready · Mock Plan · 2 tasks');
-    });
+    await screen.findByTestId('planning-create-workflow');
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
 
     expect(mock.api.planningChatSubmit).not.toHaveBeenCalled();
     expect(mock.api.startReady).not.toHaveBeenCalled();
@@ -1773,12 +1772,9 @@ describe('Invoker terminal (component)', () => {
 
     submitPlanningText('draft the Workers Surface plan');
 
-    await waitFor(() => {
-      expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('Draft ready · Workers Surface · 2 workflows · 4 tasks');
-    });
-
-    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
     await screen.findByTestId('planning-create-workflow');
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    expect(screen.getAllByTestId('draft-task-group')).toHaveLength(2);
     fireEvent.click(screen.getByTestId('planning-create-workflow'));
 
     await waitFor(() => {
@@ -1814,10 +1810,9 @@ describe('Invoker terminal (component)', () => {
     await openPlanningTerminal();
 
     submitPlanningText('draft the full plan');
-    await screen.findByTestId('invoker-terminal-ready-bar');
-
-    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
-    fireEvent.click(await screen.findByTestId('planning-create-workflow'));
+    await screen.findByTestId('planning-create-workflow');
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('planning-create-workflow'));
 
     expect(screen.getByTestId('planning-create-workflow')).toBeInTheDocument();
     expect(mock.api.refreshTaskGraph).not.toHaveBeenCalled();
@@ -1875,9 +1870,9 @@ describe('Invoker terminal (component)', () => {
     await openPlanningTerminal();
 
     submitPlanningText('draft the full plan');
-    await screen.findByTestId('invoker-terminal-ready-bar');
-    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
-    fireEvent.click(await screen.findByTestId('planning-create-workflow'));
+    await screen.findByTestId('planning-create-workflow');
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('planning-create-workflow'));
     await waitFor(() => expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' }));
 
     fireEvent.click(screen.getByTestId('sidebar-home'));

--- a/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
@@ -74,9 +74,9 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
     await openPlanningTerminal();
 
     submitPlanningText('draft the full plan');
-    await screen.findByTestId('invoker-terminal-ready-bar');
-    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
-    fireEvent.click(await screen.findByTestId('planning-create-workflow'));
+    await screen.findByTestId('planning-create-workflow');
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('planning-create-workflow'));
 
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -113,6 +113,7 @@ interface InvokerTerminalProps {
   presetOptions: PlanningPresetOptionView[];
   selectedConfirmationMode: PlanningConfirmationMode;
   draftPlanAvailable: boolean;
+  draftReviewOpen?: boolean;
   draftPlanSummary?: {
     name: string;
     taskCount: number;
@@ -535,6 +536,7 @@ export function InvokerTerminal({
   presetOptions,
   selectedConfirmationMode,
   draftPlanAvailable,
+  draftReviewOpen = false,
   draftPlanSummary,
   planningStream,
   readOnly = false,
@@ -901,7 +903,7 @@ export function InvokerTerminal({
             )}
           </div>
 
-          {draftPlanAvailable && !readOnly && (
+          {draftPlanAvailable && !draftReviewOpen && !readOnly && (
             <div
               data-testid="invoker-terminal-ready-bar"
               className="sticky bottom-0 z-10 border-t border-border bg-card/80 px-4 py-3.5 text-sm text-foreground backdrop-blur-sm"


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=d19a0f4af741226c3edb9509e2768529bf97fef9; job=playwright / 1-of-9 -->

Hide the terminal draft-ready bar while the Review draft panel is open.

CI job `playwright / 1-of-9` first failed on default-branch commit d19a0f4af741226c3edb9509e2768529bf97fef9 in run 30680710516.

It was most recently still red at e73ee552a6e174a85fc6107186bb802b32ec4b6e in run 31629955741.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/30680710516/job/91317782173

## Review Claim

The planning terminal renders no draft-ready bar when the active draft is already open for review.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

This behavior slice contains the planning surface change and its directly affected component checks.

## Non-goals

- No change to plan creation or submission behavior.
- No unrelated refactor, cleanup, snapshot churn, or test weakening.
- The guarded `dag-surface-background-click-noop` behavior remains unchanged.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/surfaces build`
- [x] `pnpm --filter @invoker/app build`
- [x] On `origin/master`: `cd packages/app && CAPTURE_MODE=before CAPTURE_VIDEO=1 npx playwright test e2e/visual-proof.spec.ts --grep 'terminal planning loads graph' --output=/tmp/invoker-pr-proof-d19a0f4.4NWLzo/target-before-results`
- [x] On the full stack tip: `cd packages/app && CAPTURE_MODE=after CAPTURE_VIDEO=1 npx playwright test e2e/visual-proof.spec.ts --grep 'terminal planning loads graph' --output=/tmp/invoker-pr-proof-d19a0f4.4NWLzo/target-after-results`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-1-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/visual-proof.spec.ts e2e/edit-task-command.spec.ts e2e/headless-thundering-herd.spec.ts e2e/launching-stall-watchdog.spec.ts e2e/embedded-terminal-pty.spec.ts e2e/keyboard-navigation.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — builds passed, then the local macOS run exited 254 because `xvfb-run` is unavailable.

</details>

## Visual Proof

![Before — the open Review draft panel still has a duplicate Draft ready bar](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260813-0b7a42/draft-review-before.png)

![After — the Review draft panel is open without the duplicate bar](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260813-0b7a42/draft-review-after.png)

[Before walkthrough — the base flow pauses on the Review draft action](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260813-0b7a42/terminal-draft-flow-before.webm)

[After walkthrough — the branch flow reaches review without the duplicate bar](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260813-0b7a42/terminal-draft-flow-after.webm)

Manually inspected: The before image shows Review draft open while Draft ready remains below the transcript. The after image shows the same panel with that bar absent. The walkthrough frames show the corresponding base and branch flows.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a6d7f66c7e1e3d3b2b4fe535ecbf66416d1c3273`
- Post-revert steps: Rerun the focused planning-terminal Playwright scenario.
- Data migration? No

</details>
