### PR TITLE
[CI regression: 7471853-fleet-7471853-3-jobs](1) Clear leftover .git lock before ui-vitest checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,9 @@ jobs:
 
     steps:
       - name: Reclaim workspace
-        run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" "$HOME/.invoker" "$HOME/.claude" 2>/dev/null || true
+        run: |
+          sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" "$HOME/.invoker" "$HOME/.claude" 2>/dev/null || true
+          find "$GITHUB_WORKSPACE/.git" -name '*.lock' -delete 2>/dev/null || true
         shell: bash
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

CI job `fleet / 7471853 (3 jobs)` first failed on default-branch commit 74718538a683da0f74ae6ef2688feee8ec851906.

The `ui-vitest` job's "Reclaim workspace" step chowns the workspace but leaves a leftover `.git/*.lock` file behind from a prior interrupted run on the same reused self-hosted runner.

The next checkout on that runner then fails because git refuses to operate with a leftover lock file present.

This slice adds one extra line to that step so the leftover lock is gone before checkout runs.

## Review Claim

Approve the added `find` line in the `ui-vitest` job's "Reclaim workspace" step in `.github/workflows/ci.yml`, immediately after the existing `chown` line, that clears the leftover git lock file (see `## Safety Invariant` for the exact command).

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The added line is:

```
find "$GITHUB_WORKSPACE/.git" -name '*.lock' -delete 2>/dev/null || true
```

It is a best-effort operation guarded the same way as the adjacent `chown` line (redirected and `|| true`), so it cannot fail the step or affect any job other than `ui-vitest`. It runs before checkout, so it cannot touch a lock held by an in-progress git operation in this same job.

## Slice Rationale

This is the single root-cause line for the `fleet / 7471853 (3 jobs)` regression. It is kept separate from the downstream `/reflect` findings (CLAUDE.md class-search guidance) so the behavior fix and the process/docs follow-up are independently reviewable.

## Non-goals

Does not touch the other 6 copies of the "Reclaim workspace" step in `.github/workflows/ci.yml`; those are out of scope for this job-specific regression and are called out explicitly rather than silently left unfixed.

Does not change any other CI step, package, or product code.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
