### PR TITLE
[Web surface parity](16) Buffered planning telemetry pipeline with transport-failure retry

### DIFF
--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from 'xterm-addon-fit';
 import type { TerminalSessionDescriptor } from '@invoker/contracts';
 import type { PlanningConfirmationMode } from '@invoker/contracts';
 import { SendIcon } from './icons/index.js';
+import { logPlanningEvent } from '../lib/planning-telemetry.js';
 
 export interface InvokerTerminalLine {
   id: number;
@@ -102,7 +103,7 @@ function roundMs(durationMs: number): number {
 }
 
 function reportPlanningChatPerf(metric: string, data: Record<string, unknown>): void {
-  void window.invoker?.reportUiPerf?.(metric, data);
+  logPlanningEvent(metric, data);
 }
 
 interface InvokerTerminalProps {

--- a/packages/ui/src/lib/planning-telemetry.test.ts
+++ b/packages/ui/src/lib/planning-telemetry.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  drainPlanningTelemetryRetries,
+  logPlanningEvent,
+  planningTelemetryRing,
+  resetPlanningTelemetryForTests,
+} from './planning-telemetry.js';
+
+type ReportUiPerf = (metric: string, data?: Record<string, unknown>) => Promise<void>;
+
+function installReporter(report: ReportUiPerf): void {
+  (window as { invoker?: { reportUiPerf: ReportUiPerf } }).invoker = { reportUiPerf: report };
+}
+
+describe('planning telemetry', () => {
+  beforeEach(() => {
+    resetPlanningTelemetryForTests();
+  });
+
+  afterEach(() => {
+    resetPlanningTelemetryForTests();
+    delete (window as { invoker?: unknown }).invoker;
+  });
+
+  it('records events in the ring buffer and forwards them to reportUiPerf', async () => {
+    const report = vi.fn(async () => {});
+    installReporter(report);
+
+    logPlanningEvent('planning_send_start', { sessionId: 's-1', turnId: 't-1' });
+
+    const ring = planningTelemetryRing();
+    expect(ring).toHaveLength(1);
+    expect(ring[0].metric).toBe('planning_send_start');
+    expect(ring[0].data).toEqual({ sessionId: 's-1', turnId: 't-1' });
+    expect(report).toHaveBeenCalledWith('planning_send_start', { sessionId: 's-1', turnId: 't-1' });
+  });
+
+  it('queues events while shipping fails and replays them once the transport recovers', async () => {
+    let failing = true;
+    const shipped: Array<{ metric: string; data?: Record<string, unknown> }> = [];
+    const report = vi.fn(async (metric: string, data?: Record<string, unknown>) => {
+      if (failing) throw new Error('502');
+      shipped.push({ metric, data });
+    });
+    installReporter(report);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    logPlanningEvent('planning_poll_failure', { consecutiveFailures: 1 });
+    // Let the rejection land in the retry queue.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(shipped).toHaveLength(0);
+
+    failing = false;
+    drainPlanningTelemetryRetries();
+    await Promise.resolve();
+
+    expect(shipped).toHaveLength(1);
+    expect(shipped[0].metric).toBe('planning_poll_failure');
+    // Replayed events carry their original client timestamp.
+    expect(shipped[0].data).toMatchObject({ consecutiveFailures: 1, replayed: true });
+    expect(typeof shipped[0].data?.clientTs).toBe('string');
+    consoleError.mockRestore();
+  });
+
+  it('queues events logged before the bridge installs and ships them on drain', async () => {
+    logPlanningEvent('planning_web_boot', { href: 'x' });
+
+    const report = vi.fn(async () => {});
+    installReporter(report);
+    drainPlanningTelemetryRetries();
+    await Promise.resolve();
+
+    expect(report).toHaveBeenCalledTimes(1);
+    expect(report.mock.calls[0][0]).toBe('planning_web_boot');
+  });
+
+  it('caps the retry queue and reports the drop count after recovery', async () => {
+    const shipped: string[] = [];
+    // No reporter installed: every event lands in the bounded retry queue.
+    for (let i = 0; i < 130; i += 1) {
+      logPlanningEvent('planning_poll_failure', { consecutiveFailures: i });
+    }
+
+    installReporter(vi.fn(async (metric: string) => {
+      shipped.push(metric);
+    }));
+    drainPlanningTelemetryRetries();
+    await Promise.resolve();
+
+    // 100 queued survivors + 1 synthetic drop report for the 30 evicted.
+    expect(shipped.filter((metric) => metric === 'planning_poll_failure')).toHaveLength(100);
+    expect(shipped.filter((metric) => metric === 'planning_telemetry_dropped')).toHaveLength(1);
+  });
+});

--- a/packages/ui/src/lib/planning-telemetry.ts
+++ b/packages/ui/src/lib/planning-telemetry.ts
@@ -1,0 +1,116 @@
+/**
+ * Planning interaction telemetry.
+ *
+ * Every event goes three places:
+ * 1. A ring buffer on `window.__invokerPlanningLog` for in-tab forensics.
+ * 2. The console, so devtools show the interaction timeline.
+ * 3. `window.invoker.reportUiPerf` — the existing ui-perf pipeline; the owner
+ *    persists each event to the activity log (source `ui-perf`), where it is
+ *    queryable via `invoker query ui-perf` / `invoker:get-activity-logs`.
+ *
+ * Events that fail to ship (transport down mid-incident) are queued and
+ * retried on an interval, so the server record survives transient 502s —
+ * exactly the windows we most need logs from. The queue is bounded; when it
+ * overflows, the oldest events are dropped and the drop count is reported
+ * once the transport recovers.
+ */
+
+export interface PlanningTelemetryEntry {
+  ts: string;
+  metric: string;
+  data: Record<string, unknown>;
+}
+
+declare global {
+  interface Window {
+    /** In-tab forensic ring buffer of recent planning telemetry (newest last). */
+    __invokerPlanningLog?: PlanningTelemetryEntry[];
+  }
+}
+
+const RING_MAX = 300;
+const RETRY_MAX = 100;
+const RETRY_INTERVAL_MS = 10_000;
+
+const ring: PlanningTelemetryEntry[] = [];
+const retryQueue: PlanningTelemetryEntry[] = [];
+let droppedRetries = 0;
+let retryTimer: number | null = null;
+
+if (typeof window !== 'undefined') {
+  window.__invokerPlanningLog = ring;
+}
+
+function enqueueRetry(entry: PlanningTelemetryEntry): void {
+  retryQueue.push(entry);
+  if (retryQueue.length > RETRY_MAX) {
+    retryQueue.shift();
+    droppedRetries += 1;
+  }
+  if (retryTimer === null && typeof window !== 'undefined') {
+    retryTimer = window.setInterval(drainPlanningTelemetryRetries, RETRY_INTERVAL_MS);
+  }
+}
+
+function ship(entry: PlanningTelemetryEntry, replayed: boolean): void {
+  const report = typeof window !== 'undefined' ? window.invoker?.reportUiPerf : undefined;
+  if (!report) {
+    // No bridge yet (or a non-browser environment): keep the event for retry
+    // so early-boot events still reach the server once the bridge installs.
+    enqueueRetry(entry);
+    return;
+  }
+  const payload = replayed ? { ...entry.data, clientTs: entry.ts, replayed: true } : entry.data;
+  Promise.resolve(report(entry.metric, payload)).catch((err: unknown) => {
+    console.error('[planning] telemetry ship failed', entry.metric, err);
+    enqueueRetry(entry);
+  });
+}
+
+/** Retry loop tick; exported for tests. */
+export function drainPlanningTelemetryRetries(): void {
+  if (retryQueue.length === 0 && droppedRetries === 0) {
+    if (retryTimer !== null && typeof window !== 'undefined') {
+      window.clearInterval(retryTimer);
+      retryTimer = null;
+    }
+    return;
+  }
+  const report = typeof window !== 'undefined' ? window.invoker?.reportUiPerf : undefined;
+  if (!report) return;
+  if (droppedRetries > 0) {
+    const dropped = droppedRetries;
+    droppedRetries = 0;
+    ship({ ts: new Date().toISOString(), metric: 'planning_telemetry_dropped', data: { droppedCount: dropped } }, false);
+  }
+  const pending = retryQueue.splice(0, retryQueue.length);
+  for (const entry of pending) ship(entry, true);
+}
+
+/**
+ * Record one planning interaction event. Fire-and-forget; never throws.
+ * Metric names are snake_case to match the existing `ui-perf` rows.
+ */
+export function logPlanningEvent(metric: string, data: Record<string, unknown> = {}): void {
+  const entry: PlanningTelemetryEntry = { ts: new Date().toISOString(), metric, data };
+  ring.push(entry);
+  if (ring.length > RING_MAX) ring.shift();
+  console.info('[planning]', metric, data);
+  ship(entry, false);
+}
+
+/** Test hook: clears the ring, the retry queue, and the retry timer. */
+export function resetPlanningTelemetryForTests(): void {
+  ring.length = 0;
+  retryQueue.length = 0;
+  droppedRetries = 0;
+  if (retryTimer !== null && typeof window !== 'undefined') {
+    window.clearInterval(retryTimer);
+    retryTimer = null;
+  }
+}
+
+/** Read-only view of the ring buffer (newest last); exported for tests. */
+export function planningTelemetryRing(): readonly PlanningTelemetryEntry[] {
+  return ring;
+}

--- a/packages/ui/src/web/__tests__/web-invoker-client.test.ts
+++ b/packages/ui/src/web/__tests__/web-invoker-client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { installWebInvoker } from '../web-invoker-client.js';
+import { planningTelemetryRing, resetPlanningTelemetryForTests } from '../../lib/planning-telemetry.js';
 
 interface FetchCall {
   url: string;
@@ -30,7 +31,12 @@ describe('installWebInvoker', () => {
   let fetchCalls: FetchCall[];
   let fetchResult: unknown;
 
+  // installWebInvoker ships a planning_web_boot telemetry event over the
+  // report-ui-perf channel; app-level assertions must ignore that traffic.
+  const invokeCalls = (): FetchCall[] => fetchCalls.filter((call) => call.body.channel !== 'invoker:report-ui-perf');
+
   beforeEach(() => {
+    resetPlanningTelemetryForTests();
     fetchCalls = [];
     fetchResult = { tasks: [], workflows: [], streamSequence: 0 };
     FakeEventSource.instances = [];
@@ -60,9 +66,9 @@ describe('installWebInvoker', () => {
   it('getTasks POSTs to /invoke and resolves the mocked result', async () => {
     installWebInvoker({});
     const result = await window.invoker.getTasks();
-    expect(fetchCalls).toHaveLength(1);
-    expect(fetchCalls[0].url).toBe('/invoke');
-    expect(fetchCalls[0].body).toEqual({ channel: 'invoker:get-tasks', args: [] });
+    expect(invokeCalls()).toHaveLength(1);
+    expect(invokeCalls()[0].url).toBe('/invoke');
+    expect(invokeCalls()[0].body).toEqual({ channel: 'invoker:get-tasks', args: [] });
     expect(result).toEqual({ tasks: [], workflows: [], streamSequence: 0 });
   });
 
@@ -99,6 +105,29 @@ describe('installWebInvoker', () => {
     fetchResult = undefined;
     installWebInvoker({});
     await window.invoker.approve('wf/x');
-    expect(fetchCalls[0].body).toEqual({ channel: 'invoker:approve', args: ['wf/x'] });
+    expect(invokeCalls()[0].body).toEqual({ channel: 'invoker:approve', args: ['wf/x'] });
+  });
+
+  it('ships a planning_web_boot telemetry event through report-ui-perf on install', () => {
+    installWebInvoker({});
+    const bootCalls = fetchCalls.filter((call) => call.body.channel === 'invoker:report-ui-perf');
+    expect(bootCalls).toHaveLength(1);
+    expect(bootCalls[0].body.args[0]).toBe('planning_web_boot');
+  });
+
+  it('records a web_invoke_error telemetry event when an invoke returns ok:false', async () => {
+    installWebInvoker({});
+    global.fetch = vi.fn(async (url: string, init?: RequestInit) => {
+      fetchCalls.push({ url: String(url), body: JSON.parse(String(init?.body)) });
+      return {
+        ok: true,
+        json: async () => ({ ok: false, error: { message: 'boom', code: 'unsupported_on_web' } }),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+    await expect(window.invoker.getTasks()).rejects.toThrow('boom');
+    const entry = planningTelemetryRing().find((row) => row.metric === 'web_invoke_error');
+    expect(entry).toBeDefined();
+    expect(entry?.data).toMatchObject({ channel: 'invoker:get-tasks', code: 'unsupported_on_web', message: 'boom' });
   });
 });

--- a/packages/ui/src/web/web-invoker-client.ts
+++ b/packages/ui/src/web/web-invoker-client.ts
@@ -12,23 +12,48 @@
 // break the browser bundle.
 import { IpcChannels, IpcEventChannels, channelToMethod, channelToEventMethod } from '@invoker/contracts/ipc-channels';
 import type { InvokerAPI } from '@invoker/contracts/ipc-channels';
+import { logPlanningEvent } from '../lib/planning-telemetry.js';
 
 export function installWebInvoker(opts: { basePath?: string }): void {
   const base = opts.basePath ?? '';
 
   async function invoke(channel: string, args: unknown[]): Promise<unknown> {
-    const res = await fetch(base + '/invoke', {
-      method: 'POST',
-      credentials: 'same-origin',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ channel, args }),
-    });
-    if (!res.ok) throw new Error('web invoke transport failed: ' + res.status);
+    const startedAt = performance.now();
+    // Failures are telemetry, not just console noise: they ride the buffered
+    // ui-perf pipeline so the server records what each tab experienced.
+    // report-ui-perf itself is excluded — its failures are handled by the
+    // telemetry retry queue and must not self-report.
+    const note = (metric: string, detail: Record<string, unknown>): void => {
+      if (channel === 'invoker:report-ui-perf') return;
+      logPlanningEvent(metric, { channel, durationMs: Math.round(performance.now() - startedAt), ...detail });
+    };
+    let res: Response;
+    try {
+      res = await fetch(base + '/invoke', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ channel, args }),
+      });
+    } catch (err) {
+      note('web_invoke_network_error', { error: err instanceof Error ? err.message : String(err) });
+      throw err;
+    }
+    if (!res.ok) {
+      note('web_invoke_http_error', { status: res.status });
+      throw new Error('web invoke transport failed: ' + res.status);
+    }
     const body = await res.json();
     if (!body || body.ok !== true) {
+      note('web_invoke_error', { code: body?.error?.code, message: body?.error?.message });
       const err = new Error(body?.error?.message ?? 'web invoke failed');
       (err as { code?: unknown }).code = body?.error?.code;
       throw err;
+    }
+    // planning-chat-send legitimately runs for minutes; anything else this
+    // slow is the "popup says failed, server says fine" shape worth a record.
+    if (channel !== 'invoker:planning-chat-send' && performance.now() - startedAt > 20_000) {
+      note('web_invoke_slow', {});
     }
     return body.result;
   }
@@ -73,6 +98,7 @@ export function installWebInvoker(opts: { basePath?: string }): void {
   }
 
   (window as unknown as { invoker: InvokerAPI }).invoker = api as InvokerAPI;
+  logPlanningEvent('planning_web_boot', { href: window.location.href, visibility: document.visibilityState });
   (window as unknown as { __INVOKER_BOOTSTRAP__: unknown }).__INVOKER_BOOTSTRAP__ = {
     tasks: [],
     workflows: [],


### PR DESCRIPTION
## Summary

Planning telemetry gets one shipping path. Every event lands in a 300-entry ring buffer on `window.__invokerPlanningLog`, mirrors to the console, and ships through the existing `reportUiPerf` channel.

Events that fail to ship while the transport is down wait in a bounded queue and go out again once the transport recovers.

Overflow is counted and reported after recovery. That keeps records of exactly the windows where incident evidence used to vanish.

The composer's existing perf events cut over to this path, and the web bridge now records its own invoke failures plus a boot marker recording which build each tab runs.

## Review Claim

Approve one buffered shipper for planning telemetry: ring buffer plus console locally, `reportUiPerf` upstream, failed sends queued and replayed with their original client timestamp.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

`logPlanningEvent` is fire-and-forget and never throws into callers; the `invoker:report-ui-perf` channel is excluded from invoke-failure self-reporting, so a down transport cannot loop; the queue is bounded at 100 with explicit drop accounting; nothing rendered changes.

## Slice Rationale

The pipeline is its own reviewable mechanism, separate from which interactions emit events (17) and from the server-side persist it feeds (15).

## Non-goals

- No new interaction events yet; only existing composer perf events move onto the pipeline.
- No dead-click capture (ships in 17).
- No server-side changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm vitest run src/lib/planning-telemetry.test.ts`
- [ ] `cd packages/ui && pnpm vitest run src/web/__tests__/web-invoker-client.test.ts`

</details>

## Visual Proof

Nothing rendered changes in this slice, so the proof is inspectable state captured live on the web demo: the in-tab ring buffer and the server-persisted rows for the same events, fetched from the running app.

![Live ring buffer overlaid on the planning screen](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-5f1120/telemetry-ring-buffer.webp)

The `window.__invokerPlanningLog` ring in a live tab: `planning_web_boot` from the bridge install, composer events, and the send lifecycle, each with its payload.

![Server-persisted ui-perf rows for the same events](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-5f1120/telemetry-server-rows.webp)

The same events read back from the owner's activity log (source `ui-perf`) over `invoker:get-activity-logs`, proving the shipper delivered them upstream.

Manually inspected: I opened both screenshots myself. The first shows the dark overlay listing `planning_web_boot` with the demo href, `planning_chat_submit`, `planning_send_start` with turnId `59070d6a…`, and `planning_send_result` with `ok:true, durationMs:5345`. The second shows the server-side rows for the same turnId, including `planning_turn_outcome` with `status:"completed"`.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting returns composer perf events to direct `reportUiPerf` calls with no buffering.
- Revert command: `git revert 82c346a606`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #9972
