### PR TITLE
[Docker CI Unzip Drift](1) Remove docker/comprehensive's now-dead unzip provisioning step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1216,30 +1216,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Install Electron repair dependency
-        shell: bash
-        run: |
-          set -euo pipefail
-          if command -v unzip >/dev/null 2>&1; then
-            exit 0
-          fi
-          if ! command -v apt-get >/dev/null 2>&1; then
-            echo "::error::The Docker CI job requires unzip for Electron provisioning, but apt-get is unavailable."
-            exit 1
-          fi
-          if [ "$(id -u)" -eq 0 ]; then
-            apt-get update -qq
-            apt-get install -y unzip
-            exit 0
-          fi
-          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-            sudo -n apt-get update -qq
-            sudo -n apt-get install -y unzip
-            exit 0
-          fi
-          echo "::error::The Docker CI job requires unzip; run as root or provide passwordless sudo for apt-get."
-          exit 1
-
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -246,14 +246,9 @@ assert(
 
 assert(jobs.docker, 'Missing docker job');
 assert(jobs.docker.if === NON_PR_GATE, 'docker must not run on pull_request events');
-assertStepBefore(jobs.docker, 'Install Electron repair dependency', 'Install dependencies', 'docker');
-const dockerElectronRepairStep = jobs.docker.steps.find(
-  (step) => step.name === 'Install Electron repair dependency',
-);
 assert(
-  String(dockerElectronRepairStep?.run ?? '').includes('apt-get install -y unzip')
-    && String(dockerElectronRepairStep?.run ?? '').includes('sudo -n apt-get install -y unzip'),
-  'docker must provision unzip so the Electron repair fallback can complete during pnpm install',
+  !jobs.docker.steps.some((step) => step.name === 'Install Electron repair dependency'),
+  'docker must not provision system unzip: scripts/electron.cjs\'s repair path uses the bundled extract-zip package, not a system unzip binary (see PR #9406)',
 );
 
 assert(


### PR DESCRIPTION
## Summary

`docker / comprehensive` has been failing because one of its early steps needs a system tool that a same-day, already-merged PR (#9406) made unnecessary.

That PR moved a fallback extraction path onto a bundled package instead, but never took out the now-pointless provisioning step that PR #9352 had added the day before, or the policy check that required it.

This PR takes out both, since neither has any remaining reason to run.

## Review Claim

The reviewer is approving that a provisioning step and its matching policy check are removed, since the thing they provisioned for no longer needs it, without any other step depending on it.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Confirmed the underlying repair path (`scripts/electron.cjs`) has zero references to the tool this step provisioned — it already moved onto a bundled package via #9406. Nothing else in this job's steps needs it either (other archive handling uses `tar`).

## Slice Rationale

Kept separate from the other CI-failure fixes landing in this same push, since this is an independent root cause behind a different failing job with no overlapping files.

## Non-goals

Does not touch the five other `.github/workflows/ci.yml` jobs that provision the same tool for a mixed-purpose native-build step — those still need it for other packages, so they're flagged as a possible follow-up rather than changed here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs` — `CI merge-queue policy is valid.`, exit 0

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge sha>`
- Post-revert steps: None
- Data migration? No

</details>
