### PR TITLE
[CI Repair Dedup Ledger](3) Add the repair-filing headless command

### DIFF
--- a/packages/app/src/__tests__/headless-repair-filing.test.ts
+++ b/packages/app/src/__tests__/headless-repair-filing.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runHeadless } from '../headless.js';
+
+function makeDeps(insertRepairFiling: ReturnType<typeof vi.fn>, deleteRepairFiling?: ReturnType<typeof vi.fn>) {
+  return {
+    persistence: { insertRepairFiling, deleteRepairFiling } as any,
+  } as any;
+}
+
+describe('headless repair-filing insert', () => {
+  it('inserts a new (kind, subject, stateSha) row and prints the result as JSON', async () => {
+    const insertRepairFiling = vi.fn(() => ({
+      inserted: true,
+      row: { id: 1, kind: 'ci-regression:required-fast-guardrails', subject: 'master', stateSha: 'sha-a', metadata: null, createdAt: '2026-08-16T00:00:00.000Z' },
+    }));
+    const deps = makeDeps(insertRepairFiling);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHeadless(['repair-filing', 'insert', '--kind', 'ci-regression:required-fast-guardrails', '--subject', 'master', '--state-sha', 'sha-a'], deps);
+
+    expect(insertRepairFiling).toHaveBeenCalledWith({
+      kind: 'ci-regression:required-fast-guardrails',
+      subject: 'master',
+      stateSha: 'sha-a',
+      metadata: null,
+    });
+    const printed = JSON.parse(write.mock.calls.map(([chunk]) => String(chunk)).join(''));
+    expect(printed.inserted).toBe(true);
+    write.mockRestore();
+  });
+
+  it('reports inserted: false for a duplicate key without throwing', async () => {
+    const insertRepairFiling = vi.fn(() => ({
+      inserted: false,
+      row: { id: 1, kind: 'admin-requeue:rebase-conflict', subject: '9425', stateSha: 'sha-b', metadata: null, createdAt: '2026-08-16T00:00:00.000Z' },
+    }));
+    const deps = makeDeps(insertRepairFiling);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHeadless(['repair-filing', 'insert', '--kind', 'admin-requeue:rebase-conflict', '--subject', '9425', '--state-sha', 'sha-b'], deps);
+
+    const printed = JSON.parse(write.mock.calls.map(([chunk]) => String(chunk)).join(''));
+    expect(printed.inserted).toBe(false);
+    write.mockRestore();
+  });
+
+  it('parses --metadata as JSON and passes it through', async () => {
+    const insertRepairFiling = vi.fn(() => ({
+      inserted: true,
+      row: { id: 2, kind: 'ci-regression:fleet', subject: 'master', stateSha: 'sha-c', metadata: { memberJobs: ['a', 'b'] }, createdAt: '2026-08-16T00:00:00.000Z' },
+    }));
+    const deps = makeDeps(insertRepairFiling);
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHeadless(['repair-filing', 'insert', '--kind', 'ci-regression:fleet', '--subject', 'master', '--state-sha', 'sha-c', '--metadata', '{"memberJobs":["a","b"]}'], deps);
+
+    expect(insertRepairFiling).toHaveBeenCalledWith({
+      kind: 'ci-regression:fleet',
+      subject: 'master',
+      stateSha: 'sha-c',
+      metadata: { memberJobs: ['a', 'b'] },
+    });
+  });
+
+  it('throws a usage error when a required flag is missing', async () => {
+    const deps = makeDeps(vi.fn());
+    await expect(runHeadless(['repair-filing', 'insert', '--kind', 'k'], deps)).rejects.toThrow('Usage: --headless repair-filing');
+  });
+
+  it('throws a usage error for an unknown subcommand', async () => {
+    const deps = makeDeps(vi.fn());
+    await expect(runHeadless(['repair-filing', 'bogus'], deps)).rejects.toThrow('Usage: --headless repair-filing');
+  });
+
+  it('release calls deleteRepairFiling and reports whether a row was actually removed', async () => {
+    const deleteRepairFiling = vi.fn(() => true);
+    const deps = makeDeps(vi.fn(), deleteRepairFiling);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHeadless(['repair-filing', 'release', '--kind', 'ci-regression:required-fast-guardrails', '--subject', 'master', '--state-sha', 'sha-a'], deps);
+
+    expect(deleteRepairFiling).toHaveBeenCalledWith('ci-regression:required-fast-guardrails', 'master', 'sha-a');
+    const printed = JSON.parse(write.mock.calls.map(([chunk]) => String(chunk)).join(''));
+    expect(printed.released).toBe(true);
+    write.mockRestore();
+  });
+});

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -29,6 +29,7 @@ export const HEADLESS_COMMANDS = [
   { name: 'query', kind: 'read' },
   { name: 'set', kind: 'special' },
   { name: 'migrate-compat', kind: 'write' },
+  { name: 'repair-filing', kind: 'write' },
   { name: 'install-skills', kind: 'special' },
   { name: 'watch', kind: 'read' },
   { name: 'run', kind: 'write' },

--- a/packages/app/src/headless-usage.ts
+++ b/packages/app/src/headless-usage.ts
@@ -70,6 +70,10 @@ ${BOLD}Configure:${RESET}
   set workflow <workflowId> <fieldPath> <value>      Safely update workflow metadata/config
   set task <taskId> <fieldPath> <value>              Safely update task metadata/config
   migrate-compat                                     Normalize persisted compatibility workflow/task state
+  repair-filing insert --kind K --subject S --state-sha SHA [--metadata JSON]
+                                                      Atomic insert-if-not-exists into the repair_filings dedup ledger
+  repair-filing release --kind K --subject S --state-sha SHA
+                                                      Release a claimed repair_filings row (e.g. filing failed after the claim succeeded)
 
 ${BOLD}Lifecycle:${RESET}
   cancel <taskId>                                     Cancel task + all downstream

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -239,7 +239,7 @@ async function headlessInstallSkills(
 
 // ── Headless Command Router ──────────────────────────────────
 
-export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<void> {
+export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<unknown> {
   const command = args[0];
 
   if (isHeadlessHelpCommand(command)) {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -211,6 +211,78 @@ async function headlessMigrateCompatibility(deps: HeadlessDeps): Promise<void> {
   process.stdout.write(`  normalizedLegacyAcknowledgedLaunchDispatches: ${report.normalizedLegacyAcknowledgedLaunchDispatches}\n`);
 }
 
+function parseHeadlessRepairFilingInsertFlags(args: string[]): {
+  kind?: string;
+  subject?: string;
+  stateSha?: string;
+  metadata?: string;
+} {
+  const flags: { kind?: string; subject?: string; stateSha?: string; metadata?: string } = {};
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+    if (arg === '--kind' && i + 1 < args.length) {
+      flags.kind = args[i + 1];
+      i += 2;
+    } else if (arg === '--subject' && i + 1 < args.length) {
+      flags.subject = args[i + 1];
+      i += 2;
+    } else if (arg === '--state-sha' && i + 1 < args.length) {
+      flags.stateSha = args[i + 1];
+      i += 2;
+    } else if (arg === '--metadata' && i + 1 < args.length) {
+      flags.metadata = args[i + 1];
+      i += 2;
+    } else {
+      throw new Error(`Unrecognized repair-filing insert argument: "${arg}"`);
+    }
+  }
+  return flags;
+}
+
+const REPAIR_FILING_USAGE = 'Usage: --headless repair-filing <insert|release> --kind <kind> --subject <subject> --state-sha <sha> [--metadata <json>]';
+
+async function headlessRepairFiling(args: string[], deps: HeadlessDeps): Promise<{ inserted: boolean; row: unknown } | { released: boolean }> {
+  const subCommand = args[0];
+  if (subCommand !== 'insert' && subCommand !== 'release') {
+    throw new Error(REPAIR_FILING_USAGE);
+  }
+  const flags = parseHeadlessRepairFilingInsertFlags(args.slice(1));
+  if (!flags.kind || !flags.subject || !flags.stateSha) {
+    throw new Error(REPAIR_FILING_USAGE);
+  }
+
+  if (subCommand === 'release') {
+    const released = deps.persistence.deleteRepairFiling(flags.kind, flags.subject, flags.stateSha);
+    const output = { released };
+    process.stdout.write(`${JSON.stringify(output)}\n`);
+    return output;
+  }
+
+  let metadata: Record<string, unknown> | null = null;
+  if (flags.metadata !== undefined) {
+    try {
+      metadata = JSON.parse(flags.metadata) as Record<string, unknown>;
+    } catch (err) {
+      throw new Error(`--metadata must be valid JSON: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  const result = deps.persistence.insertRepairFiling({
+    kind: flags.kind,
+    subject: flags.subject,
+    stateSha: flags.stateSha,
+    metadata,
+  });
+  const output = { inserted: result.inserted, row: result.row };
+  // Printed for direct/standalone CLI callers; also returned so IPC-delegated
+  // callers (headless.exec against a live owner) get the same payload back
+  // instead of the generic `{ ok: true }` mutation ack -- see runHeadless's
+  // return-value plumbing and executeHeadlessExec/main.ts's standalone
+  // headless.exec handler, both of which merge this into their response.
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+  return output;
+}
+
 async function headlessInstallSkills(
   mode: BundledSkillsInstallMode | undefined,
   deps: Pick<HeadlessDeps, 'installBundledSkills'>,
@@ -261,6 +333,8 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<u
     case 'migrate-compat':
       await headlessMigrateCompatibility(deps);
       break;
+    case 'repair-filing':
+      return headlessRepairFiling(args.slice(1), deps);
     case 'install-skills':
       await headlessInstallSkills(
         args[1] === 'reinstall' || args[1] === 'update' ? args[1] : 'install',

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -758,7 +758,7 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
     ) {
       cancelDeferredWorkflowLaunch(resolvedHeadlessTarget.workflowId, `headless.${headlessCommand}`);
     }
-    await runHeadless(payload.args, {
+    const commandResult = await runHeadless(payload.args, {
       logger,
       orchestrator, persistence, executorRegistry, messageBus,
       commandService,
@@ -802,7 +802,10 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
       module: 'ipc-delegate',
     });
     if (!workflowId) {
-      return { ok: true };
+      return {
+        ok: true,
+        ...(commandResult && typeof commandResult === 'object' ? commandResult as Record<string, unknown> : {}),
+      };
     }
     orchestrator.syncFromDb(workflowId);
     const tasks = orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflowId);

--- a/packages/data-store/src/__tests__/repair-filings.test.ts
+++ b/packages/data-store/src/__tests__/repair-filings.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+describe('repair_filings ledger', () => {
+  it('rejects a second insert for the identical (kind, subject, stateSha) key', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const first = adapter.insertRepairFiling({
+        kind: 'ci-regression:required-fast-guardrails',
+        subject: 'master',
+        stateSha: 'sha-a',
+      });
+      expect(first.inserted).toBe(true);
+
+      // Same process, same connection, identical key -- this is the case a
+      // naive "read the file, decide, then append" implementation would get
+      // right too; the real proof is the cross-process case below.
+      const second = adapter.insertRepairFiling({
+        kind: 'ci-regression:required-fast-guardrails',
+        subject: 'master',
+        stateSha: 'sha-a',
+      });
+      expect(second.inserted).toBe(false);
+      expect(second.row.id).toBe(first.row.id);
+
+      const rows = adapter.listRepairFilings('ci-regression:required-fast-guardrails', 'master');
+      expect(rows).toHaveLength(1);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('rejects a duplicate filed by a fresh adapter instance against the same on-disk DB (simulated second process)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'repair-filings-'));
+    const dbPath = join(dir, 'invoker.db');
+    try {
+      const callerA = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+      const filedByA = callerA.insertRepairFiling({
+        kind: 'admin-requeue:rebase-conflict',
+        subject: '9425',
+        stateSha: 'sha-b',
+      });
+      expect(filedByA.inserted).toBe(true);
+      callerA.close();
+
+      // A brand new adapter instance opened fresh against the same file --
+      // no in-memory state carried over from callerA -- stands in for a
+      // second, independent OS process (e.g. a second cron sweep) racing
+      // to file the same repair.
+      const callerB = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+      const filedByB = callerB.insertRepairFiling({
+        kind: 'admin-requeue:rebase-conflict',
+        subject: '9425',
+        stateSha: 'sha-b',
+      });
+      expect(filedByB.inserted).toBe(false);
+      expect(filedByB.row.id).toBe(filedByA.row.id);
+
+      const rows = callerB.listRepairFilings('admin-requeue:rebase-conflict', '9425');
+      expect(rows).toHaveLength(1);
+      callerB.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not suppress a genuinely new state: different kind or different stateSha both file as new work', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      // Worked example from the design: rebase-conflict repaired at shaA,
+      // then a *different* check (ui-vitest) fails at shaB on the same PR,
+      // then master moves and the PR needs rebasing again, still at shaB.
+      const rebaseAtShaA = adapter.insertRepairFiling({
+        kind: 'admin-requeue:rebase-conflict',
+        subject: '9425',
+        stateSha: 'sha-a',
+      });
+      expect(rebaseAtShaA.inserted).toBe(true);
+
+      const uiVitestAtShaB = adapter.insertRepairFiling({
+        kind: 'admin-requeue:check:ui-vitest',
+        subject: '9425',
+        stateSha: 'sha-b',
+      });
+      expect(uiVitestAtShaB.inserted).toBe(true);
+
+      const rebaseAtShaBAgain = adapter.insertRepairFiling({
+        kind: 'admin-requeue:rebase-conflict',
+        subject: '9425',
+        stateSha: 'sha-b',
+      });
+      expect(rebaseAtShaBAgain.inserted).toBe(true);
+
+      // But re-detecting the same problem on the same state still collapses to one row.
+      const rebaseAtShaBRepeat = adapter.insertRepairFiling({
+        kind: 'admin-requeue:rebase-conflict',
+        subject: '9425',
+        stateSha: 'sha-b',
+      });
+      expect(rebaseAtShaBRepeat.inserted).toBe(false);
+
+      const rows = adapter.listRepairFilings('admin-requeue:rebase-conflict', '9425');
+      expect(rows).toHaveLength(2); // shaA and shaB, not a third for the repeat
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('release deletes a claimed row so a later attempt can reclaim the same key', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const claimed = adapter.insertRepairFiling({
+        kind: 'ci-regression:required-fast-guardrails',
+        subject: 'master',
+        stateSha: 'sha-d',
+      });
+      expect(claimed.inserted).toBe(true);
+
+      const released = adapter.deleteRepairFiling('ci-regression:required-fast-guardrails', 'master', 'sha-d');
+      expect(released).toBe(true);
+      expect(adapter.getRepairFiling('ci-regression:required-fast-guardrails', 'master', 'sha-d')).toBeUndefined();
+
+      // Reclaiming after release must succeed -- a transient downstream
+      // filing failure must not permanently block all future retries for
+      // this (kind, subject, stateSha).
+      const reclaimed = adapter.insertRepairFiling({
+        kind: 'ci-regression:required-fast-guardrails',
+        subject: 'master',
+        stateSha: 'sha-d',
+      });
+      expect(reclaimed.inserted).toBe(true);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('release on a key that was never claimed is a no-op that returns false', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const released = adapter.deleteRepairFiling('ci-regression:required-fast-guardrails', 'master', 'sha-never-claimed');
+      expect(released).toBe(false);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('stamps created_at from the DB clock, not a caller-supplied value', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const result = adapter.insertRepairFiling({
+        kind: 'ci-regression:fleet',
+        subject: 'master',
+        stateSha: 'sha-c',
+        metadata: { memberJobs: ['a', 'b', 'c'] },
+      });
+      expect(result.row.createdAt).toBeTruthy();
+      expect(result.row.metadata).toEqual({ memberJobs: ['a', 'b', 'c'] });
+
+      const fetched = adapter.getRepairFiling('ci-regression:fleet', 'master', 'sha-c');
+      expect(fetched?.createdAt).toBe(result.row.createdAt);
+    } finally {
+      adapter.close();
+    }
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -101,6 +101,30 @@ export interface WorkflowChannel {
   createdAt: string;
 }
 
+// ── Repair Filing Types (cross-system CI/PR repair dedup ledger) ─
+
+export interface RepairFiling {
+  id: number;
+  kind: string;
+  subject: string;
+  stateSha: string;
+  metadata?: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+export interface RepairFilingInsertInput {
+  kind: string;
+  subject: string;
+  stateSha: string;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface RepairFilingInsertResult {
+  /** True only when this call created the row; false means an identical (kind, subject, stateSha) row already existed. */
+  inserted: boolean;
+  row: RepairFiling;
+}
+
 // ── Workflow Types ──────────────────────────────────────────
 
 export interface Workflow {
@@ -429,6 +453,13 @@ export interface PersistenceAdapter {
   loadSlackPendingConfirmation(confirmKey: string): SlackPendingConfirmation | undefined;
   loadLatestSlackPendingConfirmationByThread(threadTs: string): SlackPendingConfirmation | undefined;
   deleteSlackPendingConfirmation(confirmKey: string): void;
+
+  // Repair filings (cross-system CI/PR repair dedup ledger)
+  insertRepairFiling(input: RepairFilingInsertInput): RepairFilingInsertResult;
+  getRepairFiling(kind: string, subject: string, stateSha: string): RepairFiling | undefined;
+  listRepairFilings(kind?: string, subject?: string): RepairFiling[];
+  /** Release a claimed (kind, subject, stateSha) row -- e.g. the actual filing failed after the claim succeeded -- so a later attempt can reclaim it. Returns true iff a row was deleted. */
+  deleteRepairFiling(kind: string, subject: string, stateSha: string): boolean;
 
   // Workflow channels (Slack workflow↔channel mapping)
   saveWorkflowChannel(rec: WorkflowChannel): void;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -41,6 +41,9 @@ import type {
   ExecutionResourceLeaseReleaseRow,
   LaunchDispatchInvalidationRow,
   PersistenceAdapter,
+  RepairFiling,
+  RepairFilingInsertInput,
+  RepairFilingInsertResult,
   ReviewGateLookup,
   Workflow,
   WorkflowReadOptions,
@@ -2636,6 +2639,73 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   deleteSlackPendingConfirmation(confirmKey: string): void {
     this.execRun('DELETE FROM slack_pending_confirmations WHERE confirm_key = ?', [confirmKey]);
+  }
+
+  // ── Repair Filings (cross-system CI/PR repair dedup ledger) ──
+
+  private mapRepairFilingRow(row: any): RepairFiling {
+    return {
+      id: row.id as number,
+      kind: row.kind as string,
+      subject: row.subject as string,
+      stateSha: row.state_sha as string,
+      metadata: row.metadata ? (JSON.parse(row.metadata as string) as Record<string, unknown>) : null,
+      createdAt: row.created_at as string,
+    };
+  }
+
+  insertRepairFiling(input: RepairFilingInsertInput): RepairFilingInsertResult {
+    return this.runTransaction(() => {
+      this.execRun(
+        `INSERT INTO repair_filings (kind, subject, state_sha, metadata)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(kind, subject, state_sha) DO NOTHING`,
+        [input.kind, input.subject, input.stateSha, input.metadata ? JSON.stringify(input.metadata) : null],
+      );
+      const inserted = this.db.getRowsModified() > 0;
+      const row = this.queryOne(
+        'SELECT * FROM repair_filings WHERE kind = ? AND subject = ? AND state_sha = ?',
+        [input.kind, input.subject, input.stateSha],
+      );
+      if (!row) {
+        throw new Error('insertRepairFiling: row missing immediately after INSERT ... ON CONFLICT DO NOTHING');
+      }
+      return { inserted, row: this.mapRepairFilingRow(row) };
+    });
+  }
+
+  getRepairFiling(kind: string, subject: string, stateSha: string): RepairFiling | undefined {
+    const row = this.queryOne(
+      'SELECT * FROM repair_filings WHERE kind = ? AND subject = ? AND state_sha = ?',
+      [kind, subject, stateSha],
+    );
+    return row ? this.mapRepairFilingRow(row) : undefined;
+  }
+
+  listRepairFilings(kind?: string, subject?: string): RepairFiling[] {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+    if (kind !== undefined) {
+      conditions.push('kind = ?');
+      params.push(kind);
+    }
+    if (subject !== undefined) {
+      conditions.push('subject = ?');
+      params.push(subject);
+    }
+    const where = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';
+    const rows = this.queryAll(`SELECT * FROM repair_filings${where} ORDER BY created_at DESC`, params);
+    return rows.map((row: any) => this.mapRepairFilingRow(row));
+  }
+
+  deleteRepairFiling(kind: string, subject: string, stateSha: string): boolean {
+    return this.runTransaction(() => {
+      this.execRun(
+        'DELETE FROM repair_filings WHERE kind = ? AND subject = ? AND state_sha = ?',
+        [kind, subject, stateSha],
+      );
+      return this.db.getRowsModified() > 0;
+    });
   }
 
   // ── Workflow Channels (Slack workflow↔channel mapping) ──

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -533,6 +533,18 @@ export const SCHEMA_DDL = `
         updated_at TEXT NOT NULL DEFAULT (datetime('now'))
       );
 
+      CREATE TABLE IF NOT EXISTS repair_filings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        kind TEXT NOT NULL,
+        subject TEXT NOT NULL,
+        state_sha TEXT NOT NULL,
+        metadata TEXT CHECK (metadata IS NULL OR json_valid(metadata)),
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_repair_filings_kind_subject_sha
+        ON repair_filings(kind, subject, state_sha);
+
     `;
 
 /** Idempotent `ALTER TABLE ... ADD COLUMN` migrations for older databases. */
@@ -676,6 +688,18 @@ export const POST_MIGRATION_STATEMENTS = [
     last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
   )`,
+  // repair_filings: durable cross-system dedup ledger for auto-filed CI/PR
+  // repair work. UNIQUE(kind, subject, state_sha) is the atomic
+  // insert-if-not-exists primitive -- see insertRepairFiling().
+  `CREATE TABLE IF NOT EXISTS repair_filings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    state_sha TEXT NOT NULL,
+    metadata TEXT CHECK (metadata IS NULL OR json_valid(metadata)),
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`,
+  'CREATE UNIQUE INDEX IF NOT EXISTS idx_repair_filings_kind_subject_sha ON repair_filings(kind, subject, state_sha)',
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */


### PR DESCRIPTION
## Summary

Adds a `--headless repair-filing insert|release` command over the `repair_filings` table from the foundation slice.

`insert` claims a `(kind, subject, state-sha)` triple or reports that it was already claimed. `release` clears a claim.

Both paths hand back their real result now that the previous two slices threaded it through both owner-delegate paths. No existing caller is wired in yet.

## Review Claim

Approve the new `repair-filing insert|release` command as net-new, tested surface with zero existing callers.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Nothing today calls this command, so nothing existing can regress. The insert path returns whatever the adapter method from the foundation slice already guarantees atomically; this slice adds argument parsing and a thin call-through, no new database logic.

## Slice Rationale

This is the exposed surface for the storage layer two slices back, kept separate from the JS/Python wrapper libraries that will call it, since those live under a different review unit in this repo's own file-based classification.

## Non-goals

Does not wire any existing watcher to this yet -- that's a later slice. Does not add the JS/Python wrapper libraries that call it -- that's the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
