### PR TITLE
[CI regression: cd07355-required-fast-mergify-admin-requeue](1) Mock review-gate lookup in valid-noop repro

### DIFF
--- a/scripts/repro/repro-babysit-pr-body-valid-noop.sh
+++ b/scripts/repro/repro-babysit-pr-body-valid-noop.sh
@@ -42,6 +42,21 @@ exit 42
 EOF
 chmod +x "$TMP/bin/claude"
 
+# Without this, resolve_workflow_for_pr (mergify_admin_requeue_workflow_fastpath.py)
+# shells out to a live Invoker owner over IPC to look up a review-gate workflow
+# mapping for PR #5810, which this hermetic repro never provides -- the lookup
+# subprocess fails to connect and admin-bypass-dispatch-degraded fires before
+# the worker ever reaches the PR Body valid-noop path this repro is meant to
+# test. Mocked the same way its sibling repros already do (e.g.
+# repro-babysit-pr-body-human-split.sh, repro-babysit-pr-body-prereq-split.sh).
+cat > "$TMP/review-gate.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{}\n'
+EOF
+chmod +x "$TMP/review-gate.sh"
+export INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh"
+
 REMOTE="$TMP/origin.git"
 SEED="$TMP/seed"
 WORK_ROOT="$WORK_PARENT/5810"


### PR DESCRIPTION
## Summary

CI job `required-fast / Mergify Admin Requeue` first failed on default-branch commit `cd07355fe0` and stayed red through `863f30de1a`.

The failing repro, `scripts/repro/repro-babysit-pr-body-valid-noop.sh`, called `resolve_workflow_for_pr` without mocking its review-gate lookup.

That lookup shells out over IPC to a live Invoker owner. In this hermetic repro there is no owner to answer, so the lookup subprocess fails.

That failure fires `admin-bypass-dispatch-degraded` before the worker ever reaches the PR Body valid-noop path the repro exists to test.

This change mocks the review-gate lookup the same way sibling repros already do, so the repro reaches and asserts its intended path.

## Review Claim

The repro fix corrects the CI regression's root cause at its source: a missing review-gate mock, with no unrelated edits.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The change is confined to one repro fixture script under `scripts/repro/`. It adds a local mock for an external IPC call inside a hermetic test harness. It does not touch product code, other CI jobs, or any non-repro script.

## Slice Rationale

One proof slice for the repaired CI job: the repro script's own fix and its passing re-run are the same local claim, kept together instead of two separate PRs.

## Non-goals

No product code changes. No refactor of `mergify_admin_requeue.py` or its workflow-fastpath module. No changes to other repro fixtures.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-babysit-pr-body-valid-noop.sh` (exits 0 on this branch; exits 1 on the pre-fix version of this script with `tick 1: missing PR Body valid-noop trace`, because `admin-bypass-dispatch-degraded` fires first when the review-gate lookup is unmocked)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
