### PR TITLE
[CI regression: cd07355-required-fast-mergify-admin-requeue](1) Add hermetic ledger fake for mergify_admin_requeue repros

### DIFF
--- a/scripts/repro/fixtures/fake-headless-ipc.js
+++ b/scripts/repro/fixtures/fake-headless-ipc.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+// Reusable fake for scripts/headless-ipc.js, scoped to the one command every
+// mergify_admin_requeue/pr-maintenance-worker repro needs: the repair_filings
+// dedup ledger's `repair-filing insert`/`repair-filing release` mutation
+// (see scripts/repair_filing_ledger.py, scripts/repair-filing-ledger.mjs).
+//
+// scripts/headless-lib.sh's headless_mutation() always delegates through the
+// real scripts/headless-ipc.js unless INVOKER_HEADLESS_STANDALONE=1, which
+// requires a live Invoker owner process (IPC) or a built headless-client.js
+// (standalone) neither of which a hermetic repro provides. Point
+// INVOKER_HEADLESS_IPC_HELPER at this file so headless_mutation resolves the
+// ledger claim without either, matching the ledger-free behavior every one
+// of these repros had before scripts/mergify_admin_requeue_plan.py wired the
+// real entrypoint to the shared claim/release primitive (#9474).
+//
+// Any other headless_mutation command (e.g. `run <plan.yaml>` for submitting
+// an actual repair workflow) is not this fixture's concern -- forward it
+// unchanged to the real scripts/headless-ipc.js, which already has its own
+// no-owner-available fallback (standalone mode via a built headless-client.js).
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const args = process.argv.slice(2);
+const sepIndex = args.indexOf('--');
+const headlessArgs = sepIndex >= 0 ? args.slice(sepIndex + 1) : [];
+const [command, subcommand] = headlessArgs;
+
+if (args[0] === 'exec' && command === 'repair-filing' && subcommand === 'insert') {
+  process.stdout.write(`${JSON.stringify({ inserted: true, row: {} })}\n`);
+  process.exit(0);
+}
+
+if (args[0] === 'exec' && command === 'repair-filing' && subcommand === 'release') {
+  process.stdout.write(`${JSON.stringify({ released: true })}\n`);
+  process.exit(0);
+}
+
+const REAL_IPC_HELPER = path.join(__dirname, '..', '..', 'headless-ipc.js');
+const result = spawnSync(process.execPath, [REAL_IPC_HELPER, ...args], { stdio: 'inherit' });
+process.exit(result.status ?? 1);

--- a/scripts/repro/repro-babysit-amended-repair-push.sh
+++ b/scripts/repro/repro-babysit-amended-repair-push.sh
@@ -23,6 +23,7 @@ export FAKE_GH_STATE_DIR="$TMP/state"
 REAL_NODE="$(command -v node)"
 export REAL_NODE
 export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export INVOKER_HEADLESS_IPC_HELPER="$ROOT/scripts/repro/fixtures/fake-headless-ipc.js"
 
 FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
 import sys

