### PR TITLE
[Web surface parity](5) Filter planning presets by the agent allowlist

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -3,6 +3,8 @@ import type * as NodeOs from 'node:os';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { resolveInvokerConfigPath } from '@invoker/contracts';
 import {
+  filterExecutionHarnesses,
+  filterPlanningPresets,
   loadConfig,
   resolveAutoFixExecutionModel,
   resolveAutoFixPoolId,
@@ -11,6 +13,7 @@ import {
   resolveDefaultTaskExecutionSettings,
   resolveConflictResolutionSettings,
   resolveEmbeddedTerminalBackendConfig,
+  resolveEnabledExecutionAgents,
 } from '../config.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
@@ -81,6 +84,23 @@ describe('loadConfig', () => {
     );
     const config = loadConfig();
     expect(config.planningHeartbeatIntervalSeconds).toBe(30);
+  });
+
+  it('reads enabledExecutionAgents from user config', () => {
+    writeUserConfig({ enabledExecutionAgents: ['claude', 'omp'] });
+    expect(loadConfig().enabledExecutionAgents).toEqual(['claude', 'omp']);
+  });
+
+  it('rejects non-array enabledExecutionAgents', () => {
+    writeUserConfig({ enabledExecutionAgents: 'claude' });
+    expect(() => loadConfig()).toThrow(/enabledExecutionAgents must be an array/);
+  });
+
+  it('rejects empty or non-string enabledExecutionAgents entries', () => {
+    writeUserConfig({ enabledExecutionAgents: ['claude', '  '] });
+    expect(() => loadConfig()).toThrow(/non-empty strings/);
+    writeUserConfig({ enabledExecutionAgents: [42] });
+    expect(() => loadConfig()).toThrow(/non-empty strings/);
   });
 
   it('reads disableAutoRunOnStartup from user config', () => {
@@ -512,5 +532,81 @@ describe('resolveEmbeddedTerminalBackendConfig', () => {
       {},
       { INVOKER_EMBEDDED_TERMINAL_BACKEND: 'external' },
     )).toThrow(/Invalid embedded terminal backend/);
+  });
+});
+
+describe('resolveEnabledExecutionAgents', () => {
+  it('returns null when the field is unset', () => {
+    expect(resolveEnabledExecutionAgents({})).toBeNull();
+  });
+
+  it('returns null when the field is empty or whitespace-only', () => {
+    expect(resolveEnabledExecutionAgents({ enabledExecutionAgents: [] })).toBeNull();
+    expect(resolveEnabledExecutionAgents({ enabledExecutionAgents: ['  ', ''] })).toBeNull();
+  });
+
+  it('trims and lowercases entries and drops empty ones', () => {
+    expect(resolveEnabledExecutionAgents({ enabledExecutionAgents: ['  Claude ', 'OMP', ''] }))
+      .toEqual(new Set(['claude', 'omp']));
+  });
+});
+
+describe('filterExecutionHarnesses', () => {
+  const harnesses = [
+    { name: 'claude', supportedModels: [] },
+    { name: 'codex', supportedModels: [] },
+    { name: 'omp', supportedModels: [] },
+  ];
+
+  it('returns the input unchanged when no allowlist is configured', () => {
+    expect(filterExecutionHarnesses(harnesses, {})).toEqual(harnesses);
+    expect(filterExecutionHarnesses(harnesses, { enabledExecutionAgents: [] })).toEqual(harnesses);
+  });
+
+  it('drops harnesses missing from the allowlist', () => {
+    expect(filterExecutionHarnesses(harnesses, { enabledExecutionAgents: ['claude'] }))
+      .toEqual([{ name: 'claude', supportedModels: [] }]);
+  });
+
+  it('matches case-insensitively with whitespace tolerated', () => {
+    expect(filterExecutionHarnesses(harnesses, { enabledExecutionAgents: [' CLAUDE ', 'Omp'] }))
+      .toEqual([
+        { name: 'claude', supportedModels: [] },
+        { name: 'omp', supportedModels: [] },
+      ]);
+  });
+});
+
+describe('filterPlanningPresets', () => {
+  const presets = [
+    { key: 'claude', tool: 'claude', model: undefined },
+    { key: 'codex', tool: 'codex', model: undefined },
+    { key: 'cursor+claude', tool: 'cursor', model: 'claude' },
+    { key: 'cursor+codex', tool: 'cursor', model: 'codex' },
+    { key: 'omp+claude', tool: 'omp', model: 'claude' },
+  ];
+
+  it('returns the input unchanged when no allowlist is configured', () => {
+    expect(filterPlanningPresets(presets, {})).toEqual(presets);
+  });
+
+  it('keeps direct-tool presets and wrapper presets whose model is allowed', () => {
+    expect(filterPlanningPresets(presets, { enabledExecutionAgents: ['claude'] }).map((p) => p.key))
+      .toEqual(['claude', 'cursor+claude', 'omp+claude']);
+  });
+
+  it('drops wrapper presets whose model is not allowed', () => {
+    expect(filterPlanningPresets(presets, { enabledExecutionAgents: ['codex'] }).map((p) => p.key))
+      .toEqual(['codex', 'cursor+codex']);
+  });
+
+  it('does not treat a non-wrapper tool model as an allowlist match', () => {
+    const custom = [{ key: 'x', tool: 'someplanner', model: 'claude' }];
+    expect(filterPlanningPresets(custom, { enabledExecutionAgents: ['claude'] })).toEqual([]);
+  });
+
+  it('normalizes allowlist whitespace and case', () => {
+    expect(filterPlanningPresets(presets, { enabledExecutionAgents: [' Claude '] }).map((p) => p.key))
+      .toEqual(['claude', 'cursor+claude', 'omp+claude']);
   });
 });

