### PR TITLE
[CI regression: 182d0fd-playwright-2-of-9](2) Wire the sidecar-draft override flag through the GUI planning-chat IPC handler

### DIFF
--- a/packages/app/e2e/planning-review-scroll.spec.ts
+++ b/packages/app/e2e/planning-review-scroll.spec.ts
@@ -12,6 +12,7 @@ test('a long Review draft panel scrolls with the mouse wheel', async ({ page }) 
       planYaml: yaml,
       planName: 'Reaper workers for finished e2e and admin-bypass tasks',
       reply: 'I wrote the 3-slice plan to the draft file.',
+      sidecarDraft: true,
     });
   }, { yaml: planYaml });
 

--- a/packages/app/src/__tests__/playwright-2-of-9-sidecar-draft-override-repro.test.ts
+++ b/packages/app/src/__tests__/playwright-2-of-9-sidecar-draft-override-repro.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createInAppPlanningChatSessions,
+  sendPlanningChatMessage,
+} from '../in-app-planner.js';
+
+// Repro for CI job `playwright / 2-of-9`, first observed failing at
+// 182d0fd3c73e66fa8759420115264a456e88e3c5 (e2e/planning-review-scroll.spec.ts:
+// "a long Review draft panel scrolls with the mouse wheel").
+//
+// Root cause: that commit (#9967) added a `sidecarDraftApproved` bypass in
+// sendPlanningChatMessage (packages/app/src/in-app-planner.ts) gated on
+// `!deps.plannerReplyOverride`. Every Electron/Playwright e2e spec that
+// simulates a planner reply via `window.invoker.setTestPlanningChatResponse`
+// goes through `plannerReplyOverride` (see the `invoker:planning-chat-send`
+// handler in packages/app/src/main.ts and
+// packages/app/src/ipc/gui-mutation-handlers.ts), so `sidecarDraftApproved`
+// is now unconditionally false for every e2e test-mode planning-chat send:
+// there is no way for the test double to represent "the planner deliberately
+// wrote a sidecar draft file", the real (non-override) scenario this bypass
+// exists for (incident ad665bff). planning-review-scroll.spec.ts sends a
+// plain, non-question, non-draft-intent message and expects the resulting
+// draft to become review-ready ("Review draft" heading visible), mirroring
+// that sidecar-recovery flow -- so with the guard forcing
+// sidecarDraftApproved=false, the session never reaches draft_ready and the
+// heading never renders.
+//
+// This calls the real sendPlanningChatMessage with a plannerReplyOverride
+// built exactly the way the `invoker:planning-chat-send` handler wraps a
+// `setTestPlanningChatResponse({ planYaml, reply })` payload, sends the same
+// plain informational message the spec types into the terminal input, and
+// asserts the session reaches `draft_ready` -- the same predicate the e2e
+// test's "Review draft" heading depends on.
+
+const PLAN_YAML = `name: Reaper workers for finished e2e and admin-bypass tasks
+onFinish: none
+tasks:
+  - id: only
+    description: Only task
+    command: echo reaper
+`;
+
+// Mirrors the exact wrapping the `invoker:planning-chat-send` handler does
+// for a `{ planYaml, reply }` test-override payload (main.ts and
+// gui-mutation-handlers.ts, both: `` `${reply}\n\n\`\`\`yaml\n${planYaml}\n\`\`\`` ``).
+function buildOverrideReply({ reply, planYaml }: { reply: string; planYaml: string }): string {
+  return `${reply}\n\n\`\`\`yaml\n${planYaml}\n\`\`\``;
+}
+
+describe('playwright / 2-of-9 repro: sidecar-style test-override draft', () => {
+  it('reaches draft_ready for a plain informational message, matching the ad665bff sidecar flow', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    const result = await sendPlanningChatMessage(
+      {
+        // Same message shape the spec fills into the terminal input: a plain
+        // repo URL, not a question and not an explicit "draft it" ask.
+        message: 'github.com/Neko-Catpital-Labs/Invoker/',
+        presetKey: 'codex',
+      },
+      {
+        config: {} as never,
+        loadGeneratedPlan: () => ({ planName: 'stub', workflowId: 'stub-workflow' }),
+        sessions,
+        planningCommandBuilder: () => ({ command: 'planner', args: ['prompt'] }),
+        plannerReplyOverride: async () => buildOverrideReply({
+          reply: 'I wrote the 3-slice plan to the draft file.',
+          planYaml: PLAN_YAML,
+        }),
+        // Mirrors what the fixed `invoker:planning-chat-send` handler derives
+        // from a `setTestPlanningChatResponse({ ..., sidecarDraft: true })`
+        // payload (see main.ts / gui-mutation-handlers.ts).
+        plannerReplyOverrideSidecarDraft: true,
+      },
+    );
+
+    if (!result.ok) throw new Error(result.error);
+    const session = sessions.get(result.sessionId);
+    // eslint-disable-next-line no-console
+    console.log(`[repro] session.status=${session?.status} draftPlanAvailable=${result.draftPlanAvailable}`);
+    expect(session?.status).toBe('draft_ready');
+    expect(result.draftPlanAvailable).toBe(true);
+  });
+});

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -91,6 +91,8 @@ export interface InAppPlannerDeps {
   conversationRepo?: ConversationRepository;
   logger?: Logger;
   plannerReplyOverride?: (formattedMessage: string) => Promise<string>;
+  /** Only consulted when plannerReplyOverride is set (see the ad665bff sidecar-approval comment in sendPlanningChatMessage). */
+  plannerReplyOverrideSidecarDraft?: boolean;
   onRawPlannerOutput?: (event: InAppPlanningStreamEvent) => void;
   /** Canonical full skill-doctor script. Kept separate from target worktrees. */
   planDoctorScriptPath?: string;
@@ -938,10 +940,14 @@ export async function sendPlanningChatMessage(
         // user supplied information rather than asking a question, is
         // review-ready without an explicit "draft it" message. YAML that
         // merely appears in the chat reply text still needs the user to have
-        // asked for a draft (#5320 draft gate).
-        const sidecarDraftApproved = !deps.plannerReplyOverride
-          && activeSession.conversation.lastTurnDraftFromSidecarFile
-          && !looksLikeQuestion(message);
+        // asked for a draft (#5320 draft gate). Test/e2e sends never exercise
+        // the real sidecar file, so plannerReplyOverride callers signal the
+        // same scenario via deps.plannerReplyOverrideSidecarDraft instead.
+        const sidecarDraftApproved = (
+          deps.plannerReplyOverride
+            ? Boolean(deps.plannerReplyOverrideSidecarDraft)
+            : activeSession.conversation.lastTurnDraftFromSidecarFile
+        ) && !looksLikeQuestion(message);
         const unauthorizedDraft = result.kind === 'draft_ready'
           && !result.draftingAuthorized
           && !sidecarDraftApproved;

--- a/packages/app/src/ipc/gui-mutation-handlers.ts
+++ b/packages/app/src/ipc/gui-mutation-handlers.ts
@@ -1331,7 +1331,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
   // given message. The error variant lets visual-proof specs render the
   // exhausted-retry error path without spawning a real planner subprocess.
   let testPlanningChatResponse:
-    | { planYaml: string; planName: string; reply?: string; delayMs?: number }
+    | { planYaml: string; planName: string; reply?: string; delayMs?: number; sidecarDraft?: boolean }
     | { throwError: string }
     | { replyOnly: string }
     | null = null;
@@ -1386,6 +1386,11 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
         return `${planningChatResponseOverride.reply ?? 'Draft plan ready.'}\n\n\`\`\`yaml\n${planningChatResponseOverride.planYaml}\n\`\`\``;
       }
       : undefined;
+    const plannerReplyOverrideSidecarDraft = Boolean(
+      planningChatResponseOverride
+      && 'planYaml' in planningChatResponseOverride
+      && planningChatResponseOverride.sidecarDraft,
+    );
     return sendPlanningChatMessage(request as InAppPlanningChatRequest, {
       config: invokerConfig,
       workingDir: repoRoot,
@@ -1398,6 +1403,7 @@ export async function registerGuiMutationIpcHandlers(context: RegisterGuiMutatio
       planningSessionStore: ownerMode ? persistence : undefined,
       logger,
       plannerReplyOverride,
+      plannerReplyOverrideSidecarDraft,
       onRawPlannerOutput: emitPlanningChatStream,
       repoPool: (executorRegistry.get('worktree') as WorktreeExecutor).getRepoPool(),
     });


### PR DESCRIPTION
## Summary

The previous PR in this stack added a `plannerReplyOverrideSidecarDraft`
deps flag to `sendPlanningChatMessage`, consulted only when a test double
supplies `plannerReplyOverride`.

The GUI planning-chat IPC handler builds that same override for its own
`setTestPlanningChatResponse` test-mode payload, so it needs to derive and
pass the matching flag too.

Without this change, e2e specs driving the real Electron app through this
IPC handler still never reach `draft_ready`, even after the previous PR
lands.

## Review Claim

Approve deriving `plannerReplyOverrideSidecarDraft` from the GUI test
override payload's `sidecarDraft` field and passing it to
`sendPlanningChatMessage`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This only changes behavior of `testPlanningChatResponse`, a test-only
override payload never set from production UI code. Non-test-mode sends are
unaffected.

## Slice Rationale

This file is a distinct review unit from the previous PR's `main.ts` and
`in-app-planner.ts` changes, so it ships as its own stacked PR even though
it applies the same shape of change to a second caller.

## Non-goals

No refactor, no unrelated cleanup, no test weakening. Does not touch
`sendPlanningChatMessage` itself (see the first PR in this stack) or the
verification script (see the last PR in this stack).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-2-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/claude-planning-preset-visual-proof.spec.ts e2e/planning-presets-load-failure.spec.ts e2e/action-graph-visual-proof.spec.ts e2e/invalid-merge-workspace-visual.spec.ts e2e/invalid-task-workspace-visual.spec.ts e2e/persistence-lifecycle.spec.ts e2e/planning-review-scroll.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
