### PR TITLE
Stop hardcoding executionAgent: codex on the CI-regression fix task

### DIFF
--- a/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
+++ b/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
@@ -14,7 +14,6 @@ repoUrl: {{repo_url}}
 
 tasks:
   - id: fix-ci-{{job_slug}}
-    executionAgent: codex
     description: |
       Fix CI job {{job_name}} first observed failing at {{sha}}.
       Review claim: The change corrects the CI regression's root cause at its source, with no unrelated edits.


### PR DESCRIPTION
## Summary

The CI-regression fix task has been pinned to codex since #7086, from the same day and same outage as a sibling hardcode already fixed this session in #9452.

That outage has since reversed direction -- codex hit its own usage-limit quota tonight while claude was healthy, and the pinned task kept failing anyway.

This removes the pin so the task uses whichever agent is actually configured.

## Review Claim

Approve removing one hardcoded `executionAgent: codex` line from the ci-regression-watch formula's fix task, matching the same fix already landed for the sibling admin-bypass-repair generator.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Only the fix task's declared agent changes -- everything else in the formula (its prompt, dependencies, the `reflect-ci` task's own `executionAgent: claude`) stays exactly as it was. `reflect-ci` is untouched deliberately: it runs the /reflect process, which is Claude-specific by design, not an availability workaround.

## Slice Rationale

One self-contained slice: the formula's hardcoded line, mirroring the sibling fix already landed in #9452. The matching regression-check update lands as its own following slice, since the two files classify under different review units.

## Non-goals

Does not touch `reflect-ci`'s agent pin. Does not change any other formula. Does not touch the `admin-bypass-repair` generator -- that's the already-landed sibling fix. Does not update the regression check that covers this formula (next slice).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/test-plan-to-invoker-skill.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert <merge-commit-sha>`
- Post-revert steps: None -- reverts to the prior hardcode.
- Data migration? No

</details>
