### PR TITLE
[CI policy](2) Provision build-artifacts native toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
+      - name: Install native build tools
+        run: sudo apt-get update -qq && sudo apt-get install -y make g++
+
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -61,6 +61,15 @@ assert(
   jobs['build-artifacts']['runs-on'] === 'ubuntu-latest',
   'build-artifacts must use fresh GitHub-hosted capacity so stale Git ref locks cannot block checkout',
 );
+assertStepBefore(jobs['build-artifacts'], 'Install native build tools', 'Install dependencies', 'build-artifacts');
+const buildArtifactsNativeBuildStep = jobs['build-artifacts'].steps.find(
+  (step) => step.name === 'Install native build tools',
+);
+assert(
+  String(buildArtifactsNativeBuildStep?.run ?? '').includes('make')
+    && String(buildArtifactsNativeBuildStep?.run ?? '').includes('g++'),
+  'build-artifacts must install make and g++ so pnpm can build native dependencies on self-hosted runners',
+);
 
 assert(jobs['quality-required'], 'Missing quality-required job');
 assert(!jobs['quality-required'].if, 'quality-required must run on ordinary PRs');


### PR DESCRIPTION
## Summary

The build-artifacts job needs native build tools before workspace dependencies install.

This unchanged patch installs `make` and `g++` and enforces their ordering in the CI policy test.

The PR now depends directly on the isolated UI Vitest bootstrap prerequisite, PR #9231.

## Review Claim

Approve provisioning the native build tools required by `build-artifacts` and enforcing that CI policy.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

PR #9209 retains its existing two-file build-artifacts patch byte-for-byte; product code, UI test selection, Node 26, Runner_Vitest, and UI bootstrap logic remain unchanged in this slice.

## Slice Rationale

Build-artifacts native-toolchain provisioning is independent from the UI Vitest privilege repair and remains its own review unit.

## Non-goals

- No product edits.
- No UI Vitest bootstrap changes in this slice.
- No Node downgrade or runner reassignment.
- No test selection changes or test skipping.
- No unrelated CI cleanup.

## Architecture

### Before

The build-artifacts patch was based directly on `master`.

### After

Only the PR-stack dependency order changes: this build-artifacts policy slice follows the isolated UI Vitest prerequisite in PR #9231.

Within this slice, `build-artifacts` provisions its native toolchain before installing workspace dependencies.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
  - Observed on the composed stack: `CI merge-queue policy is valid.` and `COMPOSED_STACK_POLICY_EXIT=0`.
- [x] Stable patch-ID comparison against `319d4510c6c4bf8f489e916811dd77341247757b`
  - Observed unchanged patch ID: `54c9a927007104b5bc779c1148bae17f417e7fa4`.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <PR merge commit>`
- Post-revert steps: Re-run the focused CI policy test before re-queueing a replacement.
- Data migration? No

</details>
