### PR TITLE
[CI regression: e3bd9bf-required-fast-start-running-mece-repros](1) Replace unzip shell-out with extract-zip in Electron repair

### DIFF
--- a/scripts/electron.cjs
+++ b/scripts/electron.cjs
@@ -68,7 +68,7 @@ function getElectronPlatformPath() {
   }
 }
 
-async function repairElectronWithSystemUnzip(electronPackageDir) {
+async function repairElectronWithPackageExtractor(electronPackageDir) {
   if (process.env.ELECTRON_OVERRIDE_DIST_PATH) {
     return null;
   }
@@ -78,6 +78,10 @@ async function repairElectronWithSystemUnzip(electronPackageDir) {
     paths: [electronPackageDir],
   });
   const { downloadArtifact } = require(electronGetPath);
+  const extractZipPath = require.resolve('extract-zip', {
+    paths: [electronPackageDir],
+  });
+  const extractZip = require(extractZipPath);
   const platformPath = getElectronPlatformPath();
   const platform = process.env.npm_config_platform || process.platform;
   const arch = process.env.npm_config_arch || process.arch;
@@ -96,19 +100,7 @@ async function repairElectronWithSystemUnzip(electronPackageDir) {
   const distPath = path.join(electronPackageDir, 'dist');
   fs.rmSync(distPath, { recursive: true, force: true });
   fs.mkdirSync(distPath, { recursive: true });
-
-  const unzip = spawnSync('unzip', ['-q', '-o', zipPath, '-d', distPath], {
-    cwd: electronPackageDir,
-    env: process.env,
-    stdio: 'inherit',
-  });
-  if (unzip.status !== 0) {
-    return null;
-  }
-  if (unzip.signal) {
-    process.kill(process.pid, unzip.signal);
-    return null;
-  }
+  await extractZip(zipPath, { dir: distPath });
 
   const sourceTypeDefinitions = path.join(distPath, 'electron.d.ts');
   if (fs.existsSync(sourceTypeDefinitions)) {
@@ -166,7 +158,7 @@ async function installElectronOrExit() {
     return installedBinary;
   }
 
-  const repairedBinary = await repairElectronWithSystemUnzip(electronPackageDir);
+  const repairedBinary = await repairElectronWithPackageExtractor(electronPackageDir);
   if (!repairedBinary) {
     console.error(
       'Electron is still unavailable after running its installer. ' +


### PR DESCRIPTION
## Summary

CI job `required-fast / Start Running MECE Repros` first failed on default-branch commit e3bd9bf0efa644a902dcb494fd7cf0e2f151cb89, in run 31928105866.

It was still red at 59df38dfc7557db5cb55cf9d545435ed2833c045, in run 31928558144.

The job's Electron repair step shelled out to a system `unzip` binary. A missing or differently-behaving binary on the CI runner makes the repair silently fail.

This change replaces the `unzip` shell-out with the `extract-zip` npm package, already a project dependency. The repair no longer depends on anything outside `node_modules`.

A local run of the failing suite passed after the change. A downstream reflection pass looked for a durable skill or check update it could add.

It found none, so no `skills/` files change in this PR.

## Review Claim

The change corrects the CI regression's root cause — a host-provisioned `unzip` dependency in the Electron repair path — with no unrelated edits.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The only file touched is `scripts/electron.cjs`, a build-time helper script that runs during Electron installation/repair. It does not run in production or affect any other CI job's behavior; other jobs and product behavior stay unchanged except for this corrected defect.

## Slice Rationale

This is the only concrete file change produced across the fix, verify, and reflect tasks for this regression: the verify task ran a proof command with no code diff, and the reflect task's synthesis found no durable finding, so there is nothing to review as separate slices. Bundling them into one PR avoids publishing empty-diff PRs into the stack.

## Non-goals

No refactor of unrelated Electron install/repair logic, no unrelated cleanup, no test weakening, no snapshot churn. No skill or check changes are included, since the reflection pass found no durable finding to encode.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/18-start-running-mece-repros.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert ad5c49abf678aa0bc2415ec326403480d9761b1d`
- Post-revert steps: None
- Data migration? No

</details>
