### PR TITLE
[CI Repair Spend Hygiene](2) Retire CI-watcher failures CI stops reporting on instead of re-filing them forever

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -64,6 +64,24 @@ export const RECOVERY_COOLDOWN_MS = parseNonNegativeInteger(
   process.env.INVOKER_CI_WATCH_RECOVERY_COOLDOWN_MS,
   24 * 60 * 60 * 1000,
 );
+/**
+ * A job CI hasn't reported on (green or red) in this long is presumed
+ * renamed, removed, or otherwise no longer produced by the current
+ * workflow -- most concretely, a job kept "mapped" only by a
+ * LEGACY_PLAYWRIGHT_JOB_ALIASES-style compatibility shim after a shard
+ * rename. Such a job can never again resolve itself via a real 'ok'
+ * observation in reconcileCiRun, so the filing sweep retires it instead of
+ * re-filing repairs against it forever.
+ */
+export const STALE_OBSERVATION_MS = parseNonNegativeInteger(
+  process.env.INVOKER_CI_WATCH_STALE_OBSERVATION_MS,
+  3 * 24 * 60 * 60 * 1000,
+);
+
+export function isObservationStale(failure, nowMs, staleMs = STALE_OBSERVATION_MS) {
+  const observedMs = failure?.lastObservedAt ? new Date(failure.lastObservedAt).getTime() : NaN;
+  return Number.isFinite(observedMs) && (nowMs - observedMs) > staleMs;
+}
 
 const STATE_DIR = process.env.INVOKER_CI_WATCH_STATE_DIR
   ?? process.env.INVOKER_E2E_WATCH_STATE_DIR
