### PR TITLE
Add pending assertions for claude-oauth-refresh's upcoming default-on flip

### DIFF
--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -150,16 +150,20 @@ const AUTO_STARTED_OWNER_WORKER_KIND_OPTION_CASES = [
   { prMaintenanceEnabled: false },
 ] satisfies AutoStartOptions[];
 
+function withoutDefaultOnKinds(kinds: readonly string[]): string[] {
+  return kinds.filter((kind) => kind !== CLAUDE_OAUTH_REFRESH_WORKER_KIND);
+}
+
 function expectConfigGate(
   workerKind: string,
   configWhenTrue: AutoStartConfig,
   configWhenFalse: AutoStartConfig,
 ): void {
-  expect(autoStartedOwnerWorkerKindsForConfig(configWhenTrue)).toEqual([
+  expect(withoutDefaultOnKinds(autoStartedOwnerWorkerKindsForConfig(configWhenTrue))).toEqual([
     PR_STATUS_WORKER_KIND,
     workerKind,
   ]);
-  expect(autoStartedOwnerWorkerKindsForConfig(configWhenFalse)).toEqual([PR_STATUS_WORKER_KIND]);
+  expect(withoutDefaultOnKinds(autoStartedOwnerWorkerKindsForConfig(configWhenFalse))).toEqual([PR_STATUS_WORKER_KIND]);
   expect(autoStartedOwnerWorkerKindsForConfig({})).not.toContain(workerKind);
 }
 
@@ -212,8 +216,12 @@ function controller(
 }
 
 describe('autoStartedOwnerWorkerKindsForConfig', () => {
-  it('fresh install auto-start config includes only pr-status', () => {
-    expect(autoStartedOwnerWorkerKindsForConfig({})).toEqual([PR_STATUS_WORKER_KIND]);
+  // claude-oauth-refresh is about to default on; flips to a real assertion once that lands.
+  it.fails('fresh install auto-start config includes pr-status and claude-oauth-refresh', () => {
+    expect(autoStartedOwnerWorkerKindsForConfig({})).toEqual([
+      PR_STATUS_WORKER_KIND,
+      CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+    ]);
   });
 
   it('includes disk-headroom only when diskHeadroom.cleanupEnabled is true', () => {
@@ -224,12 +232,15 @@ describe('autoStartedOwnerWorkerKindsForConfig', () => {
     );
   });
 
-  it('includes claude-oauth-refresh only when claudeOauthRefresh.enabled is true', () => {
-    expectConfigGate(
-      CLAUDE_OAUTH_REFRESH_WORKER_KIND,
-      { claudeOauthRefresh: { enabled: true } },
-      { claudeOauthRefresh: { enabled: false } },
-    );
+  // claude-oauth-refresh is about to default on; flips to a real assertion once that lands.
+  it.fails('includes claude-oauth-refresh unless claudeOauthRefresh.enabled is explicitly false', () => {
+    expect(autoStartedOwnerWorkerKindsForConfig({
+      claudeOauthRefresh: { enabled: true },
+    })).toEqual([PR_STATUS_WORKER_KIND, CLAUDE_OAUTH_REFRESH_WORKER_KIND]);
+    expect(autoStartedOwnerWorkerKindsForConfig({
+      claudeOauthRefresh: { enabled: false },
+    })).toEqual([PR_STATUS_WORKER_KIND]);
+    expect(autoStartedOwnerWorkerKindsForConfig({})).toContain(CLAUDE_OAUTH_REFRESH_WORKER_KIND);
   });
 
   it('includes auto-approve only when autoApproveAIFixes is true', () => {
@@ -296,13 +307,15 @@ describe('autoStartedOwnerWorkerKindsForConfig', () => {
     );
   });
 
-  it('prMaintenance.enabled adds all PR-maintenance workers together', () => {
+  // claude-oauth-refresh is about to default on; flips to a real assertion once that lands.
+  it.fails('prMaintenance.enabled adds all PR-maintenance workers together', () => {
     expect(autoStartedOwnerWorkerKindsForConfig({ prMaintenance: { enabled: true } })).toEqual([
       PR_STATUS_WORKER_KIND,
       PR_ADMIN_BYPASS_LAND_WORKER_KIND,
       PR_ORPHAN_REPAIR_WORKER_KIND,
       PR_DUPLICATE_CLOSE_WORKER_KIND,
       PR_AUTO_LABEL_WORKER_KIND,
+      CLAUDE_OAUTH_REFRESH_WORKER_KIND,
     ]);
   });
 


### PR DESCRIPTION
## Summary

The Claude OAuth refresh worker exists to refresh this owner's Claude Code OAuth token ahead of expiry and distribute it to every SSH pool member.

It currently ships opt-in, off by default. The next PR in this stack flips that default on.

This PR adds the test coverage first, marked `it.fails` since the code hasn't changed yet. It proves today's gap: a fresh install does not auto-start this worker.

## Review Claim

Approve adding three `it.fails`-marked assertions describing the intended default-on behavior, plus a small `expectConfigGate` helper change so other workers' gate tests ignore claude-oauth-refresh's presence.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change, no production code touched. `pnpm test` for this file passes today (33/33) — the three new assertions correctly fail against the current default-off code, and `it.fails` catches that expected failure so the suite stays green.

## Slice Rationale

Landing the proof before the fix, per this repo's stack-ordering convention: the next PR flips the default and removes these `it.fails` markers, turning them into real passing assertions.

## Non-goals

Does not change any production code. Does not change the worker's own refresh/distribute logic.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- src/__tests__/worker-control.test.ts` — 33/33 passed (the 3 new assertions fail as expected under `it.fails`)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
