### PR TITLE
[CI Repair Dedup Ledger](5) Wire ci-regression-watch to the repair_filings dedup ledger

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -15,6 +15,7 @@ import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { shouldRetry, isStale } from './retry-ledger.mjs';
+import { insertRepairFiling, releaseRepairFiling } from './repair-filing-ledger.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = dirname(dirname(__filename));
@@ -442,8 +443,13 @@ function failureIsMapped(failure, jobDefinitions) {
   return Boolean(getVerifyCommandForFailure(failure, jobDefinitions));
 }
 
-function buildFleetJobName(sha, count) {
-  return `fleet / ${shortSha(sha)} (${count} jobs)`;
+// Deliberately does NOT embed the member-job count: membership can change
+// between sweeps (a 4th co-failing job joins, or one flips back to green)
+// without that being a *different* fleet event for dedup purposes. The
+// member list belongs in the failure description/metadata, not the key --
+// see buildFleetFailureDescription and REPAIR_FILING_KIND_FLEET's stateSha.
+function buildFleetJobName(sha) {
+  return `fleet / ${shortSha(sha)}`;
 }
 
 function buildFleetFailureDescription(sha, members) {
@@ -492,7 +498,7 @@ function synthesizeFleetFailure(state, sha, members, jobDefinitions) {
     if (runDelta !== 0) return runDelta;
     return a.jobName.localeCompare(b.jobName);
   }).at(0);
-  const jobName = buildFleetJobName(sha, members.length);
+  const jobName = buildFleetJobName(sha);
   return {
     ...(existing ?? {}),
     jobName,
@@ -902,6 +908,68 @@ export function liveQueryHasNonTerminalWork(failureOrSha, jobName, queryFn = hea
   );
 }
 
+// ---------------------------------------------------------------------------
+// repair_filings ledger gate (replaces liveQueryHasNonTerminalWork as the
+// default dedup gate; see scripts/repair-filing-ledger.mjs)
+// ---------------------------------------------------------------------------
+
+/**
+ * kind is namespaced per CI job and deliberately excludes the sha (that's
+ * stateSha) and, for fleet events, excludes the member-job count (that's
+ * metadata only) -- see buildFleetJobName.
+ */
+export function repairFilingKind(failure) {
+  const job = failure.markerJobName ?? failure.jobName;
+  return `ci-regression:${slugify(job)}`;
+}
+
+export function buildRepairFilingMetadata(failure) {
+  const metadata = { jobName: failure.jobName };
+  if (Array.isArray(failure.memberJobNames)) metadata.memberJobNames = failure.memberJobNames;
+  return metadata;
+}
+
+/**
+ * Atomically claims the (kind, subject='master', stateSha) key for this
+ * failure. Returns true when the caller should SKIP filing -- either because
+ * another filer already holds this exact claim, or because the ledger call
+ * itself failed and we fail closed (same philosophy as the old
+ * liveQueryHasNonTerminalWork: a broken dedup check must never risk a
+ * duplicate fix PR). Returns false when this call created the claim and the
+ * caller should proceed to file -- on failure to actually file, the caller
+ * MUST call releaseRepairFilingClaim(failure) to undo the claim, or this key
+ * would be permanently blocked from ever being retried.
+ */
+export function claimRepairFiling(failure, insert = insertRepairFiling) {
+  try {
+    const result = insert({
+      kind: repairFilingKind(failure),
+      subject: 'master',
+      stateSha: failure.firstBadSha,
+      metadata: buildRepairFilingMetadata(failure),
+    });
+    return !result.inserted;
+  } catch (err) {
+    console.error(`ci-regression-watch: claimRepairFiling failed for kind="${repairFilingKind(failure)}" sha="${failure.firstBadSha}", assuming already claimed: ${err instanceof Error ? err.message : String(err)}`);
+    return true;
+  }
+}
+
+/**
+ * Releases a claim made by claimRepairFiling when the subsequent fileFailure
+ * call throws, so a later sweep can retry the same (kind, subject, stateSha)
+ * instead of being permanently blocked. Never throws -- a failed release
+ * must not crash the sweep; it just means this key stays claimed until a
+ * human clears it or the sha changes.
+ */
+export function releaseRepairFilingClaim(failure, release = releaseRepairFiling) {
+  try {
+    release({ kind: repairFilingKind(failure), subject: 'master', stateSha: failure.firstBadSha });
+  } catch (err) {
+    console.error(`ci-regression-watch: releaseRepairFilingClaim failed for kind="${repairFilingKind(failure)}" sha="${failure.firstBadSha}"; this key stays claimed until manually cleared: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
 export function fileBugfixPlan(failure, opts = {}) {
   const repoUrl = opts.repoUrl ?? getRepoUrl();
   const jobDefinitions = opts.jobDefinitions ?? buildCiJobDefinitions();
@@ -925,7 +993,8 @@ export function processFailureFilingSweep(state, {
   maxAttempts = MAX_ATTEMPTS,
   capPerSweep = CAP_PER_SWEEP,
   jobDefinitions = null,
-  liveQuery = liveQueryHasNonTerminalWork,
+  liveQuery = claimRepairFiling,
+  releaseFiling = releaseRepairFilingClaim,
   fileFailure = () => {},
   save = () => {},
   onNeedsHuman = () => {},
@@ -999,12 +1068,17 @@ export function processFailureFilingSweep(state, {
       counts.groupsInBackoff += 1;
       continue;
     }
-    if (liveQuery(failure)) {
-      counts.groupsSkippedAlreadyAddressed += 1;
-      continue;
-    }
+    // Cap check must run BEFORE the ledger claim below: liveQuery (default
+    // claimRepairFiling) now has a side effect -- it inserts the dedup row
+    // -- so deferring a failure by the per-sweep cap after already claiming
+    // it would leak a permanently-unfileable claim (no fileFailure call ever
+    // follows to either succeed or release it).
     if (capPerSweep > 0 && counts.groupsFiled >= capPerSweep) {
       counts.groupsDeferredByCap += 1;
+      continue;
+    }
+    if (liveQuery(failure)) {
+      counts.groupsSkippedAlreadyAddressed += 1;
       continue;
     }
 
@@ -1021,6 +1095,11 @@ export function processFailureFilingSweep(state, {
     } catch (error) {
       counts.groupsFailedToFile += 1;
       onFileError(failure, error);
+      // The liveQuery call above already claimed this (kind, subject,
+      // stateSha) in the repair_filings ledger; the filing attempt itself
+      // never got submitted, so release the claim or this key would be
+      // permanently blocked from every future retry.
+      releaseFiling(failure);
       recordFailureFiled(state, failure, filedAt);
       save(state);
       continue;

--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -6,6 +6,8 @@ import { tmpdir } from 'node:os';
 import {
   buildCiJobDefinitions,
   buildMarker,
+  buildRepairFilingMetadata,
+  claimRepairFiling,
   fileBugfixPlan,
   getActionableFailures,
   groupFailuresBySha,
@@ -17,6 +19,8 @@ import {
   normalizeState,
   processFailureFilingSweep,
   reconcileCiRun,
+  releaseRepairFilingClaim,
+  repairFilingKind,
   RECOVERY_COOLDOWN_MS,
   STALE_OBSERVATION_MS,
 } from './e2e-regression-watch.mjs';
@@ -114,6 +118,128 @@ describe('liveQueryHasNonTerminalWork', () => {
   });
 });
 
+describe('repair_filings ledger gate (claimRepairFiling / releaseRepairFilingClaim)', () => {
+  function makeFakeLedger() {
+    const rows = new Map();
+    return {
+      rows,
+      insert: ({ kind, subject, stateSha, metadata }) => {
+        const key = `${kind} ${subject} ${stateSha}`;
+        if (rows.has(key)) return { inserted: false, row: rows.get(key) };
+        const row = { kind, subject, stateSha, metadata };
+        rows.set(key, row);
+        return { inserted: true, row };
+      },
+      release: ({ kind, subject, stateSha }) => {
+        rows.delete(`${kind} ${subject} ${stateSha}`);
+      },
+    };
+  }
+
+  it('kind is namespaced per CI job and excludes the sha and the fleet member count', () => {
+    assert.equal(
+      repairFilingKind(makeFailure({ jobName: 'required-fast / Guardrails' })),
+      'ci-regression:required-fast-guardrails',
+    );
+    assert.equal(
+      repairFilingKind(makeFailure({ jobName: 'fleet / abc123d', markerJobName: 'fleet' })),
+      'ci-regression:fleet',
+    );
+  });
+
+  it('prevents a duplicate PR: a second claim for the identical (kind, subject, stateSha) is rejected', () => {
+    const ledger = makeFakeLedger();
+    const failure = makeFailure({ firstBadSha: 'shaA' });
+
+    const firstAttemptSkips = claimRepairFiling(failure, ledger.insert);
+    assert.equal(firstAttemptSkips, false, 'first claim must succeed (caller proceeds to file)');
+    assert.equal(ledger.rows.size, 1);
+
+    // A second, independent caller (e.g. a fresh sweep, or a different
+    // process) tries to claim the exact same key.
+    const secondAttemptSkips = claimRepairFiling(failure, ledger.insert);
+    assert.equal(secondAttemptSkips, true, 'second claim for the identical key must be rejected');
+    assert.equal(ledger.rows.size, 1, 'exactly one row must exist for this key, not two');
+  });
+
+  it('worked example: different kind or different stateSha both claim as new work; same kind+sha collapses to one', () => {
+    const ledger = makeFakeLedger();
+    const rebaseAtShaA = makeFailure({ jobName: 'admin-requeue / rebase-conflict', firstBadSha: 'shaA' });
+    const uiVitestAtShaB = makeFailure({ jobName: 'admin-requeue / check-ui-vitest', firstBadSha: 'shaB' });
+    const rebaseAtShaBAgain = makeFailure({ jobName: 'admin-requeue / rebase-conflict', firstBadSha: 'shaB' });
+
+    assert.equal(claimRepairFiling(rebaseAtShaA, ledger.insert), false);
+    assert.equal(claimRepairFiling(uiVitestAtShaB, ledger.insert), false);
+    assert.equal(claimRepairFiling(rebaseAtShaBAgain, ledger.insert), false, 'different sha for the same kind must not be suppressed as a duplicate');
+    // Re-detecting the same problem on the same state must collapse to one row.
+    assert.equal(claimRepairFiling(rebaseAtShaBAgain, ledger.insert), true);
+    assert.equal(ledger.rows.size, 3);
+  });
+
+  it('releasing a claim after a failed filing lets a later sweep reclaim the identical key', () => {
+    const ledger = makeFakeLedger();
+    const failure = makeFailure({ firstBadSha: 'shaA' });
+
+    assert.equal(claimRepairFiling(failure, ledger.insert), false);
+    assert.equal(ledger.rows.size, 1);
+
+    // fileFailure threw downstream -- release the claim.
+    releaseRepairFilingClaim(failure, ledger.release);
+    assert.equal(ledger.rows.size, 0);
+
+    // A later attempt for the identical key must succeed now.
+    assert.equal(claimRepairFiling(failure, ledger.insert), false);
+    assert.equal(ledger.rows.size, 1);
+  });
+
+  it('fails closed (treats as already claimed) when the ledger call throws', () => {
+    const failure = makeFailure({ firstBadSha: 'shaA' });
+    const throwingInsert = () => { throw new Error('headless_mutation timed out'); };
+    assert.equal(claimRepairFiling(failure, throwingInsert), true);
+  });
+
+  it('puts the fleet member list in metadata, not the key', () => {
+    const failure = makeFailure({
+      jobName: 'fleet / abc123d',
+      markerJobName: 'fleet',
+      memberJobNames: ['required-fast / Vitest Workspace', 'quality / Dependency Cruise', 'docker / comprehensive'],
+    });
+    const metadata = buildRepairFilingMetadata(failure);
+    assert.deepEqual(metadata.memberJobNames, failure.memberJobNames);
+    assert.equal(repairFilingKind(failure), 'ci-regression:fleet');
+  });
+
+  it('processFailureFilingSweep end-to-end: a second sweep for the same (kind, subject, stateSha) never calls fileFailure again', () => {
+    const ledger = makeFakeLedger();
+    const state = stateWithFailure(makeFailure({ firstBadSha: 'shaA' }));
+    let filedCount = 0;
+
+    processFailureFilingSweep(state, {
+      now: new Date('2026-08-12T01:00:00Z'),
+      liveQuery: (failure) => claimRepairFiling(failure, ledger.insert),
+      releaseFiling: (failure) => releaseRepairFilingClaim(failure, ledger.release),
+      fileFailure: () => { filedCount += 1; },
+      isPaused: () => false,
+    });
+    assert.equal(filedCount, 1);
+
+    // Simulate a second, independent sweep run (fresh local state entry for
+    // the same underlying failure, same ledger backing store) racing to file
+    // the identical (kind, subject, stateSha).
+    const secondSweepState = stateWithFailure(makeFailure({ firstBadSha: 'shaA' }));
+    processFailureFilingSweep(secondSweepState, {
+      now: new Date('2026-08-12T01:00:01Z'),
+      liveQuery: (failure) => claimRepairFiling(failure, ledger.insert),
+      releaseFiling: (failure) => releaseRepairFilingClaim(failure, ledger.release),
+      fileFailure: () => { filedCount += 1; },
+      isPaused: () => false,
+    });
+
+    assert.equal(filedCount, 1, 'the second sweep must not file a duplicate for the identical key');
+    assert.equal(ledger.rows.size, 1);
+  });
+});
+
 describe('fleet SHA correlation', () => {
   it('groups active failures by first bad SHA', () => {
     const sha = 'abc123def456abc123def456abc123def456ab1';
@@ -155,7 +281,7 @@ describe('fleet SHA correlation', () => {
     });
 
     assert.equal(filed.length, 1);
-    assert.equal(filed[0].jobName, 'fleet / abc123d (3 jobs)');
+    assert.equal(filed[0].jobName, 'fleet / abc123d');
     assert.equal(filed[0].markerJobName, 'fleet');
     assert.ok(filed[0].verifyCommand.startsWith('bash scripts/verify-'));
     assert.equal(filed[0].description.includes('No local verify command is mapped'), false);
@@ -166,7 +292,7 @@ describe('fleet SHA correlation', () => {
     assert.deepEqual(liveMarkers, [buildMarker(sha, 'fleet')]);
     assert.equal(counts.groupsCorrelated, 1);
     assert.equal(counts.groupsFiled, 1);
-    assert.equal(state.activeFailures['fleet / abc123d (3 jobs)'].attempts, 1);
+    assert.equal(state.activeFailures['fleet / abc123d'].attempts, 1);
   });
 
   it('keeps two same-SHA failures on the per-job path', () => {
@@ -223,7 +349,7 @@ describe('fleet SHA correlation', () => {
       },
     });
     assert.equal(filedCounts.groupsFiled, 1);
-    assert.equal(state.activeFailures['fleet / abc123d (3 jobs)'].attempts, 1);
+    assert.equal(state.activeFailures['fleet / abc123d'].attempts, 1);
 
     let liveQueryCalled = false;
     const cappedCounts = processFailureFilingSweep(state, {
@@ -242,7 +368,59 @@ describe('fleet SHA correlation', () => {
     assert.equal(liveQueryCalled, false, 'attempt cap should skip before live workflow dedup');
     assert.equal(cappedCounts.groupsNeedingHuman, 1);
     assert.equal(filed, 1);
-    assert.equal(state.activeFailures['fleet / abc123d (3 jobs)'].needsHuman, true);
+    assert.equal(state.activeFailures['fleet / abc123d'].needsHuman, true);
+  });
+
+  it('buildFleetJobName-derived key is stable when fleet membership grows between sweeps', () => {
+    // Regression test: the fleet key used to embed the member-job COUNT
+    // ("fleet / abc123d (3 jobs)"), so a 4th co-failing job joining on the
+    // same sha rotated the key mid-flight. The old entry's attempt/backoff
+    // history was carried over by SHA lookup, but a caller keying its own
+    // dedup off the *jobName string itself must see one stable identity
+    // across the membership change, not a churn of keys.
+    const sha = 'abc123def456abc123def456abc123def456ab1';
+    const threeJobs = [
+      'required-fast / Vitest Workspace',
+      'quality / Dependency Cruise',
+      'docker / comprehensive',
+    ];
+    const fourthJob = 'ssh / shard-30';
+    const state = stateWithFailures(threeJobs.map((jobName) => makeFailure({ jobName, firstBadSha: sha })));
+
+    const firstSweep = processFailureFilingSweep(state, {
+      now: new Date('2026-08-12T01:00:00Z'),
+      jobDefinitions: jobDefinitionsFor(threeJobs),
+      liveQuery: () => false,
+      fileFailure: () => {},
+      isPaused: () => false,
+    });
+    assert.equal(firstSweep.groupsFiled, 1);
+    const fleetKeysAfterFirst = Object.keys(state.activeFailures).filter((key) => key.startsWith('fleet /'));
+    assert.deepEqual(fleetKeysAfterFirst, ['fleet / abc123d']);
+    assert.equal(state.activeFailures['fleet / abc123d'].attempts, 1);
+    assert.equal(state.activeFailures['fleet / abc123d'].memberJobNames.length, 3);
+
+    // A 4th job on the same sha joins the fleet on the next sweep.
+    state.activeFailures[fourthJob] = makeFailure({ jobName: fourthJob, firstBadSha: sha });
+
+    const secondSweep = processFailureFilingSweep(state, {
+      now: new Date('2026-08-12T01:05:00Z'), // well inside backoff -- must not re-file
+      jobDefinitions: jobDefinitionsFor([...threeJobs, fourthJob]),
+      liveQuery: () => false,
+      fileFailure: () => {
+        throw new Error('must not file again: still the same fleet key, still in backoff');
+      },
+      isPaused: () => false,
+    });
+
+    // Still exactly one fleet key -- membership growth did not fork a new
+    // "fleet / abc123d (4 jobs)" entry that would have reset attempts to 0
+    // and let a brand-new filing sneak past the attempt cap/backoff.
+    const fleetKeysAfterSecond = Object.keys(state.activeFailures).filter((key) => key.startsWith('fleet /'));
+    assert.deepEqual(fleetKeysAfterSecond, ['fleet / abc123d']);
+    assert.equal(state.activeFailures['fleet / abc123d'].attempts, 1, 'attempts must carry over, not reset on membership growth');
+    assert.equal(state.activeFailures['fleet / abc123d'].memberJobNames.length, 4);
+    assert.equal(secondSweep.groupsInBackoff, 1);
   });
 
   it('keeps remaining members under an existing fleet key after the active count drops below threshold', () => {
@@ -324,7 +502,7 @@ describe('fleet SHA correlation', () => {
 
     assert.equal(historicalFilings.length, 11);
     assert.equal(fleetFilings.length, 1);
-    assert.equal(fleetFilings[0].jobName, 'fleet / 631a0d0 (11 jobs)');
+    assert.equal(fleetFilings[0].jobName, 'fleet / 631a0d0');
     for (const jobName of jobs) assert.match(fleetFilings[0].description, new RegExp(jobName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
     assert.equal(counts.groupsCorrelated, 1);
     assert.equal(counts.groupsFiled, 1);


### PR DESCRIPTION
## Summary

`ci-regression-watch` now claims a `(kind, subject, state-sha)` row in `repair_filings` before filing a fix, instead of the old marker-substring check against live workflow state.

It lets the claim go if filing fails. The old check failed closed already; this preserves that while making the guarantee atomic instead of read-then-write.

Also fixes the fleet-correlated marker to drop the count of co-failing jobs. That count used to change the marker text itself when membership shifted between sweeps.

That was the leading candidate explanation for the incident that started this stack: the same regression filed twice, minutes apart.

## Review Claim

Approve `ci-regression-watch` as the first real caller of the ledger built in this stack, and the fleet-marker fix that removes a job count from what should be a stable key.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

A ledger error or an unclaimed row is treated the same way the old check treated "can't tell, so don't file" -- fails closed, tried again next sweep. Worst case after this change is identical to worst case before it: a filing gets skipped once and picked up on a later pass, never a filing that goes missing permanently.

## Slice Rationale

This is the first slice in the stack with an actual behavior change visible outside the new surface itself -- everything before it was inert until a caller showed up. Kept as its own PR since it is the one piece a reviewer needs to trust actually changes what ships to production.

## Non-goals

Does not wire the per-PR watcher that handles individual admin-bypass PR checks -- that one keeps its own separate state for now and is left as a follow-up beyond this stack. Does not reinstall the cron that runs this watcher on a fixed schedule -- that is an operational change, not a code change, and stays out of this diff.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node --test scripts/e2e-regression-watch.test.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
