### PR TITLE
[Plan Doctor Standalone Install](2) Record the source checkout so a fresh install needs no env var

### DIFF
--- a/packages/cli/src/__tests__/bundled-skills.test.ts
+++ b/packages/cli/src/__tests__/bundled-skills.test.ts
@@ -580,4 +580,64 @@ describe('bundled-skills', () => {
       }
     }
   });
+
+  it('records the source checkout in the manifest for the unpackaged CLI install, so installed doctor scripts outside any git repo (e.g. ~/.claude/skills/invoker-plan-to-invoker/scripts) can still resolve their Invoker checkout', () => {
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const cliHome = makeTempRoot('invoker-cli-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = cliHome;
+
+    try {
+      writeSkill(repoRoot, 'plan-to-invoker');
+      writePlanToInvokerCommands(repoRoot);
+
+      installBundledSkills({
+        isPackaged: false,
+        repoRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      });
+
+      const manifest = JSON.parse(readFileSync(join(invokerHomeRoot, 'bundled-skills.json'), 'utf-8'));
+      expect(manifest.sourceRepoRoot).toBe(repoRoot);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('omits sourceRepoRoot for packaged Electron installs, whose resources dir is not a real Invoker checkout', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const codexHome = makeTempRoot('invoker-codex-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = codexHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      writePlanToInvokerCommands(resourcesRoot);
+
+      installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      });
+
+      const manifest = JSON.parse(readFileSync(join(invokerHomeRoot, 'bundled-skills.json'), 'utf-8'));
+      expect(manifest.sourceRepoRoot).toBeUndefined();
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
 });

--- a/packages/shell/src/bundled-skills.ts
+++ b/packages/shell/src/bundled-skills.ts
@@ -28,6 +28,15 @@ interface BundledSkillsManifest {
   targets: Record<string, { path: string; installedSkillNames: string[] }>;
   commandTargets?: Record<string, { path: string; installedCommandNames: string[] }>;
   mcpTargets?: Record<string, { path: string; serverName: string }>;
+  /**
+   * The Invoker source checkout these skills were bundled from (unset for
+   * packaged Electron builds, whose resources dir isn't a real checkout).
+   * Read by installed doctor scripts (e.g. skills/plan-to-invoker/scripts/
+   * validate-plan.sh, lint-review-units.mjs) as a last-resort fallback when
+   * they're running from a machine-level skill install outside any git repo
+   * and can't resolve their own Invoker checkout via git.
+   */
+  sourceRepoRoot?: string;
 }
 
 interface BundledSkillsContext {
@@ -713,6 +722,7 @@ export function installBundledSkills(
     targets: manifestTargets,
     commandTargets: manifestCommandTargets,
     mcpTargets: manifestMcpTargets,
+    sourceRepoRoot: context.isPackaged ? undefined : context.repoRoot,
   };
 
   writeManifest(invokerHomeRoot, manifest);

--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -278,10 +278,34 @@ STANDALONE_ENV_REVIEW_UNITS_STATUS="$(printf '%s' "$STANDALONE_ENV_OUTPUT" | nod
 ' "lint-review-units")"
 [[ "$STANDALONE_ENV_REVIEW_UNITS_STATUS" == "passed" ]] || fail "Standalone install with INVOKER_REPO_ROOT override must pass lint-review-units; got status=$STANDALONE_ENV_REVIEW_UNITS_STATUS. Full output: $STANDALONE_ENV_OUTPUT"
 
+# With the bundled-skills manifest recording the source checkout (what
+# `installBundledSkills()` now writes on every install/reinstall), both
+# validate-plan and lint-review-units must pass standalone with no env var set —
+# the ordinary case for an agent working in a non-Invoker repo after running
+# `scripts/setup-agent-skills.sh` once.
+cat > "$STANDALONE_INVOKER_HOME/bundled-skills.json" <<EOF
+{"sourceRepoRoot": "$REPO_ROOT"}
+EOF
+STANDALONE_MANIFEST_OUTPUT="$(cd /tmp && env -u INVOKER_REPO_ROOT INVOKER_DB_DIR="$STANDALONE_INVOKER_HOME" bash "$STANDALONE_DOCTOR" --skip-assumptions "$STANDALONE_FIXTURE" 2>/dev/null || true)"
+STANDALONE_MANIFEST_VALIDATE_STATUS="$(printf '%s' "$STANDALONE_MANIFEST_OUTPUT" | node -e '
+  const raw = require("node:fs").readFileSync(0, "utf8");
+  const report = JSON.parse(raw);
+  const check = report.checks.find((c) => c.stepId === process.argv[1]);
+  process.stdout.write(check ? String(check.status) : "missing");
+' "validate-plan")"
+[[ "$STANDALONE_MANIFEST_VALIDATE_STATUS" == "passed" ]] || fail "Standalone install (via bundled-skills.json sourceRepoRoot) must pass validate-plan; got status=$STANDALONE_MANIFEST_VALIDATE_STATUS. Full output: $STANDALONE_MANIFEST_OUTPUT"
+STANDALONE_MANIFEST_REVIEW_UNITS_STATUS="$(printf '%s' "$STANDALONE_MANIFEST_OUTPUT" | node -e '
+  const raw = require("node:fs").readFileSync(0, "utf8");
+  const report = JSON.parse(raw);
+  const check = report.checks.find((c) => c.stepId === process.argv[1]);
+  process.stdout.write(check ? String(check.status) : "missing");
+' "lint-review-units")"
+[[ "$STANDALONE_MANIFEST_REVIEW_UNITS_STATUS" == "passed" ]] || fail "Standalone install (via bundled-skills.json sourceRepoRoot) must pass lint-review-units; got status=$STANDALONE_MANIFEST_REVIEW_UNITS_STATUS. Full output: $STANDALONE_MANIFEST_OUTPUT"
+
 rm -rf "$STANDALONE_INSTALL_DIR" "$STANDALONE_INVOKER_HOME"
 trap - EXIT
 
-echo "OK: skill-doctor works from a machine-level standalone install via INVOKER_REPO_ROOT (outside any git checkout)"
+echo "OK: skill-doctor works from a machine-level standalone install (outside any git checkout)"
 
 # Playbook — Phase 1a / 1b focused lanes and anti-patterns
 must_contain "$PLAYBOOK" "### Phase 1a — Static analysis" "Playbook must define Phase 1a"


### PR DESCRIPTION
Slice 1 requires the caller to set INVOKER_REPO_ROOT before the machine-level
doctor scripts work outside a git checkout. Persist the Invoker checkout used
to build the bundled skills (`installBundledSkills()`'s repoRoot, unpackaged
CLI installs only) into ~/.invoker/bundled-skills.json as `sourceRepoRoot`,
so a plain `scripts/setup-agent-skills.sh` install is enough on its own.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

Depends-On: #9621

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved standalone CLI installations so they can locate the Invoker source checkout automatically when the repository path is not otherwise configured.
  * Packaged Electron installations continue to omit development-only repository information.

* **Tests**
  * Expanded regression coverage for manifest-based repository discovery across plan validation and review-unit linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->