### PR TITLE
Check final task status before treating a repair as crashed on infra

### DIFF
--- a/scripts/mergify_admin_requeue_infra_signal.py
+++ b/scripts/mergify_admin_requeue_infra_signal.py
@@ -29,12 +29,43 @@ def find_latest_workflow_id(plan_name: str, *, run_headless_fn=run_headless) -> 
     return matches[-1].get("id")
 
 
+def _repair_task_completed(workflow_id: str, *, run_headless_fn=run_headless) -> bool | None:
+    """True/False when the `repair` task's current status is known, None when
+    the status lookup itself failed (caller should fail open toward "crashed")."""
+    completed = run_headless_fn('headless_query query tasks "$2"', workflow_id)
+    if completed.returncode != 0:
+        return None
+    try:
+        tasks = json.loads(completed.stdout)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    repair_task = next(
+        (t for t in tasks if isinstance(t, dict) and str(t.get("id", "")).endswith("/repair")),
+        None,
+    )
+    if repair_task is None:
+        return None
+    return repair_task.get("status") == "completed"
+
+
 def repair_task_crashed_on_infra(plan_name: str, *, run_headless_fn=run_headless) -> bool:
     """True when plan_name's most recent Invoker workflow's `repair` task
     crashed with the known SSH/OAuth infra signature -- a submission that
-    never gave the coding agent a chance to touch the PR at all."""
+    never gave the coding agent a chance to touch the PR at all.
+
+    A task that ultimately completed proves the agent did launch and finish,
+    even if an earlier SSH retry attempt logged the signature before self-
+    healing (e.g. credentials still propagating across the pool) -- checking
+    the signature alone without the final status flags that case as crashed
+    and triggers a redundant resubmission while the first attempt is still
+    finishing. See PR #9309's own bot-thread repair (2026-08-16) for a real
+    instance: the signature appeared 4 times, then the task completed.
+    """
     workflow_id = find_latest_workflow_id(plan_name, run_headless_fn=run_headless_fn)
     if workflow_id is None:
         return False
     completed = run_headless_fn('headless_query query task-output "$2"', f"{workflow_id}/repair")
-    return completed.returncode == 0 and SSH_OAUTH_INFRA_SIGNATURE in completed.stdout
+    if completed.returncode != 0 or SSH_OAUTH_INFRA_SIGNATURE not in completed.stdout:
+        return False
+    task_completed = _repair_task_completed(workflow_id, run_headless_fn=run_headless_fn)
+    return task_completed is not True

--- a/scripts/test_mergify_admin_requeue_infra_signal.py
+++ b/scripts/test_mergify_admin_requeue_infra_signal.py
@@ -60,13 +60,16 @@ class FindLatestWorkflowId(unittest.TestCase):
 
 
 class RepairTaskCrashedOnInfra(unittest.TestCase):
-    def _run_headless_fn(self, workflows_result, task_output_result):
+    def _run_headless_fn(self, workflows_result, task_output_result, task_status_result=None):
         def run_headless_fn(command, *extra_args):
             if "query workflows" in command:
                 return workflows_result
-            self.assertIn("task-output", command)
-            self.assertEqual(extra_args, ("wf-1/repair",))
-            return task_output_result
+            if "task-output" in command:
+                self.assertEqual(extra_args, ("wf-1/repair",))
+                return task_output_result
+            self.assertIn("query tasks", command)
+            self.assertEqual(extra_args, ("wf-1",))
+            return task_status_result if task_status_result is not None else workflows_json({"id": "wf-1/repair", "status": "failed"})
         return run_headless_fn
 
     def test_false_when_workflow_not_found(self):
@@ -96,6 +99,58 @@ class RepairTaskCrashedOnInfra(unittest.TestCase):
             workflows_json({"id": "wf-1", "name": "plan-a", "createdAt": "2026-01-01T00:00:00Z"}),
             completed(stdout="[SshExecutor] Running task payload...\n" + s.SSH_OAUTH_INFRA_SIGNATURE + "\n"),
         )
+        result = s.repair_task_crashed_on_infra("plan-a", run_headless_fn=run_headless_fn)
+        self.assertTrue(result)
+
+    def test_false_when_the_signature_appears_but_the_task_ultimately_completed(self):
+        # Repro: a real repair task (wf-1786846308456-6/repair, PR #9309,
+        # 2026-08-16) hit "OAuth session expired" 4 times on early SSH retry
+        # attempts while credentials were still propagating across the pool,
+        # then self-healed and finished successfully. Its cumulative output
+        # log still contained the signature text from those earlier attempts,
+        # so the old substring-only check reported "crashed on infra" for a
+        # task that had, in fact, completed -- causing plan_bot_thread_repairs
+        # to bypass the in-flight guard and fire a fully redundant second
+        # repair while the first was still finishing.
+        def run_headless_fn(command, *extra_args):
+            if "query workflows" in command:
+                return workflows_json({"id": "wf-1", "name": "plan-a", "createdAt": "2026-01-01T00:00:00Z"})
+            if "task-output" in command:
+                self.assertEqual(extra_args, ("wf-1/repair",))
+                return completed(
+                    stdout="[SshExecutor] Running task payload...\n"
+                    + (s.SSH_OAUTH_INFRA_SIGNATURE + "\n") * 4
+                    + "[SshExecutor] Recording task result and pushing branch on remote...\n",
+                )
+            self.assertIn("query tasks", command)
+            self.assertEqual(extra_args, ("wf-1",))
+            return workflows_json({"id": "wf-1/repair", "status": "completed"})
+
+        result = s.repair_task_crashed_on_infra("plan-a", run_headless_fn=run_headless_fn)
+        self.assertFalse(result)
+
+    def test_true_when_the_signature_appears_and_the_task_did_not_complete(self):
+        def run_headless_fn(command, *extra_args):
+            if "query workflows" in command:
+                return workflows_json({"id": "wf-1", "name": "plan-a", "createdAt": "2026-01-01T00:00:00Z"})
+            if "task-output" in command:
+                return completed(stdout="[SshExecutor] Running task payload...\n" + s.SSH_OAUTH_INFRA_SIGNATURE + "\n")
+            self.assertIn("query tasks", command)
+            return workflows_json({"id": "wf-1/repair", "status": "failed"})
+
+        result = s.repair_task_crashed_on_infra("plan-a", run_headless_fn=run_headless_fn)
+        self.assertTrue(result)
+
+    def test_true_when_the_task_status_query_itself_fails(self):
+        # A status-lookup failure must not silently suppress a real crash
+        # signal -- fail open toward "still treat it as crashed" like before.
+        def run_headless_fn(command, *extra_args):
+            if "query workflows" in command:
+                return workflows_json({"id": "wf-1", "name": "plan-a", "createdAt": "2026-01-01T00:00:00Z"})
+            if "task-output" in command:
+                return completed(stdout=s.SSH_OAUTH_INFRA_SIGNATURE)
+            return completed(returncode=1)
+
         result = s.repair_task_crashed_on_infra("plan-a", run_headless_fn=run_headless_fn)
         self.assertTrue(result)
 


### PR DESCRIPTION
## Summary

A live PR #9309 bot-thread repair tonight hit an OAuth-expired error 4 times on early SSH attempts while credentials were still spreading across the pool, then self-healed and finished on its own.

Its full log still held that old error text, so the crash check flagged it as dead with no way to tell a passing hiccup apart from a real dead end. That wrongly told the planner to skip its own cooldown guard and fire a second, fully redundant repair while the first was still wrapping up.

Nothing was lost -- the second repair's own stale-head check caught the resulting race and refused to push -- but a whole second repair cycle ran for nothing.

## Review Claim

The reviewer is approving that the crash check now confirms the repair task's final status before trusting old error text in its log, using the exact real captured incident as the test fixture.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

A status-lookup failure still counts as a possible crash (unchanged fail-open direction), so this cannot silently hide a genuine dead task. Every other caller of this function is unaffected.

## Slice Rationale

One self-contained slice: a single function plus its test, proven against the exact incident data captured tonight.

## Non-goals

Does not touch the in-flight cooldown guard itself, only the signal that decides whether to bypass it. Does not change how repairs are submitted or how PR #9309 lands.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 scripts/test_mergify_admin_requeue_infra_signal.py`
- [ ] `python3 -m unittest discover -s scripts -p "test_mergify_admin_requeue*.py"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert 92f3ae7306`
- Post-revert steps: None
- Data migration? No

</details>
