### PR TITLE
Add Slack community join link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ If you've read [Part 2: Architecture](docs/invoker-medium-article.md), most of t
 
 The roadmap and issue tracker live at **[invoker.productlane.com/roadmap](https://invoker.productlane.com/roadmap)**. File bugs, feature requests, and roadmap feedback there. GitHub Issues is fine for code-level discussion tied to a specific PR or commit, but the productlane board is the source of truth for what we're working on next.
 
+Join the community on **[Invoker Slack](https://join.slack.com/t/invoker-ai/shared_invite/zt-476imo738-VqNp_SDfI6DFZp80EGgscQ)**.
+
 When you file an issue, the most useful things you can include are:
 
 - The plan (or a minimal version of it) that reproduces the behavior.

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@
 [![npm invoker-cli](https://img.shields.io/npm/v/@neko-catpital-labs/invoker-cli?label=invoker-cli&style=flat-square)](https://www.npmjs.com/package/@neko-catpital-labs/invoker-cli)
 [![npm invoker-ui](https://img.shields.io/npm/v/@neko-catpital-labs/invoker-ui?label=invoker-ui&style=flat-square)](https://www.npmjs.com/package/@neko-catpital-labs/invoker-ui)
 [![npm invoker-slack](https://img.shields.io/npm/v/@neko-catpital-labs/invoker-slack?label=invoker-slack&style=flat-square)](https://www.npmjs.com/package/@neko-catpital-labs/invoker-slack)
+[![Slack](https://img.shields.io/badge/slack-join-4A154B?style=flat-square&logo=slack&logoColor=white)](https://join.slack.com/t/invoker-ai/shared_invite/zt-476imo738-VqNp_SDfI6DFZp80EGgscQ)
 
 A DAG of tasks in isolated git worktrees, composed through merge gates and review — desktop, CLI, and Slack on one control plane.
 
-**[Download](https://github.com/Neko-Catpital-Labs/Invoker/releases/latest)** · **[Website](https://invoker-control.dev)**
+**[Download](https://github.com/Neko-Catpital-Labs/Invoker/releases/latest)** · **[Website](https://invoker-control.dev)** · **[Join Slack](https://join.slack.com/t/invoker-ai/shared_invite/zt-476imo738-VqNp_SDfI6DFZp80EGgscQ)**
 
 <video src="docs/assets/invoker-preview.mp4" controls muted playsinline width="100%"></video>
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting started
 
-Install, configure, and run Invoker. For the product overview, see the [README](../README.md). Version history lives in [CHANGELOG.md](../CHANGELOG.md).
+Install, configure, and run Invoker. For the product overview, see the [README](../README.md). Version history lives in [CHANGELOG.md](../CHANGELOG.md). Join the community on [Invoker Slack](https://join.slack.com/t/invoker-ai/shared_invite/zt-476imo738-VqNp_SDfI6DFZp80EGgscQ).
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

People landing on the repo had no public Slack invite to click.

This adds the Invoker Slack join link on the README hero, next to Download and Website.

The same invite is in CONTRIBUTING and getting-started so contributors see it too.

## Review Claim

Approve adding the public Invoker Slack invite to the README hero and the two contributor docs that already send people to community surfaces.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Only markdown docs change. No product code, install path, or Slack bot behavior is touched.

## Slice Rationale

Docs-only so the invite can land without mixing product, policy, or Slack integration work.

## Non-goals

Does not change Slack bot setup, invite rotation, or the marketing website.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `rg -n 'join.slack.com/t/invoker-ai' README.md CONTRIBUTING.md docs/getting-started.md`
- [ ] `git diff --name-only origin/master`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b9f79de09a`
- Post-revert steps: None
- Data migration? No

</details>
