### PR TITLE
[CI regression: d19a0f4-playwright-1-of-9](2) Align visual proof with review state

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -835,9 +835,8 @@ test.describe('Visual proof capture', () => {
     await page.keyboard.press('Escape');
     await expect(page.getByTestId('invoker-terminal-expanded')).toHaveCount(0);
 
-    await expect(page.getByTestId('invoker-terminal-ready-bar')).toBeVisible();
-    await page.getByRole('button', { name: 'Review draft' }).click();
     await expect(page.getByRole('heading', { name: 'Review draft' })).toBeVisible();
+    await expect(page.getByTestId('invoker-terminal-ready-bar')).toHaveCount(0);
     await expect(page.getByTestId('draft-raw-yaml')).toContainText('name: Terminal Planned Flow');
     // planning-draft-locked-note is a net-new element; this spec also runs
     // against the pre-change base branch for before/after visual proof, where
@@ -970,9 +969,8 @@ test.describe('Visual proof capture', () => {
     await expect(page.getByRole('heading', { name: 'Planning chat' })).toBeVisible();
     await page.getByTestId('invoker-terminal-input').fill('Draft a plan to submit');
     await page.getByRole('button', { name: 'Send' }).click();
-    await expect(page.getByTestId('invoker-terminal-ready-bar')).toBeVisible();
-    await page.getByRole('button', { name: 'Review draft' }).click();
     await expect(page.getByRole('heading', { name: 'Review draft' })).toBeVisible();
+    await expect(page.getByTestId('invoker-terminal-ready-bar')).toHaveCount(0);
     await page.getByTestId('planning-create-workflow').click();
     await expect(page.getByRole('heading', { name: 'Planning chat' })).toBeVisible();
 
@@ -1283,8 +1281,8 @@ test.describe('Visual proof capture', () => {
     await expect(page.getByTestId('invoker-terminal-input')).toBeVisible();
     await page.getByTestId('invoker-terminal-input').fill('Draft a YAML plan for the Workers Surface');
     await page.getByRole('button', { name: 'Send' }).click();
-    await expect(page.getByTestId('invoker-terminal-ready-bar')).toBeVisible();
-    await page.getByRole('button', { name: 'Review draft' }).click();
+    await expect(page.getByRole('heading', { name: 'Review draft' })).toBeVisible();
+    await expect(page.getByTestId('invoker-terminal-ready-bar')).toHaveCount(0);
     await page.getByTestId('planning-create-workflow').click();
 
     const transcript = page.getByTestId('invoker-terminal-transcript');

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4591,12 +4591,12 @@ export function App() {
 
   const planningReadyCount = planningSessions.filter((session) => session.status === 'draft_ready').length;
   const submittedPlanningSessionCount = planningSessions.filter((session) => session.status === 'submitted').length;
+  const activeDraftReviewOpen = reviewDraftSessionId === activePlanningSession.id && Boolean(draftPlanSummary);
   const connectedAgentLabels = (systemDiagnostics?.tools ?? [])
     .filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed)
     .map((tool) => tool.name.replace(/\s+CLI$/i, ''));
 
   const renderPlanningContextPanel = (): JSX.Element => {
-    const reviewingDraft = reviewDraftSessionId === activePlanningSession.id && Boolean(draftPlanSummary);
     const draftTaskGroups = draftPlanSummary?.taskGroups ?? (
       draftPlanSummary ? [{ workflow: null, tasks: draftPlanSummary.steps }] : []
     );
@@ -4608,7 +4608,7 @@ export function App() {
       >
         <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border px-3 py-2.5">
           {!planningContextCollapsed && (
-            <h2 className="text-sm font-semibold text-foreground">{reviewingDraft ? 'Review draft' : 'Current plan'}</h2>
+            <h2 className="text-sm font-semibold text-foreground">{activeDraftReviewOpen ? 'Review draft' : 'Current plan'}</h2>
           )}
           <button
             type="button"
@@ -4621,7 +4621,7 @@ export function App() {
           </button>
         </div>
         {!planningContextCollapsed && (
-          reviewingDraft ? (
+          activeDraftReviewOpen ? (
             <div className="min-h-0 flex-1 space-y-4 overflow-y-auto overscroll-contain p-4 text-sm">
               <p data-testid="planning-draft-locked-note" className="text-xs text-muted-foreground">
                 This draft is locked — critique in chat, or ask Invoker to re-draft, to change it.
@@ -4840,6 +4840,7 @@ export function App() {
             presetOptions={planningPresetOptions}
             selectedConfirmationMode={selectedPlanningConfirmationMode}
             draftPlanAvailable={draftPlanAvailable}
+            draftReviewOpen={activeDraftReviewOpen}
             draftPlanSummary={draftPlanSummary}
             planningStream={activePlanningStream}
             readOnly={activePlanningReadOnly}

--- a/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
@@ -55,9 +55,9 @@ describe('CodeRabbit PR #3050 — draft state cleared after submit', () => {
     fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'draft the full plan' } });
     fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
 
-    await screen.findByTestId('invoker-terminal-ready-bar');
-    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
-    fireEvent.click(await screen.findByTestId('planning-create-workflow'));
+    await screen.findByTestId('planning-create-workflow');
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('planning-create-workflow'));
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });

--- a/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
@@ -49,9 +49,9 @@ describe('CodeRabbit PR #3050 — submitted planning stays read-only after start
 
     fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'draft the full plan' } });
     fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
-    await screen.findByTestId('invoker-terminal-ready-bar');
-    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
-    fireEvent.click(await screen.findByTestId('planning-create-workflow'));
+    await screen.findByTestId('planning-create-workflow');
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('planning-create-workflow'));
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1721,9 +1721,8 @@ describe('Invoker terminal (component)', () => {
 
     submitPlanningText('draft the full plan');
 
-    await waitFor(() => {
-      expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('Draft ready · Mock Plan · 2 tasks');
-    });
+    await screen.findByTestId('planning-create-workflow');
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
 
     expect(mock.api.planningChatSubmit).not.toHaveBeenCalled();
     expect(mock.api.startReady).not.toHaveBeenCalled();
@@ -1773,12 +1772,9 @@ describe('Invoker terminal (component)', () => {
 
     submitPlanningText('draft the Workers Surface plan');
 
-    await waitFor(() => {
-      expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('Draft ready · Workers Surface · 2 workflows · 4 tasks');
-    });
-
-    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
     await screen.findByTestId('planning-create-workflow');
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    expect(screen.getAllByTestId('draft-task-group')).toHaveLength(2);
     fireEvent.click(screen.getByTestId('planning-create-workflow'));
 
     await waitFor(() => {
@@ -1814,10 +1810,9 @@ describe('Invoker terminal (component)', () => {
     await openPlanningTerminal();
 
     submitPlanningText('draft the full plan');
-    await screen.findByTestId('invoker-terminal-ready-bar');
-
-    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
-    fireEvent.click(await screen.findByTestId('planning-create-workflow'));
+    await screen.findByTestId('planning-create-workflow');
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('planning-create-workflow'));
 
     expect(screen.getByTestId('planning-create-workflow')).toBeInTheDocument();
     expect(mock.api.refreshTaskGraph).not.toHaveBeenCalled();
@@ -1875,9 +1870,9 @@ describe('Invoker terminal (component)', () => {
     await openPlanningTerminal();
 
     submitPlanningText('draft the full plan');
-    await screen.findByTestId('invoker-terminal-ready-bar');
-    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
-    fireEvent.click(await screen.findByTestId('planning-create-workflow'));
+    await screen.findByTestId('planning-create-workflow');
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('planning-create-workflow'));
     await waitFor(() => expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' }));
 
     fireEvent.click(screen.getByTestId('sidebar-home'));

--- a/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
@@ -74,9 +74,9 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
     await openPlanningTerminal();
 
     submitPlanningText('draft the full plan');
-    await screen.findByTestId('invoker-terminal-ready-bar');
-    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
-    fireEvent.click(await screen.findByTestId('planning-create-workflow'));
+    await screen.findByTestId('planning-create-workflow');
+    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('planning-create-workflow'));
 
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -113,6 +113,7 @@ interface InvokerTerminalProps {
   presetOptions: PlanningPresetOptionView[];
   selectedConfirmationMode: PlanningConfirmationMode;
   draftPlanAvailable: boolean;
+  draftReviewOpen?: boolean;
   draftPlanSummary?: {
     name: string;
     taskCount: number;
@@ -535,6 +536,7 @@ export function InvokerTerminal({
   presetOptions,
   selectedConfirmationMode,
   draftPlanAvailable,
+  draftReviewOpen = false,
   draftPlanSummary,
   planningStream,
   readOnly = false,
@@ -901,7 +903,7 @@ export function InvokerTerminal({
             )}
           </div>
 
-          {draftPlanAvailable && !readOnly && (
+          {draftPlanAvailable && !draftReviewOpen && !readOnly && (
             <div
               data-testid="invoker-terminal-ready-bar"
               className="sticky bottom-0 z-10 border-t border-border bg-card/80 px-4 py-3.5 text-sm text-foreground backdrop-blur-sm"


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=d19a0f4af741226c3edb9509e2768529bf97fef9; job=playwright / 1-of-9 -->

Update the planning visual scenario to follow the open Review draft panel without clicking the retired terminal action.

The scenario also checks that the terminal draft-ready bar is absent during review.

## Review Claim

The visual scenario exercises the open draft-review state and checks that the terminal ready bar is absent.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the visual scenario changes; product behavior remains owned by the preceding stack slice.

## Slice Rationale

A separate proof-only slice keeps visual harness changes isolated from the activation-surface change.

## Non-goals

- No product code changes.
- No snapshot updates or unrelated visual scenario changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] On `origin/master`: `cd packages/app && CAPTURE_MODE=before CAPTURE_VIDEO=1 npx playwright test e2e/visual-proof.spec.ts --grep 'terminal planning loads graph' --output=/tmp/invoker-pr-proof-d19a0f4.4NWLzo/target-before-results`
- [x] On this stack tip: `cd packages/app && CAPTURE_MODE=after CAPTURE_VIDEO=1 npx playwright test e2e/visual-proof.spec.ts --grep 'terminal planning loads graph' --output=/tmp/invoker-pr-proof-d19a0f4.4NWLzo/target-after-results`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-1-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/visual-proof.spec.ts e2e/edit-task-command.spec.ts e2e/headless-thundering-herd.spec.ts e2e/launching-stall-watchdog.spec.ts e2e/embedded-terminal-pty.spec.ts e2e/keyboard-navigation.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — builds passed, then the local macOS run exited 254 because `xvfb-run` is unavailable.

</details>

## Visual Proof

![Before — the open Review draft panel still has a Draft ready bar](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260813-ead5a0/draft-review-before.png)

![After — the Review draft panel is open without the terminal ready bar](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260813-ead5a0/draft-review-after.png)

[Before walkthrough — the base flow pauses on the Review draft action](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260813-ead5a0/terminal-draft-flow-before.webm)

[After walkthrough — the stack tip reaches review without the terminal ready bar](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260813-ead5a0/terminal-draft-flow-after.webm)

Manually inspected: The before image shows Review draft open while Draft ready remains below the transcript. The after image shows the same panel with that bar absent. The walkthrough frames show the corresponding base and stack-tip flows.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 066c3f0ab615ac160668a09091e814d0f48914d5`
- Post-revert steps: None
- Data migration? No

</details>
