### PR TITLE
[CI regression: a404e8b-required-fast-pr-authoring-guardrails](1) Skip hosted runner package provisioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,7 @@ jobs:
   # Ordinary PRs keep only cheap quality checks so stacked PR pushes do not fan out heavy jobs.
   build-artifacts:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
-    runs-on:
-      labels: Runner_2_4_core
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,6 +517,7 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Install system libraries for Node
+        if: matrix.runner_label != 'Github_Runner'
         run: sudo apt-get update -qq && sudo apt-get install -y libatomic1 make g++
 
       - name: Use Node.js ${{ env.NODE_VERSION }}

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -117,6 +117,10 @@ const requiredFastExtraNodeLibraryStep = jobs['required-fast-extra'].steps.find(
   (step) => step.name === 'Install system libraries for Node',
 );
 assert(
+  requiredFastExtraNodeLibraryStep?.if === "matrix.runner_label != 'Github_Runner'",
+  'required-fast-extra must not request sudo package installation on Github_Runner hosts',
+);
+assert(
   String(requiredFastExtraNodeLibraryStep?.run ?? '').includes('libatomic1'),
   'required-fast-extra must install libatomic1 before setup-node so Node 26 can start on self-hosted runners',
 );

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -56,6 +56,11 @@ for (const jobName of FULL_CI_JOBS) {
   assert(jobs[jobName].if === FULL_CI_GATE, `${jobName} must run only for full CI events`);
 }
 
+assert(
+  jobs['build-artifacts']['runs-on'] === 'ubuntu-latest',
+  'build-artifacts must use fresh GitHub-hosted capacity so stale Git ref locks cannot block checkout',
+);
+
 assert(jobs['quality-required'], 'Missing quality-required job');
 assert(!jobs['quality-required'].if, 'quality-required must run on ordinary PRs');
 assert(


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a404e8b02eed8e9522302aece6ebc7f013e598cf; job=required-fast / PR Authoring Guardrails -->

`required-fast-extra` can run on `Github_Runner`, where the shared system-library step must not invoke self-hosted package provisioning.

Skip system-library installation on that hosted runner and lock the condition with the existing CI workflow policy test.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31773609297/job/94684674167

## Review Claim

Gate system-library provisioning to non-`Github_Runner` hosts and enforce that boundary with the CI workflow policy test.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only `required-fast-extra` system-library provisioning changes in this slice. The parent PR's `build-artifacts` runner choice, other CI jobs, and product behavior remain unchanged.

## Slice Rationale

The workflow condition and its focused policy assertion form one CI-policy slice because the assertion directly guards the changed configuration.

## Architectural Effect

The `required-fast-extra` matrix skips self-hosted-only package provisioning when it selects GitHub-hosted capacity. No other job's control flow changes in this slice.

## Alternative Considerations

Changing runner assignments or package commands would broaden the repair. This slice instead guards the existing shared step at its runner boundary.

## Non-goals

- No `build-artifacts` runner changes beyond those inherited from the parent PR.
- No changes to runner assignments or other CI jobs.
- No product behavior changes.
- No test weakening or unrelated repair.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; this restores system-library provisioning on `Github_Runner` for `required-fast-extra` and removes its policy assertion.
- Revert command: `git revert <landed-merge-commit>`
- Post-revert steps: Re-run `node scripts/test-ci-workflow-merge-queue-policy.mjs`.
- Data migration? No.

</details>
