### PR TITLE
[Shared Retry Ledger](3b) Reproduce the head_sha reset bug, end-to-end

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -14,6 +14,7 @@ import {
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { shouldRetry, isStale } from './retry-ledger.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = dirname(dirname(__filename));
@@ -79,8 +80,7 @@ export const STALE_OBSERVATION_MS = parseNonNegativeInteger(
 );
 
 export function isObservationStale(failure, nowMs, staleMs = STALE_OBSERVATION_MS) {
-  const observedMs = failure?.lastObservedAt ? new Date(failure.lastObservedAt).getTime() : NaN;
-  return Number.isFinite(observedMs) && (nowMs - observedMs) > staleMs;
+  return isStale({ lastObservedAt: failure?.lastObservedAt, nowMs, staleMs });
 }
 
 const STATE_DIR = process.env.INVOKER_CI_WATCH_STATE_DIR
@@ -382,20 +382,13 @@ export function shouldFileFailure(failure, {
   maxAttempts = MAX_ATTEMPTS,
   backoffBaseMs = ATTEMPT_BACKOFF_BASE_MS,
 } = {}) {
-  const attempts = Number(failure?.attempts ?? 0);
-  if (attempts >= maxAttempts) {
-    return { action: 'needs-human', attempts };
-  }
-  if (failure?.lastFiledAt) {
-    const lastFiledMs = Date.parse(failure.lastFiledAt);
-    if (Number.isFinite(lastFiledMs)) {
-      const backoffUntilMs = lastFiledMs + (backoffBaseMs * (2 ** attempts));
-      if (nowMs < backoffUntilMs) {
-        return { action: 'backoff', attempts, backoffUntilMs };
-      }
-    }
-  }
-  return { action: 'file', attempts };
+  return shouldRetry({
+    attempts: failure?.attempts,
+    lastAttemptAt: failure?.lastFiledAt,
+    nowMs,
+    maxAttempts,
+    backoffBaseMs,
+  });
 }
 
 export function markFailureNeedsHuman(state, failure) {

--- a/scripts/repro/repro-mergify-admin-requeue-head-sha-reset.py
+++ b/scripts/repro/repro-mergify-admin-requeue-head-sha-reset.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Hermetic repro for the admin-bypass retry-cap head_sha reset thrash.
+
+Live incident shape: PR 9067's `UI Vitest` check kept failing, and each
+repair attempt that ran pushed a new commit (a normal side effect of a
+repair) -- so the *next* tick's ledger lookup, keyed on the current
+head_sha, never saw the prior attempts. The retry cap (max_repair_attempts=3)
+never fired: the same check refiled repeatedly across several different
+head_shas in one day, never once appearing "capped" to a human.
+
+This drives the *real* production code path -- AdminBypassRepairer.repair_check
+and mergify_failed_check_actions, backed by a real on-disk Ledger -- across
+four simulated ticks, each on a new head_sha (mirroring the real side effect
+of a successful repair push). Only the actual external submission boundary
+(async_repair.run_headless, which would otherwise shell out to a live
+Invoker instance) is faked, following the same pattern as
+repro-admin-bypass-ledger-gap.py.
+
+Run:  python3 scripts/repro/repro-mergify-admin-requeue-head-sha-reset.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.dont_write_bytecode = True
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import scripts.mergify_admin_requeue_async_repair as async_repair
+import scripts.mergify_admin_requeue_headless_shell as headless_shell
+import scripts.mergify_admin_requeue_model as m
+import scripts.mergify_admin_requeue_plan as plan_mod
+from scripts.mergify_admin_requeue_logger import AdminBypassLogger
+from scripts.mergify_admin_requeue_repairer import AdminBypassRepairer
+
+PR = 9067
+CHECK = "UI Vitest"
+REPO = "Neko-Catpital-Labs/Invoker"
+NOW = 1_786_732_000
+MAX_REPAIR_ATTEMPTS = 3
+HEAD_SHAS = [f"{n}" * 40 for n in ("1", "2", "3", "4")]
+
+
+class FakeGh:
+    """GhClient double: PR is always OPEN so terminal_repair_outcome never exits early."""
+
+    def pr_detail(self, repo, number):
+        return {"state": "OPEN"}
+
+
+class FakeExecutor:
+    """AdminBypassGhExecutor double: a non-empty job log so repair_check
+    doesn't take the queue-only-noop branch for this ordinary failed check."""
+
+    def __init__(self, work: Path):
+        self.log = work / "job-log.txt"
+        self.log.write_text("UI Vitest: 3 failing tests\nexit 1\n", encoding="utf-8")
+
+    def download_job_log(self, repo, details_url, pr_number, check_name):
+        return str(self.log)
+
+
+def make_snapshot(head_sha: str) -> m.PrSnapshot:
+    """Build the PR snapshot as it would look right after a push lands: same
+    check still failing, but on a brand-new commit -- the exact real-world
+    side effect a successful repair attempt produces."""
+    latest = m.MergifyQueueEvent(
+        comment_id="c1",
+        state="dequeued",
+        queue_rule_name="default",
+        queued_at="2026-08-14T09:00:00Z",
+        head_sha=head_sha,
+        waiting_for=(),
+        failing_checks=(CHECK,),
+        comment_url=f"https://github.com/{REPO}/pull/{PR}#issuecomment-1",
+        queue_pr_number=9067,
+    )
+    ctx = m.CheckContext(
+        name=CHECK,
+        state="failure",
+        details_url="https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/1/job/2",
+        head_sha=head_sha,
+        completed_at="2026-08-14T09:00:00Z",
+    )
+    return m.PrSnapshot(
+        number=PR,
+        title="[CI regression: e73ee55-ui-vitest] Install libatomic for UI Vitest",
+        body="",
+        url=f"https://github.com/{REPO}/pull/{PR}",
+        state="OPEN",
+        is_draft=False,
+        base_ref_name="master",
+        head_ref_name="stack/ui-vitest-fix",
+        head_ref_oid=head_sha,
+        merge_state_status="BLOCKED",
+        mergeable="MERGEABLE",
+        labels=frozenset({"admin-bypass"}),
+        checks={CHECK: ctx},
+        review_threads=(),
+        latest_mergify=latest,
+    )
+
+
+class HeadShaResetThrash(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="repro-admin-requeue-head-sha-reset-")
+        self.addCleanup(self.tmp.cleanup)
+        self.work = Path(self.tmp.name)
+        self.ledger_path = self.work / "mergify-admin-requeue-state.jsonl"
+        self.submitted_plan_names: list[str] = []
+
+        def ok_run_headless(command, *extra_args, timeout_seconds=headless_shell.DEFAULT_TIMEOUT_SECONDS):
+            plan_path = Path(extra_args[0])
+            first_line = plan_path.read_text(encoding="utf-8").splitlines()[0]
+            self.submitted_plan_names.append(first_line[len("name: "):].strip())
+            return subprocess.CompletedProcess(["bash", "-c", command], returncode=0, stdout="ok", stderr="")
+
+        headless = mock.patch.object(async_repair, "run_headless", ok_run_headless)
+        headless.start()
+        self.addCleanup(headless.stop)
+
+        infra = mock.patch.object(plan_mod, "repair_task_crashed_on_infra", lambda plan_name: False)
+        infra.start()
+        self.addCleanup(infra.stop)
+
+        self.repairer = AdminBypassRepairer(
+            FakeGh(), FakeExecutor(self.work), AdminBypassLogger(), m.Ledger(self.ledger_path), REPO,
+        )
+
+    def fresh_ledger(self) -> m.Ledger:
+        return m.Ledger(self.ledger_path)
+
+    def planner_actions(self, head_sha: str, now: int):
+        return plan_mod.mergify_failed_check_actions(
+            make_snapshot(head_sha), self.fresh_ledger(), MAX_REPAIR_ATTEMPTS, now,
+        )
+
+    def test_four_repair_attempts_across_four_head_shas_never_caps(self):
+        # Three real repair attempts, each on a NEW head_sha (as if the prior
+        # attempt's own push landed before this tick's sweep ran).
+        for index, head_sha in enumerate(HEAD_SHAS[:3]):
+            outcome = self.repairer.repair_check(make_snapshot(head_sha), CHECK, now=NOW + index)
+            self.assertEqual(outcome.status, "submitted")
+
+        self.assertEqual(len(self.submitted_plan_names), 3)
+        # Each of the 3 attempts landed as its own ledger row (proves nothing
+        # was silently dropped) -- but every row is under a DIFFERENT head_sha.
+        for head_sha in HEAD_SHAS[:3]:
+            self.assertEqual(self.fresh_ledger().count("repair-check", PR, head_sha, CHECK), 1)
+
+        # This is the bug, pinned down deliberately: on the 4th head_sha, with
+        # 3 real prior attempts already on record, the planner still says
+        # "repair_check" (file a 4th) instead of "comment_blocked" (cap it).
+        # scripts/mergify_admin_requeue_plan.py's Ledger.count() filters on the
+        # CURRENT head_sha, so it can never see the 3 prior rows recorded
+        # under 3 different head_shas.
+        actions = self.planner_actions(HEAD_SHAS[3], NOW + 10)
+        self.assertEqual([(a.kind, a.key) for a in actions], [("repair_check", CHECK)])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/retry-ledger.mjs
+++ b/scripts/retry-ledger.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Shared retry/backoff/staleness decision primitive.
+//
+// Extracted from scripts/e2e-regression-watch.mjs (the default-branch CI
+// watcher) so scripts/mergify_admin_requeue_plan.py -- a separate,
+// Python-based auto-repair system that watches individual PR checks -- can
+// call the same, already-tested decision logic instead of re-deriving it.
+// Both systems already spawn shell entrypoints from an in-process Invoker
+// worker every tick; Python calling this module's CLI via subprocess is the
+// same pattern, one level down.
+import { readFileSync } from 'node:fs';
+
+export function shouldRetry({
+  attempts = 0,
+  lastAttemptAt = null,
+  nowMs = Date.now(),
+  maxAttempts,
+  backoffBaseMs,
+} = {}) {
+  const attemptCount = Number(attempts ?? 0);
+  if (attemptCount >= maxAttempts) {
+    return { action: 'needs-human', attempts: attemptCount };
+  }
+  if (lastAttemptAt) {
+    const lastAttemptMs = Date.parse(lastAttemptAt);
+    if (Number.isFinite(lastAttemptMs)) {
+      const backoffUntilMs = lastAttemptMs + (backoffBaseMs * (2 ** attemptCount));
+      if (nowMs < backoffUntilMs) {
+        return { action: 'backoff', attempts: attemptCount, backoffUntilMs };
+      }
+    }
+  }
+  return { action: 'file', attempts: attemptCount };
+}
+
+export function isStale({ lastObservedAt, nowMs = Date.now(), staleMs } = {}) {
+  const observedMs = lastObservedAt ? new Date(lastObservedAt).getTime() : NaN;
+  return Number.isFinite(observedMs) && (nowMs - observedMs) > staleMs;
+}
+
+function readJsonArg(argv) {
+  const flagIndex = argv.indexOf('--json');
+  if (flagIndex !== -1 && argv[flagIndex + 1]) {
+    return argv[flagIndex + 1];
+  }
+  return readFileSync(0, 'utf8');
+}
+
+function usage() {
+  return [
+    'Usage: node scripts/retry-ledger.mjs decide --json \'<input>\'',
+    '  input: {"attempts":2,"lastAttemptAt":"2026-08-14T09:41:32Z","nowMs":1786732000000,"maxAttempts":3,"backoffBaseMs":1800000}',
+    '  (or pipe the same JSON object on stdin instead of --json)',
+    'Prints one JSON decision to stdout: {"action":"file"|"backoff"|"needs-human", ...}',
+  ].join('\n');
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const [command, ...rest] = argv;
+  if (command !== 'decide') {
+    console.error(`retry-ledger: unknown command "${command ?? ''}"\n\n${usage()}`);
+    process.exitCode = 1;
+    return;
+  }
+  let input;
+  try {
+    input = JSON.parse(readJsonArg(rest));
+  } catch (err) {
+    console.error(`retry-ledger: invalid JSON input: ${err.message}\n\n${usage()}`);
+    process.exitCode = 1;
+    return;
+  }
+  const result = shouldRetry({
+    attempts: input.attempts,
+    lastAttemptAt: input.lastAttemptAt,
+    nowMs: input.nowMs,
+    maxAttempts: input.maxAttempts,
+    backoffBaseMs: input.backoffBaseMs,
+  });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main().catch((err) => {
+    console.error('retry-ledger: fatal error', err);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/retry-ledger.test.mjs
+++ b/scripts/retry-ledger.test.mjs
@@ -1,0 +1,90 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { shouldRetry, isStale } from './retry-ledger.mjs';
+
+const SCRIPT_PATH = join(dirname(fileURLToPath(import.meta.url)), 'retry-ledger.mjs');
+const STALE_OBSERVATION_MS = 3 * 24 * 60 * 60 * 1000;
+
+describe('shouldRetry', () => {
+  it('files when there are no prior attempts', () => {
+    const result = shouldRetry({ attempts: 0, lastAttemptAt: null, nowMs: 1000, maxAttempts: 3, backoffBaseMs: 1_800_000 });
+    assert.deepEqual(result, { action: 'file', attempts: 0 });
+  });
+
+  it('backs off when still inside the exponential backoff window', () => {
+    const lastAttemptAt = new Date(1_000_000).toISOString();
+    const result = shouldRetry({
+      attempts: 1,
+      lastAttemptAt,
+      nowMs: 1_000_000 + 1_800_000, // exactly at the 2^1 * base boundary, still short of it below
+      maxAttempts: 3,
+      backoffBaseMs: 1_800_000,
+    });
+    assert.equal(result.action, 'backoff');
+    assert.equal(result.attempts, 1);
+    assert.equal(result.backoffUntilMs, 1_000_000 + 1_800_000 * 2);
+  });
+
+  it('files again once the backoff window has passed', () => {
+    const lastAttemptAt = new Date(1_000_000).toISOString();
+    const result = shouldRetry({
+      attempts: 1,
+      lastAttemptAt,
+      nowMs: 1_000_000 + 1_800_000 * 2 + 1,
+      maxAttempts: 3,
+      backoffBaseMs: 1_800_000,
+    });
+    assert.deepEqual(result, { action: 'file', attempts: 1 });
+  });
+
+  it('needs-human once attempts reach the cap, regardless of backoff timing', () => {
+    const result = shouldRetry({ attempts: 3, lastAttemptAt: null, nowMs: 1000, maxAttempts: 3, backoffBaseMs: 1_800_000 });
+    assert.deepEqual(result, { action: 'needs-human', attempts: 3 });
+  });
+});
+
+describe('isStale', () => {
+  it('is false just inside the window and true just past it', () => {
+    const lastObservedAt = '2026-08-06T01:21:00.000Z';
+    const lastObservedMs = new Date(lastObservedAt).getTime();
+    assert.equal(
+      isStale({ lastObservedAt, nowMs: lastObservedMs + STALE_OBSERVATION_MS - 1, staleMs: STALE_OBSERVATION_MS }),
+      false,
+    );
+    assert.equal(
+      isStale({ lastObservedAt, nowMs: lastObservedMs + STALE_OBSERVATION_MS + 1, staleMs: STALE_OBSERVATION_MS }),
+      true,
+    );
+  });
+});
+
+describe('CLI (e2e, real subprocess)', () => {
+  it('decide reads --json and prints the decision to stdout', () => {
+    const input = JSON.stringify({
+      attempts: 2,
+      lastAttemptAt: '2026-08-14T09:41:32Z',
+      nowMs: Date.parse('2026-08-14T09:41:32Z') + 1_800_000 * 4 + 1,
+      maxAttempts: 3,
+      backoffBaseMs: 1_800_000,
+    });
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, 'decide', '--json', input], { encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), { action: 'file', attempts: 2 });
+  });
+
+  it('decide reads JSON from stdin when --json is not given', () => {
+    const input = JSON.stringify({ attempts: 0, lastAttemptAt: null, nowMs: 1000, maxAttempts: 3, backoffBaseMs: 1_800_000 });
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, 'decide'], { input, encoding: 'utf8' });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), { action: 'file', attempts: 0 });
+  });
+
+  it('exits non-zero with usage text on an unknown command', () => {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, 'bogus'], { encoding: 'utf8' });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /unknown command/);
+  });
+});

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -1003,6 +1003,31 @@ class InfraCrashDoesNotCountAgainstCap(PlannerTestCase):
         self.assertIsNone(action)
 
 
