### PR TITLE
Bugfix: PR Body diff-atomicity linter cross-matches unrelated assertion call sites as a flipped test assertion

### DIFF
--- a/scripts/lint-pr-diff-atomicity.mjs
+++ b/scripts/lint-pr-diff-atomicity.mjs
@@ -157,6 +157,8 @@ export function parseUnifiedDiff(diffText, source = 'diff') {
   let current = null;
   let counter = 0;
   let oldCounter = 0;
+  let groupCounter = 0;
+  let inChangeRun = false;
 
   const start = (header) => {
     const finalized = finalizeFile(current);
@@ -172,6 +174,8 @@ export function parseUnifiedDiff(diffText, source = 'diff') {
       changeType: 'modify',
       addedLineNumbers: new Set(),
       removedLineNumbers: new Set(),
+      addedGroupMap: new Map(),
+      removedGroupMap: new Map(),
       removedCount: 0,
       newLineMap: new Map(),
       oldLineMap: new Map(),
@@ -181,6 +185,8 @@ export function parseUnifiedDiff(diffText, source = 'diff') {
     };
     counter = 0;
     oldCounter = 0;
+    groupCounter = 0;
+    inChangeRun = false;
   };
 
   for (const line of lines) {
@@ -223,20 +229,31 @@ export function parseUnifiedDiff(diffText, source = 'diff') {
       const match = /@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
       oldCounter = match ? Number.parseInt(match[1], 10) : 0;
       counter = match ? Number.parseInt(match[2], 10) : 0;
+      inChangeRun = false;
       continue;
     }
     if (counter < 1 && oldCounter < 1) {
       continue;
     }
     if (line.startsWith('+') && !line.startsWith('+++')) {
+      if (!inChangeRun) {
+        groupCounter += 1;
+        inChangeRun = true;
+      }
       current.newLineMap.set(counter, line.slice(1));
       current.addedLineNumbers.add(counter);
+      current.addedGroupMap.set(counter, groupCounter);
       counter += 1;
       continue;
     }
     if (line.startsWith('-') && !line.startsWith('---')) {
+      if (!inChangeRun) {
+        groupCounter += 1;
+        inChangeRun = true;
+      }
       current.oldLineMap.set(oldCounter, line.slice(1));
       current.removedLineNumbers.add(oldCounter);
+      current.removedGroupMap.set(oldCounter, groupCounter);
       current.removedCount += 1;
       oldCounter += 1;
       continue;
@@ -246,6 +263,7 @@ export function parseUnifiedDiff(diffText, source = 'diff') {
       current.oldLineMap.set(oldCounter, line.slice(1));
       counter += 1;
       oldCounter += 1;
+      inChangeRun = false;
     }
   }
 
@@ -318,7 +336,7 @@ function analyzeAssertionCall(ts, node) {
   return { target, matcherName, matcherArgs, negated };
 }
 
-function collectAssertionCalls(file, content, lineNumbers) {
+function collectAssertionCalls(file, content, lineNumbers, groupMap) {
   if (!CODE_EXTENSIONS.has(path.extname(file.path)) || lineNumbers.size === 0) {
     return [];
   }
@@ -335,14 +353,18 @@ function collectAssertionCalls(file, content, lineNumbers) {
       const startLine = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
       const endLine = sourceFile.getLineAndCharacterOfPosition(node.getEnd()).line + 1;
       let touchesChangedLine = false;
+      const groupIds = new Set();
       for (let line = startLine; line <= endLine; line += 1) {
         if (lineNumbers.has(line)) {
           touchesChangedLine = true;
-          break;
+          const groupId = groupMap.get(line);
+          if (groupId !== undefined) {
+            groupIds.add(groupId);
+          }
         }
       }
       if (touchesChangedLine) {
-        assertions.push({ ...assertion, line: startLine });
+        assertions.push({ ...assertion, line: startLine, groupIds });
       }
     }
     ts.forEachChild(node, walk);
@@ -350,6 +372,15 @@ function collectAssertionCalls(file, content, lineNumbers) {
 
   walk(sourceFile);
   return assertions;
+}
+
+function groupIdsIntersect(a, b) {
+  for (const id of a) {
+    if (b.has(id)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function collectTestAssertionWeakenedFindings(files) {
@@ -363,16 +394,17 @@ function collectTestAssertionWeakenedFindings(files) {
     if (file.category !== 'test') {
       continue;
     }
-    const removedAssertions = collectAssertionCalls(file, file.oldContent, file.removedLineNumbers);
+    const removedAssertions = collectAssertionCalls(file, file.oldContent, file.removedLineNumbers, file.removedGroupMap);
     if (removedAssertions.length === 0) {
       continue;
     }
-    const addedAssertions = collectAssertionCalls(file, file.newContent, file.addedLineNumbers);
+    const addedAssertions = collectAssertionCalls(file, file.newContent, file.addedLineNumbers, file.addedGroupMap);
     for (const added of addedAssertions) {
       const flipped = removedAssertions.some((removed) =>
         removed.target === added.target
         && removed.matcherName === added.matcherName
-        && (removed.negated !== added.negated || removed.matcherArgs !== added.matcherArgs));
+        && (removed.negated !== added.negated || removed.matcherArgs !== added.matcherArgs)
+        && groupIdsIntersect(removed.groupIds, added.groupIds));
       if (flipped) {
         findings.push(makeFinding('test-assertion-weakened', file.path, added.line, file.source));
       }


### PR DESCRIPTION
## Summary

The PR Body diff-atomicity linter wrongly flags an assertion as flipped when a
different, unrelated `it()` block edits a matching mock call nearby.

`test-assertion-weakened` paired any removed assertion in a test file with any
added assertion sharing the same target and matcher, ignoring where in the
diff each edit lived.

PR #9966 hit this. Its test file added `turnId: expect.any(String)` to one
call and separately edited an unrelated literal at a different call site.

The linter cross-matched the two edits and failed CI.

This change scopes the matching to same-edit-location pairs, so unrelated
call sites sharing a target and matcher no longer cross-match.

## Review Claim

Approve scoping `test-assertion-weakened` matching in
`scripts/lint-pr-diff-atomicity.mjs` to assertion pairs whose changed lines
share a diff edit group, eliminating the cross-file-location false positive
while keeping genuine same-call-site flips detected.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

All other behavior in `scripts/lint-pr-diff-atomicity.mjs` is unchanged; only
the `test-assertion-weakened` pairing logic gains a same-edit-group
requirement. Genuine same-call-site flips (the existing case A/case B
fixtures in `scripts/test-pr-diff-atomicity.mjs` and
`scripts/test-pr-diff-atomicity-multiline-assertion.mjs`) are still flagged
after this change.

## Slice Rationale

One policy slice: the cross-matching defect in the shared linter, isolated to
its own file with no product, test, or doc changes bundled in.

## Non-goals

No refactor of the linter's other findings, no new POLICY entries, no
unrelated cleanup, no doc edits, no change to any other rule's severity or
message.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-pr-diff-atomicity.mjs`
- [ ] `node scripts/test-pr-diff-atomicity-multiline-assertion.mjs`
- [ ] `node /tmp/repro-diff-atomicity-turnid.mjs` (inline repro shaped like PR #9966: a product-file change plus a test file whose same-target/matcher `toHaveBeenCalledWith` call is edited at two unrelated `it()` blocks — one gets a field added, one gets an unrelated literal replacement. Fails on the unpatched linter with a false-positive finding at the field-addition site; passes after this fix while still flagging the genuine same-call-site flip.)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>