### PR TITLE
[CI regression: 85b789c-ui-vitest](1) Add UI Vitest worker-action node repro probe

### DIFF
--- a/scripts/repro/repro-ui-vitest-worker-action-node-render.sh
+++ b/scripts/repro/repro-ui-vitest-worker-action-node-render.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Narrowest local probe for CI job "UI Vitest", first observed failing at
+# 85b789cd95ead25b19bace5ea4c9cae46675ced8:
+#   FAIL src/__tests__/task-interaction.test.tsx > Task interaction (component)
+#     > renders task.worker_action events in the task timeline
+#   TestingLibraryElementError: Unable to find an element by:
+#     [data-testid="rf__node-task-worker-action"]
+#
+# This did not reproduce locally: a full `pnpm --filter @invoker/ui test`
+# run at the anchor commit (94/94 files, 863/863 tests) passed, and it still
+# passed under synthetic CPU contention (6 busy-loop processes pinned on a
+# 4-core sandbox). Treat this script as a standing probe for the same
+# symptom, not as proof of the failure -- see the Repro waiver in the fix
+# task summary for the CI-only evidence this fix is based on.
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR/packages/ui"
+
+exec pnpm exec vitest run src/__tests__/task-interaction.test.tsx \
+  -t "renders task.worker_action events in the task timeline"


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=85b789cd95ead25b19bace5ea4c9cae46675ced8; job=UI Vitest -->

CI job `UI Vitest` failed in the worker-action interaction test at commit 85b789cd95ead25b19bace5ea4c9cae46675ced8.

This slice adds a standing probe for that exact test and assertion under `scripts/repro/`.

The failure did not reproduce locally at the anchor commit, including under synthetic CPU contention. The script records that limitation directly.

## Review Claim

Approve one narrowly scoped shell probe that runs the named worker-action test without changing product or test code.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds an unreferenced script under `scripts/repro/`; build output, runtime behavior, and existing tests remain unchanged.

## Slice Rationale

The standing probe precedes the test synchronization so reviewers can inspect the regression target before the next slice changes its timing.

## Non-goals

- No product code changes.
- No test assertion changes.
- No claim that the failure reproduced locally.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-ui-vitest-worker-action-node-render.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 403af16f8a57bf40275ccb3b75098c837241e1cc`
- Post-revert steps: None
- Data migration? No

</details>
