### PR TITLE
[CI regression: cd07355-required-fast-mergify-admin-requeue](2) hermetic review-gate mock in prereq-split repro

### DIFF
--- a/scripts/repro/repro-babysit-pr-body-prereq-split.sh
+++ b/scripts/repro/repro-babysit-pr-body-prereq-split.sh
@@ -97,6 +97,22 @@ git add .github/workflows/ci.yml scripts/test-suites/required/guardrails.sh
 git commit -m "worker tooling-policy repair" >/dev/null
 EOF
 chmod +x "$TMP/bin/claude"
+
+# Without this, resolve_workflow_for_pr (mergify_admin_requeue_workflow_fastpath.py)
+# shells out to a live Invoker owner over IPC to look up a review-gate workflow
+# mapping for PR #5800, which this hermetic repro never provides -- the lookup
+# subprocess fails to connect, resolve_workflow_for_pr raises, and the whole
+# repair attempt aborts before reaching the async repair path below (same
+# hermetic-IPC class as the Incident 2026-08-12 note further down; mocked the
+# same way its sibling repros already do, e.g. repro-babysit-pr-body-human-split.sh).
+cat > "$TMP/review-gate.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{}\n'
+EOF
+chmod +x "$TMP/review-gate.sh"
+export INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh"
+
 REMOTE="$TMP/origin.git"
 SEED="$TMP/seed"
 WORK_ROOT="$WORK_PARENT/5800"


### PR DESCRIPTION
## Summary

CI job `required-fast / Mergify Admin Requeue` (rendered by `required-fast-extra`) first failed on
default-branch commit cd07355fe00361ce676b048a6c1be5696968fe2a.

That job pattern-matches and runs every proof repro under `scripts/repro/` whose name or content
mentions `mergify_admin_requeue`. One of those hermetic repros never provides a live Invoker owner.

So a lookup helper it calls (`resolve_workflow_for_pr` in
`mergify_admin_requeue_workflow_fastpath.py`) tries a real IPC call to look up a review-gate
workflow mapping for a fixture PR, and fails to connect.

The repro then aborts before it ever reaches the repair path it is meant to exercise.

This change adds a small local mock for that one lookup, matching how sibling repros already stub
the same call, so the repro stays hermetic end to end.

## Review Claim

This PR mocks one IPC lookup inside one CI proof repro so it runs hermetically end to end.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The assertions the repro makes are identical before and after this change. The mock only stands in
for a live Invoker owner IPC call the repro should never depend on in CI; it does not change what
the repro checks.

## Slice Rationale

The CI job this repro belongs to pattern-matches and runs many proof repros by name/content, so it
can go red for two unrelated defects at once. This PR is the one IPC-lookup fix only, kept separate
from the unrelated CI-install-step fix in the prior PR in this stack.

## Non-goals

Does not touch `.github/workflows/ci.yml`, `scripts/test-ci-workflow-merge-queue-policy.mjs`, or any
skills/docs content; those are separate PRs in this stack. Does not change
`scripts/repro/repro-babysit-pr-body-prereq-split.sh`'s assertions, only its hermeticity.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-babysit-pr-body-prereq-split.sh`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/12-mergify-admin-requeue.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert abc53bf530f83850ea5f738197a045f11705c3cc`
- Post-revert steps: None
- Data migration? No

</details>
