### PR TITLE
[CI regression: a404e8b-fleet-a404e8b-2-jobs](1) Route PR Authoring Guardrails to GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,7 +498,7 @@ jobs:
             runner_label: Runner_2_4_core
           - name: PR Authoring Guardrails
             command: bash scripts/test-suites/required/11-pr-authoring-guardrails.sh
-            runner_label: Github_Runner
+            runner_label: ubuntu-latest
           - name: Mergify Admin Requeue
             command: bash scripts/test-suites/required/12-mergify-admin-requeue.sh
             runner_label: Runner_2_4_core

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -127,6 +127,12 @@ assert(
   branchCarryForwardEntry.runner_label === 'ubuntu-latest',
   'Branch Carry Forward must use GitHub-hosted capacity with non-interactive system package installation',
 );
+const prAuthoringGuardrailsEntry = requiredFastExtraEntries.find((entry) => entry.name === 'PR Authoring Guardrails');
+assert(prAuthoringGuardrailsEntry, 'required-fast-extra matrix must include PR Authoring Guardrails');
+assert(
+  prAuthoringGuardrailsEntry.runner_label === 'ubuntu-latest',
+  'PR Authoring Guardrails must use GitHub-hosted capacity with non-interactive system package installation',
+);
 const mergeGateConcurrencyEntry = requiredFastExtraEntries.find((entry) => entry.name === 'Merge Gate Concurrency Repro');
 assert(mergeGateConcurrencyEntry, 'required-fast-extra matrix must include Merge Gate Concurrency Repro');
 assert(


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=a404e8b02eed8e9522302aece6ebc7f013e598cf; job=fleet -->

Two required-fast jobs first failed together on default-branch commit `a404e8b02eed8e9522302aece6ebc7f013e598cf`.

Route PR Authoring Guardrails to GitHub-hosted capacity and lock its runner assignment with a focused CI policy assertion.

Member jobs:

- [required-fast / PR Authoring Guardrails](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31773609297/job/94684674167)
- [required-fast / Start Running MECE Repros](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31773609297/job/94684674122)

## Review Claim

Approve assigning PR Authoring Guardrails to `ubuntu-latest`, with a focused policy assertion preserving that assignment.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect. Unaffected matrix entries retain their existing commands and runner labels.

## Slice Rationale

The runner assignment and its focused assertion form one CI-policy slice because the assertion directly guards the changed configuration.

## Non-goals

- No product behavior changes.
- No changes to Start Running MECE Repros or other unrelated runner assignments.
- No weakened checks, job deletions, snapshots, or runner fleet configuration changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/11-pr-authoring-guardrails.sh`
- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting restores the previous runner assignment.
- Revert command: `git revert e3152240a43289e4a9943bc2727aa1bab7964779`
- Post-revert steps: Re-run `node scripts/test-ci-workflow-merge-queue-policy.mjs` and monitor PR Authoring Guardrails on the next default-branch push.
- Data migration? No.

</details>
