### PR TITLE
Classify .github/ paths as scope kind "policy" to match their tooling-policy review unit

### DIFF
--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -891,6 +891,12 @@ assert(
   JSON.stringify(scopeKindsForChangedFiles(proofToolingPolicyFiles)) === JSON.stringify(['policy']),
   'scopeKindsForChangedFiles should drop other files and keep sorted unique policy kinds',
 );
+assert(
+  JSON.stringify(scopeKindsForChangedFiles(['.github/workflows/ci.yml'])) === JSON.stringify(['policy']),
+  'a .github/ file alone must map to scope kind "policy", matching its tooling-policy review unit -- '
+  + 'otherwise the repair-normalize auto-split gate (which requires "policy" in scopeKinds) silently '
+  + 'refuses to split a proof-lane PR whose only tooling-policy file lives under .github/',
+);
 
 const refactorBody = `## Summary
 

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -237,7 +237,7 @@ export function classifyScopeKind(filePath) {
   if (path.startsWith('scripts/repro/')) return 'proof';
   if (path.startsWith('packages/app/e2e/visual-proof/')) return 'product-test';
   if (path.startsWith('skills/') || path.startsWith('docs/') || path.endsWith('.md')) return 'docs';
-  if (path.startsWith('scripts/')) return 'policy';
+  if (path.startsWith('scripts/') || path.startsWith('.github/')) return 'policy';
   if (
     path.includes('/e2e/')
     || path.includes('/__tests__/')


### PR DESCRIPTION
## Summary

PR #9379's repair kept failing the same "proof cannot ship with tooling-policy files" error, even though its fix genuinely needed a CI-config change. The auto-split step meant to handle that refused to fire.

Two classifiers disagree about `.github/` files: one already treats them as `tooling-policy`. The other had no rule for `.github/` at all, so it silently dropped them. That mismatch broke the auto-split check.

This adds the missing rule so both classifiers agree.

## Review Claim

Approve one classifier rule: `.github/` paths now map to scope kind `"policy"`, matching how they're already classified as review unit `tooling-policy` elsewhere in this file.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The only behavior change is what `classifyScopeKind` returns for paths under `.github/` -- every other path prefix's classification is untouched. `.github/` paths already reject cleanly as `tooling-policy` review unit; this only fixes their `scopeKinds` classification to match.

## Slice Rationale

One self-contained fix: the missing classifier rule plus the isolated test that proves it, in the same file pair the existing tests already live in.

## Non-goals

Does not change `review-unit-rules.mjs`'s existing `tooling-policy` classification for `.github/` -- that was already correct. Does not touch the repair-normalize Python script itself; its logic was correct, it was just fed wrong data. Does not touch the `dag-surface-background-click-noop` guard (packages/ui/src/App.tsx) -- the linter flags it only because this diff's insertion shifts the line number of that guard's marker string as it appears inside this file's own `guardedBehaviorTouchingDiff` test fixture (sample diff text used to test the guarded-behavior detector), not because any real behavior changed.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-pr-body-validator.mjs`
- [ ] `node scripts/test-review-unit-classification.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert <merge-commit-sha>`
- Post-revert steps: None -- reverts to the prior (broken) classification, no data involved.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated change classification so workflow files are correctly recognized as policy-related.
  * Preserved existing handling for script-related changes and automated review splitting.

* **Tests**
  * Added regression coverage for workflow-only changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->