### PR TITLE
[First Agent Tutorial] Normalize temporary project paths

### DIFF
--- a/examples/first-agent-workflow/create-local-project.sh
+++ b/examples/first-agent-workflow/create-local-project.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
 TEMPLATE_DIR="$ROOT/template"
-TARGET_DIR="${1:-${TMPDIR:-/tmp}/invoker-first-agent-workflow}"
+TMP_ROOT="${TMPDIR:-/tmp}"
+TARGET_DIR="${1:-${TMP_ROOT%/}/invoker-first-agent-workflow}"
 PLAN_DIR="$TARGET_DIR/invoker-plans"
 
 if [ -e "$TARGET_DIR" ] && [ -n "$(find "$TARGET_DIR" -mindepth 1 -maxdepth 1 2>/dev/null)" ]; then


### PR DESCRIPTION
## Summary

Normalize a trailing slash in `$TMPDIR` before constructing the tutorial project path.

This prevents generated paths such as `T//invoker-first-agent-workflow`.

## Review Claim

The tutorial generator emits one normalized temporary project path.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Explicit target arguments remain unchanged; only the default temporary-root join is normalized.

## Slice Rationale

This shell-only correction is independent of planner and UI behavior.

## Non-goals

No generated project content, branch, or workflow behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash -n examples/first-agent-workflow/create-local-project.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7a781638a`
- Post-revert steps: None
- Data migration? No

</details>
