### PR TITLE
[Missing CLI Build Artifact](1) Build and package packages/cli into the shared CI build artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,8 @@ jobs:
           pnpm --filter @invoker/ui build
           pnpm --filter @invoker/surfaces build
           pnpm --filter @invoker/app build
-          tar -czf app-build-dist.tgz packages/ui/dist packages/app/dist packages/surfaces/dist
+          pnpm --filter @invoker/cli build
+          tar -czf app-build-dist.tgz packages/ui/dist packages/app/dist packages/surfaces/dist packages/cli/dist
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Several jobs sharing one build artifact have been failing with zero passing cases, without any per-case detail explaining why.

They all extract the same tarball, and one piece of this repo has never been part of it, without anyone adding it back when those jobs started needing it.

This PR adds that missing piece to the tarball, alongside the three that are already there.

## Review Claim

The reviewer is approving that a fourth workspace package gets built and included in the shared tarball several CI jobs already extract, without changing what those jobs otherwise do.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only adds one more `pnpm --filter` build call and one more path to an existing `tar` command in a CI-only workflow file. Does not change any product runtime code or any job's other steps.

## Slice Rationale

Kept separate from a paired PR that fixes a second, independent bug this uncovered (the built package currently crashes at startup) — different files, different kind of change. Also kept separate from the other CI-failure fixes landing in this same push.

## Non-goals

Does not itself make the built package runnable — see the paired PR for that. Does not change which jobs consume this tarball or add any new job.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Reproduced the failure first: `rm -rf packages/cli/dist && pnpm install` against unmodified code — `WARN Failed to create bin at .../invoker-cli. ENOENT: no such file or directory, open '.../packages/cli/dist/index.js'`, matching the CI log line
- [x] With this change applied: `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && pnpm --filter @invoker/cli build` — all four exit 0
- [x] `tar -czf app-build-dist.tgz packages/ui/dist packages/app/dist packages/surfaces/dist packages/cli/dist` then extracted into a workspace with `node_modules` already installed — `packages/cli/dist/index.js` present and executable

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge sha>`
- Post-revert steps: None
- Data migration? No

</details>
