### PR TITLE
[Plan Doctor Standalone Install](5) Resolve yaml via bare import, review-unit-rules.mjs via vendoring

### DIFF
--- a/skills/plan-to-invoker/scripts/lint-review-units.mjs
+++ b/skills/plan-to-invoker/scripts/lint-review-units.mjs
@@ -10,17 +10,18 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 /**
- * Locate the Invoker checkout that owns this doctor script. Checked in order:
+ * Locate the Invoker checkout that owns this doctor script, for
+ * `review-unit-rules.mjs` when it isn't already vendored under ./vendor
+ * (dev-convenience fallback — see resolveReviewUnitRulesModulePath below) and
+ * for `yaml` when it isn't resolvable as a real installed dependency (see
+ * resolveYamlModulePath below). Checked in order:
  * 1. `INVOKER_REPO_ROOT` (explicit override, same convention used elsewhere
  *    in the app, e.g. packages/contracts/src/repo-root.ts).
  * 2. The local relative path (this script running from inside a live
  *    Invoker checkout or worktree).
  * 3. The shared checkout behind a linked git worktree's common dir.
  * 4. `sourceRepoRoot` recorded in ~/.invoker/bundled-skills.json by the last
- *    `scripts/setup-agent-skills.sh` install — needed when this script is
- *    running from a machine-level skill install (e.g.
- *    ~/.claude/skills/invoker-plan-to-invoker/scripts), which ships outside
- *    any git repository and can't resolve steps 2-3.
+ *    `scripts/setup-agent-skills.sh` install.
  */
 function resolveInvokerRepoRoot(scriptDir) {
   const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
@@ -57,31 +58,74 @@ function resolveInvokerRepoRoot(scriptDir) {
   return null;
 }
 
-const invokerRepoRoot = resolveInvokerRepoRoot(__dirname);
-if (!invokerRepoRoot) {
+/**
+ * `yaml` is a real declared dependency of the published `invoker-cli` npm
+ * package (packages/npm-cli/package.json), so when this script runs from
+ * inside that package's install (npm places `yaml` in an ancestor
+ * node_modules, e.g. <install-root>/node_modules/yaml sitting above
+ * <install-root>/vendor/skills/plan-to-invoker/scripts), a plain bare
+ * import resolves it via Node's own module resolution — no custom path
+ * logic needed. Fall back to locating a real Invoker checkout only when
+ * that fails, e.g. a machine-level skill install (~/.claude/skills/...)
+ * copied via `installBundledSkills()`, which has no such node_modules
+ * anywhere nearby.
+ */
+async function importYaml(scriptDir) {
+  try {
+    return await import('yaml');
+  } catch {
+    // Fall through to the checkout-based lookup below.
+  }
+
+  const invokerRepoRoot = resolveInvokerRepoRoot(scriptDir);
+  if (invokerRepoRoot) {
+    const repoYamlPath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
+    if (existsSync(repoYamlPath)) return import(repoYamlPath);
+  }
+
   throw new Error(
-    'Unable to resolve the Invoker checkout for this doctor script (checked INVOKER_REPO_ROOT, the local '
-    + 'worktree, the shared git checkout, and ~/.invoker/bundled-skills.json). Set INVOKER_REPO_ROOT to an '
-    + "Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so "
-    + '~/.invoker/bundled-skills.json records the source checkout.',
+    "Unable to resolve yaml runtime. Checked a plain 'yaml' import (present if this script is "
+    + 'running from inside the invoker-cli npm install, which declares it as a real dependency) '
+    + 'and packages/app/node_modules/yaml/dist/index.js in a resolvable Invoker checkout '
+    + '(INVOKER_REPO_ROOT, a live git checkout, or ~/.invoker/bundled-skills.json). Set '
+    + 'INVOKER_REPO_ROOT to an Invoker checkout if neither applies.',
   );
 }
 
-const yamlModulePath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-if (!existsSync(yamlModulePath)) {
-  throw new Error(`Unable to resolve yaml runtime. Expected it at ${yamlModulePath}.`);
-}
-const { parse: parseYaml } = await import(yamlModulePath);
+/**
+ * Primary path: a copy vendored directly under this script's own directory
+ * (./vendor/review-unit-rules.mjs), re-synced by
+ * `bash scripts/vendor-plan-doctor-deps.sh` and drift-tested by
+ * scripts/test-plan-to-invoker-skill.sh. Unlike `yaml`, this file is not a
+ * published npm package -- it's a private helper shared with other
+ * repo-root scripts (validate-pr-body.mjs, etc.) -- so there is no
+ * "declare a dependency" option for it; vendoring is what makes this script
+ * self-sufficient wherever skills/ ends up copied.
+ */
+function resolveReviewUnitRulesModulePath(scriptDir) {
+  const vendoredPath = resolve(scriptDir, 'vendor', 'review-unit-rules.mjs');
+  if (existsSync(vendoredPath)) return vendoredPath;
 
-const reviewUnitRulesPath = resolve(invokerRepoRoot, 'scripts/review-unit-rules.mjs');
-if (!existsSync(reviewUnitRulesPath)) {
-  throw new Error(`Unable to resolve review-unit-rules.mjs. Expected it at ${reviewUnitRulesPath}.`);
+  const invokerRepoRoot = resolveInvokerRepoRoot(scriptDir);
+  if (invokerRepoRoot) {
+    const repoReviewUnitRulesPath = resolve(invokerRepoRoot, 'scripts/review-unit-rules.mjs');
+    if (existsSync(repoReviewUnitRulesPath)) return repoReviewUnitRulesPath;
+  }
+
+  throw new Error(
+    'Unable to resolve review-unit-rules.mjs. Checked ./vendor/review-unit-rules.mjs (run '
+    + "'bash scripts/vendor-plan-doctor-deps.sh' if this checkout is missing it) and "
+    + 'scripts/review-unit-rules.mjs in a resolvable Invoker checkout.',
+  );
 }
+
+const { parse: parseYaml } = await importYaml(__dirname);
+
 const {
   getLabelSection,
   validateChangeTypeItems,
   validateSingleReviewUnitFocus,
-} = await import(reviewUnitRulesPath);
+} = await import(resolveReviewUnitRulesModulePath(__dirname));
 
 function reviewFocusTexts(text) {
   return [

--- a/skills/plan-to-invoker/scripts/validate-plan.mjs
+++ b/skills/plan-to-invoker/scripts/validate-plan.mjs
@@ -17,17 +17,16 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 /**
- * Locate the Invoker checkout that owns this doctor script. Checked in order:
+ * Locate the Invoker checkout that owns this doctor script, for `yaml` when
+ * it isn't resolvable as a real installed dependency. Dev-convenience/other-
+ * install-shape fallback — see importYaml below. Checked in order:
  * 1. `INVOKER_REPO_ROOT` (explicit override, same convention used elsewhere
  *    in the app, e.g. packages/contracts/src/repo-root.ts).
  * 2. The local relative path (this script running from inside a live
  *    Invoker checkout or worktree).
  * 3. The shared checkout behind a linked git worktree's common dir.
  * 4. `sourceRepoRoot` recorded in ~/.invoker/bundled-skills.json by the last
- *    `scripts/setup-agent-skills.sh` install — needed when this script is
- *    running from a machine-level skill install (e.g.
- *    ~/.claude/skills/invoker-plan-to-invoker/scripts), which ships outside
- *    any git repository and can't resolve steps 2-3.
+ *    `scripts/setup-agent-skills.sh` install.
  */
 function resolveInvokerRepoRoot(scriptDir) {
   const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
@@ -64,22 +63,41 @@ function resolveInvokerRepoRoot(scriptDir) {
   return null;
 }
 
-const invokerRepoRoot = resolveInvokerRepoRoot(__dirname);
-if (!invokerRepoRoot) {
+/**
+ * `yaml` is a real declared dependency of the published `invoker-cli` npm
+ * package (packages/npm-cli/package.json), so when this script runs from
+ * inside that package's install (npm places `yaml` in an ancestor
+ * node_modules, e.g. <install-root>/node_modules/yaml sitting above
+ * <install-root>/vendor/skills/plan-to-invoker/scripts), a plain bare
+ * import resolves it via Node's own module resolution — no custom path
+ * logic needed. Fall back to locating a real Invoker checkout only when
+ * that fails, e.g. a machine-level skill install (~/.claude/skills/...)
+ * copied via `installBundledSkills()`, which has no such node_modules
+ * anywhere nearby.
+ */
+async function importYaml(scriptDir) {
+  try {
+    return await import('yaml');
+  } catch {
+    // Fall through to the checkout-based lookup below.
+  }
+
+  const invokerRepoRoot = resolveInvokerRepoRoot(scriptDir);
+  if (invokerRepoRoot) {
+    const repoYamlPath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
+    if (existsSync(repoYamlPath)) return import(repoYamlPath);
+  }
+
   throw new Error(
-    'Unable to resolve the Invoker checkout for this doctor script (checked INVOKER_REPO_ROOT, the local '
-    + 'worktree, the shared git checkout, and ~/.invoker/bundled-skills.json). Set INVOKER_REPO_ROOT to an '
-    + "Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so "
-    + '~/.invoker/bundled-skills.json records the source checkout.',
+    "Unable to resolve yaml runtime. Checked a plain 'yaml' import (present if this script is "
+    + 'running from inside the invoker-cli npm install, which declares it as a real dependency) '
+    + 'and packages/app/node_modules/yaml/dist/index.js in a resolvable Invoker checkout '
+    + '(INVOKER_REPO_ROOT, a live git checkout, or ~/.invoker/bundled-skills.json). Set '
+    + 'INVOKER_REPO_ROOT to an Invoker checkout if neither applies.',
   );
 }
 
-const yamlPath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-if (!existsSync(yamlPath)) {
-  throw new Error(`Unable to resolve yaml runtime. Expected it at ${yamlPath}.`);
-}
-
-const { parse: parseYaml } = await import(yamlPath);
+const { parse: parseYaml } = await importYaml(__dirname);
 
 const VALID_ON_FINISH = ['none', 'merge', 'pull_request'];
 const VALID_MERGE_MODE = ['manual', 'automatic', 'external_review', 'no_op'];

--- a/skills/plan-to-invoker/scripts/validate-plan.sh
+++ b/skills/plan-to-invoker/scripts/validate-plan.sh
@@ -6,41 +6,14 @@ set -euo pipefail
 
 file="${1:?Usage: validate-plan.sh <plan.yaml>}"
 
-# Call typed validator (ESM .mjs - no compilation needed)
-# Run from packages/app directory so ESM can resolve 'yaml' from local node_modules
+# Call typed validator (ESM .mjs - no compilation needed).
 # Resolve to the physical script dir so this works via canonical path or symlink.
 script_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-
-# Resolve the Invoker checkout that owns this doctor script. Prefer an
-# explicit override, then a live git checkout (works across layouts and
-# worktrees), then the source checkout recorded by the last
-# `setup-agent-skills.sh` install — needed when running from a machine-level
-# skill install (e.g. ~/.claude/skills/invoker-plan-to-invoker/scripts),
-# which ships outside any git repository and can't resolve via git.
-repo_root="${INVOKER_REPO_ROOT:-}"
-if [[ -z "$repo_root" ]]; then
-  repo_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || true)"
-fi
-if [[ -z "$repo_root" ]]; then
-  invoker_home="${INVOKER_DB_DIR:-$HOME/.invoker}"
-  manifest="$invoker_home/bundled-skills.json"
-  if [[ -f "$manifest" ]] && command -v node &>/dev/null; then
-    repo_root="$(node -e '
-      const fs = require("node:fs");
-      try {
-        const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-        if (typeof manifest.sourceRepoRoot === "string") process.stdout.write(manifest.sourceRepoRoot);
-      } catch {}
-    ' "$manifest" 2>/dev/null || true)"
-  fi
-fi
-
-if [[ -z "$repo_root" || ! -d "$repo_root/packages/app" ]]; then
-  echo "Error: could not determine repository root from $script_dir" >&2
-  echo "Set INVOKER_REPO_ROOT to an Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so ~/.invoker/bundled-skills.json records the source checkout." >&2
-  exit 1
-fi
 abs_file="$(cd "$(dirname "$file")" && pwd)/$(basename "$file")"
 
-cd "$repo_root/packages/app"
+# validate-plan.mjs resolves its own `yaml` runtime (a plain 'yaml' import,
+# which works when this script is running from inside the invoker-cli npm
+# install -- see packages/npm-cli/package.json's real dependency on yaml --
+# falling back to a resolvable Invoker checkout otherwise). No cwd change
+# or repo-root resolution needed here at all.
 exec node "$script_dir/validate-plan.mjs" "$abs_file"

--- a/skills/plan-to-invoker/scripts/vendor/review-unit-rules.mjs
+++ b/skills/plan-to-invoker/scripts/vendor/review-unit-rules.mjs
@@ -1,0 +1,416 @@
+export const VALID_REVIEW_UNITS = [
+  'contract',
+  'ownership-refactor',
+  'read-path',
+  'validation-policy',
+  'write-path',
+  'routing',
+  'activation-surface',
+  'tooling-policy',
+  'proof',
+  'docs',
+  'cleanup',
+];
+
+const VALID_REVIEW_UNIT_SET = new Set(VALID_REVIEW_UNITS);
+const PRODUCT_REVIEW_UNITS = new Set([
+  'contract',
+  'ownership-refactor',
+  'read-path',
+  'validation-policy',
+  'write-path',
+  'routing',
+  'activation-surface',
+  'cleanup',
+]);
+
+const UNIT_PATTERNS = [
+  ['contract', [
+    /\bcontracts?\b/,
+    /\binterfaces?\b/,
+    /\btypes?\b/,
+    /\bports?\b/,
+    /\bschemas?\b/,
+  ]],
+  ['ownership-refactor', [
+    /\bownership\b/,
+    /\brefactor\b/,
+    /\bextract(?:s|ed|ing)?\b/,
+    /\bsplit(?:s|ting)?\b/,
+    /\bmove(?:s|d)?\b/,
+    /\bmoved\b/,
+  ]],
+  ['read-path', [
+    /\bscan(?:s|ned|ning)?\b/,
+    /\benumerat(?:e|es|ed|ing)\b/,
+    /\blist(?:s|ed|ing)?\b/,
+    /\bdiscover(?:s|ed|ing)?\b/,
+  ]],
+  ['validation-policy', [
+    /\bvalidat(?:e|es|ed|ing|ion)\b/,
+    /\beligib(?:le|ility)\b/,
+    /\bineligible\b/,
+    /\bstale\b/,
+    /\bretr(?:y|ies)\b/,
+    /\bdedupe\b/,
+    /\bdeduplicat(?:e|es|ed|ing|ion)\b/,
+    /\bduplicates?\b/,
+    /\bsuppress(?:es|ed|ing)?\b/,
+    /\bskip(?:s|ped|ping)?\b/,
+    /\breject(?:s|ed|ing)?\b/,
+    /\balready queued\b/,
+    /\bopen fix intents?\b/,
+  ]],
+  ['write-path', [
+    /\bsubmit(?:s|ted|ting)?\b/,
+    /\benqueue(?:s|d|ing)?\b/,
+    /\bcreate(?:s|d|ing)?\s+(?:a\s+)?(?:workflow\s+)?mutation intents?\b/,
+    /\bfix-with-agent\b/,
+  ]],
+  ['routing', [
+    /\broute(?:s|d|ing)?\b/,
+    /\brouting\b/,
+    /\bwakeups?\b/,
+    /\bmessage bus\b/,
+    /\bsubscriptions?\b/,
+    /\blifecycle events?\b/,
+  ]],
+  ['activation-surface', [
+    /\bactivate(?:s|d|ing)?\b/,
+    /\bactivation\b/,
+    /\bexpose(?:s|d|ing)?\b/,
+    /\bheadless\b/,
+    /\bcli\b/,
+    /\bcommands?\b/,
+  ]],
+  ['tooling-policy', [
+    /\bskill-doctor\b/,
+    /\bplan-to-invoker\b/,
+    /\bvalidators?\b/,
+    /\blint(?:er|ing)?\b/,
+    /\bpr bod(?:y|ies)\b/,
+    /\bcreate-pr\b/,
+    /\bmergify\b/,
+    /\bci policy\b/,
+  ]],
+  ['proof', [
+    /\btests?\b/,
+    /\bregression\b/,
+    /\brepros?\b/,
+    /\bbenchmarks?\b/,
+    /\bproof\b/,
+    /\bverification\b/,
+    /\bvisual proof\b/,
+  ]],
+  ['docs', [
+    /\bdocs?\b/,
+    /\bdocumentation\b/,
+    /\breadme\b/,
+    /\bskill\.md\b/,
+  ]],
+  ['cleanup', [
+    /\bcleanup\b/,
+    /\bdelete(?:s|d|ing)?\b/,
+    /\bremove(?:s|d|ing)?\b/,
+    /\bdead code\b/,
+  ]],
+];
+
+const ALLOWED_CHANGE_OPERATIONS = new Set([
+  'create',
+  'modify',
+  'delete',
+  'rename',
+  'move',
+  'config-only',
+  'test-only',
+  'docs-only',
+  'generated',
+  'none',
+]);
+
+const PATH_LIKE = /^(?:packages|scripts|skills|docs|plans|\.github|[A-Za-z0-9_.-]+\/)[^:]+/;
+const APP_SRC_PREFIX = 'packages/app/src/';
+const REVIEW_GATE_PUBLICATION_PATH = 'packages/execution-engine/src/merge-runner.ts';
+const REVIEW_GATE_POLLING_PATH = 'packages/execution-engine/src/task-runner.ts';
+
+
+export function firstMeaningfulLine(value = '') {
+  return String(value)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean) ?? '';
+}
+
+export function getMarkdownSection(body, heading) {
+  const lines = String(body).split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim().toLowerCase() === heading.toLowerCase());
+  if (start === -1) return '';
+
+  const sectionLines = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^##\s+/.test(line.trim())) break;
+    sectionLines.push(line);
+  }
+  return sectionLines.join('\n').trim();
+}
+
+export function getLabelSection(text, label) {
+  const labelPattern = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`(^|\\n)\\s*${labelPattern}:\\s*`, 'i');
+  const match = pattern.exec(String(text));
+  if (!match) return '';
+
+  const start = match.index + match[0].length;
+  const rest = String(text).slice(start);
+  const nextHeading = /\n\s*[A-Za-z][A-Za-z _-]*:\s*/.exec(rest);
+  return (nextHeading ? rest.slice(0, nextHeading.index) : rest).trim();
+}
+
+export function normalizeReviewUnit(value = '') {
+  return firstMeaningfulLine(value).replace(/^[-*]\s*/, '').trim().toLowerCase();
+}
+
+export function detectReviewUnits(text) {
+  const haystack = String(text).toLowerCase();
+  const detected = new Set();
+  for (const [unit, patterns] of UNIT_PATTERNS) {
+    if (patterns.some((pattern) => pattern.test(haystack))) {
+      detected.add(unit);
+    }
+  }
+  return detected;
+}
+
+function includedWorkText(text) {
+  return String(text)
+    .split(/\r?\n/)
+    .filter((line) => !/\b(separate|non-goals?|do not|does not|without|no\s+)\b/i.test(line))
+    .join('\n');
+}
+
+export function validateSingleReviewUnitFocus({ texts = [], context }) {
+  const errors = [];
+
+  const detected = new Set();
+  for (const text of texts) {
+    for (const unit of detectReviewUnits(includedWorkText(text))) {
+      detected.add(unit);
+    }
+  }
+
+  const detectedProductUnits = Array.from(detected).filter((unit) => PRODUCT_REVIEW_UNITS.has(unit));
+  if (detectedProductUnits.length > 1) {
+    errors.push(
+      `${context} mentions multiple review units (${formatReviewUnits(detectedProductUnits)}); split into one conceptual unit per diff/task.`,
+    );
+  }
+
+  if (detected.has('docs') && detectedProductUnits.length > 0) {
+    errors.push(`${context} mixes docs language with product-unit language; split docs from implementation policy.`);
+  }
+
+  return errors;
+}
+
+export function validateReviewUnitValue(reviewUnit, context) {
+  if (!reviewUnit) return [];
+  if (VALID_REVIEW_UNIT_SET.has(reviewUnit)) return [];
+
+  return [`Invalid review unit: ${reviewUnit}. Expected one of ${VALID_REVIEW_UNITS.join(', ')}.`];
+}
+
+export function validateReviewLaneUnitCompatibility({ reviewLane = '', reviewUnit = '', context }) {
+  if (!reviewLane || !VALID_REVIEW_UNIT_SET.has(reviewUnit)) return [];
+
+  const productUnits = new Set([
+    'contract',
+    'ownership-refactor',
+    'read-path',
+    'validation-policy',
+    'write-path',
+    'routing',
+    'activation-surface',
+  ]);
+
+  if ((reviewLane === 'behavior' || reviewLane === 'refactor') && productUnits.has(reviewUnit)) return [];
+  if (reviewLane === 'cleanup' && reviewUnit === 'cleanup') return [];
+  if (reviewLane === 'policy' && reviewUnit === 'tooling-policy') return [];
+  if (reviewLane === 'proof' && reviewUnit === 'proof') return [];
+  if (reviewLane === 'docs' && reviewUnit === 'docs') return [];
+
+  return [`${context} Review Lane "${reviewLane}" is not compatible with Review Unit "${reviewUnit}".`];
+}
+
+export function validateReviewUnitFocus({ declaredReviewUnit, texts = [], context }) {
+  const errors = validateSingleReviewUnitFocus({ texts, context });
+  if (!VALID_REVIEW_UNIT_SET.has(declaredReviewUnit)) return errors;
+
+  const detected = new Set();
+  for (const text of texts) {
+    for (const unit of detectReviewUnits(includedWorkText(text))) {
+      detected.add(unit);
+    }
+  }
+
+  const detectedProductUnits = Array.from(detected).filter((unit) => PRODUCT_REVIEW_UNITS.has(unit));
+  if (detectedProductUnits.length === 1 && PRODUCT_REVIEW_UNITS.has(declaredReviewUnit) && detectedProductUnits[0] !== declaredReviewUnit) {
+    errors.push(
+      `${context} Review Unit "${declaredReviewUnit}" does not match the described ${detectedProductUnits[0]} work.`,
+    );
+  }
+
+  return errors;
+}
+
+export function classifyReviewUnitsForPath(filePath) {
+  const path = String(filePath).replace(/\\/g, '/');
+  const lowerPath = path.toLowerCase();
+  const basename = path.split('/').pop() ?? '';
+
+  if (path.startsWith('scripts/repro/')) return ['proof'];
+  if (
+    path === 'scripts/pr-body-template.md'
+    || path === 'scripts/test-create-pr-visual-proof.mjs'
+    || path.startsWith('scripts/fixtures/')
+  ) return ['tooling-policy'];
+  if (path.startsWith('packages/app/e2e/visual-proof/')) return ['activation-surface'];
+  if (/(benchmark|performance)/.test(lowerPath)) return ['proof'];
+  if (/visual-proof/.test(lowerPath) && path.includes('/e2e/')) return ['proof'];
+  if (
+    path === 'skills/make-pr/SKILL.md'
+    || path === 'skills/plan-to-invoker/SKILL.md'
+    || path === 'skills/land-stack/SKILL.md'
+    || path === 'skills/visual-proof/SKILL.md'
+    || path === 'skills/prove-it/SKILL.md'
+    || path === 'skills/admin-bypass-sweep/SKILL.md'
+  ) return ['tooling-policy'];
+  if (path.startsWith('docs/') || path.startsWith('skills/') || path.endsWith('.md')) return ['docs'];
+  if (path.startsWith('.github/')) return ['tooling-policy'];
+  if (
+    path === 'package.json'
+    || path === 'pnpm-lock.yaml'
+    || /^tsconfig.*\.json$/.test(path)
+    || /^packages\/[^/]+\/package\.json$/.test(path)
+    || /^packages\/[^/]+\/tsconfig.*\.json$/.test(path)
+  ) {
+    return [];
+  }
+  if (path === 'run.sh') return ['tooling-policy'];
+  if (path.startsWith('scripts/')) return ['tooling-policy'];
+  if (
+    path.startsWith('packages/')
+    && (path.includes('/e2e/') || path.includes('/__tests__/') || /\.(spec|test)\.[^.]+$/.test(path))
+  ) {
+    return [];
+  }
+  if (path.startsWith('packages/contracts/')) return ['contract'];
+  if (
+    path.startsWith('packages/cli/')
+    || path.startsWith('packages/npm-cli/')
+    || path.startsWith('packages/npm-ui/bin/')
+    || path.startsWith('packages/ui/')
+    || path.startsWith('packages/app/src/window/')
+    || path === 'packages/app/src/preload.ts'
+    || path === 'packages/app/src/app-menu.ts'
+    || path === 'packages/app/src/headless.ts'
+    || /^packages\/app\/src\/headless-[^/]+\.ts$/.test(path)
+    || path === 'packages/app/src/api-server.ts'
+    || path === 'packages/app/src/workflow-actions.ts'
+    || path === 'packages/app/src/workflow-mutation-facade.ts'
+    || path === 'packages/app/src/web/web-invoker-dispatch.ts'
+    || path.startsWith('packages/app/src/ipc/')
+  ) {
+    return ['activation-surface'];
+  }
+  if (
+    path.startsWith('packages/workflow-core/')
+    || path.startsWith('packages/execution-engine/')
+    || path === 'packages/app/src/launch-dispatcher.ts'
+    || path === 'packages/app/src/global-topup.ts'
+    || path === 'packages/app/src/main.ts'
+    || path === 'packages/app/src/workflow-mutation-facade.ts'
+    || path === 'packages/app/src/headless-standalone-launch-dispatcher.ts'
+  ) {
+    return ['routing'];
+  }
+  if (path.startsWith(APP_SRC_PREFIX) && /(gating|policy|validator|validation|eligibility|config)/.test(basename)) {
+    return ['validation-policy'];
+  }
+  if (path.startsWith(APP_SRC_PREFIX) && /(recovery|scanner|store|persistence)/.test(basename)) {
+    return ['read-path'];
+  }
+  if (path.startsWith(APP_SRC_PREFIX)) return ['routing'];
+  return [];
+}
+
+export function reviewUnitsForChangedFiles(changedFiles = []) {
+  const units = new Set();
+  for (const changedFile of changedFiles) {
+    for (const unit of classifyReviewUnitsForPath(changedFile)) {
+      units.add(unit);
+    }
+  }
+  return VALID_REVIEW_UNITS.filter((unit) => units.has(unit));
+}
+
+export function formatReviewUnits(units) {
+  const unitSet = new Set(units);
+  return VALID_REVIEW_UNITS.filter((unit) => unitSet.has(unit)).join(', ');
+}
+
+export function validateReviewUnitChangedFiles({ declaredReviewUnit, changedFiles = [], context }) {
+  if (!VALID_REVIEW_UNIT_SET.has(declaredReviewUnit) || changedFiles.length === 0) return [];
+
+  const forbidden = reviewUnitsForChangedFiles(changedFiles).filter((unit) => unit !== declaredReviewUnit);
+  if (forbidden.length === 0) return [];
+
+  return [
+    `${context} Review Unit "${declaredReviewUnit}" cannot ship with ${formatReviewUnits(forbidden)} files in the same PR. Split this into one Review Unit per PR.`,
+  ];
+}
+
+export function validateKnownReviewBoundaries({ reviewLane = '', changedFiles = [], context }) {
+  if (!['behavior', 'refactor'].includes(reviewLane) || changedFiles.length === 0) return [];
+
+  const changedFileSet = new Set(changedFiles);
+  if (
+    !changedFileSet.has(REVIEW_GATE_PUBLICATION_PATH)
+    || !changedFileSet.has(REVIEW_GATE_POLLING_PATH)
+  ) {
+    return [];
+  }
+
+  return [
+    `${context} Publication and poll/approval runtime behavior must be split into separate PRs. Do not change ${REVIEW_GATE_PUBLICATION_PATH} and ${REVIEW_GATE_POLLING_PATH} in the same PR.`,
+  ];
+}
+
+export function parseChangeTypeItems(section) {
+  return String(section)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.replace(/^[-*]\s*/, '').trim())
+    .filter(Boolean);
+}
+
+export function validateChangeTypeItems(section, context) {
+  const errors = [];
+  for (const item of parseChangeTypeItems(section)) {
+    const lower = item.toLowerCase();
+    const directOperation = ALLOWED_CHANGE_OPERATIONS.has(lower);
+    const [pathPart, opPart = ''] = item.split(':', 2).map((part) => part.trim());
+    const operation = opPart.toLowerCase().split(/\s+/)[0] ?? '';
+    const pathWithOperation = PATH_LIKE.test(pathPart) && ALLOWED_CHANGE_OPERATIONS.has(operation);
+    if (directOperation || pathWithOperation) continue;
+
+    const detectedUnits = Array.from(detectReviewUnits(item)).filter((unit) => PRODUCT_REVIEW_UNITS.has(unit));
+    if (detectedUnits.length > 0 || /\b(add|implement|wire|route|validate|submit|scan)\b/i.test(item)) {
+      errors.push(
+        `${context} Change types entry "${item}" is conceptual work, not a per-file operation. Use entries like "packages/app/src/file.ts: modify" and keep conceptual work in Review Claim or Slice Rationale.`,
+      );
+    }
+  }
+  return errors;
+}


