### PR TITLE
[Plan Doctor Standalone Install](1) Resolve the Invoker checkout via INVOKER_REPO_ROOT outside a git checkout

### DIFF
--- a/skills/plan-to-invoker/scripts/lint-review-units.mjs
+++ b/skills/plan-to-invoker/scripts/lint-review-units.mjs
@@ -2,21 +2,34 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import {
-  getLabelSection,
-  validateChangeTypeItems,
-  validateSingleReviewUnitFocus,
-} from '../../../scripts/review-unit-rules.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-function resolveYamlModulePath(scriptDir) {
+/**
+ * Locate the Invoker checkout that owns this doctor script. Checked in order:
+ * 1. `INVOKER_REPO_ROOT` (explicit override, same convention used elsewhere
+ *    in the app, e.g. packages/contracts/src/repo-root.ts).
+ * 2. The local relative path (this script running from inside a live
+ *    Invoker checkout or worktree).
+ * 3. The shared checkout behind a linked git worktree's common dir.
+ * 4. `sourceRepoRoot` recorded in ~/.invoker/bundled-skills.json by the last
+ *    `scripts/setup-agent-skills.sh` install — needed when this script is
+ *    running from a machine-level skill install (e.g.
+ *    ~/.claude/skills/invoker-plan-to-invoker/scripts), which ships outside
+ *    any git repository and can't resolve steps 2-3.
+ */
+function resolveInvokerRepoRoot(scriptDir) {
+  const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
+
+  const envRoot = process.env.INVOKER_REPO_ROOT;
+  if (envRoot && hasWorkspaceMarker(envRoot)) return resolve(envRoot);
+
   const localRepoRoot = resolve(scriptDir, '../../..');
-  const localYamlPath = resolve(localRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-  if (existsSync(localYamlPath)) return localYamlPath;
+  if (hasWorkspaceMarker(localRepoRoot)) return localRepoRoot;
 
   try {
     const gitCommonDir = execSync('git rev-parse --git-common-dir', {
@@ -25,18 +38,50 @@ function resolveYamlModulePath(scriptDir) {
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
     const sharedRepoRoot = resolve(scriptDir, gitCommonDir, '..');
-    const sharedYamlPath = resolve(sharedRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-    if (existsSync(sharedYamlPath)) return sharedYamlPath;
+    if (hasWorkspaceMarker(sharedRepoRoot)) return sharedRepoRoot;
   } catch {
-    // Fall through to the explicit error below.
+    // Fall through to the manifest-based lookup below.
   }
 
+  try {
+    const invokerHome = process.env.INVOKER_DB_DIR ?? resolve(homedir(), '.invoker');
+    const manifestPath = resolve(invokerHome, 'bundled-skills.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    if (typeof manifest.sourceRepoRoot === 'string' && hasWorkspaceMarker(manifest.sourceRepoRoot)) {
+      return resolve(manifest.sourceRepoRoot);
+    }
+  } catch {
+    // Fall through to the explicit error at the call site.
+  }
+
+  return null;
+}
+
+const invokerRepoRoot = resolveInvokerRepoRoot(__dirname);
+if (!invokerRepoRoot) {
   throw new Error(
-    'Unable to resolve yaml runtime. Checked packages/app/node_modules/yaml/dist/index.js in the current worktree and the shared git checkout.',
+    'Unable to resolve the Invoker checkout for this doctor script (checked INVOKER_REPO_ROOT, the local '
+    + 'worktree, the shared git checkout, and ~/.invoker/bundled-skills.json). Set INVOKER_REPO_ROOT to an '
+    + "Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so "
+    + '~/.invoker/bundled-skills.json records the source checkout.',
   );
 }
 
-const { parse: parseYaml } = await import(resolveYamlModulePath(__dirname));
+const yamlModulePath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
+if (!existsSync(yamlModulePath)) {
+  throw new Error(`Unable to resolve yaml runtime. Expected it at ${yamlModulePath}.`);
+}
+const { parse: parseYaml } = await import(yamlModulePath);
+
+const reviewUnitRulesPath = resolve(invokerRepoRoot, 'scripts/review-unit-rules.mjs');
+if (!existsSync(reviewUnitRulesPath)) {
+  throw new Error(`Unable to resolve review-unit-rules.mjs. Expected it at ${reviewUnitRulesPath}.`);
+}
+const {
+  getLabelSection,
+  validateChangeTypeItems,
+  validateSingleReviewUnitFocus,
+} = await import(reviewUnitRulesPath);
 
 function reviewFocusTexts(text) {
   return [

--- a/skills/plan-to-invoker/scripts/validate-plan.mjs
+++ b/skills/plan-to-invoker/scripts/validate-plan.mjs
@@ -9,18 +9,34 @@
 
 import { execFileSync, execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, normalize, resolve } from 'node:path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-function resolveYamlModulePath(scriptDir) {
+/**
+ * Locate the Invoker checkout that owns this doctor script. Checked in order:
+ * 1. `INVOKER_REPO_ROOT` (explicit override, same convention used elsewhere
+ *    in the app, e.g. packages/contracts/src/repo-root.ts).
+ * 2. The local relative path (this script running from inside a live
+ *    Invoker checkout or worktree).
+ * 3. The shared checkout behind a linked git worktree's common dir.
+ * 4. `sourceRepoRoot` recorded in ~/.invoker/bundled-skills.json by the last
+ *    `scripts/setup-agent-skills.sh` install — needed when this script is
+ *    running from a machine-level skill install (e.g.
+ *    ~/.claude/skills/invoker-plan-to-invoker/scripts), which ships outside
+ *    any git repository and can't resolve steps 2-3.
+ */
+function resolveInvokerRepoRoot(scriptDir) {
+  const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
+
+  const envRoot = process.env.INVOKER_REPO_ROOT;
+  if (envRoot && hasWorkspaceMarker(envRoot)) return resolve(envRoot);
+
   const localRepoRoot = resolve(scriptDir, '../../..');
-  const localYamlPath = resolve(localRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-  if (existsSync(localYamlPath)) {
-    return localYamlPath;
-  }
+  if (hasWorkspaceMarker(localRepoRoot)) return localRepoRoot;
 
   try {
     const gitCommonDir = execSync('git rev-parse --git-common-dir', {
@@ -29,20 +45,39 @@ function resolveYamlModulePath(scriptDir) {
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
     const sharedRepoRoot = resolve(scriptDir, gitCommonDir, '..');
-    const sharedYamlPath = resolve(sharedRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-    if (existsSync(sharedYamlPath)) {
-      return sharedYamlPath;
-    }
+    if (hasWorkspaceMarker(sharedRepoRoot)) return sharedRepoRoot;
   } catch {
-    // Ignore git lookup failure and fall through to the explicit error below.
+    // Fall through to the manifest-based lookup below.
   }
 
+  try {
+    const invokerHome = process.env.INVOKER_DB_DIR ?? resolve(homedir(), '.invoker');
+    const manifestPath = resolve(invokerHome, 'bundled-skills.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    if (typeof manifest.sourceRepoRoot === 'string' && hasWorkspaceMarker(manifest.sourceRepoRoot)) {
+      return resolve(manifest.sourceRepoRoot);
+    }
+  } catch {
+    // Fall through to the explicit error at the call site.
+  }
+
+  return null;
+}
+
+const invokerRepoRoot = resolveInvokerRepoRoot(__dirname);
+if (!invokerRepoRoot) {
   throw new Error(
-    'Unable to resolve yaml runtime. Checked packages/app/node_modules/yaml/dist/index.js in the current worktree and the shared git checkout.',
+    'Unable to resolve the Invoker checkout for this doctor script (checked INVOKER_REPO_ROOT, the local '
+    + 'worktree, the shared git checkout, and ~/.invoker/bundled-skills.json). Set INVOKER_REPO_ROOT to an '
+    + "Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so "
+    + '~/.invoker/bundled-skills.json records the source checkout.',
   );
 }
 
-const yamlPath = resolveYamlModulePath(__dirname);
+const yamlPath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
+if (!existsSync(yamlPath)) {
+  throw new Error(`Unable to resolve yaml runtime. Expected it at ${yamlPath}.`);
+}
 
 const { parse: parseYaml } = await import(yamlPath);
 

--- a/skills/plan-to-invoker/scripts/validate-plan.sh
+++ b/skills/plan-to-invoker/scripts/validate-plan.sh
@@ -10,10 +10,34 @@ file="${1:?Usage: validate-plan.sh <plan.yaml>}"
 # Run from packages/app directory so ESM can resolve 'yaml' from local node_modules
 # Resolve to the physical script dir so this works via canonical path or symlink.
 script_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-# Resolve repo root from git so this works across layouts/worktrees.
-repo_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+
+# Resolve the Invoker checkout that owns this doctor script. Prefer an
+# explicit override, then a live git checkout (works across layouts and
+# worktrees), then the source checkout recorded by the last
+# `setup-agent-skills.sh` install — needed when running from a machine-level
+# skill install (e.g. ~/.claude/skills/invoker-plan-to-invoker/scripts),
+# which ships outside any git repository and can't resolve via git.
+repo_root="${INVOKER_REPO_ROOT:-}"
 if [[ -z "$repo_root" ]]; then
+  repo_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+if [[ -z "$repo_root" ]]; then
+  invoker_home="${INVOKER_DB_DIR:-$HOME/.invoker}"
+  manifest="$invoker_home/bundled-skills.json"
+  if [[ -f "$manifest" ]] && command -v node &>/dev/null; then
+    repo_root="$(node -e '
+      const fs = require("node:fs");
+      try {
+        const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+        if (typeof manifest.sourceRepoRoot === "string") process.stdout.write(manifest.sourceRepoRoot);
+      } catch {}
+    ' "$manifest" 2>/dev/null || true)"
+  fi
+fi
+
+if [[ -z "$repo_root" || ! -d "$repo_root/packages/app" ]]; then
   echo "Error: could not determine repository root from $script_dir" >&2
+  echo "Set INVOKER_REPO_ROOT to an Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so ~/.invoker/bundled-skills.json records the source checkout." >&2
   exit 1
 fi
 abs_file="$(cd "$(dirname "$file")" && pwd)/$(basename "$file")"


### PR DESCRIPTION
## Summary

The plan-doctor scripts under `skills/plan-to-invoker/scripts/` only worked when run from inside a live Invoker git checkout.

They located their dependencies (the `yaml` npm package, a shared helper file) by walking up a fixed number of directories, or by asking git for the repo root.

That breaks once these same files are copied elsewhere — such as the machine-level skill install `scripts/setup-agent-skills.sh` already produces on every machine, which sits outside any git repository.

An agent planning a change against a different repo had no working doctor: the only copy it could reach was the installed one, and that one was broken.

This slice adds an `INVOKER_REPO_ROOT` override, checked before the existing git-based lookup. When neither resolves, the scripts fail with one actionable line instead of a raw stack trace.

## Review Claim

The plan-doctor's dependency-resolution and unit-lint scripts should locate their own dependencies via `INVOKER_REPO_ROOT` (or existing git-based detection) instead of assuming they're running from inside the Invoker checkout.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This only touches dependency-resolution code inside `skills/plan-to-invoker/scripts/*` — pure path lookups with `existsSync` guards and a thrown error on failure. No behavior changes for the existing in-checkout case: same files are found via the same relative path first, before any new fallback runs.

## Slice Rationale

The review-unit gate classifies everything under `skills/` as `docs` scope and does not allow mixing it with `scripts/`-prefixed (`tooling-policy`) or `packages/`-prefixed (product) files in the same PR. This slice covers only the `skills/` files; the manifest field these scripts can also fall back to, plus a verification that all of it works together, land as the next two PRs in this stack.

## Non-goals

Does not add the `sourceRepoRoot` manifest field these scripts also check as a fallback (next slice). Does not add a regression test for the standalone-install scenario (slice 3). Does not change any other skill's scripts.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/test-plan-to-invoker-skill.sh` (62/62 fixture tests + full contract suite, unchanged behavior)
- [ ] Manual repro: copy `skills/plan-to-invoker/scripts/*.{sh,mjs}` to a directory outside any git repo, run `bash skill-doctor.sh --skip-assumptions <fixture.yaml>` with no `INVOKER_REPO_ROOT` set — fails with a message naming `INVOKER_REPO_ROOT`, not a stack trace. Re-run with `INVOKER_REPO_ROOT=<path-to-this-checkout>` set — `validate-plan` and `lint-review-units` both pass.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert be61a97727`
- Post-revert steps: None
- Data migration? No

</details>
