### PR TITLE
[Repair PR #9198 PR Body runner prerequisite](1) Assign PR Body validation to GitHub-hosted capacity

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -24,8 +24,7 @@ env:
 jobs:
   validate:
     name: PR Body
-    runs-on:
-      labels: Github_Runner
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -150,6 +150,10 @@ assert(
 assert(jobs.docker, 'Missing docker job');
 assert(jobs.docker.if === NON_PR_GATE, 'docker must not run on pull_request events');
 
+assert(
+  prBodyWorkflow.jobs.validate['runs-on'] === 'ubuntu-latest',
+  'PR Body validation must use fresh GitHub-hosted capacity so self-hosted runner state cannot block validation',
+);
 assert(prBodyWorkflow.concurrency, 'PR Body workflow must declare concurrency');
 assert(
   String(prBodyWorkflow.concurrency.group ?? '').includes("startsWith(github.head_ref, 'mergify/merge-queue/')"),


### PR DESCRIPTION
## Summary

Run trusted-base PR Body validation on `ubuntu-latest` instead of mutable self-hosted capacity.

PR #9198's check failed before validation on missing passwordless sudo, then its next run failed during runner startup with no disk space.

Because `pull_request_target` loads workflow code from `master`, this runner-policy prerequisite must land separately from PR #9198.

## Review Claim

Approve assigning PR Body validation to `ubuntu-latest` so mutable self-hosted runner state cannot stop the job before validation.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

PR-body target resolution, trusted-base checkout, rollout gating, dependency installation, and validation semantics remain unchanged; only the validate job's runner assignment and directly affected policy assertion change.

## Slice Rationale

This is one base-branch CI-policy prerequisite because `pull_request_target` ignores workflow edits on PR #9198's head branch.

## Non-goals

- No edits to PR #9198's Playwright files.
- No changes to PR-body content rules, enforced authors, concurrency, Node version, dependency installation, or validation commands.
- No changes to other workflows, open repair PRs, or unrelated code.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [x] `node scripts/test-pr-body-rollout.mjs`
- [x] `git diff --check origin/master...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting restores the previous self-hosted runner assignment and removes its GitHub-hosted policy assertion.
- Revert command: `git revert <PR merge commit>`
- Post-revert steps: Rerun both focused Node policy checks.
- Data migration? No.

</details>

