### PR TITLE
[CI regression: cd07355-required-fast-mergify-admin-requeue](1) required-fast-extra install step gains unzip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -581,7 +581,7 @@ jobs:
 
       - name: Install system libraries for Node
         if: matrix.runner_label != 'Github_Runner'
-        run: sudo apt-get update -qq && sudo apt-get install -y libatomic1 make g++
+        run: sudo apt-get update -qq && sudo apt-get install -y libatomic1 make g++ unzip
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -194,6 +194,10 @@ assert(
     && String(requiredFastExtraNodeLibraryStep?.run ?? '').includes('g++'),
   'required-fast-extra must install make and g++ so pnpm can build native dependencies on self-hosted runners',
 );
+assert(
+  String(requiredFastExtraNodeLibraryStep?.run ?? '').includes('unzip'),
+  'required-fast-extra must install unzip so the Electron repair fallback can complete during pnpm install',
+);
 const requiredFastExtraEntries = jobs['required-fast-extra'].strategy?.matrix?.include ?? [];
 const branchCarryForwardEntry = requiredFastExtraEntries.find((entry) => entry.name === 'Branch Carry Forward');
 assert(branchCarryForwardEntry, 'required-fast-extra matrix must include Branch Carry Forward');


### PR DESCRIPTION
## Summary

CI job `required-fast / Mergify Admin Requeue` (rendered by `required-fast-extra`) first failed on
default-branch commit cd07355fe00361ce676b048a6c1be5696968fe2a.

The job's Node system-library install step was missing `unzip`. The Electron repair fallback needs
it during `pnpm install` on self-hosted runners.

This change adds `unzip` to the install step and asserts it in the CI workflow policy test, so a
future edit to that step can't drop it silently again.

## Review Claim

The `required-fast-extra` install step gains `unzip`, and the policy test asserts it stays there.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Adding one apt package to one CI install step cannot change product or other-job behavior. The step
only runs `if: matrix.runner_label != 'Github_Runner'`, so it is scoped to self-hosted runners.

## Slice Rationale

`scripts/test-suites/required/12-mergify-admin-requeue.sh` discovers and runs every
`scripts/repro/repro-*.sh` matching `mergify_admin_requeue` by name/content, so the same composite
job can go red for two independent root causes at once. This slice is the install-step fix only,
isolated from the unrelated repro-script IPC-mock fix in the next PR in this stack.

## Non-goals

Does not touch `scripts/repro/repro-babysit-pr-body-prereq-split.sh` or any skills/docs content;
those are separate slices later in this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/12-mergify-admin-requeue.sh`
- [ ] `node scripts/test-ci-workflow-merge-queue-policy.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8d01c990f`
- Post-revert steps: None
- Data migration? No

</details>
