### PR TITLE
[Web surface parity](14) Send spinner and deferred sends while a repo bind is in flight

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -637,7 +637,7 @@ export function App() {
   const activePlanningWorkflowRunning = activePlanningSession.submittedWorkflowId
     ? workflows.get(activePlanningSession.submittedWorkflowId)?.status === 'running'
     : false;
-  const activePlanningRepoLocked = activePlanningSession.messages.length > 0
+  const activePlanningRepoLocked = activePlanningSession.messages.some((message) => message.role !== 'system')
     || Boolean(activePlanningSession.terminalSession)
     || activePlanningSession.mode === 'tmux'
     || activePlanningReadOnly;
@@ -2790,22 +2790,23 @@ export function App() {
     }));
   }, [activePlanningSession.id, updatePlanningSessionById]);
 
-  const planningRepoCommitInFlightRef = useRef<Promise<{ ok: boolean; sessionId: string | null }> | null>(null);
+  const planningRepoCommitInFlightRef = useRef<Promise<{ ok: boolean; sessionId: string | null; error?: string }> | null>(null);
+  const [planningRepoBindingId, setPlanningRepoBindingId] = useState<string | null>(null);
 
-  const commitPlanningRepo = useCallback((): Promise<{ ok: boolean; sessionId: string | null }> => {
+  const commitPlanningRepo = useCallback((): Promise<{ ok: boolean; sessionId: string | null; error?: string }> => {
     // Clicking Send or Tmux blurs the repo input, so the blur commit and the
     // caller's commit can race; every caller must share one in-flight run.
     const inFlight = planningRepoCommitInFlightRef.current;
     if (inFlight) return inFlight;
 
-    const run = (async (): Promise<{ ok: boolean; sessionId: string | null }> => {
+    const run = (async (): Promise<{ ok: boolean; sessionId: string | null; error?: string }> => {
       // Read the latest view state from refs: render closures go stale across
       // the awaits below and would re-materialize an already-swapped session.
       const viewSessionId = activePlanningSessionIdRef.current;
       const session = planningSessionsRef.current.find((current) => current.id === viewSessionId);
       if (!session) return { ok: true, sessionId: null };
       const currentBackendId = session.id.startsWith('local-') ? null : session.id;
-      const locked = session.messages.length > 0
+      const locked = session.messages.some((message) => message.role !== 'system')
         || Boolean(session.terminalSession)
         || session.mode === 'tmux'
         || session.status === 'submitted'
@@ -2817,10 +2818,15 @@ export function App() {
 
       let sessionId = currentBackendId;
       let viewId = session.id;
+      const failBind = (id: string, sessionIdForResult: string | null, message: string): { ok: false; sessionId: string | null; error: string } => {
+        updatePlanningSessionById(id, (current) => ({ ...current, repoError: message }));
+        appendTerminalLine(`Could not bind repository: ${message}`, 'system', 'error', id);
+        return { ok: false, sessionId: sessionIdForResult, error: message };
+      };
+      setPlanningRepoBindingId(viewId);
       if (!sessionId) {
         if (!invoker?.planningChatCreate) {
-          updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: 'Planner is not available.' }));
-          return { ok: false, sessionId: null };
+          return failBind(viewId, null, 'Planner is not available.');
         }
         try {
           const result = await invoker.planningChatCreate({
@@ -2829,8 +2835,7 @@ export function App() {
             confirmationMode: session.confirmationMode ?? selectedPlanningConfirmationMode,
           });
           if (!result.ok) {
-            updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: result.error }));
-            return { ok: false, sessionId: null };
+            return failBind(viewId, null, result.error);
           }
           const localId = viewId;
           sessionId = result.session.id;
@@ -2855,22 +2860,20 @@ export function App() {
           setActivePlanningSessionId((currentSessionId) => (
             currentSessionId === localId ? result.session.id : currentSessionId
           ));
+          setPlanningRepoBindingId((current) => (current === localId ? result.session.id : current));
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Failed to create a planning session.';
-          updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: message }));
-          return { ok: false, sessionId: null };
+          return failBind(viewId, null, message);
         }
       }
 
       if (!invoker?.planningChatRebindRepo) {
-        updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: 'Repo binding is not available.' }));
-        return { ok: false, sessionId };
+        return failBind(viewId, sessionId, 'Repo binding is not available.');
       }
       try {
         const result = await invoker.planningChatRebindRepo({ sessionId, repoUrl: pending });
         if (!result.ok) {
-          updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: result.error }));
-          return { ok: false, sessionId };
+          return failBind(viewId, sessionId, result.error);
         }
         updatePlanningSessionById(viewId, (current) => ({
           ...current,
@@ -2882,19 +2885,20 @@ export function App() {
         return { ok: true, sessionId };
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to bind the repository.';
-        updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: message }));
-        return { ok: false, sessionId };
+        return failBind(viewId, sessionId, message);
       }
     })();
 
     planningRepoCommitInFlightRef.current = run;
     void run.finally(() => {
+      setPlanningRepoBindingId(null);
       if (planningRepoCommitInFlightRef.current === run) {
         planningRepoCommitInFlightRef.current = null;
       }
     });
     return run;
   }, [
+    appendTerminalLine,
     invoker,
     runtimeStatus,
     selectedPlanningConfirmationMode,
@@ -4725,6 +4729,7 @@ export function App() {
             activeConversationKey={activePlanningConversationKey}
             lines={terminalLines}
             busy={activePlanningSessionBusy}
+            binding={planningRepoBindingId !== null && planningRepoBindingId === activePlanningSessionId}
             value={planningInput}
             selectedPresetKey={selectedPlanningPresetKey}
             presetOptions={planningPresetOptions}

--- a/packages/ui/src/__tests__/planning-repo-binding.test.tsx
+++ b/packages/ui/src/__tests__/planning-repo-binding.test.tsx
@@ -140,6 +140,81 @@ describe('planning composer repo binding', () => {
     expect(screen.getByTestId('invoker-terminal-input')).toHaveValue('');
   });
 
+  it('shows the send spinner and defers the send while a send-triggered bind is in flight', async () => {
+    let resolveRebind!: (value: { ok: true; action: 'provision' }) => void;
+    mock.api.planningChatRebindRepo = vi.fn(() => new Promise<{ ok: true; action: 'provision' }>((resolve) => {
+      resolveRebind = resolve;
+    }));
+
+    render(<App />);
+    await openComposerOptions();
+
+    const repoInput = screen.getByTestId('invoker-terminal-repo');
+    fireEvent.change(repoInput, { target: { value: '/tmp/repo-a' } });
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+
+    // Clicking Send first blurs the repo field, then submits the form.
+    fireEvent.blur(repoInput);
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-send-spinner')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    expect(mock.api.planningChatSend).not.toHaveBeenCalled();
+
+    resolveRebind({ ok: true, action: 'provision' });
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows the send spinner during a blur-committed bind without sending', async () => {
+    let resolveRebind!: (value: { ok: true; action: 'provision' }) => void;
+    mock.api.planningChatRebindRepo = vi.fn(() => new Promise<{ ok: true; action: 'provision' }>((resolve) => {
+      resolveRebind = resolve;
+    }));
+
+    render(<App />);
+    await openComposerOptions();
+
+    const repoInput = screen.getByTestId('invoker-terminal-repo');
+    fireEvent.change(repoInput, { target: { value: '/tmp/repo-a' } });
+    fireEvent.blur(repoInput);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-send-spinner')).toBeInTheDocument();
+    });
+
+    resolveRebind({ ok: true, action: 'provision' });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('invoker-terminal-send-spinner')).not.toBeInTheDocument();
+    });
+    expect(mock.api.planningChatSend).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failed bind in the transcript and keeps the typed message', async () => {
+    mock.api.planningChatRebindRepo = vi.fn(async () => ({ ok: false as const, error: 'boom' }));
+
+    render(<App />);
+    await openComposerOptions();
+
+    const repoInput = screen.getByTestId('invoker-terminal-repo');
+    fireEvent.change(repoInput, { target: { value: '/tmp/repo-a' } });
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+
+    fireEvent.blur(repoInput);
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    const errorLines = await screen.findAllByText('Could not bind repository: boom');
+    expect(errorLines.length).toBeGreaterThanOrEqual(1);
+    expect(mock.api.planningChatSend).not.toHaveBeenCalled();
+    expect(screen.getByTestId('invoker-terminal-input')).toHaveValue('hello planner');
+    expect(screen.queryByTestId('invoker-terminal-send-spinner')).not.toBeInTheDocument();
+  });
+
   it('hides the repo field once the conversation has messages', async () => {
     mock.api.planningChatList = vi.fn(async () => ({
       ok: true,

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -108,6 +108,7 @@ function reportPlanningChatPerf(metric: string, data: Record<string, unknown>): 
 interface InvokerTerminalProps {
   lines: InvokerTerminalLine[];
   busy: boolean;
+  binding?: boolean;
   value: string;
   selectedPresetKey: string;
   presetOptions: PlanningPresetOptionView[];
@@ -539,6 +540,7 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActi
 export function InvokerTerminal({
   lines,
   busy,
+  binding = false,
   value,
   selectedPresetKey,
   presetOptions,
@@ -686,7 +688,7 @@ export function InvokerTerminal({
   };
 
   const composerDisabledCursorClass = busy || readOnly ? 'disabled:cursor-not-allowed' : '';
-  const sendButtonDisabled = busy || readOnly || !value.trim();
+  const sendButtonDisabled = busy || binding || readOnly || !value.trim();
   const sendButtonDisabledCursorClass = 'disabled:cursor-not-allowed';
   const harnessChoices = useMemo(() => buildPlanningHarnessChoices(presetOptions), [presetOptions]);
   const selectedPreset = useMemo(
@@ -762,7 +764,7 @@ export function InvokerTerminal({
   };
 
   const handleInputKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): void => {
-    if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing && !busy && !readOnly && value.trim()) {
+    if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing && !busy && !binding && !readOnly && value.trim()) {
       event.preventDefault();
       submitFromComposer('enter');
     }
@@ -902,7 +904,7 @@ export function InvokerTerminal({
                     <button
                       key={chip}
                       type="button"
-                      disabled={busy || readOnly}
+                      disabled={busy || binding || readOnly}
                       onClick={() => {
                         onValueChange(chip);
                         focusComposer();
@@ -1014,7 +1016,7 @@ export function InvokerTerminal({
                 ref={inputRef}
                 data-testid="invoker-terminal-input"
                 value={value}
-                disabled={busy || readOnly}
+                disabled={busy || binding || readOnly}
                 rows={expanded ? 5 : 1}
                 onChange={handleValueChange}
                 onKeyDown={handleInputKeyDown}
@@ -1084,7 +1086,7 @@ export function InvokerTerminal({
                             data-testid="invoker-terminal-repo"
                             list="invoker-terminal-repo-suggestions"
                             value={repoValue}
-                            disabled={readOnly}
+                            disabled={readOnly || binding}
                             placeholder="path or URL (default if empty)"
                             onChange={(event) => onRepoInputChange?.(event.target.value)}
                             onBlur={() => onRepoCommit?.()}
@@ -1113,7 +1115,7 @@ export function InvokerTerminal({
                   disabled={sendButtonDisabled}
                   className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-amber-400 text-white shadow-sm transition-colors hover:bg-amber-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-amber-300 disabled:bg-gray-700 disabled:text-gray-400 disabled:shadow-none disabled:hover:bg-gray-700 disabled:opacity-50 ${sendButtonDisabledCursorClass}`}
                 >
-                  {busy ? (
+                  {busy || binding ? (
                     <span
                       data-testid="invoker-terminal-send-spinner"
                       aria-hidden="true"


### PR DESCRIPTION
## Summary

Pressing Send while the chat's repo field holds an uncommitted path now runs the repo bind first. The Send button shows the pending ring while the bind is in flight.

The message goes out only once the bind lands. Before this, the send could race the bind and run against the wrong repository.

A failed bind surfaces its error in the transcript instead of silently dropping the send.

## Review Claim

Approve the composer's bind-aware Send: a dirty repo field triggers the bind first, the spinner shows while it runs, the send goes out only on success, and a failed bind surfaces its error in the transcript.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The deferral rides the existing single-flight bind promise (`planningRepoCommitInFlightRef`), so no second bind fires; a chat with a clean or empty repo field sends exactly as before, and the busy-turn path is untouched.

## Slice Rationale

This is the send-side half of the repo binding introduced in (8) and (9); it ships beneath the failure-detection and telemetry slices that observe it.

## Non-goals

- No change to the busy-turn spinner from (13).
- No telemetry; interaction events ship in (18).
- No change to the guarded `dag-surface-background-click-noop` behavior in `App.tsx`; background clicks on the DAG surface stay a no-op.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm vitest run src/__tests__/planning-repo-binding.test.tsx`
- [ ] `cd packages/ui && pnpm vitest run` (full package suite)

</details>

## Visual Proof

Captured on the live web demo running this code, in a throwaway chat of mine: a message typed with an unbound repo path, Send pressed, the pending ring during the bind, then the bind failure surfacing.

![Bind-deferral walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-0d694a/bind-walkthrough.mp4)

![Pending ring while the bind runs](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-0d694a/bind-spinner-during.webp)

The Send button showing the spinner ring while the repository at `/nonexistent/bind-proof-repo` is being bound; the send has not fired yet.

![Bind failure surfaced](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-0d694a/bind-error-final.webp)

The System line in the transcript reading "Could not bind repository: git clone /nonexistent/bind-proof-repo … does not exist", with the same error echoed under the repo field and the Send arrow restored.

Manually inspected: I opened both stills and the video's frames myself. The during-frame shows the gray Send button with the spinner ring and the repo field holding `/nonexistent/bind-proof-repo`; the final frame shows the red "Could not bind repository" System entry in the transcript, the inline error under the repo field, and the arrow icon back on the Send button.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting returns Send to racing an in-flight repo bind.
- Revert command: `git revert fea18306d0`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #9970