### PR TITLE
[CI regression: 2f7c85f-required-fast-pr-babysit-harness](1) Resilient apt-get install for required-fast-extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,7 +581,48 @@ jobs:
 
       - name: Install system libraries for Node
         if: matrix.runner_label != 'Github_Runner'
-        run: sudo apt-get update -qq && sudo apt-get install -y libatomic1 make g++
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          has_libatomic() {
+            if command -v ldconfig >/dev/null 2>&1; then
+              ldconfig -p 2>/dev/null | grep -q 'libatomic\.so\.1'
+              return
+            fi
+            find /lib /usr/lib -name 'libatomic.so.1*' -print -quit 2>/dev/null | grep -q .
+          }
+
+          missing_native_tools=()
+          for tool in make g++; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              missing_native_tools+=("$tool")
+            fi
+          done
+
+          if has_libatomic && [ "${#missing_native_tools[@]}" -eq 0 ]; then
+            exit 0
+          fi
+
+          if ! command -v apt-get >/dev/null 2>&1; then
+            echo "::error::required-fast-extra requires libatomic1, make, and g++, but apt-get is unavailable."
+            exit 1
+          fi
+
+          if [ "$(id -u)" -eq 0 ]; then
+            apt-get update -qq
+            apt-get install -y libatomic1 make g++
+            exit 0
+          fi
+
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo -n apt-get update -qq
+            sudo -n apt-get install -y libatomic1 make g++
+            exit 0
+          fi
+
+          echo "::error::required-fast-extra requires libatomic1, make, and g++; run as root or provide passwordless sudo for apt-get."
+          exit 1
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

CI job `required-fast / PR Babysit Harness` first failed on default-branch push commit 2f7c85ff4f4b339640b6defd0fbe0949eb5d16d8 (run 31913088942) and was still red at 59df38dfc7557db5cb55cf9d545435ed2833c045 (run 31928558144).

The `required-fast-extra` runner's "Install system libraries for Node" step ran a plain `sudo apt-get install`. That assumes root or passwordless sudo is always available.

That assumption isn't true on every runner in the pool. When `sudo` can't run non-interactively, the step fails outright and blocks every downstream job, including the PR Babysit Harness test.

This PR swaps that plain install for the has_libatomic/sudo-n resilient pattern already used elsewhere in this workflow.

It skips the install when the tools are already present, installs directly as root, falls back to passwordless sudo, and only errors when none of those paths work.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31913088942/job/95083431923

## Review Claim

Approve replacing required-fast-extra's brittle `sudo apt-get install` step with the existing has_libatomic/sudo-n resilient install pattern, with no other CI or product behavior changed.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The new install step is a strict superset of the old one: it still installs libatomic1, make, and g++ whenever they're missing, but now also tolerates environments where they're already present or where root/passwordless sudo isn't available. No other job step, workflow file section, or product code path is touched.

## Slice Rationale

This is the smallest fix for the first-bad-commit regression: one CI step, in one job, in one file. The reflect/skill-update pass over this same repair is kept in a separate downstream PR so each slice carries exactly one reviewable claim.

## Non-goals

Does not touch the other apt-get install steps elsewhere in this workflow file that share the same brittle shape (see Consolidation signal). Does not change any product code, test code, or skill/docs files.

Consolidation signal: `git log --oneline --all -S "apt-get install" -- .github/workflows/ci.yml` and the narrower `-S "has_libatomic"` search show this has_libatomic/sudo-n resilience pattern has already been applied independently at least 4 times in this workflow file before this fix (e.g. `d269de2f5`, `ec4a30c54`, `daaa3bdaf`, `876f8bda1`). A shared composite action or script would prevent this class of regression from recurring in yet another job's own copy of the install step; that consolidation is recommended, not performed, in this job-scoped fix.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/28-pr-babysit-harness.sh` — exit code 0

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the original plain `apt-get install` step, which is only unsafe on runners without root or passwordless sudo — the original failure mode this PR fixes.
- Data migration? No

</details>

