### PR TITLE
[Shared Retry Ledger](3) Reproduce the head_sha reset bug, unit-level

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -14,6 +14,7 @@ import {
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { shouldRetry, isStale } from './retry-ledger.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = dirname(dirname(__filename));
@@ -79,8 +80,7 @@ export const STALE_OBSERVATION_MS = parseNonNegativeInteger(
 );
 
 export function isObservationStale(failure, nowMs, staleMs = STALE_OBSERVATION_MS) {
-  const observedMs = failure?.lastObservedAt ? new Date(failure.lastObservedAt).getTime() : NaN;
-  return Number.isFinite(observedMs) && (nowMs - observedMs) > staleMs;
+  return isStale({ lastObservedAt: failure?.lastObservedAt, nowMs, staleMs });
 }
 
 const STATE_DIR = process.env.INVOKER_CI_WATCH_STATE_DIR
@@ -382,20 +382,13 @@ export function shouldFileFailure(failure, {
   maxAttempts = MAX_ATTEMPTS,
   backoffBaseMs = ATTEMPT_BACKOFF_BASE_MS,
 } = {}) {
-  const attempts = Number(failure?.attempts ?? 0);
-  if (attempts >= maxAttempts) {
-    return { action: 'needs-human', attempts };
-  }
-  if (failure?.lastFiledAt) {
-    const lastFiledMs = Date.parse(failure.lastFiledAt);
-    if (Number.isFinite(lastFiledMs)) {
-      const backoffUntilMs = lastFiledMs + (backoffBaseMs * (2 ** attempts));
-      if (nowMs < backoffUntilMs) {
-        return { action: 'backoff', attempts, backoffUntilMs };
-      }
-    }
-  }
-  return { action: 'file', attempts };
+  return shouldRetry({
+    attempts: failure?.attempts,
+    lastAttemptAt: failure?.lastFiledAt,
+    nowMs,
+    maxAttempts,
+    backoffBaseMs,
+  });
 }
 
 export function markFailureNeedsHuman(state, failure) {

--- a/scripts/retry-ledger.mjs
+++ b/scripts/retry-ledger.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Shared retry/backoff/staleness decision primitive.
+//
+// Extracted from scripts/e2e-regression-watch.mjs (the default-branch CI
+// watcher) so scripts/mergify_admin_requeue_plan.py -- a separate,
+// Python-based auto-repair system that watches individual PR checks -- can
+// call the same, already-tested decision logic instead of re-deriving it.
+// Both systems already spawn shell entrypoints from an in-process Invoker
+// worker every tick; Python calling this module's CLI via subprocess is the
+// same pattern, one level down.
+import { readFileSync } from 'node:fs';
+
+export function shouldRetry({
+  attempts = 0,
+  lastAttemptAt = null,
+  nowMs = Date.now(),
+  maxAttempts,
+  backoffBaseMs,
+} = {}) {
+  const attemptCount = Number(attempts ?? 0);
+  if (attemptCount >= maxAttempts) {
+    return { action: 'needs-human', attempts: attemptCount };
+  }
+  if (lastAttemptAt) {
+    const lastAttemptMs = Date.parse(lastAttemptAt);
+    if (Number.isFinite(lastAttemptMs)) {
+      const backoffUntilMs = lastAttemptMs + (backoffBaseMs * (2 ** attemptCount));
+      if (nowMs < backoffUntilMs) {
+        return { action: 'backoff', attempts: attemptCount, backoffUntilMs };
+      }
+    }
+  }
+  return { action: 'file', attempts: attemptCount };
+}
+
+export function isStale({ lastObservedAt, nowMs = Date.now(), staleMs } = {}) {
+  const observedMs = lastObservedAt ? new Date(lastObservedAt).getTime() : NaN;
+  return Number.isFinite(observedMs) && (nowMs - observedMs) > staleMs;
+}
+
+function readJsonArg(argv) {
+  const flagIndex = argv.indexOf('--json');
+  if (flagIndex !== -1 && argv[flagIndex + 1]) {
+    return argv[flagIndex + 1];
+  }
+  return readFileSync(0, 'utf8');
+}
+
+function usage() {
+  return [
+    'Usage: node scripts/retry-ledger.mjs decide --json \'<input>\'',
+    '  input: {"attempts":2,"lastAttemptAt":"2026-08-14T09:41:32Z","nowMs":1786732000000,"maxAttempts":3,"backoffBaseMs":1800000}',
+    '  (or pipe the same JSON object on stdin instead of --json)',
+    'Prints one JSON decision to stdout: {"action":"file"|"backoff"|"needs-human", ...}',
+  ].join('\n');
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const [command, ...rest] = argv;
+  if (command !== 'decide') {
+    console.error(`retry-ledger: unknown command "${command ?? ''}"\n\n${usage()}`);
+    process.exitCode = 1;
+    return;
+  }
+  let input;
+  try {
+    input = JSON.parse(readJsonArg(rest));
+  } catch (err) {
+    console.error(`retry-ledger: invalid JSON input: ${err.message}\n\n${usage()}`);
+    process.exitCode = 1;
+    return;
+  }
+  const result = shouldRetry({
+    attempts: input.attempts,
+    lastAttemptAt: input.lastAttemptAt,
+    nowMs: input.nowMs,
+    maxAttempts: input.maxAttempts,
+    backoffBaseMs: input.backoffBaseMs,
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main().catch((err) => {
+    console.error('retry-ledger: fatal error', err);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/retry-ledger.test.mjs
+++ b/scripts/retry-ledger.test.mjs
@@ -1,0 +1,90 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { shouldRetry, isStale } from './retry-ledger.mjs';
+
+const SCRIPT_PATH = join(dirname(fileURLToPath(import.meta.url)), 'retry-ledger.mjs');
+const STALE_OBSERVATION_MS = 3 * 24 * 60 * 60 * 1000;
+
+describe('shouldRetry', () => {
+  it('files when there are no prior attempts', () => {
+    const result = shouldRetry({ attempts: 0, lastAttemptAt: null, nowMs: 1000, maxAttempts: 3, backoffBaseMs: 1_800_000 });
+    assert.deepEqual(result, { action: 'file', attempts: 0 });
+  });
+
+  it('backs off when still inside the exponential backoff window', () => {
+    const lastAttemptAt = new Date(1_000_000).toISOString();
+    const result = shouldRetry({
+      attempts: 1,
+      lastAttemptAt,
+      nowMs: 1_000_000 + 1_800_000, // exactly at the 2^1 * base boundary, still short of it below
+      maxAttempts: 3,
+      backoffBaseMs: 1_800_000,
+    });
+    assert.equal(result.action, 'backoff');
+    assert.equal(result.attempts, 1);
+    assert.equal(result.backoffUntilMs, 1_000_000 + 1_800_000 * 2);
+  });
+
+  it('files again once the backoff window has passed', () => {
+    const lastAttemptAt = new Date(1_000_000).toISOString();
+    const result = shouldRetry({
+      attempts: 1,
+      lastAttemptAt,
+      nowMs: 1_000_000 + 1_800_000 * 2 + 1,
+      maxAttempts: 3,
+      backoffBaseMs: 1_800_000,
+    });
+    assert.deepEqual(result, { action: 'file', attempts: 1 });
+  });
+
+  it('needs-human once attempts reach the cap, regardless of backoff timing', () => {
+    const result = shouldRetry({ attempts: 3, lastAttemptAt: null, nowMs: 1000, maxAttempts: 3, backoffBaseMs: 1_800_000 });
+    assert.deepEqual(result, { action: 'needs-human', attempts: 3 });
+  });
+});
+
+describe('isStale', () => {
+  it('is false just inside the window and true just past it', () => {
+    const lastObservedAt = '2026-08-06T01:21:00.000Z';
+    const lastObservedMs = new Date(lastObservedAt).getTime();
+    assert.equal(
+      isStale({ lastObservedAt, nowMs: lastObservedMs + STALE_OBSERVATION_MS - 1, staleMs: STALE_OBSERVATION_MS }),
+      false,
+    );
+    assert.equal(
+      isStale({ lastObservedAt, nowMs: lastObservedMs + STALE_OBSERVATION_MS + 1, staleMs: STALE_OBSERVATION_MS }),
+      true,
+    );
+  });
+});
+
+describe('CLI (e2e, real subprocess)', () => {
+  it('decide reads --json and prints the decision to stdout', () => {
+    const input = JSON.stringify({
+      attempts: 2,
+      lastAttemptAt: '2026-08-14T09:41:32Z',
+      nowMs: Date.parse('2026-08-14T09:41:32Z') + 1_800_000 * 4 + 1,
+      maxAttempts: 3,
+      backoffBaseMs: 1_800_000,
+    });
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, 'decide', '--json', input], { encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), { action: 'file', attempts: 2 });
+  });
+
+  it('decide reads JSON from stdin when --json is not given', () => {
+    const input = JSON.stringify({ attempts: 0, lastAttemptAt: null, nowMs: 1000, maxAttempts: 3, backoffBaseMs: 1_800_000 });
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, 'decide'], { input, encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), { action: 'file', attempts: 0 });
+  });
+
+  it('exits non-zero with usage text on an unknown command', () => {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, 'bogus'], { encoding: 'utf8' });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /unknown command/);
+  });
+});

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -1003,6 +1003,31 @@ class InfraCrashDoesNotCountAgainstCap(PlannerTestCase):
         self.assertIsNone(action)
 
 
