### PR TITLE
[Required-Fast-Extra Disk Full](1) Add stale-scratch disk cleanup to required-fast-extra's self-hosted jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,6 +573,9 @@ jobs:
       - name: Reclaim workspace
         run: sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" "$HOME/.invoker" "$HOME/.claude" 2>/dev/null || true
         shell: bash
+      - name: Reclaim disk space
+        run: find /tmp -maxdepth 1 -name 'invoker-*' -mmin +360 -exec rm -rf {} + 2>/dev/null || true
+        shell: bash
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Three jobs in one matrix have been failing with a runner out of disk space, without any test-specific error to point at.

The step that already runs first in this job only fixes file ownership, without ever freeing any actual space.

This PR adds a step that clears old scratch left behind by past runs before anything else starts, separate from that ownership step.

## Review Claim

The reviewer is approving that this job's self-hosted runner clears old scratch left over from past runs, without touching anything from a run still in progress.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only removes entries older than 6 hours — well past this job's own 45-minute timeout, so nothing from a live run can be caught by it. Confirmed the age-based logic itself with an isolated test: an old matching entry got removed, a fresh matching entry and an unrelated entry were both left alone (see Test Plan). A no-op on ephemeral, hosted runners in the same matrix, since they never accumulate this kind of leftover.

## Slice Rationale

Kept separate from the other CI-failure fixes landing in this same push, since this is an independent root cause behind a different set of failing jobs.

## Non-goals

Does not address whether Invoker's own existing periodic reclaim mechanism should also cover this runner pool — live evidence on a related pool shows real, current disk pressure (two hosts at 90% and 92% used) that mechanism hasn't prevented, but fixing that mechanism itself is a separate, larger piece of work flagged here, not done in this PR. Does not change any test logic — only when stale scratch gets cleared.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Isolated test of the age-based logic: created a fake old (8h) matching entry, a fresh matching entry, and an unrelated entry in a throwaway temp root, then ran the exact `find ... -mmin +360 -exec rm -rf {} +` command scoped to that root — only the old matching entry was removed; the fresh entry and the unrelated one were both preserved
- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs` — `CI merge-queue policy is valid.`, exit 0
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — parses without error

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge sha>`
- Post-revert steps: None
- Data migration? No

</details>
