### PR TITLE
[CI regression: cd07355-required-fast-mergify-admin-requeue](2) Mock review-gate IPC hermetically in prereq-split repro

### DIFF
--- a/scripts/repro/repro-babysit-pr-body-prereq-split.sh
+++ b/scripts/repro/repro-babysit-pr-body-prereq-split.sh
@@ -97,6 +97,22 @@ git add .github/workflows/ci.yml scripts/test-suites/required/guardrails.sh
 git commit -m "worker tooling-policy repair" >/dev/null
 EOF
 chmod +x "$TMP/bin/claude"
+
+# Without this, resolve_workflow_for_pr (mergify_admin_requeue_workflow_fastpath.py)
+# shells out to a live Invoker owner over IPC to look up a review-gate workflow
+# mapping for PR #5800, which this hermetic repro never provides -- the lookup
+# subprocess fails to connect, resolve_workflow_for_pr raises, and the whole
+# repair attempt aborts before reaching the async repair path below (same
+# hermetic-IPC class as the Incident 2026-08-12 note further down; mocked the
+# same way its sibling repros already do, e.g. repro-babysit-pr-body-human-split.sh).
+cat > "$TMP/review-gate.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{}\n'
+EOF
+chmod +x "$TMP/review-gate.sh"
+export INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh"
+
 REMOTE="$TMP/origin.git"
 SEED="$TMP/seed"
 WORK_ROOT="$WORK_PARENT/5800"


### PR DESCRIPTION
## Summary

`scripts/test-suites/required/12-mergify-admin-requeue.sh` runs every
`scripts/repro/repro-*.sh` whose contents mention `mergify_admin_requeue`,
so this job's prereq repro is part of the required-fast / Mergify Admin
Requeue job.

That repro was failing for a second, unrelated reason: it never mocked the
review-gate lookup. `resolve_workflow_for_pr` tried to reach a live Invoker
owner over IPC instead.

The lookup aborted before exercising the repair path the repro is meant to
test.

This stubs `INVOKER_PR_CRON_REVIEW_GATE_CMD` to a script that prints `{}`,
matching the same hermetic-IPC pattern a sibling repro already uses.

## Review Claim

Approve mocking the review-gate IPC lookup in this job's prereq repro
script so it runs hermetically.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The command is identical before and after the fix: only test-harness
plumbing inside one repro script changes, and the change is scoped to an
environment variable the repro's own subprocess reads. No product code or
other repro script is touched.

## Slice Rationale

This is a second, independent bug that this job's auto-detection pulled in
alongside the missing-`unzip` provisioning fixed in the previous PR.
Keeping each fix in its own PR preserves one reviewable claim per fix,
instead of one PR claiming to fix "the root cause" of a job that actually
had two problems.

## Non-goals

Does not change the CI workflow's package provisioning (previous PR in this
stack). Does not change any other repro script, even
`repro-babysit-pr-body-human-split.sh`, which shares the same
hermetic-IPC gap.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-babysit-pr-body-prereq-split.sh`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/12-mergify-admin-requeue.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge sha>`
- Post-revert steps: None
- Data migration? No

</details>
