### PR TITLE
[CI regression: cd07355-fleet-cd07355-14-jobs](1) Provision unzip for Docker Electron repair

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1149,6 +1149,30 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
+      - name: Install Electron repair dependency
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v unzip >/dev/null 2>&1; then
+            exit 0
+          fi
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "::error::The Docker CI job requires unzip for Electron provisioning, but apt-get is unavailable."
+            exit 1
+          fi
+          if [ "$(id -u)" -eq 0 ]; then
+            apt-get update -qq
+            apt-get install -y unzip
+            exit 0
+          fi
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo -n apt-get update -qq
+            sudo -n apt-get install -y unzip
+            exit 0
+          fi
+          echo "::error::The Docker CI job requires unzip; run as root or provide passwordless sudo for apt-get."
+          exit 1
+
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -228,6 +228,15 @@ assert(
 
 assert(jobs.docker, 'Missing docker job');
 assert(jobs.docker.if === NON_PR_GATE, 'docker must not run on pull_request events');
+assertStepBefore(jobs.docker, 'Install Electron repair dependency', 'Install dependencies', 'docker');
+const dockerElectronRepairStep = jobs.docker.steps.find(
+  (step) => step.name === 'Install Electron repair dependency',
+);
+assert(
+  String(dockerElectronRepairStep?.run ?? '').includes('apt-get install -y unzip')
+    && String(dockerElectronRepairStep?.run ?? '').includes('sudo -n apt-get install -y unzip'),
+  'docker must provision unzip so the Electron repair fallback can complete during pnpm install',
+);
 
 assert(
   prBodyWorkflow.jobs.validate['runs-on'] === 'ubuntu-latest',


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=cd07355fe00361ce676b048a6c1be5696968fe2a; job=fleet -->

Fourteen CI jobs first failed together on default-branch push commit `cd07355fe00361ce676b048a6c1be5696968fe2a`.

The Docker job reached Electron provisioning without `unzip`, so dependency installation stopped before its intended checks ran.

This slice provisions `unzip` before dependency installation and asserts the workflow step order for root and passwordless-sudo runners.

<details>
<summary>Fleet member jobs</summary>

- [docker / comprehensive](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31917892808/job/95093153022)
- [e2e-proof / shard 3](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31917892808/job/95093153066)
- [playwright / 5-of-9](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31917892808/job/95093153130)
- [playwright / 6-of-9](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31917892808/job/95093153169)
- [playwright / 7-of-9](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31917892808/job/95093153141)
- [playwright / planning-chat-restore](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31917892808/job/95093153126)
- [required-fast / Guardrails](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31917892808/job/95093153098)
- [required-fast / Launch Dispatch Queue Repro](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31917892808/job/95093153104)
- [required-fast / Merge Gate Concurrency Repro](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31917892808/job/95093153095)
- [required-fast / Mergify Admin Requeue](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31917892808/job/95093153148)
- [required-fast / PR Babysit Harness](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31917892808/job/95093153103)
- [required-fast / Submit Workflow Chain](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31917892808/job/95093153021)
- [required-fast / Vitest Workspace](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31917892808/job/95093153011)
- [UI Vitest](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31917892808/job/95093041075)

</details>

## Review Claim

Approve provisioning `unzip` before Docker dependency installation so Electron repair can complete on minimal CI runners.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the Docker job bootstrap changes, and the new step exits immediately when `unzip` already exists. Product behavior and other CI jobs remain unchanged.

## Slice Rationale

The Docker workflow policy and its direct structural assertion form one reviewable CI bootstrap claim.

## Non-goals

- No product behavior changes.
- No runner-image, job-selection, or unrelated workflow changes.
- No weakened assertions or snapshot updates.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting restores the previous Docker bootstrap sequence.
- Revert command: `git revert 3598dfa011b94d0c1cb8c90ab9a3c40f400eddd4`
- Post-revert steps: Re-run the Test Plan command.
- Data migration? No.

</details>
