### PR TITLE
[Codex OAuth + Cursor Append](1) Refresh Codex auth and allow Slack Cursor session append

### DIFF
--- a/packages/execution-engine/src/__tests__/claude-oauth-refresh-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/claude-oauth-refresh-worker.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import {
   buildDistributeCredentialsScript,
+  createClaudeOauthRefreshWorker,
+  runClaudeAndCodexOauthRefreshCheck,
   runClaudeOauthRefreshCheck,
+  runCodexOauthRefreshCheck,
   type ClaudeOauthRefreshTarget,
   type ClaudeOauthRefreshWorkerOptions,
+  type CodexOauthRefreshWorkerOptions,
 } from '../workers/claude-oauth-refresh-worker.js';
+import { CODEX_LAST_REFRESH_MAX_AGE_MS } from '../codex-oauth-refresh.js';
 import type { WorkerDecisionStore } from '../worker-decision-ledger.js';
 
 function credentialsJson(expiresAt: number): string {
@@ -214,6 +223,248 @@ describe('runClaudeOauthRefreshCheck', () => {
     });
     expect(refreshFn).not.toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalled();
+  });
+});
+
+function jwtWithExp(expSeconds: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ exp: expSeconds })).toString('base64url');
+  return `${header}.${payload}.sig`;
+}
+
+function codexAuthJson(now: number, overrides: { lastRefresh?: string; expSeconds?: number } = {}): string {
+  const expSeconds = overrides.expSeconds ?? Math.floor((now + 60 * 60 * 1000) / 1000);
+  return JSON.stringify({
+    auth_mode: 'chatgpt',
+    tokens: {
+      access_token: jwtWithExp(expSeconds),
+      refresh_token: 'refresh-old',
+    },
+    last_refresh: overrides.lastRefresh ?? new Date(now).toISOString(),
+  });
+}
+
+function makeCodexOptions(overrides: Partial<CodexOauthRefreshWorkerOptions> = {}): CodexOauthRefreshWorkerOptions {
+  return {
+    logger: makeLogger(),
+    authPath: '/home/invoker/.codex/auth.json',
+    remoteTargets: [],
+    ...overrides,
+  };
+}
+
+describe('runCodexOauthRefreshCheck', () => {
+  it('does nothing when the local token and every remote target are all healthy', async () => {
+    const now = 1_000_000_000_000;
+    const writeCredentials = vi.fn();
+    const refreshFn = vi.fn();
+    const distributeFn = vi.fn();
+    await runCodexOauthRefreshCheck(makeCodexOptions({
+      remoteTargets: [makeTarget('do1')],
+      readCredentials: () => codexAuthJson(now),
+      readRemoteCredentials: async () => codexAuthJson(now),
+      writeCredentials,
+      refreshFn,
+      distributeFn,
+      now: () => now,
+    }));
+    expect(refreshFn).not.toHaveBeenCalled();
+    expect(writeCredentials).not.toHaveBeenCalled();
+    expect(distributeFn).not.toHaveBeenCalled();
+  });
+
+  it('refreshes, writes the local file, and distributes to every remote target when the token is expiring', async () => {
+    const now = 1_000_000_000_000;
+    const refreshed = codexAuthJson(now + 3_600_000);
+    const writeCredentials = vi.fn();
+    const distributeFn = vi.fn(async () => undefined);
+    const { store, rows } = makeStore();
+
+    await runCodexOauthRefreshCheck(makeCodexOptions({
+      remoteTargets: [makeTarget('do1'), makeTarget('do3')],
+      store,
+      readCredentials: () => codexAuthJson(now, { expSeconds: Math.floor(now / 1000) }),
+      writeCredentials,
+      refreshFn: async () => refreshed,
+      distributeFn,
+      now: () => now,
+    }));
+
+    expect(writeCredentials).toHaveBeenCalledWith('/home/invoker/.codex/auth.json', refreshed);
+    expect(distributeFn).toHaveBeenCalledTimes(2);
+    expect(distributeFn).toHaveBeenCalledWith(expect.objectContaining({ name: 'do1' }), refreshed);
+    expect(distributeFn).toHaveBeenCalledWith(expect.objectContaining({ name: 'do3' }), refreshed);
+    const statuses = (rows as { status: string; subjectId: string }[]).map((r) => `${r.subjectId}:${r.status}`);
+    expect(statuses).toContain('codex:local:completed');
+    expect(statuses).toContain('codex:do1:completed');
+    expect(statuses).toContain('codex:do3:completed');
+  });
+
+  it('distributes current Codex auth to a remote target whose own copy is stale, even when the local token is healthy', async () => {
+    const now = 1_000_000_000_000;
+    const healthyLocal = codexAuthJson(now);
+    const staleRemote = codexAuthJson(now, {
+      lastRefresh: new Date(now - CODEX_LAST_REFRESH_MAX_AGE_MS - 1).toISOString(),
+    });
+    const distributeFn = vi.fn(async () => undefined);
+    const refreshFn = vi.fn();
+    const writeCredentials = vi.fn();
+    const { store, rows } = makeStore();
+
+    await runCodexOauthRefreshCheck(makeCodexOptions({
+      remoteTargets: [makeTarget('do1'), makeTarget('do2')],
+      store,
+      readCredentials: () => healthyLocal,
+      readRemoteCredentials: async (target) =>
+        target.name === 'do1' ? staleRemote : codexAuthJson(now),
+      writeCredentials,
+      refreshFn,
+      distributeFn,
+      now: () => now,
+    }));
+
+    expect(refreshFn).not.toHaveBeenCalled();
+    expect(writeCredentials).not.toHaveBeenCalled();
+    expect(distributeFn).toHaveBeenCalledTimes(1);
+    expect(distributeFn).toHaveBeenCalledWith(expect.objectContaining({ name: 'do1' }), healthyLocal);
+    const statuses = Object.fromEntries((rows as { subjectId: string; status: string }[]).map((r) => [r.subjectId, r.status]));
+    expect(statuses['codex:do1']).toBe('completed');
+    expect(statuses['codex:do2']).toBeUndefined();
+  });
+});
+
+describe('runClaudeAndCodexOauthRefreshCheck', () => {
+  it('still runs the Codex pass when Claude refresh fails', async () => {
+    const now = 1_000_000_000_000;
+    const refreshedCodex = codexAuthJson(now + 3_600_000);
+    const writeClaude = vi.fn();
+    const writeCodex = vi.fn();
+    const distributeClaude = vi.fn();
+    const distributeCodex = vi.fn(async () => undefined);
+    const { store, rows } = makeStore();
+
+    await runClaudeAndCodexOauthRefreshCheck(
+      {
+        logger: makeLogger(),
+        credentialsPath: '/home/invoker/.claude/.credentials.json',
+        remoteTargets: [makeTarget('do1')],
+        store,
+        readCredentials: () => credentialsJson(now),
+        writeCredentials: writeClaude,
+        refreshFn: async () => null,
+        distributeFn: distributeClaude,
+        now: () => now,
+      },
+      makeCodexOptions({
+        remoteTargets: [makeTarget('do1')],
+        store,
+        readCredentials: () => codexAuthJson(now, { expSeconds: Math.floor(now / 1000) }),
+        writeCredentials: writeCodex,
+        refreshFn: async () => refreshedCodex,
+        distributeFn: distributeCodex,
+        now: () => now,
+      }),
+    );
+
+    expect(writeClaude).not.toHaveBeenCalled();
+    expect(distributeClaude).not.toHaveBeenCalled();
+    expect(writeCodex).toHaveBeenCalledWith('/home/invoker/.codex/auth.json', refreshedCodex);
+    expect(distributeCodex).toHaveBeenCalledTimes(1);
+    const statuses = (rows as { subjectId: string; status: string }[]).map((r) => `${r.subjectId}:${r.status}`);
+    expect(statuses).toContain('local:failed');
+    expect(statuses).toContain('codex:local:completed');
+    expect(statuses).toContain('codex:do1:completed');
+  });
+
+  it('does not fail the Claude pass when Codex auth.json is missing', async () => {
+    const now = 1_000_000_000_000;
+    const refreshedClaude = credentialsJson(now + 3_600_000);
+    const writeClaude = vi.fn();
+    const refreshCodex = vi.fn();
+    const distributeCodex = vi.fn();
+    const { store, rows } = makeStore();
+
+    await runClaudeAndCodexOauthRefreshCheck(
+      {
+        logger: makeLogger(),
+        credentialsPath: '/home/invoker/.claude/.credentials.json',
+        remoteTargets: [makeTarget('do1')],
+        store,
+        readCredentials: () => credentialsJson(now),
+        writeCredentials: writeClaude,
+        refreshFn: async () => refreshedClaude,
+        distributeFn: vi.fn(async () => undefined),
+        now: () => now,
+      },
+      makeCodexOptions({
+        remoteTargets: [makeTarget('do1')],
+        store,
+        readCredentials: () => { throw new Error('ENOENT'); },
+        refreshFn: refreshCodex,
+        distributeFn: distributeCodex,
+        now: () => now,
+      }),
+    );
+
+    expect(writeClaude).toHaveBeenCalledWith('/home/invoker/.claude/.credentials.json', refreshedClaude);
+    expect(refreshCodex).not.toHaveBeenCalled();
+    expect(distributeCodex).not.toHaveBeenCalled();
+    const statuses = (rows as { subjectId: string; status: string }[]).map((r) => `${r.subjectId}:${r.status}`);
+    expect(statuses).toContain('local:completed');
+    expect(statuses).toContain('do1:completed');
+    expect(statuses.some((s) => s.startsWith('codex:'))).toBe(false);
+  });
+});
+
+describe('createClaudeOauthRefreshWorker filesystem e2e', () => {
+  it('one startup tick refreshes Claude + Codex files on disk and distributes both independently', async () => {
+    const now = 1_000_000_000_000;
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-oauth-e2e-'));
+    const claudePath = join(dir, '.credentials.json');
+    const codexPath = join(dir, 'auth.json');
+    writeFileSync(claudePath, credentialsJson(now), { mode: 0o600 });
+    writeFileSync(codexPath, codexAuthJson(now, { expSeconds: Math.floor(now / 1000) }), { mode: 0o600 });
+
+    const refreshedClaude = credentialsJson(now + 3_600_000);
+    const refreshedCodex = codexAuthJson(now + 3_600_000);
+    const distributeClaude = vi.fn(async () => undefined);
+    const distributeCodex = vi.fn(async () => undefined);
+    const { store, rows } = makeStore();
+
+    const worker = createClaudeOauthRefreshWorker({
+      logger: makeLogger(),
+      credentialsPath: claudePath,
+      codexAuthPath: codexPath,
+      remoteTargets: [makeTarget('do1')],
+      store,
+      intervalMs: 0,
+      tickOnStart: true,
+      now: () => now,
+      refreshFn: async () => refreshedClaude,
+      refreshCodexFn: async () => refreshedCodex,
+      distributeFn: distributeClaude,
+      distributeCodexFn: distributeCodex,
+    });
+
+    try {
+      worker.start();
+      await vi.waitFor(() => {
+        expect(readFileSync(claudePath, 'utf8')).toBe(refreshedClaude);
+        expect(readFileSync(codexPath, 'utf8')).toBe(refreshedCodex);
+      });
+      expect(distributeClaude).toHaveBeenCalledWith(expect.objectContaining({ name: 'do1' }), refreshedClaude);
+      expect(distributeCodex).toHaveBeenCalledWith(expect.objectContaining({ name: 'do1' }), refreshedCodex);
+      const statuses = (rows as { subjectId: string; status: string }[]).map((r) => `${r.subjectId}:${r.status}`);
+      expect(statuses).toEqual(expect.arrayContaining([
+        'local:completed',
+        'do1:completed',
+        'codex:local:completed',
+        'codex:do1:completed',
+      ]));
+    } finally {
+      await worker.stop({ settleTimeoutMs: 2_000 });
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/execution-engine/src/__tests__/codex-oauth-refresh.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-oauth-refresh.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+
+import { OAUTH_EXPIRY_BUFFER_MS } from '../claude-oauth-refresh.js';
+import {
+  applyRefreshedCodexToken,
+  CODEX_LAST_REFRESH_MAX_AGE_MS,
+  isCodexAuthExpiring,
+  parseCodexAuthFile,
+  readCodexRefreshToken,
+  refreshCodexOauthCredentials,
+  resolveCodexAuthPath,
+  resolveCodexRefreshTokenUrl,
+} from '../codex-oauth-refresh.js';
+
+function jwtWithExp(expSeconds: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ exp: expSeconds })).toString('base64url');
+  return `${header}.${payload}.sig`;
+}
+
+function authJson(overrides: {
+  refreshToken?: string;
+  accessToken?: string;
+  lastRefresh?: string | number;
+  extra?: Record<string, unknown>;
+} = {}): string {
+  return JSON.stringify({
+    auth_mode: 'chatgpt',
+    tokens: {
+      access_token: overrides.accessToken ?? jwtWithExp(2_000_000_000),
+      id_token: 'id-old',
+      refresh_token: overrides.refreshToken ?? 'refresh-old',
+    },
+    last_refresh: overrides.lastRefresh ?? '2026-01-01T00:00:00.000Z',
+    ...(overrides.extra ?? {}),
+  });
+}
+
+describe('resolveCodexAuthPath', () => {
+  it('prefers INVOKER_CODEX_AUTH_PATH over CODEX_HOME', () => {
+    expect(resolveCodexAuthPath({
+      INVOKER_CODEX_AUTH_PATH: '/tmp/custom-auth.json',
+      CODEX_HOME: '/tmp/codex-home',
+    })).toBe('/tmp/custom-auth.json');
+  });
+
+  it('joins CODEX_HOME/auth.json when no explicit path is set', () => {
+    expect(resolveCodexAuthPath({ CODEX_HOME: '/tmp/codex-home' })).toBe('/tmp/codex-home/auth.json');
+  });
+});
+
+describe('resolveCodexRefreshTokenUrl', () => {
+  it('honors CODEX_REFRESH_TOKEN_URL_OVERRIDE', () => {
+    expect(resolveCodexRefreshTokenUrl({
+      CODEX_REFRESH_TOKEN_URL_OVERRIDE: 'https://example.test/oauth/token',
+    })).toBe('https://example.test/oauth/token');
+  });
+});
+
+describe('parseCodexAuthFile / readCodexRefreshToken', () => {
+  it('returns the stored refresh token', () => {
+    expect(parseCodexAuthFile(authJson())?.auth_mode).toBe('chatgpt');
+    expect(readCodexRefreshToken(authJson())).toBe('refresh-old');
+  });
+
+  it('returns null for unparseable JSON or a blank refresh token', () => {
+    expect(parseCodexAuthFile('not json')).toBeNull();
+    expect(readCodexRefreshToken(authJson({ refreshToken: '  ' }))).toBeNull();
+  });
+});
+
+describe('isCodexAuthExpiring', () => {
+  const now = 1_800_000_000_000;
+
+  it('is false for API-key files with no refresh token', () => {
+    expect(isCodexAuthExpiring(JSON.stringify({ openai_api_key: 'sk-test' }), now)).toBe(false);
+  });
+
+  it('is true when the access-token JWT is inside the refresh buffer', () => {
+    const expSeconds = Math.floor((now + OAUTH_EXPIRY_BUFFER_MS - 1000) / 1000);
+    expect(isCodexAuthExpiring(authJson({
+      accessToken: jwtWithExp(expSeconds),
+      lastRefresh: new Date(now).toISOString(),
+    }), now)).toBe(true);
+  });
+
+  it('is false when the JWT has more than the buffer left and last_refresh is recent', () => {
+    const expSeconds = Math.floor((now + OAUTH_EXPIRY_BUFFER_MS + 60_000) / 1000);
+    expect(isCodexAuthExpiring(authJson({
+      accessToken: jwtWithExp(expSeconds),
+      lastRefresh: new Date(now).toISOString(),
+    }), now)).toBe(false);
+  });
+
+  it('is true when last_refresh is older than seven days', () => {
+    const expSeconds = Math.floor((now + 60 * 60 * 1000) / 1000);
+    expect(isCodexAuthExpiring(authJson({
+      accessToken: jwtWithExp(expSeconds),
+      lastRefresh: new Date(now - CODEX_LAST_REFRESH_MAX_AGE_MS - 1).toISOString(),
+    }), now)).toBe(true);
+  });
+
+  it('is true when expiry metadata is missing or unparseable', () => {
+    expect(isCodexAuthExpiring(JSON.stringify({
+      tokens: { refresh_token: 'refresh-old', access_token: 'not-a-jwt' },
+    }), now)).toBe(true);
+  });
+});
+
+describe('applyRefreshedCodexToken', () => {
+  it('overwrites access_token, rotates refresh_token, and stamps last_refresh', () => {
+    const result = applyRefreshedCodexToken(
+      authJson({ extra: { keep: 'me' } }),
+      { access_token: 'access-new', id_token: 'id-new', refresh_token: 'refresh-new' },
+      1_000_000_000_000,
+    );
+    const parsed = JSON.parse(result!);
+    expect(parsed.keep).toBe('me');
+    expect(parsed.tokens).toMatchObject({
+      access_token: 'access-new',
+      id_token: 'id-new',
+      refresh_token: 'refresh-new',
+    });
+    expect(parsed.last_refresh).toBe(new Date(1_000_000_000_000).toISOString());
+  });
+
+  it('keeps the existing refresh token when the server does not rotate it', () => {
+    const result = applyRefreshedCodexToken(authJson(), { access_token: 'access-new' });
+    expect(JSON.parse(result!).tokens.refresh_token).toBe('refresh-old');
+  });
+
+  it('returns null when the response has no usable access_token', () => {
+    expect(applyRefreshedCodexToken(authJson(), {})).toBeNull();
+    expect(applyRefreshedCodexToken('not json', { access_token: 'x' })).toBeNull();
+  });
+});
+
+describe('refreshCodexOauthCredentials', () => {
+  it('posts JSON grant_type=refresh_token and returns updated credentials on success', async () => {
+    const calls: Array<{ url: string; init: unknown }> = [];
+    const result = await refreshCodexOauthCredentials(authJson(), {
+      now: 1_000_000_000_000,
+      fetchFn: async (url, init) => {
+        calls.push({ url, init });
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ access_token: 'access-new', refresh_token: 'refresh-new' }),
+        };
+      },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe('https://auth.openai.com/oauth/token');
+    expect(JSON.parse((calls[0].init as { body: string }).body)).toEqual({
+      client_id: 'app_EMoamEEZ73f0CkXaXp7hrann',
+      grant_type: 'refresh_token',
+      refresh_token: 'refresh-old',
+    });
+    expect(JSON.parse(result!).tokens.access_token).toBe('access-new');
+    expect(JSON.parse(result!).tokens.refresh_token).toBe('refresh-new');
+  });
+
+  it('returns null without a network call when there is no refresh token', async () => {
+    let called = false;
+    const result = await refreshCodexOauthCredentials(JSON.stringify({ openai_api_key: 'sk-test' }), {
+      fetchFn: async () => { called = true; return { ok: true, status: 200, json: async () => ({}) }; },
+    });
+    expect(called).toBe(false);
+    expect(result).toBeNull();
+  });
+
+  it('returns null on a non-2xx response or a thrown network error', async () => {
+    expect(await refreshCodexOauthCredentials(authJson(), {
+      fetchFn: async () => ({ ok: false, status: 401, json: async () => ({ error: 'invalid_grant' }) }),
+    })).toBeNull();
+    expect(await refreshCodexOauthCredentials(authJson(), {
+      fetchFn: async () => { throw new Error('ECONNRESET'); },
+    })).toBeNull();
+  });
+});

--- a/packages/execution-engine/src/__tests__/harness-session-driver.test.ts
+++ b/packages/execution-engine/src/__tests__/harness-session-driver.test.ts
@@ -3,6 +3,7 @@ import { ExecutionHarnessSessionDriver, ReplayHarnessSessionDriver } from '../ha
 import { ClaudeExecutionAgent } from '../agents/claude-execution-agent.js';
 import { CodexExecutionAgent } from '../agents/codex-execution-agent.js';
 import { OmpExecutionAgent } from '../agents/omp-execution-agent.js';
+import { CursorExecutionAgent } from '../agents/cursor-execution-agent.js';
 import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions } from '../agent.js';
 
 describe('ExecutionHarnessSessionDriver', () => {
@@ -208,6 +209,41 @@ describe('ExecutionHarnessSessionDriver', () => {
         'chatgpt-5.4',
         '-p',
         'Ship it',
+      ]);
+    });
+  });
+
+  describe('cursor', () => {
+    const driver = new ExecutionHarnessSessionDriver(new CursorExecutionAgent({ command: 'cursor-test' }));
+
+    it('append resumes with print/trust and the trailing prompt', () => {
+      const result = driver.append('session-cursor', 'Now add a test', { model: 'grok-4.5' });
+
+      expect(driver.harness).toBe('cursor');
+      expect(result.command).toBe('cursor-test');
+      expect(result.sessionId).toBe('session-cursor');
+      expect(result.args).toEqual([
+        'agent',
+        '--resume',
+        'session-cursor',
+        '--print',
+        '--trust',
+        '--model',
+        'grok-4.5',
+        'Now add a test',
+      ]);
+    });
+
+    it('append omits model args when no model is given', () => {
+      const result = driver.append('session-cursor', 'Now add a test');
+
+      expect(result.args).toEqual([
+        'agent',
+        '--resume',
+        'session-cursor',
+        '--print',
+        '--trust',
+        'Now add a test',
       ]);
     });
   });

