### PR TITLE
[Worker Agent Defaults](1) Stop pinning Claude on the CI regression reflect task

### DIFF
--- a/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
+++ b/skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml
@@ -93,7 +93,6 @@ tasks:
       - fix-ci-{{job_slug}}
 
   - id: reflect-ci-{{job_slug}}
-    executionAgent: claude
     description: |
       Run the /reflect skill against this repair to find how the regression
       escaped, and draft (not auto-apply) any resulting skill updates.


### PR DESCRIPTION
## Summary

The CI regression formula still pins Claude on the optional reflect task.

That ignores `defaultExecutionAgent` in the owner's config, so switching workers to Cursor Grok never reaches this task.

This slice drops the pin so plan submission fills the configured default.

## Review Claim

The CI regression reflect task no longer hardcodes an execution agent.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Worker-submitted prompt tasks omit `executionAgent` so the submitting owner's `defaultExecutionAgent` applies. Changing that config (or leaving it unset for the built-in codex fallback) is the only way to pick the agent.

## Slice Rationale

Formula YAML under `skills/` is a docs review unit. The repro lock that forbids any future pin ships in the next slice.

## Non-goals

- Does not change admin-bypass repair plan generation (already unpinned on master).
- Does not change `autoFixAgent` retry routing.
- Does not install or configure the Cursor CLI on droplets.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `rg -n 'executionAgent' skills/plan-to-invoker/formulas/ci-regression-watch/ci-regression-watch.workflow.yaml` (no matches)
- [x] `python3 -m unittest scripts.test_mergify_admin_requeue_async_repair -v`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
