### PR TITLE
[CI regression: e73ee55-required-fast-merge-gate-concurrency-repro](1) Guard the libatomic1 fix with a policy assertion

### DIFF
--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -35,6 +35,18 @@ function jobForCheck(checkName) {
   return checkName.split(' / ')[0];
 }
 
+function stepIndex(job, stepName) {
+  return (job.steps ?? []).findIndex((step) => step.name === stepName);
+}
+
+function assertStepBefore(job, firstStepName, secondStepName, jobName) {
+  const firstIndex = stepIndex(job, firstStepName);
+  const secondIndex = stepIndex(job, secondStepName);
+  assert(firstIndex >= 0, `${jobName} must include "${firstStepName}"`);
+  assert(secondIndex >= 0, `${jobName} must include "${secondStepName}"`);
+  assert(firstIndex < secondIndex, `${jobName} must run "${firstStepName}" before "${secondStepName}"`);
+}
+
 for (const jobName of FULL_CI_JOBS) {
   assert(jobs[jobName], `Missing CI job ${jobName}`);
   assert(jobs[jobName].if === FULL_CI_GATE, `${jobName} must run only for full CI events`);
@@ -78,6 +90,29 @@ const uiVitestLibatomicIndex = uiVitestSteps.findIndex(
 assert(
   uiVitestLibatomicIndex >= 0 && uiVitestLibatomicIndex < uiVitestNodeSetupIndex,
   'ui-vitest must install libatomic1 before actions/setup-node@v4',
+);
+
+assert(jobs['required-fast-extra'], 'Missing required-fast-extra job');
+assert(jobs['required-fast-extra'].if === FULL_CI_GATE, 'required-fast-extra must run only for full CI events');
+assertStepBefore(
+  jobs['required-fast-extra'],
+  'Install system libraries for Node',
+  'Use Node.js ${{ env.NODE_VERSION }}',
+  'required-fast-extra',
+);
+const requiredFastExtraNodeLibraryStep = jobs['required-fast-extra'].steps.find(
+  (step) => step.name === 'Install system libraries for Node',
+);
+assert(
+  String(requiredFastExtraNodeLibraryStep?.run ?? '').includes('libatomic1'),
+  'required-fast-extra must install libatomic1 before setup-node so Node 26 can start on self-hosted runners',
+);
+const requiredFastExtraEntries = jobs['required-fast-extra'].strategy?.matrix?.include ?? [];
+const mergeGateConcurrencyEntry = requiredFastExtraEntries.find((entry) => entry.name === 'Merge Gate Concurrency Repro');
+assert(mergeGateConcurrencyEntry, 'required-fast-extra matrix must include Merge Gate Concurrency Repro');
+assert(
+  mergeGateConcurrencyEntry.runner_label === 'Runner_2_4_core',
+  'Merge Gate Concurrency Repro must run on the core runner, not the smaller Runner_1 host that missed Node runtime libraries',
 );
 
 assert(jobs.docker, 'Missing docker job');


### PR DESCRIPTION
## Summary

CI job `required-fast / Merge Gate Concurrency Repro` failed on default-branch commit e73ee552a6e174a85fc6107186bb802b32ec4b6e because Node could not load `libatomic.so.1` on the runner.

That defect was already fixed on master by installing `libatomic1` for every `required-fast-extra` matrix entry before Node setup.

This change adds policy assertions that pin that fix in place. It checks the install step runs before Node setup, includes `libatomic1`, and the job stays on the core runner.

Without this guard, a future edit could silently drop the install step or move the job back. CI would not catch it until the job failed again.

## Review Claim

Approve adding CI policy assertions that lock in the existing `libatomic1`/runner-label fix for `required-fast / Merge Gate Concurrency Repro`, with no other changes.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice only adds assertions to `scripts/test-ci-workflow-merge-queue-policy.mjs`. It does not edit `.github/workflows/ci.yml` or any product file, so it cannot change CI or app behavior; it can only fail loudly if a later change reintroduces the regression.

## Slice Rationale

One policy slice: new assertions that guard the already-fixed CI job's configuration, kept separate from the workflow YAML itself and from any product code.

## Non-goals

Does not modify `.github/workflows/ci.yml` or any other CI workflow file.

Does not change any package source, build, or runtime behavior.

Does not re-fix the regression; the underlying fix already landed on master in #8988.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
