### PR TITLE
[Verify CodeRabbit findings on PR #9309](2) Require explicit disk-full evidence

### DIFF
--- a/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
@@ -291,13 +291,7 @@ describe('infra-repair worker', () => {
     ]));
   });
 
-  it('classifies a disk-full ref-lock failure, reclaims remote disk space, and queues retry-task', async () => {
-    // Repro: a live SSH task failure captured 2026-08-16 on a remote pool
-    // member whose disk was at 100% (`df -h /` showed 0 bytes available).
-    // git's own worktree/branch setup fails with "cannot lock ref ... unable
-    // to create directory" because there is no free space to create the ref
-    // directory -- this text matched none of FailureClassifier's patterns
-    // before this fix, so infra-repair silently dropped the candidate.
+  it('classifies an explicit disk-full failure, reclaims remote disk space, and queues retry-task', async () => {
     const h = makeHarness([
       makeTask({
         execution: {
@@ -305,7 +299,8 @@ describe('infra-repair worker', () => {
             + "STDERR:\n"
             + "Preparing worktree (new branch 'experiment/wf-1/fix-ci-x/g0.t0.a-a1')\n"
             + "fatal: cannot lock ref 'refs/heads/experiment/wf-1/fix-ci-x/g0.t0.a-a1': "
-            + "unable to create directory for .git/refs/heads/experiment/wf-1/fix-ci-x/g0.t0.a-a1",
+            + "unable to create directory for .git/refs/heads/experiment/wf-1/fix-ci-x/g0.t0.a-a1\n"
+            + 'mkdir: No space left on device',
         },
       }),
     ]);

--- a/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
@@ -114,6 +114,14 @@ function makeHarness(
   const runRemoteProvisionRepairFn = vi.fn(async () => 'remote repair ok');
   const runRepoMirrorRepairFn = vi.fn(async () => 'mirror repair ok');
   const resolveRemoteBranchOwnerPathFn = vi.fn(async () => undefined as string | undefined);
+  const cleanupRemoteInvokerHomeFn = vi.fn(async () => ({
+    targetKey: 'ssh:remote-1 ~/.invoker',
+    ok: true as const,
+    reason: 'cleaned' as const,
+    detail: 'freed 21GB',
+    protectedSkipCount: 0,
+    protectedSkipBytes: 0,
+  }));
   let nowMs = Date.parse('2026-01-01T00:00:00.000Z');
   const tick = createInfraRepairTick({
     store,
@@ -134,6 +142,7 @@ function makeHarness(
     runRemoteProvisionRepairFn,
     runRepoMirrorRepairFn,
     resolveRemoteBranchOwnerPathFn,
+    cleanupRemoteInvokerHomeFn,
     now: () => nowMs,
   });
 
@@ -147,6 +156,7 @@ function makeHarness(
     runRemoteProvisionRepairFn,
     runRepoMirrorRepairFn,
     resolveRemoteBranchOwnerPathFn,
+    cleanupRemoteInvokerHomeFn,
     setNow: (nextNowMs: number) => { nowMs = nextNowMs; },
   };
 }
@@ -275,6 +285,53 @@ describe('infra-repair worker', () => {
         status: 'completed',
         payload: expect.objectContaining({
           infraReason: 'ssh-repo-mirror-corrupt',
+          channel: INFRA_REPAIR_RETRY_TASK_CHANNEL,
+        }),
+      }),
+    ]));
+  });
+
+  it('classifies a disk-full ref-lock failure, reclaims remote disk space, and queues retry-task', async () => {
+    // Repro: a live SSH task failure captured 2026-08-16 on a remote pool
+    // member whose disk was at 100% (`df -h /` showed 0 bytes available).
+    // git's own worktree/branch setup fails with "cannot lock ref ... unable
+    // to create directory" because there is no free space to create the ref
+    // directory -- this text matched none of FailureClassifier's patterns
+    // before this fix, so infra-repair silently dropped the candidate.
+    const h = makeHarness([
+      makeTask({
+        execution: {
+          error: "Error: Executor startup failed (ssh): SSH remote script failed (exit=255)\n"
+            + "STDERR:\n"
+            + "Preparing worktree (new branch 'experiment/wf-1/fix-ci-x/g0.t0.a-a1')\n"
+            + "fatal: cannot lock ref 'refs/heads/experiment/wf-1/fix-ci-x/g0.t0.a-a1': "
+            + "unable to create directory for .git/refs/heads/experiment/wf-1/fix-ci-x/g0.t0.a-a1",
+        },
+      }),
+    ]);
+
+    await h.tick(POLL_CTX);
+
+    expect(h.cleanupRemoteInvokerHomeFn).toHaveBeenCalledTimes(1);
+    expect(h.cleanupRemoteInvokerHomeFn).toHaveBeenCalledWith(expect.objectContaining({
+      target: expect.objectContaining({
+        name: 'remote-1',
+        connection: expect.objectContaining({ host: '203.0.113.10' }),
+      }),
+    }));
+    expect(h.runRepoMirrorRepairFn).not.toHaveBeenCalled();
+    expect(h.runRemoteProvisionRepairFn).not.toHaveBeenCalled();
+    expect(h.submit).toHaveBeenCalledTimes(1);
+    expect(h.submissions[0]?.channel).toBe(INFRA_REPAIR_RETRY_TASK_CHANNEL);
+    expect(parseInfraRepairRetryTaskMutationArgs(h.submissions[0]?.args ?? [])).toEqual({ taskId: 'wf-1/task-1' });
+    expect(workerActions(h.actions)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        workerKind: INFRA_REPAIR_WORKER_KIND,
+        actionType: 'repair-infra-failure',
+        taskId: 'wf-1/task-1',
+        status: 'completed',
+        payload: expect.objectContaining({
+          infraReason: 'ssh-disk-full',
           channel: INFRA_REPAIR_RETRY_TASK_CHANNEL,
         }),
       }),

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -27,6 +27,8 @@ import {
   execRemoteCapture,
   shellPosixSingleQuote,
 } from '../ssh-git-exec.js';
+import { cleanupRemoteInvokerHome, type DiskCleanupResult } from './disk-headroom-reclaim.js';
+import type { RemoteDiskTarget } from './disk-headroom-monitor.js';
 
 function buildPortableBase64DecodeFunction(functionName = 'invoker_base64_decode'): string {
   return `${functionName}() {
@@ -129,6 +131,7 @@ export interface InfraRepairWorkerPolicyOptions {
   resolveRemoteBranchOwnerPathFn?: typeof resolveRemoteBranchOwnerPath;
   runRemoteProvisionRepairFn?: typeof runRemoteProvisionRepair;
   runRepoMirrorRepairFn?: typeof runRepoMirrorRepair;
+  cleanupRemoteInvokerHomeFn?: (opts: { target: RemoteDiskTarget }) => Promise<DiskCleanupResult>;
 }
 
 export interface InfraRepairWorkerOptions {
@@ -652,6 +655,64 @@ async function handleRepoMirrorCorruptRecovery(
   );
 }
 
+async function handleDiskFullRecovery(
+  options: InfraRepairWorkerPolicyOptions,
+  candidate: ValidatedGenericSshInfraCandidate,
+): Promise<void> {
+  const remoteDiskTarget: RemoteDiskTarget = {
+    name: candidate.targetId,
+    connection: {
+      host: candidate.target.host,
+      user: candidate.target.user,
+      sshKeyPath: candidate.target.sshKeyPath,
+      port: candidate.target.port,
+    },
+    remotePath: candidate.target.remoteInvokerHome ?? '~/.invoker',
+  };
+
+  const repair = await runTargetRepairWithCooldown(options, {
+    targetKey: candidate.targetId,
+    reason: candidate.reason,
+    execute: async () => {
+      const result = await (options.cleanupRemoteInvokerHomeFn ?? cleanupRemoteInvokerHome)({
+        target: remoteDiskTarget,
+      });
+      if (!result.ok) {
+        throw new Error(`Disk cleanup ${result.reason} for ${result.targetKey}${result.detail ? `: ${result.detail}` : ''}`);
+      }
+      return result.detail ?? 'cleaned';
+    },
+  });
+
+  if (repair.kind === 'cooldown-skip') {
+    recordTaskDecision(options, candidate, candidate.reason, 'skipped', 'Skipped infra repair because target cooldown is active', {
+      targetId: candidate.targetId,
+      repairStatus: repair.action.status,
+    }, 'repair-cooldown');
+    return;
+  }
+  if (repair.kind === 'failed') {
+    recordTaskDecision(options, candidate, candidate.reason, 'failed', `Infra repair failed: ${firstLine(repair.errorMessage) ?? 'unknown error'}`, {
+      targetId: candidate.targetId,
+      error: repair.errorMessage,
+    }, 'repair-failed');
+    return;
+  }
+
+  await submitFollowUpMutation(
+    options,
+    candidate,
+    candidate.reason,
+    INFRA_REPAIR_RETRY_TASK_CHANNEL,
+    buildInfraRepairRetryTaskMutationArgs(candidate.taskId),
+    {
+      targetId: candidate.targetId,
+      reusedRecentRepair: repair.kind === 'reused-success',
+    },
+    'Queued retry-task after reclaiming disk space on the remote target',
+  );
+}
+
 async function handleMissingWorktreeRecovery(
   options: InfraRepairWorkerPolicyOptions,
   candidate: ValidatedGenericSshInfraCandidate,
@@ -818,6 +879,10 @@ async function handleValidatedGenericSshInfraCandidate(
   }
   if (candidate.reason === 'ssh-oauth-session-expired') {
     await handleOauthSessionExpiredRecovery(options, candidate);
+    return;
+  }
+  if (candidate.reason === 'ssh-disk-full') {
+    await handleDiskFullRecovery(options, candidate);
     return;
   }
   await handleInvalidReferenceRecovery(options, candidate);

--- a/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
+++ b/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { PR_6976_OAUTH_SESSION_EXPIRED_ERROR } from '../../../execution-engine/src/__tests__/fixtures/pr-6976-oauth-session-expired.js';
 import { FailureClassifier, SSH_INFRA_FAILURE_CLASSES } from '../failure-classifier.js';
 
+const GIT_REF_PATH_CONFLICT_ERROR =
+  "fatal: cannot lock ref 'refs/heads/experiment/child': "
+  + 'unable to create directory for .git/refs/heads/experiment/child';
+
 describe('FailureClassifier.classifyError', () => {
   it('classifies the env.sh invalid-export signature', () => {
     expect(FailureClassifier.classifyError(
@@ -37,17 +41,14 @@ describe('FailureClassifier.classifyError', () => {
       .toBe('ssh-oauth-session-expired');
   });
 
-  it('classifies the disk-full ref-lock signature (real error captured 2026-08-16 from a live SSH task failure on a 100%-full remote disk)', () => {
-    expect(FailureClassifier.classifyError(
-      "Error: Executor startup failed (ssh): SSH remote script failed (exit=255)\n"
-      + "STDERR:\n"
-      + "Preparing worktree (new branch 'experiment/wf-1786843012160-2/fix-ci-cd07355-fleet-cd07355-14-jobs/g0.t0.a-a0c172096-f593013d')\n"
-      + "fatal: cannot lock ref 'refs/heads/experiment/wf-1786843012160-2/fix-ci-cd07355-fleet-cd07355-14-jobs/g0.t0.a-a0c172096-f593013d': "
-      + "unable to create directory for .git/refs/heads/experiment/wf-1786843012160-2/fix-ci-cd07355-fleet-cd07355-14-jobs/g0.t0.a-a0c172096-f593013d",
-    )).toBe('ssh-disk-full');
+  it('classifies an explicit disk-full signature', () => {
     expect(FailureClassifier.classifyError(
       'No space left on device',
     )).toBe('ssh-disk-full');
+  });
+
+  it('does not classify a non-ENOSPC Git ref-path conflict as disk-full', () => {
+    expect(FailureClassifier.classifyError(GIT_REF_PATH_CONFLICT_ERROR)).toBeUndefined();
   });
 
   it('does not classify a bare "not a git repository" outside the bootstrap-clone phase', () => {

--- a/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
+++ b/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
@@ -37,6 +37,19 @@ describe('FailureClassifier.classifyError', () => {
       .toBe('ssh-oauth-session-expired');
   });
 
+  it('classifies the disk-full ref-lock signature (real error captured 2026-08-16 from a live SSH task failure on a 100%-full remote disk)', () => {
+    expect(FailureClassifier.classifyError(
+      "Error: Executor startup failed (ssh): SSH remote script failed (exit=255)\n"
+      + "STDERR:\n"
+      + "Preparing worktree (new branch 'experiment/wf-1786843012160-2/fix-ci-cd07355-fleet-cd07355-14-jobs/g0.t0.a-a0c172096-f593013d')\n"
+      + "fatal: cannot lock ref 'refs/heads/experiment/wf-1786843012160-2/fix-ci-cd07355-fleet-cd07355-14-jobs/g0.t0.a-a0c172096-f593013d': "
+      + "unable to create directory for .git/refs/heads/experiment/wf-1786843012160-2/fix-ci-cd07355-fleet-cd07355-14-jobs/g0.t0.a-a0c172096-f593013d",
+    )).toBe('ssh-disk-full');
+    expect(FailureClassifier.classifyError(
+      'No space left on device',
+    )).toBe('ssh-disk-full');
+  });
+
   it('does not classify a bare "not a git repository" outside the bootstrap-clone phase', () => {
     expect(FailureClassifier.classifyError(
       'fatal: not a git repository (or any of the parent directories): .git',

--- a/packages/workflow-graph/src/failure-classifier.ts
+++ b/packages/workflow-graph/src/failure-classifier.ts
@@ -53,10 +53,7 @@ export class FailureClassifier {
     if (errorText.includes('Failed to authenticate: OAuth session expired and could not be refreshed')) {
       return 'ssh-oauth-session-expired';
     }
-    if (
-      (errorText.includes('cannot lock ref') && errorText.includes('unable to create directory'))
-      || errorText.includes('No space left on device')
-    ) {
+    if (errorText.includes('No space left on device')) {
       return 'ssh-disk-full';
     }
     return undefined;

--- a/packages/workflow-graph/src/failure-classifier.ts
+++ b/packages/workflow-graph/src/failure-classifier.ts
@@ -20,6 +20,7 @@ export const SSH_INFRA_FAILURE_CLASSES: readonly SshInfraFailureClass[] = [
   'ssh-invalid-reference',
   'ssh-repo-mirror-corrupt',
   'ssh-oauth-session-expired',
+  'ssh-disk-full',
 ];
 
 export class FailureClassifier {
@@ -51,6 +52,12 @@ export class FailureClassifier {
     }
     if (errorText.includes('Failed to authenticate: OAuth session expired and could not be refreshed')) {
       return 'ssh-oauth-session-expired';
+    }
+    if (
+      (errorText.includes('cannot lock ref') && errorText.includes('unable to create directory'))
+      || errorText.includes('No space left on device')
+    ) {
+      return 'ssh-disk-full';
     }
     return undefined;
   }

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -198,7 +198,8 @@ export type SshInfraFailureClass =
   | 'ssh-worktree-missing'
   | 'ssh-invalid-reference'
   | 'ssh-repo-mirror-corrupt'
-  | 'ssh-oauth-session-expired';
+  | 'ssh-oauth-session-expired'
+  | 'ssh-disk-full';
 
 export type FailureClass = 'liveness_stall' | SshInfraFailureClass;
 


### PR DESCRIPTION
## Summary

The disk-full classifier previously accepted a generic Git ref-lock directory error. It now requires explicit ENOSPC evidence.

## Workflow Summary

Verify CodeRabbit findings on PR #9309 — 1 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1786847882151-19/verify-coderabbit-pr-9309 | Fetch CodeRabbit's inline review comments on PR #9309 (Neko-Catpital-Labs/Invoker), independently verify each against the actual code at the flagged location, and post one summary verdict comment on the PR. | completed |

</details>

<details>
<summary>File changes per task</summary>

### wf-1786847882151-19/verify-coderabbit-pr-9309 — Fetch CodeRabbit's inline review comments on PR #9309 (Neko-Catpital-Labs/Invoker), independently verify each against the actual code at the flagged location, and post one summary verdict comment on the PR.

</details>

## Review Claim

Narrow the disk-full route to SSH errors containing explicit `No space left on device` evidence.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The repair worker and existing failure classes remain unchanged; this slice only narrows when the new disk-full route can activate.

## Slice Rationale

This follow-up isolates CodeRabbit's routing concern from the underlying recovery behavior introduced in the preceding slice.

## Non-goals

This slice does not change remote cleanup, cooldown handling, retry submission, task scheduling, or any non-disk failure route.

## Architecture

### Before

A generic Git ref-lock directory error could select disk cleanup without an explicit disk-full signal.

### After

Only errors containing `No space left on device` select the disk-full repair route; the generic ref-lock signature remains unclassified.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --dir packages/workflow-graph test -- src/__tests__/failure-classifier.test.ts`
  - 8 test files passed; 116 tests passed.
- [x] `pnpm --dir packages/execution-engine test -- src/__tests__/infra-repair-worker.test.ts`
  - 1 test file passed; 20 tests passed.
- [x] `pnpm exec tsc -p tsconfig.typecheck.json --noEmit`
  - Completed successfully.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? No; reverting restores the overly broad classification rejected by this slice.
- Revert command: `git revert 0ea8601fbedc857c98ffc3a46fb9c4896eb380c4`
- Post-revert steps: Re-run the focused classifier and worker tests, then reassess the restored routing risk.
- Data migration? No

</details>
