### PR TITLE
[Flaky Suite Quarantine](1) Extend the registry and wire the do1 worker

### DIFF
--- a/scripts/daily-e2e-do-submit.sh
+++ b/scripts/daily-e2e-do-submit.sh
@@ -16,6 +16,11 @@
 # Test seams: INVOKER_DAILY_E2E_SKIP_BATTERY=1 skips the refresh+battery and
 # reuses a pre-seeded state file; INVOKER_DAILY_E2E_SUBMIT_CMD overrides the
 # submit binary; INVOKER_DAILY_E2E_DRY_RUN=1 logs intended submissions only.
+#
+# Suites quarantined via `node scripts/flaky-test-registry.mjs quarantine
+# <suite-relpath> --kind suite` are excluded from the battery entirely (they
+# never run and never get a state-file row), so no fix plan is ever filed for
+# them.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -33,6 +38,11 @@ RESUBMIT_GUARD_MIN="${INVOKER_DAILY_E2E_RESUBMIT_GUARD_MIN:-1200}"
 
 log() { printf '[daily-e2e-do %s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
 
+FLAKY_SUITE_EXCLUDE="$(node scripts/flaky-test-registry.mjs exclude-suites-env 2>/dev/null || true)"
+if [ -n "$FLAKY_SUITE_EXCLUDE" ]; then
+  log "excluding quarantined flaky suites: $FLAKY_SUITE_EXCLUDE"
+fi
+
 # 1. Refresh to latest master and rebuild the app (the extended battery's
 #    Playwright suite needs the built app), then run the battery.
 if [ "${INVOKER_DAILY_E2E_SKIP_BATTERY:-0}" != "1" ]; then
@@ -48,7 +58,8 @@ if [ "${INVOKER_DAILY_E2E_SKIP_BATTERY:-0}" != "1" ]; then
   mkdir -p "$(dirname "$STATE_FILE")"
   log "running extended e2e battery"
   set +e
-  env INVOKER_TEST_ALL_EXTENDED=1 INVOKER_TEST_ALL_STATE_FILE="$STATE_FILE" bash scripts/run-all-tests.sh
+  env INVOKER_TEST_ALL_EXTENDED=1 INVOKER_TEST_ALL_STATE_FILE="$STATE_FILE" \
+      INVOKER_TEST_ALL_EXCLUDE="$FLAKY_SUITE_EXCLUDE" bash scripts/run-all-tests.sh
   log "battery finished (exit $?)"
   set -e
 else

--- a/scripts/flaky-test-registry.mjs
+++ b/scripts/flaky-test-registry.mjs
@@ -1,8 +1,12 @@
 #!/usr/bin/env node
-// Checked-in registry of known-flaky test files, quarantined by file glob.
-// CI reads this via computeVitestExcludeArgs() to skip them without editing
-// test source; `node scripts/flaky-test-registry.mjs quarantine|restore|list`
-// is the manual entry point.
+// Checked-in registry of known-flaky quarantine targets. Each entry is either
+// a vitest test-file glob (kind: 'vitest-file', the default) or a
+// scripts/test-suites/**.sh relpath (kind: 'suite').
+// CI reads this via computeVitestExcludeArgs() to skip flaky vitest files
+// without editing test source; the do1 e2e worker reads it via
+// computeSuiteExcludeList() to skip flaky suite scripts. `node
+// scripts/flaky-test-registry.mjs quarantine|restore|list` is the manual
+// entry point.
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -12,30 +16,36 @@ const REPO_ROOT = dirname(dirname(__filename));
 
 export const REGISTRY_PATH = resolve(REPO_ROOT, 'scripts/flaky-test-registry.json');
 
+const VALID_KINDS = new Set(['vitest-file', 'suite']);
+
 export function readRegistry(registryText) {
   if (!registryText || !registryText.trim()) return {};
   const parsed = JSON.parse(registryText);
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-    throw new Error('flaky-test-registry.json must be a JSON object keyed by test-file glob.');
+    throw new Error('flaky-test-registry.json must be a JSON object keyed by quarantine target.');
   }
   return parsed;
 }
 
