### PR TITLE
Remove the same production-DB guard from run.sh's delete-all path

### DIFF
--- a/packages/cli/src/__tests__/cli-mutations.test.ts
+++ b/packages/cli/src/__tests__/cli-mutations.test.ts
@@ -37,7 +37,6 @@ function captureProcessOutput() {
 
 describe('invoker-cli mutations', () => {
   const previousInvokerDbDir = process.env.INVOKER_DB_DIR;
-  const previousAllowProductionDeleteAll = process.env.INVOKER_ALLOW_PRODUCTION_DELETE_ALL;
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -49,49 +48,10 @@ describe('invoker-cli mutations', () => {
     } else {
       process.env.INVOKER_DB_DIR = previousInvokerDbDir;
     }
-    if (previousAllowProductionDeleteAll === undefined) {
-      delete process.env.INVOKER_ALLOW_PRODUCTION_DELETE_ALL;
-    } else {
-      process.env.INVOKER_ALLOW_PRODUCTION_DELETE_ALL = previousAllowProductionDeleteAll;
-    }
   });
 
-  it('refuses delete-all against the default production DB root with exit 64', async () => {
+  it('runs delete-all against the default production DB root with no guard', async () => {
     process.env.INVOKER_DB_DIR = join(process.env.HOME ?? '', '.invoker');
-    delete process.env.INVOKER_ALLOW_PRODUCTION_DELETE_ALL;
-    const output = captureProcessOutput();
-
-    const code = await main(['delete-all'], {
-      createMessageBus: () => {
-        throw new Error('delete-all guard should run before IPC setup');
-      },
-    });
-
-    expect(code).toBe(64);
-    expect(output.stderr).toContain("ERROR: Refusing to run 'delete-all' against production DB root:");
-    expect(output.stderr).toContain('Set INVOKER_DB_DIR to an isolated temp directory for tests.');
-    expect(output.stderr).toContain('Override only if intentional: INVOKER_ALLOW_PRODUCTION_DELETE_ALL=1');
-    output.restore();
-  });
-
-  it('runs the delete-all guard before owner discovery or IPC send', async () => {
-    process.env.INVOKER_DB_DIR = join(process.env.HOME ?? '', '.invoker');
-    delete process.env.INVOKER_ALLOW_PRODUCTION_DELETE_ALL;
-    const output = captureProcessOutput();
-    const createMessageBus = vi.fn(() => {
-      throw new Error('should not be called');
-    });
-
-    const code = await main(['delete-all'], { createMessageBus });
-
-    expect(code).toBe(64);
-    expect(createMessageBus).not.toHaveBeenCalled();
-    output.restore();
-  });
-
-  it('allows delete-all past the production guard when the documented override is set', async () => {
-    process.env.INVOKER_DB_DIR = join(process.env.HOME ?? '', '.invoker');
-    process.env.INVOKER_ALLOW_PRODUCTION_DELETE_ALL = '1';
     const output = captureProcessOutput();
     const bus = new LocalBus();
     const execHandler = vi.fn(async (request: unknown) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
-import { basename, dirname, resolve, join } from 'node:path';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
 import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import {
@@ -378,49 +378,6 @@ function resolveQueryDbDir(): string {
   return resolve(process.env.INVOKER_DB_DIR ?? join(homedir(), '.invoker'));
 }
 
-function expandHomePath(raw: string): string {
-  if (raw === '~') return homedir();
-  if (raw.startsWith('~/')) return join(homedir(), raw.slice(2));
-  return raw;
-}
-
-function isDirectory(path: string): boolean {
-  try {
-    return statSync(path).isDirectory();
-  } catch {
-    return false;
-  }
-}
-
-function normalizeDeleteAllGuardPath(raw: string): string {
-  let expanded = expandHomePath(raw);
-  expanded = expanded.endsWith('/') ? expanded.slice(0, -1) : expanded;
-  if (expanded.length === 0) expanded = '/';
-
-  if (isDirectory(expanded)) {
-    return realpathSync(expanded);
-  }
-
-  const parent = dirname(expanded);
-  if (isDirectory(parent)) {
-    return join(realpathSync(parent), basename(expanded));
-  }
-
-  return expanded;
-}
-
-function checkDeleteAllProductionGuard(): number | undefined {
-  const dbRoot = normalizeDeleteAllGuardPath(process.env.INVOKER_DB_DIR ?? join(homedir(), '.invoker'));
-  const prodRoot = normalizeDeleteAllGuardPath(join(homedir(), '.invoker'));
-  if (process.env.INVOKER_ALLOW_PRODUCTION_DELETE_ALL !== '1' && dbRoot === prodRoot) {
-    process.stderr.write(`ERROR: Refusing to run 'delete-all' against production DB root: ${dbRoot}\n`);
-    process.stderr.write('Set INVOKER_DB_DIR to an isolated temp directory for tests.\n');
-    process.stderr.write('Override only if intentional: INVOKER_ALLOW_PRODUCTION_DELETE_ALL=1\n');
-    return 64;
-  }
-  return undefined;
-}
-
 function serializeWorkflowForQuery(workflow: Workflow): Record<string, unknown> {
   return {
     id: workflow.id,
@@ -634,9 +591,6 @@ async function runSimpleMutation(command: 'retry-task' | 'retry' | 'resume', tar
 }
 
 async function runDeleteAllMutation(deps: CliDeps): Promise<number> {
-  const guardExitCode = checkDeleteAllProductionGuard();
-  if (guardExitCode !== undefined) return guardExitCode;
-
   let bus: MessageBus | undefined;
   try {
     bus = await (deps.createMessageBus?.() ?? createDefaultMessageBus());

--- a/run.sh
+++ b/run.sh
@@ -55,53 +55,6 @@ ensure_workspace_bootstrapped() {
   touch "$BOOTSTRAP_STAMP"
 }
 
-expand_home_path() {
-  case "$1" in
-    "~") printf '%s\n' "$HOME" ;;
-    "~/"*) printf '%s\n' "$HOME/${1#~/}" ;;
-    *) printf '%s\n' "$1" ;;
-  esac
-}
-
-normalize_path() {
-  local raw="$1"
-  local expanded
-  expanded="$(expand_home_path "$raw")"
-  expanded="${expanded%/}"
-  if [ -z "$expanded" ]; then
-    expanded="/"
-  fi
-
-  if [ -d "$expanded" ]; then
-    (cd "$expanded" && pwd -P)
-    return
-  fi
-
-  local parent base
-  parent="$(dirname "$expanded")"
-  base="$(basename "$expanded")"
-  if [ -d "$parent" ]; then
-    printf '%s/%s\n' "$(cd "$parent" && pwd -P)" "$base"
-  else
-    printf '%s\n' "$expanded"
-  fi
-}
-
-# Hard safety guard: never allow headless delete-all to target the default
-# production DB unless explicitly overridden.
-if [ "${1:-}" = "--headless" ] && [ "${2:-}" = "delete-all" ]; then
-  DB_ROOT_RAW="${INVOKER_DB_DIR:-$HOME/.invoker}"
-  DB_ROOT="$(normalize_path "$DB_ROOT_RAW")"
-  PROD_ROOT="$(normalize_path "$HOME/.invoker")"
-
-  if [ "${INVOKER_ALLOW_PRODUCTION_DELETE_ALL:-0}" != "1" ] && [ "$DB_ROOT" = "$PROD_ROOT" ]; then
-    echo "ERROR: Refusing to run 'delete-all' against production DB root: $DB_ROOT" >&2
-    echo "Set INVOKER_DB_DIR to an isolated temp directory for tests." >&2
-    echo "Override only if intentional: INVOKER_ALLOW_PRODUCTION_DELETE_ALL=1" >&2
-    exit 64
-  fi
-fi
-
 # Ensure workspace dependencies are linked before building.
 # Headless commands must keep stdout clean because scripts parse labels/JSON.
 ensure_workspace_bootstrapped


### PR DESCRIPTION
## Summary

`run.sh` no longer checks whether the resolved DB root is the default production path before running `delete-all`.

Matches the `invoker-cli` removal in the prior PR of this stack.

## Review Claim

The reviewer is approving that `./run.sh --headless delete-all` runs directly, with no env var required for any target DB path.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Nothing else in `run.sh`'s bootstrap or launch path changes; only this one check is gone.

## Slice Rationale

Split from the prior PR because this repo's review-unit rules classify `run.sh` as `tooling-policy`, separate from that PR's `activation-surface` file.

## Non-goals

Does not change any other `run.sh` behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash -n run.sh`
- [ ] `git grep -n INVOKER_ALLOW_PRODUCTION_DELETE_ALL run.sh` returns nothing

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert aa03890539`
- Post-revert steps: None
- Data migration? No

</details>
