### PR TITLE
[First Agent Tutorial] Keep planning bound to its repository

### DIFF
--- a/plans/rendered/step-1-persistence.yaml
+++ b/plans/rendered/step-1-persistence.yaml
@@ -1,0 +1,69 @@
+name: "PR #9903 rebase (1) contracts layer"
+description: |
+  Add PR #9903's `repoBinding?: InAppPlanningRepoBinding` field to
+  `InAppPlanningChatRequest` in packages/contracts/src/ipc-channels.ts
+  alongside the `turnId?: string` field master independently added in the
+  same interface (web-surface-parity stack, #9963/#9977). Both fields are
+  additive and optional; there is no semantic conflict here, only a textual
+  one from two unrelated features touching the same interface body. This is
+  the bottom of the stack; the domain (in-app-planner.ts) and ui (App.tsx)
+  layers build on it.
+onFinish: pull_request
+mergeMode: external_review
+baseBranch: master
+repoUrl: https://github.com/Neko-Catpital-Labs/Invoker.git
+
+tasks:
+  - id: implement-planning-repo-binding-rebase-persistence
+    description: |
+      Add `repoBinding?: InAppPlanningRepoBinding` to `InAppPlanningChatRequest`
+      in packages/contracts/src/ipc-channels.ts, next to the existing
+      `turnId?: string` field.
+      Review claim: InAppPlanningChatRequest carries both repoBinding (PR #9903) and turnId (master #9977) as sibling optional fields, with no behavior change to either.
+      Review lane: behavior
+      Safety invariant: Only the persistence layer changes; all other behavior in packages/contracts/src/ipc-channels.ts stays identical.
+      Slice rationale: One layer slice; the domain and ui layers build on this one.
+      Architectural effect: Restores the repoBinding request field that PR #9903 introduced, which was lost to a merge conflict against master's independently-added turnId field.
+      Goal: Implement the persistence layer so `grep -q 'repoBinding?: InAppPlanningRepoBinding' packages/contracts/src/ipc-channels.ts && grep -q 'turnId?: string' packages/contracts/src/ipc-channels.ts` passes.
+      Motivation: PR #9903 (Keep planning bound to its repository) cannot land as-is because master moved 93 commits and an unrelated web-surface-parity stack added a sibling field in the same interface, producing a GitHub merge conflict.
+      Alternative considerations: Building all three layers (contracts, domain, ui) in one slice was rejected as unreviewable; this contracts-only slice is the safe bottom layer since it is a pure additive merge with no logic to reconcile.
+      Implementation details: In packages/contracts/src/ipc-channels.ts's InAppPlanningChatRequest interface, add `repoBinding?: InAppPlanningRepoBinding;` as a new optional field alongside the existing `turnId?: string;` field. Reuse the InAppPlanningRepoBinding type already defined elsewhere in this file (PR #9903, commit d759e7e1a "Keep planning repository binding canonical") — do not redefine it.
+      Non-goals: No higher-layer work, no refactor, no unrelated cleanup, no doc edits.
+      Layer: persistence
+      Feature state: active
+      Files: packages/contracts/src/ipc-channels.ts
+      Change types:
+      - packages/contracts/src/ipc-channels.ts: modify
+      Acceptance criteria:
+      - `grep -q 'repoBinding?: InAppPlanningRepoBinding' packages/contracts/src/ipc-channels.ts && grep -q 'turnId?: string' packages/contracts/src/ipc-channels.ts` exits 0 after the change.
+    prompt: |
+      Goal: Add PR #9903's repoBinding field back to InAppPlanningChatRequest so it coexists with master's turnId field.
+      Review lane: behavior
+      Motivation: PR #9903 (Keep planning bound to its repository, https://github.com/Neko-Catpital-Labs/Invoker/pull/9903) has a GitHub merge conflict against master because master independently added a `turnId?: string` field to the same `InAppPlanningChatRequest` interface in packages/contracts/src/ipc-channels.ts (web-surface-parity stack, PR #9977). Both fields must coexist.
+      Alternative considerations: Do not bundle the domain-layer (in-app-planner.ts) or ui-layer (App.tsx) work here. Do not rename or remove turnId.
+      Implementation details: Edit packages/contracts/src/ipc-channels.ts. In the InAppPlanningChatRequest interface (currently has sessionId, message, presetKey, confirmationMode, and turnId fields), add a new optional field `repoBinding?: InAppPlanningRepoBinding;`. The InAppPlanningRepoBinding type is already defined in this same file from PR #9903's first commit (d759e7e1a, "Keep planning repository binding canonical") — reuse it, do not redeclare it. Keep the existing turnId field unchanged.
+      Non-goals: No higher-layer work, no refactor, no unrelated cleanup.
+      Assume no prior context. You are given only this task.
+      Implement the persistence layer described above in packages/contracts/src/ipc-channels.ts. Touch nothing outside this layer.
+      Acceptance criteria:
+      - `grep -q 'repoBinding?: InAppPlanningRepoBinding' packages/contracts/src/ipc-channels.ts && grep -q 'turnId?: string' packages/contracts/src/ipc-channels.ts` exits 0 after your change (this is the pass condition).
+    dependencies: []
+
+  - id: verify-planning-repo-binding-rebase-persistence
+    description: |
+      Run the deterministic proof for the contracts layer.
+      Review claim: `grep -q 'repoBinding?: InAppPlanningRepoBinding' packages/contracts/src/ipc-channels.ts && grep -q 'turnId?: string' packages/contracts/src/ipc-channels.ts` passes only when both fields are present on the same interface.
+      Review lane: proof
+      Safety invariant: Proof-only; adds no product behavior.
+      Slice rationale: One proof slice for the contracts layer.
+      Architectural effect: None; verification only.
+      Goal: Prove the contracts layer deterministically.
+      Motivation: Each layer carries its own proof so the domain layer's task can assume the request type already has repoBinding available.
+      Alternative considerations: Manual verification was rejected as non-deterministic.
+      Implementation details: Execute the grep check as the terminal proof.
+      Non-goals: No product edits here; proof only.
+      Layer: app_regression
+      Feature state: active
+    command: "grep -q 'repoBinding?: InAppPlanningRepoBinding' packages/contracts/src/ipc-channels.ts && grep -q 'turnId?: string' packages/contracts/src/ipc-channels.ts"
+    dependencies:
+      - implement-planning-repo-binding-rebase-persistence

--- a/plans/rendered/step-2-domain.yaml
+++ b/plans/rendered/step-2-domain.yaml
@@ -1,0 +1,86 @@
+name: "PR #9903 rebase (2) domain layer"
+description: |
+  Reconcile PR #9903's backend planning-repo-binding logic in
+  packages/app/src/in-app-planner.ts with master's independently-landed
+  "[Planning draft ownership]" doctor-approved-draft flow
+  (commit 55cd5119e, #10249), which master added inside the exact same
+  function PR #9903 modifies (the draft-preparation branch of the chat-turn
+  handler). PR #9903 adds two pieces here: `resolvePlanningRepoBinding` /
+  `activatePlanningSessionWorktree` (pure new insertions, no master
+  equivalent), and a `silentRepoMismatch` correction block that retries the
+  planner once when a draft silently names a different repository than the
+  session is bound to. Master's doctor-approved-draft flow requires
+  `activeSession.conversation.approvedPlanningDraft` to exist and derives
+  `reviewedPlanText`/`planningDraftId`/`planningDraftHash` from it before the
+  draft is accepted. These two must be composed in the right order: the
+  mismatch check/correction has to run against the draft that actually gets
+  reviewed, and if a correction happens, the corrected draft must still
+  satisfy the doctor-approval requirement (not bypass it). Gated on the
+  contracts workflow's merge, since it needs the `repoBinding` request field.
+onFinish: pull_request
+mergeMode: external_review
+baseBranch: master
+repoUrl: https://github.com/Neko-Catpital-Labs/Invoker.git
+
+externalDependencies:
+  - workflowId: "wf-1787605362540-6"
+    taskId: "__merge__"
+    requiredStatus: completed
+    gatePolicy: review_ready
+
+tasks:
+  - id: implement-planning-repo-binding-rebase-domain
+    description: |
+      Reapply PR #9903's backend repo-binding logic in in-app-planner.ts on
+      top of current master, reconciled with master's doctor-approved-draft
+      flow (55cd5119e, #10249).
+      Review claim: in-app-planner.ts carries PR #9903's backend-owned repoBinding default resolution and silent-mismatch correction, composed with master's doctor-approved-draft gate so neither feature bypasses the other.
+      Review lane: behavior
+      Safety invariant: Only the domain layer changes; the persistence layer's repoBinding field (from the prior workflow in this stack) is already available. A drift correction must never produce a draft that skips the doctor-approval check when draftDoctorEnabled is true.
+      Slice rationale: One layer slice built on the contracts layer; the ui layer builds on this one.
+      Architectural effect: Restores PR #9903's canonical-binding behavior (backend session binding is the default and validated repository source for in-app planning) without regressing the doctor-approved-draft invariant master added afterward.
+      Goal: Implement the domain layer so `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts -t "automatically corrects|backend-bound repository|cross-repository draft"` passes, and no existing doctor-approved-draft test in the same file regresses.
+      Motivation: PR #9903 (https://github.com/Neko-Catpital-Labs/Invoker/pull/9903, "Keep planning bound to its repository") has a GitHub merge conflict against master because master's "[Planning draft ownership]" stack (landed 2026-08-2x, commit 55cd5119e / #10249) added a doctor-approved-draft requirement inside the exact same draft-preparation code region PR #9903 modifies.
+      Alternative considerations: Silently keeping only one side (either drop the mismatch-correction retry, or drop the doctor-approval gate) was rejected — both are safety-relevant: the mismatch correction prevents a planner from silently switching repos, and the doctor-approval gate prevents review-identity spoofing. They must compose, not compete. Also rejected: reordering so doctor-approval runs before mismatch correction, since that would let doctor approval bless a draft that is then silently rewritten by the correction retry, invalidating the approval.
+      Implementation details: In packages/app/src/in-app-planner.ts, reinsert `resolvePlanningRepoBinding` and `activatePlanningSessionWorktree` (from PR #9903 commit d759e7e1a) unchanged, placed alongside the newer `listInAppPlanningPresets` doc comment master added (both are pure insertions at that location, order between them does not matter functionally). Then, in the chat-turn handler's draft-preparation branch, run PR #9903's `silentRepoMismatch` check/correction (from commit a46b024e3) against `review.planText` BEFORE deriving `reviewedPlanText`/`planningDraftId`/`planningDraftHash` from `activeSession.conversation.approvedPlanningDraft` (master's doctor-approval block, 55cd5119e). Concretely: after `review` is finalized (including any mismatch-triggered correction that reassigns `review`), only then evaluate `if (!deps.plannerReplyOverride && activeSession.conversation.draftDoctorEnabled)` and require `approvedPlanningDraft`, exactly as master does today, using the (possibly corrected) `review.planText` as the value that must match the doctor-approved draft. If a mismatch correction changes the draft text, the doctor-approval flow must fail closed the normal way (throw "no immutable doctor-approved draft") rather than silently accepting the corrected text as pre-approved, since the doctor never saw the corrected content.
+      Non-goals: No persistence or ui work here, no refactor, no unrelated cleanup, no doc edits, no change to rebindPlanningChatRepo (pre-existing, unrelated to this conflict).
+      Layer: domain
+      Feature state: active
+      Files: packages/app/src/in-app-planner.ts
+      Change types:
+      - packages/app/src/in-app-planner.ts: modify
+      Acceptance criteria:
+      - `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts -t "automatically corrects|backend-bound repository|cross-repository draft"` exits 0 after the change.
+      - `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts -t "doctor-approved draft"` exits 0 after the change (no regression to the pre-existing master behavior).
+    prompt: |
+      Goal: Reapply PR #9903's backend repo-binding logic in in-app-planner.ts on top of current master, reconciled with master's doctor-approved-draft flow.
+      Review lane: behavior
+      Motivation: PR #9903 (https://github.com/Neko-Catpital-Labs/Invoker/pull/9903, head SHA a46b024e37963287e13b7d0b9d50f0055f469d80, "Keep planning bound to its repository") cannot merge into master due to a GitHub-reported conflict. `git merge-base master pr/planning-repo-binding` is 7a163f926b60f637b765c220979f1bd748e6d9db; master has moved 93 commits ahead since then. Two independent master features touch the same file region as this PR: a doctor-approved-draft requirement (commit 55cd5119e, "[Planning draft ownership](5) Bind in-app review identity", #10249) inside the same chat-turn handler this PR's `silentRepoMismatch` correction touches.
+      Alternative considerations: Do not drop either feature to make the merge textually trivial. Do not bundle contracts (ipc-channels.ts) or ui (App.tsx) work here — those are separate workflow steps in this stack; assume the contracts step already landed the `repoBinding` field on `InAppPlanningChatRequest`.
+      Implementation details: Fetch PR #9903's three commits for reference (`git fetch origin refs/pull/9903/head`, or `git log -p a46b024e3 acb1f1e3 d759e7e1a -- packages/app/src/in-app-planner.ts`) to see the exact original diff. Reinsert `resolvePlanningRepoBinding(config)` (resolves `config.defaultRepoUrl`/`config.defaultBranch` into an `InAppPlanningRepoBinding`) and `activatePlanningSessionWorktree` unchanged — these have no equivalent in current master. Then locate the chat-turn handler's draft-preparation branch (search for `preparePlanningReview` and `draftDoctorEnabled` in the same function) and compose PR #9903's `silentRepoMismatch` retry-and-correct block with master's existing doctor-approved-draft block so that: (1) the mismatch check/correction runs first, using and potentially replacing `review`/`reply`; (2) the doctor-approval check (`if (!deps.plannerReplyOverride && activeSession.conversation.draftDoctorEnabled)`) then runs against the resulting `review.planText`, exactly as it does in current master, so a mismatch-corrected draft still must be doctor-approved when that gate is enabled — do not let a correction bypass doctor approval.
+      Non-goals: No persistence or ui work, no refactor, no unrelated cleanup, no change to rebindPlanningChatRepo.
+      Assume no prior context. You are given only this task.
+      Implement the domain layer described above in packages/app/src/in-app-planner.ts. Touch nothing outside this layer.
+      Acceptance criteria:
+      - `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts -t "automatically corrects|backend-bound repository|cross-repository draft"` exits 0 after your change (this is the pass condition).
+      - `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts -t "doctor-approved draft"` exits 0 after your change (no regression).
+    dependencies: []
+
+  - id: verify-planning-repo-binding-rebase-domain
+    description: |
+      Run the deterministic proof for the domain layer.
+      Review claim: The targeted PR #9903 tests pass and the pre-existing doctor-approved-draft tests do not regress.
+      Review lane: proof
+      Safety invariant: Proof-only; adds no product behavior.
+      Slice rationale: One proof slice for the domain layer.
+      Architectural effect: None; verification only.
+      Goal: Prove the domain layer deterministically.
+      Motivation: The domain layer is the highest-risk slice in this stack (two safety-relevant features composed in one function); it needs both the PR's original targeted tests and a check that master's existing doctor-approval tests still pass.
+      Alternative considerations: Manual verification was rejected as non-deterministic.
+      Implementation details: Execute both targeted vitest filters as the terminal proof.
+      Non-goals: No product edits here; proof only.
+      Layer: app_regression
+      Feature state: active
+    command: "pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts -t \"automatically corrects|backend-bound repository|cross-repository draft|doctor-approved draft\""
+    dependencies:
+      - implement-planning-repo-binding-rebase-domain

--- a/plans/rendered/step-3-surface.yaml
+++ b/plans/rendered/step-3-surface.yaml
@@ -1,0 +1,83 @@
+name: "PR #9903 rebase (3) ui layer"
+description: |
+  Reconcile PR #9903's UI-side repo-binding hydration and submit logic in
+  packages/ui/src/App.tsx with master's independently-landed
+  "[Web surface parity]" per-chat repo-binding UI (#9961/#9963/#9977), which
+  rewrote the exact same hydration effect and submit handler PR #9903
+  modifies. Master turned the old hydration `useEffect` into a
+  `refreshPlanningSessionsNow` useCallback with new session-dedup/alias/
+  gone-tracking logic (`admissibleRestored`, `aliasedBackendIds`,
+  `goneCounts`), and added a `commitPlanningRepo()` / `activePlanningRepoLocked`
+  / `repoInput` per-chat repo-edit flow to `handlePlanningSubmit`, introducing
+  a new `sendSessionId` variable in place of the plain `planningSessionId`
+  this PR reads. PR #9903's two changes (default `planningRepoBindingRef`
+  hydration from `chatList.repoBinding`, and conditionally attaching
+  `repoBinding` to the first-send request) need to be re-threaded into
+  master's current structure rather than pasted back verbatim. Gated on the
+  domain workflow's merge, since it needs the reconciled backend behavior.
+onFinish: pull_request
+mergeMode: external_review
+baseBranch: master
+repoUrl: https://github.com/Neko-Catpital-Labs/Invoker.git
+
+externalDependencies:
+  - workflowId: "wf-1787605381072-7"
+    taskId: "__merge__"
+    requiredStatus: completed
+    gatePolicy: review_ready
+
+tasks:
+  - id: implement-planning-repo-binding-rebase-surface
+    description: |
+      Reapply PR #9903's UI-side repo-binding default hydration and
+      first-send request wiring in App.tsx on top of master's rewritten
+      `refreshPlanningSessionsNow` / `handlePlanningSubmit`.
+      Review claim: App.tsx hydrates the backend-default repoBinding into planningRepoBindingRef inside master's current refreshPlanningSessionsNow, and attaches repoBinding to a first-send request only when the user has not already committed a different explicit per-chat repo via commitPlanningRepo.
+      Review lane: behavior
+      Safety invariant: Only the ui layer changes; master's admissibleRestored/aliasedBackendIds/goneCounts dedup logic and the commitPlanningRepo/repoInput per-chat repo-edit flow keep their current behavior for sessions that already have an explicit repoInput commit.
+      Slice rationale: One layer slice built on the domain layer; it is the top of the stack.
+      Architectural effect: Restores PR #9903's UI behavior (new "local-" sessions display and send with the backend-resolved default repo binding) without regressing master's newer per-chat repo-override and session-dedup mechanisms.
+      Goal: Implement the ui layer so `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx` passes, and no App.tsx test covering refreshPlanningSessionsNow's dedup/alias/gone-tracking or commitPlanningRepo regresses.
+      Motivation: PR #9903 (https://github.com/Neko-Catpital-Labs/Invoker/pull/9903, "Keep planning bound to its repository") has a GitHub merge conflict against master because master's "[Web surface parity]" stack (#9961, #9963, #9977) rewrote the exact hydration effect and submit handler this PR touches, in the 93 commits since this PR's merge-base.
+      Alternative considerations: Dropping master's dedup/alias/gone-tracking logic to make the textual merge trivial was rejected — it was added to fix real session-duplication and lost-connection bugs. Dropping PR #9903's default-binding hydration was also rejected — that is the PR's core purpose. Making repoBinding always override an explicit user-committed repoInput was rejected as a regression of the newer per-chat override feature; the default binding must only apply when the user has not explicitly named a different repo for this chat.
+      Implementation details: In packages/ui/src/App.tsx's `refreshPlanningSessionsNow` (the useCallback that replaced the old hydration useEffect), add PR #9903's `planningRepoBindingRef.current = chatList.repoBinding ?? {}` assignment, and reapply the `chatList.sessions.length === 0` early-return branch that maps existing "local-" sessions to include the resolved repoBinding fields — insert it consistently with the function's current admissibleRestored/dedup flow (i.e. still run before the dedup logic, since it only applies when there are zero server sessions to reconcile against). In `handlePlanningSubmit`, change PR #9903's original condition (`!planningSessionId && session.repoUrl && session.baseBranch`) to use master's current `sendSessionId` variable instead of `planningSessionId` (so it still means "this is a first send with no prior backend session"), and only attach `repoBinding` to the request when the user did not just commit an explicit `pendingRepoInput` via `commitPlanningRepo` in this same submit (i.e. `bind.sessionId` was not just set) — an explicit per-chat repo commit takes precedence over the passive default binding.
+      Non-goals: No persistence or domain work here, no refactor, no unrelated cleanup, no doc edits, no change to the dedup/alias/gone-tracking algorithm itself.
+      Layer: ui
+      Feature state: active
+      Files: packages/ui/src/App.tsx
+      Change types:
+      - packages/ui/src/App.tsx: modify
+      Acceptance criteria:
+      - `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx` exits 0 after the change.
+    prompt: |
+      Goal: Reapply PR #9903's UI-side repo-binding default hydration and first-send request wiring in App.tsx on top of master's rewritten refreshPlanningSessionsNow/handlePlanningSubmit.
+      Review lane: behavior
+      Motivation: PR #9903 (https://github.com/Neko-Catpital-Labs/Invoker/pull/9903, head SHA a46b024e37963287e13b7d0b9d50f0055f469d80) cannot merge into master due to a GitHub-reported conflict. Master's "[Web surface parity]" stack (#9961, #9963, #9977) rewrote packages/ui/src/App.tsx's planning-session hydration from a `useEffect` into a `refreshPlanningSessionsNow` useCallback with new `admissibleRestored`/`aliasedBackendIds`/`goneCounts` dedup logic, and added `commitPlanningRepo()`/`activePlanningRepoLocked`/`repoInput` (a per-chat repo-edit flow) plus a `sendSessionId` variable to `handlePlanningSubmit`, in the 93 commits since this PR's merge-base.
+      Alternative considerations: Do not bundle contracts (ipc-channels.ts) or domain (in-app-planner.ts) work here — assume those workflow steps already landed. Do not remove or simplify master's dedup/alias/gone-tracking logic. Do not make the default repoBinding override an explicit per-chat repoInput commit.
+      Implementation details: Fetch PR #9903 for reference (`git fetch origin refs/pull/9903/head`, or `git log -p a46b024e3 -- packages/ui/src/App.tsx`) to see the exact original diff (two hunks: the hydration effect around what is now `refreshPlanningSessionsNow`, and the request-building object inside `handlePlanningSubmit`). In `refreshPlanningSessionsNow`, add `planningRepoBindingRef.current = chatList.repoBinding ?? {}` and the `chatList.sessions.length === 0` early-return branch (mapping "local-" sessions to include the resolved repoBinding), placed before the current dedup/admissibleRestored logic runs. In `handlePlanningSubmit`, change the original `!planningSessionId && session.repoUrl && session.baseBranch` condition to read master's `sendSessionId` in place of `planningSessionId`, and gate it so it does not fire when this same submit already committed an explicit `pendingRepoInput` via `commitPlanningRepo` (i.e. skip when `bind.sessionId` was just set) — explicit per-chat binding wins over the passive default.
+      Non-goals: No persistence or domain work, no refactor, no unrelated cleanup, no change to the dedup/alias/gone-tracking algorithm.
+      Assume no prior context. You are given only this task.
+      Implement the ui layer described above in packages/ui/src/App.tsx. Touch nothing outside this layer.
+      Acceptance criteria:
+      - `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx` exits 0 after your change (this is the pass condition).
+    dependencies: []
+
+  - id: verify-planning-repo-binding-rebase-surface
+    description: |
+      Run the deterministic proof for the ui layer.
+      Review claim: `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx` passes only when the ui layer is correct.
+      Review lane: proof
+      Safety invariant: Proof-only; adds no product behavior.
+      Slice rationale: One proof slice for the ui layer; it is the top of the stack.
+      Architectural effect: None; verification only.
+      Goal: Prove the ui layer deterministically.
+      Motivation: This is the original PR's own recorded test plan entry for the UI change.
+      Alternative considerations: Manual verification was rejected as non-deterministic.
+      Implementation details: Execute `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx` as the terminal proof.
+      Non-goals: No product edits here; proof only.
+      Layer: app_regression
+      Layer exception: allowed — this proof task verifies the "ui" layer implementation task above; the formula's normalized layer list places "ui" after "app_regression", so a same-step verify-follows-implement dependency here is an expected, deliberate ordering, not a foundational-layer-depends-on-integration-layer mistake.
+      Feature state: active
+    command: "pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx"
+    dependencies:
+      - implement-planning-repo-binding-rebase-surface


### PR DESCRIPTION
## Summary

Keep in-app planning sessions, generated drafts, and automatic corrections on the repository displayed by Invoker.

Explicit user-named cross-repository plans remain supported.

## Review Claim

The backend session binding is the default and validated repository source for in-app planning.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Repository binding remains backend-owned; cross-repository planning requires the user to name the resulting `repoUrl` explicitly.

## Slice Rationale

This PR intentionally groups three dependent commits: binding must exist before drafts can validate it, and validation must exist before host feedback can correct violations.

## Non-goals

No changes to Slack repository routing, task execution, or Git remotes.

## Architecture

The backend resolves one session binding. The UI displays it, first-send session creation reuses it, and draft validation feeds mismatches back for one automatic planner correction.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts -t "automatically corrects|backend-bound repository|cross-repository draft"`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a46b024e3 acb1f1e39 d759e7e1a`
- Post-revert steps: Restart Invoker
- Data migration? No

</details>