@@ -907,6 +925,7 @@ export function processFailureFilingSweep(state, {
     groupsNeedingHuman: 0,
     groupsInBackoff: 0,
     groupsRetired: prepared.retiredFleetMembers.length,
+    groupsRetiredStale: 0,
     groupsCorrelated: prepared.groupsCorrelated,
   };
 
@@ -915,7 +934,15 @@ export function processFailureFilingSweep(state, {
       counts.groupsRetired += 1;
       markFailureRetired(state, failure, true);
       save(state);
-      onRetired(failure);
+      onRetired(failure, 'unmapped');
+      continue;
+    }
+    if (isObservationStale(failure, nowMs)) {
+      counts.groupsRetired += 1;
+      counts.groupsRetiredStale += 1;
+      markFailureRetired(state, failure, true);
+      save(state);
+      onRetired(failure, 'stale-observation');
       continue;
     }
     const attemptGate = shouldFileFailure(failure, { nowMs, maxAttempts });
@@ -1001,8 +1028,11 @@ export async function main() {
     onNeedsHuman: (failure, attemptGate) => {
       console.error(`ci-regression-watch: failure key "${buildMarker(failure.firstBadSha, failure.jobName)}" reached attempt cap (${attemptGate.attempts}); needs human review`);
     },
-    onRetired: (failure) => {
-      console.error(`ci-regression-watch: failure key "${buildMarker(failure.firstBadSha, failure.jobName)}" has no mapped local verify command; marking retired and skipping filing`);
+    onRetired: (failure, reason) => {
+      const detail = reason === 'stale-observation'
+        ? `CI has not reported this job in either direction for over ${Math.round(STALE_OBSERVATION_MS / 86_400_000)}d (last observed ${failure.lastObservedAt}); presumed renamed or removed`
+        : 'has no mapped local verify command';
+      console.error(`ci-regression-watch: failure key "${buildMarker(failure.firstBadSha, failure.jobName)}" ${detail}; marking retired and skipping filing`);
     },
   });
 

--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -6,6 +6,7 @@ import {
   fileBugfixPlan,
   getActionableFailures,
   groupFailuresBySha,
+  isObservationStale,
   jobNameIsMapped,
   loadEmptyState,
   liveQueryHasNonTerminalWork,
@@ -13,6 +14,7 @@ import {
   processFailureFilingSweep,
   reconcileCiRun,
   RECOVERY_COOLDOWN_MS,
+  STALE_OBSERVATION_MS,
 } from './e2e-regression-watch.mjs';
 
 function makeFailure(overrides = {}) {
@@ -661,5 +663,72 @@ describe('reconcileCiRun flaky-job flap handling', () => {
 
     assert.equal(state.activeFailures[jobName].attempts, 0, 'a genuinely new regression starts with a fresh budget');
     assert.equal(state.activeFailures[jobName].occurrences, 1);
+  });
+});
+
+describe('stale-observation retirement', () => {
+  const jobName = 'playwright / launch-dispatch-stuck-lease';
+
+  it('isObservationStale is false just inside the window and true just past it', () => {
+    const lastObservedAt = '2026-08-06T01:21:00.000Z';
+    const lastObservedMs = new Date(lastObservedAt).getTime();
+    assert.equal(
+      isObservationStale({ lastObservedAt }, lastObservedMs + STALE_OBSERVATION_MS - 1),
+      false,
+    );
+    assert.equal(
+      isObservationStale({ lastObservedAt }, lastObservedMs + STALE_OBSERVATION_MS + 1),
+      true,
+    );
+  });
+
+  it('reproduces the bug: a job kept "mapped" by a legacy alias, but never re-observed by CI, gets filed forever', () => {
+    // Models LEGACY_PLAYWRIGHT_JOB_ALIASES: jobDefinitions has a real,
+    // permanent entry for a job CI stopped producing after a shard rename
+    // (the incident: no run reported this job, green or red, for 8+ days,
+    // yet the watcher kept dispatching real "diagnose and fix" agents).
+    const jobDefinitions = jobDefinitionsFor([jobName]);
+    const state = stateWithFailure(makeFailure({
+      jobName,
+      occurrences: 66,
+      attempts: 2,
+      lastFiledAt: '2026-08-14T00:20:38.634Z',
+      lastObservedAt: '2026-08-06T01:21:00.000Z',
+    }));
+    const filed = [];
+
+    const counts = processFailureFilingSweep(state, {
+      now: new Date('2026-08-14T01:00:00.000Z'),
+      jobDefinitions,
+      liveQuery: () => false,
+      fileFailure: (failure) => filed.push(failure.jobName),
+    });
+
+    assert.deepEqual(filed, [], 'a job CI has not reported on in either direction must not be re-filed');
+    assert.equal(counts.groupsRetiredStale, 1);
+    assert.equal(counts.groupsFiled, 0);
+    assert.equal(state.activeFailures[jobName].retired, true);
+  });
+
+  it('still files normally for a mapped job CI observed recently', () => {
+    const jobDefinitions = jobDefinitionsFor([jobName]);
+    const state = stateWithFailure(makeFailure({
+      jobName,
+      attempts: 0,
+      lastFiledAt: null,
+      lastObservedAt: '2026-08-13T23:00:00.000Z',
+    }));
+    const filed = [];
+
+    const counts = processFailureFilingSweep(state, {
+      now: new Date('2026-08-14T01:00:00.000Z'),
+      jobDefinitions,
+      liveQuery: () => false,
+      fileFailure: (failure) => filed.push(failure.jobName),
+    });
+
+    assert.deepEqual(filed, [jobName]);
+    assert.equal(counts.groupsRetiredStale, 0);
+    assert.equal(state.activeFailures[jobName].retired, false);
   });
 });


### PR DESCRIPTION
## Summary

A CI job's name can stop existing after a shard rename, but a compatibility alias can keep it looking mapped forever.

CI then never again reports that job, green or red, so the watcher's failure record for it can never resolve on its own.

Before this slice, that meant the sweep kept dispatching real "diagnose and fix" agents against it, forever.

This slice retires any failure CI has not reported on, in either direction, for 3+ days, the same way an unmapped job already gets retired.

## Review Claim

Approve that `processFailureFilingSweep` retires a failure whose `lastObservedAt` is older than the staleness window, before ever reaching the attempt/backoff gate.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Retirement only sets the existing `retired` flag on that one failure record and stops future filing for it; it does not touch any live workflow, does not delete history, and a human can always re-open the underlying CI job as a fresh incident.

## Slice Rationale

Builds directly on the flap-reset cooldown slice below it (same file, same reconcile/sweep functions) but is a separate, independently reviewable behavior: staleness-based retirement rather than flap-tolerant attempt bookkeeping.

## Non-goals

Does not change the compatibility-alias mechanism itself. Does not touch the auto-fix worker or any pause/circuit-breaker mechanism.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --test scripts/e2e-regression-watch.test.mjs` — 27/27 pass, including the new `stale-observation retirement` suite (repro run against the pre-fix logic first, confirmed failing, then passing after the fix)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
