### PR TITLE
[Web surface parity](12) Reload-safe planning sends in the composer

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
-import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, PlanningConfirmationMode, PlanningPresetOption, ReviewGateQueryResponse, RuntimeStatus, StartReadyFreshBaseScope, StartReadyRequest, StartReadyResult, TerminalOutputEvent, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
+import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningChatResponse, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InAppPlanningTurnOutcome, InvokerSetupRequest, InvokerSetupResult, PlanningConfirmationMode, PlanningPresetOption, ReviewGateQueryResponse, RuntimeStatus, StartReadyFreshBaseScope, StartReadyRequest, StartReadyResult, TerminalOutputEvent, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import { resolvePlanningSubmitAction } from '@invoker/contracts/planning-surface';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus, WorkerActionSummary, WorkerLogEntry, WorkerStatusEntry } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
@@ -373,7 +373,7 @@ function planningSessionFromSummary(
       tone: line.tone,
     })),
     input: '',
-    busy: false,
+    busy: summary.activeTurnStatus === 'running',
     conversationKey: summary.id,
     mode: summary.terminalMode ?? 'chat',
     terminalSession: restoredTerminalSession,
@@ -445,7 +445,7 @@ function reconcileHydratedPlanningSessions(
     return {
       ...restored,
       input: session.input,
-      busy: session.busy,
+      busy: restored.activeTurnStatus === 'running' ? session.busy : false,
       conversationKey: session.conversationKey,
       mode: session.mode === 'tmux' || restored.mode === 'tmux' ? 'tmux' : restored.mode,
       terminalSession: restored.terminalSession ?? session.terminalSession,
@@ -477,6 +477,10 @@ function planningRepoStatusText(repoUrl: string | undefined, baseCommit: string 
   if (!repoUrl) return 'No repository bound yet';
   const label = planningRepoLabel(repoUrl);
   return baseCommit ? `${label} @ ${baseCommit.slice(0, 7)}` : label;
+}
+
+function newPlanningTurnId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `turn-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
 function previewPlanningMessage(session: PlanningSessionView): string {
@@ -897,6 +901,8 @@ export function App() {
   const [activePlanningSessionId, setActivePlanningSessionId] = useState('local-planning-session-1');
   const nextPlanningSessionLocalIdRef = useRef(2);
   const nextTerminalLineIdRef = useRef(1);
+  const applyTurnOutcomeRef = useRef<(sessionId: string, turnId: string, outcome: InAppPlanningTurnOutcome) => void>(() => {});
+  const planningPollFailureCountRef = useRef(0);
   const [planningStreamBySessionId, setPlanningStreamBySessionId] = useState<Record<string, PlanningStreamState>>({});
   const [planningPresetOptions, setPlanningPresetOptions] = useState<PlanningPresetOption[]>([]);
   const [selectedPlanningPresetKey, setSelectedPlanningPresetKey] = useState('');
@@ -1146,48 +1152,88 @@ export function App() {
     }).catch(() => {});
   }, []);
 
-  useEffect(() => {
-    let cancelled = false;
-    const hydratePlanningSessions = async (): Promise<void> => {
-      const planningChatList = window.invoker?.planningChatList;
-      if (!planningChatList) return;
-      try {
-        const [chatList, terminalList] = await Promise.all([
-          planningChatList(),
-          window.invoker?.planningTerminalList?.().catch(() => [] as TerminalSessionDescriptor[]) ?? Promise.resolve([] as TerminalSessionDescriptor[]),
-        ]);
-        if (cancelled || !chatList.ok || chatList.sessions.length === 0) return;
-        const terminalsByPlanningSession = new Map(
-          terminalList
-            .filter((session) => session.kind === 'planning' && session.planningSessionId)
-            .map((session) => [session.planningSessionId!, session]),
-        );
-        const restored = chatList.sessions.map((summary) => {
-          const liveTerminal = terminalsByPlanningSession.get(summary.id);
-          return liveTerminal
-            ? planningSessionFromSummary(summary, { terminalSession: liveTerminal })
-            : planningSessionFromSummary(summary);
-        });
-        const nextSessions = reconcileHydratedPlanningSessions(planningSessionsRef.current, restored);
-        planningSessionsRef.current = nextSessions;
-        setPlanningSessions(nextSessions);
-        const currentSessionId = activePlanningSessionIdRef.current;
-        const nextActiveSessionId = nextSessions.some((session) => session.id === currentSessionId)
-          ? currentSessionId
-          : nextSessions[0]?.id ?? currentSessionId;
-        activePlanningSessionIdRef.current = nextActiveSessionId;
-        setActivePlanningSessionId(nextActiveSessionId);
-        const maxLineId = Math.max(1, ...restored.flatMap((session) => session.messages.map((message) => message.id)));
-        nextTerminalLineIdRef.current = Math.max(nextTerminalLineIdRef.current, maxLineId + 1);
-      } catch {
-        /* planning chat restore is best-effort */
-      }
-    };
-    void hydratePlanningSessions();
-    return () => {
-      cancelled = true;
-    };
+  const refreshPlanningSessionsNow = useCallback(async (): Promise<boolean> => {
+    const planningChatList = window.invoker?.planningChatList;
+    if (!planningChatList) return false;
+    try {
+      const [chatList, terminalList] = await Promise.all([
+        planningChatList(),
+        window.invoker?.planningTerminalList?.().catch(() => [] as TerminalSessionDescriptor[]) ?? Promise.resolve([] as TerminalSessionDescriptor[]),
+      ]);
+      if (!chatList.ok) return false;
+      if (chatList.sessions.length === 0) return true;
+      const terminalsByPlanningSession = new Map(
+        terminalList
+          .filter((session) => session.kind === 'planning' && session.planningSessionId)
+          .map((session) => [session.planningSessionId!, session]),
+      );
+      const restored = chatList.sessions.map((summary) => {
+        const liveTerminal = terminalsByPlanningSession.get(summary.id);
+        return liveTerminal
+          ? planningSessionFromSummary(summary, { terminalSession: liveTerminal })
+          : planningSessionFromSummary(summary);
+      });
+      // A first send from a local view runs against a backend session whose
+      // id this tab does not know yet. Appending that session as a new row
+      // would duplicate the chat; the response's id-swap adopts it instead.
+      const currentIds = new Set(planningSessionsRef.current.map((session) => session.id));
+      const aliasedBackendIds = new Set(planningStreamSessionAliasesRef.current.keys());
+      const hasBusyLocalView = planningSessionsRef.current.some((session) => session.id.startsWith('local-') && session.busy);
+      const admissibleRestored = restored.filter((session) => {
+        if (currentIds.has(session.id)) return true;
+        if (aliasedBackendIds.has(session.id)) return false;
+        return !(hasBusyLocalView && session.activeTurnStatus === 'running');
+      });
+      const nextSessions = reconcileHydratedPlanningSessions(planningSessionsRef.current, admissibleRestored);
+      planningSessionsRef.current = nextSessions;
+      setPlanningSessions(nextSessions);
+      const currentSessionId = activePlanningSessionIdRef.current;
+      const nextActiveSessionId = nextSessions.some((session) => session.id === currentSessionId)
+        ? currentSessionId
+        : nextSessions[0]?.id ?? currentSessionId;
+      activePlanningSessionIdRef.current = nextActiveSessionId;
+      setActivePlanningSessionId(nextActiveSessionId);
+      const maxLineId = Math.max(1, ...restored.flatMap((session) => session.messages.map((message) => message.id)));
+      nextTerminalLineIdRef.current = Math.max(nextTerminalLineIdRef.current, maxLineId + 1);
+      return true;
+    } catch (err) {
+      console.error('[planning] planning session refresh failed', err);
+      return false;
+    }
   }, []);
+
+  useEffect(() => {
+    void refreshPlanningSessionsNow();
+  }, [refreshPlanningSessionsNow]);
+
+  const anyPlanningSessionBusy = planningSessions.some((session) => session.busy);
+
+  useEffect(() => {
+    if (!anyPlanningSessionBusy) {
+      planningPollFailureCountRef.current = 0;
+      return;
+    }
+    const interval = setInterval(() => {
+      void refreshPlanningSessionsNow().then((refreshed) => {
+        if (refreshed) {
+          planningPollFailureCountRef.current = 0;
+          return;
+        }
+        planningPollFailureCountRef.current += 1;
+        if (planningPollFailureCountRef.current < 3) return;
+        planningPollFailureCountRef.current = 0;
+        for (const session of planningSessionsRef.current) {
+          if (session.busy && session.activeTurnId) {
+            applyTurnOutcomeRef.current(session.id, session.activeTurnId, {
+              status: 'failed',
+              error: 'Lost connection to the planner.',
+            });
+          }
+        }
+      });
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [anyPlanningSessionBusy, refreshPlanningSessionsNow]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -1276,6 +1322,10 @@ export function App() {
   useEffect(() => {
     const unsubscribe = window.invoker?.onPlanningChatStream?.((event) => {
       const sessionId = typeof event.sessionId === 'string' ? event.sessionId.trim() : '';
+      if (sessionId && event.turn && typeof event.turn === 'object' && typeof event.turnId === 'string') {
+        applyTurnOutcomeRef.current(sessionId, event.turnId, event.turn);
+        return;
+      }
       if (!sessionId || typeof event.chunk !== 'string' || !event.chunk) return;
 
       const sessions = planningSessionsRef.current;
@@ -2666,6 +2716,195 @@ export function App() {
     }
   }, [updateActivePlanningSession, updatePlanningSessionById]);
 
+  // The ONLY code path that lands a planning turn result. Response, stream
+  // event, and poll deliveries all funnel through here, so whichever arrives
+  // first wins and the rest are dropped by the activeTurnId guard.
+  const applyPlanningTurnOutcome = useCallback((sessionId: string, turnId: string, outcome: InAppPlanningTurnOutcome) => {
+    const target = planningSessionsRef.current.find((session) => session.id === sessionId)
+      ?? planningSessionsRef.current.find((session) => session.id === planningStreamSessionAliasesRef.current.get(sessionId));
+    if (!target || target.activeTurnId !== turnId) return; // already applied or foreign turn
+    const targetId = target.id;
+    const updatedAt = new Date().toISOString();
+    if (outcome.status === 'completed') {
+      const replyLineId = nextTerminalLineIdRef.current;
+      nextTerminalLineIdRef.current += 1;
+      const applyCompleted = (session: PlanningSessionView): PlanningSessionView => {
+        if (session.id !== targetId) return session;
+        return {
+          ...session,
+          busy: false,
+          activeTurnId: undefined,
+          activeTurnStatus: undefined,
+          activeTurnError: undefined,
+          confirmationMode: outcome.confirmationMode ?? session.confirmationMode ?? 'require',
+          status: outcome.draftPlanAvailable ? 'draft_ready' : outcome.reply.includes('?') ? 'waiting_for_answer' : 'still_discussing',
+          messages: [...session.messages, {
+            id: replyLineId,
+            text: outcome.reply,
+            role: 'assistant' as const,
+            ...(outcome.reasoning ? { reasoning: outcome.reasoning } : {}),
+          }],
+          draftPlanAvailable: outcome.draftPlanAvailable,
+          draftPlanSummary: outcome.draftPlanAvailable ? outcome.draftPlanSummary : undefined,
+          draftPlanText: outcome.draftPlanAvailable ? outcome.draftPlanText : undefined,
+          updatedAt,
+        };
+      };
+      // Sync the ref immediately: a second delivery of the same outcome can
+      // arrive before the render commits, and the guard reads the ref.
+      planningSessionsRef.current = planningSessionsRef.current.map(applyCompleted);
+      setPlanningSessions((prev) => prev.map(applyCompleted));
+      clearPlanningStreamForSessionIds([sessionId, targetId]);
+      forgetPlanningStreamAliasesForSessionIds([sessionId, targetId]);
+      pendingPlanningStreamSessionIdsRef.current.delete(sessionId);
+      pendingPlanningStreamSessionIdsRef.current.delete(targetId);
+      setHasLoadedPlan(false);
+      setKeptPlanningDraftSessionIds((prev) => {
+        const next = new Set(prev);
+        next.delete(sessionId);
+        next.delete(targetId);
+        return next;
+      });
+      if (outcome.draftPlanAvailable) {
+        setReviewDraftSessionId(targetId);
+        setPlanningContextCollapsed(false);
+      }
+      return;
+    }
+    const applyFailed = (session: PlanningSessionView): PlanningSessionView => (
+      session.id === targetId
+        ? { ...session, busy: false, activeTurnStatus: 'failed' as const, activeTurnError: outcome.error, updatedAt }
+        : session
+    );
+    planningSessionsRef.current = planningSessionsRef.current.map(applyFailed);
+    setPlanningSessions((prev) => prev.map(applyFailed));
+    clearPlanningStreamForSessionIds([sessionId, targetId]);
+    forgetPlanningStreamAliasesForSessionIds([sessionId, targetId]);
+    pendingPlanningStreamSessionIdsRef.current.delete(sessionId);
+    pendingPlanningStreamSessionIdsRef.current.delete(targetId);
+  }, [clearPlanningStreamForSessionIds, forgetPlanningStreamAliasesForSessionIds]);
+
+  useEffect(() => {
+    applyTurnOutcomeRef.current = applyPlanningTurnOutcome;
+  }, [applyPlanningTurnOutcome]);
+
+  const markPlanningTurnRunning = useCallback((sessionId: string, turnId: string) => {
+    const markRunning = (session: PlanningSessionView): PlanningSessionView => (
+      session.id === sessionId
+        ? { ...session, busy: true, activeTurnId: turnId, activeTurnStatus: 'running' as const, activeTurnError: undefined }
+        : session
+    );
+    // Sync the ref immediately: a response can resolve before the render
+    // commits, and applyPlanningTurnOutcome's guard reads the ref.
+    planningSessionsRef.current = planningSessionsRef.current.map(markRunning);
+    setPlanningSessions((prev) => prev.map(markRunning));
+  }, []);
+
+  const handlePlanningSendResult = useCallback((
+    previousSessionId: string,
+    turnId: string,
+    result: InAppPlanningChatResponse,
+    options: { inputForTitle?: string; presetKey?: string } = {},
+  ) => {
+    if (result.ok) {
+      const swapId = (session: PlanningSessionView): PlanningSessionView => {
+        if (session.id !== previousSessionId) return session;
+        return {
+          ...session,
+          id: result.sessionId,
+          title: session.title === 'Untitled plan' && options.inputForTitle
+            ? (options.inputForTitle.length > 56 ? `${options.inputForTitle.slice(0, 53).trimEnd()}…` : options.inputForTitle)
+            : session.title,
+          presetKey: options.presetKey ?? session.presetKey,
+        };
+      };
+      // Drop a row the busy poll may have appended for the same backend
+      // session, then swap the in-flight view onto the backend id. Sync the
+      // refs immediately so applyPlanningTurnOutcome finds the swapped id
+      // before the next render commits.
+      const dedupeAndSwap = (sessions: PlanningSessionView[]): PlanningSessionView[] => (
+        sessions.some((session) => session.id === previousSessionId)
+          ? sessions
+              .filter((session) => session.id === previousSessionId || session.id !== result.sessionId)
+              .map(swapId)
+          : sessions
+      );
+      planningSessionsRef.current = dedupeAndSwap(planningSessionsRef.current);
+      activePlanningSessionIdRef.current = activePlanningSessionIdRef.current === previousSessionId
+        ? result.sessionId
+        : activePlanningSessionIdRef.current;
+      setPlanningSessions((prev) => dedupeAndSwap(prev));
+      setActivePlanningSessionId((currentSessionId) => (
+        currentSessionId === previousSessionId ? result.sessionId : currentSessionId
+      ));
+      applyPlanningTurnOutcome(result.sessionId, turnId, {
+        status: 'completed',
+        reply: result.reply,
+        reasoning: (result as { reasoning?: string }).reasoning,
+        confirmationMode: result.confirmationMode,
+        draftPlanAvailable: result.draftPlanAvailable,
+        draftPlanSummary: result.draftPlanSummary,
+        draftPlanText: result.draftPlanText,
+      });
+      return;
+    }
+    if (result.error === 'duplicate-turn') {
+      // The original request's outcome will land via response, event, or poll.
+      return;
+    }
+    if (result.turnId === turnId) {
+      if (result.sessionId && result.sessionId !== previousSessionId) {
+        const failedSessionId = result.sessionId;
+        const dedupeAndSwap = (sessions: PlanningSessionView[]): PlanningSessionView[] => (
+          sessions.some((session) => session.id === previousSessionId)
+            ? sessions.filter((session) => session.id !== failedSessionId).map((session) => (
+                session.id === previousSessionId ? { ...session, id: failedSessionId } : session
+              ))
+            : sessions
+        );
+        planningSessionsRef.current = dedupeAndSwap(planningSessionsRef.current);
+        activePlanningSessionIdRef.current = activePlanningSessionIdRef.current === previousSessionId
+          ? failedSessionId
+          : activePlanningSessionIdRef.current;
+        setPlanningSessions((prev) => dedupeAndSwap(prev));
+        setActivePlanningSessionId((currentSessionId) => (
+          currentSessionId === previousSessionId ? failedSessionId : currentSessionId
+        ));
+      }
+      applyPlanningTurnOutcome(result.sessionId ?? previousSessionId, turnId, { status: 'failed', error: result.error });
+      return;
+    }
+    // Pre-turn failures without our turnId keep the error-line + modal path.
+    updatePlanningSessionById(previousSessionId, (session) => ({
+      ...session,
+      busy: false,
+      activeTurnId: undefined,
+      activeTurnStatus: undefined,
+      activeTurnError: undefined,
+    }));
+    keepPlanningStreamFailureForSessionIds([previousSessionId, result.sessionId], result.error);
+    forgetPlanningStreamAliasesForSessionIds([previousSessionId, result.sessionId]);
+    pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
+    if (result.sessionId) pendingPlanningStreamSessionIdsRef.current.delete(result.sessionId);
+    appendTerminalLine(result.error, 'system', 'error', previousSessionId);
+    if (result.sessionId) {
+      const failedSessionId = result.sessionId;
+      setPlanningSessions((prev) => prev.map((session) => (
+        session.id === previousSessionId ? { ...session, id: failedSessionId } : session
+      )));
+      setActivePlanningSessionId((currentSessionId) => (
+        currentSessionId === previousSessionId ? failedSessionId : currentSessionId
+      ));
+    }
+    setPlanningSubmitError({ title: 'Planner could not respond', message: result.error });
+  }, [
+    applyPlanningTurnOutcome,
+    appendTerminalLine,
+    forgetPlanningStreamAliasesForSessionIds,
+    keepPlanningStreamFailureForSessionIds,
+    updatePlanningSessionById,
+  ]);
+
   const handleStartReadyAction = useCallback(async (
     request: StartReadyRequest = {},
   ): Promise<StartReadyResult | null> => {
@@ -3047,89 +3286,27 @@ export function App() {
       return;
     }
 
+    const turnId = newPlanningTurnId();
     const request = {
       message: input,
       presetKey: selectedPlanningPresetKey || undefined,
       confirmationMode: selectedPlanningConfirmationMode,
+      turnId,
       ...(sendSessionId ? { sessionId: sendSessionId } : {}),
     };
     const previousSessionId = activeViewId;
     pendingPlanningStreamSessionIdsRef.current.add(previousSessionId);
     clearPlanningStreamForSessionIds([previousSessionId, sendSessionId]);
     forgetPlanningStreamAliasesForSessionIds([previousSessionId, sendSessionId]);
-    updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: true }));
+    markPlanningTurnRunning(previousSessionId, turnId);
     try {
       const result = await invoker.planningChatSend(request);
-      if (result.ok) {
-        const updatedAt = new Date().toISOString();
-        const replyLineId = nextTerminalLineIdRef.current;
-        nextTerminalLineIdRef.current += 1;
-        setPlanningSessions((prev) => prev.map((session) => {
-          if (session.id !== previousSessionId) return session;
-          return {
-            ...session,
-            busy: false,
-            id: result.sessionId,
-            title: session.title === 'Untitled plan'
-              ? (input.length > 56 ? `${input.slice(0, 53).trimEnd()}…` : input)
-              : session.title,
-            presetKey: request.presetKey ?? session.presetKey,
-            confirmationMode: result.confirmationMode ?? session.confirmationMode ?? 'require',
-            status: result.draftPlanAvailable ? 'draft_ready' : result.reply.includes('?') ? 'waiting_for_answer' : 'still_discussing',
-            messages: [...session.messages, { id: replyLineId, text: result.reply, role: 'assistant', ...((result as { reasoning?: string }).reasoning ? { reasoning: (result as { reasoning?: string }).reasoning } : {}) }],
-            draftPlanAvailable: result.draftPlanAvailable,
-            draftPlanSummary: result.draftPlanAvailable ? result.draftPlanSummary : undefined,
-            draftPlanText: result.draftPlanAvailable ? result.draftPlanText : undefined,
-            updatedAt,
-          };
-        }));
-        setActivePlanningSessionId((currentSessionId) => (
-          currentSessionId === previousSessionId ? result.sessionId : currentSessionId
-        ));
-        clearPlanningStreamForSessionIds([previousSessionId, result.sessionId]);
-        forgetPlanningStreamAliasesForSessionIds([previousSessionId, result.sessionId]);
-        pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
-        pendingPlanningStreamSessionIdsRef.current.delete(result.sessionId);
-        setHasLoadedPlan(false);
-        setKeptPlanningDraftSessionIds((prev) => {
-          const next = new Set(prev);
-          next.delete(previousSessionId);
-          next.delete(result.sessionId);
-          return next;
-        });
-        if (result.draftPlanAvailable) {
-          setReviewDraftSessionId(result.sessionId);
-          setPlanningContextCollapsed(false);
-        }
-      } else {
-        updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: false }));
-        keepPlanningStreamFailureForSessionIds([previousSessionId, result.sessionId], result.error);
-        forgetPlanningStreamAliasesForSessionIds([previousSessionId, result.sessionId]);
-        pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
-        if (result.sessionId) pendingPlanningStreamSessionIdsRef.current.delete(result.sessionId);
-        appendTerminalLine(result.error, 'system', 'error', previousSessionId);
-        if (result.sessionId) {
-          const failedSessionId = result.sessionId;
-          setPlanningSessions((prev) => prev.map((session) => (
-            session.id === previousSessionId
-              ? { ...session, id: failedSessionId }
-              : session
-          )));
-          setActivePlanningSessionId((currentSessionId) => (
-            currentSessionId === previousSessionId ? failedSessionId : currentSessionId
-          ));
-        }
-        setPlanningSubmitError({ title: 'Planner could not respond', message: result.error });
-      }
+      handlePlanningSendResult(previousSessionId, turnId, result, { inputForTitle: input, presetKey: request.presetKey });
     } catch (err) {
-      updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: false }));
-      const message = err instanceof Error ? err.message : 'Failed to reach the planner.';
-      keepPlanningStreamFailureForSessionIds([previousSessionId, sendSessionId], message);
-      forgetPlanningStreamAliasesForSessionIds([previousSessionId, sendSessionId]);
-      pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
-      if (sendSessionId) pendingPlanningStreamSessionIdsRef.current.delete(sendSessionId);
-      setPlanningSubmitError({ title: 'Planner could not respond', message });
-      appendTerminalLine(message, 'system', 'error', previousSessionId);
+      // Keep the turn marked running: recovery rides the busy poll, which
+      // either observes the finished turn or fails it after 3 missed polls.
+      console.error('[planning] planningChatSend transport failure', err);
+      void refreshPlanningSessionsNow();
     }
   }, [
     activePlanningSessionBusy,
@@ -3140,11 +3317,13 @@ export function App() {
     commitPlanningRepo,
     clearPlanningStreamForSessionIds,
     forgetPlanningStreamAliasesForSessionIds,
+    handlePlanningSendResult,
     handlePlanningSubmitDraft,
     handleStartReadyAction,
     hasLoadedPlan,
-    keepPlanningStreamFailureForSessionIds,
     invoker,
+    markPlanningTurnRunning,
+    refreshPlanningSessionsNow,
     activePlanningSession.draftPlanAvailable,
     activePlanningSession.messages.length,
     activePlanningSession.repoInput,
@@ -3158,6 +3337,39 @@ export function App() {
     tasks.size,
     updatePlanningSessionById,
     workflows.size,
+  ]);
+
+  const handleRetryPlanningTurn = useCallback(async () => {
+    const session = activePlanningSession;
+    if (session.activeTurnStatus !== 'failed' || !session.activeTurnId || session.busy) return;
+    const lastUserLine = [...session.messages].reverse().find((line) => line.role === 'user');
+    if (!lastUserLine || !invoker?.planningChatSend) return;
+    const turnId = session.activeTurnId;
+    const previousSessionId = session.id;
+    markPlanningTurnRunning(previousSessionId, turnId);
+    try {
+      const result = await invoker.planningChatSend({
+        ...(previousSessionId.startsWith('local-') ? {} : { sessionId: previousSessionId }),
+        turnId,
+        message: lastUserLine.text,
+        presetKey: selectedPlanningPresetKey || undefined,
+        confirmationMode: selectedPlanningConfirmationMode,
+      });
+      handlePlanningSendResult(previousSessionId, turnId, result);
+    } catch (err) {
+      // Same recovery contract as handlePlanningSubmit's catch: stay busy,
+      // let the poll observe the turn or fail it after 3 missed polls.
+      console.error('[planning] planningChatSend retry transport failure', err);
+      void refreshPlanningSessionsNow();
+    }
+  }, [
+    activePlanningSession,
+    handlePlanningSendResult,
+    invoker,
+    markPlanningTurnRunning,
+    refreshPlanningSessionsNow,
+    selectedPlanningConfirmationMode,
+    selectedPlanningPresetKey,
   ]);
 
   const makeFreshLocalPlanningSession = useCallback((): PlanningSessionView => {
@@ -4846,6 +5058,8 @@ export function App() {
             repoLocked={activePlanningRepoLocked}
             repoSuggestions={planningRepoSuggestions}
             repoError={activePlanningSession.repoError ?? null}
+            turnError={activePlanningSession.activeTurnStatus === 'failed' ? activePlanningSession.activeTurnError ?? 'The planner turn failed.' : null}
+            onRetryTurn={() => void handleRetryPlanningTurn()}
             onValueChange={setPlanningInput}
             onSubmit={() => void handlePlanningSubmit()}
             onPresetChange={handlePlanningPresetChange}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -893,24 +893,31 @@ export function App() {
       planningPollFailureCountRef.current = 0;
       return;
     }
+    let inFlight = false;
     const interval = setInterval(() => {
-      void refreshPlanningSessionsNow().then((refreshed) => {
-        if (refreshed) {
-          planningPollFailureCountRef.current = 0;
-          return;
-        }
-        planningPollFailureCountRef.current += 1;
-        if (planningPollFailureCountRef.current < 3) return;
-        planningPollFailureCountRef.current = 0;
-        for (const session of planningSessionsRef.current) {
-          if (session.busy && session.activeTurnId) {
-            applyTurnOutcomeRef.current(session.id, session.activeTurnId, {
-              status: 'failed',
-              error: 'Lost connection to the planner.',
-            });
+      if (inFlight) return;
+      inFlight = true;
+      void refreshPlanningSessionsNow()
+        .then((refreshed) => {
+          if (refreshed) {
+            planningPollFailureCountRef.current = 0;
+            return;
           }
-        }
-      });
+          planningPollFailureCountRef.current += 1;
+          if (planningPollFailureCountRef.current < 3) return;
+          planningPollFailureCountRef.current = 0;
+          for (const session of planningSessionsRef.current) {
+            if (session.busy && session.activeTurnId) {
+              applyTurnOutcomeRef.current(session.id, session.activeTurnId, {
+                status: 'failed',
+                error: 'Lost connection to the planner.',
+              });
+            }
+          }
+        })
+        .finally(() => {
+          inFlight = false;
+        });
     }, 5000);
     return () => clearInterval(interval);
   }, [anyPlanningSessionBusy, refreshPlanningSessionsNow]);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -64,6 +64,7 @@ import {
 import {
   isInitialPlanningSessionPlaceholder,
   makeInitialPlanningSession,
+  maxPlanningMessageId,
   newPlanningTurnId,
   planningNeedsAttention,
   planningRepoStatusText,
@@ -799,7 +800,7 @@ export function App() {
         const restored = response.sessions.map(planningSessionSummaryToView);
         const nextSessions = reconcileHydratedPlanningSessions(currentSessions, restored);
         if (nextSessions === currentSessions) return;
-        const maxLineId = Math.max(1, ...restored.flatMap((session) => session.messages.map((message) => message.id)));
+        const maxLineId = maxPlanningMessageId(restored);
         nextTerminalLineIdRef.current = Math.max(nextTerminalLineIdRef.current, maxLineId + 1);
         planningSessionsRef.current = nextSessions;
         setPlanningSessions(nextSessions);
@@ -872,7 +873,7 @@ export function App() {
         : nextSessions[0]?.id ?? currentSessionId;
       activePlanningSessionIdRef.current = nextActiveSessionId;
       setActivePlanningSessionId(nextActiveSessionId);
-      const maxLineId = Math.max(1, ...restored.flatMap((session) => session.messages.map((message) => message.id)));
+      const maxLineId = maxPlanningMessageId(restored);
       nextTerminalLineIdRef.current = Math.max(nextTerminalLineIdRef.current, maxLineId + 1);
       return true;
     } catch (err) {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
-import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningChatResponse, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InAppPlanningTurnOutcome, InvokerSetupRequest, InvokerSetupResult, PlanningConfirmationMode, PlanningPresetOption, ReviewGateQueryResponse, RuntimeStatus, StartReadyFreshBaseScope, StartReadyRequest, StartReadyResult, TerminalOutputEvent, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
+import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningChatResponse, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InAppPlanningTurnOutcome, InvokerSetupRequest, InvokerSetupResult, PlanningConfirmationMode, PlanningPresetOption, ReviewGateQueryResponse, RuntimeStatus, StartReadyRequest, StartReadyResult, TerminalOutputEvent, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import { resolvePlanningSubmitAction } from '@invoker/contracts/planning-surface';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus, WorkerActionSummary, WorkerLogEntry, WorkerStatusEntry } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
@@ -52,6 +52,30 @@ import { KeepMounted } from './components/KeepMounted.js';
 import { LeftStatusColumn } from './components/LeftStatusColumn.js';
 import { BrowserTaskRow, BrowserWorkflowRow } from './components/BrowserListRows.js';
 import { useTheme } from './lib/theme.js';
+import {
+  freshBaseModeHasVisibleTargets,
+  getStartReadyRailMode,
+  isPendingOrQueuedStatus,
+  START_READY_RAIL_MODES,
+  startReadyPreviewRows,
+  startReadyRequestForMode,
+  type StartReadyRailModeId,
+} from './lib/start-ready-rail-modes.js';
+import {
+  isInitialPlanningSessionPlaceholder,
+  makeInitialPlanningSession,
+  newPlanningTurnId,
+  planningNeedsAttention,
+  planningRepoStatusText,
+  planningSessionFromSummary,
+  planningSessionStatusLabel,
+  planningSessionSummaryToView,
+  previewPlanningMessage,
+  reconcileHydratedPlanningSessions,
+  relativePlanningUpdatedAt,
+  type PlanningSessionView,
+  type PlanningStreamState,
+} from './lib/planning-session-view.js';
 import { InvokerTerminal, type InvokerTerminalLine, type PlanningTerminalMode } from './components/InvokerTerminal.js';
 import { WorkflowContextMenu, type ContextMenuCloseOptions } from './components/WorkflowContextMenu.js';
 import { Toaster, toast } from 'sonner';
@@ -166,351 +190,6 @@ function formatCount(count: number, singular: string, plural = `${singular}s`): 
   return `${count} ${count === 1 ? singular : plural}`;
 }
 
-type StartReadyRailModeId =
-  | 'recreateFailed'
-  | 'recreateFailedAndPending'
-  | 'recreateFailedPendingAndRunning'
-  | 'freshBaseFailed'
-  | 'freshBaseFailedAndPending'
-  | 'freshBaseFailedPendingAndRunning';
-
-type StartReadyRailMode = {
-  id: StartReadyRailModeId;
-  kind: 'recreate' | 'freshBase';
-  testId: string;
-  label: string;
-  title: string;
-  confirmLabel: string;
-  request: StartReadyRequest;
-  includesPending: boolean;
-  includesRunning: boolean;
-  freshBaseScope?: StartReadyFreshBaseScope;
-};
-
-const START_READY_RAIL_MODES: readonly StartReadyRailMode[] = [
-  {
-    id: 'recreateFailed',
-    kind: 'recreate',
-    testId: 'rail-start-ready-recreate-failed',
-    label: 'Start and recreate failed…',
-    title: 'Start and recreate failed',
-    confirmLabel: 'Start and recreate',
-    request: { recreateFailed: true },
-    includesPending: false,
-    includesRunning: false,
-  },
-  {
-    id: 'recreateFailedAndPending',
-    kind: 'recreate',
-    testId: 'rail-start-ready-recreate-failed-and-pending',
-    label: 'Start and recreate failed and pending…',
-    title: 'Start and recreate failed and pending',
-    confirmLabel: 'Start and recreate',
-    request: { recreateFailedAndPending: true },
-    includesPending: true,
-    includesRunning: false,
-  },
-  {
-    id: 'recreateFailedPendingAndRunning',
-    kind: 'recreate',
-    testId: 'rail-start-ready-recreate-failed-pending-and-running',
-    label: 'Start and recreate failed, pending, and running…',
-    title: 'Start and recreate failed, pending, and running',
-    confirmLabel: 'Start and recreate',
-    request: { recreateFailedPendingAndRunning: true },
-    includesPending: true,
-    includesRunning: true,
-  },
-  {
-    id: 'freshBaseFailed',
-    kind: 'freshBase',
-    testId: 'rail-start-ready-fresh-base-failed',
-    label: 'Recreate failed from fresh base…',
-    title: 'Start and recreate failed from fresh base',
-    confirmLabel: 'Start and recreate from fresh base',
-    request: { freshBaseScope: 'failed' },
-    includesPending: false,
-    includesRunning: false,
-    freshBaseScope: 'failed',
-  },
-  {
-    id: 'freshBaseFailedAndPending',
-    kind: 'freshBase',
-    testId: 'rail-start-ready-fresh-base-failed-and-pending',
-    label: 'Recreate failed and pending from fresh base…',
-    title: 'Start and recreate failed and pending from fresh base',
-    confirmLabel: 'Start and recreate from fresh base',
-    request: { freshBaseScope: 'failed-and-pending' },
-    includesPending: true,
-    includesRunning: false,
-    freshBaseScope: 'failed-and-pending',
-  },
-  {
-    id: 'freshBaseFailedPendingAndRunning',
-    kind: 'freshBase',
-    testId: 'rail-start-ready-fresh-base-failed-pending-and-running',
-    label: 'Recreate failed, pending, and running from fresh base…',
-    title: 'Start and recreate failed, pending, and running from fresh base',
-    confirmLabel: 'Start and recreate from fresh base',
-    request: { freshBaseScope: 'failed-pending-and-running' },
-    includesPending: true,
-    includesRunning: true,
-    freshBaseScope: 'failed-pending-and-running',
-  },
-];
-
-const START_READY_RAIL_MODE_BY_ID = new Map(
-  START_READY_RAIL_MODES.map((mode) => [mode.id, mode]),
-);
-
-function getStartReadyRailMode(id: StartReadyRailModeId): StartReadyRailMode {
-  return START_READY_RAIL_MODE_BY_ID.get(id) ?? START_READY_RAIL_MODES[0];
-}
-
-function startReadyRequestForMode(mode: StartReadyRailMode, dryRun = false): StartReadyRequest {
-  return dryRun ? { dryRun: true, ...mode.request } : { ...mode.request };
-}
-
-function isPendingOrQueuedStatus(status: TaskState['status']): boolean {
-  return status === 'pending' || (status as string) === 'queued';
-}
-
-function freshBaseModeHasVisibleTargets(
-  mode: StartReadyRailMode,
-  targetCounts: { failed: number; pending: number; running: number },
-): boolean {
-  if (mode.kind !== 'freshBase') return true;
-  switch (mode.freshBaseScope) {
-    case 'failed':
-      return targetCounts.failed > 0;
-    case 'failed-and-pending':
-      return targetCounts.pending > 0;
-    case 'failed-pending-and-running':
-      return targetCounts.running > 0;
-    default:
-      return false;
-  }
-}
-
-function startReadyPreviewRows(mode: StartReadyRailMode, result: StartReadyResult): Array<[string, number]> {
-  const rows: Array<[string, number]> = [
-    ['Ready tasks', result.preview.readyTaskIds.length],
-    ['Recoverable tasks', result.preview.recoverableTaskIds.length],
-    ['Failed workflows', result.preview.failedWorkflowIds.length],
-  ];
-
-  if (mode.includesPending) {
-    rows.push(
-      ['Pending workflows', result.preview.pendingWorkflowIds.length],
-      ['Pending tasks', result.preview.skipped.pendingTasks],
-    );
-  }
-  if (mode.includesRunning) {
-    rows.push(
-      ['Running workflows', result.preview.runningWorkflowIds.length],
-      ['Running tasks', result.preview.skipped.runningTasks],
-    );
-  }
-  if (mode.kind === 'freshBase' && result.preview.freshBase) {
-    rows.push(
-      ['Fresh-base workflows', result.preview.freshBase.workflowIds.length],
-      ['Fresh-base failed workflows', result.preview.freshBase.failedWorkflowIds.length],
-    );
-    if (mode.includesPending) {
-      rows.push(['Fresh-base pending workflows', result.preview.freshBase.pendingWorkflowIds.length]);
-    }
-    if (mode.includesRunning) {
-      rows.push(['Fresh-base running workflows', result.preview.freshBase.runningWorkflowIds.length]);
-    }
-  }
-
-  rows.push(
-    ['Awaiting approval', result.preview.skipped.awaitingApproval],
-    ['Review ready', result.preview.skipped.reviewReady],
-    ['Blocked', result.preview.skipped.blocked],
-  );
-  return rows;
-}
-type PlanningSessionView = Omit<InAppPlanningSessionSummary, 'messages'> & {
-  messages: InvokerTerminalLine[];
-  input: string;
-  busy: boolean;
-  conversationKey: string;
-  mode: PlanningTerminalMode;
-  terminalSession?: TerminalSessionDescriptor | null;
-  terminalBusy?: boolean;
-  terminalError?: string | null;
-  repoInput?: string;
-  repoError?: string | null;
-};
-
-function planningSessionFromSummary(
-  summary: InAppPlanningSessionSummary,
-  overrides: Partial<PlanningSessionView> = {},
-): PlanningSessionView {
-  const restoredTerminalSession = summary.terminalSessionId
-    && (summary.terminalStatus === 'running' || summary.terminalStatus === 'exited')
-    ? {
-        sessionId: summary.terminalSessionId,
-        taskId: `planning:${summary.id}`,
-        kind: 'planning' as const,
-        planningSessionId: summary.id,
-        status: summary.terminalStatus,
-        exitCode: summary.terminalExitCode,
-        cwd: undefined,
-        mode: 'spawn' as const,
-        attached: false,
-        createdAt: summary.terminalUpdatedAt ?? summary.updatedAt,
-        outputSnapshot: summary.terminalOutputSnapshot ?? '',
-      }
-    : null;
-  return {
-    ...summary,
-    messages: summary.messages.map((line) => ({
-      id: line.id,
-      text: line.text,
-      role: line.role,
-      tone: line.tone,
-    })),
-    input: '',
-    busy: summary.activeTurnStatus === 'running',
-    conversationKey: summary.id,
-    mode: summary.terminalMode ?? 'chat',
-    terminalSession: restoredTerminalSession,
-    terminalBusy: false,
-    terminalError: null,
-    ...overrides,
-  };
-}
-
-type PlanningStreamState = {
-  text: string;
-  status: 'streaming' | 'failed';
-};
-
-function makeInitialPlanningSession(
-  now: string = new Date().toISOString(),
-  confirmationMode: PlanningConfirmationMode = 'require',
-): PlanningSessionView {
-  return {
-    id: 'local-planning-session-1',
-    title: 'Untitled plan',
-    status: 'still_discussing',
-    presetKey: '',
-    confirmationMode,
-    messages: [],
-    input: '',
-    draftPlanAvailable: false,
-    busy: false,
-    createdAt: now,
-    updatedAt: now,
-    conversationKey: 'local-planning-session-1',
-    mode: 'chat',
-    terminalSession: null,
-    terminalBusy: false,
-    terminalError: null,
-  };
-}
-
-function isInitialPlanningSessionPlaceholder(session: PlanningSessionView | undefined): boolean {
-  if (!session) return false;
-  return session.id === 'local-planning-session-1'
-    && session.title === 'Untitled plan'
-    && session.input === ''
-    && !session.busy
-    && session.messages.length === 0
-    && !session.draftPlanAvailable
-    && !session.terminalSession
-    && !session.terminalBusy
-    && !session.terminalError;
-}
-
-function reconcileHydratedPlanningSessions(
-  currentSessions: PlanningSessionView[],
-  restoredSessions: PlanningSessionView[],
-): PlanningSessionView[] {
-  if (restoredSessions.length === 0) return currentSessions;
-  if (
-    currentSessions.length === 0
-    || (currentSessions.length === 1 && isInitialPlanningSessionPlaceholder(currentSessions[0]))
-  ) {
-    return restoredSessions;
-  }
-
-  const restoredById = new Map(restoredSessions.map((session) => [session.id, session]));
-  const currentIds = new Set(currentSessions.map((session) => session.id));
-  const mergedCurrentSessions = currentSessions.map((session) => {
-    const restored = restoredById.get(session.id);
-    if (!restored) return session;
-    return {
-      ...restored,
-      input: session.input,
-      busy: restored.activeTurnStatus === 'running' ? session.busy : false,
-      conversationKey: session.conversationKey,
-      mode: session.mode === 'tmux' || restored.mode === 'tmux' ? 'tmux' : restored.mode,
-      terminalSession: restored.terminalSession ?? session.terminalSession,
-      terminalBusy: restored.terminalSession ? false : session.terminalBusy,
-      terminalError: restored.terminalSession ? null : session.terminalError,
-      repoInput: session.repoInput,
-      repoError: session.repoError,
-    };
-  });
-  const newRestoredSessions = restoredSessions.filter((session) => !currentIds.has(session.id));
-  return [...mergedCurrentSessions, ...newRestoredSessions];
-}
-
-function planningSessionSummaryToView(session: InAppPlanningSessionSummary): PlanningSessionView {
-  return planningSessionFromSummary(session);
-}
-
-function planningNeedsAttention(status: InAppPlanningSessionStatus): boolean {
-  return status === 'waiting_for_answer' || status === 'draft_ready';
-}
-
-function planningRepoLabel(repoUrl: string): string {
-  const trimmed = repoUrl.trim().replace(/\.git$/, '');
-  const segments = trimmed.split(/[/:]/).filter(Boolean);
-  return segments.length >= 2 ? segments.slice(-2).join('/') : (segments.at(-1) ?? trimmed);
-}
-
-function planningRepoStatusText(repoUrl: string | undefined, baseCommit: string | undefined): string {
-  if (!repoUrl) return 'No repository bound yet';
-  const label = planningRepoLabel(repoUrl);
-  return baseCommit ? `${label} @ ${baseCommit.slice(0, 7)}` : label;
-}
-
-function newPlanningTurnId(): string {
-  return globalThis.crypto?.randomUUID?.() ?? `turn-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-}
-
-function previewPlanningMessage(session: PlanningSessionView): string {
-  const last = [...session.messages].reverse().find((line) => line.role !== 'system') ?? session.messages.at(-1);
-  return last?.text.replace(/\s+/g, ' ').trim() || 'No messages yet';
-}
-
-function planningSessionStatusLabel(session: PlanningSessionView): string {
-  if (session.busy) return 'Working';
-  if (session.status === 'draft_ready') return 'Draft ready';
-  if (session.status === 'waiting_for_answer') return 'Waiting for answer';
-  if (session.status === 'submitted') return 'Submitted';
-  return 'Still discussing';
-}
-
-function relativePlanningUpdatedAt(value: string): string {
-  const timestamp = Date.parse(value);
-  if (!Number.isFinite(timestamp)) return 'now';
-  const seconds = Math.max(0, Math.round((Date.now() - timestamp) / 1000));
-  if (seconds < 60) return 'now';
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) return `${minutes}m`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 24) return `${hours}h`;
-  const days = Math.round(hours / 24);
-  if (days < 30) return `${days}d`;
-  const months = Math.round(days / 30);
-  if (months < 12) return `${months}mo`;
-  return `${Math.round(months / 12)}y`;
-}
 const PLANNING_TYPING_LAG_METRIC = 'planning_typing_lag_baseline';
 const PLANNING_TYPING_SCENARIO = 'many-chats-many-messages-typing';
 

