### PR TITLE
[PR 9312 prerequisite](1) reproduce Electron fallback without system unzip

### DIFF
--- a/scripts/repro/repro-mece-04-remote-electron-provisioning.sh
+++ b/scripts/repro/repro-mece-04-remote-electron-provisioning.sh
@@ -2,16 +2,21 @@
 set -euo pipefail
 
 EXPECT_ISSUE=0
+EXPECT_MISSING_UNZIP_ISSUE=0
 if [[ "${1:-}" == "--expect-issue" ]]; then
   EXPECT_ISSUE=1
   shift
+elif [[ "${1:-}" == "--expect-missing-unzip-issue" ]]; then
+  EXPECT_MISSING_UNZIP_ISSUE=1
+  shift
 fi
 if [[ $# -ne 0 ]]; then
-  echo "usage: $0 [--expect-issue]" >&2
+  echo "usage: $0 [--expect-issue|--expect-missing-unzip-issue]" >&2
   exit 2
 fi
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+NODE_BIN="$(node -p 'process.execPath')"
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-electron-provision.XXXXXX")"
 cleanup() {
   rm -rf "$TMP_DIR"
@@ -21,7 +26,10 @@ trap cleanup EXIT
 mkdir -p \
   "$TMP_DIR/repo/scripts" \
   "$TMP_DIR/repo/packages/app" \
-  "$TMP_DIR/repo/node_modules/electron"
+  "$TMP_DIR/repo/node_modules/electron" \
+  "$TMP_DIR/repo/node_modules/@electron/get" \
+  "$TMP_DIR/repo/node_modules/extract-zip" \
+  "$TMP_DIR/empty-path"
 cp "$ROOT_DIR/scripts/electron.cjs" "$TMP_DIR/repo/scripts/electron.cjs"
 
 cat >"$TMP_DIR/repo/node_modules/electron/package.json" <<'JSON'
@@ -32,10 +40,17 @@ cat >"$TMP_DIR/repo/node_modules/electron/package.json" <<'JSON'
 }
 JSON
 
+cat >"$TMP_DIR/repo/node_modules/electron/checksums.json" <<'JSON'
+{}
+JSON
+
 cat >"$TMP_DIR/repo/node_modules/electron/install.js" <<'JS'
 const fs = require('node:fs');
 const path = require('node:path');
 fs.writeFileSync(path.join(__dirname, '..', '..', 'installer-ran'), 'yes\n');
+if (process.env.FAKE_ELECTRON_INSTALL_EMPTY_SUCCESS === '1') {
+  process.exit(0);
+}
 if (process.env.FAKE_ELECTRON_INSTALL_SUCCESS === '1') {
   const distDir = path.join(__dirname, 'dist');
   fs.mkdirSync(distDir, { recursive: true });
@@ -45,6 +60,46 @@ if (process.env.FAKE_ELECTRON_INSTALL_SUCCESS === '1') {
 }
 console.error('fake Electron installer ran');
 process.exit(42);
+JS
+
+cat >"$TMP_DIR/repo/node_modules/@electron/get/package.json" <<'JSON'
+{
+  "name": "@electron/get",
+  "version": "0.0.0-test",
+  "main": "index.js"
+}
+JSON
+
+cat >"$TMP_DIR/repo/node_modules/@electron/get/index.js" <<'JS'
+const fs = require('node:fs');
+
+exports.downloadArtifact = async function downloadArtifact() {
+  fs.writeFileSync(process.env.FAKE_ELECTRON_DOWNLOAD_MARKER, 'yes\n');
+  return process.env.FAKE_ELECTRON_ZIP;
+};
+JS
+
+cat >"$TMP_DIR/repo/node_modules/extract-zip/package.json" <<'JSON'
+{
+  "name": "extract-zip",
+  "version": "0.0.0-test",
+  "main": "index.js"
+}
+JSON
+
+cat >"$TMP_DIR/repo/node_modules/extract-zip/index.js" <<'JS'
+const fs = require('node:fs');
+const path = require('node:path');
+
+module.exports = async function extractZip(zipPath, options) {
+  if (zipPath !== process.env.FAKE_ELECTRON_ZIP) {
+    throw new Error(`unexpected Electron archive: ${zipPath}`);
+  }
+  fs.writeFileSync(process.env.FAKE_EXTRACT_ZIP_MARKER, 'yes\n');
+  fs.mkdirSync(options.dir, { recursive: true });
+  fs.writeFileSync(path.join(options.dir, 'electron'), '#!/usr/bin/env sh\nexit 0\n', { mode: 0o755 });
+  fs.writeFileSync(path.join(options.dir, 'electron.d.ts'), 'export {};\n');
+};
 JS
 
 set +e
@@ -89,15 +144,63 @@ if ! grep -q "Electron is not installed. Provision this machine before running I
   exit 1
 fi
 
+FAKE_ELECTRON_ZIP="$TMP_DIR/electron.zip"
+FAKE_ELECTRON_DOWNLOAD_MARKER="$TMP_DIR/repo/electron-download-ran"
+FAKE_EXTRACT_ZIP_MARKER="$TMP_DIR/repo/extract-zip-ran"
+: >"$FAKE_ELECTRON_ZIP"
+
+set +e
 (
   cd "$TMP_DIR/repo"
-  FAKE_ELECTRON_INSTALL_SUCCESS=1 node scripts/electron.cjs --install-only
+  PATH="$TMP_DIR/empty-path" \
+    FAKE_ELECTRON_INSTALL_EMPTY_SUCCESS=1 \
+    FAKE_ELECTRON_ZIP="$FAKE_ELECTRON_ZIP" \
+    FAKE_ELECTRON_DOWNLOAD_MARKER="$FAKE_ELECTRON_DOWNLOAD_MARKER" \
+    FAKE_EXTRACT_ZIP_MARKER="$FAKE_EXTRACT_ZIP_MARKER" \
+    "$NODE_BIN" scripts/electron.cjs --install-only
 ) >"$TMP_DIR/install-stdout" 2>"$TMP_DIR/install-stderr"
+INSTALL_STATUS=$?
+set -e
+
 if [[ ! -f "$INSTALLER_MARKER" ]]; then
   echo "repro: install-only did not invoke Electron provisioning" >&2
   echo "--- stderr ---" >&2
   cat "$TMP_DIR/install-stderr" >&2
   exit 1
 fi
+if [[ ! -f "$FAKE_ELECTRON_DOWNLOAD_MARKER" ]]; then
+  echo "repro: Electron fallback did not download the archive" >&2
+  echo "--- stderr ---" >&2
+  cat "$TMP_DIR/install-stderr" >&2
+  exit 1
+fi
 
-echo "remote-electron-provisioning fixed: missing Electron fails without installer"
+if [[ "$EXPECT_MISSING_UNZIP_ISSUE" -eq 1 ]]; then
+  if [[ "$INSTALL_STATUS" -eq 0 ]]; then
+    echo "repro: expected fallback to fail without a host unzip executable" >&2
+    exit 1
+  fi
+  if [[ -f "$FAKE_EXTRACT_ZIP_MARKER" ]]; then
+    echo "repro: expected broken fallback not to use extract-zip" >&2
+    exit 1
+  fi
+  echo "remote-electron-provisioning missing-unzip issue reproduced: fallback failed without a host unzip executable"
+  exit 0
+fi
+
+if [[ "$INSTALL_STATUS" -ne 0 ]]; then
+  echo "repro: expected Electron fallback extraction to succeed without a host unzip executable" >&2
+  echo "--- stderr ---" >&2
+  cat "$TMP_DIR/install-stderr" >&2
+  exit 1
+fi
+if [[ ! -f "$FAKE_EXTRACT_ZIP_MARKER" ]]; then
+  echo "repro: repaired fallback did not use extract-zip" >&2
+  exit 1
+fi
+if [[ ! -x "$TMP_DIR/repo/node_modules/electron/dist/electron" ]]; then
+  echo "repro: repaired fallback did not leave a usable Electron binary" >&2
+  exit 1
+fi
+
+echo "remote-electron-provisioning fixed: fallback extraction succeeds without a host unzip executable"


### PR DESCRIPTION
## Summary

Add deterministic proof for PR #9312's shared Electron provisioning failure without changing Electron or product behavior.

The fixture models an installer that exits successfully without creating a binary.

It removes host `unzip` from `PATH` so the current fallback failure is reproducible.

This proof stays separate from the Electron repair and PR #9312's Python repair-status classification.

## Review Claim

The provisioning repro deterministically observes the missing-system-unzip fallback failure after the installer exits successfully without creating a binary.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the isolated fake-package repro changes; Electron provisioning, application behavior, CI workflow policy, dependencies, and PR #9312's Python files remain unchanged.

## Slice Rationale

Evidence lands before the repair, keeping this proof separate from the shared provisioning fix and PR #9312.

## Non-goals

No production helper, workflow, manifest, lockfile, dependency, Python, UI, or runner changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-mece-04-remote-electron-provisioning.sh --expect-missing-unzip-issue`
- [x] `bash -n scripts/repro/repro-mece-04-remote-electron-provisioning.sh`
- [x] `git diff --check origin/master...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for testing Electron provisioning when the system lacks the `unzip` utility.
  * Added verification for archive downloads, extraction fallback behavior, and successful Electron installation.
  * Added an option to explicitly reproduce and validate missing-`unzip` failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->