### PR TITLE
Fix web UI unable to switch execution model (unknown_channel)

### DIFF
--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -17,6 +17,7 @@ function makeTask(id: string) {
 function makeDispatch(overrides: Record<string, unknown> = {}) {
   const approveTask = vi.fn(async () => ({ ok: true }));
   const spawnRepairWorkflow = vi.fn(async () => ({ ok: true }));
+  const editTaskModel = vi.fn(async () => ({ ok: true }));
   const deps = {
     orchestrator: {
       syncAllFromDb: vi.fn(),
@@ -27,7 +28,7 @@ function makeDispatch(overrides: Record<string, unknown> = {}) {
     persistence: {
       listWorkflows: () => [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
     },
-    mutations: { approveTask, spawnRepairWorkflow },
+    mutations: { approveTask, spawnRepairWorkflow, editTaskModel },
     agentRegistry: { listExecutionHarnesses: () => [] },
     loadConfig: () => ({}),
     getStreamSequence: () => 7,
@@ -36,7 +37,7 @@ function makeDispatch(overrides: Record<string, unknown> = {}) {
     detachWorkflow: vi.fn(async () => {}),
     ...overrides,
   };
-  return { dispatch: buildWebInvokerDispatch(deps as never), approveTask, spawnRepairWorkflow };
+  return { dispatch: buildWebInvokerDispatch(deps as never), approveTask, spawnRepairWorkflow, editTaskModel };
 }
 function makeTaskTerminalAdapter() {
   return {
@@ -176,6 +177,12 @@ describe('buildWebInvokerDispatch', () => {
     const { dispatch, spawnRepairWorkflow } = makeDispatch();
     await dispatch('invoker:spawn-repair-workflow', [payload]);
     expect(spawnRepairWorkflow).toHaveBeenCalledWith(payload);
+  });
+
+  it('edit-task-model routes to the mutation facade', async () => {
+    const { dispatch, editTaskModel } = makeDispatch();
+    await dispatch('invoker:edit-task-model', ['wf-1/task-1', 'gpt-5.3-codex-spark']);
+    expect(editTaskModel).toHaveBeenCalledWith('wf-1/task-1', 'gpt-5.3-codex-spark');
   });
 
   it('open-terminal degrades gracefully when task terminal support is absent', async () => {

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -80,6 +80,7 @@ export interface ApiMutationFacade {
   editTaskPrompt(taskId: string, newPrompt: string): Promise<MutationResult>;
   editTaskType(taskId: string, runnerKind: string, poolMemberId?: string): Promise<MutationResult>;
   editTaskAgent(taskId: string, agentName: string): Promise<MutationResult>;
+  editTaskModel(taskId: string, executionModel: string | null): Promise<MutationResult>;
   setTaskExternalGatePolicies(
     taskId: string,
     updates: ExternalGatePolicyUpdate[],

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -227,6 +227,8 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return mutations.editTaskPrompt(String(args[0]), String(args[1]));
       case 'invoker:edit-task-agent':
         return mutations.editTaskAgent(String(args[0]), String(args[1]));
+      case 'invoker:edit-task-model':
+        return mutations.editTaskModel(String(args[0]), args[1] === undefined || args[1] === null ? null : String(args[1]));
       case 'invoker:edit-task-type':
         return mutations.editTaskType(
           String(args[0]),

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -692,6 +692,14 @@ export function editTaskAgent(
   return deps.orchestrator.editTaskAgent(taskId, agentName);
 }
 
+export function editTaskModel(
+  taskId: string,
+  executionModel: string | null,
+  deps: Pick<ActionDeps, 'orchestrator'>,
+): TaskState[] {
+  return deps.orchestrator.editTaskModel(taskId, executionModel);
+}
+
 export function setTaskExternalGatePolicies(
   taskId: string,
   updates: ExternalGatePolicyUpdate[],

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -40,6 +40,7 @@ import {
   editTaskPrompt as sharedEditTaskPrompt,
   editTaskType as sharedEditTaskType,
   editTaskAgent as sharedEditTaskAgent,
+  editTaskModel as sharedEditTaskModel,
   setTaskExternalGatePolicies as sharedSetTaskExternalGatePolicies,
   setWorkflowExternalGatePolicies as sharedSetWorkflowExternalGatePolicies,
   setWorkflowMergeMode as sharedSetWorkflowMergeMode,
@@ -259,6 +260,14 @@ export class WorkflowMutationFacade {
       orchestrator: this.deps.orchestrator,
     });
     return this.finalizeWithTopup(started, 'facade.edit-task-agent', { scopedTaskIds: [taskId] });
+  }
+
+  async editTaskModel(taskId: string, executionModel: string | null): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
+    const started = sharedEditTaskModel(taskId, executionModel, {
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.edit-task-model', { scopedTaskIds: [taskId] });
   }
 
   async setTaskExternalGatePolicies(

--- a/scripts/repro/repro-web-edit-task-model-unknown-channel.sh
+++ b/scripts/repro/repro-web-edit-task-model-unknown-channel.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Repro: the web bridge (packages/app/src/web/web-invoker-dispatch.ts) has no
+# case for 'invoker:edit-task-model', so the browser UI's "AI Model" dropdown
+# fails with "request failed" (code: unknown_channel) and never reaches
+# WorkflowMutationFacade/orchestrator.editTaskModel. edit-task-agent works
+# fine because it does have a case in the same switch.
+#
+# Usage: bash scripts/repro/repro-web-edit-task-model-unknown-channel.sh
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+pnpm --filter @invoker/app test -- -t "edit-task-model routes to the mutation facade"


### PR DESCRIPTION
The web-served UI's HTTP dispatch (web-invoker-dispatch.ts) never had a
case for the 'invoker:edit-task-model' channel, unlike its sibling
'invoker:edit-task-agent'. Picking a model in the AI Model dropdown from
a browser (e.g. owner-serve mode) always failed with a generic "request
failed" toast before ever reaching the backend mutation logic.

Adds editTaskModel through the same facade chain edit-task-agent already
uses (workflow-actions -> WorkflowMutationFacade -> ApiMutationFacade)
and wires the missing dispatch case. Regression test added; repro script
at scripts/repro/repro-web-edit-task-model-unknown-channel.sh fails
before this change and passes after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for editing a task’s execution model, including clearing the model when needed.
  * Updates now close the task review, refresh affected tasks, and apply any required top-up actions.
  * Added web bridge routing for task execution-model updates.

* **Tests**
  * Added coverage confirming task IDs and execution models are forwarded correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->