### PR TITLE
Stop hardcoding executionAgent: codex on admin-bypass repair tasks

### DIFF
--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -80,9 +80,6 @@ def _repair_task_yaml(*, description: str, prompt: str) -> str:
     return (
         "  - id: repair\n"
         f"    description: {_yaml_str(description)}\n"
-        # codex reaches every SSH pool member; the default claude agent's
-        # session is broken on most of them right now.
-        "    executionAgent: codex\n"
         "    prompt: |\n"
         f"{_indent_block(prompt, 6)}\n"
     )

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -93,7 +93,14 @@ class AsyncRepairPlanTests(unittest.TestCase):
         self.assertIn("mergify_admin_requeue_repair_normalize.py", plan.yaml_text)
         self.assertIn("--json-kind 'repair-check-settled'", plan.yaml_text)
         self.assertIn("Failed check: PR Body", plan.yaml_text)
-        self.assertIn("executionAgent: codex", plan.yaml_text)
+        self.assertNotIn(
+            "executionAgent", plan.yaml_text,
+            "repair task must not hardcode an execution agent -- Invoker's own plan-submission "
+            "path already fills in the configured defaultExecutionAgent, and pinning one agent "
+            "here just trades one single-point-of-failure for another the next time that agent "
+            "has an outage (see #7085 for codex, and the 2026-08-16 claude OAuth incident this "
+            "hardcode caused)",
+        )
         # PR titles with quotes/colons must not corrupt the YAML document.
         self.assertIn('Fix \\"quoted\\" title: with colons', plan.yaml_text)
 
@@ -155,7 +162,7 @@ class AsyncRepairPlanTests(unittest.TestCase):
         self.assertIn("--json-kind 'conflict-repair-settled'", plan.yaml_text)
         self.assertIn("--json-key 'conflict:2647'", plan.yaml_text)
         self.assertIn("commit locally. Do not push.", plan.yaml_text)
-        self.assertIn("executionAgent: codex", plan.yaml_text)
+        self.assertNotIn("executionAgent", plan.yaml_text)
 
     def test_repair_bot_thread_plan_uses_thread_id_as_key(self):
         plan = async_repair.build_repair_bot_thread_plan(
@@ -164,7 +171,7 @@ class AsyncRepairPlanTests(unittest.TestCase):
         self.assertIn("--json-kind 'repair-bot-thread-settled'", plan.yaml_text)
         self.assertIn("--json-key 'tbot'", plan.yaml_text)
         self.assertIn("Thread: tbot", plan.yaml_text)
-        self.assertIn("executionAgent: codex", plan.yaml_text)
+        self.assertNotIn("executionAgent", plan.yaml_text)
 
     def test_submit_async_repair_plan_calls_headless_run_and_cleans_up_temp_file(self):
         plan = async_repair.AsyncRepairPlan(plan_name="admin-bypass-repair-check-pr-1-abc", yaml_text="name: x\n")


### PR DESCRIPTION
## Summary

Every admin-bypass repair task has been hardcoded to run on codex since PR #7085, back when claude's OAuth session was broken fleet-wide.

Today codex hit its own usage-limit quota while claude was healthy again -- and every repair task kept crashing anyway, still pinned to the now-broken agent.

This removes the hardcode so repairs use whatever agent is actually configured and healthy.

## Review Claim

Approve removing one hardcoded `executionAgent: codex` line from the generated repair task's YAML, letting Invoker's existing plan-submission default-filling (`applyConfiguredPlanDefaults`) supply the configured agent instead, the same way every other plan generator already works.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the three `build_repair_*_plan` functions' generated `repair` task changes -- it no longer specifies an agent, so it falls back to whatever `defaultExecutionAgent` is configured. No other task's shape, dependency, or command changes.

## Slice Rationale

One self-contained fix: the generator change plus its three existing test assertions, flipped to prove the agent is no longer hardcoded.

## Non-goals

Does not add per-task agent-failover logic (retry on a different agent automatically) -- that's a larger feature, not this fix's scope. Does not change any other plan generator's execution-agent handling.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 -m unittest scripts.test_mergify_admin_requeue_async_repair -v`
- [ ] `python3 -m pytest scripts/ -q -k "mergify_admin_requeue"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert <merge-commit-sha>`
- Post-revert steps: None -- reverts to the prior hardcode.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repair tasks now use the configured default execution agent instead of forcing a specific agent.
  * Updated repair, conflict-repair, and bot-thread plans to omit the execution-agent setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->