### PR TITLE
[CI policy](1) Repair UI Vitest bootstrap without interactive sudo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,17 +160,68 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Install Node runtime system dependencies
+        shell: bash
         run: |
-          if ! ldconfig -p 2>/dev/null | grep -Fq 'libatomic.so.1'; then
-            if command -v apt-get >/dev/null 2>&1; then
-              SUDO=""
-              if command -v sudo >/dev/null 2>&1; then
-                SUDO="sudo"
-              fi
-              $SUDO apt-get update
-              $SUDO apt-get install -y libatomic1 make g++ python3
+          set -euo pipefail
+
+          has_libatomic() {
+            if command -v ldconfig >/dev/null 2>&1; then
+              ldconfig -p 2>/dev/null | grep -q 'libatomic\.so\.1'
+              return
             fi
+            find /lib /usr/lib -name 'libatomic.so.1*' -print -quit 2>/dev/null | grep -q .
+          }
+
+          has_build_tools() {
+            command -v make >/dev/null 2>&1 && command -v g++ >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1
+          }
+
+          if has_libatomic && has_build_tools; then
+            exit 0
           fi
+
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "::error::libatomic1, make, g++, and python3 are required for Node ${NODE_VERSION}, but apt-get is unavailable."
+            exit 1
+          fi
+
+          if [ "$(id -u)" -eq 0 ]; then
+            apt-get update
+            apt-get install -y libatomic1 make g++ python3
+            exit 0
+          fi
+
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo -n apt-get update
+            sudo -n apt-get install -y libatomic1 make g++ python3
+            exit 0
+          fi
+
+          if ! has_build_tools; then
+            echo "::error::make, g++, and python3 are required for Node ${NODE_VERSION} but cannot be installed without sudo."
+            exit 1
+          fi
+
+          libatomic_dir="$(mktemp -d "${RUNNER_TEMP:-/tmp}/node-runtime-system-deps.XXXXXX")"
+          mkdir -p "$libatomic_dir/apt-state/lists/partial" "$libatomic_dir/apt-cache/archives/partial"
+          (
+            cd "$libatomic_dir"
+            apt_options=(
+              -o "Dir::State=$libatomic_dir/apt-state"
+              -o "Dir::State::status=/var/lib/dpkg/status"
+              -o "Dir::Cache=$libatomic_dir/apt-cache"
+            )
+            apt-get "${apt_options[@]}" update
+            apt-get "${apt_options[@]}" download libatomic1
+            dpkg-deb -x ./*.deb root
+          )
+          libatomic_file="$(find "$libatomic_dir/root" -type f -name 'libatomic.so.1*' -print -quit)"
+          if [ -z "$libatomic_file" ]; then
+            echo "::error::Downloaded libatomic1 package did not contain libatomic.so.1."
+            exit 1
+          fi
+          libatomic_path="${libatomic_file%/*}"
+          echo "LD_LIBRARY_PATH=$libatomic_path${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -9,16 +9,6 @@ const PR_BODY_MERGE_QUEUE_CANCEL_GATE = "${{ !startsWith(github.head_ref, 'mergi
 const MERGE_QUEUE_HEAD_GATE = "${{ startsWith(github.head_ref, 'mergify/merge-queue/') }}";
 const HEAD_REF_EXPRESSION = '${{ github.head_ref }}';
 const FULL_CI_JOBS = new Set(['build-artifacts', 'e2e-proof', 'e2e-proof-aggregate', 'required-fast', 'playwright', 'ssh', 'optional-other']);
-const UI_VITEST_LIBATOMIC_INSTALL = `if ! ldconfig -p 2>/dev/null | grep -Fq 'libatomic.so.1'; then
-  if command -v apt-get >/dev/null 2>&1; then
-    SUDO=""
-    if command -v sudo >/dev/null 2>&1; then
-      SUDO="sudo"
-    fi
-    $SUDO apt-get update
-    $SUDO apt-get install -y libatomic1 make g++ python3
-  fi
-fi`;
 
 const workflow = YAML.parse(readFileSync('.github/workflows/ci.yml', 'utf8'));
 const prBodyWorkflow = YAML.parse(readFileSync('.github/workflows/pr-body.yml', 'utf8'));
@@ -125,10 +115,6 @@ assert(
   uiVitestSystemDependencyIndex >= 0 && uiVitestSystemDependencyIndex < uiVitestNodeSetupIndex,
   'ui-vitest must install Node system dependencies before actions/setup-node@v4',
 );
-assert(
-  String(uiVitestSteps[uiVitestSystemDependencyIndex].run ?? '').trim() === UI_VITEST_LIBATOMIC_INSTALL,
-  'ui-vitest must mutate the package index and install libatomic1 only when libatomic.so.1 is unavailable',
-);
 const uiVitestTestStep = uiVitestSteps.find((step) => step.name === 'Run UI vitest');
 assert(
   String(uiVitestTestStep?.run ?? '').trim() === 'pnpm --filter @invoker/ui test',
@@ -149,6 +135,20 @@ for (const requiredPackage of ['libatomic1', 'make', 'g++', 'python3']) {
     `ui-vitest system dependency step must install ${requiredPackage}`,
   );
 }
+assert(
+  uiVitestSystemDependencyRun.includes('sudo -n true')
+    && uiVitestSystemDependencyRun.includes('sudo -n apt-get')
+    && !uiVitestSystemDependencyRun.includes('SUDO="sudo"')
+    && !/^\s*sudo\s+(?!-n\b)/m.test(uiVitestSystemDependencyRun),
+  'ui-vitest libatomic install must prove passwordless sudo and use it noninteractively',
+);
+assert(
+  uiVitestSystemDependencyRun.includes('download libatomic1')
+    && uiVitestSystemDependencyRun.includes('Dir::State')
+    && uiVitestSystemDependencyRun.includes('LD_LIBRARY_PATH=')
+    && uiVitestSystemDependencyRun.includes('GITHUB_ENV'),
+  'ui-vitest libatomic install must provide a no-root LD_LIBRARY_PATH fallback',
+);
 
 const requiredFastEntries = jobs['required-fast'].strategy?.matrix?.include ?? [];
 const vitestWorkspaceEntry = requiredFastEntries.find((entry) => entry.name === 'Vitest Workspace');


### PR DESCRIPTION
## Summary

UI Vitest selected sudo by binary presence, which can invoke interactive sudo before Node setup.

The bootstrap now proves root or passwordless-sudo capability before privileged apt operations.

When neither is available, it unpacks libatomic1 into runner-owned storage and exports its library path.

The focused policy test enforces both noninteractive sudo and the no-root fallback.

## Review Claim

Approve a UI Vitest bootstrap that never invokes interactive sudo and still provisions Node runtime dependencies before `actions/setup-node`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only UI Vitest runner setup and its focused policy assertion change; product behavior, test selection, Node 26, Runner_Vitest, and unrelated jobs remain unchanged.

## Slice Rationale

UI Vitest privilege handling is an independently reviewable prerequisite, separate from build-artifacts native-toolchain provisioning.

## Non-goals

- No product edits.
- No Node downgrade or runner reassignment.
- No UI test selection changes or test skipping.
- No build-artifacts toolchain changes.
- No unrelated CI cleanup.

## Architecture

### Before

Previously, executable presence selected sudo even when it required a terminal or password.

### After

Now the bootstrap uses direct apt as root, `sudo -n` only after a successful probe, or a runner-owned libatomic extraction without root.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
  - Observed at the prerequisite commit: `CI merge-queue policy is valid.` and `PREREQUISITE_POLICY_EXIT=0`.
- [x] `git diff --check 7da25818da4f0ac27bd5ef2a435340267d1fd8a4^ 7da25818da4f0ac27bd5ef2a435340267d1fd8a4`
  - Observed exit code 0.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <PR merge commit>`
- Post-revert steps: Re-run the focused policy test before re-queueing a replacement.
- Data migration? No

</details>
