### PR TITLE
[PR Body runner-permission prerequisite](1) Reclaim runner paths before checkout

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -29,6 +29,22 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: Reclaim runner paths
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          owner="$(id -u):$(id -g)"
+          sudo chown -R "${owner}" "$GITHUB_WORKSPACE"
+
+          if [[ -d "$RUNNER_TOOL_CACHE" ]]; then
+            sudo chown "${owner}" "$RUNNER_TOOL_CACHE"
+          fi
+
+          if [[ -d "$RUNNER_TOOL_CACHE/node" ]]; then
+            sudo chown -R "${owner}" "$RUNNER_TOOL_CACHE/node"
+          fi
+
       - name: Checkout trusted base
         uses: actions/checkout@v4
         with:

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -160,6 +160,33 @@ assert(
   'PR Body workflow must not cancel in-progress merge-queue runs',
 );
 
+const prBodyValidateSteps = prBodyWorkflow.jobs?.validate?.steps ?? [];
+const prBodyReclaimStep = prBodyValidateSteps[0];
+assert(
+  prBodyReclaimStep?.name === 'Reclaim runner paths'
+    && prBodyReclaimStep.shell === 'bash'
+    && prBodyValidateSteps[1]?.name === 'Checkout trusted base',
+  'PR Body validate must start with a bash runner-path reclaim step followed by trusted-base checkout',
+);
+const prBodyReclaimCommand = String(prBodyReclaimStep?.run ?? '');
+assert(
+  prBodyReclaimCommand.includes('set -euo pipefail')
+    && prBodyReclaimCommand.includes('owner="$(id -u):$(id -g)"')
+    && /sudo chown -R "\$\{owner\}" "\$GITHUB_WORKSPACE"/.test(prBodyReclaimCommand),
+  'PR Body runner reclaim must fail on errors and recursively repair GITHUB_WORKSPACE for the current user',
+);
+assert(
+  /if \[\[ -d "\$RUNNER_TOOL_CACHE" \]\]; then\s+sudo chown "\$\{owner\}" "\$RUNNER_TOOL_CACHE"\s+fi/.test(prBodyReclaimCommand)
+    && /if \[\[ -d "\$RUNNER_TOOL_CACHE\/node" \]\]; then\s+sudo chown -R "\$\{owner\}" "\$RUNNER_TOOL_CACHE\/node"\s+fi/.test(prBodyReclaimCommand)
+    && !/chown -R [^\n]*"\$RUNNER_TOOL_CACHE"(?:\s|$)/.test(prBodyReclaimCommand),
+  'PR Body runner reclaim must repair the optional tool-cache parent and existing Node directory without recursively chowning the entire cache',
+);
+const prBodySetupNodeIndex = prBodyValidateSteps.findIndex((step) => step.uses === 'actions/setup-node@v4');
+assert(
+  prBodySetupNodeIndex > 0,
+  'PR Body runner reclaim must run before actions/setup-node@v4',
+);
+
 assert(
   existsSync(closeCleanupPath),
   'Merge-queue close cleanup workflow must cancel runs left behind by closed wrapper PRs',


### PR DESCRIPTION
## Summary

Add a first-step permission reclaim for workspace and existing Node cache paths in the trusted-base PR Body workflow.

Jobs 94869207221 and 94904766097 stopped during checkout and Node setup with permission errors before PR-body checks began.

The existing later step prepares the cache parent. The new first step also restores workspace write access and repairs any existing Node cache contents before checkout.

The adjacent CI policy test locks down the new ordering and path coverage without changing PR-body content rules.

## Review Claim

PR Body starts with a runner-permission normalization step covering `GITHUB_WORKSPACE` and existing Node tool-cache contents.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

PR-body rules and trusted-base execution stay unchanged. The step only reclaims runner-owned paths needed by checkout and Node setup, skipping absent optional paths.

## Slice Rationale

This prerequisite must land on master because `pull_request_target` evaluates the base workflow; #9167 cannot change the workflow used by its own check.

## Non-goals

No changes to PR-body rules, enforcement rollout, concurrency, Node version, runner labels, #9167's test file, or unrelated CI jobs.

## Architecture

### Before

```mermaid
graph LR
    A["Checkout trusted base"] --> B["Prepare Node cache parent"] --> C["Set up Node"] --> D["Check PR body"]
```

### After

```mermaid
graph LR
    A["Reclaim workspace and existing Node cache paths"] --> B["Checkout trusted base"] --> C["Prepare Node cache parent"] --> D["Set up Node"] --> E["Check PR body"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs` — `CI merge-queue policy is valid.`
- [x] `node scripts/test-pr-body-rollout.mjs` — `OK: PR body rollout checks passed`.
- [x] `git diff --check origin/master...HEAD` — exit 0.
- [x] `git diff --name-only origin/master...HEAD` — only `.github/workflows/pr-body.yml` and `scripts/test-ci-workflow-merge-queue-policy.mjs`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
