### PR TITLE
[Repair PR 9213 UI Vitest native-toolchain prerequisite](1) Provision UI Vitest native toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
               SUDO="sudo"
             fi
             $SUDO apt-get update
-            $SUDO apt-get install -y libatomic1
+            $SUDO apt-get install -y libatomic1 make g++
           fi
 
       - name: Use Node.js ${{ env.NODE_VERSION }}

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -99,6 +99,12 @@ assert(
   uiVitestLibatomicIndex >= 0 && uiVitestLibatomicIndex < uiVitestNodeSetupIndex,
   'ui-vitest must install libatomic1 before actions/setup-node@v4',
 );
+const uiVitestNodePrerequisiteStep = uiVitestSteps[uiVitestLibatomicIndex];
+assert(
+  String(uiVitestNodePrerequisiteStep?.run ?? '').includes('make')
+    && String(uiVitestNodePrerequisiteStep?.run ?? '').includes('g++'),
+  'ui-vitest must install make and g++ so pnpm can build native dependencies on self-hosted runners',
+);
 
 assert(jobs['required-fast-extra'], 'Missing required-fast-extra job');
 assert(jobs['required-fast-extra'].if === FULL_CI_GATE, 'required-fast-extra must run only for full CI events');


### PR DESCRIPTION
## Summary

UI Vitest now installs native build tools before dependency installation can invoke node-gyp for node-pty.

Node 26 has no matching Linux prebuild, so PR #9213 failed before Vitest because the self-hosted runner lacked `make`.

The focused workflow-policy regression now requires `libatomic1`, `make`, and `g++` while preserving the existing runner, Node version, and test command.

## Review Claim

UI Vitest installs `make` and `g++` before pnpm may invoke node-gyp for node-pty.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only UI Vitest's self-hosted setup and focused policy assertion change; its test command, runner label, Node version, and PR #9213's formula diff remain unchanged.

## Slice Rationale

The workflow prerequisite and its directly affected policy assertion form one CI-policy unit, separate from PR #9213's formula review claim.

## Non-goals

No UI or product-code changes, runner reassignment, Node or dependency version changes, lifecycle-script suppression, PR #9213 formula edits, unrelated cleanup, or test-gate weakening.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm install --frozen-lockfile && node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [x] `git diff --check origin/master...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: Requeue CI only after restoring equivalent native build prerequisites on `Runner_Vitest`.
- Data migration? No

</details>
