### PR TITLE
[CI regression: 59df38d-required-fast-merge-gate-concurrency-repro](1) Skip Electron binary download in required-fast-extra's pnpm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,6 +656,9 @@ jobs:
             .node-version
 
       - name: Install dependencies
+        env:
+          INVOKER_SKIP_ELECTRON_INSTALL: '1'
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
         run: pnpm install --frozen-lockfile
 
       - name: Download build artifacts

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -211,6 +211,16 @@ assert(
   requiredFastExtraNodeLibraryScript.includes('python3'),
   'required-fast-extra must install python3 for node-gyp native builds on self-hosted runners',
 );
+const requiredFastExtraInstallDepsStep = jobs['required-fast-extra'].steps.find(
+  (step) => step.name === 'Install dependencies',
+);
+assert(
+  requiredFastExtraInstallDepsStep?.env?.INVOKER_SKIP_ELECTRON_INSTALL === '1'
+    && requiredFastExtraInstallDepsStep?.env?.ELECTRON_SKIP_BINARY_DOWNLOAD === '1',
+  'required-fast-extra must skip installing Electron during pnpm install -- none of its suites launch the app, '
+  + 'and downloading the Electron binary is an unnecessary network dependency that can fail independently of '
+  + 'the system packages required-fast-extra actually needs',
+);
 const requiredFastExtraEntries = jobs['required-fast-extra'].strategy?.matrix?.include ?? [];
 const branchCarryForwardEntry = requiredFastExtraEntries.find((entry) => entry.name === 'Branch Carry Forward');
 assert(branchCarryForwardEntry, 'required-fast-extra matrix must include Branch Carry Forward');


### PR DESCRIPTION
## Summary

CI job `required-fast / Merge Gate Concurrency Repro` (and its sibling required-fast-extra suites) first failed on default-branch commit 59df38dfc7557db5cb55cf9d545435ed2833c045 and stayed red through a71f331faa98bb83d660a422e4bd7e051d90ad87.

required-fast-extra's "Install dependencies" step ran a plain `pnpm install --frozen-lockfile`. That step downloads the Electron binary even though none of required-fast-extra's suites launch the app.

The Electron download is an unrelated network dependency that can fail on its own, independent of the system packages required-fast-extra actually needs.

This PR sets `INVOKER_SKIP_ELECTRON_INSTALL=1` and `ELECTRON_SKIP_BINARY_DOWNLOAD=1` on that step, and extends the CI workflow policy validator to assert both env vars stay present.

A downstream verify task re-ran the failing suite locally; it passed. A downstream reflect task looked for a durable process lesson, found none, and made no skill changes.

Neither of those two tasks produced a file diff, so their work is folded into this single slice instead of publishing empty-diff PRs.

## Review Claim

Skipping the Electron binary download in required-fast-extra's `pnpm install` step removes an unrelated network dependency from the job, without changing which suites run or what they assert.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change only adds two environment variables to one CI step (`required-fast-extra`'s "Install dependencies" step) and one matching static assertion in `scripts/test-ci-workflow-merge-queue-policy.mjs`. It does not touch product code, any other CI job's steps, or any test's pass/fail logic, so other CI jobs and product behavior stay unchanged.

## Slice Rationale

The fix/verify/reflect task sequence only produced one file-level diff: the verify task re-ran an existing script with no code change, and the reflect task found no durable finding to record. Folding all three into one slice avoids publishing empty-diff PRs for tasks that made no code change.

## Non-goals

- No change to which suites run in `required-fast-extra` or any other CI job.
- No change to `scripts/test-suites/required/17-merge-gate-concurrency-repro.sh` itself.
- No skill or documentation changes — the reflect task found no durable finding to record.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
