### PR TITLE
[Idle task cleanup](2) Expose closeIdleTask as a headless close-task command

### DIFF
--- a/packages/app/src/__tests__/headless-close-task.test.ts
+++ b/packages/app/src/__tests__/headless-close-task.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { headlessCloseTask } from '../headless-approve-delete.js';
+
+function makeDeps(overrides: { closeIdleTaskResult: { ok: true; data: unknown } | { ok: false; error: { message: string } } }) {
+  const workflows = [{ id: 'wf-1' }];
+  const tasks = [{ id: 'wf-1/task-a' }];
+  return {
+    orchestrator: {
+      syncFromDb: vi.fn(),
+    } as any,
+    persistence: {
+      listWorkflows: vi.fn(() => workflows),
+      loadTasks: vi.fn(() => tasks),
+    } as any,
+    commandService: {
+      closeIdleTask: vi.fn(async () => overrides.closeIdleTaskResult),
+    } as any,
+  };
+}
+
+describe('headlessCloseTask', () => {
+  it('closes a task via commandService.closeIdleTask and reports success', async () => {
+    const deps = makeDeps({ closeIdleTaskResult: { ok: true, data: { id: 'wf-1/task-a', status: 'closed' } } });
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await headlessCloseTask('wf-1/task-a', deps);
+
+    expect(deps.commandService.closeIdleTask).toHaveBeenCalledTimes(1);
+    const [envelope] = deps.commandService.closeIdleTask.mock.calls[0];
+    expect(envelope.payload.taskId).toBe('wf-1/task-a');
+    expect(write.mock.calls.map(([chunk]) => String(chunk)).join('')).toContain('Closed task: wf-1/task-a');
+    write.mockRestore();
+  });
+
+  it('propagates a TASK_NOT_CLOSABLE-style command failure', async () => {
+    const deps = makeDeps({
+      closeIdleTaskResult: { ok: false, error: { message: 'Task "wf-1/task-a" is "pending"; only failed, completed, or review_ready tasks can be closed' } },
+    });
+
+    await expect(headlessCloseTask('wf-1/task-a', deps)).rejects.toThrow('only failed, completed, or review_ready');
+  });
+
+  it('throws when taskId is missing', async () => {
+    const deps = makeDeps({ closeIdleTaskResult: { ok: true, data: {} } });
+    await expect(headlessCloseTask('', deps)).rejects.toThrow('Missing taskId');
+  });
+});

--- a/packages/app/src/__tests__/headless-command-classification.test.ts
+++ b/packages/app/src/__tests__/headless-command-classification.test.ts
@@ -55,6 +55,7 @@ describe('headless-command-classification', () => {
     expect(isHeadlessMutatingCommand(['migrate-compat'])).toBe(true);
     expect(isHeadlessMutatingCommand(['check-pr-status'])).toBe(true);
     expect(isHeadlessMutatingCommand(['cancel-workflow'])).toBe(true);
+    expect(isHeadlessMutatingCommand(['close-task'])).toBe(true);
     expect(isHeadlessMutatingCommand(['set', 'prompt'])).toBe(true);
     expect(isHeadlessMutatingCommand(['set', 'agent'])).toBe(true);
     expect(isHeadlessMutatingCommand(['set', 'fix-context'])).toBe(true);

--- a/packages/app/src/headless-approve-delete.ts
+++ b/packages/app/src/headless-approve-delete.ts
@@ -307,6 +307,17 @@ export async function headlessDeleteTask(taskId: string, deps: HeadlessDeps): Pr
   });
 }
 
