### PR TITLE
[Idle task cleanup](1) Add closeIdleTask orchestrator primitive

### DIFF
--- a/packages/workflow-core/src/__tests__/cancel-task.test.ts
+++ b/packages/workflow-core/src/__tests__/cancel-task.test.ts
@@ -298,6 +298,98 @@ describe('cancelTask', () => {
   });
 });
 
+describe('closeIdleTask', () => {
+  let orchestrator: Orchestrator;
+  let persistence: InMemoryPersistence;
+  let bus: InMemoryBus;
+  let publishedDeltas: TaskDelta[];
+
+  beforeEach(() => {
+    persistence = new InMemoryPersistence();
+    bus = new InMemoryBus();
+    publishedDeltas = [];
+
+    bus.subscribe('task.delta', (delta) => {
+      publishedDeltas.push(delta as TaskDelta);
+    });
+
+    orchestrator = new Orchestrator({
+      persistence,
+      messageBus: bus,
+      maxConcurrency: 3,
+    });
+  });
+
+  it('throws TASK_NOT_CLOSABLE for a non-terminal status', () => {
+    orchestrator.loadPlan(simplePlan());
+    expect(orchestrator.getTask('a')!.status).toBe('pending');
+
+    expect(() => orchestrator.closeIdleTask('a')).toThrow(/pending/);
+  });
+
+  it('throws TASK_NOT_FOUND for an unknown task id', () => {
+    orchestrator.loadPlan(simplePlan());
+    expect(() => orchestrator.closeIdleTask('does-not-exist')).toThrow('not found');
+  });
+
+  it('closes a failed task without touching its blocked dependents', () => {
+    orchestrator.loadPlan(simplePlan());
+    orchestrator.cancelTask('a');
+    expect(orchestrator.getTask('a')!.status).toBe('failed');
+    expect(orchestrator.getTask('b')!.status).toBe('blocked');
+    expect(orchestrator.getTask('c')!.status).toBe('blocked');
+
+    orchestrator.closeIdleTask('a');
+
+    expect(orchestrator.getTask('a')!.status).toBe('closed');
+    // Dependents are untouched — closeIdleTask never cascades.
+    expect(orchestrator.getTask('b')!.status).toBe('blocked');
+    expect(orchestrator.getTask('c')!.status).toBe('blocked');
+  });
+
+  it('closes a completed task', () => {
+    orchestrator.loadPlan(simplePlan());
+    orchestrator.startExecution();
+    orchestrator.handleWorkerResponse(
+      makeResponse({ actionId: 'a', status: 'completed', outputs: { exitCode: 0 } }),
+    );
+    expect(orchestrator.getTask('a')!.status).toBe('completed');
+
+    orchestrator.closeIdleTask('a');
+
+    expect(orchestrator.getTask('a')!.status).toBe('closed');
+  });
+
+  it('closes a review_ready task', () => {
+    orchestrator.loadPlan(simplePlan());
+    orchestrator.startExecution();
+    orchestrator.setTaskReviewReady('a');
+    expect(orchestrator.getTask('a')!.status).toBe('review_ready');
+
+    orchestrator.closeIdleTask('a');
+
+    expect(orchestrator.getTask('a')!.status).toBe('closed');
+  });
+
+  it('publishes a single delta for the closed task, not its dependents', () => {
+    orchestrator.loadPlan(simplePlan());
+    orchestrator.cancelTask('a');
+
+    publishedDeltas = [];
+    orchestrator.closeIdleTask('a');
+
+    const sa = sid(orchestrator, 0, 'a');
+    const closeDeltas = publishedDeltas.filter(
+      (d): d is Extract<TaskDelta, { type: 'updated' }> => d.type === 'updated' && d.taskId === sa,
+    );
+    expect(closeDeltas).toHaveLength(1);
+    const otherTaskDeltas = publishedDeltas.filter(
+      (d): d is Extract<TaskDelta, { type: 'updated' }> => d.type === 'updated' && d.taskId !== sa,
+    );
+    expect(otherTaskDeltas).toHaveLength(0);
+  });
+});
+
 describe('cancelWorkflow', () => {
   let orchestrator: Orchestrator;
   let persistence: InMemoryPersistence;

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -424,6 +424,16 @@ export class CommandService {
     );
   }
 
+  async closeIdleTask(
+    envelope: CommandEnvelope<{ taskId: string }>,
+  ): Promise<CommandResult<TaskState>> {
+    return this.executeCommand<TaskState>(
+      'CLOSE_IDLE_TASK_FAILED',
+      () => this.orchestrator.closeIdleTask(envelope.payload.taskId),
+      this.workflowIdForTask(envelope.payload.taskId),
+    );
+  }
+
   async cancelWorkflow(
     envelope: CommandEnvelope<{ workflowId: string }>,
   ): Promise<CommandResult<CancelResult>> {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -49,6 +49,7 @@ function mergeTrace(tag: string, data: Record<string, unknown>): void {
 export const OrchestratorErrorCode = {
   TASK_NOT_FOUND: 'TASK_NOT_FOUND',
   TASK_ALREADY_TERMINAL: 'TASK_ALREADY_TERMINAL',
+  TASK_NOT_CLOSABLE: 'TASK_NOT_CLOSABLE',
   WORKFLOW_NOT_FOUND: 'WORKFLOW_NOT_FOUND',
   REVIEW_GATE_NOT_APPROVED: 'REVIEW_GATE_NOT_APPROVED',
 } as const;
@@ -111,6 +112,7 @@ import {
   cancelActiveCandidatesImpl,
   cancelTaskImpl,
   cancelWorkflowImpl,
+  closeIdleTaskImpl,
   deferTaskImpl,
   finalizeCancelInvalidationImpl,
 } from './orchestrator/cancellation.js';
@@ -3399,6 +3401,15 @@ export class Orchestrator {
    */
   cancelTask(taskId: string): { cancelled: string[]; runningCancelled: string[] } {
     return cancelTaskImpl(this as unknown as CancellationHost, taskId);
+  }
+
+  /**
+   * Close a single idle task (`failed` / `completed` / `review_ready`) without
+   * cascading to dependents, ancestors, or the parent workflow's status.
+   * Used by the stale-task cleanup sweep, distinct from `cancelTask`.
+   */
+  closeIdleTask(taskId: string): TaskState {
+    return closeIdleTaskImpl(this as unknown as CancellationHost, taskId);
   }
 
   /**

--- a/packages/workflow-core/src/orchestrator/cancellation.ts
+++ b/packages/workflow-core/src/orchestrator/cancellation.ts
@@ -301,6 +301,48 @@ export function cancelTaskImpl(
   return { cancelled, runningCancelled, toCancelIds };
 }
 
+const CLOSABLE_STATUSES: Partial<Record<TaskStatus, true>> = {
+  failed: true,
+  completed: true,
+  review_ready: true,
+};
+
+/**
+ * Close a single idle task in a terminal-ish status (`failed` / `completed` /
+ * `review_ready`) without touching any other task.
+ *
+ * Unlike `cancelTaskImpl`, this never cascades to dependents and never
+ * inspects the DAG — it is a narrow bookkeeping transition for a stale-task
+ * sweep, not a cancellation. Dependents, ancestors, and the parent
+ * workflow's own status are left exactly as they were (beyond the routine
+ * `checkWorkflowCompletion` recheck every task write triggers).
+ */
+export function closeIdleTaskImpl(host: CancellationHost, taskId: string): TaskState {
+  host.refreshFromDb();
+
+  const task = host.stateGetTask(taskId);
+  if (!task) throw new OrchestratorError('TASK_NOT_FOUND', `Task "${taskId}" not found`);
+
+  if (!CLOSABLE_STATUSES[task.status]) {
+    throw new OrchestratorError(
+      'TASK_NOT_CLOSABLE',
+      `Task "${taskId}" is "${task.status}"; only failed, completed, or review_ready tasks can be closed`,
+    );
+  }
+
+  const changes: TaskStateChanges = {
+    status: 'closed',
+    execution: { completedAt: task.execution.completedAt ?? new Date() },
+  };
+  const updated = host.writeAndSync(taskId, changes);
+  const delta: TaskDelta = host.buildUpdateDelta(task, updated, changes);
+  host.persistence.logEvent?.(taskId, 'task.closed_idle', changes);
+  host.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+
+  host.checkWorkflowCompletion(task.config.workflowId);
+  return updated;
+}
+
 /**
  * Cancel all active tasks in a workflow.
  * Terminal tasks (completed/stale) are preserved as-is.


### PR DESCRIPTION
## Summary

Invoker has no way to close a single stale task on its own.

The existing cancel path always cascades to every downstream task.

It also refuses to touch a task that already reached a finished state.

A future idle-task sweep needs to close one finished task in place.

This adds that one narrow primitive, separate from cancellation.

## Review Claim

Approve a new orchestrator method that flips one task to closed, with no downstream effect.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new method only ever writes the one task named by its argument.

It never looks up dependents, ancestors, or any other task in the workflow.

A test asserts a dependent task's status is byte-for-byte unchanged afterward.

Nothing calls this method yet, so no existing flow can be affected by adding it.

## Slice Rationale

This is the one primitive every later slice in this stack builds on.

Landing it alone keeps the orchestrator-level change reviewable on its own, before any caller exists.

## Non-goals

Does not wire this into any other surface yet — that follows in the next slice.

Does not change cancel's existing cascade or terminal-status behavior.

Does not decide which tasks qualify for cleanup; that comes later in this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/workflow-core test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
