### PR TITLE
[Worker Registry](1) Add claude-oauth-refresh to the built-in-worker-list test

### DIFF
--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -20,6 +20,7 @@ import {
 } from '../workers/pr-maintenance-workers.js';
 import { PR_STATUS_WORKER_KIND } from '../workers/pr-status-worker.js';
 import { DISK_HEADROOM_WORKER_KIND } from '../workers/disk-headroom-worker.js';
+import { CLAUDE_OAUTH_REFRESH_WORKER_KIND } from '../workers/claude-oauth-refresh-worker.js';
 import { INFRA_REPAIR_WORKER_KIND } from '../workers/infra-repair-worker.js';
 import { REAPER_WORKER_KIND } from '../workers/reaper-worker.js';
 import { REQUEUE_WORKER_KIND } from '../workers/requeue-worker.js';
@@ -79,6 +80,7 @@ describe('worker registry', () => {
       PR_STATUS_WORKER_KIND,
       INFRA_REPAIR_WORKER_KIND,
       DISK_HEADROOM_WORKER_KIND,
+      CLAUDE_OAUTH_REFRESH_WORKER_KIND,
       REAPER_WORKER_KIND,
       AUTO_APPROVE_WORKER_KIND,
       PR_ADMIN_BYPASS_LAND_WORKER_KIND,
@@ -96,6 +98,7 @@ describe('worker registry', () => {
     expect(registry.get(PR_STATUS_WORKER_KIND)).toBeDefined();
     expect(registry.get(INFRA_REPAIR_WORKER_KIND)).toBeDefined();
     expect(registry.get(DISK_HEADROOM_WORKER_KIND)).toBeDefined();
+    expect(registry.get(CLAUDE_OAUTH_REFRESH_WORKER_KIND)).toBeDefined();
     expect(registry.get(REAPER_WORKER_KIND)).toBeDefined();
     expect(registry.get(AUTO_APPROVE_WORKER_KIND)).toBeDefined();
     expect(registry.get(PR_ADMIN_BYPASS_LAND_WORKER_KIND)).toBeDefined();


### PR DESCRIPTION
## Summary

The worker registry test asserts the exact list of every built-in worker, in order.

An earlier change registered a new worker, claude-oauth-refresh, but never touched this test.

Every CI run since has failed on that one assertion. This adds the missing entry.

## Review Claim

Approve adding the claude-oauth-refresh worker kind to the registry test's exact-list assertion and its matching toBeDefined() check, in the same registration-order position it actually holds in builtin-workers.ts.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change, one file, no production code touched. The new assertion position was confirmed against builtin-workers.ts's real registration call order before editing, and the full test file was run and passes.

## Slice Rationale

One self-contained proof fix: the test file that was silently broken, nothing else.

## Non-goals

Does not touch builtin-workers.ts or the claude-oauth-refresh worker itself. Does not address any other failing test found elsewhere in this run.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test -- src/__tests__/worker-registry.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert <merge-commit-sha>`
- Post-revert steps: None -- reverts to the prior (broken) test.
- Data migration? No

</details>
