### PR TITLE
[Repair PR #9172](1) Reclaim PR Body Node tool cache

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -138,6 +138,33 @@ jobs:
           "${apt_get[@]}" update
           "${apt_get[@]}" install -y --no-install-recommends libatomic1
 
+      - name: Reclaim Node.js tool cache
+        if: steps.targets.outputs.enabled == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${RUNNER_TOOL_CACHE:-}" ]]; then
+            echo "::error::RUNNER_TOOL_CACHE is not set; cannot prepare the Node.js tool cache."
+            exit 1
+          fi
+
+          if ! sudo -n true 2>/dev/null; then
+            echo "::error::Making RUNNER_TOOL_CACHE writable requires passwordless sudo on this runner."
+            exit 1
+          fi
+
+          if ! sudo -n mkdir -p -- "${RUNNER_TOOL_CACHE}" ||
+            ! sudo -n chown "$(id -u):$(id -g)" -- "${RUNNER_TOOL_CACHE}"; then
+            echo "::error::Could not assign RUNNER_TOOL_CACHE to the current runner account."
+            exit 1
+          fi
+
+          if [[ ! -d "${RUNNER_TOOL_CACHE}" || ! -w "${RUNNER_TOOL_CACHE}" ]]; then
+            echo "::error::RUNNER_TOOL_CACHE is not writable by the current runner account."
+            exit 1
+          fi
+
       - name: Use Node.js ${{ env.NODE_VERSION }}
         if: steps.targets.outputs.enabled == 'true'
         uses: actions/setup-node@v4

--- a/scripts/test-pr-body-rollout.mjs
+++ b/scripts/test-pr-body-rollout.mjs
@@ -47,28 +47,28 @@ assert.ok(
   'PR Body must install libatomic1 after pnpm setup and before actions/setup-node can probe the pnpm cache',
 );
 
-const libatomicStep = prBodyWorkflow.slice(installLibatomicIndex, setupNodeIndex);
+const libatomicDependencyStep = prBodyWorkflow.slice(installLibatomicIndex, setupNodeIndex);
 assert.match(
-  libatomicStep,
+  libatomicDependencyStep,
   /command -v apt-get/,
   'PR Body must install libatomic1 through apt when apt is available',
 );
 assert.match(
-  libatomicStep,
+  libatomicDependencyStep,
   /sudo -n true/,
   'PR Body must probe for passwordless sudo noninteractively before using sudo',
 );
 assert.match(
-  libatomicStep,
+  libatomicDependencyStep,
   /apt_get=\(sudo apt-get\)/,
   'PR Body must only use sudo for apt after the noninteractive sudo probe',
 );
 assert.ok(
-  libatomicStep.indexOf('sudo -n true') < libatomicStep.indexOf('apt_get=(sudo apt-get)'),
+  libatomicDependencyStep.indexOf('sudo -n true') < libatomicDependencyStep.indexOf('apt_get=(sudo apt-get)'),
   'PR Body must not construct the sudo apt command before the noninteractive sudo probe succeeds',
 );
 assert.match(
-  libatomicStep,
+  libatomicDependencyStep,
   /if ! sudo -n true[\s\S]*if ldconfig -p[\s\S]*grep -q 'libatomic\\\.so\\\.1'; then\s+exit 0[\s\S]*requires passwordless sudo/,
   'PR Body must still pass without sudo when libatomic.so.1 is already present, and otherwise fail clearly',
 );
@@ -99,6 +99,7 @@ const enabledOnlyCondition = "steps.targets.outputs.enabled == 'true'";
 const resolveTargetsStepIndex = findWorkflowStepIndex((step) => step.includes('name: Resolve PR Body targets'));
 const setupNodeStepIndex = findWorkflowStepIndex((step) => step.includes('uses: actions/setup-node@v4'));
 const libatomicStepIndex = findWorkflowStepIndex((step) => step.includes('name: Install Node.js runtime prerequisites'));
+const toolCacheStepIndex = findWorkflowStepIndex((step) => step.includes('name: Reclaim Node.js tool cache'));
 
 assert.notEqual(resolveTargetsStepIndex, -1, 'PR Body must resolve rollout targets before runtime setup');
 assert.notEqual(setupNodeStepIndex, -1, 'PR Body must select a Node.js runtime with actions/setup-node');
@@ -111,6 +112,12 @@ assert.ok(
   libatomicStepIndex < setupNodeStepIndex,
   'PR Body must install libatomic1 before actions/setup-node selects Node.js 26',
 );
+assert.notEqual(toolCacheStepIndex, -1, 'PR Body must reclaim RUNNER_TOOL_CACHE before Node setup');
+assert.equal(
+  toolCacheStepIndex + 1,
+  setupNodeStepIndex,
+  'PR Body must reclaim RUNNER_TOOL_CACHE immediately before actions/setup-node',
+);
 
 const libatomicPrerequisitesStep = prBodyWorkflowSteps[libatomicStepIndex];
 assert.match(
@@ -122,6 +129,38 @@ assert.match(
   libatomicPrerequisitesStep,
   /^        run: \|\n          sudo apt-get update\n          sudo apt-get install -y libatomic1$/m,
   'PR Body libatomic prerequisite install must update apt and install libatomic1',
+);
+
+const toolCacheStep = prBodyWorkflowSteps[toolCacheStepIndex];
+assert.match(
+  toolCacheStep,
+  new RegExp(`^        if: ${enabledOnlyCondition.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'm'),
+  'PR Body tool-cache ownership repair must use the same enabled-only gate as Node setup',
+);
+assert.match(
+  toolCacheStep,
+  /RUNNER_TOOL_CACHE/,
+  'PR Body tool-cache ownership repair must use the runner-provided RUNNER_TOOL_CACHE path',
+);
+assert.match(
+  toolCacheStep,
+  /sudo -n mkdir -p -- "\$\{RUNNER_TOOL_CACHE\}"/,
+  'PR Body tool-cache ownership repair must create the resolved cache directory with passwordless sudo',
+);
+assert.match(
+  toolCacheStep,
+  /sudo -n chown "\$\(id -u\):\$\(id -g\)" -- "\$\{RUNNER_TOOL_CACHE\}"/,
+  'PR Body tool-cache ownership repair must assign only the resolved cache directory to the runner account',
+);
+assert.match(
+  toolCacheStep,
+  /\[\[ ! -d "\$\{RUNNER_TOOL_CACHE\}" \|\| ! -w "\$\{RUNNER_TOOL_CACHE\}" \]\][\s\S]*::error::RUNNER_TOOL_CACHE is not writable[\s\S]*exit 1/,
+  'PR Body tool-cache ownership repair must fail clearly unless the resolved cache directory is writable',
+);
+assert.doesNotMatch(
+  toolCacheStep,
+  /\/home\/runner(?:\/|['"])/,
+  'PR Body tool-cache ownership repair must not hard-code a runner path',
 );
 
 const outputDir = mkdtempSync(join(tmpdir(), 'pr-body-rollout-'));


### PR DESCRIPTION
## Summary

Repair the trusted-base PR Body workflow so `actions/setup-node` can install a missing Node version on the self-hosted `Github_Runner`.

The failed job hit `EACCES` while creating the Node tool-cache directory. The workflow now reclaims only `RUNNER_TOOL_CACHE` immediately before Node setup.

Regression coverage locks the cache-reclaim step's ordering, rollout gate, and directory scope while retaining both existing libatomic policy assertions.

## Review Claim

The PR Body workflow makes `RUNNER_TOOL_CACHE` writable by the runner account before `actions/setup-node`, so setup-node can install an uncached Node runtime.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

PR-body target resolution, rollout gating, trusted-base checkout, dependency installation, and validation semantics remain unchanged; only `RUNNER_TOOL_CACHE` ownership is repaired before Node setup.

## Slice Rationale

This base-branch CI-policy prerequisite stands alone because `pull_request_target` cannot consume a workflow edit from PR #9172. That PR's separate extraction remains untouched.

## Non-goals

No changes to `scripts/retry-ledger.mjs`, retry-ledger tests, PR-body validation rules, author rollout, the selected Node version, other workflows, or runner directories outside `RUNNER_TOOL_CACHE`.

## Architecture

### Before

The trusted PR Body bootstrap runs `actions/setup-node` without ensuring the runner-provided tool-cache directory is writable.

### After

The bootstrap creates and assigns only `RUNNER_TOOL_CACHE` to the runner account immediately before `actions/setup-node`, under the existing enabled-target gate.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile`
- [x] `node scripts/test-pr-body-rollout.mjs`
- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/repair-pr-9172-1.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged SHA for this PR>`
- Post-revert steps: None
- Data migration? No

</details>
