### PR TITLE
[CI regression: 14dbf53-fleet-14dbf53](3) Fix stale conversational-planning-mode prompt assertions

### DIFF
--- a/packages/app/src/__tests__/restore-planning-chat-conversational-mode.repro.test.ts
+++ b/packages/app/src/__tests__/restore-planning-chat-conversational-mode.repro.test.ts
@@ -86,9 +86,9 @@ describe('restored in-app planning chat conversational mode', () => {
 
     expect(result.ok).toBe(true);
     expect(prompt).toContain('conversational planning mode');
-    expect(prompt).toContain('hosting surface reads that exact YAML');
-    expect(prompt).toContain('Slack orchestrator or the in-app planner');
+    expect(prompt).toContain('the in-app host stages that exact draft in its review panel');
+    expect(prompt).toContain('Current planning host: Invoker in-app planner.');
     expect(prompt).not.toContain('Generate a YAML task plan');
-    expect(prompt).not.toContain('Slack orchestrator reads that exact YAML');
+    expect(prompt).not.toContain('Current planning host: Invoker Slack planner.');
   });
 });


### PR DESCRIPTION
## Summary

The `required-fast / Vitest Workspace` CI job (fleet/14dbf53) still fails after the two prior fixes in this stack (#10137, #10138) land, because `restore-planning-chat-conversational-mode.repro.test.ts` asserts prompt substrings (`hosting surface reads that exact YAML`, `Slack orchestrator or the in-app planner`, `Slack orchestrator reads that exact YAML`) that no longer exist anywhere in the codebase.

The conversational-planning prompt for this code path (`restorePlanningChatSessions` → `sendPlanningChatMessage`) is now built by `planningHostContext` in `planning-surface.ts`, which already uses different, correct wording (`the in-app host stages that exact draft in its review panel`, `Current planning host: Invoker in-app planner.`). This updates the test's assertions to match that real, current prompt text.

## Review Claim

Approve updating one repro test's outdated prompt-substring assertions to match `planningHostContext`'s already-correct, already-shipped wording.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the test file changes. `packages/contracts/src/planning-surface.ts` and `packages/app/src/in-app-planner.ts` are unchanged, so production behavior cannot regress.

## Slice Rationale

Third, independent local claim in the fleet/14dbf53 CI regression stack: fixing this one repro test's outdated prompt-wording assertions, kept apart from the SQLite column-name fix (#10137) and the Slack plan-draft assertion fixes (#10138).

## Non-goals

Does not change any prompt-building source file. Does not touch the other two tests already fixed in this stack.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test -- src/__tests__/restore-planning-chat-conversational-mode.repro.test.ts` — `Test Files 1 passed (1)`, `Tests 2 passed (2)`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && bash scripts/test-suites/required/10-vitest-workspace.sh` — exit 0 (data-store 29/29, ui, surfaces 53/53, app 208/208 (2026/2027, 1 pre-existing skip), slack-manager 10/10, watcher 1/1)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored planning chat sessions now consistently remain in conversational planning mode.
  * Updated restored-session behavior to use the in-app planner context and review-panel workflow.
  * Prevented restored sessions from reverting to the Slack planner or generating YAML task plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
