### PR TITLE
[Web surface parity](11) Persist planning turns and retry them

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -56,6 +56,12 @@ tasks:
 
 const NO_COMPLETE_PLAN_DRAFTED_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
 
+const INTERRUPTED_TURN_SYSTEM_LINE = {
+  role: 'system',
+  text: 'Planner was interrupted before it could answer.',
+  tone: 'error',
+} as const;
+
 function planningSession(
   overrides: Partial<InAppPlanningChatSession> & Pick<InAppPlanningChatSession, 'id' | 'title'>,
 ): InAppPlanningChatSession {
@@ -282,7 +288,7 @@ describe('planning chat', () => {
       loadGeneratedPlan: vi.fn(),
       sessions,
       planningCommandBuilder,
-    })).resolves.toEqual({ ok: false, sessionId: 'session-1', error: 'Type a message first.' });
+    })).resolves.toEqual({ ok: false, sessionId: 'session-1', turnId: expect.any(String), error: 'Type a message first.' });
     expect(sessions.size).toBe(0);
   });
 
@@ -297,7 +303,7 @@ describe('planning chat', () => {
       loadGeneratedPlan: vi.fn(),
       sessions,
       planningCommandBuilder,
-    })).resolves.toEqual({ ok: false, sessionId: undefined, error: 'Unknown planner preset "bad".' });
+    })).resolves.toEqual({ ok: false, sessionId: undefined, turnId: expect.any(String), error: 'Unknown planner preset "bad".' });
     expect(sessions.size).toBe(0);
   });
 
@@ -398,6 +404,7 @@ describe('planning chat', () => {
     })).resolves.toEqual({
       ok: false,
       sessionId: 'missing-session',
+      turnId: expect.any(String),
       error: 'Planning session "missing-session" was not found.',
     });
 
@@ -970,6 +977,126 @@ tasks:
     expect(secondResult.ok && secondResult.reply).toBe('turn 2 reply');
     expect(thirdResult.ok && thirdResult.reply).toBe('turn 3 reply');
     expect(overrideCalls.length).toBe(2);
