### PR TITLE
[Web surface parity](2) Move Function: createTrackedHeadlessExecutor to headless-shared

### DIFF
--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -48,6 +48,7 @@ import {
   BOLD,
   RESET,
   createHeadlessExecutor,
+  createTrackedHeadlessExecutor,
   wireHeadlessApproveHook,
   buildHeadlessApiServerDeps,
   trackHeadlessWorkflow,
@@ -196,25 +197,7 @@ function printStartReadyOutcomeSummary(result: StartReadyResult, request: StartR
     process.stdout.write(`  workflow outcomes: ${succeeded} succeeded, ${failed} failed\n`);
   }
 }
-function createTrackedHeadlessExecutor(
-  deps: HeadlessDeps,
-  taskHandles: TaskHandleMap,
-) {
-  return createHeadlessExecutor(
-    {
-      ...deps,
-      ownerTaskRunnerProvider: undefined,
-    },
-    {
-      onSpawned: (taskId, handle, executor) => {
-        taskHandles.set(taskId, { handle, executor });
-      },
-      onComplete: (taskId) => {
-        taskHandles.delete(taskId);
-      },
-    },
-  );
-}
+
 
 function startTrackedHeadlessLaunchDispatcher(
   deps: HeadlessDeps,

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -37,6 +37,7 @@ import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import type { RuntimeServices } from '@invoker/runtime-service';
 import type { ReviewGateCiRepairCommandResult } from './review-gate-ci-repair-command.js';
 import type { WorkerRuntimeController } from './worker-control.js';
+import type { TaskHandleMap } from './execution/task-runner-wiring.js';
 
 
 export interface HeadlessDeps {
@@ -224,15 +225,40 @@ export function createHeadlessExecutor(
   return executor;
 }
 
-export function wireHeadlessApproveHook(deps: HeadlessDeps, te: TaskRunner): void {
-  deps.orchestrator.setBeforeApproveHook(async (task) => {
-    if (task.config.isMergeNode && task.config.workflowId && task.execution.pendingFixError === undefined) {
-      const workflow = deps.persistence.loadWorkflow(task.config.workflowId);
-      if (workflow?.mergeMode === "external_review") return;
-      await te.approveMerge(task.config.workflowId);
-    }
-  });
+/**
+ * Tracked variant of {@link createHeadlessExecutor}: registers every spawned
+ * task handle in `taskHandles` so surfaces that need live process handles
+ * (web task terminals) can reach running tasks. Strips
+ * `ownerTaskRunnerProvider` because an owner-provided TaskRunner ignores
+ * callback overrides.
+ */
+export function createTrackedHeadlessExecutor(
+  deps: HeadlessDeps,
+  taskHandles: TaskHandleMap,
+): TaskRunner {
+  return createHeadlessExecutor(
+    {
+      ...deps,
+      ownerTaskRunnerProvider: undefined,
+    },
+    {
+      onSpawned: (taskId, handle, executor) => {
+        taskHandles.set(taskId, { handle, executor });
+      },
+      onComplete: (taskId) => {
+        taskHandles.delete(taskId);
+      },
+    },
+  );
 }
+
+export function wireHeadlessApproveHook(deps: HeadlessDeps, te: TaskRunner): void { deps.orchestrator.setBeforeApproveHook(async (task) => {
+  if (task.config.isMergeNode && task.config.workflowId && task.execution.pendingFixError === undefined) {
+    const workflow = deps.persistence.loadWorkflow(task.config.workflowId);
+    if (workflow?.mergeMode === "external_review") return;
+    await te.approveMerge(task.config.workflowId);
+  }
+}); }
 
 export interface QueryFlags {
   output: 'text' | 'label' | 'json' | 'jsonl';

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -68,6 +68,7 @@ import {
   BOLD,
   RESET,
   createHeadlessExecutor,
+  createTrackedHeadlessExecutor,
   wireHeadlessApproveHook,
   parseQueryFlags,
   trackHeadlessWorkflow,
@@ -76,7 +77,7 @@ import {
   withRestoredTaskUnlessDeleteAllWon,
 } from './headless-shared.js';
 
-export { createHeadlessExecutor, wireHeadlessApproveHook, parseQueryFlags };
+export { createHeadlessExecutor, createTrackedHeadlessExecutor, wireHeadlessApproveHook, parseQueryFlags };
 export type { HeadlessDeps, QueryFlags };
 import { headlessQuery, headlessQuerySelect, renderWorkerStatus } from './headless-query-list.js';
 export { resolveAgentSession } from './headless-query-list.js';


### PR DESCRIPTION
Rehomes the tracked executor helper from headless-run-resume so the
owner-serve flow can reuse it, and re-exports it through the headless
barrel. No behavior change.

Depends-On: #9948