### PR TITLE
[Shared Retry Ledger](4b) Confirm the fix through the end-to-end repro

### DIFF
--- a/scripts/repro/repro-mergify-admin-requeue-head-sha-reset.py
+++ b/scripts/repro/repro-mergify-admin-requeue-head-sha-reset.py
@@ -153,14 +153,12 @@ class HeadShaResetThrash(unittest.TestCase):
         for head_sha in HEAD_SHAS[:3]:
             self.assertEqual(self.fresh_ledger().count("repair-check", PR, head_sha, CHECK), 1)
 
-        # This is the bug, pinned down deliberately: on the 4th head_sha, with
-        # 3 real prior attempts already on record, the planner still says
-        # "repair_check" (file a 4th) instead of "comment_blocked" (cap it).
-        # scripts/mergify_admin_requeue_plan.py's Ledger.count() filters on the
-        # CURRENT head_sha, so it can never see the 3 prior rows recorded
-        # under 3 different head_shas.
+        # Fixed: on the 4th head_sha, with 3 real prior attempts already on
+        # record, the planner now correctly caps it instead of filing a 4th.
+        # retry_decision() counts via Ledger.count_by_unit(), which persists
+        # across the head_sha change instead of resetting on every new commit.
         actions = self.planner_actions(HEAD_SHAS[3], NOW + 10)
-        self.assertEqual([(a.kind, a.key) for a in actions], [("repair_check", CHECK)])
+        self.assertEqual([(a.kind, a.key) for a in actions], [("comment_blocked", "capped")])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Flips the end-to-end repro's assertion to the correct, post-fix behavior.

The 4th tick, on the 4th commit SHA, now correctly caps instead of resubmitting — proven through the real production code path, not just the unit-level test.

## Review Claim

Approve that this is the expected, correct outcome now that the previous PR's fix is in place.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The repro's setup is unchanged — same three real prior attempts, same fake external boundary. Only the expected outcome changes, to match the now-fixed behavior.

## Slice Rationale

Kept separate from the fix itself so "does the fix work, proven through the real code path" is its own explicit, reviewable claim, landing right after the fix instead of bundled into it.

## Non-goals

Does not touch the unit-level test (already flipped alongside the fix, since both live in the same file as the planner code it tests).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 scripts/repro/repro-mergify-admin-requeue-head-sha-reset.py` — passes, now asserting the correct (capped) outcome

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Reverting this alone (without reverting the fix) would make this repro red again, correctly reflecting a reintroduced bug
- Data migration? No

</details>
