### PR TITLE
[Fix misleading worker status fallback](2b) Label cached and unavailable worker status

### DIFF
--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -21,15 +21,36 @@ import {
 } from '@invoker/execution-engine';
 
 import type { WorkerActionRecord } from '@invoker/data-store';
+import type { WorkerStatusSnapshot } from '@invoker/contracts';
 import {
   autoStartedOwnerWorkerKinds,
   autoStartedOwnerWorkerKindsForConfig,
   createLocalWorkerStatusSnapshot,
+  createOwnerWorkerStatusReader,
   createWorkerRuntimeController,
   listWorkerActionHistory,
   listWorkerDecisions,
   toWorkerActionSummary,
 } from '../worker-control.js';
+
+function ownerSnapshot(
+  generatedAt: string,
+  lifecycles: Record<string, 'running' | 'stopped'>,
+): WorkerStatusSnapshot {
+  return {
+    generatedAt,
+    workers: Object.entries(lifecycles).map(([kind, lifecycle]) => ({
+      kind,
+      note: `${kind} worker`,
+      lifecycle,
+      policy: 'enabled',
+      autoStarts: lifecycle === 'running',
+      startable: lifecycle !== 'running',
+      stoppable: lifecycle === 'running',
+      recentActions: [],
+    })),
+  };
+}
 
 interface TestWorkerRuntime extends WorkerRuntime {
   forceExit: () => void;
@@ -617,6 +638,70 @@ describe('toWorkerActionSummary', () => {
     const act = toWorkerActionSummary(decisionRow({ id: 'a', status: 'queued', payload: {} }));
     expect(act.decision).toBe('act');
     expect(act.reason).toBeUndefined();
+  });
+});
+
+describe('createOwnerWorkerStatusReader', () => {
+  it('keeps the complete last owner snapshot stale through a timeout and replaces it on recovery', async () => {
+    const first = ownerSnapshot('2026-01-01T00:00:00.000Z', {
+      'pr-status': 'running',
+      autofix: 'stopped',
+    });
+    const recovered = ownerSnapshot('2026-01-01T00:02:00.000Z', {
+      'pr-status': 'stopped',
+      autofix: 'running',
+    });
+    const queryOwner = vi.fn()
+      .mockResolvedValueOnce(first)
+      .mockRejectedValueOnce(new Error('Owner request timed out'))
+      .mockResolvedValueOnce(recovered);
+    const now = vi.fn()
+      .mockReturnValueOnce('2026-01-01T00:00:01.000Z')
+      .mockReturnValueOnce('2026-01-01T00:02:01.000Z');
+    const read = createOwnerWorkerStatusReader({
+      queryOwner,
+      createUnavailableSnapshot: () => ownerSnapshot('2026-01-01T00:01:00.000Z', {
+        'pr-status': 'stopped',
+        autofix: 'stopped',
+      }),
+      now,
+    });
+
+    await expect(read()).resolves.toEqual({
+      ...first,
+      authority: 'live',
+      lastSuccessfulAt: '2026-01-01T00:00:01.000Z',
+    });
+    await expect(read()).resolves.toEqual({
+      ...first,
+      authority: 'cached',
+      lastSuccessfulAt: '2026-01-01T00:00:01.000Z',
+      unavailableReason: 'Owner request timed out',
+    });
+    await expect(read()).resolves.toEqual({
+      ...recovered,
+      authority: 'live',
+      lastSuccessfulAt: '2026-01-01T00:02:01.000Z',
+    });
+  });
+
+  it('marks the local fallback unavailable before any owner response succeeds', async () => {
+    const localGuess = ownerSnapshot('2026-01-01T00:00:00.000Z', {
+      'pr-status': 'stopped',
+      autofix: 'stopped',
+    });
+    const read = createOwnerWorkerStatusReader({
+      queryOwner: vi.fn().mockRejectedValue(new Error('Owner request timed out')),
+      createUnavailableSnapshot: () => localGuess,
+      now: () => '2026-01-01T00:00:01.000Z',
+    });
+
+    await expect(read()).resolves.toEqual({
+      generatedAt: localGuess.generatedAt,
+      workers: [],
+      authority: 'unavailable',
+      unavailableReason: 'Owner request timed out',
+    });
   });
 });
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -72,6 +72,7 @@ import type {
   Logger,
   StartReadyRequest,
   StartReadyResult,
+  WorkerStatusSnapshot,
 } from '@invoker/contracts';
 import { ConversationRepository, SqliteTaskRepository, hasLiveWritableOwner } from '@invoker/data-store';
 import type { SQLiteAdapter } from '@invoker/data-store';
