### PR TITLE
[CI regression: a71f331-fleet-a71f331-12-jobs](1) Prefer system unzip in the Electron postinstall repair

### DIFF
--- a/scripts/electron.cjs
+++ b/scripts/electron.cjs
@@ -68,6 +68,23 @@ function getElectronPlatformPath() {
   }
 }
 
+function systemUnzipIsAvailable() {
+  const probe = spawnSync('unzip', ['-v'], { stdio: 'ignore' });
+  return !probe.error && probe.status === 0;
+}
+
+// extract-zip's yauzl-based streaming reader has been observed to hang indefinitely on
+// zipfile.openReadStream() for the first entry on some self-hosted CI filesystems, leaving
+// the postinstall process to exit early with nothing extracted and no error surfaced. System
+// unzip reliably extracts the same archive in seconds, so prefer it when present.
+function extractZipWithSystemUnzip(zipPath, destDir) {
+  if (!systemUnzipIsAvailable()) {
+    return false;
+  }
+  const result = spawnSync('unzip', ['-q', '-o', zipPath, '-d', destDir], { stdio: 'inherit' });
+  return !result.error && result.status === 0;
+}
+
 async function repairElectronWithPackageExtractor(electronPackageDir) {
   if (process.env.ELECTRON_OVERRIDE_DIST_PATH) {
     return null;
@@ -102,7 +119,9 @@ async function repairElectronWithPackageExtractor(electronPackageDir) {
   fs.rmSync(stagingPath, { recursive: true, force: true });
   fs.mkdirSync(stagingPath, { recursive: true });
   try {
-    await extractZip(zipPath, { dir: stagingPath });
+    if (!extractZipWithSystemUnzip(zipPath, stagingPath)) {
+      await extractZip(zipPath, { dir: stagingPath });
+    }
 
     const stagedBinary = path.join(stagingPath, platformPath);
     if (!fs.existsSync(stagedBinary)) {


### PR DESCRIPTION
## Summary

CI jobs in the a71f331 fleet failed while the postinstall step repaired a broken Electron install.

The repair unpacked the downloaded Electron archive with the bundled Node unzip library. On some self-hosted CI filesystems its streaming reader hangs on the first entry.

The hang left the repair with nothing unpacked and nothing surfaced as an error.

`scripts/electron.cjs` now prefers the system `unzip` binary when a quick probe shows it works. The bundled library stays as the fallback when the probe or the extraction fails.

## Review Claim

The Electron postinstall repair in `scripts/electron.cjs` now succeeds on machines where the bundled unzip library hangs, and behaves exactly as before everywhere the system `unzip` binary is absent or failing.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect: when the system `unzip` binary is absent or exits nonzero, the repair takes the same code path as before this change.

## Slice Rationale

One slice for the fleet repair itself, touching only `scripts/electron.cjs`. The reflect findings recorded from this repair land in the next slice so this diff stays reviewable as one repair.

## Non-goals

- No change to how the Electron archive is downloaded.
- No changes to other scripts or CI workflow definitions.
- No product code changes and no test weakening.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --check scripts/electron.cjs`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash 'scripts/test-suites/optional/30-e2e-ssh.sh'` (run by the workflow's verify task on this diff; exit 0)
- [x] `node scripts/validate-pr-body-local.mjs --body-file /tmp/pr1.md --base master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-sha-of-this-PR>`
- Post-revert steps: None
- Data migration? No

</details>
