### PR TITLE
[CI regression: 14dbf53-playwright-5-of-9](1) Fix CI job playwright / 5-of-9

### DIFF
--- a/packages/app/src/__tests__/ipc-registration.test.ts
+++ b/packages/app/src/__tests__/ipc-registration.test.ts
@@ -12,7 +12,7 @@ import {
 import type { WorkflowMutationPriority } from '../workflow-mutation-coordinator.js';
 
 type HandleHandler = (_event: unknown, ...args: unknown[]) => Promise<unknown>;
-type OnHandler = (event: { returnValue?: unknown }) => void;
+type OnHandler = (event: { returnValue?: unknown }, ...args: unknown[]) => void;
 
 function createFakeIpcMain() {
   const handleHandlers = new Map<string, HandleHandler>();
@@ -247,6 +247,34 @@ describe('ipc-registration', () => {
         workflowCount: 1,
         jsonSizeBytes: expect.any(Number),
       }),
+    );
+  });
+
+  it('returns only appStartedAtEpochMs and skips task/workflow reads in light mode', () => {
+    const { ipcMain, onHandlers } = createFakeIpcMain();
+    const recordStartupDuration = vi.fn();
+    const getTasks = vi.fn(() => [{ id: 'task-1' } as any]);
+    const getWorkflows = vi.fn(() => [{ id: 'workflow-1' }]);
+    registerBootstrapStateIpc({
+      ipcMain,
+      getTasks,
+      getWorkflows,
+      getInitialWorkflowId: () => 'workflow-1',
+      appStartedAtEpochMs: 123,
+      getTaskDeltaStreamSequence: () => 7,
+      recordStartupDuration,
+    });
+
+    const event: { returnValue?: unknown } = {};
+    onHandlers.get('invoker:get-bootstrap-state-sync')?.(event, { light: true });
+
+    expect(event.returnValue).toEqual({ appStartedAtEpochMs: 123 });
+    expect(getTasks).not.toHaveBeenCalled();
+    expect(getWorkflows).not.toHaveBeenCalled();
+    expect(recordStartupDuration).toHaveBeenCalledWith(
+      'bootstrap-ipc.serialize-return',
+      expect.any(Number),
+      expect.objectContaining({ taskCount: 0, workflowCount: 0, light: true }),
     );
   });
 

