### PR TITLE
[Web surface parity](7) Offer only enabled agents in harness lists and the fix menu

### DIFF
--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -96,6 +96,20 @@ describe('buildWebInvokerDispatch', () => {
     expect(await dispatch('invoker:get-execution-harnesses', [])).toEqual(harnesses);
   });
 
+  it('get-execution-harnesses honors the enabledExecutionAgents allowlist', async () => {
+    const harnesses = [
+      { name: 'claude', supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }] },
+      { name: 'codex', supportedModels: [] },
+    ];
+    const { dispatch } = makeDispatch({
+      agentRegistry: { listExecutionHarnesses: () => harnesses },
+      loadConfig: () => ({ enabledExecutionAgents: ['claude'] } as unknown as InvokerConfig),
+    });
+    expect(await dispatch('invoker:get-execution-harnesses', [])).toEqual([
+      { name: 'claude', supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }] },
+    ]);
+  });
+
   it('get-planning-presets returns configured planning presets', async () => {
     const { dispatch } = makeDispatch({
       loadConfig: () =>

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -42,6 +42,7 @@ import {
 import type { AgentRegistry, WorkerRegistry, WorkerRuntimeDependencies } from '@invoker/execution-engine';
 import {
   DEFAULT_SLACK_HARNESS_PRESETS,
+  filterExecutionHarnesses,
   loadConfig,
   resolveAutoFixExecutionModel,
   resolveDefaultTaskExecutionSettings,
@@ -2684,7 +2685,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   });
 
   ipcMain.handle('invoker:get-execution-harnesses', () => {
-    return agentRegistry.listExecutionHarnesses();
+    return filterExecutionHarnesses(agentRegistry.listExecutionHarnesses(), loadConfig());
   });
 
   ipcMain.handle('invoker:get-planning-presets', () => {

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -22,7 +22,7 @@ import type {
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { AgentRegistry } from '@invoker/execution-engine';
 import type { ExternalGatePolicyUpdate, Orchestrator } from '@invoker/workflow-core';
-import { resolveDefaultTaskExecutionSettings, type InvokerConfig } from '../config.js';
+import { filterExecutionHarnesses, resolveDefaultTaskExecutionSettings, type InvokerConfig } from '../config.js';
 import { listInAppPlanningPresets } from '../in-app-planner.js';
 import type { ApiMutationFacade } from '../api-server.js';
 import { getEventsPage } from '../get-events-page.js';
@@ -159,7 +159,7 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       case 'invoker:get-execution-pools':
         return Object.keys(deps.loadConfig().executionPools ?? {});
       case 'invoker:get-execution-harnesses':
-        return agentRegistry.listExecutionHarnesses();
+        return filterExecutionHarnesses(agentRegistry.listExecutionHarnesses(), deps.loadConfig());
       case 'invoker:get-planning-presets':
         return listInAppPlanningPresets(deps.loadConfig());
       case 'invoker:get-execution-defaults':

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -5486,6 +5486,7 @@ export function App() {
           onDelete={handleDeleteTask}
           onClose={closeContextMenu}
           autoFocus={Boolean(contextMenu.returnFocusRegion)}
+          agents={executionHarnesses.map((harness) => harness.name)}
         />
       )}
     </div>

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -514,6 +514,10 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
     pressMenuKey('ArrowDown');
     await expectHighlightedMenuItem('Fix with Codex');
     pressMenuKey('ArrowDown');
+    // The fix menu offers every harness the owner reports (mock: claude,
+    // codex, omp), so the disabled Open Terminal entry is skipped after Omp.
+    await expectHighlightedMenuItem('Fix with Omp');
+    pressMenuKey('ArrowDown');
     await expectHighlightedMenuItem('Restart Task');
     pressMenuKey('Enter');
 

--- a/packages/ui/src/components/ContextMenu.tsx
+++ b/packages/ui/src/components/ContextMenu.tsx
@@ -29,6 +29,8 @@ interface ContextMenuProps {
   onDelete?: (taskId: string) => void;
   onClose: (options?: { restoreFocus?: boolean }) => void;
   autoFocus?: boolean;
+  /** Execution agents offered for fix actions; defaults to the builtin pair. */
+  agents?: string[];
 }
 
 function stopMenuKeyboardEvent(e: KeyboardEvent | React.KeyboardEvent) {
@@ -57,6 +59,7 @@ export function ContextMenu({
   onDelete,
   onClose,
   autoFocus = false,
+  agents,
 }: ContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
@@ -66,7 +69,9 @@ export function ContextMenu({
   const [showMore, setShowMore] = useState(false);
 
   // Generate menu items
-  const items = getMenuItems(task, { agents: ['claude', 'codex'] });
+  const items = getMenuItems(task, {
+    agents: agents && agents.length > 0 ? agents : ['claude', 'codex'],
+  });
 
   // Filter items based on available handlers
   const availableItems = items.filter((item) => {


### PR DESCRIPTION
The execution-harness reads on both surfaces apply the allowlist, and
the task context menu builds its fix actions from the harnesses the
owner reports instead of a hardcoded claude/codex pair.

Depends-On: #9953