### PR TITLE
[Root Test Chain Unblock](1) Fix duplicate libatomicStep declaration breaking the root test chain

### DIFF
--- a/scripts/test-pr-body-rollout.mjs
+++ b/scripts/test-pr-body-rollout.mjs
@@ -112,14 +112,14 @@ assert.ok(
   'PR Body must install libatomic1 before actions/setup-node selects Node.js 26',
 );
 
-const libatomicStep = prBodyWorkflowSteps[libatomicStepIndex];
+const libatomicPrerequisitesStep = prBodyWorkflowSteps[libatomicStepIndex];
 assert.match(
-  libatomicStep,
+  libatomicPrerequisitesStep,
   new RegExp(`^        if: ${enabledOnlyCondition.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'm'),
   'PR Body libatomic prerequisite install must use the same enabled-only gate as Node setup',
 );
 assert.match(
-  libatomicStep,
+  libatomicPrerequisitesStep,
   /^        run: \|\n          sudo apt-get update\n          sudo apt-get install -y libatomic1$/m,
   'PR Body libatomic prerequisite install must update apt and install libatomic1',
 );


### PR DESCRIPTION
## Summary

`scripts/test-pr-body-rollout.mjs` declared `const libatomicStep` twice at module scope.

One check covers the "Install Node.js runtime dependency" workflow step. A later check, added separately, covers the "Install Node.js runtime prerequisites" step. Both are real, distinct checks.

The name collision throws a `SyntaxError` the moment this script runs. It runs early in the root `pnpm test` chain, so every check after it silently never ran, in CI or locally.

Renamed the second declaration to `libatomicPrerequisitesStep`. Both checks now run independently and pass.

## Review Claim

Approve that renaming the colliding declaration is the correct, minimal fix, and that both underlying checks still assert what they always meant to.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Renaming a local identifier does not change what either check asserts against `.github/workflows/pr-body.yml`; both blocks keep their original regexes and messages.

## Slice Rationale

This unblocks the entire root `pnpm test` chain, which a later PR in this stack depends on to actually exercise its own new test in CI. It has to land first.

## Non-goals

Does not change `.github/workflows/pr-body.yml` or either check's assertions.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-pr-body-rollout.mjs` — exits 0, prints "OK: PR body rollout checks passed"

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — reverting restores the duplicate-declaration crash, which was already broken before this PR.
- Data migration? No

</details>
