### PR TITLE
[Web surface parity](14) Fail planner turns whose session vanished server-side

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -3,6 +3,8 @@ import type * as NodeOs from 'node:os';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { resolveInvokerConfigPath } from '@invoker/contracts';
 import {
+  filterExecutionHarnesses,
+  filterPlanningPresets,
   loadConfig,
   resolveAutoFixExecutionModel,
   resolveAutoFixPoolId,
@@ -11,6 +13,7 @@ import {
   resolveDefaultTaskExecutionSettings,
   resolveConflictResolutionSettings,
   resolveEmbeddedTerminalBackendConfig,
+  resolveEnabledExecutionAgents,
 } from '../config.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
@@ -81,6 +84,23 @@ describe('loadConfig', () => {
     );
     const config = loadConfig();
     expect(config.planningHeartbeatIntervalSeconds).toBe(30);
+  });
+
+  it('reads enabledExecutionAgents from user config', () => {
+    writeUserConfig({ enabledExecutionAgents: ['claude', 'omp'] });
+    expect(loadConfig().enabledExecutionAgents).toEqual(['claude', 'omp']);
+  });
+
+  it('rejects non-array enabledExecutionAgents', () => {
+    writeUserConfig({ enabledExecutionAgents: 'claude' });
+    expect(() => loadConfig()).toThrow(/enabledExecutionAgents must be an array/);
+  });
+
+  it('rejects empty or non-string enabledExecutionAgents entries', () => {
+    writeUserConfig({ enabledExecutionAgents: ['claude', '  '] });
+    expect(() => loadConfig()).toThrow(/non-empty strings/);
+    writeUserConfig({ enabledExecutionAgents: [42] });
+    expect(() => loadConfig()).toThrow(/non-empty strings/);
   });
 
   it('reads disableAutoRunOnStartup from user config', () => {
@@ -512,5 +532,81 @@ describe('resolveEmbeddedTerminalBackendConfig', () => {
       {},
       { INVOKER_EMBEDDED_TERMINAL_BACKEND: 'external' },
     )).toThrow(/Invalid embedded terminal backend/);
+  });
+});
+
+describe('resolveEnabledExecutionAgents', () => {
+  it('returns null when the field is unset', () => {
+    expect(resolveEnabledExecutionAgents({})).toBeNull();
+  });
+
+  it('returns null when the field is empty or whitespace-only', () => {
+    expect(resolveEnabledExecutionAgents({ enabledExecutionAgents: [] })).toBeNull();
+    expect(resolveEnabledExecutionAgents({ enabledExecutionAgents: ['  ', ''] })).toBeNull();
+  });
+
+  it('trims and lowercases entries and drops empty ones', () => {
+    expect(resolveEnabledExecutionAgents({ enabledExecutionAgents: ['  Claude ', 'OMP', ''] }))
+      .toEqual(new Set(['claude', 'omp']));
+  });
+});
+
+describe('filterExecutionHarnesses', () => {
+  const harnesses = [
+    { name: 'claude', supportedModels: [] },
+    { name: 'codex', supportedModels: [] },
+    { name: 'omp', supportedModels: [] },
+  ];
+
+  it('returns the input unchanged when no allowlist is configured', () => {
+    expect(filterExecutionHarnesses(harnesses, {})).toEqual(harnesses);
+    expect(filterExecutionHarnesses(harnesses, { enabledExecutionAgents: [] })).toEqual(harnesses);
+  });
+
+  it('drops harnesses missing from the allowlist', () => {
+    expect(filterExecutionHarnesses(harnesses, { enabledExecutionAgents: ['claude'] }))
+      .toEqual([{ name: 'claude', supportedModels: [] }]);
+  });
+
+  it('matches case-insensitively with whitespace tolerated', () => {
+    expect(filterExecutionHarnesses(harnesses, { enabledExecutionAgents: [' CLAUDE ', 'Omp'] }))
+      .toEqual([
+        { name: 'claude', supportedModels: [] },
+        { name: 'omp', supportedModels: [] },
+      ]);
+  });
+});
+
+describe('filterPlanningPresets', () => {
+  const presets = [
+    { key: 'claude', tool: 'claude', model: undefined },
+    { key: 'codex', tool: 'codex', model: undefined },
+    { key: 'cursor+claude', tool: 'cursor', model: 'claude' },
+    { key: 'cursor+codex', tool: 'cursor', model: 'codex' },
+    { key: 'omp+claude', tool: 'omp', model: 'claude' },
+  ];
+
+  it('returns the input unchanged when no allowlist is configured', () => {
+    expect(filterPlanningPresets(presets, {})).toEqual(presets);
+  });
+
+  it('keeps direct-tool presets and wrapper presets whose model is allowed', () => {
+    expect(filterPlanningPresets(presets, { enabledExecutionAgents: ['claude'] }).map((p) => p.key))
+      .toEqual(['claude', 'cursor+claude', 'omp+claude']);
+  });
+
+  it('drops wrapper presets whose model is not allowed', () => {
+    expect(filterPlanningPresets(presets, { enabledExecutionAgents: ['codex'] }).map((p) => p.key))
+      .toEqual(['codex', 'cursor+codex']);
+  });
+
+  it('does not treat a non-wrapper tool model as an allowlist match', () => {
+    const custom = [{ key: 'x', tool: 'someplanner', model: 'claude' }];
+    expect(filterPlanningPresets(custom, { enabledExecutionAgents: ['claude'] })).toEqual([]);
+  });
+
+  it('normalizes allowlist whitespace and case', () => {
+    expect(filterPlanningPresets(presets, { enabledExecutionAgents: [' Claude '] }).map((p) => p.key))
+      .toEqual(['claude', 'cursor+claude', 'omp+claude']);
   });
 });

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -56,6 +56,12 @@ tasks:
 
 const NO_COMPLETE_PLAN_DRAFTED_ERROR = 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.';
 
+const INTERRUPTED_TURN_SYSTEM_LINE = {
+  role: 'system',
+  text: 'Planner was interrupted before it could answer.',
+  tone: 'error',
+} as const;
+
 function planningSession(
   overrides: Partial<InAppPlanningChatSession> & Pick<InAppPlanningChatSession, 'id' | 'title'>,
 ): InAppPlanningChatSession {
@@ -282,7 +288,7 @@ describe('planning chat', () => {
       loadGeneratedPlan: vi.fn(),
       sessions,
       planningCommandBuilder,
-    })).resolves.toEqual({ ok: false, sessionId: 'session-1', error: 'Type a message first.' });
+    })).resolves.toEqual({ ok: false, sessionId: 'session-1', turnId: expect.any(String), error: 'Type a message first.' });
     expect(sessions.size).toBe(0);
   });
 
@@ -297,7 +303,7 @@ describe('planning chat', () => {
       loadGeneratedPlan: vi.fn(),
       sessions,
       planningCommandBuilder,
-    })).resolves.toEqual({ ok: false, sessionId: undefined, error: 'Unknown planner preset "bad".' });
+    })).resolves.toEqual({ ok: false, sessionId: undefined, turnId: expect.any(String), error: 'Unknown planner preset "bad".' });
     expect(sessions.size).toBe(0);
   });
 
@@ -398,6 +404,7 @@ describe('planning chat', () => {
     })).resolves.toEqual({
       ok: false,
       sessionId: 'missing-session',
+      turnId: expect.any(String),
       error: 'Planning session "missing-session" was not found.',
     });
 
@@ -970,6 +977,126 @@ tasks:
     expect(secondResult.ok && secondResult.reply).toBe('turn 2 reply');
     expect(thirdResult.ok && thirdResult.reply).toBe('turn 3 reply');
     expect(overrideCalls.length).toBe(2);
+  });
+
+  it('echoes an explicit turnId and rejects a duplicate send while that turn runs', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    let resolveTurn: ((value: string) => void) | undefined;
+    let turnStarted!: () => void;
+    const started = new Promise<void>((resolve) => { turnStarted = resolve; });
+    const plannerReplyOverride = vi.fn(() => {
+      turnStarted();
+      return new Promise<string>((resolve) => { resolveTurn = resolve; });
+    });
+    const deps = {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+      plannerReplyOverride,
+    };
+
+    const first = sendPlanningChatMessage({ message: 'draft', presetKey: 'codex', turnId: 'turn-explicit' }, deps);
+    await started;
+
+    const sessionId = [...sessions.keys()][0];
+    const duplicate = await sendPlanningChatMessage({ sessionId, message: 'draft', turnId: 'turn-explicit' }, deps);
+    expect(duplicate).toMatchObject({ ok: false, turnId: 'turn-explicit', error: 'duplicate-turn' });
+
+    resolveTurn?.('turn reply');
+    const result = await first;
+    if (!result.ok) throw new Error(result.error);
+    expect(result.turnId).toBe('turn-explicit');
+    expect(plannerReplyOverride).toHaveBeenCalledTimes(1);
+  });
+
+  it('records a failed turn and a retry with the same turnId re-runs without duplicating the user line', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const sessions = createInAppPlanningChatSessions();
+      const plannerReplyOverride = vi.fn()
+        .mockRejectedValueOnce(new Error('planner crashed'))
+        .mockResolvedValueOnce('recovered reply');
+      const deps = {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        plannerReplyOverride,
+        planningSessionStore: adapter,
+      };
+
+      const failed = await sendPlanningChatMessage({ message: 'draft', presetKey: 'codex', turnId: 'turn-retry' }, deps);
+      if (failed.ok) throw new Error('expected the first turn to fail');
+      expect(failed.turnId).toBe('turn-retry');
+      const sessionId = failed.sessionId;
+      if (!sessionId) throw new Error('expected a sessionId on the failed turn');
+      const session = sessions.get(sessionId);
+      expect(session?.activeTurnId).toBe('turn-retry');
+      expect(session?.activeTurnStatus).toBe('failed');
+      expect(session?.activeTurnError).toBe('planner crashed');
+      const persisted = adapter.loadInAppPlanningSession(sessionId);
+      expect(persisted?.activeTurnId).toBe('turn-retry');
+      expect(persisted?.activeTurnStatus).toBe('failed');
+      expect(persisted?.activeTurnError).toBe('planner crashed');
+      const userLinesBefore = session?.messages.filter((line) => line.role === 'user').length;
+
+      const retried = await sendPlanningChatMessage({ sessionId, message: 'draft', turnId: 'turn-retry' }, deps);
+      if (!retried.ok) throw new Error(retried.error);
+      expect(retried.reply).toBe('recovered reply');
+      expect(session?.messages.filter((line) => line.role === 'user').length).toBe(userLinesBefore);
+      expect(session?.activeTurnId).toBeUndefined();
+      expect(session?.activeTurnStatus).toBeUndefined();
+      expect(session?.activeTurnError).toBeUndefined();
+      const persistedAfter = adapter.loadInAppPlanningSession(sessionId);
+      expect(persistedAfter?.activeTurnId).toBeUndefined();
+      expect(persistedAfter?.activeTurnStatus).toBeUndefined();
+      expect(persistedAfter?.activeTurnError).toBeUndefined();
+      expect(plannerReplyOverride).toHaveBeenCalledTimes(2);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('emits turn outcome events on the planning stream channel', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    const onRawPlannerOutput = vi.fn();
+    const ok = await sendPlanningChatMessage({ message: 'draft', presetKey: 'codex', turnId: 'turn-events' }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+      plannerReplyOverride: async () => 'turn reply',
+      onRawPlannerOutput,
+    });
+    if (!ok.ok) throw new Error(ok.error);
+    const completedEvent = onRawPlannerOutput.mock.calls
+      .map(([event]) => event)
+      .find((event) => event?.turn?.status === 'completed');
+    expect(completedEvent).toMatchObject({
+      sessionId: ok.sessionId,
+      turnId: 'turn-events',
+      turn: { status: 'completed', reply: 'turn reply', draftPlanAvailable: false },
+    });
+
+    const failSessions = createInAppPlanningChatSessions();
+    const onFailEvent = vi.fn();
+    const failed = await sendPlanningChatMessage({ message: 'draft', presetKey: 'codex', turnId: 'turn-fail' }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions: failSessions,
+      planningCommandBuilder,
+      plannerReplyOverride: async () => { throw new Error('boom'); },
+      onRawPlannerOutput: onFailEvent,
+    });
+    expect(failed.ok).toBe(false);
+    const failedEvent = onFailEvent.mock.calls
+      .map(([event]) => event)
+      .find((event) => event?.turn?.status === 'failed');
+    expect(failedEvent).toMatchObject({
+      turnId: 'turn-fail',
+      turn: { status: 'failed', error: 'boom' },
+    });
   });
 
   it('never constructs a session in mode: agent (createSession and planFromGoal paths)', async () => {
@@ -1571,14 +1698,54 @@ tasks:
         planningSessionStore: adapter,
       });
 
-      const restored = sessions.get('planning-interrupted');
-      expect(restored?.pendingSend).toBeUndefined();
-      expect(restored?.messages.at(-1)).toMatchObject({
-        role: 'system',
-        text: 'Planner was interrupted before it could answer. Send another message to continue.',
-        tone: 'error',
-      });
+      const restoredInterrupted = sessions.get('planning-interrupted');
+      expect(restoredInterrupted?.pendingSend).toBeUndefined();
+      expect(restoredInterrupted?.messages.at(-1)).toMatchObject(INTERRUPTED_TURN_SYSTEM_LINE);
       expect(adapter.loadInAppPlanningSession('planning-interrupted')?.pendingResponse).toBe(false);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('restores an interrupted pending turn as failed with its turnId preserved', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const record: InAppPlanningSessionRecord = {
+        id: 'planning-interrupted-turn',
+        title: 'Interrupted turn',
+        presetKey: 'codex',
+        status: 'still_discussing',
+        confirmationMode: 'require',
+        messages: [
+          { id: 1, role: 'user', text: 'Continue', createdAt: '2026-07-07T00:00:01.000Z' },
+        ],
+        activeTurnId: 'turn-x',
+        activeTurnStatus: 'running',
+        pendingResponse: true,
+        createdAt: '2026-07-07T00:00:00.000Z',
+        updatedAt: '2026-07-07T00:00:01.000Z',
+      };
+      adapter.upsertInAppPlanningSession(record);
+      const sessions = createInAppPlanningChatSessions();
+
+      await restorePlanningChatSessions([record], {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo: new ConversationRepository(adapter),
+        planningSessionStore: adapter,
+      });
+
+      const restoredTurn = sessions.get('planning-interrupted-turn');
+      expect(restoredTurn?.activeTurnId).toBe('turn-x');
+      expect(restoredTurn?.activeTurnStatus).toBe('failed');
+      expect(restoredTurn?.activeTurnError).toBe(INTERRUPTED_TURN_SYSTEM_LINE.text);
+      expect(restoredTurn?.messages.at(-1)).toMatchObject(INTERRUPTED_TURN_SYSTEM_LINE);
+      const persisted = adapter.loadInAppPlanningSession('planning-interrupted-turn');
+      expect(persisted?.activeTurnId).toBe('turn-x');
+      expect(persisted?.activeTurnStatus).toBe('failed');
+      expect(persisted?.pendingResponse).toBe(false);
     } finally {
       adapter.close();
     }

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -2214,6 +2214,149 @@ describe('rebindPlanningChatRepo', () => {
     expect(stored?.conversation).toBe(originalConversation);
   });
 
