### PR TITLE
[Vendor Reflect Skill](1) Add a script to vendor skills/reflect/ from catstack

### DIFF
--- a/scripts/vendor-reflect-skill.sh
+++ b/scripts/vendor-reflect-skill.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Vendors skills/reflect/ from the canonical catstack repo into this repo.
+#
+# catstack (https://github.com/EdbertChan/catstack) is the source of truth
+# for the reflect skill. Invoker keeps a self-contained copy because the
+# ci-regression-watch workflow spawns headless tasks on remote SSH pool
+# workers that read skills/reflect/SKILL.md straight out of this repo --
+# those ephemeral droplets don't have catstack cloned. Run this script
+# whenever catstack's reflect skill changes, instead of hand-editing the
+# copy here, so the two never silently diverge.
+#
+# Usage: bash scripts/vendor-reflect-skill.sh [--source <path-to-catstack-checkout>]
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+SOURCE="${CATSTACK_PATH:-../catstack}"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --source) SOURCE="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ ! -d "$SOURCE/skills/reflect" ]; then
+  echo "FAIL: no skills/reflect/ found at $SOURCE" >&2
+  echo "Pass --source <path> or set CATSTACK_PATH to a catstack checkout." >&2
+  exit 1
+fi
+
+SOURCE_SHA="$(git -C "$SOURCE" rev-parse HEAD)"
+DIRTY=""
+if [ -n "$(git -C "$SOURCE" status --porcelain -- skills/reflect)" ]; then
+  DIRTY=" (with uncommitted local changes to skills/reflect)"
+fi
+
+rm -rf skills/reflect
+mkdir -p skills/reflect
+cp -R "$SOURCE/skills/reflect/." skills/reflect/
+
+cat > skills/reflect/.vendor-source.json <<JSON
+{
+  "source": "catstack",
+  "sourceRepo": "https://github.com/EdbertChan/catstack",
+  "sourceCommit": "$SOURCE_SHA$DIRTY",
+  "vendoredAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+JSON
+
+echo "Vendored skills/reflect/ from $SOURCE @ $SOURCE_SHA$DIRTY"


### PR DESCRIPTION
## Summary

Invoker's local copy of `skills/reflect/` had quietly drifted from catstack's, the repo where it's actually maintained.

Catstack had multi-conversation mode, two extra scripts, and two thrash-detectors that Invoker's copy was missing entirely.

Nothing caught this. There was no sync step and no version marker, so the two copies just diverged in silence.

This adds the sync tool: a script that copies `skills/reflect/` from a catstack checkout and stamps the source commit. It does not run it yet.

## Review Claim

Approve a one-way sync script (catstack → Invoker) for `skills/reflect/`.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The script only touches `skills/reflect/` and only when explicitly invoked. It fails closed (`set -euo pipefail`, exits with a clear message) if the source path has no `skills/reflect/`, so it can't silently no-op or half-copy.

## Slice Rationale

Tool first, application second: this slice ships the mechanism on its own so it's reviewable independent of the (large, mostly-vendored) content diff it will apply in the next slice.

## Non-goals

Does not run the script or touch `skills/reflect/` in this slice — that's the next PR in this stack. Does not build automatic/scheduled syncing; this stays a manual step run when catstack's reflect skill changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/vendor-reflect-skill.sh --help` — prints usage and exits 0
- [x] `bash scripts/vendor-reflect-skill.sh --source /nonexistent` — fails closed with a clear error and non-zero exit

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
