### PR TITLE
[Fix misleading worker status fallback](2a) Preserve owner snapshots across timeouts

### DIFF
--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -21,15 +21,36 @@ import {
 } from '@invoker/execution-engine';
 
 import type { WorkerActionRecord } from '@invoker/data-store';
+import type { WorkerStatusSnapshot } from '@invoker/contracts';
 import {
   autoStartedOwnerWorkerKinds,
   autoStartedOwnerWorkerKindsForConfig,
   createLocalWorkerStatusSnapshot,
+  createOwnerWorkerStatusReader,
   createWorkerRuntimeController,
   listWorkerActionHistory,
   listWorkerDecisions,
   toWorkerActionSummary,
 } from '../worker-control.js';
+
+function ownerSnapshot(
+  generatedAt: string,
+  lifecycles: Record<string, 'running' | 'stopped'>,
+): WorkerStatusSnapshot {
+  return {
+    generatedAt,
+    workers: Object.entries(lifecycles).map(([kind, lifecycle]) => ({
+      kind,
+      note: `${kind} worker`,
+      lifecycle,
+      policy: 'enabled',
+      autoStarts: lifecycle === 'running',
+      startable: lifecycle !== 'running',
+      stoppable: lifecycle === 'running',
+      recentActions: [],
+    })),
+  };
+}
 
 interface TestWorkerRuntime extends WorkerRuntime {
   forceExit: () => void;
@@ -617,6 +638,70 @@ describe('toWorkerActionSummary', () => {
     const act = toWorkerActionSummary(decisionRow({ id: 'a', status: 'queued', payload: {} }));
     expect(act.decision).toBe('act');
     expect(act.reason).toBeUndefined();
+  });
+});
+
+describe('createOwnerWorkerStatusReader', () => {
+  it('keeps the complete last owner snapshot stale through a timeout and replaces it on recovery', async () => {
+    const first = ownerSnapshot('2026-01-01T00:00:00.000Z', {
+      'pr-status': 'running',
+      autofix: 'stopped',
+    });
+    const recovered = ownerSnapshot('2026-01-01T00:02:00.000Z', {
+      'pr-status': 'stopped',
+      autofix: 'running',
+    });
+    const queryOwner = vi.fn()
+      .mockResolvedValueOnce(first)
+      .mockRejectedValueOnce(new Error('Owner request timed out'))
+      .mockResolvedValueOnce(recovered);
+    const now = vi.fn()
+      .mockReturnValueOnce('2026-01-01T00:00:01.000Z')
+      .mockReturnValueOnce('2026-01-01T00:02:01.000Z');
+    const read = createOwnerWorkerStatusReader({
+      queryOwner,
+      createUnavailableSnapshot: () => ownerSnapshot('2026-01-01T00:01:00.000Z', {
+        'pr-status': 'stopped',
+        autofix: 'stopped',
+      }),
+      now,
+    });
+
+    await expect(read()).resolves.toEqual({
+      ...first,
+      authority: 'live',
+      lastSuccessfulAt: '2026-01-01T00:00:01.000Z',
+    });
+    await expect(read()).resolves.toEqual({
+      ...first,
+      authority: 'cached',
+      lastSuccessfulAt: '2026-01-01T00:00:01.000Z',
+      unavailableReason: 'Owner request timed out',
+    });
+    await expect(read()).resolves.toEqual({
+      ...recovered,
+      authority: 'live',
+      lastSuccessfulAt: '2026-01-01T00:02:01.000Z',
+    });
+  });
+
+  it('marks the local fallback unavailable before any owner response succeeds', async () => {
+    const localGuess = ownerSnapshot('2026-01-01T00:00:00.000Z', {
+      'pr-status': 'stopped',
+      autofix: 'stopped',
+    });
+    const read = createOwnerWorkerStatusReader({
+      queryOwner: vi.fn().mockRejectedValue(new Error('Owner request timed out')),
+      createUnavailableSnapshot: () => localGuess,
+      now: () => '2026-01-01T00:00:01.000Z',
+    });
+
+    await expect(read()).resolves.toEqual({
+      generatedAt: localGuess.generatedAt,
+      workers: [],
+      authority: 'unavailable',
+      unavailableReason: 'Owner request timed out',
+    });
   });
 });
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -72,6 +72,7 @@ import type {
   Logger,
   StartReadyRequest,
   StartReadyResult,
+  WorkerStatusSnapshot,
 } from '@invoker/contracts';
 import { ConversationRepository, SqliteTaskRepository, hasLiveWritableOwner } from '@invoker/data-store';
 import type { SQLiteAdapter } from '@invoker/data-store';