+  it('rejects rebinding once the conversation has a message', async () => {
+    const repoPool = createFakeRebindRepoPool('/fake/worktree/should-not-be-used', 'new-head-sha');
+    const sessions = createInAppPlanningChatSessions();
+    const session = planningSession({
+      id: 'message-rebind-session',
+      title: 'Message rebind',
+      repoUrl: 'https://example.com/repo.git',
+      baseBranch: 'main',
+      baseCommit: 'sha-a',
+      worktreePath: '/fake/worktree/existing-message',
+      worktreeBranch: 'invoker/planning/message-rebind-session',
+      messages: [
+        { id: 1, role: 'user', text: 'What does this repo do?', createdAt: '2026-07-07T00:00:01.000Z' },
+      ],
+    });
+    const originalConversation = session.conversation;
+    sessions.set(session.id, session);
+
+    const result = await rebindPlanningChatRepo({
+      sessionId: session.id,
+      repoUrl: 'https://example.com/other-repo.git',
+      baseBranch: 'main',
+    }, {
+      config: {},
+      sessions,
+      repoPool,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Set the repo before the conversation or terminal starts.',
+    });
+    expect(repoPool.ensureCloneThroughRepoQueue).not.toHaveBeenCalled();
+    expect(repoPool.acquireWorktree).not.toHaveBeenCalled();
+    expect(repoPool.release).not.toHaveBeenCalled();
+
+    const stored = sessions.get(session.id);
+    expect(stored?.repoUrl).toBe('https://example.com/repo.git');
+    expect(stored?.baseCommit).toBe('sha-a');
+    expect(stored?.worktreePath).toBe('/fake/worktree/existing-message');
+    expect(stored?.conversation).toBe(originalConversation);
+  });
+
+  it('rejects rebinding once a terminal session exists', async () => {
+    const repoPool = createFakeRebindRepoPool('/fake/worktree/should-not-be-used', 'new-head-sha');
+    const sessions = createInAppPlanningChatSessions();
+    const session = planningSession({
+      id: 'terminal-rebind-session',
+      title: 'Terminal rebind',
+      repoUrl: 'https://example.com/repo.git',
+      baseBranch: 'main',
+      baseCommit: 'sha-a',
+      worktreePath: '/fake/worktree/existing-terminal',
+      worktreeBranch: 'invoker/planning/terminal-rebind-session',
+      terminalMode: 'tmux',
+      terminalSessionId: 'term-planning-rebind',
+    });
+    const originalConversation = session.conversation;
+    sessions.set(session.id, session);
+
+    const result = await rebindPlanningChatRepo({
+      sessionId: session.id,
+      repoUrl: 'https://example.com/other-repo.git',
+      baseBranch: 'main',
+    }, {
+      config: {},
+      sessions,
+      repoPool,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Set the repo before the conversation or terminal starts.',
+    });
+    expect(repoPool.ensureCloneThroughRepoQueue).not.toHaveBeenCalled();
+    expect(repoPool.acquireWorktree).not.toHaveBeenCalled();
+
+    const stored = sessions.get(session.id);
+    expect(stored?.repoUrl).toBe('https://example.com/repo.git');
+    expect(stored?.baseCommit).toBe('sha-a');
+    expect(stored?.worktreePath).toBe('/fake/worktree/existing-terminal');
+    expect(stored?.conversation).toBe(originalConversation);
+  });
+
+  it('rebinds an untouched session with a prior binding to a different repo', async () => {
+    const worktreePath = '/fake/worktree/retarget-session';
+    const repoPool = createFakeRebindRepoPool(worktreePath, 'new-head-sha');
+    const sessions = createInAppPlanningChatSessions();
+    const session = planningSession({
+      id: 'retarget-session',
+      title: 'Retarget test',
+      repoUrl: 'https://example.com/repo.git',
+      baseBranch: 'main',
+      baseCommit: 'sha-a',
+      worktreePath: '/fake/worktree/existing-retarget',
+      worktreeBranch: 'invoker/planning/retarget-session',
+    });
+    sessions.set(session.id, session);
+
+    const result = await rebindPlanningChatRepo({
+      sessionId: session.id,
+      repoUrl: 'https://example.com/other-repo.git',
+      baseBranch: 'main',
+    }, {
+      config: {},
+      sessions,
+      repoPool,
+    });
+
+    expect(result).toEqual({ ok: true, action: 'provision' });
+    const stored = sessions.get(session.id);
+    expect(stored?.repoUrl).toBe('https://example.com/other-repo.git');
+    expect(stored?.baseCommit).toBe('new-head-sha');
+    expect(stored?.worktreePath).toBe(worktreePath);
+  });
+
+  it('threads the planning command builder into the rebuilt conversation', async () => {
+    const worktreePath = '/fake/worktree/builder-session';
+    const repoPool = createFakeRebindRepoPool(worktreePath, 'new-head-sha');
+    const sessions = createInAppPlanningChatSessions();
+    const planningCommandBuilder = vi.fn(() => ({ command: 'planner', args: ['prompt'] }));
+    const session = planningSession({ id: 'builder-session', title: 'Builder test' });
+    sessions.set(session.id, session);
+
+    const result = await rebindPlanningChatRepo({
+      sessionId: session.id,
+      repoUrl: 'https://example.com/new-repo.git',
+      baseBranch: 'main',
+    }, {
+      config: {},
+      sessions,
+      repoPool,
+      planningCommandBuilder,
+    });
+
+    expect(result).toEqual({ ok: true, action: 'provision' });
+    const stored = sessions.get(session.id);
+    // Without the builder the conversation falls back to spawning the literal
+    // `agent` CLI, which does not exist on headless hosts.
+    const conversation = stored?.conversation as unknown as { planningCommandBuilder?: unknown };
+    expect(conversation.planningCommandBuilder).toBe(planningCommandBuilder);
+  });
+
   it('returns an error when no repo URL can be resolved', async () => {
     const repoPool = createFakeRebindRepoPool('/fake/worktree/should-not-be-used', 'sha-a');
     const sessions = createInAppPlanningChatSessions();

--- a/packages/app/src/__tests__/planning-chat-e2e-acceptance.test.ts
+++ b/packages/app/src/__tests__/planning-chat-e2e-acceptance.test.ts
@@ -52,7 +52,7 @@ tasks:
     command: echo coincidental
 \`\`\``;
 
-const PLAN_C_REPLY = `Here is the revised plan against the new repo.
+const PLAN_C_REPLY = `Here is the revised plan.
 
 \`\`\`yaml
 name: Plan C
@@ -97,7 +97,7 @@ function sidecarPathFor(sessionId: string): string {
   return join(resolveInvokerHomeRoot(), 'plan-drafts', `${sessionId}.yaml`);
 }
 
-describe('planning chat E2E acceptance: explore -> draft -> critique -> repo switch -> re-draft -> submit', () => {
+describe('planning chat E2E acceptance: explore -> draft -> critique -> locked repo binding -> re-draft -> submit', () => {
   let sessionId: string | undefined;
 
   afterEach(() => {
@@ -105,7 +105,7 @@ describe('planning chat E2E acceptance: explore -> draft -> critique -> repo swi
     vi.restoreAllMocks();
   });
 
-  it('proves worktree binding, durable draft persistence, post-draft immutability, repo-switch invalidation, and DB-identical submit all hold together across one continuous session', async () => {
+  it('proves worktree binding, durable draft persistence, post-draft immutability, mid-conversation rebind refusal, and DB-identical submit all hold together across one continuous session', async () => {
     const worktreeRoot = mkdtempSync(join(tmpdir(), 'planning-chat-e2e-'));
     const repoPool = createFakeRepoPool({
       [REPO_A]: { worktreePath: join(worktreeRoot, 'repo-a'), headSha: 'sha-repo-a' },
@@ -192,7 +192,8 @@ describe('planning chat E2E acceptance: explore -> draft -> critique -> repo swi
       expect(sessions.get(sessionId)?.status).toBe('draft_ready');
       expect(adapter.loadInAppPlanningSession(sessionId)?.draftPlanText).toBe(planAText);
 
-      const rebindResult = await rebindPlanningChatRepo({
+      const messageCountBeforeRebind = sessions.get(sessionId)?.messages.length;
+      const rebindRefusal = await rebindPlanningChatRepo({
         sessionId,
         repoUrl: REPO_B,
         baseBranch: 'main',
@@ -202,30 +203,27 @@ describe('planning chat E2E acceptance: explore -> draft -> critique -> repo swi
         repoPool,
         planningSessionStore: adapter,
       });
-      expect(rebindResult).toEqual({ ok: true, action: 'invalidate_and_block_submit' });
-      expect(sessions.get(sessionId)?.draftPlanText).toBeUndefined();
-      expect(sessions.get(sessionId)?.status).toBe('still_discussing');
-      expect(sessions.get(sessionId)?.repoUrl).toBe(REPO_B);
-      expect(sessions.get(sessionId)?.baseCommit).toBe('sha-repo-b');
-      expect(adapter.loadInAppPlanningSession(sessionId)?.draftPlanText).toBeUndefined();
-      expect(existsSync(sidecarPathFor(sessionId))).toBe(false);
-      const invalidateMessage = sessions.get(sessionId)?.messages.at(-1);
-      expect(invalidateMessage?.tone).toBe('error');
-
-      const submitBeforeRedraft = await submitPlanningChatDraft({ sessionId }, {
-        sessions,
-        loadGeneratedPlan,
-        planningSessionStore: adapter,
+      expect(rebindRefusal).toEqual({
+        ok: false,
+        error: 'Set the repo before the conversation or terminal starts.',
       });
-      expect(submitBeforeRedraft.ok).toBe(false);
-      expect(loadGeneratedPlan).not.toHaveBeenCalled();
+      const sessionAfterRefusedRebind = sessions.get(sessionId);
+      expect(sessionAfterRefusedRebind).toMatchObject({
+        draftPlanText: planAText,
+        status: 'draft_ready',
+        repoUrl: REPO_A,
+        baseCommit: 'sha-repo-a',
+      });
+      expect(sessionAfterRefusedRebind?.messages.length).toBe(messageCountBeforeRebind);
+      expect(adapter.loadInAppPlanningSession(sessionId)?.draftPlanText).toBe(planAText);
+      expect(readFileSync(sidecarPathFor(sessionId), 'utf8')).toBe(planAText);
 
       spawnPlanner.mockResolvedValueOnce(PLAN_C_REPLY);
       const redraftTurn = await sendPlanningChatMessage({
         sessionId,
         message: 'draft the full plan again',
       }, {
-        config: { defaultRepoUrl: REPO_B, defaultBranch: 'main' },
+        config: { defaultRepoUrl: REPO_A, defaultBranch: 'main' },
         loadGeneratedPlan,
         sessions,
         planningCommandBuilder,

--- a/packages/app/src/__tests__/planning-terminal-invoker-cli.test.ts
+++ b/packages/app/src/__tests__/planning-terminal-invoker-cli.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Planning-terminal repo binding + live-owner CLI reachability.
+ *
+ * Two contracts:
+ *   1. A planning session bound to a repo opens its terminal in that
+ *      provisioned worktree, not the owner's repoRoot; unbound sessions keep
+ *      the repoRoot fallback (resolvePlanningTerminalCwd).
+ *   2. The planning terminal is a first-class surface for driving the RUNNING
+ *      Invoker: the request "please delete all running workflows" typed into
+ *      the terminal reaches a stand-in agent CLI whose tool call runs the real
+ *      `invoker-cli delete-all` against a live owner bus, and the owner's
+ *      running workflows are deleted. The agent's natural-language-to-command
+ *      step is a test stub (`claude` fixture script); everything downstream —
+ *      terminal PTY plumbing, the real packages/cli binary, IPC discovery,
+ *      `headless.exec` delegation — is production code.
+ */
+
+import { describe, it, expect, beforeAll, afterEach, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { IpcBus } from '@invoker/transport';
+import {
+  EmbeddedTerminalManager,
+  createBashTerminalBackend,
+} from '../embedded-terminal-manager.js';
+import {
+  createPlanningTerminalAdapter,
+  resolvePlanningTerminalCwd,
+  type PlanningTerminalAdapter,
+} from '../terminal-session-ipc.js';
+import type { InAppPlanningChatSession, InAppPlanningChatSessions } from '../in-app-planner.js';
+
+const REPO_ROOT = resolve(__dirname, '..', '..', '..', '..');
+const CLI_ENTRY = join(REPO_ROOT, 'packages', 'cli', 'dist', 'index.js');
+
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+};
+
+function makePlanningSession(
+  id: string,
+  overrides: Partial<InAppPlanningChatSession> = {},
+): InAppPlanningChatSession {
+  return {
+    id,
+    title: 'Ops session',
+    presetKey: 'claude',
+    confirmationMode: 'require',
+    status: 'still_discussing',
+    messages: [],
+    conversation: {} as InAppPlanningChatSession['conversation'],
+    terminalMode: 'chat',
+    terminalOutputSnapshot: '',
+    createdAt: '2026-08-19T00:00:00.000Z',
+    updatedAt: '2026-08-19T00:00:00.000Z',
+    nextMessageId: 1,
+    ...overrides,
+  };
+}
+
+function makeAdapter(
+  sessions: InAppPlanningChatSessions,
+  manager: EmbeddedTerminalManager,
+  repoRoot: string,
+): PlanningTerminalAdapter {
+  return createPlanningTerminalAdapter({
+    embeddedTerminalManager: manager,
+    logger: noopLogger,
+    planningChatSessions: sessions,
+    getPlanningSessionStore: () => undefined,
+    isPlanningTerminalWriteAllowed: () => true,
+    repoRoot,
+  });
+}
+
+describe('resolvePlanningTerminalCwd', () => {
+  it('prefers the bound worktree when it exists', () => {
+    const worktree = mkdtempSync(join(tmpdir(), 'inv-wt-'));
+    try {
+      expect(resolvePlanningTerminalCwd({ worktreePath: worktree }, '/repo-root')).toBe(worktree);
+    } finally {
+      rmSync(worktree, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to repoRoot when unbound or the worktree is gone', () => {
+    expect(resolvePlanningTerminalCwd({}, '/repo-root')).toBe('/repo-root');
+    expect(resolvePlanningTerminalCwd({ worktreePath: '   ' }, '/repo-root')).toBe('/repo-root');
+    expect(
+      resolvePlanningTerminalCwd({ worktreePath: '/definitely/not/a/real/dir' }, '/repo-root'),
+    ).toBe('/repo-root');
+  });
+});
+
+describe('planning terminal repo binding', () => {
+  const cleanups: Array<() => void> = [];
+  afterEach(() => {
+    while (cleanups.length > 0) cleanups.pop()?.();
+  });
+
+  it('opens the terminal in the session worktree, and in repoRoot when unbound', async () => {
+    const worktree = mkdtempSync(join(tmpdir(), 'inv-wt-'));
+    const repoRoot = mkdtempSync(join(tmpdir(), 'inv-root-'));
+    cleanups.push(() => rmSync(worktree, { recursive: true, force: true }));
+    cleanups.push(() => rmSync(repoRoot, { recursive: true, force: true }));
+
+    const spawns: Array<{ cwd: string }> = [];
+    const manager = new EmbeddedTerminalManager({
+      backend: {
+        name: 'bash',
+        spawn(opts) {
+          spawns.push({ cwd: opts.cwd });
+          return {
+            write() {},
+            resize() {},
+            getAppliedSize: () => null,
+            close() {},
+          };
+        },
+      },
+    });
+    const sessions: InAppPlanningChatSessions = new Map([
+      ['bound', makePlanningSession('bound', { worktreePath: worktree })],
+      ['unbound', makePlanningSession('unbound')],
+    ]);
+    const adapter = makeAdapter(sessions, manager, repoRoot);
+
+    const bound = await adapter.open('bound');
+    expect(bound.opened).toBe(true);
+    expect(spawns[0]?.cwd).toBe(worktree);
+    expect(bound.session?.cwd).toBe(worktree);
+
+    const unbound = await adapter.open('unbound');
+    expect(unbound.opened).toBe(true);
+    expect(spawns[1]?.cwd).toBe(repoRoot);
+  });
+});
+
+describe('planning terminal drives the running invoker', () => {
+  const cleanups: Array<() => void> = [];
+  afterEach(() => {
+    while (cleanups.length > 0) cleanups.pop()?.();
+  });
+
+  beforeAll(() => {
+    if (!existsSync(CLI_ENTRY)) {
+      execFileSync('pnpm', ['--filter', '@invoker/cli', 'build'], {
+        cwd: REPO_ROOT,
+        stdio: 'ignore',
+        timeout: 180_000,
+      });
+    }
+  });
+
+  it('"please delete all running workflows" typed into the terminal runs invoker-cli delete-all against the live owner', async () => {
+    const worktree = mkdtempSync(join(tmpdir(), 'inv-wt-'));
+    cleanups.push(() => rmSync(worktree, { recursive: true, force: true }));
+
+    // Short socket path: macOS sun_path is 104 bytes.
+    const sockDir = mkdtempSync(join('/tmp', 'inv-s-'));
+    const socketPath = join(sockDir, 's.sock');
+    cleanups.push(() => rmSync(sockDir, { recursive: true, force: true }));
+
+    // ── Live owner fixture: real IPC bus server with running workflows ──
+    const workflows = new Map<string, { status: string }>([
+      ['wf-run-1', { status: 'running' }],
+      ['wf-run-2', { status: 'running' }],
+    ]);
+    const execRequests: unknown[] = [];
+    const ownerBus = new IpcBus(socketPath);
+    await ownerBus.ready();
+    cleanups.push(() => ownerBus.disconnect());
+    ownerBus.onRequest('headless.owner-ping', async () => ({
+      ownerId: 'test-owner',
+      mode: 'standalone',
+    }));
+    ownerBus.onRequest('headless.exec', async (req: unknown) => {
+      execRequests.push(req);
+      const { args } = req as { args: string[] };
+      if (args[0] === 'delete-all') workflows.clear();
+      return { ok: true };
+    });
+
+    // ── Stand-in agent CLI: maps the request to its invoker tool call ──
+    const claudeStub = join(worktree, 'claude');
+    writeFileSync(
+      claudeStub,
+      [
+        '#!/bin/bash',
+        '# Test stand-in for the agent CLI: for this planning request the',
+        '# agent\'s tool call is the invoker delete-all mutation.',
+        'if [[ "$*" == *"please delete all running workflows"* ]]; then',
+        '  exec invoker-cli delete-all',
+        'fi',
+        'echo "unexpected prompt: $*" >&2',
+        'exit 1',
+        '',
+      ].join('\n'),
+    );
+    chmodSync(claudeStub, 0o755);
+    const cliShim = join(worktree, 'invoker-cli');
+    writeFileSync(
+      cliShim,
+      `#!/bin/bash\nexec "${process.execPath}" "${CLI_ENTRY}" "$@"\n`,
+    );
+    chmodSync(cliShim, 0o755);
+
+    // ── Real planning terminal (real bash child) over the adapter ──
+    const manager = new EmbeddedTerminalManager({ backend: createBashTerminalBackend() });
+    const sessions: InAppPlanningChatSessions = new Map([
+      ['ops', makePlanningSession('ops', { worktreePath: worktree })],
+    ]);
+    const adapter = makeAdapter(sessions, manager, '/tmp');
+
+    let output = '';
+    manager.on('output', (event: { data: string }) => {
+      output += event.data;
+    });
+
+    const opened = await adapter.open('ops');
+    expect(opened.opened).toBe(true);
+    const sessionId = opened.session!.sessionId;
+    cleanups.push(() => {
+      manager.close(sessionId);
+    });
+    expect(opened.session?.cwd).toBe(worktree);
+
+    const wrote = adapter.write(
+      sessionId,
+      `INVOKER_IPC_SOCKET='${socketPath}' PATH="$PWD:$PATH" claude "please delete all running workflows"\n`,
+    );
+    expect(wrote.ok).toBe(true);
+
+    await vi.waitFor(
+      () => {
+        expect(output).toContain('delete-all accepted by live owner.');
+      },
+      { timeout: 20_000, interval: 250 },
+    );
+
+    expect(execRequests).toEqual([{ args: ['delete-all'], noTrack: true }]);
+    expect(workflows.size).toBe(0);
+  }, 30_000);
+});

--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -96,6 +96,20 @@ describe('buildWebInvokerDispatch', () => {
     expect(await dispatch('invoker:get-execution-harnesses', [])).toEqual(harnesses);
   });
 
