### PR TITLE
[Admin-bypass-sweep skill](3) Add stale-mergeability recheck to Step 5

### DIFF
--- a/scripts/test-admin-bypass-sweep-skill.sh
+++ b/scripts/test-admin-bypass-sweep-skill.sh
@@ -97,6 +97,27 @@ must_contain "genuine content conflict" \
 must_contain "re-query every PR number touched" \
   "admin-bypass-sweep must require re-querying final PR state before reporting"
 
+# Rule out stale mergeability (false-positive CONFLICTING from an un-rebased
+# stack branch) before accepting Step 5's real-conflict verdict.
+must_contain "## Step 5a: Rule out a stale mergeability check before giving up" \
+  "admin-bypass-sweep must have a Step 5a stale-mergeability recheck section"
+must_appear_before "## Step 5: Never guess at real conflicts" \
+  "## Step 5a: Rule out a stale mergeability check before giving up" \
+  "admin-bypass-sweep must place Step 5a after Step 5"
+must_appear_before "## Step 5a: Rule out a stale mergeability check before giving up" \
+  "## Step 6: Prove the final state" \
+  "admin-bypass-sweep must place Step 5a before Step 6"
+must_contain "git rebase origin/master" \
+  "admin-bypass-sweep's Step 5a must rebase the PR branch in a scratch worktree to test for a real conflict"
+must_contain "Rebase applies clean" \
+  "admin-bypass-sweep's Step 5a must define the clean-rebase (stale mergeability) case"
+must_contain "Rebase stops with conflict markers" \
+  "admin-bypass-sweep's Step 5a must define the conflict-markers (genuine conflict) case"
+must_contain "attempt to resolve the markers by picking a side" \
+  "admin-bypass-sweep's Step 5a must still forbid picking a side on a genuine conflict"
+must_contain "never touch their primary working tree's branch or" \
+  "admin-bypass-sweep's Step 5a must require a disposable worktree, not the human's main checkout"
+
 # Cross-reference to the separate, deterministic worker path, and that
 # satisfying one authorization path is not sufficient for the other.
 must_contain "scripts/jailbreak-admin-bypass-land.mjs" \

--- a/skills/admin-bypass-sweep/SKILL.md
+++ b/skills/admin-bypass-sweep/SKILL.md
@@ -159,6 +159,47 @@ stack's chain at the conflicting PR (its children can't land either), record
 it as blocked, and continue with the other independent stacks. Report all
 blocked PRs clearly at the end rather than silently dropping them.
 
+## Step 5a: Rule out a stale mergeability check before giving up
+
+`CONFLICTING` can mean two different things, and only one of them needs a
+human:
+
+1. **Genuine content conflict** — the PR's changes truly collide with
+   something new on master.
+2. **Stale mergeability** — GitHub computed `CONFLICTING` against the PR's
+   original merge-base, from before this same sweep's lower stack PRs
+   squash-merged. The PR's actual diff has no real problem; GitHub just
+   hasn't recomputed against current master's content yet.
+
+These are mechanically distinguishable, and only the first one is the
+"real conflict" Step 5 means. Before recording a `CONFLICTING` PR as
+blocked, check which case it is, in a disposable worktree outside the
+human's main checkout — never touch their primary working tree's branch or
+uncommitted state to do this:
+
+```bash
+git fetch origin master
+git worktree add /tmp/<scratch-dir>/pr-<n> origin/<pr-head-branch>
+cd /tmp/<scratch-dir>/pr-<n>
+git checkout -b fix/pr-<n>-rebase
+git rebase origin/master
+```
+
+- **Rebase applies clean** (no conflict markers, `git status` clean) — this
+  was stale mergeability, not a real conflict. Force-push the rebased
+  branch back to the PR's head with `--force-with-lease` pinned to the
+  known old SHA, wait for GitHub to recompute (`sleep 5`), confirm
+  `mergeable` now reads `MERGEABLE`, then continue this PR (and its
+  children) through Step 4 as normal.
+- **Rebase stops with conflict markers** — this is Step 5's real-conflict
+  case. Run `git rebase --abort`, remove the scratch worktree, and follow
+  Step 5 as written: stop the chain, record as blocked, move on. Do not
+  attempt to resolve the markers by picking a side — that part of Step 5
+  still applies.
+
+Remove the scratch worktree (`git worktree remove --force`) once the PR's
+fate — merged or genuinely blocked — is decided.
+
 ## Step 6: Prove the final state
 
 Before reporting results, re-query every PR number touched — do not trust


### PR DESCRIPTION
## Summary

The admin-bypass-sweep skill stops and reports a PR as blocked whenever GitHub says it's `CONFLICTING`.

During a live sweep, a PR showed `CONFLICTING` twice, but it had no real conflict. GitHub was comparing against a stale merge-base from before that stack's lower PRs squash-merged.

A plain rebase in a scratch worktree applied with zero conflict markers, which is how the false positive was caught by hand.

This adds a new Step 5a: before giving up, rebase the `CONFLICTING` PR in a disposable worktree first.

Clean rebase means it was a false positive — keep going. Conflict markers means it's real — stop, exactly as Step 5 already says.

## Review Claim

Approve adding a mechanical stale-mergeability recheck (Step 5a) to the admin-bypass-sweep skill, so a false-positive `CONFLICTING` from an un-rebased stack branch no longer requires a human to intervene by hand.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This only edits skill instructions (prose an agent reads before acting), not product code or runtime behavior. Step 5a doesn't touch or weaken the STOP section's human-authorization gate before Step 4's merge, and it doesn't weaken Step 5's real-conflict handling — a rebase that leaves conflict markers still stops the chain exactly as before. Worst case if the new step is somehow wrong: the agent just falls back to always treating `CONFLICTING` as real, which is today's existing behavior.

## Slice Rationale

Single, self-contained addition to one skill file plus its matching pinning-test assertions. No other file needed to change.

## Non-goals

Does not change Step 4's merge authorization requirements, Step 5's "never pick a side on a real conflict" rule, or anything about `scripts/jailbreak-admin-bypass-land.mjs`'s separate worker path.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-admin-bypass-sweep-skill.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
