### PR TITLE
Add an opt-in worker that refreshes and distributes Claude OAuth credentials

### DIFF
--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   AUTO_APPROVE_WORKER_KIND,
   AUTO_FIX_WORKER_KIND,
+  CLAUDE_OAUTH_REFRESH_WORKER_KIND,
   DISK_HEADROOM_WORKER_KIND,
   PR_ADMIN_BYPASS_LAND_WORKER_KIND,
   PR_AUTO_LABEL_WORKER_KIND,
@@ -220,6 +221,14 @@ describe('autoStartedOwnerWorkerKindsForConfig', () => {
       DISK_HEADROOM_WORKER_KIND,
       { diskHeadroom: { cleanupEnabled: true } },
       { diskHeadroom: { cleanupEnabled: false } },
+    );
+  });
+
+  it('includes claude-oauth-refresh only when claudeOauthRefresh.enabled is true', () => {
+    expectConfigGate(
+      CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+      { claudeOauthRefresh: { enabled: true } },
+      { claudeOauthRefresh: { enabled: false } },
     );
   });
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -400,6 +400,9 @@ function buildRegisteredOwnerWorkerDeps(
       remoteTargets,
       cleanupEnabled: invokerConfig.diskHeadroom?.cleanupEnabled,
     },
+    claudeOauthRefresh: {
+      remoteTargets: remoteTargets.map((target) => ({ name: target.name, connection: target.connection })),
+    },
     infraRepair: {
       ownerRepoRoot: repoRoot,
       ownerInvokerHome: resolveInvokerHomeRoot(),

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -15,6 +15,7 @@ import type { SQLiteAdapter, TaskEvent, WorkerActionRecord } from '@invoker/data
 import {
   AUTO_FIX_WORKER_KIND,
   AUTO_APPROVE_WORKER_KIND,
+  CLAUDE_OAUTH_REFRESH_WORKER_KIND,
   DISK_HEADROOM_WORKER_KIND,
   E2E_AUTOFIX_WORKER_KIND,
   IDLE_TASK_CLEANUP_WORKER_KIND,
@@ -62,6 +63,7 @@ type AutoStartedOwnerWorkerKindOptions = {
   workflowResumeEnabled?: boolean;
   requeueEnabled?: boolean;
   staleTaskCleanupEnabled?: boolean;
+  claudeOauthRefreshEnabled?: boolean;
 };
 
 type AutoStartedOwnerWorkerKindConfig = {
@@ -76,6 +78,7 @@ type AutoStartedOwnerWorkerKindConfig = {
   workflowResume?: { enabled?: boolean };
   requeueEnabled?: boolean;
   staleTaskCleanup?: { enabled?: boolean };
+  claudeOauthRefresh?: { enabled?: boolean };
 };
 
 /**
@@ -97,6 +100,7 @@ export function autoStartedOwnerWorkerKinds(
     options.requeueEnabled,
     options.slackBugScanEnabled,
     options.staleTaskCleanupEnabled,
+    options.claudeOauthRefreshEnabled,
   ].some((value) => value !== undefined);
   if (options.prMaintenanceEnabled && !hasWorkerGateOverrides) {
     workerKinds.push(PR_ADMIN_BYPASS_LAND_WORKER_KIND, INFRA_REPAIR_WORKER_KIND);
@@ -132,6 +136,9 @@ export function autoStartedOwnerWorkerKinds(
   if (options.staleTaskCleanupEnabled) {
     workerKinds.push(IDLE_TASK_CLEANUP_WORKER_KIND);
   }
+  if (options.claudeOauthRefreshEnabled) {
+    workerKinds.push(CLAUDE_OAUTH_REFRESH_WORKER_KIND);
+  }
   return workerKinds;
 }
 
@@ -150,6 +157,7 @@ export function autoStartedOwnerWorkerKindsForConfig(
     requeueEnabled: Boolean(config?.requeueEnabled),
     slackBugScanEnabled: Boolean(config?.slackBugScan?.enabled),
     staleTaskCleanupEnabled: Boolean(config?.staleTaskCleanup?.enabled),
+    claudeOauthRefreshEnabled: Boolean(config?.claudeOauthRefresh?.enabled),
   });
   return config?.e2eAutoFixEnabled
     ? [...workerKinds, E2E_AUTOFIX_WORKER_KIND]

--- a/packages/execution-engine/src/__tests__/claude-oauth-refresh-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/claude-oauth-refresh-worker.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildDistributeCredentialsScript,
+  runClaudeOauthRefreshCheck,
+  type ClaudeOauthRefreshTarget,
+  type ClaudeOauthRefreshWorkerOptions,
+} from '../workers/claude-oauth-refresh-worker.js';
+import type { WorkerDecisionStore } from '../worker-decision-ledger.js';
+
+function credentialsJson(expiresAt: number): string {
+  return JSON.stringify({
+    claudeAiOauth: { accessToken: 'access-old', refreshToken: 'refresh-old', expiresAt, scopes: [] },
+  });
+}
+
+function makeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as unknown as ClaudeOauthRefreshWorkerOptions['logger'];
+}
+
+function makeTarget(name: string): ClaudeOauthRefreshTarget {
+  return { name, connection: { host: `${name}.example.test`, user: 'invoker', sshKeyPath: '/tmp/key' } };
+}
+
+function makeStore(): { store: WorkerDecisionStore; rows: unknown[] } {
+  const rows: unknown[] = [];
+  return {
+    rows,
+    store: {
+      getWorkerAction: () => undefined,
+      upsertWorkerAction: (action) => { rows.push(action); return action as never; },
+    },
+  };
+}
+
+describe('runClaudeOauthRefreshCheck', () => {
+  it('does nothing when the token is not close to expiring', async () => {
+    const writeCredentials = vi.fn();
+    const refreshFn = vi.fn();
+    const distributeFn = vi.fn();
+    await runClaudeOauthRefreshCheck({
+      logger: makeLogger(),
+      credentialsPath: '/home/invoker/.claude/.credentials.json',
+      remoteTargets: [makeTarget('do1')],
+      readCredentials: () => credentialsJson(Date.now() + 60 * 60 * 1000),
+      writeCredentials,
+      refreshFn,
+      distributeFn,
+      now: () => Date.now(),
+    });
+    expect(refreshFn).not.toHaveBeenCalled();
+    expect(writeCredentials).not.toHaveBeenCalled();
+    expect(distributeFn).not.toHaveBeenCalled();
+  });
+
+  it('refreshes, writes the local file, and distributes to every remote target when the token is expiring', async () => {
+    const now = 1_000_000_000_000;
+    const refreshed = credentialsJson(now + 3_600_000);
+    const writeCredentials = vi.fn();
+    const distributeFn = vi.fn(async () => undefined);
+    const { store, rows } = makeStore();
+
+    await runClaudeOauthRefreshCheck({
+      logger: makeLogger(),
+      credentialsPath: '/home/invoker/.claude/.credentials.json',
+      remoteTargets: [makeTarget('do1'), makeTarget('do3')],
+      store,
+      readCredentials: () => credentialsJson(now),
+      writeCredentials,
+      refreshFn: async () => refreshed,
+      distributeFn,
+      now: () => now,
+    });
+
+    expect(writeCredentials).toHaveBeenCalledWith('/home/invoker/.claude/.credentials.json', refreshed);
+    expect(distributeFn).toHaveBeenCalledTimes(2);
+    expect(distributeFn).toHaveBeenCalledWith(expect.objectContaining({ name: 'do1' }), refreshed);
+    expect(distributeFn).toHaveBeenCalledWith(expect.objectContaining({ name: 'do3' }), refreshed);
+    const statuses = (rows as { status: string; subjectId: string }[]).map((r) => `${r.subjectId}:${r.status}`);
+    expect(statuses).toContain('local:completed');
+    expect(statuses).toContain('do1:completed');
+    expect(statuses).toContain('do3:completed');
+  });
+
+  it('logs and records a failure without throwing when the refresh request itself fails, leaving existing credentials in place', async () => {
+    const logger = makeLogger();
+    const writeCredentials = vi.fn();
+    const distributeFn = vi.fn();
+    const { store, rows } = makeStore();
+
+    await runClaudeOauthRefreshCheck({
+      logger,
+      credentialsPath: '/home/invoker/.claude/.credentials.json',
+      remoteTargets: [makeTarget('do1')],
+      store,
+      readCredentials: () => credentialsJson(1_000_000_000_000),
+      writeCredentials,
+      refreshFn: async () => null,
+      distributeFn,
+      now: () => 1_000_000_000_000,
+    });
+
+    expect(writeCredentials).not.toHaveBeenCalled();
+    expect(distributeFn).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+    expect((rows as { status: string }[])[0].status).toBe('failed');
+  });
+
+  it('reproduces the real incident: one remote target failing to distribute must not stop the others or lose the local refresh', async () => {
+    // Real incident tonight: 6 SSH pool machines all had "OAuth session
+    // expired" simultaneously. A worker that gave up after the first failed
+    // distribution would leave every other machine stuck too.
+    const now = 1_000_000_000_000;
+    const refreshed = credentialsJson(now + 3_600_000);
+    const { store, rows } = makeStore();
+    const distributeFn = vi.fn(async (target: ClaudeOauthRefreshTarget) => {
+      if (target.name === 'do6') throw new Error('ssh: connection refused');
+    });
+
+    await runClaudeOauthRefreshCheck({
+      logger: makeLogger(),
+      credentialsPath: '/home/invoker/.claude/.credentials.json',
+      remoteTargets: [makeTarget('do1'), makeTarget('do6'), makeTarget('do7')],
+      store,
+      readCredentials: () => credentialsJson(now),
+      writeCredentials: vi.fn(),
+      refreshFn: async () => refreshed,
+      distributeFn,
+      now: () => now,
+    });
+
+    expect(distributeFn).toHaveBeenCalledTimes(3);
+    const statuses = Object.fromEntries((rows as { subjectId: string; status: string }[]).map((r) => [r.subjectId, r.status]));
+    expect(statuses.do1).toBe('completed');
+    expect(statuses.do7).toBe('completed');
+    expect(statuses.do6).toBe('failed');
+  });
+
+  it('fails closed on a local read error without throwing, and never attempts a refresh or distribution', async () => {
+    const logger = makeLogger();
+    const refreshFn = vi.fn();
+    await runClaudeOauthRefreshCheck({
+      logger,
+      credentialsPath: '/home/invoker/.claude/.credentials.json',
+      remoteTargets: [],
+      readCredentials: () => { throw new Error('ENOENT'); },
+      refreshFn,
+      now: () => Date.now(),
+    });
+    expect(refreshFn).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+
+describe('buildDistributeCredentialsScript', () => {
+  it('writes the credentials to a temp path and renames atomically into place', () => {
+    const script = buildDistributeCredentialsScript('~/.claude/.credentials.json', '{"a":1}');
+    expect(script).toContain('REMOTE_PATH="~/.claude/.credentials.json"');
+    expect(script).toContain('mv "$TMP_PATH" "$REMOTE_PATH"');
+    expect(script).toContain('chmod 600 "$TMP_PATH"');
+  });
+
+  it('base64-encodes the content so JSON quoting/special characters never break the remote shell', () => {
+    const script = buildDistributeCredentialsScript('/x', '{"token":"a\'b$(rm -rf /)"}');
+    expect(script).not.toContain('rm -rf /');
+    expect(script).toMatch(/printf '%s' '[A-Za-z0-9+/=]+' \| invoker_base64_decode/);
+  });
+});

--- a/packages/execution-engine/src/__tests__/claude-oauth-refresh.test.ts
+++ b/packages/execution-engine/src/__tests__/claude-oauth-refresh.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyRefreshedToken,
+  isOauthTokenExpiring,
+  OAUTH_EXPIRY_BUFFER_MS,
+  parseClaudeOauthBlob,
+  readRefreshToken,
+  refreshClaudeOauthCredentials,
+} from '../claude-oauth-refresh.js';
+
+function credentialsJson(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    claudeAiOauth: {
+      accessToken: 'access-old',
+      refreshToken: 'refresh-old',
+      expiresAt: 1_800_000_000_000,
+      scopes: ['user:inference'],
+      ...overrides,
+    },
+  });
+}
+
+describe('parseClaudeOauthBlob', () => {
+  it('returns the claudeAiOauth block from valid JSON', () => {
+    expect(parseClaudeOauthBlob(credentialsJson())).toMatchObject({ accessToken: 'access-old' });
+  });
+
+  it('returns null for unparseable JSON', () => {
+    expect(parseClaudeOauthBlob('not json')).toBeNull();
+  });
+
+  it('returns null when claudeAiOauth is absent', () => {
+    expect(parseClaudeOauthBlob(JSON.stringify({ other: 1 }))).toBeNull();
+  });
+
+  it('returns null when claudeAiOauth is an array, not an object', () => {
+    expect(parseClaudeOauthBlob(JSON.stringify({ claudeAiOauth: [] }))).toBeNull();
+  });
+});
+
+describe('readRefreshToken', () => {
+  it('returns the stored refresh token', () => {
+    expect(readRefreshToken(credentialsJson())).toBe('refresh-old');
+  });
+
+  it('returns null when the refresh token is blank', () => {
+    expect(readRefreshToken(credentialsJson({ refreshToken: '  ' }))).toBeNull();
+  });
+
+  it('returns null when credentials are unparseable', () => {
+    expect(readRefreshToken('not json')).toBeNull();
+  });
+});
+
+describe('isOauthTokenExpiring', () => {
+  const now = 1_800_000_000_000 - OAUTH_EXPIRY_BUFFER_MS - 1000;
+
+  it('is false when the token has more than the buffer left', () => {
+    expect(isOauthTokenExpiring(credentialsJson(), now)).toBe(false);
+  });
+
+  it('is true once inside the refresh buffer', () => {
+    expect(isOauthTokenExpiring(credentialsJson(), now + 2000)).toBe(true);
+  });
+
+  it('is true when expiresAt is missing, so a blob with no expiry metadata still gets refreshed proactively', () => {
+    expect(isOauthTokenExpiring(credentialsJson({ expiresAt: undefined }), now)).toBe(true);
+  });
+
+  it('is false when there is no claudeAiOauth block at all (nothing to refresh)', () => {
+    expect(isOauthTokenExpiring(JSON.stringify({}), now)).toBe(false);
+  });
+});
+
+describe('applyRefreshedToken', () => {
+  it('overwrites accessToken/expiresAt/scope and preserves the refresh token when the server does not rotate it', () => {
+    const result = applyRefreshedToken(
+      credentialsJson(),
+      { access_token: 'access-new', expires_in: 3600, scope: 'user:inference user:profile' },
+      1_000_000_000_000,
+    );
+    const parsed = JSON.parse(result!);
+    expect(parsed.claudeAiOauth).toMatchObject({
+      accessToken: 'access-new',
+      expiresAt: 1_000_000_000_000 + 3_600_000,
+      refreshToken: 'refresh-old',
+      scopes: ['user:inference', 'user:profile'],
+    });
+  });
+
+  it('rotates the refresh token when the server issues a new single-use one', () => {
+    const result = applyRefreshedToken(
+      credentialsJson(),
+      { access_token: 'access-new', refresh_token: 'refresh-new' },
+      1_000_000_000_000,
+    );
+    expect(JSON.parse(result!).claudeAiOauth.refreshToken).toBe('refresh-new');
+  });
+
+  it('preserves every other top-level field the caller already had', () => {
+    const withExtra = JSON.stringify({ claudeAiOauth: JSON.parse(credentialsJson()).claudeAiOauth, otherField: 'keep-me' });
+    const result = applyRefreshedToken(withExtra, { access_token: 'access-new' });
+    expect(JSON.parse(result!).otherField).toBe('keep-me');
+  });
+
+  it('returns null when the response has no usable access_token', () => {
+    expect(applyRefreshedToken(credentialsJson(), {})).toBeNull();
+    expect(applyRefreshedToken(credentialsJson(), { access_token: '  ' })).toBeNull();
+  });
+
+  it('returns null for unparseable input JSON', () => {
+    expect(applyRefreshedToken('not json', { access_token: 'x' })).toBeNull();
+  });
+});
+
+describe('refreshClaudeOauthCredentials', () => {
+  it('posts grant_type=refresh_token with the stored token and returns updated credentials on success', async () => {
+    const calls: Array<{ url: string; init: unknown }> = [];
+    const result = await refreshClaudeOauthCredentials(credentialsJson(), {
+      now: 1_000_000_000_000,
+      fetchFn: async (url, init) => {
+        calls.push({ url, init });
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ access_token: 'access-new', expires_in: 3600, refresh_token: 'refresh-new' }),
+        };
+      },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://platform.claude.com/v1/oauth/token');
+    const body = (calls[0].init as { body: string }).body;
+    expect(body).toContain('grant_type=refresh_token');
+    expect(body).toContain('refresh_token=refresh-old');
+    const parsed = JSON.parse(result!);
+    expect(parsed.claudeAiOauth.accessToken).toBe('access-new');
+    expect(parsed.claudeAiOauth.refreshToken).toBe('refresh-new');
+  });
+
+  it('returns null without making a network call when there is no refresh token to send', async () => {
+    let called = false;
+    const result = await refreshClaudeOauthCredentials(JSON.stringify({}), {
+      fetchFn: async () => { called = true; return { ok: true, status: 200, json: async () => ({}) }; },
+    });
+    expect(called).toBe(false);
+    expect(result).toBeNull();
+  });
+
+  it('returns null on a non-2xx response instead of throwing', async () => {
+    const result = await refreshClaudeOauthCredentials(credentialsJson(), {
+      fetchFn: async () => ({ ok: false, status: 400, json: async () => ({ error: 'invalid_grant' }) }),
+    });
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the network call itself throws, so a transient outage never crashes the caller', async () => {
+    const result = await refreshClaudeOauthCredentials(credentialsJson(), {
+      fetchFn: async () => { throw new Error('ECONNRESET'); },
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -5,6 +5,7 @@ import type { WorkerRegistry } from './worker-registry.js';
 import { registerE2eAutoFixWorker } from './workers/e2e-autofix-worker.js';
 import { registerIdleTaskCleanupWorker } from './workers/idle-task-cleanup-worker.js';
 import { registerDiskHeadroomWorker } from './workers/disk-headroom-worker.js';
+import { registerClaudeOauthRefreshWorker } from './workers/claude-oauth-refresh-worker.js';
 import { registerInfraRepairWorker } from './workers/infra-repair-worker.js';
 import { registerPrMaintenanceWorkers } from './workers/pr-maintenance-workers.js';
 import { registerPrStatusWorker } from './workers/pr-status-worker.js';
@@ -23,6 +24,7 @@ export function registerBuiltinWorkers(
   registerPrStatusWorker(registry);
   registerInfraRepairWorker(registry);
   registerDiskHeadroomWorker(registry);
+  registerClaudeOauthRefreshWorker(registry);
   registerReaperWorker(registry);
   registerAutoApproveWorker(registry);
   registerPrMaintenanceWorkers(registry);

--- a/packages/execution-engine/src/claude-oauth-refresh.ts
+++ b/packages/execution-engine/src/claude-oauth-refresh.ts
@@ -1,0 +1,147 @@
+// Refreshes a Claude Code OAuth credential blob directly against Anthropic's
+// token endpoint, instead of relying on the `claude` CLI to refresh itself
+// and scraping the result back out -- that path can copy a refresh token
+// that the CLI already burned (Anthropic issues single-use refresh tokens),
+// stranding a stale credential. Owning the refresh means Invoker persists
+// the rotated refresh token atomically, the same way the credential is
+// actually meant to be rotated.
+const OAUTH_TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
+// Public Claude Code OAuth client id -- not a secret, the same value the
+// `claude` CLI itself sends on every refresh request.
+const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+
+// Refresh slightly ahead of expiry so a task launch never races a token that
+// dies mid-flight. Matches the CLI's own refresh skew.
+export const OAUTH_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+const REFRESH_TIMEOUT_MS = 10_000;
+
+interface ClaudeOauthBlob {
+  accessToken?: unknown;
+  refreshToken?: unknown;
+  expiresAt?: unknown;
+  scopes?: unknown;
+  [key: string]: unknown;
+}
+
+interface ClaudeCredentials {
+  claudeAiOauth?: ClaudeOauthBlob;
+  [key: string]: unknown;
+}
+
+interface TokenEndpointResponse {
+  access_token?: unknown;
+  expires_in?: unknown;
+  refresh_token?: unknown;
+  scope?: unknown;
+}
+
+/** Parses the `claudeAiOauth` block out of a credentials JSON string, or null if absent/unparseable. */
+export function parseClaudeOauthBlob(credentialsJson: string): ClaudeOauthBlob | null {
+  try {
+    const parsed = JSON.parse(credentialsJson) as ClaudeCredentials;
+    const oauth = parsed?.claudeAiOauth;
+    return oauth && typeof oauth === 'object' && !Array.isArray(oauth) ? oauth : null;
+  } catch {
+    return null;
+  }
+}
+
+export function readRefreshToken(credentialsJson: string): string | null {
+  const oauth = parseClaudeOauthBlob(credentialsJson);
+  const token = oauth?.refreshToken;
+  return typeof token === 'string' && token.trim() !== '' ? token.trim() : null;
+}
+
+/**
+ * True when the stored access token is already expired or within the
+ * refresh buffer. A missing/non-numeric expiresAt is treated as
+ * "needs refresh" rather than trusted indefinitely.
+ */
+export function isOauthTokenExpiring(credentialsJson: string, now: number = Date.now()): boolean {
+  const oauth = parseClaudeOauthBlob(credentialsJson);
+  if (!oauth) return false;
+  const expiresAt = oauth.expiresAt;
+  if (typeof expiresAt !== 'number' || !Number.isFinite(expiresAt)) return true;
+  return now + OAUTH_EXPIRY_BUFFER_MS >= expiresAt;
+}
+
+/**
+ * Merges a token-endpoint response into stored credentials JSON, preserving
+ * every field the caller already had and only overwriting what the response
+ * provides. Returns null on malformed input or a missing access token.
+ */
+export function applyRefreshedToken(
+  credentialsJson: string,
+  response: TokenEndpointResponse,
+  now: number = Date.now(),
+): string | null {
+  let parsed: ClaudeCredentials;
+  try {
+    parsed = JSON.parse(credentialsJson) as ClaudeCredentials;
+  } catch {
+    return null;
+  }
+  const accessToken = response.access_token;
+  if (typeof accessToken !== 'string' || accessToken.trim() === '') return null;
+
+  const oauth: ClaudeOauthBlob = { ...parsed.claudeAiOauth };
+  oauth.accessToken = accessToken;
+  if (typeof response.expires_in === 'number' && Number.isFinite(response.expires_in)) {
+    oauth.expiresAt = now + response.expires_in * 1000;
+  }
+  // Anthropic issues single-use refresh tokens; persisting the rotated value
+  // is the entire point of owning this refresh instead of scraping the CLI.
+  if (typeof response.refresh_token === 'string' && response.refresh_token.trim() !== '') {
+    oauth.refreshToken = response.refresh_token;
+  }
+  if (typeof response.scope === 'string' && response.scope.trim() !== '') {
+    oauth.scopes = response.scope.split(' ');
+  }
+  parsed.claudeAiOauth = oauth;
+  return JSON.stringify(parsed);
+}
+
+export type OauthFetchFn = (url: string, init: {
+  method: string;
+  headers: Record<string, string>;
+  body: string;
+  signal?: AbortSignal;
+}) => Promise<{ ok: boolean; status: number; json(): Promise<unknown> }>;
+
+/**
+ * Refreshes the OAuth token for a stored credentials blob against
+ * Anthropic's token endpoint. Returns the updated credentials JSON on
+ * success, or null on any failure (no refresh token present, network error,
+ * non-2xx response, malformed response body). Never throws -- callers treat
+ * null as "keep the existing credentials," so a transient failure here is
+ * never worse than not refreshing at all.
+ */
+export async function refreshClaudeOauthCredentials(
+  credentialsJson: string,
+  opts: { fetchFn?: OauthFetchFn; now?: number } = {},
+): Promise<string | null> {
+  const refreshToken = readRefreshToken(credentialsJson);
+  if (!refreshToken) return null;
+
+  const fetchFn = opts.fetchFn ?? (globalThis.fetch as OauthFetchFn | undefined);
+  if (!fetchFn) return null;
+  const now = opts.now ?? Date.now();
+
+  try {
+    const res = await fetchFn(OAUTH_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: OAUTH_CLIENT_ID,
+      }).toString(),
+      signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    const body = await res.json() as TokenEndpointResponse;
+    return applyRefreshedToken(credentialsJson, body, now);
+  } catch {
+    return null;
+  }
+}

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -68,6 +68,8 @@ export * from './workers/pr-status-worker.js';
 export * from './workers/infra-repair-worker.js';
 export * from './workers/auto-approve-worker.js';
 export * from './workers/disk-headroom-worker.js';
+export * from './workers/claude-oauth-refresh-worker.js';
+export * from './claude-oauth-refresh.js';
 export * from './workers/disk-headroom-monitor.js';
 export * from './workers/disk-headroom-reclaim.js';
 export * from './workers/disk-headroom.js';

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -16,6 +16,7 @@ import type {
 import type { PrMaintenanceWorkerConfig } from './workers/pr-maintenance-workers.js';
 import type { E2eAutoFixWorkerConfig } from './workers/e2e-autofix-worker.js';
 import type { DiskHeadroomWorkerConfig } from './workers/disk-headroom-worker.js';
+import type { ClaudeOauthRefreshWorkerConfig } from './workers/claude-oauth-refresh-worker.js';
 import type { DiskHeadroomWorkerStore } from './workers/disk-headroom-reclaim.js';
 import type { SlackBugScanWorkerConfig } from './workers/slack-bug-scan-worker.js';
 import type {
@@ -70,6 +71,8 @@ export interface WorkerRuntimeDependencies {
   prMaintenance?: PrMaintenanceWorkerConfig;
   /** Disk-headroom worker configuration (local/remote paths and thresholds). */
   diskHeadroom?: DiskHeadroomWorkerConfig;
+  /** Claude OAuth refresh worker configuration (local credentials path and SSH pool distribution targets). */
+  claudeOauthRefresh?: ClaudeOauthRefreshWorkerConfig;
   /** Infra-repair worker configuration (owner/local repo plus remote SSH repair targets). */
   infraRepair?: InfraRepairWorkerConfig;
   /** Auto-approval tuning for worker-owned AI fix approvals. */

--- a/packages/execution-engine/src/workers/claude-oauth-refresh-worker.ts
+++ b/packages/execution-engine/src/workers/claude-oauth-refresh-worker.ts
@@ -1,0 +1,223 @@
+import { readFileSync, writeFileSync, renameSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import type { Logger } from '@invoker/contracts';
+
+import {
+  isOauthTokenExpiring,
+  refreshClaudeOauthCredentials,
+  type OauthFetchFn,
+} from '../claude-oauth-refresh.js';
+import { recordWorkerDecisionRow, type WorkerDecisionStore } from '../worker-decision-ledger.js';
+import { base64Encode, execRemoteCapture } from '../ssh-git-exec.js';
+import { buildSshConnectionArgs } from '../ssh-transport-options.js';
+import type { SshTargetConnection } from '../ssh-transport-options.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const CLAUDE_OAUTH_REFRESH_WORKER_KIND = 'claude-oauth-refresh';
+export const DEFAULT_CLAUDE_OAUTH_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
+
+export interface ClaudeOauthRefreshTarget {
+  name: string;
+  connection: SshTargetConnection;
+  /** Absolute remote path to the credentials file. Defaults to ~/.claude/.credentials.json on that host. */
+  remotePath?: string;
+}
+
+export interface ClaudeOauthRefreshWorkerConfig {
+  /** Local credentials file path. Defaults to ~/.claude/.credentials.json. */
+  credentialsPath?: string;
+  remoteTargets?: ClaudeOauthRefreshTarget[];
+  intervalMs?: number;
+  tickOnStart?: boolean;
+  store?: WorkerDecisionStore;
+
+  /** Test seams. */
+  readCredentials?: (path: string) => string;
+  writeCredentials?: (path: string, contents: string) => void;
+  refreshFn?: (credentialsJson: string) => Promise<string | null>;
+  distributeFn?: (target: ClaudeOauthRefreshTarget, credentialsJson: string) => Promise<void>;
+  fetchFn?: OauthFetchFn;
+  now?: () => number;
+  onTick?: WorkerTick;
+}
+
+export interface ClaudeOauthRefreshWorkerOptions {
+  logger: Logger;
+  credentialsPath: string;
+  remoteTargets: ClaudeOauthRefreshTarget[];
+  intervalMs?: number;
+  tickOnStart?: boolean;
+  store?: WorkerDecisionStore;
+  readCredentials?: (path: string) => string;
+  writeCredentials?: (path: string, contents: string) => void;
+  refreshFn?: (credentialsJson: string) => Promise<string | null>;
+  distributeFn?: (target: ClaudeOauthRefreshTarget, credentialsJson: string) => Promise<void>;
+  now?: () => number;
+  onTick?: WorkerTick;
+}
+
+export function resolveClaudeCredentialsPath(env: NodeJS.ProcessEnv = process.env): string {
+  return env.INVOKER_CLAUDE_CREDENTIALS_PATH?.trim() || join(homedir(), '.claude', '.credentials.json');
+}
+
+function defaultReadCredentials(path: string): string {
+  return readFileSync(path, 'utf8');
+}
+
+function defaultWriteCredentials(path: string, contents: string): void {
+  // Atomic write: a crash or concurrent read mid-write must never observe a
+  // truncated credentials file -- write to a sibling temp path, then rename,
+  // which is atomic on the same filesystem.
+  const tmpPath = `${path}.tmp-${process.pid}`;
+  writeFileSync(tmpPath, contents, { mode: 0o600 });
+  renameSync(tmpPath, path);
+}
+
+function buildPortableBase64DecodeFunction(functionName = 'invoker_base64_decode'): string {
+  return `${functionName}() {
+  if base64 --decode </dev/null >/dev/null 2>&1; then
+    base64 --decode
+  elif base64 -d </dev/null >/dev/null 2>&1; then
+    base64 -d
+  else
+    base64 -D
+  fi
+}`;
+}
+
+export function buildDistributeCredentialsScript(remotePath: string, credentialsJson: string): string {
+  const contentB64 = base64Encode(credentialsJson);
+  return `set -euo pipefail
+${buildPortableBase64DecodeFunction()}
+REMOTE_PATH="${remotePath}"
+mkdir -p "$(dirname "$REMOTE_PATH")"
+TMP_PATH="$REMOTE_PATH.tmp-$$"
+printf '%s' '${contentB64}' | invoker_base64_decode > "$TMP_PATH"
+chmod 600 "$TMP_PATH"
+mv "$TMP_PATH" "$REMOTE_PATH"`;
+}
+
+function defaultDistribute(target: ClaudeOauthRefreshTarget, credentialsJson: string): Promise<void> {
+  const remotePath = target.remotePath ?? '~/.claude/.credentials.json';
+  const sshArgs = buildSshConnectionArgs(target.connection, { batchMode: true });
+  return execRemoteCapture({
+    sshArgs,
+    script: buildDistributeCredentialsScript(remotePath, credentialsJson),
+    phase: `claude-oauth-refresh:${target.name}`,
+  }).then(() => undefined);
+}
+
+function recordDecision(
+  store: WorkerDecisionStore | undefined,
+  externalKey: string,
+  status: 'completed' | 'failed' | 'skipped',
+  summary: string,
+  payload: Record<string, unknown> = {},
+): void {
+  if (!store) return;
+  recordWorkerDecisionRow(store, {
+    workerKind: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+    actionType: 'oauth-refresh',
+    externalKey,
+    subjectType: 'credentials',
+    subjectId: externalKey,
+    status,
+    summary,
+    payload,
+  });
+}
+
+export async function runClaudeOauthRefreshCheck(options: ClaudeOauthRefreshWorkerOptions): Promise<void> {
+  const readCredentials = options.readCredentials ?? defaultReadCredentials;
+  const writeCredentials = options.writeCredentials ?? defaultWriteCredentials;
+  const distribute = options.distributeFn ?? defaultDistribute;
+  const now = options.now ?? Date.now;
+
+  let credentialsJson: string;
+  try {
+    credentialsJson = readCredentials(options.credentialsPath);
+  } catch (error) {
+    options.logger.error(`[${CLAUDE_OAUTH_REFRESH_WORKER_KIND}] failed to read ${options.credentialsPath}: ${error instanceof Error ? error.message : String(error)}`, {
+      module: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+    });
+    return;
+  }
+
+  if (!isOauthTokenExpiring(credentialsJson, now())) return;
+
+  const refresh = options.refreshFn ?? ((json: string) => refreshClaudeOauthCredentials(json, { now: now() }));
+  const refreshed = await refresh(credentialsJson);
+  if (!refreshed) {
+    options.logger.error(`[${CLAUDE_OAUTH_REFRESH_WORKER_KIND}] token refresh failed for ${options.credentialsPath}; leaving existing credentials in place`, {
+      module: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+    });
+    recordDecision(options.store, 'local', 'failed', 'OAuth token refresh request failed');
+    return;
+  }
+
+  writeCredentials(options.credentialsPath, refreshed);
+  recordDecision(options.store, 'local', 'completed', 'Refreshed local Claude OAuth credentials');
+  options.logger.info(`[${CLAUDE_OAUTH_REFRESH_WORKER_KIND}] refreshed local credentials`, {
+    module: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+  });
+
+  for (const target of options.remoteTargets) {
+    try {
+      await distribute(target, refreshed);
+      recordDecision(options.store, target.name, 'completed', `Distributed refreshed credentials to ${target.name}`);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      options.logger.error(`[${CLAUDE_OAUTH_REFRESH_WORKER_KIND}] failed to distribute to ${target.name}: ${detail}`, {
+        module: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+        target: target.name,
+      });
+      recordDecision(options.store, target.name, 'failed', `Failed to distribute refreshed credentials to ${target.name}: ${detail}`);
+    }
+  }
+}
+
+export function createClaudeOauthRefreshWorker(config: ClaudeOauthRefreshWorkerConfig & { logger: Logger }): WorkerRuntime {
+  const options: ClaudeOauthRefreshWorkerOptions = {
+    logger: config.logger,
+    credentialsPath: config.credentialsPath ?? resolveClaudeCredentialsPath(),
+    remoteTargets: config.remoteTargets ?? [],
+    store: config.store,
+    readCredentials: config.readCredentials,
+    writeCredentials: config.writeCredentials,
+    refreshFn: config.refreshFn ?? (config.fetchFn
+      ? (json: string) => refreshClaudeOauthCredentials(json, { fetchFn: config.fetchFn, now: config.now?.() })
+      : undefined),
+    distributeFn: config.distributeFn,
+    now: config.now,
+  };
+  const onTick: WorkerTick = config.onTick ?? (async () => {
+    await runClaudeOauthRefreshCheck(options);
+  });
+  return createWorkerRuntime({
+    kind: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+    logger: config.logger,
+    onTick,
+    intervalMs: config.intervalMs ?? DEFAULT_CLAUDE_OAUTH_REFRESH_INTERVAL_MS,
+    tickOnStart: config.tickOnStart ?? true,
+  });
+}
+
+export function registerClaudeOauthRefreshWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+    note: 'Refreshes this owner\'s Claude Code OAuth credentials before they expire and distributes them to every SSH pool member.',
+    source: 'built-in',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createClaudeOauthRefreshWorker({
+        logger: deps.logger,
+        ...deps.claudeOauthRefresh,
+      }),
+  });
+  return registry;
+}


### PR DESCRIPTION
## Summary

Every SSH pool machine hit "OAuth session expired" tonight, all at once. The only fix was manually copying a fresh credentials file to all 6 machines by hand, twice in one session.

This adds a worker that refreshes the owner's own Claude Code credentials against Anthropic's token endpoint before they expire, then pushes the refreshed file to every configured SSH machine.

## Review Claim

The reviewer is approving a new worker implementation (registration, tick logic, credential refresh, and per-target distribution) proven against a real incident from tonight's session (all 6 pool machines expiring simultaneously) plus the actual token-refresh mechanics (single-use refresh token rotation, atomic local write, per-target failure isolation). The worker cannot auto-start yet; the config gate that lets it opt in ships as a following slice.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

It only ever touches the owner's own `~/.claude/.credentials.json` and the exact same file path on each configured remote target -- no other file, no other host. A refresh-request failure or an individual target's distribution failure leaves the previous credentials file untouched on that host and never blocks the other targets.

## Slice Rationale

This slice is the self-contained worker mechanics: the pure OAuth-refresh functions, the worker that wires them to local/remote credential files, and its gating hook in `worker-control.ts`. It ships with no way to auto-start (the config field that flips it on lands in the next slice), so it changes no runtime behavior for anyone on its own.

## Non-goals

Does not change how the `claude` CLI itself refreshes when run interactively. Does not touch codex credentials (a separate, unrelated auth system already hit its own usage limit tonight for a different reason). Does not add UI for viewing refresh history; the worker-decision ledger already covers that generically. Does not add the config field to opt in (next slice) or the headless CLI factory wiring (slice after that).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test -- src/__tests__/claude-oauth-refresh.test.ts src/__tests__/claude-oauth-refresh-worker.test.ts`
- [ ] `cd packages/app && pnpm test -- src/__tests__/worker-control.test.ts`
- [ ] `npx tsc -p tsconfig.typecheck.json`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert <merge-commit-sha>`
- Post-revert steps: None -- the worker has no config path to auto-start yet, so nothing depends on it existing.
- Data migration? No

</details>
