### PR TITLE
PR 9202 prerequisite (2): right-size UI Vitest CI budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
     name: UI Vitest
     runs-on:
       labels: Runner_Vitest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Reclaim workspace
@@ -161,13 +161,15 @@ jobs:
 
       - name: Install Node runtime system dependencies
         run: |
-          if command -v apt-get >/dev/null 2>&1; then
-            SUDO=""
-            if command -v sudo >/dev/null 2>&1; then
-              SUDO="sudo"
+          if ! ldconfig -p 2>/dev/null | grep -Fq 'libatomic.so.1'; then
+            if command -v apt-get >/dev/null 2>&1; then
+              SUDO=""
+              if command -v sudo >/dev/null 2>&1; then
+                SUDO="sudo"
+              fi
+              $SUDO apt-get update
+              $SUDO apt-get install -y libatomic1 make g++ python3
             fi
-            $SUDO apt-get update
-            $SUDO apt-get install -y libatomic1 make g++ python3
           fi
 
       - name: Use Node.js ${{ env.NODE_VERSION }}

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -9,6 +9,16 @@ const PR_BODY_MERGE_QUEUE_CANCEL_GATE = "${{ !startsWith(github.head_ref, 'mergi
 const MERGE_QUEUE_HEAD_GATE = "${{ startsWith(github.head_ref, 'mergify/merge-queue/') }}";
 const HEAD_REF_EXPRESSION = '${{ github.head_ref }}';
 const FULL_CI_JOBS = new Set(['build-artifacts', 'e2e-proof', 'e2e-proof-aggregate', 'required-fast', 'playwright', 'ssh', 'optional-other']);
+const UI_VITEST_LIBATOMIC_INSTALL = `if ! ldconfig -p 2>/dev/null | grep -Fq 'libatomic.so.1'; then
+  if command -v apt-get >/dev/null 2>&1; then
+    SUDO=""
+    if command -v sudo >/dev/null 2>&1; then
+      SUDO="sudo"
+    fi
+    $SUDO apt-get update
+    $SUDO apt-get install -y libatomic1 make g++ python3
+  fi
+fi`;
 
 const workflow = YAML.parse(readFileSync('.github/workflows/ci.yml', 'utf8'));
 const prBodyWorkflow = YAML.parse(readFileSync('.github/workflows/pr-body.yml', 'utf8'));
@@ -95,6 +105,12 @@ assert(
   'required-package-builds must run on ordinary PRs and skip merge queue refs',
 );
 
+assert(jobs['ui-vitest'], 'Missing ui-vitest job');
+assert(jobs['ui-vitest']['timeout-minutes'] === 15, 'ui-vitest must have a 15-minute timeout');
+assert(
+  jobs['ui-vitest']['runs-on']?.labels === 'Runner_Vitest',
+  'ui-vitest must keep the Runner_Vitest runner label',
+);
 const uiVitestSteps = jobs['ui-vitest']?.steps ?? [];
 const uiVitestNodeSetupIndex = uiVitestSteps.findIndex((step) => step.uses === 'actions/setup-node@v4');
 assert(uiVitestNodeSetupIndex >= 0, 'ui-vitest must configure Node with actions/setup-node@v4');
@@ -108,6 +124,15 @@ const uiVitestSystemDependencyIndex = uiVitestSteps.findIndex(
 assert(
   uiVitestSystemDependencyIndex >= 0 && uiVitestSystemDependencyIndex < uiVitestNodeSetupIndex,
   'ui-vitest must install Node system dependencies before actions/setup-node@v4',
+);
+assert(
+  String(uiVitestSteps[uiVitestSystemDependencyIndex].run ?? '').trim() === UI_VITEST_LIBATOMIC_INSTALL,
+  'ui-vitest must mutate the package index and install libatomic1 only when libatomic.so.1 is unavailable',
+);
+const uiVitestTestStep = uiVitestSteps.find((step) => step.name === 'Run UI vitest');
+assert(
+  String(uiVitestTestStep?.run ?? '').trim() === 'pnpm --filter @invoker/ui test',
+  'ui-vitest must run the full pnpm --filter @invoker/ui test command',
 );
 assert(
   uiVitestSystemDependencyIndex < uiVitestDependencyInstallIndex,


### PR DESCRIPTION
## Summary

The self-hosted UI Vitest job previously updated the package index even when `libatomic` was already available.

The job now checks runtime-library availability first and keeps installation as a fallback.

Its timeout increases from 10 to 15 minutes, covering the observed 5.5-minute setup and 5.4-minute suite.

This stacks after the test-contract repair and leaves PR #9202's admin-bypass-sweep files untouched.

## Review Claim

UI Vitest conditionally installs `libatomic` according to runtime-library availability and has a 15-minute timeout that contains observed setup plus suite duration.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

UI Vitest still installs `libatomic` when absent and runs the complete unchanged package test command. All other jobs, runner labels, and timeouts stay unchanged.

## Slice Rationale

This CI-policy slice follows the independently reviewable UI test-contract repair. It contains no UI test or product changes.

## Non-goals

- No runner reassignment or changes to other jobs.
- No package-version changes or test filtering.
- No product or UI-test edits.
- No changes to PR #9202's admin-bypass-sweep files.

## Architecture

### Before

```mermaid
flowchart LR
    A["Start UI Vitest job"] --> B["Update package index"]
    B --> C["Install libatomic"]
    C --> D["Run the full UI suite within 10 minutes"]
```

### After

```mermaid
flowchart LR
    A["Start UI Vitest job"] --> B{"libatomic.so.1 is resolvable"}
    B -->|"Yes"| D["Run the full UI suite within 15 minutes"]
    B -->|"No"| C["Update the package index and install libatomic"]
    C --> D
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge commit>`
- Post-revert steps: Rerun `node scripts/test-ci-workflow-merge-queue-policy.mjs`.
- Data migration? No

</details>
