### PR TITLE
[Electron Interrupted Extraction](1) Reproduce: interrupted Electron extraction leaves a half-written dist/

### DIFF
--- a/scripts/repro/repro-mece-04-remote-electron-provisioning.sh
+++ b/scripts/repro/repro-mece-04-remote-electron-provisioning.sh
@@ -204,3 +204,68 @@ if [[ ! -x "$TMP_DIR/repo/node_modules/electron/dist/electron" ]]; then
 fi
 
 echo "remote-electron-provisioning fixed: fallback extraction succeeds without a host unzip executable"
+
+# Regression: a self-hosted CI runner reuses the same on-disk workspace across
+# job runs. If a run is killed (job cancellation, timeout-minutes) while
+# extract-zip is mid-write, an extraction straight into the live dist/
+# directory can leave some files present but not the platform binary --
+# resolveInstalledElectronBinary()'s existence-only check must never treat
+# that half-written state as installed, and a subsequent install-only must
+# never leave dist/ in that half-written shape either.
+cat >"$TMP_DIR/repo/node_modules/extract-zip/index.js" <<'JS'
+const fs = require('node:fs');
+const path = require('node:path');
+
+module.exports = async function extractZip(zipPath, options) {
+  if (zipPath !== process.env.FAKE_ELECTRON_ZIP) {
+    throw new Error(`unexpected Electron archive: ${zipPath}`);
+  }
+  fs.writeFileSync(process.env.FAKE_EXTRACT_ZIP_MARKER, 'yes\n');
+  fs.mkdirSync(path.join(options.dir, 'locales'), { recursive: true });
+  fs.writeFileSync(path.join(options.dir, 'locales', 'en-US.pak'), 'fake-locale-data');
+  throw new Error('simulated interruption: killed mid-extraction before the platform binary was written');
+};
+JS
+
+rm -f "$TMP_DIR/repo/installer-ran" "$FAKE_ELECTRON_DOWNLOAD_MARKER" "$FAKE_EXTRACT_ZIP_MARKER"
+rm -rf "$TMP_DIR/repo/node_modules/electron/dist" "$TMP_DIR/repo/node_modules/electron/path.txt"
+PLATFORM_BINARY_PATH="$("$NODE_BIN" -e "
+switch (process.platform) {
+  case 'mas':
+  case 'darwin':
+    console.log('Electron.app/Contents/MacOS/Electron');
+    break;
+  case 'win32':
+    console.log('electron.exe');
+    break;
+  default:
+    console.log('electron');
+}
+")"
+
+set +e
+(
+  cd "$TMP_DIR/repo"
+  PATH="$TMP_DIR/empty-path" \
+    FAKE_ELECTRON_INSTALL_EMPTY_SUCCESS=1 \
+    FAKE_ELECTRON_ZIP="$FAKE_ELECTRON_ZIP" \
+    FAKE_ELECTRON_DOWNLOAD_MARKER="$FAKE_ELECTRON_DOWNLOAD_MARKER" \
+    FAKE_EXTRACT_ZIP_MARKER="$FAKE_EXTRACT_ZIP_MARKER" \
+    "$NODE_BIN" scripts/electron.cjs --install-only
+) >"$TMP_DIR/interrupted-install-stdout" 2>"$TMP_DIR/interrupted-install-stderr"
+INTERRUPTED_STATUS=$?
+set -e
+
+if [[ "$INTERRUPTED_STATUS" -eq 0 ]]; then
+  echo "repro: expected install-only to fail after an interrupted extraction" >&2
+  echo "--- stderr ---" >&2
+  cat "$TMP_DIR/interrupted-install-stderr" >&2
+  exit 1
+fi
+if [[ -e "$TMP_DIR/repo/node_modules/electron/dist" ]] && [[ ! -e "$TMP_DIR/repo/node_modules/electron/dist/$PLATFORM_BINARY_PATH" ]]; then
+  echo "repro: an interrupted extraction left a half-written dist/ (has locales/ but not the platform binary) -- this is the corrupted state observed on the real CI fleet" >&2
+  find "$TMP_DIR/repo/node_modules/electron/dist" >&2
+  exit 1
+fi
+
+echo "remote-electron-provisioning interrupted-extraction fixed: a killed extraction never leaves a half-written dist/"


### PR DESCRIPTION
## Summary

Every playwright CI job and several others have been failing at fixture setup, before any test-specific code runs, on the self-hosted runner fleet.

Live evidence on all 5 of those runners: the Electron package's platform binary is missing, while the archive it comes from is present and valid. Something interrupts extraction partway through.

This PR adds a case reproducing exactly that: a killed extraction that writes some files but not the platform binary.

## Review Claim

The reviewer is approving a new case in the existing Electron provisioning repro script that demonstrates today's real failure mode, confirmed failing against the current, unfixed extraction code.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This PR only adds a repro case; it does not change any product code. Confirmed the new case fails against the current, unmodified extraction path (see Test Plan) — this is a genuine before-state, not a case written to already pass.

## Slice Rationale

Split from the fix itself (paired PR, landing separately) so the failure is demonstrated before the change that addresses it is approved, per this repo's proof-before-fix convention. Kept separate from the other CI-failure fixes landing in this same push, since this is an independent root cause behind a different set of failing jobs.

## Non-goals

Does not fix the extraction bug this demonstrates — see the paired fix PR. Does not address a separate, pre-existing gap in this same script's original case (its fake hardcodes the Linux binary name, so it only runs reliably under `npm_config_platform=linux` on a non-Linux dev machine) — flagged, not fixed here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `npm_config_platform=linux bash scripts/repro/repro-mece-04-remote-electron-provisioning.sh` against this PR's code alone (current unfixed `scripts/electron.cjs`) — exit 1, `repro: an interrupted extraction left a half-written dist/ (has locales/ but not the platform binary) -- this is the corrupted state observed on the real CI fleet`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge sha>`
- Post-revert steps: None
- Data migration? No

</details>
