### PR TITLE
[CI regression: f8533de-playwright-1-of-9](3) Activate readiness regression checks

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -572,18 +572,18 @@ async function loadPlanAndSelectWorkflow(page: Page, plan: unknown): Promise<str
     return workflows.map((workflow: { id: string }) => workflow.id);
   });
   await page.evaluate((yaml) => window.invoker.loadPlan(yaml), yamlStringify(plan));
-  const workflow = await page.evaluate(async (knownIds) => {
+  const findNewWorkflowId = async (): Promise<string | null> => page.evaluate(async (knownIds) => {
     const workflows = await window.invoker.listWorkflows();
-    return workflows.find((candidate: { id: string }) => !knownIds.includes(candidate.id))
-      ?? workflows[workflows.length - 1]
-      ?? null;
+    return workflows.find((candidate: { id: string }) => !knownIds.includes(candidate.id))?.id ?? null;
   }, beforeIds);
-  expect(workflow?.id).toBeTruthy();
+  await expect.poll(findNewWorkflowId, { timeout: 10000 }).not.toBeNull();
+  const workflowId = await findNewWorkflowId();
+  expect(workflowId).toBeTruthy();
   await openPlanGraph(page);
   await page.getByTestId('rail-refresh').click();
   await page.waitForTimeout(300);
-  await selectWorkflowNode(page, workflow!.id, expectedTitle);
-  return workflow!.id;
+  await selectWorkflowNode(page, workflowId!, expectedTitle);
+  return workflowId!;
 }
 async function seedActiveLaunchAttempt(dbPath: string, taskId: string, attemptId: string, now: Date): Promise<void> {
   const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
@@ -1954,6 +1954,12 @@ test.describe('Visual proof capture', () => {
 
   test('status bar — no system log button', async ({ page }) => {
     await loadPlan(page, TEST_PLAN);
+    await injectTaskStates(page, [
+      {
+        taskId: 'task-alpha',
+        changes: { status: 'running', execution: { startedAt: new Date() } },
+      },
+    ]);
     await expect(page.locator('.react-flow__node[data-testid$="task-alpha"]')).toBeVisible();
     await selectWorkflowNode(page, 'wf-test-1');
     await waitForStableViewportTransform(page, page.getByTestId('workflow-graph-surface').locator('.react-flow__viewport').first());
@@ -2083,6 +2089,7 @@ test.describe('Visual proof capture', () => {
   });
 
   test('review gate stack side panel shows a linear PR chain', async ({ page }) => {
+    test.fixme(true, 'TODO(ci-regression-f8533de): enable after merge-task state refresh lands');
     await loadPlanAndSelectWorkflow(page, MERGE_GATE_TEXT_VISUAL_PLAN);
     await page.locator('.react-flow__node[data-testid$="mg-visual-work"]').first().waitFor({ state: 'visible', timeout: 15000 });
 
@@ -2131,6 +2138,7 @@ test.describe('Visual proof capture', () => {
   });
 
   test('workflow inspector captures review-ready and not-review-ready pull request states', async ({ page }) => {
+    test.fixme(true, 'TODO(ci-regression-f8533de): enable after merge-task state refresh lands');
     const workflowId = await loadPlanAndSelectWorkflow(page, REVIEW_READY_WORKFLOW_PR_PLAN);
     await page.locator('.react-flow__node[data-testid$="rr-work"]').first().waitFor({ state: 'visible', timeout: 15000 });
 
@@ -2172,6 +2180,7 @@ test.describe('Visual proof capture', () => {
   });
 
   test('sidebar keyboard navigation focuses the first inspector item, not the container', async ({ page }) => {
+    test.fixme(true, 'TODO(ci-regression-f8533de): enable after merge-task state refresh lands');
     const workflowId = await loadPlanAndSelectWorkflow(page, REVIEW_READY_WORKFLOW_PR_PLAN);
     await page.locator('.react-flow__node[data-testid$="rr-work"]').first().waitFor({ state: 'visible', timeout: 15000 });
 

--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -2089,7 +2089,6 @@ test.describe('Visual proof capture', () => {
   });
 
   test('review gate stack side panel shows a linear PR chain', async ({ page }) => {
-    test.fixme(true, 'TODO(ci-regression-f8533de): enable after merge-task state refresh lands');
     await loadPlanAndSelectWorkflow(page, MERGE_GATE_TEXT_VISUAL_PLAN);
     await page.locator('.react-flow__node[data-testid$="mg-visual-work"]').first().waitFor({ state: 'visible', timeout: 15000 });
 
@@ -2138,7 +2137,6 @@ test.describe('Visual proof capture', () => {
   });
 
   test('workflow inspector captures review-ready and not-review-ready pull request states', async ({ page }) => {
-    test.fixme(true, 'TODO(ci-regression-f8533de): enable after merge-task state refresh lands');
     const workflowId = await loadPlanAndSelectWorkflow(page, REVIEW_READY_WORKFLOW_PR_PLAN);
     await page.locator('.react-flow__node[data-testid$="rr-work"]').first().waitFor({ state: 'visible', timeout: 15000 });
 
@@ -2180,7 +2178,6 @@ test.describe('Visual proof capture', () => {
   });
 
   test('sidebar keyboard navigation focuses the first inspector item, not the container', async ({ page }) => {
-    test.fixme(true, 'TODO(ci-regression-f8533de): enable after merge-task state refresh lands');
     const workflowId = await loadPlanAndSelectWorkflow(page, REVIEW_READY_WORKFLOW_PR_PLAN);
     await page.locator('.react-flow__node[data-testid$="rr-work"]').first().waitFor({ state: 'visible', timeout: 15000 });
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1726,6 +1726,12 @@ export function App() {
     if (!activeWorkflowId) return EMPTY_SELECTED_WORKFLOW_TASKS;
     return tasksByWorkflow.get(activeWorkflowId) ?? EMPTY_SELECTED_WORKFLOW_TASKS;
   }, [selectedWorkflow, selectedWorkflowId, tasksByWorkflow]);
+  const selectedMergeTaskStateVersion = useMemo(() => {
+    for (const task of miniDagTasks.values()) {
+      if (task.config.isMergeNode) return task.taskStateVersion;
+    }
+    return null;
+  }, [miniDagTasks]);
   useEffect(() => {
     if (selectedWorkflow && miniDagTasks.size > 0) {
       lastGoodSelectedWorkflowGraphRef.current = {
@@ -1826,7 +1832,7 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [selectedWorkflow?.id, selectedWorkflow?.onFinish]);
+  }, [selectedMergeTaskStateVersion, selectedWorkflow?.id, selectedWorkflow?.onFinish]);
 
   useEffect(() => {
     if (!selectedWorkflowId) {

--- a/scripts/repro/repro-playwright-load-plan-readiness.sh
+++ b/scripts/repro/repro-playwright-load-plan-readiness.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Reproduces the playwright / 1-of-9 readiness regressions with focused tests
+# for workflow creation and live review metadata.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+pnpm --filter @invoker/ui build
+pnpm --filter @invoker/surfaces build
+pnpm --filter @invoker/app build
+
+export INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-repro-load-plan-readiness'
+export INVOKER_PLAYWRIGHT_WORKERS=1
+export INVOKER_PLAYWRIGHT_FILES='e2e/visual-proof.spec.ts'
+export INVOKER_PLAYWRIGHT_ARGS='--reporter=line --grep=workflow.delete.propagation|status.bar|review.gate.stack|workflow.inspector|sidebar.keyboard'
+exec bash scripts/test-suites/optional/40-playwright-app.sh


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=f8533de99d21ae3fcb2167b708feaf4440992287; job=playwright / 1-of-9 -->

This slice reenables three review-metadata expectations after the behavior repair.

The focused readiness command now executes all five scenarios as ordinary passing tests.

## Review Claim

The focused probe continuously verifies the repaired review stack, workflow inspector, and keyboard-navigation metadata states.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The focused command is identical to the pre-fix repro; this slice only reenables the expectations after the behavior repair.

## Slice Rationale

This final proof slice follows the behavior repair so every stack level stays green while retaining the regression coverage.

## Non-goals

No product behavior, test setup, unrelated assertions, CI policy, or snapshot changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-playwright-load-plan-readiness.sh` — exit 0; 5 passed.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; it restores the explicit deferrals without changing product behavior.
- Revert command: `git revert 1383edc0a2e07f57704f6ed5f889c3a065208879`
- Post-revert steps: None.
- Data migration? No.

</details>
