### PR TITLE
[Bug sweep](1) Restore the in-app first-draft authorization gate

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -342,11 +342,11 @@ describe('planning chat', () => {
     });
 
     expect(spawnPlanner).toHaveBeenCalledTimes(1);
-    const prompt = spawnPlanner.mock.calls[0]?.[0] ?? '';
-    expect(prompt).toContain('Treat this as a conversation before a plan.');
-    expect(prompt).toContain('Talk through edge cases, corner cases, architecture, and ambiguity with the human.');
-    expect(prompt).toContain('Resolve those points before producing a YAML plan.');
-    expect(prompt).toContain('Draft YAML only after the human asks you to draft/proceed');
+    const sentPlannerPrompt = spawnPlanner.mock.calls[0]?.[0] ?? '';
+    expect(sentPlannerPrompt).toContain('This session is a planning conversation before any task plan exists.');
+    expect(sentPlannerPrompt).toContain('Discuss relevant edge cases, corner cases, architecture choices, ambiguity');
+    expect(sentPlannerPrompt).toContain('Drafting is not authorized yet. Do NOT output a ```yaml code block');
+    expect(sentPlannerPrompt).toContain('Do not rush directly to YAML unless the user has clearly approved drafting a plan.');
   });
 
   it('reuses an existing session and keeps its original preset', async () => {

--- a/packages/app/src/__tests__/planning-draft-gate-bypass-repro.test.ts
+++ b/packages/app/src/__tests__/planning-draft-gate-bypass-repro.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createInAppPlanningChatSessions,
+  sendPlanningChatMessage,
+} from '../in-app-planner.js';
+
+// Regression test for the draft-authorization gate bypass.
+//
+// Draft Gate Step 2 (c506ceaf9f, PR #5320) enforced: YAML the user never asked
+// for must NOT become draft-ready. 5b6408e736 rewrote evaluatePlanningTurn so
+// authorization only gated REPLACING an existing draft, and d14fac3858 passed
+// requireDraftAuthorization: false whenever a fresh reply contained YAML.
+// The gate now lives at the send-message layer: unauthorized inline YAML stays
+// a conversation message; only a deliberate sidecar write after a plain answer
+// is review-ready without an explicit ask (incident ad665bff).
+const UNREQUESTED_YAML_REPLY = `Here is what I found, and incidentally a full YAML you did not ask for.
+
+\`\`\`yaml
+name: Mock Plan
+onFinish: none
+tasks:
+  - id: first
+    description: First task
+    command: echo first
+\`\`\``;
+
+describe('draft gate bypass repro', () => {
+  it('keeps unrequested YAML from becoming draft-ready on a fresh session', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    const result = await sendPlanningChatMessage({
+      // No draft intent, no prior assistant offer to draft.
+      message: 'What files are in this repo?',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder: vi.fn(() => ({ command: 'planner', args: ['prompt'] })),
+      plannerReplyOverride: async () => UNREQUESTED_YAML_REPLY,
+    });
+
+    if (!result.ok) throw new Error(result.error);
+    expect(result.draftPlanAvailable).toBe(false);
+    expect(sessions.get(result.sessionId)?.status).not.toBe('draft_ready');
+    expect(sessions.get(result.sessionId)?.draftPlanText).toBeUndefined();
+  });
+});

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -47,6 +47,7 @@ import {
   formatPlanningHostedTurn,
   hasExplicitDraftIntent as hasCoreExplicitDraftIntent,
   isDraftingAuthorized,
+  looksLikeQuestion,
   preparePlanningReview,
   submitPlanningReview,
   summarizePlanText,
@@ -933,7 +934,7 @@ export async function sendPlanningChatMessage(
         // asked for a draft (#5320 draft gate).
         const sidecarDraftApproved = !deps.plannerReplyOverride
           && activeSession.conversation.lastTurnDraftFromSidecarFile
-          && !message.includes('?');
+          && !looksLikeQuestion(message);
         const unauthorizedDraft = result.kind === 'draft_ready'
           && !result.draftingAuthorized
           && !sidecarDraftApproved;

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -923,13 +923,29 @@ export async function sendPlanningChatMessage(
           messagesBeforeTurn,
           assistantReply: reply,
           immediateDraftPlanText,
-          requireDraftAuthorization: hasDraftPlan(activeSession) || !immediateDraftPlanText,
           hasExistingDraft: hasDraftPlan(activeSession),
         });
-        if (result.kind === 'message') {
+        // Prompt-mode sidecar approval (incident ad665bff): a draft the
+        // planner deliberately wrote to the sidecar file, in a turn where the
+        // user supplied information rather than asking a question, is
+        // review-ready without an explicit "draft it" message. YAML that
+        // merely appears in the chat reply text still needs the user to have
+        // asked for a draft (#5320 draft gate).
+        const sidecarDraftApproved = !deps.plannerReplyOverride
+          && activeSession.conversation.lastTurnDraftFromSidecarFile
+          && !message.includes('?');
+        const unauthorizedDraft = result.kind === 'draft_ready'
+          && !result.draftingAuthorized
+          && !sidecarDraftApproved;
+        if (result.kind === 'message' || unauthorizedDraft) {
+          const conversationStatus = result.kind === 'message'
+            ? result.status
+            : reply.includes('?')
+              ? 'waiting_for_answer'
+              : 'still_discussing';
           activeSession.status = hasDraftPlan(activeSession)
             ? 'draft_ready'
-            : result.status;
+            : conversationStatus;
           appendSessionMessage(activeSession, 'assistant', reply);
           persistPlanningSession(activeSession, deps.planningSessionStore, false);
           return {

--- a/packages/planning-core/src/__tests__/lifecycle.test.ts
+++ b/packages/planning-core/src/__tests__/lifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   hasExplicitDraftIntent,
   isDraftingAuthorized,
+  looksLikeQuestion,
 } from '../lifecycle.js';
 
 describe('Planning Terminal lifecycle contract', () => {
@@ -17,5 +18,18 @@ describe('Planning Terminal lifecycle contract', () => {
     expect(isDraftingAuthorized('yes', [
       { role: 'assistant', content: 'Here is an explanation.' },
     ])).toBe(false);
+  });
+
+  it('classifies questions without relying solely on an ASCII "?"', () => {
+    expect(looksLikeQuestion('What files are in this repo')).toBe(true);
+    expect(looksLikeQuestion('How does this work')).toBe(true);
+    expect(looksLikeQuestion('Can you explain the auth flow')).toBe(true);
+    expect(looksLikeQuestion('这个文件在哪里？')).toBe(true);
+    expect(looksLikeQuestion('¿Qué archivos hay')).toBe(true);
+    expect(looksLikeQuestion('من فضلك، أين الملف؟')).toBe(true);
+    expect(looksLikeQuestion('What files are in this repo?')).toBe(true);
+    expect(looksLikeQuestion('Here is the info you need.')).toBe(false);
+    expect(looksLikeQuestion('The API key is stored in .env.')).toBe(false);
+    expect(looksLikeQuestion('')).toBe(false);
   });
 });

--- a/packages/planning-core/src/lifecycle.ts
+++ b/packages/planning-core/src/lifecycle.ts
@@ -46,6 +46,20 @@ export function isShortDraftConfirmation(message: string): boolean {
   ].includes(normalized(message).replace(/[.!]+$/g, '').replace(/\s+/g, ' '));
 }
 
+const QUESTION_PUNCTUATION_PATTERN = /[?？¿؟՞︖⁇⁈⁉]/;
+
+const LEADING_QUESTION_WORD_PATTERN = /^(what|when|where|who|whom|whose|which|why|how|is|are|am|was|were|do|does|did|can|could|will|would|shall|should|may|might|must)\b/i;
+
+// A bare `?` check misses punctuation-free ("What files are in this repo")
+// and non-ASCII questions, which can slip past authorization gates that key
+// off "is this a question."
+export function looksLikeQuestion(message: string): boolean {
+  const trimmed = message.trim();
+  if (!trimmed) return false;
+  if (QUESTION_PUNCTUATION_PATTERN.test(trimmed)) return true;
+  return LEADING_QUESTION_WORD_PATTERN.test(trimmed);
+}
+
 export function assistantAskedWhetherToDraft(message: string): boolean {
   return message.includes('?')
     && /\b(draft|create|generate|write|produce)\b/i.test(message)

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -513,6 +513,7 @@ export class PlanConversation {
   private _initialized = false;
   private _lastTurnReasoning: string[] = [];
   private _lastTurnDraftPlanText: string | null = null;
+  private _lastTurnDraftFromSidecarFile = false;
   private _lastTurnPlanIntentSignal: PlanIntentSignal | null = null;
   private lastKnownGoodPlanText: string | null = null;
   private harnessSessionDriver?: HarnessSessionDriver;
@@ -656,9 +657,8 @@ export class PlanConversation {
     }
     const fileDraft = this.readPlanDraftFile();
     const inlineDraft = extractYamlPlan(message);
-    let nextDraft = fileDraft && summarizePlanText(fileDraft)
-      ? fileDraft
-      : inlineDraft;
+    const sidecarDraftSelected = Boolean(fileDraft && summarizePlanText(fileDraft));
+    let nextDraft = sidecarDraftSelected ? fileDraft : inlineDraft;
     let finalFormatted = formatted;
     if (nextDraft && this.draftDoctor) {
       const gated = await this.gateDraftForReview(nextDraft, message, formatted, turn);
@@ -667,6 +667,7 @@ export class PlanConversation {
       finalFormatted = gated.formatted;
     }
     this._lastTurnDraftPlanText = nextDraft;
+    this._lastTurnDraftFromSidecarFile = sidecarDraftSelected && Boolean(nextDraft);
     if (nextDraft) this.lastKnownGoodPlanText = nextDraft;
     this._lastTurnPlanIntentSignal = this.mode === 'agent' ? this.readPlanIntentSignalFile() : null;
     if (!nextDraft) {
@@ -790,6 +791,14 @@ export class PlanConversation {
     return this._lastTurnDraftPlanText;
   }
 
+  /**
+   * Whether this turn's draft came from the dedicated plan-draft sidecar file
+   * (a deliberate planner act), rather than YAML embedded in the chat reply.
+   */
+  get lastTurnDraftFromSidecarFile(): boolean {
+    return this._lastTurnDraftFromSidecarFile;
+  }
+
   /** The plan-intent signal the model wrote this turn (agent mode only), if any. */
   get lastTurnPlanIntentSignal(): PlanIntentSignal | null {
     return this._lastTurnPlanIntentSignal;
@@ -910,6 +919,7 @@ export class PlanConversation {
     this._submittedPlanText = null;
     this._planSubmitted = false;
     this._lastTurnDraftPlanText = null;
+    this._lastTurnDraftFromSidecarFile = false;
     this._lastTurnPlanIntentSignal = null;
     this.lastKnownGoodPlanText = null;
     if (this.conversationRepo && this.threadTs) {


### PR DESCRIPTION
## Summary

YAML the user never asked for no longer becomes a locked draft. A planner reply carrying YAML stays an ordinary chat message until the user asks for a draft.

A draft the planner deliberately writes to its sidecar file still goes review-ready when the user's message supplied information rather than asking a question.

That keeps the ad665bff recovery flow working.

Two changes on different branches opened this hole: one gated authorization only for replacing an existing draft, the other turned it off whenever a fresh reply carried YAML.

## Review Claim

Approve the restored first-draft authorization gate: inline YAML needs the user to have asked; a deliberate sidecar draft after a plain answer stays review-ready; a locked existing draft is still never replaced without an explicit ask.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The change is confined to how one send-message turn classifies a planner reply. Shared planning-core evaluation and the Slack surface path are untouched, and an over-strict classification degrades to an ordinary chat message, never a crash or a lost reply.

## Slice Rationale

One behavior decision — when a first draft becomes review-ready — spans the send-message layer and the sidecar-channel flag it reads, so they land together and nothing else rides along.

## Non-goals

- No change to planning-core's `evaluatePlanningTurn` staging semantics or its own suite.
- No change to the Slack surface's draft staging path.
- No renderer changes.

## Architecture

### Before

```mermaid
graph TD
    A["planner reply with YAML (inline or sidecar)"] --> B["evaluatePlanningTurn"]
    B --> C["draft_ready — authorization ignored for first drafts"]
```

### After

```mermaid
graph TD
    A["planner reply with YAML"] --> B["evaluatePlanningTurn (unchanged)"]
    B --> C{"draftingAuthorized?"}
    C -->|yes| D["draft_ready"]
    C -->|"no, sidecar file + plain answer"| D
    C -->|"no, inline YAML or question turn"| E["ordinary chat message"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm vitest run src/__tests__/in-app-planner.test.ts` (70 pass; the four #5320 gate cases were red on master)
- [ ] `cd packages/app && pnpm vitest run src/__tests__/planning-draft-gate-bypass-repro.test.ts`
- [ ] `cd packages/app && pnpm vitest run src/__tests__/planning-chat-e2e-acceptance.test.ts` (incident ad665bff stays green)
- [ ] `cd packages/surfaces && pnpm vitest run src/__tests__/plan-draft-file-activation.test.ts src/__tests__/plan-conversation.test.ts`
- [ ] `npx tsc -p tsconfig.typecheck.json --noEmit`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting reopens the first-draft bypass but breaks nothing else.
- Revert command: `git revert ebbb0bff5d`
- Post-revert steps: None
- Data migration? No

</details>
