### PR TITLE
[CI Repair Dedup Ledger](7) Gate plan_direct_repairs' own repair_check/repair_conflict paths

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -13,6 +13,7 @@ try:
     from .mergify_admin_requeue_logger import AdminBypassLogger
     from .mergify_admin_requeue_model import Action, Ledger, PrSnapshot, load_mergify_rules
     from .mergify_admin_requeue_plan import (
+        CONFLICT_REPAIR_FILING_KIND,
         REBASE_CONFLICT_REPAIR_FILING_KIND,
         ClaimRepairFiling,
         ReleaseRepairFiling,
@@ -35,6 +36,7 @@ except ImportError:
     from mergify_admin_requeue_logger import AdminBypassLogger
     from mergify_admin_requeue_model import Action, Ledger, PrSnapshot, load_mergify_rules
     from mergify_admin_requeue_plan import (
+        CONFLICT_REPAIR_FILING_KIND,
         REBASE_CONFLICT_REPAIR_FILING_KIND,
         ClaimRepairFiling,
         ReleaseRepairFiling,
@@ -303,6 +305,8 @@ def run_cycle(
                         key=action.key,
                         error=str(exc),
                     )
+                    if release_repair_filing is not None:
+                        release_repair_filing(CONFLICT_REPAIR_FILING_KIND, str(action.pr_number), pr.head_ref_oid)
                     should_poll = True
                     continue
                 if progressed:

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -81,6 +81,7 @@ def repair_filing_kind_for_check(check_name: str) -> str:
 
 
 REBASE_CONFLICT_REPAIR_FILING_KIND = "admin-requeue:rebase-conflict"
+CONFLICT_REPAIR_FILING_KIND = "admin-requeue:conflict"
 
 # Every claim_repair_filing call site below uses `subject=str(pr.number)` --
 # the raw PR number, same shape as repair_check_plan_name/repair_conflict_plan_name
@@ -976,10 +977,10 @@ def plan_direct_repairs(
                     continue
                 if not decision["crashed_on_infra"] and repair_in_flight(ledger, pr.number, pr.head_ref_oid, "conflict-repair", key, now):
                     continue
-                # Not yet gated by claim_repair_filing (repair_conflict is a
-                # separate, un-namespaced filing point from
-                # mergify_failed_check_actions/plan_rebase_onto_base) --
-                # see the handoff notes for this known gap.
+                if claim_repair_filing is not None and claim_repair_filing(
+                    CONFLICT_REPAIR_FILING_KIND, str(pr.number), pr.head_ref_oid,
+                ):
+                    continue
                 return Action("repair_conflict", pr.number, key, blocker.detail)
             if blocker.kind == "failed_check":
                 if facts.stale_base_by_pr.get(pr.number):
@@ -997,6 +998,16 @@ def plan_direct_repairs(
                 if decision["action"] == "backoff":
                     continue
                 if not decision["crashed_on_infra"] and repair_in_flight(ledger, pr.number, pr.head_ref_oid, "repair-check", blocker.key, now):
+                    continue
+                # Same kind formula as mergify_failed_check_actions -- a claim
+                # made via that path (the Mergify-queue-driven view of this
+                # same check) and a claim made via this path (the PR's own
+                # check state) collapse to the identical ledger key, which is
+                # exactly what closes the bug this class reproduces: both
+                # paths often fire for the same real check at once.
+                if claim_repair_filing is not None and claim_repair_filing(
+                    repair_filing_kind_for_check(blocker.key), str(pr.number), pr.head_ref_oid,
+                ):
                     continue
                 return Action("repair_check", pr.number, blocker.key, blocker.detail)
     return None

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -1004,6 +1004,48 @@ class ClaimRepairFilingGate(PlannerTestCase):
         self.assertEqual(plan.actions[0].kind, "requeue")
 
 
+class PlanDirectRepairsUnguardedSecondPathRepro(PlannerTestCase):
+    """Reproduces the exact gap flagged in PR #9474's Non-goals: when BOTH the
+    Mergify queue event AND the PR's own check report the same check as
+    failing (the common case -- a real CI failure usually shows up both
+    places), mergify_failed_check_actions correctly honors a duplicate claim
+    and returns (), but plan_direct_repairs' own separate, un-gated
+    failed_check/conflict blocker handling picks the exact same repair right
+    back up and refiles it anyway. This is the live bug: the ledger claim
+    said "someone else already has this", and the planner filed it a second
+    time through a different code path regardless."""
+
+    def _plan(self, snapshot, claim_repair_filing):
+        ledger = self._ledger()
+        stack = m.StackGroup("s", (snapshot,))
+        facts = p.build_stack_facts(stack, REQUIRED, ledger, (), {}, "master", stale_base_by_pr={})
+        return p.plan_actions_from_facts(facts, ledger, max_requeue_attempts=2, max_repair_attempts=3, now=NOW, claim_repair_filing=claim_repair_filing)
+
+    def test_duplicate_claim_is_not_honored_by_plan_direct_repairs_failed_check_path(self):
+        # Both signals present: the PR's own "build" check is failing (drives
+        # classify_pr's failed_check blocker, which plan_direct_repairs
+        # handles inline) AND the Mergify queue event also lists "build" as
+        # failing (drives mergify_failed_check_actions, which IS gated).
+        snapshot = pr(checks={"build": check("failure")}, latest_mergify=event(failing=("build",)))
+        actions = self._plan(snapshot, claim_repair_filing=lambda kind, subject, sha: True)
+        repair_check_actions = [a for a in actions if a.kind == "repair_check"]
+        self.assertEqual(
+            repair_check_actions, [],
+            "plan_direct_repairs' own failed_check path refiled a repair_check the ledger "
+            "already said was claimed elsewhere -- it is not gated by claim_repair_filing",
+        )
+
+    def test_duplicate_claim_is_not_honored_by_plan_direct_repairs_conflict_path(self):
+        snapshot = pr(mergeable="CONFLICTING")
+        actions = self._plan(snapshot, claim_repair_filing=lambda kind, subject, sha: True)
+        repair_conflict_actions = [a for a in actions if a.kind == "repair_conflict"]
+        self.assertEqual(
+            repair_conflict_actions, [],
+            "plan_direct_repairs' own conflict path refiled a repair_conflict the ledger "
+            "already said was claimed elsewhere -- it is not gated by claim_repair_filing",
+        )
+
+
 class DefaultClaimAndReleaseRepairFiling(PlannerTestCase):
     """default_claim_repair_filing/default_release_repair_filing are the real
     production functions wired into mergify_admin_requeue.py's main(); they


### PR DESCRIPTION
## Summary

`plan_direct_repairs` had its own separate, un-gated path to the same two actions the previous slice claimed against.

Proven by a red test: a Mergify-queue-driven claim and this function's own PR-check-driven path both returned a repair for the identical real failure.

Gates both of its inline paths the same way, reusing the same key formula on the check path so a claim from either side of the two watchers collapses correctly.

## Review Claim

Approve gating `plan_direct_repairs`'s own `repair_check` and `repair_conflict` paths, closing the gap flagged as a known limitation in the previous slice.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The new argument defaults to `None` in every case, same posture as the previous two slices -- passing `None` reproduces the exact prior decision tree. The repro test that failed against pre-fix code now passes, and every pre-existing case in the suite still passes unchanged.

## Slice Rationale

Kept apart from the slice that introduced the claim primitive for this system, since this is a distinct finding with its own repro and its own fix, surfaced by that earlier slice's own tests rather than assumed up front.

## Non-goals

Does not address the PR-number-as-subject limitation, still flagged inline elsewhere in this file. Does not add cross-check correlation beyond the two paths fixed here.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `python3 scripts/test_mergify_admin_requeue_plan.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
