### PR TITLE
Check each remote target's own credential expiry, not just the local owner's

### DIFF
--- a/packages/execution-engine/src/__tests__/claude-oauth-refresh-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/claude-oauth-refresh-worker.test.ts
@@ -34,23 +34,88 @@ function makeStore(): { store: WorkerDecisionStore; rows: unknown[] } {
 }
 
 describe('runClaudeOauthRefreshCheck', () => {
-  it('does nothing when the token is not close to expiring', async () => {
+  it('does nothing when the local token and every remote target are all healthy', async () => {
     const writeCredentials = vi.fn();
     const refreshFn = vi.fn();
     const distributeFn = vi.fn();
+    const now = Date.now();
     await runClaudeOauthRefreshCheck({
       logger: makeLogger(),
       credentialsPath: '/home/invoker/.claude/.credentials.json',
       remoteTargets: [makeTarget('do1')],
-      readCredentials: () => credentialsJson(Date.now() + 60 * 60 * 1000),
+      readCredentials: () => credentialsJson(now + 60 * 60 * 1000),
+      readRemoteCredentials: async () => credentialsJson(now + 60 * 60 * 1000),
       writeCredentials,
       refreshFn,
       distributeFn,
-      now: () => Date.now(),
+      now: () => now,
     });
     expect(refreshFn).not.toHaveBeenCalled();
     expect(writeCredentials).not.toHaveBeenCalled();
     expect(distributeFn).not.toHaveBeenCalled();
+  });
+
+  it('reproduces the real incident: distributes current credentials to a remote target whose own copy is expiring, even when the local token is healthy', async () => {
+    // Real incident, 2026-08-16: the owner's own credentials stayed healthy
+    // (refreshed by its own live CLI usage) while all 5 SSH pool targets
+    // independently expired. The worker never fired because the entire
+    // check -- local refresh AND remote distribution -- was gated on the
+    // local token's own expiry alone.
+    const now = 1_000_000_000_000;
+    const healthyLocal = credentialsJson(now + 60 * 60 * 1000);
+    const distributeFn = vi.fn(async () => undefined);
+    const refreshFn = vi.fn();
+    const writeCredentials = vi.fn();
+    const { store, rows } = makeStore();
+
+    await runClaudeOauthRefreshCheck({
+      logger: makeLogger(),
+      credentialsPath: '/home/invoker/.claude/.credentials.json',
+      remoteTargets: [makeTarget('do1'), makeTarget('do2')],
+      store,
+      readCredentials: () => healthyLocal,
+      readRemoteCredentials: async (target) =>
+        target.name === 'do1' ? credentialsJson(now - 1) : credentialsJson(now + 60 * 60 * 1000),
+      writeCredentials,
+      refreshFn,
+      distributeFn,
+      now: () => now,
+    });
+
+    expect(refreshFn).not.toHaveBeenCalled();
+    expect(writeCredentials).not.toHaveBeenCalled();
+    expect(distributeFn).toHaveBeenCalledTimes(1);
+    expect(distributeFn).toHaveBeenCalledWith(expect.objectContaining({ name: 'do1' }), healthyLocal);
+    const statuses = Object.fromEntries((rows as { subjectId: string; status: string }[]).map((r) => [r.subjectId, r.status]));
+    expect(statuses.do1).toBe('completed');
+    expect(statuses.do2).toBeUndefined();
+  });
+
+  it('treats a failed remote credential read as needing distribution, without stopping other targets', async () => {
+    const now = 1_000_000_000_000;
+    const healthyLocal = credentialsJson(now + 60 * 60 * 1000);
+    const distributeFn = vi.fn(async () => undefined);
+    const { store, rows } = makeStore();
+
+    await runClaudeOauthRefreshCheck({
+      logger: makeLogger(),
+      credentialsPath: '/home/invoker/.claude/.credentials.json',
+      remoteTargets: [makeTarget('do1'), makeTarget('do2')],
+      store,
+      readCredentials: () => healthyLocal,
+      readRemoteCredentials: async (target) => {
+        if (target.name === 'do1') throw new Error('ssh: connection refused');
+        return credentialsJson(now + 60 * 60 * 1000);
+      },
+      distributeFn,
+      now: () => now,
+    });
+
+    expect(distributeFn).toHaveBeenCalledTimes(1);
+    expect(distributeFn).toHaveBeenCalledWith(expect.objectContaining({ name: 'do1' }), healthyLocal);
+    const statuses = Object.fromEntries((rows as { subjectId: string; status: string }[]).map((r) => [r.subjectId, r.status]));
+    expect(statuses.do1).toBe('completed');
+    expect(statuses.do2).toBeUndefined();
   });
 
   it('refreshes, writes the local file, and distributes to every remote target when the token is expiring', async () => {

--- a/packages/execution-engine/src/workers/claude-oauth-refresh-worker.ts
+++ b/packages/execution-engine/src/workers/claude-oauth-refresh-worker.ts
@@ -37,6 +37,8 @@ export interface ClaudeOauthRefreshWorkerConfig {
 
   /** Test seams. */
   readCredentials?: (path: string) => string;
+  /** Reads a remote target's own credentials file. Null means unreadable (missing, unparseable, or an SSH failure). */
+  readRemoteCredentials?: (target: ClaudeOauthRefreshTarget) => Promise<string | null>;
   writeCredentials?: (path: string, contents: string) => void;
   refreshFn?: (credentialsJson: string) => Promise<string | null>;
   distributeFn?: (target: ClaudeOauthRefreshTarget, credentialsJson: string) => Promise<void>;
@@ -53,6 +55,7 @@ export interface ClaudeOauthRefreshWorkerOptions {
   tickOnStart?: boolean;
   store?: WorkerDecisionStore;
   readCredentials?: (path: string) => string;
+  readRemoteCredentials?: (target: ClaudeOauthRefreshTarget) => Promise<string | null>;
   writeCredentials?: (path: string, contents: string) => void;
   refreshFn?: (credentialsJson: string) => Promise<string | null>;
   distributeFn?: (target: ClaudeOauthRefreshTarget, credentialsJson: string) => Promise<void>;
@@ -111,6 +114,21 @@ function defaultDistribute(target: ClaudeOauthRefreshTarget, credentialsJson: st
   }).then(() => undefined);
 }
 
+async function defaultReadRemoteCredentials(target: ClaudeOauthRefreshTarget): Promise<string | null> {
+  const remotePath = target.remotePath ?? '~/.claude/.credentials.json';
+  const sshArgs = buildSshConnectionArgs(target.connection, { batchMode: true });
+  try {
+    const output = await execRemoteCapture({
+      sshArgs,
+      script: `cat "${remotePath}" 2>/dev/null || true`,
+      phase: `claude-oauth-refresh-check:${target.name}`,
+    });
+    return output.trim() ? output : null;
+  } catch {
+    return null;
+  }
+}
+
 function recordDecision(
   store: WorkerDecisionStore | undefined,
   externalKey: string,
@@ -131,8 +149,29 @@ function recordDecision(
   });
 }
 
+async function distributeToTarget(
+  options: ClaudeOauthRefreshWorkerOptions,
+  distribute: NonNullable<ClaudeOauthRefreshWorkerOptions['distributeFn']> | typeof defaultDistribute,
+  target: ClaudeOauthRefreshTarget,
+  credentialsJson: string,
+  summary: string,
+): Promise<void> {
+  try {
+    await distribute(target, credentialsJson);
+    recordDecision(options.store, target.name, 'completed', summary);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    options.logger.error(`[${CLAUDE_OAUTH_REFRESH_WORKER_KIND}] failed to distribute to ${target.name}: ${detail}`, {
+      module: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+      target: target.name,
+    });
+    recordDecision(options.store, target.name, 'failed', `Failed to distribute credentials to ${target.name}: ${detail}`);
+  }
+}
+
 export async function runClaudeOauthRefreshCheck(options: ClaudeOauthRefreshWorkerOptions): Promise<void> {
   const readCredentials = options.readCredentials ?? defaultReadCredentials;
+  const readRemoteCredentials = options.readRemoteCredentials ?? defaultReadRemoteCredentials;
   const writeCredentials = options.writeCredentials ?? defaultWriteCredentials;
   const distribute = options.distributeFn ?? defaultDistribute;
   const now = options.now ?? Date.now;
@@ -147,7 +186,29 @@ export async function runClaudeOauthRefreshCheck(options: ClaudeOauthRefreshWork
     return;
   }
 
-  if (!isOauthTokenExpiring(credentialsJson, now())) return;
+  if (!isOauthTokenExpiring(credentialsJson, now())) {
+    // The owner's own token can stay healthy (refreshed by its own live CLI
+    // usage) for a long time while a remote target's separate copy silently
+    // expires on its own clock -- checked here, independently of the local
+    // refresh cycle above, so redistribution isn't gated on the local token
+    // ever needing a refresh of its own.
+    for (const target of options.remoteTargets) {
+      let remoteJson: string | null;
+      try {
+        remoteJson = await readRemoteCredentials(target);
+      } catch (error) {
+        options.logger.error(`[${CLAUDE_OAUTH_REFRESH_WORKER_KIND}] failed to read remote credentials for ${target.name}: ${error instanceof Error ? error.message : String(error)}`, {
+          module: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+          target: target.name,
+        });
+        remoteJson = null;
+      }
+      const remoteNeedsDistribution = remoteJson === null || isOauthTokenExpiring(remoteJson, now());
+      if (!remoteNeedsDistribution) continue;
+      await distributeToTarget(options, distribute, target, credentialsJson, `Distributed current credentials to ${target.name} (its own copy was stale)`);
+    }
+    return;
+  }
 
   const refresh = options.refreshFn ?? ((json: string) => refreshClaudeOauthCredentials(json, { now: now() }));
   const refreshed = await refresh(credentialsJson);
@@ -166,17 +227,7 @@ export async function runClaudeOauthRefreshCheck(options: ClaudeOauthRefreshWork
   });
 
   for (const target of options.remoteTargets) {
-    try {
-      await distribute(target, refreshed);
-      recordDecision(options.store, target.name, 'completed', `Distributed refreshed credentials to ${target.name}`);
-    } catch (error) {
-      const detail = error instanceof Error ? error.message : String(error);
-      options.logger.error(`[${CLAUDE_OAUTH_REFRESH_WORKER_KIND}] failed to distribute to ${target.name}: ${detail}`, {
-        module: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
-        target: target.name,
-      });
-      recordDecision(options.store, target.name, 'failed', `Failed to distribute refreshed credentials to ${target.name}: ${detail}`);
-    }
+    await distributeToTarget(options, distribute, target, refreshed, `Distributed refreshed credentials to ${target.name}`);
   }
 }
 
@@ -187,6 +238,7 @@ export function createClaudeOauthRefreshWorker(config: ClaudeOauthRefreshWorkerC
     remoteTargets: config.remoteTargets ?? [],
     store: config.store,
     readCredentials: config.readCredentials,
+    readRemoteCredentials: config.readRemoteCredentials,
     writeCredentials: config.writeCredentials,
     refreshFn: config.refreshFn ?? (config.fetchFn
       ? (json: string) => refreshClaudeOauthCredentials(json, { fetchFn: config.fetchFn, now: config.now?.() })


### PR DESCRIPTION
## Summary

The OAuth-refresh worker's whole cycle ran off one signal: whether the owner's own local token was close to expiring.

That token can stay healthy on its own for a long time while a pool target's separate copy quietly runs out on its own clock. On 2026-08-16 all 5 pool targets hit exactly that, and the worker never acted because it never looked at their state.

This adds an independent check for each target.

## Review Claim

Approve reading each pool target's own credential state and pushing the owner's current, already-valid credentials to any target whose own copy is stale or unreadable, without requiring the local token to need a refresh first.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A target read failure (SSH error, missing file, bad JSON) is treated the same as "stale" -- it triggers a push of the owner's already-known-good current credentials, never a blind refresh request. One target's read or push failure is caught and logged per-target and never stops the remaining targets, matching the existing behavior for the refresh-triggered path.

## Slice Rationale

One self-contained behavior slice: the new per-target check plus its tests, in the same file and function this session already shipped.

## Non-goals

Does not change what happens when the local token itself needs a refresh -- that path (refresh, write, push to every target) is untouched. Does not add a new worker or config flag; this runs on the same schedule the worker already has.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test -- src/__tests__/claude-oauth-refresh-worker.test.ts src/__tests__/claude-oauth-refresh.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert <merge-commit-sha>`
- Post-revert steps: None -- reverts to the prior (local-only) trigger condition.
- Data migration? No

</details>