--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -259,4 +259,69 @@ describe('buildWebInvokerDispatch', () => {
     const { dispatch } = makeDispatch();
     await expect(dispatch('invoker:does-not-exist', [])).rejects.toMatchObject({ code: 'unknown_channel' });
   });
+
+  describe('planning routes', () => {
+    it('routes planning-chat channels through guiMutations when wired', async () => {
+      const guiMutations = vi.fn(async (channel: string) => ({ ok: true, channel }));
+      const { dispatch } = makeDispatch({ guiMutations });
+      const request = { title: 'demo' };
+      expect(await dispatch('invoker:planning-chat-create', [request])).toEqual({
+        ok: true,
+        channel: 'invoker:planning-chat-create',
+      });
+      expect(guiMutations).toHaveBeenCalledWith('invoker:planning-chat-create', [request]);
+      await dispatch('invoker:planning-chat-list', []);
+      await dispatch('invoker:planning-chat-set-terminal-mode', [{ sessionId: 's1', mode: 'tmux' }]);
+      expect(guiMutations).toHaveBeenCalledTimes(3);
+    });
+
+    it('keeps the historical downgrades when guiMutations is absent', async () => {
+      const { dispatch } = makeDispatch();
+      await expect(dispatch('invoker:planning-chat-create', [{}])).rejects.toMatchObject({
+        code: 'unsupported_on_web',
+      });
+      expect(await dispatch('invoker:planning-chat-set-terminal-mode', [{}])).toEqual({
+        ok: false,
+        error: 'Planning tmux is not available in the web UI',
+      });
+    });
+
+    it('routes planning-terminal channels through the adapter when wired', async () => {
+      const planningTerminals = {
+        open: vi.fn(async (planningSessionId: string) => ({
+          opened: true,
+          session: { sessionId: `pt-${planningSessionId}`, taskId: `planning:${planningSessionId}`, kind: 'planning', status: 'running' },
+        })),
+        list: vi.fn(() => [{ sessionId: 'pt-1', taskId: 'planning:chat-1', kind: 'planning', status: 'running' }]),
+        write: vi.fn((sessionId: string, data: string) => ({ ok: true as const, sessionId, bytes: data.length })),
+        resize: vi.fn(() => ({ ok: true as const })),
+        appliedSize: vi.fn(() => ({ cols: 80, rows: 24 })),
+        close: vi.fn(() => ({ ok: true as const })),
+      };
+      const { dispatch } = makeDispatch({ planningTerminals });
+      const opened = await dispatch('invoker:planning-terminal-open', ['chat-1']) as { opened: boolean };
+      expect(opened.opened).toBe(true);
+      expect(planningTerminals.open).toHaveBeenCalledWith('chat-1');
+      expect(await dispatch('invoker:planning-terminal-list', [])).toHaveLength(1);
+      await dispatch('invoker:planning-terminal-write', ['pt-1', 'ls\n']);
+      expect(planningTerminals.write).toHaveBeenCalledWith('pt-1', 'ls\n');
+      await dispatch('invoker:planning-terminal-resize', ['pt-1', 120, 40]);
+      expect(planningTerminals.resize).toHaveBeenCalledWith('pt-1', 120, 40);
+      expect(await dispatch('invoker:planning-terminal-applied-size', ['pt-1'])).toEqual({ cols: 80, rows: 24 });
+      await dispatch('invoker:planning-terminal-close', ['pt-1']);
+      expect(planningTerminals.close).toHaveBeenCalledWith('pt-1');
+    });
+
+    it('keeps planning terminals downgraded when the adapter is absent', async () => {
+      const { dispatch } = makeDispatch();
+      expect(await dispatch('invoker:planning-terminal-open', ['chat-1'])).toEqual({
+        opened: false,
+        reason: 'Planning terminals are not available in the web UI',
+      });
+      expect(await dispatch('invoker:planning-terminal-list', [])).toEqual([]);
+      expect(await dispatch('invoker:planning-terminal-applied-size', ['pt-1'])).toBeNull();
+      expect(await dispatch('invoker:planning-terminal-write', ['pt-1', 'x'])).toEqual({ ok: false, reason: 'unsupported' });
+    });
+  });
+
 });

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -25,6 +25,17 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
     throw new Error('defaultExecutionModel requires defaultExecutionAgent');
   }
 