--- a/packages/execution-engine/src/codex-oauth-refresh.ts
+++ b/packages/execution-engine/src/codex-oauth-refresh.ts
@@ -1,0 +1,147 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { OAUTH_EXPIRY_BUFFER_MS, type OauthFetchFn } from './claude-oauth-refresh.js';
+
+const DEFAULT_OAUTH_TOKEN_URL = 'https://auth.openai.com/oauth/token';
+// Public Codex CLI OAuth client id — not a secret, the same value the
+// `codex` CLI itself sends on every refresh request.
+const OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+const REFRESH_TIMEOUT_MS = 10_000;
+export const CODEX_LAST_REFRESH_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface CodexTokenBlob {
+  access_token?: unknown;
+  id_token?: unknown;
+  refresh_token?: unknown;
+  [key: string]: unknown;
+}
+
+interface CodexAuthFile {
+  tokens?: CodexTokenBlob;
+  last_refresh?: unknown;
+  [key: string]: unknown;
+}
+
+interface CodexTokenEndpointResponse {
+  access_token?: unknown;
+  id_token?: unknown;
+  refresh_token?: unknown;
+}
+
+export function resolveCodexAuthPath(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env.INVOKER_CODEX_AUTH_PATH?.trim();
+  if (override) return override;
+  const home = env.CODEX_HOME?.trim() || join(homedir(), '.codex');
+  return join(home, 'auth.json');
+}
+
+export function resolveCodexRefreshTokenUrl(env: NodeJS.ProcessEnv = process.env): string {
+  return env.CODEX_REFRESH_TOKEN_URL_OVERRIDE?.trim() || DEFAULT_OAUTH_TOKEN_URL;
+}
+
+export function parseCodexAuthFile(authJson: string): CodexAuthFile | null {
+  try {
+    const parsed = JSON.parse(authJson) as CodexAuthFile;
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function readCodexRefreshToken(authJson: string): string | null {
+  const parsed = parseCodexAuthFile(authJson);
+  const token = parsed?.tokens?.refresh_token;
+  return typeof token === 'string' && token.trim() !== '' ? token.trim() : null;
+}
+
+function readJwtExpMs(accessToken: string): number | null {
+  const parts = accessToken.split('.');
+  if (parts.length < 2) return null;
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')) as { exp?: unknown };
+    if (typeof payload.exp !== 'number' || !Number.isFinite(payload.exp)) return null;
+    return payload.exp * 1000;
+  } catch {
+    return null;
+  }
+}
+
+function readLastRefreshMs(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+/**
+ * True when a ChatGPT-login Codex auth blob should be refreshed. API-key
+ * files (no refresh token) are never treated as expiring. A missing or
+ * unparseable expiry is treated as "needs refresh".
+ */
+export function isCodexAuthExpiring(authJson: string, now: number = Date.now()): boolean {
+  if (!readCodexRefreshToken(authJson)) return false;
+  const parsed = parseCodexAuthFile(authJson);
+  const accessToken = parsed?.tokens?.access_token;
+  const jwtExpMs = typeof accessToken === 'string' ? readJwtExpMs(accessToken) : null;
+  const lastRefreshMs = readLastRefreshMs(parsed?.last_refresh);
+  if (jwtExpMs === null && lastRefreshMs === null) return true;
+  if (jwtExpMs !== null && now + OAUTH_EXPIRY_BUFFER_MS >= jwtExpMs) return true;
+  if (lastRefreshMs !== null && now - lastRefreshMs >= CODEX_LAST_REFRESH_MAX_AGE_MS) return true;
+  return false;
+}
+
+export function applyRefreshedCodexToken(
+  authJson: string,
+  response: CodexTokenEndpointResponse,
+  now: number = Date.now(),
+): string | null {
+  const parsed = parseCodexAuthFile(authJson);
+  if (!parsed) return null;
+  const accessToken = response.access_token;
+  if (typeof accessToken !== 'string' || accessToken.trim() === '') return null;
+
+  const tokens: CodexTokenBlob = { ...parsed.tokens };
+  tokens.access_token = accessToken;
+  if (typeof response.id_token === 'string' && response.id_token.trim() !== '') {
+    tokens.id_token = response.id_token;
+  }
+  if (typeof response.refresh_token === 'string' && response.refresh_token.trim() !== '') {
+    tokens.refresh_token = response.refresh_token;
+  }
+  parsed.tokens = tokens;
+  parsed.last_refresh = new Date(now).toISOString();
+  return JSON.stringify(parsed);
+}
+
+export async function refreshCodexOauthCredentials(
+  authJson: string,
+  opts: { fetchFn?: OauthFetchFn; now?: number; env?: NodeJS.ProcessEnv } = {},
+): Promise<string | null> {
+  const refreshToken = readCodexRefreshToken(authJson);
+  if (!refreshToken) return null;
+
+  const fetchFn = opts.fetchFn ?? (globalThis.fetch as OauthFetchFn | undefined);
+  if (!fetchFn) return null;
+  const now = opts.now ?? Date.now();
+
+  try {
+    const res = await fetchFn(resolveCodexRefreshTokenUrl(opts.env), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_id: OAUTH_CLIENT_ID,
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+      }),
+      signal: AbortSignal.timeout(REFRESH_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    const body = await res.json() as CodexTokenEndpointResponse;
+    return applyRefreshedCodexToken(authJson, body, now);
+  } catch {
+    return null;
+  }
+}

--- a/packages/execution-engine/src/harness-session-driver.ts
+++ b/packages/execution-engine/src/harness-session-driver.ts
@@ -90,6 +90,8 @@ export class ExecutionHarnessSessionDriver implements HarnessSessionDriver {
         return ['exec', 'resume', ...resumeArgs.slice(1), ...(model ? ['--model', model] : []), prompt];
       case 'omp':
         return [...resumeArgs, ...(model ? ['--model', model] : []), '-p', prompt];
+      case 'cursor':
+        return [...resumeArgs, '--print', '--trust', ...(model ? ['--model', model] : []), prompt];
       default:
         throw new Error(`Harness "${this.agent.name}" does not support non-interactive session append.`);
     }

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -70,6 +70,7 @@ export * from './workers/auto-approve-worker.js';
 export * from './workers/disk-headroom-worker.js';
 export * from './workers/claude-oauth-refresh-worker.js';
 export * from './claude-oauth-refresh.js';
+export * from './codex-oauth-refresh.js';
 export * from './workers/disk-headroom-monitor.js';
 export * from './workers/disk-headroom-reclaim.js';
 export * from './workers/disk-headroom.js';

--- a/packages/execution-engine/src/workers/claude-oauth-refresh-worker.ts
+++ b/packages/execution-engine/src/workers/claude-oauth-refresh-worker.ts
@@ -9,6 +9,11 @@ import {
   refreshClaudeOauthCredentials,
   type OauthFetchFn,
 } from '../claude-oauth-refresh.js';
+import {
+  isCodexAuthExpiring,
+  refreshCodexOauthCredentials,
+  resolveCodexAuthPath,
+} from '../codex-oauth-refresh.js';
 import { recordWorkerDecisionRow, type WorkerDecisionStore } from '../worker-decision-ledger.js';
 import { base64Encode, execRemoteCapture } from '../ssh-git-exec.js';
 import { buildSshConnectionArgs } from '../ssh-transport-options.js';
@@ -19,6 +24,8 @@ import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../wor
 
 export const CLAUDE_OAUTH_REFRESH_WORKER_KIND = 'claude-oauth-refresh';
 export const DEFAULT_CLAUDE_OAUTH_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
+const DEFAULT_CODEX_REMOTE_AUTH_PATH = '~/.codex/auth.json';
+const DEFAULT_CLAUDE_REMOTE_CREDENTIALS_PATH = '~/.claude/.credentials.json';
 
 export interface ClaudeOauthRefreshTarget {
   name: string;
@@ -42,6 +49,13 @@ export interface ClaudeOauthRefreshWorkerConfig {
   writeCredentials?: (path: string, contents: string) => void;
   refreshFn?: (credentialsJson: string) => Promise<string | null>;
   distributeFn?: (target: ClaudeOauthRefreshTarget, credentialsJson: string) => Promise<void>;
+  /** Local Codex auth.json path. Defaults to $CODEX_HOME/auth.json or ~/.codex/auth.json. */
+  codexAuthPath?: string;
+  readCodexCredentials?: (path: string) => string;
+  readRemoteCodexCredentials?: (target: ClaudeOauthRefreshTarget) => Promise<string | null>;
+  writeCodexCredentials?: (path: string, contents: string) => void;
+  refreshCodexFn?: (authJson: string) => Promise<string | null>;
+  distributeCodexFn?: (target: ClaudeOauthRefreshTarget, authJson: string) => Promise<void>;
   fetchFn?: OauthFetchFn;
   now?: () => number;
   onTick?: WorkerTick;
@@ -61,6 +75,19 @@ export interface ClaudeOauthRefreshWorkerOptions {
   distributeFn?: (target: ClaudeOauthRefreshTarget, credentialsJson: string) => Promise<void>;
   now?: () => number;
   onTick?: WorkerTick;
+}
+
+export interface CodexOauthRefreshWorkerOptions {
+  logger: Logger;
+  authPath: string;
+  remoteTargets: ClaudeOauthRefreshTarget[];
+  store?: WorkerDecisionStore;
+  readCredentials?: (path: string) => string;
+  readRemoteCredentials?: (target: ClaudeOauthRefreshTarget) => Promise<string | null>;
+  writeCredentials?: (path: string, contents: string) => void;
+  refreshFn?: (authJson: string) => Promise<string | null>;
+  distributeFn?: (target: ClaudeOauthRefreshTarget, authJson: string) => Promise<void>;
+  now?: () => number;
 }
 
 export function resolveClaudeCredentialsPath(env: NodeJS.ProcessEnv = process.env): string {
@@ -104,29 +131,66 @@ chmod 600 "$TMP_PATH"
 mv "$TMP_PATH" "$REMOTE_PATH"`;
 }
 
-function defaultDistribute(target: ClaudeOauthRefreshTarget, credentialsJson: string): Promise<void> {
-  const remotePath = target.remotePath ?? '~/.claude/.credentials.json';
+function defaultDistributeToPath(
+  target: ClaudeOauthRefreshTarget,
+  credentialsJson: string,
+  remotePath: string,
+  phase: string,
+): Promise<void> {
   const sshArgs = buildSshConnectionArgs(target.connection, { batchMode: true });
   return execRemoteCapture({
     sshArgs,
     script: buildDistributeCredentialsScript(remotePath, credentialsJson),
-    phase: `claude-oauth-refresh:${target.name}`,
+    phase,
   }).then(() => undefined);
 }
 
-async function defaultReadRemoteCredentials(target: ClaudeOauthRefreshTarget): Promise<string | null> {
-  const remotePath = target.remotePath ?? '~/.claude/.credentials.json';
+function defaultDistribute(target: ClaudeOauthRefreshTarget, credentialsJson: string): Promise<void> {
+  return defaultDistributeToPath(
+    target,
+    credentialsJson,
+    target.remotePath ?? DEFAULT_CLAUDE_REMOTE_CREDENTIALS_PATH,
+    `claude-oauth-refresh:${target.name}`,
+  );
+}
+
+function defaultDistributeCodex(target: ClaudeOauthRefreshTarget, authJson: string): Promise<void> {
+  return defaultDistributeToPath(
+    target,
+    authJson,
+    DEFAULT_CODEX_REMOTE_AUTH_PATH,
+    `codex-oauth-refresh:${target.name}`,
+  );
+}
+
+async function defaultReadRemoteFile(target: ClaudeOauthRefreshTarget, remotePath: string, phase: string): Promise<string | null> {
   const sshArgs = buildSshConnectionArgs(target.connection, { batchMode: true });
   try {
     const output = await execRemoteCapture({
       sshArgs,
       script: `cat "${remotePath}" 2>/dev/null || true`,
-      phase: `claude-oauth-refresh-check:${target.name}`,
+      phase,
     });
     return output.trim() ? output : null;
   } catch {
     return null;
   }
+}
+
+async function defaultReadRemoteCredentials(target: ClaudeOauthRefreshTarget): Promise<string | null> {
+  return defaultReadRemoteFile(
+    target,
+    target.remotePath ?? DEFAULT_CLAUDE_REMOTE_CREDENTIALS_PATH,
+    `claude-oauth-refresh-check:${target.name}`,
+  );
+}
+
+async function defaultReadRemoteCodexCredentials(target: ClaudeOauthRefreshTarget): Promise<string | null> {
+  return defaultReadRemoteFile(
+    target,
+    DEFAULT_CODEX_REMOTE_AUTH_PATH,
+    `codex-oauth-refresh-check:${target.name}`,
+  );
 }
 
 function recordDecision(
@@ -150,22 +214,23 @@ function recordDecision(
 }
 
 async function distributeToTarget(
-  options: ClaudeOauthRefreshWorkerOptions,
-  distribute: NonNullable<ClaudeOauthRefreshWorkerOptions['distributeFn']> | typeof defaultDistribute,
+  options: { logger: Logger; store?: WorkerDecisionStore },
+  distribute: (target: ClaudeOauthRefreshTarget, contents: string) => Promise<void>,
   target: ClaudeOauthRefreshTarget,
   credentialsJson: string,
   summary: string,
+  subjectId: string = target.name,
 ): Promise<void> {
   try {
     await distribute(target, credentialsJson);
-    recordDecision(options.store, target.name, 'completed', summary);
+    recordDecision(options.store, subjectId, 'completed', summary);
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     options.logger.error(`[${CLAUDE_OAUTH_REFRESH_WORKER_KIND}] failed to distribute to ${target.name}: ${detail}`, {
       module: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
       target: target.name,
     });
-    recordDecision(options.store, target.name, 'failed', `Failed to distribute credentials to ${target.name}: ${detail}`);
+    recordDecision(options.store, subjectId, 'failed', `Failed to distribute credentials to ${target.name}: ${detail}`);
   }
 }
 
@@ -231,6 +296,97 @@ export async function runClaudeOauthRefreshCheck(options: ClaudeOauthRefreshWork
   }
 }
 
+export async function runCodexOauthRefreshCheck(options: CodexOauthRefreshWorkerOptions): Promise<void> {
+  const readCredentials = options.readCredentials ?? defaultReadCredentials;
+  const readRemoteCredentials = options.readRemoteCredentials ?? defaultReadRemoteCodexCredentials;
+  const writeCredentials = options.writeCredentials ?? defaultWriteCredentials;
+  const distribute = options.distributeFn ?? defaultDistributeCodex;
+  const now = options.now ?? Date.now;
+
+  let authJson: string;
+  try {
+    authJson = readCredentials(options.authPath);
+  } catch (error) {
+    options.logger.error(`[${CLAUDE_OAUTH_REFRESH_WORKER_KIND}] failed to read ${options.authPath}: ${error instanceof Error ? error.message : String(error)}`, {
+      module: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+    });
+    return;
+  }
+
+  if (!isCodexAuthExpiring(authJson, now())) {
+    for (const target of options.remoteTargets) {
+      let remoteJson: string | null;
+      try {
+        remoteJson = await readRemoteCredentials(target);
+      } catch (error) {
+        options.logger.error(`[${CLAUDE_OAUTH_REFRESH_WORKER_KIND}] failed to read remote Codex auth for ${target.name}: ${error instanceof Error ? error.message : String(error)}`, {
+          module: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+          target: target.name,
+        });
+        remoteJson = null;
+      }
+      const remoteNeedsDistribution = remoteJson === null || isCodexAuthExpiring(remoteJson, now());
+      if (!remoteNeedsDistribution) continue;
+      await distributeToTarget(
+        options,
+        distribute,
+        target,
+        authJson,
+        `Distributed current Codex auth to ${target.name} (its own copy was stale)`,
+        `codex:${target.name}`,
+      );
+    }
+    return;
+  }
+
+  const refresh = options.refreshFn ?? ((json: string) => refreshCodexOauthCredentials(json, { now: now() }));
+  const refreshed = await refresh(authJson);
+  if (!refreshed) {
+    options.logger.error(`[${CLAUDE_OAUTH_REFRESH_WORKER_KIND}] Codex token refresh failed for ${options.authPath}; leaving existing auth in place`, {
+      module: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+    });
+    recordDecision(options.store, 'codex:local', 'failed', 'Codex OAuth token refresh request failed');
+    return;
+  }
+
+  writeCredentials(options.authPath, refreshed);
+  recordDecision(options.store, 'codex:local', 'completed', 'Refreshed local Codex OAuth credentials');
+  options.logger.info(`[${CLAUDE_OAUTH_REFRESH_WORKER_KIND}] refreshed local Codex auth`, {
+    module: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+  });
+
+  for (const target of options.remoteTargets) {
+    await distributeToTarget(
+      options,
+      distribute,
+      target,
+      refreshed,
+      `Distributed refreshed Codex auth to ${target.name}`,
+      `codex:${target.name}`,
+    );
+  }
+}
+
+export async function runClaudeAndCodexOauthRefreshCheck(
+  claude: ClaudeOauthRefreshWorkerOptions,
+  codex: CodexOauthRefreshWorkerOptions,
+): Promise<void> {
+  try {
+    await runClaudeOauthRefreshCheck(claude);
+  } catch (error) {
+    claude.logger.error(`[${CLAUDE_OAUTH_REFRESH_WORKER_KIND}] Claude pass threw: ${error instanceof Error ? error.message : String(error)}`, {
+      module: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+    });
+  }
+  try {
+    await runCodexOauthRefreshCheck(codex);
+  } catch (error) {
+    codex.logger.error(`[${CLAUDE_OAUTH_REFRESH_WORKER_KIND}] Codex pass threw: ${error instanceof Error ? error.message : String(error)}`, {
+      module: CLAUDE_OAUTH_REFRESH_WORKER_KIND,
+    });
+  }
+}
+
 export function createClaudeOauthRefreshWorker(config: ClaudeOauthRefreshWorkerConfig & { logger: Logger }): WorkerRuntime {
   const options: ClaudeOauthRefreshWorkerOptions = {
     logger: config.logger,
@@ -246,8 +402,22 @@ export function createClaudeOauthRefreshWorker(config: ClaudeOauthRefreshWorkerC
     distributeFn: config.distributeFn,
     now: config.now,
   };
+  const codexOptions: CodexOauthRefreshWorkerOptions = {
+    logger: config.logger,
+    authPath: config.codexAuthPath ?? resolveCodexAuthPath(),
+    remoteTargets: config.remoteTargets ?? [],
+    store: config.store,
+    readCredentials: config.readCodexCredentials,
+    readRemoteCredentials: config.readRemoteCodexCredentials,
+    writeCredentials: config.writeCodexCredentials,
+    refreshFn: config.refreshCodexFn ?? (config.fetchFn
+      ? (json: string) => refreshCodexOauthCredentials(json, { fetchFn: config.fetchFn, now: config.now?.() })
+      : undefined),
+    distributeFn: config.distributeCodexFn,
+    now: config.now,
+  };
   const onTick: WorkerTick = config.onTick ?? (async () => {
-    await runClaudeOauthRefreshCheck(options);
+    await runClaudeAndCodexOauthRefreshCheck(options, codexOptions);
   });
   return createWorkerRuntime({
     kind: CLAUDE_OAUTH_REFRESH_WORKER_KIND,

--- a/packages/surfaces/src/__tests__/slack-cursor-planning.e2e.test.ts
+++ b/packages/surfaces/src/__tests__/slack-cursor-planning.e2e.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import * as childProcess from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  ConversationRepository,
+  SlackPlanDraftRepository,
+  SlackSessionRepository,
+  SQLiteAdapter,
+} from '@invoker/data-store';
+import { registerBuiltinAgents } from '@invoker/execution-engine';
+import { SlackSurface } from '../slack/slack-surface.js';
+import { selectHarnessSessionDriver } from '../slack/harness-session-driver-select.js';
+import type { SurfaceCommand } from '../surface.js';
+
+/**
+ * End-to-end proof that Slack planning with the real slack-manager wiring
+ * (`registerBuiltinAgents` + `selectHarnessSessionDriver`) can start and
+ * append a Cursor session without throwing, and that `/plan` YAML stages
+ * Approve/Cancel. Spawn is mocked; Bolt is mocked; the harness argv path is real.
+ */
+
+interface MockHandler {
+  pattern: string | RegExp;
+  handler: Function;
+}
+
+const sharedSlack = vi.hoisted(() => ({
+  client: {
+    auth: { test: vi.fn().mockResolvedValue({ user_id: 'UBOT' }) },
+    chat: {
+      postMessage: vi.fn().mockResolvedValue({ ts: 'posted' }),
+      update: vi.fn().mockResolvedValue({}),
+      delete: vi.fn().mockResolvedValue({}),
+    },
+    reactions: { add: vi.fn().mockResolvedValue({}), remove: vi.fn().mockResolvedValue({}) },
+    conversations: { replies: vi.fn().mockResolvedValue({ messages: [] }) },
+    files: { uploadV2: vi.fn().mockResolvedValue({ ok: true, files: [{ ok: true, files: [{ id: 'F-CURSOR' }] }] }) },
+  },
+}));
+
+vi.mock('@slack/bolt', () => {
+  class MockApp {
+    _eventHandlers: MockHandler[] = [];
+    _actionHandlers: MockHandler[] = [];
+    command = vi.fn();
+    event = vi.fn((pattern: string, handler: Function) => this._eventHandlers.push({ pattern, handler }));
+    action = vi.fn((pattern: string | RegExp, handler: Function) => this._actionHandlers.push({ pattern, handler }));
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    client = sharedSlack.client;
+  }
+  return { App: MockApp };
+});
+
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:child_process')>()),
+  spawn: vi.fn(),
+}));
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+const silentLog = () => {};
+
+const PLAN_YAML = `\`\`\`yaml
+name: "Cursor planning proof"
+repoUrl: "https://github.com/example/repo.git"
+onFinish: pull_request
+mergeMode: none
+tasks:
+  - id: prove-cursor
+    description: "Prove Slack cursor append works"
+    command: "pnpm test"
+    dependencies: []
+\`\`\``;
+
+function processWith(stdout: string): any {
+  const process = new EventEmitter() as any;
+  process.stdout = new EventEmitter();
+  process.stderr = new EventEmitter();
+  process.kill = vi.fn();
+  queueMicrotask(() => {
+    process.stdout.emit('data', Buffer.from(stdout));
+    process.emit('close', 0);
+  });
+  return process;
+}
+
+function handler(surface: SlackSurface, pattern: string): Function {
+  const found = (surface.getApp() as any)._eventHandlers.find((entry: MockHandler) => entry.pattern === pattern);
+  if (!found) throw new Error(`Missing ${pattern} handler`);
+  return found.handler;
+}
+
+async function start(surface: SlackSurface, commands: SurfaceCommand[]) {
+  await surface.start(async (command) => { commands.push(command); });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function mention(surface: SlackSurface, text: string, ts: string, threadTs?: string) {
+  const say = vi.fn().mockResolvedValue({ ts: `${ts}-reply` });
+  await handler(surface, 'app_mention')({
+    event: { text: `<@UBOT> ${text}`, ts, thread_ts: threadTs, user: 'U_CURSOR', channel: 'C_LOBBY' },
+    say,
+  });
+  return say;
+}
+
+function spawnArgv(): string[] {
+  const call = mockSpawn.mock.calls.at(-1);
+  if (!call) throw new Error('expected a spawn call');
+  const [command, args] = call as [string, string[]];
+  return [command, ...args];
+}
+
+describe('Slack cursor+grok planning e2e', () => {
+  let adapter: SQLiteAdapter;
+  let repo: ConversationRepository;
+  let slackSessions: SlackSessionRepository;
+  let slackPlanDrafts: SlackPlanDraftRepository;
+  let workingDir: string;
+  let surfaces: SlackSurface[];
+
+  beforeEach(async () => {
+    mockSpawn.mockReset();
+    sharedSlack.client.auth.test.mockClear();
+    sharedSlack.client.chat.postMessage.mockClear();
+    sharedSlack.client.files.uploadV2.mockClear();
+    adapter = await SQLiteAdapter.create(':memory:');
+    repo = new ConversationRepository(adapter, { info: silentLog, warn: silentLog, error: silentLog });
+    slackSessions = new SlackSessionRepository(adapter);
+    slackPlanDrafts = new SlackPlanDraftRepository(adapter);
+    workingDir = mkdtempSync(join(tmpdir(), 'invoker-slack-cursor-'));
+    surfaces = [];
+  });
+
+  afterEach(async () => {
+    await Promise.all(surfaces.map((surface) => surface.stop()));
+    adapter.close();
+    rmSync(workingDir, { recursive: true, force: true });
+  });
+
+  function surface(commands: SurfaceCommand[]) {
+    // Same seams slack-manager uses on DO1 for cursor+grok planning.
+    const executionAgentRegistry = registerBuiltinAgents({
+      cursorExecution: { command: 'cursor-test' },
+    });
+    const planningCommandBuilder = (opts: { tool: string; model?: string; prompt: string }) =>
+      executionAgentRegistry.getPlanningOrThrow(opts.tool).buildPlanningCommand(opts.prompt, { model: opts.model });
+    const harnessSessionDriverFactory = (preset: { tool: string; model?: string }) =>
+      selectHarnessSessionDriver(preset, { executionAgentRegistry, planningCommandBuilder });
+
+    const created = new SlackSurface({
+      botToken: 'xoxb-cursor',
+      appToken: 'xapp-cursor',
+      signingSecret: 'cursor',
+      channelId: 'C_DEFAULT',
+      defaultRepoUrl: 'https://github.com/example/repo.git',
+      lobbyChannelId: 'C_LOBBY',
+      conversationRepo: repo,
+      slackSessionRepo: slackSessions,
+      slackPlanDraftRepo: slackPlanDrafts,
+      workingDir,
+      enableImmediateAck: false,
+      planningHeartbeatIntervalSeconds: 0,
+      log: silentLog,
+      harnessPresets: {
+        'cursor+grok': { tool: 'cursor', model: 'grok-4.5' },
+      },
+      defaultHarnessPreset: 'cursor+grok',
+      harnessSessionDriverFactory,
+      planningCommandBuilder,
+    });
+    surfaces.push(created);
+    return created;
+  }
+
+  it('starts with cursor agent --print --trust --model grok-4.5, resumes on /plan, and stages Approve/Cancel', async () => {
+    const commands: SurfaceCommand[] = [];
+    const slack = surface(commands);
+    await start(slack, commands);
+
+    mockSpawn.mockImplementationOnce(() => processWith('Looking at the request now.'));
+    await mention(slack, 'Please scope a small proof plan for cursor append.', 'cursor-thread');
+
+    const startArgv = spawnArgv();
+    expect(startArgv[0]).toBe('cursor-test');
+    expect(startArgv).toEqual(expect.arrayContaining(['agent', '--print', '--trust', '--model', 'grok-4.5']));
+    expect(startArgv).not.toContain('--resume');
+    const sessionIdIndex = startArgv.indexOf('--resume');
+    expect(sessionIdIndex).toBe(-1);
+    const startPrompt = startArgv.at(-1) ?? '';
+    expect(startPrompt).toContain('Please scope a small proof plan for cursor append.');
+
+    const planningContext = (slack as any).planningContexts.get('cursor-thread');
+    expect(planningContext?.harnessSessionId).toBeTruthy();
+    const sessionId = planningContext.harnessSessionId as string;
+
+    mockSpawn.mockImplementationOnce(() => processWith(PLAN_YAML));
+    const say = await mention(slack, '/plan', 'plan-turn', 'cursor-thread');
+
+    const appendArgv = spawnArgv();
+    expect(appendArgv.slice(0, 8)).toEqual([
+      'cursor-test',
+      'agent',
+      '--resume',
+      sessionId,
+      '--print',
+      '--trust',
+      '--model',
+      'grok-4.5',
+    ]);
+    expect(appendArgv).toHaveLength(9);
+
+    const draft = slackPlanDrafts.getReady('C_LOBBY', 'cursor-thread');
+    expect(draft).toEqual(expect.objectContaining({
+      status: 'ready',
+      planText: expect.stringContaining('name: Cursor planning proof'),
+    }));
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({
+      thread_ts: 'cursor-thread',
+      blocks: expect.arrayContaining([
+        expect.objectContaining({
+          elements: expect.arrayContaining([
+            expect.objectContaining({ action_id: 'plan_draft_approve', text: expect.objectContaining({ text: 'Approve' }) }),
+            expect.objectContaining({ action_id: 'plan_draft_cancel', text: expect.objectContaining({ text: 'Cancel' }) }),
+          ]),
+        }),
+      ]),
+    }));
+    expect(commands).not.toContainEqual(expect.objectContaining({ type: 'start_plan' }));
+  });
+});


### PR DESCRIPTION
## Summary

Slack Cursor planning crashed on the second turn because append was unsupported once Cursor became an execution agent.

The same hourly Claude OAuth worker now also refreshes Codex ChatGPT login and redistributes `~/.codex/auth.json` to SSH pool hosts.

Claude failure no longer skips the Codex pass, and a missing Codex auth file stays a no-op.

## Review Claim

Approve that Slack can start and resume Cursor planning sessions, and that the existing OAuth worker independently refreshes and redistributes Codex auth without coupling to Claude success.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

No token values are logged. Codex refresh never throws into the Claude path. Missing `auth.json` does not fail Claude. Remote Codex always uses `~/.codex/auth.json`, ignoring Claude `remotePath`.

## Slice Rationale

Both fixes landed together because they unblock the same DO1 Slack planning path: Cursor+Grok turns need append, and Codex auth must stay fresh on the same fleet hosts.

## Non-goals

Does not change worker kind, auto-start gate, or add a Codex-only kill switch. Does not deploy to DO1 or change live Slack presets.

## Architecture

### Before

```mermaid
flowchart LR
  tick["hourly tick"] --> claude["Claude only"]
  claude --> distC["SSH ~/.claude/.credentials.json"]
  append["Slack Cursor append"] --> throw["throws unsupported"]
```

### After

```mermaid
flowchart LR
  tick["hourly tick"] --> claude["Claude pass"]
  tick --> codex["Codex pass"]
  claude --> distC["SSH ~/.claude/.credentials.json"]
  codex --> distX["SSH ~/.codex/auth.json"]
  append["Slack Cursor append"] --> resume["cursor agent --resume --print --trust"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/harness-session-driver.test.ts src/__tests__/codex-oauth-refresh.test.ts src/__tests__/claude-oauth-refresh-worker.test.ts`
- [x] `cd packages/execution-engine && pnpm test` (131 files, 1695 passed)
- [x] `cd packages/surfaces && pnpm test -- src/__tests__/slack-cursor-planning.e2e.test.ts`
- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/claude-oauth-refresh-worker.test.ts` (includes filesystem worker e2e tick)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 68383b5562`
- Post-revert steps: None
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Codex OAuth credential refresh, including expiration handling and secure credential distribution.
  * Claude and Codex authentication checks now operate independently, improving reliability when one provider encounters an issue.
  * Added non-interactive Cursor session continuation with optional model selection.
  * Enhanced Slack planning with Cursor-based session resumption, approval, and cancellation actions.

* **Bug Fixes**
  * Improved handling of missing, stale, invalid, or unavailable authentication credentials without interrupting other provider workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->