### PR TITLE
[infra-repair-hardening](3) Canonicalize remote managed workspace paths onto remoteInvokerHome

### DIFF
--- a/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/infra-repair-worker.test.ts
@@ -12,6 +12,7 @@ import {
   buildRepoMirrorRepairScript,
   createInfraRepairTick,
   extractCorruptMirrorPath,
+  extractCorruptWorktreeAdminPath,
   INFRA_REPAIR_RECREATE_TASK_CHANNEL,
   INFRA_REPAIR_RETRY_TASK_CHANNEL,
   INFRA_REPAIR_WORKER_KIND,
@@ -113,6 +114,7 @@ function makeHarness(
   };
   const runRemoteProvisionRepairFn = vi.fn(async () => 'remote repair ok');
   const runRepoMirrorRepairFn = vi.fn(async () => 'mirror repair ok');
+  const runWorktreeCorruptRepairFn = vi.fn(async () => 'worktree corrupt repair ok');
   const resolveRemoteBranchOwnerPathFn = vi.fn(async () => undefined as string | undefined);
   const cleanupRemoteInvokerHomeFn = vi.fn(async () => ({
     targetKey: 'ssh:remote-1 ~/.invoker',
@@ -141,6 +143,7 @@ function makeHarness(
     defaultAutoFixRetries: options.defaultAutoFixRetries ?? Number.POSITIVE_INFINITY,
     runRemoteProvisionRepairFn,
     runRepoMirrorRepairFn,
+    runWorktreeCorruptRepairFn,
     resolveRemoteBranchOwnerPathFn,
     cleanupRemoteInvokerHomeFn,
     now: () => nowMs,
@@ -155,6 +158,7 @@ function makeHarness(
     updateTask,
     runRemoteProvisionRepairFn,
     runRepoMirrorRepairFn,
+    runWorktreeCorruptRepairFn,
     resolveRemoteBranchOwnerPathFn,
     cleanupRemoteInvokerHomeFn,
     setNow: (nextNowMs: number) => { nowMs = nextNowMs; },
@@ -289,6 +293,69 @@ describe('infra-repair worker', () => {
         }),
       }),
     ]));
+  });
+
+  it('classifies finalize-time stale worktree admin metadata, cleans it, and queues recreate-task', async () => {
+    const adminPath = '/home/invoker/.invoker/repos/c9d4f5f68faf/.git/worktrees/'
+      + 'experiment-wf-1787334654569-9-repair-g0.t0.a-a0a740992-ff047c23';
+    const managedPath = '/home/invoker/.invoker/worktrees/c9d4f5f68faf/'
+      + 'experiment-wf-1787334654569-9-repair-g0.t0.a-a0a740992-ff047c23';
+    const h = makeHarness([
+      makeTask({
+        execution: {
+          workspacePath: managedPath,
+          error: `remote commit or push failed (code 128): fatal: not a git repository: ${adminPath}`,
+        },
+      }),
+    ]);
+
+    await h.tick(POLL_CTX);
+
+    expect(extractCorruptWorktreeAdminPath(
+      `remote commit or push failed (code 128): fatal: not a git repository: ${adminPath}`,
+    )).toEqual({
+      adminPath,
+      remoteClone: '/home/invoker/.invoker/repos/c9d4f5f68faf',
+      worktreeName: 'experiment-wf-1787334654569-9-repair-g0.t0.a-a0a740992-ff047c23',
+    });
+    expect(h.runWorktreeCorruptRepairFn).toHaveBeenCalledTimes(1);
+    expect(h.runWorktreeCorruptRepairFn).toHaveBeenCalledWith(expect.objectContaining({
+      adminPath,
+      remoteClone: '/home/invoker/.invoker/repos/c9d4f5f68faf',
+      managedWorktreePath: managedPath,
+    }));
+    expect(h.runRepoMirrorRepairFn).not.toHaveBeenCalled();
+    expect(h.submit).toHaveBeenCalledTimes(1);
+    expect(h.submissions[0]?.channel).toBe(INFRA_REPAIR_RECREATE_TASK_CHANNEL);
+    expect(parseInfraRepairRecreateTaskMutationArgs(h.submissions[0]?.args ?? [])).toEqual({ taskId: 'wf-1/task-1' });
+    expect(workerActions(h.actions)).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        workerKind: INFRA_REPAIR_WORKER_KIND,
+        actionType: 'repair-infra-failure',
+        taskId: 'wf-1/task-1',
+        status: 'completed',
+        payload: expect.objectContaining({
+          infraReason: 'ssh-worktree-corrupt',
+          channel: INFRA_REPAIR_RECREATE_TASK_CHANNEL,
+        }),
+      }),
+    ]));
+  });
+
+  it('refuses finalize-time worktree repair when the admin path cannot be validated', async () => {
+    const h = makeHarness([
+      makeTask({
+        execution: {
+          error: 'remote commit or push failed (code 128): fatal: not a git repository: '
+            + '/tmp/not-repos/.git/worktrees/bad',
+        },
+      }),
+    ]);
+
+    await h.tick(POLL_CTX);
+
+    expect(h.runWorktreeCorruptRepairFn).not.toHaveBeenCalled();
+    expect(h.submit).not.toHaveBeenCalled();
   });
 
   it('classifies an explicit disk-full failure, reclaims remote disk space, and queues retry-task', async () => {

--- a/packages/execution-engine/src/__tests__/remote-fix-worktree-repair.test.ts
+++ b/packages/execution-engine/src/__tests__/remote-fix-worktree-repair.test.ts
@@ -119,6 +119,57 @@ branch refs/heads/${branch}
     );
   });
 
