### PR TITLE
Fix check-pr-body-keywords.mjs to scan only the sections the real validator scans

### DIFF
--- a/scripts/check-pr-body-keywords.mjs
+++ b/scripts/check-pr-body-keywords.mjs
@@ -3,14 +3,19 @@
 // scan, run BEFORE drafting is considered done, not discovered by trial and
 // error against the full validator. Calls the same exported validators the
 // real check uses (validateSingleReviewUnitFocus, validateReviewUnitFocus)
-// instead of re-deriving the product-vs-non-product unit distinction, so
-// this can never drift out of sync with what CI actually enforces.
+// against the same three sections the real validator scans (Summary, Review
+// Claim, Slice Rationale), via getMarkdownSection/getReviewMetadata, instead
+// of the whole body — scanning the whole body flags Test Plan/Safety
+// Invariant/Non-goals prose the real check never looks at, producing false
+// failures that don't reproduce against CI.
 import { readFileSync } from 'node:fs';
 import {
   validateSingleReviewUnitFocus,
   validateReviewUnitFocus,
+  getMarkdownSection,
   VALID_REVIEW_UNITS,
 } from './review-unit-rules.mjs';
+import { getReviewMetadata } from './validate-pr-body.mjs';
 
 function parseArgs(argv) {
   const args = { bodyFile: null, declaredUnit: null };
@@ -33,10 +38,12 @@ function main() {
     process.exit(2);
   }
 
-  const text = readFileSync(bodyFile, 'utf8');
+  const text = readFileSync(bodyFile, 'utf8').trim();
+  const { reviewClaim, sliceRationale } = getReviewMetadata(text);
+  const texts = [getMarkdownSection(text, '## Summary'), reviewClaim, sliceRationale];
   const errors = [...new Set([
-    ...validateSingleReviewUnitFocus({ texts: [text], context: 'PR body' }),
-    ...validateReviewUnitFocus({ declaredReviewUnit: declaredUnit, texts: [text], context: 'PR body' }),
+    ...validateSingleReviewUnitFocus({ texts, context: 'PR body' }),
+    ...validateReviewUnitFocus({ declaredReviewUnit: declaredUnit, texts, context: 'PR body' }),
   ])];
 
   if (errors.length === 0) {

--- a/scripts/test-check-pr-body-keywords.mjs
+++ b/scripts/test-check-pr-body-keywords.mjs
@@ -47,7 +47,25 @@ try {
   );
   assert.equal(nonProductMix.exitCode, 0, 'a non-product-unit keyword (tooling-policy) must not be flagged as a conflict');
 
-  console.log('PASS: check-pr-body-keywords.mjs matches the real validator on all 3 cases');
+  // Reproduces the exact false-positive hit while drafting a real PR body:
+  // the real validator only scans Summary/Review Claim/Slice Rationale, but
+  // this tool used to scan the whole file, so a Test Plan command mentioning
+  // "delete" (a cleanup-unit keyword) wrongly flagged an activation-surface PR.
+  const testPlanOnly = run(
+    '## Summary\nAdds a headless CLI flag.\n\n'
+      + '## Review Claim\nApproving one new flag.\n\n'
+      + '## Slice Rationale\nStands alone.\n\n'
+      + '## Test Plan\n<details>\n<summary>Test Plan</summary>\n\n'
+      + "- [ ] `node scripts/test-delete-all.mjs`\n\n</details>\n",
+    'activation-surface',
+  );
+  assert.equal(
+    testPlanOnly.exitCode,
+    0,
+    'a conflicting keyword inside Test Plan (unscanned by the real validator) must not be flagged',
+  );
+
+  console.log('PASS: check-pr-body-keywords.mjs matches the real validator on all 4 cases');
 } finally {
   rmSync(dir, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary

This tool used to inspect an entire PR body file for review-unit keyword conflicts, but the real validator only ever looks at three sections: Summary, Review Claim, and Slice Rationale.

That mismatch produced false failures on keywords appearing only in Test Plan, Safety Invariant, or Non-goals, sections CI never checks.

Found tonight while drafting a PR body: a Test Plan line naming a test file wrongly flagged a conflict the real check never raised.

## Review Claim

The reviewer is approving that this tool now pulls its input text from `getMarkdownSection`/`getReviewMetadata`, the exact same section-extraction the real validator uses, instead of the raw file body.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The tool's own existing three test cases still pass unchanged; a fourth case pins the exact bug (a conflicting word only inside a Test Plan block) and is shown failing on the old code, passing on the new code.

## Slice Rationale

Small, self-contained fix to a script shipped a few PRs earlier tonight (#9284), kept as its own PR since it is unrelated to the unconditional-`delete-all` stack (#9288-#9291) it surfaced while drafting.

## Non-goals

Does not change the real validator (`scripts/validate-pr-body.mjs`) itself, only this standalone pre-flight wrapper around it.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-check-pr-body-keywords.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert e8970524bf`
- Post-revert steps: None
- Data migration? No

</details>
