### PR TITLE
[CI Repair Spend Hygiene](3) Add usage-limit failure classification and a fleet-wide auto-fix pause breaker

### DIFF
--- a/packages/execution-engine/src/__tests__/auto-fix-circuit-breaker-integration.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-circuit-breaker-integration.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import type { TaskState } from '@invoker/workflow-core';
+
+import { createAutoFixAttemptLedger } from '../auto-fix-attempt-ledger.js';
+import { createAutoFixRecoveryTick } from '../auto-fix-recovery.js';
+import { loadCircuitBreakerState, isCircuitBreakerPaused, tripCircuitBreaker } from '../auto-fix-circuit-breaker.js';
+
+const logger = {
+  info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn(), child: vi.fn(),
+};
+
+function makeFailedTask(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id: 'wf-1/build',
+    description: 'build',
+    status: 'failed',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: 'wf-1', command: 'pnpm build', ...(config ?? {}) },
+    execution: {
+      generation: 2,
+      selectedAttemptId: 'attempt-1',
+      branch: 'feature/build',
+      error: 'AssertionError: expected 1 to be 2',
+      ...(execution ?? {}),
+    },
+    taskStateVersion: 7,
+    ...rest,
+  } as TaskState;
+}
+
+function makeStore(tasks: TaskState[]) {
+  const byId = new Map(tasks.map((t) => [t.id, t]));
+  return {
+    listWorkflows: () => [{ id: 'wf-1' }],
+    loadTasks: () => tasks,
+    loadTask: (taskId: string) => byId.get(taskId),
+    listWorkflowMutationIntents: () => [],
+    logEvent: vi.fn(),
+    getWorkerAction: vi.fn(() => undefined),
+    upsertWorkerAction: vi.fn((action) => ({ ...action, attemptCount: 1 })),
+  };
+}
+
+describe('auto-fix circuit breaker integration', () => {
+  let dir: string;
+  let circuitBreakerPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'invoker-autofix-breaker-'));
+    circuitBreakerPath = join(dir, 'auto-fix-pause.json');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reproduces the bug: a usage-limit failure on one task does not stop an UNRELATED failed task from being dispatched the same tick', async () => {
+    // Before this fix, FailureClassifier had no usage-limit category and
+    // auto-fix-recovery had no circuit breaker: this task would consume its
+    // own attempt budget on a certain-to-fail retry, and every OTHER failed
+    // task in the system kept getting dispatched normally, fleet-wide,
+    // until the shared provider quota was gone.
+    const usageLimitTask = makeFailedTask({
+      id: 'wf-1/usage-limited',
+      execution: {
+        generation: 2, selectedAttemptId: 'a1', branch: 'x',
+        error: "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage "
+          + 'to purchase more credits or try again at Aug 20th, 2026 4:36 AM.',
+      },
+    });
+    const unrelatedTask = makeFailedTask({ id: 'wf-1/unrelated' });
+    const submitted: string[] = [];
+    const submitter = { submit: vi.fn((_wf, _prio, _channel, args: unknown[]) => { submitted.push(args[0] as string); return 1; }) };
+    const store = makeStore([usageLimitTask, unrelatedTask]);
+
+    const tick = createAutoFixRecoveryTick({
+      store, submitter, logger,
+      attemptLedger: createAutoFixAttemptLedger(),
+      defaultAutoFixRetries: 3,
+      circuitBreakerPath,
+      circuitBreakerPauseMs: 60 * 60 * 1000,
+    });
+
+    await tick({} as any);
+
+    expect(submitted).not.toContain('wf-1/usage-limited');
+    // The point of the circuit breaker, not just per-task classification:
+    // the sibling task must ALSO be blocked in this same tick.
+    expect(submitted).not.toContain('wf-1/unrelated');
+
+    const state = loadCircuitBreakerState(circuitBreakerPath);
+    expect(state.reason).toBe('usage-limit');
+    expect(isCircuitBreakerPaused(state, Date.now())).toBe(true);
+  });
+
+  it('an unrelated failed task dispatches normally once the pause window has elapsed', async () => {
+    tripCircuitBreaker(circuitBreakerPath, {
+      now: new Date(Date.now() - 2 * 60 * 60 * 1000),
+      reason: 'usage-limit',
+      pauseMs: 60 * 60 * 1000, // already expired
+    });
+    const unrelatedTask = makeFailedTask({ id: 'wf-1/unrelated' });
+    const submitted: string[] = [];
+    const submitter = { submit: vi.fn((_wf, _prio, _channel, args: unknown[]) => { submitted.push(args[0] as string); return 1; }) };
+    const store = makeStore([unrelatedTask]);
+
+    const tick = createAutoFixRecoveryTick({
+      store, submitter, logger,
+      attemptLedger: createAutoFixAttemptLedger(),
+      defaultAutoFixRetries: 3,
+      circuitBreakerPath,
+    });
+
+    await tick({} as any);
+
+    expect(submitted).toContain('wf-1/unrelated');
+  });
+
+  it('dispatches normally with no pause file at all', async () => {
+    const unrelatedTask = makeFailedTask({ id: 'wf-1/unrelated' });
+    const submitted: string[] = [];
+    const submitter = { submit: vi.fn((_wf, _prio, _channel, args: unknown[]) => { submitted.push(args[0] as string); return 1; }) };
+    const store = makeStore([unrelatedTask]);
+
+    const tick = createAutoFixRecoveryTick({
+      store, submitter, logger,
+      attemptLedger: createAutoFixAttemptLedger(),
+      defaultAutoFixRetries: 3,
+      circuitBreakerPath,
+    });
+
+    await tick({} as any);
+
+    expect(submitted).toContain('wf-1/unrelated');
+  });
+});

