### PR TITLE
[CI regression: 2f7c85f-required-fast-pr-babysit-harness](1) Skip repair-filing claim during dry runs

### DIFF
--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -171,6 +171,13 @@ def run_cycle(
     repair_dispatch_last_error: str | None = None
     open_pr_numbers = set(pr_by_number)
     stale_base_by_pr = compute_stale_base_by_pr(stacks, trunk, args.repo, gh, logger)
+    # A dry run never dispatches a repair (see the `if args.dry_run: continue`
+    # below, right after print_action), so it has nothing to dedup against
+    # other systems for -- claiming here would perform a real ledger write
+    # for a filing that's never going to happen, and a claim that fails
+    # closed (ledger/owner unreachable) would silently drop the action from
+    # the printed plan instead.
+    dry_run_claim_repair_filing = None if args.dry_run else claim_repair_filing
     for stack in stacks:
         plan = plan_stack_execution(
             stack,
@@ -183,7 +190,7 @@ def run_cycle(
             args.max_repair_attempts,
             trunk,
             stale_base_by_pr,
-            claim_repair_filing,
+            dry_run_claim_repair_filing,
         )
         queue_only_noop_check = plan.queue_only_noop_check
         logger.stack("admin-bypass-stack", plan.summary)


### PR DESCRIPTION
## Summary

`required-fast / PR Babysit Harness` was red because a dry run could still perform a real repair-filing claim.

`run_cycle` passed the live `claim_repair_filing` callback into `plan_stack_execution` on every cycle, dry run or not.

A dry run never dispatches a repair, so that claim call wrote to the ledger for a filing that was never going to happen.

The fix swaps in `None` for dry runs, so `plan_stack_execution` only claims a filing when a repair can actually be dispatched.

## Review Claim

Approve gating the repair-filing claim callback behind `args.dry_run`, so dry runs stop writing real ledger claims.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The change only narrows when `claim_repair_filing` is invoked; it does not run in `--dry-run` mode, where it previously ran unconditionally. Non-dry-run behavior is unchanged: the real callback is still passed through exactly as before.

## Slice Rationale

One tooling-policy slice: the failing CI job's root cause in `scripts/mergify_admin_requeue_exec.py`, with no unrelated edits.

## Non-goals

No refactor of `plan_stack_execution` or the ledger claim mechanism itself. No unrelated cleanup. No test weakening.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/28-pr-babysit-harness.sh` — exit code 0 on this branch (recorded by the verification task, `Invoker-Finalize-Id: d9ce9f2f-7df6-4b24-abc8-8e38f4f9813b`)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 49744c6e5`
- Post-revert steps: None
- Data migration? No

</details>
