### PR TITLE
Stop one poison-pill CI job from crashing the whole regression sweep

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -930,6 +930,7 @@ export function processFailureFilingSweep(state, {
   save = () => {},
   onNeedsHuman = () => {},
   onRetired = () => {},
+  onFileError = () => {},
   fleetEventThreshold = FLEET_EVENT_THRESHOLD,
   isPaused = isAutoFixCircuitBreakerPaused,
 } = {}) {
@@ -967,6 +968,7 @@ export function processFailureFilingSweep(state, {
     groupsRetired: prepared.retiredFleetMembers.length,
     groupsRetiredStale: 0,
     groupsCorrelated: prepared.groupsCorrelated,
+    groupsFailedToFile: 0,
   };
 
   for (const failure of prepared.failures) {
@@ -1006,7 +1008,23 @@ export function processFailureFilingSweep(state, {
       continue;
     }
 
-    fileFailure(failure);
+    // One failure's own render/lint/submit (fileFailure) throwing must never
+    // stop the whole sweep -- confirmed live: a CI job whose name happened to
+    // contain a review-unit keyword ("optional / Visual Proof Validate")
+    // tripped skill-doctor.sh's lint and killed the entire process, so every
+    // other actionable failure in this sweep silently got zero filing
+    // attempts. recordFailureFiled still runs so this failure's attempt
+    // count advances toward the existing needs-human cap instead of
+    // retry-crashing forever on the same poison-pill job every sweep.
+    try {
+      fileFailure(failure);
+    } catch (error) {
+      counts.groupsFailedToFile += 1;
+      onFileError(failure, error);
+      recordFailureFiled(state, failure, filedAt);
+      save(state);
+      continue;
+    }
     recordFailureFiled(state, failure, filedAt);
     save(state);
     counts.groupsFiled += 1;
@@ -1073,6 +1091,9 @@ export async function main() {
         ? `CI has not reported this job in either direction for over ${Math.round(STALE_OBSERVATION_MS / 86_400_000)}d (last observed ${failure.lastObservedAt}); presumed renamed or removed`
         : 'has no mapped local verify command';
       console.error(`ci-regression-watch: failure key "${buildMarker(failure.firstBadSha, failure.jobName)}" ${detail}; marking retired and skipping filing`);
+    },
+    onFileError: (failure, error) => {
+      console.error(`ci-regression-watch: failed to render/lint/submit a repair plan for "${buildMarker(failure.firstBadSha, failure.jobName)}": ${error.message}; continuing with the rest of the sweep`);
     },
   });
 

--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -862,3 +862,71 @@ describe('auto-fix circuit breaker (shared with execution-engine)', () => {
     assert.equal(counts.pausedByCircuitBreaker, undefined);
   }));
 });
+
+describe('a poison-pill failure must not abort the whole sweep', () => {
+  it('reproduces the bug: one fileFailure throwing used to stop every later candidate in the same sweep', () => {
+    // Real incident: e2e-regression-watch filed 4 repair plans successfully,
+    // then hit a CI job named "optional / Visual Proof Validate" -- its
+    // interpolated job name tripped skill-doctor.sh's review-unit lint, and
+    // that thrown error propagated all the way out of processFailureFilingSweep,
+    // so the 5th+ actionable failures in that sweep got zero filing attempts.
+    const jobs = [
+      'required-fast / Vitest Workspace',
+      'optional / Visual Proof Validate',
+      'docker / comprehensive',
+    ];
+    const state = stateWithFailures(jobs.map((jobName, index) => makeFailure({
+      jobName,
+      firstBadSha: `a5d6b3e626ace9e963e924c0de9410dc0302de9${index}`,
+    })));
+    const jobDefinitions = jobDefinitionsFor(jobs);
+    const filed = [];
+
+    const counts = processFailureFilingSweep(state, {
+      now: new Date('2026-08-12T00:00:00Z'),
+      jobDefinitions,
+      isPaused: () => false,
+      liveQuery: () => false,
+      fileFailure: (failure) => {
+        if (failure.jobName === 'optional / Visual Proof Validate') {
+          throw new Error('skill-doctor.sh lint-review-units failed: mixes docs language with product-unit language');
+        }
+        filed.push(failure.jobName);
+      },
+    });
+
+    assert.deepEqual(
+      filed.sort(),
+      ['docker / comprehensive', 'required-fast / Vitest Workspace'],
+      'the two healthy candidates must still get filed even though the middle one threw',
+    );
+    assert.equal(counts.groupsFiled, 2);
+    assert.equal(counts.groupsFailedToFile, 1);
+  });
+
+  it('logs the failure via onFileError and still advances the attempt count so it eventually escalates to needs-human', () => {
+    const jobName = 'optional / Visual Proof Validate';
+    const state = stateWithFailure(makeFailure({ jobName }));
+    const errors = [];
+
+    processFailureFilingSweep(state, {
+      now: new Date('2026-08-12T00:00:00Z'),
+      jobDefinitions: jobDefinitionsFor([jobName]),
+      isPaused: () => false,
+      liveQuery: () => false,
+      fileFailure: () => {
+        throw new Error('lint-review-units failed');
+      },
+      onFileError: (failure, error) => {
+        errors.push({ jobName: failure.jobName, message: error.message });
+      },
+    });
+
+    assert.deepEqual(errors, [{ jobName, message: 'lint-review-units failed' }]);
+    assert.equal(
+      state.activeFailures[jobName].attempts,
+      1,
+      'a failed filing attempt must still count toward the cap, or this job would crash-loop every sweep forever',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The regression watcher tonight filed 4 repair plans, then hit one CI job whose name happened to trip an unrelated lint rule while rendering its plan. That thrown error killed the whole run, so every other broken job in that sweep got no repair attempt at all.

Now one bad plan can't take the rest down. It's logged, counted toward its own attempt cap, and the sweep continues to the next candidate.

## Review Claim

The reviewer is approving that a single failing plan render no longer aborts the regression sweep, proven against the exact incident from tonight's run.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the per-candidate error handling changes. A candidate that already filed successfully behaves exactly as before. A candidate whose plan can never render still eventually reaches the same needs-human cap every other stuck candidate already reaches, so nothing loops forever silently.

## Slice Rationale

One slice: the try/catch around one call, proven with two tests built from the real job name and error text captured live tonight.

## Non-goals

Does not fix the underlying lint false-positive that a job's own name can trip; that is a separate, pre-existing gap in the review-unit checker. Does not touch the large, already-flaky test count in this same file's own suite, confirmed identical on current master before this change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node --test --test-name-pattern="poison-pill" scripts/e2e-regression-watch.test.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert 5687717939`
- Post-revert steps: None
- Data migration? No

</details>
