### PR TITLE
[Web surface parity](15) Persist web-surface UI telemetry to the activity log

### DIFF
--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -53,6 +53,34 @@ function makeTaskTerminalAdapter() {
 }
 
 describe('buildWebInvokerDispatch', () => {
+  it('report-ui-perf persists the metric to the activity log like the GUI handler', async () => {
+    const writeActivityLog = vi.fn();
+    const { dispatch } = makeDispatch({
+      persistence: {
+        listWorkflows: () => [],
+        writeActivityLog,
+      },
+    });
+    await dispatch('invoker:report-ui-perf', ['planning_send_start', { sessionId: 's-1', turnId: 't-1' }]);
+    expect(writeActivityLog).toHaveBeenCalledTimes(1);
+    const [source, level, message] = writeActivityLog.mock.calls[0];
+    expect(source).toBe('ui-perf');
+    expect(level).toBe('info');
+    expect(JSON.parse(message)).toMatchObject({ metric: 'planning_send_start', sessionId: 's-1', turnId: 't-1' });
+  });
+
+  it('report-ui-perf swallows activity-log write failures', async () => {
+    const { dispatch } = makeDispatch({
+      persistence: {
+        listWorkflows: () => [],
+        writeActivityLog: vi.fn(() => {
+          throw new Error('database is locked');
+        }),
+      },
+    });
+    await expect(dispatch('invoker:report-ui-perf', ['planning_send_start', {}])).resolves.toBeUndefined();
+  });
+
   it('list-workflows returns the persisted workflows', async () => {
     const { dispatch } = makeDispatch();
     expect(await dispatch('invoker:list-workflows', [])).toEqual([

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -206,8 +206,23 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return { ownerMode: true, readOnly: false, mode: 'local-owner' };
       case 'invoker:get-ui-perf-stats':
         return {};
-      case 'invoker:report-ui-perf':
+      case 'invoker:report-ui-perf': {
+        // Mirror the GUI handler (gui-mutation-handlers.ts): persist every
+        // renderer metric to the activity log so web-surface interactions are
+        // diagnosable after the fact. Previously a silent no-op, which left
+        // web incidents with no client-side record at all.
+        const payload = {
+          ts: new Date().toISOString(),
+          metric: String(args[0] ?? ''),
+          ...((args[1] ?? {}) as Record<string, unknown>),
+        };
+        try {
+          persistence.writeActivityLog('ui-perf', 'info', JSON.stringify(payload));
+        } catch {
+          // DB might be locked; matching the GUI handler's tolerance.
+        }
         return undefined;
+      }
       case 'invoker:trace-renderer-task-graph-event':
         return undefined;
       case 'invoker:check-pr-statuses':


### PR DESCRIPTION
## Summary

The web dispatch treated `invoker:report-ui-perf` as a no-op. Every UI metric a web-surface tab reported was silently discarded, which is why the demo incident left no client-side record.

Now the web dispatch persists each metric to the activity log with source `ui-perf`, matching what the Electron GUI handler already does.

Rows become readable through `invoker:get-activity-logs` and the existing `ui-perf` query tooling.

## Review Claim

Approve the web dispatch writing each `report-ui-perf` payload to the activity log with source `ui-perf`, timestamped like the GUI handler's rows.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Additive persist inside a try/catch that tolerates a locked DB, mirroring the GUI handler's tolerance; the channel still resolves `undefined`, so no caller-visible contract changes.

## Slice Rationale

Server-side foundation first: the client pipeline (16) and interaction events (17) are only worth shipping once the web owner actually stores what tabs report.

## Non-goals

- No renderer-stats aggregation on the web surface (`get-ui-perf-stats` still returns `{}`).
- No new channels and no Electron-side changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm vitest run src/__tests__/web-invoker-dispatch.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting returns the channel to a no-op and web tabs stop persisting metrics.
- Revert command: `git revert 233e308404`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #9971