-export function quarantineInRegistry(registry, testGlob, { reason, source, now }) {
-  if (!testGlob || !testGlob.trim()) {
-    throw new Error('A test-file glob is required to quarantine.');
+export function quarantineInRegistry(registry, target, { reason, source, now, kind }) {
+  if (!target || !target.trim()) {
+    throw new Error('A quarantine target (test-file glob or suite path) is required.');
+  }
+  const resolvedKind = kind ?? 'vitest-file';
+  if (!VALID_KINDS.has(resolvedKind)) {
+    throw new Error(`Unknown kind "${resolvedKind}". Use "vitest-file" or "suite".`);
   }
   return {
     ...registry,
-    [testGlob]: { reason: reason || 'unspecified', source: source || 'manual', quarantinedAt: now },
+    [target]: { reason: reason || 'unspecified', source: source || 'manual', quarantinedAt: now, kind: resolvedKind },
   };
 }
 
-export function restoreInRegistry(registry, testGlob) {
-  if (!(testGlob in registry)) {
-    throw new Error(`"${testGlob}" is not currently quarantined.`);
+export function restoreInRegistry(registry, target) {
+  if (!(target in registry)) {
+    throw new Error(`"${target}" is not currently quarantined.`);
   }
-  const { [testGlob]: _removed, ...rest } = registry;
+  const { [target]: _removed, ...rest } = registry;
   return rest;
 }
 
@@ -43,9 +53,23 @@ export function restoreInRegistry(registry, testGlob) {
  * vitest's CLI `--exclude <glob>` is additive to (not a replacement of) its
  * own default excludes (node_modules, dist, etc.), so this only ever adds
  * exclusions on top of the normal run -- never widens what already runs.
+ * Suite-kind entries are never vitest globs, so they are filtered out here.
  */
 export function computeVitestExcludeArgs(registry) {
-  return Object.keys(registry).flatMap((testGlob) => ['--exclude', testGlob]);
+  return Object.entries(registry)
+    .filter(([, entry]) => (entry.kind ?? 'vitest-file') === 'vitest-file')
+    .flatMap(([testGlob]) => ['--exclude', testGlob]);
+}
+
+/**
+ * Suite-kind entries as a list of scripts/test-suites/**.sh relpaths, ready
+ * to join into run-all-tests.sh's INVOKER_TEST_ALL_EXCLUDE (comma or
+ * space separated).
+ */
+export function computeSuiteExcludeList(registry) {
+  return Object.entries(registry)
+    .filter(([, entry]) => entry.kind === 'suite')
+    .map(([suitePath]) => suitePath);
 }
 
 function readRegistryFile() {
@@ -58,7 +82,7 @@ function writeRegistryFile(registry) {
 }
 
 function main(argv) {
-  const [command, testGlob, ...rest] = argv;
+  const [command, target, ...rest] = argv;
   if (command === 'list') {
     process.stdout.write(`${JSON.stringify(readRegistryFile(), null, 2)}\n`);
     return;
@@ -67,9 +91,13 @@ function main(argv) {
     process.stdout.write(`${computeVitestExcludeArgs(readRegistryFile()).join(' ')}\n`);
     return;
   }
-  if (!command || !testGlob) {
+  if (command === 'exclude-suites-env') {
+    process.stdout.write(`${computeSuiteExcludeList(readRegistryFile()).join(',')}\n`);
+    return;
+  }
+  if (!command || !target) {
     process.stderr.write(
-      'Usage: node scripts/flaky-test-registry.mjs <quarantine|restore|list|exclude-args> "<test file glob>" [--reason "..."] [--source auto|manual]\n',
+      'Usage: node scripts/flaky-test-registry.mjs <quarantine|restore|list|exclude-args|exclude-suites-env> "<test file glob or suite path>" [--reason "..."] [--source auto|manual] [--kind vitest-file|suite]\n',
     );
     process.exit(1);
   }
@@ -77,23 +105,26 @@ function main(argv) {
   const reason = reasonIndex !== -1 ? rest[reasonIndex + 1] : undefined;
   const sourceIndex = rest.indexOf('--source');
   const source = sourceIndex !== -1 ? rest[sourceIndex + 1] : undefined;
+  const kindIndex = rest.indexOf('--kind');
+  const kind = kindIndex !== -1 ? rest[kindIndex + 1] : undefined;
 
   if (command === 'quarantine') {
-    const registry = quarantineInRegistry(readRegistryFile(), testGlob, {
+    const registry = quarantineInRegistry(readRegistryFile(), target, {
       reason,
       source,
+      kind,
       now: new Date().toISOString(),
     });
     writeRegistryFile(registry);
-    process.stdout.write(`Quarantined "${testGlob}": ${reason || 'unspecified'}\n`);
+    process.stdout.write(`Quarantined "${target}": ${reason || 'unspecified'}\n`);
     return;
   }
   if (command === 'restore') {
-    writeRegistryFile(restoreInRegistry(readRegistryFile(), testGlob));
-    process.stdout.write(`Restored "${testGlob}".\n`);
+    writeRegistryFile(restoreInRegistry(readRegistryFile(), target));
+    process.stdout.write(`Restored "${target}".\n`);
     return;
   }
-  throw new Error(`Unknown command "${command}". Use quarantine, restore, list, or exclude-args.`);
+  throw new Error(`Unknown command "${command}". Use quarantine, restore, list, exclude-args, or exclude-suites-env.`);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/test-daily-e2e-do-submit.sh
+++ b/scripts/test-daily-e2e-do-submit.sh
@@ -8,6 +8,8 @@
 #      a valid single-task plan with onFinish: pull_request.
 #   B. Real run: submits exactly once for the failing suite and records a marker.
 #   C. Resubmit guard: a fresh marker makes the suite skip (no submit).
+#   D. Flaky-suite quarantine: a suite-kind registry entry is logged as
+#      excluded before the battery would run.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -17,8 +19,22 @@ WORKER="$REPO_ROOT/scripts/daily-e2e-do-submit.sh"
 FAIL_REL="required/20-e2e-dry-run.sh"
 FAIL_SLUG="20-e2e-dry-run"
 
+# D uses the real, checked-in registry file (the worker always resolves it
+# relative to REPO_ROOT) -- save and restore its exact bytes rather than
+# pointing it at a scratch path, matching flaky-test-registry.mjs's own test
+# convention.
+FLAKY_REGISTRY="$REPO_ROOT/scripts/flaky-test-registry.json"
+FLAKY_REGISTRY_BACKUP="$(mktemp "${TMPDIR:-/tmp}/flaky-test-registry-backup.XXXXXX")"
+cp "$FLAKY_REGISTRY" "$FLAKY_REGISTRY_BACKUP"
+
 SANDBOXES=()
-cleanup() { local d; for d in ${SANDBOXES[@]+"${SANDBOXES[@]}"}; do rm -rf "$d"; done; return 0; }
+cleanup() {
+  local d
+  for d in ${SANDBOXES[@]+"${SANDBOXES[@]}"}; do rm -rf "$d"; done
+  cp "$FLAKY_REGISTRY_BACKUP" "$FLAKY_REGISTRY"
+  rm -f "$FLAKY_REGISTRY_BACKUP"
+  return 0
+}
 trap cleanup EXIT
 
 fail() { echo "FAIL: $1" >&2; [ -n "${2:-}" ] && { echo "----- log -----" >&2; cat "$2" >&2; }; exit 1; }
@@ -107,5 +123,21 @@ grep -q "submitted within" "$sb/worker2.log" \
 grep -q "skipped=1" "$sb/worker2.log" || fail "C: summary should report skipped=1" "$sb/worker2.log"
 echo "  C ok: resubmit guard skips a recently submitted suite"
 
-echo "PASS: daily-e2e-do-submit.sh behavior verified (dry-run, submit, resubmit-guard)"
+# ── D. Flaky-suite quarantine: logged as excluded before the battery ──────────
+# This proves the worker computes and logs the exclude value from the real
+# registry -- not that run-all-tests.sh itself honors INVOKER_TEST_ALL_EXCLUDE
+# end-to-end. That exclusion mechanism is pre-existing and already relied on
+# by other callers; re-proving it here would mean running the real (and
+# destructive: git reset --hard / git clean -fd) battery path, which this
+# harness deliberately never does (see run_worker's INVOKER_DAILY_E2E_SKIP_BATTERY=1).
+node scripts/flaky-test-registry.mjs quarantine "optional/99-test-only.sh" \
+  --kind suite --reason "test: case D" >/dev/null
+export INVOKER_DAILY_E2E_DRY_RUN=1
+run_worker
+grep -q "excluding quarantined flaky suites: optional/99-test-only.sh" "$log" \
+  || fail "D: worker did not log the quarantined suite exclusion" "$log"
+cp "$FLAKY_REGISTRY_BACKUP" "$FLAKY_REGISTRY"
+echo "  D ok: a quarantined suite is logged as excluded before the battery runs"
+
+echo "PASS: daily-e2e-do-submit.sh behavior verified (dry-run, submit, resubmit-guard, flaky-suite quarantine)"
 exit 0

--- a/scripts/test-flaky-test-registry.mjs
+++ b/scripts/test-flaky-test-registry.mjs
@@ -8,6 +8,7 @@ import {
   quarantineInRegistry,
   restoreInRegistry,
   computeVitestExcludeArgs,
+  computeSuiteExcludeList,
 } from './flaky-test-registry.mjs';
 
 // readRegistry
@@ -31,14 +32,24 @@ import {
     now: '2026-08-16T00:00:00Z',
   });
   assert.deepEqual(quarantined, {
-    'packages/ui/src/flaky.test.ts': { reason: 'timing race', source: 'manual', quarantinedAt: '2026-08-16T00:00:00Z' },
-  });
+    'packages/ui/src/flaky.test.ts': {
+      reason: 'timing race',
+      source: 'manual',
+      quarantinedAt: '2026-08-16T00:00:00Z',
+      kind: 'vitest-file',
+    },
+  }, 'kind defaults to vitest-file when omitted');
   assert.deepEqual(empty, {}, 'quarantineInRegistry must not mutate its input');
 
   const restored = restoreInRegistry(quarantined, 'packages/ui/src/flaky.test.ts');
   assert.deepEqual(restored, {}, 'restoring the only entry empties the registry');
   assert.deepEqual(quarantined, {
-    'packages/ui/src/flaky.test.ts': { reason: 'timing race', source: 'manual', quarantinedAt: '2026-08-16T00:00:00Z' },
+    'packages/ui/src/flaky.test.ts': {
+      reason: 'timing race',
+      source: 'manual',
+      quarantinedAt: '2026-08-16T00:00:00Z',
+      kind: 'vitest-file',
+    },
   }, 'restoreInRegistry must not mutate its input');
 
   assert.throws(
@@ -48,21 +59,61 @@ import {
   );
   assert.throws(
     () => quarantineInRegistry({}, '', { now: '2026-08-16T00:00:00Z' }),
-    /test-file glob is required/,
-    'an empty glob is rejected',
+    /A quarantine target .* is required/,
+    'an empty target is rejected',
+  );
+
+  const suiteQuarantined = quarantineInRegistry({}, 'optional/40-playwright-app.sh', {
+    reason: 'batch-only flake',
+    source: 'manual',
+    now: '2026-08-16T00:00:00Z',
+    kind: 'suite',
+  });
+  assert.deepEqual(suiteQuarantined, {
+    'optional/40-playwright-app.sh': {
+      reason: 'batch-only flake',
+      source: 'manual',
+      quarantinedAt: '2026-08-16T00:00:00Z',
+      kind: 'suite',
+    },
+  }, 'kind: suite is stored as given');
+
+  assert.throws(
+    () => quarantineInRegistry({}, 'x.test.ts', { now: '2026-08-16T00:00:00Z', kind: 'bogus' }),
+    /Unknown kind "bogus"/,
+    'an invalid kind is rejected',
   );
 }
 
-// computeVitestExcludeArgs
+// computeVitestExcludeArgs / computeSuiteExcludeList
 {
   assert.deepEqual(computeVitestExcludeArgs({}), [], 'an empty registry produces no exclude args');
   assert.deepEqual(
     computeVitestExcludeArgs({
       'packages/ui/src/a.test.ts': { reason: 'r1' },
-      'packages/ui/src/b.test.ts': { reason: 'r2' },
+      'packages/ui/src/b.test.ts': { reason: 'r2', kind: 'vitest-file' },
     }),
     ['--exclude', 'packages/ui/src/a.test.ts', '--exclude', 'packages/ui/src/b.test.ts'],
-    'one --exclude pair per quarantined glob, in registry order',
+    'one --exclude pair per quarantined vitest-file glob, in registry order (kind omitted or explicit)',
+  );
+  assert.deepEqual(
+    computeVitestExcludeArgs({
+      'packages/ui/src/a.test.ts': { reason: 'r1' },
+      'optional/40-playwright-app.sh': { reason: 'r2', kind: 'suite' },
+    }),
+    ['--exclude', 'packages/ui/src/a.test.ts'],
+    'suite-kind entries never leak into vitest exclude args',
+  );
+
+  assert.deepEqual(computeSuiteExcludeList({}), [], 'an empty registry produces no suite excludes');
+  assert.deepEqual(
+    computeSuiteExcludeList({
+      'packages/ui/src/a.test.ts': { reason: 'r1', kind: 'vitest-file' },
+      'optional/40-playwright-app.sh': { reason: 'r2', kind: 'suite' },
+      'required/18-start-running-mece-repros.sh': { reason: 'r3', kind: 'suite' },
+    }),
+    ['optional/40-playwright-app.sh', 'required/18-start-running-mece-repros.sh'],
+    'only suite-kind entries are returned, vitest-file entries are excluded',
   );
 }
 
@@ -104,6 +155,28 @@ import {
 
     const afterRestore = run(['exclude-args']);
     assert.equal(afterRestore.stdout.trim(), '', 'no excludes remain after restoring the only entry');
+
+    const quarantineSuite = run([
+      'quarantine', 'optional/99-test-only.sh', '--reason', 'batch-only flake', '--kind', 'suite',
+    ]);
+    assert.equal(quarantineSuite.exitCode, 0);
+    assert.match(quarantineSuite.stdout, /Quarantined "optional\/99-test-only\.sh"/);
+
+    const suiteExcludeEnv = run(['exclude-suites-env']);
+    assert.equal(suiteExcludeEnv.stdout.trim(), 'optional/99-test-only.sh');
+
+    const excludeArgsWithSuite = run(['exclude-args']);
+    assert.equal(
+      excludeArgsWithSuite.stdout.trim(),
+      '',
+      'a suite-kind entry must never appear in vitest exclude-args',
+    );
+
+    const restoreSuite = run(['restore', 'optional/99-test-only.sh']);
+    assert.equal(restoreSuite.exitCode, 0);
+
+    const afterRestoreSuite = run(['exclude-suites-env']);
+    assert.equal(afterRestoreSuite.stdout.trim(), '', 'no suite excludes remain after restoring the only entry');
   } finally {
     writeFileSync(realRegistryPath, original);
   }


### PR DESCRIPTION
## Summary

The do1 twice-daily e2e worker used to file an automatic "fix this" PR for every failing suite, even a suite that is known to just be flaky.

PR #9369 added a registry for quarantining flaky vitest test files, but it had no concept of a shell suite script, which is what the do1 worker runs.

This extends that same registry with a `kind` field (`vitest-file` or `suite`).

The do1 worker now leaves any suite marked `kind: suite` out of its battery entirely, so it never files a fix plan for something that was never actually broken.

## Review Claim

The reviewer is approving the `kind`-aware extension to the flaky-test registry and the small change in the do1 worker script that leaves quarantined suites out of its battery, proven end-to-end against the real registry file and the worker's own behavior harness.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The registry starts empty (unchanged from #9369), so this ships with zero behavior change today. `computeVitestExcludeArgs` now filters to `kind: vitest-file` entries only, so a suite-kind entry can never leak into the ui-vitest CI job's exclude flags. Suite exclusion only ever narrows what `run-all-tests.sh` runs (additive, never widens); it has no effect on the real CI merge-queue gate, since `required-fast` runs suite scripts directly and never goes through `run-all-tests.sh`'s exclusion path.

## Slice Rationale

One self-contained slice: the registry's `kind` extension, the one worker wired to consume it, and both test files updated together, proven with a real quarantine/exclude/restore cycle against the actual registry file.

## Non-goals

- No automatic flaky-detection; entries are still added manually.
- No tier restriction on quarantine targets (any suite path, including `required/*`, is a legal target — it still cannot affect the CI merge-queue gate).
- No change to the already-merged ui-vitest CI wiring itself.
- No change to `run-all-tests.sh`'s exclusion mechanism, which already existed and is reused as-is.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-flaky-test-registry.mjs`
- [x] `bash scripts/test-daily-e2e-do-submit.sh`
- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [x] Manual: quarantine `optional/40-playwright-app.sh` with `--kind suite`, confirm `exclude-suites-env` prints it and `exclude-args` stays empty, then `restore` and confirm `git diff` on the registry file is clean.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <merge-commit-sha>`.
- Post-revert steps: None.
- Data migration? No.

</details>
