### PR TITLE
Thread runHeadless's return value through the standalone-owner delegate

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2017,8 +2017,8 @@ function startHeadlessMode(): void {
           const { workflowId, priority } = classifyStandaloneHeadlessExecMutation(payload);
           const acknowledgement = acknowledgeNoTrackHeadlessExec(payload, workflowId, priority, 'standalone', headlessExecMutationContext);
           if (acknowledgement) return acknowledgement;
-          await runStandaloneWorkflowMutation(workflowId, priority, 'headless.exec', [payload], async () => {
-            await runHeadless(args, {
+          const commandResult = await runStandaloneWorkflowMutation(workflowId, priority, 'headless.exec', [payload], async () => {
+            return runHeadless(args, {
               ...headlessDeps,
               waitForApproval: delegatedWait,
               noTrack: delegatedNoTrack,
@@ -2026,7 +2026,10 @@ function startHeadlessMode(): void {
               mutationTiming: activeMutationContext?.mutationTiming,
             });
           });
-          return { ok: true };
+          return {
+            ok: true,
+            ...(commandResult && typeof commandResult === 'object' ? commandResult as Record<string, unknown> : {}),
+          };
         });
         messageBus.onRequest('headless.gui-mutation', async (req: unknown) => {
           noteStandaloneOwnerActivity();


### PR DESCRIPTION
The standalone-owner headless.exec path in main.ts also awaited
runHeadless and discarded its result before acking { ok: true },
mirroring the GUI-owner delegate's gap fixed in the previous slice.
Same fix, same rationale, split here because main.ts and the IPC
handler live in different review units (routing vs. activation-surface)
per this repo's own review-unit classification.

Depends-On: #9455