### PR TITLE
[Jailbreak admin-bypass land](4b) docs: update helper header

### DIFF
--- a/scripts/cron-pr-lib.sh
+++ b/scripts/cron-pr-lib.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
-# Shared helpers for the two surviving PR-maintenance cron jobs that run
-# co-located with the Invoker owner:
-#
-#   scripts/cron-pr-admin-bypass-land.sh
-#   scripts/cron-pr-orphan-repair.sh
+# Shared helpers for PR-maintenance cron jobs that run co-located with the
+# Invoker owner.
 # Source this AFTER `set -euo pipefail`:
 #   source "$(dirname "$0")/cron-pr-lib.sh"
 #


### PR DESCRIPTION
## Summary

Updates the shared PR-maintenance helper header so it no longer undercounts the scripts that source it.

Keeps the comment accurate without maintaining another hard-coded caller list.

## Review Claim

The shared PR-maintenance helper header accurately describes its callers without changing shell behavior.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Comment-only change; executable shell content and runtime behavior remain unchanged.

## Slice Rationale

Repository-tooling commentary has a different review unit from architecture documentation, so the validator requires this separate slice.

## Non-goals

This does not change helper behavior, locking, configuration, logging, or any caller.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `! grep -q 'two surviving' scripts/cron-pr-lib.sh`
- [x] `git diff --check HEAD^...HEAD`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <landed-commit-sha>`
- Post-revert steps: None
- Data migration? No

</details>
