### PR TITLE
[Slack Plan Review Card](1) Fix silent Slack plan-review card posting failures

### DIFF
--- a/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
@@ -279,6 +279,157 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
       await adapter.close();
     });
 
+    it('surfaces a visible error and fires a lobby alert when the YAML upload fails during auto-stage', async () => {
+      const adapter = await SQLiteAdapter.create(':memory:');
+      const slackPlanDraftRepo = new SlackPlanDraftRepository(adapter);
+      const slackSessionRepo = new SlackSessionRepository(adapter);
+      surface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
+        workingDir: '/tmp/repo',
+        botToken: 'xoxb-test',
+        appToken: 'xapp-test',
+        signingSecret: 'test-secret',
+        channelId: 'C-test',
+        anthropicApiKey: 'test-anthropic-key',
+        slackPlanDraftRepo,
+        slackSessionRepo,
+        conversationalPlanning: true,
+      });
+
+      const planText = 'name: "Debug Issue"\ntasks:\n  - id: t1\n    description: "Run the debugger"\n    dependencies: []\n';
+      mockSendMessage.mockResolvedValue('Here is the drafted plan.');
+      mockLastTurnDraftPlanText = planText;
+      mockPlanConversation.conversationMode = 'plan';
+
+      const app = surface.getApp() as any;
+      app.client.files.uploadV2.mockRejectedValueOnce(new Error('missing_scope'));
+
+      await surface.start(async (cmd) => {
+        receivedCommands.push(cmd);
+      });
+
+      const mentionHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')?.handler;
+      const say = vi.fn().mockImplementation(async ({ text }) => {
+        const ts = `${Date.now()}.${Math.random().toString(36).substr(2, 6)}`;
+        apiCalls.push({ method: 'postMessage', channel: 'C-test', text, ts });
+        return { ts, ok: true };
+      });
+
+      await mentionHandler({
+        event: { text: '<@UBOT123456> create a plan for me', ts: '2222.001', thread_ts: undefined, user: 'U123' },
+        say,
+      });
+
+      const errorReply = apiCalls.find((c) => c.text?.includes('I hit an error trying to prepare the plan review card'));
+      expect(errorReply).toBeTruthy();
+      expect(errorReply?.text).toContain('missing_scope');
+
+      const alertPost = apiCalls.find((c) => c.text?.includes('Plan review card failed to post'));
+      expect(alertPost).toBeTruthy();
+
+      mockPlanConversation.conversationMode = 'agent';
+      await adapter.close();
+    });
+
+    it('stays silent during auto-stage when the turn is not draft-ready yet', async () => {
+      const adapter = await SQLiteAdapter.create(':memory:');
+      const slackPlanDraftRepo = new SlackPlanDraftRepository(adapter);
+      const slackSessionRepo = new SlackSessionRepository(adapter);
+      surface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
+        workingDir: '/tmp/repo',
+        botToken: 'xoxb-test',
+        appToken: 'xapp-test',
+        signingSecret: 'test-secret',
+        channelId: 'C-test',
+        anthropicApiKey: 'test-anthropic-key',
+        slackPlanDraftRepo,
+        slackSessionRepo,
+        conversationalPlanning: true,
+      });
+
+      mockSendMessage.mockResolvedValue('Still thinking about your request.');
+      mockLastTurnDraftPlanText = 'not a real yaml plan';
+      mockPlanConversation.conversationMode = 'plan';
+
+      await surface.start(async (cmd) => {
+        receivedCommands.push(cmd);
+      });
+
+      const app = surface.getApp() as any;
+      const mentionHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')?.handler;
+      const say = vi.fn().mockImplementation(async ({ text }) => {
+        const ts = `${Date.now()}.${Math.random().toString(36).substr(2, 6)}`;
+        apiCalls.push({ method: 'postMessage', channel: 'C-test', text, ts });
+        return { ts, ok: true };
+      });
+
+      await mentionHandler({
+        event: { text: '<@UBOT123456> create a plan for me', ts: '3333.001', thread_ts: undefined, user: 'U123' },
+        say,
+      });
+
+      expect(apiCalls.some((c) => c.text?.includes('error trying to prepare'))).toBe(false);
+      expect(apiCalls.some((c) => c.text?.includes('Plan review card failed to post'))).toBe(false);
+      expect(slackPlanDraftRepo.getReady('C-test', '3333.001')).toBeFalsy();
+
+      mockPlanConversation.conversationMode = 'agent';
+      await adapter.close();
+    });
+
+    it('surfaces a visible error on the explicit /plan path when the YAML upload fails', async () => {
+      const adapter = await SQLiteAdapter.create(':memory:');
+      const slackPlanDraftRepo = new SlackPlanDraftRepository(adapter);
+      const slackSessionRepo = new SlackSessionRepository(adapter);
+      surface = new SlackSurface({
+        defaultRepoUrl: 'https://github.com/example/repo.git',
+        workingDir: '/tmp/repo',
+        botToken: 'xoxb-test',
+        appToken: 'xapp-test',
+        signingSecret: 'test-secret',
+        channelId: 'C-test',
+        anthropicApiKey: 'test-anthropic-key',
+        slackPlanDraftRepo,
+        slackSessionRepo,
+      });
+
+      const planText = 'name: "Debug Issue"\ntasks:\n  - id: t1\n    description: "Run the debugger"\n    dependencies: []\n';
+      mockSendMessage.mockResolvedValue('Sure, let me look into it.');
+      mockRunPlanConversion.mockResolvedValue('Here is the plan.');
+      mockLastTurnDraftPlanText = planText;
+
+      const app = surface.getApp() as any;
+      app.client.files.uploadV2.mockRejectedValueOnce(new Error('missing_scope'));
+
+      await surface.start(async (cmd) => {
+        receivedCommands.push(cmd);
+      });
+
+      const mentionHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')?.handler;
+      const say = vi.fn().mockImplementation(async ({ text }) => {
+        const ts = `${Date.now()}.${Math.random().toString(36).substr(2, 6)}`;
+        apiCalls.push({ method: 'postMessage', channel: 'C-test', text, ts });
+        return { ts, ok: true };
+      });
+
+      await mentionHandler({
+        event: { text: '<@UBOT123456> create a plan for me', ts: '4444.001', thread_ts: undefined, user: 'U123' },
+        say,
+      });
+
+      await mentionHandler({
+        event: { text: '<@UBOT123456> /plan', ts: '4444.5', thread_ts: '4444.001', user: 'U123' },
+        say,
+      });
+
+      const errorReply = apiCalls.find((c) => c.text?.includes('I hit an error trying to prepare the plan review card'));
+      expect(errorReply).toBeTruthy();
+      expect(errorReply?.text).toContain('missing_scope');
+      expect(errorReply?.text).toContain('An operator needs to look at draft');
+
+      await adapter.close();
+    });
+
     it('replies to a literal `plan:` mention as normal agent text and clears the Processing ack', async () => {
       surface = new SlackSurface({
         defaultRepoUrl: 'https://github.com/example/repo.git',

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -191,6 +191,18 @@ export type LocalRequest =
   | { kind: 'agent'; text: string }
   | { kind: 'change'; text: string };
 
+export class PlanDraftPostingError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'PlanDraftPostingError';
+  }
+}
+
+type StageDraftReviewResult =
+  | { staged: true }
+  | { staged: false; reason: 'not_ready' | 'no_context' }
+  | { staged: false; reason: 'posting_error'; message: string; draftId: string };
+
 type AlertSurfaceEvent = Extract<SurfaceEvent, { type: 'alert' }>;
 
 function normalizeAlertSurfaceEvent(event: AlertSurfaceEvent): AlertSurfaceEvent {
@@ -1304,7 +1316,13 @@ export class SlackSurface implements Surface {
       return;
     }
     const plannerOutput = await conversation.runPlanConversion();
-    await this.stageDraftReviewFromPlannerOutput(plannerOutput, conversation, channel, threadTs, userId, say, { silentWhenNotReady: false });
+    const result = await this.stageDraftReviewFromPlannerOutput(plannerOutput, conversation, channel, threadTs, userId, say, { silentWhenNotReady: false });
+    if (result.staged === false && result.reason === 'posting_error') {
+      await this.sayWithRateLimitRetry(say, {
+        text: `I hit an error trying to prepare the plan review card: ${result.message}. An operator needs to look at draft ${result.draftId}.`,
+        thread_ts: threadTs,
+      });
+    }
   }
 
   private async stageDraftReviewFromPlannerOutput(
@@ -1315,8 +1333,8 @@ export class SlackSurface implements Surface {
     userId: string,
     say: SayFn,
     opts: { silentWhenNotReady: boolean },
-  ): Promise<void> {
-    if (!this.slackPlanDraftRepo) return;
+  ): Promise<StageDraftReviewResult> {
+    if (!this.slackPlanDraftRepo) return { staged: false, reason: 'not_ready' };
     const review = preparePlanningReview({
       plannerOutput,
       extractDraftPlanText: () => conversation.lastTurnDraftPlanText,
@@ -1326,20 +1344,20 @@ export class SlackSurface implements Surface {
       if (!opts.silentWhenNotReady) {
         await this.sayWithRateLimitRetry(say, { text: review.reply, thread_ts: threadTs });
       }
-      return;
+      return { staged: false, reason: 'not_ready' };
     }
     const draftReview = review;
     const context = this.loadPlanningContext(threadTs);
     if (!context?.repoUrl || !context.workingDir) {
       if (opts.silentWhenNotReady) {
         this.log('slack', 'warn', `[DRAFT_STAGE] Skipped staging draft for thread ${threadTs}: no pinned repository context.`);
-        return;
+        return { staged: false, reason: 'no_context' };
       }
       await this.sayWithRateLimitRetry(say, {
         text: 'This thread has no pinned repository context. Start a new thread with the repository selected.',
         thread_ts: threadTs,
       });
-      return;
+      return { staged: false, reason: 'no_context' };
     }
     const normalizedPlanText = this.normalizeDraftedPlanRepoUrl(draftReview.planText, context.repoUrl);
     const normalizedSummary = summarizePlanText(normalizedPlanText) ?? draftReview.summary;
@@ -1356,15 +1374,25 @@ export class SlackSurface implements Surface {
     });
     try {
       await this.postSlackPlanDraft(draft, normalizedSummary, say);
+      return { staged: true };
     } catch (error) {
       // The draft row already exists at this point and postSlackPlanDraft has
-      // already surfaced the failure by updating the Slack message in place,
-      // so this must not propagate: letting it reach the button handler's
-      // catch would restore the pending confirmation and offer "click
-      // Approve to retry", which re-runs this whole method and creates a
+      // already surfaced the failure by updating the Slack message in place.
+      // Returning a result here (instead of throwing) matters: a caller that
+      // offers a retry button must not treat this as a fresh, unhandled
+      // failure to re-arm -- re-running this method on retry would create a
       // second, orphaned draft instead of reconciling the one that exists.
-      this.log('slack', 'error', `Posting plan draft ${draft.draftId}:${draft.version} failed: ${error instanceof Error ? error.message : String(error)}`);
-      return;
+      const message = error instanceof Error ? error.message : String(error);
+      this.log('slack', 'error', `Posting plan draft ${draft.draftId}:${draft.version} failed: ${message}`);
+      await this.handleEvent({
+        type: 'alert',
+        severity: 'critical',
+        source: 'slack-plan-draft',
+        subject: draft.draftId,
+        message: `Plan review card failed to post: ${message}`,
+        alertKey: `plan-draft-post-failed:${draft.draftId}`,
+      });
+      return { staged: false, reason: 'posting_error', message, draftId: draft.draftId };
     }
   }
 
@@ -1705,7 +1733,7 @@ export class SlackSurface implements Surface {
       thread_ts: draft.threadTs,
       blocks: this.planDraftBlocks(summary, draft, 'plain'),
     });
-    if (!posted?.ts) throw new Error('Slack did not return a timestamp for the plan review message.');
+    if (!posted?.ts) throw new PlanDraftPostingError('Slack did not return a timestamp for the plan review message.');
     this.slackPlanDraftRepo.bindMessage(draft, posted.ts);
     try {
       const upload = await this.app.client.files.uploadV2({
@@ -1727,13 +1755,14 @@ export class SlackSurface implements Surface {
         this.planDraftBlocks(summary, draft, 'ready'),
       );
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       await this.app.client.chat.update({
         channel: draft.channelId,
         ts: posted.ts,
-        text: `Plan review could not attach YAML: ${error instanceof Error ? error.message : String(error)}`,
+        text: `Plan review could not attach YAML: ${message}`,
         blocks: [],
       });
-      throw error;
+      throw new PlanDraftPostingError(message, { cause: error });
     }
   }
 
@@ -2996,8 +3025,14 @@ ${text}`;
 
       if (this.conversationalPlanning && conversation.conversationMode === 'plan' && conversation.lastTurnDraftPlanText) {
         try {
-          await this.stageDraftReviewFromPlannerOutput(reply, conversation, channel, threadTs,
+          const stageResult = await this.stageDraftReviewFromPlannerOutput(reply, conversation, channel, threadTs,
             planIntentContext?.userId ?? 'unknown', say, { silentWhenNotReady: true });
+          if (stageResult.staged === false && stageResult.reason === 'posting_error') {
+            await this.sayWithRateLimitRetry(say, {
+              text: `I hit an error trying to prepare the plan review card: ${stageResult.message}.`,
+              thread_ts: threadTs,
+            });
+          }
         } catch (err) {
           this.log('slack', 'error', `[DRAFT_STAGE] failed to stage conversational draft thread_ts=${threadTs}: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
         }


### PR DESCRIPTION
## Summary

A Slack plan-review card sometimes silently failed to post. The bot would say a plan was "staged" while no Approve/Cancel card ever appeared.

Root cause: a real posting failure (the YAML upload to Slack throwing) was swallowed identically to the normal "draft isn't ready yet" case. Both looked like silence to the caller.

`stageDraftReviewFromPlannerOutput` now returns a typed result instead of throwing, so callers can tell a genuine posting failure apart from the routine not-ready state.

A genuine failure now posts a visible error in the Slack thread, and also fires an existing-but-previously-unused alert pipeline so it reaches the lobby channel.

## Review Claim

Approve that a genuine plan-review-card posting failure is now always visible (in-thread error + lobby alert), while the deliberate protection against a second Approve click creating a second orphaned draft is preserved.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

A real posting failure can never again be silently swallowed for any caller (auto-stage conversational path or explicit `/plan` path). The `lobby_plan_for_execution` button path (`startPlanIntent` → `handleExplicitPlanAction`) still cannot create a second, orphaned draft row as a side effect of surfacing this error, because `stageDraftReviewFromPlannerOutput` returns a result instead of throwing — so the button handler's own catch (which re-offers the Approve button for another click) is never triggered by a posting failure.

## Slice Rationale

Single, self-contained fix to one silent-failure code path plus its regression tests. Not bundled with unrelated Slack surface work.

## Non-goals

Does not change the alert-cooldown mechanism itself, does not add a new Slack channel for alerts (reuses the existing lobby channel), and does not change how the YAML attachment is posted (still a separate follow-up message from the card).

## Architecture

### Before

```mermaid
graph TD
    A["postSlackPlanDraft throws on upload failure"] --> B["stageDraftReviewFromPlannerOutput catches, logs, returns silently"]
    B --> C["handleConversationMessage: nothing posted to thread"]
    B --> D["handleExplicitPlanAction: nothing posted to thread"]
```

### After

```mermaid
graph TD
    A["postSlackPlanDraft throws PlanDraftPostingError on upload failure"] --> B["stageDraftReviewFromPlannerOutput catches, logs, fires lobby alert, returns {staged:false, reason:'posting_error'}"]
    B --> C["handleConversationMessage: posts visible error in-thread"]
    B --> D["handleExplicitPlanAction: posts visible error in-thread"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/surfaces && pnpm test`
- [x] Live end-to-end against a real Slack workspace: switched `slack-manager` from the DO1 production droplet to a local build with this fix, started a real plan conversation in the lobby, confirmed a real Approve/Cancel card posted, clicked Approve, confirmed a real workflow (`wf-1786664150285-4`) was submitted and started — verified via the Slack API (`conversations.replies`) showing the card message's real `edited` timestamp and the resulting "Workflow ... is running" message.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
