### PR TITLE
[E2E Proof Race Fixes](1) Fix loadPlan and expectWorkflowStatus timing races

### DIFF
--- a/packages/app/e2e/attach-workflow.spec.ts
+++ b/packages/app/e2e/attach-workflow.spec.ts
@@ -1,57 +1,26 @@
-import { test, expect, waitForStableUI, E2E_REPO_URL } from './fixtures/electron-app.js';
+import { test, expect, loadPlan, waitForStableUI, E2E_REPO_URL } from './fixtures/electron-app.js';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
-import { stringify as yamlStringify } from 'yaml';
-
-function yamlPlan(plan: Record<string, unknown>): string {
-  return yamlStringify(plan);
-}
 
 const OUT_DIR = path.resolve(__dirname, '..', 'e2e-scratch', 'attach-workflow');
 
 test('attach removes the Detached badge from a workflow node', async ({ page }) => {
   await fs.mkdir(OUT_DIR, { recursive: true });
 
-  const upstreamIdsBefore = await page.evaluate(async () => {
-    const workflows = await window.invoker.listWorkflows();
-    return workflows.map((w: { id: string }) => w.id);
-  });
-  await page.evaluate((p) => window.invoker.loadPlan(p), yamlPlan({
+  const upstreamId = await loadPlan(page, {
     name: 'e2e-attach-upstream',
     repoUrl: E2E_REPO_URL,
     onFinish: 'none',
     tasks: [{ id: 'up', description: 'upstream', command: 'echo up' }],
-  }));
-  const upstreamId: string = await page.waitForFunction(
-    (knownIds) => window.invoker.listWorkflows().then((workflows: { id: string }[]) => {
-      const created = workflows.find((w) => !knownIds.includes(w.id));
-      return created?.id ?? null;
-    }),
-    upstreamIdsBefore,
-    { timeout: 10000 },
-  ).then((handle) => handle.jsonValue());
-  expect(upstreamId).toBeTruthy();
-
-  const downstreamIdsBefore = await page.evaluate(async () => {
-    const workflows = await window.invoker.listWorkflows();
-    return workflows.map((w: { id: string }) => w.id);
   });
-  await page.evaluate((p) => window.invoker.loadPlan(p), yamlPlan({
+
+  const downstreamId = await loadPlan(page, {
     name: 'e2e-attach-downstream',
     repoUrl: E2E_REPO_URL,
     onFinish: 'none',
     externalDependencies: [{ workflowId: upstreamId, gatePolicy: 'completed' }],
     tasks: [{ id: 'down', description: 'downstream', command: 'echo down' }],
-  }));
-  const downstreamId: string = await page.waitForFunction(
-    (knownIds) => window.invoker.listWorkflows().then((workflows: { id: string }[]) => {
-      const created = workflows.find((w) => !knownIds.includes(w.id));
-      return created?.id ?? null;
-    }),
-    downstreamIdsBefore,
-    { timeout: 10000 },
-  ).then((handle) => handle.jsonValue());
-  expect(downstreamId).toBeTruthy();
+  });
 
   await page.getByTestId('sidebar-planning').click();
   await page.getByRole('button', { name: 'Refresh' }).click();

--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -361,18 +361,22 @@ export async function selectFirstWorkflow(page: Page): Promise<void> {
 }
 
 /** Load a plan into the running app via the IPC bridge and wait for its mini-DAG to render. */
-export async function loadPlan(page: Page, plan: { tasks: readonly { id: string }[] }): Promise<void> {
+export async function loadPlan(page: Page, plan: { tasks: readonly { id: string }[] }): Promise<string> {
   const planYaml = yamlStringify(plan);
   const beforeIds = await page.evaluate(async () => {
     const workflows = await window.invoker.listWorkflows();
     return workflows.map((workflow: { id: string }) => workflow.id);
   });
   await page.evaluate((p) => window.invoker.loadPlan(p), planYaml);
-  const workflowId = await page.evaluate(async (knownIds) => {
-    const workflows = await window.invoker.listWorkflows();
-    const created = workflows.find((workflow: { id: string }) => !knownIds.includes(workflow.id));
-    return created?.id ?? workflows[workflows.length - 1]?.id ?? null;
-  }, beforeIds);
+  let workflowId: string | undefined;
+  await expect.poll(async () => {
+    const workflows = await page.evaluate(() => window.invoker.listWorkflows());
+    workflowId = workflows.find((workflow: { id: string }) => !beforeIds.includes(workflow.id))?.id;
+    return workflowId;
+  }, { timeout: 10000 }).toBeTruthy();
+  if (!workflowId) {
+    throw new Error('Loaded plan did not create a workflow');
+  }
   await page.waitForFunction(
     (expectedTaskCount) => window.invoker.getTasks().then((result) => {
       const tasks = Array.isArray(result) ? result : result.tasks;
@@ -385,8 +389,9 @@ export async function loadPlan(page: Page, plan: { tasks: readonly { id: string 
   await page.getByTestId('sidebar-planning').click();
   await page.getByRole('heading', { name: 'Plan graph' }).waitFor({ state: 'visible', timeout: 10000 });
   await page.getByRole('button', { name: 'Refresh' }).click();
-  await selectWorkflowNode(page, workflowId ?? undefined);
+  await selectWorkflowNode(page, workflowId);
   await page.locator(`.react-flow__node[data-testid$="${plan.tasks[0].id}"]`).first().waitFor({ state: 'visible', timeout: 10000 });
+  return workflowId;
 }
 
 /** Open Plan graph so rail Refresh / DAG chrome exist (default surface is Planning home). */

--- a/packages/app/e2e/workflow-status-composition.spec.ts
+++ b/packages/app/e2e/workflow-status-composition.spec.ts
@@ -17,9 +17,17 @@ async function workflowSnapshot(page: import('@playwright/test').Page) {
   return workflows[0] as any;
 }
 
-async function expectWorkflowStatus(page: import('@playwright/test').Page, status: string) {
-  await expect.poll(async () => (await workflowSnapshot(page)).status).toBe(status);
-  return workflowSnapshot(page);
+async function expectWorkflowStatus(
+  page: import('@playwright/test').Page,
+  status: string,
+  hasExpectedRollup: (workflow: any) => boolean = () => true,
+) {
+  let workflow: any;
+  await expect.poll(async () => {
+    workflow = await workflowSnapshot(page);
+    return workflow.status === status && hasExpectedRollup(workflow);
+  }).toBe(true);
+  return workflow;
 }
 
 test.describe('Workflow status composition', () => {
@@ -71,7 +79,12 @@ test.describe('Workflow status composition', () => {
       { taskId: 'beta', changes: { status: 'failed', execution: { error: 'beta failed differently', exitCode: 22 } } },
       { taskId: mergeTask.id, changes: { status: 'failed', execution: { error: 'merge could not proceed', exitCode: 33 } } },
     ]);
-    workflow = await expectWorkflowStatus(page, 'failed');
+    const expectedFailureErrors = ['alpha exploded', 'beta failed differently', 'merge could not proceed'];
+    workflow = await expectWorkflowStatus(page, 'failed', (candidate) =>
+      expectedFailureErrors.every((error) =>
+        candidate.rollup.failedTasks.some((task: { error?: string }) => task.error === error),
+      ),
+    );
     expect(workflow.rollup.failedTasks).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ error: 'alpha exploded' }),
@@ -115,7 +128,9 @@ test.describe('Workflow status composition', () => {
     await injectTaskStates(page, [
       { taskId: 'alpha', changes: { status: 'stale' } },
     ]);
-    workflow = await expectWorkflowStatus(page, 'completed');
+    workflow = await expectWorkflowStatus(page, 'completed', (candidate) =>
+      candidate.rollup.countsByStatus.completed === 2 && candidate.rollup.countsByStatus.stale === 1,
+    );
     expect(workflow.rollup.countsByStatus.completed).toBe(2);
     expect(workflow.rollup.countsByStatus.stale).toBe(1);
   });


### PR DESCRIPTION
## Summary

Two Playwright e2e specs had timing races baked into their own helpers, not the app itself.

`loadPlan()` read the newly created workflow's ID immediately after the IPC call, before the app had necessarily registered it. It now polls until the ID actually appears.

`expectWorkflowStatus()` only waited for the top-level status string. It could resolve while the workflow's rollup counts were still catching up. It now accepts an optional predicate for the full expected state.

Neither assertion got weaker. Both now wait for the actual condition they claim to check.

## Review Claim

Approve fixing the two proof-level race conditions in `loadPlan` and `expectWorkflowStatus`, with no change to what either assertion verifies.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

No product code changes. Both fixes make an existing e2e helper wait for the condition it already claimed to assert, rather than reading a value one tick too early. `attach-workflow.spec.ts` is updated only to use `loadPlan`'s new return value instead of re-deriving the workflow ID itself.

## Slice Rationale

One cohesive fix: two helpers in the same e2e fixture file, both fixing the same class of premature-read race, plus the one caller each affects.

## Non-goals

Does not change any product behavior. Does not touch other e2e specs that call `window.invoker.loadPlan` directly (a different, unrelated function) rather than this fixture's `loadPlan` helper.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app exec playwright test e2e/attach-workflow.spec.ts e2e/workflow-status-composition.spec.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
