### PR TITLE
[Slack plan review block limit](2) Clamp the plan-review card text to Slack's 3000-char block limit

### DIFF
--- a/packages/surfaces/src/__tests__/slack-plan-draft-block-limit.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-draft-block-limit.test.ts
@@ -29,8 +29,7 @@ describe('plan draft review card stays within Slack block text limits', () => {
 
   afterEach(() => adapter.close());
 
-  // TODO(slack-plan-review-block-limit fix slice): flip to `it` once planDraftBlocks clamps its text.
-  it.fails('clamps the section text to 3000 chars even when task descriptions are long', async () => {
+  it('clamps the section text to 3000 chars even when task descriptions are long', async () => {
     const longDescription = 'Goal: '.padEnd(3500, 'x');
     const planText = `name: Oversized plan\ntasks:\n  - id: a\n    description: "${longDescription}"\n`;
 

--- a/packages/surfaces/src/__tests__/slack-plan-draft-oversized-description.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-plan-draft-oversized-description.e2e.test.ts
@@ -100,8 +100,7 @@ describe('a drafted plan with an oversized task description does not trip Slack 
     nextDraftPlanText = null;
   });
 
-  // TODO(slack-plan-review-block-limit fix slice): flip to `it` once planDraftBlocks clamps its text.
-  it.fails('clamps the review card mrkdwn text to 3000 chars instead of posting an oversized block', async () => {
+  it('clamps the review card mrkdwn text to 3000 chars instead of posting an oversized block', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     const surface = new SlackSurface({
       botToken: 'xoxb-test',

--- a/packages/surfaces/src/slack/slack-formatter.ts
+++ b/packages/surfaces/src/slack/slack-formatter.ts
@@ -40,7 +40,7 @@ function statusEmoji(status: string): string {
 function statusLabel(status: string): string {
   return STATUS_LABEL[status] ?? status;
 }
-function clampMrkdwnText(text: string, max = 3000): string {
+export function clampMrkdwnText(text: string, max = 3000): string {
   return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
 }
 

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -23,7 +23,7 @@ import {
 import type { Surface, CommandHandler, SurfaceCommand, SurfaceEvent, LogFn, WorkflowOp, WorkflowOpResult, WorkflowOpProgress } from '../surface.js';
 import { parseSlackCommand } from './slack-commands.js';
 import type { ConversationCommand } from './slack-commands.js';
-import { formatSurfaceEvent, formatWorkflowStatus } from './slack-formatter.js';
+import { formatSurfaceEvent, formatWorkflowStatus, clampMrkdwnText } from './slack-formatter.js';
 import {
   splitForSlack,
   sanitizeSlackOutbound,
@@ -1679,7 +1679,7 @@ export class SlackSurface implements Surface {
     draft: SlackPlanDraft,
     state: 'ready' | 'kept',
   ): unknown[] {
-    const text = [`*${summary.name}*`, ...formatPlanSummaryLines(summary)].join('\n');
+    const text = clampMrkdwnText([`*${summary.name}*`, ...formatPlanSummaryLines(summary)].join('\n'));
     const actionButtons = state === 'ready'
       ? [
           {


### PR DESCRIPTION
## Summary

Fixes the Slack plan-review card so it never sends Slack a block of text longer than Slack allows.

The card was joining every task description into one message with no length cap.

Every other Slack card builder in this codebase already caps its text at 3000 characters; this one card was the exception.

A plan with long or verbose task descriptions could push the joined text past that limit, and Slack's API would return an `invalid_blocks` error instead of posting the card.

## Review Claim

Approve wrapping the plan-review card's text in the existing `clampMrkdwnText` helper before it submits the block to Slack's API -- the same helper every other Slack card in this file already uses.

## Review Lane

behavior

## Review Unit

write-path

## Safety Invariant

Only the Slack-displayed summary text is shortened. The plan's actual YAML (`planText`/`summaryJson`) stored on the draft row is untouched, so clicking Approve still submits the exact original plan.

## Slice Rationale

Isolated from the previous proof slice so the actual behavior change is a minimal, reviewable diff on its own: one export, one import, one call site wrapped.

## Non-goals

Does not touch the unrelated, unused duplicate `formatPlanSummaryLines` in `packages/surfaces/src/slack/plan-summary.ts` (confirmed dead -- nothing imports it outside its own test). Does not address other potential Slack payload limits (block count, action-element count) beyond the one this bug hit.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/surfaces && pnpm test -- slack-plan-draft-block-limit slack-plan-draft-oversized-description`
- [ ] `cd packages/surfaces && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented lengthy task descriptions from exceeding Slack’s 3,000-character message limit.
  * Plan draft summaries and review cards are now safely shortened when necessary, helping ensure they display correctly in Slack.
* **Tests**
  * Added coverage confirming that oversized descriptions and plan draft content remain within Slack’s supported text length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->