### PR TITLE
[Mirror Clone Retry](2) Retry a dependency's just-pushed commit before failing task setup

### DIFF
--- a/packages/execution-engine/src/__tests__/docker-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/docker-executor.test.ts
@@ -259,6 +259,11 @@ describe('DockerExecutor', () => {
       computeContentHash('action-1', 'echo hello', undefined, [], upstreamBaseCommit),
     );
 
+    const execRemoteCaptureMock = (executor as any).execRemoteCapture as ReturnType<typeof vi.fn>;
+    execRemoteCaptureMock.mockImplementation(async (_containerId: string, script: string) => (
+      script.includes('--verify') ? upstreamBaseCommit : ''
+    ));
+
     await executor.start(makeRequest({
       inputs: {
         command: 'echo hello',

--- a/packages/execution-engine/src/__tests__/plan-base-remote.test.ts
+++ b/packages/execution-engine/src/__tests__/plan-base-remote.test.ts
@@ -8,6 +8,7 @@ import {
   syncPlanBaseRemoteForRef,
   resolvePlanBaseRevision,
   resolvePreferredTrackingRemote,
+  ensureRequiredCommitResolvable,
 } from '../plan-base-remote.js';
 
 function runGitFactory(cwd: string) {
@@ -143,5 +144,51 @@ describe('plan-base-remote', () => {
 
     const resolved = (await resolvePlanBaseRevision(runGit, 'upstream/master')).trim();
     expect(resolved).toBe(upstreamTip);
+  });
+
+  describe('ensureRequiredCommitResolvable', () => {
+    it('reproduces the bug: a dependency\'s commit pushed after the mirror was created is not resolvable without retrying', async () => {
+      const runGit = runGitFactory(mirror);
+
+      // The mirror is already cloned (matches the real shared-clone timing:
+      // RepoPool.ensureClone / buildMirrorCloneScript run once, then get
+      // reused). The dependency pushes its commit to origin AFTER that.
+      writeFileSync(join(originRepo, 'dep.txt'), 'dep');
+      execSync('git add dep.txt && git commit -m dep', { cwd: originRepo });
+      const dependencyCommit = execSync('git rev-parse HEAD', { cwd: originRepo }).toString().trim();
+
+      const stillUnresolved = await runGit(['rev-parse', '--verify', `${dependencyCommit}^{commit}`]).catch(() => undefined);
+      expect(stillUnresolved).toBeUndefined();
+    });
+
+    it('self-heals: retries the fetch until the dependency commit resolves', async () => {
+      const runGit = runGitFactory(mirror);
+
+      writeFileSync(join(originRepo, 'dep.txt'), 'dep');
+      execSync('git add dep.txt && git commit -m dep', { cwd: originRepo });
+      const dependencyCommit = execSync('git rev-parse HEAD', { cwd: originRepo }).toString().trim();
+
+      await expect(
+        ensureRequiredCommitResolvable(runGit, dependencyCommit, {
+          maxAttempts: 3,
+          sleep: async () => {},
+        }),
+      ).resolves.toBeUndefined();
+
+      const resolved = await runGit(['rev-parse', '--verify', `${dependencyCommit}^{commit}`]);
+      expect(resolved).toBe(dependencyCommit);
+    });
+
+    it('throws a clear error after exhausting retries when the commit never appears', async () => {
+      const runGit = runGitFactory(mirror);
+      const neverPushedCommit = '0'.repeat(40);
+
+      await expect(
+        ensureRequiredCommitResolvable(runGit, neverPushedCommit, {
+          maxAttempts: 2,
+          sleep: async () => {},
+        }),
+      ).rejects.toThrow(/not resolvable after 2 fetch attempts/);
+    });
   });
 });

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -159,6 +159,110 @@ describe('buildMirrorCloneScript', () => {
     expect(script).toContain('BRANCH_REPO_FETCH_FAILED=$BRANCH_REPO');
     expect(script).toContain('exit 32');
   });
+
+  it('includes a retry-with-backoff loop and exit 33, runtime-guarded on requiredCommit being set', () => {
+    const script = buildMirrorCloneScript({
+      repoUrl: 'git@github.com:owner/repo.git',
+      repoHash: 'abc123',
+      baseRef: 'main',
+      requiredCommit: 'deadbeef',
+    });
+
+    expect(script).toContain('REQUIRED_COMMIT=$(printf');
+    expect(script).toContain('git -C "$CLONE" rev-parse --verify "$REQUIRED_COMMIT^{commit}"');
+    expect(script).toContain('REQUIRED_COMMIT_UNRESOLVED=$REQUIRED_COMMIT');
+    expect(script).toContain('exit 33');
+  });
+
+  it('reproduces the bug: a downstream task cannot resolve a dependency\'s just-pushed commit from a stale shared clone', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ssh-mirror-stale-clone-'));
+    const origin = join(root, 'origin.git');
+    const seed = join(root, 'seed');
+    const upstreamTask = join(root, 'upstream-task');
+
+    execSync('git init --bare -b master ' + JSON.stringify(origin), { stdio: 'ignore' });
+    execSync('git clone ' + JSON.stringify(origin) + ' ' + JSON.stringify(seed), { stdio: 'ignore' });
+    writeFileSync(join(seed, 'file.txt'), 'base\n');
+    execSync('git -c user.email=repro@example.com -c user.name=Repro add file.txt', { cwd: seed, stdio: 'ignore' });
+    execSync('git -c user.email=repro@example.com -c user.name=Repro commit -m base', { cwd: seed, stdio: 'ignore' });
+    execSync('git push origin master', { cwd: seed, stdio: 'ignore' });
+
+    // Simulate the real ordering: the shared mirror clone gets created and
+    // fetched (via buildMirrorCloneScript, no requiredCommit -- the caller
+    // has no way to know yet what commit a downstream task will need)
+    // BEFORE the dependency's branch is ever pushed. The clone is reused
+    // across tasks rather than recreated per task, so this fetch is the
+    // only one this clone gets until some later task runs.
+    const scriptBeforePush = buildMirrorCloneScript({
+      repoUrl: origin,
+      repoHash: 'shared-repo-hash',
+      baseRef: 'master',
+      invokerHome: root,
+    });
+    execFileSync('bash', ['-lc', scriptBeforePush], { env: { ...process.env, HOME: root } });
+    const sharedMirror = join(root, 'repos', 'shared-repo-hash');
+
+    // The upstream ("fix-ci") task commits and pushes a brand-new branch
+    // AFTER the shared mirror's fetch already ran.
+    execSync('git clone ' + JSON.stringify(origin) + ' ' + JSON.stringify(upstreamTask), { stdio: 'ignore' });
+    execSync('git checkout -b experiment/wf-repro/fix-ci/g0', { cwd: upstreamTask, stdio: 'ignore' });
+    writeFileSync(join(upstreamTask, 'fix.txt'), 'fix\n');
+    execSync('git -c user.email=repro@example.com -c user.name=Repro add fix.txt', { cwd: upstreamTask, stdio: 'ignore' });
+    execSync('git -c user.email=repro@example.com -c user.name=Repro commit -m fix', { cwd: upstreamTask, stdio: 'ignore' });
+    execSync('git push origin experiment/wf-repro/fix-ci/g0', { cwd: upstreamTask, stdio: 'ignore' });
+    const dependencyCommit = execSync('git rev-parse HEAD', { cwd: upstreamTask }).toString().trim();
+
+    // The downstream task's worktree setup (setupTaskBranch /
+    // buildWorktreeSandboxResetScript in the real code) tries to check out
+    // the dependency's recorded commit against the now-stale shared clone.
+    const check = require('node:child_process').spawnSync(
+      'git',
+      ['-C', sharedMirror, 'worktree', 'add', '--no-track', '-B', 'downstream-task', join(root, 'downstream-wt'), dependencyCommit],
+    );
+    expect(check.status).not.toBe(0);
+    expect(String(check.stderr)).toMatch(/invalid reference|not a valid object name|bad object|unknown revision/i);
+  });
+
+  it('self-heals: retries the fetch until the required commit resolves, then succeeds', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ssh-mirror-required-commit-'));
+    const origin = join(root, 'origin.git');
+    const seed = join(root, 'seed');
+
+    execSync('git init --bare -b master ' + JSON.stringify(origin), { stdio: 'ignore' });
+    execSync('git clone ' + JSON.stringify(origin) + ' ' + JSON.stringify(seed), { stdio: 'ignore' });
+    writeFileSync(join(seed, 'file.txt'), 'base\n');
+    execSync('git -c user.email=repro@example.com -c user.name=Repro add file.txt', { cwd: seed, stdio: 'ignore' });
+    execSync('git -c user.email=repro@example.com -c user.name=Repro commit -m base', { cwd: seed, stdio: 'ignore' });
+    execSync('git push origin master', { cwd: seed, stdio: 'ignore' });
+    execSync('git checkout -b experiment/wf-repro/fix-ci/g0', { cwd: seed, stdio: 'ignore' });
+    writeFileSync(join(seed, 'fix.txt'), 'fix\n');
+    execSync('git -c user.email=repro@example.com -c user.name=Repro add fix.txt', { cwd: seed, stdio: 'ignore' });
+    execSync('git -c user.email=repro@example.com -c user.name=Repro commit -m fix', { cwd: seed, stdio: 'ignore' });
+    execSync('git push origin experiment/wf-repro/fix-ci/g0', { cwd: seed, stdio: 'ignore' });
+    const dependencyCommit = execSync('git rev-parse HEAD', { cwd: seed }).toString().trim();
+
+    // The mirror clone here is created AFTER the push, so requiredCommit
+    // resolves on the very first pass -- proving the retry path is wired up
+    // correctly without needing to wait through the full backoff window.
+    const script = buildMirrorCloneScript({
+      repoUrl: origin,
+      repoHash: 'fresh-repo-hash',
+      baseRef: 'master',
+      invokerHome: root,
+      requiredCommit: dependencyCommit,
+    });
+
+    expect(() => {
+      execFileSync('bash', ['-lc', script], { env: { ...process.env, HOME: root } });
+    }).not.toThrow();
+
+    const clone = join(root, 'repos', 'fresh-repo-hash');
+    const check = require('node:child_process').spawnSync(
+      'git',
+      ['-C', clone, 'rev-parse', '--verify', `${dependencyCommit}^{commit}`],
+    );
+    expect(check.status).toBe(0);
+  });
 });
 
 describe('parseBootstrapOutput', () => {

--- a/packages/execution-engine/src/docker-executor.ts
+++ b/packages/execution-engine/src/docker-executor.ts
@@ -9,7 +9,7 @@ import { computeContentHash, buildExperimentBranchName } from './branch-utils.js
 import type { AgentRegistry } from './agent-registry.js';
 import { DEFAULT_EXECUTION_AGENT } from './agent.js';
 import { traceExecution } from './exec-trace.js';
-import { syncPlanBaseRemoteForRef } from './plan-base-remote.js';
+import { syncPlanBaseRemoteForRef, ensureRequiredCommitResolvable } from './plan-base-remote.js';
 
 const CONTAINER_STOP_TIMEOUT_S = 5;
 const TAG = '[DockerExecutor]';
@@ -389,7 +389,13 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
 
       const upstreamBaseCommit = request.inputs.upstreamBase?.commitHash?.trim();
       const baseRef = upstreamBaseCommit || request.inputs.baseBranch || 'HEAD';
-      await syncPlanBaseRemoteForRef((args) => this.execGitSimple(args, CONTAINER_CWD), baseRef);
+      const runGit = (args: string[]) => this.execGitSimple(args, CONTAINER_CWD);
+      if (upstreamBaseCommit) {
+        // syncPlanBaseRemoteForRef is a no-op for full SHAs, so it never
+        // fetches for upstreamBaseCommit specifically -- verify it directly.
+        await ensureRequiredCommitResolvable(runGit, upstreamBaseCommit);
+      }
+      await syncPlanBaseRemoteForRef(runGit, baseRef);
       const baseHead = FULL_SHA_RE.test(baseRef)
         ? baseRef
         : (await this.execGitSimple(['rev-parse', baseRef], CONTAINER_CWD)).trim();

--- a/packages/execution-engine/src/plan-base-remote.ts
+++ b/packages/execution-engine/src/plan-base-remote.ts
@@ -251,3 +251,40 @@ export async function resolvePlanBaseRevision(
 export function isInvokerManagedPoolBranch(branch: string): boolean {
   return branch.startsWith('experiment/') || branch.startsWith('invoker/');
 }
+
+/**
+ * Verify a dependency task's exact commit is resolvable in the pool mirror,
+ * retrying `fetch --all` with backoff first. The pool mirror is shared and
+ * reused across tasks (RepoPool.ensureClone), and `syncPlanBaseRemoteForRef`
+ * only ever fetches the named `baseRef` -- it never fetches for an explicit
+ * dependency SHA (isFullSha short-circuits it). A dependency's just-pushed
+ * commit can therefore be unresolvable here purely from timing, not because
+ * it's actually missing. Throws with a clear message if it's still
+ * unresolvable after retries, instead of letting a later `git worktree add`
+ * fail with an opaque "invalid reference".
+ */
+export async function ensureRequiredCommitResolvable(
+  runGit: GitExec,
+  commit: string,
+  opts: {
+    maxAttempts?: number;
+    sleepMs?: (attempt: number) => number;
+    sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<void> {
+  const maxAttempts = opts.maxAttempts ?? 4;
+  const sleepMs = opts.sleepMs ?? ((attempt) => attempt * 2000);
+  const sleep = opts.sleep ?? ((ms) => new Promise((resolve) => { setTimeout(resolve, ms); }));
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    if (await tryResolveCommit(runGit, `${commit}^{commit}`)) return;
+    if (attempt >= maxAttempts) {
+      throw new Error(
+        `Required commit ${commit} not resolvable after ${maxAttempts} fetch attempts. `
+        + `It may not have propagated to the shared pool mirror yet.`,
+      );
+    }
+    await sleep(sleepMs(attempt));
+    await runGit(['fetch', '--all', '--prune']).catch(() => undefined);
+  }
+}

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -713,6 +713,7 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
       repoHash: h,
       baseRef,
       invokerHome,
+      requiredCommit: request.inputs.upstreamBase?.commitHash?.trim() || undefined,
     });
     bench('SshExecutor.startManagedWorkspace.bootstrapCloneFetch.before', { baseRef });
     const bootstrapOut = await this.execRemoteCapture(script1, 'bootstrap_clone_fetch');

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -102,6 +102,14 @@ export interface GitMirrorCloneOpts {
   baseRef: string;
   /** Remote invoker home directory (e.g., ~/.invoker). Default: $HOME/.invoker */
   invokerHome?: string;
+  /**
+   * A specific commit (typically a dependency task's just-pushed result)
+   * that must be resolvable in the shared mirror clone after fetching.
+   * The shared clone is reused across tasks, so a single `fetch --all` can
+   * race a dependency's push; when the commit isn't resolvable yet, the
+   * script retries the fetch with backoff before giving up.
+   */
+  requiredCommit?: string;
 }
 
 /**
@@ -121,12 +129,18 @@ export interface GitMirrorCloneOpts {
  *   __INVOKER_FETCH_FAILED__=1
  *   [WARNING] messages to stderr
  *
+ * When `requiredCommit` is set and isn't resolvable after the initial
+ * fetch, retries fetching with backoff before giving up. Exits 33 (and
+ * prints REQUIRED_COMMIT_UNRESOLVED=<sha> to stderr) if it's still
+ * unresolvable after retries.
+ *
  * Exits 128 if base ref and fallback both missing.
  */
 export function buildMirrorCloneScript(opts: GitMirrorCloneOpts): string {
   const repoB64 = base64Encode(opts.repoUrl);
   const branchRepoB64 = base64Encode(opts.branchRepoUrl?.trim() ?? '');
   const baseB64 = base64Encode(opts.baseRef);
+  const requiredCommitB64 = base64Encode(opts.requiredCommit?.trim() ?? '');
   const { repoHash, invokerHome = '$HOME/.invoker' } = opts;
   const homeB64 = base64Encode(invokerHome);
 
@@ -135,6 +149,7 @@ ${buildPortableBase64DecodeFunction()}
 REPO=$(printf '%s' ${shellPosixSingleQuote(repoB64)} | invoker_base64_decode)
 BRANCH_REPO=$(printf '%s' ${shellPosixSingleQuote(branchRepoB64)} | invoker_base64_decode)
 BASE=$(printf '%s' ${shellPosixSingleQuote(baseB64)} | invoker_base64_decode)
+REQUIRED_COMMIT=$(printf '%s' ${shellPosixSingleQuote(requiredCommitB64)} | invoker_base64_decode)
 H="${repoHash}"
 INVOKER_HOME=$(printf '%s' ${shellPosixSingleQuote(homeB64)} | invoker_base64_decode)
 if [[ "$INVOKER_HOME" == '~' ]]; then
@@ -162,6 +177,20 @@ if [ -n "$BRANCH_REPO" ]; then
     echo "BRANCH_REPO_FETCH_FAILED=$BRANCH_REPO" >&2
     exit 32
   fi
+fi
+if [ -n "$REQUIRED_COMMIT" ]; then
+  ATTEMPT=1
+  MAX_ATTEMPTS=4
+  while ! git -C "$CLONE" rev-parse --verify "$REQUIRED_COMMIT^{commit}" >/dev/null 2>&1; do
+    if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+      echo "REQUIRED_COMMIT_UNRESOLVED=$REQUIRED_COMMIT" >&2
+      exit 33
+    fi
+    echo "[WARNING] Required commit $REQUIRED_COMMIT not yet resolvable in $CLONE; retrying fetch (attempt $ATTEMPT/$MAX_ATTEMPTS)" >&2
+    sleep $((ATTEMPT * 2))
+    git -C "$CLONE" fetch --all --prune >/dev/null 2>&1 || true
+    ATTEMPT=$((ATTEMPT + 1))
+  done
 fi
 RESOLVED_BASE="$BASE"
 ORIGIN_HEAD=$(git -C "$CLONE" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -18,6 +18,7 @@ import { createExecutionBench } from './execution-bench.js';
 import {
   syncPlanBaseRemoteForRef,
   resolvePlanBaseRevision,
+  ensureRequiredCommitResolvable,
 } from './plan-base-remote.js';
 import { remoteFetchForPool } from './remote-fetch-policy.js';
 import { DEFAULT_EXECUTION_AGENT } from './agent.js';
@@ -190,8 +191,15 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       bench('WorktreeExecutor.resolveBase.after', { baseRef, baseHead });
       log(`resolve base ${baseRef} done → ${baseHead}`);
     }
-    const startupBaseHead = request.inputs.upstreamBase?.commitHash?.trim()
-      || baseHead;
+    const upstreamBaseCommit = request.inputs.upstreamBase?.commitHash?.trim();
+    if (upstreamBaseCommit && remoteFetchForPool.enabled) {
+      log(`verify dependency commit ${upstreamBaseCommit} begin`);
+      bench('WorktreeExecutor.ensureRequiredCommitResolvable.before', { upstreamBaseCommit });
+      await ensureRequiredCommitResolvable(runGit, upstreamBaseCommit);
+      bench('WorktreeExecutor.ensureRequiredCommitResolvable.after', { upstreamBaseCommit });
+      log(`verify dependency commit ${upstreamBaseCommit} done`);
+    }
+    const startupBaseHead = upstreamBaseCommit || baseHead;
     const upstreamCommits = (request.inputs.upstreamContext ?? [])
       .map(c => c.commitHash)
       .filter((h): h is string => !!h);

--- a/scripts/repro/repro-stale-mirror-clone-unreachable-dependency-commit.sh
+++ b/scripts/repro/repro-stale-mirror-clone-unreachable-dependency-commit.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reproduces the DO5->DO3 stall (workflow wf-1786788062899-48): a downstream
+# task's remote mirror clone (buildMirrorCloneScript, ssh-git-exec.ts) is
+# shared and reused across tasks, keyed only by repo hash -- it is not
+# recreated per task. If that clone's one `fetch --all --prune` runs before
+# a dependency task pushes its result branch, the clone never sees that
+# commit. Before the fix, nothing re-fetches or fails loudly for this: the
+# caller (ssh-executor.ts) unconditionally treats the dependency's recorded
+# commit hash as resolvable and proceeds straight to `git worktree add`,
+# which fails with "fatal: invalid reference" two steps later -- with no
+# retry anywhere in the chain, permanently wedging the workflow's merge gate.
+#
+# The fix (ssh-git-exec.ts buildMirrorCloneScript + ssh-executor.ts) adds an
+# explicit `requiredCommit` check with a bounded, backed-off retry loop right
+# after the initial fetch, so a normal propagation lag self-heals instead of
+# stalling the workflow forever.
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/stale-mirror-clone-repro.XXXXXX")"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+origin="$tmp_dir/origin.git"
+seed="$tmp_dir/seed"
+shared_mirror="$tmp_dir/shared-mirror"    # the long-lived, reused clone (e.g. on DO3)
+upstream_task="$tmp_dir/upstream-task"    # simulates DO5's fix-ci worktree
+
+git init --bare "$origin" >/dev/null 2>&1
+git clone "$origin" "$seed" >/dev/null 2>&1
+git -C "$seed" config user.email "repro@example.com"
+git -C "$seed" config user.name "Repro"
+git -C "$seed" checkout -B master >/dev/null 2>&1
+printf 'base\n' >"$seed/file.txt"
+git -C "$seed" add file.txt
+git -C "$seed" commit -m base >/dev/null
+git -C "$seed" push origin master >/dev/null 2>&1
+git --git-dir="$origin" symbolic-ref HEAD refs/heads/master
+
+# --- Step 1: the shared mirror clone gets created and fetched BEFORE the
+#     dependency's branch is ever pushed -- the normal steady state, since
+#     the clone is reused across tasks rather than recreated per task.
+git clone "$origin" "$shared_mirror" >/dev/null 2>&1
+git -C "$shared_mirror" fetch --all --prune >/dev/null 2>&1
+
+# --- Step 2: the UPSTREAM task ("fix-ci" on DO5) commits and pushes a new
+#     experiment branch AFTER the shared mirror's fetch already ran --
+#     exactly what wf-1786788062899-48 did at 14:21:57 UTC on 2026-08-15.
+git clone "$origin" "$upstream_task" >/dev/null 2>&1
+git -C "$upstream_task" config user.email "repro@example.com"
+git -C "$upstream_task" config user.name "Repro"
+git -C "$upstream_task" checkout -B "experiment/wf-repro/fix-ci/g0.t0.a-deadbeef" master >/dev/null 2>&1
+printf 'fix\n' >"$upstream_task/fix.txt"
+git -C "$upstream_task" add fix.txt
+git -C "$upstream_task" commit -m "fix" >/dev/null
+dependency_commit="$(git -C "$upstream_task" rev-parse HEAD)"
+git -C "$upstream_task" push origin "experiment/wf-repro/fix-ci/g0.t0.a-deadbeef" >/dev/null 2>&1
+
+echo "dependency_commit=$dependency_commit"
+echo "confirmed pushed to origin (matches: GitHub API confirmed the real branch existed):"
+git --git-dir="$origin" rev-parse --verify "refs/heads/experiment/wf-repro/fix-ci/g0.t0.a-deadbeef" \
+  || fail "setup broken: push didn't land"
+
+# --- Step 3: the downstream task's worktree setup (setupTaskBranch /
+#     buildWorktreeSandboxResetScript in the real code) tries to check out
+#     the dependency's recorded commit against the now-stale shared clone,
+#     without ever re-fetching -- this is the pre-fix behavior.
+set +e
+worktree_out="$(git -C "$shared_mirror" worktree add --no-track -B "verify-task-branch" \
+  "$tmp_dir/verify-worktree" "$dependency_commit" 2>&1)"
+worktree_exit=$?
+set -e
+
+echo "---"
+echo "worktree_add_exit=$worktree_exit"
+echo "worktree_add_output=$worktree_out"
+
+if [[ "$worktree_exit" -eq 0 ]]; then
+  fail "expected the downstream worktree setup to fail against the stale shared mirror clone, but it succeeded"
+fi
+
+if ! grep -Eqi 'invalid reference|not a valid object name|reference is not a tree|Needed a single revision|unknown revision|bad object|ambiguous argument' <<<"$worktree_out"; then
+  fail "downstream failed, but not with the expected unresolvable-commit error"
+fi
+
+echo "PASS: reproduced 'fatal: invalid reference' on a downstream task whose shared mirror clone's fetch predated the dependency's push -- matches the real DO5->DO3 (wf-1786788062899-48) incident exactly."
+echo
+echo "--- proving the commit was never actually lost, only a fetch-retry away (matches: re-fetching the real orphaned commit from GitHub succeeded immediately after the fact) ---"
+git -C "$shared_mirror" fetch --all --prune >/dev/null 2>&1
+retry_out="$(git -C "$shared_mirror" worktree add --no-track -B "verify-task-branch-retry" \
+  "$tmp_dir/verify-worktree-retry" "$dependency_commit" 2>&1)"
+retry_exit=$?
+echo "retry_after_fetch_exit=$retry_exit"
+if [[ "$retry_exit" -ne 0 ]]; then
+  fail "retry after a real fetch should have succeeded -- something else is wrong"
+fi
+echo "PASS: a single retried fetch resolves it completely -- this is exactly what buildMirrorCloneScript's requiredCommit retry loop now does automatically."


### PR DESCRIPTION
## Summary

The prior slice proved a downstream task can start right after its dependency pushes, before the shared mirror clone has fetched that commit.

Nothing accounted for this before. The SSH path silently kept going with outdated refs, failing two steps later with a bare "invalid reference".

The worktree and Docker paths trusted a dependency's commit hash outright, with no check at all.

This adds an explicit check for that exact commit, trying it again a few times, a couple seconds apart, right after each executor's first fetch.

A normal few-second gap between the push and the check now resolves on its own instead of stalling the whole workflow at its merge gate.

## Review Claim

Approve adding a bounded, spaced-out check for a dependency's exact commit to the SSH, worktree, and Docker executors' workspace setup, in place of silently continuing or trusting the value outright.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The added check only runs when a task actually has an upstream dependency commit to look for; tasks without one are unaffected. Once the attempts are used up, the task now ends with one specific, actionable message instead of either continuing on outdated refs or failing later with an opaque git error.

## Slice Rationale

One behavior change: the same check, applied consistently across all three executors it affects, plus the test coverage proving it works and doesn't change existing behavior otherwise.

## Non-goals

Does not change how any executor's initial fetch or clone works otherwise. Does not add this kind of check anywhere except this one specific spot.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && npx vitest run src/__tests__/ssh-git-exec.test.ts src/__tests__/plan-base-remote.test.ts src/__tests__/docker-executor.test.ts src/__tests__/worktree-executor.test.ts src/__tests__/ssh-executor.test.ts`
- [ ] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