+  });
+
+  it('echoes an explicit turnId and rejects a duplicate send while that turn runs', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    let resolveTurn: ((value: string) => void) | undefined;
+    let turnStarted!: () => void;
+    const started = new Promise<void>((resolve) => { turnStarted = resolve; });
+    const plannerReplyOverride = vi.fn(() => {
+      turnStarted();
+      return new Promise<string>((resolve) => { resolveTurn = resolve; });
+    });
+    const deps = {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+      plannerReplyOverride,
+    };
+
+    const first = sendPlanningChatMessage({ message: 'draft', presetKey: 'codex', turnId: 'turn-explicit' }, deps);
+    await started;
+
+    const sessionId = [...sessions.keys()][0];
+    const duplicate = await sendPlanningChatMessage({ sessionId, message: 'draft', turnId: 'turn-explicit' }, deps);
+    expect(duplicate).toMatchObject({ ok: false, turnId: 'turn-explicit', error: 'duplicate-turn' });
+
+    resolveTurn?.('turn reply');
+    const result = await first;
+    if (!result.ok) throw new Error(result.error);
+    expect(result.turnId).toBe('turn-explicit');
+    expect(plannerReplyOverride).toHaveBeenCalledTimes(1);
+  });
+
+  it('records a failed turn and a retry with the same turnId re-runs without duplicating the user line', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const sessions = createInAppPlanningChatSessions();
+      const plannerReplyOverride = vi.fn()
+        .mockRejectedValueOnce(new Error('planner crashed'))
+        .mockResolvedValueOnce('recovered reply');
+      const deps = {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        plannerReplyOverride,
+        planningSessionStore: adapter,
+      };
+
+      const failed = await sendPlanningChatMessage({ message: 'draft', presetKey: 'codex', turnId: 'turn-retry' }, deps);
+      if (failed.ok) throw new Error('expected the first turn to fail');
+      expect(failed.turnId).toBe('turn-retry');
+      const sessionId = failed.sessionId;
+      if (!sessionId) throw new Error('expected a sessionId on the failed turn');
+      const session = sessions.get(sessionId);
+      expect(session?.activeTurnId).toBe('turn-retry');
+      expect(session?.activeTurnStatus).toBe('failed');
+      expect(session?.activeTurnError).toBe('planner crashed');
+      const persisted = adapter.loadInAppPlanningSession(sessionId);
+      expect(persisted?.activeTurnId).toBe('turn-retry');
+      expect(persisted?.activeTurnStatus).toBe('failed');
+      expect(persisted?.activeTurnError).toBe('planner crashed');
+      const userLinesBefore = session?.messages.filter((line) => line.role === 'user').length;
+
+      const retried = await sendPlanningChatMessage({ sessionId, message: 'draft', turnId: 'turn-retry' }, deps);
+      if (!retried.ok) throw new Error(retried.error);
+      expect(retried.reply).toBe('recovered reply');
+      expect(session?.messages.filter((line) => line.role === 'user').length).toBe(userLinesBefore);
+      expect(session?.activeTurnId).toBeUndefined();
+      expect(session?.activeTurnStatus).toBeUndefined();
+      expect(session?.activeTurnError).toBeUndefined();
+      const persistedAfter = adapter.loadInAppPlanningSession(sessionId);
+      expect(persistedAfter?.activeTurnId).toBeUndefined();
+      expect(persistedAfter?.activeTurnStatus).toBeUndefined();
+      expect(persistedAfter?.activeTurnError).toBeUndefined();
+      expect(plannerReplyOverride).toHaveBeenCalledTimes(2);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('emits turn outcome events on the planning stream channel', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    const onRawPlannerOutput = vi.fn();
+    const ok = await sendPlanningChatMessage({ message: 'draft', presetKey: 'codex', turnId: 'turn-events' }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+      plannerReplyOverride: async () => 'turn reply',
+      onRawPlannerOutput,
+    });
+    if (!ok.ok) throw new Error(ok.error);
+    const completedEvent = onRawPlannerOutput.mock.calls
+      .map(([event]) => event)
+      .find((event) => event?.turn?.status === 'completed');
+    expect(completedEvent).toMatchObject({
+      sessionId: ok.sessionId,
+      turnId: 'turn-events',
+      turn: { status: 'completed', reply: 'turn reply', draftPlanAvailable: false },
+    });
+
+    const failSessions = createInAppPlanningChatSessions();
+    const onFailEvent = vi.fn();
+    const failed = await sendPlanningChatMessage({ message: 'draft', presetKey: 'codex', turnId: 'turn-fail' }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions: failSessions,
+      planningCommandBuilder,
+      plannerReplyOverride: async () => { throw new Error('boom'); },
+      onRawPlannerOutput: onFailEvent,
+    });
+    expect(failed.ok).toBe(false);
+    const failedEvent = onFailEvent.mock.calls
+      .map(([event]) => event)
+      .find((event) => event?.turn?.status === 'failed');
+    expect(failedEvent).toMatchObject({
+      turnId: 'turn-fail',
+      turn: { status: 'failed', error: 'boom' },
+    });
   });
 
   it('never constructs a session in mode: agent (createSession and planFromGoal paths)', async () => {
@@ -1571,14 +1698,54 @@ tasks:
         planningSessionStore: adapter,
       });
 
