### PR TITLE
[CI regression: cd07355-required-fast-mergify-admin-requeue](1) Mock review-gate IPC in valid-noop repro

### DIFF
--- a/scripts/repro/repro-babysit-pr-body-valid-noop.sh
+++ b/scripts/repro/repro-babysit-pr-body-valid-noop.sh
@@ -42,6 +42,21 @@ exit 42
 EOF
 chmod +x "$TMP/bin/claude"
 
+# Without this, resolve_workflow_for_pr (mergify_admin_requeue_workflow_fastpath.py)
+# shells out to a live Invoker owner over IPC to look up a review-gate workflow
+# mapping for PR #5810, which this hermetic repro never provides -- the lookup
+# subprocess fails to connect and admin-bypass-dispatch-degraded fires before
+# the worker ever reaches the PR Body valid-noop path this repro is meant to
+# test. Mocked the same way its sibling repros already do (e.g.
+# repro-babysit-pr-body-human-split.sh, repro-babysit-pr-body-prereq-split.sh).
+cat > "$TMP/review-gate.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{}\n'
+EOF
+chmod +x "$TMP/review-gate.sh"
+export INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh"
+
 REMOTE="$TMP/origin.git"
 SEED="$TMP/seed"
 WORK_ROOT="$WORK_PARENT/5810"


### PR DESCRIPTION
## Summary

The `required-fast / Mergify Admin Requeue` CI job runs every `scripts/repro/repro-*.sh` file that mentions `mergify_admin_requeue`.

One of those, `repro-babysit-pr-body-valid-noop.sh`, was hermetic in every way except one: it never stubbed the review-gate lookup.

`resolve_workflow_for_pr` (in `mergify_admin_requeue_workflow_fastpath.py`) shells out over IPC to a live Invoker owner to resolve a review-gate workflow mapping for PR #5810.

This repro never runs against a live Invoker owner, so that subprocess call fails to connect.

`admin-bypass-dispatch-degraded` fires before the worker ever reaches the PR-Body valid-noop path the repro exists to exercise.

Sibling repros (`repro-babysit-pr-body-human-split.sh`, `repro-babysit-pr-body-prereq-split.sh`) already mock this call.

They point `INVOKER_PR_CRON_REVIEW_GATE_CMD` at a stub script. This PR applies that same stub to the one repro missing it.

## Review Claim

`repro-babysit-pr-body-valid-noop.sh` now mocks the review-gate lookup the same way its sibling repros already do, so it exercises the valid-noop path instead of failing on a live IPC dependency.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The only changed file is `scripts/repro/repro-babysit-pr-body-valid-noop.sh`, a test-only repro script invoked by `scripts/test-suites/required/12-mergify-admin-requeue.sh`. The change adds a local stub script and an env var export inside the repro's own hermetic temp dir; it does not touch `mergify_admin_requeue_workflow_fastpath.py`, any other product path, or any other repro file, so no other CI job or runtime behavior is affected.

## Slice Rationale

This is the single root-cause fix for the one failing CI job (`required-fast / Mergify Admin Requeue`). There is no separate product change to split out: the defect and its fix live in the same nine-line repro-only patch.

## Non-goals

This PR does not change `mergify_admin_requeue_workflow_fastpath.py` or any other product code. It does not touch the other repro scripts that already mock this call. It does not weaken the check: the stub returns an empty JSON review-gate mapping, matching the sibling repros' existing behavior, not a bypass of the assertion the repro makes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-babysit-pr-body-valid-noop.sh`
- [x] `bash scripts/test-suites/required/12-mergify-admin-requeue.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
