### PR TITLE
[Repair PR 9209: reclaim nested PR Body tool cache](1) Reclaim nested PR Body tool-cache ownership

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -155,7 +155,7 @@ jobs:
           fi
 
           if ! sudo -n mkdir -p -- "${RUNNER_TOOL_CACHE}" ||
-            ! sudo -n chown "$(id -u):$(id -g)" -- "${RUNNER_TOOL_CACHE}"; then
+            ! sudo -n chown -R "$(id -u):$(id -g)" -- "${RUNNER_TOOL_CACHE}"; then
             echo "::error::Could not assign RUNNER_TOOL_CACHE to the current runner account."
             exit 1
           fi

--- a/scripts/test-pr-body-rollout.mjs
+++ b/scripts/test-pr-body-rollout.mjs
@@ -149,8 +149,8 @@ assert.match(
 );
 assert.match(
   toolCacheStep,
-  /sudo -n chown "\$\(id -u\):\$\(id -g\)" -- "\$\{RUNNER_TOOL_CACHE\}"/,
-  'PR Body tool-cache ownership repair must assign only the resolved cache directory to the runner account',
+  /sudo -n chown (?:-R|--recursive) "\$\(id -u\):\$\(id -g\)" -- "\$\{RUNNER_TOOL_CACHE\}"/,
+  'PR Body tool-cache ownership repair must recursively assign only the resolved cache directory to the runner account',
 );
 assert.match(
   toolCacheStep,


### PR DESCRIPTION
## Summary

Repair PR Body's trusted tool-cache bootstrap before changing PR #9209.

The current permission repair stops at `RUNNER_TOOL_CACHE`, so a pre-existing root-controlled `node/` descendant can still make setup-node fail with EACCES.

Recursively reclaim that subtree and strengthen the focused rollout assertion to catch top-level-only permission repair.

PR #9209's two-file build-artifacts patch remains unchanged. After this prerequisite lands on master, retrigger PR Body for #9209 against the repaired trusted workflow.

## Review Claim

PR Body recursively assigns only `RUNNER_TOOL_CACHE` to the runner before setup-node, including pre-existing nested directories.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

PR targeting, rollout gates, Node selection, dependency installation, and checker semantics stay unchanged; only permissions below the runner-provided tool-cache path are repaired.

## Slice Rationale

This is a master prerequisite because `pull_request_target` cannot consume a workflow fix from PR #9209. Mixing it into that build-artifacts slice would combine independent CI policies.

## Non-goals

No change to PR #9209's branch, build-artifacts provisioning, Node version, runner labels, PR-body schema, target resolution, UI Vitest, or directories outside `RUNNER_TOOL_CACHE`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-rollout.mjs`
- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [x] `git diff --check origin/master...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes. Reverting restores the prior top-level-only tool-cache ownership repair.
- Revert command: `git revert 5929536d050e46b63477042c68335eac71fa0885`
- Post-revert steps: Retrigger PR Body only after another trusted-workflow repair lands on master.
- Data migration? No.

</details>
