### PR TITLE
[First Agent Tutorial] Restart stale owners for hot development

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "clean": "pnpm -r clean",
     "setup:agent-skills": "bash scripts/setup-agent-skills.sh",
     "dev": "pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && pnpm --filter @invoker/app start",
-    "dev:hot": "concurrently --kill-others-on-fail \"pnpm --filter @invoker/ui exec vite --host 127.0.0.1 --port 5173 --strictPort\" \"sleep 3 && VITE_DEV_SERVER_URL=http://127.0.0.1:5173 pnpm --filter @invoker/app build && VITE_DEV_SERVER_URL=http://127.0.0.1:5173 pnpm --filter @invoker/app start\"",
+    "dev:hot": "bash scripts/cleanup-local-invoker-processes.sh && concurrently --kill-others-on-fail \"pnpm --filter @invoker/ui exec vite --host 127.0.0.1 --port 5173 --strictPort\" \"sleep 3 && VITE_DEV_SERVER_URL=http://127.0.0.1:5173 pnpm --filter @invoker/app build && VITE_DEV_SERVER_URL=http://127.0.0.1:5173 pnpm --filter @invoker/app start\"",
     "dev:cli": "pnpm --filter @invoker/cli build && node packages/cli/dist/index.js",
     "check:required-builds": "bash scripts/required-builds.sh",
     "check:deps": "depcruise packages --config .dependency-cruiser.js",

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2812,6 +2812,7 @@ startMainProcessBootstrap({
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
+        process.exitCode = 1;
         app.quit();
         return;
       }
@@ -2827,6 +2828,7 @@ startMainProcessBootstrap({
         const message = err instanceof Error ? err.message : String(err);
         if (!message.includes('[db-writer-lock]')) {
           process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
+          process.exitCode = 1;
           app.quit();
           return;
         }
@@ -2834,6 +2836,7 @@ startMainProcessBootstrap({
         if (!isStandaloneCapable(owner)) {
           process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
           process.stderr.write(`${RED}Detached viewer fallback requires a reachable owner, but no owner answered IPC.\n${RESET}`);
+          process.exitCode = 1;
           app.quit();
           return;
         }

--- a/run.sh
+++ b/run.sh
@@ -106,7 +106,7 @@ fi
 if ! node ./scripts/cleanup-orphaned-automation-chrome.mjs; then
   echo "WARN: orphaned automation Chrome cleanup failed; continuing launch" >&2
 fi
-pkill -f "electron.*packages/app/dist/main.js" 2>/dev/null || true
+bash "$REPO_ROOT/scripts/cleanup-local-invoker-processes.sh"
 pkill -f "tsup.*packages/app" 2>/dev/null || true
 sleep 0.2
 

--- a/scripts/cleanup-local-invoker-processes.sh
+++ b/scripts/cleanup-local-invoker-processes.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MAIN_JS="$REPO_ROOT/packages/app/dist/main.js"
+
+PIDS="$(pgrep -f "$MAIN_JS" 2>/dev/null || true)"
+if [ -z "$PIDS" ]; then
+  exit 0
+fi
+
+while IFS= read -r pid; do
+  [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+done <<< "$PIDS"
+
+for _ in {1..20}; do
+  if ! pgrep -f "$MAIN_JS" >/dev/null 2>&1; then
+    exit 0
+  fi
+  sleep 0.1
+done
+
+PIDS="$(pgrep -f "$MAIN_JS" 2>/dev/null || true)"
+while IFS= read -r pid; do
+  [ -n "$pid" ] && kill -KILL "$pid" 2>/dev/null || true
+done <<< "$PIDS"


### PR DESCRIPTION
## Summary

Make `dev:hot` replace stale owner processes from the current checkout before launching.

GUI startup failures now exit non-zero instead of appearing successful.

## Review Claim

Hot development starts against a fresh compatible owner from the same checkout.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Cleanup matches only Invoker Electron processes whose command contains this checkout's absolute `packages/app/dist/main.js` path.

## Slice Rationale

Launcher cleanup and failure propagation jointly define one reliable development startup path.

## Non-goals

No production owner lifecycle, unrelated Electron process, or renderer HMR behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash -n scripts/cleanup-local-invoker-processes.sh`
- [x] `bash -n run.sh`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm dev:hot` with an existing detached owner, followed by a Vite readiness probe

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 213581d8e`
- Post-revert steps: Restart development processes
- Data migration? No

</details>