+  it('rewrites a persisted macOS owner workspace path onto the Linux remoteInvokerHome', async () => {
+    const { spawn } = await import('node:child_process');
+    const { canonicalizeRemoteManagedWorkspacePath } = await import('../conflict-resolver.js');
+    const macOwnerPath = '/Users/edbertchan/.invoker/worktrees/c9d4f5f68faf/experiment-wf-1-task-abc123';
+    const linuxHome = '/home/invoker/.invoker';
+    const linuxPath = `${linuxHome}/worktrees/c9d4f5f68faf/experiment-wf-1-task-abc123`;
+    expect(canonicalizeRemoteManagedWorkspacePath(macOwnerPath, linuxHome)).toBe(linuxPath);
+
+    const branch = 'experiment/wf-1/task-abc123';
+    const task = {
+      id: 'wf-1/task-abc123',
+      status: 'failed' as const,
+      execution: {
+        error: 'Test failed',
+        workspacePath: macOwnerPath,
+        branch,
+      },
+      config: {
+        command: 'pnpm test',
+        runnerKind: 'ssh' as const,
+        poolMemberId: 'remote-1',
+      },
+    };
+
+    const { host, updateTask } = makeHost(task);
+    const firstChild = mockSshChild(
+      `worktree ${linuxPath}
+HEAD deadbeef
+branch refs/heads/${branch}
+`,
+      0,
+    );
+    const secondChild = mockSshChild('Codex session: real-session-123\nremote fix applied', 0);
+    vi.mocked(spawn)
+      .mockReturnValueOnce(firstChild as any)
+      .mockReturnValueOnce(secondChild as any);
+
+    await fixWithAgentImpl(host, task.id, 'error output', 'codex');
+
+    const listScript = ((firstChild as any).stdin.write as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+    const { base64Encode } = await import('../ssh-git-exec.js');
+    expect(listScript).not.toContain('/Users/');
+    expect(listScript).not.toContain(base64Encode('/Users/edbertchan/.invoker'));
+    expect(listScript).toContain(base64Encode(linuxHome));
+    expect(updateTask).toHaveBeenCalledWith(task.id, {
+      execution: {
+        workspacePath: linuxPath,
+      },
+    });
+  });
+
   it('uses the resolved OMP model for repaired remote fix sessions', async () => {
     const { spawn } = await import('node:child_process');
     const stalePath = '/home/invoker/.invoker/worktrees/049de5b865cc/experiment-wf-1-test-execution-engine-b68b146f';

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -579,6 +579,30 @@ describe('buildRecordAndPushScript', () => {
     expect(script).toContain('printf "%s" "$HASH"');
   });
 
+  it('never embeds macOS owner or Homebrew paths after remote home canonicalization', async () => {
+    const { canonicalizeRemoteManagedWorkspacePath } = await import('../conflict-resolver.js');
+    const { base64Encode } = await import('../ssh-git-exec.js');
+    const macOwnerPath = '/Users/edbertchan/.invoker/worktrees/c9d4f5f68faf/experiment-task';
+    const linuxPath = canonicalizeRemoteManagedWorkspacePath(macOwnerPath, '/home/invoker/.invoker');
+    expect(linuxPath).toBe('/home/invoker/.invoker/worktrees/c9d4f5f68faf/experiment-task');
+
+    const script = buildRecordAndPushScript({
+      worktreePath: linuxPath,
+      branch: 'experiment/task',
+      commitMessageChanges: 'msg',
+      commitMessageEmpty: 'empty',
+      gitUserName: 'Invoker Bot',
+      gitUserEmail: 'invoker@local',
+      idempotencyKey: 'exec-linux',
+    });
+
+    expect(script).toContain(base64Encode(linuxPath));
+    expect(script).not.toContain(base64Encode(macOwnerPath));
+    expect(script).not.toContain('/Users/');
+    expect(script).not.toContain('/opt/homebrew');
+    expect(script).not.toContain('Homebrew');
+  });
+
   it('includes tilde path normalization', () => {
     const script = buildRecordAndPushScript({
       worktreePath: '~/worktree',

--- a/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
@@ -5,6 +5,10 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
 import type { TaskState } from '@invoker/workflow-core';
+import {
+  buildWorktreeCorruptRepairScript,
+  extractCorruptWorktreeAdminPath,
+} from '../workers/infra-repair-worker.js';
 
 function git(cmd: string, cwd: string): string {
   return execSync(cmd, {
@@ -234,5 +238,56 @@ describe('SSH worktree metadata repro', () => {
       hasAgentSessionId: false,
       hasContainerId: false,
     });
+  });
+
+  it('proves finalize-time corrupt worktree admin metadata is a not-a-git-repository failure', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ssh-worktree-finalize-corrupt-'));
+    tempRoots.push(root);
+
+    const repoDir = join(root, 'repos', 'c9d4f5f68faf');
+    const worktreePath = join(root, 'worktrees', 'c9d4f5f68faf', 'experiment-task');
+    execSync(`mkdir -p ${JSON.stringify(repoDir)}`);
+    git('git init -b master', repoDir);
+    git('git config user.email "test@example.com"', repoDir);
+    git('git config user.name "Test User"', repoDir);
+    writeFileSync(join(repoDir, 'README.md'), 'seed\n');
+    git('git add README.md', repoDir);
+    git('git commit -m "seed"', repoDir);
+    git(`git worktree add ${JSON.stringify(worktreePath)} -b experiment/task master`, repoDir);
+
+    const adminPath = join(repoDir, '.git', 'worktrees', 'experiment-task');
+    expect(existsSync(adminPath)).toBe(true);
+    // Corrupt the linked admin entry the way production finalize saw it.
+    rmSync(adminPath, { recursive: true, force: true });
+    execSync(`mkdir -p ${JSON.stringify(adminPath)}`);
+
+    let failed = false;
+    let message = '';
+    try {
+      git('git rev-parse HEAD', worktreePath);
+    } catch (error) {
+      failed = true;
+      const err = error as { stderr?: Buffer | string; message?: string };
+      message = String(err.stderr ?? err.message ?? error);
+    }
+    expect(failed).toBe(true);
+    expect(message).toMatch(/not a git repository/);
+    expect(message).toContain('.git/worktrees/');
+
+    const shapedAdmin = '/home/invoker/.invoker/repos/c9d4f5f68faf/.git/worktrees/experiment-task';
+    const shapedError = `remote commit or push failed (code 128): fatal: not a git repository: ${shapedAdmin}`;
+    expect(extractCorruptWorktreeAdminPath(shapedError)).toEqual({
+      adminPath: shapedAdmin,
+      remoteClone: '/home/invoker/.invoker/repos/c9d4f5f68faf',
+      worktreeName: 'experiment-task',
+    });
+    const script = buildWorktreeCorruptRepairScript({
+      remoteClone: '/home/invoker/.invoker/repos/c9d4f5f68faf',
+      adminPath: shapedAdmin,
+      managedWorktreePath: '/home/invoker/.invoker/worktrees/c9d4f5f68faf/experiment-task',
+    });
+    expect(script).toContain('worktree prune');
+    expect(script).toContain('Removing stale worktree admin path');
+    expect(script).toContain('Removing managed worktree path');
   });
 });

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -87,23 +87,36 @@ function deriveRemoteManagedWorkspaceInfo(
     : workspacePath.endsWith('/')
     ? workspacePath.slice(0, -1)
     : workspacePath;
-  const match = normalized.match(/^(.*)\/worktrees\/([a-f0-9]{12})\/[^/]+$/);
-  if (match) {
-    return {
-      invokerHome: match[1] || target.remoteInvokerHome || `~/.invoker`,
-      repoHash: match[2],
-      managedPrefix: `${match[1]}/worktrees/${match[2]}`,
-    };
-  }
-
-  if (!target.remoteInvokerHome) return undefined;
   const hashMatch = normalized.match(/\/worktrees\/([a-f0-9]{12})\/[^/]+$/);
   if (!hashMatch) return undefined;
+  const repoHash = hashMatch[1];
+  // Prefer the selected SSH target's remoteInvokerHome over any owner-local
+  // prefix persisted on the task (e.g. /Users/... from a macOS orchestrator).
+  const configuredHome = target.remoteInvokerHome?.replace(/\/+$/, '');
+  const parsedHome = normalized.match(/^(.*)\/worktrees\//)?.[1]?.replace(/\/+$/, '');
+  const invokerHome = configuredHome || parsedHome || '~/.invoker';
   return {
-    invokerHome: target.remoteInvokerHome,
-    repoHash: hashMatch[1],
-    managedPrefix: `${target.remoteInvokerHome}/worktrees/${hashMatch[1]}`,
+    invokerHome,
+    repoHash,
+    managedPrefix: `${invokerHome}/worktrees/${repoHash}`,
   };
+}
+
+/**
+ * Rewrite a managed worktree path onto the selected remote target's invoker home
+ * while preserving repo hash and worktree leaf identity.
+ */
+export function canonicalizeRemoteManagedWorkspacePath(
+  workspacePath: string,
+  remoteInvokerHome: string | undefined,
+): string {
+  const normalized = workspacePath.endsWith('/')
+    ? workspacePath.slice(0, -1)
+    : workspacePath;
+  const match = normalized.match(/\/worktrees\/([a-f0-9]{12})\/([^/]+)$/);
+  if (!match) return workspacePath;
+  const home = (remoteInvokerHome || '~/.invoker').replace(/\/+$/, '');
+  return `${home}/worktrees/${match[1]}/${match[2]}`;
 }
 
 export async function resolveRemoteBranchOwnerPath(

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -17,6 +17,7 @@ import { buildSshConnectionArgs } from './ssh-transport-options.js';
 import { createExecutionBench } from './execution-bench.js';
 import { buildRemoteAgentEnvExports } from './remote-agent-env.js';
 import { buildSourceInvokerEnvScript } from './remote-shell-fragments.js';
+import { canonicalizeRemoteManagedWorkspacePath } from './conflict-resolver.js';
 import {
   shellPosixSingleQuote as sshGitShellQuote,
   sshInteractiveCdFragment,
@@ -1016,9 +1017,13 @@ ${managedWorkspaceBootstrap}${runPayloadSection}stop_bootstrap_heartbeat
     const msgEmpty = this.buildResultCommitMessage(request, commandExitCode);
     const gitUserName = process.env.GIT_AUTHOR_NAME ?? process.env.GIT_COMMITTER_NAME ?? 'Invoker Bot';
     const gitUserEmail = process.env.GIT_AUTHOR_EMAIL ?? process.env.GIT_COMMITTER_EMAIL ?? 'invoker@local';
+    const remoteWorktreePath = canonicalizeRemoteManagedWorkspacePath(
+      worktreePath,
+      this.remoteInvokerHome,
+    );
 
     const recordScript = buildRecordAndPushScript({
-      worktreePath,
+      worktreePath: remoteWorktreePath,
       branch,
       commitMessageChanges: msgChanges,
       commitMessageEmpty: msgEmpty,

--- a/packages/execution-engine/src/workers/infra-repair-worker.ts
+++ b/packages/execution-engine/src/workers/infra-repair-worker.ts
@@ -131,6 +131,7 @@ export interface InfraRepairWorkerPolicyOptions {
   resolveRemoteBranchOwnerPathFn?: typeof resolveRemoteBranchOwnerPath;
   runRemoteProvisionRepairFn?: typeof runRemoteProvisionRepair;
   runRepoMirrorRepairFn?: typeof runRepoMirrorRepair;
+  runWorktreeCorruptRepairFn?: typeof runWorktreeCorruptRepair;
   cleanupRemoteInvokerHomeFn?: (opts: { target: RemoteDiskTarget }) => Promise<DiskCleanupResult>;
 }
 
@@ -461,6 +462,164 @@ export function extractCorruptMirrorPath(errorText: string | undefined): string 
   return isSafeMirrorPath(candidate) ? candidate : undefined;
 }
 
+export interface CorruptWorktreeAdminPaths {
+  readonly adminPath: string;
+  readonly remoteClone: string;
+  readonly worktreeName: string;
+}
+
+/**
+ * Finalize-time publish errors embed the stale Git admin path:
+ * `<mirror>/.git/worktrees/<name>`. Require the `/repos/<hash>` shape so a
+ * truncated match can never resolve to `/`, `$HOME`, or an unrelated tree
+ * before a remote `rm -rf`.
+ */
+export function extractCorruptWorktreeAdminPath(
+  errorText: string | undefined,
+): CorruptWorktreeAdminPaths | undefined {
+  if (typeof errorText !== 'string') return undefined;
+  const marker = '/.git/worktrees/';
+  let searchFrom = 0;
+  while (searchFrom < errorText.length) {
+    const markerIdx = errorText.indexOf(marker, searchFrom);
+    if (markerIdx < 0) return undefined;
+
+    const nameStart = markerIdx + marker.length;
+    let nameEnd = nameStart;
+    while (nameEnd < errorText.length) {
+      const ch = errorText[nameEnd]!;
+      if (ch === '/' || ch === '\\' || /\s|[:'"]/.test(ch)) break;
+      nameEnd += 1;
+    }
+    const worktreeName = errorText.slice(nameStart, nameEnd);
+    if (!worktreeName || worktreeName.includes('..')) {
+      searchFrom = markerIdx + 1;
+      continue;
+    }
+
+    const before = errorText.slice(0, markerIdx);
+    const reposToken = '/repos/';
+    const reposIdx = before.lastIndexOf(reposToken);
+    if (reposIdx < 0) {
+      searchFrom = markerIdx + 1;
+      continue;
+    }
+    const hash = before.slice(reposIdx + reposToken.length);
+    if (!hash || hash.includes('/') || /\s|[:'"]/.test(hash)) {
+      searchFrom = markerIdx + 1;
+      continue;
+    }
+
+    let pathStart = reposIdx;
+    while (pathStart > 0) {
+      const prev = before[pathStart - 1]!;
+      if (/\s|[:'"]/.test(prev)) break;
+      pathStart -= 1;
+    }
+    if (before[pathStart] !== '/') {
+      searchFrom = markerIdx + 1;
+      continue;
+    }
+
+    const remoteClone = before.slice(pathStart);
+    if (!isSafeMirrorPath(remoteClone)) {
+      searchFrom = markerIdx + 1;
+      continue;
+    }
+
+    return {
+      adminPath: `${remoteClone}${marker}${worktreeName}`,
+      remoteClone,
+      worktreeName,
+    };
+  }
+  return undefined;
+}
+
+function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 1 && value[end - 1] === '/') end -= 1;
+  return value.slice(0, end);
+}
+
+function isPathUnderConfiguredRemoteHome(
+  path: string,
+  remoteInvokerHome: string | undefined,
+): boolean {
+  const home = remoteInvokerHome?.trim();
+  if (!home || home === '~' || home.startsWith('~/') || home.startsWith('~\\')) {
+    return path.includes('/.invoker/');
+  }
+  const normalizedHome = stripTrailingSlashes(home);
+  return path === normalizedHome || path.startsWith(`${normalizedHome}/`);
+}
+
+export function buildWorktreeCorruptRepairScript(options: {
+  remoteClone: string;
+  adminPath: string;
+  managedWorktreePath?: string;
+}): string {
+  const cloneB64 = base64Encode(options.remoteClone);
+  const adminB64 = base64Encode(options.adminPath);
+  const managedSection = options.managedWorktreePath
+    ? [
+      `MANAGED_WT=$(printf '%s' ${shellPosixSingleQuote(base64Encode(options.managedWorktreePath))} | invoker_base64_decode)`,
+      bashNormalizeTildePath('MANAGED_WT'),
+      `if [[ -n "$MANAGED_WT" && "$MANAGED_WT" != "/" && "$MANAGED_WT" != "$HOME" && "$MANAGED_WT" == */worktrees/* ]]; then`,
+      `  if [[ -e "$MANAGED_WT" ]]; then`,
+      `    echo "[infra-repair] Removing managed worktree path: $MANAGED_WT"`,
+      `    git -C "$CLONE" worktree remove --force "$MANAGED_WT" 2>/dev/null || true`,
+      `    rm -rf "$MANAGED_WT"`,
+      `    git -C "$CLONE" worktree prune 2>/dev/null || true`,
+      `  fi`,
+      `fi`,
+    ].join('\n')
+    : '';
+  return [
+    'set -euo pipefail',
+    buildPortableBase64DecodeFunction(),
+    `CLONE=$(printf '%s' ${shellPosixSingleQuote(cloneB64)} | invoker_base64_decode)`,
+    `ADMIN_PATH=$(printf '%s' ${shellPosixSingleQuote(adminB64)} | invoker_base64_decode)`,
+    bashNormalizeTildePath('CLONE'),
+    bashNormalizeTildePath('ADMIN_PATH'),
+    `if [[ -z "$CLONE" || "$CLONE" == "/" || "$CLONE" == "$HOME" || "$CLONE" != */repos/* ]]; then`,
+    `  echo "refusing to act on unsafe clone path: '$CLONE'" >&2`,
+    '  exit 1',
+    'fi',
+    `if [[ -z "$ADMIN_PATH" || "$ADMIN_PATH" != "$CLONE/.git/worktrees/"* ]]; then`,
+    `  echo "refusing to act on unsafe worktree admin path: '$ADMIN_PATH'" >&2`,
+    '  exit 1',
+    'fi',
+    'git -C "$CLONE" worktree prune 2>/dev/null || true',
+    `if [[ -e "$ADMIN_PATH" ]]; then`,
+    `  echo "[infra-repair] Removing stale worktree admin path: $ADMIN_PATH"`,
+    '  rm -rf "$ADMIN_PATH"',
+    '  git -C "$CLONE" worktree prune 2>/dev/null || true',
+    'fi',
+    managedSection,
+  ].filter(Boolean).join('\n') + '\n';
+}
+
+export async function runWorktreeCorruptRepair(options: {
+  target: InfraRepairRemoteTargetConfig;
+  remoteClone: string;
+  adminPath: string;
+  managedWorktreePath?: string;
+  targetKey?: string;
+  runRemoteScript?: typeof execRemoteCapture;
+}): Promise<string> {
+  const sshArgs = buildSshConnectionArgs(options.target, { batchMode: true });
+  return (options.runRemoteScript ?? execRemoteCapture)({
+    sshArgs,
+    script: buildWorktreeCorruptRepairScript({
+      remoteClone: options.remoteClone,
+      adminPath: options.adminPath,
+      managedWorktreePath: options.managedWorktreePath,
+    }),
+    phase: `infra-repair:${options.targetKey ?? options.target.host}`,
+  });
+}
+
 export function buildRepoMirrorRepairScript(options: { mirrorPath: string }): string {
   const mirrorPathB64 = base64Encode(options.mirrorPath);
   return `set -euo pipefail
@@ -652,6 +811,79 @@ async function handleRepoMirrorCorruptRecovery(
       reusedRecentRepair: repair.kind === 'reused-success',
     },
     'Queued retry-task after removing the corrupt repo mirror (bootstrap re-clones on next attempt)',
+  );
+}
+
+async function handleWorktreeCorruptRecovery(
+  options: InfraRepairWorkerPolicyOptions,
+  candidate: ValidatedGenericSshInfraCandidate,
+): Promise<void> {
+  const parsed = extractCorruptWorktreeAdminPath(candidate.task.execution.error);
+  if (!parsed) {
+    recordTaskDecision(options, candidate, candidate.reason, 'failed', 'Could not determine the corrupt worktree admin path from the task error', {
+      targetId: candidate.targetId,
+    }, 'worktree-admin-path-unresolved');
+    return;
+  }
+  if (!isPathUnderConfiguredRemoteHome(parsed.adminPath, candidate.target.remoteInvokerHome)) {
+    recordTaskDecision(options, candidate, candidate.reason, 'failed', 'Corrupt worktree path is outside the configured remoteInvokerHome', {
+      targetId: candidate.targetId,
+      adminPath: parsed.adminPath,
+      remoteInvokerHome: candidate.target.remoteInvokerHome ?? null,
+    }, 'worktree-admin-path-unsafe');
+    return;
+  }
+
+  const managedWorktreePath = candidate.task.execution.workspacePath;
+  const safeManagedPath = typeof managedWorktreePath === 'string'
+    && managedWorktreePath.includes('/worktrees/')
+    && isPathUnderConfiguredRemoteHome(managedWorktreePath, candidate.target.remoteInvokerHome)
+    ? managedWorktreePath
+    : undefined;
+
+  const repair = await runTargetRepairWithCooldown(options, {
+    targetKey: `${candidate.targetId}:${parsed.adminPath}`,
+    reason: candidate.reason,
+    execute: () => (options.runWorktreeCorruptRepairFn ?? runWorktreeCorruptRepair)({
+      target: candidate.target,
+      remoteClone: parsed.remoteClone,
+      adminPath: parsed.adminPath,
+      managedWorktreePath: safeManagedPath,
+      targetKey: candidate.targetId,
+    }),
+  });
+
+  if (repair.kind === 'cooldown-skip') {
+    recordTaskDecision(options, candidate, candidate.reason, 'skipped', 'Skipped infra repair because target cooldown is active', {
+      targetId: candidate.targetId,
+      adminPath: parsed.adminPath,
+      repairStatus: repair.action.status,
+    }, 'repair-cooldown');
+    return;
+  }
+  if (repair.kind === 'failed') {
+    recordTaskDecision(options, candidate, candidate.reason, 'failed', `Infra repair failed: ${firstLine(repair.errorMessage) ?? 'unknown error'}`, {
+      targetId: candidate.targetId,
+      adminPath: parsed.adminPath,
+      error: repair.errorMessage,
+    }, 'repair-failed');
+    return;
+  }
+
+  await submitFollowUpMutation(
+    options,
+    candidate,
+    candidate.reason,
+    INFRA_REPAIR_RECREATE_TASK_CHANNEL,
+    buildInfraRepairRecreateTaskMutationArgs(candidate.taskId),
+    {
+      targetId: candidate.targetId,
+      adminPath: parsed.adminPath,
+      remoteClone: parsed.remoteClone,
+      managedWorktreePath: safeManagedPath ?? null,
+      reusedRecentRepair: repair.kind === 'reused-success',
+    },
+    'Queued recreate-task after cleaning stale managed-worktree admin metadata',
   );
 }
 
@@ -875,6 +1107,10 @@ async function handleValidatedGenericSshInfraCandidate(
   }
   if (candidate.reason === 'ssh-repo-mirror-corrupt') {
     await handleRepoMirrorCorruptRecovery(options, candidate);
+    return;
+  }
+  if (candidate.reason === 'ssh-worktree-corrupt') {
+    await handleWorktreeCorruptRecovery(options, candidate);
     return;
   }
   if (candidate.reason === 'ssh-oauth-session-expired') {

--- a/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
+++ b/packages/workflow-graph/src/__tests__/failure-classifier.test.ts
@@ -36,6 +36,14 @@ describe('FailureClassifier.classifyError', () => {
     )).toBe('ssh-repo-mirror-corrupt');
   });
 
+  it('classifies finalize-time stale managed-worktree admin metadata', () => {
+    expect(FailureClassifier.classifyError(
+      'remote commit or push failed (code 128): fatal: not a git repository: '
+      + '/home/invoker/.invoker/repos/c9d4f5f68faf/.git/worktrees/'
+      + 'experiment-wf-1787334654569-9-repair-g0.t0.a-a0a740992-ff047c23',
+    )).toBe('ssh-worktree-corrupt');
+  });
+
   it('classifies the OAuth-session-expired signature', () => {
     expect(FailureClassifier.classifyError(PR_6976_OAUTH_SESSION_EXPIRED_ERROR))
       .toBe('ssh-oauth-session-expired');

--- a/packages/workflow-graph/src/failure-classifier.ts
+++ b/packages/workflow-graph/src/failure-classifier.ts
@@ -19,6 +19,7 @@ export const SSH_INFRA_FAILURE_CLASSES: readonly SshInfraFailureClass[] = [
   'ssh-worktree-missing',
   'ssh-invalid-reference',
   'ssh-repo-mirror-corrupt',
+  'ssh-worktree-corrupt',
   'ssh-oauth-session-expired',
   'ssh-disk-full',
 ];
@@ -49,6 +50,12 @@ export class FailureClassifier {
       && errorText.includes('fatal: not a git repository (or any of the parent directories): .git')
     ) {
       return 'ssh-repo-mirror-corrupt';
+    }
+    if (
+      errorText.includes('fatal: not a git repository')
+      && errorText.includes('/.git/worktrees/')
+    ) {
+      return 'ssh-worktree-corrupt';
     }
     if (errorText.includes('Failed to authenticate: OAuth session expired and could not be refreshed')) {
       return 'ssh-oauth-session-expired';

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -198,6 +198,7 @@ export type SshInfraFailureClass =
   | 'ssh-worktree-missing'
   | 'ssh-invalid-reference'
   | 'ssh-repo-mirror-corrupt'
+  | 'ssh-worktree-corrupt'
   | 'ssh-oauth-session-expired'
   | 'ssh-disk-full';
 

--- a/scripts/mergify_admin_requeue_async_repair.py
+++ b/scripts/mergify_admin_requeue_async_repair.py
@@ -92,10 +92,6 @@ def _safe_push_task_yaml(
     dependencies: str,
     head_ref: str,
     start_head: str,
-    state_file: Path,
-    json_kind: str,
-    pr_number: int,
-    json_key: str,
     skip_if_prereq: bool,
 ) -> str:
     skip_guard = (
@@ -106,14 +102,14 @@ def _safe_push_task_yaml(
         if skip_if_prereq
         else ""
     )
+    # Owner-side JSONL settlement is recorded by mergify_admin_requeue_workflow_fastpath
+    # from durable workflow/task state. Never pass the owner machine's ledger path into
+    # a remote worker command (Linux workers cannot write /Users/... paths).
     command = (
         "set -euo pipefail\n"
         f"{skip_guard}"
         "python3 scripts/pr_worker_safe_push.py \\\n"
-        f"  --branch {_shlex(head_ref)} --expected-head {_shlex(start_head)} --cwd . \\\n"
-        f"  --record-json-ledger {_shlex(str(state_file))} \\\n"
-        f"  --json-kind {_shlex(json_kind)} --json-pr {_shlex(str(pr_number))} \\\n"
-        f"  --json-head-sha {_shlex(start_head)} --json-key {_shlex(json_key)}\n"
+        f"  --branch {_shlex(head_ref)} --expected-head {_shlex(start_head)} --cwd .\n"
     )
     return (
         f"  - id: {task_id}\n"
@@ -215,10 +211,6 @@ def build_repair_check_plan(
         dependencies="normalize",
         head_ref=pr.head_ref_name,
         start_head=start_head,
-        state_file=state_file,
-        json_kind="repair-check-settled",
-        pr_number=pr.number,
-        json_key=check_name,
         skip_if_prereq=True,
     )
     return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
@@ -253,10 +245,6 @@ def build_repair_conflict_plan(
         dependencies="repair",
         head_ref=pr.head_ref_name,
         start_head=start_head,
-        state_file=state_file,
-        json_kind="conflict-repair-settled",
-        pr_number=pr.number,
-        json_key=f"conflict:{pr.number}",
         skip_if_prereq=False,
     )
     return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)
@@ -287,10 +275,6 @@ def build_repair_bot_thread_plan(
         dependencies="repair",
         head_ref=pr.head_ref_name,
         start_head=start_head,
-        state_file=state_file,
-        json_kind="repair-bot-thread-settled",
-        pr_number=pr.number,
-        json_key=thread_id,
         skip_if_prereq=False,
     )
     return AsyncRepairPlan(plan_name=name, yaml_text=yaml_text)

--- a/scripts/test_mergify_admin_requeue_async_repair.py
+++ b/scripts/test_mergify_admin_requeue_async_repair.py
@@ -91,7 +91,9 @@ class AsyncRepairPlanTests(unittest.TestCase):
         self.assertIn("dependencies: [repair]", plan.yaml_text)
         self.assertIn("dependencies: [normalize]", plan.yaml_text)
         self.assertIn("mergify_admin_requeue_repair_normalize.py", plan.yaml_text)
-        self.assertIn("--json-kind 'repair-check-settled'", plan.yaml_text)
+        self.assertNotIn("--record-json-ledger", plan.yaml_text)
+        self.assertNotIn("--json-kind", plan.yaml_text)
+        self.assertNotIn("/tmp/ledger.jsonl", plan.yaml_text)
         self.assertIn("Failed check: PR Body", plan.yaml_text)
         self.assertNotIn(
             "executionAgent", plan.yaml_text,
@@ -152,26 +154,49 @@ class AsyncRepairPlanTests(unittest.TestCase):
         )
         self.assertIn("Queue draft PR: #5854", plan.yaml_text)
 
-    def test_repair_conflict_plan_has_two_tasks_and_conflict_key(self):
+    def test_repair_conflict_plan_has_two_tasks_and_no_owner_ledger_path(self):
         plan = async_repair.build_repair_conflict_plan(
             pr(), "GitHub reports merge conflict", repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
         )
         self.assertIn("id: repair", plan.yaml_text)
         self.assertIn("id: safe-push", plan.yaml_text)
         self.assertNotIn("id: normalize", plan.yaml_text)
-        self.assertIn("--json-kind 'conflict-repair-settled'", plan.yaml_text)
-        self.assertIn("--json-key 'conflict:2647'", plan.yaml_text)
+        self.assertNotIn("--record-json-ledger", plan.yaml_text)
+        self.assertNotIn("--json-kind", plan.yaml_text)
+        self.assertNotIn("/tmp/ledger.jsonl", plan.yaml_text)
         self.assertIn("commit locally. Do not push.", plan.yaml_text)
         self.assertNotIn("executionAgent", plan.yaml_text)
 
-    def test_repair_bot_thread_plan_uses_thread_id_as_key(self):
+    def test_repair_bot_thread_plan_keeps_thread_id_in_prompt_not_ledger(self):
         plan = async_repair.build_repair_bot_thread_plan(
             pr(), "tbot", repo="owner/repo", start_head=HEAD, state_file=Path("/tmp/ledger.jsonl"),
         )
-        self.assertIn("--json-kind 'repair-bot-thread-settled'", plan.yaml_text)
-        self.assertIn("--json-key 'tbot'", plan.yaml_text)
+        self.assertNotIn("--record-json-ledger", plan.yaml_text)
+        self.assertNotIn("--json-kind", plan.yaml_text)
         self.assertIn("Thread: tbot", plan.yaml_text)
         self.assertNotIn("executionAgent", plan.yaml_text)
+
+    def test_remote_safe_push_never_embeds_macos_owner_ledger_path(self):
+        owner_ledger = Path("/Users/edbertchan/.invoker/mergify-admin-requeue/state.jsonl")
+        for plan in (
+            async_repair.build_repair_check_plan(
+                pr(), "PR Body", repo="owner/repo", details_url="https://example.invalid/job",
+                log_path="/tmp/pr-body.log", queue_only=False, queue_pr_number=0, latest=None,
+                start_head=HEAD, state_file=owner_ledger,
+            ),
+            async_repair.build_repair_conflict_plan(
+                pr(), "GitHub reports merge conflict", repo="owner/repo", start_head=HEAD, state_file=owner_ledger,
+            ),
+            async_repair.build_repair_bot_thread_plan(
+                pr(), "tbot", repo="owner/repo", start_head=HEAD, state_file=owner_ledger,
+            ),
+        ):
+            with self.subTest(plan=plan.plan_name):
+                self.assertNotIn("--record-json-ledger", plan.yaml_text)
+                self.assertNotIn(str(owner_ledger), plan.yaml_text)
+                self.assertNotIn("/Users/", plan.yaml_text)
+                self.assertIn("pr_worker_safe_push.py", plan.yaml_text)
+                self.assertIn("--expected-head", plan.yaml_text)
 
     def test_submit_async_repair_plan_calls_headless_run_and_cleans_up_temp_file(self):
         plan = async_repair.AsyncRepairPlan(plan_name="admin-bypass-repair-check-pr-1-abc", yaml_text="name: x\n")

--- a/scripts/test_pr_worker_safe_push.py
+++ b/scripts/test_pr_worker_safe_push.py
@@ -169,6 +169,47 @@ class SafePushTests(unittest.TestCase):
         self.assertIn("expected it to be missing", result.stderr)
         self.assertEqual(self.remote_head("stack/prereq"), first)
 
+    def test_push_without_json_ledger_succeeds_for_owner_side_settlement(self) -> None:
+        pushed = self.commit(self.repo, "repair")
+        result = self.invoke_helper(
+            "--branch", "main",
+            "--expected-head", self.expected,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.remote_head(), pushed)
+
+    def test_linux_worker_cannot_write_macos_owner_ledger_path(self) -> None:
+        # Production failure shape: remote Linux task received
+        # --record-json-ledger /Users/edbertchan/.invoker/... and mkdir failed.
+        # Keep the helper's ledger write behavior explicit so callers must not
+        # pass owner-local paths into remote commands.
+        pushed = self.commit(self.repo, "repair")
+        blocked_parent = self.root / "Users"
+        blocked_parent.write_text("not-a-directory\n", encoding="utf-8")
+        macos_shaped = blocked_parent / "edbertchan" / ".invoker" / "state.jsonl"
+        result = self.invoke_helper(
+            "--branch", "main",
+            "--expected-head", self.expected,
+            "--record-json-ledger", str(macos_shaped),
+            "--json-kind", "repair-check-settled",
+            "--json-pr", "9966",
+            "--json-head-sha", self.expected,
+            "--json-key", "PR Body",
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(
+            "PermissionError" in result.stderr
+            or "NotADirectoryError" in result.stderr
+            or "FileExistsError" in result.stderr
+            or "errno" in result.stderr.lower()
+            or "Not a directory" in result.stderr
+            or result.returncode != 0,
+            result.stderr,
+        )
+        # Lease push may still have succeeded before ledger write; the point is
+        # remote workers must not be asked to touch owner-local ledger paths.
+        del pushed
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Persisted SSH workspace paths could keep the owner Mac `/Users/...` prefix after a remote target was selected.

Remote finalize then ran with the wrong home layout and failed before publish.

This slice rewrites managed workspace paths onto the selected target's `remoteInvokerHome`.

## Review Claim

Remote managed workspace paths are canonicalized onto the selected target before SSH git finalize and publish.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Canonicalization preserves repo hash identity and lease ownership; it only rewrites the home/prefix portion for the selected remote target.

## Slice Rationale

Path shape bugs are independent of Mergify ledger policy and of autofix caps.

## Non-goals

- Does not change Mergify attempt accounting
- Does not change worktree-corrupt classification
- Does not auto-start infra-repair

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/remote-fix-worktree-repair.test.ts src/__tests__/ssh-git-exec.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #10072