### PR TITLE
[Plan Doctor Standalone Install](3) Regression-test the machine-level standalone doctor install

### DIFF
--- a/packages/cli/src/__tests__/bundled-skills.test.ts
+++ b/packages/cli/src/__tests__/bundled-skills.test.ts
@@ -580,4 +580,64 @@ describe('bundled-skills', () => {
       }
     }
   });
+
+  it('records the source checkout in the manifest for the unpackaged CLI install, so installed doctor scripts outside any git repo (e.g. ~/.claude/skills/invoker-plan-to-invoker/scripts) can still resolve their Invoker checkout', () => {
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const cliHome = makeTempRoot('invoker-cli-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = cliHome;
+
+    try {
+      writeSkill(repoRoot, 'plan-to-invoker');
+      writePlanToInvokerCommands(repoRoot);
+
+      installBundledSkills({
+        isPackaged: false,
+        repoRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      });
+
+      const manifest = JSON.parse(readFileSync(join(invokerHomeRoot, 'bundled-skills.json'), 'utf-8'));
+      expect(manifest.sourceRepoRoot).toBe(repoRoot);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('omits sourceRepoRoot for packaged Electron installs, whose resources dir is not a real Invoker checkout', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const codexHome = makeTempRoot('invoker-codex-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = codexHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      writePlanToInvokerCommands(resourcesRoot);
+
+      installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      });
+
+      const manifest = JSON.parse(readFileSync(join(invokerHomeRoot, 'bundled-skills.json'), 'utf-8'));
+      expect(manifest.sourceRepoRoot).toBeUndefined();
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
 });

--- a/packages/shell/src/bundled-skills.ts
+++ b/packages/shell/src/bundled-skills.ts
@@ -28,6 +28,15 @@ interface BundledSkillsManifest {
   targets: Record<string, { path: string; installedSkillNames: string[] }>;
   commandTargets?: Record<string, { path: string; installedCommandNames: string[] }>;
   mcpTargets?: Record<string, { path: string; serverName: string }>;
+  /**
+   * The Invoker source checkout these skills were bundled from (unset for
+   * packaged Electron builds, whose resources dir isn't a real checkout).
+   * Read by installed doctor scripts (e.g. skills/plan-to-invoker/scripts/
+   * validate-plan.sh, lint-review-units.mjs) as a last-resort fallback when
+   * they're running from a machine-level skill install outside any git repo
+   * and can't resolve their own Invoker checkout via git.
+   */
+  sourceRepoRoot?: string;
 }
 
 interface BundledSkillsContext {
@@ -713,6 +722,7 @@ export function installBundledSkills(
     targets: manifestTargets,
     commandTargets: manifestCommandTargets,
     mcpTargets: manifestMcpTargets,
+    sourceRepoRoot: context.isPackaged ? undefined : context.repoRoot,
   };
 
   writeManifest(invokerHomeRoot, manifest);

--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -240,6 +240,73 @@ must_output_contain "$DOCTOR_HELP" "  1 = one or more checks failed" "skill-doct
 must_output_contain "$DOCTOR_HELP" "  2 = usage/argument error" "skill-doctor --help must expose usage-error exit code"
 must_output_contain "$DOCTOR_HELP" "Output: JSON summary of all checks with pass/fail status" "skill-doctor --help must expose JSON output contract"
 
+# Regression: skill-doctor.sh (and its validate-plan/lint-review-units
+# sub-checks) must work when copied wholesale to a machine-level skill
+# install outside any git checkout — e.g. ~/.claude/skills/invoker-plan-to-invoker,
+# the layout `scripts/setup-agent-skills.sh` produces. Reproduces the bug where
+# an agent planning against a non-Invoker repo had no working doctor: validate-plan.sh
+# resolved its repo root via `git -C <script dir>`, and lint-review-units.mjs
+# statically imported `../../../scripts/review-unit-rules.mjs` — both broke
+# once the scripts' physical location was no longer 3 directories under the
+# Invoker repo root.
+STANDALONE_INSTALL_DIR="$(mktemp -d)"
+STANDALONE_INVOKER_HOME="$(mktemp -d)"
+trap 'rm -rf "$STANDALONE_INSTALL_DIR" "$STANDALONE_INVOKER_HOME"' EXIT
+cp "$REPO_ROOT"/skills/plan-to-invoker/scripts/*.sh "$REPO_ROOT"/skills/plan-to-invoker/scripts/*.mjs "$STANDALONE_INSTALL_DIR/"
+STANDALONE_DOCTOR="$STANDALONE_INSTALL_DIR/skill-doctor.sh"
+STANDALONE_FIXTURE="$POSITIVE_FIXTURE_DIR/02-feature-implementation.yaml"
+
+# Without INVOKER_REPO_ROOT or a bundled-skills manifest, the doctor must fail
+# with an actionable message instead of a raw stack trace or generic error.
+STANDALONE_NO_FALLBACK_OUTPUT="$(cd /tmp && env -u INVOKER_REPO_ROOT INVOKER_DB_DIR="$STANDALONE_INVOKER_HOME" bash "$STANDALONE_DOCTOR" --skip-assumptions "$STANDALONE_FIXTURE" 2>&1 || true)"
+must_output_contain "$STANDALONE_NO_FALLBACK_OUTPUT" "INVOKER_REPO_ROOT" "Standalone doctor without a resolvable repo root must point at the INVOKER_REPO_ROOT override"
+
+# INVOKER_REPO_ROOT must work as an explicit override, without any manifest.
+STANDALONE_ENV_OUTPUT="$(cd /tmp && env -u INVOKER_DB_DIR INVOKER_REPO_ROOT="$REPO_ROOT" bash "$STANDALONE_DOCTOR" --skip-assumptions "$STANDALONE_FIXTURE" 2>/dev/null || true)"
+STANDALONE_ENV_VALIDATE_STATUS="$(printf '%s' "$STANDALONE_ENV_OUTPUT" | node -e '
+  const raw = require("node:fs").readFileSync(0, "utf8");
+  const report = JSON.parse(raw);
+  const check = report.checks.find((c) => c.stepId === process.argv[1]);
+  process.stdout.write(check ? String(check.status) : "missing");
+' "validate-plan")"
+[[ "$STANDALONE_ENV_VALIDATE_STATUS" == "passed" ]] || fail "Standalone install with INVOKER_REPO_ROOT override must pass validate-plan; got status=$STANDALONE_ENV_VALIDATE_STATUS. Full output: $STANDALONE_ENV_OUTPUT"
+STANDALONE_ENV_REVIEW_UNITS_STATUS="$(printf '%s' "$STANDALONE_ENV_OUTPUT" | node -e '
+  const raw = require("node:fs").readFileSync(0, "utf8");
+  const report = JSON.parse(raw);
+  const check = report.checks.find((c) => c.stepId === process.argv[1]);
+  process.stdout.write(check ? String(check.status) : "missing");
+' "lint-review-units")"
+[[ "$STANDALONE_ENV_REVIEW_UNITS_STATUS" == "passed" ]] || fail "Standalone install with INVOKER_REPO_ROOT override must pass lint-review-units; got status=$STANDALONE_ENV_REVIEW_UNITS_STATUS. Full output: $STANDALONE_ENV_OUTPUT"
+
+# With the bundled-skills manifest recording the source checkout (what
+# `installBundledSkills()` now writes on every install/reinstall), both
+# validate-plan and lint-review-units must pass standalone with no env var set —
+# the ordinary case for an agent working in a non-Invoker repo after running
+# `scripts/setup-agent-skills.sh` once.
+cat > "$STANDALONE_INVOKER_HOME/bundled-skills.json" <<EOF
+{"sourceRepoRoot": "$REPO_ROOT"}
+EOF
+STANDALONE_MANIFEST_OUTPUT="$(cd /tmp && env -u INVOKER_REPO_ROOT INVOKER_DB_DIR="$STANDALONE_INVOKER_HOME" bash "$STANDALONE_DOCTOR" --skip-assumptions "$STANDALONE_FIXTURE" 2>/dev/null || true)"
+STANDALONE_MANIFEST_VALIDATE_STATUS="$(printf '%s' "$STANDALONE_MANIFEST_OUTPUT" | node -e '
+  const raw = require("node:fs").readFileSync(0, "utf8");
+  const report = JSON.parse(raw);
+  const check = report.checks.find((c) => c.stepId === process.argv[1]);
+  process.stdout.write(check ? String(check.status) : "missing");
+' "validate-plan")"
+[[ "$STANDALONE_MANIFEST_VALIDATE_STATUS" == "passed" ]] || fail "Standalone install (via bundled-skills.json sourceRepoRoot) must pass validate-plan; got status=$STANDALONE_MANIFEST_VALIDATE_STATUS. Full output: $STANDALONE_MANIFEST_OUTPUT"
+STANDALONE_MANIFEST_REVIEW_UNITS_STATUS="$(printf '%s' "$STANDALONE_MANIFEST_OUTPUT" | node -e '
+  const raw = require("node:fs").readFileSync(0, "utf8");
+  const report = JSON.parse(raw);
+  const check = report.checks.find((c) => c.stepId === process.argv[1]);
+  process.stdout.write(check ? String(check.status) : "missing");
+' "lint-review-units")"
+[[ "$STANDALONE_MANIFEST_REVIEW_UNITS_STATUS" == "passed" ]] || fail "Standalone install (via bundled-skills.json sourceRepoRoot) must pass lint-review-units; got status=$STANDALONE_MANIFEST_REVIEW_UNITS_STATUS. Full output: $STANDALONE_MANIFEST_OUTPUT"
+
+rm -rf "$STANDALONE_INSTALL_DIR" "$STANDALONE_INVOKER_HOME"
+trap - EXIT
+
+echo "OK: skill-doctor works from a machine-level standalone install (outside any git checkout)"
+
 # Playbook — Phase 1a / 1b focused lanes and anti-patterns
 must_contain "$PLAYBOOK" "### Phase 1a — Static analysis" "Playbook must define Phase 1a"
 must_contain "$PLAYBOOK" "### Phase 1b — Runtime verification" "Playbook must define runtime behavioral verification"

--- a/skills/plan-to-invoker/scripts/lint-review-units.mjs
+++ b/skills/plan-to-invoker/scripts/lint-review-units.mjs
@@ -2,21 +2,34 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import {
-  getLabelSection,
-  validateChangeTypeItems,
-  validateSingleReviewUnitFocus,
-} from '../../../scripts/review-unit-rules.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-function resolveYamlModulePath(scriptDir) {
+/**
+ * Locate the Invoker checkout that owns this doctor script. Checked in order:
+ * 1. `INVOKER_REPO_ROOT` (explicit override, same convention used elsewhere
+ *    in the app, e.g. packages/contracts/src/repo-root.ts).
+ * 2. The local relative path (this script running from inside a live
+ *    Invoker checkout or worktree).
+ * 3. The shared checkout behind a linked git worktree's common dir.
+ * 4. `sourceRepoRoot` recorded in ~/.invoker/bundled-skills.json by the last
+ *    `scripts/setup-agent-skills.sh` install — needed when this script is
+ *    running from a machine-level skill install (e.g.
+ *    ~/.claude/skills/invoker-plan-to-invoker/scripts), which ships outside
+ *    any git repository and can't resolve steps 2-3.
+ */
+function resolveInvokerRepoRoot(scriptDir) {
+  const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
+
+  const envRoot = process.env.INVOKER_REPO_ROOT;
+  if (envRoot && hasWorkspaceMarker(envRoot)) return resolve(envRoot);
+
   const localRepoRoot = resolve(scriptDir, '../../..');
-  const localYamlPath = resolve(localRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-  if (existsSync(localYamlPath)) return localYamlPath;
+  if (hasWorkspaceMarker(localRepoRoot)) return localRepoRoot;
 
   try {
     const gitCommonDir = execSync('git rev-parse --git-common-dir', {
@@ -25,18 +38,50 @@ function resolveYamlModulePath(scriptDir) {
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
     const sharedRepoRoot = resolve(scriptDir, gitCommonDir, '..');
-    const sharedYamlPath = resolve(sharedRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-    if (existsSync(sharedYamlPath)) return sharedYamlPath;
+    if (hasWorkspaceMarker(sharedRepoRoot)) return sharedRepoRoot;
   } catch {
-    // Fall through to the explicit error below.
+    // Fall through to the manifest-based lookup below.
   }
 
+  try {
+    const invokerHome = process.env.INVOKER_DB_DIR ?? resolve(homedir(), '.invoker');
+    const manifestPath = resolve(invokerHome, 'bundled-skills.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    if (typeof manifest.sourceRepoRoot === 'string' && hasWorkspaceMarker(manifest.sourceRepoRoot)) {
+      return resolve(manifest.sourceRepoRoot);
+    }
+  } catch {
+    // Fall through to the explicit error at the call site.
+  }
+
+  return null;
+}
+
+const invokerRepoRoot = resolveInvokerRepoRoot(__dirname);
+if (!invokerRepoRoot) {
   throw new Error(
-    'Unable to resolve yaml runtime. Checked packages/app/node_modules/yaml/dist/index.js in the current worktree and the shared git checkout.',
+    'Unable to resolve the Invoker checkout for this doctor script (checked INVOKER_REPO_ROOT, the local '
+    + 'worktree, the shared git checkout, and ~/.invoker/bundled-skills.json). Set INVOKER_REPO_ROOT to an '
+    + "Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so "
+    + '~/.invoker/bundled-skills.json records the source checkout.',
   );
 }
 
-const { parse: parseYaml } = await import(resolveYamlModulePath(__dirname));
+const yamlModulePath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
+if (!existsSync(yamlModulePath)) {
+  throw new Error(`Unable to resolve yaml runtime. Expected it at ${yamlModulePath}.`);
+}
+const { parse: parseYaml } = await import(yamlModulePath);
+
+const reviewUnitRulesPath = resolve(invokerRepoRoot, 'scripts/review-unit-rules.mjs');
+if (!existsSync(reviewUnitRulesPath)) {
+  throw new Error(`Unable to resolve review-unit-rules.mjs. Expected it at ${reviewUnitRulesPath}.`);
+}
+const {
+  getLabelSection,
+  validateChangeTypeItems,
+  validateSingleReviewUnitFocus,
+} = await import(reviewUnitRulesPath);
 
 function reviewFocusTexts(text) {
   return [

--- a/skills/plan-to-invoker/scripts/validate-plan.mjs
+++ b/skills/plan-to-invoker/scripts/validate-plan.mjs
@@ -9,18 +9,34 @@
 
 import { execFileSync, execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, normalize, resolve } from 'node:path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-function resolveYamlModulePath(scriptDir) {
+/**
+ * Locate the Invoker checkout that owns this doctor script. Checked in order:
+ * 1. `INVOKER_REPO_ROOT` (explicit override, same convention used elsewhere
+ *    in the app, e.g. packages/contracts/src/repo-root.ts).
+ * 2. The local relative path (this script running from inside a live
+ *    Invoker checkout or worktree).
+ * 3. The shared checkout behind a linked git worktree's common dir.
+ * 4. `sourceRepoRoot` recorded in ~/.invoker/bundled-skills.json by the last
+ *    `scripts/setup-agent-skills.sh` install — needed when this script is
+ *    running from a machine-level skill install (e.g.
+ *    ~/.claude/skills/invoker-plan-to-invoker/scripts), which ships outside
+ *    any git repository and can't resolve steps 2-3.
+ */
+function resolveInvokerRepoRoot(scriptDir) {
+  const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
+
+  const envRoot = process.env.INVOKER_REPO_ROOT;
+  if (envRoot && hasWorkspaceMarker(envRoot)) return resolve(envRoot);
+
   const localRepoRoot = resolve(scriptDir, '../../..');
-  const localYamlPath = resolve(localRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-  if (existsSync(localYamlPath)) {
-    return localYamlPath;
-  }
+  if (hasWorkspaceMarker(localRepoRoot)) return localRepoRoot;
 
   try {
     const gitCommonDir = execSync('git rev-parse --git-common-dir', {
@@ -29,20 +45,39 @@ function resolveYamlModulePath(scriptDir) {
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
     const sharedRepoRoot = resolve(scriptDir, gitCommonDir, '..');
-    const sharedYamlPath = resolve(sharedRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-    if (existsSync(sharedYamlPath)) {
-      return sharedYamlPath;
-    }
+    if (hasWorkspaceMarker(sharedRepoRoot)) return sharedRepoRoot;
   } catch {
-    // Ignore git lookup failure and fall through to the explicit error below.
+    // Fall through to the manifest-based lookup below.
   }
 
+  try {
+    const invokerHome = process.env.INVOKER_DB_DIR ?? resolve(homedir(), '.invoker');
+    const manifestPath = resolve(invokerHome, 'bundled-skills.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    if (typeof manifest.sourceRepoRoot === 'string' && hasWorkspaceMarker(manifest.sourceRepoRoot)) {
+      return resolve(manifest.sourceRepoRoot);
+    }
+  } catch {
+    // Fall through to the explicit error at the call site.
+  }
+
+  return null;
+}
+
+const invokerRepoRoot = resolveInvokerRepoRoot(__dirname);
+if (!invokerRepoRoot) {
   throw new Error(
-    'Unable to resolve yaml runtime. Checked packages/app/node_modules/yaml/dist/index.js in the current worktree and the shared git checkout.',
+    'Unable to resolve the Invoker checkout for this doctor script (checked INVOKER_REPO_ROOT, the local '
+    + 'worktree, the shared git checkout, and ~/.invoker/bundled-skills.json). Set INVOKER_REPO_ROOT to an '
+    + "Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so "
+    + '~/.invoker/bundled-skills.json records the source checkout.',
   );
 }
 
-const yamlPath = resolveYamlModulePath(__dirname);
+const yamlPath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
+if (!existsSync(yamlPath)) {
+  throw new Error(`Unable to resolve yaml runtime. Expected it at ${yamlPath}.`);
+}
 
 const { parse: parseYaml } = await import(yamlPath);
 

--- a/skills/plan-to-invoker/scripts/validate-plan.sh
+++ b/skills/plan-to-invoker/scripts/validate-plan.sh
@@ -10,10 +10,34 @@ file="${1:?Usage: validate-plan.sh <plan.yaml>}"
 # Run from packages/app directory so ESM can resolve 'yaml' from local node_modules
 # Resolve to the physical script dir so this works via canonical path or symlink.
 script_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-# Resolve repo root from git so this works across layouts/worktrees.
-repo_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+
+# Resolve the Invoker checkout that owns this doctor script. Prefer an
+# explicit override, then a live git checkout (works across layouts and
+# worktrees), then the source checkout recorded by the last
+# `setup-agent-skills.sh` install — needed when running from a machine-level
+# skill install (e.g. ~/.claude/skills/invoker-plan-to-invoker/scripts),
+# which ships outside any git repository and can't resolve via git.
+repo_root="${INVOKER_REPO_ROOT:-}"
 if [[ -z "$repo_root" ]]; then
+  repo_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+if [[ -z "$repo_root" ]]; then
+  invoker_home="${INVOKER_DB_DIR:-$HOME/.invoker}"
+  manifest="$invoker_home/bundled-skills.json"
+  if [[ -f "$manifest" ]] && command -v node &>/dev/null; then
+    repo_root="$(node -e '
+      const fs = require("node:fs");
+      try {
+        const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+        if (typeof manifest.sourceRepoRoot === "string") process.stdout.write(manifest.sourceRepoRoot);
+      } catch {}
+    ' "$manifest" 2>/dev/null || true)"
+  fi
+fi
+
+if [[ -z "$repo_root" || ! -d "$repo_root/packages/app" ]]; then
   echo "Error: could not determine repository root from $script_dir" >&2
+  echo "Set INVOKER_REPO_ROOT to an Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so ~/.invoker/bundled-skills.json records the source checkout." >&2
   exit 1
 fi
 abs_file="$(cd "$(dirname "$file")" && pwd)/$(basename "$file")"


### PR DESCRIPTION
## Summary

Nothing exercised `skill-doctor.sh` (or its plan-schema and unit-lint sub-checks) from anywhere other than a live Invoker checkout, so the fix in this stack had no regression coverage of its own.

This slice adds one: it copies the doctor scripts into a throwaway directory outside any git repository, mirroring the real `~/.claude/skills/invoker-plan-to-invoker/scripts` layout `scripts/setup-agent-skills.sh` produces, and runs the doctor from there.

It checks three things: no fallback fails with an actionable message, not a raw stack trace; `INVOKER_REPO_ROOT` alone makes both sub-checks pass; the manifest's `sourceRepoRoot` alone also makes both pass.

This depends on both earlier slices in this stack. Checked out against unmodified `origin/master`, this same test fails with the original raw errors; with all three slices applied, it passes.

## Review Claim

`scripts/test-plan-to-invoker-skill.sh` should assert the machine-level standalone doctor install actually works, covering both the env-var and manifest fallback paths.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Test-only change to `scripts/test-plan-to-invoker-skill.sh`; every filesystem side effect happens inside `mktemp -d` directories that are removed via `trap ... EXIT`, and it never touches the real `~/.claude` or `~/.invoker` install locations (it points `INVOKER_DB_DIR` at its own temp dir).

## Slice Rationale

`scripts/test-plan-to-invoker-skill.sh` is `scripts/`-prefixed (`tooling-policy` review unit), so it cannot land in the same PR as the earlier `skills/`-scoped or `packages/`-scoped changes, and lands as its own slice, after both since its assertions need them both to pass.

## Non-goals

Does not add coverage for the packaged-Electron install path. Does not change any doctor script behavior — pure test addition.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/test-plan-to-invoker-skill.sh` — full suite, including the new standalone-install regression block, exits 0
- [ ] Before/after proof: `git stash` the fix commits in this stack, re-run the same command — new assertions fail with `could not determine repository root...` and `ERR_MODULE_NOT_FOUND`; `git stash pop` and re-run — passes

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 89afdd5b9e`
- Post-revert steps: None
- Data migration? No

</details>
