### PR TITLE
PR 9202 prerequisite (1): align deferred graph test timing

### DIFF
--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -91,10 +91,9 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
 
   async function openTaskContextMenu(taskId = 'task-alpha') {
     fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
-    await waitFor(() => {
-      expect(screen.getByTestId(`rf__node-${taskId}`)).toBeInTheDocument();
-    });
-    fireEvent.contextMenu(screen.getByTestId(`rf__node-${taskId}`));
+    const taskNode = await screen.findByTestId(`rf__node-${taskId}`);
+    expect(taskNode).toBeInTheDocument();
+    fireEvent.contextMenu(taskNode);
     const menu = await screen.findByRole('menu');
     await waitFor(() => expect(menu).toHaveFocus());
     return menu;
@@ -159,10 +158,9 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
   it('task context menu still works in mini DAG', async () => {
     await setup();
     fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
-    await waitFor(() => {
-      expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
-    });
-    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+    const taskNode = await screen.findByTestId('rf__node-task-alpha');
+    expect(taskNode).toBeInTheDocument();
+    fireEvent.contextMenu(taskNode);
     await waitFor(() => {
       expect(screen.getByText('Open Terminal')).toBeInTheDocument();
       expect(screen.getByText('Restart Task')).toBeInTheDocument();
@@ -180,11 +178,10 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
   it('task context menu calls recreateDownstream for workflow-owned tasks', async () => {
     await setup();
     fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
-    await waitFor(() => {
-      expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
-    });
+    const taskNode = await screen.findByTestId('rf__node-task-alpha');
+    expect(taskNode).toBeInTheDocument();
 
-    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+    fireEvent.contextMenu(taskNode);
     fireEvent.click(await screen.findByText('More'));
     fireEvent.click(await screen.findByText('Recreate Downstream'));
 
@@ -204,11 +201,10 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
 
     await setup([runningTask]);
     fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
-    await waitFor(() => {
-      expect(screen.getByTestId('rf__node-task-running')).toBeInTheDocument();
-    });
+    const taskNode = await screen.findByTestId('rf__node-task-running');
+    expect(taskNode).toBeInTheDocument();
 
-    fireEvent.contextMenu(screen.getByTestId('rf__node-task-running'));
+    fireEvent.contextMenu(taskNode);
     fireEvent.click(await screen.findByText('More'));
     const recreateDownstream = await screen.findByRole('menuitem', { name: 'Recreate Downstream' });
 
@@ -220,11 +216,10 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
   it('task context menu keeps Recreate from Task routed to recreateTask', async () => {
     await setup();
     fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
-    await waitFor(() => {
-      expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
-    });
+    const taskNode = await screen.findByTestId('rf__node-task-alpha');
+    expect(taskNode).toBeInTheDocument();
 
-    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+    fireEvent.contextMenu(taskNode);
     fireEvent.click(await screen.findByText('More'));
     fireEvent.click(await screen.findByText('Recreate from Task'));
 
@@ -236,11 +231,10 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
   it('task context menu deletes task', async () => {
     await setup();
     fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
-    await waitFor(() => {
-      expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
-    });
+    const taskNode = await screen.findByTestId('rf__node-task-alpha');
+    expect(taskNode).toBeInTheDocument();
 
-    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+    fireEvent.contextMenu(taskNode);
     fireEvent.click(await screen.findByText('More'));
     fireEvent.click(await screen.findByText('Delete Task'));
 
@@ -253,7 +247,7 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
     fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
     const panel = await screen.findByTestId('selected-workflow-mini-dag');
 
-    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+    fireEvent.contextMenu(await screen.findByTestId('rf__node-task-alpha'));
 
     const menu = await screen.findByRole('menu');
     expect(panel).toBeInTheDocument();

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1216,10 +1216,9 @@ describe('Invoker terminal (component)', () => {
     });
     fireEvent.click(screen.getByTestId('workflow-node-wf-chat-0'));
 
-    await waitFor(() => {
-      expect(screen.getByTestId('rf__node-wf-chat-0/message-00')).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByTestId('rf__node-wf-chat-0/message-00'));
+    const promptTaskNode = await screen.findByTestId('rf__node-wf-chat-0/message-00');
+    expect(promptTaskNode).toBeInTheDocument();
+    fireEvent.click(promptTaskNode);
 
     await waitFor(() => {
       expect(screen.getByTestId('prompt-command-display')).toBeInTheDocument();
@@ -2276,7 +2275,7 @@ describe('Invoker terminal submit context (component)', () => {
     });
 
     for (let attempt = 0; attempt < 5; attempt += 1) {
-      fireEvent.click(screen.getByTestId('rf__node-task-a'));
+      fireEvent.click(await screen.findByTestId('rf__node-task-a'));
       await waitFor(() => {
         expect(
           screen

--- a/packages/ui/src/__tests__/keyboard-controls.test.tsx
+++ b/packages/ui/src/__tests__/keyboard-controls.test.tsx
@@ -53,9 +53,10 @@ const tasks = [
 async function renderKeyboardFixture(mock: MockInvoker) {
   mock.setTasks(tasks, workflows);
   render(<App />);
-    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+  fireEvent.click(await screen.findByTestId('sidebar-planning'));
   await screen.findByTestId('workflow-node-wf-a');
   await screen.findByTestId('selected-workflow-mini-dag');
+  await screen.findByTestId('rf__node-wf-a/task-a');
 }
 
 function key(keyName: string, init: Partial<KeyboardEvent> = {}) {
@@ -753,7 +754,7 @@ describe('Graph camera controls (component)', () => {
   it('clicking a task node selects it and centers the camera', async () => {
     await renderAndSettle();
 
-    fireEvent.click(screen.getByTestId('rf__node-wf-a/task-b'));
+    fireEvent.click(await screen.findByTestId('rf__node-wf-a/task-b'));
 
     await waitFor(() => {
       expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Second Task');

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -46,10 +46,13 @@ describe('Task interaction (component)', () => {
 
     fireEvent.click(screen.getByTestId('rf__node-wf-a'));
 
-    await waitFor(() => {
-      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
-      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
-    });
+    const miniDag = screen.getByTestId('selected-workflow-mini-dag');
+    expect(miniDag).toHaveTextContent('Workflow A');
+    expect(miniDag).toHaveTextContent('Loading graph…');
+    expect(screen.queryByTestId('rf__node-task-alpha')).not.toBeInTheDocument();
+    expect(await screen.findByTestId('rf__node-task-alpha')).toBeInTheDocument();
+    expect(await screen.findByTestId('rf__node-task-beta')).toBeInTheDocument();
+    expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
   });
 
   it('scopes mini DAG layering to the workflow graph surface', async () => {

--- a/packages/ui/src/test-setup.ts
+++ b/packages/ui/src/test-setup.ts
@@ -2,7 +2,10 @@
 process.env.TZ = 'UTC';
 
 import '@testing-library/jest-dom/vitest';
+import { configure } from '@testing-library/react';
 import { beforeEach } from 'vitest';
+
+configure({ asyncUtilTimeout: 2_000 });
 
 if (typeof globalThis.ResizeObserver === 'undefined') {
   class ResizeObserverPolyfill {


### PR DESCRIPTION
## Summary

Production defers selected-workflow graph bodies by 1,000 ms, exactly matching Testing Library's previous polling limit.

This test-only prerequisite gives asynchronous graph assertions bounded headroom and makes direct node consumers await delayed nodes.

Production behavior and assertions remain intact, keeping PR #9202 focused on its skill-only change.

## Review Claim

UI component tests consistently observe selected-workflow task nodes after the intentional 1,000 ms graph-body deferral without weakening assertions or changing production behavior.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

`SELECTED_WORKFLOW_GRAPH_BODY_DELAY_MS` remains 1,000 ms. No test or assertion is skipped, deleted, or relaxed, and the asynchronous test budget remains explicitly bounded.

## Slice Rationale

The shared async timeout and existing tests that consume delayed task nodes form one test-synchronization boundary. Workflow configuration and PR #9202's skill changes stay separate.

## Non-goals

- No product UI or graph-layout changes.
- No snapshot churn or broad `act` warning cleanup.
- No CI timeout, runner, or workflow configuration changes.
- No assertion skips, deletions, or relaxations.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `CI=true pnpm --filter @invoker/ui test -- src/__tests__/task-interaction.test.tsx src/__tests__/context-menu-e2e.test.tsx src/__tests__/invoker-terminal.test.tsx src/__tests__/keyboard-controls.test.tsx --reporter=dot`
- [x] `CI=true pnpm --filter @invoker/ui test -- --reporter=dot`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit>`
- Post-revert steps: Rerun the complete UI package test command above.
- Data migration? No

</details>
