### PR TITLE
[Bug sweep](2) Catch multi-line assertion edits in the diff atomicity linter

### DIFF
--- a/scripts/lint-pr-diff-atomicity.mjs
+++ b/scripts/lint-pr-diff-atomicity.mjs
@@ -329,9 +329,20 @@ function collectAssertionCalls(file, content, lineNumbers) {
   const walk = (node) => {
     const assertion = analyzeAssertionCall(ts, node);
     if (assertion) {
-      const lineNumber = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
-      if (lineNumbers.has(lineNumber)) {
-        assertions.push({ ...assertion, line: lineNumber });
+      // Match on the call's full line RANGE, not just its start line: an
+      // expected-value edit inside a multi-line argument list leaves the
+      // `expect(` line untouched and must still count as a changed assertion.
+      const startLine = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+      const endLine = sourceFile.getLineAndCharacterOfPosition(node.getEnd()).line + 1;
+      let touchesChangedLine = false;
+      for (let line = startLine; line <= endLine; line += 1) {
+        if (lineNumbers.has(line)) {
+          touchesChangedLine = true;
+          break;
+        }
+      }
+      if (touchesChangedLine) {
+        assertions.push({ ...assertion, line: startLine });
       }
     }
     ts.forEachChild(node, walk);

--- a/scripts/test-pr-diff-atomicity-multiline-assertion.mjs
+++ b/scripts/test-pr-diff-atomicity-multiline-assertion.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// Repro: the test-assertion-weakened check only sees assertions whose
+// expect(...) START line is among the diff's changed lines
+// (collectAssertionCalls keeps an assertion only when
+// lineNumbers.has(startLine), lint-pr-diff-atomicity.mjs:332-333), so an
+// expected-value change inside a multi-line argument list — where the
+// expect( line itself is an untouched context line — is never paired by
+// collectTestAssertionWeakenedFindings (lint-pr-diff-atomicity.mjs:360-368).
+//
+// Case A (single-line edit) passes today. Case B (the identical semantic
+// edit spread across lines) fails today — that failing assertion is the
+// blind-spot proof.
+import assert from 'node:assert/strict';
+
+import { collectDiffAtomicityFindings } from './lint-pr-diff-atomicity.mjs';
+
+function diff(lines) {
+  return `${lines.join('\n')}\n`;
+}
+
+function kinds(findings) {
+  return findings.map((finding) => finding.kind).sort();
+}
+
+const productChange = [
+  'diff --git a/packages/app/src/api.ts b/packages/app/src/api.ts',
+  '--- a/packages/app/src/api.ts',
+  '+++ b/packages/app/src/api.ts',
+  '@@ -1,3 +1,3 @@',
+  ' export function send(payload) {',
+  '-  return post(payload);',
+  '+  return post({ ...payload, retries: 1 });',
+  ' }',
+];
+
+// Case A: single-line assertion — the expected value changes on the same
+// line as the expect(...) call start. Flagged today.
+{
+  const text = diff([
+    ...productChange,
+    'diff --git a/packages/app/src/api.test.ts b/packages/app/src/api.test.ts',
+    '--- a/packages/app/src/api.test.ts',
+    '+++ b/packages/app/src/api.test.ts',
+    '@@ -1,3 +1,3 @@',
+    " it('sends payload', () => {",
+    '-  expect(mock.api.send).toHaveBeenCalledWith({ a: 1 });',
+    '+  expect(mock.api.send).toHaveBeenCalledWith({ a: 2 });',
+    ' });',
+  ]);
+  const findings = collectDiffAtomicityFindings({ diffText: text });
+  assert.deepEqual(
+    kinds(findings),
+    ['test-assertion-weakened'],
+    'case A (single-line expected-value change) must be flagged',
+  );
+  console.log('ok case A: single-line expected-value change is flagged');
+}
+
+// Case B: the SAME assertion and the SAME expected-value change, but the
+// call is written across multiple lines and only an interior argument line
+// changes — the expect( start line is an untouched context line.
+{
+  const text = diff([
+    ...productChange,
+    'diff --git a/packages/app/src/api.test.ts b/packages/app/src/api.test.ts',
+    '--- a/packages/app/src/api.test.ts',
+    '+++ b/packages/app/src/api.test.ts',
+    '@@ -1,6 +1,6 @@',
+    " it('sends payload', () => {",
+    '   expect(mock.api.send).toHaveBeenCalledWith({',
+    '-    a: 1,',
+    '+    a: 2,',
+    '   });',
+    ' });',
+  ]);
+  const findings = collectDiffAtomicityFindings({ diffText: text });
+  assert.deepEqual(
+    kinds(findings),
+    ['test-assertion-weakened'],
+    'case B (multi-line expected-value change, expect( line untouched) must be flagged',
+  );
+  console.log('ok case B: multi-line expected-value change is flagged');
+}
+
+console.log('ok pr diff atomicity multi-line assertion');


### PR DESCRIPTION
## Summary

The diff-atomicity check that guards changed test assertions matched an assertion only by the line where `expect(` starts. An expected-value edit inside a multi-line argument list never matched.

The identical one-line edit was caught, so the guard's coverage depended on code formatting rather than on what changed.

Assertions now match on their full line range. A regression script drives both shapes — one-line and multi-line — through the finding collector.

## Review Claim

Approve range-based matching in `collectAssertionCalls`: an assertion counts as changed when any line it spans changed, not only its first line.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Widening only adds findings: every assertion flagged before is still flagged, because the start line is always inside the range. No finding kind, severity, or pairing rule changed.

## Slice Rationale

A standalone linter correction with its own regression script; the other sweep slices do not depend on it.

## Non-goals

- No change to `test-assertion-weakened` pairing (target, matcher, args comparison).
- No change to any other finding kind or severity.
- No change to how diffs are parsed.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-pr-diff-atomicity-multiline-assertion.mjs` (case A one-line and case B multi-line both flagged)
- [ ] `node scripts/test-pr-diff-atomicity.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting restores the multi-line blind spot only.
- Revert command: `git revert af96045c77`
- Post-revert steps: None
- Data migration? No

</details>
