### PR TITLE
[CI regression: 59df38d-required-fast-merge-gate-concurrency-repro](1) Skip Electron binary download in required-fast-extra install step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,6 +656,9 @@ jobs:
             .node-version
 
       - name: Install dependencies
+        env:
+          INVOKER_SKIP_ELECTRON_INSTALL: '1'
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
         run: pnpm install --frozen-lockfile
 
       - name: Download build artifacts

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -211,6 +211,16 @@ assert(
   requiredFastExtraNodeLibraryScript.includes('python3'),
   'required-fast-extra must install python3 for node-gyp native builds on self-hosted runners',
 );
+const requiredFastExtraInstallDepsStep = jobs['required-fast-extra'].steps.find(
+  (step) => step.name === 'Install dependencies',
+);
+assert(
+  requiredFastExtraInstallDepsStep?.env?.INVOKER_SKIP_ELECTRON_INSTALL === '1'
+    && requiredFastExtraInstallDepsStep?.env?.ELECTRON_SKIP_BINARY_DOWNLOAD === '1',
+  'required-fast-extra must skip installing Electron during pnpm install -- none of its suites launch the app, '
+  + 'and downloading the Electron binary is an unnecessary network dependency that can fail independently of '
+  + 'the system packages required-fast-extra actually needs',
+);
 const requiredFastExtraEntries = jobs['required-fast-extra'].strategy?.matrix?.include ?? [];
 const branchCarryForwardEntry = requiredFastExtraEntries.find((entry) => entry.name === 'Branch Carry Forward');
 assert(branchCarryForwardEntry, 'required-fast-extra matrix must include Branch Carry Forward');


### PR DESCRIPTION
## Summary

CI job `required-fast / Merge Gate Concurrency Repro` (part of the `required-fast-extra` matrix) first failed on default-branch commit `59df38dfc7557db5cb55cf9d545435ed2833c045`.

That job's `Install dependencies` step ran a plain `pnpm install --frozen-lockfile`, which downloads the full Electron binary. None of `required-fast-extra`'s suites launch the app.

That download is an unnecessary network dependency. It can fail on its own, independent of the system packages the job actually needs.

The fix sets `INVOKER_SKIP_ELECTRON_INSTALL=1` and `ELECTRON_SKIP_BINARY_DOWNLOAD=1` on that step's `env`, and adds a matching assertion to `scripts/test-ci-workflow-merge-queue-policy.mjs` so the workflow YAML cannot silently drop the env vars again.

## Review Claim

Approve the two added env vars on `required-fast-extra`'s `Install dependencies` step, plus the workflow-policy test assertion that pins them in place.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change touches only `.github/workflows/ci.yml` and its policy test; it adds environment variables to one install step and asserts on them, and does not alter any other job, step, or product code path.

## Slice Rationale

This is the only file-changing task in the workflow. The two downstream tasks in this repair (running the local verification command, and running `/reflect` against the fix transcript) produced no additional diff, so the whole repair lands as one reviewable change.

## Non-goals

No refactor of the CI workflow beyond the two touched lines. No change to any other job's install step, matrix entry, or dependency policy. No change to product code or tests outside the workflow-policy script.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-ci-workflow-merge-queue-policy.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