@@ -221,6 +222,7 @@ import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 import {
   autoStartedOwnerWorkerKindsForConfig,
   createLocalWorkerStatusSnapshot,
+  createOwnerWorkerStatusReader,
   createWorkerRuntimeController,
   type WorkerRuntimeController,
 } from './worker-control.js';
@@ -3362,30 +3364,36 @@ startMainProcessBootstrap({
       planningTerminalState.restorePersistedPlanningTerminals();
     }
 
-    ipcMain.handle('invoker:get-workers', async () => {
-      if (!ownerMode) {
-        try {
-          return await messageBus.request('headless.query', { kind: 'workers' });
-        } catch (err) {
-          if (isMutationOwnerUnavailableError(err)) markDaemonOwnerUnavailable(err instanceof Error ? err.message : String(err));
-          logger.warn(
-            `get-workers owner delegation failed; falling back to local read-only snapshot: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-            { module: 'ipc' },
-          );
-        }
-        return createLocalWorkerStatusSnapshot({
-          registry: createRegisteredWorkerRegistry(),
-          persistence,
-          autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
-        });
-      }
-      return workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+    const createUnavailableWorkerStatusSnapshot = (): WorkerStatusSnapshot =>
+      createLocalWorkerStatusSnapshot({
         registry: createRegisteredWorkerRegistry(),
         persistence,
         autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
       });
+    const readOwnerWorkerStatus = createOwnerWorkerStatusReader({
+      queryOwner: () => messageBus.request<{ kind: 'workers' }, WorkerStatusSnapshot>(
+        'headless.query',
+        { kind: 'workers' },
+      ),
+      createUnavailableSnapshot: createUnavailableWorkerStatusSnapshot,
+      onUnavailable: (err) => {
+        if (isMutationOwnerUnavailableError(err)) {
+          markDaemonOwnerUnavailable(err instanceof Error ? err.message : String(err));
+        }
+        logger.warn(
+          `get-workers owner delegation failed; preserving last owner snapshot when available: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          { module: 'ipc' },
+        );
+      },
+    });
+
+    ipcMain.handle('invoker:get-workers', async () => {
+      if (!ownerMode) {
+        return readOwnerWorkerStatus();
+      }
+      return workerRuntimeController?.snapshot() ?? createUnavailableWorkerStatusSnapshot();
     });
 
     ipcMain.handle('invoker:get-activity-logs', (_event, sinceId?: number, limit?: number) => {

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -164,6 +164,58 @@ export interface WorkerRuntimeController {
   snapshot(): WorkerStatusSnapshot;
 }
 
+export function createOwnerWorkerStatusReader(options: {
+  queryOwner: () => Promise<WorkerStatusSnapshot>;
+  createUnavailableSnapshot: () => WorkerStatusSnapshot;
+  now?: () => string;
+  onUnavailable?: (error: unknown) => void;
+}): () => Promise<WorkerStatusSnapshot> {
+  let latestSuccessfulSnapshot: WorkerStatusSnapshot | null = null;
+  const now = options.now ?? (() => new Date().toISOString());
+
+  return async () => {
+    try {
+      const ownerSnapshot = await options.queryOwner();
+      const {
+        authority: _authority,
+        lastSuccessfulAt: _lastSuccessfulAt,
+        unavailableReason: _unavailableReason,
+        ...snapshot
+      } = ownerSnapshot;
+      const liveSnapshot: WorkerStatusSnapshot = {
+        ...snapshot,
+        authority: 'live',
+        lastSuccessfulAt: now(),
+      };
+      latestSuccessfulSnapshot = liveSnapshot;
+      return liveSnapshot;
+    } catch (error) {
+      options.onUnavailable?.(error);
+      const unavailableReason = error instanceof Error ? error.message : String(error);
+      if (latestSuccessfulSnapshot) {
+        return {
+          ...latestSuccessfulSnapshot,
+          authority: 'cached',
+          unavailableReason,
+        };
+      }
+      const {
+        authority: _authority,
+        lastSuccessfulAt: _lastSuccessfulAt,
+        unavailableReason: _unavailableReason,
+        workers: _workers,
+        ...snapshot
+      } = options.createUnavailableSnapshot();
+      return {
+        ...snapshot,
+        workers: [],
+        authority: 'unavailable',
+        unavailableReason,
+      };
+    }
+  };
+}
+
 type WorkerStatusPersistence = Pick<
   SQLiteAdapter,
   | 'listWorkerActions'

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -218,6 +218,7 @@ export type WorkerActionStatus =
 export type WorkerSource = 'built-in' | 'external';
 export type WorkerAvailability = 'available' | 'unknown';
 export type WorkerLogSource = 'worker_actions' | 'task_events';
+export type WorkerSnapshotAuthority = 'live' | 'cached' | 'unavailable';
 
 export interface WorkerLogEntry {
   id: string;
@@ -304,6 +305,9 @@ export interface WorkerStatusEntry {
 export interface WorkerStatusSnapshot {
   generatedAt: string;
   workers: WorkerStatusEntry[];
+  authority?: WorkerSnapshotAuthority;
+  lastSuccessfulAt?: string;
+  unavailableReason?: string;
 }
 
 export interface WorkerActionHistoryRequest {

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -10,7 +10,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act, cleanup, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
-import type { WorkflowMeta } from '../types.js';
+import type { WorkerStatusSnapshot, WorkflowMeta } from '../types.js';
+import { WorkerActivityCard } from '../components/WorkerActivityCard.js';
 
 vi.mock('@xyflow/react', async () => {
   // Dynamic import is required because Vitest hoists mock factories before test imports.
@@ -20,6 +21,28 @@ vi.mock('@xyflow/react', async () => {
 
 // Dynamic import is required so App sees the hoisted @xyflow/react mock.
 const { App } = await import('../App.js');
+
+function workerSnapshot(
+  authority: WorkerStatusSnapshot['authority'],
+  lifecycles: Record<string, 'running' | 'stopped'>,
+  extras: Partial<WorkerStatusSnapshot> = {},
+): WorkerStatusSnapshot {
+  return {
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    authority,
+    workers: Object.entries(lifecycles).map(([kind, lifecycle]) => ({
+      kind,
+      note: `${kind} worker`,
+      lifecycle,
+      policy: 'enabled',
+      autoStarts: lifecycle === 'running',
+      startable: lifecycle !== 'running',
+      stoppable: lifecycle === 'running',
+      recentActions: [],
+    })),
+    ...extras,
+  };
+}
 
 describe('App launch (component)', () => {
   let mock: MockInvoker;
@@ -154,6 +177,60 @@ describe('App launch (component)', () => {
 
     await waitFor(() => expect(mock.api.stopWorker).toHaveBeenCalledWith('pr-status'));
     expect(mock.api.startWorker).not.toHaveBeenCalled();
+  });
+
+  it('labels saved owner values during a timeout and clears the warning on recovery', () => {
+    const props = {
+      selectedWorkerKind: null,
+      onSelectWorker: vi.fn(),
+      showControls: false,
+    };
+    const live = workerSnapshot('live', {
+      'pr-status': 'running',
+      autofix: 'stopped',
+    }, { lastSuccessfulAt: '2026-01-01T00:00:01.000Z' });
+    const { rerender } = render(<WorkerActivityCard snapshot={live} {...props} />);
+
+    expect(screen.queryByTestId('worker-snapshot-freshness')).not.toBeInTheDocument();
+    expect(screen.getByTestId('worker-lifecycle-pr-status')).toHaveAttribute('data-lifecycle', 'running');
+    expect(screen.getByTestId('worker-lifecycle-autofix')).toHaveAttribute('data-lifecycle', 'stopped');
+
+    rerender(<WorkerActivityCard snapshot={{
+      ...live,
+      authority: 'cached',
+      unavailableReason: 'Owner request timed out',
+    }} {...props} />);
+
+    expect(screen.getByTestId('worker-snapshot-freshness')).toHaveTextContent('Showing saved worker status');
+    expect(screen.getByTestId('worker-snapshot-freshness')).toHaveTextContent('Last owner response: 2026-01-01 00:00:01 UTC');
+    expect(screen.getByTestId('worker-snapshot-freshness')).toHaveTextContent('Owner request timed out');
+    expect(screen.getByTestId('worker-lifecycle-pr-status')).toHaveAttribute('data-lifecycle', 'running');
+    expect(screen.getByTestId('worker-lifecycle-autofix')).toHaveAttribute('data-lifecycle', 'stopped');
+
+    rerender(<WorkerActivityCard snapshot={workerSnapshot('live', {
+      'pr-status': 'stopped',
+      autofix: 'running',
+    }, { lastSuccessfulAt: '2026-01-01T00:02:01.000Z' })} {...props} />);
+
+    expect(screen.queryByTestId('worker-snapshot-freshness')).not.toBeInTheDocument();
+    expect(screen.getByTestId('worker-lifecycle-pr-status')).toHaveAttribute('data-lifecycle', 'stopped');
+    expect(screen.getByTestId('worker-lifecycle-autofix')).toHaveAttribute('data-lifecycle', 'running');
+  });
+
+  it('shows explicit unavailability instead of guessed stopped rows before the first owner response', () => {
+    render(<WorkerActivityCard
+      snapshot={workerSnapshot('unavailable', {
+        'pr-status': 'stopped',
+        autofix: 'stopped',
+      }, { unavailableReason: 'Owner request timed out' })}
+      selectedWorkerKind={null}
+      onSelectWorker={vi.fn()}
+      showControls={false}
+    />);
+
+    expect(screen.getByTestId('worker-snapshot-freshness')).toHaveTextContent('Worker status unavailable');
+    expect(screen.getByTestId('worker-snapshot-freshness')).toHaveTextContent('Owner request timed out');
+    expect(screen.queryByText('Process: Stopped')).not.toBeInTheDocument();
   });
   it('renders the Apple-like source list without manual plan loading', async () => {
     Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -47,6 +47,12 @@ function activityExplanation(worker: WorkerStatusEntry, lifecycle: string): stri
   return 'Worker disabled. Enable it to listen for work.';
 }
 
+function formatOwnerResponseTime(timestamp: string): string {
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime())) return timestamp;
+  return `${parsed.toISOString().slice(0, 19).replace('T', ' ')} UTC`;
+}
+
 export function WorkerActivityCard({
   snapshot,
   selectedWorkerKind,
@@ -97,13 +103,43 @@ export function WorkerActivityCard({
     });
   }, [snapshot, optimisticByKind]);
 
+  const freshnessNotice = snapshot?.authority === 'cached'
+    ? {
+        title: 'Showing saved worker status',
+        detail: snapshot.lastSuccessfulAt
+          ? `Owner is temporarily unavailable. Last owner response: ${formatOwnerResponseTime(snapshot.lastSuccessfulAt)}.`
+          : 'Owner is temporarily unavailable. Last owner response time is unavailable.',
+      }
+    : snapshot?.authority === 'unavailable'
+      ? {
+          title: 'Worker status unavailable',
+          detail: 'Invoker has not received worker status from the owner yet.',
+        }
+      : null;
+
   return (
     <div data-testid="worker-activity-card" className="flex min-h-0 flex-col">
       {!snapshot ? (
         <div className="rounded border border-border bg-card/60 px-3 py-2 text-sm text-muted-foreground">Worker status unavailable</div>
       ) : (
-        <div data-testid="worker-process-list" className="min-h-0 space-y-3">
-          {snapshot.workers.map((worker) => {
+        <>
+          {freshnessNotice ? (
+            <div
+              role="status"
+              aria-live="polite"
+              data-testid="worker-snapshot-freshness"
+              className="mb-3 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-100"
+            >
+              <div className="font-medium">{freshnessNotice.title}</div>
+              <div className="mt-0.5 text-xs text-amber-100/80">{freshnessNotice.detail}</div>
+              {snapshot.unavailableReason ? (
+                <div className="mt-1 text-xs text-amber-100/80">{snapshot.unavailableReason}</div>
+              ) : null}
+            </div>
+          ) : null}
+          {snapshot.authority === 'unavailable' ? null : (
+            <div data-testid="worker-process-list" className="min-h-0 space-y-3">
+              {snapshot.workers.map((worker) => {
             const copy = getWorkerDisplayCopy(worker.kind);
             const disabledTitle = readOnly ? 'Read-only window' : worker.controlDisabledReason;
             const lifecycle = optimisticByKind[worker.kind] ?? worker.lifecycle;
@@ -210,7 +246,9 @@ export function WorkerActivityCard({
               </div>
             );
           })}
-        </div>
+            </div>
+          )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

The Workers screen now exposes whether snapshot values are cached or unavailable.

Cached rows keep their last owner-reported lifecycles and include a timestamp.

Unavailable snapshots show a text notice instead of guessed rows.

## Review Claim

Expose cached and unavailable worker authority in accessible text while preserving last-known row values only for cached snapshots.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Presentation changes cannot alter worker controls, cached values are never labeled live, and unavailable snapshots never present guessed worker rows.

## Slice Rationale

Authority presentation and its directly affected component coverage define one Workers-screen behavior on top of the owner snapshot flow.

## Non-goals

Outside scope: worker lifecycle controls, owner request handling, request timing, persistence across app restarts, and unrelated layout.

## Architecture

### Before

```mermaid
graph LR
    A["Snapshot reaches Workers screen"] --> B["Render every worker row"]
```

### After

```mermaid
graph LR
    A["Snapshot reaches Workers screen"] --> B{"Authority state"}
    B -->|"live"| C["Render current rows"]
    B -->|"cached"| D["Render saved rows with text notice"]
    B -->|"unavailable"| E["Render unavailable notice without rows"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/app-launch.test.tsx` — `Tests  19 passed (19)`
- [x] `pnpm run check:types` — exited 0
- [x] `bash scripts/ui-visual-proof.sh capture-before --spec e2e/worker-status-authority-visual-proof.spec.ts --output-dir /tmp/invoker-worker-ui-proof` — `1 passed (6.9s)`
- [x] `bash scripts/ui-visual-proof.sh capture-after --spec e2e/worker-status-authority-visual-proof.spec.ts --output-dir /tmp/invoker-worker-ui-proof` — `1 passed (6.1s)`

</details>

## Visual Proof

![Before: unavailable owner data has no explanatory label](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260816-e3d54f/worker-status-authority-before.png)

![After: unavailable owner data has an explicit text notice and timeout reason](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260816-e3d54f/worker-status-authority-after.png)

[Animated before/after walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260816-3d8688/worker-status-authority-before-after.mp4)

Manually inspected: the before image shows only the plain `No workers found` empty state with no authority notice. The after image adds an amber `Worker status unavailable` box reporting "Owner request timed out" above the same empty state.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5b48b42e5`
- Post-revert steps: None
- Data migration? No

</details>

