### PR TITLE
[CI regression: ec83295-fleet-ec83295-3-jobs](1) Assign affected jobs to GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,8 +218,7 @@ jobs:
 
   quality-extra:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
-    runs-on:
-      labels: ${{ matrix.runner_label }}
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       fail-fast: false
@@ -227,7 +226,6 @@ jobs:
         include:
           - name: Release Version Sync
             command: pnpm run check:versions
-            runner_label: Runner_2_4_core
 
     name: quality / ${{ matrix.name }}
 
@@ -477,8 +475,7 @@ jobs:
   required-fast-extra:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
-    runs-on:
-      labels: ${{ matrix.runner_label }}
+    runs-on: ${{ matrix.runner_label }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -486,7 +483,7 @@ jobs:
         include:
           - name: Branch Carry Forward
             command: bash scripts/test-suites/required/16-branch-carry-forward.sh
-            runner_label: Runner_2_4_core
+            runner_label: ubuntu-latest
           - name: Merge Gate Concurrency Repro
             command: bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh
             runner_label: Runner_2_4_core
@@ -1014,8 +1011,7 @@ jobs:
   optional-other:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
-    runs-on:
-      labels: ${{ matrix.runner_label }}
+    runs-on: ${{ matrix.runner_label }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -1023,7 +1019,7 @@ jobs:
         include:
           - name: Worktree Provisioning
             command: bash scripts/test-suites/optional/60-worktree-provisioning.sh
-            runner_label: Runner_2_4_core
+            runner_label: ubuntu-latest
           - name: Visual Proof Validate
             command: bash scripts/test-suites/optional/70-ui-visual-proof-validate.sh
             runner_label: Runner_1

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -72,6 +72,10 @@ assert(
 
 assert(jobs['quality-extra'], 'Missing quality-extra job');
 assert(jobs['quality-extra'].if === ORDINARY_PR_GATE, 'quality-extra must run on ordinary PRs and skip merge queue refs');
+assert(
+  jobs['quality-extra']['runs-on'] === 'ubuntu-latest',
+  'Release Version Sync must use fresh GitHub-hosted capacity so stale workspace ownership cannot block checkout',
+);
 
 assert(jobs['typescript-types'], 'Missing typescript-types job');
 assert(
@@ -117,6 +121,12 @@ assert(
   'required-fast-extra must install make and g++ so pnpm can build native dependencies on self-hosted runners',
 );
 const requiredFastExtraEntries = jobs['required-fast-extra'].strategy?.matrix?.include ?? [];
+const branchCarryForwardEntry = requiredFastExtraEntries.find((entry) => entry.name === 'Branch Carry Forward');
+assert(branchCarryForwardEntry, 'required-fast-extra matrix must include Branch Carry Forward');
+assert(
+  branchCarryForwardEntry.runner_label === 'ubuntu-latest',
+  'Branch Carry Forward must use GitHub-hosted capacity with non-interactive system package installation',
+);
 const mergeGateConcurrencyEntry = requiredFastExtraEntries.find((entry) => entry.name === 'Merge Gate Concurrency Repro');
 assert(mergeGateConcurrencyEntry, 'required-fast-extra matrix must include Merge Gate Concurrency Repro');
 assert(
@@ -128,6 +138,13 @@ const optionalOtherSteps = stepNames('optional-other');
 assert(
   optionalOtherSteps[0] === 'Reclaim workspace' && optionalOtherSteps[1] === 'Checkout',
   'optional-other must reclaim the self-hosted runner workspace before checkout',
+);
+const optionalOtherEntries = jobs['optional-other'].strategy?.matrix?.include ?? [];
+const worktreeProvisioningEntry = optionalOtherEntries.find((entry) => entry.name === 'Worktree Provisioning');
+assert(worktreeProvisioningEntry, 'optional-other matrix must include Worktree Provisioning');
+assert(
+  worktreeProvisioningEntry.runner_label === 'ubuntu-latest',
+  'Worktree Provisioning must use GitHub-hosted capacity with non-interactive system package installation',
 );
 
 assert(jobs.docker, 'Missing docker job');


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=ec832954ab8db6d657b0605f935b096521b389ff; job=fleet -->

Three jobs first failed together on default-branch push commit `ec832954ab8db6d657b0605f935b096521b389ff`.

This change assigns those jobs to GitHub-hosted runners and adds policy assertions that lock their runner assignments.

Member jobs:

- [optional / Worktree Provisioning](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31828467673/job/94859701866)
- [quality / Release Version Sync](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31828467673/job/94858228385)
- [required-fast / Branch Carry Forward](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31828467673/job/94859702016)

Repro waiver: these failures depend on self-hosted runner state and cannot be reproduced faithfully on this workstation.

The failing CI logs report:

> Release Version Sync: `File was unable to be removed Error: EACCES: permission denied, rmdir '/home/runner/actions-runner/_work/Invoker/Invoker/.git/invoker-test-all-logs/20260814-102225-1304'`

> Worktree Provisioning: `sudo: a terminal is required to read the password`

> Branch Carry Forward: `sudo: a terminal is required to read the password`

## Review Claim

Approve assigning Release Version Sync, Worktree Provisioning, and Branch Carry Forward to `ubuntu-latest`, with focused policy assertions preserving those assignments.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect. Unaffected matrix entries retain their existing commands and runner labels.

## Slice Rationale

One CI policy slice covers the three fleet-correlated failures because they share the same self-hosted runner constraint and one focused policy test.

## Non-goals

- No product behavior changes.
- No changes to unrelated workflow configuration or runner assignments.
- No weakened checks, job deletions, or snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:versions`
- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting restores the previous runner assignments.
- Revert command: `git revert dadd94c3cd6381c8305284f67bdaac86c155454c`
- Post-revert steps: Re-run `node scripts/test-ci-workflow-merge-queue-policy.mjs` and monitor the three CI jobs on the next default-branch push.
- Data migration? No.

</details>
