### PR TITLE
[Bugfix: restart mutations preserve downstream workflow gates](1) Preserve downstream workflow gates

### DIFF
--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -892,7 +892,7 @@ describe('headless delegation enforcement', () => {
 
         await runHeadless(['retry', 'wf-1'], depsWithNoTrack);
 
-        expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+        expect(preemptWorkflowExecution).not.toHaveBeenCalled();
         expect(mockDeps.commandService.cancelWorkflow).not.toHaveBeenCalled();
         expect(mockDeps.commandService.retryWorkflow).toHaveBeenCalled();
         expect(deferRunnableTasks).toHaveBeenCalledTimes(1);
@@ -1071,7 +1071,7 @@ describe('headless delegation enforcement', () => {
         expect(runnable.map((task: any) => task.id)).toEqual(['wf-1/task-1', 'wf-2/task-9']);
       });
 
-      it('headless retry always preempts, even when the workflow has no active execution', async () => {
+      it('headless retry delegates cancel-first ownership to commandService', async () => {
         const preemptWorkflowExecution = vi.fn(async () => {});
         const depsWithNoTrack: HeadlessDeps = {
           ...mockDeps,
@@ -1082,11 +1082,11 @@ describe('headless delegation enforcement', () => {
 
         await runHeadless(['retry', 'wf-1'], depsWithNoTrack);
 
-        expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+        expect(preemptWorkflowExecution).not.toHaveBeenCalled();
         expect(mockDeps.commandService.retryWorkflow).toHaveBeenCalled();
       });
 
-      it('headless recreate preempts workflow before recreate mutation', async () => {
+      it('headless recreate delegates cancel-first ownership to commandService', async () => {
         const preemptWorkflowExecution = vi.fn(async () => ({ cancelled: [], runningCancelled: [] }));
         (mockDeps.commandService as any).recreateWorkflow = vi.fn(async () => ({ ok: true as const, data: [] }));
         mockDeps.persistence.updateWorkflow = vi.fn();
@@ -1099,7 +1099,7 @@ describe('headless delegation enforcement', () => {
 
         await runHeadless(['recreate', 'wf-1'], depsWithNoTrack);
 
-        expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+        expect(preemptWorkflowExecution).not.toHaveBeenCalled();
         expect(mockDeps.commandService.recreateWorkflow).toHaveBeenCalled();
       });
 
@@ -1154,7 +1154,7 @@ describe('headless delegation enforcement', () => {
         executeTasksSpy.mockRestore();
       });
 
-      it('headless rebase preempts resolved workflow before rebase mutation', async () => {
+      it('headless rebase does not run an outer workflow preemption', async () => {
         const preemptWorkflowExecution = vi.fn(async () => ({ cancelled: [], runningCancelled: [] }));
         mockDeps.persistence.listWorkflows = vi.fn(() => [{
           id: 'wf-1',
@@ -1197,7 +1197,7 @@ describe('headless delegation enforcement', () => {
         } as HeadlessDeps;
 
         await expect(runHeadless(['rebase-retry', 'task-1'], depsWithNoTrack)).rejects.toThrow();
-        expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+        expect(preemptWorkflowExecution).not.toHaveBeenCalled();
       });
 
       // ── Step 12: routing assertions ────────────────────────────────────
@@ -1275,15 +1275,21 @@ describe('headless delegation enforcement', () => {
 
           await runHeadless(['rebase-retry', 'task-1'], depsWithNoTrack);
 
-          expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+          expect(preemptWorkflowExecution).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
-          // Cancel-first invariant: preempt before the recreate-from-fresh-base method.
-          const preemptOrder = (preemptWorkflowExecution.mock.invocationCallOrder ?? [])[0];
+          expect(mockDeps.orchestrator.cancelWorkflow).toHaveBeenCalledWith(
+            'wf-1',
+            { detachDependents: false },
+          );
+          // Cancel-first remains inside applyInvalidation, before the retry primitive.
+          const cancelOrder = (
+            (mockDeps.orchestrator.cancelWorkflow as any).mock.invocationCallOrder ?? []
+          )[0];
           const retryOrder = (
             (mockDeps.orchestrator.retryWorkflow as any).mock.invocationCallOrder ?? []
           )[0];
-          expect(preemptOrder).toBeLessThan(retryOrder);
+          expect(cancelOrder).toBeLessThan(retryOrder);
 
           preparePoolSpy.mockRestore();
         });
@@ -1339,7 +1345,7 @@ describe('headless delegation enforcement', () => {
 
           await runHeadless(['rebase-recreate', 'wf-1'], depsWithNoTrack);
 
-          expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+          expect(preemptWorkflowExecution).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith('wf-1', expect.any(Object));
           expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
           expect(preparePoolSpy).toHaveBeenCalledWith(
@@ -1362,7 +1368,7 @@ describe('headless delegation enforcement', () => {
 
           await runHeadless(['rebase-recreate', '__merge__wf-1'], depsWithNoTrack);
 
-          expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+          expect(preemptWorkflowExecution).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith('wf-1', expect.any(Object));
 
           preparePoolSpy.mockRestore();
@@ -1379,7 +1385,7 @@ describe('headless delegation enforcement', () => {
 
           await runHeadless(['rebase-recreate', 'task-1'], depsWithNoTrack);
 
-          expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+          expect(preemptWorkflowExecution).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith('wf-1', expect.any(Object));
 
           preparePoolSpy.mockRestore();
@@ -1397,6 +1403,7 @@ describe('headless delegation enforcement', () => {
 
           await runHeadless(['recreate', 'wf-1'], depsWithNoTrack);
 
+          expect(preemptWorkflowExecution).not.toHaveBeenCalled();
           expect((mockDeps.commandService as any).recreateWorkflow).toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
           expect(preparePoolSpy).not.toHaveBeenCalled();
@@ -1420,6 +1427,7 @@ describe('headless delegation enforcement', () => {
 
           await runHeadless(['retry', 'wf-1'], depsWithNoTrack);
 
+          expect(preemptWorkflowExecution).not.toHaveBeenCalled();
           expect(mockDeps.commandService.retryWorkflow).toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();

--- a/packages/app/src/__tests__/recreate-preserves-downstream-gates.test.ts
+++ b/packages/app/src/__tests__/recreate-preserves-downstream-gates.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IpcMain } from 'electron';
+import {
+  buildWorkflowInvalidationDeps,
+  CommandService,
+  Orchestrator,
+} from '@invoker/workflow-core';
+import { InMemoryBus, InMemoryPersistence } from '@invoker/test-kit';
+import { runHeadless } from '../headless.js';
+import type { HeadlessDeps } from '../headless.js';
+import {
+  registerGuiMutationIpcHandlers,
+  type GuiMutationTaskActions,
+  type RegisterGuiMutationIpcHandlersContext,
+} from '../ipc/gui-mutation-handlers.js';
+import { createRendererUiPerfCounters } from '../renderer-ui-perf.js';
+
+type Fixture = ReturnType<typeof createGatedWorkflowFixture>;
+
+function createGatedWorkflowFixture() {
+  const persistence = new InMemoryPersistence();
+  const messageBus = new InMemoryBus();
+  const orchestrator = new Orchestrator({
+    persistence,
+    messageBus,
+    maxConcurrency: 8,
+    resolveRepoDefaultBranch: () => 'main',
+  } as never);
+
+  orchestrator.loadPlan({
+    name: 'upstream',
+    repoUrl: 'memory://restart-gate-test',
+    baseBranch: 'main',
+    featureBranch: 'feature/upstream',
+    tasks: [{ id: 'upstream-task', description: 'upstream task' }],
+  });
+  const upstreamTask = orchestrator.getAllTasks().find((task) => task.id.endsWith('/upstream-task'))!;
+  const upstreamWorkflowId = upstreamTask.config.workflowId!;
+
+  orchestrator.loadPlan({
+    name: 'downstream',
+    repoUrl: 'memory://restart-gate-test',
+    baseBranch: 'feature/upstream',
+    featureBranch: 'feature/downstream',
+    externalDependencies: [{
+      workflowId: upstreamWorkflowId,
+      taskId: '__merge__',
+      requiredStatus: 'completed',
+      gatePolicy: 'completed',
+    }],
+    tasks: [{ id: 'downstream-task', description: 'gated downstream task' }],
+  });
+  const downstreamTask = orchestrator.getAllTasks().find((task) => task.id.endsWith('/downstream-task'))!;
+  const downstreamWorkflowId = downstreamTask.config.workflowId!;
+  const killActiveExecution = vi.fn(async () => undefined);
+  const invalidationDeps = buildWorkflowInvalidationDeps({
+    orchestrator,
+    requireWorkflow: (workflowId) => {
+      const workflow = persistence.loadWorkflow(workflowId);
+      if (!workflow) throw new Error(`Workflow ${workflowId} not found`);
+      return workflow;
+    },
+    killActiveExecution,
+  });
+  const commandService = new CommandService(orchestrator, invalidationDeps);
+
+  orchestrator.startExecution();
+  expect(orchestrator.getTask(upstreamTask.id)?.status).toBe('running');
+  expect(orchestrator.getTask(downstreamTask.id)?.status).toBe('pending');
+
+  return {
+    persistence,
+    messageBus,
+    orchestrator,
+    commandService,
+    killActiveExecution,
+    upstreamTaskId: upstreamTask.id,
+    upstreamWorkflowId,
+    downstreamTaskId: downstreamTask.id,
+    downstreamWorkflowId,
+  };
+}
+
+function expectDownstreamPendingAndAttached(fixture: Fixture): void {
+  expect(fixture.orchestrator.getTask(fixture.downstreamTaskId)?.status).toBe('pending');
+  expect(
+    fixture.persistence.loadWorkflow(fixture.downstreamWorkflowId)?.externalDependencies,
+  ).toContainEqual({
+    workflowId: fixture.upstreamWorkflowId,
+    taskId: '__merge__',
+    requiredStatus: 'completed',
+    gatePolicy: 'completed',
+  });
+}
+
+function createLogger() {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger;
+}
+
+function makeProxy<T extends object>(overrides: Partial<T> = {}): T {
+  const target = { ...overrides } as Record<PropertyKey, unknown>;
+  return new Proxy(target as T, {
+    get(obj, prop) {
+      if (prop in obj) return obj[prop];
+      const fn = vi.fn();
+      obj[prop] = fn;
+      return fn;
+    },
+  });
+}
+
+async function runDirectGuiRecreate(fixture: Fixture): Promise<void> {
+  Object.assign(fixture.persistence, {
+    listInAppPlanningSessions: vi.fn(() => []),
+  });
+  const logger = createLogger();
+  const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+  const taskRunner = makeProxy({
+    executeTasks: vi.fn(async () => undefined),
+    killActiveExecution: fixture.killActiveExecution,
+  });
+  const rendererTaskFeed = makeProxy({
+    listKnownTaskIds: vi.fn(() => []),
+    clearTaskSnapshots: vi.fn(),
+    replaceWorkflowRollups: vi.fn(),
+  });
+  const actions = makeProxy<GuiMutationTaskActions>({
+    submitWorkflowMutation: vi.fn(),
+    workflowIdForTaskArg: vi.fn((taskId: unknown) => fixture.orchestrator.getTask(String(taskId))?.config.workflowId),
+    workflowIdForTargetArg: vi.fn(() => fixture.upstreamWorkflowId),
+    workflowIdForRepairWorkflowPayload: vi.fn(),
+    performCancelTask: vi.fn(),
+    performDeleteTask: vi.fn(),
+    performCancelWorkflow: vi.fn(),
+    preemptTaskSubgraph: vi.fn(),
+    preemptWorkflowExecution: vi.fn(async (workflowId: string) => {
+      const result = await fixture.commandService.cancelWorkflow({
+        commandId: `outer-preempt-${workflowId}`,
+        source: 'ui',
+        scope: 'workflow',
+        idempotencyKey: `outer-preempt-${workflowId}`,
+        payload: { workflowId },
+      });
+      if (!result.ok) throw new Error(result.error.message);
+      return result.data;
+    }),
+  });
+  const ipcMain = {
+    handle: vi.fn(),
+    on: vi.fn(),
+  } as unknown as IpcMain;
+  const context = {
+    ipcMain,
+    app: { getVersion: () => 'test', isPackaged: false },
+    logger,
+    persistence: fixture.persistence,
+    messageBus: fixture.messageBus,
+    executorRegistry: { get: vi.fn(() => ({ getRepoPool: vi.fn(() => null) })) },
+    agentRegistry: {},
+    repoRoot: '/repo',
+    invokerConfig: {},
+    effectiveMaxConcurrency: 8,
+    taskHandles: new Map(),
+    getOrchestrator: () => fixture.orchestrator,
+    setOrchestrator: vi.fn(),
+    getCommandService: () => fixture.commandService,
+    setCommandService: vi.fn(),
+    getWorkflowMutationCoordinator: () => null,
+    workflowMutationDispatcher,
+    getActiveMutationContext: () => undefined,
+    getRendererTaskFeed: () => rendererTaskFeed,
+    getStartupWorkflowId: () => null,
+    getLaunchDispatcher: () => null,
+    requireTaskExecutor: () => taskRunner,
+    getTaskExecutor: () => taskRunner,
+    rebuildTaskRunner: vi.fn(),
+    initServices: vi.fn(async () => undefined),
+    requestWorkflowMetadataPublish: vi.fn(),
+    cancelDeferredWorkflowLaunch: vi.fn(),
+    killRunningTask: fixture.killActiveExecution,
+    buildCommandServiceInvalidationDeps: vi.fn(),
+    getMainWindow: () => null,
+    getOwnerMode: () => true,
+    getWorkerRuntimeController: () => null,
+    registrars: {
+      registerGuiMutationHandler: vi.fn(),
+      registerWorkflowScopedGuiMutationHandler: vi.fn(
+        (channel: string, _resolveWorkflowId: unknown, _priority: unknown, handler: (...args: unknown[]) => Promise<unknown>) => {
+          workflowMutationDispatcher.set(channel, handler);
+        },
+      ),
+    },
+    actions,
+    planningChatSessions: makeProxy({}),
+    planningCommandBuilder: makeProxy({}),
+    emitPlanningChatStream: vi.fn(),
+    taskGraphEventPublisher: makeProxy({}),
+    loadTaskByIdFromPersistence: vi.fn(),
+    markDaemonOwnerUnavailable: vi.fn(),
+    recordStartupDuration: vi.fn(),
+    getTaskDeltaStreamSequence: () => 0,
+    computeRuntimeStatus: vi.fn(() => ({})),
+    getUiPerfStats: vi.fn(() => ({})),
+    uiPerfStats: createRendererUiPerfCounters(),
+    createRegisteredWorkerRegistry: vi.fn(() => makeProxy({})),
+    buildCliInstallerContext: vi.fn(() => ({})),
+    resolveSetupCliPath: vi.fn(() => '/tmp/invoker'),
+    getBundledSkillsStatus: vi.fn(),
+    installPackagedSkills: vi.fn(),
+  } as unknown as RegisterGuiMutationIpcHandlersContext;
+
+  await registerGuiMutationIpcHandlers(context);
+  const recreate = workflowMutationDispatcher.get('invoker:recreate-workflow');
+  expect(recreate).toBeDefined();
+  await recreate!(fixture.upstreamWorkflowId);
+}
+
+async function runDelegatedHeadlessRecreate(fixture: Fixture): Promise<void> {
+  const taskRunner = makeProxy({
+    executeTasks: vi.fn(async () => undefined),
+    killActiveExecution: fixture.killActiveExecution,
+  });
+  const preemptWorkflowExecution = vi.fn(async (workflowId: string) => {
+    const result = await fixture.commandService.cancelWorkflow({
+      commandId: `delegated-preempt-${workflowId}`,
+      source: 'headless',
+      scope: 'workflow',
+      idempotencyKey: `delegated-preempt-${workflowId}`,
+      payload: { workflowId },
+    });
+    if (!result.ok) throw new Error(result.error.message);
+    return result.data;
+  });
+
+  await runHeadless(['recreate', fixture.upstreamWorkflowId], {
+    logger: createLogger(),
+    orchestrator: fixture.orchestrator,
+    persistence: fixture.persistence,
+    commandService: fixture.commandService,
+    executorRegistry: {} as never,
+    messageBus: fixture.messageBus,
+    repoRoot: '/repo',
+    invokerConfig: {},
+    initServices: vi.fn(async () => undefined),
+    noTrack: true,
+    preemptWorkflowExecution,
+    ownerTaskRunnerProvider: () => taskRunner,
+  } as unknown as HeadlessDeps);
+}
+
+describe('restart-class workflow mutations preserve downstream gates', () => {
+  it('keeps a downstream workflow pending and attached through direct GUI recreate', async () => {
+    const fixture = createGatedWorkflowFixture();
+
+    await runDirectGuiRecreate(fixture);
+
+    expectDownstreamPendingAndAttached(fixture);
+    expect(fixture.killActiveExecution).toHaveBeenCalledWith(fixture.upstreamTaskId);
+  });
+
+  it('keeps a downstream workflow pending and attached through delegated headless recreate', async () => {
+    const fixture = createGatedWorkflowFixture();
+
+    await runDelegatedHeadlessRecreate(fixture);
+
+    expectDownstreamPendingAndAttached(fixture);
+    expect(fixture.killActiveExecution).toHaveBeenCalledWith(fixture.upstreamTaskId);
+  });
+
+  it('still detaches dependents for explicit Cancel Workflow', async () => {
+    const fixture = createGatedWorkflowFixture();
+
+    const result = await fixture.commandService.cancelWorkflow({
+      commandId: 'explicit-cancel',
+      source: 'ui',
+      scope: 'workflow',
+      idempotencyKey: 'explicit-cancel',
+      payload: { workflowId: fixture.upstreamWorkflowId },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(fixture.persistence.loadWorkflow(fixture.downstreamWorkflowId)?.externalDependencies).toBeUndefined();
+  });
+});

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -43,7 +43,6 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
-import { preemptWorkflowBeforeMutation } from './workflow-preemption.js';
 import {
   type HeadlessDeps,
   BOLD,
@@ -55,7 +54,6 @@ import {
   restoreWorkflowForTaskUnlessDeleteAllWon,
   withRestoredTaskUnlessDeleteAllWon,
   preemptTaskSubgraph,
-  preemptWorkflowExecution,
 } from './headless-shared.js';
 import { parseStartReadyExcludeSelector, runStartReady } from './start-ready.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
@@ -752,12 +750,6 @@ export async function headlessResolveConflict(taskId: string, deps: HeadlessDeps
 export async function headlessRebaseRetry(target: string, deps: HeadlessDeps): Promise<void> {
   if (!target) throw new Error('Missing arguments. Usage: --headless rebase-retry <workflowId|mergeTaskId|taskId>');
   const workflowId = resolveHeadlessTargetWorkflowId(target, deps.persistence);
-  await preemptWorkflowBeforeMutation(workflowId, {
-    preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
-    logger: deps.logger,
-    context: 'headless.rebase-retry',
-    mutationTiming: deps.mutationTiming,
-  });
   const te = createHeadlessExecutor(deps);
   const started = await rebaseRetry(target, {
     ...deps,
@@ -796,12 +788,6 @@ export async function headlessRebaseRetry(target: string, deps: HeadlessDeps): P
 export async function headlessRebaseRecreate(workflowTarget: string, deps: HeadlessDeps): Promise<void> {
   if (!workflowTarget) throw new Error('Missing arguments. Usage: --headless rebase-recreate <workflowId|mergeTaskId|taskId>');
   const workflowId = resolveHeadlessTargetWorkflowId(workflowTarget, deps.persistence);
-  await preemptWorkflowBeforeMutation(workflowId, {
-    preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
-    logger: deps.logger,
-    context: 'headless.rebase-recreate',
-    mutationTiming: deps.mutationTiming,
-  });
   const te = createHeadlessExecutor(deps);
   const started = await rebaseRecreate(workflowTarget, {
     ...deps,
@@ -841,12 +827,6 @@ export async function headlessRecreateWorkflow(workflowId: string, deps: Headles
   if (!workflowId) {
     throw new Error('Missing arguments. Usage: --headless recreate <workflowId>');
   }
-  await preemptWorkflowBeforeMutation(workflowId, {
-    preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
-    logger: deps.logger,
-    context: 'headless.recreate-workflow',
-    mutationTiming: deps.mutationTiming,
-  });
   const recreateWfEnvelope = makeEnvelope('recreate-workflow', 'headless', 'workflow', { workflowId });
   const recreateWfResult = deps.mutationTiming
     ? await deps.mutationTiming.span(
@@ -1047,12 +1027,6 @@ export async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDe
   }
   deps.logger.info(`headlessRetryWorkflow begin workflow="${workflowId}" noTrack=${deps.noTrack ? 'true' : 'false'}`, {
     module: 'headless',
-  });
-  await preemptWorkflowBeforeMutation(workflowId, {
-    preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
-    logger: deps.logger,
-    context: 'headless.retry-workflow',
-    mutationTiming: deps.mutationTiming,
   });
   const envelope = makeEnvelope('retry-workflow', 'headless', 'workflow', { workflowId });
   const result = deps.mutationTiming

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -2052,12 +2052,6 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     cancelDeferredWorkflowLaunch(workflowId, 'ipc.recreate-workflow');
     logger.info(`recreate-workflow: "${workflowId}"`, { module: 'ipc' });
     try {
-      await preemptWorkflowBeforeMutation(workflowId, {
-        preemptWorkflowExecution,
-        logger,
-        context: 'ipc.recreate-workflow',
-        mutationTiming: activeMutationContext?.mutationTiming,
-      });
       const recreateWfEnvelope = makeEnvelope('recreate-workflow', 'ui', 'workflow', { workflowId });
       const recreateWfResult = activeMutationContext?.mutationTiming
         ? await activeMutationContext.mutationTiming.span(
@@ -2194,12 +2188,6 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     cancelDeferredWorkflowLaunch(workflowId, 'ipc.retry-workflow');
     logger.info(`retry-workflow: "${workflowId}"`, { module: 'ipc' });
     try {
-      await preemptWorkflowBeforeMutation(workflowId, {
-        preemptWorkflowExecution,
-        logger,
-        context: 'ipc.retry-workflow',
-        mutationTiming: activeMutationContext?.mutationTiming,
-      });
       const envelope = makeEnvelope('retry-workflow', 'ui', 'workflow', { workflowId });
       const result = activeMutationContext?.mutationTiming
         ? await activeMutationContext.mutationTiming.span(
@@ -2242,12 +2230,6 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     }
     logger.info(`rebase-retry: "${target}"`, { module: 'ipc' });
     try {
-      await preemptWorkflowBeforeMutation(workflowId, {
-        preemptWorkflowExecution,
-        logger,
-        context: 'ipc.rebase-retry',
-        mutationTiming: activeMutationContext?.mutationTiming,
-      });
       const started = await rebaseRetry(target, {
         logger,
         orchestrator,
@@ -2286,12 +2268,6 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     cancelDeferredWorkflowLaunch(workflowId, 'ipc.rebase-recreate');
     logger.info(`rebase-recreate: "${target}"`, { module: 'ipc' });
     try {
-      await preemptWorkflowBeforeMutation(workflowId, {
-        preemptWorkflowExecution,
-        logger,
-        context: 'ipc.rebase-recreate',
-        mutationTiming: activeMutationContext?.mutationTiming,
-      });
       const started = await rebaseRecreate(target, {
         logger,
         orchestrator,


### PR DESCRIPTION
## Summary

Restart actions entered an outer cancellation path before the application mutation service handled the same action.

That outer path detached downstream gates. Direct and headless entry points now defer cancellation to the application mutation service.

Explicit cancellation still detaches dependents. Restart actions preserve downstream gates and continue canceling active execution inside the application service.

## Review Claim

Direct and headless restart entry points leave downstream workflows gated until their upstream finishes while retaining cancel-first execution termination.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Explicit Cancel Workflow may still detach dependents. Restart-class mutations preserve active stack gates and retain cancel-first process termination through CommandService invalidation.

## Slice Rationale

Direct and headless entry points are the two application surfaces for the same restart policy, so they must change together.

## Non-goals

No changes to cancellation defaults, explicit cancel semantics, delete semantics, task-scoped mutations, workflow metadata schemas, scheduler policy, or unrelated cleanup.

## Architecture

### Before

Each direct or headless restart entry point canceled the workflow before CommandService ran its own non-detaching invalidation.

### After

Entry points call CommandService directly. Its invalidation performs cancel-first termination without detaching downstream gates, while explicit cancellation retains detach behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -t 'restart-class workflow mutations preserve downstream gates'`
  - `✓ src/__tests__/recreate-preserves-downstream-gates.test.ts (3 tests) 56ms`
  - `Test Files  1 passed | 203 skipped (204)`
  - `Tests  3 passed | 1979 skipped (1982)`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2a72a032a`
- Post-revert steps: Re-run the focused regression command above.
- Data migration? No

</details>
