### PR TITLE
[Plan Doctor Standalone Install](2) Record the source checkout in the bundled-skills manifest

### DIFF
--- a/packages/cli/src/__tests__/bundled-skills.test.ts
+++ b/packages/cli/src/__tests__/bundled-skills.test.ts
@@ -580,4 +580,64 @@ describe('bundled-skills', () => {
       }
     }
   });
+
+  it('records the source checkout in the manifest for the unpackaged CLI install, so installed doctor scripts outside any git repo (e.g. ~/.claude/skills/invoker-plan-to-invoker/scripts) can still resolve their Invoker checkout', () => {
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const cliHome = makeTempRoot('invoker-cli-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = cliHome;
+
+    try {
+      writeSkill(repoRoot, 'plan-to-invoker');
+      writePlanToInvokerCommands(repoRoot);
+
+      installBundledSkills({
+        isPackaged: false,
+        repoRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      });
+
+      const manifest = JSON.parse(readFileSync(join(invokerHomeRoot, 'bundled-skills.json'), 'utf-8'));
+      expect(manifest.sourceRepoRoot).toBe(repoRoot);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('omits sourceRepoRoot for packaged Electron installs, whose resources dir is not a real Invoker checkout', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const codexHome = makeTempRoot('invoker-codex-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = codexHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      writePlanToInvokerCommands(resourcesRoot);
+
+      installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      });
+
+      const manifest = JSON.parse(readFileSync(join(invokerHomeRoot, 'bundled-skills.json'), 'utf-8'));
+      expect(manifest.sourceRepoRoot).toBeUndefined();
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
 });

--- a/packages/shell/src/bundled-skills.ts
+++ b/packages/shell/src/bundled-skills.ts
@@ -28,6 +28,15 @@ interface BundledSkillsManifest {
   targets: Record<string, { path: string; installedSkillNames: string[] }>;
   commandTargets?: Record<string, { path: string; installedCommandNames: string[] }>;
   mcpTargets?: Record<string, { path: string; serverName: string }>;
+  /**
+   * The Invoker source checkout these skills were bundled from (unset for
+   * packaged Electron builds, whose resources dir isn't a real checkout).
+   * Read by installed doctor scripts (e.g. skills/plan-to-invoker/scripts/
+   * validate-plan.sh, lint-review-units.mjs) as a last-resort fallback when
+   * they're running from a machine-level skill install outside any git repo
+   * and can't resolve their own Invoker checkout via git.
+   */
+  sourceRepoRoot?: string;
 }
 
 interface BundledSkillsContext {
@@ -713,6 +722,7 @@ export function installBundledSkills(
     targets: manifestTargets,
     commandTargets: manifestCommandTargets,
     mcpTargets: manifestMcpTargets,
+    sourceRepoRoot: context.isPackaged ? undefined : context.repoRoot,
   };
 
   writeManifest(invokerHomeRoot, manifest);

--- a/skills/plan-to-invoker/scripts/lint-review-units.mjs
+++ b/skills/plan-to-invoker/scripts/lint-review-units.mjs
@@ -2,21 +2,34 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import {
-  getLabelSection,
-  validateChangeTypeItems,
-  validateSingleReviewUnitFocus,
-} from '../../../scripts/review-unit-rules.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-function resolveYamlModulePath(scriptDir) {
+/**
+ * Locate the Invoker checkout that owns this doctor script. Checked in order:
+ * 1. `INVOKER_REPO_ROOT` (explicit override, same convention used elsewhere
+ *    in the app, e.g. packages/contracts/src/repo-root.ts).
+ * 2. The local relative path (this script running from inside a live
+ *    Invoker checkout or worktree).
+ * 3. The shared checkout behind a linked git worktree's common dir.
+ * 4. `sourceRepoRoot` recorded in ~/.invoker/bundled-skills.json by the last
+ *    `scripts/setup-agent-skills.sh` install — needed when this script is
+ *    running from a machine-level skill install (e.g.
+ *    ~/.claude/skills/invoker-plan-to-invoker/scripts), which ships outside
+ *    any git repository and can't resolve steps 2-3.
+ */
+function resolveInvokerRepoRoot(scriptDir) {
+  const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
+
+  const envRoot = process.env.INVOKER_REPO_ROOT;
+  if (envRoot && hasWorkspaceMarker(envRoot)) return resolve(envRoot);
+
   const localRepoRoot = resolve(scriptDir, '../../..');
-  const localYamlPath = resolve(localRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-  if (existsSync(localYamlPath)) return localYamlPath;
+  if (hasWorkspaceMarker(localRepoRoot)) return localRepoRoot;
 
   try {
     const gitCommonDir = execSync('git rev-parse --git-common-dir', {
@@ -25,18 +38,50 @@ function resolveYamlModulePath(scriptDir) {
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
     const sharedRepoRoot = resolve(scriptDir, gitCommonDir, '..');
-    const sharedYamlPath = resolve(sharedRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-    if (existsSync(sharedYamlPath)) return sharedYamlPath;
+    if (hasWorkspaceMarker(sharedRepoRoot)) return sharedRepoRoot;
   } catch {
-    // Fall through to the explicit error below.
+    // Fall through to the manifest-based lookup below.
   }
 
+  try {
+    const invokerHome = process.env.INVOKER_DB_DIR ?? resolve(homedir(), '.invoker');
+    const manifestPath = resolve(invokerHome, 'bundled-skills.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    if (typeof manifest.sourceRepoRoot === 'string' && hasWorkspaceMarker(manifest.sourceRepoRoot)) {
+      return resolve(manifest.sourceRepoRoot);
+    }
+  } catch {
+    // Fall through to the explicit error at the call site.
+  }
+
+  return null;
+}
+
+const invokerRepoRoot = resolveInvokerRepoRoot(__dirname);
+if (!invokerRepoRoot) {
   throw new Error(
-    'Unable to resolve yaml runtime. Checked packages/app/node_modules/yaml/dist/index.js in the current worktree and the shared git checkout.',
+    'Unable to resolve the Invoker checkout for this doctor script (checked INVOKER_REPO_ROOT, the local '
+    + 'worktree, the shared git checkout, and ~/.invoker/bundled-skills.json). Set INVOKER_REPO_ROOT to an '
+    + "Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so "
+    + '~/.invoker/bundled-skills.json records the source checkout.',
   );
 }
 
-const { parse: parseYaml } = await import(resolveYamlModulePath(__dirname));
+const yamlModulePath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
+if (!existsSync(yamlModulePath)) {
+  throw new Error(`Unable to resolve yaml runtime. Expected it at ${yamlModulePath}.`);
+}
+const { parse: parseYaml } = await import(yamlModulePath);
+
+const reviewUnitRulesPath = resolve(invokerRepoRoot, 'scripts/review-unit-rules.mjs');
+if (!existsSync(reviewUnitRulesPath)) {
+  throw new Error(`Unable to resolve review-unit-rules.mjs. Expected it at ${reviewUnitRulesPath}.`);
+}
+const {
+  getLabelSection,
+  validateChangeTypeItems,
+  validateSingleReviewUnitFocus,
+} = await import(reviewUnitRulesPath);
 
 function reviewFocusTexts(text) {
   return [

--- a/skills/plan-to-invoker/scripts/validate-plan.mjs
+++ b/skills/plan-to-invoker/scripts/validate-plan.mjs
@@ -9,18 +9,34 @@
 
 import { execFileSync, execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, normalize, resolve } from 'node:path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-function resolveYamlModulePath(scriptDir) {
+/**
+ * Locate the Invoker checkout that owns this doctor script. Checked in order:
+ * 1. `INVOKER_REPO_ROOT` (explicit override, same convention used elsewhere
+ *    in the app, e.g. packages/contracts/src/repo-root.ts).
+ * 2. The local relative path (this script running from inside a live
+ *    Invoker checkout or worktree).
+ * 3. The shared checkout behind a linked git worktree's common dir.
+ * 4. `sourceRepoRoot` recorded in ~/.invoker/bundled-skills.json by the last
+ *    `scripts/setup-agent-skills.sh` install — needed when this script is
+ *    running from a machine-level skill install (e.g.
+ *    ~/.claude/skills/invoker-plan-to-invoker/scripts), which ships outside
+ *    any git repository and can't resolve steps 2-3.
+ */
+function resolveInvokerRepoRoot(scriptDir) {
+  const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
+
+  const envRoot = process.env.INVOKER_REPO_ROOT;
+  if (envRoot && hasWorkspaceMarker(envRoot)) return resolve(envRoot);
+
   const localRepoRoot = resolve(scriptDir, '../../..');
-  const localYamlPath = resolve(localRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-  if (existsSync(localYamlPath)) {
-    return localYamlPath;
-  }
+  if (hasWorkspaceMarker(localRepoRoot)) return localRepoRoot;
 
   try {
     const gitCommonDir = execSync('git rev-parse --git-common-dir', {
@@ -29,20 +45,39 @@ function resolveYamlModulePath(scriptDir) {
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
     const sharedRepoRoot = resolve(scriptDir, gitCommonDir, '..');
-    const sharedYamlPath = resolve(sharedRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-    if (existsSync(sharedYamlPath)) {
-      return sharedYamlPath;
-    }
+    if (hasWorkspaceMarker(sharedRepoRoot)) return sharedRepoRoot;
   } catch {
-    // Ignore git lookup failure and fall through to the explicit error below.
+    // Fall through to the manifest-based lookup below.
   }
 
+  try {
+    const invokerHome = process.env.INVOKER_DB_DIR ?? resolve(homedir(), '.invoker');
+    const manifestPath = resolve(invokerHome, 'bundled-skills.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    if (typeof manifest.sourceRepoRoot === 'string' && hasWorkspaceMarker(manifest.sourceRepoRoot)) {
+      return resolve(manifest.sourceRepoRoot);
+    }
+  } catch {
+    // Fall through to the explicit error at the call site.
+  }
+
+  return null;
+}
+
+const invokerRepoRoot = resolveInvokerRepoRoot(__dirname);
+if (!invokerRepoRoot) {
   throw new Error(
-    'Unable to resolve yaml runtime. Checked packages/app/node_modules/yaml/dist/index.js in the current worktree and the shared git checkout.',
+    'Unable to resolve the Invoker checkout for this doctor script (checked INVOKER_REPO_ROOT, the local '
+    + 'worktree, the shared git checkout, and ~/.invoker/bundled-skills.json). Set INVOKER_REPO_ROOT to an '
+    + "Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so "
+    + '~/.invoker/bundled-skills.json records the source checkout.',
   );
 }
 
-const yamlPath = resolveYamlModulePath(__dirname);
+const yamlPath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
+if (!existsSync(yamlPath)) {
+  throw new Error(`Unable to resolve yaml runtime. Expected it at ${yamlPath}.`);
+}
 
 const { parse: parseYaml } = await import(yamlPath);
 

--- a/skills/plan-to-invoker/scripts/validate-plan.sh
+++ b/skills/plan-to-invoker/scripts/validate-plan.sh
@@ -10,10 +10,34 @@ file="${1:?Usage: validate-plan.sh <plan.yaml>}"
 # Run from packages/app directory so ESM can resolve 'yaml' from local node_modules
 # Resolve to the physical script dir so this works via canonical path or symlink.
 script_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-# Resolve repo root from git so this works across layouts/worktrees.
-repo_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+
+# Resolve the Invoker checkout that owns this doctor script. Prefer an
+# explicit override, then a live git checkout (works across layouts and
+# worktrees), then the source checkout recorded by the last
+# `setup-agent-skills.sh` install — needed when running from a machine-level
+# skill install (e.g. ~/.claude/skills/invoker-plan-to-invoker/scripts),
+# which ships outside any git repository and can't resolve via git.
+repo_root="${INVOKER_REPO_ROOT:-}"
 if [[ -z "$repo_root" ]]; then
+  repo_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+if [[ -z "$repo_root" ]]; then
+  invoker_home="${INVOKER_DB_DIR:-$HOME/.invoker}"
+  manifest="$invoker_home/bundled-skills.json"
+  if [[ -f "$manifest" ]] && command -v node &>/dev/null; then
+    repo_root="$(node -e '
+      const fs = require("node:fs");
+      try {
+        const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+        if (typeof manifest.sourceRepoRoot === "string") process.stdout.write(manifest.sourceRepoRoot);
+      } catch {}
+    ' "$manifest" 2>/dev/null || true)"
+  fi
+fi
+
+if [[ -z "$repo_root" || ! -d "$repo_root/packages/app" ]]; then
   echo "Error: could not determine repository root from $script_dir" >&2
+  echo "Set INVOKER_REPO_ROOT to an Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so ~/.invoker/bundled-skills.json records the source checkout." >&2
   exit 1
 fi
 abs_file="$(cd "$(dirname "$file")" && pwd)/$(basename "$file")"


### PR DESCRIPTION
## Summary

`installBundledSkills()` copies `skills/` from an Invoker checkout into every agent harness's global skill store (`~/.claude/skills/invoker-plan-to-invoker`, and the Codex/Cursor/OMP equivalents), then writes an install manifest at `~/.invoker/bundled-skills.json`.

That manifest never recorded which checkout it copied from.

The previous slice taught the installed doctor scripts to read a `sourceRepoRoot` field from that manifest as a last-resort fallback, avoiding a manual `INVOKER_REPO_ROOT` environment variable.

This slice writes that field: `repoRoot` for the normal unpackaged install path, left unset for packaged Electron builds, whose resources directory isn't a real source checkout.

## Review Claim

`installBundledSkills()` should persist the Invoker source checkout it installed skills from into the manifest, so a plain `scripts/setup-agent-skills.sh` run is enough for the doctor scripts to work standalone, with no manual env var required.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

Purely additive: one new optional field on a JSON manifest this process already owns and rewrites on every install. No existing manifest consumer reads or depends on this field's absence, so nothing downstream can break by it now being present.

## Slice Rationale

`packages/shell/src/bundled-skills.ts` and its test are product code (unconstrained by the `skills/`-vs-`scripts/` docs/policy split), so they're kept separate from both the docs-lane script fix (previous slice) and the policy-lane regression test (next slice), which the review-unit gate would otherwise reject as mixed.

## Non-goals

Does not change what the installed doctor scripts do with this field — that already landed in the previous slice. Does not change install behavior for packaged Electron builds. Does not back-fill `sourceRepoRoot` for machines that installed skills before this change; they need one more `scripts/setup-agent-skills.sh` run.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `packages/cli/src/__tests__/bundled-skills.test.ts` — new cases assert `sourceRepoRoot` is written for unpackaged installs and omitted for packaged ones (added in this slice; not executed in this session due to a pre-existing, unrelated build break in this checkout — `packages/shell`'s `tsup --dts` step fails with `TS5097` on unmodified `origin/master` too, confirmed by stashing this change and re-running the same build)
- [ ] Manual: `node -e "JSON.parse(require('fs').readFileSync('~/.invoker/bundled-skills.json'))"` after a real `scripts/setup-agent-skills.sh` run shows a `sourceRepoRoot` key pointing at the checkout that was built

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5645633d5a`
- Post-revert steps: None (the previous slice's `INVOKER_REPO_ROOT` fallback keeps working without this field)
- Data migration? No

</details>
