### PR TITLE
[CI regression: 0d620ba-playwright-7-of-9](1) Fix Promise-truthiness race in dag-click-hitch-responsiveness spec

### DIFF
--- a/packages/app/e2e/dag-click-hitch-responsiveness.spec.ts
+++ b/packages/app/e2e/dag-click-hitch-responsiveness.spec.ts
@@ -65,14 +65,13 @@ test('workflow select shows mini-DAG within 250ms under a fat events table', asy
   }, planText);
   await page.getByRole('button', { name: 'Refresh' }).click();
 
-  const smallId = await page.waitForFunction(
-    (knownIds) => window.invoker.listWorkflows().then((workflows) => {
-      const created = workflows.find((workflow) => !knownIds.includes(workflow.id));
-      return created?.id ?? null;
-    }),
-    [...beforeIds],
-    { timeout: 30_000 },
-  ).then(async (handle) => handle.jsonValue());
+  let smallId: string | null = null;
+  await expect.poll(async () => {
+    const workflows = await page.evaluate(async () => window.invoker.listWorkflows());
+    const created = workflows.find((workflow) => !beforeIds.has(workflow.id));
+    smallId = created?.id ?? null;
+    return smallId;
+  }, { timeout: 30_000 }).toBeTruthy();
   expect(smallId, 'expected newly loaded ack plan workflow').toBeTruthy();
 
   const workflowNode = page.getByTestId(`workflow-node-${smallId}`);


### PR DESCRIPTION
## Summary

CI job `playwright / 7-of-9` first failed on default-branch commit 0d620ba0e5a00e07f69cd4bc991aac73796404fb.

`dag-click-hitch-responsiveness.spec.ts` polled for a newly created workflow ID with `page.waitForFunction(predicate)`, where the predicate called `window.invoker.listWorkflows().then(...)`.

That predicate returns a Promise object, which Playwright always treats as truthy. The poll resolved on its first tick instead of actually waiting for the workflow to appear.

The spec now uses `expect.poll()` with an async callback that awaits `listWorkflows()` and returns the resolved workflow ID, so the wait only succeeds once the workflow is actually present.

This is the same class of bug PR #9267 fixed in the shared `loadPlan()` helper. This spec's own inline duplicate was missed by that fix.

## Review Claim

The reviewer is approving that switching this spec's polling from `page.waitForFunction` (with a Promise-returning, always-truthy predicate) to `expect.poll()` (with an awaited async callback) fixes the flaky/failing wait with no product code changes.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only `packages/app/e2e/dag-click-hitch-responsiveness.spec.ts` changes. No product code is touched. The assertion still waits for the same condition (a newly created workflow ID appearing in `listWorkflows()`) with the same 30-second timeout; it now actually waits for that condition instead of resolving immediately.

## Slice Rationale

One proof slice for the CI job's root cause: a single test-file fix, no unrelated edits. The `/reflect` findings from this repair (the reusable anti-pattern and the two other live instances of it) ship as the next stack slice so this fix reviews independently of the process lesson.

## Non-goals

- No refactor of `loadPlan()` or other shared e2e helpers.
- No fix to the two other live instances of this pattern (`visual-proof.spec.ts:2724`, `embedded-terminal-restart-persistence.spec.ts:99`); those are called out as backlog in the next stack slice.
- No product code changes.
- No snapshot churn.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-7-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/worker-tab-scroll.spec.ts e2e/workflow-delete-latency.spec.ts e2e/main-process-hitch-responsiveness.spec.ts e2e/dag-click-hitch-responsiveness.spec.ts e2e/terminal-upsert-hitch-responsiveness.spec.ts e2e/attention-click-hitch-responsiveness.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — the full-shard acceptance command, run by this workflow's `verify-ci-0d620ba-playwright-7-of-9` task against this exact fix commit. Recorded result: exit code 0 (see commit `96a2d4e06`).
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-pr-publish-verify' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/dag-click-hitch-responsiveness.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — re-run directly by me against this published stack branch, narrowed to the changed spec. Result: 2 passed (27.6s), exit code 0.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, but reverting restores the Promise-truthiness race and re-flakes/fails `playwright / 7-of-9`.
- Revert command: `git revert 7eaeb51f5`
- Post-revert steps: None
- Data migration? No

</details>
