### PR TITLE
Remove the INVOKER_ALLOW_PRODUCTION_DELETE_ALL guard from invoker-cli

### DIFF
--- a/packages/cli/src/__tests__/cli-mutations.test.ts
+++ b/packages/cli/src/__tests__/cli-mutations.test.ts
@@ -37,7 +37,6 @@ function captureProcessOutput() {
 
 describe('invoker-cli mutations', () => {
   const previousInvokerDbDir = process.env.INVOKER_DB_DIR;
-  const previousAllowProductionDeleteAll = process.env.INVOKER_ALLOW_PRODUCTION_DELETE_ALL;
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -49,49 +48,10 @@ describe('invoker-cli mutations', () => {
     } else {
       process.env.INVOKER_DB_DIR = previousInvokerDbDir;
     }
-    if (previousAllowProductionDeleteAll === undefined) {
-      delete process.env.INVOKER_ALLOW_PRODUCTION_DELETE_ALL;
-    } else {
-      process.env.INVOKER_ALLOW_PRODUCTION_DELETE_ALL = previousAllowProductionDeleteAll;
-    }
   });
 
-  it('refuses delete-all against the default production DB root with exit 64', async () => {
+  it('runs delete-all against the default production DB root with no guard', async () => {
     process.env.INVOKER_DB_DIR = join(process.env.HOME ?? '', '.invoker');
-    delete process.env.INVOKER_ALLOW_PRODUCTION_DELETE_ALL;
-    const output = captureProcessOutput();
-
-    const code = await main(['delete-all'], {
-      createMessageBus: () => {
-        throw new Error('delete-all guard should run before IPC setup');
-      },
-    });
-
-    expect(code).toBe(64);
-    expect(output.stderr).toContain("ERROR: Refusing to run 'delete-all' against production DB root:");
-    expect(output.stderr).toContain('Set INVOKER_DB_DIR to an isolated temp directory for tests.');
-    expect(output.stderr).toContain('Override only if intentional: INVOKER_ALLOW_PRODUCTION_DELETE_ALL=1');
-    output.restore();
-  });
-
-  it('runs the delete-all guard before owner discovery or IPC send', async () => {
-    process.env.INVOKER_DB_DIR = join(process.env.HOME ?? '', '.invoker');
-    delete process.env.INVOKER_ALLOW_PRODUCTION_DELETE_ALL;
-    const output = captureProcessOutput();
-    const createMessageBus = vi.fn(() => {
-      throw new Error('should not be called');
-    });
-
-    const code = await main(['delete-all'], { createMessageBus });
-
-    expect(code).toBe(64);
-    expect(createMessageBus).not.toHaveBeenCalled();
-    output.restore();
-  });
-
-  it('allows delete-all past the production guard when the documented override is set', async () => {
-    process.env.INVOKER_DB_DIR = join(process.env.HOME ?? '', '.invoker');
-    process.env.INVOKER_ALLOW_PRODUCTION_DELETE_ALL = '1';
     const output = captureProcessOutput();
     const bus = new LocalBus();
     const execHandler = vi.fn(async (request: unknown) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
-import { basename, dirname, resolve, join } from 'node:path';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
 import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import {
@@ -378,49 +378,6 @@ function resolveQueryDbDir(): string {
   return resolve(process.env.INVOKER_DB_DIR ?? join(homedir(), '.invoker'));
 }
 
-function expandHomePath(raw: string): string {
-  if (raw === '~') return homedir();
-  if (raw.startsWith('~/')) return join(homedir(), raw.slice(2));
-  return raw;
-}
-
-function isDirectory(path: string): boolean {
-  try {
-    return statSync(path).isDirectory();
-  } catch {
-    return false;
-  }
-}
-
-function normalizeDeleteAllGuardPath(raw: string): string {
-  let expanded = expandHomePath(raw);
-  expanded = expanded.endsWith('/') ? expanded.slice(0, -1) : expanded;
-  if (expanded.length === 0) expanded = '/';
-
-  if (isDirectory(expanded)) {
-    return realpathSync(expanded);
-  }
-
-  const parent = dirname(expanded);
-  if (isDirectory(parent)) {
-    return join(realpathSync(parent), basename(expanded));
-  }
-
-  return expanded;
-}
-
-function checkDeleteAllProductionGuard(): number | undefined {
-  const dbRoot = normalizeDeleteAllGuardPath(process.env.INVOKER_DB_DIR ?? join(homedir(), '.invoker'));
-  const prodRoot = normalizeDeleteAllGuardPath(join(homedir(), '.invoker'));
-  if (process.env.INVOKER_ALLOW_PRODUCTION_DELETE_ALL !== '1' && dbRoot === prodRoot) {
-    process.stderr.write(`ERROR: Refusing to run 'delete-all' against production DB root: ${dbRoot}\n`);
-    process.stderr.write('Set INVOKER_DB_DIR to an isolated temp directory for tests.\n');
-    process.stderr.write('Override only if intentional: INVOKER_ALLOW_PRODUCTION_DELETE_ALL=1\n');
-    return 64;
-  }
-  return undefined;
-}
-
 function serializeWorkflowForQuery(workflow: Workflow): Record<string, unknown> {
   return {
     id: workflow.id,
@@ -634,9 +591,6 @@ async function runSimpleMutation(command: 'retry-task' | 'retry' | 'resume', tar
 }
 
 async function runDeleteAllMutation(deps: CliDeps): Promise<number> {
-  const guardExitCode = checkDeleteAllProductionGuard();
-  if (guardExitCode !== undefined) return guardExitCode;
-
   let bus: MessageBus | undefined;
   try {
     bus = await (deps.createMessageBus?.() ?? createDefaultMessageBus());


### PR DESCRIPTION
## Summary

`delete-all` no longer checks whether `INVOKER_DB_DIR` resolves to the default production path before running.

Combined with the CLI-side guard no longer present as of an earlier stack (#9288-#9291), `delete-all` now runs unconditionally on every entry path.

## Review Claim

The reviewer is approving that `invoker-cli delete-all` runs directly, with no env var required for any target DB path.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The pre-wipe DB snapshot step this repo relies on for recoverability lives elsewhere and is unchanged in this PR.

## Slice Rationale

Companion `run.sh` change lives in the next PR since this repo's review-unit rules classify it as `tooling-policy`, separate from this file's `activation-surface`.

## Non-goals

Does not touch the snapshot-before-wipe behavior. Does not change any other CLI command.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/cli && pnpm test -- src/__tests__/cli-mutations.test.ts`
- [ ] `npx tsc -p tsconfig.typecheck.json`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert 66ac4f2215`
- Post-revert steps: None
- Data migration? No

</details>
