### PR TITLE
[CI Regression Watcher Fleet Orphan](1) Reproduce an orphaned fleet key staying un-retired forever

### DIFF
--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -329,6 +329,73 @@ describe('fleet SHA correlation', () => {
     assert.equal(counts.groupsCorrelated, 1);
     assert.equal(counts.groupsFiled, 1);
   });
+
+  it('reproduces the bug: an orphaned fleet key is left un-retired forever when its last unmapped member goes silent', () => {
+    const sha1 = 'e73ee551a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7';
+    const sha2 = 'f00df00d1122334455667788990011223344f00d';
+    const jobA = 'quality / Dependency Cruise';
+    const jobB = 'required-fast / Vitest Workspace';
+
+    const state = stateWithFailures([
+      makeFailure({
+        jobName: jobA, firstBadSha: sha1, firstBadRunId: 100,
+        firstJobDatabaseId: 200, firstJobUrl: 'https://example.test/job/200',
+      }),
+      makeFailure({
+        jobName: jobB, firstBadSha: sha1, firstBadRunId: 101,
+        firstJobDatabaseId: 201, firstJobUrl: 'https://example.test/job/201',
+      }),
+    ]);
+
+    // Sweep 1: correlates jobA + jobB into one fleet entry under sha1. This
+    // is the pre-existing fleet-level entry the bug later orphans.
+    processFailureFilingSweep(state, {
+      jobDefinitions: jobDefinitionsFor([jobA, jobB]),
+      fleetEventThreshold: 2,
+      now: new Date('2026-08-12T00:00:00Z'),
+      liveQuery: () => false,
+      fileFailure: () => {},
+    });
+    const fleetKey = Object.keys(state.activeFailures).find((key) => key.startsWith('fleet /'));
+    assert.ok(fleetKey, 'expected a fleet entry to be synthesized');
+
+    // jobB recovers. Its own individual activeFailures entry never had its
+    // own lastFiledAt stamped (only the fleet-level object did, via
+    // recordFailureFiled), so withinRecoveryCooldown reads false
+    // immediately -- no artificial 24h time jump is needed to make
+    // reconcileCiRun delete it outright.
+    reconcileCiRun(state, makeRun({
+      headSha: sha1, jobName: jobB, conclusion: 'success',
+      databaseId: 102, jobDatabaseId: 202, createdAt: '2026-08-12T01:00:00Z',
+    }));
+    assert.equal(state.activeFailures[jobB], undefined);
+
+    // jobB re-fails on a brand-new commit. This creates a fresh, standalone
+    // activeFailures entry for jobB keyed to sha2 -- unrelated to the old
+    // fleet entry still sitting under sha1.
+    reconcileCiRun(state, makeRun({
+      headSha: sha2, jobName: jobB, conclusion: 'failure',
+      databaseId: 103, jobDatabaseId: 203, createdAt: '2026-08-12T02:00:00Z',
+    }));
+
+    // Sweep 2: jobA is now unmapped (simulating a rename/removal from CI).
+    // The old fleet entry's group now contains only jobA, which can't
+    // synthesize a valid fleet failure (no verify command) -- this is the
+    // sweep where the bug fires.
+    const filed = [];
+    processFailureFilingSweep(state, {
+      jobDefinitions: jobDefinitionsFor([jobB]),
+      fleetEventThreshold: 2,
+      now: new Date('2026-08-12T03:00:00Z'),
+      liveQuery: () => false,
+      fileFailure: (failure) => filed.push(failure),
+    });
+
+    assert.equal(state.activeFailures[fleetKey].retired, true);
+    assert.equal(state.activeFailures[jobA].retired, true);
+    assert.deepEqual(filed.map((failure) => failure.jobName), [jobB]);
+    assert.equal(filed[0].firstBadSha, sha2);
+  });
 });
 
 describe('attempt ledger filing gate', () => {

--- a/scripts/test-pr-body-rollout.mjs
+++ b/scripts/test-pr-body-rollout.mjs
@@ -112,14 +112,14 @@ assert.ok(
   'PR Body must install libatomic1 before actions/setup-node selects Node.js 26',
 );
 
-const libatomicStep = prBodyWorkflowSteps[libatomicStepIndex];
+const libatomicPrerequisitesStep = prBodyWorkflowSteps[libatomicStepIndex];
 assert.match(
-  libatomicStep,
+  libatomicPrerequisitesStep,
   new RegExp(`^        if: ${enabledOnlyCondition.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'm'),
   'PR Body libatomic prerequisite install must use the same enabled-only gate as Node setup',
 );
 assert.match(
-  libatomicStep,
+  libatomicPrerequisitesStep,
   /^        run: \|\n          sudo apt-get update\n          sudo apt-get install -y libatomic1$/m,
   'PR Body libatomic prerequisite install must update apt and install libatomic1',
 );


### PR DESCRIPTION
## Summary

The CI-regression watcher groups jobs that break together on the same commit into one "fleet" entry, instead of filing a separate repair per job.

This adds a test proving a specific case goes wrong. One fleet member re-fails on a new commit after briefly going green. The fleet's other member has gone permanently silent.

The old fleet-level entry is silently abandoned. It is never marked closed, and never re-checked.

No live work is lost. The still-broken member keeps filing repairs under its new commit. But the old entry sits there forever, invisible to every later sweep.

This test fails against the current watcher. The next PR in this stack fixes it.

## Review Claim

Approve that this test accurately reproduces the orphaned-entry bug and will correctly flip to passing once the watcher is fixed.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Test-only change. Adds one new case to the existing `fleet SHA correlation` test group; does not modify the watcher script itself, and is not yet wired into any test runner, so it cannot affect CI in this PR.

## Slice Rationale

Lands the proof before the fix, so the bug is demonstrated before the behavior change that fixes it is asked for approval.

## Non-goals

Does not fix the bug. Does not wire this test file into CI (a later PR in this stack does that, only once the fix below it makes the whole file green).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node --test scripts/e2e-regression-watch.test.mjs` — the new test fails; all other existing tests in the file still pass

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
