### PR TITLE
[Plan Doctor Standalone Install](1) Resolve Invoker checkout via INVOKER_REPO_ROOT outside a git checkout

### DIFF
--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -240,6 +240,49 @@ must_output_contain "$DOCTOR_HELP" "  1 = one or more checks failed" "skill-doct
 must_output_contain "$DOCTOR_HELP" "  2 = usage/argument error" "skill-doctor --help must expose usage-error exit code"
 must_output_contain "$DOCTOR_HELP" "Output: JSON summary of all checks with pass/fail status" "skill-doctor --help must expose JSON output contract"
 
+# Regression: skill-doctor.sh (and its validate-plan/lint-review-units
+# sub-checks) must work when copied wholesale to a machine-level skill
+# install outside any git checkout — e.g. ~/.claude/skills/invoker-plan-to-invoker,
+# the layout `scripts/setup-agent-skills.sh` produces. Reproduces the bug where
+# an agent planning against a non-Invoker repo had no working doctor: validate-plan.sh
+# resolved its repo root via `git -C <script dir>`, and lint-review-units.mjs
+# statically imported `../../../scripts/review-unit-rules.mjs` — both broke
+# once the scripts' physical location was no longer 3 directories under the
+# Invoker repo root.
+STANDALONE_INSTALL_DIR="$(mktemp -d)"
+STANDALONE_INVOKER_HOME="$(mktemp -d)"
+trap 'rm -rf "$STANDALONE_INSTALL_DIR" "$STANDALONE_INVOKER_HOME"' EXIT
+cp "$REPO_ROOT"/skills/plan-to-invoker/scripts/*.sh "$REPO_ROOT"/skills/plan-to-invoker/scripts/*.mjs "$STANDALONE_INSTALL_DIR/"
+STANDALONE_DOCTOR="$STANDALONE_INSTALL_DIR/skill-doctor.sh"
+STANDALONE_FIXTURE="$POSITIVE_FIXTURE_DIR/02-feature-implementation.yaml"
+
+# Without INVOKER_REPO_ROOT or a bundled-skills manifest, the doctor must fail
+# with an actionable message instead of a raw stack trace or generic error.
+STANDALONE_NO_FALLBACK_OUTPUT="$(cd /tmp && env -u INVOKER_REPO_ROOT INVOKER_DB_DIR="$STANDALONE_INVOKER_HOME" bash "$STANDALONE_DOCTOR" --skip-assumptions "$STANDALONE_FIXTURE" 2>&1 || true)"
+must_output_contain "$STANDALONE_NO_FALLBACK_OUTPUT" "INVOKER_REPO_ROOT" "Standalone doctor without a resolvable repo root must point at the INVOKER_REPO_ROOT override"
+
+# INVOKER_REPO_ROOT must work as an explicit override, without any manifest.
+STANDALONE_ENV_OUTPUT="$(cd /tmp && env -u INVOKER_DB_DIR INVOKER_REPO_ROOT="$REPO_ROOT" bash "$STANDALONE_DOCTOR" --skip-assumptions "$STANDALONE_FIXTURE" 2>/dev/null || true)"
+STANDALONE_ENV_VALIDATE_STATUS="$(printf '%s' "$STANDALONE_ENV_OUTPUT" | node -e '
+  const raw = require("node:fs").readFileSync(0, "utf8");
+  const report = JSON.parse(raw);
+  const check = report.checks.find((c) => c.stepId === process.argv[1]);
+  process.stdout.write(check ? String(check.status) : "missing");
+' "validate-plan")"
+[[ "$STANDALONE_ENV_VALIDATE_STATUS" == "passed" ]] || fail "Standalone install with INVOKER_REPO_ROOT override must pass validate-plan; got status=$STANDALONE_ENV_VALIDATE_STATUS. Full output: $STANDALONE_ENV_OUTPUT"
+STANDALONE_ENV_REVIEW_UNITS_STATUS="$(printf '%s' "$STANDALONE_ENV_OUTPUT" | node -e '
+  const raw = require("node:fs").readFileSync(0, "utf8");
+  const report = JSON.parse(raw);
+  const check = report.checks.find((c) => c.stepId === process.argv[1]);
+  process.stdout.write(check ? String(check.status) : "missing");
+' "lint-review-units")"
+[[ "$STANDALONE_ENV_REVIEW_UNITS_STATUS" == "passed" ]] || fail "Standalone install with INVOKER_REPO_ROOT override must pass lint-review-units; got status=$STANDALONE_ENV_REVIEW_UNITS_STATUS. Full output: $STANDALONE_ENV_OUTPUT"
+
+rm -rf "$STANDALONE_INSTALL_DIR" "$STANDALONE_INVOKER_HOME"
+trap - EXIT
+
+echo "OK: skill-doctor works from a machine-level standalone install via INVOKER_REPO_ROOT (outside any git checkout)"
+
 # Playbook — Phase 1a / 1b focused lanes and anti-patterns
 must_contain "$PLAYBOOK" "### Phase 1a — Static analysis" "Playbook must define Phase 1a"
 must_contain "$PLAYBOOK" "### Phase 1b — Runtime verification" "Playbook must define runtime behavioral verification"

--- a/skills/plan-to-invoker/scripts/lint-review-units.mjs
+++ b/skills/plan-to-invoker/scripts/lint-review-units.mjs
@@ -2,21 +2,34 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import {
-  getLabelSection,
-  validateChangeTypeItems,
-  validateSingleReviewUnitFocus,
-} from '../../../scripts/review-unit-rules.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-function resolveYamlModulePath(scriptDir) {
+/**
+ * Locate the Invoker checkout that owns this doctor script. Checked in order:
+ * 1. `INVOKER_REPO_ROOT` (explicit override, same convention used elsewhere
+ *    in the app, e.g. packages/contracts/src/repo-root.ts).
+ * 2. The local relative path (this script running from inside a live
+ *    Invoker checkout or worktree).
+ * 3. The shared checkout behind a linked git worktree's common dir.
+ * 4. `sourceRepoRoot` recorded in ~/.invoker/bundled-skills.json by the last
+ *    `scripts/setup-agent-skills.sh` install — needed when this script is
+ *    running from a machine-level skill install (e.g.
+ *    ~/.claude/skills/invoker-plan-to-invoker/scripts), which ships outside
+ *    any git repository and can't resolve steps 2-3.
+ */
+function resolveInvokerRepoRoot(scriptDir) {
+  const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
+
+  const envRoot = process.env.INVOKER_REPO_ROOT;
+  if (envRoot && hasWorkspaceMarker(envRoot)) return resolve(envRoot);
+
   const localRepoRoot = resolve(scriptDir, '../../..');
-  const localYamlPath = resolve(localRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-  if (existsSync(localYamlPath)) return localYamlPath;
+  if (hasWorkspaceMarker(localRepoRoot)) return localRepoRoot;
 
   try {
     const gitCommonDir = execSync('git rev-parse --git-common-dir', {
@@ -25,18 +38,50 @@ function resolveYamlModulePath(scriptDir) {
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
     const sharedRepoRoot = resolve(scriptDir, gitCommonDir, '..');
-    const sharedYamlPath = resolve(sharedRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-    if (existsSync(sharedYamlPath)) return sharedYamlPath;
+    if (hasWorkspaceMarker(sharedRepoRoot)) return sharedRepoRoot;
   } catch {
-    // Fall through to the explicit error below.
+    // Fall through to the manifest-based lookup below.
   }
 
+  try {
+    const invokerHome = process.env.INVOKER_DB_DIR ?? resolve(homedir(), '.invoker');
+    const manifestPath = resolve(invokerHome, 'bundled-skills.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    if (typeof manifest.sourceRepoRoot === 'string' && hasWorkspaceMarker(manifest.sourceRepoRoot)) {
+      return resolve(manifest.sourceRepoRoot);
+    }
+  } catch {
+    // Fall through to the explicit error at the call site.
+  }
+
+  return null;
+}
+
+const invokerRepoRoot = resolveInvokerRepoRoot(__dirname);
+if (!invokerRepoRoot) {
   throw new Error(
-    'Unable to resolve yaml runtime. Checked packages/app/node_modules/yaml/dist/index.js in the current worktree and the shared git checkout.',
+    'Unable to resolve the Invoker checkout for this doctor script (checked INVOKER_REPO_ROOT, the local '
+    + 'worktree, the shared git checkout, and ~/.invoker/bundled-skills.json). Set INVOKER_REPO_ROOT to an '
+    + "Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so "
+    + '~/.invoker/bundled-skills.json records the source checkout.',
   );
 }
 
-const { parse: parseYaml } = await import(resolveYamlModulePath(__dirname));
+const yamlModulePath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
+if (!existsSync(yamlModulePath)) {
+  throw new Error(`Unable to resolve yaml runtime. Expected it at ${yamlModulePath}.`);
+}
+const { parse: parseYaml } = await import(yamlModulePath);
+
+const reviewUnitRulesPath = resolve(invokerRepoRoot, 'scripts/review-unit-rules.mjs');
+if (!existsSync(reviewUnitRulesPath)) {
+  throw new Error(`Unable to resolve review-unit-rules.mjs. Expected it at ${reviewUnitRulesPath}.`);
+}
+const {
+  getLabelSection,
+  validateChangeTypeItems,
+  validateSingleReviewUnitFocus,
+} = await import(reviewUnitRulesPath);
 
 function reviewFocusTexts(text) {
   return [

--- a/skills/plan-to-invoker/scripts/validate-plan.mjs
+++ b/skills/plan-to-invoker/scripts/validate-plan.mjs
@@ -9,18 +9,34 @@
 
 import { execFileSync, execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, normalize, resolve } from 'node:path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-function resolveYamlModulePath(scriptDir) {
+/**
+ * Locate the Invoker checkout that owns this doctor script. Checked in order:
+ * 1. `INVOKER_REPO_ROOT` (explicit override, same convention used elsewhere
+ *    in the app, e.g. packages/contracts/src/repo-root.ts).
+ * 2. The local relative path (this script running from inside a live
+ *    Invoker checkout or worktree).
+ * 3. The shared checkout behind a linked git worktree's common dir.
+ * 4. `sourceRepoRoot` recorded in ~/.invoker/bundled-skills.json by the last
+ *    `scripts/setup-agent-skills.sh` install — needed when this script is
+ *    running from a machine-level skill install (e.g.
+ *    ~/.claude/skills/invoker-plan-to-invoker/scripts), which ships outside
+ *    any git repository and can't resolve steps 2-3.
+ */
+function resolveInvokerRepoRoot(scriptDir) {
+  const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
+
+  const envRoot = process.env.INVOKER_REPO_ROOT;
+  if (envRoot && hasWorkspaceMarker(envRoot)) return resolve(envRoot);
+
   const localRepoRoot = resolve(scriptDir, '../../..');
-  const localYamlPath = resolve(localRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-  if (existsSync(localYamlPath)) {
-    return localYamlPath;
-  }
+  if (hasWorkspaceMarker(localRepoRoot)) return localRepoRoot;
 
   try {
     const gitCommonDir = execSync('git rev-parse --git-common-dir', {
@@ -29,20 +45,39 @@ function resolveYamlModulePath(scriptDir) {
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
     const sharedRepoRoot = resolve(scriptDir, gitCommonDir, '..');
-    const sharedYamlPath = resolve(sharedRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-    if (existsSync(sharedYamlPath)) {
-      return sharedYamlPath;
-    }
+    if (hasWorkspaceMarker(sharedRepoRoot)) return sharedRepoRoot;
   } catch {
-    // Ignore git lookup failure and fall through to the explicit error below.
+    // Fall through to the manifest-based lookup below.
   }
 
+  try {
+    const invokerHome = process.env.INVOKER_DB_DIR ?? resolve(homedir(), '.invoker');
+    const manifestPath = resolve(invokerHome, 'bundled-skills.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    if (typeof manifest.sourceRepoRoot === 'string' && hasWorkspaceMarker(manifest.sourceRepoRoot)) {
+      return resolve(manifest.sourceRepoRoot);
+    }
+  } catch {
+    // Fall through to the explicit error at the call site.
+  }
+
+  return null;
+}
+
+const invokerRepoRoot = resolveInvokerRepoRoot(__dirname);
+if (!invokerRepoRoot) {
   throw new Error(
-    'Unable to resolve yaml runtime. Checked packages/app/node_modules/yaml/dist/index.js in the current worktree and the shared git checkout.',
+    'Unable to resolve the Invoker checkout for this doctor script (checked INVOKER_REPO_ROOT, the local '
+    + 'worktree, the shared git checkout, and ~/.invoker/bundled-skills.json). Set INVOKER_REPO_ROOT to an '
+    + "Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so "
+    + '~/.invoker/bundled-skills.json records the source checkout.',
   );
 }
 
-const yamlPath = resolveYamlModulePath(__dirname);
+const yamlPath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
+if (!existsSync(yamlPath)) {
+  throw new Error(`Unable to resolve yaml runtime. Expected it at ${yamlPath}.`);
+}
 
 const { parse: parseYaml } = await import(yamlPath);
 

--- a/skills/plan-to-invoker/scripts/validate-plan.sh
+++ b/skills/plan-to-invoker/scripts/validate-plan.sh
@@ -10,10 +10,34 @@ file="${1:?Usage: validate-plan.sh <plan.yaml>}"
 # Run from packages/app directory so ESM can resolve 'yaml' from local node_modules
 # Resolve to the physical script dir so this works via canonical path or symlink.
 script_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-# Resolve repo root from git so this works across layouts/worktrees.
-repo_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+
+# Resolve the Invoker checkout that owns this doctor script. Prefer an
+# explicit override, then a live git checkout (works across layouts and
+# worktrees), then the source checkout recorded by the last
+# `setup-agent-skills.sh` install — needed when running from a machine-level
+# skill install (e.g. ~/.claude/skills/invoker-plan-to-invoker/scripts),
+# which ships outside any git repository and can't resolve via git.
+repo_root="${INVOKER_REPO_ROOT:-}"
 if [[ -z "$repo_root" ]]; then
+  repo_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+if [[ -z "$repo_root" ]]; then
+  invoker_home="${INVOKER_DB_DIR:-$HOME/.invoker}"
+  manifest="$invoker_home/bundled-skills.json"
+  if [[ -f "$manifest" ]] && command -v node &>/dev/null; then
+    repo_root="$(node -e '
+      const fs = require("node:fs");
+      try {
+        const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+        if (typeof manifest.sourceRepoRoot === "string") process.stdout.write(manifest.sourceRepoRoot);
+      } catch {}
+    ' "$manifest" 2>/dev/null || true)"
+  fi
+fi
+
+if [[ -z "$repo_root" || ! -d "$repo_root/packages/app" ]]; then
   echo "Error: could not determine repository root from $script_dir" >&2
+  echo "Set INVOKER_REPO_ROOT to an Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so ~/.invoker/bundled-skills.json records the source checkout." >&2
   exit 1
 fi
 abs_file="$(cd "$(dirname "$file")" && pwd)/$(basename "$file")"


### PR DESCRIPTION
skills/plan-to-invoker/scripts/validate-plan.sh and lint-review-units.mjs
located their yaml runtime, review-unit-rules.mjs, and repo root purely via
`git -C <script dir>` or a hardcoded `../../../` relative path. Both break
once these scripts are copied to a machine-level skill install (e.g.
~/.claude/skills/invoker-plan-to-invoker/scripts, the layout
scripts/setup-agent-skills.sh already produces), since that location sits
outside any git repository.

Add an INVOKER_REPO_ROOT override, checked before the existing git-based
resolution, and replace the raw stack trace / cryptic git error with an
actionable message pointing at it.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>