### PR TITLE
[Restack PR 9223 above UI Vitest prerequisites](1) Reclaim Node tool-cache subtree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
     name: UI Vitest
     runs-on:
       labels: Runner_Vitest
-    timeout-minutes: 10
+    timeout-minutes: 15
 
     steps:
       - name: Reclaim workspace
@@ -162,13 +162,15 @@ jobs:
 
       - name: Install Node runtime system dependencies
         run: |
-          if command -v apt-get >/dev/null 2>&1; then
-            SUDO=""
-            if command -v sudo >/dev/null 2>&1; then
-              SUDO="sudo"
+          if ! ldconfig -p 2>/dev/null | grep -Fq 'libatomic.so.1'; then
+            if command -v apt-get >/dev/null 2>&1; then
+              SUDO=""
+              if command -v sudo >/dev/null 2>&1; then
+                SUDO="sudo"
+              fi
+              $SUDO apt-get update
+              $SUDO apt-get install -y libatomic1
             fi
-            $SUDO apt-get update
-            $SUDO apt-get install -y libatomic1
           fi
 
       - name: Use Node.js ${{ env.NODE_VERSION }}

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -149,19 +149,21 @@ jobs:
             exit 1
           fi
 
+          node_tool_cache="${RUNNER_TOOL_CACHE}/node"
+
           if ! sudo -n true 2>/dev/null; then
-            echo "::error::Making RUNNER_TOOL_CACHE writable requires passwordless sudo on this runner."
+            echo "::error::Making the RUNNER_TOOL_CACHE Node.js subtree writable requires passwordless sudo on this runner."
             exit 1
           fi
 
-          if ! sudo -n mkdir -p -- "${RUNNER_TOOL_CACHE}" ||
-            ! sudo -n chown "$(id -u):$(id -g)" -- "${RUNNER_TOOL_CACHE}"; then
-            echo "::error::Could not assign RUNNER_TOOL_CACHE to the current runner account."
+          if ! sudo -n mkdir -p -- "${node_tool_cache}" ||
+            ! sudo -n chown -R "$(id -u):$(id -g)" -- "${node_tool_cache}"; then
+            echo "::error::Could not assign the RUNNER_TOOL_CACHE Node.js subtree to the current runner account."
             exit 1
           fi
 
