### PR TITLE
[Repair PR #8320: reclaim the nested Node tool cache](1) Repair nested cache ownership

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -149,19 +149,21 @@ jobs:
             exit 1
           fi
 
+          node_tool_cache="${RUNNER_TOOL_CACHE}/node"
+
           if ! sudo -n true 2>/dev/null; then
-            echo "::error::Making RUNNER_TOOL_CACHE writable requires passwordless sudo on this runner."
+            echo "::error::Making the RUNNER_TOOL_CACHE Node.js subtree writable requires passwordless sudo on this runner."
             exit 1
           fi
 
-          if ! sudo -n mkdir -p -- "${RUNNER_TOOL_CACHE}" ||
-            ! sudo -n chown "$(id -u):$(id -g)" -- "${RUNNER_TOOL_CACHE}"; then
-            echo "::error::Could not assign RUNNER_TOOL_CACHE to the current runner account."
+          if ! sudo -n mkdir -p -- "${node_tool_cache}" ||
+            ! sudo -n chown -R "$(id -u):$(id -g)" -- "${node_tool_cache}"; then
+            echo "::error::Could not assign the RUNNER_TOOL_CACHE Node.js subtree to the current runner account."
             exit 1
           fi
 
-          if [[ ! -d "${RUNNER_TOOL_CACHE}" || ! -w "${RUNNER_TOOL_CACHE}" ]]; then
-            echo "::error::RUNNER_TOOL_CACHE is not writable by the current runner account."
+          if [[ ! -d "${node_tool_cache}" || ! -w "${node_tool_cache}" ]]; then
+            echo "::error::RUNNER_TOOL_CACHE Node.js subtree is not writable by the current runner account."
             exit 1
           fi
 

--- a/scripts/test-pr-body-rollout.mjs
+++ b/scripts/test-pr-body-rollout.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { strict as assert } from 'node:assert';
-import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -144,18 +144,23 @@ assert.match(
 );
 assert.match(
   toolCacheStep,
-  /sudo -n mkdir -p -- "\$\{RUNNER_TOOL_CACHE\}"/,
-  'PR Body tool-cache ownership repair must create the resolved cache directory with passwordless sudo',
+  /node_tool_cache="\$\{RUNNER_TOOL_CACHE\}\/node"/,
+  'PR Body tool-cache ownership repair must resolve only the Node subtree beneath RUNNER_TOOL_CACHE',
 );
 assert.match(
   toolCacheStep,
-  /sudo -n chown "\$\(id -u\):\$\(id -g\)" -- "\$\{RUNNER_TOOL_CACHE\}"/,
-  'PR Body tool-cache ownership repair must assign only the resolved cache directory to the runner account',
+  /sudo -n mkdir -p -- "\$\{node_tool_cache\}"/,
+  'PR Body tool-cache ownership repair must create the Node subtree with passwordless sudo',
+);
+assert.deepEqual(
+  toolCacheStep.match(/^.*sudo -n chown.*$/gm),
+  ['            ! sudo -n chown -R "$(id -u):$(id -g)" -- "${node_tool_cache}"; then'],
+  'PR Body tool-cache ownership repair must recursively assign only the Node subtree and its descendants',
 );
 assert.match(
   toolCacheStep,
-  /\[\[ ! -d "\$\{RUNNER_TOOL_CACHE\}" \|\| ! -w "\$\{RUNNER_TOOL_CACHE\}" \]\][\s\S]*::error::RUNNER_TOOL_CACHE is not writable[\s\S]*exit 1/,
-  'PR Body tool-cache ownership repair must fail clearly unless the resolved cache directory is writable',
+  /\[\[ ! -d "\$\{node_tool_cache\}" \|\| ! -w "\$\{node_tool_cache\}" \]\][\s\S]*::error::RUNNER_TOOL_CACHE Node\.js subtree is not writable[\s\S]*exit 1/,
+  'PR Body tool-cache ownership repair must fail clearly unless the Node subtree is writable',
 );
 assert.doesNotMatch(
   toolCacheStep,
@@ -211,6 +216,46 @@ try {
   assert.equal(JSON.parse(result.stdout).enabled, true);
 } finally {
   rmSync(spacedPathDir, { recursive: true, force: true });
+}
+
+const nestedCacheDir = mkdtempSync(join(tmpdir(), 'pr-body-node-cache-'));
+try {
+  const nodeCacheDir = join(nestedCacheDir, 'node');
+  const versionDir = join(nodeCacheDir, '24.19.0');
+  mkdirSync(nodeCacheDir);
+  chmodSync(nestedCacheDir, 0o700);
+  chmodSync(nodeCacheDir, 0o555);
+
+  const rootOnlyAttempt = spawnSync(process.execPath, [
+    '-e',
+    "require('node:fs').mkdirSync(process.argv[1])",
+    versionDir,
+  ], { encoding: 'utf8' });
+  assert.notEqual(
+    rootOnlyAttempt.status,
+    0,
+    'A writable RUNNER_TOOL_CACHE root must not hide a non-writable Node subtree',
+  );
+  assert.match(
+    rootOnlyAttempt.stderr,
+    /EACCES/,
+    'The root-only ownership assumption must reproduce setup-node\'s nested EACCES failure',
+  );
+
+  chmodSync(nodeCacheDir, 0o755);
+  const targetedRepairAttempt = spawnSync(process.execPath, [
+    '-e',
+    "require('node:fs').mkdirSync(process.argv[1])",
+    versionDir,
+  ], { encoding: 'utf8' });
+  assert.equal(
+    targetedRepairAttempt.status,
+    0,
+    `Repairing only the Node subtree must permit version-directory creation without sudo:\n${targetedRepairAttempt.stderr}`,
+  );
+} finally {
+  chmodSync(nestedCacheDir, 0o700);
+  rmSync(nestedCacheDir, { recursive: true, force: true });
 }
 
 console.log('OK: PR body rollout checks passed');


### PR DESCRIPTION
## Summary

PR Body currently checks only the tool-cache root before setup-node. A stale root-owned `node` child can still cause EACCES on reused self-hosted runners.

This change recursively reclaims only `RUNNER_TOOL_CACHE/node`, then verifies that subtree is writable before setup-node runs.

As a trusted-base prerequisite, it repairs PR #8320 without touching that branch's entity-research changes.

## Review Claim

Approve recursively assigning only `RUNNER_TOOL_CACHE/node` to the runner account before setup-node, including stale root-owned descendants.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

PR-body target resolution, rollout gating, validation semantics, the selected Node version, and directories outside `RUNNER_TOOL_CACHE/node` remain unchanged.

The workflow still fails clearly if that Node subtree cannot be made writable.

## Slice Rationale

This base-branch CI prerequisite stands alone because `pull_request_target` cannot consume workflow edits from PR #8320. The directly affected regression coverage stays with the policy fix.

## Non-goals

- Do not edit PR #8320's entity-research files.
- Do not change runners, Node or pnpm versions, validation rules, rollout authors, or other workflows.
- Do not reclaim directories outside `RUNNER_TOOL_CACHE/node`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-rollout.mjs`
- [x] `git diff --check origin/master...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting restores the previous root-only cache ownership check.
- Revert command: `git revert 016130e4a`
- Post-revert steps: Re-run `node scripts/test-pr-body-rollout.mjs` and monitor PR #8320's PR Body check.
- Data migration? No.

</details>
