### PR TITLE
[Web surface parity](5) enabledExecutionAgents config field and filters

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -3,6 +3,8 @@ import type * as NodeOs from 'node:os';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { resolveInvokerConfigPath } from '@invoker/contracts';
 import {
+  filterExecutionHarnesses,
+  filterPlanningPresets,
   loadConfig,
   resolveAutoFixExecutionModel,
   resolveAutoFixPoolId,
@@ -11,6 +13,7 @@ import {
   resolveDefaultTaskExecutionSettings,
   resolveConflictResolutionSettings,
   resolveEmbeddedTerminalBackendConfig,
+  resolveEnabledExecutionAgents,
 } from '../config.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
@@ -81,6 +84,23 @@ describe('loadConfig', () => {
     );
     const config = loadConfig();
     expect(config.planningHeartbeatIntervalSeconds).toBe(30);
+  });
+
+  it('reads enabledExecutionAgents from user config', () => {
+    writeUserConfig({ enabledExecutionAgents: ['claude', 'omp'] });
+    expect(loadConfig().enabledExecutionAgents).toEqual(['claude', 'omp']);
+  });
+
+  it('rejects non-array enabledExecutionAgents', () => {
+    writeUserConfig({ enabledExecutionAgents: 'claude' });
+    expect(() => loadConfig()).toThrow(/enabledExecutionAgents must be an array/);
+  });
+
+  it('rejects empty or non-string enabledExecutionAgents entries', () => {
+    writeUserConfig({ enabledExecutionAgents: ['claude', '  '] });
+    expect(() => loadConfig()).toThrow(/non-empty strings/);
+    writeUserConfig({ enabledExecutionAgents: [42] });
+    expect(() => loadConfig()).toThrow(/non-empty strings/);
   });
 
   it('reads disableAutoRunOnStartup from user config', () => {
@@ -512,5 +532,81 @@ describe('resolveEmbeddedTerminalBackendConfig', () => {
       {},
       { INVOKER_EMBEDDED_TERMINAL_BACKEND: 'external' },
     )).toThrow(/Invalid embedded terminal backend/);
+  });
+});
+
+describe('resolveEnabledExecutionAgents', () => {
+  it('returns null when the field is unset', () => {
+    expect(resolveEnabledExecutionAgents({})).toBeNull();
+  });
+
+  it('returns null when the field is empty or whitespace-only', () => {
+    expect(resolveEnabledExecutionAgents({ enabledExecutionAgents: [] })).toBeNull();
+    expect(resolveEnabledExecutionAgents({ enabledExecutionAgents: ['  ', ''] })).toBeNull();
+  });
+
+  it('trims and lowercases entries and drops empty ones', () => {
+    expect(resolveEnabledExecutionAgents({ enabledExecutionAgents: ['  Claude ', 'OMP', ''] }))
+      .toEqual(new Set(['claude', 'omp']));
+  });
+});
+
+describe('filterExecutionHarnesses', () => {
+  const harnesses = [
+    { name: 'claude', supportedModels: [] },
+    { name: 'codex', supportedModels: [] },
+    { name: 'omp', supportedModels: [] },
+  ];
+
+  it('returns the input unchanged when no allowlist is configured', () => {
+    expect(filterExecutionHarnesses(harnesses, {})).toEqual(harnesses);
+    expect(filterExecutionHarnesses(harnesses, { enabledExecutionAgents: [] })).toEqual(harnesses);
+  });
+
+  it('drops harnesses missing from the allowlist', () => {
+    expect(filterExecutionHarnesses(harnesses, { enabledExecutionAgents: ['claude'] }))
+      .toEqual([{ name: 'claude', supportedModels: [] }]);
+  });
+
+  it('matches case-insensitively with whitespace tolerated', () => {
+    expect(filterExecutionHarnesses(harnesses, { enabledExecutionAgents: [' CLAUDE ', 'Omp'] }))
+      .toEqual([
+        { name: 'claude', supportedModels: [] },
+        { name: 'omp', supportedModels: [] },
+      ]);
+  });
+});
+
+describe('filterPlanningPresets', () => {
+  const presets = [
+    { key: 'claude', tool: 'claude', model: undefined },
+    { key: 'codex', tool: 'codex', model: undefined },
+    { key: 'cursor+claude', tool: 'cursor', model: 'claude' },
+    { key: 'cursor+codex', tool: 'cursor', model: 'codex' },
+    { key: 'omp+claude', tool: 'omp', model: 'claude' },
+  ];
+
+  it('returns the input unchanged when no allowlist is configured', () => {
+    expect(filterPlanningPresets(presets, {})).toEqual(presets);
+  });
+
+  it('keeps direct-tool presets and wrapper presets whose model is allowed', () => {
+    expect(filterPlanningPresets(presets, { enabledExecutionAgents: ['claude'] }).map((p) => p.key))
+      .toEqual(['claude', 'cursor+claude', 'omp+claude']);
+  });
+
+  it('drops wrapper presets whose model is not allowed', () => {
+    expect(filterPlanningPresets(presets, { enabledExecutionAgents: ['codex'] }).map((p) => p.key))
+      .toEqual(['codex', 'cursor+codex']);
+  });
+
+  it('does not treat a non-wrapper tool model as an allowlist match', () => {
+    const custom = [{ key: 'x', tool: 'someplanner', model: 'claude' }];
+    expect(filterPlanningPresets(custom, { enabledExecutionAgents: ['claude'] })).toEqual([]);
+  });
+
+  it('normalizes allowlist whitespace and case', () => {
+    expect(filterPlanningPresets(presets, { enabledExecutionAgents: [' Claude '] }).map((p) => p.key))
+      .toEqual(['claude', 'cursor+claude', 'omp+claude']);
   });
 });

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -25,6 +25,17 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
     throw new Error('defaultExecutionModel requires defaultExecutionAgent');
   }
 
