### PR TITLE
[First Agent Tutorial] Stage planning workflows until explicit start

### DIFF
--- a/packages/app/src/__tests__/formatter.test.ts
+++ b/packages/app/src/__tests__/formatter.test.ts
@@ -318,6 +318,7 @@ describe('serializeWorkflow', () => {
       baseBranch: 'master',
       featureBranch: 'feature/test',
       generation: 2,
+      staged: true,
     };
     const result = serializeWorkflow(wf);
     expect(result.description).toBe('A test workflow');
@@ -326,6 +327,7 @@ describe('serializeWorkflow', () => {
     expect(result.baseBranch).toBe('master');
     expect(result.featureBranch).toBe('feature/test');
     expect(result.generation).toBe(2);
+    expect(result.staged).toBe(true);
   });
 
   it('omits undefined optional fields', () => {

--- a/packages/app/src/__tests__/plan-submission-loader.test.ts
+++ b/packages/app/src/__tests__/plan-submission-loader.test.ts
@@ -8,16 +8,20 @@ vi.mock('../plan-backup.js', () => ({
 import { loadPlanSubmissionBundle } from '../plan-submission-loader.js';
 
 function makeDeps() {
-  const workflows: Array<{ id: string; featureBranch?: string }> = [];
+  const workflows: Array<{ id: string; featureBranch?: string; staged?: boolean }> = [];
   const loadedPlans: PlanDefinition[] = [];
   return {
     loadedPlans,
     deps: {
       persistence: {
         listWorkflows: vi.fn(() => workflows.map((workflow) => ({ ...workflow }))),
+        updateWorkflow: vi.fn((workflowId: string, changes: { staged: boolean }) => {
+          const workflow = workflows.find((candidate) => candidate.id === workflowId);
+          if (workflow) workflow.staged = changes.staged;
+        }),
       },
       orchestrator: {
-        loadPlan: vi.fn((plan: PlanDefinition, _opts: { allowGraphMutation?: boolean }) => {
+        loadPlan: vi.fn((plan: PlanDefinition, _opts: { allowGraphMutation?: boolean; staged?: boolean }) => {
           loadedPlans.push(plan);
           workflows.push({
             id: `wf-${loadedPlans.length}`,
@@ -31,6 +35,26 @@ function makeDeps() {
 }
 
 describe('loadPlanSubmissionBundle', () => {
+  it('passes staged state only when requested by the planning preview path', async () => {
+    const { deps } = makeDeps();
+    const plan = `
+name: Preview
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: build
+    description: Build it
+`;
+
+    await loadPlanSubmissionBundle(plan, deps, { staged: true });
+
+    expect(deps.orchestrator.loadPlan).toHaveBeenCalledWith(
+      expect.anything(),
+      { allowGraphMutation: true, staged: true },
+    );
+    expect(deps.persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { staged: true });
+    expect(deps.persistence.listWorkflows()[0]?.staged).toBe(true);
+  });
+
   it('pins a single submitted workflow base branch to master', async () => {
     const { deps, loadedPlans } = makeDeps();
 

--- a/packages/app/src/__tests__/start-ready.test.ts
+++ b/packages/app/src/__tests__/start-ready.test.ts
@@ -38,6 +38,8 @@ function harness(
     getPersistedActiveTaskIds: vi.fn(() => new Set(activeTaskIds)),
     getExecutableReadyTasks: vi.fn(() => readyTasks),
     getWorkflowMergeMode: vi.fn((workflowId: string) => mergeModes[workflowId]),
+    activateStagedWorkflows: vi.fn(() => []),
+    getStagedWorkflowIds: vi.fn(() => ['wf-staged']),
     prepareTaskForNewAttempt: vi.fn((taskId: string) => {
       tasks = tasks.map((task) => task.id === taskId
         ? { ...task, status: 'pending' as TaskState['status'], execution: {} }
@@ -58,6 +60,18 @@ function harness(
 }
 
 describe('start-ready', () => {
+  it('activates staged pending workflows before starting ready work', async () => {
+    const ready = makeTask('wf-staged/ready', 'pending');
+    const orchestrator = harness([ready], [ready]);
+
+    await runStartReady(orchestrator);
+
+    expect(orchestrator.activateStagedWorkflows).toHaveBeenCalledWith(['wf-staged']);
+    expect(orchestrator.activateStagedWorkflows.mock.invocationCallOrder[0]).toBeLessThan(
+      orchestrator.startExecution.mock.invocationCallOrder[0]!,
+    );
+  });
+
   it('previews ready, recoverable, failed, and gated work', () => {
     const ready = makeTask('wf-1/ready', 'pending');
     const recoverable = makeTask('wf-1/recoverable', 'pending', {

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -437,6 +437,7 @@ export function serializeWorkflow(wf: Workflow): Record<string, unknown> {
     ...(wf.externalDependencyChanges != null && { externalDependencyChanges: wf.externalDependencyChanges }),
     ...(wf.detachedExternalDependencies != null && { detachedExternalDependencies: wf.detachedExternalDependencies }),
     ...(wf.generation != null && { generation: wf.generation }),
+    staged: wf.staged === true,
   };
 }
 

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1305,6 +1305,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       logLabel: options?.logLabel ?? 'plan-from-goal',
       preserveTaskHandles: options?.preserveTaskHandles,
       taskHandles,
+      staged: true,
     });
   }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1337,7 +1337,7 @@ function startHeadlessMode(): void {
           orchestrator,
           allowGraphMutation: invokerConfig.allowGraphMutation,
           logger,
-        })
+        }, { staged: true })
       );
 
       // Web clients get planning-chat token streaming over SSE. The bridge does

--- a/packages/app/src/plan-submission-loader.ts
+++ b/packages/app/src/plan-submission-loader.ts
@@ -10,8 +10,11 @@ export interface PlanSubmissionLoadResult {
 }
 
 export interface PlanSubmissionLoadDeps {
-  persistence: { listWorkflows(): Array<{ id: string; featureBranch?: string }> };
-  orchestrator: { loadPlan(plan: PlanDefinition, opts: { allowGraphMutation?: boolean }): void };
+  persistence: {
+    listWorkflows(): Array<{ id: string; featureBranch?: string; staged?: boolean }>;
+    updateWorkflow(workflowId: string, changes: { staged: boolean }): void;
+  };
+  orchestrator: { loadPlan(plan: PlanDefinition, opts: { allowGraphMutation?: boolean; staged?: boolean }): void };
   allowGraphMutation?: boolean;
   logger?: Logger;
 }
@@ -20,6 +23,7 @@ export interface PlanSubmissionLoadOptions {
   logLabel?: string;
   preserveTaskHandles?: boolean;
   taskHandles?: { clear(): void };
+  staged?: boolean;
 }
 
 export async function loadPlanSubmissionBundle(
@@ -64,10 +68,13 @@ export async function loadPlanSubmissionBundle(
       };
     }
     backupPlan(plan, undefined, deps.logger);
-    deps.orchestrator.loadPlan(plan, { allowGraphMutation: deps.allowGraphMutation });
+    deps.orchestrator.loadPlan(plan, { allowGraphMutation: deps.allowGraphMutation, staged: options?.staged });
     const workflow = deps.persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
     if (!workflow) {
       throw new Error('Loaded plan did not create a workflow.');
+    }
+    if (options?.staged && workflow.staged !== true) {
+      deps.persistence.updateWorkflow(workflow.id, { staged: true });
     }
     existingWorkflowIds.add(workflow.id);
     loadedWorkflowIds.push(workflow.id);

--- a/packages/app/src/start-ready.ts
+++ b/packages/app/src/start-ready.ts
@@ -19,6 +19,8 @@ type StartReadyOrchestrator = Pick<
   | 'recreateWorkflow'
   | 'startExecution'
   | 'getWorkflowMergeMode'
+  | 'activateStagedWorkflows'
+  | 'getStagedWorkflowIds'
 >;
 
 type StartReadyRequestExt = StartReadyRequest & {
@@ -225,7 +227,7 @@ function formatStartReadyError(err: unknown): string {
 
 export function collectStartReadyPreview(orchestrator: StartReadyOrchestrator): StartReadyPreview {
   const tasks = orchestrator.getAllTasks();
-  const readyTasks = orchestrator.getExecutableReadyTasks();
+  const readyTasks = orchestrator.getExecutableReadyTasks({ includeStaged: true });
   const recoverableTasks = collectRecoverableTasks(orchestrator);
   const failedTasks = tasks.filter((task) => task.status === 'failed');
   const pendingTasks = tasks.filter((task) => isPendingOrQueued(task));
@@ -297,6 +299,7 @@ async function runStartReadyAsync(
   const recreatedWorkflowIds: string[] = [];
   const freshBaseRecreatedWorkflowIds: string[] = [];
   const workflowOutcomes: StartReadyWorkflowOutcome[] = [];
+  orchestrator.activateStagedWorkflows(orchestrator.getStagedWorkflowIds());
 
   if (freshBasePreview) {
     if (freshBasePreview.workflowIds.length > 0 && !options.freshBaseRecreateWorkflow) {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2689,6 +2689,17 @@ describe('SQLiteAdapter', () => {
   });
 
   describe('updateWorkflow', () => {
+    it('persists staged workflow activation with active as the default', () => {
+      adapter.saveWorkflow(testWorkflow);
+      expect(adapter.loadWorkflow('wf-1')?.staged).toBe(false);
+
+      adapter.updateWorkflow('wf-1', { staged: true });
+      expect(adapter.loadWorkflow('wf-1')?.staged).toBe(true);
+
+      adapter.updateWorkflow('wf-1', { staged: false });
+      expect(adapter.loadWorkflow('wf-1')?.staged).toBe(false);
+    });
+
     it('ignores workflow status mutations because status is derived from tasks', () => {
       adapter.saveWorkflow(testWorkflow);
       // @ts-expect-error workflow status is derived output, not a persistence input.

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -163,6 +163,7 @@ export interface Workflow {
   /** Read-only provenance for dependencies removed by `detachWorkflow`. Never re-read by scheduling. */
   detachedExternalDependencies?: DetachedExternalDependency[];
   generation?: number;
+  staged?: boolean;
   deletedAt?: number;
   createdAt: string;
   updatedAt: string;
@@ -395,7 +396,7 @@ export type InAppPlanningSessionPatch = Partial<Pick<
 export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;
-  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
+  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'staged' | 'updatedAt'>>): void;
   loadWorkflow(workflowId: string, options?: WorkflowReadOptions): Workflow | undefined;
   listWorkflows(options?: WorkflowReadOptions): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -47,6 +47,7 @@ export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
     externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
     detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) as DetachedExternalDependency[] : undefined,
     generation: row.generation ?? 0,
+    staged: row.staged === 1,
     deletedAt: row.deleted_at === null || row.deleted_at === undefined ? undefined : Number(row.deleted_at),
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -27,6 +27,7 @@ export const SCHEMA_DDL = `
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
         detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+        staged INTEGER NOT NULL DEFAULT 0 CHECK (staged IN (0, 1)),
         deleted_at INTEGER,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
@@ -673,6 +674,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE slack_plan_drafts ADD COLUMN planning_draft_id TEXT',
   'ALTER TABLE in_app_planning_sessions ADD COLUMN planning_draft_id TEXT',
   'ALTER TABLE in_app_planning_sessions ADD COLUMN planning_draft_hash TEXT',
+  'ALTER TABLE workflows ADD COLUMN staged INTEGER NOT NULL DEFAULT 0 CHECK (staged IN (0, 1))',
 ];
 
 /**

--- a/packages/data-store/src/sqlite-workflow-repository.ts
+++ b/packages/data-store/src/sqlite-workflow-repository.ts
@@ -54,6 +54,7 @@ export type WorkflowMetadataChanges = Partial<
     | 'externalDependencyChanges'
     | 'detachedExternalDependencies'
     | 'generation'
+    | 'staged'
     | 'updatedAt'
   >
 >;
@@ -100,8 +101,8 @@ export class SqliteWorkflowRepository {
     assertWorkflowConsistent(workflow);
     this.exec.runTransaction(() => {
       this.exec.execRun(`
-        INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, deleted_at, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, staged, deleted_at, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `, [
         workflow.id, workflow.name,
         workflow.description ?? null,
@@ -114,6 +115,7 @@ export class SqliteWorkflowRepository {
         workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
         workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
         workflow.generation ?? 0,
+        workflow.staged ? 1 : 0,
         workflow.deletedAt ?? null,
         workflow.createdAt, workflow.updatedAt,
       ]);
@@ -162,6 +164,10 @@ export class SqliteWorkflowRepository {
     if (changes.generation !== undefined) {
       setClauses.push('generation = ?');
       values.push(changes.generation);
+    }
+    if (changes.staged !== undefined) {
+      setClauses.push('staged = ?');
+      values.push(changes.staged ? 1 : 0);
     }
     if (changes.mergeMode !== undefined) {
       // handled by columnMap; kept for backward-compatible patch shapes

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2773,16 +2773,10 @@ export function App() {
         }));
         await refreshTaskGraph();
         workflowGraphViewportRef.current = null;
-        const startResult = await handleStartReadyAction();
-        const startMessage = startResult
-          ? startResult.started.length > 0
-            ? ` Started ${startResult.started.length} ready task${startResult.started.length === 1 ? '' : 's'}.`
-            : ' No ready work to start.'
-          : ' Ready work could not be started.';
         appendTerminalLine(
           result.workflowCount && result.workflowCount > 1
-            ? `Plan "${result.planName}" submitted as ${result.workflowCount} stacked workflows.${startMessage}`
-            : `Plan "${result.planName}" submitted to Invoker.${startMessage}`,
+            ? `Plan "${result.planName}" submitted as ${result.workflowCount} stacked workflows. Review the graph, then Start ready work.`
+            : `Plan "${result.planName}" submitted to Invoker. Review the graph, then Start ready work.`,
           'system',
           'success',
         );
@@ -2797,7 +2791,7 @@ export function App() {
       setPlanningSubmitError({ title: 'Plan could not be submitted', message });
       appendTerminalLine(`Plan could not be submitted:\n${message}`, 'system', 'error');
     }
-  }, [activePlanningReadOnly, appendTerminalLine, handleStartReadyAction, invoker, issueCameraCommand, planningSessionId, refreshTaskGraph, updatePlanningSessionById]);
+  }, [activePlanningReadOnly, appendTerminalLine, invoker, issueCameraCommand, planningSessionId, refreshTaskGraph, updatePlanningSessionById]);
   const handlePlanningCancelReview = useCallback(() => {
     appendTerminalLine('Submission cancelled. Draft kept.', 'system');
     setKeptPlanningDraftSessionIds((prev) => new Set(prev).add(activePlanningSessionId));

--- a/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
@@ -61,7 +61,7 @@ describe('CodeRabbit PR #3050 — draft state cleared after submit', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });
-    await screen.findByText('Plan "Mock Plan" submitted to Invoker. No ready work to start.');
+    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review the graph, then Start ready work.');
     // The submit succeeded; the ready bar must be gone so it cannot resubmit the same session.
     await waitFor(() => {
       expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();

--- a/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
@@ -56,14 +56,14 @@ describe('CodeRabbit PR #3050 — submitted planning stays read-only after start
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
     });
 
-    await screen.findByText('Plan "Mock Plan" submitted to Invoker. No ready work to start.');
+    await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review the graph, then Start ready work.');
     expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
-    expect(mock.api.startReady).toHaveBeenCalledTimes(1);
+    expect(mock.api.startReady).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByTestId('sidebar-planning'));
     fireEvent.click(await screen.findByTestId('rail-start-ready'));
     await waitFor(() => {
-      expect(mock.api.startReady).toHaveBeenCalledTimes(2);
+      expect(mock.api.startReady).toHaveBeenCalledTimes(1);
     });
     expect(screen.queryByTestId('rail-start')).not.toBeInTheDocument();
     expect(screen.queryByTestId('rail-stop')).not.toBeInTheDocument();

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1743,7 +1743,7 @@ describe('Invoker terminal (component)', () => {
     );
   });
 
-  it('submits a draft and starts ready work when the user types submit', async () => {
+  it('submits a draft without starting staged work', async () => {
     mock.api.planningChatSend = vi.fn(async () => ({
       ok: true,
       sessionId: 'session-1',
@@ -1766,11 +1766,11 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });
       expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
-      expect(mock.api.startReady).toHaveBeenCalledWith({});
     });
+    expect(mock.api.startReady).not.toHaveBeenCalled();
     fireEvent.click(screen.getByTestId('sidebar-home'));
     expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
-    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. No ready work to start.');
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review the graph, then Start ready work.');
     expect(screen.queryByRole('heading', { name: 'Plan graph' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Submit to Invoker' })).not.toBeInTheDocument();
@@ -1861,7 +1861,7 @@ describe('Invoker terminal (component)', () => {
     });
     fireEvent.click(screen.getByTestId('sidebar-home'));
     expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
-    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. No ready work to start.');
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. Review the graph, then Start ready work.');
     expect(screen.queryByRole('heading', { name: 'Plan graph' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Submit to Invoker' })).not.toBeInTheDocument();

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1815,12 +1815,12 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });
       expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
-      expect(mock.api.startReady).toHaveBeenCalledWith({});
     });
+    expect(mock.api.startReady).not.toHaveBeenCalled();
     fireEvent.click(screen.getByTestId('sidebar-home'));
     expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
     expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(
-      'Plan "Workers Surface" submitted as 2 stacked workflows. No ready work to start.',
+      'Plan "Workers Surface" submitted as 2 stacked workflows. Review the graph, then Start ready work.',
     );
     expect(screen.queryByRole('heading', { name: 'Plan graph' })).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
@@ -1857,8 +1857,8 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(2);
       expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
-      expect(mock.api.startReady).toHaveBeenCalledWith({});
     });
+    expect(mock.api.startReady).not.toHaveBeenCalled();
     fireEvent.click(screen.getByTestId('sidebar-home'));
     expect(screen.getByRole('heading', { name: 'Planning chat' })).toBeInTheDocument();
     expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. Review the graph, then Start ready work.');

--- a/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
@@ -81,7 +81,7 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'session-1' });
     });
-    expect(await screen.findByText('Plan "Mock Plan" submitted to Invoker. No ready work to start.')).toBeInTheDocument();
+    expect(await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review the graph, then Start ready work.')).toBeInTheDocument();
     expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
     expect(screen.getByTestId('invoker-terminal-harness')).toBeDisabled();
 

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -22,6 +22,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     generation?: number;
+    staged?: boolean;
   }>();
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
   private attempts = new Map<string, Attempt[]>();
@@ -34,8 +35,9 @@ class InMemoryPersistence implements OrchestratorPersistence {
     mergeMode?: 'manual' | 'automatic' | 'external_review';
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
-    generation?: number;
-  } }> = [];
+      generation?: number;
+      staged?: boolean;
+    } }> = [];
 
   saveWorkflow(workflow: {
     id: string;
@@ -47,6 +49,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     generation?: number;
+    staged?: boolean;
   }): void {
     const now = new Date().toISOString();
     this.workflows.set(workflow.id, {
@@ -71,6 +74,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
       externalDependencies?: ExternalDependency[];
       externalDependencyChanges?: ExternalDependencyChange[];
       generation?: number;
+      staged?: boolean;
     },
   ): void {
     const wf = this.workflows.get(workflowId);
@@ -95,6 +99,9 @@ class InMemoryPersistence implements OrchestratorPersistence {
     if (wf && changes.generation !== undefined) {
       wf.generation = changes.generation;
     }
+    if (wf && changes.staged !== undefined) {
+      wf.staged = changes.staged;
+    }
 
   }
 
@@ -106,6 +113,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     generation?: number;
+    staged?: boolean;
   } | undefined {
     const wf = this.workflows.get(workflowId);
     if (!wf) return undefined;
@@ -1149,6 +1157,22 @@ describe('Orchestrator', () => {
   // ── loadPlan ────────────────────────────────────────────
 
   describe('loadPlan', () => {
+    it('keeps staged workflows out of automatic execution until activation', () => {
+      orchestrator.loadPlan({
+        name: 'staged-plan',
+        tasks: [{ id: 't1', description: 'Staged task' }],
+      }, { staged: true });
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+
+      expect(persistence.workflows.get(workflowId)?.staged).toBe(true);
+      expect(orchestrator.getExecutableReadyTasks()).toEqual([]);
+      expect(orchestrator.startExecution()).toEqual([]);
+
+      expect(orchestrator.activateStagedWorkflows([workflowId])).toEqual([workflowId]);
+      expect(persistence.workflows.get(workflowId)?.staged).toBe(false);
+      expect(orchestrator.startExecution().map((task) => task.id)).toEqual([sid(orchestrator, 0, 't1')]);
+    });
+
     it('creates tasks with correct dependencies', () => {
       const plan: PlanDefinition = {
         name: 'test-plan',

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -280,8 +280,9 @@ export interface OrchestratorPersistence {
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     detachedExternalDependencies?: DetachedExternalDependency[];
+    staged?: boolean;
   }): void;
-  updateWorkflow?(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op'; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[]; detachedExternalDependencies?: DetachedExternalDependency[] }): void;
+  updateWorkflow?(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review' | 'no_op'; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[]; detachedExternalDependencies?: DetachedExternalDependency[]; staged?: boolean }): void;
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges, opts?: { skipWorkflowStatusSync?: boolean }): void;
   updateTaskLaunchState?(taskId: string, changes: TaskStateChanges): void;
@@ -306,6 +307,7 @@ export interface OrchestratorPersistence {
     externalDependencyChanges?: ExternalDependencyChange[];
     detachedExternalDependencies?: DetachedExternalDependency[];
     generation?: number;
+    staged?: boolean;
   }>;
   loadTasks(workflowId: string): TaskState[];
   /**
@@ -363,6 +365,7 @@ export interface OrchestratorPersistence {
     externalDependencyChanges?: ExternalDependencyChange[];
     detachedExternalDependencies?: DetachedExternalDependency[];
     generation?: number;
+    staged?: boolean;
   } | undefined;
   /** Delete a single workflow and its tasks from the DB. */
   deleteWorkflow?(workflowId: string): void;
@@ -1382,7 +1385,7 @@ export class Orchestrator {
    * Parse a plan definition and create tasks with dependencies.
    * Persists workflow and tasks, publishes deltas via MessageBus.
    */
-  loadPlan(plan: PlanDefinition, opts?: { allowGraphMutation?: boolean }): void {
+  loadPlan(plan: PlanDefinition, opts?: { allowGraphMutation?: boolean; staged?: boolean }): void {
     const workflowId = nextWorkflowId();
     const localToScoped = buildPlanLocalToScopedIdMap(workflowId, plan.tasks);
     const workflowExternalDependencies = this.normalizePlanExternalDependencies([
@@ -1536,6 +1539,7 @@ export class Orchestrator {
       featureBranch: plan.featureBranch,
       mergeMode: plan.mergeMode,
       externalDependencies: workflowExternalDependencies.length > 0 ? workflowExternalDependencies : undefined,
+      staged: opts?.staged === true,
       createdAt,
       updatedAt: createdAt,
     });
@@ -1582,11 +1586,7 @@ export class Orchestrator {
 
     const activeAttempts = this.countActivePersistedAttempts();
     const hasPerCallLimit = typeof opts?.limit === 'number' && opts.limit >= 0;
-    const readyTasks = hasPerCallLimit
-      ? this.getExecutableReadyTasks({ alreadyRefreshed: true })
-      : this.stateMachine
-        .getReadyTasks()
-        .filter((task) => this.getExternalDependencyBlocker(task) === undefined);
+    const readyTasks = this.getExecutableReadyTasks({ alreadyRefreshed: true });
     this.logger.info('[orchestrator] startExecution', {
       ready: readyTasks.length,
       active: activeAttempts,
@@ -3327,9 +3327,13 @@ export class Orchestrator {
     return this.stateMachine.getReadyTasks();
   }
 
-  getExecutableReadyTasks(opts?: { alreadyRefreshed?: boolean }): TaskState[] {
+  getExecutableReadyTasks(opts?: { alreadyRefreshed?: boolean; includeStaged?: boolean }): TaskState[] {
+    const stagedWorkflowIds = opts?.includeStaged
+      ? new Set<string>()
+      : new Set(this.persistence.listWorkflows().filter((workflow) => workflow.staged === true).map((workflow) => workflow.id));
     const readyTasks = this.stateMachine
       .getReadyTasks()
+      .filter((task) => !task.config.workflowId || !stagedWorkflowIds.has(task.config.workflowId))
       .filter((task) => this.getExternalDependencyBlocker(task) === undefined);
     const readyTasksById = new Map(readyTasks.map((task) => [task.id, task]));
     return getPendingLaunchQueueSnapshotImpl(
@@ -3343,6 +3347,29 @@ export class Orchestrator {
     )
       .map((job) => readyTasksById.get(job.taskId))
       .filter((task): task is TaskState => task !== undefined);
+  }
+
+  private isWorkflowStaged(workflowId: string | undefined): boolean {
+    if (!workflowId) return false;
+    const workflow = this.persistence.loadWorkflow?.(workflowId)
+      ?? this.persistence.listWorkflows().find((candidate) => candidate.id === workflowId);
+    return workflow?.staged === true;
+  }
+
+  activateStagedWorkflows(workflowIds: string[]): string[] {
+    const activated: string[] = [];
+    for (const workflowId of workflowIds) {
+      if (!this.isWorkflowStaged(workflowId)) continue;
+      this.persistence.updateWorkflow?.(workflowId, { staged: false, updatedAt: new Date().toISOString() });
+      activated.push(workflowId);
+    }
+    return activated;
+  }
+
+  getStagedWorkflowIds(): string[] {
+    return this.persistence.listWorkflows()
+      .filter((workflow) => workflow.staged === true)
+      .map((workflow) => workflow.id);
   }
 
   /**


### PR DESCRIPTION
## Summary

Load in-app planning submissions as staged workflows and start them only after explicit Start ready confirmation.

Automatic dispatcher polling cannot launch staged tasks.

## Review Claim

Create workflow stages work; Start ready work is the activation boundary.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only planning-preview workflows are staged; existing and non-preview workflows remain runnable by default.

## Slice Rationale

Persistence, scheduler filtering, app activation, and UI submission must land together to maintain one executable lifecycle.

## Non-goals

No task dependency, retry, approval, or non-planning submission behavior changes.

## Visual Proof

The transition is covered by focused UI and workflow-core regressions rather than static media because the claim is a launch boundary across time.

Manually inspected: the live graph remained pending after Create workflow and began execution only after Start ready work.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/orchestrator.test.ts -t "keeps staged workflows"`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/start-ready.test.ts src/__tests__/plan-submission-loader.test.ts`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sqlite-adapter.test.ts -t "persists staged workflow activation"`
- [x] `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx -t "submits a draft without starting staged work"`
- [x] `pnpm --filter @invoker/app build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c6c9d2781`
- Post-revert steps: Restart Invoker
- Data migration? The additive `staged` column remains harmless if code is reverted.

</details>
