### PR TITLE
Fail fast on a build-mismatched owner instead of retrying until timeout

### DIFF
--- a/packages/app/src/__tests__/headless-client-build-mismatch.test.ts
+++ b/packages/app/src/__tests__/headless-client-build-mismatch.test.ts
@@ -1,0 +1,94 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LocalBus } from '@invoker/transport';
+
+// Isolated in its own file (not headless-client.test.ts) because it mocks
+// build-identity.js at module scope -- vitest scopes vi.mock to the file it
+// appears in, so this cannot leak into the large shared test file.
+vi.mock('../build-identity.js', async () => {
+  const actual = await vi.importActual<typeof import('../build-identity.js')>('../build-identity.js');
+  return {
+    ...actual,
+    currentBuildIdentity: () => ({ version: '1.0.0', sha: 'local-sha-aaa' }),
+  };
+});
+
+import { tryAcquireOwnerBootstrapLock } from '../headless-owner-bootstrap.js';
+import { OwnerBuildMismatchError, ensureStandaloneOwnerViaBootstrap } from '../headless-client.js';
+
+describe('ensureStandaloneOwnerViaBootstrap build-mismatch handling', () => {
+  const savedDbDir = process.env.INVOKER_DB_DIR;
+  const savedTimeout = process.env.INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS;
+  let dbDir: string;
+
+  beforeEach(() => {
+    dbDir = mkdtempSync(join(tmpdir(), 'headless-client-build-mismatch-'));
+    process.env.INVOKER_DB_DIR = dbDir;
+    // Short timeout as a safety net -- the fix should return in well under
+    // this, but a regression back to "poll until timeout" would still fail
+    // the test (just slowly) instead of hanging indefinitely.
+    process.env.INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS = '5000';
+  });
+
+  afterEach(() => {
+    if (savedDbDir === undefined) delete process.env.INVOKER_DB_DIR;
+    else process.env.INVOKER_DB_DIR = savedDbDir;
+    if (savedTimeout === undefined) delete process.env.INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS;
+    else process.env.INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS = savedTimeout;
+    rmSync(dbDir, { recursive: true, force: true });
+  });
+
+  it('fails fast with OwnerBuildMismatchError instead of polling until timeout', async () => {
+    // Hold the bootstrap lock ourselves so the function under test sees
+    // lockAcquired=false and never spawns a real detached owner process.
+    const heldLock = tryAcquireOwnerBootstrapLock(dbDir);
+    expect(heldLock).not.toBeNull();
+
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({
+      ok: true,
+      ownerId: 'owner-mismatched',
+      mode: 'standalone',
+      buildVersion: '1.0.0',
+      buildSha: 'remote-sha-bbb',
+    }));
+
+    const startedAt = Date.now();
+    let thrown: unknown;
+    try {
+      await ensureStandaloneOwnerViaBootstrap(bus);
+    } catch (err) {
+      thrown = err;
+    }
+    const elapsedMs = Date.now() - startedAt;
+    heldLock?.release();
+
+    expect(thrown).toBeInstanceOf(OwnerBuildMismatchError);
+    expect((thrown as Error).message).toContain('remote-sha-bbb');
+    expect((thrown as Error).message).toContain('local-sha-aaa');
+    // Must fail almost immediately, not after waiting out the whole
+    // 5s bootstrap timeout window.
+    expect(elapsedMs).toBeLessThan(2_000);
+  }, 10_000);
+
+  it('still succeeds normally when the discovered owner build matches', async () => {
+    const heldLock = tryAcquireOwnerBootstrapLock(dbDir);
+    expect(heldLock).not.toBeNull();
+
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({
+      ok: true,
+      ownerId: 'owner-matched',
+      mode: 'standalone',
+      buildVersion: '1.0.0',
+      buildSha: 'local-sha-aaa',
+    }));
+
+    await expect(ensureStandaloneOwnerViaBootstrap(bus)).resolves.toBeUndefined();
+    heldLock?.release();
+  }, 10_000);
+});

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -117,6 +117,13 @@ export function isSharedMutationOwnerTimeoutError(error: unknown): error is Shar
   return error instanceof SharedMutationOwnerTimeoutError;
 }
 
