### PR TITLE
[Repair PR Body nested Node tool-cache ownership](1) Reclaim nested Node tool-cache ownership

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -160,6 +160,12 @@ jobs:
             exit 1
           fi
 
+          if [[ -e "${RUNNER_TOOL_CACHE}/node" || -L "${RUNNER_TOOL_CACHE}/node" ]] &&
+            ! sudo -n chown -R -h -P "$(id -u):$(id -g)" -- "${RUNNER_TOOL_CACHE}/node"; then
+            echo "::error::Could not assign the existing Node.js tool-cache subtree to the current runner account."
+            exit 1
+          fi
+
           if [[ ! -d "${RUNNER_TOOL_CACHE}" || ! -w "${RUNNER_TOOL_CACHE}" ]]; then
             echo "::error::RUNNER_TOOL_CACHE is not writable by the current runner account."
             exit 1

--- a/scripts/repro-pr-body-tool-cache-permissions.sh
+++ b/scripts/repro-pr-body-tool-cache-permissions.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/pr-body-tool-cache-permissions.XXXXXX")"
+tool_cache="${fixture_root}/tool cache"
+node_cache="${tool_cache}/node"
+requested_node="${node_cache}/24.19.0"
+
+cleanup() {
+  chmod -R u+rwX -- "${fixture_root}" 2>/dev/null || true
+  rm -rf -- "${fixture_root}"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+mkdir -p -- "${node_cache}"
+
+# Model a cache root repaired for the current account while its existing Node
+# subtree still has the non-writable mode that foreign ownership exposes.
+chmod u+rwx -- "${tool_cache}"
+chmod 0555 -- "${node_cache}"
+
+if mkdir -- "${requested_node}" 2>"${fixture_root}/shallow-repair.stderr"; then
+  echo "ERROR: shallow root-only repair unexpectedly created node/24.19.0" >&2
+  exit 1
+fi
+
+echo "REPRODUCED: shallow root-only repair cannot create node/24.19.0"
+
+# Use mode repair as a sudo-free stand-in for recursively restoring ownership
+# to the current account. The workflow performs the corresponding chown.
+chmod -R u+rwX -- "${node_cache}"
+
+if ! mkdir -- "${requested_node}"; then
+  echo "ERROR: nested Node cache repair could not create node/24.19.0" >&2
+  exit 1
+fi
+
+echo "CORRECTED: nested Node cache repair can create node/24.19.0"

--- a/scripts/test-pr-body-rollout.mjs
+++ b/scripts/test-pr-body-rollout.mjs
@@ -150,7 +150,17 @@ assert.match(
 assert.match(
   toolCacheStep,
   /sudo -n chown "\$\(id -u\):\$\(id -g\)" -- "\$\{RUNNER_TOOL_CACHE\}"/,
-  'PR Body tool-cache ownership repair must assign only the resolved cache directory to the runner account',
+  'PR Body tool-cache ownership repair must assign the resolved cache directory to the runner account',
+);
+assert.match(
+  toolCacheStep,
+  /\[\[ -e "\$\{RUNNER_TOOL_CACHE\}\/node" \|\| -L "\$\{RUNNER_TOOL_CACHE\}\/node" \]\][\s\S]*sudo -n chown -R -h -P "\$\(id -u\):\$\(id -g\)" -- "\$\{RUNNER_TOOL_CACHE\}\/node"/,
+  'PR Body tool-cache ownership repair must recursively assign the existing Node cache subtree without following symlinks',
+);
+assert.doesNotMatch(
+  toolCacheStep,
+  /chown[^\n]*-R[^\n]*-- "\$\{RUNNER_TOOL_CACHE\}"(?:\s|$)/,
+  'PR Body tool-cache ownership repair must not recursively assign the whole runner tool cache',
 );
 assert.match(
   toolCacheStep,
@@ -161,6 +171,24 @@ assert.doesNotMatch(
   toolCacheStep,
   /\/home\/runner(?:\/|['"])/,
   'PR Body tool-cache ownership repair must not hard-code a runner path',
+);
+
+const toolCachePermissionsRepro = spawnSync('bash', [
+  'scripts/repro-pr-body-tool-cache-permissions.sh',
+], {
+  cwd: new URL('..', import.meta.url),
+  encoding: 'utf8',
+});
+assert.equal(toolCachePermissionsRepro.status, 0, toolCachePermissionsRepro.stderr);
+assert.match(
+  toolCachePermissionsRepro.stdout,
+  /REPRODUCED: shallow root-only repair cannot create node\/24\.19\.0/,
+  'PR Body focused checks must reproduce the shallow ownership-repair denial',
+);
+assert.match(
+  toolCachePermissionsRepro.stdout,
+  /CORRECTED: nested Node cache repair can create node\/24\.19\.0/,
+  'PR Body focused checks must prove the nested ownership repair succeeds',
 );
 
 const outputDir = mkdtempSync(join(tmpdir(), 'pr-body-rollout-'));


### PR DESCRIPTION
## Summary

PR Body now repairs ownership across the runner-provided Node tool-cache subtree before setup-node writes a version directory.

A deterministic shell repro prevents cache-root-only ownership checks from masking unwritable nested directories.

## Review Claim

PR Body makes the existing Node cache subtree writable before actions/setup-node without changing paths outside `RUNNER_TOOL_CACHE`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the runner-provided `RUNNER_TOOL_CACHE` path and its existing descendants may have ownership repaired; target resolution, rollout gating, Node selection, validation behavior, and PR #9231's diff remain unchanged.

## Slice Rationale

This prerequisite keeps the ownership policy with its directly affected regression proof. It must land on master because `pull_request_target` ignores workflow edits from PR #9231.

## Non-goals

This does not alter `.github/workflows/ci.yml`, PR #9231, PR-body validation rules, author rollout, Node or pnpm versions, workflow triggers, or unrelated runner directories.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro-pr-body-tool-cache-permissions.sh`
- [x] `node scripts/test-pr-body-rollout.mjs`
- [x] `git diff --check`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
