### PR TITLE
[Fix misleading worker status fallback](1) Define snapshot freshness metadata

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -218,6 +218,7 @@ export type WorkerActionStatus =
 export type WorkerSource = 'built-in' | 'external';
 export type WorkerAvailability = 'available' | 'unknown';
 export type WorkerLogSource = 'worker_actions' | 'task_events';
+export type WorkerSnapshotAuthority = 'live' | 'cached' | 'unavailable';
 
 export interface WorkerLogEntry {
   id: string;
@@ -304,6 +305,9 @@ export interface WorkerStatusEntry {
 export interface WorkerStatusSnapshot {
   generatedAt: string;
   workers: WorkerStatusEntry[];
+  authority?: WorkerSnapshotAuthority;
+  lastSuccessfulAt?: string;
+  unavailableReason?: string;
 }
 
 export interface WorkerActionHistoryRequest {


### PR DESCRIPTION
## Summary

Worker status snapshots can now describe whether their values are live, cached, or unavailable.

All new fields are optional, so existing snapshot producers and consumers remain compatible.

## Review Claim

Add optional worker-snapshot freshness metadata without changing the meaning of existing snapshots.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Existing snapshots that contain only `generatedAt` and `workers` remain valid and keep their current meaning.

## Slice Rationale

Define the dormant data shape before any producer or screen begins using it.

## Non-goals

This slice does not change worker lifecycle values, worker control actions, request cadence, or screen behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/contracts build` — `DTS ⚡️ Build success in 803ms`
- [x] `pnpm run check:types` — exited 0

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3d9b7d991`
- Post-revert steps: None
- Data migration? No

</details>

