### PR TITLE
Queue CodeRabbit bot-thread repairs as external review instead of manual

### DIFF
--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -65,11 +65,11 @@ class AsyncRepairPlan:
     yaml_text: str
 
 
-def _write_plan_header(*, name: str, base_branch: str, repo: str) -> str:
+def _write_plan_header(*, name: str, base_branch: str, repo: str, merge_mode: str = "manual") -> str:
     return (
         f"name: {name}\n"
         "onFinish: none\n"
-        "mergeMode: manual\n"
+        f"mergeMode: {merge_mode}\n"
         f"repoUrl: {_yaml_str(_repo_url(repo))}\n"
         f"baseBranch: {_yaml_str(base_branch)}\n"
         "tasks:\n"
@@ -280,7 +280,9 @@ def build_repair_bot_thread_plan(
         "If the thread is already resolved, or the PR is closed or merged, make no commit and exit 0.\n\n"
         f"PR: #{pr.number}\nHead branch: {pr.head_ref_name}\nHead SHA: {start_head}\nThread: {thread_id}\n"
     )
-    yaml_text = _write_plan_header(name=name, base_branch=pr.base_ref_name, repo=repo)
+    yaml_text = _write_plan_header(
+        name=name, base_branch=pr.base_ref_name, repo=repo, merge_mode="external_review"
+    )
     yaml_text += _repair_task_yaml(description=f"Resolve bot review thread on PR #{pr.number}", prompt=prompt)
     yaml_text += _safe_push_task_yaml(
         task_id="safe-push",

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -58,14 +58,15 @@ class AsyncRepairPlanTests(unittest.TestCase):
         bot_thread_plan = async_repair.build_repair_bot_thread_plan(
             pr(), "tbot", repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
         )
-        for plan, expected_task_ids in (
-            (checks_plan, ["repair", "normalize", "safe-push"]),
-            (conflict_plan, ["repair", "safe-push"]),
-            (bot_thread_plan, ["repair", "safe-push"]),
+        for plan, expected_task_ids, expected_merge_mode in (
+            (checks_plan, ["repair", "normalize", "safe-push"], "manual"),
+            (conflict_plan, ["repair", "safe-push"], "manual"),
+            (bot_thread_plan, ["repair", "safe-push"], "external_review"),
         ):
             with self.subTest(plan=plan.plan_name):
                 doc = yaml.safe_load(plan.yaml_text)
                 self.assertEqual(doc["onFinish"], "none")
+                self.assertEqual(doc["mergeMode"], expected_merge_mode)
                 self.assertEqual(doc["repoUrl"], "https://github.com/owner/repo.git")
                 self.assertEqual([task["id"] for task in doc["tasks"]], expected_task_ids)
                 for task, expected_id in zip(doc["tasks"][1:], expected_task_ids[1:]):


### PR DESCRIPTION
## Summary

CodeRabbit bot-thread repair plans used to finish as soon as Invoker's own manual approval fired, with no check on GitHub's real review state. Now they wait on that real review state instead.

The other two repair plan types (failed-check repair, merge-conflict repair) are unchanged; they still finish on manual approval.

## Review Claim

The reviewer is approving that only the CodeRabbit bot-thread repair plan switches from `mergeMode: manual` to `mergeMode: external_review`, while the check-repair and conflict-repair plans stay on `manual`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The shared `_write_plan_header` helper defaults its new `merge_mode` parameter to `"manual"`, so every other caller is unaffected unless it explicitly opts in. Only the bot-thread plan builder passes `merge_mode="external_review"`.

## Slice Rationale

One self-contained slice: a single optional parameter on a shared helper, plus one call site opting into the new value, proven with a test that fails on the old code and passes on the new code.

## Non-goals

Does not change the check-repair or conflict-repair plan builders. Does not change how bot-thread repairs are submitted or dispatched, only what condition marks them done.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 scripts/test_mergify_admin_requeue_async_repair.py`
- [ ] `python3 -m unittest discover -s scripts -p "test_mergify_admin_requeue*.py"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert 861768f7a6`
- Post-revert steps: None
- Data migration? No

</details>