--- a/packages/execution-engine/src/__tests__/auto-fix-circuit-breaker.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-fix-circuit-breaker.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  clearCircuitBreaker,
+  isCircuitBreakerPaused,
+  loadCircuitBreakerState,
+  tripCircuitBreaker,
+} from '../auto-fix-circuit-breaker.js';
+
+describe('auto-fix circuit breaker', () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'invoker-circuit-breaker-'));
+    path = join(dir, 'auto-fix-pause.json');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reports not paused when no pause file exists', () => {
+    const state = loadCircuitBreakerState(path);
+    expect(isCircuitBreakerPaused(state, Date.now())).toBe(false);
+  });
+
+  it('tripping the breaker pauses until the window elapses, then resumes', () => {
+    const now = new Date('2026-08-14T06:00:00.000Z');
+    tripCircuitBreaker(path, { now, reason: 'usage-limit', pauseMs: 6 * 60 * 60 * 1000 });
+
+    const state = loadCircuitBreakerState(path);
+    expect(state.reason).toBe('usage-limit');
+    expect(isCircuitBreakerPaused(state, now.getTime() + 1000)).toBe(true);
+    expect(isCircuitBreakerPaused(state, now.getTime() + 6 * 60 * 60 * 1000 + 1)).toBe(false);
+  });
+
+  it('a later trip re-arms the window from its own time, not the first trip', () => {
+    const first = new Date('2026-08-14T06:00:00.000Z');
+    tripCircuitBreaker(path, { now: first, reason: 'usage-limit', pauseMs: 60 * 60 * 1000 });
+
+    const second = new Date('2026-08-14T06:50:00.000Z');
+    tripCircuitBreaker(path, { now: second, reason: 'usage-limit', pauseMs: 60 * 60 * 1000 });
+
+    const state = loadCircuitBreakerState(path);
+    // Still "paused" at the first window's original expiry, because the
+    // second failure (still inside that window) re-armed it further out.
+    expect(isCircuitBreakerPaused(state, first.getTime() + 60 * 60 * 1000 + 1000)).toBe(true);
+    expect(isCircuitBreakerPaused(state, second.getTime() + 60 * 60 * 1000 + 1000)).toBe(false);
+  });
+
+  it('clearCircuitBreaker lets a human override the pause immediately', () => {
+    tripCircuitBreaker(path, { now: new Date(), reason: 'usage-limit', pauseMs: 24 * 60 * 60 * 1000 });
+    clearCircuitBreaker(path);
+
+    const state = loadCircuitBreakerState(path);
+    expect(isCircuitBreakerPaused(state, Date.now())).toBe(false);
+  });
+
+  it('does not treat a corrupt pause file as paused', () => {
+    writeFileSync(path, '{ this is not valid json');
+    const state = loadCircuitBreakerState(path);
+    expect(isCircuitBreakerPaused(state, Date.now())).toBe(false);
+  });
+});