-      const restored = sessions.get('planning-interrupted');
-      expect(restored?.pendingSend).toBeUndefined();
-      expect(restored?.messages.at(-1)).toMatchObject({
-        role: 'system',
-        text: 'Planner was interrupted before it could answer. Send another message to continue.',
-        tone: 'error',
-      });
+      const restoredInterrupted = sessions.get('planning-interrupted');
+      expect(restoredInterrupted?.pendingSend).toBeUndefined();
+      expect(restoredInterrupted?.messages.at(-1)).toMatchObject(INTERRUPTED_TURN_SYSTEM_LINE);
       expect(adapter.loadInAppPlanningSession('planning-interrupted')?.pendingResponse).toBe(false);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('restores an interrupted pending turn as failed with its turnId preserved', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const record: InAppPlanningSessionRecord = {
+        id: 'planning-interrupted-turn',
+        title: 'Interrupted turn',
+        presetKey: 'codex',
+        status: 'still_discussing',
+        confirmationMode: 'require',
+        messages: [
+          { id: 1, role: 'user', text: 'Continue', createdAt: '2026-07-07T00:00:01.000Z' },
+        ],
+        activeTurnId: 'turn-x',
+        activeTurnStatus: 'running',
+        pendingResponse: true,
+        createdAt: '2026-07-07T00:00:00.000Z',
+        updatedAt: '2026-07-07T00:00:01.000Z',
+      };
+      adapter.upsertInAppPlanningSession(record);
+      const sessions = createInAppPlanningChatSessions();
+
+      await restorePlanningChatSessions([record], {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo: new ConversationRepository(adapter),
+        planningSessionStore: adapter,
+      });
+
+      const restoredTurn = sessions.get('planning-interrupted-turn');
+      expect(restoredTurn?.activeTurnId).toBe('turn-x');
+      expect(restoredTurn?.activeTurnStatus).toBe('failed');
+      expect(restoredTurn?.activeTurnError).toBe(INTERRUPTED_TURN_SYSTEM_LINE.text);
+      expect(restoredTurn?.messages.at(-1)).toMatchObject(INTERRUPTED_TURN_SYSTEM_LINE);
+      const persisted = adapter.loadInAppPlanningSession('planning-interrupted-turn');
+      expect(persisted?.activeTurnId).toBe('turn-x');
+      expect(persisted?.activeTurnStatus).toBe('failed');
+      expect(persisted?.pendingResponse).toBe(false);
     } finally {
       adapter.close();
     }

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -280,7 +280,7 @@ describe('planning chat', () => {
   it('rejects blank messages without creating a session', async () => {
     const sessions = createInAppPlanningChatSessions();
 
-    await expect(sendPlanningChatMessage({
+    const rejected = await sendPlanningChatMessage({
       sessionId: 'session-1',
       message: '   ',
     }, {
@@ -288,14 +288,15 @@ describe('planning chat', () => {
       loadGeneratedPlan: vi.fn(),
       sessions,
       planningCommandBuilder,
-    })).resolves.toEqual({ ok: false, sessionId: 'session-1', turnId: expect.any(String), error: 'Type a message first.' });
+    });
+    expect(rejected).toEqual({ ok: false, sessionId: 'session-1', turnId: expect.any(String), error: 'Type a message first.' });
     expect(sessions.size).toBe(0);
   });
 
   it('rejects an unknown preset without creating a session', async () => {
     const sessions = createInAppPlanningChatSessions();
 
-    await expect(sendPlanningChatMessage({
+    const rejected = await sendPlanningChatMessage({
       message: 'hello',
       presetKey: 'bad',
     }, {
@@ -303,7 +304,8 @@ describe('planning chat', () => {
       loadGeneratedPlan: vi.fn(),
       sessions,
       planningCommandBuilder,
-    })).resolves.toEqual({ ok: false, sessionId: undefined, turnId: expect.any(String), error: 'Unknown planner preset "bad".' });
+    });
+    expect(rejected).toEqual({ ok: false, sessionId: undefined, turnId: expect.any(String), error: 'Unknown planner preset "bad".' });
     expect(sessions.size).toBe(0);
   });
 

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -28,6 +28,7 @@ import type {
   InAppPlanningStreamEvent,
   InAppPlanningSubmitRequest,
   InAppPlanningSubmitResponse,
+  InAppPlanningTurnStatus,
   Logger,
   PlanningConfirmationMode,
   PlanningTerminalMode,
@@ -119,6 +120,9 @@ export interface InAppPlanningChatSession {
   terminalExitCode?: number;
   terminalOutputSnapshot?: string;
   terminalUpdatedAt?: string;
+  activeTurnId?: string;
+  activeTurnStatus?: InAppPlanningTurnStatus;
+  activeTurnError?: string;
   createdAt: string;
   updatedAt: string;
   nextMessageId: number;
@@ -453,6 +457,9 @@ function sessionToRecord(session: InAppPlanningChatSession, pendingResponse: boo
     terminalExitCode: session.terminalExitCode,
     terminalOutputSnapshot: session.terminalOutputSnapshot ?? '',
     terminalUpdatedAt: session.terminalUpdatedAt,
+    activeTurnId: session.activeTurnId,
+    activeTurnStatus: session.activeTurnStatus,
+    activeTurnError: session.activeTurnError,
     pendingResponse,
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
@@ -508,6 +515,9 @@ function sessionToSummary(session: InAppPlanningChatSession): InAppPlanningSessi
     terminalExitCode: session.terminalExitCode,
     terminalOutputSnapshot: session.terminalOutputSnapshot ?? '',
     terminalUpdatedAt: session.terminalUpdatedAt,
+    activeTurnId: session.activeTurnId,
+    activeTurnStatus: session.activeTurnStatus,
+    activeTurnError: session.activeTurnError,
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
   };
@@ -849,8 +859,9 @@ export async function sendPlanningChatMessage(
     taggedMessage.confirmationMode ?? rawRequest?.confirmationMode,
     resolveDefaultPlanningConfirmationMode(deps.config),
   );
+  const turnId = (typeof rawRequest?.turnId === 'string' && rawRequest.turnId.trim()) || randomUUID();
   if (!message) {
-    return { ok: false, sessionId: rawRequest?.sessionId, error: 'Type a message first.' };
+    return { ok: false, sessionId: rawRequest?.sessionId, turnId, error: 'Type a message first.' };
   }
 
   const suppliedSessionId = typeof rawRequest?.sessionId === 'string'
@@ -865,6 +876,7 @@ export async function sendPlanningChatMessage(
       return {
         ok: false,
         sessionId: suppliedSessionId,
+        turnId,
         error: `Planning session "${suppliedSessionId}" was not found.`,
       };
     }
@@ -875,14 +887,18 @@ export async function sendPlanningChatMessage(
         confirmationMode: requestedConfirmationMode,
       }, deps);
       if ('error' in created) {
-        return { ok: false, sessionId, error: created.error };
+        return { ok: false, sessionId, turnId, error: created.error };
       }
       session = created;
       sessionId = session.id;
     }
     if (session.status === 'submitted') {
-      return { ok: false, sessionId: session.id, error: 'This planning session was already submitted. Start a new planning chat for changes.' };
+      return { ok: false, sessionId: session.id, turnId, error: 'This planning session was already submitted. Start a new planning chat for changes.' };
     }
+    if (session.activeTurnStatus === 'running' && session.activeTurnId === turnId) {
+      return { ok: false, sessionId: session.id, turnId, error: 'duplicate-turn' };
+    }
+    const isRetry = session.activeTurnStatus === 'failed' && session.activeTurnId === turnId;
 
     const activeSession = session;
     activeSession.confirmationMode = requestedConfirmationMode;
@@ -893,11 +909,36 @@ export async function sendPlanningChatMessage(
         role: entry.role,
         content: entry.text,
       }));
-      appendSessionMessage(activeSession, 'user', message);
+      if (!isRetry) {
+        appendSessionMessage(activeSession, 'user', message);
+      }
       if (activeSession.title === 'Untitled plan') {
         activeSession.title = titleFromMessage(message);
       }
+      activeSession.activeTurnId = turnId;
+      activeSession.activeTurnStatus = 'running';
+      activeSession.activeTurnError = undefined;
       persistPlanningSession(activeSession, deps.planningSessionStore, true);
+
+      const finishTurn = (response: Extract<InAppPlanningChatResponse, { ok: true }>): InAppPlanningChatResponse => {
+        activeSession.activeTurnId = undefined;
+        activeSession.activeTurnStatus = undefined;
+        activeSession.activeTurnError = undefined;
+        persistPlanningSession(activeSession, deps.planningSessionStore, false);
+        deps.onRawPlannerOutput?.({
+          sessionId: activeSession.id,
+          turnId,
+          turn: {
+            status: 'completed',
+            reply: response.reply,
+            confirmationMode: response.confirmationMode,
+            draftPlanAvailable: response.draftPlanAvailable,
+            draftPlanSummary: response.draftPlanSummary,
+            draftPlanText: response.draftPlanText,
+          },
+        });
+        return response;
+      };
 
       try {
         const hostedMessage = formatPlanningHostedTurn('in_app', message);
@@ -955,17 +996,17 @@ export async function sendPlanningChatMessage(
             ? 'draft_ready'
             : conversationStatus;
           appendSessionMessage(activeSession, 'assistant', reply);
-          persistPlanningSession(activeSession, deps.planningSessionStore, false);
-          return {
+          return finishTurn({
             ok: true,
             sessionId: activeSession.id,
+            turnId,
             reply,
             reasoning,
             confirmationMode: activeSession.confirmationMode,
             draftPlanAvailable: hasDraftPlan(activeSession),
             draftPlanSummary: activeSession.draftPlanSummary,
             draftPlanText: activeSession.draftPlanText,
-          } as InAppPlanningChatResponse;
+          } as Extract<InAppPlanningChatResponse, { ok: true }>);
         }
 
         const review = preparePlanningReview({
@@ -978,40 +1019,49 @@ export async function sendPlanningChatMessage(
             ? 'draft_ready'
             : 'still_discussing';
           appendSessionMessage(activeSession, 'assistant', review.reply);
-          persistPlanningSession(activeSession, deps.planningSessionStore, false);
-          return {
+          return finishTurn({
             ok: true,
             sessionId: activeSession.id,
+            turnId,
             reply: review.reply,
             reasoning,
             confirmationMode: activeSession.confirmationMode,
             draftPlanAvailable: hasDraftPlan(activeSession),
             draftPlanSummary: activeSession.draftPlanSummary,
             draftPlanText: activeSession.draftPlanText,
-          } as InAppPlanningChatResponse;
+          } as Extract<InAppPlanningChatResponse, { ok: true }>);
         }
 
         activeSession.draftPlanSummary = review.summary;
         activeSession.draftPlanText = review.planText;
         activeSession.status = 'draft_ready';
         appendSessionMessage(activeSession, 'assistant', reply);
-        persistPlanningSession(activeSession, deps.planningSessionStore, false);
-        return {
+        return finishTurn({
           ok: true,
           sessionId: activeSession.id,
+          turnId,
           reply,
           reasoning,
           confirmationMode: activeSession.confirmationMode,
           draftPlanAvailable: true,
           draftPlanSummary: review.summary,
           draftPlanText: review.planText,
-        } as InAppPlanningChatResponse;
+        } as Extract<InAppPlanningChatResponse, { ok: true }>);
       } catch (error) {
+        const failureMessage = error instanceof Error ? error.message : String(error);
+        activeSession.activeTurnStatus = 'failed';
+        activeSession.activeTurnError = failureMessage;
         persistPlanningSession(activeSession, deps.planningSessionStore, false);
+        deps.onRawPlannerOutput?.({
+          sessionId: activeSession.id,
+          turnId,
+          turn: { status: 'failed', error: failureMessage },
+        });
         return {
           ok: false,
           sessionId: activeSession.id,
-          error: error instanceof Error ? error.message : String(error),
+          turnId,
+          error: failureMessage,
         };
       }
     });
@@ -1021,6 +1071,7 @@ export async function sendPlanningChatMessage(
     return {
       ok: false,
       sessionId,
+      turnId,
       error: error instanceof Error ? error.message : String(error),
     };
   }
@@ -1380,6 +1431,9 @@ export async function restorePlanningChatSessions(
       terminalExitCode: record.terminalExitCode,
       terminalOutputSnapshot: record.terminalOutputSnapshot ?? '',
       terminalUpdatedAt: record.terminalUpdatedAt,
+      activeTurnId: record.activeTurnId,
+      activeTurnStatus: record.activeTurnStatus,
+      activeTurnError: record.activeTurnError,
       createdAt: record.createdAt,
       updatedAt: record.updatedAt,
       nextMessageId,
@@ -1391,9 +1445,12 @@ export async function restorePlanningChatSessions(
         appendSessionMessage(
           session,
           'system',
-          'Planner was interrupted before it could answer. Send another message to continue.',
+          'Planner was interrupted before it could answer.',
           'error',
         );
+        session.activeTurnId = record.activeTurnId ?? randomUUID();
+        session.activeTurnStatus = 'failed';
+        session.activeTurnError = 'Planner was interrupted before it could answer.';
       }
       shouldPersist = true;
     }

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -6,7 +6,7 @@
  */
 
 import type { TaskState, TaskStateChanges, PlanDefinition, Attempt, WorkflowDerivedStatus, WorkflowRollup, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency } from '@invoker/workflow-core';
-import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, PlanningConfirmationMode, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
+import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, InAppPlanningTurnStatus, PlanningConfirmationMode, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
 
 
@@ -337,6 +337,9 @@ export interface InAppPlanningSessionRecord {
   terminalExitCode?: number;
   terminalOutputSnapshot?: string;
   terminalUpdatedAt?: string;
+  activeTurnId?: string;
+  activeTurnStatus?: InAppPlanningTurnStatus;
+  activeTurnError?: string;
   pendingResponse: boolean;
   createdAt: string;
   updatedAt: string;
@@ -363,6 +366,9 @@ export type InAppPlanningSessionPatch = Partial<Pick<
   | 'terminalExitCode'
   | 'terminalOutputSnapshot'
   | 'terminalUpdatedAt'
+  | 'activeTurnId'
+  | 'activeTurnStatus'
+  | 'activeTurnError'
   | 'pendingResponse'
   | 'updatedAt'
 >>;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -644,6 +644,9 @@ type InAppPlanningSessionRow = {
   terminal_output_snapshot?: unknown;
   terminal_updated_at?: unknown;
   pending_response?: unknown;
+  active_turn_id?: unknown;
+  active_turn_status?: unknown;
+  active_turn_error?: unknown;
   created_at?: unknown;
   updated_at?: unknown;
 };
@@ -1404,9 +1407,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
           terminal_output_snapshot,
           terminal_updated_at,
           pending_response,
+          active_turn_id,
+          active_turn_status,
+          active_turn_error,
           created_at,
           updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(session_id) DO UPDATE SET
           title = excluded.title,
           preset_key = excluded.preset_key,
@@ -1428,6 +1434,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
           terminal_output_snapshot = excluded.terminal_output_snapshot,
           terminal_updated_at = excluded.terminal_updated_at,
           pending_response = excluded.pending_response,
+          active_turn_id = excluded.active_turn_id,
+          active_turn_status = excluded.active_turn_status,
+          active_turn_error = excluded.active_turn_error,
           created_at = excluded.created_at,
           updated_at = excluded.updated_at`,
         [
@@ -1452,6 +1461,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
           record.terminalOutputSnapshot ?? '',
           record.terminalUpdatedAt ?? null,
           record.pendingResponse ? 1 : 0,
+          record.activeTurnId ?? null,
+          record.activeTurnStatus ?? null,
+          record.activeTurnError ?? null,
           record.createdAt,
           record.updatedAt,
         ],
@@ -1557,6 +1569,18 @@ export class SQLiteAdapter implements PersistenceAdapter {
       if (Object.hasOwn(patch, 'pendingResponse')) {
         setClauses.push('pending_response = ?');
         values.push(patch.pendingResponse ? 1 : 0);
+      }
+      if (Object.hasOwn(patch, 'activeTurnId')) {
+        setClauses.push('active_turn_id = ?');
+        values.push(patch.activeTurnId ?? null);
+      }
+      if (Object.hasOwn(patch, 'activeTurnStatus')) {
+        setClauses.push('active_turn_status = ?');
+        values.push(patch.activeTurnStatus ?? null);
+      }
+      if (Object.hasOwn(patch, 'activeTurnError')) {
+        setClauses.push('active_turn_error = ?');
+        values.push(patch.activeTurnError ?? null);
       }
       if (Object.hasOwn(patch, 'updatedAt')) {
         setClauses.push('updated_at = ?');
@@ -3335,6 +3359,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
         ...(typeof row.terminal_exit_code === 'number' ? { terminalExitCode: row.terminal_exit_code } : {}),
         terminalOutputSnapshot: typeof row.terminal_output_snapshot === 'string' ? row.terminal_output_snapshot : '',
         ...(typeof row.terminal_updated_at === 'string' ? { terminalUpdatedAt: row.terminal_updated_at } : {}),
+        ...(typeof row.active_turn_id === 'string' ? { activeTurnId: row.active_turn_id } : {}),
+        ...(row.active_turn_status === 'running' || row.active_turn_status === 'failed'
+          ? { activeTurnStatus: row.active_turn_status }
+          : {}),
+        ...(typeof row.active_turn_error === 'string' ? { activeTurnError: row.active_turn_error } : {}),
         pendingResponse: row.pending_response === 1,
         createdAt,
         updatedAt,

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -254,6 +254,9 @@ export const SCHEMA_DDL = `
         terminal_output_snapshot TEXT NOT NULL DEFAULT '',
         terminal_updated_at TEXT,
         pending_response INTEGER NOT NULL DEFAULT 0 CHECK (pending_response IN (0, 1)),
+        active_turn_id TEXT,
+        active_turn_status TEXT CHECK (active_turn_status IS NULL OR active_turn_status IN ('running', 'failed')),
+        active_turn_error TEXT,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
       );
@@ -641,6 +644,9 @@ export const COLUMN_MIGRATIONS = [
   // a later slice's scoped retry count -- unused for now.
   'ALTER TABLE task_launch_dispatch ADD COLUMN abandon_reason TEXT',
   'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN active_turn_id TEXT',
+  "ALTER TABLE in_app_planning_sessions ADD COLUMN active_turn_status TEXT CHECK (active_turn_status IS NULL OR active_turn_status IN ('running', 'failed'))",
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN active_turn_error TEXT',
 ];
 
 /**


### PR DESCRIPTION
## Summary

A planning turn now survives the app process. The session row records the running turn, keeps a failure with its message, and clears once the reply lands.

A resend carrying the same turn id while that turn runs is refused, so one accidental resend cannot run the planner twice.

A send that repeats a failed turn id reruns the planner while keeping a single copy of the user line.

On boot, a turn that died mid-flight is marked failed with its turn id kept.

Turn outcomes also ride the existing planning stream channel, so a renderer can learn a turn finished even when its original request died.

## Review Claim

Approve the persisted turn state machine: running written before the planner spawns, failed kept with its turn id and error, refusal of a resend for a running turn, rerun of a failed turn keeping one user line, and boot recovery marking interrupted turns failed.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

One active turn per chat is enforced by the same per-session send chain as before. The three new columns are nullable and ignored by older readers. Interrupted turns are never rerun automatically; a human must ask again.

## Slice Rationale

The store columns and the planner turn state change together because they form one persistence flow; the composer that consumes this state is its own slice above.

## Non-goals

- No renderer or composer changes.
- No change to the send response shape beyond the echoed turn id.
- No automatic rerun of interrupted turns on boot.

## Architecture

### Before

```mermaid
graph TD
    A["send request"] --> B["planner turn (in memory only)"]
    B --> C["response resolves"]
    C --> D["session row updated"]
```

### After

```mermaid
graph TD
    A["send request + turnId"] --> B["session row: activeTurn running"]
    B --> C["planner turn"]
    C -->|success| D["row cleared + turn event on stream"]
    C -->|failure| E["row: activeTurn failed + turn event on stream"]
    E -->|same turnId again| C
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm vitest run src/__tests__/in-app-planner.test.ts -t 'planning chat'`
- [ ] `cd packages/app && pnpm vitest run src/__tests__/planning-chat-e2e-acceptance.test.ts`
- [ ] `npx tsc -p tsconfig.typecheck.json --noEmit`

</details>

## Visual Proof

Turn failures persisted here surface in the composer. Captured on the live web demo after restarting the app process mid-turn and reloading.

![Interrupted turn offers Retry](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260820-0dc773/planning-turn-interrupted-retry.webp)

Red interruption line in the transcript plus the persisted error and Retry button above the composer — the failed-turn state restored from this slice's columns.

![Retry recovered the turn](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260820-0dc773/planning-turn-retry-recovered.webp)

After Retry: the reply landed with exactly one copy of the user message, and the preserved System interruption line above it.

Manually inspected: I opened both images myself. The first shows one chat, the transcript's "You" line, a red "Planner was interrupted before it could answer." System line, and the same red error above the composer next to an enabled Retry button. The second shows the full Invoker reply below that System line, a "Waiting for answer" chip, a re-enabled composer, and only one copy of "Plan a tiny README glossary section".

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes. The columns are additive and nullable; reverting returns to response-only delivery.
- Revert command: `git revert 3086fa4e56`
- Post-revert steps: None; existing rows with turn columns are ignored.
- Data migration? No

</details>

Depends-On: #9964

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Planning conversations now track each turn with a unique ID and status.
  * Failed turns can be retried without duplicating the original user message.
  * Turn IDs and failure details are returned with responses and errors.
  * Interrupted planning turns are restored as failed while preserving their interruption message.

* **Bug Fixes**
  * Prevented duplicate turn submissions.
  * Improved persistence and recovery of failed or interrupted planning turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->