### PR TITLE
[Mini-DAG Async Render Flake](1) Fix task-interaction mini-dag test to await async render

### DIFF
--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -46,7 +46,7 @@ describe('Task interaction (component)', () => {
 
     fireEvent.click(screen.getByTestId('rf__node-wf-a'));
 
-    const miniDag = screen.getByTestId('selected-workflow-mini-dag');
+    const miniDag = await screen.findByTestId('selected-workflow-mini-dag');
     expect(miniDag).toHaveTextContent('Workflow A');
     expect(miniDag).toHaveTextContent('Loading graph…');
     expect(screen.queryByTestId('rf__node-task-alpha')).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

`required-fast / Vitest Workspace` failed on one test out of 857: a mini-DAG node was looked up before it had actually rendered.

The lookup used a synchronous form that only checks the first render pass, but this element appears after an async state update finishes.

This PR switches that one lookup to an async form that waits for the element, instead of assuming it's already there.

## Review Claim

The reviewer is approving that one test lookup waits for its target to render, instead of assuming a synchronous first pass is enough.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change to one assertion in one file. Does not touch any production component or rendering logic.

## Slice Rationale

Kept separate from the other CI-failure fixes landing in this same push, since this is an independent root cause behind a different failing job with no overlapping files.

## Non-goals

Does not change the underlying component's render timing — only how the test observes it.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm test -- task-interaction.test.tsx` (from `packages/ui`) — `Test Files 1 passed (1)`, `Tests 12 passed (12)`, exit 0

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge sha>`
- Post-revert steps: None
- Data migration? No

</details>