--- a/packages/execution-engine/src/auto-fix-circuit-breaker.ts
+++ b/packages/execution-engine/src/auto-fix-circuit-breaker.ts
@@ -1,0 +1,72 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+export interface CircuitBreakerState {
+  pausedUntil: string | null;
+  reason: string | null;
+  triggeredAt: string | null;
+}
+
+const EMPTY_STATE: CircuitBreakerState = { pausedUntil: null, reason: null, triggeredAt: null };
+
+export function defaultCircuitBreakerPath(): string {
+  return process.env.INVOKER_AUTO_FIX_PAUSE_FILE
+    ?? join(homedir(), '.invoker', 'auto-fix-pause.json');
+}
+
+export function loadCircuitBreakerState(path: string): CircuitBreakerState {
+  if (!existsSync(path)) return { ...EMPTY_STATE };
+  try {
+    const raw = JSON.parse(readFileSync(path, 'utf8'));
+    return {
+      pausedUntil: typeof raw?.pausedUntil === 'string' ? raw.pausedUntil : null,
+      reason: typeof raw?.reason === 'string' ? raw.reason : null,
+      triggeredAt: typeof raw?.triggeredAt === 'string' ? raw.triggeredAt : null,
+    };
+  } catch {
+    // A corrupt or half-written pause file must not itself become a reason
+    // to keep dispatching agents; treat it as "not paused" rather than throw.
+    return { ...EMPTY_STATE };
+  }
+}
+
+export function saveCircuitBreakerState(path: string, state: CircuitBreakerState): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(state, null, 2));
+}
+
+export function isCircuitBreakerPaused(state: CircuitBreakerState, nowMs: number): boolean {
+  if (!state.pausedUntil) return false;
+  const untilMs = new Date(state.pausedUntil).getTime();
+  return Number.isFinite(untilMs) && nowMs < untilMs;
+}
+
+export interface TripCircuitBreakerOptions {
+  now?: Date;
+  reason: string;
+  pauseMs: number;
+}
+
+/**
+ * Trip the breaker for `pauseMs` from `now`. Called again while already
+ * paused, this re-arms the pause window from the new failure -- the
+ * generic reset-to-open mechanism instead of parsing an exact reset time
+ * out of free-text provider error messages (fragile: no timezone, ordinal
+ * day suffixes). Failures naturally stop recurring once the underlying
+ * cause (e.g. a quota window) actually clears.
+ */
+export function tripCircuitBreaker(path: string, options: TripCircuitBreakerOptions): CircuitBreakerState {
+  const now = options.now ?? new Date();
+  const state: CircuitBreakerState = {
+    pausedUntil: new Date(now.getTime() + options.pauseMs).toISOString(),
+    reason: options.reason,
+    triggeredAt: now.toISOString(),
+  };
+  saveCircuitBreakerState(path, state);
+  return state;
+}
+
+export function clearCircuitBreaker(path: string): void {
+  saveCircuitBreakerState(path, { ...EMPTY_STATE });
+}

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -8,8 +8,14 @@ import type {
   WorkflowMutationPriority,
 } from '@invoker/data-store';
 import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
-import type { TaskState } from '@invoker/workflow-core';
+import { FailureClassifier, type TaskState } from '@invoker/workflow-core';
 
