### PR TITLE
[Shared Retry Ledger](1) Extract the shared retry/backoff decision primitive

### DIFF
--- a/scripts/retry-ledger.mjs
+++ b/scripts/retry-ledger.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Shared retry/backoff/staleness decision primitive.
+//
+// Extracted from scripts/e2e-regression-watch.mjs (the default-branch CI
+// watcher) so scripts/mergify_admin_requeue_plan.py -- a separate,
+// Python-based auto-repair system that watches individual PR checks -- can
+// call the same, already-tested decision logic instead of re-deriving it.
+// Both systems already spawn shell entrypoints from an in-process Invoker
+// worker every tick; Python calling this module's CLI via subprocess is the
+// same pattern, one level down.
+import { readFileSync } from 'node:fs';
+
+export function shouldRetry({
+  attempts = 0,
+  lastAttemptAt = null,
+  nowMs = Date.now(),
+  maxAttempts,
+  backoffBaseMs,
+} = {}) {
+  const attemptCount = Number(attempts ?? 0);
+  if (attemptCount >= maxAttempts) {
+    return { action: 'needs-human', attempts: attemptCount };
+  }
+  if (lastAttemptAt) {
+    const lastAttemptMs = Date.parse(lastAttemptAt);
+    if (Number.isFinite(lastAttemptMs)) {
+      const backoffUntilMs = lastAttemptMs + (backoffBaseMs * (2 ** attemptCount));
+      if (nowMs < backoffUntilMs) {
+        return { action: 'backoff', attempts: attemptCount, backoffUntilMs };
+      }
+    }
+  }
+  return { action: 'file', attempts: attemptCount };
+}
+
+export function isStale({ lastObservedAt, nowMs = Date.now(), staleMs } = {}) {
+  const observedMs = lastObservedAt ? new Date(lastObservedAt).getTime() : NaN;
+  return Number.isFinite(observedMs) && (nowMs - observedMs) > staleMs;
+}
+
+function readJsonArg(argv) {
+  const flagIndex = argv.indexOf('--json');
+  if (flagIndex !== -1 && argv[flagIndex + 1]) {
+    return argv[flagIndex + 1];
+  }
+  return readFileSync(0, 'utf8');
+}
+
+function usage() {
+  return [
+    'Usage: node scripts/retry-ledger.mjs decide --json \'<input>\'',
+    '  input: {"attempts":2,"lastAttemptAt":"2026-08-14T09:41:32Z","nowMs":1786732000000,"maxAttempts":3,"backoffBaseMs":1800000}',
+    '  (or pipe the same JSON object on stdin instead of --json)',
+    'Prints one JSON decision to stdout: {"action":"file"|"backoff"|"needs-human", ...}',
+  ].join('\n');
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const [command, ...rest] = argv;
+  if (command !== 'decide') {
+    console.error(`retry-ledger: unknown command "${command ?? ''}"\n\n${usage()}`);
+    process.exitCode = 1;
+    return;
+  }
+  let input;
+  try {
+    input = JSON.parse(readJsonArg(rest));
+  } catch (err) {
+    console.error(`retry-ledger: invalid JSON input: ${err.message}\n\n${usage()}`);
+    process.exitCode = 1;
+    return;
+  }
+  const result = shouldRetry({
+    attempts: input.attempts,
+    lastAttemptAt: input.lastAttemptAt,
+    nowMs: input.nowMs,
+    maxAttempts: input.maxAttempts,
+    backoffBaseMs: input.backoffBaseMs,
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main().catch((err) => {
+    console.error('retry-ledger: fatal error', err);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/retry-ledger.test.mjs
+++ b/scripts/retry-ledger.test.mjs
@@ -1,0 +1,90 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { shouldRetry, isStale } from './retry-ledger.mjs';
+
+const SCRIPT_PATH = join(dirname(fileURLToPath(import.meta.url)), 'retry-ledger.mjs');
+const STALE_OBSERVATION_MS = 3 * 24 * 60 * 60 * 1000;
+
+describe('shouldRetry', () => {
+  it('files when there are no prior attempts', () => {
+    const result = shouldRetry({ attempts: 0, lastAttemptAt: null, nowMs: 1000, maxAttempts: 3, backoffBaseMs: 1_800_000 });
+    assert.deepEqual(result, { action: 'file', attempts: 0 });
+  });
+
+  it('backs off when still inside the exponential backoff window', () => {
+    const lastAttemptAt = new Date(1_000_000).toISOString();
+    const result = shouldRetry({
+      attempts: 1,
+      lastAttemptAt,
+      nowMs: 1_000_000 + 1_800_000, // exactly at the 2^1 * base boundary, still short of it below
+      maxAttempts: 3,
+      backoffBaseMs: 1_800_000,
+    });
+    assert.equal(result.action, 'backoff');
+    assert.equal(result.attempts, 1);
+    assert.equal(result.backoffUntilMs, 1_000_000 + 1_800_000 * 2);
+  });
+
+  it('files again once the backoff window has passed', () => {
+    const lastAttemptAt = new Date(1_000_000).toISOString();
+    const result = shouldRetry({
+      attempts: 1,
+      lastAttemptAt,
+      nowMs: 1_000_000 + 1_800_000 * 2 + 1,
+      maxAttempts: 3,
+      backoffBaseMs: 1_800_000,
+    });
+    assert.deepEqual(result, { action: 'file', attempts: 1 });
+  });
+
+  it('needs-human once attempts reach the cap, regardless of backoff timing', () => {
+    const result = shouldRetry({ attempts: 3, lastAttemptAt: null, nowMs: 1000, maxAttempts: 3, backoffBaseMs: 1_800_000 });
+    assert.deepEqual(result, { action: 'needs-human', attempts: 3 });
+  });
+});
+
+describe('isStale', () => {
+  it('is false just inside the window and true just past it', () => {
+    const lastObservedAt = '2026-08-06T01:21:00.000Z';
+    const lastObservedMs = new Date(lastObservedAt).getTime();
+    assert.equal(
+      isStale({ lastObservedAt, nowMs: lastObservedMs + STALE_OBSERVATION_MS - 1, staleMs: STALE_OBSERVATION_MS }),
+      false,
+    );
+    assert.equal(
+      isStale({ lastObservedAt, nowMs: lastObservedMs + STALE_OBSERVATION_MS + 1, staleMs: STALE_OBSERVATION_MS }),
+      true,
+    );
+  });
+});
+
+describe('CLI (e2e, real subprocess)', () => {
+  it('decide reads --json and prints the decision to stdout', () => {
+    const input = JSON.stringify({
+      attempts: 2,
+      lastAttemptAt: '2026-08-14T09:41:32Z',
+      nowMs: Date.parse('2026-08-14T09:41:32Z') + 1_800_000 * 4 + 1,
+      maxAttempts: 3,
+      backoffBaseMs: 1_800_000,
+    });
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, 'decide', '--json', input], { encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), { action: 'file', attempts: 2 });
+  });
+
+  it('decide reads JSON from stdin when --json is not given', () => {
+    const input = JSON.stringify({ attempts: 0, lastAttemptAt: null, nowMs: 1000, maxAttempts: 3, backoffBaseMs: 1_800_000 });
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, 'decide'], { input, encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), { action: 'file', attempts: 0 });
+  });
+
+  it('exits non-zero with usage text on an unknown command', () => {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, 'bogus'], { encoding: 'utf8' });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /unknown command/);
+  });
+});


