### PR TITLE
[Admin-bypass-sweep skill](1) Classify the admin-bypass-sweep skill as tooling-policy

### DIFF
--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -283,6 +283,7 @@ export function classifyReviewUnitsForPath(filePath) {
     || path === 'skills/land-stack/SKILL.md'
     || path === 'skills/visual-proof/SKILL.md'
     || path === 'skills/prove-it/SKILL.md'
+    || path === 'skills/admin-bypass-sweep/SKILL.md'
   ) return ['tooling-policy'];
   if (path.startsWith('docs/') || path.startsWith('skills/') || path.endsWith('.md')) return ['docs'];
   if (path.startsWith('.github/')) return ['tooling-policy'];


### PR DESCRIPTION
## Summary

A new skill document and its own pinning test naturally sort into different review units under the current path-based classifier.

Every existing skill that ships with a test already has an explicit exception in the classifier for exactly this reason.

This adds the next skill's document to that same allowlist, nothing else.

## Review Claim

Approve adding one path to an existing allowlist; approve nothing about the skill this unblocks, which ships separately.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change is a single new string literal in an existing array; it narrows nothing else this classifier already covers and cannot affect any other file's classification.

## Slice Rationale

This has to land before the skill and test it unblocks, since the classifier trusts only the already-merged copy of its own rules when checking a PR — a PR cannot widen its own allowed scope.

## Non-goals

Does not add, remove, or change any other entry in the existing exception list.

Does not touch the skill document or test this unblocks; those ship in the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node -e "import('./scripts/review-unit-rules.mjs').then(m => console.log(m.classifyReviewUnitsForPath('skills/admin-bypass-sweep/SKILL.md')))"` prints `[ 'tooling-policy' ]`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
