### PR TITLE
[Web Edit Task Model](2) Wire invoker:edit-task-model into the web dispatch

### DIFF
--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -17,6 +17,7 @@ function makeTask(id: string) {
 function makeDispatch(overrides: Record<string, unknown> = {}) {
   const approveTask = vi.fn(async () => ({ ok: true }));
   const spawnRepairWorkflow = vi.fn(async () => ({ ok: true }));
+  const editTaskModel = vi.fn(async () => ({ ok: true }));
   const deps = {
     orchestrator: {
       syncAllFromDb: vi.fn(),
@@ -27,7 +28,7 @@ function makeDispatch(overrides: Record<string, unknown> = {}) {
     persistence: {
       listWorkflows: () => [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
     },
-    mutations: { approveTask, spawnRepairWorkflow },
+    mutations: { approveTask, spawnRepairWorkflow, editTaskModel },
     agentRegistry: { listExecutionHarnesses: () => [] },
     loadConfig: () => ({}),
     getStreamSequence: () => 7,
@@ -36,7 +37,7 @@ function makeDispatch(overrides: Record<string, unknown> = {}) {
     detachWorkflow: vi.fn(async () => {}),
     ...overrides,
   };
-  return { dispatch: buildWebInvokerDispatch(deps as never), approveTask, spawnRepairWorkflow };
+  return { dispatch: buildWebInvokerDispatch(deps as never), approveTask, spawnRepairWorkflow, editTaskModel };
 }
 function makeTaskTerminalAdapter() {
   return {
@@ -178,11 +179,10 @@ describe('buildWebInvokerDispatch', () => {
     expect(spawnRepairWorkflow).toHaveBeenCalledWith(payload);
   });
 
-  it('edit-task-model currently rejects as unknown_channel (bug: not wired into the web dispatch)', async () => {
-    const { dispatch } = makeDispatch();
-    await expect(dispatch('invoker:edit-task-model', ['wf-1/task-1', 'gpt-5.3-codex-spark'])).rejects.toMatchObject({
-      code: 'unknown_channel',
-    });
+  it('edit-task-model routes to the mutation facade', async () => {
+    const { dispatch, editTaskModel } = makeDispatch();
+    await dispatch('invoker:edit-task-model', ['wf-1/task-1', 'gpt-5.3-codex-spark']);
+    expect(editTaskModel).toHaveBeenCalledWith('wf-1/task-1', 'gpt-5.3-codex-spark');
   });
 
   it('open-terminal degrades gracefully when task terminal support is absent', async () => {

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -80,6 +80,7 @@ export interface ApiMutationFacade {
   editTaskPrompt(taskId: string, newPrompt: string): Promise<MutationResult>;
   editTaskType(taskId: string, runnerKind: string, poolMemberId?: string): Promise<MutationResult>;
   editTaskAgent(taskId: string, agentName: string): Promise<MutationResult>;
+  editTaskModel(taskId: string, executionModel: string | null): Promise<MutationResult>;
   setTaskExternalGatePolicies(
     taskId: string,
     updates: ExternalGatePolicyUpdate[],

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -227,6 +227,8 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return mutations.editTaskPrompt(String(args[0]), String(args[1]));
       case 'invoker:edit-task-agent':
         return mutations.editTaskAgent(String(args[0]), String(args[1]));
+      case 'invoker:edit-task-model':
+        return mutations.editTaskModel(String(args[0]), args[1] === undefined || args[1] === null ? null : String(args[1]));
       case 'invoker:edit-task-type':
         return mutations.editTaskType(
           String(args[0]),

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -692,6 +692,14 @@ export function editTaskAgent(
   return deps.orchestrator.editTaskAgent(taskId, agentName);
 }
 
+export function editTaskModel(
+  taskId: string,
+  executionModel: string | null,
+  deps: Pick<ActionDeps, 'orchestrator'>,
+): TaskState[] {
+  return deps.orchestrator.editTaskModel(taskId, executionModel);
+}
+
 export function setTaskExternalGatePolicies(
   taskId: string,
   updates: ExternalGatePolicyUpdate[],

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -40,6 +40,7 @@ import {
   editTaskPrompt as sharedEditTaskPrompt,
   editTaskType as sharedEditTaskType,
   editTaskAgent as sharedEditTaskAgent,
+  editTaskModel as sharedEditTaskModel,
   setTaskExternalGatePolicies as sharedSetTaskExternalGatePolicies,
   setWorkflowExternalGatePolicies as sharedSetWorkflowExternalGatePolicies,
   setWorkflowMergeMode as sharedSetWorkflowMergeMode,
@@ -259,6 +260,14 @@ export class WorkflowMutationFacade {
       orchestrator: this.deps.orchestrator,
     });
     return this.finalizeWithTopup(started, 'facade.edit-task-agent', { scopedTaskIds: [taskId] });
+  }
+
+  async editTaskModel(taskId: string, executionModel: string | null): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
+    const started = sharedEditTaskModel(taskId, executionModel, {
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.edit-task-model', { scopedTaskIds: [taskId] });
   }
 
   async setTaskExternalGatePolicies(


### PR DESCRIPTION
## Summary

This fixes the bug proved in the previous slice: the web UI's AI Model dropdown couldn't actually switch a task's model.

The request never reached the backend. The web bridge's command dispatch had no case exposed for editing a task's model.

This adds that case, following the exact pattern its sibling (agent editing) already uses.

Only the browser-served UI (owner-serve's HTTP bridge, e.g. a remote droplet viewed at `:4200`) was affected. The desktop Electron app uses a separate IPC path that already worked.

## Review Claim

Approve wiring `invoker:edit-task-model` through the same facade chain `edit-task-agent` already uses, so the web UI's model dropdown reaches the backend.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Every new method (`workflow-actions.editTaskModel`, `WorkflowMutationFacade.editTaskModel`) is a one-line mirror of the existing, already-shipped `editTaskAgent` sibling in the same files, calling the same already-tested `orchestrator.editTaskModel`. No new logic, no new validation, no changed behavior for any other channel.

## Slice Rationale

Single behavior slice: one missing command case, exposed at every layer it needs to pass through (shared action → facade → HTTP dispatch), with the previous slice's proof test flipped from asserting the bug to asserting the fix.

## Non-goals

Does not add a new public REST endpoint (`POST /api/tasks/:id/edit-model`) to `api-server.ts`'s separate HTTP endpoint table — that's a distinct, unreported consumer, out of scope here.

Does not touch codex model discovery/catalog logic (`CODEX_FALLBACK_MODELS`, `discoverSupportedModels`) — that was investigated and ruled out as the cause of the reported failure.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-web-edit-task-model-unknown-channel.sh` — now matches 0 tests (exit 0): this slice renames the bug-proof test the script targets into the passing test below, so the script's original assertion no longer applies
- [x] `pnpm --filter @invoker/app test -- src/__tests__/web-invoker-dispatch.test.ts src/__tests__/workflow-mutation-facade.test.ts src/__tests__/workflow-actions.test.ts src/__tests__/api-server.test.ts` — 209/209 passed
- [x] `pnpm --filter @invoker/app build` — clean, no type errors

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