--- a/scripts/repro/repro-babysit-land-dryrun.sh
+++ b/scripts/repro/repro-babysit-land-dryrun.sh
@@ -16,6 +16,7 @@ fail() { echo "[repro] FAIL: $1"; [ -n "${2:-}" ] && echo "----- output -----" &
 mkdir -p "$TMP/state"
 export FAKE_GH_STATE_DIR="$TMP/state"
 export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export INVOKER_HEADLESS_IPC_HELPER="$ROOT/scripts/repro/fixtures/fake-headless-ipc.js"
 
 # The fake gh expands the "*" checks default to the repo's real required-check
 # names, so the landing brain sees every .mergify.yml-required check green.

--- a/scripts/repro/repro-babysit-merged-during-repair.sh
+++ b/scripts/repro/repro-babysit-merged-during-repair.sh
@@ -20,6 +20,7 @@ export HOME="$TMP/home"
 mkdir -p "$HOME" "$TMP/state" "$TMP/bin"
 export FAKE_GH_STATE_DIR="$TMP/state"
 export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export INVOKER_HEADLESS_IPC_HELPER="$ROOT/scripts/repro/fixtures/fake-headless-ipc.js"
 
 FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
 import sys

--- a/scripts/repro/repro-babysit-pr-body-human-split.sh
+++ b/scripts/repro/repro-babysit-pr-body-human-split.sh
@@ -23,6 +23,7 @@ export FAKE_GH_STATE_DIR="$TMP/state"
 REAL_NODE="$(command -v node)"
 export REAL_NODE
 export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export INVOKER_HEADLESS_IPC_HELPER="$ROOT/scripts/repro/fixtures/fake-headless-ipc.js"
 
 FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
 import sys

--- a/scripts/repro/repro-babysit-pr-body-prereq-split.sh
+++ b/scripts/repro/repro-babysit-pr-body-prereq-split.sh
@@ -22,6 +22,7 @@ WORK_PARENT="$HOME/.invoker/mergify-admin-requeue-work"
 mkdir -p "$WORK_PARENT" "$TMP/state" "$TMP/bin"
 export FAKE_GH_STATE_DIR="$TMP/state"
 export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export INVOKER_HEADLESS_IPC_HELPER="$ROOT/scripts/repro/fixtures/fake-headless-ipc.js"
 
 FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
 import sys

--- a/scripts/repro/repro-babysit-pr-body-proof-human-split.sh
+++ b/scripts/repro/repro-babysit-pr-body-proof-human-split.sh
@@ -23,6 +23,7 @@ export FAKE_GH_STATE_DIR="$TMP/state"
 REAL_NODE="$(command -v node)"
 export REAL_NODE
 export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export INVOKER_HEADLESS_IPC_HELPER="$ROOT/scripts/repro/fixtures/fake-headless-ipc.js"
 
 FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
 import sys

--- a/scripts/repro/repro-babysit-pr-body-valid-noop.sh
+++ b/scripts/repro/repro-babysit-pr-body-valid-noop.sh
@@ -21,6 +21,7 @@ WORK_PARENT="$HOME/.invoker/mergify-admin-requeue-work"
 mkdir -p "$WORK_PARENT" "$TMP/state" "$TMP/bin"
 export FAKE_GH_STATE_DIR="$TMP/state"
 export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export INVOKER_HEADLESS_IPC_HELPER="$ROOT/scripts/repro/fixtures/fake-headless-ipc.js"
 export CLAUDE_CALLED="$TMP/claude-called"
 
 FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'

--- a/scripts/repro/repro-babysit-queue-only-check.sh
+++ b/scripts/repro/repro-babysit-queue-only-check.sh
@@ -22,6 +22,7 @@ WORK_PARENT="$HOME/.invoker/mergify-admin-requeue-work"
 mkdir -p "$WORK_PARENT" "$TMP/state" "$TMP/bin"
 export FAKE_GH_STATE_DIR="$TMP/state"
 export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export INVOKER_HEADLESS_IPC_HELPER="$ROOT/scripts/repro/fixtures/fake-headless-ipc.js"
 
 FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
 import sys

--- a/scripts/repro/repro-babysit-queue-only-empty-log.sh
+++ b/scripts/repro/repro-babysit-queue-only-empty-log.sh
@@ -21,6 +21,7 @@ WORK_PARENT="$HOME/.invoker/mergify-admin-requeue-work"
 mkdir -p "$WORK_PARENT" "$TMP/state" "$TMP/bin"
 export FAKE_GH_STATE_DIR="$TMP/state"
 export PATH="$TMP/bin:$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export INVOKER_HEADLESS_IPC_HELPER="$ROOT/scripts/repro/fixtures/fake-headless-ipc.js"
 export CLAUDE_CALLED="$TMP/claude-called"
 
 FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'

--- a/scripts/repro/repro-babysit-rebase-onto-base.sh
+++ b/scripts/repro/repro-babysit-rebase-onto-base.sh
@@ -21,6 +21,7 @@ WORK_PARENT="$HOME/.invoker/mergify-admin-requeue-work"
 mkdir -p "$WORK_PARENT" "$TMP/state"
 export FAKE_GH_STATE_DIR="$TMP/state"
 export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export INVOKER_HEADLESS_IPC_HELPER="$ROOT/scripts/repro/fixtures/fake-headless-ipc.js"
 
 FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
 import sys

--- a/scripts/repro/repro-babysit-stale-base-skips-agent-repair.sh
+++ b/scripts/repro/repro-babysit-stale-base-skips-agent-repair.sh
@@ -21,6 +21,7 @@ WORK_PARENT="$HOME/.invoker/mergify-admin-requeue-work"
 mkdir -p "$WORK_PARENT" "$TMP/state"
 export FAKE_GH_STATE_DIR="$TMP/state"
 export PATH="$ROOT/scripts/repro/fixtures/fake-gh/bin:$PATH"
+export INVOKER_HEADLESS_IPC_HELPER="$ROOT/scripts/repro/fixtures/fake-headless-ipc.js"
 
 FAKE_GH_REQUIRED_CHECKS="$(python3 - <<'PY'
 import sys

--- a/scripts/repro/repro-mergify-admin-requeue.sh
+++ b/scripts/repro/repro-mergify-admin-requeue.sh
@@ -117,6 +117,7 @@ PY
 chmod +x "$TMP/bin/gh"
 
 export PATH="$TMP/bin:$PATH"
+export INVOKER_HEADLESS_IPC_HELPER="$ROOT/scripts/repro/fixtures/fake-headless-ipc.js"
 out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo Neko-Catpital-Labs/Invoker --author EdbertChan --state-file "$TMP/ledger.jsonl")"
 printf '%s\n' "$out"
 

