### PR TITLE
[Repair PR 9185 trusted PR Body prerequisite](1) Reclaim the Node tool-cache subtree

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -149,19 +149,21 @@ jobs:
             exit 1
           fi
 
+          node_tool_cache="${RUNNER_TOOL_CACHE}/node"
+
           if ! sudo -n true 2>/dev/null; then
-            echo "::error::Making RUNNER_TOOL_CACHE writable requires passwordless sudo on this runner."
+            echo "::error::Making the RUNNER_TOOL_CACHE Node.js subtree writable requires passwordless sudo on this runner."
             exit 1
           fi
 
-          if ! sudo -n mkdir -p -- "${RUNNER_TOOL_CACHE}" ||
-            ! sudo -n chown "$(id -u):$(id -g)" -- "${RUNNER_TOOL_CACHE}"; then
-            echo "::error::Could not assign RUNNER_TOOL_CACHE to the current runner account."
+          if ! sudo -n mkdir -p -- "${node_tool_cache}" ||
+            ! sudo -n chown -R "$(id -u):$(id -g)" -- "${node_tool_cache}"; then
+            echo "::error::Could not assign the RUNNER_TOOL_CACHE Node.js subtree to the current runner account."
             exit 1
           fi
 
-          if [[ ! -d "${RUNNER_TOOL_CACHE}" || ! -w "${RUNNER_TOOL_CACHE}" ]]; then
-            echo "::error::RUNNER_TOOL_CACHE is not writable by the current runner account."
+          if [[ ! -d "${node_tool_cache}" || ! -w "${node_tool_cache}" ]]; then
+            echo "::error::RUNNER_TOOL_CACHE Node.js subtree is not writable by the current runner account."
             exit 1
           fi
 

