### PR TITLE
[Web surface parity](15) Fail planner turns whose session vanished server-side

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -637,7 +637,7 @@ export function App() {
   const activePlanningWorkflowRunning = activePlanningSession.submittedWorkflowId
     ? workflows.get(activePlanningSession.submittedWorkflowId)?.status === 'running'
     : false;
-  const activePlanningRepoLocked = activePlanningSession.messages.length > 0
+  const activePlanningRepoLocked = activePlanningSession.messages.some((message) => message.role !== 'system')
     || Boolean(activePlanningSession.terminalSession)
     || activePlanningSession.mode === 'tmux'
     || activePlanningReadOnly;
@@ -2790,22 +2790,23 @@ export function App() {
     }));
   }, [activePlanningSession.id, updatePlanningSessionById]);
 
-  const planningRepoCommitInFlightRef = useRef<Promise<{ ok: boolean; sessionId: string | null }> | null>(null);
+  const planningRepoCommitInFlightRef = useRef<Promise<{ ok: boolean; sessionId: string | null; error?: string }> | null>(null);
+  const [planningRepoBindingId, setPlanningRepoBindingId] = useState<string | null>(null);
 
-  const commitPlanningRepo = useCallback((): Promise<{ ok: boolean; sessionId: string | null }> => {
+  const commitPlanningRepo = useCallback((): Promise<{ ok: boolean; sessionId: string | null; error?: string }> => {
     // Clicking Send or Tmux blurs the repo input, so the blur commit and the
     // caller's commit can race; every caller must share one in-flight run.
     const inFlight = planningRepoCommitInFlightRef.current;
     if (inFlight) return inFlight;
 
-    const run = (async (): Promise<{ ok: boolean; sessionId: string | null }> => {
+    const run = (async (): Promise<{ ok: boolean; sessionId: string | null; error?: string }> => {
       // Read the latest view state from refs: render closures go stale across
       // the awaits below and would re-materialize an already-swapped session.
       const viewSessionId = activePlanningSessionIdRef.current;
       const session = planningSessionsRef.current.find((current) => current.id === viewSessionId);
       if (!session) return { ok: true, sessionId: null };
       const currentBackendId = session.id.startsWith('local-') ? null : session.id;
-      const locked = session.messages.length > 0
+      const locked = session.messages.some((message) => message.role !== 'system')
         || Boolean(session.terminalSession)
         || session.mode === 'tmux'
         || session.status === 'submitted'
@@ -2817,10 +2818,15 @@ export function App() {
 
       let sessionId = currentBackendId;
       let viewId = session.id;
+      const failBind = (id: string, sessionIdForResult: string | null, message: string): { ok: false; sessionId: string | null; error: string } => {
+        updatePlanningSessionById(id, (current) => ({ ...current, repoError: message }));
+        appendTerminalLine(`Could not bind repository: ${message}`, 'system', 'error', id);
+        return { ok: false, sessionId: sessionIdForResult, error: message };
+      };
+      setPlanningRepoBindingId(viewId);
       if (!sessionId) {
         if (!invoker?.planningChatCreate) {
-          updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: 'Planner is not available.' }));
-          return { ok: false, sessionId: null };
+          return failBind(viewId, null, 'Planner is not available.');
         }
         try {
           const result = await invoker.planningChatCreate({
@@ -2829,8 +2835,7 @@ export function App() {
             confirmationMode: session.confirmationMode ?? selectedPlanningConfirmationMode,
           });
           if (!result.ok) {
-            updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: result.error }));
-            return { ok: false, sessionId: null };
+            return failBind(viewId, null, result.error);
           }
           const localId = viewId;
           sessionId = result.session.id;
@@ -2855,22 +2860,20 @@ export function App() {
           setActivePlanningSessionId((currentSessionId) => (
             currentSessionId === localId ? result.session.id : currentSessionId
           ));
+          setPlanningRepoBindingId((current) => (current === localId ? result.session.id : current));
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Failed to create a planning session.';
-          updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: message }));
-          return { ok: false, sessionId: null };
+          return failBind(viewId, null, message);
         }
       }
 
       if (!invoker?.planningChatRebindRepo) {
-        updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: 'Repo binding is not available.' }));
-        return { ok: false, sessionId };
+        return failBind(viewId, sessionId, 'Repo binding is not available.');
       }
       try {
         const result = await invoker.planningChatRebindRepo({ sessionId, repoUrl: pending });
         if (!result.ok) {
-          updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: result.error }));
-          return { ok: false, sessionId };
+          return failBind(viewId, sessionId, result.error);
         }
         updatePlanningSessionById(viewId, (current) => ({
           ...current,
@@ -2882,19 +2885,20 @@ export function App() {
         return { ok: true, sessionId };
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to bind the repository.';
-        updatePlanningSessionById(viewId, (current) => ({ ...current, repoError: message }));
-        return { ok: false, sessionId };
+        return failBind(viewId, sessionId, message);
       }
     })();
 
     planningRepoCommitInFlightRef.current = run;
     void run.finally(() => {
+      setPlanningRepoBindingId(null);
       if (planningRepoCommitInFlightRef.current === run) {
         planningRepoCommitInFlightRef.current = null;
       }
     });
     return run;
   }, [
+    appendTerminalLine,
     invoker,
     runtimeStatus,
     selectedPlanningConfirmationMode,
@@ -4725,6 +4729,7 @@ export function App() {
             activeConversationKey={activePlanningConversationKey}
             lines={terminalLines}
             busy={activePlanningSessionBusy}
+            binding={planningRepoBindingId !== null && planningRepoBindingId === activePlanningSessionId}
             value={planningInput}
             selectedPresetKey={selectedPlanningPresetKey}
             presetOptions={planningPresetOptions}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -583,6 +583,7 @@ export function App() {
   const nextTerminalLineIdRef = useRef(1);
   const applyTurnOutcomeRef = useRef<(sessionId: string, turnId: string, outcome: InAppPlanningTurnOutcome) => void>(() => {});
   const planningPollFailureCountRef = useRef(0);
+  const planningTurnGoneCountsRef = useRef<Map<string, number>>(new Map());
   const [planningStreamBySessionId, setPlanningStreamBySessionId] = useState<Record<string, PlanningStreamState>>({});
   const [planningPresetOptions, setPlanningPresetOptions] = useState<PlanningPresetOption[]>([]);
   const [selectedPlanningPresetKey, setSelectedPlanningPresetKey] = useState('');
@@ -841,7 +842,6 @@ export function App() {
         window.invoker?.planningTerminalList?.().catch(() => [] as TerminalSessionDescriptor[]) ?? Promise.resolve([] as TerminalSessionDescriptor[]),
       ]);
       if (!chatList.ok) return false;
-      if (chatList.sessions.length === 0) return true;
       const terminalsByPlanningSession = new Map(
         terminalList
           .filter((session) => session.kind === 'planning' && session.planningSessionId)
@@ -875,6 +875,41 @@ export function App() {
       setActivePlanningSessionId(nextActiveSessionId);
       const maxLineId = maxPlanningMessageId(restored);
       nextTerminalLineIdRef.current = Math.max(nextTerminalLineIdRef.current, maxLineId + 1);
+      const serverIds = new Set(chatList.sessions.map((session) => session.id));
+      const serverHasUnknownRunningTurn = chatList.sessions.some(
+        (session) => session.activeTurnStatus === 'running' && !currentIds.has(session.id),
+      );
+      const goneCounts = planningTurnGoneCountsRef.current;
+      const liveIds = new Set(planningSessionsRef.current.map((session) => session.id));
+      for (const key of goneCounts.keys()) {
+        if (!liveIds.has(key)) goneCounts.delete(key);
+      }
+      for (const session of planningSessionsRef.current) {
+        if (!session.busy || !session.activeTurnId) {
+          goneCounts.delete(session.id);
+          continue;
+        }
+        // A busy local view's backend twin is unknown by id; any unknown running
+        // turn may be it, so its absence across polls is the "gone" signal. With
+        // several busy local views this under-fails (never false-fails).
+        const gone = session.id.startsWith('local-')
+          ? !serverHasUnknownRunningTurn
+          : !serverIds.has(session.id);
+        if (!gone) {
+          goneCounts.delete(session.id);
+          continue;
+        }
+        const count = (goneCounts.get(session.id) ?? 0) + 1;
+        if (count < 2) {
+          goneCounts.set(session.id, count);
+          continue;
+        }
+        goneCounts.delete(session.id);
+        applyTurnOutcomeRef.current(session.id, session.activeTurnId, {
+          status: 'failed',
+          error: 'The planner session no longer exists on the server. It may have been reset.',
+        });
+      }
       return true;
     } catch (err) {
       console.error('[planning] planning session refresh failed', err);

--- a/packages/ui/src/__tests__/planning-repo-binding.test.tsx
+++ b/packages/ui/src/__tests__/planning-repo-binding.test.tsx
@@ -140,6 +140,81 @@ describe('planning composer repo binding', () => {
     expect(screen.getByTestId('invoker-terminal-input')).toHaveValue('');
   });
 
+  it('shows the send spinner and defers the send while a send-triggered bind is in flight', async () => {
+    let resolveRebind!: (value: { ok: true; action: 'provision' }) => void;
+    mock.api.planningChatRebindRepo = vi.fn(() => new Promise<{ ok: true; action: 'provision' }>((resolve) => {
+      resolveRebind = resolve;
+    }));
+
+    render(<App />);
+    await openComposerOptions();
+
+    const repoInput = screen.getByTestId('invoker-terminal-repo');
+    fireEvent.change(repoInput, { target: { value: '/tmp/repo-a' } });
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+
+    // Clicking Send first blurs the repo field, then submits the form.
+    fireEvent.blur(repoInput);
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-send-spinner')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    expect(mock.api.planningChatSend).not.toHaveBeenCalled();
+
+    resolveRebind({ ok: true, action: 'provision' });
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSend).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows the send spinner during a blur-committed bind without sending', async () => {
+    let resolveRebind!: (value: { ok: true; action: 'provision' }) => void;
+    mock.api.planningChatRebindRepo = vi.fn(() => new Promise<{ ok: true; action: 'provision' }>((resolve) => {
+      resolveRebind = resolve;
+    }));
+
+    render(<App />);
+    await openComposerOptions();
+
+    const repoInput = screen.getByTestId('invoker-terminal-repo');
+    fireEvent.change(repoInput, { target: { value: '/tmp/repo-a' } });
+    fireEvent.blur(repoInput);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-send-spinner')).toBeInTheDocument();
+    });
+
+    resolveRebind({ ok: true, action: 'provision' });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('invoker-terminal-send-spinner')).not.toBeInTheDocument();
+    });
+    expect(mock.api.planningChatSend).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a failed bind in the transcript and keeps the typed message', async () => {
+    mock.api.planningChatRebindRepo = vi.fn(async () => ({ ok: false as const, error: 'boom' }));
+
+    render(<App />);
+    await openComposerOptions();
+
+    const repoInput = screen.getByTestId('invoker-terminal-repo');
+    fireEvent.change(repoInput, { target: { value: '/tmp/repo-a' } });
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+
+    fireEvent.blur(repoInput);
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    const errorLines = await screen.findAllByText('Could not bind repository: boom');
+    expect(errorLines.length).toBeGreaterThanOrEqual(1);
+    expect(mock.api.planningChatSend).not.toHaveBeenCalled();
+    expect(screen.getByTestId('invoker-terminal-input')).toHaveValue('hello planner');
+    expect(screen.queryByTestId('invoker-terminal-send-spinner')).not.toBeInTheDocument();
+  });
+
   it('hides the repo field once the conversation has messages', async () => {
     mock.api.planningChatList = vi.fn(async () => ({
       ok: true,

--- a/packages/ui/src/__tests__/planning-turn-durability.test.tsx
+++ b/packages/ui/src/__tests__/planning-turn-durability.test.tsx
@@ -233,4 +233,230 @@ describe('planning turn durability', () => {
     expect(transcriptText.split('I can help draft that.').length - 1).toBe(1);
     expect(screen.getByTestId('invoker-terminal-input')).not.toBeDisabled();
   });
+  it('fails a wiped mid-first-send turn into the banner and keeps the chat', async () => {
+    mock.api.planningChatSend = vi.fn((request: { turnId?: string }) => new Promise(() => {
+      void request; // never resolves: the server was wiped mid-turn
+    })) as typeof mock.api.planningChatSend;
+    const serverSessions = { current: [] as ReturnType<typeof makePlanningSessionSummary>[] };
+    mock.api.planningChatList = vi.fn(async () => ({ ok: true, sessions: serverSessions.current }));
+
+    render(<App />);
+    await openPlanningSurface();
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+      fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+      serverSessions.current = [
+        makePlanningSessionSummary({
+          id: 'server-1',
+          title: 'Server chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          messages: [
+            { id: 1, role: 'user', text: 'hello planner', createdAt: '2026-07-07T00:00:01.000Z' },
+          ],
+          activeTurnId: 'turn-live',
+          activeTurnStatus: 'running',
+        }),
+      ];
+
+      // While the server still reports the running turn, nothing fails.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      expect(screen.queryByTestId('invoker-terminal-turn-error')).not.toBeInTheDocument();
+
+      // Server wiped: two consecutive polls prove the turn is gone.
+      serverSessions.current = [];
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      expect(screen.queryByTestId('invoker-terminal-turn-error')).not.toBeInTheDocument();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+
+      expect(screen.getByTestId('invoker-terminal-turn-error'))
+        .toHaveTextContent('The planner session no longer exists on the server. It may have been reset.');
+      expect(screen.getByTestId('invoker-terminal-retry-turn')).toBeInTheDocument();
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('hello planner');
+      expect(screen.queryByTestId('invoker-terminal-send-spinner')).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('fails a hydrated running turn when its server session disappears, keeping the row and transcript', async () => {
+    const serverSessions = {
+      current: [
+        makePlanningSessionSummary({
+          id: 'busy-chat',
+          title: 'Busy chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          messages: [
+            { id: 1, role: 'user', text: 'Draft the plan', createdAt: '2026-07-07T00:00:01.000Z' },
+          ],
+          activeTurnId: 'turn-live',
+          activeTurnStatus: 'running',
+        }),
+      ] as ReturnType<typeof makePlanningSessionSummary>[],
+    };
+    mock.api.planningChatList = vi.fn(async () => ({ ok: true, sessions: serverSessions.current }));
+
+    // Fake timers from the start so the busy poll's interval is fake-timer
+    // driven even though hydration (not a send) flips the session busy.
+    vi.useFakeTimers();
+    try {
+      render(<App />);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      fireEvent.click(screen.getByTestId('sidebar-home'));
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+
+      serverSessions.current = [];
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      expect(screen.queryByTestId('invoker-terminal-turn-error')).not.toBeInTheDocument();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+
+      expect(screen.getByTestId('invoker-terminal-turn-error'))
+        .toHaveTextContent('The planner session no longer exists on the server. It may have been reset.');
+      expect(screen.getByTestId('invoker-terminal-retry-turn')).toBeInTheDocument();
+      expect(screen.getAllByText('Busy chat').length).toBeGreaterThan(0);
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Draft the plan');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not fail the turn on a transient one-poll miss', async () => {
+    mock.api.planningChatSend = vi.fn((request: { turnId?: string }) => new Promise(() => {
+      void request;
+    })) as typeof mock.api.planningChatSend;
+    const runningServerSession = makePlanningSessionSummary({
+      id: 'server-1',
+      title: 'Server chat',
+      status: 'still_discussing',
+      draftPlanAvailable: false,
+      draftPlanSummary: undefined,
+      draftPlanText: undefined,
+      messages: [
+        { id: 1, role: 'user', text: 'hello planner', createdAt: '2026-07-07T00:00:01.000Z' },
+      ],
+      activeTurnId: 'turn-live',
+      activeTurnStatus: 'running',
+    });
+    const serverSessions = { current: [] as ReturnType<typeof makePlanningSessionSummary>[] };
+    mock.api.planningChatList = vi.fn(async () => ({ ok: true, sessions: serverSessions.current }));
+
+    render(<App />);
+    await openPlanningSurface();
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+      fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+      serverSessions.current = [runningServerSession];
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+
+      // One empty poll: not enough to fail the turn.
+      serverSessions.current = [];
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      expect(screen.queryByTestId('invoker-terminal-turn-error')).not.toBeInTheDocument();
+
+      // The turn reappears: the gone counter resets.
+      serverSessions.current = [runningServerSession];
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+
+      expect(screen.queryByTestId('invoker-terminal-turn-error')).not.toBeInTheDocument();
+      expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('lets a late send response overwrite the gone-turn failure', async () => {
+    let resolveSend: (() => void) | undefined;
+    mock.api.planningChatSend = vi.fn((request: { turnId?: string }) => new Promise((resolve) => {
+      resolveSend = () => resolve({
+        ok: true,
+        sessionId: 'server-1',
+        turnId: request.turnId,
+        reply: 'Landed after all.',
+        confirmationMode: 'require',
+        draftPlanAvailable: false,
+      });
+    })) as typeof mock.api.planningChatSend;
+    const serverSessions = { current: [] as ReturnType<typeof makePlanningSessionSummary>[] };
+    mock.api.planningChatList = vi.fn(async () => ({ ok: true, sessions: serverSessions.current }));
+
+    render(<App />);
+    await openPlanningSurface();
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+      fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+      serverSessions.current = [
+        makePlanningSessionSummary({
+          id: 'server-1',
+          title: 'Server chat',
+          status: 'still_discussing',
+          draftPlanAvailable: false,
+          draftPlanSummary: undefined,
+          draftPlanText: undefined,
+          messages: [
+            { id: 1, role: 'user', text: 'hello planner', createdAt: '2026-07-07T00:00:01.000Z' },
+          ],
+          activeTurnId: 'turn-live',
+          activeTurnStatus: 'running',
+        }),
+      ];
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      serverSessions.current = [];
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5100);
+      });
+      expect(screen.getByTestId('invoker-terminal-turn-error')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    // The failed turn keeps its activeTurnId, so the genuine reply still lands.
+    await act(async () => {
+      resolveSend?.();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Landed after all.');
+    });
+    expect(screen.queryByTestId('invoker-terminal-turn-error')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('invoker-terminal-retry-turn')).not.toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -108,6 +108,7 @@ function reportPlanningChatPerf(metric: string, data: Record<string, unknown>): 
 interface InvokerTerminalProps {
   lines: InvokerTerminalLine[];
   busy: boolean;
+  binding?: boolean;
   value: string;
   selectedPresetKey: string;
   presetOptions: PlanningPresetOptionView[];
@@ -539,6 +540,7 @@ function PlanningTmuxPane({ session, busy, error, readOnly = false, terminalActi
 export function InvokerTerminal({
   lines,
   busy,
+  binding = false,
   value,
   selectedPresetKey,
   presetOptions,
@@ -686,7 +688,7 @@ export function InvokerTerminal({
   };
 
   const composerDisabledCursorClass = busy || readOnly ? 'disabled:cursor-not-allowed' : '';
-  const sendButtonDisabled = busy || readOnly || !value.trim();
+  const sendButtonDisabled = busy || binding || readOnly || !value.trim();
   const sendButtonDisabledCursorClass = 'disabled:cursor-not-allowed';
   const harnessChoices = useMemo(() => buildPlanningHarnessChoices(presetOptions), [presetOptions]);
   const selectedPreset = useMemo(
@@ -762,7 +764,7 @@ export function InvokerTerminal({
   };
 
   const handleInputKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>): void => {
-    if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing && !busy && !readOnly && value.trim()) {
+    if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing && !busy && !binding && !readOnly && value.trim()) {
       event.preventDefault();
       submitFromComposer('enter');
     }
@@ -902,7 +904,7 @@ export function InvokerTerminal({
                     <button
                       key={chip}
                       type="button"
-                      disabled={busy || readOnly}
+                      disabled={busy || binding || readOnly}
                       onClick={() => {
                         onValueChange(chip);
                         focusComposer();
@@ -1014,7 +1016,7 @@ export function InvokerTerminal({
                 ref={inputRef}
                 data-testid="invoker-terminal-input"
                 value={value}
-                disabled={busy || readOnly}
+                disabled={busy || binding || readOnly}
                 rows={expanded ? 5 : 1}
                 onChange={handleValueChange}
                 onKeyDown={handleInputKeyDown}
@@ -1084,7 +1086,7 @@ export function InvokerTerminal({
                             data-testid="invoker-terminal-repo"
                             list="invoker-terminal-repo-suggestions"
                             value={repoValue}
-                            disabled={readOnly}
+                            disabled={readOnly || binding}
                             placeholder="path or URL (default if empty)"
                             onChange={(event) => onRepoInputChange?.(event.target.value)}
                             onBlur={() => onRepoCommit?.()}
@@ -1113,7 +1115,7 @@ export function InvokerTerminal({
                   disabled={sendButtonDisabled}
                   className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-sm bg-amber-400 text-white shadow-sm transition-colors hover:bg-amber-300 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-amber-300 disabled:bg-gray-700 disabled:text-gray-400 disabled:shadow-none disabled:hover:bg-gray-700 disabled:opacity-50 ${sendButtonDisabledCursorClass}`}
                 >
-                  {busy ? (
+                  {busy || binding ? (
                     <span
                       data-testid="invoker-terminal-send-spinner"
                       aria-hidden="true"


### PR DESCRIPTION
## Summary

When the server loses a chat mid-turn (a reset wipes its state), the tab used to show Working… forever.

The busy poll only counted transport failures, so successful polls against a wiped server never ended the wait.

Now two consecutive successful polls that no longer contain the busy turn's session fail that turn into the existing turn-error banner.

The transcript stays. The user sees the same red banner used for other turn failures and can start over from it.

## Review Claim

Approve the gone-turn sweep in `refreshPlanningSessionsNow`: a busy turn whose backend session is absent from two consecutive successful poll responses fails into the existing turn-error banner instead of spinning forever.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The sweep only touches sessions already busy with an `activeTurnId`, and only after two consecutive successful list polls miss them; transport failures keep their separate 3-strike counter. A failed turn keeps its `activeTurnId`, so a late genuine reply still lands and clears the banner (covered by a test).

## Slice Rationale

Smallest user-visible fix for the incident where a server-side wipe hung the composer forever. The telemetry that observes this sweep ships separately in (18).

## Non-goals

- No change to the transport-failure path or its `Lost connection to the planner.` message.
- No change to the 5s polling cadence.
- No server-side changes.
- No change to the guarded `dag-surface-background-click-noop` behavior in `App.tsx`; background clicks on the DAG surface stay a no-op.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm vitest run src/__tests__/planning-turn-durability.test.tsx`
- [ ] `cd packages/ui && pnpm vitest run` (full package suite)

</details>

## Visual Proof

Captured on the live web demo running this change. My own throwaway chat was mid-turn (Working…) when its backend session was deleted server-side; within two poll ticks and without a refresh the spinner is gone and the banner appears.

![Spinner-to-banner walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-f27993/gone-turn-walkthrough.mp4)

![Mid-turn spinner before the server-side wipe](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-f27993/gone-turn-spinner-before.webp)

Working pill in the header, Working… line in the transcript, and the spinner inside the Send button while the turn runs.

![Banner shown once the session vanished](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-f27993/gone-turn-banner-final.webp)

Red banner reading "The planner session no longer exists on the server. It may have been reset." with the Retry button, the user message still in the transcript, and the Send arrow restored.

Manually inspected: I opened the before and after frames myself. The before frame shows the "Working" pill, the "Working…" transcript line, and the spinner ring in the Send button; the after frame shows the red banner text quoted above with the Retry button on the right, the "proof capture: draft a careful long plan for a notes app" message still present, the status pill flipped to "Still discussing", and the Send arrow back. The video's frames step through the wait and land on the banner state.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting restores the previous behavior (hang until transport failure or reply).
- Revert command: `git revert e7d63d160b`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #9977