### PR TITLE
[CI regression: a404e8b-required-fast-start-running-mece-repros](1) Provision native build tools for required-fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,7 +521,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Install system libraries for Node
-        run: sudo apt-get update -qq && sudo apt-get install -y libatomic1
+        run: sudo apt-get update -qq && sudo apt-get install -y libatomic1 make g++
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -111,6 +111,11 @@ assert(
   String(requiredFastExtraNodeLibraryStep?.run ?? '').includes('libatomic1'),
   'required-fast-extra must install libatomic1 before setup-node so Node 26 can start on self-hosted runners',
 );
+assert(
+  String(requiredFastExtraNodeLibraryStep?.run ?? '').includes('make')
+    && String(requiredFastExtraNodeLibraryStep?.run ?? '').includes('g++'),
+  'required-fast-extra must install make and g++ so pnpm can build native dependencies on self-hosted runners',
+);
 const requiredFastExtraEntries = jobs['required-fast-extra'].strategy?.matrix?.include ?? [];
 const mergeGateConcurrencyEntry = requiredFastExtraEntries.find((entry) => entry.name === 'Merge Gate Concurrency Repro');
 assert(mergeGateConcurrencyEntry, 'required-fast-extra matrix must include Merge Gate Concurrency Repro');


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a404e8b02eed8e9522302aece6ebc7f013e598cf; job=required-fast / Start Running MECE Repros -->

CI job `required-fast / Start Running MECE Repros` first failed on default-branch push commit a404e8b02eed8e9522302aece6ebc7f013e598cf in run 31773609297.

It was most recently still red at ec832954ab8db6d657b0605f935b096521b389ff in run 31828467673.

The `required-fast-extra` job now installs `make` and `g++` alongside `libatomic1` before setup-node.

The existing workflow policy test enforces the presence of both packages.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31773609297/job/94684674122

## Review Claim

Approve provisioning the native build tools needed by Start Running MECE Repros and enforcing that CI policy.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged; this slice only changes the `required-fast-extra` system-package install and its policy assertion.

## Slice Rationale

The workflow package update and its directly affected policy assertion form one reviewable CI-policy change.

The verification task changed no files, so its empty slice is folded into this policy slice.

## Non-goals

- No product behavior changes.
- No unrelated CI job changes.
- No test weakening or snapshot churn.
- No refactor or dependency upgrade.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/18-start-running-mece-repros.sh`
- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [x] `node scripts/validate-pr-body-local.mjs --body-file pr-body-a404e8b.md --base master`
- [x] `node scripts/validate-pr-body.mjs --body-file pr-body-a404e8b.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <PR merge commit>`
- Post-revert steps: Re-run the Test Plan commands before re-queueing a replacement CI-policy change.
- Data migration? No

</details>
