### PR TITLE
[Web surface parity](8) Bind planning repos before the conversation starts

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -2214,6 +2214,149 @@ describe('rebindPlanningChatRepo', () => {
     expect(stored?.conversation).toBe(originalConversation);
   });
 
+  it('rejects rebinding once the conversation has a message', async () => {
+    const repoPool = createFakeRebindRepoPool('/fake/worktree/should-not-be-used', 'new-head-sha');
+    const sessions = createInAppPlanningChatSessions();
+    const session = planningSession({
+      id: 'message-rebind-session',
+      title: 'Message rebind',
+      repoUrl: 'https://example.com/repo.git',
+      baseBranch: 'main',
+      baseCommit: 'sha-a',
+      worktreePath: '/fake/worktree/existing-message',
+      worktreeBranch: 'invoker/planning/message-rebind-session',
+      messages: [
+        { id: 1, role: 'user', text: 'What does this repo do?', createdAt: '2026-07-07T00:00:01.000Z' },
+      ],
+    });
+    const originalConversation = session.conversation;
+    sessions.set(session.id, session);
+
+    const result = await rebindPlanningChatRepo({
+      sessionId: session.id,
+      repoUrl: 'https://example.com/other-repo.git',
+      baseBranch: 'main',
+    }, {
+      config: {},
+      sessions,
+      repoPool,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Set the repo before the conversation or terminal starts.',
+    });
+    expect(repoPool.ensureCloneThroughRepoQueue).not.toHaveBeenCalled();
+    expect(repoPool.acquireWorktree).not.toHaveBeenCalled();
+    expect(repoPool.release).not.toHaveBeenCalled();
+
+    const stored = sessions.get(session.id);
+    expect(stored?.repoUrl).toBe('https://example.com/repo.git');
+    expect(stored?.baseCommit).toBe('sha-a');
+    expect(stored?.worktreePath).toBe('/fake/worktree/existing-message');
+    expect(stored?.conversation).toBe(originalConversation);
+  });
+
+  it('rejects rebinding once a terminal session exists', async () => {
+    const repoPool = createFakeRebindRepoPool('/fake/worktree/should-not-be-used', 'new-head-sha');
+    const sessions = createInAppPlanningChatSessions();
+    const session = planningSession({
+      id: 'terminal-rebind-session',
+      title: 'Terminal rebind',
+      repoUrl: 'https://example.com/repo.git',
+      baseBranch: 'main',
+      baseCommit: 'sha-a',
+      worktreePath: '/fake/worktree/existing-terminal',
+      worktreeBranch: 'invoker/planning/terminal-rebind-session',
+      terminalMode: 'tmux',
+      terminalSessionId: 'term-planning-rebind',
+    });
+    const originalConversation = session.conversation;
+    sessions.set(session.id, session);
+
+    const result = await rebindPlanningChatRepo({
+      sessionId: session.id,
+      repoUrl: 'https://example.com/other-repo.git',
+      baseBranch: 'main',
+    }, {
+      config: {},
+      sessions,
+      repoPool,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Set the repo before the conversation or terminal starts.',
+    });
+    expect(repoPool.ensureCloneThroughRepoQueue).not.toHaveBeenCalled();
+    expect(repoPool.acquireWorktree).not.toHaveBeenCalled();
+
+    const stored = sessions.get(session.id);
+    expect(stored?.repoUrl).toBe('https://example.com/repo.git');
+    expect(stored?.baseCommit).toBe('sha-a');
+    expect(stored?.worktreePath).toBe('/fake/worktree/existing-terminal');
+    expect(stored?.conversation).toBe(originalConversation);
+  });
+
+  it('rebinds an untouched session with a prior binding to a different repo', async () => {
+    const worktreePath = '/fake/worktree/retarget-session';
+    const repoPool = createFakeRebindRepoPool(worktreePath, 'new-head-sha');
+    const sessions = createInAppPlanningChatSessions();
+    const session = planningSession({
+      id: 'retarget-session',
+      title: 'Retarget test',
+      repoUrl: 'https://example.com/repo.git',
+      baseBranch: 'main',
+      baseCommit: 'sha-a',
+      worktreePath: '/fake/worktree/existing-retarget',
+      worktreeBranch: 'invoker/planning/retarget-session',
+    });
+    sessions.set(session.id, session);
+
+    const result = await rebindPlanningChatRepo({
+      sessionId: session.id,
+      repoUrl: 'https://example.com/other-repo.git',
+      baseBranch: 'main',
+    }, {
+      config: {},
+      sessions,
+      repoPool,
+    });
+
+    expect(result).toEqual({ ok: true, action: 'provision' });
+    const stored = sessions.get(session.id);
+    expect(stored?.repoUrl).toBe('https://example.com/other-repo.git');
+    expect(stored?.baseCommit).toBe('new-head-sha');
+    expect(stored?.worktreePath).toBe(worktreePath);
+  });
+
+  it('threads the planning command builder into the rebuilt conversation', async () => {
+    const worktreePath = '/fake/worktree/builder-session';
+    const repoPool = createFakeRebindRepoPool(worktreePath, 'new-head-sha');
+    const sessions = createInAppPlanningChatSessions();
+    const planningCommandBuilder = vi.fn(() => ({ command: 'planner', args: ['prompt'] }));
+    const session = planningSession({ id: 'builder-session', title: 'Builder test' });
+    sessions.set(session.id, session);
+
+    const result = await rebindPlanningChatRepo({
+      sessionId: session.id,
+      repoUrl: 'https://example.com/new-repo.git',
+      baseBranch: 'main',
+    }, {
+      config: {},
+      sessions,
+      repoPool,
+      planningCommandBuilder,
+    });
+
+    expect(result).toEqual({ ok: true, action: 'provision' });
+    const stored = sessions.get(session.id);
+    // Without the builder the conversation falls back to spawning the literal
+    // `agent` CLI, which does not exist on headless hosts.
+    const conversation = stored?.conversation as unknown as { planningCommandBuilder?: unknown };
+    expect(conversation.planningCommandBuilder).toBe(planningCommandBuilder);
+  });
+
   it('returns an error when no repo URL can be resolved', async () => {
     const repoPool = createFakeRebindRepoPool('/fake/worktree/should-not-be-used', 'sha-a');
     const sessions = createInAppPlanningChatSessions();

--- a/packages/app/src/__tests__/planning-chat-e2e-acceptance.test.ts
+++ b/packages/app/src/__tests__/planning-chat-e2e-acceptance.test.ts
@@ -52,7 +52,7 @@ tasks:
     command: echo coincidental
 \`\`\``;
 
-const PLAN_C_REPLY = `Here is the revised plan against the new repo.
+const PLAN_C_REPLY = `Here is the revised plan.
 
 \`\`\`yaml
 name: Plan C
@@ -97,7 +97,7 @@ function sidecarPathFor(sessionId: string): string {
   return join(resolveInvokerHomeRoot(), 'plan-drafts', `${sessionId}.yaml`);
 }
 
-describe('planning chat E2E acceptance: explore -> draft -> critique -> repo switch -> re-draft -> submit', () => {
+describe('planning chat E2E acceptance: explore -> draft -> critique -> locked repo binding -> re-draft -> submit', () => {
   let sessionId: string | undefined;
 
   afterEach(() => {
@@ -105,7 +105,7 @@ describe('planning chat E2E acceptance: explore -> draft -> critique -> repo swi
     vi.restoreAllMocks();
   });
 
-  it('proves worktree binding, durable draft persistence, post-draft immutability, repo-switch invalidation, and DB-identical submit all hold together across one continuous session', async () => {
+  it('proves worktree binding, durable draft persistence, post-draft immutability, mid-conversation rebind refusal, and DB-identical submit all hold together across one continuous session', async () => {
     const worktreeRoot = mkdtempSync(join(tmpdir(), 'planning-chat-e2e-'));
     const repoPool = createFakeRepoPool({
       [REPO_A]: { worktreePath: join(worktreeRoot, 'repo-a'), headSha: 'sha-repo-a' },
@@ -192,7 +192,8 @@ describe('planning chat E2E acceptance: explore -> draft -> critique -> repo swi
       expect(sessions.get(sessionId)?.status).toBe('draft_ready');
       expect(adapter.loadInAppPlanningSession(sessionId)?.draftPlanText).toBe(planAText);
 
-      const rebindResult = await rebindPlanningChatRepo({
+      const messageCountBeforeRebind = sessions.get(sessionId)?.messages.length;
+      const rebindRefusal = await rebindPlanningChatRepo({
         sessionId,
         repoUrl: REPO_B,
         baseBranch: 'main',
@@ -202,30 +203,27 @@ describe('planning chat E2E acceptance: explore -> draft -> critique -> repo swi
         repoPool,
         planningSessionStore: adapter,
       });
-      expect(rebindResult).toEqual({ ok: true, action: 'invalidate_and_block_submit' });
-      expect(sessions.get(sessionId)?.draftPlanText).toBeUndefined();
-      expect(sessions.get(sessionId)?.status).toBe('still_discussing');
-      expect(sessions.get(sessionId)?.repoUrl).toBe(REPO_B);
-      expect(sessions.get(sessionId)?.baseCommit).toBe('sha-repo-b');
-      expect(adapter.loadInAppPlanningSession(sessionId)?.draftPlanText).toBeUndefined();
-      expect(existsSync(sidecarPathFor(sessionId))).toBe(false);
-      const invalidateMessage = sessions.get(sessionId)?.messages.at(-1);
-      expect(invalidateMessage?.tone).toBe('error');
-
-      const submitBeforeRedraft = await submitPlanningChatDraft({ sessionId }, {
-        sessions,
-        loadGeneratedPlan,
-        planningSessionStore: adapter,
+      expect(rebindRefusal).toEqual({
+        ok: false,
+        error: 'Set the repo before the conversation or terminal starts.',
       });
-      expect(submitBeforeRedraft.ok).toBe(false);
-      expect(loadGeneratedPlan).not.toHaveBeenCalled();
+      const sessionAfterRefusedRebind = sessions.get(sessionId);
+      expect(sessionAfterRefusedRebind).toMatchObject({
+        draftPlanText: planAText,
+        status: 'draft_ready',
+        repoUrl: REPO_A,
+        baseCommit: 'sha-repo-a',
+      });
+      expect(sessionAfterRefusedRebind?.messages.length).toBe(messageCountBeforeRebind);
+      expect(adapter.loadInAppPlanningSession(sessionId)?.draftPlanText).toBe(planAText);
+      expect(readFileSync(sidecarPathFor(sessionId), 'utf8')).toBe(planAText);
 
       spawnPlanner.mockResolvedValueOnce(PLAN_C_REPLY);
       const redraftTurn = await sendPlanningChatMessage({
         sessionId,
         message: 'draft the full plan again',
       }, {
-        config: { defaultRepoUrl: REPO_B, defaultBranch: 'main' },
+        config: { defaultRepoUrl: REPO_A, defaultBranch: 'main' },
         loadGeneratedPlan,
         sessions,
         planningCommandBuilder,

--- a/packages/app/src/__tests__/planning-terminal-invoker-cli.test.ts
+++ b/packages/app/src/__tests__/planning-terminal-invoker-cli.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Planning-terminal repo binding + live-owner CLI reachability.
+ *
+ * Two contracts:
+ *   1. A planning session bound to a repo opens its terminal in that
+ *      provisioned worktree, not the owner's repoRoot; unbound sessions keep
+ *      the repoRoot fallback (resolvePlanningTerminalCwd).
+ *   2. The planning terminal is a first-class surface for driving the RUNNING
+ *      Invoker: the request "please delete all running workflows" typed into
+ *      the terminal reaches a stand-in agent CLI whose tool call runs the real
+ *      `invoker-cli delete-all` against a live owner bus, and the owner's
+ *      running workflows are deleted. The agent's natural-language-to-command
+ *      step is a test stub (`claude` fixture script); everything downstream —
+ *      terminal PTY plumbing, the real packages/cli binary, IPC discovery,
+ *      `headless.exec` delegation — is production code.
+ */
+
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { IpcBus } from '@invoker/transport';
+import {
+  EmbeddedTerminalManager,
+  createBashTerminalBackend,
+} from '../embedded-terminal-manager.js';
+import {
+  createPlanningTerminalAdapter,
+  resolvePlanningTerminalCwd,
+  type PlanningTerminalAdapter,
+} from '../terminal-session-ipc.js';
+import type { InAppPlanningChatSession, InAppPlanningChatSessions } from '../in-app-planner.js';
+
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const CLI_ENTRY = join(REPO_ROOT, 'packages', 'cli', 'dist', 'index.js');
+
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+};
+
+function makePlanningSession(
+  id: string,
+  overrides: Partial<InAppPlanningChatSession> = {},
+): InAppPlanningChatSession {
+  return {
+    id,
+    title: 'Ops session',
+    presetKey: 'claude',
+    confirmationMode: 'require',
+    status: 'still_discussing',
+    messages: [],
+    conversation: {} as InAppPlanningChatSession['conversation'],
+    terminalMode: 'chat',
+    terminalOutputSnapshot: '',
+    createdAt: '2026-08-19T00:00:00.000Z',
+    updatedAt: '2026-08-19T00:00:00.000Z',
+    nextMessageId: 1,
+    ...overrides,
+  };
+}
+
+function makeAdapter(
+  sessions: InAppPlanningChatSessions,
+  manager: EmbeddedTerminalManager,
+  repoRoot: string,
+): PlanningTerminalAdapter {
+  return createPlanningTerminalAdapter({
+    embeddedTerminalManager: manager,
+    logger: noopLogger,
+    planningChatSessions: sessions,
+    getPlanningSessionStore: () => undefined,
+    isPlanningTerminalWriteAllowed: () => true,
+    repoRoot,
+  });
+}
+
+describe('resolvePlanningTerminalCwd', () => {
+  it('prefers the bound worktree when it exists', () => {
+    const worktree = mkdtempSync(join(tmpdir(), 'inv-wt-'));
+    try {
+      expect(resolvePlanningTerminalCwd({ worktreePath: worktree }, '/repo-root')).toBe(worktree);
+    } finally {
+      rmSync(worktree, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to repoRoot when unbound or the worktree is gone', () => {
+    expect(resolvePlanningTerminalCwd({}, '/repo-root')).toBe('/repo-root');
+    expect(resolvePlanningTerminalCwd({ worktreePath: '   ' }, '/repo-root')).toBe('/repo-root');
+    expect(
+      resolvePlanningTerminalCwd({ worktreePath: '/definitely/not/a/real/dir' }, '/repo-root'),
+    ).toBe('/repo-root');
+  });
+});
+
+describe('planning terminal repo binding', () => {
+  const cleanups: Array<() => void> = [];
+  afterEach(() => {
+    while (cleanups.length > 0) cleanups.pop()?.();
+  });
+
+  it('opens the terminal in the session worktree, and in repoRoot when unbound', async () => {
+    const worktree = mkdtempSync(join(tmpdir(), 'inv-wt-'));
+    const repoRoot = mkdtempSync(join(tmpdir(), 'inv-root-'));
+    cleanups.push(() => rmSync(worktree, { recursive: true, force: true }));
+    cleanups.push(() => rmSync(repoRoot, { recursive: true, force: true }));
+
+    const spawns: Array<{ cwd: string }> = [];
+    const manager = new EmbeddedTerminalManager({
+      backend: {
+        name: 'bash',
+        spawn(opts) {
+          spawns.push({ cwd: opts.cwd });
+          return {
+            write() {},
+            resize() {},
+            getAppliedSize: () => null,
+            close() {},
+          };
+        },
+      },
+    });
+    const sessions: InAppPlanningChatSessions = new Map([
+      ['bound', makePlanningSession('bound', { worktreePath: worktree })],
+      ['unbound', makePlanningSession('unbound')],
+    ]);
+    const adapter = makeAdapter(sessions, manager, repoRoot);
+
+    const bound = await adapter.open('bound');
+    expect(bound.opened).toBe(true);
+    expect(spawns[0]?.cwd).toBe(worktree);
+    expect(bound.session?.cwd).toBe(worktree);
+
+    const unbound = await adapter.open('unbound');
+    expect(unbound.opened).toBe(true);
+    expect(spawns[1]?.cwd).toBe(repoRoot);
+  });
+});
+
+describe('planning terminal drives the running invoker', () => {
+  const cleanups: Array<() => void> = [];
+  afterEach(() => {
+    while (cleanups.length > 0) cleanups.pop()?.();
+  });
+
+  beforeAll(() => {
+    if (!existsSync(CLI_ENTRY)) {
+      execFileSync('pnpm', ['--filter', '@invoker/cli', 'build'], {
+        cwd: REPO_ROOT,
+        stdio: 'ignore',
+        timeout: 180_000,
+      });
+    }
+  });
+
+  it('"please delete all running workflows" typed into the terminal runs invoker-cli delete-all against the live owner', async () => {
+    const worktree = mkdtempSync(join(tmpdir(), 'inv-wt-'));
+    cleanups.push(() => rmSync(worktree, { recursive: true, force: true }));
+
+    // Short socket path: macOS sun_path is 104 bytes.
+    const sockDir = mkdtempSync(join('/tmp', 'inv-s-'));
+    const socketPath = join(sockDir, 's.sock');
+    cleanups.push(() => rmSync(sockDir, { recursive: true, force: true }));
+
+    // ── Live owner fixture: real IPC bus server with running workflows ──
+    const workflows = new Map<string, { status: string }>([
+      ['wf-run-1', { status: 'running' }],
+      ['wf-run-2', { status: 'running' }],
+    ]);
+    const execRequests: unknown[] = [];
+    const ownerBus = new IpcBus(socketPath);
+    await ownerBus.ready();
+    cleanups.push(() => ownerBus.disconnect());
+    ownerBus.onRequest('headless.owner-ping', async () => ({
+      ownerId: 'test-owner',
+      mode: 'standalone',
+    }));
+    ownerBus.onRequest('headless.exec', async (req: unknown) => {
+      execRequests.push(req);
+      const { args } = req as { args: string[] };
+      if (args[0] === 'delete-all') workflows.clear();
+      return { ok: true };
+    });
+
+    // ── Stand-in agent CLI: maps the request to its invoker tool call ──
+    const claudeStub = join(worktree, 'claude');
+    writeFileSync(
+      claudeStub,
+      [
+        '#!/bin/bash',
+        '# Test stand-in for the agent CLI: for this planning request the',
+        '# agent\'s tool call is the invoker delete-all mutation.',
+        'if [[ "$*" == *"please delete all running workflows"* ]]; then',
+        '  exec invoker-cli delete-all',
+        'fi',
+        'echo "unexpected prompt: $*" >&2',
+        'exit 1',
+        '',
+      ].join('\n'),
+    );
+    chmodSync(claudeStub, 0o755);
+    const cliShim = join(worktree, 'invoker-cli');
+    writeFileSync(
+      cliShim,
+      `#!/bin/bash\nexec "${process.execPath}" "${CLI_ENTRY}" "$@"\n`,
+    );
+    chmodSync(cliShim, 0o755);
+
+    // ── Real planning terminal (real bash child) over the adapter ──
+    const manager = new EmbeddedTerminalManager({ backend: createBashTerminalBackend() });
+    const sessions: InAppPlanningChatSessions = new Map([
+      ['ops', makePlanningSession('ops', { worktreePath: worktree })],
+    ]);
+    const adapter = makeAdapter(sessions, manager, '/tmp');
+
+    let output = '';
+    manager.on('output', (event: { data: string }) => {
+      output += event.data;
+    });
+
+    const opened = await adapter.open('ops');
+    expect(opened.opened).toBe(true);
+    const sessionId = opened.session!.sessionId;
+    cleanups.push(() => {
+      manager.close(sessionId);
+    });
+    expect(opened.session?.cwd).toBe(worktree);
+
+    const wrote = adapter.write(
+      sessionId,
+      `INVOKER_IPC_SOCKET='${socketPath}' PATH="$PWD:$PATH" claude "please delete all running workflows"\n`,
+    );
+    expect(wrote.ok).toBe(true);
+
+    await vi.waitFor(
+      () => {
+        expect(output).toContain('delete-all accepted by live owner.');
+      },
+      { timeout: 20_000, interval: 250 },
+    );
+
+    expect(execRequests).toEqual([{ args: ['delete-all'], noTrack: true }]);
+    expect(workflows.size).toBe(0);
+  }, 30_000);
+});

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -1129,13 +1129,14 @@ export function setPlanningChatTerminalMode(
 
 export async function rebindPlanningChatRepo(
   request: InAppPlanningRebindRepoRequest,
-  deps: {
-    config: InvokerConfig;
+  deps: Pick<
+    InAppPlannerDeps,
+    'config' | 'workingDir' | 'planningCommandBuilder' | 'executionAgentRegistry'
+    | 'conversationRepo' | 'logger' | 'onRawPlannerOutput' | 'planDoctorScriptPath'
+  > & {
     sessions: InAppPlanningChatSessions;
     planningSessionStore?: InAppPlanningSessionStore;
     repoPool?: PlanningRepoPool;
-    workingDir?: string;
-    planDoctorScriptPath?: string;
   },
 ): Promise<InAppPlanningRebindRepoResponse> {
   const rawRequest = request as Partial<InAppPlanningRebindRepoRequest> | null | undefined;
@@ -1146,6 +1147,9 @@ export async function rebindPlanningChatRepo(
   }
   if (session.status === 'submitted') {
     return { ok: false, error: 'This planning session was already submitted. Start a new planning chat for changes.' };
+  }
+  if (session.messages.length > 0 || session.terminalSessionId) {
+    return { ok: false, error: 'Set the repo before the conversation or terminal starts.' };
   }
   if (!deps.repoPool) {
     return { ok: false, error: 'Worktree provisioning is not available.' };

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1452,6 +1452,11 @@ function startHeadlessMode(): void {
             return rebindPlanningChatRepo(payload.args[0] as InAppPlanningRebindRepoRequest, {
               config: invokerConfig,
               sessions: planningChatSessions,
+              planningCommandBuilder,
+              executionAgentRegistry: agentRegistry,
+              conversationRepo: planningConversationRepo,
+              logger,
+              onRawPlannerOutput: emitPlanningChatStreamToWeb,
               planningSessionStore: readOnlyMode ? undefined : persistence,
               repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
               workingDir: repoRoot,

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -11,10 +11,12 @@ import {
   type TerminalUiPerfReporter,
   type TerminalUiPerfSink,
 } from './terminal-ui-perf.js';
+import { existsSync } from 'node:fs';
 import {
   ensurePlanningTerminalSummaryBridge,
   hydrateRemotePlanningTerminalSession,
   updatePlanningChatTerminalState,
+  type InAppPlanningChatSession,
   type InAppPlanningChatSessions,
   type InAppPlanningSessionStore,
 } from './in-app-planner.js';
@@ -385,6 +387,21 @@ function planningTerminalWritable(
   return { ok: true };
 }
 
+/**
+ * Planning terminals follow the conversation's repo binding: a session bound
+ * to a repo opens its terminal in that provisioned worktree; unbound sessions
+ * (and sessions whose worktree no longer exists on disk) fall back to the
+ * owner's repoRoot.
+ */
+export function resolvePlanningTerminalCwd(
+  session: Pick<InAppPlanningChatSession, 'worktreePath'>,
+  repoRoot: string,
+): string {
+  const worktreePath = session.worktreePath?.trim();
+  if (worktreePath && existsSync(worktreePath)) return worktreePath;
+  return repoRoot;
+}
+
 function planningTerminalTargetKey(planningSessionId: string, repoRoot: string): string {
   return JSON.stringify({
     kind: 'planning',
@@ -444,14 +461,15 @@ export function bindPlanningTerminalSessionState(deps: {
           session.terminalOutputSnapshot ?? '',
           MAX_OUTPUT_SNAPSHOT_CHARS,
         );
+        const terminalCwd = resolvePlanningTerminalCwd(session, repoRoot);
         embeddedTerminalManager.restoreSpawnSession({
           sessionId: session.terminalSessionId,
           taskId: `planning:${session.id}`,
           kind: 'planning',
           planningSessionId: session.id,
-          targetKey: planningTerminalTargetKey(session.id, repoRoot),
-          spec: { cwd: repoRoot },
-          cwd: repoRoot,
+          targetKey: planningTerminalTargetKey(session.id, terminalCwd),
+          spec: { cwd: terminalCwd },
+          cwd: terminalCwd,
           createdAt: session.terminalUpdatedAt ?? session.updatedAt,
           outputSnapshot,
         });
@@ -540,12 +558,13 @@ export function createPlanningTerminalAdapter(deps: PlanningTerminalAdapterDeps)
           planningSession.terminalOutputSnapshot ?? '',
           MAX_OUTPUT_SNAPSHOT_CHARS,
         );
+        const terminalCwd = resolvePlanningTerminalCwd(planningSession, repoRoot);
         const session = embeddedTerminalManager.openOrReuse({
           kind: 'planning',
           taskId: `planning:${planningSessionId}`,
           planningSessionId,
-          spec: { cwd: repoRoot },
-          cwd: repoRoot,
+          spec: { cwd: terminalCwd },
+          cwd: terminalCwd,
           outputSnapshot,
         });
         updatePlanningChatTerminalState(planningSessionId, {


### PR DESCRIPTION
## Summary

Planning chats can bind a repository only while they are still empty.

Once the conversation has a message or a tmux terminal, the binding is fixed for the life of the chat.

Before this, a rebind arriving mid-conversation would silently swap the worktree underneath an ongoing discussion and could clear a drafted plan.

Now `rebindPlanningChatRepo` answers such requests with a clear error and leaves the existing binding exactly as it was.

The rebind function and its standalone dispatch now get the same harness wiring as the other planning calls.

Without that wiring, a rebound chat's planner fell back to a missing `agent` binary.

## Review Claim

Repo rebinds are refused once a planning conversation or its terminal exists; empty sessions keep rebinding as before.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A refused rebind touches nothing: repo, base commit, worktree, conversation, draft, and messages stay byte-for-byte what they were before the call, and empty sessions keep the prior rebind behavior unchanged.

## Slice Rationale

The guard lands before the composer surface that drives it, so the API can never be steered into the mid-conversation path the UI no longer offers.

## Non-goals

- The `invalidate_and_block_submit` response variant stays in the contracts union and in planning-core's `decideWorktreeBinding`; it is simply never produced by `rebindPlanningChatRepo` anymore, because a draft requires messages and messages now refuse the rebind.
- No UI changes; the composer Repo field ships in the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm vitest run -t 'rebind' src/__tests__/in-app-planner.test.ts`
- [x] `cd packages/app && pnpm vitest run src/__tests__/planning-chat-e2e-acceptance.test.ts`
- [x] `npx tsc -p tsconfig.typecheck.json --noEmit`

</details>

## Visual Proof

A refused bind surfaces the backend's error in the composer and keeps the previous binding:

![Backend bind error surfaced inline](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260820-9ec126/repo-bind-error.webp)

A rebound chat's planner answers from the newly bound repository, proving the harness wiring holds after a rebind:

![Planner reply from the rebound repository](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260820-9ec126/repo-send-once.webp)

Manually inspected: I opened both captures on the live demo myself. The first shows the exact red git-clone error line under the composer Options row with the typed path still visible in the Repo field. The second shows an Invoker reply naming README.md as the rebound repository's only tracked file, which is that repository's true content.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 4aab2f38f1`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #9961