### PR TITLE
[Web surface parity](13) Pending spinner on Send while a turn runs

### DIFF
--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -2230,6 +2230,15 @@ describe('Invoker terminal (component)', () => {
     expect(within(sendButton).getByTestId('invoker-terminal-send-icon')).toBeInTheDocument();
   });
 
+  it('swaps the send icon for a pending spinner while a turn is running', () => {
+    render(<InvokerTerminal {...terminalProps({ busy: true })} />);
+
+    const sendButton = screen.getByRole('button', { name: 'Send' });
+    expect(sendButton).toBeDisabled();
+    expect(within(sendButton).getByTestId('invoker-terminal-send-spinner')).toBeInTheDocument();
+    expect(within(sendButton).queryByTestId('invoker-terminal-send-icon')).not.toBeInTheDocument();
+  });
+
   it('uses the amber send-button styling in the enabled state', () => {
     render(<InvokerTerminal {...terminalProps({ value: 'draft a plan' })} />);
 

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -1113,10 +1113,18 @@ export function InvokerTerminal({
                   disabled={sendButtonDisabled}
                   className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-amber-400 text-white shadow-sm transition-colors hover:bg-amber-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-amber-300 disabled:bg-gray-700 disabled:text-gray-400 disabled:shadow-none disabled:hover:bg-gray-700 disabled:opacity-50 ${sendButtonDisabledCursorClass}`}
                 >
-                  <SendIcon
-                    data-testid="invoker-terminal-send-icon"
-                    className="h-4 w-4"
-                  />
+                  {busy ? (
+                    <span
+                      data-testid="invoker-terminal-send-spinner"
+                      aria-hidden="true"
+                      className="inline-block h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-gray-500 border-t-gray-100"
+                    />
+                  ) : (
+                    <SendIcon
+                      data-testid="invoker-terminal-send-icon"
+                      className="h-4 w-4"
+                    />
+                  )}
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## Summary

While the planner works on a turn, the Send button shows a pending spinner in place of the arrow icon.

The wait is now visible right at the composer, next to where the user just acted, instead of only in the transcript's Working line.

The arrow returns the moment the reply lands and the composer unlocks.

## Review Claim

Approve the busy-state swap inside the Send button: spinner while `busy`, arrow icon otherwise.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Purely presentational: the button's disabled logic is untouched, and the swap keys off the same `busy` flag the composer already uses to lock the input.

## Slice Rationale

A single visible affordance on top of the turn lifecycle slices below it; nothing outside the terminal component changes.

## Non-goals

- No change to the transcript's Working indicator.
- No change to when the button or input are disabled.
- No change to any send behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm vitest run src/__tests__/invoker-terminal.test.tsx` (includes the new spinner swap case)
- [ ] `cd packages/ui && pnpm vitest run src/__tests__/planning-turn-durability.test.tsx`

</details>

## Visual Proof

Captured on the live web demo running this stack. The spinner is an animation, so the primary evidence is video: message typed with the amber arrow, the button swapping to the spinner on send, the ring at different angles across the wait, and the arrow back once the reply lands.

![Send spinner walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-33593b/send-spinner-walkthrough.mp4)

![Idle composer with the amber arrow](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-33593b/send-spinner-idle-typed.webp)

Amber Send button with the arrow icon while the message sits in the composer.

![Pending spinner while waiting](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-33593b/send-spinner-busy.webp)

The same button while the planner works: grayed, with the spinner ring in place of the arrow.

![Arrow restored once the reply landed](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-33593b/send-spinner-restored.webp)

Manually inspected: I opened the video's extracted frames and each image myself. The idle still shows the amber arrow button with "Draft a short plan to tidy the README" typed; the waiting still shows the gray button with a spinner ring; consecutive video frames show the ring's arc at different rotation angles (and the amber-to-gray color fade mid-swap); the final still shows the arrow icon back on the unlocked composer.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting restores the static arrow icon during waits.
- Revert command: `git revert c5c1619d28`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #9966

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * The send button now shows an animated loading indicator while a request is processing.
  * The button is disabled during processing to prevent duplicate submissions.
* **Tests**
  * Added coverage to verify the button’s loading and disabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->