### PR TITLE
[Web surface parity](10) Planning turn contract fields

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -500,6 +500,9 @@ export interface InAppPlanningSessionSummary {
   terminalExitCode?: number;
   terminalOutputSnapshot?: string;
   terminalUpdatedAt?: string;
+  activeTurnId?: string;
+  activeTurnStatus?: InAppPlanningTurnStatus;
+  activeTurnError?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -525,9 +528,25 @@ export type InAppPlanningListSessionsResponse = {
   sessions: InAppPlanningSessionSummary[];
 };
 
+export type InAppPlanningTurnStatus = 'running' | 'failed';
+
+export type InAppPlanningTurnOutcome =
+  | {
+      status: 'completed';
+      reply: string;
+      reasoning?: string;
+      confirmationMode?: PlanningConfirmationMode;
+      draftPlanAvailable: boolean;
+      draftPlanSummary?: InAppPlanningPlanSummary;
+      draftPlanText?: string;
+    }
+  | { status: 'failed'; error: string };
+
 export interface InAppPlanningStreamEvent {
   sessionId: string;
-  chunk: string;
+  chunk?: string;
+  turnId?: string;
+  turn?: InAppPlanningTurnOutcome;
 }
 
 export interface InAppPlanningChatRequest {
@@ -535,12 +554,14 @@ export interface InAppPlanningChatRequest {
   message: string;
   presetKey?: string;
   confirmationMode?: PlanningConfirmationMode;
+  turnId?: string;
 }
 
 export type InAppPlanningChatResponse =
   | {
       ok: true;
       sessionId: string;
+      turnId?: string;
       reply: string;
       confirmationMode?: PlanningConfirmationMode;
       draftPlanAvailable: boolean;
@@ -550,6 +571,7 @@ export type InAppPlanningChatResponse =
   | {
       ok: false;
       sessionId?: string;
+      turnId?: string;
       error: string;
     };
 


### PR DESCRIPTION
## Summary

Planning chats now describe each turn on the wire. Requests and responses carry a turn id, the stream can carry a turn outcome, and session summaries carry active-turn state.

Every new field is optional. Nothing reads them yet; the two slices above persist them and drive the composer with them.

## Review Claim

Approve the added planning turn fields: `turnId` on chat request and response, `InAppPlanningTurnOutcome` on the stream event, and `activeTurnId`/`activeTurnStatus`/`activeTurnError` on session summaries.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Additive only: each field is optional, `InAppPlanningStreamEvent` keeps its single-interface shape with `chunk` merely optional, and every existing consumer keeps compiling (repo-wide type check exits 0).

## Slice Rationale

Wire shape first. The store lifecycle and the composer both build on these types, so they land alone where the whole turn vocabulary is visible in one diff.

## Non-goals

- No persistence of turn state (next slice).
- No composer or renderer changes.
- No change to how stream events are emitted or transported.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `npx tsc -p tsconfig.typecheck.json --noEmit`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes, nothing consumes the new fields within this slice.
- Revert command: `git revert 39a49bc6f1`
- Post-revert steps: None
- Data migration? No

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added turn tracking for in-app planning conversations.
  - Planning sessions now show active turn IDs, running or failed statuses, and error details.
  - Chat responses can include turn IDs and completed or failed turn outcomes.
  - Planning updates now support turn-specific events, replies, reasoning, confirmations, and draft plans.

- **Bug Fixes**
  - Completed planning turns now clear active-turn status correctly.
  - Failed turns now report actionable error information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #9963