### PR TITLE
[CI regression: 14dbf53-playwright-planning-chat-restore](1) Fix outdated ready-bar assertion in planning chat restore repro

### DIFF
--- a/packages/app/e2e/planning-chat-restore-conversational-mode-repro.spec.ts
+++ b/packages/app/e2e/planning-chat-restore-conversational-mode-repro.spec.ts
@@ -132,7 +132,7 @@ base.describe('Planning chat conversational mode restore', () => {
 
       await openPlanningTerminal(page);
       await submitPlanningText(page, 'Draft a YAML plan to add a README');
-      await expect(page.getByTestId('invoker-terminal-ready-bar')).toContainText('Draft ready', { timeout: 10000 });
+      await expect(page.getByRole('heading', { name: 'Review draft' })).toBeVisible({ timeout: 10000 });
       const savedSessionId = await page.evaluate(async () => {
         const list = await window.invoker.planningChatList();
         return list.sessions[0]?.id;


### PR DESCRIPTION
## Summary

CI job `playwright / planning-chat-restore` started failing because its repro spec waited on an outdated UI cue.

The spec asserted the planning terminal's ready bar would contain the text "Draft ready". That text no longer renders.

The current planning flow instead exposes a "Review draft" heading once a plan draft is ready for review.

This updates the repro spec's wait condition to the heading that the activation surface actually renders today.

## Review Claim

Approve updating the outdated ready-bar text assertion in the planning-chat-restore repro spec to the current "Review draft" heading, with no other changes.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect: only the repro spec's wait condition changes, no product source file is touched.

## Slice Rationale

One behavior slice: the failing CI job's root cause (an outdated test assertion) and its deterministic proof, with the empty follow-up verification commit folded in since it produced no additional diff.

## Non-goals

No refactor, no unrelated cleanup, no test weakening, and no snapshot churn beyond the one corrected wait condition.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-planning-chat-restore' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/planning-chat-restore-conversational-mode-repro.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert bfb964623b0bf199ffc46c77961307b1712363fc` (or the landed squash-merge commit for this PR)
- Post-revert steps: None
- Data migration? No

</details>