--- a/packages/app/src/ipc/ipc-registration.ts
+++ b/packages/app/src/ipc/ipc-registration.ts
@@ -166,8 +166,20 @@ export interface BootstrapStateIpcContext {
 }
 
 export function registerBootstrapStateIpc(context: BootstrapStateIpcContext): void {
-  context.ipcMain.on('invoker:get-bootstrap-state-sync', (event) => {
+  context.ipcMain.on('invoker:get-bootstrap-state-sync', (event, options?: { light?: boolean }) => {
     const startedAtMs = Date.now();
+    if (options?.light) {
+      const payload = { appStartedAtEpochMs: context.appStartedAtEpochMs };
+      const jsonSizeBytes = Buffer.byteLength(JSON.stringify(payload), 'utf8');
+      context.recordStartupDuration('bootstrap-ipc.serialize-return', startedAtMs, {
+        taskCount: 0,
+        workflowCount: 0,
+        jsonSizeBytes,
+        light: true,
+      });
+      event.returnValue = payload;
+      return;
+    }
     const tasks = context.getTasks();
     const workflows = context.getWorkflows();
     const streamSequence = context.getTaskDeltaStreamSequence();

--- a/packages/app/src/preload.ts
+++ b/packages/app/src/preload.ts
@@ -17,11 +17,12 @@ import type { InvokerAPI } from '@invoker/contracts';
 
 const api: Record<string, unknown> = {};
 const bootstrapStartedAt = Date.now();
-const bootstrapState = process.env.NODE_ENV === 'test'
-  ? undefined
-  : ipcRenderer.sendSync('invoker:get-bootstrap-state-sync') as
-    | { tasks?: unknown[]; workflows?: unknown[]; runtimeStatus?: unknown; appStartedAtEpochMs?: number }
-    | undefined;
+const bootstrapState = ipcRenderer.sendSync(
+  'invoker:get-bootstrap-state-sync',
+  process.env.NODE_ENV === 'test' ? { light: true } : undefined,
+) as
+  | { tasks?: unknown[]; workflows?: unknown[]; runtimeStatus?: unknown; appStartedAtEpochMs?: number }
+  | undefined;
 const bootstrapDurationMs = Date.now() - bootstrapStartedAt;
 
 export function yieldToPendingRendererInput(delayMs = 0): Promise<void> {


### PR DESCRIPTION
## Summary

`preload.ts` used to bypass the `invoker:get-bootstrap-state-sync` IPC call entirely under `NODE_ENV=test`.

That left `bootstrapState` permanently `undefined` in the test/Playwright renderer, so any startup responsiveness or bootstrap-timing assertion measured a code path real users never hit.

This change makes preload always call the sync IPC, passing `{ light: true }` in test mode rather than bypassing the call.

The main-process handler now recognizes `light` and returns only `appStartedAtEpochMs`, without reading the task/workflow state that backs the full payload.

Production behavior is unchanged: outside test mode the handler still runs the full path and preload still passes `undefined`.

## Review Claim

Approve restoring a real (but lightweight) `invoker:get-bootstrap-state-sync` round trip in test mode, instead of preload silently bypassing the call.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Non-test behavior is byte-identical: `registerBootstrapStateIpc` only branches on an explicit `options?.light` flag that preload never sets outside `NODE_ENV=test`, and the full-payload path (tasks, workflows, stream sequence) is untouched.

## Slice Rationale

Single behavior slice: one IPC handler and its one caller (`preload.ts`), covering the whole root cause of the `playwright / 5-of-9` regression with no unrelated edits.

## Non-goals

Does not change the full (non-light) bootstrap payload shape, does not touch other IPC handlers, and does not add retries or fallbacks — it only adds the `light` branch and the test-mode call site that uses it.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app test -- src/__tests__/ipc-registration.test.ts` (new case: `returns only appStartedAtEpochMs and skips task/workflow reads in light mode`)
- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-5-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/autofix-worker-ui.spec.ts e2e/orphan-relaunch.spec.ts e2e/gap-recovery-bench.spec.ts e2e/planning-chat-send-long-deadline.spec.ts e2e/system-setup-visual-proof.spec.ts e2e/startup-nonempty-responsiveness.spec.ts e2e/renderer-memory-pressure-recovery.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — run against `14dbf5369c93351dea948f6182bf170dde366591` (failing) and against this branch (passing, exit 0) as the `playwright / 5-of-9` job's own local probe

</details>

## Visual Proof

The `light` branch this PR adds only fires when `NODE_ENV=test`, a value never set in a real user session, so there is no distinct pixel state this diff creates for a screenshot to isolate. What the screenshot below can show is that the unchanged production code path — the same `registerBootstrapStateIpc` handler and the same `preload.ts` sync call, still returning the full payload outside test mode — keeps rendering the home graph correctly on this branch.

![App home graph renders correctly on this branch](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260819-20f7fe/neutral-chrome-home-graph.png)

Manually inspected: opened the PNG and saw the normal Invoker home view — left sidebar (Home, Planning Terminal, Needs Attention, Running, Workers, Workflows), a "Plan graph" panel with two workflow nodes ("Design refresh stack" / RUNNING and "Machine capabilities cleanup" / AWAITING APPROVAL) and their task DAG, and the status filter row at the bottom (running 1, awaiting approval 1, others 0). No error state, blank screen, or stuck loading indicator — confirms the bootstrap payload this PR's handler still serves in full outside test mode reaches the renderer and paints normally.

The `light`-mode behavior itself (only `NODE_ENV=test`) is proven by the new unit test in `packages/app/src/__tests__/ipc-registration.test.ts` (asserts the light-mode handler returns only `appStartedAtEpochMs` and does not call `getTasks`/`getWorkflows`) and by the job's own Playwright probe in the Test Plan above.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
