### PR TITLE
[CI Regression Watch](1) File member jobs when a fleet key hits needsHuman

### DIFF
--- a/scripts/e2e-regression-watch.mjs
+++ b/scripts/e2e-regression-watch.mjs
@@ -530,6 +530,8 @@ function synthesizeFleetFailure(state, sha, members, jobDefinitions) {
 function prepareFleetCorrelatedFailures(state, failures, {
   threshold = FLEET_EVENT_THRESHOLD,
   jobDefinitions = null,
+  maxAttempts = MAX_ATTEMPTS,
+  nowMs = Date.now(),
 } = {}) {
   const normalized = normalizeStateForMutation(state);
   const groups = groupFailuresBySha(failures);
@@ -537,6 +539,7 @@ function prepareFleetCorrelatedFailures(state, failures, {
   const fleetFailures = [];
   const retiredFleetMembers = [];
   let stateChanged = false;
+  let groupsNeedingHuman = 0;
   const existingFleetBySha = new Map(
     Object.values(normalized.activeFailures)
       .filter((failure) => isFleetEventFailure(failure) && typeof failure.firstBadSha === 'string')
@@ -577,6 +580,21 @@ function prepareFleetCorrelatedFailures(state, failures, {
     if (existingFleet?.jobName && existingFleet.jobName !== fleetFailure.jobName) {
       delete normalized.activeFailures[existingFleet.jobName];
     }
+
+    // When the consolidated fleet key has exhausted its attempt budget,
+    // keep the fleet record as needs-human but stop swallowing members —
+    // otherwise those jobs sit forever at attempts:0 with no repair queued.
+    const fleetGate = shouldFileFailure(fleetFailure, { nowMs, maxAttempts });
+    if (fleetGate.action === 'needs-human') {
+      normalized.activeFailures[fleetFailure.jobName] = {
+        ...fleetFailure,
+        needsHuman: true,
+      };
+      groupsNeedingHuman += 1;
+      stateChanged = true;
+      continue;
+    }
+
     normalized.activeFailures[fleetFailure.jobName] = fleetFailure;
     fleetFailures.push(fleetFailure);
     stateChanged = true;
@@ -625,6 +643,7 @@ function prepareFleetCorrelatedFailures(state, failures, {
   return {
     failures: prepared,
     groupsCorrelated: fleetFailures.length,
+    groupsNeedingHuman,
     retiredFleetMembers,
     stateChanged,
   };
@@ -1123,6 +1142,8 @@ export function processFailureFilingSweep(state, {
   const prepared = prepareFleetCorrelatedFailures(state, failures, {
     threshold: fleetEventThreshold,
     jobDefinitions,
+    maxAttempts,
+    nowMs,
   });
   if (prepared.stateChanged) save(state);
   for (const retired of prepared.retiredFleetMembers) onRetired(retired);
@@ -1131,7 +1152,7 @@ export function processFailureFilingSweep(state, {
     groupsFiled: 0,
     groupsSkippedAlreadyAddressed: 0,
     groupsDeferredByCap: 0,
-    groupsNeedingHuman: 0,
+    groupsNeedingHuman: prepared.groupsNeedingHuman ?? 0,
     groupsInBackoff: 0,
     groupsRetired: prepared.retiredFleetMembers.length,
     groupsRetiredStale: 0,

--- a/scripts/e2e-regression-watch.test.mjs
+++ b/scripts/e2e-regression-watch.test.mjs
@@ -32,14 +32,14 @@ function makeFailure(overrides = {}) {
     jobName: 'playwright / launch-dispatch-stuck-lease',
     firstBadSha: 'a5d6b3e626ace9e963e924c0de9410dc0302de9a',
     firstBadRunId: 100,
-    firstBadRunCreatedAt: '2026-08-12T00:00:00Z',
+    firstBadRunCreatedAt: '2026-08-18T00:00:00Z',
     firstJobDatabaseId: 200,
     firstJobUrl: 'https://example.test/job/200',
     lastBadSha: 'a5d6b3e626ace9e963e924c0de9410dc0302de9a',
     lastBadRunId: 100,
     lastJobDatabaseId: 200,
     lastJobUrl: 'https://example.test/job/200',
-    lastObservedAt: '2026-08-12T00:00:00Z',
+    lastObservedAt: '2026-08-18T00:00:00Z',
     occurrences: 1,
     attempts: 0,
     lastFiledAt: null,
@@ -354,12 +354,14 @@ describe('fleet SHA correlation', () => {
     assert.equal(state.activeFailures['fleet / abc123d'].attempts, 1);
 
     let liveQueryCalled = false;
+    const liveQueried = [];
     const cappedCounts = processFailureFilingSweep(state, {
       now: new Date('2026-08-12T03:00:00Z'),
       maxAttempts: 1,
       jobDefinitions,
-      liveQuery: () => {
+      liveQuery: (failure) => {
         liveQueryCalled = true;
+        liveQueried.push(failure.jobName);
         return false;
       },
       fileFailure: () => {
@@ -367,9 +369,56 @@ describe('fleet SHA correlation', () => {
       },
     });
 
-    assert.equal(liveQueryCalled, false, 'attempt cap should skip before live workflow dedup');
+    // Fleet key is exhausted in prepare (before liveQuery); members fall back
+    // to the per-job path and are claimed/filed individually.
+    assert.equal(liveQueried.includes('fleet / abc123d'), false);
+    assert.equal(liveQueryCalled, true);
     assert.equal(cappedCounts.groupsNeedingHuman, 1);
-    assert.equal(filed, 1);
+    assert.equal(cappedCounts.groupsFiled, 3);
+    assert.equal(filed, 4);
+    assert.equal(state.activeFailures['fleet / abc123d'].needsHuman, true);
+    for (const jobName of jobs) {
+      assert.equal(state.activeFailures[jobName].memberOfFleetEvent, undefined);
+      assert.equal(state.activeFailures[jobName].attempts, 1);
+    }
+  });
+
+  it('files member jobs individually once a fleet key is already needsHuman', () => {
+    const sha = 'abc123def456abc123def456abc123def456ab1';
+    const jobs = [
+      'required-fast / Vitest Workspace',
+      'quality / Dependency Cruise',
+      'docker / comprehensive',
+    ];
+    const state = stateWithFailures(jobs.map((jobName) => makeFailure({
+      jobName,
+      firstBadSha: sha,
+      memberOfFleetEvent: sha,
+    })));
+    state.activeFailures['fleet / abc123d'] = makeFailure({
+      jobName: 'fleet / abc123d',
+      markerJobName: 'fleet',
+      isFleetEvent: true,
+      firstBadSha: sha,
+      attempts: 3,
+      needsHuman: true,
+      lastFiledAt: '2026-08-12T00:00:00.000Z',
+      memberJobNames: jobs,
+    });
+    const filed = [];
+
+    const counts = processFailureFilingSweep(state, {
+      now: new Date('2026-08-12T04:00:00Z'),
+      maxAttempts: 3,
+      jobDefinitions: jobDefinitionsFor(jobs),
+      liveQuery: () => false,
+      fileFailure: (failure) => filed.push(failure.jobName),
+    });
+
+    assert.equal(counts.groupsCorrelated, 0);
+    assert.equal(counts.groupsNeedingHuman, 1);
+    assert.deepEqual(filed.sort(), [...jobs].sort());
+    assert.equal(counts.groupsFiled, 3);
     assert.equal(state.activeFailures['fleet / abc123d'].needsHuman, true);
   });
 


### PR DESCRIPTION
## Summary

When several CI jobs first fail on the same master commit, the watcher files one fleet repair.

After that fleet key burns its three attempts, member jobs used to stay stuck with no repair filed.

This change keeps the exhausted fleet marked for human review, then files each member job on its own path.

## Review Claim

Exhausted fleet keys no longer permanently block per-job CI regression filing for their members.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Fleet attempt exhaustion only changes which failure keys are eligible to file. It does not raise caps, skip the repair-filing ledger, or file unmapped jobs.

## Slice Rationale

This is the filing-policy fix alone. Owner exec-result and repair-filing noTrack fallthrough stay on a separate branch.

## Non-goals

Does not change fleet correlation thresholds, attempt caps, verify-command mapping, or the repair plan prompt formula.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node --test scripts/e2e-regression-watch.test.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 80dbf8adfb34`
- Post-revert steps: None
- Data migration? No

</details>
