### PR TITLE
[PR Maintenance Ledger Test](1) Isolate the decision-row test from the real ledger file

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
@@ -432,6 +432,7 @@ describe('PR maintenance workers', () => {
       lockProbe: () => ({ held: false }),
       installSignalHandlers: false,
       store,
+      env: { INVOKER_MERGIFY_ADMIN_REQUEUE_STATE_FILE: join(repoRoot, 'mergify-admin-requeue-state.jsonl') },
     });
 
     await worker.tick();


### PR DESCRIPTION
## Summary

One test for the admin-bypass-land worker checks that a successful run records exactly two decision rows: running, then completed.

It never pointed the worker at a fake ledger file, so on a machine that already has a real one under ~/.invoker, the worker reads that machine's actual blocked-PR history and adds extra rows, breaking the check.

This points the test at an empty, repo-scoped file instead, matching a sibling test right below it that already does this.

## Review Claim

Approve passing an explicit, empty INVOKER_MERGIFY_ADMIN_REQUEUE_STATE_FILE path to this one test so it stops reading whatever real ledger file happens to exist on the machine running it.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change, one file, one line. Confirmed failing before the change (real machine ledger with 107 blocked-PR rows leaking in) and passing after, both runs pasted in the PR discussion below.

## Slice Rationale

One self-contained proof fix, unrelated to the worker-registry.test.ts fix in #9589 -- separate root cause, separate file, no shared code path.

## Non-goals

Does not touch createPrAdminBypassLandWorker or the real ledger-reading behavior it exercises in production. Does not add env overrides to the other tests in this file that don't need one (they either skip the store entirely or already assert loosely enough not to break).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test -- src/__tests__/pr-maintenance-workers.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert via: `git revert <merge-commit-sha>`
- Post-revert steps: None -- reverts to the prior, machine-dependent test.
- Data migration? No

</details>
