### PR TITLE
[First Agent Tutorial] Hide invalid no-merge actions

### DIFF
--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -762,6 +762,48 @@ describe('WorkflowInspector', () => {
     expect(screen.getByTestId('inspector-pending-fix-error')).toHaveTextContent('tests failed');
   });
 
+  it('hides merge approval actions when the workflow has no merge configured', () => {
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready', onFinish: 'none' }}
+        task={makeTask({
+          status: 'review_ready',
+          config: { workflowId: 'wf-1', isMergeNode: true, runnerKind: 'merge' },
+        })}
+        collapsed={false}
+        advancedExpanded={false}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Approve Merge' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Reject Merge' })).not.toBeInTheDocument();
+  });
+
+  it('keeps merge approval actions for workflows with a configured finish action', () => {
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready', onFinish: 'pull_request' }}
+        task={makeTask({
+          status: 'review_ready',
+          config: { workflowId: 'wf-1', isMergeNode: true, runnerKind: 'merge' },
+        })}
+        collapsed={false}
+        advancedExpanded={false}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Approve Merge' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Reject Merge' })).toBeVisible();
+  });
+
   it('surfaces an executor-selection failure captured in pendingFixError so approve dispatch errors are visible', () => {
     const capabilityError =
       'Error: SSH target "remote_digital_ocean_3" cannot run codex: missing execution harness "codex"';

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -439,9 +439,11 @@ export function WorkflowInspector({
   const statusText = taskColors?.text ?? workflowVisual?.textClass ?? 'text-muted-foreground';
   const statusDot = taskColors?.dot ?? '';
   const isFixApproval = Boolean(task?.execution.pendingFixError);
+  const isNoMergeGate = Boolean(task?.config.isMergeNode && workflow?.onFinish === 'none');
   const showApprovalActions = Boolean(
     task
     && (task.status === 'awaiting_approval' || task.status === 'review_ready')
+    && !isNoMergeGate
     && onApprove
     && onReject,
   );


### PR DESCRIPTION
## Summary

Hide merge approval and rejection controls when a workflow explicitly configures `onFinish: none`.

Configured merge and pull-request workflows retain their controls.

## Review Claim

The inspector offers merge actions only when the backend has a merge action to perform.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only no-merge gates lose controls; configured merge and pull-request workflows remain unchanged.

## Slice Rationale

This is an isolated inspector affordance correction backed by the backend's existing rejection semantics.

## Non-goals

No change to `review_ready`, merge execution, or approval backend semantics.

## Visual Proof

Focused inspector tests cover both hidden no-merge controls and retained pull-request controls.

Manually inspected: the no-merge review gate showed no impossible approval buttons while configured gates retained them.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/workflow-inspector.test.tsx -t "merge approval actions"`
- [x] `pnpm --filter @invoker/ui build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 824dfb7ec`
- Post-revert steps: None
- Data migration? No

</details>
