### PR TITLE
[Electron Interrupted Extraction](2) Make Electron's repair-extract path crash-safe against interrupted runs

### DIFF
--- a/scripts/electron.cjs
+++ b/scripts/electron.cjs
@@ -98,9 +98,23 @@ async function repairElectronWithPackageExtractor(electronPackageDir) {
   });
 
   const distPath = path.join(electronPackageDir, 'dist');
-  fs.rmSync(distPath, { recursive: true, force: true });
-  fs.mkdirSync(distPath, { recursive: true });
-  await extractZip(zipPath, { dir: distPath });
+  const stagingPath = path.join(electronPackageDir, `dist.staging-${process.pid}`);
+  fs.rmSync(stagingPath, { recursive: true, force: true });
+  fs.mkdirSync(stagingPath, { recursive: true });
+  try {
+    await extractZip(zipPath, { dir: stagingPath });
+
+    const stagedBinary = path.join(stagingPath, platformPath);
+    if (!fs.existsSync(stagedBinary)) {
+      throw new Error(`extract-zip did not produce ${platformPath} in ${stagingPath}; extraction was interrupted or incomplete`);
+    }
+
+    fs.rmSync(distPath, { recursive: true, force: true });
+    fs.renameSync(stagingPath, distPath);
+  } catch (error) {
+    fs.rmSync(stagingPath, { recursive: true, force: true });
+    throw error;
+  }
 
   const sourceTypeDefinitions = path.join(distPath, 'electron.d.ts');
   if (fs.existsSync(sourceTypeDefinitions)) {


### PR DESCRIPTION
## Summary

Every playwright CI job and several others have been failing at fixture setup on the self-hosted runner fleet: `Electron failed to install correctly`.

The extraction step wrote straight into the live, shared install directory with no check that the platform binary actually landed, and marked itself done regardless. An interrupted run (job cancellation, resource pressure) left exactly that corrupted, half-written shape behind for the next job to hit.

This PR extracts into an isolated location first, checks the binary landed, and only then swaps it into place.

## Review Claim

The reviewer is approving that Electron's extraction step becomes atomic: an interrupted run now leaves the live install directory untouched instead of half-written.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The successful-completion path is unchanged in outcome — a clean, uninterrupted run still ends with the same files in the same place. The only behavior change is what happens when a run is interrupted partway through: previously a corrupted, half-written directory; now the previous good state (or a clean absence) is preserved instead.

## Slice Rationale

Split from the paired proof PR (landing first) that reproduces this exact failure against the current, unfixed code, per this repo's proof-before-fix convention. Kept separate from the other CI-failure fixes landing in this same push, since this is an independent root cause behind a different set of failing jobs.

## Non-goals

Does not clean up the runner fleet's already-corrupted install directories left over from before this fix — that's a one-time operational cleanup on the runners themselves, not something a code change on this repo's side can reach. Does not address a separate, pre-existing gap where the repro script's original case hardcodes a Linux binary name (flagged in the paired proof PR, not fixed here).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `npm_config_platform=linux bash scripts/repro/repro-mece-04-remote-electron-provisioning.sh` with this PR's `scripts/electron.cjs` change and the paired PR's new case both applied together — exit 0, both `... fixed: fallback extraction succeeds without a host unzip executable` and `... interrupted-extraction fixed: a killed extraction never leaves a half-written dist/`
- [x] `npm_config_platform=linux bash scripts/repro/repro-mece-04-remote-electron-provisioning.sh` with only this PR's change (paired case not present) — exit 0, `... fixed: fallback extraction succeeds without a host unzip executable` (confirms the existing case still passes)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge sha>`
- Post-revert steps: None
- Data migration? No

</details>