--- a/packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx
@@ -51,7 +51,7 @@ describe('CodeRabbit PR #3050 — Enter-to-submit ignores IME composition', () =
     // A subsequent plain Enter (composition finished) submits normally.
     fireEvent.keyDown(input, { key: 'Enter' });
     await waitFor(() => {
-      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'こんにちは', presetKey: 'codex', confirmationMode: 'require' });
+      expect(vi.mocked(mock.api.planningChatSend)).toHaveBeenCalledWith({ turnId: expect.any(String), message: 'こんにちは', presetKey: 'codex', confirmationMode: 'require' });
     });
   });
 });

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -212,9 +212,10 @@ export function createMockInvoker(
       },
     })),
     planningChatList: vi.fn(async () => ({ ok: true, sessions: [] })),
-    planningChatSend: vi.fn(async () => ({
+    planningChatSend: vi.fn(async (request?: { turnId?: string }) => ({
       ok: true,
       sessionId: 'session-1',
+      turnId: request?.turnId,
       reply: 'I can help draft that.',
       confirmationMode: 'require',
       draftPlanAvailable: false,

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -385,6 +385,30 @@ describe('Invoker terminal (component)', () => {
     expect(screen.queryByTestId('invoker-terminal-model')).not.toBeInTheDocument();
   });
 
+  it('announces the turn error and only renders Retry when a handler is provided', () => {
+    const { rerender } = render(<InvokerTerminal
+      {...terminalProps({
+        turnError: 'Planner was interrupted before it could answer.',
+      })}
+    />);
+
+    const errorBar = screen.getByTestId('invoker-terminal-turn-error');
+    expect(errorBar).toHaveAttribute('role', 'alert');
+    expect(errorBar).toHaveTextContent('Planner was interrupted before it could answer.');
+    expect(screen.queryByTestId('invoker-terminal-retry-turn')).not.toBeInTheDocument();
+
+    const onRetryTurn = vi.fn();
+    rerender(<InvokerTerminal
+      {...terminalProps({
+        turnError: 'Planner was interrupted before it could answer.',
+        onRetryTurn,
+      })}
+    />);
+
+    fireEvent.click(screen.getByTestId('invoker-terminal-retry-turn'));
+    expect(onRetryTurn).toHaveBeenCalledTimes(1);
+  });
+
   it('preserves a still-valid model when switching harnesses', () => {
     const onPresetChange = vi.fn();
     render(<InvokerTerminal

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -747,7 +747,7 @@ describe('Invoker terminal (component)', () => {
     submitPlanningText('hello');
 
     await waitFor(() => {
-      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'hello', presetKey: 'codex', confirmationMode: 'require' });
+      expect(vi.mocked(mock.api.planningChatSend)).toHaveBeenCalledWith({ turnId: expect.any(String), message: 'hello', presetKey: 'codex', confirmationMode: 'require' });
       expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('I can help draft that.');
     });
     expect(screen.queryByText(/Unknown command/)).not.toBeInTheDocument();
@@ -828,6 +828,7 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledTimes(2);
       expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
+        turnId: expect.any(String),
         sessionId: 'session-1',
         message: 'try again',
         presetKey: 'codex',
@@ -1038,7 +1039,7 @@ describe('Invoker terminal (component)', () => {
     fireEvent.keyDown(input, { key: 'Enter' });
 
     await waitFor(() => {
-      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'hello', presetKey: 'codex', confirmationMode: 'require' });
+      expect(vi.mocked(mock.api.planningChatSend)).toHaveBeenCalledWith({ turnId: expect.any(String), message: 'hello', presetKey: 'codex', confirmationMode: 'require' });
     });
   });
 
@@ -1310,6 +1311,7 @@ describe('Invoker terminal (component)', () => {
 
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        turnId: expect.any(String),
         sessionId: 'saved-pressure-chat',
         message: 'continue the restored session',
         presetKey: 'codex',
@@ -1525,6 +1527,7 @@ describe('Invoker terminal (component)', () => {
 
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
+        turnId: expect.any(String),
         sessionId: 'session-1',
         message: 'make the plan more detailed',
         presetKey: 'codex',
@@ -1576,7 +1579,7 @@ describe('Invoker terminal (component)', () => {
     submitPlanningText('draft a plan');
 
     await waitFor(() => {
-      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'draft a plan', presetKey: 'omp+claude', confirmationMode: 'require' });
+      expect(vi.mocked(mock.api.planningChatSend)).toHaveBeenCalledWith({ turnId: expect.any(String), message: 'draft a plan', presetKey: 'omp+claude', confirmationMode: 'require' });
     });
   });
 
@@ -1620,6 +1623,7 @@ describe('Invoker terminal (component)', () => {
 
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        turnId: expect.any(String),
         sessionId: 'session-1',
         message: 'submit',
         presetKey: 'codex',

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -847,12 +847,20 @@ describe('Invoker terminal (component)', () => {
       expect(panel).toHaveTextContent('Planning stopped. Try again when ready.');
     });
 
+    const firstTurnId = vi.mocked(mock.api.planningChatSend).mock.calls[0][0].turnId;
+    expect(typeof firstTurnId).toBe('string');
+
     submitPlanningText('try again');
 
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledTimes(2);
+      const secondTurnId = vi.mocked(mock.api.planningChatSend).mock.calls[1][0].turnId;
+      // A plain resend after failure is a new turn, not the dedicated Retry
+      // action (which reuses activeTurnId) — it must mint a fresh turnId.
+      expect(typeof secondTurnId).toBe('string');
+      expect(secondTurnId).not.toBe(firstTurnId);
       expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
-        turnId: expect.any(String),
+        turnId: secondTurnId,
         sessionId: 'session-1',
         message: 'try again',
         presetKey: 'codex',

--- a/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
@@ -94,6 +94,7 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledTimes(2);
       expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
+        turnId: expect.any(String),
         message: 'draft the next plan',
         presetKey: 'codex',
         confirmationMode: 'require',

--- a/packages/ui/src/__tests__/planning-poll-overlap-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-poll-overlap-repro.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+describe('planning poll overlap repro', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  it('skips a poll tick while the previous refresh is still in flight', async () => {
+    const pending: Array<ReturnType<typeof deferred<{ ok: boolean; sessions: ReturnType<typeof makePlanningSessionSummary>[] }>>> = [];
+    let callCount = 0;
+    const busySessions = [
+      makePlanningSessionSummary({
+        id: 'busy-chat',
+        title: 'Busy chat',
+        status: 'still_discussing',
+        draftPlanAvailable: false,
+        draftPlanSummary: undefined,
+        draftPlanText: undefined,
+        activeTurnId: 'turn-live',
+        activeTurnStatus: 'running',
+      }),
+    ];
+    mock.api.planningChatList = vi.fn(() => {
+      callCount += 1;
+      // Mount fires two independent hydrate calls (a legacy startup hydrate
+      // and refreshPlanningSessionsNow's own mount effect) before the busy
+      // poll's interval ever attaches; both settle with the busy session so
+      // anyPlanningSessionBusy flips true and the interval starts.
+      if (callCount <= 2) {
+        return Promise.resolve({ ok: true, sessions: busySessions });
+      }
+      const d = deferred<{ ok: boolean; sessions: ReturnType<typeof makePlanningSessionSummary>[] }>();
+      pending.push(d);
+      return d.promise;
+    }) as any;
+
+    vi.useFakeTimers();
+    try {
+      render(<App />);
+      // Flush the two mount-time hydrate calls (microtasks only, no timers
+      // involved) so the busy session lands and the poll interval attaches.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(callCount).toBe(2);
+
+      // First poll tick starts the poll's own refresh, which we leave in flight.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      expect(callCount).toBe(3);
+      expect(pending).toHaveLength(1);
+
+      // A second tick fires while the poll's refresh is still pending.
+      // With the in-flight guard, this tick must be skipped.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+      expect(callCount).toBe(3);
+
+      // Resolving the in-flight refresh clears the guard; the next tick
+      // is free to start a new refresh again.
+      await act(async () => {
+        pending[0]!.resolve({ ok: true, sessions: [] });
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+      expect(callCount).toBe(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/ui/src/__tests__/planning-session-view-max-message-id.test.ts
+++ b/packages/ui/src/__tests__/planning-session-view-max-message-id.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { maxPlanningMessageId, type PlanningSessionView } from '../lib/planning-session-view.js';
+
+function makeSession(messageIds: number[]): PlanningSessionView {
+  return {
+    id: `session-${messageIds[0] ?? 'empty'}`,
+    title: 'Untitled plan',
+    status: 'still_discussing',
+    presetKey: '',
+    confirmationMode: 'require',
+    messages: messageIds.map((id) => ({ id, text: `message ${id}`, role: 'assistant' })),
+    input: '',
+    draftPlanAvailable: false,
+    busy: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    conversationKey: `session-${messageIds[0] ?? 'empty'}`,
+    mode: 'chat',
+    terminalSession: null,
+    terminalBusy: false,
+    terminalError: null,
+  } as PlanningSessionView;
+}
+
+describe('maxPlanningMessageId', () => {
+  it('returns 1 for no sessions or sessions with no messages', () => {
+    expect(maxPlanningMessageId([])).toBe(1);
+    expect(maxPlanningMessageId([makeSession([])])).toBe(1);
+  });
+
+  it('returns the highest message id across all restored sessions', () => {
+    const sessions = [makeSession([1, 5, 3]), makeSession([2, 9])];
+    expect(maxPlanningMessageId(sessions)).toBe(9);
+  });
+
+  it('does not throw on a message count that would overflow a spread-based Math.max', () => {
+    const hugeMessageIds = Array.from({ length: 200_000 }, (_, index) => index + 1);
+    const sessions = [makeSession(hugeMessageIds)];
+    expect(() => Math.max(1, ...hugeMessageIds)).toThrow(RangeError);
+    expect(() => maxPlanningMessageId(sessions)).not.toThrow();
+    expect(maxPlanningMessageId(sessions)).toBe(200_000);
+  });
+});

--- a/packages/ui/src/__tests__/planning-session-view-reconcile-busy.test.ts
+++ b/packages/ui/src/__tests__/planning-session-view-reconcile-busy.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { reconcileHydratedPlanningSessions, type PlanningSessionView } from '../lib/planning-session-view.js';
+
+function makeSession(overrides: Partial<PlanningSessionView> = {}): PlanningSessionView {
+  return {
+    id: 'session-1',
+    title: 'Untitled plan',
+    status: 'still_discussing',
+    presetKey: '',
+    confirmationMode: 'require',
+    messages: [],
+    input: '',
+    draftPlanAvailable: false,
+    busy: false,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    conversationKey: 'session-1',
+    mode: 'chat',
+    terminalSession: null,
+    terminalBusy: false,
+    terminalError: null,
+    ...overrides,
+  } as PlanningSessionView;
+}
+
+describe('reconcileHydratedPlanningSessions busy derivation', () => {
+  it('marks a session busy when the restored turn is running, even if the local view was not busy', () => {
+    const current = [makeSession({ busy: false })];
+    const restored = [makeSession({ busy: false, activeTurnStatus: 'running', activeTurnId: 'turn-1' })];
+
+    const [merged] = reconcileHydratedPlanningSessions(current, restored);
+
+    expect(merged.busy).toBe(true);
+  });
+
+  it('clears busy when the restored turn is no longer running', () => {
+    const current = [makeSession({ busy: true })];
+    const restored = [makeSession({ busy: false, activeTurnStatus: undefined, activeTurnId: undefined })];
+
+    const [merged] = reconcileHydratedPlanningSessions(current, restored);
+
+    expect(merged.busy).toBe(false);
+  });
+});

--- a/packages/ui/src/__tests__/planning-terminal-preset-switch-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-preset-switch-repro.test.tsx
@@ -83,6 +83,7 @@ describe('planning terminal preset ownership repro', () => {
 
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        turnId: expect.any(String),
         sessionId: 'claude-chat',
         message: 'continue with claude',
         presetKey: 'omp+claude',
@@ -179,6 +180,7 @@ describe('planning terminal preset ownership repro', () => {
 
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        turnId: expect.any(String),
         sessionId: 'existing-chat',
         message: 'continue with a different model',
         presetKey: 'omp+claude',

--- a/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
@@ -62,6 +62,7 @@ describe('planning terminal failed first send session id persist repro', () => {
     submitPlanningText('draft a plan that fails before replying');
     expect(await screen.findByText('planner exited before producing a reply')).toBeInTheDocument();
     expect(mock.api.planningChatSend).toHaveBeenNthCalledWith(1, {
+      turnId: expect.any(String),
       message: 'draft a plan that fails before replying',
       presetKey: 'codex',
       confirmationMode: 'require',
@@ -72,6 +73,7 @@ describe('planning terminal failed first send session id persist repro', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledTimes(2);
       expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
+        turnId: expect.any(String),
         sessionId: 'session-created-before-error',
         message: 'retry in the same chat',
         presetKey: 'codex',

--- a/packages/ui/src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx
@@ -151,6 +151,7 @@ describe('planning terminal startup hydrate race repro', () => {
     submitPlanningText('start a local plan before restore');
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        turnId: expect.any(String),
         message: 'start a local plan before restore',
         presetKey: 'codex',
         confirmationMode: 'require',

--- a/packages/ui/src/__tests__/planning-turn-durability.test.tsx
+++ b/packages/ui/src/__tests__/planning-turn-durability.test.tsx
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  // Dynamic import is required because Vitest hoists mock factories before test imports.
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+// Dynamic import is required so App sees the hoisted @xyflow/react mock.
+const { App } = await import('../App.js');
+
+describe('planning turn durability', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  async function openPlanningSurface() {
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-input')).toBeInTheDocument();
+    });
+  }
+
+  it('keeps a hydrated running turn busy and lands its reply from the stream event', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'busy-chat',
+          title: 'Busy chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          messages: [
+            { id: 1, role: 'user', text: 'Draft the plan', createdAt: '2026-07-07T00:00:01.000Z' },
+          ],
+          activeTurnId: 'turn-live',
+          activeTurnStatus: 'running',
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningSurface();
+
+    // Reload-safe busy: the hydrated running turn locks the composer.
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    });
+
+    await act(async () => {
+      mock.firePlanningChatStream({
+        sessionId: 'busy-chat',
+        turnId: 'turn-live',
+        turn: { status: 'completed', reply: 'Done thinking.', draftPlanAvailable: false },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Done thinking.');
+      expect(screen.getByTestId('invoker-terminal-input')).not.toBeDisabled();
+    });
+  });
+
+  it('offers Retry for a hydrated failed turn and re-sends the same turnId and message', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'failed-chat',
+          title: 'Failed chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          messages: [
+            { id: 1, role: 'user', text: 'Draft the plan', createdAt: '2026-07-07T00:00:01.000Z' },
+          ],
+          activeTurnId: 'turn-x',
+          activeTurnStatus: 'failed',
+          activeTurnError: 'Planner was interrupted before it could answer.',
+        }),
+      ],
+    }));
+    mock.api.planningChatSend = vi.fn(async (request: { sessionId?: string; turnId?: string }) => ({
+      ok: true as const,
+      sessionId: request.sessionId ?? 'failed-chat',
+      turnId: request.turnId,
+      reply: 'Recovered fine.',
+      confirmationMode: 'require' as const,
+      draftPlanAvailable: false,
+    }));
+
+    render(<App />);
+    await openPlanningSurface();
+
+    const retryButton = await screen.findByTestId('invoker-terminal-retry-turn');
+    expect(screen.getByTestId('invoker-terminal-turn-error'))
+      .toHaveTextContent('Planner was interrupted before it could answer.');
+
+    fireEvent.click(retryButton);
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: 'failed-chat',
+        turnId: 'turn-x',
+        message: 'Draft the plan',
+      }));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Recovered fine.');
+    });
+    expect(screen.queryByTestId('invoker-terminal-retry-turn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoker-terminal-turn-error')).not.toBeInTheDocument();
+  });
+
+  it('silently ignores a duplicate-turn response and stays busy', async () => {
+    mock.api.planningChatSend = vi.fn(async (request: { turnId?: string }) => ({
+      ok: false as const,
+      sessionId: 'session-1',
+      turnId: request.turnId,
+      error: 'duplicate-turn',
+    }));
+
+    render(<App />);
+    await openPlanningSurface();
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1);
+    });
+    // The original request's outcome will land via response, event, or poll:
+    // the session stays busy and no error UI appears.
+    expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    expect(screen.queryByText('Planner could not respond')).not.toBeInTheDocument();
+    expect(screen.queryByText(/duplicate-turn/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoker-terminal-retry-turn')).not.toBeInTheDocument();
+  });
+
+  it('keeps one chat row when the poll observes the in-flight send before the response lands', async () => {
+    let resolveSend: (() => void) | undefined;
+    mock.api.planningChatSend = vi.fn((request: { turnId?: string }) => new Promise((resolve) => {
+      resolveSend = () => resolve({
+        ok: true,
+        sessionId: 'server-1',
+        turnId: request.turnId,
+        reply: 'Landed on the server session.',
+        confirmationMode: 'require',
+        draftPlanAvailable: false,
+      });
+    })) as typeof mock.api.planningChatSend;
+    // Empty at mount; the backend session appears only once the send is in
+    // flight, exactly what the busy poll would observe server-side.
+    const serverSessions = { current: [] as ReturnType<typeof makePlanningSessionSummary>[] };
+    mock.api.planningChatList = vi.fn(async () => ({ ok: true, sessions: serverSessions.current }));
+
+    render(<App />);
+    await openPlanningSurface();
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+      fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+      serverSessions.current = [
+        makePlanningSessionSummary({
+          id: 'server-1',
+          title: 'Server chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          messages: [
+            { id: 1, role: 'user', text: 'hello planner', createdAt: '2026-07-07T00:00:01.000Z' },
+          ],
+          activeTurnId: 'turn-live',
+          activeTurnStatus: 'running',
+        }),
+      ];
+
+      // The busy poll observes the backend session for this in-flight send.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      // No duplicate row: the backend session is not appended as a new chat.
+      expect(screen.queryByText('Server chat')).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    await act(async () => {
+      resolveSend?.();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Landed on the server session.');
+    });
+  });
+
+  it('lands a turn outcome exactly once when both the response and the stream event deliver it', async () => {
+    render(<App />);
+    await openPlanningSurface();
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('I can help draft that.');
+    });
+
+    const sendRequest = vi.mocked(mock.api.planningChatSend).mock.calls[0]?.[0] as { turnId?: string };
+    expect(typeof sendRequest.turnId).toBe('string');
+
+    await act(async () => {
+      mock.firePlanningChatStream({
+        sessionId: 'session-1',
+        turnId: sendRequest.turnId,
+        turn: { status: 'completed', reply: 'I can help draft that.', draftPlanAvailable: false },
+      });
+    });
+
+    const transcriptText = screen.getByTestId('invoker-terminal-transcript').textContent ?? '';
+    expect(transcriptText.split('I can help draft that.').length - 1).toBe(1);
+    expect(screen.getByTestId('invoker-terminal-input')).not.toBeDisabled();
+  });
+});

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -133,6 +133,8 @@ interface InvokerTerminalProps {
   repoLocked?: boolean;
   repoSuggestions?: string[];
   repoError?: string | null;
+  turnError?: string | null;
+  onRetryTurn?: () => void;
   onValueChange: (value: string) => void;
   onSubmit: () => void;
   onPresetChange: (presetKey: string) => void;
@@ -559,6 +561,8 @@ export function InvokerTerminal({
   repoLocked = true,
   repoSuggestions = [],
   repoError = null,
+  turnError = null,
+  onRetryTurn,
   onPresetChange,
   onConfirmationModeChange,
   onRepoInputChange,
@@ -914,6 +918,24 @@ export function InvokerTerminal({
               transcriptContent
             )}
           </div>
+
+          {turnError && !readOnly && (
+            <div
+              data-testid="invoker-terminal-turn-error"
+              className="sticky bottom-0 z-10 flex flex-wrap items-center justify-between gap-3 border-t border-border bg-card/80 px-4 py-3.5 backdrop-blur-sm"
+            >
+              <span className="min-w-0 flex-1 text-xs text-red-400">{turnError}</span>
+              <button
+                type="button"
+                data-testid="invoker-terminal-retry-turn"
+                disabled={busy}
+                onClick={() => onRetryTurn?.()}
+                className="rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Retry
+              </button>
+            </div>
+          )}
 
           {draftPlanAvailable && !draftReviewOpen && !readOnly && (
             <div

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -922,18 +922,21 @@ export function InvokerTerminal({
           {turnError && !readOnly && (
             <div
               data-testid="invoker-terminal-turn-error"
+              role="alert"
               className="sticky bottom-0 z-10 flex flex-wrap items-center justify-between gap-3 border-t border-border bg-card/80 px-4 py-3.5 backdrop-blur-sm"
             >
               <span className="min-w-0 flex-1 text-xs text-red-400">{turnError}</span>
-              <button
-                type="button"
-                data-testid="invoker-terminal-retry-turn"
-                disabled={busy}
-                onClick={() => onRetryTurn?.()}
-                className="rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                Retry
-              </button>
+              {onRetryTurn && (
+                <button
+                  type="button"
+                  data-testid="invoker-terminal-retry-turn"
+                  disabled={busy}
+                  onClick={onRetryTurn}
+                  className="rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Retry
+                </button>
+              )}
             </div>
           )}
 

--- a/packages/ui/src/lib/planning-session-view.ts
+++ b/packages/ui/src/lib/planning-session-view.ts
@@ -120,7 +120,7 @@ export function reconcileHydratedPlanningSessions(
     return {
       ...restored,
       input: session.input,
-      busy: restored.activeTurnStatus === 'running' ? session.busy : false,
+      busy: restored.activeTurnStatus === 'running',
       conversationKey: session.conversationKey,
       mode: session.mode === 'tmux' || restored.mode === 'tmux' ? 'tmux' : restored.mode,
       terminalSession: restored.terminalSession ?? session.terminalSession,

--- a/packages/ui/src/lib/planning-session-view.ts
+++ b/packages/ui/src/lib/planning-session-view.ts
@@ -1,0 +1,188 @@
+import type {
+  InAppPlanningSessionStatus,
+  InAppPlanningSessionSummary,
+  PlanningConfirmationMode,
+  TerminalSessionDescriptor,
+} from '@invoker/contracts';
+import type { InvokerTerminalLine, PlanningTerminalMode } from '../components/InvokerTerminal.js';
+
+export type PlanningSessionView = Omit<InAppPlanningSessionSummary, 'messages'> & {
+  messages: InvokerTerminalLine[];
+  input: string;
+  busy: boolean;
+  conversationKey: string;
+  mode: PlanningTerminalMode;
+  terminalSession?: TerminalSessionDescriptor | null;
+  terminalBusy?: boolean;
+  terminalError?: string | null;
+  repoInput?: string;
+  repoError?: string | null;
+};
+
+export function planningSessionFromSummary(
+  summary: InAppPlanningSessionSummary,
+  overrides: Partial<PlanningSessionView> = {},
+): PlanningSessionView {
+  const restoredTerminalSession = summary.terminalSessionId
+    && (summary.terminalStatus === 'running' || summary.terminalStatus === 'exited')
+    ? {
+        sessionId: summary.terminalSessionId,
+        taskId: `planning:${summary.id}`,
+        kind: 'planning' as const,
+        planningSessionId: summary.id,
+        status: summary.terminalStatus,
+        exitCode: summary.terminalExitCode,
+        cwd: undefined,
+        mode: 'spawn' as const,
+        attached: false,
+        createdAt: summary.terminalUpdatedAt ?? summary.updatedAt,
+        outputSnapshot: summary.terminalOutputSnapshot ?? '',
+      }
+    : null;
+  return {
+    ...summary,
+    messages: summary.messages.map((line) => ({
+      id: line.id,
+      text: line.text,
+      role: line.role,
+      tone: line.tone,
+    })),
+    input: '',
+    busy: summary.activeTurnStatus === 'running',
+    conversationKey: summary.id,
+    mode: summary.terminalMode ?? 'chat',
+    terminalSession: restoredTerminalSession,
+    terminalBusy: false,
+    terminalError: null,
+    ...overrides,
+  };
+}
+
+export type PlanningStreamState = {
+  text: string;
+  status: 'streaming' | 'failed';
+};
+
+export function makeInitialPlanningSession(
+  now: string = new Date().toISOString(),
+  confirmationMode: PlanningConfirmationMode = 'require',
+): PlanningSessionView {
+  return {
+    id: 'local-planning-session-1',
+    title: 'Untitled plan',
+    status: 'still_discussing',
+    presetKey: '',
+    confirmationMode,
+    messages: [],
+    input: '',
+    draftPlanAvailable: false,
+    busy: false,
+    createdAt: now,
+    updatedAt: now,
+    conversationKey: 'local-planning-session-1',
+    mode: 'chat',
+    terminalSession: null,
+    terminalBusy: false,
+    terminalError: null,
+  };
+}
+
+export function isInitialPlanningSessionPlaceholder(session: PlanningSessionView | undefined): boolean {
+  if (!session) return false;
+  return session.id === 'local-planning-session-1'
+    && session.title === 'Untitled plan'
+    && session.input === ''
+    && !session.busy
+    && session.messages.length === 0
+    && !session.draftPlanAvailable
+    && !session.terminalSession
+    && !session.terminalBusy
+    && !session.terminalError;
+}
+
+export function reconcileHydratedPlanningSessions(
+  currentSessions: PlanningSessionView[],
+  restoredSessions: PlanningSessionView[],
+): PlanningSessionView[] {
+  if (restoredSessions.length === 0) return currentSessions;
+  if (
+    currentSessions.length === 0
+    || (currentSessions.length === 1 && isInitialPlanningSessionPlaceholder(currentSessions[0]))
+  ) {
+    return restoredSessions;
+  }
+
+  const restoredById = new Map(restoredSessions.map((session) => [session.id, session]));
+  const currentIds = new Set(currentSessions.map((session) => session.id));
+  const mergedCurrentSessions = currentSessions.map((session) => {
+    const restored = restoredById.get(session.id);
+    if (!restored) return session;
+    return {
+      ...restored,
+      input: session.input,
+      busy: restored.activeTurnStatus === 'running' ? session.busy : false,
+      conversationKey: session.conversationKey,
+      mode: session.mode === 'tmux' || restored.mode === 'tmux' ? 'tmux' : restored.mode,
+      terminalSession: restored.terminalSession ?? session.terminalSession,
+      terminalBusy: restored.terminalSession ? false : session.terminalBusy,
+      terminalError: restored.terminalSession ? null : session.terminalError,
+      repoInput: session.repoInput,
+      repoError: session.repoError,
+    };
+  });
+  const newRestoredSessions = restoredSessions.filter((session) => !currentIds.has(session.id));
+  return [...mergedCurrentSessions, ...newRestoredSessions];
+}
+
+export function planningSessionSummaryToView(session: InAppPlanningSessionSummary): PlanningSessionView {
+  return planningSessionFromSummary(session);
+}
+
+export function planningNeedsAttention(status: InAppPlanningSessionStatus): boolean {
+  return status === 'waiting_for_answer' || status === 'draft_ready';
+}
+
+export function planningRepoLabel(repoUrl: string): string {
+  const trimmed = repoUrl.trim().replace(/\.git$/, '');
+  const segments = trimmed.split(/[/:]/).filter(Boolean);
+  return segments.length >= 2 ? segments.slice(-2).join('/') : (segments.at(-1) ?? trimmed);
+}
+
+export function planningRepoStatusText(repoUrl: string | undefined, baseCommit: string | undefined): string {
+  if (!repoUrl) return 'No repository bound yet';
+  const label = planningRepoLabel(repoUrl);
+  return baseCommit ? `${label} @ ${baseCommit.slice(0, 7)}` : label;
+}
+
+export function newPlanningTurnId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `turn-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function previewPlanningMessage(session: PlanningSessionView): string {
+  const last = [...session.messages].reverse().find((line) => line.role !== 'system') ?? session.messages.at(-1);
+  return last?.text.replace(/\s+/g, ' ').trim() || 'No messages yet';
+}
+
+export function planningSessionStatusLabel(session: PlanningSessionView): string {
+  if (session.busy) return 'Working';
+  if (session.status === 'draft_ready') return 'Draft ready';
+  if (session.status === 'waiting_for_answer') return 'Waiting for answer';
+  if (session.status === 'submitted') return 'Submitted';
+  return 'Still discussing';
+}
+
+export function relativePlanningUpdatedAt(value: string): string {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) return 'now';
+  const seconds = Math.max(0, Math.round((Date.now() - timestamp) / 1000));
+  if (seconds < 60) return 'now';
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.round(hours / 24);
+  if (days < 30) return `${days}d`;
+  const months = Math.round(days / 30);
+  if (months < 12) return `${months}mo`;
+  return `${Math.round(months / 12)}y`;
+}

--- a/packages/ui/src/lib/planning-session-view.ts
+++ b/packages/ui/src/lib/planning-session-view.ts
@@ -138,6 +138,16 @@ export function planningSessionSummaryToView(session: InAppPlanningSessionSummar
   return planningSessionFromSummary(session);
 }
 
+export function maxPlanningMessageId(sessions: PlanningSessionView[]): number {
+  let max = 1;
+  for (const session of sessions) {
+    for (const message of session.messages) {
+      if (message.id > max) max = message.id;
+    }
+  }
+  return max;
+}
+
 export function planningNeedsAttention(status: InAppPlanningSessionStatus): boolean {
   return status === 'waiting_for_answer' || status === 'draft_ready';
 }

--- a/packages/ui/src/lib/start-ready-rail-modes.ts
+++ b/packages/ui/src/lib/start-ready-rail-modes.ts
@@ -1,0 +1,168 @@
+import type { StartReadyFreshBaseScope, StartReadyRequest, StartReadyResult } from '@invoker/contracts';
+import type { TaskState } from '../types.js';
+
+export type StartReadyRailModeId =
+  | 'recreateFailed'
+  | 'recreateFailedAndPending'
+  | 'recreateFailedPendingAndRunning'
+  | 'freshBaseFailed'
+  | 'freshBaseFailedAndPending'
+  | 'freshBaseFailedPendingAndRunning';
+
+export type StartReadyRailMode = {
+  id: StartReadyRailModeId;
+  kind: 'recreate' | 'freshBase';
+  testId: string;
+  label: string;
+  title: string;
+  confirmLabel: string;
+  request: StartReadyRequest;
+  includesPending: boolean;
+  includesRunning: boolean;
+  freshBaseScope?: StartReadyFreshBaseScope;
+};
+
+export const START_READY_RAIL_MODES: readonly StartReadyRailMode[] = [
+  {
+    id: 'recreateFailed',
+    kind: 'recreate',
+    testId: 'rail-start-ready-recreate-failed',
+    label: 'Start and recreate failed…',
+    title: 'Start and recreate failed',
+    confirmLabel: 'Start and recreate',
+    request: { recreateFailed: true },
+    includesPending: false,
+    includesRunning: false,
+  },
+  {
+    id: 'recreateFailedAndPending',
+    kind: 'recreate',
+    testId: 'rail-start-ready-recreate-failed-and-pending',
+    label: 'Start and recreate failed and pending…',
+    title: 'Start and recreate failed and pending',
+    confirmLabel: 'Start and recreate',
+    request: { recreateFailedAndPending: true },
+    includesPending: true,
+    includesRunning: false,
+  },
+  {
+    id: 'recreateFailedPendingAndRunning',
+    kind: 'recreate',
+    testId: 'rail-start-ready-recreate-failed-pending-and-running',
+    label: 'Start and recreate failed, pending, and running…',
+    title: 'Start and recreate failed, pending, and running',
+    confirmLabel: 'Start and recreate',
+    request: { recreateFailedPendingAndRunning: true },
+    includesPending: true,
+    includesRunning: true,
+  },
+  {
+    id: 'freshBaseFailed',
+    kind: 'freshBase',
+    testId: 'rail-start-ready-fresh-base-failed',
+    label: 'Recreate failed from fresh base…',
+    title: 'Start and recreate failed from fresh base',
+    confirmLabel: 'Start and recreate from fresh base',
+    request: { freshBaseScope: 'failed' },
+    includesPending: false,
+    includesRunning: false,
+    freshBaseScope: 'failed',
+  },
+  {
+    id: 'freshBaseFailedAndPending',
+    kind: 'freshBase',
+    testId: 'rail-start-ready-fresh-base-failed-and-pending',
+    label: 'Recreate failed and pending from fresh base…',
+    title: 'Start and recreate failed and pending from fresh base',
+    confirmLabel: 'Start and recreate from fresh base',
+    request: { freshBaseScope: 'failed-and-pending' },
+    includesPending: true,
+    includesRunning: false,
+    freshBaseScope: 'failed-and-pending',
+  },
+  {
+    id: 'freshBaseFailedPendingAndRunning',
+    kind: 'freshBase',
+    testId: 'rail-start-ready-fresh-base-failed-pending-and-running',
+    label: 'Recreate failed, pending, and running from fresh base…',
+    title: 'Start and recreate failed, pending, and running from fresh base',
+    confirmLabel: 'Start and recreate from fresh base',
+    request: { freshBaseScope: 'failed-pending-and-running' },
+    includesPending: true,
+    includesRunning: true,
+    freshBaseScope: 'failed-pending-and-running',
+  },
+];
+
+const START_READY_RAIL_MODE_BY_ID = new Map(
+  START_READY_RAIL_MODES.map((mode) => [mode.id, mode]),
+);
+
+export function getStartReadyRailMode(id: StartReadyRailModeId): StartReadyRailMode {
+  return START_READY_RAIL_MODE_BY_ID.get(id) ?? START_READY_RAIL_MODES[0];
+}
+
+export function startReadyRequestForMode(mode: StartReadyRailMode, dryRun = false): StartReadyRequest {
+  return dryRun ? { dryRun: true, ...mode.request } : { ...mode.request };
+}
+
+export function isPendingOrQueuedStatus(status: TaskState['status']): boolean {
+  return status === 'pending' || (status as string) === 'queued';
+}
+
+export function freshBaseModeHasVisibleTargets(
+  mode: StartReadyRailMode,
+  targetCounts: { failed: number; pending: number; running: number },
+): boolean {
+  if (mode.kind !== 'freshBase') return true;
+  switch (mode.freshBaseScope) {
+    case 'failed':
+      return targetCounts.failed > 0;
+    case 'failed-and-pending':
+      return targetCounts.pending > 0;
+    case 'failed-pending-and-running':
+      return targetCounts.running > 0;
+    default:
+      return false;
+  }
+}
+
+export function startReadyPreviewRows(mode: StartReadyRailMode, result: StartReadyResult): Array<[string, number]> {
+  const rows: Array<[string, number]> = [
+    ['Ready tasks', result.preview.readyTaskIds.length],
+    ['Recoverable tasks', result.preview.recoverableTaskIds.length],
+    ['Failed workflows', result.preview.failedWorkflowIds.length],
+  ];
+
+  if (mode.includesPending) {
+    rows.push(
+      ['Pending workflows', result.preview.pendingWorkflowIds.length],
+      ['Pending tasks', result.preview.skipped.pendingTasks],
+    );
+  }
+  if (mode.includesRunning) {
+    rows.push(
+      ['Running workflows', result.preview.runningWorkflowIds.length],
+      ['Running tasks', result.preview.skipped.runningTasks],
+    );
+  }
+  if (mode.kind === 'freshBase' && result.preview.freshBase) {
+    rows.push(
+      ['Fresh-base workflows', result.preview.freshBase.workflowIds.length],
+      ['Fresh-base failed workflows', result.preview.freshBase.failedWorkflowIds.length],
+    );
+    if (mode.includesPending) {
+      rows.push(['Fresh-base pending workflows', result.preview.freshBase.pendingWorkflowIds.length]);
+    }
+    if (mode.includesRunning) {
+      rows.push(['Fresh-base running workflows', result.preview.freshBase.runningWorkflowIds.length]);
+    }
+  }
+
+  rows.push(
+    ['Awaiting approval', result.preview.skipped.awaitingApproval],
+    ['Review ready', result.preview.skipped.reviewReady],
+    ['Blocked', result.preview.skipped.blocked],
+  );
+  return rows;
+}


### PR DESCRIPTION
## Summary

Reloading the page no longer loses a planning turn. The composer restores its busy lock from the session summary; the reply lands via stream event or five-second poll.

A failed turn shows its error above the composer with a button that reruns the same turn id, keeping exactly one copy of the user message.

Every path that lands a result — response, stream event, poll — funnels through one idempotent handler, so a result arriving twice renders once.

A response answering a resend of an already-running turn is ignored quietly.

A transport error during a send keeps the chat busy; the poll then finds the finished turn or fails it after three misses.

## Review Claim

Approve the composer's reload-safe turn handling: busy state hydrated from summaries, one idempotent outcome path across response, stream event, and poll, and a rerun affordance for failed turns.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The composer stays locked while a turn runs, so no second turn can start from the same chat. Outcomes for unknown or already-landed turns are dropped by the turn-id guard, and old backends without turn ids keep today's error-dialog path.

## Slice Rationale

UI-only slice: it consumes the turn wire shape and the persisted lifecycle from the two slices below it and touches nothing outside `packages/ui`.

## Non-goals

- No backend or store changes.
- No change to streamed chunk rendering.
- Pre-turn failures from older backends keep the existing error line and dialog.
- The guarded `dag-surface-background-click-noop` behavior in `App.tsx` is untouched; nearby edits only shift its line position.

## Architecture

### Before

```mermaid
graph TD
    A["planningChatSend response"] --> B["reply applied inline in handlePlanningSubmit"]
    C["page reload"] --> D["busy state lost; reply never shown"]
```

### After

```mermaid
graph TD
    A["response"] --> F["applyPlanningTurnOutcome (turn-id guarded)"]
    B["stream turn event"] --> F
    C["busy poll (5s)"] --> F
    F -->|completed| G["reply appended once; busy cleared"]
    F -->|failed| H["error + Retry above the composer"]
    H -->|Retry, same turnId| A
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm vitest run src/__tests__/planning-turn-durability.test.tsx`
- [ ] `cd packages/ui && pnpm vitest run src/__tests__/planning-repo-binding.test.tsx src/__tests__/planning-terminal-preset-switch-repro.test.tsx src/__tests__/invoker-terminal.test.tsx src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx src/__tests__/planning-terminal-session-id-persist-repro.test.tsx src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx`
- [ ] `npx tsc -p tsconfig.typecheck.json --noEmit`

</details>

## Visual Proof

Captured on the live web demo (`demo.invoker-control.dev`) running this stack.

Reload persistence is a state transition, so the primary evidence is a continuous walkthrough video: message typed, turn working, hard reload mid-turn, busy lock restored, reply landing with no user action.

![Reload-safe turn walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260820-098bf7/planning-turn-reload-walkthrough.mp4)

![Busy lock restored after a hard reload](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260820-098bf7/planning-turn-busy-after-reload.webp)

"Working" chip and locked composer immediately after a hard reload mid-turn — restored purely from the session summary.

![Reply landed with no user action](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260820-098bf7/planning-turn-reply-landed-after-reload.webp)

The same chat after waiting: reply and Draft ready state landed via the poll/stream path, composer re-enabled.

![Failed turn offers Retry](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260820-098bf7/planning-turn-interrupted-retry.webp)

The app process was restarted mid-turn: after reload the error renders above the composer with the Retry button.

![Retry recovered the turn](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260820-098bf7/planning-turn-retry-recovered.webp)

After clicking Retry: the reply landed with exactly one copy of the user message.

Manually inspected: I opened the video's extracted frames and each image myself. The video shows the typed message, the Working state, the post-reload frame still locked with the same transcript, and the final frame with the planner's reply and an enabled composer. The stills show the "Working" chip with a disabled input after reload, the landed reply with the "Draft ready" chip, the red interruption row with its Retry button, and the recovered chat with one "Plan a tiny README glossary section" line.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes. Reverting returns the composer to response-only delivery; backend turn state is simply unread.
- Revert command: `git revert eada543968`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #9965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Retry support for failed planning turns.
  - Planning sessions now restore active and completed turns more reliably.
  - Busy turns continue updating after session restoration.
  - Turn errors are displayed directly in the planning terminal.

- **Bug Fixes**
  - Prevented duplicate planning responses and chat entries.
  - Improved handling of connection loss and interrupted turns.
  - Preserved session context and original messages during retries.
  - Ensured completed responses are applied consistently across polling and streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->