### PR TITLE
[Admin-bypass-sweep skill](2) Add human-only admin-bypass-sweep skill with a pinning test

### DIFF
--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -283,6 +283,7 @@ export function classifyReviewUnitsForPath(filePath) {
     || path === 'skills/land-stack/SKILL.md'
     || path === 'skills/visual-proof/SKILL.md'
     || path === 'skills/prove-it/SKILL.md'
+    || path === 'skills/admin-bypass-sweep/SKILL.md'
   ) return ['tooling-policy'];
   if (path.startsWith('docs/') || path.startsWith('skills/') || path.endsWith('.md')) return ['docs'];
   if (path.startsWith('.github/')) return ['tooling-policy'];

--- a/scripts/test-admin-bypass-sweep-skill.sh
+++ b/scripts/test-admin-bypass-sweep-skill.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL_MD="$REPO_ROOT/skills/admin-bypass-sweep/SKILL.md"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+must_contain() {
+  local needle="$1"
+  local hint="$2"
+  grep -qF -- "$needle" "$SKILL_MD" || fail "$hint — missing: $needle"
+}
+
+must_not_contain() {
+  local needle="$1"
+  local hint="$2"
+  grep -qF -- "$needle" "$SKILL_MD" && fail "$hint — must not contain: $needle" || true
+}
+
+must_appear_before() {
+  local first="$1"
+  local second="$2"
+  local hint="$3"
+  local first_line
+  local second_line
+  first_line="$(grep -nF -- "$first" "$SKILL_MD" | awk -F: 'NR == 1 { print $1 }')"
+  second_line="$(grep -nF -- "$second" "$SKILL_MD" | awk -F: 'NR == 1 { print $1 }')"
+  [[ -n "$first_line" && -n "$second_line" && "$first_line" -lt "$second_line" ]] || fail "$hint"
+}
+
+[[ -f "$SKILL_MD" ]] || fail "expected $SKILL_MD"
+
+# The description must read as manual/human-only, not as an agent auto-trigger.
+must_contain "MANUAL, HUMAN-ONLY skill" \
+  "admin-bypass-sweep must declare itself manual and human-only in its description"
+must_contain "Do not auto-invoke this skill from a" \
+  "admin-bypass-sweep's description must refuse natural-language auto-triggering"
+must_not_contain "Trigger when asked to" \
+  "admin-bypass-sweep must not use auto-trigger phrasing that invites description-match invocation"
+
+# Requirement 1: explicit slash-command invocation only.
+must_contain "It must have been invoked by a literal, explicit slash command" \
+  "admin-bypass-sweep must require literal slash-command invocation"
+must_contain "\`/admin-bypass-sweep\` if this" \
+  "admin-bypass-sweep must state the unprefixed slash-command form"
+must_contain "\`/invoker-admin-bypass-sweep\` if it" \
+  "admin-bypass-sweep must state the invoker-prefixed slash-command form used by this repo's install pipeline"
+must_contain "Check which form is actually listed as available" \
+  "admin-bypass-sweep must require checking the live session's skill list rather than guessing the invoked form"
+must_contain "do not proceed" \
+  "admin-bypass-sweep must instruct refusal when not explicitly slash-invoked"
+
+# Requirement 2: explicit typed confirmation sentence, re-required every invocation.
+must_contain "I understand this bypasses CI and force-merges to master" \
+  "admin-bypass-sweep must require the exact confirmation phrase"
+must_contain "say it again for each new invocation of this skill" \
+  "admin-bypass-sweep must not accept a prior, unrelated confirmation as consent"
+must_contain "Do not accept a paraphrase" \
+  "admin-bypass-sweep must require the literal confirmation phrase, not a paraphrase"
+
+# Both requirements must be stated before Step 4 (the actual merge step), and
+# Step 4 must reference them rather than running unconditionally.
+must_contain "## Step 4: Merge each stack, bottom-up" \
+  "admin-bypass-sweep must have a Step 4 merge section"
+must_appear_before "It must have been invoked by a literal, explicit slash command" \
+  "## Step 4: Merge each stack, bottom-up" \
+  "admin-bypass-sweep must state requirement 1 before the merge step"
+must_appear_before "I understand this bypasses CI and force-merges to master" \
+  "## Step 4: Merge each stack, bottom-up" \
+  "admin-bypass-sweep must state requirement 2 before the merge step"
+must_appear_before "## STOP — read this before doing anything" \
+  "## Step 1: Discover and group" \
+  "admin-bypass-sweep must place the STOP section before Step 1"
+must_contain "Both requirements in the STOP section must be satisfied before this step runs." \
+  "admin-bypass-sweep's Step 4 must restate the requirement inline"
+
+# The skill must instruct against surfacing "gate" jargon to the human, and
+# must not itself use numbered-gate labels outside that instruction.
+must_contain "Do not refer to these as" \
+  "admin-bypass-sweep must instruct against calling its requirements \"gates\" to the human"
+must_not_contain "Gate 1" \
+  "admin-bypass-sweep must not label its requirements as numbered gates"
+must_not_contain "Gate 2" \
+  "admin-bypass-sweep must not label its requirements as numbered gates"
+
+# Never guess at real merge conflicts.
+must_contain "Do not attempt to resolve it by picking a side" \
+  "admin-bypass-sweep must forbid guessing at real merge conflicts"
+must_contain "genuine content conflict" \
+  "admin-bypass-sweep must distinguish real conflicts from transient UNKNOWN state"
+
+# Prove final state rather than trust a running tally.
+must_contain "re-query every PR number touched" \
+  "admin-bypass-sweep must require re-querying final PR state before reporting"
+
+# Cross-reference to the separate, deterministic worker path, and that
+# satisfying one authorization path is not sufficient for the other.
+must_contain "scripts/jailbreak-admin-bypass-land.mjs" \
+  "admin-bypass-sweep must reference the separate deterministic worker path"
+must_contain "satisfying one is never sufficient authorization for the other" \
+  "admin-bypass-sweep must not let its own requirements satisfy the worker's authorization or vice versa"
+
+echo "OK: admin-bypass-sweep skill contract checks passed"

