### PR TITLE
[CI Regression Watch Reflect Step](1) Add a reflect-ci task to the plan formula

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -29,6 +29,22 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: Reclaim runner paths
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          owner="$(id -u):$(id -g)"
+          sudo chown -R "${owner}" "$GITHUB_WORKSPACE"
+
+          if [[ -d "$RUNNER_TOOL_CACHE" ]]; then
+            sudo chown "${owner}" "$RUNNER_TOOL_CACHE"
+          fi
+
+          if [[ -d "$RUNNER_TOOL_CACHE/node" ]]; then
+            sudo chown -R "${owner}" "$RUNNER_TOOL_CACHE/node"
+          fi
+
       - name: Checkout trusted base
         uses: actions/checkout@v4
         with:

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -160,6 +160,33 @@ assert(
   'PR Body workflow must not cancel in-progress merge-queue runs',
 );
 
+const prBodyValidateSteps = prBodyWorkflow.jobs?.validate?.steps ?? [];
+const prBodyReclaimStep = prBodyValidateSteps[0];
+assert(
+  prBodyReclaimStep?.name === 'Reclaim runner paths'
+    && prBodyReclaimStep.shell === 'bash'
+    && prBodyValidateSteps[1]?.name === 'Checkout trusted base',
+  'PR Body validate must start with a bash runner-path reclaim step followed by trusted-base checkout',
+);
+const prBodyReclaimCommand = String(prBodyReclaimStep?.run ?? '');
+assert(
+  prBodyReclaimCommand.includes('set -euo pipefail')
+    && prBodyReclaimCommand.includes('owner="$(id -u):$(id -g)"')
+    && /sudo chown -R "\$\{owner\}" "\$GITHUB_WORKSPACE"/.test(prBodyReclaimCommand),
+  'PR Body runner reclaim must fail on errors and recursively repair GITHUB_WORKSPACE for the current user',
+);
+assert(
+  /if \[\[ -d "\$RUNNER_TOOL_CACHE" \]\]; then\s+sudo chown "\$\{owner\}" "\$RUNNER_TOOL_CACHE"\s+fi/.test(prBodyReclaimCommand)
+    && /if \[\[ -d "\$RUNNER_TOOL_CACHE\/node" \]\]; then\s+sudo chown -R "\$\{owner\}" "\$RUNNER_TOOL_CACHE\/node"\s+fi/.test(prBodyReclaimCommand)
+    && !/chown -R [^\n]*"\$RUNNER_TOOL_CACHE"(?:\s|$)/.test(prBodyReclaimCommand),
+  'PR Body runner reclaim must repair the optional tool-cache parent and existing Node directory without recursively chowning the entire cache',
+);
+const prBodySetupNodeIndex = prBodyValidateSteps.findIndex((step) => step.uses === 'actions/setup-node@v4');
+assert(
+  prBodySetupNodeIndex > 0,
+  'PR Body runner reclaim must run before actions/setup-node@v4',
+);
+
 assert(
   existsSync(closeCleanupPath),
   'Merge-queue close cleanup workflow must cancel runs left behind by closed wrapper PRs',

--- a/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
+++ b/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
@@ -88,3 +88,105 @@ tasks:
       {{verify_command}}
     dependencies:
       - fix-ci-{{job_slug}}
+
+  - id: reflect-ci-{{job_slug}}
+    executionAgent: claude
+    description: |
+      Run the /reflect skill against this repair to find how the regression
+      escaped, and draft (not auto-apply) any resulting skill updates.
+      Review claim: Any skill edit in this task's diff is traceable to a
+      specific, cited finding from this repair's own transcript, not a
+      speculative rewrite.
+      Review lane: proof
+      Safety invariant: This task never merges or applies skill edits on its
+      own authority. Every edit lands only as a commit on this same PR branch,
+      subject to the same external human review as the fix itself. If
+      /reflect finds nothing durable, this task makes no changes and exits 0.
+      Slice rationale: Kept as its own task, downstream of the proof slice, so
+      "did this regression teach us something" is an explicit, separately
+      reviewable claim rather than folded into the fix.
+      Architectural effect: None to product code; may add or edit files under
+      skills/ in this repo, and best-effort in the separate catstack skills
+      repo (see below).
+      Goal: Reduce the odds that the same class of regression escapes again.
+      Motivation: CI job `{{job_name}}` first failed at {{sha}} and reached
+      this repair without an existing skill or check catching it first.
+      Alternative considerations: Silently auto-applying skill edits was
+      rejected -- skill edits affect every future session and must go through
+      the same review as any other change.
+      Implementation details: Follow this repo's `skills/reflect/SKILL.md`
+      process against the transcript(s) for the `fix-ci-{{job_slug}}` and
+      `verify-ci-{{job_slug}}` tasks in this workflow: locate the transcript,
+      run the cost audit, spawn the parallel review lenses, synthesize into
+      Accepted / Backlog / Rejected. Since no interactive human is present to
+      approve mid-run, do not apply anything at that step; instead, for
+      Accepted findings that map to a concrete skill edit, make that edit as
+      a normal file change in this task's own branch, so it surfaces in this
+      PR's diff for the human reviewer -- the PR review *is* the approval
+      gate reflect normally asks for interactively. Backlog and Rejected
+      findings go in the task summary as prose, not as file changes.
+      If a finding is best fixed in the shared skills repo
+      (https://github.com/EdbertChan/catstack, deployed to all pool
+      machines) rather than this repo, clone it to a scratch dir, make the
+      same kind of edit, and open a PR there with `gh pr create`; note its
+      URL in this task's summary. Treat catstack push access as unverified --
+      if the clone, push, or PR creation fails for permission reasons, say so
+      explicitly in the summary and continue; that is not a task failure.
+      Non-goals: No refactor of unrelated skills; no edits outside skills/
+      (in either repo); no auto-merge; no editing this same formula file from
+      inside the task it renders.
+      Layer: e2e_regression
+      Feature state: active
+      Files:
+      - Unknown at filing time; determined by what /reflect's synthesis step
+        actually finds Accepted.
+      Change types:
+      - Unknown at filing time; determined during the reflect pass.
+      Acceptance criteria:
+      - The task summary states, explicitly, either "no durable finding" or
+        lists each Accepted finding with the file(s) it changed.
+      - Any skill file changed in this repo is included in this PR's diff.
+      - Any catstack PR opened is linked by URL in the task summary, or the
+        summary states why one was not opened.
+    prompt: |
+      Goal: Run this repo's `/reflect` process against the repair you (or a
+      prior task) just completed for CI job `{{job_name}}` (first observed
+      failing at {{sha}}), and turn any durable learning into a reviewable
+      skill edit -- never an auto-applied one.
+      Review lane: proof
+      Motivation: This regression reached a filed repair workflow without an
+      existing skill or check catching it first. If there's a real, durable
+      lesson here (not a one-off), it should change a skill so the same class
+      of bug is easier to catch next time.
+      Implementation details:
+      1. Read `skills/reflect/SKILL.md` in this repo and follow its process
+         (locate the transcript for this workflow's tasks, run the token/cost
+         audit script, spawn the lens reviewers, synthesize into Accepted /
+         Backlog / Rejected).
+      2. There is no interactive human to approve mid-run. Do NOT use that as
+         license to skip the approval step or auto-apply broadly -- instead,
+         for each Accepted finding that maps to a concrete skill edit, make
+         that edit as a normal, reviewable file change on this task's own
+         branch. It will appear in this PR's diff, and the PR's existing
+         external human review (`mergeMode: external_review`) is the approval
+         gate.
+      3. For a finding that belongs in the shared skills repo
+         (https://github.com/EdbertChan/catstack) instead of this one: clone
+         it to a scratch directory, make the analogous edit, and run
+         `gh pr create` there. Record the resulting PR URL in your task
+         summary. If any step (clone/push/PR) fails on permissions, say so
+         plainly in the summary -- do not treat that as a task failure, and
+         do not attempt to work around a permission denial.
+      4. Backlog and Rejected findings go in the summary as prose only, never
+         as file changes.
+      5. If /reflect finds nothing durable and skill-worthy about this
+         specific repair, make no file changes and say so plainly.
+      Acceptance criteria: Task summary states explicitly what was found
+      (or that nothing durable was found), and every skill file changed is
+      part of this task's own commit(s) -- nothing is applied outside this
+      PR's review.
+      Non-goals: Do not edit this workflow's own rendering formula from
+      inside the task it produced. Do not touch product code. Do not retry
+      or second-guess the fix/verify tasks above this one in the chain.
+    dependencies:
+      - verify-ci-{{job_slug}}


### PR DESCRIPTION
## Summary

CI-regression-watch automatically writes a fix-and-verify plan for every failing CI job. This adds one more task: after a fix lands, it asks Claude to reflect on what happened.

If reflect finds a lasting lesson, it turns that into a proposed change to a skill file the reviewer can accept or reject in the PR.

Nothing runs without review. The new task never touches product code and never applies anything outside this repair's own PR.

This PR is stacked on #9197 so its checks use the repaired trusted-base workflow. The runner-permission policy remains isolated in #9197.

## Review Claim

Approve adding one new task, `reflect-ci-{{job_slug}}`, to the ci-regression-watch plan template, downstream of the existing verify task.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

The new task never merges or applies a skill change on its own authority; every proposed edit lands only as a normal file change on the same PR branch as the fix, subject to the same external human review as the fix itself. If reflect finds nothing durable, the task exits 0 with no changes.

## Slice Rationale

This template-only addition changes future auto-generated repair plans, not a specific repair. The runner-permission prerequisite stays in #9197 so policy and formula remain separate review units.

## Non-goals

Does not change how any existing CI job gets fixed. Does not auto-apply any skill file change. Does not modify #9197 or duplicate its runner policy. Does not touch anything outside skills/ in this repo, or the separate catstack skills repo (best-effort there, its own PR).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `test "$(git diff --name-only d806635dd969e62031b069e00a4b7623dd02a8bf...70f9bf3ad60406053034299d19056089fa0e776b)" = 'skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml'`
- [x] `test "$(git show --pretty=format: f05fe8edac73e5b18858489b97adebada9c2f825 | git patch-id --stable | cut -d' ' -f1)" = "$(git show --pretty=format: 70f9bf3ad60406053034299d19056089fa0e776b | git patch-id --stable | cut -d' ' -f1)"`
- [ ] Manual read-through of the new task's prompt against `skills/reflect/SKILL.md`'s process

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 70f9bf3ad60406053034299d19056089fa0e776b`
- Post-revert steps: None
- Data migration? No

</details>