+import {
+  defaultCircuitBreakerPath,
+  isCircuitBreakerPaused,
+  loadCircuitBreakerState,
+  tripCircuitBreaker,
+} from './auto-fix-circuit-breaker.js';
 import {
   buildFixWithAgentMutationArgs,
   listOpenFixIntentsForTask,
@@ -47,6 +53,15 @@ export const AUTO_FIX_COMMAND_CHANNEL = 'invoker:fix-with-agent';
 export const AUTO_FIX_BARE_RETRY_CHANNEL = 'invoker:retry-task';
 const AUTO_FIX_ACTION_TYPE = 'auto-fix';
 const AUTO_FIX_BARE_RETRY_ACTION_TYPE = 'auto-retry';
+/**
+ * A failed task's auto-fix attempt is a real, capacity-limited agent
+ * dispatch, not a free retry. If the provider itself is out of quota, every
+ * other failed task's auto-fix attempt fails identically -- so one such
+ * failure pauses all auto-fix dispatch fleet-wide for this long, instead of
+ * each failed task separately burning its own attempt budget on certain
+ * failure. See auto-fix-circuit-breaker.ts.
+ */
+export const DEFAULT_CIRCUIT_BREAKER_PAUSE_MS = 6 * 60 * 60 * 1000;
 
 const AUTO_FIX_WORKER_AUDIT_EVENTS: Record<string, { eventType: string; action: 'submit' | 'skip' }> = {
   'worker-autofix-submitted': { eventType: 'recovery.worker.submit', action: 'submit' },
@@ -99,6 +114,8 @@ export interface AutoFixRecoveryPolicyOptions {
   getAutoFixAgent?: () => string | undefined;
   getRetryBudget?: (task: TaskState) => number;
   drainWakeupHints?: () => RecoveryWorkerWakeupHint[];
+  circuitBreakerPath?: string;
+  circuitBreakerPauseMs?: number;
 }
 /** Register the built-in auto-fix worker. */
 export function registerAutoFixWorker(
@@ -424,6 +441,12 @@ function validateAutoFixCandidate(
   }
   const latestRef = snapshotComparison.ref;
 
+  if (latest.status === 'failed' && FailureClassifier.isUsageLimit(latest.execution.error)) {
+    tripAutoFixCircuitBreaker(options);
+    skipAutoFixCandidate(options, candidate, 'usage-limit', { status: latest.status });
+    return undefined;
+  }
+
   const latestRetryBudget = retryBudgetForTask(latest, options);
   if (!isRuntimeAutoFixEligibleTask(latest, options)) {
     const reason = latestRetryBudget <= 0
@@ -460,9 +483,25 @@ export function collectValidatedAutoFixRecoveryCandidates(
     .filter((candidate): candidate is ValidatedAutoFixRecoveryCandidate => Boolean(candidate));
 }
 
+function tripAutoFixCircuitBreaker(options: AutoFixRecoveryPolicyOptions): void {
+  tripCircuitBreaker(options.circuitBreakerPath ?? defaultCircuitBreakerPath(), {
+    reason: 'usage-limit',
+    pauseMs: options.circuitBreakerPauseMs ?? DEFAULT_CIRCUIT_BREAKER_PAUSE_MS,
+  });
+}
+
 export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions): WorkerTick {
   return async (ctx) => {
     ctx.signal?.throwIfAborted();
+    const breakerState = loadCircuitBreakerState(options.circuitBreakerPath ?? defaultCircuitBreakerPath());
+    if (isCircuitBreakerPaused(breakerState, Date.now())) {
+      options.logger.debug?.(`[worker:${RECOVERY_WORKER_KIND}] worker-autofix-circuit-breaker-paused`, {
+        module: 'auto-fix-recovery',
+        pausedUntil: breakerState.pausedUntil,
+        reason: breakerState.reason,
+      });
+      return;
+    }
     // Drain wake hints (coalesce only). Discover work from a fresh scan —
     // wake snapshots go stale across bare-retry generation bumps.
     options.drainWakeupHints?.();
@@ -470,6 +509,19 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
     const submittedThisTick = new Set<string>();
 
     for (const candidate of collectValidatedAutoFixRecoveryCandidates(options, candidates)) {
+      // Re-check per candidate, not just once at tick start: candidate
+      // validation above can itself trip the breaker (a usage-limit
+      // failure), and every candidate after it in this same tick must stop
+      // too, not just on the next tick a minute later.
+      const breakerState = loadCircuitBreakerState(options.circuitBreakerPath ?? defaultCircuitBreakerPath());
+      if (isCircuitBreakerPaused(breakerState, Date.now())) {
+        skipAutoFixCandidate(options, candidate, 'circuit-breaker-paused', {
+          pausedUntil: breakerState.pausedUntil,
+          breakerReason: breakerState.reason,
+        });
+        continue;
+      }
+
       if (submittedThisTick.has(candidate.taskId)) {
         skipAutoFixCandidate(options, candidate, 'duplicate-candidate');
         continue;

--- a/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
+++ b/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
@@ -71,4 +71,19 @@ describe('FailureClassifier predicates', () => {
     expect(FailureClassifier.isCancellation('boom')).toBe(false);
     expect(FailureClassifier.isCancellation(undefined)).toBe(false);
   });
+
+  it('isUsageLimit matches both real agent-quota failure shapes seen in production', () => {
+    // Live incident text captured from a real failed task's execution.error.
+    expect(FailureClassifier.isUsageLimit(
+      '[Fix with Agent failed] SSH remote script failed (exit=1, phase=remote_agent_fix)\n'
+      + "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to "
+      + 'purchase more credits or try again at Aug 20th, 2026 4:36 AM.',
+    )).toBe(true);
+    // Distinct phrasing this repo's own codex-driver tests already model.
+    expect(FailureClassifier.isUsageLimit(
+      'codex fix exited with code 1: [assistant] Model refused: usage limit reached',
+    )).toBe(true);
+    expect(FailureClassifier.isUsageLimit('AssertionError: expected 1 to be 2')).toBe(false);
+    expect(FailureClassifier.isUsageLimit(undefined)).toBe(false);
+  });
 });

--- a/packages/workflow-graph/src/failure-classifier.ts
+++ b/packages/workflow-graph/src/failure-classifier.ts
@@ -75,4 +75,15 @@ export class FailureClassifier {
     return errorText.startsWith('Cancelled by user') || errorText.startsWith('Cancelled:')
       || errorText.startsWith('Terminated by user') || errorText.startsWith('Terminated:');
   }
+
+  /**
+   * True when the failure is the agent provider refusing to run because its
+   * usage/rate quota is exhausted, not a defect in the task itself. Retrying
+   * immediately cannot succeed until the quota resets, so callers should
+   * back off globally rather than spend a per-task auto-fix attempt on it.
+   */
+  static isUsageLimit(errorText: unknown): boolean {
+    if (typeof errorText !== 'string') return false;
+    return /usage limit|rate limit/i.test(errorText);
+  }
 }


### PR DESCRIPTION
## Summary

A Codex usage-limit failure looks like an ordinary task failure today: nothing in the codebase recognizes it as a distinct category.

The in-process auto-fix worker dispatches an agent for it like a real code defect, spending that task's own attempt allowance on a call certain to fail the same way again.

Every other failed task in the system is unaffected by the first one's exhausted quota, so each keeps dispatching its own agent the same way.

This slice adds a `FailureClassifier.isUsageLimit` check and a small file-backed pause flag: one such failure now pauses all auto-fix dispatch, fleet-wide, for a window that re-arms on repeat failures.

## Review Claim

Approve that a usage-limit failure pauses all auto-fix dispatch through a shared flag instead of consuming that task's own attempt allowance, and that the worker checks the flag before every dispatch in the same tick, not only at the next poll.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The pause flag only gates whether the existing auto-fix worker dispatches this tick; it introduces no new write path, does not touch task state, and a corrupt or missing pause file is treated as not-paused so a filesystem hiccup cannot itself block legitimate recovery.

## Slice Rationale

This is the foundation slice: the classifier and the pause primitive, wired into the one in-process consumer that can actually observe a task's failure text. The separate cron-watcher wiring is its own slice on top, since it is a different consumer of the same shared state.

## Non-goals

Does not wire the standalone CI-regression cron into this pause flag; that is the next slice. Does not attempt to parse an exact quota-reset time out of free-text provider errors -- the pause window is a fixed, re-arming duration instead.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-graph && pnpm test` — 114/114 pass, including the new `isUsageLimit` case (repro run against the pre-fix classifier first, confirmed failing with `isUsageLimit is not a function`, then passing after the fix)
- [x] `cd packages/execution-engine && pnpm test -- auto-fix` — 30/30 pass, including the breaker module tests and the integration test proving an unrelated failed task is blocked in the same tick a usage-limit failure trips the breaker (repro run against the pre-fix worker first, confirmed failing, then passing after the fix)
- [x] `cd packages/workflow-graph && pnpm build` and `cd packages/execution-engine && pnpm build` — both build clean with generated type declarations

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No -- a stale `~/.invoker/auto-fix-pause.json` left behind after revert is inert; nothing reads it once this code is gone

</details>