+export async function headlessCloseTask(taskId: string, deps: Pick<HeadlessDeps, 'commandService' | 'orchestrator' | 'persistence'>): Promise<void> {
+  if (!taskId) throw new Error('Missing taskId. Usage: --headless close-task <taskId>');
+  await withRestoredTaskUnlessDeleteAllWon(taskId, deps, 'close-task', async (restored) => {
+    taskId = restored.resolvedTaskId;
+    const envelope = makeEnvelope('close-task', 'headless', 'task', { taskId });
+    const result = await deps.commandService.closeIdleTask(envelope);
+    if (!result.ok) throw new Error(result.error.message);
+    process.stdout.write(`Closed task: ${taskId}\n`);
+  });
+}
+
 export async function headlessDeleteWorkflow(workflowId: string, deps: HeadlessDeps): Promise<void> {
   if (!workflowId) throw new Error('Missing workflowId. Usage: --headless delete-workflow <workflowId>');
   // Preempt running tasks (kill processes + cancel) — matches owner-mode bridge contract

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -56,6 +56,7 @@ export const HEADLESS_COMMANDS = [
   { name: 'cancel', kind: 'write' },
   { name: 'cancel-workflow', kind: 'write' },
   { name: 'delete-task', kind: 'write' },
+  { name: 'close-task', kind: 'write' },
   { name: 'delete', kind: 'write' },
   { name: 'delete-all', kind: 'write' },
   { name: 'open-terminal', kind: 'read' },

--- a/packages/app/src/headless-usage.ts
+++ b/packages/app/src/headless-usage.ts
@@ -75,6 +75,7 @@ ${BOLD}Lifecycle:${RESET}
   cancel <taskId>                                     Cancel task + all downstream
   cancel-workflow <workflowId>                        Cancel all active tasks in a workflow
   delete-task <taskId>                                 Delete one task and retarget dependents
+  close-task <taskId>                                  Close one failed/completed/review_ready task, no cascade
   delete <workflowId>                                  Delete a single workflow
   delete-all                                           Delete all workflows (requires INVOKER_ALLOW_DELETE_ALL=1)
   open-terminal <taskId>                              Open OS terminal for a task

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -106,6 +106,7 @@ import {
   headlessCancelWorkflow,
   headlessDeleteWorkflow,
   headlessDeleteTask,
+  headlessCloseTask,
   headlessDetachWorkflow,
   headlessAttachWorkflow,
   headlessOpenTerminal,
@@ -378,6 +379,9 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       break;
     case 'delete-task':
       await headlessDeleteTask(args[1], deps);
+      break;
+    case 'close-task':
+      await headlessCloseTask(args[1], deps);
       break;
     case 'delete':
       await headlessDeleteWorkflow(args[1], deps);

--- a/packages/workflow-core/src/__tests__/cancel-task.test.ts
+++ b/packages/workflow-core/src/__tests__/cancel-task.test.ts
@@ -298,6 +298,98 @@ describe('cancelTask', () => {
   });
 });
 
+describe('closeIdleTask', () => {
+  let orchestrator: Orchestrator;
+  let persistence: InMemoryPersistence;
+  let bus: InMemoryBus;
+  let publishedDeltas: TaskDelta[];
+
+  beforeEach(() => {
+    persistence = new InMemoryPersistence();
+    bus = new InMemoryBus();
+    publishedDeltas = [];
+
+    bus.subscribe('task.delta', (delta) => {
+      publishedDeltas.push(delta as TaskDelta);
+    });
+
+    orchestrator = new Orchestrator({
+      persistence,
+      messageBus: bus,
+      maxConcurrency: 3,
+    });
+  });
+
+  it('throws TASK_NOT_CLOSABLE for a non-terminal status', () => {
+    orchestrator.loadPlan(simplePlan());
+    expect(orchestrator.getTask('a')!.status).toBe('pending');
+
+    expect(() => orchestrator.closeIdleTask('a')).toThrow(/pending/);
+  });
+
+  it('throws TASK_NOT_FOUND for an unknown task id', () => {
+    orchestrator.loadPlan(simplePlan());
+    expect(() => orchestrator.closeIdleTask('does-not-exist')).toThrow('not found');
+  });
+
+  it('closes a failed task without touching its blocked dependents', () => {
+    orchestrator.loadPlan(simplePlan());
+    orchestrator.cancelTask('a');
+    expect(orchestrator.getTask('a')!.status).toBe('failed');
+    expect(orchestrator.getTask('b')!.status).toBe('blocked');
+    expect(orchestrator.getTask('c')!.status).toBe('blocked');
+
+    orchestrator.closeIdleTask('a');
+
+    expect(orchestrator.getTask('a')!.status).toBe('closed');
+    // Dependents are untouched — closeIdleTask never cascades.
+    expect(orchestrator.getTask('b')!.status).toBe('blocked');
+    expect(orchestrator.getTask('c')!.status).toBe('blocked');
+  });
+
+  it('closes a completed task', () => {
+    orchestrator.loadPlan(simplePlan());
+    orchestrator.startExecution();
+    orchestrator.handleWorkerResponse(
+      makeResponse({ actionId: 'a', status: 'completed', outputs: { exitCode: 0 } }),
+    );
+    expect(orchestrator.getTask('a')!.status).toBe('completed');
+
+    orchestrator.closeIdleTask('a');
+
+    expect(orchestrator.getTask('a')!.status).toBe('closed');
+  });
+
+  it('closes a review_ready task', () => {
+    orchestrator.loadPlan(simplePlan());
+    orchestrator.startExecution();
+    orchestrator.setTaskReviewReady('a');
+    expect(orchestrator.getTask('a')!.status).toBe('review_ready');
+
+    orchestrator.closeIdleTask('a');
+
+    expect(orchestrator.getTask('a')!.status).toBe('closed');
+  });
+
+  it('publishes a single delta for the closed task, not its dependents', () => {
+    orchestrator.loadPlan(simplePlan());
+    orchestrator.cancelTask('a');
+
+    publishedDeltas = [];
+    orchestrator.closeIdleTask('a');
+
+    const sa = sid(orchestrator, 0, 'a');
+    const closeDeltas = publishedDeltas.filter(
+      (d): d is Extract<TaskDelta, { type: 'updated' }> => d.type === 'updated' && d.taskId === sa,
+    );
+    expect(closeDeltas).toHaveLength(1);
+    const otherTaskDeltas = publishedDeltas.filter(
+      (d): d is Extract<TaskDelta, { type: 'updated' }> => d.type === 'updated' && d.taskId !== sa,
+    );
+    expect(otherTaskDeltas).toHaveLength(0);
+  });
+});
+
 describe('cancelWorkflow', () => {
   let orchestrator: Orchestrator;
   let persistence: InMemoryPersistence;

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -424,6 +424,16 @@ export class CommandService {
     );
   }
 
+  async closeIdleTask(
+    envelope: CommandEnvelope<{ taskId: string }>,
+  ): Promise<CommandResult<TaskState>> {
+    return this.executeCommand<TaskState>(
+      'CLOSE_IDLE_TASK_FAILED',
+      () => this.orchestrator.closeIdleTask(envelope.payload.taskId),
+      this.workflowIdForTask(envelope.payload.taskId),
+    );
+  }
+
   async cancelWorkflow(
     envelope: CommandEnvelope<{ workflowId: string }>,
   ): Promise<CommandResult<CancelResult>> {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -49,6 +49,7 @@ function mergeTrace(tag: string, data: Record<string, unknown>): void {
 export const OrchestratorErrorCode = {
   TASK_NOT_FOUND: 'TASK_NOT_FOUND',
   TASK_ALREADY_TERMINAL: 'TASK_ALREADY_TERMINAL',
+  TASK_NOT_CLOSABLE: 'TASK_NOT_CLOSABLE',
   WORKFLOW_NOT_FOUND: 'WORKFLOW_NOT_FOUND',
   REVIEW_GATE_NOT_APPROVED: 'REVIEW_GATE_NOT_APPROVED',
 } as const;
@@ -111,6 +112,7 @@ import {
   cancelActiveCandidatesImpl,
   cancelTaskImpl,
   cancelWorkflowImpl,
+  closeIdleTaskImpl,
   deferTaskImpl,
   finalizeCancelInvalidationImpl,
 } from './orchestrator/cancellation.js';
@@ -3399,6 +3401,15 @@ export class Orchestrator {
    */
   cancelTask(taskId: string): { cancelled: string[]; runningCancelled: string[] } {
     return cancelTaskImpl(this as unknown as CancellationHost, taskId);
+  }
+
+  /**
+   * Close a single idle task (`failed` / `completed` / `review_ready`) without
+   * cascading to dependents, ancestors, or the parent workflow's status.
+   * Used by the stale-task cleanup sweep, distinct from `cancelTask`.
+   */
+  closeIdleTask(taskId: string): TaskState {
+    return closeIdleTaskImpl(this as unknown as CancellationHost, taskId);
   }
 
   /**

--- a/packages/workflow-core/src/orchestrator/cancellation.ts
+++ b/packages/workflow-core/src/orchestrator/cancellation.ts
@@ -301,6 +301,48 @@ export function cancelTaskImpl(
   return { cancelled, runningCancelled, toCancelIds };
 }
 
+const CLOSABLE_STATUSES: Partial<Record<TaskStatus, true>> = {
+  failed: true,
+  completed: true,
+  review_ready: true,
+};
+
+/**
+ * Close a single idle task in a terminal-ish status (`failed` / `completed` /
+ * `review_ready`) without touching any other task.
+ *
+ * Unlike `cancelTaskImpl`, this never cascades to dependents and never
+ * inspects the DAG — it is a narrow bookkeeping transition for a stale-task
+ * sweep, not a cancellation. Dependents, ancestors, and the parent
+ * workflow's own status are left exactly as they were (beyond the routine
+ * `checkWorkflowCompletion` recheck every task write triggers).
+ */
+export function closeIdleTaskImpl(host: CancellationHost, taskId: string): TaskState {
+  host.refreshFromDb();
+
+  const task = host.stateGetTask(taskId);
+  if (!task) throw new OrchestratorError('TASK_NOT_FOUND', `Task "${taskId}" not found`);
+
+  if (!CLOSABLE_STATUSES[task.status]) {
+    throw new OrchestratorError(
+      'TASK_NOT_CLOSABLE',
+      `Task "${taskId}" is "${task.status}"; only failed, completed, or review_ready tasks can be closed`,
+    );
+  }
+
+  const changes: TaskStateChanges = {
+    status: 'closed',
+    execution: { completedAt: task.execution.completedAt ?? new Date() },
+  };
+  const updated = host.writeAndSync(taskId, changes);
+  const delta: TaskDelta = host.buildUpdateDelta(task, updated, changes);
+  host.persistence.logEvent?.(taskId, 'task.closed_idle', changes);
+  host.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+
+  host.checkWorkflowCompletion(task.config.workflowId);
+  return updated;
+}
+
 /**
  * Cancel all active tasks in a workflow.
  * Terminal tasks (completed/stale) are preserved as-is.


### PR DESCRIPTION
## Summary

The previous PR added a way to close one finished task in place.

Nothing outside workflow-core can reach it yet.

This adds `close-task <taskId>`, a new headless CLI command that calls it.

It follows the same shape as this repo's other single-task headless commands.

## Review Claim

Approve a new headless command that exposes the prior PR's method to the CLI.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The new command only runs the one method added in the prior PR.

It rejects a task in the wrong state with a clear error instead of doing nothing silently.

## Slice Rationale

Keeping the CLI wiring in its own PR isolates the CLI activation surface from the orchestrator change underneath it, so each is reviewable on its own terms.

## Non-goals

Does not add a worker or automated caller for this command yet.

Does not change any other headless command's behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
