### PR TITLE
[Repair In-Flight Settlement](1) Settle ad-hoc repair-plan rows on failure

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -17,6 +17,7 @@ try:
     from .mergify_admin_requeue_snapshot import GhClient
     from .mergify_admin_requeue_workflow_fastpath import (
         resolve_workflow_for_pr,
+        settle_repairer_plan_rows,
         settle_workflow_fastpath_rows,
         submit_rebase_recreate,
         submit_repair_review_gate_ci,
@@ -31,6 +32,7 @@ except ImportError:
     from mergify_admin_requeue_snapshot import GhClient
     from mergify_admin_requeue_workflow_fastpath import (
         resolve_workflow_for_pr,
+        settle_repairer_plan_rows,
         settle_workflow_fastpath_rows,
         submit_rebase_recreate,
         submit_repair_review_gate_ci,
@@ -126,6 +128,12 @@ def run_cycle(args: argparse.Namespace) -> bool:
             logger.trace("admin-bypass-fastpath-settled", count=fastpath_settled)
     except Exception as exc:
         logger.trace("admin-bypass-fastpath-settle-failed", error=str(exc))
+    try:
+        repairer_plan_settled = settle_repairer_plan_rows(ledger, now)
+        if repairer_plan_settled:
+            logger.trace("admin-bypass-repairer-plan-settled", count=repairer_plan_settled)
+    except Exception as exc:
+        logger.trace("admin-bypass-repairer-plan-settle-failed", error=str(exc))
     pr_by_number = {pr.number: pr for stack in stacks for pr in stack.prs}
     logger.trace(
         "admin-bypass-scan-loaded",

--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -10,9 +10,19 @@ from pathlib import Path
 try:
     from .mergify_admin_requeue_headless_shell import DEFAULT_TIMEOUT_SECONDS
     from .mergify_admin_requeue_headless_shell import run_headless as _run_headless
+    from .mergify_admin_requeue_async_repair import (
+        repair_bot_thread_plan_name,
+        repair_check_plan_name,
+        repair_conflict_plan_name,
+    )
 except ImportError:
     from mergify_admin_requeue_headless_shell import DEFAULT_TIMEOUT_SECONDS
     from mergify_admin_requeue_headless_shell import run_headless as _run_headless
+    from mergify_admin_requeue_async_repair import (
+        repair_bot_thread_plan_name,
+        repair_check_plan_name,
+        repair_conflict_plan_name,
+    )
 
 
 def resolve_workflow_for_pr(pr_number: int) -> str | None:
@@ -142,6 +152,85 @@ def settle_workflow_fastpath_rows(ledger, now: int) -> int:
             ledger.record(
                 f"{kind}-settled", pr, head, key, now,
                 meta={"workflowId": str(workflow_id), "workflowStatus": status, "settledBy": "fastpath-observer"},
+            )
+            settled += 1
+    return settled
+
+
+def list_workflows() -> list[dict] | None:
+    """List every known workflow. Used by settle_repairer_plan_rows, which
+    (unlike settle_workflow_fastpath_rows) has no workflowId to look up
+    directly and must find its match by name instead."""
+    completed = _run_headless('headless_query query workflows --output json')
+    if completed.returncode != 0:
+        return None
+    text = completed.stdout.strip()
+    if not text:
+        return None
+    for line in reversed(text.splitlines()):
+        line = line.strip()
+        if not line.startswith("["):
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, list):
+            return parsed
+    return None
+
+
+# repairer.py's ad-hoc repair plans (repair-check, conflict-repair,
+# repair-bot-thread) settle via their own plan's `safe-push` task, which only
+# runs if the upstream `repair` task succeeds. When `repair` itself fails,
+# `safe-push` never runs and the `-settled` row is never written -- the row
+# repairer.py records before submission (see AdminBypassRepairer) carries no
+# meta.workflowId, so settle_workflow_fastpath_rows's lookup can't find it
+# either. Unlike a fast-path rebase-recreate, these plan names are fully
+# deterministic from (pr, headSha, key) via the same *_plan_name() helpers
+# used to build the plan, so the matching workflow can be found by name
+# instead of by a recorded id (PR #9172: a failed repair-bot-thread attempt
+# left `repair_in_flight` believing a repair was still running for the rest
+# of its 90-minute TTL, even though the workflow had already failed).
+_REPAIRER_PLAN_SETTLE_KINDS = ("repair-check", "conflict-repair", "repair-bot-thread")
+
+
+def _repairer_plan_name(kind: str, pr: int, head: str, key: str) -> str:
+    if kind == "repair-check":
+        return repair_check_plan_name(pr, key, head)
+    if kind == "conflict-repair":
+        return repair_conflict_plan_name(pr, head)
+    return repair_bot_thread_plan_name(pr, head)
+
+
+def settle_repairer_plan_rows(ledger, now: int) -> int:
+    """Write `<kind>-settled` rows for repairer.py's ad-hoc repair plans whose
+    workflow reached a terminal status but whose own safe-push task never ran
+    to write it. Returns how many rows were settled."""
+    pending = [row for row in ledger.rows if row.get("kind") in _REPAIRER_PLAN_SETTLE_KINDS]
+    if not pending:
+        return 0
+    workflows: list[dict] | None = None
+    settled = 0
+    for row in pending:
+        kind = str(row.get("kind"))
+        pr = int(row.get("pr", -1))
+        head = str(row.get("headSha") or "")
+        key = str(row.get("key") or "")
+        existing = ledger.latest(f"{kind}-settled", pr, head, key)
+        if existing is not None and int(existing.get("epoch", 0) or 0) >= int(row.get("epoch", 0) or 0):
+            continue
+        if workflows is None:
+            workflows = list_workflows() or []
+        plan_name = _repairer_plan_name(kind, pr, head, key)
+        match = next((w for w in workflows if w.get("name") == plan_name), None)
+        if match is None:
+            continue
+        status = match.get("status")
+        if status in _TERMINAL_WORKFLOW_STATUSES:
+            ledger.record(
+                f"{kind}-settled", pr, head, key, now,
+                meta={"workflowId": match.get("id"), "workflowStatus": status, "settledBy": "repairer-plan-observer"},
             )
             settled += 1
     return settled

--- a/scripts/test_mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/test_mergify_admin_requeue_workflow_fastpath.py
@@ -174,3 +174,84 @@ class FastpathSettleObserver(unittest.TestCase):
     def test_parse_last_json_object_skips_noise_lines(self):
         stdout = '[invoker] maxConcurrency=13 exceeds pool capacity\n{"id": "wf-1", "status": "failed"}\n'
         self.assertEqual(f._parse_last_json_object(stdout), {"id": "wf-1", "status": "failed"})
+
+
+class RepairerPlanSettleObserver(unittest.TestCase):
+    def _ledger(self, tmpdir):
+        from mergify_admin_requeue_model import Ledger
+        return Ledger(Path(tmpdir) / "state.jsonl")
+
+    def test_settles_a_failed_bot_thread_repair_by_matching_its_plan_name(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            head = "7bbccbd" + "0" * 33
+            ledger.record("repair-bot-thread", 9172, head, "PRRT_thread1", 100)
+            plan_name = f.repair_bot_thread_plan_name(9172, head)
+            workflows = [{"id": "wf-1", "name": plan_name, "status": "failed"}]
+            with mock.patch.object(f, "list_workflows", return_value=workflows):
+                settled = f.settle_repairer_plan_rows(ledger, 200)
+            self.assertEqual(settled, 1)
+            row = ledger.latest("repair-bot-thread-settled", 9172, head, "PRRT_thread1")
+            self.assertIsNotNone(row)
+            self.assertEqual(row["meta"]["workflowStatus"], "failed")
+            self.assertEqual(row["meta"]["workflowId"], "wf-1")
+
+    def test_settles_a_failed_check_repair_and_a_failed_conflict_repair_too(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            head = "abc1234" + "0" * 33
+            ledger.record("repair-check", 100, head, "UI Vitest", 100)
+            ledger.record("conflict-repair", 200, head, "conflict:200", 100)
+            workflows = [
+                {"id": "wf-c1", "name": f.repair_check_plan_name(100, "UI Vitest", head), "status": "failed"},
+                {"id": "wf-c2", "name": f.repair_conflict_plan_name(200, head), "status": "completed"},
+            ]
+            with mock.patch.object(f, "list_workflows", return_value=workflows):
+                settled = f.settle_repairer_plan_rows(ledger, 200)
+            self.assertEqual(settled, 2)
+            self.assertIsNotNone(ledger.latest("repair-check-settled", 100, head, "UI Vitest"))
+            self.assertIsNotNone(ledger.latest("conflict-repair-settled", 200, head, "conflict:200"))
+
+    def test_leaves_a_still_running_repair_unsettled(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            head = "7bbccbd" + "0" * 33
+            ledger.record("repair-bot-thread", 9172, head, "PRRT_thread1", 100)
+            plan_name = f.repair_bot_thread_plan_name(9172, head)
+            workflows = [{"id": "wf-1", "name": plan_name, "status": "running"}]
+            with mock.patch.object(f, "list_workflows", return_value=workflows):
+                self.assertEqual(f.settle_repairer_plan_rows(ledger, 200), 0)
+            self.assertIsNone(ledger.latest("repair-bot-thread-settled", 9172, head, "PRRT_thread1"))
+
+    def test_does_not_resettle_an_already_settled_row(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            head = "7bbccbd" + "0" * 33
+            ledger.record("repair-bot-thread", 9172, head, "PRRT_thread1", 100)
+            ledger.record("repair-bot-thread-settled", 9172, head, "PRRT_thread1", 150,
+                          meta={"workflowId": "wf-1"})
+            with mock.patch.object(f, "list_workflows") as listed:
+                self.assertEqual(f.settle_repairer_plan_rows(ledger, 200), 0)
+                listed.assert_not_called()
+
+    def test_does_not_call_list_workflows_when_nothing_is_pending(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            with mock.patch.object(f, "list_workflows") as listed:
+                self.assertEqual(f.settle_repairer_plan_rows(ledger, 200), 0)
+                listed.assert_not_called()
+
+    def test_unmatched_workflow_name_leaves_row_for_ttl_backstop(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            head = "7bbccbd" + "0" * 33
+            ledger.record("repair-bot-thread", 9172, head, "PRRT_thread1", 100)
+            with mock.patch.object(f, "list_workflows", return_value=[]):
+                self.assertEqual(f.settle_repairer_plan_rows(ledger, 200), 0)
+            self.assertIsNone(ledger.latest("repair-bot-thread-settled", 9172, head, "PRRT_thread1"))


### PR DESCRIPTION
## Summary

Live on DO1: PR #9172's bot-thread repair failed in under a minute, but the worker kept treating it as running for nearly an hour, blocking the whole PR stack behind it.

Each ad-hoc repair plan closes out its own ledger row through a step inside that same plan, one that only runs if the earlier repair step went well. A failed repair step means that closing-out step never runs.

From then on there is no record that the attempt is over, only a real record that it started. The worker keeps deferring to a 90-minute window meant for genuinely slow work, not an attempt that already ended.

This adds a second pass that finds those rows by their own predictable name and closes them out the moment the matching run reaches any final state, win or lose.

## Review Claim

Approve that an attempt whose own step failed is now recognized as over (not just one whose own step went well), using the exact name it was launched under to find the matching run.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only adds a second observation pass; nothing about how an attempt is launched, how the existing pass behaves, or the 90-minute window itself changes. A run this pass cannot match is left exactly as before, deferring to that same window as a backstop.

## Slice Rationale

The fix and its unit tests land here; the end-to-end proof against the real functions lands as its own following slice, since this repo keeps proof files in a separate review unit from policy/tooling files.

## Non-goals

Does not change anything about how repairs are chosen, launched, or capped. Does not touch the existing pass or the 90-minute window itself.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -m unittest scripts.test_mergify_admin_requeue_workflow_fastpath -v` (from repo root) -- 22/22 pass, 6 new, proven failing first against the prior code, then passing after, real output captured both times.
- [ ] `python3 -m unittest scripts.test_mergify_admin_requeue scripts.test_mergify_admin_requeue_model scripts.test_mergify_admin_requeue_plan scripts.test_mergify_admin_requeue_snapshot scripts.test_mergify_admin_requeue_infra_signal scripts.test_mergify_admin_requeue_workflow_fastpath` (from repo root) -- 227/227 pass, no change in behavior for the surrounding suites.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None -- reverting restores the previous behavior (deferring to the 90-minute window), not a crash
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repair workflow recovery by automatically settling completed or failed repair records.
  * Added support for matching repairs across bot-thread, check, and conflict workflows.
  * Preserved active, unmatched, and already-settled records without changing their status.

* **Reliability**
  * Recovery scans now report settlement results and handle settlement failures gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->