### PR TITLE
[Mirror Clone Retry](3) Document the shared clone's recurring unreachable-commit history

### DIFF
--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -135,6 +135,18 @@ export interface GitMirrorCloneOpts {
  * unresolvable after retries.
  *
  * Exits 128 if base ref and fallback both missing.
+ *
+ * This shared/reused clone (one per repo hash, fetched once at task start,
+ * never recreated) has repeatedly produced "downstream task can't resolve
+ * a commit" incidents since the design was introduced: 2026-04-07
+ * (4df97a3d0c, fetch failures silently swallowed from day one), 2026-04-08
+ * (ed5f9d0552, made visible via warnings but kept non-blocking), 2026-04-17
+ * (56eb3e872c, a different symptom of the same drifted mirror), 2026-07-30
+ * (#6836, a wrong-ref-selected-for-push variant), 2026-08-15 (this
+ * `requiredCommit` retry, the first fix that actually verifies and retries
+ * instead of trusting or warning). If a new instance of this symptom shows
+ * up, it is very likely the same architectural hazard again -- check here
+ * first before re-deriving the history from `git log`.
  */
 export function buildMirrorCloneScript(opts: GitMirrorCloneOpts): string {
   const repoB64 = base64Encode(opts.repoUrl);


### PR DESCRIPTION
## Summary

The shared mirror clone this function builds has caused the same shape of incident four times since it was introduced in April.

Each earlier fix addressed one specific cause, not the pattern itself, so the next person who hit it had to re-derive the whole history from scratch.

This adds that history directly to the function's own doc comment, with dates and commit SHAs, so the lineage is visible right where the code lives.

## Review Claim

Approve adding a doc-comment paragraph recording four prior incidents tied to this shared clone's design, with no code change.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

Comment-only addition. No behavior change.

## Slice Rationale

Small, standalone documentation addition, separate from the behavior fix it follows up on.

## Non-goals

Does not touch any executable code. Behavior unchanged.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `git diff --stat` shows only a doc-comment addition

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
