### PR TITLE
[CI regression: 7471853-fleet-7471853-3-jobs](1) clean up stale .git lock before checkout in UI Vitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,9 @@ jobs:
 
     steps:
       - name: Reclaim workspace
-        run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" "$HOME/.invoker" "$HOME/.claude" 2>/dev/null || true
+        run: |
+          sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" "$HOME/.invoker" "$HOME/.claude" 2>/dev/null || true
+          find "$GITHUB_WORKSPACE/.git" -name '*.lock' -delete 2>/dev/null || true
         shell: bash
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

The `UI Vitest` job in `.github/workflows/ci.yml` intermittently failed before checkout with `cannot lock ref 'refs/remotes/origin/master': ... File exists`.

The runner is self-hosted and reused across jobs. A leftover `.git/refs/.../*.lock` file from a prior run's interrupted git process survives between jobs.

The `Reclaim workspace` step already runs a `chown` pass before checkout. It did not touch leftover lock files, so an old lock blocked the next job's fetch.

This fix adds a `find` step that clears matching lock files from `$GITHUB_WORKSPACE/.git`, right after the `chown` pass and before checkout.

## Review Claim

The added line clears leftover `.git/**/*.lock` files before checkout, and does not change any other step or job.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change only adds a best-effort `find -delete` (already using `|| true`, matching the existing chown line's failure-tolerant style) to a workspace-reset step that runs before checkout on a self-hosted runner. It cannot affect any other job, since each job's copy of `Reclaim workspace` is independent, and it cannot affect application behavior since it only touches the runner's own `.git` metadata before source is checked out.

## Slice Rationale

This is the one behavior change in the stack: a single-line fix to the `ui-vitest` job's `Reclaim workspace` step. The follow-on `/reflect` pass over this fix is published separately as a `docs` lane PR downstream of this one, so the behavior fix and the docs-only lesson-learned update review independently.

## Non-goals

No refactor of the `Reclaim workspace` step into a shared/composite action, and no changes to the other 6 copies of this step across `.github/workflows/ci.yml`'s other jobs. The downstream `reflect` PR in this stack documents that gap explicitly rather than silently expanding this PR's scope; a structural fix (composite action, or a lint check for step-body drift across jobs) is recorded there as backlog for a separate task.

## Test Plan

<details>
<summary>Test Plan</summary>

This is an infra-class fix (a stale `.git/*.lock` race on a reused self-hosted runner, before checkout) and is not exercised by the package's own unit test command — the failure never reaches application code. Evidence and verification instead come from the CI job logs directly.

- [x] Repro waiver — quoted directly from the failing run's job log (`UI Vitest`, run 31930355390, job 95124889275, first bad commit `74718538a683da0f74ae6ef2688feee8ec851906`):
  ```
  2026-08-16T06:08:37.7155038Z ##[error]error: cannot lock ref 'refs/remotes/origin/master': Unable to create '/opt/actions-runner/_work/Invoker/Invoker/.git/refs/remotes/origin/master.lock': File exists.
  2026-08-16T06:08:56.2597752Z ##[error]error: cannot lock ref 'refs/remotes/origin/master': Unable to create '/opt/actions-runner/_work/Invoker/Invoker/.git/refs/remotes/origin/master.lock': File exists.
  2026-08-16T06:09:21.0370553Z ##[error]error: cannot lock ref 'refs/remotes/origin/master': Unable to create '/opt/actions-runner/_work/Invoker/Invoker/.git/refs/remotes/origin/master.lock': File exists.
  2026-08-16T06:09:21.1796952Z ##[error]The process '/usr/bin/git' failed with exit code 1
  ```
- [x] `pnpm --filter @invoker/ui test` — the job's stated acceptance command; it does not exercise the lock-cleanup path, but was run here to confirm this PR carries no unrelated regression. Result: 93 test files, 857 tests, all passed, exit 0.
- [ ] Post-merge: confirm the next `UI Vitest` run on this runner passes checkout without a `cannot lock ref` error.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a407980d8`
- Post-revert steps: None
- Data migration? No

</details>
