### PR TITLE
[Plan Doctor Standalone Install](8) Package skills/ into the invoker-slack release, e2e-prove both binaries

### DIFF
--- a/packages/cli/src/__tests__/bundled-skills.test.ts
+++ b/packages/cli/src/__tests__/bundled-skills.test.ts
@@ -580,4 +580,64 @@ describe('bundled-skills', () => {
       }
     }
   });
+
+  it('records the source checkout in the manifest for the unpackaged CLI install, so installed doctor scripts outside any git repo (e.g. ~/.claude/skills/invoker-plan-to-invoker/scripts) can still resolve their Invoker checkout', () => {
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const cliHome = makeTempRoot('invoker-cli-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = cliHome;
+
+    try {
+      writeSkill(repoRoot, 'plan-to-invoker');
+      writePlanToInvokerCommands(repoRoot);
+
+      installBundledSkills({
+        isPackaged: false,
+        repoRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      });
+
+      const manifest = JSON.parse(readFileSync(join(invokerHomeRoot, 'bundled-skills.json'), 'utf-8'));
+      expect(manifest.sourceRepoRoot).toBe(repoRoot);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('omits sourceRepoRoot for packaged Electron installs, whose resources dir is not a real Invoker checkout', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const codexHome = makeTempRoot('invoker-codex-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = codexHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      writePlanToInvokerCommands(resourcesRoot);
+
+      installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+        isInstalled: allHarnessesInstalled,
+      });
+
+      const manifest = JSON.parse(readFileSync(join(invokerHomeRoot, 'bundled-skills.json'), 'utf-8'));
+      expect(manifest.sourceRepoRoot).toBeUndefined();
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
 });

--- a/packages/npm-cli/package.json
+++ b/packages/npm-cli/package.json
@@ -22,6 +22,9 @@
     "postinstall": "node scripts/install.js",
     "test": "node bin/invoker-cli.js --version || true"
   },
+  "dependencies": {
+    "yaml": "^2.8.2"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/npm-slack/package.json
+++ b/packages/npm-slack/package.json
@@ -21,6 +21,9 @@
     "postinstall": "node scripts/install.js",
     "test": "node bin/invoker-slack.js --version || true"
   },
+  "dependencies": {
+    "yaml": "^2.8.2"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/npm-slack/scripts/install.js
+++ b/packages/npm-slack/scripts/install.js
@@ -23,6 +23,7 @@ const vendor = join(root, 'vendor');
 const archivePath = join(vendor, asset);
 const sumsPath = join(vendor, 'SHA256SUMS');
 const binaryPath = join(vendor, 'invoker-slack');
+const skillsPath = join(vendor, 'skills');
 
 if (!['darwin', 'linux'].includes(process.platform) || !['x64', 'arm64'].includes(process.arch)) {
   throw new Error(`Unsupported Invoker Slack platform: ${process.platform}-${process.arch}`);
@@ -52,6 +53,7 @@ function expectedHash(sums, name) {
 
 await mkdir(vendor, { recursive: true });
 await rm(binaryPath, { force: true });
+await rm(skillsPath, { force: true, recursive: true });
 await download(`${baseUrl}/SHA256SUMS`, sumsPath);
 await download(`${baseUrl}/${asset}`, archivePath);
 
@@ -66,9 +68,15 @@ if (actual !== expected) {
 }
 
 execFileSync('tar', ['-xzf', archivePath, '-C', vendor], { stdio: 'inherit' });
-const extracted = join(vendor, asset.replace(/\.tar\.gz$/, ''), 'invoker-slack');
+const extractedDir = join(vendor, asset.replace(/\.tar\.gz$/, ''));
+const extracted = join(extractedDir, 'invoker-slack');
 if (!existsSync(extracted)) {
   throw new Error(`Downloaded archive did not contain ${extracted}`);
 }
 execFileSync('cp', [extracted, binaryPath]);
 await chmod(binaryPath, 0o755);
+
+const extractedSkills = join(extractedDir, 'skills');
+if (existsSync(extractedSkills)) {
+  execFileSync('cp', ['-r', extractedSkills, skillsPath]);
+}

--- a/packages/shell/src/bundled-skills.ts
+++ b/packages/shell/src/bundled-skills.ts
@@ -28,6 +28,15 @@ interface BundledSkillsManifest {
   targets: Record<string, { path: string; installedSkillNames: string[] }>;
   commandTargets?: Record<string, { path: string; installedCommandNames: string[] }>;
   mcpTargets?: Record<string, { path: string; serverName: string }>;
+  /**
+   * The Invoker source checkout these skills were bundled from (unset for
+   * packaged Electron builds, whose resources dir isn't a real checkout).
+   * Read by installed doctor scripts (e.g. skills/plan-to-invoker/scripts/
+   * validate-plan.sh, lint-review-units.mjs) as a last-resort fallback when
+   * they're running from a machine-level skill install outside any git repo
+   * and can't resolve their own Invoker checkout via git.
+   */
+  sourceRepoRoot?: string;
 }
 
 interface BundledSkillsContext {
@@ -713,6 +722,7 @@ export function installBundledSkills(
     targets: manifestTargets,
     commandTargets: manifestCommandTargets,
     mcpTargets: manifestMcpTargets,
+    sourceRepoRoot: context.isPackaged ? undefined : context.repoRoot,
   };
 
   writeManifest(invokerHomeRoot, manifest);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,7 +290,11 @@ importers:
         specifier: ^2.8.2
         version: 2.8.2
 
-  packages/npm-slack: {}
+  packages/npm-slack:
+    dependencies:
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
 
   packages/npm-ui:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,7 +284,11 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
 
-  packages/npm-cli: {}
+  packages/npm-cli:
+    dependencies:
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
 
   packages/npm-slack: {}
 

--- a/scripts/archive-slack-binary.sh
+++ b/scripts/archive-slack-binary.sh
@@ -19,6 +19,7 @@ mkdir -p "$STAGE/$NAME"
 cp "$BINARY" "$STAGE/$NAME/invoker-slack"
 chmod +x "$STAGE/$NAME/invoker-slack"
 cp "$ROOT/packages/npm-slack/README.md" "$STAGE/$NAME/README.md"
+cp -r "$ROOT/skills" "$STAGE/$NAME/skills"
 
 (cd "$STAGE" && tar -czf "$RELEASE_DIR/$NAME.tar.gz" "$NAME")
 rm -rf "$STAGE"

--- a/scripts/e2e-npm-cli-install.sh
+++ b/scripts/e2e-npm-cli-install.sh
@@ -97,3 +97,25 @@ node -e "
 "
 
 echo "ok npm install yields working invoker-cli $VERSION (direct bin + ui wrapper + pinned dependency)"
+
+# The plan-doctor scripts ship inside this real npm install's own
+# vendor/skills/ (scripts/archive-cli-binary.sh's payload) with no monorepo,
+# no INVOKER_REPO_ROOT, and no ~/.invoker/bundled-skills.json anywhere near
+# it — the exact shape a cut invoker-cli binary has for anyone who
+# `npm install -g`'d it. Prove the doctor actually runs there, not just that
+# the binary prints a version.
+CLI_INSTALL_ROOT="$PROJECT_DIR/node_modules/@neko-catpital-labs/invoker-cli"
+CLI_DOCTOR="$CLI_INSTALL_ROOT/vendor/skills/plan-to-invoker/scripts/skill-doctor.sh"
+[ -f "$CLI_DOCTOR" ] || fail "npm install did not lay down $CLI_DOCTOR"
+DOCTOR_OUTPUT="$(cd "$SCRATCH" && env -u INVOKER_REPO_ROOT -u INVOKER_DB_DIR bash "$CLI_DOCTOR" --skip-assumptions "$ROOT/skills/plan-to-invoker/fixtures/positive/02-feature-implementation.yaml" 2>/dev/null || true)"
+for step in validate-plan lint-review-units; do
+  STATUS="$(printf '%s' "$DOCTOR_OUTPUT" | node -e '
+    const raw = require("node:fs").readFileSync(0, "utf8");
+    const report = JSON.parse(raw);
+    const check = report.checks.find((c) => c.stepId === process.argv[1]);
+    process.stdout.write(check ? String(check.status) : "missing");
+  ' "$step")"
+  [ "$STATUS" = "passed" ] || fail "real npm-installed invoker-cli doctor step $step did not pass; got status=$STATUS. Full output: $DOCTOR_OUTPUT"
+done
+
+echo "ok the real npm-installed invoker-cli's plan-doctor works (validate-plan + lint-review-units)"

--- a/scripts/e2e-npm-cli-install.sh
+++ b/scripts/e2e-npm-cli-install.sh
@@ -107,7 +107,13 @@ echo "ok npm install yields working invoker-cli $VERSION (direct bin + ui wrappe
 CLI_INSTALL_ROOT="$PROJECT_DIR/node_modules/@neko-catpital-labs/invoker-cli"
 CLI_DOCTOR="$CLI_INSTALL_ROOT/vendor/skills/plan-to-invoker/scripts/skill-doctor.sh"
 [ -f "$CLI_DOCTOR" ] || fail "npm install did not lay down $CLI_DOCTOR"
-DOCTOR_OUTPUT="$(cd "$SCRATCH" && env -u INVOKER_REPO_ROOT -u INVOKER_DB_DIR bash "$CLI_DOCTOR" --skip-assumptions "$ROOT/skills/plan-to-invoker/fixtures/positive/02-feature-implementation.yaml" 2>/dev/null || true)"
+# Isolate HOME and INVOKER_DB_DIR under $SCRATCH: an inherited real
+# ~/.invoker/bundled-skills.json would let the doctor's manifest fallback
+# resolve yaml/scripts via the tester's own monorepo checkout, masking a
+# missing packaged dependency instead of proving the npm install stands alone.
+DOCTOR_HOME="$SCRATCH/doctor-home"
+mkdir -p "$DOCTOR_HOME"
+DOCTOR_OUTPUT="$(cd "$SCRATCH" && env -u INVOKER_REPO_ROOT HOME="$DOCTOR_HOME" INVOKER_DB_DIR="$DOCTOR_HOME/.invoker" bash "$CLI_DOCTOR" --skip-assumptions "$ROOT/skills/plan-to-invoker/fixtures/positive/02-feature-implementation.yaml" 2>/dev/null || true)"
 for step in validate-plan lint-review-units; do
   STATUS="$(printf '%s' "$DOCTOR_OUTPUT" | node -e '
     const raw = require("node:fs").readFileSync(0, "utf8");

--- a/scripts/e2e-npm-slack-install.sh
+++ b/scripts/e2e-npm-slack-install.sh
@@ -73,7 +73,13 @@ ACTUAL_VERSION="$("$PROJECT_DIR/node_modules/.bin/invoker-slack" --version)"
 SLACK_INSTALL_ROOT="$PROJECT_DIR/node_modules/@neko-catpital-labs/invoker-slack"
 SLACK_DOCTOR="$SLACK_INSTALL_ROOT/vendor/skills/plan-to-invoker/scripts/skill-doctor.sh"
 [ -f "$SLACK_DOCTOR" ] || fail "npm install did not lay down $SLACK_DOCTOR"
-DOCTOR_OUTPUT="$(cd "$SCRATCH" && env -u INVOKER_REPO_ROOT -u INVOKER_DB_DIR bash "$SLACK_DOCTOR" --skip-assumptions "$ROOT/skills/plan-to-invoker/fixtures/positive/02-feature-implementation.yaml" 2>/dev/null || true)"
+# Isolate HOME and INVOKER_DB_DIR under $SCRATCH: an inherited real
+# ~/.invoker/bundled-skills.json would let the doctor's manifest fallback
+# resolve yaml/scripts via the tester's own monorepo checkout, masking a
+# missing packaged dependency instead of proving the npm install stands alone.
+DOCTOR_HOME="$SCRATCH/doctor-home"
+mkdir -p "$DOCTOR_HOME"
+DOCTOR_OUTPUT="$(cd "$SCRATCH" && env -u INVOKER_REPO_ROOT HOME="$DOCTOR_HOME" INVOKER_DB_DIR="$DOCTOR_HOME/.invoker" bash "$SLACK_DOCTOR" --skip-assumptions "$ROOT/skills/plan-to-invoker/fixtures/positive/02-feature-implementation.yaml" 2>/dev/null || true)"
 for step in validate-plan lint-review-units; do
   STATUS="$(printf '%s' "$DOCTOR_OUTPUT" | node -e '
     const raw = require("node:fs").readFileSync(0, "utf8");

--- a/scripts/e2e-npm-slack-install.sh
+++ b/scripts/e2e-npm-slack-install.sh
@@ -64,4 +64,24 @@ ACTUAL_VERSION="$("$PROJECT_DIR/node_modules/.bin/invoker-slack" --version)"
 [ -x "$PROJECT_DIR/node_modules/@neko-catpital-labs/invoker-slack/vendor/invoker-slack" ] \
   || fail "invoker-slack postinstall did not install vendor binary"
 
-echo "ok npm install yields working invoker-slack $VERSION"
+# The plan-doctor scripts ship inside this real npm install's own
+# vendor/skills/ (scripts/archive-slack-binary.sh's payload) with no
+# monorepo, no INVOKER_REPO_ROOT, and no ~/.invoker/bundled-skills.json
+# anywhere near it — the exact shape a cut invoker-slack binary has for
+# anyone who `npm install -g`'d it. Prove the doctor actually runs there,
+# not just that the binary and its vendor files exist.
+SLACK_INSTALL_ROOT="$PROJECT_DIR/node_modules/@neko-catpital-labs/invoker-slack"
+SLACK_DOCTOR="$SLACK_INSTALL_ROOT/vendor/skills/plan-to-invoker/scripts/skill-doctor.sh"
+[ -f "$SLACK_DOCTOR" ] || fail "npm install did not lay down $SLACK_DOCTOR"
+DOCTOR_OUTPUT="$(cd "$SCRATCH" && env -u INVOKER_REPO_ROOT -u INVOKER_DB_DIR bash "$SLACK_DOCTOR" --skip-assumptions "$ROOT/skills/plan-to-invoker/fixtures/positive/02-feature-implementation.yaml" 2>/dev/null || true)"
+for step in validate-plan lint-review-units; do
+  STATUS="$(printf '%s' "$DOCTOR_OUTPUT" | node -e '
+    const raw = require("node:fs").readFileSync(0, "utf8");
+    const report = JSON.parse(raw);
+    const check = report.checks.find((c) => c.stepId === process.argv[1]);
+    process.stdout.write(check ? String(check.status) : "missing");
+  ' "$step")"
+  [ "$STATUS" = "passed" ] || fail "real npm-installed invoker-slack doctor step $step did not pass; got status=$STATUS. Full output: $DOCTOR_OUTPUT"
+done
+
+echo "ok npm install yields working invoker-slack $VERSION with a working plan-doctor (validate-plan + lint-review-units)"

--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -240,6 +240,73 @@ must_output_contain "$DOCTOR_HELP" "  1 = one or more checks failed" "skill-doct
 must_output_contain "$DOCTOR_HELP" "  2 = usage/argument error" "skill-doctor --help must expose usage-error exit code"
 must_output_contain "$DOCTOR_HELP" "Output: JSON summary of all checks with pass/fail status" "skill-doctor --help must expose JSON output contract"
 
+# Regression: skill-doctor.sh (and its validate-plan/lint-review-units
+# sub-checks) must work when copied wholesale to a machine-level skill
+# install outside any git checkout — e.g. ~/.claude/skills/invoker-plan-to-invoker,
+# the layout `scripts/setup-agent-skills.sh` produces. Reproduces the bug where
+# an agent planning against a non-Invoker repo had no working doctor: validate-plan.sh
+# resolved its repo root via `git -C <script dir>`, and lint-review-units.mjs
+# statically imported `../../../scripts/review-unit-rules.mjs` — both broke
+# once the scripts' physical location was no longer 3 directories under the
+# Invoker repo root.
+STANDALONE_INSTALL_DIR="$(mktemp -d)"
+STANDALONE_INVOKER_HOME="$(mktemp -d)"
+trap 'rm -rf "$STANDALONE_INSTALL_DIR" "$STANDALONE_INVOKER_HOME"' EXIT
+cp "$REPO_ROOT"/skills/plan-to-invoker/scripts/*.sh "$REPO_ROOT"/skills/plan-to-invoker/scripts/*.mjs "$STANDALONE_INSTALL_DIR/"
+STANDALONE_DOCTOR="$STANDALONE_INSTALL_DIR/skill-doctor.sh"
+STANDALONE_FIXTURE="$POSITIVE_FIXTURE_DIR/02-feature-implementation.yaml"
+
+# Without INVOKER_REPO_ROOT or a bundled-skills manifest, the doctor must fail
+# with an actionable message instead of a raw stack trace or generic error.
+STANDALONE_NO_FALLBACK_OUTPUT="$(cd /tmp && env -u INVOKER_REPO_ROOT INVOKER_DB_DIR="$STANDALONE_INVOKER_HOME" bash "$STANDALONE_DOCTOR" --skip-assumptions "$STANDALONE_FIXTURE" 2>&1 || true)"
+must_output_contain "$STANDALONE_NO_FALLBACK_OUTPUT" "INVOKER_REPO_ROOT" "Standalone doctor without a resolvable repo root must point at the INVOKER_REPO_ROOT override"
+
+# INVOKER_REPO_ROOT must work as an explicit override, without any manifest.
+STANDALONE_ENV_OUTPUT="$(cd /tmp && env -u INVOKER_DB_DIR INVOKER_REPO_ROOT="$REPO_ROOT" bash "$STANDALONE_DOCTOR" --skip-assumptions "$STANDALONE_FIXTURE" 2>/dev/null || true)"
+STANDALONE_ENV_VALIDATE_STATUS="$(printf '%s' "$STANDALONE_ENV_OUTPUT" | node -e '
+  const raw = require("node:fs").readFileSync(0, "utf8");
+  const report = JSON.parse(raw);
+  const check = report.checks.find((c) => c.stepId === process.argv[1]);
+  process.stdout.write(check ? String(check.status) : "missing");
+' "validate-plan")"
+[[ "$STANDALONE_ENV_VALIDATE_STATUS" == "passed" ]] || fail "Standalone install with INVOKER_REPO_ROOT override must pass validate-plan; got status=$STANDALONE_ENV_VALIDATE_STATUS. Full output: $STANDALONE_ENV_OUTPUT"
+STANDALONE_ENV_REVIEW_UNITS_STATUS="$(printf '%s' "$STANDALONE_ENV_OUTPUT" | node -e '
+  const raw = require("node:fs").readFileSync(0, "utf8");
+  const report = JSON.parse(raw);
+  const check = report.checks.find((c) => c.stepId === process.argv[1]);
+  process.stdout.write(check ? String(check.status) : "missing");
+' "lint-review-units")"
+[[ "$STANDALONE_ENV_REVIEW_UNITS_STATUS" == "passed" ]] || fail "Standalone install with INVOKER_REPO_ROOT override must pass lint-review-units; got status=$STANDALONE_ENV_REVIEW_UNITS_STATUS. Full output: $STANDALONE_ENV_OUTPUT"
+
+# With the bundled-skills manifest recording the source checkout (what
+# `installBundledSkills()` now writes on every install/reinstall), both
+# validate-plan and lint-review-units must pass standalone with no env var set —
+# the ordinary case for an agent working in a non-Invoker repo after running
+# `scripts/setup-agent-skills.sh` once.
+cat > "$STANDALONE_INVOKER_HOME/bundled-skills.json" <<EOF
+{"sourceRepoRoot": "$REPO_ROOT"}
+EOF
+STANDALONE_MANIFEST_OUTPUT="$(cd /tmp && env -u INVOKER_REPO_ROOT INVOKER_DB_DIR="$STANDALONE_INVOKER_HOME" bash "$STANDALONE_DOCTOR" --skip-assumptions "$STANDALONE_FIXTURE" 2>/dev/null || true)"
+STANDALONE_MANIFEST_VALIDATE_STATUS="$(printf '%s' "$STANDALONE_MANIFEST_OUTPUT" | node -e '
+  const raw = require("node:fs").readFileSync(0, "utf8");
+  const report = JSON.parse(raw);
+  const check = report.checks.find((c) => c.stepId === process.argv[1]);
+  process.stdout.write(check ? String(check.status) : "missing");
+' "validate-plan")"
+[[ "$STANDALONE_MANIFEST_VALIDATE_STATUS" == "passed" ]] || fail "Standalone install (via bundled-skills.json sourceRepoRoot) must pass validate-plan; got status=$STANDALONE_MANIFEST_VALIDATE_STATUS. Full output: $STANDALONE_MANIFEST_OUTPUT"
+STANDALONE_MANIFEST_REVIEW_UNITS_STATUS="$(printf '%s' "$STANDALONE_MANIFEST_OUTPUT" | node -e '
+  const raw = require("node:fs").readFileSync(0, "utf8");
+  const report = JSON.parse(raw);
+  const check = report.checks.find((c) => c.stepId === process.argv[1]);
+  process.stdout.write(check ? String(check.status) : "missing");
+' "lint-review-units")"
+[[ "$STANDALONE_MANIFEST_REVIEW_UNITS_STATUS" == "passed" ]] || fail "Standalone install (via bundled-skills.json sourceRepoRoot) must pass lint-review-units; got status=$STANDALONE_MANIFEST_REVIEW_UNITS_STATUS. Full output: $STANDALONE_MANIFEST_OUTPUT"
+
+rm -rf "$STANDALONE_INSTALL_DIR" "$STANDALONE_INVOKER_HOME"
+trap - EXIT
+
+echo "OK: skill-doctor works from a machine-level standalone install (outside any git checkout)"
+
 # Playbook — Phase 1a / 1b focused lanes and anti-patterns
 must_contain "$PLAYBOOK" "### Phase 1a — Static analysis" "Playbook must define Phase 1a"
 must_contain "$PLAYBOOK" "### Phase 1b — Runtime verification" "Playbook must define runtime behavioral verification"

--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -307,6 +307,76 @@ trap - EXIT
 
 echo "OK: skill-doctor works from a machine-level standalone install (outside any git checkout)"
 
+# Regression: the vendored copy under skills/plan-to-invoker/scripts/vendor/
+# must stay byte-identical to its source, so `resolveReviewUnitRulesModulePath`
+# never silently serves stale logic.
+VENDOR_DIR="$SKILL_DIR/scripts/vendor"
+[[ -f "$VENDOR_DIR/review-unit-rules.mjs" ]] || fail "Missing vendored copy: $VENDOR_DIR/review-unit-rules.mjs (run bash scripts/vendor-plan-doctor-deps.sh)"
+diff -q "$REPO_ROOT/scripts/review-unit-rules.mjs" "$VENDOR_DIR/review-unit-rules.mjs" >/dev/null 2>&1 \
+  || fail "$VENDOR_DIR/review-unit-rules.mjs has drifted from scripts/review-unit-rules.mjs — re-run bash scripts/vendor-plan-doctor-deps.sh"
+echo "OK: vendored plan-doctor dependency matches its source"
+
+# Regression: both sub-checks must work from the real invoker-cli npm-install
+# shape -- skills/ sitting under <install-root>/vendor/, with a real `yaml`
+# install (npm's declared-dependency placement, not a symlink into a pnpm
+# store) at <install-root>/node_modules/yaml, and nothing else: no git repo,
+# no INVOKER_REPO_ROOT, no ~/.invoker/bundled-skills.json, no packages/, no
+# repo-root scripts/ directory. This is exactly the payload
+# scripts/archive-cli-binary.sh ships next to the compiled invoker-cli
+# release binary, plus the `yaml` dependency packages/npm-cli/package.json
+# now declares, which npm installs into that same install root. It proves:
+# lint-review-units resolves via the vendored review-unit-rules.mjs copy
+# (there's no npm-based alternative for a private, unpublished helper file);
+# validate-plan resolves `yaml` via a plain bare import, walking up to the
+# sibling node_modules/yaml -- Node's own module resolution, no custom path
+# logic, no vendored copy.
+NPM_CLI_INSTALL_ROOT="$(mktemp -d)"
+trap 'rm -rf "$NPM_CLI_INSTALL_ROOT"' EXIT
+mkdir -p "$NPM_CLI_INSTALL_ROOT/node_modules" "$NPM_CLI_INSTALL_ROOT/vendor"
+cp -RL "$REPO_ROOT/packages/app/node_modules/yaml" "$NPM_CLI_INSTALL_ROOT/node_modules/yaml"
+cp -R "$SKILL_DIR" "$NPM_CLI_INSTALL_ROOT/vendor/plan-to-invoker"
+NPM_CLI_DOCTOR="$NPM_CLI_INSTALL_ROOT/vendor/plan-to-invoker/scripts/skill-doctor.sh"
+NPM_CLI_FIXTURE="$POSITIVE_FIXTURE_DIR/02-feature-implementation.yaml"
+NPM_CLI_OUTPUT="$(cd /tmp && env -u INVOKER_REPO_ROOT -u INVOKER_DB_DIR bash "$NPM_CLI_DOCTOR" --skip-assumptions "$NPM_CLI_FIXTURE" 2>/dev/null || true)"
+NPM_CLI_VALIDATE_STATUS="$(printf '%s' "$NPM_CLI_OUTPUT" | node -e '
+  const raw = require("node:fs").readFileSync(0, "utf8");
+  const report = JSON.parse(raw);
+  const check = report.checks.find((c) => c.stepId === process.argv[1]);
+  process.stdout.write(check ? String(check.status) : "missing");
+' "validate-plan")"
+[[ "$NPM_CLI_VALIDATE_STATUS" == "passed" ]] || fail "The invoker-cli npm-install shape (skills/ under vendor/, sibling node_modules/yaml) must pass validate-plan via a plain 'yaml' import; got status=$NPM_CLI_VALIDATE_STATUS. Full output: $NPM_CLI_OUTPUT"
+NPM_CLI_REVIEW_UNITS_STATUS="$(printf '%s' "$NPM_CLI_OUTPUT" | node -e '
+  const raw = require("node:fs").readFileSync(0, "utf8");
+  const report = JSON.parse(raw);
+  const check = report.checks.find((c) => c.stepId === process.argv[1]);
+  process.stdout.write(check ? String(check.status) : "missing");
+' "lint-review-units")"
+[[ "$NPM_CLI_REVIEW_UNITS_STATUS" == "passed" ]] || fail "The invoker-cli npm-install shape (skills/ under vendor/, sibling node_modules/yaml) must pass lint-review-units via the vendored review-unit-rules.mjs; got status=$NPM_CLI_REVIEW_UNITS_STATUS. Full output: $NPM_CLI_OUTPUT"
+
+rm -rf "$NPM_CLI_INSTALL_ROOT"
+trap - EXIT
+
+echo "OK: skill-doctor works from the invoker-cli npm-install shape (yaml as a real declared dependency, review-unit-rules.mjs vendored)"
+
+# Boundary check, not a bug: a skills/plan-to-invoker/ copy with truly
+# nothing else nearby -- no node_modules (so no declared `yaml` dependency
+# to find), no git repo, no INVOKER_REPO_ROOT, no manifest -- correctly
+# fails validate-plan with an actionable message, not a crash. Nothing can
+# make YAML parsing available with zero real dependency and zero checkout
+# present anywhere; this documents that boundary instead of silently
+# dropping coverage of it.
+TOTALLY_BARE_DIR="$(mktemp -d)"
+trap 'rm -rf "$TOTALLY_BARE_DIR"' EXIT
+cp -R "$SKILL_DIR" "$TOTALLY_BARE_DIR/plan-to-invoker"
+TOTALLY_BARE_DOCTOR="$TOTALLY_BARE_DIR/plan-to-invoker/scripts/skill-doctor.sh"
+TOTALLY_BARE_OUTPUT="$(cd /tmp && env -u INVOKER_REPO_ROOT -u INVOKER_DB_DIR bash "$TOTALLY_BARE_DOCTOR" --skip-assumptions "$NPM_CLI_FIXTURE" 2>&1 || true)"
+must_output_contain "$TOTALLY_BARE_OUTPUT" "INVOKER_REPO_ROOT" "A totally bare skills/plan-to-invoker/ copy with no yaml dependency and no checkout anywhere must fail with an actionable message, not a raw stack trace"
+
+rm -rf "$TOTALLY_BARE_DIR"
+trap - EXIT
+
+echo "OK: a totally bare skills/plan-to-invoker/ copy fails informatively, not with a raw crash"
+
 # Playbook — Phase 1a / 1b focused lanes and anti-patterns
 must_contain "$PLAYBOOK" "### Phase 1a — Static analysis" "Playbook must define Phase 1a"
 must_contain "$PLAYBOOK" "### Phase 1b — Runtime verification" "Playbook must define runtime behavioral verification"

--- a/scripts/vendor-plan-doctor-deps.sh
+++ b/scripts/vendor-plan-doctor-deps.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Vendors the plan-doctor's private dependency into
+# skills/plan-to-invoker/scripts/vendor/, so lint-review-units.mjs works from
+# ANY copy of the skills/ directory alone -- including a distributed
+# invoker-cli / invoker-slack release tarball (scripts/archive-cli-binary.sh,
+# scripts/archive-slack-binary.sh), which ship skills/ with no packages/, no
+# node_modules, and no repo-root scripts/ directory alongside it.
+#
+# Vendored: scripts/review-unit-rules.mjs -- source of truth is this repo's
+# own scripts/review-unit-rules.mjs, shared by several other repo-root
+# scripts (validate-pr-body.mjs, check-pr-body-keywords.mjs, etc.), so it
+# stays canonical at that path and is copied, not moved.
+#
+# The doctor's other out-of-tree dependency, the `yaml` npm package, is NOT
+# vendored -- it's a real declared dependency of the published `invoker-cli`
+# npm package (packages/npm-cli/package.json), so a plain `import 'yaml'`
+# resolves it through npm's own install wherever that package lands. See
+# validate-plan.mjs / lint-review-units.mjs for the resolution order.
+#
+# Run this whenever scripts/review-unit-rules.mjs changes.
+# scripts/test-plan-to-invoker-skill.sh fails CI if the vendored copy drifts
+# from its source.
+#
+# Usage: bash scripts/vendor-plan-doctor-deps.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+VENDOR_DIR="skills/plan-to-invoker/scripts/vendor"
+
+cp scripts/review-unit-rules.mjs "$VENDOR_DIR/review-unit-rules.mjs"
+
+echo "Vendored review-unit-rules.mjs into $VENDOR_DIR/"

--- a/skills/plan-to-invoker/scripts/lint-review-units.mjs
+++ b/skills/plan-to-invoker/scripts/lint-review-units.mjs
@@ -10,17 +10,18 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 /**
- * Locate the Invoker checkout that owns this doctor script. Checked in order:
+ * Locate the Invoker checkout that owns this doctor script, for
+ * `review-unit-rules.mjs` when it isn't already vendored under ./vendor
+ * (dev-convenience fallback — see resolveReviewUnitRulesModulePath below) and
+ * for `yaml` when it isn't resolvable as a real installed dependency (see
+ * resolveYamlModulePath below). Checked in order:
  * 1. `INVOKER_REPO_ROOT` (explicit override, same convention used elsewhere
  *    in the app, e.g. packages/contracts/src/repo-root.ts).
  * 2. The local relative path (this script running from inside a live
  *    Invoker checkout or worktree).
  * 3. The shared checkout behind a linked git worktree's common dir.
  * 4. `sourceRepoRoot` recorded in ~/.invoker/bundled-skills.json by the last
- *    `scripts/setup-agent-skills.sh` install — needed when this script is
- *    running from a machine-level skill install (e.g.
- *    ~/.claude/skills/invoker-plan-to-invoker/scripts), which ships outside
- *    any git repository and can't resolve steps 2-3.
+ *    `scripts/setup-agent-skills.sh` install.
  */
 function resolveInvokerRepoRoot(scriptDir) {
   const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
@@ -57,31 +58,74 @@ function resolveInvokerRepoRoot(scriptDir) {
   return null;
 }
 
-const invokerRepoRoot = resolveInvokerRepoRoot(__dirname);
-if (!invokerRepoRoot) {
+/**
+ * `yaml` is a real declared dependency of the published `invoker-cli` npm
+ * package (packages/npm-cli/package.json), so when this script runs from
+ * inside that package's install (npm places `yaml` in an ancestor
+ * node_modules, e.g. <install-root>/node_modules/yaml sitting above
+ * <install-root>/vendor/skills/plan-to-invoker/scripts), a plain bare
+ * import resolves it via Node's own module resolution — no custom path
+ * logic needed. Fall back to locating a real Invoker checkout only when
+ * that fails, e.g. a machine-level skill install (~/.claude/skills/...)
+ * copied via `installBundledSkills()`, which has no such node_modules
+ * anywhere nearby.
+ */
+async function importYaml(scriptDir) {
+  try {
+    return await import('yaml');
+  } catch {
+    // Fall through to the checkout-based lookup below.
+  }
+
+  const invokerRepoRoot = resolveInvokerRepoRoot(scriptDir);
+  if (invokerRepoRoot) {
+    const repoYamlPath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
+    if (existsSync(repoYamlPath)) return import(repoYamlPath);
+  }
+
   throw new Error(
-    'Unable to resolve the Invoker checkout for this doctor script (checked INVOKER_REPO_ROOT, the local '
-    + 'worktree, the shared git checkout, and ~/.invoker/bundled-skills.json). Set INVOKER_REPO_ROOT to an '
-    + "Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so "
-    + '~/.invoker/bundled-skills.json records the source checkout.',
+    "Unable to resolve yaml runtime. Checked a plain 'yaml' import (present if this script is "
+    + 'running from inside the invoker-cli npm install, which declares it as a real dependency) '
+    + 'and packages/app/node_modules/yaml/dist/index.js in a resolvable Invoker checkout '
+    + '(INVOKER_REPO_ROOT, a live git checkout, or ~/.invoker/bundled-skills.json). Set '
+    + 'INVOKER_REPO_ROOT to an Invoker checkout if neither applies.',
   );
 }
 
-const yamlModulePath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-if (!existsSync(yamlModulePath)) {
-  throw new Error(`Unable to resolve yaml runtime. Expected it at ${yamlModulePath}.`);
-}
-const { parse: parseYaml } = await import(yamlModulePath);
+/**
+ * Primary path: a copy vendored directly under this script's own directory
+ * (./vendor/review-unit-rules.mjs), re-synced by
+ * `bash scripts/vendor-plan-doctor-deps.sh` and drift-tested by
+ * scripts/test-plan-to-invoker-skill.sh. Unlike `yaml`, this file is not a
+ * published npm package -- it's a private helper shared with other
+ * repo-root scripts (validate-pr-body.mjs, etc.) -- so there is no
+ * "declare a dependency" option for it; vendoring is what makes this script
+ * self-sufficient wherever skills/ ends up copied.
+ */
+function resolveReviewUnitRulesModulePath(scriptDir) {
+  const vendoredPath = resolve(scriptDir, 'vendor', 'review-unit-rules.mjs');
+  if (existsSync(vendoredPath)) return vendoredPath;
 
-const reviewUnitRulesPath = resolve(invokerRepoRoot, 'scripts/review-unit-rules.mjs');
-if (!existsSync(reviewUnitRulesPath)) {
-  throw new Error(`Unable to resolve review-unit-rules.mjs. Expected it at ${reviewUnitRulesPath}.`);
+  const invokerRepoRoot = resolveInvokerRepoRoot(scriptDir);
+  if (invokerRepoRoot) {
+    const repoReviewUnitRulesPath = resolve(invokerRepoRoot, 'scripts/review-unit-rules.mjs');
+    if (existsSync(repoReviewUnitRulesPath)) return repoReviewUnitRulesPath;
+  }
+
+  throw new Error(
+    'Unable to resolve review-unit-rules.mjs. Checked ./vendor/review-unit-rules.mjs (run '
+    + "'bash scripts/vendor-plan-doctor-deps.sh' if this checkout is missing it) and "
+    + 'scripts/review-unit-rules.mjs in a resolvable Invoker checkout.',
+  );
 }
+
+const { parse: parseYaml } = await importYaml(__dirname);
+
 const {
   getLabelSection,
   validateChangeTypeItems,
   validateSingleReviewUnitFocus,
-} = await import(reviewUnitRulesPath);
+} = await import(resolveReviewUnitRulesModulePath(__dirname));
 
 function reviewFocusTexts(text) {
   return [

--- a/skills/plan-to-invoker/scripts/lint-review-units.mjs
+++ b/skills/plan-to-invoker/scripts/lint-review-units.mjs
@@ -2,21 +2,34 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import {
-  getLabelSection,
-  validateChangeTypeItems,
-  validateSingleReviewUnitFocus,
-} from '../../../scripts/review-unit-rules.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-function resolveYamlModulePath(scriptDir) {
+/**
+ * Locate the Invoker checkout that owns this doctor script. Checked in order:
+ * 1. `INVOKER_REPO_ROOT` (explicit override, same convention used elsewhere
+ *    in the app, e.g. packages/contracts/src/repo-root.ts).
+ * 2. The local relative path (this script running from inside a live
+ *    Invoker checkout or worktree).
+ * 3. The shared checkout behind a linked git worktree's common dir.
+ * 4. `sourceRepoRoot` recorded in ~/.invoker/bundled-skills.json by the last
+ *    `scripts/setup-agent-skills.sh` install — needed when this script is
+ *    running from a machine-level skill install (e.g.
+ *    ~/.claude/skills/invoker-plan-to-invoker/scripts), which ships outside
+ *    any git repository and can't resolve steps 2-3.
+ */
+function resolveInvokerRepoRoot(scriptDir) {
+  const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
+
+  const envRoot = process.env.INVOKER_REPO_ROOT;
+  if (envRoot && hasWorkspaceMarker(envRoot)) return resolve(envRoot);
+
   const localRepoRoot = resolve(scriptDir, '../../..');
-  const localYamlPath = resolve(localRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-  if (existsSync(localYamlPath)) return localYamlPath;
+  if (hasWorkspaceMarker(localRepoRoot)) return localRepoRoot;
 
   try {
     const gitCommonDir = execSync('git rev-parse --git-common-dir', {
@@ -25,18 +38,50 @@ function resolveYamlModulePath(scriptDir) {
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
     const sharedRepoRoot = resolve(scriptDir, gitCommonDir, '..');
-    const sharedYamlPath = resolve(sharedRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-    if (existsSync(sharedYamlPath)) return sharedYamlPath;
+    if (hasWorkspaceMarker(sharedRepoRoot)) return sharedRepoRoot;
   } catch {
-    // Fall through to the explicit error below.
+    // Fall through to the manifest-based lookup below.
   }
 
+  try {
+    const invokerHome = process.env.INVOKER_DB_DIR ?? resolve(homedir(), '.invoker');
+    const manifestPath = resolve(invokerHome, 'bundled-skills.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    if (typeof manifest.sourceRepoRoot === 'string' && hasWorkspaceMarker(manifest.sourceRepoRoot)) {
+      return resolve(manifest.sourceRepoRoot);
+    }
+  } catch {
+    // Fall through to the explicit error at the call site.
+  }
+
+  return null;
+}
+
+const invokerRepoRoot = resolveInvokerRepoRoot(__dirname);
+if (!invokerRepoRoot) {
   throw new Error(
-    'Unable to resolve yaml runtime. Checked packages/app/node_modules/yaml/dist/index.js in the current worktree and the shared git checkout.',
+    'Unable to resolve the Invoker checkout for this doctor script (checked INVOKER_REPO_ROOT, the local '
+    + 'worktree, the shared git checkout, and ~/.invoker/bundled-skills.json). Set INVOKER_REPO_ROOT to an '
+    + "Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so "
+    + '~/.invoker/bundled-skills.json records the source checkout.',
   );
 }
 
-const { parse: parseYaml } = await import(resolveYamlModulePath(__dirname));
+const yamlModulePath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
+if (!existsSync(yamlModulePath)) {
+  throw new Error(`Unable to resolve yaml runtime. Expected it at ${yamlModulePath}.`);
+}
+const { parse: parseYaml } = await import(yamlModulePath);
+
+const reviewUnitRulesPath = resolve(invokerRepoRoot, 'scripts/review-unit-rules.mjs');
+if (!existsSync(reviewUnitRulesPath)) {
+  throw new Error(`Unable to resolve review-unit-rules.mjs. Expected it at ${reviewUnitRulesPath}.`);
+}
+const {
+  getLabelSection,
+  validateChangeTypeItems,
+  validateSingleReviewUnitFocus,
+} = await import(reviewUnitRulesPath);
 
 function reviewFocusTexts(text) {
   return [

--- a/skills/plan-to-invoker/scripts/validate-plan.mjs
+++ b/skills/plan-to-invoker/scripts/validate-plan.mjs
@@ -9,18 +9,34 @@
 
 import { execFileSync, execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, normalize, resolve } from 'node:path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-function resolveYamlModulePath(scriptDir) {
+/**
+ * Locate the Invoker checkout that owns this doctor script. Checked in order:
+ * 1. `INVOKER_REPO_ROOT` (explicit override, same convention used elsewhere
+ *    in the app, e.g. packages/contracts/src/repo-root.ts).
+ * 2. The local relative path (this script running from inside a live
+ *    Invoker checkout or worktree).
+ * 3. The shared checkout behind a linked git worktree's common dir.
+ * 4. `sourceRepoRoot` recorded in ~/.invoker/bundled-skills.json by the last
+ *    `scripts/setup-agent-skills.sh` install — needed when this script is
+ *    running from a machine-level skill install (e.g.
+ *    ~/.claude/skills/invoker-plan-to-invoker/scripts), which ships outside
+ *    any git repository and can't resolve steps 2-3.
+ */
+function resolveInvokerRepoRoot(scriptDir) {
+  const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
+
+  const envRoot = process.env.INVOKER_REPO_ROOT;
+  if (envRoot && hasWorkspaceMarker(envRoot)) return resolve(envRoot);
+
   const localRepoRoot = resolve(scriptDir, '../../..');
-  const localYamlPath = resolve(localRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-  if (existsSync(localYamlPath)) {
-    return localYamlPath;
-  }
+  if (hasWorkspaceMarker(localRepoRoot)) return localRepoRoot;
 
   try {
     const gitCommonDir = execSync('git rev-parse --git-common-dir', {
@@ -29,20 +45,39 @@ function resolveYamlModulePath(scriptDir) {
       stdio: ['ignore', 'pipe', 'ignore'],
     }).trim();
     const sharedRepoRoot = resolve(scriptDir, gitCommonDir, '..');
-    const sharedYamlPath = resolve(sharedRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-    if (existsSync(sharedYamlPath)) {
-      return sharedYamlPath;
-    }
+    if (hasWorkspaceMarker(sharedRepoRoot)) return sharedRepoRoot;
   } catch {
-    // Ignore git lookup failure and fall through to the explicit error below.
+    // Fall through to the manifest-based lookup below.
   }
 
+  try {
+    const invokerHome = process.env.INVOKER_DB_DIR ?? resolve(homedir(), '.invoker');
+    const manifestPath = resolve(invokerHome, 'bundled-skills.json');
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    if (typeof manifest.sourceRepoRoot === 'string' && hasWorkspaceMarker(manifest.sourceRepoRoot)) {
+      return resolve(manifest.sourceRepoRoot);
+    }
+  } catch {
+    // Fall through to the explicit error at the call site.
+  }
+
+  return null;
+}
+
+const invokerRepoRoot = resolveInvokerRepoRoot(__dirname);
+if (!invokerRepoRoot) {
   throw new Error(
-    'Unable to resolve yaml runtime. Checked packages/app/node_modules/yaml/dist/index.js in the current worktree and the shared git checkout.',
+    'Unable to resolve the Invoker checkout for this doctor script (checked INVOKER_REPO_ROOT, the local '
+    + 'worktree, the shared git checkout, and ~/.invoker/bundled-skills.json). Set INVOKER_REPO_ROOT to an '
+    + "Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so "
+    + '~/.invoker/bundled-skills.json records the source checkout.',
   );
 }
 
-const yamlPath = resolveYamlModulePath(__dirname);
+const yamlPath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
+if (!existsSync(yamlPath)) {
+  throw new Error(`Unable to resolve yaml runtime. Expected it at ${yamlPath}.`);
+}
 
 const { parse: parseYaml } = await import(yamlPath);
 

--- a/skills/plan-to-invoker/scripts/validate-plan.mjs
+++ b/skills/plan-to-invoker/scripts/validate-plan.mjs
@@ -17,17 +17,16 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 /**
- * Locate the Invoker checkout that owns this doctor script. Checked in order:
+ * Locate the Invoker checkout that owns this doctor script, for `yaml` when
+ * it isn't resolvable as a real installed dependency. Dev-convenience/other-
+ * install-shape fallback — see importYaml below. Checked in order:
  * 1. `INVOKER_REPO_ROOT` (explicit override, same convention used elsewhere
  *    in the app, e.g. packages/contracts/src/repo-root.ts).
  * 2. The local relative path (this script running from inside a live
  *    Invoker checkout or worktree).
  * 3. The shared checkout behind a linked git worktree's common dir.
  * 4. `sourceRepoRoot` recorded in ~/.invoker/bundled-skills.json by the last
- *    `scripts/setup-agent-skills.sh` install — needed when this script is
- *    running from a machine-level skill install (e.g.
- *    ~/.claude/skills/invoker-plan-to-invoker/scripts), which ships outside
- *    any git repository and can't resolve steps 2-3.
+ *    `scripts/setup-agent-skills.sh` install.
  */
 function resolveInvokerRepoRoot(scriptDir) {
   const hasWorkspaceMarker = (dir) => existsSync(resolve(dir, 'pnpm-workspace.yaml'));
@@ -64,22 +63,41 @@ function resolveInvokerRepoRoot(scriptDir) {
   return null;
 }
 
-const invokerRepoRoot = resolveInvokerRepoRoot(__dirname);
-if (!invokerRepoRoot) {
+/**
+ * `yaml` is a real declared dependency of the published `invoker-cli` npm
+ * package (packages/npm-cli/package.json), so when this script runs from
+ * inside that package's install (npm places `yaml` in an ancestor
+ * node_modules, e.g. <install-root>/node_modules/yaml sitting above
+ * <install-root>/vendor/skills/plan-to-invoker/scripts), a plain bare
+ * import resolves it via Node's own module resolution — no custom path
+ * logic needed. Fall back to locating a real Invoker checkout only when
+ * that fails, e.g. a machine-level skill install (~/.claude/skills/...)
+ * copied via `installBundledSkills()`, which has no such node_modules
+ * anywhere nearby.
+ */
+async function importYaml(scriptDir) {
+  try {
+    return await import('yaml');
+  } catch {
+    // Fall through to the checkout-based lookup below.
+  }
+
+  const invokerRepoRoot = resolveInvokerRepoRoot(scriptDir);
+  if (invokerRepoRoot) {
+    const repoYamlPath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
+    if (existsSync(repoYamlPath)) return import(repoYamlPath);
+  }
+
   throw new Error(
-    'Unable to resolve the Invoker checkout for this doctor script (checked INVOKER_REPO_ROOT, the local '
-    + 'worktree, the shared git checkout, and ~/.invoker/bundled-skills.json). Set INVOKER_REPO_ROOT to an '
-    + "Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so "
-    + '~/.invoker/bundled-skills.json records the source checkout.',
+    "Unable to resolve yaml runtime. Checked a plain 'yaml' import (present if this script is "
+    + 'running from inside the invoker-cli npm install, which declares it as a real dependency) '
+    + 'and packages/app/node_modules/yaml/dist/index.js in a resolvable Invoker checkout '
+    + '(INVOKER_REPO_ROOT, a live git checkout, or ~/.invoker/bundled-skills.json). Set '
+    + 'INVOKER_REPO_ROOT to an Invoker checkout if neither applies.',
   );
 }
 
-const yamlPath = resolve(invokerRepoRoot, 'packages/app/node_modules/yaml/dist/index.js');
-if (!existsSync(yamlPath)) {
-  throw new Error(`Unable to resolve yaml runtime. Expected it at ${yamlPath}.`);
-}
-
-const { parse: parseYaml } = await import(yamlPath);
+const { parse: parseYaml } = await importYaml(__dirname);
 
 const VALID_ON_FINISH = ['none', 'merge', 'pull_request'];
 const VALID_MERGE_MODE = ['manual', 'automatic', 'external_review', 'no_op'];

--- a/skills/plan-to-invoker/scripts/validate-plan.sh
+++ b/skills/plan-to-invoker/scripts/validate-plan.sh
@@ -10,10 +10,34 @@ file="${1:?Usage: validate-plan.sh <plan.yaml>}"
 # Run from packages/app directory so ESM can resolve 'yaml' from local node_modules
 # Resolve to the physical script dir so this works via canonical path or symlink.
 script_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-# Resolve repo root from git so this works across layouts/worktrees.
-repo_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+
+# Resolve the Invoker checkout that owns this doctor script. Prefer an
+# explicit override, then a live git checkout (works across layouts and
+# worktrees), then the source checkout recorded by the last
+# `setup-agent-skills.sh` install — needed when running from a machine-level
+# skill install (e.g. ~/.claude/skills/invoker-plan-to-invoker/scripts),
+# which ships outside any git repository and can't resolve via git.
+repo_root="${INVOKER_REPO_ROOT:-}"
 if [[ -z "$repo_root" ]]; then
+  repo_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+fi
+if [[ -z "$repo_root" ]]; then
+  invoker_home="${INVOKER_DB_DIR:-$HOME/.invoker}"
+  manifest="$invoker_home/bundled-skills.json"
+  if [[ -f "$manifest" ]] && command -v node &>/dev/null; then
+    repo_root="$(node -e '
+      const fs = require("node:fs");
+      try {
+        const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+        if (typeof manifest.sourceRepoRoot === "string") process.stdout.write(manifest.sourceRepoRoot);
+      } catch {}
+    ' "$manifest" 2>/dev/null || true)"
+  fi
+fi
+
+if [[ -z "$repo_root" || ! -d "$repo_root/packages/app" ]]; then
   echo "Error: could not determine repository root from $script_dir" >&2
+  echo "Set INVOKER_REPO_ROOT to an Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so ~/.invoker/bundled-skills.json records the source checkout." >&2
   exit 1
 fi
 abs_file="$(cd "$(dirname "$file")" && pwd)/$(basename "$file")"

--- a/skills/plan-to-invoker/scripts/validate-plan.sh
+++ b/skills/plan-to-invoker/scripts/validate-plan.sh
@@ -6,41 +6,14 @@ set -euo pipefail
 
 file="${1:?Usage: validate-plan.sh <plan.yaml>}"
 
-# Call typed validator (ESM .mjs - no compilation needed)
-# Run from packages/app directory so ESM can resolve 'yaml' from local node_modules
+# Call typed validator (ESM .mjs - no compilation needed).
 # Resolve to the physical script dir so this works via canonical path or symlink.
 script_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-
-# Resolve the Invoker checkout that owns this doctor script. Prefer an
-# explicit override, then a live git checkout (works across layouts and
-# worktrees), then the source checkout recorded by the last
-# `setup-agent-skills.sh` install — needed when running from a machine-level
-# skill install (e.g. ~/.claude/skills/invoker-plan-to-invoker/scripts),
-# which ships outside any git repository and can't resolve via git.
-repo_root="${INVOKER_REPO_ROOT:-}"
-if [[ -z "$repo_root" ]]; then
-  repo_root="$(git -C "$script_dir" rev-parse --show-toplevel 2>/dev/null || true)"
-fi
-if [[ -z "$repo_root" ]]; then
-  invoker_home="${INVOKER_DB_DIR:-$HOME/.invoker}"
-  manifest="$invoker_home/bundled-skills.json"
-  if [[ -f "$manifest" ]] && command -v node &>/dev/null; then
-    repo_root="$(node -e '
-      const fs = require("node:fs");
-      try {
-        const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-        if (typeof manifest.sourceRepoRoot === "string") process.stdout.write(manifest.sourceRepoRoot);
-      } catch {}
-    ' "$manifest" 2>/dev/null || true)"
-  fi
-fi
-
-if [[ -z "$repo_root" || ! -d "$repo_root/packages/app" ]]; then
-  echo "Error: could not determine repository root from $script_dir" >&2
-  echo "Set INVOKER_REPO_ROOT to an Invoker checkout, or reinstall skills with 'bash scripts/setup-agent-skills.sh' so ~/.invoker/bundled-skills.json records the source checkout." >&2
-  exit 1
-fi
 abs_file="$(cd "$(dirname "$file")" && pwd)/$(basename "$file")"
 
-cd "$repo_root/packages/app"
+# validate-plan.mjs resolves its own `yaml` runtime (a plain 'yaml' import,
+# which works when this script is running from inside the invoker-cli npm
+# install -- see packages/npm-cli/package.json's real dependency on yaml --
+# falling back to a resolvable Invoker checkout otherwise). No cwd change
+# or repo-root resolution needed here at all.
 exec node "$script_dir/validate-plan.mjs" "$abs_file"

--- a/skills/plan-to-invoker/scripts/vendor/review-unit-rules.mjs
+++ b/skills/plan-to-invoker/scripts/vendor/review-unit-rules.mjs
@@ -1,0 +1,416 @@
+export const VALID_REVIEW_UNITS = [
+  'contract',
+  'ownership-refactor',
+  'read-path',
+  'validation-policy',
+  'write-path',
+  'routing',
+  'activation-surface',
+  'tooling-policy',
+  'proof',
+  'docs',
+  'cleanup',
+];
+
+const VALID_REVIEW_UNIT_SET = new Set(VALID_REVIEW_UNITS);
+const PRODUCT_REVIEW_UNITS = new Set([
+  'contract',
+  'ownership-refactor',
+  'read-path',
+  'validation-policy',
+  'write-path',
+  'routing',
+  'activation-surface',
+  'cleanup',
+]);
+
+const UNIT_PATTERNS = [
+  ['contract', [
+    /\bcontracts?\b/,
+    /\binterfaces?\b/,
+    /\btypes?\b/,
+    /\bports?\b/,
+    /\bschemas?\b/,
+  ]],
+  ['ownership-refactor', [
+    /\bownership\b/,
+    /\brefactor\b/,
+    /\bextract(?:s|ed|ing)?\b/,
+    /\bsplit(?:s|ting)?\b/,
+    /\bmove(?:s|d)?\b/,
+    /\bmoved\b/,
+  ]],
+  ['read-path', [
+    /\bscan(?:s|ned|ning)?\b/,
+    /\benumerat(?:e|es|ed|ing)\b/,
+    /\blist(?:s|ed|ing)?\b/,
+    /\bdiscover(?:s|ed|ing)?\b/,
+  ]],
+  ['validation-policy', [
+    /\bvalidat(?:e|es|ed|ing|ion)\b/,
+    /\beligib(?:le|ility)\b/,
+    /\bineligible\b/,
+    /\bstale\b/,
+    /\bretr(?:y|ies)\b/,
+    /\bdedupe\b/,
+    /\bdeduplicat(?:e|es|ed|ing|ion)\b/,
+    /\bduplicates?\b/,
+    /\bsuppress(?:es|ed|ing)?\b/,
+    /\bskip(?:s|ped|ping)?\b/,
+    /\breject(?:s|ed|ing)?\b/,
+    /\balready queued\b/,
+    /\bopen fix intents?\b/,
+  ]],
+  ['write-path', [
+    /\bsubmit(?:s|ted|ting)?\b/,
+    /\benqueue(?:s|d|ing)?\b/,
+    /\bcreate(?:s|d|ing)?\s+(?:a\s+)?(?:workflow\s+)?mutation intents?\b/,
+    /\bfix-with-agent\b/,
+  ]],
+  ['routing', [
+    /\broute(?:s|d|ing)?\b/,
+    /\brouting\b/,
+    /\bwakeups?\b/,
+    /\bmessage bus\b/,
+    /\bsubscriptions?\b/,
+    /\blifecycle events?\b/,
+  ]],
+  ['activation-surface', [
+    /\bactivate(?:s|d|ing)?\b/,
+    /\bactivation\b/,
+    /\bexpose(?:s|d|ing)?\b/,
+    /\bheadless\b/,
+    /\bcli\b/,
+    /\bcommands?\b/,
+  ]],
+  ['tooling-policy', [
+    /\bskill-doctor\b/,
+    /\bplan-to-invoker\b/,
+    /\bvalidators?\b/,
+    /\blint(?:er|ing)?\b/,
+    /\bpr bod(?:y|ies)\b/,
+    /\bcreate-pr\b/,
+    /\bmergify\b/,
+    /\bci policy\b/,
+  ]],
+  ['proof', [
+    /\btests?\b/,
+    /\bregression\b/,
+    /\brepros?\b/,
+    /\bbenchmarks?\b/,
+    /\bproof\b/,
+    /\bverification\b/,
+    /\bvisual proof\b/,
+  ]],
+  ['docs', [
+    /\bdocs?\b/,
+    /\bdocumentation\b/,
+    /\breadme\b/,
+    /\bskill\.md\b/,
+  ]],
+  ['cleanup', [
+    /\bcleanup\b/,
+    /\bdelete(?:s|d|ing)?\b/,
+    /\bremove(?:s|d|ing)?\b/,
+    /\bdead code\b/,
+  ]],
+];
+
+const ALLOWED_CHANGE_OPERATIONS = new Set([
+  'create',
+  'modify',
+  'delete',
+  'rename',
+  'move',
+  'config-only',
+  'test-only',
+  'docs-only',
+  'generated',
+  'none',
+]);
+
+const PATH_LIKE = /^(?:packages|scripts|skills|docs|plans|\.github|[A-Za-z0-9_.-]+\/)[^:]+/;
+const APP_SRC_PREFIX = 'packages/app/src/';
+const REVIEW_GATE_PUBLICATION_PATH = 'packages/execution-engine/src/merge-runner.ts';
+const REVIEW_GATE_POLLING_PATH = 'packages/execution-engine/src/task-runner.ts';
+
+
+export function firstMeaningfulLine(value = '') {
+  return String(value)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean) ?? '';
+}
+
+export function getMarkdownSection(body, heading) {
+  const lines = String(body).split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim().toLowerCase() === heading.toLowerCase());
+  if (start === -1) return '';
+
+  const sectionLines = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^##\s+/.test(line.trim())) break;
+    sectionLines.push(line);
+  }
+  return sectionLines.join('\n').trim();
+}
+
+export function getLabelSection(text, label) {
+  const labelPattern = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`(^|\\n)\\s*${labelPattern}:\\s*`, 'i');
+  const match = pattern.exec(String(text));
+  if (!match) return '';
+
+  const start = match.index + match[0].length;
+  const rest = String(text).slice(start);
+  const nextHeading = /\n\s*[A-Za-z][A-Za-z _-]*:\s*/.exec(rest);
+  return (nextHeading ? rest.slice(0, nextHeading.index) : rest).trim();
+}
+
+export function normalizeReviewUnit(value = '') {
+  return firstMeaningfulLine(value).replace(/^[-*]\s*/, '').trim().toLowerCase();
+}
+
+export function detectReviewUnits(text) {
+  const haystack = String(text).toLowerCase();
+  const detected = new Set();
+  for (const [unit, patterns] of UNIT_PATTERNS) {
+    if (patterns.some((pattern) => pattern.test(haystack))) {
+      detected.add(unit);
+    }
+  }
+  return detected;
+}
+
+function includedWorkText(text) {
+  return String(text)
+    .split(/\r?\n/)
+    .filter((line) => !/\b(separate|non-goals?|do not|does not|without|no\s+)\b/i.test(line))
+    .join('\n');
+}
+
+export function validateSingleReviewUnitFocus({ texts = [], context }) {
+  const errors = [];
+
+  const detected = new Set();
+  for (const text of texts) {
+    for (const unit of detectReviewUnits(includedWorkText(text))) {
+      detected.add(unit);
+    }
+  }
+
+  const detectedProductUnits = Array.from(detected).filter((unit) => PRODUCT_REVIEW_UNITS.has(unit));
+  if (detectedProductUnits.length > 1) {
+    errors.push(
+      `${context} mentions multiple review units (${formatReviewUnits(detectedProductUnits)}); split into one conceptual unit per diff/task.`,
+    );
+  }
+
+  if (detected.has('docs') && detectedProductUnits.length > 0) {
+    errors.push(`${context} mixes docs language with product-unit language; split docs from implementation policy.`);
+  }
+
+  return errors;
+}
+
+export function validateReviewUnitValue(reviewUnit, context) {
+  if (!reviewUnit) return [];
+  if (VALID_REVIEW_UNIT_SET.has(reviewUnit)) return [];
+
+  return [`Invalid review unit: ${reviewUnit}. Expected one of ${VALID_REVIEW_UNITS.join(', ')}.`];
+}
+
+export function validateReviewLaneUnitCompatibility({ reviewLane = '', reviewUnit = '', context }) {
+  if (!reviewLane || !VALID_REVIEW_UNIT_SET.has(reviewUnit)) return [];
+
+  const productUnits = new Set([
+    'contract',
+    'ownership-refactor',
+    'read-path',
+    'validation-policy',
+    'write-path',
+    'routing',
+    'activation-surface',
+  ]);
+
+  if ((reviewLane === 'behavior' || reviewLane === 'refactor') && productUnits.has(reviewUnit)) return [];
+  if (reviewLane === 'cleanup' && reviewUnit === 'cleanup') return [];
+  if (reviewLane === 'policy' && reviewUnit === 'tooling-policy') return [];
+  if (reviewLane === 'proof' && reviewUnit === 'proof') return [];
+  if (reviewLane === 'docs' && reviewUnit === 'docs') return [];
+
+  return [`${context} Review Lane "${reviewLane}" is not compatible with Review Unit "${reviewUnit}".`];
+}
+
+export function validateReviewUnitFocus({ declaredReviewUnit, texts = [], context }) {
+  const errors = validateSingleReviewUnitFocus({ texts, context });
+  if (!VALID_REVIEW_UNIT_SET.has(declaredReviewUnit)) return errors;
+
+  const detected = new Set();
+  for (const text of texts) {
+    for (const unit of detectReviewUnits(includedWorkText(text))) {
+      detected.add(unit);
+    }
+  }
+
+  const detectedProductUnits = Array.from(detected).filter((unit) => PRODUCT_REVIEW_UNITS.has(unit));
+  if (detectedProductUnits.length === 1 && PRODUCT_REVIEW_UNITS.has(declaredReviewUnit) && detectedProductUnits[0] !== declaredReviewUnit) {
+    errors.push(
+      `${context} Review Unit "${declaredReviewUnit}" does not match the described ${detectedProductUnits[0]} work.`,
+    );
+  }
+
+  return errors;
+}
+
+export function classifyReviewUnitsForPath(filePath) {
+  const path = String(filePath).replace(/\\/g, '/');
+  const lowerPath = path.toLowerCase();
+  const basename = path.split('/').pop() ?? '';
+
+  if (path.startsWith('scripts/repro/')) return ['proof'];
+  if (
+    path === 'scripts/pr-body-template.md'
+    || path === 'scripts/test-create-pr-visual-proof.mjs'
+    || path.startsWith('scripts/fixtures/')
+  ) return ['tooling-policy'];
+  if (path.startsWith('packages/app/e2e/visual-proof/')) return ['activation-surface'];
+  if (/(benchmark|performance)/.test(lowerPath)) return ['proof'];
+  if (/visual-proof/.test(lowerPath) && path.includes('/e2e/')) return ['proof'];
+  if (
+    path === 'skills/make-pr/SKILL.md'
+    || path === 'skills/plan-to-invoker/SKILL.md'
+    || path === 'skills/land-stack/SKILL.md'
+    || path === 'skills/visual-proof/SKILL.md'
+    || path === 'skills/prove-it/SKILL.md'
+    || path === 'skills/admin-bypass-sweep/SKILL.md'
+  ) return ['tooling-policy'];
+  if (path.startsWith('docs/') || path.startsWith('skills/') || path.endsWith('.md')) return ['docs'];
+  if (path.startsWith('.github/')) return ['tooling-policy'];
+  if (
+    path === 'package.json'
+    || path === 'pnpm-lock.yaml'
+    || /^tsconfig.*\.json$/.test(path)
+    || /^packages\/[^/]+\/package\.json$/.test(path)
+    || /^packages\/[^/]+\/tsconfig.*\.json$/.test(path)
+  ) {
+    return [];
+  }
+  if (path === 'run.sh') return ['tooling-policy'];
+  if (path.startsWith('scripts/')) return ['tooling-policy'];
+  if (
+    path.startsWith('packages/')
+    && (path.includes('/e2e/') || path.includes('/__tests__/') || /\.(spec|test)\.[^.]+$/.test(path))
+  ) {
+    return [];
+  }
+  if (path.startsWith('packages/contracts/')) return ['contract'];
+  if (
+    path.startsWith('packages/cli/')
+    || path.startsWith('packages/npm-cli/')
+    || path.startsWith('packages/npm-ui/bin/')
+    || path.startsWith('packages/ui/')
+    || path.startsWith('packages/app/src/window/')
+    || path === 'packages/app/src/preload.ts'
+    || path === 'packages/app/src/app-menu.ts'
+    || path === 'packages/app/src/headless.ts'
+    || /^packages\/app\/src\/headless-[^/]+\.ts$/.test(path)
+    || path === 'packages/app/src/api-server.ts'
+    || path === 'packages/app/src/workflow-actions.ts'
+    || path === 'packages/app/src/workflow-mutation-facade.ts'
+    || path === 'packages/app/src/web/web-invoker-dispatch.ts'
+    || path.startsWith('packages/app/src/ipc/')
+  ) {
+    return ['activation-surface'];
+  }
+  if (
+    path.startsWith('packages/workflow-core/')
+    || path.startsWith('packages/execution-engine/')
+    || path === 'packages/app/src/launch-dispatcher.ts'
+    || path === 'packages/app/src/global-topup.ts'
+    || path === 'packages/app/src/main.ts'
+    || path === 'packages/app/src/workflow-mutation-facade.ts'
+    || path === 'packages/app/src/headless-standalone-launch-dispatcher.ts'
+  ) {
+    return ['routing'];
+  }
+  if (path.startsWith(APP_SRC_PREFIX) && /(gating|policy|validator|validation|eligibility|config)/.test(basename)) {
+    return ['validation-policy'];
+  }
+  if (path.startsWith(APP_SRC_PREFIX) && /(recovery|scanner|store|persistence)/.test(basename)) {
+    return ['read-path'];
+  }
+  if (path.startsWith(APP_SRC_PREFIX)) return ['routing'];
+  return [];
+}
+
+export function reviewUnitsForChangedFiles(changedFiles = []) {
+  const units = new Set();
+  for (const changedFile of changedFiles) {
+    for (const unit of classifyReviewUnitsForPath(changedFile)) {
+      units.add(unit);
+    }
+  }
+  return VALID_REVIEW_UNITS.filter((unit) => units.has(unit));
+}
+
+export function formatReviewUnits(units) {
+  const unitSet = new Set(units);
+  return VALID_REVIEW_UNITS.filter((unit) => unitSet.has(unit)).join(', ');
+}
+
+export function validateReviewUnitChangedFiles({ declaredReviewUnit, changedFiles = [], context }) {
+  if (!VALID_REVIEW_UNIT_SET.has(declaredReviewUnit) || changedFiles.length === 0) return [];
+
+  const forbidden = reviewUnitsForChangedFiles(changedFiles).filter((unit) => unit !== declaredReviewUnit);
+  if (forbidden.length === 0) return [];
+
+  return [
+    `${context} Review Unit "${declaredReviewUnit}" cannot ship with ${formatReviewUnits(forbidden)} files in the same PR. Split this into one Review Unit per PR.`,
+  ];
+}
+
+export function validateKnownReviewBoundaries({ reviewLane = '', changedFiles = [], context }) {
+  if (!['behavior', 'refactor'].includes(reviewLane) || changedFiles.length === 0) return [];
+
+  const changedFileSet = new Set(changedFiles);
+  if (
+    !changedFileSet.has(REVIEW_GATE_PUBLICATION_PATH)
+    || !changedFileSet.has(REVIEW_GATE_POLLING_PATH)
+  ) {
+    return [];
+  }
+
+  return [
+    `${context} Publication and poll/approval runtime behavior must be split into separate PRs. Do not change ${REVIEW_GATE_PUBLICATION_PATH} and ${REVIEW_GATE_POLLING_PATH} in the same PR.`,
+  ];
+}
+
+export function parseChangeTypeItems(section) {
+  return String(section)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.replace(/^[-*]\s*/, '').trim())
+    .filter(Boolean);
+}
+
+export function validateChangeTypeItems(section, context) {
+  const errors = [];
+  for (const item of parseChangeTypeItems(section)) {
+    const lower = item.toLowerCase();
+    const directOperation = ALLOWED_CHANGE_OPERATIONS.has(lower);
+    const [pathPart, opPart = ''] = item.split(':', 2).map((part) => part.trim());
+    const operation = opPart.toLowerCase().split(/\s+/)[0] ?? '';
+    const pathWithOperation = PATH_LIKE.test(pathPart) && ALLOWED_CHANGE_OPERATIONS.has(operation);
+    if (directOperation || pathWithOperation) continue;
+
+    const detectedUnits = Array.from(detectReviewUnits(item)).filter((unit) => PRODUCT_REVIEW_UNITS.has(unit));
+    if (detectedUnits.length > 0 || /\b(add|implement|wire|route|validate|submit|scan)\b/i.test(item)) {
+      errors.push(
+        `${context} Change types entry "${item}" is conceptual work, not a per-file operation. Use entries like "packages/app/src/file.ts: modify" and keep conceptual work in Review Claim or Slice Rationale.`,
+      );
+    }
+  }
+  return errors;
+}


### PR DESCRIPTION
## Summary

The Slack manager release packaging never staged `skills/` into its own tarball at all — the previous slice's postinstall logic had nothing to find.

This slice adds the one missing line, matching what the terminal installer's own packaging step already does.

It also strengthens both real end-to-end install scripts (real build, real pack, a real `npm install` against a locally served release directory).

Each script now asserts the plan-doctor actually runs afterward, not just that the binary prints a version.

A bot review comment on this PR flagged a real risk. An inherited `~/.invoker/bundled-skills.json` could let the doctor fall back to the tester's own monorepo checkout.

That fallback could mask a genuinely missing packaged dependency. Both e2e scripts now isolate `HOME` and `INVOKER_DB_DIR` under `$SCRATCH`.

That isolation proves the npm-installed binary stands on its own, not on the tester's machine state.

Verified for real in this session: with only slices 1-7 applied, a real install of the Slack package failed with "did not lay down ... skill-doctor.sh".

With this slice, the same real install passes both plan-doctor checks under an isolated `HOME`.

## Review Claim

The Slack manager release packaging should stage `skills/` alongside the compiled binary, and both real install scripts should assert the plan-doctor works afterward against an isolated `HOME`/`INVOKER_DB_DIR`, not the tester's own environment.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

One new line copying an existing directory into a release staging area, plus test-only assertions and environment isolation (`HOME`, `INVOKER_DB_DIR` under `$SCRATCH`) appended to two existing real-install test scripts. No change to what gets published beyond the added directory; no change to any already-passing assertion; the `HOME`/`INVOKER_DB_DIR` overrides are scoped to the e2e test process only.

## Slice Rationale

These three files are `scripts/`-prefixed (`tooling-policy` review unit), which the review gate keeps separate from the `packages/`-scoped dependency and postinstall change in the previous slice — and this coverage needs that slice's postinstall logic to already exist to mean anything. The `HOME`/`INVOKER_DB_DIR` isolation fix responds to a bot review thread on this same PR and is folded into this slice rather than published as a separate no-new-claim fixup PR, per the stack's fixup-folding rule.

## Non-goals

Does not change the desktop app packaging path. Does not add a Windows or Linux equivalent — this repo's release matrix for these two binaries is macOS/Linux only, unchanged by this slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm run dist:slack && bash scripts/e2e-npm-slack-install.sh` — real build, real pack, real install under an isolated `HOME`, both plan-doctor checks pass
- [ ] `pnpm run dist:cli && bash scripts/e2e-npm-cli-install.sh` — same, for the CLI package
- [ ] Before/after: with the previous two slices' dependency-declaration and postinstall-extraction changes stashed, the same real install fails with "did not lay down ... skill-doctor.sh"; restored, it passes

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 260921ea4 bb123d6fa4` (revert the HOME-isolation fixup before the base slice, newest first)
- Post-revert steps: None
- Data migration? No

</details>