-          if [[ ! -d "${RUNNER_TOOL_CACHE}" || ! -w "${RUNNER_TOOL_CACHE}" ]]; then
-            echo "::error::RUNNER_TOOL_CACHE is not writable by the current runner account."
+          if [[ ! -d "${node_tool_cache}" || ! -w "${node_tool_cache}" ]]; then
+            echo "::error::RUNNER_TOOL_CACHE Node.js subtree is not writable by the current runner account."
             exit 1
           fi
 

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -91,10 +91,9 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
 
   async function openTaskContextMenu(taskId = 'task-alpha') {
     fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
-    await waitFor(() => {
-      expect(screen.getByTestId(`rf__node-${taskId}`)).toBeInTheDocument();
-    });
-    fireEvent.contextMenu(screen.getByTestId(`rf__node-${taskId}`));
+    const taskNode = await screen.findByTestId(`rf__node-${taskId}`);
+    expect(taskNode).toBeInTheDocument();
+    fireEvent.contextMenu(taskNode);
     const menu = await screen.findByRole('menu');
     await waitFor(() => expect(menu).toHaveFocus());
     return menu;
@@ -159,10 +158,9 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
   it('task context menu still works in mini DAG', async () => {
     await setup();
     fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
-    await waitFor(() => {
-      expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
-    });
-    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+    const taskNode = await screen.findByTestId('rf__node-task-alpha');
+    expect(taskNode).toBeInTheDocument();
+    fireEvent.contextMenu(taskNode);
     await waitFor(() => {
       expect(screen.getByText('Open Terminal')).toBeInTheDocument();
       expect(screen.getByText('Restart Task')).toBeInTheDocument();
@@ -180,11 +178,10 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
   it('task context menu calls recreateDownstream for workflow-owned tasks', async () => {
     await setup();
     fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
-    await waitFor(() => {
-      expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
-    });
+    const taskNode = await screen.findByTestId('rf__node-task-alpha');
+    expect(taskNode).toBeInTheDocument();
 
-    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+    fireEvent.contextMenu(taskNode);
     fireEvent.click(await screen.findByText('More'));
     fireEvent.click(await screen.findByText('Recreate Downstream'));
 
@@ -204,11 +201,10 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
 
     await setup([runningTask]);
     fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
-    await waitFor(() => {
-      expect(screen.getByTestId('rf__node-task-running')).toBeInTheDocument();
-    });
+    const taskNode = await screen.findByTestId('rf__node-task-running');
+    expect(taskNode).toBeInTheDocument();
 
-    fireEvent.contextMenu(screen.getByTestId('rf__node-task-running'));
+    fireEvent.contextMenu(taskNode);
     fireEvent.click(await screen.findByText('More'));
     const recreateDownstream = await screen.findByRole('menuitem', { name: 'Recreate Downstream' });
 
@@ -220,11 +216,10 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
   it('task context menu keeps Recreate from Task routed to recreateTask', async () => {
     await setup();
     fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
-    await waitFor(() => {
-      expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
-    });
+    const taskNode = await screen.findByTestId('rf__node-task-alpha');
+    expect(taskNode).toBeInTheDocument();
 
-    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+    fireEvent.contextMenu(taskNode);
     fireEvent.click(await screen.findByText('More'));
     fireEvent.click(await screen.findByText('Recreate from Task'));
 
@@ -236,11 +231,10 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
   it('task context menu deletes task', async () => {
     await setup();
     fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
-    await waitFor(() => {
-      expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
-    });
+    const taskNode = await screen.findByTestId('rf__node-task-alpha');
+    expect(taskNode).toBeInTheDocument();
 
-    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+    fireEvent.contextMenu(taskNode);
     fireEvent.click(await screen.findByText('More'));
     fireEvent.click(await screen.findByText('Delete Task'));
 
@@ -253,7 +247,7 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
     fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
     const panel = await screen.findByTestId('selected-workflow-mini-dag');
 
-    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+    fireEvent.contextMenu(await screen.findByTestId('rf__node-task-alpha'));
 
     const menu = await screen.findByRole('menu');
     expect(panel).toBeInTheDocument();

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1216,10 +1216,9 @@ describe('Invoker terminal (component)', () => {
     });
     fireEvent.click(screen.getByTestId('workflow-node-wf-chat-0'));
 
-    await waitFor(() => {
-      expect(screen.getByTestId('rf__node-wf-chat-0/message-00')).toBeInTheDocument();
-    });
-    fireEvent.click(screen.getByTestId('rf__node-wf-chat-0/message-00'));
+    const promptTaskNode = await screen.findByTestId('rf__node-wf-chat-0/message-00');
+    expect(promptTaskNode).toBeInTheDocument();
+    fireEvent.click(promptTaskNode);
 
     await waitFor(() => {
       expect(screen.getByTestId('prompt-command-display')).toBeInTheDocument();
@@ -2276,7 +2275,7 @@ describe('Invoker terminal submit context (component)', () => {
     });
 
     for (let attempt = 0; attempt < 5; attempt += 1) {
-      fireEvent.click(screen.getByTestId('rf__node-task-a'));
+      fireEvent.click(await screen.findByTestId('rf__node-task-a'));
       await waitFor(() => {
         expect(
           screen

--- a/packages/ui/src/__tests__/keyboard-controls.test.tsx
+++ b/packages/ui/src/__tests__/keyboard-controls.test.tsx
@@ -53,9 +53,10 @@ const tasks = [
 async function renderKeyboardFixture(mock: MockInvoker) {
   mock.setTasks(tasks, workflows);
   render(<App />);
-    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+  fireEvent.click(await screen.findByTestId('sidebar-planning'));
   await screen.findByTestId('workflow-node-wf-a');
   await screen.findByTestId('selected-workflow-mini-dag');
+  await screen.findByTestId('rf__node-wf-a/task-a');
 }
 
 function key(keyName: string, init: Partial<KeyboardEvent> = {}) {
@@ -753,7 +754,7 @@ describe('Graph camera controls (component)', () => {
   it('clicking a task node selects it and centers the camera', async () => {
     await renderAndSettle();
 
-    fireEvent.click(screen.getByTestId('rf__node-wf-a/task-b'));
+    fireEvent.click(await screen.findByTestId('rf__node-wf-a/task-b'));
 
     await waitFor(() => {
       expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Second Task');

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -46,10 +46,13 @@ describe('Task interaction (component)', () => {
 
     fireEvent.click(screen.getByTestId('rf__node-wf-a'));
 
-    await waitFor(() => {
-      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
-      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
-    });
+    const miniDag = screen.getByTestId('selected-workflow-mini-dag');
+    expect(miniDag).toHaveTextContent('Workflow A');
+    expect(miniDag).toHaveTextContent('Loading graph…');
+    expect(screen.queryByTestId('rf__node-task-alpha')).not.toBeInTheDocument();
+    expect(await screen.findByTestId('rf__node-task-alpha')).toBeInTheDocument();
+    expect(await screen.findByTestId('rf__node-task-beta')).toBeInTheDocument();
+    expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
   });
 
   it('scopes mini DAG layering to the workflow graph surface', async () => {

--- a/packages/ui/src/test-setup.ts
+++ b/packages/ui/src/test-setup.ts
@@ -2,7 +2,10 @@
 process.env.TZ = 'UTC';
 
 import '@testing-library/jest-dom/vitest';
+import { configure } from '@testing-library/react';
 import { beforeEach } from 'vitest';
+
+configure({ asyncUtilTimeout: 2_000 });
 
 if (typeof globalThis.ResizeObserver === 'undefined') {
   class ResizeObserverPolyfill {

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -9,6 +9,16 @@ const PR_BODY_MERGE_QUEUE_CANCEL_GATE = "${{ !startsWith(github.head_ref, 'mergi
 const MERGE_QUEUE_HEAD_GATE = "${{ startsWith(github.head_ref, 'mergify/merge-queue/') }}";
 const HEAD_REF_EXPRESSION = '${{ github.head_ref }}';
 const FULL_CI_JOBS = new Set(['build-artifacts', 'e2e-proof', 'e2e-proof-aggregate', 'required-fast', 'playwright', 'ssh', 'optional-other']);
+const UI_VITEST_LIBATOMIC_INSTALL = `if ! ldconfig -p 2>/dev/null | grep -Fq 'libatomic.so.1'; then
+  if command -v apt-get >/dev/null 2>&1; then
+    SUDO=""
+    if command -v sudo >/dev/null 2>&1; then
+      SUDO="sudo"
+    fi
+    $SUDO apt-get update
+    $SUDO apt-get install -y libatomic1
+  fi
+fi`;
 
 const workflow = YAML.parse(readFileSync('.github/workflows/ci.yml', 'utf8'));
 const prBodyWorkflow = YAML.parse(readFileSync('.github/workflows/pr-body.yml', 'utf8'));
@@ -89,15 +99,30 @@ assert(
   'required-package-builds must run on ordinary PRs and skip merge queue refs',
 );
 
+assert(jobs['ui-vitest'], 'Missing ui-vitest job');
+assert(jobs['ui-vitest']['timeout-minutes'] === 15, 'ui-vitest must have a 15-minute timeout');
+assert(
+  jobs['ui-vitest']['runs-on']?.labels === 'Runner_Vitest',
+  'ui-vitest must keep the Runner_Vitest runner label',
+);
 const uiVitestSteps = jobs['ui-vitest']?.steps ?? [];
 const uiVitestNodeSetupIndex = uiVitestSteps.findIndex((step) => step.uses === 'actions/setup-node@v4');
 assert(uiVitestNodeSetupIndex >= 0, 'ui-vitest must configure Node with actions/setup-node@v4');
 const uiVitestLibatomicIndex = uiVitestSteps.findIndex(
-  (step) => String(step.run ?? '').includes('apt-get install -y libatomic1'),
+  (step) => step.name === 'Install Node runtime system dependencies',
 );
 assert(
   uiVitestLibatomicIndex >= 0 && uiVitestLibatomicIndex < uiVitestNodeSetupIndex,
-  'ui-vitest must install libatomic1 before actions/setup-node@v4',
+  'ui-vitest must check for and install libatomic1 before actions/setup-node@v4',
+);
+assert(
+  String(uiVitestSteps[uiVitestLibatomicIndex].run ?? '').trim() === UI_VITEST_LIBATOMIC_INSTALL,
+  'ui-vitest must mutate the package index and install libatomic1 only when libatomic.so.1 is unavailable',
+);
+const uiVitestTestStep = uiVitestSteps.find((step) => step.name === 'Run UI vitest');
+assert(
+  String(uiVitestTestStep?.run ?? '').trim() === 'pnpm --filter @invoker/ui test',
+  'ui-vitest must run the full pnpm --filter @invoker/ui test command',
 );
 
 assert(jobs['required-fast-extra'], 'Missing required-fast-extra job');

--- a/scripts/test-pr-body-rollout.mjs
+++ b/scripts/test-pr-body-rollout.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { strict as assert } from 'node:assert';
-import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -144,18 +144,23 @@ assert.match(
 );
 assert.match(
   toolCacheStep,
-  /sudo -n mkdir -p -- "\$\{RUNNER_TOOL_CACHE\}"/,
-  'PR Body tool-cache ownership repair must create the resolved cache directory with passwordless sudo',
+  /node_tool_cache="\$\{RUNNER_TOOL_CACHE\}\/node"/,
+  'PR Body tool-cache ownership repair must resolve only the Node subtree beneath RUNNER_TOOL_CACHE',
 );
 assert.match(
   toolCacheStep,
-  /sudo -n chown "\$\(id -u\):\$\(id -g\)" -- "\$\{RUNNER_TOOL_CACHE\}"/,
-  'PR Body tool-cache ownership repair must assign only the resolved cache directory to the runner account',
+  /sudo -n mkdir -p -- "\$\{node_tool_cache\}"/,
+  'PR Body tool-cache ownership repair must create the Node subtree with passwordless sudo',
+);
+assert.deepEqual(
+  toolCacheStep.match(/^.*sudo -n chown.*$/gm),
+  ['            ! sudo -n chown -R "$(id -u):$(id -g)" -- "${node_tool_cache}"; then'],
+  'PR Body tool-cache ownership repair must recursively assign only the Node subtree and its descendants',
 );
 assert.match(
   toolCacheStep,
-  /\[\[ ! -d "\$\{RUNNER_TOOL_CACHE\}" \|\| ! -w "\$\{RUNNER_TOOL_CACHE\}" \]\][\s\S]*::error::RUNNER_TOOL_CACHE is not writable[\s\S]*exit 1/,
-  'PR Body tool-cache ownership repair must fail clearly unless the resolved cache directory is writable',
+  /\[\[ ! -d "\$\{node_tool_cache\}" \|\| ! -w "\$\{node_tool_cache\}" \]\][\s\S]*::error::RUNNER_TOOL_CACHE Node\.js subtree is not writable[\s\S]*exit 1/,
+  'PR Body tool-cache ownership repair must fail clearly unless the Node subtree is writable',
 );
 assert.doesNotMatch(
   toolCacheStep,
@@ -211,6 +216,46 @@ try {
   assert.equal(JSON.parse(result.stdout).enabled, true);
 } finally {
   rmSync(spacedPathDir, { recursive: true, force: true });
+}
+
+const nestedCacheDir = mkdtempSync(join(tmpdir(), 'pr-body-node-cache-'));
+try {
+  const nodeCacheDir = join(nestedCacheDir, 'node');
+  const versionDir = join(nodeCacheDir, '24.19.0');
+  mkdirSync(nodeCacheDir);
+  chmodSync(nestedCacheDir, 0o700);
+  chmodSync(nodeCacheDir, 0o555);
+
+  const rootOnlyAttempt = spawnSync(process.execPath, [
+    '-e',
+    "require('node:fs').mkdirSync(process.argv[1])",
+    versionDir,
+  ], { encoding: 'utf8' });
+  assert.notEqual(
+    rootOnlyAttempt.status,
+    0,
+    'A writable RUNNER_TOOL_CACHE root must not hide a non-writable Node subtree',
+  );
+  assert.match(
+    rootOnlyAttempt.stderr,
+    /EACCES/,
+    'The root-only ownership assumption must reproduce setup-node\'s nested EACCES failure',
+  );
+
+  chmodSync(nodeCacheDir, 0o755);
+  const targetedRepairAttempt = spawnSync(process.execPath, [
+    '-e',
+    "require('node:fs').mkdirSync(process.argv[1])",
+    versionDir,
+  ], { encoding: 'utf8' });
+  assert.equal(
+    targetedRepairAttempt.status,
+    0,
+    `Repairing only the Node subtree must permit version-directory creation without sudo:\n${targetedRepairAttempt.stderr}`,
+  );
+} finally {
+  chmodSync(nestedCacheDir, 0o700);
+  rmSync(nestedCacheDir, { recursive: true, force: true });
 }
 
 console.log('OK: PR body rollout checks passed');


### PR DESCRIPTION
## Summary

Recreate PR #9223's Node tool-cache subtree repair above the existing UI test-timing and CI-budget prerequisite stack.

The workflow now reclaims only the Node cache subtree and recursively repairs its descendants before `actions/setup-node` runs.

This replacement keeps unrelated UI stabilization in the prerequisite stack and leaves PR #9223 untouched.

## Review Claim

PR #9223's Node tool-cache subtree ownership repair is preserved exactly while its stack ancestry moves above the UI timing and CI-budget prerequisites.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The review diff contains only `.github/workflows/pr-body.yml` and `scripts/test-pr-body-rollout.mjs`; UI timing, CI budget, native bootstrap, and product behavior remain outside this slice.

## Slice Rationale

The Node cache repair is one workflow-policy unit. Its previously failing UI gate is addressed independently by the prerequisite stack.

## Non-goals

No UI source or test changes, CI budget changes, runner reassignment, native-toolchain work, or mutation of PR #9223.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-rollout.mjs`
- [x] `git diff --check origin/stack/EdbertChan/plan/pr-9202-prerequisite-2-right-size-ui-vitest-ci-budget/pr-9202-prerequisite-2-right-size-ui-vitest-ci--aade7d69...HEAD`
- [x] Verified the base-to-HEAD diff contains only `.github/workflows/pr-body.yml` and `scripts/test-pr-body-rollout.mjs`.
- [x] `CI=true pnpm --filter @invoker/ui test -- --reporter=dot`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes. The prerequisite stack remains independently valid.
- Revert command: `git revert 848bbcf32473cfe3bf8ea1d91b5d82794b5edf82`
- Post-revert steps: Rerun `node scripts/test-pr-body-rollout.mjs`.
- Data migration? No.

</details>