### PR DESCRIPTION
## Summary

The previous slice declared `yaml` as a real dependency of the published standalone Invoker installer package, but nothing used it yet.

This slice tries a plain `import 'yaml'` first, before the earlier checkout-based fallback chain (`INVOKER_REPO_ROOT`, a live checkout, or the recorded manifest path).

A plain import resolves through Node's own module lookup wherever a real `yaml` install sits above these scripts — no path-guessing code needed for that case.

The checkout-based fallback stays for the case that import can't reach: a machine-level skill install (`~/.claude/skills/...`) with no `node_modules` of its own, sitting on a machine that usually has a real Invoker checkout elsewhere.

The unit-lint sub-check's own private helper file gets a small local copy here too, since there's no npm-package equivalent for it to declare.

## Review Claim

The doctor's two sub-checks should resolve `yaml` through a plain import first, falling back to a checkout lookup, and resolve their private helper file from a small local copy.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Resolution-order change plus one small copied file. The existing checkout-based lookup is unchanged and still runs whenever the new first attempt fails — nothing that worked before stops working.

## Slice Rationale

These files sit under `skills/`, which the review gate scopes separately from the `packages/`-scoped dependency declaration in the previous slice and the `scripts/`-scoped coverage in the next one.

## Non-goals

Does not add coverage proving this works end to end — next slice. Does not change the checkout-based fallback logic itself, only where it sits in the resolution order.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/test-plan-to-invoker-skill.sh` (62/62 fixture tests + full contract suite, unchanged for the existing checkout case)
- [ ] Manual: from a directory with a real `yaml` install as a sibling `node_modules/yaml` and nothing else nearby, run `node validate-plan.mjs <fixture>` — succeeds via the plain import, no environment variable set

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4b94cc0af7`
- Post-revert steps: None (falls back to the previous slices' checkout-lookup-only behavior)
- Data migration? No

</details>