+  if (config.enabledExecutionAgents !== undefined) {
+    if (!Array.isArray(config.enabledExecutionAgents)) {
+      throw new Error('enabledExecutionAgents must be an array of agent names');
+    }
+    for (const entry of config.enabledExecutionAgents) {
+      if (typeof entry !== 'string' || entry.trim().length === 0) {
+        throw new Error('enabledExecutionAgents entries must be non-empty strings');
+      }
+    }
+  }
+
   validateConfiguredModel(config.defaultExecution?.executionAgent, config.defaultExecution?.executionModel);
   validateConfiguredModel(config.defaultExecutionAgent, config.defaultExecutionModel);
   return config;

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -178,6 +178,15 @@ export interface InvokerConfig {
   /** Default execution model for prompt-backed tasks when the task does not override it. */
   defaultExecutionModel?: string;
   /**
+   * Allowlist of execution agents offered by UI surfaces (execution-harness
+   * pickers and planning presets). Entries are agent names, e.g. 'claude',
+   * 'codex', 'omp'; matching is case-insensitive and whitespace-trimmed.
+   * Unset (or empty after trimming) means every registered agent is offered.
+   * This only restricts what surfaces offer — a task explicitly pinned to a
+   * disabled agent still runs.
+   */
+  enabledExecutionAgents?: string[];
+  /**
    * Config-owned default execution harness/model for tasks that omit them.
    * This is separate from Slack planning presets and applies across surfaces.
    */
@@ -502,6 +511,52 @@ export function loadConfig(): InvokerConfig {
 export function resolveDefaultExecutionAgent(config: InvokerConfig): string {
   const configured = config.defaultExecutionAgent?.trim();
   return configured && configured.length > 0 ? configured : BUILT_IN_DEFAULT_EXECUTION_AGENT;
+}
+
+/**
+ * Resolve the configured execution-agent allowlist.
+ * Returns null when `enabledExecutionAgents` is unset or empty after trimming
+ * (null = no restriction). Entries are trimmed and lowercased.
+ */
+export function resolveEnabledExecutionAgents(config: InvokerConfig): Set<string> | null {
+  const entries = (config.enabledExecutionAgents ?? [])
+    .map((name) => (typeof name === 'string' ? name.trim().toLowerCase() : ''))
+    .filter((name) => name.length > 0);
+  return entries.length > 0 ? new Set(entries) : null;
+}
+
+/**
+ * Filter execution harnesses down to the configured allowlist.
+ * No allowlist configured -> input returned unchanged.
+ */
+export function filterExecutionHarnesses<T extends { name: string }>(harnesses: T[], config: InvokerConfig): T[] {
+  const enabled = resolveEnabledExecutionAgents(config);
+  if (!enabled) return harnesses;
+  return harnesses.filter((harness) => enabled.has(harness.name.trim().toLowerCase()));
+}
+
+/** Planning tools that wrap another agent; their `model` names the wrapped agent. */
+const WRAPPER_PLANNING_TOOLS: Record<string, true> = { cursor: true, omp: true };
+
+/**
+ * Filter planning presets down to the configured allowlist.
+ * A preset is kept when its `tool` is allowlisted, or when the tool is a
+ * wrapper ('cursor'/'omp') whose `model` names an allowlisted agent.
+ * No allowlist configured -> input returned unchanged.
+ */
+export function filterPlanningPresets<T extends { tool: string; model?: string }>(
+  presets: T[],
+  config: InvokerConfig,
+): T[] {
+  const enabled = resolveEnabledExecutionAgents(config);
+  if (!enabled) return presets;
+  return presets.filter((preset) => {
+    const tool = preset.tool.trim().toLowerCase();
+    if (enabled.has(tool)) return true;
+    if (!WRAPPER_PLANNING_TOOLS[tool]) return false;
+    const model = preset.model?.trim().toLowerCase();
+    return Boolean(model && enabled.has(model));
+  });
 }
 
 

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -53,7 +53,7 @@ import {
   type PlanningMessage,
 } from '@invoker/planning-core';
 import type { HarnessPreset, PlanConversation, PlanConversationConfig, PlanningCommandBuilder } from '@invoker/surfaces';
-import type { InvokerConfig } from './config.js';
+import { filterPlanningPresets, type InvokerConfig } from './config.js';
 import {
   ensurePlanningWorktreeReady,
   planningMcpConfigPath,
@@ -733,11 +733,17 @@ async function createSession(
   return session;
 }
 
+/**
+ * List the planning presets offered to pickers.
+ * The `enabledExecutionAgents` allowlist is applied HERE (not at the IPC/web
+ * dispatch surfaces) so every caller — the Electron IPC handler and the web
+ * dispatch — gets the same filtered view without double-filtering.
+ */
 export async function listInAppPlanningPresets(config: InvokerConfig): Promise<PlanningPresetOption[]> {
   const presets = await resolveHarnessPresets(config);
   const defaultPresetKey = await resolveDefaultPresetKey(config);
   const defaultConfirmationMode = resolveDefaultPlanningConfirmationMode(config);
-  return Object.entries(presets).map(([key, preset]) => ({
+  const options = Object.entries(presets).map(([key, preset]) => ({
     key,
     label: labelForPresetKey(key),
     tool: preset.tool,
@@ -745,6 +751,7 @@ export async function listInAppPlanningPresets(config: InvokerConfig): Promise<P
     isDefault: key === defaultPresetKey,
     defaultConfirmationMode,
   }));
+  return filterPlanningPresets(options, config);
 }
 
 export function createPlanningCommandBuilderFromRegistry(

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -68,6 +68,8 @@ import type {
   InAppPlanningListSessionsResponse,
   InAppPlanningRebindRepoRequest,
   InAppPlanningResetRequest,
+  InAppPlanningSetTerminalModeRequest,
+  InAppPlanningStreamEvent,
   InAppPlanningSubmitRequest,
   Logger,
   StartReadyRequest,
@@ -159,6 +161,7 @@ import {
   tryDelegateExec,
   tryDelegateQuery,
   createHeadlessExecutor,
+  createTrackedHeadlessExecutor,
   wireHeadlessApproveHook,
   type HeadlessDeps,
 } from './headless.js';
@@ -254,6 +257,7 @@ import {
 } from './renderer-ui-perf.js';
 import {
   bindPlanningTerminalSessionState,
+  createPlanningTerminalAdapter,
   registerPlanningTerminalSessionIpcHandlers,
   registerTerminalSessionIpcHandlers,
   registerTerminalSessionPersistence,
@@ -284,6 +288,7 @@ import {
   resetPlanningChat,
   restorePlanningChatSessions,
   sendPlanningChatMessage,
+  setPlanningChatTerminalMode,
   submitPlanningChatDraft,
 } from './in-app-planner.js';
 import { discoverOwner, isStandaloneCapable } from './owner-endpoint.js';
@@ -1246,11 +1251,16 @@ function startHeadlessMode(): void {
         getWorkerRuntimeController: () => workerRuntimeController,
       } as HeadlessDeps;
 
-      const createStandaloneTaskExecutor = (): TaskRunner => {
-        const executor = createHeadlessExecutor(headlessDeps);
-        wireHeadlessApproveHook(headlessDeps, executor);
-        return executor;
-      };
+      // Every standalone execution path (launch dispatcher, fix/retry handlers,
+            // REST mutations) builds its executor through this factory, so one shared
+            // handle map covers all owner-serve task processes. The web surface needs
+            // those live handles to open task terminals in the browser.
+            const standaloneTaskHandles: TaskHandleMap = new Map();
+            const createStandaloneTaskExecutor = (): TaskRunner => {
+              const executor = createTrackedHeadlessExecutor(headlessDeps, standaloneTaskHandles);
+              wireHeadlessApproveHook(headlessDeps, executor);
+              return executor;
+            };
 
       const executeStandaloneHeadlessRun = async (payload: HeadlessRunMutationPayload): Promise<unknown> => {
         const { applyConfiguredPlanDefaults, parsePlanFile } = await import('./plan-parser.js');
@@ -1289,6 +1299,14 @@ function startHeadlessMode(): void {
         })
       );
 
+      // Web clients get planning-chat token streaming over SSE. The bridge does
+      // not exist yet when these handlers are built, so route through a
+      // mutable ref that owner-serve fills in after the web surface starts.
+      let broadcastPlanningChatStream: ((event: InAppPlanningStreamEvent) => void) | undefined;
+      const emitPlanningChatStreamToWeb = (event: InAppPlanningStreamEvent): void => {
+        broadcastPlanningChatStream?.(event);
+      };
+
       const planningConversationRepo = new ConversationRepository(persistence, {
         info: (message) => logger.info(message, { module: 'planning-chat' }),
         warn: (message) => logger.warn(message, { module: 'planning-chat' }),
@@ -1305,6 +1323,7 @@ function startHeadlessMode(): void {
         conversationRepo: planningConversationRepo,
         planningSessionStore: readOnlyMode ? undefined : persistence,
         logger,
+        onRawPlannerOutput: emitPlanningChatStreamToWeb,
         repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
       });
 
@@ -1365,6 +1384,7 @@ function startHeadlessMode(): void {
               conversationRepo: planningConversationRepo,
               planningSessionStore: readOnlyMode ? undefined : persistence,
               logger,
+              onRawPlannerOutput: emitPlanningChatStreamToWeb,
               repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
             });
           }
@@ -1399,6 +1419,7 @@ function startHeadlessMode(): void {
               planningSessionStore: readOnlyMode ? undefined : persistence,
               logger,
               plannerReplyOverride,
+              onRawPlannerOutput: emitPlanningChatStreamToWeb,
               repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
             });
           }
@@ -1417,6 +1438,12 @@ function startHeadlessMode(): void {
           }
           case 'invoker:planning-chat-reset': {
             return resetPlanningChat(payload.args[0] as InAppPlanningResetRequest, {
+              sessions: planningChatSessions,
+              planningSessionStore: readOnlyMode ? undefined : persistence,
+            });
+          }
+          case 'invoker:planning-chat-set-terminal-mode': {
+            return setPlanningChatTerminalMode(payload.args[0] as InAppPlanningSetTerminalModeRequest, {
               sessions: planningChatSessions,
               planningSessionStore: readOnlyMode ? undefined : persistence,
             });
@@ -2092,10 +2119,17 @@ function startHeadlessMode(): void {
               executionAgentRegistry: agentRegistry,
               invokerConfig,
               repoRoot,
+              executorRegistry,
+              taskHandles: standaloneTaskHandles,
               appRootDir: __dirname,
+              guiMutations: (channel, args) => executeStandaloneGuiMutation({ channel, args } as GuiMutationPayload),
+              planningChatSessions,
             },
             apiServerDeps,
           );
+          broadcastPlanningChatStream = (event) => {
+            headlessWebBridge?.broadcast('invoker:planning-chat-stream', event);
+          };
           startOwnerSocketSentinelForBus(messageBus);
         }
 
@@ -2291,6 +2325,16 @@ startMainProcessBootstrap({
       };
     },
   };
+  // Planning terminals for the desktop-owned web surface. Shares the same
+  // EmbeddedTerminalManager and session map as the Electron IPC handlers, so
+  // browser and desktop views stay consistent.
+  const webPlanningTerminals = createPlanningTerminalAdapter({
+    embeddedTerminalManager,
+    logger,
+    planningChatSessions,
+    getPlanningSessionStore: () => (ownerMode ? persistence : undefined),
+    repoRoot,
+  });
   const startupMarks = new Map<string, number>();
   const startupPhaseDetails: Array<Record<string, unknown>> = [];
   const recordStartupMark = (phase: string, extra?: Record<string, unknown>): void => {
@@ -2728,6 +2772,14 @@ startMainProcessBootstrap({
             autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
           }),
           taskTerminals,
+          guiMutations: async (channel, args) => {
+            const handler = guiMutationHandlers.get(channel);
+            if (!handler) {
+              throw new Error(`No GUI mutation handler registered for ${channel}`);
+            }
+            return handler(...args);
+          },
+          planningTerminals: webPlanningTerminals,
           getSystemDiagnostics: () => collectSystemDiagnostics({
             appVersion: app.getVersion(),
             isPackaged: app.isPackaged,
@@ -3325,6 +3377,7 @@ startMainProcessBootstrap({
         if (mainWindow && !mainWindow.isDestroyed() && uiInteractive) {
           mainWindow.webContents.send('invoker:planning-chat-stream', event);
         }
+        webBridge?.broadcast('invoker:planning-chat-stream', event);
       },
       taskGraphEventPublisher,
       loadTaskByIdFromPersistence,

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -477,8 +477,7 @@ export function bindPlanningTerminalSessionState(deps: {
   return { restorePersistedPlanningTerminals };
 }
 
-export function registerPlanningTerminalSessionIpcHandlers(deps: {
-  ipcMain: IpcMain;
+export interface PlanningTerminalAdapterDeps {
   embeddedTerminalManager: EmbeddedTerminalManager;
   logger: PlanningTerminalLogger;
   planningChatSessions: InAppPlanningChatSessions;
@@ -486,9 +485,25 @@ export function registerPlanningTerminalSessionIpcHandlers(deps: {
   repoRoot: string;
   resolveRemotePlanningSession?: (planningSessionId: string) => Promise<InAppPlanningSessionSummary | undefined>;
   isPlanningTerminalWriteAllowed?: () => boolean;
-}): void {
+}
+
+/**
+ * Transport-neutral planning-terminal operations shared by the Electron IPC
+ * handlers and the web-surface dispatch. All state lives in the
+ * EmbeddedTerminalManager and the planning chat session map, so multiple
+ * adapter instances over the same stores stay consistent.
+ */
+export interface PlanningTerminalAdapter {
+  open(planningSessionId: string): Promise<{ opened: boolean; reason?: string; session?: TerminalSessionDescriptor }>;
+  list(): TerminalSessionDescriptor[];
+  write(sessionId: string, data: string): { ok: boolean; reason?: string };
+  resize(sessionId: string, cols: number, rows: number): { ok: boolean; reason?: string };
+  appliedSize(sessionId: string): { cols: number; rows: number } | null;
+  close(sessionId: string): { ok: boolean; reason?: string };
+}
+
+export function createPlanningTerminalAdapter(deps: PlanningTerminalAdapterDeps): PlanningTerminalAdapter {
   const {
-    ipcMain,
     embeddedTerminalManager,
     logger,
     planningChatSessions,
@@ -498,89 +513,122 @@ export function registerPlanningTerminalSessionIpcHandlers(deps: {
     isPlanningTerminalWriteAllowed = () => Boolean(getPlanningSessionStore()),
   } = deps;
 
-  ipcMain.handle('invoker:planning-terminal-open', async (_event, planningSessionIdArg: string) => {
-    const planningSessionId = String(planningSessionIdArg ?? '').trim();
-    if (!planningSessionId) {
-      return { opened: false, reason: 'Planning session id is required.' };
-    }
-    let planningSession = planningChatSessions.get(planningSessionId);
-    if (!planningSession && resolveRemotePlanningSession) {
-      const remoteSummary = await resolveRemotePlanningSession(planningSessionId);
-      if (remoteSummary) {
-        planningSession = hydrateRemotePlanningTerminalSession(remoteSummary);
-        planningChatSessions.set(planningSessionId, planningSession);
+  return {
+    async open(planningSessionIdArg: string) {
+      const planningSessionId = String(planningSessionIdArg ?? '').trim();
+      if (!planningSessionId) {
+        return { opened: false, reason: 'Planning session id is required.' };
       }
-    }
-    if (!planningSession) {
-      return { opened: false, reason: 'Planning conversation was not found.' };
-    }
-    if (planningSession.status === 'submitted') {
-      return { opened: false, reason: 'This planning session was already submitted.' };
-    }
-    logger.info(`invoked for planningSession="${planningSessionId}"`, { module: 'planning-terminal' });
-    try {
-      const outputSnapshot = ensurePlanningTerminalSummaryBridge(
-        planningSession,
-        planningSession.terminalOutputSnapshot ?? '',
-        MAX_OUTPUT_SNAPSHOT_CHARS,
+      let planningSession = planningChatSessions.get(planningSessionId);
+      if (!planningSession && resolveRemotePlanningSession) {
+        const remoteSummary = await resolveRemotePlanningSession(planningSessionId);
+        if (remoteSummary) {
+          planningSession = hydrateRemotePlanningTerminalSession(remoteSummary);
+          planningChatSessions.set(planningSessionId, planningSession);
+        }
+      }
+      if (!planningSession) {
+        return { opened: false, reason: 'Planning conversation was not found.' };
+      }
+      if (planningSession.status === 'submitted') {
+        return { opened: false, reason: 'This planning session was already submitted.' };
+      }
+      logger.info(`invoked for planningSession="${planningSessionId}"`, { module: 'planning-terminal' });
+      try {
+        const outputSnapshot = ensurePlanningTerminalSummaryBridge(
+          planningSession,
+          planningSession.terminalOutputSnapshot ?? '',
+          MAX_OUTPUT_SNAPSHOT_CHARS,
+        );
+        const session = embeddedTerminalManager.openOrReuse({
+          kind: 'planning',
+          taskId: `planning:${planningSessionId}`,
+          planningSessionId,
+          spec: { cwd: repoRoot },
+          cwd: repoRoot,
+          outputSnapshot,
+        });
+        updatePlanningChatTerminalState(planningSessionId, {
+          terminalMode: 'tmux',
+          terminalSessionId: session.sessionId,
+          terminalStatus: session.status,
+          terminalExitCode: session.exitCode,
+          terminalOutputSnapshot: session.outputSnapshot ?? '',
+          touchSessionUpdatedAt: true,
+        }, {
+          sessions: planningChatSessions,
+          planningSessionStore: getPlanningSessionStore(),
+        });
+        return { opened: true, session };
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        logger.warn(`planning terminal spawn failed for session="${planningSessionId}": ${reason}`, { module: 'planning-terminal' });
+        return { opened: false, reason: `Failed to start planning terminal session: ${reason}` };
+      }
+    },
+
+    list() {
+      return embeddedTerminalManager.list().filter((session) => session.kind === 'planning');
+    },
+
+    write(sessionId: string, data: string) {
+      const allowed = planningTerminalWritable(
+        embeddedTerminalManager,
+        planningChatSessions,
+        isPlanningTerminalWriteAllowed,
+        sessionId,
       );
-      const session = embeddedTerminalManager.openOrReuse({
-        kind: 'planning',
-        taskId: `planning:${planningSessionId}`,
-        planningSessionId,
-        spec: { cwd: repoRoot },
-        cwd: repoRoot,
-        outputSnapshot,
-      });
-      updatePlanningChatTerminalState(planningSessionId, {
-        terminalMode: 'tmux',
-        terminalSessionId: session.sessionId,
-        terminalStatus: session.status,
-        terminalExitCode: session.exitCode,
-        terminalOutputSnapshot: session.outputSnapshot ?? '',
-        touchSessionUpdatedAt: true,
-      }, {
-        sessions: planningChatSessions,
-        planningSessionStore: getPlanningSessionStore(),
-      });
-      return { opened: true, session };
-    } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err);
-      logger.warn(`planning terminal spawn failed for session="${planningSessionId}": ${reason}`, { module: 'planning-terminal' });
-      return { opened: false, reason: `Failed to start planning terminal session: ${reason}` };
-    }
+      if (!allowed.ok) return allowed;
+      return embeddedTerminalManager.write(sessionId, data);
+    },
+
+    resize(sessionId: string, cols: number, rows: number) {
+      const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
+      if (!allowed.ok) return allowed;
+      return embeddedTerminalManager.resize(sessionId, cols, rows);
+    },
+
+    appliedSize(sessionId: string) {
+      const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
+      if (!allowed.ok) return null;
+      return embeddedTerminalManager.getAppliedSize(sessionId);
+    },
+
+    close(sessionId: string) {
+      const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
+      if (!allowed.ok) return allowed;
+      return embeddedTerminalManager.close(sessionId);
+    },
+  };
+}
+
+export function registerPlanningTerminalSessionIpcHandlers(deps: PlanningTerminalAdapterDeps & {
+  ipcMain: IpcMain;
+}): void {
+  const { ipcMain, ...adapterDeps } = deps;
+  const adapter = createPlanningTerminalAdapter(adapterDeps);
+
+  ipcMain.handle('invoker:planning-terminal-open', async (_event, planningSessionIdArg: string) => {
+    return adapter.open(planningSessionIdArg);
   });
 
   ipcMain.handle('invoker:planning-terminal-list', async () => {
-    return embeddedTerminalManager.list().filter((session) => session.kind === 'planning');
+    return adapter.list();
   });
 
   ipcMain.handle('invoker:planning-terminal-write', async (_event, sessionId: string, data: string) => {
-    const allowed = planningTerminalWritable(
-      embeddedTerminalManager,
-      planningChatSessions,
-      isPlanningTerminalWriteAllowed,
-      sessionId,
-    );
-    if (!allowed.ok) return allowed;
-    return embeddedTerminalManager.write(sessionId, data);
+    return adapter.write(sessionId, data);
   });
 
   ipcMain.handle('invoker:planning-terminal-resize', async (_event, sessionId: string, cols: number, rows: number) => {
-    const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
-    if (!allowed.ok) return allowed;
-    return embeddedTerminalManager.resize(sessionId, cols, rows);
+    return adapter.resize(sessionId, cols, rows);
   });
 
   ipcMain.handle('invoker:planning-terminal-applied-size', async (_event, sessionId: string) => {
-    const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
-    if (!allowed.ok) return null;
-    return embeddedTerminalManager.getAppliedSize(sessionId);
+    return adapter.appliedSize(sessionId);
   });
 
   ipcMain.handle('invoker:planning-terminal-close', async (_event, sessionId: string) => {
-    const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
-    if (!allowed.ok) return allowed;
-    return embeddedTerminalManager.close(sessionId);
+    return adapter.close(sessionId);
   });
 }

--- a/packages/app/src/web/start-web-surface.ts
+++ b/packages/app/src/web/start-web-surface.ts
@@ -46,9 +46,12 @@ import {
   createTerminalUiPerfSink,
 } from '../terminal-ui-perf.js';
 import {
+  createPlanningTerminalAdapter,
   registerTerminalSessionPersistence,
+  type PlanningTerminalAdapter,
   type TerminalSessionPersistenceHandle,
 } from '../terminal-session-ipc.js';
+import type { InAppPlanningChatSessions } from '../in-app-planner.js';
 import { WorkflowRollupProjection } from '../workflow-rollup-projection.js';
 import { autoStartedOwnerWorkerKindsForConfig, createLocalWorkerStatusSnapshot } from '../worker-control.js';
 import { buildWebInvokerDispatch } from './web-invoker-dispatch.js';
@@ -95,6 +98,10 @@ export interface StartHeadlessWebSurfaceDeps {
   /** Main process dist directory (`__dirname` of main.js) used to locate the built UI. */
   appRootDir: string;
   getBundledSkillsStatus?: () => BundledSkillsStatus;
+  /** Routes planning-chat channels to the owner's shared GUI-mutation handlers. */
+  guiMutations?: (channel: string, args: unknown[]) => Promise<unknown>;
+  /** Enables planning terminals over the web when present (with repoRoot + executorRegistry + taskHandles). */
+  planningChatSessions?: InAppPlanningChatSessions;
 }
 
 export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebBridge | null {
@@ -113,6 +120,7 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
 
   let terminalSessionPersistenceHandle: TerminalSessionPersistenceHandle | null = null;
   let taskTerminals: TaskTerminalAdapter | undefined;
+  let planningTerminals: PlanningTerminalAdapter | undefined;
   let terminalEvents: WebBridgeTerminalEvents | undefined;
   if (deps.repoRoot && deps.executorRegistry && deps.taskHandles) {
     const embeddedTerminalManager = new EmbeddedTerminalManager({
@@ -159,6 +167,16 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
         };
       },
     };
+    if (deps.planningChatSessions) {
+      const planningChatSessions = deps.planningChatSessions;
+      planningTerminals = createPlanningTerminalAdapter({
+        embeddedTerminalManager,
+        logger: deps.logger,
+        planningChatSessions,
+        getPlanningSessionStore: () => deps.persistence,
+        repoRoot: deps.repoRoot,
+      });
+    }
   }
   const streamSeq = createTaskDeltaStreamSequence();
   const projection = new WorkflowRollupProjection();
@@ -210,6 +228,8 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
       autoStartKinds: autoStartedOwnerWorkerKindsForConfig(deps.config),
     }),
     taskTerminals,
+    guiMutations: deps.guiMutations,
+    planningTerminals,
     logger: deps.logger,
   });
 
@@ -253,6 +273,8 @@ export interface HeadlessWebSurfaceHost {
   taskHandles?: TaskHandleMap;
   appRootDir?: string;
   getBundledSkillsStatus?: () => BundledSkillsStatus;
+  guiMutations?: (channel: string, args: unknown[]) => Promise<unknown>;
+  planningChatSessions?: InAppPlanningChatSessions;
 }
 
 /**
@@ -284,5 +306,7 @@ export function startWebSurfaceForHeadless(
     taskHandles: host.taskHandles,
     appRootDir: host.appRootDir ?? __dirname,
     getBundledSkillsStatus: host.getBundledSkillsStatus,
+    guiMutations: host.guiMutations,
+    planningChatSessions: host.planningChatSessions,
   });
 }

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -33,6 +33,22 @@ import { resolveAgentSession } from '../headless-query-list.js';
 import { buildTaskGraphSnapshot } from './task-graph-snapshot.js';
 import type { TaskTerminalAdapter } from '../task-terminal-adapter.js';
 
+
+/**
+ * Consumer-side port for planning terminals. The owner hosts pass the adapter
+ * built by `createPlanningTerminalAdapter` (terminal-session-ipc.ts), which
+ * satisfies this shape structurally; declaring the port here keeps the web
+ * dispatch free of a hard dependency on the Electron IPC module's exports.
+ */
+export interface WebPlanningTerminals {
+  open(planningSessionId: string): Promise<{ opened: boolean; reason?: string; session?: unknown }>;
+  list(): unknown[] | Promise<unknown[]>;
+  write(sessionId: string, data: string): { ok: boolean; reason?: string } | Promise<{ ok: boolean; reason?: string }>;
+  resize(sessionId: string, cols: number, rows: number): { ok: boolean; reason?: string } | Promise<{ ok: boolean; reason?: string }>;
+  appliedSize(sessionId: string): { cols: number; rows: number } | null | Promise<{ cols: number; rows: number } | null>;
+  close(sessionId: string): { ok: boolean; reason?: string } | Promise<{ ok: boolean; reason?: string }>;
+}
+
 export interface WebInvokerDispatchDeps {
   orchestrator: Orchestrator;
   persistence: SQLiteAdapter;
@@ -51,6 +67,13 @@ export interface WebInvokerDispatchDeps {
   checkPrStatuses?: () => void | Promise<void>;
   getWorkers?: () => WorkerStatusSnapshot;
   taskTerminals?: TaskTerminalAdapter;
+  /**
+   * Routes planning-chat channels (and plan-from-goal) to the owner's shared
+   * GUI-mutation handlers. Wired by both the desktop-owned and headless web
+   * surfaces; absent means the historical web downgrades stay in effect.
+   */
+  guiMutations?: (channel: string, args: unknown[]) => Promise<unknown>;
+  planningTerminals?: WebPlanningTerminals;
   logger?: Logger;
 }
 
@@ -279,15 +302,41 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
           return { ok: false, reason: 'unsupported' };
         }
         return deps.taskTerminals.close(String(args[0]));
+      // ── Planning chat + planning terminals ──
+      // Routed to the owner's shared GUI-mutation handlers / terminal adapter
+      // when the host wires them; otherwise keep the historical downgrades.
+      case 'invoker:plan-from-goal':
+      case 'invoker:planning-chat-create':
+      case 'invoker:planning-chat-list':
+      case 'invoker:planning-chat-send':
+      case 'invoker:planning-chat-submit':
+      case 'invoker:planning-chat-discard-draft':
+      case 'invoker:planning-chat-reset':
+      case 'invoker:planning-chat-delete':
+      case 'invoker:planning-chat-delete-submitted':
+      case 'invoker:planning-chat-rebind-repo':
+        if (deps.guiMutations) return deps.guiMutations(channel, args);
+        return unsupported(channel);
+      case 'invoker:planning-chat-set-terminal-mode':
+        if (deps.guiMutations) return deps.guiMutations(channel, args);
+        return { ok: false, error: 'Planning tmux is not available in the web UI' };
       case 'invoker:planning-terminal-open':
+        if (deps.planningTerminals) return deps.planningTerminals.open(String(args[0]));
         return { opened: false, reason: 'Planning terminals are not available in the web UI' };
       case 'invoker:planning-terminal-list':
-        return [];
-      case 'invoker:planning-chat-set-terminal-mode':
-        return { ok: false, error: 'Planning tmux is not available in the web UI' };
+        return deps.planningTerminals?.list() ?? [];
+      case 'invoker:planning-terminal-applied-size':
+        return deps.planningTerminals?.appliedSize(String(args[0])) ?? null;
       case 'invoker:planning-terminal-write':
+        if (deps.planningTerminals) return deps.planningTerminals.write(String(args[0]), String(args[1]));
+        return { ok: false, reason: 'unsupported' };
       case 'invoker:planning-terminal-resize':
+        if (deps.planningTerminals) {
+          return deps.planningTerminals.resize(String(args[0]), Number(args[1]), Number(args[2]));
+        }
+        return { ok: false, reason: 'unsupported' };
       case 'invoker:planning-terminal-close':
+        if (deps.planningTerminals) return deps.planningTerminals.close(String(args[0]));
         return { ok: false, reason: 'unsupported' };
 
       // ── Mutations not exposed on the facade / global lifecycle ──


### PR DESCRIPTION
## Summary

`listInAppPlanningPresets` returned every builtin harness preset regardless of deployment config.

It now applies `filterPlanningPresets`, so a deployment that sets `enabledExecutionAgents` only offers presets whose tool or wrapped model is enabled. Both callers — the desktop IPC read and the web dispatch — route through this one function, so the filter lives here and nothing double-filters.

## Review Claim

With `enabledExecutionAgents` unset the presets are unchanged; with an allowlist, presets whose tool (or wrapped model, for cursor/omp wrappers) is disabled disappear from every surface that routes through `listInAppPlanningPresets`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Single-callee change guarded by the earlier slice's helper whose null path returns input unchanged; unset config is byte-equivalent.

## Slice Rationale

The preset surface is one shared function that both surfaces route through; changing it is a separate claim from the harness reads and the fix menu (next slice).

## Non-goals

- No harness-read or context-menu changes.
- No preset availability probing (whether an agent binary is installed stays out of scope).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm test -- src/__tests__/config.test.ts` (59 passed; wrapper/normalization cases)
- [x] `cd packages/app && pnpm test -- -t 'listInAppPlanningPresets' src/__tests__/in-app-planner.test.ts` (1 passed, 69 skipped)
- [x] `npx tsc -p tsconfig.typecheck.json --noEmit` (exit 0)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #9958