--- a/scripts/repro/repro-mergify-rejected-pr.sh
+++ b/scripts/repro/repro-mergify-rejected-pr.sh
@@ -116,6 +116,7 @@ PY
 chmod +x "$TMP/bin/gh"
 
 export PATH="$TMP/bin:$PATH"
+export INVOKER_HEADLESS_IPC_HELPER="$ROOT/scripts/repro/fixtures/fake-headless-ipc.js"
 out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo Neko-Catpital-Labs/Invoker --author EdbertChan --state-file "$TMP/ledger.jsonl" --pr 2969)"
 printf '%s\n' "$out"
 

--- a/scripts/repro/worker-routing-driver.mjs
+++ b/scripts/repro/worker-routing-driver.mjs
@@ -41,7 +41,7 @@ function makeLeg(kind) {
   writeFileSync(nodeLog, '');
   writeFileSync(
     join(bin, 'node'),
-    `#!/usr/bin/env bash\nif [[ "$#" -ge 1 && "$1" == *"/scripts/retry-ledger.mjs" ]]; then\n  exec ${JSON.stringify(process.execPath)} "$@"\nfi\nprintf 'node %s\\n' "$*" >> ${JSON.stringify(nodeLog)}\nexit 0\n`,
+    `#!/usr/bin/env bash\nif [[ "$#" -ge 1 && ( "$1" == *"/scripts/retry-ledger.mjs" || ( "$1" == *"/scripts/repro/fixtures/fake-headless-ipc.js" && "$*" == *"repair-filing"* ) ) ]]; then\n  exec ${JSON.stringify(process.execPath)} "$@"\nfi\nprintf 'node %s\\n' "$*" >> ${JSON.stringify(nodeLog)}\nexit 0\n`,
     { mode: 0o755 },
   );
   const lines = [];
@@ -56,6 +56,7 @@ function makeLeg(kind) {
     FAKE_GH_STATE_DIR: state,
     INVOKER_GITHUB_TARGET_REPO: 'fake/repo',
     INVOKER_PR_CRON_AUTHOR: 'fake-bot',
+    INVOKER_HEADLESS_IPC_HELPER: join(ROOT, 'scripts/repro/fixtures/fake-headless-ipc.js'),
   };
   return { kind, legDir, bin, state, home, nodeLog, lines, logger, baseEnv };
 }


### PR DESCRIPTION
## Summary

CI job `required-fast / Mergify Admin Requeue` first failed on default-branch commit
`cd07355fe00361ce676b048a6c1be5696968fe2a` and stayed red through `2dd5b898d986823f0517e28754eaa2bee43af8f7`.

A repro-suite fixture used to skip the `repair_filings` dedup ledger entirely.

A later change wired the real entrypoint into that ledger's claim/release primitive.
The fixture never caught up, so the repro suite started failing.

This PR adds a fake for that one ledger call and points the shared repro fixture at it,
so the suite resolves the claim locally without a live owner process.

## Review Claim

Approve adding a fake for the single `repair-filing insert`/`repair-filing release` ledger
call, wired into the repro suite's shared fixture, so the `mergify_admin_requeue` repros
resolve the ledger claim locally instead of needing a live owner process.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Every changed file is under `scripts/repro/`. `scripts/repro/fixtures/fake-headless-ipc.js`
only intercepts `repair-filing insert`/`repair-filing release`; every other call is forwarded
unchanged to the real `scripts/headless-ipc.js`, which keeps its own no-owner-available
fallback. No product code, CI workflow, or non-repro test file changes.

## Slice Rationale

One proof slice: the repro-harness fix for the failing CI job, with a deterministic local
repro command as the only verification. No unrelated repro or fixture changes are bundled in.

## Non-goals

No product code changes. No CI workflow changes. No changes to non-`mergify_admin_requeue`
repros beyond pointing `scripts/repro/worker-routing-driver.mjs`'s shared fake `node` shim at
the same fixture the `mergify_admin_requeue` repros already use.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/12-mergify-admin-requeue.sh`
- [ ] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-body-ci-regression-cd07355.md`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
