### PR TITLE
[Vitest Workspace CI Scope Fix](1) Stop the job from running the full pnpm test chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,7 +414,7 @@ jobs:
             runner_label: Runner_2_4_core
           - name: Vitest Workspace
             command: bash scripts/test-suites/required/10-vitest-workspace.sh
-            runner_label: Runner_2_4_core
+            runner_label: ubuntu-latest
           - name: Submit Workflow Chain
             command: bash scripts/test-suites/required/15-submit-workflow-chain.sh
             runner_label: Github_Runner

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -13,6 +13,7 @@ const FULL_CI_JOBS = new Set(['build-artifacts', 'e2e-proof', 'e2e-proof-aggrega
 const workflow = YAML.parse(readFileSync('.github/workflows/ci.yml', 'utf8'));
 const prBodyWorkflow = YAML.parse(readFileSync('.github/workflows/pr-body.yml', 'utf8'));
 const closeCleanupPath = '.github/workflows/merge-queue-close-cleanup.yml';
+const vitestWorkspaceSuite = readFileSync('scripts/test-suites/required/10-vitest-workspace.sh', 'utf8');
 const mergify = YAML.parse(readFileSync('.mergify.yml', 'utf8'));
 const jobs = workflow.jobs ?? {};
 
@@ -98,6 +99,30 @@ const uiVitestLibatomicIndex = uiVitestSteps.findIndex(
 assert(
   uiVitestLibatomicIndex >= 0 && uiVitestLibatomicIndex < uiVitestNodeSetupIndex,
   'ui-vitest must install libatomic1 before actions/setup-node@v4',
+);
+
+const requiredFastEntries = jobs['required-fast'].strategy?.matrix?.include ?? [];
+const vitestWorkspaceEntry = requiredFastEntries.find((entry) => entry.name === 'Vitest Workspace');
+assert(vitestWorkspaceEntry, 'required-fast matrix must include Vitest Workspace');
+assert(
+  vitestWorkspaceEntry.runner_label === 'ubuntu-latest',
+  'Vitest Workspace must use fresh GitHub-hosted capacity so runner disk and toolchain state cannot block the suite',
+);
+assert(
+  !vitestWorkspaceSuite.includes('pnpm test'),
+  'Vitest Workspace must not inherit unrelated root test-chain checks through pnpm test',
+);
+const planToInvokerCheckIndex = vitestWorkspaceSuite.indexOf('scripts/test-plan-to-invoker-skill.sh');
+const workspaceTestIndex = vitestWorkspaceSuite.indexOf('scripts/workspace-test.sh');
+assert(planToInvokerCheckIndex >= 0, 'Vitest Workspace must run the plan-to-invoker skill check');
+assert(workspaceTestIndex >= 0, 'Vitest Workspace must run workspace package tests');
+assert(
+  planToInvokerCheckIndex < workspaceTestIndex,
+  'Vitest Workspace must run the plan-to-invoker check before workspace package tests',
+);
+assert(
+  vitestWorkspaceSuite.includes('INVOKER_WORKSPACE_TEST_CONCURRENCY=1'),
+  'Vitest Workspace must run packages serially so local and CI probes use the same resource profile',
 );
 
 assert(jobs['required-fast-extra'], 'Missing required-fast-extra job');

--- a/scripts/test-suites/required/10-vitest-workspace.sh
+++ b/scripts/test-suites/required/10-vitest-workspace.sh
@@ -3,4 +3,6 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
-exec pnpm test
+bash scripts/test-plan-to-invoker-skill.sh
+export INVOKER_WORKSPACE_TEST_CONCURRENCY=1
+exec bash scripts/workspace-test.sh


### PR DESCRIPTION
## Summary

The `Vitest Workspace` CI job was named for one thing but did another. Its script ran `exec pnpm test`, which chains 17 unrelated scripts together.

That includes skill tests, PR-body checks, and slow daily-release/daily-e2e tests, plus three full package builds, on top of the actual vitest suite.

Every CI-repair attempt against this job ended up running the whole chain to verify a fix, taking hours instead of minutes.

This narrows the job to just the plan-to-invoker check and the real vitest run, and routes it onto `ubuntu-latest` instead of a self-hosted runner.

## Review Claim

Approve narrowing the `Vitest Workspace` CI job to only the checks its name promises, with a policy assertion so it can't silently regress back to the full chain.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The job still runs the plan-to-invoker check and the full vitest workspace suite; it only stops running the 15 other, unrelated scripts that `pnpm test` happened to chain in. `test-ci-workflow-merge-queue-policy.mjs` now asserts both checks are present, in order, and that `pnpm test` is not reintroduced.

## Slice Rationale

One cohesive fix to one CI job's scope, plus the regression test that proves it and prevents recurrence. No other job's configuration changes.

## Non-goals

Does not change what the plan-to-invoker check or the vitest suite themselves verify. Does not touch any other `required-fast` matrix entry.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [ ] `bash -n scripts/test-suites/required/10-vitest-workspace.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
