### PR TITLE
[CI regression: 48ee3e7-ui-vitest](1) Provision unzip for UI Vitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
           }
 
           missing_native_tools=()
-          for tool in make g++ python3; do
+          for tool in make g++ python3 unzip; do
             if ! command -v "$tool" >/dev/null 2>&1; then
               missing_native_tools+=("$tool")
             fi
@@ -187,19 +187,19 @@ jobs:
           fi
 
           if ! command -v apt-get >/dev/null 2>&1; then
-            echo "::error::UI Vitest requires libatomic1, make, g++, and python3, but apt-get is unavailable."
+            echo "::error::UI Vitest requires libatomic1, make, g++, python3, and unzip, but apt-get is unavailable."
             exit 1
           fi
 
           if [ "$(id -u)" -eq 0 ]; then
             apt-get update
-            apt-get install -y libatomic1 make g++ python3
+            apt-get install -y libatomic1 make g++ python3 unzip
             exit 0
           fi
 
           if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
             sudo -n apt-get update
-            sudo -n apt-get install -y libatomic1 make g++ python3
+            sudo -n apt-get install -y libatomic1 make g++ python3 unzip
             exit 0
           fi
 

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -126,9 +126,10 @@ assert(
 );
 const uiVitestSystemDependenciesScript = String(uiVitestSteps[uiVitestSystemDependenciesIndex]?.run ?? '');
 assert(
-  uiVitestSystemDependenciesScript.includes('apt-get install -y libatomic1 make g++ python3')
-    && uiVitestSystemDependenciesScript.includes('sudo -n apt-get install -y libatomic1 make g++ python3'),
-  'ui-vitest must install make, g++, and python3 so pnpm can build native dependencies',
+  uiVitestSystemDependenciesScript.includes('for tool in make g++ python3 unzip; do')
+    && uiVitestSystemDependenciesScript.includes('apt-get install -y libatomic1 make g++ python3 unzip')
+    && uiVitestSystemDependenciesScript.includes('sudo -n apt-get install -y libatomic1 make g++ python3 unzip'),
+  'ui-vitest must install the native build tools and unzip needed by Electron provisioning',
 );
 assert(
   uiVitestSystemDependenciesScript.includes('sudo -n true')


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=48ee3e72562d9e2e0f42d611b53647bb2dcc5b94; job=UI Vitest -->

CI job `UI Vitest` first failed on default-branch commit `48ee3e72562d9e2e0f42d611b53647bb2dcc5b94` in run 31910791177.

The runner lacked `unzip`, which Electron provisioning needs when dependency build scripts do not leave a usable binary.

This slice provisions `unzip` through both privileged installation paths and locks that requirement into the CI workflow policy test.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31910791177/job/95076244236

## Review Claim

The UI Vitest bootstrap now provides every system tool required by Electron provisioning, including `unzip`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged; only the UI Vitest runner dependency bootstrap and its matching policy assertion change.

## Slice Rationale

This is one CI policy slice: provision the missing tool and keep its deterministic workflow assertion beside the configuration change.

## Non-goals

- No product behavior changes.
- No UI test weakening or snapshot churn.
- No refactor of the repository's other system-dependency installation steps.
- No changes to other CI jobs.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [x] `pnpm --filter @invoker/ui test` — 93 files and 855 tests passed.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; this restores the previous UI Vitest runner bootstrap.
- Revert command: `git revert 7d2e8535b062b7ac9fb82a4e7c6c9d2488d113eb`
- Post-revert steps: Re-run `node scripts/test-ci-workflow-merge-queue-policy.mjs`.
- Data migration? No.

</details>
