### PR TITLE
[CI Repair Dedup Ledger](1) Add the repair_filings dedup ledger table and adapter methods

### DIFF
--- a/packages/data-store/src/__tests__/repair-filings.test.ts
+++ b/packages/data-store/src/__tests__/repair-filings.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+describe('repair_filings ledger', () => {
+  it('rejects a second insert for the identical (kind, subject, stateSha) key', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const first = adapter.insertRepairFiling({
+        kind: 'ci-regression:required-fast-guardrails',
+        subject: 'master',
+        stateSha: 'sha-a',
+      });
+      expect(first.inserted).toBe(true);
+
+      // Same process, same connection, identical key -- this is the case a
+      // naive "read the file, decide, then append" implementation would get
+      // right too; the real proof is the cross-process case below.
+      const second = adapter.insertRepairFiling({
+        kind: 'ci-regression:required-fast-guardrails',
+        subject: 'master',
+        stateSha: 'sha-a',
+      });
+      expect(second.inserted).toBe(false);
+      expect(second.row.id).toBe(first.row.id);
+
+      const rows = adapter.listRepairFilings('ci-regression:required-fast-guardrails', 'master');
+      expect(rows).toHaveLength(1);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('rejects a duplicate filed by a fresh adapter instance against the same on-disk DB (simulated second process)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'repair-filings-'));
+    const dbPath = join(dir, 'invoker.db');
+    try {
+      const callerA = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+      const filedByA = callerA.insertRepairFiling({
+        kind: 'admin-requeue:rebase-conflict',
+        subject: '9425',
+        stateSha: 'sha-b',
+      });
+      expect(filedByA.inserted).toBe(true);
+      callerA.close();
+
+      // A brand new adapter instance opened fresh against the same file --
+      // no in-memory state carried over from callerA -- stands in for a
+      // second, independent OS process (e.g. a second cron sweep) racing
+      // to file the same repair.
+      const callerB = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+      const filedByB = callerB.insertRepairFiling({
+        kind: 'admin-requeue:rebase-conflict',
+        subject: '9425',
+        stateSha: 'sha-b',
+      });
+      expect(filedByB.inserted).toBe(false);
+      expect(filedByB.row.id).toBe(filedByA.row.id);
+
+      const rows = callerB.listRepairFilings('admin-requeue:rebase-conflict', '9425');
+      expect(rows).toHaveLength(1);
+      callerB.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not suppress a genuinely new state: different kind or different stateSha both file as new work', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      // Worked example from the design: rebase-conflict repaired at shaA,
+      // then a *different* check (ui-vitest) fails at shaB on the same PR,
+      // then master moves and the PR needs rebasing again, still at shaB.
+      const rebaseAtShaA = adapter.insertRepairFiling({
+        kind: 'admin-requeue:rebase-conflict',
+        subject: '9425',
+        stateSha: 'sha-a',
+      });
+      expect(rebaseAtShaA.inserted).toBe(true);
+
+      const uiVitestAtShaB = adapter.insertRepairFiling({
+        kind: 'admin-requeue:check:ui-vitest',
+        subject: '9425',
+        stateSha: 'sha-b',
+      });
+      expect(uiVitestAtShaB.inserted).toBe(true);
+
+      const rebaseAtShaBAgain = adapter.insertRepairFiling({
+        kind: 'admin-requeue:rebase-conflict',
+        subject: '9425',
+        stateSha: 'sha-b',
+      });
+      expect(rebaseAtShaBAgain.inserted).toBe(true);
+
+      // But re-detecting the same problem on the same state still collapses to one row.
+      const rebaseAtShaBRepeat = adapter.insertRepairFiling({
+        kind: 'admin-requeue:rebase-conflict',
+        subject: '9425',
+        stateSha: 'sha-b',
+      });
+      expect(rebaseAtShaBRepeat.inserted).toBe(false);
+
+      const rows = adapter.listRepairFilings('admin-requeue:rebase-conflict', '9425');
+      expect(rows).toHaveLength(2); // shaA and shaB, not a third for the repeat
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('release deletes a claimed row so a later attempt can reclaim the same key', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const claimed = adapter.insertRepairFiling({
+        kind: 'ci-regression:required-fast-guardrails',
+        subject: 'master',
+        stateSha: 'sha-d',
+      });
+      expect(claimed.inserted).toBe(true);
+
+      const released = adapter.deleteRepairFiling('ci-regression:required-fast-guardrails', 'master', 'sha-d');
+      expect(released).toBe(true);
+      expect(adapter.getRepairFiling('ci-regression:required-fast-guardrails', 'master', 'sha-d')).toBeUndefined();
+
+      // Reclaiming after release must succeed -- a transient downstream
+      // filing failure must not permanently block all future retries for
+      // this (kind, subject, stateSha).
+      const reclaimed = adapter.insertRepairFiling({
+        kind: 'ci-regression:required-fast-guardrails',
+        subject: 'master',
+        stateSha: 'sha-d',
+      });
+      expect(reclaimed.inserted).toBe(true);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('release on a key that was never claimed is a no-op that returns false', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const released = adapter.deleteRepairFiling('ci-regression:required-fast-guardrails', 'master', 'sha-never-claimed');
+      expect(released).toBe(false);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('stamps created_at from the DB clock, not a caller-supplied value', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const result = adapter.insertRepairFiling({
+        kind: 'ci-regression:fleet',
+        subject: 'master',
+        stateSha: 'sha-c',
+        metadata: { memberJobs: ['a', 'b', 'c'] },
+      });
+      expect(result.row.createdAt).toBeTruthy();
+      expect(result.row.metadata).toEqual({ memberJobs: ['a', 'b', 'c'] });
+
+      const fetched = adapter.getRepairFiling('ci-regression:fleet', 'master', 'sha-c');
+      expect(fetched?.createdAt).toBe(result.row.createdAt);
+    } finally {
+      adapter.close();
+    }
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -101,6 +101,30 @@ export interface WorkflowChannel {
   createdAt: string;
 }
 
+// ── Repair Filing Types (cross-system CI/PR repair dedup ledger) ─
+
+export interface RepairFiling {
+  id: number;
+  kind: string;
+  subject: string;
+  stateSha: string;
+  metadata?: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+export interface RepairFilingInsertInput {
+  kind: string;
+  subject: string;
+  stateSha: string;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface RepairFilingInsertResult {
+  /** True only when this call created the row; false means an identical (kind, subject, stateSha) row already existed. */
+  inserted: boolean;
+  row: RepairFiling;
+}
+
 // ── Workflow Types ──────────────────────────────────────────
 
 export interface Workflow {
@@ -429,6 +453,13 @@ export interface PersistenceAdapter {
   loadSlackPendingConfirmation(confirmKey: string): SlackPendingConfirmation | undefined;
   loadLatestSlackPendingConfirmationByThread(threadTs: string): SlackPendingConfirmation | undefined;
   deleteSlackPendingConfirmation(confirmKey: string): void;
+
+  // Repair filings (cross-system CI/PR repair dedup ledger)
+  insertRepairFiling(input: RepairFilingInsertInput): RepairFilingInsertResult;
+  getRepairFiling(kind: string, subject: string, stateSha: string): RepairFiling | undefined;
+  listRepairFilings(kind?: string, subject?: string): RepairFiling[];
+  /** Release a claimed (kind, subject, stateSha) row -- e.g. the actual filing failed after the claim succeeded -- so a later attempt can reclaim it. Returns true iff a row was deleted. */
+  deleteRepairFiling(kind: string, subject: string, stateSha: string): boolean;
 
   // Workflow channels (Slack workflow↔channel mapping)
   saveWorkflowChannel(rec: WorkflowChannel): void;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -41,6 +41,9 @@ import type {
   ExecutionResourceLeaseReleaseRow,
   LaunchDispatchInvalidationRow,
   PersistenceAdapter,
+  RepairFiling,
+  RepairFilingInsertInput,
+  RepairFilingInsertResult,
   ReviewGateLookup,
   Workflow,
   WorkflowReadOptions,
@@ -2636,6 +2639,73 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   deleteSlackPendingConfirmation(confirmKey: string): void {
     this.execRun('DELETE FROM slack_pending_confirmations WHERE confirm_key = ?', [confirmKey]);
+  }
+
+  // ── Repair Filings (cross-system CI/PR repair dedup ledger) ──
+
+  private mapRepairFilingRow(row: any): RepairFiling {
+    return {
+      id: row.id as number,
+      kind: row.kind as string,
+      subject: row.subject as string,
+      stateSha: row.state_sha as string,
+      metadata: row.metadata ? (JSON.parse(row.metadata as string) as Record<string, unknown>) : null,
+      createdAt: row.created_at as string,
+    };
+  }
+
+  insertRepairFiling(input: RepairFilingInsertInput): RepairFilingInsertResult {
+    return this.runTransaction(() => {
+      this.execRun(
+        `INSERT INTO repair_filings (kind, subject, state_sha, metadata)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(kind, subject, state_sha) DO NOTHING`,
+        [input.kind, input.subject, input.stateSha, input.metadata ? JSON.stringify(input.metadata) : null],
+      );
+      const inserted = this.db.getRowsModified() > 0;
+      const row = this.queryOne(
+        'SELECT * FROM repair_filings WHERE kind = ? AND subject = ? AND state_sha = ?',
+        [input.kind, input.subject, input.stateSha],
+      );
+      if (!row) {
+        throw new Error('insertRepairFiling: row missing immediately after INSERT ... ON CONFLICT DO NOTHING');
+      }
+      return { inserted, row: this.mapRepairFilingRow(row) };
+    });
+  }
+
+  getRepairFiling(kind: string, subject: string, stateSha: string): RepairFiling | undefined {
+    const row = this.queryOne(
+      'SELECT * FROM repair_filings WHERE kind = ? AND subject = ? AND state_sha = ?',
+      [kind, subject, stateSha],
+    );
+    return row ? this.mapRepairFilingRow(row) : undefined;
+  }
+
+  listRepairFilings(kind?: string, subject?: string): RepairFiling[] {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+    if (kind !== undefined) {
+      conditions.push('kind = ?');
+      params.push(kind);
+    }
+    if (subject !== undefined) {
+      conditions.push('subject = ?');
+      params.push(subject);
+    }
+    const where = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';
+    const rows = this.queryAll(`SELECT * FROM repair_filings${where} ORDER BY created_at DESC`, params);
+    return rows.map((row: any) => this.mapRepairFilingRow(row));
+  }
+
+  deleteRepairFiling(kind: string, subject: string, stateSha: string): boolean {
+    return this.runTransaction(() => {
+      this.execRun(
+        'DELETE FROM repair_filings WHERE kind = ? AND subject = ? AND state_sha = ?',
+        [kind, subject, stateSha],
+      );
+      return this.db.getRowsModified() > 0;
+    });
   }
 
   // ── Workflow Channels (Slack workflow↔channel mapping) ──

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -533,6 +533,18 @@ export const SCHEMA_DDL = `
         updated_at TEXT NOT NULL DEFAULT (datetime('now'))
       );
 
+      CREATE TABLE IF NOT EXISTS repair_filings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        kind TEXT NOT NULL,
+        subject TEXT NOT NULL,
+        state_sha TEXT NOT NULL,
+        metadata TEXT CHECK (metadata IS NULL OR json_valid(metadata)),
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_repair_filings_kind_subject_sha
+        ON repair_filings(kind, subject, state_sha);
+
     `;
 
 /** Idempotent `ALTER TABLE ... ADD COLUMN` migrations for older databases. */
@@ -676,6 +688,18 @@ export const POST_MIGRATION_STATEMENTS = [
     last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
   )`,
+  // repair_filings: durable cross-system dedup ledger for auto-filed CI/PR
+  // repair work. UNIQUE(kind, subject, state_sha) is the atomic
+  // insert-if-not-exists primitive -- see insertRepairFiling().
+  `CREATE TABLE IF NOT EXISTS repair_filings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    state_sha TEXT NOT NULL,
+    metadata TEXT CHECK (metadata IS NULL OR json_valid(metadata)),
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`,
+  'CREATE UNIQUE INDEX IF NOT EXISTS idx_repair_filings_kind_subject_sha ON repair_filings(kind, subject, state_sha)',
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */


### PR DESCRIPTION
## Summary

Adds a `repair_filings` table with a `NOT NULL` `UNIQUE(kind, subject, state_sha)` index, plus `insertRepairFiling`, `getRepairFiling`, `listRepairFilings`, and `deleteRepairFiling` adapter methods on top of it.

The table is additive only. No existing table, column, or query changes.

## Review Claim

Approve the new `repair_filings` table shape and its adapter methods as the storage layer the next slice in this stack builds on.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The migration only adds a new table and a new index; it does not alter any existing table, column, or query, so no other adapter caller can be broken by this slice alone. The insert path is a single atomic statement (`INSERT ... ON CONFLICT DO NOTHING` inside a transaction), so two callers racing on the same key resolve deterministically at the database layer rather than by check-then-write ordering.

## Slice Rationale

This is the foundation the rest of the stack builds on: a later surface needs adapter methods to call, and those adapter methods need a table to back them. Landing the storage layer first lets each following piece of this stack focus on its own review claim.

## Non-goals

Does not expose this table through any headless command, CLI, or script yet -- that's the next slice. Does not wire any existing caller (ci-regression-watch, mergify_admin_requeue) to it -- that's a later slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/data-store test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No -- the migration only adds a table and index; reverting it drops an unused table with no other code path referencing it yet

</details>
