### PR TITLE
[CI regression: 85b789c-ui-vitest](2) Wait for the mini-DAG before clicking the worker-action node

### DIFF
--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -156,6 +156,7 @@ describe('Task interaction (component)', () => {
     fireEvent.click(await screen.findByTestId('sidebar-planning'));
     act(() => mock.setTasks([task], workflows));
 
+    await screen.findByTestId('selected-workflow-mini-dag');
     fireEvent.click(await screen.findByTestId('rf__node-task-worker-action'));
 
     await waitFor(() => {

--- a/scripts/repro/repro-ui-vitest-worker-action-node-render.sh
+++ b/scripts/repro/repro-ui-vitest-worker-action-node-render.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Narrowest local probe for CI job "UI Vitest", first observed failing at
+# 85b789cd95ead25b19bace5ea4c9cae46675ced8:
+#   FAIL src/__tests__/task-interaction.test.tsx > Task interaction (component)
+#     > renders task.worker_action events in the task timeline
+#   TestingLibraryElementError: Unable to find an element by:
+#     [data-testid="rf__node-task-worker-action"]
+#
+# This did not reproduce locally: a full `pnpm --filter @invoker/ui test`
+# run at the anchor commit (94/94 files, 863/863 tests) passed, and it still
+# passed under synthetic CPU contention (6 busy-loop processes pinned on a
+# 4-core sandbox). Treat this script as a standing probe for the same
+# symptom, not as proof of the failure -- see the Repro waiver in the fix
+# task summary for the CI-only evidence this fix is based on.
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR/packages/ui"
+
+exec pnpm exec vitest run src/__tests__/task-interaction.test.tsx \
+  -t "renders task.worker_action events in the task timeline"


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=85b789cd95ead25b19bace5ea4c9cae46675ced8; job=UI Vitest -->

The worker-action interaction test queried its task node without first waiting for selected workflow mini-DAG readiness.

The test now waits for the mini-DAG before querying the node. Product code and the tested assertion remain unchanged.

## Review Claim

Approve synchronizing the worker-action interaction test with mini-DAG readiness before it clicks the task node.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only test timing changes. Product behavior and the worker-action assertion remain unchanged.

## Slice Rationale

This timing adjustment follows the standing probe and remains separate so each stack slice has one proof claim.

## Non-goals

- No product behavior changes.
- No assertion weakening or snapshot updates.
- No unrelated test cleanup.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-ui-vitest-worker-action-node-render.sh`
- [x] `pnpm --filter @invoker/ui test`

</details>

## Visual Proof

![Selected workflow mini-DAG showing its task cards before task interaction](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260821-82813e/ci-regression-85b789c-ui-vitest-mini-dag.png)

Manually inspected: The captured Invoker window shows the selected workflow mini-DAG in the upper-right of the plan graph with three task cards visible.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert db8396014e506294db496c883b55279e2acfc9a6`
- Post-revert steps: Rerun the focused repro probe.
- Data migration? No

</details>
