### PR TITLE
Stop queue-only checks from starving a PR's real failing check

### DIFF
--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -414,7 +414,15 @@ def mergify_failed_check_actions(
     latest = pr.latest_mergify
     if not latest or latest.state != "dequeued" or latest.head_sha != pr.head_ref_oid:
         return ()
-    for name in latest.failing_checks:
+    # A queue-only check always resolves to a no-op repair (nothing to fix
+    # outside the queue -- see is_queue_only_required_check), so trying a
+    # genuinely repairable check first prevents a queue-only check earlier
+    # in Mergify's list from starving out the one failing check a repair
+    # could actually fix.
+    ordered_failing_checks = sorted(
+        latest.failing_checks, key=lambda name: is_queue_only_required_check(name)
+    )
+    for name in ordered_failing_checks:
         if name in suppressed:
             continue
         detail = f"Mergify queue check failed: {name}"

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -973,6 +973,35 @@ class InfraCrashDoesNotCountAgainstCap(PlannerTestCase):
         self.assertEqual(len(actions), 1)
         self.assertEqual((actions[0].kind, actions[0].key), ("repair_check", "build"))
 
+    def test_mergify_failed_check_actions_prioritizes_real_check_over_queue_only(self):
+        # Real incident: PR #9309 dequeued with six failing checks, five of
+        # them "required-fast /" queue-only matrix jobs that only run inside
+        # the merge queue (cancelled side effects of the sixth), plus one
+        # genuinely repairable check, UI Vitest. Queue-only checks always
+        # resolve to a no-op repair (nothing to fix outside the queue), so
+        # if the loop returns whichever failing check comes first in
+        # Mergify's list, it can pick a queue-only check forever and never
+        # reach the one check a repair could actually fix.
+        ledger = self._ledger()
+        snapshot = pr(
+            labels=frozenset({"admin-bypass"}),
+            latest_mergify=event(
+                state="dequeued",
+                failing=(
+                    "required-fast / Guardrails",
+                    "required-fast / Launch Dispatch Queue Repro",
+                    "required-fast / Merge Gate Concurrency Repro",
+                    "required-fast / Start Running MECE Repros",
+                    "required-fast / Submit Workflow Chain",
+                    "UI Vitest",
+                ),
+            ),
+        )
+        with unittest.mock.patch.object(p, "repair_task_crashed_on_infra", return_value=True):
+            actions = p.mergify_failed_check_actions(snapshot, ledger, max_repair_attempts=3, now=NOW)
+        self.assertEqual(len(actions), 1)
+        self.assertEqual((actions[0].kind, actions[0].key), ("repair_check", "UI Vitest"))
+
     def test_cap_still_applies_once_genuine_non_infra_attempts_reach_it(self):
         # Three genuinely-attempted (not infra-crashed) repairs plus one more
         # that crashed on infra: the cap must still fire on the three real


### PR DESCRIPTION
## Summary

The automated PR-repair worker checks a dequeued PR's failing checks and always tried to fix whichever one came first in the list. Some required checks only ever run inside the merge queue itself, so trying to fix one standalone always does nothing.

Tonight PR #9309 sat dequeued for over 90 minutes because two of those queue-only checks kept sorting ahead of `UI Vitest`, the one check that actually needed a real repair attempt. The worker kept re-trying the no-op check every 5 minutes and never got to the real one.

The fix tries genuinely repairable checks before queue-only ones, so a real failure is never starved out by one that can never resolve on its own.

## Review Claim

The reviewer is approving that `mergify_failed_check_actions` orders a dequeued PR's failing checks so a real, repairable check is always attempted before a queue-only one, proven against PR #9309's exact live failing-checks list.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the iteration order changes. A PR whose only failing checks are queue-only behaves exactly as before (the existing `test_queue_only_missing_head_check_repairs_from_mergify_failure` test still passes unchanged), so the existing no-op-then-requeue path for that case is untouched.

## Slice Rationale

One self-contained slice: a single ordering change in one function, proven with a repro built from a real live incident.

## Non-goals

Does not change how a queue-only check itself resolves, does not touch the requeue mechanism, does not change any other planner function.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 scripts/test_mergify_admin_requeue_plan.py`
- [ ] `python3 -m unittest discover -s scripts -p "test_mergify_admin_requeue*.py"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert 01ea3f4e33`
- Post-revert steps: None
- Data migration? No

</details>
