### PR TITLE
[Repair PR #9181 PR Body prerequisite](1) Remove duplicate interactive libatomic bootstrap

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -96,12 +96,6 @@ jobs:
           TARGET_AUTHORS: ${{ steps.targets.outputs.authors }}
         run: echo "PR body validation is not enforced for ${TARGET_AUTHORS} yet."
 
-      - name: Install Node.js runtime prerequisites
-        if: steps.targets.outputs.enabled == 'true'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libatomic1
-
       - name: Install pnpm
         if: steps.targets.outputs.enabled == 'true'
         uses: pnpm/action-setup@v4

--- a/scripts/test-pr-body-rollout.mjs
+++ b/scripts/test-pr-body-rollout.mjs
@@ -98,19 +98,28 @@ const findWorkflowStepIndex = (predicate) => prBodyWorkflowSteps.findIndex((step
 const enabledOnlyCondition = "steps.targets.outputs.enabled == 'true'";
 const resolveTargetsStepIndex = findWorkflowStepIndex((step) => step.includes('name: Resolve PR Body targets'));
 const setupNodeStepIndex = findWorkflowStepIndex((step) => step.includes('uses: actions/setup-node@v4'));
-const libatomicStepIndex = findWorkflowStepIndex((step) => step.includes('name: Install Node.js runtime prerequisites'));
+const obsoleteLibatomicStepIndex = findWorkflowStepIndex((step) => step.includes('name: Install Node.js runtime prerequisites'));
+const libatomicStepIndexes = prBodyWorkflowSteps
+  .map((step, index) => step.includes('name: Install Node.js runtime dependency') ? index : -1)
+  .filter((index) => index !== -1);
 const toolCacheStepIndex = findWorkflowStepIndex((step) => step.includes('name: Reclaim Node.js tool cache'));
 
 assert.notEqual(resolveTargetsStepIndex, -1, 'PR Body must resolve rollout targets before runtime setup');
 assert.notEqual(setupNodeStepIndex, -1, 'PR Body must select a Node.js runtime with actions/setup-node');
-assert.notEqual(libatomicStepIndex, -1, 'PR Body must install libatomic1 before selecting Node.js 26');
+assert.equal(
+  obsoleteLibatomicStepIndex,
+  -1,
+  'PR Body must not include the obsolete Install Node.js runtime prerequisites raw-sudo step',
+);
+assert.equal(libatomicStepIndexes.length, 1, 'PR Body must retain exactly one guarded Node.js runtime dependency step');
+const [libatomicStepIndex] = libatomicStepIndexes;
 assert.ok(
   libatomicStepIndex > resolveTargetsStepIndex,
-  'PR Body must install Node.js runtime prerequisites after resolving rollout targets',
+  'PR Body must install the Node.js runtime dependency after resolving rollout targets',
 );
 assert.ok(
   libatomicStepIndex < setupNodeStepIndex,
-  'PR Body must install libatomic1 before actions/setup-node selects Node.js 26',
+  'PR Body must install the single guarded libatomic1 dependency before actions/setup-node',
 );
 assert.notEqual(toolCacheStepIndex, -1, 'PR Body must reclaim RUNNER_TOOL_CACHE before Node setup');
 assert.equal(
@@ -119,16 +128,11 @@ assert.equal(
   'PR Body must reclaim RUNNER_TOOL_CACHE immediately before actions/setup-node',
 );
 
-const libatomicPrerequisitesStep = prBodyWorkflowSteps[libatomicStepIndex];
+const guardedLibatomicStep = prBodyWorkflowSteps[libatomicStepIndex];
 assert.match(
-  libatomicPrerequisitesStep,
+  guardedLibatomicStep,
   new RegExp(`^        if: ${enabledOnlyCondition.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'm'),
-  'PR Body libatomic prerequisite install must use the same enabled-only gate as Node setup',
-);
-assert.match(
-  libatomicPrerequisitesStep,
-  /^        run: \|\n          sudo apt-get update\n          sudo apt-get install -y libatomic1$/m,
-  'PR Body libatomic prerequisite install must update apt and install libatomic1',
+  'PR Body guarded libatomic dependency install must use the same enabled-only gate as Node setup',
 );
 
 const toolCacheStep = prBodyWorkflowSteps[toolCacheStepIndex];


### PR DESCRIPTION
## Summary

PR #9181 cannot repair its own `pull_request_target` workflow because GitHub loads that workflow from `master`.

The trusted workflow ran two libatomic installers. The unconditional path used interactive sudo and could stop before pnpm and PR-body validation.

This slice retires only that obsolete path and makes the focused rollout regression enforce the remaining guarded installer.

## Review Claim

The PR Body workflow reaches pnpm and validation when libatomic is already available on a Github_Runner that does not grant passwordless sudo.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

PR #9181's product diff and PR-body validation semantics remain unchanged; only the redundant raw-sudo bootstrap step and its directly affected regression assertions change.

## Slice Rationale

A separate base-branch prerequisite is required because `pull_request_target` loads this workflow from `master`, so PR #9181 cannot repair its own failing check.

The read-only verification task produced no file changes, so it is recorded in this slice's test evidence instead of becoming an empty PR.

## Non-goals

No edits to PR #9181 settlement code, Node versions, rollout authors, PR-body rules, pnpm setup, tool-cache ownership, other workflows, or unrelated cleanup.

## Architecture

### Before

```mermaid
flowchart LR
    A["Resolve rollout targets"] --> B["Run unconditional sudo apt-get"]
    B --> C["Install pnpm"]
    C --> D["Run guarded libatomic provisioning"]
    D --> E["Set up Node and validate PR bodies"]
```

### After

```mermaid
flowchart LR
    A["Resolve rollout targets"] --> B["Install pnpm"]
    B --> C["Run one guarded libatomic provisioning path"]
    C --> D["Set up Node and validate PR bodies"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-rollout.mjs`
- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [x] `git diff --check origin/master...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7281bb9543b0699e9951366a156dbeddb0377f28`
- Post-revert steps: Rerun the focused rollout and adjacent workflow-policy tests.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined automated workflow setup by removing a redundant Node.js prerequisite installation step.
  * Retained conditional runtime dependency handling to keep workflow execution efficient and consistent.

* **Tests**
  * Updated workflow validation to confirm a single guarded dependency step in the correct execution order.
  * Removed checks for obsolete package installation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->