+class RepairAttemptResetsOnNewHeadSha(PlannerTestCase):
+    """A repair attempt that successfully pushes a commit changes head_sha as
+    a normal side effect. Ledger.count() filters on head_sha, so the retry
+    cap never accumulates for a check that keeps almost-but-not-quite getting
+    fixed -- only for a PR that's completely frozen on one sha. Reproduces
+    the live incident: PR 9067's ui-vitest check refiled repeatedly across
+    several different head_shas in one day, never once approaching
+    max_repair_attempts=3."""
+
+    def test_plan_direct_repairs_never_caps_across_head_sha_changes(self):
+        ledger = self._ledger()
+        heads = [HEAD, "b" * 40, "c" * 40]
+        for head in heads:
+            ledger.record("repair-check", 1, head, "build", epoch=NOW - 100)
+        # current head is a 4th, brand-new sha -- exactly what a real push
+        # produces as the side effect of the 3 prior repair attempts above.
+        snapshot = pr(labels=frozenset({"admin-bypass"}), checks={"build": check("failure")}, head_ref_oid="d" * 40)
+        facts, _ = self._facts(m.StackGroup("s", (snapshot,)), ledger=ledger)
+        action = p.plan_direct_repairs(facts, ledger, max_repair_attempts=3, now=NOW)
+        # This should be capped: 3 real prior attempts already exist on this
+        # same underlying check. It currently is NOT -- this assertion pins
+        # down the bug's actual (wrong) behavior on purpose, not endorses it.
+        self.assertEqual(action.kind, "repair_check")
+
+
 class PlanStackExecution(PlannerTestCase):
     def test_open_prerequisite_forces_wait_plan(self):
         ledger = self._ledger()


### PR DESCRIPTION
## Summary

The unit-level proof from the previous PR calls the planner's decision function directly, against a hand-built ledger.

This drives the real production code path instead: the actual repair-submission class, backed by a real on-disk ledger, across four simulated ticks, each on a new commit SHA — the exact real-world side effect a successful repair push produces.

Only the actual external submission boundary is faked (it would otherwise shell out to a live Invoker instance), following the same pattern as an existing repro in this same directory.

## Review Claim

Approve that this repro exercises the real repair-submission code path end-to-end, and that its fakes are limited to the one genuine external boundary rather than mocking internal logic.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Three real attempts land as three real ledger rows — nothing is silently dropped by this repro's setup. The bug it demonstrates is in the code under test, not an artifact of the repro's own fakes.

## Slice Rationale

A second, independent proof of the same bug through the real production path, landing right after the unit-level one and before the fix — matching this repo's existing repro convention (`scripts/repro/`) for exactly this kind of hermetic, real-code-path reproduction.

## Non-goals

Does not fix the bug. Does not replace the unit-level test from the previous PR — both stay, testing the same defect at two different levels.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 scripts/repro/repro-mergify-admin-requeue-head-sha-reset.py` — passes today, pinning down the bug's actual (wrong) behavior through the real production code path

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
