### PR TITLE
[CI regression: cd07355-fleet-cd07355-14-jobs](2) Require target-matched verification evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1149,6 +1149,30 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
+      - name: Install Electron repair dependency
+        shell: bash
+        run: |
+          set -euo pipefail
+          if command -v unzip >/dev/null 2>&1; then
+            exit 0
+          fi
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "::error::The Docker CI job requires unzip for Electron provisioning, but apt-get is unavailable."
+            exit 1
+          fi
+          if [ "$(id -u)" -eq 0 ]; then
+            apt-get update -qq
+            apt-get install -y unzip
+            exit 0
+          fi
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo -n apt-get update -qq
+            sudo -n apt-get install -y unzip
+            exit 0
+          fi
+          echo "::error::The Docker CI job requires unzip; run as root or provide passwordless sudo for apt-get."
+          exit 1
+
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -228,6 +228,15 @@ assert(
 
 assert(jobs.docker, 'Missing docker job');
 assert(jobs.docker.if === NON_PR_GATE, 'docker must not run on pull_request events');
+assertStepBefore(jobs.docker, 'Install Electron repair dependency', 'Install dependencies', 'docker');
+const dockerElectronRepairStep = jobs.docker.steps.find(
+  (step) => step.name === 'Install Electron repair dependency',
+);
+assert(
+  String(dockerElectronRepairStep?.run ?? '').includes('apt-get install -y unzip')
+    && String(dockerElectronRepairStep?.run ?? '').includes('sudo -n apt-get install -y unzip'),
+  'docker must provision unzip so the Electron repair fallback can complete during pnpm install',
+);
 
 assert(
   prBodyWorkflow.jobs.validate['runs-on'] === 'ubuntu-latest',

--- a/scripts/test-prove-it-skill.sh
+++ b/scripts/test-prove-it-skill.sh
@@ -48,6 +48,8 @@ must_contain "write \`UNVERIFIED:\` immediately before the claim" \
   "prove-it skill must require the UNVERIFIED prefix when evidence is missing"
 must_contain "Proxy proof:" \
   "prove-it skill must include a generalized proxy-proof example"
+must_contain "Wrong-target verify command:" \
+  "prove-it skill must require verify commands to invoke the changed file"
 must_contain "Stale state:" \
   "prove-it skill must include a generalized stale-state example"
 must_contain "Wrong target:" \

--- a/skills/prove-it/SKILL.md
+++ b/skills/prove-it/SKILL.md
@@ -43,6 +43,7 @@ When asked what happened, why it happened, or to investigate/diagnose/debug a pr
 ## Examples this rule is meant to stop
 
 - Proxy proof: do not cite "a test passed" when the reported failure was visual or behavioral and was never exercised.
+- Wrong-target verify command: do not treat an automated task template's default `verify_command`/"Acceptance criteria" as proof without checking it actually invokes the changed file. A fleet CI-repair chain filed `pnpm --filter @invoker/ui test` as its acceptance command for a fix that only touched `scripts/test-ci-workflow-merge-queue-policy.mjs` — a script wired only into the root `pnpm test` chain, never into the UI package's own test script (confirmed by running both: `pnpm --filter @invoker/ui test` never references the file, while `node scripts/test-ci-workflow-merge-queue-policy.mjs` does and passes). The picker had chosen the shortest verify command among several unrelated jobs bundled into one event, not the one covering the job actually diagnosed and fixed — so the recorded "Exit code: 0" most likely proved an unrelated, already-passing suite, not the fix.
 - Stale state: do not report an old merge, CI, task, or workflow status without a fresh live query.
 - Wrong target: do not reproduce against a sample, another branch, another PR, or another deployment unless you label the result as not the current target.
 - Broken repro: do not explain a failure from a repro that did not execute, did not fail, or failed for setup reasons.


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=cd07355fe00361ce676b048a6c1be5696968fe2a; job=fleet -->

Reflection found that the fleet repair's recorded UI test probe never invoked the workflow policy test changed by the repair.

The evidence skill now names this mismatch explicitly, and a focused skill check locks the instruction in place.

## Review Claim

Approve requiring fleet repair evidence to confirm that the selected verification probe invokes the changed file.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice changes only reviewer guidance and its focused check. Runtime behavior, workflow configuration, and the earlier Docker repair remain unchanged.

## Slice Rationale

The durable review rule follows the verified repair because it is a separate tooling-policy claim with no runtime effect.

## Non-goals

- No change to fleet probe choice.
- No product or CI workflow behavior changes.
- No unrelated skill edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-prove-it-skill.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting removes only the added guidance and its contract check.
- Revert command: `git revert 9a6474daed1856a334ab649ff35da3bbd8841cab`
- Post-revert steps: Re-run the Test Plan command.
- Data migration? No.

</details>

Depends-On: #9352
