### PR TITLE
[CI Repair Spend Hygiene](4) Wire the CI-regression watcher into the shared auto-fix circuit breaker

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -89,6 +89,26 @@ const STATE_DIR = process.env.INVOKER_CI_WATCH_STATE_DIR
 const STATE_FILE = join(STATE_DIR, 'state.json');
 const SWEEP_LOG_FILE = join(STATE_DIR, 'sweep-log.jsonl');
 const WORKFLOW_PATH = join(REPO_ROOT, '.github', 'workflows', WORKFLOW_FILE);
+/**
+ * Shared fleet-wide auto-fix pause flag, same file and format written by
+ * packages/execution-engine/src/auto-fix-circuit-breaker.ts. One usage-limit
+ * failure anywhere in Invoker (not just here) pauses this watcher's filing
+ * too, since a filed repair here dispatches the same rate-limited agent.
+ */
+const AUTO_FIX_PAUSE_FILE = process.env.INVOKER_AUTO_FIX_PAUSE_FILE
+  ?? join(homedir(), '.invoker', 'auto-fix-pause.json');
+
+export function isAutoFixCircuitBreakerPaused(nowMs = Date.now(), path = AUTO_FIX_PAUSE_FILE) {
+  if (!existsSync(path)) return false;
+  try {
+    const raw = JSON.parse(readFileSync(path, 'utf8'));
+    if (!raw?.pausedUntil) return false;
+    const untilMs = new Date(raw.pausedUntil).getTime();
+    return Number.isFinite(untilMs) && nowMs < untilMs;
+  } catch {
+    return false;
+  }
+}
 const BUILD_APP_COMMAND = [
   'pnpm --filter @invoker/ui build',
   'pnpm --filter @invoker/surfaces build',
@@ -908,9 +928,26 @@ export function processFailureFilingSweep(state, {
   onNeedsHuman = () => {},
   onRetired = () => {},
   fleetEventThreshold = FLEET_EVENT_THRESHOLD,
+  isPaused = isAutoFixCircuitBreakerPaused,
 } = {}) {
   const filedAt = now instanceof Date ? now : new Date(now);
   const nowMs = filedAt.getTime();
+
+  if (isPaused(nowMs)) {
+    return {
+      groupsFound: failures.length,
+      groupsFiled: 0,
+      groupsSkippedAlreadyAddressed: 0,
+      groupsDeferredByCap: 0,
+      groupsNeedingHuman: 0,
+      groupsInBackoff: 0,
+      groupsRetired: 0,
+      groupsRetiredStale: 0,
+      groupsCorrelated: 0,
+      pausedByCircuitBreaker: true,
+    };
+  }
+
   const prepared = prepareFleetCorrelatedFailures(state, failures, {
     threshold: fleetEventThreshold,
     jobDefinitions,
@@ -1035,6 +1072,10 @@ export async function main() {
       console.error(`ci-regression-watch: failure key "${buildMarker(failure.firstBadSha, failure.jobName)}" ${detail}; marking retired and skipping filing`);
     },
   });
+
+  if (filingCounts.pausedByCircuitBreaker) {
+    console.error('ci-regression-watch: auto-fix circuit breaker is paused; skipped filing this sweep');
+  }
 
   appendSweepLog({
     runsProcessed,

--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -1,11 +1,15 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
   buildCiJobDefinitions,
   buildMarker,
   fileBugfixPlan,
   getActionableFailures,
   groupFailuresBySha,
+  isAutoFixCircuitBreakerPaused,
   isObservationStale,
   jobNameIsMapped,
   loadEmptyState,
@@ -731,4 +735,63 @@ describe('stale-observation retirement', () => {
     assert.equal(counts.groupsRetiredStale, 0);
     assert.equal(state.activeFailures[jobName].retired, false);
   });
+});
+
+describe('auto-fix circuit breaker (shared with execution-engine)', () => {
+  let dir;
+  let breakerPath;
+
+  function withDir(fn) {
+    dir = mkdtempSync(join(tmpdir(), 'invoker-watch-breaker-'));
+    breakerPath = join(dir, 'auto-fix-pause.json');
+    try {
+      return fn();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it('isAutoFixCircuitBreakerPaused reads the same pause-file format execution-engine writes', () => withDir(() => {
+    writeFileSync(breakerPath, JSON.stringify({
+      pausedUntil: '2026-08-14T12:00:00.000Z',
+      reason: 'usage-limit',
+      triggeredAt: '2026-08-14T06:00:00.000Z',
+    }));
+    assert.equal(isAutoFixCircuitBreakerPaused(new Date('2026-08-14T08:00:00.000Z').getTime(), breakerPath), true);
+    assert.equal(isAutoFixCircuitBreakerPaused(new Date('2026-08-15T00:00:00.000Z').getTime(), breakerPath), false);
+  }));
+
+  it('reproduces the bug: without a pause check, the sweep files new repair work while the fleet is out of quota', () => withDir(() => {
+    const jobName = 'required-fast / Vitest Workspace';
+    const state = stateWithFailure(makeFailure({ jobName }));
+    const filed = [];
+
+    const counts = processFailureFilingSweep(state, {
+      now: new Date('2026-08-14T08:00:00.000Z'),
+      jobDefinitions: jobDefinitionsFor([jobName]),
+      liveQuery: () => false,
+      fileFailure: (failure) => filed.push(failure.jobName),
+      isPaused: () => true,
+    });
+
+    assert.deepEqual(filed, [], 'must not file while the shared circuit breaker is paused');
+    assert.equal(counts.pausedByCircuitBreaker, true);
+  }));
+
+  it('resumes filing once the breaker is no longer paused', () => withDir(() => {
+    const jobName = 'required-fast / Vitest Workspace';
+    const state = stateWithFailure(makeFailure({ jobName }));
+    const filed = [];
+
+    const counts = processFailureFilingSweep(state, {
+      now: new Date('2026-08-14T08:00:00.000Z'),
+      jobDefinitions: jobDefinitionsFor([jobName]),
+      liveQuery: () => false,
+      fileFailure: (failure) => filed.push(failure.jobName),
+      isPaused: () => false,
+    });
+
+    assert.deepEqual(filed, [jobName]);
+    assert.equal(counts.pausedByCircuitBreaker, undefined);
+  }));
 });


### PR DESCRIPTION
## Summary

The standalone CI-regression cron dispatches the same rate-limited Codex agent as the in-process auto-fix worker below it in this stack.

Before this slice, the cron had no way to see that a usage-limit failure anywhere else had already tripped the shared pause.

It would keep filing new repair work every 15-minute sweep even while the whole fleet was out of quota.

This slice makes the sweep read the same pause file the worker writes to and skip filing entirely while it is paused.

## Review Claim

Approve that `processFailureFilingSweep` checks the shared pause file before doing any work this sweep, and skips filing (without touching any failure's own attempt/backoff state) while paused.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The pause check is a pure read of a shared file, gated behind an injectable `isPaused` parameter that defaults to the real reader; it changes no other branch of the sweep and, when not paused, behaves exactly as before this slice.

## Slice Rationale

The pause primitive and its one in-process consumer landed as the slice below this one; this slice is the second, independent consumer, kept separate because it touches a different top-level area of the repo (the standalone script, not the execution-engine package).

## Non-goals

Does not add a way to trip the breaker from the cron side; only the in-process worker (previous slice) currently detects usage-limit failures and trips it.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --test scripts/e2e-regression-watch.test.mjs` — 30/30 pass, including the new `auto-fix circuit breaker (shared with execution-engine)` suite (repro run against the pre-fix sweep first, confirmed failing, then passing after the fix)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a safety pause for automated failure filing when the auto-fix circuit breaker is active.
  - Filing is skipped while paused, with the paused status reported in orchestration logs.
  - Missing, malformed, or expired pause information is handled safely as an unpaused state.
  - Automated filing resumes automatically once the circuit breaker pause is cleared.

- **Tests**
  - Added coverage for pause detection, filing suppression, and automatic resumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->