### PR TITLE
[Missing CLI Build Artifact](2) Declare @slack/web-api as a real CLI dependency instead of bundling it

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
     "@invoker/transport": "workspace:*",
     "@invoker/workflow-core": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@slack/web-api": "^7.14.1",
     "yaml": "^2.8.2",
     "zod": "^4.4.3"
   },

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   banner: {
     js: '#!/usr/bin/env node',
   },
-  external: ['node:sqlite', 'yaml', 'dockerode', 'ssh2', 'cpu-features'],
+  external: ['node:sqlite', 'yaml', 'dockerode', 'ssh2', 'cpu-features', '@slack/web-api'],
   noExternal: [
     '@invoker/contracts',
     '@invoker/data-store',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,6 +145,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
+      '@slack/web-api':
+        specifier: ^7.14.1
+        version: 7.14.1
       yaml:
         specifier: ^2.8.2
         version: 2.8.2


### PR DESCRIPTION
## Summary

Once actually built, this repo's standalone command-line package crashes the instant it starts, before doing anything.

The crash traces to a notifications SDK getting bundled in by accident. One of the workspace pieces this package bundles wholesale registers a notifications-related capability unconditionally at startup, pulling that SDK along with it even though this package itself never asked for it.

This PR declares that SDK as a real, direct requirement instead, resolved normally instead of bundled in.

## Review Claim

The reviewer is approving that one SDK becomes a normal, direct requirement of this package instead of being bundled in by accident, resolved the same way three others already are.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Matches an existing, already-accepted pattern in this same config for three other packages that need the same treatment for the same reason. The package version pinned here already matches what a sibling workspace piece already uses elsewhere in this repo.

## Slice Rationale

Kept separate from a paired PR (this repo's shared CI build step, which needs this package built at all before this bug is even visible) — different files, different kind of change. Also kept separate from the other CI-failure fixes landing in this same push.

## Non-goals

Does not change the notifications-related capability's own logic — only how one of its dependencies gets resolved when this unrelated package happens to bundle the workspace piece that registers it. Does not address why that capability gets registered unconditionally regardless of whether the consumer needs it — flagging that as a separate, larger question for a later pass, not fixed here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Reproduced first, against unmodified code: built the package and ran its own existing startup smoke script — crashed with `Error: Dynamic require of "os" is not supported`, thrown from the notifications SDK's own instrumentation code
- [x] With this change applied: same build and smoke script — exits 0, prints `hello-from-invoker-cli`, confirming the package now actually starts and completes a real run

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge sha>`
- Post-revert steps: None
- Data migration? No

</details>