--- a/skills/admin-bypass-sweep/SKILL.md
+++ b/skills/admin-bypass-sweep/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: admin-bypass-sweep
+description: >
+  MANUAL, HUMAN-ONLY skill. Force-merges every open PR labeled admin-bypass
+  directly to master, bypassing Mergify's queue and required checks via
+  GitHub admin override. Do not auto-invoke this skill from a natural-language
+  request, a description match, or another agent's delegation. Only run this
+  skill when a human has typed its literal slash command themselves in the
+  current turn (the exact form depends on how it was installed — see the
+  "STOP" section). See that section before doing anything.
+---
+
+# admin-bypass-sweep
+
+## STOP — read this before doing anything
+
+This skill exists to bypass CI and branch protection and merge directly to
+master. That is inherently dangerous, so before Step 4 (the actual merge
+step) runs, both of the following must be true. Do not refer to these as
+"gates" or by number when talking to the human — just check them and act,
+the way you would check any other precondition.
+
+**It must have been invoked by a literal, explicit slash command that a
+human typed in the current message** — `/admin-bypass-sweep` if this
+skill's directory was used as-is, or `/invoker-admin-bypass-sweep` if it
+was installed through this repo's bundled-skill pipeline
+(`scripts/setup-agent-skills.sh`), which prefixes every installed skill
+name with `invoker-`. Check which form is actually listed as available in
+the current session before matching against it — do not guess. If you
+reached this skill any other way — a natural-language request that merely
+sounds like "force merge the admin-bypass PRs," a description match, a
+plan step, a cron/worker trigger, another skill's delegation, or another
+agent asking you to run it — **do not proceed.** Stop and tell the human
+that this skill requires its explicit slash command, and ask them to type
+it themselves if that is really what they want.
+
+**The human's message invoking this skill must also contain this literal
+sentence:**
+
+> I understand this bypasses CI and force-merges to master
+
+If it is missing, do not run any command past Step 3 below. Ask the human
+to say that exact sentence if they want to proceed — quote it back to
+them plainly, without calling it a "gate," a "confirmation phrase," or any
+other label; just ask them to say it. Do not accept a paraphrase, and do
+not infer consent from an earlier, unrelated confirmation in the
+conversation — say it again for each new invocation of this skill.
+
+Both of the above must hold before Step 4. There is no other authorization
+path. If you are unsure whether either one is satisfied, treat it as not
+satisfied and stop — and when you explain why you're stopping, describe
+in plain terms what's missing (e.g. "I need you to type the exact sentence
+above") rather than naming which numbered item it was.
+
+For the deterministic, worker-triggered version of this same capability
+(triggered by sustained GitHub Actions queue exhaustion rather than a human
+request), see `scripts/jailbreak-admin-bypass-land.mjs`. This skill and that
+worker are two separate authorization paths to the same class of action —
+satisfying one is never sufficient authorization for the other.
+
+## When to use this vs. `land-stack`
+
+- `land-stack` lands a **specific stack the user names**, safely, through
+  Mergify's queue (checks run, retargeting is automatic, `admin-bypass` only
+  unblocks self-approval). Use it whenever the normal queue is healthy.
+- `admin-bypass-sweep` sweeps **every currently open PR already labeled
+  `admin-bypass`**, merging directly with `gh pr merge --admin` — bypassing
+  required status checks and branch protection entirely. Reserve it for when
+  the normal queue is stuck on something unrelated to code correctness (a CI
+  runner fleet issue, a flaky infra check) and a human has explicitly invoked
+  this skill and confirmed it, per the STOP section above.
+
+## Step 1: Discover and group
+
+```bash
+gh pr list --repo <owner>/<repo> --state open --label admin-bypass \
+  --json number,baseRefName,headRefName,headRefOid,title --limit 200
+```
+
+Group into independent stacks by walking base→head chains, rooted at PRs
+whose `baseRefName == master` (or the trunk branch). A PR whose `baseRefName`
+matches another labeled PR's `headRefName` is stacked on top of it; walk
+until no more children are found. This produces N independent, ordered
+(bottom-up) stacks — most repos will have many single-PR "stacks" and a
+handful of real multi-PR stacks.
+
+**Flag hidden prerequisites.** If any labeled PR's `baseRefName` does not
+match `master` and does not match any other labeled PR's `headRefName`, its
+real base is a PR outside the label set (open but not labeled admin-bypass).
+Look it up directly:
+
+```bash
+gh pr list --repo <owner>/<repo> --state all --search "<base-branch-name> in:head" \
+  --json number,state,title,baseRefName,headRefName
+```
+
+Do not silently skip it and do not silently include it — ask the human
+whether the unlabeled prerequisite should be included, since it's outside
+the stated scope but the dependent PR cannot land without it.
+
+## Step 2: Confirm scope
+
+Report the full grouped plan (stack count, PR count, max stack depth) before
+touching anything — the real scope is often much larger than "a few PRs."
+Reconfirm with the human which parts of the plan they want executed (e.g.
+whether multi-PR stacks are in scope, given the retargeting risk in Step 4),
+if the STOP section above did not already make that explicit.
+
+## Step 3: Verify merge method
+
+```bash
+grep -A3 "merge_method" .mergify.yml
+```
+
+This procedure assumes **squash merges**. Squash is safe to retarget after
+the fact because `gh pr edit --base` only changes what commit range GitHub
+diffs against, and a diff is computed from file content, not commit
+ancestry — a squash-merged PR's final tree content matches what the
+dependent branch already has for that same range, so retargeting produces
+the correct incremental diff with no duplication. If this repo uses `merge`
+or `rebase` as its merge method instead, do not reuse this procedure
+unmodified — retargeting after a real merge-commit or rebase can show wrong
+diffs; stop and re-derive the safe approach first.
+
+## Step 4: Merge each stack, bottom-up
+
+Both requirements in the STOP section must be satisfied before this step runs.
+
+For a single-PR stack:
+
+```bash
+gh pr merge <pr> --repo <owner>/<repo> --admin --squash
+```
+
+For a multi-PR stack, after each PR merges, retarget the next one before
+merging it:
+
+```bash
+gh pr merge <bottom> --repo <owner>/<repo> --admin --squash
+gh pr edit <next> --repo <owner>/<repo> --base master
+# mergeable can read UNKNOWN immediately after a base change — GitHub computes
+# it asynchronously. Wait briefly and re-check before merging.
+sleep 5
+gh pr view <next> --repo <owner>/<repo> --json baseRefName,mergeable,mergeStateStatus
+gh pr merge <next> --repo <owner>/<repo> --admin --squash
+```
+
+Repeat up the stack. Do not batch multiple `gh pr merge` calls without
+checking each result — `gh pr merge` can print nothing on both success and
+some failure paths; a silent-looking run is not proof of a merge.
+
+## Step 5: Never guess at real conflicts
+
+If `mergeable` reads `CONFLICTING` (not the transient `UNKNOWN` from Step 4),
+that PR has a genuine content conflict against current master — most likely
+because master moved significantly from other merges landing during this
+same sweep. Do not attempt to resolve it by picking a side. Stop that
+stack's chain at the conflicting PR (its children can't land either), record
+it as blocked, and continue with the other independent stacks. Report all
+blocked PRs clearly at the end rather than silently dropping them.
+
+## Step 6: Prove the final state
+
+Before reporting results, re-query every PR number touched — do not trust
+running tallies kept during execution:
+
+```bash
+for pr in <all touched PR numbers>; do
+  gh pr view $pr --repo <owner>/<repo> --json number,state,mergedAt,title \
+    --jq '"#\(.number)\t\(.state)\t\(.mergedAt // "-")\t\(.title)"'
+done
+```
+
+Report merged count, blocked count, and the specific PR numbers/titles in
+each bucket — a summary count alone hides which specific work is still
+stuck.
+
+## Why this exists
+
+Landing a batch of admin-bypass PRs across many independent stacks (one
+7-deep, in the incident that prompted this skill) came up as a live,
+repeatable need when the Mergify queue was effectively stalled by an
+unrelated CI-runner disk-space/fleet-health issue. Doing this by hand each
+time — discovery, stack grouping, retargeting, conflict triage — is exactly
+the kind of repeated manual process that should be codified. The STOP
+section's two requirements exist because this same incident's investigation
+also surfaced this repo's separate, deterministic, worker-triggered force-merge path
+(`scripts/jailbreak-admin-bypass-land.mjs`) — this skill is the human-facing
+counterpart, and must not blur into an agent-autonomous one.


