### PR TITLE
[CI Repair Spend Hygiene](1) Preserve CI-watcher attempt/backoff history across a flaky-job flap

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -52,6 +52,18 @@ export const FLEET_EVENT_THRESHOLD = parsePositiveInteger(
   3,
 );
 export const ATTEMPT_BACKOFF_BASE_MS = 30 * 60 * 1000;
+/**
+ * How long a job's attempt/backoff/occurrence history survives after CI
+ * reports it green, before a later red observation is treated as a brand
+ * new regression. Without this, one green run on a flaky job (one that
+ * flaps pass/fail on the same underlying defect) wipes `attempts` back to
+ * 0, handing it a fresh attempt budget every flap and defeating the cap
+ * in `shouldFileFailure`.
+ */
+export const RECOVERY_COOLDOWN_MS = parseNonNegativeInteger(
+  process.env.INVOKER_CI_WATCH_RECOVERY_COOLDOWN_MS,
+  24 * 60 * 60 * 1000,
+);
 
 const STATE_DIR = process.env.INVOKER_CI_WATCH_STATE_DIR
   ?? process.env.INVOKER_E2E_WATCH_STATE_DIR
@@ -223,7 +235,27 @@ export function reconcileCiRun(state, run) {
     if (classification === 'ok') {
       okJobs += 1;
       headRecord.jobs[jobName] = { ...baseObservation, state: 'ok' };
-      delete normalized.activeFailures[jobName];
+      const existing = normalized.activeFailures[jobName];
+      const lastFiledMs = existing?.lastFiledAt ? new Date(existing.lastFiledAt).getTime() : NaN;
+      const observedAtMs = baseObservation.observedAt ? new Date(baseObservation.observedAt).getTime() : NaN;
+      const withinRecoveryCooldown = existing
+        && Number.isFinite(lastFiledMs)
+        && Number.isFinite(observedAtMs)
+        && (observedAtMs - lastFiledMs) < RECOVERY_COOLDOWN_MS;
+      // A flaky job can report green once and then red again shortly after
+      // on the same underlying defect. Keep attempts/occurrences/lastFiledAt
+      // through the cooldown so that flap resumes the existing backoff
+      // instead of starting over; getActionableFailures excludes it via
+      // lastObservedState while it reads as currently green.
+      if (withinRecoveryCooldown) {
+        normalized.activeFailures[jobName] = {
+          ...existing,
+          ...normalizeActiveFailure(existing, jobName),
+          lastObservedState: 'ok',
+        };
+      } else {
+        delete normalized.activeFailures[jobName];
+      }
       continue;
     }
 
@@ -241,6 +273,7 @@ export function reconcileCiRun(state, run) {
           lastJobUrl: job.url ?? '',
           lastObservedAt: baseObservation.observedAt,
           occurrences: Number(existing.occurrences ?? 1) + 1,
+          lastObservedState: 'broken',
         };
       } else {
         normalized.activeFailures[jobName] = {
@@ -259,6 +292,7 @@ export function reconcileCiRun(state, run) {
           attempts: 0,
           lastFiledAt: null,
           needsHuman: false,
+          lastObservedState: 'broken',
         };
       }
       continue;
@@ -277,6 +311,10 @@ export function getActionableFailures(state) {
   const normalized = normalizeState(state);
   return Object.values(normalized.activeFailures)
     .filter((failure) => failure && typeof failure.jobName === 'string' && typeof failure.firstBadSha === 'string')
+    // Retained during the post-recovery cooldown (see reconcileCiRun) purely
+    // to preserve attempt/backoff history for a possible flap back to red;
+    // CI currently reports it passing, so it is not actionable right now.
+    .filter((failure) => failure.lastObservedState !== 'ok')
     .sort((a, b) => {
       const runDelta = Number(a.firstBadRunId ?? 0) - Number(b.firstBadRunId ?? 0);
       if (runDelta !== 0) return runDelta;

--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -4,12 +4,15 @@ import {
   buildCiJobDefinitions,
   buildMarker,
   fileBugfixPlan,
+  getActionableFailures,
   groupFailuresBySha,
   jobNameIsMapped,
   loadEmptyState,
   liveQueryHasNonTerminalWork,
   normalizeState,
   processFailureFilingSweep,
+  reconcileCiRun,
+  RECOVERY_COOLDOWN_MS,
 } from './e2e-regression-watch.mjs';
 
 function makeFailure(overrides = {}) {
@@ -555,5 +558,108 @@ describe('retired CI job filing gate', () => {
     assert.equal(counts.groupsNeedingHuman, 1);
     assert.equal(state.activeFailures[key].retired, false);
     assert.equal(state.activeFailures[key].needsHuman, true);
+  });
+});
+
+function makeRun({ headSha, jobName, conclusion, databaseId, jobDatabaseId, createdAt }) {
+  return {
+    headSha,
+    headBranch: 'master',
+    databaseId,
+    createdAt,
+    jobs: [
+      {
+        name: jobName,
+        status: 'completed',
+        conclusion,
+        databaseId: jobDatabaseId,
+        url: `https://example.test/job/${jobDatabaseId}`,
+        completedAt: createdAt,
+      },
+    ],
+  };
+}
+
+describe('reconcileCiRun flaky-job flap handling', () => {
+  const jobName = 'playwright / launch-dispatch-stuck-lease';
+  const sha = 'a5d6b3e626ace9e963e924c0de9410dc0302de9e';
+
+  it('reproduces the bug: a single green run used to wipe attempts/occurrences before a flap back to red', () => {
+    // This is the historical (pre-fix) behavior this test guards against: a
+    // job filed twice (attempts: 2) goes green once -- CI flakiness, not a
+    // real fix -- then red again 10 minutes later. The watcher must not
+    // hand it a brand-new 3-attempt budget for what is still the same
+    // unresolved regression.
+    const state = stateWithFailure(makeFailure({
+      jobName,
+      firstBadSha: sha,
+      lastBadSha: sha,
+      occurrences: 40,
+      attempts: 2,
+      lastFiledAt: '2026-08-13T20:00:00.000Z',
+    }));
+
+    reconcileCiRun(state, makeRun({
+      headSha: sha, jobName, conclusion: 'success',
+      databaseId: 101, jobDatabaseId: 201, createdAt: '2026-08-13T20:05:00.000Z',
+    }));
+    reconcileCiRun(state, makeRun({
+      headSha: sha, jobName, conclusion: 'failure',
+      databaseId: 102, jobDatabaseId: 202, createdAt: '2026-08-13T20:15:00.000Z',
+    }));
+
+    const failure = state.activeFailures[jobName];
+    assert.ok(failure, 'failure record must survive the flap, not disappear');
+    assert.equal(failure.attempts, 2, 'attempts must be preserved across a same-defect flap');
+    assert.equal(failure.occurrences, 41, 'occurrences should accumulate, not reset to 1');
+  });
+
+  it('does not re-file work for a job currently reporting green during its recovery cooldown', () => {
+    const state = stateWithFailure(makeFailure({
+      jobName,
+      firstBadSha: sha,
+      lastBadSha: sha,
+      attempts: 1,
+      lastFiledAt: '2026-08-13T20:00:00.000Z',
+    }));
+
+    reconcileCiRun(state, makeRun({
+      headSha: sha, jobName, conclusion: 'success',
+      databaseId: 101, jobDatabaseId: 201, createdAt: '2026-08-13T20:05:00.000Z',
+    }));
+
+    assert.ok(state.activeFailures[jobName], 'record kept for cooldown bookkeeping');
+    assert.deepEqual(
+      getActionableFailures(state).map((f) => f.jobName),
+      [],
+      'a job CI currently reports green must not be filed again while its record is retained',
+    );
+  });
+
+  it('still clears attempts/occurrences once the job has stayed green past the recovery cooldown', () => {
+    const state = stateWithFailure(makeFailure({
+      jobName,
+      firstBadSha: sha,
+      lastBadSha: sha,
+      occurrences: 40,
+      attempts: 2,
+      lastFiledAt: '2026-08-13T20:00:00.000Z',
+    }));
+
+    reconcileCiRun(state, makeRun({
+      headSha: sha, jobName, conclusion: 'success',
+      databaseId: 101, jobDatabaseId: 201,
+      createdAt: new Date(new Date('2026-08-13T20:00:00.000Z').getTime() + RECOVERY_COOLDOWN_MS + 1000).toISOString(),
+    }));
+
+    assert.equal(state.activeFailures[jobName], undefined, 'a durably green job should still clear its history');
+
+    reconcileCiRun(state, makeRun({
+      headSha: 'f'.repeat(40), jobName, conclusion: 'failure',
+      databaseId: 103, jobDatabaseId: 203, createdAt: '2026-08-20T00:00:00.000Z',
+    }));
+
+    assert.equal(state.activeFailures[jobName].attempts, 0, 'a genuinely new regression starts with a fresh budget');
+    assert.equal(state.activeFailures[jobName].occurrences, 1);
   });
 });


### PR DESCRIPTION
## Summary

A CI job can flap green-then-red-again on the same underlying defect instead of ever being truly fixed.

The watcher used to wipe its whole attempt history the instant it saw one green run, handing that job a fresh 3-attempt budget on every flap.

That defeated the existing attempt cap: a flaky job could get re-diagnosed by a full agent session on every flap, indefinitely.

This slice keeps the attempt/occurrence history through a 24h cooldown window, so a flap back to red resumes the existing backoff instead of starting over.

## Review Claim

Approve that `reconcileCiRun`'s green-observation branch preserves attempt/occurrence history through a cooldown window instead of always deleting it, and that `getActionableFailures` correctly excludes a currently-green job during that window.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the failure record's own attempt/occurrence bookkeeping changes; no other job's record, no live workflow dispatch, and no GitHub API call is touched by this slice.

## Slice Rationale

This is the narrowest fix for the flap-reset defect on its own, independent of the separate stale-observation and circuit-breaker fixes stacked on top of it.

## Non-goals

Does not change what counts as a mapped or stale job. Does not touch the auto-fix worker or any pause/circuit-breaker mechanism.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --test scripts/e2e-regression-watch.test.mjs` — 24/24 pass, including the new `reconcileCiRun flaky-job flap handling` suite (repro run against the pre-fix logic first, confirmed failing, then passing after the fix)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
