### PR TITLE
[CI regression: 9651a79-playwright-1-of-9](1) Suppress duplicate failed-turn banner/log on redelivery

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2493,6 +2493,11 @@ export function App() {
       }
       return;
     }
+    // A failed turn keeps its activeTurnId (Retry re-sends it), so a second
+    // delivery of the same failure — e.g. a lagging poll after the direct
+    // response already landed — must not re-append the error line or the
+    // stopped banner a second time.
+    const wasAlreadyFailed = target.activeTurnStatus === 'failed';
     const applyFailed = (session: PlanningSessionView): PlanningSessionView => (
       session.id === targetId
         ? { ...session, busy: false, activeTurnStatus: 'failed' as const, activeTurnError: outcome.error, updatedAt }
@@ -2500,11 +2505,14 @@ export function App() {
     );
     planningSessionsRef.current = planningSessionsRef.current.map(applyFailed);
     setPlanningSessions((prev) => prev.map(applyFailed));
-    clearPlanningStreamForSessionIds([sessionId, targetId]);
+    if (!wasAlreadyFailed) {
+      appendTerminalLine(outcome.error, 'system', 'error', targetId);
+      keepPlanningStreamFailureForSessionIds([sessionId, targetId], outcome.error);
+    }
     forgetPlanningStreamAliasesForSessionIds([sessionId, targetId]);
     pendingPlanningStreamSessionIdsRef.current.delete(sessionId);
     pendingPlanningStreamSessionIdsRef.current.delete(targetId);
-  }, [clearPlanningStreamForSessionIds, forgetPlanningStreamAliasesForSessionIds]);
+  }, [appendTerminalLine, forgetPlanningStreamAliasesForSessionIds, keepPlanningStreamFailureForSessionIds]);
 
   useEffect(() => {
     applyTurnOutcomeRef.current = applyPlanningTurnOutcome;

--- a/packages/ui/src/__tests__/planning-turn-durability.test.tsx
+++ b/packages/ui/src/__tests__/planning-turn-durability.test.tsx
@@ -239,7 +239,6 @@ describe('planning turn durability', () => {
     })) as typeof mock.api.planningChatSend;
     const serverSessions = { current: [] as ReturnType<typeof makePlanningSessionSummary>[] };
     mock.api.planningChatList = vi.fn(async () => ({ ok: true, sessions: serverSessions.current }));
-
     render(<App />);
     await openPlanningSurface();
 
@@ -458,5 +457,42 @@ describe('planning turn durability', () => {
     });
     expect(screen.queryByTestId('invoker-terminal-turn-error')).not.toBeInTheDocument();
     expect(screen.queryByTestId('invoker-terminal-retry-turn')).not.toBeInTheDocument();
+  });
+
+  it('lands a failed turn outcome exactly once when both the response and the stream event deliver it', async () => {
+    mock.api.planningChatSend = vi.fn(async (request: { sessionId?: string; turnId?: string }) => ({
+      ok: false as const,
+      sessionId: request.sessionId ?? 'session-1',
+      turnId: request.turnId,
+      error: 'Planner was interrupted before it could answer.',
+    }));
+
+    render(<App />);
+    await openPlanningSurface();
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello planner' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-turn-error'))
+        .toHaveTextContent('Planner was interrupted before it could answer.');
+    });
+
+    const sendRequest = vi.mocked(mock.api.planningChatSend).mock.calls[0]?.[0] as { sessionId?: string; turnId?: string };
+    expect(typeof sendRequest.turnId).toBe('string');
+
+    // A lagging stream event re-delivers the same failure for the same
+    // turnId after the direct response already landed it.
+    await act(async () => {
+      mock.firePlanningChatStream({
+        sessionId: sendRequest.sessionId ?? 'session-1',
+        turnId: sendRequest.turnId,
+        turn: { status: 'failed', error: 'Planner was interrupted before it could answer.' },
+      });
+    });
+
+    const transcriptText = screen.getByTestId('invoker-terminal-transcript').textContent ?? '';
+    expect(transcriptText.split('Planner was interrupted before it could answer.').length - 1).toBe(1);
+    expect(screen.getByTestId('invoker-terminal-retry-turn')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

<!-- invoker-ci-regression-watch: first-bad-sha=9651a79c196de75a9ed7b6c322450a7dbb604641; job=playwright / 1-of-9 -->

CI job `playwright / 1-of-9` first failed at `9651a79c196de75a9ed7b6c322450a7dbb604641` in [run 32548682742](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/32548682742/job/96973705716).

A failed planning turn keeps its `activeTurnId` so the same identifier stays valid for a follow-up send.

That also means a second delivery of the same failure, like a lagging poll tick landing after the direct response, was landing again.

Before this change, a failed turn's error was never written into the transcript, only into a separate banner. This change adds that transcript line.

A second delivery of the same failed outcome no longer appends that line, or resets the stopped banner, a second time.

`visual-proof.spec.ts` is one of six specs CI job `playwright / 1-of-9` runs. A redelivery race like this is exactly the kind of timing issue that flakes a CI spec.

## Review Claim

`applyPlanningTurnOutcome`'s failed-turn branch in `packages/ui/src/App.tsx` must append the error line to the transcript exactly once per turn, even when the same failed outcome is delivered more than once for the same `activeTurnId`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Other CI jobs and product behavior stay unchanged except for the corrected defect: the added check only short-circuits the transcript-append and stream-failure-keep calls when `target.activeTurnStatus` is already `'failed'` for that exact session, so a first-time failure (or a failure on a different session) is unaffected.

## Slice Rationale

One behavior slice: the failing CI job's root cause (the redelivery check on the failed-turn branch) plus its regression proof, with no unrelated edits.

## Non-goals

Does not change the completed-turn path (already handled by the existing `activeTurnId` guard at the top of `applyPlanningTurnOutcome`), the re-send behavior wired to the terminal's retry control, or any other planning-session reducer branch. Does not touch the unrelated `dag-surface-background-click-noop` guarded behavior at `packages/ui/src/App.tsx:2024` (background-click no-op on the DAG surface, tracked separately in #4982); that marker is pre-existing context in this file and is not modified by this diff.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- planning-turn-durability` — 10 tests passed after rebasing onto current `origin/master`.
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app build && env INVOKER_PLAYWRIGHT_RUN_LABEL='ci-playwright-1-of-9' INVOKER_PLAYWRIGHT_WORKERS=1 INVOKER_PLAYWRIGHT_FILES='e2e/visual-proof.spec.ts e2e/edit-task-command.spec.ts e2e/headless-thundering-herd.spec.ts e2e/launching-stall-watchdog.spec.ts e2e/embedded-terminal-pty.spec.ts e2e/keyboard-navigation.spec.ts' INVOKER_PLAYWRIGHT_ARGS='--reporter=line' bash scripts/test-suites/optional/40-playwright-app.sh` — the workflow verification task recorded exit code 0.

</details>

## Visual Proof

![Failed planning turn with one transcript error line](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260822-ba0f0c/redelivery-single-error.png)

Manually inspected: the Electron screenshot shows one red system transcript line reading "Planner was interrupted before it could answer," followed by one "Planning stopped" notice and one bottom error banner with Retry.

The second-delivery guard is not reliably drivable through product controls. `planning-turn-durability.test.tsx` supplies the same failed outcome through the direct response and stream event, then checks the rendered transcript contains one error line.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d0736af37c156d152ede515a6ac851132ab8f722` (or the squash-merge commit once queued)
- Post-revert steps: None
- Data migration? No

</details>
