### PR TITLE
[CI regression: 14dbf53-playwright-6-of-9](1) Match planning terminal e2e assertions to the Review draft UI

### DIFF
--- a/packages/app/e2e/planning-terminal-restart-persistence.spec.ts
+++ b/packages/app/e2e/planning-terminal-restart-persistence.spec.ts
@@ -132,7 +132,8 @@ base.describe('Planning Terminal restart persistence', () => {
 
       await openPlanningTerminal(page);
       await submitPlanningText(page, 'Draft a YAML plan to add a README');
-      await expect(page.getByTestId('invoker-terminal-ready-bar')).toContainText('Draft ready', { timeout: 10000 });
+      await expect(page.getByRole('heading', { name: 'Review draft' })).toBeVisible({ timeout: 10000 });
+      await expect(page.getByTestId('draft-raw-yaml')).toContainText('name: Planning Terminal Restart', { timeout: 10000 });
       const savedSessionId = await page.evaluate(async () => {
         const list = await window.invoker.planningChatList();
         return list.sessions[0]?.id;
@@ -193,7 +194,8 @@ base.describe('Planning Terminal restart persistence', () => {
 
       await openPlanningTerminal(page);
       await submitPlanningText(page, 'Draft a YAML plan to add a README');
-      await expect(page.getByTestId('invoker-terminal-ready-bar')).toContainText('Draft ready', { timeout: 10000 });
+      await expect(page.getByRole('heading', { name: 'Review draft' })).toBeVisible({ timeout: 10000 });
+      await expect(page.getByTestId('draft-raw-yaml')).toContainText('name: Planning Terminal Restart', { timeout: 10000 });
       const savedSessionId = await page.evaluate(async () => {
         const list = await window.invoker.planningChatList();
         return list.sessions[0]?.id;

--- a/packages/app/e2e/planning-terminal-tmux-blank-repro.spec.ts
+++ b/packages/app/e2e/planning-terminal-tmux-blank-repro.spec.ts
@@ -129,7 +129,8 @@ async function bootstrapPlanningDraft(page: Page, planYaml: string): Promise<str
 
   await openPlanningTerminal(page);
   await submitPlanningText(page, 'Draft a YAML plan to reproduce planning terminal tmux blanking');
-  await expect(page.getByTestId('invoker-terminal-ready-bar')).toContainText(/draft ready/i, { timeout: 10000 });
+  await expect(page.getByRole('heading', { name: 'Review draft' })).toBeVisible({ timeout: 10000 });
+  await expect(page.getByTestId('draft-raw-yaml')).toContainText('name: Planning Terminal Tmux Blank Repro', { timeout: 10000 });
   const sessionId = await page.evaluate(async () => {
     const list = await window.invoker.planningChatList();
     return list.sessions[0]?.id;


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=14dbf5369c93351dea948f6182bf170dde366591; job=playwright / 6-of-9 -->

CI job `playwright / 6-of-9` first failed on default-branch push commit 14dbf5369c93351dea948f6182bf170dde366591 in run 31906721279. It was most recently still red at 2dd5b898d986823f0517e28754eaa2bee43af8f7 in run 32207862999.

Two Playwright specs asserted only that the terminal's ready bar contained "Draft ready" text before continuing. That bar's summary text is dynamic.

The bar itself also unmounts once the draft review panel opens, so the check raced the UI.

This slice makes both specs wait for the "Review draft" heading and the `draft-raw-yaml` panel instead. That is the state each test actually depends on next.

First bad job: https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/31906721279/job/95069185348

## Review Claim

Approve replacing the two specs' "Draft ready" ready-bar assertion with a wait on the "Review draft" heading and the `draft-raw-yaml` panel.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect.

## Slice Rationale

One behavior slice: the two spec files whose assertion caused the shard failure. The visual-baseline PNG refresh produced by re-running the shard is kept in its own slice next in the stack.

## Non-goals

- No refactor, no unrelated cleanup.
- No product source changes; both edited files are Playwright specs.
- No snapshot churn outside the two spec files.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build`
- [x] `env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-6-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/embedded-terminal-spawn-failure.spec.ts e2e/embedded-terminal-restart-persistence.spec.ts e2e/planning-terminal-restart-persistence.spec.ts e2e/planning-terminal-open-daemon-owner-repro.spec.ts e2e/planning-terminal-tmux-blank-repro.spec.ts e2e/planning-tmux-blank-repro.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — `8 passed (1.7m)`, exit 0.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <PR merge commit>`
- Post-revert steps: None
- Data migration? No

</details>
