### PR TITLE
[Web surface parity](17) Buffered planning telemetry pipeline with transport-failure retry

### DIFF
--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -53,6 +53,34 @@ function makeTaskTerminalAdapter() {
 }
 
 describe('buildWebInvokerDispatch', () => {
+  it('report-ui-perf persists the metric to the activity log like the GUI handler', async () => {
+    const writeActivityLog = vi.fn();
+    const { dispatch } = makeDispatch({
+      persistence: {
+        listWorkflows: () => [],
+        writeActivityLog,
+      },
+    });
+    await dispatch('invoker:report-ui-perf', ['planning_send_start', { sessionId: 's-1', turnId: 't-1' }]);
+    expect(writeActivityLog).toHaveBeenCalledTimes(1);
+    const [source, level, message] = writeActivityLog.mock.calls[0];
+    expect(source).toBe('ui-perf');
+    expect(level).toBe('info');
+    expect(JSON.parse(message)).toMatchObject({ metric: 'planning_send_start', sessionId: 's-1', turnId: 't-1' });
+  });
+
+  it('report-ui-perf swallows activity-log write failures', async () => {
+    const { dispatch } = makeDispatch({
+      persistence: {
+        listWorkflows: () => [],
+        writeActivityLog: vi.fn(() => {
+          throw new Error('database is locked');
+        }),
+      },
+    });
+    await expect(dispatch('invoker:report-ui-perf', ['planning_send_start', {}])).resolves.toBeUndefined();
+  });
+
   it('list-workflows returns the persisted workflows', async () => {
     const { dispatch } = makeDispatch();
     expect(await dispatch('invoker:list-workflows', [])).toEqual([

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -206,8 +206,23 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return { ownerMode: true, readOnly: false, mode: 'local-owner' };
       case 'invoker:get-ui-perf-stats':
         return {};
-      case 'invoker:report-ui-perf':
+      case 'invoker:report-ui-perf': {
+        // Mirror the GUI handler (gui-mutation-handlers.ts): persist every
+        // renderer metric to the activity log so web-surface interactions are
+        // diagnosable after the fact. Previously a silent no-op, which left
+        // web incidents with no client-side record at all.
+        const payload = {
+          ts: new Date().toISOString(),
+          metric: String(args[0] ?? ''),
+          ...((args[1] ?? {}) as Record<string, unknown>),
+        };
+        try {
+          persistence.writeActivityLog('ui-perf', 'info', JSON.stringify(payload));
+        } catch {
+          // DB might be locked; matching the GUI handler's tolerance.
+        }
         return undefined;
+      }
       case 'invoker:trace-renderer-task-graph-event':
         return undefined;
       case 'invoker:check-pr-statuses':

--- a/plans/restack-pr-9980-onto-web-surface-parity-16-tip.yaml
+++ b/plans/restack-pr-9980-onto-web-surface-parity-16-tip.yaml
@@ -1,0 +1,89 @@
+name: "restack-pr-9980-onto-web-surface-parity-16-tip"
+onFinish: none
+mergeMode: manual
+repoUrl: "https://github.com/Neko-Catpital-Labs/Invoker.git"
+
+tasks:
+  - id: restack-pr-9980-onto-base-tip
+    description: >
+      Review claim: PR #9980's head branch
+      (stack/EdbertChan/pr/web-planning-parity/web-surface-parity-17-buffered-planning-telemetry--e15a8670)
+      reports a merge conflict against its base
+      (stack/EdbertChan/pr/web-planning-parity/web-surface-parity-16-persist-web-surface-ui--917b4e24)
+      because it still carries 7 stale local commits for stack items (9) through (16) that
+      have since each been independently merged into the base branch as their own separate
+      PRs (#9963, #9964, #9965, #9966, #9970, #9977, #9978). A plain `git rebase` onto the
+      current base tip auto-skips 4 of those 7 via patch-id matching but the other 3
+      (items 9, 11, 12 as observed at diagnosis time) fail to skip because their merged
+      counterparts drifted slightly from the stale local copies (e.g. review feedback,
+      added PR number in the merged trailer), producing real content conflicts in
+      packages/ui/src/App.tsx, packages/ui/src/components/InvokerTerminal.tsx, and
+      packages/ui/src/__tests__/planning-repo-binding.test.tsx when git tries to re-apply
+      already-landed changes on top of themselves.
+
+      The only commit on PR #9980's branch that is not already present in some form on the
+      base branch is 5c30a394325995bdd2bc025c274e4b5a292c5b3e, "[Web surface parity](17)
+      Buffered planning telemetry pipeline with transport-failure retry". Verified at
+      diagnosis time: cherry-picking that single commit onto the current base tip
+      (94dcb3116) applies with zero conflicts and reproduces the same 5-file diff stat as
+      the original commit.
+
+      Review lane: tooling-policy.
+
+      Safety invariant: never touch the remote head branch unless its current tip is
+      exactly the expected SHA ccdc94138798e733a782a502127e7cec8bdc9cc3 at push time; push
+      only with --force-with-lease keyed to that SHA (never a bare --force), so a
+      concurrent human/agent push to the same branch aborts this task instead of being
+      silently overwritten. Abort without pushing anything if the (17) commit no longer
+      cherry-picks cleanly onto the base branch's current tip (base may have moved further
+      since diagnosis).
+
+      Slice rationale: pure branch history restructuring; no new file content beyond what
+      commit 5c30a3943 already introduced. This only drops already-landed duplicate
+      commits from PR #9980's ancestry so its diff against the (moving) base branch stops
+      being polluted by stale copies of already-merged work.
+
+      Architectural effect: none on shipped code; this changes only which commits PR
+      #9980's branch contains, not what ends up on master once every stack PR lands.
+
+      Layer: tooling_policy.
+      Feature state: active.
+      Files: none (git history only).
+      Change types: git fetch of both branches, cherry-pick of the single new commit onto
+      the base branch's current tip, force-with-lease push of the existing remote head
+      branch.
+      Acceptance criteria: the command exits 0 only if (a) the fetched head branch tip
+      matched the expected SHA before rewriting, (b) the cherry-pick of
+      5c30a394325995bdd2bc025c274e4b5a292c5b3e onto the base branch's current tip succeeded
+      with no conflicts, and (c) the force-with-lease push of the resulting commit onto the
+      head branch succeeded. Any other outcome must exit non-zero and must not push
+      anything, leaving PR #9980 for manual restructuring instead.
+    command: |
+      set -eu
+
+      BASE_REF="stack/EdbertChan/pr/web-planning-parity/web-surface-parity-16-persist-web-surface-ui--917b4e24"
+      HEAD_REF="stack/EdbertChan/pr/web-planning-parity/web-surface-parity-17-buffered-planning-telemetry--e15a8670"
+      EXPECTED_HEAD_SHA="ccdc94138798e733a782a502127e7cec8bdc9cc3"
+      NEW_COMMIT_SHA="5c30a394325995bdd2bc025c274e4b5a292c5b3e"
+
+      git fetch origin "$BASE_REF":refs/heads/__restack_base
+      git fetch origin "$HEAD_REF":refs/heads/__restack_head
+
+      ACTUAL_HEAD_SHA="$(git rev-parse __restack_head)"
+      if [ "$ACTUAL_HEAD_SHA" != "$EXPECTED_HEAD_SHA" ]; then
+        echo "head branch moved since diagnosis (expected $EXPECTED_HEAD_SHA, got $ACTUAL_HEAD_SHA); aborting without pushing" >&2
+        exit 1
+      fi
+
+      git branch -f __restack_new __restack_base
+      git checkout __restack_new
+
+      if ! git cherry-pick -x "$NEW_COMMIT_SHA"; then
+        git cherry-pick --abort || true
+        echo "cherry-pick of $NEW_COMMIT_SHA onto the current base tip conflicted; this PR needs manual restructuring instead" >&2
+        exit 1
+      fi
+
+      git push "--force-with-lease=refs/heads/$HEAD_REF:$ACTUAL_HEAD_SHA" origin "__restack_new:refs/heads/$HEAD_REF"
+    dependencies: []
+    requiresManualApproval: true


### PR DESCRIPTION
## Summary

Planning telemetry gets one shipping path. Every event lands in a 300-entry ring buffer on `window.__invokerPlanningLog`, mirrors to the console, and ships through the existing `reportUiPerf` channel.

Events that fail to ship while the transport is down wait in a bounded queue and go out again once the transport recovers.

Overflow is counted and reported after recovery. That keeps records of exactly the windows where incident evidence used to vanish.

The composer's existing perf events cut over to this path, and the web bridge now records its own invoke failures plus a boot marker recording which build each tab runs.

## Review Claim

Approve one buffered shipper for planning telemetry: ring buffer plus console locally, `reportUiPerf` upstream, failed sends queued and replayed with their original client timestamp.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

`logPlanningEvent` is fire-and-forget and never throws into callers; the `invoker:report-ui-perf` channel is excluded from invoke-failure self-reporting, so a down transport cannot loop; the queue is bounded at 100 with explicit drop accounting; nothing rendered changes.

## Slice Rationale

The pipeline is its own reviewable mechanism, separate from which interactions emit events (18) and from the server-side persist it feeds (16).

## Non-goals

- No new interaction events yet; only existing composer perf events move onto the pipeline.
- No dead-click capture (ships in 18).
- No server-side changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm vitest run src/lib/planning-telemetry.test.ts`
- [ ] `cd packages/ui && pnpm vitest run src/web/__tests__/web-invoker-client.test.ts`

</details>

## Visual Proof

Nothing rendered changes in this slice, so the proof is inspectable state captured live on the web demo: the in-tab ring buffer and the server-persisted rows for the same events, fetched from the running app.

![Live ring buffer overlaid on the planning screen](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-5ed634/telemetry-ring-buffer.webp)

The `window.__invokerPlanningLog` ring in a live tab: `planning_web_boot` from the bridge install, composer events, and the send lifecycle, each with its payload.

![Server-persisted ui-perf rows for the same events](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-5ed634/telemetry-server-rows.webp)

The same events read back from the owner's activity log (source `ui-perf`) over `invoker:get-activity-logs`, proving the shipper delivered them upstream.

Manually inspected: I opened both screenshots myself. The first shows the dark overlay listing `planning_web_boot` with the demo href, `planning_chat_submit`, `planning_send_start` with turnId `59070d6a…`, and `planning_send_result` with `ok:true, durationMs:5345`. The second shows the server-side rows for the same turnId, including `planning_turn_outcome` with `status:"completed"`.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes; reverting returns composer perf events to direct `reportUiPerf` calls with no buffering.
- Revert command: `git revert f3f6a41158`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #9979