### PR TITLE
Default the Claude OAuth refresh worker to enabled

### DIFF
--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -216,8 +216,7 @@ function controller(
 }
 
 describe('autoStartedOwnerWorkerKindsForConfig', () => {
-  // claude-oauth-refresh is about to default on; flips to a real assertion once that lands.
-  it.fails('fresh install auto-start config includes pr-status and claude-oauth-refresh', () => {
+  it('fresh install auto-start config includes pr-status and claude-oauth-refresh', () => {
     expect(autoStartedOwnerWorkerKindsForConfig({})).toEqual([
       PR_STATUS_WORKER_KIND,
       CLAUDE_OAUTH_REFRESH_WORKER_KIND,
@@ -232,8 +231,7 @@ describe('autoStartedOwnerWorkerKindsForConfig', () => {
     );
   });
 
-  // claude-oauth-refresh is about to default on; flips to a real assertion once that lands.
-  it.fails('includes claude-oauth-refresh unless claudeOauthRefresh.enabled is explicitly false', () => {
+  it('includes claude-oauth-refresh unless claudeOauthRefresh.enabled is explicitly false', () => {
     expect(autoStartedOwnerWorkerKindsForConfig({
       claudeOauthRefresh: { enabled: true },
     })).toEqual([PR_STATUS_WORKER_KIND, CLAUDE_OAUTH_REFRESH_WORKER_KIND]);
@@ -307,8 +305,7 @@ describe('autoStartedOwnerWorkerKindsForConfig', () => {
     );
   });
 
-  // claude-oauth-refresh is about to default on; flips to a real assertion once that lands.
-  it.fails('prMaintenance.enabled adds all PR-maintenance workers together', () => {
+  it('prMaintenance.enabled adds all PR-maintenance workers together', () => {
     expect(autoStartedOwnerWorkerKindsForConfig({ prMaintenance: { enabled: true } })).toEqual([
       PR_STATUS_WORKER_KIND,
       PR_ADMIN_BYPASS_LAND_WORKER_KIND,

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -157,7 +157,7 @@ export function autoStartedOwnerWorkerKindsForConfig(
     requeueEnabled: Boolean(config?.requeueEnabled),
     slackBugScanEnabled: Boolean(config?.slackBugScan?.enabled),
     staleTaskCleanupEnabled: Boolean(config?.staleTaskCleanup?.enabled),
-    claudeOauthRefreshEnabled: Boolean(config?.claudeOauthRefresh?.enabled),
+    claudeOauthRefreshEnabled: config?.claudeOauthRefresh?.enabled !== false,
   });
   return config?.e2eAutoFixEnabled
     ? [...workerKinds, E2E_AUTOFIX_WORKER_KIND]


### PR DESCRIPTION
## Summary

The Claude OAuth refresh worker (packages/execution-engine/src/workers/claude-oauth-refresh-worker.ts) already exists to refresh this owner's Claude Code OAuth token ahead of expiry and distribute it to every SSH pool member.

It shipped opt-in, off unless `claudeOauthRefresh.enabled: true` is explicitly set in config.json.

We hit the exact failure it exists to prevent: a repair task on an SSH pool member failed mid-run with "OAuth session expired and could not be refreshed", since nothing refreshed it proactively.

This flips its auto-start default to on, matching disk-headroom's already-established enabled-by-default behavior in the same function. An explicit `enabled: false` still disables it.

## Review Claim

Approve flipping `claudeOauthRefreshEnabled`'s computation from `Boolean(config?.claudeOauthRefresh?.enabled)` (false when unset) to `config?.claudeOauthRefresh?.enabled !== false` (true when unset, still respects an explicit `false`).

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This only changes a boolean default on an existing, already-shipped, already-tested worker (merged via #9376). No new worker logic, no new production code path. The worker's own refresh/distribute behavior is unchanged; only whether it auto-starts on a fresh config is unchanged.

## Slice Rationale

Stacks on #9848, which already added the assertions this PR turns into real passing checks. One config-default flip in `worker-control.ts`'s auto-start gate function, isolated from any change to the worker's own logic.

## Non-goals

Does not change the worker's refresh/distribute implementation. Does not change any other worker's auto-start default. Does not add a UI toggle for this setting.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- src/__tests__/worker-control.test.ts` — 33/33 passed, including the three assertions this PR's parent (#9848) added as `it.fails`, now passing for real
- [x] `cd packages/app && pnpm test` — same 6 pre-existing failures as unmodified origin/master (confirmed via `git stash`/`git stash pop` on this branch before either commit), 0 new failures introduced

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>` or set `claudeOauthRefresh: { enabled: false }` in config.json to opt back out without a code revert
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude OAuth refresh now starts automatically by default.
  * Claude OAuth refresh can still be disabled explicitly through configuration.
  * PR-maintenance workers now include Claude OAuth refresh automatically.

* **Bug Fixes**
  * Corrected default handling so refresh is enabled when no setting is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->