### PR TITLE
CI regression: cd07355-required-fast-mergify-admin-requeue

### DIFF
--- a/scripts/repro/repro-babysit-queue-only-empty-log.sh
+++ b/scripts/repro/repro-babysit-queue-only-empty-log.sh
@@ -42,6 +42,21 @@ exit 42
 EOF
 chmod +x "$TMP/bin/claude"
 
+# Without this, resolve_workflow_for_pr (mergify_admin_requeue_workflow_fastpath.py)
+# shells out to a live Invoker owner over IPC to look up a review-gate workflow
+# mapping for PR #5810, which this hermetic repro never provides -- the lookup
+# subprocess fails to connect and admin-bypass-dispatch-degraded fires before
+# the worker ever reaches the queue-only-empty-log path this repro is meant to
+# test. Mocked the same way its sibling repros already do (e.g.
+# repro-babysit-queue-only-check.sh, repro-babysit-pr-body-valid-noop.sh).
+cat > "$TMP/review-gate.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '{}\n'
+EOF
+chmod +x "$TMP/review-gate.sh"
+export INVOKER_PR_CRON_REVIEW_GATE_CMD="$TMP/review-gate.sh"
+
 REMOTE="$TMP/origin.git"
 SEED="$TMP/seed"
 WORK_ROOT="$WORK_PARENT/5810"


### PR DESCRIPTION
## Summary

CI job `required-fast / Mergify Admin Requeue` first failed on default-branch push commit `cd07355fe0`, in run 31917892808, and was still red through `9651a79c19`, in run 32548682742.

Investigation found this job's `queue-only-empty-log` path (a Mergify-payload check with an empty CI job log) was already correctly handled by `scripts/mergify_admin_requeue.py`, but had no hermetic repro guarding it.

This slice adds that missing repro so the class of failure this job caught cannot silently regress again without a local, deterministic signal.

## Review Claim

Approve adding `scripts/repro/repro-babysit-queue-only-empty-log.sh`, a new hermetic repro that proves the admin-requeue worker treats a queue-only Mergify check with an empty CI log as a no-op instead of invoking Claude or retrying it.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

The new file only adds a self-contained repro script under `scripts/repro/`. It does not modify `scripts/mergify_admin_requeue.py`, any production code path, or any other CI job's files, so it carries no risk to other CI jobs or product behavior.

## Slice Rationale

This is the sole file-level change produced by the CI-regression investigation for this job; it is proof-only, so it is published as its own `proof`-lane slice rather than bundled with product code (there is none in this diff).

## Non-goals

Does not change `scripts/mergify_admin_requeue.py` or any other production file. Does not touch other CI jobs' repro scripts or fixtures. Does not add or change `.github/workflows/ci.yml`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/repro/repro-babysit-queue-only-empty-log.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
