### PR TITLE
[Bug sweep](3) Sync renderer task types with workflow-graph

### DIFF
--- a/packages/ui/src/lib/status-colors.ts
+++ b/packages/ui/src/lib/status-colors.ts
@@ -59,6 +59,16 @@ export const STATUS_VISUALS: Record<StatusVisualKey, StatusVisual> = {
     active: true,
     pulse: true,
   },
+  queued: {
+    bg: NEUTRAL_SURFACE,
+    border: 'border-border',
+    text: 'text-amber-300',
+    dot: 'bg-amber-400',
+    rail: 'bg-amber-400',
+    inline: { bg: NEUTRAL_INLINE_BG, border: NEUTRAL_INLINE_BORDER, text: '#fcd34d' },
+    active: true,
+    pulse: true,
+  },
   running_executing: {
     bg: NEUTRAL_SURFACE,
     border: 'border-border',

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -2,8 +2,11 @@
  * UI type definitions.
  *
  * Re-declares the types from @invoker/core and @invoker/app to avoid
- * importing Electron dependencies into the renderer process.
+ * importing Electron dependencies into the renderer process. Complex leaf
+ * types shared with the runtime come from @invoker/workflow-graph (a pure
+ * types package that @invoker/contracts also imports from).
  */
+import type { FailureClass, ReviewGateState, TaskHeartbeatSource } from '@invoker/workflow-graph';
 
 // ── Task Status ─────────────────────────────────────────────
 
@@ -18,7 +21,8 @@ export type TaskStatus =
   | 'blocked'
   | 'review_ready'
   | 'awaiting_approval'
-  | 'stale';
+  | 'stale'
+  | 'queued';
 
 // ── Experiment Types ────────────────────────────────────────
 
@@ -110,14 +114,22 @@ export interface TaskExecution {
   readonly inputPrompt?: string;
   readonly exitCode?: number;
   readonly error?: string;
+  readonly failureClass?: FailureClass;
+  readonly protocolErrorCode?: string;
+  readonly protocolErrorMessage?: string;
   readonly startedAt?: Date;
   readonly completedAt?: Date;
   readonly lastHeartbeatAt?: Date;
+  readonly remoteHeartbeatAt?: Date;
+  readonly heartbeatSource?: TaskHeartbeatSource;
   readonly launchStartedAt?: Date;
   readonly launchCompletedAt?: Date;
   readonly actionRequestId?: string;
   readonly branch?: string;
   readonly commit?: string;
+  readonly fixedIntegrationSha?: string;
+  readonly fixedIntegrationRecordedAt?: Date;
+  readonly fixedIntegrationSource?: string;
   readonly agentSessionId?: string;
   readonly lastAgentSessionId?: string;
   readonly agentName?: string;
@@ -129,15 +141,22 @@ export interface TaskExecution {
   readonly selectedExperiments?: readonly string[];
   readonly experimentResults?: readonly ExperimentResultEntry[];
   readonly pendingFixError?: string;
+  readonly fixSessionEntryStatus?: TaskStatus;
   readonly isFixingWithAI?: boolean;
   readonly reviewUrl?: string;
   readonly reviewId?: string;
   readonly reviewStatus?: string;
   readonly reviewProviderId?: string;
+  readonly reviewGate?: ReviewGateState;
   readonly mergeConflict?: {
     readonly failedBranch: string;
     readonly conflictFiles: readonly string[];
   };
+  readonly selectedAttemptId?: string;
+  readonly crashPreservedAt?: Date;
+  readonly crashPreservedOwnerPid?: number;
+  readonly crashPreservedReportPath?: string;
+  readonly crashPreservedDiagnosticSummary?: string;
 }
 
 // ── Task State ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The renderer's hand-copied task definitions drifted from the runtime's: the `queued` status and fifteen execution fields were missing, so the package-local compiler check reported dozens of unfixable errors.

The copy now matches `@invoker/workflow-graph`, importing the complex leaf shapes from that shared dependency instead of re-declaring them by hand.

Queued tasks also gain a defined visual — the amber in-flight styling mirroring the assigning state — instead of an undefined entry in the status map.

## Review Claim

Approve the renderer task-shape sync with `@invoker/workflow-graph` plus the new `queued` entry in `STATUS_VISUALS`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Every added field is optional, so no existing renderer code changes meaning. The only pixel-affecting change is queued tasks gaining defined styling where the visual lookup previously returned `undefined`.

## Slice Rationale

The drift and its one visible consequence land together; the remaining package-local diagnostics are configuration issues with their own follow-up.

## Non-goals

- Does not fix the remaining 64 package-local diagnostics (JSX-namespace and cross-package tsconfig issues).
- Does not add a CI gate for `packages/ui` type checking.
- No behavior change for any status other than `queued`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && npx tsc -p tsconfig.json --noEmit 2>&1 | grep -cE 'error TS'` (89 before, 64 after; zero mentions of `queued`/`crashPreserved`/`selectedAttemptId`)
- [ ] `cd packages/ui && pnpm vitest run` (93 files, 859 pass)
- [ ] `npx tsc -p tsconfig.typecheck.json --noEmit`

</details>

## Visual Proof

A type sync has no screenshot-able pixel change except the new `queued` status visual, and no live queued task was available to photograph; the measurable change is the diagnostic delta below. The `queued` entry duplicates the existing amber `assigning` visual verbatim.

![Diagnostic delta and the new queued visual entry](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260820-bc2422/ui-type-sync-diagnostics.webp)

Manually inspected: I opened this image myself. It shows the comparison table — 89 total diagnostics on master dropping to 64 with this change, the three drift families (queued status, missing TaskExecution fields, status-union cascades) each at zero — and the amber-dot `queued` entry line mirroring `assigning`.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting restores the type drift and the undefined queued visual only.
- Revert command: `git revert 1488dd6876`
- Post-revert steps: None
- Data migration? No

</details>
