### PR TITLE
Flip the CI-regression formula's regression check to prove the codex pin stays removed

### DIFF
--- a/scripts/repro/repro-e2e-regression-watch.mjs
+++ b/scripts/repro/repro-e2e-regression-watch.mjs
@@ -216,7 +216,8 @@ function testPlanVarsAndDryRunRendering() {
     if (!rendered.planPath.endsWith('ci-regression-watch.yaml')) fail('dry run did not render expected plan path');
     if (rendered.submitted) fail('dry run must not submit');
     const planText = readFileSync(rendered.planPath, 'utf8');
-    if (!planText.includes('executionAgent: codex')) fail('fix task must request codex (default claude agent hits the broken SSH pool)');
+    // #7086's codex pin outlived the outage it was a stopgap for; see #9452.
+    if (planText.includes('executionAgent: codex')) fail('fix task must not hardcode codex; let the configured default agent apply');
   } finally {
     rmSync(outRoot, { recursive: true, force: true });
   }

--- a/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
+++ b/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
@@ -14,7 +14,6 @@ repoUrl: {{repo_url}}
 
 tasks:
   - id: fix-ci-{{job_slug}}
-    executionAgent: codex
     description: |
       Fix CI job {{job_name}} first observed failing at {{sha}}.
       Review claim: The change corrects the CI regression's root cause at its source, with no unrelated edits.


### PR DESCRIPTION
## Summary

The prior slice removed the CI-regression fix task's hardcoded `executionAgent: codex`.

This flips the matching check in the formula's own regression script, from requiring that hardcode to requiring its absence.

## Review Claim

Approve one assertion flip in `scripts/repro/repro-e2e-regression-watch.mjs` so it now fails if the removed hardcode is ever reintroduced.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This changes only what the regression script asserts about a rendered plan's text -- it runs no product code path differently and ships no behavior change of its own.

## Slice Rationale

Kept separate from the prior formula-fix slice because the two files classify under different review units; this is the proof half of that pairing.

## Non-goals

Does not change any other assertion in this file. Does not add new coverage beyond confirming the removed hardcode stays removed.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/repro/repro-e2e-regression-watch.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert <merge-commit-sha>`
- Post-revert steps: None -- reverts the assertion back to its prior direction.
- Data migration? No

</details>
