### PR TITLE
[CI Repair Dedup Ledger](4) Add JS/Python client libraries for the repair-filing headless command

### DIFF
--- a/packages/app/src/__tests__/headless-repair-filing.test.ts
+++ b/packages/app/src/__tests__/headless-repair-filing.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runHeadless } from '../headless.js';
+
+function makeDeps(insertRepairFiling: ReturnType<typeof vi.fn>, deleteRepairFiling?: ReturnType<typeof vi.fn>) {
+  return {
+    persistence: { insertRepairFiling, deleteRepairFiling } as any,
+  } as any;
+}
+
+describe('headless repair-filing insert', () => {
+  it('inserts a new (kind, subject, stateSha) row and prints the result as JSON', async () => {
+    const insertRepairFiling = vi.fn(() => ({
+      inserted: true,
+      row: { id: 1, kind: 'ci-regression:required-fast-guardrails', subject: 'master', stateSha: 'sha-a', metadata: null, createdAt: '2026-08-16T00:00:00.000Z' },
+    }));
+    const deps = makeDeps(insertRepairFiling);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHeadless(['repair-filing', 'insert', '--kind', 'ci-regression:required-fast-guardrails', '--subject', 'master', '--state-sha', 'sha-a'], deps);
+
+    expect(insertRepairFiling).toHaveBeenCalledWith({
+      kind: 'ci-regression:required-fast-guardrails',
+      subject: 'master',
+      stateSha: 'sha-a',
+      metadata: null,
+    });
+    const printed = JSON.parse(write.mock.calls.map(([chunk]) => String(chunk)).join(''));
+    expect(printed.inserted).toBe(true);
+    write.mockRestore();
+  });
+
+  it('reports inserted: false for a duplicate key without throwing', async () => {
+    const insertRepairFiling = vi.fn(() => ({
+      inserted: false,
+      row: { id: 1, kind: 'admin-requeue:rebase-conflict', subject: '9425', stateSha: 'sha-b', metadata: null, createdAt: '2026-08-16T00:00:00.000Z' },
+    }));
+    const deps = makeDeps(insertRepairFiling);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHeadless(['repair-filing', 'insert', '--kind', 'admin-requeue:rebase-conflict', '--subject', '9425', '--state-sha', 'sha-b'], deps);
+
+    const printed = JSON.parse(write.mock.calls.map(([chunk]) => String(chunk)).join(''));
+    expect(printed.inserted).toBe(false);
+    write.mockRestore();
+  });
+
+  it('parses --metadata as JSON and passes it through', async () => {
+    const insertRepairFiling = vi.fn(() => ({
+      inserted: true,
+      row: { id: 2, kind: 'ci-regression:fleet', subject: 'master', stateSha: 'sha-c', metadata: { memberJobs: ['a', 'b'] }, createdAt: '2026-08-16T00:00:00.000Z' },
+    }));
+    const deps = makeDeps(insertRepairFiling);
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHeadless(['repair-filing', 'insert', '--kind', 'ci-regression:fleet', '--subject', 'master', '--state-sha', 'sha-c', '--metadata', '{"memberJobs":["a","b"]}'], deps);
+
+    expect(insertRepairFiling).toHaveBeenCalledWith({
+      kind: 'ci-regression:fleet',
+      subject: 'master',
+      stateSha: 'sha-c',
+      metadata: { memberJobs: ['a', 'b'] },
+    });
+  });
+
+  it('throws a usage error when a required flag is missing', async () => {
+    const deps = makeDeps(vi.fn());
+    await expect(runHeadless(['repair-filing', 'insert', '--kind', 'k'], deps)).rejects.toThrow('Usage: --headless repair-filing');
+  });
+
+  it('throws a usage error for an unknown subcommand', async () => {
+    const deps = makeDeps(vi.fn());
+    await expect(runHeadless(['repair-filing', 'bogus'], deps)).rejects.toThrow('Usage: --headless repair-filing');
+  });
+
+  it('release calls deleteRepairFiling and reports whether a row was actually removed', async () => {
+    const deleteRepairFiling = vi.fn(() => true);
+    const deps = makeDeps(vi.fn(), deleteRepairFiling);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHeadless(['repair-filing', 'release', '--kind', 'ci-regression:required-fast-guardrails', '--subject', 'master', '--state-sha', 'sha-a'], deps);
+
+    expect(deleteRepairFiling).toHaveBeenCalledWith('ci-regression:required-fast-guardrails', 'master', 'sha-a');
+    const printed = JSON.parse(write.mock.calls.map(([chunk]) => String(chunk)).join(''));
+    expect(printed.released).toBe(true);
+    write.mockRestore();
+  });
+});

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -29,6 +29,7 @@ export const HEADLESS_COMMANDS = [
   { name: 'query', kind: 'read' },
   { name: 'set', kind: 'special' },
   { name: 'migrate-compat', kind: 'write' },
+  { name: 'repair-filing', kind: 'write' },
   { name: 'install-skills', kind: 'special' },
   { name: 'watch', kind: 'read' },
   { name: 'run', kind: 'write' },

--- a/packages/app/src/headless-usage.ts
+++ b/packages/app/src/headless-usage.ts
@@ -70,6 +70,10 @@ ${BOLD}Configure:${RESET}
   set workflow <workflowId> <fieldPath> <value>      Safely update workflow metadata/config
   set task <taskId> <fieldPath> <value>              Safely update task metadata/config
   migrate-compat                                     Normalize persisted compatibility workflow/task state
+  repair-filing insert --kind K --subject S --state-sha SHA [--metadata JSON]
+                                                      Atomic insert-if-not-exists into the repair_filings dedup ledger
+  repair-filing release --kind K --subject S --state-sha SHA
+                                                      Release a claimed repair_filings row (e.g. filing failed after the claim succeeded)
 
 ${BOLD}Lifecycle:${RESET}
   cancel <taskId>                                     Cancel task + all downstream

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -239,7 +239,7 @@ async function headlessInstallSkills(
 
 // ── Headless Command Router ──────────────────────────────────
 
-export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<void> {
+export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<unknown> {
   const command = args[0];
 
   if (isHeadlessHelpCommand(command)) {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -211,6 +211,78 @@ async function headlessMigrateCompatibility(deps: HeadlessDeps): Promise<void> {
   process.stdout.write(`  normalizedLegacyAcknowledgedLaunchDispatches: ${report.normalizedLegacyAcknowledgedLaunchDispatches}\n`);
 }
 
+function parseHeadlessRepairFilingInsertFlags(args: string[]): {
+  kind?: string;
+  subject?: string;
+  stateSha?: string;
+  metadata?: string;
+} {
+  const flags: { kind?: string; subject?: string; stateSha?: string; metadata?: string } = {};
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+    if (arg === '--kind' && i + 1 < args.length) {
+      flags.kind = args[i + 1];
+      i += 2;
+    } else if (arg === '--subject' && i + 1 < args.length) {
+      flags.subject = args[i + 1];
+      i += 2;
+    } else if (arg === '--state-sha' && i + 1 < args.length) {
+      flags.stateSha = args[i + 1];
+      i += 2;
+    } else if (arg === '--metadata' && i + 1 < args.length) {
+      flags.metadata = args[i + 1];
+      i += 2;
+    } else {
+      throw new Error(`Unrecognized repair-filing insert argument: "${arg}"`);
+    }
+  }
+  return flags;
+}
+
+const REPAIR_FILING_USAGE = 'Usage: --headless repair-filing <insert|release> --kind <kind> --subject <subject> --state-sha <sha> [--metadata <json>]';
+
+async function headlessRepairFiling(args: string[], deps: HeadlessDeps): Promise<{ inserted: boolean; row: unknown } | { released: boolean }> {
+  const subCommand = args[0];
+  if (subCommand !== 'insert' && subCommand !== 'release') {
+    throw new Error(REPAIR_FILING_USAGE);
+  }
+  const flags = parseHeadlessRepairFilingInsertFlags(args.slice(1));
+  if (!flags.kind || !flags.subject || !flags.stateSha) {
+    throw new Error(REPAIR_FILING_USAGE);
+  }
+
+  if (subCommand === 'release') {
+    const released = deps.persistence.deleteRepairFiling(flags.kind, flags.subject, flags.stateSha);
+    const output = { released };
+    process.stdout.write(`${JSON.stringify(output)}\n`);
+    return output;
+  }
+
+  let metadata: Record<string, unknown> | null = null;
+  if (flags.metadata !== undefined) {
+    try {
+      metadata = JSON.parse(flags.metadata) as Record<string, unknown>;
+    } catch (err) {
+      throw new Error(`--metadata must be valid JSON: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  const result = deps.persistence.insertRepairFiling({
+    kind: flags.kind,
+    subject: flags.subject,
+    stateSha: flags.stateSha,
+    metadata,
+  });
+  const output = { inserted: result.inserted, row: result.row };
+  // Printed for direct/standalone CLI callers; also returned so IPC-delegated
+  // callers (headless.exec against a live owner) get the same payload back
+  // instead of the generic `{ ok: true }` mutation ack -- see runHeadless's
+  // return-value plumbing and executeHeadlessExec/main.ts's standalone
+  // headless.exec handler, both of which merge this into their response.
+  process.stdout.write(`${JSON.stringify(output)}\n`);
+  return output;
+}
+
 async function headlessInstallSkills(
   mode: BundledSkillsInstallMode | undefined,
   deps: Pick<HeadlessDeps, 'installBundledSkills'>,
@@ -261,6 +333,8 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<u
     case 'migrate-compat':
       await headlessMigrateCompatibility(deps);
       break;
+    case 'repair-filing':
+      return headlessRepairFiling(args.slice(1), deps);
     case 'install-skills':
       await headlessInstallSkills(
         args[1] === 'reinstall' || args[1] === 'update' ? args[1] : 'install',

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -758,7 +758,7 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
     ) {
       cancelDeferredWorkflowLaunch(resolvedHeadlessTarget.workflowId, `headless.${headlessCommand}`);
     }
-    await runHeadless(payload.args, {
+    const commandResult = await runHeadless(payload.args, {
       logger,
       orchestrator, persistence, executorRegistry, messageBus,
       commandService,
@@ -802,7 +802,10 @@ export function createGuiMutationTaskActions(context: GuiMutationTaskActionsCont
       module: 'ipc-delegate',
     });
     if (!workflowId) {
-      return { ok: true };
+      return {
+        ok: true,
+        ...(commandResult && typeof commandResult === 'object' ? commandResult as Record<string, unknown> : {}),
+      };
     }
     orchestrator.syncFromDb(workflowId);
     const tasks = orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflowId);

--- a/packages/data-store/src/__tests__/repair-filings.test.ts
+++ b/packages/data-store/src/__tests__/repair-filings.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+describe('repair_filings ledger', () => {
+  it('rejects a second insert for the identical (kind, subject, stateSha) key', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const first = adapter.insertRepairFiling({
+        kind: 'ci-regression:required-fast-guardrails',
+        subject: 'master',
+        stateSha: 'sha-a',
+      });
+      expect(first.inserted).toBe(true);
+
+      // Same process, same connection, identical key -- this is the case a
+      // naive "read the file, decide, then append" implementation would get
+      // right too; the real proof is the cross-process case below.
+      const second = adapter.insertRepairFiling({
+        kind: 'ci-regression:required-fast-guardrails',
+        subject: 'master',
+        stateSha: 'sha-a',
+      });
+      expect(second.inserted).toBe(false);
+      expect(second.row.id).toBe(first.row.id);
+
+      const rows = adapter.listRepairFilings('ci-regression:required-fast-guardrails', 'master');
+      expect(rows).toHaveLength(1);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('rejects a duplicate filed by a fresh adapter instance against the same on-disk DB (simulated second process)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'repair-filings-'));
+    const dbPath = join(dir, 'invoker.db');
+    try {
+      const callerA = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+      const filedByA = callerA.insertRepairFiling({
+        kind: 'admin-requeue:rebase-conflict',
+        subject: '9425',
+        stateSha: 'sha-b',
+      });
+      expect(filedByA.inserted).toBe(true);
+      callerA.close();
+
+      // A brand new adapter instance opened fresh against the same file --
+      // no in-memory state carried over from callerA -- stands in for a
+      // second, independent OS process (e.g. a second cron sweep) racing
+      // to file the same repair.
+      const callerB = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+      const filedByB = callerB.insertRepairFiling({
+        kind: 'admin-requeue:rebase-conflict',
+        subject: '9425',
+        stateSha: 'sha-b',
+      });
+      expect(filedByB.inserted).toBe(false);
+      expect(filedByB.row.id).toBe(filedByA.row.id);
+
+      const rows = callerB.listRepairFilings('admin-requeue:rebase-conflict', '9425');
+      expect(rows).toHaveLength(1);
+      callerB.close();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not suppress a genuinely new state: different kind or different stateSha both file as new work', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      // Worked example from the design: rebase-conflict repaired at shaA,
+      // then a *different* check (ui-vitest) fails at shaB on the same PR,
+      // then master moves and the PR needs rebasing again, still at shaB.
+      const rebaseAtShaA = adapter.insertRepairFiling({
+        kind: 'admin-requeue:rebase-conflict',
+        subject: '9425',
+        stateSha: 'sha-a',
+      });
+      expect(rebaseAtShaA.inserted).toBe(true);
+
+      const uiVitestAtShaB = adapter.insertRepairFiling({
+        kind: 'admin-requeue:check:ui-vitest',
+        subject: '9425',
+        stateSha: 'sha-b',
+      });
+      expect(uiVitestAtShaB.inserted).toBe(true);
+
+      const rebaseAtShaBAgain = adapter.insertRepairFiling({
+        kind: 'admin-requeue:rebase-conflict',
+        subject: '9425',
+        stateSha: 'sha-b',
+      });
+      expect(rebaseAtShaBAgain.inserted).toBe(true);
+
+      // But re-detecting the same problem on the same state still collapses to one row.
+      const rebaseAtShaBRepeat = adapter.insertRepairFiling({
+        kind: 'admin-requeue:rebase-conflict',
+        subject: '9425',
+        stateSha: 'sha-b',
+      });
+      expect(rebaseAtShaBRepeat.inserted).toBe(false);
+
+      const rows = adapter.listRepairFilings('admin-requeue:rebase-conflict', '9425');
+      expect(rows).toHaveLength(2); // shaA and shaB, not a third for the repeat
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('release deletes a claimed row so a later attempt can reclaim the same key', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const claimed = adapter.insertRepairFiling({
+        kind: 'ci-regression:required-fast-guardrails',
+        subject: 'master',
+        stateSha: 'sha-d',
+      });
+      expect(claimed.inserted).toBe(true);
+
+      const released = adapter.deleteRepairFiling('ci-regression:required-fast-guardrails', 'master', 'sha-d');
+      expect(released).toBe(true);
+      expect(adapter.getRepairFiling('ci-regression:required-fast-guardrails', 'master', 'sha-d')).toBeUndefined();
+
+      // Reclaiming after release must succeed -- a transient downstream
+      // filing failure must not permanently block all future retries for
+      // this (kind, subject, stateSha).
+      const reclaimed = adapter.insertRepairFiling({
+        kind: 'ci-regression:required-fast-guardrails',
+        subject: 'master',
+        stateSha: 'sha-d',
+      });
+      expect(reclaimed.inserted).toBe(true);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('release on a key that was never claimed is a no-op that returns false', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const released = adapter.deleteRepairFiling('ci-regression:required-fast-guardrails', 'master', 'sha-never-claimed');
+      expect(released).toBe(false);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('stamps created_at from the DB clock, not a caller-supplied value', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const result = adapter.insertRepairFiling({
+        kind: 'ci-regression:fleet',
+        subject: 'master',
+        stateSha: 'sha-c',
+        metadata: { memberJobs: ['a', 'b', 'c'] },
+      });
+      expect(result.row.createdAt).toBeTruthy();
+      expect(result.row.metadata).toEqual({ memberJobs: ['a', 'b', 'c'] });
+
+      const fetched = adapter.getRepairFiling('ci-regression:fleet', 'master', 'sha-c');
+      expect(fetched?.createdAt).toBe(result.row.createdAt);
+    } finally {
+      adapter.close();
+    }
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -101,6 +101,30 @@ export interface WorkflowChannel {
   createdAt: string;
 }
 
+// ── Repair Filing Types (cross-system CI/PR repair dedup ledger) ─
+
+export interface RepairFiling {
+  id: number;
+  kind: string;
+  subject: string;
+  stateSha: string;
+  metadata?: Record<string, unknown> | null;
+  createdAt: string;
+}
+
+export interface RepairFilingInsertInput {
+  kind: string;
+  subject: string;
+  stateSha: string;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface RepairFilingInsertResult {
+  /** True only when this call created the row; false means an identical (kind, subject, stateSha) row already existed. */
+  inserted: boolean;
+  row: RepairFiling;
+}
+
 // ── Workflow Types ──────────────────────────────────────────
 
 export interface Workflow {
@@ -429,6 +453,13 @@ export interface PersistenceAdapter {
   loadSlackPendingConfirmation(confirmKey: string): SlackPendingConfirmation | undefined;
   loadLatestSlackPendingConfirmationByThread(threadTs: string): SlackPendingConfirmation | undefined;
   deleteSlackPendingConfirmation(confirmKey: string): void;
+
+  // Repair filings (cross-system CI/PR repair dedup ledger)
+  insertRepairFiling(input: RepairFilingInsertInput): RepairFilingInsertResult;
+  getRepairFiling(kind: string, subject: string, stateSha: string): RepairFiling | undefined;
+  listRepairFilings(kind?: string, subject?: string): RepairFiling[];
+  /** Release a claimed (kind, subject, stateSha) row -- e.g. the actual filing failed after the claim succeeded -- so a later attempt can reclaim it. Returns true iff a row was deleted. */
+  deleteRepairFiling(kind: string, subject: string, stateSha: string): boolean;
 
   // Workflow channels (Slack workflow↔channel mapping)
   saveWorkflowChannel(rec: WorkflowChannel): void;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -41,6 +41,9 @@ import type {
   ExecutionResourceLeaseReleaseRow,
   LaunchDispatchInvalidationRow,
   PersistenceAdapter,
+  RepairFiling,
+  RepairFilingInsertInput,
+  RepairFilingInsertResult,
   ReviewGateLookup,
   Workflow,
   WorkflowReadOptions,
@@ -2636,6 +2639,73 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   deleteSlackPendingConfirmation(confirmKey: string): void {
     this.execRun('DELETE FROM slack_pending_confirmations WHERE confirm_key = ?', [confirmKey]);
+  }
+
+  // ── Repair Filings (cross-system CI/PR repair dedup ledger) ──
+
+  private mapRepairFilingRow(row: any): RepairFiling {
+    return {
+      id: row.id as number,
+      kind: row.kind as string,
+      subject: row.subject as string,
+      stateSha: row.state_sha as string,
+      metadata: row.metadata ? (JSON.parse(row.metadata as string) as Record<string, unknown>) : null,
+      createdAt: row.created_at as string,
+    };
+  }
+
+  insertRepairFiling(input: RepairFilingInsertInput): RepairFilingInsertResult {
+    return this.runTransaction(() => {
+      this.execRun(
+        `INSERT INTO repair_filings (kind, subject, state_sha, metadata)
+         VALUES (?, ?, ?, ?)
+         ON CONFLICT(kind, subject, state_sha) DO NOTHING`,
+        [input.kind, input.subject, input.stateSha, input.metadata ? JSON.stringify(input.metadata) : null],
+      );
+      const inserted = this.db.getRowsModified() > 0;
+      const row = this.queryOne(
+        'SELECT * FROM repair_filings WHERE kind = ? AND subject = ? AND state_sha = ?',
+        [input.kind, input.subject, input.stateSha],
+      );
+      if (!row) {
+        throw new Error('insertRepairFiling: row missing immediately after INSERT ... ON CONFLICT DO NOTHING');
+      }
+      return { inserted, row: this.mapRepairFilingRow(row) };
+    });
+  }
+
+  getRepairFiling(kind: string, subject: string, stateSha: string): RepairFiling | undefined {
+    const row = this.queryOne(
+      'SELECT * FROM repair_filings WHERE kind = ? AND subject = ? AND state_sha = ?',
+      [kind, subject, stateSha],
+    );
+    return row ? this.mapRepairFilingRow(row) : undefined;
+  }
+
+  listRepairFilings(kind?: string, subject?: string): RepairFiling[] {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+    if (kind !== undefined) {
+      conditions.push('kind = ?');
+      params.push(kind);
+    }
+    if (subject !== undefined) {
+      conditions.push('subject = ?');
+      params.push(subject);
+    }
+    const where = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : '';
+    const rows = this.queryAll(`SELECT * FROM repair_filings${where} ORDER BY created_at DESC`, params);
+    return rows.map((row: any) => this.mapRepairFilingRow(row));
+  }
+
+  deleteRepairFiling(kind: string, subject: string, stateSha: string): boolean {
+    return this.runTransaction(() => {
+      this.execRun(
+        'DELETE FROM repair_filings WHERE kind = ? AND subject = ? AND state_sha = ?',
+        [kind, subject, stateSha],
+      );
+      return this.db.getRowsModified() > 0;
+    });
   }
 
   // ── Workflow Channels (Slack workflow↔channel mapping) ──

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -533,6 +533,18 @@ export const SCHEMA_DDL = `
         updated_at TEXT NOT NULL DEFAULT (datetime('now'))
       );
 
+      CREATE TABLE IF NOT EXISTS repair_filings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        kind TEXT NOT NULL,
+        subject TEXT NOT NULL,
+        state_sha TEXT NOT NULL,
+        metadata TEXT CHECK (metadata IS NULL OR json_valid(metadata)),
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_repair_filings_kind_subject_sha
+        ON repair_filings(kind, subject, state_sha);
+
     `;
 
 /** Idempotent `ALTER TABLE ... ADD COLUMN` migrations for older databases. */
@@ -676,6 +688,18 @@ export const POST_MIGRATION_STATEMENTS = [
     last_received_seq INTEGER NOT NULL DEFAULT 0 CHECK (typeof(last_received_seq) = 'integer' AND last_received_seq >= 0),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
   )`,
+  // repair_filings: durable cross-system dedup ledger for auto-filed CI/PR
+  // repair work. UNIQUE(kind, subject, state_sha) is the atomic
+  // insert-if-not-exists primitive -- see insertRepairFiling().
+  `CREATE TABLE IF NOT EXISTS repair_filings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind TEXT NOT NULL,
+    subject TEXT NOT NULL,
+    state_sha TEXT NOT NULL,
+    metadata TEXT CHECK (metadata IS NULL OR json_valid(metadata)),
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`,
+  'CREATE UNIQUE INDEX IF NOT EXISTS idx_repair_filings_kind_subject_sha ON repair_filings(kind, subject, state_sha)',
 ];
 
 /** Rebuilt `workflows` table used to drop a legacy `status` column. */

--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -15,6 +15,7 @@ import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { shouldRetry, isStale } from './retry-ledger.mjs';
+import { insertRepairFiling, releaseRepairFiling } from './repair-filing-ledger.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = dirname(dirname(__filename));
@@ -442,8 +443,13 @@ function failureIsMapped(failure, jobDefinitions) {
   return Boolean(getVerifyCommandForFailure(failure, jobDefinitions));
 }
 
-function buildFleetJobName(sha, count) {
-  return `fleet / ${shortSha(sha)} (${count} jobs)`;
+// Deliberately does NOT embed the member-job count: membership can change
+// between sweeps (a 4th co-failing job joins, or one flips back to green)
+// without that being a *different* fleet event for dedup purposes. The
+// member list belongs in the failure description/metadata, not the key --
+// see buildFleetFailureDescription and REPAIR_FILING_KIND_FLEET's stateSha.
+function buildFleetJobName(sha) {
+  return `fleet / ${shortSha(sha)}`;
 }
 
 function buildFleetFailureDescription(sha, members) {
@@ -492,7 +498,7 @@ function synthesizeFleetFailure(state, sha, members, jobDefinitions) {
     if (runDelta !== 0) return runDelta;
     return a.jobName.localeCompare(b.jobName);
   }).at(0);
-  const jobName = buildFleetJobName(sha, members.length);
+  const jobName = buildFleetJobName(sha);
   return {
     ...(existing ?? {}),
     jobName,
@@ -902,6 +908,68 @@ export function liveQueryHasNonTerminalWork(failureOrSha, jobName, queryFn = hea
   );
 }
 
+// ---------------------------------------------------------------------------
+// repair_filings ledger gate (replaces liveQueryHasNonTerminalWork as the
+// default dedup gate; see scripts/repair-filing-ledger.mjs)
+// ---------------------------------------------------------------------------
+
+/**
+ * kind is namespaced per CI job and deliberately excludes the sha (that's
+ * stateSha) and, for fleet events, excludes the member-job count (that's
+ * metadata only) -- see buildFleetJobName.
+ */
+export function repairFilingKind(failure) {
+  const job = failure.markerJobName ?? failure.jobName;
+  return `ci-regression:${slugify(job)}`;
+}
+
+export function buildRepairFilingMetadata(failure) {
+  const metadata = { jobName: failure.jobName };
+  if (Array.isArray(failure.memberJobNames)) metadata.memberJobNames = failure.memberJobNames;
+  return metadata;
+}
+
+/**
+ * Atomically claims the (kind, subject='master', stateSha) key for this
+ * failure. Returns true when the caller should SKIP filing -- either because
+ * another filer already holds this exact claim, or because the ledger call
+ * itself failed and we fail closed (same philosophy as the old
+ * liveQueryHasNonTerminalWork: a broken dedup check must never risk a
+ * duplicate fix PR). Returns false when this call created the claim and the
+ * caller should proceed to file -- on failure to actually file, the caller
+ * MUST call releaseRepairFilingClaim(failure) to undo the claim, or this key
+ * would be permanently blocked from ever being retried.
+ */
+export function claimRepairFiling(failure, insert = insertRepairFiling) {
+  try {
+    const result = insert({
+      kind: repairFilingKind(failure),
+      subject: 'master',
+      stateSha: failure.firstBadSha,
+      metadata: buildRepairFilingMetadata(failure),
+    });
+    return !result.inserted;
+  } catch (err) {
+    console.error(`ci-regression-watch: claimRepairFiling failed for kind="${repairFilingKind(failure)}" sha="${failure.firstBadSha}", assuming already claimed: ${err instanceof Error ? err.message : String(err)}`);
+    return true;
+  }
+}
+
+/**
+ * Releases a claim made by claimRepairFiling when the subsequent fileFailure
+ * call throws, so a later sweep can retry the same (kind, subject, stateSha)
+ * instead of being permanently blocked. Never throws -- a failed release
+ * must not crash the sweep; it just means this key stays claimed until a
+ * human clears it or the sha changes.
+ */
+export function releaseRepairFilingClaim(failure, release = releaseRepairFiling) {
+  try {
+    release({ kind: repairFilingKind(failure), subject: 'master', stateSha: failure.firstBadSha });
+  } catch (err) {
+    console.error(`ci-regression-watch: releaseRepairFilingClaim failed for kind="${repairFilingKind(failure)}" sha="${failure.firstBadSha}"; this key stays claimed until manually cleared: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
 export function fileBugfixPlan(failure, opts = {}) {
   const repoUrl = opts.repoUrl ?? getRepoUrl();
   const jobDefinitions = opts.jobDefinitions ?? buildCiJobDefinitions();
@@ -925,7 +993,8 @@ export function processFailureFilingSweep(state, {
   maxAttempts = MAX_ATTEMPTS,
   capPerSweep = CAP_PER_SWEEP,
   jobDefinitions = null,
-  liveQuery = liveQueryHasNonTerminalWork,
+  liveQuery = claimRepairFiling,
+  releaseFiling = releaseRepairFilingClaim,
   fileFailure = () => {},
   save = () => {},
   onNeedsHuman = () => {},
@@ -999,12 +1068,17 @@ export function processFailureFilingSweep(state, {
       counts.groupsInBackoff += 1;
       continue;
     }
-    if (liveQuery(failure)) {
-      counts.groupsSkippedAlreadyAddressed += 1;
-      continue;
-    }
+    // Cap check must run BEFORE the ledger claim below: liveQuery (default
+    // claimRepairFiling) now has a side effect -- it inserts the dedup row
+    // -- so deferring a failure by the per-sweep cap after already claiming
+    // it would leak a permanently-unfileable claim (no fileFailure call ever
+    // follows to either succeed or release it).
     if (capPerSweep > 0 && counts.groupsFiled >= capPerSweep) {
       counts.groupsDeferredByCap += 1;
+      continue;
+    }
+    if (liveQuery(failure)) {
+      counts.groupsSkippedAlreadyAddressed += 1;
       continue;
     }
 
@@ -1021,6 +1095,11 @@ export function processFailureFilingSweep(state, {
     } catch (error) {
       counts.groupsFailedToFile += 1;
       onFileError(failure, error);
+      // The liveQuery call above already claimed this (kind, subject,
+      // stateSha) in the repair_filings ledger; the filing attempt itself
+      // never got submitted, so release the claim or this key would be
+      // permanently blocked from every future retry.
+      releaseFiling(failure);
       recordFailureFiled(state, failure, filedAt);
       save(state);
       continue;

--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -6,6 +6,8 @@ import { tmpdir } from 'node:os';
 import {
   buildCiJobDefinitions,
   buildMarker,
+  buildRepairFilingMetadata,
+  claimRepairFiling,
   fileBugfixPlan,
   getActionableFailures,
   groupFailuresBySha,
@@ -17,6 +19,8 @@ import {
   normalizeState,
   processFailureFilingSweep,
   reconcileCiRun,
+  releaseRepairFilingClaim,
+  repairFilingKind,
   RECOVERY_COOLDOWN_MS,
   STALE_OBSERVATION_MS,
 } from './e2e-regression-watch.mjs';
@@ -114,6 +118,128 @@ describe('liveQueryHasNonTerminalWork', () => {
   });
 });
 
+describe('repair_filings ledger gate (claimRepairFiling / releaseRepairFilingClaim)', () => {
+  function makeFakeLedger() {
+    const rows = new Map();
+    return {
+      rows,
+      insert: ({ kind, subject, stateSha, metadata }) => {
+        const key = `${kind} ${subject} ${stateSha}`;
+        if (rows.has(key)) return { inserted: false, row: rows.get(key) };
+        const row = { kind, subject, stateSha, metadata };
+        rows.set(key, row);
+        return { inserted: true, row };
+      },
+      release: ({ kind, subject, stateSha }) => {
+        rows.delete(`${kind} ${subject} ${stateSha}`);
+      },
+    };
+  }
+
+  it('kind is namespaced per CI job and excludes the sha and the fleet member count', () => {
+    assert.equal(
+      repairFilingKind(makeFailure({ jobName: 'required-fast / Guardrails' })),
+      'ci-regression:required-fast-guardrails',
+    );
+    assert.equal(
+      repairFilingKind(makeFailure({ jobName: 'fleet / abc123d', markerJobName: 'fleet' })),
+      'ci-regression:fleet',
+    );
+  });
+
+  it('prevents a duplicate PR: a second claim for the identical (kind, subject, stateSha) is rejected', () => {
+    const ledger = makeFakeLedger();
+    const failure = makeFailure({ firstBadSha: 'shaA' });
+
+    const firstAttemptSkips = claimRepairFiling(failure, ledger.insert);
+    assert.equal(firstAttemptSkips, false, 'first claim must succeed (caller proceeds to file)');
+    assert.equal(ledger.rows.size, 1);
+
+    // A second, independent caller (e.g. a fresh sweep, or a different
+    // process) tries to claim the exact same key.
+    const secondAttemptSkips = claimRepairFiling(failure, ledger.insert);
+    assert.equal(secondAttemptSkips, true, 'second claim for the identical key must be rejected');
+    assert.equal(ledger.rows.size, 1, 'exactly one row must exist for this key, not two');
+  });
+
+  it('worked example: different kind or different stateSha both claim as new work; same kind+sha collapses to one', () => {
+    const ledger = makeFakeLedger();
+    const rebaseAtShaA = makeFailure({ jobName: 'admin-requeue / rebase-conflict', firstBadSha: 'shaA' });
+    const uiVitestAtShaB = makeFailure({ jobName: 'admin-requeue / check-ui-vitest', firstBadSha: 'shaB' });
+    const rebaseAtShaBAgain = makeFailure({ jobName: 'admin-requeue / rebase-conflict', firstBadSha: 'shaB' });
+
+    assert.equal(claimRepairFiling(rebaseAtShaA, ledger.insert), false);
+    assert.equal(claimRepairFiling(uiVitestAtShaB, ledger.insert), false);
+    assert.equal(claimRepairFiling(rebaseAtShaBAgain, ledger.insert), false, 'different sha for the same kind must not be suppressed as a duplicate');
+    // Re-detecting the same problem on the same state must collapse to one row.
+    assert.equal(claimRepairFiling(rebaseAtShaBAgain, ledger.insert), true);
+    assert.equal(ledger.rows.size, 3);
+  });
+
+  it('releasing a claim after a failed filing lets a later sweep reclaim the identical key', () => {
+    const ledger = makeFakeLedger();
+    const failure = makeFailure({ firstBadSha: 'shaA' });
+
+    assert.equal(claimRepairFiling(failure, ledger.insert), false);
+    assert.equal(ledger.rows.size, 1);
+
+    // fileFailure threw downstream -- release the claim.
+    releaseRepairFilingClaim(failure, ledger.release);
+    assert.equal(ledger.rows.size, 0);
+
+    // A later attempt for the identical key must succeed now.
+    assert.equal(claimRepairFiling(failure, ledger.insert), false);
+    assert.equal(ledger.rows.size, 1);
+  });
+
+  it('fails closed (treats as already claimed) when the ledger call throws', () => {
+    const failure = makeFailure({ firstBadSha: 'shaA' });
+    const throwingInsert = () => { throw new Error('headless_mutation timed out'); };
+    assert.equal(claimRepairFiling(failure, throwingInsert), true);
+  });
+
+  it('puts the fleet member list in metadata, not the key', () => {
+    const failure = makeFailure({
+      jobName: 'fleet / abc123d',
+      markerJobName: 'fleet',
+      memberJobNames: ['required-fast / Vitest Workspace', 'quality / Dependency Cruise', 'docker / comprehensive'],
+    });
+    const metadata = buildRepairFilingMetadata(failure);
+    assert.deepEqual(metadata.memberJobNames, failure.memberJobNames);
+    assert.equal(repairFilingKind(failure), 'ci-regression:fleet');
+  });
+
+  it('processFailureFilingSweep end-to-end: a second sweep for the same (kind, subject, stateSha) never calls fileFailure again', () => {
+    const ledger = makeFakeLedger();
+    const state = stateWithFailure(makeFailure({ firstBadSha: 'shaA' }));
+    let filedCount = 0;
+
+    processFailureFilingSweep(state, {
+      now: new Date('2026-08-12T01:00:00Z'),
+      liveQuery: (failure) => claimRepairFiling(failure, ledger.insert),
+      releaseFiling: (failure) => releaseRepairFilingClaim(failure, ledger.release),
+      fileFailure: () => { filedCount += 1; },
+      isPaused: () => false,
+    });
+    assert.equal(filedCount, 1);
+
+    // Simulate a second, independent sweep run (fresh local state entry for
+    // the same underlying failure, same ledger backing store) racing to file
+    // the identical (kind, subject, stateSha).
+    const secondSweepState = stateWithFailure(makeFailure({ firstBadSha: 'shaA' }));
+    processFailureFilingSweep(secondSweepState, {
+      now: new Date('2026-08-12T01:00:01Z'),
+      liveQuery: (failure) => claimRepairFiling(failure, ledger.insert),
+      releaseFiling: (failure) => releaseRepairFilingClaim(failure, ledger.release),
+      fileFailure: () => { filedCount += 1; },
+      isPaused: () => false,
+    });
+
+    assert.equal(filedCount, 1, 'the second sweep must not file a duplicate for the identical key');
+    assert.equal(ledger.rows.size, 1);
+  });
+});
+
 describe('fleet SHA correlation', () => {
   it('groups active failures by first bad SHA', () => {
     const sha = 'abc123def456abc123def456abc123def456ab1';
@@ -155,7 +281,7 @@ describe('fleet SHA correlation', () => {
     });
 
     assert.equal(filed.length, 1);
-    assert.equal(filed[0].jobName, 'fleet / abc123d (3 jobs)');
+    assert.equal(filed[0].jobName, 'fleet / abc123d');
     assert.equal(filed[0].markerJobName, 'fleet');
     assert.ok(filed[0].verifyCommand.startsWith('bash scripts/verify-'));
     assert.equal(filed[0].description.includes('No local verify command is mapped'), false);
@@ -166,7 +292,7 @@ describe('fleet SHA correlation', () => {
     assert.deepEqual(liveMarkers, [buildMarker(sha, 'fleet')]);
     assert.equal(counts.groupsCorrelated, 1);
     assert.equal(counts.groupsFiled, 1);
-    assert.equal(state.activeFailures['fleet / abc123d (3 jobs)'].attempts, 1);
+    assert.equal(state.activeFailures['fleet / abc123d'].attempts, 1);
   });
 
   it('keeps two same-SHA failures on the per-job path', () => {
@@ -223,7 +349,7 @@ describe('fleet SHA correlation', () => {
       },
     });
     assert.equal(filedCounts.groupsFiled, 1);
-    assert.equal(state.activeFailures['fleet / abc123d (3 jobs)'].attempts, 1);
+    assert.equal(state.activeFailures['fleet / abc123d'].attempts, 1);
 
     let liveQueryCalled = false;
     const cappedCounts = processFailureFilingSweep(state, {
@@ -242,7 +368,59 @@ describe('fleet SHA correlation', () => {
     assert.equal(liveQueryCalled, false, 'attempt cap should skip before live workflow dedup');
     assert.equal(cappedCounts.groupsNeedingHuman, 1);
     assert.equal(filed, 1);
-    assert.equal(state.activeFailures['fleet / abc123d (3 jobs)'].needsHuman, true);
+    assert.equal(state.activeFailures['fleet / abc123d'].needsHuman, true);
+  });
+
+  it('buildFleetJobName-derived key is stable when fleet membership grows between sweeps', () => {
+    // Regression test: the fleet key used to embed the member-job COUNT
+    // ("fleet / abc123d (3 jobs)"), so a 4th co-failing job joining on the
+    // same sha rotated the key mid-flight. The old entry's attempt/backoff
+    // history was carried over by SHA lookup, but a caller keying its own
+    // dedup off the *jobName string itself must see one stable identity
+    // across the membership change, not a churn of keys.
+    const sha = 'abc123def456abc123def456abc123def456ab1';
+    const threeJobs = [
+      'required-fast / Vitest Workspace',
+      'quality / Dependency Cruise',
+      'docker / comprehensive',
+    ];
+    const fourthJob = 'ssh / shard-30';
+    const state = stateWithFailures(threeJobs.map((jobName) => makeFailure({ jobName, firstBadSha: sha })));
+
+    const firstSweep = processFailureFilingSweep(state, {
+      now: new Date('2026-08-12T01:00:00Z'),
+      jobDefinitions: jobDefinitionsFor(threeJobs),
+      liveQuery: () => false,
+      fileFailure: () => {},
+      isPaused: () => false,
+    });
+    assert.equal(firstSweep.groupsFiled, 1);
+    const fleetKeysAfterFirst = Object.keys(state.activeFailures).filter((key) => key.startsWith('fleet /'));
+    assert.deepEqual(fleetKeysAfterFirst, ['fleet / abc123d']);
+    assert.equal(state.activeFailures['fleet / abc123d'].attempts, 1);
+    assert.equal(state.activeFailures['fleet / abc123d'].memberJobNames.length, 3);
+
+    // A 4th job on the same sha joins the fleet on the next sweep.
+    state.activeFailures[fourthJob] = makeFailure({ jobName: fourthJob, firstBadSha: sha });
+
+    const secondSweep = processFailureFilingSweep(state, {
+      now: new Date('2026-08-12T01:05:00Z'), // well inside backoff -- must not re-file
+      jobDefinitions: jobDefinitionsFor([...threeJobs, fourthJob]),
+      liveQuery: () => false,
+      fileFailure: () => {
+        throw new Error('must not file again: still the same fleet key, still in backoff');
+      },
+      isPaused: () => false,
+    });
+
+    // Still exactly one fleet key -- membership growth did not fork a new
+    // "fleet / abc123d (4 jobs)" entry that would have reset attempts to 0
+    // and let a brand-new filing sneak past the attempt cap/backoff.
+    const fleetKeysAfterSecond = Object.keys(state.activeFailures).filter((key) => key.startsWith('fleet /'));
+    assert.deepEqual(fleetKeysAfterSecond, ['fleet / abc123d']);
+    assert.equal(state.activeFailures['fleet / abc123d'].attempts, 1, 'attempts must carry over, not reset on membership growth');
+    assert.equal(state.activeFailures['fleet / abc123d'].memberJobNames.length, 4);
+    assert.equal(secondSweep.groupsInBackoff, 1);
   });
 
   it('keeps remaining members under an existing fleet key after the active count drops below threshold', () => {
@@ -324,7 +502,7 @@ describe('fleet SHA correlation', () => {
 
     assert.equal(historicalFilings.length, 11);
     assert.equal(fleetFilings.length, 1);
-    assert.equal(fleetFilings[0].jobName, 'fleet / 631a0d0 (11 jobs)');
+    assert.equal(fleetFilings[0].jobName, 'fleet / 631a0d0');
     for (const jobName of jobs) assert.match(fleetFilings[0].description, new RegExp(jobName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
     assert.equal(counts.groupsCorrelated, 1);
     assert.equal(counts.groupsFiled, 1);

--- a/scripts/repair-filing-ledger.mjs
+++ b/scripts/repair-filing-ledger.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// Shared cross-system dedup primitive for auto-filed CI/PR repair work.
+//
+// Backing store: the `repair_filings` SQLite table (see
+// packages/data-store/src/sqlite-schema.ts), keyed on a composite
+// (kind, subject, stateSha) UNIQUE index. The insert is atomic -- a single
+// `INSERT ... ON CONFLICT DO NOTHING` statement inside a transaction -- so
+// two callers racing on the identical key never both "win"; exactly one of
+// them observes `inserted: true`.
+//
+// Both scripts/e2e-regression-watch.mjs (in-process, imports insertRepairFiling
+// directly) and the mergify_admin_requeue Python scripts (out-of-process, via
+// this file's CLI) call the same primitive so their dedup state lives in one
+// place and each system can see the other's filings.
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = dirname(dirname(__filename));
+
+function runHeadlessMutation(args, { execFile = execFileSync } = {}) {
+  // Args are passed as real argv entries to `bash -c '... "$@"'` (never
+  // string-interpolated into the script itself), so a kind/subject/stateSha
+  // value can't break out of the intended command line.
+  const script = `source "${join(REPO_ROOT, 'scripts', 'headless-lib.sh')}" && headless_mutation "$@"`;
+  return execFile('bash', ['-c', script, 'repair-filing-ledger', ...args], {
+    encoding: 'utf8',
+    cwd: REPO_ROOT,
+    timeout: 90_000,
+    killSignal: 'SIGKILL',
+  });
+}
+
+/**
+ * Pull the `{inserted, row}` result out of headless_mutation's stdout.
+ *
+ * Shape differs by delegation path: a standalone owner (`run.sh --headless`)
+ * prints the raw `{inserted, row}` line from headlessRepairFiling; an
+ * IPC-delegated owner (`headless-ipc.js exec`) wraps it as
+ * `{..., ok: true, response: {inserted, row}}`. Scan from the last line
+ * backwards and accept either shape.
+ */
+export function extractInsertResult(stdout) {
+  return extractResult(stdout, (candidate) => typeof candidate.inserted === 'boolean' && candidate.row);
+}
+
+export function extractReleaseResult(stdout) {
+  return extractResult(stdout, (candidate) => typeof candidate.released === 'boolean');
+}
+
+function extractResult(stdout, matches) {
+  const lines = String(stdout ?? '').trim().split(/\r?\n/).filter(Boolean);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    let parsed;
+    try {
+      parsed = JSON.parse(lines[i]);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== 'object') continue;
+    if (matches(parsed)) return parsed;
+    if (parsed.response && typeof parsed.response === 'object' && matches(parsed.response)) {
+      return parsed.response;
+    }
+  }
+  return null;
+}
+
+/**
+ * Atomic insert-if-not-exists for the (kind, subject, stateSha) dedup key.
+ * Returns `{ inserted, row }`. Fails closed: a malformed/unparseable
+ * response throws rather than silently returning `inserted: true`, so a
+ * caller can never mistake a broken plumbing call for "safe to file".
+ */
+export function insertRepairFiling({ kind, subject, stateSha, metadata }, opts = {}) {
+  if (!kind || !subject || !stateSha) {
+    throw new Error('insertRepairFiling requires kind, subject, and stateSha');
+  }
+  const args = ['repair-filing', 'insert', '--kind', kind, '--subject', subject, '--state-sha', stateSha];
+  if (metadata !== undefined && metadata !== null) {
+    args.push('--metadata', JSON.stringify(metadata));
+  }
+  const stdout = runHeadlessMutation(args, opts);
+  const result = extractInsertResult(stdout);
+  if (!result) {
+    throw new Error(`repair-filing-ledger: could not parse insert result from headless_mutation output: ${JSON.stringify(stdout)}`);
+  }
+  return result;
+}
+
+/**
+ * Release a previously-claimed (kind, subject, stateSha) row. Call this when
+ * insertRepairFiling returned `inserted: true` but the actual repair filing
+ * then failed downstream -- without releasing the claim, a transient render/
+ * lint/submit error would permanently block every future retry attempt for
+ * that key, since the row would otherwise never go away on its own.
+ */
+export function releaseRepairFiling({ kind, subject, stateSha }, opts = {}) {
+  if (!kind || !subject || !stateSha) {
+    throw new Error('releaseRepairFiling requires kind, subject, and stateSha');
+  }
+  const args = ['repair-filing', 'release', '--kind', kind, '--subject', subject, '--state-sha', stateSha];
+  const stdout = runHeadlessMutation(args, opts);
+  const result = extractReleaseResult(stdout);
+  if (!result) {
+    throw new Error(`repair-filing-ledger: could not parse release result from headless_mutation output: ${JSON.stringify(stdout)}`);
+  }
+  return result;
+}
+
+function usage() {
+  return [
+    'Usage: node scripts/repair-filing-ledger.mjs insert --kind <kind> --subject <subject> --state-sha <sha> [--metadata <json>]',
+    '   or: node scripts/repair-filing-ledger.mjs release --kind <kind> --subject <subject> --state-sha <sha>',
+    'insert prints: {"inserted":true|false,"row":{...}}',
+    '  inserted=true  -- this call created the row; caller should proceed and file the repair.',
+    '  inserted=false -- an identical (kind, subject, stateSha) row already existed; caller should skip filing.',
+    'release prints: {"released":true|false} -- call after a claimed insert whose filing then failed, to allow a later retry.',
+  ].join('\n');
+}
+
+function parseInsertFlags(argv) {
+  const flags = {};
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+    if (arg === '--kind' || arg === '--subject' || arg === '--state-sha' || arg === '--metadata') {
+      const key = arg === '--state-sha' ? 'stateSha' : arg.slice(2);
+      flags[key] = argv[i + 1];
+      i += 2;
+    } else {
+      throw new Error(`Unrecognized argument: "${arg}"`);
+    }
+  }
+  return flags;
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const [command, ...rest] = argv;
+  if (command !== 'insert' && command !== 'release') {
+    console.error(`repair-filing-ledger: unknown command "${command ?? ''}"\n\n${usage()}`);
+    process.exitCode = 1;
+    return;
+  }
+  let flags;
+  try {
+    flags = parseInsertFlags(rest);
+  } catch (err) {
+    console.error(`repair-filing-ledger: ${err.message}\n\n${usage()}`);
+    process.exitCode = 1;
+    return;
+  }
+  if (!flags.kind || !flags.subject || !flags.stateSha) {
+    console.error(`repair-filing-ledger: missing required flag\n\n${usage()}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (command === 'release') {
+    try {
+      const result = releaseRepairFiling({ kind: flags.kind, subject: flags.subject, stateSha: flags.stateSha });
+      process.stdout.write(`${JSON.stringify(result)}\n`);
+    } catch (err) {
+      console.error(`repair-filing-ledger: ${err instanceof Error ? err.message : String(err)}`);
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  let metadata;
+  if (flags.metadata !== undefined) {
+    try {
+      metadata = JSON.parse(flags.metadata);
+    } catch (err) {
+      console.error(`repair-filing-ledger: --metadata must be valid JSON: ${err.message}`);
+      process.exitCode = 1;
+      return;
+    }
+  }
+  try {
+    const result = insertRepairFiling({ kind: flags.kind, subject: flags.subject, stateSha: flags.stateSha, metadata });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+  } catch (err) {
+    console.error(`repair-filing-ledger: ${err instanceof Error ? err.message : String(err)}`);
+    process.exitCode = 1;
+  }
+}
+
+const isMain = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main().catch((err) => {
+    console.error('repair-filing-ledger: fatal error', err);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/repair-filing-ledger.test.mjs
+++ b/scripts/repair-filing-ledger.test.mjs
@@ -1,0 +1,148 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  extractInsertResult,
+  extractReleaseResult,
+  insertRepairFiling,
+  releaseRepairFiling,
+} from './repair-filing-ledger.mjs';
+
+const SCRIPT_PATH = join(dirname(fileURLToPath(import.meta.url)), 'repair-filing-ledger.mjs');
+
+describe('extractInsertResult', () => {
+  it('reads the raw {inserted, row} line printed by a standalone owner', () => {
+    const stdout = `${JSON.stringify({ inserted: true, row: { id: 1, kind: 'k', subject: 's', stateSha: 'sha', createdAt: 'now' } })}\n`;
+    const result = extractInsertResult(stdout);
+    assert.equal(result.inserted, true);
+    assert.equal(result.row.id, 1);
+  });
+
+  it('unwraps the {ok, response} envelope printed by an IPC-delegated owner', () => {
+    const stdout = `${JSON.stringify({
+      args: ['repair-filing', 'insert'],
+      ok: true,
+      response: { inserted: false, row: { id: 2, kind: 'k', subject: 's', stateSha: 'sha', createdAt: 'now' } },
+    })}\n`;
+    const result = extractInsertResult(stdout);
+    assert.equal(result.inserted, false);
+    assert.equal(result.row.id, 2);
+  });
+
+  it('returns null for output with no matching JSON line', () => {
+    assert.equal(extractInsertResult('not json\n{"ok":true}\n'), null);
+  });
+
+  it('scans from the last line backwards past unrelated log noise', () => {
+    const stdout = [
+      'some stderr-like line that leaked onto stdout',
+      JSON.stringify({ inserted: true, row: { id: 3 } }),
+    ].join('\n');
+    const result = extractInsertResult(stdout);
+    assert.equal(result.inserted, true);
+  });
+});
+
+describe('extractReleaseResult', () => {
+  it('reads the raw {released} line', () => {
+    assert.deepEqual(extractReleaseResult(`${JSON.stringify({ released: true })}\n`), { released: true });
+  });
+
+  it('unwraps the {ok, response} envelope', () => {
+    const stdout = `${JSON.stringify({ ok: true, response: { released: false } })}\n`;
+    assert.deepEqual(extractReleaseResult(stdout), { released: false });
+  });
+});
+
+describe('insertRepairFiling', () => {
+  it('invokes headless_mutation via bash with argv-safe args (no string interpolation of caller data)', () => {
+    let capturedCmd;
+    let capturedArgs;
+    const execFile = (cmd, args) => {
+      capturedCmd = cmd;
+      capturedArgs = args;
+      return `${JSON.stringify({ inserted: true, row: { id: 1 } })}\n`;
+    };
+    const result = insertRepairFiling(
+      { kind: 'ci-regression:fleet', subject: 'master', stateSha: 'sha-a; rm -rf /' },
+      { execFile },
+    );
+    assert.equal(result.inserted, true);
+    assert.equal(capturedCmd, 'bash');
+    assert.deepEqual(
+      capturedArgs.slice(2),
+      ['repair-filing-ledger', 'repair-filing', 'insert', '--kind', 'ci-regression:fleet', '--subject', 'master', '--state-sha', 'sha-a; rm -rf /'],
+    );
+  });
+
+  it('passes --metadata as a single JSON-stringified argv entry', () => {
+    let capturedArgs;
+    const execFile = (_cmd, args) => {
+      capturedArgs = args;
+      return `${JSON.stringify({ inserted: true, row: { id: 1 } })}\n`;
+    };
+    insertRepairFiling(
+      { kind: 'k', subject: 's', stateSha: 'sha', metadata: { memberJobs: ['a', 'b'] } },
+      { execFile },
+    );
+    const metadataIndex = capturedArgs.indexOf('--metadata');
+    assert.ok(metadataIndex !== -1);
+    assert.deepEqual(JSON.parse(capturedArgs[metadataIndex + 1]), { memberJobs: ['a', 'b'] });
+  });
+
+  it('throws when the underlying output cannot be parsed (fails closed, never silently reports inserted:true)', () => {
+    const execFile = () => 'garbage, not json\n';
+    assert.throws(
+      () => insertRepairFiling({ kind: 'k', subject: 's', stateSha: 'sha' }, { execFile }),
+      /could not parse insert result/,
+    );
+  });
+
+  it('requires kind, subject, and stateSha', () => {
+    assert.throws(() => insertRepairFiling({ kind: '', subject: 's', stateSha: 'sha' }));
+    assert.throws(() => insertRepairFiling({ kind: 'k', subject: '', stateSha: 'sha' }));
+    assert.throws(() => insertRepairFiling({ kind: 'k', subject: 's', stateSha: '' }));
+  });
+});
+
+describe('releaseRepairFiling', () => {
+  it('invokes headless_mutation with the release subcommand', () => {
+    let capturedArgs;
+    const execFile = (_cmd, args) => {
+      capturedArgs = args;
+      return `${JSON.stringify({ released: true })}\n`;
+    };
+    const result = releaseRepairFiling({ kind: 'k', subject: 's', stateSha: 'sha' }, { execFile });
+    assert.deepEqual(result, { released: true });
+    assert.deepEqual(
+      capturedArgs.slice(2),
+      ['repair-filing-ledger', 'repair-filing', 'release', '--kind', 'k', '--subject', 's', '--state-sha', 'sha'],
+    );
+  });
+});
+
+describe('CLI (e2e, real subprocess)', () => {
+  it('exits non-zero with usage text on an unknown command', () => {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, 'bogus'], { encoding: 'utf8' });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /unknown command/);
+  });
+
+  it('exits non-zero when a required flag is missing', () => {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, 'insert', '--kind', 'k'], { encoding: 'utf8' });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /missing required flag/);
+  });
+
+  it('exits non-zero on invalid --metadata JSON', () => {
+    const result = spawnSync(
+      process.execPath,
+      [SCRIPT_PATH, 'insert', '--kind', 'k', '--subject', 's', '--state-sha', 'sha', '--metadata', 'not-json'],
+      { encoding: 'utf8' },
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /--metadata must be valid JSON/);
+  });
+});

--- a/scripts/repair_filing_ledger.py
+++ b/scripts/repair_filing_ledger.py
@@ -1,0 +1,116 @@
+"""Python bridge to the shared repair_filings dedup ledger.
+
+Mirrors scripts/repair-filing-ledger.mjs. Both scripts/e2e-regression-watch.mjs
+(in-process, JS) and this module (subprocess, Python) call the same underlying
+`repair-filing insert`/`repair-filing release` headless commands, backed by
+the `repair_filings` SQLite table (packages/data-store/src/sqlite-schema.ts),
+so mergify_admin_requeue_* and ci-regression-watch dedup state lives in one
+place and each system can see the other's filings.
+
+Precedent: scripts/mergify_admin_requeue_plan.py's retry_decision() already
+shells out to `node scripts/retry-ledger.mjs decide` for shared retry/backoff
+logic instead of re-deriving it in Python -- this module is the same pattern,
+one primitive deeper (atomic cross-process claim instead of a pure decision
+function).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+try:
+    from .mergify_admin_requeue_headless_shell import run_headless
+except ImportError:
+    from mergify_admin_requeue_headless_shell import run_headless
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class RepairFilingLedgerError(RuntimeError):
+    """Raised when the headless_mutation call itself fails or its output can't be parsed."""
+
+
+def _extract(stdout: str, required_key: str) -> dict[str, Any] | None:
+    """Scan stdout lines from the last backwards for a JSON object carrying
+    required_key, unwrapping an IPC-delegated owner's {..., response: {...}}
+    envelope the same way scripts/repair-filing-ledger.mjs does."""
+    lines = [line for line in stdout.strip().splitlines() if line.strip()]
+    for line in reversed(lines):
+        try:
+            parsed = json.loads(line)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        if required_key in parsed:
+            return parsed
+        response = parsed.get("response")
+        if isinstance(response, dict) and required_key in response:
+            return response
+    return None
+
+
+def insert_repair_filing(
+    kind: str,
+    subject: str,
+    state_sha: str,
+    metadata: Mapping[str, Any] | None = None,
+    *,
+    run_headless_fn=run_headless,
+) -> dict[str, Any]:
+    """Atomic insert-if-not-exists for (kind, subject, state_sha).
+
+    Returns {"inserted": bool, "row": {...}}. Raises RepairFilingLedgerError
+    on any failure to reach the ledger or parse its response -- callers that
+    want fail-closed-on-error semantics (matching e2e-regression-watch.mjs's
+    claimRepairFiling) should catch this and treat it as "already claimed".
+    """
+    if not kind or not subject or not state_sha:
+        raise ValueError("insert_repair_filing requires kind, subject, and state_sha")
+    command = 'headless_mutation repair-filing insert --kind "$2" --subject "$3" --state-sha "$4"'
+    args = [kind, subject, state_sha]
+    if metadata is not None:
+        command += ' --metadata "$5"'
+        args.append(json.dumps(dict(metadata)))
+    completed = run_headless_fn(command, *args)
+    if completed.returncode != 0:
+        raise RepairFilingLedgerError(
+            f"repair-filing insert failed (exit {completed.returncode}): {completed.stderr.strip()}"
+        )
+    result = _extract(completed.stdout, "inserted")
+    if result is None:
+        raise RepairFilingLedgerError(
+            f"could not parse insert result from headless_mutation output: {completed.stdout!r}"
+        )
+    return result
+
+
+def release_repair_filing(
+    kind: str,
+    subject: str,
+    state_sha: str,
+    *,
+    run_headless_fn=run_headless,
+) -> dict[str, Any]:
+    """Releases a claim made by insert_repair_filing whose downstream filing
+    then failed, so a later attempt can reclaim the identical key. Never
+    raises on a ledger-side failure -- callers should not let a failed
+    release crash their own error-handling path; they should log and move on
+    (the key just stays claimed until manually cleared or the sha changes)."""
+    if not kind or not subject or not state_sha:
+        raise ValueError("release_repair_filing requires kind, subject, and state_sha")
+    completed = run_headless_fn(
+        'headless_mutation repair-filing release --kind "$2" --subject "$3" --state-sha "$4"',
+        kind, subject, state_sha,
+    )
+    if completed.returncode != 0:
+        raise RepairFilingLedgerError(
+            f"repair-filing release failed (exit {completed.returncode}): {completed.stderr.strip()}"
+        )
+    result = _extract(completed.stdout, "released")
+    if result is None:
+        raise RepairFilingLedgerError(
+            f"could not parse release result from headless_mutation output: {completed.stdout!r}"
+        )
+    return result

--- a/scripts/test_repair_filing_ledger.py
+++ b/scripts/test_repair_filing_ledger.py
@@ -1,0 +1,106 @@
+"""Behavioural tests for ``repair_filing_ledger``.
+
+Documentation-by-test: given a stubbed ``run_headless_fn`` standing in for the
+real Invoker headless CLI bridge, prove insert_repair_filing/release_repair_filing
+build the right argv, parse both response shapes (raw and IPC-delegated
+envelope), and fail loudly (never silently report inserted:true) when the
+underlying call breaks.
+
+Run:  python3 scripts/test_repair_filing_ledger.py
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import repair_filing_ledger as rfl
+
+
+def completed(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args=["fake"], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class InsertRepairFiling(unittest.TestCase):
+    def test_claims_a_fresh_key(self):
+        calls = []
+        result = rfl.insert_repair_filing(
+            "ci-regression:fleet", "master", "sha-a",
+            run_headless_fn=lambda *a: calls.append(a) or completed(
+                stdout=json.dumps({"inserted": True, "row": {"id": 1}}),
+            ),
+        )
+        self.assertEqual(result, {"inserted": True, "row": {"id": 1}})
+        command, kind, subject, sha = calls[0]
+        self.assertIn("repair-filing insert", command)
+        self.assertEqual((kind, subject, sha), ("ci-regression:fleet", "master", "sha-a"))
+
+    def test_rejects_a_duplicate_key(self):
+        result = rfl.insert_repair_filing(
+            "admin-requeue:rebase-conflict", "9425", "sha-b",
+            run_headless_fn=lambda *a: completed(stdout=json.dumps({"inserted": False, "row": {"id": 1}})),
+        )
+        self.assertFalse(result["inserted"])
+
+    def test_unwraps_the_ipc_delegated_envelope(self):
+        result = rfl.insert_repair_filing(
+            "k", "s", "sha",
+            run_headless_fn=lambda *a: completed(stdout=json.dumps({
+                "ok": True,
+                "response": {"inserted": True, "row": {"id": 2}},
+            })),
+        )
+        self.assertEqual(result, {"inserted": True, "row": {"id": 2}})
+
+    def test_passes_metadata_as_a_single_json_argument(self):
+        calls = []
+        rfl.insert_repair_filing(
+            "k", "s", "sha", metadata={"memberJobs": ["a", "b"]},
+            run_headless_fn=lambda *a: calls.append(a) or completed(stdout=json.dumps({"inserted": True, "row": {}})),
+        )
+        command, kind, subject, sha, metadata_json = calls[0]
+        self.assertIn("--metadata", command)
+        self.assertEqual(json.loads(metadata_json), {"memberJobs": ["a", "b"]})
+
+    def test_raises_on_nonzero_exit_instead_of_silently_reporting_inserted_true(self):
+        with self.assertRaises(rfl.RepairFilingLedgerError):
+            rfl.insert_repair_filing(
+                "k", "s", "sha",
+                run_headless_fn=lambda *a: completed(returncode=1, stderr="owner unreachable"),
+            )
+
+    def test_raises_on_unparseable_output(self):
+        with self.assertRaises(rfl.RepairFilingLedgerError):
+            rfl.insert_repair_filing("k", "s", "sha", run_headless_fn=lambda *a: completed(stdout="not json"))
+
+    def test_requires_kind_subject_and_state_sha(self):
+        with self.assertRaises(ValueError):
+            rfl.insert_repair_filing("", "s", "sha", run_headless_fn=lambda *a: completed())
+        with self.assertRaises(ValueError):
+            rfl.insert_repair_filing("k", "", "sha", run_headless_fn=lambda *a: completed())
+        with self.assertRaises(ValueError):
+            rfl.insert_repair_filing("k", "s", "", run_headless_fn=lambda *a: completed())
+
+
+class ReleaseRepairFiling(unittest.TestCase):
+    def test_releases_a_claimed_key(self):
+        calls = []
+        result = rfl.release_repair_filing(
+            "k", "s", "sha",
+            run_headless_fn=lambda *a: calls.append(a) or completed(stdout=json.dumps({"released": True})),
+        )
+        self.assertEqual(result, {"released": True})
+        command = calls[0][0]
+        self.assertIn("repair-filing release", command)
+
+    def test_raises_on_failure_instead_of_silently_succeeding(self):
+        with self.assertRaises(rfl.RepairFilingLedgerError):
+            rfl.release_repair_filing("k", "s", "sha", run_headless_fn=lambda *a: completed(returncode=1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `scripts/repair-filing-ledger.mjs` (in-process JS) and `scripts/repair_filing_ledger.py` (Python subprocess bridge), thin wrappers around the `repair-filing insert|release` surface from the previous slice.

This follows an existing pattern in this codebase for sharing one tested helper across a JS watcher and a Python worker rather than each maintaining its own version.

No caller is wired in yet.

## Review Claim

Approve the JS and Python wrapper libraries as net-new tooling with no existing caller.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Nothing today imports either wrapper, so nothing existing can be affected by this slice.

## Slice Rationale

These wrappers exist so more than one watcher can reach the same underlying primitive instead of each inventing its own version. Kept in its own PR because it has no dependency on which specific watcher ends up using it.

## Non-goals

Does not wire any existing watcher to these wrappers yet -- that is the next slice for the first caller, with a second watcher's wiring left as a documented follow-up beyond this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node --test scripts/repair-filing-ledger.test.mjs`
- [ ] `python3 scripts/test_repair_filing_ledger.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
