### PR TITLE
[Delete-all Guard Drift](2) Fix delete-all --help text to match its removed production DB guard

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -195,7 +195,7 @@ function usage(): string {
     '  retry <workflowId>  Ask a live Invoker owner to retry a workflow.',
     '  resume <workflowId> Ask a live Invoker owner to resume a workflow.',
     '  retry-tasks --status <status>  Retry all tasks matching a status through a live owner.',
-    '  delete-all      Ask a live Invoker owner to delete all workflows, after the production DB guard passes.',
+    '  delete-all      Ask a live Invoker owner to delete all workflows. Runs unconditionally; the owner snapshots the DB first.',
     '  owner serve     Start a headless Invoker owner process.',
     '  doctor          Validate tools, config, and your default planning preset.',
     '  setup [planner|slack]  Run the setup wizard, or directly configure planner MCP or Slack.',


### PR DESCRIPTION
## Summary

A short usage string in this repo's command-line tool still described a safety response that no longer exists.

That response was intentionally taken out a few PRs ago (#9290, #9291, #9305, #9306), without this string ever getting updated to match.

This PR updates that one line of text to describe the actual, current behavior, separate from any change to what the underlying operation itself does.

## Review Claim

The reviewer is approving a one-line text update, without any change to behavior.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Text-only change to a usage string in `packages/cli/src/index.ts`. No execution path or test assertion is affected.

## Slice Rationale

Kept separate from the check-level fix landing alongside this one (a policy check, not this repo's product-facing text), since the two are different kinds of change even though they're motivated by the same underlying update elsewhere.

## Non-goals

Does not change delete-all's behavior or the test that verifies it (see the paired PR for that).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `grep "delete-all" packages/cli/src/index.ts` — confirms the new text reads "Runs unconditionally; the owner snapshots the DB first."

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge sha>`
- Post-revert steps: None
- Data migration? No

</details>
