### PR TITLE
[CI Regression Watcher Fleet Orphan](2) Retire an orphaned fleet key when its group can no longer refile

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -546,6 +546,16 @@ function prepareFleetCorrelatedFailures(state, failures, {
     if (members.length < threshold && !existingFleetBySha.has(sha)) continue;
     const fleetFailure = synthesizeFleetFailure(normalized, sha, members, jobDefinitions);
     if (!fleetFailure) {
+      if (existingFleetBySha.has(sha)) {
+        const existingFleetEntry = existingFleetBySha.get(sha);
+        if (normalized.activeFailures[existingFleetEntry.jobName]) {
+          normalized.activeFailures[existingFleetEntry.jobName] = {
+            ...normalized.activeFailures[existingFleetEntry.jobName],
+            retired: true,
+          };
+          stateChanged = true;
+        }
+      }
       for (const member of members) {
         const existing = normalized.activeFailures[member.jobName];
         if (!existing) continue;

--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -329,6 +329,73 @@ describe('fleet SHA correlation', () => {
     assert.equal(counts.groupsCorrelated, 1);
     assert.equal(counts.groupsFiled, 1);
   });
+
+  it('reproduces the bug: an orphaned fleet key is left un-retired forever when its last unmapped member goes silent', () => {
+    const sha1 = 'e73ee551a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7';
+    const sha2 = 'f00df00d1122334455667788990011223344f00d';
+    const jobA = 'quality / Dependency Cruise';
+    const jobB = 'required-fast / Vitest Workspace';
+
+    const state = stateWithFailures([
+      makeFailure({
+        jobName: jobA, firstBadSha: sha1, firstBadRunId: 100,
+        firstJobDatabaseId: 200, firstJobUrl: 'https://example.test/job/200',
+      }),
+      makeFailure({
+        jobName: jobB, firstBadSha: sha1, firstBadRunId: 101,
+        firstJobDatabaseId: 201, firstJobUrl: 'https://example.test/job/201',
+      }),
+    ]);
+
+    // Sweep 1: correlates jobA + jobB into one fleet entry under sha1. This
+    // is the pre-existing fleet-level entry the bug later orphans.
+    processFailureFilingSweep(state, {
+      jobDefinitions: jobDefinitionsFor([jobA, jobB]),
+      fleetEventThreshold: 2,
+      now: new Date('2026-08-12T00:00:00Z'),
+      liveQuery: () => false,
+      fileFailure: () => {},
+    });
+    const fleetKey = Object.keys(state.activeFailures).find((key) => key.startsWith('fleet /'));
+    assert.ok(fleetKey, 'expected a fleet entry to be synthesized');
+
+    // jobB recovers. Its own individual activeFailures entry never had its
+    // own lastFiledAt stamped (only the fleet-level object did, via
+    // recordFailureFiled), so withinRecoveryCooldown reads false
+    // immediately -- no artificial 24h time jump is needed to make
+    // reconcileCiRun delete it outright.
+    reconcileCiRun(state, makeRun({
+      headSha: sha1, jobName: jobB, conclusion: 'success',
+      databaseId: 102, jobDatabaseId: 202, createdAt: '2026-08-12T01:00:00Z',
+    }));
+    assert.equal(state.activeFailures[jobB], undefined);
+
+    // jobB re-fails on a brand-new commit. This creates a fresh, standalone
+    // activeFailures entry for jobB keyed to sha2 -- unrelated to the old
+    // fleet entry still sitting under sha1.
+    reconcileCiRun(state, makeRun({
+      headSha: sha2, jobName: jobB, conclusion: 'failure',
+      databaseId: 103, jobDatabaseId: 203, createdAt: '2026-08-12T02:00:00Z',
+    }));
+
+    // Sweep 2: jobA is now unmapped (simulating a rename/removal from CI).
+    // The old fleet entry's group now contains only jobA, which can't
+    // synthesize a valid fleet failure (no verify command) -- this is the
+    // sweep where the bug fires.
+    const filed = [];
+    processFailureFilingSweep(state, {
+      jobDefinitions: jobDefinitionsFor([jobB]),
+      fleetEventThreshold: 2,
+      now: new Date('2026-08-12T03:00:00Z'),
+      liveQuery: () => false,
+      fileFailure: (failure) => filed.push(failure),
+    });
+
+    assert.equal(state.activeFailures[fleetKey].retired, true);
+    assert.equal(state.activeFailures[jobA].retired, true);
+    assert.deepEqual(filed.map((failure) => failure.jobName), [jobB]);
+    assert.equal(filed[0].firstBadSha, sha2);
+  });
 });
 
 describe('attempt ledger filing gate', () => {

--- a/scripts/test-pr-body-rollout.mjs
+++ b/scripts/test-pr-body-rollout.mjs
@@ -112,14 +112,14 @@ assert.ok(
   'PR Body must install libatomic1 before actions/setup-node selects Node.js 26',
 );
 
-const libatomicStep = prBodyWorkflowSteps[libatomicStepIndex];
+const libatomicPrerequisitesStep = prBodyWorkflowSteps[libatomicStepIndex];
 assert.match(
-  libatomicStep,
+  libatomicPrerequisitesStep,
   new RegExp(`^        if: ${enabledOnlyCondition.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'm'),
   'PR Body libatomic prerequisite install must use the same enabled-only gate as Node setup',
 );
 assert.match(
-  libatomicStep,
+  libatomicPrerequisitesStep,
   /^        run: \|\n          sudo apt-get update\n          sudo apt-get install -y libatomic1$/m,
   'PR Body libatomic prerequisite install must update apt and install libatomic1',
 );


### PR DESCRIPTION
## Summary

The CI-regression watcher already knows how to close out a single job that stops reporting. It marks that entry closed so it stops filing repairs against a job that no longer exists.

It never applied the same handling to a multi-job "fleet" grouping. When a fleet's group can no longer produce a valid repair, the watcher closed out the leftover member.

But it left the fleet's own tracking entry untouched — not closed, not filed, just abandoned.

This marks that fleet-level entry closed too, the same way an individually silent job already gets closed. It changes nothing about which jobs get repairs filed.

## Review Claim

Approve that marking the pre-existing fleet entry closed, only in the specific case where its group can no longer produce a repair, is the correct and complete fix, and that it changes no other filing behavior.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only ever flips an already-abandoned, never-filed entry's closed flag; verified by the full existing test suite (including the previous PR's new case) passing unchanged, with the same jobs filed under the same conditions as before.

## Slice Rationale

The behavior change on its own, once its proof already exists as a separate reviewable claim in the PR below this one.

## Non-goals

Does not delete the old fleet entry from state, matching how an individually stale job is already handled — closed and left in place, not removed. Does not touch the cleanup pass that already runs for fully-vanished groups.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node --test scripts/e2e-regression-watch.test.mjs` — all tests pass, including the previously-failing case from the PR below this one

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — reverting restores the orphaned-entry bug, which was already present before this stack.
- Data migration? No

</details>
