### PR TITLE
[Heartbeat Requeue](1) Rename the requeue worker kind to heartbeat-requeue

### DIFF
--- a/packages/execution-engine/src/__tests__/requeue-retry-cap-restart.repro.test.ts
+++ b/packages/execution-engine/src/__tests__/requeue-retry-cap-restart.repro.test.ts
@@ -27,7 +27,7 @@ const logger = {
 };
 
 const POLL_CTX = {
-  identity: { kind: 'requeue', instanceId: 'r1' },
+  identity: { kind: 'heartbeat-requeue', instanceId: 'r1' },
   reason: 'poll' as const,
   tickNumber: 1,
   signal: new AbortController().signal,
@@ -115,7 +115,7 @@ describe('requeue retry cap restart regression', () => {
 
     await firstProcessTick(POLL_CTX);
     expect(h.submit.mock.calls.map((call) => call[2])).toEqual([REQUEUE_COMMAND_CHANNEL]);
-    expect(h.store.getWorkerAction('requeue', requeueRetryCapExternalKey('wf-1/gate'))?.attemptCount).toBe(1);
+    expect(h.store.getWorkerAction('heartbeat-requeue', requeueRetryCapExternalKey('wf-1/gate'))?.attemptCount).toBe(1);
 
     await firstProcessTick(POLL_CTX);
     expect(h.submit.mock.calls.map((call) => call[2])).toEqual([

--- a/packages/execution-engine/src/__tests__/requeue-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/requeue-worker.test.ts
@@ -22,7 +22,7 @@ const logger = {
   child: vi.fn(),
 };
 
-const POLL_CTX = { identity: { kind: 'requeue', instanceId: 'r1' }, reason: 'poll' as const, tickNumber: 1, signal: new AbortController().signal };
+const POLL_CTX = { identity: { kind: 'heartbeat-requeue', instanceId: 'r1' }, reason: 'poll' as const, tickNumber: 1, signal: new AbortController().signal };
 
 function makeTask(overrides: Partial<TaskState> = {}): TaskState {
   const { config, execution, ...rest } = overrides;

--- a/packages/execution-engine/src/requeue-retry-cap.ts
+++ b/packages/execution-engine/src/requeue-retry-cap.ts
@@ -3,7 +3,7 @@ import { recordWorkerDecisionRow, type WorkerDecisionStore } from './worker-deci
 
 export const REQUEUE_RETRY_CAP_ACTION_TYPE = 'stall-requeue-cap';
 
-const REQUEUE_RETRY_CAP_WORKER_KIND = 'requeue';
+const REQUEUE_RETRY_CAP_WORKER_KIND = 'heartbeat-requeue';
 
 export function requeueRetryCapExternalKey(taskId: string): string {
   return `stall-requeue-cap:${taskId}`;

--- a/packages/execution-engine/src/workers/requeue-worker.ts
+++ b/packages/execution-engine/src/workers/requeue-worker.ts
@@ -19,7 +19,7 @@ import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../wor
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import type { WorkerRegistry } from '../worker-registry.js';
 
-export const REQUEUE_WORKER_KIND = 'requeue';
+export const REQUEUE_WORKER_KIND = 'heartbeat-requeue';
 
 export const REQUEUE_COMMAND_CHANNEL = 'invoker:requeue';
 export const REQUEUE_ESCALATE_CHANNEL = 'invoker:requeue-escalate';
@@ -329,7 +329,7 @@ export function registerRequeueWorker(
 ): WorkerRegistry<WorkerRuntimeDependencies> {
   registry.register({
     kind: REQUEUE_WORKER_KIND,
-    note: 'Re-runs liveness-stalled tasks (requeue) with bounded budget/backoff; escalates to needs_input.',
+    note: 'Re-runs heartbeat-stalled tasks with bounded budget/backoff; escalates to needs_input.',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
       createRequeueWorker({
         logger: deps.logger,


### PR DESCRIPTION
## Summary

The heartbeat-stall worker registered as `requeue`, which hid its real job.

This slice renames that worker's identity to `heartbeat-requeue`.

Start, stop, desired-state, and cap rows now key on the new kind.

## Review Claim

The heartbeat-stall worker's registered kind is `heartbeat-requeue`, and its cap ledger uses the same kind.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the registered worker kind string and its matching retry-cap ledger key change. Existing `requeue` desired-state and worker_action rows are not migrated. Config, channels, and attempt-ledger decision kinds stay `requeue`.

## Slice Rationale

The kind string and cap key must change together. Changing only one would write cap rows under the wrong worker.

This is one claim, so it is a one-slice stack.

## Non-goals

Does not change `requeueEnabled`, `invoker:requeue` channels, or attempt-ledger decision kind `requeue`.

Does not rename other workers, migrate old `requeue` rows, or add worker display copy.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/requeue-worker.test.ts src/__tests__/requeue-retry-cap-restart.repro.test.ts src/__tests__/worker-registry.test.ts src/__tests__/requeue-attempt-ledger.test.ts`
- [x] `cd packages/app && pnpm test -- src/__tests__/worker-control.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a2ed747454`
- Post-revert steps: Restart Invoker if a `heartbeat-requeue` worker is running, then start `requeue` again if that kind is still desired.
- Data migration? No. Rows written under `heartbeat-requeue` stay; they are unused after revert.

</details>
