### PR TITLE
[Plan Doctor Standalone Install](5) Regression-test the vendored-dependency install shape

### DIFF
--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -307,6 +307,59 @@ trap - EXIT
 
 echo "OK: skill-doctor works from a machine-level standalone install (outside any git checkout)"
 
+# Regression: the vendored copies under skills/plan-to-invoker/scripts/vendor/
+# must stay byte-identical to their sources, so `resolveYamlModulePath` /
+# `resolveReviewUnitRulesModulePath` never silently serve stale logic.
+VENDOR_DIR="$SKILL_DIR/scripts/vendor"
+[[ -f "$VENDOR_DIR/review-unit-rules.mjs" ]] || fail "Missing vendored copy: $VENDOR_DIR/review-unit-rules.mjs (run bash scripts/vendor-plan-doctor-deps.sh)"
+diff -q "$REPO_ROOT/scripts/review-unit-rules.mjs" "$VENDOR_DIR/review-unit-rules.mjs" >/dev/null 2>&1 \
+  || fail "$VENDOR_DIR/review-unit-rules.mjs has drifted from scripts/review-unit-rules.mjs — re-run bash scripts/vendor-plan-doctor-deps.sh"
+[[ -f "$VENDOR_DIR/yaml/index.js" ]] || fail "Missing vendored copy: $VENDOR_DIR/yaml/index.js (run bash scripts/vendor-plan-doctor-deps.sh)"
+[[ -d "$VENDOR_DIR/yaml/lib" ]] || fail "Missing vendored copy: $VENDOR_DIR/yaml/lib (run bash scripts/vendor-plan-doctor-deps.sh)"
+# .gitignore excludes any directory named `dist/`, so vendor-plan-doctor-deps.sh
+# renames yaml's `dist/` to `lib/` and rewrites the one file that references it
+# by name; everything under it is an untouched byte-for-byte copy.
+diff -rq "$REPO_ROOT/packages/app/node_modules/yaml/browser/dist" "$VENDOR_DIR/yaml/lib" >/dev/null 2>&1 \
+  || fail "$VENDOR_DIR/yaml/lib has drifted from packages/app/node_modules/yaml/browser/dist — re-run bash scripts/vendor-plan-doctor-deps.sh"
+diff -q <(sed "s#\./dist/index\.js#./lib/index.js#g" "$REPO_ROOT/packages/app/node_modules/yaml/browser/index.js") "$VENDOR_DIR/yaml/index.js" >/dev/null 2>&1 \
+  || fail "$VENDOR_DIR/yaml/index.js has drifted from packages/app/node_modules/yaml/browser/index.js (beyond the expected dist->lib rename) — re-run bash scripts/vendor-plan-doctor-deps.sh"
+echo "OK: vendored plan-doctor dependencies match their sources"
+
+# Regression: the plan-doctor must work from NOTHING but a copy of
+# skills/plan-to-invoker/ — no git repo, no INVOKER_REPO_ROOT, no
+# ~/.invoker/bundled-skills.json, no packages/, no repo-root scripts/
+# directory. This is exactly the payload scripts/archive-cli-binary.sh and
+# scripts/archive-slack-binary.sh ship next to the compiled invoker-cli /
+# invoker-slack release binaries — an installed binary with no backing
+# Invoker monorepo checkout anywhere on the machine. Before vendoring,
+# validate-plan failed with "could not determine repository root" and
+# lint-review-units failed with ERR_MODULE_NOT_FOUND in this exact layout.
+BARE_INSTALL_DIR="$(mktemp -d)"
+trap 'rm -rf "$BARE_INSTALL_DIR"' EXIT
+cp -R "$SKILL_DIR" "$BARE_INSTALL_DIR/plan-to-invoker"
+BARE_DOCTOR="$BARE_INSTALL_DIR/plan-to-invoker/scripts/skill-doctor.sh"
+BARE_FIXTURE="$POSITIVE_FIXTURE_DIR/02-feature-implementation.yaml"
+BARE_OUTPUT="$(cd /tmp && env -u INVOKER_REPO_ROOT -u INVOKER_DB_DIR bash "$BARE_DOCTOR" --skip-assumptions "$BARE_FIXTURE" 2>/dev/null || true)"
+BARE_VALIDATE_STATUS="$(printf '%s' "$BARE_OUTPUT" | node -e '
+  const raw = require("node:fs").readFileSync(0, "utf8");
+  const report = JSON.parse(raw);
+  const check = report.checks.find((c) => c.stepId === process.argv[1]);
+  process.stdout.write(check ? String(check.status) : "missing");
+' "validate-plan")"
+[[ "$BARE_VALIDATE_STATUS" == "passed" ]] || fail "A bare skills/plan-to-invoker/ copy (no repo, no env var, no manifest) must pass validate-plan; got status=$BARE_VALIDATE_STATUS. Full output: $BARE_OUTPUT"
+BARE_REVIEW_UNITS_STATUS="$(printf '%s' "$BARE_OUTPUT" | node -e '
+  const raw = require("node:fs").readFileSync(0, "utf8");
+  const report = JSON.parse(raw);
+  const check = report.checks.find((c) => c.stepId === process.argv[1]);
+  process.stdout.write(check ? String(check.status) : "missing");
+' "lint-review-units")"
+[[ "$BARE_REVIEW_UNITS_STATUS" == "passed" ]] || fail "A bare skills/plan-to-invoker/ copy (no repo, no env var, no manifest) must pass lint-review-units; got status=$BARE_REVIEW_UNITS_STATUS. Full output: $BARE_OUTPUT"
+
+rm -rf "$BARE_INSTALL_DIR"
+trap - EXIT
+
+echo "OK: skill-doctor works from a bare skills/plan-to-invoker/ copy alone (the invoker-cli/invoker-slack release tarball shape)"
+
 # Playbook — Phase 1a / 1b focused lanes and anti-patterns
 must_contain "$PLAYBOOK" "### Phase 1a — Static analysis" "Playbook must define Phase 1a"
 must_contain "$PLAYBOOK" "### Phase 1b — Runtime verification" "Playbook must define runtime behavioral verification"