+  if (config.enabledExecutionAgents !== undefined) {
+    if (!Array.isArray(config.enabledExecutionAgents)) {
+      throw new Error('enabledExecutionAgents must be an array of agent names');
+    }
+    for (const entry of config.enabledExecutionAgents) {
+      if (typeof entry !== 'string' || entry.trim().length === 0) {
+        throw new Error('enabledExecutionAgents entries must be non-empty strings');
+      }
+    }
+  }
+
   validateConfiguredModel(config.defaultExecution?.executionAgent, config.defaultExecution?.executionModel);
   validateConfiguredModel(config.defaultExecutionAgent, config.defaultExecutionModel);
   return config;

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -178,6 +178,15 @@ export interface InvokerConfig {
   /** Default execution model for prompt-backed tasks when the task does not override it. */
   defaultExecutionModel?: string;
   /**
+   * Allowlist of execution agents offered by UI surfaces (execution-harness
+   * pickers and planning presets). Entries are agent names, e.g. 'claude',
+   * 'codex', 'omp'; matching is case-insensitive and whitespace-trimmed.
+   * Unset (or empty after trimming) means every registered agent is offered.
+   * This only restricts what surfaces offer — a task explicitly pinned to a
+   * disabled agent still runs.
+   */
+  enabledExecutionAgents?: string[];
+  /**
    * Config-owned default execution harness/model for tasks that omit them.
    * This is separate from Slack planning presets and applies across surfaces.
    */
@@ -502,6 +511,52 @@ export function loadConfig(): InvokerConfig {
 export function resolveDefaultExecutionAgent(config: InvokerConfig): string {
   const configured = config.defaultExecutionAgent?.trim();
   return configured && configured.length > 0 ? configured : BUILT_IN_DEFAULT_EXECUTION_AGENT;
+}
+
+/**
+ * Resolve the configured execution-agent allowlist.
+ * Returns null when `enabledExecutionAgents` is unset or empty after trimming
+ * (null = no restriction). Entries are trimmed and lowercased.
+ */
+export function resolveEnabledExecutionAgents(config: InvokerConfig): Set<string> | null {
+  const entries = (config.enabledExecutionAgents ?? [])
+    .map((name) => (typeof name === 'string' ? name.trim().toLowerCase() : ''))
+    .filter((name) => name.length > 0);
+  return entries.length > 0 ? new Set(entries) : null;
+}
+
+/**
+ * Filter execution harnesses down to the configured allowlist.
+ * No allowlist configured -> input returned unchanged.
+ */
+export function filterExecutionHarnesses<T extends { name: string }>(harnesses: T[], config: InvokerConfig): T[] {
+  const enabled = resolveEnabledExecutionAgents(config);
+  if (!enabled) return harnesses;
+  return harnesses.filter((harness) => enabled.has(harness.name.trim().toLowerCase()));
+}
+
+/** Planning tools that wrap another agent; their `model` names the wrapped agent. */
+const WRAPPER_PLANNING_TOOLS: Record<string, true> = { cursor: true, omp: true };
+
+/**
+ * Filter planning presets down to the configured allowlist.
+ * A preset is kept when its `tool` is allowlisted, or when the tool is a
+ * wrapper ('cursor'/'omp') whose `model` names an allowlisted agent.
+ * No allowlist configured -> input returned unchanged.
+ */
+export function filterPlanningPresets<T extends { tool: string; model?: string }>(
+  presets: T[],
+  config: InvokerConfig,
+): T[] {
+  const enabled = resolveEnabledExecutionAgents(config);
+  if (!enabled) return presets;
+  return presets.filter((preset) => {
+    const tool = preset.tool.trim().toLowerCase();
+    if (enabled.has(tool)) return true;
+    if (!WRAPPER_PLANNING_TOOLS[tool]) return false;
+    const model = preset.model?.trim().toLowerCase();
+    return Boolean(model && enabled.has(model));
+  });
 }
 
 


### PR DESCRIPTION
Adds the config allowlist plus resolveEnabledExecutionAgents,
filterExecutionHarnesses, and filterPlanningPresets helpers with
validation. Nothing consumes the helpers yet; unset config keeps
today's behavior.

Depends-On: #9951