### PR TITLE
[CI regression: 59df38d-required-fast-merge-gate-concurrency-repro](1) Skip Electron binary download in required-fast-extra pnpm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,6 +656,9 @@ jobs:
             .node-version
 
       - name: Install dependencies
+        env:
+          INVOKER_SKIP_ELECTRON_INSTALL: '1'
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
         run: pnpm install --frozen-lockfile
 
       - name: Download build artifacts

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -211,6 +211,16 @@ assert(
   requiredFastExtraNodeLibraryScript.includes('python3'),
   'required-fast-extra must install python3 for node-gyp native builds on self-hosted runners',
 );
+const requiredFastExtraInstallDepsStep = jobs['required-fast-extra'].steps.find(
+  (step) => step.name === 'Install dependencies',
+);
+assert(
+  requiredFastExtraInstallDepsStep?.env?.INVOKER_SKIP_ELECTRON_INSTALL === '1'
+    && requiredFastExtraInstallDepsStep?.env?.ELECTRON_SKIP_BINARY_DOWNLOAD === '1',
+  'required-fast-extra must skip installing Electron during pnpm install -- none of its suites launch the app, '
+  + 'and downloading the Electron binary is an unnecessary network dependency that can fail independently of '
+  + 'the system packages required-fast-extra actually needs',
+);
 const requiredFastExtraEntries = jobs['required-fast-extra'].strategy?.matrix?.include ?? [];
 const branchCarryForwardEntry = requiredFastExtraEntries.find((entry) => entry.name === 'Branch Carry Forward');
 assert(branchCarryForwardEntry, 'required-fast-extra matrix must include Branch Carry Forward');


### PR DESCRIPTION
## Summary

CI job `required-fast / Merge Gate Concurrency Repro` first failed on default-branch push commit
`59df38dfc7557db5cb55cf9d545435ed2833c045` (run [31928558144](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31928558144/job/95120880830)) and stayed red through `a71f331faa98bb83d660a422e4bd7e051d90ad87` (run 31970017739).

The `required-fast-extra` job's "Install dependencies" step ran a plain `pnpm install --frozen-lockfile`, which downloads and installs the Electron binary as part of the root `postinstall` script.

None of the suites in `required-fast-extra` launch the Electron app, so that download is pure overhead. It is also a network dependency that can fail on its own.

This PR sets `INVOKER_SKIP_ELECTRON_INSTALL=1` and `ELECTRON_SKIP_BINARY_DOWNLOAD=1` on that step's `pnpm install`.

It also extends `scripts/test-ci-workflow-merge-queue-policy.mjs` to assert both env vars stay set on that step, so a future edit cannot silently drop them.

The two Invoker tasks downstream of this fix (local verification, and a `/reflect` pass over this repair's transcripts) made no file changes.

The verify task only re-ran the acceptance command and exited 0. The reflect task's synthesis found no durable, skill-worthy finding from this repair.

Both are folded into this single PR instead of publishing empty-diff PR slices — see Test Plan.

## Review Claim

The added env vars on `required-fast-extra`'s "Install dependencies" step correct this job's root cause (an unnecessary Electron binary download/install) with no unrelated edits, and the policy script now enforces that both env vars stay present.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change is scoped to one CI workflow step's environment variables plus a matching static assertion in the policy test script. It does not touch product code, other CI jobs' steps, or `required-fast-extra`'s existing package-list/sudo-guard install behavior, so other jobs and runtime behavior stay unchanged.

## Slice Rationale

This is the one behavior-bearing slice in a 3-task Invoker workflow (fix, verify, reflect) for this CI regression. The verify and reflect tasks made no file changes on top of this fix — folding them into empty PR slices would violate this repo's diff-atomicity rule against publishing empty-diff PRs, so their outcomes are recorded here instead of as separate PRs.

## Non-goals

Does not touch `required-fast-extra`'s existing `libatomic1`/`make`/`g++`/`python3`/`unzip` package list or its `sudo -n` guard, both already covered by `scripts/test-ci-workflow-merge-queue-policy.mjs`. Does not change any other job's "Install dependencies"/"Install system libraries" step. No product code changes. No skill edits — the downstream `/reflect` task found no durable finding from this repair.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-ci-workflow-merge-queue-policy.mjs` (static assertion that `required-fast-extra`'s "Install dependencies" step sets `INVOKER_SKIP_ELECTRON_INSTALL=1` and `ELECTRON_SKIP_BINARY_DOWNLOAD=1`; this is the real proof for a workflow-YAML-only provisioning fix, not the product build/test chain below)
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh` (the task's original acceptance command; exited 0 on this branch, re-run by the downstream verify task with no code changes)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
