### PR TITLE
Fix flaky-registry glob format and extend it to Vitest Workspace

### DIFF
--- a/scripts/flaky-test-registry.mjs
+++ b/scripts/flaky-test-registry.mjs
@@ -27,6 +27,15 @@ export function readRegistry(registryText) {
   return parsed;
 }
 
+// vitest resolves --exclude relative to each package's own directory (the
+// cwd it runs in, whether invoked via `pnpm --filter <pkg> test` or `pnpm -r
+// test`), never the repo root. A repo-root-relative glob like
+// "packages/ui/src/foo.test.ts" silently matches nothing and quarantines
+// nothing -- confirmed live: it left the target test running. Requiring a
+// double-star wildcard prefix on vitest-file targets keeps every such entry
+// package-relative-safe by construction instead of relying on whoever adds
+// an entry to remember this. Suite targets are shell script relpaths, not
+// vitest globs, so the requirement does not apply to them.
 export function quarantineInRegistry(registry, target, { reason, source, now, kind }) {
   if (!target || !target.trim()) {
     throw new Error('A quarantine target (test-file glob or suite path) is required.');
@@ -34,6 +43,11 @@ export function quarantineInRegistry(registry, target, { reason, source, now, ki
   const resolvedKind = kind ?? 'vitest-file';
   if (!VALID_KINDS.has(resolvedKind)) {
     throw new Error(`Unknown kind "${resolvedKind}". Use "vitest-file" or "suite".`);
+  }
+  if (resolvedKind === 'vitest-file' && !target.startsWith('**/')) {
+    throw new Error(
+      `Test-file glob "${target}" must start with "**/" so it matches regardless of which package vitest runs from (e.g. "**/src/__tests__/foo.test.ts").`,
+    );
   }
   return {
     ...registry,

--- a/scripts/test-flaky-test-registry.mjs
+++ b/scripts/test-flaky-test-registry.mjs
@@ -26,13 +26,13 @@ import {
 // quarantineInRegistry / restoreInRegistry
 {
   const empty = {};
-  const quarantined = quarantineInRegistry(empty, 'packages/ui/src/flaky.test.ts', {
+  const quarantined = quarantineInRegistry(empty, '**/src/__tests__/flaky.test.ts', {
     reason: 'timing race',
     source: 'manual',
     now: '2026-08-16T00:00:00Z',
   });
   assert.deepEqual(quarantined, {
-    'packages/ui/src/flaky.test.ts': {
+    '**/src/__tests__/flaky.test.ts': {
       reason: 'timing race',
       source: 'manual',
       quarantinedAt: '2026-08-16T00:00:00Z',
@@ -41,10 +41,10 @@ import {
   }, 'kind defaults to vitest-file when omitted');
   assert.deepEqual(empty, {}, 'quarantineInRegistry must not mutate its input');
 
-  const restored = restoreInRegistry(quarantined, 'packages/ui/src/flaky.test.ts');
+  const restored = restoreInRegistry(quarantined, '**/src/__tests__/flaky.test.ts');
   assert.deepEqual(restored, {}, 'restoring the only entry empties the registry');
   assert.deepEqual(quarantined, {
-    'packages/ui/src/flaky.test.ts': {
+    '**/src/__tests__/flaky.test.ts': {
       reason: 'timing race',
       source: 'manual',
       quarantinedAt: '2026-08-16T00:00:00Z',
@@ -83,6 +83,18 @@ import {
     /Unknown kind "bogus"/,
     'an invalid kind is rejected',
   );
+
+  // Reproduces a real bug: vitest resolves --exclude relative to each
+  // package's own cwd, not the repo root, so a repo-root-relative glob
+  // silently excludes nothing. Confirmed live before this guard existed:
+  // `pnpm --filter @invoker/ui test -- --exclude "packages/ui/src/__tests__/task-panel-error.test.tsx"`
+  // still ran that file. The guard rejects that shape at write time instead
+  // of letting it ship as a no-op quarantine entry.
+  assert.throws(
+    () => quarantineInRegistry({}, 'packages/ui/src/__tests__/flaky.test.ts', { now: '2026-08-16T00:00:00Z' }),
+    /must start with "\*\*\/"/,
+    'a repo-root-relative glob (no wildcard prefix) is rejected, not silently accepted as a no-op',
+  );
 }
 
 // computeVitestExcludeArgs / computeSuiteExcludeList
@@ -90,25 +102,25 @@ import {
   assert.deepEqual(computeVitestExcludeArgs({}), [], 'an empty registry produces no exclude args');
   assert.deepEqual(
     computeVitestExcludeArgs({
-      'packages/ui/src/a.test.ts': { reason: 'r1' },
-      'packages/ui/src/b.test.ts': { reason: 'r2', kind: 'vitest-file' },
+      '**/src/__tests__/a.test.ts': { reason: 'r1' },
+      '**/src/__tests__/b.test.ts': { reason: 'r2', kind: 'vitest-file' },
     }),
-    ['--exclude', 'packages/ui/src/a.test.ts', '--exclude', 'packages/ui/src/b.test.ts'],
+    ['--exclude', '**/src/__tests__/a.test.ts', '--exclude', '**/src/__tests__/b.test.ts'],
     'one --exclude pair per quarantined vitest-file glob, in registry order (kind omitted or explicit)',
   );
   assert.deepEqual(
     computeVitestExcludeArgs({
-      'packages/ui/src/a.test.ts': { reason: 'r1' },
+      '**/src/__tests__/a.test.ts': { reason: 'r1' },
       'optional/40-playwright-app.sh': { reason: 'r2', kind: 'suite' },
     }),
-    ['--exclude', 'packages/ui/src/a.test.ts'],
+    ['--exclude', '**/src/__tests__/a.test.ts'],
     'suite-kind entries never leak into vitest exclude args',
   );
 
   assert.deepEqual(computeSuiteExcludeList({}), [], 'an empty registry produces no suite excludes');
   assert.deepEqual(
     computeSuiteExcludeList({
-      'packages/ui/src/a.test.ts': { reason: 'r1', kind: 'vitest-file' },
+      '**/src/__tests__/a.test.ts': { reason: 'r1', kind: 'vitest-file' },
       'optional/40-playwright-app.sh': { reason: 'r2', kind: 'suite' },
       'required/18-start-running-mece-repros.sh': { reason: 'r3', kind: 'suite' },
     }),
@@ -138,20 +150,20 @@ import {
   const realRegistryPath = join(import.meta.dirname, 'flaky-test-registry.json');
   const original = readFileSync(realRegistryPath, 'utf8');
   try {
-    const quarantine = run(['quarantine', 'packages/ui/src/scratch.test.ts', '--reason', 'ci-only repro']);
+    const quarantine = run(['quarantine', '**/src/__tests__/scratch.test.ts', '--reason', 'ci-only repro']);
     assert.equal(quarantine.exitCode, 0);
-    assert.match(quarantine.stdout, /Quarantined "packages\/ui\/src\/scratch\.test\.ts"/);
+    assert.match(quarantine.stdout, /Quarantined "\*\*\/src\/__tests__\/scratch\.test\.ts"/);
 
     const list = run(['list']);
     const listed = JSON.parse(list.stdout);
-    assert.ok('packages/ui/src/scratch.test.ts' in listed, 'the quarantined glob shows up in list');
+    assert.ok('**/src/__tests__/scratch.test.ts' in listed, 'the quarantined glob shows up in list');
 
     const excludeArgs = run(['exclude-args']);
-    assert.equal(excludeArgs.stdout.trim(), '--exclude packages/ui/src/scratch.test.ts');
+    assert.equal(excludeArgs.stdout.trim(), '--exclude **/src/__tests__/scratch.test.ts');
 
-    const restore = run(['restore', 'packages/ui/src/scratch.test.ts']);
+    const restore = run(['restore', '**/src/__tests__/scratch.test.ts']);
     assert.equal(restore.exitCode, 0);
-    assert.match(restore.stdout, /Restored "packages\/ui\/src\/scratch\.test\.ts"/);
+    assert.match(restore.stdout, /Restored "\*\*\/src\/__tests__\/scratch\.test\.ts"/);
 
     const afterRestore = run(['exclude-args']);
     assert.equal(afterRestore.stdout.trim(), '', 'no excludes remain after restoring the only entry');

--- a/scripts/test-workspace-test-flaky-wiring.sh
+++ b/scripts/test-workspace-test-flaky-wiring.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Verifies workspace-test.sh's CI-only flaky-exclude wiring by stubbing pnpm
+# (recording its args) instead of running the real, slow workspace suite.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"; git checkout -- scripts/flaky-test-registry.json 2>/dev/null || true' EXIT
+
+cat > "$STUB_DIR/pnpm" <<'EOF'
+#!/usr/bin/env bash
+echo "pnpm-called: $*" >> "$PNPM_CALL_LOG"
+exit 0
+EOF
+chmod +x "$STUB_DIR/pnpm"
+
+CALL_LOG="$(mktemp)"
+
+run_with_stub() {
+  PATH="$STUB_DIR:$PATH" PNPM_CALL_LOG="$CALL_LOG" INVOKER_WORKSPACE_TEST_CONCURRENCY=1 "$@" bash scripts/workspace-test.sh >/dev/null
+}
+
+: > "$CALL_LOG"
+run_with_stub env
+if grep -q -- "--exclude" "$CALL_LOG"; then
+  echo "FAIL: local run (no CI env var) must not pass any --exclude args" >&2
+  cat "$CALL_LOG" >&2
+  exit 1
+fi
+echo "ok: local run passes no --exclude args"
+
+node scripts/flaky-test-registry.mjs quarantine "**/src/__tests__/task-panel-error.test.tsx" --reason "wiring test" --source manual
+: > "$CALL_LOG"
+run_with_stub env CI=1
+if ! grep -q -- "--exclude \*\*/src/__tests__/task-panel-error.test.tsx" "$CALL_LOG"; then
+  echo "FAIL: CI run must forward the quarantined glob as --exclude" >&2
+  cat "$CALL_LOG" >&2
+  exit 1
+fi
+echo "ok: CI run forwards the quarantined glob"
+node scripts/flaky-test-registry.mjs restore "**/src/__tests__/task-panel-error.test.tsx"
+
+: > "$CALL_LOG"
+run_with_stub env CI=1
+if grep -q -- "--exclude" "$CALL_LOG"; then
+  echo "FAIL: after restore, CI run must not pass any --exclude args" >&2
+  cat "$CALL_LOG" >&2
+  exit 1
+fi
+echo "ok: CI run passes no --exclude args once the registry is empty again"
+
+echo "OK: workspace-test.sh flaky-exclude wiring"

--- a/scripts/workspace-test.sh
+++ b/scripts/workspace-test.sh
@@ -18,7 +18,18 @@ if ! [[ "$CONCURRENCY" =~ ^[0-9]+$ ]] || [ "$CONCURRENCY" -lt 1 ]; then
   exit 2
 fi
 
+# CI-only: local `pnpm -r test` runs the full suite unchanged. vitest
+# resolves --exclude relative to the package it runs in either way, so the
+# same registry entries work whether this ran via `pnpm --filter <pkg> test`
+# (a single package) or `pnpm -r test` (every package) -- see
+# scripts/flaky-test-registry.mjs.
+FLAKY_EXCLUDE_ARGS=()
+if [ -n "${CI:-}" ]; then
+  # shellcheck disable=SC2207
+  FLAKY_EXCLUDE_ARGS=($(node "$ROOT/scripts/flaky-test-registry.mjs" exclude-args))
+fi
+
 echo "==> Running package workspace tests (concurrency=$CONCURRENCY)"
-env -u INVOKER_HEADLESS_STANDALONE pnpm -r --workspace-concurrency="$CONCURRENCY" test
+env -u INVOKER_HEADLESS_STANDALONE pnpm -r --workspace-concurrency="$CONCURRENCY" test -- "${FLAKY_EXCLUDE_ARGS[@]}"
 echo "==> Running required package builds"
 env -u INVOKER_HEADLESS_STANDALONE bash "$ROOT/scripts/required-builds.sh"


### PR DESCRIPTION
## Summary

The flaky-test registry shipped tonight had a real gap: vitest resolves an exclusion path relative to each package's own folder, not the repo root. A registry entry written the natural way would silently exclude nothing.

This makes that mistake impossible to make going forward, and extends the same registry to the other vitest job in CI, gated so local test runs are never affected.

## Review Claim

The reviewer is approving a write-time guard on the registry's glob format, proven against the exact silent-failure this format caused, plus wiring the same registry into the Vitest Workspace job.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The registry is empty today, so this ships with zero live behavior change. The new guard only rejects a glob shape at write time; it changes nothing about how an already-valid glob is applied. The Vitest Workspace wiring only activates when `CI` is set, so local runs are unaffected either way.

## Slice Rationale

One slice: fix the format gap in the mechanism just shipped, and extend it to the one other vitest job while the wiring pattern is fresh, proven end-to-end with a stubbed run rather than the real multi-minute suite.

## Non-goals

Does not touch Playwright, which needs a different mechanism entirely (its shards are hardcoded file lists in ci.yml, not a CLI flag) — scoped separately.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-flaky-test-registry.mjs`
- [ ] `bash scripts/test-workspace-test-flaky-wiring.sh`
- [ ] `node scripts/test-ci-workflow-merge-queue-policy.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert ab2d9f05b0`
- Post-revert steps: None
- Data migration? No

</details>