@@ -221,6 +222,7 @@ import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 import {
   autoStartedOwnerWorkerKindsForConfig,
   createLocalWorkerStatusSnapshot,
+  createOwnerWorkerStatusReader,
   createWorkerRuntimeController,
   type WorkerRuntimeController,
 } from './worker-control.js';
@@ -3362,30 +3364,36 @@ startMainProcessBootstrap({
       planningTerminalState.restorePersistedPlanningTerminals();
     }
 
-    ipcMain.handle('invoker:get-workers', async () => {
-      if (!ownerMode) {
-        try {
-          return await messageBus.request('headless.query', { kind: 'workers' });
-        } catch (err) {
-          if (isMutationOwnerUnavailableError(err)) markDaemonOwnerUnavailable(err instanceof Error ? err.message : String(err));
-          logger.warn(
-            `get-workers owner delegation failed; falling back to local read-only snapshot: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-            { module: 'ipc' },
-          );
-        }
-        return createLocalWorkerStatusSnapshot({
-          registry: createRegisteredWorkerRegistry(),
-          persistence,
-          autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
-        });
-      }
-      return workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+    const createUnavailableWorkerStatusSnapshot = (): WorkerStatusSnapshot =>
+      createLocalWorkerStatusSnapshot({
         registry: createRegisteredWorkerRegistry(),
         persistence,
         autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
       });
+    const readOwnerWorkerStatus = createOwnerWorkerStatusReader({
+      queryOwner: () => messageBus.request<{ kind: 'workers' }, WorkerStatusSnapshot>(
+        'headless.query',
+        { kind: 'workers' },
+      ),
+      createUnavailableSnapshot: createUnavailableWorkerStatusSnapshot,
+      onUnavailable: (err) => {
+        if (isMutationOwnerUnavailableError(err)) {
+          markDaemonOwnerUnavailable(err instanceof Error ? err.message : String(err));
+        }
+        logger.warn(
+          `get-workers owner delegation failed; preserving last owner snapshot when available: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          { module: 'ipc' },
+        );
+      },
+    });
+
+    ipcMain.handle('invoker:get-workers', async () => {
+      if (!ownerMode) {
+        return readOwnerWorkerStatus();
+      }
+      return workerRuntimeController?.snapshot() ?? createUnavailableWorkerStatusSnapshot();
     });
 
     ipcMain.handle('invoker:get-activity-logs', (_event, sinceId?: number, limit?: number) => {

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -164,6 +164,58 @@ export interface WorkerRuntimeController {
   snapshot(): WorkerStatusSnapshot;
 }
 
+export function createOwnerWorkerStatusReader(options: {
+  queryOwner: () => Promise<WorkerStatusSnapshot>;
+  createUnavailableSnapshot: () => WorkerStatusSnapshot;
+  now?: () => string;
+  onUnavailable?: (error: unknown) => void;
+}): () => Promise<WorkerStatusSnapshot> {
+  let latestSuccessfulSnapshot: WorkerStatusSnapshot | null = null;
+  const now = options.now ?? (() => new Date().toISOString());
+
+  return async () => {
+    try {
+      const ownerSnapshot = await options.queryOwner();
+      const {
+        authority: _authority,
+        lastSuccessfulAt: _lastSuccessfulAt,
+        unavailableReason: _unavailableReason,
+        ...snapshot
+      } = ownerSnapshot;
+      const liveSnapshot: WorkerStatusSnapshot = {
+        ...snapshot,
+        authority: 'live',
+        lastSuccessfulAt: now(),
+      };
+      latestSuccessfulSnapshot = liveSnapshot;
+      return liveSnapshot;
+    } catch (error) {
+      options.onUnavailable?.(error);
+      const unavailableReason = error instanceof Error ? error.message : String(error);
+      if (latestSuccessfulSnapshot) {
+        return {
+          ...latestSuccessfulSnapshot,
+          authority: 'cached',
+          unavailableReason,
+        };
+      }
+      const {
+        authority: _authority,
+        lastSuccessfulAt: _lastSuccessfulAt,
+        unavailableReason: _unavailableReason,
+        workers: _workers,
+        ...snapshot
+      } = options.createUnavailableSnapshot();
+      return {
+        ...snapshot,
+        workers: [],
+        authority: 'unavailable',
+        unavailableReason,
+      };
+    }
+  };
+}
+
 type WorkerStatusPersistence = Pick<
   SQLiteAdapter,
   | 'listWorkerActions'

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -218,6 +218,7 @@ export type WorkerActionStatus =
 export type WorkerSource = 'built-in' | 'external';
 export type WorkerAvailability = 'available' | 'unknown';
 export type WorkerLogSource = 'worker_actions' | 'task_events';
+export type WorkerSnapshotAuthority = 'live' | 'cached' | 'unavailable';
 
 export interface WorkerLogEntry {
   id: string;
@@ -304,6 +305,9 @@ export interface WorkerStatusEntry {
 export interface WorkerStatusSnapshot {
   generatedAt: string;
   workers: WorkerStatusEntry[];
+  authority?: WorkerSnapshotAuthority;
+  lastSuccessfulAt?: string;
+  unavailableReason?: string;
 }
 
 export interface WorkerActionHistoryRequest {


### PR DESCRIPTION
## Summary

Worker status polling now remembers the last successful owner response.

If a later owner query times out, the app keeps showing that saved data instead of guessing workers stopped.

Before any successful response ever arrives, the app reports unavailable instead of stopped.

## Review Claim

Retain the last owner-derived worker snapshot across timeouts and label it not current, instead of letting a timeout masquerade as stopped workers.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Enabling or disabling one worker never changes the displayed state of unrelated workers, cached data is never presented as live, and only a successful owner response advances the saved snapshot.

## Slice Rationale

This is the app-layer half of the timeout fix: the saved-snapshot behavior and its direct test coverage in `packages/app`. The screen-level labeling of that saved data is a separate slice.

## Non-goals

This slice does not change worker start, stop, or restart behavior, polling frequency, retry configuration, persistence across app restarts, or how the Workers screen renders the data.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/worker-control.test.ts` — `Tests  32 passed (32)`
- [x] `pnpm run check:types` — exited 0

</details>

## Visual Proof

![Workers screen with this slice applied, "PR status" worker card showing State: Running](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260816-a7192b/worker-status-preserve-2a-workers-surface.png)

This slice only changes IPC data in `packages/app/src/main.ts` and `packages/app/src/worker-control.ts`; `WorkerActivityCard.tsx` is not part of this diff, so the Workers screen renders the same as it did on `master` for this steady-state case. This image confirms that render path is unaffected.

The actual condition this slice fixes — an owner response that succeeds once and then a later request that times out — only exists mid-session, and no Playwright fixture in this repo currently drives a real owner process into that timeout. That exact behavior is instead proven by the new regression cases in `packages/app/src/__tests__/worker-control.test.ts` listed in Test Plan above, which assert the saved values, stale flag, unavailable-before-first-success case, and recovery on the next owner response.

Manually inspected: the captured screen shows the "PR status" worker card with `State: Running`, a normal registry panel, and no stale or unavailable indicator, matching the untouched renderer at this commit.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 0977207ee`
- Post-revert steps: None
- Data migration? No

</details>
