### PR TITLE
[Docker Reclaim](1) Reclaim docker CI workspace before checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1218,6 +1218,11 @@ jobs:
     name: docker / comprehensive
 
     steps:
+      - name: Reclaim workspace
+        run: |
+          sudo chown -R "$(id -u):$(id -g)" "$GITHUB_WORKSPACE" "$HOME/.invoker" "$HOME/.claude" 2>/dev/null || true
+          find "$GITHUB_WORKSPACE/.git" -name '*.lock' -delete 2>/dev/null || true
+        shell: bash
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -256,6 +256,11 @@ assert(
 
 assert(jobs.docker, 'Missing docker job');
 assert(jobs.docker.if === NON_PR_GATE, 'docker must not run on pull_request events');
+const dockerSteps = stepNames('docker');
+assert(
+  dockerSteps[0] === 'Reclaim workspace' && dockerSteps[1] === 'Checkout',
+  'docker must reclaim the self-hosted runner workspace before checkout so leftover Playwright artifacts cannot block actions/checkout',
+);
 assert(
   !jobs.docker.steps.some((step) => step.name === 'Install Electron repair dependency'),
   'docker must not provision system unzip: scripts/electron.cjs\'s repair path uses the bundled extract-zip package, not a system unzip binary (see PR #9406)',


### PR DESCRIPTION
## Summary

Master `docker / comprehensive` died in checkout, not in the suite.

Playwright on the same self-hosted runner left root-owned files under `.git/playwright-artifacts`.

`actions/checkout` could not delete them (`EACCES`) and never reached the Docker tests.

This job was the sibling that never got the Reclaim workspace step other self-hosted jobs already run.

## Review Claim

Approve adding Reclaim workspace before checkout on `docker / comprehensive`, with a static assertion so the step cannot drift off again.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the docker CI job gains a pre-checkout chown. Product code and the Docker suite itself are unchanged.

## Slice Rationale

One job, one missing hygiene step, one assertion. Other self-hosted jobs still without reclaim stay out of this slice.

## Non-goals

Does not add reclaim to playwright, e2e-proof, ssh, or reset-rulebook. Does not change the Docker comprehensive suite.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-ci-workflow-merge-queue-policy.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 121f6259ee`
- Post-revert steps: None
- Data migration? No

</details>
