### PR TITLE
[Web Edit Task Model](1) Prove web UI edit-task-model is unreachable (unknown_channel)

### DIFF
--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -178,6 +178,13 @@ describe('buildWebInvokerDispatch', () => {
     expect(spawnRepairWorkflow).toHaveBeenCalledWith(payload);
   });
 
+  it('edit-task-model currently rejects as unknown_channel (bug: not wired into the web dispatch)', async () => {
+    const { dispatch } = makeDispatch();
+    await expect(dispatch('invoker:edit-task-model', ['wf-1/task-1', 'gpt-5.3-codex-spark'])).rejects.toMatchObject({
+      code: 'unknown_channel',
+    });
+  });
+
   it('open-terminal degrades gracefully when task terminal support is absent', async () => {
     const { dispatch } = makeDispatch();
     expect(await dispatch('invoker:open-terminal', ['t'])).toEqual({

--- a/scripts/repro/repro-web-edit-task-model-unknown-channel.sh
+++ b/scripts/repro/repro-web-edit-task-model-unknown-channel.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Repro: the web bridge (packages/app/src/web/web-invoker-dispatch.ts) has no
+# case for 'invoker:edit-task-model', so the browser UI's "AI Model" dropdown
+# fails with "request failed" (code: unknown_channel) and never reaches
+# WorkflowMutationFacade/orchestrator.editTaskModel. edit-task-agent works
+# fine because it does have a case in the same switch.
+#
+# Usage: bash scripts/repro/repro-web-edit-task-model-unknown-channel.sh
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+pnpm --filter @invoker/app test -- -t "edit-task-model currently rejects as unknown_channel"


### PR DESCRIPTION
## Summary

The web UI's "AI Model" dropdown (used by browser-served instances, e.g. an owner-serve droplet) always fails to switch models.

The failure is a generic "request failed" toast. Nothing about it reaches the server-side logger.

This slice proves why: the web bridge's channel router has no case for the model-edit channel at all.

Its sibling channel, agent editing, already has a working case in the same switch. Model editing was never added alongside it.

## Review Claim

Approve a test and repro script that prove `invoker:edit-task-model` currently falls through to `unknown_channel` in the web dispatch, before any fix is applied.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Adds a test and a script only. No product code changes in this slice, so there is nothing to review for runtime risk.

## Slice Rationale

Per the repo's stacking convention, the proof lands before the fix so the bug is demonstrated and reviewable on its own before the behavior change is approved. The fix is the next PR in this stack.

## Non-goals

Does not change any product code. Does not fix the bug — that's the next slice in the stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-web-edit-task-model-unknown-channel.sh` — passes, proving the current code rejects with `unknown_channel`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/web-invoker-dispatch.test.ts` — passes

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
