### PR TITLE
[PR Body Nested Node Cache](1) Bugfix: PR Body setup-node cannot write an existing nested Node tool-cache directory

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -154,14 +154,14 @@ jobs:
             exit 1
           fi
 
-          if ! sudo -n mkdir -p -- "${RUNNER_TOOL_CACHE}" ||
-            ! sudo -n chown "$(id -u):$(id -g)" -- "${RUNNER_TOOL_CACHE}"; then
-            echo "::error::Could not assign RUNNER_TOOL_CACHE to the current runner account."
+          if ! sudo -n mkdir -p -- "${RUNNER_TOOL_CACHE}/node" ||
+            ! sudo -n chown -R "$(id -u):$(id -g)" -- "${RUNNER_TOOL_CACHE}/node"; then
+            echo "::error::Could not assign the Node.js tool cache to the current runner account."
             exit 1
           fi
 
-          if [[ ! -d "${RUNNER_TOOL_CACHE}" || ! -w "${RUNNER_TOOL_CACHE}" ]]; then
-            echo "::error::RUNNER_TOOL_CACHE is not writable by the current runner account."
+          if [[ ! -d "${RUNNER_TOOL_CACHE}/node" || ! -w "${RUNNER_TOOL_CACHE}/node" ]]; then
+            echo "::error::Node.js tool cache is not writable by the current runner account."
             exit 1
           fi
 

--- a/scripts/test-pr-body-rollout.mjs
+++ b/scripts/test-pr-body-rollout.mjs
@@ -144,18 +144,23 @@ assert.match(
 );
 assert.match(
   toolCacheStep,
-  /sudo -n mkdir -p -- "\$\{RUNNER_TOOL_CACHE\}"/,
-  'PR Body tool-cache ownership repair must create the resolved cache directory with passwordless sudo',
+  /sudo -n mkdir -p -- "\$\{RUNNER_TOOL_CACHE\}\/node"/,
+  'PR Body tool-cache ownership repair must create the nested Node.js cache directory with passwordless sudo',
 );
 assert.match(
   toolCacheStep,
-  /sudo -n chown "\$\(id -u\):\$\(id -g\)" -- "\$\{RUNNER_TOOL_CACHE\}"/,
-  'PR Body tool-cache ownership repair must assign only the resolved cache directory to the runner account',
+  /sudo -n chown -R "\$\(id -u\):\$\(id -g\)" -- "\$\{RUNNER_TOOL_CACHE\}\/node"/,
+  'PR Body tool-cache ownership repair must recursively assign the nested Node.js cache to the runner account',
 );
 assert.match(
   toolCacheStep,
-  /\[\[ ! -d "\$\{RUNNER_TOOL_CACHE\}" \|\| ! -w "\$\{RUNNER_TOOL_CACHE\}" \]\][\s\S]*::error::RUNNER_TOOL_CACHE is not writable[\s\S]*exit 1/,
-  'PR Body tool-cache ownership repair must fail clearly unless the resolved cache directory is writable',
+  /\[\[ ! -d "\$\{RUNNER_TOOL_CACHE\}\/node" \|\| ! -w "\$\{RUNNER_TOOL_CACHE\}\/node" \]\][\s\S]*::error::Node\.js tool cache is not writable[\s\S]*exit 1/,
+  'PR Body tool-cache ownership repair must fail clearly unless the nested Node.js cache directory is writable',
+);
+assert.doesNotMatch(
+  toolCacheStep,
+  /chown -R[^\n]*-- "\$\{RUNNER_TOOL_CACHE\}"/,
+  'PR Body tool-cache ownership repair must not recursively change ownership of the entire runner tool cache',
 );
 assert.doesNotMatch(
   toolCacheStep,


### PR DESCRIPTION
## Summary

Repair the trusted-base PR Body bootstrap that blocks PR #9185.

An existing Node tool-cache subtree can remain owned by another account, causing setup-node to fail with EACCES while creating its version directory.

Create and recursively reclaim only `$RUNNER_TOOL_CACHE/node` before setup-node, with a regression assertion that protects unrelated tool caches.

## Review Claim

The PR Body bootstrap recursively assigns the existing `$RUNNER_TOOL_CACHE/node` subtree to the runner account before setup-node writes a version directory.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the Node.js subtree under `RUNNER_TOOL_CACHE` changes ownership; unrelated tool caches, Node and pnpm versions, target resolution, rollout gating, and validation behavior remain unchanged.

## Slice Rationale

This trusted-base PR Body prerequisite cannot ship inside PR #9185 because `pull_request_target` ignores workflow edits from the pull request it checks. The workflow rule and its executable policy check form one reviewable slice.

## Non-goals

No changes to PR #9185's required-fast runner assignment, other workflows, Node or pnpm versions, PR-body validation semantics, or directories outside the Node.js tool-cache subtree.

## Architecture

### Before

The bootstrap creates and assigns only `$RUNNER_TOOL_CACHE`, leaving an existing nested `node` subtree potentially unwritable.

### After

The bootstrap creates and recursively assigns `$RUNNER_TOOL_CACHE/node` immediately before setup-node, without recursively changing the cache root.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-rollout.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, but reverting restores the setup-node EACCES risk on runners with a foreign-owned nested Node cache.
- Revert command: `git revert 9f684c57f81d5e3f7be6dd6ed182310818d7a639`
- Post-revert steps: Re-run `node scripts/test-pr-body-rollout.mjs` and confirm the expected regression before pushing the revert.
- Data migration? No.

</details>