+  it('get-execution-harnesses honors the enabledExecutionAgents allowlist', async () => {
+    const harnesses = [
+      { name: 'claude', supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }] },
+      { name: 'codex', supportedModels: [] },
+    ];
+    const { dispatch } = makeDispatch({
+      agentRegistry: { listExecutionHarnesses: () => harnesses },
+      loadConfig: () => ({ enabledExecutionAgents: ['claude'] } as unknown as InvokerConfig),
+    });
+    expect(await dispatch('invoker:get-execution-harnesses', [])).toEqual([
+      { name: 'claude', supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }] },
+    ]);
+  });
+
   it('get-planning-presets returns configured planning presets', async () => {
     const { dispatch } = makeDispatch({
       loadConfig: () =>

--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -259,4 +259,69 @@ describe('buildWebInvokerDispatch', () => {
     const { dispatch } = makeDispatch();
     await expect(dispatch('invoker:does-not-exist', [])).rejects.toMatchObject({ code: 'unknown_channel' });
   });
+
+  describe('planning routes', () => {
+    it('routes planning-chat channels through guiMutations when wired', async () => {
+      const guiMutations = vi.fn(async (channel: string) => ({ ok: true, channel }));
+      const { dispatch } = makeDispatch({ guiMutations });
+      const request = { title: 'demo' };
+      expect(await dispatch('invoker:planning-chat-create', [request])).toEqual({
+        ok: true,
+        channel: 'invoker:planning-chat-create',
+      });
+      expect(guiMutations).toHaveBeenCalledWith('invoker:planning-chat-create', [request]);
+      await dispatch('invoker:planning-chat-list', []);
+      await dispatch('invoker:planning-chat-set-terminal-mode', [{ sessionId: 's1', mode: 'tmux' }]);
+      expect(guiMutations).toHaveBeenCalledTimes(3);
+    });
+
+    it('keeps the historical downgrades when guiMutations is absent', async () => {
+      const { dispatch } = makeDispatch();
+      await expect(dispatch('invoker:planning-chat-create', [{}])).rejects.toMatchObject({
+        code: 'unsupported_on_web',
+      });
+      expect(await dispatch('invoker:planning-chat-set-terminal-mode', [{}])).toEqual({
+        ok: false,
+        error: 'Planning tmux is not available in the web UI',
+      });
+    });
+
+    it('routes planning-terminal channels through the adapter when wired', async () => {
+      const planningTerminals = {
+        open: vi.fn(async (planningSessionId: string) => ({
+          opened: true,
+          session: { sessionId: `pt-${planningSessionId}`, taskId: `planning:${planningSessionId}`, kind: 'planning', status: 'running' },
+        })),
+        list: vi.fn(() => [{ sessionId: 'pt-1', taskId: 'planning:chat-1', kind: 'planning', status: 'running' }]),
+        write: vi.fn((sessionId: string, data: string) => ({ ok: true as const, sessionId, bytes: data.length })),
+        resize: vi.fn(() => ({ ok: true as const })),
+        appliedSize: vi.fn(() => ({ cols: 80, rows: 24 })),
+        close: vi.fn(() => ({ ok: true as const })),
+      };
+      const { dispatch } = makeDispatch({ planningTerminals });
+      const opened = await dispatch('invoker:planning-terminal-open', ['chat-1']) as { opened: boolean };
+      expect(opened.opened).toBe(true);
+      expect(planningTerminals.open).toHaveBeenCalledWith('chat-1');
+      expect(await dispatch('invoker:planning-terminal-list', [])).toHaveLength(1);
+      await dispatch('invoker:planning-terminal-write', ['pt-1', 'ls\n']);
+      expect(planningTerminals.write).toHaveBeenCalledWith('pt-1', 'ls\n');
+      await dispatch('invoker:planning-terminal-resize', ['pt-1', 120, 40]);
+      expect(planningTerminals.resize).toHaveBeenCalledWith('pt-1', 120, 40);
+      expect(await dispatch('invoker:planning-terminal-applied-size', ['pt-1'])).toEqual({ cols: 80, rows: 24 });
+      await dispatch('invoker:planning-terminal-close', ['pt-1']);
+      expect(planningTerminals.close).toHaveBeenCalledWith('pt-1');
+    });
+
+    it('keeps planning terminals downgraded when the adapter is absent', async () => {
+      const { dispatch } = makeDispatch();
+      expect(await dispatch('invoker:planning-terminal-open', ['chat-1'])).toEqual({
+        opened: false,
+        reason: 'Planning terminals are not available in the web UI',
+      });
+      expect(await dispatch('invoker:planning-terminal-list', [])).toEqual([]);
+      expect(await dispatch('invoker:planning-terminal-applied-size', ['pt-1'])).toBeNull();
+      expect(await dispatch('invoker:planning-terminal-write', ['pt-1', 'x'])).toEqual({ ok: false, reason: 'unsupported' });
+    });
+  });
+
 });

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -25,6 +25,17 @@ export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
     throw new Error('defaultExecutionModel requires defaultExecutionAgent');
   }
 
+  if (config.enabledExecutionAgents !== undefined) {
+    if (!Array.isArray(config.enabledExecutionAgents)) {
+      throw new Error('enabledExecutionAgents must be an array of agent names');
+    }
+    for (const entry of config.enabledExecutionAgents) {
+      if (typeof entry !== 'string' || entry.trim().length === 0) {
+        throw new Error('enabledExecutionAgents entries must be non-empty strings');
+      }
+    }
+  }
+
   validateConfiguredModel(config.defaultExecution?.executionAgent, config.defaultExecution?.executionModel);
   validateConfiguredModel(config.defaultExecutionAgent, config.defaultExecutionModel);
   return config;

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -178,6 +178,15 @@ export interface InvokerConfig {
   /** Default execution model for prompt-backed tasks when the task does not override it. */
   defaultExecutionModel?: string;
   /**
+   * Allowlist of execution agents offered by UI surfaces (execution-harness
+   * pickers and planning presets). Entries are agent names, e.g. 'claude',
+   * 'codex', 'omp'; matching is case-insensitive and whitespace-trimmed.
+   * Unset (or empty after trimming) means every registered agent is offered.
+   * This only restricts what surfaces offer — a task explicitly pinned to a
+   * disabled agent still runs.
+   */
+  enabledExecutionAgents?: string[];
+  /**
    * Config-owned default execution harness/model for tasks that omit them.
    * This is separate from Slack planning presets and applies across surfaces.
    */
@@ -502,6 +511,52 @@ export function loadConfig(): InvokerConfig {
 export function resolveDefaultExecutionAgent(config: InvokerConfig): string {
   const configured = config.defaultExecutionAgent?.trim();
   return configured && configured.length > 0 ? configured : BUILT_IN_DEFAULT_EXECUTION_AGENT;
+}
+
+/**
+ * Resolve the configured execution-agent allowlist.
+ * Returns null when `enabledExecutionAgents` is unset or empty after trimming
+ * (null = no restriction). Entries are trimmed and lowercased.
+ */
+export function resolveEnabledExecutionAgents(config: InvokerConfig): Set<string> | null {
+  const entries = (config.enabledExecutionAgents ?? [])
+    .map((name) => (typeof name === 'string' ? name.trim().toLowerCase() : ''))
+    .filter((name) => name.length > 0);
+  return entries.length > 0 ? new Set(entries) : null;
+}
+
+/**
+ * Filter execution harnesses down to the configured allowlist.
+ * No allowlist configured -> input returned unchanged.
+ */
+export function filterExecutionHarnesses<T extends { name: string }>(harnesses: T[], config: InvokerConfig): T[] {
+  const enabled = resolveEnabledExecutionAgents(config);
+  if (!enabled) return harnesses;
+  return harnesses.filter((harness) => enabled.has(harness.name.trim().toLowerCase()));
+}
+
+/** Planning tools that wrap another agent; their `model` names the wrapped agent. */
+const WRAPPER_PLANNING_TOOLS: Record<string, true> = { cursor: true, omp: true };
+
+/**
+ * Filter planning presets down to the configured allowlist.
+ * A preset is kept when its `tool` is allowlisted, or when the tool is a
+ * wrapper ('cursor'/'omp') whose `model` names an allowlisted agent.
+ * No allowlist configured -> input returned unchanged.
+ */
+export function filterPlanningPresets<T extends { tool: string; model?: string }>(
+  presets: T[],
+  config: InvokerConfig,
+): T[] {
+  const enabled = resolveEnabledExecutionAgents(config);
+  if (!enabled) return presets;
+  return presets.filter((preset) => {
+    const tool = preset.tool.trim().toLowerCase();
+    if (enabled.has(tool)) return true;
+    if (!WRAPPER_PLANNING_TOOLS[tool]) return false;
+    const model = preset.model?.trim().toLowerCase();
+    return Boolean(model && enabled.has(model));
+  });
 }
 
 

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -48,6 +48,7 @@ import {
   BOLD,
   RESET,
   createHeadlessExecutor,
+  createTrackedHeadlessExecutor,
   wireHeadlessApproveHook,
   buildHeadlessApiServerDeps,
   trackHeadlessWorkflow,
@@ -196,25 +197,7 @@ function printStartReadyOutcomeSummary(result: StartReadyResult, request: StartR
     process.stdout.write(`  workflow outcomes: ${succeeded} succeeded, ${failed} failed\n`);
   }
 }
-function createTrackedHeadlessExecutor(
-  deps: HeadlessDeps,
-  taskHandles: TaskHandleMap,
-) {
-  return createHeadlessExecutor(
-    {
-      ...deps,
-      ownerTaskRunnerProvider: undefined,
-    },
-    {
-      onSpawned: (taskId, handle, executor) => {
-        taskHandles.set(taskId, { handle, executor });
-      },
-      onComplete: (taskId) => {
-        taskHandles.delete(taskId);
-      },
-    },
-  );
-}
+
 
 function startTrackedHeadlessLaunchDispatcher(
   deps: HeadlessDeps,

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -37,6 +37,7 @@ import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import type { RuntimeServices } from '@invoker/runtime-service';
 import type { ReviewGateCiRepairCommandResult } from './review-gate-ci-repair-command.js';
 import type { WorkerRuntimeController } from './worker-control.js';
+import type { TaskHandleMap } from './execution/task-runner-wiring.js';
 
 
 export interface HeadlessDeps {
@@ -224,15 +225,40 @@ export function createHeadlessExecutor(
   return executor;
 }
 
-export function wireHeadlessApproveHook(deps: HeadlessDeps, te: TaskRunner): void {
-  deps.orchestrator.setBeforeApproveHook(async (task) => {
-    if (task.config.isMergeNode && task.config.workflowId && task.execution.pendingFixError === undefined) {
-      const workflow = deps.persistence.loadWorkflow(task.config.workflowId);
-      if (workflow?.mergeMode === "external_review") return;
-      await te.approveMerge(task.config.workflowId);
-    }
-  });
+/**
+ * Tracked variant of {@link createHeadlessExecutor}: registers every spawned
+ * task handle in `taskHandles` so surfaces that need live process handles
+ * (web task terminals) can reach running tasks. Strips
+ * `ownerTaskRunnerProvider` because an owner-provided TaskRunner ignores
+ * callback overrides.
+ */
+export function createTrackedHeadlessExecutor(
+  deps: HeadlessDeps,
+  taskHandles: TaskHandleMap,
+): TaskRunner {
+  return createHeadlessExecutor(
+    {
+      ...deps,
+      ownerTaskRunnerProvider: undefined,
+    },
+    {
+      onSpawned: (taskId, handle, executor) => {
+        taskHandles.set(taskId, { handle, executor });
+      },
+      onComplete: (taskId) => {
+        taskHandles.delete(taskId);
+      },
+    },
+  );
 }
+
+export function wireHeadlessApproveHook(deps: HeadlessDeps, te: TaskRunner): void { deps.orchestrator.setBeforeApproveHook(async (task) => {
+  if (task.config.isMergeNode && task.config.workflowId && task.execution.pendingFixError === undefined) {
+    const workflow = deps.persistence.loadWorkflow(task.config.workflowId);
+    if (workflow?.mergeMode === "external_review") return;
+    await te.approveMerge(task.config.workflowId);
+  }
+}); }
 
 export interface QueryFlags {
   output: 'text' | 'label' | 'json' | 'jsonl';

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -68,6 +68,7 @@ import {
   BOLD,
   RESET,
   createHeadlessExecutor,
+  createTrackedHeadlessExecutor,
   wireHeadlessApproveHook,
   parseQueryFlags,
   trackHeadlessWorkflow,
@@ -76,7 +77,7 @@ import {
   withRestoredTaskUnlessDeleteAllWon,
 } from './headless-shared.js';
 
-export { createHeadlessExecutor, wireHeadlessApproveHook, parseQueryFlags };
+export { createHeadlessExecutor, createTrackedHeadlessExecutor, wireHeadlessApproveHook, parseQueryFlags };
 export type { HeadlessDeps, QueryFlags };
 import { headlessQuery, headlessQuerySelect, renderWorkerStatus } from './headless-query-list.js';
 export { resolveAgentSession } from './headless-query-list.js';

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -28,6 +28,7 @@ import type {
   InAppPlanningStreamEvent,
   InAppPlanningSubmitRequest,
   InAppPlanningSubmitResponse,
+  InAppPlanningTurnStatus,
   Logger,
   PlanningConfirmationMode,
   PlanningTerminalMode,
@@ -118,6 +119,9 @@ export interface InAppPlanningChatSession {
   terminalExitCode?: number;
   terminalOutputSnapshot?: string;
   terminalUpdatedAt?: string;
+  activeTurnId?: string;
+  activeTurnStatus?: InAppPlanningTurnStatus;
+  activeTurnError?: string;
   createdAt: string;
   updatedAt: string;
   nextMessageId: number;
@@ -452,6 +456,9 @@ function sessionToRecord(session: InAppPlanningChatSession, pendingResponse: boo
     terminalExitCode: session.terminalExitCode,
     terminalOutputSnapshot: session.terminalOutputSnapshot ?? '',
     terminalUpdatedAt: session.terminalUpdatedAt,
+    activeTurnId: session.activeTurnId,
+    activeTurnStatus: session.activeTurnStatus,
+    activeTurnError: session.activeTurnError,
     pendingResponse,
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
@@ -507,6 +514,9 @@ function sessionToSummary(session: InAppPlanningChatSession): InAppPlanningSessi
     terminalExitCode: session.terminalExitCode,
     terminalOutputSnapshot: session.terminalOutputSnapshot ?? '',
     terminalUpdatedAt: session.terminalUpdatedAt,
+    activeTurnId: session.activeTurnId,
+    activeTurnStatus: session.activeTurnStatus,
+    activeTurnError: session.activeTurnError,
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
   };
@@ -848,8 +858,9 @@ export async function sendPlanningChatMessage(
     taggedMessage.confirmationMode ?? rawRequest?.confirmationMode,
     resolveDefaultPlanningConfirmationMode(deps.config),
   );
+  const turnId = (typeof rawRequest?.turnId === 'string' && rawRequest.turnId.trim()) || randomUUID();
   if (!message) {
-    return { ok: false, sessionId: rawRequest?.sessionId, error: 'Type a message first.' };
+    return { ok: false, sessionId: rawRequest?.sessionId, turnId, error: 'Type a message first.' };
   }
 
   const suppliedSessionId = typeof rawRequest?.sessionId === 'string'
@@ -864,6 +875,7 @@ export async function sendPlanningChatMessage(
       return {
         ok: false,
         sessionId: suppliedSessionId,
+        turnId,
         error: `Planning session "${suppliedSessionId}" was not found.`,
       };
     }
@@ -874,14 +886,18 @@ export async function sendPlanningChatMessage(
         confirmationMode: requestedConfirmationMode,
       }, deps);
       if ('error' in created) {
-        return { ok: false, sessionId, error: created.error };
+        return { ok: false, sessionId, turnId, error: created.error };
       }
       session = created;
       sessionId = session.id;
     }
     if (session.status === 'submitted') {
-      return { ok: false, sessionId: session.id, error: 'This planning session was already submitted. Start a new planning chat for changes.' };
+      return { ok: false, sessionId: session.id, turnId, error: 'This planning session was already submitted. Start a new planning chat for changes.' };
     }
+    if (session.activeTurnStatus === 'running' && session.activeTurnId === turnId) {
+      return { ok: false, sessionId: session.id, turnId, error: 'duplicate-turn' };
+    }
+    const isRetry = session.activeTurnStatus === 'failed' && session.activeTurnId === turnId;
 
     const activeSession = session;
     activeSession.confirmationMode = requestedConfirmationMode;
@@ -892,11 +908,36 @@ export async function sendPlanningChatMessage(
         role: entry.role,
         content: entry.text,
       }));
-      appendSessionMessage(activeSession, 'user', message);
+      if (!isRetry) {
+        appendSessionMessage(activeSession, 'user', message);
+      }
       if (activeSession.title === 'Untitled plan') {
         activeSession.title = titleFromMessage(message);
       }
+      activeSession.activeTurnId = turnId;
+      activeSession.activeTurnStatus = 'running';
+      activeSession.activeTurnError = undefined;
       persistPlanningSession(activeSession, deps.planningSessionStore, true);
+
+      const finishTurn = (response: Extract<InAppPlanningChatResponse, { ok: true }>): InAppPlanningChatResponse => {
+        activeSession.activeTurnId = undefined;
+        activeSession.activeTurnStatus = undefined;
+        activeSession.activeTurnError = undefined;
+        persistPlanningSession(activeSession, deps.planningSessionStore, false);
+        deps.onRawPlannerOutput?.({
+          sessionId: activeSession.id,
+          turnId,
+          turn: {
+            status: 'completed',
+            reply: response.reply,
+            confirmationMode: response.confirmationMode,
+            draftPlanAvailable: response.draftPlanAvailable,
+            draftPlanSummary: response.draftPlanSummary,
+            draftPlanText: response.draftPlanText,
+          },
+        });
+        return response;
+      };
 
       try {
         const hostedMessage = formatPlanningHostedTurn('in_app', message);
@@ -938,17 +979,17 @@ export async function sendPlanningChatMessage(
             ? 'draft_ready'
             : result.status;
           appendSessionMessage(activeSession, 'assistant', reply);
-          persistPlanningSession(activeSession, deps.planningSessionStore, false);
-          return {
+          return finishTurn({
             ok: true,
             sessionId: activeSession.id,
+            turnId,
             reply,
             reasoning,
             confirmationMode: activeSession.confirmationMode,
             draftPlanAvailable: hasDraftPlan(activeSession),
             draftPlanSummary: activeSession.draftPlanSummary,
             draftPlanText: activeSession.draftPlanText,
-          } as InAppPlanningChatResponse;
+          } as Extract<InAppPlanningChatResponse, { ok: true }>);
         }
 
         const review = preparePlanningReview({
@@ -961,40 +1002,49 @@ export async function sendPlanningChatMessage(
             ? 'draft_ready'
             : 'still_discussing';
           appendSessionMessage(activeSession, 'assistant', review.reply);
-          persistPlanningSession(activeSession, deps.planningSessionStore, false);
-          return {
+          return finishTurn({
             ok: true,
             sessionId: activeSession.id,
+            turnId,
             reply: review.reply,
             reasoning,
             confirmationMode: activeSession.confirmationMode,
             draftPlanAvailable: hasDraftPlan(activeSession),
             draftPlanSummary: activeSession.draftPlanSummary,
             draftPlanText: activeSession.draftPlanText,
-          } as InAppPlanningChatResponse;
+          } as Extract<InAppPlanningChatResponse, { ok: true }>);
         }
 
         activeSession.draftPlanSummary = review.summary;
         activeSession.draftPlanText = review.planText;
         activeSession.status = 'draft_ready';
         appendSessionMessage(activeSession, 'assistant', reply);
-        persistPlanningSession(activeSession, deps.planningSessionStore, false);
-        return {
+        return finishTurn({
           ok: true,
           sessionId: activeSession.id,
+          turnId,
           reply,
           reasoning,
           confirmationMode: activeSession.confirmationMode,
           draftPlanAvailable: true,
           draftPlanSummary: review.summary,
           draftPlanText: review.planText,
-        } as InAppPlanningChatResponse;
+        } as Extract<InAppPlanningChatResponse, { ok: true }>);
       } catch (error) {
+        const failureMessage = error instanceof Error ? error.message : String(error);
+        activeSession.activeTurnStatus = 'failed';
+        activeSession.activeTurnError = failureMessage;
         persistPlanningSession(activeSession, deps.planningSessionStore, false);
+        deps.onRawPlannerOutput?.({
+          sessionId: activeSession.id,
+          turnId,
+          turn: { status: 'failed', error: failureMessage },
+        });
         return {
           ok: false,
           sessionId: activeSession.id,
-          error: error instanceof Error ? error.message : String(error),
+          turnId,
+          error: failureMessage,
         };
       }
     });
@@ -1004,6 +1054,7 @@ export async function sendPlanningChatMessage(
     return {
       ok: false,
       sessionId,
+      turnId,
       error: error instanceof Error ? error.message : String(error),
     };
   }
@@ -1363,6 +1414,9 @@ export async function restorePlanningChatSessions(
       terminalExitCode: record.terminalExitCode,
       terminalOutputSnapshot: record.terminalOutputSnapshot ?? '',
       terminalUpdatedAt: record.terminalUpdatedAt,
+      activeTurnId: record.activeTurnId,
+      activeTurnStatus: record.activeTurnStatus,
+      activeTurnError: record.activeTurnError,
       createdAt: record.createdAt,
       updatedAt: record.updatedAt,
       nextMessageId,
@@ -1374,9 +1428,12 @@ export async function restorePlanningChatSessions(
         appendSessionMessage(
           session,
           'system',
-          'Planner was interrupted before it could answer. Send another message to continue.',
+          'Planner was interrupted before it could answer.',
           'error',
         );
+        session.activeTurnId = record.activeTurnId ?? randomUUID();
+        session.activeTurnStatus = 'failed';
+        session.activeTurnError = 'Planner was interrupted before it could answer.';
       }
       shouldPersist = true;
     }

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -1129,13 +1129,14 @@ export function setPlanningChatTerminalMode(
 
 export async function rebindPlanningChatRepo(
   request: InAppPlanningRebindRepoRequest,
-  deps: {
-    config: InvokerConfig;
+  deps: Pick<
+    InAppPlannerDeps,
+    'config' | 'workingDir' | 'planningCommandBuilder' | 'executionAgentRegistry'
+    | 'conversationRepo' | 'logger' | 'onRawPlannerOutput' | 'planDoctorScriptPath'
+  > & {
     sessions: InAppPlanningChatSessions;
     planningSessionStore?: InAppPlanningSessionStore;
     repoPool?: PlanningRepoPool;
-    workingDir?: string;
-    planDoctorScriptPath?: string;
   },
 ): Promise<InAppPlanningRebindRepoResponse> {
   const rawRequest = request as Partial<InAppPlanningRebindRepoRequest> | null | undefined;
@@ -1146,6 +1147,9 @@ export async function rebindPlanningChatRepo(
   }
   if (session.status === 'submitted') {
     return { ok: false, error: 'This planning session was already submitted. Start a new planning chat for changes.' };
+  }
+  if (session.messages.length > 0 || session.terminalSessionId) {
+    return { ok: false, error: 'Set the repo before the conversation or terminal starts.' };
   }
   if (!deps.repoPool) {
     return { ok: false, error: 'Worktree provisioning is not available.' };

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -53,7 +53,7 @@ import {
   type PlanningMessage,
 } from '@invoker/planning-core';
 import type { HarnessPreset, PlanConversation, PlanConversationConfig, PlanningCommandBuilder } from '@invoker/surfaces';
-import type { InvokerConfig } from './config.js';
+import { filterPlanningPresets, type InvokerConfig } from './config.js';
 import {
   ensurePlanningWorktreeReady,
   planningMcpConfigPath,
@@ -733,11 +733,17 @@ async function createSession(
   return session;
 }
 
+/**
+ * List the planning presets offered to pickers.
+ * The `enabledExecutionAgents` allowlist is applied HERE (not at the IPC/web
+ * dispatch surfaces) so every caller — the Electron IPC handler and the web
+ * dispatch — gets the same filtered view without double-filtering.
+ */
 export async function listInAppPlanningPresets(config: InvokerConfig): Promise<PlanningPresetOption[]> {
   const presets = await resolveHarnessPresets(config);
   const defaultPresetKey = await resolveDefaultPresetKey(config);
   const defaultConfirmationMode = resolveDefaultPlanningConfirmationMode(config);
-  return Object.entries(presets).map(([key, preset]) => ({
+  const options = Object.entries(presets).map(([key, preset]) => ({
     key,
     label: labelForPresetKey(key),
     tool: preset.tool,
@@ -745,6 +751,7 @@ export async function listInAppPlanningPresets(config: InvokerConfig): Promise<P
     isDefault: key === defaultPresetKey,
     defaultConfirmationMode,
   }));
+  return filterPlanningPresets(options, config);
 }
 
 export function createPlanningCommandBuilderFromRegistry(

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1434,6 +1434,11 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
     return rebindPlanningChatRepo(request as InAppPlanningRebindRepoRequest, {
       config: invokerConfig,
       sessions: planningChatSessions,
+      planningCommandBuilder,
+      executionAgentRegistry: agentRegistry,
+      conversationRepo: planningConversationRepo,
+      logger,
+      onRawPlannerOutput: emitPlanningChatStream,
       planningSessionStore: ownerMode ? persistence : undefined,
       repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
       workingDir: repoRoot,

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -42,6 +42,7 @@ import {
 import type { AgentRegistry, WorkerRegistry, WorkerRuntimeDependencies } from '@invoker/execution-engine';
 import {
   DEFAULT_SLACK_HARNESS_PRESETS,
+  filterExecutionHarnesses,
   loadConfig,
   resolveAutoFixExecutionModel,
   resolveDefaultTaskExecutionSettings,
@@ -2684,7 +2685,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   });
 
   ipcMain.handle('invoker:get-execution-harnesses', () => {
-    return agentRegistry.listExecutionHarnesses();
+    return filterExecutionHarnesses(agentRegistry.listExecutionHarnesses(), loadConfig());
   });
 
   ipcMain.handle('invoker:get-planning-presets', () => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1452,6 +1452,11 @@ function startHeadlessMode(): void {
             return rebindPlanningChatRepo(payload.args[0] as InAppPlanningRebindRepoRequest, {
               config: invokerConfig,
               sessions: planningChatSessions,
+              planningCommandBuilder,
+              executionAgentRegistry: agentRegistry,
+              conversationRepo: planningConversationRepo,
+              logger,
+              onRawPlannerOutput: emitPlanningChatStreamToWeb,
               planningSessionStore: readOnlyMode ? undefined : persistence,
               repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
               workingDir: repoRoot,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -68,6 +68,8 @@ import type {
   InAppPlanningListSessionsResponse,
   InAppPlanningRebindRepoRequest,
   InAppPlanningResetRequest,
+  InAppPlanningSetTerminalModeRequest,
+  InAppPlanningStreamEvent,
   InAppPlanningSubmitRequest,
   Logger,
   StartReadyRequest,
@@ -159,6 +161,7 @@ import {
   tryDelegateExec,
   tryDelegateQuery,
   createHeadlessExecutor,
+  createTrackedHeadlessExecutor,
   wireHeadlessApproveHook,
   type HeadlessDeps,
 } from './headless.js';
@@ -254,6 +257,7 @@ import {
 } from './renderer-ui-perf.js';
 import {
   bindPlanningTerminalSessionState,
+  createPlanningTerminalAdapter,
   registerPlanningTerminalSessionIpcHandlers,
   registerTerminalSessionIpcHandlers,
   registerTerminalSessionPersistence,
@@ -284,6 +288,7 @@ import {
   resetPlanningChat,
   restorePlanningChatSessions,
   sendPlanningChatMessage,
+  setPlanningChatTerminalMode,
   submitPlanningChatDraft,
 } from './in-app-planner.js';
 import { discoverOwner, isStandaloneCapable } from './owner-endpoint.js';
@@ -1246,11 +1251,16 @@ function startHeadlessMode(): void {
         getWorkerRuntimeController: () => workerRuntimeController,
       } as HeadlessDeps;
 
-      const createStandaloneTaskExecutor = (): TaskRunner => {
-        const executor = createHeadlessExecutor(headlessDeps);
-        wireHeadlessApproveHook(headlessDeps, executor);
-        return executor;
-      };
+      // Every standalone execution path (launch dispatcher, fix/retry handlers,
+            // REST mutations) builds its executor through this factory, so one shared
+            // handle map covers all owner-serve task processes. The web surface needs
+            // those live handles to open task terminals in the browser.
+            const standaloneTaskHandles: TaskHandleMap = new Map();
+            const createStandaloneTaskExecutor = (): TaskRunner => {
+              const executor = createTrackedHeadlessExecutor(headlessDeps, standaloneTaskHandles);
+              wireHeadlessApproveHook(headlessDeps, executor);
+              return executor;
+            };
 
       const executeStandaloneHeadlessRun = async (payload: HeadlessRunMutationPayload): Promise<unknown> => {
         const { applyConfiguredPlanDefaults, parsePlanFile } = await import('./plan-parser.js');
@@ -1289,6 +1299,14 @@ function startHeadlessMode(): void {
         })
       );
 
+      // Web clients get planning-chat token streaming over SSE. The bridge does
+      // not exist yet when these handlers are built, so route through a
+      // mutable ref that owner-serve fills in after the web surface starts.
+      let broadcastPlanningChatStream: ((event: InAppPlanningStreamEvent) => void) | undefined;
+      const emitPlanningChatStreamToWeb = (event: InAppPlanningStreamEvent): void => {
+        broadcastPlanningChatStream?.(event);
+      };
+
       const planningConversationRepo = new ConversationRepository(persistence, {
         info: (message) => logger.info(message, { module: 'planning-chat' }),
         warn: (message) => logger.warn(message, { module: 'planning-chat' }),
@@ -1305,6 +1323,7 @@ function startHeadlessMode(): void {
         conversationRepo: planningConversationRepo,
         planningSessionStore: readOnlyMode ? undefined : persistence,
         logger,
+        onRawPlannerOutput: emitPlanningChatStreamToWeb,
         repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
       });
 
@@ -1365,6 +1384,7 @@ function startHeadlessMode(): void {
               conversationRepo: planningConversationRepo,
               planningSessionStore: readOnlyMode ? undefined : persistence,
               logger,
+              onRawPlannerOutput: emitPlanningChatStreamToWeb,
               repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
             });
           }
@@ -1399,6 +1419,7 @@ function startHeadlessMode(): void {
               planningSessionStore: readOnlyMode ? undefined : persistence,
               logger,
               plannerReplyOverride,
+              onRawPlannerOutput: emitPlanningChatStreamToWeb,
               repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
             });
           }
@@ -1417,6 +1438,12 @@ function startHeadlessMode(): void {
           }
           case 'invoker:planning-chat-reset': {
             return resetPlanningChat(payload.args[0] as InAppPlanningResetRequest, {
+              sessions: planningChatSessions,
+              planningSessionStore: readOnlyMode ? undefined : persistence,
+            });
+          }
+          case 'invoker:planning-chat-set-terminal-mode': {
+            return setPlanningChatTerminalMode(payload.args[0] as InAppPlanningSetTerminalModeRequest, {
               sessions: planningChatSessions,
               planningSessionStore: readOnlyMode ? undefined : persistence,
             });
@@ -2092,10 +2119,17 @@ function startHeadlessMode(): void {
               executionAgentRegistry: agentRegistry,
               invokerConfig,
               repoRoot,
+              executorRegistry,
+              taskHandles: standaloneTaskHandles,
               appRootDir: __dirname,
+              guiMutations: (channel, args) => executeStandaloneGuiMutation({ channel, args } as GuiMutationPayload),
+              planningChatSessions,
             },
             apiServerDeps,
           );
+          broadcastPlanningChatStream = (event) => {
+            headlessWebBridge?.broadcast('invoker:planning-chat-stream', event);
+          };
           startOwnerSocketSentinelForBus(messageBus);
         }
 
@@ -2291,6 +2325,16 @@ startMainProcessBootstrap({
       };
     },
   };
+  // Planning terminals for the desktop-owned web surface. Shares the same
+  // EmbeddedTerminalManager and session map as the Electron IPC handlers, so
+  // browser and desktop views stay consistent.
+  const webPlanningTerminals = createPlanningTerminalAdapter({
+    embeddedTerminalManager,
+    logger,
+    planningChatSessions,
+    getPlanningSessionStore: () => (ownerMode ? persistence : undefined),
+    repoRoot,
+  });
   const startupMarks = new Map<string, number>();
   const startupPhaseDetails: Array<Record<string, unknown>> = [];
   const recordStartupMark = (phase: string, extra?: Record<string, unknown>): void => {
@@ -2728,6 +2772,14 @@ startMainProcessBootstrap({
             autoStartKinds: autoStartedOwnerWorkerKindsForConfig(invokerConfig),
           }),
           taskTerminals,
+          guiMutations: async (channel, args) => {
+            const handler = guiMutationHandlers.get(channel);
+            if (!handler) {
+              throw new Error(`No GUI mutation handler registered for ${channel}`);
+            }
+            return handler(...args);
+          },
+          planningTerminals: webPlanningTerminals,
           getSystemDiagnostics: () => collectSystemDiagnostics({
             appVersion: app.getVersion(),
             isPackaged: app.isPackaged,
@@ -3325,6 +3377,7 @@ startMainProcessBootstrap({
         if (mainWindow && !mainWindow.isDestroyed() && uiInteractive) {
           mainWindow.webContents.send('invoker:planning-chat-stream', event);
         }
+        webBridge?.broadcast('invoker:planning-chat-stream', event);
       },
       taskGraphEventPublisher,
       loadTaskByIdFromPersistence,

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -11,10 +11,12 @@ import {
   type TerminalUiPerfReporter,
   type TerminalUiPerfSink,
 } from './terminal-ui-perf.js';
+import { existsSync } from 'node:fs';
 import {
   ensurePlanningTerminalSummaryBridge,
   hydrateRemotePlanningTerminalSession,
   updatePlanningChatTerminalState,
+  type InAppPlanningChatSession,
   type InAppPlanningChatSessions,
   type InAppPlanningSessionStore,
 } from './in-app-planner.js';
@@ -385,6 +387,21 @@ function planningTerminalWritable(
   return { ok: true };
 }
 
+/**
+ * Planning terminals follow the conversation's repo binding: a session bound
+ * to a repo opens its terminal in that provisioned worktree; unbound sessions
+ * (and sessions whose worktree no longer exists on disk) fall back to the
+ * owner's repoRoot.
+ */
+export function resolvePlanningTerminalCwd(
+  session: Pick<InAppPlanningChatSession, 'worktreePath'>,
+  repoRoot: string,
+): string {
+  const worktreePath = session.worktreePath?.trim();
+  if (worktreePath && existsSync(worktreePath)) return worktreePath;
+  return repoRoot;
+}
+
 function planningTerminalTargetKey(planningSessionId: string, repoRoot: string): string {
   return JSON.stringify({
     kind: 'planning',
@@ -444,14 +461,15 @@ export function bindPlanningTerminalSessionState(deps: {
           session.terminalOutputSnapshot ?? '',
           MAX_OUTPUT_SNAPSHOT_CHARS,
         );
+        const terminalCwd = resolvePlanningTerminalCwd(session, repoRoot);
         embeddedTerminalManager.restoreSpawnSession({
           sessionId: session.terminalSessionId,
           taskId: `planning:${session.id}`,
           kind: 'planning',
           planningSessionId: session.id,
-          targetKey: planningTerminalTargetKey(session.id, repoRoot),
-          spec: { cwd: repoRoot },
-          cwd: repoRoot,
+          targetKey: planningTerminalTargetKey(session.id, terminalCwd),
+          spec: { cwd: terminalCwd },
+          cwd: terminalCwd,
           createdAt: session.terminalUpdatedAt ?? session.updatedAt,
           outputSnapshot,
         });
@@ -540,12 +558,13 @@ export function createPlanningTerminalAdapter(deps: PlanningTerminalAdapterDeps)
           planningSession.terminalOutputSnapshot ?? '',
           MAX_OUTPUT_SNAPSHOT_CHARS,
         );
+        const terminalCwd = resolvePlanningTerminalCwd(planningSession, repoRoot);
         const session = embeddedTerminalManager.openOrReuse({
           kind: 'planning',
           taskId: `planning:${planningSessionId}`,
           planningSessionId,
-          spec: { cwd: repoRoot },
-          cwd: repoRoot,
+          spec: { cwd: terminalCwd },
+          cwd: terminalCwd,
           outputSnapshot,
         });
         updatePlanningChatTerminalState(planningSessionId, {

--- a/packages/app/src/terminal-session-ipc.ts
+++ b/packages/app/src/terminal-session-ipc.ts
@@ -477,8 +477,7 @@ export function bindPlanningTerminalSessionState(deps: {
   return { restorePersistedPlanningTerminals };
 }
 
-export function registerPlanningTerminalSessionIpcHandlers(deps: {
-  ipcMain: IpcMain;
+export interface PlanningTerminalAdapterDeps {
   embeddedTerminalManager: EmbeddedTerminalManager;
   logger: PlanningTerminalLogger;
   planningChatSessions: InAppPlanningChatSessions;
@@ -486,9 +485,25 @@ export function registerPlanningTerminalSessionIpcHandlers(deps: {
   repoRoot: string;
   resolveRemotePlanningSession?: (planningSessionId: string) => Promise<InAppPlanningSessionSummary | undefined>;
   isPlanningTerminalWriteAllowed?: () => boolean;
-}): void {
+}
+
+/**
+ * Transport-neutral planning-terminal operations shared by the Electron IPC
+ * handlers and the web-surface dispatch. All state lives in the
+ * EmbeddedTerminalManager and the planning chat session map, so multiple
+ * adapter instances over the same stores stay consistent.
+ */
+export interface PlanningTerminalAdapter {
+  open(planningSessionId: string): Promise<{ opened: boolean; reason?: string; session?: TerminalSessionDescriptor }>;
+  list(): TerminalSessionDescriptor[];
+  write(sessionId: string, data: string): { ok: boolean; reason?: string };
+  resize(sessionId: string, cols: number, rows: number): { ok: boolean; reason?: string };
+  appliedSize(sessionId: string): { cols: number; rows: number } | null;
+  close(sessionId: string): { ok: boolean; reason?: string };
+}
+
+export function createPlanningTerminalAdapter(deps: PlanningTerminalAdapterDeps): PlanningTerminalAdapter {
   const {
-    ipcMain,
     embeddedTerminalManager,
     logger,
     planningChatSessions,
@@ -498,89 +513,122 @@ export function registerPlanningTerminalSessionIpcHandlers(deps: {
     isPlanningTerminalWriteAllowed = () => Boolean(getPlanningSessionStore()),
   } = deps;
 
-  ipcMain.handle('invoker:planning-terminal-open', async (_event, planningSessionIdArg: string) => {
-    const planningSessionId = String(planningSessionIdArg ?? '').trim();
-    if (!planningSessionId) {
-      return { opened: false, reason: 'Planning session id is required.' };
-    }
-    let planningSession = planningChatSessions.get(planningSessionId);
-    if (!planningSession && resolveRemotePlanningSession) {
-      const remoteSummary = await resolveRemotePlanningSession(planningSessionId);
-      if (remoteSummary) {
-        planningSession = hydrateRemotePlanningTerminalSession(remoteSummary);
-        planningChatSessions.set(planningSessionId, planningSession);
+  return {
+    async open(planningSessionIdArg: string) {
+      const planningSessionId = String(planningSessionIdArg ?? '').trim();
+      if (!planningSessionId) {
+        return { opened: false, reason: 'Planning session id is required.' };
       }
-    }
-    if (!planningSession) {
-      return { opened: false, reason: 'Planning conversation was not found.' };
-    }
-    if (planningSession.status === 'submitted') {
-      return { opened: false, reason: 'This planning session was already submitted.' };
-    }
-    logger.info(`invoked for planningSession="${planningSessionId}"`, { module: 'planning-terminal' });
-    try {
-      const outputSnapshot = ensurePlanningTerminalSummaryBridge(
-        planningSession,
-        planningSession.terminalOutputSnapshot ?? '',
-        MAX_OUTPUT_SNAPSHOT_CHARS,
+      let planningSession = planningChatSessions.get(planningSessionId);
+      if (!planningSession && resolveRemotePlanningSession) {
+        const remoteSummary = await resolveRemotePlanningSession(planningSessionId);
+        if (remoteSummary) {
+          planningSession = hydrateRemotePlanningTerminalSession(remoteSummary);
+          planningChatSessions.set(planningSessionId, planningSession);
+        }
+      }
+      if (!planningSession) {
+        return { opened: false, reason: 'Planning conversation was not found.' };
+      }
+      if (planningSession.status === 'submitted') {
+        return { opened: false, reason: 'This planning session was already submitted.' };
+      }
+      logger.info(`invoked for planningSession="${planningSessionId}"`, { module: 'planning-terminal' });
+      try {
+        const outputSnapshot = ensurePlanningTerminalSummaryBridge(
+          planningSession,
+          planningSession.terminalOutputSnapshot ?? '',
+          MAX_OUTPUT_SNAPSHOT_CHARS,
+        );
+        const session = embeddedTerminalManager.openOrReuse({
+          kind: 'planning',
+          taskId: `planning:${planningSessionId}`,
+          planningSessionId,
+          spec: { cwd: repoRoot },
+          cwd: repoRoot,
+          outputSnapshot,
+        });
+        updatePlanningChatTerminalState(planningSessionId, {
+          terminalMode: 'tmux',
+          terminalSessionId: session.sessionId,
+          terminalStatus: session.status,
+          terminalExitCode: session.exitCode,
+          terminalOutputSnapshot: session.outputSnapshot ?? '',
+          touchSessionUpdatedAt: true,
+        }, {
+          sessions: planningChatSessions,
+          planningSessionStore: getPlanningSessionStore(),
+        });
+        return { opened: true, session };
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        logger.warn(`planning terminal spawn failed for session="${planningSessionId}": ${reason}`, { module: 'planning-terminal' });
+        return { opened: false, reason: `Failed to start planning terminal session: ${reason}` };
+      }
+    },
+
+    list() {
+      return embeddedTerminalManager.list().filter((session) => session.kind === 'planning');
+    },
+
+    write(sessionId: string, data: string) {
+      const allowed = planningTerminalWritable(
+        embeddedTerminalManager,
+        planningChatSessions,
+        isPlanningTerminalWriteAllowed,
+        sessionId,
       );
-      const session = embeddedTerminalManager.openOrReuse({
-        kind: 'planning',
-        taskId: `planning:${planningSessionId}`,
-        planningSessionId,
-        spec: { cwd: repoRoot },
-        cwd: repoRoot,
-        outputSnapshot,
-      });
-      updatePlanningChatTerminalState(planningSessionId, {
-        terminalMode: 'tmux',
-        terminalSessionId: session.sessionId,
-        terminalStatus: session.status,
-        terminalExitCode: session.exitCode,
-        terminalOutputSnapshot: session.outputSnapshot ?? '',
-        touchSessionUpdatedAt: true,
-      }, {
-        sessions: planningChatSessions,
-        planningSessionStore: getPlanningSessionStore(),
-      });
-      return { opened: true, session };
-    } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err);
-      logger.warn(`planning terminal spawn failed for session="${planningSessionId}": ${reason}`, { module: 'planning-terminal' });
-      return { opened: false, reason: `Failed to start planning terminal session: ${reason}` };
-    }
+      if (!allowed.ok) return allowed;
+      return embeddedTerminalManager.write(sessionId, data);
+    },
+
+    resize(sessionId: string, cols: number, rows: number) {
+      const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
+      if (!allowed.ok) return allowed;
+      return embeddedTerminalManager.resize(sessionId, cols, rows);
+    },
+
+    appliedSize(sessionId: string) {
+      const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
+      if (!allowed.ok) return null;
+      return embeddedTerminalManager.getAppliedSize(sessionId);
+    },
+
+    close(sessionId: string) {
+      const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
+      if (!allowed.ok) return allowed;
+      return embeddedTerminalManager.close(sessionId);
+    },
+  };
+}
+
+export function registerPlanningTerminalSessionIpcHandlers(deps: PlanningTerminalAdapterDeps & {
+  ipcMain: IpcMain;
+}): void {
+  const { ipcMain, ...adapterDeps } = deps;
+  const adapter = createPlanningTerminalAdapter(adapterDeps);
+
+  ipcMain.handle('invoker:planning-terminal-open', async (_event, planningSessionIdArg: string) => {
+    return adapter.open(planningSessionIdArg);
   });
 
   ipcMain.handle('invoker:planning-terminal-list', async () => {
-    return embeddedTerminalManager.list().filter((session) => session.kind === 'planning');
+    return adapter.list();
   });
 
   ipcMain.handle('invoker:planning-terminal-write', async (_event, sessionId: string, data: string) => {
-    const allowed = planningTerminalWritable(
-      embeddedTerminalManager,
-      planningChatSessions,
-      isPlanningTerminalWriteAllowed,
-      sessionId,
-    );
-    if (!allowed.ok) return allowed;
-    return embeddedTerminalManager.write(sessionId, data);
+    return adapter.write(sessionId, data);
   });
 
   ipcMain.handle('invoker:planning-terminal-resize', async (_event, sessionId: string, cols: number, rows: number) => {
-    const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
-    if (!allowed.ok) return allowed;
-    return embeddedTerminalManager.resize(sessionId, cols, rows);
+    return adapter.resize(sessionId, cols, rows);
   });
 
   ipcMain.handle('invoker:planning-terminal-applied-size', async (_event, sessionId: string) => {
-    const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
-    if (!allowed.ok) return null;
-    return embeddedTerminalManager.getAppliedSize(sessionId);
+    return adapter.appliedSize(sessionId);
   });
 
   ipcMain.handle('invoker:planning-terminal-close', async (_event, sessionId: string) => {
-    const allowed = planningTerminalOnly(embeddedTerminalManager, planningChatSessions, sessionId);
-    if (!allowed.ok) return allowed;
-    return embeddedTerminalManager.close(sessionId);
+    return adapter.close(sessionId);
   });
 }

--- a/packages/app/src/web/start-web-surface.ts
+++ b/packages/app/src/web/start-web-surface.ts
@@ -46,9 +46,12 @@ import {
   createTerminalUiPerfSink,
 } from '../terminal-ui-perf.js';
 import {
+  createPlanningTerminalAdapter,
   registerTerminalSessionPersistence,
+  type PlanningTerminalAdapter,
   type TerminalSessionPersistenceHandle,
 } from '../terminal-session-ipc.js';
+import type { InAppPlanningChatSessions } from '../in-app-planner.js';
 import { WorkflowRollupProjection } from '../workflow-rollup-projection.js';
 import { autoStartedOwnerWorkerKindsForConfig, createLocalWorkerStatusSnapshot } from '../worker-control.js';
 import { buildWebInvokerDispatch } from './web-invoker-dispatch.js';
@@ -95,6 +98,10 @@ export interface StartHeadlessWebSurfaceDeps {
   /** Main process dist directory (`__dirname` of main.js) used to locate the built UI. */
   appRootDir: string;
   getBundledSkillsStatus?: () => BundledSkillsStatus;
+  /** Routes planning-chat channels to the owner's shared GUI-mutation handlers. */
+  guiMutations?: (channel: string, args: unknown[]) => Promise<unknown>;
+  /** Enables planning terminals over the web when present (with repoRoot + executorRegistry + taskHandles). */
+  planningChatSessions?: InAppPlanningChatSessions;
 }
 
 export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebBridge | null {
@@ -113,6 +120,7 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
 
   let terminalSessionPersistenceHandle: TerminalSessionPersistenceHandle | null = null;
   let taskTerminals: TaskTerminalAdapter | undefined;
+  let planningTerminals: PlanningTerminalAdapter | undefined;
   let terminalEvents: WebBridgeTerminalEvents | undefined;
   if (deps.repoRoot && deps.executorRegistry && deps.taskHandles) {
     const embeddedTerminalManager = new EmbeddedTerminalManager({
@@ -159,6 +167,16 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
         };
       },
     };
+    if (deps.planningChatSessions) {
+      const planningChatSessions = deps.planningChatSessions;
+      planningTerminals = createPlanningTerminalAdapter({
+        embeddedTerminalManager,
+        logger: deps.logger,
+        planningChatSessions,
+        getPlanningSessionStore: () => deps.persistence,
+        repoRoot: deps.repoRoot,
+      });
+    }
   }
   const streamSeq = createTaskDeltaStreamSequence();
   const projection = new WorkflowRollupProjection();
@@ -210,6 +228,8 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
       autoStartKinds: autoStartedOwnerWorkerKindsForConfig(deps.config),
     }),
     taskTerminals,
+    guiMutations: deps.guiMutations,
+    planningTerminals,
     logger: deps.logger,
   });
 
@@ -253,6 +273,8 @@ export interface HeadlessWebSurfaceHost {
   taskHandles?: TaskHandleMap;
   appRootDir?: string;
   getBundledSkillsStatus?: () => BundledSkillsStatus;
+  guiMutations?: (channel: string, args: unknown[]) => Promise<unknown>;
+  planningChatSessions?: InAppPlanningChatSessions;
 }
 
 /**
@@ -284,5 +306,7 @@ export function startWebSurfaceForHeadless(
     taskHandles: host.taskHandles,
     appRootDir: host.appRootDir ?? __dirname,
     getBundledSkillsStatus: host.getBundledSkillsStatus,
+    guiMutations: host.guiMutations,
+    planningChatSessions: host.planningChatSessions,
   });
 }

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -33,6 +33,22 @@ import { resolveAgentSession } from '../headless-query-list.js';
 import { buildTaskGraphSnapshot } from './task-graph-snapshot.js';
 import type { TaskTerminalAdapter } from '../task-terminal-adapter.js';
 
+
+/**
+ * Consumer-side port for planning terminals. The owner hosts pass the adapter
+ * built by `createPlanningTerminalAdapter` (terminal-session-ipc.ts), which
+ * satisfies this shape structurally; declaring the port here keeps the web
+ * dispatch free of a hard dependency on the Electron IPC module's exports.
+ */
+export interface WebPlanningTerminals {
+  open(planningSessionId: string): Promise<{ opened: boolean; reason?: string; session?: unknown }>;
+  list(): unknown[] | Promise<unknown[]>;
+  write(sessionId: string, data: string): { ok: boolean; reason?: string } | Promise<{ ok: boolean; reason?: string }>;
+  resize(sessionId: string, cols: number, rows: number): { ok: boolean; reason?: string } | Promise<{ ok: boolean; reason?: string }>;
+  appliedSize(sessionId: string): { cols: number; rows: number } | null | Promise<{ cols: number; rows: number } | null>;
+  close(sessionId: string): { ok: boolean; reason?: string } | Promise<{ ok: boolean; reason?: string }>;
+}
+
 export interface WebInvokerDispatchDeps {
   orchestrator: Orchestrator;
   persistence: SQLiteAdapter;
@@ -51,6 +67,13 @@ export interface WebInvokerDispatchDeps {
   checkPrStatuses?: () => void | Promise<void>;
   getWorkers?: () => WorkerStatusSnapshot;
   taskTerminals?: TaskTerminalAdapter;
+  /**
+   * Routes planning-chat channels (and plan-from-goal) to the owner's shared
+   * GUI-mutation handlers. Wired by both the desktop-owned and headless web
+   * surfaces; absent means the historical web downgrades stay in effect.
+   */
+  guiMutations?: (channel: string, args: unknown[]) => Promise<unknown>;
+  planningTerminals?: WebPlanningTerminals;
   logger?: Logger;
 }
 
@@ -279,15 +302,41 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
           return { ok: false, reason: 'unsupported' };
         }
         return deps.taskTerminals.close(String(args[0]));
+      // ── Planning chat + planning terminals ──
+      // Routed to the owner's shared GUI-mutation handlers / terminal adapter
+      // when the host wires them; otherwise keep the historical downgrades.
+      case 'invoker:plan-from-goal':
+      case 'invoker:planning-chat-create':
+      case 'invoker:planning-chat-list':
+      case 'invoker:planning-chat-send':
+      case 'invoker:planning-chat-submit':
+      case 'invoker:planning-chat-discard-draft':
+      case 'invoker:planning-chat-reset':
+      case 'invoker:planning-chat-delete':
+      case 'invoker:planning-chat-delete-submitted':
+      case 'invoker:planning-chat-rebind-repo':
+        if (deps.guiMutations) return deps.guiMutations(channel, args);
+        return unsupported(channel);
+      case 'invoker:planning-chat-set-terminal-mode':
+        if (deps.guiMutations) return deps.guiMutations(channel, args);
+        return { ok: false, error: 'Planning tmux is not available in the web UI' };
       case 'invoker:planning-terminal-open':
+        if (deps.planningTerminals) return deps.planningTerminals.open(String(args[0]));
         return { opened: false, reason: 'Planning terminals are not available in the web UI' };
       case 'invoker:planning-terminal-list':
-        return [];
-      case 'invoker:planning-chat-set-terminal-mode':
-        return { ok: false, error: 'Planning tmux is not available in the web UI' };
+        return deps.planningTerminals?.list() ?? [];
+      case 'invoker:planning-terminal-applied-size':
+        return deps.planningTerminals?.appliedSize(String(args[0])) ?? null;
       case 'invoker:planning-terminal-write':
+        if (deps.planningTerminals) return deps.planningTerminals.write(String(args[0]), String(args[1]));
+        return { ok: false, reason: 'unsupported' };
       case 'invoker:planning-terminal-resize':
+        if (deps.planningTerminals) {
+          return deps.planningTerminals.resize(String(args[0]), Number(args[1]), Number(args[2]));
+        }
+        return { ok: false, reason: 'unsupported' };
       case 'invoker:planning-terminal-close':
+        if (deps.planningTerminals) return deps.planningTerminals.close(String(args[0]));
         return { ok: false, reason: 'unsupported' };
 
       // ── Mutations not exposed on the facade / global lifecycle ──

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -22,7 +22,7 @@ import type {
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { AgentRegistry } from '@invoker/execution-engine';
 import type { ExternalGatePolicyUpdate, Orchestrator } from '@invoker/workflow-core';
-import { resolveDefaultTaskExecutionSettings, type InvokerConfig } from '../config.js';
+import { filterExecutionHarnesses, resolveDefaultTaskExecutionSettings, type InvokerConfig } from '../config.js';
 import { listInAppPlanningPresets } from '../in-app-planner.js';
 import type { ApiMutationFacade } from '../api-server.js';
 import { getEventsPage } from '../get-events-page.js';
@@ -174,7 +174,7 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       case 'invoker:get-execution-pools':
         return Object.keys(deps.loadConfig().executionPools ?? {});
       case 'invoker:get-execution-harnesses':
-        return agentRegistry.listExecutionHarnesses();
+        return filterExecutionHarnesses(agentRegistry.listExecutionHarnesses(), deps.loadConfig());
       case 'invoker:get-planning-presets':
         return listInAppPlanningPresets(deps.loadConfig());
       case 'invoker:get-execution-defaults':

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -500,6 +500,9 @@ export interface InAppPlanningSessionSummary {
   terminalExitCode?: number;
   terminalOutputSnapshot?: string;
   terminalUpdatedAt?: string;
+  activeTurnId?: string;
+  activeTurnStatus?: InAppPlanningTurnStatus;
+  activeTurnError?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -525,9 +528,25 @@ export type InAppPlanningListSessionsResponse = {
   sessions: InAppPlanningSessionSummary[];
 };
 
+export type InAppPlanningTurnStatus = 'running' | 'failed';
+
+export type InAppPlanningTurnOutcome =
+  | {
+      status: 'completed';
+      reply: string;
+      reasoning?: string;
+      confirmationMode?: PlanningConfirmationMode;
+      draftPlanAvailable: boolean;
+      draftPlanSummary?: InAppPlanningPlanSummary;
+      draftPlanText?: string;
+    }
+  | { status: 'failed'; error: string };
+
 export interface InAppPlanningStreamEvent {
   sessionId: string;
-  chunk: string;
+  chunk?: string;
+  turnId?: string;
+  turn?: InAppPlanningTurnOutcome;
 }
 
 export interface InAppPlanningChatRequest {
@@ -535,12 +554,14 @@ export interface InAppPlanningChatRequest {
   message: string;
   presetKey?: string;
   confirmationMode?: PlanningConfirmationMode;
+  turnId?: string;
 }
 
 export type InAppPlanningChatResponse =
   | {
       ok: true;
       sessionId: string;
+      turnId?: string;
       reply: string;
       confirmationMode?: PlanningConfirmationMode;
       draftPlanAvailable: boolean;
@@ -550,6 +571,7 @@ export type InAppPlanningChatResponse =
   | {
       ok: false;
       sessionId?: string;
+      turnId?: string;
       error: string;
     };
 

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -6,7 +6,7 @@
  */
 
 import type { TaskState, TaskStateChanges, PlanDefinition, Attempt, WorkflowDerivedStatus, WorkflowRollup, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency } from '@invoker/workflow-core';
-import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, PlanningConfirmationMode, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
+import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, InAppPlanningTurnStatus, PlanningConfirmationMode, PlanningTerminalMode, SearchResultItem, SearchOptions } from '@invoker/contracts';
 import type { CostAttributionAttempt } from './attempt-read-models.js';
 
 
@@ -337,6 +337,9 @@ export interface InAppPlanningSessionRecord {
   terminalExitCode?: number;
   terminalOutputSnapshot?: string;
   terminalUpdatedAt?: string;
+  activeTurnId?: string;
+  activeTurnStatus?: InAppPlanningTurnStatus;
+  activeTurnError?: string;
   pendingResponse: boolean;
   createdAt: string;
   updatedAt: string;
@@ -363,6 +366,9 @@ export type InAppPlanningSessionPatch = Partial<Pick<
   | 'terminalExitCode'
   | 'terminalOutputSnapshot'
   | 'terminalUpdatedAt'
+  | 'activeTurnId'
+  | 'activeTurnStatus'
+  | 'activeTurnError'
   | 'pendingResponse'
   | 'updatedAt'
 >>;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -644,6 +644,9 @@ type InAppPlanningSessionRow = {
   terminal_output_snapshot?: unknown;
   terminal_updated_at?: unknown;
   pending_response?: unknown;
+  active_turn_id?: unknown;
+  active_turn_status?: unknown;
+  active_turn_error?: unknown;
   created_at?: unknown;
   updated_at?: unknown;
 };
@@ -1404,9 +1407,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
           terminal_output_snapshot,
           terminal_updated_at,
           pending_response,
+          active_turn_id,
+          active_turn_status,
+          active_turn_error,
           created_at,
           updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(session_id) DO UPDATE SET
           title = excluded.title,
           preset_key = excluded.preset_key,
@@ -1428,6 +1434,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
           terminal_output_snapshot = excluded.terminal_output_snapshot,
           terminal_updated_at = excluded.terminal_updated_at,
           pending_response = excluded.pending_response,
+          active_turn_id = excluded.active_turn_id,
+          active_turn_status = excluded.active_turn_status,
+          active_turn_error = excluded.active_turn_error,
           created_at = excluded.created_at,
           updated_at = excluded.updated_at`,
         [
@@ -1452,6 +1461,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
           record.terminalOutputSnapshot ?? '',
           record.terminalUpdatedAt ?? null,
           record.pendingResponse ? 1 : 0,
+          record.activeTurnId ?? null,
+          record.activeTurnStatus ?? null,
+          record.activeTurnError ?? null,
           record.createdAt,
           record.updatedAt,
         ],
@@ -1557,6 +1569,18 @@ export class SQLiteAdapter implements PersistenceAdapter {
       if (Object.hasOwn(patch, 'pendingResponse')) {
         setClauses.push('pending_response = ?');
         values.push(patch.pendingResponse ? 1 : 0);
+      }
+      if (Object.hasOwn(patch, 'activeTurnId')) {
+        setClauses.push('active_turn_id = ?');
+        values.push(patch.activeTurnId ?? null);
+      }
+      if (Object.hasOwn(patch, 'activeTurnStatus')) {
+        setClauses.push('active_turn_status = ?');
+        values.push(patch.activeTurnStatus ?? null);
+      }
+      if (Object.hasOwn(patch, 'activeTurnError')) {
+        setClauses.push('active_turn_error = ?');
+        values.push(patch.activeTurnError ?? null);
       }
       if (Object.hasOwn(patch, 'updatedAt')) {
         setClauses.push('updated_at = ?');
@@ -3335,6 +3359,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
         ...(typeof row.terminal_exit_code === 'number' ? { terminalExitCode: row.terminal_exit_code } : {}),
         terminalOutputSnapshot: typeof row.terminal_output_snapshot === 'string' ? row.terminal_output_snapshot : '',
         ...(typeof row.terminal_updated_at === 'string' ? { terminalUpdatedAt: row.terminal_updated_at } : {}),
+        ...(typeof row.active_turn_id === 'string' ? { activeTurnId: row.active_turn_id } : {}),
+        ...(row.active_turn_status === 'running' || row.active_turn_status === 'failed'
+          ? { activeTurnStatus: row.active_turn_status }
+          : {}),
+        ...(typeof row.active_turn_error === 'string' ? { activeTurnError: row.active_turn_error } : {}),
         pendingResponse: row.pending_response === 1,
         createdAt,
         updatedAt,

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -254,6 +254,9 @@ export const SCHEMA_DDL = `
         terminal_output_snapshot TEXT NOT NULL DEFAULT '',
         terminal_updated_at TEXT,
         pending_response INTEGER NOT NULL DEFAULT 0 CHECK (pending_response IN (0, 1)),
+        active_turn_id TEXT,
+        active_turn_status TEXT CHECK (active_turn_status IS NULL OR active_turn_status IN ('running', 'failed')),
+        active_turn_error TEXT,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
       );
@@ -641,6 +644,9 @@ export const COLUMN_MIGRATIONS = [
   // a later slice's scoped retry count -- unused for now.
   'ALTER TABLE task_launch_dispatch ADD COLUMN abandon_reason TEXT',
   'ALTER TABLE workflows ADD COLUMN deleted_at INTEGER',
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN active_turn_id TEXT',
+  "ALTER TABLE in_app_planning_sessions ADD COLUMN active_turn_status TEXT CHECK (active_turn_status IS NULL OR active_turn_status IN ('running', 'failed'))",
+  'ALTER TABLE in_app_planning_sessions ADD COLUMN active_turn_error TEXT',
 ];
 
 /**

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -340,6 +340,8 @@ type PlanningSessionView = Omit<InAppPlanningSessionSummary, 'messages'> & {
   terminalSession?: TerminalSessionDescriptor | null;
   terminalBusy?: boolean;
   terminalError?: string | null;
+  repoInput?: string;
+  repoError?: string | null;
 };
 
 function planningSessionFromSummary(
@@ -449,6 +451,8 @@ function reconcileHydratedPlanningSessions(
       terminalSession: restored.terminalSession ?? session.terminalSession,
       terminalBusy: restored.terminalSession ? false : session.terminalBusy,
       terminalError: restored.terminalSession ? null : session.terminalError,
+      repoInput: session.repoInput,
+      repoError: session.repoError,
     };
   });
   const newRestoredSessions = restoredSessions.filter((session) => !currentIds.has(session.id));
@@ -1185,6 +1189,18 @@ export function App() {
   const activePlanningWorkflowRunning = activePlanningSession.submittedWorkflowId
     ? workflows.get(activePlanningSession.submittedWorkflowId)?.status === 'running'
     : false;
+  const activePlanningRepoLocked = activePlanningSession.messages.length > 0
+    || Boolean(activePlanningSession.terminalSession)
+    || activePlanningSession.mode === 'tmux'
+    || activePlanningReadOnly;
+  const planningRepoSuggestions = useMemo(() => {
+    const repos = new Set<string>();
+    for (const workflow of workflows.values()) {
+      if (workflow.repoUrl) repos.add(workflow.repoUrl);
+    }
+    if (activePlanningSession.repoUrl) repos.add(activePlanningSession.repoUrl);
+    return [...repos].sort();
+  }, [activePlanningSession.repoUrl, workflows]);
   const [systemDiagnostics, setSystemDiagnostics] = useState<SystemDiagnostics | null>(null);
   const [showSystemSetup, setShowSystemSetup] = useState(false);
   const [showSystemBanner, setShowSystemBanner] = useState(false);
@@ -2871,16 +2887,22 @@ export function App() {
     text: string,
     role: InvokerTerminalLine['role'] = 'system',
     tone?: InvokerTerminalLine['tone'],
+    targetSessionId?: string,
   ) => {
     const id = nextTerminalLineIdRef.current;
     nextTerminalLineIdRef.current += 1;
     const updatedAt = new Date().toISOString();
-    updateActivePlanningSession((session) => ({
+    const appendLine = (session: PlanningSessionView): PlanningSessionView => ({
       ...session,
       messages: [...session.messages, { id, text, role, tone }],
       updatedAt,
-    }));
-  }, [updateActivePlanningSession]);
+    });
+    if (targetSessionId) {
+      updatePlanningSessionById(targetSessionId, appendLine);
+    } else {
+      updateActivePlanningSession(appendLine);
+    }
+  }, [updateActivePlanningSession, updatePlanningSessionById]);
 
   const handleStartReadyAction = useCallback(async (
     request: StartReadyRequest = {},
@@ -3072,11 +3094,146 @@ export function App() {
     }));
   }, [appendTerminalLine, invoker, planningSessionId, updatePlanningSessionById]);
 
+  const handlePlanningRepoInputChange = useCallback((value: string) => {
+    updatePlanningSessionById(activePlanningSession.id, (session) => ({
+      ...session,
+      repoInput: value,
+      repoError: null,
+    }));
+  }, [activePlanningSession.id, updatePlanningSessionById]);
+
+  const planningRepoCommitInFlightRef = useRef<Promise<{ ok: boolean; sessionId: string | null }> | null>(null);
+
+  const commitPlanningRepo = useCallback((): Promise<{ ok: boolean; sessionId: string | null }> => {
+    // Clicking Send or Tmux blurs the repo input, so the blur commit and the
+    // caller's commit can race; every caller must share one in-flight run.
+    const inFlight = planningRepoCommitInFlightRef.current;
+    if (inFlight) return inFlight;
+
+    const run = (async (): Promise<{ ok: boolean; sessionId: string | null }> => {
+      // Read the latest view state from refs: render closures go stale across
+      // the awaits below and would re-materialize an already-swapped session.
+      const viewSessionId = activePlanningSessionIdRef.current;
+      const session = planningSessionsRef.current.find((current) => current.id === viewSessionId);
+      if (!session) return { ok: true, sessionId: null };
+      const currentBackendId = session.id.startsWith('local-') ? null : session.id;
+      const locked = session.messages.length > 0
+        || Boolean(session.terminalSession)
+        || session.mode === 'tmux'
+        || session.status === 'submitted'
+        || runtimeStatus?.readOnly === true;
+      const pending = (session.repoInput ?? '').trim();
+      if (locked || !pending || pending === (session.repoUrl ?? '')) {
+        return { ok: true, sessionId: currentBackendId };
+      }
+
+      let sessionId = currentBackendId;
+      let viewId = session.id;
+      if (!sessionId) {
+        if (!invoker?.planningChatCreate) {
+          updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: 'Planner is not available.' }));
+          return { ok: false, sessionId: null };
+        }
+        try {
+          const result = await invoker.planningChatCreate({
+            presetKey: session.presetKey || selectedPlanningPresetKey || undefined,
+            title: session.title,
+            confirmationMode: session.confirmationMode ?? selectedPlanningConfirmationMode,
+          });
+          if (!result.ok) {
+            updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: result.error }));
+            return { ok: false, sessionId: null };
+          }
+          const localId = viewId;
+          sessionId = result.session.id;
+          viewId = result.session.id;
+          const materialize = (current: PlanningSessionView): PlanningSessionView => (
+            current.id === localId
+              ? planningSessionFromSummary(result.session, {
+                  input: current.input,
+                  busy: false,
+                  repoInput: current.repoInput,
+                  repoError: null,
+                })
+              : current
+          );
+          // Sync the refs immediately so concurrent callers see the swap
+          // before the next render commits.
+          planningSessionsRef.current = planningSessionsRef.current.map(materialize);
+          activePlanningSessionIdRef.current = activePlanningSessionIdRef.current === localId
+            ? result.session.id
+            : activePlanningSessionIdRef.current;
+          setPlanningSessions((prev) => prev.map(materialize));
+          setActivePlanningSessionId((currentSessionId) => (
+            currentSessionId === localId ? result.session.id : currentSessionId
+          ));
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Failed to create a planning session.';
+          updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: message }));
+          return { ok: false, sessionId: null };
+        }
+      }
+
+      if (!invoker?.planningChatRebindRepo) {
+        updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: 'Repo binding is not available.' }));
+        return { ok: false, sessionId };
+      }
+      try {
+        const result = await invoker.planningChatRebindRepo({ sessionId, repoUrl: pending });
+        if (!result.ok) {
+          updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: result.error }));
+          return { ok: false, sessionId };
+        }
+        updatePlanningSessionById(viewId, (current) => ({
+          ...current,
+          repoUrl: pending,
+          baseCommit: undefined,
+          repoInput: undefined,
+          repoError: null,
+        }));
+        return { ok: true, sessionId };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Failed to bind the repository.';
+        updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: message }));
+        return { ok: false, sessionId };
+      }
+    })();
+
+    planningRepoCommitInFlightRef.current = run;
+    void run.finally(() => {
+      if (planningRepoCommitInFlightRef.current === run) {
+        planningRepoCommitInFlightRef.current = null;
+      }
+    });
+    return run;
+  }, [
+    invoker,
+    runtimeStatus,
+    selectedPlanningConfirmationMode,
+    selectedPlanningPresetKey,
+    updatePlanningSessionById,
+  ]);
+
   const handlePlanningSubmit = useCallback(async () => {
     const input = planningInput.trim();
     if (!input || activePlanningSessionBusy || activePlanningReadOnly) return;
-    appendTerminalLine(input, 'user');
-    setPlanningInput('');
+
+    let sendSessionId = planningSessionId;
+    let activeViewId = activePlanningSessionId;
+    const pendingRepoInput = (activePlanningSession.repoInput ?? '').trim();
+    if (!activePlanningRepoLocked && pendingRepoInput && pendingRepoInput !== (activePlanningSession.repoUrl ?? '')) {
+      const bind = await commitPlanningRepo();
+      if (!bind.ok) return;
+      if (bind.sessionId) {
+        sendSessionId = bind.sessionId;
+        activeViewId = bind.sessionId;
+      }
+    }
+
+    appendTerminalLine(input, 'user', undefined, activeViewId);
+    // Clear via the view id: a repo commit may have just swapped the active
+    // session, and setPlanningInput would target the stale id.
+    updatePlanningSessionById(activeViewId, (session) => ({ ...session, input: '' }));
     setPlanningSubmitError(null);
 
     if (input.toLowerCase() === 'run') {
@@ -3088,7 +3245,7 @@ export function App() {
         );
         return;
       }
-      updatePlanningSessionById(activePlanningSessionId, (session) => ({ ...session, busy: true }));
+      updatePlanningSessionById(activeViewId, (session) => ({ ...session, busy: true }));
       try {
         const result = await handleStartReadyAction();
         if (result && !result.dryRun) {
@@ -3099,10 +3256,11 @@ export function App() {
               : 'No ready work to start.',
             'system',
             startedCount > 0 ? 'success' : undefined,
+            activeViewId,
           );
         }
       } finally {
-        updatePlanningSessionById(activePlanningSessionId, (session) => ({ ...session, busy: false }));
+        updatePlanningSessionById(activeViewId, (session) => ({ ...session, busy: false }));
       }
       return;
     }
@@ -3117,13 +3275,13 @@ export function App() {
     }
 
     if (!invoker?.planningChatSend) {
-      appendTerminalLine('Planner is not available.', 'system', 'error');
+      appendTerminalLine('Planner is not available.', 'system', 'error', activeViewId);
       return;
     }
 
-    if (!planningSessionId && activePlanningSession.messages.length > 0) {
+    if (!sendSessionId && activePlanningSession.messages.length > 0) {
       setPlanningSubmitError({ title: 'Planner could not respond', message: PLANNING_CONTINUATION_LOST_MESSAGE });
-      appendTerminalLine(PLANNING_CONTINUATION_LOST_MESSAGE, 'system', 'error');
+      appendTerminalLine(PLANNING_CONTINUATION_LOST_MESSAGE, 'system', 'error', activeViewId);
       return;
     }
 
@@ -3131,12 +3289,12 @@ export function App() {
       message: input,
       presetKey: selectedPlanningPresetKey || undefined,
       confirmationMode: selectedPlanningConfirmationMode,
-      ...(planningSessionId ? { sessionId: planningSessionId } : {}),
+      ...(sendSessionId ? { sessionId: sendSessionId } : {}),
     };
-    const previousSessionId = activePlanningSessionId;
+    const previousSessionId = activeViewId;
     pendingPlanningStreamSessionIdsRef.current.add(previousSessionId);
-    clearPlanningStreamForSessionIds([previousSessionId, planningSessionId]);
-    forgetPlanningStreamAliasesForSessionIds([previousSessionId, planningSessionId]);
+    clearPlanningStreamForSessionIds([previousSessionId, sendSessionId]);
+    forgetPlanningStreamAliasesForSessionIds([previousSessionId, sendSessionId]);
     updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: true }));
     try {
       const result = await invoker.planningChatSend(request);
@@ -3187,7 +3345,7 @@ export function App() {
         forgetPlanningStreamAliasesForSessionIds([previousSessionId, result.sessionId]);
         pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
         if (result.sessionId) pendingPlanningStreamSessionIdsRef.current.delete(result.sessionId);
-        appendTerminalLine(result.error, 'system', 'error');
+        appendTerminalLine(result.error, 'system', 'error', previousSessionId);
         if (result.sessionId) {
           const failedSessionId = result.sessionId;
           setPlanningSessions((prev) => prev.map((session) => (
@@ -3204,18 +3362,20 @@ export function App() {
     } catch (err) {
       updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: false }));
       const message = err instanceof Error ? err.message : 'Failed to reach the planner.';
-      keepPlanningStreamFailureForSessionIds([previousSessionId, planningSessionId], message);
-      forgetPlanningStreamAliasesForSessionIds([previousSessionId, planningSessionId]);
+      keepPlanningStreamFailureForSessionIds([previousSessionId, sendSessionId], message);
+      forgetPlanningStreamAliasesForSessionIds([previousSessionId, sendSessionId]);
       pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
-      if (planningSessionId) pendingPlanningStreamSessionIdsRef.current.delete(planningSessionId);
+      if (sendSessionId) pendingPlanningStreamSessionIdsRef.current.delete(sendSessionId);
       setPlanningSubmitError({ title: 'Planner could not respond', message });
-      appendTerminalLine(message, 'system', 'error');
+      appendTerminalLine(message, 'system', 'error', previousSessionId);
     }
   }, [
     activePlanningSessionBusy,
     activePlanningSessionId,
     activePlanningReadOnly,
+    activePlanningRepoLocked,
     appendTerminalLine,
+    commitPlanningRepo,
     clearPlanningStreamForSessionIds,
     forgetPlanningStreamAliasesForSessionIds,
     handlePlanningSubmitDraft,
@@ -3225,6 +3385,8 @@ export function App() {
     invoker,
     activePlanningSession.draftPlanAvailable,
     activePlanningSession.messages.length,
+    activePlanningSession.repoInput,
+    activePlanningSession.repoUrl,
     activePlanningSession.status,
     planningInput,
     planningSessionId,
@@ -3359,54 +3521,76 @@ export function App() {
     let terminalSession = sourceSession.terminalSession ?? null;
 
     if (sourceSession.id.startsWith('local-')) {
-      if (!invoker?.planningChatCreate) {
-        updatePlanningSessionById(sourceSession.id, (session) => ({
+      // Switching to tmux blurs the repo input; share its commit so a pending
+      // repo bind and this materialization never create two backend sessions.
+      const bind = await commitPlanningRepo();
+      if (!bind.ok) {
+        updatePlanningSessionById(bind.sessionId ?? sourceSession.id, (session) => ({
           ...session,
+          mode: 'chat',
           terminalBusy: false,
-          terminalError: 'Planner is not available.',
         }));
         return;
       }
-
-      try {
-        const result = await invoker.planningChatCreate({
-          presetKey: sourceSession.presetKey || selectedPlanningPresetKey || undefined,
-          title: sourceSession.title,
-          confirmationMode: sourceSession.confirmationMode ?? selectedPlanningConfirmationMode,
-        });
-        if (!result.ok) {
+      if (bind.sessionId) {
+        targetSessionId = bind.sessionId;
+        terminalSession = null;
+        updatePlanningSessionById(targetSessionId, (session) => ({
+          ...session,
+          mode: 'tmux',
+          terminalBusy: true,
+          terminalError: null,
+        }));
+      } else {
+        if (!invoker?.planningChatCreate) {
           updatePlanningSessionById(sourceSession.id, (session) => ({
             ...session,
             terminalBusy: false,
-            terminalError: result.error,
+            terminalError: 'Planner is not available.',
           }));
           return;
         }
 
-        targetSessionId = result.session.id;
-        terminalSession = null;
-        setPlanningSessions((prev) => prev.map((session) => (
-          session.id === sourceSession.id
-            ? planningSessionFromSummary(result.session, {
-                input: session.input,
-                busy: false,
-                mode: 'tmux',
-                terminalBusy: true,
-                terminalError: null,
-              })
-            : session
-        )));
-        setActivePlanningSessionId((currentSessionId) => (
-          currentSessionId === sourceSession.id ? targetSessionId : currentSessionId
-        ));
-      } catch (err) {
-        const message = err instanceof Error ? err.message : 'Failed to create a planning session.';
-        updatePlanningSessionById(sourceSession.id, (session) => ({
-          ...session,
-          terminalBusy: false,
-          terminalError: message,
-        }));
-        return;
+        try {
+          const result = await invoker.planningChatCreate({
+            presetKey: sourceSession.presetKey || selectedPlanningPresetKey || undefined,
+            title: sourceSession.title,
+            confirmationMode: sourceSession.confirmationMode ?? selectedPlanningConfirmationMode,
+          });
+          if (!result.ok) {
+            updatePlanningSessionById(sourceSession.id, (session) => ({
+              ...session,
+              terminalBusy: false,
+              terminalError: result.error,
+            }));
+            return;
+          }
+
+          targetSessionId = result.session.id;
+          terminalSession = null;
+          setPlanningSessions((prev) => prev.map((session) => (
+            session.id === sourceSession.id
+              ? planningSessionFromSummary(result.session, {
+                  input: session.input,
+                  busy: false,
+                  mode: 'tmux',
+                  terminalBusy: true,
+                  terminalError: null,
+                })
+              : session
+          )));
+          setActivePlanningSessionId((currentSessionId) => (
+            currentSessionId === sourceSession.id ? targetSessionId : currentSessionId
+          ));
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Failed to create a planning session.';
+          updatePlanningSessionById(sourceSession.id, (session) => ({
+            ...session,
+            terminalBusy: false,
+            terminalError: message,
+          }));
+          return;
+        }
       }
     }
 
@@ -3461,6 +3645,7 @@ export function App() {
   }, [
     activePlanningReadOnly,
     activePlanningSession,
+    commitPlanningRepo,
     invoker,
     selectedPlanningPresetKey,
     updatePlanningSessionById,
@@ -4895,10 +5080,16 @@ export function App() {
             terminalError={activePlanningTerminalError}
             workflowRunning={activePlanningWorkflowRunning}
             submittedPlanName={activePlanningSession.submittedPlanName}
+            repoValue={activePlanningSession.repoInput ?? activePlanningSession.repoUrl ?? ''}
+            repoLocked={activePlanningRepoLocked}
+            repoSuggestions={planningRepoSuggestions}
+            repoError={activePlanningSession.repoError ?? null}
             onValueChange={setPlanningInput}
             onSubmit={() => void handlePlanningSubmit()}
             onPresetChange={handlePlanningPresetChange}
             onConfirmationModeChange={handlePlanningConfirmationModeChange}
+            onRepoInputChange={handlePlanningRepoInputChange}
+            onRepoCommit={() => void commitPlanningRepo()}
             onModeChange={(mode) => void handlePlanningModeChange(mode)}
             onExpand={() => setPlanningTerminalExpanded(true)}
             onCloseExpanded={() => setPlanningTerminalExpanded(false)}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
-import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, PlanningConfirmationMode, PlanningPresetOption, ReviewGateQueryResponse, RuntimeStatus, StartReadyFreshBaseScope, StartReadyRequest, StartReadyResult, TerminalOutputEvent, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
+import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningChatResponse, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InAppPlanningTurnOutcome, InvokerSetupRequest, InvokerSetupResult, PlanningConfirmationMode, PlanningPresetOption, ReviewGateQueryResponse, RuntimeStatus, StartReadyFreshBaseScope, StartReadyRequest, StartReadyResult, TerminalOutputEvent, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import { resolvePlanningSubmitAction } from '@invoker/contracts/planning-surface';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus, WorkerActionSummary, WorkerLogEntry, WorkerStatusEntry } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
@@ -373,7 +373,7 @@ function planningSessionFromSummary(
       tone: line.tone,
     })),
     input: '',
-    busy: false,
+    busy: summary.activeTurnStatus === 'running',
     conversationKey: summary.id,
     mode: summary.terminalMode ?? 'chat',
     terminalSession: restoredTerminalSession,
@@ -445,7 +445,7 @@ function reconcileHydratedPlanningSessions(
     return {
       ...restored,
       input: session.input,
-      busy: session.busy,
+      busy: restored.activeTurnStatus === 'running' ? session.busy : false,
       conversationKey: session.conversationKey,
       mode: session.mode === 'tmux' || restored.mode === 'tmux' ? 'tmux' : restored.mode,
       terminalSession: restored.terminalSession ?? session.terminalSession,
@@ -477,6 +477,10 @@ function planningRepoStatusText(repoUrl: string | undefined, baseCommit: string 
   if (!repoUrl) return 'No repository bound yet';
   const label = planningRepoLabel(repoUrl);
   return baseCommit ? `${label} @ ${baseCommit.slice(0, 7)}` : label;
+}
+
+function newPlanningTurnId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `turn-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
 function previewPlanningMessage(session: PlanningSessionView): string {
@@ -1135,6 +1139,8 @@ export function App() {
   const [activePlanningSessionId, setActivePlanningSessionId] = useState('local-planning-session-1');
   const nextPlanningSessionLocalIdRef = useRef(2);
   const nextTerminalLineIdRef = useRef(1);
+  const applyTurnOutcomeRef = useRef<(sessionId: string, turnId: string, outcome: InAppPlanningTurnOutcome) => void>(() => {});
+  const planningPollFailureCountRef = useRef(0);
   const [planningStreamBySessionId, setPlanningStreamBySessionId] = useState<Record<string, PlanningStreamState>>({});
   const [planningPresetOptions, setPlanningPresetOptions] = useState<PlanningPresetOption[]>([]);
   const [selectedPlanningPresetKey, setSelectedPlanningPresetKey] = useState('');
@@ -1384,48 +1390,88 @@ export function App() {
     }).catch(() => {});
   }, []);
 
-  useEffect(() => {
-    let cancelled = false;
-    const hydratePlanningSessions = async (): Promise<void> => {
-      const planningChatList = window.invoker?.planningChatList;
-      if (!planningChatList) return;
-      try {
-        const [chatList, terminalList] = await Promise.all([
-          planningChatList(),
-          window.invoker?.planningTerminalList?.().catch(() => [] as TerminalSessionDescriptor[]) ?? Promise.resolve([] as TerminalSessionDescriptor[]),
-        ]);
-        if (cancelled || !chatList.ok || chatList.sessions.length === 0) return;
-        const terminalsByPlanningSession = new Map(
-          terminalList
-            .filter((session) => session.kind === 'planning' && session.planningSessionId)
-            .map((session) => [session.planningSessionId!, session]),
-        );
-        const restored = chatList.sessions.map((summary) => {
-          const liveTerminal = terminalsByPlanningSession.get(summary.id);
-          return liveTerminal
-            ? planningSessionFromSummary(summary, { terminalSession: liveTerminal })
-            : planningSessionFromSummary(summary);
-        });
-        const nextSessions = reconcileHydratedPlanningSessions(planningSessionsRef.current, restored);
-        planningSessionsRef.current = nextSessions;
-        setPlanningSessions(nextSessions);
-        const currentSessionId = activePlanningSessionIdRef.current;
-        const nextActiveSessionId = nextSessions.some((session) => session.id === currentSessionId)
-          ? currentSessionId
-          : nextSessions[0]?.id ?? currentSessionId;
-        activePlanningSessionIdRef.current = nextActiveSessionId;
-        setActivePlanningSessionId(nextActiveSessionId);
-        const maxLineId = Math.max(1, ...restored.flatMap((session) => session.messages.map((message) => message.id)));
-        nextTerminalLineIdRef.current = Math.max(nextTerminalLineIdRef.current, maxLineId + 1);
-      } catch {
-        /* planning chat restore is best-effort */
-      }
-    };
-    void hydratePlanningSessions();
-    return () => {
-      cancelled = true;
-    };
+  const refreshPlanningSessionsNow = useCallback(async (): Promise<boolean> => {
+    const planningChatList = window.invoker?.planningChatList;
+    if (!planningChatList) return false;
+    try {
+      const [chatList, terminalList] = await Promise.all([
+        planningChatList(),
+        window.invoker?.planningTerminalList?.().catch(() => [] as TerminalSessionDescriptor[]) ?? Promise.resolve([] as TerminalSessionDescriptor[]),
+      ]);
+      if (!chatList.ok) return false;
+      if (chatList.sessions.length === 0) return true;
+      const terminalsByPlanningSession = new Map(
+        terminalList
+          .filter((session) => session.kind === 'planning' && session.planningSessionId)
+          .map((session) => [session.planningSessionId!, session]),
+      );
+      const restored = chatList.sessions.map((summary) => {
+        const liveTerminal = terminalsByPlanningSession.get(summary.id);
+        return liveTerminal
+          ? planningSessionFromSummary(summary, { terminalSession: liveTerminal })
+          : planningSessionFromSummary(summary);
+      });
+      // A first send from a local view runs against a backend session whose
+      // id this tab does not know yet. Appending that session as a new row
+      // would duplicate the chat; the response's id-swap adopts it instead.
+      const currentIds = new Set(planningSessionsRef.current.map((session) => session.id));
+      const aliasedBackendIds = new Set(planningStreamSessionAliasesRef.current.keys());
+      const hasBusyLocalView = planningSessionsRef.current.some((session) => session.id.startsWith('local-') && session.busy);
+      const admissibleRestored = restored.filter((session) => {
+        if (currentIds.has(session.id)) return true;
+        if (aliasedBackendIds.has(session.id)) return false;
+        return !(hasBusyLocalView && session.activeTurnStatus === 'running');
+      });
+      const nextSessions = reconcileHydratedPlanningSessions(planningSessionsRef.current, admissibleRestored);
+      planningSessionsRef.current = nextSessions;
+      setPlanningSessions(nextSessions);
+      const currentSessionId = activePlanningSessionIdRef.current;
+      const nextActiveSessionId = nextSessions.some((session) => session.id === currentSessionId)
+        ? currentSessionId
+        : nextSessions[0]?.id ?? currentSessionId;
+      activePlanningSessionIdRef.current = nextActiveSessionId;
+      setActivePlanningSessionId(nextActiveSessionId);
+      const maxLineId = Math.max(1, ...restored.flatMap((session) => session.messages.map((message) => message.id)));
+      nextTerminalLineIdRef.current = Math.max(nextTerminalLineIdRef.current, maxLineId + 1);
+      return true;
+    } catch (err) {
+      console.error('[planning] planning session refresh failed', err);
+      return false;
+    }
   }, []);
+
+  useEffect(() => {
+    void refreshPlanningSessionsNow();
+  }, [refreshPlanningSessionsNow]);
+
+  const anyPlanningSessionBusy = planningSessions.some((session) => session.busy);
+
+  useEffect(() => {
+    if (!anyPlanningSessionBusy) {
+      planningPollFailureCountRef.current = 0;
+      return;
+    }
+    const interval = setInterval(() => {
+      void refreshPlanningSessionsNow().then((refreshed) => {
+        if (refreshed) {
+          planningPollFailureCountRef.current = 0;
+          return;
+        }
+        planningPollFailureCountRef.current += 1;
+        if (planningPollFailureCountRef.current < 3) return;
+        planningPollFailureCountRef.current = 0;
+        for (const session of planningSessionsRef.current) {
+          if (session.busy && session.activeTurnId) {
+            applyTurnOutcomeRef.current(session.id, session.activeTurnId, {
+              status: 'failed',
+              error: 'Lost connection to the planner.',
+            });
+          }
+        }
+      });
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [anyPlanningSessionBusy, refreshPlanningSessionsNow]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -1514,6 +1560,10 @@ export function App() {
   useEffect(() => {
     const unsubscribe = window.invoker?.onPlanningChatStream?.((event) => {
       const sessionId = typeof event.sessionId === 'string' ? event.sessionId.trim() : '';
+      if (sessionId && event.turn && typeof event.turn === 'object' && typeof event.turnId === 'string') {
+        applyTurnOutcomeRef.current(sessionId, event.turnId, event.turn);
+        return;
+      }
       if (!sessionId || typeof event.chunk !== 'string' || !event.chunk) return;
 
       const sessions = planningSessionsRef.current;
@@ -2904,6 +2954,195 @@ export function App() {
     }
   }, [updateActivePlanningSession, updatePlanningSessionById]);
 
+  // The ONLY code path that lands a planning turn result. Response, stream
+  // event, and poll deliveries all funnel through here, so whichever arrives
+  // first wins and the rest are dropped by the activeTurnId guard.
+  const applyPlanningTurnOutcome = useCallback((sessionId: string, turnId: string, outcome: InAppPlanningTurnOutcome) => {
+    const target = planningSessionsRef.current.find((session) => session.id === sessionId)
+      ?? planningSessionsRef.current.find((session) => session.id === planningStreamSessionAliasesRef.current.get(sessionId));
+    if (!target || target.activeTurnId !== turnId) return; // already applied or foreign turn
+    const targetId = target.id;
+    const updatedAt = new Date().toISOString();
+    if (outcome.status === 'completed') {
+      const replyLineId = nextTerminalLineIdRef.current;
+      nextTerminalLineIdRef.current += 1;
+      const applyCompleted = (session: PlanningSessionView): PlanningSessionView => {
+        if (session.id !== targetId) return session;
+        return {
+          ...session,
+          busy: false,
+          activeTurnId: undefined,
+          activeTurnStatus: undefined,
+          activeTurnError: undefined,
+          confirmationMode: outcome.confirmationMode ?? session.confirmationMode ?? 'require',
+          status: outcome.draftPlanAvailable ? 'draft_ready' : outcome.reply.includes('?') ? 'waiting_for_answer' : 'still_discussing',
+          messages: [...session.messages, {
+            id: replyLineId,
+            text: outcome.reply,
+            role: 'assistant' as const,
+            ...(outcome.reasoning ? { reasoning: outcome.reasoning } : {}),
+          }],
+          draftPlanAvailable: outcome.draftPlanAvailable,
+          draftPlanSummary: outcome.draftPlanAvailable ? outcome.draftPlanSummary : undefined,
+          draftPlanText: outcome.draftPlanAvailable ? outcome.draftPlanText : undefined,
+          updatedAt,
+        };
+      };
+      // Sync the ref immediately: a second delivery of the same outcome can
+      // arrive before the render commits, and the guard reads the ref.
+      planningSessionsRef.current = planningSessionsRef.current.map(applyCompleted);
+      setPlanningSessions((prev) => prev.map(applyCompleted));
+      clearPlanningStreamForSessionIds([sessionId, targetId]);
+      forgetPlanningStreamAliasesForSessionIds([sessionId, targetId]);
+      pendingPlanningStreamSessionIdsRef.current.delete(sessionId);
+      pendingPlanningStreamSessionIdsRef.current.delete(targetId);
+      setHasLoadedPlan(false);
+      setKeptPlanningDraftSessionIds((prev) => {
+        const next = new Set(prev);
+        next.delete(sessionId);
+        next.delete(targetId);
+        return next;
+      });
+      if (outcome.draftPlanAvailable) {
+        setReviewDraftSessionId(targetId);
+        setPlanningContextCollapsed(false);
+      }
+      return;
+    }
+    const applyFailed = (session: PlanningSessionView): PlanningSessionView => (
+      session.id === targetId
+        ? { ...session, busy: false, activeTurnStatus: 'failed' as const, activeTurnError: outcome.error, updatedAt }
+        : session
+    );
+    planningSessionsRef.current = planningSessionsRef.current.map(applyFailed);
+    setPlanningSessions((prev) => prev.map(applyFailed));
+    clearPlanningStreamForSessionIds([sessionId, targetId]);
+    forgetPlanningStreamAliasesForSessionIds([sessionId, targetId]);
+    pendingPlanningStreamSessionIdsRef.current.delete(sessionId);
+    pendingPlanningStreamSessionIdsRef.current.delete(targetId);
+  }, [clearPlanningStreamForSessionIds, forgetPlanningStreamAliasesForSessionIds]);
+
+  useEffect(() => {
+    applyTurnOutcomeRef.current = applyPlanningTurnOutcome;
+  }, [applyPlanningTurnOutcome]);
+
+  const markPlanningTurnRunning = useCallback((sessionId: string, turnId: string) => {
+    const markRunning = (session: PlanningSessionView): PlanningSessionView => (
+      session.id === sessionId
+        ? { ...session, busy: true, activeTurnId: turnId, activeTurnStatus: 'running' as const, activeTurnError: undefined }
+        : session
+    );
+    // Sync the ref immediately: a response can resolve before the render
+    // commits, and applyPlanningTurnOutcome's guard reads the ref.
+    planningSessionsRef.current = planningSessionsRef.current.map(markRunning);
+    setPlanningSessions((prev) => prev.map(markRunning));
+  }, []);
+
+  const handlePlanningSendResult = useCallback((
+    previousSessionId: string,
+    turnId: string,
+    result: InAppPlanningChatResponse,
+    options: { inputForTitle?: string; presetKey?: string } = {},
+  ) => {
+    if (result.ok) {
+      const swapId = (session: PlanningSessionView): PlanningSessionView => {
+        if (session.id !== previousSessionId) return session;
+        return {
+          ...session,
+          id: result.sessionId,
+          title: session.title === 'Untitled plan' && options.inputForTitle
+            ? (options.inputForTitle.length > 56 ? `${options.inputForTitle.slice(0, 53).trimEnd()}…` : options.inputForTitle)
+            : session.title,
+          presetKey: options.presetKey ?? session.presetKey,
+        };
+      };
+      // Drop a row the busy poll may have appended for the same backend
+      // session, then swap the in-flight view onto the backend id. Sync the
+      // refs immediately so applyPlanningTurnOutcome finds the swapped id
+      // before the next render commits.
+      const dedupeAndSwap = (sessions: PlanningSessionView[]): PlanningSessionView[] => (
+        sessions.some((session) => session.id === previousSessionId)
+          ? sessions
+              .filter((session) => session.id === previousSessionId || session.id !== result.sessionId)
+              .map(swapId)
+          : sessions
+      );
+      planningSessionsRef.current = dedupeAndSwap(planningSessionsRef.current);
+      activePlanningSessionIdRef.current = activePlanningSessionIdRef.current === previousSessionId
+        ? result.sessionId
+        : activePlanningSessionIdRef.current;
+      setPlanningSessions((prev) => dedupeAndSwap(prev));
+      setActivePlanningSessionId((currentSessionId) => (
+        currentSessionId === previousSessionId ? result.sessionId : currentSessionId
+      ));
+      applyPlanningTurnOutcome(result.sessionId, turnId, {
+        status: 'completed',
+        reply: result.reply,
+        reasoning: (result as { reasoning?: string }).reasoning,
+        confirmationMode: result.confirmationMode,
+        draftPlanAvailable: result.draftPlanAvailable,
+        draftPlanSummary: result.draftPlanSummary,
+        draftPlanText: result.draftPlanText,
+      });
+      return;
+    }
+    if (result.error === 'duplicate-turn') {
+      // The original request's outcome will land via response, event, or poll.
+      return;
+    }
+    if (result.turnId === turnId) {
+      if (result.sessionId && result.sessionId !== previousSessionId) {
+        const failedSessionId = result.sessionId;
+        const dedupeAndSwap = (sessions: PlanningSessionView[]): PlanningSessionView[] => (
+          sessions.some((session) => session.id === previousSessionId)
+            ? sessions.filter((session) => session.id !== failedSessionId).map((session) => (
+                session.id === previousSessionId ? { ...session, id: failedSessionId } : session
+              ))
+            : sessions
+        );
+        planningSessionsRef.current = dedupeAndSwap(planningSessionsRef.current);
+        activePlanningSessionIdRef.current = activePlanningSessionIdRef.current === previousSessionId
+          ? failedSessionId
+          : activePlanningSessionIdRef.current;
+        setPlanningSessions((prev) => dedupeAndSwap(prev));
+        setActivePlanningSessionId((currentSessionId) => (
+          currentSessionId === previousSessionId ? failedSessionId : currentSessionId
+        ));
+      }
+      applyPlanningTurnOutcome(result.sessionId ?? previousSessionId, turnId, { status: 'failed', error: result.error });
+      return;
+    }
+    // Pre-turn failures without our turnId keep the error-line + modal path.
+    updatePlanningSessionById(previousSessionId, (session) => ({
+      ...session,
+      busy: false,
+      activeTurnId: undefined,
+      activeTurnStatus: undefined,
+      activeTurnError: undefined,
+    }));
+    keepPlanningStreamFailureForSessionIds([previousSessionId, result.sessionId], result.error);
+    forgetPlanningStreamAliasesForSessionIds([previousSessionId, result.sessionId]);
+    pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
+    if (result.sessionId) pendingPlanningStreamSessionIdsRef.current.delete(result.sessionId);
+    appendTerminalLine(result.error, 'system', 'error', previousSessionId);
+    if (result.sessionId) {
+      const failedSessionId = result.sessionId;
+      setPlanningSessions((prev) => prev.map((session) => (
+        session.id === previousSessionId ? { ...session, id: failedSessionId } : session
+      )));
+      setActivePlanningSessionId((currentSessionId) => (
+        currentSessionId === previousSessionId ? failedSessionId : currentSessionId
+      ));
+    }
+    setPlanningSubmitError({ title: 'Planner could not respond', message: result.error });
+  }, [
+    applyPlanningTurnOutcome,
+    appendTerminalLine,
+    forgetPlanningStreamAliasesForSessionIds,
+    keepPlanningStreamFailureForSessionIds,
+    updatePlanningSessionById,
+  ]);
+
   const handleStartReadyAction = useCallback(async (
     request: StartReadyRequest = {},
   ): Promise<StartReadyResult | null> => {
@@ -3285,89 +3524,27 @@ export function App() {
       return;
     }
 
+    const turnId = newPlanningTurnId();
     const request = {
       message: input,
       presetKey: selectedPlanningPresetKey || undefined,
       confirmationMode: selectedPlanningConfirmationMode,
+      turnId,
       ...(sendSessionId ? { sessionId: sendSessionId } : {}),
     };
     const previousSessionId = activeViewId;
     pendingPlanningStreamSessionIdsRef.current.add(previousSessionId);
     clearPlanningStreamForSessionIds([previousSessionId, sendSessionId]);
     forgetPlanningStreamAliasesForSessionIds([previousSessionId, sendSessionId]);
-    updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: true }));
+    markPlanningTurnRunning(previousSessionId, turnId);
     try {
       const result = await invoker.planningChatSend(request);
-      if (result.ok) {
-        const updatedAt = new Date().toISOString();
-        const replyLineId = nextTerminalLineIdRef.current;
-        nextTerminalLineIdRef.current += 1;
-        setPlanningSessions((prev) => prev.map((session) => {
-          if (session.id !== previousSessionId) return session;
-          return {
-            ...session,
-            busy: false,
-            id: result.sessionId,
-            title: session.title === 'Untitled plan'
-              ? (input.length > 56 ? `${input.slice(0, 53).trimEnd()}…` : input)
-              : session.title,
-            presetKey: request.presetKey ?? session.presetKey,
-            confirmationMode: result.confirmationMode ?? session.confirmationMode ?? 'require',
-            status: result.draftPlanAvailable ? 'draft_ready' : result.reply.includes('?') ? 'waiting_for_answer' : 'still_discussing',
-            messages: [...session.messages, { id: replyLineId, text: result.reply, role: 'assistant', ...((result as { reasoning?: string }).reasoning ? { reasoning: (result as { reasoning?: string }).reasoning } : {}) }],
-            draftPlanAvailable: result.draftPlanAvailable,
-            draftPlanSummary: result.draftPlanAvailable ? result.draftPlanSummary : undefined,
-            draftPlanText: result.draftPlanAvailable ? result.draftPlanText : undefined,
-            updatedAt,
-          };
-        }));
-        setActivePlanningSessionId((currentSessionId) => (
-          currentSessionId === previousSessionId ? result.sessionId : currentSessionId
-        ));
-        clearPlanningStreamForSessionIds([previousSessionId, result.sessionId]);
-        forgetPlanningStreamAliasesForSessionIds([previousSessionId, result.sessionId]);
-        pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
-        pendingPlanningStreamSessionIdsRef.current.delete(result.sessionId);
-        setHasLoadedPlan(false);
-        setKeptPlanningDraftSessionIds((prev) => {
-          const next = new Set(prev);
-          next.delete(previousSessionId);
-          next.delete(result.sessionId);
-          return next;
-        });
-        if (result.draftPlanAvailable) {
-          setReviewDraftSessionId(result.sessionId);
-          setPlanningContextCollapsed(false);
-        }
-      } else {
-        updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: false }));
-        keepPlanningStreamFailureForSessionIds([previousSessionId, result.sessionId], result.error);
-        forgetPlanningStreamAliasesForSessionIds([previousSessionId, result.sessionId]);
-        pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
-        if (result.sessionId) pendingPlanningStreamSessionIdsRef.current.delete(result.sessionId);
-        appendTerminalLine(result.error, 'system', 'error', previousSessionId);
-        if (result.sessionId) {
-          const failedSessionId = result.sessionId;
-          setPlanningSessions((prev) => prev.map((session) => (
-            session.id === previousSessionId
-              ? { ...session, id: failedSessionId }
-              : session
-          )));
-          setActivePlanningSessionId((currentSessionId) => (
-            currentSessionId === previousSessionId ? failedSessionId : currentSessionId
-          ));
-        }
-        setPlanningSubmitError({ title: 'Planner could not respond', message: result.error });
-      }
+      handlePlanningSendResult(previousSessionId, turnId, result, { inputForTitle: input, presetKey: request.presetKey });
     } catch (err) {
-      updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: false }));
-      const message = err instanceof Error ? err.message : 'Failed to reach the planner.';
-      keepPlanningStreamFailureForSessionIds([previousSessionId, sendSessionId], message);
-      forgetPlanningStreamAliasesForSessionIds([previousSessionId, sendSessionId]);
-      pendingPlanningStreamSessionIdsRef.current.delete(previousSessionId);
-      if (sendSessionId) pendingPlanningStreamSessionIdsRef.current.delete(sendSessionId);
-      setPlanningSubmitError({ title: 'Planner could not respond', message });
-      appendTerminalLine(message, 'system', 'error', previousSessionId);
+      // Keep the turn marked running: recovery rides the busy poll, which
+      // either observes the finished turn or fails it after 3 missed polls.
+      console.error('[planning] planningChatSend transport failure', err);
+      void refreshPlanningSessionsNow();
     }
   }, [
     activePlanningSessionBusy,
@@ -3378,11 +3555,13 @@ export function App() {
     commitPlanningRepo,
     clearPlanningStreamForSessionIds,
     forgetPlanningStreamAliasesForSessionIds,
+    handlePlanningSendResult,
     handlePlanningSubmitDraft,
     handleStartReadyAction,
     hasLoadedPlan,
-    keepPlanningStreamFailureForSessionIds,
     invoker,
+    markPlanningTurnRunning,
+    refreshPlanningSessionsNow,
     activePlanningSession.draftPlanAvailable,
     activePlanningSession.messages.length,
     activePlanningSession.repoInput,
@@ -3396,6 +3575,39 @@ export function App() {
     tasks.size,
     updatePlanningSessionById,
     workflows.size,
+  ]);
+
+  const handleRetryPlanningTurn = useCallback(async () => {
+    const session = activePlanningSession;
+    if (session.activeTurnStatus !== 'failed' || !session.activeTurnId || session.busy) return;
+    const lastUserLine = [...session.messages].reverse().find((line) => line.role === 'user');
+    if (!lastUserLine || !invoker?.planningChatSend) return;
+    const turnId = session.activeTurnId;
+    const previousSessionId = session.id;
+    markPlanningTurnRunning(previousSessionId, turnId);
+    try {
+      const result = await invoker.planningChatSend({
+        ...(previousSessionId.startsWith('local-') ? {} : { sessionId: previousSessionId }),
+        turnId,
+        message: lastUserLine.text,
+        presetKey: selectedPlanningPresetKey || undefined,
+        confirmationMode: selectedPlanningConfirmationMode,
+      });
+      handlePlanningSendResult(previousSessionId, turnId, result);
+    } catch (err) {
+      // Same recovery contract as handlePlanningSubmit's catch: stay busy,
+      // let the poll observe the turn or fail it after 3 missed polls.
+      console.error('[planning] planningChatSend retry transport failure', err);
+      void refreshPlanningSessionsNow();
+    }
+  }, [
+    activePlanningSession,
+    handlePlanningSendResult,
+    invoker,
+    markPlanningTurnRunning,
+    refreshPlanningSessionsNow,
+    selectedPlanningConfirmationMode,
+    selectedPlanningPresetKey,
   ]);
 
   const makeFreshLocalPlanningSession = useCallback((): PlanningSessionView => {
@@ -5084,6 +5296,8 @@ export function App() {
             repoLocked={activePlanningRepoLocked}
             repoSuggestions={planningRepoSuggestions}
             repoError={activePlanningSession.repoError ?? null}
+            turnError={activePlanningSession.activeTurnStatus === 'failed' ? activePlanningSession.activeTurnError ?? 'The planner turn failed.' : null}
+            onRetryTurn={() => void handleRetryPlanningTurn()}
             onValueChange={setPlanningInput}
             onSubmit={() => void handlePlanningSubmit()}
             onPresetChange={handlePlanningPresetChange}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -5486,6 +5486,7 @@ export function App() {
           onDelete={handleDeleteTask}
           onClose={closeContextMenu}
           autoFocus={Boolean(contextMenu.returnFocusRegion)}
+          agents={executionHarnesses.map((harness) => harness.name)}
         />
       )}
     </div>

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1141,6 +1141,7 @@ export function App() {
   const nextTerminalLineIdRef = useRef(1);
   const applyTurnOutcomeRef = useRef<(sessionId: string, turnId: string, outcome: InAppPlanningTurnOutcome) => void>(() => {});
   const planningPollFailureCountRef = useRef(0);
+  const planningTurnGoneCountsRef = useRef<Map<string, number>>(new Map());
   const [planningStreamBySessionId, setPlanningStreamBySessionId] = useState<Record<string, PlanningStreamState>>({});
   const [planningPresetOptions, setPlanningPresetOptions] = useState<PlanningPresetOption[]>([]);
   const [selectedPlanningPresetKey, setSelectedPlanningPresetKey] = useState('');
@@ -1399,7 +1400,6 @@ export function App() {
         window.invoker?.planningTerminalList?.().catch(() => [] as TerminalSessionDescriptor[]) ?? Promise.resolve([] as TerminalSessionDescriptor[]),
       ]);
       if (!chatList.ok) return false;
-      if (chatList.sessions.length === 0) return true;
       const terminalsByPlanningSession = new Map(
         terminalList
           .filter((session) => session.kind === 'planning' && session.planningSessionId)
@@ -1433,6 +1433,41 @@ export function App() {
       setActivePlanningSessionId(nextActiveSessionId);
       const maxLineId = Math.max(1, ...restored.flatMap((session) => session.messages.map((message) => message.id)));
       nextTerminalLineIdRef.current = Math.max(nextTerminalLineIdRef.current, maxLineId + 1);
+      const serverIds = new Set(chatList.sessions.map((session) => session.id));
+      const serverHasUnknownRunningTurn = chatList.sessions.some(
+        (session) => session.activeTurnStatus === 'running' && !currentIds.has(session.id),
+      );
+      const goneCounts = planningTurnGoneCountsRef.current;
+      const liveIds = new Set(planningSessionsRef.current.map((session) => session.id));
+      for (const key of goneCounts.keys()) {
+        if (!liveIds.has(key)) goneCounts.delete(key);
+      }
+      for (const session of planningSessionsRef.current) {
+        if (!session.busy || !session.activeTurnId) {
+          goneCounts.delete(session.id);
+          continue;
+        }
+        // A busy local view's backend twin is unknown by id; any unknown running
+        // turn may be it, so its absence across polls is the "gone" signal. With
+        // several busy local views this under-fails (never false-fails).
+        const gone = session.id.startsWith('local-')
+          ? !serverHasUnknownRunningTurn
+          : !serverIds.has(session.id);
+        if (!gone) {
+          goneCounts.delete(session.id);
+          continue;
+        }
+        const count = (goneCounts.get(session.id) ?? 0) + 1;
+        if (count < 2) {
+          goneCounts.set(session.id, count);
+          continue;
+        }
+        goneCounts.delete(session.id);
+        applyTurnOutcomeRef.current(session.id, session.activeTurnId, {
+          status: 'failed',
+          error: 'The planner session no longer exists on the server. It may have been reset.',
+        });
+      }
       return true;
     } catch (err) {
       console.error('[planning] planning session refresh failed', err);

--- a/packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx
@@ -51,7 +51,7 @@ describe('CodeRabbit PR #3050 — Enter-to-submit ignores IME composition', () =
     // A subsequent plain Enter (composition finished) submits normally.
     fireEvent.keyDown(input, { key: 'Enter' });
     await waitFor(() => {
-      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'こんにちは', presetKey: 'codex', confirmationMode: 'require' });
+      expect(vi.mocked(mock.api.planningChatSend)).toHaveBeenCalledWith({ turnId: expect.any(String), message: 'こんにちは', presetKey: 'codex', confirmationMode: 'require' });
     });
   });
 });

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -514,6 +514,10 @@ describe('Context menu (component)', { timeout: APP_CONTEXT_MENU_TEST_TIMEOUT_MS
     pressMenuKey('ArrowDown');
     await expectHighlightedMenuItem('Fix with Codex');
     pressMenuKey('ArrowDown');
+    // The fix menu offers every harness the owner reports (mock: claude,
+    // codex, omp), so the disabled Open Terminal entry is skipped after Omp.
+    await expectHighlightedMenuItem('Fix with Omp');
+    pressMenuKey('ArrowDown');
     await expectHighlightedMenuItem('Restart Task');
     pressMenuKey('Enter');
 

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -233,6 +233,7 @@ export function createMockInvoker(
       return () => { planningChatStreamCallbacks.delete(cb); };
     }),
     planningChatSetTerminalMode: vi.fn(async () => ({ ok: true })),
+    planningChatRebindRepo: vi.fn(async () => ({ ok: true, action: 'provision' })),
     planningTerminalOpen: vi.fn(async (planningSessionId: string) => ({
       opened: true,
       session: {

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -212,9 +212,10 @@ export function createMockInvoker(
       },
     })),
     planningChatList: vi.fn(async () => ({ ok: true, sessions: [] })),
-    planningChatSend: vi.fn(async () => ({
+    planningChatSend: vi.fn(async (request?: { turnId?: string }) => ({
       ok: true,
       sessionId: 'session-1',
+      turnId: request?.turnId,
       reply: 'I can help draft that.',
       confirmationMode: 'require',
       draftPlanAvailable: false,

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -2198,6 +2198,15 @@ describe('Invoker terminal (component)', () => {
     expect(within(sendButton).getByTestId('invoker-terminal-send-icon')).toBeInTheDocument();
   });
 
+  it('swaps the send icon for a pending spinner while a turn is running', () => {
+    render(<InvokerTerminal {...terminalProps({ busy: true })} />);
+
+    const sendButton = screen.getByRole('button', { name: 'Send' });
+    expect(sendButton).toBeDisabled();
+    expect(within(sendButton).getByTestId('invoker-terminal-send-spinner')).toBeInTheDocument();
+    expect(within(sendButton).queryByTestId('invoker-terminal-send-icon')).not.toBeInTheDocument();
+  });
+
   it('uses the amber send-button styling in the enabled state', () => {
     render(<InvokerTerminal {...terminalProps({ value: 'draft a plan' })} />);
 

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -747,7 +747,7 @@ describe('Invoker terminal (component)', () => {
     submitPlanningText('hello');
 
     await waitFor(() => {
-      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'hello', presetKey: 'codex', confirmationMode: 'require' });
+      expect(vi.mocked(mock.api.planningChatSend)).toHaveBeenCalledWith({ turnId: expect.any(String), message: 'hello', presetKey: 'codex', confirmationMode: 'require' });
       expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('I can help draft that.');
     });
     expect(screen.queryByText(/Unknown command/)).not.toBeInTheDocument();
@@ -828,6 +828,7 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledTimes(2);
       expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
+        turnId: expect.any(String),
         sessionId: 'session-1',
         message: 'try again',
         presetKey: 'codex',
@@ -1038,7 +1039,7 @@ describe('Invoker terminal (component)', () => {
     fireEvent.keyDown(input, { key: 'Enter' });
 
     await waitFor(() => {
-      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'hello', presetKey: 'codex', confirmationMode: 'require' });
+      expect(vi.mocked(mock.api.planningChatSend)).toHaveBeenCalledWith({ turnId: expect.any(String), message: 'hello', presetKey: 'codex', confirmationMode: 'require' });
     });
   });
 
@@ -1310,6 +1311,7 @@ describe('Invoker terminal (component)', () => {
 
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        turnId: expect.any(String),
         sessionId: 'saved-pressure-chat',
         message: 'continue the restored session',
         presetKey: 'codex',
@@ -1525,6 +1527,7 @@ describe('Invoker terminal (component)', () => {
 
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
+        turnId: expect.any(String),
         sessionId: 'session-1',
         message: 'make the plan more detailed',
         presetKey: 'codex',
@@ -1576,7 +1579,7 @@ describe('Invoker terminal (component)', () => {
     submitPlanningText('draft a plan');
 
     await waitFor(() => {
-      expect(mock.api.planningChatSend).toHaveBeenCalledWith({ message: 'draft a plan', presetKey: 'omp+claude', confirmationMode: 'require' });
+      expect(vi.mocked(mock.api.planningChatSend)).toHaveBeenCalledWith({ turnId: expect.any(String), message: 'draft a plan', presetKey: 'omp+claude', confirmationMode: 'require' });
     });
   });
 
@@ -1620,6 +1623,7 @@ describe('Invoker terminal (component)', () => {
 
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        turnId: expect.any(String),
         sessionId: 'session-1',
         message: 'submit',
         presetKey: 'codex',

--- a/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-draft-submit-new-turn-stream-repro.test.tsx
@@ -94,6 +94,7 @@ describe('planning draft submit -> new turn live planner stream repro', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledTimes(2);
       expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
+        turnId: expect.any(String),
         message: 'draft the next plan',
         presetKey: 'codex',
         confirmationMode: 'require',

--- a/packages/ui/src/__tests__/planning-repo-binding.test.tsx
+++ b/packages/ui/src/__tests__/planning-repo-binding.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+describe('planning composer repo binding', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  async function openComposerOptions() {
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    const expandPlanningChats = screen.queryByRole('button', { name: 'Expand planning chats' });
+    if (expandPlanningChats) fireEvent.click(expandPlanningChats);
+    if (!screen.queryByTestId('invoker-terminal-harness')) {
+      fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+    }
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toBeInTheDocument();
+    });
+  }
+
+  it('binds a repo typed into an empty chat and shows it in the details panel', async () => {
+    render(<App />);
+    await openComposerOptions();
+
+    const repoInput = screen.getByTestId('invoker-terminal-repo');
+    fireEvent.change(repoInput, { target: { value: '/tmp/repo-a' } });
+    fireEvent.keyDown(repoInput, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mock.api.planningChatCreate).toHaveBeenCalledWith({
+        presetKey: 'codex',
+        title: 'Untitled plan',
+        confirmationMode: 'require',
+      });
+      expect(mock.api.planningChatRebindRepo).toHaveBeenCalledWith({
+        sessionId: 'session-1',
+        repoUrl: '/tmp/repo-a',
+      });
+    });
+
+    fireEvent.click(screen.getByTestId('planning-context-toggle'));
+    await waitFor(() => {
+      expect(screen.getByTestId('planning-repo-status')).toHaveTextContent('tmp/repo-a');
+    });
+    expect(screen.queryByTestId('invoker-terminal-repo-error')).not.toBeInTheDocument();
+  });
+
+  it('shows the bind error and keeps the previous binding when the rebind is refused', async () => {
+    mock.api.planningChatRebindRepo = vi.fn(async () => ({
+      ok: false as const,
+      error: 'Set the repo before the conversation or terminal starts.',
+    }));
+
+    render(<App />);
+    await openComposerOptions();
+
+    const repoInput = screen.getByTestId('invoker-terminal-repo');
+    fireEvent.change(repoInput, { target: { value: '/tmp/repo-b' } });
+    fireEvent.keyDown(repoInput, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-repo-error')).toHaveTextContent(
+        'Set the repo before the conversation or terminal starts.',
+      );
+    });
+    fireEvent.click(screen.getByTestId('planning-context-toggle'));
+    expect(await screen.findByTestId('planning-repo-status')).toHaveTextContent('No repository bound yet');
+    expect(screen.getByTestId('invoker-terminal-repo')).toHaveValue('/tmp/repo-b');
+  });
+
+  it('sends exactly once when Send is clicked with uncommitted repo text', async () => {
+    let createCalls = 0;
+    mock.api.planningChatCreate = vi.fn(async () => {
+      createCalls += 1;
+      return {
+        ok: true as const,
+        session: makePlanningSessionSummary({
+          id: `created-${createCalls}`,
+          title: 'Untitled plan',
+          status: 'still_discussing',
+          presetKey: 'codex',
+          messages: [],
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+        }),
+      };
+    });
+    mock.api.planningChatSend = vi.fn(async (request) => ({
+      ok: true as const,
+      sessionId: request.sessionId ?? 'server-created',
+      reply: 'On it.',
+      confirmationMode: 'require' as const,
+      draftPlanAvailable: false,
+    }));
+
+    render(<App />);
+    await openComposerOptions();
+
+    const repoInput = screen.getByTestId('invoker-terminal-repo');
+    fireEvent.change(repoInput, { target: { value: '/tmp/repo-a' } });
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+
+    // Clicking the Send button first blurs the repo field, then submits the form.
+    fireEvent.blur(repoInput);
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1);
+    });
+    expect(mock.api.planningChatCreate).toHaveBeenCalledTimes(1);
+    expect(mock.api.planningChatRebindRepo).toHaveBeenCalledTimes(1);
+    expect(mock.api.planningChatRebindRepo).toHaveBeenCalledWith({
+      sessionId: 'created-1',
+      repoUrl: '/tmp/repo-a',
+    });
+    expect(mock.api.planningChatSend).toHaveBeenCalledWith(expect.objectContaining({
+      sessionId: 'created-1',
+      message: 'hello planner',
+    }));
+    // The message renders in the transcript and again as the sidebar preview.
+    expect(screen.getAllByText('hello planner').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('On it.').length).toBeGreaterThanOrEqual(1);
+    // The composer must clear, or a second click re-sends the same message.
+    expect(screen.getByTestId('invoker-terminal-input')).toHaveValue('');
+  });
+
+  it('hides the repo field once the conversation has messages', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'existing-chat',
+          title: 'Existing chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+        }),
+      ],
+    }));
+
+    render(<App />);
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    const rail = await screen.findByTestId('planning-session-list');
+    await waitFor(() => {
+      expect(within(rail).getByText('Existing chat')).toBeInTheDocument();
+    });
+    fireEvent.click(await screen.findByRole('button', { name: 'Options' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('invoker-terminal-repo')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/__tests__/planning-repo-binding.test.tsx
+++ b/packages/ui/src/__tests__/planning-repo-binding.test.tsx
@@ -140,6 +140,81 @@ describe('planning composer repo binding', () => {
     expect(screen.getByTestId('invoker-terminal-input')).toHaveValue('');
   });
 
+  it('shows the send spinner and defers the send while a send-triggered bind is in flight', async () => {
+    let resolveRebind!: (value: { ok: true; action: 'provision' }) => void;
+    mock.api.planningChatRebindRepo = vi.fn(() => new Promise<{ ok: true; action: 'provision' }>((resolve) => {
+      resolveRebind = resolve;
+    }));
+
+    render(<App />);
+    await openComposerOptions();
+
+    const repoInput = screen.getByTestId('invoker-terminal-repo');
+    fireEvent.change(repoInput, { target: { value: '/tmp/repo-a' } });
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+
+    // Clicking Send first blurs the repo field, then submits the form.
+    fireEvent.blur(repoInput);
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-send-spinner')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    expect(mock.api.planningChatSend).not.toHaveBeenCalled();
+
+    resolveRebind({ ok: true, action: 'provision' });
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows the send spinner during a blur-committed bind without sending', async () => {
+    let resolveRebind!: (value: { ok: true; action: 'provision' }) => void;
+    mock.api.planningChatRebindRepo = vi.fn(() => new Promise<{ ok: true; action: 'provision' }>((resolve) => {
+      resolveRebind = resolve;
+    }));
+
+    render(<App />);
+    await openComposerOptions();
+
+    const repoInput = screen.getByTestId('invoker-terminal-repo');
+    fireEvent.change(repoInput, { target: { value: '/tmp/repo-a' } });
+    fireEvent.blur(repoInput);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-send-spinner')).toBeInTheDocument();
+    });
+
+    resolveRebind({ ok: true, action: 'provision' });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('invoker-terminal-send-spinner')).not.toBeInTheDocument();
+    });
+    expect(mock.api.planningChatSend).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failed bind in the transcript and keeps the typed message', async () => {
+    mock.api.planningChatRebindRepo = vi.fn(async () => ({ ok: false as const, error: 'boom' }));
+
+    render(<App />);
+    await openComposerOptions();
+
+    const repoInput = screen.getByTestId('invoker-terminal-repo');
+    fireEvent.change(repoInput, { target: { value: '/tmp/repo-a' } });
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+
+    fireEvent.blur(repoInput);
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    const errorLines = await screen.findAllByText('Could not bind repository: boom');
+    expect(errorLines.length).toBeGreaterThanOrEqual(1);
+    expect(mock.api.planningChatSend).not.toHaveBeenCalled();
+    expect(screen.getByTestId('invoker-terminal-input')).toHaveValue('hello planner');
+    expect(screen.queryByTestId('invoker-terminal-send-spinner')).not.toBeInTheDocument();
+  });
+
   it('hides the repo field once the conversation has messages', async () => {
     mock.api.planningChatList = vi.fn(async () => ({
       ok: true,

--- a/packages/ui/src/__tests__/planning-terminal-preset-switch-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-preset-switch-repro.test.tsx
@@ -83,6 +83,7 @@ describe('planning terminal preset ownership repro', () => {
 
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        turnId: expect.any(String),
         sessionId: 'claude-chat',
         message: 'continue with claude',
         presetKey: 'omp+claude',
@@ -179,6 +180,7 @@ describe('planning terminal preset ownership repro', () => {
 
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        turnId: expect.any(String),
         sessionId: 'existing-chat',
         message: 'continue with a different model',
         presetKey: 'omp+claude',

--- a/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-session-id-persist-repro.test.tsx
@@ -62,6 +62,7 @@ describe('planning terminal failed first send session id persist repro', () => {
     submitPlanningText('draft a plan that fails before replying');
     expect(await screen.findByText('planner exited before producing a reply')).toBeInTheDocument();
     expect(mock.api.planningChatSend).toHaveBeenNthCalledWith(1, {
+      turnId: expect.any(String),
       message: 'draft a plan that fails before replying',
       presetKey: 'codex',
       confirmationMode: 'require',
@@ -72,6 +73,7 @@ describe('planning terminal failed first send session id persist repro', () => {
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledTimes(2);
       expect(mock.api.planningChatSend).toHaveBeenLastCalledWith({
+        turnId: expect.any(String),
         sessionId: 'session-created-before-error',
         message: 'retry in the same chat',
         presetKey: 'codex',

--- a/packages/ui/src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx
+++ b/packages/ui/src/__tests__/planning-terminal-startup-hydrate-race-repro.test.tsx
@@ -151,6 +151,7 @@ describe('planning terminal startup hydrate race repro', () => {
     submitPlanningText('start a local plan before restore');
     await waitFor(() => {
       expect(mock.api.planningChatSend).toHaveBeenCalledWith({
+        turnId: expect.any(String),
         message: 'start a local plan before restore',
         presetKey: 'codex',
         confirmationMode: 'require',

--- a/packages/ui/src/__tests__/planning-turn-durability.test.tsx
+++ b/packages/ui/src/__tests__/planning-turn-durability.test.tsx
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  // Dynamic import is required because Vitest hoists mock factories before test imports.
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+// Dynamic import is required so App sees the hoisted @xyflow/react mock.
+const { App } = await import('../App.js');
+
+describe('planning turn durability', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  async function openPlanningSurface() {
+    fireEvent.click(await screen.findByTestId('sidebar-home'));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-input')).toBeInTheDocument();
+    });
+  }
+
+  it('keeps a hydrated running turn busy and lands its reply from the stream event', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'busy-chat',
+          title: 'Busy chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          messages: [
+            { id: 1, role: 'user', text: 'Draft the plan', createdAt: '2026-07-07T00:00:01.000Z' },
+          ],
+          activeTurnId: 'turn-live',
+          activeTurnStatus: 'running',
+        }),
+      ],
+    }));
+
+    render(<App />);
+    await openPlanningSurface();
+
+    // Reload-safe busy: the hydrated running turn locks the composer.
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    });
+
+    await act(async () => {
+      mock.firePlanningChatStream({
+        sessionId: 'busy-chat',
+        turnId: 'turn-live',
+        turn: { status: 'completed', reply: 'Done thinking.', draftPlanAvailable: false },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Done thinking.');
+      expect(screen.getByTestId('invoker-terminal-input')).not.toBeDisabled();
+    });
+  });
+
+  it('offers Retry for a hydrated failed turn and re-sends the same turnId and message', async () => {
+    mock.api.planningChatList = vi.fn(async () => ({
+      ok: true,
+      sessions: [
+        makePlanningSessionSummary({
+          id: 'failed-chat',
+          title: 'Failed chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          messages: [
+            { id: 1, role: 'user', text: 'Draft the plan', createdAt: '2026-07-07T00:00:01.000Z' },
+          ],
+          activeTurnId: 'turn-x',
+          activeTurnStatus: 'failed',
+          activeTurnError: 'Planner was interrupted before it could answer.',
+        }),
+      ],
+    }));
+    mock.api.planningChatSend = vi.fn(async (request: { sessionId?: string; turnId?: string }) => ({
+      ok: true as const,
+      sessionId: request.sessionId ?? 'failed-chat',
+      turnId: request.turnId,
+      reply: 'Recovered fine.',
+      confirmationMode: 'require' as const,
+      draftPlanAvailable: false,
+    }));
+
+    render(<App />);
+    await openPlanningSurface();
+
+    const retryButton = await screen.findByTestId('invoker-terminal-retry-turn');
+    expect(screen.getByTestId('invoker-terminal-turn-error'))
+      .toHaveTextContent('Planner was interrupted before it could answer.');
+
+    fireEvent.click(retryButton);
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledWith(expect.objectContaining({
+        sessionId: 'failed-chat',
+        turnId: 'turn-x',
+        message: 'Draft the plan',
+      }));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Recovered fine.');
+    });
+    expect(screen.queryByTestId('invoker-terminal-retry-turn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoker-terminal-turn-error')).not.toBeInTheDocument();
+  });
+
+  it('silently ignores a duplicate-turn response and stays busy', async () => {
+    mock.api.planningChatSend = vi.fn(async (request: { turnId?: string }) => ({
+      ok: false as const,
+      sessionId: 'session-1',
+      turnId: request.turnId,
+      error: 'duplicate-turn',
+    }));
+
+    render(<App />);
+    await openPlanningSurface();
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1);
+    });
+    // The original request's outcome will land via response, event, or poll:
+    // the session stays busy and no error UI appears.
+    expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    expect(screen.queryByText('Planner could not respond')).not.toBeInTheDocument();
+    expect(screen.queryByText(/duplicate-turn/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoker-terminal-retry-turn')).not.toBeInTheDocument();
+  });
+
+  it('keeps one chat row when the poll observes the in-flight send before the response lands', async () => {
+    let resolveSend: (() => void) | undefined;
+    mock.api.planningChatSend = vi.fn((request: { turnId?: string }) => new Promise((resolve) => {
+      resolveSend = () => resolve({
+        ok: true,
+        sessionId: 'server-1',
+        turnId: request.turnId,
+        reply: 'Landed on the server session.',
+        confirmationMode: 'require',
+        draftPlanAvailable: false,
+      });
+    })) as typeof mock.api.planningChatSend;
+    // Empty at mount; the backend session appears only once the send is in
+    // flight, exactly what the busy poll would observe server-side.
+    const serverSessions = { current: [] as ReturnType<typeof makePlanningSessionSummary>[] };
+    mock.api.planningChatList = vi.fn(async () => ({ ok: true, sessions: serverSessions.current }));
+
+    render(<App />);
+    await openPlanningSurface();
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+      fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+      serverSessions.current = [
+        makePlanningSessionSummary({
+          id: 'server-1',
+          title: 'Server chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          messages: [
+            { id: 1, role: 'user', text: 'hello planner', createdAt: '2026-07-07T00:00:01.000Z' },
+          ],
+          activeTurnId: 'turn-live',
+          activeTurnStatus: 'running',
+        }),
+      ];
+
+      // The busy poll observes the backend session for this in-flight send.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      // No duplicate row: the backend session is not appended as a new chat.
+      expect(screen.queryByText('Server chat')).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    await act(async () => {
+      resolveSend?.();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Landed on the server session.');
+    });
+  });
+
+  it('lands a turn outcome exactly once when both the response and the stream event deliver it', async () => {
+    render(<App />);
+    await openPlanningSurface();
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('I can help draft that.');
+    });
+
+    const sendRequest = vi.mocked(mock.api.planningChatSend).mock.calls[0]?.[0] as { turnId?: string };
+    expect(typeof sendRequest.turnId).toBe('string');
+
+    await act(async () => {
+      mock.firePlanningChatStream({
+        sessionId: 'session-1',
+        turnId: sendRequest.turnId,
+        turn: { status: 'completed', reply: 'I can help draft that.', draftPlanAvailable: false },
+      });
+    });
+
+    const transcriptText = screen.getByTestId('invoker-terminal-transcript').textContent ?? '';
+    expect(transcriptText.split('I can help draft that.').length - 1).toBe(1);
+    expect(screen.getByTestId('invoker-terminal-input')).not.toBeDisabled();
+  });
+});

--- a/packages/ui/src/__tests__/planning-turn-durability.test.tsx
+++ b/packages/ui/src/__tests__/planning-turn-durability.test.tsx
@@ -233,4 +233,230 @@ describe('planning turn durability', () => {
     expect(transcriptText.split('I can help draft that.').length - 1).toBe(1);
     expect(screen.getByTestId('invoker-terminal-input')).not.toBeDisabled();
   });
+  it('fails a wiped mid-first-send turn into the banner and keeps the chat', async () => {
+    mock.api.planningChatSend = vi.fn((request: { turnId?: string }) => new Promise(() => {
+      void request; // never resolves: the server was wiped mid-turn
+    })) as typeof mock.api.planningChatSend;
+    const serverSessions = { current: [] as ReturnType<typeof makePlanningSessionSummary>[] };
+    mock.api.planningChatList = vi.fn(async () => ({ ok: true, sessions: serverSessions.current }));
+
+    render(<App />);
+    await openPlanningSurface();
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+      fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+      serverSessions.current = [
+        makePlanningSessionSummary({
+          id: 'server-1',
+          title: 'Server chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          messages: [
+            { id: 1, role: 'user', text: 'hello planner', createdAt: '2026-07-07T00:00:01.000Z' },
+          ],
+          activeTurnId: 'turn-live',
+          activeTurnStatus: 'running',
+        }),
+      ];
+
+      // While the server still reports the running turn, nothing fails.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      expect(screen.queryByTestId('invoker-terminal-turn-error')).not.toBeInTheDocument();
+
+      // Server wiped: two consecutive polls prove the turn is gone.
+      serverSessions.current = [];
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      expect(screen.queryByTestId('invoker-terminal-turn-error')).not.toBeInTheDocument();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+
+      expect(screen.getByTestId('invoker-terminal-turn-error'))
+        .toHaveTextContent('The planner session no longer exists on the server. It may have been reset.');
+      expect(screen.getByTestId('invoker-terminal-retry-turn')).toBeInTheDocument();
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('hello planner');
+      expect(screen.queryByTestId('invoker-terminal-send-spinner')).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('fails a hydrated running turn when its server session disappears, keeping the row and transcript', async () => {
+    const serverSessions = {
+      current: [
+        makePlanningSessionSummary({
+          id: 'busy-chat',
+          title: 'Busy chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          messages: [
+            { id: 1, role: 'user', text: 'Draft the plan', createdAt: '2026-07-07T00:00:01.000Z' },
+          ],
+          activeTurnId: 'turn-live',
+          activeTurnStatus: 'running',
+        }),
+      ] as ReturnType<typeof makePlanningSessionSummary>[],
+    };
+    mock.api.planningChatList = vi.fn(async () => ({ ok: true, sessions: serverSessions.current }));
+
+    // Fake timers from the start so the busy poll's interval is fake-timer
+    // driven even though hydration (not a send) flips the session busy.
+    vi.useFakeTimers();
+    try {
+      render(<App />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      fireEvent.click(screen.getByTestId('sidebar-home'));
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+
+      serverSessions.current = [];
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      expect(screen.queryByTestId('invoker-terminal-turn-error')).not.toBeInTheDocument();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+
+      expect(screen.getByTestId('invoker-terminal-turn-error'))
+        .toHaveTextContent('The planner session no longer exists on the server. It may have been reset.');
+      expect(screen.getByTestId('invoker-terminal-retry-turn')).toBeInTheDocument();
+      expect(screen.getAllByText('Busy chat').length).toBeGreaterThan(0);
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Draft the plan');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not fail the turn on a transient one-poll miss', async () => {
+    mock.api.planningChatSend = vi.fn((request: { turnId?: string }) => new Promise(() => {
+      void request;
+    })) as typeof mock.api.planningChatSend;
+    const runningServerSession = makePlanningSessionSummary({
+      id: 'server-1',
+      title: 'Server chat',
+      status: 'still_discussing',
+      draftPlanAvailable: false,
+      draftPlanSummary: undefined,
+      draftPlanText: undefined,
+      messages: [
+        { id: 1, role: 'user', text: 'hello planner', createdAt: '2026-07-07T00:00:01.000Z' },
+      ],
+      activeTurnId: 'turn-live',
+      activeTurnStatus: 'running',
+    });
+    const serverSessions = { current: [] as ReturnType<typeof makePlanningSessionSummary>[] };
+    mock.api.planningChatList = vi.fn(async () => ({ ok: true, sessions: serverSessions.current }));
+
+    render(<App />);
+    await openPlanningSurface();
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+      fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+      serverSessions.current = [runningServerSession];
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+
+      // One empty poll: not enough to fail the turn.
+      serverSessions.current = [];
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      expect(screen.queryByTestId('invoker-terminal-turn-error')).not.toBeInTheDocument();
+
+      // The turn reappears: the gone counter resets.
+      serverSessions.current = [runningServerSession];
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+
+      expect(screen.queryByTestId('invoker-terminal-turn-error')).not.toBeInTheDocument();
+      expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('lets a late send response overwrite the gone-turn failure', async () => {
+    let resolveSend: (() => void) | undefined;
+    mock.api.planningChatSend = vi.fn((request: { turnId?: string }) => new Promise((resolve) => {
+      resolveSend = () => resolve({
+        ok: true,
+        sessionId: 'server-1',
+        turnId: request.turnId,
+        reply: 'Landed after all.',
+        confirmationMode: 'require',
+        draftPlanAvailable: false,
+      });
+    })) as typeof mock.api.planningChatSend;
+    const serverSessions = { current: [] as ReturnType<typeof makePlanningSessionSummary>[] };
+    mock.api.planningChatList = vi.fn(async () => ({ ok: true, sessions: serverSessions.current }));
+
+    render(<App />);
+    await openPlanningSurface();
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+      fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+      serverSessions.current = [
+        makePlanningSessionSummary({
+          id: 'server-1',
+          title: 'Server chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          messages: [
+            { id: 1, role: 'user', text: 'hello planner', createdAt: '2026-07-07T00:00:01.000Z' },
+          ],
+          activeTurnId: 'turn-live',
+          activeTurnStatus: 'running',
+        }),
+      ];
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      serverSessions.current = [];
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      expect(screen.getByTestId('invoker-terminal-turn-error')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    // The failed turn keeps its activeTurnId, so the genuine reply still lands.
+    await act(async () => {
+      resolveSend?.();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Landed after all.');
+    });
+    expect(screen.queryByTestId('invoker-terminal-turn-error')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoker-terminal-retry-turn')).not.toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/components/ContextMenu.tsx
+++ b/packages/ui/src/components/ContextMenu.tsx
@@ -29,6 +29,8 @@ interface ContextMenuProps {
   onDelete?: (taskId: string) => void;
   onClose: (options?: { restoreFocus?: boolean }) => void;
   autoFocus?: boolean;
+  /** Execution agents offered for fix actions; defaults to the builtin pair. */
+  agents?: string[];
 }
 
 function stopMenuKeyboardEvent(e: KeyboardEvent | React.KeyboardEvent) {
@@ -57,6 +59,7 @@ export function ContextMenu({
   onDelete,
   onClose,
   autoFocus = false,
+  agents,
 }: ContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
@@ -66,7 +69,9 @@ export function ContextMenu({
   const [showMore, setShowMore] = useState(false);
 
   // Generate menu items
-  const items = getMenuItems(task, { agents: ['claude', 'codex'] });
+  const items = getMenuItems(task, {
+    agents: agents && agents.length > 0 ? agents : ['claude', 'codex'],
+  });
 
   // Filter items based on available handlers
   const availableItems = items.filter((item) => {

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -1110,10 +1110,18 @@ export function InvokerTerminal({
                   disabled={sendButtonDisabled}
                   className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-amber-400 text-white shadow-sm transition-colors hover:bg-amber-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-amber-300 disabled:bg-gray-700 disabled:text-gray-400 disabled:shadow-none disabled:hover:bg-gray-700 disabled:opacity-50 ${sendButtonDisabledCursorClass}`}
                 >
-                  <SendIcon
-                    data-testid="invoker-terminal-send-icon"
-                    className="h-4 w-4"
-                  />
+                  {busy ? (
+                    <span
+                      data-testid="invoker-terminal-send-spinner"
+                      aria-hidden="true"
+                      className="inline-block h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-gray-500 border-t-gray-100"
+                    />
+                  ) : (
+                    <SendIcon
+                      data-testid="invoker-terminal-send-icon"
+                      className="h-4 w-4"
+                    />
+                  )}
                 </button>
               </div>
             </div>

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -133,6 +133,8 @@ interface InvokerTerminalProps {
   repoLocked?: boolean;
   repoSuggestions?: string[];
   repoError?: string | null;
+  turnError?: string | null;
+  onRetryTurn?: () => void;
   onValueChange: (value: string) => void;
   onSubmit: () => void;
   onPresetChange: (presetKey: string) => void;
@@ -559,6 +561,8 @@ export function InvokerTerminal({
   repoLocked = true,
   repoSuggestions = [],
   repoError = null,
+  turnError = null,
+  onRetryTurn,
   onPresetChange,
   onConfirmationModeChange,
   onRepoInputChange,
@@ -914,6 +918,24 @@ export function InvokerTerminal({
               transcriptContent
             )}
           </div>
+
+          {turnError && !readOnly && (
+            <div
+              data-testid="invoker-terminal-turn-error"
+              className="sticky bottom-0 z-10 flex flex-wrap items-center justify-between gap-3 border-t border-border bg-card/80 px-4 py-3.5 backdrop-blur-sm"
+            >
+              <span className="min-w-0 flex-1 text-xs text-red-400">{turnError}</span>
+              <button
+                type="button"
+                data-testid="invoker-terminal-retry-turn"
+                disabled={busy}
+                onClick={() => onRetryTurn?.()}
+                className="rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Retry
+              </button>
+            </div>
+          )}
 
           {draftPlanAvailable && !draftReviewOpen && !readOnly && (
             <div

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -129,10 +129,16 @@ interface InvokerTerminalProps {
   terminalError?: string | null;
   terminalActive?: boolean;
   workflowRunning?: boolean;
+  repoValue?: string;
+  repoLocked?: boolean;
+  repoSuggestions?: string[];
+  repoError?: string | null;
   onValueChange: (value: string) => void;
   onSubmit: () => void;
   onPresetChange: (presetKey: string) => void;
   onConfirmationModeChange: (confirmationMode: PlanningConfirmationMode) => void;
+  onRepoInputChange?: (value: string) => void;
+  onRepoCommit?: () => void;
   onModeChange?: (mode: PlanningTerminalMode) => void;
   onExpand: () => void;
   onCloseExpanded?: () => void;
@@ -549,8 +555,14 @@ export function InvokerTerminal({
   workflowRunning = false,
   onValueChange,
   onSubmit,
+  repoValue = '',
+  repoLocked = true,
+  repoSuggestions = [],
+  repoError = null,
   onPresetChange,
   onConfirmationModeChange,
+  onRepoInputChange,
+  onRepoCommit,
   onModeChange,
   onExpand,
   onCloseExpanded,
@@ -1040,6 +1052,33 @@ export function InvokerTerminal({
                           <option value="require">Ask first</option>
                         </select>
                       </label>
+                      {!repoLocked && (
+                        <label className="text-xs text-muted-foreground">
+                          Repo
+                          <input
+                            data-testid="invoker-terminal-repo"
+                            list="invoker-terminal-repo-suggestions"
+                            value={repoValue}
+                            disabled={readOnly}
+                            placeholder="path or URL (default if empty)"
+                            onChange={(event) => onRepoInputChange?.(event.target.value)}
+                            onBlur={() => onRepoCommit?.()}
+                            onKeyDown={(event) => {
+                              if (event.key === 'Enter') {
+                                event.preventDefault();
+                                onRepoCommit?.();
+                              }
+                            }}
+                            className="ml-2 w-56 rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground outline-none hover:border-border-strong focus:border-ring"
+                          />
+                          <datalist id="invoker-terminal-repo-suggestions">
+                            {repoSuggestions.map((repo) => <option key={repo} value={repo} />)}
+                          </datalist>
+                        </label>
+                      )}
+                      {repoError && !repoLocked && (
+                        <span data-testid="invoker-terminal-repo-error" className="text-xs text-red-400">{repoError}</span>
+                      )}
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
## Summary

When the server loses a chat mid-turn (a reset wipes its state), the tab used to show Working… forever.

The busy poll only counted transport failures, so successful polls against a wiped server never ended the wait.

Now two consecutive successful polls that no longer contain the busy turn's session fail that turn into the existing turn-error banner.

The transcript stays. The user sees the same red banner used for other turn failures and can start over from it.

## Review Claim

Approve the gone-turn sweep in `refreshPlanningSessionsNow`: a busy turn whose backend session is absent from two consecutive successful poll responses fails into the existing turn-error banner instead of spinning forever.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The sweep only touches sessions already busy with an `activeTurnId`, and only after two consecutive successful list polls miss them; transport failures keep their separate 3-strike counter. A failed turn keeps its `activeTurnId`, so a late genuine reply still lands and clears the banner (covered by a test).

## Slice Rationale

Smallest user-visible fix for the incident where a server-side wipe hung the composer forever. The telemetry that observes this sweep ships separately in (17).

## Non-goals

- No change to the transport-failure path or its `Lost connection to the planner.` message.
- No change to the 5s polling cadence.
- No server-side changes.
- No change to the guarded `dag-surface-background-click-noop` behavior in `App.tsx`; background clicks on the DAG surface stay a no-op.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm vitest run src/__tests__/planning-turn-durability.test.tsx`
- [ ] `cd packages/ui && pnpm vitest run` (full package suite)

</details>

## Visual Proof

Captured on the live web demo running this change. My own throwaway chat was mid-turn (Working…) when its backend session was deleted server-side; within two poll ticks and without a refresh the spinner is gone and the banner appears.

![Spinner-to-banner walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-ed825e/gone-turn-walkthrough.mp4)

![Mid-turn spinner before the server-side wipe](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-ed825e/gone-turn-spinner-before.webp)

Working pill in the header, Working… line in the transcript, and the spinner inside the Send button while the turn runs.

![Banner shown once the session vanished](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-ed825e/gone-turn-banner-final.webp)

Red banner reading "The planner session no longer exists on the server. It may have been reset." with the Retry button, the user message still in the transcript, and the Send arrow restored.

Manually inspected: I opened the before and after frames myself. The before frame shows the "Working" pill, the "Working…" transcript line, and the spinner ring in the Send button; the after frame shows the red banner text quoted above with the Retry button on the right, the "proof capture: draft a careful long plan for a notes app" message still present, the status pill flipped to "Still discussing", and the Send arrow back. The video's frames step through the wait and land on the banner state.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting restores the previous behavior (hang until transport failure or reply).
- Revert command: `git revert ec3a7c4073`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #9970
