### PR TITLE
Stop @Invoker restart from spawning a duplicate owner-serve

### DIFF
--- a/packages/app/src/owner-split-brain.ts
+++ b/packages/app/src/owner-split-brain.ts
@@ -13,7 +13,12 @@ import { IpcBus } from '@invoker/transport';
 
 export const OWNER_SPLIT_BRAIN_PREFIX = '[owner-split-brain]';
 
-const DEFAULT_PROBE_TIMEOUT_MS = 2_000;
+// Must stay >= the slack-manager watchdog's own owner-ping patience
+// (pingTimeoutMs in packages/slack-manager/src/index.ts) -- a shorter value
+// here means a merely-slow-but-alive owner can fail this probe even though
+// the watchdog itself would still consider it healthy, misclassifying it as
+// split-brain and spawning a redundant competing owner.
+const DEFAULT_PROBE_TIMEOUT_MS = 10_000;
 
 export interface OwnerPingAnswer {
   ok?: boolean;

--- a/packages/slack-manager/src/__tests__/invoker-client.test.ts
+++ b/packages/slack-manager/src/__tests__/invoker-client.test.ts
@@ -266,6 +266,7 @@ describe('IpcInvokerClient', () => {
 
     const result = await client.launch({ force: true });
     expect(terminatePid).not.toHaveBeenCalled();
+    expect(spawnInvoker).not.toHaveBeenCalled();
     expect(result.healthy).toBe(true);
   });
 

--- a/packages/slack-manager/src/invoker-client.ts
+++ b/packages/slack-manager/src/invoker-client.ts
@@ -363,8 +363,9 @@ export class IpcInvokerClient implements InvokerClient {
         this.log('warn', `launch throttled — only ${Math.round(sinceLast / 1000)}s since last launch`);
         return { healthy: false, cause: 'throttled' };
       }
-    } else {
-      await this.forceReclaimSplitBrainHolder();
+    } else if (await this.forceReclaimSplitBrainHolder()) {
+      this.lockReadUnknownStreak = 0;
+      return { healthy: true };
     }
     if (await this.doLaunch()) {
       this.lockReadUnknownStreak = 0;
@@ -403,17 +404,21 @@ export class IpcInvokerClient implements InvokerClient {
    * Safety invariant: only explicit force restarts reach here, the holder is
    * re-confirmed unreachable after a fresh ping, and the signal is SIGTERM so
    * the holder's lock release() and shutdown cleanup still run.
+   *
+   * Returns true when the owner turned out to already be alive (nothing to
+   * reclaim) -- the caller must skip launching a new instance in that case,
+   * or it duplicates a healthy owner.
    */
-  private async forceReclaimSplitBrainHolder(): Promise<void> {
-    if (await this.ping()) return;
+  private async forceReclaimSplitBrainHolder(): Promise<boolean> {
+    if (await this.ping()) return true;
     const holder = this.detectUnreachableLockHolder();
-    if (holder.status !== 'unreachable') return;
+    if (holder.status !== 'unreachable') return false;
     const holderPid = holder.pid;
     this.log('warn', `force restart: writer lock held by unreachable PID ${holderPid} — sending SIGTERM`);
     try {
       this.terminatePid(holderPid);
     } catch {
-      return;
+      return false;
     }
     const deadline = this.now() + 10_000;
     while (this.now() < deadline && this.isPidAlive(holderPid)) {
@@ -422,6 +427,7 @@ export class IpcInvokerClient implements InvokerClient {
     if (this.isPidAlive(holderPid)) {
       this.log('error', `force restart: PID ${holderPid} did not exit within 10s of SIGTERM`);
     }
+    return false;
   }
 
   subscribe(channel: string, handler: (message: unknown) => void): () => void {


### PR DESCRIPTION
## Summary

`@Invoker restart` could spawn a second owner-serve process even while the original was alive and answering IPC, because a confirmation deep in the call chain never reached its caller.

That produced two processes fighting over the same SQLite writer lock -- high CPU, a stuck state, and a confusing "database is locked by a live PID" message.

This fixes the caller to stand down once the owner is confirmed alive. It also raises a mismatched probe timeout that made the same slowness look like a crash to a competing process.

## Review Claim

Approve that a restart/relaunch attempt against an alive, IPC-responsive owner never spawns a second owner-serve process.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The genuine-recovery path is unchanged: when the lock holder is truly unreachable, `forceReclaimSplitBrainHolder` still SIGTERMs it and the caller still launches a fresh instance -- covered by the existing test at `packages/slack-manager/src/__tests__/invoker-client.test.ts:229` ("force launch SIGTERMs a re-confirmed unreachable lock holder before respawning"), which still passes unchanged.

## Slice Rationale

Single, self-contained fix for one reproduced bug: the missing early-return in the forced-restart launch path, plus the timeout mismatch that made the same root symptom (a slow-but-alive owner) look like a hard failure to a second process.

## Non-goals

Does not change the unforced watchdog relaunch path, which already had a correct ping-success early return. Does not add a pre-spawn liveness check to `invoker-launcher.ts`'s `spawnInvoker` itself -- the fix is centralized at the one call site that was missing it.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Reproduced first: added `expect(spawnInvoker).not.toHaveBeenCalled()` to the existing test and confirmed it failed on unmodified code (spawnInvoker was called once despite the owner answering IPC).
- [x] `cd packages/slack-manager && pnpm test` -- 66/66 pass after the fix, including the now-passing repro assertion and the unchanged genuine-recovery test.
- [x] `cd packages/app && pnpm test` -- 1966/1974 pass; the 5 pre-existing failures are all in `in-app-planner.test.ts` / `restore-planning-chat-conversational-mode.repro.test.ts` (conversational-planning prompt text), unrelated files not touched by this diff.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
