### PR TITLE
[Plan Doctor Standalone Install](7) Extract skills/ and declare yaml for invoker-slack too

### DIFF
--- a/packages/npm-slack/package.json
+++ b/packages/npm-slack/package.json
@@ -21,6 +21,9 @@
     "postinstall": "node scripts/install.js",
     "test": "node bin/invoker-slack.js --version || true"
   },
+  "dependencies": {
+    "yaml": "^2.8.2"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/npm-slack/scripts/install.js
+++ b/packages/npm-slack/scripts/install.js
@@ -23,6 +23,7 @@ const vendor = join(root, 'vendor');
 const archivePath = join(vendor, asset);
 const sumsPath = join(vendor, 'SHA256SUMS');
 const binaryPath = join(vendor, 'invoker-slack');
+const skillsPath = join(vendor, 'skills');
 
 if (!['darwin', 'linux'].includes(process.platform) || !['x64', 'arm64'].includes(process.arch)) {
   throw new Error(`Unsupported Invoker Slack platform: ${process.platform}-${process.arch}`);
@@ -52,6 +53,7 @@ function expectedHash(sums, name) {
 
 await mkdir(vendor, { recursive: true });
 await rm(binaryPath, { force: true });
+await rm(skillsPath, { force: true, recursive: true });
 await download(`${baseUrl}/SHA256SUMS`, sumsPath);
 await download(`${baseUrl}/${asset}`, archivePath);
 
@@ -66,9 +68,15 @@ if (actual !== expected) {
 }
 
 execFileSync('tar', ['-xzf', archivePath, '-C', vendor], { stdio: 'inherit' });
-const extracted = join(vendor, asset.replace(/\.tar\.gz$/, ''), 'invoker-slack');
+const extractedDir = join(vendor, asset.replace(/\.tar\.gz$/, ''));
+const extracted = join(extractedDir, 'invoker-slack');
 if (!existsSync(extracted)) {
   throw new Error(`Downloaded archive did not contain ${extracted}`);
 }
 execFileSync('cp', [extracted, binaryPath]);
 await chmod(binaryPath, 0o755);
+
+const extractedSkills = join(extractedDir, 'skills');
+if (existsSync(extractedSkills)) {
+  execFileSync('cp', ['-r', extractedSkills, skillsPath]);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,7 +290,11 @@ importers:
         specifier: ^2.8.2
         version: 2.8.2
 
-  packages/npm-slack: {}
+  packages/npm-slack:
+    dependencies:
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
 
   packages/npm-ui:
     dependencies:


### PR DESCRIPTION
## Summary

Slices 4-6 covered the published Invoker standalone terminal installer package. The published Slack manager installer package has the exact same postinstall shape and needed the same two changes.

Its postinstall only ever placed the compiled binary on disk. There was nowhere for the local `skills/` copy to land even after the next slice starts shipping it in the release payload.

This adds the missing extraction step, mirroring the standalone terminal installer's postinstall line for line, and declares `yaml` as a real dependency the same way.

## Review Claim

The Slack manager installer package's postinstall should lay `skills/` down from the release payload, and its `package.json` should declare `yaml` as a real dependency, mirroring the earlier standalone terminal installer fix.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Purely additive: one new extraction step (only runs if the archive contains a `skills/` entry, a no-op today since nothing produces one until the next slice) and one new dependency declaration. Nothing existing changes behavior.

## Slice Rationale

These two files are `packages/`-scoped (`product`), which the review gate keeps separate from the `scripts/`-scoped packaging fix and coverage in the next slice — that fix is what actually makes this extraction step do anything.

## Non-goals

Does not change the release packaging step itself — next slice. Does not add coverage — next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm install --no-frozen-lockfile` (confirms the lockfile entry resolves cleanly)
- [ ] Manual: with the next slice's packaging fix temporarily applied, `bash scripts/e2e-npm-slack-install.sh` — verified in this session, see next slice's proof

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert bb1c4e15dd`
- Post-revert steps: `pnpm install` to update the lockfile back
- Data migration? No

</details>