--- a/scripts/test-pr-body-rollout.mjs
+++ b/scripts/test-pr-body-rollout.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { strict as assert } from 'node:assert';
-import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -144,18 +144,23 @@ assert.match(
 );
 assert.match(
   toolCacheStep,
-  /sudo -n mkdir -p -- "\$\{RUNNER_TOOL_CACHE\}"/,
-  'PR Body tool-cache ownership repair must create the resolved cache directory with passwordless sudo',
+  /node_tool_cache="\$\{RUNNER_TOOL_CACHE\}\/node"/,
+  'PR Body tool-cache ownership repair must resolve only the Node subtree beneath RUNNER_TOOL_CACHE',
 );
 assert.match(
   toolCacheStep,
-  /sudo -n chown "\$\(id -u\):\$\(id -g\)" -- "\$\{RUNNER_TOOL_CACHE\}"/,
-  'PR Body tool-cache ownership repair must assign only the resolved cache directory to the runner account',
+  /sudo -n mkdir -p -- "\$\{node_tool_cache\}"/,
+  'PR Body tool-cache ownership repair must create the Node subtree with passwordless sudo',
+);
+assert.deepEqual(
+  toolCacheStep.match(/^.*sudo -n chown.*$/gm),
+  ['            ! sudo -n chown -R "$(id -u):$(id -g)" -- "${node_tool_cache}"; then'],
+  'PR Body tool-cache ownership repair must recursively assign only the Node subtree and its descendants',
 );
 assert.match(
   toolCacheStep,
-  /\[\[ ! -d "\$\{RUNNER_TOOL_CACHE\}" \|\| ! -w "\$\{RUNNER_TOOL_CACHE\}" \]\][\s\S]*::error::RUNNER_TOOL_CACHE is not writable[\s\S]*exit 1/,
-  'PR Body tool-cache ownership repair must fail clearly unless the resolved cache directory is writable',
+  /\[\[ ! -d "\$\{node_tool_cache\}" \|\| ! -w "\$\{node_tool_cache\}" \]\][\s\S]*::error::RUNNER_TOOL_CACHE Node\.js subtree is not writable[\s\S]*exit 1/,
+  'PR Body tool-cache ownership repair must fail clearly unless the Node subtree is writable',
 );
 assert.doesNotMatch(
   toolCacheStep,
@@ -211,6 +216,46 @@ try {
   assert.equal(JSON.parse(result.stdout).enabled, true);
 } finally {
   rmSync(spacedPathDir, { recursive: true, force: true });
+}
+
+const nestedCacheDir = mkdtempSync(join(tmpdir(), 'pr-body-node-cache-'));
+try {
+  const nodeCacheDir = join(nestedCacheDir, 'node');
+  const versionDir = join(nodeCacheDir, '24.19.0');
+  mkdirSync(nodeCacheDir);
+  chmodSync(nestedCacheDir, 0o700);
+  chmodSync(nodeCacheDir, 0o555);
+
+  const rootOnlyAttempt = spawnSync(process.execPath, [
+    '-e',
+    "require('node:fs').mkdirSync(process.argv[1])",
+    versionDir,
+  ], { encoding: 'utf8' });
+  assert.notEqual(
+    rootOnlyAttempt.status,
+    0,
+    'A writable RUNNER_TOOL_CACHE root must not hide a non-writable Node subtree',
+  );
+  assert.match(
+    rootOnlyAttempt.stderr,
+    /EACCES/,
+    'The root-only ownership assumption must reproduce setup-node\'s nested EACCES failure',
+  );
+
+  chmodSync(nodeCacheDir, 0o755);
+  const targetedRepairAttempt = spawnSync(process.execPath, [
+    '-e',
+    "require('node:fs').mkdirSync(process.argv[1])",
+    versionDir,
+  ], { encoding: 'utf8' });
+  assert.equal(
+    targetedRepairAttempt.status,
+    0,
+    `Repairing only the Node subtree must permit version-directory creation without sudo:\n${targetedRepairAttempt.stderr}`,
+  );
+} finally {
+  chmodSync(nestedCacheDir, 0o700);
+  rmSync(nestedCacheDir, { recursive: true, force: true });
 }
 
 console.log('OK: PR body rollout checks passed');


### PR DESCRIPTION
## Summary

Repair the trusted PR Body bootstrap so setup-node can create a version directory beneath a reused Node tool-cache subtree.

Reclaim only `${RUNNER_TOOL_CACHE}/node`; focused coverage reproduces the nested permission failure and proves the targeted repair.

## Review Claim

The trusted PR Body bootstrap recursively assigns only `${RUNNER_TOOL_CACHE}/node` to the runner before setup-node creates a version directory.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

PR #9185's two-file policy change, PR-body target resolution, rollout gating, validation semantics, Node version, and directories outside `${RUNNER_TOOL_CACHE}/node` remain unchanged.

## Slice Rationale

`pull_request_target` loads the trusted workflow from master, so this base-first prerequisite cannot ship inside PR #9185.

## Non-goals

No edits to PR #9185, PR-body content rules, runner assignment, Node or pnpm versions, unrelated workflow setup, or directories outside the Node tool-cache subtree.

## Architecture

### Before

The bootstrap assigned only the tool-cache root, allowing a stale Node child to remain unwritable when setup-node created a version directory.

### After

The bootstrap creates, recursively assigns, and checks only the Node subtree immediately before setup-node. All later PR Body control flow stays unchanged.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-rollout.mjs`
- [x] `git diff --check origin/master...HEAD`
- [x] `test "$(git diff --name-only origin/master...HEAD)" = $'.github/workflows/pr-body.yml\nscripts/test-pr-body-rollout.mjs'`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 008b21d10f7968d47acc51d245afdb4d21a52b6c`
- Post-revert steps: Rerun `node scripts/test-pr-body-rollout.mjs` and confirm the expected root-only regression returns.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup reliability by preparing only the Node.js tool-cache area for writing.
  * Added clearer validation and error handling when the Node.js cache directory is unavailable or not writable.
* **Tests**
  * Added coverage for permission-related failures and recovery when creating Node.js version directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->