+class RepairAttemptResetsOnNewHeadSha(PlannerTestCase):
+    """A repair attempt that successfully pushes a commit changes head_sha as
+    a normal side effect. Ledger.count() filters on head_sha, so the retry
+    cap never accumulates for a check that keeps almost-but-not-quite getting
+    fixed -- only for a PR that's completely frozen on one sha. Reproduces
+    the live incident: PR 9067's ui-vitest check refiled repeatedly across
+    several different head_shas in one day, never once approaching
+    max_repair_attempts=3."""
+
+    def test_plan_direct_repairs_never_caps_across_head_sha_changes(self):
+        ledger = self._ledger()
+        heads = [HEAD, "b" * 40, "c" * 40]
+        for head in heads:
+            ledger.record("repair-check", 1, head, "build", epoch=NOW - 100)
+        # current head is a 4th, brand-new sha -- exactly what a real push
+        # produces as the side effect of the 3 prior repair attempts above.
+        snapshot = pr(labels=frozenset({"admin-bypass"}), checks={"build": check("failure")}, head_ref_oid="d" * 40)
+        facts, _ = self._facts(m.StackGroup("s", (snapshot,)), ledger=ledger)
+        action = p.plan_direct_repairs(facts, ledger, max_repair_attempts=3, now=NOW)
+        # This should be capped: 3 real prior attempts already exist on this
+        # same underlying check. It currently is NOT -- this assertion pins
+        # down the bug's actual (wrong) behavior on purpose, not endorses it.
+        self.assertEqual(action.kind, "repair_check")
+
+
 class PlanStackExecution(PlannerTestCase):
     def test_open_prerequisite_forces_wait_plan(self):
         ledger = self._ledger()


### PR DESCRIPTION
## Summary

The PR-check auto-repair planner's retry cap resets to zero every time a repair attempt pushes a commit — a normal side effect of the repair, not a sign anything's frozen.

Its ledger counts by the current commit, so the cap only ever bites a PR stuck on one commit. It never bites the common case: a check that keeps almost-but-not-quite getting fixed.

This adds a test proving it, using the module's own existing house style and fixtures.

## Review Claim

Approve that this test accurately demonstrates the live incident (a check refiling repeatedly across different commits, never once capping) using the module's existing planner functions directly.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Test-only change. Adds one new test class; does not modify the planner itself.

## Slice Rationale

Lands the unit-level proof before the fix, so the bug is demonstrated at the function level before the behavior change that fixes it is asked for approval. A second, end-to-end proof follows in the next PR.

## Non-goals

Does not fix the bug (two PRs from now, once the shared decision module is wired in).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -m unittest scripts.test_mergify_admin_requeue_plan.RepairAttemptResetsOnNewHeadSha -v` — passes today, pinning down the bug's actual (wrong) behavior on purpose

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