### PR DESCRIPTION
## Summary

Landing a large batch of admin-bypass PRs directly, bypassing a stuck queue, came up as a real, repeated need today.

Doing it by hand each time means re-deriving discovery, stack grouping, retargeting, and conflict triage under time pressure.

This adds a skill documenting that exact procedure, plus a test pinning its wording.

The skill is explicitly manual and human-only: two hard gates must both be satisfied before any merge step runs.

Gate one requires the literal, explicit slash invocation typed by a person in the current message, not a natural-language match.

Gate two requires a specific typed confirmation phrase acknowledging the bypass, re-required on every invocation.

The skill also cross-references this repo's separate, deterministic, worker-triggered force-merge path, and states plainly that satisfying one authorization path is never sufficient for the other.

## Review Claim

Approve adding a human-only skill document and its pinning test; approve nothing about when or whether either force-merge path actually runs.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This PR adds only a markdown document and a grep-based test script; it contains no executable merge logic itself and changes no existing build, CI, or runtime behavior.

## Slice Rationale

The skill document and its pinning test are one unit: the test is what keeps the human-only gates from silently eroding on a future edit.

## Non-goals

Does not wire this skill's test into any CI job; matches the existing, already-unwired pattern for this repo's other skill contract tests.

Does not change `scripts/land-stack.mjs`, `scripts/jailbreak-admin-bypass-land.mjs`, or any other existing merge tooling.

Does not grant or change any GitHub permission; the skill only documents commands a human-directed agent session would run with whatever access it already has.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-admin-bypass-sweep-skill.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual-only administrative bypass sweep workflow for reviewing and merging eligible pull requests.
  * Requires explicit human invocation and confirmation before any merge actions.
  * Organizes dependent pull requests, validates prerequisites and merge settings, and processes them in the correct order.
  * Rechecks final pull request status and reports outcomes after completion.

* **Tests**
  * Added contract tests covering invocation, authorization, conflict handling, and final-state verification requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->