### PR TITLE
[Worker Agent Defaults](1) Assert CI repair plans never pin an execution agent or model

### DIFF
--- a/scripts/repro/repro-e2e-regression-watch.mjs
+++ b/scripts/repro/repro-e2e-regression-watch.mjs
@@ -216,8 +216,8 @@ function testPlanVarsAndDryRunRendering() {
     if (!rendered.planPath.endsWith('ci-regression-watch.yaml')) fail('dry run did not render expected plan path');
     if (rendered.submitted) fail('dry run must not submit');
     const planText = readFileSync(rendered.planPath, 'utf8');
-    // #7086's codex pin outlived the outage it was a stopgap for; see #9452.
-    if (planText.includes('executionAgent: codex')) fail('fix task must not hardcode codex; let the configured default agent apply');
+    if (planText.includes('executionAgent:')) fail('fix task must not pin an execution agent');
+    if (planText.includes('executionModel:')) fail('fix task must not pin an execution model');
   } finally {
     rmSync(outRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

The CI regression-watch repro only rejected a hardcoded Codex agent name.

Any other hardcoded harness in the formula would still pass that check.

This change requires the rendered plan to omit both `executionAgent` and `executionModel`.

## Review Claim

The CI regression-watch repro fails if a rendered repair plan pins an agent or model.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Worker-submitted prompt tasks omit `executionAgent` so the submitting owner's `defaultExecutionAgent` applies. Changing that config (or leaving it unset for the built-in codex fallback) is the only way to pick the agent.

## Slice Rationale

`scripts/repro/` is a proof review unit. The prior formula-only slice is no longer needed after the reflect task left the formula on master, so this proof is the whole remaining stack.

## Non-goals

- Does not change filing or submission behavior in `e2e-regression-watch.mjs`.
- Does not change which agent the owner config selects.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] Rebased onto current `origin/master` with a clean single-commit history
- [x] Plan-vars dry-run assertion forbids any `executionAgent:` / `executionModel:` pin

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