+export class OwnerBuildMismatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OwnerBuildMismatchError';
+  }
+}
+
 const STALE_OWNER_NO_TRACK_TASK_COMMANDS = new Set([
   'retry-task',
   'recreate-task',
@@ -536,7 +543,7 @@ export interface HeadlessClientDeps {
   runElectronHeadless: (args: string[]) => Promise<number>;
 }
 
-async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void> {
+export async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void> {
   const invokerHomeRoot = resolveInvokerHomeRoot();
   const bootstrapLock = tryAcquireOwnerBootstrapLock(invokerHomeRoot);
   const startedAt = Date.now();
@@ -551,6 +558,12 @@ async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void>
     while (Date.now() < deadline) {
       attempts += 1;
       const owner = await discoverOwner(bus, 1500);
+      if (owner?.buildMismatchReason) {
+        delegationClientLog(
+          `bootstrap build mismatch attempts=${attempts} elapsedMs=${Date.now() - startedAt} ownerId=${owner.ownerId}: ${owner.buildMismatchReason}`,
+        );
+        throw new OwnerBuildMismatchError(owner.buildMismatchReason);
+      }
       if (isStandaloneCapable(owner)) {
         delegationClientLog(
           `bootstrap owner ready attempts=${attempts} elapsedMs=${Date.now() - startedAt} ownerId=${owner.ownerId}`,


### PR DESCRIPTION
## Summary

Found live on DO1: starting a plan from the command line hung for over four minutes before someone had to kill it by hand.

The CLI already knew exactly why. It computes a clear reason the moment it notices the running app is a different build than itself.

That reason just never reached the code deciding whether to keep waiting. So it kept quietly polling until a generic timeout fired, instead of stopping right away.

This makes the wait loop check for that reason on every poll and stop immediately once it sees one.

## Review Claim

Approve that a build-mismatched owner now fails the command in about a second with its real reason, instead of polling silently for up to a minute across three passes before a generic timeout.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the failure path changes. When the discovered owner's build genuinely matches, behavior stays the same (covered by the second new test). The existing bootstrap lock is still acquired and released exactly as before; the new early-return sits inside the same try/finally.

## Slice Rationale

One narrow fix at the exact point the reason was being discarded, plus its own test file kept separate from the large existing `headless-client.test.ts` because it needs to fake build identity at module scope.

## Non-goals

Does not address why the two builds went out of sync on DO1 in the first place (a packaged GUI app vs. a freshly compiled CLI, installed through two different pipelines) -- that is a deployment gap, not something this change can fix.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm exec vitest run src/__tests__/headless-client-build-mismatch.test.ts` (from `packages/app`) -- both new cases pass; proven failing first against the pre-fix code (missing exports), then passing after, real output captured both times.
- [ ] `pnpm exec vitest run src/__tests__/headless-client.test.ts src/__tests__/headless-client-build-mismatch.test.ts src/__tests__/owner-resolver.test.ts src/__tests__/owner-endpoint.test.ts src/__tests__/headless-owner-bootstrap.test.ts` (from `packages/app`) -- 86/86 pass, no change in behavior for the surrounding owner-discovery suites.
- [ ] Live check on DO1 against a real mismatched owner: before the fix, `./run.sh --headless run <plan> --no-track` hung 4+ minutes and had to be killed; after the fix and a real rebuild, the same command failed in 1.4s with the real build-mismatch message, and left no extra processes behind.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None -- reverting restores the previous (slow, generic-timeout) failure mode, not a crash
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standalone owner startup now detects mismatched builds earlier and stops with a clear error.
  * Error messages include both the expected and discovered build identifiers.
  * Matching builds continue startup normally.

* **Tests**
  * Added coverage for build-mismatch failures and successful matching-build startup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->