### PR TITLE
[CI regression: 631a0d0-required-fast-guardrails](3) Bundle Slack bug scan into Electron output

### DIFF
--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     '@invoker/execution-engine',
     '@invoker/planning-core',
     '@invoker/shell',
+    '@invoker/slack-bug-scan',
     'yaml',
   ],
   clean: true,


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=631a0d08c7072e9544813fc1b93fb616586ce441; job=required-fast / Guardrails -->

CI job `required-fast / Guardrails` first failed on default-branch push commit 631a0d08c7072e9544813fc1b93fb616586ce441 in run 31620499765.

It remained red through e73ee552a6e174a85fc6107186bb802b32ec4b6e in run 31629955741.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31620499765/job/94234217679

The Electron app now bundles its Slack bug reporting workspace package so the built headless entry point can load it at runtime.

## Review Claim

The Electron build bundles the Slack bug reporting workspace package so headless startup can load it at runtime.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

The existing functional guard already proves this bundling boundary, so this slice contains only the required one-line activation change.

## Non-goals

- No Slack bug-scan behavior or public API changes.
- No app entry-point changes.
- No unrelated dependency changes or cleanup.
- No test or guard weakening.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node packages/app/scripts/verify-noexternal-completeness.cjs`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/05-delete-all-prod-db-guard.sh && bash scripts/test-suites/required/06-large-file-guardrail.sh && bash scripts/test-suites/required/07-invalid-config-json.sh && bash scripts/test-suites/required/08-build-artifact-surfaces-guard.sh && bash scripts/test-suites/required/09-headless-cli-boots-smoke.sh && bash scripts/test-suites/required/10-dag-background-click-noop-guard.sh && bash scripts/test-suites/required/15-owner-boundary-policy.sh && bash scripts/test-suites/required/50-verify-executor-routing.sh && bash scripts/test-suites/required/51-verify-scratch-execution.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert 1ea9d1e100db06cbfef1c73908f355c51b7ba75f`
- Post-revert steps: Rerun `required-fast / Guardrails`.
- Data migration? No.

</details>
