### PR TITLE
[CI regression: 59df38d-e2e-proof-shard-1](1) Fall back to extract-zip when system unzip fails

### DIFF
--- a/scripts/electron.cjs
+++ b/scripts/electron.cjs
@@ -68,6 +68,32 @@ function getElectronPlatformPath() {
   }
 }
 
+async function extractElectronArchive(electronPackageDir, zipPath, distPath) {
+  const unzip = spawnSync('unzip', ['-q', '-o', zipPath, '-d', distPath], {
+    cwd: electronPackageDir,
+    env: process.env,
+    stdio: 'inherit',
+  });
+  if (unzip.signal) {
+    process.kill(process.pid, unzip.signal);
+    return false;
+  }
+  if (!unzip.error && unzip.status === 0) {
+    return true;
+  }
+
+  const extractZipPath = require.resolve('extract-zip', {
+    paths: [electronPackageDir],
+  });
+  const extractZip = require(extractZipPath);
+  try {
+    await extractZip(zipPath, { dir: distPath });
+  } catch {
+    return false;
+  }
+  return true;
+}
+
 async function repairElectronWithSystemUnzip(electronPackageDir) {
   if (process.env.ELECTRON_OVERRIDE_DIST_PATH) {
     return null;
@@ -97,16 +123,8 @@ async function repairElectronWithSystemUnzip(electronPackageDir) {
   fs.rmSync(distPath, { recursive: true, force: true });
   fs.mkdirSync(distPath, { recursive: true });
 
-  const unzip = spawnSync('unzip', ['-q', '-o', zipPath, '-d', distPath], {
-    cwd: electronPackageDir,
-    env: process.env,
-    stdio: 'inherit',
-  });
-  if (unzip.status !== 0) {
-    return null;
-  }
-  if (unzip.signal) {
-    process.kill(process.pid, unzip.signal);
+  const extracted = await extractElectronArchive(electronPackageDir, zipPath, distPath);
+  if (!extracted) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

CI job `e2e-proof / shard 1` first failed on default-branch commit
59df38dfc7557db5cb55cf9d545435ed2833c045, run 31928558144.

The Electron postinstall repair step shells out to system `unzip` to
unpack Electron's prebuilt distribution archive.

When `unzip` is missing or fails, the repair silently returned null
with no fallback, so `pnpm install` on affected runners failed before
any test could run.

This adds a pure-JS unpacking fallback, using the already-vendored
`extract-zip` package, for when system `unzip` is unavailable or exits
non-zero.

## Review Claim

Approve that `repairElectronWithSystemUnzip` in `scripts/electron.cjs`
now falls back to `extract-zip` when system `unzip` fails or is absent,
instead of leaving the Electron dist directory unrepaired.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change is scoped to one build/tooling script (`scripts/electron.cjs`)
used only during `pnpm install`'s Electron postinstall repair step. It
does not touch product code, runtime behavior, or any other CI job's
setup. When system `unzip` succeeds (the common case), behavior is
byte-for-byte identical to before; the new code path only runs when
`unzip` was already going to fail.

## Slice Rationale

This is the one behavior change needed to make `e2e-proof / shard 1`
pass: a missing unpacking fallback in the Electron postinstall repair
script. The follow-up slice (skill guidance) is kept separate because
it is a distinct review claim about repair process, not code behavior.

## Non-goals

Does not change any other CI job's setup step. Does not change Electron
version pinning, packaging, or runtime code. Does not add general retry
or install logic beyond the one archive-unpacking path.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_SHARD_INDEX='1' INVOKER_TEST_ALL_SHARD_TOTAL=4 INVOKER_TEST_ALL_STATE_FILE=/tmp/invoker-ci-watch-proof-state.tsv TMPDIR=/tmp/invoker-tmp bash scripts/run-all-tests.sh` — exit 0 after this change (was failing before at 59df38dfc7557db5cb55cf9d545435ed2833c045)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

