### PR TITLE
Give remote CI runners the same warn-paced /tmp cleanup local targets already get

### DIFF
--- a/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
@@ -154,6 +154,34 @@ describe('disk-headroom cleanup guards', () => {
     expect(script).toContain('$INVOKER_HOME/pr-cron-work');
   });
 
+  it('stale-only mode skips the destructive Invoker-managed-dir wipe but keeps the /tmp scratch sweep', () => {
+    const criticalScript = buildInvokerHomeCleanupScript('~/.invoker', [], 'critical');
+    const staleOnlyScript = buildInvokerHomeCleanupScript('~/.invoker', [], 'stale-only');
+
+    // critical still does the full destructive sweep.
+    expect(criticalScript).toContain("pkill -9 -f 'pnpm install");
+    expect(criticalScript).toContain('remove_path "$INVOKER_HOME/runtime"');
+    expect(criticalScript).toContain('remove_path "$INVOKER_HOME/pr-cron-work"');
+    expect(criticalScript).toContain('sweep_children_preserving "$INVOKER_HOME/repos" "repos"');
+    expect(criticalScript).toContain('mkdir -p');
+
+    // stale-only never kills provision grinders or wipes/recreates Invoker's own dirs.
+    expect(staleOnlyScript).not.toContain("pkill -9 -f 'pnpm install");
+    expect(staleOnlyScript).not.toContain('remove_path "$INVOKER_HOME/runtime"');
+    expect(staleOnlyScript).not.toContain('remove_path "$INVOKER_HOME/pr-cron-work"');
+    expect(staleOnlyScript).not.toContain('sweep_children_preserving "$INVOKER_HOME/repos" "repos"');
+    expect(staleOnlyScript).not.toContain('mkdir -p');
+
+    // stale-only still runs the age-gated /tmp CI-scratch sweep, unconditionally.
+    for (const glob of TMP_SCRATCH_GLOBS) {
+      expect(staleOnlyScript).toContain(glob);
+    }
+    expect(staleOnlyScript).toContain('reap_tmp');
+    expect(staleOnlyScript).toContain(`-mmin +${TMP_SCRATCH_MIN_AGE_MINUTES}`);
+    expect(staleOnlyScript).toContain('stale-only begin');
+    expect(staleOnlyScript).toContain('stale-only done');
+  });
+
   it('sweeps only Invoker/test scratch from the shared temp dir, never a blanket /tmp wipe', () => {
     const script = buildInvokerHomeCleanupScript('~/.invoker');
     // Resolves the temp dir with a safe fallback, and re-anchors unsafe values to /tmp.
@@ -645,6 +673,25 @@ describe('cleanupRemoteInvokerHome', () => {
     expect(otherResult.ok).toBe(true);
     expect(capturedScripts[1]).toContain('worktrees/hash2/branch');
     expect(capturedScripts[1]).not.toContain('worktrees/hash1/branch');
+  });
+
+  it('passes mode through to the generated script and result reason, defaulting to critical', async () => {
+    const target = makeTarget();
+    const capturedScripts: string[] = [];
+    const runRemoteScript = vi.fn(async (_t: RemoteDiskTarget, script: string) => {
+      capturedScripts.push(script);
+      return 'ok';
+    });
+
+    const staleResult = await cleanupRemoteInvokerHome({ target, runRemoteScript, mode: 'stale-only' });
+    expect(staleResult.ok).toBe(true);
+    expect(staleResult.reason).toBe('warn-paced');
+    expect(capturedScripts[0]).not.toContain("pkill -9 -f 'pnpm install");
+
+    const defaultResult = await cleanupRemoteInvokerHome({ target, runRemoteScript });
+    expect(defaultResult.ok).toBe(true);
+    expect(defaultResult.reason).toBe('critical-cleanup');
+    expect(capturedScripts[1]).toContain("pkill -9 -f 'pnpm install");
   });
 
   it('clears everything (empty PRESERVE) when no store is provided', async () => {

--- a/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-reclaim.test.ts
@@ -629,6 +629,28 @@ describe('cleanupRemoteInvokerHome', () => {
     expect(result.reason).toBe('cleanup-error');
   });
 
+  it('stale-only mode skips the preservation lookup entirely, even when the store throws', async () => {
+    const target = makeTarget();
+    const throwingStore: DiskHeadroomWorkerStore = {
+      listWorkflows: () => {
+        throw new Error('db unavailable');
+      },
+      loadTasks: () => [],
+    };
+    const runRemoteScript = vi.fn(async () => 'ok');
+
+    const result = await cleanupRemoteInvokerHome({
+      target,
+      store: throwingStore,
+      runRemoteScript,
+      mode: 'stale-only',
+    });
+
+    expect(runRemoteScript).toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe('warn-paced');
+  });
+
   it('narrows preservation to this target\'s own poolMemberId and embeds it in the generated script', async () => {
     const target = makeTarget({ name: 'remote-1', remotePath: '/home/remote/.invoker' });
     const otherTarget = makeTarget({ name: 'remote-2', remotePath: '/home/remote/.invoker' });

--- a/packages/execution-engine/src/__tests__/disk-headroom-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/disk-headroom-worker.test.ts
@@ -244,6 +244,76 @@ describe('disk-headroom worker', () => {
     );
   });
 
+  it('runs remote warn-paced stale-only cleanup after consecutive warn ticks, same as local', async () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registerDiskHeadroomWorker(registry);
+
+    const remoteTargets: RemoteDiskTarget[] = [
+      {
+        name: 'remote-1',
+        connection: { host: 'h', user: 'u', sshKeyPath: '/k' },
+        remotePath: '~/.invoker',
+      },
+    ];
+    const remoteLabel = 'ssh:remote-1 ~/.invoker';
+    const evaluations = [
+      warnEval(remoteLabel),
+      warnEval(remoteLabel),
+      warnEval(remoteLabel),
+      criticalEval(remoteLabel),
+    ];
+    let tick = 0;
+    const runCheck = vi.fn(async () => [evaluations[tick++] ?? evaluations[evaluations.length - 1]!]);
+    const cleanupRemote = vi.fn(async ({ target, mode }: { target: RemoteDiskTarget; mode?: string }) => ({
+      targetKey: `ssh:${target.name} ${target.remotePath}`,
+      ok: true,
+      reason: mode === 'stale-only' ? 'warn-paced' : 'critical-cleanup',
+      protectedSkipCount: 0,
+      protectedSkipBytes: 0,
+    }));
+    const upsertWorkerAction = vi.fn((row: unknown) => row);
+
+    const definition = registry.get(DISK_HEADROOM_WORKER_KIND)!;
+    const runtime = definition.factory({
+      store: { upsertWorkerAction } as any,
+      submitter: { submit: vi.fn() } as any,
+      logger: makeLogger(),
+      diskHeadroom: {
+        localPath: '/tmp/invoker-home',
+        remoteTargets,
+        thresholds: { warnPercent: 85, criticalPercent: 95 },
+        intervalMs: 0,
+        tickOnStart: false,
+        cleanupCooldownMs: 60_000,
+        runCheck,
+        cleanupRemote,
+      },
+    });
+
+    await runtime.tick('manual');
+    expect(cleanupRemote).not.toHaveBeenCalled();
+
+    await runtime.tick('manual');
+    expect(cleanupRemote).toHaveBeenCalledTimes(1);
+    expect(cleanupRemote.mock.calls[0]?.[0]).toMatchObject({
+      target: remoteTargets[0],
+      mode: 'stale-only',
+    });
+
+    await runtime.tick('manual');
+    expect(cleanupRemote).toHaveBeenCalledTimes(1);
+
+    await runtime.tick('manual');
+    expect(cleanupRemote).toHaveBeenCalledTimes(2);
+    expect(cleanupRemote.mock.calls[1]?.[0]).toMatchObject({ target: remoteTargets[0] });
+    expect(cleanupRemote.mock.calls[1]?.[0]).not.toHaveProperty('mode');
+    expect(upsertWorkerAction).toHaveBeenCalledWith(expect.objectContaining({
+      externalKey: `cleanup:${remoteLabel}:warn-paced`,
+      payload: expect.objectContaining({ reason: 'warn-paced' }),
+      status: 'completed',
+    }));
+  });
+
   it('respects cleanup cooldown on a second critical tick', async () => {
     const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
     registerDiskHeadroomWorker(registry);

--- a/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
@@ -75,6 +75,14 @@ export interface DiskCleanupResult {
 
 export type LocalDiskCleanupMode = 'critical' | 'stale-only';
 
+/**
+ * 'stale-only' skips the destructive Invoker-managed-dir wipe entirely and
+ * only age-gate-sweeps shared /tmp CI scratch -- safe to run at the `warn`
+ * threshold instead of waiting for `critical`, mirroring
+ * cleanupLocalInvokerHome's stale-only contract for local targets.
+ */
+export type RemoteDiskCleanupMode = 'critical' | 'stale-only';
+
 export interface CleanupLocalInvokerHomeOptions {
   invokerHome: string;
   targetKey?: string;
@@ -155,6 +163,7 @@ const REMOTE_CHILD_SWEPT_DIRS = ['repos', 'worktrees', 'merge-clones', 'merge-la
 export function buildInvokerHomeCleanupScript(
   invokerHome: string,
   preservePaths: readonly string[] = [],
+  mode: RemoteDiskCleanupMode = 'critical',
 ): string {
   const homeQ = shellPosixSingleQuote(invokerHome);
   const preserveArrayLiteral = preservePaths.map((p) => shellPosixSingleQuote(p)).join(' ');
@@ -169,6 +178,24 @@ remove_path "$INVOKER_HOME/pr-cron-work"`;
     .join(' ');
   const tmpGlobList = TMP_SCRATCH_GLOBS.join(' ');
   const transientTestGlobList = TMP_TRANSIENT_TEST_GLOBS.join(' ');
+  // stale-only (warn-paced) never kills provision grinders, wipes Invoker's own
+  // managed dirs, or recreates them -- it only age-gate-sweeps shared /tmp CI
+  // scratch, the same non-destructive contract cleanupLocalInvokerHome's
+  // stale-only mode already keeps for local targets.
+  const destructiveSection = mode === 'critical' ? `# Provision grinders only — do not pkill -f INVOKER_HOME (kills this SSH session).
+pkill -9 -f 'pnpm install --frozen-lockfile' >/dev/null 2>&1
+pkill -9 -f 'pnpm install' >/dev/null 2>&1
+pkill -9 -f 'electron-v[0-9].*-linux-x64.zip' >/dev/null 2>&1
+pkill -9 -f 'node_modules/.pnpm/electron@' >/dev/null 2>&1
+sleep 1
+# Prior rename leftovers from interrupted cleanups.
+rm -rf "$INVOKER_HOME"/*.deleting.* >/dev/null 2>&1
+${childSweptRemoveCalls}
+${wholeDirRemoveCalls}
+rm -rf "$INVOKER_HOME"/*.deleting.* >/dev/null 2>&1
+mkdir -p ${mkdirArgs}
+chmod 700 ${mkdirArgs}
+` : '';
   return `set +e
 INVOKER_HOME=${homeQ}
 ${bashNormalizeTildePath('INVOKER_HOME')}
@@ -178,16 +205,8 @@ case "$INVOKER_HOME" in
     exit 64
     ;;
 esac
-echo "[disk-headroom-cleanup] begin home=$INVOKER_HOME"
+echo "[disk-headroom-cleanup] ${mode === 'stale-only' ? 'stale-only ' : ''}begin home=$INVOKER_HOME"
 df -h / | tail -1
-# Provision grinders only — do not pkill -f INVOKER_HOME (kills this SSH session).
-pkill -9 -f 'pnpm install --frozen-lockfile' >/dev/null 2>&1
-pkill -9 -f 'pnpm install' >/dev/null 2>&1
-pkill -9 -f 'electron-v[0-9].*-linux-x64.zip' >/dev/null 2>&1
-pkill -9 -f 'node_modules/.pnpm/electron@' >/dev/null 2>&1
-sleep 1
-# Prior rename leftovers from interrupted cleanups.
-rm -rf "$INVOKER_HOME"/*.deleting.* >/dev/null 2>&1
 remove_path() {
   local path="$1"
   if [ -e "$path" ]; then
@@ -225,12 +244,7 @@ sweep_children_preserving() {
     remove_path "$child"
   done
 }
-${childSweptRemoveCalls}
-${wholeDirRemoveCalls}
-rm -rf "$INVOKER_HOME"/*.deleting.* >/dev/null 2>&1
-mkdir -p ${mkdirArgs}
-chmod 700 ${mkdirArgs}
-# Shared temp dir: reclaim only Invoker/test scratch, never a blanket /tmp wipe.
+${destructiveSection}# Shared temp dir: reclaim only Invoker/test scratch, never a blanket /tmp wipe.
 # Age guard leaves entries newer than ${TMP_SCRATCH_MIN_AGE_MINUTES}m alone (an active run may hold them).
 TMP_CLEAN="\${TMPDIR:-/tmp}"
 TMP_CLEAN="\${TMP_CLEAN%/}"
@@ -270,7 +284,7 @@ find "$TMP_CLEAN" -mindepth 1 -maxdepth 1 -mmin +${TMP_SCRATCH_MIN_AGE_MINUTES} 
   -print0 2>/dev/null | while IFS= read -r -d '' entry; do
   reap_tmp "$entry"
 done
-echo "[disk-headroom-cleanup] done"
+echo "[disk-headroom-cleanup] ${mode === 'stale-only' ? 'stale-only ' : ''}done"
 df -h / | tail -1
 exit 0
 `;
@@ -842,8 +856,10 @@ export async function cleanupRemoteInvokerHome(opts: {
   target: RemoteDiskTarget;
   logger?: Logger;
   store?: DiskHeadroomWorkerStore;
+  mode?: RemoteDiskCleanupMode;
   runRemoteScript?: (target: RemoteDiskTarget, script: string) => Promise<string>;
 }): Promise<DiskCleanupResult> {
+  const mode = opts.mode ?? 'critical';
   const targetKey = `ssh:${opts.target.name} ${opts.target.remotePath}`;
   if (!isSafeRemoteInvokerHomePath(opts.target.remotePath)) {
     return {
@@ -870,15 +886,16 @@ export async function cleanupRemoteInvokerHome(opts: {
     }
   }
 
-  const script = buildInvokerHomeCleanupScript(opts.target.remotePath, preservePaths);
+  const script = buildInvokerHomeCleanupScript(opts.target.remotePath, preservePaths, mode);
   const run = opts.runRemoteScript ?? defaultRunRemoteCleanup;
+  const reason = mode === 'stale-only' ? 'warn-paced' : 'critical-cleanup';
   try {
-    opts.logger?.info?.(`[disk-headroom-cleanup] remote begin ${targetKey}`, {
+    opts.logger?.info?.(`[disk-headroom-cleanup] remote ${mode === 'stale-only' ? 'stale-only ' : ''}begin ${targetKey}`, {
       module: 'disk-headroom',
       targetKey,
     });
     const output = await run(opts.target, script);
-    opts.logger?.info?.(`[disk-headroom-cleanup] remote done ${targetKey}`, {
+    opts.logger?.info?.(`[disk-headroom-cleanup] remote ${mode === 'stale-only' ? 'stale-only ' : ''}done ${targetKey}`, {
       module: 'disk-headroom',
       targetKey,
       outputTail: output.slice(-400),
@@ -886,7 +903,7 @@ export async function cleanupRemoteInvokerHome(opts: {
     return {
       targetKey,
       ok: true,
-      reason: 'critical-cleanup',
+      reason,
       detail: output.slice(-400),
       protectedSkipCount: 0,
       protectedSkipBytes: 0,

--- a/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-reclaim.ts
@@ -873,7 +873,7 @@ export async function cleanupRemoteInvokerHome(opts: {
   }
 
   let preservePaths: string[] = [];
-  if (opts.store) {
+  if (mode === 'critical' && opts.store) {
     try {
       preservePaths = computeRemotePreservationPaths(opts.store, opts.target);
     } catch (err) {

--- a/packages/execution-engine/src/workers/disk-headroom-worker.ts
+++ b/packages/execution-engine/src/workers/disk-headroom-worker.ts
@@ -133,10 +133,6 @@ function recordCleanupDecision(
 
 const WARN_PACED_STREAK = 2;
 
-function isLocalTargetKey(targetKey: string): boolean {
-  return !targetKey.startsWith('ssh:');
-}
-
 function warnPacedCooldownKey(targetKey: string): string {
   return `cleanup:${targetKey}:warn-paced`;
 }
@@ -201,7 +197,6 @@ export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): Wo
       const warnPacedTargets: DiskHeadroomEvaluation[] = [];
       for (const evaluation of evaluationsRaw) {
         const targetKey = evaluation.label;
-        if (!isLocalTargetKey(targetKey)) continue;
         if (evaluation.level !== 'warn') {
           warnStreaks.delete(targetKey);
           continue;
@@ -237,13 +232,35 @@ export function createDiskHeadroomWorker(options: DiskHeadroomWorkerOptions): Wo
           `[disk-headroom-cleanup] warn-paced begin ${targetKey}`,
           { module: 'disk-headroom', targetKey },
         );
-        const result = await cleanupLocal({
-          invokerHome: options.localPath,
-          targetKey,
-          logger: options.logger,
-          store: options.workflowStore,
-          mode: 'stale-only',
-        });
+        let result: DiskCleanupResult;
+        if (targetKey.startsWith('ssh:')) {
+          const target = options.remoteTargets.find(
+            (t) => `ssh:${t.name} ${t.remotePath}` === targetKey,
+          );
+          result = target
+            ? await cleanupRemote({
+              target,
+              logger: options.logger,
+              store: options.workflowStore,
+              mode: 'stale-only',
+            })
+            : {
+              targetKey,
+              ok: false,
+              reason: 'cleanup-error',
+              detail: `remote target not found for ${targetKey}`,
+              protectedSkipCount: 0,
+              protectedSkipBytes: 0,
+            };
+        } else {
+          result = await cleanupLocal({
+            invokerHome: options.localPath,
+            targetKey,
+            logger: options.logger,
+            store: options.workflowStore,
+            mode: 'stale-only',
+          });
+        }
         const recordedResult: DiskCleanupResult = result.ok
           ? { ...result, reason: 'warn-paced' }
           : result;


### PR DESCRIPTION
## Summary

The disk-headroom worker only ever reclaims space on remote CI runners once they hit 95% usage. A lighter pass that runs for local targets at 85% never applied to any remote target at all.

That left CI scratch growing freely on remote runners for a long time before anything acted on it. Two separate machines hit "No space left on device" mid-job tonight as a direct result.

This routes remote targets through the same 85%-level pass local targets already use.

## Review Claim

Approve a second script variant for remote targets that reclaims only shared `/tmp` CI scratch (the same age-gated logic the existing script already runs) without touching any Invoker-managed directory, wired into the worker's existing 85%-level path the same way local targets already use it.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

`stale-only` mode never kills provision-grinder processes, never touches `runtime`/`pr-cron-work`/`repos`/`worktrees`/`merge-clones`/`merge-launches`, and never recreates directories -- it only runs the pre-existing, already-guarded `/tmp` age-gated sweep (60-minute-old entries only, preserves any `.jsonl` session transcript, never a blanket wipe). The `critical` path's full destructive behavior is completely unchanged; only what runs at `warn` changes, from nothing to this one safe sweep.

## Slice Rationale

One self-contained behavior slice: threading a mode parameter through the existing remote script builder and worker dispatch, mirroring a pattern this file already implements for local targets.

## Non-goals

Does not change the `critical` threshold's behavior for either local or remote targets. Does not add a new configurable threshold -- reuses the existing `warn`/`critical` percentages and the existing warn-paced streak/cooldown logic verbatim.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test -- src/__tests__/disk-headroom-reclaim.test.ts src/__tests__/disk-headroom-worker.test.ts src/__tests__/disk-headroom.test.ts src/__tests__/disk-headroom-monitor.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert <merge-commit-sha>`
- Post-revert steps: None -- reverts remote targets to critical-only cleanup, the prior (safe, just less proactive) behavior.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disk-space recovery for remote targets.
  * Warning-level disk pressure now triggers cautious, age-based cleanup without removing active runtime files.
  * Critical disk pressure continues to perform full cleanup and recovery.
  * Added cooldown handling to prevent repeated warning cleanups from running too frequently.
* **Tests**
  * Expanded coverage for local and remote cleanup modes, escalation behavior, and persisted cleanup status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->