### PR TITLE
[CI regression: e16d911-fleet-e16d911-4-jobs](1) Make transient GitHub repro self-contained

### DIFF
--- a/scripts/repro/repro-mergify-admin-requeue-transient-gh-failure.sh
+++ b/scripts/repro/repro-mergify-admin-requeue-transient-gh-failure.sh
@@ -9,10 +9,12 @@ set -euo pipefail
 # failure. One blip killed the whole babysitting cycle.
 #
 # This script proves it two ways:
-#   1. Against the last-committed version of the file (HEAD, before this fix): a
-#      single simulated transient gh failure crashes run_logged. FAIL.
-#   2. Against the current working tree (after this fix): the same failure is
-#      retried and the call succeeds. PASS.
+#   1. BEFORE: a hardcoded reimplementation of the old (pre-fix) run_logged — a
+#      single simulated transient gh failure crashes it. FAIL. This is inlined
+#      rather than read via `git show HEAD:...` so the repro stays correct after
+#      this fix lands and HEAD itself contains the retry logic.
+#   2. AFTER: the real run_logged from the current scripts/ tree — the same
+#      failure is retried and the call succeeds. PASS.
 #
 # No network access required — subprocess.run is mocked.
 
@@ -27,19 +29,13 @@ fail() {
   exit 1
 }
 
-BEFORE_DIR="$TMP/before"
-mkdir -p "$BEFORE_DIR"
-git show HEAD:scripts/mergify_admin_requeue_snapshot.py > "$BEFORE_DIR/mergify_admin_requeue_snapshot.py"
-git show HEAD:scripts/mergify_admin_requeue_model.py > "$BEFORE_DIR/mergify_admin_requeue_model.py"
-
 HARNESS="$TMP/harness.py"
 cat > "$HARNESS" <<'PY'
 import subprocess
 import sys
 from unittest import mock
 
-sys.path.insert(0, sys.argv[1])
-import mergify_admin_requeue_snapshot as s  # noqa: E402
+MODE = sys.argv[1]
 
 transient = subprocess.CalledProcessError(
     1,
@@ -48,27 +44,49 @@ transient = subprocess.CalledProcessError(
 )
 success = subprocess.CompletedProcess(["gh", "pr", "list"], 0, stdout="[]", stderr="")
 
-with mock.patch("mergify_admin_requeue_snapshot.subprocess.run", side_effect=[transient, success]) as run_mock:
-    try:
-        out = s.run_logged(["gh", "pr", "list", "--repo", "Neko-Catpital-Labs/Invoker", "--label", "admin-bypass"])
-    except subprocess.CalledProcessError as exc:
-        print(f"RESULT crashed calls={run_mock.call_count} stderr={exc.stderr!r}")
-        sys.exit(1)
-    print(f"RESULT succeeded calls={run_mock.call_count} out={out!r}")
-    sys.exit(0)
+
+def old_run_logged(args):
+    # Pre-fix scripts/mergify_admin_requeue_snapshot.py::run_logged: one
+    # subprocess.run(check=True), no retry, no timeout.
+    completed = subprocess.run(list(args), check=True, text=True, capture_output=True)
+    return completed.stdout or ""
+
+
+if MODE == "before":
+    with mock.patch("subprocess.run", side_effect=[transient, success]) as run_mock:
+        try:
+            out = old_run_logged(["gh", "pr", "list", "--repo", "Neko-Catpital-Labs/Invoker", "--label", "admin-bypass"])
+        except subprocess.CalledProcessError as exc:
+            print(f"RESULT crashed calls={run_mock.call_count} stderr={exc.stderr!r}")
+            sys.exit(1)
+        print(f"RESULT succeeded calls={run_mock.call_count} out={out!r}")
+        sys.exit(0)
+else:
+    sys.path.insert(0, "scripts")
+    import mergify_admin_requeue_snapshot as s  # noqa: E402
+
+    with mock.patch("mergify_admin_requeue_snapshot.subprocess.run", side_effect=[transient, success]) as run_mock:
+        with mock.patch("mergify_admin_requeue_snapshot.time.sleep"):
+            try:
+                out = s.run_logged(["gh", "pr", "list", "--repo", "Neko-Catpital-Labs/Invoker", "--label", "admin-bypass"])
+            except subprocess.CalledProcessError as exc:
+                print(f"RESULT crashed calls={run_mock.call_count} stderr={exc.stderr!r}")
+                sys.exit(1)
+            print(f"RESULT succeeded calls={run_mock.call_count} out={out!r}")
+            sys.exit(0)
 PY
 
-echo "[repro] === BEFORE (HEAD, unfixed run_logged) — one 502, then a clean success queued up ==="
-if python3 "$HARNESS" "$BEFORE_DIR" 2>&1 | tee "$TMP/before.out"; then
+echo "[repro] === BEFORE (hardcoded pre-fix run_logged) — one 502, then a clean success queued up ==="
+if python3 "$HARNESS" before 2>&1 | tee "$TMP/before.out"; then
   fail "expected the unfixed version to crash on the first transient error, but it succeeded"
 fi
 grep -q "^RESULT crashed calls=1 " "$TMP/before.out" || fail "unfixed version did not crash the way we expected (see output above)"
 echo "[repro] confirmed: unfixed code died on attempt 1/1, never tried the call that would have succeeded"
 echo
 
-echo "[repro] === AFTER (current working tree, fixed run_logged) — same scenario ==="
-python3 "$HARNESS" "scripts" | tee "$TMP/after.out"
-grep -q "^RESULT succeeded calls=2 " "$TMP/after.out" || fail "fixed version did not retry-and-succeed as expected"
+echo "[repro] === AFTER (current scripts/mergify_admin_requeue_snapshot.py) — same scenario ==="
+python3 "$HARNESS" after | tee "$TMP/after.out"
+grep -q "^RESULT succeeded calls=2 " "$TMP/after.out" || fail "current run_logged did not retry-and-succeed as expected"
 echo "[repro] confirmed: fixed code retried once and returned the successful result"
 echo
-echo "[repro] PASS: transient-gh-failure repro reproduced the bug on HEAD and confirmed the fix on the working tree"
+echo "[repro] PASS: transient-gh-failure repro reproduced the pre-fix bug and confirmed the fix on the current tree"


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=e16d911461644e5a0bb24ee127bda6293f84943e; job=fleet -->

Four CI jobs first failed at `e16d911461644e5a0bb24ee127bda6293f84943e`; this proof slice covers the [Mergify Admin Requeue](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31769956876/job/94673906705) member.

The probe embeds the pre-fix single-attempt helper and compares it with the current retrying helper without network access.

## Review Claim

Approve a self-contained proof that contrasts the pre-fix single-attempt helper with the current retrying helper.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The verification command remains identical before and after the repair; this slice only makes its embedded pre-fix fixture stable after commit.

## Slice Rationale

This proof is isolated from product and CI-policy changes so reviewers can evaluate one deterministic regression claim.

## Non-goals

No product behavior, retry policy, workflow definition, test expectation, or network interaction changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-mergify-admin-requeue-transient-gh-failure.sh`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/12-mergify-admin-requeue.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <published-commit-sha>`
- Post-revert steps: Re-run the test-plan commands.
- Data migration? No

</details>
