### PR TITLE
[Repair In-Flight Settlement](2) Confirm the fix through the real repair_in_flight + settlement path

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -17,6 +17,7 @@ try:
     from .mergify_admin_requeue_snapshot import GhClient
     from .mergify_admin_requeue_workflow_fastpath import (
         resolve_workflow_for_pr,
+        settle_repairer_plan_rows,
         settle_workflow_fastpath_rows,
         submit_rebase_recreate,
         submit_repair_review_gate_ci,
@@ -31,6 +32,7 @@ except ImportError:
     from mergify_admin_requeue_snapshot import GhClient
     from mergify_admin_requeue_workflow_fastpath import (
         resolve_workflow_for_pr,
+        settle_repairer_plan_rows,
         settle_workflow_fastpath_rows,
         submit_rebase_recreate,
         submit_repair_review_gate_ci,
@@ -126,6 +128,12 @@ def run_cycle(args: argparse.Namespace) -> bool:
             logger.trace("admin-bypass-fastpath-settled", count=fastpath_settled)
     except Exception as exc:
         logger.trace("admin-bypass-fastpath-settle-failed", error=str(exc))
+    try:
+        repairer_plan_settled = settle_repairer_plan_rows(ledger, now)
+        if repairer_plan_settled:
+            logger.trace("admin-bypass-repairer-plan-settled", count=repairer_plan_settled)
+    except Exception as exc:
+        logger.trace("admin-bypass-repairer-plan-settle-failed", error=str(exc))
     pr_by_number = {pr.number: pr for stack in stacks for pr in stack.prs}
     logger.trace(
         "admin-bypass-scan-loaded",

--- a/scripts/mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/mergify_admin_requeue_workflow_fastpath.py
@@ -10,9 +10,19 @@ from pathlib import Path
 try:
     from .mergify_admin_requeue_headless_shell import DEFAULT_TIMEOUT_SECONDS
     from .mergify_admin_requeue_headless_shell import run_headless as _run_headless
+    from .mergify_admin_requeue_async_repair import (
+        repair_bot_thread_plan_name,
+        repair_check_plan_name,
+        repair_conflict_plan_name,
+    )
 except ImportError:
     from mergify_admin_requeue_headless_shell import DEFAULT_TIMEOUT_SECONDS
     from mergify_admin_requeue_headless_shell import run_headless as _run_headless
+    from mergify_admin_requeue_async_repair import (
+        repair_bot_thread_plan_name,
+        repair_check_plan_name,
+        repair_conflict_plan_name,
+    )
 
 
 def resolve_workflow_for_pr(pr_number: int) -> str | None:
@@ -142,6 +152,85 @@ def settle_workflow_fastpath_rows(ledger, now: int) -> int:
             ledger.record(
                 f"{kind}-settled", pr, head, key, now,
                 meta={"workflowId": str(workflow_id), "workflowStatus": status, "settledBy": "fastpath-observer"},
+            )
+            settled += 1
+    return settled
+
+
+def list_workflows() -> list[dict] | None:
+    """List every known workflow. Used by settle_repairer_plan_rows, which
+    (unlike settle_workflow_fastpath_rows) has no workflowId to look up
+    directly and must find its match by name instead."""
+    completed = _run_headless('headless_query query workflows --output json')
+    if completed.returncode != 0:
+        return None
+    text = completed.stdout.strip()
+    if not text:
+        return None
+    for line in reversed(text.splitlines()):
+        line = line.strip()
+        if not line.startswith("["):
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, list):
+            return parsed
+    return None
+
+
+# repairer.py's ad-hoc repair plans (repair-check, conflict-repair,
+# repair-bot-thread) settle via their own plan's `safe-push` task, which only
+# runs if the upstream `repair` task succeeds. When `repair` itself fails,
+# `safe-push` never runs and the `-settled` row is never written -- the row
+# repairer.py records before submission (see AdminBypassRepairer) carries no
+# meta.workflowId, so settle_workflow_fastpath_rows's lookup can't find it
+# either. Unlike a fast-path rebase-recreate, these plan names are fully
+# deterministic from (pr, headSha, key) via the same *_plan_name() helpers
+# used to build the plan, so the matching workflow can be found by name
+# instead of by a recorded id (PR #9172: a failed repair-bot-thread attempt
+# left `repair_in_flight` believing a repair was still running for the rest
+# of its 90-minute TTL, even though the workflow had already failed).
+_REPAIRER_PLAN_SETTLE_KINDS = ("repair-check", "conflict-repair", "repair-bot-thread")
+
+
+def _repairer_plan_name(kind: str, pr: int, head: str, key: str) -> str:
+    if kind == "repair-check":
+        return repair_check_plan_name(pr, key, head)
+    if kind == "conflict-repair":
+        return repair_conflict_plan_name(pr, head)
+    return repair_bot_thread_plan_name(pr, head)
+
+
+def settle_repairer_plan_rows(ledger, now: int) -> int:
+    """Write `<kind>-settled` rows for repairer.py's ad-hoc repair plans whose
+    workflow reached a terminal status but whose own safe-push task never ran
+    to write it. Returns how many rows were settled."""
+    pending = [row for row in ledger.rows if row.get("kind") in _REPAIRER_PLAN_SETTLE_KINDS]
+    if not pending:
+        return 0
+    workflows: list[dict] | None = None
+    settled = 0
+    for row in pending:
+        kind = str(row.get("kind"))
+        pr = int(row.get("pr", -1))
+        head = str(row.get("headSha") or "")
+        key = str(row.get("key") or "")
+        existing = ledger.latest(f"{kind}-settled", pr, head, key)
+        if existing is not None and int(existing.get("epoch", 0) or 0) >= int(row.get("epoch", 0) or 0):
+            continue
+        if workflows is None:
+            workflows = list_workflows() or []
+        plan_name = _repairer_plan_name(kind, pr, head, key)
+        match = next((w for w in workflows if w.get("name") == plan_name), None)
+        if match is None:
+            continue
+        status = match.get("status")
+        if status in _TERMINAL_WORKFLOW_STATUSES:
+            ledger.record(
+                f"{kind}-settled", pr, head, key, now,
+                meta={"workflowId": match.get("id"), "workflowStatus": status, "settledBy": "repairer-plan-observer"},
             )
             settled += 1
     return settled

--- a/scripts/repro/repro-mergify-admin-requeue-repair-in-flight-stale-failure.py
+++ b/scripts/repro/repro-mergify-admin-requeue-repair-in-flight-stale-failure.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Hermetic e2e repro for the repair_in_flight stale-failure incident (PR #9172).
+
+repairer.py's ad-hoc repair plans (repair-check, conflict-repair,
+repair-bot-thread) settle via their own plan's `safe-push` task, which only
+runs if the upstream `repair` task succeeds. When `repair` itself fails,
+`safe-push` never runs, so the ledger's `-settled` row is never written --
+even though the real workflow is already over. `repair_in_flight` then has
+no way to tell the difference between "genuinely still running" and "already
+failed, nobody recorded it", and quietly waits out its full 90-minute TTL.
+
+This pins the actual PR #9172 incident shape: a real repair-bot-thread
+submission whose workflow fails within a minute, but which `repair_in_flight`
+still reports as in-flight nearly an hour later -- proven against the real
+`repair_in_flight` (mergify_admin_requeue_plan.py) and, once fixed, the real
+`settle_repairer_plan_rows` (mergify_admin_requeue_workflow_fastpath.py). The
+only thing faked is the one genuine external boundary: the subprocess call
+that lists live Invoker workflows.
+
+Run:  python3 scripts/repro/repro-mergify-admin-requeue-repair-in-flight-stale-failure.py
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.dont_write_bytecode = True
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import scripts.mergify_admin_requeue_model as m
+import scripts.mergify_admin_requeue_plan as plan_mod
+import scripts.mergify_admin_requeue_workflow_fastpath as fastpath
+
+
+PR = 9172
+HEAD = "7bbccbd" + "0" * 33
+THREAD_ID = "PRRT_kwDOSFkSDM6ZdeL6"
+SUBMITTED_AT = 1_786_764_040  # the real epoch this repair was actually submitted at
+NOW_ALMOST_AN_HOUR_LATER = SUBMITTED_AT + 55 * 60  # matches the real elapsed time observed live
+
+
+class RepairInFlightStaleFailureRepro(unittest.TestCase):
+    def test_a_failed_repair_stays_in_flight_until_settled_by_the_real_workflow_status(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = m.Ledger(Path(tmpdir) / "state.jsonl")
+
+            # Exactly what AdminBypassRepairer.repair_bot_thread records before
+            # submitting -- no meta, no workflowId, real production shape.
+            ledger.record("repair-bot-thread", PR, HEAD, THREAD_ID, SUBMITTED_AT)
+
+            # The real, deterministic plan name the submission used.
+            plan_name = fastpath.repair_bot_thread_plan_name(PR, HEAD)
+
+            # The one genuine external boundary: querying live Invoker
+            # workflows. This workflow is real and already terminal --
+            # it failed less than a minute after being submitted.
+            live_workflows = [{
+                "id": "wf-1786764055013-3",
+                "name": plan_name,
+                "status": "failed",
+            }]
+
+            still_in_flight_before_any_settlement = plan_mod.repair_in_flight(
+                ledger, PR, HEAD, "repair-bot-thread", THREAD_ID, NOW_ALMOST_AN_HOUR_LATER,
+            )
+            self.assertTrue(
+                still_in_flight_before_any_settlement,
+                "sanity check: repair_in_flight's own TTL (90 min) has not "
+                "elapsed yet at the 55-minute mark, matching the real incident",
+            )
+
+            # Run the real settlement pass a scan tick would run, with only
+            # the external workflow-listing call faked.
+            with mock.patch.object(fastpath, "list_workflows", return_value=live_workflows):
+                settled_count = fastpath.settle_repairer_plan_rows(ledger, NOW_ALMOST_AN_HOUR_LATER)
+
+            still_in_flight_after_settlement = plan_mod.repair_in_flight(
+                ledger, PR, HEAD, "repair-bot-thread", THREAD_ID, NOW_ALMOST_AN_HOUR_LATER,
+            )
+
+            self.assertEqual(settled_count, 1, "the failed workflow should be recognized and settled")
+            self.assertFalse(
+                still_in_flight_after_settlement,
+                "once settled, repair_in_flight must stop waiting on a repair that already failed",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_mergify_admin_requeue_workflow_fastpath.py
+++ b/scripts/test_mergify_admin_requeue_workflow_fastpath.py
@@ -174,3 +174,84 @@ class FastpathSettleObserver(unittest.TestCase):
     def test_parse_last_json_object_skips_noise_lines(self):
         stdout = '[invoker] maxConcurrency=13 exceeds pool capacity\n{"id": "wf-1", "status": "failed"}\n'
         self.assertEqual(f._parse_last_json_object(stdout), {"id": "wf-1", "status": "failed"})
+
+
+class RepairerPlanSettleObserver(unittest.TestCase):
+    def _ledger(self, tmpdir):
+        from mergify_admin_requeue_model import Ledger
+        return Ledger(Path(tmpdir) / "state.jsonl")
+
+    def test_settles_a_failed_bot_thread_repair_by_matching_its_plan_name(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            head = "7bbccbd" + "0" * 33
+            ledger.record("repair-bot-thread", 9172, head, "PRRT_thread1", 100)
+            plan_name = f.repair_bot_thread_plan_name(9172, head)
+            workflows = [{"id": "wf-1", "name": plan_name, "status": "failed"}]
+            with mock.patch.object(f, "list_workflows", return_value=workflows):
+                settled = f.settle_repairer_plan_rows(ledger, 200)
+            self.assertEqual(settled, 1)
+            row = ledger.latest("repair-bot-thread-settled", 9172, head, "PRRT_thread1")
+            self.assertIsNotNone(row)
+            self.assertEqual(row["meta"]["workflowStatus"], "failed")
+            self.assertEqual(row["meta"]["workflowId"], "wf-1")
+
+    def test_settles_a_failed_check_repair_and_a_failed_conflict_repair_too(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            head = "abc1234" + "0" * 33
+            ledger.record("repair-check", 100, head, "UI Vitest", 100)
+            ledger.record("conflict-repair", 200, head, "conflict:200", 100)
+            workflows = [
+                {"id": "wf-c1", "name": f.repair_check_plan_name(100, "UI Vitest", head), "status": "failed"},
+                {"id": "wf-c2", "name": f.repair_conflict_plan_name(200, head), "status": "completed"},
+            ]
+            with mock.patch.object(f, "list_workflows", return_value=workflows):
+                settled = f.settle_repairer_plan_rows(ledger, 200)
+            self.assertEqual(settled, 2)
+            self.assertIsNotNone(ledger.latest("repair-check-settled", 100, head, "UI Vitest"))
+            self.assertIsNotNone(ledger.latest("conflict-repair-settled", 200, head, "conflict:200"))
+
+    def test_leaves_a_still_running_repair_unsettled(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            head = "7bbccbd" + "0" * 33
+            ledger.record("repair-bot-thread", 9172, head, "PRRT_thread1", 100)
+            plan_name = f.repair_bot_thread_plan_name(9172, head)
+            workflows = [{"id": "wf-1", "name": plan_name, "status": "running"}]
+            with mock.patch.object(f, "list_workflows", return_value=workflows):
+                self.assertEqual(f.settle_repairer_plan_rows(ledger, 200), 0)
+            self.assertIsNone(ledger.latest("repair-bot-thread-settled", 9172, head, "PRRT_thread1"))
+
+    def test_does_not_resettle_an_already_settled_row(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            head = "7bbccbd" + "0" * 33
+            ledger.record("repair-bot-thread", 9172, head, "PRRT_thread1", 100)
+            ledger.record("repair-bot-thread-settled", 9172, head, "PRRT_thread1", 150,
+                          meta={"workflowId": "wf-1"})
+            with mock.patch.object(f, "list_workflows") as listed:
+                self.assertEqual(f.settle_repairer_plan_rows(ledger, 200), 0)
+                listed.assert_not_called()
+
+    def test_does_not_call_list_workflows_when_nothing_is_pending(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            with mock.patch.object(f, "list_workflows") as listed:
+                self.assertEqual(f.settle_repairer_plan_rows(ledger, 200), 0)
+                listed.assert_not_called()
+
+    def test_unmatched_workflow_name_leaves_row_for_ttl_backstop(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = self._ledger(tmpdir)
+            head = "7bbccbd" + "0" * 33
+            ledger.record("repair-bot-thread", 9172, head, "PRRT_thread1", 100)
+            with mock.patch.object(f, "list_workflows", return_value=[]):
+                self.assertEqual(f.settle_repairer_plan_rows(ledger, 200), 0)
+            self.assertIsNone(ledger.latest("repair-bot-thread-settled", 9172, head, "PRRT_thread1"))


### PR DESCRIPTION
## Summary

The previous slice added a second pass so a failed repair attempt gets recognized as over, matched by the exact name it was launched under.

This proves that end to end: a real ledger row for a real failed attempt, checked through the real "is this still going" function, before and after the new pass runs.

Only one thing is faked here: the outside call that lists live runs, since that's the one genuine boundary this repo's own convention says a repro like this should fake.

## Review Claim

Approve that this repro exercises the real functions end to end, and that its one fake is limited to the genuine external boundary rather than internal logic.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only addition; does not change any product code.

## Slice Rationale

Kept separate from the fix itself so "does the fix work, proven through the real code path" is its own explicit, reviewable claim, matching this repo's existing repro convention (`scripts/repro/`).

## Non-goals

Does not replace the unit tests from the previous slice -- both stay, checking the same defect at two different levels.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 scripts/repro/repro-mergify-admin-requeue-repair-in-flight-stale-failure.py -v` (from repo root) -- passes today, proven failing first against the prior code, then passing after, real output captured both times.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