### PR DESCRIPTION
## Summary

`scripts/e2e-regression-watch.mjs` (the default-branch CI watcher) already has correct, well-tested retry-cap and staleness logic.

A second, unrelated auto-repair system watches individual PR checks instead. It has the same class of bug, because it built its own version independently instead of sharing this one.

This relocates the logic into a new, generic file. Both functions already took plain `{attempts, lastAttemptAt}`-shaped input, nothing specific to the CI watcher, so nothing about their behavior changes.

A small subprocess entrypoint is added so the other system can reach this file across the language boundary, the same pattern both systems already use for their own tick loops.

## Review Claim

Approve that the function bodies are unchanged apart from generalized field names, and that the new subprocess shape (JSON in, one JSON decision out) is reasonable for a caller in a different language.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Function bodies are byte-identical apart from renamed fields; nothing calls this new file yet within this PR, so there is no behavior change to observe.

## Slice Rationale

Landing this relocation on its own, before anything switches to using it, keeps this PR reviewable purely as "did relocating this code preserve its behavior," separate from "does the caller wiring work."

## Non-goals

Does not change `scripts/e2e-regression-watch.mjs` itself (next PR in this stack). Does not touch the Python system.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node --test scripts/retry-ledger.test.mjs` — 8/8 pass, including a real subprocess test of the new entrypoint

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — nothing depends on this file yet within this PR
- Data migration? No

</details>
