### PR TITLE
[CI regression: 1a8a89d-build-artifacts](1) Use GitHub-hosted capacity for build-artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,7 @@ jobs:
   # Ordinary PRs keep only cheap quality checks so stacked PR pushes do not fan out heavy jobs.
   build-artifacts:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
-    runs-on:
-      labels: Runner_2_4_core
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -56,6 +56,11 @@ for (const jobName of FULL_CI_JOBS) {
   assert(jobs[jobName].if === FULL_CI_GATE, `${jobName} must run only for full CI events`);
 }
 
+assert(
+  jobs['build-artifacts']['runs-on'] === 'ubuntu-latest',
+  'build-artifacts must use fresh GitHub-hosted capacity so stale Git ref locks cannot block checkout',
+);
+
 assert(jobs['quality-required'], 'Missing quality-required job');
 assert(!jobs['quality-required'].if, 'quality-required must run on ordinary PRs');
 assert(


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=1a8a89d83df8b25a95f765d368507addf198161e; job=build-artifacts -->

`build-artifacts` first failed on commit `1a8a89d83df8b25a95f765d368507addf198161e` and remained red through `0052c7abad027b8fed8b908107de05fc9b6cfc65` because checkout encountered leftover Git ref locks.

The workflow now uses fresh GitHub-hosted capacity for this job and records that runner assignment in the focused CI policy test.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31783717537/job/94714828813

## Review Claim

Assign `build-artifacts` to GitHub-hosted capacity so leftover state on reused self-hosted runners cannot block checkout.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the `build-artifacts` runner selection changes; its gates, build commands, outputs, other CI jobs, and product behavior remain unchanged.

## Slice Rationale

This policy slice pairs the runner assignment with its focused assertion so the repaired CI requirement is reviewable and enforced together.

## Non-goals

- No build command or artifact changes.
- No changes to other CI jobs.
- No product behavior changes.
- No test weakening or unrelated cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; this restores the prior self-hosted runner selection and its policy assertion.
- Revert command: `git revert 76cce1e74eed9029f721b9e2cbd0a3ddde7e3c3b`
- Post-revert steps: Re-run the CI workflow policy test.
- Data migration? No.

</details>