--- a/scripts/vendor-plan-doctor-deps.sh
+++ b/scripts/vendor-plan-doctor-deps.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Vendors the plan-doctor's two out-of-tree dependencies into
+# skills/plan-to-invoker/scripts/vendor/, so skill-doctor.sh (and its
+# validate-plan/lint-review-units sub-checks) work from ANY copy of the
+# skills/ directory alone -- including a distributed invoker-cli / invoker-slack
+# release tarball (scripts/archive-cli-binary.sh, scripts/archive-slack-binary.sh),
+# which ship skills/ with no packages/, no node_modules, and no repo-root
+# scripts/ directory alongside it.
+#
+# Vendored:
+#   - the `yaml` npm package (pure JS, no runtime deps, ISC license) --
+#     source of truth is packages/app/node_modules/yaml.
+#   - scripts/review-unit-rules.mjs -- source of truth is this repo's own
+#     scripts/review-unit-rules.mjs, shared by several other repo-root
+#     scripts (validate-pr-body.mjs, check-pr-body-keywords.mjs, etc.), so
+#     it stays canonical at that path and is copied, not moved.
+#
+# Run this whenever the `yaml` dependency is upgraded or
+# scripts/review-unit-rules.mjs changes. scripts/test-plan-to-invoker-skill.sh
+# fails CI if the vendored copies drift from their sources.
+#
+# Usage: bash scripts/vendor-plan-doctor-deps.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+YAML_SOURCE="packages/app/node_modules/yaml"
+VENDOR_DIR="skills/plan-to-invoker/scripts/vendor"
+
+if [ ! -d "$YAML_SOURCE/browser" ]; then
+  echo "FAIL: no $YAML_SOURCE/browser found. Run pnpm install first." >&2
+  exit 1
+fi
+
+YAML_VERSION="$(node -p "require('./$YAML_SOURCE/package.json').version")"
+
+rm -rf "$VENDOR_DIR/yaml"
+mkdir -p "$VENDOR_DIR/yaml"
+cp -R "$YAML_SOURCE/browser/." "$VENDOR_DIR/yaml/"
+cp "$YAML_SOURCE/LICENSE" "$VENDOR_DIR/yaml/LICENSE"
+
+# The repo's root .gitignore excludes any directory named `dist/` (build
+# output), which would silently swallow this vendored copy's `dist/` folder
+# on every commit. Rename it and fix the one file that references it by
+# that name -- internal imports within the folder are all sibling-relative
+# and don't care what the folder itself is called.
+mv "$VENDOR_DIR/yaml/dist" "$VENDOR_DIR/yaml/lib"
+sed -i.bak "s#\./dist/index\.js#./lib/index.js#g" "$VENDOR_DIR/yaml/index.js"
+rm -f "$VENDOR_DIR/yaml/index.js.bak"
+
+cat > "$VENDOR_DIR/yaml/.vendor-source.json" <<JSON
+{
+  "source": "yaml",
+  "sourceRegistry": "https://www.npmjs.com/package/yaml",
+  "sourceVersion": "$YAML_VERSION",
+  "sourceLocalPath": "$YAML_SOURCE/browser",
+  "vendoredAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+JSON
+
+cp scripts/review-unit-rules.mjs "$VENDOR_DIR/review-unit-rules.mjs"
+
+echo "Vendored yaml@$YAML_VERSION and review-unit-rules.mjs into $VENDOR_DIR/"


### PR DESCRIPTION
## Summary

Nothing proved the previous slice's vendored copies stay in sync with their sources, or that the doctor actually works from nothing but a bare copy of `skills/plan-to-invoker/`.

That bare-copy shape is exactly what the real release packaging ships next to a compiled standalone binary — no monorepo, no environment override, no local manifest.

This slice adds the tool that produced the previous slice's vendored files, so it's reproducible. It adds two checks: a byte-for-byte comparison against both sources, and a full doctor run from an isolated directory holding only that one skill folder.

Checked against the four earlier slices alone (no vendoring), that isolated run still failed with the original raw errors; with this slice, it passes.

## Review Claim

A regression test should prove the doctor works from an isolated copy of `skills/plan-to-invoker/` alone, and that its vendored dependencies stay byte-identical to their sources.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Test-only change plus one new standalone shell tool. Every filesystem side effect in the new test happens inside `mktemp -d` directories removed via `trap ... EXIT`; the vendoring tool only ever writes under `skills/plan-to-invoker/scripts/vendor/`, never outside the checkout.

## Slice Rationale

`scripts/vendor-plan-doctor-deps.sh` and the `scripts/test-plan-to-invoker-skill.sh` additions are `scripts/`-prefixed (`tooling-policy` review unit), so they cannot land in the same PR as the `docs`-scoped vendored files from the previous slice, and land here instead, after it, since these checks need those files to already exist.

## Non-goals

Does not cover the packaged-Electron install shape. Does not change any doctor script behavior — pure tooling and test addition.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/test-plan-to-invoker-skill.sh` — full suite, including both new checks, exits 0
- [ ] Before/after proof: with only the first four slices of this stack applied (no vendored copies), the same isolated-directory run fails with `could not determine repository root` and `ERR_MODULE_NOT_FOUND`; with this slice, it passes

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 646ed9a5f7`
- Post-revert steps: None
- Data migration? No

</details>
