### PR TITLE
[CI regression: deab6d1-required-fast-guardrails](1) Guarded libgtk-3 install for required-fast / Guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,6 +537,44 @@ jobs:
         continue-on-error: true
         run: pnpm --filter @invoker/app exec playwright install-deps chromium
 
+      - name: Install Electron GUI system libraries
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          has_libgtk3() {
+            if command -v ldconfig >/dev/null 2>&1; then
+              ldconfig -p 2>/dev/null | grep -q 'libgtk-3\.so\.0'
+              return
+            fi
+            find /lib /usr/lib -name 'libgtk-3.so.0*' -print -quit 2>/dev/null | grep -q .
+          }
+
+          # Electron links against libgtk-3, but `playwright install-deps
+          # chromium` does not install it (Chromium alone does not need
+          # GTK3), so guard scripts that boot Electron directly (see
+          # scripts/test-suites/required/05-delete-all-prod-db-guard.sh and
+          # 09-headless-cli-boots-smoke.sh) fail with "libgtk-3.so.0: cannot
+          # open shared object file" unless it's installed separately.
+          if has_libgtk3; then
+            exit 0
+          fi
+
+          if [ "$(id -u)" -eq 0 ]; then
+            apt-get update
+            apt-get install -y libgtk-3-0t64
+            exit 0
+          fi
+
+          if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+            sudo -n apt-get update
+            sudo -n apt-get install -y libgtk-3-0t64
+            exit 0
+          fi
+
+          echo "::error::Guardrails requires libgtk-3 (Electron GUI dependency); run as root or provide passwordless sudo for apt-get."
+          exit 1
+
       - name: Run suite group
         run: ${{ matrix.command }}
 


### PR DESCRIPTION
## Summary

CI job `required-fast / Guardrails` boots Electron directly to run its guard scripts on a self-hosted runner.

`playwright install-deps chromium` does not install `libgtk-3`, since Chromium alone does not need it. Electron does need it.

Without `libgtk-3`, Electron fails to start with `libgtk-3.so.0: cannot open shared object file`, so the guard scripts never run and the job fails.

This adds a guarded install step that installs `libgtk-3` only when it is missing, mirroring the existing `sudo -n` pattern already used by `required-fast-extra`'s native-build-deps step.

## Review Claim

Approve adding a guarded `libgtk-3` install step to the `required-fast / Guardrails` job so Electron can boot on the self-hosted runner.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The step checks for an existing `libgtk-3` install first and exits immediately if found. It only runs `apt-get install` when already root or when passwordless `sudo` is available, otherwise it fails loudly instead of hanging on a password prompt. It touches only this one step in the `required-fast / Guardrails` job; no other job, step, or product file changes.

## Slice Rationale

This is the only file-changing commit on this branch. The paired verification step re-ran the job's guard-script probe against this change and recorded a passing exit code, but produced no additional diff of its own, so there is nothing left to split into a separate slice.

## Non-goals

No changes to any other CI job or step.

No changes to product code, application behavior, or guard script contents.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/05-delete-all-prod-db-guard.sh && bash scripts/test-suites/required/06-large-file-guardrail.sh && bash scripts/test-suites/required/07-invalid-config-json.sh && bash scripts/test-suites/required/08-build-artifact-surfaces-guard.sh && bash scripts/test-suites/required/09-headless-cli-boots-smoke.sh && bash scripts/test-suites/required/10-dag-background-click-noop-guard.sh && bash scripts/test-suites/required/15-owner-boundary-policy.sh && bash scripts/test-suites/required/50-verify-executor-routing.sh && bash scripts/test-suites/required/51-verify-scratch-execution.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 83cafaa09`
- Post-revert steps: None
- Data migration? No

</details>
