### PR TITLE
[admin-bypass-repair-check-pr-9312-pr-body-92f3ae7](1) Check final task status before treating a repair as crashed on infra

### DIFF
--- a/scripts/mergify_admin_requeue_infra_signal.py
+++ b/scripts/mergify_admin_requeue_infra_signal.py
@@ -29,12 +29,43 @@ def find_latest_workflow_id(plan_name: str, *, run_headless_fn=run_headless) -> 
     return matches[-1].get("id")
 
 
+def _repair_task_completed(workflow_id: str, *, run_headless_fn=run_headless) -> bool | None:
+    """True/False when the `repair` task's current status is known, None when
+    the status lookup itself failed (caller should fail open toward "crashed")."""
+    completed = run_headless_fn('headless_query query tasks "$2"', workflow_id)
+    if completed.returncode != 0:
+        return None
+    try:
+        tasks = json.loads(completed.stdout)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    repair_task = next(
+        (t for t in tasks if isinstance(t, dict) and str(t.get("id", "")).endswith("/repair")),
+        None,
+    )
+    if repair_task is None:
+        return None
+    return repair_task.get("status") == "completed"
+
+
 def repair_task_crashed_on_infra(plan_name: str, *, run_headless_fn=run_headless) -> bool:
     """True when plan_name's most recent Invoker workflow's `repair` task
     crashed with the known SSH/OAuth infra signature -- a submission that
-    never gave the coding agent a chance to touch the PR at all."""
+    never gave the coding agent a chance to touch the PR at all.
+
+    A task that ultimately completed proves the agent did launch and finish,
+    even if an earlier SSH retry attempt logged the signature before self-
+    healing (e.g. credentials still propagating across the pool) -- checking
+    the signature alone without the final status flags that case as crashed
+    and triggers a redundant resubmission while the first attempt is still
+    finishing. See PR #9309's own bot-thread repair (2026-08-16) for a real
+    instance: the signature appeared 4 times, then the task completed.
+    """
     workflow_id = find_latest_workflow_id(plan_name, run_headless_fn=run_headless_fn)
     if workflow_id is None:
         return False
     completed = run_headless_fn('headless_query query task-output "$2"', f"{workflow_id}/repair")
-    return completed.returncode == 0 and SSH_OAUTH_INFRA_SIGNATURE in completed.stdout
+    if completed.returncode != 0 or SSH_OAUTH_INFRA_SIGNATURE not in completed.stdout:
+        return False
+    task_completed = _repair_task_completed(workflow_id, run_headless_fn=run_headless_fn)
+    return task_completed is not True

--- a/scripts/test_mergify_admin_requeue_infra_signal.py
+++ b/scripts/test_mergify_admin_requeue_infra_signal.py
@@ -60,13 +60,16 @@ class FindLatestWorkflowId(unittest.TestCase):
 
 
 class RepairTaskCrashedOnInfra(unittest.TestCase):
-    def _run_headless_fn(self, workflows_result, task_output_result):
+    def _run_headless_fn(self, workflows_result, task_output_result, task_status_result=None):
         def run_headless_fn(command, *extra_args):
             if "query workflows" in command:
                 return workflows_result
-            self.assertIn("task-output", command)
-            self.assertEqual(extra_args, ("wf-1/repair",))
-            return task_output_result
+            if "task-output" in command:
+                self.assertEqual(extra_args, ("wf-1/repair",))
+                return task_output_result
+            self.assertIn("query tasks", command)
+            self.assertEqual(extra_args, ("wf-1",))
+            return task_status_result if task_status_result is not None else workflows_json({"id": "wf-1/repair", "status": "failed"})
         return run_headless_fn
 
     def test_false_when_workflow_not_found(self):
@@ -96,6 +99,58 @@ class RepairTaskCrashedOnInfra(unittest.TestCase):
             workflows_json({"id": "wf-1", "name": "plan-a", "createdAt": "2026-01-01T00:00:00Z"}),
             completed(stdout="[SshExecutor] Running task payload...\n" + s.SSH_OAUTH_INFRA_SIGNATURE + "\n"),
         )
+        result = s.repair_task_crashed_on_infra("plan-a", run_headless_fn=run_headless_fn)
+        self.assertTrue(result)
+
+    def test_false_when_the_signature_appears_but_the_task_ultimately_completed(self):
+        # Repro: a real repair task (wf-1786846308456-6/repair, PR #9309,
+        # 2026-08-16) hit "OAuth session expired" 4 times on early SSH retry
+        # attempts while credentials were still propagating across the pool,
+        # then self-healed and finished successfully. Its cumulative output
+        # log still contained the signature text from those earlier attempts,
+        # so the old substring-only check reported "crashed on infra" for a
+        # task that had, in fact, completed -- causing plan_bot_thread_repairs
+        # to bypass the in-flight guard and fire a fully redundant second
+        # repair while the first was still finishing.
+        def run_headless_fn(command, *extra_args):
+            if "query workflows" in command:
+                return workflows_json({"id": "wf-1", "name": "plan-a", "createdAt": "2026-01-01T00:00:00Z"})
+            if "task-output" in command:
+                self.assertEqual(extra_args, ("wf-1/repair",))
+                return completed(
+                    stdout="[SshExecutor] Running task payload...\n"
+                    + (s.SSH_OAUTH_INFRA_SIGNATURE + "\n") * 4
+                    + "[SshExecutor] Recording task result and pushing branch on remote...\n",
+                )
+            self.assertIn("query tasks", command)
+            self.assertEqual(extra_args, ("wf-1",))
+            return workflows_json({"id": "wf-1/repair", "status": "completed"})
+
+        result = s.repair_task_crashed_on_infra("plan-a", run_headless_fn=run_headless_fn)
+        self.assertFalse(result)
+
+    def test_true_when_the_signature_appears_and_the_task_did_not_complete(self):
+        def run_headless_fn(command, *extra_args):
+            if "query workflows" in command:
+                return workflows_json({"id": "wf-1", "name": "plan-a", "createdAt": "2026-01-01T00:00:00Z"})
+            if "task-output" in command:
+                return completed(stdout="[SshExecutor] Running task payload...\n" + s.SSH_OAUTH_INFRA_SIGNATURE + "\n")
+            self.assertIn("query tasks", command)
+            return workflows_json({"id": "wf-1/repair", "status": "failed"})
+
+        result = s.repair_task_crashed_on_infra("plan-a", run_headless_fn=run_headless_fn)
+        self.assertTrue(result)
+
+    def test_true_when_the_task_status_query_itself_fails(self):
+        # A status-lookup failure must not silently suppress a real crash
+        # signal -- fail open toward "still treat it as crashed" like before.
+        def run_headless_fn(command, *extra_args):
+            if "query workflows" in command:
+                return workflows_json({"id": "wf-1", "name": "plan-a", "createdAt": "2026-01-01T00:00:00Z"})
+            if "task-output" in command:
+                return completed(stdout=s.SSH_OAUTH_INFRA_SIGNATURE)
+            return completed(returncode=1)
+
         result = s.repair_task_crashed_on_infra("plan-a", run_headless_fn=run_headless_fn)
         self.assertTrue(result)
 


### PR DESCRIPTION
## Summary

The planner now checks a repair task's final status before classifying earlier infrastructure output as terminal.

Final completion prevents an unnecessary second repair cycle after transient authentication errors recover.

## Review Claim

Approve checking a repair task's final status before treating earlier infrastructure-error output as a terminal crash.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

A failed status lookup still preserves the prior fail-open result, so a genuine dead task is not silently hidden.

## Slice Rationale

The status check and its focused tests form one policy decision and can be reviewed together.

## Non-goals

This does not change the cooldown guard, repair submission, or pull-request landing behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 scripts/test_mergify_admin_requeue_infra_signal.py`
- [x] `python3 -m unittest discover -s scripts -p "test_mergify_admin_requeue*.py"`

</details>

## Workflow Summary

admin-bypass-repair-check-pr-9312-pr-body-92f3ae7 — 3 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1786848715097-20/repair | Repair PR #9312 (failed check PR Body) | completed |
| wf-1786848715097-20/normalize | Normalize PR #9312 repair commit; split a prerequisite PR if required | completed (passed) |
| wf-1786848715097-20/safe-push | Safely push PR #9312 only if its head did not move and no prerequisite was split | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1786848715097-20/repair — Repair PR #9312 (failed check PR Body)

### wf-1786848715097-20/normalize — Normalize PR #9312 repair commit; split a prerequisite PR if required

### wf-1786848715097-20/safe-push — Safely push PR #9312 only if its head did not move and no prerequisite was split

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 92f3ae73060f37fe3d5ffab3cfc6c2cb4142d8c4`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved infrastructure failure detection by confirming that a repair task did not ultimately complete.
  - Prevented completed tasks from being incorrectly reported as infrastructure crashes.
  - Preserved crash reporting when the task fails or its final status cannot be determined.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->